### PR TITLE
front: fix scenario loader position

### DIFF
--- a/front/src/styles/scss/applications/operationalStudies/_scenarioContentV2.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_scenarioContentV2.scss
@@ -28,6 +28,7 @@
     padding-right: 8px;
   }
   .center-column {
+    position: relative;
     width: 100%;
     overflow: auto;
     padding-inline: 8px;

--- a/front/src/styles/scss/applications/operationalStudies/_scenarioV2.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_scenarioV2.scss
@@ -1,7 +1,7 @@
 .scenario-header-container {
   .scenario-header {
     position: relative;
-    z-index: 1;
+    z-index: 4;
     display: flex;
     justify-content: space-between;
     align-items: center;


### PR DESCRIPTION
Fix scenario loader position to stay in the center column.
Modify the z-index of scenario header to keep it above the loader.

close #12260