### PR TITLE
tests: fuzzer: fix conftest.session in standalone script

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,6 +50,13 @@ def etcs_infra(session: Session) -> Iterator[Infra]:
 
 @pytest.fixture(scope="session")
 def session() -> Iterator[Session]:
+    yield session_no_fixture()
+
+
+def session_no_fixture() -> Session:
+    """
+    Used to generate a session without calling a fixture, useful for standalone scripts (e.g. fuzzer)
+    """
     # A failed request will retry up to 5 times with the following timings [2, 4, 8, 16, 32] for a total of 62 seconds
     retry_strategy = Retry(
         total=5,
@@ -60,7 +67,7 @@ def session() -> Iterator[Session]:
     session = Session()
     session.mount("http://", adapter)
     session.mount("https://", adapter)
-    yield session
+    return session
 
 
 @pytest.fixture

--- a/tests/fuzzer/fuzzer.py
+++ b/tests/fuzzer/fuzzer.py
@@ -337,7 +337,7 @@ def _get_rolling_stock(editoast_url: str, rolling_stock_name: str) -> _RollingSt
     :param rolling_stock_name: name of the rolling stock
     :return: ID the rolling stock
     """
-    session = next(conftest.session())
+    session = conftest.session_no_fixture()
     return _RollingStock(
         rolling_stock_name,
         conftest.get_rolling_stock(session, editoast_url, rolling_stock_name),
@@ -620,7 +620,7 @@ _to_ms = _to_mm
 if __name__ == "__main__":
     infra_id = get_infra(_EDITOAST_URL, _INFRA_NAME)
     new_scenario = create_scenario(_EDITOAST_URL, infra_id)
-    session = next(conftest.session())
+    session = conftest.session_no_fixture()
     if _ROLLING_STOCK_NAME == "fast_rolling_stock":
         try:
             _get_rolling_stock(_EDITOAST_URL, _ROLLING_STOCK_NAME)


### PR DESCRIPTION
Calling a fixture doesn't work when the script is run directly