### PR TITLE
front: fix NGE import error when a TrainrunSection is reversed

### DIFF
--- a/front/src/applications/operationalStudies/components/MacroEditor/__tests__/ngeToOsrd.spec.ts
+++ b/front/src/applications/operationalStudies/components/MacroEditor/__tests__/ngeToOsrd.spec.ts
@@ -1,0 +1,22 @@
+import { readFile } from 'node:fs/promises';
+
+import { describe, expect, test, vi } from 'vitest';
+
+import { convertNgeDtoToOsrd } from 'applications/operationalStudies/components/MacroEditor/ngeToOsrd';
+import type { NetzgrafikDto } from 'applications/operationalStudies/components/NGE/types';
+
+async function readJsonFile(path: string): Promise<unknown> {
+  return JSON.parse(await readFile(new URL(path, import.meta.url).pathname, 'utf-8'));
+}
+
+vi.setSystemTime(new Date('2025-06-25T13:00:00.000Z'));
+
+describe('convertNgeDtoToOsrd', () => {
+  test.each(['sharedSource', 'sharedTarget'])('outOfOrderSourceTarget-$0', async (name) => {
+    const dto = (await readJsonFile(`./outOfOrderSourceTarget-${name}-dto.json`)) as NetzgrafikDto;
+    const expected = await readJsonFile(`./outOfOrderSourceTarget-output.json`);
+    const result = convertNgeDtoToOsrd(dto);
+    // Go through JSON encoding to discard undefined fields
+    expect(JSON.parse(JSON.stringify(result))).toEqual(expected);
+  });
+});

--- a/front/src/applications/operationalStudies/components/MacroEditor/__tests__/outOfOrderSourceTarget-output.json
+++ b/front/src/applications/operationalStudies/components/MacroEditor/__tests__/outOfOrderSourceTarget-output.json
@@ -1,0 +1,67 @@
+{
+  "macro_nodes": [
+    {
+      "ngeId": 6,
+      "trigram": "SS",
+      "full_name": "Sursee",
+      "connection_time": 6,
+      "position_x": 672,
+      "position_y": 800,
+      "labels": [],
+      "path_item_key": "trigram:SS"
+    },
+    {
+      "ngeId": 7,
+      "trigram": "RTR",
+      "full_name": "Rothrist",
+      "connection_time": 5,
+      "position_x": 320,
+      "position_y": 32,
+      "labels": [],
+      "path_item_key": "trigram:RTR"
+    },
+    {
+      "ngeId": 8,
+      "trigram": "LTH",
+      "full_name": "Langenthal",
+      "connection_time": 5,
+      "position_x": 320,
+      "position_y": 192,
+      "labels": [],
+      "path_item_key": "trigram:LTH"
+    }
+  ],
+  "paced_trains": [
+    {
+      "constraint_distribution": "STANDARD",
+      "rolling_stock_name": "",
+      "exceptions": [],
+      "train_name": "Carotte",
+      "labels": ["InterCity"],
+      "path": [
+        { "trigram": "RTR", "id": "7-0", "deleted": false, "track_reference": null },
+        { "trigram": "LTH", "id": "8-1", "deleted": false, "track_reference": null },
+        { "trigram": "SS", "id": "6-2", "deleted": false, "track_reference": null }
+      ],
+      "start_time": "2025-06-25T13:00:00.000Z",
+      "schedule": [
+        {
+          "at": "8-1",
+          "arrival": "PT1M",
+          "stop_for": "PT2M",
+          "locked": false,
+          "reception_signal": "OPEN"
+        },
+        {
+          "at": "6-2",
+          "arrival": "PT4M",
+          "stop_for": null,
+          "locked": false,
+          "reception_signal": "OPEN"
+        }
+      ],
+      "paced": { "interval": "PT1H", "time_window": "PT2H" }
+    }
+  ],
+  "train_schedules": []
+}

--- a/front/src/applications/operationalStudies/components/MacroEditor/__tests__/outOfOrderSourceTarget-sharedSource-dto.json
+++ b/front/src/applications/operationalStudies/components/MacroEditor/__tests__/outOfOrderSourceTarget-sharedSource-dto.json
@@ -1,0 +1,414 @@
+{
+  "nodes": [
+    {
+      "id": 6,
+      "betriebspunktName": "SS",
+      "fullName": "Sursee",
+      "positionX": 672,
+      "positionY": 800,
+      "ports": [{ "id": 8, "trainrunSectionId": 4, "positionIndex": 0, "positionAlignment": 0 }],
+      "transitions": [],
+      "connections": [],
+      "resourceId": 7,
+      "perronkanten": 5,
+      "connectionTime": 6,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitIPV": { "haltezeit": 3, "no_halt": false },
+        "HaltezeitA": { "haltezeit": 2, "no_halt": false },
+        "HaltezeitB": { "haltezeit": 2, "no_halt": false },
+        "HaltezeitC": { "haltezeit": 1, "no_halt": false },
+        "HaltezeitD": { "haltezeit": 1, "no_halt": false },
+        "HaltezeitUncategorized": { "haltezeit": 0, "no_halt": true }
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 7,
+      "betriebspunktName": "RTR",
+      "fullName": "Rothrist",
+      "positionX": 320,
+      "positionY": 32,
+      "ports": [{ "id": 6, "trainrunSectionId": 3, "positionIndex": 0, "positionAlignment": 1 }],
+      "transitions": [],
+      "connections": [],
+      "resourceId": 8,
+      "perronkanten": 5,
+      "connectionTime": 5,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitIPV": { "haltezeit": 3, "no_halt": false },
+        "HaltezeitA": { "haltezeit": 2, "no_halt": false },
+        "HaltezeitB": { "haltezeit": 2, "no_halt": false },
+        "HaltezeitC": { "haltezeit": 1, "no_halt": false },
+        "HaltezeitD": { "haltezeit": 1, "no_halt": false },
+        "HaltezeitUncategorized": { "haltezeit": 0, "no_halt": true }
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 8,
+      "betriebspunktName": "LTH",
+      "fullName": "Langenthal",
+      "positionX": 320,
+      "positionY": 192,
+      "ports": [
+        { "id": 5, "trainrunSectionId": 3, "positionIndex": 0, "positionAlignment": 0 },
+        { "id": 7, "trainrunSectionId": 4, "positionIndex": 0, "positionAlignment": 1 }
+      ],
+      "transitions": [{ "id": 2, "port1Id": 5, "port2Id": 7, "isNonStopTransit": false }],
+      "connections": [],
+      "resourceId": 9,
+      "perronkanten": 5,
+      "connectionTime": 5,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitIPV": { "haltezeit": 3, "no_halt": false },
+        "HaltezeitA": { "haltezeit": 2, "no_halt": false },
+        "HaltezeitB": { "haltezeit": 2, "no_halt": false },
+        "HaltezeitC": { "haltezeit": 1, "no_halt": false },
+        "HaltezeitD": { "haltezeit": 1, "no_halt": false },
+        "HaltezeitUncategorized": { "haltezeit": 0, "no_halt": true }
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    }
+  ],
+  "trainrunSections": [
+    {
+      "id": 3,
+      "sourceNodeId": 8,
+      "sourcePortId": 5,
+      "targetNodeId": 7,
+      "targetPortId": 6,
+      "travelTime": {
+        "time": 1,
+        "consecutiveTime": 1,
+        "lock": true,
+        "warning": null,
+        "timeFormatter": null
+      },
+      "sourceDeparture": {
+        "time": 59,
+        "consecutiveTime": 59,
+        "lock": false,
+        "warning": null,
+        "timeFormatter": null
+      },
+      "sourceArrival": {
+        "time": 1,
+        "consecutiveTime": 1,
+        "lock": false,
+        "warning": null,
+        "timeFormatter": null
+      },
+      "targetDeparture": {
+        "time": 0,
+        "consecutiveTime": 0,
+        "lock": false,
+        "warning": null,
+        "timeFormatter": null
+      },
+      "targetArrival": {
+        "time": 0,
+        "consecutiveTime": 60,
+        "lock": false,
+        "warning": null,
+        "timeFormatter": null
+      },
+      "numberOfStops": 0,
+      "trainrunId": 2,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          { "x": 336, "y": 190 },
+          { "x": 336, "y": 126 },
+          { "x": 336, "y": 162 },
+          { "x": 336, "y": 98 }
+        ],
+        "textPositions": {
+          "0": { "x": 348, "y": 172 },
+          "1": { "x": 324, "y": 144 },
+          "2": { "x": 324, "y": 116 },
+          "3": { "x": 348, "y": 144 },
+          "4": { "x": 324, "y": 144 },
+          "5": { "x": 324, "y": 144 },
+          "6": { "x": 348, "y": 144 }
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 4,
+      "sourceNodeId": 8,
+      "sourcePortId": 7,
+      "targetNodeId": 6,
+      "targetPortId": 8,
+      "travelTime": {
+        "time": 1,
+        "consecutiveTime": 1,
+        "lock": true,
+        "warning": null,
+        "timeFormatter": null
+      },
+      "sourceDeparture": {
+        "time": 3,
+        "consecutiveTime": 3,
+        "lock": false,
+        "warning": null,
+        "timeFormatter": null
+      },
+      "sourceArrival": {
+        "time": 57,
+        "consecutiveTime": 57,
+        "lock": false,
+        "warning": null,
+        "timeFormatter": null
+      },
+      "targetDeparture": {
+        "time": 56,
+        "consecutiveTime": 56,
+        "lock": false,
+        "warning": null,
+        "timeFormatter": null
+      },
+      "targetArrival": {
+        "time": 4,
+        "consecutiveTime": 4,
+        "lock": false,
+        "warning": null,
+        "timeFormatter": null
+      },
+      "numberOfStops": 0,
+      "trainrunId": 2,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          { "x": 336, "y": 258 },
+          { "x": 336, "y": 322 },
+          { "x": 688, "y": 734 },
+          { "x": 688, "y": 798 }
+        ],
+        "textPositions": {
+          "0": { "x": 324, "y": 276 },
+          "1": { "x": 348, "y": 304 },
+          "2": { "x": 700, "y": 780 },
+          "3": { "x": 676, "y": 752 },
+          "4": { "x": 524, "y": 528 },
+          "5": { "x": 524, "y": 528 },
+          "6": { "x": 500, "y": 528 }
+        }
+      },
+      "warnings": null
+    }
+  ],
+  "trainruns": [
+    {
+      "id": 2,
+      "name": "Carotte",
+      "categoryId": 1,
+      "frequencyId": 3,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": []
+    }
+  ],
+  "resources": [
+    { "id": 1, "capacity": 2 },
+    { "id": 2, "capacity": 2 },
+    { "id": 3, "capacity": 2 },
+    { "id": 4, "capacity": 2 },
+    { "id": 5, "capacity": 2 },
+    { "id": 6, "capacity": 2 },
+    { "id": 7, "capacity": 2 },
+    { "id": 8, "capacity": 2 },
+    { "id": 9, "capacity": 2 },
+    { "id": 10, "capacity": 2 },
+    { "id": 11, "capacity": 2 }
+  ],
+  "metadata": {
+    "analyticsSettings": { "originDestinationSettings": { "connectionPenalty": 5 } },
+    "trainrunCategories": [
+      {
+        "id": 0,
+        "order": 0,
+        "shortName": "EC",
+        "name": "International",
+        "colorRef": "EC",
+        "fachCategory": "HaltezeitIPV",
+        "minimalTurnaroundTime": 4,
+        "nodeHeadwayStop": 2,
+        "nodeHeadwayNonStop": 2,
+        "sectionHeadway": 2
+      },
+      {
+        "id": 1,
+        "order": 1,
+        "shortName": "IC",
+        "name": "InterCity",
+        "colorRef": "IC",
+        "fachCategory": "HaltezeitA",
+        "minimalTurnaroundTime": 4,
+        "nodeHeadwayStop": 2,
+        "nodeHeadwayNonStop": 2,
+        "sectionHeadway": 2
+      },
+      {
+        "id": 2,
+        "order": 2,
+        "shortName": "IR",
+        "name": "InterRegio",
+        "colorRef": "IR",
+        "fachCategory": "HaltezeitB",
+        "minimalTurnaroundTime": 4,
+        "nodeHeadwayStop": 2,
+        "nodeHeadwayNonStop": 2,
+        "sectionHeadway": 2
+      },
+      {
+        "id": 3,
+        "order": 3,
+        "shortName": "RE",
+        "name": "RegioExpress",
+        "colorRef": "RE",
+        "fachCategory": "HaltezeitC",
+        "minimalTurnaroundTime": 4,
+        "nodeHeadwayStop": 2,
+        "nodeHeadwayNonStop": 2,
+        "sectionHeadway": 2
+      },
+      {
+        "id": 4,
+        "order": 4,
+        "shortName": "S",
+        "name": "RegioUndSBahnverkehr",
+        "colorRef": "S",
+        "fachCategory": "HaltezeitD",
+        "minimalTurnaroundTime": 4,
+        "nodeHeadwayStop": 2,
+        "nodeHeadwayNonStop": 2,
+        "sectionHeadway": 2
+      },
+      {
+        "id": 5,
+        "order": 5,
+        "shortName": "GEX",
+        "name": "GüterExpress",
+        "colorRef": "GEX",
+        "fachCategory": "HaltezeitUncategorized",
+        "minimalTurnaroundTime": 4,
+        "nodeHeadwayStop": 3,
+        "nodeHeadwayNonStop": 3,
+        "sectionHeadway": 3
+      },
+      {
+        "id": 6,
+        "order": 6,
+        "shortName": "G",
+        "name": "Güterverkehr",
+        "colorRef": "G",
+        "fachCategory": "HaltezeitUncategorized",
+        "minimalTurnaroundTime": 4,
+        "nodeHeadwayStop": 3,
+        "nodeHeadwayNonStop": 3,
+        "sectionHeadway": 3
+      }
+    ],
+    "trainrunFrequencies": [
+      {
+        "id": 0,
+        "order": 0,
+        "frequency": 15,
+        "offset": 0,
+        "shortName": "15",
+        "name": "verkehrt viertelstündlich",
+        "linePatternRef": "15"
+      },
+      {
+        "id": 1,
+        "order": 0,
+        "frequency": 20,
+        "offset": 0,
+        "shortName": "20",
+        "name": "verkehrt im 20 Minuten Takt",
+        "linePatternRef": "20"
+      },
+      {
+        "id": 2,
+        "order": 0,
+        "frequency": 30,
+        "offset": 0,
+        "shortName": "30",
+        "name": "verkehrt halbstündlich",
+        "linePatternRef": "30"
+      },
+      {
+        "id": 3,
+        "order": 0,
+        "frequency": 60,
+        "offset": 0,
+        "shortName": "60",
+        "name": "verkehrt stündlich",
+        "linePatternRef": "60"
+      },
+      {
+        "id": 4,
+        "order": 0,
+        "frequency": 120,
+        "offset": 0,
+        "shortName": "120",
+        "name": "verkehrt zweistündlich (gerade)",
+        "linePatternRef": "120"
+      },
+      {
+        "id": 5,
+        "order": 0,
+        "frequency": 120,
+        "offset": 60,
+        "shortName": "120+",
+        "name": "verkehrt zweistündlich (ungerade)",
+        "linePatternRef": "120"
+      }
+    ],
+    "trainrunTimeCategories": [
+      {
+        "id": 0,
+        "order": 0,
+        "shortName": "7/24",
+        "name": "verkehrt uneingeschränkt",
+        "dayTimeInterval": [],
+        "weekday": [1, 2, 3, 4, 5, 6, 7],
+        "linePatternRef": "7/24"
+      },
+      {
+        "id": 1,
+        "order": 0,
+        "shortName": "HVZ",
+        "name": "verkehrt zur Hauptverkehrszeit",
+        "dayTimeInterval": [
+          { "from": 360, "to": 420 },
+          { "from": 960, "to": 1140 }
+        ],
+        "weekday": [1, 2, 3, 4, 5, 6, 7],
+        "linePatternRef": "HVZ"
+      },
+      {
+        "id": 2,
+        "order": 0,
+        "shortName": "zeitweise",
+        "name": "verkehrt zeitweise",
+        "dayTimeInterval": [],
+        "weekday": [],
+        "linePatternRef": "ZEITWEISE"
+      }
+    ],
+    "netzgrafikColors": []
+  },
+  "freeFloatingTexts": [],
+  "labels": [],
+  "labelGroups": [],
+  "filterData": { "filterSettings": [] }
+}

--- a/front/src/applications/operationalStudies/components/MacroEditor/__tests__/outOfOrderSourceTarget-sharedTarget-dto.json
+++ b/front/src/applications/operationalStudies/components/MacroEditor/__tests__/outOfOrderSourceTarget-sharedTarget-dto.json
@@ -1,0 +1,414 @@
+{
+  "nodes": [
+    {
+      "id": 6,
+      "betriebspunktName": "SS",
+      "fullName": "Sursee",
+      "positionX": 672,
+      "positionY": 800,
+      "ports": [{ "id": 3, "trainrunSectionId": 2, "positionIndex": 0, "positionAlignment": 0 }],
+      "transitions": [],
+      "connections": [],
+      "resourceId": 7,
+      "perronkanten": 5,
+      "connectionTime": 6,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitIPV": { "haltezeit": 3, "no_halt": false },
+        "HaltezeitA": { "haltezeit": 2, "no_halt": false },
+        "HaltezeitB": { "haltezeit": 2, "no_halt": false },
+        "HaltezeitC": { "haltezeit": 1, "no_halt": false },
+        "HaltezeitD": { "haltezeit": 1, "no_halt": false },
+        "HaltezeitUncategorized": { "haltezeit": 0, "no_halt": true }
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 7,
+      "betriebspunktName": "RTR",
+      "fullName": "Rothrist",
+      "positionX": 320,
+      "positionY": 32,
+      "ports": [{ "id": 1, "trainrunSectionId": 1, "positionIndex": 0, "positionAlignment": 1 }],
+      "transitions": [],
+      "connections": [],
+      "resourceId": 8,
+      "perronkanten": 5,
+      "connectionTime": 5,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitIPV": { "haltezeit": 3, "no_halt": false },
+        "HaltezeitA": { "haltezeit": 2, "no_halt": false },
+        "HaltezeitB": { "haltezeit": 2, "no_halt": false },
+        "HaltezeitC": { "haltezeit": 1, "no_halt": false },
+        "HaltezeitD": { "haltezeit": 1, "no_halt": false },
+        "HaltezeitUncategorized": { "haltezeit": 0, "no_halt": true }
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 8,
+      "betriebspunktName": "LTH",
+      "fullName": "Langenthal",
+      "positionX": 320,
+      "positionY": 192,
+      "ports": [
+        { "id": 2, "trainrunSectionId": 1, "positionIndex": 0, "positionAlignment": 0 },
+        { "id": 4, "trainrunSectionId": 2, "positionIndex": 0, "positionAlignment": 1 }
+      ],
+      "transitions": [{ "id": 1, "port1Id": 2, "port2Id": 4, "isNonStopTransit": false }],
+      "connections": [],
+      "resourceId": 9,
+      "perronkanten": 5,
+      "connectionTime": 5,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitIPV": { "haltezeit": 3, "no_halt": false },
+        "HaltezeitA": { "haltezeit": 2, "no_halt": false },
+        "HaltezeitB": { "haltezeit": 2, "no_halt": false },
+        "HaltezeitC": { "haltezeit": 1, "no_halt": false },
+        "HaltezeitD": { "haltezeit": 1, "no_halt": false },
+        "HaltezeitUncategorized": { "haltezeit": 0, "no_halt": true }
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    }
+  ],
+  "trainrunSections": [
+    {
+      "id": 1,
+      "sourceNodeId": 7,
+      "sourcePortId": 1,
+      "targetNodeId": 8,
+      "targetPortId": 2,
+      "travelTime": {
+        "time": 1,
+        "consecutiveTime": 1,
+        "lock": true,
+        "warning": null,
+        "timeFormatter": null
+      },
+      "sourceDeparture": {
+        "time": 0,
+        "consecutiveTime": 0,
+        "lock": false,
+        "warning": null,
+        "timeFormatter": null
+      },
+      "sourceArrival": {
+        "time": 0,
+        "consecutiveTime": 60,
+        "lock": false,
+        "warning": null,
+        "timeFormatter": null
+      },
+      "targetDeparture": {
+        "time": 59,
+        "consecutiveTime": 59,
+        "lock": false,
+        "warning": null,
+        "timeFormatter": null
+      },
+      "targetArrival": {
+        "time": 1,
+        "consecutiveTime": 1,
+        "lock": false,
+        "warning": null,
+        "timeFormatter": null
+      },
+      "numberOfStops": 0,
+      "trainrunId": 1,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          { "x": 336, "y": 98 },
+          { "x": 336, "y": 162 },
+          { "x": 336, "y": 126 },
+          { "x": 336, "y": 190 }
+        ],
+        "textPositions": {
+          "0": { "x": 324, "y": 116 },
+          "1": { "x": 348, "y": 144 },
+          "2": { "x": 348, "y": 172 },
+          "3": { "x": 324, "y": 144 },
+          "4": { "x": 324, "y": 144 },
+          "5": { "x": 324, "y": 144 },
+          "6": { "x": 348, "y": 144 }
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 2,
+      "sourceNodeId": 6,
+      "sourcePortId": 3,
+      "targetNodeId": 8,
+      "targetPortId": 4,
+      "travelTime": {
+        "time": 1,
+        "consecutiveTime": 1,
+        "lock": true,
+        "warning": null,
+        "timeFormatter": null
+      },
+      "sourceDeparture": {
+        "time": 56,
+        "consecutiveTime": 56,
+        "lock": false,
+        "warning": null,
+        "timeFormatter": null
+      },
+      "sourceArrival": {
+        "time": 4,
+        "consecutiveTime": 4,
+        "lock": false,
+        "warning": null,
+        "timeFormatter": null
+      },
+      "targetDeparture": {
+        "time": 3,
+        "consecutiveTime": 3,
+        "lock": false,
+        "warning": null,
+        "timeFormatter": null
+      },
+      "targetArrival": {
+        "time": 57,
+        "consecutiveTime": 57,
+        "lock": false,
+        "warning": null,
+        "timeFormatter": null
+      },
+      "numberOfStops": 0,
+      "trainrunId": 1,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          { "x": 688, "y": 798 },
+          { "x": 688, "y": 734 },
+          { "x": 336, "y": 322 },
+          { "x": 336, "y": 258 }
+        ],
+        "textPositions": {
+          "0": { "x": 700, "y": 780 },
+          "1": { "x": 676, "y": 752 },
+          "2": { "x": 324, "y": 276 },
+          "3": { "x": 348, "y": 304 },
+          "4": { "x": 524, "y": 528 },
+          "5": { "x": 524, "y": 528 },
+          "6": { "x": 500, "y": 528 }
+        }
+      },
+      "warnings": null
+    }
+  ],
+  "trainruns": [
+    {
+      "id": 1,
+      "name": "Carotte",
+      "categoryId": 1,
+      "frequencyId": 3,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": []
+    }
+  ],
+  "resources": [
+    { "id": 1, "capacity": 2 },
+    { "id": 2, "capacity": 2 },
+    { "id": 3, "capacity": 2 },
+    { "id": 4, "capacity": 2 },
+    { "id": 5, "capacity": 2 },
+    { "id": 6, "capacity": 2 },
+    { "id": 7, "capacity": 2 },
+    { "id": 8, "capacity": 2 },
+    { "id": 9, "capacity": 2 },
+    { "id": 10, "capacity": 2 },
+    { "id": 11, "capacity": 2 }
+  ],
+  "metadata": {
+    "analyticsSettings": { "originDestinationSettings": { "connectionPenalty": 5 } },
+    "trainrunCategories": [
+      {
+        "id": 0,
+        "order": 0,
+        "shortName": "EC",
+        "name": "International",
+        "colorRef": "EC",
+        "fachCategory": "HaltezeitIPV",
+        "minimalTurnaroundTime": 4,
+        "nodeHeadwayStop": 2,
+        "nodeHeadwayNonStop": 2,
+        "sectionHeadway": 2
+      },
+      {
+        "id": 1,
+        "order": 1,
+        "shortName": "IC",
+        "name": "InterCity",
+        "colorRef": "IC",
+        "fachCategory": "HaltezeitA",
+        "minimalTurnaroundTime": 4,
+        "nodeHeadwayStop": 2,
+        "nodeHeadwayNonStop": 2,
+        "sectionHeadway": 2
+      },
+      {
+        "id": 2,
+        "order": 2,
+        "shortName": "IR",
+        "name": "InterRegio",
+        "colorRef": "IR",
+        "fachCategory": "HaltezeitB",
+        "minimalTurnaroundTime": 4,
+        "nodeHeadwayStop": 2,
+        "nodeHeadwayNonStop": 2,
+        "sectionHeadway": 2
+      },
+      {
+        "id": 3,
+        "order": 3,
+        "shortName": "RE",
+        "name": "RegioExpress",
+        "colorRef": "RE",
+        "fachCategory": "HaltezeitC",
+        "minimalTurnaroundTime": 4,
+        "nodeHeadwayStop": 2,
+        "nodeHeadwayNonStop": 2,
+        "sectionHeadway": 2
+      },
+      {
+        "id": 4,
+        "order": 4,
+        "shortName": "S",
+        "name": "RegioUndSBahnverkehr",
+        "colorRef": "S",
+        "fachCategory": "HaltezeitD",
+        "minimalTurnaroundTime": 4,
+        "nodeHeadwayStop": 2,
+        "nodeHeadwayNonStop": 2,
+        "sectionHeadway": 2
+      },
+      {
+        "id": 5,
+        "order": 5,
+        "shortName": "GEX",
+        "name": "GüterExpress",
+        "colorRef": "GEX",
+        "fachCategory": "HaltezeitUncategorized",
+        "minimalTurnaroundTime": 4,
+        "nodeHeadwayStop": 3,
+        "nodeHeadwayNonStop": 3,
+        "sectionHeadway": 3
+      },
+      {
+        "id": 6,
+        "order": 6,
+        "shortName": "G",
+        "name": "Güterverkehr",
+        "colorRef": "G",
+        "fachCategory": "HaltezeitUncategorized",
+        "minimalTurnaroundTime": 4,
+        "nodeHeadwayStop": 3,
+        "nodeHeadwayNonStop": 3,
+        "sectionHeadway": 3
+      }
+    ],
+    "trainrunFrequencies": [
+      {
+        "id": 0,
+        "order": 0,
+        "frequency": 15,
+        "offset": 0,
+        "shortName": "15",
+        "name": "verkehrt viertelstündlich",
+        "linePatternRef": "15"
+      },
+      {
+        "id": 1,
+        "order": 0,
+        "frequency": 20,
+        "offset": 0,
+        "shortName": "20",
+        "name": "verkehrt im 20 Minuten Takt",
+        "linePatternRef": "20"
+      },
+      {
+        "id": 2,
+        "order": 0,
+        "frequency": 30,
+        "offset": 0,
+        "shortName": "30",
+        "name": "verkehrt halbstündlich",
+        "linePatternRef": "30"
+      },
+      {
+        "id": 3,
+        "order": 0,
+        "frequency": 60,
+        "offset": 0,
+        "shortName": "60",
+        "name": "verkehrt stündlich",
+        "linePatternRef": "60"
+      },
+      {
+        "id": 4,
+        "order": 0,
+        "frequency": 120,
+        "offset": 0,
+        "shortName": "120",
+        "name": "verkehrt zweistündlich (gerade)",
+        "linePatternRef": "120"
+      },
+      {
+        "id": 5,
+        "order": 0,
+        "frequency": 120,
+        "offset": 60,
+        "shortName": "120+",
+        "name": "verkehrt zweistündlich (ungerade)",
+        "linePatternRef": "120"
+      }
+    ],
+    "trainrunTimeCategories": [
+      {
+        "id": 0,
+        "order": 0,
+        "shortName": "7/24",
+        "name": "verkehrt uneingeschränkt",
+        "dayTimeInterval": [],
+        "weekday": [1, 2, 3, 4, 5, 6, 7],
+        "linePatternRef": "7/24"
+      },
+      {
+        "id": 1,
+        "order": 0,
+        "shortName": "HVZ",
+        "name": "verkehrt zur Hauptverkehrszeit",
+        "dayTimeInterval": [
+          { "from": 360, "to": 420 },
+          { "from": 960, "to": 1140 }
+        ],
+        "weekday": [1, 2, 3, 4, 5, 6, 7],
+        "linePatternRef": "HVZ"
+      },
+      {
+        "id": 2,
+        "order": 0,
+        "shortName": "zeitweise",
+        "name": "verkehrt zeitweise",
+        "dayTimeInterval": [],
+        "weekday": [],
+        "linePatternRef": "ZEITWEISE"
+      }
+    ],
+    "netzgrafikColors": []
+  },
+  "freeFloatingTexts": [],
+  "labels": [],
+  "labelGroups": [],
+  "filterData": { "filterSettings": [] }
+}

--- a/front/src/applications/operationalStudies/components/MacroEditor/ngeToOsrd.ts
+++ b/front/src/applications/operationalStudies/components/MacroEditor/ngeToOsrd.ts
@@ -55,6 +55,14 @@ import type {
 const getNodeById = (nodes: NodeDto[], nodeId: number | string) =>
   nodes.find((node) => node.id === nodeId);
 
+const findConnectedPortId = (node: NodeDto, portId: number) => {
+  const transition = node.transitions.find((tr) => tr.port1Id === portId || tr.port2Id === portId);
+  if (!transition) {
+    return null;
+  }
+  return transition.port1Id === portId ? transition.port2Id : transition.port1Id;
+};
+
 const getTrainrunSectionsByTrainrunId = (netzgrafikDto: NetzgrafikDto, trainrunId: number) => {
   // The sections we obtain here may be out-of-order. For instance, for a path
   // A → B → C, we may get two sections B → C and then A → B. We need to
@@ -74,58 +82,111 @@ const getTrainrunSectionsByTrainrunId = (netzgrafikDto: NetzgrafikDto, trainrunI
   //                 │                      │
   //                 └──────────────────────┘
   //
+  // Two subsequent sections can be linked together at a node by connecting
+  // each section's source or target to a transition via a port. Example:
   //
-  // Two subsequent sections can be linked together at a node with a target
-  // port followed by a transition itself followed by a source port.
+  //     const node = { id: 10, transitions: [{ port1Id: 30, port2Id: 31 }], … };
+  //     const leftSection = { id: 20, targetNodeId: 10, targetPortId: 30, … };
+  //     const rightSection = { id: 21, sourceNodeId: 10, sourcePortId: 31, … };
   //
-  // Build a map of sections keyed by their previous section's target port ID.
-  // Find the departure section: it's the one without a transition for its
-  // source port.
-  let departureSection: TrainrunSectionDto | undefined;
-  const sectionsByPrevTargetPortId = new Map<number, TrainrunSectionDto>();
+  // Note, there is no guarantee that a train run will be made up of stricly
+  // ordered source → target chains. Source and target are arbitrary names for
+  // a section's ends. For instance, two sections' sources might point to the
+  // same node:
+  //
+  //     const node = { id: 10, transitions: [{ port1Id: 30, port2Id: 31 }], … };
+  //     const leftSection = { id: 20, sourceNodeId: 10, sourcePortId: 30, … };
+  //     const rightSection = { id: 21, sourceNodeId: 10, sourcePortId: 31, … };
+  //
+  // Build a map of sections keyed by the outgoing port ID they are connected
+  // to. Find the leaf (departure/arrival) sections: these are the ones without
+  // a transition for their source or target port.
+  const sectionsByConnectedPortId = new Map<number, TrainrunSectionDto>();
+  const leafSectionsAndNodes: [TrainrunSectionDto, number][] = [];
   for (const section of sections) {
     const sourceNode = getNodeById(netzgrafikDto.nodes, section.sourceNodeId)!;
-    const transition = sourceNode.transitions.find(
-      (tr) => tr.port1Id === section.sourcePortId || tr.port2Id === section.sourcePortId
-    );
-    if (transition) {
-      const prevPortId =
-        transition.port1Id === section.sourcePortId ? transition.port2Id : transition.port1Id;
-      sectionsByPrevTargetPortId.set(prevPortId, section);
+    const targetNode = getNodeById(netzgrafikDto.nodes, section.targetNodeId)!;
+
+    const sourceConnectedPortId = findConnectedPortId(sourceNode, section.sourcePortId);
+    const targetConnectedPortId = findConnectedPortId(targetNode, section.targetPortId);
+
+    if (sourceConnectedPortId !== null) {
+      sectionsByConnectedPortId.set(sourceConnectedPortId, section);
     } else {
-      departureSection = section;
+      leafSectionsAndNodes.push([section, section.sourceNodeId]);
+    }
+    if (targetConnectedPortId !== null) {
+      sectionsByConnectedPortId.set(targetConnectedPortId, section);
+    } else {
+      leafSectionsAndNodes.push([section, section.targetNodeId]);
     }
   }
-  if (!departureSection) {
-    throw new Error('Trainrun is missing departure section');
-  }
 
-  // Start with the departure section and iterate over the path
-  const orderedSections = [departureSection];
-  const seenSectionIds = new Set<number>([departureSection.id]);
-  let section: TrainrunSectionDto | undefined = departureSection;
-  for (;;) {
-    section = sectionsByPrevTargetPortId.get(section.targetPortId);
-    if (!section) {
-      break;
+  // Start with a leaf node and walk over the path. Ignore any leaf node we've
+  // already seen (because we've reached it at the end of a previous walk).
+  const seenSectionIds = new Set<number>();
+  const orderedSectionPaths = [];
+  for (const [startSection, startNodeId] of leafSectionsAndNodes) {
+    if (seenSectionIds.has(startSection.id)) {
+      continue;
     }
 
-    orderedSections.push(section);
+    let section: TrainrunSectionDto | undefined = startSection;
+    let nodeId = startNodeId;
+    const orderedSections = [];
+    while (section) {
+      // Make sure we don't enter an infinite loop
+      if (seenSectionIds.has(section.id)) {
+        throw new Error('Cycle detected in trainrun');
+      }
+      seenSectionIds.add(section.id);
 
-    // Make sure we don't enter an infinite loop
-    if (seenSectionIds.has(section.id)) {
-      throw new Error('Cycle detected in trainrun');
+      if (section.sourceNodeId === nodeId) {
+        orderedSections.push(section);
+        nodeId = section.targetNodeId;
+        section = sectionsByConnectedPortId.get(section.targetPortId);
+      } else if (section.targetNodeId === nodeId) {
+        // Swap source and target, so that the rest of the conversion logic
+        // can assume sections are always ordered from source to target
+        orderedSections.push({
+          ...section,
+          sourceNodeId: section.targetNodeId,
+          targetNodeId: section.sourceNodeId,
+          sourcePortId: section.targetPortId,
+          targetPortId: section.sourcePortId,
+          sourceDeparture: section.targetDeparture,
+          targetDeparture: section.sourceDeparture,
+          sourceArrival: section.targetArrival,
+          targetArrival: section.sourceArrival,
+        });
+        nodeId = section.sourceNodeId;
+        section = sectionsByConnectedPortId.get(section.sourcePortId);
+      } else {
+        // Unreachable: the previous section's end node should be either this
+        // node's source or target
+        throw new Error('Section is disconnected from previous section');
+      }
     }
-    seenSectionIds.add(section.id);
+
+    orderedSectionPaths.push(orderedSections);
   }
 
-  // If we haven't seen all sections belonging to the trainrun, it's because
-  // it's made up of multiple separate parts
-  if (orderedSections.length !== sections.length) {
+  // We should've seen all of the train run's sections by now
+  if (seenSectionIds.size !== sections.length) {
+    throw new Error('Trainrun graph search failed to find all sections');
+  }
+
+  if (orderedSectionPaths.length === 0) {
+    throw new Error('Trainrun has no path');
+  }
+
+  // TODO: some train runs are made up of multiple parts. We should create one
+  // train schedule per part.
+  if (orderedSectionPaths.length > 1) {
     throw new Error('Trainrun is not continuous');
   }
 
-  return orderedSections;
+  return orderedSectionPaths[0];
 };
 
 const createPathItemFromNode = (node: NodeDto, index: number) => {


### PR DESCRIPTION
NGE doesn't guarantee that trainrun sections will always follow the

    [source → target] [source → target] …

order. The following are valid NGE trainruns:

    [source → target] [target → source]
    [target → source] [target → source]
    [target → source] [source → target]

Introduce a more robust graph search algorithm which accommodates for these cases and is closer to NGE's TrainrunIterator, by tracking the current node in addition to the current section.

To test:

- Open https://nge.flatland.cloud/
- Create a train run from LTH to ZF
- Extend the train run by clicking from ZG to ZF (*not* from ZF to ZG)
- Export as JSON (result:  [networkGraphic.json](https://github.com/user-attachments/files/20779478networkGraphic.1.json))
- Import into OSRD (failed before, should work now)