### PR TITLE
front: correct css tabs for Horizon scrollbars

### DIFF
--- a/front/src/modules/timesStops/TimesStops.tsx
+++ b/front/src/modules/timesStops/TimesStops.tsx
@@ -59,7 +59,6 @@ const TimesStops = <T extends TimesStopsRow>({
       }}
       stickyRightColumn={stickyRightColumn}
       lockRows
-      height={600}
       headerRowHeight={headerRowHeight}
       rowClassName={({ rowData, rowIndex }) =>
         cx({

--- a/front/src/styles/scss/_overrideBootstrapSNCF.scss
+++ b/front/src/styles/scss/_overrideBootstrapSNCF.scss
@@ -77,7 +77,7 @@
   }
 
   input {
-    width: auto;
+    width: 100%;
     flex-grow: 1;
     line-height: 1;
     height: 35.2px;

--- a/front/src/styles/scss/common/components/_tabs.scss
+++ b/front/src/styles/scss/common/components/_tabs.scss
@@ -75,7 +75,7 @@
         font-weight: 500;
         transition: all ease 0.3s;
         padding: 8px 16px;
-        border: 2px solid transparent;
+        border: 1px solid transparent;
         border-radius: var(--border-radius);
         background-color: var(--white);
         color: var(--primary);


### PR DESCRIPTION
close #9969 

An old bug dating from December stated that two
scrollbars were appearing on the tabs component.
This was due to the fact that the tabs component
was not correctly overriding the default
Bootstrap SNCF styles.
Fixes are: _overrideBootstrapSNCF.scss got changed so that the horizontal scrollbar is not displayed
anymore.
_tabs.scss got changed so that the text inside the tabs could fit better on smaller screens (was
not linked with the bug).

Here's the video of the bug: 

https://github.com/user-attachments/assets/b72a2985-cd6c-45e6-8178-11fcd71603ec

Link of the Issue post: https://github.com/OpenRailAssociation/osrd/issues/9969

Here's its solution demo:

https://github.com/user-attachments/assets/d4cbbca7-879b-4022-beb1-1a2b6df2ad7c

tested on local environment.

Note: on smaller screens, the width of the timetable array can exceed the width of the screen. I tested it: the horizontal scrollbar shows up at the bottom of the timetable, the user can easily navigate the timetable by scrolling horizontally with holding shift + scroll.
