### PR TITLE
front: fetch steps uic ch and coord on pathfinding fails

### DIFF
--- a/front/src/modules/pathfinding/hooks/usePathfinding.ts
+++ b/front/src/modules/pathfinding/hooks/usePathfinding.ts
@@ -70,14 +70,14 @@ const usePathfinding = ({
 
   /**
    * Fetches operational point data for the given path steps using a search API call
-   * and updates each step with the matched operational point's name (if found).
+   * and updates each step with the matched operational point's name, uic, ch and coordinates (if found).
    *
    * This is useful when the pathfinding can not be ran or fails.
    * If pathfinding is successful, calling this function is unnecessary.
    *
    * @param steps - An array of `PathStep` objects to be enriched with operational point data.
    */
-  const fetchPathStepsOperationalPointNames = useCallback(
+  const fetchPathStepsOperationalPointData = useCallback(
     async (steps: PathStep[]) => {
       if (!infraId || !steps.length) return;
 
@@ -113,7 +113,10 @@ const usePathfinding = ({
 
         return {
           ...step,
-          name: matchedOp?.name,
+          ...(matchedOp?.name && { name: matchedOp.name }),
+          ...(matchedOp?.uic !== undefined && { uic: matchedOp.uic }),
+          ...(matchedOp?.ch && { secondary_code: matchedOp.ch }),
+          ...(matchedOp?.geographic && { coordinates: matchedOp.geographic.coordinates }),
         };
       });
 
@@ -273,7 +276,7 @@ const usePathfinding = ({
 
       if (!pathfindingInput) {
         setIsMissingParam();
-        await fetchPathStepsOperationalPointNames(steps.filter((step) => step !== null));
+        await fetchPathStepsOperationalPointData(steps.filter((step) => step !== null));
         return;
       }
 
@@ -286,7 +289,7 @@ const usePathfinding = ({
           return;
         }
 
-        await fetchPathStepsOperationalPointNames(steps.filter((step) => step !== null));
+        await fetchPathStepsOperationalPointData(steps.filter((step) => step !== null));
 
         const incompatibleConstraintsCheck =
           pathfindingResult.failed_status === 'pathfinding_not_found' &&


### PR DESCRIPTION
We previously started fetching path steps names when the pathfinding could not be ran. This made train schedules much more readable, but it is still insufficient to properly debug them. Not only do we lose time finding the steps on the map by hand, but we can't distinguish between steps with identical names.

Thus additionally fetch ch, uic and coordinates, which will make the errors that caused the pathfinding to fail much more obvious, as well as vastly increase the schedule readability. There is no additional cost involved, as all the required information was already present in the existing search request. 

The only thing that will remain missing is the positionOnPath for track-based path steps, but without a path...

See:
[Screencast_20250709_193604.webm](https://github.com/user-attachments/assets/6ca318ef-9d70-417c-9351-45fb226d5b6f)
