### PR TITLE
editoast: adapt project path response

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -1773,7 +1773,9 @@ paths:
               schema:
                 type: object
                 additionalProperties:
-                  $ref: '#/components/schemas/ProjectPathTrainResult'
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/SpaceTimeCurve'
   /paced_train/simulation_summary:
     post:
       tags:
@@ -3862,7 +3864,9 @@ paths:
               schema:
                 type: object
                 additionalProperties:
-                  $ref: '#/components/schemas/ProjectPathTrainResult'
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/SpaceTimeCurve'
   /train_schedule/simulation_summary:
     post:
       tags:
@@ -10245,51 +10249,6 @@ components:
                 type: string
                 maxLength: 255
                 minLength: 1
-    ProjectPathTrainResult:
-      allOf:
-      - type: object
-        description: Project path output is described by time-space points and blocks
-        required:
-        - space_time_curves
-        properties:
-          space_time_curves:
-            type: array
-            items:
-              type: object
-              required:
-              - positions
-              - times
-              properties:
-                positions:
-                  type: array
-                  items:
-                    type: integer
-                    format: int64
-                    minimum: 0
-                  minItems: 2
-                times:
-                  type: array
-                  items:
-                    type: integer
-                    format: int64
-                    minimum: 0
-                  minItems: 2
-            description: List of space-time curves sections along the path
-      - type: object
-        required:
-        - departure_time
-        - rolling_stock_length
-        properties:
-          departure_time:
-            type: string
-            format: date-time
-            description: Departure time of the train
-          rolling_stock_length:
-            type: integer
-            format: int64
-            description: Rolling stock length in mm
-            minimum: 0
-      description: Project path output is described by time-space points and blocks
     ProjectWithStudies:
       allOf:
       - $ref: '#/components/schemas/Project'
@@ -12109,6 +12068,26 @@ components:
           type: number
           format: double
       additionalProperties: false
+    SpaceTimeCurve:
+      type: object
+      required:
+      - positions
+      - times
+      properties:
+        positions:
+          type: array
+          items:
+            type: integer
+            format: int64
+            minimum: 0
+          minItems: 2
+        times:
+          type: array
+          items:
+            type: integer
+            format: int64
+            minimum: 0
+          minItems: 2
     SpacingRequirement:
       type: object
       required:

--- a/editoast/src/views/projection.rs
+++ b/editoast/src/views/projection.rs
@@ -1,5 +1,3 @@
-use chrono::DateTime;
-use chrono::Utc;
 use core_client::CoreClient;
 use core_client::pathfinding::PathfindingResultSuccess;
 use core_client::pathfinding::TrackRange;
@@ -7,7 +5,6 @@ use core_client::simulation::CompleteReportTrain;
 use core_client::simulation::ReportTrain;
 use core_client::simulation::SignalCriticalPosition;
 use core_client::simulation::ZoneUpdate;
-use editoast_common::units;
 use editoast_models::DbConnection;
 use editoast_schemas::primitives::Identifier;
 use itertools::izip;
@@ -22,15 +19,12 @@ use std::sync::Arc;
 use tracing::info;
 use utoipa::ToSchema;
 
-use super::rolling_stock::RollingStockError;
 use crate::ValkeyClient;
 use crate::ValkeyConnection;
 use crate::client::get_app_version;
 use crate::error::Result;
 use crate::models;
-use crate::models::RollingStock;
 use crate::models::infra::Infra;
-use crate::models::prelude::*;
 use crate::models::train_schedule::TrainSchedule;
 use crate::views::path::pathfinding::PathfindingResult;
 use crate::views::path::projection::PathProjection;
@@ -40,9 +34,11 @@ use crate::views::timetable::simulation::SimulationResponseSuccess;
 use crate::views::timetable::simulation::train_simulation_batch;
 
 editoast_common::schemas! {
-    ProjectPathTrainResult,
     ProjectPathForm,
+    SpaceTimeCurve,
 }
+
+pub type SpaceTimeCurves = Vec<SpaceTimeCurve>;
 
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct ProjectPathForm {
@@ -76,26 +72,6 @@ pub struct SpaceTimeCurve {
     // List of times in ms since `departure_time` associated to a position
     #[schema(min_items = 2)]
     times: Vec<u64>,
-}
-
-/// Project path output is described by time-space points and blocks
-#[derive(Debug, Deserialize, Serialize, ToSchema)]
-pub struct ProjectPathTrainResult {
-    /// Departure time of the train
-    pub departure_time: DateTime<Utc>,
-    /// Rolling stock length in mm
-    pub rolling_stock_length: u64,
-    #[serde(flatten)]
-    #[schema(inline)]
-    pub cached: CachedProjectPathTrainResult,
-}
-
-/// Project path output is described by time-space points and blocks
-#[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
-pub struct CachedProjectPathTrainResult {
-    /// List of space-time curves sections along the path
-    #[schema(inline)]
-    pub space_time_curves: Vec<SpaceTimeCurve>,
 }
 
 /// Input for the projection of a train schedule on a path
@@ -153,7 +129,7 @@ impl TrainSimulationDetails {
 pub async fn compute_batch_space_time_curves(
     trains_details: &Vec<TrainSimulationDetails>,
     path_projection: &PathProjection<'_>,
-) -> HashMap<i64, Vec<SpaceTimeCurve>> {
+) -> HashMap<i64, SpaceTimeCurves> {
     let mut space_time_curves = HashMap::new();
 
     for train_detail in trains_details {
@@ -169,7 +145,7 @@ pub async fn compute_batch_space_time_curves(
 fn compute_space_time_curves(
     project_path_input: &TrainSimulationDetails,
     path_projection: &PathProjection,
-) -> Vec<SpaceTimeCurve> {
+) -> SpaceTimeCurves {
     let train_path = PathProjection::new(&project_path_input.train_path);
     let intersections = path_projection.get_intersections(&project_path_input.train_path);
     let positions = &project_path_input.positions;
@@ -305,26 +281,11 @@ pub async fn compute_projected_train_paths(
     infra: &Infra,
     trains_schedules: Vec<models::TrainSchedule>,
     electrical_profile_set_id: Option<i64>,
-) -> Result<HashMap<i64, ProjectPathTrainResult>> {
+) -> Result<HashMap<i64, SpaceTimeCurves>> {
     let path_projection = PathProjection::new(&track_section_ranges);
     let mut valkey_conn = valkey_client.get_connection().await?;
 
-    let (rolling_stocks, _): (Vec<_>, _) = RollingStock::retrieve_batch(
-        conn,
-        trains_schedules
-            .iter()
-            .map::<String, _>(|t| t.rolling_stock_name.clone()),
-    )
-    .await
-    .map_err(RollingStockError::from)?;
-
-    // 1. Get rolling stock length
-    let rolling_stock_length: HashMap<_, _> = rolling_stocks
-        .into_iter()
-        .map(|rs| (rs.name, rs.length))
-        .collect();
-
-    // 2. Get train simulations
+    // 1. Get train simulations
     let simulations = train_simulation_batch(
         conn,
         valkey_client.clone(),
@@ -335,7 +296,7 @@ pub async fn compute_projected_train_paths(
     )
     .await?;
 
-    // 3. Extracts train simulation details and computes unique hashes for projected train paths.
+    // 2. Extracts train simulation details and computes unique hashes for projected train paths.
     let trains_details = extract_train_details(&trains_schedules, simulations).await?;
 
     let mut trains_hash_values = vec![];
@@ -344,14 +305,14 @@ pub async fn compute_projected_train_paths(
         t.compute_projection_hash_with_versioning(infra.id, infra.version, &track_section_ranges)
     }));
 
-    // 4. Retrieve cached projection
+    // 3. Retrieve cached projection
     let (miss_cache, mut hit_cache) =
         retrieve_cached_projection(&mut valkey_conn, &trains_hash_values, &trains_details).await?;
 
-    // 5. Compute space time curves for all miss cache
+    // 4. Compute space time curves for all miss cache
     let space_time_curves = compute_batch_space_time_curves(&miss_cache, &path_projection).await;
 
-    // 6. Store the projection in the cache (using pipeline)
+    // 5. Store the projection in the cache (using pipeline)
     let trains_hash_values: HashMap<_, _> = trains_details
         .iter()
         .map(|t| t.train_id)
@@ -360,50 +321,28 @@ pub async fn compute_projected_train_paths(
     let mut new_items = vec![];
     for train_id in miss_cache.iter().map(|t| t.train_id) {
         let hash = &trains_hash_values[&train_id];
-        let cached_value: CachedProjectPathTrainResult = CachedProjectPathTrainResult {
-            space_time_curves: space_time_curves
-                .get(&train_id)
-                .expect("Space time curves not available for train")
-                .clone(),
-        };
+        let cached_value = space_time_curves
+            .get(&train_id)
+            .expect("Space time curves not available for train")
+            .clone();
         hit_cache.push((cached_value.clone(), train_id));
         new_items.push((hash, cached_value));
     }
     valkey_conn.json_set_bulk(&new_items).await?;
 
-    let train_map: HashMap<i64, TrainSchedule> =
-        trains_schedules.into_iter().map(|ts| (ts.id, ts)).collect();
-
-    // 7. Build the projection response
-    let mut project_path_result = HashMap::new();
-    for (cached, train_id) in hit_cache {
-        let train = train_map.get(&train_id).expect("Train not found");
-        let length = rolling_stock_length
-            .get(&train.rolling_stock_name)
-            .expect("Rolling stock length not found");
-
-        project_path_result.insert(
-            train_id,
-            ProjectPathTrainResult {
-                departure_time: train.start_time,
-                rolling_stock_length: units::millimeter::from(*length) as u64,
-                cached,
-            },
-        );
-    }
-
-    Ok(project_path_result)
+    // 6. Build the projection response
+    Ok(hit_cache
+        .into_iter()
+        .map(|(cached, train_id)| (train_id, cached))
+        .collect())
 }
 
 async fn retrieve_cached_projection(
     valkey_conn: &mut ValkeyConnection,
     trains_hash_values: &[String],
     trains_details: &[TrainSimulationDetails],
-) -> Result<(
-    Vec<TrainSimulationDetails>,
-    Vec<(CachedProjectPathTrainResult, i64)>,
-)> {
-    let cached_projections: Vec<Option<CachedProjectPathTrainResult>> = valkey_conn
+) -> Result<(Vec<TrainSimulationDetails>, Vec<(SpaceTimeCurves, i64)>)> {
+    let cached_projections: Vec<Option<SpaceTimeCurves>> = valkey_conn
         .json_get_bulk(trains_hash_values)
         .await?
         .collect();

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -1493,9 +1493,5 @@ mod tests {
             app.fetch(request).assert_status(StatusCode::OK).json_into();
         // EXPECT
         assert_eq!(response.len(), 1);
-        assert_eq!(
-            response[&paced_train_valid.id].departure_time,
-            train_schedule_base.start_time
-        );
     }
 }

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -32,7 +32,7 @@ use crate::views::infra::InfraIdQueryParam;
 use crate::views::path::pathfinding::PathfindingResult;
 use crate::views::path::pathfinding::pathfinding_from_train;
 use crate::views::projection::ProjectPathForm;
-use crate::views::projection::ProjectPathTrainResult;
+use crate::views::projection::SpaceTimeCurves;
 use crate::views::projection::compute_projected_train_paths;
 use crate::views::timetable::occupancy_blocks::OccupancyBlockForm;
 use crate::views::timetable::occupancy_blocks::OccupancyBlocks;
@@ -556,8 +556,7 @@ async fn simulation(
     tag = "paced_train",
     request_body = ProjectPathForm,
     responses(
-        (status = 200, description = "Project Path Output", body = HashMap<i64, ProjectPathTrainResult>),
-    ),
+        (status = 200, description = "Project Path Output", body = HashMap<i64, Vec<SpaceTimeCurve>>)),
 )]
 async fn project_path(
     State(AppState {
@@ -573,7 +572,7 @@ async fn project_path(
         track_section_ranges,
         electrical_profile_set_id,
     }): Json<ProjectPathForm>,
-) -> Result<Json<HashMap<i64, ProjectPathTrainResult>>> {
+) -> Result<Json<HashMap<i64, SpaceTimeCurves>>> {
     let infra = &Infra::retrieve_real_or_fail(db_pool.get().await?, infra_id, || {
         PacedTrainError::InfraNotFound { infra_id }
     })
@@ -713,7 +712,6 @@ mod tests {
 
     use crate::error::InternalError;
     use crate::models;
-    use crate::models::fixtures::PartialProjectPathTrainResult;
     use crate::models::fixtures::create_created_exception_with_change_groups;
     use crate::models::fixtures::create_fast_rolling_stock;
     use crate::models::fixtures::create_paced_train_with_exceptions;
@@ -731,6 +729,7 @@ mod tests {
     use crate::views::tests::mocked_core_pathfinding_sim_and_proj;
     use crate::views::timetable::paced_train::PacedTrainResponse;
     use crate::views::timetable::paced_train::PacedTrainSummaryResponse;
+    use crate::views::timetable::paced_train::SpaceTimeCurves;
     use crate::views::timetable::simulation;
     use crate::views::timetable::simulation::SimulationResponseSuccess;
     use crate::views::timetable::simulation::SummaryResponse;
@@ -1459,13 +1458,8 @@ mod tests {
         let db_pool = DbConnectionPoolV2::for_tests();
 
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
-        let rolling_stock = create_fast_rolling_stock(&mut db_pool.get_ok(), "R2D2").await;
         let timetable = create_timetable(&mut db_pool.get_ok()).await;
-        let train_schedule_base = TrainSchedule {
-            rolling_stock_name: rolling_stock.name.clone(),
-            ..serde_json::from_str(include_str!("../../tests/train_schedules/simple.json"))
-                .expect("Unable to parse")
-        };
+        let _ = create_fast_rolling_stock(&mut db_pool.get_ok(), "R2D2").await;
         let paced_train_valid =
             create_simple_paced_train(&mut db_pool.get_ok(), timetable.id).await;
         let paced_train_fail = simple_paced_train_changeset(timetable.id)
@@ -1495,9 +1489,8 @@ mod tests {
                 }
             ],
         }));
-        let response: HashMap<i64, PartialProjectPathTrainResult> =
+        let response: HashMap<i64, SpaceTimeCurves> =
             app.fetch(request).assert_status(StatusCode::OK).json_into();
-
         // EXPECT
         assert_eq!(response.len(), 1);
         assert_eq!(

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -1213,10 +1213,6 @@ pub mod tests {
 
         // EXPECT
         assert_eq!(response.len(), 1);
-        assert_eq!(
-            response[&train_schedule_valid.id].departure_time,
-            train_schedule_base.start_time
-        );
     }
 
     #[rstest]

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -43,7 +43,7 @@ use crate::views::path::pathfinding::pathfinding_from_train;
 use crate::views::path::projection::PathProjection;
 use crate::views::path::projection::TrackLocationFromPath;
 use crate::views::projection::ProjectPathForm;
-use crate::views::projection::ProjectPathTrainResult;
+use crate::views::projection::SpaceTimeCurves;
 use crate::views::projection::compute_projected_train_paths;
 use crate::views::projection::find_index_upper;
 use crate::views::projection::interpolate;
@@ -500,7 +500,7 @@ async fn get_path(
     tag = "train_schedule",
     request_body = ProjectPathForm,
     responses(
-        (status = 200, description = "Project Path Output", body = HashMap<i64, ProjectPathTrainResult>),
+        (status = 200, description = "Project Path Output", body = HashMap<i64, Vec<SpaceTimeCurve>>),
     ),
 )]
 async fn project_path(
@@ -517,7 +517,7 @@ async fn project_path(
         track_section_ranges,
         electrical_profile_set_id,
     }): Json<ProjectPathForm>,
-) -> Result<Json<HashMap<i64, ProjectPathTrainResult>>> {
+) -> Result<Json<HashMap<i64, SpaceTimeCurves>>> {
     let infra = &Infra::retrieve_real_or_fail(db_pool.get().await?, infra_id, || {
         TrainScheduleError::InfraNotFound { infra_id }
     })
@@ -973,7 +973,7 @@ pub mod tests {
     use serde_json::json;
 
     use super::*;
-    use crate::models::fixtures::PartialProjectPathTrainResult;
+
     use crate::models::fixtures::create_fast_rolling_stock;
     use crate::models::fixtures::create_simple_train_schedule;
     use crate::models::fixtures::create_small_infra;
@@ -1208,7 +1208,7 @@ pub mod tests {
                 },
             ],
         }));
-        let response: HashMap<i64, PartialProjectPathTrainResult> =
+        let response: HashMap<i64, SpaceTimeCurves> =
             app.fetch(request).assert_status(StatusCode::OK).json_into();
 
         // EXPECT

--- a/front/src/applications/operationalStudies/helpers/TrainProjectionLazyLoader.ts
+++ b/front/src/applications/operationalStudies/helpers/TrainProjectionLazyLoader.ts
@@ -1,12 +1,12 @@
 import {
   osrdEditoastApi,
-  type ProjectPathTrainResult,
   type PostTrainScheduleProjectPathApiResponse,
   type PostTrainScheduleOccupancyBlocksApiResponse,
   type PostPacedTrainProjectPathApiResponse,
   type PostPacedTrainOccupancyBlocksApiResponse,
   type OccupancyBlockForm,
   type OccupancyBlocks,
+  type SpaceTimeCurve,
 } from 'common/api/osrdEditoastApi';
 import type { TimetableItemId } from 'reducers/osrdconf/types';
 import type { AppDispatch } from 'store';
@@ -20,7 +20,8 @@ import {
 
 const BATCH_SIZE = 20;
 
-export type ProjectionResult = ProjectPathTrainResult & {
+export type ProjectionResult = {
+  space_time_curves: SpaceTimeCurve[];
   signal_updates: OccupancyBlocks['signal_updates'];
 };
 
@@ -169,7 +170,7 @@ export default class TrainProjectionLazyLoader {
     for (const [id, result] of Object.entries(rawTrainScheduleResults)) {
       const trainScheduleId = formatEditoastIdToTrainScheduleId(Number(id));
       rawResults.set(trainScheduleId, {
-        ...result,
+        space_time_curves: result,
         signal_updates: rawTrainScheduleOccupancyBlocks[id].signal_updates,
       });
     }
@@ -177,7 +178,7 @@ export default class TrainProjectionLazyLoader {
     for (const [id, result] of Object.entries(rawPacedTrainResults)) {
       const pacedTrainId = formatEditoastIdToPacedTrainId(Number(id));
       rawResults.set(pacedTrainId, {
-        ...result,
+        space_time_curves: result,
         signal_updates: rawPacedTrainOccupancyBlocks[id].signal_updates,
       });
     }

--- a/front/src/applications/operationalStudies/helpers/upsertNewProjectedTrains.ts
+++ b/front/src/applications/operationalStudies/helpers/upsertNewProjectedTrains.ts
@@ -25,7 +25,7 @@ const upsertNewProjectedTrains = (
     }
     const projectedTrain = {
       name: matchingTrain?.train_name || 'Train name not found',
-      departureTime: new Date(trainData.departure_time),
+      departureTime: new Date(matchingTrain?.start_time),
       spaceTimeCurves: trainData.space_time_curves,
       signalUpdates: trainData.signal_updates,
       ...(isPacedTrainResponseWithPacedTrainId(matchingTrain)

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -1727,7 +1727,7 @@ export type PostPacedTrainOccupancyBlocksApiArg = {
   occupancyBlockForm: OccupancyBlockForm;
 };
 export type PostPacedTrainProjectPathApiResponse = /** status 200 Project Path Output */ {
-  [key: string]: ProjectPathTrainResult;
+  [key: string]: SpaceTimeCurve[];
 };
 export type PostPacedTrainProjectPathApiArg = {
   projectPathForm: ProjectPathForm;
@@ -2215,7 +2215,7 @@ export type PostTrainScheduleOccupancyBlocksApiArg = {
   occupancyBlockForm: OccupancyBlockForm;
 };
 export type PostTrainScheduleProjectPathApiResponse = /** status 200 Project Path Output */ {
-  [key: string]: ProjectPathTrainResult;
+  [key: string]: SpaceTimeCurve[];
 };
 export type PostTrainScheduleProjectPathApiArg = {
   projectPathForm: ProjectPathForm;
@@ -3385,17 +3385,9 @@ export type OccupancyBlockForm = {
     track_section_ranges: TrackRange[];
   };
 };
-export type ProjectPathTrainResult = {
-  /** List of space-time curves sections along the path */
-  space_time_curves: {
-    positions: number[];
-    times: number[];
-  }[];
-} & {
-  /** Departure time of the train */
-  departure_time: string;
-  /** Rolling stock length in mm */
-  rolling_stock_length: number;
+export type SpaceTimeCurve = {
+  positions: number[];
+  times: number[];
 };
 export type ProjectPathForm = {
   electrical_profile_set_id?: number | null;


### PR DESCRIPTION
The aim of this PR is to lighten the project_path response in order to facilitate the calculation of occurrences (in a future PR)
The front end can directly retrieve the `start_time` and the `rolling_stock_length` from the train_schedule.

This PR will enable us to better manage paced trains exceptions projections.  (cf : https://github.com/OpenRailAssociation/osrd/pull/12132)