### PR TITLE
front: refacto of onconfirm props in confirmmodal

### DIFF
--- a/front/src/common/BootstrapSNCF/ModalSNCF/ConfirmModal.tsx
+++ b/front/src/common/BootstrapSNCF/ModalSNCF/ConfirmModal.tsx
@@ -10,7 +10,7 @@ export interface ConfirmModalProps {
   confirmLabel?: string;
   cancelLabel?: string;
   confirmDisabled?: boolean;
-  onConfirm: () => void | Promise<void>;
+  onConfirm?: () => void | Promise<void>;
   onCancel?: () => void | Promise<void>;
   withCloseButton?: boolean;
 }
@@ -30,15 +30,19 @@ export const ConfirmModal = ({
   const [disabled, setDisabled] = useState(false);
 
   const confirm = useCallback(async () => {
-    setDisabled(true);
-    try {
-      await onConfirm();
-    } catch (e) {
-      console.error(e);
-    } finally {
-      setDisabled(false);
+    if (onConfirm) {
+      setDisabled(true);
+      try {
+        await onConfirm();
+      } catch (e) {
+        console.error(e);
+      } finally {
+        setDisabled(false);
+      }
+    } else {
+      closeModal();
     }
-  }, [onConfirm]);
+  }, [onConfirm, closeModal]);
 
   const cancel = useCallback(async () => {
     if (onCancel) {

--- a/front/src/modules/project/components/AddOrEditProjectModal.tsx
+++ b/front/src/modules/project/components/AddOrEditProjectModal.tsx
@@ -268,7 +268,6 @@ export default function AddOrEditProjectModal({
           <div className="confirm-modal-content">
             <ConfirmModal
               title={t('common.leaveEditionMode', { ns: 'translation' })}
-              onConfirm={closeModal}
               onCancel={resetClickedOutside}
               withCloseButton={false}
             />

--- a/front/src/modules/scenario/components/AddOrEditScenarioModal.tsx
+++ b/front/src/modules/scenario/components/AddOrEditScenarioModal.tsx
@@ -266,7 +266,6 @@ const AddOrEditScenarioModal = ({ editionMode = false, scenario }: AddOrEditScen
           <div className="confirm-modal-content">
             <ConfirmModal
               title={t('common.leaveEditionMode', { ns: 'translation' })}
-              onConfirm={closeModal}
               onCancel={resetClickedOutside}
               withCloseButton={false}
             />

--- a/front/src/modules/study/components/AddOrEditStudyModal.tsx
+++ b/front/src/modules/study/components/AddOrEditStudyModal.tsx
@@ -221,7 +221,6 @@ const AddOrEditStudyModal = ({ editionMode, study, scenarios }: AddOrEditStudyMo
           <div className="confirm-modal-content">
             <ConfirmModal
               title={t('common.leaveEditionMode', { ns: 'translation' })}
-              onConfirm={closeModal}
               onCancel={resetClickedOutside}
               withCloseButton={false}
             />


### PR DESCRIPTION
the `closeModal` function is always passed in the `onConfirm` props, I think we can add it in the confirm function