### PR TITLE
editoast: paced train exceptions conflicts implementation

### DIFF
--- a/editoast/editoast_schemas/src/paced_train.rs
+++ b/editoast/editoast_schemas/src/paced_train.rs
@@ -48,34 +48,63 @@ pub struct Paced {
     pub interval: PositiveDuration,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
+#[derive(Debug, Clone, Serialize, PartialEq, ToSchema)]
 pub struct PacedTrain {
     #[serde(flatten)]
     pub train_schedule_base: TrainSchedule,
     #[schema(inline)]
     pub paced: Paced,
-    #[serde(default, deserialize_with = "deserialize_exceptions")]
+    #[serde(default)]
     #[schema(required)]
     pub exceptions: Vec<PacedTrainException>,
 }
 
-fn deserialize_exceptions<'de, D>(deserializer: D) -> Result<Vec<PacedTrainException>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let list = Vec::<PacedTrainException>::deserialize(deserializer)?;
-
-    let mut seen = HashSet::with_capacity(list.len());
-    for e in &list {
-        let key = &e.key;
-        if !seen.insert(key) {
-            return Err(serde::de::Error::custom(format!(
-                "Duplicate exception key: {}",
-                key
-            )));
+impl<'de> Deserialize<'de> for PacedTrain {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct PacedTrainJson {
+            #[serde(flatten)]
+            pub train_schedule_base: TrainSchedule,
+            pub paced: Paced,
+            #[serde(default)]
+            pub exceptions: Vec<PacedTrainException>,
         }
+        let raw = PacedTrainJson::deserialize(deserializer)?;
+
+        let mut seen_keys = HashSet::with_capacity(raw.exceptions.len());
+        for e in &raw.exceptions {
+            if !seen_keys.insert(&e.key) {
+                return Err(serde::de::Error::custom(format!(
+                    "Duplicate exception key: '{}'",
+                    e.key
+                )));
+            }
+        }
+
+        let time_window_secs = raw.paced.time_window.num_seconds();
+        let interval_secs = raw.paced.interval.num_seconds();
+        let num_occurrences = (time_window_secs / interval_secs) as usize;
+
+        for ex in &raw.exceptions {
+            if let ExceptionType::Modified { occurrence_index } = ex.exception_type {
+                if occurrence_index as usize > num_occurrences {
+                    return Err(serde::de::Error::custom(format!(
+                        "Modified exception '{}' references invalid occurrence index {}",
+                        ex.key, occurrence_index,
+                    )));
+                }
+            }
+        }
+
+        Ok(PacedTrain {
+            train_schedule_base: raw.train_schedule_base,
+            paced: raw.paced,
+            exceptions: raw.exceptions,
+        })
     }
-    Ok(list)
 }
 
 /// Represents an exception for a paced train occurrence.

--- a/editoast/src/models/fixtures.rs
+++ b/editoast/src/models/fixtures.rs
@@ -129,7 +129,7 @@ pub fn create_created_exception_with_change_groups(key: &str) -> PacedTrainExcep
         exception_type: ExceptionType::Created {},
         disabled: false,
         train_name: Some(TrainNameChangeGroup {
-            value: "exception_train_name".into(),
+            value: "created_exception_train_name".into(),
         }),
         constraint_distribution: Some(ConstraintDistributionChangeGroup {
             value: Distribution::Mareco,
@@ -213,7 +213,7 @@ pub fn create_created_exception_with_change_groups(key: &str) -> PacedTrainExcep
             value: Some(NonBlankString("GB".into())),
         }),
         start_time: Some(StartTimeChangeGroup {
-            value: DateTime::<Utc>::from_str("2025-05-05T20:05:00+02:00").unwrap(),
+            value: DateTime::<Utc>::from_str("2025-05-15T15:10:00+02:00").unwrap(),
         }),
     }
 }
@@ -224,6 +224,10 @@ pub fn create_modified_exception_with_change_groups(
 ) -> PacedTrainException {
     let mut exception = create_created_exception_with_change_groups(key);
     exception.exception_type = ExceptionType::Modified { occurrence_index };
+    exception.start_time = None;
+    exception.train_name = Some(TrainNameChangeGroup {
+        value: "modified_exception_train_name".to_string(),
+    });
     exception
 }
 

--- a/editoast/src/models/paced_train.rs
+++ b/editoast/src/models/paced_train.rs
@@ -5,6 +5,7 @@ use editoast_derive::Model;
 use editoast_models::rolling_stock::TrainCategory;
 use editoast_schemas;
 use editoast_schemas::paced_train;
+use editoast_schemas::paced_train::ExceptionType;
 use editoast_schemas::paced_train::Paced;
 use editoast_schemas::paced_train::PacedTrainException;
 use editoast_schemas::train_schedule::Comfort;
@@ -14,10 +15,12 @@ use editoast_schemas::train_schedule::PathItem;
 use editoast_schemas::train_schedule::PowerRestrictionItem;
 use editoast_schemas::train_schedule::ScheduleItem;
 use editoast_schemas::train_schedule::TrainScheduleOptions;
+use itertools::Itertools;
 
 use super::Tags;
 use crate::models::prelude::*;
 use crate::models::train_schedule::TrainSchedule;
+use crate::views::timetable::TrainId;
 
 #[derive(Debug, Clone, Model)]
 #[cfg_attr(test, derive(Default, PartialEq))]
@@ -57,13 +60,6 @@ pub struct PacedTrain {
 }
 
 impl PacedTrain {
-    pub fn apply_exceptions(&self, exceptions: &[PacedTrainException]) -> Vec<TrainSchedule> {
-        exceptions
-            .iter()
-            .map(|exception| self.apply_exception(exception))
-            .collect()
-    }
-
     pub fn apply_exception(&self, exception: &PacedTrainException) -> TrainSchedule {
         let mut train_schedule = self.clone().into_train_schedule();
 
@@ -85,6 +81,11 @@ impl PacedTrain {
         }
         if let Some(change_group) = &exception.start_time {
             train_schedule.start_time = change_group.value
+        }
+        if let (ExceptionType::Modified { occurrence_index }, None) =
+            (&exception.exception_type, &exception.start_time)
+        {
+            train_schedule.start_time = self.get_occurrence_start_time(*occurrence_index);
         }
         if let Some(change_group) = &exception.constraint_distribution {
             train_schedule.constraint_distribution = change_group.value;
@@ -126,16 +127,84 @@ impl PacedTrain {
         }
     }
 
-    pub fn iter_occurrences(&self) -> impl Iterator<Item = TrainSchedule> {
-        let base_occurrence = self.clone().into_train_schedule();
-
-        (0..self.num_occurrences()).map(move |occurrence_idx| TrainSchedule {
-            start_time: base_occurrence.start_time + self.interval * occurrence_idx as i32,
-            ..base_occurrence.clone()
-        })
+    /// Returns an iterator over "created" train exceptions with their IDs and schedules.
+    fn get_created_occurrences_exceptions(&self) -> impl Iterator<Item = (TrainId, TrainSchedule)> {
+        self.exceptions
+            .iter()
+            .filter(|exception| matches!(exception.exception_type, ExceptionType::Created { .. }))
+            .map(|exception| {
+                (
+                    TrainId::PacedTrainCreatedException {
+                        paced_train_id: self.id,
+                        exception_key: exception.key.clone(),
+                    },
+                    self.apply_exception(exception),
+                )
+            })
     }
 
-    pub fn num_occurrences(&self) -> usize {
+    fn get_occurrence_start_time(&self, occurrence_index: i32) -> DateTime<Utc> {
+        self.start_time + self.interval * occurrence_index
+    }
+
+    /// Returns all base train occurrences without any exceptions applied.
+    fn get_base_occurrences(&self) -> Vec<(TrainId, TrainSchedule)> {
+        (0..self.num_base_occurrences())
+            .map(move |occurrence_idx| {
+                let base_start_time = self.get_occurrence_start_time(occurrence_idx as i32);
+                let train_id = TrainId::PacedTrainBaseOccurrence {
+                    paced_train_id: self.id,
+                    index: occurrence_idx as u64,
+                };
+                let train_schedule = TrainSchedule {
+                    start_time: base_start_time,
+                    ..self.clone().into_train_schedule()
+                };
+                (train_id, train_schedule)
+            })
+            .collect()
+    }
+
+    /// Returns an iterator over all train occurrences, including:
+    /// - base occurrences
+    /// - occurrences modified by exceptions (which replace a base one)
+    /// - occurrences created by exceptions (additional trains)
+    ///
+    /// This function replaces any base occurrence that has a `Modified` exception,
+    /// and appends any `Created` exceptions as new trains.
+    ///
+    /// The result is sorted by `start_time` to reflect the chronological order of the trains.
+    pub fn iter_occurrences(&self) -> impl Iterator<Item = (TrainId, TrainSchedule)> {
+        let mut base_occurrences = self.get_base_occurrences();
+
+        let enabled_modified_exceptions = self
+            .exceptions
+            .iter()
+            .filter(|ex| !ex.disabled)
+            .filter_map(|e| match e.exception_type {
+                ExceptionType::Modified { occurrence_index } => Some((occurrence_index, e)),
+                _ => None,
+            });
+
+        for (occurrence_index, exception) in enabled_modified_exceptions {
+            if let Some(occurrence) = base_occurrences.get_mut(occurrence_index as usize) {
+                let train_id = TrainId::PacedTrainModifiedException {
+                    paced_train_id: self.id,
+                    index: occurrence_index as u64,
+                    exception_key: exception.key.clone(),
+                };
+                *occurrence = (train_id, self.apply_exception(exception));
+            }
+        }
+
+        base_occurrences
+            .into_iter()
+            .chain(self.get_created_occurrences_exceptions())
+            .sorted_by_key(|(_, ts)| ts.start_time)
+    }
+
+    /// Returns the number of base train occurrences within the pacing window.
+    pub fn num_base_occurrences(&self) -> usize {
         (self.time_window.num_seconds() / self.interval.num_seconds()) as usize
     }
 }
@@ -205,6 +274,7 @@ mod tests {
     use chrono::Utc;
     use editoast_models::rolling_stock::TrainCategory;
     use editoast_schemas::paced_train::PacedTrainException;
+    use editoast_schemas::paced_train::StartTimeChangeGroup;
     use editoast_schemas::train_schedule::Comfort;
     use editoast_schemas::train_schedule::Distribution;
     use editoast_schemas::train_schedule::Margins;
@@ -212,10 +282,12 @@ mod tests {
     use pretty_assertions::assert_eq;
     use rstest::rstest;
 
+    use crate::models;
     use crate::models::PacedTrain;
     use crate::models::Tags;
     use crate::models::fixtures::create_created_exception_with_change_groups;
     use crate::models::fixtures::create_modified_exception_with_change_groups;
+    use crate::views::timetable::TrainId;
 
     pub fn create_paced_train(exceptions: Vec<PacedTrainException>) -> PacedTrain {
         PacedTrain {
@@ -239,7 +311,7 @@ mod tests {
             schedule: vec![],
             speed_limit_tag: None,
             options: TrainScheduleOptions::default(),
-            start_time: DateTime::<Utc>::from_str("2024-09-17T20:05:00+02:00").unwrap(),
+            start_time: DateTime::<Utc>::from_str("2025-05-15T14:00:00+02:00").unwrap(),
             time_window: chrono::Duration::try_hours(2).unwrap(),
             interval: chrono::Duration::try_minutes(30).unwrap(),
             exceptions,
@@ -322,6 +394,158 @@ mod tests {
         assert_eq!(
             paced_train_exception.options,
             exception.options.unwrap().value
+        );
+    }
+
+    #[rstest]
+    async fn num_base_occurrences_without_exceptions() {
+        let paced_train = create_paced_train(vec![]);
+        assert_eq!(paced_train.num_base_occurrences(), 4);
+    }
+
+    #[rstest]
+    async fn num_base_occurrences_with_exceptions() {
+        let paced_train = create_paced_train(vec![
+            create_created_exception_with_change_groups("key_2"),
+            create_modified_exception_with_change_groups("key_1", 0),
+        ]);
+        assert_eq!(paced_train.num_base_occurrences(), 4);
+    }
+
+    #[rstest]
+    async fn iter_occurrences_with_exceptions() {
+        let exception_1 = create_modified_exception_with_change_groups("key_1", 1);
+        let exception_2 = create_created_exception_with_change_groups("key_2");
+        let mut exception_3 = create_modified_exception_with_change_groups("key_3", 0);
+        exception_3.disabled = true;
+
+        let paced_train =
+            create_paced_train(vec![exception_1.clone(), exception_2.clone(), exception_3]);
+        let occurrences: Vec<(TrainId, models::TrainSchedule)> =
+            paced_train.iter_occurrences().collect();
+
+        assert_eq!(occurrences.len(), 5);
+
+        let start_times: Vec<DateTime<Utc>> =
+            occurrences.iter().map(|(_, o)| o.start_time).collect();
+        let train_names: Vec<String> = occurrences
+            .iter()
+            .map(|(_, o)| o.train_name.clone())
+            .collect();
+        let types: Vec<TrainId> = occurrences.iter().map(|(t, _)| t.clone()).collect();
+
+        assert_eq!(
+            start_times,
+            vec![
+                DateTime::<Utc>::from_str("2025-05-15T14:00:00+02:00").unwrap(),
+                DateTime::<Utc>::from_str("2025-05-15T14:30:00+02:00").unwrap(),
+                DateTime::<Utc>::from_str("2025-05-15T15:00:00+02:00").unwrap(),
+                DateTime::<Utc>::from_str("2025-05-15T15:10:00+02:00").unwrap(),
+                DateTime::<Utc>::from_str("2025-05-15T15:30:00+02:00").unwrap(),
+            ]
+        );
+
+        assert_eq!(
+            train_names,
+            vec![
+                "train_name".to_string(),
+                "modified_exception_train_name".to_string(),
+                "train_name".to_string(),
+                "created_exception_train_name".to_string(),
+                "train_name".to_string(),
+            ]
+        );
+
+        assert_eq!(
+            types,
+            vec![
+                TrainId::PacedTrainBaseOccurrence {
+                    paced_train_id: paced_train.id,
+                    index: 0
+                },
+                TrainId::PacedTrainModifiedException {
+                    paced_train_id: paced_train.id,
+                    index: 1,
+                    exception_key: "key_1".to_string()
+                },
+                TrainId::PacedTrainBaseOccurrence {
+                    paced_train_id: paced_train.id,
+                    index: 2
+                },
+                TrainId::PacedTrainCreatedException {
+                    paced_train_id: paced_train.id,
+                    exception_key: "key_2".to_string()
+                },
+                TrainId::PacedTrainBaseOccurrence {
+                    paced_train_id: paced_train.id,
+                    index: 3
+                },
+            ]
+        );
+    }
+
+    #[rstest]
+    async fn iter_occurrences_with_modified_start_time_exception() {
+        let mut exception_1 = create_modified_exception_with_change_groups("key_1", 1);
+        exception_1.start_time = Some(StartTimeChangeGroup {
+            value: DateTime::<Utc>::from_str("2025-05-15T14:31:00+02:00").unwrap(),
+        });
+
+        let paced_train = create_paced_train(vec![exception_1.clone()]);
+        let occurrences: Vec<(TrainId, models::TrainSchedule)> =
+            paced_train.iter_occurrences().collect();
+
+        assert_eq!(occurrences.len(), 4);
+
+        let start_times: Vec<DateTime<Utc>> =
+            occurrences.iter().map(|(_, o)| o.start_time).collect();
+        let train_names: Vec<String> = occurrences
+            .iter()
+            .map(|(_, o)| o.train_name.clone())
+            .collect();
+        let types: Vec<TrainId> = occurrences.iter().map(|(t, _)| t.clone()).collect();
+
+        assert_eq!(
+            start_times,
+            vec![
+                DateTime::<Utc>::from_str("2025-05-15T14:00:00+02:00").unwrap(),
+                DateTime::<Utc>::from_str("2025-05-15T14:31:00+02:00").unwrap(),
+                DateTime::<Utc>::from_str("2025-05-15T15:00:00+02:00").unwrap(),
+                DateTime::<Utc>::from_str("2025-05-15T15:30:00+02:00").unwrap(),
+            ]
+        );
+
+        assert_eq!(
+            train_names,
+            vec![
+                "train_name".to_string(),
+                "modified_exception_train_name".to_string(),
+                "train_name".to_string(),
+                "train_name".to_string(),
+            ]
+        );
+
+        assert_eq!(
+            types,
+            vec![
+                TrainId::PacedTrainBaseOccurrence {
+                    paced_train_id: paced_train.id,
+                    index: 0
+                },
+                TrainId::PacedTrainModifiedException {
+                    paced_train_id: paced_train.id,
+                    index: 1,
+                    exception_key: "key_1".to_string()
+                },
+                TrainId::PacedTrainBaseOccurrence {
+                    paced_train_id: paced_train.id,
+                    index: 2
+                },
+                TrainId::PacedTrainBaseOccurrence {
+                    paced_train_id: paced_train.id,
+                    index: 3
+                },
+            ]
         );
     }
 }

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -492,7 +492,7 @@ enum PacedTrainOccurrenceRef {
 
 #[derive(Debug, Clone, PartialEq)]
 /// This ID is used to identify paced train occurrences and exceptions when sending them to the core API for conflict detection.
-enum TrainId {
+pub enum TrainId {
     TrainSchedule(i64),
     PacedTrainBaseOccurrence {
         paced_train_id: i64,
@@ -696,6 +696,7 @@ async fn retrieve_simulations(
     let paced_train_to_ts = paced_trains
         .iter()
         .flat_map(|pt| pt.iter_occurrences())
+        .map(|(_, pt)| pt)
         .collect::<Vec<_>>();
     let mut conn_clone = conn.clone();
     let (train_simulations, paced_train_simulations) = tokio::try_join!(
@@ -770,15 +771,12 @@ fn build_conflict_core_request(
                 _ => continue,
             };
 
-            let key = TrainId::PacedTrainBaseOccurrence {
-                paced_train_id: paced_train.id,
-                index: index as u64,
-            }
-            .to_string();
+            let (train_id, occurence) = &occurrences[index];
+
             trains_requirements.insert(
-                key,
+                train_id.to_string(),
                 TrainRequirements {
-                    start_time: occurrences[index].start_time,
+                    start_time: occurence.start_time,
                     spacing_requirements: final_output.spacing_requirements.clone(),
                     routing_requirements: final_output.routing_requirements.clone(),
                 },
@@ -1167,7 +1165,7 @@ mod tests {
             .bytes();
         assert_eq!(
             &String::from_utf8(response).unwrap(),
-            "Failed to deserialize the JSON body into the target type: [0].exceptions: Duplicate exception key: duplicated_key_1 at line 1 column 2448"
+            "Failed to deserialize the JSON body into the target type: [0]: Duplicate exception key: 'duplicated_key_1' at line 1 column 2449"
         )
     }
 
@@ -1316,10 +1314,7 @@ mod tests {
             start_time: paced_start_time,
             time_window: chrono::Duration::try_hours(2).unwrap(),
             interval: paced_interval,
-            exceptions: vec![
-                simple_created_exception_with_change_groups("exception_key_1"),
-                simple_modified_exception_with_change_groups("exception_key_2", 0),
-            ],
+            exceptions: vec![],
             ..Default::default()
         };
         let paced_trains = vec![paced_train.clone()];

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -842,7 +842,36 @@ mod tests {
             .bytes();
         assert_eq!(
             &String::from_utf8(response).unwrap(),
-            "Failed to deserialize the JSON body into the target type: exceptions: Duplicate exception key: duplicated_key_1 at line 1 column 1328"
+            "Failed to deserialize the JSON body into the target type: Duplicate exception key: 'duplicated_key_1'"
+        )
+    }
+
+    #[rstest]
+    async fn update_paced_train_with_invalid_exceptions_occurrence_index() {
+        let app = TestAppBuilder::default_app();
+        let pool = app.db_pool();
+
+        let timetable = create_timetable(&mut pool.get_ok()).await;
+        let paced_train = create_simple_paced_train(&mut pool.get_ok(), timetable.id).await;
+
+        let mut paced_train_base = simple_paced_train_base();
+        paced_train_base.paced.time_window = Duration::minutes(60).try_into().unwrap();
+        paced_train_base.paced.interval = Duration::minutes(15).try_into().unwrap();
+        paced_train_base.exceptions =
+            vec![simple_modified_exception_with_change_groups("key_1", 5)];
+
+        let request = app
+            .put(format!("/paced_train/{}", paced_train.id).as_str())
+            .json(&json!(&paced_train_base));
+
+        let response = app
+            .fetch(request)
+            .assert_status(StatusCode::UNPROCESSABLE_ENTITY)
+            .bytes();
+
+        assert_eq!(
+            &String::from_utf8(response).unwrap(),
+            "Failed to deserialize the JSON body into the target type: Modified exception 'key_1' references invalid occurrence index 5"
         )
     }
 

--- a/tests/tests/test_timetable.py
+++ b/tests/tests/test_timetable.py
@@ -1,4 +1,5 @@
 from typing import Any
+from collections import Counter
 
 import pytest
 from requests import Session
@@ -234,17 +235,6 @@ def test_conflicts_with_reception_on_closed_signal(
     response_project_path.raise_for_status()
 
 
-def _create_paced_train_exception_payload(key: str = "exception_key_1"):
-    return {
-        "key": key,
-        "disabled": False,
-        "start_time": {
-            "value": "2024-05-22T08:16:00.000Z",
-        },
-        "train_name": {"value": "exception_train_name"},
-    }
-
-
 @pytest.mark.parametrize(
     ["paced_train_interval", "expected_conflict_types"],
     [
@@ -288,7 +278,7 @@ def test_paced_train_conflicts(
         "start_time": "2024-05-22T08:00:00.000Z",
         "train_name": "paced train",
         "paced": {"time_window": "PT1H", "interval": paced_train_interval},
-        "exceptions": [_create_paced_train_exception_payload()],
+        "exceptions": [],
     }
 
     paced_train_response = session.post(
@@ -306,6 +296,129 @@ def test_paced_train_conflicts(
         conflict["conflict_type"] for conflict in conflicts_response.json()
     }
     assert actual_conflicts == expected_conflict_types
+
+
+# This test verifies that conflicts between a paced train and its exceptions are correctly detected.
+# It focuses on scenarios where exceptions override the default behavior of paced train occurrences,
+# either by changing the start time or modifying the train name at a specific index.
+#
+# The paced train is scheduled with:
+#   - a base `start_time` of "2024-05-22T08:00:00.000Z"
+#   - a pacing interval of 15 minutes ("PT15M")
+#
+# It defines 3 exceptions:
+# 1. `created_ex_key` creates a new train occurrence at "2024-05-22T08:01:00.000Z"
+# 2. `modified_ex_key` modifies the 3rd occurrence (index=2), normally scheduled at "2024-05-22T08:30:00.000Z"
+# 3. `created_ex_conflict_modified_key` creates a new occurrence also at "2024-05-22T08:30:00.000Z"
+#
+# This results in two expected conflicts:
+# - One between the base occurrence at 08:00 and the new exception at 08:01
+# - Another between the modified occurrence at 08:30 and the newly created conflicting exception at the same time
+def test_paced_train_with_exceptions_conflicts(
+    small_infra: Infra,
+    timetable_id: int,
+    fast_rolling_stock: int,
+    session: Session,
+):
+    session.post(f"{EDITOAST_URL}infra/{small_infra.id}/load").raise_for_status()
+    paced_train_payload = {
+        "comfort": "STANDARD",
+        "constraint_distribution": "STANDARD",
+        "initial_speed": 0,
+        "labels": [],
+        "options": {"use_electrical_profiles": False},
+        "path": [
+            {"id": "start", "track": "TC1", "offset": 185000},
+            {"id": "end", "track": "TD0", "offset": 24820000},
+        ],
+        "power_restrictions": [],
+        "rolling_stock_name": "fast_rolling_stock",
+        "schedule": [
+            {
+                "at": "start",
+            },
+            {
+                "at": "end",
+            },
+        ],
+        "speed_limit_tag": "MA100",
+        "start_time": "2024-05-22T08:00:00.000Z",
+        "train_name": "paced train",
+        "paced": {"time_window": "PT1H", "interval": "PT15M"},
+        "exceptions": [
+            {
+                "key": "created_ex_key",
+                "disabled": False,
+                "start_time": {
+                    "value": "2024-05-22T08:01:00.000Z",
+                },
+                "train_name": {"value": "created_exception_train_name"},
+            },
+            {
+                "key": "modified_ex_key",
+                "occurrence_index": 2,
+                "disabled": False,
+                "train_name": {"value": "modified_exception_train_name"},
+            },
+            {
+                "key": "created_ex_conflict_modified_key",
+                "disabled": False,
+                "start_time": {
+                    "value": "2024-05-22T08:30:00.000Z",
+                },
+                "train_name": {"value": "exception_train_name"},
+            },
+        ],
+    }
+
+    paced_train_response = session.post(
+        f"{EDITOAST_URL}timetable/{timetable_id}/paced_trains",
+        json=[paced_train_payload],
+    )
+    paced_train_response.raise_for_status()
+
+    conflicts_response = session.get(
+        f"{EDITOAST_URL}timetable/{timetable_id}/conflicts/?infra_id={small_infra.id}"
+    )
+    conflicts_response.raise_for_status()
+    conflicts_response_json = conflicts_response.json()
+
+    paced_train_occurrence_ids = [
+        [
+            {
+                "index": c.get("index", None),
+                "exception_key": c.get("exception_key", None),
+            }
+            for c in conflict["paced_train_occurrence_ids"]
+        ]
+        for conflict in conflicts_response_json
+    ]
+
+    expected_conflict_with_created_exception = [
+        {"exception_key": None, "index": 0},
+        {"exception_key": "created_ex_key", "index": None},
+    ]
+
+    expected_conflict_with_modified_exception = [
+        {"exception_key": "modified_ex_key", "index": 2},
+        {"exception_key": "created_ex_conflict_modified_key", "index": None},
+    ]
+
+    assert any(
+        _match_conflict_lists(conflict, expected_conflict_with_created_exception)
+        for conflict in paced_train_occurrence_ids
+    ), "Missing expected_conflict_with_created_exception"
+
+    assert any(
+        _match_conflict_lists(conflict, expected_conflict_with_modified_exception)
+        for conflict in paced_train_occurrence_ids
+    ), "Missing expected_conflict_with_modified_exception"
+
+
+def _match_conflict_lists(a, b):
+    return Counter(frozenset(d.items()) for d in a) == Counter(
+        frozenset(d.items()) for d in b
+    )
 
 
 def test_scheduled_points_with_incompatible_margins(


### PR DESCRIPTION
Part of #11456

This PR implement conflicts detections with paced trains exceptions
Integrations tests
Handles the generation of occurrences for paced train exceptions