### PR TITLE
front: e2e: improve and fix rs get and delete

### DIFF
--- a/front/tests/utils/api-utils.ts
+++ b/front/tests/utils/api-utils.ts
@@ -6,7 +6,6 @@ import type {
   GetProjectsApiResponse,
   GetProjectsByProjectIdStudiesApiResponse,
   GetProjectsByProjectIdStudiesAndStudyIdScenariosApiResponse,
-  GetLightRollingStockApiResponse,
   LightElectricalProfileSet,
   GetInfraApiResponse,
   InfraWithState,
@@ -221,14 +220,10 @@ export const getScenario = async (
  * @returns {Promise<RollingStock>} - The matching rolling stock data.
  */
 export const getRollingStock = async (rollingStockName: string): Promise<LightRollingStock> => {
-  const rollingStocks: GetLightRollingStockApiResponse = await getApiRequest(
-    '/api/light_rolling_stock',
-    { page_size: 500 }
+  const rollingStock: LightRollingStockWithLiveries = await getApiRequest(
+    `api/light_rolling_stock/name/${encodeURIComponent(rollingStockName)}`
   );
-  const rollingStock = rollingStocks.results.find(
-    (r: LightRollingStockWithLiveries) => r.name === rollingStockName
-  );
-  return rollingStock as LightRollingStock;
+  return rollingStock;
 };
 
 /**

--- a/front/tests/utils/api-utils.ts
+++ b/front/tests/utils/api-utils.ts
@@ -20,7 +20,6 @@ import type {
   LightRollingStock,
   StdcmSearchEnvironment,
   TowedRollingStock,
-  GetTowedRollingStockApiResponse,
   PaginationStats,
 } from 'common/api/osrdEditoastApi';
 
@@ -327,11 +326,10 @@ export async function deleteStdcmEnvironment(stdcmSearchEnvId: number): Promise<
 export const getTowedRollingStockByName = async (
   towedRollingStockName: string
 ): Promise<TowedRollingStock | undefined> => {
-  const towedRollingStocks: GetTowedRollingStockApiResponse = await getApiRequest(
-    '/api/towed_rolling_stock',
-    { page_size: 50 }
-  );
-  const towedRollingStock = towedRollingStocks.results.find(
+  const towedRollingStocks: TowedRollingStock[] = await listApiRequest('/api/towed_rolling_stock', {
+    page_size: 50,
+  });
+  const towedRollingStock = towedRollingStocks.find(
     (t: TowedRollingStock) => t.name === towedRollingStockName
   );
   return towedRollingStock;

--- a/front/tests/utils/teardown-utils.ts
+++ b/front/tests/utils/teardown-utils.ts
@@ -1,9 +1,6 @@
-import type {
-  GetLightRollingStockApiResponse,
-  LightRollingStock,
-} from 'common/api/osrdEditoastApi';
+import type { LightRollingStock, LightRollingStockWithLiveries } from 'common/api/osrdEditoastApi';
 
-import { getApiRequest, deleteApiRequest, getStudy, getScenario, getProject } from './api-utils';
+import { deleteApiRequest, getStudy, getScenario, getProject, listApiRequest } from './api-utils';
 import { logger } from '../logging-fixture';
 
 /**
@@ -28,13 +25,12 @@ export async function deleteProject(projectName: string): Promise<void> {
  * @returns {Promise<void>} - A promise that resolves when the matching rolling stocks are deleted or if none are found.
  */
 export async function deleteRollingStocks(rollingStockNames: string[]): Promise<void> {
-  const rollingStocks: GetLightRollingStockApiResponse = await getApiRequest(
-    '/api/light_rolling_stock',
-    { page_size: 500 }
+  const rollingStocks: LightRollingStockWithLiveries[] = await listApiRequest(
+    '/api/light_rolling_stock'
   );
 
   // Find rolling stocks that match the provided names
-  const rollingStockIds = rollingStocks.results
+  const rollingStockIds = rollingStocks
     .filter((r: LightRollingStock) => rollingStockNames.includes(r.name))
     .map((r: LightRollingStock) => r.id);
 


### PR DESCRIPTION
To get or delete a specific rolling stock, we were listing the first 500 (or 50 for towed rs) and filtering by name, hoping that the rs we wanted was in that list. This can fail if there are too many rolling stocks in our database.

Instead, either directly fetch the desired rolling stock by name if possible, or if impossible properly fetch all pages, ensuring the desired rolling stock is in the list.