### PR TITLE
editoast: rename similar schedules to similar trains and fix request

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -3027,10 +3027,10 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/SearchResultItem'
-  /similar_schedules:
+  /similar_trains:
     post:
       tags:
-      - similar_schedules
+      - similar_trains
       - stdcm
       - sncf
       requestBody:
@@ -3063,37 +3063,37 @@ paths:
                 waypoints:
                   type: array
                   items:
-                    $ref: '#/components/schemas/SimilarScheduleWaypoint'
+                    $ref: '#/components/schemas/SimilarTrainWaypoint'
         required: true
       responses:
         '200':
-          description: A combination of reference train schedules identifiers similar to the provided schedule
+          description: A combination of reference train identifiers similar to the provided train
           content:
             application/json:
               schema:
                 type: object
                 required:
-                - similar_schedules
+                - similar_trains
                 properties:
-                  similar_schedules:
+                  similar_trains:
                     type: array
                     items:
                       type: object
                       required:
-                      - schedule_id
+                      - train_name
                       - start_time
                       - begin
                       - end
                       properties:
                         begin:
-                          $ref: '#/components/schemas/SimilarScheduleWaypointResponse'
+                          $ref: '#/components/schemas/SimilarTrainWaypointResponse'
                         end:
-                          $ref: '#/components/schemas/SimilarScheduleWaypointResponse'
-                        schedule_id:
-                          type: string
+                          $ref: '#/components/schemas/SimilarTrainWaypointResponse'
                         start_time:
                           type: string
                           format: date-time
+                        train_name:
+                          type: string
   /sprites/signaling_systems:
     get:
       tags:
@@ -12137,7 +12137,7 @@ components:
           format: int64
           description: The aspects start being displayed at this time (number of ms since `departure_time`)
           minimum: 0
-    SimilarScheduleWaypoint:
+    SimilarTrainWaypoint:
       type: object
       required:
       - ci
@@ -12151,7 +12151,7 @@ components:
           format: int64
         stop:
           type: boolean
-    SimilarScheduleWaypointResponse:
+    SimilarTrainWaypointResponse:
       type: object
       required:
       - ci

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -3041,7 +3041,12 @@ paths:
               required:
               - rolling_stock
               - waypoints
+              - infra_id
+              - timetable_id
               properties:
+                infra_id:
+                  type: integer
+                  format: int64
                 rolling_stock:
                   type: object
                   required:
@@ -3052,6 +3057,9 @@ paths:
                     speed_limit_tag:
                       type: string
                       nullable: true
+                timetable_id:
+                  type: integer
+                  format: int64
                 waypoints:
                   type: array
                   items:

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -1,6 +1,6 @@
 mod occupancy_blocks;
 pub mod paced_train;
-pub mod similar_schedules;
+mod similar_trains;
 pub mod simulation;
 pub mod stdcm;
 pub mod train_schedule;
@@ -93,7 +93,7 @@ crate::routes! {
     },
     &paced_train,
     &train_schedule,
-    &similar_schedules,
+    &similar_trains,
 }
 
 editoast_common::schemas! {
@@ -103,7 +103,7 @@ editoast_common::schemas! {
     paced_train::schemas(),
     train_schedule::schemas(),
     simulation::schemas(),
-    similar_schedules::schemas(),
+    similar_trains::schemas(),
 }
 
 #[derive(Debug, Error, EditoastError, derive_more::From)]

--- a/editoast/src/views/timetable/similar_schedules.rs
+++ b/editoast/src/views/timetable/similar_schedules.rs
@@ -60,6 +60,8 @@ struct Request {
     rolling_stock: RollingStockCharacteristics,
     #[schema(value_type = Vec<SimilarScheduleWaypoint>)]
     waypoints: Vec<Waypoint>,
+    infra_id: i64,
+    timetable_id: i64,
 }
 
 #[derive(Debug, Serialize, ToSchema)]

--- a/editoast/src/views/timetable/similar_trains.rs
+++ b/editoast/src/views/timetable/similar_trains.rs
@@ -20,9 +20,7 @@ editoast_common::schemas! {
 }
 
 crate::routes! {
-    "/similar_schedules" => {
-        similar_schedules,
-    },
+    "/similar_trains" => similar_trains,
 }
 
 #[derive(Debug, Deserialize, ToSchema)]
@@ -34,7 +32,7 @@ struct RollingStockCharacteristics {
 
 #[derive(Clone, Deserialize, ToSchema)]
 #[cfg_attr(test, derive(PartialEq))]
-#[schema(as = SimilarScheduleWaypoint)]
+#[schema(as = SimilarTrainWaypoint)]
 struct Waypoint {
     ci: i64,
     ch: String,
@@ -58,7 +56,7 @@ impl std::fmt::Debug for Waypoint {
 struct Request {
     #[schema(inline)]
     rolling_stock: RollingStockCharacteristics,
-    #[schema(value_type = Vec<SimilarScheduleWaypoint>)]
+    #[schema(value_type = Vec<SimilarTrainWaypoint>)]
     waypoints: Vec<Waypoint>,
     infra_id: i64,
     timetable_id: i64,
@@ -66,41 +64,41 @@ struct Request {
 
 #[derive(Debug, Serialize, ToSchema)]
 #[cfg_attr(test, derive(PartialEq))]
-#[schema(as = SimilarScheduleWaypointResponse)]
+#[schema(as = SimilarTrainWaypointResponse)]
 struct WaypointResponse {
     ci: i64,
     ch: String,
 }
 
 #[derive(Debug, Serialize, ToSchema)]
-struct SimilarScheduleItem {
-    schedule_id: String,
+struct SimilarTrainItem {
+    train_name: String,
     start_time: DateTime<Utc>,
-    #[schema(value_type = SimilarScheduleWaypointResponse)]
+    #[schema(value_type = SimilarTrainWaypointResponse)]
     begin: WaypointResponse,
-    #[schema(value_type = SimilarScheduleWaypointResponse)]
+    #[schema(value_type = SimilarTrainWaypointResponse)]
     end: WaypointResponse,
 }
 
 #[derive(Debug, Serialize, ToSchema)]
 struct Response {
     #[schema(inline)]
-    similar_schedules: Vec<SimilarScheduleItem>,
+    similar_trains: Vec<SimilarTrainItem>,
 }
 
 #[utoipa::path(
     post, path = "",
-    tag = "similar_schedules,stdcm,sncf",
+    tag = "similar_trains,stdcm,sncf",
     request_body = inline(Request),
     responses(
         (
             status = 200,
-            description = "A combination of reference train schedules identifiers similar to the provided schedule",
+            description = "A combination of reference train identifiers similar to the provided train",
             body = inline(Response),
         ),
     ),
 )]
-async fn similar_schedules(
+async fn similar_trains(
     Extension(auth): AuthenticationExt,
     State(AppState { .. }): State<AppState>,
     Json(Request { .. }): Json<Request>,
@@ -113,10 +111,10 @@ async fn similar_schedules(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    let similar_schedules = Response {
-        similar_schedules: vec![
-            SimilarScheduleItem {
-                schedule_id: "mock_similar_schedule_1".to_string(),
+    let similar_trains = Response {
+        similar_trains: vec![
+            SimilarTrainItem {
+                train_name: "mock_similar_train_1".to_string(),
                 start_time: DateTime::parse_from_rfc3339("2025-05-14T00:00:00Z")
                     .unwrap()
                     .to_utc(),
@@ -129,8 +127,8 @@ async fn similar_schedules(
                     ch: "B1".to_string(),
                 },
             },
-            SimilarScheduleItem {
-                schedule_id: "mock_similar_schedule_2".to_string(),
+            SimilarTrainItem {
+                train_name: "mock_similar_train_2".to_string(),
                 start_time: DateTime::parse_from_rfc3339("2025-05-14T00:00:00Z")
                     .unwrap()
                     .to_utc(),
@@ -146,5 +144,5 @@ async fn similar_schedules(
         ],
     };
 
-    Ok(Json(similar_schedules))
+    Ok(Json(similar_trains))
 }

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -20,7 +20,7 @@ export const addTagTypes = [
   'rolling_stock_livery',
   'round_trips',
   'search',
-  'similar_schedules',
+  'similar_trains',
   'stdcm',
   'sncf',
   'sprites',
@@ -925,12 +925,9 @@ const injectedRtkApi = api
         }),
         invalidatesTags: ['search'],
       }),
-      postSimilarSchedules: build.mutation<
-        PostSimilarSchedulesApiResponse,
-        PostSimilarSchedulesApiArg
-      >({
-        query: (queryArg) => ({ url: `/similar_schedules`, method: 'POST', body: queryArg.body }),
-        invalidatesTags: ['similar_schedules', 'stdcm', 'sncf'],
+      postSimilarTrains: build.mutation<PostSimilarTrainsApiResponse, PostSimilarTrainsApiArg>({
+        query: (queryArg) => ({ url: `/similar_trains`, method: 'POST', body: queryArg.body }),
+        invalidatesTags: ['similar_trains', 'stdcm', 'sncf'],
       }),
       getSpritesSignalingSystems: build.query<
         GetSpritesSignalingSystemsApiResponse,
@@ -2090,16 +2087,16 @@ export type PostSearchApiArg = {
   pageSize?: number | null;
   searchPayload: SearchPayload;
 };
-export type PostSimilarSchedulesApiResponse =
-  /** status 200 A combination of reference train schedules identifiers similar to the provided schedule */ {
-    similar_schedules: {
-      begin: SimilarScheduleWaypointResponse;
-      end: SimilarScheduleWaypointResponse;
-      schedule_id: string;
+export type PostSimilarTrainsApiResponse =
+  /** status 200 A combination of reference train identifiers similar to the provided train */ {
+    similar_trains: {
+      begin: SimilarTrainWaypointResponse;
+      end: SimilarTrainWaypointResponse;
       start_time: string;
+      train_name: string;
     }[];
   };
-export type PostSimilarSchedulesApiArg = {
+export type PostSimilarTrainsApiArg = {
   body: {
     infra_id: number;
     rolling_stock: {
@@ -2107,7 +2104,7 @@ export type PostSimilarSchedulesApiArg = {
       speed_limit_tag?: string | null;
     };
     timetable_id: number;
-    waypoints: SimilarScheduleWaypoint[];
+    waypoints: SimilarTrainWaypoint[];
   };
 };
 export type GetSpritesSignalingSystemsApiResponse =
@@ -4216,11 +4213,11 @@ export type SearchPayload = {
   object: string;
   query: SearchQuery;
 };
-export type SimilarScheduleWaypointResponse = {
+export type SimilarTrainWaypointResponse = {
   ch: string;
   ci: number;
 };
-export type SimilarScheduleWaypoint = {
+export type SimilarTrainWaypoint = {
   ch: string;
   ci: number;
   stop: boolean;

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -2101,10 +2101,12 @@ export type PostSimilarSchedulesApiResponse =
   };
 export type PostSimilarSchedulesApiArg = {
   body: {
+    infra_id: number;
     rolling_stock: {
       name: string;
       speed_limit_tag?: string | null;
     };
+    timetable_id: number;
     waypoints: SimilarScheduleWaypoint[];
   };
 };


### PR DESCRIPTION
- **editoast: require timetable and infra in similar train request**
- **editoast: rename `similar_schedules` to `similar_trains`**
