### PR TITLE
readme: authorizations

### DIFF
--- a/docker/docker-compose.pr-tests.yml
+++ b/docker/docker-compose.pr-tests.yml
@@ -152,11 +152,13 @@ services:
       TELEMETRY_ENDPOINT: "http://jaeger:4319"
       OSRD_MQ_URL: "amqp://osrd:password@rabbitmq:5673/%2f"
       EDITOAST_OPENFGA_URL: "http://openfga:8191"
-      EDITOAST_ENABLE_AUTHORIZATION: ${EDITOAST_ENABLE_AUTHORIZATION:-false}
-    command:
-      - /bin/sh
-      - -c
-      - "diesel migration run --locked-schema && exec editoast runserver"
+      EDITOAST_ENABLE_AUTHORIZATION: ${EDITOAST_ENABLE_AUTHORIZATION:-true}
+    command: >
+      /bin/sh -c "
+        diesel migration run --locked-schema &&
+        editoast user add 'mock/mocked' 'Example User' &&
+        editoast roles add 'mock/mocked' Admin &&
+        exec editoast runserver"
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:8089/health" ]
       start_period: 4s

--- a/editoast/README.md
+++ b/editoast/README.md
@@ -90,6 +90,44 @@ Running editoast with deactivated cache can help repeating calls when debugging.
 NO_CACHE=true cargo run -- runserver
 ```
 
+## Authorization
+
+
+### How to disable authorizations
+
+By default editoast is running with authorization enabled. 
+You can disable it by using the environment variable `EDITOAST_ENABLE_AUTHORIZATION=false`
+
+```sh 
+EDITOAST_ENABLE_AUTHORIZATION=false cargo run -- runserver
+```
+
+If you run the stack with docker: 
+
+```sh 
+EDITOAST_ENABLE_AUTHORIZATION=false docker compose up  
+```
+
+If your client has a direct access to editoast, an other possibility is to add the header `x-osrd-skip-authz` in your requests.
+
+### User & role management
+
+You can create a new user with `Admin` role by using the following commands : 
+
+```sh 
+cargo run user add 'mock/mocked' 'Example User'
+cargo run roles add 'mock/mocked' Admin 
+```
+
+Where `mock/mocked` is the **identity** of the user and `Example User` its **name**. 
+In development, the default user `mock/mocked` which is given by the gateway.
+
+If you run the stack with docker, you can use:
+```sh
+docker exec osrd-editoast editoast user add 'mock/mocked' 'Example User'
+docker exec osrd-editoast editoast roles add 'mock/mocked' Admin 
+```
+
 ## For M1 MacOS users
 
 Our `docker-compose.yml` at the root of the project uses the `postgis` image by default.

--- a/front/README.md
+++ b/front/README.md
@@ -60,9 +60,9 @@ Launches end to end tests.
 It requires:
 
 - Install Playwright dependencies `cd ./front/ && npx playwright install --with-deps`
-- Backend containers to be up:
+- Backend containers to be up with authorization disabled:
 
-  `docker compose up --no-build --detach valkey postgres gateway core editoast`
+  `EDITOAST_ENABLE_AUTHORIZATION=false docker compose up --no-build --detach valkey postgres gateway core editoast`
 
 - Running front with `docker compose up --build --detach front`
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -2,7 +2,7 @@
 
 ### Run the tests
 
-To run tests `uv run pytest` after starting docker containers (`docker compose up` at the root of the project) and installing dependencies (`uv sync --all-extras`, see [uv doc](https://docs.astral.sh/uv/)).
+To run tests `uv run pytest` after starting docker containers without authorization mode (`EDITOAST_ENABLE_AUTHORIZATION=false docker compose up` at the root of the project) and installing dependencies (`uv sync --all-extras`, see [uv doc](https://docs.astral.sh/uv/)).
 
 To run a list of specific tests, run `uv run pytest -k test_name_1 test_name_2 ...`.
 


### PR DESCRIPTION
Adding authz documentation in readme files : 
- To run E2E & python test locally, you need to disable the authorizations on editoast
- in editoast to know how to disable it, and also manage users & roles

Follow-up on #11251