### PR TITLE
scripts: run playwright container in docker-compose network

### DIFF
--- a/front/playwright.config.ts
+++ b/front/playwright.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig, devices } from '@playwright/test';
 
+import { BASE_URL } from './tests/assets/constants/project-const';
+
 export default defineConfig({
   testDir: './tests',
 
@@ -16,7 +18,7 @@ export default defineConfig({
   use: {
     navigationTimeout: 30_000,
     actionTimeout: 10_000,
-    baseURL: process.env.BASE_URL || 'http://localhost:4000',
+    baseURL: BASE_URL,
     trace: 'retain-on-failure',
     video: 'retain-on-failure',
     locale: 'fr',

--- a/front/tests/assets/constants/project-const.ts
+++ b/front/tests/assets/constants/project-const.ts
@@ -1,4 +1,4 @@
-export const BASE_URL = 'http://localhost:4000';
+export const BASE_URL = process.env.BASE_URL || 'http://localhost:4000';
 export const electricRollingStockName = 'ELECTRIC_RS_E2E';
 export const dualModeRollingStockName = 'DUAL-MODE_RS_E2E';
 export const slowRollingStockName = 'SLOW_RS_E2E';

--- a/scripts/run-front-playwright-container.sh
+++ b/scripts/run-front-playwright-container.sh
@@ -18,11 +18,12 @@ if [ "$(echo "$VERSION" | wc -l)" -ne 1 ]; then
 fi
 cd ..
 
-# Loop through each argument passed to the scripts, and replace --ui with --ui=host=localhost
+# Loop through each argument passed to the scripts, and replace --ui with
+# something which works in Docker containers
 args=()
 for arg in "$@"; do
   if [ "$arg" = "--ui" ]; then
-    args+=("--ui-host=localhost")
+    args+=("--ui-host=0.0.0.0" "--ui-port=8888")
   else
     args+=("$arg")
   fi
@@ -37,9 +38,11 @@ mkdir -p "$PWD/front/tests/test-saved-environment"
 
 docker run -it --rm \
   --ipc=host \
-  --network=host \
+  --network=osrd_default \
+  -p 8888:8888 \
   -v "$PWD/front/playwright-report:/app/front/playwright-report" \
   -v "$PWD/front/test-results:/app/front/test-results" \
   -v "$PWD/front/tests/test-saved-environment:/app/front/tests/test-saved-environment" \
   -u "$(stat -c %u:%g .)" \
+  -e BASE_URL="http://gateway:4000" \
   osrd-playwright:latest npx playwright test "${args[@]}"


### PR DESCRIPTION
On some systems (e.g. macOS), host network mode isn't available.
Additionally, host network mode isn't the default for developers.

Attach the playwright container to the docker-compose network
instead.