### PR TITLE
front: add details to pathfinding error

### DIFF
--- a/front/public/locales/en/stdcm.json
+++ b/front/public/locales/en/stdcm.json
@@ -178,6 +178,17 @@
   "simulationSheet": "Simulation sheet",
   "spaceTimeGraphic": "Space-Time graph",
   "stdcmErrors": {
+    "incompatibleConstraintsDetails": {
+      "incompatibleElectrical_one": "- {{count}} electrification error",
+      "incompatibleElectrical_other": "- {{count}} electrification errors",
+      "incompatibleLoadingGauge_one": "- {{count}} loading gauge incompatibility",
+      "incompatibleLoadingGauge_other": "- {{count}} loading gauge incompatibilities",
+      "incompatibleSignalingSystem_one": "- {{count}} signaling system error",
+      "incompatibleSignalingSystem_other": "- {{count}} signaling system errors"
+    },
+    "incompatibleConstraints_one": "The requested path contains the following error:",
+    "incompatibleConstraints_other": "The requested path contains the following errors:",
+    "incompatibleConstraints_zero": "Constraint error on the requested path",
     "infraNotLoaded": "Infrastructure is loading",
     "invalidFields": {
       "maxSpeed": "the maximum speed of the consist",

--- a/front/public/locales/fr/stdcm.json
+++ b/front/public/locales/fr/stdcm.json
@@ -178,6 +178,17 @@
   "simulationSheet": "Fiche de simulation",
   "spaceTimeGraphic": "Graphique Espace-Temps",
   "stdcmErrors": {
+    "incompatibleConstraintsDetails": {
+      "incompatibleElectrical_one": "- {{count}} erreur d'électrification",
+      "incompatibleElectrical_other": "- {{count}} erreurs d'électrification",
+      "incompatibleLoadingGauge_one": "- {{count}} incompatibilité du gabarit",
+      "incompatibleLoadingGauge_other": "- {{count}} incompatibilités du gabarit",
+      "incompatibleSignalingSystem_one": "- {{count}} erreur de signalisation",
+      "incompatibleSignalingSystem_other": "- {{count}} erreurs de signalisation"
+    },
+    "incompatibleConstraints_one": "Le parcours demandé contient l'erreur suivante :",
+    "incompatibleConstraints_other": "Le parcours demandé contient les erreurs suivantes :",
+    "incompatibleConstraints_zero": "Erreur de contrainte sur le chemin demandé",
     "infraNotLoaded": "Infrastructure en cours de chargement",
     "invalidFields": {
       "maxSpeed": "la vitesse maximale du convoi",

--- a/front/src/applications/stdcm/components/StdcmWarningBox.tsx
+++ b/front/src/applications/stdcm/components/StdcmWarningBox.tsx
@@ -4,7 +4,12 @@ import { Button } from '@osrd-project/ui-core';
 import { Alert } from '@osrd-project/ui-icons';
 import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
+import { useSelector } from 'react-redux';
 
+import useInfraStatus from 'modules/pathfinding/hooks/useInfraStatus';
+import { getStdcmInfraID } from 'reducers/osrdconf/stdcmConf/selectors';
+
+import useStaticPathfinding from '../hooks/useStaticPathfinding';
 import { StdcmConfigErrorTypes, type StdcmConfigErrors } from '../types';
 
 const SHORT_TEXT_ERRORS = [StdcmConfigErrorTypes.INFRA_NOT_LOADED];
@@ -31,6 +36,40 @@ const StdcmWarningBox = ({
   const hasInvalidFields = (errorDetails?.invalidFields?.length ?? 0) > 0;
   const hasMissingFields = (errorDetails?.missingFields?.length ?? 0) > 0;
   const hasRouteErrors = (errorDetails?.routeErrors?.length ?? 0) > 0;
+
+  const infraId = useSelector(getStdcmInfraID);
+  const { infra } = useInfraStatus({ infraId });
+  const { pathfinding, isPathFindingLoading: _ } = useStaticPathfinding(infra);
+  const hasIncompatibleConstraints =
+    pathfinding?.status === 'failure' &&
+    pathfinding.failed_status === 'pathfinding_not_found' &&
+    pathfinding.error_type === 'incompatible_constraints';
+
+  const electricalConstraintCount = hasIncompatibleConstraints
+    ? pathfinding?.incompatible_constraints.incompatible_electrification_ranges.length
+    : 0;
+  const loadingGaugeConstraintCount = hasIncompatibleConstraints
+    ? pathfinding?.incompatible_constraints.incompatible_gauge_ranges.length
+    : 0;
+  const signalingSystemConstraintCount = hasIncompatibleConstraints
+    ? pathfinding?.incompatible_constraints.incompatible_signaling_system_ranges.length
+    : 0;
+  const errorConstraintCount =
+    electricalConstraintCount + loadingGaugeConstraintCount + signalingSystemConstraintCount;
+
+  const renderIncompatibleConstraintWarning = (
+    constraintType:
+      | 'incompatibleElectrical'
+      | 'incompatibleLoadingGauge'
+      | 'incompatibleSignalingSystem',
+    count: number
+  ) => {
+    if (count === 0) return null;
+
+    return (
+      <div>{t(`stdcmErrors.incompatibleConstraintsDetails.${constraintType}`, { count })}</div>
+    );
+  };
 
   return (
     <div ref={ref} data-testid="warning-box" className="warning-box">
@@ -67,14 +106,31 @@ const StdcmWarningBox = ({
       )}
 
       {!hasInvalidFields && !hasMissingFields && !hasRouteErrors && (
-        <p
-          className={cx('mb-0', {
+        <div
+          className={cx({
             'text-center': SHORT_TEXT_ERRORS.includes(errorType),
             'text-justify': !SHORT_TEXT_ERRORS.includes(errorType),
           })}
         >
-          {t(`stdcmErrors.${errorType}`)}
-        </p>
+          {!hasIncompatibleConstraints && t(`stdcmErrors.${errorType}`)}
+          {hasIncompatibleConstraints && (
+            <div>
+              {t(`stdcmErrors.incompatibleConstraints`, { count: errorConstraintCount })}
+              {renderIncompatibleConstraintWarning(
+                'incompatibleElectrical',
+                electricalConstraintCount
+              )}
+              {renderIncompatibleConstraintWarning(
+                'incompatibleLoadingGauge',
+                loadingGaugeConstraintCount
+              )}
+              {renderIncompatibleConstraintWarning(
+                'incompatibleSignalingSystem',
+                signalingSystemConstraintCount
+              )}
+            </div>
+          )}
+        </div>
       )}
 
       {hasInvalidFields && (

--- a/front/src/applications/stdcm/hooks/useStaticPathfinding.ts
+++ b/front/src/applications/stdcm/hooks/useStaticPathfinding.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { compact, isEqual } from 'lodash';
 import { useSelector } from 'react-redux';
@@ -85,12 +85,7 @@ const useStaticPathfinding = (infra?: InfraWithState) => {
     launchPathfinding();
   }, [pathStepsLocations, rollingStock, loadingGauge, infra]);
 
-  const result = useMemo(
-    () => (pathfinding ? { status: pathfinding.status } : null),
-    [pathfinding]
-  );
-
-  return { pathfinding: result, isPathFindingLoading: isFetching };
+  return { pathfinding, isPathFindingLoading: isFetching };
 };
 
 export default useStaticPathfinding;

--- a/front/src/applications/stdcm/hooks/useStaticPathfinding.ts
+++ b/front/src/applications/stdcm/hooks/useStaticPathfinding.ts
@@ -8,7 +8,6 @@ import {
   type InfraWithState,
   type PathfindingResult,
 } from 'common/api/osrdEditoastApi';
-import usePathProperties from 'modules/pathfinding/hooks/usePathProperties';
 import { getPathfindingQuery } from 'modules/pathfinding/utils';
 import { useStoreDataForRollingStockSelector } from 'modules/rollingStock/components/RollingStockSelector/useStoreDataForRollingStockSelector';
 import {
@@ -50,12 +49,6 @@ const useStaticPathfinding = (infra?: InfraWithState) => {
     });
   }, [pathSteps]);
 
-  const pathProperties = usePathProperties(
-    infra?.id,
-    pathfinding?.status === 'success' ? pathfinding : undefined,
-    ['geometry']
-  );
-
   useEffect(() => {
     const launchPathfinding = async () => {
       setPathfinding(undefined);
@@ -93,11 +86,8 @@ const useStaticPathfinding = (infra?: InfraWithState) => {
   }, [pathStepsLocations, rollingStock, loadingGauge, infra]);
 
   const result = useMemo(
-    () =>
-      pathfinding
-        ? { status: pathfinding.status, geometry: pathProperties?.geometry ?? undefined }
-        : null,
-    [pathfinding, pathProperties]
+    () => (pathfinding ? { status: pathfinding.status } : null),
+    [pathfinding]
   );
 
   return { pathfinding: result, isPathFindingLoading: isFetching };


### PR DESCRIPTION
Add details to the pathfindings error.

French text are validated by @Arthur-Lefebvre except for `incompatibleConstraints_zero` that should not be displayed (it is here for the future if there is a 4th category of error that is not implemented here)
English text are not validated

I removed the geometry from pathfinding of `useStaticPathfinding` because it was'nt used and replaced status by the whole PathfindingResult (that include status)