### PR TITLE
front: fix cat mismatch warning appearing globally

### DIFF
--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -266,6 +266,7 @@
     },
     "anyTrack": "Any track",
     "category": "Category",
+    "categoryMismatch": "The combination of the rolling stock and the category is unusual",
     "deleteRoute": "Delete the route",
     "deleteVias": "Delete steps",
     "destination": "Destination",

--- a/front/public/locales/en/translation.json
+++ b/front/public/locales/en/translation.json
@@ -698,7 +698,6 @@
       "choose": "Choose a category",
       "noCategory": "No category"
     },
-    "categoryMismatch": "The combination of the rolling stock and the category is unusual",
     "chooseRollingStock": "Select a rolling stock to display informations",
     "comfort": "Comfort",
     "comfortAcceleration": "Comfort acceleration",

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -266,6 +266,7 @@
     },
     "anyTrack": "Toutes voies",
     "category": "Catégorie",
+    "categoryMismatch": "L’association du matériel roulant et de la catégorie est atypique",
     "deleteRoute": "Supprimer l'itinéraire",
     "deleteVias": "Supprimer les étapes",
     "destination": "Destination",

--- a/front/public/locales/fr/translation.json
+++ b/front/public/locales/fr/translation.json
@@ -698,7 +698,6 @@
       "choose": "Choisissez une catégorie",
       "noCategory": "Pas de catégorie"
     },
-    "categoryMismatch": "L’association du matériel roulant et de la catégorie est atypique",
     "chooseRollingStock": "Sélectionnez un matériel roulant pour en afficher les informations.",
     "comfort": "Confort",
     "comfortAcceleration": "Accélération « confort »",

--- a/front/src/applications/operationalStudies/views/ManageTrainSchedule.tsx
+++ b/front/src/applications/operationalStudies/views/ManageTrainSchedule.tsx
@@ -32,6 +32,7 @@ import {
   updateRollingStockComfort,
 } from 'reducers/osrdconf/operationalStudiesConf';
 import {
+  getCategory,
   getConstraintDistribution,
   getDestination,
   getOperationalStudiesRollingStockID,
@@ -62,6 +63,7 @@ const ManageTrainSchedule = () => {
   const pathSteps = useSelector(getPathSteps);
   const speedLimitByTag = useSelector(getOperationalStudiesSpeedLimitByTag);
   const rollingStockId = useSelector(getOperationalStudiesRollingStockID);
+  const currentCategory = useSelector(getCategory);
 
   const markersInformation = useMemo(
     () =>
@@ -221,6 +223,13 @@ const ManageTrainSchedule = () => {
     []
   );
 
+  const showCategoryWarning =
+    rollingStock &&
+    currentCategory &&
+    currentCategory !== rollingStock.primary_category &&
+    !rollingStock.other_categories.includes(currentCategory);
+  const categoryWarning = showCategoryWarning ? t('categoryMismatch') : undefined;
+
   return (
     <>
       <div className="osrd-config-item-container mb-3">
@@ -232,6 +241,7 @@ const ManageTrainSchedule = () => {
         fullWidth
         fullHeight
         tabs={[tabRollingStock, tabPathFinding, tabTimesStops, tabSimulationSettings]}
+        warning={categoryWarning}
       />
     </>
   );

--- a/front/src/common/Tabs.tsx
+++ b/front/src/common/Tabs.tsx
@@ -1,15 +1,8 @@
 import { useState } from 'react';
 
 import cx from 'classnames';
-import { useTranslation } from 'react-i18next';
-import { useSelector } from 'react-redux';
 
 import AlertBox from 'common/AlertBox';
-import { useStoreDataForRollingStockSelector } from 'modules/rollingStock/components/RollingStockSelector/useStoreDataForRollingStockSelector';
-import {
-  getCategory,
-  getOperationalStudiesRollingStockID,
-} from 'reducers/osrdconf/operationalStudiesConf/selectors';
 
 type TabComponentProps = {
   label: string;
@@ -29,6 +22,7 @@ type TabsProps = {
   pills?: boolean;
   fullWidth?: boolean;
   fullHeight?: boolean;
+  warning?: string;
 };
 
 const Tab = ({ label, content }: TabComponentProps) => (
@@ -37,19 +31,14 @@ const Tab = ({ label, content }: TabComponentProps) => (
   </div>
 );
 
-const Tabs = ({ tabs, pills = false, fullWidth = false, fullHeight = false }: TabsProps) => {
+const Tabs = ({
+  tabs,
+  pills = false,
+  fullWidth = false,
+  fullHeight = false,
+  warning,
+}: TabsProps) => {
   const [activeTabIndex, setActiveTabIndex] = useState(0);
-  const { t } = useTranslation();
-  const currentCategory = useSelector(getCategory);
-  const rollingStockId = useSelector(getOperationalStudiesRollingStockID);
-  const { rollingStock } = useStoreDataForRollingStockSelector({
-    rollingStockId,
-  });
-  const showWarning =
-    rollingStock &&
-    currentCategory &&
-    currentCategory !== rollingStock.primary_category &&
-    !rollingStock.other_categories.includes(currentCategory);
 
   const handleTabClick = (index: number) => {
     setActiveTabIndex(index);
@@ -57,7 +46,7 @@ const Tabs = ({ tabs, pills = false, fullWidth = false, fullHeight = false }: Ta
 
   return (
     <div className={cx('tabs-container', { 'full-width': fullWidth, 'full-height': fullHeight })}>
-      {showWarning && <AlertBox message={t('rollingStock.categoryMismatch')} />}
+      {warning && <AlertBox message={warning} />}
       <div className={cx('tabs', pills && 'pills')}>
         {tabs.map((tab, index) => (
           <div


### PR DESCRIPTION
Close #12283

Tabs component is a generic component, used by unrelated parts of the application. It should not contain manage train schedule specific logic, nor fetch data from the store.

Thus move the managetrainschedule specific "category and rolling stock mismatch" warning
logic outside of tabs and into managetrainschedule, preventing it from appearing in other components unexpectedly.

(Note: in my opinion, this kind of bug would be much less likely to happen if we reduced our usage of the store.)