### PR TITLE
python, tests: fix pyright config not typechecking most files in ci

### DIFF
--- a/python/osrd_schemas/justfile
+++ b/python/osrd_schemas/justfile
@@ -23,7 +23,7 @@ format:
 # Verify code lints without applying any fix
 lint:
     uv run ruff check
-    uv run pyright .
+    uv run pyright
 
 # Fix all the lints that can be automatically applied
 fix-lint:

--- a/python/osrd_schemas/pyproject.toml
+++ b/python/osrd_schemas/pyproject.toml
@@ -13,3 +13,7 @@ check = ["pyright ~= 1.1.393", "ruff ~= 0.9.5"]
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.pyright]
+include = ["osrd_schemas"]
+exclude = ["**/__pycache__"]

--- a/python/railjson_generator/justfile
+++ b/python/railjson_generator/justfile
@@ -23,7 +23,7 @@ format:
 # Verify code lints without applying any fix
 lint:
     uv run ruff check
-    uv run pyright .
+    uv run pyright
 
 # Fix all the lints that can be automatically applied
 fix-lint:

--- a/python/railjson_generator/pyproject.toml
+++ b/python/railjson_generator/pyproject.toml
@@ -16,7 +16,9 @@ check = [
 ]
 
 [tool.pyright]
-include = ["../osrd_schemas"]
+include = ["railjson_generator"]
+exclude = ["**/__pycache__"]
+extraPaths = ["../osrd_schemas"]
 
 [tool.uv.sources]
 osrd-schemas = { path = "../osrd_schemas", editable = true }

--- a/tests/infra-scripts/nested_switches.py
+++ b/tests/infra-scripts/nested_switches.py
@@ -33,9 +33,9 @@ Warning: track sections lengths are not consistent with their geometrical coordi
 import sys
 from pathlib import Path
 
-from osrd_schemas.infra import Direction
 from railjson_generator import InfraBuilder
 from railjson_generator.schema.infra.route import Route
+from railjson_generator.schema.infra.direction import Direction
 from railjson_generator.schema.infra.track_section import TrackSection
 from small_infra_creator import ScenarioData
 

--- a/tests/infra-scripts/one_line.py
+++ b/tests/infra-scripts/one_line.py
@@ -2,9 +2,16 @@
 
 import sys
 from pathlib import Path
+from typing import cast
 
 from railjson_generator import ApplicableDirection, InfraBuilder
 from small_infra_creator import ScenarioData
+
+from railjson_generator.schema.infra.track_section import TrackSection
+
+
+class TrackSectionWithInvertedFlag(TrackSection):
+    inverted: bool
 
 
 def _build_scenario_data():
@@ -12,7 +19,10 @@ def _build_scenario_data():
     builder = InfraBuilder()
 
     # Create track sections
-    tracks = [builder.add_track_section(length=1000) for _ in range(10)]
+    base_tracks: list[TrackSection] = [
+        builder.add_track_section(length=1000) for _ in range(10)
+    ]
+    tracks = [cast(TrackSectionWithInvertedFlag, track) for track in base_tracks]
     for i, track in enumerate(tracks):
         track.inverted = i % 2 == 1
 

--- a/tests/infra-scripts/small_infra_creator/__init__.py
+++ b/tests/infra-scripts/small_infra_creator/__init__.py
@@ -9,7 +9,7 @@ https://osrd.fr/en/docs/explanation/models/data-models-full-example/
 from typing import NamedTuple
 from collections.abc import Mapping
 
-from osrd_schemas.infra import LoadingGaugeType, Switch
+from osrd_schemas.infra import LoadingGaugeType
 from railjson_generator import (
     ApplicableDirection,
     ExternalGeneratedInputs,
@@ -19,6 +19,7 @@ from railjson_generator.schema.infra.direction import Direction
 from railjson_generator.schema.infra.electrification import Electrification
 from railjson_generator.schema.infra.infra import Infra
 from railjson_generator.schema.infra.track_section import TrackSection
+from railjson_generator.schema.infra.switch import Switch
 
 
 def place_regular_signals_detectors(

--- a/tests/justfile
+++ b/tests/justfile
@@ -22,7 +22,7 @@ format:
 # Verify code lints without applying any fix
 lint:
     uv run ruff check
-    uv run pyright .
+    uv run pyright
 
 # Fix all the lints that can be automatically applied
 fix-lint:

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -17,7 +17,9 @@ dependencies = [
 check = ["pyright ~= 1.1.393", "ruff ~= 0.11.2"]
 
 [tool.pyright]
-include = ["../python/osrd_schemas"]
+include = ["conftest.py", "fuzzer", "infra-scripts", "tests"]
+exclude = ["**/__pycache__"]
+extraPaths = ["../python/osrd_schemas", "../python/railjson_generator"]
 
 [tool.uv.sources]
 osrd_schemas = { path = "../python/osrd_schemas/", editable = true }


### PR DESCRIPTION
First 2 commits fix pyright issues in tests.

Third commit fix pyright config, which lead to these issues not being caught. See https://github.com/OpenRailAssociation/osrd/actions/runs/15373972691/job/43256663165?pr=11969 for a test of this commit individually (where the issues fixed by the first 2 commits are raised in ci).

Last commit align justfile usage with ci, using pyright config without overriding it with explicit input call.