### PR TITLE
Remove weblate

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@
   <a href="https://osrd.fr/en/docs/guides/contribute/"><img src="https://img.shields.io/github/contributors-anon/OpenRailAssociation/osrd" alt="Contributors badge" /></a>
   <a href="https://github.com/OpenRailAssociation/osrd/blob/dev/LICENSE"><img src="https://img.shields.io/badge/license-LGPL-blue.svg" alt="LGPL License badge" /></a>
   <a href="https://github.com/OpenRailAssociation/osrd/actions/workflows/build.yml"><img src="https://github.com/OpenRailAssociation/osrd/actions/workflows/build.yml/badge.svg" alt="Build Status" /></a>
-  <a href="https://hosted.weblate.org/engage/osrd/"><img src="https://hosted.weblate.org/widget/osrd/svg-badge.svg" alt="Translation status" /></a>
   <a href="https://api.reuse.software/info/github.com/OpenRailAssociation/osrd"><img src="https://api.reuse.software/badge/github.com/OpenRailAssociation/osrd" alt="REUSE status" /></a>
   <a href="https://github.com/OpenRailAssociation/technical-committee/blob/main/incubation-process.md"><img src="https://openrailassociation.org/badges/openrail-project-stage-2.svg" alt="Openrail Incubation Stage" /></a>
 </p>


### PR DESCRIPTION
Weblate does not support i18next correctly, poor handling of plurals.

> [!NOTE]
> Following the merge of this PR, the Weblate project will be deleted. 