### PR TITLE
core: stdcm: fix post-processing mismatch

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdge.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdge.kt
@@ -92,7 +92,7 @@ data class STDCMEdge(
                     stopDuration,
                     graph.delayManager.getMaxAdditionalStopDuration(
                         infraExplorerWithNewEnvelope,
-                        timeData.earliestReachableTime + totalTime
+                        getEdgeEndTime(),
                     )
                 ),
                 endSpeed,
@@ -171,5 +171,24 @@ data class STDCMEdge(
      */
     fun fromTravelledOffset(travelledPathOffset: Offset<TravelledPath>): Offset<BlockPath> {
         return infraExplorer.getIncrementalPath().fromTravelledPath(travelledPathOffset)
+    }
+
+    /** Return the time at which the train quits this edge and moves on to the next. */
+    private fun getEdgeEndTime(): Double {
+        return timeData.earliestReachableTime + totalTime
+    }
+
+    /**
+     * Return how much delay we can add on this edge. We need to be given the time added on the next
+     * edges (both departure delaying and allowances), as they carry over previous edges.
+     */
+    fun getMaxAddedDelay(addedAllowanceOnNextEdges: Double): Double {
+        val maxAddedDelay = timeData.timeOfNextConflictAtLocation - getEdgeEndTime()
+        return maxAddedDelay - addedAllowanceOnNextEdges
+    }
+
+    /** Return all delay added to this edge, engineering + departure delay */
+    fun getTotalAddedDelayOnEdge(): Double {
+        return timeData.delayAddedToLastDeparture + (engineeringAllowance?.extraDuration ?: 0.0)
     }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
@@ -162,6 +162,8 @@ class STDCMGraph(
         while (true) {
             val edge = node.previousEdge ?: return maxTime
 
+            // TODO: this is wrong, we should use `edge.getMaxAddedDelay` instead.
+            // But doing so can lead to infinite loops, especially in the unit test "infraWithLoop".
             val latestTimeWithMaxShift =
                 edge.timeData.earliestReachableTime +
                     edge.totalTime +

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/engineering_allowance/EngineeringAllowanceManager.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/engineering_allowance/EngineeringAllowanceManager.kt
@@ -16,6 +16,10 @@ class EngineeringAllowanceManager(
     private val graph: STDCMGraph?,
 ) {
 
+    // Account for the approximations made during const deceleration,
+    // not to be too optimistic in allowance opportunities
+    private val constDecelerationScaling = 0.9
+
     /**
      * Check whether an engineering allowance can be used in this context to be at the expected
      * start time at the node location. Returns the allowance length if it's possible, or null if it
@@ -109,7 +113,7 @@ class EngineeringAllowanceManager(
                 computeConstDeceleration(
                     cachedSegments.drop(i + 1),
                     newBeginSpeed,
-                    constDeceleration
+                    constDeceleration * constDecelerationScaling
                 )
             val decelerationResults = checkDeceleration(decelerationSequence, newBeginSpeed)
             if (decelerationResults.hasConflict) break

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/engineering_allowance/EngineeringAllowanceManager.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/engineering_allowance/EngineeringAllowanceManager.kt
@@ -51,8 +51,8 @@ class EngineeringAllowanceManager(
         // We still try to roughly guess the maximum length over which to add the time
         var distance = 0.meters
         for (segment in segments) {
+            if (segment.maxAddedDelay <= requiredAdditionalTime) break
             distance += segment.length
-            if (distance > 10_000.meters) return distance
         }
         return Distance.max(solution.distance, distance)
     }
@@ -209,6 +209,7 @@ class EngineeringAllowanceManager(
         constDeceleration: Double
     ): Sequence<ConstDecelerationData> = sequence {
         var endSpeed = decelerationEndSpeed
+        var intersection = false
         for (segment in prevSegments) {
             val pureDecelerationSim =
                 runSimplifiedSimulation(
@@ -216,14 +217,26 @@ class EngineeringAllowanceManager(
                     endSpeed,
                     segment.length.meters,
                 )
+            var simTravelTime = pureDecelerationSim.newDuration
             if (pureDecelerationSim.newBeginSpeed > segment.beginSpeed) {
-                // Intersection with base sim. We could try to guess the exact added time,
-                // but ignoring this segment is generally good enough.
-                break
+                // Intersection with base sim. We estimate the new time with a basic speed plateau +
+                // const deceleration, return this segment, and exit the loop.
+                if (segment.beginSpeed < endSpeed || segment.beginSpeed <= 0.0)
+                    break // Can't run the simplified sim, there's an acceleration
+                val newTime =
+                    simplifiedSpeedPlateauThenDeceleration(
+                        constDeceleration,
+                        segment.beginSpeed,
+                        endSpeed,
+                        segment.length.meters
+                    )
+                intersection = true
+                simTravelTime = newTime
             }
-            val newTravelTime =
-                scaleAllowanceTime(graph, pureDecelerationSim.newDuration, segment.length)
-            val addedTimeOnSegment = positive(newTravelTime - segment.travelTime)
+
+            var newTravelTime = scaleAllowanceTime(graph, simTravelTime, segment.length)
+            newTravelTime = max(newTravelTime, segment.travelTime)
+            val addedTimeOnSegment = newTravelTime - segment.travelTime
 
             yield(
                 ConstDecelerationData(
@@ -232,6 +245,7 @@ class EngineeringAllowanceManager(
                     addedTimeOnSegment,
                 )
             )
+            if (intersection) break
             endSpeed = pureDecelerationSim.newBeginSpeed
         }
     }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/engineering_allowance/SimulationSegment.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/engineering_allowance/SimulationSegment.kt
@@ -62,12 +62,14 @@ fun generatePreviousSimulationSegments(
     maxLength: Distance = 100.meters
 ): Sequence<SimulationSegment> = sequence {
     var currentEdge = initialEdge
+    var alreadyAddedDelay = 0.0
     while (currentEdge != null) {
         if (currentEdge.endAtStop) break
 
         val envelope = currentEdge.originalEnvelope
         val edgeEndTime = currentEdge.timeData.earliestReachableTime + currentEdge.totalTime
-        val maxAddedDelay = currentEdge.timeData.timeOfNextConflictAtLocation - edgeEndTime
+        val maxAddedDelay =
+            currentEdge.timeData.timeOfNextConflictAtLocation - edgeEndTime - alreadyAddedDelay
         if (maxAddedDelay <= 0.0) break
 
         val backwardsPointPairs =
@@ -101,6 +103,8 @@ fun generatePreviousSimulationSegments(
                 )
             )
         }
+        currentEdge.engineeringAllowance?.let { alreadyAddedDelay += it.extraDuration }
+        alreadyAddedDelay += currentEdge.timeData.delayAddedToLastDeparture
         currentEdge = currentEdge.previousNode.previousEdge
     }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/engineering_allowance/SimulationSegment.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/engineering_allowance/SimulationSegment.kt
@@ -67,9 +67,7 @@ fun generatePreviousSimulationSegments(
         if (currentEdge.endAtStop) break
 
         val envelope = currentEdge.originalEnvelope
-        val edgeEndTime = currentEdge.timeData.earliestReachableTime + currentEdge.totalTime
-        val maxAddedDelay =
-            currentEdge.timeData.timeOfNextConflictAtLocation - edgeEndTime - alreadyAddedDelay
+        val maxAddedDelay = currentEdge.getMaxAddedDelay(alreadyAddedDelay)
         if (maxAddedDelay <= 0.0) break
 
         val backwardsPointPairs =
@@ -103,8 +101,7 @@ fun generatePreviousSimulationSegments(
                 )
             )
         }
-        currentEdge.engineeringAllowance?.let { alreadyAddedDelay += it.extraDuration }
-        alreadyAddedDelay += currentEdge.timeData.delayAddedToLastDeparture
+        alreadyAddedDelay += currentEdge.getTotalAddedDelayOnEdge()
         currentEdge = currentEdge.previousNode.previousEdge
     }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/engineering_allowance/Utils.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/engineering_allowance/Utils.kt
@@ -5,6 +5,7 @@ import fr.sncf.osrd.envelope.EnvelopeTimeInterpolate.EnvelopePoint
 import fr.sncf.osrd.stdcm.graph.STDCMGraph
 import fr.sncf.osrd.utils.units.Distance
 import kotlin.math.abs
+import kotlin.math.pow
 import kotlin.math.sqrt
 
 /** Run a very simplified simulation with a constant acceleration value. */
@@ -24,6 +25,28 @@ fun runSimplifiedSimulation(
         initialSpeed,
         time,
     )
+}
+
+/**
+ * Similar function as above, computes a simplified simulation using basic kinetic equations. Here
+ * we compute the travel time over some known distance, with first a speed plateau and then a
+ * deceleration. The exact transition isn't known, but we know the start/end speed and acceleration.
+ */
+fun simplifiedSpeedPlateauThenDeceleration(
+    acceleration: Double,
+    initialSpeed: Double,
+    finalSpeed: Double,
+    distance: Double
+): Double {
+    require(initialSpeed > 0.0)
+    require(finalSpeed >= 0.0)
+    require(initialSpeed > finalSpeed)
+    require(distance > 0.0)
+
+    val constSpeedTime = distance / initialSpeed
+    val addedDecelerationTime =
+        (initialSpeed - finalSpeed).pow(2.0) / abs(2.0 * acceleration * initialSpeed)
+    return constSpeedTime + addedDecelerationTime
 }
 
 /**

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/EngineeringAllowanceManagerTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/EngineeringAllowanceManagerTests.kt
@@ -58,7 +58,7 @@ class EngineeringAllowanceManagerTests {
                 .toList()
         print(opportunities)
         assertEquals(3, opportunities.size)
-        assertEquals(100.meters, opportunities[0].distance)
+        assertEquals(200.meters, opportunities[0].distance)
         assertEquals(200.meters, opportunities[1].distance)
         assertEquals(300.meters, opportunities[2].distance)
 

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/EngineeringAllowanceTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/EngineeringAllowanceTests.kt
@@ -360,6 +360,56 @@ class EngineeringAllowanceTests {
         occupancyTest(res, occupancyGraph, 2 * timeStep)
     }
 
+    /**
+     * Similar test as above, but values have been tweaked to reproduce #12541. Distances are too
+     * short to actually run an engineering allowance.
+     */
+    @Test
+    fun testSeveralDelaysWithConflictAtStart() {
+        /*
+        a --> b --> c --> d --> e
+
+        space
+          ^
+        e |################################ end
+          |################################/__________
+        d |#################### /         /
+          |####################/_________/____________
+        c |############# /    /         /
+          |#############/____/_________/______________
+        b | /          /    /   ######################
+          |/          /    /    ######################
+        a start______/____/_____#######################> time
+
+         */
+        val infra = DummyInfra()
+        val firstBlock = infra.addBlock("a", "b")
+        val secondBlock = infra.addBlock("b", "c")
+        val thirdBlock = infra.addBlock("c", "d")
+        val forthBlock = infra.addBlock("d", "e")
+        val occupancyGraph =
+            ImmutableMultimap.of(
+                firstBlock,
+                OccupancySegment(1_000.0, Double.POSITIVE_INFINITY, 0.meters, 100.meters),
+                secondBlock,
+                OccupancySegment(0.0, 800.0, 0.meters, 100.meters),
+                thirdBlock,
+                OccupancySegment(0.0, 1_200.0, 0.meters, 100.meters),
+                forthBlock,
+                OccupancySegment(0.0, 1_200.0, 0.meters, 100.meters)
+            )
+        val res =
+            STDCMPathfindingBuilder()
+                .setInfra(infra.fullInfra())
+                .setStartLocations(setOf(EdgeLocation(firstBlock, Offset(0.meters))))
+                .setEndLocations(setOf(EdgeLocation(forthBlock, Offset(1.meters))))
+                .setUnavailableTimes(occupancyGraph)
+                .setMaxRunTime(Double.POSITIVE_INFINITY)
+                .run() ?: return // No solution found is valid here (and expected)
+        // But if we find a solution there must be no conflict
+        occupancyTest(res, occupancyGraph)
+    }
+
     /** Test that we return null with no crash when we can't slow down fast enough */
     @Test
     fun testImpossibleEngineeringAllowance() {


### PR DESCRIPTION
Fix https://github.com/OpenRailAssociation/osrd/issues/12541

There's a couple small bugfixes, but ultimately it seems like we're just too optimistic on the ability to fully stop and restart. Likely because we don't properly account for slopes in previous edges.

I've added some tolerance by lowering the const deceleration value by 10%. It's good enough to fix the issue with the same request as the one reported in the bug, I'll run the fuzzer to see if it's actually enough. **=> fuzzer shows no new error, but we still have timeout outside of the south-east perimeter**

Bench: we find *a little* less solutions (as we were too optimistic on the engineering allowances). It also slows the processing down a little. But there's a second PR in progress for that: https://github.com/OpenRailAssociation/osrd/pull/12586 (I figured out while debugging this issue that we spend a lot of time computing redundant allowances). 