### PR TITLE
scripts, all: uniformize shell error flags

### DIFF
--- a/.github/scripts/check-commit-titles.sh
+++ b/.github/scripts/check-commit-titles.sh
@@ -5,6 +5,8 @@
 # output an error message when titles are deemed invalid,
 # and exits accordingly
 
+set -e
+
 if [ -z "$NOCOLOR" ]; then
     RED=$(tput setaf 1 2>/dev/null)
     BLUE=$(tput setaf 4 2>/dev/null)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: |
-          set -eo pipefail
+          set -euo pipefail
           echo ::group::Github context
           python3 -m json.tool <<< "${GITHUB_CONTEXT}"
           echo ::endgroup::
@@ -71,7 +71,7 @@ jobs:
       #   full message: `ERROR: failed to solve: DeadlineExceeded: failed to compute cache key: failed to copy: httpReadSeeker: failed open: failed to authorize: no active session for XXXXX: context deadline exceeded`
       - name: Build and push
         run: |
-          set -eo pipefail
+          set -euo pipefail
 
           # disable cache mounts as github cache is slow
           find -name Dockerfile -o -name "Dockerfile.*" -print0 | xargs -0 sed -Ei 's/--mount=type=cache,target=[^[:blank:]]+//g'
@@ -190,7 +190,7 @@ jobs:
 
       - name: Find and check all Dockerfiles using docker build --check
         run: |
-          set -eo pipefail
+          set -euo pipefail
           find . -name 'Dockerfile*' -print0 | xargs -0 -I {} docker build --file {} --check .
 
   check_scripts:
@@ -484,7 +484,7 @@ jobs:
       - name: Startup the test infrastructure
         id: start_editoast_tests_infra
         run: |
-          set -e
+          set -euo pipefail
 
           services='openfga'
           composes='-f docker-compose.yml'
@@ -800,7 +800,7 @@ jobs:
       - name: Startup the test infrastructure
         id: start_integration_worker
         run: |
-          set -e
+          set -euo pipefail
           export TAG='${{ needs.build.outputs.stable_version }}'
 
           # Inside /docker/osrdyne.yml, replace core_image "osrd-core:dev" with "osrd-core:$TAG"
@@ -900,7 +900,7 @@ jobs:
       - name: Startup the test infrastructure
         id: start_playwright_worker
         run: |
-          set -e
+          set -euo pipefail
           export TAG='${{ needs.build.outputs.stable_version }}'
           export GATEWAY_FLAVOR='front'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: |
-          set -eo pipefail
+          set -euo pipefail
 
           # disable cache mounts as github cache is slow
           find -name Dockerfile -print0 | xargs -0 sed -Ei 's/--mount=type=cache,target=[^[:blank:]]+//g'

--- a/chart/templates/editoast/init_script.yaml
+++ b/chart/templates/editoast/init_script.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   script.sh: |
     #!/bin/sh
-    set -e
+    set -euo pipefail
     
     {{- with .Values.services.editoast.init.extend }}
     {{ . | nindent 4 }}

--- a/editoast/assets/fonts/generate-glyphs.sh
+++ b/editoast/assets/fonts/generate-glyphs.sh
@@ -4,7 +4,7 @@
 # Those glyphs are used to display text on the map
 # You will need build_pbf_glyphs, you can install it with:
 # `$ cargo install build_pbf_glyphs`
-set -e
+set -eu
 
 fonts_directory=$(dirname "$(realpath "$0")")
 echo "Converting fonts in ${fonts_directory} to glyphs"

--- a/editoast/assets/sprites/generate-atlas.sh
+++ b/editoast/assets/sprites/generate-atlas.sh
@@ -3,7 +3,7 @@
 # This script should be used to generate signaling systems atlas given svg.
 # First add all your svg in a subfolder named to the signaling system (eg: `BAL`)
 # Then run this script. You will need docker.
-set -e
+set -eu
 
 sprites_directory=$(dirname "$(realpath "$0")")
 echo "Processing sprites in ${sprites_directory}"

--- a/front/docker/dev-entrypoint.sh
+++ b/front/docker/dev-entrypoint.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 
-set -e
-
+set -eu
 # This script changes the user and group of the dev server
 # process to match the owner of the project's files.
 # The development server would otherwise create cache files

--- a/osrd-compose
+++ b/osrd-compose
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -eo pipefail
+
 BASE_PATH="$(realpath "$(dirname "$0")")"
 STATE_FILE="${BASE_PATH}/.osrd-compose-state"
 BASE_COMPOSE="${BASE_PATH}/docker-compose.yml"

--- a/scripts/cleanup-db.sh
+++ b/scripts/cleanup-db.sh
@@ -6,8 +6,7 @@
 # On windows, docker cp does not like leading double / on the container path.
 # As a workaround, use relative paths: container:tmp/foo instead of container://tmp/foo
 
-set -e
-
+set -eu
 # Check arguments
 if [ "$#" -ne 0 ]; then
   echo "usage: $0"

--- a/scripts/create-backup.sh
+++ b/scripts/create-backup.sh
@@ -6,7 +6,7 @@
 # On windows, docker cp does not like leading double / on the container path.
 # As a workaround, use relative paths: container:tmp/foo instead of container://tmp/foo
 
-set -e
+set -eu
 
 OUTPUT_DIR="."
 if [ "$#" -eq 1 ]; then

--- a/scripts/load-backup.sh
+++ b/scripts/load-backup.sh
@@ -6,7 +6,7 @@
 # On windows, docker cp does not like leading double / on the container path.
 # As a workaround, use relative paths: container:tmp/foo instead of container://tmp/foo
 
-set -e
+set -eu
 
 # Check arguments
 if [ "$#" -ne 1 ]; then

--- a/scripts/load-railjson-infra.sh
+++ b/scripts/load-railjson-infra.sh
@@ -6,7 +6,7 @@
 # On windows, docker cp does not like leading double / on the container path.
 # As a workaround, use relative paths: container:tmp/foo instead of container://tmp/foo
 
-set -e
+set -eu
 
 infra_name="${1:?missing infrastructure name}"
 infra_path="${2:?missing path to RailJSON infrastructure}"

--- a/scripts/load-railjson-rolling-stock.sh
+++ b/scripts/load-railjson-rolling-stock.sh
@@ -6,7 +6,7 @@
 # On windows, docker cp does not like leading double / on the container path.
 # As a workaround, use relative paths: container:tmp/foo instead of container://tmp/foo
 
-set -e
+set -eu
 
 if [ "$#" = 0 ]; then
     echo "Missing path to RailJSON rolling stock"

--- a/scripts/pr-tests-compose.sh
+++ b/scripts/pr-tests-compose.sh
@@ -13,8 +13,7 @@
 # Of course:
 # * the regular stack and "single-worker" stack should still work alone
 
-
-set -e
+set -eu
 
 # For Macos ARM chip users set a postgis image compiled to run on ARM, it makes their DB runs faster as their computer don't have to emulate x86_64's architecture.
 case "$(uname -s)" in

--- a/scripts/run-front-playwright-container.sh
+++ b/scripts/run-front-playwright-container.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
 # Open the base osrd folder, assuming the script is located in osrd/scripts
 cd "$(realpath "$(dirname "$0")"/..)"

--- a/scripts/sync-openapi.sh
+++ b/scripts/sync-openapi.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -e
+set -eu
 
 root_path="$(realpath "$(dirname "$0")"/..)"
 


### PR DESCRIPTION
Set all scripts to use set -eu if specifying sh or  set -euo pipefail if specifying bash, both for consistency and maximal safety.
