### PR TITLE
front: rolling-stock-editor: hide description text in presentation card

### DIFF
--- a/front/src/modules/rollingStock/components/RollingStockSelector/RollingStockHelpers.tsx
+++ b/front/src/modules/rollingStock/components/RollingStockSelector/RollingStockHelpers.tsx
@@ -53,7 +53,10 @@ export const RollingStockInfo = ({
           </span>
         )}
         {showMiddle && metadata?.series && (
-          <span className="rollingstock-info-middle">
+          <span
+            className="rollingstock-info-middle"
+            title={`${metadata.family} / ${metadata.type} / ${metadata.grouping}`}
+          >
             {`${metadata.family} / ${metadata.type} / ${metadata.grouping}`}
           </span>
         )}

--- a/front/src/modules/rollingStock/styles/_rollingStockCard.scss
+++ b/front/src/modules/rollingStock/styles/_rollingStockCard.scss
@@ -143,8 +143,8 @@
         }
       }
       .rollingstock-info-middle {
-        white-space: normal;
-        overflow-wrap: break-word;
+        white-space: nowrap;
+        text-overflow: ellipsis;
         overflow: hidden;
         max-width: 55%;
         text-transform: uppercase;


### PR DESCRIPTION
close #6420 

Changes in css file:
1/Made sure the text use a single line
2/Cropped and the text with '...'

Changes in tsx file:
3/Added title tag to make the whole content display when hovering

before/after
<img width="393" height="100" alt="image" src="https://github.com/user-attachments/assets/008afe5d-28f6-4d59-bc0e-a4a6c3c34fb1" />
<img width="394" height="100" alt="image" src="https://github.com/user-attachments/assets/c735639f-78de-465f-8052-ce5191797497" />