### PR TITLE
core, editoast: specify if etcs signal braking curve is for a spacing or a routing conflict

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/api/etcs/ETCSBrakingCurvesEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/etcs/ETCSBrakingCurvesEndpoint.kt
@@ -1,14 +1,12 @@
 package fr.sncf.osrd.api.etcs
 
 import fr.sncf.osrd.api.*
+import fr.sncf.osrd.conflicts.ConflictType
 import fr.sncf.osrd.envelope.Envelope
 import fr.sncf.osrd.envelope.part.EnvelopePart
 import fr.sncf.osrd.envelope_sim.EnvelopeProfile
 import fr.sncf.osrd.envelope_sim.EnvelopeSimContext
-import fr.sncf.osrd.envelope_sim.etcs.BrakingCurves
-import fr.sncf.osrd.envelope_sim.etcs.BrakingType
-import fr.sncf.osrd.envelope_sim.etcs.ETCSBrakingSimulatorImpl
-import fr.sncf.osrd.envelope_sim.etcs.EoaType
+import fr.sncf.osrd.envelope_sim.etcs.*
 import fr.sncf.osrd.envelope_sim_infra.EnvelopeTrainPath
 import fr.sncf.osrd.reporting.warnings.DiagnosticRecorderImpl
 import fr.sncf.osrd.signaling.etcs_level2.ETCS_LEVEL2
@@ -154,7 +152,7 @@ class ETCSBrakingCurvesEndpoint(
                 ETCSBrakingCurvesResponse(
                     slowdownBrakingCurves.map { buildETCSCurves(it.value) },
                     stopBrakingCurves.map { buildETCSCurves(it.value) },
-                    conflictBrakingCurves.map { buildETCSCurves(it.value) }
+                    buildETCSConflictCurves(conflictBrakingCurves)
                 )
             RsJson(RsWithBody(etcsBrakingCurvesResponseAdapter.toJson(res)))
         } catch (ex: Throwable) {
@@ -225,17 +223,31 @@ class ETCSBrakingCurvesEndpoint(
         return Envelope.make(*mrspParts.toTypedArray())
     }
 
+    private fun buildETCSConflictCurves(
+        eoaBrakingCurves: EOABrakingCurves
+    ): List<ETCSConflictCurves> {
+        return eoaBrakingCurves.map {
+            assert(it.key.eoaType == EoaType.SPACING || it.key.eoaType == EoaType.ROUTING)
+            ETCSConflictCurves(
+                it.value[BrakingType.IND]!!.brakingCurve.buildSimpleEnvelope(),
+                it.value[BrakingType.PS]!!.brakingCurve.buildSimpleEnvelope(),
+                it.value[BrakingType.GUI]!!.brakingCurve.buildSimpleEnvelope(),
+                if (it.key.eoaType == EoaType.SPACING) ConflictType.SPACING
+                else ConflictType.ROUTING
+            )
+        }
+    }
+
     private fun buildETCSCurves(brakingCurves: BrakingCurves): ETCSCurves {
         return ETCSCurves(
-            buildSimpleEnvelope(brakingCurves[BrakingType.IND]?.brakingCurve),
-            buildSimpleEnvelope(brakingCurves[BrakingType.PS]!!.brakingCurve)!!,
-            buildSimpleEnvelope(brakingCurves[BrakingType.GUI]!!.brakingCurve)!!,
+            brakingCurves[BrakingType.IND]?.brakingCurve?.buildSimpleEnvelope(),
+            brakingCurves[BrakingType.PS]!!.brakingCurve.buildSimpleEnvelope(),
+            brakingCurves[BrakingType.GUI]!!.brakingCurve.buildSimpleEnvelope(),
         )
     }
 
-    private fun buildSimpleEnvelope(envelope: Envelope?): SimpleEnvelope? {
-        if (envelope == null) return envelope
-        val points = envelope.iteratePoints().distinct()
+    private fun Envelope.buildSimpleEnvelope(): SimpleEnvelope {
+        val points = this.iteratePoints().distinct()
         // Reduce the number of points in the envelope. Epsilon = 1.0 for now, reduce its value if
         // more precision is needed.
         val simplifiedEnvelope = simplifyEnvelopePoints(points)

--- a/core/src/main/kotlin/fr/sncf/osrd/api/etcs/ETCSBrakingCurvesResponse.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/etcs/ETCSBrakingCurvesResponse.kt
@@ -4,6 +4,7 @@ import com.squareup.moshi.Json
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import fr.sncf.osrd.conflicts.ConflictType
 import fr.sncf.osrd.sim_infra.api.TravelledPath
 import fr.sncf.osrd.utils.json.UnitAdapterFactory
 import fr.sncf.osrd.utils.units.Offset
@@ -12,13 +13,20 @@ import fr.sncf.osrd.utils.units.TimeDelta
 data class ETCSBrakingCurvesResponse(
     val slowdowns: List<ETCSCurves>,
     val stops: List<ETCSCurves>,
-    val signals: List<ETCSCurves>,
+    val conflicts: List<ETCSConflictCurves>,
 )
 
 data class ETCSCurves(
     val indication: SimpleEnvelope?, // null for open-signal stops
     @Json(name = "permitted_speed") val permittedSpeed: SimpleEnvelope,
     val guidance: SimpleEnvelope
+)
+
+data class ETCSConflictCurves(
+    val indication: SimpleEnvelope,
+    @Json(name = "permitted_speed") val permittedSpeed: SimpleEnvelope,
+    val guidance: SimpleEnvelope,
+    @Json(name = "conflict_type") val conflictType: ConflictType
 )
 
 data class SimpleEnvelope(

--- a/editoast/core_client/src/etcs_braking_curves.rs
+++ b/editoast/core_client/src/etcs_braking_curves.rs
@@ -5,6 +5,7 @@ use utoipa::ToSchema;
 
 use crate::AsCoreRequest;
 use crate::Json;
+use crate::conflict_detection::ConflictType;
 use crate::simulation::PhysicsConsist;
 use crate::simulation::SimulationPath;
 use crate::simulation::SimulationPowerRestrictionItem;
@@ -14,6 +15,7 @@ use crate::simulation::SpeedLimitProperties;
 editoast_common::schemas! {
     Response,
     ETCSCurves,
+    ETCSConflictCurves,
 }
 
 #[derive(Debug, Serialize)]
@@ -37,8 +39,11 @@ pub struct Response {
     pub slowdowns: Vec<ETCSCurves>,
     /// List of ETCS braking curves associated to the train schedule's ETCS stops
     pub stops: Vec<ETCSCurves>,
-    /// List of ETCS braking curves associated to the train schedule's ETCS signals
-    pub signals: Vec<ETCSCurves>,
+    /// List of ETCS conflict braking curves associated to the train schedule's ETCS signals.
+    /// For each non-route delimiter (F) signal, the associated spacing conflict curve is returned.
+    /// For each route delimiter (Nf) signal, 2 sets of curves are returned, associated to the
+    /// corresponding potential spacing or routing conflict.
+    pub conflicts: Vec<ETCSConflictCurves>,
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug, ToSchema)]
@@ -49,6 +54,18 @@ pub struct ETCSCurves {
     pub permitted_speed: SimpleEnvelope,
     #[schema(inline)]
     pub guidance: SimpleEnvelope,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Clone, Debug, ToSchema)]
+pub struct ETCSConflictCurves {
+    #[schema(inline)]
+    pub indication: SimpleEnvelope,
+    #[schema(inline)]
+    pub permitted_speed: SimpleEnvelope,
+    #[schema(inline)]
+    pub guidance: SimpleEnvelope,
+    #[schema(inline)]
+    pub conflict_type: ConflictType,
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug, ToSchema)]

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -5125,13 +5125,17 @@ components:
       required:
       - slowdowns
       - stops
-      - signals
+      - conflicts
       properties:
-        signals:
+        conflicts:
           type: array
           items:
-            $ref: '#/components/schemas/ETCSCurves'
-          description: List of ETCS braking curves associated to the train schedule's ETCS signals
+            $ref: '#/components/schemas/ETCSConflictCurves'
+          description: |-
+            List of ETCS conflict braking curves associated to the train schedule's ETCS signals.
+            For each non-route delimiter (F) signal, the associated spacing conflict curve is returned.
+            For each route delimiter (Nf) signal, 2 sets of curves are returned, associated to the
+            corresponding potential spacing or routing conflict.
         slowdowns:
           type: array
           items:
@@ -5142,6 +5146,106 @@ components:
           items:
             $ref: '#/components/schemas/ETCSCurves'
           description: List of ETCS braking curves associated to the train schedule's ETCS stops
+    ETCSConflictCurves:
+      type: object
+      required:
+      - indication
+      - permitted_speed
+      - guidance
+      - conflict_type
+      properties:
+        conflict_type:
+          type: string
+          enum:
+          - Spacing
+          - Routing
+        guidance:
+          type: object
+          required:
+          - positions
+          - times
+          - speeds
+          properties:
+            positions:
+              type: array
+              items:
+                type: integer
+                format: int64
+                minimum: 0
+              description: |-
+                List of positions of a train
+                Both positions (in mm) and times (in ms) must have the same length
+            speeds:
+              type: array
+              items:
+                type: number
+                format: double
+              description: List of speeds (in m/s) associated to a position
+            times:
+              type: array
+              items:
+                type: integer
+                format: int64
+                minimum: 0
+              description: List of times (in ms) associated to a position
+        indication:
+          type: object
+          required:
+          - positions
+          - times
+          - speeds
+          properties:
+            positions:
+              type: array
+              items:
+                type: integer
+                format: int64
+                minimum: 0
+              description: |-
+                List of positions of a train
+                Both positions (in mm) and times (in ms) must have the same length
+            speeds:
+              type: array
+              items:
+                type: number
+                format: double
+              description: List of speeds (in m/s) associated to a position
+            times:
+              type: array
+              items:
+                type: integer
+                format: int64
+                minimum: 0
+              description: List of times (in ms) associated to a position
+        permitted_speed:
+          type: object
+          required:
+          - positions
+          - times
+          - speeds
+          properties:
+            positions:
+              type: array
+              items:
+                type: integer
+                format: int64
+                minimum: 0
+              description: |-
+                List of positions of a train
+                Both positions (in mm) and times (in ms) must have the same length
+            speeds:
+              type: array
+              items:
+                type: number
+                format: double
+              description: List of speeds (in m/s) associated to a position
+            times:
+              type: array
+              items:
+                type: integer
+                format: int64
+                minimum: 0
+              description: List of times (in ms) associated to a position
     ETCSCurves:
       type: object
       required:

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -4580,6 +4580,36 @@ export type TrainScheduleForm = TrainSchedule & {
   /** Timetable attached to the train schedule */
   timetable_id?: number | null;
 };
+export type EtcsConflictCurves = {
+  conflict_type: 'Spacing' | 'Routing';
+  guidance: {
+    /** List of positions of a train
+        Both positions (in mm) and times (in ms) must have the same length */
+    positions: number[];
+    /** List of speeds (in m/s) associated to a position */
+    speeds: number[];
+    /** List of times (in ms) associated to a position */
+    times: number[];
+  };
+  indication: {
+    /** List of positions of a train
+        Both positions (in mm) and times (in ms) must have the same length */
+    positions: number[];
+    /** List of speeds (in m/s) associated to a position */
+    speeds: number[];
+    /** List of times (in ms) associated to a position */
+    times: number[];
+  };
+  permitted_speed: {
+    /** List of positions of a train
+        Both positions (in mm) and times (in ms) must have the same length */
+    positions: number[];
+    /** List of speeds (in m/s) associated to a position */
+    speeds: number[];
+    /** List of times (in ms) associated to a position */
+    times: number[];
+  };
+};
 export type EtcsCurves = {
   guidance: {
     /** List of positions of a train
@@ -4610,8 +4640,11 @@ export type EtcsCurves = {
   };
 };
 export type EtcsBrakingCurvesResponse = {
-  /** List of ETCS braking curves associated to the train schedule's ETCS signals */
-  signals: EtcsCurves[];
+  /** List of ETCS conflict braking curves associated to the train schedule's ETCS signals.
+    For each non-route delimiter (F) signal, the associated spacing conflict curve is returned.
+    For each route delimiter (Nf) signal, 2 sets of curves are returned, associated to the
+    corresponding potential spacing or routing conflict. */
+  conflicts: EtcsConflictCurves[];
   /** List of ETCS braking curves associated to the train schedule's ETCS slowdowns */
   slowdowns: EtcsCurves[];
   /** List of ETCS braking curves associated to the train schedule's ETCS stops */

--- a/tests/tests/test_train_schedule.py
+++ b/tests/tests/test_train_schedule.py
@@ -1243,7 +1243,7 @@ def test_etcs_schedule_braking_curves_endpoint(
     )
     slowdowns = etcs_braking_curves_response.json()["slowdowns"]
     stops = etcs_braking_curves_response.json()["stops"]
-    signals = etcs_braking_curves_response.json()["signals"]
+    conflicts = etcs_braking_curves_response.json()["conflicts"]
 
     # Check that the correct stop curves (EoAs = stops) are present
     first_stop_offset = 29_294_000
@@ -1324,12 +1324,15 @@ def test_etcs_schedule_braking_curves_endpoint(
             and permitted_speed["speeds"][0] <= guidance["speeds"][0]
         )
 
-    # Check that the correct signal curves are present: 29 spacing curves and 7 routing curves
-    assert len(signals) == 36
-    for i in range(len(signals)):
-        indication = signals[i]["indication"]
-        permitted_speed = signals[i]["permitted_speed"]
-        guidance = signals[i]["guidance"]
+    # Check that the correct conflict curves are present: 29 spacing conflict curves and 7 routing conflict curves
+    assert len(conflicts) == 36
+    spacing_count = 0
+    routing_count = 0
+    for i in range(len(conflicts)):
+        indication = conflicts[i]["indication"]
+        permitted_speed = conflicts[i]["permitted_speed"]
+        guidance = conflicts[i]["guidance"]
+        conflict_type = conflicts[i]["conflict_type"]
         assert indication["speeds"][-1] == 0
         assert permitted_speed["speeds"][-1] == 0
         assert guidance["speeds"][-1] == 0
@@ -1341,9 +1344,15 @@ def test_etcs_schedule_braking_curves_endpoint(
             permitted_speed["positions"][0] <= guidance["positions"][0]
             and permitted_speed["speeds"][0] <= guidance["speeds"][0]
         )
-    last_signal_curves = signals[-1]
-    assert last_signal_curves["indication"]["positions"][0] == 42_766_050
-    assert last_signal_curves["indication"]["positions"][-1] == 44_538_000
+        if conflict_type == "Spacing":
+            spacing_count += 1
+        elif conflict_type == "Routing":
+            routing_count += 1
+    assert spacing_count == 29
+    assert routing_count == 7
+    last_conflict_curves = conflicts[-1]
+    assert last_conflict_curves["indication"]["positions"][0] == 42_766_050
+    assert last_conflict_curves["indication"]["positions"][-1] == 44_538_000
 
 
 def _assert_equal_speeds(left, right):


### PR DESCRIPTION
Requires: https://github.com/OpenRailAssociation/osrd/pull/12457. Only the last commit is part of this PR (not going to rebase every single time).
Etcs braking curves endpoint now returns 2 sets of curves for a given signal: one for the associated spacing conflict and one for the associated routing conflict. Make the information available for the front-end.