### PR TITLE
ui, github: re-enable automated osrd-ui releases

### DIFF
--- a/.github/workflows/chart-publish.yml
+++ b/.github/workflows/chart-publish.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   release:
+    if: ${{ github.event_name == "workflow_dispatch" || startsWith(github.event.release.tag_name, 'v') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/osrd-ui-publish.yml
+++ b/.github/workflows/osrd-ui-publish.yml
@@ -1,13 +1,12 @@
 name: Publish osrd-ui on Release
 
 on:
-  # TODO: re-enable automatic releases once we've decided on a scheme
-  workflow_dispatch:
-  #release:
-  #  types: [released]
+  release:
+    types: [released]
 
 jobs:
   publish:
+    if: ${{ startsWith(github.ref, 'refs/tags/ui-v') }}
     runs-on: ubuntu-latest
 
     steps:
@@ -35,7 +34,7 @@ jobs:
       - name: Publish
         run: |
           TAG=${GITHUB_REF/refs\/tags\//}
-          VERSION=${TAG/v/}
+          VERSION=${TAG/ui-v/}
           cd front
           npm ci
           cd ui

--- a/.github/workflows/osrd-ui-website.yml
+++ b/.github/workflows/osrd-ui-website.yml
@@ -1,13 +1,13 @@
 name: Publish osrd-ui website
 
 on:
-  # TODO: re-enable automatic releases once we've decided on a scheme
   workflow_dispatch:
-  #release:
-  #  types: [created]
+  release:
+    types: [released]
 
 jobs:
   publish:
+    if: ${{ startsWith(github.ref, 'refs/tags/ui-v') }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   build:
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-latest
 
     permissions:

--- a/front/ui/README.md
+++ b/front/ui/README.md
@@ -24,7 +24,16 @@ To execute the test suite, run `npm run test`.
 
 ## Publishing versions
 
-TBD
+1. Go to the [new release page](//github.com/OpenRailAssociation/osrd/releases/new).
+2. In "Choose a tag", type `ui-vX.Y.Z` and click "Create new tag".
+3. In "Previous tag", pick the latest osrd-ui release and click "Generate
+   release notes".
+4. In "Release title", type "osrd-ui vX.Y.Z".
+5. Trim down the release notes by filtering out OSRD PRs, only keeping ui-*
+   material. Organize the changelog by package and highlight breaking API
+   changes.
+6. Untick "Set as latest release".
+7. Publish the release.
 
 ### Implications
 


### PR DESCRIPTION
Adjust GitHub Actions manifests for osrd-ui releases based on the tag name. Add instructions for cutting new releases in the README.