### PR TITLE
front: fix missing translation namespace in OccurrenceIndicator

### DIFF
--- a/front/src/modules/trainschedule/components/Timetable/PacedTrain/OccurrenceIndicator.tsx
+++ b/front/src/modules/trainschedule/components/Timetable/PacedTrain/OccurrenceIndicator.tsx
@@ -17,7 +17,7 @@ type OccurrenceIndicatorProps = {
 const TOOLTIP_BOTTOM_MARGIN = 24;
 
 const OccurrenceIndicator = ({ occurrence }: OccurrenceIndicatorProps) => {
-  const { t } = useTranslation('operational-studies', { keyPrefix: 'main.timetable' });
+  const { t } = useTranslation(['operational-studies', 'translation'], { keyPrefix: 'main.timetable' });
   const dotRef = useRef<HTMLDivElement>(null);
   const changeGroupsRef = useRef<HTMLDivElement>(null);
 


### PR DESCRIPTION
All used namespaces must be provided upfront to useTranslation(). Right now things work by chance because another component happens to load the namespace beforehand.