### PR TITLE
editoast: valkey 'get_bulk' returns an iterator

### DIFF
--- a/editoast/src/valkey_utils.rs
+++ b/editoast/src/valkey_utils.rs
@@ -123,27 +123,25 @@ impl ValkeyConnection {
     pub async fn json_get_bulk<T: DeserializeOwned, K: Debug + ToRedisArgs + Send + Sync>(
         &mut self,
         keys: &[K],
-    ) -> Result<Vec<Option<T>>> {
-        // Avoid mget to fail if keys is empty
-        if keys.is_empty() {
-            return Ok(vec![]);
-        }
-        let values: Vec<Option<String>> = self.mget(keys).await?;
-        let cached_values = values
-            .into_iter()
-            .map(|value| {
-                value.and_then(|v| match serde_json::from_str(&v) {
-                    Ok(value) => Some(value),
-                    Err(e) => {
-                        tracing::warn!(
-                            "the cached value is not a valid JSON for type '{}': {e}",
-                            std::any::type_name::<T>()
-                        );
-                        None
-                    }
-                })
+    ) -> Result<impl Iterator<Item = Option<T>>> {
+        let values: Vec<Option<String>> = if !keys.is_empty() {
+            self.mget(keys).await?
+        } else {
+            // Avoid mget to fail if keys is empty
+            vec![]
+        };
+        let cached_values = values.into_iter().map(|value| {
+            value.and_then(|v| match serde_json::from_str(&v) {
+                Ok(value) => Some(value),
+                Err(e) => {
+                    tracing::warn!(
+                        "the cached value is not a valid JSON for type '{}': {e}",
+                        std::any::type_name::<T>()
+                    );
+                    None
+                }
             })
-            .collect();
+        });
         Ok(cached_values)
     }
 
@@ -240,17 +238,18 @@ impl ValkeyConnection {
     pub async fn compressed_get_bulk<K: Debug + ToRedisArgs + Send + Sync, T: DeserializeOwned>(
         &mut self,
         keys: &[K],
-    ) -> Result<Vec<Option<T>>> {
-        // Avoid mget to fail if keys is empty
-        if keys.is_empty() {
-            return Ok(vec![]);
-        }
+    ) -> Result<impl Iterator<Item = Option<T>>> {
         debug!(nb_keys = keys.len());
 
         // Fetch the values from Redis
-        let values = span!(Level::INFO, "Fetching values from Redis")
-            .in_scope(|| self.mget::<_, Vec<Option<Vec<u8>>>>(keys))
-            .await?;
+        let values = if !keys.is_empty() {
+            span!(Level::INFO, "Fetching values from Redis")
+                .in_scope(|| self.mget::<_, Vec<Option<Vec<u8>>>>(keys))
+                .await?
+        } else {
+            // Avoid mget to fail if keys is empty
+            vec![]
+        };
 
         // Decompress each value if it exists
         let cached_values = span!(Level::INFO, "Decompressing data").in_scope(|| {
@@ -271,7 +270,6 @@ impl ValkeyConnection {
                         }
                     })
                 })
-                .collect()
         });
         Ok(cached_values)
     }

--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -275,8 +275,7 @@ async fn pathfinding_blocks_batch(
     let pathfinding_cached_results: Vec<Option<Arc<PathfindingResult>>> = valkey_conn
         .compressed_get_bulk(&hashes)
         .await?
-        .iter()
-        .map(|result| result.clone().map(Arc::new))
+        .map(|result| result.map(Arc::new))
         .collect();
     let pathfinding_cached_results: HashMap<_, _> =
         hashes.into_iter().zip(pathfinding_cached_results).collect();

--- a/editoast/src/views/projection.rs
+++ b/editoast/src/views/projection.rs
@@ -409,8 +409,10 @@ async fn retrieve_cached_projection(
     Vec<TrainSimulationDetails>,
     Vec<(CachedProjectPathTrainResult, i64)>,
 )> {
-    let cached_projections: Vec<Option<CachedProjectPathTrainResult>> =
-        valkey_conn.json_get_bulk(trains_hash_values).await?;
+    let cached_projections: Vec<Option<CachedProjectPathTrainResult>> = valkey_conn
+        .json_get_bulk(trains_hash_values)
+        .await?
+        .collect();
 
     let mut hit_cache = vec![];
     let mut miss_cache = vec![];

--- a/editoast/src/views/timetable/occupancy_blocks.rs
+++ b/editoast/src/views/timetable/occupancy_blocks.rs
@@ -158,8 +158,10 @@ async fn retrieve_cached_occupancy_blocks(
     trains_hash_values: &[String],
     trains_details: &[TrainSimulationDetails],
 ) -> Result<(Vec<TrainSimulationDetails>, Vec<(OccupancyBlocks, i64)>)> {
-    let cached_projections: Vec<Option<OccupancyBlocks>> =
-        valkey_conn.json_get_bulk(trains_hash_values).await?;
+    let cached_projections: Vec<Option<OccupancyBlocks>> = valkey_conn
+        .json_get_bulk(trains_hash_values)
+        .await?
+        .collect();
 
     let mut hit_cache = vec![];
     let mut miss_cache = vec![];

--- a/editoast/src/views/timetable/simulation.rs
+++ b/editoast/src/views/timetable/simulation.rs
@@ -347,8 +347,7 @@ pub async fn consist_train_simulation_batch(
     let cached_results: Vec<Option<Arc<simulation::Response>>> = valkey_conn
         .compressed_get_bulk(&cached_simulation_hash)
         .await?
-        .into_iter()
-        .map(|result| result.map(Arc::new))
+        .map(|simulation| simulation.map(Arc::new))
         .collect();
 
     let nb_hit = cached_results.iter().flatten().count();


### PR DESCRIPTION
Follow up on #12134 (i.e. now, we do not iterate on `Result<Option<T>>` but only on `Option<T>` so we can directly stream it).

The caller should have the responsibility to collect or do something else with each returned cache value.