### PR TITLE
core: stdcm: filter out nodes before adding them to the queue

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
@@ -202,8 +202,6 @@ class STDCMPathfinding(
             lastFValue = fValue
 
             progressLogger.processNode(endNode)
-            if (endNode.timeData.timeSinceDeparture + endNode.remainingTimeEstimation > maxRunTime)
-                continue
             if (endNode.infraExplorer.getStepTracker().hasReachedDestination()) {
                 return buildResult(endNode)
             }
@@ -212,7 +210,10 @@ class STDCMPathfinding(
     }
 
     private fun getAdjacentNodes(node: STDCMNode): Collection<STDCMNode> {
-        return graph.getAdjacentEdges(node).map { it.getEdgeEnd(graph) }
+        return graph
+            .getAdjacentEdges(node)
+            .map { it.getEdgeEnd(graph) }
+            .filter { it.timeData.timeSinceDeparture + it.remainingTimeEstimation <= maxRunTime }
     }
 
     private fun buildResult(node: STDCMNode): Result {


### PR DESCRIPTION
Fix https://github.com/OpenRailAssociation/osrd/issues/12103

Negligible impact on both processing speed and memory usage, but it was still wasteful to do it that way. By the end of the search we could have 10s of thousands of useless nodes in the queue. 