### PR TITLE
front: fix start time exception reset when editing a paced train.

### DIFF
--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/helpers/buildPacedTrainException.ts
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/helpers/buildPacedTrainException.ts
@@ -271,13 +271,12 @@ export function checkChangeGroups(
       const originalStartTimeToTest = dayjs(new Date(updatedPacedTrain.start_time))
         .add(exception.occurrence_index * originalPacedTrainInterval.ms, 'ms')
         .toDate();
-      const pacedTrainStartTime = new Date(updatedPacedTrain.start_time);
+      const exceptionStartTime = new Date(exception.start_time.value);
 
       // Remove milliseconds to avoid issues with the comparison
       originalStartTimeToTest.setMilliseconds(0);
-      pacedTrainStartTime.setMilliseconds(0);
-
-      if (isEqual(originalStartTimeToTest, pacedTrainStartTime)) {
+      exceptionStartTime.setMilliseconds(0);
+      if (isEqual(originalStartTimeToTest, exceptionStartTime)) {
         delete updatedException.start_time;
       }
     }


### PR DESCRIPTION
To reproduce:

1. Change start time of an occurrence
2. Edit the paced train to match the edited occurrence
3. It should remove the exception