### PR TITLE
front: fix strict mode violation for toast notifiaction

### DIFF
--- a/front/tests/008-op-times-and-stops-tab.spec.ts
+++ b/front/tests/008-op-times-and-stops-tab.spec.ts
@@ -176,6 +176,7 @@ test.describe('Times and Stops Tab Verification', () => {
 
     // Add train schedule, verify results and output table data
     await operationalStudiesPage.addTimetableItem();
+    await operationalStudiesPage.closeToastNotification();
     await operationalStudiesPage.returnSimulationResult();
     await scenarioPage.toggleConflictsList();
     await timeAndStopSimulationOutputs.verifyTimesStopsDataSheetVisibility();

--- a/front/tests/009-op-simulation-settings-tab.spec.ts
+++ b/front/tests/009-op-simulation-settings-tab.spec.ts
@@ -187,6 +187,7 @@ test.describe('Simulation Settings Tab Verification', () => {
     await simulationSettingsTab.checkMarecoMargin();
     // Add the train schedule and verify output results
     await operationalStudiesPage.addTimetableItem();
+    await operationalStudiesPage.closeToastNotification();
     await operationalStudiesPage.returnSimulationResult();
     await scenarioTimetableSection.getTrainArrivalTime('11:53');
     await scenarioPage.toggletrainList();
@@ -236,6 +237,7 @@ test.describe('Simulation Settings Tab Verification', () => {
     await simulationSettingsTab.selectCodeCompoOption('HLP');
     // Add the train schedule and verify output results
     await operationalStudiesPage.addTimetableItem();
+    await operationalStudiesPage.closeToastNotification();
     await operationalStudiesPage.returnSimulationResult();
     await scenarioTimetableSection.getTrainArrivalTime('12:03');
     await scenarioPage.toggletrainList();
@@ -295,6 +297,7 @@ test.describe('Simulation Settings Tab Verification', () => {
     await simulationSettingsTab.activateLinearMargin();
     // Add the train schedule and verify output results
     await operationalStudiesPage.addTimetableItem();
+    await operationalStudiesPage.closeToastNotification();
     await operationalStudiesPage.returnSimulationResult();
     await scenarioTimetableSection.getTrainArrivalTime('11:55');
     await scenarioPage.toggletrainList();
@@ -356,6 +359,7 @@ test.describe('Simulation Settings Tab Verification', () => {
     await simulationSettingsTab.selectCodeCompoOption('HLP');
     // Add the train schedule and verify output results
     await operationalStudiesPage.addTimetableItem();
+    await operationalStudiesPage.closeToastNotification();
     await operationalStudiesPage.returnSimulationResult();
     await scenarioPage.toggletrainList();
     await scenarioPage.toggleConflictsList();

--- a/front/tests/pages/common-page.ts
+++ b/front/tests/pages/common-page.ts
@@ -60,7 +60,7 @@ class CommonPage {
 
   // Close all visible toast notifications safely
   async closeToastNotification(): Promise<void> {
-    await this.closeToastButton.waitFor();
+    await this.closeToastButton.last().waitFor();
     const closeToastElements = await this.closeToastButton.all();
     await Promise.all(
       closeToastElements.map(async (closeToastElement) => {


### PR DESCRIPTION
The test fails due to Playwright's strict mode.
The line `await this.closeToastButton.waitFor();` sometimes resolves to two elements, because the creation notification hasn't closed yet when the update notification appears

Build exemple : https://github.com/OpenRailAssociation/osrd/actions/runs/15851357614/job/44685863734
