### PR TITLE
editoast: serde: use remote crate mechanics for De / Serialize traits specialization

### DIFF
--- a/editoast/editoast_schemas/src/rolling_stock/effort_curves.rs
+++ b/editoast/editoast_schemas/src/rolling_stock/effort_curves.rs
@@ -70,9 +70,10 @@ pub struct EffortCurveConditions {
     power_restriction_code: Option<String>,
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, ToSchema, Educe)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, ToSchema, Educe)]
 #[educe(Hash)]
 #[serde(deny_unknown_fields)]
+#[serde(remote = "Self")]
 pub struct EffortCurve {
     #[educe(Hash(method(editoast_common::hash_float_slice::<3,_>)))]
     #[schema(min_items = 2, example = json!([0.0, 2.958, 46.719]))]
@@ -89,49 +90,53 @@ impl<'de> Deserialize<'de> for EffortCurve {
     where
         D: Deserializer<'de>,
     {
-        #[derive(Deserialize)]
-        struct InnerParams {
-            speeds: Vec<f64>,
-            max_efforts: Vec<f64>,
-        }
-
-        let inner = InnerParams::deserialize(deserializer)?;
+        let effort_curve = EffortCurve::deserialize(deserializer)?;
 
         // Validate the curve
-        if inner.max_efforts.len() != inner.speeds.len() {
+        if effort_curve.max_efforts.len() != effort_curve.speeds.len() {
             return Err(serde::de::Error::custom(
                 "effort curve invalid, max_efforts and speeds arrays should have the same length",
             ));
         }
 
-        if inner.max_efforts.len() < 2 {
+        if effort_curve.max_efforts.len() < 2 {
             return Err(serde::de::Error::custom(
                 "effort curve should have at least 2 points.",
             ));
         }
 
-        if inner.max_efforts.iter().any(|&x| x < 0.0) {
+        if effort_curve.max_efforts.iter().any(|&x| x < 0.0) {
             return Err(serde::de::Error::custom(
                 "max_efforts values must be equal or greater than 0.",
             ));
         };
 
-        if inner.speeds.iter().any(|&x| x < 0.0) {
+        if effort_curve.speeds.iter().any(|&x| x < 0.0) {
             return Err(serde::de::Error::custom(
                 "speeds values must be equal or greater than 0.",
             ));
         };
 
-        if inner.speeds.windows(2).any(|window| window[0] >= window[1]) {
+        if effort_curve
+            .speeds
+            .windows(2)
+            .any(|window| window[0] >= window[1])
+        {
             return Err(serde::de::Error::custom(
                 "speeds values must be strictly increasing.",
             ));
         }
 
-        Ok(EffortCurve {
-            speeds: inner.speeds,
-            max_efforts: inner.max_efforts,
-        })
+        Ok(effort_curve)
+    }
+}
+
+impl Serialize for EffortCurve {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        EffortCurve::serialize(self, serializer)
     }
 }
 

--- a/editoast/editoast_schemas/src/train_schedule.rs
+++ b/editoast/editoast_schemas/src/train_schedule.rs
@@ -63,7 +63,8 @@ editoast_common::schemas! {
     TrainSchedule,
 }
 
-#[derive(Debug, Default, Clone, PartialEq, Serialize, ToSchema)]
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[serde(remote = "Self")]
 pub struct TrainSchedule {
     pub train_name: String,
     #[serde(default)]
@@ -100,41 +101,15 @@ impl<'de> Deserialize<'de> for TrainSchedule {
     where
         D: serde::Deserializer<'de>,
     {
-        #[derive(Deserialize)]
-        #[serde(deny_unknown_fields)]
-        struct Internal {
-            train_name: String,
-            #[serde(default)]
-            labels: Vec<String>,
-            rolling_stock_name: String,
-            start_time: DateTime<Utc>,
-            path: Vec<PathItem>,
-            #[serde(default)]
-            schedule: Vec<ScheduleItem>,
-            #[serde(default)]
-            margins: Margins,
-            #[serde(default)]
-            initial_speed: f64,
-            #[serde(default)]
-            comfort: Comfort,
-            constraint_distribution: Distribution,
-            #[serde(default)]
-            speed_limit_tag: Option<NonBlankString>,
-            #[serde(default)]
-            power_restrictions: Vec<PowerRestrictionItem>,
-            #[serde(default)]
-            options: TrainScheduleOptions,
-            category: Option<TrainCategory>,
-        }
-        let internal = Internal::deserialize(deserializer)?;
+        let train_schedule = TrainSchedule::deserialize(deserializer)?;
 
         // Look for invalid path waypoint reference
-        let path_ids: HashSet<_> = internal.path.iter().map(|p| &p.id).collect();
-        if path_ids.len() != internal.path.len() {
+        let path_ids: HashSet<_> = train_schedule.path.iter().map(|p| &p.id).collect();
+        if path_ids.len() != train_schedule.path.len() {
             return Err(SerdeError::custom("Duplicate path waypoint ids"));
         }
 
-        for schedule_item in &internal.schedule {
+        for schedule_item in &train_schedule.schedule {
             if !path_ids.contains(&schedule_item.at) {
                 return Err(SerdeError::custom(format!(
                     "Invalid schedule, path waypoint '{}' not found",
@@ -143,7 +118,7 @@ impl<'de> Deserialize<'de> for TrainSchedule {
             }
         }
 
-        for boundary in &internal.margins.boundaries {
+        for boundary in &train_schedule.margins.boundaries {
             if !path_ids.contains(&boundary) {
                 return Err(SerdeError::custom(format!(
                     "Invalid boundary, path waypoint '{boundary}' not found"
@@ -151,7 +126,7 @@ impl<'de> Deserialize<'de> for TrainSchedule {
             }
         }
 
-        for power_restriction in internal.power_restrictions.iter() {
+        for power_restriction in train_schedule.power_restrictions.iter() {
             if !path_ids.contains(&power_restriction.from) {
                 return Err(SerdeError::custom(format!(
                     "Invalid power restriction, path waypoint '{}' not found",
@@ -167,11 +142,11 @@ impl<'de> Deserialize<'de> for TrainSchedule {
         }
 
         // Check scheduled points
-        let schedules: HashMap<_, _> = internal.schedule.iter().map(|s| (&s.at, s)).collect();
-        if schedules.len() != internal.schedule.len() {
+        let schedules: HashMap<_, _> = train_schedule.schedule.iter().map(|s| (&s.at, s)).collect();
+        if schedules.len() != train_schedule.schedule.len() {
             return Err(SerdeError::custom("Schedule points at the same location"));
         }
-        let first_point_id = &internal.path.first().unwrap().id;
+        let first_point_id = &train_schedule.path.first().unwrap().id;
         if schedules
             .get(first_point_id)
             .is_some_and(|s| s.arrival.is_some())
@@ -181,22 +156,16 @@ impl<'de> Deserialize<'de> for TrainSchedule {
             ));
         }
 
-        Ok(TrainSchedule {
-            train_name: internal.train_name,
-            labels: internal.labels,
-            rolling_stock_name: internal.rolling_stock_name,
-            start_time: internal.start_time,
-            path: internal.path,
-            schedule: internal.schedule,
-            margins: internal.margins,
-            initial_speed: internal.initial_speed,
-            comfort: internal.comfort,
-            constraint_distribution: internal.constraint_distribution,
-            speed_limit_tag: internal.speed_limit_tag,
-            power_restrictions: internal.power_restrictions,
-            options: internal.options,
-            category: internal.category,
-        })
+        Ok(train_schedule)
+    }
+}
+
+impl Serialize for TrainSchedule {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        TrainSchedule::serialize(self, serializer)
     }
 }
 

--- a/editoast/editoast_schemas/src/train_schedule/margins.rs
+++ b/editoast/editoast_schemas/src/train_schedule/margins.rs
@@ -10,9 +10,10 @@ editoast_common::schemas! {
     Margins,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Educe, ToSchema)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Educe, ToSchema)]
 #[serde(deny_unknown_fields)]
 #[educe(Default)]
+#[serde(remote = "Self")]
 pub struct Margins {
     #[schema(inline)]
     pub boundaries: Vec<NonBlankString>,
@@ -28,19 +29,22 @@ impl<'de> Deserialize<'de> for Margins {
     where
         D: serde::Deserializer<'de>,
     {
-        #[derive(Deserialize)]
-        struct InternalMargins {
-            boundaries: Vec<NonBlankString>,
-            values: Vec<MarginValue>,
-        }
-
-        let InternalMargins { boundaries, values } = InternalMargins::deserialize(deserializer)?;
-        if boundaries.len() + 1 != values.len() {
+        let margins = Margins::deserialize(deserializer)?;
+        if margins.boundaries.len() + 1 != margins.values.len() {
             return Err(serde::de::Error::custom(
                 "It's expected to have one more value than boundaries",
             ));
         }
-        Ok(Margins { boundaries, values })
+        Ok(margins)
+    }
+}
+
+impl Serialize for Margins {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        Margins::serialize(self, serializer)
     }
 }
 

--- a/editoast/editoast_schemas/src/train_schedule/schedule_item.rs
+++ b/editoast/editoast_schemas/src/train_schedule/schedule_item.rs
@@ -21,8 +21,9 @@ pub enum ReceptionSignal {
     ShortSlipStop,
 }
 
-#[derive(Debug, Default, Clone, PartialEq, Serialize, ToSchema)]
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
 #[serde(deny_unknown_fields)]
+#[serde(remote = "Self")]
 pub struct ScheduleItem {
     /// Position on the path of the schedule item.
     #[schema(inline)]
@@ -49,33 +50,25 @@ impl<'de> Deserialize<'de> for ScheduleItem {
     where
         D: serde::Deserializer<'de>,
     {
-        #[derive(Deserialize)]
-        #[serde(deny_unknown_fields)]
-        struct Internal {
-            pub at: NonBlankString,
-            pub arrival: Option<PositiveDuration>,
-            pub stop_for: Option<PositiveDuration>,
-            #[serde(default)]
-            pub reception_signal: ReceptionSignal,
-            #[serde(default)]
-            pub locked: bool,
-        }
-        let internal = Internal::deserialize(deserializer)?;
-
+        let schedule_item = ScheduleItem::deserialize(deserializer)?;
         // Check that the reception_signal is Open if stop_for duration is None
-        if internal.reception_signal != ReceptionSignal::Open && internal.stop_for.is_none() {
+        if schedule_item.reception_signal != ReceptionSignal::Open
+            && schedule_item.stop_for.is_none()
+        {
             return Err(serde::de::Error::custom(
                 "Field reception_signal must be `Open` if stop_for is None",
             ));
         }
+        Ok(schedule_item)
+    }
+}
 
-        Ok(Self {
-            at: internal.at,
-            arrival: internal.arrival,
-            stop_for: internal.stop_for,
-            reception_signal: internal.reception_signal,
-            locked: internal.locked,
-        })
+impl Serialize for ScheduleItem {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        ScheduleItem::serialize(self, serializer)
     }
 }
 

--- a/editoast/src/views/stdcm_search_environment.rs
+++ b/editoast/src/views/stdcm_search_environment.rs
@@ -36,7 +36,8 @@ editoast_common::schemas! {
     StdcmSearchEnvironment,
 }
 
-#[derive(ToSchema)]
+#[derive(Deserialize, ToSchema)]
+#[serde(remote = "Self")]
 #[cfg_attr(test, derive(Serialize))]
 struct StdcmSearchEnvironmentCreateForm {
     infra_id: i64,
@@ -55,46 +56,31 @@ impl<'de> Deserialize<'de> for StdcmSearchEnvironmentCreateForm {
     where
         D: serde::Deserializer<'de>,
     {
-        #[derive(Deserialize)]
-        #[serde(deny_unknown_fields)]
-        struct Internal {
-            infra_id: i64,
-            electrical_profile_set_id: Option<i64>,
-            work_schedule_group_id: Option<i64>,
-            temporary_speed_limit_group_id: Option<i64>,
-            timetable_id: i64,
-            search_window_begin: DateTime<Utc>,
-            search_window_end: DateTime<Utc>,
-            enabled_from: DateTime<Utc>,
-            enabled_until: DateTime<Utc>,
-        }
-        let internal = Internal::deserialize(deserializer)?;
-
+        let create_form = StdcmSearchEnvironmentCreateForm::deserialize(deserializer)?;
         // Check dates
-        if internal.search_window_begin >= internal.search_window_end {
+        if create_form.search_window_begin >= create_form.search_window_end {
             return Err(SerdeError::custom(format!(
                 "The search environment simulation window begin '{}' must be before the end '{}'",
-                internal.search_window_begin, internal.search_window_end
+                create_form.search_window_begin, create_form.search_window_end
             )));
         }
-        if internal.enabled_from >= internal.enabled_until {
+        if create_form.enabled_from >= create_form.enabled_until {
             return Err(SerdeError::custom(format!(
                 "The search environment enabled window begin '{}' must be before the end '{}'",
-                internal.enabled_from, internal.enabled_until
+                create_form.enabled_from, create_form.enabled_until
             )));
         }
+        Ok(create_form)
+    }
+}
 
-        Ok(StdcmSearchEnvironmentCreateForm {
-            infra_id: internal.infra_id,
-            electrical_profile_set_id: internal.electrical_profile_set_id,
-            work_schedule_group_id: internal.work_schedule_group_id,
-            temporary_speed_limit_group_id: internal.temporary_speed_limit_group_id,
-            timetable_id: internal.timetable_id,
-            search_window_begin: internal.search_window_begin,
-            search_window_end: internal.search_window_end,
-            enabled_from: internal.enabled_from,
-            enabled_until: internal.enabled_until,
-        })
+#[cfg(test)]
+impl Serialize for StdcmSearchEnvironmentCreateForm {
+    fn serialize<S>(&self, serializer: S) -> StdResult<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        StdcmSearchEnvironmentCreateForm::serialize(self, serializer)
     }
 }
 

--- a/editoast/src/views/temporary_speed_limits.rs
+++ b/editoast/src/views/temporary_speed_limits.rs
@@ -30,7 +30,9 @@ crate::routes! {
     "/temporary_speed_limit_group" => create_temporary_speed_limit_group,
 }
 
-#[derive(Serialize, ToSchema)]
+#[derive(Deserialize, ToSchema)]
+#[serde(remote = "Self")]
+#[cfg_attr(test, derive(Serialize))]
 struct TemporarySpeedLimitItemForm {
     start_date_time: NaiveDateTime,
     end_date_time: NaiveDateTime,
@@ -39,7 +41,8 @@ struct TemporarySpeedLimitItemForm {
     obj_id: String,
 }
 
-#[derive(Serialize, Deserialize, ToSchema)]
+#[derive(Deserialize, ToSchema)]
+#[cfg_attr(test, derive(Serialize))]
 struct TemporarySpeedLimitCreateForm {
     speed_limit_group_name: String,
     #[schema(inline)]
@@ -71,38 +74,24 @@ impl<'de> Deserialize<'de> for TemporarySpeedLimitItemForm {
     where
         D: serde::Deserializer<'de>,
     {
-        #[derive(Deserialize)]
-        #[serde(deny_unknown_fields)]
-        struct Internal {
-            start_date_time: NaiveDateTime,
-            end_date_time: NaiveDateTime,
-            track_ranges: Vec<DirectionalTrackRange>,
-            speed_limit: f64,
-            obj_id: String,
-        }
-        let Internal {
-            start_date_time,
-            end_date_time,
-            track_ranges,
-            speed_limit,
-            obj_id,
-        } = Internal::deserialize(deserializer)?;
-
-        // Validation checks
-
-        if end_date_time <= start_date_time {
+        let speed_limit = TemporarySpeedLimitItemForm::deserialize(deserializer)?;
+        if speed_limit.end_date_time <= speed_limit.start_date_time {
             return Err(SerdeError::custom(format!(
-                "The temporary_speed_limit start date '{start_date_time}' must be before the end date '{end_date_time}'"
+                "The temporary_speed_limit start date '{}' must be before the end date '{}'",
+                speed_limit.start_date_time, speed_limit.end_date_time,
             )));
         }
+        Ok(speed_limit)
+    }
+}
 
-        Ok(TemporarySpeedLimitItemForm {
-            start_date_time,
-            end_date_time,
-            track_ranges,
-            speed_limit,
-            obj_id,
-        })
+#[cfg(test)]
+impl Serialize for TemporarySpeedLimitItemForm {
+    fn serialize<S>(&self, serializer: S) -> StdResult<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        TemporarySpeedLimitItemForm::serialize(self, serializer)
     }
 }
 

--- a/editoast/src/views/work_schedules.rs
+++ b/editoast/src/views/work_schedules.rs
@@ -88,7 +88,8 @@ impl From<work_schedules::WsGroupError> for WorkScheduleError {
     }
 }
 
-#[derive(Serialize, ToSchema)]
+#[derive(Serialize, Deserialize, ToSchema)]
+#[serde(remote = "Self")]
 struct WorkScheduleItemForm {
     pub start_date_time: DateTime<Utc>,
     pub end_date_time: DateTime<Utc>,
@@ -103,32 +104,24 @@ impl<'de> Deserialize<'de> for WorkScheduleItemForm {
     where
         D: serde::Deserializer<'de>,
     {
-        #[derive(Deserialize)]
-        #[serde(deny_unknown_fields)]
-        struct Internal {
-            start_date_time: DateTime<Utc>,
-            end_date_time: DateTime<Utc>,
-            track_ranges: Vec<TrackRange>,
-            obj_id: String,
-            work_schedule_type: WorkScheduleType,
-        }
-        let internal = Internal::deserialize(deserializer)?;
-
+        let item_form = WorkScheduleItemForm::deserialize(deserializer)?;
         // Check dates
-        if internal.start_date_time >= internal.end_date_time {
+        if item_form.start_date_time >= item_form.end_date_time {
             return Err(SerdeError::custom(format!(
                 "The work_schedule start date '{}' must be before the end date '{}'",
-                internal.start_date_time, internal.end_date_time
+                item_form.start_date_time, item_form.end_date_time
             )));
         }
+        Ok(item_form)
+    }
+}
 
-        Ok(WorkScheduleItemForm {
-            start_date_time: internal.start_date_time,
-            end_date_time: internal.end_date_time,
-            track_ranges: internal.track_ranges,
-            obj_id: internal.obj_id,
-            work_schedule_type: internal.work_schedule_type,
-        })
+impl Serialize for WorkScheduleItemForm {
+    fn serialize<S>(&self, serializer: S) -> StdResult<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        WorkScheduleItemForm::serialize(self, serializer)
     }
 }
 


### PR DESCRIPTION
There were two ways to specialize serde `Deserialize` / `Serialize` traits in Editoast: by using serde remote crate mechanics with `Self` as the remote or by declaring an intermediate struct during deserialization. Replace uses of the latter by the former.