### PR TITLE
front: drop version field from package.json

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -6,7 +6,6 @@
   "packages": {
     "": {
       "name": "osrd",
-      "version": "0.1.0",
       "workspaces": [
         "ui/base",
         "ui/ui-icons",

--- a/front/package.json
+++ b/front/package.json
@@ -1,6 +1,5 @@
 {
   "name": "osrd",
-  "version": "0.1.0",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/front/src/index.tsx
+++ b/front/src/index.tsx
@@ -2,7 +2,6 @@ import ReactDOM from 'react-dom/client';
 import { Provider } from 'react-redux';
 import { PersistGate } from 'redux-persist/integration/react';
 
-// Styles
 import 'maplibre-gl/dist/maplibre-gl.css';
 import 'styles/styles.scss';
 
@@ -10,12 +9,7 @@ import { Loader } from 'common/Loaders';
 import App from 'main/app';
 import { persistor, store } from 'store';
 
-// Components
-import { version } from '../package.json';
-
 export default function Container() {
-  console.info('OSRD VERSION', version);
-
   return (
     <Provider store={store}>
       <PersistGate loading={<Loader />} persistor={persistor}>


### PR DESCRIPTION
This version number is meaningless and outdated. Let's just remove it so we don't have to keep it in sync.

We already log the GIT_DESCRIBE version on front startup.