### PR TITLE
front: allow infra filtering by id

### DIFF
--- a/front/src/modules/infra/components/InfraSelector/InfraSelectorModal.tsx
+++ b/front/src/modules/infra/components/InfraSelector/InfraSelectorModal.tsx
@@ -48,8 +48,10 @@ const InfraSelectorModal = ({ onlySelectionMode = false, isInEditor }: InfraSele
 
   function filterInfras(infrasListLocal: Infra[]) {
     if (debouncedFilter) {
-      infrasListLocal = infrasListLocal.filter((infra) =>
-        infra.name.toLowerCase().includes(debouncedFilter.toLowerCase())
+      infrasListLocal = infrasListLocal.filter(
+        (infra) =>
+          infra.name.toLowerCase().includes(debouncedFilter.toLowerCase()) ||
+          infra.id.toString().includes(debouncedFilter)
       );
     }
     const filteredInfrasListLocal = infrasListLocal


### PR DESCRIPTION
Allow filtering infras by id on top of names. This was requested by people working on circulation debugging.

Since ids are numeric and names are typically not, it's unlikely people could get additional unwanted results this way.