### PR TITLE
front: useSimulationResults now handles exceptions

### DIFF
--- a/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
+++ b/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
@@ -17,6 +17,7 @@ import {
   isTrainScheduleId,
   extractEditoastIdFromPacedTrainId,
   extractPacedTrainIdFromOccurrenceId,
+  isAddedExceptionId,
 } from 'utils/trainId';
 
 import type { SimulationResults } from '../types';
@@ -115,6 +116,10 @@ const useSimulationResults = (infraId: number): SimulationResults | undefined =>
         : undefined;
     }
     if (!selectedPacedTrain) return undefined;
+
+    if (isAddedExceptionId(selectedTrainId)) {
+      return undefined;
+    }
 
     const selectedOccurrenceIndex = extractOccurrenceIndexFromOccurrenceId(selectedTrainId);
     const pacedTrainIntervalInMs = Duration.parse(selectedPacedTrain.paced.interval).ms;

--- a/front/src/utils/trainId.ts
+++ b/front/src/utils/trainId.ts
@@ -22,7 +22,8 @@ export const isPacedTrainId = (id: string): id is PacedTrainId => id.startsWith(
 export const isIndexedOccurrenceId = (id: string): id is IndexedOccurrenceId =>
   id.startsWith('indexedoccurrence_');
 
-const isAddedExceptionId = (id: string): id is AddedExceptionId => id.startsWith('exception_');
+export const isAddedExceptionId = (id: string): id is AddedExceptionId =>
+  id.startsWith('exception_');
 
 export const isOccurrenceId = (id: string): id is OccurrenceId =>
   isIndexedOccurrenceId(id) || isAddedExceptionId(id);


### PR DESCRIPTION
The bug listed as #12281 is caused by useSimulationResults not being able to handle exceptions. When adding
an exception, disabling the first occurence
triggered the error 'The occurence id should
match the format "indexedoccurrence_{pacedTrainId}_{occurrenceIndex}"'
#12281

A cheap an quick fix is to return undefined
when the selectedTrainId is an exception in the
useSimulationResults hook.

Here's a demo of the fix tested on local environment:



https://github.com/user-attachments/assets/28efc0ef-bd11-4743-b458-293be54b7f8c


