### PR TITLE
front: add round trips modal card

### DIFF
--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -154,8 +154,12 @@
       "cadence": "Cadence",
       "manageRoundTrips": "Manage round trips",
       "oneWays": "One-ways",
+      "openRoundTripsMenu": "Open round trips management menu",
+      "pickReturn": "Pick a return",
+      "restore": "Move to todo",
       "roundTrips": "Round trips",
       "roundTripsManagement": "Round trips management",
+      "setOneWay": "Set as one way",
       "todo": "Todo"
     },
     "scenarioCancel": "Cancel",

--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -151,6 +151,7 @@
     "pacedTrain_zero": "0 service",
     "requestedPoint": "requested point ({{ count }})",
     "roundTripsModal": {
+      "cadence": "Cadence",
       "manageRoundTrips": "Manage round trips",
       "oneWays": "One-ways",
       "roundTrips": "Round trips",

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -151,6 +151,7 @@
     "pacedTrain_zero": "",
     "requestedPoint": "point demandé ({{ count }})",
     "roundTripsModal": {
+      "cadence": "Cadence",
       "manageRoundTrips": "Gérer les aller-retours",
       "oneWays": "Aller simples",
       "roundTrips": "Aller-retours",

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -154,8 +154,12 @@
       "cadence": "Cadence",
       "manageRoundTrips": "Gérer les aller-retours",
       "oneWays": "Aller simples",
+      "openRoundTripsMenu": "Ouvrir le menu de gestion des aller-retours",
+      "pickReturn": "Sélectionner un retour",
+      "restore": "Remettre à traiter",
       "roundTrips": "Aller-retours",
       "roundTripsManagement": "Gestion des aller-retours",
+      "setOneWay": "Forcer un aller simple",
       "todo": "À traiter"
     },
     "scenarioCancel": "Annuler",

--- a/front/src/common/AnchoredMenu.tsx
+++ b/front/src/common/AnchoredMenu.tsx
@@ -8,6 +8,7 @@ type AnchoreMenuParams = {
   children?: React.ReactNode;
   anchorRef: React.RefObject<HTMLElement>;
   onDismiss: () => void;
+  container?: Element | null;
 };
 
 /**
@@ -21,7 +22,7 @@ type AnchoreMenuParams = {
  *
  * It handles the space needed by the menu to know if the children should be positioned above or below the anchor element.
  */
-const AnchoredMenu = ({ children, anchorRef, onDismiss }: AnchoreMenuParams) => {
+const AnchoredMenu = ({ children, anchorRef, onDismiss, container }: AnchoreMenuParams) => {
   const [menuPosition, setMenuPosition] = useState<{
     top?: number;
     left: number;
@@ -71,7 +72,7 @@ const AnchoredMenu = ({ children, anchorRef, onDismiss }: AnchoreMenuParams) => 
         {children}
       </div>
     </div>,
-    document.body
+    container || document.body
   );
 };
 

--- a/front/src/common/AnchoredMenu.tsx
+++ b/front/src/common/AnchoredMenu.tsx
@@ -9,6 +9,7 @@ type AnchoreMenuParams = {
   anchorRef: React.RefObject<HTMLElement>;
   onDismiss: () => void;
   container?: Element | null;
+  alignment?: 'left' | 'right' | 'auto';
 };
 
 /**
@@ -22,7 +23,13 @@ type AnchoreMenuParams = {
  *
  * It handles the space needed by the menu to know if the children should be positioned above or below the anchor element.
  */
-const AnchoredMenu = ({ children, anchorRef, onDismiss, container }: AnchoreMenuParams) => {
+const AnchoredMenu = ({
+  children,
+  anchorRef,
+  onDismiss,
+  container,
+  alignment = 'auto',
+}: AnchoreMenuParams) => {
   const [menuPosition, setMenuPosition] = useState<{
     top?: number;
     left: number;
@@ -36,14 +43,31 @@ const AnchoredMenu = ({ children, anchorRef, onDismiss, container }: AnchoreMenu
     const anchorRefBoundingRect = anchorRef.current?.getBoundingClientRect();
     const menuRefBoundingRect = menuRef.current?.getBoundingClientRect();
 
-    if (anchorRefBoundingRect && menuRefBoundingRect) {
+    if (anchorRefBoundingRect && menuRefBoundingRect && menuRefBoundingRect.width > 0) {
       // Check if there is enough space below the anchor element
       const isSpaceBelow =
         window.innerHeight - anchorRefBoundingRect.bottom > menuRefBoundingRect.height;
 
+      // Check if menu would overflow on the right side of the viewport
+      const wouldOverflowRight =
+        anchorRefBoundingRect.left + menuRefBoundingRect.width > window.innerWidth;
+
+      // Determine the alignment based on prop and overflow detection
+      let boxLeftPosition: number;
+      if (alignment === 'right') {
+        boxLeftPosition = anchorRefBoundingRect.right - menuRefBoundingRect.width;
+      } else if (alignment === 'left') {
+        boxLeftPosition = anchorRefBoundingRect.left;
+      } else {
+        // auto alignment: switch to right alignment if would overflow
+        boxLeftPosition = wouldOverflowRight
+          ? anchorRefBoundingRect.right - menuRefBoundingRect.width
+          : anchorRefBoundingRect.left;
+      }
+
       setMenuPosition({
         top: isSpaceBelow ? anchorRefBoundingRect.bottom : undefined,
-        left: anchorRefBoundingRect.left,
+        left: boxLeftPosition,
         bottom: isSpaceBelow ? undefined : window.innerHeight - anchorRefBoundingRect.top,
       });
     }

--- a/front/src/modules/timetableItem/components/Timetable/RoundTrips/RoundTripsModal.tsx
+++ b/front/src/modules/timetableItem/components/Timetable/RoundTrips/RoundTripsModal.tsx
@@ -53,8 +53,8 @@ const RoundTripsModal = ({
         <RoundTripsModalColumn type="roundTrips" pairingItems={[]} />
       </div>
       <div className="round-trips-modal-footer">
-        <Button label={commonT('cancel')} variant="Cancel" onClick={closeModal} />
-        <Button label={commonT('saveEdits')} variant="Primary" onClick={closeModal} />
+        <Button label={commonT('cancel')} variant="Cancel" size="medium" onClick={closeModal} />
+        <Button label={commonT('saveEdits')} variant="Primary" size="medium" onClick={closeModal} />
       </div>
     </dialog>
   );

--- a/front/src/modules/timetableItem/components/Timetable/RoundTrips/RoundTripsModal.tsx
+++ b/front/src/modules/timetableItem/components/Timetable/RoundTrips/RoundTripsModal.tsx
@@ -48,9 +48,9 @@ const RoundTripsModal = ({
         <h1 className="title">{t('roundTripsModal.roundTripsManagement')}</h1>
       </div>
       <div className="round-trips-modal-body">
-        <RoundTripsModalColumn columnType="todo" pairingItems={[]} />
-        <RoundTripsModalColumn columnType="oneWays" pairingItems={[]} />
-        <RoundTripsModalColumn columnType="roundTrips" pairingItems={[]} />
+        <RoundTripsModalColumn type="todo" pairingItems={[]} />
+        <RoundTripsModalColumn type="oneWays" pairingItems={[]} />
+        <RoundTripsModalColumn type="roundTrips" pairingItems={[]} />
       </div>
       <div className="round-trips-modal-footer">
         <Button label={commonT('cancel')} variant="Cancel" onClick={closeModal} />

--- a/front/src/modules/timetableItem/components/Timetable/RoundTrips/RoundTripsModalCard.tsx
+++ b/front/src/modules/timetableItem/components/Timetable/RoundTrips/RoundTripsModalCard.tsx
@@ -1,0 +1,73 @@
+import { ArrowRight, ArrowSwitch, KebabHorizontal, Services, Square } from '@osrd-project/ui-icons';
+import cx from 'classnames';
+import { useTranslation } from 'react-i18next';
+
+import { TRAIN_CATEGORY_CLASS } from '../consts';
+import type { PairingItem } from '../types';
+
+type RoundTripsModalCardProps = {
+  pairingItem: PairingItem;
+};
+
+const RoundTripsModalCard = ({
+  pairingItem: {
+    name,
+    category,
+    interval,
+    status,
+    stops,
+    startTime,
+    origin,
+    arrivalTime,
+    destination,
+  },
+}: RoundTripsModalCardProps) => {
+  const { t } = useTranslation('operational-studies', { keyPrefix: 'main.roundTripsModal' });
+
+  const getStatusIcon = (itemStatus: 'todo' | 'oneWays' | 'roundTrip') => {
+    if (itemStatus === 'todo') {
+      return <Square />;
+    }
+    if (itemStatus === 'oneWays') {
+      return <ArrowRight />;
+    }
+    return <ArrowSwitch />;
+  };
+
+  return (
+    <div className="round-trips-card">
+      <div className="round-trips-card-header">
+        <h3
+          className={cx('name', `train-category-text-${TRAIN_CATEGORY_CLASS[category ?? 'None']}`)}
+        >
+          {name}
+        </h3>
+        <div className="interval" title={t('cadence')}>
+          {interval ? `${interval.total('minute')}\u2019` : '\u2013'}
+        </div>
+        <div className="status">{getStatusIcon(status)}</div>
+        <div className="card-menu">
+          <KebabHorizontal />
+        </div>
+      </div>
+      <div className="round-trips-card-body">
+        <div className="stops">
+          <span className={cx({ 'no-stops': stops.length === 0 })}>{stops.length}</span>
+          <Services className="stops-icon" />
+        </div>
+        <div className="od-infos">
+          <div className="extremity">
+            <div className="times">{startTime.getMinutes().toString().padStart(2, '0')}</div>
+            <div className="location">{origin}</div>
+          </div>
+          <div className="extremity">
+            <div className="times">{arrivalTime.getMinutes().toString().padStart(2, '0')}</div>
+            <div className="location">{destination}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default RoundTripsModalCard;

--- a/front/src/modules/timetableItem/components/Timetable/RoundTrips/RoundTripsModalCard.tsx
+++ b/front/src/modules/timetableItem/components/Timetable/RoundTrips/RoundTripsModalCard.tsx
@@ -1,6 +1,13 @@
+import { useMemo, useRef, useState } from 'react';
+
 import { ArrowRight, ArrowSwitch, KebabHorizontal, Services, Square } from '@osrd-project/ui-icons';
 import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
+import { BsXCircleFill } from 'react-icons/bs';
+
+import AnchoredMenu from 'common/AnchoredMenu';
+import type { OSRDMenuItem } from 'common/OSRDMenu';
+import OSRDMenu from 'common/OSRDMenu';
 
 import { TRAIN_CATEGORY_CLASS } from '../consts';
 import type { PairingItem } from '../types';
@@ -23,6 +30,10 @@ const RoundTripsModalCard = ({
   },
 }: RoundTripsModalCardProps) => {
   const { t } = useTranslation('operational-studies', { keyPrefix: 'main.roundTripsModal' });
+  const menuRef = useRef<HTMLDivElement>(null);
+  const menuButtonRef = useRef<HTMLButtonElement>(null);
+
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   const getStatusIcon = (itemStatus: 'todo' | 'oneWays' | 'roundTrip') => {
     if (itemStatus === 'todo') {
@@ -33,6 +44,54 @@ const RoundTripsModalCard = ({
     }
     return <ArrowSwitch />;
   };
+
+  const closeMenu = () => {
+    setIsMenuOpen(false);
+  };
+
+  // TODO : add actions for each menu item
+  const menuItems: Record<string, OSRDMenuItem> = {
+    restore: {
+      title: t('restore'),
+      icon: <BsXCircleFill />,
+      onClick: () => {
+        closeMenu();
+      },
+    },
+    setOneWay: {
+      title: t('setOneWay'),
+      icon: <ArrowRight />,
+      onClick: () => {
+        closeMenu();
+      },
+    },
+    pickReturn: {
+      title: t('pickReturn'),
+      icon: <ArrowSwitch />,
+      onClick: () => {
+        closeMenu();
+      },
+    },
+  };
+
+  const filteredMenuItems = useMemo(() => {
+    const { restore, setOneWay, pickReturn } = menuItems;
+
+    if (status === 'todo') {
+      return [setOneWay, pickReturn];
+    }
+
+    return [restore];
+  }, [menuItems, status]);
+
+  const menu = AnchoredMenu({
+    children: isMenuOpen && (
+      <OSRDMenu menuRef={menuRef} items={filteredMenuItems} className="round-trips-menu" />
+    ),
+    anchorRef: menuButtonRef,
+    onDismiss: closeMenu,
+    container: document.querySelector('.round-trips-modal'),
+  });
 
   return (
     <div className="round-trips-card">
@@ -46,9 +105,19 @@ const RoundTripsModalCard = ({
           {interval ? `${interval.total('minute')}\u2019` : '\u2013'}
         </div>
         <div className="status">{getStatusIcon(status)}</div>
-        <div className="card-menu">
+        <button
+          ref={menuButtonRef}
+          type="button"
+          className="card-menu"
+          title={t('openRoundTripsMenu')}
+          onClick={(e) => {
+            e.stopPropagation();
+            setIsMenuOpen(true);
+          }}
+        >
           <KebabHorizontal />
-        </div>
+        </button>
+        {menu}
       </div>
       <div className="round-trips-card-body">
         <div className="stops">

--- a/front/src/modules/timetableItem/components/Timetable/RoundTrips/RoundTripsModalColumn.tsx
+++ b/front/src/modules/timetableItem/components/Timetable/RoundTrips/RoundTripsModalColumn.tsx
@@ -3,6 +3,7 @@ import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
 
 import type { PairingItem } from '../types';
+import RoundTripsModalCard from './RoundTripsModalCard';
 
 type RoundTripsModalColumnProps =
   | {
@@ -30,14 +31,35 @@ const RoundTripsModalColumn = ({ type, pairingItems }: RoundTripsModalColumnProp
         <div className="item-count">{pairingItems.length}</div>
       </h2>
       <div className="column-wrapper">
-        {pairingItems.length === 0 && type !== 'roundTrips' && <div className="card-placeholder" />}
-        {pairingItems.length === 0 && type === 'roundTrips' && (
-          <>
+        {type !== 'roundTrips' &&
+          (pairingItems.length === 0 ? (
             <div className="card-placeholder" />
-            <div className="separator" />
-            <div className="card-placeholder" />
-          </>
-        )}
+          ) : (
+            pairingItems.map((pairingItem) => (
+              <RoundTripsModalCard key={pairingItem.id} pairingItem={pairingItem} />
+            ))
+          ))}
+        {type === 'roundTrips' &&
+          (pairingItems.length === 0 ? (
+            <div className="round-trip-pair">
+              <div className="card-placeholder" />
+              <div className="separator" />
+              <div className="card-placeholder" />
+            </div>
+          ) : (
+            pairingItems.map(({ pair, isValid }) => (
+              <div className="round-trip-pair" key={`${pair[0].id}-${pair[1].id}`}>
+                <RoundTripsModalCard pairingItem={pair[0]} />
+                <div
+                  className={cx('separator', {
+                    valid: isValid,
+                    invalid: !isValid,
+                  })}
+                />
+                <RoundTripsModalCard pairingItem={pair[1]} />
+              </div>
+            ))
+          ))}
       </div>
     </section>
   );

--- a/front/src/modules/timetableItem/components/Timetable/RoundTrips/RoundTripsModalColumn.tsx
+++ b/front/src/modules/timetableItem/components/Timetable/RoundTrips/RoundTripsModalColumn.tsx
@@ -4,31 +4,34 @@ import { useTranslation } from 'react-i18next';
 
 import type { PairingItem } from '../types';
 
-type RoundTripsModalColumnProps = {
-  columnType: 'todo' | 'oneWays' | 'roundTrips';
-  pairingItems: PairingItem[];
-};
+type RoundTripsModalColumnProps =
+  | {
+      type: 'todo' | 'oneWays';
+      pairingItems: PairingItem[];
+    }
+  | {
+      type: 'roundTrips';
+      pairingItems: { pair: [PairingItem, PairingItem]; isValid: boolean }[];
+    };
 
-const RoundTripsModalColumn = ({ columnType, pairingItems }: RoundTripsModalColumnProps) => {
+const RoundTripsModalColumn = ({ type, pairingItems }: RoundTripsModalColumnProps) => {
   const { t } = useTranslation('operational-studies', { keyPrefix: 'main.roundTripsModal' });
 
   return (
     <section
       className={cx('round-trips-modal-column', {
-        'round-trips-column': columnType === 'roundTrips',
+        'round-trips-column': type === 'roundTrips',
       })}
     >
       <h2 className="column-title">
-        {columnType === 'oneWays' && <ArrowRight />}
-        {columnType === 'roundTrips' && <ArrowSwitch />}
-        <span>{t(columnType)}</span>
+        {type === 'oneWays' && <ArrowRight />}
+        {type === 'roundTrips' && <ArrowSwitch />}
+        <span>{t(type)}</span>
         <div className="item-count">{pairingItems.length}</div>
       </h2>
       <div className="column-wrapper">
-        {pairingItems.length === 0 && columnType !== 'roundTrips' && (
-          <div className="card-placeholder" />
-        )}
-        {pairingItems.length === 0 && columnType === 'roundTrips' && (
+        {pairingItems.length === 0 && type !== 'roundTrips' && <div className="card-placeholder" />}
+        {pairingItems.length === 0 && type === 'roundTrips' && (
           <>
             <div className="card-placeholder" />
             <div className="separator" />

--- a/front/src/modules/timetableItem/components/Timetable/types.ts
+++ b/front/src/modules/timetableItem/components/Timetable/types.ts
@@ -120,20 +120,12 @@ export type ExceptionChangeGroupName = keyof ExceptionChangeGroups;
 export type PairingItem = {
   id: number;
   name: string;
-  interval: Duration;
+  category: TrainCategory | null;
+  interval: Duration | null;
   origin: string;
   stops: string[];
   destination: string;
   startTime: Date;
   arrivalTime: Date;
-  status:
-    | {
-        type: 'todo' | 'oneWays';
-      }
-    | {
-        type: 'roundTrip';
-        matchId: number;
-        // Match is valid if the pairing results in one line in macro mode
-        validMatch: boolean;
-      };
+  status: 'todo' | 'oneWays' | 'roundTrip';
 };

--- a/front/src/styles/scss/applications/operationalStudies/_roundTripsModal.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_roundTripsModal.scss
@@ -240,4 +240,10 @@
     gap: 24px;
     padding-right: 34px;
   }
+
+  .round-trips-menu {
+    width: 198px;
+    margin-top: 5px;
+    margin-left: -6px;
+  }
 }

--- a/front/src/styles/scss/applications/operationalStudies/_roundTripsModal.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_roundTripsModal.scss
@@ -36,8 +36,8 @@
     padding-inline: 56px;
 
     .round-trips-modal-column {
-      // TODO : remove this hard coded width after item cards are integrated
       width: 344px;
+      min-width: 0;
 
       &.round-trips-column {
         width: 664px;
@@ -72,30 +72,160 @@
 
       .column-wrapper {
         display: flex;
-        align-items: center;
-        gap: 2px;
+        flex-direction: column;
+        gap: 17px;
         width: 100%;
         padding: 16px;
         background-color: var(--white100);
         border: 1px solid var(--grey10);
         border-radius: 12px;
 
-        // TODO : replace this by card styles
-        div {
-          width: 100%;
+        .round-trip-pair {
+          display: flex;
+          align-items: center;
+          gap: 2px;
+
+          .separator {
+            width: 4px;
+            height: 38px;
+            border-radius: 2px;
+            background-color: var(--grey5);
+
+            &.valid {
+              background-color: var(--info30);
+            }
+            &.invalid {
+              background-color: var(--warning30);
+            }
+          }
+        }
+
+        .round-trips-card {
+          display: flex;
+          flex-direction: column;
+          flex: 1;
+          min-width: 0;
+          min-height: 67px;
+          border-radius: 8px;
+          border: 1px solid var(--grey30);
+
+          &:hover {
+            border: 1px solid var(--grey60);
+          }
+
+          .round-trips-card-header {
+            display: flex;
+            align-items: center;
+            height: 26px;
+            color: var(--black100);
+            background-color: var(--white100);
+            border-top-left-radius: 8px;
+            border-top-right-radius: 8px;
+            border-bottom: 1px solid var(--grey30);
+
+            .name {
+              flex: 1;
+              font-size: 14px;
+              font-weight: 600;
+              margin-bottom: 0;
+              white-space: nowrap;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              padding-inline: 12px 4px;
+            }
+
+            .interval {
+              display: flex;
+              justify-content: center;
+              align-items: center;
+              width: 28px;
+              height: 100%;
+              font-size: 12px;
+              color: var(--info60);
+              border-left: 1px solid var(--grey30);
+              border-right: 1px solid var(--grey30);
+            }
+
+            .status {
+              width: 32px;
+              height: 100%;
+              padding-inline: 8px;
+              color: var(--info30);
+              border-right: 1px solid var(--grey30);
+            }
+
+            .card-menu {
+              width: 32px;
+              padding-inline: 8px;
+              color: var(--grey40);
+            }
+          }
+          .round-trips-card-body {
+            display: flex;
+            align-items: center;
+            gap: 2px;
+            flex: 1;
+            font-size: 14px;
+            color: var(--black60);
+            background-color: var(--ambientB10);
+            border-bottom-left-radius: 8px;
+            border-bottom-right-radius: 8px;
+            padding-right: 4px;
+
+            .stops {
+              display: flex;
+              justify-content: end;
+              align-items: center;
+              min-width: 36px;
+              font-size: 14px;
+              font-weight: 600;
+              text-align: end;
+
+              span:first-child {
+                color: var(--primary60);
+                margin-top: 2px; // Vertical alignment with icon
+
+                &.no-stops {
+                  color: var(--grey30);
+                }
+              }
+
+              .stops-icon svg {
+                color: var(--purple50);
+                margin-left: -2px;
+              }
+            }
+
+            .od-infos {
+              min-width: 0;
+
+              .extremity {
+                display: flex;
+                align-items: center;
+                gap: 4px;
+
+                .times {
+                  font-size: 10px;
+                  color: var(--info60);
+                }
+
+                .location {
+                  font-size: 12px;
+                  color: var(--grey80);
+                  white-space: nowrap;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                }
+              }
+            }
+          }
         }
 
         .card-placeholder {
+          width: 100%;
           height: 67px;
           background-color: var(--grey5);
           border-radius: 8px;
-        }
-
-        .separator {
-          width: 4px;
-          height: 38px;
-          border-radius: 2px;
-          background-color: var(--grey5);
         }
       }
     }

--- a/front/src/styles/scss/common/components/_osrdMenu.scss
+++ b/front/src/styles/scss/common/components/_osrdMenu.scss
@@ -31,8 +31,8 @@
 
     .icon {
       color: var(--primary40);
-      padding-inline: 16px;
-      margin-bottom: 4px;
+      padding-inline: 10px 8px;
+      margin-bottom: 2px;
     }
   }
 }

--- a/front/ui/ui-icons/README.md
+++ b/front/ui/ui-icons/README.md
@@ -16,5 +16,5 @@ Based upon https://octicons.github.com our icons set provide slick & clear picto
 
 In osrd-ui
 
-- launch `npm run build`
-- launch `npm run storybook`
+1. launch `npm run build-ui`
+2. Run `cd storybook` and `npm start`

--- a/front/ui/ui-icons/icons/services-16.svg
+++ b/front/ui/ui-icons/icons/services-16.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><title>icon/16/services-16</title><path d="M8 0a2 2 0 0 1 .751 3.854v2.292a2 2 0 0 1 0 3.708v2.292a2 2 0 1 1-1.501 0V9.854a2 2 0 0 1 0-3.71v-2.29A2 2 0 0 1 8 0"/></svg>

--- a/front/ui/ui-icons/icons/services-24.svg
+++ b/front/ui/ui-icons/icons/services-24.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><title>icon/24/services-24</title><path d="M12 2.045a2 2 0 0 1 .75 3.854v4.291a2 2 0 0 1 .001 3.709v4.266a2 2 0 1 1-1.502-.036V13.9a2.001 2.001 0 0 1 .001-3.708V5.899A2 2 0 0 1 10 4a2 2 0 0 1 2-1.955"/></svg>


### PR DESCRIPTION
close #12367

This PR : 
- adapt some types to match the format timetable items will be stored in this [issue](https://github.com/osrd-project/osrd-confidential/issues/1022)
- update `ui-icons` readme which was outdated
- add the new `services` icon in ui-icons
- change some styles on the OSRD menu to match the last updates in sketch
- update hook `AnchoredMenu` to pass a props to chose where the `createPortal` is redirected so the menu can properly be displayed when a `dialog` element is opened
- update hook `AnchoredMenu` to pass a props to chose the alignment of the menu
- add the card component to the round trips modal

To test the cards, here is an example of item that could be put in columns : 
```
{
                id: 1,
                name: 'Paris - Lyon',
                category: 'HIGH_SPEED_TRAIN',
                interval: Duration.parse('PT20M'),
                origin: 'Paris Gare de Lyon PLY',
                stops: ['Le Creusot Montchanin TGV', 'Mâcon Loché TGV', 'Lyon Part-Dieu'],
                destination: 'Lyon Perrache LYP',
                startTime: new Date('2025-07-07T10:15:00Z'),
                arrivalTime: new Date('2025-07-07T12:27:00Z'),
                status: 'todo',
}
```