### PR TITLE
editoast: subcategory rename category to main category

### DIFF
--- a/editoast/editoast_models/src/tables.rs
+++ b/editoast/editoast_models/src/tables.rs
@@ -453,7 +453,7 @@ diesel::table! {
         options -> Jsonb,
         time_window -> Interval,
         interval -> Interval,
-        category -> Nullable<TrainCategory>,
+        main_category -> Nullable<TrainCategory>,
         exceptions -> Jsonb,
     }
 }
@@ -808,7 +808,7 @@ diesel::table! {
         speed_limit_tag -> Nullable<Varchar>,
         power_restrictions -> Jsonb,
         options -> Jsonb,
-        category -> Nullable<TrainCategory>,
+        main_category -> Nullable<TrainCategory>,
     }
 }
 

--- a/editoast/migrations/2025-07-07-122814_rename_category_to_main_category/down.sql
+++ b/editoast/migrations/2025-07-07-122814_rename_category_to_main_category/down.sql
@@ -1,0 +1,4 @@
+-- This file should undo anything in `up.sql`
+
+ALTER TABLE paced_train RENAME COLUMN main_category TO category;
+ALTER TABLE train_schedule RENAME COLUMN main_category TO category;

--- a/editoast/migrations/2025-07-07-122814_rename_category_to_main_category/up.sql
+++ b/editoast/migrations/2025-07-07-122814_rename_category_to_main_category/up.sql
@@ -1,0 +1,4 @@
+-- Your SQL goes here
+
+ALTER TABLE paced_train RENAME COLUMN category TO main_category;
+ALTER TABLE train_schedule RENAME COLUMN category TO main_category;

--- a/editoast/src/models/paced_train.rs
+++ b/editoast/src/models/paced_train.rs
@@ -54,7 +54,7 @@ pub struct PacedTrain {
     pub time_window: ChronoDuration,
     /// Time between two occurrences
     pub interval: ChronoDuration,
-    pub category: Option<TrainCategory>,
+    pub main_category: Option<TrainCategory>,
     #[model(json)]
     pub exceptions: Vec<PacedTrainException>,
 }
@@ -71,7 +71,7 @@ impl PacedTrain {
             train_schedule.rolling_stock_name = change_group.rolling_stock_name.clone();
         }
         if let Some(change_group) = &exception.rolling_stock_category {
-            train_schedule.category = change_group.value.clone().map(TrainCategory);
+            train_schedule.main_category = change_group.value.clone().map(TrainCategory);
         }
         if let Some(change_group) = &exception.labels {
             train_schedule.labels = change_group.value.iter().cloned().map(Some).collect();
@@ -123,7 +123,7 @@ impl PacedTrain {
             speed_limit_tag: self.speed_limit_tag,
             power_restrictions: self.power_restrictions,
             options: self.options,
-            category: self.category,
+            main_category: self.main_category,
         }
     }
 
@@ -233,7 +233,7 @@ impl From<paced_train::PacedTrain> for PacedTrainChangeset {
             .options(train_schedule_base.options)
             .time_window(ChronoDuration::from(paced.time_window))
             .interval(ChronoDuration::from(paced.interval))
-            .category(train_schedule_base.category.map(TrainCategory))
+            .main_category(train_schedule_base.category.map(TrainCategory))
             .exceptions(exceptions)
     }
 }
@@ -255,7 +255,7 @@ impl From<PacedTrain> for paced_train::PacedTrain {
                 speed_limit_tag: paced_train.speed_limit_tag.map(Into::into),
                 power_restrictions: paced_train.power_restrictions,
                 options: paced_train.options,
-                category: paced_train.category.as_deref().cloned(),
+                category: paced_train.main_category.as_deref().cloned(),
             },
             exceptions: paced_train.exceptions,
             paced: Paced {
@@ -297,7 +297,7 @@ mod tests {
             rolling_stock_name: "R2D2".to_string(),
             comfort: Comfort::Standard,
             initial_speed: 25.0,
-            category: Some(TrainCategory(
+            main_category: Some(TrainCategory(
                 editoast_schemas::rolling_stock::TrainCategory::HighSpeedTrain,
             )),
             constraint_distribution: Distribution::Standard,
@@ -342,7 +342,7 @@ mod tests {
             exception.initial_speed.unwrap().value
         );
         assert_eq!(
-            paced_train_exception.category,
+            paced_train_exception.main_category,
             exception
                 .rolling_stock_category
                 .unwrap()

--- a/editoast/src/models/timetable/sql/get_train_schedules_in_time_window.sql
+++ b/editoast/src/models/timetable/sql/get_train_schedules_in_time_window.sql
@@ -34,7 +34,7 @@ SELECT train_schedule.id,
     train_schedule.speed_limit_tag,
     train_schedule.power_restrictions,
     train_schedule.options,
-    train_schedule.category
+    train_schedule.main_category
 FROM train_schedule
     LEFT JOIN arrival_time ON train_schedule.id = arrival_time.id
 WHERE train_schedule.start_time <= $2

--- a/editoast/src/models/train_schedule.rs
+++ b/editoast/src/models/train_schedule.rs
@@ -41,7 +41,7 @@ pub struct TrainSchedule {
     pub power_restrictions: Vec<PowerRestrictionItem>,
     #[model(json)]
     pub options: TrainScheduleOptions,
-    pub category: Option<TrainCategory>,
+    pub main_category: Option<TrainCategory>,
 }
 
 impl From<editoast_schemas::TrainSchedule> for TrainScheduleChangeset {
@@ -77,6 +77,6 @@ impl From<editoast_schemas::TrainSchedule> for TrainScheduleChangeset {
             .start_time(start_time)
             .train_name(train_name)
             .options(options)
-            .category(category.map(TrainCategory))
+            .main_category(category.map(TrainCategory))
     }
 }

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -518,7 +518,7 @@ impl VirtualTrainRun {
             speed_limit_tag: stdcm_request.speed_limit_tags.clone(),
             power_restrictions: vec![],
             options: Default::default(),
-            category: None,
+            main_category: None,
         };
 
         // Compute simulation of a train schedule

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -155,7 +155,7 @@ impl From<models::TrainSchedule> for TrainScheduleResponse {
                 speed_limit_tag: value.speed_limit_tag.map(Into::into),
                 power_restrictions: value.power_restrictions,
                 options: value.options,
-                category: value.category.as_deref().cloned(),
+                category: value.main_category.as_deref().cloned(),
             },
         }
     }


### PR DESCRIPTION
part of [#12357](https://github.com/OpenRailAssociation/osrd/issues/12357)

Renamed the `category` field to `main_category` in TrainSchedule and PacedTrain.
The schema still uses `category`, as it will later be combined with the `sub_category` field in a future PR.