### PR TITLE
front: Adapt front for inter OP: train schedule endpoint

### DIFF
--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -523,8 +523,11 @@
     "timeSpaceChartSettings": {
       "capacity": "Capacity",
       "conflicts": "Conflicts",
+      "operationalPointProjection": "Onto operational point",
       "paths": "Paths",
-      "signalsStates": "Signals states"
+      "projection": "Projection",
+      "signalsStates": "Signals states",
+      "trackProjection": "Onto track"
     },
     "timetableOutput": "Timetable Output",
     "toggleManchetteMenu": "Toggle manchette menu",

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -523,8 +523,11 @@
     "timeSpaceChartSettings": {
       "capacity": "Capacité",
       "conflicts": "Conflits",
+      "operationalPointProjection": "Au point remarquable",
       "paths": "Sillons",
-      "signalsStates": "États des signaux"
+      "projection": "Projection",
+      "signalsStates": "États des signaux",
+      "trackProjection": "À la voie"
     },
     "timetableOutput": "Table horaire de sortie",
     "toggleManchetteMenu": "Basculer l'affichage du menu de la manchette",

--- a/front/src/applications/operationalStudies/helpers/TrainOpProjectionLazyLoader.ts
+++ b/front/src/applications/operationalStudies/helpers/TrainOpProjectionLazyLoader.ts
@@ -1,0 +1,116 @@
+import {
+  osrdEditoastApi,
+  type PathProperties,
+  type PostTrainScheduleOccupancyBlocksApiResponse,
+  type PostTrainScheduleProjectPathOpApiResponse,
+} from 'common/api/osrdEditoastApi';
+import type { TimetableItemId } from 'reducers/osrdconf/types';
+import {
+  extractEditoastIdFromPacedTrainId,
+  extractEditoastIdFromTrainScheduleId,
+  formatEditoastIdToTrainScheduleId,
+  isTrainScheduleId,
+} from 'utils/trainId';
+
+import TrainProjectionLazyLoaderAbstract, {
+  type ProjectionResult,
+  type TrainProjectionLazyLoaderOptions,
+} from './TrainProjectionLazyLoaderAbstract';
+
+export default class TrainOpProjectionLazyLoader extends TrainProjectionLazyLoaderAbstract {
+  readonly opIds: string[];
+
+  readonly opDistances: number[];
+
+  constructor(
+    options: TrainProjectionLazyLoaderOptions,
+    operationalPoints: PathProperties['operational_points']
+  ) {
+    super(options);
+    this.opIds = [];
+    this.opDistances = [];
+    if (!operationalPoints || operationalPoints.length === 0) return;
+    operationalPoints.forEach(({ id, position }, index) => {
+      this.opIds.push(id);
+      if (index > 0) {
+        this.opDistances.push(position - operationalPoints[index - 1].position);
+      }
+    });
+  }
+
+  async processBatch(batch: TimetableItemId[]) {
+    const { infraId, path, electricalProfileSetId } = this.options;
+
+    const rawTrainScheduleIds = [];
+    const rawPacedTrainIds = [];
+
+    // TODO: handle paced trains in operational point projection when the endpoint is delivered
+
+    for (const id of batch) {
+      if (isTrainScheduleId(id)) {
+        rawTrainScheduleIds.push(extractEditoastIdFromTrainScheduleId(id));
+      } else {
+        rawPacedTrainIds.push(extractEditoastIdFromPacedTrainId(id));
+      }
+    }
+
+    let trainSchedulePromise: Promise<PostTrainScheduleProjectPathOpApiResponse> = Promise.resolve(
+      {}
+    );
+    let trainScheduleOccupancyBlocksPromise: Promise<PostTrainScheduleOccupancyBlocksApiResponse> =
+      Promise.resolve({});
+
+    if (rawTrainScheduleIds.length > 0) {
+      trainSchedulePromise = this.options
+        .dispatch(
+          osrdEditoastApi.endpoints.postTrainScheduleProjectPathOp.initiate(
+            {
+              body: {
+                infra_id: infraId,
+                train_ids: rawTrainScheduleIds,
+                operational_points_ids: this.opIds,
+                operational_points_distances: this.opDistances,
+              },
+            },
+            { subscribe: false }
+          )
+        )
+        .unwrap();
+
+      trainScheduleOccupancyBlocksPromise = this.options
+        .dispatch(
+          osrdEditoastApi.endpoints.postTrainScheduleOccupancyBlocks.initiate(
+            {
+              occupancyBlockForm: {
+                infra_id: infraId,
+                path,
+                ids: rawTrainScheduleIds,
+                electrical_profile_set_id: electricalProfileSetId,
+              },
+            },
+            { subscribe: false }
+          )
+        )
+        .unwrap();
+    }
+
+    const rawTrainScheduleResults = await trainSchedulePromise;
+    const rawTrainScheduleOccupancyBlocks = await trainScheduleOccupancyBlocksPromise;
+
+    if (this.cancelled) {
+      return;
+    }
+
+    const rawResults = new Map<TimetableItemId, ProjectionResult>();
+
+    for (const [id, result] of Object.entries(rawTrainScheduleResults)) {
+      const trainScheduleId = formatEditoastIdToTrainScheduleId(Number(id));
+      rawResults.set(trainScheduleId, {
+        space_time_curves: result,
+        signal_updates: rawTrainScheduleOccupancyBlocks[id],
+      });
+    }
+
+    this.options.onProgress(rawResults);
+  }
+}

--- a/front/src/applications/operationalStudies/helpers/TrainProjectionLazyLoaderAbstract.ts
+++ b/front/src/applications/operationalStudies/helpers/TrainProjectionLazyLoaderAbstract.ts
@@ -1,0 +1,59 @@
+import {
+  type SignalUpdate,
+  type PathfindingResultSuccess,
+  type SpaceTimeCurve,
+} from 'common/api/osrdEditoastApi';
+import type { TimetableItemId } from 'reducers/osrdconf/types';
+import type { AppDispatch } from 'store';
+
+const BATCH_SIZE = 20;
+
+export type ProjectionResult = {
+  space_time_curves: SpaceTimeCurve[];
+  signal_updates?: SignalUpdate[];
+};
+
+export type TrainProjectionLazyLoaderOptions = {
+  dispatch: AppDispatch;
+  infraId: number;
+  path: PathfindingResultSuccess;
+  electricalProfileSetId?: number;
+  onProgress: (results: Map<TimetableItemId, ProjectionResult>) => void;
+};
+
+export default abstract class TrainProjectionLazyLoaderAbstract {
+  readonly options: TrainProjectionLazyLoaderOptions;
+
+  pending: TimetableItemId[] = [];
+
+  prevPromise: Promise<void> = Promise.resolve();
+
+  cancelled = false;
+
+  constructor(options: TrainProjectionLazyLoaderOptions) {
+    this.options = options;
+  }
+
+  projectTimetableItems(ids: TimetableItemId[]) {
+    if (this.cancelled) {
+      throw new Error('projectTimetableItems() called after cancel()');
+    }
+    this.pending.push(...ids);
+    this.prevPromise = this.prevPromise.finally(() => this.processPending());
+  }
+
+  cancel() {
+    this.pending = [];
+    this.cancelled = true;
+  }
+
+  async processPending() {
+    while (this.pending.length > 0) {
+      const batch = this.pending.slice(0, BATCH_SIZE);
+      this.pending = this.pending.slice(BATCH_SIZE);
+      await this.processBatch(batch);
+    }
+  }
+
+  abstract processBatch(batch: TimetableItemId[]): Promise<void>;
+}

--- a/front/src/applications/operationalStudies/helpers/TrainTrackProjectionLazyLoader.ts
+++ b/front/src/applications/operationalStudies/helpers/TrainTrackProjectionLazyLoader.ts
@@ -1,72 +1,23 @@
-import {
-  osrdEditoastApi,
-  type PostTrainScheduleProjectPathApiResponse,
-  type PostTrainScheduleOccupancyBlocksApiResponse,
-  type PostPacedTrainProjectPathApiResponse,
-  type PostPacedTrainOccupancyBlocksApiResponse,
-  type OccupancyBlockForm,
-  type SpaceTimeCurve,
-  type SignalUpdate,
+import type {
+  PostPacedTrainOccupancyBlocksApiResponse,
+  PostPacedTrainProjectPathApiResponse,
+  PostTrainScheduleOccupancyBlocksApiResponse,
+  PostTrainScheduleProjectPathApiResponse,
 } from 'common/api/osrdEditoastApi';
+import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import type { TimetableItemId } from 'reducers/osrdconf/types';
-import type { AppDispatch } from 'store';
 import {
-  formatEditoastIdToPacedTrainId,
-  formatEditoastIdToTrainScheduleId,
   extractEditoastIdFromPacedTrainId,
   extractEditoastIdFromTrainScheduleId,
+  formatEditoastIdToPacedTrainId,
+  formatEditoastIdToTrainScheduleId,
   isTrainScheduleId,
 } from 'utils/trainId';
 
-const BATCH_SIZE = 20;
+import TrainProjectionLazyLoaderAbstract from './TrainProjectionLazyLoaderAbstract';
+import type { ProjectionResult } from './TrainProjectionLazyLoaderAbstract';
 
-export type ProjectionResult = {
-  space_time_curves: SpaceTimeCurve[];
-  signal_updates: SignalUpdate[];
-};
-
-type TrainProjectionLazyLoaderOptions = {
-  dispatch: AppDispatch;
-  infraId: number;
-  electricalProfileSetId?: number;
-  path: OccupancyBlockForm['path'];
-  onProgress: (results: Map<TimetableItemId, ProjectionResult>) => void;
-};
-
-export default class TrainProjectionLazyLoader {
-  readonly options: TrainProjectionLazyLoaderOptions;
-
-  pending: TimetableItemId[] = [];
-
-  prevPromise: Promise<void> = Promise.resolve();
-
-  cancelled = false;
-
-  constructor(options: TrainProjectionLazyLoaderOptions) {
-    this.options = options;
-  }
-
-  projectTimetableItems(ids: TimetableItemId[]) {
-    if (this.cancelled) {
-      throw new Error('projectTimetableItems() called after cancel()');
-    }
-    this.pending.push(...ids);
-    this.prevPromise = this.prevPromise.finally(() => this.processPending());
-  }
-
-  cancel() {
-    this.pending = [];
-    this.cancelled = true;
-  }
-
-  async processPending() {
-    while (this.pending.length > 0) {
-      const batch = this.pending.slice(0, BATCH_SIZE);
-      this.pending = this.pending.slice(BATCH_SIZE);
-      await this.processBatch(batch);
-    }
-  }
-
+export default class TrainTrackProjectionLazyLoader extends TrainProjectionLazyLoaderAbstract {
   async processBatch(batch: TimetableItemId[]) {
     const { infraId, path, electricalProfileSetId } = this.options;
 

--- a/front/src/applications/operationalStudies/helpers/upsertNewProjectedTrains.ts
+++ b/front/src/applications/operationalStudies/helpers/upsertNewProjectedTrains.ts
@@ -6,7 +6,7 @@ import {
   isPacedTrainResponseWithPacedTrainId,
 } from 'utils/trainId';
 
-import type { ProjectionResult } from './TrainProjectionLazyLoader';
+import type { ProjectionResult } from './TrainProjectionLazyLoaderAbstract';
 
 const upsertNewProjectedTrains = (
   projectedTrains: Map<TimetableItemId, TrainSpaceTimeData>,
@@ -27,7 +27,7 @@ const upsertNewProjectedTrains = (
       name: matchingTrain?.train_name || 'Train name not found',
       departureTime: new Date(matchingTrain?.start_time),
       spaceTimeCurves: trainData.space_time_curves,
-      signalUpdates: trainData.signal_updates,
+      signalUpdates: trainData.signal_updates || [],
       ...(isPacedTrainResponseWithPacedTrainId(matchingTrain)
         ? {
             id: formatPacedTrainIdToIndexedOccurrenceId(matchingTrain.id, 0),

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -1231,7 +1231,7 @@ const injectedRtkApi = api
         }),
         providesTags: ['train_schedule'],
       }),
-      postTrainScheduleProjectPathOp: build.mutation<
+      postTrainScheduleProjectPathOp: build.query<
         PostTrainScheduleProjectPathOpApiResponse,
         PostTrainScheduleProjectPathOpApiArg
       >({
@@ -1240,7 +1240,7 @@ const injectedRtkApi = api
           method: 'POST',
           body: queryArg.body,
         }),
-        invalidatesTags: ['train_schedule'],
+        providesTags: ['train_schedule'],
       }),
       postTrainScheduleSimulationSummary: build.query<
         PostTrainScheduleSimulationSummaryApiResponse,

--- a/front/src/config/openapi-editoast-config.cts
+++ b/front/src/config/openapi-editoast-config.cts
@@ -21,6 +21,7 @@ const config: ConfigFile = {
         'postPacedTrainOccupancyBlocks',
         'postTrainScheduleSimulationSummary',
         'postTrainScheduleProjectPath',
+        'postTrainScheduleProjectPathOp',
         'postTrainScheduleOccupancyBlocks',
         'postWorkSchedulesProjectPath',
       ],

--- a/front/src/modules/simulationResult/components/ManchetteWithSpaceTimeChart/SettingsPanel.tsx
+++ b/front/src/modules/simulationResult/components/ManchetteWithSpaceTimeChart/SettingsPanel.tsx
@@ -1,8 +1,14 @@
 import { type ChangeEvent } from 'react';
 
-import { Checkbox } from '@osrd-project/ui-core';
+import { Checkbox, RadioGroup } from '@osrd-project/ui-core';
 import { X } from '@osrd-project/ui-icons';
 import { useTranslation } from 'react-i18next';
+import { useSelector } from 'react-redux';
+
+import { updateProjectionType } from 'reducers/simulationResults';
+import { getProjectionType } from 'reducers/simulationResults/selectors';
+import type { ProjectionType } from 'reducers/simulationResults/types';
+import { useAppDispatch } from 'store';
 
 type Settings = {
   showConflicts: boolean;
@@ -17,6 +23,8 @@ type SettingsPanelProps = {
 
 const SettingsPanel = ({ settings, onChange, onClose }: SettingsPanelProps) => {
   const { t } = useTranslation('operational-studies', { keyPrefix: 'simulationResults' });
+  const dispatch = useAppDispatch();
+  const projectionType = useSelector(getProjectionType);
 
   const handleChange = (key: keyof Settings) => (event: ChangeEvent<HTMLInputElement>) => {
     onChange({ ...settings, [key]: event.target.checked });
@@ -27,6 +35,24 @@ const SettingsPanel = ({ settings, onChange, onClose }: SettingsPanelProps) => {
       <button type="button" className="close-btn" onClick={onClose}>
         <X />
       </button>
+
+      <section className="pb-3">
+        <RadioGroup
+          label={t('timeSpaceChartSettings.projection')}
+          value={projectionType}
+          onChange={(value) => dispatch(updateProjectionType(value as ProjectionType))}
+          options={[
+            {
+              label: t('timeSpaceChartSettings.trackProjection'),
+              value: 'trackProjection',
+            },
+            {
+              label: t('timeSpaceChartSettings.operationalPointProjection'),
+              value: 'operationalPointProjection',
+            },
+          ]}
+        />
+      </section>
 
       <section className="pb-4">
         <header>{t('timeSpaceChartSettings.capacity')}</header>

--- a/front/src/modules/simulationResult/components/SpaceTimeChart/useGetProjectedTrainOperationalPoints.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChart/useGetProjectedTrainOperationalPoints.ts
@@ -2,12 +2,14 @@ import { useEffect, useState } from 'react';
 
 import { omit } from 'lodash';
 import { useTranslation } from 'react-i18next';
+import { useSelector } from 'react-redux';
 
 import { upsertMapWaypointsInOperationalPoints } from 'applications/operationalStudies/helpers/upsertMapWaypointsInOperationalPoints';
 import { osrdEditoastApi, type PathfindingResult } from 'common/api/osrdEditoastApi';
 import { isStation } from 'modules/pathfinding/utils';
 import type { PathOperationalPoint } from 'modules/simulationResult/types';
 import type { TimetableItem } from 'reducers/osrdconf/types';
+import { getProjectionType } from 'reducers/simulationResults/selectors';
 import {
   extractEditoastIdFromPacedTrainId,
   extractEditoastIdFromTrainScheduleId,
@@ -26,6 +28,7 @@ const useGetProjectedTrainOperationalPoints = ({
   timetableItemUsedForProjection?: TimetableItem;
 }) => {
   const { t } = useTranslation('operational-studies');
+  const projectionType = useSelector(getProjectionType);
 
   const [operationalPoints, setOperationalPoints] = useState<PathOperationalPoint[]>([]);
   const [filteredOperationalPoints, setFilteredOperationalPoints] =
@@ -73,13 +76,16 @@ const useGetProjectedTrainOperationalPoints = ({
             opId: op.id,
           })) || [];
 
-        operationalPointsWithUniqueIds = upsertMapWaypointsInOperationalPoints(
-          'PathOperationalPoint',
-          timetableItemUsedForProjection.path,
-          path.path_item_positions,
-          operationalPointsWithUniqueIds,
-          t
-        );
+        operationalPointsWithUniqueIds =
+          projectionType === 'trackProjection'
+            ? upsertMapWaypointsInOperationalPoints(
+                'PathOperationalPoint',
+                timetableItemUsedForProjection.path,
+                path.path_item_positions,
+                operationalPointsWithUniqueIds,
+                t
+              )
+            : operationalPointsWithUniqueIds;
 
         setOperationalPoints(operationalPointsWithUniqueIds);
 
@@ -109,7 +115,7 @@ const useGetProjectedTrainOperationalPoints = ({
     };
 
     getOperationalPoints();
-  }, [timetableItemUsedForProjection, infraId, t]);
+  }, [timetableItemUsedForProjection, infraId, t, projectionType]);
 
   return { operationalPoints, filteredOperationalPoints, setFilteredOperationalPoints };
 };

--- a/front/src/modules/simulationResult/components/SpaceTimeChart/useLazyProjectTrains.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChart/useLazyProjectTrains.ts
@@ -1,18 +1,23 @@
 import { useEffect, useState, useCallback, useRef } from 'react';
 
-import TrainProjectionLazyLoader, {
-  type ProjectionResult,
-} from 'applications/operationalStudies/helpers/TrainProjectionLazyLoader';
+import { skipToken } from '@reduxjs/toolkit/query/react';
+import { useSelector } from 'react-redux';
+
+import TrainOpProjectionLazyLoader from 'applications/operationalStudies/helpers/TrainOpProjectionLazyLoader';
+import type { ProjectionResult } from 'applications/operationalStudies/helpers/TrainProjectionLazyLoaderAbstract';
+import type TrainProjectionLazyLoaderAbstract from 'applications/operationalStudies/helpers/TrainProjectionLazyLoaderAbstract';
+import TrainTrackProjectionLazyLoader from 'applications/operationalStudies/helpers/TrainTrackProjectionLazyLoader';
 import upsertNewProjectedTrains from 'applications/operationalStudies/helpers/upsertNewProjectedTrains';
-import type { OccupancyBlockForm } from 'common/api/osrdEditoastApi';
+import { osrdEditoastApi, type PathfindingResultSuccess } from 'common/api/osrdEditoastApi';
 import type { TrainSpaceTimeData } from 'modules/simulationResult/types';
 import type { TimetableItemId, TimetableItem } from 'reducers/osrdconf/types';
+import { getProjectionType } from 'reducers/simulationResults/selectors';
 import { useAppDispatch } from 'store';
 
 type UseLazyProjectTrainsOptions = {
   infraId: number;
   electricalProfileSetId?: number;
-  path?: OccupancyBlockForm['path'];
+  path?: PathfindingResultSuccess;
 };
 
 const useLazyProjectTrains = ({
@@ -21,27 +26,46 @@ const useLazyProjectTrains = ({
   path,
 }: UseLazyProjectTrainsOptions) => {
   const dispatch = useAppDispatch();
-  const loaderRef = useRef<TrainProjectionLazyLoader>(null);
+  const loaderRef = useRef<TrainProjectionLazyLoaderAbstract>(null);
   const timetableItemsByIdRef = useRef<Map<TimetableItemId, TimetableItem>>(new Map());
   const [projectedTrainsById, setProjectedTrainsById] = useState<
     Map<TimetableItemId, TrainSpaceTimeData>
   >(new Map());
+  const projectionType = useSelector(getProjectionType);
+
+  const { data: pathProperties } =
+    osrdEditoastApi.endpoints.postInfraByInfraIdPathProperties.useQuery(
+      projectionType === 'operationalPointProjection' && path
+        ? {
+            infraId,
+            props: ['operational_points'],
+            pathPropertiesInput: {
+              track_section_ranges: path.track_section_ranges,
+            },
+          }
+        : skipToken
+    );
+
+  const onProgress = useCallback((results: Map<TimetableItemId, ProjectionResult>) => {
+    setProjectedTrainsById((prev) =>
+      upsertNewProjectedTrains(prev, results, timetableItemsByIdRef.current)
+    );
+  }, []);
 
   useEffect(() => {
     if (!path) return undefined;
-
-    const { blocks, routes, track_section_ranges } = path;
-    const loader = new TrainProjectionLazyLoader({
+    const options = {
       dispatch,
       infraId,
-      path: { blocks, routes, track_section_ranges },
+      path,
       electricalProfileSetId,
-      onProgress: (results: Map<TimetableItemId, ProjectionResult>) => {
-        setProjectedTrainsById((prev) =>
-          upsertNewProjectedTrains(prev, results, timetableItemsByIdRef.current)
-        );
-      },
-    });
+      onProgress,
+    };
+
+    const loader =
+      projectionType === 'trackProjection'
+        ? new TrainTrackProjectionLazyLoader(options)
+        : new TrainOpProjectionLazyLoader(options, pathProperties?.operational_points);
 
     loader.projectTimetableItems([...timetableItemsByIdRef.current.keys()]);
 
@@ -50,7 +74,7 @@ const useLazyProjectTrains = ({
       loader.cancel();
       loaderRef.current = null;
     };
-  }, [infraId, electricalProfileSetId, path]);
+  }, [infraId, electricalProfileSetId, path, projectionType, pathProperties]);
 
   const projectTimetableItems = useCallback((timetableItems: TimetableItem[]) => {
     for (const timetableItem of timetableItems) {
@@ -88,6 +112,14 @@ const useLazyProjectTrains = ({
         });
         return next;
       });
+      // Update the timetable item in the reference map
+      // This is necessary to keep the reference up-to-date for future projections
+      // and to ensure that the projected trains are correctly updated
+      // when the projection type changes
+      const timetableItem = timetableItemsByIdRef.current.get(id);
+      if (timetableItem) {
+        timetableItem.start_time = newDeparture.toISOString();
+      }
     },
     []
   );

--- a/front/src/modules/simulationResult/styles/manchetteWithSpaceTimeChart.scss
+++ b/front/src/modules/simulationResult/styles/manchetteWithSpaceTimeChart.scss
@@ -112,5 +112,26 @@
       font-weight: 600;
       margin-bottom: 7px;
     }
+
+    section {
+      // Correctly align the checkbox with the radio buttons
+      .custom-checkbox {
+        margin-left: 4px;
+      }
+
+      // Override the default padding of the radio button wrapper
+      .radio-button-wrapper {
+        padding-left: 0;
+        padding-block: 0;
+
+        .radio-button {
+          padding-left: 8px;
+
+          label {
+            font-weight: 400;
+          }
+        }
+      }
+    }
   }
 }

--- a/front/src/reducers/simulationResults/index.ts
+++ b/front/src/reducers/simulationResults/index.ts
@@ -2,12 +2,13 @@ import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 import type { Draft } from 'immer';
 
 import type { TimetableItemId, TrainId } from 'reducers/osrdconf/types';
-import { type SimulationResultsState } from 'reducers/simulationResults/types';
+import type { ProjectionType, SimulationResultsState } from 'reducers/simulationResults/types';
 
 export const simulationResultsInitialState: SimulationResultsState = {
   chart: undefined,
   selectedTrainId: undefined,
   trainIdUsedForProjection: undefined,
+  projectionType: 'trackProjection',
 };
 
 export const simulationResultsSlice = createSlice({
@@ -26,10 +27,16 @@ export const simulationResultsSlice = createSlice({
     ) {
       state.trainIdUsedForProjection = action.payload;
     },
+    updateProjectionType(
+      state: Draft<SimulationResultsState>,
+      action: PayloadAction<ProjectionType>
+    ) {
+      state.projectionType = action.payload;
+    },
   },
 });
 
-export const { updateSelectedTrainId, updateTrainIdUsedForProjection } =
+export const { updateSelectedTrainId, updateTrainIdUsedForProjection, updateProjectionType } =
   simulationResultsSlice.actions;
 
 export default simulationResultsSlice.reducer;

--- a/front/src/reducers/simulationResults/selectors.ts
+++ b/front/src/reducers/simulationResults/selectors.ts
@@ -9,3 +9,4 @@ const makeOsrdSimulationSelector = makeSubSelector<SimulationResultsState>(getSi
 
 export const getSelectedTrainId = makeOsrdSimulationSelector('selectedTrainId');
 export const getTrainIdUsedForProjection = makeOsrdSimulationSelector('trainIdUsedForProjection');
+export const getProjectionType = makeOsrdSimulationSelector('projectionType');

--- a/front/src/reducers/simulationResults/simulationResultsReducer.spec.ts
+++ b/front/src/reducers/simulationResults/simulationResultsReducer.spec.ts
@@ -57,4 +57,13 @@ describe('simulationResultsReducer', () => {
     const state = store.getState()[simulationResultsSlice.name];
     expect(state.trainIdUsedForProjection).toBe('paced-1');
   });
+
+  it('should handle updateProjectionType', () => {
+    const store = createStore();
+    const newProjectionType = 'operationalPointProjection';
+    store.dispatch(simulationResultsSlice.actions.updateProjectionType(newProjectionType));
+
+    const state = store.getState()[simulationResultsSlice.name];
+    expect(state.projectionType).toBe(newProjectionType);
+  });
 });

--- a/front/src/reducers/simulationResults/types.ts
+++ b/front/src/reducers/simulationResults/types.ts
@@ -28,8 +28,11 @@ export type SpeedRanges = {
   speeds: number[];
 };
 
+export type ProjectionType = 'trackProjection' | 'operationalPointProjection';
+
 export interface SimulationResultsState {
   chart?: Chart;
   selectedTrainId?: TrainId;
   trainIdUsedForProjection?: TimetableItemId;
+  projectionType: ProjectionType;
 }

--- a/front/ui/ui-core/src/components/inputs/RadioGroup.tsx
+++ b/front/ui/ui-core/src/components/inputs/RadioGroup.tsx
@@ -17,6 +17,7 @@ export type RadioGroupProps = {
   value?: string;
   options: RadioButtonProps[];
   statusWithMessage?: StatusWithMessage;
+  onChange?: (value: string) => void;
 };
 
 const RadioGroup = ({
@@ -29,6 +30,7 @@ const RadioGroup = ({
   statusWithMessage,
   required,
   small,
+  onChange,
 }: RadioGroupProps) => {
   const [selectedValue, setSelectedValue] = useState<string | undefined>(value);
 
@@ -36,6 +38,7 @@ const RadioGroup = ({
     if (!readOnly) {
       setSelectedValue(nextOption.value);
       nextOption.onChange?.(e);
+      onChange?.(nextOption.value);
     }
   };
 


### PR DESCRIPTION
The purpose of this PR is to enable use of the new `/train_schedule/project_path_op` endpoint.

For this we have:
- Transform class `TrainProjectionLazyLoader` into an Abstract class `TrainProjectionLazyLoaderAbstract`
- Create two classes inherited from `TrainProjectionLazyLoaderAbstract`:
  - `TrainTrackProjectionLazyLoader` which uses `/project_path` endpoint
  - `TrainOpProjectionLazyLoader` which currently uses `/train_schedule/project_path_op` endpoint

A radio button in the GET panel setting switches from track projection to Operational point projection

closes #11537 