### PR TITLE
front: prioritize macro nodes stored in DB when deduplicating

### DIFF
--- a/front/src/applications/operationalStudies/components/MacroEditor/MacroEditorState.ts
+++ b/front/src/applications/operationalStudies/components/MacroEditor/MacroEditorState.ts
@@ -121,6 +121,8 @@ export default class MacroEditorState {
         delete trigramAggreg[trig];
       }
       trigramAggreg[trig] = sortBy(trigramAggreg[trig], (key) => {
+        const node = this.nodes[this.indexByPathKey[key]];
+        if (node?.dbId) return 0;
         if (key.startsWith('op_id:')) return 1;
         if (key.startsWith('trigram:')) return 2;
         if (key.startsWith('uic:')) return 3;


### PR DESCRIPTION
When NGE loads, we can end up with two macro nodes referring to the same OP. For instance, one train schedule might have

    { trigram: 'FOO', secondary_code: 'BV' }

in its path while another has

    { uic: 42, secondary_code: 'BV' }

When we load macro nodes from the DB, the path_item_key might refer to either of these.

dedupNodes() takes care of merging and redirecting all of these to a single macro node. However, it might erase data from the DB because it has a fixed priority order. As an example, path item key "uic:42/BV" might be stored in DB, and overwritten by "trigram:FOO/BV" because trigrams have a higher priority than UICs.

This results in macro nodes loosing their position (and other information).

To fix this, always prioritize macro nodes stored in the DB when de-duplicating.

To test:

- Create a train schedule in micro mode (this uses UIC path steps)
- Switch to macro mode
- Move the node positions a bit
- Create a train run with the same path (this uses trigram path steps)
- Switch to micro mode and back

At this point the nodes should retain the position manually set, rather than revert to the automatically picked position.

Closes: https://github.com/OpenRailAssociation/osrd/issues/10391