### PR TITLE
front: fix text overlaps and step in time inputs

### DIFF
--- a/front/src/modules/timesStops/TimeInput.tsx
+++ b/front/src/modules/timesStops/TimeInput.tsx
@@ -34,7 +34,7 @@ const TimeInput = ({ focus, rowData, active, setRowData }: TimeInputProps) => {
       type="time"
       tabIndex={-1}
       ref={ref}
-      step={2}
+      step={1}
       style={{
         pointerEvents: focus ? 'auto' : 'none',
         opacity: rowData || active ? undefined : 0,

--- a/front/src/modules/timesStops/TimeInput.tsx
+++ b/front/src/modules/timesStops/TimeInput.tsx
@@ -1,6 +1,5 @@
 import { useRef, useState, useEffect } from 'react';
 
-import cx from 'classnames';
 import type { CellProps } from 'react-datasheet-grid/dist/types';
 import { useTranslation } from 'react-i18next';
 
@@ -53,21 +52,14 @@ const TimeInput = ({ focus, rowData, active, setRowData }: TimeInputProps) => {
     />
   );
 
-  if (tempTimeValue?.daySinceDeparture && tempTimeValue.dayDisplayed) {
-    return (
-      <div className="time-input-container">
-        {input}
-        <span
-          className={cx('extra-text', {
-            'extra-text-firefox': navigator.userAgent.search('Firefox') !== -1,
-          })}
-        >
-          {t('timeStopTable.dayCounter', { count: tempTimeValue.daySinceDeparture })}
-        </span>
-      </div>
-    );
-  }
-  return input;
+  return (
+    <div className="time-input-container">
+      {input}
+      {!!tempTimeValue?.daySinceDeparture &&
+        tempTimeValue.dayDisplayed &&
+        t('timeStopTable.dayCounter', { count: tempTimeValue.daySinceDeparture })}
+    </div>
+  );
 };
 
 export default TimeInput;

--- a/front/src/modules/timesStops/styles/_timeInput.scss
+++ b/front/src/modules/timesStops/styles/_timeInput.scss
@@ -1,20 +1,10 @@
 .time-input-container {
-  position: relative;
-  width: 100%;
+  padding-left: 11px;
 
   input.dsg-input {
-    width: 100%;
-  }
-
-  span.extra-text {
-    position: absolute;
-    left: 88px;
-    top: 1.2px;
-    pointer-events: none;
-  }
-
-  span.extra-text-firefox {
-    top: 0.48px;
-    left: 97.6px;
+    display: inline;
+    padding-left: 0;
+    padding-right: 4px;
+    margin-left: -3px;
   }
 }


### PR DESCRIPTION
Close [#11416](https://github.com/OpenRailAssociation/osrd/issues/11416)

In 12 hour time, with a day counter displayed ("D+1"), the "AM" or "PM" text was overlapping the counter.
On chromium there was an additional collision with the time input icon.

- Remove the absolute and relative positioning of elements in the time input, so the day counter may start a new line if needed.
- Adjust the margins and paddings so that text on each line is properly aligned, while producing no visible style change from before if on one line (except potentially for reduced excess space before the day counter).
- Simplify the structure of time input, ensuring the same style is always applied.

Second commit : 
- adjust step from 2s to 1s in time input (this seemed to already be the case in practice)