### PR TITLE
front: improve simulation settings panel style

### DIFF
--- a/front/src/modules/timetableItem/components/ManageTimetableItem/ConstraintDistributionSwitch.tsx
+++ b/front/src/modules/timetableItem/components/ManageTimetableItem/ConstraintDistributionSwitch.tsx
@@ -44,7 +44,7 @@ const ConstraintDistributionSwitch = ({ constraintDistribution }: Props) => {
   );
 
   return (
-    <div className="osrd-config-item-container d-flex align-items-center mb-2">
+    <div className="toggle-container constraint-distribution-switch">
       <span className="mr-2 text-muted">{t('allowances.standard-allowance')}</span>
       <OptionsSNCF
         name="constraint-distribution-switch"

--- a/front/src/modules/timetableItem/components/ManageTimetableItem/ElectricalProfiles.tsx
+++ b/front/src/modules/timetableItem/components/ManageTimetableItem/ElectricalProfiles.tsx
@@ -13,7 +13,7 @@ export default function ElectricalProfiles() {
   const { t } = useTranslation('operational-studies', { keyPrefix: 'manageTimetableItem' });
 
   return (
-    <div className="osrd-config-item-container d-flex align-items-center mb-2">
+    <div className="toggle-container">
       <img className="mr-2" src={electricalProfilesIcon} alt="infraIcon" width="32px" />
       <span className="mr-2 text-muted">{t('usingElectricalProfiles')}</span>
       <span className="ml-auto mt-1">

--- a/front/src/modules/timetableItem/components/ManageTimetableItem/SimulationSettings.tsx
+++ b/front/src/modules/timetableItem/components/ManageTimetableItem/SimulationSettings.tsx
@@ -17,10 +17,12 @@ const SimulationSettings = ({
   dispatchUpdateSpeedLimitByTag,
   constraintDistribution,
 }: Props) => (
-  <div className="row no-gutters">
-    <div className="col-lg-6 pr-lg-2">
+  <div className="simulation-settings">
+    <div className="first-row">
       <ElectricalProfiles />
       <ConstraintDistributionSwitch constraintDistribution={constraintDistribution} />
+    </div>
+    <div className="second-row">
       <SpeedLimitByTagSelector
         selectedSpeedLimitByTag={speedLimitByTag}
         speedLimitsByTags={speedLimitsByTags}

--- a/front/src/styles/scss/applications/operationalStudies/_manageTimetableItem.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_manageTimetableItem.scss
@@ -37,4 +37,31 @@
     text-overflow: ellipsis;
     padding-right: 50px;
   }
+
+  .simulation-settings {
+    .first-row {
+      display: flex;
+      gap: 16px;
+      margin-bottom: 8px;
+
+      .toggle-container {
+        flex-grow: 1;
+        display: flex;
+        align-items: center;
+        background-color: white;
+        padding: 8px;
+        border-radius: 4px;
+      }
+
+      .constraint-distribution-switch {
+        justify-content: space-between;
+      }
+    }
+
+    .second-row {
+      background-color: white;
+      border-radius: 4px;
+      margin-bottom: 8px;
+    }
+  }
 }


### PR DESCRIPTION
Before:
<img width="1843" height="967" alt="image" src="https://github.com/user-attachments/assets/e8fef745-7c42-4fca-81ce-90d0c4e6bc5e" />


After:
<img width="1843" height="967" alt="Capture d’écran du 2025-07-18 10-25-43" src="https://github.com/user-attachments/assets/5bed78ca-1475-4ea3-8e20-d7364e3aa51c" />


Closes #12516

