### PR TITLE
front: expand .dockerignore

### DIFF
--- a/front/.dockerignore
+++ b/front/.dockerignore
@@ -1,4 +1,9 @@
-node_modules
+**/node_modules
 npm-debug.log
 Dockerfile
+build
+coverage
+test-results
 playwright-report
+ui/**/dist
+ui/storybook/storybook-static


### PR DESCRIPTION
The .dockerignore file specifies files to not include in the build context. Making the context lighter speeds up builds (avoids copying large files) and improves caching.