### PR TITLE
front: memorize if occurrence list open in train list

### DIFF
--- a/front/public/locales/en/translation.json
+++ b/front/public/locales/en/translation.json
@@ -268,7 +268,7 @@
         "end": "Arrival",
         "endpoint": "Endpoint:",
         "from": "from",
-        "geometry-error": "An exception occured during calculation of this route",
+        "geometry-error": "An exception occurred during calculation of this route",
         "help": {
           "actions-on-edit-route": "You can delete the route, edit it or create a new one.",
           "select-endpoints": "The route must have a starting and ending point.",
@@ -422,7 +422,7 @@
         "attached-electrifications": "electrifications",
         "attached-speed-sections": "Speed limits",
         "default-electrifications-error": "An error occurred when loading the electrifications linked to this track section.",
-        "default-speed-sections-error": "An exception occured when loading speed limits related to this track section.",
+        "default-speed-sections-error": "An exception occurred when loading speed limits related to this track section.",
         "help": {
           "add-anchor-point": "Click to add a point at the end of the track section. Click on the track to add an intermediate point.",
           "add-point": "Click to add a point at the end of the track section.",

--- a/front/scripts/i18n-checker.ts
+++ b/front/scripts/i18n-checker.ts
@@ -81,7 +81,7 @@ async function readJsonFile<T extends { [key: string]: unknown }>(filePath: stri
     const data = await readFile(filePath, 'utf-8');
     return JSON.parse(data) as T;
   } catch (e) {
-    console.error(`Problem occured while reading ${filePath}`);
+    console.error(`Problem occurred while reading ${filePath}`);
     throw e;
   }
 }

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/PacedTrainSettings/AddedOccurrences.tsx
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/PacedTrainSettings/AddedOccurrences.tsx
@@ -10,7 +10,7 @@ import { getAddedExceptions } from 'reducers/osrdconf/operationalStudiesConf/sel
 import { useAppDispatch } from 'store';
 import { formatLocalDate, formatLocalTime } from 'utils/date';
 
-const AddedOccurences = () => {
+const AddedOccurrences = () => {
   const [date, setDate] = useState('');
   const [time, setTime] = useState('');
   const addedExceptions = useSelector(getAddedExceptions);
@@ -105,4 +105,4 @@ const AddedOccurences = () => {
   );
 };
 
-export default AddedOccurences;
+export default AddedOccurrences;

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/PacedTrainSettings/PacedTrainSettings.tsx
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/PacedTrainSettings/PacedTrainSettings.tsx
@@ -8,7 +8,7 @@ import { getTimeWindow, getInterval } from 'reducers/osrdconf/operationalStudies
 import { useAppDispatch } from 'store';
 import { Duration } from 'utils/duration';
 
-import AddedOccurences from './AddedOccurences';
+import AddedOccurrences from './AddedOccurrences';
 
 const PacedTrainSettings = () => {
   const timeWindow = useSelector(getTimeWindow).total('minute');
@@ -66,7 +66,7 @@ const PacedTrainSettings = () => {
           />
         </span>
       </div>
-      <AddedOccurences />
+      <AddedOccurrences />
     </div>
   );
 };

--- a/front/src/modules/trainschedule/components/Timetable/PacedTrain/PacedTrainItem.tsx
+++ b/front/src/modules/trainschedule/components/Timetable/PacedTrain/PacedTrainItem.tsx
@@ -1,4 +1,4 @@
-import { useContext, useState } from 'react';
+import { useContext } from 'react';
 
 import { Checkbox } from '@osrd-project/ui-core';
 import { ChevronDown, ChevronRight, Clock, Flame, Manchette } from '@osrd-project/ui-icons';
@@ -47,6 +47,8 @@ import useOccurrenceActions from './hooks/useOccurrenceActions';
 type PacedTrainItemProps = {
   isInSelection: boolean;
   handleSelectPacedTrain: (pacedTrainId: PacedTrainId) => void;
+  isOccurrencesListOpen: boolean;
+  handleOpenOccurrencesList: (pacedTrainId: PacedTrainId) => void;
   pacedTrain: PacedTrainWithDetails;
   isOnEdit: boolean;
   isProjectionPathUsed: boolean;
@@ -64,6 +66,8 @@ type PacedTrainItemProps = {
 const PacedTrainItem = ({
   isInSelection,
   handleSelectPacedTrain,
+  isOccurrencesListOpen,
+  handleOpenOccurrencesList,
   pacedTrain,
   isOnEdit,
   isProjectionPathUsed,
@@ -80,8 +84,6 @@ const PacedTrainItem = ({
   const { closeModal } = useContext(ModalContext);
   const timetableId = useSelector(getOperationalStudiesTimetableID);
 
-  const [isOccurrencesListOpen, setIsOccurrencesListOpen] = useState(false);
-
   const { occurrences, occurrencesCount } = useOccurrences(pacedTrain, rollingStockList);
 
   const occurrenceActions = useOccurrenceActions({
@@ -95,8 +97,6 @@ const PacedTrainItem = ({
   const [postPacedTrain] = osrdEditoastApi.endpoints.postTimetableByIdPacedTrains.useMutation();
   const [getPacedTrainById] = osrdEditoastApi.endpoints.getPacedTrainById.useLazyQuery();
   const [deletePacedTrains] = osrdEditoastApi.endpoints.deletePacedTrain.useMutation();
-
-  const toggleOccurrencesList = () => setIsOccurrencesListOpen((open) => !open);
 
   const selectPathProjection = async () => {
     dispatch(updateTrainIdUsedForProjection(pacedTrain.id));
@@ -229,7 +229,7 @@ const PacedTrainItem = ({
           data-testid="paced-train-main-info"
           title={pacedTrain.name}
           className="paced-train-main-info"
-          onClick={toggleOccurrencesList}
+          onClick={() => handleOpenOccurrencesList(pacedTrain.id)}
           role="button"
           tabIndex={0}
         >

--- a/front/src/modules/trainschedule/components/Timetable/PacedTrain/hooks/useOccurrenceActions.ts
+++ b/front/src/modules/trainschedule/components/Timetable/PacedTrain/hooks/useOccurrenceActions.ts
@@ -8,7 +8,7 @@ import { updatePacedTrainExceptionsList } from 'modules/trainschedule/components
 import { formatPacedTrainWithDetailsToPacedTrainPayload } from 'modules/trainschedule/components/ManageTrainSchedule/helpers/formatTimetableItemPayload';
 import {
   findExceptionWithOccurrenceId,
-  formatPacedTrainWithOccurenceDetails,
+  formatPacedTrainWithOccurrenceDetails,
 } from 'modules/trainschedule/helpers/pacedTrain';
 import { storePacedTrain } from 'modules/trainschedule/helpers/updateTimetableItemHelpers';
 import { getOperationalStudiesTimetableID } from 'reducers/osrdconf/operationalStudiesConf/selectors';
@@ -65,7 +65,7 @@ const useOccurrenceActions = ({
       );
 
       if (occurrenceToUpdateException) {
-        const pacedTrainWithOccurrenceDetails = formatPacedTrainWithOccurenceDetails(
+        const pacedTrainWithOccurrenceDetails = formatPacedTrainWithOccurrenceDetails(
           updatedPacedtrain,
           occurrenceToUpdateException
         );

--- a/front/src/modules/trainschedule/components/Timetable/Timetable.tsx
+++ b/front/src/modules/trainschedule/components/Timetable/Timetable.tsx
@@ -63,6 +63,9 @@ const Timetable = ({
   const { t, i18n } = useTranslation('operational-studies', { keyPrefix: 'main' });
 
   const [selectedTimetableItemIds, setSelectedTimetableItemIds] = useState<TimetableItemId[]>([]);
+  const [expandedTimetableItemIds, setExpandedTimetableItemIds] = useState<Set<TimetableItemId>>(
+    new Set()
+  );
   const [showTrainDetails, setShowTrainDetails] = useState(false);
   const selectedTrainId = useSelector(getSelectedTrainId);
   const trainIdUsedForProjection = useSelector(getTrainIdUsedForProjection);
@@ -98,6 +101,18 @@ const Timetable = ({
     },
     [selectedTimetableItemIds]
   );
+
+  const handleExpandTimetableItem = useCallback((id: TimetableItemId) => {
+    setExpandedTimetableItemIds((prevExpandedIds) => {
+      const newExpandedIds = new Set(prevExpandedIds);
+      if (newExpandedIds.has(id)) {
+        newExpandedIds.delete(id);
+      } else {
+        newExpandedIds.add(id);
+      }
+      return newExpandedIds;
+    });
+  }, []);
 
   const currentDepartureDates = useMemo(
     () =>
@@ -202,6 +217,8 @@ const Timetable = ({
                   isInSelection={selectedTimetableItemIds.includes(timetableItem.id)}
                   selectPacedTrainToEdit={selectTimetableItemToEdit}
                   handleSelectPacedTrain={handleSelectTimetableItem}
+                  isOccurrencesListOpen={expandedTimetableItemIds.has(timetableItem.id)}
+                  handleOpenOccurrencesList={handleExpandTimetableItem}
                   isOnEdit={timetableItem.id === timetableItemToEditData?.timetableItemId}
                   selectedTrainId={selectedTrainId}
                   upsertTimetableItems={upsertTimetableItems}

--- a/front/src/modules/trainschedule/helpers/__tests__/pacedTrain.spec.ts
+++ b/front/src/modules/trainschedule/helpers/__tests__/pacedTrain.spec.ts
@@ -5,7 +5,7 @@ import type { PacedTrainWithDetails } from 'modules/trainschedule/components/Tim
 import type { PacedTrainId } from 'reducers/osrdconf/types';
 import { Duration } from 'utils/duration';
 
-import { formatPacedTrainWithOccurenceDetails, getOccurrencesNb } from '../pacedTrain';
+import { formatPacedTrainWithOccurrenceDetails, getOccurrencesNb } from '../pacedTrain';
 
 describe('getOccurrencesNb', () => {
   it('should properly compute occurrence nb for time window of 2h and interval of 30min', () => {
@@ -39,7 +39,7 @@ describe('getOccurrencesNb', () => {
   });
 });
 
-describe('formatPacedTrainWithOccurenceDetails', () => {
+describe('formatPacedTrainWithOccurrenceDetails', () => {
   const pacedTrain: PacedTrainWithDetails = {
     id: 'paced_123' as PacedTrainId,
     name: '8608',
@@ -80,7 +80,7 @@ describe('formatPacedTrainWithOccurenceDetails', () => {
       key: '123123',
       train_name: { value: '8608 updated' },
     };
-    const updatedPacedTrain = formatPacedTrainWithOccurenceDetails(pacedTrain, exception);
+    const updatedPacedTrain = formatPacedTrainWithOccurrenceDetails(pacedTrain, exception);
     expect(updatedPacedTrain).toEqual({
       ...pacedTrain,
       name: '8608 updated',
@@ -92,7 +92,7 @@ describe('formatPacedTrainWithOccurenceDetails', () => {
       key: '123123',
       speed_limit_tag: { value: null },
     };
-    const updatedPacedTrain = formatPacedTrainWithOccurenceDetails(pacedTrain, exception);
+    const updatedPacedTrain = formatPacedTrainWithOccurrenceDetails(pacedTrain, exception);
     expect(updatedPacedTrain).toEqual({
       ...pacedTrain,
       speedLimitTag: null,
@@ -104,7 +104,7 @@ describe('formatPacedTrainWithOccurenceDetails', () => {
       key: '123123',
       options: { value: { use_electrical_profiles: true } },
     };
-    const updatedPacedTrain = formatPacedTrainWithOccurenceDetails(pacedTrain, exception);
+    const updatedPacedTrain = formatPacedTrainWithOccurrenceDetails(pacedTrain, exception);
     expect(updatedPacedTrain).toEqual({
       ...pacedTrain,
       options: {
@@ -134,7 +134,7 @@ describe('formatPacedTrainWithOccurenceDetails', () => {
         power_restrictions: [],
       },
     };
-    const updatedPacedTrain = formatPacedTrainWithOccurenceDetails(pacedTrain, exception);
+    const updatedPacedTrain = formatPacedTrainWithOccurrenceDetails(pacedTrain, exception);
     expect(updatedPacedTrain).toEqual({
       ...pacedTrain,
       path: exception.path_and_schedule!.path,

--- a/front/src/modules/trainschedule/helpers/pacedTrain.ts
+++ b/front/src/modules/trainschedule/helpers/pacedTrain.ts
@@ -31,7 +31,7 @@ export const findExceptionWithOccurrenceId = (
   return exceptions.find(({ key }) => addedExceptionId === key);
 };
 
-export const formatPacedTrainWithOccurenceDetails = (
+export const formatPacedTrainWithOccurrenceDetails = (
   pacedTrain: PacedTrainWithDetails,
   exceptionChangeGroups: ExceptionChangeGroups
 ) => {

--- a/front/src/utils/__tests__/trainId.spec.ts
+++ b/front/src/utils/__tests__/trainId.spec.ts
@@ -126,20 +126,20 @@ describe('formatPacedTrainIdToExceptionId', () => {
 
 describe('extractPacedTrainIdFromOccurrenceId', () => {
   it('should return the pacedTrainId for a regular occurrence', () => {
-    const occurenceId = 'indexedoccurrence_123_0' as OccurrenceId;
-    const result = extractPacedTrainIdFromOccurrenceId(occurenceId);
+    const occurrenceId = 'indexedoccurrence_123_0' as OccurrenceId;
+    const result = extractPacedTrainIdFromOccurrenceId(occurrenceId);
     expect(result).toBe('paced_123');
   });
 
   it('should return the pacedTrainId for an added exception', () => {
-    const occurenceId = 'exception_123_0' as OccurrenceId;
-    const result = extractPacedTrainIdFromOccurrenceId(occurenceId);
+    const occurrenceId = 'exception_123_0' as OccurrenceId;
+    const result = extractPacedTrainIdFromOccurrenceId(occurrenceId);
     expect(result).toBe('paced_123');
   });
 
   it('should throw if the key is invalid', () => {
-    const occurenceId = 'exception-indexedoccurrence_123_0' as OccurrenceId;
-    expect(() => extractPacedTrainIdFromOccurrenceId(occurenceId)).toThrow(
+    const occurrenceId = 'exception-indexedoccurrence_123_0' as OccurrenceId;
+    expect(() => extractPacedTrainIdFromOccurrenceId(occurrenceId)).toThrow(
       'The occurrence id should match the format "indexedoccurrence_{pacedTrainId}_{occurrenceIndex}" or "exception_{pacedTrainId}_{exceptionId}"'
     );
   });


### PR DESCRIPTION
Close #11788

The state of pacedTrainItem is lost when the component is no longer rendered, and we only render part of the list for performance reasons. Whether the occurrence list of a paced train is opened or not is thus lost when scrolling to another part of the train list.

To fix it, keep the set of pacedTrainItem id with opened occurrence list in the timetable parent component containing the train list, which is always rendered.

I may add another commit to use a set for selectedTimetableItemIds too.

Edit : added a commit to fix occurence -> occurrence spelling mistakes everywhere