### PR TITLE
core, editoast: use simple envelope in simulation response

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/api/CommonSchemas.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/CommonSchemas.kt
@@ -95,3 +95,9 @@ data class WorkSchedule(
     @Json(name = "start_time") val startTime: TimeDelta,
     @Json(name = "end_time") val endTime: TimeDelta,
 )
+
+data class SimpleEnvelope(
+    val positions: List<Offset<TravelledPath>>,
+    val times: List<TimeDelta>, // Times are compared to the departure time
+    val speeds: List<Double>,
+)

--- a/core/src/main/kotlin/fr/sncf/osrd/api/etcs/ETCSBrakingCurvesResponse.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/etcs/ETCSBrakingCurvesResponse.kt
@@ -4,10 +4,8 @@ import com.squareup.moshi.Json
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
-import fr.sncf.osrd.sim_infra.api.TravelledPath
+import fr.sncf.osrd.api.SimpleEnvelope
 import fr.sncf.osrd.utils.json.UnitAdapterFactory
-import fr.sncf.osrd.utils.units.Offset
-import fr.sncf.osrd.utils.units.TimeDelta
 
 data class ETCSBrakingCurvesResponse(
     val slowdowns: List<ETCSCurves>,
@@ -19,12 +17,6 @@ data class ETCSCurves(
     val indication: SimpleEnvelope?, // null for open-signal stops
     @Json(name = "permitted_speed") val permittedSpeed: SimpleEnvelope,
     val guidance: SimpleEnvelope
-)
-
-data class SimpleEnvelope(
-    val positions: List<Offset<TravelledPath>>,
-    val times: List<TimeDelta>, // Times are compared to the departure time
-    val speeds: List<Double>,
 )
 
 val etcsBrakingCurvesResponseAdapter: JsonAdapter<ETCSBrakingCurvesResponse> =

--- a/core/src/main/kotlin/fr/sncf/osrd/api/standalone_sim/SimulationResponse.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/standalone_sim/SimulationResponse.kt
@@ -9,9 +9,7 @@ import fr.sncf.osrd.api.*
 import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.sim_infra.api.SpeedLimitProperty
 import fr.sncf.osrd.sim_infra.api.SpeedLimitSource
-import fr.sncf.osrd.sim_infra.api.TravelledPath
 import fr.sncf.osrd.utils.json.UnitAdapterFactory
-import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.TimeDelta
 
 interface SimulationResponse
@@ -40,9 +38,7 @@ sealed class ElectricalProfileValue {
 }
 
 class CompleteReportTrain(
-    positions: List<Offset<TravelledPath>>,
-    times: List<TimeDelta>, // Times are compared to the departure time
-    speeds: List<Double>,
+    envelope: SimpleEnvelope,
     @Json(name = "energy_consumption") energyConsumption: Double,
     @Json(name = "path_item_times") pathItemTimes: List<TimeDelta>,
     @Json(name = "signal_critical_positions")
@@ -50,12 +46,10 @@ class CompleteReportTrain(
     @Json(name = "zone_updates") val zoneUpdates: List<ZoneUpdate>,
     @Json(name = "spacing_requirements") val spacingRequirements: List<RJSSpacingRequirement>,
     @Json(name = "routing_requirements") val routingRequirements: List<RJSRoutingRequirement>
-) : ReportTrain(positions, times, speeds, energyConsumption, pathItemTimes)
+) : ReportTrain(envelope, energyConsumption, pathItemTimes)
 
 open class ReportTrain(
-    val positions: List<Offset<TravelledPath>>,
-    val times: List<TimeDelta>, // Times are compared to the departure time
-    val speeds: List<Double>,
+    val envelope: SimpleEnvelope,
     @Json(name = "energy_consumption") val energyConsumption: Double,
     @Json(name = "path_item_times") val pathItemTimes: List<TimeDelta>,
 )

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
@@ -215,9 +215,7 @@ class STDCMEndpoint(private val infraManager: InfraProvider) : Take {
         // Lighter description of the same simulation result
         val simpleReportTrain =
             ReportTrain(
-                reportTrain.positions,
-                reportTrain.times,
-                reportTrain.speeds,
+                reportTrain.envelope,
                 reportTrain.energyConsumption,
                 reportTrain.pathItemTimes
             )

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
@@ -285,9 +285,7 @@ fun runScheduleMetadataExtractor(
             pathItemPositions
         )
     return CompleteReportTrain(
-        reportTrain.positions,
-        reportTrain.times,
-        reportTrain.speeds,
+        reportTrain.envelope,
         reportTrain.energyConsumption,
         reportTrain.pathItemTimes,
         signalCriticalPositions,
@@ -342,9 +340,11 @@ fun makeSimpleReportTrain(
     assert(simplified.isNotEmpty()) { "simulation result shouldn't be empty" }
 
     return ReportTrain(
-        simplified.map { Offset(it.position.meters) },
-        simplified.map { it.time.seconds },
-        simplified.map { it.speed },
+        SimpleEnvelope(
+            simplified.map { Offset(it.position.meters) },
+            simplified.map { it.time.seconds },
+            simplified.map { it.speed },
+        ),
         mechanicalEnergyConsumed,
         pathItemTimes,
     )

--- a/core/src/test/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulationTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulationTest.kt
@@ -252,15 +252,15 @@ class StandaloneSimulationTest {
             val arrival =
                 getTimeAt(
                     scheduledPoint.pathOffset,
-                    res.finalOutput.positions,
-                    res.finalOutput.times,
+                    res.finalOutput.envelope.positions,
+                    res.finalOutput.envelope.times,
                     false
                 )
             val departure =
                 getTimeAt(
                     scheduledPoint.pathOffset,
-                    res.finalOutput.positions,
-                    res.finalOutput.times,
+                    res.finalOutput.envelope.positions,
+                    res.finalOutput.envelope.times,
                     true
                 )
             if (scheduledPoint.arrival != null) {
@@ -438,7 +438,7 @@ class StandaloneSimulationTest {
         train: ReportTrain,
         interpolateRight: Boolean
     ): Double {
-        return getTimeAt(offset, train.positions, train.times, interpolateRight)
+        return getTimeAt(offset, train.envelope.positions, train.envelope.times, interpolateRight)
     }
 
     /**

--- a/editoast/core_client/src/etcs_braking_curves.rs
+++ b/editoast/core_client/src/etcs_braking_curves.rs
@@ -4,6 +4,7 @@ use utoipa::ToSchema;
 
 use crate::AsCoreRequest;
 use crate::Json;
+use crate::simulation::SimpleEnvelope;
 use crate::simulation::{
     PhysicsConsist, SimulationPath, SimulationPowerRestrictionItem, SimulationScheduleItem,
     SpeedLimitProperties,
@@ -47,17 +48,6 @@ pub struct ETCSCurves {
     pub permitted_speed: Option<SimpleEnvelope>,
     #[schema(inline)]
     pub guidance: Option<SimpleEnvelope>,
-}
-
-#[derive(Serialize, Deserialize, PartialEq, Clone, Debug, ToSchema)]
-pub struct SimpleEnvelope {
-    /// List of positions of a train
-    /// Both positions (in mm) and times (in ms) must have the same length
-    pub positions: Vec<u64>,
-    /// List of times (in ms) associated to a position
-    pub times: Vec<u64>,
-    /// List of speeds (in m/s) associated to a position
-    pub speeds: Vec<f64>,
 }
 
 impl AsCoreRequest<Json<Response>> for Request {

--- a/editoast/core_client/src/simulation.rs
+++ b/editoast/core_client/src/simulation.rs
@@ -36,6 +36,7 @@ editoast_common::schemas! {
     RoutingZoneRequirement,
     ZoneUpdate,
     ReportTrain,
+    SimpleEnvelope,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Educe, ToSchema)]
@@ -144,14 +145,21 @@ pub struct SimulationPath {
     pub path_item_positions: Vec<u64>,
 }
 
+#[derive(Serialize, Deserialize, Default, PartialEq, Clone, Debug, ToSchema)]
+pub struct SimpleEnvelope {
+    /// List of positions of a train
+    /// Positions (in mm), speeds (in m/s) and times (in ms) must have the same length
+    pub positions: Vec<u64>,
+    /// List of times (in ms) associated to a position
+    pub times: Vec<u64>,
+    /// List of speeds (in m/s) associated to a position
+    pub speeds: Vec<f64>,
+}
+
 #[derive(Deserialize, Default, PartialEq, Serialize, Clone, Debug, ToSchema)]
 pub struct ReportTrain {
-    /// List of positions of a train
-    /// Both positions (in mm) and times (in ms) must have the same length
-    pub positions: Vec<u64>,
-    pub times: Vec<u64>,
-    /// List of speeds associated to a position
-    pub speeds: Vec<f64>,
+    #[serde(flatten)]
+    pub envelope: SimpleEnvelope,
     /// Total energy consumption
     pub energy_consumption: f64,
     /// Time in ms of each path item given as input of the pathfinding

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -4879,7 +4879,7 @@ components:
                   minimum: 0
                 description: |-
                   List of positions of a train
-                  Both positions (in mm) and times (in ms) must have the same length
+                  Positions (in mm), speeds (in m/s) and times (in ms) must have the same length
               speeds:
                 type: array
                 items:
@@ -4910,7 +4910,7 @@ components:
                   minimum: 0
                 description: |-
                   List of positions of a train
-                  Both positions (in mm) and times (in ms) must have the same length
+                  Positions (in mm), speeds (in m/s) and times (in ms) must have the same length
               speeds:
                 type: array
                 items:
@@ -4941,7 +4941,7 @@ components:
                   minimum: 0
                 description: |-
                   List of positions of a train
-                  Both positions (in mm) and times (in ms) must have the same length
+                  Positions (in mm), speeds (in m/s) and times (in ms) must have the same length
               speeds:
                 type: array
                 items:
@@ -10639,48 +10639,26 @@ components:
         value:
           description: Value to replace with.
     ReportTrain:
-      type: object
-      required:
-      - positions
-      - times
-      - speeds
-      - energy_consumption
-      - path_item_times
-      properties:
-        energy_consumption:
-          type: number
-          format: double
-          description: Total energy consumption
-        path_item_times:
-          type: array
-          items:
-            type: integer
-            format: int64
-            minimum: 0
-          description: |-
-            Time in ms of each path item given as input of the pathfinding
-            The first value is always `0` (beginning of the path) and the last one, the total time of the simulation (end of the path)
-        positions:
-          type: array
-          items:
-            type: integer
-            format: int64
-            minimum: 0
-          description: |-
-            List of positions of a train
-            Both positions (in mm) and times (in ms) must have the same length
-        speeds:
-          type: array
-          items:
+      allOf:
+      - $ref: '#/components/schemas/SimpleEnvelope'
+      - type: object
+        required:
+        - energy_consumption
+        - path_item_times
+        properties:
+          energy_consumption:
             type: number
             format: double
-          description: List of speeds associated to a position
-        times:
-          type: array
-          items:
-            type: integer
-            format: int64
-            minimum: 0
+            description: Total energy consumption
+          path_item_times:
+            type: array
+            items:
+              type: integer
+              format: int64
+              minimum: 0
+            description: |-
+              Time in ms of each path item given as input of the pathfinding
+              The first value is always `0` (beginning of the path) and the last one, the total time of the simulation (end of the path)
     ResourceType:
       type: string
       enum:
@@ -11998,6 +11976,35 @@ components:
         ci:
           type: integer
           format: int64
+    SimpleEnvelope:
+      type: object
+      required:
+      - positions
+      - times
+      - speeds
+      properties:
+        positions:
+          type: array
+          items:
+            type: integer
+            format: int64
+            minimum: 0
+          description: |-
+            List of positions of a train
+            Positions (in mm), speeds (in m/s) and times (in ms) must have the same length
+        speeds:
+          type: array
+          items:
+            type: number
+            format: double
+          description: List of speeds (in m/s) associated to a position
+        times:
+          type: array
+          items:
+            type: integer
+            format: int64
+            minimum: 0
+          description: List of times (in ms) associated to a position
     SimulationResponse:
       oneOf:
       - allOf:

--- a/editoast/src/views/projection.rs
+++ b/editoast/src/views/projection.rs
@@ -393,14 +393,12 @@ pub async fn extract_train_details(
             }
             _ => continue,
         };
-        let ReportTrain {
-            times, positions, ..
-        } = report_train;
+        let ReportTrain { envelope, .. } = report_train;
 
         let train_details = TrainSimulationDetails {
             train_id: train.id,
-            positions,
-            times,
+            positions: envelope.positions,
+            times: envelope.times,
             signal_critical_positions,
             zone_updates,
             train_path: track_ranges.clone(),

--- a/editoast/src/views/stdcm_logs.rs
+++ b/editoast/src/views/stdcm_logs.rs
@@ -163,6 +163,7 @@ mod tests {
     use core_client::simulation::ElectricalProfiles;
     use core_client::simulation::ReportTrain;
     use core_client::simulation::Response;
+    use core_client::simulation::SimpleEnvelope;
     use core_client::simulation::SimulationSuccess;
     use core_client::simulation::SpeedLimitProperties;
     use editoast_authz as authz;
@@ -283,24 +284,30 @@ mod tests {
     fn simulation_response() -> Response {
         Response::Success(SimulationSuccess {
             base: ReportTrain {
-                positions: vec![],
-                times: vec![],
-                speeds: vec![],
+                envelope: SimpleEnvelope {
+                    positions: vec![],
+                    times: vec![],
+                    speeds: vec![],
+                },
                 energy_consumption: 0.0,
                 path_item_times: vec![0, 10],
             },
             provisional: ReportTrain {
-                positions: vec![],
-                times: vec![0, 10],
-                speeds: vec![],
+                envelope: SimpleEnvelope {
+                    positions: vec![],
+                    times: vec![],
+                    speeds: vec![],
+                },
                 energy_consumption: 0.0,
                 path_item_times: vec![0, 10],
             },
             final_output: CompleteReportTrain {
                 report_train: ReportTrain {
-                    positions: vec![],
-                    times: vec![],
-                    speeds: vec![],
+                    envelope: SimpleEnvelope {
+                        positions: vec![],
+                        times: vec![],
+                        speeds: vec![],
+                    },
                     energy_consumption: 0.0,
                     path_item_times: vec![0, 10],
                 },

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -693,6 +693,7 @@ mod tests {
     use core_client::simulation::CompleteReportTrain;
     use core_client::simulation::ElectricalProfiles;
     use core_client::simulation::ReportTrain;
+    use core_client::simulation::SimpleEnvelope;
     use core_client::simulation::SimulationSuccess;
     use core_client::simulation::SpeedLimitProperties;
     use editoast_models::DbConnectionPoolV2;
@@ -974,24 +975,30 @@ mod tests {
             response,
             core_client::simulation::Response::Success(SimulationSuccess {
                 base: ReportTrain {
-                    positions: vec![],
-                    times: vec![],
-                    speeds: vec![],
+                    envelope: SimpleEnvelope {
+                        positions: vec![],
+                        times: vec![],
+                        speeds: vec![],
+                    },
                     energy_consumption: 0.0,
                     path_item_times: vec![0, 1000, 2000, 3000]
                 },
                 provisional: ReportTrain {
-                    positions: vec![],
-                    times: vec![],
-                    speeds: vec![],
+                    envelope: SimpleEnvelope {
+                        positions: vec![],
+                        times: vec![],
+                        speeds: vec![],
+                    },
                     energy_consumption: 0.0,
                     path_item_times: vec![0, 1000, 2000, 3000]
                 },
                 final_output: CompleteReportTrain {
                     report_train: ReportTrain {
-                        positions: vec![0],
-                        times: vec![0],
-                        speeds: vec![],
+                        envelope: SimpleEnvelope {
+                            positions: vec![],
+                            times: vec![],
+                            speeds: vec![],
+                        },
                         energy_consumption: 0.0,
                         path_item_times: vec![0, 1000, 2000, 3000]
                     },
@@ -1047,24 +1054,30 @@ mod tests {
             response,
             simulation::Response::Success(SimulationResponseSuccess {
                 base: ReportTrain {
-                    positions: vec![],
-                    times: vec![],
-                    speeds: vec![],
+                    envelope: SimpleEnvelope {
+                        positions: vec![],
+                        times: vec![],
+                        speeds: vec![],
+                    },
                     energy_consumption: 0.0,
                     path_item_times: vec![0, 1000, 2000, 3000]
                 },
                 provisional: ReportTrain {
-                    positions: vec![],
-                    times: vec![],
-                    speeds: vec![],
+                    envelope: SimpleEnvelope {
+                        positions: vec![],
+                        times: vec![],
+                        speeds: vec![],
+                    },
                     energy_consumption: 0.0,
                     path_item_times: vec![0, 1000, 2000, 3000]
                 },
                 final_output: CompleteReportTrain {
                     report_train: ReportTrain {
-                        positions: vec![0],
-                        times: vec![0],
-                        speeds: vec![],
+                        envelope: SimpleEnvelope {
+                            positions: vec![],
+                            times: vec![],
+                            speeds: vec![],
+                        },
                         energy_consumption: 0.0,
                         path_item_times: vec![0, 1000, 2000, 3000]
                     },

--- a/editoast/src/views/timetable/simulation.rs
+++ b/editoast/src/views/timetable/simulation.rs
@@ -85,6 +85,7 @@ impl Response {
         if let Response::Success(SimulationResponseSuccess { provisional, .. }) = self {
             Some(
                 *provisional
+                    .envelope
                     .times
                     .last()
                     .expect("core error: empty simulation result"),
@@ -166,8 +167,8 @@ impl From<simulation::Response> for SummaryResponse {
             }) => {
                 let report = final_output.report_train;
                 Self::Success {
-                    length: *report.positions.last().unwrap(),
-                    time: *report.times.last().unwrap(),
+                    length: *report.envelope.positions.last().unwrap(),
+                    time: *report.envelope.times.last().unwrap(),
                     energy_consumption: report.energy_consumption,
                     path_item_times_final: report.path_item_times.clone(),
                     path_item_times_provisional: provisional.path_item_times.clone(),

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -404,7 +404,12 @@ fn build_train_requirements(
 
         // First check that the train overlaps with the simulation range
         let start_time = train.start_time;
-        let train_duration_ms = *final_output.report_train.times.last().unwrap_or(&0);
+        let train_duration_ms = *final_output
+            .report_train
+            .envelope
+            .times
+            .last()
+            .unwrap_or(&0);
         if !is_resource_in_range(
             departure_time,
             latest_simulation_end,
@@ -561,6 +566,7 @@ fn build_single_margin(margin: Option<MarginValue>) -> Margins {
 mod tests {
     use axum::http::StatusCode;
     use chrono::DateTime;
+    use core_client::simulation::SimpleEnvelope;
     use core_client::simulation::SimulationSuccess;
     use editoast_common::units;
     use editoast_models::DbConnectionPoolV2;
@@ -696,24 +702,30 @@ mod tests {
     fn simulation_response() -> core_client::simulation::Response {
         core_client::simulation::Response::Success(SimulationSuccess {
             base: ReportTrain {
-                positions: vec![],
-                times: vec![],
-                speeds: vec![],
+                envelope: SimpleEnvelope {
+                    positions: vec![],
+                    times: vec![],
+                    speeds: vec![],
+                },
                 energy_consumption: 0.0,
                 path_item_times: vec![0, 10],
             },
             provisional: ReportTrain {
-                positions: vec![],
-                times: vec![0, 10],
-                speeds: vec![],
+                envelope: SimpleEnvelope {
+                    positions: vec![],
+                    times: vec![],
+                    speeds: vec![],
+                },
                 energy_consumption: 0.0,
                 path_item_times: vec![0, 10],
             },
             final_output: CompleteReportTrain {
                 report_train: ReportTrain {
-                    positions: vec![],
-                    times: vec![],
-                    speeds: vec![],
+                    envelope: SimpleEnvelope {
+                        positions: vec![],
+                        times: vec![],
+                        speeds: vec![],
+                    },
                     energy_consumption: 0.0,
                     path_item_times: vec![0, 10],
                 },

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -977,15 +977,15 @@ fn interpolate_track_occupancy(
         .iter()
         .filter_map(|track_offset| {
             path_projection.get_position(track_offset).map(|position| {
-                let index = find_index_upper(&report_train.positions, position);
+                let index = find_index_upper(&report_train.envelope.positions, position);
                 let time = if index == 0 {
-                    report_train.times[0]
+                    report_train.envelope.times[0]
                 } else {
                     interpolate(
-                        report_train.positions[index - 1],
-                        report_train.positions[index],
-                        report_train.times[index - 1],
-                        report_train.times[index],
+                        report_train.envelope.positions[index - 1],
+                        report_train.envelope.positions[index],
+                        report_train.envelope.times[index - 1],
+                        report_train.envelope.times[index],
                         position,
                     )
                 };
@@ -1116,6 +1116,7 @@ pub mod tests {
     #[cfg(test)]
     use core_client::mocking::MockingClient;
     use core_client::pathfinding::TrackRange;
+    use core_client::simulation::SimpleEnvelope;
     use editoast_schemas::infra::Direction;
     use editoast_schemas::primitives::Identifier;
     use editoast_schemas::train_schedule::{
@@ -1486,9 +1487,11 @@ pub mod tests {
             offset,
         }];
         let report_train = ReportTrain {
-            positions: positions.clone(),
-            times: times.clone(),
-            speeds: vec![10.0; positions.len()],
+            envelope: SimpleEnvelope {
+                positions: positions.clone(),
+                times: times.clone(),
+                speeds: vec![10.0; positions.len()],
+            },
             energy_consumption: 0.0,
             path_item_times: vec![0, 1000],
         };
@@ -1536,9 +1539,11 @@ pub mod tests {
         }];
 
         let report_train = ReportTrain {
-            positions: vec![0, 50, 100, 150],
-            times: vec![0, expected_time, 2000, 3000],
-            speeds: vec![10.0; 4],
+            envelope: SimpleEnvelope {
+                positions: vec![0, 50, 100, 150],
+                times: vec![0, expected_time, 2000, 3000],
+                speeds: vec![10.0; 4],
+            },
             energy_consumption: 0.0,
             path_item_times: vec![0, expected_time, 2000],
         };

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -3601,18 +3601,21 @@ export type PacedTrainResponse = PacedTrain & {
   id: number;
   timetable_id: number;
 };
-export type ReportTrain = {
+export type SimpleEnvelope = {
+  /** List of positions of a train
+    Positions (in mm), speeds (in m/s) and times (in ms) must have the same length */
+  positions: number[];
+  /** List of speeds (in m/s) associated to a position */
+  speeds: number[];
+  /** List of times (in ms) associated to a position */
+  times: number[];
+};
+export type ReportTrain = SimpleEnvelope & {
   /** Total energy consumption */
   energy_consumption: number;
   /** Time in ms of each path item given as input of the pathfinding
     The first value is always `0` (beginning of the path) and the last one, the total time of the simulation (end of the path) */
   path_item_times: number[];
-  /** List of positions of a train
-    Both positions (in mm) and times (in ms) must have the same length */
-  positions: number[];
-  /** List of speeds associated to a position */
-  speeds: number[];
-  times: number[];
 };
 export type RoutingZoneRequirement = {
   /** Time in ms */
@@ -4377,7 +4380,7 @@ export type TrainScheduleForm = TrainSchedule & {
 export type EtcsCurves = {
   guidance?: {
     /** List of positions of a train
-        Both positions (in mm) and times (in ms) must have the same length */
+        Positions (in mm), speeds (in m/s) and times (in ms) must have the same length */
     positions: number[];
     /** List of speeds (in m/s) associated to a position */
     speeds: number[];
@@ -4386,7 +4389,7 @@ export type EtcsCurves = {
   } | null;
   indication?: {
     /** List of positions of a train
-        Both positions (in mm) and times (in ms) must have the same length */
+        Positions (in mm), speeds (in m/s) and times (in ms) must have the same length */
     positions: number[];
     /** List of speeds (in m/s) associated to a position */
     speeds: number[];
@@ -4395,7 +4398,7 @@ export type EtcsCurves = {
   } | null;
   permitted_speed?: {
     /** List of positions of a train
-        Both positions (in mm) and times (in ms) must have the same length */
+        Positions (in mm), speeds (in m/s) and times (in ms) must have the same length */
     positions: number[];
     /** List of speeds (in m/s) associated to a position */
     speeds: number[];


### PR DESCRIPTION
Mutualise `SimpleEnvelope` in core and editoast for the ETCS braking curves endpoint and the simulation endpoint.

Weirdly enough I thought `flatten` would make the integration/end to end tests not fail, but it seems there's still a pb -> yeah so basically flatten works for serialization and deserialization, meaning I can't both have a `SimpleEnvelope` coming from core and a flattened `positions, times, speeds` being sent to the frontend with the same common struct `SimpleEnvelope`.