### PR TITLE
front: handle round trip trainruns for nge import

### DIFF
--- a/front/src/applications/operationalStudies/components/MacroEditor/__tests__/outOfOrderSourceTarget-output.json
+++ b/front/src/applications/operationalStudies/components/MacroEditor/__tests__/outOfOrderSourceTarget-output.json
@@ -61,6 +61,36 @@
         }
       ],
       "paced": { "interval": "PT1H", "time_window": "PT2H" }
+    },
+    {
+      "constraint_distribution": "STANDARD",
+      "rolling_stock_name": "",
+      "exceptions": [],
+      "train_name": "Carotte",
+      "labels": ["InterCity"],
+      "path": [
+        { "trigram": "SS", "id": "6-0", "deleted": false, "track_reference": null },
+        { "trigram": "LTH", "id": "8-1", "deleted": false, "track_reference": null },
+        { "trigram": "RTR", "id": "7-2", "deleted": false, "track_reference": null }
+      ],
+      "start_time": "2025-06-25T13:56:00.000Z",
+      "schedule": [
+        {
+          "at": "8-1",
+          "arrival": "PT1M",
+          "stop_for": "PT2M",
+          "locked": false,
+          "reception_signal": "OPEN"
+        },
+        {
+          "at": "7-2",
+          "arrival": "PT4M",
+          "stop_for": null,
+          "locked": false,
+          "reception_signal": "OPEN"
+        }
+      ],
+      "paced": { "interval": "PT1H", "time_window": "PT2H" }
     }
   ],
   "train_schedules": []

--- a/front/src/applications/operationalStudies/components/MacroEditor/consts.ts
+++ b/front/src/applications/operationalStudies/components/MacroEditor/consts.ts
@@ -9,6 +9,11 @@ import type {
   TrainrunTimeCategory,
 } from '../NGE/types';
 
+export enum TRAINRUN_DIRECTIONS {
+  FORWARD = 'forward',
+  BACKWARD = 'backward',
+}
+
 export const TRAINRUN_CATEGORY_HALTEZEITEN = {
   HaltezeitIPV: { haltezeit: 0, no_halt: false },
   HaltezeitA: { haltezeit: 0, no_halt: false },

--- a/front/src/applications/operationalStudies/components/MacroEditor/ngeToOsrd.ts
+++ b/front/src/applications/operationalStudies/components/MacroEditor/ngeToOsrd.ts
@@ -305,7 +305,7 @@ const generateSchedule = (
   });
 
 /**
- * Generate properties for trainrun related caracteristics.
+ * Generate properties (labels, startDate and trainrunSections) for a trainrun.
  */
 const generateTrainrunProperties = (
   netzgrafikDto: NetzgrafikDto,
@@ -313,7 +313,6 @@ const generateTrainrunProperties = (
   oldStartDate?: Date
 ) => {
   const trainrunSections = getTrainrunSectionsByTrainrunId(netzgrafikDto, trainrun.id);
-  const path = generatePath(trainrunSections, netzgrafikDto.nodes);
   const labels = compact(
     uniq(
       trainrun.labelIds.map(
@@ -322,9 +321,21 @@ const generateTrainrunProperties = (
     )
   );
   const startDate = calculateStartDate(trainrunSections, oldStartDate || new Date());
-  const schedule = generateSchedule(trainrunSections, netzgrafikDto.nodes, startDate);
 
-  return { path, labels, startDate, schedule };
+  return { labels, startDate, trainrunSections };
+};
+
+/**
+ * Generate path and schedule from a trainrun.
+ */
+const generatePathAndSchedule = (
+  trainrunSections: TrainrunSectionDto[],
+  nodes: NodeDto[],
+  startDate: Date
+) => {
+  const path = generatePath(trainrunSections, nodes);
+  const schedule = generateSchedule(trainrunSections, nodes, startDate);
+  return { path, schedule };
 };
 
 // TODO: drop this function once this PR is merged:
@@ -383,7 +394,15 @@ const handleCreateTimetableItem = async (
   dispatch: AppDispatch,
   addUpsertedTimetableItems: (timetableItems: TimetableItem[]) => void
 ) => {
-  const { path, labels, startDate, schedule } = generateTrainrunProperties(netzgrafikDto, trainrun);
+  const { labels, startDate, trainrunSections } = generateTrainrunProperties(
+    netzgrafikDto,
+    trainrun
+  );
+  const { path, schedule } = generatePathAndSchedule(
+    trainrunSections,
+    netzgrafikDto.nodes,
+    startDate
+  );
   await populateSecondaryCodesInPath(path, infraId, dispatch);
   const pacedTrain: PacedTrain = {
     ...DEFAULT_PACED_TRAIN_PAYLOAD,
@@ -440,10 +459,15 @@ const handleUpdateTimetableItem = async ({
 }) => {
   const timetableItemId = state.timetableItemIdByNgeId.get(trainrun.id)!;
   const timetableItem = await fetchTimetableItem(timetableItemId, dispatch);
-  const { path, labels, startDate, schedule } = generateTrainrunProperties(
+  const { labels, startDate, trainrunSections } = generateTrainrunProperties(
     netzgrafikDto,
     trainrun,
     new Date(timetableItem.start_time)
+  );
+  const { path, schedule } = generatePathAndSchedule(
+    trainrunSections,
+    netzgrafikDto.nodes,
+    startDate
   );
   await populateSecondaryCodesInPath(path, infraId, dispatch);
 
@@ -780,7 +804,8 @@ export const convertNgeDtoToOsrd = (dto: NetzgrafikDto) => {
   const trainSchedules: TrainSchedule[] = [];
   const pacedTrains: PacedTrain[] = [];
   for (const trainrun of dto.trainruns) {
-    const { path, labels, startDate, schedule } = generateTrainrunProperties(dto, trainrun);
+    const { labels, startDate, trainrunSections } = generateTrainrunProperties(dto, trainrun);
+    const { path, schedule } = generatePathAndSchedule(trainrunSections, dto.nodes, startDate);
     const category = dto.metadata.trainrunCategories.find((cat) => cat.id === trainrun.categoryId);
     if (category) labels.push(category.name);
     const commonProps = {

--- a/front/src/applications/operationalStudies/components/MacroEditor/ngeToOsrd.ts
+++ b/front/src/applications/operationalStudies/components/MacroEditor/ngeToOsrd.ts
@@ -32,6 +32,7 @@ import {
   DEFAULT_PACED_TRAIN_PAYLOAD,
   DEFAULT_TRAIN_SCHEDULE_PAYLOAD,
   DEFAULT_TIME_WINDOW,
+  TRAINRUN_DIRECTIONS,
 } from './consts';
 import type MacroEditorState from './MacroEditorState';
 import type { NodeIndexed } from './MacroEditorState';
@@ -219,15 +220,17 @@ const formatDateDifferenceFrom = (start: Date, stop: Date) =>
  */
 export const generatePath = (
   trainrunSections: TrainrunSectionDto[],
-  nodes: NodeDto[]
+  nodes: NodeDto[],
+  trainrunDirection: TRAINRUN_DIRECTIONS
 ): TrainSchedule['path'] => {
+  const isForward = trainrunDirection === TRAINRUN_DIRECTIONS.FORWARD;
   const path = trainrunSections.map((section, index) => {
-    const sourceNode = getNodeById(nodes, section.sourceNodeId);
-    const targetNode = getNodeById(nodes, section.targetNodeId);
-    if (!sourceNode || !targetNode) return [];
-    const originPathItem = createPathItemFromNode(sourceNode, index);
+    const fromNode = getNodeById(nodes, isForward ? section.sourceNodeId : section.targetNodeId);
+    const toNode = getNodeById(nodes, isForward ? section.targetNodeId : section.sourceNodeId);
+    if (!fromNode || !toNode) return [];
+    const originPathItem = createPathItemFromNode(fromNode, index);
     if (index === trainrunSections.length - 1) {
-      const destinationPathItem = createPathItemFromNode(targetNode, index + 1);
+      const destinationPathItem = createPathItemFromNode(toNode, index + 1);
       return [originPathItem, destinationPathItem];
     }
     return [originPathItem];
@@ -238,9 +241,16 @@ export const generatePath = (
 /**
  * Calculate the start date of a trainrun.
  */
-const calculateStartDate = (trainrunSections: TrainrunSectionDto[], startDate: Date): Date => {
+const calculateStartDate = (
+  trainrunSections: TrainrunSectionDto[],
+  startDate: Date,
+  trainrunDirection: TRAINRUN_DIRECTIONS = TRAINRUN_DIRECTIONS.FORWARD
+): Date => {
   // The departure time of the first section is guaranteed to be non-null
-  const startTimeLock = trainrunSections[0].sourceDeparture;
+  const startTimeLock =
+    trainrunDirection === TRAINRUN_DIRECTIONS.BACKWARD
+      ? trainrunSections[0].targetDeparture
+      : trainrunSections[0].sourceDeparture;
   startDate.setMinutes(startTimeLock.time!, 0, 0);
   return startDate;
 };
@@ -248,30 +258,41 @@ const calculateStartDate = (trainrunSections: TrainrunSectionDto[], startDate: D
 /**
  * Generate a schedule (list of stops with their arrival and departure times)
  * from a list of trainrun sections.
+ * The schedule is generated based on the trainrun direction.
  */
 const generateSchedule = (
   trainrunSections: TrainrunSectionDto[],
   nodes: NodeDto[],
-  startDate: Date
-): TrainSchedule['schedule'] =>
-  trainrunSections.flatMap((section, index) => {
+  startDate: Date,
+  trainrunDirection: TRAINRUN_DIRECTIONS
+): TrainSchedule['schedule'] => {
+  const isForward = trainrunDirection === TRAINRUN_DIRECTIONS.FORWARD;
+  return trainrunSections.flatMap((section, index) => {
     const nextSection = trainrunSections[index + 1];
-    const node = getNodeById(nodes, section.targetNodeId)!;
-    const transition = node.transitions.find(
-      (tr) => tr.port1Id === section.targetPortId || tr.port2Id === section.targetPortId
+    const toNodeId = isForward ? section.targetNodeId : section.sourceNodeId;
+    const toPortId = isForward ? section.targetPortId : section.sourcePortId;
+
+    const transition = getNodeById(nodes, toNodeId)!.transitions.find(
+      (tr) => tr.port1Id === toPortId || tr.port2Id === toPortId
     );
     const isNonStopTransit = transition?.isNonStopTransit ?? false;
 
-    // Note that arrival is the time the train arrives at the node
-    // and departure is the time the train leaves the node
-    let arrival = getTimeLockDate(
-      section.targetArrival,
-      trainrunSections[0].sourceDeparture,
-      startDate
-    );
-    const departure = nextSection
-      ? getTimeLockDate(nextSection.sourceDeparture, trainrunSections[0].sourceDeparture, startDate)
-      : null;
+    // Note that "arrival" is the time the train arrives at the node
+    // and "departure" is the time the train leaves the node
+    const firstSection = trainrunSections[0];
+    const arrivalTimeLock = isForward ? section.targetArrival : section.sourceArrival;
+    const trainrunStartTimeLock = isForward
+      ? firstSection.sourceDeparture
+      : firstSection.targetDeparture;
+
+    let arrival = getTimeLockDate(arrivalTimeLock, trainrunStartTimeLock, startDate);
+    let departure: Date | null = null;
+    if (nextSection) {
+      const nextDepartureTimeLock = isForward
+        ? nextSection.sourceDeparture
+        : nextSection.targetDeparture;
+      departure = getTimeLockDate(nextDepartureTimeLock, trainrunStartTimeLock, startDate);
+    }
 
     if (!arrival && !departure) {
       if (index === trainrunSections.length - 1) {
@@ -280,7 +301,7 @@ const generateSchedule = (
         // This need to be done here so it doesn't make an exception pop because the
         // destination is not configured the same way in macro.
         return {
-          at: `${section.targetNodeId}-${index + 1}`,
+          at: `${toNodeId}-${index + 1}`,
           stop_for: 'P0D',
           // Default information
           locked: false,
@@ -294,7 +315,7 @@ const generateSchedule = (
     arrival = arrival || departure!;
 
     return {
-      at: `${section.targetNodeId}-${index + 1}`,
+      at: `${toNodeId}-${index + 1}`,
       arrival: formatDateDifferenceFrom(startDate, arrival),
       stop_for:
         departure && !isNonStopTransit ? formatDateDifferenceFrom(arrival, departure) : null,
@@ -303,6 +324,7 @@ const generateSchedule = (
       reception_signal: 'OPEN',
     };
   });
+};
 
 /**
  * Generate properties (labels, startDate and trainrunSections) for a trainrun.
@@ -326,15 +348,23 @@ const generateTrainrunProperties = (
 };
 
 /**
- * Generate path and schedule from a trainrun.
+ * Generate path and schedule from a trainrun. If the trainrun is backward,
+ * the sections are reversed.
  */
 const generatePathAndSchedule = (
   trainrunSections: TrainrunSectionDto[],
   nodes: NodeDto[],
-  startDate: Date
+  startDate: Date,
+  trainrunDirection: TRAINRUN_DIRECTIONS = TRAINRUN_DIRECTIONS.FORWARD
 ) => {
-  const path = generatePath(trainrunSections, nodes);
-  const schedule = generateSchedule(trainrunSections, nodes, startDate);
+  let sections = trainrunSections;
+  let directionStartDate = startDate;
+  if (trainrunDirection === TRAINRUN_DIRECTIONS.BACKWARD) {
+    sections = [...trainrunSections].reverse();
+    directionStartDate = calculateStartDate(sections, startDate, trainrunDirection);
+  }
+  const path = generatePath(sections, nodes, trainrunDirection);
+  const schedule = generateSchedule(sections, nodes, directionStartDate, trainrunDirection); // directionStartDate, trainrunDirection);
   return { path, schedule };
 };
 
@@ -805,28 +835,37 @@ export const convertNgeDtoToOsrd = (dto: NetzgrafikDto) => {
   const pacedTrains: PacedTrain[] = [];
   for (const trainrun of dto.trainruns) {
     const { labels, startDate, trainrunSections } = generateTrainrunProperties(dto, trainrun);
-    const { path, schedule } = generatePathAndSchedule(trainrunSections, dto.nodes, startDate);
     const category = dto.metadata.trainrunCategories.find((cat) => cat.id === trainrun.categoryId);
     if (category) labels.push(category.name);
-    const commonProps = {
-      train_name: trainrun.name,
-      labels,
-      path,
-      start_time: startDate.toISOString(),
-      schedule,
-    };
-    const paced = createPacedAttributesFromTrainrun(trainrun, dto);
-    if (paced) {
-      pacedTrains.push({
-        ...DEFAULT_PACED_TRAIN_PAYLOAD,
-        ...commonProps,
-        paced,
-      });
-    } else {
-      trainSchedules.push({
-        ...DEFAULT_TRAIN_SCHEDULE_PAYLOAD,
-        ...commonProps,
-      });
+    for (const direction of Object.values(TRAINRUN_DIRECTIONS)) {
+      // TODO: handle the one-way trainrun cases when this PR is merged:
+      // https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/pull/477
+      const { path, schedule } = generatePathAndSchedule(
+        trainrunSections,
+        dto.nodes,
+        startDate,
+        direction
+      );
+      const commonProps = {
+        train_name: trainrun.name,
+        labels,
+        path,
+        start_time: startDate.toISOString(),
+        schedule,
+      };
+      const paced = createPacedAttributesFromTrainrun(trainrun, dto);
+      if (paced) {
+        pacedTrains.push({
+          ...DEFAULT_PACED_TRAIN_PAYLOAD,
+          ...commonProps,
+          paced,
+        });
+      } else {
+        trainSchedules.push({
+          ...DEFAULT_TRAIN_SCHEDULE_PAYLOAD,
+          ...commonProps,
+        });
+      }
     }
   }
 


### PR DESCRIPTION
Part of https://github.com/osrd-project/osrd-confidential/issues/1081

Instead of creating 1 `TimetableItem` per imported trainrun, now 1 for each direction is imported.

This will need to be overworked when https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/pull/477 is merged. For now, all upcoming NGE files are composed of round-trip trainruns only.

To test this PR, import any NGE file, like this one, in OSRD Operational Studies:
[reticulaire.json](https://github.com/user-attachments/files/20708713/reticulaire.json)
