### PR TITLE
front: make add pace train modal responsive

### DIFF
--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/PacedTrainSettings/PacedTrainSettings.tsx
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/PacedTrainSettings/PacedTrainSettings.tsx
@@ -19,7 +19,7 @@ const PacedTrainSettings = () => {
   return (
     <div className="paced-train-settings">
       <div className="time-settings">
-        <span className="mr-3">
+        <span className="mr-3 time-settings-item">
           <InputSNCF
             type="number"
             label={
@@ -42,7 +42,7 @@ const PacedTrainSettings = () => {
             sm
           />
         </span>
-        <span>
+        <span className="time-settings-item">
           <InputSNCF
             type="number"
             label={

--- a/front/src/modules/trainschedule/styles/ManageTimetableItem/_pacedTrainsSettings.scss
+++ b/front/src/modules/trainschedule/styles/ManageTimetableItem/_pacedTrainsSettings.scss
@@ -2,6 +2,11 @@
   .time-settings {
     display: flex;
     margin: 15px 12px;
+    flex-wrap: wrap;
+
+    .time-settings-item {
+      flex: 0 1 180px;
+    }
 
     .cadence-icon {
       transform: rotate(90deg);
@@ -17,9 +22,12 @@
 
     .controls {
       display: flex;
+      align-items: flex-end;
+      flex-wrap: wrap;
+      margin-bottom: 24px;
 
       .add-button {
-        margin: 32px 16px;
+        margin: 16px 0 5px 16px;
       }
     }
 


### PR DESCRIPTION
The modal used to add paced trains was not responsive, and would be unusable with an even slightly small screen or window size.

This PR aims to make it responsive, with minimal style changes to accommodate this new behaviour.