### PR TITLE
core: fix warning about nullable java type used as non-nullable in kt

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/visited_node_tracking/VisitedRange.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/visited_node_tracking/VisitedRange.kt
@@ -24,7 +24,8 @@ abstract class VisitedRange {
      * Returns the range that is most likely to define elements as "already visited". Used to merge
      * overlapping ranges in the range map.
      */
-    fun mergeWith(other: VisitedRange, timeRange: Range<Double>): VisitedRange {
+    fun mergeWith(other: VisitedRange?, timeRange: Range<Double>): VisitedRange {
+        if (other == null) return this
         return sequenceOf(this, other).minBy { it.getLowestCostOnRange(timeRange) }
     }
 

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/visited_node_tracking/VisitedRangeMap.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/visited_node_tracking/VisitedRangeMap.kt
@@ -28,7 +28,7 @@ data class VisitedRangeMap(
         fun putRange(start: Double, end: Double, value: VisitedRange) {
             if (start < end) {
                 val range = Range.closedOpen(start, end)
-                map.merge(range, value) { a, b -> a.mergeWith(b, range) }
+                map.merge(range, value) { a, b -> a?.mergeWith(b, range) ?: b }
             }
         }
 


### PR DESCRIPTION
The type were marked as `@nullable` in the java lib, but the lambda was only compatible with a non nullable type here. That causes a warning that will eventually turn into an error with some kt update. 

I don't exactly *get* when that function can be called with null inputs, but it's an easy case to handle anyway. [Here's the doc](https://guava.dev/releases/31.0-jre/api/docs/com/google/common/collect/RangeMap.html#merge(com.google.common.collect.Range,V,java.util.function.BiFunction)) if someone understands that case. 