### PR TITLE
ci: separate pull and up command in starting the test infrastructure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -909,10 +909,10 @@ jobs:
           # to match the version of the core image we just built inside osrdyne
           sed -i "s/osrd-core:dev/osrd-core:$TAG/" docker/osrdyne.yml
 
-          services='editoast osrdyne core gateway'
+          services='editoast osrdyne core gateway jaeger openfga'
           composes='-f docker-compose.yml'
-          docker compose $composes pull --policy missing $services
-          docker compose $composes up --no-build -d $services jaeger openfga
+          docker compose $composes pull $services
+          docker compose $composes up --no-build -d $services
         env:
           DOCKER_BUILDKIT: 1
           COMPOSE_DOCKER_CLI_BUILD: 1


### PR DESCRIPTION
**The startup of the test infrastructure is flaky in the end-to-end CI builds.**

**Error:** `fatal error: concurrent map writes`  
**Example build:** https://github.com/OpenRailAssociation/osrd/actions/runs/15484825758/job/43597357439  
**Current Docker Compose version:** `v2.35.1` (used by the latest Ubuntu distro)

**Proposed solutions:**
- Upgrade Docker Compose to `v2.36.0` or later ([docker/compose#12747](https://github.com/docker/compose/issues/12747))
- **Workaround:** Split the `docker compose pull` and `docker compose up` commands to avoid parallel pulls 
