### PR TITLE
front: avoid using an outdated updateTrainDepartureTime()

### DIFF
--- a/front/src/applications/operationalStudies/hooks/useScenarioData.ts
+++ b/front/src/applications/operationalStudies/hooks/useScenarioData.ts
@@ -301,13 +301,8 @@ const useScenarioData = (scenario: ScenarioResponse, infra: InfraWithState) => {
     [updateTrainDepartureTime]
   );
 
-  useEffect(() => {
-    const channel = new BroadcastChannel(`osrd-scenario-${scenario.id}`);
-    broadcastChannel.current = channel;
-
-    channel.addEventListener('message', (event) => {
-      const msg: ScenarioBroadcastMessage = event.data;
-
+  const handleBroadcastChannelMessage = useCallback(
+    (msg: ScenarioBroadcastMessage) => {
       switch (msg.type) {
         case 'upsertTimetableItems':
           upsertTimetableItems(msg.timetableItems);
@@ -331,6 +326,21 @@ const useScenarioData = (scenario: ScenarioResponse, infra: InfraWithState) => {
           'paced_train',
         ])
       );
+    },
+    [upsertTimetableItems, removeTimetableItems, updateTrainDepartureTime, dispatch]
+  );
+
+  // Keep a ref with the freshest callback
+  const handleBroadcastChannelMessageRef = useRef(handleBroadcastChannelMessage);
+  handleBroadcastChannelMessageRef.current = handleBroadcastChannelMessage;
+
+  useEffect(() => {
+    const channel = new BroadcastChannel(`osrd-scenario-${scenario.id}`);
+    broadcastChannel.current = channel;
+
+    channel.addEventListener('message', (event) => {
+      const msg: ScenarioBroadcastMessage = event.data;
+      handleBroadcastChannelMessageRef.current(msg);
     });
 
     return () => {


### PR DESCRIPTION
This callback depends on `timetableItems`, ie. it's re-generated when the timetable item list changes. However, we were capturing it from the broadcast channel `useEffect()` without a proper dep on it.

Since we don't want to re-create the broadcast channel each time the timetable item list changes, store the callback in a ref so that we always use the latest one.

Ideally we shouldn't depend on `timetableItems` in `updateTrainDepartureTime()`, and instead pass a callback to `setTimetableItems()` and PATCH the timetable item, but that requires a lot more work.