### PR TITLE
editoast, front: enhance PostTimetableByIdStdcmApiResponse

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMResponse.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMResponse.kt
@@ -7,7 +7,7 @@ import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import fr.sncf.osrd.api.pathfinding.PathfindingBlockResponse
 import fr.sncf.osrd.api.pathfinding.polymorphicPathfindingResponseAdapter
-import fr.sncf.osrd.api.standalone_sim.SimulationResponse
+import fr.sncf.osrd.api.standalone_sim.SimulationSuccess
 import fr.sncf.osrd.api.standalone_sim.polymorphicElectricalProfileAdapter
 import fr.sncf.osrd.api.standalone_sim.polymorphicSimulationResponseAdapter
 import fr.sncf.osrd.api.standalone_sim.polymorphicSpeedLimitSourceAdapter
@@ -17,7 +17,7 @@ import java.time.ZonedDateTime
 interface STDCMResponse
 
 class STDCMSuccess(
-    var simulation: SimulationResponse,
+    var simulation: SimulationSuccess,
     var path: PathfindingBlockResponse,
     @Json(name = "departure_time") var departureTime: ZonedDateTime
 ) : STDCMResponse

--- a/editoast/core_client/src/simulation.rs
+++ b/editoast/core_client/src/simulation.rs
@@ -288,24 +288,35 @@ pub struct Request {
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
+pub struct SimulationSuccess {
+    /// Simulation without any regularity margins
+    pub base: ReportTrain,
+    /// Simulation that takes into account the regularity margins
+    pub provisional: ReportTrain,
+    /// User-selected simulation: can be base or provisional
+    pub final_output: CompleteReportTrain,
+    pub mrsp: SpeedLimitProperties,
+    pub electrical_profiles: ElectricalProfiles,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
 #[serde(tag = "status", rename_all = "snake_case")]
 // We accepted the difference of memory size taken by variants
 // Since there is only on success and others are error cases
 #[allow(clippy::large_enum_variant)]
 pub enum Response {
-    Success {
-        /// Simulation without any regularity margins
-        base: ReportTrain,
-        /// Simulation that takes into account the regularity margins
-        provisional: ReportTrain,
-        /// User-selected simulation: can be base or provisional
-        final_output: CompleteReportTrain,
-        mrsp: SpeedLimitProperties,
-        electrical_profiles: ElectricalProfiles,
-    },
-    SimulationFailed {
-        core_error: RawError,
-    },
+    Success(SimulationSuccess),
+    SimulationFailed { core_error: RawError },
+}
+
+impl Response {
+    #[cfg(feature = "mocking_client")]
+    pub fn success(self) -> Option<SimulationSuccess> {
+        match self {
+            Response::Success(simulation_success) => Some(simulation_success),
+            Response::SimulationFailed { .. } => None,
+        }
+    }
 }
 
 impl AsCoreRequest<Json<Response>> for Request {

--- a/editoast/core_client/src/stdcm.rs
+++ b/editoast/core_client/src/stdcm.rs
@@ -14,8 +14,8 @@ use utoipa::ToSchema;
 use super::conflict_detection::TrainRequirements;
 use super::pathfinding::PathfindingResultSuccess;
 use super::pathfinding::TrackRange;
-use super::simulation;
 use super::simulation::PhysicsConsist;
+use super::simulation::SimulationSuccess;
 use crate::AsCoreRequest;
 use crate::Json;
 
@@ -130,7 +130,7 @@ pub struct UndirectedTrackRange {
 #[allow(clippy::large_enum_variant)]
 pub enum Response {
     Success {
-        simulation: simulation::Response,
+        simulation: SimulationSuccess,
         path: PathfindingResultSuccess,
         departure_time: DateTime<Utc>,
     },

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -3567,7 +3567,7 @@ paths:
                     path:
                       $ref: '#/components/schemas/PathfindingResultSuccess'
                     simulation:
-                      $ref: '#/components/schemas/SimulationResponse'
+                      $ref: '#/components/schemas/SimulationResponseSuccess'
                     status:
                       type: string
                       enum:
@@ -11815,153 +11815,16 @@ components:
           format: int64
     SimulationResponse:
       oneOf:
-      - type: object
-        required:
-        - base
-        - provisional
-        - final_output
-        - mrsp
-        - electrical_profiles
-        - status
-        properties:
-          base:
-            $ref: '#/components/schemas/ReportTrain'
-          electrical_profiles:
-            type: object
-            required:
-            - boundaries
-            - values
-            properties:
-              boundaries:
-                type: array
-                items:
-                  type: integer
-                  format: int64
-                  minimum: 0
-                description: |-
-                  List of `n` boundaries of the ranges (block path).
-                  A boundary is a distance from the beginning of the path in mm.
-              values:
-                type: array
-                items:
-                  oneOf:
-                  - type: object
-                    required:
-                    - electrical_profile_type
-                    properties:
-                      electrical_profile_type:
-                        type: string
-                        enum:
-                        - no_profile
-                  - type: object
-                    required:
-                    - handled
-                    - electrical_profile_type
-                    properties:
-                      electrical_profile_type:
-                        type: string
-                        enum:
-                        - profile
-                      handled:
-                        type: boolean
-                      profile:
-                        type: string
-                        nullable: true
-                description: List of `n+1` values associated to the ranges
-          final_output:
-            allOf:
-            - $ref: '#/components/schemas/ReportTrain'
-            - type: object
-              required:
-              - signal_critical_positions
-              - zone_updates
-              - spacing_requirements
-              - routing_requirements
-              properties:
-                routing_requirements:
-                  type: array
-                  items:
-                    $ref: '#/components/schemas/RoutingRequirement'
-                signal_critical_positions:
-                  type: array
-                  items:
-                    $ref: '#/components/schemas/SignalCriticalPosition'
-                spacing_requirements:
-                  type: array
-                  items:
-                    $ref: '#/components/schemas/SpacingRequirement'
-                zone_updates:
-                  type: array
-                  items:
-                    $ref: '#/components/schemas/ZoneUpdate'
-          mrsp:
-            type: object
-            description: A MRSP computation result (Most Restrictive Speed Profile)
-            required:
-            - boundaries
-            - values
-            properties:
-              boundaries:
-                type: array
-                items:
-                  type: integer
-                  format: int64
-                  minimum: 0
-                description: |-
-                  List of `n` boundaries of the ranges (block path).
-                  A boundary is a distance from the beginning of the path in mm.
-              values:
-                type: array
-                items:
-                  type: object
-                  required:
-                  - speed
-                  properties:
-                    source:
-                      allOf:
-                      - oneOf:
-                        - type: object
-                          required:
-                          - tag
-                          - speed_limit_source_type
-                          properties:
-                            speed_limit_source_type:
-                              type: string
-                              enum:
-                              - given_train_tag
-                            tag:
-                              type: string
-                        - type: object
-                          required:
-                          - tag
-                          - speed_limit_source_type
-                          properties:
-                            speed_limit_source_type:
-                              type: string
-                              enum:
-                              - fallback_tag
-                            tag:
-                              type: string
-                        - type: object
-                          required:
-                          - speed_limit_source_type
-                          properties:
-                            speed_limit_source_type:
-                              type: string
-                              enum:
-                              - unknown_tag
-                      nullable: true
-                    speed:
-                      type: number
-                      format: double
-                      description: in meters per second
-                description: List of `n+1` values associated to the ranges
-          provisional:
-            $ref: '#/components/schemas/ReportTrain'
-          status:
-            type: string
-            enum:
-            - success
+      - allOf:
+        - $ref: '#/components/schemas/SimulationResponseSuccess'
+        - type: object
+          required:
+          - status
+          properties:
+            status:
+              type: string
+              enum:
+              - success
       - type: object
         required:
         - pathfinding_failed
@@ -11984,6 +11847,149 @@ components:
             type: string
             enum:
             - simulation_failed
+    SimulationResponseSuccess:
+      type: object
+      required:
+      - base
+      - provisional
+      - final_output
+      - mrsp
+      - electrical_profiles
+      properties:
+        base:
+          $ref: '#/components/schemas/ReportTrain'
+        electrical_profiles:
+          type: object
+          required:
+          - boundaries
+          - values
+          properties:
+            boundaries:
+              type: array
+              items:
+                type: integer
+                format: int64
+                minimum: 0
+              description: |-
+                List of `n` boundaries of the ranges (block path).
+                A boundary is a distance from the beginning of the path in mm.
+            values:
+              type: array
+              items:
+                oneOf:
+                - type: object
+                  required:
+                  - electrical_profile_type
+                  properties:
+                    electrical_profile_type:
+                      type: string
+                      enum:
+                      - no_profile
+                - type: object
+                  required:
+                  - handled
+                  - electrical_profile_type
+                  properties:
+                    electrical_profile_type:
+                      type: string
+                      enum:
+                      - profile
+                    handled:
+                      type: boolean
+                    profile:
+                      type: string
+                      nullable: true
+              description: List of `n+1` values associated to the ranges
+        final_output:
+          allOf:
+          - $ref: '#/components/schemas/ReportTrain'
+          - type: object
+            required:
+            - signal_critical_positions
+            - zone_updates
+            - spacing_requirements
+            - routing_requirements
+            properties:
+              routing_requirements:
+                type: array
+                items:
+                  $ref: '#/components/schemas/RoutingRequirement'
+              signal_critical_positions:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SignalCriticalPosition'
+              spacing_requirements:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SpacingRequirement'
+              zone_updates:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ZoneUpdate'
+        mrsp:
+          type: object
+          description: A MRSP computation result (Most Restrictive Speed Profile)
+          required:
+          - boundaries
+          - values
+          properties:
+            boundaries:
+              type: array
+              items:
+                type: integer
+                format: int64
+                minimum: 0
+              description: |-
+                List of `n` boundaries of the ranges (block path).
+                A boundary is a distance from the beginning of the path in mm.
+            values:
+              type: array
+              items:
+                type: object
+                required:
+                - speed
+                properties:
+                  source:
+                    allOf:
+                    - oneOf:
+                      - type: object
+                        required:
+                        - tag
+                        - speed_limit_source_type
+                        properties:
+                          speed_limit_source_type:
+                            type: string
+                            enum:
+                            - given_train_tag
+                          tag:
+                            type: string
+                      - type: object
+                        required:
+                        - tag
+                        - speed_limit_source_type
+                        properties:
+                          speed_limit_source_type:
+                            type: string
+                            enum:
+                            - fallback_tag
+                          tag:
+                            type: string
+                      - type: object
+                        required:
+                        - speed_limit_source_type
+                        properties:
+                          speed_limit_source_type:
+                            type: string
+                            enum:
+                            - unknown_tag
+                    nullable: true
+                  speed:
+                    type: number
+                    format: double
+                    description: in meters per second
+              description: List of `n+1` values associated to the ranges
+        provisional:
+          $ref: '#/components/schemas/ReportTrain'
     SimulationSummaryResult:
       oneOf:
       - type: object
@@ -12523,7 +12529,7 @@ components:
           path:
             $ref: '#/components/schemas/PathfindingResultSuccess'
           simulation:
-            $ref: '#/components/schemas/SimulationResponse'
+            $ref: '#/components/schemas/SimulationResponseSuccess'
           status:
             type: string
             enum:

--- a/editoast/src/views/projection.rs
+++ b/editoast/src/views/projection.rs
@@ -36,6 +36,7 @@ use crate::views::path::pathfinding::PathfindingResult;
 use crate::views::path::projection::PathProjection;
 use crate::views::path::projection::TrackLocationFromPath;
 use crate::views::timetable::simulation;
+use crate::views::timetable::simulation::SimulationResponseSuccess;
 use crate::views::timetable::simulation::train_simulation_batch;
 
 editoast_common::schemas! {
@@ -448,7 +449,9 @@ pub async fn extract_train_details(
             zone_updates,
             ..
         } = match Arc::unwrap_or_clone(sim) {
-            simulation::Response::Success { final_output, .. } => final_output,
+            simulation::Response::Success(SimulationResponseSuccess { final_output, .. }) => {
+                final_output
+            }
             _ => continue,
         };
         let ReportTrain {

--- a/editoast/src/views/stdcm_logs.rs
+++ b/editoast/src/views/stdcm_logs.rs
@@ -162,6 +162,8 @@ mod tests {
     use core_client::simulation::CompleteReportTrain;
     use core_client::simulation::ElectricalProfiles;
     use core_client::simulation::ReportTrain;
+    use core_client::simulation::Response;
+    use core_client::simulation::SimulationSuccess;
     use core_client::simulation::SpeedLimitProperties;
     use editoast_authz as authz;
     use editoast_authz::InfraGrant;
@@ -259,7 +261,7 @@ mod tests {
             .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(core_client::stdcm::Response::Success {
-                simulation: simulation_response(),
+                simulation: simulation_response().success().unwrap(),
                 path: pathfinding_result_success(),
                 departure_time: DateTime::from_str("2024-01-02T00:00:00Z")
                     .expect("Failed to parse datetime"),
@@ -278,8 +280,8 @@ mod tests {
         }
     }
 
-    fn simulation_response() -> core_client::simulation::Response {
-        core_client::simulation::Response::Success {
+    fn simulation_response() -> Response {
+        Response::Success(SimulationSuccess {
             base: ReportTrain {
                 positions: vec![],
                 times: vec![],
@@ -315,7 +317,7 @@ mod tests {
                 boundaries: vec![],
                 values: vec![],
             },
-        }
+        })
     }
 
     async fn execute_stdcm_request(app: &TestApp, user: Option<&authz::subject::User>) -> String {

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -70,6 +70,7 @@ use crate::models::timetable::TimetableWithTrains;
 use crate::models::train_schedule::TrainScheduleChangeset;
 use crate::views::AuthenticationExt;
 use crate::views::AuthorizationError;
+use crate::views::timetable::simulation::SimulationResponseSuccess;
 
 crate::routes! {
     "/timetable" => {
@@ -731,7 +732,9 @@ fn build_conflict_core_request(
     // Build train schedule train requirements
     for (train, sim) in trains.iter().zip(train_simulations) {
         let final_output = match sim.as_ref() {
-            simulation::Response::Success { final_output, .. } => final_output,
+            simulation::Response::Success(SimulationResponseSuccess { final_output, .. }) => {
+                final_output
+            }
             _ => continue,
         };
         let key = TrainId::TrainSchedule(train.id).to_string();
@@ -761,7 +764,9 @@ fn build_conflict_core_request(
 
         for (index, sim) in simulations.into_iter().enumerate() {
             let final_output = match sim.as_ref() {
-                simulation::Response::Success { final_output, .. } => final_output,
+                simulation::Response::Success(SimulationResponseSuccess {
+                    final_output, ..
+                }) => final_output,
                 _ => continue,
             };
 
@@ -1258,17 +1263,19 @@ mod tests {
                 end_time: 15,
             }],
         };
-        let train_simulations = [Arc::new(simulation::Response::Success {
-            base: ReportTrain::default(),
-            provisional: ReportTrain::default(),
-            final_output: CompleteReportTrain {
-                spacing_requirements: vec![spacing_requirement.clone()],
-                routing_requirements: vec![routing_requirement.clone()],
-                ..Default::default()
+        let train_simulations = [Arc::new(simulation::Response::Success(
+            SimulationResponseSuccess {
+                base: ReportTrain::default(),
+                provisional: ReportTrain::default(),
+                final_output: CompleteReportTrain {
+                    spacing_requirements: vec![spacing_requirement.clone()],
+                    routing_requirements: vec![routing_requirement.clone()],
+                    ..Default::default()
+                },
+                mrsp: SpeedLimitProperties::default(),
+                electrical_profiles: ElectricalProfiles::default(),
             },
-            mrsp: SpeedLimitProperties::default(),
-            electrical_profiles: ElectricalProfiles::default(),
-        })];
+        ))];
         let paced_id = 42;
         let paced_start_time = NaiveDate::from_ymd_opt(2025, 1, 1)
             .unwrap()
@@ -1290,7 +1297,7 @@ mod tests {
         };
         let paced_trains = vec![paced_train.clone()];
         let paced_train_simulations = std::iter::repeat_n(
-            Arc::new(simulation::Response::Success {
+            Arc::new(simulation::Response::Success(SimulationResponseSuccess {
                 base: ReportTrain::default(),
                 provisional: ReportTrain::default(),
                 final_output: CompleteReportTrain {
@@ -1300,7 +1307,7 @@ mod tests {
                 },
                 mrsp: SpeedLimitProperties::default(),
                 electrical_profiles: ElectricalProfiles::default(),
-            }),
+            })),
             2,
         )
         .collect_vec();

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -694,6 +694,7 @@ mod tests {
     use core_client::simulation::CompleteReportTrain;
     use core_client::simulation::ElectricalProfiles;
     use core_client::simulation::ReportTrain;
+    use core_client::simulation::SimulationSuccess;
     use core_client::simulation::SpeedLimitProperties;
     use editoast_models::DbConnectionPoolV2;
     use editoast_schemas::fixtures::simple_created_exception_with_change_groups;
@@ -730,6 +731,7 @@ mod tests {
     use crate::views::timetable::paced_train::PacedTrainResponse;
     use crate::views::timetable::paced_train::PacedTrainSummaryResponse;
     use crate::views::timetable::simulation;
+    use crate::views::timetable::simulation::SimulationResponseSuccess;
     use crate::views::timetable::simulation::SummaryResponse;
 
     #[rstest]
@@ -911,7 +913,7 @@ mod tests {
 
         assert_eq!(
             response,
-            core_client::simulation::Response::Success {
+            core_client::simulation::Response::Success(SimulationSuccess {
                 base: ReportTrain {
                     positions: vec![],
                     times: vec![],
@@ -947,7 +949,7 @@ mod tests {
                     boundaries: vec![],
                     values: vec![]
                 }
-            }
+            })
         );
     }
 
@@ -984,7 +986,7 @@ mod tests {
 
         assert_eq!(
             response,
-            simulation::Response::Success {
+            simulation::Response::Success(SimulationResponseSuccess {
                 base: ReportTrain {
                     positions: vec![],
                     times: vec![],
@@ -1020,7 +1022,7 @@ mod tests {
                     boundaries: vec![],
                     values: vec![]
                 }
-            }
+            })
         );
     }
 

--- a/editoast/src/views/timetable/simulation.rs
+++ b/editoast/src/views/timetable/simulation.rs
@@ -46,6 +46,22 @@ pub const TRAIN_SIZE_BATCH: usize = 100;
 editoast_common::schemas! {
     Response,
     SummaryResponse,
+    SimulationResponseSuccess,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Clone, Debug, ToSchema)]
+pub struct SimulationResponseSuccess {
+    /// Simulation without any regularity margins
+    pub base: ReportTrain,
+    /// Simulation that takes into account the regularity margins
+    pub provisional: ReportTrain,
+    #[schema(inline)]
+    /// User-selected simulation: can be base or provisional
+    pub final_output: CompleteReportTrain,
+    #[schema(inline)]
+    pub mrsp: SpeedLimitProperties,
+    #[schema(inline)]
+    pub electrical_profiles: ElectricalProfiles,
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug, ToSchema)]
@@ -55,19 +71,7 @@ editoast_common::schemas! {
 #[allow(clippy::large_enum_variant)]
 #[schema(as = SimulationResponse)]
 pub enum Response {
-    Success {
-        /// Simulation without any regularity margins
-        base: ReportTrain,
-        /// Simulation that takes into account the regularity margins
-        provisional: ReportTrain,
-        #[schema(inline)]
-        /// User-selected simulation: can be base or provisional
-        final_output: CompleteReportTrain,
-        #[schema(inline)]
-        mrsp: SpeedLimitProperties,
-        #[schema(inline)]
-        electrical_profiles: ElectricalProfiles,
-    },
+    Success(SimulationResponseSuccess),
     PathfindingFailed {
         pathfinding_failed: PathfindingFailure,
     },
@@ -78,7 +82,7 @@ pub enum Response {
 
 impl Response {
     pub fn simulation_run_time(&self) -> Option<u64> {
-        if let Response::Success { provisional, .. } = self {
+        if let Response::Success(SimulationResponseSuccess { provisional, .. }) = self {
             Some(
                 *provisional
                     .times
@@ -91,22 +95,24 @@ impl Response {
     }
 }
 
+impl From<core_client::simulation::SimulationSuccess> for SimulationResponseSuccess {
+    fn from(response: core_client::simulation::SimulationSuccess) -> Self {
+        SimulationResponseSuccess {
+            base: response.base,
+            provisional: response.provisional,
+            final_output: response.final_output,
+            mrsp: response.mrsp,
+            electrical_profiles: response.electrical_profiles,
+        }
+    }
+}
+
 impl From<core_client::simulation::Response> for Response {
     fn from(response: core_client::simulation::Response) -> Self {
         match response {
-            core_client::simulation::Response::Success {
-                base,
-                provisional,
-                final_output,
-                mrsp,
-                electrical_profiles,
-            } => Self::Success {
-                base,
-                provisional,
-                final_output,
-                mrsp,
-                electrical_profiles,
-            },
+            core_client::simulation::Response::Success(simulation_success) => {
+                Self::Success(simulation_success.into())
+            }
             core_client::simulation::Response::SimulationFailed { core_error } => {
                 Self::SimulationFailed {
                     core_error: core_error.into(),
@@ -152,12 +158,12 @@ pub enum SummaryResponse {
 impl From<simulation::Response> for SummaryResponse {
     fn from(response: simulation::Response) -> Self {
         match response {
-            simulation::Response::Success {
+            simulation::Response::Success(SimulationResponseSuccess {
                 final_output,
                 provisional,
                 base,
                 ..
-            } => {
+            }) => {
                 let report = final_output.report_train;
                 Self::Success {
                     length: *report.positions.last().unwrap(),

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -57,6 +57,7 @@ use crate::views::path::pathfinding::PathfindingResult;
 use crate::views::timetable::Conflict;
 use crate::views::timetable::PhysicsConsistParameters;
 use crate::views::timetable::simulation;
+use crate::views::timetable::simulation::SimulationResponseSuccess;
 use crate::views::timetable::simulation::consist_train_simulation_batch;
 use crate::views::timetable::train_simulation_batch;
 
@@ -76,8 +77,7 @@ crate::routes! {
 #[allow(clippy::large_enum_variant)]
 enum StdcmResponse {
     Success {
-        #[schema(value_type = SimulationResponse)]
-        simulation: simulation::Response,
+        simulation: SimulationResponseSuccess,
         path: PathfindingResultSuccess,
         departure_time: DateTime<Utc>,
     },
@@ -396,7 +396,9 @@ fn build_train_requirements(
     let mut trains_requirements = HashMap::new();
     for (train, sim) in train_schedules.iter().zip(simulation_responses) {
         let final_output = match sim.as_ref() {
-            simulation::Response::Success { final_output, .. } => final_output,
+            simulation::Response::Success(SimulationResponseSuccess { final_output, .. }) => {
+                final_output
+            }
             _ => continue,
         };
 
@@ -559,6 +561,7 @@ fn build_single_margin(margin: Option<MarginValue>) -> Margins {
 mod tests {
     use axum::http::StatusCode;
     use chrono::DateTime;
+    use core_client::simulation::SimulationSuccess;
     use editoast_common::units;
     use editoast_models::DbConnectionPoolV2;
     use editoast_schemas::fixtures::simple_rolling_stock;
@@ -691,7 +694,7 @@ mod tests {
     }
 
     fn simulation_response() -> core_client::simulation::Response {
-        core_client::simulation::Response::Success {
+        core_client::simulation::Response::Success(SimulationSuccess {
             base: ReportTrain {
                 positions: vec![],
                 times: vec![],
@@ -727,7 +730,7 @@ mod tests {
                 boundaries: vec![],
                 values: vec![],
             },
-        }
+        })
     }
 
     #[test]
@@ -935,7 +938,7 @@ mod tests {
             .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(core_client::stdcm::Response::Success {
-                simulation: simulation_response(),
+                simulation: simulation_response().success().unwrap(),
                 path: pathfinding_result_success(),
                 departure_time: DateTime::from_str("2024-01-02T00:00:00Z")
                     .expect("Failed to parse datetime"),
@@ -964,7 +967,7 @@ mod tests {
             assert_eq!(
                 stdcm_response,
                 StdcmResponse::Success {
-                    simulation: simulation_response().into(),
+                    simulation: simulation_response().success().unwrap().into(),
                     path,
                     departure_time: DateTime::from_str("2024-01-02T00:00:00Z")
                         .expect("Failed to parse datetime")
@@ -981,7 +984,7 @@ mod tests {
             .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(core_client::stdcm::Response::Success {
-                simulation: simulation_response(),
+                simulation: simulation_response().success().unwrap(),
                 path: pathfinding_result_success(),
                 departure_time: DateTime::from_str("2024-01-02T00:00:00Z")
                     .expect("Failed to parse datetime"),
@@ -1025,7 +1028,7 @@ mod tests {
             .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(core_client::stdcm::Response::Success {
-                simulation: simulation_response(),
+                simulation: simulation_response().success().unwrap(),
                 path: pathfinding_result_success(),
                 departure_time: DateTime::from_str("2024-01-02T00:00:00Z")
                     .expect("Failed to parse datetime"),
@@ -1071,7 +1074,7 @@ mod tests {
             .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(core_client::stdcm::Response::Success {
-                simulation: simulation_response(),
+                simulation: simulation_response().success().unwrap(),
                 path: pathfinding_result_success(),
                 departure_time: DateTime::from_str("2024-01-02T00:00:00Z")
                     .expect("Failed to parse datetime"),
@@ -1107,7 +1110,7 @@ mod tests {
             assert_eq!(
                 stdcm_response,
                 StdcmResponse::Success {
-                    simulation: simulation_response().into(),
+                    simulation: simulation_response().success().unwrap().into(),
                     path,
                     departure_time: DateTime::from_str("2024-01-02T00:00:00Z")
                         .expect("Failed to parse datetime")

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -47,6 +47,7 @@ use crate::views::projection::ProjectPathTrainResult;
 use crate::views::projection::compute_projected_train_paths;
 use crate::views::projection::find_index_upper;
 use crate::views::projection::interpolate;
+use crate::views::timetable::SimulationResponseSuccess;
 use crate::views::timetable::occupancy_blocks::OccupancyBlockForm;
 use crate::views::timetable::occupancy_blocks::OccupancyBlocks;
 use crate::views::timetable::occupancy_blocks::compute_occupancy_blocks;
@@ -882,7 +883,9 @@ fn find_track_occupancy_for_operational_point(
 
     // Get the positions and the times from the simulation
     let report_train = match simulation {
-        Response::Success { final_output, .. } => &final_output.report_train,
+        Response::Success(SimulationResponseSuccess { final_output, .. }) => {
+            &final_output.report_train
+        }
         _ => {
             tracing::info!(train_schedule.id, "simulation failed");
             return vec![];

--- a/front/src/applications/operationalStudies/types.ts
+++ b/front/src/applications/operationalStudies/types.ts
@@ -6,6 +6,7 @@ import type {
   PathProperties,
   PathfindingResultSuccess,
   SimulationResponse,
+  SimulationResponseSuccess,
   TrainSchedule,
   MacroNodeForm,
   RollingStockWithLiveries,
@@ -96,8 +97,6 @@ export type PathPropertiesFormatted = {
 };
 
 export type PowerRestriction = ArrayElement<TrainSchedule['power_restrictions']>;
-
-export type SimulationResponseSuccess = Extract<SimulationResponse, { status: 'success' }>;
 
 export type ElectrificationVoltage = {
   type: string;

--- a/front/src/applications/operationalStudies/utils.ts
+++ b/front/src/applications/operationalStudies/utils.ts
@@ -4,6 +4,7 @@ import type { Dictionary } from 'lodash';
 import type {
   PathfindingResultSuccess,
   PathProperties,
+  SimulationResponseSuccess,
   SimulationSummaryResult,
   TrainSchedule,
 } from 'common/api/osrdEditoastApi';
@@ -24,7 +25,6 @@ import type {
   ElectrificationValue,
   PathPropertiesFormatted,
   PositionData,
-  SimulationResponseSuccess,
 } from './types';
 
 /**

--- a/front/src/applications/stdcm/types.ts
+++ b/front/src/applications/stdcm/types.ts
@@ -6,7 +6,6 @@ import type {
   PathfindingResultSuccess,
   PostTimetableByIdStdcmApiResponse,
   RollingStockWithLiveries,
-  SimulationResponse,
   TowedRollingStock,
   PathProperties,
   LoadingGaugeType,
@@ -23,11 +22,10 @@ import type { ValueOf } from 'utils/types';
 
 export type StdcmRequestStatus = ValueOf<typeof STDCM_REQUEST_STATUS>;
 
-export type StdcmSuccessResponse = Omit<
-  Extract<PostTimetableByIdStdcmApiResponse, { status: 'success' }>,
-  'simulation'
+export type StdcmSuccessResponse = Extract<
+  PostTimetableByIdStdcmApiResponse,
+  { status: 'success' }
 > & {
-  simulation: Extract<SimulationResponse, { status: 'success' }>;
   rollingStock: LightRollingStock;
   creationDate: Date;
   speedLimitByTag?: string;

--- a/front/src/applications/stdcm/utils/formatSimulationReportSheet.ts
+++ b/front/src/applications/stdcm/utils/formatSimulationReportSheet.ts
@@ -1,4 +1,4 @@
-import type { SimulationResponse } from 'common/api/osrdEditoastApi';
+import type { SimulationResponseSuccess } from 'common/api/osrdEditoastApi';
 import { matchPathStepAndOp } from 'modules/pathfinding/utils';
 import { interpolateValue } from 'modules/simulationResult/SimulationResultExport/utils';
 import type { SuggestedOP } from 'modules/trainschedule/components/ManageTrainSchedule/types';
@@ -270,7 +270,7 @@ export function consolidateOvertakesToSingleSteps(
  */
 export function getOperationalPointsWithTimes(
   operationalPoints: SuggestedOP[],
-  simulation: Extract<SimulationResponse, { status: 'success' }>,
+  simulation: SimulationResponseSuccess,
   simulationPathSteps: StdcmPathStep[],
   departureTime: Date
 ): StdcmResultsOperationalPoint[] {

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -2098,7 +2098,7 @@ export type PostTimetableByIdStdcmApiResponse = /** status 201 The simulation re
   | {
       departure_time: string;
       path: PathfindingResultSuccess;
-      simulation: SimulationResponse;
+      simulation: SimulationResponseSuccess;
       status: 'success';
     }
   | {
@@ -3635,60 +3635,62 @@ export type ZoneUpdate = {
   time: number;
   zone: string;
 };
+export type SimulationResponseSuccess = {
+  base: ReportTrain;
+  electrical_profiles: {
+    /** List of `n` boundaries of the ranges (block path).
+        A boundary is a distance from the beginning of the path in mm. */
+    boundaries: number[];
+    /** List of `n+1` values associated to the ranges */
+    values: (
+      | {
+          electrical_profile_type: 'no_profile';
+        }
+      | {
+          electrical_profile_type: 'profile';
+          handled: boolean;
+          profile?: string | null;
+        }
+    )[];
+  };
+  final_output: ReportTrain & {
+    routing_requirements: RoutingRequirement[];
+    signal_critical_positions: SignalCriticalPosition[];
+    spacing_requirements: SpacingRequirement[];
+    zone_updates: ZoneUpdate[];
+  };
+  /** A MRSP computation result (Most Restrictive Speed Profile) */
+  mrsp: {
+    /** List of `n` boundaries of the ranges (block path).
+        A boundary is a distance from the beginning of the path in mm. */
+    boundaries: number[];
+    /** List of `n+1` values associated to the ranges */
+    values: {
+      source?:
+        | (
+            | {
+                speed_limit_source_type: 'given_train_tag';
+                tag: string;
+              }
+            | {
+                speed_limit_source_type: 'fallback_tag';
+                tag: string;
+              }
+            | {
+                speed_limit_source_type: 'unknown_tag';
+              }
+          )
+        | null;
+      /** in meters per second */
+      speed: number;
+    }[];
+  };
+  provisional: ReportTrain;
+};
 export type SimulationResponse =
-  | {
-      base: ReportTrain;
-      electrical_profiles: {
-        /** List of `n` boundaries of the ranges (block path).
-        A boundary is a distance from the beginning of the path in mm. */
-        boundaries: number[];
-        /** List of `n+1` values associated to the ranges */
-        values: (
-          | {
-              electrical_profile_type: 'no_profile';
-            }
-          | {
-              electrical_profile_type: 'profile';
-              handled: boolean;
-              profile?: string | null;
-            }
-        )[];
-      };
-      final_output: ReportTrain & {
-        routing_requirements: RoutingRequirement[];
-        signal_critical_positions: SignalCriticalPosition[];
-        spacing_requirements: SpacingRequirement[];
-        zone_updates: ZoneUpdate[];
-      };
-      /** A MRSP computation result (Most Restrictive Speed Profile) */
-      mrsp: {
-        /** List of `n` boundaries of the ranges (block path).
-        A boundary is a distance from the beginning of the path in mm. */
-        boundaries: number[];
-        /** List of `n+1` values associated to the ranges */
-        values: {
-          source?:
-            | (
-                | {
-                    speed_limit_source_type: 'given_train_tag';
-                    tag: string;
-                  }
-                | {
-                    speed_limit_source_type: 'fallback_tag';
-                    tag: string;
-                  }
-                | {
-                    speed_limit_source_type: 'unknown_tag';
-                  }
-              )
-            | null;
-          /** in meters per second */
-          speed: number;
-        }[];
-      };
-      provisional: ReportTrain;
+  | (SimulationResponseSuccess & {
       status: 'success';
-    }
+    })
   | {
       pathfinding_failed: PathfindingFailure;
       status: 'pathfinding_failed';
@@ -4247,7 +4249,7 @@ export type StdcmResponse =
   | {
       departure_time: string;
       path: PathfindingResultSuccess;
-      simulation: SimulationResponse;
+      simulation: SimulationResponseSuccess;
       status: 'success';
     }
   | {

--- a/front/src/modules/simulationResult/SimulationResultExport/SimulationResultsExport.tsx
+++ b/front/src/modules/simulationResult/SimulationResultExport/SimulationResultsExport.tsx
@@ -6,11 +6,11 @@ import { useTranslation } from 'react-i18next';
 import type {
   OperationalPointWithTimeAndSpeed,
   PathPropertiesFormatted,
-  SimulationResponseSuccess,
 } from 'applications/operationalStudies/types';
 import type {
   PathfindingResultSuccess,
   RollingStockWithLiveries,
+  SimulationResponseSuccess,
 } from 'common/api/osrdEditoastApi';
 import type { Train } from 'reducers/osrdconf/types';
 

--- a/front/src/modules/simulationResult/SimulationResultExport/exportTrainCSV.ts
+++ b/front/src/modules/simulationResult/SimulationResultExport/exportTrainCSV.ts
@@ -1,9 +1,8 @@
 import type {
   ElectrificationRange,
   OperationalPointWithTimeAndSpeed,
-  SimulationResponseSuccess,
 } from 'applications/operationalStudies/types';
-import type { ReportTrain } from 'common/api/osrdEditoastApi';
+import type { ReportTrain, SimulationResponseSuccess } from 'common/api/osrdEditoastApi';
 import type { Train } from 'reducers/osrdconf/types';
 import type { PositionSpeedTime, SpeedRanges } from 'reducers/simulationResults/types';
 import { dateToHHMMSS } from 'utils/date';

--- a/front/src/modules/simulationResult/SimulationResultExport/types.ts
+++ b/front/src/modules/simulationResult/SimulationResultExport/types.ts
@@ -1,5 +1,7 @@
-import type { SimulationResponseSuccess } from 'applications/operationalStudies/types';
-import type { RollingStockWithLiveries } from 'common/api/osrdEditoastApi';
+import type {
+  RollingStockWithLiveries,
+  SimulationResponseSuccess,
+} from 'common/api/osrdEditoastApi';
 
 export type SimulationSheetData = {
   trainName?: string;

--- a/front/src/modules/simulationResult/SimulationResultExport/utils.ts
+++ b/front/src/modules/simulationResult/SimulationResultExport/utils.ts
@@ -3,9 +3,12 @@ import * as d3 from 'd3';
 import type {
   OperationalPointWithTimeAndSpeed,
   PathPropertiesFormatted,
-  SimulationResponseSuccess,
 } from 'applications/operationalStudies/types';
-import { type ReportTrain, type TrackSection } from 'common/api/osrdEditoastApi';
+import {
+  type ReportTrain,
+  type TrackSection,
+  type SimulationResponseSuccess,
+} from 'common/api/osrdEditoastApi';
 import { matchPathStepAndOp } from 'modules/pathfinding/utils';
 import type { Train } from 'reducers/osrdconf/types';
 import type { SpeedRanges } from 'reducers/simulationResults/types';

--- a/front/src/modules/simulationResult/components/SpeedSpaceChart/SpeedSpaceChartContainer.tsx
+++ b/front/src/modules/simulationResult/components/SpeedSpaceChart/SpeedSpaceChartContainer.tsx
@@ -9,11 +9,11 @@ import { useTranslation } from 'react-i18next';
 import { CgLoadbar } from 'react-icons/cg';
 import { Rnd } from 'react-rnd';
 
+import type { PathPropertiesFormatted } from 'applications/operationalStudies/types';
 import type {
+  RollingStockWithLiveries,
   SimulationResponseSuccess,
-  PathPropertiesFormatted,
-} from 'applications/operationalStudies/types';
-import type { RollingStockWithLiveries } from 'common/api/osrdEditoastApi';
+} from 'common/api/osrdEditoastApi';
 
 import { formatData } from './helpers';
 

--- a/front/src/modules/simulationResult/components/SpeedSpaceChart/__tests__/helpers.spec.ts
+++ b/front/src/modules/simulationResult/components/SpeedSpaceChart/__tests__/helpers.spec.ts
@@ -1,11 +1,8 @@
 import type { ElectrificationValues, LayerData } from '@osrd-project/ui-charts';
 import { describe, it, expect } from 'vitest';
 
-import type {
-  PathPropertiesFormatted,
-  PositionData,
-  SimulationResponseSuccess,
-} from 'applications/operationalStudies/types';
+import type { PathPropertiesFormatted, PositionData } from 'applications/operationalStudies/types';
+import type { SimulationResponseSuccess } from 'common/api/osrdEditoastApi';
 
 import {
   formatSpeeds,

--- a/front/src/modules/simulationResult/components/SpeedSpaceChart/helpers.ts
+++ b/front/src/modules/simulationResult/components/SpeedSpaceChart/helpers.ts
@@ -8,12 +8,8 @@ import type {
   SpeedLimitTagValues,
 } from '@osrd-project/ui-charts';
 
-import type {
-  PathPropertiesFormatted,
-  PositionData,
-  SimulationResponseSuccess,
-} from 'applications/operationalStudies/types';
-import type { ReportTrain } from 'common/api/osrdEditoastApi';
+import type { PathPropertiesFormatted, PositionData } from 'applications/operationalStudies/types';
+import type { ReportTrain, SimulationResponseSuccess } from 'common/api/osrdEditoastApi';
 import { TAG_COLORS } from 'modules/simulationResult/consts';
 import type { SpeedLimitTagValue } from 'modules/simulationResult/types';
 import { mmToKm, msToKmh, mToKm } from 'utils/physics';

--- a/front/src/modules/simulationResult/hooks/useFormattedOperationalPoints.ts
+++ b/front/src/modules/simulationResult/hooks/useFormattedOperationalPoints.ts
@@ -5,8 +5,8 @@ import { useScenarioContext } from 'applications/operationalStudies/hooks/useSce
 import type {
   OperationalPointWithTimeAndSpeed,
   PathPropertiesFormatted,
-  SimulationResponseSuccess,
 } from 'applications/operationalStudies/types';
+import type { SimulationResponseSuccess } from 'common/api/osrdEditoastApi';
 import type { Train } from 'reducers/osrdconf/types';
 
 import { formatOperationalPoints } from '../SimulationResultExport/utils';

--- a/front/src/modules/simulationResult/types.ts
+++ b/front/src/modules/simulationResult/types.ts
@@ -2,16 +2,14 @@ import type { Dispatch, SetStateAction } from 'react';
 
 import type { LayerData, PowerRestrictionValues } from '@osrd-project/ui-charts';
 
-import type {
-  PathPropertiesFormatted,
-  SimulationResponseSuccess,
-} from 'applications/operationalStudies/types';
+import type { PathPropertiesFormatted } from 'applications/operationalStudies/types';
 import type {
   PacedTrainException,
   OccupancyBlocks,
   PathProperties,
   PathfindingResultSuccess,
   RollingStockWithLiveries,
+  SimulationResponseSuccess,
   TrainSchedule,
 } from 'common/api/osrdEditoastApi';
 import type { PacedTrainWithDetails } from 'modules/trainschedule/components/Timetable/types';

--- a/front/src/modules/timesStops/TimesStopsOutput.tsx
+++ b/front/src/modules/timesStops/TimesStopsOutput.tsx
@@ -1,10 +1,10 @@
 import cx from 'classnames';
 
+import type { PathPropertiesFormatted } from 'applications/operationalStudies/types';
 import type {
-  PathPropertiesFormatted,
+  PathfindingResultSuccess,
   SimulationResponseSuccess,
-} from 'applications/operationalStudies/types';
-import type { PathfindingResultSuccess } from 'common/api/osrdEditoastApi';
+} from 'common/api/osrdEditoastApi';
 import type { TimetableItemWithDetails } from 'modules/trainschedule/components/Timetable/types';
 import type { Train } from 'reducers/osrdconf/types';
 import { NO_BREAK_SPACE } from 'utils/strings';

--- a/front/src/modules/timesStops/hooks/useOutputTableData.ts
+++ b/front/src/modules/timesStops/hooks/useOutputTableData.ts
@@ -4,11 +4,11 @@ import { keyBy } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
 import { useScenarioContext } from 'applications/operationalStudies/hooks/useScenarioContext';
+import type { PathPropertiesFormatted } from 'applications/operationalStudies/types';
 import type {
-  PathPropertiesFormatted,
+  PathfindingResultSuccess,
   SimulationResponseSuccess,
-} from 'applications/operationalStudies/types';
-import type { PathfindingResultSuccess } from 'common/api/osrdEditoastApi';
+} from 'common/api/osrdEditoastApi';
 import { interpolateValue } from 'modules/simulationResult/SimulationResultExport/utils';
 import type { TimetableItemWithDetails } from 'modules/trainschedule/components/Timetable/types';
 import type { Train } from 'reducers/osrdconf/types';


### PR DESCRIPTION
Close #11037 
The aim is to ensure that PostTimetableByIdStdcmApiResponse returns the Success variant in the simulation field in case of success.

As a variant cannot be treated as a type, editoast's SimulationResponse enum has been modified so that the fields of its Success variant are contained in a structure, called SimulationResponseSuccess. As a result, the simulation field of the Success variant of the StdcmResponse enum has been changed from SimulationResponse to SimulationResponseSuccess.