### PR TITLE
editoast: adapt edition endpoint using zadd

### DIFF
--- a/editoast/src/infra_cache/mod.rs
+++ b/editoast/src/infra_cache/mod.rs
@@ -43,6 +43,8 @@ use enum_map::EnumMap;
 use geos::geojson::Geometry;
 pub use graph::Graph;
 use itertools::Itertools as _;
+use serde::Deserialize;
+use serde::Serialize;
 use std::ops::DerefMut;
 use thiserror::Error;
 
@@ -69,6 +71,9 @@ pub struct InfraCache {
 
     /// Map reference to their cache object
     objects: EnumMap<ObjectType, HashMap<String, ObjectCache>>,
+
+    /// Infra version of the current infra
+    pub infra_version: i64,
 }
 
 pub trait Cache: OSRDObject {
@@ -79,7 +84,7 @@ pub trait Cache: OSRDObject {
     fn get_object_cache(&self) -> ObjectCache;
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub enum ObjectCache {
     TrackSection(TrackSectionCache),
     Signal(SignalCache),

--- a/editoast/src/infra_cache/object_cache/buffer_stop_cache.rs
+++ b/editoast/src/infra_cache/object_cache/buffer_stop_cache.rs
@@ -4,12 +4,14 @@ use editoast_schemas::primitives::OSRDIdentified;
 use editoast_schemas::primitives::OSRDTyped;
 use editoast_schemas::primitives::ObjectType;
 use educe::Educe;
+use serde::Deserialize;
+use serde::Serialize;
 
 use crate::infra_cache::Cache;
 use crate::infra_cache::ObjectCache;
 use editoast_schemas::infra::BufferStop;
 
-#[derive(QueryableByName, Debug, Clone, Educe)]
+#[derive(QueryableByName, Debug, Clone, Educe, Deserialize, Serialize)]
 #[educe(Hash, PartialEq)]
 pub struct BufferStopCache {
     #[diesel(sql_type = Text)]

--- a/editoast/src/infra_cache/object_cache/detector_cache.rs
+++ b/editoast/src/infra_cache/object_cache/detector_cache.rs
@@ -4,12 +4,14 @@ use editoast_schemas::primitives::OSRDIdentified;
 use editoast_schemas::primitives::OSRDTyped;
 use editoast_schemas::primitives::ObjectType;
 use educe::Educe;
+use serde::Deserialize;
+use serde::Serialize;
 
 use crate::infra_cache::Cache;
 use crate::infra_cache::ObjectCache;
 use editoast_schemas::infra::Detector;
 
-#[derive(QueryableByName, Debug, Clone, Educe)]
+#[derive(QueryableByName, Debug, Clone, Educe, Deserialize, Serialize)]
 #[educe(Hash, PartialEq)]
 pub struct DetectorCache {
     #[diesel(sql_type = Text)]

--- a/editoast/src/infra_cache/object_cache/operational_point_cache.rs
+++ b/editoast/src/infra_cache/object_cache/operational_point_cache.rs
@@ -11,7 +11,7 @@ use crate::infra_cache::ObjectCache;
 use editoast_schemas::infra::OperationalPoint;
 use editoast_schemas::infra::OperationalPointPart;
 
-#[derive(Debug, Clone, Educe)]
+#[derive(Debug, Clone, Educe, Deserialize, Serialize)]
 #[educe(Hash, PartialEq)]
 pub struct OperationalPointCache {
     pub obj_id: String,

--- a/editoast/src/infra_cache/object_cache/signal_cache.rs
+++ b/editoast/src/infra_cache/object_cache/signal_cache.rs
@@ -6,13 +6,15 @@ use editoast_schemas::primitives::OSRDIdentified;
 use editoast_schemas::primitives::OSRDTyped;
 use editoast_schemas::primitives::ObjectType;
 use educe::Educe;
+use serde::Deserialize;
+use serde::Serialize;
 
 use crate::infra_cache::Cache;
 use crate::infra_cache::ObjectCache;
 use editoast_schemas::infra::LogicalSignal;
 use editoast_schemas::infra::Signal;
 
-#[derive(QueryableByName, Debug, Clone, Educe)]
+#[derive(QueryableByName, Debug, Clone, Educe, Deserialize, Serialize)]
 #[educe(Hash, PartialEq)]
 pub struct SignalCache {
     #[diesel(sql_type = Text)]

--- a/editoast/src/infra_cache/object_cache/switch_cache.rs
+++ b/editoast/src/infra_cache/object_cache/switch_cache.rs
@@ -3,13 +3,15 @@ use editoast_schemas::primitives::OSRDIdentified;
 use editoast_schemas::primitives::OSRDTyped;
 use editoast_schemas::primitives::ObjectType;
 use educe::Educe;
+use serde::Deserialize;
+use serde::Serialize;
 use std::collections::HashMap;
 
 use crate::infra_cache::Cache;
 use crate::infra_cache::ObjectCache;
 use editoast_schemas::infra::Switch;
 
-#[derive(Debug, Clone, Educe)]
+#[derive(Debug, Clone, Educe, Deserialize, Serialize)]
 #[educe(Hash, PartialEq)]
 pub struct SwitchCache {
     pub obj_id: String,

--- a/editoast/src/infra_cache/object_cache/track_section_cache.rs
+++ b/editoast/src/infra_cache/object_cache/track_section_cache.rs
@@ -6,13 +6,15 @@ use editoast_schemas::primitives::OSRDIdentified;
 use editoast_schemas::primitives::OSRDTyped;
 use editoast_schemas::primitives::ObjectType;
 use educe::Educe;
+use serde::Deserialize;
+use serde::Serialize;
 
 use crate::infra_cache::Cache;
 use crate::infra_cache::ObjectCache;
 use editoast_schemas::infra::TrackSection;
 use editoast_schemas::primitives::BoundingBox;
 
-#[derive(Debug, Clone, Educe)]
+#[derive(Debug, Clone, Educe, Deserialize, Serialize)]
 #[educe(Hash, PartialEq, Default)]
 pub struct TrackSectionCache {
     pub obj_id: String,

--- a/editoast/src/infra_cache/operation/mod.rs
+++ b/editoast/src/infra_cache/operation/mod.rs
@@ -111,7 +111,7 @@ impl<'s> ToSchema<'s> for Operation {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Deserialize, Serialize)]
 pub enum CacheOperation {
     Create(ObjectCache),
     Update(ObjectCache),

--- a/editoast/src/valkey_utils.rs
+++ b/editoast/src/valkey_utils.rs
@@ -18,6 +18,7 @@ use deadpool_redis::redis::aio::ConnectionLike;
 use deadpool_redis::redis::cmd;
 use futures::FutureExt;
 use futures::future;
+use serde::Deserialize;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use tracing::Level;
@@ -97,6 +98,19 @@ impl ConnectionLike for ValkeyConnection {
             ValkeyConnection::NoCache => 0,
         }
     }
+}
+
+#[derive(Clone, Serialize)]
+struct ZaddWrapper<'a, M: Serialize> {
+    member: &'a M,
+    nonce: u64,
+}
+
+#[derive(Clone, Deserialize)]
+struct ZrangebyscoreWrapper<M> {
+    member: M,
+    #[expect(dead_code)]
+    nonce: u64,
 }
 
 impl ValkeyConnection {
@@ -278,14 +292,18 @@ impl ValkeyConnection {
     pub async fn json_zadd<
         K: Debug + ToRedisArgs + Send + Sync,
         S: ToRedisArgs + Send + Sync,
-        M: Serialize,
+        M: Serialize + ToOwned,
     >(
         &mut self,
         key: K,
         member: &M,
         score: S,
     ) -> Result<()> {
-        let str_member = match serde_json::to_string(member) {
+        let member = ZaddWrapper {
+            member,
+            nonce: rand::random(),
+        };
+        let str_member = match serde_json::to_string(&member) {
             Ok(member) => member,
             Err(_) => {
                 return Err(RedisError::from((
@@ -314,19 +332,18 @@ impl ValkeyConnection {
         let serialized_members = self
             .zrangebyscore::<_, _, _, Vec<String>>(key, min, max)
             .await?;
-        let deserialized_members =
-            serialized_members
-                .into_iter()
-                .filter_map(|value| match serde_json::from_str(&value) {
-                    Ok(value) => Some(value),
-                    Err(e) => {
-                        tracing::warn!(
-                            "the cached value is not a valid JSON for type '{}': {e}",
-                            std::any::type_name::<T>()
-                        );
-                        None
-                    }
-                });
+        let deserialized_members = serialized_members.into_iter().map(|value| {
+            match serde_json::from_str::<ZrangebyscoreWrapper<T>>(&value) {
+                Ok(value) => Some(value.member),
+                Err(e) => {
+                    tracing::warn!(
+                        "the cached value is not a valid JSON for type '{}': {e}",
+                        std::any::type_name::<T>()
+                    );
+                    None
+                }
+            }
+        });
         Ok(deserialized_members)
     }
 }

--- a/editoast/src/views/infra/edition.rs
+++ b/editoast/src/views/infra/edition.rs
@@ -23,12 +23,15 @@ use json_patch::RemoveOperation;
 use json_patch::ReplaceOperation;
 use serde_json::json;
 use std::collections::HashMap;
+use std::sync::Arc;
 use thiserror::Error;
 use tracing::error;
 use tracing::info;
 use uuid::Uuid;
 
 use crate::AppState;
+use crate::ValkeyClient;
+use crate::client::get_app_version;
 use crate::error::Result;
 use crate::generated_data;
 use crate::infra_cache::InfraCache;
@@ -113,6 +116,7 @@ async fn edit(
         &mut infra,
         &operations,
         &mut infra_cache,
+        valkey.clone(),
     )
     .await?;
 
@@ -355,6 +359,7 @@ pub async fn split_track_section(
         &mut infra,
         &operations,
         &mut infra_cache,
+        valkey.clone(),
     )
     .await?;
     let mut conn = valkey.get_connection().await?;
@@ -864,6 +869,7 @@ async fn apply_edit(
     infra: &mut Infra,
     operations: &[Operation],
     infra_cache: &mut InfraCache,
+    valkey: Arc<ValkeyClient>,
 ) -> Result<Vec<InfraObject>> {
     let infra_id = infra.id;
     // Check if the infra is locked
@@ -903,6 +909,17 @@ async fn apply_edit(
                 infra.bump_version(&mut conn.clone()).await?;
                 // Apply operations to infra cache
                 infra_cache.apply_operations(&cache_operations)?;
+
+                infra_cache.infra_version = infra.version;
+                let osrd_version = get_app_version().unwrap_or_default();
+                let mut valkey_conn = valkey.get_connection().await?;
+                let _ = valkey_conn
+                    .json_zadd(
+                        format!("infra_patches.{osrd_version}.{infra_id})"),
+                        &cache_operations,
+                        infra_cache.infra_version,
+                    )
+                    .await;
 
                 // Refresh layers if needed
                 generated_data::update_all(
@@ -1083,6 +1100,7 @@ pub mod tests {
             &mut small_infra,
             &operations,
             &mut infra_cache,
+            app.valkey_client(),
         )
         .await
         .ok()
@@ -1119,10 +1137,15 @@ pub mod tests {
             }),
         ]
         .to_vec();
-        let result: Vec<InfraObject> =
-            apply_edit(conn, &mut small_infra, &operations, &mut infra_cache)
-                .await
-                .unwrap();
+        let result: Vec<InfraObject> = apply_edit(
+            conn,
+            &mut small_infra,
+            &operations,
+            &mut infra_cache,
+            app.valkey_client(),
+        )
+        .await
+        .unwrap();
 
         // Check that the updated track has the new length
         assert_eq!(1234.0, result[0].get_data()["length"]);
@@ -1165,7 +1188,14 @@ pub mod tests {
             }),
         ]
         .to_vec();
-        let result = apply_edit(conn, &mut small_infra, &operations, &mut infra_cache).await;
+        let result = apply_edit(
+            conn,
+            &mut small_infra,
+            &operations,
+            &mut infra_cache,
+            app.valkey_client(),
+        )
+        .await;
 
         // Check that we have an error
         assert!(result.is_err());

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -355,6 +355,10 @@ impl TestApp {
         self.app_state.db_pool.clone()
     }
 
+    pub fn valkey_client(&self) -> Arc<ValkeyClient> {
+        self.app_state.valkey.clone()
+    }
+
     pub fn regulator(&self) -> Regulator {
         self.app_state.regulator.clone()
     }


### PR DESCRIPTION
Close #12432 

Firstly, I adapt InfraCache to store the infra_version version of the current infrastructure. 
Then, I adapt the apply_edit function (called by the edition endpoint) to store cache operations in valkey using zadd, as follows :

- score -> the latest infra_version version
- key -> infra_patches.{OSRD_VERSION}.{infra_id}
- value -> List of cache operations