### PR TITLE
front: add trainrun category as label for nge import

### DIFF
--- a/front/src/applications/operationalStudies/components/MacroEditor/ngeToOsrd.ts
+++ b/front/src/applications/operationalStudies/components/MacroEditor/ngeToOsrd.ts
@@ -719,6 +719,8 @@ export const convertNgeDtoToOsrd = (dto: NetzgrafikDto) => {
   const pacedTrains: PacedTrain[] = [];
   for (const trainrun of dto.trainruns) {
     const { path, labels, startDate, schedule } = generateTrainrunProperties(dto, trainrun);
+    const category = dto.metadata.trainrunCategories.find((cat) => cat.id === trainrun.categoryId);
+    if (category) labels.push(category.name);
     const commonProps = {
       train_name: trainrun.name,
       labels,


### PR DESCRIPTION
Part of https://github.com/osrd-project/osrd-confidential/issues/1081

To test this PR, import any NGE file, like this one, in OSRD Operational Studies:
[reticulaire.json](https://github.com/user-attachments/files/20708713/reticulaire.json)

To go further, we could also try to catch the category and check if it matches with the exact same train categories already used in OSRD. If matched, we could directly set the right category, and not add a label for it.
I will be useful only for this case : exporting NGE file from OSRD/NGE and importing it in OSRD. Would it be interesting? Or overfit? Since we already have a more complexe import on OSRD side?
