### PR TITLE
docker: upgrade Alpine to version 3.22

### DIFF
--- a/editoast/Dockerfile
+++ b/editoast/Dockerfile
@@ -1,7 +1,7 @@
 ##############
 # Cargo chef #
 ##############
-FROM lukemathwalker/cargo-chef:0.1.71-rust-1.87-alpine3.21 AS chef
+FROM lukemathwalker/cargo-chef:0.1.71-rust-1.87-alpine3.22 AS chef
 WORKDIR /editoast
 
 #######################
@@ -79,7 +79,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 ###############
 # Running env #
 ###############
-FROM alpine:3.21 AS running_env
+FROM alpine:3.22 AS running_env
 RUN apk add --no-cache jemalloc curl ca-certificates geos libpq openssl postgresql16-client
 
 COPY --from=run_builder /usr/local/cargo/bin/editoast /usr/local/bin/editoast

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -3,7 +3,7 @@
 ##############
 # Cargo chef #
 ##############
-FROM lukemathwalker/cargo-chef:0.1.71-rust-1.87-alpine3.21 AS chef
+FROM lukemathwalker/cargo-chef:0.1.71-rust-1.87-alpine3.22 AS chef
 WORKDIR /gateway
 
 #######################
@@ -46,7 +46,7 @@ COPY . .
 #######################
 # Running env : build #
 #######################
-FROM alpine:3.21 AS running_env
+FROM alpine:3.22 AS running_env
 RUN apk add --no-cache curl ca-certificates bind-tools jq
 COPY --from=run_builder /usr/local/cargo/bin/osrd_gateway /usr/local/bin/osrd_gateway
 

--- a/osrdyne/Dockerfile
+++ b/osrdyne/Dockerfile
@@ -3,7 +3,7 @@
 ##############
 # Cargo chef #
 ##############
-FROM lukemathwalker/cargo-chef:0.1.71-rust-1.87-alpine3.21 AS chef
+FROM lukemathwalker/cargo-chef:0.1.71-rust-1.87-alpine3.22 AS chef
 WORKDIR /osrdyne
 
 #######################
@@ -46,7 +46,7 @@ COPY . .
 #######################
 # Running env : build #
 #######################
-FROM alpine:3.21 AS running_env
+FROM alpine:3.22 AS running_env
 RUN apk add --no-cache curl ca-certificates bind-tools
 COPY --from=run_builder /usr/local/cargo/bin/osrdyne /usr/local/bin/osrdyne
 


### PR DESCRIPTION
Alpine 3.22 has been released back in May:
https://alpinelinux.org/posts/Alpine-3.22.0-released.html