### PR TITLE
front: wait for the rolling stock loader to disappear

### DIFF
--- a/front/src/common/Loaders/Loader.tsx
+++ b/front/src/common/Loaders/Loader.tsx
@@ -74,7 +74,7 @@ export const Loader = ({
   childClass = '',
   className = '',
 }: LoaderProps) => (
-  <div className={`loader ${position} ${className}`}>
+  <div data-testid="loader" className={`loader ${position} ${className}`}>
     <Spinner />
     <div className={childClass}>{msg}</div>
   </div>

--- a/front/src/modules/rollingStock/components/RollingStockCard/RollingStockCard.tsx
+++ b/front/src/modules/rollingStock/components/RollingStockCard/RollingStockCard.tsx
@@ -84,7 +84,7 @@ const RollingStockCard = ({
         tabIndex={0}
         ref={isOpen && !isOnEditMode ? ref2scrollWhenOpened : undefined}
       >
-        <div className="rollingstock-title">
+        <div data-testid="rollingstock-title" className="rollingstock-title">
           <RollingStockInfo rollingStock={rollingStock} />
           <div className="sr-only">
             <small className="text-primary mr-1">ID</small>

--- a/front/src/modules/rollingStock/components/RollingStockEditor/RollingStockInformationPanel.tsx
+++ b/front/src/modules/rollingStock/components/RollingStockEditor/RollingStockInformationPanel.tsx
@@ -39,7 +39,7 @@ export default function RollingStockInformationPanel({
     <div className={cx('rollingstock-editor-form', { borders: !isEditing })}>
       <div>
         <div className="rollingstock-card-header">
-          <div className="rollingstock-title">
+          <div data-testid="rollingstock-title" className="rollingstock-title">
             <RollingStockInfo rollingStock={rollingStock} />
           </div>
         </div>

--- a/front/tests/005-rolling-stock-editor.spec.ts
+++ b/front/tests/005-rolling-stock-editor.spec.ts
@@ -185,28 +185,28 @@ test.describe('Rollingstock editor page tests', () => {
     const initialRollingStockFoundNumber = await rollingStockSelector.getRollingStockSearchNumber();
 
     // Filter electric rolling stocks and verify count
-    await rollingStockSelector.setElectricRollingStockFilter();
+    await rollingStockSelector.toggleElectricRollingStockFilter();
     expect(await rollingStockSelector.electricRollingStockIcons.count()).toEqual(
       await rollingStockSelector.getRollingStockSearchNumber()
     );
     // Clear electric filter
-    await rollingStockSelector.setElectricRollingStockFilter();
+    await rollingStockSelector.toggleElectricRollingStockFilter();
 
     // Filter thermal rolling stocks and verify count
-    await rollingStockSelector.setThermalRollingStockFilter();
+    await rollingStockSelector.toggleThermalRollingStockFilter();
     expect(await rollingStockSelector.thermalRollingStockIcons.count()).toEqual(
       await rollingStockSelector.getRollingStockSearchNumber()
     );
 
     // Filter both electric and thermal rolling stocks (dual-mode) and verify count
-    await rollingStockSelector.setElectricRollingStockFilter();
+    await rollingStockSelector.toggleElectricRollingStockFilter();
     expect(await rollingStockSelector.dualModeRollingStockIcons.count()).toEqual(
       await rollingStockSelector.getRollingStockSearchNumber()
     );
 
     // Clear filters and verify the count returns to the initial number
-    await rollingStockSelector.setElectricRollingStockFilter();
-    await rollingStockSelector.setThermalRollingStockFilter();
+    await rollingStockSelector.toggleElectricRollingStockFilter();
+    await rollingStockSelector.toggleThermalRollingStockFilter();
     expect(await rollingStockSelector.rollingStockList.count()).toEqual(
       initialRollingStockFoundNumber
     );

--- a/front/tests/006-op-rolling-stock-tab.spec.ts
+++ b/front/tests/006-op-rolling-stock-tab.spec.ts
@@ -98,8 +98,8 @@ test.describe('Rolling stock Tab Verification', () => {
 
     // Reopen the rolling stock selector and apply filters
     await rollingStockSelector.openRollingstockModal();
-    await rollingStockSelector.setThermalRollingStockFilter();
-    await rollingStockSelector.setElectricRollingStockFilter();
+    await rollingStockSelector.toggleThermalRollingStockFilter();
+    await rollingStockSelector.toggleElectricRollingStockFilter();
 
     // Select the dual-mode rolling stock and confirm the selection
     await rollingStockSelector.selectRollingStockCard({

--- a/front/tests/pages/common-page.ts
+++ b/front/tests/pages/common-page.ts
@@ -19,6 +19,8 @@ class CommonPage {
 
   private readonly navigationBackButton: Locator;
 
+  private readonly loader: Locator;
+
   constructor(page: Page) {
     this.page = page;
     this.toastContainer = page.getByTestId('toast-SNCF');
@@ -28,6 +30,7 @@ class CommonPage {
     this.closeToastButton = page.getByTestId('close-toast-button');
     this.navigationToHomeButton = page.getByTestId('navigation-to-home-button');
     this.navigationBackButton = page.getByTestId('navigation-back-button');
+    this.loader = page.getByTestId('loader');
   }
 
   // Set the tag of project, study or scenario
@@ -76,6 +79,13 @@ class CommonPage {
   async expectResourceNotFoundPage() {
     await expect(this.navigationToHomeButton).toBeVisible();
     await expect(this.navigationBackButton).toBeVisible();
+  }
+
+  async waitForLoaderToDisappear() {
+    const count = await this.loader.count();
+    if (count > 0) {
+      await expect(this.loader).not.toBeVisible();
+    }
   }
 }
 

--- a/front/tests/pages/rolling-stock/rolling-stock-editor-page.ts
+++ b/front/tests/pages/rolling-stock/rolling-stock-editor-page.ts
@@ -109,10 +109,12 @@ class RollingstockEditorPage extends CommonPage {
 
   async searchRollingStock(rollingStockName: string) {
     await this.rollingStockSearchInput.fill(rollingStockName);
+    await this.waitForLoaderToDisappear();
   }
 
   async clearSearchRollingStock() {
     await this.rollingStockSearchInput.clear();
+    await this.waitForLoaderToDisappear();
   }
 
   async selectRollingStock(rollingStockName: string) {

--- a/front/tests/pages/rolling-stock/rolling-stock-selector.ts
+++ b/front/tests/pages/rolling-stock/rolling-stock-selector.ts
@@ -44,7 +44,7 @@ class RollingStockSelector extends CommonPage {
     super(page);
     this.rollingStockSelectorButton = page.getByTestId('rollingstock-selector');
     this.rollingStockSelectorModal = page.locator('.modal-dialog');
-    this.rollingStockList = page.locator('.rollingstock-editor-list .rollingstock-title');
+    this.rollingStockList = page.getByTestId('rollingstock-title');
     this.emptyRollingStockSelector = page.getByTestId('rollingstock-selector-empty');
     this.rollingStockModalSearch = this.rollingStockSelectorModal.locator('#searchfilter');
     this.rollingStockMiniCards = page.locator('.rollingstock-selector-minicard');
@@ -113,12 +113,14 @@ class RollingStockSelector extends CommonPage {
     return this.rollingStockMiniCards.getByTestId('rollingstock-info-comfort');
   }
 
-  async setThermalRollingStockFilter() {
+  async toggleThermalRollingStockFilter() {
     await this.thermalRollingStockFilter.click();
+    await this.waitForLoaderToDisappear();
   }
 
-  async setElectricRollingStockFilter() {
+  async toggleElectricRollingStockFilter() {
     await this.electricRollingStockFilter.click();
+    await this.waitForLoaderToDisappear();
   }
 
   async getRollingStockSearchNumber(): Promise<number> {


### PR DESCRIPTION
Since the search resulsts of RS are not fully loaded, the test proceeds to the verification step too early, which sometimes causes it to fail
Build exemple : https://github.com/OpenRailAssociation/osrd/actions/runs/15850732067?pr=12240