### PR TITLE
Fix the Loading Gauge (Disabled) style

### DIFF
--- a/front/src/applications/stdcm/components/StdcmForm/StdcmConsist.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmConsist.tsx
@@ -269,6 +269,7 @@ const StdcmConsist = ({
               }
             }}
             {...createStandardSelectOptions(GAUGE_LIST)}
+            disabled={disabled}
             narrow
           />
         </div>


### PR DESCRIPTION
close #12011

Add `disabled={disabled}` to the Loading Gauge Select