### PR TITLE
core: pure ETCS level 2 spacing requirements

### DIFF
--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/Envelope.kt
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/Envelope.kt
@@ -235,6 +235,10 @@ class Envelope(parts: Array<EnvelopePart>) :
         return (totalTimeUS.toDouble()) / 1000000
     }
 
+    override fun getRawEnvelopeIfSingle(): Envelope? {
+        return this
+    }
+
     /**
      * Returns the total time required to get from the start of the envelope to the start of an
      * envelope part, in microseconds

--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/EnvelopeConcat.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/EnvelopeConcat.java
@@ -13,10 +13,10 @@ import java.util.List;
  */
 public class EnvelopeConcat implements EnvelopeInterpolate {
 
-    private final List<LocatedEnvelope> envelopes;
+    private final List<LocatedEnvelopeInterpolate> envelopes;
     private final double endPos;
 
-    private EnvelopeConcat(List<LocatedEnvelope> envelopes, double endPos) {
+    private EnvelopeConcat(List<LocatedEnvelopeInterpolate> envelopes, double endPos) {
         this.envelopes = envelopes;
         this.endPos = endPos;
     }
@@ -31,19 +31,20 @@ public class EnvelopeConcat implements EnvelopeInterpolate {
 
     /** Creates an instance from a list of located envelopes.
      * Avoids redundant initialization when elements are appended to one envelope list. */
-    public static EnvelopeConcat fromLocated(List<LocatedEnvelope> envelopes) {
+    public static EnvelopeConcat fromLocated(List<LocatedEnvelopeInterpolate> envelopes) {
         var lastEnvelope = envelopes.get(envelopes.size() - 1);
         var endPos = lastEnvelope.startOffset + lastEnvelope.envelope.getEndPos();
         return new EnvelopeConcat(envelopes, endPos);
     }
 
     /** Place all envelopes in a record containing the offset on which they start */
-    private static List<LocatedEnvelope> initLocatedEnvelopes(List<? extends EnvelopeInterpolate> envelopes) {
+    private static List<LocatedEnvelopeInterpolate> initLocatedEnvelopes(
+            List<? extends EnvelopeInterpolate> envelopes) {
         double currentOffset = 0.0;
         double currentTime = 0.0;
-        var res = new ArrayList<LocatedEnvelope>();
+        var res = new ArrayList<LocatedEnvelopeInterpolate>();
         for (var envelope : envelopes) {
-            res.add(new LocatedEnvelope(envelope, currentOffset, currentTime));
+            res.add(new LocatedEnvelopeInterpolate(envelope, currentOffset, currentTime));
             currentOffset += envelope.getEndPos();
             currentTime += envelope.getTotalTime();
         }
@@ -103,18 +104,16 @@ public class EnvelopeConcat implements EnvelopeInterpolate {
     @Override
     public List<EnvelopePoint> iteratePoints() {
         return envelopes.stream()
-                .flatMap(locatedEnvelope -> locatedEnvelope.envelope.iteratePoints().stream()
+                .flatMap(envelope -> envelope.envelope.iteratePoints().stream()
                         .map(p -> new EnvelopePoint(
-                                p.time() + locatedEnvelope.startTime,
-                                p.speed(),
-                                p.position() + locatedEnvelope.startOffset)))
+                                p.time() + envelope.startTime, p.speed(), p.position() + envelope.startOffset)))
                 .toList();
     }
 
     /**
      * Returns the envelope at the given position.
      */
-    private LocatedEnvelope findEnvelopeLeftAt(double position) {
+    private LocatedEnvelopeInterpolate findEnvelopeLeftAt(double position) {
         var index = findEnvelopeIndexAt(position, true);
         return index == -1 ? null : envelopes.get(index);
     }
@@ -122,7 +121,7 @@ public class EnvelopeConcat implements EnvelopeInterpolate {
     /**
      * Returns the envelope at the given position.
      */
-    private LocatedEnvelope findEnvelopeRightAt(double position) {
+    private LocatedEnvelopeInterpolate findEnvelopeRightAt(double position) {
         var index = findEnvelopeIndexAt(position, false);
         return index == -1 ? null : envelopes.get(index);
     }
@@ -183,5 +182,5 @@ public class EnvelopeConcat implements EnvelopeInterpolate {
         return maxSpeed;
     }
 
-    public record LocatedEnvelope(EnvelopeInterpolate envelope, double startOffset, double startTime) {}
+    public record LocatedEnvelopeInterpolate(EnvelopeInterpolate envelope, double startOffset, double startTime) {}
 }

--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/EnvelopeConcat.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/EnvelopeConcat.java
@@ -6,6 +6,7 @@ import static java.lang.Math.min;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * This class is used to concatenate envelopes without a deep copy of all the underlying data. All
@@ -99,6 +100,12 @@ public class EnvelopeConcat implements EnvelopeInterpolate {
     public double getTotalTime() {
         var lastEnvelope = envelopes.get(envelopes.size() - 1);
         return lastEnvelope.startTime + lastEnvelope.envelope.getTotalTime();
+    }
+
+    @Override
+    public @Nullable Envelope getRawEnvelopeIfSingle() {
+        // See interface: building concatenation is probably not a good idea
+        return null;
     }
 
     @Override

--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/EnvelopeTimeInterpolate.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/EnvelopeTimeInterpolate.java
@@ -1,6 +1,7 @@
 package fr.sncf.osrd.envelope;
 
 import java.util.List;
+import org.jetbrains.annotations.Nullable;
 
 public interface EnvelopeTimeInterpolate {
 
@@ -35,6 +36,13 @@ public interface EnvelopeTimeInterpolate {
 
     /** Returns the total time of the envelope */
     double getTotalTime();
+
+    /** Get underlying envelope if it's not a concatenation (null in that case)
+     * Note: Building the single envelope from the concatenation does not look good performance-wise
+     *   Probably better to just ask the required capacity from the interface in that case.
+     *   Ex: List<EnvelopePoint> getIntersections(envelope: EnvelopeInterpolate) */
+    @Nullable
+    Envelope getRawEnvelopeIfSingle();
 
     record EnvelopePoint(double time, double speed, double position) {}
 

--- a/core/kt-osrd-signaling/src/main/kotlin/fr/sncf/osrd/signaling/SignalDriver.kt
+++ b/core/kt-osrd-signaling/src/main/kotlin/fr/sncf/osrd/signaling/SignalDriver.kt
@@ -95,6 +95,7 @@ interface SignalingSystemDriver {
     val settingsSchema: SigSettingsSchema
     val isBlockDelimiterExpr: String
     val isRouteDelimiterExpr: String
+    val isCurveBased: Boolean
 
     fun checkBlock(reporter: BlockDiagReporter, block: SigBlock)
 

--- a/core/kt-osrd-signaling/src/main/kotlin/fr/sncf/osrd/signaling/SignalDriver.kt
+++ b/core/kt-osrd-signaling/src/main/kotlin/fr/sncf/osrd/signaling/SignalDriver.kt
@@ -98,5 +98,5 @@ interface SignalingSystemDriver {
 
     fun checkBlock(reporter: BlockDiagReporter, block: SigBlock)
 
-    fun isConstraining(signalState: SigState, trainState: SignalingTrainState): Boolean
+    fun isConstrainingOnSight(signalState: SigState, trainState: SignalingTrainState): Boolean
 }

--- a/core/kt-osrd-signaling/src/main/kotlin/fr/sncf/osrd/signaling/impl/MockSigSystemManager.kt
+++ b/core/kt-osrd-signaling/src/main/kotlin/fr/sncf/osrd/signaling/impl/MockSigSystemManager.kt
@@ -66,6 +66,10 @@ class MockSigSystemManager(
         return this.sigSystem
     }
 
+    override fun isCurveBased(sigSystem: SignalingSystemId): Boolean {
+        return false
+    }
+
     override fun getCost(sigSystem: SignalingSystemId): Double {
         TODO("Implement this")
     }

--- a/core/kt-osrd-signaling/src/main/kotlin/fr/sncf/osrd/signaling/impl/SigSystemManagerImpl.kt
+++ b/core/kt-osrd-signaling/src/main/kotlin/fr/sncf/osrd/signaling/impl/SigSystemManagerImpl.kt
@@ -77,6 +77,10 @@ class SigSystemManagerImpl : SigSystemManager {
         return sigSystemPool[sigSystem].id
     }
 
+    override fun isCurveBased(sigSystem: SignalingSystemId): Boolean {
+        return sigSystemPool[sigSystem].isCurveBased
+    }
+
     override fun getCost(sigSystem: SignalingSystemId): Double {
         return sigSystemCost[sigSystem]
             ?: throw RuntimeException("signaling system does not have an assigned cost")

--- a/core/kt-osrd-signaling/src/main/kotlin/fr/sncf/osrd/signaling/impl/SigSystemManagerImpl.kt
+++ b/core/kt-osrd-signaling/src/main/kotlin/fr/sncf/osrd/signaling/impl/SigSystemManagerImpl.kt
@@ -51,7 +51,7 @@ class SigSystemManagerImpl : SigSystemManager {
         trainState: SignalingTrainState
     ): Boolean {
         val driver = sigSystemPool[signalingSystem]
-        return driver.isConstraining(signalState, trainState)
+        return driver.isConstrainingOnSight(signalState, trainState)
     }
 
     override val signalingSystems: StaticIdxSpace<SignalingSystem>

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/LoadedSignalingInfra.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/LoadedSignalingInfra.kt
@@ -48,6 +48,8 @@ interface InfraSigSystemManager {
 
     fun getName(sigSystem: SignalingSystemId): String
 
+    fun isCurveBased(sigSystem: SignalingSystemId): Boolean
+
     fun getCost(sigSystem: SignalingSystemId): Double
 
     val drivers: StaticIdxSpace<SignalDriver>

--- a/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/bal/BAL.kt
+++ b/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/bal/BAL.kt
@@ -13,6 +13,7 @@ object BAL : SignalingSystemDriver {
     override val parametersSchema = SigParametersSchema { flag("jaune_cli") }
     override val isBlockDelimiterExpr = "true"
     override val isRouteDelimiterExpr = "Nf"
+    override val isCurveBased = false
 
     override fun checkBlock(reporter: BlockDiagReporter, block: SigBlock) {
         // Check that we have the correct number of signals

--- a/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/bal/BAL.kt
+++ b/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/bal/BAL.kt
@@ -23,7 +23,7 @@ object BAL : SignalingSystemDriver {
         }
     }
 
-    override fun isConstraining(
+    override fun isConstrainingOnSight(
         signalState: SigData<SignalStateMarker>,
         trainState: SignalingTrainState
     ): Boolean {

--- a/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/bapr/BAPR.kt
+++ b/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/bapr/BAPR.kt
@@ -44,7 +44,7 @@ object BAPR : SignalingSystemDriver {
         }
     }
 
-    override fun isConstraining(
+    override fun isConstrainingOnSight(
         signalState: SigData<SignalStateMarker>,
         trainState: SignalingTrainState
     ): Boolean {

--- a/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/bapr/BAPR.kt
+++ b/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/bapr/BAPR.kt
@@ -16,6 +16,7 @@ object BAPR : SignalingSystemDriver {
     override val parametersSchema = SigParametersSchema {}
     override val isBlockDelimiterExpr = "!distant"
     override val isRouteDelimiterExpr = "Nf"
+    override val isCurveBased = false
 
     override fun checkBlock(reporter: BlockDiagReporter, block: SigBlock) {
         // Check that we have the correct number of signals

--- a/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/etcs_level2/ETCS_LEVEL2.kt
+++ b/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/etcs_level2/ETCS_LEVEL2.kt
@@ -53,7 +53,10 @@ object ETCS_LEVEL2 : SignalingSystemDriver {
         }
     }
 
-    override fun isConstraining(signalState: SigState, trainState: SignalingTrainState): Boolean {
+    override fun isConstrainingOnSight(
+        signalState: SigState,
+        trainState: SignalingTrainState
+    ): Boolean {
         if (signalState.getEnum("aspect").contains("VL")) {
             // VL should never be considered constraining,
             // it would cause infinite loops in spacing resource generation

--- a/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/etcs_level2/ETCS_LEVEL2.kt
+++ b/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/etcs_level2/ETCS_LEVEL2.kt
@@ -27,6 +27,7 @@ object ETCS_LEVEL2 : SignalingSystemDriver {
 
     override val isBlockDelimiterExpr = "true"
     override val isRouteDelimiterExpr = "Nf"
+    override val isCurveBased = true
 
     override fun checkBlock(reporter: BlockDiagReporter, block: SigBlock) {
         // Check that we have the correct number of signals

--- a/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/etcs_level2/ETCS_LEVEL2.kt
+++ b/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/etcs_level2/ETCS_LEVEL2.kt
@@ -8,8 +8,6 @@ import fr.sncf.osrd.sim_infra.api.SigParametersSchema
 import fr.sncf.osrd.sim_infra.api.SigSettingsSchema
 import fr.sncf.osrd.sim_infra.api.SigState
 import fr.sncf.osrd.sim_infra.api.SigStateSchema
-import fr.sncf.osrd.utils.units.Speed
-import fr.sncf.osrd.utils.units.kilometersPerHour
 
 /**
  * PLACEHOLDER CODE copied from TVM signaling
@@ -39,29 +37,10 @@ object ETCS_LEVEL2 : SignalingSystemDriver {
         }
     }
 
-    private fun maxSpeedForState(state: SigState): Speed {
-        return when (val aspect = state.getEnum("aspect")) {
-            "300VL" -> 315.kilometersPerHour
-            "300(VL)" -> 315.kilometersPerHour
-            "270A" -> 315.kilometersPerHour
-            "220A" -> 285.kilometersPerHour
-            "160A" -> 235.kilometersPerHour
-            "080A" -> 170.kilometersPerHour
-            "000" -> 80.kilometersPerHour
-            "OCCUPIED" -> 0.kilometersPerHour
-            else -> throw IllegalArgumentException("Unknown aspect: $aspect")
-        }
-    }
-
     override fun isConstrainingOnSight(
         signalState: SigState,
         trainState: SignalingTrainState
     ): Boolean {
-        if (signalState.getEnum("aspect").contains("VL")) {
-            // VL should never be considered constraining,
-            // it would cause infinite loops in spacing resource generation
-            return false
-        }
-        return trainState.speed > maxSpeedForState(signalState)
+        return false
     }
 }

--- a/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/tvm300/TVM300.kt
+++ b/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/tvm300/TVM300.kt
@@ -23,6 +23,7 @@ object TVM300 : SignalingSystemDriver {
     override val parametersSchema = SigParametersSchema {}
     override val isBlockDelimiterExpr = "true"
     override val isRouteDelimiterExpr = "Nf"
+    override val isCurveBased = false
 
     private fun maxSpeedForState(state: SigState): Speed {
         return when (val aspect = state.getEnum("aspect")) {

--- a/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/tvm300/TVM300.kt
+++ b/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/tvm300/TVM300.kt
@@ -39,7 +39,10 @@ object TVM300 : SignalingSystemDriver {
         }
     }
 
-    override fun isConstraining(signalState: SigState, trainState: SignalingTrainState): Boolean {
+    override fun isConstrainingOnSight(
+        signalState: SigState,
+        trainState: SignalingTrainState
+    ): Boolean {
         if (signalState.getEnum("aspect").contains("VL")) {
             // VL should never be considered constraining,
             // it would cause infinite loops in spacing resource generation

--- a/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/tvm430/TVM430.kt
+++ b/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/tvm430/TVM430.kt
@@ -45,7 +45,10 @@ object TVM430 : SignalingSystemDriver {
         }
     }
 
-    override fun isConstraining(signalState: SigState, trainState: SignalingTrainState): Boolean {
+    override fun isConstrainingOnSight(
+        signalState: SigState,
+        trainState: SignalingTrainState
+    ): Boolean {
         if (signalState.getEnum("aspect").contains("VL")) {
             // VL should never be considered constraining,
             // it would cause infinite loops in spacing resource generation

--- a/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/tvm430/TVM430.kt
+++ b/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/tvm430/TVM430.kt
@@ -4,7 +4,10 @@ import fr.sncf.osrd.signaling.BlockDiagReporter
 import fr.sncf.osrd.signaling.SigBlock
 import fr.sncf.osrd.signaling.SignalingSystemDriver
 import fr.sncf.osrd.signaling.SignalingTrainState
-import fr.sncf.osrd.sim_infra.api.*
+import fr.sncf.osrd.sim_infra.api.SigParametersSchema
+import fr.sncf.osrd.sim_infra.api.SigSettingsSchema
+import fr.sncf.osrd.sim_infra.api.SigState
+import fr.sncf.osrd.sim_infra.api.SigStateSchema
 import fr.sncf.osrd.utils.units.Speed
 import fr.sncf.osrd.utils.units.kilometersPerHour
 
@@ -21,6 +24,7 @@ object TVM430 : SignalingSystemDriver {
 
     override val isBlockDelimiterExpr = "true"
     override val isRouteDelimiterExpr = "Nf"
+    override val isCurveBased = false
 
     override fun checkBlock(reporter: BlockDiagReporter, block: SigBlock) {
         // Check that we have the correct number of signals

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/EnvelopeStopWrapper.java
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/EnvelopeStopWrapper.java
@@ -3,10 +3,12 @@ package fr.sncf.osrd.standalone_sim;
 import static fr.sncf.osrd.envelope_sim.TrainPhysicsIntegrator.arePositionsEqual;
 import static fr.sncf.osrd.envelope_utils.DoubleUtils.clamp;
 
+import fr.sncf.osrd.envelope.Envelope;
 import fr.sncf.osrd.envelope.EnvelopeInterpolate;
 import fr.sncf.osrd.train.TrainStop;
 import java.util.ArrayList;
 import java.util.List;
+import org.jetbrains.annotations.Nullable;
 
 /** Wraps an envelope with stops, to include the stop durations when getting the time at any point.
  * When getting the time at an exact stop location, the stop *is included*. */
@@ -75,6 +77,11 @@ public class EnvelopeStopWrapper implements EnvelopeInterpolate {
     public double getTotalTime() {
         return envelope.getTotalTime()
                 + stops.stream().mapToDouble(stop -> stop.duration).sum();
+    }
+
+    @Override
+    public @Nullable Envelope getRawEnvelopeIfSingle() {
+        return envelope.getRawEnvelopeIfSingle();
     }
 
     /** Returns all the points as (time, speed, position), with time adjusted for stop duration */

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
@@ -6,7 +6,10 @@ import fr.sncf.osrd.api.pathfinding.findWaypointBlocks
 import fr.sncf.osrd.api.pathfinding.hasDuplicateTracks
 import fr.sncf.osrd.api.pathfinding.runPathfindingBlockPostProcessing
 import fr.sncf.osrd.api.standalone_sim.*
-import fr.sncf.osrd.conflicts.*
+import fr.sncf.osrd.conflicts.IncrementalConflictDetector
+import fr.sncf.osrd.conflicts.NoConflictResponse
+import fr.sncf.osrd.conflicts.Requirements
+import fr.sncf.osrd.conflicts.SpacingRequirement
 import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceValue
 import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceValue.Percentage
 import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceValue.TimePerDistance
@@ -20,6 +23,7 @@ import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop
 import fr.sncf.osrd.reporting.exceptions.ErrorType
 import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.reporting.warnings.DiagnosticRecorderImpl
+import fr.sncf.osrd.signaling.etcs_level2.ETCS_LEVEL2
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.DirTrackChunkId
 import fr.sncf.osrd.sim_infra.api.RawSignalingInfra
@@ -103,7 +107,10 @@ class STDCMEndpoint(private val infraManager: InfraProvider) : Take {
                 parseRawRollingStock(
                     request.physicsConsist,
                     request.rollingStockLoadingGauge,
-                    request.rollingStockSupportedSignalingSystems
+                    request.rollingStockSupportedSignalingSystems.filter {
+                        // Ignoring ETCS as it is not (yet) supported for STDCM
+                        it != ETCS_LEVEL2.id
+                    }
                 )
             val trainsRequirements =
                 parseTrainsRequirements(

--- a/core/src/main/kotlin/fr/sncf/osrd/conflicts/IncrementalRequirementEnvelopeAdapter.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/conflicts/IncrementalRequirementEnvelopeAdapter.kt
@@ -1,5 +1,6 @@
 package fr.sncf.osrd.conflicts
 
+import fr.sncf.osrd.envelope.Envelope
 import fr.sncf.osrd.envelope.EnvelopeInterpolate
 import fr.sncf.osrd.envelope_sim.PhysicsRollingStock
 import fr.sncf.osrd.sim_infra.api.TravelledPath
@@ -58,6 +59,10 @@ class IncrementalRequirementEnvelopeAdapter(
             return Double.POSITIVE_INFINITY
         }
         return envelopeWithStops.interpolateDepartureFrom(pastStop)
+    }
+
+    override fun getRawEnvelopeIfSingle(): Envelope? {
+        return envelopeWithStops?.rawEnvelopeIfSingle
     }
 
     override fun arrivalTimeInRange(

--- a/core/src/main/kotlin/fr/sncf/osrd/conflicts/Resources.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/conflicts/Resources.kt
@@ -1,5 +1,6 @@
 package fr.sncf.osrd.conflicts
 
+import fr.sncf.osrd.envelope.Envelope
 import fr.sncf.osrd.sim_infra.api.BlockPath
 import fr.sncf.osrd.sim_infra.api.LogicalSignalId
 import fr.sncf.osrd.sim_infra.api.TravelledPath
@@ -35,6 +36,8 @@ interface IncrementalRequirementCallbacks {
 
     // departure time from a given stop. if the train never gets to a stop, +inf is returned
     fun departureFromStop(stopOffset: Offset<TravelledPath>): Double
+
+    fun getRawEnvelopeIfSingle(): Envelope?
 }
 
 data class PathSignal(

--- a/core/src/main/kotlin/fr/sncf/osrd/conflicts/SpacingResourceGenerator.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/conflicts/SpacingResourceGenerator.kt
@@ -1,8 +1,10 @@
 package fr.sncf.osrd.conflicts
 
+import fr.sncf.osrd.envelope_sim.EnvelopeSimContext
 import fr.sncf.osrd.signaling.SignalingSimulator
 import fr.sncf.osrd.signaling.SignalingTrainState
 import fr.sncf.osrd.signaling.ZoneStatus
+import fr.sncf.osrd.signaling.etcs_level2.ETCS_LEVEL2
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.standalone_sim.CLOSED_SIGNAL_RESERVATION_MARGIN
 import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
@@ -48,6 +50,8 @@ class SpacingRequirementAutomaton(
     val simulator: SignalingSimulator,
     var callbacks: IncrementalRequirementCallbacks, // Not read-only to be updated along the path
     var incrementalPath: IncrementalPath, // Not read-only to be updated along the path
+    // TODO: Required for ETCS (STDCM doesn't provide it currently, will have to eventually)
+    val context: EnvelopeSimContext? = null,
 ) {
     private var nextProcessedBlock = 0
 
@@ -328,13 +332,14 @@ class SpacingRequirementAutomaton(
         setupInitialRequirements()
 
         val routes = incrementalPath.routes.toList()
+        val etcsSimulator = context?.let { ETCSBrakingSimulatorImpl(it) }
 
         // for all signals, update zone requirement times until a signal is found for which
         // more path is needed
         while (pendingSignals.isNotEmpty()) {
             val pathSignal = pendingSignals.first()
 
-            val status = addSightSignalRequirements(pathSignal, routes)
+            val status = addSignalRequirements(pathSignal, routes, etcsSimulator)
 
             if (status == SignalRequirementsCreationStatus.NOT_SEEN_IN_AVAILABLE_SIM) {
                 break
@@ -370,6 +375,36 @@ class SpacingRequirementAutomaton(
         REQUIREMENTS_ADDED,
         NOT_SEEN_IN_AVAILABLE_SIM,
         NOT_ENOUGH_PATH,
+    }
+
+    private fun addSignalRequirements(
+        pathSignal: PathSignal,
+        routes: List<RouteId>,
+        etcsSimulator: ETCSBrakingSimulator?,
+    ): SignalRequirementsCreationStatus {
+        val sigSystemId = loadedSignalInfra.getSignalingSystem(pathSignal.signal)
+        val isCurveBased = simulator.sigModuleManager.isCurveBased(sigSystemId)
+        return if (isCurveBased) {
+            if (
+                simulator.sigModuleManager.getName(sigSystemId) != ETCS_LEVEL2.id ||
+                    etcsSimulator == null
+            ) {
+                TODO(
+                    "Spacing requirements for curve-based signal are only available for " +
+                        "ETCS_LEVEL2 and through StandaloneSimulation"
+                )
+            }
+            addEtcsSignalRequirements(pathSignal, etcsSimulator)
+        } else {
+            addSightSignalRequirements(pathSignal, routes)
+        }
+    }
+
+    private fun addEtcsSignalRequirements(
+        pathSignal: PathSignal,
+        etcsSimulator: ETCSBrakingSimulator,
+    ): SignalRequirementsCreationStatus {
+        TODO()
     }
 
     private fun addSightSignalRequirements(
@@ -481,7 +516,8 @@ class SpacingRequirementAutomaton(
                 this.blockInfra,
                 this.simulator,
                 this.callbacks.clone(),
-                this.incrementalPath.clone()
+                this.incrementalPath.clone(),
+                this.context,
             )
         res.nextProcessedBlock = nextProcessedBlock
         res.lastEmittedZone = lastEmittedZone

--- a/core/src/main/kotlin/fr/sncf/osrd/conflicts/SpacingResourceGenerator.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/conflicts/SpacingResourceGenerator.kt
@@ -135,7 +135,7 @@ class SpacingRequirementAutomaton(
         pendingRequirements.add(req)
     }
 
-    private fun getSignalProtectedZone(signal: PathSignal): Int {
+    private fun getSignalFirstProtectedZone(signal: PathSignal): Int {
         // the signal protects all zone inside the block
         // if a signal is at a block boundary,
         return incrementalPath.getBlockEndZone(signal.minBlockPathIndex)
@@ -166,7 +166,7 @@ class SpacingRequirementAutomaton(
         val firstSignal = pendingSignals.firstOrNull()
         val firstProtectedZone =
             if (firstSignal != null) {
-                getSignalProtectedZone(firstSignal)
+                getSignalFirstProtectedZone(firstSignal)
             } else {
                 startZone + 1
             }
@@ -296,7 +296,7 @@ class SpacingRequirementAutomaton(
         // the solutions mostly follow a gaussian distribution centered
         // on start+20 that rarely exceeds start+40.
         // We run a binary search on that range, and iterate one by one when the solution is above.
-        var lowerBound = getSignalProtectedZone(pathSignal)
+        var lowerBound = getSignalFirstProtectedZone(pathSignal)
         val initialUpperBound = min(lowerBound + 40, lastZoneIndex)
         var upperBound = initialUpperBound
 
@@ -361,7 +361,7 @@ class SpacingRequirementAutomaton(
             val trainState = SignalingTrainStateImpl(speed = maxSpeedInSignalArea.metersPerSecond)
 
             // Find the first and last zone required by the signal
-            val firstRequiredZone = getSignalProtectedZone(pathSignal)
+            val firstRequiredZone = getSignalFirstProtectedZone(pathSignal)
             val firstNonRequiredZone =
                 findFirstNonRequiredZoneIndex(pathSignal, routes, trainState)
                     ?: return NotEnoughPath

--- a/core/src/main/kotlin/fr/sncf/osrd/conflicts/SpacingResourceGenerator.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/conflicts/SpacingResourceGenerator.kt
@@ -1,6 +1,10 @@
 package fr.sncf.osrd.conflicts
 
 import fr.sncf.osrd.envelope_sim.EnvelopeSimContext
+import fr.sncf.osrd.envelope_sim.etcs.BrakingType.IND
+import fr.sncf.osrd.envelope_sim.etcs.ETCSBrakingSimulator
+import fr.sncf.osrd.envelope_sim.etcs.ETCSBrakingSimulatorImpl
+import fr.sncf.osrd.envelope_sim.etcs.EndOfAuthority
 import fr.sncf.osrd.signaling.SignalingSimulator
 import fr.sncf.osrd.signaling.SignalingTrainState
 import fr.sncf.osrd.signaling.ZoneStatus
@@ -10,8 +14,10 @@ import fr.sncf.osrd.standalone_sim.CLOSED_SIGNAL_RESERVATION_MARGIN
 import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.Speed
+import fr.sncf.osrd.utils.units.meters
 import fr.sncf.osrd.utils.units.metersPerSecond
 import kotlin.math.min
+import mu.KotlinLogging
 
 /*
  * ```
@@ -28,6 +34,8 @@ import kotlin.math.min
  * We have to emit implicit requirements for all zones between and including those occupied by the train
  * when it starts, and the first zone required by signaling.
  */
+
+val logger = KotlinLogging.logger {}
 
 data class PendingSpacingRequirement(
     val zoneIndex: Int,
@@ -143,6 +151,13 @@ class SpacingRequirementAutomaton(
         // the signal protects all zone inside the block
         // if a signal is at a block boundary,
         return incrementalPath.getBlockEndZone(signal.minBlockPathIndex)
+    }
+
+    private fun getSignalFirstProtectedBlockLastZone(signal: PathSignal): Int {
+        if (signal.minBlockPathIndex >= incrementalPath.blockCount) {
+            return incrementalPath.zonePathCount - 1
+        }
+        return incrementalPath.getBlockEndZone(signal.minBlockPathIndex + 1) - 1
     }
 
     // create requirements for zones occupied by the train at the beginning of the simulation
@@ -404,7 +419,49 @@ class SpacingRequirementAutomaton(
         pathSignal: PathSignal,
         etcsSimulator: ETCSBrakingSimulator,
     ): SignalRequirementsCreationStatus {
-        TODO()
+        val signalOffset = incrementalPath.toTravelledPath(pathSignal.pathOffset)
+        // Find the first zone of the block protected by signal
+        val firstRequiredZone = getSignalFirstProtectedZone(pathSignal)
+        val blockStartOffset =
+            incrementalPath.toTravelledPath(
+                incrementalPath.getZonePathStartOffset(firstRequiredZone)
+            )
+
+        var isNf = true
+        try {
+            isNf = loadedSignalInfra.getSettings(pathSignal.signal).getFlag("Nf")
+        } catch (e: Throwable) {
+            logger.warn {
+                "Unable to determine if " +
+                    "signal ${rawInfra.getLogicalSignalName(pathSignal.signal)} is Nf or F: $e"
+            }
+        }
+
+        // EoA offset is the detector (blockStartOffset) if signal is 'F' and signalOffset if 'Nf'
+        // SvL offset is always the detector
+        val eoa = EndOfAuthority(if (isNf) signalOffset else blockStartOffset, blockStartOffset)
+
+        val envelope = callbacks.getRawEnvelopeIfSingle()
+        // TODO: stop using a single envelope that's unavailable in STDCM and maybe move to a
+        //   dedicated EnvelopeTimeInterpolate.getIntersection().
+        //   Then probably protect its failure by returning
+        //   SignalRequirementsCreationStatus.NOT_SEEN_IN_AVAILABLE_SIM.
+        assert(envelope != null) {
+            "A single envelope covering whole path is currently expected (used only through standalone simulation)"
+        }
+        val curvesList = etcsSimulator.computeStopBrakingCurves(envelope!!, listOf(eoa))
+
+        assert(curvesList.size == 1)
+        val reqPos = curvesList[eoa]!![IND]!!.brakingCurve.beginPos.meters
+
+        // Find the last zone required by the signal
+        val lastRequiredZone = getSignalFirstProtectedBlockLastZone(pathSignal)
+
+        val reqTime = callbacks.arrivalTimeInRange(Offset(reqPos), Offset(reqPos))
+        assert(reqTime.isFinite())
+        addSignalRequirements(firstRequiredZone, lastRequiredZone, reqTime)
+
+        return SignalRequirementsCreationStatus.REQUIREMENTS_ADDED
     }
 
     private fun addSightSignalRequirements(

--- a/core/src/main/kotlin/fr/sncf/osrd/conflicts/SpacingResourceGenerator.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/conflicts/SpacingResourceGenerator.kt
@@ -206,11 +206,9 @@ class SpacingRequirementAutomaton(
         }
 
         // emit requirements for zones protected by this signal
-        for (requiredZoneIndex in
-            lastEmittedZone + 1 until endZoneIndex + 1) addZonePendingRequirement(
-            requiredZoneIndex,
-            sightTime
-        )
+        for (requiredZoneIndex in lastEmittedZone + 1..endZoneIndex) {
+            addZonePendingRequirement(requiredZoneIndex, sightTime)
+        }
         lastEmittedZone = endZoneIndex
     }
 
@@ -400,7 +398,6 @@ class SpacingRequirementAutomaton(
     ): SpacingRequirement? {
         val zonePath = incrementalPath.getZonePath(pendingRequirement.zoneIndex)
         val zone = rawInfra.getZonePathZone(zonePath)
-        val zoneName = rawInfra.getZoneName(zone)
         val zoneEntryPathOffset =
             incrementalPath.getZonePathStartOffset(pendingRequirement.zoneIndex)
         val zoneEntryOffset = incrementalPath.toTravelledPath(zoneEntryPathOffset)

--- a/core/src/main/kotlin/fr/sncf/osrd/conflicts/SpacingResourceGenerator.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/conflicts/SpacingResourceGenerator.kt
@@ -333,40 +333,13 @@ class SpacingRequirementAutomaton(
         // more path is needed
         while (pendingSignals.isNotEmpty()) {
             val pathSignal = pendingSignals.first()
-            val physicalSignal = loadedSignalInfra.getPhysicalSignal(pathSignal.signal)
 
-            // figure out when the signal is first seen
-            val signalOffset = incrementalPath.toTravelledPath(pathSignal.pathOffset)
-            val sightOffset = signalOffset - rawInfra.getSignalSightDistance(physicalSignal)
-            // If the train's simulation hasn't reached the point where the signal is seen, bail out
-            if (callbacks.currentPathOffset <= sightOffset) {
+            val status = addSightSignalRequirements(pathSignal, routes)
+
+            if (status == SignalRequirementsCreationStatus.NOT_SEEN_IN_AVAILABLE_SIM) {
                 break
-            }
-            val sightTime = callbacks.arrivalTimeInRange(sightOffset, signalOffset)
-            assert(sightTime.isFinite())
-
-            // Build the train state. We need to have the position of the next signal or to have a
-            // complete path.
-            val nextSignalOffset =
-                if (pendingSignals.size > 1) {
-                    incrementalPath.toTravelledPath(pendingSignals[1].pathOffset)
-                } else if (incrementalPath.pathComplete) {
-                    incrementalPath.toTravelledPath(incrementalPath.travelledPathEnd)
-                } else {
-                    return NotEnoughPath
-                }
-            val maxSpeedInSignalArea = callbacks.maxSpeedInRange(sightOffset, nextSignalOffset)
-
-            class SignalingTrainStateImpl(override val speed: Speed) : SignalingTrainState
-            val trainState = SignalingTrainStateImpl(speed = maxSpeedInSignalArea.metersPerSecond)
-
-            // Find the first and last zone required by the signal
-            val firstRequiredZone = getSignalFirstProtectedZone(pathSignal)
-            val firstNonRequiredZone =
-                findFirstNonRequiredZoneIndex(pathSignal, routes, trainState)
-                    ?: return NotEnoughPath
-            for (i in firstRequiredZone until firstNonRequiredZone) {
-                addSignalRequirements(firstRequiredZone, i, sightTime)
+            } else if (status == SignalRequirementsCreationStatus.NOT_ENOUGH_PATH) {
+                return NotEnoughPath
             }
 
             pendingSignals.removeFirst()
@@ -391,6 +364,54 @@ class SpacingRequirementAutomaton(
         for (i in 0 until firstIncompleteReq) pendingRequirements.removeFirst()
 
         return SpacingRequirements(spacingRequirements)
+    }
+
+    private enum class SignalRequirementsCreationStatus {
+        REQUIREMENTS_ADDED,
+        NOT_SEEN_IN_AVAILABLE_SIM,
+        NOT_ENOUGH_PATH,
+    }
+
+    private fun addSightSignalRequirements(
+        pathSignal: PathSignal,
+        routes: List<RouteId>
+    ): SignalRequirementsCreationStatus {
+        val physicalSignal = loadedSignalInfra.getPhysicalSignal(pathSignal.signal)
+
+        // figure out when the signal is first seen
+        val signalOffset = incrementalPath.toTravelledPath(pathSignal.pathOffset)
+        val sightOffset = signalOffset - rawInfra.getSignalSightDistance(physicalSignal)
+        // If the train's simulation hasn't reached the point where the signal is seen, bail out
+        if (callbacks.currentPathOffset <= sightOffset) {
+            return SignalRequirementsCreationStatus.NOT_SEEN_IN_AVAILABLE_SIM
+        }
+        val sightTime = callbacks.arrivalTimeInRange(sightOffset, signalOffset)
+        assert(sightTime.isFinite())
+
+        // Build the train state. We need to have the position of the next signal or to have a
+        // complete path.
+        val nextSignalOffset =
+            if (pendingSignals.size > 1) {
+                incrementalPath.toTravelledPath(pendingSignals[1].pathOffset)
+            } else if (incrementalPath.pathComplete) {
+                incrementalPath.toTravelledPath(incrementalPath.travelledPathEnd)
+            } else {
+                return SignalRequirementsCreationStatus.NOT_ENOUGH_PATH
+            }
+        val maxSpeedInSignalArea = callbacks.maxSpeedInRange(sightOffset, nextSignalOffset)
+
+        class SignalingTrainStateImpl(override val speed: Speed) : SignalingTrainState
+        val trainState = SignalingTrainStateImpl(speed = maxSpeedInSignalArea.metersPerSecond)
+
+        // Find the first and last zone required by the signal
+        val firstRequiredZone = getSignalFirstProtectedZone(pathSignal)
+        val firstNonRequiredZone =
+            findFirstNonRequiredZoneIndex(pathSignal, routes, trainState)
+                ?: return SignalRequirementsCreationStatus.NOT_ENOUGH_PATH
+        for (i in firstRequiredZone until firstNonRequiredZone) {
+            addSignalRequirements(firstRequiredZone, i, sightTime)
+        }
+        return SignalRequirementsCreationStatus.REQUIREMENTS_ADDED
     }
 
     private fun postProcessRequirement(

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
@@ -10,6 +10,7 @@ import fr.sncf.osrd.envelope.Envelope
 import fr.sncf.osrd.envelope.EnvelopeInterpolate
 import fr.sncf.osrd.envelope.EnvelopePhysics
 import fr.sncf.osrd.envelope.EnvelopeTimeInterpolate
+import fr.sncf.osrd.envelope_sim.EnvelopeSimContext
 import fr.sncf.osrd.envelope_sim_infra.EnvelopeTrainPath
 import fr.sncf.osrd.signaling.SigSystemManager
 import fr.sncf.osrd.signaling.SignalingSimulator
@@ -90,6 +91,7 @@ fun runScheduleMetadataExtractor(
     rollingStock: RollingStock,
     schedule: List<SimulationScheduleItem>,
     pathItemPositions: List<Offset<TravelledPath>>,
+    context: EnvelopeSimContext? = null,
 ): CompleteReportTrain {
     assert(envelope.continuous)
 
@@ -238,7 +240,8 @@ fun runScheduleMetadataExtractor(
             blockInfra,
             simulator,
             envelopeAdapter,
-            incrementalPath
+            incrementalPath,
+            context,
         )
     incrementalPath.extend(
         PathFragment(

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulation.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulation.kt
@@ -184,6 +184,7 @@ fun runStandaloneSimulation(
             rollingStock,
             schedule,
             pathItemPositions,
+            context,
         )
 
     return SimulationSuccess(

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelopeImpl.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelopeImpl.kt
@@ -6,7 +6,7 @@ import fr.sncf.osrd.conflicts.SpacingRequirementAutomaton
 import fr.sncf.osrd.conflicts.SpacingRequirements
 import fr.sncf.osrd.envelope.Envelope
 import fr.sncf.osrd.envelope.EnvelopeConcat
-import fr.sncf.osrd.envelope.EnvelopeConcat.LocatedEnvelope
+import fr.sncf.osrd.envelope.EnvelopeConcat.LocatedEnvelopeInterpolate
 import fr.sncf.osrd.envelope.EnvelopeInterpolate
 import fr.sncf.osrd.envelope_sim.PhysicsRollingStock
 import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal.SHORT_SLIP_STOP
@@ -27,7 +27,7 @@ import java.lang.ref.SoftReference
 
 data class InfraExplorerWithEnvelopeImpl(
     private val infraExplorer: InfraExplorer,
-    private val envelopes: AppendOnlyLinkedList<LocatedEnvelope>,
+    private val envelopes: AppendOnlyLinkedList<LocatedEnvelopeInterpolate>,
     private val spacingRequirementAutomaton: SpacingRequirementAutomaton,
     private val rollingStock: PhysicsRollingStock,
     private var stopTimeData: List<StopTimeData> = listOf(),
@@ -84,7 +84,7 @@ data class InfraExplorerWithEnvelopeImpl(
             prevEndTime = lastEnvelope.startTime + lastEnvelope.envelope.totalTime
             prevEndOffset = lastEnvelope.startOffset + lastEnvelope.envelope.endPos
         }
-        envelopes.add(LocatedEnvelope(envelope, prevEndOffset, prevEndTime))
+        envelopes.add(LocatedEnvelopeInterpolate(envelope, prevEndOffset, prevEndTime))
         envelopeCache = null
         spacingRequirementsCache = null
         return this
@@ -94,7 +94,7 @@ data class InfraExplorerWithEnvelopeImpl(
         return copy(
             envelopes =
                 appendOnlyLinkedListOf(
-                    LocatedEnvelope(envelope, 0.0, 0.0),
+                    LocatedEnvelopeInterpolate(envelope, 0.0, 0.0),
                 ),
             spacingRequirementAutomaton =
                 SpacingRequirementAutomaton(

--- a/tests/tests/test_train_schedule.py
+++ b/tests/tests/test_train_schedule.py
@@ -928,6 +928,108 @@ def test_etcs_schedule_result_slowdowns_with_stop(
         )
 
 
+def test_etcs_spacing_req(etcs_scenario: Scenario, etcs_rolling_stock: int):
+    """
+    spacing requirements should:
+    * start at the same time the braking curve starts if stoping on closed signal on the entry of the block
+    * end when leaving the block
+    """
+    rolling_stock_response = requests.get(
+        EDITOAST_URL + f"light_rolling_stock/{etcs_rolling_stock}"
+    )
+    etcs_rolling_stock_name = rolling_stock_response.json()["name"]
+    ts_response = requests.post(
+        f"{EDITOAST_URL}timetable/{etcs_scenario.timetable}/train_schedules/",
+        json=[
+            {
+                "train_name": "slowdowns to respect MRSP and ETCS with intermediate stop",
+                "labels": [],
+                "rolling_stock_name": etcs_rolling_stock_name,
+                "start_time": "2024-01-01T07:00:00Z",
+                "path": [
+                    {"id": "zero", "track": "TA0", "offset": 0},
+                    {"id": "stop", "track": "TH0", "offset": 662_000},
+                    {"id": "last", "track": "TH1", "offset": 5_000_000},
+                ],
+                "schedule": [
+                    {"at": "zero", "stop_for": "P0D"},
+                    {"at": "stop", "stop_for": "PT10S", "reception_signal": "STOP"},
+                    {"at": "last", "stop_for": "P0D"},
+                ],
+                "margins": {"boundaries": [], "values": ["0%"]},
+                "initial_speed": 0,
+                "comfort": "STANDARD",
+                "constraint_distribution": "STANDARD",
+                "speed_limit_tag": "foo",
+                "power_restrictions": [],
+            }
+        ],
+    )
+
+    schedule = ts_response.json()[0]
+    schedule_id = schedule["id"]
+    ts_id_response = requests.get(f"{EDITOAST_URL}train_schedule/{schedule_id}/")
+    ts_id_response.raise_for_status()
+    simu_response = requests.get(
+        f"{EDITOAST_URL}train_schedule/{schedule_id}/simulation?infra_id={etcs_scenario.infra}"
+    )
+    simulation_final_output = simu_response.json()["final_output"]
+
+    assert len(simulation_final_output["positions"]) == len(
+        simulation_final_output["speeds"]
+    )
+
+    # To debug this test: please add a breakpoint then use front to display speed-space chart
+    # (activate Context for Slopes and Speed limits).
+
+    # zone entry buffer_stop.0
+    spacing_req_z0 = simulation_final_output["spacing_requirements"][0]
+    assert spacing_req_z0["zone"] == "zone.[DA2:DECREASING, buffer_stop.0:INCREASING]"
+    assert spacing_req_z0["begin_time"] == 0
+    assert spacing_req_z0["end_time"] == 103241
+
+    # zone entry DA2 (triggered by SA2)
+    spacing_req_z1 = simulation_final_output["spacing_requirements"][1]
+    assert (
+        spacing_req_z1["zone"]
+        == "zone.[DA2:INCREASING, DA3:DECREASING, DA7:INCREASING]"
+    )
+    assert spacing_req_z1["begin_time"] == 62181
+    assert spacing_req_z1["end_time"] == 111927
+
+    # zone entry DA3 (triggered by SA2)
+    spacing_req_z2 = simulation_final_output["spacing_requirements"][2]
+    assert spacing_req_z2["zone"] == "zone.[DA3:INCREASING, DA6_1:DECREASING]"
+    assert spacing_req_z2["begin_time"] == 62181
+    assert spacing_req_z2["end_time"] == 145858
+
+    # zone entry DD0_8 (triggered by SD0_8)
+    spacing_req_zone_intersect_full_speed = simulation_final_output[
+        "spacing_requirements"
+    ][19]
+    assert (
+        spacing_req_zone_intersect_full_speed["zone"]
+        == "zone.[DD0_8:INCREASING, DD0_9:DECREASING]"
+    )
+    assert spacing_req_zone_intersect_full_speed["begin_time"] == 347978
+    assert spacing_req_zone_intersect_full_speed["end_time"] == 464473
+
+    # zone entry DH1 (triggered by SG0)
+    spacing_req_zone_stop = simulation_final_output["spacing_requirements"][32]
+    assert spacing_req_zone_stop["zone"] == "zone.[DH1:INCREASING, DH2:DECREASING]"
+    assert spacing_req_zone_stop["begin_time"] == 535548
+    assert spacing_req_zone_stop["end_time"] == 843357
+
+    # zone entry DH1_2 (triggered by SH1_2)
+    spacing_req_zone_final = simulation_final_output["spacing_requirements"][36]
+    assert (
+        spacing_req_zone_final["zone"]
+        == "zone.[DH1_2:INCREASING, buffer_stop.7:DECREASING]"
+    )
+    assert spacing_req_zone_final["begin_time"] == 892060
+    assert spacing_req_zone_final["end_time"] == 1087037
+
+
 def _assert_equal_speeds(left, right):
     assert abs(left - right) < 1e-2
 


### PR DESCRIPTION
Fix #11725 (no signaling-system transition)

TODO:

- [x] (integration) tests
- [ ] ~maybe switch signal handling to 2 batches (one for curve-base, one for on-sight) instead of single signal handling.~
       > As this is a dequeue, it's more complicated to handle it in separate batches than one-by-one
- [x] maybe deactivate ETCS in STDCM to allow use of ETCS-capable trains in STDCM outside of ETCS blocks

---

✅ Hand-checked that for integration tests:
  - creating (tinkering into core's stop computation) a stop with the same EoA/SvL at the limiting signal leads to an intersection of MRSP and braking curve that's at the begin-time of reservation.
  - visual check that the end-time is at the moment the tail leaves the zone (duplicate exact same train and print conflict in space-time chart)
  ![spacing](https://github.com/user-attachments/assets/751bf1f8-3d3e-4180-8ef9-525f3ff4eb2e)

---

🔍 review by commit should be quite easy