### PR TITLE
core: paths: add basic route/block projections with backtracks

### DIFF
--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/PathOffsetProjector.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/PathOffsetProjector.kt
@@ -1,62 +1,82 @@
 package fr.sncf.osrd.path.implementations
 
-import fr.sncf.osrd.path.interfaces.CoveredPath
 import fr.sncf.osrd.path.interfaces.FullBlockPath
 import fr.sncf.osrd.path.interfaces.FullRoutePath
-import fr.sncf.osrd.path.interfaces.HeadTravelledPath
-import fr.sncf.osrd.sim_infra.api.Block
-import fr.sncf.osrd.sim_infra.api.Route
 import fr.sncf.osrd.utils.units.Distance
-import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
 
 /**
  * This class is in charge of all projections across path types. For now the only implemented
- * projections are among "adjacent" path types, but it can easily be extended.
+ * projections are to and from FullRoutePath (as we can project every offset type into this one with
+ * no data loss). Remaining conversions can be added as needed by chaining the other ones.
  */
 data class PathOffsetProjector(
-    val firstBlockOffset: Offset<FullRoutePath>,
-    val coveredPathBeginOffset: Offset<FullBlockPath>,
-    val coveredPathEndOffset: Offset<FullBlockPath>,
+    /** List of all backtrack locations on the path. */
     val backtrackLocations: List<BacktrackLocation>,
-) {
-    data class BacktrackLocation(
-        val coveredPathOffset: Offset<CoveredPath>,
-        val rollingStockLength: Distance,
+    /** Offset of the first block start on the route path */
+    val firstBlockOffset: Offset<FullRoutePath>,
 
-        // The following data is used to identify where to "cut" the block and route paths,
-        // without adding an explicit Infra dependency.
-        val previousBlockLength: Length<Block>,
-        val nextBlockLength: Length<Block>,
-        val previousRouteLength: Length<Route>,
-        val nextRouteLength: Length<Route>,
+    // val coveredPathBeginOffset: Offset<FullBlockPath>,
+    // val rollingStockLength: Distance,
+) {
+
+    /** Contains all the data we need to convert offsets around and after backtracking locations. */
+    data class BacktrackLocation(
+        /** Exact location where the (old) train head stops, defined on route path. */
+        val exactRouteOffset: Offset<FullRoutePath>,
+        /** Remaining length of the current block when the train stops. */
+        val remainingBlockAfterBacktrack: Distance,
+        /**
+         * Length of the blocks that will be fully skipped and aren't part of the block path. Can be
+         * at the end of the current route or at the start of the next one (or both).
+         */
+        val skippedBlocksAroundBacktrack: Distance,
+
+        // val skippedNextRoute: Distance,
     ) {
+        val blockBacktrackStart =
+            Offset<FullRoutePath>(exactRouteOffset.distance + remainingBlockAfterBacktrack)
+
         // TODO: add constructors, especially with infra and block/route lists
     }
 
     // TODO: add convenient constructors
 
     fun routeToBlock(routeOffset: Offset<FullRoutePath>): Offset<FullBlockPath> {
-        TODO()
+        var currentOffsetDiff = firstBlockOffset.distance
+        for (backtrack in backtrackLocations) {
+            // As absolute route offset
+            val blockBacktrackStart =
+                backtrack.exactRouteOffset + backtrack.remainingBlockAfterBacktrack
+            val blockBacktrackEnd = blockBacktrackStart + backtrack.skippedBlocksAroundBacktrack
+
+            if (blockBacktrackStart > routeOffset) break // Next backtrack is beyond the input
+
+            if (routeOffset in blockBacktrackStart..blockBacktrackEnd) {
+                // Input is in a range that's in the route path but not in the block path:
+                // result clipped to the start of that range
+                val backtrackStartOnBlock =
+                    Offset<FullBlockPath>(blockBacktrackStart.distance - currentOffsetDiff)
+                return backtrackStartOnBlock
+            }
+
+            currentOffsetDiff += backtrack.skippedBlocksAroundBacktrack
+        }
+        return Offset(routeOffset.distance - currentOffsetDiff)
     }
 
     fun blockToRoute(blockOffset: Offset<FullBlockPath>): Offset<FullRoutePath> {
-        TODO()
+        var currentOffsetDiff = firstBlockOffset.distance
+        for (backtrack in backtrackLocations) {
+            val blockBacktrackStart = backtrack.blockBacktrackStart
+
+            if (blockBacktrackStart.distance > blockOffset.distance + currentOffsetDiff)
+                break // Next backtrack is beyond the input
+
+            currentOffsetDiff += backtrack.skippedBlocksAroundBacktrack
+        }
+        return Offset(blockOffset.distance + currentOffsetDiff)
     }
 
-    fun blockToCovered(blockOffset: Offset<FullBlockPath>): Offset<CoveredPath> {
-        TODO()
-    }
-
-    fun coveredToBlock(coveredOffset: Offset<CoveredPath>): Offset<FullBlockPath> {
-        TODO()
-    }
-
-    fun coveredToHeadTravelled(coveredOffset: Offset<CoveredPath>): Offset<HeadTravelledPath> {
-        TODO()
-    }
-
-    fun headTravelledToCovered(headTravelled: Offset<HeadTravelledPath>): Offset<CoveredPath> {
-        TODO()
-    }
+    // TODO: add remaining conversions to/from FullRoutePath
 }

--- a/core/kt-osrd-path/src/test/kotlin/fr/sncf/osrd/path/PathOffsetProjectorTests.kt
+++ b/core/kt-osrd-path/src/test/kotlin/fr/sncf/osrd/path/PathOffsetProjectorTests.kt
@@ -1,0 +1,106 @@
+package fr.sncf.osrd.path
+
+import fr.sncf.osrd.path.implementations.PathOffsetProjector
+import fr.sncf.osrd.path.interfaces.FullRoutePath
+import fr.sncf.osrd.utils.units.Offset
+import fr.sncf.osrd.utils.units.meters
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PathOffsetProjectorTests {
+    @Test
+    fun simpleTestNoBacktrack() {
+        val firstBlockOffset = Offset<FullRoutePath>(50.meters)
+        val projector =
+            PathOffsetProjector(
+                firstBlockOffset = firstBlockOffset,
+                backtrackLocations = listOf(),
+                // coveredPathBeginOffset = Offset.zero(),
+                // rollingStockLength = 0.meters,
+            )
+
+        assertEquals(Offset(55.meters), projector.blockToRoute(Offset(5.meters)))
+
+        testSymmetry(
+            { projector.blockToRoute(it) },
+            { projector.routeToBlock(it) },
+        )
+    }
+
+    @Test
+    fun testWithBacktrack() {
+        // A and B are in opposite directions, but the route path is displayed in a single line here
+        //
+        // Covered path offsets: A2 + 5m                   B2 + 12m
+        // Covered path offsets:    v                         v
+        // Covered Path:       |----|         (skipped)       |--...>
+        // Routes: -----------------------> | ---------------------->
+        // Routes:       A: 100 meters              B: 100 meters
+        // Blocks: ----------> | ---------> | ----------> | -------->
+        // Blocks:  A1: 70        A2: 30        B1: 45        B2: 55
+        //
+        // Route path: A -> B
+        // Block path: A2 -> B2, NO B1 (fully skipped) nor A1 (before the start)
+
+        // First block offset is before A and B, not pictured here
+        val firstBlockOffset = Offset<FullRoutePath>(70.meters)
+        val backtrack =
+            PathOffsetProjector.BacktrackLocation(
+                exactRouteOffset = Offset(70.meters + 5.meters),
+                remainingBlockAfterBacktrack = 25.meters,
+                skippedBlocksAroundBacktrack = 45.meters,
+                // skippedNextRoute = 45.meters + 12.meters,
+            )
+        val projector =
+            PathOffsetProjector(
+                firstBlockOffset = firstBlockOffset,
+                backtrackLocations = listOf(backtrack),
+                // coveredPathBeginOffset = Offset.zero(),
+                // rollingStockLength = 0.meters,
+            )
+
+        // Before backtrack
+        assertEquals(Offset(73.meters), projector.blockToRoute(Offset(3.meters)))
+
+        // Still on A2 (block before backtrack), but past the actual backtrack point.
+        // In this projection, we're still on the pre-backtrack elements.
+        assertEquals(Offset(85.meters), projector.blockToRoute(Offset(15.meters)))
+
+        // Right after backtrack
+        assertEquals(
+            Offset(100.meters + 45.meters + 5.meters), // A, B1, part of B2
+            projector.blockToRoute(Offset(30.meters + 5.meters)) // A2, part of B2
+        )
+
+        testSymmetry(
+            { projector.blockToRoute(it) },
+            { projector.routeToBlock(it) },
+            -100..300, // Block offsets
+            0 ..< 0, // Route offsets: converting to block will truncate (not symmetrical)
+        )
+    }
+
+    /**
+     * Given two types of offset and functions that convert from one type to the other, test that
+     * converting back and forth doesn't change the value over a given range.
+     */
+    fun <T, U> testSymmetry(
+        oneWay: (Offset<T>) -> Offset<U>,
+        otherWay: (Offset<U>) -> Offset<T>,
+        firstTypeRange: IntRange = -100..100,
+        secondTypeRange: IntRange = -100..100,
+    ) {
+        for (i in firstTypeRange) {
+            val t = Offset<T>(i.meters)
+            val converted = oneWay(t)
+            val convertedBack = otherWay(converted)
+            assertEquals(t, convertedBack)
+        }
+        for (i in secondTypeRange) {
+            val t = Offset<U>(i.meters)
+            val converted = otherWay(t)
+            val convertedBack = oneWay(converted)
+            assertEquals(t, convertedBack)
+        }
+    }
+}


### PR DESCRIPTION
Progress for https://github.com/OpenRailAssociation/osrd/issues/12530

There's only one kind of projection for now, across block and route paths. Just to make sure we're doing it right, as the code is already quite complex. 