### PR TITLE
editoast: use worker_pool_id from CoreArgs instead of "core"

### DIFF
--- a/editoast/src/client/healthcheck.rs
+++ b/editoast/src/client/healthcheck.rs
@@ -21,7 +21,7 @@ pub async fn healthcheck_cmd(
     let valkey = ValkeyClient::new(valkey_config.into()).unwrap();
     let core_client = CoreClient::new_mq(mq_client::Options {
         uri: core_config.mq_url,
-        worker_pool_identifier: String::from("core"),
+        worker_pool_identifier: core_config.worker_pool_id,
         timeout: core_config.core_timeout,
         single_worker: core_config.core_single_worker,
         num_channels: core_config.core_client_channels_size,

--- a/editoast/src/client/runserver.rs
+++ b/editoast/src/client/runserver.rs
@@ -24,6 +24,8 @@ pub struct CoreArgs {
     pub(super) core_single_worker: bool,
     #[clap(long, env = "CORE_CLIENT_CHANNELS_SIZE", default_value_t = 8)]
     pub(super) core_client_channels_size: usize,
+    #[clap(long, env = "EDITOAST_CORE_WORKER_POOL_ID", default_value_t = String::from("core"))]
+    pub(super) worker_pool_id: String,
 }
 
 #[derive(Args, Debug)]
@@ -64,6 +66,7 @@ pub async fn runserver(
                 core_timeout,
                 core_single_worker,
                 core_client_channels_size,
+                worker_pool_id,
             },
         enable_authorization,
         enable_stdcm_logging,
@@ -89,6 +92,7 @@ pub async fn runserver(
                 timeout: Duration::seconds(core_timeout as i64),
                 single_worker: core_single_worker,
                 num_channels: core_client_channels_size,
+                worker_pool_id,
             },
         },
         valkey_config: valkey.into(),

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -476,6 +476,7 @@ pub struct CoreConfig {
     pub timeout: Duration,
     pub single_worker: bool,
     pub num_channels: usize,
+    pub worker_pool_id: String,
 }
 
 pub struct OsrdyneConfig {
@@ -579,10 +580,11 @@ impl AppState {
                 timeout,
                 single_worker,
                 num_channels,
+                worker_pool_id,
             } = config.osrdyne_config.core.clone();
             let options = mq_client::Options {
                 uri: config.osrdyne_config.mq_url.clone(),
-                worker_pool_identifier: "core".to_owned(),
+                worker_pool_identifier: worker_pool_id,
                 timeout: timeout.num_seconds() as u64,
                 single_worker,
                 num_channels,

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -169,6 +169,7 @@ impl TestAppBuilder {
                     timeout: chrono::Duration::seconds(180),
                     single_worker: false,
                     num_channels: 8,
+                    worker_pool_id: "core".into(),
                 },
             },
             valkey_config: ValkeyConfig {


### PR DESCRIPTION
It looks like a refacto because nothing change with the actual version but now, we can use a custom pool_id (envvar or argument). Actually, it is not used so it's the default value "core" that is used

Related to issue #11871