### PR TITLE
[WIP] editoast: add new similar schedules functionality

### DIFF
--- a/editoast/editoast_schemas/src/train_schedule/path_item.rs
+++ b/editoast/editoast_schemas/src/train_schedule/path_item.rs
@@ -29,6 +29,30 @@ pub struct PathItem {
     pub location: PathItemLocation,
 }
 
+impl PathItem {
+    #[cfg(feature = "testing")]
+    pub fn new(id: String, location: PathItemLocation) -> Self {
+        Self {
+            id: id.into(),
+            deleted: false,
+            location,
+        }
+    }
+
+    pub fn get_uic(&self) -> Option<u32> {
+        if let PathItemLocation::OperationalPointReference(operational_point_reference) =
+            &self.location
+        {
+            if let OperationalPointIdentifier::OperationalPointUic { uic, .. } =
+                &operational_point_reference.reference
+            {
+                return Some(*uic);
+            }
+        }
+        None
+    }
+}
+
 /// The location of a path waypoint
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema, Hash)]
 #[serde(untagged, deny_unknown_fields)]

--- a/editoast/src/generated_data/speed_limit_tags_config.rs
+++ b/editoast/src/generated_data/speed_limit_tags_config.rs
@@ -1,6 +1,7 @@
 use serde::Deserialize;
 use serde::Serialize;
 use std::collections::HashMap;
+use std::ops::Deref;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SpeedLimitTagIds(pub Vec<String>);
@@ -24,5 +25,13 @@ impl SpeedLimitTagIds {
                 .cloned()
                 .collect(),
         )
+    }
+}
+
+impl Deref for SpeedLimitTagIds {
+    type Target = Vec<String>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }

--- a/editoast/src/models/train_schedule.rs
+++ b/editoast/src/models/train_schedule.rs
@@ -1,8 +1,18 @@
+use std::ops::DerefMut;
+
+use crate::models::prelude::*;
 use chrono::DateTime;
 use chrono::Utc;
+use diesel::sql_query;
+use diesel::sql_types::Nullable;
+use diesel::sql_types::Text;
+use diesel_async::RunQueryDsl;
 use editoast_derive::Model;
+use editoast_models::DatabaseError;
+use editoast_models::DbConnection;
 use editoast_models::rolling_stock::TrainCategory;
 use editoast_schemas;
+use editoast_schemas::primitives::NonBlankString;
 use editoast_schemas::train_schedule::Comfort;
 use editoast_schemas::train_schedule::Distribution;
 use editoast_schemas::train_schedule::Margins;
@@ -10,8 +20,6 @@ use editoast_schemas::train_schedule::PathItem;
 use editoast_schemas::train_schedule::PowerRestrictionItem;
 use editoast_schemas::train_schedule::ScheduleItem;
 use editoast_schemas::train_schedule::TrainScheduleOptions;
-
-use crate::models::prelude::*;
 
 #[derive(Debug, Default, Clone, Model)]
 #[model(table = editoast_models::tables::train_schedule)]
@@ -41,6 +49,57 @@ pub struct TrainSchedule {
     #[model(json)]
     pub options: TrainScheduleOptions,
     pub category: Option<TrainCategory>,
+}
+
+impl TrainSchedule {
+    pub async fn get_by_rolling_stock_name_and_speed_limit_tag(
+        conn: DbConnection,
+        rolling_stock_name: String,
+        speed_limit_tag: Option<String>,
+    ) -> Result<Vec<TrainSchedule>, DatabaseError> {
+        let result = sql_query(
+            "SELECT * FROM train_schedule
+            WHERE rolling_stock_name = $1
+            AND ($2 IS NULL OR speed_limit_tag = $2)",
+        )
+        .bind::<Text, _>(rolling_stock_name)
+        .bind::<Nullable<Text>, _>(speed_limit_tag)
+        .get_results::<TrainScheduleRow>(conn.write().await.deref_mut())
+        .await;
+
+        match result {
+            Ok(result) => Ok(result.into_iter().map(Into::into).collect()),
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    fn stop_at(&self, path_item_id: &NonBlankString) -> bool {
+        self.schedule.iter().any(|schedule_item| {
+            schedule_item.at == *path_item_id && schedule_item.stop_for.is_some()
+        })
+    }
+
+    /// Checks if the schedule contains two stops (start and end) in the correct order,
+    /// and that there are no other stops in between.
+    pub fn contains_stops_in_order(&self, start_uic: u32, end_uic: u32) -> bool {
+        let mut found_first = false;
+
+        for path_item in &self.path {
+            if let Some(uic) = path_item.get_uic() {
+                if self.stop_at(&path_item.id) {
+                    if uic == start_uic {
+                        found_first = true;
+                    } else if found_first && uic != end_uic {
+                        return false;
+                    } else if uic == end_uic && found_first {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        false
+    }
 }
 
 impl From<editoast_schemas::TrainSchedule> for TrainScheduleChangeset {
@@ -77,5 +136,148 @@ impl From<editoast_schemas::TrainSchedule> for TrainScheduleChangeset {
             .train_name(train_name)
             .options(options)
             .category(category.map(TrainCategory))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Duration;
+    use editoast_schemas::infra::TrackOffset;
+    use editoast_schemas::primitives::PositiveDuration;
+    use editoast_schemas::train_schedule::OperationalPointIdentifier;
+    use editoast_schemas::train_schedule::OperationalPointReference;
+    use editoast_schemas::train_schedule::PathItem;
+    use editoast_schemas::train_schedule::PathItemLocation;
+    use editoast_schemas::train_schedule::ScheduleItem;
+
+    use super::TrainSchedule;
+
+    fn create_path_item_uic(id: &str, uic: u32) -> PathItem {
+        let location = PathItemLocation::OperationalPointReference(OperationalPointReference {
+            reference: OperationalPointIdentifier::OperationalPointUic {
+                uic,
+                secondary_code: None,
+            },
+            track_reference: None,
+        });
+        PathItem::new(id.to_string(), location)
+    }
+
+    fn create_schedule_item(id: &str) -> ScheduleItem {
+        ScheduleItem {
+            at: id.into(),
+            stop_for: Some(PositiveDuration::try_from(Duration::zero()).unwrap()),
+            ..Default::default()
+        }
+    }
+
+    fn create_path_item_track_offset(id: &str) -> PathItem {
+        let location = PathItemLocation::TrackOffset(TrackOffset::new("track", 0));
+        PathItem::new(id.to_string(), location)
+    }
+
+    #[test]
+    fn test_stops_in_order() {
+        let path = vec![
+            create_path_item_uic("1", 1),
+            create_path_item_uic("2", 2),
+            create_path_item_uic("3", 3),
+        ];
+        let schedule = vec![create_schedule_item("1"), create_schedule_item("3")];
+        let train_schedule = TrainSchedule {
+            path,
+            schedule,
+            ..Default::default()
+        };
+        assert!(train_schedule.contains_stops_in_order(1, 3));
+    }
+
+    #[test]
+    fn test_contains_stops_in_order_with_multiple_scheduled_stops() {
+        let path = vec![
+            create_path_item_uic("1", 1),
+            create_path_item_uic("2", 2),
+            create_path_item_uic("3", 3),
+            create_path_item_uic("4", 4),
+            create_path_item_uic("5", 5),
+            create_path_item_uic("6", 6),
+        ];
+        let schedule = vec![
+            create_schedule_item("2"),
+            create_schedule_item("4"),
+            create_schedule_item("6"),
+        ];
+        let train_schedule = TrainSchedule {
+            path,
+            schedule,
+            ..Default::default()
+        };
+        assert!(train_schedule.contains_stops_in_order(2, 4));
+    }
+
+    #[test]
+    fn test_stops_not_in_order() {
+        let path = vec![
+            create_path_item_uic("1", 1),
+            create_path_item_uic("2", 2),
+            create_path_item_uic("3", 3),
+        ];
+        let schedule = vec![create_schedule_item("1"), create_schedule_item("3")];
+        let train_schedule = TrainSchedule {
+            path,
+            schedule,
+            ..Default::default()
+        };
+        assert!(!train_schedule.contains_stops_in_order(3, 1));
+    }
+
+    #[test]
+    fn test_one_stop_missing() {
+        let path = vec![create_path_item_uic("1", 1), create_path_item_uic("2", 2)];
+        let schedule = vec![create_schedule_item("1"), create_schedule_item("2")];
+        let train_schedule = TrainSchedule {
+            path,
+            schedule,
+            ..Default::default()
+        };
+        assert!(!train_schedule.contains_stops_in_order(1, 9));
+        assert!(!train_schedule.contains_stops_in_order(9, 2));
+    }
+
+    #[test]
+    fn test_path_with_non_uic_items() {
+        let path = vec![
+            create_path_item_uic("1", 1),
+            create_path_item_track_offset("3"),
+            create_path_item_uic("2", 2),
+        ];
+        let schedule = vec![create_schedule_item("1"), create_schedule_item("2")];
+        let train_schedule = TrainSchedule {
+            path,
+            schedule,
+            ..Default::default()
+        };
+        assert!(train_schedule.contains_stops_in_order(1, 2));
+    }
+
+    #[test]
+    fn test_path_with_intermediate_stop() {
+        let path = vec![
+            create_path_item_uic("1", 1),
+            create_path_item_uic("2", 2),
+            create_path_item_uic("3", 3),
+        ];
+        let schedule = vec![
+            create_schedule_item("1"),
+            create_schedule_item("2"),
+            create_schedule_item("3"),
+        ];
+        let train_schedule = TrainSchedule {
+            path,
+            schedule,
+            ..Default::default()
+        };
+
+        assert!(!train_schedule.contains_stops_in_order(1, 3));
     }
 }

--- a/editoast/src/views/timetable/similar_schedules.rs
+++ b/editoast/src/views/timetable/similar_schedules.rs
@@ -1,89 +1,32 @@
+mod error;
+mod request;
+mod response;
+
 use axum::Extension;
 use axum::Json;
 use axum::extract::State;
 use chrono::DateTime;
-use chrono::Utc;
 use editoast_authz::Role;
-use serde::Deserialize;
-use serde::Serialize;
-use utoipa::ToSchema;
+use request::Request;
+use request::Segment;
+use response::Response;
 
 use crate::error::Result;
+use crate::models::TrainSchedule;
 
 use super::AppState;
 use super::AuthenticationExt;
 use super::AuthorizationError;
 
 editoast_common::schemas! {
-    Waypoint,
-    WaypointResponse,
+    request::schemas(),
+    response::schemas(),
 }
 
 crate::routes! {
     "/similar_schedules" => {
         similar_schedules,
     },
-}
-
-#[derive(Debug, Deserialize, ToSchema)]
-#[expect(dead_code)]
-struct RollingStockCharacteristics {
-    name: String,
-    speed_limit_tag: Option<String>,
-}
-
-#[derive(Clone, Deserialize, ToSchema)]
-#[cfg_attr(test, derive(PartialEq))]
-#[schema(as = SimilarScheduleWaypoint)]
-struct Waypoint {
-    ci: i64,
-    ch: String,
-    stop: bool,
-}
-
-impl std::fmt::Debug for Waypoint {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}:{}{}",
-            self.ci,
-            self.ch,
-            if self.stop { "[STOP]" } else { "" },
-        )
-    }
-}
-
-#[derive(Debug, Deserialize, ToSchema)]
-#[expect(dead_code)]
-struct Request {
-    #[schema(inline)]
-    rolling_stock: RollingStockCharacteristics,
-    #[schema(value_type = Vec<SimilarScheduleWaypoint>)]
-    waypoints: Vec<Waypoint>,
-}
-
-#[derive(Debug, Serialize, ToSchema)]
-#[cfg_attr(test, derive(PartialEq))]
-#[schema(as = SimilarScheduleWaypointResponse)]
-struct WaypointResponse {
-    ci: i64,
-    ch: String,
-}
-
-#[derive(Debug, Serialize, ToSchema)]
-struct SimilarScheduleItem {
-    schedule_id: String,
-    start_time: DateTime<Utc>,
-    #[schema(value_type = SimilarScheduleWaypointResponse)]
-    begin: WaypointResponse,
-    #[schema(value_type = SimilarScheduleWaypointResponse)]
-    end: WaypointResponse,
-}
-
-#[derive(Debug, Serialize, ToSchema)]
-struct Response {
-    #[schema(inline)]
-    similar_schedules: Vec<SimilarScheduleItem>,
 }
 
 #[utoipa::path(
@@ -100,8 +43,15 @@ struct Response {
 )]
 async fn similar_schedules(
     Extension(auth): AuthenticationExt,
-    State(AppState { .. }): State<AppState>,
-    Json(Request { .. }): Json<Request>,
+    State(AppState {
+        db_pool,
+        speed_limit_tag_ids,
+        ..
+    }): State<AppState>,
+    Json(Request {
+        rolling_stock,
+        waypoints,
+    }): Json<Request>,
 ) -> Result<Json<Response>> {
     let authorized = auth
         .check_roles([Role::Stdcm].into())
@@ -111,32 +61,74 @@ async fn similar_schedules(
         return Err(AuthorizationError::Forbidden.into());
     }
 
+    // Step 1: input validation and preprocessing
+    // ------------------------------------------
+
+    rolling_stock
+        .validate(&mut db_pool.get().await?, &speed_limit_tag_ids)
+        .await?;
+    let waypoints = request::Waypoint::squash_successive_waypoints(waypoints);
+    let waypoints_count = waypoints.len();
+    let segments = Segment::split_segments(waypoints)?;
+
+    tracing::debug!(
+        n_segments = segments.len(),
+        n_waypoints = waypoints_count,
+        "pre-processing complete"
+    );
+
+    // Step 2: query train schedules and build the search graph
+    // ------------------------------------------------------------
+
+    let train_schedules = TrainSchedule::get_by_rolling_stock_name_and_speed_limit_tag(
+        db_pool.get().await?,
+        rolling_stock.name,
+        rolling_stock.speed_limit_tag,
+    )
+    .await?;
+
+    for segment in segments {
+        let start_waypoint = segment.start()?;
+        let end_waypoint = segment.end()?;
+        let similar_schedules = train_schedules
+            .iter()
+            .filter(|ts| ts.contains_stops_in_order(start_waypoint.ci, end_waypoint.ci))
+            .collect::<Vec<_>>();
+        tracing::info!("TEST similar_schedules count: {}", similar_schedules.len());
+
+        if similar_schedules.is_empty() {
+            return Ok(Json(Response {
+                similar_schedules: vec![],
+            }));
+        }
+    }
+
     let similar_schedules = Response {
         similar_schedules: vec![
-            SimilarScheduleItem {
+            response::SimilarScheduleItem {
                 schedule_id: "mock_similar_schedule_1".to_string(),
                 start_time: DateTime::parse_from_rfc3339("2025-05-14T00:00:00Z")
                     .unwrap()
                     .to_utc(),
-                begin: WaypointResponse {
+                begin: response::Waypoint {
                     ci: 123,
                     ch: "A1".to_string(),
                 },
-                end: WaypointResponse {
+                end: response::Waypoint {
                     ci: 456,
                     ch: "B1".to_string(),
                 },
             },
-            SimilarScheduleItem {
+            response::SimilarScheduleItem {
                 schedule_id: "mock_similar_schedule_2".to_string(),
                 start_time: DateTime::parse_from_rfc3339("2025-05-14T00:00:00Z")
                     .unwrap()
                     .to_utc(),
-                begin: WaypointResponse {
+                begin: response::Waypoint {
                     ci: 123,
                     ch: "A1".to_string(),
                 },
-                end: WaypointResponse {
+                end: response::Waypoint {
                     ci: 456,
                     ch: "B1".to_string(),
                 },

--- a/editoast/src/views/timetable/similar_schedules/error.rs
+++ b/editoast/src/views/timetable/similar_schedules/error.rs
@@ -1,0 +1,19 @@
+use editoast_derive::EditoastError;
+
+#[derive(Debug, thiserror::Error, EditoastError)]
+#[cfg_attr(test, derive(PartialEq))]
+#[editoast_error(base_id = "similar_schedules")]
+pub enum Error {
+    #[error("Not enough waypoints to split into segments")]
+    NotEnoughWaypoints,
+    #[error("First waypoint is not a stop")]
+    FirstWaypointNotAStop,
+    #[error("Last waypoint is not a stop")]
+    LastWaypointNotAStop,
+    #[error("Rolling stock not found")]
+    RollingStockNotFound,
+    #[error("Speed limit tag not found")]
+    SpeedLimitTagNotFound,
+    #[error("Empty segment")]
+    EmptySegment,
+}

--- a/editoast/src/views/timetable/similar_schedules/request.rs
+++ b/editoast/src/views/timetable/similar_schedules/request.rs
@@ -1,0 +1,417 @@
+use std::collections::VecDeque;
+use std::ops::Deref;
+use std::ops::DerefMut;
+
+use editoast_models::DbConnection;
+use serde::Deserialize;
+use utoipa::ToSchema;
+
+use crate::generated_data::speed_limit_tags_config::SpeedLimitTagIds;
+use crate::models::Exists;
+use crate::models::RollingStock;
+
+use super::error::Error;
+
+editoast_common::schemas! {
+    Waypoint,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct Request {
+    #[schema(inline)]
+    pub rolling_stock: RollingStockCharacteristics,
+    #[schema(value_type = Vec<SimilarScheduleWaypoint>)]
+    pub waypoints: Vec<Waypoint>,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct RollingStockCharacteristics {
+    pub name: String,
+    pub speed_limit_tag: Option<String>,
+}
+
+impl RollingStockCharacteristics {
+    pub async fn validate(
+        &self,
+        conn: &mut DbConnection,
+        speed_limit_tag_ids: &SpeedLimitTagIds,
+    ) -> Result<(), Error> {
+        if !RollingStock::exists(conn, self.name.clone())
+            .await
+            .map_err(|_| Error::RollingStockNotFound)?
+        {
+            return Err(Error::RollingStockNotFound);
+        }
+
+        if self
+            .speed_limit_tag
+            .as_ref()
+            .is_some_and(|tag| !speed_limit_tag_ids.contains(tag))
+        {
+            return Err(Error::SpeedLimitTagNotFound);
+        }
+
+        Ok(())
+    }
+
+    #[cfg(test)]
+    fn new(name: String, speed_limit_tag: Option<String>) -> Self {
+        Self {
+            name,
+            speed_limit_tag,
+        }
+    }
+}
+
+#[derive(Clone, Deserialize, ToSchema)]
+#[cfg_attr(test, derive(PartialEq))]
+#[schema(as = SimilarScheduleWaypoint)]
+pub struct Waypoint {
+    pub ci: u32,
+    pub ch: String,
+    pub stop: bool,
+}
+
+impl Waypoint {
+    #[cfg(test)]
+    fn new(ci: u32, ch: String, stop: bool) -> Self {
+        Self { ci, ch, stop }
+    }
+
+    pub fn squash_successive_waypoints(waypoints: Vec<Waypoint>) -> Vec<Waypoint> {
+        let mut result = Vec::<Waypoint>::with_capacity(waypoints.len());
+        for waypoint in waypoints {
+            if let Some(prev) = result.last_mut() {
+                if prev.ci == waypoint.ci && prev.ch == waypoint.ch {
+                    prev.stop |= waypoint.stop;
+                    continue;
+                }
+            }
+            result.push(waypoint);
+        }
+        result
+    }
+}
+
+impl std::fmt::Debug for Waypoint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}:{}{}",
+            self.ci,
+            self.ch,
+            if self.stop { "[STOP]" } else { "" },
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+#[cfg_attr(test, derive(PartialEq))]
+pub struct Segment(VecDeque<Waypoint>);
+
+impl Segment {
+    /// Splits the waypoints into segments between each stops
+    ///
+    /// The stop waypoint at the end of one segment is included in the next segment.
+    ///
+    /// # Panics
+    ///
+    /// The first and last provided waypoints must be stop waypoints.
+    /// There must be at least two waypoints in the provided list. (duh)
+    pub fn split_segments(waypoints: Vec<Waypoint>) -> Result<Vec<Segment>, Error> {
+        if waypoints.len() < 2 {
+            return Err(Error::NotEnoughWaypoints);
+        }
+        if !waypoints.last().unwrap().stop {
+            return Err(Error::LastWaypointNotAStop);
+        }
+
+        let mut segments = Vec::<VecDeque<Waypoint>>::new();
+        for waypoint in waypoints {
+            if waypoint.stop {
+                if let Some(last_segment) = segments.last_mut() {
+                    last_segment.push_back(waypoint.clone());
+                }
+                segments.push(VecDeque::from([waypoint]));
+            } else if let Some(last_segment) = segments.last_mut() {
+                last_segment.push_back(waypoint);
+            } else {
+                return Err(Error::FirstWaypointNotAStop);
+            }
+        }
+
+        if segments.last().map(|s| s.len()) == Some(1) {
+            segments.pop();
+        }
+
+        Ok(segments.into_iter().map(Segment).collect())
+    }
+
+    pub fn start(&self) -> Result<&Waypoint, Error> {
+        self.front().ok_or(Error::EmptySegment)
+    }
+
+    pub fn end(&self) -> Result<&Waypoint, Error> {
+        self.back().ok_or(Error::EmptySegment)
+    }
+}
+
+impl Deref for Segment {
+    type Target = VecDeque<Waypoint>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for Segment {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+
+    use editoast_models::DbConnectionPoolV2;
+    use editoast_schemas::fixtures::simple_rolling_stock;
+    use pretty_assertions::assert_eq;
+    use rstest::rstest;
+
+    use crate::generated_data::speed_limit_tags_config::SpeedLimitTagIds;
+    use crate::models::Changeset;
+    use crate::models::Create;
+    use crate::models::RollingStock;
+
+    use super::Error;
+    use super::RollingStockCharacteristics;
+    use super::Segment;
+    use super::Waypoint;
+
+    #[test]
+    fn test_split_segments_valid() {
+        let waypoints = vec![
+            Waypoint::new(1, "1".into(), true),
+            Waypoint::new(2, "2".into(), false),
+            Waypoint::new(3, "3".into(), true),
+            Waypoint::new(4, "4".into(), false),
+            Waypoint::new(5, "5".into(), true),
+        ];
+
+        let expected_segments = vec![
+            Segment(VecDeque::from([
+                Waypoint::new(1, "1".into(), true),
+                Waypoint::new(2, "2".into(), false),
+                Waypoint::new(3, "3".into(), true),
+            ])),
+            Segment(VecDeque::from([
+                Waypoint::new(3, "3".into(), true),
+                Waypoint::new(4, "4".into(), false),
+                Waypoint::new(5, "5".into(), true),
+            ])),
+        ];
+
+        let result = Segment::split_segments(waypoints).unwrap();
+        assert_eq!(result, expected_segments);
+    }
+
+    #[test]
+    fn test_split_segments_minimum_input() {
+        let waypoints = vec![
+            Waypoint::new(1, "1".into(), true),
+            Waypoint::new(2, "2".into(), true),
+        ];
+
+        let expected_segments = vec![Segment(VecDeque::from([
+            Waypoint::new(1, "1".into(), true),
+            Waypoint::new(2, "2".into(), true),
+        ]))];
+
+        let result = Segment::split_segments(waypoints).unwrap();
+        assert_eq!(result, expected_segments);
+    }
+
+    #[test]
+    fn test_split_segments_only_stops() {
+        let waypoints = vec![
+            Waypoint::new(1, "1".into(), true),
+            Waypoint::new(2, "2".into(), true),
+            Waypoint::new(3, "3".into(), true),
+        ];
+
+        let expected_segments = vec![
+            Segment(VecDeque::from([
+                Waypoint::new(1, "1".into(), true),
+                Waypoint::new(2, "2".into(), true),
+            ])),
+            Segment(VecDeque::from([
+                Waypoint::new(2, "2".into(), true),
+                Waypoint::new(3, "3".into(), true),
+            ])),
+        ];
+
+        let result = Segment::split_segments(waypoints).unwrap();
+        assert_eq!(result, expected_segments);
+    }
+
+    #[test]
+    fn test_split_segments_not_enough_waypoints() {
+        let waypoints = vec![Waypoint::new(1, "1".into(), true)];
+        let result = Segment::split_segments(waypoints);
+        assert_eq!(result, Err(Error::NotEnoughWaypoints));
+    }
+
+    #[test]
+    fn test_split_segments_first_not_stop() {
+        let waypoints = vec![
+            Waypoint::new(1, "1".into(), false),
+            Waypoint::new(2, "2".into(), true),
+        ];
+        let result = Segment::split_segments(waypoints);
+        assert_eq!(result, Err(Error::FirstWaypointNotAStop));
+    }
+
+    #[test]
+    fn test_split_segments_last_not_stop() {
+        let waypoints = vec![
+            Waypoint::new(1, "1".into(), true),
+            Waypoint::new(2, "2".into(), false),
+        ];
+        let result = Segment::split_segments(waypoints);
+        assert_eq!(result, Err(Error::LastWaypointNotAStop));
+    }
+
+    #[rstest]
+    async fn test_validate_rolling_stock_exists_no_speed_limit_tag() {
+        let db_pool = DbConnectionPoolV2::for_tests();
+        let rolling_stock_changeset: Changeset<RollingStock> = simple_rolling_stock().into();
+        let rolling_stock = rolling_stock_changeset
+            .version(1)
+            .create(&mut db_pool.get_ok())
+            .await
+            .expect("Failed to create rolling stock");
+        let rolling_stock_characteristics =
+            RollingStockCharacteristics::new(rolling_stock.name, None);
+
+        assert!(
+            rolling_stock_characteristics
+                .validate(&mut db_pool.get_ok(), &SpeedLimitTagIds::load())
+                .await
+                .is_ok(),
+        );
+    }
+
+    #[rstest]
+    async fn test_validate_rolling_stock_exists_valid_speed_limit_tag() {
+        let db_pool = DbConnectionPoolV2::for_tests();
+        let rolling_stock_changeset: Changeset<RollingStock> = simple_rolling_stock().into();
+        let rolling_stock = rolling_stock_changeset
+            .version(1)
+            .create(&mut db_pool.get_ok())
+            .await
+            .expect("Failed to create rolling stock");
+
+        let rolling_stock_characteristics =
+            RollingStockCharacteristics::new(rolling_stock.name, Some("V140".to_string()));
+
+        assert!(
+            rolling_stock_characteristics
+                .validate(&mut db_pool.get_ok(), &SpeedLimitTagIds::load())
+                .await
+                .is_ok(),
+        );
+    }
+
+    #[rstest]
+    async fn test_validate_rolling_stock_not_found() {
+        let db_pool = DbConnectionPoolV2::for_tests();
+        let rolling_stock_characteristics =
+            RollingStockCharacteristics::new("non_existent_rolling_stock".to_string(), None);
+
+        let result = rolling_stock_characteristics
+            .validate(&mut db_pool.get_ok(), &SpeedLimitTagIds::load())
+            .await;
+
+        assert_eq!(result, Err(Error::RollingStockNotFound),);
+    }
+
+    #[rstest]
+    async fn test_validate_invalid_speed_limit_tag() {
+        let db_pool = DbConnectionPoolV2::for_tests();
+        let rolling_stock_changeset: Changeset<RollingStock> = simple_rolling_stock().into();
+        let rolling_stock = rolling_stock_changeset
+            .version(1)
+            .create(&mut db_pool.get_ok())
+            .await
+            .expect("Failed to create rolling stock");
+
+        let rolling_stock_characteristics =
+            RollingStockCharacteristics::new(rolling_stock.name, Some("invalid_tag".to_string()));
+
+        let result = rolling_stock_characteristics
+            .validate(&mut db_pool.get_ok(), &SpeedLimitTagIds::load())
+            .await;
+
+        assert_eq!(result, Err(Error::SpeedLimitTagNotFound),);
+    }
+
+    #[test]
+    fn test_empty_vec() {
+        let input = vec![];
+        let result = Waypoint::squash_successive_waypoints(input);
+        assert_eq!(result, vec![]);
+    }
+
+    #[test]
+    fn test_single_waypoint() {
+        let input = vec![Waypoint::new(1, "A".to_string(), true)];
+        let result = Waypoint::squash_successive_waypoints(input.clone());
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn test_no_duplicates() {
+        let input = vec![
+            Waypoint::new(1, "A".to_string(), true),
+            Waypoint::new(2, "B".to_string(), false),
+            Waypoint::new(3, "C".to_string(), true),
+        ];
+        let result = Waypoint::squash_successive_waypoints(input.clone());
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn test_consecutive_duplicates() {
+        let input = vec![
+            Waypoint::new(1, "A".to_string(), true),
+            Waypoint::new(1, "A".to_string(), false),
+            Waypoint::new(1, "A".to_string(), false),
+            Waypoint::new(2, "B".to_string(), true),
+        ];
+        let expected = vec![
+            Waypoint::new(1, "A".to_string(), true),
+            Waypoint::new(2, "B".to_string(), true),
+        ];
+        let result = Waypoint::squash_successive_waypoints(input);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_non_consecutive_duplicates() {
+        let input = vec![
+            Waypoint::new(1, "A".to_string(), true),
+            Waypoint::new(2, "B".to_string(), false),
+            Waypoint::new(1, "A".to_string(), false),
+            Waypoint::new(3, "C".to_string(), true),
+        ];
+        let expected = vec![
+            Waypoint::new(1, "A".to_string(), true),
+            Waypoint::new(2, "B".to_string(), false),
+            Waypoint::new(1, "A".to_string(), false),
+            Waypoint::new(3, "C".to_string(), true),
+        ];
+        let result = Waypoint::squash_successive_waypoints(input);
+        assert_eq!(result, expected);
+    }
+}

--- a/editoast/src/views/timetable/similar_schedules/response.rs
+++ b/editoast/src/views/timetable/similar_schedules/response.rs
@@ -1,0 +1,32 @@
+use chrono::DateTime;
+use chrono::Utc;
+use serde::Serialize;
+use utoipa::ToSchema;
+
+editoast_common::schemas! {
+    Waypoint,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+#[cfg_attr(test, derive(PartialEq))]
+#[schema(as = SimilarScheduleWaypointResponse)]
+pub struct Waypoint {
+    pub ci: u32,
+    pub ch: String,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct SimilarScheduleItem {
+    pub schedule_id: String,
+    pub start_time: DateTime<Utc>,
+    #[schema(value_type = SimilarScheduleWaypointResponse)]
+    pub begin: Waypoint,
+    #[schema(value_type = SimilarScheduleWaypointResponse)]
+    pub end: Waypoint,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct Response {
+    #[schema(inline)]
+    pub similar_schedules: Vec<SimilarScheduleItem>,
+}


### PR DESCRIPTION
- Introduced `PathItem::new` constructor and `get_uic` method to extract UIC codes from path items.
- Added `Deref` implementation for `SpeedLimitTagIds` to access its inner `Vec<String>`.
- Implemented `TrainSchedule::get_by_rolling_stock_name_and_speed_limit_tag` for querying schedules by rolling stock and optional speed limit tag.
- Added `TrainSchedule::contains_stops_in_order` to verify stop sequences without intermediate stops.
- Included comprehensive tests for `contains_stops_in_order` covering various stop scenarios.
- Created `similar_schedules` endpoint with input validation, waypoint squashing, and segment splitting.
- Added `similar_schedules` request, response, and error modules for modular handling.
- Implemented `similar_schedules` logic to filter train schedules by stop order, returning empty results when no matches are found.