### PR TITLE
front: fix parsing of datetime-local input

### DIFF
--- a/front/src/utils/__tests__/date.spec.ts
+++ b/front/src/utils/__tests__/date.spec.ts
@@ -15,6 +15,12 @@ describe('parseLocalDateTime', () => {
     expect(isoDate?.toISOString()).toEqual('2024-04-25T08:20:10.000Z');
   });
 
+  it('should return an iso date by passing a date with a two digits year', () => {
+    const inputDate = '0024-04-25T08:20:10';
+    const isoDate = parseLocalDateTime(inputDate);
+    expect(isoDate?.toISOString()).toEqual('0024-04-25T08:20:10.000Z');
+  });
+
   it('should return an iso date by passing a date with a space between date and time instead of a T', () => {
     const inputDate = '2024-04-25 08:20:10';
     const isoDate = parseLocalDateTime(inputDate);

--- a/front/src/utils/date.ts
+++ b/front/src/utils/date.ts
@@ -20,16 +20,16 @@ export function dateTimeFormatting(date: Date, locale: string, withoutTime: bool
 }
 
 /**
- * Transform a date from a datetime-local input format to an
- * ISO 8601 date with the user timezone
+ * Transform a date from a datetime-local input format to a JS Date
  * @param inputDate e.g. 2024-04-25T08:30
- * @return an ISO 8601 date (e.g. 2024-04-25T08:30:00+02:00) or null
+ * @return a date or null
  */
 export const parseLocalDateTime = (inputDateTime: string) => {
   // Regex to check format 1234-56-78T12:00:00(:00)
   const inputDateTimeRegex = /^\d{4}-\d{2}-\d{2}[T\s]\d{2}:\d{2}(?::\d{2}){0,1}$/;
   if (inputDateTimeRegex.test(inputDateTime)) {
-    return dayjs.tz(inputDateTime, userTimeZone).toDate();
+    const date = new Date(inputDateTime);
+    return Number.isNaN(date.valueOf()) ? null : date;
   }
   return null;
 };


### PR DESCRIPTION
Fix #12502

In dayjs, parsing a date with 2 digits (or less) - which is the case when you start typing something - results in 1900+ "what you started to type". Check https://github.com/iamkun/dayjs/issues/1237

So removing the use of dayjs in the `parseLocalDateTime` function which is only used for the datetime-local input.