### PR TITLE
front: drop react-id-generator

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -86,7 +86,6 @@
         "react-dom": "^18.2.0",
         "react-i18next": "^15.5.3",
         "react-icons": "^5.5.0",
-        "react-id-generator": "^3.0.2",
         "react-infinite-scroll-component": "^6.1.0",
         "react-map-gl": "^7.1.8",
         "react-markdown": "^10.1.0",
@@ -28039,15 +28038,6 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "*"
-      }
-    },
-    "node_modules/react-id-generator": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/react-id-generator/-/react-id-generator-3.0.2.tgz",
-      "integrity": "sha512-d0rqWzZ6g0P9agHtA7wX/ErQ4iV/657/0Oz+SX3kid7nR4d0YwaWjjOTIrgYHv2lICZKrxIH4BaKppKrM8fRfw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": ">= 16.8.0"
       }
     },
     "node_modules/react-infinite-scroll-component": {

--- a/front/package.json
+++ b/front/package.json
@@ -82,7 +82,6 @@
     "react-dom": "^18.2.0",
     "react-i18next": "^15.5.3",
     "react-icons": "^5.5.0",
-    "react-id-generator": "^3.0.2",
     "react-infinite-scroll-component": "^6.1.0",
     "react-map-gl": "^7.1.8",
     "react-markdown": "^10.1.0",

--- a/front/src/applications/editor/tools/rangeEdition/speedSection/SpeedSectionMetadataForm.tsx
+++ b/front/src/applications/editor/tools/rangeEdition/speedSection/SpeedSectionMetadataForm.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { AiOutlinePlusCircle } from 'react-icons/ai';
 import { FaTimes } from 'react-icons/fa';
 import { MdSpeed } from 'react-icons/md';
-import nextId from 'react-id-generator';
+import { v4 as uuidV4 } from 'uuid';
 
 import EditorContext from 'applications/editor/context';
 import type {
@@ -41,7 +41,9 @@ const SpeedSectionMetadataForm = ({ speedLimitTags }: SpeedSectionMetadataFormPr
 
   const [tagSpeedLimits, setTagSpeedLimits] = useState<
     { id: string; tag: string; value?: number }[]
-  >(map(entity.properties.speed_limit_by_tag, (value, tag) => ({ tag, value, id: nextId() })));
+  >(() =>
+    map(entity.properties.speed_limit_by_tag, (value, tag) => ({ tag, value, id: uuidV4() }))
+  );
 
   useEffect(() => {
     const newState: Partial<RangeEditionState<SpeedSectionEntity>> = {};
@@ -152,7 +154,7 @@ const SpeedSectionMetadataForm = ({ speedLimitTags }: SpeedSectionMetadataFormPr
           onClick={async () => {
             setTagSpeedLimits((state) =>
               state.concat({
-                id: nextId(),
+                id: uuidV4(),
                 tag: getNewSpeedLimitTag(
                   entity.properties.speed_limit_by_tag || {},
                   t('Editor.tools.speed-edition.new-tag')

--- a/front/src/applications/stdcm/hooks/useStdcm.ts
+++ b/front/src/applications/stdcm/hooks/useStdcm.ts
@@ -1,8 +1,8 @@
 import { useRef, useState } from 'react';
 
 import { useTranslation } from 'react-i18next';
-import nextId from 'react-id-generator';
 import { useSelector } from 'react-redux';
+import { v4 as uuidV4 } from 'uuid';
 
 import {
   STDCM_REQUEST_STATUS,
@@ -103,7 +103,7 @@ const useStdcm = ({
         id: formatEditoastIdToTrainScheduleId(STDCM_TRAIN_ID),
         comfort: payload.body.comfort,
         constraint_distribution: 'MARECO',
-        path: payload.body.steps.map((step) => ({ ...step.location, id: nextId() })),
+        path: payload.body.steps.map((step) => ({ ...step.location, id: uuidV4() })),
         rolling_stock_name: stdcmRollingStock!.name,
         start_time: formattedResponse.departure_time,
         train_name: 'stdcm',

--- a/front/src/modules/pathfinding/components/Pathfinding/TypeAndPath.tsx
+++ b/front/src/modules/pathfinding/components/Pathfinding/TypeAndPath.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { Alert, TriangleRight } from '@osrd-project/ui-icons';
 import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
-import nextId from 'react-id-generator';
+import { v4 as uuidV4 } from 'uuid';
 
 import { useManageTrainScheduleContext } from 'applications/operationalStudies/hooks/useManageTrainScheduleContext';
 import type {
@@ -163,7 +163,7 @@ const TypeAndPath = ({ setDisplayTypeAndPath, rollingStockId }: TypeAndPathProps
         .map(({ uic, ch }) => ({
           uic,
           secondary_code: ch,
-          id: nextId(),
+          id: uuidV4(),
         }));
 
       setDisplayTypeAndPath(false);

--- a/front/src/modules/powerRestriction/helpers/createPathStep.ts
+++ b/front/src/modules/powerRestriction/helpers/createPathStep.ts
@@ -1,5 +1,5 @@
 import { sortBy } from 'lodash';
-import nextId from 'react-id-generator';
+import { v4 as uuidV4 } from 'uuid';
 
 import type { ManageTrainSchedulePathProperties } from 'applications/operationalStudies/types';
 import type { TrackSection } from 'common/api/osrdEditoastApi';
@@ -80,7 +80,7 @@ const createPathStep = (
   );
 
   return {
-    id: nextId(),
+    id: uuidV4(),
     positionOnPath,
     coordinates,
     ...trackOffset,
@@ -128,7 +128,7 @@ export const createCutAtPathStep = (
     cutAtPosition
   );
   return {
-    id: nextId(),
+    id: uuidV4(),
     positionOnPath: cutAtPosition,
     coordinates: coordinatesAtCut,
     isFromPowerRestriction: true,

--- a/front/src/modules/trainschedule/components/ImportTimetableItem/generateTrainSchedulesPayloads.ts
+++ b/front/src/modules/trainschedule/components/ImportTimetableItem/generateTrainSchedulesPayloads.ts
@@ -1,5 +1,6 @@
 /* eslint-disable import/prefer-default-export */
-import nextId from 'react-id-generator';
+
+import { v4 as uuidV4 } from 'uuid';
 
 import type { GraouTrainSchedule } from 'common/api/graouApi';
 import type { TrainSchedule } from 'common/api/osrdEditoastApi';
@@ -12,7 +13,7 @@ function generateTrainSchedulePayload(train: GraouTrainSchedule): TrainSchedule 
     schedule: NonNullable<TrainSchedule['schedule']>;
   }>(
     (acc, step) => {
-      const stepId = nextId();
+      const stepId = uuidV4();
 
       const validUICNumber = !Number.isNaN(step.uic);
 

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/ManageTrainScheduleMap/AddPathStepPopup.tsx
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/ManageTrainScheduleMap/AddPathStepPopup.tsx
@@ -4,9 +4,9 @@ import { point } from '@turf/helpers';
 import { useTranslation } from 'react-i18next';
 import { IoFlag } from 'react-icons/io5';
 import { RiMapPin2Fill, RiMapPin3Fill } from 'react-icons/ri';
-import nextId from 'react-id-generator';
 import { Popup } from 'react-map-gl/maplibre';
 import { useSelector } from 'react-redux';
+import { v4 as uuidV4 } from 'uuid';
 
 import { editoastToEditorEntity } from 'applications/editor/data/api';
 import type { TrackSectionEntity } from 'applications/editor/tools/trackEdition/types';
@@ -86,7 +86,7 @@ const AddPathStepPopup = ({
 
       const { properties } = featureInfoClick.feature;
       setNewPathStep({
-        id: nextId(),
+        id: uuidV4(),
         coordinates: featureInfoClick.coordinates.slice(0, 2),
         track: properties.id,
         offset: Math.round(offset),
@@ -133,7 +133,7 @@ const AddPathStepPopup = ({
       });
 
       setClickedOp({
-        id: nextId(),
+        id: uuidV4(),
         secondary_code: operationalPoint.extensions!.sncf!.ch,
         uic: operationalPoint.extensions!.identifier!.uic,
         tracks: trackPartCoordinates,


### PR DESCRIPTION
react-id-generator has almost entirely been replaced with react's built-in useId() hook or proper keys.

Use UUIDs for path step IDs. We were doing that in some places, but were still using nextId() in some others, which can result in collisions.

Use UUIDs for the local ID used for speed limit tags. The tag itself can't be used, because the tag is mutable and we allow intermediate states with duplicate tags. The UUIDs are generated once for existing tags when the component is mounted, and once for new tags when appending to the list, so they are stable.