### PR TITLE
editoast: change warning overlapping catenaries

### DIFF
--- a/editoast/src/generated_data/error/electrifications.rs
+++ b/editoast/src/generated_data/error/electrifications.rs
@@ -80,17 +80,24 @@ pub fn check_overlapping(infra_cache: &InfraCache, _: &Graph) -> Vec<InfraError>
     let mut overlapping_cat = HashSet::new();
     // Key: (Track, Voltage)
     // Value: RangeMap<Range, ElectrificationId>
-    let mut range_maps: HashMap<String, RangeMap<u64, String>> = Default::default();
+    // One RangeMap per (track, voltage) to allow overlaps with different voltages
+
+    let mut range_maps: HashMap<(String, Option<String>), RangeMap<u64, String>> =
+        Default::default();
 
     // Iterate over all the electrifications ensure we don't report duplicated errors
     for electrification in infra_cache.electrifications().values() {
         let electrification = electrification.unwrap_electrification();
 
+        let voltage = Some(electrification.voltage.0.clone());
+
         for track_range in electrification.track_ranges.iter() {
             let range = (track_range.begin * 100.) as u64..(track_range.end * 100.) as u64;
             let track_id = &track_range.track.0;
 
-            let range_map = range_maps.entry(track_id.clone()).or_default();
+            let key = (track_id.clone(), voltage.clone());
+            let range_map = range_maps.entry(key).or_default();
+
             for (_, overlap) in range_map.overlapping(&range) {
                 if electrification.get_id() == overlap {
                     // Avoid reporting overlap with itself
@@ -98,6 +105,7 @@ pub fn check_overlapping(infra_cache: &InfraCache, _: &Graph) -> Vec<InfraError>
                 }
                 overlapping_cat.insert((electrification.get_id().clone(), overlap.clone()));
             }
+
             range_map.insert(range.clone(), electrification.get_id().to_string());
         }
     }
@@ -156,20 +164,48 @@ mod tests {
     }
 
     #[test]
-    fn overlapping_default() {
+    fn overlapping_different_voltage() {
         let mut infra_cache = create_small_infra_cache();
         let track_ranges_1 = vec![("A", 20., 220.)];
         let mut electrification_1 = create_electrification_cache("Cat_error_1", track_ranges_1);
         electrification_1.voltage = "1500V".into();
         infra_cache.add(electrification_1).unwrap();
+
         let track_ranges_2 = vec![("A", 100., 150.), ("A", 200., 480.)];
         let mut electrification_2 = create_electrification_cache("Cat_error_2", track_ranges_2);
         electrification_2.voltage = "25000V".into();
         infra_cache.add(electrification_2).unwrap();
+
         let errors = check_overlapping(&infra_cache, &Graph::load(&infra_cache));
-        assert_eq!(1, errors.len());
-        let infra_error =
+        assert_eq!(
+            0,
+            errors.len(),
+            "No error expected for overlapping with different voltages"
+        );
+    }
+
+    #[test]
+    fn overlapping_same_voltage() {
+        let mut infra_cache = create_small_infra_cache();
+        let track_ranges_1 = vec![("A", 20., 220.)];
+        let mut electrification_1 = create_electrification_cache("Cat_error_1", track_ranges_1);
+        electrification_1.voltage = "1500V".into();
+        infra_cache.add(electrification_1).unwrap();
+
+        let track_ranges_2 = vec![("A", 100., 150.), ("A", 200., 480.)];
+        let mut electrification_2 = create_electrification_cache("Cat_error_2", track_ranges_2);
+        electrification_2.voltage = "1500V".into();
+        infra_cache.add(electrification_2).unwrap();
+
+        let errors = check_overlapping(&infra_cache, &Graph::load(&infra_cache));
+        assert_eq!(
+            1,
+            errors.len(),
+            "Error expected for overlapping with same voltages"
+        );
+
+        let expected_error =
             InfraError::new_overlapping_electrifications("Cat_error_1", "Cat_error_2");
-        assert_eq!(infra_error, errors[0]);
+        assert_eq!(expected_error, errors[0]);
     }
 }

--- a/editoast/src/generated_data/error/electrifications.rs
+++ b/editoast/src/generated_data/error/electrifications.rs
@@ -80,16 +80,14 @@ pub fn check_overlapping(infra_cache: &InfraCache, _: &Graph) -> Vec<InfraError>
     let mut overlapping_cat = HashSet::new();
     // Key: (Track, Voltage)
     // Value: RangeMap<Range, ElectrificationId>
-    // One RangeMap per (track, voltage) to allow overlaps with different voltages
 
-    let mut range_maps: HashMap<(String, Option<String>), RangeMap<u64, String>> =
-        Default::default();
+    let mut range_maps: HashMap<(String, String), RangeMap<u64, String>> = Default::default();
 
     // Iterate over all the electrifications ensure we don't report duplicated errors
     for electrification in infra_cache.electrifications().values() {
         let electrification = electrification.unwrap_electrification();
 
-        let voltage = Some(electrification.voltage.0.clone());
+        let voltage = electrification.voltage.0.clone();
 
         for track_range in electrification.track_ranges.iter() {
             let range = (track_range.begin * 100.) as u64..(track_range.end * 100.) as u64;
@@ -127,6 +125,7 @@ mod tests {
     use crate::infra_cache::tests::create_small_infra_cache;
     use editoast_schemas::primitives::ObjectRef;
     use editoast_schemas::primitives::ObjectType;
+    use rstest::rstest;
 
     #[test]
     fn invalid_ref() {
@@ -163,49 +162,48 @@ mod tests {
         assert_eq!(infra_error, errors[0]);
     }
 
-    #[test]
-    fn overlapping_different_voltage() {
+    /// Test overlapping electrifications with different voltages should not raise warnings.
+    #[rstest]
+    #[case::subset(100., 150.)]
+    #[case::overlap_at_boundary(200., 480.)]
+    fn overlapping_different_voltage(#[case] start: f64, #[case] end: f64) {
         let mut infra_cache = create_small_infra_cache();
+
         let track_ranges_1 = vec![("A", 20., 220.)];
         let mut electrification_1 = create_electrification_cache("Cat_error_1", track_ranges_1);
         electrification_1.voltage = "1500V".into();
         infra_cache.add(electrification_1).unwrap();
 
-        let track_ranges_2 = vec![("A", 100., 150.), ("A", 200., 480.)];
+        let track_ranges_2 = vec![("A", start, end)];
         let mut electrification_2 = create_electrification_cache("Cat_error_2", track_ranges_2);
         electrification_2.voltage = "25000V".into();
         infra_cache.add(electrification_2).unwrap();
 
         let errors = check_overlapping(&infra_cache, &Graph::load(&infra_cache));
-        assert_eq!(
-            0,
-            errors.len(),
-            "No error expected for overlapping with different voltages"
-        );
+        assert_eq!(0, errors.len());
     }
 
-    #[test]
-    fn overlapping_same_voltage() {
+    /// Test overlapping electrifications with same voltage should raise a warning.
+    #[rstest]
+    #[case::subset(100., 150.)]
+    #[case::overlap_at_boundary(200., 480.)]
+    fn overlapping_same_voltage(#[case] start: f64, #[case] end: f64) {
         let mut infra_cache = create_small_infra_cache();
+
         let track_ranges_1 = vec![("A", 20., 220.)];
         let mut electrification_1 = create_electrification_cache("Cat_error_1", track_ranges_1);
         electrification_1.voltage = "1500V".into();
         infra_cache.add(electrification_1).unwrap();
 
-        let track_ranges_2 = vec![("A", 100., 150.), ("A", 200., 480.)];
+        let track_ranges_2 = vec![("A", start, end)];
         let mut electrification_2 = create_electrification_cache("Cat_error_2", track_ranges_2);
         electrification_2.voltage = "1500V".into();
         infra_cache.add(electrification_2).unwrap();
 
         let errors = check_overlapping(&infra_cache, &Graph::load(&infra_cache));
-        assert_eq!(
-            1,
-            errors.len(),
-            "Error expected for overlapping with same voltages"
-        );
+        let expected = InfraError::new_overlapping_electrifications("Cat_error_1", "Cat_error_2");
 
-        let expected_error =
-            InfraError::new_overlapping_electrifications("Cat_error_1", "Cat_error_2");
-        assert_eq!(expected_error, errors[0]);
+        assert_eq!(1, errors.len());
+        assert_eq!(expected, errors[0]);
     }
 }

--- a/front/public/locales/en/translation.json
+++ b/front/public/locales/en/translation.json
@@ -75,8 +75,8 @@
           "name": "Invalid value"
         },
         "overlapping_electrifications": {
-          "description": "Electrification « {{obj_id}} » overlaps electrification « {{reference.obj_id}} »",
-          "name": "Overlapping of electrifications"
+          "description": "Electrification « {{obj_id}} » overlaps electrification « {{reference.obj_id}} » on the same track and with the same voltage",
+          "name": "Overlapping of electrification zones"
         },
         "overlapping_speed_sections": {
           "description": "Speed limit « {{obj_id}} » overlaps « {{reference.obj_id}} »",

--- a/front/public/locales/fr/translation.json
+++ b/front/public/locales/fr/translation.json
@@ -75,8 +75,8 @@
           "name": "Valeur invalide"
         },
         "overlapping_electrifications": {
-          "description": "La caténaire « {{obj_id}} » se superpose à la caténaire « {{reference.obj_id}} »",
-          "name": "Superposition de caténaires"
+          "description": "La caténaire « {{obj_id}} » se superpose à la caténaire « {{reference.obj_id}} » sur la même voie et au même voltage",
+          "name": "Superposition de caténaires sur la zone"
         },
         "overlapping_speed_sections": {
           "description": "La limite « {{obj_id}} » se superpose à la limite « {{reference.obj_id}} »",


### PR DESCRIPTION
Close https://github.com/OpenRailAssociation/osrd/issues/6116

1) Add voltage in range_maps keys
2) Extract voltage from electrification
3) Use (track_id, voltage) as key
4) Changed EN and FR warning messages 
5) Renamed and fixed default test to "overlapping_different_voltage" and added "overlapping_same_voltage"