### PR TITLE
editoast: fga: add `Client::tuple_exists` to query stored tuples

### DIFF
--- a/editoast/fga/src/client.rs
+++ b/editoast/fga/src/client.rs
@@ -297,6 +297,27 @@ impl Client {
         Ok(model_id)
     }
 
+    /// Returns whether a tuple exists in OpenFGA
+    ///
+    /// Not to be mistaken with [Client::check]. This function internally calls
+    /// `/stores/{store_id}/read`. Check out OpenFGA documentation for more information
+    /// about the distinction between tuples and checks.
+    pub async fn tuple_exists<R: Relation, U: AsUser<User = R::User>>(
+        &self,
+        tuple: Tuple<'_, R, U>,
+    ) -> Result<bool, RequestFailure> {
+        let (tuples, _continuation) = self
+            .get_stores_read(
+                &self.store.id,
+                RawTuple::from(&tuple),
+                Some(1),
+                self.authorization_model_id.as_deref(),
+                None,
+            )
+            .await?;
+        Ok(!tuples.is_empty())
+    }
+
     /// Writes up to `n` tuples in OpenFGA, with `n` the maximum number of tuple writes
     /// configured in the [ConnectionSettings::limits]'s [Limits::max_tuples_per_write].
     ///
@@ -920,6 +941,16 @@ pub trait Request {
         self,
         client: &Client,
     ) -> impl future::Future<Output = Result<Self::Response, Self::Error>>;
+}
+
+impl<R: Relation, U: AsUser<User = R::User>> Request for Tuple<'_, R, U> {
+    type Response = bool;
+
+    type Error = RequestFailure;
+
+    async fn fetch(self, client: &Client) -> Result<Self::Response, Self::Error> {
+        client.tuple_exists(self).await
+    }
 }
 
 impl<R: Relation, U: AsUser<User = R::User>> Request for Check<'_, R, U> {
@@ -1636,5 +1667,43 @@ mod tests {
             .assert_check_not(Infra::can_read().check(&fga!(User:"alice"), &fga!(Infra:"france")))
             .assert_check_not(Infra::can_read().check(&fga!(User:"bob"), &fga!(Infra:"espagne")))
             .assert_check(Infra::can_read().check(&fga!(User:"charlie"), &fga!(Infra:"germany")));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn tuple_exists() {
+        setup_tracing();
+        let model = compile_model(MODEL);
+        let mut client = test_client!();
+        client.update_authorization_model(&model).await.unwrap();
+
+        client
+            .write_tuples(&[fga!(Infra:"france"#reader@User:"alice")])
+            .await
+            .unwrap();
+
+        assert!(
+            client
+                .tuple_exists(fga!(Infra:"france"#reader@User:"alice"))
+                .await
+                .unwrap()
+        );
+        assert!(
+            !client
+                .tuple_exists(fga!(Infra:"espagne"#reader@User:"bob"))
+                .await
+                .unwrap()
+        );
+
+        client
+            .delete_tuples(&[fga!(Infra:"france"#reader@User:"alice")])
+            .await
+            .unwrap();
+
+        assert!(
+            !client
+                .tuple_exists(fga!(Infra:"france"#reader@User:"alice"))
+                .await
+                .unwrap()
+        );
     }
 }

--- a/editoast/fga/src/client/tuples.rs
+++ b/editoast/fga/src/client/tuples.rs
@@ -1,12 +1,15 @@
+use itertools::Itertools;
+
 use crate::model::AsUser;
 use crate::model::Object as _;
 use crate::model::Relation;
 use crate::model::Tuple;
 
 use super::Client;
+use super::Consistency;
 use super::RequestFailure;
 
-#[derive(Debug, serde::Serialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub(super) struct RawTuple {
     pub(super) user: String,
     pub(super) relation: String,
@@ -24,6 +27,66 @@ impl<'a, R: Relation, U: AsUser<User = R::User>> From<&Tuple<'a, R, U>> for RawT
 }
 
 impl Client {
+    #[tracing::instrument(skip(self), err)]
+    pub(super) async fn get_stores_read<'a>(
+        &self,
+        store_id: &str,
+        tuple_key: RawTuple,
+        page_size: Option<usize>,
+        authorization_model_id: Option<&str>,
+        consistency: Option<Consistency>,
+    ) -> Result<(Vec<RawTuple>, String), RequestFailure> {
+        #[derive(serde::Serialize)]
+        struct Request<'a> {
+            tuple_key: RawTuple,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            page_size: Option<usize>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            authorization_model_id: Option<&'a str>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            consistency: Option<Consistency>,
+        }
+
+        #[derive(serde::Deserialize)]
+        struct Response {
+            tuples: Vec<TupleResponse>,
+            #[serde(default)]
+            continuation_token: String,
+        }
+
+        #[derive(serde::Deserialize)]
+        struct TupleResponse {
+            key: RawTuple,
+            // timestamp — not needed for our use case
+        }
+
+        let url = self
+            .base_url()
+            .join(format!("stores/{store_id}/read").as_str())
+            .unwrap();
+
+        let Response {
+            tuples,
+            continuation_token,
+        } = self
+            .inner
+            .post(url)
+            .json(&Request {
+                tuple_key,
+                page_size,
+                authorization_model_id,
+                consistency,
+            })
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+
+        let tuples = tuples.into_iter().map(|t| t.key).collect_vec();
+        Ok((tuples, continuation_token))
+    }
+
     // It's fine to request tuples to be mapped into `RawTuple` as OpenFGA
     // doesn't support more than 100 tuples in the request. So mapping 100 objects
     // max is fine—we'll always be bounded by the network call.


### PR DESCRIPTION
refs #11697
depends on #11932
part of #11933

Allows querying stored tuples without interpreting logical relations between definitions.
