### PR TITLE
Fix flaky tests 009 and 004

### DIFF
--- a/front/src/applications/operationalStudies/helpers/TrainProjectionLazyLoader.ts
+++ b/front/src/applications/operationalStudies/helpers/TrainProjectionLazyLoader.ts
@@ -149,10 +149,10 @@ export default class TrainProjectionLazyLoader {
         .unwrap();
     }
 
-    const rawTrainScheduleResults = await trainSchedulePromise;
-    const rawPacedTrainResults = await pacedTrainPromise;
-    const rawTrainScheduleOccupancyBlocks = await trainScheduleOccupancyBlocksPromise;
-    const rawPacedTrainOccupancyBlocks = await pacedTrainOccupancyBlocksPromise;
+    const rawTrainScheduleResults = (await trainSchedulePromise) ?? {};
+    const rawPacedTrainResults = (await pacedTrainPromise) ?? {};
+    const rawTrainScheduleOccupancyBlocks = (await trainScheduleOccupancyBlocksPromise) ?? {};
+    const rawPacedTrainOccupancyBlocks = (await pacedTrainOccupancyBlocksPromise) ?? {};
 
     if (this.cancelled) {
       return;
@@ -164,7 +164,7 @@ export default class TrainProjectionLazyLoader {
       const trainScheduleId = formatEditoastIdToTrainScheduleId(Number(id));
       rawResults.set(trainScheduleId, {
         ...result,
-        signal_updates: rawTrainScheduleOccupancyBlocks[id].signal_updates,
+        signal_updates: rawTrainScheduleOccupancyBlocks[id]?.signal_updates ?? [],
       });
     }
 
@@ -172,7 +172,7 @@ export default class TrainProjectionLazyLoader {
       const pacedTrainId = formatEditoastIdToPacedTrainId(Number(id));
       rawResults.set(pacedTrainId, {
         ...result,
-        signal_updates: rawPacedTrainOccupancyBlocks[id].signal_updates,
+        signal_updates: rawPacedTrainOccupancyBlocks[id]?.signal_updates ?? [],
       });
     }
 

--- a/front/tests/pages/operational-studies/scenario-page.ts
+++ b/front/tests/pages/operational-studies/scenario-page.ts
@@ -126,6 +126,7 @@ class ScenarioPage extends CommonPage {
     tags?: string[];
     isUpdating?: boolean;
   }) {
+    await this.page.waitForLoadState('networkidle');
     await expect(this.scenarioName).toBeVisible();
     expect(await this.scenarioName.textContent()).toContain(name);
     // Wait for the scenario name to be clickable if not updating


### PR DESCRIPTION
- The test 009 fails due to uncaught exception 
![image](https://github.com/user-attachments/assets/5b608aaa-fe2e-4274-aa0a-fe59e34034d9)

Build Exemple : https://github.com/OpenRailAssociation/osrd/actions/runs/15782391809/job/44491270324

**=> Fix** : ensure train projection batch handles undefined or null API responses gracefully

- The test 004 is flaky because although the scenario name is updated correctly, Playwright throws an exception too quickly—before the page reflects the new name

**=> Fix** : add waitForLoadState('networkidle') to  ensure full page load