### PR TITLE
editoast: bump mvt to fix missing segments

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -2816,9 +2816,9 @@ dependencies = [
 
 [[package]]
 name = "mvt"
-version = "0.10.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0200b3a3fe5ed337dd7ffb674fb7c9e7ee0ff14bec48cdb39c5cc2b60c4a066c"
+checksum = "aaadb348ad72c56b8b4bf59fd1f7a09afdbdc05789c461cfda1b8e367d853be1"
 dependencies = [
  "log",
  "num-traits",

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -74,7 +74,7 @@ geos = { version = "8.3.1", features = ["json"] }
 hostname = "0.4.0"
 itertools = "0.14.0"
 lapin = "2.5.3"
-mvt = "0.10.1"
+mvt = "0.10.3"
 openssl = "0.10.73"
 opentelemetry = { version = "0.30.0", default-features = false, features = [
   "trace",


### PR DESCRIPTION
Close #6654 
Close #9262
Close #10221

The mvt side fix was just merged and released.

Mvt is the crate we use to encode our geographical features into the mapbox vector tile format.

The issue occurred when in a multiline a line started exactly where the previous one ended. Indeed, the move command to this starting point was marked as redundant, and thus dropped. 

However, the second point of the line was subsequently incorrectly treated as the first. This meant that the command to go from the end of the previous line to that point was a move command instead of a line command. (To use a metaphor, a line command is pen down, a move command pen up.) 

This meant we lost the first segment of each line that started where the previous one ended.

We now still drop the move to the first point, but correctly treat the second point as the second, and thus directly add a line command to the second point instead of a move command.

