### PR TITLE
front: remove redundant 'networkidle' waits 

### DIFF
--- a/front/tests/005-rolling-stock-editor.spec.ts
+++ b/front/tests/005-rolling-stock-editor.spec.ts
@@ -44,6 +44,7 @@ test.describe('Rollingstock editor page tests', () => {
 
       // Navigate to the rolling stock editor page
       await rollingStockEditorPage.navigateToRollingStockPage();
+      await rollingStockEditorPage.verifyFirstRollingStockCardVisibility();
     }
   );
 

--- a/front/tests/010-stdcm.spec.ts
+++ b/front/tests/010-stdcm.spec.ts
@@ -73,10 +73,7 @@ test.describe('Verify stdcm simulation page', () => {
     ];
 
     await page.goto('/stdcm');
-    await page.waitForLoadState('networkidle');
     await stdcmPage.removeViteOverlay();
-
-    // Wait for infra to be in 'CACHED' state before proceeding
     await waitForInfraStateToBeCached(infra.id);
   });
 

--- a/front/tests/011-stdcm-simulation-sheet.spec.ts
+++ b/front/tests/011-stdcm-simulation-sheet.spec.ts
@@ -64,7 +64,6 @@ test.describe('Verify stdcm simulation page', () => {
       new SimulationResultPage(page),
     ];
     await page.goto('/stdcm');
-    await page.waitForLoadState('networkidle');
     await stdcmPage.removeViteOverlay();
 
     // Wait for infra to be in 'CACHED' state before proceeding

--- a/front/tests/012-stdcm-feedback-mail.spec.ts
+++ b/front/tests/012-stdcm-feedback-mail.spec.ts
@@ -51,7 +51,6 @@ test.describe('FeedbackCard Tests', () => {
       new SimulationResultPage(page),
     ];
     await page.goto('/stdcm');
-    await page.waitForLoadState('networkidle');
     await stdcmPage.removeViteOverlay();
     // Wait for infra to be in 'CACHED' state before proceeding
     await waitForInfraStateToBeCached(infra.id);

--- a/front/tests/013-stdcm-linked-train.spec.ts
+++ b/front/tests/013-stdcm-linked-train.spec.ts
@@ -69,7 +69,6 @@ test.describe('Verify stdcm simulation page', () => {
     ];
     // Navigate to STDCM page
     await page.goto('/stdcm');
-    await page.waitForLoadState('networkidle');
     await stdcmPage.removeViteOverlay();
 
     // Wait for infra to be in 'CACHED' state before proceeding

--- a/front/tests/014-stdcm-missing-fields.spec.ts
+++ b/front/tests/014-stdcm-missing-fields.spec.ts
@@ -45,7 +45,6 @@ test.describe('Verify stdcm missing fields', () => {
     ];
 
     await page.goto('/stdcm');
-    await page.waitForLoadState('networkidle');
     await stdcmPage.removeViteOverlay();
 
     // Wait for infra to be in 'CACHED' state before proceeding

--- a/front/tests/015-train-timetable.spec.ts
+++ b/front/tests/015-train-timetable.spec.ts
@@ -79,10 +79,7 @@ test.describe('Verify train schedule elements and filters', () => {
       `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenario.id}`
     );
     await operationalStudiesPage.removeViteOverlay();
-    // Wait for infra to be in 'CACHED' state before proceeding
     await waitForInfraStateToBeCached(infra.id);
-
-    await page.waitForLoadState('networkidle');
   });
 
   /** *************** Test 1 **************** */

--- a/front/tests/016-train-timetable-multiselection.spec.ts
+++ b/front/tests/016-train-timetable-multiselection.spec.ts
@@ -69,7 +69,6 @@ test.describe('Verify train schedule elements and filters', () => {
       `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenarioItems.id}`
     );
     await waitForInfraStateToBeCached(infra.id);
-    await page.waitForLoadState('networkidle');
   });
 
   test('Duplicate and delete a paced train', async ({ page }) => {
@@ -93,7 +92,6 @@ test.describe('Verify train schedule elements and filters', () => {
       TOTAL_TIMETABLE_ITEMS,
       frTranslations
     );
-    await page.waitForLoadState('networkidle');
     // Verify timetable is empty and total label is empty
     await scenarioTimetableSection.verifyTimetableIsEmpty(frTranslations.timetable.noTrain);
   });

--- a/front/tests/017-paced-train-management.spec.ts
+++ b/front/tests/017-paced-train-management.spec.ts
@@ -129,10 +129,7 @@ test.describe('Verify simulation configuration in operational studies for train 
     );
     await operationalStudiesPage.removeViteOverlay();
 
-    // Wait for infra to be in 'CACHED' state before proceeding
     await waitForInfraStateToBeCached(infra.id);
-
-    await page.waitForLoadState('networkidle');
   });
 
   /** *************** Test 1 **************** */
@@ -213,7 +210,6 @@ test.describe('Verify simulation configuration in operational studies for train 
   /** *************** Test 3 **************** */
   test('Duplicate and delete a paced train', async ({ page }) => {
     await sendPacedTrains(scenario.timetable_id, pacedTrainsJson);
-    await waitForTrainSchedulesAndPacedTrains(scenario.timetable_id);
 
     // to trigger list of paced train initialization for this e2e test, which isn't needed locally
     await page.reload();

--- a/front/tests/017-paced-train-management.spec.ts
+++ b/front/tests/017-paced-train-management.spec.ts
@@ -213,6 +213,7 @@ test.describe('Verify simulation configuration in operational studies for train 
   /** *************** Test 3 **************** */
   test('Duplicate and delete a paced train', async ({ page }) => {
     await sendPacedTrains(scenario.timetable_id, pacedTrainsJson);
+    await waitForTrainSchedulesAndPacedTrains(scenario.timetable_id);
 
     // to trigger list of paced train initialization for this e2e test, which isn't needed locally
     await page.reload();

--- a/front/tests/018-train-edition.spec.ts
+++ b/front/tests/018-train-edition.spec.ts
@@ -97,7 +97,6 @@ test.describe('Edit train schedules and paced trains', () => {
         `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenarioItems.id}`
       );
       await waitForInfraStateToBeCached(infra.id);
-      await page.waitForLoadState('networkidle');
     }
   );
 

--- a/front/tests/019-scenario-page-synchronization.spec.ts
+++ b/front/tests/019-scenario-page-synchronization.spec.ts
@@ -100,7 +100,6 @@ test.describe('Synchronize the scenario page across multiple windows', () => {
     // Delete a paced train in the first tab and verify the update
     await firstPage.bringToFront();
     await pacedTrainSection.deletePacedTrain(1, frTranslations);
-    await firstPage.waitForLoadState('networkidle');
     await firstTimetableSection.verifyTotalItemsLabel(frTranslations, {
       totalPacedTrainCount: 1,
       totalTrainScheduleCount: 2,

--- a/front/tests/020-paced-train-exceptions.spec.ts
+++ b/front/tests/020-paced-train-exceptions.spec.ts
@@ -118,7 +118,6 @@ test.describe('Paced trains and exception management', () => {
       `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenarioItems.id}`
     );
     await waitForInfraStateToBeCached(infra.id);
-    await page.waitForLoadState('networkidle');
   });
 
   test.afterAll('Delete the created scenario', async () => {
@@ -287,7 +286,7 @@ test.describe('Paced trains and exception management', () => {
     });
   });
 
-  test('Edit an indexed occurrence', async ({ page }) => {
+  test('Edit an indexed occurrence', async () => {
     await pacedTrainSection.clickOnPacedTrain(0);
     await pacedTrainSection.checkOccurrenceMenuIcon(0);
     await pacedTrainSection.checkOccurrenceActionMenu({
@@ -301,8 +300,6 @@ test.describe('Paced trains and exception management', () => {
     await operationalStudiesPage.checkToastHasBeenLaunched(
       frTranslations.timetable.pacedTrainUpdated
     );
-
-    await page.waitForLoadState('networkidle');
 
     await pacedTrainSection.checkExceptionTooltip(
       0,

--- a/front/tests/pages/operational-studies/paced-train-section.ts
+++ b/front/tests/pages/operational-studies/paced-train-section.ts
@@ -203,7 +203,7 @@ class PacedTrainSection extends CommonPage {
     const item = isPacedTrain
       ? this.pacedTrainItem.nth(itemIndex)
       : this.testedPacedTrainOccurrences.nth(itemIndex);
-
+    await expect(item).toBeVisible();
     await item.hover({ force: true });
 
     const actionButtons: Record<string, Locator> = {
@@ -250,7 +250,7 @@ class PacedTrainSection extends CommonPage {
     }
   ) {
     const occurrenceItem = this.getNthOccurrence(occurrenceIndex);
-
+    await expect(occurrenceItem.root).toBeVisible();
     await this.verifyOccurrenceName(occurrenceIndex, occurrenceData.name, {
       copyTranslation: duplicate?.copyTranslation,
     });
@@ -303,6 +303,7 @@ class PacedTrainSection extends CommonPage {
       itemIndex: index,
       itemType: 'paced-train',
     });
+    await expect(actionButtons.editItem).toBeVisible();
     await actionButtons.editItem.click();
     await expect(this.manageTimetableItemPage).toBeVisible();
   }
@@ -313,6 +314,7 @@ class PacedTrainSection extends CommonPage {
     pacedTrainData?: PacedTrainDetails
   ) {
     const timetableItemToDelete = await this.getPacedTrainToClickableZone(index);
+    await expect(timetableItemToDelete).toBeVisible();
     await timetableItemToDelete.click();
 
     const pacedTrainActionButtons = await this.getActionButtonsLocators({
@@ -350,6 +352,7 @@ class PacedTrainSection extends CommonPage {
     ...changeGroups: ChangeGroup[]
   ) {
     const occurrenceItem = this.getNthOccurrence(occurrenceIndex);
+    await expect(occurrenceItem.indicator).toBeVisible();
     await occurrenceItem.indicator.hover();
 
     const expectedExceptionText = title + changeGroups.join('');
@@ -359,6 +362,7 @@ class PacedTrainSection extends CommonPage {
 
   async checkOccurrenceMenuIcon(occurrenceIndex: number) {
     const occurrenceItem = this.getNthOccurrence(occurrenceIndex);
+    await expect(occurrenceItem.root).toBeVisible();
     await occurrenceItem.root.hover();
     await expect(occurrenceItem.menuIcon).toBeVisible();
   }
@@ -373,6 +377,7 @@ class PacedTrainSection extends CommonPage {
     translations: TimetableFilterTranslations;
   }) {
     const occurrenceItem = this.getNthOccurrence(occurrenceIndex);
+    await expect(occurrenceItem.menuIcon).toBeVisible();
     await occurrenceItem.menuIcon.click();
     for (const buttonName of expectedButtons) {
       const button = this.portalOccurrenceMenu[buttonName];
@@ -395,6 +400,7 @@ class PacedTrainSection extends CommonPage {
 
   async resetAllPacedTrainExceptions(pacedTrainIndex: number) {
     const timetableItemToReset = await this.getPacedTrainToClickableZone(pacedTrainIndex);
+    await expect(timetableItemToReset).toBeVisible();
     await timetableItemToReset.click();
 
     const { resetExceptions } = await this.getActionButtonsLocators({
@@ -411,6 +417,7 @@ class PacedTrainSection extends CommonPage {
   }
 
   async expectOccurrencesListLength(length: number) {
+    await expect(this.testedPacedTrainOccurrences.first()).toBeVisible();
     await expect(this.testedPacedTrainOccurrences).toHaveCount(length);
   }
 }

--- a/front/tests/pages/operational-studies/scenario-page.ts
+++ b/front/tests/pages/operational-studies/scenario-page.ts
@@ -131,7 +131,6 @@ class ScenarioPage extends CommonPage {
     tags?: string[];
     isUpdating?: boolean;
   }) {
-    await this.page.waitForLoadState('networkidle');
     await expect(this.scenarioName).toBeVisible();
     expect(await this.scenarioName.textContent()).toContain(name);
     // Wait for the scenario name to be clickable if not updating

--- a/front/tests/pages/operational-studies/scenario-timetable-section.ts
+++ b/front/tests/pages/operational-studies/scenario-timetable-section.ts
@@ -183,6 +183,7 @@ class ScenarioTimetableSection extends OpSimulationResultPage {
   }
 
   async verifyTimetableItemsCount(timetableItemsCount: number): Promise<void> {
+    await expect(this.timetableItems.first()).toBeVisible();
     await expect(this.timetableItems).toHaveCount(timetableItemsCount);
   }
 
@@ -194,6 +195,7 @@ class ScenarioTimetableSection extends OpSimulationResultPage {
     }
   ): Promise<void> {
     const { totalPacedTrainCount, totalTrainScheduleCount } = itemCounts;
+    await expect(this.timetableItems.first()).toBeVisible();
     await expect(this.timetableTotalItemLabel).toBeVisible();
 
     // Total items label has the syntax : "X services and Y trains"
@@ -309,6 +311,7 @@ class ScenarioTimetableSection extends OpSimulationResultPage {
     await this.filterTrainTypeAndVerifyTrainCount('Service', pacedTrainCount);
     for (let pacedTrainIndex = 0; pacedTrainIndex < pacedTrainCount; pacedTrainIndex += 1) {
       const pacedTrain = this.timetableItems.nth(pacedTrainIndex);
+      await expect(pacedTrain).toBeVisible();
 
       await pacedTrainSection.clickOnPacedTrain(pacedTrainIndex); // opens
 
@@ -327,6 +330,7 @@ class ScenarioTimetableSection extends OpSimulationResultPage {
 
   // Iterate over each trainSchedule and verify the visibility of simulation results
   async verifyEachTrainScheduleSimulation(trainScheduleCount: number): Promise<void> {
+    await expect(this.timetableItems.first()).toBeVisible();
     const timetableItemsCount = await this.timetableItems.count();
     for (
       let currentTrainScheduleIndex = trainScheduleCount;
@@ -344,12 +348,15 @@ class ScenarioTimetableSection extends OpSimulationResultPage {
   }
 
   async editTimetableItem(index = 0) {
+    await expect(this.timetableItems.nth(index)).toBeVisible();
     await this.timetableItems.nth(index).click();
     await this.editItemButton.nth(index).click();
   }
 
   private async projectTrain(index = 0) {
-    await this.timetableItems.nth(index).hover();
+    const item = this.timetableItems.nth(index);
+    await item.scrollIntoViewIfNeeded();
+    await item.hover();
     await expect(this.projectItemButton.nth(index)).toBeVisible();
     await this.projectItemButton.nth(index).click();
   }

--- a/front/tests/pages/rolling-stock/rolling-stock-editor-page.ts
+++ b/front/tests/pages/rolling-stock/rolling-stock-editor-page.ts
@@ -95,8 +95,6 @@ class RollingstockEditorPage extends CommonPage {
 
   async navigateToRollingStockPage() {
     await this.page.goto('/rolling-stock-editor/');
-    // Wait for the page to reach the network idle state
-    await this.page.waitForLoadState('networkidle');
     await this.removeViteOverlay();
   }
 

--- a/front/tests/pages/rolling-stock/rolling-stock-editor-page.ts
+++ b/front/tests/pages/rolling-stock/rolling-stock-editor-page.ts
@@ -15,6 +15,10 @@ const frTranslations = readJsonFile<{ rollingStock: RollingStockTranslations }>(
 ).rollingStock;
 
 class RollingstockEditorPage extends CommonPage {
+  private readonly rollingstockEditorList: Locator;
+
+  private readonly rollingstockCard: Locator;
+
   private readonly newRollingstockButton: Locator;
 
   private readonly submitRollingstockButton: Locator;
@@ -57,6 +61,8 @@ class RollingstockEditorPage extends CommonPage {
 
   constructor(page: Page) {
     super(page);
+    this.rollingstockEditorList = page.getByTestId('rollingstock-editor-list');
+    this.rollingstockCard = this.rollingstockEditorList.getByTestId(/^rollingstock-/);
     this.newRollingstockButton = page.getByTestId('new-rollingstock-button');
     this.submitRollingstockButton = page.getByTestId('submit-rollingstock-button');
     this.rollingstockDetailsButton = page.getByTestId('tab-rollingstock-details');
@@ -96,6 +102,10 @@ class RollingstockEditorPage extends CommonPage {
 
   async openNewRollingStockForm() {
     await this.newRollingstockButton.click();
+  }
+
+  async verifyFirstRollingStockCardVisibility() {
+    await expect(this.rollingstockCard.first()).toBeVisible();
   }
 
   async searchRollingStock(rollingStockName: string) {

--- a/front/tests/pages/rolling-stock/rolling-stock-selector.ts
+++ b/front/tests/pages/rolling-stock/rolling-stock-selector.ts
@@ -91,7 +91,7 @@ class RollingStockSelector extends CommonPage {
     confirmSelection?: boolean;
   }): Promise<void> {
     const rollingstockCard = this.getRollingstockCardByName(name);
-
+    await expect(rollingstockCard).toBeVisible();
     await rollingstockCard.click();
     await expect(rollingstockCard).not.toHaveClass(/inactive/);
     if (selectComfort) await this.comfortACButton.click();

--- a/front/tests/pages/stdcm/simulation-results-page.ts
+++ b/front/tests/pages/stdcm/simulation-results-page.ts
@@ -127,9 +127,6 @@ class SimulationResultPage extends STDCMPage {
   }
 
   async downloadSimulation(downloadDir: string): Promise<void> {
-    // Wait until there are no network requests for stability
-    await this.page.waitForLoadState('networkidle');
-
     // Get the download link element and suggested filename
     await expect(this.downloadLink).toBeVisible();
     const suggestedFilename = await this.downloadLink.getAttribute('download');

--- a/front/tests/pages/stdcm/simulation-results-page.ts
+++ b/front/tests/pages/stdcm/simulation-results-page.ts
@@ -131,6 +131,7 @@ class SimulationResultPage extends STDCMPage {
     await this.page.waitForLoadState('networkidle');
 
     // Get the download link element and suggested filename
+    await expect(this.downloadLink).toBeVisible();
     const suggestedFilename = await this.downloadLink.getAttribute('download');
     expect(suggestedFilename).toMatch(/^Stdcm.*\.pdf$/);
 


### PR DESCRIPTION
The tests previously used `page.waitForLoadState('networkidle')` to wait for the page to become idle. However, background HTTP requests often prevented Playwright from detecting true idleness. In some cases, the page even became idle before `page.waitForLoadState('networkidle')` was called, leading to timeouts and flaky behavior.
Also is discourged to use it :   

>  * - `'networkidle'` - **DISCOURAGED** wait until there are no network connections for at least `500` ms. Don't use
>    * this method for testing, rely on web assertions to assess readiness instead.

Solution : 

- Removed all` await page.waitForLoadState('networkidle')` usages
- Replace them with [expect.poll ](https://playwright.dev/docs/test-assertions#expectpoll) to explicitly wait until:
   - Timetable items (paced trains and train schedules) are fully loaded in the scenario page.
   - Rolling stock data is available before continuing the test.
