### PR TITLE
editoast, front: properly handle and delete stdcm env in e2e tests

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -3036,6 +3036,21 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StdcmSearchEnvironment'
+  /stdcm/search_environment/{env_id}:
+    delete:
+      tags:
+      - stdcm_search_environment
+      parameters:
+      - name: env_id
+        in: path
+        description: An stdcm search environment ID
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        '204':
+          description: The stdcm search environment was deleted successfully
   /stdcm_log:
     get:
       tags:
@@ -5470,6 +5485,8 @@ components:
       - $ref: '#/components/schemas/EditoastStdcmLogErrorMissingIdAndTraceId'
       - $ref: '#/components/schemas/EditoastStdcmLogErrorNotFound'
       - $ref: '#/components/schemas/EditoastStdcmLogErrorTraceIdNotFound'
+      - $ref: '#/components/schemas/EditoastStdcmSearchEnvErrorDatabase'
+      - $ref: '#/components/schemas/EditoastStdcmSearchEnvErrorNotFound'
       - $ref: '#/components/schemas/EditoastStudyErrorDatabase'
       - $ref: '#/components/schemas/EditoastStudyErrorNotFound'
       - $ref: '#/components/schemas/EditoastStudyErrorStartDateAfterEndDate'
@@ -6857,6 +6874,49 @@ components:
           type: string
           enum:
           - editoast:stdcm_log:TraceIdNotFound
+    EditoastStdcmSearchEnvErrorDatabase:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 500
+        type:
+          type: string
+          enum:
+          - editoast:stdcm_search_env:Database
+    EditoastStdcmSearchEnvErrorNotFound:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+          required:
+          - env_id
+          properties:
+            env_id:
+              type: integer
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 404
+        type:
+          type: string
+          enum:
+          - editoast:stdcm_search_env:NotFound
     EditoastStudyErrorDatabase:
       type: object
       required:

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -3036,6 +3036,45 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StdcmSearchEnvironment'
+  /stdcm/search_environment/list:
+    get:
+      tags:
+      - stdcm_search_environment
+      parameters:
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int64
+          default: 1
+          minimum: 1
+      - name: page_size
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int64
+          default: 1000
+          nullable: true
+          maximum: 1000
+          minimum: 1
+      responses:
+        '200':
+          description: The paginated list of all existing stdcm search environments
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/PaginationStats'
+                - type: object
+                  required:
+                  - results
+                  properties:
+                    results:
+                      type: array
+                      items:
+                        $ref: '#/components/schemas/StdcmSearchEnvironment'
   /stdcm/search_environment/{env_id}:
     delete:
       tags:

--- a/editoast/src/views/stdcm_search_environment.rs
+++ b/editoast/src/views/stdcm_search_environment.rs
@@ -1,7 +1,11 @@
 use crate::models::prelude::*;
+use crate::views::pagination::PaginatedList;
+use crate::views::pagination::PaginationQueryParams;
+use crate::views::pagination::PaginationStats;
 use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
+use axum::extract::Query;
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
@@ -12,6 +16,7 @@ use editoast_authz::Role;
 use editoast_derive::EditoastError;
 use editoast_models::DbConnectionPoolV2;
 use serde::Deserialize;
+use serde::Serialize;
 use serde::de::Error as SerdeError;
 use std::result::Result as StdResult;
 use thiserror::Error;
@@ -19,8 +24,6 @@ use utoipa::IntoParams;
 use utoipa::ToSchema;
 
 #[cfg(test)]
-use serde::Serialize;
-
 use crate::Model;
 use crate::error::Result;
 use crate::models::Changeset;
@@ -33,6 +36,7 @@ crate::routes! {
     "/stdcm/search_environment" => {
         create,
         retrieve_latest,
+        "/list" => list,
         "/{env_id}" => delete,
     },
 }
@@ -211,8 +215,50 @@ async fn delete(
     Ok(axum::http::StatusCode::NO_CONTENT)
 }
 
+#[derive(Serialize, ToSchema)]
+#[cfg_attr(test, derive(Deserialize))]
+struct SdcmSearchEnvListResponse {
+    #[schema(value_type = Vec<StdcmSearchEnvironment>)]
+    results: Vec<StdcmSearchEnvironment>,
+    #[serde(flatten)]
+    stats: PaginationStats,
+}
+
+#[utoipa::path(
+    get, path = "",
+    tag = "stdcm_search_environment",
+    params(PaginationQueryParams<1000>),
+    responses(
+        (status = 200, body = inline(SdcmSearchEnvListResponse), description = "The paginated list of all existing stdcm search environments"),
+    )
+)]
+async fn list(
+    State(db_pool): State<DbConnectionPoolV2>,
+    Extension(auth): AuthenticationExt,
+    Query(page_settings): Query<PaginationQueryParams<1000>>,
+) -> Result<Json<SdcmSearchEnvListResponse>> {
+    let authorized = auth
+        .check_roles([Role::Admin].into())
+        .await
+        .map_err(AuthorizationError::AuthError)?;
+    if !authorized {
+        return Err(AuthorizationError::Forbidden.into());
+    }
+    let mut conn = db_pool.get().await?;
+    let settings = page_settings
+        .into_selection_settings()
+        .order_by(|| StdcmSearchEnvironment::ID.asc());
+    let (listed_envs, stats) = StdcmSearchEnvironment::list_paginated(&mut conn, settings).await?;
+    Ok(Json(SdcmSearchEnvListResponse {
+        results: listed_envs,
+        stats,
+    }))
+}
+
 #[cfg(test)]
 pub mod tests {
+    use std::collections::HashSet;
+
     use axum::http::StatusCode;
     use chrono::Duration;
     use chrono::DurationRound;
@@ -384,6 +430,72 @@ pub mod tests {
             .await
             .expect("Failed to query stdcm search environment");
 
-        assert_eq!(deleted, None);
+        assert_eq!(deleted_env_exists, false);
+    }
+
+    #[rstest]
+    async fn list_stdcm_search_env() {
+        // GIVEN
+        let app = TestAppBuilder::default_app();
+
+        let pool = app.db_pool();
+
+        let (
+            infra,
+            timetable,
+            work_schedule_group,
+            temporary_speed_limit_group,
+            electrical_profile_set,
+        ) = stdcm_search_env_fixtures(&mut pool.get_ok()).await;
+
+        let env1 = StdcmSearchEnvironment::changeset()
+            .infra_id(infra.id)
+            .electrical_profile_set_id(Some(electrical_profile_set.id))
+            .work_schedule_group_id(Some(work_schedule_group.id))
+            .temporary_speed_limit_group_id(Some(temporary_speed_limit_group.id))
+            .timetable_id(timetable.id)
+            .search_window_begin(Utc.with_ymd_and_hms(2024, 1, 2, 0, 0, 0).unwrap())
+            .search_window_end(Utc.with_ymd_and_hms(2024, 1, 15, 0, 0, 0).unwrap())
+            .enabled_from(Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap())
+            .enabled_until(Utc.with_ymd_and_hms(2024, 1, 1, 23, 59, 59).unwrap())
+            .create(&mut pool.get_ok())
+            .await
+            .expect("Failed to create stdcm search environment");
+
+        let env2 = env1
+            .clone()
+            .into_changeset()
+            .create(&mut pool.get_ok())
+            .await
+            .expect("Failed to create stdcm search environment");
+
+        let env3 = env1
+            .clone()
+            .into_changeset()
+            .create(&mut pool.get_ok())
+            .await
+            .expect("Failed to create stdcm search environment");
+
+        let request = app.get("/stdcm/search_environment/list");
+
+        // WHEN
+        let stdcm_search_env_response = app
+            .fetch(request)
+            .assert_status(StatusCode::OK)
+            .json_into::<SdcmSearchEnvListResponse>();
+
+        // THEN
+        let created_ids = HashSet::from([env1.id, env2.id, env3.id]);
+        let retrieved_ids: HashSet<i64> = stdcm_search_env_response
+            .results
+            .iter()
+            .map(|env| env.id)
+            .collect();
+        assert_eq!(
+            created_ids
+                .difference(&retrieved_ids)
+                .collect::<HashSet<_>>(),
+            HashSet::default()
+        );
     }
 }

--- a/editoast/src/views/stdcm_search_environment.rs
+++ b/editoast/src/views/stdcm_search_environment.rs
@@ -1,5 +1,7 @@
+use crate::models::prelude::*;
 use axum::Extension;
 use axum::extract::Json;
+use axum::extract::Path;
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
@@ -7,10 +9,13 @@ use axum::response::Response;
 use chrono::DateTime;
 use chrono::Utc;
 use editoast_authz::Role;
+use editoast_derive::EditoastError;
 use editoast_models::DbConnectionPoolV2;
 use serde::Deserialize;
 use serde::de::Error as SerdeError;
 use std::result::Result as StdResult;
+use thiserror::Error;
+use utoipa::IntoParams;
 use utoipa::ToSchema;
 
 #[cfg(test)]
@@ -28,12 +33,26 @@ crate::routes! {
     "/stdcm/search_environment" => {
         create,
         retrieve_latest,
+        "/{env_id}" => delete,
     },
 }
 
 editoast_common::schemas! {
     StdcmSearchEnvironmentCreateForm,
     StdcmSearchEnvironment,
+}
+
+#[derive(Debug, Error, EditoastError)]
+#[editoast_error(base_id = "stdcm_search_env")]
+enum StdcmSearchEnvError {
+    /// Could not find the stdcm search env with the given ID
+    #[error("Stdcm search environment '{env_id}', could not be found")]
+    #[editoast_error(status = 404)]
+    NotFound { env_id: i64 },
+
+    #[error(transparent)]
+    #[editoast_error(status = 500)]
+    Database(#[from] editoast_models::model::Error),
 }
 
 #[derive(Deserialize, ToSchema)]
@@ -155,6 +174,43 @@ async fn retrieve_latest(
     }
 }
 
+#[derive(IntoParams, Deserialize)]
+#[allow(unused)]
+struct StdcmSearchEnvIdParam {
+    /// An stdcm search environment ID
+    env_id: i64,
+}
+
+#[utoipa::path(
+    delete, path = "",
+    tag = "stdcm_search_environment",
+    params(StdcmSearchEnvIdParam),
+    responses(
+        (status = 204, description = "The stdcm search environment was deleted successfully"),
+    )
+)]
+async fn delete(
+    State(db_pool): State<DbConnectionPoolV2>,
+    Extension(auth): AuthenticationExt,
+    Path(StdcmSearchEnvIdParam { env_id }): Path<StdcmSearchEnvIdParam>,
+) -> Result<impl IntoResponse> {
+    let authorized = auth
+        .check_roles([Role::Admin].into())
+        .await
+        .map_err(AuthorizationError::AuthError)?;
+    if !authorized {
+        return Err(AuthorizationError::Forbidden.into());
+    }
+
+    let conn = &mut db_pool.get().await?;
+    StdcmSearchEnvironment::delete_static_or_fail(conn, env_id, || StdcmSearchEnvError::NotFound {
+        env_id,
+    })
+    .await?;
+
+    Ok(axum::http::StatusCode::NO_CONTENT)
+}
+
 #[cfg(test)]
 pub mod tests {
     use axum::http::StatusCode;
@@ -206,9 +262,8 @@ pub mod tests {
             .json_into::<StdcmSearchEnvironment>();
 
         // THEN
-        #[expect(deprecated)]
         let stdcm_search_env_in_db =
-            StdcmSearchEnvironment::retrieve(&mut pool.get_ok(), stdcm_search_env.id)
+            StdcmSearchEnvironment::retrieve_real(pool.get_ok(), stdcm_search_env.id)
                 .await
                 .expect("Failed to retrieve stdcm search environment")
                 .expect("Stdcm search environment not found");
@@ -289,5 +344,46 @@ pub mod tests {
 
         // THEN
         response.assert_status(StatusCode::NO_CONTENT);
+    }
+
+    #[rstest]
+    async fn delete_stdcm_search_env() {
+        // GIVEN
+        let app = TestAppBuilder::default_app();
+        let pool = app.db_pool();
+
+        let (
+            infra,
+            timetable,
+            work_schedule_group,
+            temporary_speed_limit_group,
+            electrical_profile_set,
+        ) = stdcm_search_env_fixtures(&mut pool.get_ok()).await;
+
+        let env = StdcmSearchEnvironment::changeset()
+            .infra_id(infra.id)
+            .electrical_profile_set_id(Some(electrical_profile_set.id))
+            .work_schedule_group_id(Some(work_schedule_group.id))
+            .temporary_speed_limit_group_id(Some(temporary_speed_limit_group.id))
+            .timetable_id(timetable.id)
+            .search_window_begin(Utc.with_ymd_and_hms(2024, 1, 2, 0, 0, 0).unwrap())
+            .search_window_end(Utc.with_ymd_and_hms(2024, 1, 15, 0, 0, 0).unwrap())
+            .enabled_from(Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap())
+            .enabled_until(Utc.with_ymd_and_hms(2024, 1, 1, 23, 59, 59).unwrap())
+            .create(&mut pool.get_ok())
+            .await
+            .expect("Failed to create stdcm search environment");
+
+        let request = app.delete(&format!("/stdcm/search_environment/{}", env.id));
+
+        // WHEN
+        app.fetch(request).assert_status(StatusCode::NO_CONTENT);
+
+        // THEN
+        let deleted_env_exists = StdcmSearchEnvironment::exists(&mut pool.get_ok(), env.id)
+            .await
+            .expect("Failed to query stdcm search environment");
+
+        assert_eq!(deleted, None);
     }
 }

--- a/front/.gitignore
+++ b/front/.gitignore
@@ -40,7 +40,6 @@ npm-debug.log*
 /test-results/
 /playwright-report/
 /playwright/.cache/
-/tests/test-saved-environment
 
 # config overrides
 /overrides

--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -214,6 +214,10 @@
       "NotFound": "STDCM log entry '{{id}}' could not be found",
       "TraceIdNotFound": "STDCM log entry '{{trace_id}}' could not be found"
     },
+    "stdcm_search_env": {
+      "Database": "Internal error (database)",
+      "NotFound": "Stdcm search environment '{{env_id}}' could not be found"
+    },
     "study": {
       "Database": "Internal error (database)",
       "NotFound": "Study '{{study_id}}' could not be found",

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -214,6 +214,10 @@
       "NotFound": "STDCM Log '{{id}}' n'a pas pu être trouvée",
       "TraceIdNotFound": "STDCM Log '{{trace_id}}' n'a pas pu être trouvée"
     },
+    "stdcm_search_env": {
+      "Database": "Erreur interne (base de données)",
+      "NotFound": "Environnement de recherche stdcm '{{env_id}}' non trouvé"
+    },
     "study": {
       "Database": "Erreur interne (base de données)",
       "NotFound": "Etude '{{study_id}}' non trouvée",

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -907,6 +907,16 @@ const injectedRtkApi = api
         }),
         invalidatesTags: ['stdcm_search_environment'],
       }),
+      deleteStdcmSearchEnvironmentByEnvId: build.mutation<
+        DeleteStdcmSearchEnvironmentByEnvIdApiResponse,
+        DeleteStdcmSearchEnvironmentByEnvIdApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/stdcm/search_environment/${queryArg.envId}`,
+          method: 'DELETE',
+        }),
+        invalidatesTags: ['stdcm_search_environment'],
+      }),
       getStdcmLog: build.query<GetStdcmLogApiResponse, GetStdcmLogApiArg>({
         query: (queryArg) => ({
           url: `/stdcm_log`,
@@ -1956,6 +1966,11 @@ export type GetStdcmSearchEnvironmentApiArg = void;
 export type PostStdcmSearchEnvironmentApiResponse = /** status 201  */ StdcmSearchEnvironment;
 export type PostStdcmSearchEnvironmentApiArg = {
   stdcmSearchEnvironmentCreateForm: StdcmSearchEnvironmentCreateForm;
+};
+export type DeleteStdcmSearchEnvironmentByEnvIdApiResponse = unknown;
+export type DeleteStdcmSearchEnvironmentByEnvIdApiArg = {
+  /** An stdcm search environment ID */
+  envId: number;
 };
 export type GetStdcmLogApiResponse = /** status 200 The STDCM log */ StdcmLog;
 export type GetStdcmLogApiArg = {

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -907,6 +907,19 @@ const injectedRtkApi = api
         }),
         invalidatesTags: ['stdcm_search_environment'],
       }),
+      getStdcmSearchEnvironmentList: build.query<
+        GetStdcmSearchEnvironmentListApiResponse,
+        GetStdcmSearchEnvironmentListApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/stdcm/search_environment/list`,
+          params: {
+            page: queryArg.page,
+            page_size: queryArg.pageSize,
+          },
+        }),
+        providesTags: ['stdcm_search_environment'],
+      }),
       deleteStdcmSearchEnvironmentByEnvId: build.mutation<
         DeleteStdcmSearchEnvironmentByEnvIdApiResponse,
         DeleteStdcmSearchEnvironmentByEnvIdApiArg
@@ -1966,6 +1979,14 @@ export type GetStdcmSearchEnvironmentApiArg = void;
 export type PostStdcmSearchEnvironmentApiResponse = /** status 201  */ StdcmSearchEnvironment;
 export type PostStdcmSearchEnvironmentApiArg = {
   stdcmSearchEnvironmentCreateForm: StdcmSearchEnvironmentCreateForm;
+};
+export type GetStdcmSearchEnvironmentListApiResponse =
+  /** status 200 The paginated list of all existing stdcm search environments */ PaginationStats & {
+    results: StdcmSearchEnvironment[];
+  };
+export type GetStdcmSearchEnvironmentListApiArg = {
+  page?: number;
+  pageSize?: number | null;
 };
 export type DeleteStdcmSearchEnvironmentByEnvIdApiResponse = unknown;
 export type DeleteStdcmSearchEnvironmentByEnvIdApiArg = {

--- a/front/tests/global-teardown.ts
+++ b/front/tests/global-teardown.ts
@@ -8,7 +8,11 @@ import ROLLING_STOCK_NAMES, {
   trainScheduleProjectName,
 } from './assets/constants/project-const';
 import { logger } from './logging-fixture';
-import { createStdcmEnvironment } from './utils/api-utils';
+import {
+  createStdcmEnvironment,
+  deleteStdcmEnvironment,
+  listStdcmEnvironment,
+} from './utils/api-utils';
 import { deleteInfra, deleteProject, deleteRollingStocks } from './utils/teardown-utils';
 
 teardown('teardown', async ({ browser }) => {
@@ -45,9 +49,16 @@ teardown('teardown', async ({ browser }) => {
       force: true,
     });
 
-    // Delete infra, unless it is currently used as a foreign key by the stdcm env in the database
-    if (savedEnvironment && savedEnvironment.infra_id !== Number(process.env.TEST_INFRA_ID))
-      await deleteInfra(infrastructureName);
+    // Delete all stdcm search environments which are using the current test infra
+    const testStdcmEnvs = (await listStdcmEnvironment()).filter(
+      (env) => env.infra_id === Number(process.env.TEST_INFRA_ID)
+    );
+    for (const env of testStdcmEnvs) {
+      await deleteStdcmEnvironment(env.id);
+    }
+
+    // Delete infra
+    await deleteInfra(infrastructureName);
 
     logger.info('Test data teardown completed successfully.');
   } catch (error) {

--- a/front/tests/global-teardown.ts
+++ b/front/tests/global-teardown.ts
@@ -4,12 +4,11 @@ import { test as teardown } from '@playwright/test';
 
 import ROLLING_STOCK_NAMES, {
   globalProjectName,
-  infrastructureName,
   trainScheduleProjectName,
 } from './assets/constants/project-const';
 import { logger } from './logging-fixture';
-import { deleteStdcmEnvironment, listStdcmEnvironment } from './utils/api-utils';
-import { deleteInfra, deleteProject, deleteRollingStocks } from './utils/teardown-utils';
+import { deleteApiRequest, deleteStdcmEnvironment, listStdcmEnvironment } from './utils/api-utils';
+import { deleteProject, deleteRollingStocks } from './utils/teardown-utils';
 
 teardown('teardown', async ({ browser }) => {
   try {
@@ -37,7 +36,7 @@ teardown('teardown', async ({ browser }) => {
     }
 
     // Delete infra
-    await deleteInfra(infrastructureName);
+    await deleteApiRequest(`/api/infra/${process.env.TEST_INFRA_ID}`);
 
     logger.info('Test data teardown completed successfully.');
   } catch (error) {

--- a/front/tests/global-teardown.ts
+++ b/front/tests/global-teardown.ts
@@ -8,11 +8,7 @@ import ROLLING_STOCK_NAMES, {
   trainScheduleProjectName,
 } from './assets/constants/project-const';
 import { logger } from './logging-fixture';
-import {
-  createStdcmEnvironment,
-  deleteStdcmEnvironment,
-  listStdcmEnvironment,
-} from './utils/api-utils';
+import { deleteStdcmEnvironment, listStdcmEnvironment } from './utils/api-utils';
 import { deleteInfra, deleteProject, deleteRollingStocks } from './utils/teardown-utils';
 
 teardown('teardown', async ({ browser }) => {
@@ -31,23 +27,6 @@ teardown('teardown', async ({ browser }) => {
     // Close all browser contexts
     await Promise.all(browser.contexts().map((context) => context.close()));
     logger.info('All browser contexts closed successfully.');
-
-    // Restore STDCM environment
-    const savedEnvironment = process.env.STDCM_ENVIRONMENT
-      ? JSON.parse(process.env.STDCM_ENVIRONMENT)
-      : null;
-
-    if (savedEnvironment) {
-      await createStdcmEnvironment(savedEnvironment);
-      logger.info('STDCM environment restored successfully.');
-    } else {
-      logger.warn('No STDCM environment to restore.');
-    }
-
-    fs.rmSync('./tests/test-saved-environment/savedStdcmEnvironment.json', {
-      recursive: true,
-      force: true,
-    });
 
     // Delete all stdcm search environments which are using the current test infra
     const testStdcmEnvs = (await listStdcmEnvironment()).filter(

--- a/front/tests/global-teardown.ts
+++ b/front/tests/global-teardown.ts
@@ -8,7 +8,7 @@ import ROLLING_STOCK_NAMES, {
   trainScheduleProjectName,
 } from './assets/constants/project-const';
 import { logger } from './logging-fixture';
-import { setStdcmEnvironment } from './utils/api-utils';
+import { createStdcmEnvironment } from './utils/api-utils';
 import { deleteInfra, deleteProject, deleteRollingStocks } from './utils/teardown-utils';
 
 teardown('teardown', async ({ browser }) => {
@@ -34,7 +34,7 @@ teardown('teardown', async ({ browser }) => {
       : null;
 
     if (savedEnvironment) {
-      await setStdcmEnvironment(savedEnvironment);
+      await createStdcmEnvironment(savedEnvironment);
       logger.info('STDCM environment restored successfully.');
     } else {
       logger.warn('No STDCM environment to restore.');

--- a/front/tests/utils/api-utils.ts
+++ b/front/tests/utils/api-utils.ts
@@ -22,6 +22,7 @@ import type {
   StdcmSearchEnvironment,
   TowedRollingStock,
   GetTowedRollingStockApiResponse,
+  PaginationStats,
 } from 'common/api/osrdEditoastApi';
 
 import {
@@ -57,6 +58,35 @@ export const getApiRequest = async <T>(
   const apiContext = await getApiContext();
   const response = await apiContext.get(url, { params });
   return response.json() as T;
+};
+
+/**
+ * Send GET requests to the specified paginated listing API endpoint with optional query parameters.
+ * This function will send as many requests as needed to get all pages, and return the aggregated full list of items.
+ * To get a specific page, use getApiRequest with appropriate pagination parameters.
+ *
+ * @template T - Type of the listed item.
+ * @param url - The API endpoint URL.
+ * @param params - Optional query parameters to include in the request.
+ */
+export const listApiRequest = async <T>(
+  url: string,
+  params?: { [key: string]: string | number | boolean }
+): Promise<T[]> => {
+  const apiContext = await getApiContext();
+  const itemList: T[] = [];
+  let nextPage: number | null = 1;
+  while (nextPage) {
+    const response = await apiContext.get(url, {
+      params: { page_size: 1000, ...params, page: nextPage },
+    });
+    const { results, next } = (await response.json()) as PaginationStats & {
+      results: T[];
+    };
+    itemList.push(...results);
+    nextPage = next;
+  }
+  return itemList;
 };
 
 /**

--- a/front/tests/utils/api-utils.ts
+++ b/front/tests/utils/api-utils.ts
@@ -267,9 +267,9 @@ export const setElectricalProfile = async (): Promise<ElectricalProfileSet> => {
 };
 
 /**
- * Fetch the STDCM environment if not in CI mode.
+ * Fetch the latest enabled STDCM search environment if not in CI mode.
  */
-export async function getStdcmEnvironment(): Promise<StdcmSearchEnvironment | null> {
+export async function retrieveLatestStdcmEnvironment(): Promise<StdcmSearchEnvironment | null> {
   if (process.env.CI) return null; // Skip in CI mode.
 
   try {
@@ -289,11 +289,13 @@ export async function getStdcmEnvironment(): Promise<StdcmSearchEnvironment | nu
 }
 
 /**
- * Set the STDCM environment with the provided data.
+ * Create a STDCM search environment with the provided data.
  *
  * @param stdcmEnvironment -The stdcm search environment to use.
  */
-export async function setStdcmEnvironment(stdcmEnvironment: StdcmSearchEnvironment): Promise<void> {
+export async function createStdcmEnvironment(
+  stdcmEnvironment: StdcmSearchEnvironment
+): Promise<void> {
   // Remove the `id` field to match the StdcmSearchEnvironmentCreateForm schema
   const { id: _id, ...stdcmEnvironmentWithoutId } = stdcmEnvironment;
   await postApiRequest(
@@ -301,6 +303,25 @@ export async function setStdcmEnvironment(stdcmEnvironment: StdcmSearchEnvironme
     stdcmEnvironmentWithoutId,
     undefined,
     'Failed to update STDCM configuration environment'
+  );
+}
+
+/**
+ * List the STDCM environments.
+ */
+export async function listStdcmEnvironment(): Promise<StdcmSearchEnvironment[]> {
+  return listApiRequest('/api/stdcm/search_environment/list');
+}
+
+/**
+ * Delete the STDCM environment with the provided id.
+ *
+ * @param stdcmSearchEnvId -The id of the stdcm search environment to delete.
+ */
+export async function deleteStdcmEnvironment(stdcmSearchEnvId: number): Promise<void> {
+  await deleteApiRequest(
+    `/api/stdcm/search_environment/${stdcmSearchEnvId}`,
+    `Failed to delete the STDCM search environment with id ${stdcmSearchEnvId}`
   );
 }
 

--- a/front/tests/utils/api-utils.ts
+++ b/front/tests/utils/api-utils.ts
@@ -267,11 +267,9 @@ export const setElectricalProfile = async (): Promise<ElectricalProfileSet> => {
 };
 
 /**
- * Fetch the latest enabled STDCM search environment if not in CI mode.
+ * Fetch the latest enabled STDCM search environment.
  */
 export async function retrieveLatestStdcmEnvironment(): Promise<StdcmSearchEnvironment | null> {
-  if (process.env.CI) return null; // Skip in CI mode.
-
   try {
     const apiContext = await getApiContext();
     const response = await apiContext.get('api/stdcm/search_environment');

--- a/front/tests/utils/setup-utils.ts
+++ b/front/tests/utils/setup-utils.ts
@@ -38,6 +38,7 @@ import {
 import { logger } from '../logging-fixture';
 import { createDateInSpecialTimeZone } from './date-utils';
 import type { ProjectData, StudyData } from './types';
+import { expect } from '@playwright/test';
 
 const projectData: ProjectData = readJsonFile('tests/assets/operation-studies/project.json');
 const studyData: StudyData = readJsonFile('tests/assets/operation-studies/study.json');
@@ -247,6 +248,9 @@ export async function createDataForTests(): Promise<void> {
     } as StdcmSearchEnvironment;
 
     await createStdcmEnvironment(stdcmEnvironment);
+    await expect(await retrieveLatestStdcmEnvironment()).toMatchObject({
+      infra_id: smallInfra.id,
+    });
   } catch (error) {
     throw new Error('Error during test data setup', { cause: error });
   }

--- a/front/tests/utils/setup-utils.ts
+++ b/front/tests/utils/setup-utils.ts
@@ -242,14 +242,8 @@ export async function createDataForTests(): Promise<void> {
         'Europe/Paris'
       ).toISOString(),
       timetable_id: scenarioTrainSchedule.timetable_id,
-      enabled_from: createDateInSpecialTimeZone(
-        '2024-10-16T00:00:00',
-        'Europe/Paris'
-      ).toISOString(),
-      enabled_until: createDateInSpecialTimeZone(
-        '2024-10-17T00:00:00',
-        'Europe/Paris'
-      ).toISOString(),
+      enabled_from: new Date(Date.now() - 60 * 60 * 1000).toISOString(), // one hour ago
+      enabled_until: new Date(Date.now() + 4 * 60 * 60 * 1000).toISOString(), // in four hours
     } as StdcmSearchEnvironment;
 
     await createStdcmEnvironment(stdcmEnvironment);

--- a/front/tests/utils/setup-utils.ts
+++ b/front/tests/utils/setup-utils.ts
@@ -1,4 +1,4 @@
-import { promises } from 'fs';
+import { expect } from '@playwright/test';
 
 import type {
   Infra,
@@ -18,10 +18,12 @@ import {
   postApiRequest,
   createStdcmEnvironment,
 } from './api-utils';
+import { createDateInSpecialTimeZone } from './date-utils';
 import readJsonFile from './file-utils';
 import { sendPacedTrains } from './paced-train';
 import createScenario from './scenario';
 import sendTrainSchedules from './train-schedule';
+import type { ProjectData, StudyData } from './types';
 import {
   dualModeRollingStockName,
   electricRollingStockName,
@@ -35,10 +37,6 @@ import {
   trainScheduleScenarioName,
   trainScheduleStudyName,
 } from '../assets/constants/project-const';
-import { logger } from '../logging-fixture';
-import { createDateInSpecialTimeZone } from './date-utils';
-import type { ProjectData, StudyData } from './types';
-import { expect } from '@playwright/test';
 
 const projectData: ProjectData = readJsonFile('tests/assets/operation-studies/project.json');
 const studyData: StudyData = readJsonFile('tests/assets/operation-studies/study.json');
@@ -152,42 +150,6 @@ export async function createStudy(projectId: number, studyName = globalStudyName
 }
 
 /**
- * Load and save the stdcm environment to ensure it is not erased by the e2e-tests environment
- * @param testInfraId
- */
-async function saveFormerStdcmEnvironment(testInfraId: number) {
-  const savedStdcmEnvFilePath = './tests/test-saved-environment/savedStdcmEnvironment.json';
-  let stdcmEnvironment = await retrieveLatestStdcmEnvironment();
-
-  try {
-    if (stdcmEnvironment && testInfraId !== stdcmEnvironment.infra_id) {
-      // If the stdcm env in the database isn't using the test infra, we know it is a non-test env and we save it, to avoid loss on test interruption.
-      await promises.mkdir('./tests/test-saved-environment', { recursive: true });
-      await promises.writeFile(
-        savedStdcmEnvFilePath,
-        JSON.stringify(stdcmEnvironment, null, 2),
-        'utf-8'
-      );
-    } else {
-      try {
-        // Otherwise, we check if we previously saved a non-test env and recover it.
-        // The only way this can occur normally is if the tests were interrupted before teardown.
-        stdcmEnvironment = readJsonFile<StdcmSearchEnvironment>(savedStdcmEnvFilePath);
-      } catch (error: unknown) {
-        if (!(error instanceof Error && 'code' in error && error.code === 'ENOENT')) {
-          throw error; // Rethrow errors other than file not found
-        }
-      }
-    }
-    // Finally we put the current stdcm env in an env variable in prevision of the teardown,
-    // where we will delete the saved file and put the stdcm env back into the database
-    process.env.STDCM_ENVIRONMENT = JSON.stringify(stdcmEnvironment);
-  } catch (error) {
-    logger.error('Error handling saved STDCM environment: ', error);
-  }
-}
-
-/**
  * Main function to create all necessary test data including infrastructure, rolling stocks,
  * project, study, and scenario.
  */
@@ -230,8 +192,6 @@ export async function createDataForTests(): Promise<void> {
     await sendPacedTrains(scenarioTrainSchedule.timetable_id, pacedTrainsJson);
 
     // Step 7: Configure STDCM search environment for the tests
-    await saveFormerStdcmEnvironment(smallInfra.id);
-
     const stdcmEnvironment = {
       infra_id: smallInfra.id,
       search_window_begin: createDateInSpecialTimeZone(

--- a/front/tests/utils/setup-utils.ts
+++ b/front/tests/utils/setup-utils.ts
@@ -14,9 +14,9 @@ import type {
 import {
   getApiRequest,
   getInfra,
-  getStdcmEnvironment,
+  retrieveLatestStdcmEnvironment,
   postApiRequest,
-  setStdcmEnvironment,
+  createStdcmEnvironment,
 } from './api-utils';
 import readJsonFile from './file-utils';
 import { sendPacedTrains } from './paced-train';
@@ -156,7 +156,7 @@ export async function createStudy(projectId: number, studyName = globalStudyName
  */
 async function saveFormerStdcmEnvironment(testInfraId: number) {
   const savedStdcmEnvFilePath = './tests/test-saved-environment/savedStdcmEnvironment.json';
-  let stdcmEnvironment = await getStdcmEnvironment();
+  let stdcmEnvironment = await retrieveLatestStdcmEnvironment();
 
   try {
     if (stdcmEnvironment && testInfraId !== stdcmEnvironment.infra_id) {
@@ -252,7 +252,7 @@ export async function createDataForTests(): Promise<void> {
       ).toISOString(),
     } as StdcmSearchEnvironment;
 
-    await setStdcmEnvironment(stdcmEnvironment);
+    await createStdcmEnvironment(stdcmEnvironment);
   } catch (error) {
     throw new Error('Error during test data setup', { cause: error });
   }

--- a/front/tests/utils/teardown-utils.ts
+++ b/front/tests/utils/teardown-utils.ts
@@ -3,31 +3,8 @@ import type {
   LightRollingStock,
 } from 'common/api/osrdEditoastApi';
 
-import {
-  getApiRequest,
-  deleteApiRequest,
-  getInfra,
-  getStudy,
-  getScenario,
-  getProject,
-} from './api-utils';
+import { getApiRequest, deleteApiRequest, getStudy, getScenario, getProject } from './api-utils';
 import { logger } from '../logging-fixture';
-
-/**
- * Delete infrastructure by name if it exists.
- *
- * @param infraName - The name of the infrastructure to delete.
- * @returns {Promise<void>} - A promise that resolves when the infrastructure is deleted or if not found.
- */
-export async function deleteInfra(infraName: string): Promise<void> {
-  const infra = await getInfra(infraName);
-
-  if (infra) {
-    await deleteApiRequest(`/api/infra/${infra.id}`);
-  } else {
-    logger.warn(`Infra "${infraName}" not found for deletion.`);
-  }
-}
 
 /**
  * Delete a project by name if it exists.

--- a/scripts/run-front-playwright-container.sh
+++ b/scripts/run-front-playwright-container.sh
@@ -33,13 +33,11 @@ docker build --build-arg PLAYWRIGHT_VERSION=v"$VERSION" -t osrd-playwright:lates
 # Create the bind mounted folders if they don't exist, to avoid them being created as root
 mkdir -p "$PWD/front/playwright-report"
 mkdir -p "$PWD/front/test-results"
-mkdir -p "$PWD/front/tests/test-saved-environment"
 
 docker run -it --rm \
   --ipc=host \
   --network=host \
   -v "$PWD/front/playwright-report:/app/front/playwright-report" \
   -v "$PWD/front/test-results:/app/front/test-results" \
-  -v "$PWD/front/tests/test-saved-environment:/app/front/tests/test-saved-environment" \
   -u "$(stat -c %u:%g .)" \
   osrd-playwright:latest npx playwright test "${args[@]}"


### PR DESCRIPTION
Ever since #10866 , created stdcm search envs are added on top of existing envs rather than overwriting them. In particular, this means that created envs are never deleted. This prevents the e2e-tests teardown from functionning, as to delete the test infra, we first need to delete all stdcm search envs using it. More generally, the way we handled stdcm search envs in the e2e-tests was outdated and did not correspond to the new editoast api.

To solve this :
- Commit 1 and 2 further expand the editoast stdcm search env api to include a list and delete route (admin permissions required)\*
- Commit 3 update the e2e-tests stdcm env api functions to correspond to those of the editoast api
- Commit 6 uses the new list and delete endpoints to remove all test stdcm search envs and properly deletes the test infra
- Commit 7 removes search env saving logic from the tests, which was only required due to envs being overwritten, but is no longer relevant. This means that the work around of  #10518 is gone @emersion, code should be cleaner now ^^. Of note is that we can drop the save file from the gitignore, devs should delete it from their machine if present. 

\* The reason why we need a list endpoint in addition to the delete endpoint is that it is possible for the e2e-tests teardown to fail to be executed properly (if there is a bug in the teardown) or at all (if a keyboard interrupt is sent during any test). This would prevent the test infra from being removed forever without manipulating the database manually.

- Commit 4 solves a tangentially related issue, in that the env created by the tests is not enabled today. (I gave it a 4 days window, but we may want to be a lot more restrictive). 
- Commit 5 asserts that the active env is the one we just created, to prevent this issue from being silent in the future.