### PR TITLE
front: fix the warning message block to stop moving

### DIFF
--- a/front/src/styles/scss/applications/stdcm/_home.scss
+++ b/front/src/styles/scss/applications/stdcm/_home.scss
@@ -189,7 +189,7 @@
 
         .warning-box {
           width: calc(100% + 16px);
-          transform: translateX(-8px);
+          margin-left: -8px;
           border-radius: 8px;
           box-shadow:
             0 3px 5px -2px var(--black10),
@@ -225,7 +225,7 @@
             transform: rotate(1deg);
           }
           24% {
-            transform: rotate(0eg);
+            transform: rotate(0deg);
           }
           36% {
             transform: rotate(-1deg);
@@ -237,7 +237,7 @@
             transform: rotate(1deg);
           }
           70% {
-            transform: rotate(0eg);
+            transform: rotate(0deg);
           }
           85% {
             transform: rotate(-1deg);


### PR DESCRIPTION
Close #12010 
We want the block of warning messages to stop moving when we press the button to start the simulation.


https://github.com/user-attachments/assets/ec0f2375-b9d9-4aa0-8e9c-da901045278d



