### PR TITLE
ci: fix silently failing storybook build

### DIFF
--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -81,7 +81,7 @@ RUN if [ "$SKIP_FRONT" = "1" ]; then \
     mkdir -p build; \
     echo '<html><body><h1>No front, as this image was built for running it in dev mode</h1></body></html>' > build/index.html; \
     else \
-    (npm run generate-licenses && npm run build); \
+    (CI=true npm run generate-licenses && CI=true npm run build); \
     fi
 
 #######################


### PR DESCRIPTION
Storybook tries to read stdin to when it fails (to get telemetry opt-in). If stdin is closed, it fails succesfully... Setting CI=true disable this behavior (and other similar ones), and it's a good practice to have it set anyway.

See https://github.com/OpenRailAssociation/osrd/actions/runs/15485923418/job/43600490309