### PR TITLE
front: re-introduce margin reset in ngeToOsrd

### DIFF
--- a/front/src/applications/operationalStudies/components/MacroEditor/ngeToOsrd.ts
+++ b/front/src/applications/operationalStudies/components/MacroEditor/ngeToOsrd.ts
@@ -382,6 +382,8 @@ const handleUpdateTimetableItem = async ({
     path,
     start_time: startDate.toISOString(),
     schedule,
+    // Reset margins because they contain references to path items
+    margins: undefined,
     paced: undefined,
     exceptions: undefined,
     category: getTrainCategoryFromId(trainrun.categoryId),


### PR DESCRIPTION
This breaks train run edition in NGE when a margin is set on a train. The server replies with an HTTP 400 error.

This got lost in 4662d7db81d4 ("front: handle paced trains in macro mode").