### PR TITLE
Fix last stop for track projection

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/EnvelopeStopWrapper.java
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/EnvelopeStopWrapper.java
@@ -91,11 +91,12 @@ public class EnvelopeStopWrapper implements EnvelopeInterpolate {
         double sumPreviousStopDuration = 0;
         int stopIndex = 0;
         for (var point : envelope.iteratePoints()) {
-            var shiftedPoint =
-                    new EnvelopePoint(point.time() + sumPreviousStopDuration, point.speed(), point.position());
+            var shiftedTime = point.time() + sumPreviousStopDuration;
+            var shiftedPoint = new EnvelopePoint(shiftedTime, point.speed(), point.position());
             res.add(shiftedPoint);
             if (stopIndex < stops.size() && point.position() >= stops.get(stopIndex).position) {
                 var stopDuration = stops.get(stopIndex).duration;
+                res.add(new EnvelopePoint(shiftedTime + stopDuration, point.speed(), stops.get(stopIndex).position));
                 stopIndex++;
                 sumPreviousStopDuration += stopDuration;
             }

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
@@ -21,7 +21,6 @@ import fr.sncf.osrd.sim_infra.impl.ChunkPath
 import fr.sncf.osrd.sim_infra.utils.routesOnBlock
 import fr.sncf.osrd.standalone_sim.result.ResultPosition
 import fr.sncf.osrd.standalone_sim.result.ResultSpeed
-import fr.sncf.osrd.standalone_sim.result.ResultStops
 import fr.sncf.osrd.train.RollingStock
 import fr.sncf.osrd.train.TrainStop
 import fr.sncf.osrd.utils.indexing.StaticIdxList
@@ -114,13 +113,6 @@ fun runScheduleMetadataExtractor(
     for (point in envelopeWithStops.iteratePoints()) {
         speeds.add(ResultSpeed(point.time, point.speed, point.position))
         headPositions.add(ResultPosition.from(point.time, point.position, trainPath, rawInfra))
-    }
-
-    // Compute stops
-    val stops = ArrayList<ResultStops>()
-    for (stop in legacyStops) {
-        val stopTime = envelopeWithStops.interpolateArrivalAt(stop.position)
-        stops.add(ResultStops(stopTime, stop.position, stop.duration))
     }
 
     // Compute signal updates

--- a/core/src/test/java/fr/sncf/osrd/standalone_sim/EnvelopeStopWrapperTests.java
+++ b/core/src/test/java/fr/sncf/osrd/standalone_sim/EnvelopeStopWrapperTests.java
@@ -34,17 +34,19 @@ public class EnvelopeStopWrapperTests {
         var envelopeStopWrapper = new EnvelopeStopWrapper(
                 envelopeFloor,
                 List.of(
-                        new TrainStop(1.5, 0, RJSReceptionSignal.OPEN),
-                        new TrainStop(3, 10, RJSReceptionSignal.SHORT_SLIP_STOP)));
+                        new TrainStop(3, 10, RJSReceptionSignal.SHORT_SLIP_STOP),
+                        new TrainStop(6, 5, RJSReceptionSignal.OPEN)));
         Assertions.assertEquals(
                 List.of(
                         new EnvelopeTimeInterpolate.EnvelopePoint(0, 1, 0),
                         new EnvelopeTimeInterpolate.EnvelopePoint(1, 1, 1),
                         new EnvelopeTimeInterpolate.EnvelopePoint(2, 1, 2),
                         new EnvelopeTimeInterpolate.EnvelopePoint(4, 0, 3),
+                        new EnvelopeTimeInterpolate.EnvelopePoint(4 + 10, 0, 3),
                         new EnvelopeTimeInterpolate.EnvelopePoint(6 + 10, 1, 4),
                         new EnvelopeTimeInterpolate.EnvelopePoint(7 + 10, 1, 5),
-                        new EnvelopeTimeInterpolate.EnvelopePoint(8 + 10, 1, 6)),
-                envelopeStopWrapper.iteratePoints());
+                        new EnvelopeTimeInterpolate.EnvelopePoint(8 + 10, 1, 6),
+                        new EnvelopeTimeInterpolate.EnvelopePoint(8 + 10 + 5, 1, 6)),
+                envelopeStopWrapper.iteratePoints().stream().distinct().toList());
     }
 }

--- a/editoast/src/views/projection.rs
+++ b/editoast/src/views/projection.rs
@@ -210,38 +210,37 @@ fn compute_space_time_curves(
     for intersection in intersections {
         let start = intersection.start();
         let end = intersection.end();
-        let start_index = find_index_upper(positions, start);
+        let start_index = find_index_lower(positions, start);
         let end_index = find_index_upper(positions, end);
 
         // Each segment contains the start, end and all positions between them
         // We must interpolate the start and end positions if they are not part of the positions
         let mut segment_positions = Vec::with_capacity(end_index - start_index + 2);
         let mut segment_times = Vec::with_capacity(end_index - start_index + 2);
-        if positions[start_index] > start {
-            // Interpolate the first point of the segment
-            segment_positions.push(project_pos(start, &train_path, path_projection));
-            segment_times.push(linear_interpolate(
-                positions[start_index - 1],
-                positions[start_index],
-                times[start_index - 1],
-                times[start_index],
-                start,
-            ));
-        }
+        // Interpolate the first point of the segment
+        segment_positions.push(project_pos(start, &train_path, path_projection));
+        segment_times.push(linear_interpolate(
+            positions[start_index],
+            positions[start_index + 1],
+            times[start_index],
+            times[start_index + 1],
+            start,
+        ));
 
         // Project all the points in the segment
-        for index in start_index..end_index {
+        for index in (start_index + 1)..end_index {
             segment_positions.push(project_pos(positions[index], &train_path, path_projection));
             segment_times.push(times[index]);
         }
 
         // Interpolate the last point of the segment
         segment_positions.push(project_pos(end, &train_path, path_projection));
+        // The interpolation is inverted because we want to retrieve the higher time if positions[end_index] == positions[end_index - 1]
         segment_times.push(linear_interpolate(
-            positions[end_index - 1],
             positions[end_index],
-            times[end_index - 1],
+            positions[end_index - 1],
             times[end_index],
+            times[end_index - 1],
             end,
         ));
         space_time_curves.push(SpaceTimeCurve {
@@ -252,7 +251,8 @@ fn compute_space_time_curves(
     space_time_curves
 }
 
-/// Find the index of the first element greater to a value
+/// Find the index of the first element greater than a value.
+/// In case it matches duplicate values, it returns the rightmost index.
 ///
 /// **Values must be sorted in ascending order**
 ///
@@ -284,6 +284,25 @@ pub fn find_index_upper(values: &[u64], value: u64) -> usize {
     }
 }
 
+/// Find the index of the first element lower than a value.
+/// In case it matches duplicate values, it returns the leftmost index.
+///
+/// **Values must be sorted in ascending order**
+///
+/// ## Panics
+///
+/// - If value is greater than the last element of values.
+/// - If values is empty
+pub fn find_index_lower(values: &[u64], value: u64) -> usize {
+    let mut index = find_index_upper(values, value);
+    while index > 0
+        && (values[index] > value || (values[index] == value && values[index - 1] == values[index]))
+    {
+        index -= 1;
+    }
+    index
+}
+
 /// Project a position on a train path to a position on a projection path
 ///
 /// ## Panics
@@ -308,14 +327,21 @@ fn project_pos(
     }
 }
 
-/// Interpolate a time value between two positions
-pub fn linear_interpolate(a_x: u64, b_x: u64, a_y: u64, b_y: u64, a_interpolate: u64) -> u64 {
+/// Linear interpolation between two points `a` and `b` given their x and y coordinates.
+/// Note: If `a_x` is equal to `b_x`, it returns `a_y`.
+///
+/// Panics if `x` is not between `a_x` and `b_x`.
+pub fn linear_interpolate(a_x: u64, b_x: u64, a_y: u64, b_y: u64, x: u64) -> u64 {
     if a_x == b_x {
         a_y
-    } else if a_y < b_y {
-        a_y + (a_interpolate - a_x) * (b_y - a_y) / (b_x - a_x)
+    } else if a_y < b_y && a_x < b_x {
+        a_y + (x - a_x) * (b_y - a_y) / (b_x - a_x)
+    } else if a_y >= b_y && a_x < b_x {
+        a_y - (x - a_x) * (a_y - b_y) / (b_x - a_x)
+    } else if a_y < b_y && a_x >= b_x {
+        a_y + (a_x - x) * (b_y - a_y) / (a_x - b_x)
     } else {
-        a_y - (a_interpolate - a_x) * (a_y - b_y) / (b_x - a_x)
+        a_y - (a_x - x) * (a_y - b_y) / (a_x - b_x)
     }
 }
 
@@ -672,16 +698,31 @@ mod tests {
     #[rstest]
     #[case(1, 0)]
     #[case(2, 1)]
-    #[case(3, 1)]
-    #[case(4, 2)]
-    #[case(5, 3)]
-    #[case(6, 4)]
-    #[case(7, 4)]
-    #[case(8, 5)]
-    #[case(9, 6)]
+    #[case(3, 2)]
+    #[case(4, 3)]
+    #[case(5, 5)]
+    #[case(6, 6)]
+    #[case(7, 6)]
+    #[case(8, 7)]
+    #[case(9, 9)]
     fn test_find_index_upper(#[case] value: u64, #[case] expected: usize) {
-        let values = vec![1, 3, 4, 5, 7, 8, 9];
+        let values = vec![1, 3, 3, 4, 5, 5, 7, 8, 9, 9];
         assert_eq!(find_index_upper(&values, value), expected);
+    }
+
+    #[rstest]
+    #[case(1, 0)]
+    #[case(2, 0)]
+    #[case(3, 1)]
+    #[case(4, 3)]
+    #[case(5, 4)]
+    #[case(6, 5)]
+    #[case(7, 6)]
+    #[case(8, 7)]
+    #[case(9, 8)]
+    fn test_find_index_lower(#[case] value: u64, #[case] expected: usize) {
+        let values = vec![1, 3, 3, 4, 5, 5, 7, 8, 9, 9];
+        assert_eq!(find_index_lower(&values, value), expected);
     }
 
     #[rstest]

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -1315,7 +1315,7 @@ mod tests {
             PacedTrainSummaryResponse {
                 paced_train: SummaryResponse::Success {
                     length: 0,
-                    time: 0,
+                    time: 3000,
                     energy_consumption: 0.0,
                     path_item_times_final: vec![0, 1000, 2000, 3000],
                     path_item_times_provisional: vec![0, 1000, 2000, 3000],
@@ -1327,7 +1327,7 @@ mod tests {
                     // because all simulation results from core are identical stubs
                     SummaryResponse::Success {
                         length: 0,
-                        time: 0,
+                        time: 3000,
                         energy_consumption: 0.0,
                         path_item_times_final: vec![0, 1000, 2000, 3000],
                         path_item_times_provisional: vec![0, 1000, 2000, 3000],

--- a/editoast/src/views/timetable/simulation.rs
+++ b/editoast/src/views/timetable/simulation.rs
@@ -167,7 +167,7 @@ impl From<simulation::Response> for SummaryResponse {
                 let report = final_output.report_train;
                 Self::Success {
                     length: *report.positions.last().unwrap(),
-                    time: *report.times.last().unwrap(),
+                    time: *report.path_item_times.last().unwrap(),
                     energy_consumption: report.energy_consumption,
                     path_item_times_final: report.path_item_times.clone(),
                     path_item_times_provisional: provisional.path_item_times.clone(),


### PR DESCRIPTION
Core: We did not manage the stops at the end of a simulation.
Editoast: The first and last points of a projected segment were randomly skipped. Adapt the simulation summary to return the arrival time of the train without its optional stop.

**Before:**
<img width="1448" height="561" alt="image" src="https://github.com/user-attachments/assets/4ebf126e-1b92-46d9-b965-eeaccb71e648" />

**After:**
<img width="1992" height="561" alt="image" src="https://github.com/user-attachments/assets/058f2010-49f5-4674-b440-69365b4debac" />

> [!NOTE]
> Check with @maelysLeratRosso what the expected behavior is.
