### PR TITLE
core: stdcm: consider infinite allowance time in visited nodes

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/visited_node_tracking/VisitedNodes.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/visited_node_tracking/VisitedNodes.kt
@@ -66,6 +66,10 @@ data class VisitedNodes(
         val explorer: InfraExplorer? = null, // nullable for tests
     ) {
         val nodeCost = timeData.totalRunningTime + remainingTimeEstimation
+
+        fun withClippedMarginDuration(maxMarginDurationUpperBound: Double): Parameters {
+            return copy(maxMarginDuration = min(maxMarginDurationUpperBound, maxMarginDuration))
+        }
     }
 
     /** Any class that implements this interface may be added to the visited ranges. */
@@ -111,30 +115,25 @@ data class VisitedNodes(
                     parameters.explorer.getRemainingBlocks().sumOf {
                         mrspBuilder!!.getBlockTime(it, null)
                     }
-                // We only check after adding the fastest travel time, and then add some extra
-                // margin at the end (in case engineering allowances are impossible there).
-                // TODO: we should compare possible "engineering allowances" in `isMapVisited`,
-                // with a large max allowance value here.
-                // The current margin (travel time) is a heuristic. Lowering it has a very large
-                // impact on the performance gain, but may block valid solutions when engineering
-                // allowances are impossible.
-                val newTimeData =
-                    parameters.timeData
-                        .withAddedTime(minTravelTime, null, null)
-                        .copy(
-                            maxDepartureDelayingWithoutConflict =
-                                parameters.timeData.maxDepartureDelayingWithoutConflict +
-                                    minTravelTime,
-                        )
 
-                val paramsWithLargerRange = parameters.copy(timeData = newTimeData)
+                // We compare it to a scenario with the minimum amount of added travel time, and
+                // then an infinite amount of possible "engineering allowance" added time. We don't
+                // actually know how much travel time we'd take to get there, nor if the extra
+                // travel enables more allowances. This is very conservative, we could gain
+                // performance by lowering the allowance time (but we'd miss out on some solutions).
+                val newTimeData = parameters.timeData.withAddedTime(minTravelTime, null, null)
+                val paramsWithLargerRange =
+                    parameters.copy(
+                        timeData = newTimeData,
+                        maxMarginDuration = Double.POSITIVE_INFINITY,
+                    )
                 if (mapAtDetector != null && mapAtDetector.isVisited(paramsWithLargerRange)) {
                     return true
                 }
             }
         }
         val visitedRanges = visitedRangesPerLocation[parameters.fingerprint] ?: return false
-        return visitedRanges.isVisited(parameters)
+        return visitedRanges.isVisited(parameters.withClippedMarginDuration(0.0))
     }
 
     /** Marks the input as visited */
@@ -210,12 +209,5 @@ private fun visitedRangeMapFromParameters(
 /** Utility function to map `VisitedNodes.Parameters` to `VisitedRangeMap.isVisited`. */
 private fun VisitedRangeMap.isVisited(parameters: Parameters): Boolean {
     val newMap = visitedRangeMapFromParameters(parameters, 0.0)
-
-    // TODO: better handling of new "visited with travel time" ranges
-    // (this is just to keep identical functionality during the refactoring)
-    val filtered = newMap.asMapOfRanges().filter { it.value !is VisitedWithAddedTravelTime }
-    val filteredMap = VisitedRangeMap()
-    for (range in filtered) filteredMap.put(range.key, range.value)
-
-    return isVisited(filteredMap)
+    return isVisited(newMap)
 }


### PR DESCRIPTION
When we run some checks "in advance" at the end of the lookahead, we'd use a workaround to account for possible added time. It's now checked by comparing a new allowance range.

In terms of computation time: it's usually a small improvement, but some searches keep going for longer (as we may explore more paths). This translates to a *higher* computation time *on average*, but the median computation time is slightly lower. 

 |   | time_old | time_new | diff | diff_% |
 |-----------|----------|----------|------|--------|
 | count | 88.000000 | 88.000000 | 88.000000 | 88.000000 |
 | mean | 5.157739 | 6.591943 | 1.434205 | 0.866715 |
 | std | 9.533896 | 21.573230 | 16.588537 | 42.435917 |
 | min | 0.101000 | 0.092000 | -12.410000 | -31.728665 |
 | 25% | 0.903000 | 0.849500 | -0.163500 | -9.194304 |
 | 50% | 2.577000 | 2.417000 | -0.033000 | -5.211851 |
 | 75% | 4.779250 | 4.936000 | 0.054000 | 1.510091 |
 | max | 55.828000 | 195.367000 | 154.193000 | 374.491184 |

Old computation time in blue, new in orange, we can clearly see *the* request that now has a lot more paths to consider (that's not the proper way to display this data but whatever)

![image](https://github.com/user-attachments/assets/11518d92-c8ed-4731-aed2-f700037b1446)


---

It may also *enables* some optimizations later on, such as improving the test for maximum allowance value.