### PR TITLE
front: paced train projection and selection

### DIFF
--- a/front/src/applications/operationalStudies/helpers/TrainOpProjectionLazyLoader.ts
+++ b/front/src/applications/operationalStudies/helpers/TrainOpProjectionLazyLoader.ts
@@ -17,7 +17,7 @@ import {
 } from 'utils/trainId';
 
 import TrainProjectionLazyLoaderAbstract, {
-  type ProjectionResult,
+  type RawProjectionResult,
   type TrainProjectionLazyLoaderOptions,
 } from './TrainProjectionLazyLoaderAbstract';
 
@@ -147,7 +147,7 @@ export default class TrainOpProjectionLazyLoader extends TrainProjectionLazyLoad
       return;
     }
 
-    const rawResults = new Map<TimetableItemId, ProjectionResult>();
+    const rawResults = new Map<TimetableItemId, RawProjectionResult>();
 
     for (const [id, result] of Object.entries(rawTrainScheduleResults)) {
       const trainScheduleId = formatEditoastIdToTrainScheduleId(Number(id));

--- a/front/src/applications/operationalStudies/helpers/TrainProjectionLazyLoaderAbstract.ts
+++ b/front/src/applications/operationalStudies/helpers/TrainProjectionLazyLoaderAbstract.ts
@@ -8,9 +8,10 @@ import type { AppDispatch } from 'store';
 
 const BATCH_SIZE = 20;
 
-export type ProjectionResult = {
+export type RawProjectionResult = {
   space_time_curves: SpaceTimeCurve[];
   signal_updates?: SignalUpdate[];
+  exceptions?: Map<string, { space_time_curves: SpaceTimeCurve[]; signal_updates: SignalUpdate[] }>;
 };
 
 export type TrainProjectionLazyLoaderOptions = {
@@ -18,7 +19,7 @@ export type TrainProjectionLazyLoaderOptions = {
   infraId: number;
   path: PathfindingResultSuccess;
   electricalProfileSetId?: number;
-  onProgress: (results: Map<TimetableItemId, ProjectionResult>) => void;
+  onProgress: (results: Map<TimetableItemId, RawProjectionResult>) => void;
 };
 
 export default abstract class TrainProjectionLazyLoaderAbstract {

--- a/front/src/applications/operationalStudies/helpers/TrainTrackProjectionLazyLoader.ts
+++ b/front/src/applications/operationalStudies/helpers/TrainTrackProjectionLazyLoader.ts
@@ -1,10 +1,12 @@
-import type {
-  PostPacedTrainOccupancyBlocksApiResponse,
-  PostPacedTrainProjectPathApiResponse,
-  PostTrainScheduleOccupancyBlocksApiResponse,
-  PostTrainScheduleProjectPathApiResponse,
+import { isEmpty } from 'lodash';
+
+import {
+  osrdEditoastApi,
+  type PostTrainScheduleProjectPathApiResponse,
+  type PostTrainScheduleOccupancyBlocksApiResponse,
+  type PostPacedTrainProjectPathApiResponse,
+  type PostPacedTrainOccupancyBlocksApiResponse,
 } from 'common/api/osrdEditoastApi';
-import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import type { TimetableItemId } from 'reducers/osrdconf/types';
 import {
   extractEditoastIdFromPacedTrainId,
@@ -15,7 +17,7 @@ import {
 } from 'utils/trainId';
 
 import TrainProjectionLazyLoaderAbstract from './TrainProjectionLazyLoaderAbstract';
-import type { ProjectionResult } from './TrainProjectionLazyLoaderAbstract';
+import type { RawProjectionResult } from './TrainProjectionLazyLoaderAbstract';
 
 export default class TrainTrackProjectionLazyLoader extends TrainProjectionLazyLoaderAbstract {
   async processBatch(batch: TimetableItemId[]) {
@@ -116,7 +118,7 @@ export default class TrainTrackProjectionLazyLoader extends TrainProjectionLazyL
       return;
     }
 
-    const rawResults = new Map<TimetableItemId, ProjectionResult>();
+    const rawResults = new Map<TimetableItemId, RawProjectionResult>();
 
     for (const [id, result] of Object.entries(rawTrainScheduleResults)) {
       const trainScheduleId = formatEditoastIdToTrainScheduleId(Number(id));
@@ -126,14 +128,29 @@ export default class TrainTrackProjectionLazyLoader extends TrainProjectionLazyL
       });
     }
 
+    // paced train
     for (const [id, result] of Object.entries(rawPacedTrainResults)) {
       const pacedTrainId = formatEditoastIdToPacedTrainId(Number(id));
-      const { paced_train: space_time_curves } = result;
+
+      const { paced_train: space_time_curves, exceptions } = result;
       const { paced_train: signal_updates } = rawPacedTrainOccupancyBlocks[id];
-      rawResults.set(pacedTrainId, {
+      const pacedTrainProjectionResult: RawProjectionResult = {
         space_time_curves,
         signal_updates,
-      });
+      };
+
+      // exceptions with separate projection.
+      if (!isEmpty(exceptions)) {
+        pacedTrainProjectionResult.exceptions = new Map();
+        for (const [exceptionKey, exception] of Object.entries(exceptions)) {
+          pacedTrainProjectionResult.exceptions.set(exceptionKey, {
+            space_time_curves: exception,
+            signal_updates: [],
+          });
+        }
+      }
+
+      rawResults.set(pacedTrainId, pacedTrainProjectionResult);
     }
 
     this.options.onProgress(rawResults);

--- a/front/src/applications/operationalStudies/helpers/upsertNewProjectedTrains.ts
+++ b/front/src/applications/operationalStudies/helpers/upsertNewProjectedTrains.ts
@@ -1,48 +1,100 @@
-import type { TrainSpaceTimeData } from 'modules/simulationResult/types';
-import type { TimetableItemId, TimetableItem } from 'reducers/osrdconf/types';
+import type { OccurrenceProjection, TrainSpaceTimeData } from 'modules/simulationResult/types';
+import { makeOccurrenceTime } from 'modules/timetableItem/components/Timetable/utils';
+import computeOccurrenceName from 'modules/timetableItem/helpers/computeOccurrenceName';
+import type { TimetableItem, TimetableItemId } from 'reducers/osrdconf/types';
 import { Duration } from 'utils/duration';
 import {
+  formatPacedTrainIdToExceptionId,
   formatPacedTrainIdToIndexedOccurrenceId,
   isPacedTrainResponseWithPacedTrainId,
 } from 'utils/trainId';
 
-import type { ProjectionResult } from './TrainProjectionLazyLoaderAbstract';
+import type { RawProjectionResult } from './TrainProjectionLazyLoaderAbstract';
 
+/**
+ * formats raw ProjectionResult into TrainSpaceTimeData and upsert into previous projectedTrains
+ */
 const upsertNewProjectedTrains = (
   projectedTrains: Map<TimetableItemId, TrainSpaceTimeData>,
-  projectedTrainsToUpsert: Map<TimetableItemId, ProjectionResult>,
+  projectedTrainsToUpsert: Map<TimetableItemId, RawProjectionResult>,
   timetableItemsById: Map<TimetableItemId, TimetableItem>
-) => {
+): Map<TimetableItemId, TrainSpaceTimeData> => {
   const newProjectedTrains = new Map(projectedTrains);
 
-  // For each key (train id) in projectPathTrainResult, we either add it or update it in the state
-  for (const [trainIdKey, trainData] of projectedTrainsToUpsert) {
+  // For each key (train, id) in projectPathTrainResult, we either add it or update it in the state
+  for (const [trainIdKey, trainProjectionData] of projectedTrainsToUpsert) {
     const matchingTrain = timetableItemsById.get(trainIdKey);
     if (!matchingTrain) {
-      // TODO: throw an error once useLazyProject is refactored
-      // this case should never happen
       continue;
-    }
-    const projectedTrain = {
-      name: matchingTrain?.train_name || 'Train name not found',
-      departureTime: new Date(matchingTrain?.start_time),
-      spaceTimeCurves: trainData.space_time_curves,
-      signalUpdates: trainData.signal_updates || [],
-      ...(isPacedTrainResponseWithPacedTrainId(matchingTrain)
-        ? {
-            id: formatPacedTrainIdToIndexedOccurrenceId(matchingTrain.id, 0),
-            paced: {
-              timeWindow: Duration.parse(matchingTrain.paced.time_window),
-              interval: Duration.parse(matchingTrain.paced.interval),
-            },
-            exceptions: matchingTrain.exceptions,
+    } else {
+      const baseProjectionData = {
+        name: matchingTrain?.train_name || 'Train name not found',
+        departureTime: new Date(matchingTrain?.start_time),
+        spaceTimeCurves: trainProjectionData.space_time_curves,
+        signalUpdates: trainProjectionData.signal_updates || [],
+      };
+      // ======= paced train ==========
+      if (isPacedTrainResponseWithPacedTrainId(matchingTrain)) {
+        const pacedTrainExceptionsProjections: OccurrenceProjection[] = [];
+        if (trainProjectionData.exceptions) {
+          for (const [exceptionKey, exceptionProjectionData] of trainProjectionData.exceptions) {
+            const matchingException = matchingTrain.exceptions.find(
+              (exception) => exception.key === exceptionKey
+            )!;
+
+            const name = matchingException?.train_name
+              ? matchingException.train_name.value
+              : matchingException?.occurrence_index
+                ? computeOccurrenceName(
+                    matchingTrain.train_name,
+                    matchingException.occurrence_index
+                  )
+                : `${matchingTrain.train_name}/+`;
+
+            const departureTime = matchingException.start_time
+              ? new Date(matchingException.start_time.value)
+              : makeOccurrenceTime(
+                  new Date(matchingTrain.start_time),
+                  Duration.parse(matchingTrain.paced.interval),
+                  // added_exception implies start time
+                  // no start time implies it’s not added, so it’s indexed
+                  matchingException.occurrence_index!
+                );
+
+            const id = matchingException?.occurrence_index
+              ? formatPacedTrainIdToIndexedOccurrenceId(
+                  matchingTrain.id,
+                  matchingException.occurrence_index
+                )
+              : formatPacedTrainIdToExceptionId(matchingTrain.id, matchingException.key);
+            const exceptionProjection = {
+              name,
+              departureTime,
+              spaceTimeCurves: exceptionProjectionData.space_time_curves,
+              signalUpdates: exceptionProjectionData.signal_updates,
+              id,
+              pacedTrainDepartureTime: new Date(matchingTrain.start_time),
+            };
+            pacedTrainExceptionsProjections.push(exceptionProjection);
           }
-        : { id: matchingTrain.id }),
-    };
+        }
 
-    newProjectedTrains.set(trainIdKey, projectedTrain);
+        newProjectedTrains.set(trainIdKey, {
+          ...baseProjectionData,
+          id: matchingTrain.id,
+          paced: {
+            timeWindow: Duration.parse(matchingTrain.paced.time_window),
+            interval: Duration.parse(matchingTrain.paced.interval),
+          },
+          exceptions: matchingTrain.exceptions,
+          exceptionProjections: pacedTrainExceptionsProjections,
+        });
+      } else {
+        // =========== trains schedule =============
+        newProjectedTrains.set(trainIdKey, { ...baseProjectionData, id: matchingTrain.id });
+      }
+    }
   }
-
   return newProjectedTrains;
 };
 

--- a/front/src/applications/operationalStudies/hooks/useAutoUpdateProjection.ts
+++ b/front/src/applications/operationalStudies/hooks/useAutoUpdateProjection.ts
@@ -5,10 +5,10 @@ import { useSelector } from 'react-redux';
 import type { InfraWithState } from 'common/api/osrdEditoastApi';
 import type { TimetableItemWithDetails } from 'modules/timetableItem/components/Timetable/types';
 import type { TimetableItemId } from 'reducers/osrdconf/types';
-import { updateSelectedTrainId, updateTrainIdUsedForProjection } from 'reducers/simulationResults';
+import { updateSelectedTrainId, updateTrainUsedForProjection } from 'reducers/simulationResults';
 import {
   getSelectedTrainId,
-  getTrainIdUsedForProjection,
+  getTrainUsedForProjection,
 } from 'reducers/simulationResults/selectors';
 import { useAppDispatch } from 'store';
 import {
@@ -32,13 +32,13 @@ const useAutoUpdateProjection = (
   timetableItemsWithDetails: TimetableItemWithDetails[]
 ) => {
   const dispatch = useAppDispatch();
-  const currentTrainIdForProjection = useSelector(getTrainIdUsedForProjection);
+  const trainUsedForProjection = useSelector(getTrainUsedForProjection);
   const selectedTrainId = useSelector(getSelectedTrainId);
 
   useEffect(() => {
     if (infra.state !== 'CACHED' || timetableItemIds.length === 0) {
       if (selectedTrainId) dispatch(updateSelectedTrainId(undefined));
-      if (currentTrainIdForProjection) dispatch(updateTrainIdUsedForProjection(undefined));
+      if (trainUsedForProjection) dispatch(updateTrainUsedForProjection(undefined));
       return;
     }
 
@@ -55,8 +55,8 @@ const useAutoUpdateProjection = (
     // if a selected timetable item is given and is still in the timetable, don't change the selected train
     if (timetableItemId && isSelectedTimetableItemIncluded) {
       // if no train is used for the projection, use the selected train
-      if (!currentTrainIdForProjection) {
-        dispatch(updateTrainIdUsedForProjection(timetableItemId));
+      if (!trainUsedForProjection) {
+        dispatch(updateTrainUsedForProjection({ trainId: timetableItemId }));
       }
       return;
     }
@@ -65,7 +65,7 @@ const useAutoUpdateProjection = (
     // by default, select the first valid train
     const firstValidTrain = timetableItemsWithDetails.find((item) => item.summary?.isValid);
     if (firstValidTrain) {
-      dispatch(updateTrainIdUsedForProjection(firstValidTrain.id));
+      dispatch(updateTrainUsedForProjection({ trainId: firstValidTrain.id }));
       const newTrainIdToSelect = isTrainScheduleId(firstValidTrain.id)
         ? firstValidTrain.id
         : formatPacedTrainIdToIndexedOccurrenceId(firstValidTrain.id, 0);

--- a/front/src/applications/operationalStudies/hooks/usePathProjection.ts
+++ b/front/src/applications/operationalStudies/hooks/usePathProjection.ts
@@ -4,28 +4,37 @@ import { skipToken } from '@reduxjs/toolkit/query/react';
 import { useSelector } from 'react-redux';
 
 import { osrdEditoastApi, type InfraWithState } from 'common/api/osrdEditoastApi';
-import { getTrainIdUsedForProjection } from 'reducers/simulationResults/selectors';
+import { getTrainUsedForProjection } from 'reducers/simulationResults/selectors';
 import {
   extractEditoastIdFromPacedTrainId,
   extractEditoastIdFromTrainScheduleId,
   isTrainScheduleId,
+  isPacedTrainId,
 } from 'utils/trainId';
 
 const usePathProjection = (infra: InfraWithState) => {
-  const trainIdUsedForProjection = useSelector(getTrainIdUsedForProjection);
+  const trainUsedForProjection = useSelector(getTrainUsedForProjection);
 
   const trainScheduleId =
-    trainIdUsedForProjection && isTrainScheduleId(trainIdUsedForProjection)
-      ? extractEditoastIdFromTrainScheduleId(trainIdUsedForProjection)
+    trainUsedForProjection && isTrainScheduleId(trainUsedForProjection.id)
+      ? extractEditoastIdFromTrainScheduleId(trainUsedForProjection.id)
       : undefined;
 
   const pacedTrainId =
-    trainIdUsedForProjection && !isTrainScheduleId(trainIdUsedForProjection)
-      ? extractEditoastIdFromPacedTrainId(trainIdUsedForProjection)
+    trainUsedForProjection && isPacedTrainId(trainUsedForProjection.id)
+      ? extractEditoastIdFromPacedTrainId(trainUsedForProjection.id)
       : undefined;
 
   const scheduleArg = trainScheduleId ? { id: trainScheduleId, infraId: infra.id } : skipToken;
-  const pacedArg = pacedTrainId ? { id: pacedTrainId, infraId: infra.id } : skipToken;
+  const pacedArg = pacedTrainId
+    ? {
+        id: pacedTrainId,
+        infraId: infra.id,
+        ...('exceptionKey' in trainUsedForProjection! && {
+          exceptionKey: trainUsedForProjection.exceptionKey,
+        }),
+      }
+    : skipToken;
 
   const { data: schedulePath } =
     osrdEditoastApi.endpoints.getTrainScheduleByIdPath.useQuery(scheduleArg);

--- a/front/src/applications/operationalStudies/hooks/useScenario.ts
+++ b/front/src/applications/operationalStudies/hooks/useScenario.ts
@@ -5,7 +5,7 @@ import { useParams } from 'react-router-dom';
 
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import { useOsrdConfActions } from 'common/osrdContext';
-import { updateTrainIdUsedForProjection } from 'reducers/simulationResults';
+import { updateTrainUsedForProjection } from 'reducers/simulationResults';
 import { useAppDispatch } from 'store';
 import { parseNumber } from 'utils/strings';
 
@@ -57,7 +57,7 @@ const useScenario = () => {
     } else {
       dispatch(updateTimetableID(undefined));
       dispatch(updateInfraID(undefined));
-      dispatch(updateTrainIdUsedForProjection(undefined));
+      dispatch(updateTrainUsedForProjection(undefined));
       dispatch(updateElectricalProfileSetId(undefined));
     }
   }, [scenario]);

--- a/front/src/applications/operationalStudies/hooks/useScenarioData.ts
+++ b/front/src/applications/operationalStudies/hooks/useScenarioData.ts
@@ -16,7 +16,7 @@ import {
 } from 'modules/timetableItem/helpers/formatTimetableItemWithDetails';
 import { getOperationalStudiesElectricalProfileSetId } from 'reducers/osrdconf/operationalStudiesConf/selectors';
 import type { TimetableItemId, TimetableItem } from 'reducers/osrdconf/types';
-import { getTrainIdUsedForProjection } from 'reducers/simulationResults/selectors';
+import { getTrainUsedForProjection } from 'reducers/simulationResults/selectors';
 import { useAppDispatch } from 'store';
 import {
   formatEditoastIdToPacedTrainId,
@@ -39,7 +39,7 @@ type ScenarioBroadcastMessage =
 const useScenarioData = (scenario: ScenarioResponse, infra: InfraWithState) => {
   const dispatch = useAppDispatch();
   const electricalProfileSetId = useSelector(getOperationalStudiesElectricalProfileSetId);
-  const trainIdUsedForProjection = useSelector(getTrainIdUsedForProjection);
+  const trainUsedForProjection = useSelector(getTrainUsedForProjection);
 
   const [timetableItems, setTimetableItems] = useState<TimetableItem[]>();
 
@@ -155,8 +155,8 @@ const useScenarioData = (scenario: ScenarioResponse, infra: InfraWithState) => {
   );
 
   const trainScheduleUsedForProjection = useMemo(
-    () => (trainIdUsedForProjection ? timetableItemsById.get(trainIdUsedForProjection) : undefined),
-    [trainIdUsedForProjection, timetableItems]
+    () => (trainUsedForProjection ? timetableItemsById.get(trainUsedForProjection.id) : undefined),
+    [trainUsedForProjection, timetableItems]
   );
 
   const timetableItemIds = useMemo(
@@ -355,9 +355,12 @@ const useScenarioData = (scenario: ScenarioResponse, infra: InfraWithState) => {
       timetableItemsWithDetails,
       timetableItems,
       projectionData:
-        trainScheduleUsedForProjection && projectionPath
+        trainUsedForProjection && trainScheduleUsedForProjection && projectionPath
           ? {
               trainSchedule: trainScheduleUsedForProjection,
+              ...('exceptionKey' in trainUsedForProjection && {
+                exceptionKeyUsedForProjection: trainUsedForProjection.exceptionKey,
+              }),
               ...projectionPath,
               projectedTrains,
               projectionLoaderData: {

--- a/front/src/applications/operationalStudies/hooks/useScenarioData.ts
+++ b/front/src/applications/operationalStudies/hooks/useScenarioData.ts
@@ -154,7 +154,7 @@ const useScenarioData = (scenario: ScenarioResponse, infra: InfraWithState) => {
     [projectedTrainsById]
   );
 
-  const trainScheduleUsedForProjection = useMemo(
+  const timetableItemUsedForProjection = useMemo(
     () => (trainUsedForProjection ? timetableItemsById.get(trainUsedForProjection.id) : undefined),
     [trainUsedForProjection, timetableItems]
   );
@@ -355,9 +355,9 @@ const useScenarioData = (scenario: ScenarioResponse, infra: InfraWithState) => {
       timetableItemsWithDetails,
       timetableItems,
       projectionData:
-        trainUsedForProjection && trainScheduleUsedForProjection && projectionPath
+        trainUsedForProjection && timetableItemUsedForProjection && projectionPath
           ? {
-              trainSchedule: trainScheduleUsedForProjection,
+              timetableItem: timetableItemUsedForProjection,
               ...('exceptionKey' in trainUsedForProjection && {
                 exceptionKeyUsedForProjection: trainUsedForProjection.exceptionKey,
               }),
@@ -378,7 +378,7 @@ const useScenarioData = (scenario: ScenarioResponse, infra: InfraWithState) => {
     [
       timetableItemsWithDetails,
       timetableItems,
-      trainScheduleUsedForProjection,
+      timetableItemUsedForProjection,
       projectionPath,
       projectedTrains,
       allTrainsProjected,

--- a/front/src/applications/operationalStudies/hooks/useScenarioQueryParams.ts
+++ b/front/src/applications/operationalStudies/hooks/useScenarioQueryParams.ts
@@ -60,6 +60,7 @@ const useScenarioQueryParams = () => {
   useEffect(() => {
     const selectedTrainFromUrl = getParamFromUrlOrStorage('selected_train');
     const projectionFromUrl = getParamFromUrlOrStorage('projection');
+    const projectionExceptionKeyFromUrl = getParamFromUrlOrStorage('projection_exception_key');
     if (
       selectedTrainFromUrl &&
       (isTrainScheduleId(selectedTrainFromUrl) || isOccurrenceId(selectedTrainFromUrl))
@@ -70,7 +71,12 @@ const useScenarioQueryParams = () => {
       projectionFromUrl &&
       (isTrainScheduleId(projectionFromUrl) || isPacedTrainId(projectionFromUrl))
     ) {
-      dispatch(updateTrainUsedForProjection({ trainId: projectionFromUrl }));
+      dispatch(
+        updateTrainUsedForProjection({
+          trainId: projectionFromUrl,
+          exceptionKey: projectionExceptionKeyFromUrl,
+        })
+      );
     }
   }, [dispatch, getParamFromUrlOrStorage]);
 
@@ -81,6 +87,13 @@ const useScenarioQueryParams = () => {
     }
     if (reduxProjectionTrain?.id.toString() !== getParamFromUrlOrStorage('projection')) {
       setParamsInUrlAndStorage('projection', reduxProjectionTrain?.id.toString());
+    }
+    if (
+      reduxProjectionTrain &&
+      'exceptionKey' in reduxProjectionTrain &&
+      reduxProjectionTrain.exceptionKey !== getParamFromUrlOrStorage('projection_exception_key')
+    ) {
+      setParamsInUrlAndStorage('projection_exception_key', reduxProjectionTrain.exceptionKey);
     }
   }, [
     reduxSelectedTrainId,

--- a/front/src/applications/operationalStudies/hooks/useScenarioQueryParams.ts
+++ b/front/src/applications/operationalStudies/hooks/useScenarioQueryParams.ts
@@ -3,10 +3,10 @@ import { useEffect, useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
-import { updateSelectedTrainId, updateTrainIdUsedForProjection } from 'reducers/simulationResults';
+import { updateSelectedTrainId, updateTrainUsedForProjection } from 'reducers/simulationResults';
 import {
   getSelectedTrainId,
-  getTrainIdUsedForProjection,
+  getTrainUsedForProjection,
 } from 'reducers/simulationResults/selectors';
 import { useAppDispatch } from 'store';
 import { isOccurrenceId, isPacedTrainId, isTrainScheduleId } from 'utils/trainId';
@@ -32,7 +32,7 @@ const useScenarioQueryParams = () => {
   const searchParams = useMemo(() => new URLSearchParams(location.search), [location.search]);
 
   const reduxSelectedTrainId = useSelector(getSelectedTrainId);
-  const reduxProjectionTrainId = useSelector(getTrainIdUsedForProjection);
+  const reduxProjectionTrain = useSelector(getTrainUsedForProjection);
 
   // Helper function to get a parameter from the URL, or if absent from local storage
   const getParamFromUrlOrStorage = useCallback(
@@ -70,7 +70,7 @@ const useScenarioQueryParams = () => {
       projectionFromUrl &&
       (isTrainScheduleId(projectionFromUrl) || isPacedTrainId(projectionFromUrl))
     ) {
-      dispatch(updateTrainIdUsedForProjection(projectionFromUrl));
+      dispatch(updateTrainUsedForProjection({ trainId: projectionFromUrl }));
     }
   }, [dispatch, getParamFromUrlOrStorage]);
 
@@ -79,12 +79,12 @@ const useScenarioQueryParams = () => {
     if (reduxSelectedTrainId?.toString() !== getParamFromUrlOrStorage('selected_train')) {
       setParamsInUrlAndStorage('selected_train', reduxSelectedTrainId?.toString());
     }
-    if (reduxProjectionTrainId?.toString() !== getParamFromUrlOrStorage('projection')) {
-      setParamsInUrlAndStorage('projection', reduxProjectionTrainId?.toString());
+    if (reduxProjectionTrain?.id.toString() !== getParamFromUrlOrStorage('projection')) {
+      setParamsInUrlAndStorage('projection', reduxProjectionTrain?.id.toString());
     }
   }, [
     reduxSelectedTrainId,
-    reduxProjectionTrainId,
+    reduxProjectionTrain,
     setParamsInUrlAndStorage,
     getParamFromUrlOrStorage,
   ]);

--- a/front/src/applications/operationalStudies/views/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/SimulationResults.tsx
@@ -26,7 +26,7 @@ import { findExceptionWithOccurrenceId } from 'modules/timetableItem/helpers/pac
 import { getOperationalStudiesTimetableID } from 'reducers/osrdconf/operationalStudiesConf/selectors';
 import type { TimetableItemId, TrainId } from 'reducers/osrdconf/types';
 import { updateSelectedTrainId } from 'reducers/simulationResults';
-import { getTrainIdUsedForProjection } from 'reducers/simulationResults/selectors';
+import { getTrainUsedForProjection } from 'reducers/simulationResults/selectors';
 import { useAppDispatch } from 'store';
 import {
   extractPacedTrainIdFromOccurrenceId,
@@ -71,7 +71,7 @@ const SimulationResults = ({
   const simulationResults = useSimulationResults(infraId);
   const selectedTrainId = simulationResults?.train.id;
 
-  const trainIdUsedForProjection = useSelector(getTrainIdUsedForProjection);
+  const trainUsedForProjection = useSelector(getTrainUsedForProjection);
 
   const [showWarpedMap, setShowWarpedMap] = useState(false);
 
@@ -112,6 +112,7 @@ const SimulationResults = ({
     setFilteredOperationalPoints,
   } = useGetProjectedTrainOperationalPoints({
     timetableItemUsedForProjection: projectionData?.trainSchedule,
+    exceptionKeyUsedForProjection: projectionData?.exceptionKeyUsedForProjection,
     infraId,
     timetableId,
   });
@@ -223,7 +224,7 @@ const SimulationResults = ({
 
               <div className="osrd-simulation-container d-flex flex-grow-1 flex-shrink-1">
                 <div className="chart-container">
-                  {trainIdUsedForProjection && (
+                  {trainUsedForProjection && (
                     <ManchetteWithSpaceTimeChartWrapper
                       operationalPoints={projectedOperationalPoints}
                       projectPathTrainResult={projectPathTrainResult}
@@ -250,7 +251,7 @@ const SimulationResults = ({
                       onTrainClick={(trainId) => {
                         dispatch(updateSelectedTrainId(trainId));
                       }}
-                      selectedProjectionId={trainIdUsedForProjection}
+                      selectedProjectionId={trainUsedForProjection.id}
                     />
                   )}
                 </div>

--- a/front/src/applications/operationalStudies/views/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/SimulationResults.tsx
@@ -31,6 +31,7 @@ import { useAppDispatch } from 'store';
 import {
   extractPacedTrainIdFromOccurrenceId,
   isPacedTrainWithDetails,
+  isOccurrenceId,
   isTrainScheduleId,
 } from 'utils/trainId';
 
@@ -87,15 +88,14 @@ const SimulationResults = ({
     OccupancyTrainSpaceTimeData[]
   >([]);
 
+  /** Populate projectPathTrainResult from useLayProjectTrain data */
   useEffect(() => {
     if (projectionData?.projectedTrains) {
       const timetableItemDict = keyBy(timetableItemsWithDetails, 'id');
       setProjectPathTrainResult(
         projectionData.projectedTrains.map((train) => {
-          const timetableItem =
-            timetableItemDict[
-              isTrainScheduleId(train.id) ? train.id : extractPacedTrainIdFromOccurrenceId(train.id)
-            ];
+          // TODO: handle exception in track occupancy diagram
+          const timetableItem = timetableItemDict[train.id];
           return {
             ...train,
             originPathItemLocation: timetableItem?.path.at(0),
@@ -156,7 +156,10 @@ const SimulationResults = ({
     initialDepartureTime: Date;
     stopPanning: boolean;
   }) => {
-    const draggedTrain = projectPathTrainResult.find((train) => train.id === draggedTrainId);
+    const timetableItemId = isOccurrenceId(draggedTrainId)
+      ? extractPacedTrainIdFromOccurrenceId(draggedTrainId)
+      : draggedTrainId;
+    const draggedTrain = projectPathTrainResult.find((train) => train.id === timetableItemId);
     if (!draggedTrain) return;
 
     const newTrainData = { ...draggedTrain, departureTime: newDepartureTime };
@@ -186,7 +189,7 @@ const SimulationResults = ({
     } else {
       // update in the state
       setProjectPathTrainResult(
-        projectPathTrainResult.map((train) => (train.id === draggedTrainId ? newTrainData : train))
+        projectPathTrainResult.map((train) => (train.id === timetableItemId ? newTrainData : train))
       );
     }
   };

--- a/front/src/applications/operationalStudies/views/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/SimulationResults.tsx
@@ -111,7 +111,7 @@ const SimulationResults = ({
     filteredOperationalPoints,
     setFilteredOperationalPoints,
   } = useGetProjectedTrainOperationalPoints({
-    timetableItemUsedForProjection: projectionData?.trainSchedule,
+    timetableItemUsedForProjection: projectionData?.timetableItem,
     exceptionKeyUsedForProjection: projectionData?.exceptionKeyUsedForProjection,
     infraId,
     timetableId,
@@ -233,7 +233,7 @@ const SimulationResults = ({
                       waypointsPanelData={{
                         filteredWaypoints: filteredOperationalPoints,
                         setFilteredWaypoints: setFilteredOperationalPoints,
-                        projectionPath: projectionData.trainSchedule.path,
+                        projectionPath: projectionData.timetableItem.path,
                         deployedWaypoints: new Set(
                           deployedWaypoints.map(({ waypointId }) => waypointId)
                         ),

--- a/front/src/applications/operationalStudies/views/Study/components/ScenarioCard.tsx
+++ b/front/src/applications/operationalStudies/views/Study/components/ScenarioCard.tsx
@@ -8,7 +8,7 @@ import { useNavigate } from 'react-router-dom';
 import infraLogo from 'assets/pictures/components/tracks.svg';
 import type { ScenarioWithDetails } from 'common/api/osrdEditoastApi';
 import { useOsrdConfActions } from 'common/osrdContext';
-import { updateTrainIdUsedForProjection } from 'reducers/simulationResults';
+import { updateTrainUsedForProjection } from 'reducers/simulationResults';
 import { useAppDispatch } from 'store';
 import { useDateTimeLocale } from 'utils/date';
 
@@ -33,7 +33,7 @@ export default function ScenarioCard({
 
   const handleClick = () => {
     dispatch(updateScenarioID(scenario.id));
-    dispatch(updateTrainIdUsedForProjection(undefined));
+    dispatch(updateTrainUsedForProjection(undefined));
     navigate(`scenarios/${scenario.id}`);
   };
 

--- a/front/src/common/AnchoredMenu.tsx
+++ b/front/src/common/AnchoredMenu.tsx
@@ -82,8 +82,7 @@ const AnchoredMenu = ({
   if (!shouldDisplayMenu) return null;
 
   return createPortal(
-    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
-    <div className="menu-overlay" onClick={handleClick}>
+    <div className="menu-overlay" role="menu" tabIndex={-1} onClick={handleClick}>
       <div
         style={{
           top: menuPosition?.top,

--- a/front/src/modules/simulationResult/components/ManchetteWithSpaceTimeChart/ManchetteWithSpaceTimeChart.tsx
+++ b/front/src/modules/simulationResult/components/ManchetteWithSpaceTimeChart/ManchetteWithSpaceTimeChart.tsx
@@ -42,10 +42,12 @@ import {
 } from 'common/api/osrdEditoastApi';
 import { cutSpaceTimeRect } from 'modules/simulationResult/components/SpaceTimeChart/helpers/utils';
 import { ASPECT_LABELS_COLORS } from 'modules/simulationResult/consts';
+import makeProjectedItems from 'modules/simulationResult/helpers/makeProjectedItems';
 import type {
   AspectLabel,
   LayerRangeData,
   PathOperationalPoint,
+  IndividualTrainProjection,
   TrainSpaceTimeData,
   WaypointsPanelData,
 } from 'modules/simulationResult/types';
@@ -141,7 +143,7 @@ const ManchetteWithSpaceTimeChartWrapper = ({
 
   const [hoveredItem, setHoveredItem] = useState<null | HoveredItem>(null);
   const [draggingState, setDraggingState] = useState<{
-    draggedTrain: TrainSpaceTimeData;
+    draggedTrain: IndividualTrainProjection;
     initialDepartureTime: Date;
   }>();
 
@@ -155,36 +157,7 @@ const ManchetteWithSpaceTimeChartWrapper = ({
     });
 
   const projectedTrains = useMemo(
-    () =>
-      projectPathTrainResult.flatMap<TrainSpaceTimeData>((train) => {
-        if (isTrainScheduleProjection(train)) {
-          return train;
-        }
-        // TODO exceptions : handle added exceptions in issue https://github.com/OpenRailAssociation/osrd/issues/11476
-        const pacedTrainId = extractPacedTrainIdFromOccurrenceId(train.id);
-        const occurrencesCount = getOccurrencesNb(train.paced);
-        const occurrences = [];
-        for (let i = 0; i < occurrencesCount; i += 1) {
-          const occurrenceId = formatPacedTrainIdToIndexedOccurrenceId(pacedTrainId, i);
-          const correspondingException = findExceptionWithOccurrenceId(
-            train.exceptions,
-            occurrenceId
-          );
-          // Disabled occurrences should not be projected
-          if (correspondingException?.disabled) continue;
-
-          const occurrenceStartTime = dayjs(train.departureTime)
-            .add(i * train.paced.interval.ms, 'ms')
-            .toDate();
-          occurrences.push({
-            ...train,
-            id: occurrenceId,
-            name: computeOccurrenceName(train.name, i),
-            departureTime: occurrenceStartTime,
-          });
-        }
-        return occurrences;
-      }),
+    () => makeProjectedItems(projectPathTrainResult),
     [projectPathTrainResult]
   );
 

--- a/front/src/modules/simulationResult/components/ManchetteWithSpaceTimeChart/ManchetteWithSpaceTimeChart.tsx
+++ b/front/src/modules/simulationResult/components/ManchetteWithSpaceTimeChart/ManchetteWithSpaceTimeChart.tsx
@@ -32,7 +32,6 @@ import {
 import { Slider } from '@osrd-project/ui-core';
 import { Sliders, Iterations, ZoomIn } from '@osrd-project/ui-icons';
 import cx from 'classnames';
-import dayjs from 'dayjs';
 import { compact, keyBy, sortBy } from 'lodash';
 
 import upward from 'assets/pictures/workSchedules/ScheduledMaintenanceUp.svg';
@@ -42,6 +41,7 @@ import {
 } from 'common/api/osrdEditoastApi';
 import { cutSpaceTimeRect } from 'modules/simulationResult/components/SpaceTimeChart/helpers/utils';
 import { ASPECT_LABELS_COLORS } from 'modules/simulationResult/consts';
+import makeDraggingState from 'modules/simulationResult/helpers/makeDraggingState';
 import makeProjectedItems from 'modules/simulationResult/helpers/makeProjectedItems';
 import type {
   AspectLabel,
@@ -52,21 +52,13 @@ import type {
   WaypointsPanelData,
 } from 'modules/simulationResult/types';
 import type { TimetableItemWithDetails } from 'modules/timetableItem/components/Timetable/types';
-import computeOccurrenceName from 'modules/timetableItem/helpers/computeOccurrenceName';
-import {
-  findExceptionWithOccurrenceId,
-  getOccurrencesNb,
-} from 'modules/timetableItem/helpers/pacedTrain';
 import type { TimetableItemId, TrainId } from 'reducers/osrdconf/types';
 import { updateSelectedTrainId } from 'reducers/simulationResults';
 import { useAppDispatch } from 'store';
 import {
   isTrainId,
-  formatPacedTrainIdToIndexedOccurrenceId,
   extractPacedTrainIdFromOccurrenceId,
-  isTrainScheduleProjection,
   isOccurrenceId,
-  extractOccurrenceIndexFromOccurrenceId,
   isTrainScheduleId,
   extractEditoastIdFromTrainScheduleId,
   extractEditoastIdFromPacedTrainId,
@@ -408,6 +400,13 @@ const ManchetteWithSpaceTimeChartWrapper = ({
     }));
   });
 
+  /**
+   * mains cases:
+   * 1) a train is already being dragged (we have something in draggingState)
+   * 2) no train is being dragged, but we are hovering a train and clicked it
+   *    => we add the train and initialTime in draggingState
+   * 3) mouse not over a train
+   */
   const onPanOverloaded: SpaceTimeChartProps['onPan'] = async (payload) => {
     const { isPanning } = payload;
 
@@ -417,7 +416,7 @@ const ManchetteWithSpaceTimeChartWrapper = ({
       return;
     }
 
-    // if dragging
+    // 1) a train is already being dragged
     if (draggingState) {
       const { draggedTrain, initialDepartureTime } = draggingState;
 
@@ -427,23 +426,7 @@ const ManchetteWithSpaceTimeChartWrapper = ({
 
       const timeDiff = payload.data.time - payload.initialData.time;
 
-      let newDepartureTime = new Date(initialDepartureTime.getTime() + timeDiff);
-      let draggedTrainId = draggedTrain.id;
-
-      // if the dragged train is an occurrence, we need to update the first occurrence because the others are based on it
-      if (isOccurrenceId(draggedTrain.id)) {
-        const occurrencesIndex = extractOccurrenceIndexFromOccurrenceId(draggedTrain.id);
-        const pacedTrainId = extractPacedTrainIdFromOccurrenceId(draggedTrain.id);
-        const firstOccurrence = projectPathTrainResult.find(
-          ({ id }) => isOccurrenceId(id) && extractPacedTrainIdFromOccurrenceId(id) === pacedTrainId
-        );
-        if (firstOccurrence && 'paced' in firstOccurrence) {
-          newDepartureTime = dayjs(newDepartureTime)
-            .add(occurrencesIndex * -firstOccurrence.paced.interval.ms, 'ms')
-            .toDate();
-          draggedTrainId = firstOccurrence.id;
-        }
-      }
+      const newDepartureTime = new Date(initialDepartureTime.getTime() + timeDiff);
 
       // stop dragging if necessary
       if (!isPanning) {
@@ -451,7 +434,7 @@ const ManchetteWithSpaceTimeChartWrapper = ({
       }
 
       await handleTrainDrag({
-        draggedTrainId,
+        draggedTrainId: draggedTrain.id,
         initialDepartureTime,
         newDepartureTime,
         stopPanning: !isPanning,
@@ -459,7 +442,8 @@ const ManchetteWithSpaceTimeChartWrapper = ({
       return;
     }
 
-    // if not dragging, we check if we should start dragging
+    // 2) no train is being dragged,
+    // we check if we should start dragging
     // Only a mouse hover that starts already over a path should register
     // if we start panning, and then the mouse hovers over the path,
     // it should continue just sliding the chart, not start dragging the train path
@@ -470,20 +454,17 @@ const ManchetteWithSpaceTimeChartWrapper = ({
       hoveredItem &&
       (isSegmentPickingElement(hoveredItem.element) || isPointPickingElement(hoveredItem.element))
     ) {
-      const hoveredTrainId = hoveredItem.element.pathId;
-      if (!isTrainId(hoveredTrainId)) return;
-      const train = projectedTrains.find((projectedTrain) => projectedTrain.id === hoveredTrainId);
-      if (train) {
-        setDraggingState({
-          draggedTrain: train,
-          initialDepartureTime: train.departureTime,
-        });
-      } else {
-        console.error(`No train found with id ${hoveredTrainId}`);
+      const newDraggingState = makeDraggingState(
+        hoveredItem,
+        projectedTrains,
+        projectPathTrainResult
+      );
+      if (newDraggingState) {
+        setDraggingState(newDraggingState);
       }
     }
 
-    // if no hovered train, we pan normally
+    // 3) if no hovered train, we pan normally
     spaceTimeChartProps.onPan?.(payload);
 
     if (isPanning !== previousPanning) {

--- a/front/src/modules/simulationResult/components/ManchetteWithSpaceTimeChart/ManchetteWithSpaceTimeChart.tsx
+++ b/front/src/modules/simulationResult/components/ManchetteWithSpaceTimeChart/ManchetteWithSpaceTimeChart.tsx
@@ -447,7 +447,10 @@ const ManchetteWithSpaceTimeChartWrapper = ({
     // if dragging
     if (draggingState) {
       const { draggedTrain, initialDepartureTime } = draggingState;
-      dispatch(updateSelectedTrainId(draggedTrain.id));
+
+      if (draggedTrain.id !== selectedTrainId) {
+        dispatch(updateSelectedTrainId(draggedTrain.id));
+      }
 
       const timeDiff = payload.data.time - payload.initialData.time;
 

--- a/front/src/modules/simulationResult/components/ManchetteWithSpaceTimeChart/ManchetteWithSpaceTimeChart.tsx
+++ b/front/src/modules/simulationResult/components/ManchetteWithSpaceTimeChart/ManchetteWithSpaceTimeChart.tsx
@@ -47,9 +47,9 @@ import type {
   AspectLabel,
   LayerRangeData,
   PathOperationalPoint,
-  IndividualTrainProjection,
   TrainSpaceTimeData,
   WaypointsPanelData,
+  DraggingState,
 } from 'modules/simulationResult/types';
 import type { TimetableItemWithDetails } from 'modules/timetableItem/components/Timetable/types';
 import type { TimetableItemId, TrainId } from 'reducers/osrdconf/types';
@@ -134,10 +134,7 @@ const ManchetteWithSpaceTimeChartWrapper = ({
   const activeWaypointRef = useRef<HTMLDivElement>(null);
 
   const [hoveredItem, setHoveredItem] = useState<null | HoveredItem>(null);
-  const [draggingState, setDraggingState] = useState<{
-    draggedTrain: IndividualTrainProjection;
-    initialDepartureTime: Date;
-  }>();
+  const [draggingState, setDraggingState] = useState<DraggingState>();
 
   const spaceTimeChartRef = useRef<HTMLDivElement>(null);
 
@@ -454,11 +451,7 @@ const ManchetteWithSpaceTimeChartWrapper = ({
       hoveredItem &&
       (isSegmentPickingElement(hoveredItem.element) || isPointPickingElement(hoveredItem.element))
     ) {
-      const newDraggingState = makeDraggingState(
-        hoveredItem,
-        projectedTrains,
-        projectPathTrainResult
-      );
+      const newDraggingState = makeDraggingState(hoveredItem, projectedTrains);
       if (newDraggingState) {
         setDraggingState(newDraggingState);
       }

--- a/front/src/modules/simulationResult/components/SpaceTimeChart/useGetProjectedTrainOperationalPoints.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChart/useGetProjectedTrainOperationalPoints.ts
@@ -22,10 +22,12 @@ const useGetProjectedTrainOperationalPoints = ({
   infraId,
   timetableId,
   timetableItemUsedForProjection,
+  exceptionKeyUsedForProjection,
 }: {
   infraId: number;
   timetableId: number | undefined;
   timetableItemUsedForProjection?: TimetableItem;
+  exceptionKeyUsedForProjection?: string;
 }) => {
   const { t } = useTranslation('operational-studies');
   const projectionType = useSelector(getProjectionType);
@@ -52,8 +54,10 @@ const useGetProjectedTrainOperationalPoints = ({
           infraId,
         }).unwrap();
       } else {
+        // paced train
         path = await getPacedTrainPath({
           id: extractEditoastIdFromPacedTrainId(trainIdUsedForProjection),
+          exceptionKey: exceptionKeyUsedForProjection,
           infraId,
         }).unwrap();
       }
@@ -115,7 +119,7 @@ const useGetProjectedTrainOperationalPoints = ({
     };
 
     getOperationalPoints();
-  }, [timetableItemUsedForProjection, infraId, t, projectionType]);
+  }, [timetableItemUsedForProjection, exceptionKeyUsedForProjection, infraId, t, projectionType]);
 
   return { operationalPoints, filteredOperationalPoints, setFilteredOperationalPoints };
 };

--- a/front/src/modules/simulationResult/components/SpaceTimeChart/useLazyProjectTrains.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChart/useLazyProjectTrains.ts
@@ -3,7 +3,7 @@ import { useEffect, useState, useCallback, useRef } from 'react';
 import { useSelector } from 'react-redux';
 
 import TrainOpProjectionLazyLoader from 'applications/operationalStudies/helpers/TrainOpProjectionLazyLoader';
-import type { ProjectionResult } from 'applications/operationalStudies/helpers/TrainProjectionLazyLoaderAbstract';
+import type { RawProjectionResult } from 'applications/operationalStudies/helpers/TrainProjectionLazyLoaderAbstract';
 import type TrainProjectionLazyLoaderAbstract from 'applications/operationalStudies/helpers/TrainProjectionLazyLoaderAbstract';
 import TrainTrackProjectionLazyLoader from 'applications/operationalStudies/helpers/TrainTrackProjectionLazyLoader';
 import upsertNewProjectedTrains from 'applications/operationalStudies/helpers/upsertNewProjectedTrains';
@@ -34,7 +34,7 @@ const useLazyProjectTrains = ({
   >(new Map());
   const projectionType = useSelector(getProjectionType);
 
-  const onProgress = useCallback((results: Map<TimetableItemId, ProjectionResult>) => {
+  const onProgress = useCallback((results: Map<TimetableItemId, RawProjectionResult>) => {
     setProjectedTrainsById((prev) =>
       upsertNewProjectedTrains(prev, results, timetableItemsByIdRef.current)
     );

--- a/front/src/modules/simulationResult/components/SpaceTimeChart/useTrackOccupancy.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChart/useTrackOccupancy.ts
@@ -23,8 +23,8 @@ import {
   osrdEditoastApi,
   type PathItemLocation,
 } from 'common/api/osrdEditoastApi';
-import type { TrainId } from 'reducers/osrdconf/types';
-import { extractEditoastIdFromTrainId } from 'utils/trainId';
+import type { TimetableItemId, TrainId } from 'reducers/osrdconf/types';
+import { extractEditoastIdFromTimeTableItemId, extractEditoastIdFromTrainId } from 'utils/trainId';
 
 import type { PathOperationalPoint, TrainSpaceTimeData } from '../../types';
 import { batchFetchTrackOccupancy } from './helpers/utils';
@@ -121,7 +121,7 @@ const useTrackOccupancy = ({
   const [postInfraByInfraIdMatchOperationalPoints] =
     osrdEditoastApi.endpoints.postInfraByInfraIdMatchOperationalPoints.useLazyQuery();
   const trainsDict = useMemo(
-    () => keyBy(trains, ({ id }) => extractEditoastIdFromTrainId(id)),
+    () => keyBy(trains, ({ id }) => extractEditoastIdFromTimeTableItemId(id)),
     [trains]
   );
 
@@ -419,7 +419,7 @@ const useTrackOccupancy = ({
       return;
 
     const previousTrainsDict = keyBy(previousTrains, (train) =>
-      extractEditoastIdFromTrainId(train.id)
+      extractEditoastIdFromTimeTableItemId(train.id)
     );
 
     const addedTrainIDs = new Set<number>();
@@ -427,7 +427,7 @@ const useTrackOccupancy = ({
     const modifiedTrainIDs = new Set<number>();
 
     trains.forEach((train) => {
-      const id = extractEditoastIdFromTrainId(train.id);
+      const id = extractEditoastIdFromTimeTableItemId(train.id);
       const previousTrain = previousTrainsDict[id];
       if (!previousTrain) addedTrainIDs.add(id);
       else if (!isEqual(train, previousTrain) && !draggedTrains.current.has(train.id)) {
@@ -446,7 +446,7 @@ const useTrackOccupancy = ({
     });
 
     previousTrains.forEach((train) => {
-      const id = extractEditoastIdFromTrainId(train.id);
+      const id = extractEditoastIdFromTimeTableItemId(train.id);
       if (!trainsDict[id]) {
         removedTrainIDs.add(id);
         // Remove cached station labels for this train:
@@ -512,7 +512,7 @@ const useTrackOccupancy = ({
     const fetchOperationalPoints = async () => {
       try {
         const requests: {
-          trainId: TrainId;
+          timetableItemId: TimetableItemId;
           side: Side;
           opReference: OperationalPointReference;
         }[] = [];
@@ -534,13 +534,13 @@ const useTrackOccupancy = ({
             } else if ('operational_point' in itemLocation) {
               requests.push({
                 side,
-                trainId: train.id,
+                timetableItemId: train.id,
                 opReference: { operational_point: itemLocation.operational_point },
               });
             } else if ('trigram' in itemLocation) {
               requests.push({
                 side,
-                trainId: train.id,
+                timetableItemId: train.id,
                 opReference: {
                   trigram: itemLocation.trigram,
                   secondary_code: itemLocation.secondary_code,
@@ -549,7 +549,7 @@ const useTrackOccupancy = ({
             } else if ('uic' in itemLocation) {
               requests.push({
                 side,
-                trainId: train.id,
+                timetableItemId: train.id,
                 opReference: { uic: itemLocation.uic, secondary_code: itemLocation.secondary_code },
               });
             }
@@ -565,10 +565,10 @@ const useTrackOccupancy = ({
           },
         }).unwrap();
 
-        requests.forEach(({ side, trainId }, i) => {
+        requests.forEach(({ side, timetableItemId }, i) => {
           const op = data.related_operational_points[i].at(0);
-          trainsStationLabels[trainId] = {
-            ...trainsStationLabels[trainId],
+          trainsStationLabels[timetableItemId] = {
+            ...trainsStationLabels[timetableItemId],
             [side]: {
               type: 'label',
               label: op?.extensions?.sncf?.trigram || op?.extensions?.identifier?.name || undefined,

--- a/front/src/modules/simulationResult/helpers/__tests__/makeDraggingState.spec.ts
+++ b/front/src/modules/simulationResult/helpers/__tests__/makeDraggingState.spec.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect } from 'vitest';
+
+import type { OccurrenceId, TrainScheduleId } from 'reducers/osrdconf/types';
+
+import makeDraggingState from '../makeDraggingState';
+
+describe('makeDraggingState', () => {
+  describe('train schedule', () => {
+    const projectedTrains = [
+      {
+        name: 'GE LYD',
+        departureTime: new Date('2025-07-25T11:19:04.820Z'),
+        spaceTimeCurves: [
+          {
+            positions: [0, 2408, 8726],
+            times: [0, 2000, 4000],
+          },
+        ],
+        signalUpdates: [],
+        id: 'trainschedule_8383' as TrainScheduleId,
+        originPathItemLocation: {
+          id: '2de0a9f4-d7fd-486c-8fa6-e23c85cc5ecb',
+          deleted: false,
+          uic: 1,
+          secondary_code: 'BV',
+          track_reference: null,
+        },
+        destinationPathItemLocation: {
+          id: 'c95dd420-de77-4047-be7b-21770d973283',
+          deleted: false,
+          uic: 2,
+          secondary_code: 'BV',
+          track_reference: null,
+        },
+      },
+    ];
+    it('should return the currently hovered train schedule', () => {
+      const hoveredItem = {
+        layer: 'paths',
+        element: {
+          type: 'segment',
+          pathId: 'trainschedule_8383',
+          from: {
+            x: 600.121422635069,
+            y: 164.26262468678837,
+          },
+          to: {
+            x: 601.0516031411173,
+            y: 166.68650731525275,
+          },
+        },
+      } as const;
+
+      expect(makeDraggingState(hoveredItem, projectedTrains)).toEqual({
+        draggedTrain: projectedTrains[0],
+        initialDepartureTime: projectedTrains[0].departureTime,
+      });
+    });
+    it('should handle train id no found', () => {
+      const hoveredItem = {
+        layer: 'paths',
+        element: {
+          type: 'segment',
+          pathId: 'trainschedule_6666666',
+          from: {
+            x: 600.121422635069,
+            y: 164.26262468678837,
+          },
+          to: {
+            x: 601.0516031411173,
+            y: 166.68650731525275,
+          },
+        },
+      } as const;
+      expect(makeDraggingState(hoveredItem, projectedTrains)).toEqual(null);
+    });
+    it('should handle invalid train id', () => {
+      const hoveredItem = {
+        layer: 'paths',
+        element: {
+          type: 'segment',
+          pathId: 'invalid_train_id',
+          from: {
+            x: 600.121422635069,
+            y: 164.26262468678837,
+          },
+          to: {
+            x: 601.0516031411173,
+            y: 166.68650731525275,
+          },
+        },
+      } as const;
+      expect(() => makeDraggingState(hoveredItem, projectedTrains)).toThrow(
+        'hovered train id should be a train schedule id or an occurrence i'
+      );
+    });
+  });
+  describe('paced train', () => {
+    describe('1 ADDED start time exception and 2 MODIFIED start time exceptions', () => {
+      // we are dragging a normal occurrence, it should modify the paced train start time in projectPathTrainResults
+      // (in SimulationResults where the state is held)
+      // => we use the occurrence ID and the paced train start time as initialDepartureTime
+      const projectedTrains = [
+        // 1 train schedule
+        {
+          name: 'GE LYD',
+          departureTime: new Date('2025-07-25T11:19:04.820Z'),
+          spaceTimeCurves: [
+            {
+              positions: [0, 2408, 8726],
+              times: [0, 2000, 4000],
+            },
+          ],
+          signalUpdates: [],
+          id: 'trainschedule_8383' as TrainScheduleId,
+          originPathItemLocation: {
+            id: '2de0a9f4-d7fd-486c-8fa6-e23c85cc5ecb',
+            deleted: false,
+            uic: 1,
+            secondary_code: 'BV',
+            track_reference: null,
+          },
+          destinationPathItemLocation: {
+            id: 'c95dd420-de77-4047-be7b-21770d973283',
+            deleted: false,
+            uic: 2,
+            secondary_code: 'BV',
+            track_reference: null,
+          },
+        },
+        // paced train
+        {
+          departureTime: new Date('2025-07-25T03:28:57.188Z'),
+          spaceTimeCurves: [
+            {
+              positions: [0, 2408, 8726],
+              times: [0, 2000, 4000],
+            },
+          ],
+          signalUpdates: [],
+          id: 'indexedoccurrence_2563_0' as OccurrenceId,
+          name: 'a 1',
+          isStartTimeException: false,
+          pacedTrainDepartureTime: new Date('2025-07-25T03:54:30.922Z'),
+        },
+        {
+          departureTime: new Date('2025-07-25T04:28:57.188Z'),
+          spaceTimeCurves: [
+            {
+              positions: [0, 2408, 8726],
+              times: [0, 2000, 4000],
+            },
+          ],
+          signalUpdates: [],
+          id: 'indexedoccurrence_2563_1' as OccurrenceId,
+          name: 'a 3',
+          isStartTimeException: false,
+          pacedTrainDepartureTime: new Date('2025-07-25T03:54:30.922Z'),
+        },
+        {
+          departureTime: new Date('2025-07-25T06:15:00.000Z'),
+          spaceTimeCurves: [
+            {
+              positions: [0, 2408, 8726],
+              times: [0, 2000, 4000],
+            },
+          ],
+          signalUpdates: [],
+          id: 'indexedoccurrence_2563_2' as OccurrenceId,
+          name: 'a 5',
+          isStartTimeException: true,
+          pacedTrainDepartureTime: new Date('2025-07-25T03:54:30.922Z'),
+        },
+        {
+          departureTime: new Date('2025-07-25T07:20:10.000Z'),
+          spaceTimeCurves: [
+            {
+              positions: [0, 2408, 8726],
+              times: [0, 2000, 4000],
+            },
+          ],
+          signalUpdates: [],
+          id: 'indexedoccurrence_2563_3' as OccurrenceId,
+          name: 'a 7',
+          isStartTimeException: true,
+          pacedTrainDepartureTime: new Date('2025-07-25T03:54:30.922Z'),
+        },
+        {
+          name: 'a/+',
+          departureTime: new Date('2025-07-25T10:00:00.000Z'),
+          spaceTimeCurves: [
+            {
+              positions: [0, 2408, 8726],
+              times: [0, 2000, 4000],
+            },
+          ],
+          signalUpdates: [],
+          id: 'exception_2563_ed44851d-eed0-47e9-81cb-799e58e569d5' as OccurrenceId,
+          isStartTimeException: true,
+          pacedTrainDepartureTime: new Date('2025-07-25T03:54:30.922Z'),
+        },
+      ];
+      it('should return the hovered occurrence and paced train startTime', () => {
+        const hoveredItem = {
+          layer: 'paths',
+          element: {
+            type: 'segment',
+            pathId: 'indexedoccurrence_2563_1',
+          },
+        } as const;
+        expect(makeDraggingState(hoveredItem, projectedTrains)).toEqual({
+          draggedTrain: projectedTrains[2],
+          initialDepartureTime: new Date('2025-07-25T03:54:30.922Z'),
+        });
+      });
+      it('should return null when we try to drag a MODIFIED start time exception', () => {
+        const hoveredItem = {
+          layer: 'paths',
+          element: {
+            type: 'segment',
+            pathId: 'indexedoccurrence_2563_3',
+          },
+        } as const;
+        expect(makeDraggingState(hoveredItem, projectedTrains)).toEqual(null);
+      });
+      it('should return null when we try to drag an ADDED start time exception', () => {
+        const hoveredItem = {
+          layer: 'paths',
+          element: {
+            type: 'segment',
+            pathId: 'exception_2563_ed44851d-eed0-47e9-81cb-799e58e569d5',
+          },
+        } as const;
+        expect(makeDraggingState(hoveredItem, projectedTrains)).toEqual(null);
+      });
+    });
+  });
+});

--- a/front/src/modules/simulationResult/helpers/__tests__/makeProjectedItems.spec.ts
+++ b/front/src/modules/simulationResult/helpers/__tests__/makeProjectedItems.spec.ts
@@ -1,0 +1,240 @@
+import dayjs from 'dayjs';
+import { describe, expect, test } from 'vitest';
+
+import type { PacedTrainProjection } from 'modules/simulationResult/types';
+import type { AddedExceptionId, OccurrenceId, PacedTrainId } from 'reducers/osrdconf/types';
+import { Duration } from 'utils/duration';
+
+import makeProjectedItems from '../makeProjectedItems';
+
+describe('makeProjectedItems', () => {
+  describe('paced train with indexed 2 occurrences, 2nd’s is a path exception', () => {
+    const projectPathTrainResult = [
+      {
+        name: 'GE LYD',
+        departureTime: new Date('2025-07-09T05:30:00.000Z'),
+        spaceTimeCurves: [
+          {
+            positions: [0, 2408],
+            times: [0, 2000],
+          },
+        ],
+        signalUpdates: [
+          {
+            signal_id: 'c40477be-4964-11e4-9bff-012064e0362d',
+            signaling_system: 'BAL',
+            time_start: 0,
+            time_end: 28510,
+            position_start: 206000,
+            position_end: 512000,
+            color: -16711936,
+            blinking: false,
+            aspect_label: 'VL',
+          },
+        ],
+        id: 'paced_2562' as PacedTrainId,
+        paced: {
+          timeWindow: Duration.parse('PT2H'),
+          interval: Duration.parse('PT1H'),
+        },
+        exceptions: [
+          {
+            key: '9f11f34a-8ece-42bc-ac3f-45a8ab19f5ec',
+            occurrence_index: 1,
+            disabled: false,
+            train_name: {
+              value: 'GE brg 3',
+            },
+            path_and_schedule: {
+              path: [
+                {
+                  id: 'a496f3a6-4eea-45f8-a83c-5472d9adcd6d',
+                  deleted: false,
+                  uic: 11,
+                  secondary_code: 'BV',
+                  track_reference: null,
+                },
+                {
+                  id: 'e18f50f3-2b40-451e-9726-e4dd29459bf0',
+                  deleted: false,
+                  uic: 12,
+                  secondary_code: 'BV',
+                  track_reference: null,
+                },
+              ],
+              schedule: [
+                {
+                  at: 'e18f50f3-2b40-451e-9726-e4dd29459bf0',
+                  arrival: null,
+                  stop_for: 'P0D',
+                  reception_signal: 'OPEN',
+                  locked: false,
+                },
+              ],
+              margins: {
+                boundaries: [],
+                values: ['0%'],
+              },
+              power_restrictions: [],
+            },
+          },
+        ],
+        exceptionProjections: [
+          {
+            name: 'GE brg 3',
+            departureTime: new Date('2025-07-09T06:30:00.000Z'),
+            spaceTimeCurves: [
+              {
+                positions: [0, 3600],
+                times: [0, 2000],
+              },
+              {
+                positions: [36531000, 36562976],
+                times: [2444760, 2446849],
+              },
+            ],
+            signalUpdates: [],
+            id: 'indexedoccurrence_2562_1' as OccurrenceId,
+            pacedTrainDepartureTime: new Date('2025-07-09T05:30:00.000Z'),
+          },
+        ],
+      },
+    ] as PacedTrainProjection[];
+    test('first occurrence should use paced train projection, second occurrence should use its own projection', () => {
+      const pacedTrain = projectPathTrainResult[0];
+
+      const result = makeProjectedItems(projectPathTrainResult);
+
+      expect(result[0]).toEqual({
+        name: 'GE LYD 1',
+        departureTime: pacedTrain.departureTime,
+        spaceTimeCurves: pacedTrain.spaceTimeCurves,
+        signalUpdates: pacedTrain.signalUpdates,
+        id: 'indexedoccurrence_2562_0',
+        isStartTimeException: false,
+        pacedTrainDepartureTime: new Date('2025-07-09T05:30:00.000Z'),
+      });
+      expect(result[1]).toEqual({
+        ...projectPathTrainResult[0].exceptionProjections[0],
+        isStartTimeException: false,
+        pacedTrainDepartureTime: new Date('2025-07-09T05:30:00.000Z'),
+      });
+    });
+  });
+  describe('paced train with 1 ADDED path exception', () => {
+    const projectPathTrainResult = [
+      {
+        name: 'auie',
+        departureTime: new Date('2025-07-30T09:36:52.790Z'),
+        spaceTimeCurves: [
+          {
+            positions: [0, 2408, 8726, 17630, 40899],
+            times: [0, 2000, 4000, 6000, 10000],
+          },
+        ],
+        signalUpdates: [],
+        id: 'paced_2564' as PacedTrainId,
+        paced: {
+          timeWindow: Duration.parse('PT3H'),
+          interval: Duration.parse('PT1H'),
+        },
+        exceptions: [
+          {
+            key: 'a057a742-ec2f-401e-adb1-558017f20d74',
+            path_and_schedule: {
+              margins: {
+                boundaries: [],
+                values: ['0%'],
+              },
+              path: [
+                {
+                  id: '3e6c78c6-89a9-462f-a0b3-1e4253cb6386',
+                  uic: 11,
+                  secondary_code: 'BV',
+                  deleted: false,
+                },
+                {
+                  id: '00fd1b82-32ca-43fd-a46e-24b5bc6f0fd3',
+                  uic: 14,
+                  secondary_code: 'BV',
+                  deleted: false,
+                },
+              ],
+              power_restrictions: [],
+              schedule: [
+                {
+                  at: '00fd1b82-32ca-43fd-a46e-24b5bc6f0fd3',
+                  stop_for: 'P0D',
+                },
+              ],
+            },
+            start_time: {
+              value: '2025-07-30T14:00:00.000Z',
+            },
+            train_name: {
+              value: 'GE VPE +',
+            },
+          },
+        ],
+        exceptionProjections: [
+          {
+            name: 'GE VPE +',
+            departureTime: new Date('2025-07-30T14:00:00.000Z'),
+            spaceTimeCurves: [
+              {
+                positions: [0, 2408, 8726, 17630, 28475],
+                times: [0, 2000, 4000, 6000, 8000],
+              },
+              {
+                positions: [3747000, 4062674, 4370040, 5094361, 5568162],
+                times: [276550, 292849, 308849, 348849, 374849],
+              },
+            ],
+            signalUpdates: [],
+            id: 'exception_2564_a057a742-ec2f-401e-adb1-558017f20d74' as AddedExceptionId,
+            pacedTrainDepartureTime: new Date('2025-07-30T09:36:52.790Z'),
+          },
+        ],
+      },
+    ] as PacedTrainProjection[];
+    test('added path exception should use its own projection', () => {
+      const pacedTrain = projectPathTrainResult[0];
+
+      const result = makeProjectedItems(projectPathTrainResult);
+
+      expect(result.length).toBe(4);
+      expect(result[0]).toEqual({
+        name: 'auie 1',
+        departureTime: pacedTrain.departureTime,
+        spaceTimeCurves: pacedTrain.spaceTimeCurves,
+        signalUpdates: pacedTrain.signalUpdates,
+        id: 'indexedoccurrence_2564_0',
+        isStartTimeException: false,
+        pacedTrainDepartureTime: new Date('2025-07-30T09:36:52.790Z'),
+      });
+      expect(result[1]).toEqual({
+        name: 'auie 3',
+        departureTime: dayjs(pacedTrain.departureTime).add(1, 'hour').toDate(),
+        spaceTimeCurves: pacedTrain.spaceTimeCurves,
+        signalUpdates: pacedTrain.signalUpdates,
+        id: 'indexedoccurrence_2564_1',
+        isStartTimeException: false,
+        pacedTrainDepartureTime: new Date('2025-07-30T09:36:52.790Z'),
+      });
+      expect(result[2]).toEqual({
+        name: 'auie 5',
+        departureTime: dayjs(pacedTrain.departureTime).add(2, 'hour').toDate(),
+        spaceTimeCurves: pacedTrain.spaceTimeCurves,
+        signalUpdates: pacedTrain.signalUpdates,
+        id: 'indexedoccurrence_2564_2',
+        isStartTimeException: false,
+        pacedTrainDepartureTime: new Date('2025-07-30T09:36:52.790Z'),
+      });
+      expect(result[3]).toEqual({
+        ...projectPathTrainResult[0].exceptionProjections[0],
+        isStartTimeException: true,
+        pacedTrainDepartureTime: new Date('2025-07-30T09:36:52.790Z'),
+      });
+    });
+  });
+});

--- a/front/src/modules/simulationResult/helpers/makeDraggingState.ts
+++ b/front/src/modules/simulationResult/helpers/makeDraggingState.ts
@@ -1,0 +1,48 @@
+import {
+  isPointPickingElement,
+  isSegmentPickingElement,
+  type HoveredItem,
+} from '@osrd-project/ui-charts';
+
+import { isOccurrenceProjection, isTrainId } from 'utils/trainId';
+
+import type { DraggingState, IndividualTrainProjection } from '../types';
+
+export default function makeDraggingState(
+  hoveredItem: HoveredItem,
+  projectedTrains: IndividualTrainProjection[]
+): DraggingState | null {
+  if (
+    !isSegmentPickingElement(hoveredItem.element) &&
+    !isPointPickingElement(hoveredItem.element)
+  ) {
+    throw new Error('wrong hoveredItem type');
+  }
+
+  const hoveredTrainId = hoveredItem.element.pathId;
+  if (!isTrainId(hoveredTrainId)) {
+    throw new Error('hovered train id should be a train schedule id or an occurrence id');
+  }
+  const individualTrainProjection = projectedTrains.find(
+    (projectedTrain) => projectedTrain.id === hoveredTrainId
+  );
+
+  if (!individualTrainProjection) {
+    console.error(`No train found with id ${hoveredTrainId}`);
+    return null;
+  }
+  if (isOccurrenceProjection(individualTrainProjection)) {
+    if (individualTrainProjection && individualTrainProjection.isStartTimeException) {
+      return null;
+    }
+    return {
+      draggedTrain: individualTrainProjection,
+      initialDepartureTime: individualTrainProjection.pacedTrainDepartureTime,
+    };
+  }
+
+  return {
+    draggedTrain: individualTrainProjection,
+    initialDepartureTime: individualTrainProjection.departureTime,
+  };
+}

--- a/front/src/modules/simulationResult/helpers/makeProjectedItems.ts
+++ b/front/src/modules/simulationResult/helpers/makeProjectedItems.ts
@@ -1,0 +1,109 @@
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+import { pick } from 'lodash';
+
+import type {
+  IndividualTrainProjection,
+  OccurrenceProjection,
+  TrainSpaceTimeData,
+} from 'modules/simulationResult/types';
+import { makeOccurrenceTime } from 'modules/timetableItem/components/Timetable/utils';
+import computeOccurrenceName from 'modules/timetableItem/helpers/computeOccurrenceName';
+import {
+  findExceptionWithOccurrenceId,
+  getOccurrencesNb,
+} from 'modules/timetableItem/helpers/pacedTrain';
+import {
+  formatPacedTrainIdToIndexedOccurrenceId,
+  isTrainScheduleProjection,
+  formatEditoastIdToExceptionId,
+  extractEditoastIdFromPacedTrainId,
+  extractOccurrenceIndexFromOccurrenceId,
+  isIndexedOccurrenceId,
+  extractExceptionIdFromOccurrenceId,
+  isAddedExceptionId,
+} from 'utils/trainId';
+
+/**
+ * Turns trainSpaceTimeData (trainSchedules + pacedTrains) into individual train projection.
+ * Extracts everything into one flat array.
+ */
+export default function makeProjectedItems(projectPathTrainResult: TrainSpaceTimeData[]) {
+  return projectPathTrainResult.flatMap<IndividualTrainProjection>((projectedItem) => {
+    if (isTrainScheduleProjection(projectedItem)) {
+      return projectedItem;
+    }
+    // ==== paced train ====
+    const pacedTrainId = extractEditoastIdFromPacedTrainId(projectedItem.id);
+    const occurrences: OccurrenceProjection[] = [];
+    // ========= indexed occurrences =========
+    const occurrencesCount = getOccurrencesNb(projectedItem.paced);
+    for (let i = 0; i < occurrencesCount; i += 1) {
+      const occurrenceId = formatPacedTrainIdToIndexedOccurrenceId(projectedItem.id, i);
+      const correspondingException = findExceptionWithOccurrenceId(
+        projectedItem.exceptions,
+        occurrenceId
+      );
+      // Disabled occurrences should not be projected
+      if (correspondingException?.disabled) continue;
+
+      const departureTime = correspondingException?.start_time
+        ? new Date(correspondingException.start_time.value)
+        : makeOccurrenceTime(projectedItem.departureTime, projectedItem.paced.interval, i);
+      const exceptionProjection = projectedItem.exceptionProjections.find((proj) => {
+        if (!isIndexedOccurrenceId(proj.id)) {
+          return false;
+        }
+        return (
+          extractOccurrenceIndexFromOccurrenceId(proj.id) ===
+          correspondingException?.occurrence_index
+        );
+      });
+      const name = correspondingException?.train_name
+        ? correspondingException.train_name.value
+        : computeOccurrenceName(projectedItem.name, i);
+
+      const isStartTimeException = Boolean(correspondingException?.start_time);
+      const pacedTrainData = pick(projectedItem, [
+        'departureTime',
+        'spaceTimeCurves',
+        'signalUpdates',
+      ]);
+      occurrences.push({
+        ...(exceptionProjection ?? pacedTrainData),
+        id: occurrenceId,
+        name,
+        departureTime,
+        isStartTimeException,
+        pacedTrainDepartureTime: projectedItem.departureTime,
+      });
+    }
+
+    // ========= added exceptions =========
+    for (const exception of projectedItem.exceptions) {
+      if (Number.isInteger(exception.occurrence_index)) {
+        // already done in the indexed occurrences loop above
+        continue;
+      }
+      const id = formatEditoastIdToExceptionId({ pacedTrainId, exceptionId: exception.key });
+      const name = exception.train_name ? exception.train_name.value : `${projectedItem.name}/+`;
+      const exceptionProjection = projectedItem.exceptionProjections.find(
+        (ex) =>
+          isAddedExceptionId(ex.id) && extractExceptionIdFromOccurrenceId(ex.id) === exception.key
+      );
+      if (!exception.start_time) {
+        throw new Error('added exception should have a start time');
+      }
+      const departureTime = new Date(exception.start_time.value);
+
+      occurrences.push({
+        ...(exceptionProjection ?? projectedItem),
+        id,
+        name,
+        departureTime,
+        isStartTimeException: true,
+        pacedTrainDepartureTime: projectedItem.departureTime,
+      });
+    }
+    return occurrences;
+  });
+}

--- a/front/src/modules/simulationResult/types.ts
+++ b/front/src/modules/simulationResult/types.ts
@@ -130,3 +130,8 @@ export type AspectLabel =
   | '160A'
   | '080A'
   | '000';
+
+export type DraggingState = {
+  draggedTrain: IndividualTrainProjection;
+  initialDepartureTime: Date;
+};

--- a/front/src/modules/simulationResult/types.ts
+++ b/front/src/modules/simulationResult/types.ts
@@ -59,6 +59,7 @@ export type SpeedSpaceChartData = {
 
 export type ProjectionData = {
   trainSchedule: TimetableItem;
+  exceptionKeyUsedForProjection?: string;
   projectedTrains: TrainSpaceTimeData[];
   path: PathfindingResultSuccess;
   geometry: PathProperties['geometry'];

--- a/front/src/modules/simulationResult/types.ts
+++ b/front/src/modules/simulationResult/types.ts
@@ -13,7 +13,12 @@ import type {
   TrainSchedule,
 } from 'common/api/osrdEditoastApi';
 import type { PacedTrainWithDetails } from 'modules/timetableItem/components/Timetable/types';
-import type { OccurrenceId, TimetableItem, TrainScheduleId } from 'reducers/osrdconf/types';
+import type {
+  OccurrenceId,
+  PacedTrainId,
+  TimetableItem,
+  TrainScheduleId,
+} from 'reducers/osrdconf/types';
 import type { ArrayElement } from 'utils/types';
 
 // This alias refers to an operational point, in the context of a given path, from Edistoast:
@@ -30,11 +35,8 @@ export type PathOperationalPoint = Omit<EditoastPathOperationalPoint, 'id'> & {
 };
 
 // Space Time Chart
-/**
- * Properties signal_updates time_end and time_start are in seconds taking count of the departure time
- */
-// TODO: reuse the type from osrd-ui/ui-manchette
-export type TrainSpaceTimeData = {
+
+export type BaseTrainProjection = {
   name: string;
   spaceTimeCurves: {
     positions: number[];
@@ -42,10 +44,38 @@ export type TrainSpaceTimeData = {
   }[];
   departureTime: Date;
   signalUpdates: SignalUpdate[];
-} & (
-  | { id: TrainScheduleId }
-  | { id: OccurrenceId; paced: PacedTrainWithDetails['paced']; exceptions: PacedTrainException[] }
-);
+};
+
+export type TrainScheduleProjection = BaseTrainProjection & { id: TrainScheduleId };
+
+/**
+ * contains the paced train model projection, which can be used by the occurrences
+ * and the possible occurrences projections if they are path_and_schedule exceptions
+ */
+export type PacedTrainProjection = BaseTrainProjection & {
+  id: PacedTrainId;
+  paced: PacedTrainWithDetails['paced'];
+  exceptions: PacedTrainException[];
+  exceptionProjections: OccurrenceProjection[];
+};
+
+export type OccurrenceProjection = BaseTrainProjection & {
+  id: OccurrenceId;
+  isStartTimeException?: boolean;
+  pacedTrainDepartureTime: Date;
+};
+
+/**
+ * projection data of a train schedule or a paced train with its exceptions projection
+ * Properties signal_updates time_end and time_start are in seconds taking count of the departure time
+ */
+// TODO: reuse the type from osrd-ui/ui-manchette
+export type TrainSpaceTimeData = TrainScheduleProjection | PacedTrainProjection;
+
+/**
+ * Contains an individual train, either a trainschedule or an occurrences (not a paced train, which is a group of trains)
+ */
+export type IndividualTrainProjection = TrainScheduleProjection | OccurrenceProjection;
 
 // Speed Space Chart
 export type SpeedLimitTagValue = ArrayElement<SimulationResponseSuccess['mrsp']['values']>;
@@ -58,7 +88,7 @@ export type SpeedSpaceChartData = {
 };
 
 export type ProjectionData = {
-  trainSchedule: TimetableItem;
+  timetableItem: TimetableItem;
   exceptionKeyUsedForProjection?: string;
   projectedTrains: TrainSpaceTimeData[];
   path: PathfindingResultSuccess;

--- a/front/src/modules/timetableItem/components/Timetable/PacedTrain/OccurrenceItem.tsx
+++ b/front/src/modules/timetableItem/components/Timetable/PacedTrain/OccurrenceItem.tsx
@@ -4,6 +4,7 @@ import {
   Clock,
   Flame,
   KebabHorizontal,
+  Manchette,
   Moon,
   Pencil,
   Play,
@@ -62,6 +63,7 @@ type OccurrenceItemProps = {
   occurrenceActions: ReturnType<typeof useOccurrenceActions>;
   subCategories?: SubCategory[];
   pacedTrainId: PacedTrainId;
+  showProjectionIcon?: boolean;
 };
 
 const OccurrenceItem = ({
@@ -77,6 +79,7 @@ const OccurrenceItem = ({
   },
   subCategories,
   pacedTrainId,
+  showProjectionIcon,
 }: OccurrenceItemProps) => {
   const dispatch = useAppDispatch();
   const { t } = useTranslation('operational-studies', { keyPrefix: 'main' });
@@ -232,6 +235,11 @@ const OccurrenceItem = ({
       >
         <div className="title-img">
           <div className="indicator-title">
+            {showProjectionIcon && (
+              <div className="occurrence-projected">
+                <Manchette iconColor="var(--white100)" />
+              </div>
+            )}
             <OccurrenceIndicator occurrence={occurrence} subCategories={subCategories} />
 
             <div className="label">

--- a/front/src/modules/timetableItem/components/Timetable/PacedTrain/OccurrenceItem.tsx
+++ b/front/src/modules/timetableItem/components/Timetable/PacedTrain/OccurrenceItem.tsx
@@ -21,10 +21,14 @@ import AnchoredMenu from 'common/AnchoredMenu';
 import type { SubCategory } from 'common/api/osrdEditoastApi';
 import OSRDMenu, { type OSRDMenuItem } from 'common/OSRDMenu';
 import RollingStock2Img from 'modules/rollingStock/components/RollingStock2Img';
+import type { PacedTrainId } from 'reducers/osrdconf/types';
+import { updateTrainUsedForProjection } from 'reducers/simulationResults';
+import { useAppDispatch } from 'store';
 import { addElementAtIndex } from 'utils/array';
 import { addDurationToDate } from 'utils/duration';
 import {
   getExceptionType,
+  isException,
   isExceptionFromPathOrSimulation,
   isIndexedOccurrenceId,
 } from 'utils/trainId';
@@ -57,6 +61,7 @@ type OccurrenceItemProps = {
   nextOccurrence?: Occurrence;
   occurrenceActions: ReturnType<typeof useOccurrenceActions>;
   subCategories?: SubCategory[];
+  pacedTrainId: PacedTrainId;
 };
 
 const OccurrenceItem = ({
@@ -71,7 +76,9 @@ const OccurrenceItem = ({
     deleteAddedException,
   },
   subCategories,
+  pacedTrainId,
 }: OccurrenceItemProps) => {
+  const dispatch = useAppDispatch();
   const { t } = useTranslation('operational-studies', { keyPrefix: 'main' });
   const menuRef = useRef<HTMLDivElement>(null);
   const menuButtonRef = useRef<HTMLButtonElement>(null);
@@ -89,6 +96,23 @@ const OccurrenceItem = ({
   const isNextAfterMidnight =
     !!nextOccurrence && dayjs(nextOccurrence.startTime).isAfter(startTime, 'day');
   const isStartTimeException = !!exceptionChangeGroups?.start_time?.value;
+
+  const selectPathProjection = async () => {
+    if (isException(occurrence)) {
+      dispatch(
+        updateTrainUsedForProjection({
+          trainId: pacedTrainId,
+          exceptionKey: occurrence.key,
+        })
+      );
+    } else {
+      dispatch(
+        updateTrainUsedForProjection({
+          trainId: pacedTrainId,
+        })
+      );
+    }
+  };
 
   const closeMenu = () => {
     setIsMenuOpen(false);
@@ -136,6 +160,7 @@ const OccurrenceItem = ({
       title: t('occurrenceMenu.project'),
       icon: <GiPathDistance />,
       onClick: () => {
+        selectPathProjection();
         closeMenu();
       },
       dataTestID: 'occurrence-project-button',

--- a/front/src/modules/timetableItem/components/Timetable/PacedTrain/PacedTrainItem.tsx
+++ b/front/src/modules/timetableItem/components/Timetable/PacedTrain/PacedTrainItem.tsx
@@ -33,6 +33,7 @@ import type {
   OccurrenceId,
 } from 'reducers/osrdconf/types';
 import { updateSelectedTrainId, updateTrainUsedForProjection } from 'reducers/simulationResults';
+import { getTrainUsedForProjection } from 'reducers/simulationResults/selectors';
 import { useAppDispatch } from 'store';
 import { addDurationToDate, Duration } from 'utils/duration';
 import { castErrorToFailure } from 'utils/error';
@@ -54,7 +55,6 @@ type PacedTrainItemProps = {
   handleOpenOccurrencesList: (pacedTrainId: PacedTrainId) => void;
   pacedTrain: PacedTrainWithDetails;
   isOnEdit: boolean;
-  isProjectionPathUsed: boolean;
   selectedTrainId?: TrainId;
   selectPacedTrainToEdit: (
     pacedTrainToEdit: PacedTrainWithDetails,
@@ -64,6 +64,7 @@ type PacedTrainItemProps = {
   upsertTimetableItems: (timetableItems: TimetableItem[]) => void;
   removePacedTrains: (pacedTrainIdsToRemove: TimetableItemId[]) => void;
   subCategories: SubCategory[];
+  infraIsCached: boolean;
 };
 
 const PacedTrainItem = ({
@@ -73,12 +74,12 @@ const PacedTrainItem = ({
   handleOpenOccurrencesList,
   pacedTrain,
   isOnEdit,
-  isProjectionPathUsed,
   selectPacedTrainToEdit,
   selectedTrainId,
   upsertTimetableItems,
   removePacedTrains,
   subCategories,
+  infraIsCached,
 }: PacedTrainItemProps) => {
   const { editedElementContainer } = useContext(EditedElementContainerContext);
   const { t } = useTranslation('operational-studies', { keyPrefix: 'main' });
@@ -86,6 +87,12 @@ const PacedTrainItem = ({
   const { openModal } = useContext(ModalContext);
   const { closeModal } = useContext(ModalContext);
   const timetableId = useSelector(getOperationalStudiesTimetableID);
+  const trainUsedForProjection = useSelector(getTrainUsedForProjection);
+  const projectedExceptionIsPathException =
+    trainUsedForProjection !== undefined &&
+    'exceptionKey' in trainUsedForProjection &&
+    pacedTrain.exceptions.find((ex) => ex.key === trainUsedForProjection.exceptionKey)
+      ?.path_and_schedule !== undefined;
 
   const { summary } = pacedTrain;
   const { rollingStocks } = useRollingStockContext();
@@ -260,11 +267,20 @@ const PacedTrainItem = ({
           role="button"
           tabIndex={0}
         >
-          {isProjectionPathUsed && (
-            <div className="train-projected">
-              <Manchette iconColor="var(--white100)" />
-            </div>
-          )}
+          {infraIsCached &&
+            trainUsedForProjection &&
+            trainUsedForProjection.id === pacedTrain.id && (
+              <div
+                className={cx('train-projected', {
+                  grayed:
+                    'exceptionKey' in trainUsedForProjection &&
+                    trainUsedForProjection.exceptionKey !== undefined &&
+                    projectedExceptionIsPathException,
+                })}
+              >
+                <Manchette iconColor="var(--white100)" />
+              </div>
+            )}
           <div
             data-testid="occurrences-count"
             className={cx('occurrences-count', {
@@ -367,17 +383,29 @@ const PacedTrainItem = ({
       )}
       {isOccurrencesListOpen && (
         <div className="occurrences">
-          {occurrences.map((occurrence, index) => (
-            <OccurrenceItem
-              occurrence={occurrence}
-              key={occurrence.id}
-              isSelected={selectedTrainId === occurrence.id}
-              nextOccurrence={occurrences[index + 1]}
-              occurrenceActions={occurrenceActions}
-              subCategories={subCategories}
-              pacedTrainId={pacedTrain.id}
-            />
-          ))}
+          {occurrences.map((occurrence, index) => {
+            // used to have the projection icon next to the occurrence in the list.
+            // shown if the projected occurrence key matches the one on this line
+            const showProjectionIcon =
+              infraIsCached &&
+              trainUsedForProjection &&
+              'exceptionKey' in trainUsedForProjection &&
+              trainUsedForProjection.exceptionKey !== undefined &&
+              trainUsedForProjection.exceptionKey === occurrence.key &&
+              projectedExceptionIsPathException;
+            return (
+              <OccurrenceItem
+                occurrence={occurrence}
+                key={occurrence.id}
+                isSelected={selectedTrainId === occurrence.id}
+                nextOccurrence={occurrences[index + 1]}
+                occurrenceActions={occurrenceActions}
+                subCategories={subCategories}
+                pacedTrainId={pacedTrain.id}
+                showProjectionIcon={showProjectionIcon}
+              />
+            );
+          })}
         </div>
       )}
     </div>

--- a/front/src/modules/timetableItem/components/Timetable/PacedTrain/PacedTrainItem.tsx
+++ b/front/src/modules/timetableItem/components/Timetable/PacedTrain/PacedTrainItem.tsx
@@ -32,7 +32,7 @@ import type {
   TrainId,
   OccurrenceId,
 } from 'reducers/osrdconf/types';
-import { updateSelectedTrainId, updateTrainIdUsedForProjection } from 'reducers/simulationResults';
+import { updateSelectedTrainId, updateTrainUsedForProjection } from 'reducers/simulationResults';
 import { useAppDispatch } from 'store';
 import { addDurationToDate, Duration } from 'utils/duration';
 import { castErrorToFailure } from 'utils/error';
@@ -104,7 +104,7 @@ const PacedTrainItem = ({
   const [deletePacedTrains] = osrdEditoastApi.endpoints.deletePacedTrain.useMutation();
 
   const selectPathProjection = async () => {
-    dispatch(updateTrainIdUsedForProjection(pacedTrain.id));
+    dispatch(updateTrainUsedForProjection({ trainId: pacedTrain.id }));
   };
 
   const deletePacedTrain = async (currentSelectedTrainId?: TrainId) => {
@@ -375,6 +375,7 @@ const PacedTrainItem = ({
               nextOccurrence={occurrences[index + 1]}
               occurrenceActions={occurrenceActions}
               subCategories={subCategories}
+              pacedTrainId={pacedTrain.id}
             />
           ))}
         </div>

--- a/front/src/modules/timetableItem/components/Timetable/PacedTrain/hooks/useOccurrenceActions.ts
+++ b/front/src/modules/timetableItem/components/Timetable/PacedTrain/hooks/useOccurrenceActions.ts
@@ -13,8 +13,11 @@ import {
 import { storePacedTrain } from 'modules/timetableItem/helpers/updateTimetableItemHelpers';
 import { getOperationalStudiesTimetableID } from 'reducers/osrdconf/operationalStudiesConf/selectors';
 import type { OccurrenceId, TimetableItem, TimetableItemId } from 'reducers/osrdconf/types';
-import { updateSelectedTrainId } from 'reducers/simulationResults';
-import { getSelectedTrainId } from 'reducers/simulationResults/selectors';
+import { updateSelectedTrainId, updateTrainUsedForProjection } from 'reducers/simulationResults';
+import {
+  getSelectedTrainId,
+  getTrainUsedForProjection,
+} from 'reducers/simulationResults/selectors';
 import { useAppDispatch } from 'store';
 import { isIndexedOccurrenceId, extractExceptionIdFromOccurrenceId } from 'utils/trainId';
 
@@ -43,6 +46,7 @@ const useOccurrenceActions = ({
 
   const timetableId = useSelector(getOperationalStudiesTimetableID);
   const selectedTrainId = useSelector(getSelectedTrainId);
+  const trainUsedForProjection = useSelector(getTrainUsedForProjection);
 
   const selectOccurrence = useCallback((occurrenceId: OccurrenceId) => {
     dispatch(updateSelectedTrainId(occurrenceId));
@@ -134,16 +138,23 @@ const useOccurrenceActions = ({
 
       // If we are disabling the selected occurrence, we want to put the selection
       // on the first enabled occurrence chronologically
-      if (status === 'disabled' && selectedTrainId === occurrence.id) {
+      if (status === 'disabled') {
         const firstEnabledOccurrence = occurrences.find(
           (occ) => occ.id !== occurrence.id && !occ.disabled
         );
-
-        dispatch(updateSelectedTrainId(firstEnabledOccurrence?.id));
-        // TODO exceptions : update projected occurrence id in issue https://github.com/OpenRailAssociation/osrd/issues/11476
+        if (selectedTrainId === occurrence.id) {
+          dispatch(updateSelectedTrainId(firstEnabledOccurrence?.id));
+        }
+        if (
+          trainUsedForProjection &&
+          'exceptionKey' in trainUsedForProjection &&
+          trainUsedForProjection.exceptionKey === occurrence.key
+        ) {
+          dispatch(updateTrainUsedForProjection({ trainId: pacedTrain.id }));
+        }
       }
     },
-    [pacedTrain, occurrences, selectedTrainId]
+    [pacedTrain, occurrences, selectedTrainId, trainUsedForProjection]
   );
 
   /**

--- a/front/src/modules/timetableItem/components/Timetable/PacedTrain/hooks/useOccurrences.ts
+++ b/front/src/modules/timetableItem/components/Timetable/PacedTrain/hooks/useOccurrences.ts
@@ -1,112 +1,20 @@
 import { useMemo } from 'react';
 
-import dayjs from 'dayjs';
-import { omit, sortBy } from 'lodash';
-
 import { type LightRollingStockWithLiveries } from 'common/api/osrdEditoastApi';
-import computeOccurrenceName from 'modules/timetableItem/helpers/computeOccurrenceName';
-import {
-  findExceptionWithOccurrenceId,
-  getOccurrencesNb,
-} from 'modules/timetableItem/helpers/pacedTrain';
-import {
-  formatPacedTrainIdToExceptionId,
-  formatPacedTrainIdToIndexedOccurrenceId,
-} from 'utils/trainId';
 
-import type { Occurrence, PacedTrainWithDetails } from '../../types';
+import type { PacedTrainWithDetails } from '../../types';
+import { generatePacedTrainOccurrences } from '../../utils';
 
 const useOccurrences = (
   pacedTrain: PacedTrainWithDetails,
   rollingStockList: LightRollingStockWithLiveries[] | null
 ) => {
-  const {
-    id,
-    paced,
-    name,
-    rollingStock,
-    stopsCount,
-    summary,
-    exceptions,
-    category: pacedTrainCategory,
-  } = pacedTrain;
+  const { exceptions } = pacedTrain;
 
-  const occurrencesCount = getOccurrencesNb(paced);
-
-  const occurrences = useMemo(() => {
-    const computedOccurrences: Occurrence[] = [];
-
-    // Handle indexed occurrences
-    for (let i = 0; i < occurrencesCount; i += 1) {
-      const occurrenceId = formatPacedTrainIdToIndexedOccurrenceId(id, i);
-
-      const correspondingException = findExceptionWithOccurrenceId(exceptions, occurrenceId);
-
-      let occurrenceRollingStock = rollingStock;
-      if (correspondingException?.rolling_stock && rollingStockList) {
-        const rollingStockName = correspondingException.rolling_stock.rolling_stock_name;
-        occurrenceRollingStock = rollingStockList.find((rs) => rs.name === rollingStockName);
-      }
-
-      const startTime = correspondingException?.start_time?.value
-        ? new Date(correspondingException.start_time.value)
-        : dayjs(pacedTrain.startTime)
-            .add(i * paced.interval.ms, 'ms')
-            .toDate();
-
-      computedOccurrences.push({
-        id: occurrenceId,
-        trainName: correspondingException?.train_name?.value ?? computeOccurrenceName(name, i),
-        rollingStock: occurrenceRollingStock,
-        startTime,
-        stopsCount: correspondingException?.path_and_schedule
-          ? correspondingException.path_and_schedule.schedule.filter((step) => step.stop_for).length
-          : stopsCount,
-        disabled: correspondingException?.disabled,
-        // In the model, we can currently have a null category value so we need to handle this case
-        category: correspondingException?.rolling_stock_category
-          ? correspondingException.rolling_stock_category.value
-          : pacedTrainCategory,
-        occurrenceIndex: i,
-        exceptionChangeGroups: correspondingException
-          ? omit(correspondingException, ['key', 'occurrence_index', 'disabled', 'summary'])
-          : undefined,
-        summary: correspondingException?.summary ?? summary,
-      });
-    }
-
-    // Handle added exceptions
-    exceptions.forEach((exception) => {
-      if (exception.occurrence_index !== undefined) return;
-
-      let occurrenceRollingStock = rollingStock;
-      if (exception.rolling_stock && rollingStockList) {
-        const rollingStockName = exception.rolling_stock.rolling_stock_name;
-        occurrenceRollingStock = rollingStockList.find((rs) => rs.name === rollingStockName);
-      }
-
-      // An added exception will always have a least a start time in its exceptions
-      const startTime = new Date(exception.start_time!.value);
-
-      computedOccurrences.push({
-        id: formatPacedTrainIdToExceptionId(id, exception.key),
-        trainName: exception.train_name?.value ?? `${name}/+`,
-        rollingStock: occurrenceRollingStock,
-        startTime,
-        stopsCount: exception.path_and_schedule
-          ? exception.path_and_schedule.schedule.filter((step) => step.stop_for).length
-          : stopsCount,
-        // In the model, we can currently have a null category value so we need to handle this case
-        category: exception.rolling_stock_category
-          ? exception.rolling_stock_category.value
-          : pacedTrainCategory,
-        exceptionChangeGroups: omit(exception, ['key', 'disabled', 'occurrence_index', 'summary']),
-        summary: exception.summary ?? summary,
-      });
-    });
-
-    return sortBy(computedOccurrences, 'startTime');
-  }, [pacedTrain, rollingStockList]);
+  const occurrences = useMemo(
+    () => generatePacedTrainOccurrences(pacedTrain, rollingStockList),
+    [pacedTrain, rollingStockList]
+  );
 
   // Add to the count the added exceptions and substract the disabled ones
   const occurrenceCountLabel = useMemo(
@@ -117,7 +25,6 @@ const useOccurrences = (
       }, occurrences.length),
     [occurrences.length, exceptions]
   );
-
   return { occurrencesCount: occurrenceCountLabel, occurrences };
 };
 

--- a/front/src/modules/timetableItem/components/Timetable/Timetable.tsx
+++ b/front/src/modules/timetableItem/components/Timetable/Timetable.tsx
@@ -192,9 +192,7 @@ const Timetable = ({
                   selectedTrainId={selectedTrainId}
                   upsertTimetableItems={upsertTimetableItems}
                   removePacedTrains={removeAndUnselectTrains}
-                  isProjectionPathUsed={
-                    infraState === 'CACHED' && trainUsedForProjection?.id === timetableItem.id
-                  }
+                  infraIsCached={infraState === 'CACHED'}
                   subCategories={subCategories}
                 />
               )}

--- a/front/src/modules/timetableItem/components/Timetable/Timetable.tsx
+++ b/front/src/modules/timetableItem/components/Timetable/Timetable.tsx
@@ -15,7 +15,7 @@ import type {
 } from 'reducers/osrdconf/types';
 import {
   getSelectedTrainId,
-  getTrainIdUsedForProjection,
+  getTrainUsedForProjection,
 } from 'reducers/simulationResults/selectors';
 import { useAppDispatch } from 'store';
 import { useDateTimeLocale } from 'utils/date';
@@ -70,7 +70,7 @@ const Timetable = ({
   );
 
   const selectedTrainId = useSelector(getSelectedTrainId);
-  const trainIdUsedForProjection = useSelector(getTrainIdUsedForProjection);
+  const trainUsedForProjection = useSelector(getTrainUsedForProjection);
   const dispatch = useAppDispatch();
 
   const handleSelectTimetableItem = useCallback(
@@ -176,7 +176,7 @@ const Timetable = ({
                   removeTrains={removeAndUnselectTrains}
                   selectTrainToEdit={selectTimetableItemToEdit}
                   projectionPathIsUsed={
-                    infraState === 'CACHED' && trainIdUsedForProjection === timetableItem.id
+                    infraState === 'CACHED' && trainUsedForProjection?.id === timetableItem.id
                   }
                   subCategories={subCategories}
                 />
@@ -193,7 +193,7 @@ const Timetable = ({
                   upsertTimetableItems={upsertTimetableItems}
                   removePacedTrains={removeAndUnselectTrains}
                   isProjectionPathUsed={
-                    infraState === 'CACHED' && trainIdUsedForProjection === timetableItem.id
+                    infraState === 'CACHED' && trainUsedForProjection?.id === timetableItem.id
                   }
                   subCategories={subCategories}
                 />

--- a/front/src/modules/timetableItem/components/Timetable/TrainScheduleItem.tsx
+++ b/front/src/modules/timetableItem/components/Timetable/TrainScheduleItem.tsx
@@ -18,7 +18,7 @@ import type {
   TrainScheduleId,
   TrainScheduleWithTrainId,
 } from 'reducers/osrdconf/types';
-import { updateTrainIdUsedForProjection, updateSelectedTrainId } from 'reducers/simulationResults';
+import { updateTrainUsedForProjection, updateSelectedTrainId } from 'reducers/simulationResults';
 import { useAppDispatch } from 'store';
 import { addDurationToDate, Duration } from 'utils/duration';
 import { castErrorToFailure } from 'utils/error';
@@ -148,7 +148,7 @@ const TrainScheduleItem = ({
   };
 
   const selectPathProjection = async () => {
-    dispatch(updateTrainIdUsedForProjection(train.id));
+    dispatch(updateTrainUsedForProjection({ trainId: train.id }));
   };
 
   const arrivalTime = summary?.isValid

--- a/front/src/modules/timetableItem/components/Timetable/types.ts
+++ b/front/src/modules/timetableItem/components/Timetable/types.ts
@@ -117,6 +117,7 @@ export type Occurrence = {
   stopsCount: number;
   exceptionChangeGroups?: ExceptionChangeGroups;
   summary?: SimulationSummary;
+  key?: string;
 };
 
 export type ExceptionChangeGroupName = keyof ExceptionChangeGroups;

--- a/front/src/modules/timetableItem/components/Timetable/utils.ts
+++ b/front/src/modules/timetableItem/components/Timetable/utils.ts
@@ -1,13 +1,26 @@
 import dayjs from 'dayjs';
-import { omit } from 'lodash';
+import { omit, sortBy } from 'lodash';
 
-import type { PacedTrain, TrainSchedule } from 'common/api/osrdEditoastApi';
+import type {
+  PacedTrain,
+  TrainSchedule,
+  LightRollingStockWithLiveries,
+} from 'common/api/osrdEditoastApi';
+import computeOccurrenceName from 'modules/timetableItem/helpers/computeOccurrenceName';
+import {
+  findExceptionWithOccurrenceId,
+  getOccurrencesNb,
+} from 'modules/timetableItem/helpers/pacedTrain';
 import type { TimetableItem, TimetableItemId } from 'reducers/osrdconf/types';
 import type { Duration } from 'utils/duration';
-import { isPacedTrainResponseWithPacedTrainId } from 'utils/trainId';
+import {
+  isPacedTrainResponseWithPacedTrainId,
+  formatPacedTrainIdToExceptionId,
+  formatPacedTrainIdToIndexedOccurrenceId,
+} from 'utils/trainId';
 
 import { specialCodeDictionary } from './consts';
-import type { TimetableItemWithDetails } from './types';
+import type { Occurrence, PacedTrainWithDetails, TimetableItemWithDetails } from './types';
 
 /** Filter timetable items by their names and labels */
 export const keepItem = (name: string | undefined, labels: string[], searchString: string) => {
@@ -74,3 +87,95 @@ export const exportTimetableItems = (
   a.download = 'timetable.json';
   a.click();
 };
+
+export function generatePacedTrainOccurrences(
+  pacedTrain: PacedTrainWithDetails,
+  rollingStockList: LightRollingStockWithLiveries[] | null
+) {
+  const {
+    id,
+    paced,
+    name,
+    rollingStock,
+    stopsCount,
+    exceptions,
+    category: pacedTrainCategory,
+    summary,
+  } = pacedTrain;
+
+  const occurrencesCount = getOccurrencesNb(paced);
+
+  const computedOccurrences: Occurrence[] = [];
+
+  // Handle indexed occurrences
+  for (let i = 0; i < occurrencesCount; i += 1) {
+    const occurrenceId = formatPacedTrainIdToIndexedOccurrenceId(id, i);
+
+    const correspondingException = findExceptionWithOccurrenceId(exceptions, occurrenceId);
+
+    let occurrenceRollingStock = rollingStock;
+    if (correspondingException?.rolling_stock && rollingStockList) {
+      const rollingStockName = correspondingException.rolling_stock.rolling_stock_name;
+      occurrenceRollingStock = rollingStockList.find((rs) => rs.name === rollingStockName);
+    }
+
+    const startTime = correspondingException?.start_time?.value
+      ? new Date(correspondingException.start_time.value)
+      : dayjs(pacedTrain.startTime)
+          .add(i * paced.interval.ms, 'ms')
+          .toDate();
+
+    computedOccurrences.push({
+      id: occurrenceId,
+      trainName: correspondingException?.train_name?.value ?? computeOccurrenceName(name, i),
+      rollingStock: occurrenceRollingStock,
+      startTime,
+      stopsCount: correspondingException?.path_and_schedule
+        ? correspondingException.path_and_schedule.schedule.filter((step) => step.stop_for).length
+        : stopsCount,
+      disabled: correspondingException?.disabled,
+      // In the model, we can currently have a null category value so we need to handle this case
+      category: correspondingException?.rolling_stock_category
+        ? correspondingException.rolling_stock_category.value
+        : pacedTrainCategory,
+      occurrenceIndex: i,
+      exceptionChangeGroups: correspondingException
+        ? omit(correspondingException, ['key', 'occurrence_index', 'disabled', 'summary'])
+        : undefined,
+      summary: correspondingException?.summary ?? summary,
+    });
+  }
+
+  // Handle added exceptions
+  exceptions.forEach((exception) => {
+    if (exception.occurrence_index !== undefined) return;
+
+    let occurrenceRollingStock = rollingStock;
+    if (exception.rolling_stock && rollingStockList) {
+      const rollingStockName = exception.rolling_stock.rolling_stock_name;
+      occurrenceRollingStock = rollingStockList.find((rs) => rs.name === rollingStockName);
+    }
+
+    // An added exception will always have a least a start time in its exceptions
+    const startTime = new Date(exception.start_time!.value);
+
+    computedOccurrences.push({
+      id: formatPacedTrainIdToExceptionId(id, exception.key),
+      trainName: exception.train_name?.value ?? `${name}/+`,
+      rollingStock: occurrenceRollingStock,
+      // An added exception will always have a least a start time in its exceptions
+      startTime,
+      stopsCount: exception.path_and_schedule
+        ? exception.path_and_schedule.schedule.filter((step) => step.stop_for).length
+        : stopsCount,
+      // In the model, we can currently have a null category value so we need to handle this case
+      category: exception.rolling_stock_category
+        ? exception.rolling_stock_category.value
+        : pacedTrainCategory,
+      exceptionChangeGroups: omit(exception, ['key', 'disabled', 'occurrence_index', 'summary']),
+      summary: exception.summary ?? summary,
+    });
+  });
+
+  return sortBy(computedOccurrences, 'startTime');
+}

--- a/front/src/modules/timetableItem/components/Timetable/utils.ts
+++ b/front/src/modules/timetableItem/components/Timetable/utils.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
 import dayjs from 'dayjs';
 import { omit, sortBy } from 'lodash';
 
@@ -121,9 +122,7 @@ export function generatePacedTrainOccurrences(
 
     const startTime = correspondingException?.start_time?.value
       ? new Date(correspondingException.start_time.value)
-      : dayjs(pacedTrain.startTime)
-          .add(i * paced.interval.ms, 'ms')
-          .toDate();
+      : makeOccurrenceTime(pacedTrain.startTime, paced.interval, i);
 
     computedOccurrences.push({
       id: occurrenceId,
@@ -139,6 +138,7 @@ export function generatePacedTrainOccurrences(
         ? correspondingException.rolling_stock_category.value
         : pacedTrainCategory,
       occurrenceIndex: i,
+      key: correspondingException?.key,
       exceptionChangeGroups: correspondingException
         ? omit(correspondingException, ['key', 'occurrence_index', 'disabled', 'summary'])
         : undefined,
@@ -161,6 +161,7 @@ export function generatePacedTrainOccurrences(
 
     computedOccurrences.push({
       id: formatPacedTrainIdToExceptionId(id, exception.key),
+      key: exception.key,
       trainName: exception.train_name?.value ?? `${name}/+`,
       rollingStock: occurrenceRollingStock,
       // An added exception will always have a least a start time in its exceptions
@@ -178,4 +179,17 @@ export function generatePacedTrainOccurrences(
   });
 
   return sortBy(computedOccurrences, 'startTime');
+}
+
+/**
+ * refTime + index × interval
+ */
+export function makeOccurrenceTime(
+  pacedTrainRefTime: Date | null,
+  interval: Duration,
+  index: number
+) {
+  return dayjs(pacedTrainRefTime)
+    .add(index * interval.ms, 'ms')
+    .toDate();
 }

--- a/front/src/reducers/osrdconf/types.ts
+++ b/front/src/reducers/osrdconf/types.ts
@@ -166,6 +166,9 @@ export type OccurrenceId = IndexedOccurrenceId | AddedExceptionId;
  */
 export type PacedTrainId = string & { readonly __type: unique symbol };
 
+/**
+ * an individual train run
+ */
 export type TrainId = TrainScheduleId | OccurrenceId;
 export type TimetableItemId = TrainScheduleId | PacedTrainId;
 export type TimetableItemToEditData =

--- a/front/src/reducers/simulationResults/index.ts
+++ b/front/src/reducers/simulationResults/index.ts
@@ -1,13 +1,15 @@
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 import type { Draft } from 'immer';
 
+import type { Occurrence } from 'modules/timetableItem/components/Timetable/types';
 import type { TimetableItemId, TrainId } from 'reducers/osrdconf/types';
 import type { ProjectionType, SimulationResultsState } from 'reducers/simulationResults/types';
+import { isPacedTrainId } from 'utils/trainId';
 
 export const simulationResultsInitialState: SimulationResultsState = {
   chart: undefined,
   selectedTrainId: undefined,
-  trainIdUsedForProjection: undefined,
+  trainUsedForProjection: undefined,
   projectionType: 'trackProjection',
 };
 
@@ -21,11 +23,25 @@ export const simulationResultsSlice = createSlice({
     ) {
       state.selectedTrainId = action.payload;
     },
-    updateTrainIdUsedForProjection(
+    updateTrainUsedForProjection(
       state: Draft<SimulationResultsState>,
-      action: PayloadAction<TimetableItemId | undefined>
+      action: PayloadAction<
+        { trainId: TimetableItemId; exceptionKey?: Occurrence['key'] } | undefined
+      >
     ) {
-      state.trainIdUsedForProjection = action.payload;
+      const { trainId, exceptionKey } = action.payload || {};
+      if (!trainId) {
+        state.trainUsedForProjection = undefined;
+        return;
+      }
+      if (isPacedTrainId(trainId)) {
+        state.trainUsedForProjection = {
+          id: trainId,
+          exceptionKey,
+        };
+      } else {
+        state.trainUsedForProjection = { id: trainId };
+      }
     },
     updateProjectionType(
       state: Draft<SimulationResultsState>,
@@ -36,7 +52,7 @@ export const simulationResultsSlice = createSlice({
   },
 });
 
-export const { updateSelectedTrainId, updateTrainIdUsedForProjection, updateProjectionType } =
+export const { updateSelectedTrainId, updateTrainUsedForProjection, updateProjectionType } =
   simulationResultsSlice.actions;
 
 export default simulationResultsSlice.reducer;

--- a/front/src/reducers/simulationResults/selectors.ts
+++ b/front/src/reducers/simulationResults/selectors.ts
@@ -8,5 +8,5 @@ export const getSimulationResults = (state: RootState) => state.simulation;
 const makeOsrdSimulationSelector = makeSubSelector<SimulationResultsState>(getSimulationResults);
 
 export const getSelectedTrainId = makeOsrdSimulationSelector('selectedTrainId');
-export const getTrainIdUsedForProjection = makeOsrdSimulationSelector('trainIdUsedForProjection');
+export const getTrainUsedForProjection = makeOsrdSimulationSelector('trainUsedForProjection');
 export const getProjectionType = makeOsrdSimulationSelector('projectionType');

--- a/front/src/reducers/simulationResults/simulationResultsReducer.spec.ts
+++ b/front/src/reducers/simulationResults/simulationResultsReducer.spec.ts
@@ -7,7 +7,7 @@ import {
   simulationResultsInitialState,
   simulationResultsSlice,
   updateSelectedTrainId,
-  updateTrainIdUsedForProjection,
+  updateTrainUsedForProjection,
 } from '.';
 import type { SimulationResultsState } from './types';
 
@@ -42,20 +42,20 @@ describe('simulationResultsReducer', () => {
     expect(state.selectedTrainId).toBe('paced-1-occurrence-2');
   });
 
-  it('should handle updateTrainIdUsedForProjection with a train schedule', () => {
+  it('should handle updateTrainUsedForProjection with a train schedule', () => {
     const store = createStore();
-    store.dispatch(updateTrainIdUsedForProjection('trainschedule-1' as TrainScheduleId));
+    store.dispatch(updateTrainUsedForProjection({ trainId: 'trainschedule-1' as TrainScheduleId }));
 
     const state = store.getState()[simulationResultsSlice.name];
-    expect(state.trainIdUsedForProjection).toBe('trainschedule-1');
+    expect(state.trainUsedForProjection).toEqual({ id: 'trainschedule-1' });
   });
 
-  it('should handle updateTrainIdUsedForProjection with a paced train', () => {
+  it('should handle updateTrainUsedForProjection with a paced train', () => {
     const store = createStore();
-    store.dispatch(updateTrainIdUsedForProjection('paced-1' as PacedTrainId));
+    store.dispatch(updateTrainUsedForProjection({ trainId: 'paced-1' as PacedTrainId }));
 
     const state = store.getState()[simulationResultsSlice.name];
-    expect(state.trainIdUsedForProjection).toBe('paced-1');
+    expect(state.trainUsedForProjection).toEqual({ id: 'paced-1' });
   });
 
   it('should handle updateProjectionType', () => {

--- a/front/src/reducers/simulationResults/types.ts
+++ b/front/src/reducers/simulationResults/types.ts
@@ -1,6 +1,6 @@
 import type { ScaleTime, ScaleLinear } from 'd3-scale';
 
-import type { TimetableItemId, TrainId } from 'reducers/osrdconf/types';
+import type { PacedTrainId, TrainId, TrainScheduleId } from 'reducers/osrdconf/types';
 
 type SimulationD3Scale = ScaleTime<number, number> | ScaleLinear<number, number>;
 
@@ -30,9 +30,18 @@ export type SpeedRanges = {
 
 export type ProjectionType = 'trackProjection' | 'operationalPointProjection';
 
+export type TrainUsedForProjection =
+  | {
+      id: TrainScheduleId;
+    }
+  | {
+      id: PacedTrainId;
+      exceptionKey?: string;
+    };
+
 export interface SimulationResultsState {
   chart?: Chart;
   selectedTrainId?: TrainId;
-  trainIdUsedForProjection?: TimetableItemId;
+  trainUsedForProjection?: TrainUsedForProjection;
   projectionType: ProjectionType;
 }

--- a/front/src/styles/scss/applications/operationalStudies/_pacedTrain.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_pacedTrain.scss
@@ -66,6 +66,23 @@
     z-index: 3;
   }
 
+  @mixin projected-item-icon {
+    height: 20px;
+    width: 20px;
+    margin-right: 7.5px;
+    background-color: var(--info30);
+    border-radius: 4px;
+    position: relative;
+    flex-shrink: 0;
+
+    svg {
+      position: absolute;
+      top: 0;
+      left: 0;
+      transform: translate(2px, 2px);
+    }
+  }
+
   .paced-train-main-info {
     display: flex;
     margin-left: 10.5px;
@@ -78,18 +95,10 @@
     overflow: hidden;
 
     .train-projected {
-      height: 20px;
-      width: 20px;
-      margin-right: 7.5px;
-      background-color: var(--info30);
-      border-radius: 4px;
-      position: relative;
-      flex-shrink: 0;
-      svg {
-        position: absolute;
-        top: 0;
-        left: 0;
-        transform: translate(2px, 2px);
+      @include projected-item-icon;
+
+      &.grayed {
+        background-color: var(--grey40);
       }
     }
 
@@ -220,8 +229,13 @@
 
           .indicator-title {
             display: flex;
+            align-items: center;
             position: relative;
             line-height: 24px;
+
+            .occurrence-projected {
+              @include projected-item-icon;
+            }
 
             .occurrence-indicator {
               position: relative;

--- a/front/src/utils/trainId.ts
+++ b/front/src/utils/trainId.ts
@@ -1,6 +1,11 @@
 import { isEmpty } from 'lodash';
 
-import type { TrainSpaceTimeData } from 'modules/simulationResult/types';
+import type {
+  IndividualTrainProjection,
+  OccurrenceProjection,
+  TrainScheduleProjection,
+  TrainSpaceTimeData,
+} from 'modules/simulationResult/types';
 import type {
   TimetableItemWithDetails,
   PacedTrainWithDetails,
@@ -13,6 +18,7 @@ import type {
   PacedTrainId,
   PacedTrainWithPacedTrainId,
   TimetableItem,
+  TimetableItemId,
   TrainId,
   TrainScheduleId,
 } from 'reducers/osrdconf/types';
@@ -255,5 +261,11 @@ export const extractExceptionIdFromOccurrenceId = (occurrenceId: OccurrenceId): 
  */
 export const isTrainScheduleProjection = (
   timetableItem: TrainSpaceTimeData
-): timetableItem is Extract<TrainSpaceTimeData, { id: TrainScheduleId }> =>
-  isTrainScheduleId(timetableItem.id);
+): timetableItem is TrainScheduleProjection => isTrainScheduleId(timetableItem.id);
+
+/**
+ * make out the occurrence projections from the train schedule projections
+ */
+export const isOccurrenceProjection = (
+  trainProjection: IndividualTrainProjection
+): trainProjection is OccurrenceProjection => isOccurrenceId(trainProjection.id);

--- a/front/src/utils/trainId.ts
+++ b/front/src/utils/trainId.ts
@@ -22,7 +22,8 @@ export const isPacedTrainId = (id: string): id is PacedTrainId => id.startsWith(
 export const isIndexedOccurrenceId = (id: string): id is IndexedOccurrenceId =>
   id.startsWith('indexedoccurrence_');
 
-const isAddedExceptionId = (id: string): id is AddedExceptionId => id.startsWith('exception_');
+export const isAddedExceptionId = (id: string): id is AddedExceptionId =>
+  id.startsWith('exception_');
 
 export const isOccurrenceId = (id: string): id is OccurrenceId =>
   isIndexedOccurrenceId(id) || isAddedExceptionId(id);

--- a/front/src/utils/trainId.ts
+++ b/front/src/utils/trainId.ts
@@ -204,6 +204,15 @@ export const extractEditoastIdFromTrainId = (id: TrainId): number =>
     : extractEditoastIdFromPacedTrainId(extractPacedTrainIdFromOccurrenceId(id));
 
 /**
+ * Given a timetable item id (either TrainScheduleId or PacedTrainId),
+ * returns the Editoast id (used for api).
+ */
+export const extractEditoastIdFromTimeTableItemId = (id: TimetableItemId): number =>
+  isTrainScheduleId(id)
+    ? extractEditoastIdFromTrainScheduleId(id)
+    : extractEditoastIdFromPacedTrainId(id);
+
+/**
  * Given a occurrence id with an OccurrenceId format (used across the front),
  * returns the occurrence index.
  */

--- a/front/tests/020-paced-train-exceptions.spec.ts
+++ b/front/tests/020-paced-train-exceptions.spec.ts
@@ -397,9 +397,17 @@ test.describe('Paced trains and exception management', () => {
       translations: frTranslations,
     });
 
-    // TODO: 6. projection
+    // 6. projection
+    await pacedTrainSection.clickOccurrenceMenuButton('project');
+    // TODO: check snapshots
 
     // 7. restoring to model
+    await pacedTrainSection.checkOccurrenceMenuIcon(addedOccurrenceIndex);
+    await pacedTrainSection.checkOccurrenceActionMenu({
+      occurrenceIndex: addedOccurrenceIndex,
+      expectedButtons: ADDED_AND_MODIFIED_EXCEPTION_MENU_BUTTONS,
+      translations: frTranslations,
+    });
     await pacedTrainSection.clickOccurrenceMenuButton('restore');
     await pacedTrainSection.verifyOccurrenceDetails(
       {


### PR DESCRIPTION
closes #11476 

Displaying, projecting and selecting path/schedule exceptions

## projecting on an exception path
If an occurrence is a path/schedule exception, we now fetch its own path to project other trains onto ( track_section_ranges in the endpoint `paced_train/project_path`) `/paced_train/${id}/path` now accepts an exception_key.
## projecting exceptions

following the transformation trail:

Each exception now gets its own projection from `paced_train/project_path`.
these exception projections are now handled in `TrainProjectionLazyLoader`, which returns train schedules and paced trains indistinctly in the same `Map`. Paced trains now have an exception `Map`.

```
{
  "trainschedule_8417": {
    "space_time_curves": […],
    "signal_updates": […]
  },
  "trainschedule_8418": {
    "signal_updates": […],
    "space_time_curves": […]
  },
  "paced_2564": {
    "exceptions": Map( … ),
    "signal_updates": […],
    "space_time_curves": […]
  }
}
```

This data is enriched in `upsertNewProjectedTrains`, (with name, departureTime, paced infos) and becomes `projectedTrainsById`.

`projectedTrainsById` becomes `projectedTrains` and kept in `projectionData`

`projectionData.projectedTrains` is mapped into `projectPathTrainResult`, adding track occupancy stuff.

## how this data is used:
- to get the list of stops to display on the spacetime chart. in `useGetProjectedTrainOperationalPoints`, when it’s an exception path that is used to project other train paths, we now fetch the exception path separately (`/paced_train/${id}/path`) 
- `ManchetteWithSpaceTimeChartWrapper` makes a final transformation to the train projections. Everything is flatened (train schedule and paced trains) into individual train run (`IndividualTrainProjection`) .meaning you get a final array looking like this: `[train_schedule, train_schedule, occurrence, occurrence, occurrence, exception]`: train schedules are kept as is, and every occurrence is added separately, be it a normal occurrence or exception.  (this transformation was moved into a separate function `makeProjectedItems` and tested.) 
