### PR TITLE
doc: clarify editoast's authz and no-cache

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -116,14 +116,9 @@ For core:
 ./gradlew shadowJar && ALL_INFRA=true java -jar -ea -Xmx12g -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=dump.hprof build/libs/osrd-all.jar worker --editoast-url http://localhost:8090/
 ```
 
-Removing cache on editoast is also usually helpful to repeat requests
-(please see the [dedicated section](../editoast/README.md#no-cache-mode)). \
-For editoast server, combining single-worker and no-cache modes requires a
-local instance (or a tweak of `docker-compose.single-worker.yml`):
-```sh
-cd ../editoast
-EDITOAST_CORE_SINGLE_WORKER=true NO_CACHE=true cargo run -- runserver
-```
+No-cache mode on editoast is also usually helpful to repeat requests. \
+One may want to combine it with single-worker mode and probably manage authz. \
+Please check [editoast's README](../editoast/README.md) for all that.
 
 
 Clean or restart the whole stack can be necessary sometimes and is also available

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -142,6 +142,7 @@ services:
       OSRD_MQ_URL: "amqp://osrd:password@rabbitmq:5672/%2f"
       EDITOAST_OPENFGA_URL: "http://openfga:8091"
       EDITOAST_ENABLE_AUTHORIZATION: ${EDITOAST_ENABLE_AUTHORIZATION:-true}
+      EDITOAST_NO_CACHE: ${EDITOAST_NO_CACHE:-false}
     command: >
       /bin/sh -c "
         diesel migration run --locked-schema &&

--- a/docker/docker-compose.pr-tests.yml
+++ b/docker/docker-compose.pr-tests.yml
@@ -153,6 +153,7 @@ services:
       OSRD_MQ_URL: "amqp://osrd:password@rabbitmq:5673/%2f"
       EDITOAST_OPENFGA_URL: "http://openfga:8191"
       EDITOAST_ENABLE_AUTHORIZATION: ${EDITOAST_ENABLE_AUTHORIZATION:-true}
+      EDITOAST_NO_CACHE: ${EDITOAST_NO_CACHE:-false}
     command: >
       /bin/sh -c "
         diesel migration run --locked-schema &&

--- a/editoast/README.md
+++ b/editoast/README.md
@@ -87,7 +87,13 @@ To setup `grcov`, please see [its documentation](https://github.com/mozilla/grco
 
 Running editoast with deactivated cache can help repeating calls when debugging.
 ```sh
-NO_CACHE=true cargo run -- runserver
+EDITOAST_NO_CACHE=true cargo run -- runserver
+```
+
+If you run the stack with docker:
+
+```sh
+EDITOAST_NO_CACHE=true ./osrd-compose up -d
 ```
 
 ## Authorization
@@ -95,37 +101,37 @@ NO_CACHE=true cargo run -- runserver
 
 ### How to disable authorizations
 
-By default editoast is running with authorization enabled. 
+By default editoast is running with authorization enabled.
 You can disable it by using the environment variable `EDITOAST_ENABLE_AUTHORIZATION=false`
 
-```sh 
+```sh
 EDITOAST_ENABLE_AUTHORIZATION=false cargo run -- runserver
 ```
 
-If you run the stack with docker: 
+If you run the stack with docker:
 
-```sh 
-EDITOAST_ENABLE_AUTHORIZATION=false docker compose up  
+```sh
+EDITOAST_ENABLE_AUTHORIZATION=false docker compose up
 ```
 
 If your client has a direct access to editoast, an other possibility is to add the header `x-osrd-skip-authz` in your requests.
 
 ### User & role management
 
-You can create a new user with `Admin` role by using the following commands : 
+You can create a new user with `Admin` role by using the following commands :
 
-```sh 
+```sh
 cargo run user add 'mock/mocked' 'Example User'
-cargo run roles add 'mock/mocked' Admin 
+cargo run roles add 'mock/mocked' Admin
 ```
 
-Where `mock/mocked` is the **identity** of the user and `Example User` its **name**. 
+Where `mock/mocked` is the **identity** of the user and `Example User` its **name**.
 In development, the default user `mock/mocked` which is given by the gateway.
 
 If you run the stack with docker, you can use:
 ```sh
 docker exec osrd-editoast editoast user add 'mock/mocked' 'Example User'
-docker exec osrd-editoast editoast roles add 'mock/mocked' Admin 
+docker exec osrd-editoast editoast roles add 'mock/mocked' Admin
 ```
 
 ## For M1 MacOS users

--- a/editoast/justfile
+++ b/editoast/justfile
@@ -9,6 +9,9 @@ run:
     ./assets/sprites/generate-atlas.sh
     ./assets/fonts/generate-glyphs.sh
     diesel migration run --locked-schema
+    @echo 'Authorizing "mock/mocked" user. Make sure the gateway user matches.'
+    cargo run -- user add "mock/mocked" "Example User"
+    cargo run -- roles add "mock/mocked" Admin
     @echo 'Starting editoast in single worker mode. If you use osrd-compose add the `sw` flag'
     EDITOAST_CORE_SINGLE_WORKER=true cargo run -- runserver
 

--- a/editoast/src/client/valkey_config.rs
+++ b/editoast/src/client/valkey_config.rs
@@ -8,7 +8,7 @@ use crate::valkey_utils;
 #[educe(Default)]
 pub struct ValkeyConfig {
     /// Disable cache. This should not be used in production.
-    #[clap(long, env, default_value_t = false)]
+    #[clap(long, env = "EDITOAST_NO_CACHE", default_value_t = false)]
     pub no_cache: bool,
     #[educe(Default = Url::parse("redis://localhost:6379").unwrap())]
     #[arg(long, env, default_value_t = Url::parse("redis://localhost:6379").unwrap())]


### PR DESCRIPTION
Also rename `NO_CACHE` to `EDITOAST_NO_CACHE`

Planned follow-up on #11936