### PR TITLE
front: handle roundtrips in OSRD → NGE converter

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -19,7 +19,7 @@
         "@nivo/core": "^0.99.0",
         "@nivo/line": "^0.99.0",
         "@openapi-contrib/openapi-schema-to-json-schema": "^5.1.0",
-        "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.b7294a4a37d250b11aed2714f39c38d0f3546994",
+        "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.802a8040bc210d041749884e28093be065d17889",
         "@osrd-project/ui-charts": "0.0.1-dev",
         "@osrd-project/ui-core": "0.0.1-dev",
         "@osrd-project/ui-icons": "0.0.1-dev",
@@ -5115,9 +5115,9 @@
       "link": true
     },
     "node_modules/@osrd-project/netzgrafik-frontend": {
-      "version": "0.0.0-snapshot.b7294a4a37d250b11aed2714f39c38d0f3546994",
-      "resolved": "https://registry.npmjs.org/@osrd-project/netzgrafik-frontend/-/netzgrafik-frontend-0.0.0-snapshot.b7294a4a37d250b11aed2714f39c38d0f3546994.tgz",
-      "integrity": "sha512-b754YLRaf9DHF1EfroKVRwDzsHurxcr/3H/22YkWk3bXl8qT6AGrGzO64i9+3hloEn43qEoz7mMUsj/iVNZo2Q=="
+      "version": "0.0.0-snapshot.802a8040bc210d041749884e28093be065d17889",
+      "resolved": "https://registry.npmjs.org/@osrd-project/netzgrafik-frontend/-/netzgrafik-frontend-0.0.0-snapshot.802a8040bc210d041749884e28093be065d17889.tgz",
+      "integrity": "sha512-80eWblSTXYh2cBpg2Z19AZB+yfYbU/zz9vVgJOJzkgwOfxxCslpVcSdocGNFJGMtVAuLOIgjOh7rXZzhSyncEQ=="
     },
     "node_modules/@osrd-project/storybook": {
       "resolved": "ui/storybook",

--- a/front/package.json
+++ b/front/package.json
@@ -15,7 +15,7 @@
     "@nivo/core": "^0.99.0",
     "@nivo/line": "^0.99.0",
     "@openapi-contrib/openapi-schema-to-json-schema": "^5.1.0",
-    "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.b7294a4a37d250b11aed2714f39c38d0f3546994",
+    "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.802a8040bc210d041749884e28093be065d17889",
     "@osrd-project/ui-charts": "0.0.1-dev",
     "@osrd-project/ui-core": "0.0.1-dev",
     "@osrd-project/ui-icons": "0.0.1-dev",

--- a/front/src/applications/operationalStudies/components/MacroEditor/MacroEditorState.ts
+++ b/front/src/applications/operationalStudies/components/MacroEditor/MacroEditorState.ts
@@ -1,9 +1,6 @@
 import { sortBy } from 'lodash';
 
-import type {
-  MacroNodeResponse,
-  SearchResultItemOperationalPoint,
-} from 'common/api/osrdEditoastApi';
+import type { MacroNodeResponse, OperationalPoint } from 'common/api/osrdEditoastApi';
 import type { TimetableItemId, TimetableItem } from 'reducers/osrdconf/types';
 
 import type { TrainrunCategory, TrainrunFrequency } from '../NGE/types';
@@ -246,14 +243,17 @@ export default class MacroEditorState {
   /**
    * Given a search result item, returns all possible pathKeys, ordered by weight.
    */
-  static getPathKeys(item: SearchResultItemOperationalPoint): string[] {
+  static getPathKeys(op: OperationalPoint): string[] {
+    const { uic } = op.extensions?.identifier ?? {};
+    const { trigram, ch } = op.extensions?.sncf ?? {};
+
     const result = [];
-    result.push(`op_id:${item.obj_id}`);
-    result.push(`trigram:${item.trigram}${item.ch ? `/${item.ch}` : ''}`);
-    result.push(`uic:${item.uic}${item.ch ? `/${item.ch}` : ''}`);
-    item.track_sections.forEach((ts) => {
-      result.push(`track_offset:${ts.track}+${ts.position}`);
-    });
+    result.push(`op_id:${op.id}`);
+    result.push(`trigram:${trigram}${ch ? `/${ch}` : ''}`);
+    result.push(`uic:${uic}${ch ? `/${ch}` : ''}`);
+    for (const opPart of op.parts) {
+      result.push(`track_offset:${opPart.track}+${opPart.position}`);
+    }
     return result;
   }
 }

--- a/front/src/applications/operationalStudies/components/MacroEditor/MacroEditorState.ts
+++ b/front/src/applications/operationalStudies/components/MacroEditor/MacroEditorState.ts
@@ -80,7 +80,7 @@ export default class MacroEditorState {
   /**
    * Given a NGE `Trainrun.id`, returns the OSRD `TimetableItemId`.
    */
-  timetableItemIdByNgeId: Map<number, TimetableItemId>;
+  timetableItemIdByNgeId: Map<number, [TimetableItemId, TimetableItemId | null]>;
 
   /**
    * Default constructor
@@ -98,7 +98,7 @@ export default class MacroEditorState {
     this.trainrunFrequencies = [];
     this.trainrunCategories = [];
     this.ngeResource = { id: 1, capacity: 0 };
-    this.timetableItemIdByNgeId = new Map<number, TimetableItemId>();
+    this.timetableItemIdByNgeId = new Map();
   }
 
   /**

--- a/front/src/applications/operationalStudies/components/MacroEditor/ngeToOsrd.ts
+++ b/front/src/applications/operationalStudies/components/MacroEditor/ngeToOsrd.ts
@@ -457,7 +457,8 @@ const handleCreateTimetableItem = async (
     ...newTimetableItems[0],
     id: formatEditoastIdToPacedTrainId(newTimetableItems[0].id),
   };
-  state.timetableItemIdByNgeId.set(trainrun.id, newPacedTrain.id);
+  // TODO: handle roundtrips
+  state.timetableItemIdByNgeId.set(trainrun.id, [newPacedTrain.id, null]);
   addUpsertedTimetableItems([newPacedTrain]);
 };
 
@@ -487,7 +488,8 @@ const handleUpdateTimetableItem = async ({
   addUpsertedTimetableItems: (timetableItems: TimetableItem[]) => void;
   addDeletedTimetableItemIds: (timetableItemIds: TimetableItemId[]) => void;
 }) => {
-  const timetableItemId = state.timetableItemIdByNgeId.get(trainrun.id)!;
+  // TODO: handle roundtrips
+  const timetableItemId = state.timetableItemIdByNgeId.get(trainrun.id)![0];
   const timetableItem = await fetchTimetableItem(timetableItemId, dispatch);
   const { labels, startDate, trainrunSections } = generateTrainrunProperties(
     netzgrafikDto,
@@ -551,7 +553,8 @@ const handleUpdateTimetableItem = async ({
       addDeletedTimetableItemIds
     );
   }
-  state.timetableItemIdByNgeId.set(trainrun.id, updatedTimetableItem.id);
+  // TODO: handle roundtrips
+  state.timetableItemIdByNgeId.set(trainrun.id, [updatedTimetableItem.id, null]);
 };
 
 const handleDeleteTimetableItem = async (
@@ -560,7 +563,8 @@ const handleDeleteTimetableItem = async (
   dispatch: AppDispatch,
   addDeletedTimetableItemIds: (timetableItemIds: TimetableItemId[]) => void
 ) => {
-  const timetableItemId = state.timetableItemIdByNgeId.get(trainrunId)!;
+  // TODO: handle roundtrips
+  const timetableItemId = state.timetableItemIdByNgeId.get(trainrunId)![0];
   const editoastTrainId = isPacedTrainId(timetableItemId)
     ? extractEditoastIdFromPacedTrainId(timetableItemId)
     : extractEditoastIdFromTrainScheduleId(timetableItemId);

--- a/front/src/applications/operationalStudies/components/MacroEditor/osrdToNge.ts
+++ b/front/src/applications/operationalStudies/components/MacroEditor/osrdToNge.ts
@@ -5,7 +5,7 @@ import {
   getUniqueOpRefsFromTimetableItems,
   addPathOpsToTimetableItems,
 } from 'applications/operationalStudies/utils';
-import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
+import { osrdEditoastApi, type TrainSchedule } from 'common/api/osrdEditoastApi';
 import type { TimetableItem, TimetableItemWithPathOps } from 'reducers/osrdconf/types';
 import type { AppDispatch } from 'store';
 import { Duration, addDurationToDate } from 'utils/duration';
@@ -44,6 +44,8 @@ import {
   type LabelDto,
   type TrainrunCategory,
 } from '../NGE/types';
+
+type ScheduleItem = NonNullable<TrainSchedule['schedule']>[number];
 
 /**
  * Get the TrainrunFrequencies from the TimetableItems.
@@ -349,6 +351,35 @@ const getNgeTrainruns = (
       };
     });
 
+const createTimeLock = (time: Date, startTime: Date): TimeLockDto => ({
+  time: time.getMinutes(),
+  // getTime() is in milliseconds, consecutiveTime is in minutes
+  consecutiveTime: (time.getTime() - startTime.getTime()) / (60 * 1000),
+  lock: false,
+  warning: null,
+  timeFormatter: null,
+});
+
+const createArrivalTimeLock = (scheduleItem: ScheduleItem | undefined, startTime: Date) => {
+  if (!scheduleItem?.arrival) {
+    return { ...DEFAULT_TIME_LOCK };
+  }
+  const arrival = Duration.parse(scheduleItem.arrival);
+  return createTimeLock(addDurationToDate(startTime, arrival), startTime);
+};
+
+const createDepartureTimeLock = (scheduleItem: ScheduleItem | undefined, startTime: Date) => {
+  if (!scheduleItem?.arrival) {
+    return { ...DEFAULT_TIME_LOCK };
+  }
+  const arrival = Duration.parse(scheduleItem.arrival);
+  const stopFor = scheduleItem.stop_for ? Duration.parse(scheduleItem.stop_for) : Duration.zero;
+  return createTimeLock(
+    addDurationToDate(addDurationToDate(startTime, arrival), stopFor),
+    startTime
+  );
+};
+
 /**
  * Translate the TimetableItem in NGE "TrainrunSection" & "Nodes".
  * It is needed to return the nodes as well, because we add ports & transitions on them.
@@ -393,14 +424,6 @@ const getNgeTrainrunSectionsWithNodes = (
     });
 
     const startTime = new Date(timetableItem.start_time);
-    const createTimeLock = (time: Date): TimeLockDto => ({
-      time: time.getMinutes(),
-      // getTime() is in milliseconds, consecutiveTime is in minutes
-      consecutiveTime: (time.getTime() - startTime.getTime()) / (60 * 1000),
-      lock: false,
-      warning: null,
-      timeFormatter: null,
-    });
 
     // OSRD describes the path in terms of nodes, NGE describes it in terms
     // of sections between nodes. Iterate over path items two-by-two to
@@ -450,24 +473,14 @@ const getNgeTrainrunSectionsWithNodes = (
       }
       prevPort = targetPort;
 
-      let sourceDeparture = { ...DEFAULT_TIME_LOCK };
+      let sourceDeparture;
       if (i === 0) {
-        sourceDeparture = createTimeLock(startTime);
-      } else if (sourceScheduleEntry && sourceScheduleEntry.arrival) {
-        const arrival = Duration.parse(sourceScheduleEntry.arrival);
-        const stopFor = sourceScheduleEntry.stop_for
-          ? Duration.parse(sourceScheduleEntry.stop_for)
-          : Duration.zero;
-        sourceDeparture = createTimeLock(
-          addDurationToDate(addDurationToDate(startTime, arrival), stopFor)
-        );
+        sourceDeparture = createTimeLock(startTime, startTime);
+      } else {
+        sourceDeparture = createDepartureTimeLock(sourceScheduleEntry, startTime);
       }
 
-      let targetArrival = { ...DEFAULT_TIME_LOCK };
-      if (targetScheduleEntry && targetScheduleEntry.arrival) {
-        const arrival = Duration.parse(targetScheduleEntry.arrival);
-        targetArrival = createTimeLock(addDurationToDate(startTime, arrival));
-      }
+      const targetArrival = createArrivalTimeLock(targetScheduleEntry, startTime);
 
       const travelTime = { ...DEFAULT_TIME_LOCK };
       if (targetArrival.consecutiveTime !== null && sourceDeparture.consecutiveTime !== null) {

--- a/front/src/applications/operationalStudies/components/MacroEditor/osrdToNge.ts
+++ b/front/src/applications/operationalStudies/components/MacroEditor/osrdToNge.ts
@@ -36,6 +36,7 @@ import {
 import {
   type PortDto,
   type TimeLockDto,
+  type TrainrunDto,
   type TrainrunSectionDto,
   type TrainrunFrequency,
   type NetzgrafikDto,
@@ -329,7 +330,7 @@ const getNgeTrainruns = (
   state: MacroEditorState,
   timetableItems: TimetableItem[],
   labels: LabelDto[]
-) =>
+): TrainrunDto[] =>
   timetableItems
     .filter((timetableItem) => timetableItem.path.length >= 2)
     .map((timetableItem, index) => {
@@ -344,6 +345,7 @@ const getNgeTrainruns = (
         labelIds: (timetableItem.labels || []).map((l) =>
           labels.findIndex((e) => e.label === l && e.labelGroupId === TRAINRUN_LABEL_GROUP.id)
         ),
+        trainrunDirection: 'one_way',
       };
     });
 

--- a/front/src/applications/operationalStudies/components/MacroEditor/osrdToNge.ts
+++ b/front/src/applications/operationalStudies/components/MacroEditor/osrdToNge.ts
@@ -1,10 +1,12 @@
 import type { TFunction } from 'i18next';
 import { uniqBy } from 'lodash';
 
+import {
+  getUniqueOpRefsFromTimetableItems,
+  addPathOpsToTimetableItems,
+} from 'applications/operationalStudies/utils';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
-import type { SearchResultItemOperationalPoint, TrainSchedule } from 'common/api/osrdEditoastApi';
-import buildOpSearchQuery from 'modules/operationalPoint/helpers/buildOpSearchQuery';
-import type { TimetableItem } from 'reducers/osrdconf/types';
+import type { TimetableItem, TimetableItemWithPathOps } from 'reducers/osrdconf/types';
 import type { AppDispatch } from 'store';
 import { Duration, addDurationToDate } from 'utils/duration';
 import {
@@ -79,42 +81,6 @@ const getNgeTrainrunFrequencies = (
   });
 
   return trainrunFrequencies;
-};
-
-/**
- * Execute the search payload and collect all result pages.
- */
-const executeSearch = async (
-  state: MacroEditorState,
-  timetableItems: TimetableItem[],
-  dispatch: AppDispatch
-): Promise<SearchResultItemOperationalPoint[]> => {
-  const pathSteps: TrainSchedule['path'] = timetableItems.flatMap(
-    (timetableItem) => timetableItem.path
-  );
-  const searchPayload = buildOpSearchQuery(state.infraId, pathSteps);
-  if (!searchPayload) {
-    return [];
-  }
-  const pageSize = 100;
-  let done = false;
-  const searchResults: SearchResultItemOperationalPoint[] = [];
-  for (let page = 1; !done; page += 1) {
-    const searchPromise = dispatch(
-      osrdEditoastApi.endpoints.postSearch.initiate(
-        {
-          page,
-          pageSize,
-          searchPayload,
-        },
-        { track: false }
-      )
-    );
-    const results = (await searchPromise.unwrap()) as SearchResultItemOperationalPoint[];
-    searchResults.push(...results);
-    done = results.length < pageSize;
-  }
-  return searchResults;
 };
 
 const distance = (a: [number, number], b: [number, number]): number => {
@@ -285,7 +251,7 @@ export const getTrainrunCategories = (t: TFunction<'operational-studies'>): Trai
  */
 export const loadAndIndexNge = async (
   state: MacroEditorState,
-  timetableItems: TimetableItem[],
+  timetableItems: TimetableItemWithPathOps[],
   dispatch: AppDispatch,
   t: TFunction<'operational-studies'>
 ): Promise<void> => {
@@ -310,21 +276,17 @@ export const loadAndIndexNge = async (
       }
     });
 
-  // Enhance nodes by calling the search API
-  const searchResults = await executeSearch(state, timetableItems, dispatch);
-  searchResults.forEach((searchResult) => {
-    const macroNode: Pick<NodeIndexed, 'full_name' | 'trigram' | 'geocoord'> = {
-      full_name: searchResult.name,
-      trigram: searchResult.trigram + (searchResult.ch ? `/${searchResult.ch}` : ''),
-      geocoord: {
-        lng: searchResult.geographic.coordinates[0],
-        lat: searchResult.geographic.coordinates[1],
-      },
-    };
-    MacroEditorState.getPathKeys(searchResult).forEach((pathKey) => {
-      state.updateNodeDataByKey(pathKey, macroNode);
-    });
-  });
+  const pathOps = timetableItems.flatMap((timetableItem) => timetableItem.pathOps).flat();
+  for (const op of pathOps) {
+    const { trigram, ch } = op.extensions?.sncf ?? {};
+    for (const pathKey of MacroEditorState.getPathKeys(op)) {
+      state.updateNodeDataByKey(pathKey, {
+        full_name: op.extensions?.identifier?.name,
+        trigram: trigram ? trigram + (ch ? `/${ch}` : '') : null,
+        geocoord: op.geo ? { lng: op.geo.coordinates[0], lat: op.geo.coordinates[1] } : undefined,
+      });
+    }
+  }
 
   // Load saved nodes and update the indexed nodes
   // If a saved node is not present in the timetableItems, we delete it.
@@ -585,6 +547,24 @@ export const getNgeDto = (
   };
 };
 
+const fetchTimetableItemPathOps = async (
+  infraId: number,
+  timetableItems: TimetableItem[],
+  dispatch: AppDispatch
+): Promise<TimetableItemWithPathOps[]> => {
+  const opRefs = getUniqueOpRefsFromTimetableItems(timetableItems);
+  const ops = await dispatch(
+    osrdEditoastApi.endpoints.matchAllOperationalPoints.initiate(
+      {
+        infraId,
+        opRefs,
+      },
+      { subscribe: false }
+    )
+  ).unwrap();
+  return addPathOpsToTimetableItems(timetableItems, opRefs, ops);
+};
+
 export const loadNgeDto = async (
   state: MacroEditorState,
   timetableId: number,
@@ -603,6 +583,7 @@ export const loadNgeDto = async (
       ...trainSchedule,
       id: formatEditoastIdToTrainScheduleId(trainSchedule.id),
     }));
+
   const pacedTrainsPromise = dispatch(
     osrdEditoastApi.endpoints.getAllTimetableByIdPacedTrains.initiate(
       { timetableId },
@@ -615,7 +596,13 @@ export const loadNgeDto = async (
       ...pacedTrain,
       id: formatEditoastIdToPacedTrainId(pacedTrain.id),
     }));
-  const timetableItems = [...trainSchedules, ...pacedTrains];
+
+  const timetableItems = await fetchTimetableItemPathOps(
+    state.infraId,
+    [...trainSchedules, ...pacedTrains],
+    dispatch
+  );
+
   await loadAndIndexNge(state, timetableItems, dispatch, t);
   return getNgeDto(state, timetableItems);
 };

--- a/front/src/applications/operationalStudies/components/MacroEditor/osrdToNge.ts
+++ b/front/src/applications/operationalStudies/components/MacroEditor/osrdToNge.ts
@@ -7,7 +7,11 @@ import buildOpSearchQuery from 'modules/operationalPoint/helpers/buildOpSearchQu
 import type { TimetableItem } from 'reducers/osrdconf/types';
 import type { AppDispatch } from 'store';
 import { Duration, addDurationToDate } from 'utils/duration';
-import { isPacedTrainResponseWithPacedTrainId } from 'utils/trainId';
+import {
+  isPacedTrainResponseWithPacedTrainId,
+  formatEditoastIdToPacedTrainId,
+  formatEditoastIdToTrainScheduleId,
+} from 'utils/trainId';
 
 import {
   TRAINRUN_CATEGORY_HALTEZEITEN,
@@ -579,4 +583,39 @@ export const getNgeDto = (
       filterSettings: [],
     },
   };
+};
+
+export const loadNgeDto = async (
+  state: MacroEditorState,
+  timetableId: number,
+  dispatch: AppDispatch,
+  t: TFunction<'operational-studies'>
+): Promise<NetzgrafikDto> => {
+  const trainSchedulesPromise = dispatch(
+    osrdEditoastApi.endpoints.getAllTimetableByIdTrainSchedules.initiate(
+      { timetableId },
+      { forceRefetch: true, subscribe: false }
+    )
+  );
+  const trainSchedules = (await trainSchedulesPromise.unwrap())
+    .filter((trainSchedule) => trainSchedule.path.length >= 2)
+    .map((trainSchedule) => ({
+      ...trainSchedule,
+      id: formatEditoastIdToTrainScheduleId(trainSchedule.id),
+    }));
+  const pacedTrainsPromise = dispatch(
+    osrdEditoastApi.endpoints.getAllTimetableByIdPacedTrains.initiate(
+      { timetableId },
+      { forceRefetch: true, subscribe: false }
+    )
+  );
+  const pacedTrains = (await pacedTrainsPromise.unwrap())
+    .filter((pacedTrain) => pacedTrain.path.length >= 2)
+    .map((pacedTrain) => ({
+      ...pacedTrain,
+      id: formatEditoastIdToPacedTrainId(pacedTrain.id),
+    }));
+  const timetableItems = [...trainSchedules, ...pacedTrains];
+  await loadAndIndexNge(state, timetableItems, dispatch, t);
+  return getNgeDto(state, timetableItems);
 };

--- a/front/src/applications/operationalStudies/components/MacroEditor/osrdToNge.ts
+++ b/front/src/applications/operationalStudies/components/MacroEditor/osrdToNge.ts
@@ -367,7 +367,7 @@ const getNgeTrainruns = (
   timetableItems
     .filter((timetableItem) => timetableItem.path.length >= 2)
     .map((timetableItem, index) => {
-      state.timetableItemIdByNgeId.set(index + 1, timetableItem.id);
+      state.timetableItemIdByNgeId.set(index + 1, [timetableItem.id, null]);
       const trainrunFrequency = getTrainrunFrequencyFromTimetableItem(timetableItem, state);
       return {
         id: index + 1,

--- a/front/src/applications/operationalStudies/components/MacroEditor/osrdToNge.ts
+++ b/front/src/applications/operationalStudies/components/MacroEditor/osrdToNge.ts
@@ -1,9 +1,12 @@
 import type { TFunction } from 'i18next';
 import { uniqBy } from 'lodash';
 
+import type { TimetableItemRoundTripGroups } from 'applications/operationalStudies/types';
 import {
   getUniqueOpRefsFromTimetableItems,
   addPathOpsToTimetableItems,
+  groupRoundTrips,
+  checkRoundTripCompatible,
 } from 'applications/operationalStudies/utils';
 import { osrdEditoastApi, type TrainSchedule } from 'common/api/osrdEditoastApi';
 import type { TimetableItem, TimetableItemWithPathOps } from 'reducers/osrdconf/types';
@@ -330,13 +333,14 @@ export const loadAndIndexNge = async (
  */
 const getNgeTrainruns = (
   state: MacroEditorState,
-  timetableItems: TimetableItem[],
+  groupedTimetableItems: (readonly [TimetableItem, TimetableItem | null])[],
   labels: LabelDto[]
 ): TrainrunDto[] =>
-  timetableItems
+  groupedTimetableItems
+    .map(([a, b]) => ({ ...a, returnId: b?.id ?? null }))
     .filter((timetableItem) => timetableItem.path.length >= 2)
     .map((timetableItem, index) => {
-      state.timetableItemIdByNgeId.set(index + 1, [timetableItem.id, null]);
+      state.timetableItemIdByNgeId.set(index + 1, [timetableItem.id, timetableItem.returnId]);
       const trainrunFrequency = getTrainrunFrequencyFromTimetableItem(timetableItem, state);
       return {
         id: index + 1,
@@ -347,7 +351,7 @@ const getNgeTrainruns = (
         labelIds: (timetableItem.labels || []).map((l) =>
           labels.findIndex((e) => e.label === l && e.labelGroupId === TRAINRUN_LABEL_GROUP.id)
         ),
-        trainrunDirection: 'one_way',
+        trainrunDirection: timetableItem.returnId ? 'round_trip' : 'one_way',
       };
     });
 
@@ -386,7 +390,7 @@ const createDepartureTimeLock = (scheduleItem: ScheduleItem | undefined, startTi
  */
 const getNgeTrainrunSectionsWithNodes = (
   state: MacroEditorState,
-  timetableItems: TimetableItem[],
+  groupedTimetableItems: (readonly [TimetableItem, TimetableItem | null])[],
   labels: LabelDto[]
 ) => {
   let portId = 1;
@@ -416,104 +420,133 @@ const getNgeTrainrunSectionsWithNodes = (
   // Track nge nodes
   const ngeNodesByPathKey: Record<string, NetzgrafikDto['nodes'][0]> = {};
   let trainrunSectionId = 0;
-  const trainrunSections: TrainrunSectionDto[] = timetableItems.flatMap((timetableItem, index) => {
-    // Figure out the primary node key for each path item
-    const pathNodeKeys = timetableItem.path.map((pathItem) => {
-      const node = state.getNodeByKey(MacroEditorState.getPathKey(pathItem));
-      return node!.path_item_key;
-    });
+  const trainrunSections: TrainrunSectionDto[] = groupedTimetableItems.flatMap(
+    ([timetableItem, returnTimetableItem], index) => {
+      // Figure out the primary node key for each path item
+      const pathNodeKeys = timetableItem.path.map((pathItem) => {
+        const node = state.getNodeByKey(MacroEditorState.getPathKey(pathItem));
+        return node!.path_item_key;
+      });
 
-    const startTime = new Date(timetableItem.start_time);
+      const startTime = new Date(timetableItem.start_time);
+      const returnStartTime = returnTimetableItem ? new Date(returnTimetableItem.start_time) : null;
 
-    // OSRD describes the path in terms of nodes, NGE describes it in terms
-    // of sections between nodes. Iterate over path items two-by-two to
-    // convert them.
-    let prevPort: PortDto | null = null;
-    return pathNodeKeys.slice(0, -1).map((sourceNodeKey, i) => {
-      // Get the source node or created it
-      if (!ngeNodesByPathKey[sourceNodeKey]) {
-        ngeNodesByPathKey[sourceNodeKey] = castNodeToNge(
-          state,
-          state.getNodeByKey(sourceNodeKey)!,
-          labels
+      // OSRD describes the path in terms of nodes, NGE describes it in terms
+      // of sections between nodes. Iterate over path items two-by-two to
+      // convert them.
+      let prevPort: PortDto | null = null;
+      return pathNodeKeys.slice(0, -1).map((sourceNodeKey, i) => {
+        // returnTimetableItem contains the same path as timetableItem but in
+        // reverse order. `timetableItem.path.length - 1` is the index of the
+        // last path item, subtracting `i` will iterate from the end of the
+        // list to the start.
+        const returnIndex = timetableItem.path.length - 1 - i;
+
+        // Get the source node or created it
+        if (!ngeNodesByPathKey[sourceNodeKey]) {
+          ngeNodesByPathKey[sourceNodeKey] = castNodeToNge(
+            state,
+            state.getNodeByKey(sourceNodeKey)!,
+            labels
+          );
+        }
+        const sourceNode = ngeNodesByPathKey[sourceNodeKey];
+
+        // Get the target node or created it
+        const targetNodeKey = pathNodeKeys[i + 1];
+        if (!ngeNodesByPathKey[targetNodeKey]) {
+          ngeNodesByPathKey[targetNodeKey] = castNodeToNge(
+            state,
+            state.getNodeByKey(targetNodeKey)!,
+            labels
+          );
+        }
+        const targetNode = ngeNodesByPathKey[targetNodeKey];
+
+        // Adding port
+        const sourcePort = createPort(trainrunSectionId);
+        sourceNode.ports.push(sourcePort);
+        const targetPort = createPort(trainrunSectionId);
+        targetNode.ports.push(targetPort);
+
+        // Adding schedule
+        const sourceScheduleEntry = timetableItem.schedule!.find(
+          (entry) => entry.at === timetableItem.path[i].id
         );
-      }
-      const sourceNode = ngeNodesByPathKey[sourceNodeKey];
-
-      // Get the target node or created it
-      const targetNodeKey = pathNodeKeys[i + 1];
-      if (!ngeNodesByPathKey[targetNodeKey]) {
-        ngeNodesByPathKey[targetNodeKey] = castNodeToNge(
-          state,
-          state.getNodeByKey(targetNodeKey)!,
-          labels
+        const targetScheduleEntry = timetableItem.schedule!.find(
+          (entry) => entry.at === timetableItem.path[i + 1].id
         );
-      }
-      const targetNode = ngeNodesByPathKey[targetNodeKey];
+        const returnSourceScheduleEntry = returnTimetableItem?.schedule?.find(
+          (entry) => entry.at === returnTimetableItem.path[returnIndex].id
+        );
+        const returnTargetScheduleEntry = returnTimetableItem?.schedule?.find(
+          (entry) => entry.at === returnTimetableItem.path[returnIndex - 1].id
+        );
 
-      // Adding port
-      const sourcePort = createPort(trainrunSectionId);
-      sourceNode.ports.push(sourcePort);
-      const targetPort = createPort(trainrunSectionId);
-      targetNode.ports.push(targetPort);
+        // Create a transition between the previous section and the one we're creating
+        if (prevPort) {
+          const transition = createTransition(prevPort.id, sourcePort.id);
+          transition.isNonStopTransit = !sourceScheduleEntry?.stop_for;
+          sourceNode.transitions.push(transition);
+        }
+        prevPort = targetPort;
 
-      // Adding schedule
-      const sourceScheduleEntry = timetableItem.schedule!.find(
-        (entry) => entry.at === timetableItem.path[i].id
-      );
-      const targetScheduleEntry = timetableItem.schedule!.find(
-        (entry) => entry.at === timetableItem.path[i + 1].id
-      );
+        let sourceDeparture;
+        if (i === 0) {
+          sourceDeparture = createTimeLock(startTime, startTime);
+        } else {
+          sourceDeparture = createDepartureTimeLock(sourceScheduleEntry, startTime);
+        }
 
-      // Create a transition between the previous section and the one we're creating
-      if (prevPort) {
-        const transition = createTransition(prevPort.id, sourcePort.id);
-        transition.isNonStopTransit = !sourceScheduleEntry?.stop_for;
-        sourceNode.transitions.push(transition);
-      }
-      prevPort = targetPort;
+        const targetArrival = createArrivalTimeLock(targetScheduleEntry, startTime);
 
-      let sourceDeparture;
-      if (i === 0) {
-        sourceDeparture = createTimeLock(startTime, startTime);
-      } else {
-        sourceDeparture = createDepartureTimeLock(sourceScheduleEntry, startTime);
-      }
+        let targetDeparture = { ...DEFAULT_TIME_LOCK };
+        if (returnStartTime) {
+          if (returnIndex === 1) {
+            targetDeparture = createTimeLock(returnStartTime, returnStartTime);
+          } else {
+            targetDeparture = createDepartureTimeLock(returnTargetScheduleEntry, returnStartTime);
+          }
+        }
 
-      const targetArrival = createArrivalTimeLock(targetScheduleEntry, startTime);
+        let sourceArrival = { ...DEFAULT_TIME_LOCK };
+        if (returnStartTime) {
+          sourceArrival = createArrivalTimeLock(returnSourceScheduleEntry, returnStartTime);
+        }
 
-      const travelTime = { ...DEFAULT_TIME_LOCK };
-      if (targetArrival.consecutiveTime !== null && sourceDeparture.consecutiveTime !== null) {
-        travelTime.time = targetArrival.consecutiveTime - sourceDeparture.consecutiveTime;
-        travelTime.consecutiveTime = travelTime.time;
-      }
+        const travelTime = { ...DEFAULT_TIME_LOCK };
+        if (targetArrival.consecutiveTime !== null && sourceDeparture.consecutiveTime !== null) {
+          travelTime.time = targetArrival.consecutiveTime - sourceDeparture.consecutiveTime;
+          travelTime.consecutiveTime = travelTime.time;
+        }
 
-      const trainrunSection = {
-        id: trainrunSectionId,
-        sourceNodeId: sourceNode.id,
-        sourcePortId: sourcePort.id,
-        targetNodeId: targetNode.id,
-        targetPortId: targetPort.id,
-        travelTime,
-        sourceDeparture,
-        sourceArrival: { ...DEFAULT_TIME_LOCK },
-        targetDeparture: { ...DEFAULT_TIME_LOCK },
-        targetArrival,
-        numberOfStops: 0,
-        trainrunId: index + 1,
-        resourceId: state.ngeResource.id,
-        path: {
-          path: [],
-          textPositions: [],
-        },
-        specificTrainrunSectionFrequencyId: 0,
-        warnings: [],
-      };
+        const trainrunSection = {
+          id: trainrunSectionId,
+          sourceNodeId: sourceNode.id,
+          sourcePortId: sourcePort.id,
+          targetNodeId: targetNode.id,
+          targetPortId: targetPort.id,
+          travelTime,
+          sourceDeparture,
+          sourceArrival,
+          targetDeparture,
+          targetArrival,
+          numberOfStops: 0,
+          trainrunId: index + 1,
+          resourceId: state.ngeResource.id,
+          path: {
+            path: [],
+            textPositions: [],
+          },
+          specificTrainrunSectionFrequencyId: 0,
+          warnings: [],
+        };
 
-      trainrunSectionId += 1;
-      return trainrunSection;
-    });
-  });
+        trainrunSectionId += 1;
+        return trainrunSection;
+      });
+    }
+  );
 
   return {
     trainrunSections,
@@ -540,12 +573,12 @@ const getNgeLabels = (state: MacroEditorState): LabelDto[] =>
  */
 export const getNgeDto = (
   state: MacroEditorState,
-  timetableItems: TimetableItem[]
+  groupedTimetableItems: (readonly [TimetableItem, TimetableItem | null])[]
 ): NetzgrafikDto => {
   const labels = getNgeLabels(state);
   return {
-    ...getNgeTrainrunSectionsWithNodes(state, timetableItems, labels),
-    trainruns: getNgeTrainruns(state, timetableItems, labels),
+    ...getNgeTrainrunSectionsWithNodes(state, groupedTimetableItems, labels),
+    trainruns: getNgeTrainruns(state, groupedTimetableItems, labels),
     resources: [state.ngeResource],
     metadata: {
       netzgrafikColors: getNetzgrafikColors(),
@@ -578,6 +611,24 @@ const fetchTimetableItemPathOps = async (
     )
   ).unwrap();
   return addPathOpsToTimetableItems(timetableItems, opRefs, ops);
+};
+
+const groupCompatibleRoundTrips = (
+  roundTripGroups: TimetableItemRoundTripGroups
+): (readonly [TimetableItemWithPathOps, TimetableItemWithPathOps | null])[] => {
+  const incompatible = [];
+  const compatible = [];
+  for (const [a, b] of roundTripGroups.roundTrips) {
+    if (checkRoundTripCompatible(a, b)) {
+      compatible.push([a, b] as const);
+    } else {
+      incompatible.push(a, b);
+    }
+  }
+  const oneWays = [...roundTripGroups.oneWays, ...roundTripGroups.others, ...incompatible].map(
+    (timetableItem) => [timetableItem, null] as const
+  );
+  return [...oneWays, ...compatible];
 };
 
 export const loadNgeDto = async (
@@ -618,6 +669,30 @@ export const loadNgeDto = async (
     dispatch
   );
 
+  const timetableItemsById = new Map(
+    timetableItems.map((timetableItem) => [timetableItem.id, timetableItem])
+  );
+
+  const trainScheduleRoundTripsPromise = dispatch(
+    osrdEditoastApi.endpoints.getTimetableByIdRoundTripsTrainSchedules.initiate(
+      { id: timetableId },
+      { subscribe: false }
+    )
+  );
+  const pacedTrainRoundTripsPromise = dispatch(
+    osrdEditoastApi.endpoints.getTimetableByIdRoundTripsPacedTrains.initiate(
+      { id: timetableId },
+      { subscribe: false }
+    )
+  );
+  const { results: trainScheduleRoundTrips } = await trainScheduleRoundTripsPromise.unwrap();
+  const { results: pacedTrainRoundTrips } = await pacedTrainRoundTripsPromise.unwrap();
+  const roundTripGroups = groupRoundTrips(timetableItemsById, {
+    trainSchedules: trainScheduleRoundTrips,
+    pacedTrains: pacedTrainRoundTrips,
+  });
+  const groupedTimetableItems = groupCompatibleRoundTrips(roundTripGroups);
+
   await loadAndIndexNge(state, timetableItems, dispatch, t);
-  return getNgeDto(state, timetableItems);
+  return getNgeDto(state, groupedTimetableItems);
 };

--- a/front/src/applications/operationalStudies/components/NGE/types.ts
+++ b/front/src/applications/operationalStudies/components/NGE/types.ts
@@ -55,6 +55,7 @@ export type TrainrunDto = {
   frequencyId: number;
   trainrunTimeCategoryId: number;
   labelIds: (number | string)[];
+  trainrunDirection: 'one_way' | 'round_trip';
 };
 
 export type TimeLockDto = {

--- a/front/src/applications/operationalStudies/components/Scenario/ScenarioContent.tsx
+++ b/front/src/applications/operationalStudies/components/Scenario/ScenarioContent.tsx
@@ -4,17 +4,13 @@ import { ChevronRight } from '@osrd-project/ui-icons';
 import { useTranslation } from 'react-i18next';
 
 import { handleOperation } from 'applications/operationalStudies/components/MacroEditor/ngeToOsrd';
-import {
-  loadAndIndexNge,
-  getNgeDto,
-} from 'applications/operationalStudies/components/MacroEditor/osrdToNge';
+import { loadNgeDto } from 'applications/operationalStudies/components/MacroEditor/osrdToNge';
 import type { NetzgrafikDto, NGEEvent } from 'applications/operationalStudies/components/NGE/types';
 import { MANAGE_TIMETABLE_ITEM_TYPES } from 'applications/operationalStudies/consts';
 import useScenarioData from 'applications/operationalStudies/hooks/useScenarioData';
 import type { Board } from 'applications/operationalStudies/types';
 import ManageTimetableItemModal from 'applications/operationalStudies/views/ManageTimetableItemModal';
 import SimulationResults from 'applications/operationalStudies/views/SimulationResults';
-import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import type { Conflict, InfraWithState, ScenarioResponse } from 'common/api/osrdEditoastApi';
 import { Loader } from 'common/Loaders';
 import ConflictsList from 'modules/conflict/components/ConflictsList';
@@ -27,7 +23,7 @@ import type {
 } from 'reducers/osrdconf/types';
 import { updateSelectedTrainId } from 'reducers/simulationResults';
 import { useAppDispatch } from 'store';
-import { formatEditoastIdToPacedTrainId, formatEditoastIdToTrainScheduleId } from 'utils/trainId';
+import { formatEditoastIdToTrainScheduleId } from 'utils/trainId';
 
 import MacroEditorState from '../MacroEditor/MacroEditorState';
 import NGE from '../NGE';
@@ -74,39 +70,13 @@ const ScenarioContent = ({
   const [ngeIsLoading, setNGEIsLoading] = useState(true);
 
   const refreshNge = useCallback(async () => {
-    const trainSchedulesPromise = dispatch(
-      osrdEditoastApi.endpoints.getAllTimetableByIdTrainSchedules.initiate(
-        { timetableId: scenario?.timetable_id },
-        { forceRefetch: true, subscribe: false }
-      )
-    );
-    const trainSchedules = (await trainSchedulesPromise.unwrap())
-      .filter((trainSchedule) => trainSchedule.path.length >= 2)
-      .map((trainSchedule) => ({
-        ...trainSchedule,
-        id: formatEditoastIdToTrainScheduleId(trainSchedule.id),
-      }));
-    const pacedTrainsPromise = dispatch(
-      osrdEditoastApi.endpoints.getAllTimetableByIdPacedTrains.initiate(
-        { timetableId: scenario?.timetable_id },
-        { forceRefetch: true, subscribe: false }
-      )
-    );
-    const pacedTrains = (await pacedTrainsPromise.unwrap())
-      .filter((pacedTrain) => pacedTrain.path.length >= 2)
-      .map((pacedTrain) => ({
-        ...pacedTrain,
-        id: formatEditoastIdToPacedTrainId(pacedTrain.id),
-      }));
     const state = new MacroEditorState(
       infra.id,
       scenario.id,
       scenario.study_id,
       scenario.project.id
     );
-    const ngeTimetableItems = [...trainSchedules, ...pacedTrains];
-    await loadAndIndexNge(state, ngeTimetableItems, dispatch, t);
-    const dto = getNgeDto(state, ngeTimetableItems);
+    const dto = await loadNgeDto(state, scenario.timetable_id, dispatch, t);
     macroEditorState.current = state;
     setNgeDto(dto);
   }, [

--- a/front/src/applications/operationalStudies/hooks/useTimetableItemsWithPathOps.ts
+++ b/front/src/applications/operationalStudies/hooks/useTimetableItemsWithPathOps.ts
@@ -1,43 +1,19 @@
 import { useMemo } from 'react';
 
-import {
-  osrdEditoastApi,
-  type OperationalPoint,
-  type PathItemLocation,
-} from 'common/api/osrdEditoastApi';
+import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import type { TimetableItem, TimetableItemWithPathOps } from 'reducers/osrdconf/types';
 
-import { isOperationalPointReference } from '../utils';
+import { getUniqueOpRefsFromTimetableItems, addPathOpsToTimetableItems } from '../utils';
 
 const useTimetableItemsWithPathOps = (
   infraId: number,
   timetableItems: TimetableItem[] | undefined
-) => {
+): TimetableItemWithPathOps[] => {
   // Extract all unique PathItemLocation from timetableItems.path
-  const { timetableOpRefs, timetableItemsWithKeys } = useMemo(() => {
-    if (!timetableItems) return { timetableOpRefs: [], timetableItemsWithKeys: [] };
-    const uniqueSteps = new Map<string, PathItemLocation>();
-    const timetableItemsDict: { timetableItem: TimetableItem; pathStepKeys: string[] }[] = [];
-    for (const timetableItem of timetableItems) {
-      const pathStepKeys = [];
-      for (const pathItem of timetableItem.path) {
-        const { id: _id, deleted: _deleted, ...cleanPathItem } = pathItem;
-        const pathItemLocation: PathItemLocation = cleanPathItem;
-        const key = JSON.stringify(pathItemLocation);
-        uniqueSteps.set(key, pathItemLocation);
-        pathStepKeys.push(key);
-      }
-      // Keep for each timetableItem, the keys of its path steps, this will help later
-      // to match them with their corresponding operational points
-      timetableItemsDict.push({ timetableItem, pathStepKeys });
-    }
-    return {
-      timetableOpRefs: Array.from(uniqueSteps.values()).filter((pathItem) =>
-        isOperationalPointReference(pathItem)
-      ),
-      timetableItemsWithKeys: timetableItemsDict,
-    };
-  }, [timetableItems]);
+  const timetableOpRefs = useMemo(
+    () => getUniqueOpRefsFromTimetableItems(timetableItems ?? []),
+    [timetableItems]
+  );
 
   const { currentData: timetableOperationalPoints } =
     osrdEditoastApi.endpoints.matchAllOperationalPoints.useQuery(
@@ -48,31 +24,12 @@ const useTimetableItemsWithPathOps = (
       { skip: timetableOpRefs.length === 0 }
     );
 
-  const timetableItemsWithOps: TimetableItemWithPathOps[] = useMemo(() => {
-    if (!timetableOperationalPoints || timetableOperationalPoints.length === 0) {
+  return useMemo(() => {
+    if (!timetableItems || !timetableOperationalPoints || timetableOperationalPoints.length === 0) {
       return [];
     }
-
-    // Map each operational point reference (path step) to its corresponding operational points
-    const opsByKey = new Map<string, OperationalPoint[]>();
-    timetableOperationalPoints.forEach((ops, i) => {
-      const key = JSON.stringify(timetableOpRefs[i]);
-      opsByKey.set(key, ops);
-    });
-
-    // For each timetable item, fill the pathOps property with
-    // their corresponding operational points
-    return timetableItemsWithKeys.map(({ timetableItem, pathStepKeys }) => {
-      // For each pathStepKeys, find its corresponding operational points :
-      // 1. if found, return the operational points
-      // 2. if key exists but no operational points were found, return an empty array
-      // 3. if key does not exist in opsByKey (meaning it's a track offset), return an empty array
-      const pathOps = pathStepKeys.map((key) => opsByKey.get(key) ?? []);
-      return { ...timetableItem, pathOps };
-    });
-  }, [timetableOperationalPoints]);
-
-  return timetableItemsWithOps;
+    return addPathOpsToTimetableItems(timetableItems, timetableOpRefs, timetableOperationalPoints);
+  }, [timetableItems, timetableOperationalPoints]);
 };
 
 export default useTimetableItemsWithPathOps;

--- a/front/src/applications/operationalStudies/types.ts
+++ b/front/src/applications/operationalStudies/types.ts
@@ -14,7 +14,7 @@ import type {
 import type { RangedValue } from 'common/types';
 import type { PathOperationalPoint } from 'modules/simulationResult/types';
 import type { SuggestedOP } from 'modules/timetableItem/components/ManageTimetableItem/types';
-import type { Train } from 'reducers/osrdconf/types';
+import type { Train, TimetableItemWithPathOps } from 'reducers/osrdconf/types';
 import type { Duration } from 'utils/duration';
 import type { ArrayElement } from 'utils/types';
 
@@ -126,4 +126,10 @@ export type OperationalPointWithTimeAndSpeed = {
   line_name: string | null;
   track_name: string | null;
   ch?: string | null;
+};
+
+export type TimetableItemRoundTripGroups = {
+  oneWays: TimetableItemWithPathOps[];
+  roundTrips: (readonly [TimetableItemWithPathOps, TimetableItemWithPathOps])[];
+  others: TimetableItemWithPathOps[];
 };

--- a/front/src/applications/operationalStudies/utils.ts
+++ b/front/src/applications/operationalStudies/utils.ts
@@ -13,7 +13,7 @@ import type {
 } from 'common/api/osrdEditoastApi';
 import getPathVoltages from 'modules/pathfinding/helpers/getPathVoltages';
 import { ARRIVAL_TIME_ACCEPTABLE_ERROR } from 'modules/timesStops/consts';
-import type { TimetableItem } from 'reducers/osrdconf/types';
+import type { TimetableItem, TimetableItemWithPathOps } from 'reducers/osrdconf/types';
 import { Duration } from 'utils/duration';
 import { mmToM } from 'utils/physics';
 import { SMALL_INPUT_MAX_LENGTH } from 'utils/strings';
@@ -304,3 +304,62 @@ export const isOperationalPointReference = (
 
 export const getStationFromOps = (ops: OperationalPoint[]): OperationalPoint | undefined =>
   ops.find((op) => ['BV', '00'].includes(op.extensions?.sncf?.ch || '')) || ops.at(0);
+
+/**
+ * Get a path item location (without ID and deleted fields) from a train's path
+ * item.
+ */
+const getPathItemLocation = (pathItem: TrainSchedule['path'][number]) => {
+  const { id: _id, deleted: _deleted, ...pathItemLocation } = pathItem;
+  return pathItemLocation;
+};
+
+/**
+ * Get a list of unique OP references from timetable items paths.
+ */
+export const getUniqueOpRefsFromTimetableItems = (
+  timetableItems: TimetableItem[]
+): OperationalPointReference[] => {
+  const pathItems = timetableItems.flatMap((timetableItem) => timetableItem.path);
+  const uniqueSteps = new Map<string, OperationalPointReference>();
+  for (const pathItem of pathItems) {
+    const pathItemLocation = getPathItemLocation(pathItem);
+    if (!isOperationalPointReference(pathItemLocation)) continue;
+    uniqueSteps.set(JSON.stringify(pathItemLocation), pathItemLocation);
+  }
+  return [...uniqueSteps.values()];
+};
+
+/**
+ * Attach OPs to timetable items, given a list of OP references and their
+ * matchAllOperationalPoints response.
+ */
+export const addPathOpsToTimetableItems = (
+  timetableItems: TimetableItem[],
+  timetableOpRefs: OperationalPointReference[],
+  timetableOperationalPoints: OperationalPoint[][]
+): TimetableItemWithPathOps[] => {
+  if (timetableOpRefs.length !== timetableOperationalPoints.length) {
+    throw new Error('Expected as many OP match lists as OP refs');
+  }
+
+  // Map each operational point reference (path step) to its corresponding operational points
+  const opsByKey = new Map<string, OperationalPoint[]>();
+  timetableOperationalPoints.forEach((ops, i) => {
+    const key = JSON.stringify(timetableOpRefs[i]);
+    opsByKey.set(key, ops);
+  });
+
+  // For each timetable item, fill the pathOps property with
+  // their corresponding operational points
+  return timetableItems.map((timetableItem) => {
+    // For each pathStepKeys, find its corresponding operational points :
+    // 1. if found, return the operational points
+    // 2. if key exists but no operational points were found, return an empty array
+    // 3. if key does not exist in opsByKey (meaning it's a track offset), return an empty array
+    const pathOps = timetableItem.path.map(
+      (pathItem) => opsByKey.get(JSON.stringify(getPathItemLocation(pathItem))) ?? []
+    );
+    return { ...timetableItem, pathOps };
+  });
+};

--- a/front/src/applications/operationalStudies/utils.ts
+++ b/front/src/applications/operationalStudies/utils.ts
@@ -8,17 +8,26 @@ import type {
   PathItemLocation,
   PathProperties,
   RelatedOperationalPoint,
+  RoundTrips,
   SimulationResponseSuccess,
   SimulationSummaryResult,
   TrainSchedule,
 } from 'common/api/osrdEditoastApi';
 import getPathVoltages from 'modules/pathfinding/helpers/getPathVoltages';
 import { ARRIVAL_TIME_ACCEPTABLE_ERROR } from 'modules/timesStops/consts';
-import type { TimetableItem, TimetableItemWithPathOps } from 'reducers/osrdconf/types';
+import type {
+  TimetableItem,
+  TimetableItemId,
+  TimetableItemWithPathOps,
+} from 'reducers/osrdconf/types';
 import { Duration } from 'utils/duration';
 import { mmToM } from 'utils/physics';
 import { SMALL_INPUT_MAX_LENGTH } from 'utils/strings';
-import { isPacedTrainResponseWithPacedTrainId } from 'utils/trainId';
+import {
+  formatEditoastIdToPacedTrainId,
+  formatEditoastIdToTrainScheduleId,
+  isPacedTrainResponseWithPacedTrainId,
+} from 'utils/trainId';
 
 import { upsertMapWaypointsInOperationalPoints } from './helpers/upsertMapWaypointsInOperationalPoints';
 import type {
@@ -30,6 +39,7 @@ import type {
   ElectrificationValue,
   PathPropertiesFormatted,
   PositionData,
+  TimetableItemRoundTripGroups,
 } from './types';
 
 /**
@@ -446,4 +456,43 @@ export const checkRoundTripCompatible = (
   }
 
   return true;
+};
+
+/**
+ * Group timetable items in three columns: one-ways, round-trips and others.
+ */
+export const groupRoundTrips = (
+  timetableItemsById: Map<TimetableItemId, TimetableItemWithPathOps>,
+  rawRoundTrips: { trainSchedules: RoundTrips; pacedTrains: RoundTrips }
+): TimetableItemRoundTripGroups => {
+  const oneWayIds = [
+    ...(rawRoundTrips.trainSchedules.one_ways ?? []).map(formatEditoastIdToTrainScheduleId),
+    ...(rawRoundTrips.pacedTrains.one_ways ?? []).map(formatEditoastIdToPacedTrainId),
+  ];
+  const roundTripIds = [
+    ...(rawRoundTrips.trainSchedules.round_trips ?? []).map(
+      ([leftId, rightId]) =>
+        [
+          formatEditoastIdToTrainScheduleId(leftId),
+          formatEditoastIdToTrainScheduleId(rightId),
+        ] as const
+    ),
+    ...(rawRoundTrips.pacedTrains.round_trips ?? []).map(
+      ([leftId, rightId]) =>
+        [formatEditoastIdToPacedTrainId(leftId), formatEditoastIdToPacedTrainId(rightId)] as const
+    ),
+  ];
+
+  const oneWays = oneWayIds.map((id) => timetableItemsById.get(id)!);
+  const roundTrips = roundTripIds.map(
+    ([leftId, rightId]) =>
+      [timetableItemsById.get(leftId)!, timetableItemsById.get(rightId)!] as const
+  );
+
+  const oneWayOrRoundTripIds = new Set<TimetableItemId>([...oneWayIds, ...roundTripIds.flat()]);
+  const others = [...timetableItemsById.values()].filter(
+    (timetableItem) => !oneWayOrRoundTripIds.has(timetableItem.id)
+  );
+
+  return { oneWays, roundTrips, others };
 };

--- a/front/src/applications/operationalStudies/utils.ts
+++ b/front/src/applications/operationalStudies/utils.ts
@@ -7,6 +7,7 @@ import type {
   PathfindingResultSuccess,
   PathItemLocation,
   PathProperties,
+  RelatedOperationalPoint,
   SimulationResponseSuccess,
   SimulationSummaryResult,
   TrainSchedule,
@@ -337,14 +338,14 @@ export const getUniqueOpRefsFromTimetableItems = (
 export const addPathOpsToTimetableItems = (
   timetableItems: TimetableItem[],
   timetableOpRefs: OperationalPointReference[],
-  timetableOperationalPoints: OperationalPoint[][]
+  timetableOperationalPoints: RelatedOperationalPoint[][]
 ): TimetableItemWithPathOps[] => {
   if (timetableOpRefs.length !== timetableOperationalPoints.length) {
     throw new Error('Expected as many OP match lists as OP refs');
   }
 
   // Map each operational point reference (path step) to its corresponding operational points
-  const opsByKey = new Map<string, OperationalPoint[]>();
+  const opsByKey = new Map<string, RelatedOperationalPoint[]>();
   timetableOperationalPoints.forEach((ops, i) => {
     const key = JSON.stringify(timetableOpRefs[i]);
     opsByKey.set(key, ops);

--- a/front/src/applications/operationalStudies/utils.ts
+++ b/front/src/applications/operationalStudies/utils.ts
@@ -1,5 +1,5 @@
 import type { TFunction } from 'i18next';
-import type { Dictionary } from 'lodash';
+import { type Dictionary, isEqual } from 'lodash';
 
 import type {
   OperationalPoint,
@@ -18,6 +18,7 @@ import type { TimetableItem, TimetableItemWithPathOps } from 'reducers/osrdconf/
 import { Duration } from 'utils/duration';
 import { mmToM } from 'utils/physics';
 import { SMALL_INPUT_MAX_LENGTH } from 'utils/strings';
+import { isPacedTrainResponseWithPacedTrainId } from 'utils/trainId';
 
 import { upsertMapWaypointsInOperationalPoints } from './helpers/upsertMapWaypointsInOperationalPoints';
 import type {
@@ -363,4 +364,86 @@ export const addPathOpsToTimetableItems = (
     );
     return { ...timetableItem, pathOps };
   });
+};
+
+/**
+ * Check whether a timetable item can be seen as the return of another
+ * timetable item. If this function returns true, we can draw a single line to
+ * represent the round-trip in the macro editor.
+ */
+export const checkRoundTripCompatible = (
+  timetableItemA: TimetableItemWithPathOps,
+  timetableItemB: TimetableItemWithPathOps
+): boolean => {
+  if (
+    isPacedTrainResponseWithPacedTrainId(timetableItemA) !==
+    isPacedTrainResponseWithPacedTrainId(timetableItemB)
+  ) {
+    return false;
+  }
+  if (
+    isPacedTrainResponseWithPacedTrainId(timetableItemA) &&
+    isPacedTrainResponseWithPacedTrainId(timetableItemB) &&
+    timetableItemA.paced.interval !== timetableItemB.paced.interval
+  ) {
+    return false;
+  }
+  if (!isEqual(timetableItemA.category, timetableItemB.category)) {
+    return false;
+  }
+  if (timetableItemA.pathOps.length !== timetableItemB.pathOps.length) {
+    return false;
+  }
+
+  for (const [indexA, opsA] of timetableItemA.pathOps.entries()) {
+    const indexB = timetableItemA.pathOps.length - indexA - 1;
+    const opsB = timetableItemB.pathOps[indexB];
+
+    const pathItemA = timetableItemA.path[indexA];
+    const pathItemB = timetableItemB.path[indexB];
+
+    const aExists = opsA.length > 0;
+    const bExists = opsB.length > 0;
+    if (aExists !== bExists) {
+      return false;
+    }
+    if (aExists && bExists) {
+      const stationA = getStationFromOps(opsA)!;
+      const stationB = getStationFromOps(opsB)!;
+      if (stationA.id !== stationB.id) {
+        return false;
+      }
+    } else {
+      // id is specific to each timetable item
+      // track_reference is ignored because we don't want to take tracks into account
+      // Only take into account uic/trigram/opId of the path items
+      const opRefA = {
+        ...pathItemA,
+        id: undefined,
+        deleted: undefined,
+        track_reference: undefined,
+      };
+      const opRefB = {
+        ...pathItemB,
+        id: undefined,
+        deleted: undefined,
+        track_reference: undefined,
+      };
+
+      if (!isEqual(opRefA, opRefB)) {
+        return false;
+      }
+    }
+
+    const scheduleItemA = timetableItemA.schedule?.find(({ at }) => at === pathItemA.id);
+    const scheduleItemB = timetableItemB.schedule?.find(({ at }) => at === pathItemB.id);
+
+    const isStopA = indexA === 0 || Boolean(scheduleItemA?.stop_for);
+    const isStopB = indexB === 0 || Boolean(scheduleItemB?.stop_for);
+    if (isStopA !== isStopB) {
+      return false;
+    }
+  }
+
+  return true;
 };

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -17,7 +17,7 @@ import {
   type PacedTrainResponse,
   type PathfindingResult,
   type SimulationResponse,
-  type OperationalPoint,
+  type RelatedOperationalPoint,
   type OperationalPointReference,
 } from './generatedEditoastApi';
 
@@ -189,12 +189,12 @@ const osrdEditoastApi = generatedEditoastApi
         providesTags: ['train_schedule'],
       }),
       matchAllOperationalPoints: builder.query<
-        OperationalPoint[][],
+        RelatedOperationalPoint[][],
         { infraId: number; opRefs: OperationalPointReference[] }
       >({
         queryFn: async ({ infraId, opRefs }, { dispatch }) => {
           const batchSize = 200;
-          const result: OperationalPoint[][] = [];
+          const result: RelatedOperationalPoint[][] = [];
 
           // Split opRefs into batches of 200
           for (let i = 0; i < opRefs.length; i += batchSize) {

--- a/front/src/reducers/osrdconf/types.ts
+++ b/front/src/reducers/osrdconf/types.ts
@@ -13,7 +13,7 @@ import type {
   Comfort,
   Distribution,
   LoadingGaugeType,
-  OperationalPoint,
+  RelatedOperationalPoint,
   OperationalPointReference,
   PacedTrain,
   PathItemLocation,
@@ -192,4 +192,4 @@ export type TrainBaseWithOccurrenceId = TrainSchedule & {
 export type TimetableItem = TrainScheduleWithTrainId | PacedTrainWithPacedTrainId;
 export type Train = TrainScheduleWithTrainId | TrainBaseWithOccurrenceId;
 
-export type TimetableItemWithPathOps = TimetableItem & { pathOps: OperationalPoint[][] };
+export type TimetableItemWithPathOps = TimetableItem & { pathOps: RelatedOperationalPoint[][] };


### PR DESCRIPTION
To test:

- Create a new small_infra scenario
- Import the following timetable: [timetable(2).json](https://github.com/user-attachments/files/21489212/timetable.2.json)
- Apply the hack patch below, because the backend side isn't ready yet
- Select the return train schedule
- Enable the macro editor
- Compare the times table with the macro editor

<details>

<summary>Hack patch</summary>

To apply, run `git apply`, paste the diff below, then press Ctrl+D.

```diff
diff --git a/front/src/applications/operationalStudies/utils.ts b/front/src/applications/operationalStudies/utils.ts
index cff2ffa5407d..c1538b70c36c 100644
--- a/front/src/applications/operationalStudies/utils.ts
+++ b/front/src/applications/operationalStudies/utils.ts
@@ -484,7 +484,7 @@ export const groupRoundTrips = (
   ];
 
   const oneWays = oneWayIds.map((id) => timetableItemsById.get(id)!);
-  const roundTrips = roundTripIds.map(
+  let roundTrips = roundTripIds.map(
     ([leftId, rightId]) =>
       [timetableItemsById.get(leftId)!, timetableItemsById.get(rightId)!] as const
   );
@@ -494,5 +494,15 @@ export const groupRoundTrips = (
     (timetableItem) => !oneWayOrRoundTripIds.has(timetableItem.id)
   );
 
-  return { oneWays, roundTrips, others };
+  others.sort((a, _b) =>
+    a.train_name.includes('sava') || a.train_name.includes('THE RETURN') ? 1 : -1
+  );
+
+  for (let i = 0; i < others.length; i += 2) {
+    if (i < others.length - 1) {
+      roundTrips.push([others[i], others[i + 1]] as const);
+    }
+  }
+
+  return { oneWays, roundTrips, others: [] };
 };
```

</details>

Reviewers are advised to review this PR commit-by-commit and disable whitespace changes in the diff view.

Closes: https://github.com/OpenRailAssociation/osrd/issues/12339