### PR TITLE
core, tests: use permitted speed with no svl on open signal in maxspeedenvelope etcs braking curve

### DIFF
--- a/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/ETCSBrakingSimulator.kt
+++ b/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/ETCSBrakingSimulator.kt
@@ -72,6 +72,7 @@ data class LimitOfAuthority(
 data class EndOfAuthority(
     val offsetEOA: Offset<TravelledPath>,
     val offsetSVL: Offset<TravelledPath>?,
+    val usedCurveType: BrakingType
 ) : Comparable<EndOfAuthority> {
     init {
         if (offsetSVL != null) assert(offsetSVL >= offsetEOA)
@@ -127,12 +128,13 @@ class ETCSBrakingSimulatorImpl(override val context: EnvelopeSimContext) : ETCSB
         for (endOfAuthority in sortedEndsOfAuthority) {
             val eoaBrakingCurves =
                 computeBrakingCurvesAtEOA(endOfAuthority, context, envelope, beginPos)
-            val indicationCurve = eoaBrakingCurves[IND] ?: continue
-            indicationCurve.brakingCurve.stream().forEach { builder.addPart(it) }
+            // Which braking curve (indication speed, permitted speed, ...) to use depends on the
+            // EOA
+            val usedBrakingCurve = eoaBrakingCurves[endOfAuthority.usedCurveType] ?: continue
+            usedBrakingCurve.brakingCurve.stream().forEach { builder.addPart(it) }
 
             // We build EOAs along the path. We need to handle overlaps with the next EOA. To do so,
-            // we
-            // shift the left position constraint, beginPos, to this EOA's target position.
+            // we shift the left position constraint, beginPos, to this EOA's target position.
             beginPos = endOfAuthority.offsetEOA.distance.meters
         }
         return builder.build()

--- a/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/pipelines/MaxSpeedEnvelope.kt
+++ b/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/pipelines/MaxSpeedEnvelope.kt
@@ -17,6 +17,7 @@ import fr.sncf.osrd.envelope_sim.etcs.ETCSBrakingSimulatorImpl
 import fr.sncf.osrd.envelope_sim.etcs.EndOfAuthority
 import fr.sncf.osrd.envelope_sim.etcs.LimitOfAuthority
 import fr.sncf.osrd.envelope_sim.overlays.EnvelopeDeceleration
+import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal
 import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.sim_infra.api.TravelledPath
 import fr.sncf.osrd.utils.units.Offset
@@ -27,14 +28,20 @@ import fr.sncf.osrd.utils.units.meters
  * ignoring allowances
  */
 object MaxSpeedEnvelope {
+    /**
+     * Simple data class used to pass stop data to the class. Combines the stop offset with the
+     * closed/open signal flag.
+     */
+    data class SimStopInfo(val position: Double, val rjsReceptionSignal: RJSReceptionSignal)
 
     /**
      * Simple data class for easier processing, local to this file. Combines the stop offset with
-     * the "etcs" flag.
+     * the "etcs" and closed/open signal flags.
      */
     private data class SimStop(
         val offset: Double,
         val isETCS: Boolean,
+        val rjsReceptionSignal: RJSReceptionSignal,
         val index: Int, // Index in the stop list
     )
 
@@ -128,11 +135,11 @@ object MaxSpeedEnvelope {
     private fun addStopBrakingCurves(
         etcsSimulator: ETCSBrakingSimulator,
         context: EnvelopeSimContext,
-        stopPositions: DoubleArray,
+        stopInfos: List<SimStopInfo>,
         curveWithDecelerations: Envelope
     ): Envelope {
         var envelope = curveWithDecelerations
-        val stops = makeSimStops(context, stopPositions, envelope)
+        val stops = makeSimStops(context, stopInfos, envelope)
         envelope = addETCSStopBrakingCurves(etcsSimulator, context, envelope, stops)
         envelope = addConstStopBrakingCurves(context, envelope, stops)
         return envelope
@@ -193,11 +200,12 @@ object MaxSpeedEnvelope {
      */
     private fun makeSimStops(
         context: EnvelopeSimContext,
-        stopOffsets: DoubleArray,
+        stopInfos: List<SimStopInfo>,
         envelope: Envelope
     ): List<SimStop> {
         val res = mutableListOf<SimStop>()
-        for ((i, stopOffset) in stopOffsets.withIndex()) {
+        for ((i, stopInfo) in stopInfos.withIndex()) {
+            val (stopOffset, isClosedSignal) = stopInfo
             if (stopOffset == 0.0) continue
             val isETCS =
                 context.etcsContext?.applicationRanges?.contains(stopOffset.meters) ?: false
@@ -207,18 +215,17 @@ object MaxSpeedEnvelope {
                     offset = envelope.endPos
                 else throw OSRDError.newEnvelopeError(i, offset, envelope.endPos)
             }
-            res.add(SimStop(offset, isETCS, i))
+            res.add(SimStop(offset, isETCS, isClosedSignal, i))
         }
         return res
     }
 
     /** Generate a max speed envelope given a mrsp */
     @JvmStatic
-    fun from(context: EnvelopeSimContext, stopPositions: DoubleArray, mrsp: Envelope): Envelope {
+    fun from(context: EnvelopeSimContext, stopInfos: List<SimStopInfo>, mrsp: Envelope): Envelope {
         val etcsSimulator = ETCSBrakingSimulatorImpl(context)
         var maxSpeedEnvelope = addSlowdownBrakingCurves(etcsSimulator, context, mrsp)
-        maxSpeedEnvelope =
-            addStopBrakingCurves(etcsSimulator, context, stopPositions, maxSpeedEnvelope)
+        maxSpeedEnvelope = addStopBrakingCurves(etcsSimulator, context, stopInfos, maxSpeedEnvelope)
         return maxSpeedEnvelope
     }
 }

--- a/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/pipelines/MaxSpeedEnvelope.kt
+++ b/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/pipelines/MaxSpeedEnvelope.kt
@@ -12,6 +12,8 @@ import fr.sncf.osrd.envelope_sim.EnvelopeProfile
 import fr.sncf.osrd.envelope_sim.EnvelopeSimContext
 import fr.sncf.osrd.envelope_sim.StopMeta
 import fr.sncf.osrd.envelope_sim.TrainPhysicsIntegrator
+import fr.sncf.osrd.envelope_sim.etcs.BrakingType.IND
+import fr.sncf.osrd.envelope_sim.etcs.BrakingType.PS
 import fr.sncf.osrd.envelope_sim.etcs.ETCSBrakingSimulator
 import fr.sncf.osrd.envelope_sim.etcs.ETCSBrakingSimulatorImpl
 import fr.sncf.osrd.envelope_sim.etcs.EndOfAuthority
@@ -182,7 +184,20 @@ object MaxSpeedEnvelope {
         val endsOfAuthority =
             stops
                 .filter { it.isETCS }
-                .map { EndOfAuthority(Offset(it.offset.meters), getDangerPoint(context, it)) }
+                .map {
+                    EndOfAuthority(
+                        offsetEOA = Offset(it.offset.meters),
+                        // On a closed signal, we follow the indication speed curve with an SVL at
+                        // the next danger point to protect
+                        // On an open signal, we follow the permitted speed curve with no SVL
+                        offsetSVL =
+                            if (it.rjsReceptionSignal.isStopOnClosedSignal())
+                                getDangerPoint(context, it)
+                            else null,
+                        usedCurveType =
+                            if (it.rjsReceptionSignal.isStopOnClosedSignal()) IND else PS
+                    )
+                }
         return simulator.addStopBrakingCurves(envelope, endsOfAuthority)
     }
 

--- a/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope_sim/EnvelopeMaintainSpeedTest.java
+++ b/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope_sim/EnvelopeMaintainSpeedTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 public class EnvelopeMaintainSpeedTest {
     @Test
     public void suddenSlope() {
-        var stops = new double[] {};
+        List<MaxSpeedEnvelope.SimStopInfo> stops = List.of();
         var path =
                 buildNonElectrified(10000, new double[] {0, 5000, 6000, 7000, 8000, 8500, 9000, 10000}, new double[] {
                     0, 40, -40, 0, 50, -50, 0

--- a/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope_sim/MaxEffortEnvelopeTest.java
+++ b/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope_sim/MaxEffortEnvelopeTest.java
@@ -18,6 +18,7 @@ import fr.sncf.osrd.envelope.MRSPEnvelopeBuilder;
 import fr.sncf.osrd.envelope.part.EnvelopePart;
 import fr.sncf.osrd.envelope_sim.pipelines.MaxEffortEnvelope;
 import fr.sncf.osrd.envelope_sim.pipelines.MaxSpeedEnvelope;
+import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal;
 import fr.sncf.osrd.reporting.exceptions.ErrorType;
 import fr.sncf.osrd.reporting.exceptions.OSRDError;
 import java.util.List;
@@ -125,7 +126,7 @@ public class MaxEffortEnvelopeTest {
     @Test
     public void testOverlappingBrakingCurves() {
         var testContext = makeSimpleContext(100, 0);
-        var stops = new double[] {};
+        List<MaxSpeedEnvelope.SimStopInfo> stops = List.of();
         var mrspBuilder = new MRSPEnvelopeBuilder();
         mrspBuilder.addPart(EnvelopePart.generateTimes(
                 List.of(EnvelopeProfile.CONSTANT_SPEED), new double[] {0, 50}, new double[] {30, 30}));
@@ -169,7 +170,7 @@ public class MaxEffortEnvelopeTest {
     @Test
     public void testSeveralSmallPlateau() {
         var testContext = makeSimpleContext(100, 0);
-        var stops = new double[] {3_000};
+        var stops = List.of(new MaxSpeedEnvelope.SimStopInfo(3_000, RJSReceptionSignal.SHORT_SLIP_STOP));
         var mrspBuilder = new MRSPEnvelopeBuilder();
         for (int i = 0; i < 200; i++) {
             mrspBuilder.addPart(EnvelopePart.generateTimes(
@@ -193,7 +194,7 @@ public class MaxEffortEnvelopeTest {
         var testPath = new FlatPath(10, 1_000);
         var testContext = new EnvelopeSimContext(
                 testRollingStock, testPath, TIME_STEP * 10, SimpleRollingStock.LINEAR_EFFORT_CURVE_MAP);
-        var stops = new double[] {};
+        List<MaxSpeedEnvelope.SimStopInfo> stops = List.of();
         var speeds = TreeRangeMap.<Double, Double>create();
         speeds.put(Range.open(0., 9.), 40.);
         speeds.put(Range.open(9., 10.), 60.);

--- a/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope_sim/MaxSpeedEnvelopeTest.java
+++ b/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope_sim/MaxSpeedEnvelopeTest.java
@@ -10,13 +10,15 @@ import static fr.sncf.osrd.envelope_sim.TestMRSPBuilder.makeSimpleMRSP;
 import fr.sncf.osrd.envelope.EnvelopeShape;
 import fr.sncf.osrd.envelope.EnvelopeTransitions;
 import fr.sncf.osrd.envelope_sim.pipelines.MaxSpeedEnvelope;
+import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class MaxSpeedEnvelopeTest {
     @Test
     public void testFlat() {
         var testContext = makeSimpleContext(100000, 0);
-        var stops = new double[] {8500};
+        var stops = List.of(new MaxSpeedEnvelope.SimStopInfo(8500, RJSReceptionSignal.SHORT_SLIP_STOP));
 
         var flatMRSP = makeSimpleMRSP(testContext, 44.4);
         var context = makeSimpleContext(100000, 0);
@@ -33,7 +35,7 @@ public class MaxSpeedEnvelopeTest {
     @Test
     public void testSteep() {
         var testContext = makeSimpleContext(10000, 20);
-        var stops = new double[] {8500};
+        var stops = List.of(new MaxSpeedEnvelope.SimStopInfo(8500, RJSReceptionSignal.STOP));
 
         var flatMRSP = makeSimpleMRSP(testContext, 44.4);
         var context = makeSimpleContext(10000, 20);
@@ -50,7 +52,7 @@ public class MaxSpeedEnvelopeTest {
     @Test
     public void testInitialStop() {
         var testContext = makeSimpleContext(10000, 0);
-        var stops = new double[] {0};
+        var stops = List.of(new MaxSpeedEnvelope.SimStopInfo(0, RJSReceptionSignal.OPEN));
 
         var flatMRSP = makeSimpleMRSP(testContext, 44.4);
         var context = makeSimpleContext(10000, 0);
@@ -64,7 +66,7 @@ public class MaxSpeedEnvelopeTest {
         var effortCurveMap = SimpleRollingStock.LINEAR_EFFORT_CURVE_MAP;
         var testPath = new FlatPath(10000, 0);
         var testContext = new EnvelopeSimContext(testRollingStock, testPath, TIME_STEP, effortCurveMap);
-        var stops = new double[] {8500};
+        var stops = List.of(new MaxSpeedEnvelope.SimStopInfo(8500, RJSReceptionSignal.SHORT_SLIP_STOP));
 
         var flatMRSP = makeSimpleMRSP(testContext, 44.4);
         var context = new EnvelopeSimContext(testRollingStock, testPath, TIME_STEP, effortCurveMap);
@@ -82,7 +84,9 @@ public class MaxSpeedEnvelopeTest {
     public void testWithComplexMRSP() {
         var length = 100000;
         var testContext = makeSimpleContext(length, 0);
-        var stops = new double[] {50000, length};
+        var stops = List.of(
+                new MaxSpeedEnvelope.SimStopInfo(50000, RJSReceptionSignal.SHORT_SLIP_STOP),
+                new MaxSpeedEnvelope.SimStopInfo(length, RJSReceptionSignal.SHORT_SLIP_STOP));
 
         var mrsp = makeComplexMRSP(testContext);
         var context = makeSimpleContext(length, 0);

--- a/core/envelope-sim/src/testFixtures/java/fr/sncf/osrd/envelope_sim/MaxEffortEnvelopeBuilder.java
+++ b/core/envelope-sim/src/testFixtures/java/fr/sncf/osrd/envelope_sim/MaxEffortEnvelopeBuilder.java
@@ -9,6 +9,8 @@ import com.google.common.collect.RangeMap;
 import fr.sncf.osrd.envelope.Envelope;
 import fr.sncf.osrd.envelope_sim.pipelines.MaxEffortEnvelope;
 import fr.sncf.osrd.envelope_sim.pipelines.MaxSpeedEnvelope;
+import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal;
+import java.util.ArrayList;
 
 public class MaxEffortEnvelopeBuilder {
     /** Builds max effort envelope with the specified stops, on a flat MRSP */
@@ -26,7 +28,11 @@ public class MaxEffortEnvelopeBuilder {
     /** Builds max effort envelope with one stop in the middle, one at the end, on a funky MRSP */
     static Envelope makeComplexMaxEffortEnvelope(EnvelopeSimContext context, double[] stops) {
         var mrsp = makeComplexMRSP(context);
-        var maxSpeedEnvelope = MaxSpeedEnvelope.from(context, stops, mrsp);
+        var stopInfos = new ArrayList<MaxSpeedEnvelope.SimStopInfo>();
+        for (double stop : stops) {
+            stopInfos.add(new MaxSpeedEnvelope.SimStopInfo(stop, RJSReceptionSignal.SHORT_SLIP_STOP));
+        }
+        var maxSpeedEnvelope = MaxSpeedEnvelope.from(context, stopInfos, mrsp);
         return MaxEffortEnvelope.from(context, 0, maxSpeedEnvelope);
     }
 
@@ -34,7 +40,11 @@ public class MaxEffortEnvelopeBuilder {
     public static Envelope makeMaxEffortEnvelopeFromSpeedRanges(
             EnvelopeSimContext context, RangeMap<Double, Double> speeds, double[] stops) {
         var flatMRSP = makeSimpleMRSP(context, speeds);
-        var maxSpeedEnvelope = MaxSpeedEnvelope.from(context, stops, flatMRSP);
+        var stopInfos = new ArrayList<MaxSpeedEnvelope.SimStopInfo>();
+        for (double stop : stops) {
+            stopInfos.add(new MaxSpeedEnvelope.SimStopInfo(stop, RJSReceptionSignal.SHORT_SLIP_STOP));
+        }
+        var maxSpeedEnvelope = MaxSpeedEnvelope.from(context, stopInfos, flatMRSP);
         return MaxEffortEnvelope.from(context, 0, maxSpeedEnvelope);
     }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/conflicts/SpacingResourceGenerator.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/conflicts/SpacingResourceGenerator.kt
@@ -439,7 +439,10 @@ class SpacingRequirementAutomaton(
 
         // EoA offset is the detector (blockStartOffset) if signal is 'F' and signalOffset if 'Nf'
         // SvL offset is always the detector
-        val eoa = EndOfAuthority(if (isNf) signalOffset else blockStartOffset, blockStartOffset)
+        // The braking curve used is always the indication curve, pending potential future
+        // refinements
+        val eoa =
+            EndOfAuthority(if (isNf) signalOffset else blockStartOffset, blockStartOffset, IND)
 
         val envelope = callbacks.getRawEnvelopeIfSingle()
         // TODO: stop using a single envelope that's unavailable in STDCM and maybe move to a

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulation.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulation.kt
@@ -123,8 +123,8 @@ fun runStandaloneSimulation(
         )
 
     // Max speed envelope
-    val stopPositions = getStopPositions(schedule)
-    val maxSpeedEnvelope = MaxSpeedEnvelope.from(context, stopPositions.toDoubleArray(), mrsp)
+    val simStops = getSimStops(schedule)
+    val maxSpeedEnvelope = MaxSpeedEnvelope.from(context, simStops, mrsp)
 
     // Add neutral sections
     context =
@@ -481,8 +481,10 @@ fun buildProvisionalEnvelope(
     return margin.apply(maxEffortEnvelope, context)
 }
 
-fun getStopPositions(schedule: List<SimulationScheduleItem>): List<Double> {
-    return schedule.filter { it.stopFor != null }.map { it.pathOffset.distance.meters }
+fun getSimStops(schedule: List<SimulationScheduleItem>): List<MaxSpeedEnvelope.SimStopInfo> {
+    return schedule
+        .filter { it.stopFor != null }
+        .map { MaxSpeedEnvelope.SimStopInfo(it.pathOffset.distance.meters, it.receptionSignal) }
 }
 
 // TODO: Get rid of this function, by propagating DistanceRangeMap to the whole codebase

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/EngineeringAllowanceManager.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/EngineeringAllowanceManager.kt
@@ -106,7 +106,7 @@ class EngineeringAllowanceManager(private val graph: STDCMGraph) {
 
         try {
             // Compute max speed envelope, without any slowing down
-            val maxSpeedEnvelope = MaxSpeedEnvelope.from(context, DoubleArray(0), mrsp)
+            val maxSpeedEnvelope = MaxSpeedEnvelope.from(context, emptyList(), mrsp)
             val maxEffort = MaxEffortEnvelope.from(context, beginSpeed, maxSpeedEnvelope)
             if (maxEffort.none { it.hasAttr(EnvelopeProfile.CONSTANT_SPEED) }) {
                 return 0.0 // When no constant speed part, there can't be any allowance

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
@@ -14,6 +14,7 @@ import fr.sncf.osrd.pathfinding.Pathfinding.EdgeRange
 import fr.sncf.osrd.pathfinding.PathfindingEdgeLocationId
 import fr.sncf.osrd.pathfinding.PathfindingEdgeRangeId
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
+import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal
 import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal.OPEN
 import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal.SHORT_SLIP_STOP
 import fr.sncf.osrd.sim_infra.api.*
@@ -128,9 +129,15 @@ class STDCMPostProcessing(private val graph: STDCMGraph) {
                 trainTag,
                 temporarySpeedLimitManager,
             )
-        val stopPositions = stops.map { it.position }.toMutableList()
-        if (stopAtEnd) stopPositions.add(physicsPath.length)
-        val maxSpeedEnvelope = MaxSpeedEnvelope.from(context, stopPositions.toDoubleArray(), mrsp)
+        val stopInfos =
+            stops
+                .map { MaxSpeedEnvelope.SimStopInfo(it.position, it.receptionSignal) }
+                .toMutableList()
+        if (stopAtEnd)
+            stopInfos.add(
+                MaxSpeedEnvelope.SimStopInfo(physicsPath.length, RJSReceptionSignal.SHORT_SLIP_STOP)
+            )
+        val maxSpeedEnvelope = MaxSpeedEnvelope.from(context, stopInfos, mrsp)
         return MaxEffortEnvelope.from(context, 0.0, maxSpeedEnvelope)
     }
 

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMSimulations.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMSimulations.kt
@@ -15,6 +15,7 @@ import fr.sncf.osrd.envelope_sim.pipelines.MaxSpeedEnvelope
 import fr.sncf.osrd.envelope_sim_infra.EnvelopeTrainPath
 import fr.sncf.osrd.envelope_sim_infra.computeMRSP
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
+import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal
 import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.RawSignalingInfra
@@ -93,11 +94,16 @@ class STDCMSimulations {
         if (stopPosition != null && stopPosition == start) return makeSinglePointEnvelope(0.0)
         val blockLength = infraExplorer.getCurrentBlockLength()
         if (start >= blockLength) return makeSinglePointEnvelope(initialSpeed)
-        var stops = doubleArrayOf()
+        var stops = emptyList<MaxSpeedEnvelope.SimStopInfo>()
         var simLength = blockLength.distance - start.distance
         if (stopPosition != null) {
-            stops = doubleArrayOf((stopPosition - start).meters)
-            simLength = Distance.min(simLength, stops.single().meters)
+            val stopOffset = (stopPosition - start).meters
+            // We presently consider all stdcm stops to be performed on closed signal by default
+            // This presently only affects ETCS computations, which are not yet supported in stdcm
+            // either
+            stops =
+                listOf(MaxSpeedEnvelope.SimStopInfo(stopOffset, RJSReceptionSignal.SHORT_SLIP_STOP))
+            simLength = Distance.min(simLength, stopOffset.meters)
         }
         val path = infraExplorer.getCurrentEdgePathProperties(start, simLength)
         val envelopePath = EnvelopeTrainPath.from(rawInfra, path)

--- a/core/src/test/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulationTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulationTest.kt
@@ -72,7 +72,7 @@ class StandaloneSimulationTest {
         rollingStock.mapTractiveEffortCurves(electrificationMap, Comfort.STANDARD)
     private var context =
         EnvelopeSimContext(rollingStock, envelopeSimPath, 2.0, curvesAndConditions.curves)
-    private val maxSpeedEnvelope = MaxSpeedEnvelope.from(context, doubleArrayOf(), mrsp)
+    private val maxSpeedEnvelope = MaxSpeedEnvelope.from(context, emptyList(), mrsp)
     private val maxEffortEnvelope = MaxEffortEnvelope.from(context, 0.0, maxSpeedEnvelope)
 
     /** Smoke test: we check that nothing crashes */

--- a/tests/tests/test_train_schedule.py
+++ b/tests/tests/test_train_schedule.py
@@ -3,6 +3,7 @@ import json
 from collections.abc import Sequence
 from typing import Any
 
+import pytest
 import requests
 
 from tests.infra import Infra
@@ -623,6 +624,150 @@ def test_etcs_schedule_result_stop_with_eoa_and_svl_at_different_locations(
         simulation_final_output, offset_bending_point_svl_to_eoa
     )
     _assert_equal_speeds(speed_at_bending_point_svl_to_eoa, kph2ms(60.013_601_2))
+
+
+@pytest.mark.parametrize(
+    ["stop_signal_status", "brake_start_offset", "first_bending_point_offset"],
+    [
+        ("OPEN", 34_081_530, 37_794_783),
+        ("STOP", 33_361_530, 37_239_933),
+    ],
+)
+def test_etcs_schedule_result_stop_on_open_signal(
+    etcs_scenario: Scenario,
+    etcs_rolling_stock: int,
+    session: requests.Session,
+    stop_signal_status: str,
+    brake_start_offset: int,
+    first_bending_point_offset: int,
+):
+    rolling_stock_response = session.get(
+        EDITOAST_URL + f"light_rolling_stock/{etcs_rolling_stock}"
+    )
+    etcs_rolling_stock_name = rolling_stock_response.json()["name"]
+
+    ts_response = session.post(
+        f"{EDITOAST_URL}timetable/{etcs_scenario.timetable}/train_schedules/",
+        json=[
+            {
+                "train_name": (
+                    "brake from MRSP: max_speed + closed signal EoA and SvL 100m after EoA"
+                    if stop_signal_status == "STOP"
+                    else "brake from MRSP: max_speed + open signal EoA"
+                ),
+                "labels": [],
+                "rolling_stock_name": etcs_rolling_stock_name,
+                "start_time": "2024-01-01T07:00:00Z",
+                "path": [
+                    {"id": "zero", "track": "TA0", "offset": 862_000},
+                    {"id": "first", "track": "TH0", "offset": 900_000},
+                    {"id": "last", "track": "TH1", "offset": 3_922_000},
+                ],
+                "schedule": [
+                    {"at": "zero", "stop_for": "P0D"},
+                    {
+                        "at": "first",
+                        "stop_for": "PT10S",
+                        "reception_signal": stop_signal_status,
+                    },
+                    {"at": "last", "stop_for": "P0D"},
+                ],
+                "margins": {"boundaries": [], "values": ["0%"]},
+                "initial_speed": 0,
+                "comfort": "STANDARD",
+                "constraint_distribution": "STANDARD",
+                "speed_limit_tag": "foo",
+                "power_restrictions": [],
+            }
+        ],
+    )
+
+    schedule = ts_response.json()[0]
+    schedule_id = schedule["id"]
+    ts_id_response = session.get(f"{EDITOAST_URL}train_schedule/{schedule_id}/")
+    ts_id_response.raise_for_status()
+    simu_response = session.get(
+        f"{EDITOAST_URL}train_schedule/{schedule_id}/simulation?infra_id={etcs_scenario.infra}"
+    )
+    simulation_final_output = simu_response.json()["final_output"]
+
+    assert len(simulation_final_output["positions"]) == len(
+        simulation_final_output["speeds"]
+    )
+
+    # To debug this test: please add a breakpoint then use front to display speed-space chart
+    # (activate Context for Slopes and Speed limits).
+
+    # Check that on an open signal the curves respect the EoA (EoA = stops) but ignore the SVL,
+    # and that there is an acceleration then deceleration in between (maintain speed when reach the MRSP).
+    # The EOA permitted speed curve should also be used on an open signal
+    # instead of the less permissive EOA indication speed curve used for closed signal.
+    # Here, the stop (EoA) is 100m before the PH1 switch (SvL).
+    svl_ph1_offset = 41_138_000
+    first_stop_offset = svl_ph1_offset - 100_000
+    final_stop_offset = 45_060_000
+    stop_offsets = [
+        0,
+        first_stop_offset,
+        final_stop_offset,
+    ]
+
+    # Check null speed at stops
+    for stop_offset in stop_offsets:
+        assert _get_current_or_next_speed_at(simulation_final_output, stop_offset) == 0
+
+    # Check only one acceleration then only one deceleration between stops
+    for offset_index in range(1, len(stop_offsets) - 1):
+        accelerating = True
+        prev_speed = 0
+        start_pos_index = bisect.bisect_left(
+            simulation_final_output["positions"], stop_offsets[offset_index - 1]
+        )
+        end_pos_index = bisect.bisect_left(
+            simulation_final_output["positions"], stop_offsets[offset_index]
+        )
+        for pos_index in range(start_pos_index, end_pos_index):
+            current_speed = simulation_final_output["speeds"][pos_index]
+            if accelerating:
+                if prev_speed > current_speed:
+                    accelerating = False
+            else:
+                assert prev_speed >= current_speed
+            prev_speed = current_speed
+
+    # Check that the braking curve starts at the expected offsets.
+    # In particular the braking occurs later on an open signal (this can be observed in the test params).
+    def check_brake_from_max_speed_at(offset, simulation_final_output):
+        speed_before_first_brake = _get_current_or_next_speed_at(
+            simulation_final_output, offset
+        )
+        _assert_equal_speeds(speed_before_first_brake, MAX_SPEED_288)
+        assert (
+            _get_current_or_next_speed_at(simulation_final_output, offset + 1)
+            < speed_before_first_brake
+        )
+
+    check_brake_from_max_speed_at(brake_start_offset, simulation_final_output)
+
+    # Check the first bending point for the first stop's braking curve (where the Guidance curve's influence stops).
+    # It is similarly delayed on an open signal, though less (this can be observed in the test params).
+    def check_speed_first_bending_point(offset, simulation_final_output):
+        speed_at_bending_guidance_point = _get_current_or_next_speed_at(
+            simulation_final_output, offset
+        )
+        _assert_equal_speeds(speed_at_bending_guidance_point, kph2ms(221.94))
+
+    check_speed_first_bending_point(first_bending_point_offset, simulation_final_output)
+
+    if stop_signal_status == "OPEN":
+        # Check that we continue to follow the EOA permitted speed curve for the open signal without switching to SVL
+        # This is not obvious from the shape of the curve, so this final check mostly serves to prevent accidental
+        # regression by providing a numerical value for the speed.
+        offset_post_bending_point = 40_649_200
+        speed_post_bending_point = _get_current_or_next_speed_at(
+            simulation_final_output, offset_post_bending_point
+        )
+        _assert_equal_speeds(speed_post_bending_point, kph2ms(76.84))
 
 
 def test_etcs_schedule_result_slowdowns(

--- a/tests/tests/test_train_schedule.py
+++ b/tests/tests/test_train_schedule.py
@@ -129,10 +129,10 @@ def test_etcs_schedule_stop_brakes_result_never_reach_mrsp(
                 ],
                 "schedule": [
                     {"at": "zero", "stop_for": "P0D"},
-                    {"at": "first", "stop_for": "PT10S"},
-                    {"at": "second", "stop_for": "PT10S"},
-                    {"at": "third", "stop_for": "PT10S"},
-                    {"at": "fourth", "stop_for": "PT10S"},
+                    {"at": "first", "stop_for": "PT10S", "reception_signal": "STOP"},
+                    {"at": "second", "stop_for": "PT10S", "reception_signal": "STOP"},
+                    {"at": "third", "stop_for": "PT10S", "reception_signal": "STOP"},
+                    {"at": "fourth", "stop_for": "PT10S", "reception_signal": "STOP"},
                     {"at": "last", "stop_for": "P0D"},
                 ],
                 "margins": {"boundaries": [], "values": ["0%"]},
@@ -290,8 +290,8 @@ def test_etcs_schedule_result_stop_brake_from_mrsp(
                 ],
                 "schedule": [
                     {"at": "zero", "stop_for": "P0D"},
-                    {"at": "first", "stop_for": "PT10S"},
-                    {"at": "second", "stop_for": "PT10S"},
+                    {"at": "first", "stop_for": "PT10S", "reception_signal": "STOP"},
+                    {"at": "second", "stop_for": "PT10S", "reception_signal": "STOP"},
                     {"at": "last", "stop_for": "P0D"},
                 ],
                 "margins": {"boundaries": [], "values": ["0%"]},
@@ -404,7 +404,7 @@ def test_etcs_schedule_result_stop_with_eoa_and_svl_at_same_location(
                 ],
                 "schedule": [
                     {"at": "zero", "stop_for": "P0D"},
-                    {"at": "first", "stop_for": "PT10S"},
+                    {"at": "first", "stop_for": "PT10S", "reception_signal": "STOP"},
                     {"at": "last", "stop_for": "P0D"},
                 ],
                 "margins": {"boundaries": [], "values": ["0%"]},
@@ -521,7 +521,11 @@ def test_etcs_schedule_result_stop_with_eoa_and_svl_at_different_locations(
                 ],
                 "schedule": [
                     {"at": "zero", "stop_for": "P0D"},
-                    {"at": "first", "stop_for": "PT10S"},
+                    {
+                        "at": "first",
+                        "stop_for": "PT10S",
+                        "reception_signal": "SHORT_SLIP_STOP",
+                    },
                     {"at": "last", "stop_for": "P0D"},
                 ],
                 "margins": {"boundaries": [], "values": ["0%"]},
@@ -642,7 +646,11 @@ def test_etcs_schedule_result_slowdowns(
                 ],
                 "schedule": [
                     {"at": "zero", "stop_for": "P0D"},
-                    {"at": "last", "stop_for": "P0D"},
+                    {
+                        "at": "last",
+                        "stop_for": "P0D",
+                        "reception_signal": "SHORT_SLIP_STOP",
+                    },
                 ],
                 "margins": {"boundaries": [], "values": ["0%"]},
                 "initial_speed": 0,
@@ -931,7 +939,7 @@ def test_etcs_schedule_result_slowdowns_with_stop(
 def test_etcs_spacing_req(etcs_scenario: Scenario, etcs_rolling_stock: int):
     """
     spacing requirements should:
-    * start at the same time the braking curve starts if stoping on closed signal on the entry of the block
+    * start at the same time the braking curve starts if stopping on closed signal on the entry of the block
     * end when leaving the block
     """
     rolling_stock_response = requests.get(
@@ -1027,7 +1035,7 @@ def test_etcs_spacing_req(etcs_scenario: Scenario, etcs_rolling_stock: int):
         == "zone.[DH1_2:INCREASING, buffer_stop.7:DECREASING]"
     )
     assert spacing_req_zone_final["begin_time"] == 892060
-    assert spacing_req_zone_final["end_time"] == 1087037
+    assert spacing_req_zone_final["end_time"] == 1035083
 
 
 def _assert_equal_speeds(left, right):


### PR DESCRIPTION
Close #11450
Part of https://github.com/osrd-project/osrd-confidential/issues/1004 -> One new part to distinguish Nf and F signals has been added and is still TODO after this PR

