### PR TITLE
core: remove green/gray signal blocks in space-time chart for ETCS

### DIFF
--- a/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/bal/BALtoETCS_LEVEL2.kt
+++ b/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/bal/BALtoETCS_LEVEL2.kt
@@ -1,7 +1,5 @@
 package fr.sncf.osrd.signaling.bal
 
-import fr.sncf.osrd.reporting.exceptions.ErrorType
-import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.signaling.*
 import fr.sncf.osrd.sim_infra.api.SigParameters
 import fr.sncf.osrd.sim_infra.api.SigSettings
@@ -13,18 +11,6 @@ object BALtoETCS_LEVEL2 : SignalDriver {
     override val inputSignalingSystem = "BAL"
     override val outputSignalingSystem = "ETCS_LEVEL2"
 
-    private fun cascadePrimaryAspect(aspect: String): String {
-        return when (aspect) {
-            // TODO: should really be an execution aspect (160) but we can't have that since trains
-            // don't react to signaling yet
-            "VL" -> "300VL"
-            "A" -> "300VL"
-            "S" -> "000"
-            "C" -> "000"
-            else -> throw OSRDError.newAspectError(aspect)
-        }
-    }
-
     override fun evalSignal(
         signal: SigSettings,
         parameters: SigParameters,
@@ -32,23 +18,7 @@ object BALtoETCS_LEVEL2 : SignalDriver {
         maView: MovementAuthorityView?,
         limitView: SpeedLimitView?
     ): SigState {
-        return stateSchema {
-            when (maView!!.protectionStatus) {
-                ProtectionStatus.NO_PROTECTED_ZONES ->
-                    throw OSRDError(ErrorType.BALUnprotectedZones)
-                ProtectionStatus.INCOMPATIBLE -> value("aspect", "OCCUPIED")
-                ProtectionStatus.OCCUPIED -> value("aspect", "OCCUPIED")
-                ProtectionStatus.CLEAR -> {
-                    if (!maView.hasNextSignal) {
-                        value("aspect", "000")
-                    } else {
-                        val nextSignalState = maView.nextSignalState
-                        val nextAspect = nextSignalState.getEnum("aspect")
-                        value("aspect", cascadePrimaryAspect(nextAspect))
-                    }
-                }
-            }
-        }
+        return stateSchema { value("aspect", "VL") }
     }
 
     override fun checkSignal(reporter: SignalDiagReporter, signal: SigSettings, block: SigBlock) {}

--- a/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/bapr/BAPRtoETCS_LEVEL2.kt
+++ b/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/bapr/BAPRtoETCS_LEVEL2.kt
@@ -18,7 +18,7 @@ object BAPRtoETCS_LEVEL2 : SignalDriver {
         maView: MovementAuthorityView?,
         limitView: SpeedLimitView?
     ): SigState {
-        return stateSchema { value("aspect", "300VL") }
+        return stateSchema { value("aspect", "VL") }
     }
 
     override fun checkSignal(reporter: SignalDiagReporter, signal: SigSettings, block: SigBlock) {}

--- a/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/etcs_level2/ETCS_LEVEL2.kt
+++ b/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/etcs_level2/ETCS_LEVEL2.kt
@@ -16,12 +16,7 @@ import fr.sncf.osrd.sim_infra.api.SigStateSchema
  */
 object ETCS_LEVEL2 : SignalingSystemDriver {
     override val id = "ETCS_LEVEL2"
-    override val stateSchema = SigStateSchema {
-        enum(
-            "aspect",
-            listOf("300VL", "300(VL)", "270A", "220A", "160A", "080A", "000", "OCCUPIED")
-        )
-    }
+    override val stateSchema = SigStateSchema { enum("aspect", listOf("VL", "OCCUPIED")) }
     override val settingsSchema = SigSettingsSchema { flag("Nf") }
     override val parametersSchema = SigParametersSchema {}
 

--- a/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/etcs_level2/ETCS_LEVEL2toBAL.kt
+++ b/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/etcs_level2/ETCS_LEVEL2toBAL.kt
@@ -1,7 +1,5 @@
 package fr.sncf.osrd.signaling.etcs_level2
 
-import fr.sncf.osrd.reporting.exceptions.ErrorType
-import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.signaling.*
 import fr.sncf.osrd.sim_infra.api.SigParameters
 import fr.sncf.osrd.sim_infra.api.SigSettings
@@ -13,20 +11,6 @@ object ETCS_LEVEL2toBAL : SignalDriver {
     override val inputSignalingSystem = "ETCS_LEVEL2"
     override val outputSignalingSystem = "BAL"
 
-    private fun cascadePrimaryAspect(aspect: String): String {
-        return when (aspect) {
-            "300VL" -> "VL"
-            "300(VL)" -> "VL"
-            "270A" -> "VL"
-            "220A" -> "VL"
-            "160A" -> "VL"
-            "080A" -> "VL"
-            "000" -> "A"
-            "OCCUPIED" -> "C"
-            else -> throw OSRDError.newAspectError(aspect)
-        }
-    }
-
     override fun evalSignal(
         signal: SigSettings,
         parameters: SigParameters,
@@ -34,20 +18,7 @@ object ETCS_LEVEL2toBAL : SignalDriver {
         maView: MovementAuthorityView?,
         limitView: SpeedLimitView?
     ): SigState {
-        return stateSchema {
-            assert(maView!!.hasNextSignal)
-            when (maView.protectionStatus) {
-                ProtectionStatus.NO_PROTECTED_ZONES ->
-                    throw OSRDError(ErrorType.BALUnprotectedZones)
-                ProtectionStatus.INCOMPATIBLE -> value("aspect", "C")
-                ProtectionStatus.OCCUPIED -> value("aspect", "S")
-                ProtectionStatus.CLEAR -> {
-                    val nextSignalState = maView.nextSignalState
-                    val nextAspect = nextSignalState.getEnum("aspect")
-                    value("aspect", cascadePrimaryAspect(nextAspect))
-                }
-            }
-        }
+        return stateSchema { value("aspect", "VL") }
     }
 
     override fun checkSignal(reporter: SignalDiagReporter, signal: SigSettings, block: SigBlock) {}

--- a/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/etcs_level2/ETCS_LEVEL2toETCS_LEVEL2.kt
+++ b/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/etcs_level2/ETCS_LEVEL2toETCS_LEVEL2.kt
@@ -13,20 +13,6 @@ object ETCS_LEVEL2toETCS_LEVEL2 : SignalDriver {
     override val inputSignalingSystem = "ETCS_LEVEL2"
     override val outputSignalingSystem = "ETCS_LEVEL2"
 
-    private fun cascadePrimaryAspect(aspect: String, parameters: SigParameters): String {
-        return when (aspect) {
-            "300VL" -> "300VL"
-            "300(VL)" -> "300VL"
-            "270A" -> "300(VL)"
-            "220A" -> "270A"
-            "160A" -> "220A"
-            "080A" -> "160A"
-            "000" -> "080A"
-            "OCCUPIED" -> "000"
-            else -> throw OSRDError.newAspectError(aspect)
-        }
-    }
-
     override fun evalSignal(
         signal: SigSettings,
         parameters: SigParameters,
@@ -40,15 +26,7 @@ object ETCS_LEVEL2toETCS_LEVEL2 : SignalDriver {
                     throw OSRDError(ErrorType.BALUnprotectedZones)
                 ProtectionStatus.INCOMPATIBLE -> value("aspect", "OCCUPIED")
                 ProtectionStatus.OCCUPIED -> value("aspect", "OCCUPIED")
-                ProtectionStatus.CLEAR -> {
-                    if (!maView.hasNextSignal) {
-                        value("aspect", "000")
-                    } else {
-                        val nextSignalState = maView.nextSignalState
-                        val nextAspect = nextSignalState.getEnum("aspect")
-                        value("aspect", cascadePrimaryAspect(nextAspect, parameters))
-                    }
-                }
+                ProtectionStatus.CLEAR -> value("aspect", "VL")
             }
         }
     }

--- a/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/etcs_level2/ETCS_LEVEL2toTVM300.kt
+++ b/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/etcs_level2/ETCS_LEVEL2toTVM300.kt
@@ -1,7 +1,5 @@
 package fr.sncf.osrd.signaling.etcs_level2
 
-import fr.sncf.osrd.reporting.exceptions.ErrorType
-import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.signaling.*
 import fr.sncf.osrd.sim_infra.api.SigParameters
 import fr.sncf.osrd.sim_infra.api.SigSettings
@@ -13,20 +11,6 @@ object ETCS_LEVEL2toTVM300 : SignalDriver {
     override val inputSignalingSystem = "ETCS_LEVEL2"
     override val outputSignalingSystem = "TVM300"
 
-    private fun cascadePrimaryAspect(aspect: String, parameters: SigParameters): String {
-        return when (aspect) {
-            "300VL" -> "300VL"
-            "300(VL)" -> "300VL"
-            "270A" -> "300(VL)"
-            "220A" -> "270A"
-            "160A" -> "220A"
-            "080A" -> "160A"
-            "000" -> "080A"
-            "OCCUPIED" -> "000"
-            else -> throw OSRDError.newAspectError(aspect)
-        }
-    }
-
     override fun evalSignal(
         signal: SigSettings,
         parameters: SigParameters,
@@ -34,23 +18,7 @@ object ETCS_LEVEL2toTVM300 : SignalDriver {
         maView: MovementAuthorityView?,
         limitView: SpeedLimitView?
     ): SigState {
-        return stateSchema {
-            when (maView!!.protectionStatus) {
-                ProtectionStatus.NO_PROTECTED_ZONES ->
-                    throw OSRDError(ErrorType.BALUnprotectedZones)
-                ProtectionStatus.INCOMPATIBLE -> value("aspect", "OCCUPIED")
-                ProtectionStatus.OCCUPIED -> value("aspect", "OCCUPIED")
-                ProtectionStatus.CLEAR -> {
-                    if (!maView.hasNextSignal) {
-                        value("aspect", "000")
-                    } else {
-                        val nextSignalState = maView.nextSignalState
-                        val nextAspect = nextSignalState.getEnum("aspect")
-                        value("aspect", cascadePrimaryAspect(nextAspect, parameters))
-                    }
-                }
-            }
-        }
+        return stateSchema { value("aspect", "VL") }
     }
 
     override fun checkSignal(reporter: SignalDiagReporter, signal: SigSettings, block: SigBlock) {}

--- a/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/etcs_level2/ETCS_LEVEL2toTVM430.kt
+++ b/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/etcs_level2/ETCS_LEVEL2toTVM430.kt
@@ -1,7 +1,5 @@
 package fr.sncf.osrd.signaling.etcs_level2
 
-import fr.sncf.osrd.reporting.exceptions.ErrorType
-import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.signaling.*
 import fr.sncf.osrd.sim_infra.api.SigParameters
 import fr.sncf.osrd.sim_infra.api.SigSettings
@@ -13,20 +11,6 @@ object ETCS_LEVEL2toTVM430 : SignalDriver {
     override val inputSignalingSystem = "ETCS_LEVEL2"
     override val outputSignalingSystem = "TVM430"
 
-    private fun cascadePrimaryAspect(aspect: String, parameters: SigParameters): String {
-        return when (aspect) {
-            "300VL" -> "300VL"
-            "300(VL)" -> "300VL"
-            "270A" -> "300(VL)"
-            "220A" -> "270A"
-            "160A" -> "220A"
-            "080A" -> "160A"
-            "000" -> "080A"
-            "OCCUPIED" -> "000"
-            else -> throw OSRDError.newAspectError(aspect)
-        }
-    }
-
     override fun evalSignal(
         signal: SigSettings,
         parameters: SigParameters,
@@ -34,23 +18,7 @@ object ETCS_LEVEL2toTVM430 : SignalDriver {
         maView: MovementAuthorityView?,
         limitView: SpeedLimitView?
     ): SigState {
-        return stateSchema {
-            when (maView!!.protectionStatus) {
-                ProtectionStatus.NO_PROTECTED_ZONES ->
-                    throw OSRDError(ErrorType.BALUnprotectedZones)
-                ProtectionStatus.INCOMPATIBLE -> value("aspect", "OCCUPIED")
-                ProtectionStatus.OCCUPIED -> value("aspect", "OCCUPIED")
-                ProtectionStatus.CLEAR -> {
-                    if (!maView.hasNextSignal) {
-                        value("aspect", "000")
-                    } else {
-                        val nextSignalState = maView.nextSignalState
-                        val nextAspect = nextSignalState.getEnum("aspect")
-                        value("aspect", cascadePrimaryAspect(nextAspect, parameters))
-                    }
-                }
-            }
-        }
+        return stateSchema { value("aspect", "VL") }
     }
 
     override fun checkSignal(reporter: SignalDiagReporter, signal: SigSettings, block: SigBlock) {}

--- a/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/tvm300/TVM300toETCS_LEVEL2.kt
+++ b/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/tvm300/TVM300toETCS_LEVEL2.kt
@@ -1,7 +1,5 @@
 package fr.sncf.osrd.signaling.tvm300
 
-import fr.sncf.osrd.reporting.exceptions.ErrorType
-import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.signaling.*
 import fr.sncf.osrd.sim_infra.api.SigParameters
 import fr.sncf.osrd.sim_infra.api.SigSettings
@@ -13,21 +11,6 @@ object TVM300toETCS_LEVEL2 : SignalDriver {
     override val inputSignalingSystem = "TVM300"
     override val outputSignalingSystem = "ETCS_LEVEL2"
 
-    private fun cascadePrimaryAspect(aspect: String, parameters: SigParameters): String {
-        return when (aspect) {
-            "300VL" -> "300VL"
-            "300(VL)" -> "300VL"
-            "270A" -> "300(VL)"
-            "220A" -> "270A"
-            "160A" -> "220A"
-            "080A" -> "160A"
-            "000" -> "080A"
-            "RRR" -> "000"
-            "OCCUPIED" -> "000"
-            else -> throw OSRDError.newAspectError(aspect)
-        }
-    }
-
     override fun evalSignal(
         signal: SigSettings,
         parameters: SigParameters,
@@ -35,23 +18,7 @@ object TVM300toETCS_LEVEL2 : SignalDriver {
         maView: MovementAuthorityView?,
         limitView: SpeedLimitView?
     ): SigState {
-        return stateSchema {
-            when (maView!!.protectionStatus) {
-                ProtectionStatus.NO_PROTECTED_ZONES ->
-                    throw OSRDError(ErrorType.BALUnprotectedZones)
-                ProtectionStatus.INCOMPATIBLE -> value("aspect", "OCCUPIED")
-                ProtectionStatus.OCCUPIED -> value("aspect", "OCCUPIED")
-                ProtectionStatus.CLEAR -> {
-                    if (!maView.hasNextSignal) {
-                        value("aspect", "000")
-                    } else {
-                        val nextSignalState = maView.nextSignalState
-                        val nextAspect = nextSignalState.getEnum("aspect")
-                        value("aspect", cascadePrimaryAspect(nextAspect, parameters))
-                    }
-                }
-            }
-        }
+        return stateSchema { value("aspect", "VL") }
     }
 
     override fun checkSignal(reporter: SignalDiagReporter, signal: SigSettings, block: SigBlock) {}

--- a/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/tvm430/TVM430toETCS_LEVEL2.kt
+++ b/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/tvm430/TVM430toETCS_LEVEL2.kt
@@ -1,7 +1,5 @@
 package fr.sncf.osrd.signaling.tvm430
 
-import fr.sncf.osrd.reporting.exceptions.ErrorType
-import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.signaling.*
 import fr.sncf.osrd.sim_infra.api.SigParameters
 import fr.sncf.osrd.sim_infra.api.SigSettings
@@ -13,20 +11,6 @@ object TVM430toETCS_LEVEL2 : SignalDriver {
     override val inputSignalingSystem = "TVM430"
     override val outputSignalingSystem = "ETCS_LEVEL2"
 
-    private fun cascadePrimaryAspect(aspect: String, parameters: SigParameters): String {
-        return when (aspect) {
-            "300VL" -> "300VL"
-            "300(VL)" -> "300VL"
-            "270A" -> "300(VL)"
-            "220A" -> "270A"
-            "160A" -> "220A"
-            "080A" -> "160A"
-            "000" -> "080A"
-            "OCCUPIED" -> "000"
-            else -> throw OSRDError.newAspectError(aspect)
-        }
-    }
-
     override fun evalSignal(
         signal: SigSettings,
         parameters: SigParameters,
@@ -34,23 +18,7 @@ object TVM430toETCS_LEVEL2 : SignalDriver {
         maView: MovementAuthorityView?,
         limitView: SpeedLimitView?
     ): SigState {
-        return stateSchema {
-            when (maView!!.protectionStatus) {
-                ProtectionStatus.NO_PROTECTED_ZONES ->
-                    throw OSRDError(ErrorType.BALUnprotectedZones)
-                ProtectionStatus.INCOMPATIBLE -> value("aspect", "OCCUPIED")
-                ProtectionStatus.OCCUPIED -> value("aspect", "OCCUPIED")
-                ProtectionStatus.CLEAR -> {
-                    if (!maView.hasNextSignal) {
-                        value("aspect", "000")
-                    } else {
-                        val nextSignalState = maView.nextSignalState
-                        val nextAspect = nextSignalState.getEnum("aspect")
-                        value("aspect", cascadePrimaryAspect(nextAspect, parameters))
-                    }
-                }
-            }
-        }
+        return stateSchema { value("aspect", "VL") }
     }
 
     override fun checkSignal(reporter: SignalDiagReporter, signal: SigSettings, block: SigBlock) {}

--- a/core/src/main/kotlin/fr/sncf/osrd/signal_projection/SignalProjection.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/signal_projection/SignalProjection.kt
@@ -58,7 +58,7 @@ fun projectSignals(
         value("aspect", "300VL")
     }
     leastConstrainingStates[etcsLevel2] = (sigModuleManager.getStateSchema(etcsLevel2)) {
-        value("aspect", "300VL")
+        value("aspect", "VL")
     }
 
     val zoneMap = mutableMapOf<String, Int>()

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
@@ -166,6 +166,12 @@ fun runScheduleMetadataExtractor(
     var closedSignalStopOffset =
         getStopTravelledPathOffset(closedSignalStops, indexClosedSignalStop, pathOffsetBuilder)
     for ((indexPathSignal, pathSignal) in pathSignals.withIndex()) {
+        val sigSystemId = loadedSignalInfra.getSignalingSystem(pathSignal.signal)
+        if (simulator.sigModuleManager.isCurveBased(sigSystemId)) {
+            // no on-sight green block in space-time chart (VL requirement) for curve-based signals
+            continue
+        }
+
         val physicalSignal = loadedSignalInfra.getPhysicalSignal(pathSignal.signal)
         var signalCriticalOffset =
             Offset.max(

--- a/tests/tests/test_train_schedule.py
+++ b/tests/tests/test_train_schedule.py
@@ -1084,7 +1084,8 @@ def test_etcs_schedule_result_slowdowns_with_stop(
 def test_etcs_spacing_req(etcs_scenario: Scenario, etcs_rolling_stock: int):
     """
     spacing requirements should:
-    * start at the same time the braking curve starts if stopping on closed signal on the entry of the block
+    * start **roughly** at the same time the braking curve starts if stopping on closed signal
+      on the entry of the block (depending on SvL and if signal is Nf or F, this does change)
     * end when leaving the block
     """
     rolling_stock_response = requests.get(


### PR DESCRIPTION
Fix #12096

Cleanup of ETCS signal aspects that were duplicated from TVM.

Result:
![signalETCS](https://github.com/user-attachments/assets/da9e6c5d-12eb-429b-ac02-44da4bd55590)
