### PR TITLE
front: highlight all occurrences a paced train when hovering one of them

### DIFF
--- a/front/src/modules/simulationResult/components/ManchetteWithSpaceTimeChart/utils.ts
+++ b/front/src/modules/simulationResult/components/ManchetteWithSpaceTimeChart/utils.ts
@@ -11,7 +11,7 @@ import { extractPacedTrainIdFromOccurrenceId, isOccurrenceId } from 'utils/train
 
 const getPathStyle = (
   hovered: HoveredItem | null,
-  path: { color: string; id: string },
+  train: { color: string; id: string },
   dragging: boolean,
   timetableItemsWithDetails?: TimetableItemWithDetails[],
   selectedTrainId?: TrainId
@@ -25,19 +25,21 @@ const getPathStyle = (
     backgroundColor?: string;
   };
 } => {
-  const trainId = isOccurrenceId(path.id) ? extractPacedTrainIdFromOccurrenceId(path.id) : path.id;
+  const trainId = isOccurrenceId(train.id)
+    ? extractPacedTrainIdFromOccurrenceId(train.id)
+    : train.id;
   const item = timetableItemsWithDetails?.find((t) => t.id === trainId);
   const category = item?.category;
 
   const colors = category ? TRAIN_CATEGORY_PATH_COLORS[category] : DEFAULT_TRAIN_PATH_COLORS;
 
-  if (hovered && 'pathId' in hovered.element && path.id === hovered.element.pathId && !dragging) {
+  if (hovered && 'pathId' in hovered.element && train.id === hovered.element.pathId && !dragging) {
     return { color: colors.hovered, level: 1 };
   }
   // Apply occurrence style if selectedTrainId is an occurrence from the same paced
   if (selectedTrainId) {
     if (isOccurrenceId(selectedTrainId)) {
-      if (path.id === selectedTrainId) {
+      if (train.id === selectedTrainId) {
         return {
           color: colors.normal,
           level: 1,
@@ -51,8 +53,8 @@ const getPathStyle = (
       }
       // Other occurrences from the same paced
       if (
-        isOccurrenceId(path.id) &&
-        extractPacedTrainIdFromOccurrenceId(path.id) ===
+        isOccurrenceId(train.id) &&
+        extractPacedTrainIdFromOccurrenceId(train.id) ===
           extractPacedTrainIdFromOccurrenceId(selectedTrainId)
       ) {
         return {
@@ -65,7 +67,7 @@ const getPathStyle = (
           },
         };
       }
-    } else if (path.id === selectedTrainId) {
+    } else if (train.id === selectedTrainId) {
       return { color: colors.normal, level: 1 };
     }
   }

--- a/front/src/modules/simulationResult/components/ManchetteWithSpaceTimeChart/utils.ts
+++ b/front/src/modules/simulationResult/components/ManchetteWithSpaceTimeChart/utils.ts
@@ -25,16 +25,25 @@ const getPathStyle = (
     backgroundColor?: string;
   };
 } => {
-  const trainId = isOccurrenceId(train.id)
+  const timetableItemId = isOccurrenceId(train.id)
     ? extractPacedTrainIdFromOccurrenceId(train.id)
     : train.id;
-  const item = timetableItemsWithDetails?.find((t) => t.id === trainId);
+  const item = timetableItemsWithDetails?.find((t) => t.id === timetableItemId);
   const category = item?.category;
 
   const colors = category ? TRAIN_CATEGORY_PATH_COLORS[category] : DEFAULT_TRAIN_PATH_COLORS;
 
-  if (hovered && 'pathId' in hovered.element && train.id === hovered.element.pathId && !dragging) {
-    return { color: colors.hovered, level: 1 };
+  if (hovered && 'pathId' in hovered.element && !dragging) {
+    const hoveredTrainId = hovered.element.pathId as TrainId;
+
+    if (
+      train.id === hoveredTrainId ||
+      // if the hovered train is an occurrence from the same paced train, apply the hovered style
+      (isOccurrenceId(hoveredTrainId) &&
+        timetableItemId === extractPacedTrainIdFromOccurrenceId(hoveredTrainId))
+    ) {
+      return { color: colors.hovered, level: 1 };
+    }
   }
   // Apply occurrence style if selectedTrainId is an occurrence from the same paced
   if (selectedTrainId) {


### PR DESCRIPTION
closes #11886 

All the occurrences of a paced train are now highlighted when hovering one of them ([mock-up](https://www.sketch.com/s/21923813-9522-4ebc-b0c1-a09dde6c92e9/f/5A959544-E07B-453B-87BE-F7A29442EE2E#Inspect))

![image](https://github.com/user-attachments/assets/306be4e7-5759-480f-be27-0dbdc2968765)
