### PR TITLE
editoast: authz: factorize some `Regulator` functions

### DIFF
--- a/editoast/editoast_authz/src/authorizer.rs
+++ b/editoast/editoast_authz/src/authorizer.rs
@@ -5,6 +5,7 @@ use tracing::debug;
 use crate::Authorization;
 use crate::Error;
 use crate::Infra;
+use crate::InfraGrant;
 use crate::Regulator;
 use crate::Role;
 use crate::StorageDriver;
@@ -124,33 +125,14 @@ impl<S: StorageDriver> Authorizer<S> {
             .await
     }
 
-    pub async fn grant_infra_reader(
+    pub async fn give_infra_grant(
         &self,
         user: &User,
         infra: &Infra,
+        grant: InfraGrant,
     ) -> Result<Authorization<()>, Error<S::Error>> {
         self.regulator
-            .grant_infra_reader(&User(self.user_id), user, infra)
-            .await
-    }
-
-    pub async fn grant_infra_writer(
-        &self,
-        user: &User,
-        infra: &Infra,
-    ) -> Result<Authorization<()>, Error<S::Error>> {
-        self.regulator
-            .grant_infra_writer(&User(self.user_id), user, infra)
-            .await
-    }
-
-    pub async fn grant_infra_owner(
-        &self,
-        user: &User,
-        infra: &Infra,
-    ) -> Result<Authorization<()>, Error<S::Error>> {
-        self.regulator
-            .grant_infra_owner(&User(self.user_id), user, infra)
+            .give_infra_grant(&User(self.user_id), user, infra, grant)
             .await
     }
 
@@ -222,7 +204,7 @@ mod tests {
 
         authorizer
             .regulator
-            .grant_infra_reader_unchecked(&User(authorizer.user_id()), &Infra(1))
+            .give_infra_grant_unchecked(&User(authorizer.user_id()), &Infra(1), InfraGrant::Reader)
             .await
             .expect("Update grants should be successful");
         let is_reader = authorizer
@@ -233,7 +215,7 @@ mod tests {
 
         authorizer
             .regulator
-            .grant_infra_writer_unchecked(&User(user_id), &Infra(1))
+            .give_infra_grant_unchecked(&User(user_id), &Infra(1), InfraGrant::Writer)
             .await
             .expect("Update grants should be successful");
         let is_writer = authorizer
@@ -244,7 +226,7 @@ mod tests {
 
         authorizer
             .regulator
-            .grant_infra_writer_unchecked(&User(user_id), &Infra(1))
+            .give_infra_grant_unchecked(&User(user_id), &Infra(1), InfraGrant::Writer)
             .await
             .expect("Update grants should be successful");
         let is_owner = authorizer

--- a/editoast/editoast_authz/src/authorizer.rs
+++ b/editoast/editoast_authz/src/authorizer.rs
@@ -72,22 +72,8 @@ impl<S: StorageDriver> Authorizer<S> {
             .await
     }
 
-    pub async fn check_infra_grant_reader(&self, infra: &Infra) -> Result<bool, Error<S::Error>> {
-        self.regulator
-            .check_infra_grant_reader(&User(self.user_id), infra)
-            .await
-    }
-
-    pub async fn check_infra_grant_writer(&self, infra: &Infra) -> Result<bool, Error<S::Error>> {
-        self.regulator
-            .check_infra_grant_writer(&User(self.user_id), infra)
-            .await
-    }
-
-    pub async fn check_infra_grant_owner(&self, infra: &Infra) -> Result<bool, Error<S::Error>> {
-        self.regulator
-            .check_infra_grant_owner(&User(self.user_id), infra)
-            .await
+    pub async fn infra_grant(&self, infra: &Infra) -> Result<Option<InfraGrant>, Error<S::Error>> {
+        self.regulator.infra_grant(&User(self.user_id), infra).await
     }
 
     pub async fn authorize_infra_read(
@@ -207,33 +193,33 @@ mod tests {
             .give_infra_grant_unchecked(&User(authorizer.user_id()), &Infra(1), InfraGrant::Reader)
             .await
             .expect("Update grants should be successful");
-        let is_reader = authorizer
-            .check_infra_grant_reader(&Infra(1))
+        let grant = authorizer
+            .infra_grant(&Infra(1))
             .await
             .expect("Check grants should be successful");
-        assert_eq!(is_reader, true,);
+        assert_eq!(grant, Some(InfraGrant::Reader));
 
         authorizer
             .regulator
             .give_infra_grant_unchecked(&User(user_id), &Infra(1), InfraGrant::Writer)
             .await
             .expect("Update grants should be successful");
-        let is_writer = authorizer
-            .check_infra_grant_writer(&Infra(1))
+        let grant = authorizer
+            .infra_grant(&Infra(1))
             .await
             .expect("Check grants should be successful");
-        assert_eq!(is_writer, true,);
+        assert_eq!(grant, Some(InfraGrant::Writer));
 
         authorizer
             .regulator
-            .give_infra_grant_unchecked(&User(user_id), &Infra(1), InfraGrant::Writer)
+            .give_infra_grant_unchecked(&User(user_id), &Infra(1), InfraGrant::Owner)
             .await
             .expect("Update grants should be successful");
-        let is_owner = authorizer
-            .check_infra_grant_writer(&Infra(1))
+        let grant = authorizer
+            .infra_grant(&Infra(1))
             .await
             .expect("Check grants should be successful");
-        assert_eq!(is_owner, true,);
+        assert_eq!(grant, Some(InfraGrant::Owner));
     }
 
     #[tokio::test]

--- a/editoast/editoast_authz/src/lib.rs
+++ b/editoast/editoast_authz/src/lib.rs
@@ -9,6 +9,7 @@ pub use regulator::StorageDriver;
 
 pub use model::Group;
 pub use model::Infra;
+pub use model::InfraGrant;
 pub use model::InfraPrivilege;
 pub use model::Role;
 pub use model::User;

--- a/editoast/editoast_authz/src/model.rs
+++ b/editoast/editoast_authz/src/model.rs
@@ -32,6 +32,15 @@ pub enum InfraPrivilege {
     CanShareOwnership,
 }
 
+#[derive(Debug, Display, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
+pub enum InfraGrant {
+    Reader,
+    Writer,
+    Owner,
+}
+
 #[derive(
     fga::User,
     Debug,

--- a/editoast/editoast_authz/src/regulator.rs
+++ b/editoast/editoast_authz/src/regulator.rs
@@ -737,10 +737,11 @@ impl<S: StorageDriver> Regulator<S> {
     }
 
     #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
-    pub async fn grant_infra_reader_unchecked(
+    pub async fn give_infra_grant_unchecked(
         &self,
         user: &User,
         infra: &Infra,
+        grant: InfraGrant,
     ) -> Result<(), Error<S::Error>> {
         // Check if the infra exists
         if !self
@@ -757,157 +758,46 @@ impl<S: StorageDriver> Regulator<S> {
             return Err(Error::UnknownSubject(user.0));
         }
 
-        // Avoid creating an existing tuple
-        if self
-            .openfga
-            .check(Infra::reader().check(user, infra))
-            .await?
-        {
-            return Ok(());
-        }
-
         // Remove other grants before to add the new one
         self.revoke_infra_grants_unchecked(user, infra).await?;
 
         // Grant the new one
-        self.openfga
-            .prepare_writes()
-            .write(&Infra::reader().tuple(user, infra))
-            .execute()
-            .await?;
+        let mut writes = self.openfga.prepare_writes();
+        match grant {
+            InfraGrant::Reader => {
+                writes.push(&Infra::reader().tuple(user, infra));
+            }
+            InfraGrant::Writer => {
+                writes.push(&Infra::writer().tuple(user, infra));
+            }
+            InfraGrant::Owner => {
+                writes.push(&Infra::owner().tuple(user, infra));
+            }
+        }
+        writes.execute().await?;
 
         Ok(())
     }
 
     #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
-    pub async fn grant_infra_reader(
+    pub async fn give_infra_grant(
         &self,
         issuer: &User,
         user: &User,
         infra: &Infra,
+        grant: InfraGrant,
     ) -> Result<Authorization<()>, Error<S::Error>> {
-        self.authorize_infra_sharing_read(issuer, infra)
-            .await?
+        let authz_share = match grant {
+            InfraGrant::Reader => self.authorize_infra_sharing_read(issuer, infra).await?,
+            InfraGrant::Writer => self.authorize_infra_sharing_write(issuer, infra).await?,
+            InfraGrant::Owner => {
+                self.authorize_infra_sharing_ownership(issuer, infra)
+                    .await?
+            }
+        };
+        authz_share
             .allowed_then_try(async || {
-                self.grant_infra_reader_unchecked(user, infra).await?;
-                Ok(Authorization::Granted(()))
-            })
-            .await
-    }
-
-    #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
-    pub async fn grant_infra_writer_unchecked(
-        &self,
-        user: &User,
-        infra: &Infra,
-    ) -> Result<(), Error<S::Error>> {
-        // Check if the infra exists
-        if !self
-            .driver
-            .infra_exists(infra.0)
-            .await
-            .map_err(Error::Storage)?
-        {
-            return Err(Error::UnknownResource(infra.0));
-        }
-
-        // Check if user exists
-        if !self.user_exists(user.0).await? {
-            return Err(Error::UnknownSubject(user.0));
-        }
-
-        // Avoid creating an existing tuple
-        if self
-            .openfga
-            .check(Infra::writer().check(user, infra))
-            .await?
-        {
-            return Ok(());
-        }
-
-        // Remove other grants before to add the new one
-        self.revoke_infra_grants_unchecked(user, infra).await?;
-
-        // Grant the new one
-        self.openfga
-            .prepare_writes()
-            .write(&Infra::writer().tuple(user, infra))
-            .execute()
-            .await?;
-
-        Ok(())
-    }
-
-    #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
-    pub async fn grant_infra_writer(
-        &self,
-        issuer: &User,
-        user: &User,
-        infra: &Infra,
-    ) -> Result<Authorization<()>, Error<S::Error>> {
-        self.authorize_infra_sharing_write(issuer, infra)
-            .await?
-            .allowed_then_try(async || {
-                self.grant_infra_writer_unchecked(user, infra).await?;
-                Ok(Authorization::Granted(()))
-            })
-            .await
-    }
-
-    #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
-    pub async fn grant_infra_owner_unchecked(
-        &self,
-        user: &User,
-        infra: &Infra,
-    ) -> Result<(), Error<S::Error>> {
-        // Check if the infra exists
-        if !self
-            .driver
-            .infra_exists(infra.0)
-            .await
-            .map_err(Error::Storage)?
-        {
-            return Err(Error::UnknownResource(infra.0));
-        }
-
-        // Check if user exists
-        if !self.user_exists(user.0).await? {
-            return Err(Error::UnknownSubject(user.0));
-        }
-
-        // Avoid creating an existing tuple
-        if self
-            .openfga
-            .check(Infra::owner().check(user, infra))
-            .await?
-        {
-            return Ok(());
-        }
-
-        // Remove other grants before to add the new one
-        self.revoke_infra_grants_unchecked(user, infra).await?;
-
-        // Grant the new one
-        self.openfga
-            .prepare_writes()
-            .write(&Infra::owner().tuple(user, infra))
-            .execute()
-            .await?;
-
-        Ok(())
-    }
-
-    #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
-    pub async fn grant_infra_owner(
-        &self,
-        issuer: &User,
-        user: &User,
-        infra: &Infra,
-    ) -> Result<Authorization<()>, Error<S::Error>> {
-        self.authorize_infra_sharing_ownership(issuer, infra)
-            .await?
-            .allowed_then_try(async || {
-                self.grant_infra_owner_unchecked(user, infra).await?;
+                self.give_infra_grant_unchecked(user, infra, grant).await?;
                 Ok(Authorization::Granted(()))
             })
             .await

--- a/editoast/editoast_authz/src/regulator.rs
+++ b/editoast/editoast_authz/src/regulator.rs
@@ -355,11 +355,11 @@ impl<S: StorageDriver> Regulator<S> {
     }
 
     #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
-    pub async fn check_infra_grant_reader(
+    pub async fn infra_grant(
         &self,
         user: &User,
         infra: &Infra,
-    ) -> Result<bool, Error<S::Error>> {
+    ) -> Result<Option<InfraGrant>, Error<S::Error>> {
         // Check if the infra exists
         if !self
             .driver
@@ -376,69 +376,35 @@ impl<S: StorageDriver> Regulator<S> {
         }
 
         // Calling openfga
-        let result = self
+        let (is_reader, is_writer, is_owner) = self
             .openfga
-            .check(model::Infra::reader().check(user, infra))
+            .checks((
+                model::Infra::reader().check(user, infra),
+                model::Infra::writer().check(user, infra),
+                model::Infra::owner().check(user, infra),
+            ))
             .await?;
-        Ok(result)
-    }
 
-    #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
-    pub async fn check_infra_grant_writer(
-        &self,
-        user: &User,
-        infra: &Infra,
-    ) -> Result<bool, Error<S::Error>> {
-        // Check if the infra exists
-        if !self
-            .driver
-            .infra_exists(infra.0)
-            .await
-            .map_err(Error::Storage)?
-        {
-            return Err(Error::UnknownResource(infra.0));
+        match (is_reader, is_writer, is_owner) {
+            (true, false, false) => Ok(Some(InfraGrant::Reader)),
+            (false, true, false) => Ok(Some(InfraGrant::Writer)),
+            (false, false, true) => Ok(Some(InfraGrant::Owner)),
+            (false, false, false) => Ok(None),
+            _ => {
+                tracing::error!(
+                    is_reader,
+                    is_writer,
+                    is_owner,
+                    ?user,
+                    ?infra,
+                    "User has multiple grants on the same resource"
+                );
+                panic!(
+                    "User {user:?} has multiple grants on the same resource {infra:?}, which is not supposed to happen by design. \n\
+                    Detected grants: reader: {is_reader}, writer: {is_writer}, owner: {is_owner}"
+                )
+            }
         }
-
-        // Check if user exists
-        if !self.user_exists(user.0).await? {
-            return Err(Error::UnknownSubject(user.0));
-        }
-
-        // Calling openfga
-        let result = self
-            .openfga
-            .check(model::Infra::writer().check(user, infra))
-            .await?;
-        Ok(result)
-    }
-
-    #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
-    pub async fn check_infra_grant_owner(
-        &self,
-        user: &User,
-        infra: &Infra,
-    ) -> Result<bool, Error<S::Error>> {
-        // Check if the infra exists
-        if !self
-            .driver
-            .infra_exists(infra.0)
-            .await
-            .map_err(Error::Storage)?
-        {
-            return Err(Error::UnknownResource(infra.0));
-        }
-
-        // Check if user exists
-        if !self.user_exists(user.0).await? {
-            return Err(Error::UnknownSubject(user.0));
-        }
-
-        // Calling openfga
-        let result = self
-            .openfga
-            .check(model::Infra::owner().check(user, infra))
-            .await?;
-        Ok(result)
     }
 
     #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -218,29 +218,12 @@ async fn user_authorizations(
         for infra_id in infra_ids {
             // check that the infra exists before to check the grants
             if Infra::exists(conn, *infra_id).await? {
-                let infra = authz::Infra(*infra_id);
-                let (is_reader, is_writer, is_owner) = tokio::try_join!(
-                    authorizer.check_infra_grant_reader(&infra),
-                    authorizer.check_infra_grant_writer(&infra),
-                    authorizer.check_infra_grant_owner(&infra)
-                )
-                .map_err(AuthzError::from)?;
-                let grant = match (is_reader, is_writer, is_owner) {
-                    (true, false, false) => InfraGrant::Reader,
-                    (false, true, false) => InfraGrant::Writer,
-                    (false, false, true) => InfraGrant::Owner,
-                    (false, false, false) => continue,
-                    _ => {
-                        tracing::error!(
-                            is_reader,
-                            is_writer,
-                            is_owner,
-                            user_id = authorizer.user_id(),
-                            infra_id = *infra_id,
-                            "User has multiple grants on the same resource"
-                        );
-                        continue;
-                    }
+                let Some(grant) = authorizer
+                    .infra_grant(&authz::Infra(*infra_id))
+                    .await
+                    .map_err(AuthzError::from)?
+                else {
+                    continue; // skip if the user has no grant on this infra
                 };
                 response
                     .entry(ResourceType::Infra)

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -418,27 +418,10 @@ async fn update_grants(
                 let subject = authz::User(subject_id);
                 match resource_type {
                     ResourceType::Infra => {
-                        let resource = authz::Infra(resource_id);
-                        match grant {
-                            InfraGrant::Reader => {
-                                authorizer
-                                    .grant_infra_reader(&subject, &resource)
-                                    .await?
-                                    .allowed()?;
-                            }
-                            InfraGrant::Writer => {
-                                authorizer
-                                    .grant_infra_writer(&subject, &resource)
-                                    .await?
-                                    .allowed()?;
-                            }
-                            InfraGrant::Owner => {
-                                authorizer
-                                    .grant_infra_owner(&subject, &resource)
-                                    .await?
-                                    .allowed()?;
-                            }
-                        }
+                        authorizer
+                            .give_infra_grant(&subject, &authz::Infra(resource_id), grant)
+                            .await?
+                            .allowed()?;
                     }
                 }
             }

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -13,6 +13,7 @@ use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::response::Json;
 use editoast_authz as authz;
+use editoast_authz::InfraGrant;
 use editoast_authz::InfraPrivilege;
 use editoast_authz::Role;
 use editoast_derive::EditoastError;
@@ -68,16 +69,6 @@ enum SubjectType {
 #[cfg_attr(test, derive(Debug))]
 enum ResourceType {
     Infra,
-}
-
-#[derive(Display, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-#[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
-#[cfg_attr(test, derive(Debug))]
-pub(in crate::views) enum InfraGrant {
-    Reader,
-    Writer,
-    Owner,
 }
 
 #[derive(Debug, thiserror::Error, EditoastError)]

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -19,6 +19,7 @@ use axum::response::IntoResponse;
 use core_client::AsCoreRequest;
 use core_client::infra_loading::InfraLoadRequest;
 use editoast_authz as authz;
+use editoast_authz::InfraGrant;
 use editoast_derive::EditoastError;
 use editoast_models::DbConnectionPoolV2;
 use editoast_models::model;
@@ -398,9 +399,10 @@ async fn create(
     // NOTE: we use the regulator here instead of the one in the authorizer to bypass the checks on grant_infra_owner
     if let Authentication::Authenticated(authorizer) = auth {
         regulator
-            .grant_infra_owner_unchecked(
+            .give_infra_grant_unchecked(
                 &authz::User(authorizer.user_id()),
                 &authz::Infra(infra.id),
+                InfraGrant::Owner,
             )
             .await?;
     }
@@ -463,9 +465,10 @@ async fn clone(
     // NOTE: we use the regulator here instead of the one in the authorizer to bypass the checks on grant_infra_owner
     if let Authentication::Authenticated(authorizer) = auth {
         regulator
-            .grant_infra_owner_unchecked(
+            .give_infra_grant_unchecked(
                 &authz::User(authorizer.user_id()),
                 &authz::Infra(cloned_infra.id),
+                InfraGrant::Owner,
             )
             .await?;
     }

--- a/editoast/src/views/infra/railjson.rs
+++ b/editoast/src/views/infra/railjson.rs
@@ -7,6 +7,7 @@ use axum::http::StatusCode;
 use axum::http::header;
 use axum::response::IntoResponse;
 use editoast_authz as authz;
+use editoast_authz::InfraGrant;
 use editoast_schemas::infra::RailJson;
 use enum_map::EnumMap;
 use futures::future::try_join_all;
@@ -196,9 +197,10 @@ async fn post_railjson(
     // NOTE: we use the regulator here instead of the one in the authorizer to bypass the checks on can_share_ownership
     if let Authentication::Authenticated(authorizer) = auth {
         regulator
-            .grant_infra_owner_unchecked(
+            .give_infra_grant_unchecked(
                 &authz::User(authorizer.user_id()),
                 &authz::Infra(infra.id),
+                InfraGrant::Owner,
             )
             .await?;
     }

--- a/editoast/src/views/stdcm_logs.rs
+++ b/editoast/src/views/stdcm_logs.rs
@@ -164,6 +164,7 @@ mod tests {
     use core_client::simulation::ReportTrain;
     use core_client::simulation::SpeedLimitProperties;
     use editoast_authz as authz;
+    use editoast_authz::InfraGrant;
     use editoast_schemas::train_schedule::Comfort;
     use editoast_schemas::train_schedule::MarginValue;
     use editoast_schemas::train_schedule::OperationalPointIdentifier;
@@ -323,7 +324,11 @@ mod tests {
         let small_infra = create_small_infra(&mut app.db_pool().get_ok()).await;
         if let Some(user) = user {
             app.regulator()
-                .grant_infra_owner_unchecked(&authz::User(user.id), &authz::Infra(small_infra.id))
+                .give_infra_grant_unchecked(
+                    &authz::User(user.id),
+                    &authz::Infra(small_infra.id),
+                    InfraGrant::Owner,
+                )
                 .await
                 .expect("Failed to grant infra owner");
         }

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -13,6 +13,7 @@ use axum_tracing_opentelemetry::middleware::OtelAxumLayer;
 use core_client::CoreClient;
 use core_client::mocking::MockingClient;
 use dashmap::DashMap;
+use editoast_authz::InfraGrant;
 use editoast_authz::Role;
 use editoast_authz::StorageDriver;
 use editoast_authz::subject;
@@ -47,7 +48,6 @@ use super::PostgresConfig;
 use super::Regulator;
 use super::ServerConfig;
 use super::authentication_middleware;
-use super::authz::InfraGrant;
 
 // NoopSpanExporter exists in 'opentelemetry-sdk' but is hidden behind
 // 'testing' feature which brings with it tons of unneeded dependencies

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -437,35 +437,14 @@ impl<'a> UserBuilder<'a> {
                     .expect("roles should be granted successfully");
 
                 for (infra_id, grant) in infras_grant.into_iter() {
-                    match grant {
-                        InfraGrant::Owner => {
-                            regulator
-                                .grant_infra_owner_unchecked(
-                                    &editoast_authz::User(user.id),
-                                    &editoast_authz::Infra(infra_id),
-                                )
-                                .await
-                                .expect("Infra owner should be granted successfully");
-                        }
-                        InfraGrant::Writer => {
-                            regulator
-                                .grant_infra_writer_unchecked(
-                                    &editoast_authz::User(user.id),
-                                    &editoast_authz::Infra(infra_id),
-                                )
-                                .await
-                                .expect("Infra writer should be granted successfully");
-                        }
-                        InfraGrant::Reader => {
-                            regulator
-                                .grant_infra_reader_unchecked(
-                                    &editoast_authz::User(user.id),
-                                    &editoast_authz::Infra(infra_id),
-                                )
-                                .await
-                                .expect("Infra reader should be granted successfully");
-                        }
-                    }
+                    regulator
+                        .give_infra_grant_unchecked(
+                            &editoast_authz::User(user.id),
+                            &editoast_authz::Infra(infra_id),
+                            grant,
+                        )
+                        .await
+                        .expect("Infra grant should be given successfully")
                 }
             }
             user


### PR DESCRIPTION
refs #11697

This is not an attempt at introducing genericity in the `Regulator`.  This PR just aims to reduce a bit the amount of extraneous code duplication to minimize the diff in #11933.

<details open id="prdesc">

- c6089d778 *editoast: move `InfraGrant` definition in `editoast_authz::model`*
- 010e57658 *editoast: authz: factorize infra granting functions into one*
    ```md
    We are still not generic over resource types, and we still require an
    `InfraGrant` enum repeating what's in the authorization model.  But this
    signature is more consice and it will be easier to manage group grants
    like this.
    ```
- 37e2d4946 *editoast: authz: factorize infra grant retrieval functions into one*

</details>