### PR TITLE
python: osrd-schemas: make the extensions' field optional

### DIFF
--- a/python/osrd_schemas/osrd_schemas/infra.py
+++ b/python/osrd_schemas/osrd_schemas/infra.py
@@ -638,7 +638,7 @@ def register_extension(object: Type[BaseModel], name):
             )
 
         extensions_field.annotation.model_fields[name] = FieldInfo(
-            annotation=extension,
+            annotation=Optional[extension],  # type: ignore # This is how <type> | None is handled by pydantic
             default=None,
         )
         return extension

--- a/python/osrd_schemas/osrd_schemas/infra_editor.py
+++ b/python/osrd_schemas/osrd_schemas/infra_editor.py
@@ -158,6 +158,22 @@ class _TmpSignal(BaseModel):
     )
 
 
+def make_extensions_non_nullable(schema: dict):
+    """This is required in order not to make the front weird."""
+    for name, definition in schema["$defs"].items():
+        if not name.endswith("Extensions"):
+            continue
+
+        new_properties = {}
+        for prop_name, prop_def in definition["properties"].items():
+            new_properties[prop_name] = {
+                "default": None,
+                "$ref": prop_def["anyOf"][0]["$ref"],
+            }
+
+        definition["properties"] = new_properties
+
+
 if __name__ == "__main__":
     from json import dumps
 
@@ -167,6 +183,8 @@ if __name__ == "__main__":
     railjson_schema["$defs"]["Signal"]["properties"].update(
         tmp_signal_schema["properties"]
     )
+
+    make_extensions_non_nullable(railjson_schema)
 
     # sort keys in order to diff correctly in the CI
     print(dumps(railjson_schema, indent=4, sort_keys=True))

--- a/python/osrd_schemas/pyproject.toml
+++ b/python/osrd_schemas/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "osrd_schemas"
-version = "0.8.17"
+version = "0.8.18"
 description = ""
 authors = [{ name = "OSRD Contributors", email = "contact@osrd.fr" }]
 requires-python = ">= 3.11"

--- a/python/osrd_schemas/uv.lock
+++ b/python/osrd_schemas/uv.lock
@@ -34,7 +34,7 @@ wheels = [
 
 [[package]]
 name = "osrd-schemas"
-version = "0.8.17"
+version = "0.8.18"
 source = { editable = "." }
 dependencies = [
     { name = "geojson-pydantic" },

--- a/python/railjson_generator/pyproject.toml
+++ b/python/railjson_generator/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "railjson_generator"
-version = "0.4.10"
+version = "0.4.11"
 description = ""
 authors = [{ name = "OSRD Contributors", email = "contact@osrd.fr" }]
 requires-python = ">= 3.11"

--- a/python/railjson_generator/uv.lock
+++ b/python/railjson_generator/uv.lock
@@ -106,7 +106,7 @@ wheels = [
 
 [[package]]
 name = "osrd-schemas"
-version = "0.8.17"
+version = "0.8.18"
 source = { editable = "../osrd_schemas" }
 dependencies = [
     { name = "geojson-pydantic" },
@@ -250,7 +250,7 @@ wheels = [
 
 [[package]]
 name = "railjson-generator"
-version = "0.4.10"
+version = "0.4.11"
 source = { editable = "." }
 dependencies = [
     { name = "osrd-schemas" },

--- a/tests/uv.lock
+++ b/tests/uv.lock
@@ -182,7 +182,7 @@ wheels = [
 
 [[package]]
 name = "osrd-schemas"
-version = "0.8.17"
+version = "0.8.18"
 source = { editable = "../python/osrd_schemas" }
 dependencies = [
     { name = "geojson-pydantic" },
@@ -340,7 +340,7 @@ wheels = [
 
 [[package]]
 name = "railjson-generator"
-version = "0.4.10"
+version = "0.4.11"
 source = { editable = "../python/railjson_generator" }
 dependencies = [
     { name = "osrd-schemas" },


### PR DESCRIPTION
This allows for the schemas to be able to parse objects returned by editoast's endpoints

I bumped osrd-schemas-version, synced railjson-generator so it uses the latest osrd-schemas-versions, so bumped its version, and then synced the integration tests