### PR TITLE
core: stdcm: fix error when result has duplicate blocks

### DIFF
--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/Extensions.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/Extensions.kt
@@ -13,3 +13,16 @@ fun <T> List<DirStaticIdx<T>>.toIdxList(): DirStaticIdxList<T> {
     res.addAll(this)
     return res
 }
+
+/** Removes consecutive duplicated values from a list. Keeps duplicates that aren't consecutive. */
+fun <T> List<T>.withoutConsecutiveDuplicates(): List<T> {
+    val res = mutableListOf<T>()
+    var last: T? = null
+    for (x in this) {
+        if (last != x) {
+            res.add(x)
+            last = x
+        }
+    }
+    return res
+}

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMUtils.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMUtils.kt
@@ -8,6 +8,7 @@ import fr.sncf.osrd.utils.indexing.MutableDirStaticIdxArrayList
 import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
+import fr.sncf.osrd.utils.withoutConsecutiveDuplicates
 
 /** Returns the offset of the next stop (if any) on the current block, starting at startOffset */
 fun getNextStopOnCurrentBlock(
@@ -24,7 +25,7 @@ fun getNextStopOnCurrentBlock(
 
 /** Create a TrainPath instance from a list of edge ranges */
 fun makeChunkPathFromEdges(graph: STDCMGraph, edges: List<STDCMEdge>): ChunkPath {
-    val blocks = edges.stream().map { edge -> edge.block }.distinct().toList()
+    val blocks = edges.map { edge -> edge.block }.withoutConsecutiveDuplicates()
     val totalPathLength =
         Length<TravelledPath>(
             Distance(


### PR DESCRIPTION
We'd filter duplicates even when they're far apart, which results in an invalid path (holes in the path during post-process, resulting in an unclear 500 error).
We want to keep filtering consecutive duplicates as they only indicate that a stop happened in the block.

Follow-up on https://github.com/OpenRailAssociation/osrd/pull/11632 that triggered the behavior.