### PR TITLE
front: cleanup SimulationResults and useSimulationResults hook

### DIFF
--- a/front/src/applications/operationalStudies/__tests__/sampleData.ts
+++ b/front/src/applications/operationalStudies/__tests__/sampleData.ts
@@ -8,7 +8,7 @@ import type {
   PositionData,
 } from 'applications/operationalStudies/types';
 import type { SimulationSummaryResult } from 'common/api/osrdEditoastApi';
-import type { TrainScheduleId, TrainScheduleResponseWithTrainId } from 'reducers/osrdconf/types';
+import type { TrainScheduleId, TrainScheduleWithTrainId } from 'reducers/osrdconf/types';
 
 export const pathLength = 4000;
 
@@ -347,9 +347,8 @@ export const electrificationRangesLarge: ElectrificationRange[] = [
   },
 ];
 
-export const trainScheduleTooFast: TrainScheduleResponseWithTrainId = {
+export const trainScheduleTooFast: TrainScheduleWithTrainId = {
   id: 'trainschedule-98' as TrainScheduleId,
-  timetable_id: 10,
   train_name: 'tooFast',
   labels: [],
   rolling_stock_name: 'TC64700',
@@ -414,9 +413,8 @@ export const trainSummaryTooFast: Extract<SimulationSummaryResult, { status: 'su
   path_item_times_base: [0, 1444453, 2491479],
 };
 
-export const trainScheduleNotHonored: TrainScheduleResponseWithTrainId = {
+export const trainScheduleNotHonored: TrainScheduleWithTrainId = {
   id: 'trainschedule-96' as TrainScheduleId,
-  timetable_id: 10,
   train_name: 'notHonored',
   labels: [],
   rolling_stock_name: 'TC64700',
@@ -481,9 +479,8 @@ export const trainSummaryNotHonored: Extract<SimulationSummaryResult, { status: 
   path_item_times_base: [0, 1425534, 2186885],
 };
 
-export const trainScheduleHonored: TrainScheduleResponseWithTrainId = {
+export const trainScheduleHonored: TrainScheduleWithTrainId = {
   id: 'trainschedule-95' as TrainScheduleId,
-  timetable_id: 10,
   train_name: 'normal',
   labels: [],
   rolling_stock_name: 'TC64700',
@@ -525,12 +522,12 @@ export const trainScheduleHonored: TrainScheduleResponseWithTrainId = {
   },
 };
 
-export const trainScheduleNoSchedule: TrainScheduleResponseWithTrainId = {
+export const trainScheduleNoSchedule: TrainScheduleWithTrainId = {
   ...trainScheduleHonored,
   schedule: undefined,
 };
 
-export const trainScheduleNoMatch: TrainScheduleResponseWithTrainId = {
+export const trainScheduleNoMatch: TrainScheduleWithTrainId = {
   ...trainScheduleHonored,
   schedule: [
     {

--- a/front/src/applications/operationalStudies/components/MacroEditor/ngeToOsrd.ts
+++ b/front/src/applications/operationalStudies/components/MacroEditor/ngeToOsrd.ts
@@ -14,7 +14,7 @@ import {
   storeTrainSchedule,
 } from 'modules/trainschedule/helpers/updateTimetableItemHelpers';
 import type {
-  PacedTrainResponseWithPacedTrainId,
+  PacedTrainWithPacedTrainId,
   TimetableItemId,
   TimetableItem,
 } from 'reducers/osrdconf/types';
@@ -343,7 +343,7 @@ const handleCreateTimetableItem = async (
   if (newTimetableItems.length === 0) {
     throw new Error('Failed to create paced train');
   }
-  const newPacedTrain: PacedTrainResponseWithPacedTrainId = {
+  const newPacedTrain: PacedTrainWithPacedTrainId = {
     ...newTimetableItems[0],
     id: formatEditoastIdToPacedTrainId(newTimetableItems[0].id),
   };
@@ -386,7 +386,8 @@ const handleUpdateTimetableItem = async ({
   );
   await populateSecondaryCodesInPath(path, infraId, dispatch);
 
-  const { id: _id, timetable_id: _timetableId, ...timetableItemBase } = timetableItem;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { id, ...timetableItemBase } = timetableItem;
   const timetableItemForUpdate = {
     ...timetableItemBase,
     train_name: trainrun.name,

--- a/front/src/applications/operationalStudies/components/Scenario/ScenarioContent.tsx
+++ b/front/src/applications/operationalStudies/components/Scenario/ScenarioContent.tsx
@@ -258,12 +258,10 @@ const ScenarioContent = ({
                 <NGE dto={ngeDto} onOperation={handleNGEOperation} onLoad={handleNGELoad} />
               </div>
             ) : (
-              isInfraLoaded &&
-              infra && (
+              isInfraLoaded && (
                 <SimulationResults
                   scenarioData={{ name: scenario.name, infraName: scenario.infra_name }}
                   projectionData={projectionData}
-                  infraId={infra.id}
                   conflicts={conflicts}
                   timetableItemsWithDetails={timetableItemsWithDetails}
                   updateTrainDepartureTime={updateTrainDepartureTime}

--- a/front/src/applications/operationalStudies/hooks/useScenarioData.ts
+++ b/front/src/applications/operationalStudies/hooks/useScenarioData.ts
@@ -14,7 +14,7 @@ import { getOperationalStudiesElectricalProfileSetId } from 'reducers/osrdconf/o
 import type {
   TimetableItemId,
   TimetableItem,
-  PacedTrainResponseWithPacedTrainId,
+  PacedTrainWithPacedTrainId,
 } from 'reducers/osrdconf/types';
 import { getTrainIdUsedForProjection } from 'reducers/simulationResults/selectors';
 import { useAppDispatch } from 'store';
@@ -232,7 +232,7 @@ const useScenarioData = (scenario: ScenarioResponse, infra: InfraWithState) => {
           await putPacedTrainById({
             id: editoastPacedTrainId,
             body: {
-              ...(timetableItem as PacedTrainResponseWithPacedTrainId),
+              ...(timetableItem as PacedTrainWithPacedTrainId),
               start_time: newDeparture.toISOString(),
             },
           });

--- a/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
+++ b/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
@@ -173,7 +173,6 @@ const useSimulationResults = (): SimulationResultsData => {
     selectedTimetableItemPowerRestrictions: speedSpaceChart?.formattedPowerRestrictions || [],
     timetableItemSimulation: speedSpaceChart?.simulation,
     pathProperties: speedSpaceChart?.formattedPathProperties,
-    pathLength: path?.length,
     path,
   };
 };

--- a/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
+++ b/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
@@ -6,7 +6,7 @@ import { useSelector } from 'react-redux';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import useSpeedSpaceChart from 'modules/simulationResult/components/SpeedSpaceChart/useSpeedSpaceChart';
 import { getOperationalStudiesElectricalProfileSetId } from 'reducers/osrdconf/operationalStudiesConf/selectors';
-import type { PacedTrainResponseWithPacedTrainId } from 'reducers/osrdconf/types';
+import type { PacedTrainWithPacedTrainId } from 'reducers/osrdconf/types';
 import { getSelectedTrainId } from 'reducers/simulationResults/selectors';
 import { Duration } from 'utils/duration';
 import {
@@ -124,7 +124,7 @@ const useSimulationResults = (infraId: number): SimulationResults | undefined =>
       .add(selectedOccurrenceIndex * pacedTrainIntervalInMs, 'ms')
       .toISOString();
 
-    const updatedSelectedPacedTrain: PacedTrainResponseWithPacedTrainId = {
+    const updatedSelectedPacedTrain: PacedTrainWithPacedTrainId = {
       ...selectedPacedTrain,
       id: formatEditoastIdToPacedTrainId(selectedPacedTrain.id),
       start_time: selectedOccurrenceStartTime,

--- a/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
+++ b/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
@@ -126,7 +126,6 @@ const useSimulationResults = (): SimulationResultsData => {
               id: formatEditoastIdToTrainScheduleId(selectedTrainSchedule.id),
             },
             selectedTimetableItemSimulation: selectedTrainScheduleSimulation,
-            selectedTimetableItemStartTime: selectedTrainSchedule?.start_time,
           }
         : undefined;
     }
@@ -148,7 +147,6 @@ const useSimulationResults = (): SimulationResultsData => {
     return {
       selectedTimetableItem: updatedSelectedPacedTrain,
       selectedTimetableItemSimulation: selectedPacedTrainSimulation,
-      selectedTimetableItemStartTime: selectedOccurrenceStartTime,
     };
   }, [
     selectedTrainId,
@@ -161,8 +159,7 @@ const useSimulationResults = (): SimulationResultsData => {
   const speedSpaceChart = useSpeedSpaceChart(
     selectedTimetableItemSimulationData?.selectedTimetableItem,
     path,
-    selectedTimetableItemSimulationData?.selectedTimetableItemSimulation,
-    selectedTimetableItemSimulationData?.selectedTimetableItemStartTime
+    selectedTimetableItemSimulationData?.selectedTimetableItemSimulation
   );
 
   if (!selectedTrainId)

--- a/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
+++ b/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
@@ -1,16 +1,15 @@
 import { useMemo } from 'react';
 
 import dayjs from 'dayjs';
+import { omit } from 'lodash';
 import { useSelector } from 'react-redux';
 
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import useSpeedSpaceChart from 'modules/simulationResult/components/SpeedSpaceChart/useSpeedSpaceChart';
 import { getOperationalStudiesElectricalProfileSetId } from 'reducers/osrdconf/operationalStudiesConf/selectors';
-import type { PacedTrainWithPacedTrainId } from 'reducers/osrdconf/types';
 import { getSelectedTrainId } from 'reducers/simulationResults/selectors';
 import { Duration } from 'utils/duration';
 import {
-  formatEditoastIdToPacedTrainId,
   formatEditoastIdToTrainScheduleId,
   extractEditoastIdFromTrainScheduleId,
   extractOccurrenceIndexFromOccurrenceId,
@@ -119,19 +118,16 @@ const useSimulationResults = (infraId: number): SimulationResults | undefined =>
 
     const selectedOccurrenceIndex = extractOccurrenceIndexFromOccurrenceId(selectedTrainId);
     const pacedTrainIntervalInMs = Duration.parse(selectedPacedTrain.paced.interval).ms;
-
     const selectedOccurrenceStartTime: string = dayjs(selectedPacedTrain.start_time)
       .add(selectedOccurrenceIndex * pacedTrainIntervalInMs, 'ms')
       .toISOString();
 
-    const updatedSelectedPacedTrain: PacedTrainWithPacedTrainId = {
-      ...selectedPacedTrain,
-      id: formatEditoastIdToPacedTrainId(selectedPacedTrain.id),
-      start_time: selectedOccurrenceStartTime,
-    };
-
     return {
-      selectedTimetableItem: updatedSelectedPacedTrain,
+      selectedTimetableItem: {
+        ...omit(selectedPacedTrain, ['id', 'paced', 'exceptions']),
+        id: selectedTrainId,
+        start_time: selectedOccurrenceStartTime,
+      },
       selectedTimetableItemSimulation: selectedPacedTrainSimulation,
     };
   }, [
@@ -156,7 +152,7 @@ const useSimulationResults = (infraId: number): SimulationResults | undefined =>
     return undefined;
 
   return {
-    timetableItem: selectedTimetableItemSimulationData.selectedTimetableItem,
+    train: selectedTimetableItemSimulationData.selectedTimetableItem,
     rollingStock: speedSpaceChart.rollingStock,
     powerRestrictions: speedSpaceChart.formattedPowerRestrictions || [],
     simulation: selectedTimetableItemSimulationData.selectedTimetableItemSimulation,

--- a/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
+++ b/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
@@ -4,7 +4,6 @@ import dayjs from 'dayjs';
 import { useSelector } from 'react-redux';
 
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
-import { useInfraID } from 'common/osrdContext';
 import useSpeedSpaceChart from 'modules/simulationResult/components/SpeedSpaceChart/useSpeedSpaceChart';
 import { getOperationalStudiesElectricalProfileSetId } from 'reducers/osrdconf/operationalStudiesConf/selectors';
 import type { PacedTrainResponseWithPacedTrainId } from 'reducers/osrdconf/types';
@@ -26,8 +25,7 @@ import type { SimulationResultsData } from '../types';
 /**
  * Prepare data to be used in simulation results
  */
-const useSimulationResults = (): SimulationResultsData => {
-  const infraId = useInfraID();
+const useSimulationResults = (infraId: number): SimulationResultsData => {
   const electricalProfileSetId = useSelector(getOperationalStudiesElectricalProfileSetId);
   const selectedTrainId = useSelector(getSelectedTrainId);
 
@@ -58,26 +56,20 @@ const useSimulationResults = (): SimulationResultsData => {
     osrdEditoastApi.endpoints.getTrainScheduleByIdPath.useQuery(
       {
         id: editoastSelectedTrainId!,
-        infraId: infraId!,
+        infraId,
       },
       {
-        skip:
-          !editoastSelectedTrainId ||
-          !infraId ||
-          (selectedTrainId && !isTrainScheduleId(selectedTrainId)),
+        skip: !editoastSelectedTrainId || (selectedTrainId && !isTrainScheduleId(selectedTrainId)),
       }
     );
 
   const { data: rawPacedTrainPath } = osrdEditoastApi.endpoints.getPacedTrainByIdPath.useQuery(
     {
       id: editoastSelectedTrainId!,
-      infraId: infraId!,
+      infraId,
     },
     {
-      skip:
-        !editoastSelectedTrainId ||
-        !infraId ||
-        (selectedTrainId && !isOccurrenceId(selectedTrainId)),
+      skip: !editoastSelectedTrainId || (selectedTrainId && !isOccurrenceId(selectedTrainId)),
     }
   );
   const path = useMemo(() => {
@@ -91,12 +83,9 @@ const useSimulationResults = (): SimulationResultsData => {
 
   const { data: selectedTrainScheduleSimulation } =
     osrdEditoastApi.endpoints.getTrainScheduleByIdSimulation.useQuery(
-      { id: editoastSelectedTrainId!, infraId: infraId!, electricalProfileSetId },
+      { id: editoastSelectedTrainId!, infraId, electricalProfileSetId },
       {
-        skip:
-          !editoastSelectedTrainId ||
-          !infraId ||
-          (selectedTrainId && !isTrainScheduleId(selectedTrainId)),
+        skip: !editoastSelectedTrainId || (selectedTrainId && !isTrainScheduleId(selectedTrainId)),
       }
     );
 
@@ -104,14 +93,11 @@ const useSimulationResults = (): SimulationResultsData => {
     osrdEditoastApi.endpoints.getPacedTrainByIdSimulation.useQuery(
       {
         id: editoastSelectedTrainId!,
-        infraId: infraId!,
+        infraId,
         electricalProfileSetId,
       },
       {
-        skip:
-          !editoastSelectedTrainId ||
-          !infraId ||
-          (selectedTrainId && !isOccurrenceId(selectedTrainId)),
+        skip: !editoastSelectedTrainId || (selectedTrainId && !isOccurrenceId(selectedTrainId)),
       }
     );
 

--- a/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
+++ b/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
@@ -20,12 +20,12 @@ import {
   extractPacedTrainIdFromOccurrenceId,
 } from 'utils/trainId';
 
-import type { SimulationResultsData } from '../types';
+import type { SimulationResults } from '../types';
 
 /**
  * Prepare data to be used in simulation results
  */
-const useSimulationResults = (infraId: number): SimulationResultsData => {
+const useSimulationResults = (infraId: number): SimulationResults | undefined => {
   const electricalProfileSetId = useSelector(getOperationalStudiesElectricalProfileSetId);
   const selectedTrainId = useSelector(getSelectedTrainId);
 
@@ -148,17 +148,19 @@ const useSimulationResults = (infraId: number): SimulationResultsData => {
     selectedTimetableItemSimulationData?.selectedTimetableItemSimulation
   );
 
-  if (!selectedTrainId)
-    return {
-      selectedTimetableItemPowerRestrictions: [],
-    };
+  if (
+    selectedTimetableItemSimulationData?.selectedTimetableItemSimulation?.status !== 'success' ||
+    !speedSpaceChart ||
+    !path
+  )
+    return undefined;
 
   return {
-    selectedTimetableItem: selectedTimetableItemSimulationData?.selectedTimetableItem,
-    selectedTimetableItemRollingStock: speedSpaceChart?.rollingStock,
-    selectedTimetableItemPowerRestrictions: speedSpaceChart?.formattedPowerRestrictions || [],
-    timetableItemSimulation: speedSpaceChart?.simulation,
-    pathProperties: speedSpaceChart?.formattedPathProperties,
+    timetableItem: selectedTimetableItemSimulationData.selectedTimetableItem,
+    rollingStock: speedSpaceChart.rollingStock,
+    powerRestrictions: speedSpaceChart.formattedPowerRestrictions || [],
+    simulation: selectedTimetableItemSimulationData.selectedTimetableItemSimulation,
+    pathProperties: speedSpaceChart.formattedPathProperties,
     path,
   };
 };

--- a/front/src/applications/operationalStudies/types.ts
+++ b/front/src/applications/operationalStudies/types.ts
@@ -13,7 +13,7 @@ import type {
 import type { RangedValue } from 'common/types';
 import type { PathOperationalPoint } from 'modules/simulationResult/types';
 import type { SuggestedOP } from 'modules/trainschedule/components/ManageTrainSchedule/types';
-import type { TimetableItem } from 'reducers/osrdconf/types';
+import type { Train } from 'reducers/osrdconf/types';
 import type { Duration } from 'utils/duration';
 import type { ArrayElement } from 'utils/types';
 
@@ -105,7 +105,7 @@ export type ElectrificationVoltage = {
 };
 
 export type SimulationResults = {
-  timetableItem: TimetableItem;
+  train: Train;
   rollingStock: RollingStockWithLiveries;
   simulation: SimulationResponseSuccess;
   path: PathfindingResultSuccess;

--- a/front/src/applications/operationalStudies/types.ts
+++ b/front/src/applications/operationalStudies/types.ts
@@ -5,10 +5,10 @@ import type {
   PacedTrain,
   PathProperties,
   PathfindingResultSuccess,
-  RollingStockWithLiveries,
   SimulationResponse,
   TrainSchedule,
   MacroNodeForm,
+  RollingStockWithLiveries,
 } from 'common/api/osrdEditoastApi';
 import type { RangedValue } from 'common/types';
 import type { PathOperationalPoint } from 'modules/simulationResult/types';
@@ -104,14 +104,13 @@ export type ElectrificationVoltage = {
   voltage?: string;
 };
 
-export type SimulationResultsData = {
-  selectedTimetableItem?: TimetableItem;
-  selectedTimetableItemRollingStock?: RollingStockWithLiveries;
-  selectedTimetableItemPowerRestrictions: LayerData<PowerRestrictionValues>[];
-  timetableItemSimulation?: SimulationResponseSuccess;
-  pathProperties?: PathPropertiesFormatted;
-  pathLength?: number;
-  path?: PathfindingResultSuccess;
+export type SimulationResults = {
+  timetableItem: TimetableItem;
+  rollingStock: RollingStockWithLiveries;
+  simulation: SimulationResponseSuccess;
+  path: PathfindingResultSuccess;
+  pathProperties: PathPropertiesFormatted;
+  powerRestrictions: LayerData<PowerRestrictionValues>[];
 };
 
 export type OperationalPointWithTimeAndSpeed = {

--- a/front/src/applications/operationalStudies/views/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/SimulationResults.tsx
@@ -58,14 +58,7 @@ const SimulationResults = ({
   const timetableId = useSelector(getOperationalStudiesTimetableID);
   const selectedTrainId = useSelector(getSelectedTrainId);
 
-  const {
-    selectedTimetableItem,
-    selectedTimetableItemRollingStock,
-    selectedTimetableItemPowerRestrictions,
-    timetableItemSimulation,
-    pathProperties,
-    path,
-  } = useSimulationResults(infraId);
+  const simulationResults = useSimulationResults(infraId);
 
   const trainIdUsedForProjection = useSelector(getTrainIdUsedForProjection);
 
@@ -101,10 +94,10 @@ const SimulationResults = ({
 
   const selectedTrainSummary = useMemo(
     () =>
-      timetableItemsWithDetails?.find(
-        (timetableItem) => timetableItem.id === selectedTimetableItem?.id
+      timetableItemsWithDetails.find(
+        (timetableItem) => timetableItem.id === simulationResults?.timetableItem?.id
       ),
-    [timetableItemsWithDetails, selectedTimetableItem]
+    [timetableItemsWithDetails, simulationResults?.timetableItem]
   );
 
   const handleTrainDrag = async (
@@ -128,7 +121,7 @@ const SimulationResults = ({
     }
   };
 
-  if ((!selectedTimetableItem || !timetableItemSimulation) && !projectionData) {
+  if (!simulationResults && !projectionData) {
     return null;
   }
   return (
@@ -190,35 +183,33 @@ const SimulationResults = ({
         </div>
       </ResizableSection>
 
-      {selectedTimetableItem && timetableItemSimulation && (
+      {simulationResults && (
         <>
           {/* SIMULATION : SPEED SPACE CHART */}
-          {selectedTimetableItemRollingStock && pathProperties && (
-            <div className="osrd-simulation-container speedspacechart-container">
-              <div
-                className="chart-container"
-                style={{
-                  height: `${speedSpaceChartContainerHeight + HANDLE_TAB_RESIZE_HEIGHT}px`,
-                }}
-              >
-                <SpeedSpaceChartContainer
-                  timetableItemSimulation={timetableItemSimulation}
-                  selectedTimetableItemPowerRestrictions={selectedTimetableItemPowerRestrictions}
-                  rollingStock={selectedTimetableItemRollingStock}
-                  pathProperties={pathProperties}
-                  heightOfSpeedSpaceChartContainer={speedSpaceChartContainerHeight}
-                  setHeightOfSpeedSpaceChartContainer={setSpeedSpaceChartContainerHeight}
-                />
-              </div>
+          <div className="osrd-simulation-container speedspacechart-container">
+            <div
+              className="chart-container"
+              style={{
+                height: `${speedSpaceChartContainerHeight + HANDLE_TAB_RESIZE_HEIGHT}px`,
+              }}
+            >
+              <SpeedSpaceChartContainer
+                timetableItemSimulation={simulationResults.simulation}
+                selectedTimetableItemPowerRestrictions={simulationResults.powerRestrictions}
+                rollingStock={simulationResults.rollingStock}
+                pathProperties={simulationResults.pathProperties}
+                heightOfSpeedSpaceChartContainer={speedSpaceChartContainerHeight}
+                setHeightOfSpeedSpaceChartContainer={setSpeedSpaceChartContainerHeight}
+              />
             </div>
-          )}
+          </div>
 
           {/* SIMULATION : MAP */}
           <div data-testid="simulation-map" className="simulation-map">
             <SimulationResultsMap
-              geometry={pathProperties?.geometry}
+              geometry={simulationResults.pathProperties.geometry}
               setMapCanvas={setMapCanvas}
-              pathfindingResult={path}
+              pathfindingResult={simulationResults.path}
             />
           </div>
 
@@ -226,26 +217,24 @@ const SimulationResults = ({
           <div className="time-stop-outputs">
             <p className="mt-2 mb-3 ml-3 font-weight-bold">{t('timetableOutput')}</p>
             <TimesStopsOutput
-              simulatedTimetableItem={timetableItemSimulation}
+              simulatedTimetableItem={simulationResults.simulation}
               timetableItemWithDetails={selectedTrainSummary}
-              operationalPoints={pathProperties?.operationalPoints}
-              selectedTimetableItem={selectedTimetableItem}
-              path={path}
+              operationalPoints={simulationResults.pathProperties.operationalPoints}
+              selectedTimetableItem={simulationResults.timetableItem}
+              path={simulationResults.path}
             />
           </div>
 
           {/* SIMULATION EXPORT BUTTONS */}
-          {pathProperties && selectedTimetableItemRollingStock && path && (
-            <SimulationResultExport
-              path={path}
-              scenarioData={scenarioData}
-              timetableItem={selectedTimetableItem}
-              simulation={timetableItemSimulation}
-              pathProperties={pathProperties}
-              rollingStock={selectedTimetableItemRollingStock}
-              mapCanvas={mapCanvas}
-            />
-          )}
+          <SimulationResultExport
+            path={simulationResults.path}
+            scenarioData={scenarioData}
+            timetableItem={simulationResults.timetableItem}
+            simulation={simulationResults.simulation}
+            pathProperties={simulationResults.pathProperties}
+            rollingStock={simulationResults.rollingStock}
+            mapCanvas={mapCanvas}
+          />
         </>
       )}
     </div>

--- a/front/src/applications/operationalStudies/views/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/SimulationResults.tsx
@@ -28,6 +28,7 @@ import {
 import { useAppDispatch } from 'store';
 import { extractPacedTrainIdFromOccurrenceId, isTrainScheduleId } from 'utils/trainId';
 
+import { useScenarioContext } from '../hooks/useScenarioContext';
 import useSimulationResults from '../hooks/useSimulationResults';
 
 const SPEED_SPACE_CHART_HEIGHT = 521.5;
@@ -36,7 +37,6 @@ const MANCHETTE_HEIGHT_DIFF = 76;
 
 type SimulationResultsProps = {
   scenarioData: { name: string; infraName: string };
-  infraId?: number;
   projectionData?: ProjectionData;
   timetableItemsWithDetails: TimetableItemWithDetails[];
 
@@ -46,7 +46,6 @@ type SimulationResultsProps = {
 
 const SimulationResults = ({
   scenarioData,
-  infraId,
   projectionData,
   timetableItemsWithDetails,
   conflicts = [],
@@ -54,6 +53,7 @@ const SimulationResults = ({
 }: SimulationResultsProps) => {
   const { t } = useTranslation('operational-studies', { keyPrefix: 'simulationResults' });
   const dispatch = useAppDispatch();
+  const { infraId } = useScenarioContext();
 
   const timetableId = useSelector(getOperationalStudiesTimetableID);
   const selectedTrainId = useSelector(getSelectedTrainId);
@@ -65,7 +65,7 @@ const SimulationResults = ({
     timetableItemSimulation,
     pathProperties,
     path,
-  } = useSimulationResults();
+  } = useSimulationResults(infraId);
 
   const trainIdUsedForProjection = useSelector(getTrainIdUsedForProjection);
 
@@ -235,7 +235,7 @@ const SimulationResults = ({
           </div>
 
           {/* SIMULATION EXPORT BUTTONS */}
-          {pathProperties && selectedTimetableItemRollingStock && path && infraId && (
+          {pathProperties && selectedTimetableItemRollingStock && path && (
             <SimulationResultExport
               path={path}
               scenarioData={scenarioData}

--- a/front/src/applications/operationalStudies/views/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/SimulationResults.tsx
@@ -92,13 +92,15 @@ const SimulationResults = ({
 
   const conflictZones = useProjectedConflicts(infraId, conflicts, projectionData?.path);
 
-  const selectedTrainSummary = useMemo(
-    () =>
-      timetableItemsWithDetails.find(
-        (timetableItem) => timetableItem.id === simulationResults?.timetableItem?.id
-      ),
-    [timetableItemsWithDetails, simulationResults?.timetableItem]
-  );
+  const selectedTimetableItemSummary = useMemo(() => {
+    if (!simulationResults) return undefined;
+    const selectedTimetableItemId = isTrainScheduleId(simulationResults.train.id)
+      ? simulationResults.train.id
+      : extractPacedTrainIdFromOccurrenceId(simulationResults.train.id);
+    return timetableItemsWithDetails.find(
+      (timetableItem) => timetableItem.id === selectedTimetableItemId
+    );
+  }, [timetableItemsWithDetails, simulationResults?.train]);
 
   const handleTrainDrag = async (
     draggedTrainId: TrainId,
@@ -218,9 +220,9 @@ const SimulationResults = ({
             <p className="mt-2 mb-3 ml-3 font-weight-bold">{t('timetableOutput')}</p>
             <TimesStopsOutput
               simulatedTimetableItem={simulationResults.simulation}
-              timetableItemWithDetails={selectedTrainSummary}
+              timetableItemWithDetails={selectedTimetableItemSummary}
               operationalPoints={simulationResults.pathProperties.operationalPoints}
-              selectedTimetableItem={simulationResults.timetableItem}
+              selectedTrain={simulationResults.train}
               path={simulationResults.path}
             />
           </div>
@@ -229,7 +231,7 @@ const SimulationResults = ({
           <SimulationResultExport
             path={simulationResults.path}
             scenarioData={scenarioData}
-            timetableItem={simulationResults.timetableItem}
+            train={simulationResults.train}
             simulation={simulationResults.simulation}
             pathProperties={simulationResults.pathProperties}
             rollingStock={simulationResults.rollingStock}

--- a/front/src/applications/stdcm/hooks/useProjectedTrainsForStdcm.ts
+++ b/front/src/applications/stdcm/hooks/useProjectedTrainsForStdcm.ts
@@ -13,7 +13,7 @@ import {
   getStdcmInfraID,
   getStdcmTimetableID,
 } from 'reducers/osrdconf/stdcmConf/selectors';
-import type { TimetableItemId, TrainScheduleResponseWithTrainId } from 'reducers/osrdconf/types';
+import type { TimetableItemId, TrainScheduleWithTrainId } from 'reducers/osrdconf/types';
 import { Duration, addDurationToDate } from 'utils/duration';
 import { formatEditoastIdToTrainScheduleId } from 'utils/trainId';
 import { mapBy } from 'utils/types';
@@ -73,7 +73,7 @@ const useProjectedTrainsForStdcm = (stdcmResponse?: StdcmSuccessResponse) => {
   const { data: { results: rollingStocks } = { results: null } } =
     osrdEditoastApi.endpoints.getLightRollingStock.useQuery({ pageSize: 1000 });
 
-  const formattedTrainSchedules: TrainScheduleResponseWithTrainId[] = useMemo(
+  const formattedTrainSchedules: TrainScheduleWithTrainId[] = useMemo(
     () =>
       timetable?.map((trainSchedule) => ({
         ...trainSchedule,
@@ -82,7 +82,7 @@ const useProjectedTrainsForStdcm = (stdcmResponse?: StdcmSuccessResponse) => {
     [timetable]
   );
 
-  const trainSchedulesById: Map<TimetableItemId, TrainScheduleResponseWithTrainId> = useMemo(
+  const trainSchedulesById: Map<TimetableItemId, TrainScheduleWithTrainId> = useMemo(
     () => mapBy(formattedTrainSchedules, 'id'),
     [formattedTrainSchedules]
   );

--- a/front/src/applications/stdcm/hooks/useStdcm.ts
+++ b/front/src/applications/stdcm/hooks/useStdcm.ts
@@ -24,11 +24,7 @@ import {
 import { useStoreDataForSpeedLimitByTagSelector } from 'common/SpeedLimitByTagSelector/useStoreDataForSpeedLimitByTagSelector';
 import { setFailure } from 'reducers/main';
 import { addStdcmSimulations } from 'reducers/osrdconf/stdcmConf';
-import {
-  getStdcmConf,
-  getStdcmTimetableID,
-  getStdcmInfraID,
-} from 'reducers/osrdconf/stdcmConf/selectors';
+import { getStdcmConf, getStdcmInfraID } from 'reducers/osrdconf/stdcmConf/selectors';
 import type { TimetableItem } from 'reducers/osrdconf/types';
 import { updateSelectedTrainId } from 'reducers/simulationResults';
 import { useAppDispatch } from 'store';
@@ -54,7 +50,6 @@ const useStdcm = ({
   const dispatch = useAppDispatch();
   const { t, i18n } = useTranslation(['translation', 'stdcm']);
   const osrdconf = useSelector(getStdcmConf);
-  const timetableId = useSelector(getStdcmTimetableID);
   const infraId = useSelector(getStdcmInfraID);
   const requestPromise = useRef<ReturnType<typeof postTimetableByIdStdcm>[]>();
   const isCancelledRef = useRef(false);
@@ -106,7 +101,6 @@ const useStdcm = ({
     if (formattedResponse.status === 'success') {
       const stdcmTrain: TimetableItem = {
         id: formatEditoastIdToTrainScheduleId(STDCM_TRAIN_ID),
-        timetable_id: timetableId,
         comfort: payload.body.comfort,
         constraint_distribution: 'MARECO',
         path: payload.body.steps.map((step) => ({ ...step.location, id: nextId() })),

--- a/front/src/applications/stdcm/utils/stdcmComputeChartData.ts
+++ b/front/src/applications/stdcm/utils/stdcmComputeChartData.ts
@@ -14,7 +14,7 @@ const computeChartData = (
   rollingStock: RollingStockWithLiveries,
   pathProperties: StdcmPathProperties
 ): SpeedSpaceChartData => {
-  const { simulation, path: pathfindingResult, departure_time: departureTime } = stdcmResponse;
+  const { simulation, path: pathfindingResult } = stdcmResponse;
 
   /**
    * TODO:
@@ -42,7 +42,6 @@ const computeChartData = (
     formattedPowerRestrictions,
     simulation,
     formattedPathProperties,
-    departureTime,
   } as SpeedSpaceChartData;
 };
 

--- a/front/src/modules/powerRestriction/helpers/formatPowerRestrictionRangesWithHandled.ts
+++ b/front/src/modules/powerRestriction/helpers/formatPowerRestrictionRangesWithHandled.ts
@@ -74,24 +74,20 @@ export const convertPowerRestrictionsAndCheckCompatibility = (
 };
 
 const formatPowerRestrictionRangesWithHandled = ({
-  selectedTimetableItem,
+  selectedTimetableItem: { power_restrictions: powerRestrictions, path: pathInput },
   selectedTrainRollingStock,
   pathfindingResult,
   pathProperties,
 }: {
-  selectedTimetableItem?: TimetableItem;
+  selectedTimetableItem: Pick<TimetableItem, 'path' | 'power_restrictions'>;
   selectedTrainRollingStock?: RollingStock;
   pathfindingResult: PathfindingResultSuccess;
   pathProperties: PathPropertiesFormatted;
 }) => {
-  if (
-    selectedTimetableItem &&
-    selectedTimetableItem.power_restrictions &&
-    selectedTrainRollingStock
-  ) {
+  if (powerRestrictions && selectedTrainRollingStock) {
     const powerRestrictionsRanges = formatPowerRestrictionRanges(
-      selectedTimetableItem.power_restrictions,
-      selectedTimetableItem.path,
+      powerRestrictions,
+      pathInput,
       pathfindingResult.path_item_positions
     );
     const powerRestrictionsWithHandled = convertPowerRestrictionsAndCheckCompatibility(

--- a/front/src/modules/simulationResult/SimulationResultExport/SimulationResultsExport.tsx
+++ b/front/src/modules/simulationResult/SimulationResultExport/SimulationResultsExport.tsx
@@ -12,7 +12,7 @@ import type {
   PathfindingResultSuccess,
   RollingStockWithLiveries,
 } from 'common/api/osrdEditoastApi';
-import type { TimetableItem } from 'reducers/osrdconf/types';
+import type { Train } from 'reducers/osrdconf/types';
 
 import exportTrainCSV from './exportTrainCSV';
 import SimulationReportSheetScenario from './SimulationReportSheetScenario';
@@ -21,7 +21,7 @@ import { useFormattedOperationalPoints } from '../hooks/useFormattedOperationalP
 const exportTrainPDF = async (
   path: PathfindingResultSuccess,
   scenarioData: { name: string; infraName: string },
-  timetableItem: TimetableItem,
+  train: Train,
   simulation: SimulationResponseSuccess,
   rollingStock: RollingStockWithLiveries,
   operationalPoints: OperationalPointWithTimeAndSpeed[],
@@ -32,12 +32,12 @@ const exportTrainPDF = async (
       path={path}
       scenarioData={scenarioData}
       trainData={{
-        trainName: timetableItem.train_name,
+        trainName: train.train_name,
         departure_time: '',
         simulation,
         creationDate: new Date(),
         rollingStock,
-        speedLimitByTag: timetableItem.speed_limit_tag,
+        speedLimitByTag: train.speed_limit_tag,
       }}
       operationalPointsList={operationalPoints}
       mapCanvas={mapCanvas}
@@ -53,7 +53,7 @@ const exportTrainPDF = async (
 type SimulationResultExportProps = {
   path: PathfindingResultSuccess;
   scenarioData: { name: string; infraName: string };
-  timetableItem: TimetableItem;
+  train: Train;
   simulation: SimulationResponseSuccess;
   pathProperties: PathPropertiesFormatted;
   rollingStock: RollingStockWithLiveries;
@@ -63,7 +63,7 @@ type SimulationResultExportProps = {
 const SimulationResultExport = ({
   path,
   scenarioData,
-  timetableItem,
+  train,
   simulation,
   pathProperties,
   rollingStock,
@@ -71,11 +71,7 @@ const SimulationResultExport = ({
 }: SimulationResultExportProps) => {
   const { t } = useTranslation('operational-studies');
 
-  const operationalPoints = useFormattedOperationalPoints(
-    timetableItem,
-    simulation,
-    pathProperties
-  );
+  const operationalPoints = useFormattedOperationalPoints(train, simulation, pathProperties);
 
   return (
     <div className="simulation-sheet-container">
@@ -84,7 +80,7 @@ const SimulationResultExport = ({
           exportTrainPDF(
             path,
             scenarioData,
-            timetableItem,
+            train,
             simulation,
             rollingStock,
             operationalPoints,
@@ -99,12 +95,7 @@ const SimulationResultExport = ({
 
       <Button
         onClick={() =>
-          exportTrainCSV(
-            simulation,
-            operationalPoints,
-            pathProperties.electrifications,
-            timetableItem
-          )
+          exportTrainCSV(simulation, operationalPoints, pathProperties.electrifications, train)
         }
         variant="Quiet"
         label=".csv"

--- a/front/src/modules/simulationResult/SimulationResultExport/exportTrainCSV.ts
+++ b/front/src/modules/simulationResult/SimulationResultExport/exportTrainCSV.ts
@@ -4,7 +4,7 @@ import type {
   SimulationResponseSuccess,
 } from 'applications/operationalStudies/types';
 import type { ReportTrain } from 'common/api/osrdEditoastApi';
-import type { TimetableItem } from 'reducers/osrdconf/types';
+import type { Train } from 'reducers/osrdconf/types';
 import type { PositionSpeedTime, SpeedRanges } from 'reducers/simulationResults/types';
 import { dateToHHMMSS } from 'utils/date';
 import { mmToM, mToMm } from 'utils/physics';
@@ -200,12 +200,12 @@ export default function exportTrainCSV(
   simulatedTrain: SimulationResponseSuccess,
   operationalPoints: OperationalPointWithTimeAndSpeed[],
   electrificationRanges: ElectrificationRange[],
-  timetableItem: TimetableItem
+  train: Train
 ) {
   const trainRegimeWithAccurateTime: ReportTrain = {
     ...simulatedTrain.final_output,
     times: simulatedTrain.final_output.times.map(
-      (time) => new Date(timetableItem.start_time).getTime() + time
+      (time) => new Date(train.start_time).getTime() + time
     ),
   };
 
@@ -254,5 +254,5 @@ export default function exportTrainCSV(
     }
   });
 
-  if (steps) createFakeLinkWithData(timetableItem.train_name, spreadDataBetweenSteps(steps));
+  if (steps) createFakeLinkWithData(train.train_name, spreadDataBetweenSteps(steps));
 }

--- a/front/src/modules/simulationResult/SimulationResultExport/utils.ts
+++ b/front/src/modules/simulationResult/SimulationResultExport/utils.ts
@@ -7,7 +7,7 @@ import type {
 } from 'applications/operationalStudies/types';
 import { type ReportTrain, type TrackSection } from 'common/api/osrdEditoastApi';
 import { matchPathStepAndOp } from 'modules/pathfinding/utils';
-import type { TimetableItem } from 'reducers/osrdconf/types';
+import type { Train } from 'reducers/osrdconf/types';
 import type { SpeedRanges } from 'reducers/simulationResults/types';
 import { Duration, addDurationToDate } from 'utils/duration';
 import { mmToM, msToKmhRounded } from 'utils/physics';
@@ -96,7 +96,7 @@ const getTimeAndSpeed = (
 export const formatOperationalPoints = (
   operationalPoints: PathPropertiesFormatted['operationalPoints'],
   simulatedTimetableItem: SimulationResponseSuccess,
-  timetableItem: TimetableItem,
+  timetableItem: Train,
   trackSections: Record<string, TrackSection>
 ): OperationalPointWithTimeAndSpeed[] => {
   // Format operational points

--- a/front/src/modules/simulationResult/components/SpaceTimeChart/useGetProjectedTrainOperationalPoints.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChart/useGetProjectedTrainOperationalPoints.ts
@@ -21,7 +21,7 @@ const useGetProjectedTrainOperationalPoints = ({
   timetableId,
   timetableItemUsedForProjection,
 }: {
-  infraId: number | undefined;
+  infraId: number;
   timetableId: number | undefined;
   timetableItemUsedForProjection?: TimetableItem;
 }) => {
@@ -38,7 +38,7 @@ const useGetProjectedTrainOperationalPoints = ({
 
   useEffect(() => {
     const getOperationalPoints = async () => {
-      if (!timetableItemUsedForProjection || !infraId) return;
+      if (!timetableItemUsedForProjection) return;
 
       const trainIdUsedForProjection = timetableItemUsedForProjection.id;
 

--- a/front/src/modules/simulationResult/components/SpaceTimeChart/useProjectedConflicts.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChart/useProjectedConflicts.ts
@@ -8,7 +8,7 @@ import type {
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 
 const useProjectedConflicts = (
-  infraId: number | undefined,
+  infraId: number,
   conflicts: Conflict[],
   path: PathfindingResultSuccess | undefined
 ) => {
@@ -19,7 +19,7 @@ const useProjectedConflicts = (
   useEffect(() => {
     const fetchProjectedZones = async ({ track_section_ranges }: PathfindingResultSuccess) => {
       const { zones } = await postPathProperties({
-        infraId: infraId!,
+        infraId,
         props: ['zones'],
         pathPropertiesInput: {
           track_section_ranges,

--- a/front/src/modules/simulationResult/components/SpeedSpaceChart/useSpeedSpaceChart.ts
+++ b/front/src/modules/simulationResult/components/SpeedSpaceChart/useSpeedSpaceChart.ts
@@ -20,8 +20,7 @@ import type { TimetableItem } from 'reducers/osrdconf/types';
 const useSpeedSpaceChart = (
   timetableItem?: TimetableItem,
   pathfindingResult?: PathfindingResultSuccess,
-  simulation?: SimulationResponse,
-  departureTime?: string
+  simulation?: SimulationResponse
 ): SpeedSpaceChartData | null => {
   const { t } = useTranslation('operational-studies');
   const infraId = useInfraID();
@@ -88,14 +87,12 @@ const useSpeedSpaceChart = (
   return timetableItem &&
     rollingStock &&
     simulation?.status === 'success' &&
-    formattedPathProperties &&
-    departureTime
+    formattedPathProperties
     ? {
         rollingStock,
         formattedPowerRestrictions,
         simulation,
         formattedPathProperties,
-        departureTime,
       }
     : null;
 };

--- a/front/src/modules/simulationResult/components/SpeedSpaceChart/useSpeedSpaceChart.ts
+++ b/front/src/modules/simulationResult/components/SpeedSpaceChart/useSpeedSpaceChart.ts
@@ -14,11 +14,11 @@ import { useInfraID } from 'common/osrdContext';
 import usePathProperties from 'modules/pathfinding/hooks/usePathProperties';
 import formatPowerRestrictionRangesWithHandled from 'modules/powerRestriction/helpers/formatPowerRestrictionRangesWithHandled';
 import type { SpeedSpaceChartData } from 'modules/simulationResult/types';
-import type { TimetableItem } from 'reducers/osrdconf/types';
+import type { Train } from 'reducers/osrdconf/types';
 
 /** Prepare data needed for speedSpaceChart */
 const useSpeedSpaceChart = (
-  timetableItem?: TimetableItem,
+  timetableItem?: Train,
   pathfindingResult?: PathfindingResultSuccess,
   simulation?: SimulationResponse
 ): SpeedSpaceChartData | null => {

--- a/front/src/modules/simulationResult/hooks/useFormattedOperationalPoints.ts
+++ b/front/src/modules/simulationResult/hooks/useFormattedOperationalPoints.ts
@@ -7,7 +7,7 @@ import type {
   PathPropertiesFormatted,
   SimulationResponseSuccess,
 } from 'applications/operationalStudies/types';
-import type { TimetableItem } from 'reducers/osrdconf/types';
+import type { Train } from 'reducers/osrdconf/types';
 
 import { formatOperationalPoints } from '../SimulationResultExport/utils';
 
@@ -15,7 +15,7 @@ import { formatOperationalPoints } from '../SimulationResultExport/utils';
  * add time, speed, position, duration to operational points
  */
 export const useFormattedOperationalPoints = (
-  timetableItem?: TimetableItem,
+  timetableItem?: Train,
   simulatedTimetableItem?: SimulationResponseSuccess,
   pathProperties?: PathPropertiesFormatted
 ) => {

--- a/front/src/modules/simulationResult/types.ts
+++ b/front/src/modules/simulationResult/types.ts
@@ -57,7 +57,6 @@ export type SpeedSpaceChartData = {
   formattedPowerRestrictions: LayerData<PowerRestrictionValues>[] | undefined;
   simulation?: SimulationResponseSuccess;
   formattedPathProperties: PathPropertiesFormatted;
-  departureTime: string;
 };
 
 export type ProjectionData = {

--- a/front/src/modules/timesStops/TimesStopsOutput.tsx
+++ b/front/src/modules/timesStops/TimesStopsOutput.tsx
@@ -6,7 +6,7 @@ import type {
 } from 'applications/operationalStudies/types';
 import type { PathfindingResultSuccess } from 'common/api/osrdEditoastApi';
 import type { TimetableItemWithDetails } from 'modules/trainschedule/components/Timetable/types';
-import type { TimetableItem } from 'reducers/osrdconf/types';
+import type { Train } from 'reducers/osrdconf/types';
 import { NO_BREAK_SPACE } from 'utils/strings';
 
 import useOutputTableData from './hooks/useOutputTableData';
@@ -17,7 +17,7 @@ type TimesStopsOutputProps = {
   simulatedTimetableItem?: SimulationResponseSuccess;
   timetableItemWithDetails?: TimetableItemWithDetails;
   operationalPoints?: PathPropertiesFormatted['operationalPoints'];
-  selectedTimetableItem?: TimetableItem;
+  selectedTrain?: Train;
   path?: PathfindingResultSuccess;
 };
 
@@ -25,14 +25,14 @@ const TimesStopsOutput = ({
   simulatedTimetableItem,
   timetableItemWithDetails,
   operationalPoints,
-  selectedTimetableItem,
+  selectedTrain,
   path,
 }: TimesStopsOutputProps) => {
   const enrichedOperationalPoints = useOutputTableData(
     simulatedTimetableItem?.final_output,
     timetableItemWithDetails,
     operationalPoints,
-    selectedTimetableItem,
+    selectedTrain,
     path
   );
   return (
@@ -52,7 +52,7 @@ const TimesStopsOutput = ({
         });
       }}
       headerRowHeight={40}
-      dataIsLoading={!timetableItemWithDetails || !operationalPoints || !selectedTimetableItem}
+      dataIsLoading={!timetableItemWithDetails || !operationalPoints || !selectedTrain}
     />
   );
 };

--- a/front/src/modules/timesStops/helpers/computeMargins.ts
+++ b/front/src/modules/timesStops/helpers/computeMargins.ts
@@ -1,5 +1,5 @@
 import type { TrainScheduleWithDetails } from 'modules/trainschedule/components/Timetable/types';
-import type { TimetableItem } from 'reducers/osrdconf/types';
+import type { Train } from 'reducers/osrdconf/types';
 import { ms2sec } from 'utils/timeManipulation';
 
 import { formatDigitsAndUnit } from './utils';
@@ -7,16 +7,16 @@ import type { ScheduleEntry, TheoreticalMarginsRecord } from '../types';
 
 /** Extracts the theoretical margin for each path step in the train schedule,
  * and marks whether margins are repeated or correspond to a boundary between margin values */
-export function getTheoreticalMargins(selectedTimetableItem: TimetableItem) {
-  const { margins } = selectedTimetableItem;
+export function getTheoreticalMargins(train: Pick<Train, 'margins' | 'path'>) {
+  const { margins } = train;
   if (!margins) {
     return undefined;
   }
   const theoreticalMargins: TheoreticalMarginsRecord = {};
   let marginIndex = 0;
-  selectedTimetableItem.path.forEach((step, index) => {
+  train.path.forEach((step, index) => {
     let isBoundary = index === 0;
-    if (step.id === selectedTimetableItem.margins?.boundaries[marginIndex]) {
+    if (step.id === train.margins?.boundaries[marginIndex]) {
       marginIndex += 1;
       isBoundary = true;
     }
@@ -31,18 +31,18 @@ export function getTheoreticalMargins(selectedTimetableItem: TimetableItem) {
 /** Compute all margins to display for a given train schedule path step */
 function computeMargins(
   theoreticalMargins: TheoreticalMarginsRecord | undefined,
-  selectedTimetableItem: TimetableItem,
+  train: Pick<Train, 'path' | 'margins'>,
   scheduleByAt: Record<string, ScheduleEntry>,
   pathStepIndex: number,
   pathItemTimes: NonNullable<TrainScheduleWithDetails['pathItemTimes']> // in ms
 ) {
-  const { path, margins } = selectedTimetableItem;
+  const { path, margins } = train;
   const pathStepId = path[pathStepIndex].id;
   const schedule = scheduleByAt[pathStepId];
   const stepTheoreticalMarginInfo = theoreticalMargins?.[pathStepId];
   if (
     !margins ||
-    pathStepIndex === selectedTimetableItem.path.length - 1 ||
+    pathStepIndex === train.path.length - 1 ||
     !stepTheoreticalMarginInfo ||
     !((schedule && schedule.arrival) || stepTheoreticalMarginInfo.isBoundary)
   ) {

--- a/front/src/modules/timesStops/hooks/useOutputTableData.ts
+++ b/front/src/modules/timesStops/hooks/useOutputTableData.ts
@@ -11,7 +11,7 @@ import type {
 import type { PathfindingResultSuccess } from 'common/api/osrdEditoastApi';
 import { interpolateValue } from 'modules/simulationResult/SimulationResultExport/utils';
 import type { TimetableItemWithDetails } from 'modules/trainschedule/components/Timetable/types';
-import type { TimetableItem } from 'reducers/osrdconf/types';
+import type { Train } from 'reducers/osrdconf/types';
 import { dateToHHMMSS } from 'utils/date';
 import { Duration } from 'utils/duration';
 
@@ -25,7 +25,7 @@ const useOutputTableData = (
   simulatedTrain?: SimulationResponseSuccess['final_output'],
   timetableItemWithDetails?: TimetableItemWithDetails,
   operationalPoints?: PathPropertiesFormatted['operationalPoints'],
-  selectedTimetableItem?: TimetableItem,
+  selectedTrain?: Train,
   path?: PathfindingResultSuccess
 ): TimesStopsRow[] => {
   const { t } = useTranslation();
@@ -33,20 +33,18 @@ const useOutputTableData = (
 
   const [rows, setRows] = useState<TimesStopsRow[]>([]);
 
-  const scheduleByAt: Record<string, ScheduleEntry> = keyBy(selectedTimetableItem?.schedule, 'at');
-  const theoreticalMargins = selectedTimetableItem && getTheoreticalMargins(selectedTimetableItem);
+  const scheduleByAt: Record<string, ScheduleEntry> = keyBy(selectedTrain?.schedule, 'at');
+  const theoreticalMargins = selectedTrain && getTheoreticalMargins(selectedTrain);
 
-  const startDatetime = selectedTimetableItem
-    ? new Date(selectedTimetableItem.start_time)
-    : undefined;
+  const startDatetime = selectedTrain ? new Date(selectedTrain.start_time) : undefined;
 
   const pathStepRows = useMemo(() => {
     const pathItemTimes = timetableItemWithDetails?.pathItemTimes;
-    if (!path || !selectedTimetableItem || !pathItemTimes || !startDatetime) return [];
+    if (!path || !selectedTrain || !pathItemTimes || !startDatetime) return [];
 
     let lastReferenceDate = startDatetime;
 
-    return selectedTimetableItem.path.map((pathStep, index) => {
+    return selectedTrain.path.map((pathStep, index) => {
       const schedule: ScheduleEntry | undefined = scheduleByAt[pathStep.id];
 
       const computedArrival = new Date(startDatetime.getTime() + pathItemTimes.final[index]);
@@ -61,13 +59,7 @@ const useOutputTableData = (
         theoreticalMarginSeconds,
         calculatedMargin,
         diffMargins,
-      } = computeMargins(
-        theoreticalMargins,
-        selectedTimetableItem,
-        scheduleByAt,
-        index,
-        pathItemTimes
-      );
+      } = computeMargins(theoreticalMargins, selectedTrain, scheduleByAt, index, pathItemTimes);
 
       const { theoreticalArrival, arrival, departure, refDate } = computeInputDatetimes(
         startDatetime,
@@ -105,7 +97,7 @@ const useOutputTableData = (
         positionOnPath: path.path_item_positions[index],
       };
     });
-  }, [selectedTimetableItem, path, timetableItemWithDetails?.pathItemTimes]);
+  }, [selectedTrain, path, timetableItemWithDetails?.pathItemTimes]);
 
   useEffect(() => {
     const formatRows = async () => {

--- a/front/src/modules/trainschedule/components/ImportTimetableItem/ImportTimetableItemTrainsList.tsx
+++ b/front/src/modules/trainschedule/components/ImportTimetableItem/ImportTimetableItemTrainsList.tsx
@@ -16,9 +16,9 @@ import { Loader } from 'common/Loaders';
 import rollingstockOpenData2OSRD from 'modules/trainschedule/components/ImportTimetableItem/rollingstock_opendata2osrd.json';
 import { setFailure, setSuccess } from 'reducers/main';
 import type {
-  PacedTrainResponseWithPacedTrainId,
+  PacedTrainWithPacedTrainId,
   TimetableItem,
-  TrainScheduleResponseWithTrainId,
+  TrainScheduleWithTrainId,
 } from 'reducers/osrdconf/types';
 import { useAppDispatch } from 'store';
 import { formatEditoastIdToPacedTrainId, formatEditoastIdToTrainScheduleId } from 'utils/trainId';
@@ -103,7 +103,7 @@ const ImportTimetableItemTrainsList = ({
         trainSchedulePayloads = generateTrainSchedulesPayloads(formattedTrainsList);
       }
 
-      let formattedTrainSchedules: TrainScheduleResponseWithTrainId[] = [];
+      let formattedTrainSchedules: TrainScheduleWithTrainId[] = [];
 
       if (trainSchedulePayloads.length) {
         const trainSchedules = await postTrainSchedule({
@@ -117,7 +117,7 @@ const ImportTimetableItemTrainsList = ({
         }));
       }
 
-      let formattedPacedTrains: PacedTrainResponseWithPacedTrainId[] = [];
+      let formattedPacedTrains: PacedTrainWithPacedTrainId[] = [];
       if (pacedTrainPayloads.length) {
         const pacedTrains = await postPacedTrain({
           id: timetableId,

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/CreateTimetableItemButton.tsx
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/CreateTimetableItemButton.tsx
@@ -9,9 +9,9 @@ import { setFailure, setSuccess } from 'reducers/main';
 import { clearAddedExceptionsList } from 'reducers/osrdconf/operationalStudiesConf';
 import { getOperationalStudiesConf } from 'reducers/osrdconf/operationalStudiesConf/selectors';
 import type {
-  PacedTrainResponseWithPacedTrainId,
+  PacedTrainWithPacedTrainId,
   TimetableItem,
-  TrainScheduleResponseWithTrainId,
+  TrainScheduleWithTrainId,
 } from 'reducers/osrdconf/types';
 import { useAppDispatch } from 'store';
 import { castErrorToFailure } from 'utils/error';
@@ -70,7 +70,7 @@ const CreateTimetableItemButton = ({
         }).unwrap();
 
         // We can only add one paced train at a time
-        const formattedNewPacedTrain: PacedTrainResponseWithPacedTrainId = {
+        const formattedNewPacedTrain: PacedTrainWithPacedTrainId = {
           ...newPacedTrain.at(0)!,
           id: formatEditoastIdToPacedTrainId(newPacedTrain.at(0)!.id),
         };
@@ -93,7 +93,7 @@ const CreateTimetableItemButton = ({
         }).unwrap();
 
         // We can only add one train schedule at a time
-        const formattedNewTrainSchedule: TrainScheduleResponseWithTrainId = {
+        const formattedNewTrainSchedule: TrainScheduleWithTrainId = {
           ...newTrainSchedule.at(0)!,
           id: formatEditoastIdToTrainScheduleId(newTrainSchedule.at(0)!.id),
         };

--- a/front/src/modules/trainschedule/components/Timetable/PacedTrain/PacedTrainItem.tsx
+++ b/front/src/modules/trainschedule/components/Timetable/PacedTrain/PacedTrainItem.tsx
@@ -22,7 +22,7 @@ import { setFailure, setSuccess } from 'reducers/main';
 import { getOperationalStudiesTimetableID } from 'reducers/osrdconf/operationalStudiesConf/selectors';
 import type {
   PacedTrainId,
-  PacedTrainResponseWithPacedTrainId,
+  PacedTrainWithPacedTrainId,
   TimetableItemId,
   TimetableItem,
   TrainId,
@@ -185,7 +185,7 @@ const PacedTrainItem = ({
       return;
     }
 
-    const formattedPacedTrainResponse: PacedTrainResponseWithPacedTrainId = {
+    const formattedPacedTrainResponse: PacedTrainWithPacedTrainId = {
       ...pacedTrainResult,
       id: formatEditoastIdToPacedTrainId(pacedTrainResult.id),
     };

--- a/front/src/modules/trainschedule/components/Timetable/TimetableToolbar.tsx
+++ b/front/src/modules/trainschedule/components/Timetable/TimetableToolbar.tsx
@@ -183,11 +183,10 @@ const TimetableToolbar = ({
         paced_trains: PacedTrain[];
       }>(
         (acc, timetableItem) => {
-          const omittedFields = ['id', 'timetable_id'] as const;
           if (isPacedTrainResponseWithPacedTrainId(timetableItem)) {
-            acc.paced_trains.push(omit(timetableItem, omittedFields));
+            acc.paced_trains.push(omit(timetableItem, ['id']));
           } else {
-            acc.train_schedules.push(omit(timetableItem, omittedFields));
+            acc.train_schedules.push(omit(timetableItem, ['id']));
           }
           return acc;
         },

--- a/front/src/modules/trainschedule/components/Timetable/TrainScheduleItem.tsx
+++ b/front/src/modules/trainschedule/components/Timetable/TrainScheduleItem.tsx
@@ -15,7 +15,7 @@ import type {
   TimetableItemId,
   TrainId,
   TrainScheduleId,
-  TrainScheduleResponseWithTrainId,
+  TrainScheduleWithTrainId,
 } from 'reducers/osrdconf/types';
 import { updateTrainIdUsedForProjection, updateSelectedTrainId } from 'reducers/simulationResults';
 import { useAppDispatch } from 'store';
@@ -37,7 +37,7 @@ type TrainScheduleItemProps = {
   isSelected: boolean;
   isModified?: boolean;
   handleSelectTrain: (trainId: TrainScheduleId) => void;
-  upsertTrainSchedules: (trainSchedules: TrainScheduleResponseWithTrainId[]) => void;
+  upsertTrainSchedules: (trainSchedules: TrainScheduleWithTrainId[]) => void;
   removeTrains: (trainIds: TimetableItemId[]) => void;
   projectionPathIsUsed: boolean;
   selectTrainToEdit: (train: TrainScheduleWithDetails) => void;
@@ -120,7 +120,7 @@ const TrainScheduleItem = ({
           id: trainDetail.timetable_id,
           body: [newTrain],
         }).unwrap();
-        const formattedTrainScheduleResponse: TrainScheduleResponseWithTrainId = {
+        const formattedTrainScheduleResponse: TrainScheduleWithTrainId = {
           ...trainScheduleResponse,
           id: formatEditoastIdToTrainScheduleId(trainScheduleResponse.id),
         };

--- a/front/src/modules/trainschedule/helpers/updateTimetableItemHelpers.ts
+++ b/front/src/modules/trainschedule/helpers/updateTimetableItemHelpers.ts
@@ -1,11 +1,11 @@
 import { osrdEditoastApi, type TrainSchedule, type PacedTrain } from 'common/api/osrdEditoastApi';
 import type {
   PacedTrainId,
-  PacedTrainResponseWithPacedTrainId,
+  PacedTrainWithPacedTrainId,
   TimetableItemId,
   TimetableItem,
   TrainScheduleId,
-  TrainScheduleResponseWithTrainId,
+  TrainScheduleWithTrainId,
 } from 'reducers/osrdconf/types';
 import type { AppDispatch } from 'store';
 import {
@@ -47,7 +47,7 @@ async function createTrainSchedule(
   dispatch: AppDispatch,
   timetableId: number,
   trainSchedule: TrainSchedule
-): Promise<TrainScheduleResponseWithTrainId> {
+): Promise<TrainScheduleWithTrainId> {
   const newTrainSchedules = await dispatch(
     osrdEditoastApi.endpoints.postTimetableByIdTrainSchedules.initiate({
       id: timetableId,
@@ -64,7 +64,7 @@ async function createPacedTrain(
   dispatch: AppDispatch,
   timetableId: number,
   pacedTrain: PacedTrain
-): Promise<PacedTrainResponseWithPacedTrainId> {
+): Promise<PacedTrainWithPacedTrainId> {
   const newPacedTrains = await dispatch(
     osrdEditoastApi.endpoints.postTimetableByIdPacedTrains.initiate({
       id: timetableId,
@@ -119,7 +119,7 @@ export async function storeTrainSchedule(
   dispatch: AppDispatch,
   upsertTimetableItems: (timetableItems: TimetableItem[]) => void,
   removeTimetableItems: (timetableItems: TimetableItemId[]) => void
-): Promise<TrainScheduleResponseWithTrainId> {
+): Promise<TrainScheduleWithTrainId> {
   if (isTrainScheduleId(timetableItemIdToUpdate)) {
     await updateTrainSchedule(dispatch, timetableItemIdToUpdate, trainSchedule);
     const updatedTrainSchedule = {
@@ -147,7 +147,7 @@ export async function storePacedTrain(
   dispatch: AppDispatch,
   upsertTimetableItems: (timetableItems: TimetableItem[]) => void,
   removeTimetableItems: (timetableItems: TimetableItemId[]) => void
-): Promise<PacedTrainResponseWithPacedTrainId> {
+): Promise<PacedTrainWithPacedTrainId> {
   if (isPacedTrainId(timetableItemIdToUpdate)) {
     await updatePacedTrain(dispatch, timetableItemIdToUpdate, pacedTrain);
     const updatedPacedTrain = {

--- a/front/src/reducers/osrdconf/types.ts
+++ b/front/src/reducers/osrdconf/types.ts
@@ -183,5 +183,9 @@ export type TrainScheduleWithTrainId = TrainSchedule & {
 export type PacedTrainWithPacedTrainId = PacedTrain & {
   id: PacedTrainId;
 };
+export type TrainBaseWithOccurrenceId = TrainSchedule & {
+  id: OccurrenceId;
+};
 
 export type TimetableItem = TrainScheduleWithTrainId | PacedTrainWithPacedTrainId;
+export type Train = TrainScheduleWithTrainId | TrainBaseWithOccurrenceId;

--- a/front/src/reducers/osrdconf/types.ts
+++ b/front/src/reducers/osrdconf/types.ts
@@ -14,11 +14,11 @@ import type {
   Distribution,
   LoadingGaugeType,
   OperationalPointReference,
-  PacedTrainResponse,
+  PacedTrain,
   PathItemLocation,
   ReceptionSignal,
   TrainCategory,
-  TrainScheduleResponse,
+  TrainSchedule,
 } from 'common/api/osrdEditoastApi';
 import type { PacedTrainWithDetails } from 'modules/trainschedule/components/Timetable/types';
 import type { InfraState } from 'reducers/infra';
@@ -176,12 +176,12 @@ export type TimetableItemToEditData =
       occurrenceId?: OccurrenceId;
     };
 
-export type TrainScheduleResponseWithTrainId = Omit<TrainScheduleResponse, 'id'> & {
+export type TrainScheduleWithTrainId = TrainSchedule & {
   id: TrainScheduleId;
 };
 
-export type PacedTrainResponseWithPacedTrainId = Omit<PacedTrainResponse, 'id'> & {
+export type PacedTrainWithPacedTrainId = PacedTrain & {
   id: PacedTrainId;
 };
 
-export type TimetableItem = TrainScheduleResponseWithTrainId | PacedTrainResponseWithPacedTrainId;
+export type TimetableItem = TrainScheduleWithTrainId | PacedTrainWithPacedTrainId;

--- a/front/src/utils/trainId.ts
+++ b/front/src/utils/trainId.ts
@@ -11,7 +11,7 @@ import type {
   IndexedOccurrenceId,
   OccurrenceId,
   PacedTrainId,
-  PacedTrainResponseWithPacedTrainId,
+  PacedTrainWithPacedTrainId,
   TimetableItem,
   TrainId,
   TrainScheduleId,
@@ -65,7 +65,7 @@ export const isExceptionFromPathOrSimulation = ({ exceptionChangeGroups }: Occur
 
 export const isPacedTrainResponseWithPacedTrainId = (
   timetableItem: TimetableItem
-): timetableItem is PacedTrainResponseWithPacedTrainId => isPacedTrainId(timetableItem.id);
+): timetableItem is PacedTrainWithPacedTrainId => isPacedTrainId(timetableItem.id);
 
 export const isPacedTrainWithDetails = (
   timetableItem: TimetableItemWithDetails


### PR DESCRIPTION
See commits.

This cleanup will be useful for https://github.com/OpenRailAssociation/osrd/issues/11889

I removed the useQuery in useSimulationResults to simplify the function fetchSimulationResults, but I lost the automatical refetch of RTK. As I had to manually fetch the results after a timetable item update, I moved the hook useSimulationResults in the context and added in the returned object the function fetchSimulationResults