### PR TITLE
front: unify selection styles for valid and invalid trains

### DIFF
--- a/front/src/styles/scss/applications/operationalStudies/_pacedTrain.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_pacedTrain.scss
@@ -102,7 +102,7 @@
 
     &.warning {
       &.invalid {
-        background-image: url('data:image/svg+xml,%3Csvg version="1.1" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg"%3E%3Ctitle%3EAssets/TrainList/InvalidTrain%3C/title%3E%3Cg fill-rule="evenodd"%3E%3Crect width="48" height="48" fill="%23FFEEED"/%3E%3Cpath d="m48 26v22h-22l22-22zm0-26-48 48v-22l26-26h22z" fill="%23FF6868" opacity=".1"/%3E%3C/g%3E%3C/svg%3E');
+        background-image: url('data:image/svg+xml,%3Csvg version="1.1" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg"%3E%3Ctitle%3EAssets/TrainList/InvalidTrain%3C/title%3E%3Cg fill-rule="evenodd"%3E%3Crect width="48" height="48" fill="transparent"/%3E%3Cpath d="m48 26v22h-22l22-22zm0-26-48 48v-22l26-26h22z" fill="%23FF6868" opacity=".15"/%3E%3C/g%3E%3C/svg%3E');
         background-repeat: repeat;
 
         box-shadow: inset 0 -1px 0 0 var(--black10);

--- a/front/src/styles/scss/applications/operationalStudies/_scenario.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_scenario.scss
@@ -190,7 +190,7 @@
     box-shadow: inset 0 -1px 0 0 rgba(0, 0, 0, 0.25);
   }
 
-  &.selected:not(.invalid) {
+  &.selected {
     background-color: var(--selection20);
     box-shadow: inset 0 -1px 0 0 rgba(0, 0, 0, 0.25);
     .rolling-stock::after {
@@ -203,7 +203,7 @@
   }
 
   &.invalid {
-    background-image: url('data:image/svg+xml,%3Csvg version="1.1" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg"%3E%3Ctitle%3EAssets/TrainList/InvalidTrain%3C/title%3E%3Cg fill-rule="evenodd"%3E%3Crect width="48" height="48" fill="%23FFEEED"/%3E%3Cpath d="m48 26v22h-22l22-22zm0-26-48 48v-22l26-26h22z" fill="%23FF6868" opacity=".1"/%3E%3C/g%3E%3C/svg%3E');
+    background-image: url('data:image/svg+xml,%3Csvg version="1.1" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg"%3E%3Ctitle%3EAssets/TrainList/InvalidTrain%3C/title%3E%3Cg fill-rule="evenodd"%3E%3Crect width="48" height="48" fill="transparent"/%3E%3Cpath d="m48 26v22h-22l22-22zm0-26-48 48v-22l26-26h22z" fill="%23FF6868" opacity=".15"/%3E%3C/g%3E%3C/svg%3E');
     background-repeat: repeat;
     box-shadow: inset 0 -1px 0 0 rgba(0, 0, 0, 0.25);
 


### PR DESCRIPTION
Closes https://github.com/osrd-project/osrd-confidential/issues/1146 (2nd part)

 - Removed .not(.invalid) condition in .selected rule to apply yellow selection background to both valid and invalid trains.
 - Removed background <rect> from inline SVG icon used for invalid trains.
 - Updated SVG path opacity from 10% to 15% to improve visibility on lighter backgrounds.