### PR TITLE
core: stdcm: cache engineering allowance sequences

### DIFF
--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/SoftLazy.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/SoftLazy.kt
@@ -1,0 +1,20 @@
+package fr.sncf.osrd.utils
+
+import java.lang.ref.SoftReference
+import kotlin.properties.ReadOnlyProperty
+import kotlin.reflect.KProperty
+
+/**
+ * Usage: `val myValue by SoftLazy { computeValue() }`. The value is evaluated only when it's
+ * actually accessed. It's then stored in a `SoftReference`, which may be cleared if the JVM needs
+ * more RAM. Variables defined that way can then be used transparently, as if they were of type `T`.
+ */
+class SoftLazy<T>(
+    private val computeValue: () -> T,
+) : ReadOnlyProperty<Any?, T> {
+    var cache: SoftReference<T> = SoftReference(null)
+
+    override fun getValue(thisRef: Any?, property: KProperty<*>): T {
+        return cache.get() ?: computeValue().also { cache = SoftReference(it) }
+    }
+}

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdge.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdge.kt
@@ -79,6 +79,7 @@ data class STDCMEdge(
                 null,
                 previousPlannedNodeRelativeTimeDiff,
                 graph.remainingTimeEstimator.invoke(this, null, stepTracker),
+                graph,
             )
         } else {
             // New edge on the same block, after a stop
@@ -103,6 +104,7 @@ data class STDCMEdge(
                 nextStop.originalStep.plannedTimingData,
                 previousPlannedNodeRelativeTimeDiff,
                 graph.remainingTimeEstimator.invoke(this, locationOnEdge, stepTracker),
+                graph,
             )
         }
     }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMNode.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMNode.kt
@@ -3,7 +3,10 @@ package fr.sncf.osrd.stdcm.graph
 import fr.sncf.osrd.envelope_sim.TrainPhysicsIntegrator.areTimesEqual
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.stdcm.PlannedTimingData
+import fr.sncf.osrd.stdcm.graph.engineering_allowance.generatePreviousSimulationSegments
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
+import fr.sncf.osrd.utils.SoftLazy
+import fr.sncf.osrd.utils.cacheable
 import fr.sncf.osrd.utils.units.Offset
 import kotlin.math.min
 
@@ -27,6 +30,8 @@ data class STDCMNode(
     val previousPlannedNodeRelativeTimeDiff: Double?,
     // Estimation of the min time it takes to reach the end from this node
     var remainingTimeEstimation: Double,
+    // Reference to the main graph. Only null in some unit tests, where we don't have a full graph
+    val graph: STDCMGraph?,
 ) : Comparable<STDCMNode> {
 
     /**
@@ -182,5 +187,15 @@ data class STDCMNode(
      */
     fun getRealTime(updatedTimeData: TimeData): Double {
         return timeData.getUpdatedEarliestReachableTime(updatedTimeData)
+    }
+
+    val previousSimulationSegments by SoftLazy {
+        generatePreviousSimulationSegments(previousEdge, graph).cacheable()
+    }
+    val allowanceOpportunities by SoftLazy {
+        graph!!
+            .allowanceManager
+            .generateAllowanceOpportunities(previousSimulationSegments, speed)
+            .cacheable()
     }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
@@ -117,7 +117,7 @@ class STDCMPathfinding(
             ConstraintCombiner(initConstraints(fullInfra, listOf(rollingStock)).toMutableList())
 
         assert(steps.last().stop) { "The last stop is supposed to be an actual stop" }
-        starts = getStartNodes(listOf(constraints))
+        starts = getStartNodes(graph, listOf(constraints))
         val path = findPathImpl()
         graph.stdcmSimulations.logWarnings()
         if (path == null) {
@@ -258,7 +258,10 @@ class STDCMPathfinding(
     }
 
     /** Converts start locations into starting nodes. */
-    private fun getStartNodes(constraints: List<PathfindingConstraint<Block>>): Set<STDCMNode> {
+    private fun getStartNodes(
+        graph: STDCMGraph,
+        constraints: List<PathfindingConstraint<Block>>
+    ): Set<STDCMNode> {
         val res = HashSet<STDCMNode>()
         val firstStep = steps[0]
         assert(!firstStep.stop)
@@ -292,6 +295,7 @@ class STDCMPathfinding(
                         firstStep.plannedTimingData,
                         null,
                         graph.bestPossibleTime,
+                        graph,
                     )
                 res.add(node)
             }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/engineering_allowance/EngineeringAllowanceManager.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/engineering_allowance/EngineeringAllowanceManager.kt
@@ -41,8 +41,9 @@ class EngineeringAllowanceManager(
         assert(constDeceleration > 0.0)
 
         val requiredAdditionalTime = expectedStartTime - prevNode.timeData.earliestReachableTime
-        val segments = generatePreviousSimulationSegments(prevNode.previousEdge, graph).cacheable()
-        val opportunities = generateAllowanceOpportunities(segments, prevNode.speed)
+
+        val opportunities = prevNode.allowanceOpportunities
+
         val solution =
             opportunities
                 .takeWhile { it.maxNextAllowanceValue >= requiredAdditionalTime }
@@ -50,7 +51,7 @@ class EngineeringAllowanceManager(
 
         // We still try to roughly guess the maximum length over which to add the time
         var distance = 0.meters
-        for (segment in segments) {
+        for (segment in prevNode.previousSimulationSegments) {
             if (segment.maxAddedDelay <= requiredAdditionalTime) break
             distance += segment.length
         }

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
@@ -248,6 +248,7 @@ class STDCMHeuristicTests {
                 null,
                 null,
                 0.0,
+                null
             )
         val defaultEdge =
             STDCMEdge(


### PR DESCRIPTION
We very often test several engineering allowances at the same place, with the same previous edges. This is done when we can get overtaken by more than one train at once at the same place, which is actually very common.

Caching the sequences avoids redundant computations. We still only evaluate what's necessary, and then use soft references to avoid ram issues. 


Full bench data, +3% average peak ram, -25% processing time. Run with 6 GB limit.


|   | time_old | time_per_knode_old | time_new | time_per_knode_new | time_diff |
 |---|---|---|---|---|---|
 | count | 88.000000 | 88.000000 | 88.000000 | 88.000000 | 88.000000 |
 | mean | 6.955023 | 0.706642 | 5.180443 | 0.648656 | -1.774580 |
 | std | 14.103137 | 1.221101 | 9.960951 | 1.190449 | 4.376797 |
 | min | 0.100000 | 0.038378 | 0.098000 | 0.037140 | -27.682000 |
 | 25% | 0.920000 | 0.224366 | 0.902250 | 0.163905 | -1.260750 |
 | 50% | 2.997000 | 0.321516 | 2.577500 | 0.269849 | -0.373500 |
 | 75% | 6.156500 | 0.511772 | 5.032000 | 0.448302 | -0.037500 |
 | max | 99.435000 | 6.894737 | 73.056000 | 6.631579 | 0.067000 |


|  | mb_old | mb_new | mb_diff |
 |---|---|---|---|
 | count | 88.000000 | 88.000000 | 88.000000 |
 | mean | 3257.806818 | 3350.636364 | 92.829545 |
 | std | 963.730168 | 858.745117 | 705.095122 |
 | min | 1333.000000 | 1333.000000 | -1851.000000 |
 | 25% | 2426.500000 | 2668.750000 | -301.250000 |
 | 50% | 3080.000000 | 3332.500000 | 50.000000 |
 | 75% | 3960.250000 | 3917.750000 | 492.000000 |
 | max | 5195.000000 | 5339.000000 | 2012.000000 |