### PR TITLE
editoast: adapt get_or_load() using zrangebyscore

### DIFF
--- a/chart/templates/stateful_editoast/deployment.yaml
+++ b/chart/templates/stateful_editoast/deployment.yaml
@@ -13,7 +13,7 @@ metadata:
   annotations:
     {{- toYaml $mergedAnnotations | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.services.statefulEditoast.replicas | default 2 }}
   selector:
     matchLabels:
       {{- include "osrd.selectorLabels.statefulEditoast" . | nindent 6 }}

--- a/editoast/src/infra_cache/mod.rs
+++ b/editoast/src/infra_cache/mod.rs
@@ -6,6 +6,7 @@ use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::collections::hash_map::Entry;
+use std::sync::Arc;
 
 use dashmap::DashMap;
 use dashmap::mapref::one::Ref;
@@ -62,6 +63,7 @@ use crate::infra_cache::object_cache::TrackSectionCache;
 use crate::infra_cache::operation::CacheOperation;
 use crate::models::Infra;
 use crate::models::railjson::find_all_schemas;
+use cache::Client as ValkeyClient;
 use database::DbConnection;
 use schemas::infra::InfraObject;
 use schemas::primitives::BoundingBox;
@@ -558,14 +560,17 @@ impl InfraCache {
         conn: &mut DbConnection,
         infra_caches: &'a DashMap<i64, InfraCache>,
         infra: &Infra,
+        valkey: &Arc<ValkeyClient>,
+        app_version: Option<&str>,
     ) -> Result<Ref<'a, i64, InfraCache>> {
-        // Cache hit
-        if let Some(infra_cache) = infra_caches.get(&infra.id) {
-            return Ok(infra_cache);
-        }
-        // Cache miss
-        infra_caches.insert(infra.id, InfraCache::load(&mut conn.clone(), infra).await?);
-        Ok(infra_caches.get(&infra.id).unwrap())
+        Self::get_or_load_mut(conn, infra_caches, infra, valkey, app_version)
+            .await
+            .map(|ref_mut| ref_mut.downgrade())
+    }
+
+    pub fn get_patch_key(infra_id: i64, app_version: Option<&str>) -> String {
+        let osrd_version = app_version.unwrap_or_default();
+        format!("infra_patches.{osrd_version}.{infra_id}")
     }
 
     /// This function tries to get the infra from the cache, if it fails, it loads it from the database
@@ -574,14 +579,45 @@ impl InfraCache {
         conn: &mut DbConnection,
         infra_caches: &'a DashMap<i64, InfraCache>,
         infra: &Infra,
+        valkey: &Arc<ValkeyClient>,
+        app_version: Option<&str>,
     ) -> Result<RefMut<'a, i64, InfraCache>> {
-        // Cache hit
-        if let Some(infra_cache) = infra_caches.get_mut(&infra.id) {
+        let Some(mut infra_cache) = infra_caches.get_mut(&infra.id) else {
+            // Cache miss
+            let infra_cache = InfraCache::load(conn, infra).await?;
+            return Ok(infra_caches.entry(infra.id).insert(infra_cache));
+        };
+
+        // Cache hit and up to date
+        if infra.version <= infra_cache.infra_version {
             return Ok(infra_cache);
         }
-        // Cache miss
-        infra_caches.insert(infra.id, InfraCache::load(&mut conn.clone(), infra).await?);
-        Ok(infra_caches.get_mut(&infra.id).unwrap())
+
+        // Cache hit but outdated, we need to update it
+        let expected_patch_count: usize = (infra.version - infra_cache.infra_version)
+            .try_into()
+            .expect("infra.version should be greater than infra_cache_mut.infra_version");
+
+        let mut valkey_conn = valkey.get_connection().await?;
+        let cache_operations = valkey_conn
+            .json_zrangebyscore(
+                Self::get_patch_key(infra.id, app_version),
+                infra_cache.infra_version + 1,
+                infra.version,
+            )
+            .await?
+            .flatten()
+            .collect_vec();
+
+        if cache_operations.len() != expected_patch_count {
+            // Something went wrong, reload the cache from the database
+            *infra_cache = InfraCache::load(conn, infra).await?;
+            return Ok(infra_cache);
+        }
+
+        infra_cache.apply_operations(&cache_operations)?;
+        infra_cache.infra_version = infra.version;
+        Ok(infra_cache)
     }
 
     /// Get all track sections references of a given track and type
@@ -949,7 +985,7 @@ impl From<&RailJson> for InfraCache {
 
 #[cfg(test)]
 pub mod tests {
-    use dashmap::DashMap;
+    // use dashmap::DashMap;
     use pretty_assertions::assert_eq;
 
     use schemas::infra::BufferStop;
@@ -1439,36 +1475,6 @@ pub mod tests {
         infra_cache.add(&switch).unwrap();
 
         infra_cache
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn load_infra_cache() {
-        let db_pool = DbConnectionPoolV2::for_tests();
-        let infra = create_empty_infra(&mut db_pool.get_ok()).await;
-        let infra_caches = DashMap::new();
-        InfraCache::get_or_load(&mut db_pool.get_ok(), &infra_caches, &infra)
-            .await
-            .unwrap();
-        assert_eq!(infra_caches.len(), 1);
-        InfraCache::get_or_load(&mut db_pool.get_ok(), &infra_caches, &infra)
-            .await
-            .unwrap();
-        assert_eq!(infra_caches.len(), 1);
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn load_infra_cache_mut() {
-        let db_pool = DbConnectionPoolV2::for_tests();
-        let infra = create_empty_infra(&mut db_pool.get_ok()).await;
-        let infra_caches = DashMap::new();
-        InfraCache::get_or_load_mut(&mut db_pool.get_ok(), &infra_caches, &infra)
-            .await
-            .unwrap();
-        assert_eq!(infra_caches.len(), 1);
-        InfraCache::get_or_load_mut(&mut db_pool.get_ok(), &infra_caches, &infra)
-            .await
-            .unwrap();
-        assert_eq!(infra_caches.len(), 1);
     }
 
     mod getters {

--- a/editoast/src/views/infra/attached.rs
+++ b/editoast/src/views/infra/attached.rs
@@ -65,6 +65,8 @@ pub(in crate::views) async fn attached(
     State(AppState {
         infra_caches,
         db_pool,
+        valkey_client,
+        config,
         ..
     }): State<AppState>,
     Extension(auth): AuthenticationExt,
@@ -94,7 +96,14 @@ pub(in crate::views) async fn attached(
     .await?;
 
     // Check track existence
-    let infra_cache = InfraCache::get_or_load(&mut conn, &infra_caches, &infra).await?;
+    let infra_cache = InfraCache::get_or_load(
+        &mut conn,
+        &infra_caches,
+        &infra,
+        &valkey_client,
+        config.app_version.as_deref(),
+    )
+    .await?;
     if !infra_cache.track_sections().contains_key(&track_id) {
         return Err(AttachedError::TrackNotFound {
             track_id: track_id.clone(),

--- a/editoast/src/views/infra/auto_fixes/mod.rs
+++ b/editoast/src/views/infra/auto_fixes/mod.rs
@@ -86,6 +86,8 @@ pub(in crate::views) async fn list_auto_fixes(
     State(AppState {
         infra_caches,
         db_pool,
+        valkey_client,
+        config,
         ..
     }): State<AppState>,
     Extension(auth): AuthenticationExt,
@@ -113,9 +115,15 @@ pub(in crate::views) async fn list_auto_fixes(
     .await?;
 
     // accepting the early release of ReadGuard as it's anyway released when sending the suggestions (so before edit)
-    let mut infra_cache_clone = InfraCache::get_or_load(&mut conn, &infra_caches, &infra)
-        .await?
-        .clone();
+    let mut infra_cache_clone = InfraCache::get_or_load(
+        &mut conn,
+        &infra_caches,
+        &infra,
+        &valkey_client,
+        config.app_version.as_deref(),
+    )
+    .await?
+    .clone();
 
     let mut fixes = vec![];
     for _ in 0..MAX_AUTO_FIXES_ITERATIONS {

--- a/editoast/src/views/infra/delimited_area.rs
+++ b/editoast/src/views/infra/delimited_area.rs
@@ -127,6 +127,8 @@ pub(in crate::views) async fn delimited_area(
     State(AppState {
         infra_caches,
         db_pool,
+        valkey_client,
+        config,
         ..
     }): State<AppState>,
     Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
@@ -157,7 +159,14 @@ pub(in crate::views) async fn delimited_area(
     })
     .await?;
 
-    let infra_cache = InfraCache::get_or_load(&mut conn, &infra_caches, &infra).await?;
+    let infra_cache = InfraCache::get_or_load(
+        &mut conn,
+        &infra_caches,
+        &infra,
+        &valkey_client,
+        config.app_version.as_deref(),
+    )
+    .await?;
     let graph = Graph::load(&infra_cache);
 
     // Validate user input

--- a/editoast/src/views/infra/edition.rs
+++ b/editoast/src/views/infra/edition.rs
@@ -102,8 +102,14 @@ pub(in crate::views) async fn edit(
     })
     .await?;
 
-    let mut infra_cache =
-        InfraCache::get_or_load_mut(&mut db_pool.get().await?, &infra_caches, &infra).await?;
+    let mut infra_cache = InfraCache::get_or_load_mut(
+        &mut db_pool.get().await?,
+        &infra_caches,
+        &infra,
+        &valkey_client,
+        config.app_version.as_deref(),
+    )
+    .await?;
     let operation_results = apply_edit(
         &mut db_pool.get().await?,
         &mut infra,
@@ -177,8 +183,14 @@ pub(in crate::views) async fn split_track_section(
     })
     .await?;
 
-    let mut infra_cache =
-        InfraCache::get_or_load_mut(&mut db_pool.get().await?, &infra_caches, &infra).await?;
+    let mut infra_cache = InfraCache::get_or_load_mut(
+        &mut db_pool.get().await?,
+        &infra_caches,
+        &infra,
+        &valkey_client,
+        config.app_version.as_deref(),
+    )
+    .await?;
 
     // Get tracks cache if it exists
     let tracksection_cached = infra_cache.get_track_section(&payload.track)?.clone();
@@ -912,11 +924,11 @@ async fn apply_edit(
                 infra_cache.apply_operations(&cache_operations)?;
 
                 infra_cache.infra_version = infra.version;
-                let osrd_version = app_version.unwrap_or("default");
+
                 let mut valkey_conn = valkey_client.get_connection().await?;
                 let _ = valkey_conn
                     .json_zadd(
-                        format!("infra_patches.{osrd_version}.{infra_id})"),
+                        InfraCache::get_patch_key(infra_id, app_version),
                         &cache_operations,
                         infra_cache.infra_version,
                     )
@@ -1113,7 +1125,7 @@ pub mod tests {
             &operations,
             &mut infra_cache,
             app.valkey_client(),
-            None,
+            app.config().app_version.as_deref(),
         )
         .await
         .ok()

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -159,14 +159,20 @@ pub(in crate::views) async fn refresh(
     let mut infra_refreshed = vec![];
 
     for mut infra in infras_list {
-        let infra_cache =
-            InfraCache::get_or_load(&mut db_pool.get().await?, &infra_caches, &infra).await?;
+        let infra_cache = InfraCache::get_or_load(
+            &mut db_pool.get().await?,
+            &infra_caches,
+            &infra,
+            &valkey_client,
+            config.app_version.as_deref(),
+        )
+        .await?;
         if infra.refresh(db_pool.clone(), force, &infra_cache).await? {
             infra_refreshed.push(infra.id);
         }
     }
 
-    let mut conn = valkey_client.get_connection().await?;
+    let mut conn = valkey_client.clone().get_connection().await?;
     for infra_id in infra_refreshed.iter() {
         map::invalidate_all(
             &mut conn,
@@ -1604,5 +1610,61 @@ pub mod tests {
             .collect::<Vec<_>>();
         let expected_identifiers: [Vec<&str>; 3] = [vec![], vec![], vec![]];
         assert_eq!(response_op_identifiers, expected_identifiers);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn load_infra_cache() {
+        let app = TestAppBuilder::default_app();
+        let db_pool = app.db_pool();
+        let infra = create_empty_infra(&mut db_pool.get_ok()).await;
+        let infra_caches = dashmap::DashMap::new();
+        InfraCache::get_or_load(
+            &mut db_pool.get_ok(),
+            &infra_caches,
+            &infra,
+            &app.valkey_client(),
+            app.config().app_version.as_deref(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(infra_caches.len(), 1);
+        InfraCache::get_or_load(
+            &mut db_pool.get_ok(),
+            &infra_caches,
+            &infra,
+            &app.valkey_client(),
+            app.config().app_version.as_deref(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(infra_caches.len(), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn load_infra_cache_mut() {
+        let app = TestAppBuilder::default_app();
+        let db_pool = DbConnectionPoolV2::for_tests();
+        let infra = create_empty_infra(&mut db_pool.get_ok()).await;
+        let infra_caches = dashmap::DashMap::new();
+        InfraCache::get_or_load_mut(
+            &mut db_pool.get_ok(),
+            &infra_caches,
+            &infra,
+            &app.valkey_client(),
+            app.config().app_version.as_deref(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(infra_caches.len(), 1);
+        InfraCache::get_or_load_mut(
+            &mut db_pool.get_ok(),
+            &infra_caches,
+            &infra,
+            &app.valkey_client(),
+            app.config().app_version.as_deref(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(infra_caches.len(), 1);
     }
 }

--- a/editoast/src/views/infra/pathfinding.rs
+++ b/editoast/src/views/infra/pathfinding.rs
@@ -90,6 +90,8 @@ pub(in crate::views) async fn pathfinding_view(
     State(AppState {
         db_pool,
         infra_caches,
+        valkey_client,
+        config,
         ..
     }): State<AppState>,
     Extension(auth): AuthenticationExt,
@@ -129,8 +131,14 @@ pub(in crate::views) async fn pathfinding_view(
     })
     .await?;
 
-    let infra_cache =
-        InfraCache::get_or_load(&mut db_pool.get().await?, &infra_caches, &infra).await?;
+    let infra_cache = InfraCache::get_or_load(
+        &mut db_pool.get().await?,
+        &infra_caches,
+        &infra,
+        &valkey_client,
+        config.app_version.as_deref(),
+    )
+    .await?;
 
     // Check that the starting and ending track locations are valid
     if !infra_cache

--- a/editoast/src/views/infra/railjson.rs
+++ b/editoast/src/views/infra/railjson.rs
@@ -168,7 +168,12 @@ pub(in crate::views) struct PostRailjsonResponse {
 )]
 pub(in crate::views) async fn post_railjson(
     State(AppState {
-        db_pool, regulator, ..
+        db_pool,
+        infra_caches,
+        valkey_client,
+        regulator,
+        config,
+        ..
     }): State<AppState>,
     Extension(auth): AuthenticationExt,
     Query(params): Query<PostRailjsonQueryParams>,
@@ -181,7 +186,6 @@ pub(in crate::views) async fn post_railjson(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    let infra_cache = InfraCache::from(&railjson);
     let mut infra = Infra::changeset()
         .name(params.name.clone())
         .last_railjson_version()
@@ -206,6 +210,14 @@ pub(in crate::views) async fn post_railjson(
         .await
         .map_err(|_| InfraApiError::NotFound { infra_id })?;
     if params.generate_data {
+        let infra_cache = InfraCache::get_or_load(
+            &mut db_pool.get().await?,
+            &infra_caches,
+            &infra,
+            &valkey_client,
+            config.app_version.as_deref(),
+        )
+        .await?;
         infra.refresh(db_pool, true, &infra_cache).await?;
     }
 

--- a/editoast/src/views/infra/routes.rs
+++ b/editoast/src/views/infra/routes.rs
@@ -150,6 +150,8 @@ pub(in crate::views) async fn get_routes_track_ranges(
     State(AppState {
         db_pool,
         infra_caches,
+        valkey_client,
+        config,
         ..
     }): State<AppState>,
     Extension(auth): AuthenticationExt,
@@ -181,8 +183,14 @@ pub(in crate::views) async fn get_routes_track_ranges(
     })
     .await?;
 
-    let infra_cache =
-        InfraCache::get_or_load(&mut db_pool.get().await?, &infra_caches, &infra).await?;
+    let infra_cache = InfraCache::get_or_load(
+        &mut db_pool.get().await?,
+        &infra_caches,
+        &infra,
+        &valkey_client,
+        config.app_version.as_deref(),
+    )
+    .await?;
     let graph = Graph::load(&infra_cache);
     let routes_cache = infra_cache.routes();
     let result = params
@@ -221,6 +229,8 @@ pub(in crate::views) async fn get_routes_nodes(
     State(AppState {
         db_pool,
         infra_caches,
+        valkey_client,
+        config,
         ..
     }): State<AppState>,
     Extension(auth): AuthenticationExt,
@@ -252,8 +262,14 @@ pub(in crate::views) async fn get_routes_nodes(
         return Ok(Json(RoutesFromNodesPositions::default()));
     }
 
-    let infra_cache =
-        InfraCache::get_or_load(&mut db_pool.get().await?, &infra_caches, &infra).await?;
+    let infra_cache = InfraCache::get_or_load(
+        &mut db_pool.get().await?,
+        &infra_caches,
+        &infra,
+        &valkey_client,
+        config.app_version.as_deref(),
+    )
+    .await?;
     let routes_cache = infra_cache.routes();
 
     let filtered_routes = routes_cache

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -35,7 +35,7 @@ use ::authz::StorageDriver;
 use common::Version;
 use fga::client::Limits;
 #[cfg(test)]
-pub(crate) use test_app::test_app;
+use test_app::test_app;
 use tracing::Instrument;
 
 use ::core::str;


### PR DESCRIPTION
Close #12595 

Adapt the get_or_load() function using zrangebyscore operation such that :

- Should check if the infra_version matches the current cached one
- If not we call ZRANGEBYSCORE from cached_version+1 to infra_version
- If we retrieve the expected number of patches, we can apply them to the current InfraCache
- Otherwise trash and reload from psql