### PR TITLE
front: bump vite from 6.3.5 to 7.0.4 in /front

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -147,7 +147,7 @@
         "tsx": "^4.20.3",
         "typescript": "~5.8",
         "vinyl-fs": "^4.0.2",
-        "vite": "^6.3.5",
+        "vite": "^7.0.6",
         "vite-plugin-checker": "^0.10.0",
         "vite-plugin-static-copy": "^3.0.2",
         "vite-tsconfig-paths": "^5.1.4",
@@ -32844,24 +32844,24 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.3.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
-      "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.0.6.tgz",
+      "integrity": "sha512-MHFiOENNBd+Bd9uvc8GEsIzdkn1JxMmEeYX35tI3fv0sJBUTfW5tQsoaOwuY4KhBI09A3dUJ/DXf2yxPVPUceg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2",
-        "postcss": "^8.5.3",
-        "rollup": "^4.34.9",
-        "tinyglobby": "^0.2.13"
+        "fdir": "^6.4.6",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.40.0",
+        "tinyglobby": "^0.2.14"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -32870,14 +32870,14 @@
         "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@types/node": "^20.19.0 || >=22.12.0",
         "jiti": ">=1.21.0",
-        "less": "*",
+        "less": "^4.0.0",
         "lightningcss": "^1.21.0",
-        "sass": "*",
-        "sass-embedded": "*",
-        "stylus": "*",
-        "sugarss": "*",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
         "terser": "^5.16.0",
         "tsx": "^4.8.1",
         "yaml": "^2.4.2"
@@ -33158,9 +33158,9 @@
       }
     },
     "node_modules/vite/node_modules/fdir": {
-      "version": "6.4.4",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
-      "integrity": "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==",
+      "version": "6.4.6",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
+      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -33173,9 +33173,9 @@
       }
     },
     "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/front/package.json
+++ b/front/package.json
@@ -143,7 +143,7 @@
     "tsx": "^4.20.3",
     "typescript": "~5.8",
     "vinyl-fs": "^4.0.2",
-    "vite": "^6.3.5",
+    "vite": "^7.0.6",
     "vite-plugin-checker": "^0.10.0",
     "vite-plugin-static-copy": "^3.0.2",
     "vite-tsconfig-paths": "^5.1.4",

--- a/front/vite.config.ts
+++ b/front/vite.config.ts
@@ -21,9 +21,7 @@ export default defineConfig(({ mode }) => {
       react(),
       viteTsconfigPaths(),
       checker({
-        typescript: {
-          buildMode: true,
-        },
+        typescript: true,
         eslint: {
           lintCommand: 'eslint --ext .ts,.tsx,.js,.jsx src scripts tests *.ts --max-warnings 0',
         },
@@ -46,13 +44,6 @@ export default defineConfig(({ mode }) => {
     build: {
       outDir: 'build',
       sourcemap: true,
-    },
-    css: {
-      preprocessorOptions: {
-        scss: {
-          api: 'modern',
-        },
-      },
     },
     server: {
       open: false,


### PR DESCRIPTION
fixes https://github.com/OpenRailAssociation/osrd/pull/12462 & closes [#12639](https://github.com/OpenRailAssociation/osrd/issues/12639)

Removal of `buildMode: true`: Since recent versions of vite-plugin-checker (v1+), this option has been:
- removed
- or made implicit via project configuration (tsconfig.build.json, composite: true, etc.)
The plugin now relies on the actual TypeScript context, rather than a manual Boolean option.


Removal of `api: ‘modern’`: This field was never part of the official Vite or Sass API. It most likely originated from the time when Vite used an internal or experimental interface to control the Sass compiler.
- api: ‘modern’ was not documented or officially supported.
- He did nothing in Vite 6+, except perhaps silently ignore the option.
- In Vite 7, with stricter typing, it is considered an error since scss must be a SassPreprocessorOptions (and this field does not exist in this interface).