### PR TITLE
front: introduce useDateTimeLocale() 

### DIFF
--- a/front/src/applications/operationalStudies/components/Study/DateBox.tsx
+++ b/front/src/applications/operationalStudies/components/Study/DateBox.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 
-import { dateTimeFormatting } from 'utils/date';
+import { useDateTimeLocale } from 'utils/date';
 
 type Props = {
   date?: Date | null;
@@ -9,13 +9,17 @@ type Props = {
 };
 
 export default function DateBox({ date, type, withoutTime }: Props) {
-  const { t, i18n } = useTranslation('operational-studies');
+  const { t } = useTranslation('operational-studies');
+  const dateTimeLocale = useDateTimeLocale();
   return (
     <div className={`study-details-dates-date ${type}`}>
       <span className="study-details-dates-date-label">{t(`study.date-${type}`)}</span>
       <span className="study-details-dates-date-value">
         {date ? (
-          dateTimeFormatting(date, i18n.language, withoutTime)
+          date.toLocaleString(dateTimeLocale, {
+            dateStyle: 'medium',
+            timeStyle: withoutTime ? undefined : 'short',
+          })
         ) : (
           <small className="text-muted">{t('study.noDateFound')}</small>
         )}

--- a/front/src/applications/stdcm/hooks/useStdcm.ts
+++ b/front/src/applications/stdcm/hooks/useStdcm.ts
@@ -28,6 +28,7 @@ import { getStdcmConf, getStdcmInfraID } from 'reducers/osrdconf/stdcmConf/selec
 import type { TimetableItem } from 'reducers/osrdconf/types';
 import { updateSelectedTrainId } from 'reducers/simulationResults';
 import { useAppDispatch } from 'store';
+import { useDateTimeLocale } from 'utils/date';
 import { castErrorToFailure } from 'utils/error';
 import { formatEditoastIdToTrainScheduleId } from 'utils/trainId';
 
@@ -48,7 +49,8 @@ const useStdcm = ({
   );
 
   const dispatch = useAppDispatch();
-  const { t, i18n } = useTranslation(['translation', 'stdcm']);
+  const { t } = useTranslation(['translation', 'stdcm']);
+  const dateTimeLocale = useDateTimeLocale();
   const osrdconf = useSelector(getStdcmConf);
   const infraId = useSelector(getStdcmInfraID);
   const requestPromise = useRef<ReturnType<typeof postTimetableByIdStdcm>[]>();
@@ -212,7 +214,7 @@ const useStdcm = ({
     resetStdcmState();
     isCancelledRef.current = false;
 
-    const validConfig = checkStdcmConf(dispatch, t, i18n.language, osrdconf);
+    const validConfig = checkStdcmConf(dispatch, t, dateTimeLocale, osrdconf);
     if (!validConfig) return;
 
     setCurrentStdcmRequestStatus(STDCM_REQUEST_STATUS.pending);

--- a/front/src/applications/stdcm/utils/formatStdcmConf.ts
+++ b/front/src/applications/stdcm/utils/formatStdcmConf.ts
@@ -10,7 +10,6 @@ import type {
 import getStepLocation from 'modules/pathfinding/helpers/getStepLocation';
 import { setFailure } from 'reducers/main';
 import type { OsrdStdcmConfState, StandardAllowance } from 'reducers/osrdconf/types';
-import { dateTimeFormatting } from 'utils/date';
 import type { Duration } from 'utils/duration';
 import { kmhToMs, tToKg } from 'utils/physics';
 
@@ -39,7 +38,7 @@ type ValidStdcmConfig = {
 export const checkStdcmConf = (
   dispatch: Dispatch,
   t: TFunction,
-  i18nLanguage: string,
+  dateTimeLocale: Intl.Locale,
   osrdconf: OsrdStdcmConfState
 ): ValidStdcmConfig | null => {
   const {
@@ -136,8 +135,8 @@ export const checkStdcmConf = (
         message: t(
           'operational-studies:manageTimetableItem.errorMessages.originTimeOutsideWindow',
           {
-            low: dateTimeFormatting(searchDatetimeWindow.begin, i18nLanguage, false),
-            high: dateTimeFormatting(searchDatetimeWindow.end, i18nLanguage, false),
+            low: searchDatetimeWindow.begin.toLocaleString(dateTimeLocale, { dateStyle: 'medium' }),
+            high: searchDatetimeWindow.end.toLocaleString(dateTimeLocale, { dateStyle: 'medium' }),
           }
         ),
       })

--- a/front/src/modules/project/components/ProjectCard.tsx
+++ b/front/src/modules/project/components/ProjectCard.tsx
@@ -9,7 +9,7 @@ import { Link } from 'react-router-dom';
 import { getDocument } from 'common/api/documentApi';
 import type { ProjectWithStudies, SearchResultItemProject } from 'common/api/osrdEditoastApi';
 import { getUserSafeWord } from 'reducers/user/userSelectors';
-import { dateTimeFormatting } from 'utils/date';
+import { useDateTimeLocale } from 'utils/date';
 
 type Props = {
   setFilterChips: (filterChips: string) => void;
@@ -19,7 +19,8 @@ type Props = {
 };
 
 export default function ProjectCard({ setFilterChips, project, isSelected, toggleSelect }: Props) {
-  const { t, i18n } = useTranslation('operational-studies');
+  const { t } = useTranslation('operational-studies');
+  const dateTimeLocale = useDateTimeLocale();
   const [imageUrl, setImageUrl] = useState<string>();
   const safeWord = useSelector(getUserSafeWord);
 
@@ -72,7 +73,9 @@ export default function ProjectCard({ setFilterChips, project, isSelected, toggl
           <span className="mr-1">
             <Calendar />
           </span>
-          {dateTimeFormatting(new Date(project.last_modification), i18n.language)}
+          {new Date(project.last_modification).toLocaleString(dateTimeLocale, {
+            dateStyle: 'medium',
+          })}
         </div>
         <div>
           <span className="mr-1">

--- a/front/src/modules/scenario/components/ScenarioCard.tsx
+++ b/front/src/modules/scenario/components/ScenarioCard.tsx
@@ -10,7 +10,7 @@ import type { ScenarioWithDetails } from 'common/api/osrdEditoastApi';
 import { useOsrdConfActions } from 'common/osrdContext';
 import { updateTrainIdUsedForProjection } from 'reducers/simulationResults';
 import { useAppDispatch } from 'store';
-import { dateTimeFormatting } from 'utils/date';
+import { useDateTimeLocale } from 'utils/date';
 
 type ScenarioCardProps = {
   setFilterChips: (filterChips: string) => void;
@@ -25,7 +25,8 @@ export default function ScenarioCard({
   isSelected,
   toggleSelect,
 }: ScenarioCardProps) {
-  const { t, i18n } = useTranslation('operational-studies');
+  const { t } = useTranslation('operational-studies');
+  const dateTimeLocale = useDateTimeLocale();
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
   const { updateScenarioID } = useOsrdConfActions();
@@ -98,7 +99,9 @@ export default function ScenarioCard({
           </span>
           <span className="mr-1">{t('scenario.updatedOn')}</span>
           {scenario.last_modification &&
-            dateTimeFormatting(new Date(scenario.last_modification), i18n.language)}
+            new Date(scenario.last_modification).toLocaleString(dateTimeLocale, {
+              dateStyle: 'medium',
+            })}
         </div>
       </div>
     </div>

--- a/front/src/modules/study/components/StudyCard.tsx
+++ b/front/src/modules/study/components/StudyCard.tsx
@@ -7,7 +7,7 @@ import studyLogo from 'assets/pictures/views/study.svg';
 import type { StudyWithScenarios } from 'common/api/osrdEditoastApi';
 import { useOsrdConfActions } from 'common/osrdContext';
 import { useAppDispatch } from 'store';
-import { dateTimeFormatting } from 'utils/date';
+import { useDateTimeLocale } from 'utils/date';
 import { budgetFormat } from 'utils/numbers';
 
 type StudyCardProps = {
@@ -23,7 +23,8 @@ export default function StudyCard({
   isSelected,
   toggleSelect,
 }: StudyCardProps) {
-  const { t, i18n } = useTranslation('operational-studies');
+  const { t } = useTranslation('operational-studies');
+  const dateTimeLocale = useDateTimeLocale();
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
   const { updateScenarioID, updateStudyID } = useOsrdConfActions();
@@ -122,7 +123,9 @@ export default function StudyCard({
           </span>
           <span className="mr-1">{t('study.updatedOn')}</span>
           {study.last_modification &&
-            dateTimeFormatting(new Date(study.last_modification), i18n.language)}
+            new Date(study.last_modification).toLocaleString(dateTimeLocale, {
+              dateStyle: 'medium',
+            })}
         </div>
       </div>
     </div>

--- a/front/src/modules/timetableItem/components/Timetable/Timetable.tsx
+++ b/front/src/modules/timetableItem/components/Timetable/Timetable.tsx
@@ -1,9 +1,6 @@
 import { useMemo, useState, useCallback } from 'react';
 
 import cx from 'classnames';
-import dayjs from 'dayjs';
-import 'dayjs/locale/fr';
-import 'dayjs/locale/de';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { Virtualizer } from 'virtua';
@@ -22,6 +19,7 @@ import {
   getTrainIdUsedForProjection,
 } from 'reducers/simulationResults/selectors';
 import { useAppDispatch } from 'store';
+import { useDateTimeLocale } from 'utils/date';
 import { isPacedTrainWithDetails, isTrainScheduleId } from 'utils/trainId';
 
 import PacedTrainItem from './PacedTrain/PacedTrainItem';
@@ -45,8 +43,8 @@ type TimetableProps = {
   timetableItemsWithDetails: TimetableItemWithDetails[];
 };
 
-const formatDepartureDate = (d: Date, locale: string) =>
-  dayjs(d).locale(locale).format('dddd D MMMM YYYY');
+const formatDepartureDate = (d: Date, locale: Intl.Locale) =>
+  d.toLocaleDateString(locale, { weekday: 'long', day: 'numeric', month: 'long', year: 'numeric' });
 
 const Timetable = ({
   setDisplayTimetableItemManagement,
@@ -58,7 +56,8 @@ const Timetable = ({
   timetableItems = [],
   timetableItemsWithDetails,
 }: TimetableProps) => {
-  const { t, i18n } = useTranslation('operational-studies', { keyPrefix: 'main' });
+  const { t } = useTranslation('operational-studies', { keyPrefix: 'main' });
+  const dateTimeLocale = useDateTimeLocale();
 
   const [selectedTimetableItemIds, setSelectedTimetableItemIds] = useState<TimetableItemId[]>([]);
   const [expandedTimetableItemIds, setExpandedTimetableItemIds] = useState<Set<TimetableItemId>>(
@@ -114,8 +113,8 @@ const Timetable = ({
 
   const currentDepartureDates = useMemo(
     () =>
-      filteredTimetableItems.map((train) => formatDepartureDate(train.startTime, i18n.language)),
-    [filteredTimetableItems, i18n.language]
+      filteredTimetableItems.map((train) => formatDepartureDate(train.startTime, dateTimeLocale)),
+    [filteredTimetableItems, dateTimeLocale]
   );
 
   const showDepartureDates = useMemo(() => {

--- a/front/src/utils/date.ts
+++ b/front/src/utils/date.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import dayjs from 'dayjs';
 import 'dayjs/locale/fr';
 import 'dayjs/locale/de';
@@ -5,6 +7,7 @@ import customParseFormat from 'dayjs/plugin/customParseFormat';
 import timezone from 'dayjs/plugin/timezone';
 import utc from 'dayjs/plugin/utc';
 import type { TFunction } from 'i18next';
+import { useTranslation } from 'react-i18next';
 
 import type { StdcmSearchDatetimeWindow } from 'applications/stdcm/types';
 
@@ -125,4 +128,13 @@ export const dateToHHMMSS = (date: Date, options?: { withoutSeconds?: boolean; u
   const format = options?.withoutSeconds ? 'HH:mm' : 'HH:mm:ss';
   if (options?.utc) return dayjs(date).utc().format(format);
   return dayjs(date).local().format(format);
+};
+
+export const useDateTimeLocale = () => {
+  const { i18n } = useTranslation();
+
+  return useMemo(() => {
+    const dateTimeLocale = new Intl.DateTimeFormat().resolvedOptions().locale;
+    return new Intl.Locale(dateTimeLocale, { language: i18n.language });
+  }, [i18n.language]);
 };

--- a/front/src/utils/date.ts
+++ b/front/src/utils/date.ts
@@ -4,7 +4,6 @@ import dayjs from 'dayjs';
 import 'dayjs/locale/fr';
 import 'dayjs/locale/de';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
-import timezone from 'dayjs/plugin/timezone';
 import utc from 'dayjs/plugin/utc';
 import type { TFunction } from 'i18next';
 import { useTranslation } from 'react-i18next';
@@ -12,15 +11,7 @@ import { useTranslation } from 'react-i18next';
 import type { StdcmSearchDatetimeWindow } from 'applications/stdcm/types';
 
 dayjs.extend(utc);
-dayjs.extend(timezone);
 dayjs.extend(customParseFormat);
-
-const userTimeZone = dayjs.tz.guess(); // Format : 'Europe/Paris'
-
-export function dateTimeFormatting(date: Date, locale: string, withoutTime: boolean = false) {
-  const dateFormat = withoutTime ? 'D MMM YYYY' : 'D MMM YYYY HH:mm';
-  return dayjs(date).locale(locale).tz(userTimeZone).format(dateFormat).replace(/\./gi, '');
-}
 
 /**
  * Transform a date from a datetime-local input format to a JS Date

--- a/front/tests/utils/date-utils.ts
+++ b/front/tests/utils/date-utils.ts
@@ -39,10 +39,9 @@ export const createDateInSpecialTimeZone = (dateString: string, timeZone: string
  */
 export function formatDateToDayMonthYear(dateString: string): string {
   const date = new Date(dateString);
-  const formattedDate = date.toLocaleDateString('fr-FR', {
+  return date.toLocaleDateString('fr-FR', {
     day: 'numeric',
     month: 'short',
     year: 'numeric',
   });
-  return formattedDate.replace('.', '');
 }


### PR DESCRIPTION
This small hook returns the Intl.Locale suitable for formatting
dates. It uses the user's preferred locale to format dates combined
with the language set up in OSRD.