### PR TITLE
editoast: etcs endpoint ps and gui curves cannot be null

### DIFF
--- a/editoast/core_client/src/etcs_braking_curves.rs
+++ b/editoast/core_client/src/etcs_braking_curves.rs
@@ -44,9 +44,9 @@ pub struct ETCSCurves {
     #[schema(inline)]
     pub indication: Option<SimpleEnvelope>,
     #[schema(inline)]
-    pub permitted_speed: Option<SimpleEnvelope>,
+    pub permitted_speed: SimpleEnvelope,
     #[schema(inline)]
-    pub guidance: Option<SimpleEnvelope>,
+    pub guidance: SimpleEnvelope,
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug, ToSchema)]

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -4862,38 +4862,39 @@ components:
           description: List of ETCS braking curves associated to the train schedule's ETCS stops
     ETCSCurves:
       type: object
+      required:
+      - permitted_speed
+      - guidance
       properties:
         guidance:
-          allOf:
-          - type: object
-            required:
-            - positions
-            - times
-            - speeds
-            properties:
-              positions:
-                type: array
-                items:
-                  type: integer
-                  format: int64
-                  minimum: 0
-                description: |-
-                  List of positions of a train
-                  Both positions (in mm) and times (in ms) must have the same length
-              speeds:
-                type: array
-                items:
-                  type: number
-                  format: double
-                description: List of speeds (in m/s) associated to a position
-              times:
-                type: array
-                items:
-                  type: integer
-                  format: int64
-                  minimum: 0
-                description: List of times (in ms) associated to a position
-          nullable: true
+          type: object
+          required:
+          - positions
+          - times
+          - speeds
+          properties:
+            positions:
+              type: array
+              items:
+                type: integer
+                format: int64
+                minimum: 0
+              description: |-
+                List of positions of a train
+                Both positions (in mm) and times (in ms) must have the same length
+            speeds:
+              type: array
+              items:
+                type: number
+                format: double
+              description: List of speeds (in m/s) associated to a position
+            times:
+              type: array
+              items:
+                type: integer
+                format: int64
+                minimum: 0
+              description: List of times (in ms) associated to a position
         indication:
           allOf:
           - type: object
@@ -4926,36 +4927,34 @@ components:
                 description: List of times (in ms) associated to a position
           nullable: true
         permitted_speed:
-          allOf:
-          - type: object
-            required:
-            - positions
-            - times
-            - speeds
-            properties:
-              positions:
-                type: array
-                items:
-                  type: integer
-                  format: int64
-                  minimum: 0
-                description: |-
-                  List of positions of a train
-                  Both positions (in mm) and times (in ms) must have the same length
-              speeds:
-                type: array
-                items:
-                  type: number
-                  format: double
-                description: List of speeds (in m/s) associated to a position
-              times:
-                type: array
-                items:
-                  type: integer
-                  format: int64
-                  minimum: 0
-                description: List of times (in ms) associated to a position
-          nullable: true
+          type: object
+          required:
+          - positions
+          - times
+          - speeds
+          properties:
+            positions:
+              type: array
+              items:
+                type: integer
+                format: int64
+                minimum: 0
+              description: |-
+                List of positions of a train
+                Both positions (in mm) and times (in ms) must have the same length
+            speeds:
+              type: array
+              items:
+                type: number
+                format: double
+              description: List of speeds (in m/s) associated to a position
+            times:
+              type: array
+              items:
+                type: integer
+                format: int64
+                minimum: 0
+              description: List of times (in ms) associated to a position
     EditoastAppHealthErrorCore:
       type: object
       required:

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -4375,7 +4375,7 @@ export type TrainScheduleForm = TrainSchedule & {
   timetable_id?: number | null;
 };
 export type EtcsCurves = {
-  guidance?: {
+  guidance: {
     /** List of positions of a train
         Both positions (in mm) and times (in ms) must have the same length */
     positions: number[];
@@ -4383,7 +4383,7 @@ export type EtcsCurves = {
     speeds: number[];
     /** List of times (in ms) associated to a position */
     times: number[];
-  } | null;
+  };
   indication?: {
     /** List of positions of a train
         Both positions (in mm) and times (in ms) must have the same length */
@@ -4393,7 +4393,7 @@ export type EtcsCurves = {
     /** List of times (in ms) associated to a position */
     times: number[];
   } | null;
-  permitted_speed?: {
+  permitted_speed: {
     /** List of positions of a train
         Both positions (in mm) and times (in ms) must have the same length */
     positions: number[];
@@ -4401,7 +4401,7 @@ export type EtcsCurves = {
     speeds: number[];
     /** List of times (in ms) associated to a position */
     times: number[];
-  } | null;
+  };
 };
 export type EtcsBrakingCurvesResponse = {
   /** List of ETCS braking curves associated to the train schedule's ETCS signals */


### PR DESCRIPTION
Make ps and gui curves returned by ETCS braking curves endpoint compulsory. Only the indication may be null in some cases.