### PR TITLE
core: stdcm: drop raw request requirements before running the search

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
@@ -119,6 +119,7 @@ class STDCMEndpoint(private val infraManager: InfraProvider) : Take {
                         request.startTime
                     )
                     .toMutableList()
+            request.trainsRequirements = mapOf() // Free up the RAM taken by raw requirements
             val convertedWorkSchedules =
                 convertWorkScheduleCollection(infra.rawInfra, request.workSchedules)
             trainsRequirements.add(convertedWorkSchedules)

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMRequest.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMRequest.kt
@@ -34,7 +34,7 @@ class STDCMRequest(
     @Json(name = "rolling_stock_supported_signaling_systems")
     val rollingStockSupportedSignalingSystems: List<String>,
     @Json(name = "trains_requirements")
-    val trainsRequirements: Map<String, TrainRequirementsRequest>,
+    var trainsRequirements: Map<String, TrainRequirementsRequest>,
 
     // Simulation inputs
     val comfort: Comfort,


### PR DESCRIPTION
They'd take up a lot of RAM for no good reason

Bench, average peak memory use: 5200 -> 4500 MB. Max RAM was far away during the tests though, GC may have been lazy. 