### PR TITLE
editoast: create etcs braking curves endpoint

### DIFF
--- a/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/ETCSBrakingCurves.kt
+++ b/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/ETCSBrakingCurves.kt
@@ -52,8 +52,12 @@ fun computeBrakingCurvesAtLOA(
     val targetSpeed = limitOfAuthority.speed
     assert(targetSpeed > 0.0)
     val ebdBrakingCurves =
-        computeEbdBrakingCurves(context, targetPosition, targetSpeed, maxSpeedEnvelope, beginPos)
-    return ebdBrakingCurves
+        computeEbdBrakingCurves(context, targetPosition, targetSpeed, maxSpeedEnvelope)
+    return EnumMap(
+        ebdBrakingCurves.mapValues {
+            keepBrakingCurveUnderOverlay(it.value, maxSpeedEnvelope, beginPos)
+        }
+    )
 }
 
 /**
@@ -69,8 +73,7 @@ fun computeBrakingCurvesAtEOA(
     val targetPosition = endOfAuthority.offsetEOA.distance.meters
     assert(targetPosition > 0.0)
     val targetSpeed = 0.0
-    val eoaBrakingCurves =
-        computeSbdBrakingCurves(context, targetPosition, maxSpeedEnvelope, beginPos)
+    val eoaBrakingCurves = computeSbdBrakingCurves(context, targetPosition, maxSpeedEnvelope)
     if (endOfAuthority.usedCurveType == PS) eoaBrakingCurves[IND] = null
     val svlBrakingCurves: BrakingCurves =
         if (endOfAuthority.offsetSVL == null) EnumMap(BrakingType::class.java)
@@ -80,7 +83,6 @@ fun computeBrakingCurvesAtEOA(
                 endOfAuthority.offsetSVL.distance.meters,
                 targetSpeed,
                 maxSpeedEnvelope,
-                beginPos
             )
     val brakingCurves: BrakingCurves =
         EnumMap<BrakingType, BrakingCurve?>(BrakingType::class.java).apply {
@@ -98,7 +100,11 @@ fun computeBrakingCurvesAtEOA(
             brakingCurves[IND] =
                 computeMinETCSBrakingCurves(eoaBrakingCurves[IND], svlBrakingCurves[IND])
     }
-    return brakingCurves
+    return EnumMap(
+        brakingCurves.mapValues {
+            keepBrakingCurveUnderOverlay(it.value, maxSpeedEnvelope, beginPos)
+        }
+    )
 }
 
 /**
@@ -109,7 +115,6 @@ private fun computeSbdBrakingCurves(
     context: EnvelopeSimContext,
     targetPosition: Double,
     maxSpeedEnvelope: Envelope,
-    beginPos: Double
 ): BrakingCurves {
     val targetSpeed = 0.0
     val maxSpeed = maxSpeedEnvelope.maxSpeed
@@ -136,10 +141,6 @@ private fun computeSbdBrakingCurves(
     assert(fullIndicationCurve.brakingCurve.endSpeed == targetSpeed)
     sbdBrakingCurves[sbdCurve.brakingType] = sbdCurve
     sbdBrakingCurves[guiCurve.brakingType] = guiCurve
-    // Keep all the braking curves under the max speed envelope.
-    for (entry in sbdBrakingCurves.entries) {
-        entry.setValue(keepBrakingCurveUnderOverlay(entry.value!!, maxSpeedEnvelope, beginPos))
-    }
     return sbdBrakingCurves
 }
 
@@ -149,7 +150,6 @@ private fun computeEbdBrakingCurves(
     targetPosition: Double,
     targetSpeed: Double,
     maxSpeedEnvelope: Envelope,
-    beginPos: Double
 ): BrakingCurves {
     val maxSpeed = maxSpeedEnvelope.maxSpeed
     // Add maxBecDeltaSpeed to EBD curve overhead so it reaches a sufficiently high speed to
@@ -191,10 +191,6 @@ private fun computeEbdBrakingCurves(
     ebdBrakingCurves[PS] = maintainSpeedUntil(ebdBrakingCurves[PS]!!, maintainSpeed, targetPosition)
     ebdBrakingCurves[IND] =
         maintainSpeedUntil(ebdBrakingCurves[IND]!!, maintainSpeed, targetPosition)
-    // Keep all the braking curves under the max speed envelope.
-    for (entry in ebdBrakingCurves.entries) {
-        entry.setValue(keepBrakingCurveUnderOverlay(entry.value!!, maxSpeedEnvelope, beginPos))
-    }
     return ebdBrakingCurves
 }
 

--- a/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/ETCSBrakingCurves.kt
+++ b/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/ETCSBrakingCurves.kt
@@ -475,7 +475,7 @@ private fun computeMinETCSBrakingCurves(
     val endPos2 = brakingCurve2.brakingCurve.endPos
     val beginPos1 = brakingCurve1.brakingCurve.beginPos
     val beginPos2 = brakingCurve2.brakingCurve.beginPos
-    if (brakingCurveType1 == GUI) return if (endPos2 >= endPos1) brakingCurve1 else brakingCurve2
+    if (brakingCurveType == GUI) return if (endPos2 >= endPos1) brakingCurve1 else brakingCurve2
     else if (beginPos2 >= endPos1) return brakingCurve1
     else if (beginPos1 >= endPos2) return brakingCurve2
 

--- a/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/ETCSBrakingCurves.kt
+++ b/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/ETCSBrakingCurves.kt
@@ -517,10 +517,11 @@ private fun computeMinETCSBrakingCurves(
  * with it or with begin position. If the braking curve has no intersection, return null.
  */
 private fun keepBrakingCurveUnderOverlay(
-    etcsBrakingCurve: BrakingCurve,
+    etcsBrakingCurve: BrakingCurve?,
     overlay: Envelope,
     beginPos: Double
 ): BrakingCurve? {
+    if (etcsBrakingCurve == null) return null
     var brakingCurve = etcsBrakingCurve.brakingCurve
     if (brakingCurve.beginPos >= overlay.endPos || brakingCurve.endPos <= beginPos) {
         etcsBrakingCurvesLogger.warn(
@@ -532,24 +533,27 @@ private fun keepBrakingCurveUnderOverlay(
         // Slice envelope to remove the braking curve part which is after the overlay.
         brakingCurve = Envelope.make(*brakingCurve.slice(brakingCurve.beginPos, overlay.endPos))
     }
-    if (
-        brakingCurve.minSpeed >
-            Envelope.make(
-                    *overlay.slice(
-                        max(brakingCurve.beginPos, beginPos),
-                        min(brakingCurve.endPos, overlay.endPos)
-                    )
-                )
-                .maxSpeed
-    ) {
-        // The full braking curve is above the overlay envelope: nothing to do here.
-        return null
-    }
 
     val points = brakingCurve.iteratePoints().distinct()
     val positions = points.map { it.position }
     val speeds = points.map { it.speed }
     val timeDeltas = brakingCurve.flatMap { it.getTimeDeltas() }
+    val isAboveOverlay =
+        // If the last point is strictly above the overlay, the lowest part of the braking curve is
+        // above
+        // as well.
+        brakingCurve.endSpeed > overlay.interpolateSpeedLeftDir(brakingCurve.endPos, 1.0) ||
+            // If the last point is on the overlay, if the second to last is above the overlay, then
+            // the lowest part of the braking curve is above as well.
+            (brakingCurve.endSpeed == overlay.interpolateSpeedLeftDir(brakingCurve.endPos, 1.0) &&
+                speeds[speeds.size - 2] >=
+                    overlay.interpolateSpeedLeftDir(positions[positions.size - 2], 1.0))
+    if (isAboveOverlay) {
+        // The lowest part of the braking curve is above the overlay envelope: dismiss it entirely
+        // (currently considering that higher parts of the curve which would end up under the
+        // overlay would actually be irrelevant when compared to other slowdown braking curves).
+        return null
+    }
 
     val partBuilder = EnvelopePartBuilder()
     partBuilder.setAttr(EnvelopeProfile.BRAKING)
@@ -559,40 +563,12 @@ private fun keepBrakingCurveUnderOverlay(
             PositionConstraint(max(beginPos, brakingCurve.beginPos), overlay.endPos),
             EnvelopeConstraint(overlay, EnvelopePartConstraintType.CEILING)
         )
-    val lastIndex = getIndexOfLastPointBeneathOverlay(positions, speeds, overlay)
-    // To create a braking curve with overlay builder, we need at least 2 positions.
-    if (lastIndex <= 0) return null
+    val lastIndex = positions.lastIndex
     overlayBuilder.initEnvelopePart(positions[lastIndex], speeds[lastIndex], -1.0)
     for (i in lastIndex - 1 downTo 0) {
         if (!overlayBuilder.addStep(positions[i], speeds[i], timeDeltas[i])) break
     }
     return BrakingCurve(etcsBrakingCurve.brakingType, Envelope.make(partBuilder.build()))
-}
-
-/**
- * Find the index of the last point which is located beneath the overlay envelope, -1 if none exist.
- */
-private fun getIndexOfLastPointBeneathOverlay(
-    positions: List<Double>,
-    speeds: List<Double>,
-    overlay: Envelope
-): Int {
-    if (positions.first() > overlay.endPos || positions.last() < overlay.beginPos) {
-        return -1
-    }
-    for (index in positions.size - 1 downTo 0) {
-        if (positions[index] > overlay.endPos) continue // ignore positions after overlay
-        if (positions[index] < overlay.beginPos) break // stop if reached positions before overlay
-        if (
-            speeds[index] <=
-                overlay
-                    .get(overlay.findRightDir(positions[index], -1.0))
-                    .interpolateSpeed(positions[index])
-        ) {
-            return index
-        }
-    }
-    return -1
 }
 
 private data class BecParams(val dBec: Double, val vBec: Double, val speed: Double) {

--- a/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/ETCSBrakingCurves.kt
+++ b/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/ETCSBrakingCurves.kt
@@ -71,6 +71,7 @@ fun computeBrakingCurvesAtEOA(
     val targetSpeed = 0.0
     val eoaBrakingCurves =
         computeSbdBrakingCurves(context, targetPosition, maxSpeedEnvelope, beginPos)
+    if (endOfAuthority.usedCurveType == PS) eoaBrakingCurves[IND] = null
     val svlBrakingCurves: BrakingCurves =
         if (endOfAuthority.offsetSVL == null) EnumMap(BrakingType::class.java)
         else

--- a/core/src/main/kotlin/fr/sncf/osrd/api/etcs/ETCSBrakingCurvesRequest.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/etcs/ETCSBrakingCurvesRequest.kt
@@ -5,16 +5,13 @@ import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import fr.sncf.osrd.api.RangeValues
-import fr.sncf.osrd.api.standalone_sim.PhysicsConsistModel
-import fr.sncf.osrd.api.standalone_sim.SimulationPath
-import fr.sncf.osrd.api.standalone_sim.SimulationPowerRestrictionItem
-import fr.sncf.osrd.api.standalone_sim.SimulationScheduleItem
+import fr.sncf.osrd.api.standalone_sim.*
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
 import fr.sncf.osrd.railjson.schema.rollingstock.RJSRollingResistance
 import fr.sncf.osrd.sim_infra.api.SpeedLimitProperty
 import fr.sncf.osrd.utils.json.UnitAdapterFactory
 
-class ETCSBrakingCurvesRequest(
+data class ETCSBrakingCurvesRequest(
     val infra: String,
     @Json(name = "expected_version") val expectedVersion: Int?,
 
@@ -33,6 +30,7 @@ class ETCSBrakingCurvesRequest(
 
 val etcsBrakingCurvesRequestAdapter: JsonAdapter<ETCSBrakingCurvesRequest> =
     Moshi.Builder()
+        .add(polymorphicSpeedLimitSourceAdapter)
         .add(RJSRollingResistance.adapter)
         .addLast(UnitAdapterFactory())
         .addLast(KotlinJsonAdapterFactory())

--- a/core/src/main/kotlin/fr/sncf/osrd/api/etcs/ETCSBrakingCurvesResponse.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/etcs/ETCSBrakingCurvesResponse.kt
@@ -1,5 +1,6 @@
 package fr.sncf.osrd.api.etcs
 
+import com.squareup.moshi.Json
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
@@ -8,22 +9,22 @@ import fr.sncf.osrd.utils.json.UnitAdapterFactory
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.TimeDelta
 
-class ETCSBrakingCurvesResponse(
-    slowdowns: List<ETCSCurves>,
-    stops: List<ETCSCurves>,
-    signals: List<ETCSCurves>,
+data class ETCSBrakingCurvesResponse(
+    val slowdowns: List<ETCSCurves>,
+    val stops: List<ETCSCurves>,
+    val signals: List<ETCSCurves>,
 )
 
-class ETCSCurves(
-    indication: SimpleEnvelope?, // null for open-signal stops
-    permittedSpeed: SimpleEnvelope,
-    guidance: SimpleEnvelope
+data class ETCSCurves(
+    val indication: SimpleEnvelope?, // null for open-signal stops
+    @Json(name = "permitted_speed") val permittedSpeed: SimpleEnvelope,
+    val guidance: SimpleEnvelope
 )
 
-class SimpleEnvelope(
-    positions: List<Offset<TravelledPath>>,
-    times: List<TimeDelta>, // Times are compared to the departure time
-    speeds: List<Double>,
+data class SimpleEnvelope(
+    val positions: List<Offset<TravelledPath>>,
+    val times: List<TimeDelta>, // Times are compared to the departure time
+    val speeds: List<Double>,
 )
 
 val etcsBrakingCurvesResponseAdapter: JsonAdapter<ETCSBrakingCurvesResponse> =

--- a/editoast/core_client/src/etcs_braking_curves.rs
+++ b/editoast/core_client/src/etcs_braking_curves.rs
@@ -1,0 +1,70 @@
+use editoast_schemas::train_schedule::Comfort;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use crate::AsCoreRequest;
+use crate::Json;
+use crate::simulation::{
+    PhysicsConsist, SimulationPath, SimulationPowerRestrictionItem, SimulationScheduleItem,
+    SpeedLimitProperties,
+};
+
+editoast_common::schemas! {
+    Response,
+    ETCSCurves,
+}
+
+#[derive(Debug, Serialize)]
+pub struct Request {
+    pub infra: i64,
+    pub expected_version: i64,
+    pub physics_consist: PhysicsConsist,
+    pub comfort: Comfort,
+    pub path: SimulationPath,
+    pub schedule: Vec<SimulationScheduleItem>,
+    pub power_restrictions: Vec<SimulationPowerRestrictionItem>,
+    pub electrical_profile_set_id: Option<i64>,
+    pub use_electrical_profiles: bool,
+    pub mrsp: SpeedLimitProperties,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Clone, Debug, ToSchema)]
+#[schema(as = ETCSBrakingCurvesResponse)]
+pub struct Response {
+    /// List of ETCS braking curves associated to the train schedule's ETCS slowdowns
+    pub slowdowns: Vec<ETCSCurves>,
+    /// List of ETCS braking curves associated to the train schedule's ETCS stops
+    pub stops: Vec<ETCSCurves>,
+    /// List of ETCS braking curves associated to the train schedule's ETCS signals
+    pub signals: Vec<ETCSCurves>,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Clone, Debug, ToSchema)]
+pub struct ETCSCurves {
+    #[schema(inline)]
+    pub indication: Option<SimpleEnvelope>,
+    #[schema(inline)]
+    pub permitted_speed: Option<SimpleEnvelope>,
+    #[schema(inline)]
+    pub guidance: Option<SimpleEnvelope>,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Clone, Debug, ToSchema)]
+pub struct SimpleEnvelope {
+    /// List of positions of a train
+    /// Both positions (in mm) and times (in ms) must have the same length
+    pub positions: Vec<u64>,
+    /// List of times (in ms) associated to a position
+    pub times: Vec<u64>,
+    /// List of speeds (in m/s) associated to a position
+    pub speeds: Vec<f64>,
+}
+
+impl AsCoreRequest<Json<Response>> for Request {
+    const METHOD: reqwest::Method = reqwest::Method::POST;
+    const URL_PATH: &'static str = "/etcs_braking_curves";
+
+    fn infra_id(&self) -> Option<i64> {
+        Some(self.infra)
+    }
+}

--- a/editoast/core_client/src/lib.rs
+++ b/editoast/core_client/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod conflict_detection;
+pub mod etcs_braking_curves;
 pub mod infra_loading;
 pub mod mq_client;
 pub mod path_properties;
@@ -30,6 +31,7 @@ editoast_common::schemas! {
     conflict_detection::schemas(),
     stdcm::schemas(),
     signal_projection::schemas(),
+    etcs_braking_curves::schemas(),
 }
 
 #[derive(Debug, Clone)]

--- a/editoast/editoast_schemas/src/train_schedule/train_schedule_options.rs
+++ b/editoast/editoast_schemas/src/train_schedule/train_schedule_options.rs
@@ -13,10 +13,10 @@ editoast_common::schemas! {
 pub struct TrainScheduleOptions {
     #[educe(Default = true)]
     #[serde(default = "default_use_electrical_profiles")]
-    use_electrical_profiles: bool,
+    pub use_electrical_profiles: bool,
     #[educe(Default = true)]
     #[serde(default = "default_use_speed_limits_for_simulation")]
-    use_speed_limits_for_simulation: bool,
+    pub use_speed_limits_for_simulation: bool,
 }
 
 fn default_use_electrical_profiles() -> bool {

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -4014,6 +4014,39 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TrainScheduleResponse'
+  /train_schedule/{id}/etcs_braking_curves:
+    get:
+      tags:
+      - train_schedule
+      - etcs_braking_curves
+      summary: Retrieve the etcs braking curves of an etcs train on etcs portions of the path
+      parameters:
+      - name: id
+        in: path
+        description: A train schedule ID
+        required: true
+        schema:
+          type: integer
+          format: int64
+      - name: infra_id
+        in: query
+        required: true
+        schema:
+          type: integer
+          format: int64
+      - name: electrical_profile_set_id
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int64
+      responses:
+        '200':
+          description: ETCS Braking Curves Output
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ETCSBrakingCurvesResponse'
   /train_schedule/{id}/path:
     get:
       tags:
@@ -4805,6 +4838,124 @@ components:
       enum:
       - STANDARD
       - MARECO
+    ETCSBrakingCurvesResponse:
+      type: object
+      required:
+      - slowdowns
+      - stops
+      - signals
+      properties:
+        signals:
+          type: array
+          items:
+            $ref: '#/components/schemas/ETCSCurves'
+          description: List of ETCS braking curves associated to the train schedule's ETCS signals
+        slowdowns:
+          type: array
+          items:
+            $ref: '#/components/schemas/ETCSCurves'
+          description: List of ETCS braking curves associated to the train schedule's ETCS slowdowns
+        stops:
+          type: array
+          items:
+            $ref: '#/components/schemas/ETCSCurves'
+          description: List of ETCS braking curves associated to the train schedule's ETCS stops
+    ETCSCurves:
+      type: object
+      properties:
+        guidance:
+          allOf:
+          - type: object
+            required:
+            - positions
+            - times
+            - speeds
+            properties:
+              positions:
+                type: array
+                items:
+                  type: integer
+                  format: int64
+                  minimum: 0
+                description: |-
+                  List of positions of a train
+                  Both positions (in mm) and times (in ms) must have the same length
+              speeds:
+                type: array
+                items:
+                  type: number
+                  format: double
+                description: List of speeds (in m/s) associated to a position
+              times:
+                type: array
+                items:
+                  type: integer
+                  format: int64
+                  minimum: 0
+                description: List of times (in ms) associated to a position
+          nullable: true
+        indication:
+          allOf:
+          - type: object
+            required:
+            - positions
+            - times
+            - speeds
+            properties:
+              positions:
+                type: array
+                items:
+                  type: integer
+                  format: int64
+                  minimum: 0
+                description: |-
+                  List of positions of a train
+                  Both positions (in mm) and times (in ms) must have the same length
+              speeds:
+                type: array
+                items:
+                  type: number
+                  format: double
+                description: List of speeds (in m/s) associated to a position
+              times:
+                type: array
+                items:
+                  type: integer
+                  format: int64
+                  minimum: 0
+                description: List of times (in ms) associated to a position
+          nullable: true
+        permitted_speed:
+          allOf:
+          - type: object
+            required:
+            - positions
+            - times
+            - speeds
+            properties:
+              positions:
+                type: array
+                items:
+                  type: integer
+                  format: int64
+                  minimum: 0
+                description: |-
+                  List of positions of a train
+                  Both positions (in mm) and times (in ms) must have the same length
+              speeds:
+                type: array
+                items:
+                  type: number
+                  format: double
+                description: List of speeds (in m/s) associated to a position
+              times:
+                type: array
+                items:
+                  type: integer
+                  format: int64
+                  minimum: 0
+                description: List of times (in ms) associated to a position
+          nullable: true
     EditoastAppHealthErrorCore:
       type: object
       required:
@@ -5662,6 +5813,9 @@ components:
       - $ref: '#/components/schemas/EditoastTrainScheduleErrorInfraNotFound'
       - $ref: '#/components/schemas/EditoastTrainScheduleErrorNotFound'
       - $ref: '#/components/schemas/EditoastTrainScheduleErrorOperationalPointNotFound'
+      - $ref: '#/components/schemas/EditoastTrainScheduleErrorPathfindingFailed'
+      - $ref: '#/components/schemas/EditoastTrainScheduleErrorRollingStockNotFound'
+      - $ref: '#/components/schemas/EditoastTrainScheduleErrorSimulationFailed'
       - $ref: '#/components/schemas/EditoastWorkScheduleErrorDatabase'
       - $ref: '#/components/schemas/EditoastWorkScheduleErrorNameAlreadyUsed'
       - $ref: '#/components/schemas/EditoastWorkScheduleErrorWorkScheduleGroupNotFound'
@@ -7478,6 +7632,78 @@ components:
           type: string
           enum:
           - editoast:train_schedule:OperationalPointNotFound
+    EditoastTrainScheduleErrorPathfindingFailed:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+          required:
+          - train_schedule_id
+          properties:
+            train_schedule_id:
+              type: integer
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 404
+        type:
+          type: string
+          enum:
+          - editoast:train_schedule:PathfindingFailed
+    EditoastTrainScheduleErrorRollingStockNotFound:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+          required:
+          - rolling_stock_name
+          properties:
+            rolling_stock_name:
+              type: string
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 404
+        type:
+          type: string
+          enum:
+          - editoast:train_schedule:RollingStockNotFound
+    EditoastTrainScheduleErrorSimulationFailed:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+          required:
+          - train_schedule_id
+          properties:
+            train_schedule_id:
+              type: integer
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 404
+        type:
+          type: string
+          enum:
+          - editoast:train_schedule:SimulationFailed
     EditoastWorkScheduleErrorDatabase:
       type: object
       required:

--- a/editoast/src/views/timetable/simulation.rs
+++ b/editoast/src/views/timetable/simulation.rs
@@ -421,52 +421,11 @@ fn build_simulation_request(
     electrical_profile_set_id: Option<i64>,
     physics_consist: PhysicsConsist,
 ) -> core_client::simulation::Request {
-    assert_eq!(path_item_positions.len(), train_schedule.path.len());
-    // Project path items to path offset
-    let path_items_to_position: HashMap<_, _> = train_schedule
-        .path
-        .iter()
-        .map(|p| &p.id)
-        .zip(path_item_positions.iter().copied())
-        .collect();
-
-    let schedule = train_schedule
-        .schedule
-        .iter()
-        .map(|schedule_item| SimulationScheduleItem {
-            path_offset: path_items_to_position[&schedule_item.at],
-            arrival: schedule_item
-                .arrival
-                .as_ref()
-                .map(|t| t.num_milliseconds() as u64),
-            stop_for: schedule_item
-                .stop_for
-                .as_ref()
-                .map(|t| t.num_milliseconds() as u64),
-            reception_signal: schedule_item.reception_signal,
-        })
-        .collect();
-
-    let margins = SimulationMargins {
-        boundaries: train_schedule
-            .margins
-            .boundaries
-            .iter()
-            .map(|at| path_items_to_position[at])
-            .collect(),
-        values: train_schedule.margins.values.clone(),
-    };
-
-    let power_restrictions = train_schedule
-        .power_restrictions
-        .iter()
-        .map(|item| SimulationPowerRestrictionItem {
-            from: path_items_to_position[&item.from],
-            to: path_items_to_position[&item.to],
-            value: item.value.clone(),
-        })
-        .collect();
-
+    let path_items_to_position = build_path_items_to_position(train_schedule, path_item_positions);
+    let schedule = build_sim_schedule_items(train_schedule, &path_items_to_position);
+    let margins = build_sim_margins(train_schedule, &path_items_to_position);
+    let power_restrictions =
+        build_sim_power_restriction_items(train_schedule, &path_items_to_position);
     core_client::simulation::Request {
         infra: infra.id,
         expected_version: infra.version,
@@ -482,6 +441,72 @@ fn build_simulation_request(
         physics_consist,
         electrical_profile_set_id,
     }
+}
+
+pub fn build_path_items_to_position<'t>(
+    train_schedule: &'t models::TrainSchedule,
+    path_item_positions: &[u64],
+) -> HashMap<&'t editoast_schemas::primitives::NonBlankString, u64> {
+    assert_eq!(path_item_positions.len(), train_schedule.path.len());
+    // Project path items to path offset
+    train_schedule
+        .path
+        .iter()
+        .map(|p| &p.id)
+        .zip(path_item_positions.iter().copied())
+        .collect()
+}
+
+pub fn build_sim_schedule_items(
+    train_schedule: &models::TrainSchedule,
+    path_items_to_position: &HashMap<&editoast_schemas::primitives::NonBlankString, u64>,
+) -> Vec<SimulationScheduleItem> {
+    train_schedule
+        .schedule
+        .iter()
+        .map(|schedule_item| SimulationScheduleItem {
+            path_offset: path_items_to_position[&schedule_item.at],
+            arrival: schedule_item
+                .arrival
+                .as_ref()
+                .map(|t| t.num_milliseconds() as u64),
+            stop_for: schedule_item
+                .stop_for
+                .as_ref()
+                .map(|t| t.num_milliseconds() as u64),
+            reception_signal: schedule_item.reception_signal,
+        })
+        .collect()
+}
+
+fn build_sim_margins(
+    train_schedule: &models::TrainSchedule,
+    path_items_to_position: &HashMap<&editoast_schemas::primitives::NonBlankString, u64>,
+) -> SimulationMargins {
+    SimulationMargins {
+        boundaries: train_schedule
+            .margins
+            .boundaries
+            .iter()
+            .map(|at| path_items_to_position[at])
+            .collect(),
+        values: train_schedule.margins.values.clone(),
+    }
+}
+
+pub fn build_sim_power_restriction_items(
+    train_schedule: &models::TrainSchedule,
+    path_items_to_position: &HashMap<&editoast_schemas::primitives::NonBlankString, u64>,
+) -> Vec<SimulationPowerRestrictionItem> {
+    train_schedule
+        .power_restrictions
+        .iter()
+        .map(|item| SimulationPowerRestrictionItem {
+            from: path_items_to_position[&item.from],
+            to: path_items_to_position[&item.to],
+            value: item.value.clone(),
+        })
+        .collect()
 }
 
 fn compute_train_simulation_hash_with_versioning(

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -11,7 +11,11 @@ use axum::response::IntoResponse;
 use chrono::DateTime;
 use chrono::Duration;
 use chrono::Utc;
+use core_client::AsCoreRequest;
+use core_client::pathfinding::PathfindingResultSuccess;
+use core_client::simulation::PhysicsConsist;
 use core_client::simulation::ReportTrain;
+use core_client::simulation::SimulationPath;
 use editoast_authz as authz;
 use editoast_derive::EditoastError;
 use editoast_models::DbConnectionPoolV2;
@@ -30,6 +34,7 @@ use crate::AppState;
 use crate::error::Result;
 use crate::models;
 use crate::models::OperationalPointModel;
+use crate::models::RollingStock;
 use crate::models::infra::Infra;
 use crate::models::prelude::*;
 use crate::models::train_schedule::TrainScheduleChangeset;
@@ -47,12 +52,16 @@ use crate::views::projection::SpaceTimeCurves;
 use crate::views::projection::compute_projected_train_paths;
 use crate::views::projection::find_index_upper;
 use crate::views::projection::interpolate;
+use crate::views::timetable::PhysicsConsistParameters;
 use crate::views::timetable::SimulationResponseSuccess;
 use crate::views::timetable::occupancy_blocks::OccupancyBlockForm;
 use crate::views::timetable::occupancy_blocks::OccupancyBlocks;
 use crate::views::timetable::occupancy_blocks::compute_occupancy_blocks;
 use crate::views::timetable::simulation;
 use crate::views::timetable::simulation::Response;
+use crate::views::timetable::simulation::build_path_items_to_position;
+use crate::views::timetable::simulation::build_sim_power_restriction_items;
+use crate::views::timetable::simulation::build_sim_schedule_items;
 
 use super::simulation::SummaryResponse;
 use super::simulation::train_simulation_batch;
@@ -69,6 +78,7 @@ crate::routes! {
             put,
             "/simulation" => simulation,
             "/path" => get_path,
+            "/etcs_braking_curves" => etcs_braking_curves,
         },
     },
 }
@@ -98,6 +108,15 @@ pub enum TrainScheduleError {
     #[error("Operational point '{operational_point_id}', could not be found")]
     #[editoast_error(status = 404)]
     OperationalPointNotFound { operational_point_id: String },
+    #[error("Rolling stock '{rolling_stock_name}', could not be found")]
+    #[editoast_error(status = 404)]
+    RollingStockNotFound { rolling_stock_name: String },
+    #[error("Pathfinding failed for train schedule '{train_schedule_id}'")]
+    #[editoast_error(status = 404)]
+    PathfindingFailed { train_schedule_id: i64 },
+    #[error("Simulation failed for train schedule '{train_schedule_id}'")]
+    #[editoast_error(status = 404)]
+    SimulationFailed { train_schedule_id: i64 },
     #[error(transparent)]
     #[editoast_error(status = 500)]
     Database(#[from] editoast_models::model::Error),
@@ -345,6 +364,140 @@ async fn simulation(
     .unwrap();
 
     Ok(Json(Arc::unwrap_or_clone(simulation)))
+}
+
+/// Retrieve the etcs braking curves of an etcs train on etcs portions of the path
+#[utoipa::path(
+    get, path = "",
+    tag = "train_schedule,etcs_braking_curves",
+    params(TrainScheduleIdParam, InfraIdQueryParam, ElectricalProfileSetIdQueryParam),
+    responses(
+        (status = 200, description = "ETCS Braking Curves Output", body = ETCSBrakingCurvesResponse),
+    ),
+)]
+async fn etcs_braking_curves(
+    State(AppState {
+        valkey: valkey_client,
+        core_client,
+        db_pool,
+        ..
+    }): State<AppState>,
+    Extension(auth): AuthenticationExt,
+    Path(TrainScheduleIdParam {
+        id: train_schedule_id,
+    }): Path<TrainScheduleIdParam>,
+    Query(InfraIdQueryParam { infra_id }): Query<InfraIdQueryParam>,
+    Query(ElectricalProfileSetIdQueryParam {
+        electrical_profile_set_id,
+    }): Query<ElectricalProfileSetIdQueryParam>,
+) -> Result<Json<core_client::etcs_braking_curves::Response>> {
+    let authorized = auth
+        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
+        .await
+        .map_err(AuthorizationError::AuthError)?;
+    if !authorized {
+        return Err(AuthorizationError::Forbidden.into());
+    }
+
+    // Retrieve infra or fail
+    let infra = Infra::retrieve_real_or_fail(db_pool.get().await?, infra_id, || {
+        TrainScheduleError::InfraNotFound { infra_id }
+    })
+    .await?;
+
+    // Check user privilege on infra
+    auth.check_authorization(async |authorizer| {
+        authorizer
+            .authorize_infra_read(&authz::Infra(infra_id))
+            .await
+    })
+    .await?;
+
+    // Retrieve train_schedule or fail
+    let train_schedule = models::TrainSchedule::retrieve_real_or_fail(
+        db_pool.get().await?,
+        train_schedule_id,
+        || TrainScheduleError::NotFound { train_schedule_id },
+    )
+    .await?;
+
+    // Compute simulation of a train schedule
+    let (simulation_result, pathfinding_result) = train_simulation_batch(
+        &mut db_pool.get().await?,
+        valkey_client,
+        core_client.clone(),
+        &[train_schedule.clone()],
+        &infra,
+        electrical_profile_set_id,
+    )
+    .await?
+    .pop()
+    .unwrap();
+
+    // Extract simulation path
+    let path: SimulationPath = match pathfinding_result.as_ref() {
+        PathfindingResult::Success(PathfindingResultSuccess {
+            blocks,
+            routes,
+            track_section_ranges,
+            path_item_positions,
+            ..
+        }) => SimulationPath {
+            blocks: blocks.clone(),
+            routes: routes.clone(),
+            track_section_ranges: track_section_ranges.clone(),
+            path_item_positions: path_item_positions.clone(),
+        },
+        _ => {
+            return Err(TrainScheduleError::PathfindingFailed { train_schedule_id }.into());
+        }
+    };
+
+    // Extract mrsp
+    let mrsp = match simulation_result.as_ref() {
+        simulation::Response::Success(SimulationResponseSuccess { mrsp, .. }) => mrsp.clone(),
+        _ => {
+            return Err(TrainScheduleError::SimulationFailed { train_schedule_id }.into());
+        }
+    };
+
+    // Build physics consist
+    let rs = RollingStock::retrieve_real_or_fail(
+        db_pool.get().await?,
+        train_schedule.rolling_stock_name.clone(),
+        || TrainScheduleError::RollingStockNotFound {
+            rolling_stock_name: train_schedule.rolling_stock_name.clone(),
+        },
+    )
+    .await?;
+    let physics_consist: PhysicsConsist =
+        PhysicsConsistParameters::from_traction_engine(rs.into()).into();
+
+    // Build schedule items and power restrictions
+    let path_items_to_position =
+        build_path_items_to_position(&train_schedule, &path.path_item_positions);
+    let schedule = build_sim_schedule_items(&train_schedule, &path_items_to_position);
+    let power_restrictions =
+        build_sim_power_restriction_items(&train_schedule, &path_items_to_position);
+
+    let etcs_braking_curves_request = core_client::etcs_braking_curves::Request {
+        infra: infra.id,
+        expected_version: infra.version,
+        physics_consist,
+        comfort: train_schedule.comfort,
+        path,
+        schedule,
+        power_restrictions,
+        electrical_profile_set_id,
+        use_electrical_profiles: train_schedule.options.use_electrical_profiles,
+        mrsp,
+    };
+
+    let etcs_braking_curves_response = etcs_braking_curves_request
+        .fetch(core_client.as_ref())
+        .await?;
+
+    Ok(Json(etcs_braking_curves_response))
 }
 
 #[derive(Debug, Clone, Deserialize, ToSchema)]

--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -250,7 +250,9 @@
       "NotFound": "Train Schedule '{{train_schedule_id}}' could not be found",
       "OperationalPointNotFound": "Operational Point '{{operational_point_id}}' could not be found",
       "PathNotFound": "Path '{{path_id}}' could not be found",
-      "RollingStockNotFound": "Rolling Stock '{{rolling_stock_id}}' could not be found",
+      "PathfindingFailed": "Pathfinding failed for train schedule '{{train_schedule_id}}'",
+      "RollingStockNotFound": "Rolling Stock '{{rolling_stock_name}}' could not be found",
+      "SimulationFailed": "Simulation failed for train schedule '{{train_schedule_id}}'",
       "TimetableNotFound": "Timetable '{{timetable_id}}' could not be found",
       "UnsimulatedTrainSchedule": "Train Schedule '{{train_schedule_id}}' is not simulated"
     },

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -250,7 +250,9 @@
       "NotFound": "Circulation '{{train_schedule_id}}' non trouvée",
       "OperationalPointNotFound": "Point opérationnel '{{operational_point_id}}' non trouvé",
       "PathNotFound": "Chemin '{{path_id}}' non trouvé",
-      "RollingStockNotFound": "Matériel roulant '{{rolling_stock_id}}' non trouvé",
+      "PathfindingFailed": "La recherche de chemin n'a pas abouti pour la circulation '{{train_schedule_id}}'",
+      "RollingStockNotFound": "Matériel roulant '{{rolling_stock_name}}' non trouvé",
+      "SimulationFailed": "La simulation n'a pas abouti pour la circulation '{{train_schedule_id}}'",
       "TimetableNotFound": "Grille horaire '{{timetable_id}}' non trouvée",
       "UnsimulatedTrainSchedule": "La circulation '{{train_schedule_id}}' n'est pas simulée"
     },

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -26,6 +26,7 @@ export const addTagTypes = [
   'stdcm_search_environment',
   'stdcm_log',
   'temporary_speed_limits',
+  'etcs_braking_curves',
   'work_schedules',
 ] as const;
 const injectedRtkApi = api
@@ -1180,6 +1181,19 @@ const injectedRtkApi = api
         }),
         invalidatesTags: ['train_schedule', 'timetable'],
       }),
+      getTrainScheduleByIdEtcsBrakingCurves: build.query<
+        GetTrainScheduleByIdEtcsBrakingCurvesApiResponse,
+        GetTrainScheduleByIdEtcsBrakingCurvesApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/train_schedule/${queryArg.id}/etcs_braking_curves`,
+          params: {
+            infra_id: queryArg.infraId,
+            electrical_profile_set_id: queryArg.electricalProfileSetId,
+          },
+        }),
+        providesTags: ['train_schedule', 'etcs_braking_curves'],
+      }),
       getTrainScheduleByIdPath: build.query<
         GetTrainScheduleByIdPathApiResponse,
         GetTrainScheduleByIdPathApiArg
@@ -2259,6 +2273,14 @@ export type PutTrainScheduleByIdApiArg = {
   /** A train schedule ID */
   id: number;
   trainScheduleForm: TrainScheduleForm;
+};
+export type GetTrainScheduleByIdEtcsBrakingCurvesApiResponse =
+  /** status 200 ETCS Braking Curves Output */ EtcsBrakingCurvesResponse;
+export type GetTrainScheduleByIdEtcsBrakingCurvesApiArg = {
+  /** A train schedule ID */
+  id: number;
+  infraId: number;
+  electricalProfileSetId?: number;
 };
 export type GetTrainScheduleByIdPathApiResponse = /** status 200 The path */ PathfindingResult;
 export type GetTrainScheduleByIdPathApiArg = {
@@ -4351,6 +4373,43 @@ export type TowedRollingStockLockedForm = {
 export type TrainScheduleForm = TrainSchedule & {
   /** Timetable attached to the train schedule */
   timetable_id?: number | null;
+};
+export type EtcsCurves = {
+  guidance?: {
+    /** List of positions of a train
+        Both positions (in mm) and times (in ms) must have the same length */
+    positions: number[];
+    /** List of speeds (in m/s) associated to a position */
+    speeds: number[];
+    /** List of times (in ms) associated to a position */
+    times: number[];
+  } | null;
+  indication?: {
+    /** List of positions of a train
+        Both positions (in mm) and times (in ms) must have the same length */
+    positions: number[];
+    /** List of speeds (in m/s) associated to a position */
+    speeds: number[];
+    /** List of times (in ms) associated to a position */
+    times: number[];
+  } | null;
+  permitted_speed?: {
+    /** List of positions of a train
+        Both positions (in mm) and times (in ms) must have the same length */
+    positions: number[];
+    /** List of speeds (in m/s) associated to a position */
+    speeds: number[];
+    /** List of times (in ms) associated to a position */
+    times: number[];
+  } | null;
+};
+export type EtcsBrakingCurvesResponse = {
+  /** List of ETCS braking curves associated to the train schedule's ETCS signals */
+  signals: EtcsCurves[];
+  /** List of ETCS braking curves associated to the train schedule's ETCS slowdowns */
+  slowdowns: EtcsCurves[];
+  /** List of ETCS braking curves associated to the train schedule's ETCS stops */
+  stops: EtcsCurves[];
 };
 export type Version = {
   git_describe: string | null;

--- a/tests/tests/test_train_schedule.py
+++ b/tests/tests/test_train_schedule.py
@@ -1194,6 +1194,152 @@ def test_etcs_spacing_req(
     assert spacing_req_zone_final["end_time"] == 1035083
 
 
+def test_etcs_schedule_braking_curves_endpoint(
+    etcs_scenario: Scenario, etcs_rolling_stock: int, session: Session
+):
+    rolling_stock_response = session.get(
+        EDITOAST_URL + f"light_rolling_stock/{etcs_rolling_stock}"
+    )
+    etcs_rolling_stock_name = rolling_stock_response.json()["name"]
+    ts_response = session.post(
+        f"{EDITOAST_URL}timetable/{etcs_scenario.timetable}/train_schedules/",
+        json=[
+            {
+                "train_name": "3 brakes + 2 slowdowns + 29 signals",
+                "labels": [],
+                "rolling_stock_name": etcs_rolling_stock_name,
+                "start_time": "2024-01-01T07:00:00Z",
+                "path": [
+                    {"id": "zero", "track": "TA0", "offset": 862_000},
+                    {"id": "first", "track": "TD0", "offset": 1_7156_000},
+                    {"id": "second", "track": "TH1", "offset": 1_177_000},
+                    {"id": "last", "track": "TH1", "offset": 3_922_000},
+                ],
+                "schedule": [
+                    {"at": "zero", "stop_for": "P0D"},
+                    {"at": "first", "stop_for": "PT10S", "reception_signal": "STOP"},
+                    {"at": "second", "stop_for": "PT10S", "reception_signal": "STOP"},
+                    {"at": "last", "stop_for": "P0D"},
+                ],
+                "margins": {"boundaries": [], "values": ["0%"]},
+                "initial_speed": 0,
+                "comfort": "STANDARD",
+                "constraint_distribution": "STANDARD",
+                "speed_limit_tag": "foo",
+                "power_restrictions": [],
+            }
+        ],
+    )
+
+    schedule = ts_response.json()[0]
+    schedule_id = schedule["id"]
+    ts_id_response = session.get(f"{EDITOAST_URL}train_schedule/{schedule_id}/")
+    ts_id_response.raise_for_status()
+    etcs_braking_curves_response = session.get(
+        f"{EDITOAST_URL}train_schedule/{schedule_id}/etcs_braking_curves?infra_id={etcs_scenario.infra}"
+    )
+    slowdowns = etcs_braking_curves_response.json()["slowdowns"]
+    stops = etcs_braking_curves_response.json()["stops"]
+    signals = etcs_braking_curves_response.json()["signals"]
+
+    # Check that the correct stop curves (EoAs = stops) are present
+    first_stop_offset = 29_294_000
+    second_stop_offset = 42_315_000
+    final_stop_offset = 45_060_000
+    stop_offsets = [
+        first_stop_offset,
+        second_stop_offset,
+        final_stop_offset,
+    ]
+    start_braking_curves_offsets = [
+        [21_467_192, MAX_SPEED_288],
+        [40_663_497, SPEED_LIMIT_142],
+        [43_763_476, SPEED_LIMIT_142],
+    ]
+    assert len(stops) == len(stop_offsets)
+    for i in range(len(stops)):
+        used_curve_type = "indication"
+        if i == len(stops) - 1:
+            # The last stop is on an open signal: the indication is null and the used curve is the permitted speed
+            used_curve_type = "permitted_speed"
+            assert stops[i]["indication"] is None
+        used_curve = stops[i][used_curve_type]
+        indication = stops[i]["indication"]
+        permitted_speed = stops[i]["permitted_speed"]
+        guidance = stops[i]["guidance"]
+        assert used_curve["positions"][0] == start_braking_curves_offsets[i][0]
+        assert used_curve["speeds"][0] == start_braking_curves_offsets[i][1]
+        assert used_curve["positions"][-1] == stop_offsets[i]
+        assert used_curve["speeds"][-1] == 0
+        assert permitted_speed["positions"][-1] == stop_offsets[i]
+        assert permitted_speed["speeds"][-1] == 0
+        assert guidance["positions"][-1] == stop_offsets[i]
+        assert guidance["speeds"][-1] == 0
+        if indication is not None:
+            assert indication["positions"][0] < permitted_speed["positions"][0] or (
+                indication["positions"][0] == permitted_speed["positions"][0]
+                and indication["speeds"][0] < permitted_speed["speeds"][0]
+            )
+        assert (
+            permitted_speed["positions"][0] <= guidance["positions"][0]
+            and permitted_speed["speeds"][0] <= guidance["speeds"][0]
+        )
+
+    # Check that the correct slowdown curves (LoAs = slowdowns) are present
+    first_slowdown_offset = 40_638_000
+    second_slowdown_offset = 44_638_000
+    slowdown_offsets = [
+        [first_slowdown_offset, SPEED_LIMIT_142],
+        [second_slowdown_offset, SPEED_LIMIT_112],
+    ]
+    start_braking_curves_offsets = [
+        [34_289_913, MAX_SPEED_288],
+        [43_551_825, SPEED_LIMIT_142],
+    ]
+    assert len(slowdowns) == len(slowdown_offsets)
+    for i in range(len(slowdowns)):
+        indication = slowdowns[i]["indication"]
+        permitted_speed = slowdowns[i]["permitted_speed"]
+        guidance = slowdowns[i]["guidance"]
+        assert indication["positions"][0] == start_braking_curves_offsets[i][0]
+        assert indication["speeds"][0] == start_braking_curves_offsets[i][1]
+        assert indication["positions"][-1] == slowdown_offsets[i][0]
+        assert indication["speeds"][-1] == slowdown_offsets[i][1]
+        assert permitted_speed["positions"][-1] == slowdown_offsets[i][0]
+        assert permitted_speed["speeds"][-1] == slowdown_offsets[i][1]
+        assert guidance["positions"][-1] == slowdown_offsets[i][0]
+        assert guidance["speeds"][-1] == slowdown_offsets[i][1]
+        assert indication["positions"][0] < permitted_speed["positions"][0] or (
+            indication["positions"][0] == permitted_speed["positions"][0]
+            and indication["speeds"][0] < permitted_speed["speeds"][0]
+        )
+        assert (
+            permitted_speed["positions"][0] <= guidance["positions"][0]
+            and permitted_speed["speeds"][0] <= guidance["speeds"][0]
+        )
+
+    # Check that the correct signal curves are present
+    assert len(signals) == 29
+    for i in range(len(signals)):
+        indication = signals[i]["indication"]
+        permitted_speed = signals[i]["permitted_speed"]
+        guidance = signals[i]["guidance"]
+        assert indication["speeds"][-1] == 0
+        assert permitted_speed["speeds"][-1] == 0
+        assert guidance["speeds"][-1] == 0
+        assert indication["positions"][0] < permitted_speed["positions"][0] or (
+            indication["positions"][0] == permitted_speed["positions"][0]
+            and indication["speeds"][0] < permitted_speed["speeds"][0]
+        )
+        assert (
+            permitted_speed["positions"][0] <= guidance["positions"][0]
+            and permitted_speed["speeds"][0] <= guidance["speeds"][0]
+        )
+    last_signal_curves = signals[-1]
+    assert last_signal_curves["indication"]["positions"][0] == 42_866_497
+    assert last_signal_curves["indication"]["positions"][-1] == 44_518_000
+
+
 def _assert_equal_speeds(left, right):
     assert abs(left - right) < 1e-2
 


### PR DESCRIPTION
Create editoast etcs braking curves endpoint (core part has already been merged).
Found a couple of bugs on the way, which resulted in a lot of core bug fixes.

Another PR will be coming to refacto the simulation endpoint so that both endpoints use the common structure `SimpleEnvelope` (in core and editoast).