### PR TITLE
editoast: paced train exceptions key duplicate check

### DIFF
--- a/editoast/editoast_schemas/src/paced_train.rs
+++ b/editoast/editoast_schemas/src/paced_train.rs
@@ -1,6 +1,9 @@
+use std::collections::HashSet;
+
 use chrono::DateTime;
 use chrono::Utc;
 use serde::Deserialize;
+use serde::Deserializer;
 use serde::Serialize;
 use serde_with::skip_serializing_none;
 use utoipa::ToSchema;
@@ -51,9 +54,28 @@ pub struct PacedTrain {
     pub train_schedule_base: TrainSchedule,
     #[schema(inline)]
     pub paced: Paced,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_exceptions")]
     #[schema(required)]
     pub exceptions: Vec<PacedTrainException>,
+}
+
+fn deserialize_exceptions<'de, D>(deserializer: D) -> Result<Vec<PacedTrainException>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let list = Vec::<PacedTrainException>::deserialize(deserializer)?;
+
+    let mut seen = HashSet::with_capacity(list.len());
+    for e in &list {
+        let key = &e.key;
+        if !seen.insert(key) {
+            return Err(serde::de::Error::custom(format!(
+                "Duplicate exception key: {}",
+                key
+            )));
+        }
+    }
+    Ok(list)
 }
 
 /// Represents an exception for a paced train occurrence.

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -1140,6 +1140,33 @@ mod tests {
     }
 
     #[rstest]
+    async fn create_paced_train_with_duplicated_exceptions() {
+        let app = TestAppBuilder::default_app();
+        let pool = app.db_pool();
+
+        let timetable = create_timetable(&mut pool.get_ok()).await;
+        let mut paced_train_1 = simple_paced_train_base();
+
+        paced_train_1.exceptions = vec![
+            simple_created_exception_with_change_groups("duplicated_key_1"),
+            simple_modified_exception_with_change_groups("duplicated_key_1", 0),
+        ];
+
+        let request = app
+            .post(format!("/timetable/{}/paced_trains", timetable.id).as_str())
+            .json(&vec![paced_train_1.clone()]);
+
+        let response = app
+            .fetch(request)
+            .assert_status(StatusCode::UNPROCESSABLE_ENTITY)
+            .bytes();
+        assert_eq!(
+            &String::from_utf8(response).unwrap(),
+            "Failed to deserialize the JSON body into the target type: [0].exceptions: Duplicate exception key: duplicated_key_1 at line 1 column 2448"
+        )
+    }
+
+    #[rstest]
     async fn create_paced_train() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -697,6 +697,7 @@ mod tests {
     use core_client::simulation::SpeedLimitProperties;
     use editoast_models::DbConnectionPoolV2;
     use editoast_schemas::fixtures::simple_created_exception_with_change_groups;
+    use editoast_schemas::fixtures::simple_modified_exception_with_change_groups;
     use editoast_schemas::paced_train::InitialSpeedChangeGroup;
     use editoast_schemas::paced_train::Paced;
     use editoast_schemas::paced_train::PacedTrain;
@@ -811,6 +812,36 @@ mod tests {
             .expect("Updated paced train not found");
 
         assert_eq!(paced_train_base, updated_paced_train.into());
+    }
+
+    #[rstest]
+    async fn update_paced_train_with_duplicated_exceptions() {
+        let app = TestAppBuilder::default_app();
+        let pool = app.db_pool();
+
+        let timetable = create_timetable(&mut pool.get_ok()).await;
+        let paced_train = create_simple_paced_train(&mut pool.get_ok(), timetable.id).await;
+
+        let mut paced_train_base = simple_paced_train_base();
+        paced_train_base.paced.time_window = Duration::minutes(90).try_into().unwrap();
+        paced_train_base.paced.interval = Duration::minutes(15).try_into().unwrap();
+        paced_train_base.exceptions = vec![
+            simple_created_exception_with_change_groups("duplicated_key_1"),
+            simple_modified_exception_with_change_groups("duplicated_key_1", 0),
+        ];
+
+        let request = app
+            .put(format!("/paced_train/{}", paced_train.id).as_str())
+            .json(&json!(&paced_train_base));
+
+        let response = app
+            .fetch(request)
+            .assert_status(StatusCode::UNPROCESSABLE_ENTITY)
+            .bytes();
+        assert_eq!(
+            &String::from_utf8(response).unwrap(),
+            "Failed to deserialize the JSON body into the target type: exceptions: Duplicate exception key: duplicated_key_1 at line 1 column 1328"
+        )
     }
 
     #[rstest]


### PR DESCRIPTION
Part of [#11456](https://github.com/OpenRailAssociation/osrd/issues/11456)

Add paced train exceptions keys duplication check