### PR TITLE
core: stdcm: fix heuristic initialization on first node

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMHeuristic.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMHeuristic.kt
@@ -141,7 +141,10 @@ class STDCMHeuristicBuilder(
         }
         val bestTravelTime =
             steps.first().locations.minOfOrNull {
-                remainingTimeEstimations.first()[it.edge] ?: Double.POSITIVE_INFINITY
+                val remainingTimeSinceBlockStart =
+                    remainingTimeEstimations.first()[it.edge] ?: Double.POSITIVE_INFINITY
+                val timeSinceBlockStart = mrspBuilder.getBlockTime(it.edge, it.offset)
+                remainingTimeSinceBlockStart - timeSinceBlockStart
             } ?: Double.POSITIVE_INFINITY
         logger.info(
             "STDCM heuristic built, best theoretical travel time = ${bestTravelTime.toInt()} seconds"


### PR DESCRIPTION
For the first node, the heuristic didn't account for the block offset. So it could be pessimistic, which could result in a suboptimal solution.

We *still* sometimes return suboptimal solutions even with this change. But it's still progress. 