### PR TITLE
editoast: refactor `similar_schedules` to use cached path properties

### DIFF
--- a/editoast/src/views/path.rs
+++ b/editoast/src/views/path.rs
@@ -1,7 +1,7 @@
 pub mod path_item_cache;
 pub mod pathfinding;
 pub mod projection;
-mod properties;
+pub mod properties;
 
 pub use pathfinding::pathfinding_from_train_batch;
 

--- a/editoast/src/views/path/properties.rs
+++ b/editoast/src/views/path/properties.rs
@@ -60,24 +60,24 @@ pub struct PathPropertiesInput {
 
 /// Properties along a path. Each property is optional since it depends on what the user requests.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, Default)]
-struct PathProperties {
+pub struct PathProperties {
     #[schema(inline)]
     /// Slopes along the path
-    slopes: Option<PropertyValuesF64>,
+    pub slopes: Option<PropertyValuesF64>,
     #[schema(inline)]
     /// Curves along the path
-    curves: Option<PropertyValuesF64>,
+    pub curves: Option<PropertyValuesF64>,
     /// Electrification modes and neutral section along the path
     #[schema(inline)]
-    electrifications: Option<PropertyElectrificationValues>,
+    pub electrifications: Option<PropertyElectrificationValues>,
     /// Geometry of the path
-    geometry: Option<GeoJsonLineString>,
+    pub geometry: Option<GeoJsonLineString>,
     /// Operational points along the path
     #[schema(inline)]
-    operational_points: Option<Vec<OperationalPointOnPath>>,
+    pub operational_points: Option<Vec<OperationalPointOnPath>>,
     /// Zones along the path
     #[schema(inline)]
-    zones: Option<PropertyZoneValues>,
+    pub zones: Option<PropertyZoneValues>,
 }
 
 impl PathProperties {
@@ -116,7 +116,7 @@ impl From<Props> for Properties {
 /// Enum representing the various associated properties that can be returned
 #[derive(Debug, Serialize, Deserialize, ToSchema, EnumSetType)]
 #[serde(rename_all = "snake_case")]
-enum Property {
+pub enum Property {
     Slopes,
     Curves,
     Electrifications,
@@ -221,7 +221,7 @@ fn path_properties_input_hash(path_properties_request: &PathPropertiesRequest<'_
     )
 }
 
-async fn compute_path_properties_batch(
+pub async fn compute_path_properties_batch(
     core_client: Arc<CoreClient>,
     valkey_conn: &mut ValkeyConnection,
     path_properties_requests: &[PathPropertiesRequest<'_>],

--- a/editoast/src/views/timetable/similar_schedules.rs
+++ b/editoast/src/views/timetable/similar_schedules.rs
@@ -11,11 +11,9 @@ use axum::Json;
 use axum::extract::State;
 use chrono::DateTime;
 use chrono::Utc;
-use core_client::AsCoreRequest;
 use core_client::CoreClient;
 use core_client::path_properties::OperationalPointOnPath;
 use core_client::path_properties::PathPropertiesRequest;
-use core_client::path_properties::PathPropertiesResponse;
 use editoast_authz::Role;
 use editoast_derive::EditoastError;
 use editoast_models::DbConnection;
@@ -37,6 +35,8 @@ use crate::models::stdcm_search_environment::StdcmSearchEnvironment;
 use crate::views::path::path_item_cache::PathItemCache;
 use crate::views::path::pathfinding::PathfindingResult;
 use crate::views::path::pathfinding_from_train_batch;
+use crate::views::path::properties::PathProperties;
+use crate::views::path::properties::compute_path_properties_batch;
 
 use super::AppState;
 use super::AuthenticationExt;
@@ -535,23 +535,21 @@ async fn simulate_past_schedules(
             .collect_vec()
     };
 
-    let path_properties = {
-        let futures = paths
-            .into_iter()
-            .zip(candidate_schedules.into_iter())
-            .zip(std::iter::repeat(&core_client))
-            .map(|((path, ts), core)| async move {
-                let response = PathPropertiesRequest {
-                    track_section_ranges: &path.track_section_ranges,
-                    infra: infra.id,
-                    expected_version: infra.version,
-                }
-                .fetch(core)
-                .await;
-                response.map(|properties| (ts, properties))
-            });
-        futures::future::try_join_all(futures).await?
-    };
+    let path_properties_requests = paths
+        .iter()
+        .map(|path| PathPropertiesRequest {
+            track_section_ranges: &path.track_section_ranges,
+            infra: infra.id,
+            expected_version: infra.version,
+        })
+        .collect::<Vec<_>>();
+
+    let path_properties = compute_path_properties_batch(
+        core_client,
+        &mut valkey.get_connection().await?,
+        &path_properties_requests,
+    )
+    .await?;
 
     let stop_waypoints = new_schedule
         .stops()
@@ -559,14 +557,15 @@ async fn simulate_past_schedules(
         .collect::<HashSet<_>>();
     let selected_past_schedules = path_properties
         .into_iter()
+        .zip(candidate_schedules.into_iter())
         .map(
             |(
-                ts,
-                PathPropertiesResponse {
+                PathProperties {
                     operational_points, ..
                 },
+                ts,
             )| {
-                let ops = operational_points.into_iter().filter_map(
+                let ops = operational_points.unwrap().into_iter().filter_map(
                     |OperationalPointOnPath { extensions, .. }| {
                         let sncf = extensions.sncf.as_ref()?;
                         let key = (sncf.ci as u64, Some(sncf.ch.to_smolstr()));


### PR DESCRIPTION
This PR refactors the `similar_schedules` function to use cached path properties via `compute_path_properties_batch`, improving performance by reducing redundant requests.