### PR TITLE
front: display output table for invalid trains

### DIFF
--- a/front/src/applications/operationalStudies/hooks/useInvalidTrainOps.ts
+++ b/front/src/applications/operationalStudies/hooks/useInvalidTrainOps.ts
@@ -1,0 +1,64 @@
+import { useMemo } from 'react';
+
+import type { PathPropertiesFormatted } from 'applications/operationalStudies/types';
+import {
+  osrdEditoastApi,
+  type OperationalPointPart,
+  type OperationalPointReference,
+} from 'common/api/osrdEditoastApi';
+import type { Train } from 'reducers/osrdconf/types';
+
+import { getStationFromOps, isOperationalPointReference } from '../utils';
+
+const useInvalidTrainOps = (
+  infraId: number,
+  isValid: boolean,
+  train?: Train
+): PathPropertiesFormatted['operationalPoints'] => {
+  const operationalPointReferences: OperationalPointReference[] = useMemo(() => {
+    if (isValid || !train) return [];
+    return train.path.reduce<OperationalPointReference[]>((acc, pathItem) => {
+      if (isOperationalPointReference(pathItem)) {
+        const { id: _id, deleted: _deleted, ...cleanOperationalPointReference } = pathItem;
+        acc.push(cleanOperationalPointReference);
+      }
+      return acc;
+    }, []);
+  }, [train]);
+
+  const { data: operationalPoints } =
+    osrdEditoastApi.endpoints.postInfraByInfraIdMatchOperationalPoints.useQuery(
+      {
+        infraId,
+        body: {
+          operational_point_references: operationalPointReferences,
+        },
+      },
+      { skip: operationalPointReferences.length === 0 }
+    );
+
+  // Get this type will facilitate the logic in TimesStopsOutput
+  const formattedOperationalPoints: PathPropertiesFormatted['operationalPoints'] = useMemo(() => {
+    if (
+      !operationalPoints?.related_operational_points ||
+      operationalPoints.related_operational_points.length === 0
+    ) {
+      return [];
+    }
+
+    // We have at least one related operational point
+    return operationalPoints.related_operational_points
+      .filter((ops) => ops.length !== 0) // To remove empty arrays related to invalid step
+      .map((ops) => ({
+        ...getStationFromOps(ops)!,
+        // The following properties will not be used for invalid trains output table data
+        part: { position: 0, track: 'unknown' } as OperationalPointPart,
+        position: 0,
+        weight: null,
+      }));
+  }, [operationalPoints]);
+
+  return formattedOperationalPoints;
+};
+
+export default useInvalidTrainOps;

--- a/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
+++ b/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
@@ -122,6 +122,9 @@ const useSimulationResults = (infraId: number): SimulationResults | undefined =>
       { skip: pathfinding?.status !== 'success' }
     );
 
+  if ((pathfinding?.status !== 'success' || simulation?.status !== 'success') && train)
+    return { isValid: false, train, rollingStock };
+
   if (
     !train ||
     pathfinding?.status !== 'success' ||
@@ -149,6 +152,7 @@ const useSimulationResults = (infraId: number): SimulationResults | undefined =>
     }) ?? [];
 
   return {
+    isValid: true,
     train,
     rollingStock,
     simulation,

--- a/front/src/applications/operationalStudies/types.ts
+++ b/front/src/applications/operationalStudies/types.ts
@@ -105,14 +105,17 @@ export type ElectrificationVoltage = {
   voltage?: string;
 };
 
-export type SimulationResults = {
-  train: Train;
-  rollingStock: RollingStockWithLiveries;
-  simulation: SimulationResponseSuccess;
-  path: PathfindingResultSuccess;
-  pathProperties: PathPropertiesFormatted;
-  powerRestrictions: LayerData<PowerRestrictionValues>[];
-};
+export type SimulationResults =
+  | { isValid: false; train: Train; rollingStock?: RollingStockWithLiveries }
+  | {
+      isValid: true;
+      train: Train;
+      rollingStock: RollingStockWithLiveries;
+      simulation: SimulationResponseSuccess;
+      path: PathfindingResultSuccess;
+      pathProperties: PathPropertiesFormatted;
+      powerRestrictions: LayerData<PowerRestrictionValues>[];
+    };
 
 export type OperationalPointWithTimeAndSpeed = {
   id: string | null;

--- a/front/src/applications/operationalStudies/types.ts
+++ b/front/src/applications/operationalStudies/types.ts
@@ -98,6 +98,8 @@ export type PathPropertiesFormatted = {
   voltages: RangedValue[];
 };
 
+export type PositionedOperationalPoint = PathPropertiesFormatted['operationalPoints'][number];
+
 export type PowerRestriction = ArrayElement<TrainSchedule['power_restrictions']>;
 
 export type ElectrificationVoltage = {

--- a/front/src/applications/operationalStudies/utils.ts
+++ b/front/src/applications/operationalStudies/utils.ts
@@ -496,3 +496,9 @@ export const groupRoundTrips = (
 
   return { oneWays, roundTrips, others };
 };
+
+export const getInvalidStepLabel = (step: OperationalPointReference) => {
+  if ('uic' in step) return step.uic.toString();
+  if ('trigram' in step) return step.trigram;
+  return step.operational_point;
+};

--- a/front/src/applications/operationalStudies/views/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/SimulationResults.tsx
@@ -306,6 +306,7 @@ const SimulationResults = ({
               ? {
                   isValid: true,
                   simulatedTrain: simulationResults.simulation.final_output,
+                  simulatedPath: simulationResults.path,
                   simulatedPathItemTimes: simulationSummary.pathItemTimes,
                   simulatedOperationalPoints: simulationResults.pathProperties.operationalPoints,
                 }

--- a/front/src/applications/operationalStudies/views/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/SimulationResults.tsx
@@ -260,7 +260,7 @@ const SimulationResults = ({
         </div>
       </ResizableSection>
 
-      {simulationResults && (
+      {simulationResults?.isValid && (
         <>
           {/* SIMULATION : SPEED SPACE CHART */}
           <div className="osrd-simulation-container speedspacechart-container">
@@ -291,34 +291,45 @@ const SimulationResults = ({
               />
             </div>
           </BoardWrapper>
-
-          <BoardWrapper
-            hidden={!activeBoards.has('tables')}
-            name={t('simulationResults.timetableOutput')}
-          >
-            <div className="time-stop-outputs">
-              {/* TIME STOPS TABLE */}
-              <TimesStopsOutput
-                simulatedTimetableItem={simulationResults.simulation}
-                simulationSummary={simulationSummary}
-                operationalPoints={simulationResults.pathProperties.operationalPoints}
-                selectedTrain={simulationResults.train}
-                path={simulationResults.path}
-              />
-              {/* SIMULATION EXPORT BUTTONS */}
-              <SimulationResultExport
-                path={simulationResults.path}
-                scenarioData={scenarioData}
-                train={simulationResults.train}
-                simulation={simulationResults.simulation}
-                pathProperties={simulationResults.pathProperties}
-                rollingStock={simulationResults.rollingStock}
-                mapCanvas={mapCanvas}
-              />
-            </div>
-          </BoardWrapper>
         </>
       )}
+
+      {/* TIME STOPS TABLE */}
+      <BoardWrapper
+        hidden={!activeBoards.has('tables')}
+        name={t('simulationResults.timetableOutput')}
+      >
+        <div className="time-stop-outputs">
+          <TimesStopsOutput
+            simulatedTimetableItem={
+              simulationResults?.isValid ? simulationResults.simulation : undefined
+            }
+            simulationSummary={simulationSummary}
+            operationalPoints={
+              simulationResults?.isValid
+                ? simulationResults.pathProperties.operationalPoints
+                : undefined
+            }
+            selectedTrain={simulationResults?.train}
+            path={simulationResults?.isValid ? simulationResults.path : undefined}
+          />
+        </div>
+
+        {simulationResults?.isValid && (
+          <div className="time-stop-outputs">
+            {/* SIMULATION EXPORT BUTTONS */}
+            <SimulationResultExport
+              path={simulationResults.path}
+              scenarioData={scenarioData}
+              train={simulationResults.train}
+              simulation={simulationResults.simulation}
+              pathProperties={simulationResults.pathProperties}
+              rollingStock={simulationResults.rollingStock}
+              mapCanvas={mapCanvas}
+            />
+          </div>
+        )}
+      </BoardWrapper>
     </div>
   );
 };

--- a/front/src/applications/operationalStudies/views/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/SimulationResults.tsx
@@ -301,6 +301,7 @@ const SimulationResults = ({
       >
         <div className="time-stop-outputs">
           <TimesStopsOutput
+            infraId={infraId}
             selectedTrain={simulationResults?.train}
             {...(simulationResults?.isValid && simulationSummary?.isValid
               ? {

--- a/front/src/applications/operationalStudies/views/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/SimulationResults.tsx
@@ -301,17 +301,15 @@ const SimulationResults = ({
       >
         <div className="time-stop-outputs">
           <TimesStopsOutput
-            simulatedTimetableItem={
-              simulationResults?.isValid ? simulationResults.simulation : undefined
-            }
-            simulationSummary={simulationSummary}
-            operationalPoints={
-              simulationResults?.isValid
-                ? simulationResults.pathProperties.operationalPoints
-                : undefined
-            }
             selectedTrain={simulationResults?.train}
-            path={simulationResults?.isValid ? simulationResults.path : undefined}
+            {...(simulationResults?.isValid && simulationSummary?.isValid
+              ? {
+                  isValid: true,
+                  simulatedTrain: simulationResults.simulation.final_output,
+                  simulatedPathItemTimes: simulationSummary.pathItemTimes,
+                  simulatedOperationalPoints: simulationResults.pathProperties.operationalPoints,
+                }
+              : { isValid: false })}
           />
         </div>
 

--- a/front/src/modules/timesStops/TimesStopsOutput.tsx
+++ b/front/src/modules/timesStops/TimesStopsOutput.tsx
@@ -14,6 +14,7 @@ import TimesStops from './TimesStops';
 import { TableType, type TimesStopsRow } from './types';
 
 type TimesStopsOutputProps = {
+  infraId: number;
   isValid: boolean;
   selectedTrain?: Train;
   simulatedTrain?: SimulationResponseSuccess['final_output'];
@@ -23,6 +24,7 @@ type TimesStopsOutputProps = {
 };
 
 const TimesStopsOutput = ({
+  infraId,
   isValid,
   selectedTrain,
   simulatedTrain,
@@ -31,6 +33,7 @@ const TimesStopsOutput = ({
   simulatedOperationalPoints,
 }: TimesStopsOutputProps) => {
   const rows = useOutputTableData(
+    infraId,
     isValid,
     selectedTrain,
     simulatedTrain,
@@ -55,7 +58,7 @@ const TimesStopsOutput = ({
         });
       }}
       headerRowHeight={40}
-      dataIsLoading={!simulatedPathItemTimes || !simulatedOperationalPoints || !selectedTrain}
+      dataIsLoading={!selectedTrain}
     />
   );
 };

--- a/front/src/modules/timesStops/TimesStopsOutput.tsx
+++ b/front/src/modules/timesStops/TimesStopsOutput.tsx
@@ -1,7 +1,10 @@
 import cx from 'classnames';
 
 import type { PathPropertiesFormatted } from 'applications/operationalStudies/types';
-import type { SimulationResponseSuccess } from 'common/api/osrdEditoastApi';
+import type {
+  PathfindingResultSuccess,
+  SimulationResponseSuccess,
+} from 'common/api/osrdEditoastApi';
 import type { SimulationSummary } from 'modules/timetableItem/components/Timetable/types';
 import type { Train } from 'reducers/osrdconf/types';
 import { NO_BREAK_SPACE } from 'utils/strings';
@@ -14,6 +17,7 @@ type TimesStopsOutputProps = {
   isValid: boolean;
   selectedTrain?: Train;
   simulatedTrain?: SimulationResponseSuccess['final_output'];
+  simulatedPath?: PathfindingResultSuccess;
   simulatedPathItemTimes?: Extract<SimulationSummary, { isValid: true }>['pathItemTimes'];
   simulatedOperationalPoints?: PathPropertiesFormatted['operationalPoints'];
 };
@@ -22,6 +26,7 @@ const TimesStopsOutput = ({
   isValid,
   selectedTrain,
   simulatedTrain,
+  simulatedPath,
   simulatedPathItemTimes,
   simulatedOperationalPoints,
 }: TimesStopsOutputProps) => {
@@ -29,6 +34,7 @@ const TimesStopsOutput = ({
     isValid,
     selectedTrain,
     simulatedTrain,
+    simulatedPath,
     simulatedPathItemTimes,
     simulatedOperationalPoints
   );

--- a/front/src/modules/timesStops/TimesStopsOutput.tsx
+++ b/front/src/modules/timesStops/TimesStopsOutput.tsx
@@ -47,10 +47,12 @@ const TimesStopsOutput = ({
       tableType={TableType.Output}
       cellClassName={({ rowData: rowData_, columnId }) => {
         const rowData = rowData_ as TimesStopsRow;
-        const arrivalScheduleNotRespected = rowData.arrival?.time
-          ? rowData.calculatedArrival !== rowData.arrival.time
-          : false;
-        const negativeDiffMargins = Number(rowData.diffMargins?.split(NO_BREAK_SPACE)[0]) < 0;
+        const arrivalScheduleNotRespected =
+          rowData.arrival?.time && rowData.calculatedArrival
+            ? rowData.calculatedArrival !== rowData.arrival.time
+            : false;
+        const negativeDiffMargins =
+          rowData.diffMargins && Number(rowData.diffMargins?.split(NO_BREAK_SPACE)[0]) < 0;
         return cx({
           'warning-schedule': arrivalScheduleNotRespected,
           'warning-margin': negativeDiffMargins,

--- a/front/src/modules/timesStops/TimesStopsOutput.tsx
+++ b/front/src/modules/timesStops/TimesStopsOutput.tsx
@@ -1,10 +1,7 @@
 import cx from 'classnames';
 
 import type { PathPropertiesFormatted } from 'applications/operationalStudies/types';
-import type {
-  PathfindingResultSuccess,
-  SimulationResponseSuccess,
-} from 'common/api/osrdEditoastApi';
+import type { SimulationResponseSuccess } from 'common/api/osrdEditoastApi';
 import type { SimulationSummary } from 'modules/timetableItem/components/Timetable/types';
 import type { Train } from 'reducers/osrdconf/types';
 import { NO_BREAK_SPACE } from 'utils/strings';
@@ -14,30 +11,30 @@ import TimesStops from './TimesStops';
 import { TableType, type TimesStopsRow } from './types';
 
 type TimesStopsOutputProps = {
-  simulatedTimetableItem?: SimulationResponseSuccess;
-  simulationSummary?: SimulationSummary;
-  operationalPoints?: PathPropertiesFormatted['operationalPoints'];
+  isValid: boolean;
   selectedTrain?: Train;
-  path?: PathfindingResultSuccess;
+  simulatedTrain?: SimulationResponseSuccess['final_output'];
+  simulatedPathItemTimes?: Extract<SimulationSummary, { isValid: true }>['pathItemTimes'];
+  simulatedOperationalPoints?: PathPropertiesFormatted['operationalPoints'];
 };
 
 const TimesStopsOutput = ({
-  simulatedTimetableItem,
-  simulationSummary,
-  operationalPoints,
+  isValid,
   selectedTrain,
-  path,
+  simulatedTrain,
+  simulatedPathItemTimes,
+  simulatedOperationalPoints,
 }: TimesStopsOutputProps) => {
-  const enrichedOperationalPoints = useOutputTableData(
-    simulatedTimetableItem?.final_output,
-    simulationSummary,
-    operationalPoints,
+  const rows = useOutputTableData(
+    isValid,
     selectedTrain,
-    path
+    simulatedTrain,
+    simulatedPathItemTimes,
+    simulatedOperationalPoints
   );
   return (
     <TimesStops
-      rows={enrichedOperationalPoints}
+      rows={rows}
       tableType={TableType.Output}
       cellClassName={({ rowData: rowData_, columnId }) => {
         const rowData = rowData_ as TimesStopsRow;
@@ -52,7 +49,7 @@ const TimesStopsOutput = ({
         });
       }}
       headerRowHeight={40}
-      dataIsLoading={!simulationSummary || !operationalPoints || !selectedTrain}
+      dataIsLoading={!simulatedPathItemTimes || !simulatedOperationalPoints || !selectedTrain}
     />
   );
 };

--- a/front/src/modules/timesStops/helpers/computeMargins.ts
+++ b/front/src/modules/timesStops/helpers/computeMargins.ts
@@ -1,4 +1,4 @@
-import type { TrainScheduleWithDetails } from 'modules/timetableItem/components/Timetable/types';
+import type { SimulationSummary } from 'modules/timetableItem/components/Timetable/types';
 import type { Train } from 'reducers/osrdconf/types';
 import { ms2sec } from 'utils/timeManipulation';
 
@@ -34,9 +34,7 @@ function computeMargins(
   train: Pick<Train, 'path' | 'margins'>,
   scheduleByAt: Record<string, ScheduleEntry>,
   pathStepIndex: number,
-  pathItemTimes: NonNullable<
-    Extract<NonNullable<TrainScheduleWithDetails['summary']>, { isValid: true }>['pathItemTimes']
-  > // in ms
+  pathItemTimes: Extract<SimulationSummary, { isValid: true }>['pathItemTimes'] | undefined // in ms
 ) {
   const { path, margins } = train;
   const pathStepId = path[pathStepIndex].id;
@@ -57,6 +55,15 @@ function computeMargins(
   }
 
   const { theoreticalMargin, isBoundary } = stepTheoreticalMarginInfo;
+
+  if (!pathItemTimes) {
+    return {
+      theoreticalMargin: formatDigitsAndUnit(theoreticalMargin),
+      isTheoreticalMarginBoundary: isBoundary,
+      calculatedMargin: undefined,
+      diffMargins: undefined,
+    };
+  }
 
   // find the next pathStep where constraints are defined
   let nextIndex = path.length - 1;

--- a/front/src/modules/timesStops/helpers/scheduleData.ts
+++ b/front/src/modules/timesStops/helpers/scheduleData.ts
@@ -6,7 +6,7 @@ import type { ScheduleEntry } from '../types';
 import { receptionSignalToSignalBooleans } from './utils';
 
 /** Format the stopFor, calculatedDeparture, shortSlipDistance and onStopSignal properties */
-export const formatSchedule = (arrivalTime: Date, schedule?: ScheduleEntry) => {
+export const formatSchedule = (arrivalTime?: Date, schedule?: ScheduleEntry) => {
   if (!schedule) {
     return {
       stopFor: undefined,
@@ -26,6 +26,13 @@ export const formatSchedule = (arrivalTime: Date, schedule?: ScheduleEntry) => {
 
   const stopFor = Duration.parse(schedule.stop_for);
 
+  if (!arrivalTime) {
+    return {
+      stopFor: `${stopFor.total('second')}`,
+      calculatedDeparture: undefined,
+      ...receptionSignalToSignalBooleans(schedule.reception_signal),
+    };
+  }
   return {
     stopFor: `${stopFor.total('second')}`,
     calculatedDeparture: dateToHHMMSS(addDurationToDate(arrivalTime, stopFor)),

--- a/front/src/modules/timesStops/helpers/utils.ts
+++ b/front/src/modules/timesStops/helpers/utils.ts
@@ -4,7 +4,12 @@ import dayjs from 'dayjs';
 import type { TFunction } from 'i18next';
 import { round, isEqual, isNil } from 'lodash';
 
-import type { ReceptionSignal } from 'common/api/osrdEditoastApi';
+import type { PositionedOperationalPoint } from 'applications/operationalStudies/types';
+import {
+  getInvalidStepLabel,
+  isOperationalPointReference,
+} from 'applications/operationalStudies/utils';
+import type { PathItemLocation, ReceptionSignal, TrackReference } from 'common/api/osrdEditoastApi';
 import type { TimeString } from 'common/types';
 import { matchPathStepAndOp } from 'modules/pathfinding/utils';
 import type { SuggestedOP } from 'modules/timetableItem/components/ManageTimetableItem/types';
@@ -341,3 +346,45 @@ export function receptionSignalToSignalBooleans(receptionSignal?: ReceptionSigna
   }
   return { shortSlipDistance: false, onStopSignal: false };
 }
+
+export const matchOpRefAndOp = (
+  op: PositionedOperationalPoint,
+  opRef: PathItemLocation
+): boolean => {
+  if ('operational_point' in opRef) return op.id === opRef.operational_point;
+  if ('trigram' in opRef) {
+    return (
+      opRef.trigram === op.extensions?.sncf?.trigram &&
+      (opRef.secondary_code ? opRef.secondary_code === op.extensions.sncf?.ch : true)
+    );
+  }
+  if ('uic' in opRef) {
+    return (
+      opRef.uic === op.extensions?.identifier?.uic &&
+      (opRef.secondary_code ? opRef.secondary_code === op.extensions.sncf?.ch : true)
+    );
+  }
+  return false;
+};
+
+export const getTrackReferenceLabel = (trackReference?: TrackReference | null) => {
+  if (!trackReference) return undefined;
+  return 'track_id' in trackReference ? trackReference.track_id : trackReference.track_name;
+};
+
+export const getOperationalPointName = (
+  op: PositionedOperationalPoint | undefined,
+  step: PathItemLocation,
+  mapWaypointCount: number,
+  t: TFunction<'operational-studies'>
+) => {
+  // We have a matching operational point
+  if (op) return op.extensions?.identifier?.name;
+
+  // TrackOffset
+  if (!isOperationalPointReference(step))
+    return t('main.requestedPoint', { count: mapWaypointCount });
+
+  // Invalid step
+  return getInvalidStepLabel(step);
+};

--- a/front/src/modules/timesStops/hooks/useOutputTableData.ts
+++ b/front/src/modules/timesStops/hooks/useOutputTableData.ts
@@ -4,10 +4,7 @@ import { keyBy } from 'lodash';
 
 import { useScenarioContext } from 'applications/operationalStudies/hooks/useScenarioContext';
 import type { PathPropertiesFormatted } from 'applications/operationalStudies/types';
-import type {
-  PathfindingResultSuccess,
-  SimulationResponseSuccess,
-} from 'common/api/osrdEditoastApi';
+import type { SimulationResponseSuccess } from 'common/api/osrdEditoastApi';
 import { matchPathStepAndOp } from 'modules/pathfinding/utils';
 import { interpolateValue } from 'modules/simulationResult/SimulationResultExport/utils';
 import type { SimulationSummary } from 'modules/timetableItem/components/Timetable/types';
@@ -22,11 +19,11 @@ import { formatSchedule } from '../helpers/scheduleData';
 import { type ScheduleEntry, type TimesStopsRow } from '../types';
 
 const useOutputTableData = (
-  simulatedTrain?: SimulationResponseSuccess['final_output'],
-  simulationSummary?: SimulationSummary,
-  operationalPoints?: PathPropertiesFormatted['operationalPoints'],
+  isValid: boolean,
   selectedTrain?: Train,
-  path?: PathfindingResultSuccess
+  simulatedTrain?: SimulationResponseSuccess['final_output'],
+  simulatedPathItemTimes?: Extract<SimulationSummary, { isValid: true }>['pathItemTimes'],
+  simulatedOperationalPoints?: PathPropertiesFormatted['operationalPoints']
 ): TimesStopsRow[] => {
   const { getTrackSectionsByIds } = useScenarioContext();
 
@@ -36,9 +33,7 @@ const useOutputTableData = (
   const theoreticalMargins = selectedTrain && getTheoreticalMargins(selectedTrain);
 
   const pathStepRowsById: Map<string, Partial<TimesStopsRow>> = useMemo(() => {
-    if (!selectedTrain || !simulationSummary?.isValid || !path) return new Map();
-
-    const { pathItemTimes } = simulationSummary;
+    if (!selectedTrain || !isValid || !simulatedPathItemTimes) return new Map();
 
     const startDatetime = new Date(selectedTrain.start_time);
     let lastReferenceDate = startDatetime;
@@ -47,7 +42,9 @@ const useOutputTableData = (
       selectedTrain.path.map((pathStep, index) => {
         const schedule: ScheduleEntry | undefined = scheduleByAt[pathStep.id];
 
-        const computedArrival = new Date(startDatetime.getTime() + pathItemTimes.final[index]);
+        const computedArrival = new Date(
+          startDatetime.getTime() + simulatedPathItemTimes.final[index]
+        );
 
         const { stopFor, shortSlipDistance, onStopSignal, calculatedDeparture } = formatSchedule(
           computedArrival,
@@ -59,7 +56,13 @@ const useOutputTableData = (
           theoreticalMarginSeconds,
           calculatedMargin,
           diffMargins,
-        } = computeMargins(theoreticalMargins, selectedTrain, scheduleByAt, index, pathItemTimes);
+        } = computeMargins(
+          theoreticalMargins,
+          selectedTrain,
+          scheduleByAt,
+          index,
+          simulatedPathItemTimes
+        );
 
         const { theoreticalArrival, arrival, departure, refDate } = computeInputDatetimes(
           startDatetime,
@@ -98,19 +101,19 @@ const useOutputTableData = (
         return [pathStepRow.pathStepId, pathStepRow];
       })
     );
-  }, [selectedTrain, path, simulationSummary]);
+  }, [selectedTrain, simulatedPathItemTimes]);
 
   useEffect(() => {
     const formatRows = async () => {
-      if (!operationalPoints || !selectedTrain || !simulatedTrain) {
+      if (!simulatedOperationalPoints || !selectedTrain || !simulatedTrain || !isValid) {
         setRows([]);
         return;
       }
 
-      const trackIds = operationalPoints.map((op) => op.part.track);
+      const trackIds = simulatedOperationalPoints.map((op) => op.part.track);
       const trackSections = await getTrackSectionsByIds(trackIds);
 
-      const formattedRows = operationalPoints.map((op) => {
+      const formattedRows = simulatedOperationalPoints.map((op) => {
         const matchingPathStep = selectedTrain?.path.find((pathStep) =>
           matchPathStepAndOp(pathStep, {
             opId: op.id,
@@ -159,7 +162,7 @@ const useOutputTableData = (
     };
 
     formatRows();
-  }, [operationalPoints, pathStepRowsById, simulatedTrain, getTrackSectionsByIds]);
+  }, [simulatedOperationalPoints, pathStepRowsById, simulatedTrain, getTrackSectionsByIds]);
 
   return rows;
 };

--- a/front/src/modules/timesStops/hooks/useOutputTableData.ts
+++ b/front/src/modules/timesStops/hooks/useOutputTableData.ts
@@ -1,7 +1,9 @@
 import { useEffect, useMemo, useState } from 'react';
 
 import { keyBy } from 'lodash';
+import { useTranslation } from 'react-i18next';
 
+import useInvalidTrainOps from 'applications/operationalStudies/hooks/useInvalidTrainOps';
 import { useScenarioContext } from 'applications/operationalStudies/hooks/useScenarioContext';
 import type { PathPropertiesFormatted } from 'applications/operationalStudies/types';
 import type {
@@ -19,9 +21,11 @@ import { ARRIVAL_TIME_ACCEPTABLE_ERROR } from '../consts';
 import { computeInputDatetimes } from '../helpers/arrivalTime';
 import computeMargins, { getTheoreticalMargins } from '../helpers/computeMargins';
 import { formatSchedule } from '../helpers/scheduleData';
+import { matchOpRefAndOp, getTrackReferenceLabel, getOperationalPointName } from '../helpers/utils';
 import { type ScheduleEntry, type TimesStopsRow } from '../types';
 
 const useOutputTableData = (
+  infraId: number,
   isValid: boolean,
   selectedTrain?: Train,
   simulatedTrain?: SimulationResponseSuccess['final_output'],
@@ -29,41 +33,60 @@ const useOutputTableData = (
   simulatedPathItemTimes?: Extract<SimulationSummary, { isValid: true }>['pathItemTimes'],
   simulatedOperationalPoints?: PathPropertiesFormatted['operationalPoints']
 ): TimesStopsRow[] => {
+  const { t } = useTranslation('operational-studies');
   const { getTrackSectionsByIds } = useScenarioContext();
 
   const [rows, setRows] = useState<TimesStopsRow[]>([]);
 
+  // Extract common properties between valid and invalid trains
   const scheduleByAt: Record<string, ScheduleEntry> = keyBy(selectedTrain?.schedule, 'at');
   const theoreticalMargins = selectedTrain && getTheoreticalMargins(selectedTrain);
+  const invalidTrainOperationalPoints = useInvalidTrainOps(infraId, isValid, selectedTrain);
+  const operationalPoints = useMemo(
+    () => simulatedOperationalPoints ?? invalidTrainOperationalPoints,
+    [simulatedOperationalPoints, invalidTrainOperationalPoints]
+  );
 
+  // Format input path step rows
   const pathStepRowsById: Map<string, Partial<TimesStopsRow>> = useMemo(() => {
-    if (
-      !selectedTrain ||
-      !isValid ||
-      !simulatedPathItemTimes ||
-      !simulatedPath ||
-      !simulatedOperationalPoints
-    )
-      return new Map();
+    if (!selectedTrain || !operationalPoints || operationalPoints.length === 0) return new Map();
 
     const startDatetime = new Date(selectedTrain.start_time);
     let lastReferenceDate = startDatetime;
-
+    let mapWaypointCount = 0;
     return new Map(
       selectedTrain.path.map((pathStep, index) => {
         const opPositionOnPath = simulatedPath?.path_item_positions[index];
-        const matchingOperationalPoint = simulatedOperationalPoints.find(
-          (op) => op.position === opPositionOnPath
+        const matchingOperationalPoint = operationalPoints.find((op) =>
+          opPositionOnPath ? op.position === opPositionOnPath : matchOpRefAndOp(op, pathStep)
         );
 
-        const schedule: ScheduleEntry | undefined = scheduleByAt[pathStep.id];
-        const computedArrival = new Date(
-          startDatetime.getTime() + simulatedPathItemTimes.final[index]
+        if ('track' in pathStep) mapWaypointCount += 1;
+        const name = getOperationalPointName(
+          matchingOperationalPoint,
+          pathStep,
+          mapWaypointCount,
+          t
         );
+
+        const schedule = scheduleByAt[pathStep.id];
+        const computedArrival = simulatedPathItemTimes
+          ? new Date(startDatetime.getTime() + simulatedPathItemTimes.final[index])
+          : undefined;
         const { stopFor, shortSlipDistance, onStopSignal, calculatedDeparture } = formatSchedule(
           computedArrival,
           schedule
         );
+        const { theoreticalArrival, arrival, departure, refDate } = computeInputDatetimes(
+          startDatetime,
+          lastReferenceDate,
+          schedule,
+          {
+            isDeparture: index === 0,
+          }
+        );
+        lastReferenceDate = refDate;
+
         const {
           theoreticalMargin,
           isTheoreticalMarginBoundary,
@@ -78,25 +101,19 @@ const useOutputTableData = (
           simulatedPathItemTimes
         );
 
-        const { theoreticalArrival, arrival, departure, refDate } = computeInputDatetimes(
-          startDatetime,
-          lastReferenceDate,
-          schedule,
-          {
-            isDeparture: index === 0,
-          }
-        );
-        lastReferenceDate = refDate;
-
-        const isOnTime = theoreticalArrival
-          ? Duration.subtractDate(theoreticalArrival, computedArrival).abs() <=
-            ARRIVAL_TIME_ACCEPTABLE_ERROR
-          : false;
+        const isOnTime =
+          theoreticalArrival && computedArrival
+            ? Duration.subtractDate(theoreticalArrival, computedArrival).abs() <=
+              ARRIVAL_TIME_ACCEPTABLE_ERROR
+            : false;
+        const calculatedArrival = computedArrival
+          ? dateToHHMMSS(isOnTime ? theoreticalArrival! : computedArrival)
+          : undefined;
 
         const pathStepRow = {
           pathStepId: pathStep.id,
           opId: matchingOperationalPoint?.id,
-          name: matchingOperationalPoint?.extensions?.identifier?.name,
+          name,
           ch: matchingOperationalPoint?.extensions?.sncf?.ch,
 
           arrival,
@@ -110,73 +127,98 @@ const useOutputTableData = (
           theoreticalMarginSeconds,
           calculatedMargin,
           diffMargins,
-          calculatedArrival: dateToHHMMSS(isOnTime ? theoreticalArrival! : computedArrival),
+          calculatedArrival,
           calculatedDeparture,
         };
 
         return [pathStepRow.pathStepId, pathStepRow];
       })
     );
-  }, [selectedTrain, simulatedPathItemTimes]);
+  }, [selectedTrain, simulatedPath, simulatedPathItemTimes, operationalPoints]);
 
   useEffect(() => {
     const formatRows = async () => {
-      if (!simulatedOperationalPoints || !selectedTrain || !simulatedTrain || !isValid) {
+      if (!selectedTrain || !operationalPoints) {
         setRows([]);
         return;
       }
 
-      const trackIds = simulatedOperationalPoints.map((op) => op.part.track);
-      const trackSections = await getTrackSectionsByIds(trackIds);
+      let formattedRows;
 
-      const formattedRows = simulatedOperationalPoints.map((op) => {
-        const trackName = trackSections[op.part.track]?.extensions?.sncf?.track_name;
-        const matchingPathStep = selectedTrain?.path.find((pathStep) =>
-          matchPathStepAndOp(pathStep, {
-            opId: op.id,
-            uic: op.extensions?.identifier?.uic,
-            ch: op.extensions?.sncf?.ch,
-            trigram: op.extensions?.sncf?.trigram,
-            track: op.part.track,
-            offsetOnTrack: op.part.position,
-          })
-        );
+      // For valid trains, complete the rows with the simulated path's operational points and tracks information
+      if (isValid && simulatedTrain) {
+        const trackIds = operationalPoints.map((op) => op.part.track);
+        const trackSections = await getTrackSectionsByIds(trackIds);
 
-        const matchingPathStepRow = matchingPathStep
-          ? pathStepRowsById.get(matchingPathStep.id)
-          : undefined;
+        formattedRows = operationalPoints.map((op) => {
+          const trackName = trackSections[op.part.track]?.extensions?.sncf?.track_name;
+          const matchingPathStep = selectedTrain.path.find((pathStep) =>
+            matchPathStepAndOp(pathStep, {
+              opId: op.id,
+              uic: op.extensions?.identifier?.uic,
+              ch: op.extensions?.sncf?.ch,
+              trigram: op.extensions?.sncf?.trigram,
+              track: op.part.track,
+              offsetOnTrack: op.part.position,
+            })
+          );
 
-        if (matchingPathStepRow) {
+          const matchingPathStepRow = matchingPathStep
+            ? pathStepRowsById.get(matchingPathStep.id)
+            : undefined;
+
+          if (matchingPathStepRow) {
+            return {
+              ...matchingPathStepRow,
+              trackName,
+            };
+          }
+
+          // Compute arrival time when the operational point comes from the simulation
+          const matchingReportTrainIndex = simulatedTrain.positions.findIndex(
+            (position) => position === op.position
+          );
+          const time =
+            matchingReportTrainIndex === -1
+              ? interpolateValue(simulatedTrain, op.position, 'times')
+              : simulatedTrain.times[matchingReportTrainIndex];
+          const calculatedArrival = new Date(new Date(selectedTrain.start_time).getTime() + time);
+
           return {
-            ...matchingPathStepRow,
+            opId: op.id,
+            name: op.extensions?.identifier?.name,
+            ch: op.extensions?.sncf?.ch,
+            trackName,
+            calculatedArrival: dateToHHMMSS(calculatedArrival),
+          };
+        });
+      } else {
+        const trackIds = selectedTrain.path
+          .filter((step) => 'track' in step)
+          .map((step) => step.track);
+        const trackSections = await getTrackSectionsByIds(trackIds);
+
+        formattedRows = Array.from(pathStepRowsById.values()).map((pathStepRow, index) => {
+          const matchingPathStep = selectedTrain.path[index];
+
+          // We check if a specific track has been selected when clicking on the map
+          const trackName =
+            'track' in matchingPathStep
+              ? trackSections[matchingPathStep.track]?.extensions?.sncf?.track_name
+              : getTrackReferenceLabel(matchingPathStep.track_reference);
+
+          return {
+            ...pathStepRow,
             trackName,
           };
-        }
+        });
+      }
 
-        // compute arrival time
-        const matchingReportTrainIndex = simulatedTrain.positions.findIndex(
-          (position) => position === op.position
-        );
-
-        const time =
-          matchingReportTrainIndex === -1
-            ? interpolateValue(simulatedTrain, op.position, 'times')
-            : simulatedTrain.times[matchingReportTrainIndex];
-        const calculatedArrival = new Date(new Date(selectedTrain.start_time).getTime() + time);
-
-        return {
-          opId: op.id,
-          name: op.extensions?.identifier?.name,
-          ch: op.extensions?.sncf?.ch,
-          calculatedArrival: dateToHHMMSS(calculatedArrival),
-          trackName,
-        };
-      });
       setRows(formattedRows);
     };
 
     formatRows();
-  }, [simulatedOperationalPoints, pathStepRowsById, simulatedTrain, getTrackSectionsByIds]);
+  }, [operationalPoints, pathStepRowsById, simulatedTrain, getTrackSectionsByIds]);
 
   return rows;
 };

--- a/front/src/modules/timesStops/hooks/useOutputTableData.ts
+++ b/front/src/modules/timesStops/hooks/useOutputTableData.ts
@@ -4,7 +4,10 @@ import { keyBy } from 'lodash';
 
 import { useScenarioContext } from 'applications/operationalStudies/hooks/useScenarioContext';
 import type { PathPropertiesFormatted } from 'applications/operationalStudies/types';
-import type { SimulationResponseSuccess } from 'common/api/osrdEditoastApi';
+import type {
+  PathfindingResultSuccess,
+  SimulationResponseSuccess,
+} from 'common/api/osrdEditoastApi';
 import { matchPathStepAndOp } from 'modules/pathfinding/utils';
 import { interpolateValue } from 'modules/simulationResult/SimulationResultExport/utils';
 import type { SimulationSummary } from 'modules/timetableItem/components/Timetable/types';
@@ -22,6 +25,7 @@ const useOutputTableData = (
   isValid: boolean,
   selectedTrain?: Train,
   simulatedTrain?: SimulationResponseSuccess['final_output'],
+  simulatedPath?: PathfindingResultSuccess,
   simulatedPathItemTimes?: Extract<SimulationSummary, { isValid: true }>['pathItemTimes'],
   simulatedOperationalPoints?: PathPropertiesFormatted['operationalPoints']
 ): TimesStopsRow[] => {
@@ -33,19 +37,29 @@ const useOutputTableData = (
   const theoreticalMargins = selectedTrain && getTheoreticalMargins(selectedTrain);
 
   const pathStepRowsById: Map<string, Partial<TimesStopsRow>> = useMemo(() => {
-    if (!selectedTrain || !isValid || !simulatedPathItemTimes) return new Map();
+    if (
+      !selectedTrain ||
+      !isValid ||
+      !simulatedPathItemTimes ||
+      !simulatedPath ||
+      !simulatedOperationalPoints
+    )
+      return new Map();
 
     const startDatetime = new Date(selectedTrain.start_time);
     let lastReferenceDate = startDatetime;
 
     return new Map(
       selectedTrain.path.map((pathStep, index) => {
-        const schedule: ScheduleEntry | undefined = scheduleByAt[pathStep.id];
+        const opPositionOnPath = simulatedPath?.path_item_positions[index];
+        const matchingOperationalPoint = simulatedOperationalPoints.find(
+          (op) => op.position === opPositionOnPath
+        );
 
+        const schedule: ScheduleEntry | undefined = scheduleByAt[pathStep.id];
         const computedArrival = new Date(
           startDatetime.getTime() + simulatedPathItemTimes.final[index]
         );
-
         const { stopFor, shortSlipDistance, onStopSignal, calculatedDeparture } = formatSchedule(
           computedArrival,
           schedule
@@ -81,7 +95,9 @@ const useOutputTableData = (
 
         const pathStepRow = {
           pathStepId: pathStep.id,
-          ch: undefined,
+          opId: matchingOperationalPoint?.id,
+          name: matchingOperationalPoint?.extensions?.identifier?.name,
+          ch: matchingOperationalPoint?.extensions?.sncf?.ch,
 
           arrival,
           departure,
@@ -114,6 +130,7 @@ const useOutputTableData = (
       const trackSections = await getTrackSectionsByIds(trackIds);
 
       const formattedRows = simulatedOperationalPoints.map((op) => {
+        const trackName = trackSections[op.part.track]?.extensions?.sncf?.track_name;
         const matchingPathStep = selectedTrain?.path.find((pathStep) =>
           matchPathStepAndOp(pathStep, {
             opId: op.id,
@@ -132,10 +149,7 @@ const useOutputTableData = (
         if (matchingPathStepRow) {
           return {
             ...matchingPathStepRow,
-            opId: op.id,
-            name: op.extensions?.identifier?.name,
-            ch: op.extensions?.sncf?.ch,
-            trackName: trackSections[op.part.track]?.extensions?.sncf?.track_name,
+            trackName,
           };
         }
 
@@ -155,7 +169,7 @@ const useOutputTableData = (
           name: op.extensions?.identifier?.name,
           ch: op.extensions?.sncf?.ch,
           calculatedArrival: dateToHHMMSS(calculatedArrival),
-          trackName: trackSections[op.part.track]?.extensions?.sncf?.track_name,
+          trackName,
         };
       });
       setRows(formattedRows);

--- a/front/src/modules/timesStops/hooks/useOutputTableData.ts
+++ b/front/src/modules/timesStops/hooks/useOutputTableData.ts
@@ -1,7 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 
 import { keyBy } from 'lodash';
-import { useTranslation } from 'react-i18next';
 
 import { useScenarioContext } from 'applications/operationalStudies/hooks/useScenarioContext';
 import type { PathPropertiesFormatted } from 'applications/operationalStudies/types';
@@ -29,7 +28,6 @@ const useOutputTableData = (
   selectedTrain?: Train,
   path?: PathfindingResultSuccess
 ): TimesStopsRow[] => {
-  const { t } = useTranslation();
   const { getTrackSectionsByIds } = useScenarioContext();
 
   const [rows, setRows] = useState<TimesStopsRow[]>([]);
@@ -80,7 +78,6 @@ const useOutputTableData = (
 
         const pathStepRow = {
           pathStepId: pathStep.id,
-          name: t('timeStopTable.waypoint', { id: pathStep.id }),
           ch: undefined,
 
           arrival,

--- a/front/src/modules/timetableItem/components/Timetable/RoundTrips/utils.ts
+++ b/front/src/modules/timetableItem/components/Timetable/RoundTrips/utils.ts
@@ -1,29 +1,16 @@
 import type { TFunction } from 'i18next';
 
 import {
+  getInvalidStepLabel,
   getStationFromOps,
   isOperationalPointReference,
 } from 'applications/operationalStudies/utils';
-import type {
-  OperationalPoint,
-  OperationalPointReference,
-  PathItemLocation,
-} from 'common/api/osrdEditoastApi';
+import type { OperationalPoint, PathItemLocation } from 'common/api/osrdEditoastApi';
 import type { TimetableItemWithPathOps } from 'reducers/osrdconf/types';
 import { addDurationToDate, Duration } from 'utils/duration';
 import { isPacedTrainResponseWithPacedTrainId } from 'utils/trainId';
 
 import type { RoundTripsModalColumnsData } from '../types';
-
-const getInvalidStepLabel = (step: OperationalPointReference) => {
-  if ('uic' in step) {
-    return step.uic.toString();
-  }
-  if ('trigram' in step) {
-    return step.trigram;
-  }
-  return step.operational_point;
-};
 
 const getStepLabels = (
   ops: (OperationalPoint[] | null)[],


### PR DESCRIPTION
Closes https://github.com/osrd-project/osrd-confidential/issues/1146 (1st part)
The new appearance of invalid trains is written in this PR https://github.com/OpenRailAssociation/osrd/pull/12611. 

Reviewers are advised to review this PR commit-by-commit and disable whitespace changes in the diff view.

## Tests

Examples:
[invalid_trains_output_table_timetable.json](https://github.com/user-attachments/files/21544416/invalid_trains_output_table_timetable.json)

### Valid trains
Check that the output table is still well displayed with every expected rows for valid trains schedules and paced trains.
Especially for paced trains, check that the cadencing is updated for each occurrence.

### Invalid trains
Check the output table of:
- Invalid train schedules
  - Without explicit track
  - With explicit track selected for an operational point
  - With waypoints selected directly on the map, that are not operational point
  - With a created NGE node that do not exist on the infrastructure 
- Invalid occurrences: same as above but for every occurrence 

