### PR TITLE
editoast: use schemas instead of models

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/api/project_signals/SignalProjectionEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/project_signals/SignalProjectionEndpoint.kt
@@ -33,8 +33,8 @@ class SignalProjectionEndpoint(private val infraManager: InfraProvider) : Take {
             val blockPath = infra.blockInfra.convertBlockPath(request.blocks)
             val routePath = infra.rawInfra.convertRoutePath(request.routes)
 
-            val signalProjections = mutableMapOf<Long, List<SignalUpdate>>()
-            for ((id, trainSimulation) in request.trainSimulations) {
+            val signalProjections = mutableListOf<List<SignalUpdate>>()
+            for (trainSimulation in request.trainSimulations) {
                 val signalProjection =
                     projectSignals(
                         infra,
@@ -45,13 +45,13 @@ class SignalProjectionEndpoint(private val infraManager: InfraProvider) : Take {
                         trainSimulation.zoneUpdates,
                         trainSimulation.simulationEndTime
                     )
-                signalProjections[id] = signalProjection
+                signalProjections.add(signalProjection)
             }
 
             RsJson(
                 RsWithBody(
                     signalProjectionResponseAdapter.toJson(
-                        SignalProjectionResponse(signalProjections.toMap())
+                        SignalProjectionResponse(signalProjections)
                     )
                 )
             )

--- a/core/src/main/kotlin/fr/sncf/osrd/api/project_signals/SignalProjectionRequest.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/project_signals/SignalProjectionRequest.kt
@@ -14,7 +14,7 @@ class SignalProjectionRequest(
     val blocks: List<String>,
     @Json(name = "track_section_ranges") var trackSectionRanges: List<DirectionalTrackRange>,
     var routes: List<String>,
-    @Json(name = "train_simulations") var trainSimulations: Map<Long, TrainSimulation>,
+    @Json(name = "train_simulations") var trainSimulations: List<TrainSimulation>,
     var infra: String,
     /** The expected infrastructure version */
     @Json(name = "expected_version") var expectedVersion: Int,

--- a/core/src/main/kotlin/fr/sncf/osrd/api/project_signals/SignalProjectionResponse.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/project_signals/SignalProjectionResponse.kt
@@ -10,7 +10,7 @@ import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.TimeDelta
 
 class SignalProjectionResponse(
-    @Json(name = "signal_updates") val signalUpdates: Map<Long, Collection<SignalUpdate>>
+    @Json(name = "signal_updates") val signalUpdates: List<List<SignalUpdate>>
 )
 
 class SignalUpdate(

--- a/editoast/core_client/src/signal_projection.rs
+++ b/editoast/core_client/src/signal_projection.rs
@@ -1,7 +1,6 @@
 use editoast_schemas::primitives::Identifier;
 use serde::Deserialize;
 use serde::Serialize;
-use std::collections::HashMap;
 use utoipa::ToSchema;
 
 use crate::AsCoreRequest;
@@ -28,7 +27,7 @@ pub struct SignalUpdatesRequest<'a> {
     /// Path description as block ids
     pub blocks: &'a [Identifier],
     /// List of signal critical positions and zone updates for each train
-    pub train_simulations: HashMap<usize, TrainSimulation<'a>>,
+    pub train_simulations: Vec<TrainSimulation<'a>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
@@ -63,7 +62,7 @@ pub struct TrainSimulation<'a> {
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct SignalUpdatesResponse {
-    pub signal_updates: HashMap<usize, Vec<SignalUpdate>>,
+    pub signal_updates: Vec<Vec<SignalUpdate>>,
 }
 
 impl AsCoreRequest<Json<SignalUpdatesResponse>> for SignalUpdatesRequest<'_> {

--- a/editoast/editoast_schemas/src/train_schedule.rs
+++ b/editoast/editoast_schemas/src/train_schedule.rs
@@ -96,6 +96,66 @@ pub struct TrainSchedule {
     pub category: Option<TrainMainCategory>,
 }
 
+pub trait TrainScheduleLike: Clone + Send + Sync + 'static {
+    fn rolling_stock_name(&self) -> &str;
+    fn start_time(&self) -> DateTime<Utc>;
+    fn path(&self) -> &[PathItem];
+    fn schedule(&self) -> &[ScheduleItem];
+    fn margins(&self) -> &Margins;
+    fn initial_speed(&self) -> f64;
+    fn comfort(&self) -> Comfort;
+    fn constraint_distribution(&self) -> Distribution;
+    fn speed_limit_tag(&self) -> Option<&String>;
+    fn power_restrictions(&self) -> &[PowerRestrictionItem];
+    fn options(&self) -> &TrainScheduleOptions;
+}
+
+impl TrainScheduleLike for TrainSchedule {
+    fn rolling_stock_name(&self) -> &str {
+        &self.rolling_stock_name
+    }
+
+    fn start_time(&self) -> DateTime<Utc> {
+        self.start_time
+    }
+
+    fn path(&self) -> &[PathItem] {
+        &self.path
+    }
+
+    fn schedule(&self) -> &[ScheduleItem] {
+        &self.schedule
+    }
+
+    fn margins(&self) -> &Margins {
+        &self.margins
+    }
+
+    fn initial_speed(&self) -> f64 {
+        self.initial_speed
+    }
+
+    fn comfort(&self) -> Comfort {
+        self.comfort
+    }
+
+    fn constraint_distribution(&self) -> Distribution {
+        self.constraint_distribution
+    }
+
+    fn speed_limit_tag(&self) -> Option<&String> {
+        self.speed_limit_tag.as_ref().map(|s| &s.0)
+    }
+
+    fn power_restrictions(&self) -> &[PowerRestrictionItem] {
+        &self.power_restrictions
+    }
+
+    fn options(&self) -> &TrainScheduleOptions {
+        &self.options
+    }
+}
+
 impl<'de> Deserialize<'de> for TrainSchedule {
     fn deserialize<D>(deserializer: D) -> Result<TrainSchedule, D::Error>
     where

--- a/editoast/src/models/paced_train.rs
+++ b/editoast/src/models/paced_train.rs
@@ -14,12 +14,12 @@ use editoast_schemas::train_schedule::Margins;
 use editoast_schemas::train_schedule::PathItem;
 use editoast_schemas::train_schedule::PowerRestrictionItem;
 use editoast_schemas::train_schedule::ScheduleItem;
+use editoast_schemas::train_schedule::TrainSchedule;
 use editoast_schemas::train_schedule::TrainScheduleOptions;
 use itertools::Itertools;
 
 use super::Tags;
 use crate::models::prelude::*;
-use crate::models::train_schedule::TrainSchedule;
 use crate::views::timetable::TrainId;
 
 #[derive(Debug, Clone, Model)]
@@ -71,13 +71,13 @@ impl PacedTrain {
             train_schedule.rolling_stock_name = change_group.rolling_stock_name.clone();
         }
         if let Some(change_group) = &exception.rolling_stock_category {
-            train_schedule.main_category = change_group.value.clone().map(TrainMainCategory);
+            train_schedule.category = change_group.value.clone();
         }
         if let Some(change_group) = &exception.labels {
-            train_schedule.labels = change_group.value.iter().cloned().map(Some).collect();
+            train_schedule.labels = change_group.value.clone();
         }
         if let Some(change_group) = &exception.speed_limit_tag {
-            train_schedule.speed_limit_tag = change_group.value.clone().map(|value| value.0);
+            train_schedule.speed_limit_tag = change_group.value.clone();
         }
         if let Some(change_group) = &exception.start_time {
             train_schedule.start_time = change_group.value
@@ -108,11 +108,9 @@ impl PacedTrain {
 
     pub fn into_train_schedule(self) -> TrainSchedule {
         TrainSchedule {
-            id: self.id,
             train_name: self.train_name,
-            labels: self.labels.into(),
+            labels: self.labels.to_vec(),
             rolling_stock_name: self.rolling_stock_name,
-            timetable_id: self.timetable_id,
             path: self.path,
             start_time: self.start_time,
             schedule: self.schedule,
@@ -120,10 +118,10 @@ impl PacedTrain {
             initial_speed: self.initial_speed,
             comfort: self.comfort,
             constraint_distribution: self.constraint_distribution,
-            speed_limit_tag: self.speed_limit_tag,
+            speed_limit_tag: self.speed_limit_tag.map(|s| s.into()),
             power_restrictions: self.power_restrictions,
             options: self.options,
-            main_category: self.main_category,
+            category: self.main_category.map(|category| category.0),
         }
     }
 
@@ -270,6 +268,11 @@ impl From<PacedTrain> for paced_train::PacedTrain {
 mod tests {
     use std::str::FromStr;
 
+    use crate::models::PacedTrain;
+    use crate::models::Tags;
+    use crate::models::fixtures::create_created_exception_with_change_groups;
+    use crate::models::fixtures::create_modified_exception_with_change_groups;
+    use crate::views::timetable::TrainId;
     use chrono::DateTime;
     use chrono::Utc;
     use editoast_models::rolling_stock::TrainMainCategory;
@@ -281,13 +284,6 @@ mod tests {
     use editoast_schemas::train_schedule::TrainScheduleOptions;
     use pretty_assertions::assert_eq;
     use rstest::rstest;
-
-    use crate::models;
-    use crate::models::PacedTrain;
-    use crate::models::Tags;
-    use crate::models::fixtures::create_created_exception_with_change_groups;
-    use crate::models::fixtures::create_modified_exception_with_change_groups;
-    use crate::views::timetable::TrainId;
 
     pub fn create_paced_train(exceptions: Vec<PacedTrainException>) -> PacedTrain {
         PacedTrain {
@@ -342,12 +338,8 @@ mod tests {
             exception.initial_speed.unwrap().value
         );
         assert_eq!(
-            paced_train_exception.main_category,
-            exception
-                .rolling_stock_category
-                .unwrap()
-                .value
-                .map(TrainMainCategory)
+            paced_train_exception.category,
+            exception.rolling_stock_category.unwrap().value
         );
         assert_eq!(
             paced_train_exception.constraint_distribution,
@@ -355,13 +347,7 @@ mod tests {
         );
         assert_eq!(
             paced_train_exception.labels,
-            exception
-                .labels
-                .unwrap()
-                .value
-                .into_iter()
-                .map(Some)
-                .collect::<Vec<Option<String>>>()
+            exception.labels.unwrap().value
         );
         assert_eq!(
             paced_train_exception.margins,
@@ -385,11 +371,7 @@ mod tests {
         );
         assert_eq!(
             paced_train_exception.speed_limit_tag,
-            exception
-                .speed_limit_tag
-                .unwrap()
-                .value
-                .map(|v| v.to_string())
+            exception.speed_limit_tag.unwrap().value
         );
         assert_eq!(
             paced_train_exception.options,
@@ -421,7 +403,7 @@ mod tests {
 
         let paced_train =
             create_paced_train(vec![exception_1.clone(), exception_2.clone(), exception_3]);
-        let occurrences: Vec<(TrainId, models::TrainSchedule)> =
+        let occurrences: Vec<(TrainId, editoast_schemas::TrainSchedule)> =
             paced_train.iter_occurrences().collect();
 
         assert_eq!(occurrences.len(), 5);
@@ -492,7 +474,7 @@ mod tests {
         });
 
         let paced_train = create_paced_train(vec![exception_1.clone()]);
-        let occurrences: Vec<(TrainId, models::TrainSchedule)> =
+        let occurrences: Vec<(TrainId, editoast_schemas::TrainSchedule)> =
             paced_train.iter_occurrences().collect();
 
         assert_eq!(occurrences.len(), 4);

--- a/editoast/src/models/train_schedule.rs
+++ b/editoast/src/models/train_schedule.rs
@@ -11,6 +11,7 @@ use editoast_schemas::train_schedule::Margins;
 use editoast_schemas::train_schedule::PathItem;
 use editoast_schemas::train_schedule::PowerRestrictionItem;
 use editoast_schemas::train_schedule::ScheduleItem;
+use editoast_schemas::train_schedule::TrainScheduleLike;
 use editoast_schemas::train_schedule::TrainScheduleOptions;
 
 use crate::models::prelude::*;
@@ -80,6 +81,52 @@ impl From<editoast_schemas::TrainSchedule> for TrainScheduleChangeset {
             .train_name(train_name)
             .options(options)
             .main_category(category.map(TrainMainCategory))
+    }
+}
+
+impl TrainScheduleLike for TrainSchedule {
+    fn rolling_stock_name(&self) -> &str {
+        &self.rolling_stock_name
+    }
+
+    fn start_time(&self) -> DateTime<Utc> {
+        self.start_time
+    }
+
+    fn path(&self) -> &[PathItem] {
+        &self.path
+    }
+
+    fn schedule(&self) -> &[ScheduleItem] {
+        &self.schedule
+    }
+
+    fn margins(&self) -> &Margins {
+        &self.margins
+    }
+
+    fn initial_speed(&self) -> f64 {
+        self.initial_speed
+    }
+
+    fn comfort(&self) -> Comfort {
+        self.comfort
+    }
+
+    fn constraint_distribution(&self) -> Distribution {
+        self.constraint_distribution
+    }
+
+    fn speed_limit_tag(&self) -> Option<&String> {
+        self.speed_limit_tag.as_ref()
+    }
+
+    fn power_restrictions(&self) -> &[PowerRestrictionItem] {
+        &self.power_restrictions
+    }
+
+    fn options(&self) -> &TrainScheduleOptions {
+        &self.options
     }
 }
 

--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -21,6 +21,7 @@ use editoast_common::units;
 use editoast_models::DbConnection;
 use editoast_schemas::rolling_stock::LoadingGaugeType;
 use editoast_schemas::train_schedule::PathItemLocation;
+use editoast_schemas::train_schedule::TrainScheduleLike;
 use educe::Educe;
 use itertools::Itertools;
 use ordered_float::OrderedFloat;
@@ -36,7 +37,6 @@ use crate::error::Result;
 use crate::models::Infra;
 use crate::models::Retrieve;
 use crate::models::RollingStock;
-use crate::models::train_schedule::TrainSchedule;
 use crate::valkey_utils::ValkeyConnection;
 use crate::views::AuthenticationExt;
 use crate::views::AuthorizationError;
@@ -396,16 +396,16 @@ fn build_pathfinding_request(
 }
 
 /// Compute a path given a train schedule and an infrastructure.
-pub async fn pathfinding_from_train(
+pub async fn pathfinding_from_train<T: TrainScheduleLike>(
     conn: &mut DbConnection,
     valkey: &mut ValkeyConnection,
     core: Arc<CoreClient>,
     infra: &Infra,
-    train_schedule: TrainSchedule,
+    train_schedule: T,
 ) -> Result<PathfindingResult> {
     #[expect(deprecated)]
     let rolling_stock: Vec<_> =
-        RollingStock::retrieve(conn, train_schedule.rolling_stock_name.clone())
+        RollingStock::retrieve(conn, train_schedule.rolling_stock_name().to_string())
             .await?
             .into_iter()
             .map_into()
@@ -420,12 +420,12 @@ pub async fn pathfinding_from_train(
 }
 
 /// Compute a path given a batch of trainschedule and an infrastructure.
-pub async fn pathfinding_from_train_batch(
+pub async fn pathfinding_from_train_batch<T: TrainScheduleLike>(
     conn: &mut DbConnection,
     valkey: &mut ValkeyConnection,
     core: Arc<CoreClient>,
     infra: &Infra,
-    train_schedules: &[TrainSchedule],
+    train_schedules: &[T],
     rolling_stocks: &[editoast_schemas::RollingStock],
 ) -> Result<Vec<Arc<PathfindingResult>>> {
     let initial_value = Arc::new(PathfindingResult::Failure(
@@ -433,15 +433,18 @@ pub async fn pathfinding_from_train_batch(
     ));
     let mut results = vec![initial_value; train_schedules.len()];
 
-    let rolling_stocks: HashMap<_, _> = rolling_stocks.iter().map(|rs| (&rs.name, rs)).collect();
+    let rolling_stocks: HashMap<_, _> = rolling_stocks
+        .iter()
+        .map(|rs| (rs.name.as_str(), rs))
+        .collect();
 
     let mut to_compute = vec![];
     let mut to_compute_index = vec![];
     for (index, train_schedule) in train_schedules.iter().enumerate() {
         // Retrieve rolling stock
-        let rolling_stock_name = &train_schedule.rolling_stock_name;
+        let rolling_stock_name = train_schedule.rolling_stock_name();
         let Some(rolling_stock) = rolling_stocks.get(rolling_stock_name) else {
-            let rolling_stock_name = rolling_stock_name.clone();
+            let rolling_stock_name = rolling_stock_name.into();
             results[index] = Arc::new(PathfindingResult::Failure(
                 PathfindingFailure::PathfindingInputError(
                     PathfindingInputError::RollingStockNotFound { rolling_stock_name },
@@ -466,10 +469,9 @@ pub async fn pathfinding_from_train_batch(
             )),
             rolling_stock_length: OrderedFloat(units::meter::from(rolling_stock.length)),
             path_items: train_schedule
-                .path
-                .clone()
-                .into_iter()
-                .map(|item| item.location)
+                .path()
+                .iter()
+                .map(|item| item.location.clone())
                 .collect(),
         };
         to_compute.push(path_input);

--- a/editoast/src/views/projection.rs
+++ b/editoast/src/views/projection.rs
@@ -10,6 +10,7 @@ use editoast_models::DbConnection;
 use editoast_schemas::primitives::Identifier;
 use editoast_schemas::train_schedule::OperationalPointIdentifier;
 use editoast_schemas::train_schedule::PathItemLocation;
+use editoast_schemas::train_schedule::TrainScheduleLike;
 use itertools::Itertools;
 use serde::Deserialize;
 use serde::Serialize;
@@ -24,7 +25,6 @@ use utoipa::ToSchema;
 use super::path::path_item_cache::PathItemCache;
 use crate::ValkeyClient;
 use crate::client::get_app_version;
-use crate::models;
 use crate::models::infra::Infra;
 use crate::views::path::pathfinding::PathfindingResult;
 use crate::views::path::projection::PathProjection;
@@ -345,13 +345,13 @@ pub fn linear_interpolate(a_x: u64, b_x: u64, a_y: u64, b_y: u64, x: u64) -> u64
     }
 }
 
-pub async fn compute_projected_train_paths(
+pub async fn compute_projected_train_paths<T: TrainScheduleLike>(
     conn: &mut DbConnection,
     core_client: Arc<CoreClient>,
     valkey_client: Arc<ValkeyClient>,
     track_section_ranges: Vec<TrackRange>,
     infra: &Infra,
-    train_schedules: &[models::TrainSchedule],
+    train_schedules: &[T],
     electrical_profile_set_id: Option<i64>,
 ) -> Result<Vec<Arc<SpaceTimeCurves>>> {
     let path_projection = PathProjection::new(&track_section_ranges);
@@ -465,9 +465,9 @@ pub struct TrainToProjectOnOperationalPoint {
 }
 
 impl TrainToProjectOnOperationalPoint {
-    pub fn new(ts: models::TrainSchedule, sim: simulation::Response) -> Self {
+    pub fn new<T: TrainScheduleLike>(ts: T, sim: simulation::Response) -> Self {
         let stops_input: HashMap<_, _> = ts
-            .schedule
+            .schedule()
             .iter()
             .filter_map(|schedule| {
                 schedule
@@ -476,11 +476,12 @@ impl TrainToProjectOnOperationalPoint {
                     .map(|stop_for| (&schedule.at, stop_for.num_milliseconds() as u64))
             })
             .collect();
+
         let simulation::Response::Success(SimulationResponseSuccess { final_output, .. }) = sim
         else {
             // Handle non-simulated trains
             let arrival_inputs = ts
-                .schedule
+                .schedule()
                 .iter()
                 .filter_map(|schedule| {
                     schedule
@@ -490,7 +491,7 @@ impl TrainToProjectOnOperationalPoint {
                 })
                 .collect::<HashMap<_, _>>();
 
-            let mut refs = ts.path.iter().map(|path_item| match &path_item.location {
+            let mut refs = ts.path().iter().map(|path_item| match &path_item.location {
                 PathItemLocation::OperationalPointReference(op_ref) => {
                     Some((&op_ref.reference, &path_item.id))
                 }
@@ -531,15 +532,15 @@ impl TrainToProjectOnOperationalPoint {
             times: report_train.times,
         });
         let refs = ts
-            .path
-            .into_iter()
+            .path()
+            .iter()
             .zip(report_train.path_item_times)
-            .flat_map(|(path_item, arrival_time)| match path_item.location {
+            .flat_map(|(path_item, arrival_time)| match &path_item.location {
                 PathItemLocation::OperationalPointReference(op_ref) => {
                     Some(OperationalPointRefAndTime {
                         arrival_time,
                         stop_for: stops_input.get(&path_item.id).copied().unwrap_or_default(),
-                        op_ref: op_ref.reference,
+                        op_ref: op_ref.reference.clone(),
                     })
                 }
                 PathItemLocation::TrackOffset(_) => None,

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -5,7 +5,6 @@ pub mod simulation;
 pub mod stdcm;
 pub mod train_schedule;
 
-use std::collections::HashMap;
 use std::fmt::Display;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -20,12 +19,12 @@ use axum::response::IntoResponse;
 use chrono::DateTime;
 use chrono::Utc;
 use core_client::AsCoreRequest;
-use core_client::CoreClient;
 use core_client::conflict_detection::Conflict as CoreConflict;
 use core_client::conflict_detection::ConflictDetectionRequest;
 use core_client::conflict_detection::ConflictRequirement;
 use core_client::conflict_detection::ConflictType;
 use core_client::conflict_detection::TrainRequirements;
+use core_client::simulation::CompleteReportTrain;
 use core_client::simulation::PhysicsConsist;
 use editoast_authz as authz;
 use editoast_common::units::quantities::Acceleration;
@@ -44,6 +43,7 @@ use editoast_schemas::train_schedule::TrainSchedule;
 use editoast_schemas::train_schedule::TrainScheduleLike;
 use itertools::Either;
 use itertools::Itertools;
+use itertools::izip;
 use paced_train::PacedTrainResponse;
 use serde::Deserialize;
 use serde::Serialize;
@@ -60,7 +60,6 @@ use super::pagination::PaginationQueryParams;
 use super::pagination::PaginationStats;
 use super::path::pathfinding::PathfindingResult;
 use crate::AppState;
-use crate::ValkeyClient;
 use crate::error::Result;
 use crate::models;
 use crate::models::Infra;
@@ -629,29 +628,53 @@ async fn conflicts(
 
     let (trains, paced_trains) = retrieve_trains_and_paced_trains(conn, timetable_id).await?;
 
-    let (train_simulations_and_pathfindings, paced_train_simulations_and_pathfindings) =
-        retrieve_simulations(
-            &mut db_pool.get().await?,
-            valkey_client,
-            core_client.clone(),
-            &trains,
-            &paced_trains,
-            &infra,
-            electrical_profile_set_id,
-        )
-        .await?;
-
-    let (train_simulations, _): (Vec<_>, Vec<_>) =
-        train_simulations_and_pathfindings.into_iter().unzip();
-    let (paced_train_simulations, _): (Vec<_>, Vec<_>) =
-        paced_train_simulations_and_pathfindings.into_iter().unzip();
-    let conflict_detection_request = build_conflict_core_request(
-        infra,
+    // Flatten paced trains occurrences
+    let (occurance_ids, occurance_trains): (Vec<_>, Vec<_>) = paced_trains
+        .iter()
+        .flat_map(|pt| pt.iter_occurrences())
+        .unzip();
+    let occurance_simulations: Vec<_> = train_simulation_batch(
+        &mut db_pool.get().await?,
+        valkey_client.clone(),
+        core_client.clone(),
+        &occurance_trains,
+        &infra,
+        electrical_profile_set_id,
+    )
+    .await?
+    .into_iter()
+    .map(|(sim, _)| sim)
+    .collect();
+    let simulations: Vec<_> = train_simulation_batch(
+        &mut db_pool.get().await?,
+        valkey_client.clone(),
+        core_client.clone(),
         &trains,
-        &train_simulations,
-        &paced_trains,
-        &paced_train_simulations,
-    );
+        &infra,
+        electrical_profile_set_id,
+    )
+    .await?
+    .into_iter()
+    .map(|(sim, _)| sim)
+    .collect();
+
+    // Concatenate paced trains occurrences with train schedules
+    let train_ids: Vec<_> = occurance_ids
+        .into_iter()
+        .chain(trains.iter().map(|ts| TrainId::TrainSchedule(ts.id)))
+        .collect();
+    let start_times = occurance_trains
+        .iter()
+        .map(|ts| ts.start_time())
+        .chain(trains.iter().map(|ts| ts.start_time()))
+        .collect::<Vec<_>>();
+    let simulations: Vec<_> = occurance_simulations
+        .into_iter()
+        .chain(simulations)
+        .collect();
+
+    let conflict_detection_request =
+        build_conflict_core_request(infra, start_times, train_ids, simulations);
 
     // 3. Call core
     let conflict_detection_response = conflict_detection_request.fetch(&core_client).await?;
@@ -684,110 +707,41 @@ async fn retrieve_trains_and_paced_trains(
     Ok((trains, paced_trains))
 }
 
-async fn retrieve_simulations<T: TrainScheduleLike>(
-    conn: &mut DbConnection,
-    valkey_client: Arc<ValkeyClient>,
-    core_client: Arc<CoreClient>,
-    trains: &[T],
-    paced_trains: &[models::PacedTrain],
-    infra: &Infra,
-    electrical_profile_set_id: Option<i64>,
-) -> Result<(
-    Vec<(Arc<simulation::Response>, Arc<PathfindingResult>)>,
-    Vec<(Arc<simulation::Response>, Arc<PathfindingResult>)>,
-)> {
-    let paced_train_to_ts = paced_trains
-        .iter()
-        .flat_map(|pt| pt.iter_occurrences())
-        .map(|(_, pt)| pt)
-        .collect::<Vec<_>>();
-    let mut conn_clone = conn.clone();
-    let (train_simulations, paced_train_simulations) = tokio::try_join!(
-        train_simulation_batch(
-            conn,
-            valkey_client.clone(),
-            core_client.clone(),
-            trains,
-            infra,
-            electrical_profile_set_id,
-        ),
-        train_simulation_batch(
-            &mut conn_clone,
-            valkey_client.clone(),
-            core_client.clone(),
-            &paced_train_to_ts,
-            infra,
-            electrical_profile_set_id,
-        )
-    )?;
-
-    Ok((train_simulations, paced_train_simulations))
-}
-
+/// Build the core conflict detection request
+///
+/// **Panic** if the number of start_times, train_ids, and simulations do not match.
 fn build_conflict_core_request(
     infra: Infra,
-    trains: &[models::TrainSchedule],
-    train_simulations: &[impl AsRef<simulation::Response>],
-    paced_trains: &[models::PacedTrain],
-    paced_train_simulations: &[impl AsRef<simulation::Response>],
+    start_times: Vec<DateTime<Utc>>,
+    train_ids: Vec<TrainId>,
+    simulations: Vec<Arc<simulation::Response>>,
 ) -> ConflictDetectionRequest {
-    let mut trains_requirements = HashMap::new();
+    assert_eq!(start_times.len(), simulations.len());
+    assert_eq!(train_ids.len(), simulations.len());
 
-    // Build train schedule train requirements
-    for (train, sim) in trains.iter().zip(train_simulations) {
-        let final_output = match sim.as_ref() {
-            simulation::Response::Success(SimulationResponseSuccess { final_output, .. }) => {
-                final_output
-            }
-            _ => continue,
-        };
-        let key = TrainId::TrainSchedule(train.id).to_string();
-        trains_requirements.insert(
-            key,
-            TrainRequirements {
-                start_time: train.start_time,
-                spacing_requirements: final_output.spacing_requirements.clone(),
-                routing_requirements: final_output.routing_requirements.clone(),
-            },
-        );
-    }
-
-    // Build paced train requirements
-    let mut it = paced_train_simulations.iter();
-    for paced_train in paced_trains {
-        let occurrences = paced_train.iter_occurrences().collect_vec();
-        let occurrences_count = occurrences.len();
-        let simulations: Vec<_> = it.by_ref().take(occurrences_count).collect();
-
-        if simulations.len() < occurrences_count {
-            panic!(
-                "At least one simulation is missing for paced train {}",
-                paced_train.id
-            );
-        }
-
-        for (index, sim) in simulations.into_iter().enumerate() {
-            let final_output = match sim.as_ref() {
+    let trains_requirements = izip!(start_times, train_ids, simulations)
+        .flat_map(|(start_time, train_id, sim)| {
+            let CompleteReportTrain {
+                spacing_requirements,
+                routing_requirements,
+                ..
+            } = match Arc::unwrap_or_clone(sim) {
                 simulation::Response::Success(SimulationResponseSuccess {
                     final_output, ..
-                }) => final_output,
-                _ => continue,
-            };
-
-            let (train_id, occurrence) = &occurrences[index];
-
-            trains_requirements.insert(
+                }) => Some(final_output),
+                _ => None,
+            }?;
+            Some((
                 train_id.to_string(),
                 TrainRequirements {
-                    start_time: occurrence.start_time,
-                    spacing_requirements: final_output.spacing_requirements.clone(),
-                    routing_requirements: final_output.routing_requirements.clone(),
+                    start_time,
+                    spacing_requirements,
+                    routing_requirements,
                 },
-            );
-        }
-    }
+            ))
+        })
+        .collect();
 
-    // Build core conflict request
     ConflictDetectionRequest {
         infra: infra.id,
         expected_version: infra.version,
@@ -982,6 +936,8 @@ impl From<PhysicsConsistParameters> for PhysicsConsist {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use axum::http::StatusCode;
     use chrono::Duration;
     use chrono::NaiveDate;
@@ -1003,8 +959,6 @@ mod tests {
     use editoast_schemas::rolling_stock::RollingResistance;
     use editoast_schemas::train_schedule::MarginValue;
     use editoast_schemas::train_schedule::Margins;
-    use models::PacedTrain;
-    use models::TrainSchedule;
     use pretty_assertions::assert_eq;
     use rstest::rstest;
 
@@ -1258,19 +1212,13 @@ mod tests {
     fn build_coherent_conflict_core_request() {
         // Given
         let infra = Infra::default();
-        let simple_id = 13;
-        let simple_start_time = NaiveDate::from_ymd_opt(2025, 1, 1)
+        let ts_id = 13;
+        let ts_start_time = NaiveDate::from_ymd_opt(2025, 1, 1)
             .unwrap()
             .and_hms_opt(8, 0, 0)
             .unwrap()
             .and_utc();
-        let train_schedule = TrainSchedule {
-            id: simple_id,
-            train_name: "simple".to_string(),
-            start_time: simple_start_time,
-            ..Default::default()
-        };
-        let trains = vec![train_schedule.clone()];
+
         let spacing_requirement = SpacingRequirement {
             zone: "ZONE_1".to_string(),
             begin_time: 0,
@@ -1291,7 +1239,47 @@ mod tests {
                 end_time: 15,
             }],
         };
-        let train_simulations = [Arc::new(simulation::Response::Success(
+        let paced_train_id = 42;
+        let paced_start_time = NaiveDate::from_ymd_opt(2025, 1, 1)
+            .unwrap()
+            .and_hms_opt(9, 0, 0)
+            .unwrap()
+            .and_utc();
+        let paced_interval = chrono::Duration::try_hours(1).unwrap();
+
+        // Start times
+        let start_times = vec![
+            paced_start_time,
+            paced_start_time + paced_interval,
+            ts_start_time,
+        ];
+        // Train IDs
+        let train_ids = vec![
+            TrainId::PacedTrainBaseOccurrence {
+                paced_train_id,
+                index: 0,
+            },
+            TrainId::PacedTrainBaseOccurrence {
+                paced_train_id,
+                index: 1,
+            },
+            TrainId::TrainSchedule(ts_id),
+        ];
+
+        // Simulations
+        let paced_train_sim = Arc::new(simulation::Response::Success(SimulationResponseSuccess {
+            base: ReportTrain::default(),
+            provisional: ReportTrain::default(),
+            final_output: CompleteReportTrain {
+                spacing_requirements: vec![spacing_requirement.clone()],
+                routing_requirements: vec![routing_requirement.clone()],
+                ..Default::default()
+            },
+            mrsp: SpeedLimitProperties::default(),
+            electrical_profiles: ElectricalProfiles::default(),
+        }));
+        let mut simulations = vec![paced_train_sim; 2];
+        simulations.push(Arc::new(simulation::Response::Success(
             SimulationResponseSuccess {
                 base: ReportTrain::default(),
                 provisional: ReportTrain::default(),
@@ -1303,56 +1291,19 @@ mod tests {
                 mrsp: SpeedLimitProperties::default(),
                 electrical_profiles: ElectricalProfiles::default(),
             },
-        ))];
-        let paced_id = 42;
-        let paced_start_time = NaiveDate::from_ymd_opt(2025, 1, 1)
-            .unwrap()
-            .and_hms_opt(9, 0, 0)
-            .unwrap()
-            .and_utc();
-        let paced_interval = chrono::Duration::try_hours(1).unwrap();
-        let paced_train = PacedTrain {
-            id: paced_id,
-            train_name: "paced".to_string(),
-            start_time: paced_start_time,
-            time_window: chrono::Duration::try_hours(2).unwrap(),
-            interval: paced_interval,
-            exceptions: vec![],
-            ..Default::default()
-        };
-        let paced_trains = vec![paced_train.clone()];
-        let paced_train_simulations = std::iter::repeat_n(
-            Arc::new(simulation::Response::Success(SimulationResponseSuccess {
-                base: ReportTrain::default(),
-                provisional: ReportTrain::default(),
-                final_output: CompleteReportTrain {
-                    spacing_requirements: vec![spacing_requirement.clone()],
-                    routing_requirements: vec![routing_requirement.clone()],
-                    ..Default::default()
-                },
-                mrsp: SpeedLimitProperties::default(),
-                electrical_profiles: ElectricalProfiles::default(),
-            })),
-            2,
-        )
-        .collect_vec();
+        )));
 
         // When
-        let conflict_core_request = build_conflict_core_request(
-            infra,
-            &trains,
-            &train_simulations,
-            &paced_trains,
-            &paced_train_simulations,
-        );
+        let conflict_core_request =
+            build_conflict_core_request(infra, start_times, train_ids, simulations);
 
         // Then (assert the train schedule)
         assert_eq!(conflict_core_request.trains_requirements.len(), 3);
         let simple_requirements = conflict_core_request
             .trains_requirements
-            .get(&format!("{simple_id}"))
+            .get(&format!("{ts_id}"))
             .unwrap();
-        assert_eq!(simple_requirements.start_time, simple_start_time);
+        assert_eq!(simple_requirements.start_time, ts_start_time);
         assert_eq!(
             simple_requirements.spacing_requirements,
             vec![spacing_requirement.clone()]
@@ -1365,7 +1316,7 @@ mod tests {
         // Then (assert the paced train, first occurrence)
         let paced_0_requirements = conflict_core_request
             .trains_requirements
-            .get(&format!("{paced_id}#0"))
+            .get(&format!("{paced_train_id}#0"))
             .unwrap();
         assert_eq!(paced_0_requirements.start_time, paced_start_time);
         assert_eq!(
@@ -1380,7 +1331,7 @@ mod tests {
         // Then (assert the paced train, second occurrence)
         let paced_1_requirements = conflict_core_request
             .trains_requirements
-            .get(&format!("{paced_id}#1"))
+            .get(&format!("{paced_train_id}#1"))
             .unwrap();
         assert_eq!(
             paced_1_requirements.start_time,

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -41,6 +41,7 @@ use editoast_schemas::rolling_stock::RollingResistance;
 use editoast_schemas::rolling_stock::RollingStock;
 use editoast_schemas::rolling_stock::TowedRollingStock;
 use editoast_schemas::train_schedule::TrainSchedule;
+use editoast_schemas::train_schedule::TrainScheduleLike;
 use itertools::Either;
 use itertools::Itertools;
 use paced_train::PacedTrainResponse;
@@ -683,11 +684,11 @@ async fn retrieve_trains_and_paced_trains(
     Ok((trains, paced_trains))
 }
 
-async fn retrieve_simulations(
+async fn retrieve_simulations<T: TrainScheduleLike>(
     conn: &mut DbConnection,
     valkey_client: Arc<ValkeyClient>,
     core_client: Arc<CoreClient>,
-    trains: &[models::TrainSchedule],
+    trains: &[T],
     paced_trains: &[models::PacedTrain],
     infra: &Infra,
     electrical_profile_set_id: Option<i64>,

--- a/editoast/src/views/timetable/occupancy_blocks.rs
+++ b/editoast/src/views/timetable/occupancy_blocks.rs
@@ -7,6 +7,7 @@ use core_client::signal_projection::SignalUpdatesRequest;
 use core_client::signal_projection::TrainSimulation;
 use editoast_models::DbConnection;
 use editoast_schemas::primitives::Identifier;
+use editoast_schemas::train_schedule::TrainScheduleLike;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -15,7 +16,6 @@ use utoipa::ToSchema;
 
 use crate::ValkeyClient;
 use crate::error::Result;
-use crate::models;
 use crate::models::infra::Infra;
 use crate::views::projection::ProjectPathInput;
 use crate::views::projection::extract_train_details;
@@ -73,25 +73,18 @@ pub(super) async fn compute_batch_signal_updates<'a>(
 
     let response = request.fetch(&core).await?;
 
-    let mut results = vec![vec![]; trains_details.len()];
-    response
-        .signal_updates
-        .into_iter()
-        .for_each(|(index, signal_updates)| results[index] = signal_updates);
-
-    Ok(results)
+    Ok(response.signal_updates)
 }
 
-pub(super) async fn compute_occupancy_blocks(
+pub(super) async fn compute_occupancy_blocks<T: TrainScheduleLike>(
     conn: &mut DbConnection,
     core_client: Arc<CoreClient>,
     valkey_client: Arc<ValkeyClient>,
     path: ProjectPathInput,
     infra: &Infra,
-    trains_schedules: &[models::TrainSchedule],
+    trains_schedules: &[T],
     electrical_profile_set_id: Option<i64>,
-) -> Result<Vec<Arc<OccupancyBlocks>>> // TODO: Use schemas::TrainSchedule instead
-{
+) -> Result<Vec<Arc<OccupancyBlocks>>> {
     let mut valkey_conn = valkey_client.get_connection().await?;
 
     // 1. Get train simulations

--- a/editoast/src/views/timetable/occupancy_blocks.rs
+++ b/editoast/src/views/timetable/occupancy_blocks.rs
@@ -57,16 +57,10 @@ pub(super) async fn compute_batch_signal_updates<'a>(
         blocks: path_blocks,
         train_simulations: trains_details
             .iter()
-            .enumerate()
-            .map(|(index, train_details)| {
-                (
-                    index,
-                    TrainSimulation {
-                        signal_critical_positions: &train_details.signal_critical_positions,
-                        zone_updates: &train_details.zone_updates,
-                        simulation_end_time: train_details.times[train_details.times.len() - 1],
-                    },
-                )
+            .map(|train_details| TrainSimulation {
+                signal_critical_positions: &train_details.signal_critical_positions,
+                zone_updates: &train_details.zone_updates,
+                simulation_end_time: train_details.times[train_details.times.len() - 1],
             })
             .collect(),
     };

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -25,7 +25,6 @@ use crate::models;
 use crate::models::Infra;
 use crate::models::paced_train::PacedTrainChangeset;
 use crate::models::prelude::*;
-use crate::models::train_schedule::TrainSchedule;
 use crate::views::AuthorizationError;
 use crate::views::infra::InfraIdQueryParam;
 use crate::views::path::pathfinding::PathfindingResult;
@@ -247,7 +246,7 @@ struct PacedTrainSummaryResponse {
 struct SimulationContext {
     paced_train_id: i64,
     exception_key: Option<String>,
-    train_schedule: TrainSchedule,
+    train_schedule: editoast_schemas::TrainSchedule,
 }
 
 /// Associate each paced train id with its simulation summaries response
@@ -325,7 +324,7 @@ async fn simulation_summary(
             })
             .collect();
 
-    let schedules: Vec<TrainSchedule> = simulation_contexts
+    let schedules: Vec<editoast_schemas::TrainSchedule> = simulation_contexts
         .iter()
         .map(|ctx| ctx.train_schedule.clone())
         .collect();

--- a/editoast/src/views/timetable/simulation.rs
+++ b/editoast/src/views/timetable/simulation.rs
@@ -12,6 +12,11 @@ use core_client::simulation::SimulationPowerRestrictionItem;
 use core_client::simulation::SimulationScheduleItem;
 use core_client::simulation::SpeedLimitProperties;
 use editoast_models::DbConnection;
+use editoast_schemas::train_schedule::Margins;
+use editoast_schemas::train_schedule::PathItem;
+use editoast_schemas::train_schedule::PowerRestrictionItem;
+use editoast_schemas::train_schedule::ScheduleItem;
+use editoast_schemas::train_schedule::TrainScheduleLike;
 use itertools::Itertools;
 use serde::Deserialize;
 use serde::Serialize;
@@ -30,7 +35,6 @@ use crate::ValkeyClient;
 use crate::client::get_app_version;
 use crate::error::InternalError;
 use crate::error::Result;
-use crate::models;
 use crate::models::RollingStock;
 use crate::views::CoreClient;
 use crate::views::path::pathfinding::PathfindingFailure;
@@ -199,11 +203,11 @@ impl From<simulation::Response> for SummaryResponse {
 /// Compute in batch the simulation of a list of train schedule
 ///
 /// Note: The order of the returned simulations is the same as the order of the train schedules.
-pub async fn train_simulation_batch(
+pub async fn train_simulation_batch<T: TrainScheduleLike>(
     conn: &mut DbConnection,
     valkey_client: Arc<ValkeyClient>,
     core: Arc<CoreClient>,
-    train_schedules: &[models::TrainSchedule],
+    train_schedules: &[T],
     infra: &Infra,
     electrical_profile_set_id: Option<i64>,
 ) -> Result<Vec<(Arc<simulation::Response>, Arc<PathfindingResult>)>> {
@@ -213,7 +217,7 @@ pub async fn train_simulation_batch(
 
     let rolling_stocks_ids = train_schedules
         .iter()
-        .map::<String, _>(|t| t.rolling_stock_name.clone());
+        .map::<String, _>(|t| t.rolling_stock_name().to_string());
 
     let rolling_stocks: Vec<_> =
         RollingStock::retrieve_batch_unchecked(&mut conn.clone(), rolling_stocks_ids)
@@ -232,7 +236,7 @@ pub async fn train_simulation_batch(
             let core = core.clone();
             let consists = consists.clone();
             let infra = <Infra as Clone>::clone(infra);
-            let chunk = chunk.to_vec();
+            let chunk = chunk.to_vec(); // TODO: avoid cloning the chunk
             tokio::spawn(
                 async move {
                     consist_train_simulation_batch(
@@ -259,12 +263,12 @@ pub async fn train_simulation_batch(
 }
 
 #[tracing::instrument(skip_all, fields(nb_trains = train_schedules.len()))]
-pub async fn consist_train_simulation_batch(
+pub async fn consist_train_simulation_batch<T: TrainScheduleLike>(
     conn: &mut DbConnection,
     valkey_client: Arc<ValkeyClient>,
     core: Arc<CoreClient>,
     infra: &Infra,
-    train_schedules: &[models::TrainSchedule],
+    train_schedules: &[T],
     consists: &[PhysicsConsistParameters],
     electrical_profile_set_id: Option<i64>,
 ) -> Result<Vec<(Arc<simulation::Response>, Arc<PathfindingResult>)>> {
@@ -285,7 +289,7 @@ pub async fn consist_train_simulation_batch(
 
     let consists: HashMap<_, _> = consists
         .iter()
-        .map(|consist| (&consist.traction_engine.name, consist))
+        .map(|consist| (consist.traction_engine.name.as_str(), consist))
         .collect();
 
     let mut simulation_results = vec![None::<Arc<simulation::Response>>; train_schedules.len()];
@@ -320,7 +324,7 @@ pub async fn consist_train_simulation_batch(
         };
 
         // Build simulation request
-        let physics_consist_parameters = consists[&train_schedule.rolling_stock_name].clone();
+        let physics_consist_parameters = consists[train_schedule.rolling_stock_name()].clone();
 
         let simulation_request = build_simulation_request(
             infra,
@@ -413,44 +417,47 @@ pub async fn consist_train_simulation_batch(
         .collect())
 }
 
-fn build_simulation_request(
+fn build_simulation_request<T: TrainScheduleLike>(
     infra: &Infra,
-    train_schedule: &models::TrainSchedule,
+    train_schedule: &T,
     path_item_positions: &[u64],
     path: SimulationPath,
     electrical_profile_set_id: Option<i64>,
     physics_consist: PhysicsConsist,
 ) -> core_client::simulation::Request {
-    let path_items_to_position = build_path_items_to_position(train_schedule, path_item_positions);
-    let schedule = build_sim_schedule_items(train_schedule, &path_items_to_position);
-    let margins = build_sim_margins(train_schedule, &path_items_to_position);
-    let power_restrictions =
-        build_sim_power_restriction_items(train_schedule, &path_items_to_position);
+    let path_items_to_position =
+        build_path_items_to_position(train_schedule.path(), path_item_positions);
+    let schedule = build_sim_schedule_items(train_schedule.schedule(), &path_items_to_position);
+    let margins = build_sim_margins(train_schedule.margins(), &path_items_to_position);
+    let power_restrictions = build_sim_power_restriction_items(
+        train_schedule.power_restrictions(),
+        &path_items_to_position,
+    );
     core_client::simulation::Request {
         infra: infra.id,
         expected_version: infra.version,
         path,
         schedule,
         margins,
-        initial_speed: train_schedule.initial_speed,
-        comfort: train_schedule.comfort,
-        constraint_distribution: train_schedule.constraint_distribution,
-        speed_limit_tag: train_schedule.speed_limit_tag.clone(),
+        initial_speed: train_schedule.initial_speed(),
+        comfort: train_schedule.comfort(),
+        constraint_distribution: train_schedule.constraint_distribution(),
+        speed_limit_tag: train_schedule.speed_limit_tag().cloned(),
         power_restrictions,
-        options: train_schedule.options.clone(),
+        options: train_schedule.options().clone(),
         physics_consist,
         electrical_profile_set_id,
     }
 }
 
 pub fn build_path_items_to_position<'t>(
-    train_schedule: &'t models::TrainSchedule,
+    path_items: &'t [PathItem],
     path_item_positions: &[u64],
 ) -> HashMap<&'t editoast_schemas::primitives::NonBlankString, u64> {
-    assert_eq!(path_item_positions.len(), train_schedule.path.len());
+    assert_eq!(path_item_positions.len(), path_items.len());
     // Project path items to path offset
-    train_schedule
-        .path
+
+    path_items
         .iter()
         .map(|p| &p.id)
         .zip(path_item_positions.iter().copied())
@@ -458,11 +465,10 @@ pub fn build_path_items_to_position<'t>(
 }
 
 pub fn build_sim_schedule_items(
-    train_schedule: &models::TrainSchedule,
+    schedule_items: &[ScheduleItem],
     path_items_to_position: &HashMap<&editoast_schemas::primitives::NonBlankString, u64>,
 ) -> Vec<SimulationScheduleItem> {
-    train_schedule
-        .schedule
+    schedule_items
         .iter()
         .map(|schedule_item| SimulationScheduleItem {
             path_offset: path_items_to_position[&schedule_item.at],
@@ -480,26 +486,24 @@ pub fn build_sim_schedule_items(
 }
 
 fn build_sim_margins(
-    train_schedule: &models::TrainSchedule,
+    margins: &Margins,
     path_items_to_position: &HashMap<&editoast_schemas::primitives::NonBlankString, u64>,
 ) -> SimulationMargins {
     SimulationMargins {
-        boundaries: train_schedule
-            .margins
+        boundaries: margins
             .boundaries
             .iter()
             .map(|at| path_items_to_position[at])
             .collect(),
-        values: train_schedule.margins.values.clone(),
+        values: margins.values.clone(),
     }
 }
 
 pub fn build_sim_power_restriction_items(
-    train_schedule: &models::TrainSchedule,
+    power_restrictions: &[PowerRestrictionItem],
     path_items_to_position: &HashMap<&editoast_schemas::primitives::NonBlankString, u64>,
 ) -> Vec<SimulationPowerRestrictionItem> {
-    train_schedule
-        .power_restrictions
+    power_restrictions
         .iter()
         .map(|item| SimulationPowerRestrictionItem {
             from: path_items_to_position[&item.from],

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -26,6 +26,7 @@ use editoast_schemas::primitives::PositiveDuration;
 use editoast_schemas::train_schedule::OperationalPointIdentifier;
 use editoast_schemas::train_schedule::PathItemLocation;
 use editoast_schemas::train_schedule::TrainSchedule;
+use editoast_schemas::train_schedule::TrainScheduleLike;
 use serde::Deserialize;
 use serde::Serialize;
 use thiserror::Error;
@@ -481,10 +482,12 @@ async fn etcs_braking_curves(
 
     // Build schedule items and power restrictions
     let path_items_to_position =
-        build_path_items_to_position(&train_schedule, &path.path_item_positions);
-    let schedule = build_sim_schedule_items(&train_schedule, &path_items_to_position);
-    let power_restrictions =
-        build_sim_power_restriction_items(&train_schedule, &path_items_to_position);
+        build_path_items_to_position(train_schedule.path(), &path.path_item_positions);
+    let schedule = build_sim_schedule_items(train_schedule.schedule(), &path_items_to_position);
+    let power_restrictions = build_sim_power_restriction_items(
+        train_schedule.power_restrictions(),
+        &path_items_to_position,
+    );
 
     let etcs_braking_curves_request = core_client::etcs_braking_curves::Request {
         infra: infra.id,
@@ -581,8 +584,7 @@ async fn simulation_summary(
 
     // Transform simulations to simulation summary
     let mut simulation_summaries = HashMap::new();
-    for (train_schedule, sim) in train_schedules.iter().zip(simulations) {
-        let (sim, _) = sim;
+    for (train_schedule, (sim, _)) in train_schedules.iter().zip(simulations) {
         let simulation_summary_result = SummaryResponse::from(Arc::unwrap_or_clone(sim));
         simulation_summaries.insert(train_schedule.id, simulation_summary_result);
     }
@@ -772,7 +774,7 @@ async fn project_path_op(
 
     let conn = &mut db_pool.get().await?;
 
-    let trains_schedules: Vec<models::TrainSchedule> =
+    let train_schedules: Vec<models::TrainSchedule> =
         models::TrainSchedule::retrieve_batch_or_fail(conn, train_ids, |missing| {
             TrainScheduleError::BatchTrainScheduleNotFound {
                 number: missing.len(),
@@ -780,7 +782,7 @@ async fn project_path_op(
         })
         .await?;
 
-    let path_item_locations: Vec<&PathItemLocation> = trains_schedules
+    let path_item_locations: Vec<&PathItemLocation> = train_schedules
         .iter()
         .flat_map(|ts| ts.path.iter().map(|p| &p.location))
         .collect();
@@ -805,14 +807,14 @@ async fn project_path_op(
         conn,
         valkey_client.clone(),
         core_client.clone(),
-        &trains_schedules,
+        &train_schedules,
         infra,
         electrical_profile_set_id,
     )
     .await?;
 
     let mut to_compute = HashMap::new();
-    for (ts, (sim, _)) in trains_schedules.into_iter().zip(simulations.into_iter()) {
+    for (ts, (sim, _)) in train_schedules.into_iter().zip(simulations.into_iter()) {
         let train_id = ts.id;
         to_compute
             .entry(Arc::as_ptr(&sim))
@@ -883,7 +885,7 @@ async fn occupancy_blocks(
 
     let conn = &mut db_pool.get().await?;
 
-    let trains_schedules: Vec<models::TrainSchedule> =
+    let train_schedules: Vec<models::TrainSchedule> =
         models::TrainSchedule::retrieve_batch_or_fail(conn, train_ids, |missing| {
             TrainScheduleError::BatchTrainScheduleNotFound {
                 number: missing.len(),
@@ -897,7 +899,7 @@ async fn occupancy_blocks(
         valkey_client,
         path,
         infra,
-        &trains_schedules,
+        &train_schedules,
         electrical_profile_set_id,
     )
     .await?;
@@ -906,7 +908,7 @@ async fn occupancy_blocks(
 
     occupancy_blocks_result
         .into_iter()
-        .zip(trains_schedules)
+        .zip(train_schedules)
         .for_each(|(occupancy_blocks, train_schedule)| {
             results.insert(train_schedule.id, Arc::unwrap_or_clone(occupancy_blocks));
         });
@@ -1640,7 +1642,6 @@ pub mod tests {
             path_item_times: vec![0, 1000],
         };
         let train_schedule = models::TrainSchedule::default();
-
         let result = interpolate_track_occupancy(
             &train_schedule,
             &path_projection,
@@ -1755,6 +1756,7 @@ pub mod tests {
         };
 
         // Call the function
+
         let (track, occupancy) = track_occupancy_on_path_item(
             &train_schedule,
             path_item_id,


### PR DESCRIPTION
In many places, `models::TrainSchedule` is used instead of `schemas::TrainSchedule`. In fact, `models::TrainSchedule`  s no longer necessary for simulation and pathfinding calculations, projections, etc, as the `timetable_id `and the `train_schedule.id` are now useless for this.