### PR TITLE
front: increment train schedule start time when duplicating

### DIFF
--- a/front/src/modules/trainschedule/components/Timetable/PacedTrain/PacedTrainItem.tsx
+++ b/front/src/modules/trainschedule/components/Timetable/PacedTrain/PacedTrainItem.tsx
@@ -39,7 +39,7 @@ import TimetableItemActions from '../TimetableItemActions';
 import useOccurrences from './hooks/useOccurrences';
 import OccurrenceItem from './OccurrenceItem';
 import { formatPacedTrainWithDetailsToPacedTrainPayload } from '../../ManageTrainSchedule/helpers/formatTimetableItemPayload';
-import { TRAIN_CATEGORY_CLASS } from '../consts';
+import { TIMETABLE_ITEM_DELTA, TRAIN_CATEGORY_CLASS } from '../consts';
 import type { PacedTrainWithDetails } from '../types';
 import { formatTrainDuration } from '../utils';
 import useOccurrenceActions from './hooks/useOccurrenceActions';
@@ -150,7 +150,6 @@ const PacedTrainItem = ({
   const duplicatePacedTrain = async () => {
     // Static for now, will be dynamic when UI will be ready
     const pacedTrainName = `${pacedTrain.name} (${t('timetable.copy')})`;
-    const pacedTrainDelta = 5;
 
     const editoastTrainId = extractEditoastIdFromPacedTrainId(pacedTrain.id);
 
@@ -166,14 +165,13 @@ const PacedTrainItem = ({
       return;
     }
 
-    const startTime = new Date(pacedTrainDetail.start_time);
-    const newStartTimeString = addDurationToDate(
-      startTime,
-      new Duration({ minutes: pacedTrainDelta })
+    const startTime = addDurationToDate(
+      new Date(pacedTrainDetail.start_time),
+      new Duration({ minutes: TIMETABLE_ITEM_DELTA })
     );
     const newPacedTrain: PacedTrain = {
       ...omit(pacedTrainDetail, ['id', 'timetable_id']),
-      start_time: newStartTimeString.toISOString(),
+      start_time: startTime.toISOString(),
       train_name: pacedTrainName,
     };
 

--- a/front/src/modules/trainschedule/components/Timetable/TrainScheduleItem.tsx
+++ b/front/src/modules/trainschedule/components/Timetable/TrainScheduleItem.tsx
@@ -19,6 +19,7 @@ import type {
 } from 'reducers/osrdconf/types';
 import { updateTrainIdUsedForProjection, updateSelectedTrainId } from 'reducers/simulationResults';
 import { useAppDispatch } from 'store';
+import { addDurationToDate, Duration } from 'utils/duration';
 import { castErrorToFailure } from 'utils/error';
 import {
   formatEditoastIdToTrainScheduleId,
@@ -26,7 +27,7 @@ import {
 } from 'utils/trainId';
 
 import ArrivalTimeLoader from './ArrivalTimeLoader';
-import { TRAIN_CATEGORY_CLASS } from './consts';
+import { TIMETABLE_ITEM_DELTA, TRAIN_CATEGORY_CLASS } from './consts';
 import TimetableItemActions from './TimetableItemActions';
 import type { TrainScheduleWithDetails } from './types';
 import { formatFullDate, formatTrainDuration, roundAndFormatToNearestMinute } from './utils';
@@ -108,7 +109,11 @@ const TrainScheduleItem = ({
       });
 
     if (trainDetail) {
-      const startTime = new Date(trainDetail.start_time);
+      const startTime = addDurationToDate(
+        new Date(trainDetail.start_time),
+        new Duration({ minutes: TIMETABLE_ITEM_DELTA })
+      );
+
       const newTrain: TrainSchedule = {
         ...omit(trainDetail, ['id', 'timetable_id']),
         start_time: startTime.toISOString(),

--- a/front/src/modules/trainschedule/components/Timetable/consts.ts
+++ b/front/src/modules/trainschedule/components/Timetable/consts.ts
@@ -17,3 +17,5 @@ export const TRAIN_CATEGORY_CLASS: Record<TrainCategory | 'None', string> = {
   WORK_TRAIN: 'work',
   None: 'none',
 };
+
+export const TIMETABLE_ITEM_DELTA = 5;


### PR DESCRIPTION
Since the paced trains, we lost the way to create multiple train schedule at once.
It feels better, for debugging purposes for example, to increase the start time of the train schedule when duplicating it like we do for paced trains.