### PR TITLE
editoast: paced train path and simulation tests with exceptions

### DIFF
--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -696,6 +696,7 @@ mod tests {
     use core_client::simulation::ReportTrain;
     use core_client::simulation::SpeedLimitProperties;
     use editoast_models::DbConnectionPoolV2;
+    use editoast_schemas::fixtures::simple_created_exception_with_change_groups;
     use editoast_schemas::paced_train::InitialSpeedChangeGroup;
     use editoast_schemas::paced_train::Paced;
     use editoast_schemas::paced_train::PacedTrain;
@@ -749,6 +750,44 @@ mod tests {
     }
 
     #[rstest]
+    async fn update_paced_train_exception() {
+        let app = TestAppBuilder::default_app();
+        let pool = app.db_pool();
+
+        let timetable = create_timetable(&mut pool.get_ok()).await;
+        let simple_paced_train = simple_paced_train_changeset(timetable.id).exceptions(vec![]);
+        let mut simple_paced_train = simple_paced_train
+            .create(&mut pool.get_ok())
+            .await
+            .expect("Failed to create paced train");
+
+        assert_eq!(simple_paced_train.exceptions.len(), 0);
+
+        simple_paced_train.exceptions = vec![simple_created_exception_with_change_groups(
+            "exception_key_1",
+        )];
+        let paced_train: PacedTrain = simple_paced_train.clone().into();
+
+        let request = app
+            .put(format!("/paced_train/{}", simple_paced_train.id).as_str())
+            .json(&json!(&paced_train));
+
+        app.fetch(request).assert_status(StatusCode::NO_CONTENT);
+
+        let updated_paced_train =
+            models::PacedTrain::retrieve_real(pool.get_ok(), simple_paced_train.id)
+                .await
+                .expect("Failed to retrieve updated paced train")
+                .expect("Updated paced train not found");
+
+        assert_eq!(updated_paced_train.exceptions.len(), 1);
+        assert_eq!(
+            simple_paced_train.exceptions,
+            updated_paced_train.exceptions
+        );
+    }
+
+    #[rstest]
     async fn update_paced_train() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
@@ -766,8 +805,7 @@ mod tests {
 
         app.fetch(request).assert_status(StatusCode::NO_CONTENT);
 
-        #[expect(deprecated)]
-        let updated_paced_train = models::PacedTrain::retrieve(&mut pool.get_ok(), paced_train.id)
+        let updated_paced_train = models::PacedTrain::retrieve_real(pool.get_ok(), paced_train.id)
             .await
             .expect("Failed to retrieve updated paced train")
             .expect("Updated paced train not found");

--- a/tests/tests/test_paced_train.py
+++ b/tests/tests/test_paced_train.py
@@ -31,10 +31,151 @@ def _update_simulation_with_mareco_allowances(
     return body
 
 
-def test_get_and_update_paced_train_result(
+def test_put_paced_train(
     west_to_south_east_paced_train: Sequence[Any],
-    small_infra: Infra,
     session: Session,
+    small_infra: Infra,
+):
+    paced_train = west_to_south_east_paced_train[0]
+    paced_train_id = paced_train["id"]
+
+    exception = {
+        "key": "exception_key",
+        "disabled": False,
+        "rolling_stock": {
+            "rolling_stock_name": "etcs_rolling_stock",
+            "comfort": "AIR_CONDITIONING",
+        },
+    }
+
+    paced_train["train_name"] = "update_train_name"
+    paced_train["exceptions"] = [exception]
+
+    update_response = session.put(
+        f"{EDITOAST_URL}paced_train/{paced_train_id}", json=paced_train
+    )
+    update_response.raise_for_status()
+
+    updated_paced_train = session.get(
+        f"{EDITOAST_URL}paced_train/{paced_train_id}"
+    ).json()
+
+    assert updated_paced_train["train_name"] == "update_train_name"
+    assert updated_paced_train["exceptions"] == [exception]
+
+
+def test_get_paced_train_with_exception_path(
+    west_to_south_east_paced_train: Sequence[Any], small_infra: Infra, session: Session
+):
+    paced_train = west_to_south_east_paced_train[0]
+    paced_train_id = paced_train["id"]
+
+    # Get base paced train path
+    paced_train_path_result = session.get(
+        f"{EDITOAST_URL}paced_train/{paced_train_id}/path?infra_id={small_infra.id}"
+    ).json()
+
+    # Add exception to the paced train
+    exception = {
+        "key": "exception_key",
+        "disabled": False,
+        "path_and_schedule": {
+            "power_restrictions": [],
+            "schedule": [],
+            "path": [
+                {"id": "id1", "deleted": False, "track": "TA0", "offset": 470000},
+                {"id": "id2", "deleted": False, "track": "TG4", "offset": 1993000},
+            ],
+            "margins": {
+                "boundaries": [],
+                "values": ["5%"],
+            },
+        },
+        "initial_speed": {"value": 20.0},
+    }
+    paced_train["exceptions"] = [exception]
+    update_response = session.put(
+        f"{EDITOAST_URL}paced_train/{paced_train_id}", json=paced_train
+    )
+    assert update_response.status_code == 204
+    # Get exception path
+    exception_path_result = session.get(
+        f"{EDITOAST_URL}paced_train/{paced_train_id}/path?infra_id={small_infra.id}&exception_key=exception_key"
+    ).json()
+    base_track_sections = [
+        tsr["track_section"] for tsr in paced_train_path_result["track_section_ranges"]
+    ]
+    exception_track_sections = [
+        tsr["track_section"] for tsr in exception_path_result["track_section_ranges"]
+    ]
+
+    # Check if the response is different from paced train
+    assert base_track_sections != exception_track_sections
+    assert base_track_sections == [
+        "TA2",
+        "TA5",
+        "TA7",
+        "TC2",
+        "TD1",
+        "TD3",
+        "TH0",
+        "TH1",
+    ]
+    # Check if the exception path is present in track_sections, the first is TA0 and last is TG4
+    assert exception_track_sections == [
+        "TA0",
+        "TA6",
+        "TC1",
+        "TD0",
+        "TD2",
+        "TG0",
+        "TG1",
+        "TG4",
+    ]
+
+
+def test_get_paced_train_with_exception_simulation(
+    west_to_south_east_paced_train: Sequence[Any], small_infra: Infra, session: Session
+):
+    paced_train = west_to_south_east_paced_train[0]
+    paced_train_id = paced_train["id"]
+
+    # Get base paced train simulation
+    paced_train_simulation_result = session.get(
+        f"{EDITOAST_URL}paced_train/{paced_train_id}/simulation?infra_id={small_infra.id}"
+    ).json()
+
+    # Add exception to the paced train
+    exception = {
+        "key": "exception_key",
+        "disabled": False,
+        "path_and_schedule": {
+            "path": [
+                {"id": "id1", "deleted": False, "track": "TA0", "offset": 470000},
+                {"id": "id2", "deleted": False, "track": "TG4", "offset": 1993000},
+            ],
+            "schedule": [],
+            "margins": {"boundaries": [], "values": ["0%"]},
+            "power_restrictions": [],
+        },
+        "initial_speed": {"value": 20.0},
+    }
+    paced_train["exceptions"] = [exception]
+    update_response = session.put(
+        f"{EDITOAST_URL}paced_train/{paced_train_id}", json=paced_train
+    )
+    assert update_response.status_code == 204
+    # Get exception path
+    exception_simulation_result = session.get(
+        f"{EDITOAST_URL}paced_train/{paced_train_id}/simulation?infra_id={small_infra.id}&exception_key=exception_key"
+    ).json()
+
+    # Check if the response is different from paced train
+    assert exception_simulation_result != paced_train_simulation_result
+
+
+def test_get_and_update_paced_train_result(
+    west_to_south_east_paced_train: Sequence[Any], small_infra: Infra, session: Session
 ):
     paced_train = west_to_south_east_paced_train[0]
     paced_train_id = paced_train["id"]


### PR DESCRIPTION
Part of https://github.com/OpenRailAssociation/osrd/issues/11456

Add intergrations tests:
- paced_train/id/path
- paced_train/id/simulation

Also add paced train update exceptions tests