### PR TITLE
front: change stdcm contact mail to deployment setting

### DIFF
--- a/front/public/locales/en/stdcm-help-section.json
+++ b/front/public/locales/en/stdcm-help-section.json
@@ -56,7 +56,7 @@
             },
             {
               "type": "text",
-              "value": "<a href='mailto:supportclients.SI@sncf.fr' target=\"_blank\">Contact us</a>"
+              "value": "<a href='mailto:{{stdcmFeedbackMail}}' target=\"_blank\">Contact us</a>"
             }
           ],
           "title": "Improvements"

--- a/front/public/locales/fr/stdcm-help-section.json
+++ b/front/public/locales/fr/stdcm-help-section.json
@@ -65,7 +65,7 @@
             },
             {
               "type": "text",
-              "value": "<a href='mailto:supportclients.SI@sncf.fr' target=\"_blank\">Contactez-nous</a>"
+              "value": "<a href='mailto:{{stdcmFeedbackMail}}' target=\"_blank\">Contactez-nous</a>"
             }
           ],
           "title": "Améliorations"

--- a/front/src/applications/stdcm/components/StdcmHelpModule/HelpSection.tsx
+++ b/front/src/applications/stdcm/components/StdcmHelpModule/HelpSection.tsx
@@ -2,6 +2,8 @@ import { ArrowLeft } from '@osrd-project/ui-icons';
 import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
 
+import useDeploymentSettings from 'utils/hooks/useDeploymentSettings';
+
 import SectionContentManager from './SectionContentManager';
 import type { Section } from './types';
 
@@ -13,7 +15,11 @@ type HelpSectionProps = {
 
 const HelpSection = ({ section, isActive, closeHelpSection }: HelpSectionProps) => {
   const { t } = useTranslation('stdcm-help-section');
-  const currentSection = t(`sections.${section}`, { returnObjects: true }) as Section;
+  const stdcmFeedbackMail = useDeploymentSettings()?.stdcmFeedbackMail;
+  const currentSection = t(`sections.${section}`, {
+    returnObjects: true,
+    stdcmFeedbackMail,
+  }) as Section;
 
   return (
     <div className={cx('stdcm__help-section', { active: isActive })}>


### PR DESCRIPTION
Close https://github.com/issues/assigned?issue=osrd-project%7Cosrd-confidential%7C1088 (osrd-confidential issue)

Change the contact us email adress in the stdcm help section to the feedback mail defined in the deployment settings.

This feedback mail was previously only used in the contact form under the simulations, but users would prefer the form from the help section to also use this email, as the current static one was not the most relevant.