### PR TITLE
front: fix flaky e2e tests

### DIFF
--- a/front/tests/pages/operational-studies/scenario-timetable-section.ts
+++ b/front/tests/pages/operational-studies/scenario-timetable-section.ts
@@ -356,8 +356,9 @@ class ScenarioTimetableSection extends OpSimulationResultPage {
   async getTimetableItemArrivalTime(expectedArrivalTime: string, index = 0) {
     await expect(this.timetableItemArrivalTime.nth(index)).toBeVisible();
     await expect(this.timetableItemArrivalTimeLoader).toBeHidden();
-    const actualArrivalTime = await this.timetableItemArrivalTime.nth(index).textContent();
-    expect(actualArrivalTime).toEqual(expectedArrivalTime);
+    await expect
+      .poll(async () => this.timetableItemArrivalTime.nth(index).textContent())
+      .toBe(expectedArrivalTime);
   }
 
   async selectAllTimetableItems(


### PR DESCRIPTION
Each commit tries to fix a flaky test I encountered during testing. 

I think the rs stock edition flakyness is the most important one, as I can reproduce it locally very consistently with test 005. (Edit: for some reason this stopped being an issue, so dropped for now. Since the scenario sync commit was also dropped, only the arrival time fix has been kept atm.)

The fix I'm most unsure about is the one to the scenario sync, both in terms of frequency of occurence and quality of the fix. (Edit : dropped)

(Flakyness solved by the second commit encountered in test 009, third commit in test 019).