### PR TITLE
front: surface uncaught JS errors to the user

### DIFF
--- a/front/src/main/app.tsx
+++ b/front/src/main/app.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useEffect } from 'react';
+import { Suspense, useEffect, useCallback } from 'react';
 
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import 'i18n';
@@ -20,7 +20,7 @@ import { OsrdContextLayout } from 'common/osrdContext';
 import { MODES } from 'main/consts';
 import { editorSlice } from 'reducers/editor';
 import editorSelectors from 'reducers/editor/selectors';
-import { updateLastInterfaceVersion } from 'reducers/main';
+import { setFailure, updateLastInterfaceVersion } from 'reducers/main';
 import { mapViewerSlice } from 'reducers/mapViewer';
 import mapViewerSelectors from 'reducers/mapViewer/selectors';
 import { operationalStudiesConfSlice } from 'reducers/osrdconf/operationalStudiesConf';
@@ -28,6 +28,7 @@ import simulationConfSelectors from 'reducers/osrdconf/operationalStudiesConf/se
 import { stdcmConfSlice } from 'reducers/osrdconf/stdcmConf';
 import stdcmConfSelectors from 'reducers/osrdconf/stdcmConf/selectors';
 import { useAppDispatch } from 'store';
+import { castErrorToFailure } from 'utils/error';
 import useAuth from 'utils/hooks/useAuth';
 import { DeploymentContextProvider } from 'utils/hooks/useDeploymentSettings';
 
@@ -118,12 +119,28 @@ const router = createBrowserRouter([
 
 export default function App() {
   const dispatch = useAppDispatch();
+
   useEffect(() => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     // Blindly dispatch current front version for storage
     dispatch(updateLastInterfaceVersion(import.meta.env.VITE_OSRD_GIT_DESCRIBE));
   }, []);
+
+  const handleError = useCallback((event: ErrorEvent) => {
+    if (event.error instanceof Error) {
+      dispatch(setFailure(castErrorToFailure(event.error)));
+    }
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener('error', handleError);
+    return () => {
+      window.removeEventListener('error', handleError);
+    };
+  }, [handleError]);
+
   const { isLoading } = useAuth();
+
   return (
     <Suspense fallback={<Loader />}>
       <DeploymentContextProvider>


### PR DESCRIPTION
Sometimes JavaScript errors are thrown in a callback (e.g. click
handler), or in asynchronous code. This can happen for a number
of reasons, for instance when accessing an array with a bad index.
React only catches errors in synchronous component logic, so
will miss these.

The error is logged to the browser console, but is otherwise
invisible to the user. This can be confusing: from the user's
point-of-view, clicking on a button will result in nothing
happening without any kind of feedback. Additionally, sometimes
these errors result in the app breaking in subtle ways (e.g.
the train list missing some updates, or the space time chart
missing some trains).

Surface the error to the user, so that they can open a bug report.
A bug report with a JS error details is way easier to debug,
especially for transient or hard-to-reproduce bugs.

To test, add the following to any component:

    useEffect(() => {
      setTimeout(() => {
        foo();
      }, 10);
    }, []);

Note, error handling in React will be improved once we switch to
version 19:
https://react.dev/blog/2024/12/05/react-19#error-handling