### PR TITLE
front: Refacto stdcm warning

### DIFF
--- a/front/src/applications/stdcm/components/StdcmForm/StdcmConfig.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmConfig.tsx
@@ -128,7 +128,6 @@ const StdcmConfig = ({
     } else {
       // The console error is only for debugging the user tests (temporary)
       console.warn('The form is not valid:', { pathfinding, formErrorsStatus });
-      setFormErrors(formErrorsStatus);
     }
   };
 

--- a/front/src/applications/stdcm/components/StdcmWarningBox.tsx
+++ b/front/src/applications/stdcm/components/StdcmWarningBox.tsx
@@ -10,10 +10,7 @@ import { StdcmConfigErrorTypes, type StdcmConfigErrors } from '../types';
 const SHORT_TEXT_ERRORS = [StdcmConfigErrorTypes.INFRA_NOT_LOADED];
 
 type StdcmWarningBoxProps = {
-  errorInfos: {
-    errorType: StdcmConfigErrorTypes;
-    errorDetails?: StdcmConfigErrors['errorDetails'];
-  };
+  errorInfos: StdcmConfigErrors;
   removeOriginArrivalTime: () => void;
   removeDestinationArrivalTime: () => void;
 };


### PR DESCRIPTION
A small refacto for stdcm warning

- Remove a redundant call of setFormErrors
- Use already existing type StdcmConfigErrors instead of creating a new one