### PR TITLE
front: fix category in OccurrenceIndicator

### DIFF
--- a/front/src/modules/trainschedule/components/Timetable/PacedTrain/OccurrenceIndicator.tsx
+++ b/front/src/modules/trainschedule/components/Timetable/PacedTrain/OccurrenceIndicator.tsx
@@ -18,6 +18,7 @@ const TOOLTIP_BOTTOM_MARGIN = 24;
 
 const OccurrenceIndicator = ({ occurrence }: OccurrenceIndicatorProps) => {
   const { t } = useTranslation('operational-studies', { keyPrefix: 'main.timetable' });
+  const { t: mainT } = useTranslation();
   const dotRef = useRef<HTMLDivElement>(null);
   const changeGroupsRef = useRef<HTMLDivElement>(null);
 
@@ -59,6 +60,8 @@ const OccurrenceIndicator = ({ occurrence }: OccurrenceIndicatorProps) => {
     });
   }, [isHovering]);
 
+  const rollingStockCategoryChangeGroup = occurrence.exceptionChangeGroups?.rolling_stock_category;
+
   return (
     <div
       className="occurrence-indicator"
@@ -94,12 +97,12 @@ const OccurrenceIndicator = ({ occurrence }: OccurrenceIndicatorProps) => {
               {occurrence.exceptionChangeGroups &&
                 Object.keys(occurrence.exceptionChangeGroups).map((changeGroup, i) => (
                   <span key={i} className="change-group">
-                    {changeGroup !== 'category'
-                      ? t(`occurrenceChangeGroup.${changeGroup}`)
-                      : t(
-                          `rollingStock.categoriesOptions.${occurrence.exceptionChangeGroups?.rolling_stock_category?.value}`,
-                          { ns: 'translation', keyPrefix: '' }
-                        )}
+                    {changeGroup === 'rolling_stock_category' &&
+                    rollingStockCategoryChangeGroup?.value
+                      ? mainT(
+                          `rollingStock.categoriesOptions.${rollingStockCategoryChangeGroup.value}`
+                        )
+                      : t(`occurrenceChangeGroup.${changeGroup}`)}
                   </span>
                 ))}
             </div>


### PR DESCRIPTION
- "category" will never be a key, should be "rolling_stock_category".
- t() doesn't have a keyPrefix option, this is treated as a translation variable and silently ignored.
- The change group may reset the category to null, in which case rolling_stock_category.value is null. We don't want to look up a non-existing translation key "rollingStock.categoriesOptions.null" in that case.