### PR TITLE
front: fix combobox suggestion lists width to match the mockup

### DIFF
--- a/front/src/styles/scss/applications/stdcm/_card.scss
+++ b/front/src/styles/scss/applications/stdcm/_card.scss
@@ -94,13 +94,6 @@
       margin-bottom: 0;
     }
 
-    .combo-box {
-      .suggestions-list {
-        width: 99%;
-        left: 0;
-      }
-    }
-
     // cards styles
     &.consist {
       padding-left: 24px;

--- a/front/ui/ui-core/src/styles/inputs/comboBox.css
+++ b/front/ui/ui-core/src/styles/inputs/comboBox.css
@@ -6,10 +6,9 @@
 
   .suggestions-list {
     position: absolute;
-    width: calc(100% - 2.1rem);
+    width: calc(100% - 1.55rem);
     top: calc(100% - 1.4rem);
-    left: 1rem;
-    right: 0;
+    right: 0.70rem;
     z-index: 1000;
     list-style: none;
     max-height: calc(2.5rem * var(--number-of-suggestions));
@@ -24,8 +23,8 @@
 
   &:has(.narrow) .suggestions-list {
     top: calc(100% - 7px);
-    left: 0;
-    width: calc(100% - 4px);
+    width: calc(100% + 4px);
+    left: -2px;
   }
 
   .suggestion-item {


### PR DESCRIPTION
Close #11947 
Fix the width of combobox suggestion lists to add 2px overflow on each side of the combobox.


![image](https://github.com/user-attachments/assets/69f8e5e3-b0fa-4492-9eaa-e883edd9e57f)
