### PR TITLE
core: stdcm: estimate max allowance for every node

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdge.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdge.kt
@@ -4,6 +4,7 @@ import fr.sncf.osrd.envelope.Envelope
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockPath
 import fr.sncf.osrd.sim_infra.api.TravelledPath
+import fr.sncf.osrd.stdcm.graph.engineering_allowance.generatePreviousSimulationSegments
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
 import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Length
@@ -79,6 +80,7 @@ data class STDCMEdge(
                 null,
                 previousPlannedNodeRelativeTimeDiff,
                 graph.remainingTimeEstimator.invoke(this, null, stepTracker),
+                estimateMaxMarginDuration(graph),
             )
         } else {
             // New edge on the same block, after a stop
@@ -103,8 +105,35 @@ data class STDCMEdge(
                 nextStop.originalStep.plannedTimingData,
                 previousPlannedNodeRelativeTimeDiff,
                 graph.remainingTimeEstimator.invoke(this, locationOnEdge, stepTracker),
+                estimateMaxMarginDuration(graph),
             )
         }
+    }
+
+    /**
+     * Give a (rough) estimation of how much delay we could add before this node with engineering
+     * margins. Should be on the pessimistic side.
+     */
+    private fun estimateMaxMarginDuration(graph: STDCMGraph): Double {
+        // We look for engineering allowance opportunities, but using simplified simulations (const
+        // acceleration on max block slope). We look for the largest allowance value, with an upper
+        // bound on allowance length to avoid long computations.
+        val segments = generatePreviousSimulationSegments(this, graph, runFullSimulation = false)
+        val opportunities =
+            graph.allowanceManager.generateAllowanceOpportunities(segments, endSpeed)
+
+        var lastAddedTime = 0.0
+        for (opportunity in opportunities) {
+            if (opportunity.distance >= 20_000.meters) {
+                // Long enough to reasonably stop and accelerate back, even if we're too pessimistic on
+                // the const acceleration simulation
+                return opportunity.maxNextAllowanceValue
+            }
+            lastAddedTime = opportunity.addedTime
+            if (opportunity.addedTime >= opportunity.maxNextAllowanceValue)
+                break
+        }
+        return lastAddedTime
     }
 
     /**

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
@@ -19,8 +19,6 @@ import fr.sncf.osrd.utils.CachedBlockMRSPBuilder
 import fr.sncf.osrd.utils.units.meters
 import java.lang.Double.isFinite
 import java.lang.Double.isNaN
-import kotlin.math.max
-import kotlin.math.min
 
 /**
  * This is the class that encodes the STDCM problem as a graph on which we can run our pathfinding
@@ -101,7 +99,7 @@ class STDCMGraph(
 
     override fun getAdjacentEdges(node: STDCMNode): Collection<STDCMEdge> {
         val res = ArrayList<STDCMEdge>()
-        val maxMarginDuration = estimateMaxMarginDuration(node)
+        val maxMarginDuration = node.minEngineeringAllowanceBefore
         var visitedNodesParameters =
             VisitedNodes.Parameters(
                 null,
@@ -142,40 +140,5 @@ class STDCMGraph(
             }
         }
         return res
-    }
-
-    /**
-     * Give a (rough) estimation of how much delay we could add before this node with engineering
-     * margins. Should be on the pessimistic side.
-     */
-    private fun estimateMaxMarginDuration(inputNode: STDCMNode): Double {
-        // We look for the 20km before the node (very rough estimation of a distance that lets the
-        // train slow down to a stop and speed up). We return the max delay that can be added after
-        // the train in all of those edges, on top of maximum start time delay
-
-        // TODO: use new EngineeringAllowanceManager?
-        // We'd need to use a const acceleration sim, and we may add some caching
-
-        var node = inputNode
-        var remainingDistance = 20_000.meters
-        var maxTime = Double.POSITIVE_INFINITY
-        while (true) {
-            val edge = node.previousEdge ?: return maxTime
-
-            val latestTimeWithMaxShift =
-                edge.timeData.earliestReachableTime +
-                    edge.totalTime +
-                    edge.timeData.maxDepartureDelayingWithoutConflict
-
-            // Only consider this specific edge, not the rest of the path
-            val maxDelayAddedOnEdge =
-                max(0.0, edge.timeData.timeOfNextConflictAtLocation - latestTimeWithMaxShift)
-            maxTime = min(maxTime, maxDelayAddedOnEdge)
-
-            remainingDistance -= edge.length.distance
-            if (edge.beginSpeed == 0.0 || remainingDistance <= 0.meters) return maxTime
-
-            node = edge.previousNode
-        }
     }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMNode.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMNode.kt
@@ -27,6 +27,9 @@ data class STDCMNode(
     val previousPlannedNodeRelativeTimeDiff: Double?,
     // Estimation of the min time it takes to reach the end from this node
     var remainingTimeEstimation: Double,
+    // Pessimistic estimation of maximum allowance value up to this node. We know we can add at
+    // least that much time.
+    val minEngineeringAllowanceBefore: Double = 0.0,
 ) : Comparable<STDCMNode> {
 
     /**

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
@@ -292,6 +292,7 @@ class STDCMPathfinding(
                         firstStep.plannedTimingData,
                         null,
                         graph.bestPossibleTime,
+                        minEngineeringAllowanceBefore = POSITIVE_INFINITY,
                     )
                 res.add(node)
             }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/engineering_allowance/EngineeringAllowanceManager.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/engineering_allowance/EngineeringAllowanceManager.kt
@@ -38,19 +38,26 @@ class EngineeringAllowanceManager(
 
         val requiredAdditionalTime = expectedStartTime - prevNode.timeData.earliestReachableTime
         val segments = generatePreviousSimulationSegments(prevNode.previousEdge, graph).cacheable()
+
+        // We still try to roughly guess the maximum length over which to add the time
+        val estimateMaxDistance by lazy {
+            var distance = 0.meters
+            for (segment in segments) {
+                distance += segment.length
+                if (distance > 10_000.meters) return@lazy distance
+            }
+            distance
+        }
+
+        if (prevNode.minEngineeringAllowanceBefore > requiredAdditionalTime)
+            return estimateMaxDistance
+
         val opportunities = generateAllowanceOpportunities(segments, prevNode.speed)
         val solution =
             opportunities
                 .takeWhile { it.maxNextAllowanceValue >= requiredAdditionalTime }
                 .firstOrNull { it.addedTime >= requiredAdditionalTime } ?: return null
-
-        // We still try to roughly guess the maximum length over which to add the time
-        var distance = 0.meters
-        for (segment in segments) {
-            distance += segment.length
-            if (distance > 10_000.meters) return distance
-        }
-        return Distance.max(solution.distance, distance)
+        return Distance.max(solution.distance, estimateMaxDistance)
     }
 
     /**
@@ -155,6 +162,7 @@ class EngineeringAllowanceManager(
         // Keep track of how much delay we can add before causing conflict on the braking sequence
         var maxBrakingDelay = Double.POSITIVE_INFINITY
         var totalBrakingDelay = 0.0
+        var lastSegment: ConstDecelerationData? = null
         for (decelerationSegment in decelerationSequence) {
             totalBrakingDelay += decelerationSegment.addedTimeOnSegment
             decelerationLength += decelerationSegment.segment.length
@@ -173,12 +181,15 @@ class EngineeringAllowanceManager(
                     decelerationLength = null
                 )
             }
+            lastSegment = decelerationSegment
         }
         val canStop = decelerationEndSpeed <= 0.0
         if (canStop) totalBrakingDelay = Double.POSITIVE_INFINITY
+        val allowanceBeforeLastSegment = lastSegment?.segment?.minAllowanceBefore ?: 0.0
+        val actualAddedTime = min(maxBrakingDelay, totalBrakingDelay + allowanceBeforeLastSegment)
         return DecelerationResults(
             hasConflict = false,
-            addedDelay = totalBrakingDelay,
+            addedDelay = actualAddedTime,
             decelerationLength
         )
     }
@@ -215,6 +226,13 @@ class EngineeringAllowanceManager(
             if (pureDecelerationSim.newBeginSpeed > segment.beginSpeed) {
                 // Intersection with base sim. We could try to guess the exact added time,
                 // but ignoring this segment is generally good enough.
+                yield(
+                    ConstDecelerationData(
+                        segment,
+                        segment.travelTime,
+                        0.0,
+                    )
+                )
                 break
             }
             val newTravelTime =

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/engineering_allowance/SimulationSegment.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/engineering_allowance/SimulationSegment.kt
@@ -1,5 +1,7 @@
 package fr.sncf.osrd.stdcm.graph.engineering_allowance
 
+import com.google.common.collect.ImmutableRangeMap
+import com.google.common.collect.Range
 import fr.sncf.osrd.envelope.Envelope
 import fr.sncf.osrd.envelope.part.ConstrainedEnvelopePartBuilder
 import fr.sncf.osrd.envelope.part.EnvelopePartBuilder
@@ -7,11 +9,17 @@ import fr.sncf.osrd.envelope.part.constraints.EnvelopePartConstraintType
 import fr.sncf.osrd.envelope.part.constraints.PositionConstraint
 import fr.sncf.osrd.envelope.part.constraints.SpeedConstraint
 import fr.sncf.osrd.envelope_sim.EnvelopeProfile
+import fr.sncf.osrd.envelope_sim.PhysicsRollingStock
+import fr.sncf.osrd.envelope_sim.TrainPhysicsIntegrator
+import fr.sncf.osrd.envelope_sim.electrification.Electrification
+import fr.sncf.osrd.envelope_sim.electrification.Electrified
 import fr.sncf.osrd.envelope_sim.overlays.EnvelopeAcceleration
 import fr.sncf.osrd.envelope_sim_infra.EnvelopeTrainPath
+import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
 import fr.sncf.osrd.sim_infra.api.PathProperties
 import fr.sncf.osrd.stdcm.graph.STDCMEdge
 import fr.sncf.osrd.stdcm.graph.STDCMGraph
+import fr.sncf.osrd.train.RollingStock
 import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.meters
 
@@ -28,6 +36,7 @@ data class SimulationSegment(
     // Function to compute an acceleration over this segment. Can be dummy values for tests,
     // wrap a full simulation pipeline in normal processing.
     val computeAccelSequenceFromEndSpeed: (Double) -> SummarizedSimulationResult,
+    val minAllowanceBefore: Double = 0.0,
 ) {
     init {
         positive(beginTime)
@@ -35,6 +44,7 @@ data class SimulationSegment(
         positive(beginSpeed)
         positive(travelTime)
         positive(maxAddedDelay)
+        positive(minAllowanceBefore)
     }
 }
 
@@ -59,7 +69,8 @@ data class SummarizedSimulationResult(
 fun generatePreviousSimulationSegments(
     initialEdge: STDCMEdge?,
     graph: STDCMGraph?,
-    maxLength: Distance = 100.meters
+    maxLength: Distance = 100.meters,
+    runFullSimulation: Boolean = true,
 ): Sequence<SimulationSegment> = sequence {
     var currentEdge = initialEdge
     while (currentEdge != null) {
@@ -82,6 +93,23 @@ fun generatePreviousSimulationSegments(
             val travelTime = scaleAllowanceTime(graph, positive(endT - beginT), length)
 
             val currentEdgeSnapshot = currentEdge // For closure reference
+
+            val func =
+                if (runFullSimulation)
+                    { speed: Double ->
+                        val pathProperties =
+                            currentEdgeSnapshot.infraExplorer.getCurrentEdgePathProperties(
+                                currentEdgeSnapshot.envelopeStartOffset + segmentStartOffset,
+                                segmentEndOffset - segmentStartOffset
+                            )
+                        computeAcceleration(pathProperties, speed, graph!!)
+                    }
+                else
+                    { speed: Double ->
+                        val maxSlope = currentEdgeSnapshot.infraExplorer.getLastEdgeMaxSlope()
+                        val acceleration = getAcceleration(graph!!.rollingStock, maxSlope, speed)
+                        constAcceleration(speed, length, acceleration)
+                    }
             yield(
                 SimulationSegment(
                     beginTime = beginT,
@@ -89,15 +117,8 @@ fun generatePreviousSimulationSegments(
                     beginSpeed = segmentStart.speed,
                     travelTime = travelTime,
                     maxAddedDelay = maxAddedDelay,
-                    computeAccelSequenceFromEndSpeed = { endSpeed ->
-                        val pathProperties =
-                            currentEdgeSnapshot.infraExplorer.getCurrentEdgePathProperties(
-                                offset =
-                                    currentEdgeSnapshot.envelopeStartOffset + segmentStartOffset,
-                                length = segmentEndOffset - segmentStartOffset,
-                            )
-                        computeAcceleration(pathProperties, endSpeed, graph!!)
-                    },
+                    computeAccelSequenceFromEndSpeed = func,
+                    currentEdge.previousNode.minEngineeringAllowanceBefore,
                 )
             )
         }
@@ -152,4 +173,41 @@ private fun computeAcceleration(
         envelope.beginSpeed,
         newTime,
     )
+}
+
+private fun constAcceleration(
+    endSpeed: Double,
+    length: Distance,
+    acceleration: Double,
+): SummarizedSimulationResult {
+    val sim =
+        runSimplifiedSimulation(
+            acceleration,
+            endSpeed,
+            length.meters,
+        )
+    return SummarizedSimulationResult(sim.newBeginSpeed, sim.newDuration)
+}
+
+/** Estimates the acceleration for a given rolling stock at given speed and slope. */
+private fun getAcceleration(rollingStock: RollingStock, maxSlope: Double, speed: Double): Double {
+    val electrification =
+        ImmutableRangeMap.of<Double, Electrification>(
+            Range.all(),
+            Electrified(rollingStock.modeNames.first())
+        )
+    val curve = rollingStock.mapTractiveEffortCurves(electrification, Comfort.STANDARD).curves[0.0]
+    val acceleration =
+        TrainPhysicsIntegrator.computeAcceleration(
+            rollingStock,
+            rollingStock.getRollingResistance(speed),
+            TrainPhysicsIntegrator.getWeightForce(rollingStock, maxSlope),
+            speed,
+            PhysicsRollingStock.getMaxEffort(
+                speed,
+                curve,
+            ),
+            1.0,
+        )
+    return acceleration
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
@@ -99,6 +99,8 @@ interface InfraExplorer {
 
     /** Returns the step tracker, giving data about the steps on the path (including lookahead) */
     fun getStepTracker(): StepTracker
+
+    fun getLastEdgeMaxSlope(): Double
 }
 
 /** Returns the current block and the lookahead blocks */
@@ -132,6 +134,7 @@ fun initInfraExplorer(
     val pathProps = makePathProps(blockInfra, rawInfra, block)
     val blockToPathProperties = mutableMapOf(block to pathProps)
     val routes = blockInfra.routesOnBlock(rawInfra, block)
+    val maxSlopeCache = mutableMapOf<BlockId, Double>()
 
     routes.forEach { route ->
         val incrementalPath = incrementalPathOf(rawInfra, blockInfra)
@@ -147,6 +150,7 @@ fun initInfraExplorer(
                 blockToPathProperties,
                 stepTracker = StepTracker(steps),
                 constraints = constraints,
+                maxSlopeCache = maxSlopeCache,
             )
         val infraExtended = infraExplorer.extend(route, location)
         if (infraExtended) infraExplorers.add(infraExplorer)
@@ -167,6 +171,7 @@ private class InfraExplorerImpl(
     private var stepTracker: StepTracker,
     private var predecessorLength: Length<BlockPath> = Length(0.meters), // to avoid re-computing it
     private var constraints: List<PathfindingConstraint<Block>>,
+    private val maxSlopeCache: MutableMap<BlockId, Double>
 ) : InfraExplorer {
 
     override fun getIncrementalPath(): IncrementalPath {
@@ -271,6 +276,7 @@ private class InfraExplorerImpl(
             this.stepTracker.clone(),
             this.predecessorLength,
             this.constraints,
+            this.maxSlopeCache,
         )
     }
 
@@ -280,6 +286,18 @@ private class InfraExplorerImpl(
 
     override fun getStepTracker(): StepTracker {
         return stepTracker
+    }
+
+    override fun getLastEdgeMaxSlope(): Double {
+        return maxSlopeCache.getOrPut(getCurrentBlock()) {
+            val pathProperties =
+                getCurrentEdgePathProperties(
+                    Offset(0.meters),
+                    null,
+                )
+            val maxSlope = pathProperties.getSlopes().maxOfOrNull { it.value } ?: 0.0
+            maxSlope
+        }
     }
 
     /**

--- a/core/src/test/kotlin/fr/sncf/osrd/utils/DummyInfra.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/utils/DummyInfra.kt
@@ -396,7 +396,7 @@ class DummyInfra : RawInfra, BlockInfra {
     }
 
     override fun getTrackChunkSlope(trackChunk: DirTrackChunkId): DistanceRangeMap<Double> {
-        TODO("Not yet implemented")
+        return makeRangeMap(blockPool[trackChunk.value.index].length, 0.0)
     }
 
     override fun getTrackChunkCurve(trackChunk: DirTrackChunkId): DistanceRangeMap<Double> {


### PR DESCRIPTION
With the last PR, we can now estimate the possible allowance leading up to **every stdcm node**, for only 3% of total process time. 

Which has two main consequences:

1. Inputs for `VisitedNodes` are a lot better, leading to more trimmed nodes
2. Actual engineering allowance take less process time to test: sometimes we can skip it altogether, when we don't we can still rely on the values given by previous nodes

---

Bench: roughly -10% computation time, but some results are a little worse, it's weird. It does reduce the number of nodes by a significant amount so it likely helps with RAM (I'll measure it)