### PR TITLE
core: paths: implement and use new type objects

### DIFF
--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathBuilder.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathBuilder.kt
@@ -11,18 +11,18 @@ import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.Offset.Companion.max
 import fr.sncf.osrd.utils.units.Offset.Companion.min
 import fr.sncf.osrd.utils.units.meters
+import fr.sncf.osrd.utils.units.sumOffsets
 
 /**
  * This file lists all usual builder functions to generate train paths, with useful private methods
  * to help build them.
  *
- * In the past we've had too many "path conversion methods", the goal here is to only keep the
- * actual use cases and not migrate every way to generate path objects.
- *
  * Note: several functions could be optimized at the cost of increased code complexity, if a
  * profiler leads here.
  */
-fun buildTrainPath(
+
+/** Build a TrainPath from a single block. */
+fun buildTrainPathFromBlock(
     rawInfra: RawInfra,
     blockInfra: BlockInfra,
     blockId: BlockId,
@@ -32,7 +32,6 @@ fun buildTrainPath(
     routeNames: List<String>? = null,
     electricalProfileMapping: ElectricalProfileMapping? = null,
 ): TrainPath {
-    require(routes == null || routeNames == null)
     val blockMap =
         distanceRangeMapOf(
             DistanceRangeMap.RangeMapEntry(
@@ -41,26 +40,118 @@ fun buildTrainPath(
                 BlockRange(blockId, beginOffset, endOffset),
             )
         )
-    val chunkMap = generateTrackChunks(rawInfra, blockInfra, blockMap)
+    return buildTrainPathFromBlockRanges(
+        rawInfra,
+        blockInfra,
+        blockMap,
+        routes,
+        routeNames,
+        electricalProfileMapping,
+    )
+}
+
+/** Build a TrainPath from a list of blocks (each used in full). */
+fun buildTrainPathFromBlocks(
+    rawInfra: RawInfra,
+    blockInfra: BlockInfra,
+    blocks: List<BlockId>,
+    routes: List<RouteId>? = null,
+    routeNames: List<String>? = null,
+    electricalProfileMapping: ElectricalProfileMapping? = null,
+): TrainPath {
+    var prevBlockLength = 0.meters
+    val entries = mutableListOf<DistanceRangeMap.RangeMapEntry<BlockRange>>()
+    for (block in blocks) {
+        val blockLength = blockInfra.getBlockLength(block)
+        entries.add(
+            DistanceRangeMap.RangeMapEntry(
+                prevBlockLength,
+                prevBlockLength + blockLength.distance,
+                BlockRange(block, Offset.zero(), blockLength),
+            )
+        )
+        prevBlockLength += blockLength.distance
+    }
+    val blockMap = distanceRangeMapOf(entries)
+    return buildTrainPathFromBlockRanges(
+        rawInfra,
+        blockInfra,
+        blockMap,
+        routes,
+        routeNames,
+        electricalProfileMapping,
+    )
+}
+
+/** Build a TrainPath from a list of block ranges. */
+fun buildTrainPathFromBlockRanges(
+    rawInfra: RawInfra,
+    blockInfra: BlockInfra,
+    blockRanges: DistanceRangeMap<BlockRange>,
+    routes: List<RouteId>? = null,
+    routeNames: List<String>? = null,
+    electricalProfileMapping: ElectricalProfileMapping? = null,
+): TrainPath {
+    require(routes == null || routeNames == null)
+    val chunkMap = generateTrackChunks(rawInfra, blockInfra, blockRanges)
     val routeIds = routes ?: routeNames?.map { rawInfra.getRouteFromName(it) }
     val routeMap = routeIds?.let { generateRouteRanges(rawInfra, chunkMap, it) }
     return TrainPathNoBacktrack(
         rawInfra,
         makePathProperties(rawInfra, buildChunkPath(rawInfra, chunkMap), routeIds),
         routeMap,
-        blockMap,
+        blockRanges,
         chunkMap,
         electricalProfileMapping,
     )
 }
 
+/**
+ * Build a TrainPath from chunk ranges. Blocks are filled in by picking any block on each range.
+ * Shouldn't be used where blocks actually matter (such as conflict detection).
+ */
+fun buildTrainPathFromChunks(
+    rawInfra: RawInfra,
+    blockInfra: BlockInfra,
+    chunkRanges: DistanceRangeMap<DirChunkRange>,
+    routes: List<RouteId>? = null,
+    routeNames: List<String>? = null,
+    electricalProfileMapping: ElectricalProfileMapping? = null,
+): TrainPath {
+    val blockRanges = findBlockPath(rawInfra, blockInfra, chunkRanges)
+    return buildTrainPathFromBlockRanges(
+        rawInfra,
+        blockInfra,
+        blockRanges,
+        routes,
+        routeNames,
+        electricalProfileMapping,
+    )
+}
+
+/** Create a range map from list of ranges, mapping them to the path offset (starting at 0). */
+fun <ValueType, OffsetType> buildRangeMap(
+    ranges: List<GenericLinearRange<ValueType, OffsetType>>
+): DistanceRangeMap<GenericLinearRange<ValueType, OffsetType>> {
+    var prevRangeLength = 0.meters
+    val entries =
+        mutableListOf<DistanceRangeMap.RangeMapEntry<GenericLinearRange<ValueType, OffsetType>>>()
+    for (range in ranges) {
+        entries.add(
+            DistanceRangeMap.RangeMapEntry(prevRangeLength, prevRangeLength + range.length, range)
+        )
+        prevRangeLength += range.length
+    }
+    return distanceRangeMapOf(entries)
+}
+
+/** Generate the chunk ranges from given block ranges. */
 private fun generateTrackChunks(
     rawInfra: RawInfra,
     blockInfra: BlockInfra,
     blocks: DistanceRangeMap<BlockRange>,
 ): DistanceRangeMap<DirChunkRange> {
-    val res = distanceRangeMapOf<DirChunkRange>()
-    var prevUsedChunkLength = 0.meters
+    val res = mutableListOf<DirChunkRange>()
     for (entry in blocks) {
         val blockRange = entry.value
         var currentChunkOffset = Offset<Block>(0.meters)
@@ -72,24 +163,26 @@ private fun generateTrackChunks(
             val chunkRange =
                 DirChunkRange(chunk, max(chunkStart, Offset.zero()), min(chunkEnd, chunkLength))
             if (chunkRange.length > 0.meters) {
-                res.put(prevUsedChunkLength, prevUsedChunkLength + chunkRange.length, chunkRange)
-                prevUsedChunkLength += chunkRange.length
+                res.add(chunkRange)
             }
 
             currentChunkOffset += chunkLength.distance
         }
     }
-    return res
+    return buildRangeMap(res)
 }
 
+/**
+ * Generate the route ranges from given chunk ranges, with actual route IDs given as input. This
+ * just maps the offsets and precise ranges.
+ */
 private fun generateRouteRanges(
     rawInfra: RawInfra,
     chunks: DistanceRangeMap<DirChunkRange>,
     routes: List<RouteId>,
 ): DistanceRangeMap<RouteRange> {
-    val res = distanceRangeMapOf<RouteRange>()
+    val res = mutableListOf<RouteRange>()
     val mappedChunks = chunks.map { it.value }.associateBy { it.value }
-    var prevRouteUsedLength = 0.meters
     for (route in routes) {
         // We look for the first and last point where the route is used by a chunk.
         // We assume that the chunk list is continuous and follows the route.
@@ -109,21 +202,56 @@ private fun generateRouteRanges(
 
         val usedRouteLength = usedRouteEnd - usedRouteStart
         if (usedRouteLength > 0.meters) {
-            res.put(
-                prevRouteUsedLength,
-                prevRouteUsedLength + usedRouteLength,
-                RouteRange(route, usedRouteStart, usedRouteEnd),
-            )
-            prevRouteUsedLength += usedRouteLength
+            res.add(RouteRange(route, usedRouteStart, usedRouteEnd))
         }
     }
-    return res
+    return buildRangeMap(res)
 }
 
+/**
+ * Build a ChunkPath from the given chunk ranges. Used to instantiate the internal `PathProperties`
+ * instance.
+ */
 private fun buildChunkPath(infra: RawInfra, chunkMap: DistanceRangeMap<DirChunkRange>): ChunkPath {
     val chunkRanges = chunkMap.asList().map { it.value }
     val chunkIds = chunkRanges.map { it.value }
     val beginOffset = chunkRanges.first().from
     val endOffset = beginOffset + (chunkMap.upperBound() - chunkMap.lowerBound())
     return buildChunkPath(infra, chunkIds.toIdxList(), beginOffset.cast(), endOffset.cast())
+}
+
+/**
+ * Find a valid block sequence covering the path.
+ *
+ * We don't look for the best matching one, blocks may only be partially used even in the middle of
+ * the path. Used in places where exact blocks don't matter that much (like path properties
+ * endpoint).
+ */
+private fun findBlockPath(
+    infra: RawInfra,
+    blockInfra: BlockInfra,
+    chunks: DistanceRangeMap<DirChunkRange>,
+): DistanceRangeMap<BlockRange> {
+    val res = mutableListOf<BlockRange>()
+    for (chunkEntry in chunks) {
+        val dirChunkRange = chunkEntry.value
+        val dirChunkId = dirChunkRange.value
+        val block =
+            blockInfra.getBlocksFromTrackChunk(dirChunkId.value, dirChunkId.direction).first()
+        val allBlockChunks = blockInfra.getTrackChunksFromBlock(block)
+        val chunkOffsetOnBlock =
+            allBlockChunks
+                .takeWhile { it != dirChunkId }
+                .map { infra.getTrackChunkLength(it.value) }
+                .sumOffsets()
+                .cast<Block>()
+        val newRange =
+            BlockRange(
+                block,
+                chunkOffsetOnBlock + dirChunkRange.from.distance,
+                chunkOffsetOnBlock + dirChunkRange.to.distance,
+            )
+        res.add(newRange)
+    }
+    return buildRangeMap(res)
 }

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathBuilder.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathBuilder.kt
@@ -1,0 +1,129 @@
+package fr.sncf.osrd.path.implementations
+
+import fr.sncf.osrd.path.interfaces.*
+import fr.sncf.osrd.path.legacy_objects.ElectricalProfileMapping
+import fr.sncf.osrd.sim_infra.api.*
+import fr.sncf.osrd.utils.DistanceRangeMap
+import fr.sncf.osrd.utils.distanceRangeMapOf
+import fr.sncf.osrd.utils.toIdxList
+import fr.sncf.osrd.utils.units.Distance
+import fr.sncf.osrd.utils.units.Offset
+import fr.sncf.osrd.utils.units.Offset.Companion.max
+import fr.sncf.osrd.utils.units.Offset.Companion.min
+import fr.sncf.osrd.utils.units.meters
+
+/**
+ * This file lists all usual builder functions to generate train paths, with useful private methods
+ * to help build them.
+ *
+ * In the past we've had too many "path conversion methods", the goal here is to only keep the
+ * actual use cases and not migrate every way to generate path objects.
+ *
+ * Note: several functions could be optimized at the cost of increased code complexity, if a
+ * profiler leads here.
+ */
+fun buildTrainPath(
+    rawInfra: RawInfra,
+    blockInfra: BlockInfra,
+    blockId: BlockId,
+    beginOffset: Offset<Block> = Offset(0.meters),
+    endOffset: Offset<Block> = blockInfra.getBlockLength(blockId),
+    routes: List<RouteId>? = null,
+    routeNames: List<String>? = null,
+    electricalProfileMapping: ElectricalProfileMapping? = null,
+): TrainPath {
+    require(routes == null || routeNames == null)
+    val blockMap =
+        distanceRangeMapOf(
+            DistanceRangeMap.RangeMapEntry(
+                0.meters,
+                endOffset - beginOffset,
+                BlockRange(blockId, beginOffset, endOffset),
+            )
+        )
+    val chunkMap = generateTrackChunks(rawInfra, blockInfra, blockMap)
+    val routeIds = routes ?: routeNames?.map { rawInfra.getRouteFromName(it) }
+    val routeMap = routeIds?.let { generateRouteRanges(rawInfra, chunkMap, it) }
+    return TrainPathNoBacktrack(
+        rawInfra,
+        makePathProperties(rawInfra, buildChunkPath(rawInfra, chunkMap), routeIds),
+        routeMap,
+        blockMap,
+        chunkMap,
+        electricalProfileMapping,
+    )
+}
+
+private fun generateTrackChunks(
+    rawInfra: RawInfra,
+    blockInfra: BlockInfra,
+    blocks: DistanceRangeMap<BlockRange>,
+): DistanceRangeMap<DirChunkRange> {
+    val res = distanceRangeMapOf<DirChunkRange>()
+    var prevUsedChunkLength = 0.meters
+    for (entry in blocks) {
+        val blockRange = entry.value
+        var currentChunkOffset = Offset<Block>(0.meters)
+        for (chunk in blockInfra.getTrackChunksFromBlock(blockRange.value)) {
+            val chunkLength = rawInfra.getTrackChunkLength(chunk.value)
+
+            val chunkStart = Offset<TrackChunk>(blockRange.from - currentChunkOffset)
+            val chunkEnd = Offset<TrackChunk>(blockRange.to - currentChunkOffset)
+            val chunkRange =
+                DirChunkRange(chunk, max(chunkStart, Offset.zero()), min(chunkEnd, chunkLength))
+            if (chunkRange.length > 0.meters) {
+                res.put(prevUsedChunkLength, prevUsedChunkLength + chunkRange.length, chunkRange)
+                prevUsedChunkLength += chunkRange.length
+            }
+
+            currentChunkOffset += chunkLength.distance
+        }
+    }
+    return res
+}
+
+private fun generateRouteRanges(
+    rawInfra: RawInfra,
+    chunks: DistanceRangeMap<DirChunkRange>,
+    routes: List<RouteId>,
+): DistanceRangeMap<RouteRange> {
+    val res = distanceRangeMapOf<RouteRange>()
+    val mappedChunks = chunks.map { it.value }.associateBy { it.value }
+    var prevRouteUsedLength = 0.meters
+    for (route in routes) {
+        // We look for the first and last point where the route is used by a chunk.
+        // We assume that the chunk list is continuous and follows the route.
+        var usedRouteStart = Offset<Route>(Distance.MAX)
+        var usedRouteEnd = Offset<Route>(0.meters)
+        val chunksOnRoute = rawInfra.getChunksOnRoute(route)
+
+        var chunkOffsetOnRoute = Offset<Route>(0.meters)
+        for (chunk in chunksOnRoute) {
+            mappedChunks[chunk]?.let { locatedChunk ->
+                usedRouteStart =
+                    min(usedRouteStart, chunkOffsetOnRoute + locatedChunk.from.distance)
+                usedRouteEnd = max(usedRouteEnd, chunkOffsetOnRoute + locatedChunk.to.distance)
+            }
+            chunkOffsetOnRoute += rawInfra.getTrackChunkLength(chunk.value).distance
+        }
+
+        val usedRouteLength = usedRouteEnd - usedRouteStart
+        if (usedRouteLength > 0.meters) {
+            res.put(
+                prevRouteUsedLength,
+                prevRouteUsedLength + usedRouteLength,
+                RouteRange(route, usedRouteStart, usedRouteEnd),
+            )
+            prevRouteUsedLength += usedRouteLength
+        }
+    }
+    return res
+}
+
+private fun buildChunkPath(infra: RawInfra, chunkMap: DistanceRangeMap<DirChunkRange>): ChunkPath {
+    val chunkRanges = chunkMap.asList().map { it.value }
+    val chunkIds = chunkRanges.map { it.value }
+    val beginOffset = chunkRanges.first().from
+    val endOffset = beginOffset + (chunkMap.upperBound() - chunkMap.lowerBound())
+    return buildChunkPath(infra, chunkIds.toIdxList(), beginOffset.cast(), endOffset.cast())
+}

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathBuilder.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathBuilder.kt
@@ -129,6 +129,40 @@ fun buildTrainPathFromChunks(
     )
 }
 
+/**
+ * Build a TrainPath from chunk path. Blocks are filled in by picking any block on each range.
+ * Shouldn't be used where blocks actually matter (such as conflict detection).
+ */
+fun buildTrainPathFromChunkPath(
+    rawInfra: RawInfra,
+    blockInfra: BlockInfra,
+    chunkPath: ChunkPath,
+    routes: List<RouteId>? = null,
+    routeNames: List<String>? = null,
+    electricalProfileMapping: ElectricalProfileMapping? = null,
+): TrainPath {
+    val chunkRanges = mutableListOf<DirChunkRange>()
+    var prevChunkLength = 0.meters
+    for ((i, chunk) in chunkPath.chunks.withIndex()) {
+        val isFirst = i == 0
+        val isLast = i == chunkPath.chunks.size - 1
+        val chunkLength = rawInfra.getTrackChunkLength(chunk.value)
+        val from = if (isFirst) chunkPath.beginOffset.cast<TrackChunk>() else Offset.zero()
+        var to = chunkLength
+        if (isLast) to = Offset(chunkPath.endOffset.distance - prevChunkLength)
+        chunkRanges.add(DirChunkRange(chunk, from, to))
+        prevChunkLength += chunkLength.distance
+    }
+    return buildTrainPathFromChunks(
+        rawInfra,
+        blockInfra,
+        buildRangeMap(chunkRanges),
+        routes,
+        routeNames,
+        electricalProfileMapping,
+    )
+}
+
 /** Create a range map from list of ranges, mapping them to the path offset (starting at 0). */
 fun <ValueType, OffsetType> buildRangeMap(
     ranges: List<GenericLinearRange<ValueType, OffsetType>>

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathBuilder.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathBuilder.kt
@@ -1,10 +1,11 @@
 package fr.sncf.osrd.path.implementations
 
+import com.google.common.collect.BoundType
+import com.google.common.collect.ImmutableRangeMap
+import com.google.common.collect.Range
 import fr.sncf.osrd.path.interfaces.*
 import fr.sncf.osrd.path.legacy_objects.ElectricalProfileMapping
 import fr.sncf.osrd.sim_infra.api.*
-import fr.sncf.osrd.utils.DistanceRangeMap
-import fr.sncf.osrd.utils.distanceRangeMapOf
 import fr.sncf.osrd.utils.toIdxList
 import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Offset
@@ -33,12 +34,9 @@ fun buildTrainPathFromBlock(
     electricalProfileMapping: ElectricalProfileMapping? = null,
 ): TrainPath {
     val blockMap =
-        distanceRangeMapOf(
-            DistanceRangeMap.RangeMapEntry(
-                0.meters,
-                endOffset - beginOffset,
-                BlockRange(blockId, beginOffset, endOffset),
-            )
+        ImmutableRangeMap.of(
+            Range.closed(Offset<TrainPath>(0.meters), Offset(endOffset - beginOffset)),
+            BlockRange(blockId, beginOffset, endOffset),
         )
     return buildTrainPathFromBlockRanges(
         rawInfra,
@@ -59,20 +57,17 @@ fun buildTrainPathFromBlocks(
     routeNames: List<String>? = null,
     electricalProfileMapping: ElectricalProfileMapping? = null,
 ): TrainPath {
-    var prevBlockLength = 0.meters
-    val entries = mutableListOf<DistanceRangeMap.RangeMapEntry<BlockRange>>()
+    var prevBlockFinalOffset: Offset<TrainPath> = Offset.zero()
+    val builder = ImmutableRangeMap.builder<Offset<TrainPath>, BlockRange>()
     for (block in blocks) {
         val blockLength = blockInfra.getBlockLength(block)
-        entries.add(
-            DistanceRangeMap.RangeMapEntry(
-                prevBlockLength,
-                prevBlockLength + blockLength.distance,
-                BlockRange(block, Offset.zero(), blockLength),
-            )
+        builder.put(
+            Range.closedOpen(prevBlockFinalOffset, prevBlockFinalOffset + blockLength.distance),
+            BlockRange(block, Offset.zero(), blockLength),
         )
-        prevBlockLength += blockLength.distance
+        prevBlockFinalOffset += blockLength.distance
     }
-    val blockMap = distanceRangeMapOf(entries)
+    val blockMap = builder.build()
     return buildTrainPathFromBlockRanges(
         rawInfra,
         blockInfra,
@@ -87,10 +82,11 @@ fun buildTrainPathFromBlocks(
 fun buildTrainPathFromBlockRanges(
     rawInfra: RawInfra,
     blockInfra: BlockInfra,
-    blockRanges: DistanceRangeMap<BlockRange>,
+    blockRanges: LinearObjectMap<BlockRange>,
     routes: List<RouteId>? = null,
     routeNames: List<String>? = null,
     electricalProfileMapping: ElectricalProfileMapping? = null,
+    haveApproximateBlocks: Boolean = false,
 ): TrainPath {
     require(routes == null || routeNames == null)
     val chunkMap = generateTrackChunks(rawInfra, blockInfra, blockRanges)
@@ -98,11 +94,13 @@ fun buildTrainPathFromBlockRanges(
     val routeMap = routeIds?.let { generateRouteRanges(rawInfra, chunkMap, it) }
     return TrainPathNoBacktrack(
         rawInfra,
+        blockInfra,
         makePathProperties(rawInfra, buildChunkPath(rawInfra, chunkMap), routeIds),
         routeMap,
         blockRanges,
         chunkMap,
         electricalProfileMapping,
+        haveApproximateBlocks = haveApproximateBlocks,
     )
 }
 
@@ -113,7 +111,7 @@ fun buildTrainPathFromBlockRanges(
 fun buildTrainPathFromChunks(
     rawInfra: RawInfra,
     blockInfra: BlockInfra,
-    chunkRanges: DistanceRangeMap<DirChunkRange>,
+    chunkRanges: LinearObjectMap<DirChunkRange>,
     routes: List<RouteId>? = null,
     routeNames: List<String>? = null,
     electricalProfileMapping: ElectricalProfileMapping? = null,
@@ -126,6 +124,7 @@ fun buildTrainPathFromChunks(
         routes,
         routeNames,
         electricalProfileMapping,
+        haveApproximateBlocks = true,
     )
 }
 
@@ -142,16 +141,16 @@ fun buildTrainPathFromChunkPath(
     electricalProfileMapping: ElectricalProfileMapping? = null,
 ): TrainPath {
     val chunkRanges = mutableListOf<DirChunkRange>()
-    var prevChunkLength = 0.meters
+    var prevChunkFinalOffset = 0.meters
     for ((i, chunk) in chunkPath.chunks.withIndex()) {
         val isFirst = i == 0
         val isLast = i == chunkPath.chunks.size - 1
         val chunkLength = rawInfra.getTrackChunkLength(chunk.value)
         val from = if (isFirst) chunkPath.beginOffset.cast<TrackChunk>() else Offset.zero()
         var to = chunkLength
-        if (isLast) to = Offset(chunkPath.endOffset.distance - prevChunkLength)
+        if (isLast) to = Offset(chunkPath.endOffset.distance - prevChunkFinalOffset)
         chunkRanges.add(DirChunkRange(chunk, from, to))
-        prevChunkLength += chunkLength.distance
+        prevChunkFinalOffset += chunkLength.distance
     }
     return buildTrainPathFromChunks(
         rawInfra,
@@ -166,44 +165,82 @@ fun buildTrainPathFromChunkPath(
 /** Create a range map from list of ranges, mapping them to the path offset (starting at 0). */
 fun <ValueType, OffsetType> buildRangeMap(
     ranges: List<GenericLinearRange<ValueType, OffsetType>>
-): DistanceRangeMap<GenericLinearRange<ValueType, OffsetType>> {
-    var prevRangeLength = 0.meters
-    val entries =
-        mutableListOf<DistanceRangeMap.RangeMapEntry<GenericLinearRange<ValueType, OffsetType>>>()
+): LinearObjectMap<GenericLinearRange<ValueType, OffsetType>> {
+    // Merge adjacent ranges of the same object
+    val merged = mutableListOf<GenericLinearRange<ValueType, OffsetType>>()
     for (range in ranges) {
-        entries.add(
-            DistanceRangeMap.RangeMapEntry(prevRangeLength, prevRangeLength + range.length, range)
-        )
-        prevRangeLength += range.length
+        if (merged.isEmpty() || merged.last().value != range.value) merged.add(range)
+        else merged[merged.size - 1] = merged.last().copy(to = range.to)
     }
-    return distanceRangeMapOf(entries)
+
+    // We need to adjust which intervals are closed or open to keep 0-length ranges
+    val zeroLengthIndexes = merged.map { it.from == it.to }
+    for ((i, isZeroLength) in zeroLengthIndexes.withIndex()) {
+        // This case *could* be supported, but it's a sign something is likely to be wrong.
+        // The test can be removed if we need to support it, in the meantime it's a good smoke test.
+        assert(!isZeroLength || i == 0 || i == zeroLengthIndexes.size - 1) {
+            "Zero length range that isn't first or last"
+        }
+    }
+
+    var prevRangeLength: Offset<TrainPath> = Offset.zero()
+    val builder =
+        ImmutableRangeMap.builder<Offset<TrainPath>, GenericLinearRange<ValueType, OffsetType>>()
+    for ((i, value) in merged.withIndex()) {
+        // In normal cases, we always include lower bound and never include upper bound.
+        // Exceptions: the very first and last bounds are included, and a zero-length range is
+        // included in both directions. The next range then needs to have its lower bound excluded.
+        // Two consecutive zero-length ranges are not supported.
+        val includeLowerEndpoint = i == 0 || !zeroLengthIndexes[i - 1]
+        val includeUpperEndpoint = i == merged.size - 1 || zeroLengthIndexes[i]
+        fun mapBoundType(included: Boolean) = if (included) BoundType.CLOSED else BoundType.OPEN
+        val range =
+            Range.range(
+                prevRangeLength,
+                mapBoundType(includeLowerEndpoint),
+                prevRangeLength + value.length,
+                mapBoundType(includeUpperEndpoint),
+            )
+        builder.put(range, value)
+        prevRangeLength += value.length
+    }
+    return builder.build()
 }
 
 /** Generate the chunk ranges from given block ranges. */
 private fun generateTrackChunks(
     rawInfra: RawInfra,
     blockInfra: BlockInfra,
-    blocks: DistanceRangeMap<BlockRange>,
-): DistanceRangeMap<DirChunkRange> {
+    blocks: LinearObjectMap<BlockRange>,
+): LinearObjectMap<DirChunkRange> {
     val res = mutableListOf<DirChunkRange>()
-    for (entry in blocks) {
-        val blockRange = entry.value
+    for (blockRange in blocks.asMapOfRanges().values) {
         var currentChunkOffset = Offset<Block>(0.meters)
         for (chunk in blockInfra.getTrackChunksFromBlock(blockRange.value)) {
             val chunkLength = rawInfra.getTrackChunkLength(chunk.value)
 
             val chunkStart = Offset<TrackChunk>(blockRange.from - currentChunkOffset)
             val chunkEnd = Offset<TrackChunk>(blockRange.to - currentChunkOffset)
-            val chunkRange =
-                DirChunkRange(chunk, max(chunkStart, Offset.zero()), min(chunkEnd, chunkLength))
-            if (chunkRange.length > 0.meters) {
+            if (
+                chunkStart <= chunkEnd &&
+                    Offset.zero<TrackChunk>() <= chunkEnd &&
+                    chunkStart <= chunkLength
+            ) {
+                val chunkRange =
+                    DirChunkRange(chunk, max(chunkStart, Offset.zero()), min(chunkEnd, chunkLength))
                 res.add(chunkRange)
             }
 
             currentChunkOffset += chunkLength.distance
         }
     }
-    return buildRangeMap(res)
+
+    // We need to filter out zero-length ranges that aren't first or last
+    val filtered = mutableListOf<DirChunkRange>()
+    for ((i, chunkRange) in res.withIndex()) {
+        if (i == 0 || i == res.size - 1 || chunkRange.length > 0.meters) filtered.add(chunkRange)
+    }
+    return buildRangeMap(filtered)
 }
 
 /**
@@ -212,11 +249,11 @@ private fun generateTrackChunks(
  */
 private fun generateRouteRanges(
     rawInfra: RawInfra,
-    chunks: DistanceRangeMap<DirChunkRange>,
+    chunks: LinearObjectMap<DirChunkRange>,
     routes: List<RouteId>,
-): DistanceRangeMap<RouteRange> {
+): LinearObjectMap<RouteRange> {
     val res = mutableListOf<RouteRange>()
-    val mappedChunks = chunks.map { it.value }.associateBy { it.value }
+    val mappedChunks = chunks.asMapOfRanges().map { it.value }.associateBy { it.value }
     for (route in routes) {
         // We look for the first and last point where the route is used by a chunk.
         // We assume that the chunk list is continuous and follows the route.
@@ -246,11 +283,12 @@ private fun generateRouteRanges(
  * Build a ChunkPath from the given chunk ranges. Used to instantiate the internal `PathProperties`
  * instance.
  */
-private fun buildChunkPath(infra: RawInfra, chunkMap: DistanceRangeMap<DirChunkRange>): ChunkPath {
-    val chunkRanges = chunkMap.asList().map { it.value }
+private fun buildChunkPath(infra: RawInfra, chunkMap: LinearObjectMap<DirChunkRange>): ChunkPath {
+    val chunkRanges = chunkMap.asMapOfRanges().map { it.value }
     val chunkIds = chunkRanges.map { it.value }
     val beginOffset = chunkRanges.first().from
-    val endOffset = beginOffset + (chunkMap.upperBound() - chunkMap.lowerBound())
+    val endOffset =
+        beginOffset + (chunkMap.span().upperEndpoint() - chunkMap.span().lowerEndpoint())
     return buildChunkPath(infra, chunkIds.toIdxList(), beginOffset.cast(), endOffset.cast())
 }
 
@@ -264,10 +302,10 @@ private fun buildChunkPath(infra: RawInfra, chunkMap: DistanceRangeMap<DirChunkR
 private fun findBlockPath(
     infra: RawInfra,
     blockInfra: BlockInfra,
-    chunks: DistanceRangeMap<DirChunkRange>,
-): DistanceRangeMap<BlockRange> {
+    chunks: LinearObjectMap<DirChunkRange>,
+): LinearObjectMap<BlockRange> {
     val res = mutableListOf<BlockRange>()
-    for (chunkEntry in chunks) {
+    for (chunkEntry in chunks.asMapOfRanges()) {
         val dirChunkRange = chunkEntry.value
         val dirChunkId = dirChunkRange.value
         val block =

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathImpl.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathImpl.kt
@@ -1,15 +1,17 @@
 package fr.sncf.osrd.path.implementations
 
 import com.google.common.collect.ImmutableRangeMap
+import com.google.common.collect.Range
 import com.google.common.collect.RangeMap
 import fr.sncf.osrd.path.interfaces.*
 import fr.sncf.osrd.path.legacy_objects.ElectricalProfileMapping
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.sim_infra.impl.makeDirChunk
-import fr.sncf.osrd.utils.DistanceRangeMap
-import fr.sncf.osrd.utils.distanceRangeMapOf
 import fr.sncf.osrd.utils.units.Distance
+import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
+import fr.sncf.osrd.utils.units.Offset.Companion.max
+import fr.sncf.osrd.utils.units.Offset.Companion.min
 import fr.sncf.osrd.utils.units.meters
 
 /**
@@ -18,26 +20,43 @@ import fr.sncf.osrd.utils.units.meters
  */
 data class TrainPathNoBacktrack(
     private val rawInfra: RawInfra,
+    private val blockInfra: BlockInfra,
     private val pathProperties: PathProperties,
-    private val routes: DistanceRangeMap<RouteRange>?,
-    private val blocks: DistanceRangeMap<BlockRange>,
-    private val chunks: DistanceRangeMap<DirChunkRange>,
+    private val routes: LinearObjectMap<RouteRange>?,
+    private val blocks: LinearObjectMap<BlockRange>,
+    private val chunks: LinearObjectMap<DirChunkRange>,
     private val electricalProfileMapping: ElectricalProfileMapping?,
+    // Set to true if the blocks have been generated from the track path. Throws an error if the
+    // routes are read. Note: we may eventually want to turn the error into a warning, if we do want
+    // approximate blocks along the path (when we lack context and don't have the actual ones).
+    // TODO: always forward actual blocks, from pathfinding to any Train Path constructor
+    private val haveApproximateBlocks: Boolean,
 ) : PathProperties by pathProperties, TrainPath {
 
     private val cachedEnvelopeSimPath by lazy { computeEnvelopeSimPath() }
 
     init {
+        // The sanity checks here are quite exhaustive and might be expensive to compute.
+        // Once the path types are stable, we can remove some of the tests.
         fun <ValueType, OffsetType> checkRangeMap(
-            map: DistanceRangeMap<GenericLinearRange<ValueType, OffsetType>>
+            map: LinearObjectMap<GenericLinearRange<ValueType, OffsetType>>,
+            objectLength: (ValueType) -> Length<OffsetType>,
         ) {
-            for (entry in map) require(entry.value.length == (entry.upper - entry.lower))
-            require(map.lowerBound() == 0.meters)
-            require(map.upperBound() == getLength())
+            val entries = map.asMapOfRanges()
+            for ((key, value) in entries) {
+                require(value.length == (key.upperEndpoint() - key.lowerEndpoint()))
+                require(value.from >= Offset.zero())
+                require(value.to <= objectLength(value.value))
+            }
+            require(map.span().lowerEndpoint() == Offset.zero<TrainPath>())
+            require(map.span().upperEndpoint() == getTypedLength())
         }
-        routes?.let { if (!it.isEmpty()) checkRangeMap(it) }
-        checkRangeMap(blocks)
-        checkRangeMap(chunks)
+        routes?.let {
+            if (!routes.asMapOfRanges().isEmpty())
+                checkRangeMap(routes) { rawInfra.getRouteLength(it) }
+        }
+        checkRangeMap(blocks) { blockInfra.getBlockLength(it) }
+        checkRangeMap(chunks) { rawInfra.getTrackChunkLength(it.value) }
     }
 
     override fun subPath(from: Offset<TrainPath>?, to: Offset<TrainPath>?): TrainPath {
@@ -45,19 +64,28 @@ data class TrainPathNoBacktrack(
         val toDist = to ?: Offset(getLength())
         return TrainPathNoBacktrack(
             rawInfra = rawInfra,
+            blockInfra = blockInfra,
             pathProperties = PathPropertiesView(pathProperties, fromDist.cast(), toDist.cast()),
             routes = routes?.let { linearObjectSubMap(it, fromDist, toDist) },
             blocks = linearObjectSubMap(blocks, fromDist, toDist),
             chunks = linearObjectSubMap(chunks, fromDist, toDist),
             electricalProfileMapping = electricalProfileMapping,
+            haveApproximateBlocks = haveApproximateBlocks,
         )
     }
 
-    override fun getBlocks(): DistanceRangeMap<BlockRange> = blocks
+    override fun getTypedLength(): Length<TrainPath> {
+        return Length(getLength())
+    }
 
-    override fun getRoutes(): DistanceRangeMap<RouteRange> = routes!!
+    override fun getBlocks(): LinearObjectMap<BlockRange> {
+        require(!haveApproximateBlocks)
+        return blocks
+    }
 
-    override fun getChunks(): DistanceRangeMap<DirChunkRange> = chunks
+    override fun getRoutes(): LinearObjectMap<RouteRange> = routes!!
+
+    override fun getChunks(): LinearObjectMap<DirChunkRange> = chunks
 
     override val length: Double
         get() = pathProperties.getLength().meters
@@ -90,31 +118,46 @@ data class TrainPathNoBacktrack(
 
     /** Truncate the distance range maps of linear objects, updating the underlying object range */
     private fun <ValueType, OffsetType> linearObjectSubMap(
-        map: DistanceRangeMap<GenericLinearRange<ValueType, OffsetType>>,
+        map: LinearObjectMap<GenericLinearRange<ValueType, OffsetType>>,
         from: Offset<TrainPath>,
         to: Offset<TrainPath>,
-    ): DistanceRangeMap<GenericLinearRange<ValueType, OffsetType>> {
-        val newEntries =
-            map.map { entry ->
-                    var value = entry.value
-                    val (lower, upper, _) = entry
-                    val truncatedStartDist = from.distance - lower
-                    val truncatedEndDist = upper - to.distance
+    ): LinearObjectMap<GenericLinearRange<ValueType, OffsetType>> {
+        val newMapEntries =
+            map.asMapOfRanges().mapValues { (key, value) ->
+                var value = value
+                val lower = key.lowerEndpoint()
+                val upper = key.upperEndpoint()
+                val truncatedStartDist = from.distance - lower.distance
+                val truncatedEndDist = upper.distance - to.distance
 
-                    if (truncatedStartDist > 0.meters) {
-                        value = value.copy(from = value.from + truncatedStartDist)
-                    }
-                    if (truncatedEndDist > 0.meters) {
-                        value = value.copy(to = value.to - truncatedStartDist)
-                    }
-                    entry.copy(value = value)
+                if (truncatedStartDist > 0.meters) {
+                    value = value.copy(from = value.from + truncatedStartDist)
                 }
-                .filter { it.lower < it.upper }
-        var res = distanceRangeMapOf<GenericLinearRange<ValueType, OffsetType>>()
-        res.putMany(newEntries)
-        res = res.subMap(from.distance, to.distance)
-        res.shiftPositions(-from.distance)
-        return res
+                if (truncatedEndDist > 0.meters) {
+                    value = value.copy(to = value.to - truncatedStartDist)
+                }
+                value
+            }
+        val builder =
+            ImmutableRangeMap.builder<
+                Offset<TrainPath>,
+                GenericLinearRange<ValueType, OffsetType>,
+            >()
+        for (entry in newMapEntries) {
+            val lower = max(entry.key.lowerEndpoint() - from.distance, Offset.zero())
+            val upper = min(entry.key.lowerEndpoint() - from.distance, getTypedLength())
+            if (lower <= upper) {
+                val newKey =
+                    Range.range(
+                        lower,
+                        entry.key.lowerBoundType(),
+                        upper,
+                        entry.key.upperBoundType(),
+                    )
+                builder.put(newKey, entry.value)
+            }
+        }
+        return builder.build()
     }
 
     /** *Debugging purpose*. We try to find the actual names of underlying objects. */
@@ -125,11 +168,16 @@ data class TrainPathNoBacktrack(
             }
         }
         fun <T, U> mapToPrintable(
-            map: DistanceRangeMap<GenericLinearRange<T, U>>?,
+            map: LinearObjectMap<GenericLinearRange<T, U>>?,
             toPrintable: (T) -> String,
         ): String {
-            return map?.mapValues {
-                    PrintableRange(it.from.distance, it.to.distance, toPrintable(it.value))
+            return map?.asMapOfRanges()
+                ?.mapValues {
+                    PrintableRange(
+                        it.key.lowerEndpoint().distance,
+                        it.key.upperEndpoint().distance,
+                        toPrintable(it.value.value),
+                    )
                 }
                 .toString()
         }

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathImpl.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathImpl.kt
@@ -5,8 +5,10 @@ import com.google.common.collect.RangeMap
 import fr.sncf.osrd.path.interfaces.*
 import fr.sncf.osrd.path.legacy_objects.ElectricalProfileMapping
 import fr.sncf.osrd.sim_infra.api.*
+import fr.sncf.osrd.sim_infra.impl.makeDirChunk
 import fr.sncf.osrd.utils.DistanceRangeMap
 import fr.sncf.osrd.utils.distanceRangeMapOf
+import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 
@@ -113,5 +115,27 @@ data class TrainPathNoBacktrack(
         res = res.subMap(from.distance, to.distance)
         res.shiftPositions(-from.distance)
         return res
+    }
+
+    /** *Debugging purpose*. We try to find the actual names of underlying objects. */
+    override fun toString(): String {
+        data class PrintableRange<T>(val from: Distance, val to: Distance, val value: T) {
+            override fun toString(): String {
+                return "($value[$from,$to])"
+            }
+        }
+        fun <T, U> mapToPrintable(
+            map: DistanceRangeMap<GenericLinearRange<T, U>>?,
+            toPrintable: (T) -> String,
+        ): String {
+            return map?.mapValues {
+                    PrintableRange(it.from.distance, it.to.distance, toPrintable(it.value))
+                }
+                .toString()
+        }
+        val chunks = mapToPrintable(chunks) { makeDirChunk(rawInfra, it).toString() }
+        val blocks = mapToPrintable(blocks) { "block=${it.index.toInt()}" }
+        val routes = mapToPrintable(routes) { rawInfra.getRouteName(it) }
+        return "$chunks ; blocks=$blocks ; routes=$routes"
     }
 }

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathImpl.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathImpl.kt
@@ -1,11 +1,117 @@
 package fr.sncf.osrd.path.implementations
 
-import fr.sncf.osrd.path.interfaces.TrainPath
+import com.google.common.collect.ImmutableRangeMap
+import com.google.common.collect.RangeMap
+import fr.sncf.osrd.path.interfaces.*
+import fr.sncf.osrd.path.legacy_objects.ElectricalProfileMapping
+import fr.sncf.osrd.sim_infra.api.*
+import fr.sncf.osrd.utils.DistanceRangeMap
+import fr.sncf.osrd.utils.distanceRangeMapOf
 import fr.sncf.osrd.utils.units.Offset
+import fr.sncf.osrd.utils.units.meters
 
-class TrainPathImpl : TrainPath {
-    // TODO
+/**
+ * Basic path, does not support backtracks. Paths with backtracks are meant to be concatenated
+ * versions of other path types.
+ */
+data class TrainPathNoBacktrack(
+    private val rawInfra: RawInfra,
+    private val pathProperties: PathProperties,
+    private val routes: DistanceRangeMap<RouteRange>?,
+    private val blocks: DistanceRangeMap<BlockRange>,
+    private val chunks: DistanceRangeMap<DirChunkRange>,
+    private val electricalProfileMapping: ElectricalProfileMapping?,
+) : PathProperties by pathProperties, TrainPath {
+
+    private val cachedEnvelopeSimPath by lazy { computeEnvelopeSimPath() }
+
+    init {
+        fun <ValueType, OffsetType> checkRangeMap(
+            map: DistanceRangeMap<GenericLinearRange<ValueType, OffsetType>>
+        ) {
+            for (entry in map) require(entry.value.length == (entry.upper - entry.lower))
+            require(map.lowerBound() == 0.meters)
+            require(map.upperBound() == getLength())
+        }
+        routes?.let { if (!it.isEmpty()) checkRangeMap(it) }
+        checkRangeMap(blocks)
+        checkRangeMap(chunks)
+    }
+
     override fun subPath(from: Offset<TrainPath>?, to: Offset<TrainPath>?): TrainPath {
-        TODO("Not yet implemented")
+        val fromDist = from ?: Offset(0.meters)
+        val toDist = to ?: Offset(getLength())
+        return TrainPathNoBacktrack(
+            rawInfra = rawInfra,
+            pathProperties = PathPropertiesView(pathProperties, fromDist.cast(), toDist.cast()),
+            routes = routes?.let { linearObjectSubMap(it, fromDist, toDist) },
+            blocks = linearObjectSubMap(blocks, fromDist, toDist),
+            chunks = linearObjectSubMap(chunks, fromDist, toDist),
+            electricalProfileMapping = electricalProfileMapping,
+        )
+    }
+
+    override fun getBlocks(): DistanceRangeMap<BlockRange> = blocks
+
+    override fun getRoutes(): DistanceRangeMap<RouteRange> = routes!!
+
+    override fun getChunks(): DistanceRangeMap<DirChunkRange> = chunks
+
+    override val length: Double
+        get() = pathProperties.getLength().meters
+
+    override fun getAverageGrade(begin: Double, end: Double): Double {
+        return cachedEnvelopeSimPath.getAverageGrade(begin, end)
+    }
+
+    override fun getMinGrade(begin: Double, end: Double): Double {
+        return cachedEnvelopeSimPath.getMinGrade(begin, end)
+    }
+
+    override fun getElectrificationMap(
+        basePowerClass: String?,
+        powerRestrictionMap: RangeMap<Double, String>?,
+        powerRestrictionToPowerClass: Map<String, String>?,
+        ignoreElectricalProfiles: Boolean,
+    ): ImmutableRangeMap<Double, Electrification> {
+        return cachedEnvelopeSimPath.getElectrificationMap(
+            basePowerClass,
+            powerRestrictionMap,
+            powerRestrictionToPowerClass,
+            ignoreElectricalProfiles,
+        )
+    }
+
+    private fun computeEnvelopeSimPath(): PhysicsPath {
+        return EnvelopeTrainPath.from(rawInfra, pathProperties, electricalProfileMapping)
+    }
+
+    /** Truncate the distance range maps of linear objects, updating the underlying object range */
+    private fun <ValueType, OffsetType> linearObjectSubMap(
+        map: DistanceRangeMap<GenericLinearRange<ValueType, OffsetType>>,
+        from: Offset<TrainPath>,
+        to: Offset<TrainPath>,
+    ): DistanceRangeMap<GenericLinearRange<ValueType, OffsetType>> {
+        val newEntries =
+            map.map { entry ->
+                    var value = entry.value
+                    val (lower, upper, _) = entry
+                    val truncatedStartDist = from.distance - lower
+                    val truncatedEndDist = upper - to.distance
+
+                    if (truncatedStartDist > 0.meters) {
+                        value = value.copy(from = value.from + truncatedStartDist)
+                    }
+                    if (truncatedEndDist > 0.meters) {
+                        value = value.copy(to = value.to - truncatedStartDist)
+                    }
+                    entry.copy(value = value)
+                }
+                .filter { it.lower < it.upper }
+        var res = distanceRangeMapOf<GenericLinearRange<ValueType, OffsetType>>()
+        res.putMany(newEntries)
+        res = res.subMap(from.distance, to.distance)
+        res.shiftPositions(-from.distance)
+        return res
     }
 }

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/PathProperties.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/PathProperties.kt
@@ -3,11 +3,9 @@ package fr.sncf.osrd.path.interfaces
 import fr.sncf.osrd.geom.LineString
 import fr.sncf.osrd.path.implementations.ChunkPath
 import fr.sncf.osrd.path.implementations.PathPropertiesImpl
-import fr.sncf.osrd.path.implementations.buildChunkPath
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.sim_infra.impl.TemporarySpeedLimitManager
 import fr.sncf.osrd.utils.DistanceRangeMap
-import fr.sncf.osrd.utils.indexing.DirStaticIdxList
 import fr.sncf.osrd.utils.indexing.StaticIdx
 import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Offset
@@ -77,22 +75,10 @@ interface PathProperties {
  * available in some contexts, such as unit tests. It is, however, required if speed limits are
  * computed along that path.
  */
-fun buildPathPropertiesFrom(
-    infra: RawSignalingInfra,
-    chunks: DirStaticIdxList<TrackChunk>,
-    pathBeginOffset: Offset<BlockPath>,
-    pathEndOffset: Offset<BlockPath>,
-    routes: List<RouteId>? = null,
-): PathProperties {
-    val chunkPath = buildChunkPath(infra, chunks, pathBeginOffset, pathEndOffset)
-    return makePathProperties(infra, chunkPath, routes)
-}
-
-fun makePathProperties(
+internal fun makePathProperties(
     infra: RawSignalingInfra,
     chunkPath: ChunkPath,
     routes: List<RouteId>? = null,
-    temporarySpeedLimitManager: TemporarySpeedLimitManager? = null,
 ): PathProperties {
     return PathPropertiesImpl(infra, chunkPath, routes)
 }

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/TrainPath.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/TrainPath.kt
@@ -1,11 +1,40 @@
 package fr.sncf.osrd.path.interfaces
 
+import fr.sncf.osrd.sim_infra.api.*
+import fr.sncf.osrd.utils.DistanceRangeMap
+import fr.sncf.osrd.utils.indexing.DirStaticIdx
+import fr.sncf.osrd.utils.indexing.StaticIdx
 import fr.sncf.osrd.utils.units.Offset
 
-interface TrainPath {
+interface TrainPath : PhysicsPath, PathProperties {
     fun subPath(from: Offset<TrainPath>?, to: Offset<TrainPath>?): TrainPath
+
+    fun getBlocks(): DistanceRangeMap<BlockRange>
+
+    fun getRoutes(): DistanceRangeMap<RouteRange>
+
+    fun getChunks(): DistanceRangeMap<DirChunkRange>
+    // To be expanded as needed with other linear objects
 }
 
 fun concat(vararg paths: TrainPath): TrainPath {
-    TODO()
+    TODO("Necessary for actual backtracks, not necessary earlier than that")
 }
+
+data class GenericLinearRange<ValueType, OffsetType>(
+    val value: ValueType,
+    val from: Offset<OffsetType>,
+    val to: Offset<OffsetType>,
+) {
+    val length = to - from
+}
+
+typealias LinearObjectRange<T> = GenericLinearRange<StaticIdx<T>, T>
+
+typealias LinearDirObjectRange<T> = GenericLinearRange<DirStaticIdx<T>, T>
+
+typealias RouteRange = LinearObjectRange<Route>
+
+typealias BlockRange = LinearObjectRange<Block>
+
+typealias DirChunkRange = LinearDirObjectRange<TrackChunk>

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/TrainPath.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/TrainPath.kt
@@ -1,19 +1,52 @@
 package fr.sncf.osrd.path.interfaces
 
+import com.google.common.collect.RangeMap
 import fr.sncf.osrd.sim_infra.api.*
-import fr.sncf.osrd.utils.DistanceRangeMap
 import fr.sncf.osrd.utils.indexing.DirStaticIdx
 import fr.sncf.osrd.utils.indexing.StaticIdx
+import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
+import fr.sncf.osrd.utils.units.meters
 
+/**
+ * A `TrainPath` describes the path taken by a train and its properties. It is built in a way that
+ * can easily be mapped to train simulations, where we track the distance travelled by the train
+ * head.
+ *
+ * `Offset<TrainPath>` is the correct typing to locate elements on a path.
+ *
+ * We consider that 1m of train path means 1m of train movement, not necessarily 1m of actual track
+ * length. Specifically, when a train turns around at a station, no distance is travelled. See
+ * below, where a train goes up to a point and turn around:
+ * ```
+ *                         backtrack
+ *                         location
+ * ========================>|
+ * -------------------------|-----    track section
+ * <============############|
+ *              ^   train   ^
+ *              ^   length  ^
+ *             new         old
+ *             head        head
+ * ```
+ *
+ * What we consider the "train path" is marked with `===>` symbols. The area covered by the train
+ * itself ('#') is excluded from the path after turning around. 1m after the backtrack offset is
+ * already `train length + 1m` away from the previous location.
+ *
+ * `getBlocks` and similar methods only return block ranges that are part of the train path. This
+ * may include partial blocks, especially at the edges of the path or around backtracks.
+ */
 interface TrainPath : PhysicsPath, PathProperties {
     fun subPath(from: Offset<TrainPath>?, to: Offset<TrainPath>?): TrainPath
 
-    fun getBlocks(): DistanceRangeMap<BlockRange>
+    fun getTypedLength(): Length<TrainPath>
 
-    fun getRoutes(): DistanceRangeMap<RouteRange>
+    fun getBlocks(): LinearObjectMap<BlockRange>
 
-    fun getChunks(): DistanceRangeMap<DirChunkRange>
+    fun getRoutes(): LinearObjectMap<RouteRange>
+
+    fun getChunks(): LinearObjectMap<DirChunkRange>
     // To be expanded as needed with other linear objects
 }
 
@@ -27,7 +60,16 @@ data class GenericLinearRange<ValueType, OffsetType>(
     val to: Offset<OffsetType>,
 ) {
     val length = to - from
+
+    init {
+        require(length >= 0.meters)
+    }
 }
+
+// We'd normally use `DistanceRangeMap` here, but supporting zero-length ranges is required.
+// Note: kotlin doesn't allow type arguments on type parameters, so we can't easily make it explicit
+// that T is meant to be a `GenericLinearRange` without having repeated parameters
+typealias LinearObjectMap<T> = RangeMap<Offset<TrainPath>, T>
 
 typealias LinearObjectRange<T> = GenericLinearRange<StaticIdx<T>, T>
 
@@ -38,5 +80,3 @@ typealias RouteRange = LinearObjectRange<Route>
 typealias BlockRange = LinearObjectRange<Block>
 
 typealias DirChunkRange = LinearDirObjectRange<TrackChunk>
-
-typealias DirTrackRange = LinearObjectRange<TrackSection>

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/TrainPath.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/TrainPath.kt
@@ -18,7 +18,7 @@ interface TrainPath : PhysicsPath, PathProperties {
 }
 
 fun concat(vararg paths: TrainPath): TrainPath {
-    TODO("Necessary for actual backtracks, not necessary earlier than that")
+    TODO("Required for actual backtracks, not necessary earlier than that")
 }
 
 data class GenericLinearRange<ValueType, OffsetType>(
@@ -38,3 +38,5 @@ typealias RouteRange = LinearObjectRange<Route>
 typealias BlockRange = LinearObjectRange<Block>
 
 typealias DirChunkRange = LinearDirObjectRange<TrackChunk>
+
+typealias DirTrackRange = LinearObjectRange<TrackSection>

--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/DistanceRangeMap.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/DistanceRangeMap.kt
@@ -10,6 +10,15 @@ import java.util.function.BiFunction
 /**
  * DistanceRangeMap allows to store values over intervals (e.g. elevation on sections of a track)
  * and query them. The default value is null.
+ *
+ * This is similar to guava's `RangeMap<Distance, T>`. There are tradeoffs with guava maps, detailed
+ * in the issue https://github.com/OpenRailAssociation/osrd/issues/12828. To summarize here:
+ * `DistanceRangeMap` is significantly more memory efficient, but it's a little slower than guava
+ * maps. Ours don't have proper open/closed range semantics, and we cannot support zero-length
+ * intervals.
+ *
+ * `DistanceRangeMap` should be used when memory footprint is a concern (in particular to store
+ * infra data), and only when precise interval semantics aren't necessary.
  */
 interface DistanceRangeMap<T> : Iterable<DistanceRangeMap.RangeMapEntry<T>> {
 
@@ -70,12 +79,6 @@ interface DistanceRangeMap<T> : Iterable<DistanceRangeMap.RangeMapEntry<T>> {
 
     /** Clear the map */
     fun clear()
-
-    /**
-     * Keeps the same keys, but applies the mapping to each value. Returns a copy, this instance
-     * isn't changed.
-     */
-    fun <U> mapValues(mapping: (T) -> U): DistanceRangeMap<U>
 }
 
 fun <T> distanceRangeMapOf(vararg entries: DistanceRangeMap.RangeMapEntry<T>): DistanceRangeMap<T> {

--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/DistanceRangeMap.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/DistanceRangeMap.kt
@@ -70,6 +70,12 @@ interface DistanceRangeMap<T> : Iterable<DistanceRangeMap.RangeMapEntry<T>> {
 
     /** Clear the map */
     fun clear()
+
+    /**
+     * Keeps the same keys, but applies the mapping to each value. Returns a copy, this instance
+     * isn't changed.
+     */
+    fun <U> mapValues(mapping: (T) -> U): DistanceRangeMap<U>
 }
 
 fun <T> distanceRangeMapOf(vararg entries: DistanceRangeMap.RangeMapEntry<T>): DistanceRangeMap<T> {

--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/DistanceRangeMapImpl.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/DistanceRangeMapImpl.kt
@@ -295,6 +295,12 @@ data class DistanceRangeMapImpl<T>(
         values.clear()
     }
 
+    override fun <U> mapValues(mapping: (T) -> U): DistanceRangeMap<U> {
+        return distanceRangeMapOf(
+            asList().map { DistanceRangeMap.RangeMapEntry(it.lower, it.upper, mapping(it.value)) }
+        )
+    }
+
     /** Merges adjacent values, removes 0-length ranges */
     private fun mergeAdjacent() {
         fun remove(i: Int) {
@@ -372,6 +378,18 @@ data class DistanceRangeMapImpl<T>(
     /** Asserts that the internal state is consistent */
     private fun validate() {
         assert(bounds.size == values.size + 1 || (bounds.size == 0 && values.isEmpty()))
+    }
+
+    /** Formats the map like so: `[bound1] value1 [bound2] value2 [bound3]`. */
+    override fun toString(): String {
+        val result = StringBuilder()
+        for (i in 0..<bounds.size) {
+            result.append("[${bounds[i]}] ")
+            if (i < values.size) {
+                result.append("${values[i]} ")
+            }
+        }
+        return result.toString()
     }
 
     companion object {

--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/DistanceRangeMapImpl.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/DistanceRangeMapImpl.kt
@@ -295,12 +295,6 @@ data class DistanceRangeMapImpl<T>(
         values.clear()
     }
 
-    override fun <U> mapValues(mapping: (T) -> U): DistanceRangeMap<U> {
-        return distanceRangeMapOf(
-            asList().map { DistanceRangeMap.RangeMapEntry(it.lower, it.upper, mapping(it.value)) }
-        )
-    }
-
     /** Merges adjacent values, removes 0-length ranges */
     private fun mergeAdjacent() {
         fun remove(i: Int) {
@@ -378,18 +372,6 @@ data class DistanceRangeMapImpl<T>(
     /** Asserts that the internal state is consistent */
     private fun validate() {
         assert(bounds.size == values.size + 1 || (bounds.size == 0 && values.isEmpty()))
-    }
-
-    /** Formats the map like so: `[bound1] value1 [bound2] value2 [bound3]`. */
-    override fun toString(): String {
-        val result = StringBuilder()
-        for (i in 0..<bounds.size) {
-            result.append("[${bounds[i]}] ")
-            if (i < values.size) {
-                result.append("${values[i]} ")
-            }
-        }
-        return result.toString()
     }
 
     companion object {

--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/units/Distance.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/units/Distance.kt
@@ -37,6 +37,7 @@ value class Distance(val millimeters: Long) : Comparable<Distance> {
 
     companion object {
         val ZERO = Distance(millimeters = 0L)
+        val MAX = Distance(millimeters = Long.MAX_VALUE)
 
         fun fromMeters(meters: Double) = Distance(millimeters = (Math.round(meters * 1_000.0)))
 

--- a/core/src/main/kotlin/fr/sncf/osrd/api/etcs/ETCSBrakingCurvesEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/etcs/ETCSBrakingCurvesEndpoint.kt
@@ -7,10 +7,9 @@ import fr.sncf.osrd.envelope.part.EnvelopePart
 import fr.sncf.osrd.envelope_sim.EnvelopeProfile
 import fr.sncf.osrd.envelope_sim.EnvelopeSimContext
 import fr.sncf.osrd.envelope_sim.etcs.*
-import fr.sncf.osrd.path.implementations.EnvelopeTrainPath
+import fr.sncf.osrd.path.implementations.buildTrainPathFromChunkPath
 import fr.sncf.osrd.path.interfaces.BlockPath
 import fr.sncf.osrd.path.interfaces.TravelledPath
-import fr.sncf.osrd.path.interfaces.makePathProperties
 import fr.sncf.osrd.reporting.warnings.DiagnosticRecorderImpl
 import fr.sncf.osrd.signaling.etcs_level2.ETCS_LEVEL2
 import fr.sncf.osrd.sim_infra.api.*
@@ -68,14 +67,18 @@ class ETCSBrakingCurvesEndpoint(
             // Parse path.
             val chunkPath = makeChunkPath(infra.rawInfra, request.path.trackSectionRanges)
             val routePath = convertRoutePath(infra.rawInfra, request.path.routes)
-            val pathProps = makePathProperties(infra.rawInfra, chunkPath, routePath.toList())
+            val trainPath =
+                buildTrainPathFromChunkPath(
+                    infra.rawInfra,
+                    infra.blockInfra,
+                    chunkPath,
+                    routePath.toList(),
+                )
             val blockPath = convertBlockPath(infra.blockInfra, request.path.blocks)
-            val envelopeSimPath =
-                EnvelopeTrainPath.from(infra.rawInfra, pathProps, electricalProfileMap)
             val powerRestrictionsLegacyMap =
                 parsePowerRestrictions(request.powerRestrictions).toRangeMap()
             val electrificationMap =
-                envelopeSimPath.getElectrificationMap(
+                trainPath.getElectrificationMap(
                     rollingStock.basePowerClass,
                     powerRestrictionsLegacyMap,
                     rollingStock.powerRestrictions,
@@ -88,7 +91,7 @@ class ETCSBrakingCurvesEndpoint(
             val context =
                 EnvelopeSimContext(
                     rollingStock,
-                    envelopeSimPath,
+                    trainPath,
                     2.0,
                     curvesAndConditions.curves,
                     makeETCSContext(
@@ -102,7 +105,7 @@ class ETCSBrakingCurvesEndpoint(
                 )
 
             // Parse mrsp.
-            val mrsp = parseRawMrsp(request.mrsp, Offset(envelopeSimPath.length.meters))
+            val mrsp = parseRawMrsp(request.mrsp, Offset(trainPath.getLength()))
 
             // Compute ETCS braking curves.
             val etcsSimulator = ETCSBrakingSimulatorImpl(context)

--- a/core/src/main/kotlin/fr/sncf/osrd/api/path_properties/PathPropEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/path_properties/PathPropEndpoint.kt
@@ -25,7 +25,8 @@ class PathPropEndpoint(private val infraManager: InfraProvider) : Take {
             // Load infra
             val infra = infraManager.getInfra(request.infra, request.expectedVersion, recorder)
 
-            val pathProps = makePathProps(infra.rawInfra, request.trackSectionRanges)
+            val pathProps =
+                makePathProps(infra.rawInfra, infra.blockInfra, request.trackSectionRanges)
             val res = makePathPropResponse(pathProps, infra.rawInfra)
 
             RsJson(RsWithBody(pathPropResponseAdapter.toJson(res)))

--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/IncompatibleConstraintsPostProcessing.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/IncompatibleConstraintsPostProcessing.kt
@@ -2,6 +2,7 @@ package fr.sncf.osrd.api.pathfinding
 
 import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.graph.*
+import fr.sncf.osrd.path.implementations.buildTrainPathFromBlocks
 import fr.sncf.osrd.pathfinding.Pathfinding
 import fr.sncf.osrd.pathfinding.PathfindingResultId
 import fr.sncf.osrd.pathfinding.constraints.ElectrificationConstraints
@@ -12,7 +13,6 @@ import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.utils.DistanceRangeMap
 import fr.sncf.osrd.utils.distanceRangeMapOf
 import fr.sncf.osrd.utils.filterIntersection
-import fr.sncf.osrd.utils.makePathProps
 import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Offset
 
@@ -31,7 +31,7 @@ fun buildIncompatibleConstraintsResponse(
 
     val pathRanges = possiblePathWithoutErrorNoConstraints.ranges
     val pathProps =
-        makePathProps(infra.rawInfra, infra.blockInfra, pathRanges.map { it.edge }, Offset.zero())
+        buildTrainPathFromBlocks(infra.rawInfra, infra.blockInfra, pathRanges.map { it.edge })
 
     val elecConstraints = constraints.filterIsInstance<ElectrificationConstraints>()
     assert(elecConstraints.size < 2)

--- a/core/src/main/kotlin/fr/sncf/osrd/api/standalone_sim/SimulationEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/standalone_sim/SimulationEndpoint.kt
@@ -1,7 +1,7 @@
 package fr.sncf.osrd.api.standalone_sim
 
 import fr.sncf.osrd.api.*
-import fr.sncf.osrd.path.interfaces.makePathProperties
+import fr.sncf.osrd.path.implementations.buildTrainPathFromChunkPath
 import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.reporting.warnings.DiagnosticRecorderImpl
 import fr.sncf.osrd.standalone_sim.runStandaloneSimulation
@@ -59,7 +59,13 @@ class SimulationEndpoint(
             // Parse path
             val chunkPath = makeChunkPath(infra.rawInfra, request.path.trackSectionRanges)
             val routePath = convertRoutePath(infra.rawInfra, request.path.routes)
-            val pathProps = makePathProperties(infra.rawInfra, chunkPath, routePath.toList())
+            val pathProps =
+                buildTrainPathFromChunkPath(
+                    infra.rawInfra,
+                    infra.blockInfra,
+                    chunkPath,
+                    routePath.toList(),
+                )
             val blockPath = convertBlockPath(infra.blockInfra, request.path.blocks)
 
             val res =

--- a/core/src/main/kotlin/fr/sncf/osrd/pathfinding/constraints/ElectrificationConstraints.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/pathfinding/constraints/ElectrificationConstraints.kt
@@ -4,7 +4,7 @@ import com.google.common.collect.Range
 import com.google.common.collect.RangeSet
 import com.google.common.collect.TreeRangeSet
 import fr.sncf.osrd.graph.PathfindingConstraint
-import fr.sncf.osrd.path.implementations.buildTrainPath
+import fr.sncf.osrd.path.implementations.buildTrainPathFromBlock
 import fr.sncf.osrd.path.interfaces.PathProperties
 import fr.sncf.osrd.pathfinding.Pathfinding
 import fr.sncf.osrd.sim_infra.api.*
@@ -19,7 +19,7 @@ data class ElectrificationConstraints(
     val compatibleElectrification: Collection<String>,
 ) : PathfindingConstraint<Block> {
     override fun apply(edge: BlockId): Collection<Pathfinding.Range<Block>> {
-        val path = buildTrainPath(rawInfra, blockInfra, edge)
+        val path = buildTrainPathFromBlock(rawInfra, blockInfra, edge)
         return getBlockedRanges(path, compatibleElectrification)
     }
 

--- a/core/src/main/kotlin/fr/sncf/osrd/pathfinding/constraints/ElectrificationConstraints.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/pathfinding/constraints/ElectrificationConstraints.kt
@@ -4,11 +4,11 @@ import com.google.common.collect.Range
 import com.google.common.collect.RangeSet
 import com.google.common.collect.TreeRangeSet
 import fr.sncf.osrd.graph.PathfindingConstraint
+import fr.sncf.osrd.path.implementations.buildTrainPath
 import fr.sncf.osrd.path.interfaces.PathProperties
 import fr.sncf.osrd.pathfinding.Pathfinding
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.utils.DistanceRangeMap
-import fr.sncf.osrd.utils.makePathProps
 import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Offset
 import java.util.stream.Collectors
@@ -19,7 +19,7 @@ data class ElectrificationConstraints(
     val compatibleElectrification: Collection<String>,
 ) : PathfindingConstraint<Block> {
     override fun apply(edge: BlockId): Collection<Pathfinding.Range<Block>> {
-        val path = makePathProps(blockInfra, rawInfra, edge)
+        val path = buildTrainPath(rawInfra, blockInfra, edge)
         return getBlockedRanges(path, compatibleElectrification)
     }
 

--- a/core/src/main/kotlin/fr/sncf/osrd/pathfinding/constraints/LoadingGaugeConstraints.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/pathfinding/constraints/LoadingGaugeConstraints.kt
@@ -1,12 +1,12 @@
 package fr.sncf.osrd.pathfinding.constraints
 
 import fr.sncf.osrd.graph.PathfindingConstraint
+import fr.sncf.osrd.path.implementations.buildTrainPath
 import fr.sncf.osrd.path.interfaces.PathProperties
 import fr.sncf.osrd.pathfinding.Pathfinding
 import fr.sncf.osrd.railjson.schema.rollingstock.RJSLoadingGaugeType
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.utils.DistanceRangeMap
-import fr.sncf.osrd.utils.makePathProps
 import fr.sncf.osrd.utils.units.Offset
 import java.util.stream.Collectors
 
@@ -17,7 +17,7 @@ data class LoadingGaugeConstraints(
 ) : PathfindingConstraint<Block> {
     override fun apply(edge: BlockId): Collection<Pathfinding.Range<Block>> {
         val res = HashSet<Pathfinding.Range<Block>>()
-        val path = makePathProps(blockInfra, infra, edge)
+        val path = buildTrainPath(infra, blockInfra, edge)
         res.addAll(getBlockedRanges(loadingGaugeType, path))
         return res
     }

--- a/core/src/main/kotlin/fr/sncf/osrd/pathfinding/constraints/LoadingGaugeConstraints.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/pathfinding/constraints/LoadingGaugeConstraints.kt
@@ -1,7 +1,7 @@
 package fr.sncf.osrd.pathfinding.constraints
 
 import fr.sncf.osrd.graph.PathfindingConstraint
-import fr.sncf.osrd.path.implementations.buildTrainPath
+import fr.sncf.osrd.path.implementations.buildTrainPathFromBlock
 import fr.sncf.osrd.path.interfaces.PathProperties
 import fr.sncf.osrd.pathfinding.Pathfinding
 import fr.sncf.osrd.railjson.schema.rollingstock.RJSLoadingGaugeType
@@ -17,7 +17,7 @@ data class LoadingGaugeConstraints(
 ) : PathfindingConstraint<Block> {
     override fun apply(edge: BlockId): Collection<Pathfinding.Range<Block>> {
         val res = HashSet<Pathfinding.Range<Block>>()
-        val path = buildTrainPath(infra, blockInfra, edge)
+        val path = buildTrainPathFromBlock(infra, blockInfra, edge)
         res.addAll(getBlockedRanges(loadingGaugeType, path))
         return res
     }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/ProgressLogger.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/ProgressLogger.kt
@@ -1,6 +1,6 @@
 package fr.sncf.osrd.stdcm
 
-import fr.sncf.osrd.path.implementations.buildTrainPath
+import fr.sncf.osrd.path.implementations.buildTrainPathFromBlock
 import fr.sncf.osrd.stdcm.graph.STDCMGraph
 import fr.sncf.osrd.stdcm.graph.STDCMNode
 import fr.sncf.osrd.stdcm.graph.logger
@@ -36,7 +36,8 @@ data class ProgressLogger(
         }
         if (progress >= thresholdDistance * nSamplesReached) {
             val block = node.infraExplorer.getCurrentBlock()
-            val geo = buildTrainPath(graph.rawInfra, graph.blockInfra, block).getGeo().points[0]
+            val geo =
+                buildTrainPathFromBlock(graph.rawInfra, graph.blockInfra, block).getGeo().points[0]
             val str =
                 "node sample for progress $nSamplesReached/$nStepsProgress: " +
                     "time=${node.timeData.earliestReachableTime.toInt()}s, " +

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/ProgressLogger.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/ProgressLogger.kt
@@ -1,9 +1,9 @@
 package fr.sncf.osrd.stdcm
 
+import fr.sncf.osrd.path.implementations.buildTrainPath
 import fr.sncf.osrd.stdcm.graph.STDCMGraph
 import fr.sncf.osrd.stdcm.graph.STDCMNode
 import fr.sncf.osrd.stdcm.graph.logger
-import fr.sncf.osrd.utils.makePathProps
 import fr.sncf.osrd.utils.units.Duration
 import fr.sncf.osrd.utils.units.seconds
 import java.time.Duration.*
@@ -36,7 +36,7 @@ data class ProgressLogger(
         }
         if (progress >= thresholdDistance * nSamplesReached) {
             val block = node.infraExplorer.getCurrentBlock()
-            val geo = makePathProps(graph.blockInfra, graph.rawInfra, block).getGeo().points[0]
+            val geo = buildTrainPath(graph.rawInfra, graph.blockInfra, block).getGeo().points[0]
             val str =
                 "node sample for progress $nSamplesReached/$nStepsProgress: " +
                     "time=${node.timeData.earliestReachableTime.toInt()}s, " +

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMResult.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMResult.kt
@@ -2,8 +2,7 @@ package fr.sncf.osrd.stdcm
 
 import fr.sncf.osrd.envelope.Envelope
 import fr.sncf.osrd.path.implementations.ChunkPath
-import fr.sncf.osrd.path.interfaces.PathProperties
-import fr.sncf.osrd.path.interfaces.PhysicsPath
+import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.pathfinding.PathfindingResultId
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.RouteId
@@ -16,9 +15,8 @@ import fr.sncf.osrd.train.TrainStop
 data class STDCMResult(
     val blocks: PathfindingResultId<Block>,
     val envelope: Envelope,
-    val trainPath: PathProperties,
+    val trainPath: TrainPath,
     val chunkPath: ChunkPath,
-    val physicsPath: PhysicsPath,
     val routePath: List<RouteId>,
     val departureTime: Double,
     val stopResults: List<TrainStop>,

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
@@ -129,7 +129,7 @@ class STDCMPathfinding(
         val res =
             STDCMPostProcessing(graph)
                 .makeResult(
-                    fullInfra.rawInfra,
+                    fullInfra,
                     path,
                     graph.standardAllowance,
                     rollingStock,

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
@@ -1,15 +1,15 @@
 package fr.sncf.osrd.stdcm.graph
 
+import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.envelope.Envelope
 import fr.sncf.osrd.envelope_sim.allowances.AllowanceValue
 import fr.sncf.osrd.envelope_sim.pipelines.SimStop
 import fr.sncf.osrd.envelope_sim.pipelines.maxEffortEnvelopeFrom
 import fr.sncf.osrd.envelope_sim.pipelines.maxSpeedEnvelopeFrom
 import fr.sncf.osrd.envelope_sim_infra.computeMRSP
-import fr.sncf.osrd.path.implementations.EnvelopeTrainPath
+import fr.sncf.osrd.path.implementations.buildTrainPathFromChunkPath
 import fr.sncf.osrd.path.interfaces.PathProperties
-import fr.sncf.osrd.path.interfaces.PhysicsPath
-import fr.sncf.osrd.path.interfaces.makePathProperties
+import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.pathfinding.Pathfinding
 import fr.sncf.osrd.pathfinding.Pathfinding.EdgeLocation
 import fr.sncf.osrd.pathfinding.Pathfinding.EdgeRange
@@ -45,7 +45,7 @@ class STDCMPostProcessing(private val graph: STDCMGraph) {
      */
     @WithSpan(value = "STDCM post processing", kind = SpanKind.SERVER)
     fun makeResult(
-        infra: RawSignalingInfra,
+        infra: FullInfra,
         path: Result,
         standardAllowance: AllowanceValue?,
         rollingStock: RollingStock,
@@ -61,15 +61,14 @@ class STDCMPostProcessing(private val graph: STDCMGraph) {
         val blockWaypoints = makeBlockWaypoints(path)
         val chunkPath = makeChunkPathFromEdges(graph, edges)
         val routes = edges.last().infraExplorer.getExploredRoutes()
-        val trainPath = makePathProperties(infra, chunkPath, routes, temporarySpeedLimitManager)
-        val physicsPath = EnvelopeTrainPath.from(infra, trainPath)
+        val trainPath =
+            buildTrainPathFromChunkPath(infra.rawInfra, infra.blockInfra, chunkPath, routes)
         // val departureTime = computeDepartureTime(edges, startTime)
         val updatedTimeData = computeTimeData(edges)
         val stops = makeStops(edges, updatedTimeData)
         val maxSpeedEnvelope =
             makeMaxSpeedEnvelope(
                 trainPath,
-                physicsPath,
                 stops,
                 rollingStock,
                 timeStep,
@@ -84,7 +83,7 @@ class STDCMPostProcessing(private val graph: STDCMGraph) {
                 maxSpeedEnvelope,
                 edges,
                 standardAllowance,
-                physicsPath,
+                trainPath,
                 rollingStock,
                 timeStep,
                 comfort,
@@ -98,7 +97,6 @@ class STDCMPostProcessing(private val graph: STDCMGraph) {
                 withAllowance,
                 trainPath,
                 chunkPath,
-                physicsPath,
                 routes,
                 updatedTimeData.departureTime,
 
@@ -114,8 +112,7 @@ class STDCMPostProcessing(private val graph: STDCMGraph) {
     }
 
     private fun makeMaxSpeedEnvelope(
-        trainPath: PathProperties,
-        physicsPath: PhysicsPath,
+        trainPath: TrainPath,
         stops: List<TrainStop>,
         rollingStock: RollingStock,
         timeStep: Double,
@@ -124,11 +121,11 @@ class STDCMPostProcessing(private val graph: STDCMGraph) {
         temporarySpeedLimitManager: TemporarySpeedLimitManager?,
         stopAtEnd: Boolean,
     ): Envelope {
-        val context = build(rollingStock, physicsPath, timeStep, comfort)
+        val context = build(rollingStock, trainPath, timeStep, comfort)
         val mrsp = computeMRSP(trainPath, rollingStock, false, trainTag, temporarySpeedLimitManager)
         val stopInfos =
             stops.map { SimStop(Offset(it.position.meters), it.receptionSignal) }.toMutableList()
-        if (stopAtEnd) stopInfos.add(SimStop(Offset(physicsPath.length.meters), SHORT_SLIP_STOP))
+        if (stopAtEnd) stopInfos.add(SimStop(Offset(trainPath.getLength()), SHORT_SLIP_STOP))
         val maxSpeedEnvelope = maxSpeedEnvelopeFrom(context, stopInfos, mrsp)
         return maxEffortEnvelopeFrom(context, 0.0, maxSpeedEnvelope)
     }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
@@ -7,7 +7,7 @@ import fr.sncf.osrd.conflicts.PathFragment
 import fr.sncf.osrd.conflicts.incrementalPathOf
 import fr.sncf.osrd.graph.PathfindingConstraint
 import fr.sncf.osrd.path.implementations.PathPropertiesView
-import fr.sncf.osrd.path.implementations.buildTrainPath
+import fr.sncf.osrd.path.implementations.buildTrainPathFromBlock
 import fr.sncf.osrd.path.interfaces.BlockPath
 import fr.sncf.osrd.path.interfaces.PathProperties
 import fr.sncf.osrd.pathfinding.PathfindingEdgeLocationId
@@ -131,7 +131,7 @@ fun initInfraExplorer(
 ): Collection<InfraExplorer> {
     val infraExplorers = mutableListOf<InfraExplorer>()
     val block = location.edge
-    val pathProps: PathProperties = buildTrainPath(rawInfra, blockInfra, block)
+    val pathProps: PathProperties = buildTrainPathFromBlock(rawInfra, blockInfra, block)
     val blockToPathProperties = mutableMapOf(block to pathProps)
     val routes = blockInfra.routesOnBlock(rawInfra, block)
 
@@ -186,7 +186,7 @@ private class InfraExplorerImpl(
         // So we have to correct that here now that we now which route we're on.
         val path =
             pathPropertiesCache.getOrElse(getCurrentBlock()) {
-                val res = buildTrainPath(rawInfra, blockInfra, getCurrentBlock())
+                val res = buildTrainPathFromBlock(rawInfra, blockInfra, getCurrentBlock())
                 pathPropertiesCache[getCurrentBlock()] = res
                 res
             }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
@@ -7,6 +7,7 @@ import fr.sncf.osrd.conflicts.PathFragment
 import fr.sncf.osrd.conflicts.incrementalPathOf
 import fr.sncf.osrd.graph.PathfindingConstraint
 import fr.sncf.osrd.path.implementations.PathPropertiesView
+import fr.sncf.osrd.path.implementations.buildTrainPath
 import fr.sncf.osrd.path.interfaces.BlockPath
 import fr.sncf.osrd.path.interfaces.PathProperties
 import fr.sncf.osrd.pathfinding.PathfindingEdgeLocationId
@@ -21,7 +22,6 @@ import fr.sncf.osrd.utils.appendOnlyLinkedListOf
 import fr.sncf.osrd.utils.appendOnlyMapOf
 import fr.sncf.osrd.utils.indexing.StaticIdxList
 import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
-import fr.sncf.osrd.utils.makePathProps
 import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
@@ -131,7 +131,7 @@ fun initInfraExplorer(
 ): Collection<InfraExplorer> {
     val infraExplorers = mutableListOf<InfraExplorer>()
     val block = location.edge
-    val pathProps = makePathProps(blockInfra, rawInfra, block)
+    val pathProps: PathProperties = buildTrainPath(rawInfra, blockInfra, block)
     val blockToPathProperties = mutableMapOf(block to pathProps)
     val routes = blockInfra.routesOnBlock(rawInfra, block)
 
@@ -186,7 +186,7 @@ private class InfraExplorerImpl(
         // So we have to correct that here now that we now which route we're on.
         val path =
             pathPropertiesCache.getOrElse(getCurrentBlock()) {
-                val res = makePathProps(blockInfra, rawInfra, getCurrentBlock())
+                val res = buildTrainPath(rawInfra, blockInfra, getCurrentBlock())
                 pathPropertiesCache[getCurrentBlock()] = res
                 res
             }

--- a/core/src/main/kotlin/fr/sncf/osrd/utils/CachedBlockMRSPBuilder.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/utils/CachedBlockMRSPBuilder.kt
@@ -3,6 +3,7 @@ package fr.sncf.osrd.utils
 import fr.sncf.osrd.envelope.Envelope
 import fr.sncf.osrd.envelope_sim.PhysicsRollingStock
 import fr.sncf.osrd.envelope_sim_infra.computeMRSP
+import fr.sncf.osrd.path.implementations.buildTrainPath
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.sim_infra.api.BlockInfra
@@ -46,22 +47,8 @@ data class CachedBlockMRSPBuilder(
     /** Returns the speed limits for the given block (cached). */
     fun getMRSP(block: BlockId): Envelope {
         return mrspCache.computeIfAbsent(block) {
-            val pathProps =
-                makePathProps(
-                    blockInfra,
-                    rawInfra,
-                    block,
-                    // TODO: change input to infra explorers, and fetch last route there
-                    routes = listOf(),
-                )
-            computeMRSP(
-                pathProps,
-                rsMaxSpeed,
-                rsLength,
-                addRollingStockLength = true,
-                speedLimitTag,
-                temporarySpeedLimitManager,
-            )
+            val pathProps = buildTrainPath(rawInfra, blockInfra, block, routes = listOf())
+            computeMRSP(pathProps, rsMaxSpeed, rsLength, false, null, temporarySpeedLimitManager)
         }
     }
 

--- a/core/src/main/kotlin/fr/sncf/osrd/utils/CachedBlockMRSPBuilder.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/utils/CachedBlockMRSPBuilder.kt
@@ -47,8 +47,16 @@ data class CachedBlockMRSPBuilder(
     /** Returns the speed limits for the given block (cached). */
     fun getMRSP(block: BlockId): Envelope {
         return mrspCache.computeIfAbsent(block) {
+            // TODO: change input to infra explorers, and fetch last route there
             val pathProps = buildTrainPathFromBlock(rawInfra, blockInfra, block, routes = listOf())
-            computeMRSP(pathProps, rsMaxSpeed, rsLength, false, null, temporarySpeedLimitManager)
+            computeMRSP(
+                pathProps,
+                rsMaxSpeed,
+                rsLength,
+                addRollingStockLength = true,
+                speedLimitTag,
+                temporarySpeedLimitManager,
+            )
         }
     }
 

--- a/core/src/main/kotlin/fr/sncf/osrd/utils/CachedBlockMRSPBuilder.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/utils/CachedBlockMRSPBuilder.kt
@@ -3,7 +3,7 @@ package fr.sncf.osrd.utils
 import fr.sncf.osrd.envelope.Envelope
 import fr.sncf.osrd.envelope_sim.PhysicsRollingStock
 import fr.sncf.osrd.envelope_sim_infra.computeMRSP
-import fr.sncf.osrd.path.implementations.buildTrainPath
+import fr.sncf.osrd.path.implementations.buildTrainPathFromBlock
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.sim_infra.api.BlockInfra
@@ -47,7 +47,7 @@ data class CachedBlockMRSPBuilder(
     /** Returns the speed limits for the given block (cached). */
     fun getMRSP(block: BlockId): Envelope {
         return mrspCache.computeIfAbsent(block) {
-            val pathProps = buildTrainPath(rawInfra, blockInfra, block, routes = listOf())
+            val pathProps = buildTrainPathFromBlock(rawInfra, blockInfra, block, routes = listOf())
             computeMRSP(pathProps, rsMaxSpeed, rsLength, false, null, temporarySpeedLimitManager)
         }
     }

--- a/core/src/main/kotlin/fr/sncf/osrd/utils/DebugUtils.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/utils/DebugUtils.kt
@@ -14,11 +14,11 @@ fun exportPathGeo(infra: FullInfra, res: PathfindingBlockSuccess) {
     File("$name-tracks.csv").printWriter().use { out ->
         out.println("index;linestring;id")
         for ((i, track) in res.trackSectionRanges.withIndex()) {
-            val geo = makePathProps(infra.rawInfra, listOf(track)).getGeo()
+            val geo = makePathProps(infra.rawInfra, infra.blockInfra, listOf(track)).getGeo()
             out.println("$i;$geo;${track.trackSection}")
         }
     }
-    val fullPath = makePathProps(infra.rawInfra, res.trackSectionRanges)
+    val fullPath = makePathProps(infra.rawInfra, infra.blockInfra, res.trackSectionRanges)
     val lineString = fullPath.getGeo()
     File("$name-points.csv").printWriter().use { out ->
         out.println("index;x;y")

--- a/core/src/main/kotlin/fr/sncf/osrd/utils/DebugUtils.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/utils/DebugUtils.kt
@@ -14,11 +14,14 @@ fun exportPathGeo(infra: FullInfra, res: PathfindingBlockSuccess) {
     File("$name-tracks.csv").printWriter().use { out ->
         out.println("index;linestring;id")
         for ((i, track) in res.trackSectionRanges.withIndex()) {
-            val geo = makePathProps(infra.rawInfra, infra.blockInfra, listOf(track)).getGeo()
+            val geo =
+                makePathProps(infra.rawInfra, infra.blockInfra, listOf(track), routes = listOf())
+                    .getGeo()
             out.println("$i;$geo;${track.trackSection}")
         }
     }
-    val fullPath = makePathProps(infra.rawInfra, infra.blockInfra, res.trackSectionRanges)
+    val fullPath =
+        makePathProps(infra.rawInfra, infra.blockInfra, res.trackSectionRanges, routes = listOf())
     val lineString = fullPath.getGeo()
     File("$name-points.csv").printWriter().use { out ->
         out.println("index;x;y")

--- a/core/src/main/kotlin/fr/sncf/osrd/utils/PathPropUtils.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/utils/PathPropUtils.kt
@@ -1,6 +1,5 @@
 package fr.sncf.osrd.utils
 
-import com.google.common.collect.Iterables
 import fr.sncf.osrd.api.DirectionalTrackRange
 import fr.sncf.osrd.path.implementations.ChunkPath
 import fr.sncf.osrd.path.implementations.buildChunkPath
@@ -8,10 +7,7 @@ import fr.sncf.osrd.path.interfaces.BlockPath
 import fr.sncf.osrd.path.interfaces.PathProperties
 import fr.sncf.osrd.path.interfaces.buildPathPropertiesFrom
 import fr.sncf.osrd.path.interfaces.makePathProperties
-import fr.sncf.osrd.pathfinding.PathfindingEdgeRangeId
 import fr.sncf.osrd.railjson.schema.common.graph.EdgeDirection
-import fr.sncf.osrd.railjson.schema.infra.trackranges.RJSDirectionalTrackRange
-import fr.sncf.osrd.railjson.schema.schedule.RJSTrainPath
 import fr.sncf.osrd.reporting.exceptions.ErrorType
 import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.sim_infra.api.*
@@ -19,28 +15,9 @@ import fr.sncf.osrd.utils.indexing.DirStaticIdx
 import fr.sncf.osrd.utils.indexing.MutableDirStaticIdxArrayList
 import fr.sncf.osrd.utils.indexing.StaticIdxList
 import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
-import fr.sncf.osrd.utils.units.Distance.Companion.fromMeters
 import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
-
-/** Creates the path from a given block id */
-fun makePathProps(
-    blockInfra: BlockInfra,
-    rawInfra: RawSignalingInfra,
-    blockIdx: BlockId,
-    beginOffset: Offset<Block> = Offset(0.meters),
-    endOffset: Offset<Block> = blockInfra.getBlockLength(blockIdx),
-    routes: List<String>? = null,
-): PathProperties {
-    return buildPathPropertiesFrom(
-        rawInfra,
-        blockInfra.getTrackChunksFromBlock(blockIdx),
-        beginOffset.cast(),
-        endOffset.cast(),
-        routes?.map { r -> rawInfra.getRouteFromName(r) },
-    )
-}
 
 /**
  * Creates the path from given blocks.
@@ -70,23 +47,6 @@ fun makePathProps(
     return buildPathPropertiesFrom(rawInfra, chunks, offsetFirstBlock, totalLength, routes)
 }
 
-/** Creates a `Path` instance from a list of block ranges */
-fun makePathProps(
-    rawInfra: RawSignalingInfra,
-    blockInfra: BlockInfra,
-    blockRanges: List<PathfindingEdgeRangeId<Block>>,
-    routes: List<RouteId>? = null,
-): PathProperties {
-    val chunkPath = makeChunkPath(rawInfra, blockInfra, blockRanges)
-    return makePathProperties(rawInfra, chunkPath, routes = routes)
-}
-
-/** Builds a PathProperties from an RJSTrainPath */
-fun makePathProps(rawInfra: RawSignalingInfra, rjsPath: RJSTrainPath): PathProperties {
-    val chunkPath = makeChunkPath(rawInfra, rjsPath)
-    return makePathProperties(rawInfra, chunkPath)
-}
-
 /** Builds a PathProperties from a List<TrackRange> */
 fun makePathProps(
     rawInfra: RawSignalingInfra,
@@ -94,78 +54,6 @@ fun makePathProps(
 ): PathProperties {
     val chunkPath = makeChunkPath(rawInfra, trackRanges)
     return makePathProperties(rawInfra, chunkPath)
-}
-
-/** Creates a ChunkPath from a list of block ranges */
-fun makeChunkPath(
-    rawInfra: RawSignalingInfra,
-    blockInfra: BlockInfra,
-    blockRanges: List<PathfindingEdgeRangeId<Block>>,
-): ChunkPath {
-    assert(blockRanges.isNotEmpty())
-    var totalBlockPathLength: Length<BlockPath> = Length(0.meters)
-    val chunks = MutableDirStaticIdxArrayList<TrackChunk>()
-    for (range in blockRanges) {
-        val zonePaths = blockInfra.getBlockZonePaths(range.edge)
-        for (zonePath in zonePaths) {
-            chunks.addAll(rawInfra.getZonePathChunks(zonePath))
-            val zoneLength = rawInfra.getZonePathLength(zonePath)
-            totalBlockPathLength += zoneLength.distance
-        }
-    }
-    val startOffset: Offset<BlockPath> = blockRanges[0].start.cast()
-    val lastRange = blockRanges[blockRanges.size - 1]
-    val lastBlockLength = blockInfra.getBlockLength(lastRange.edge)
-    val endOffset = totalBlockPathLength - lastBlockLength.distance + lastRange.end.distance
-    return buildChunkPath(rawInfra, chunks, startOffset, endOffset)
-}
-
-/** Builds a ChunkPath from an RJSTrainPath */
-fun makeChunkPath(rawInfra: RawSignalingInfra, rjsPath: RJSTrainPath): ChunkPath {
-    val trackRanges = ArrayList<RJSDirectionalTrackRange?>()
-    for (routePath in rjsPath.routePath) {
-        for (trackRange in routePath.trackSections) {
-            val lastTrackRange = Iterables.getLast(trackRanges, null)
-            if (
-                lastTrackRange != null && lastTrackRange.trackSectionID == trackRange.trackSectionID
-            ) {
-                assert(lastTrackRange.getEnd() == trackRange.getBegin())
-                assert(lastTrackRange.direction == trackRange.direction)
-                if (trackRange.direction == EdgeDirection.START_TO_STOP)
-                    lastTrackRange.end = trackRange.end
-                else lastTrackRange.begin = trackRange.begin
-            } else {
-                trackRanges.add(trackRange)
-            }
-        }
-    }
-    val chunks = MutableDirStaticIdxArrayList<TrackChunk>()
-    for (trackRange in trackRanges) {
-        val trackId = getTrackSectionFromNameOrThrow(trackRange!!.trackSectionID, rawInfra)
-        val dir =
-            if (trackRange.direction == EdgeDirection.START_TO_STOP) Direction.INCREASING
-            else Direction.DECREASING
-        val chunksOnTrack =
-            if (dir == Direction.INCREASING) rawInfra.getTrackSectionChunks(trackId)
-            else rawInfra.getTrackSectionChunks(trackId).reversed()
-        for (chunk in chunksOnTrack) chunks.add(DirStaticIdx(chunk, dir))
-    }
-    val firstRange = trackRanges[0]
-    var startOffset = fromMeters(firstRange!!.begin)
-    if (firstRange.direction == EdgeDirection.STOP_TO_START) {
-        val firstTrackId = getTrackSectionFromNameOrThrow(trackRanges[0]!!.trackSectionID, rawInfra)
-        startOffset =
-            rawInfra.getTrackSectionLength(firstTrackId).distance - fromMeters(firstRange.end)
-    }
-    val endOffset =
-        startOffset +
-            fromMeters(
-                trackRanges
-                    .stream()
-                    .mapToDouble { r: RJSDirectionalTrackRange? -> r!!.end - r.begin }
-                    .sum()
-            )
-    return buildChunkPath(rawInfra, chunks, Length(startOffset), Length(endOffset))
 }
 
 fun makeChunkPath(

--- a/core/src/main/kotlin/fr/sncf/osrd/utils/PathPropUtils.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/utils/PathPropUtils.kt
@@ -3,10 +3,10 @@ package fr.sncf.osrd.utils
 import fr.sncf.osrd.api.DirectionalTrackRange
 import fr.sncf.osrd.path.implementations.ChunkPath
 import fr.sncf.osrd.path.implementations.buildChunkPath
-import fr.sncf.osrd.path.interfaces.BlockPath
+import fr.sncf.osrd.path.implementations.buildRangeMap
+import fr.sncf.osrd.path.implementations.buildTrainPathFromChunks
+import fr.sncf.osrd.path.interfaces.DirChunkRange
 import fr.sncf.osrd.path.interfaces.PathProperties
-import fr.sncf.osrd.path.interfaces.buildPathPropertiesFrom
-import fr.sncf.osrd.path.interfaces.makePathProperties
 import fr.sncf.osrd.railjson.schema.common.graph.EdgeDirection
 import fr.sncf.osrd.reporting.exceptions.ErrorType
 import fr.sncf.osrd.reporting.exceptions.OSRDError
@@ -15,45 +15,35 @@ import fr.sncf.osrd.utils.indexing.DirStaticIdx
 import fr.sncf.osrd.utils.indexing.MutableDirStaticIdxArrayList
 import fr.sncf.osrd.utils.indexing.StaticIdxList
 import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
-import fr.sncf.osrd.utils.units.Length
+import fr.sncf.osrd.utils.units.Distance.Companion.max
+import fr.sncf.osrd.utils.units.Distance.Companion.min
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
-
-/**
- * Creates the path from given blocks.
- *
- * @param rawInfra RawSignalingInfra
- * @param blockInfra BlockInfra
- * @param blockIds the blocks in the order they are encountered
- * @param offsetFirstBlock the path offset on the first block in millimeters
- * @param routes non-overlapping list of routes the path follows
- * @return corresponding path
- */
-fun makePathProps(
-    rawInfra: RawSignalingInfra,
-    blockInfra: BlockInfra,
-    blockIds: List<BlockId>,
-    offsetFirstBlock: Length<BlockPath>,
-    routes: List<RouteId>? = null,
-): PathProperties {
-    val chunks = MutableDirStaticIdxArrayList<TrackChunk>()
-    var totalLength: Length<BlockPath> = Length(0.meters)
-    for (blockId in blockIds) {
-        for (zoneId in blockInfra.getBlockZonePaths(blockId)) {
-            chunks.addAll(rawInfra.getZonePathChunks(zoneId))
-            totalLength += rawInfra.getZonePathLength(zoneId).distance
-        }
-    }
-    return buildPathPropertiesFrom(rawInfra, chunks, offsetFirstBlock, totalLength, routes)
-}
 
 /** Builds a PathProperties from a List<TrackRange> */
 fun makePathProps(
     rawInfra: RawSignalingInfra,
+    blockInfra: BlockInfra,
     trackRanges: List<DirectionalTrackRange>,
 ): PathProperties {
     val chunkPath = makeChunkPath(rawInfra, trackRanges)
-    return makePathProperties(rawInfra, chunkPath)
+
+    val chunkRanges = mutableListOf<DirChunkRange>()
+    var prevChunksLength = 0.meters
+    for (chunk in chunkPath.chunks) {
+        val chunkLength = rawInfra.getTrackChunkLength(chunk.value)
+        val start = max(chunkPath.beginOffset.distance - prevChunksLength, 0.meters)
+        val end = min(chunkPath.endOffset.distance - prevChunksLength, chunkLength.distance)
+        val range = DirChunkRange(chunk, Offset(start), Offset(end))
+        chunkRanges.add(range)
+        prevChunksLength += chunkLength.distance
+    }
+    return buildTrainPathFromChunks(
+        rawInfra,
+        blockInfra,
+        buildRangeMap(chunkRanges),
+        routes = listOf(),
+    )
 }
 
 fun makeChunkPath(

--- a/core/src/main/kotlin/fr/sncf/osrd/utils/PathPropUtils.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/utils/PathPropUtils.kt
@@ -25,6 +25,7 @@ fun makePathProps(
     rawInfra: RawSignalingInfra,
     blockInfra: BlockInfra,
     trackRanges: List<DirectionalTrackRange>,
+    routes: List<RouteId>? = null,
 ): PathProperties {
     val chunkPath = makeChunkPath(rawInfra, trackRanges)
 
@@ -42,7 +43,7 @@ fun makePathProps(
         rawInfra,
         blockInfra,
         buildRangeMap(chunkRanges),
-        routes = listOf(),
+        routes = routes,
     )
 }
 

--- a/core/src/test/java/fr/sncf/osrd/DriverBehaviourTest.kt
+++ b/core/src/test/java/fr/sncf/osrd/DriverBehaviourTest.kt
@@ -1,13 +1,12 @@
 package fr.sncf.osrd
 
 import fr.sncf.osrd.envelope_sim_infra.computeMRSP
+import fr.sncf.osrd.path.implementations.buildTrainPathFromBlocks
 import fr.sncf.osrd.path.interfaces.PathProperties
 import fr.sncf.osrd.train.TestTrains
 import fr.sncf.osrd.utils.DistanceRangeMap
 import fr.sncf.osrd.utils.DummyInfra
 import fr.sncf.osrd.utils.distanceRangeMapOf
-import fr.sncf.osrd.utils.makePathProps
-import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.meters
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
@@ -22,7 +21,7 @@ class DriverBehaviourTest {
                 infra.addBlock("b", "c", 100.meters, 10.0),
                 infra.addBlock("c", "d", 100.meters, 20.0),
             )
-        val path: PathProperties = makePathProps(infra, infra, blocks, Length(0.meters), listOf())
+        val path: PathProperties = buildTrainPathFromBlocks(infra, infra, blocks, routes = listOf())
         val testRollingStock = TestTrains.VERY_SHORT_FAST_TRAIN
         val driverBehaviour = DriverBehaviour(2.0, 3.0)
         var mrsp = computeMRSP(path, testRollingStock, true, null, null)

--- a/core/src/test/kotlin/fr/sncf/osrd/envelope_sim_infra/MRSPTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/envelope_sim_infra/MRSPTest.kt
@@ -4,7 +4,7 @@ import fr.sncf.osrd.envelope.Envelope
 import fr.sncf.osrd.envelope.EnvelopeTestUtils
 import fr.sncf.osrd.envelope.MRSPEnvelopeBuilder.LimitKind
 import fr.sncf.osrd.envelope_sim.EnvelopeProfile.CONSTANT_SPEED
-import fr.sncf.osrd.path.implementations.buildTrainPath
+import fr.sncf.osrd.path.implementations.buildTrainPathFromBlock
 import fr.sncf.osrd.path.interfaces.PathProperties
 import fr.sncf.osrd.railjson.schema.common.RJSWaypointRef
 import fr.sncf.osrd.railjson.schema.common.graph.ApplicableDirection
@@ -151,11 +151,23 @@ class MRSPTest {
         // Compute paths
         val infra = fullInfraFromRJS(rjsInfra)
         val blockInfra = infra.blockInfra
-        path = buildTrainPath(infra.rawInfra, blockInfra, BlockId(0U), routes = listOf())
+        path = buildTrainPathFromBlock(infra.rawInfra, blockInfra, BlockId(0U), routes = listOf())
         val block30 = Helpers.getBlocksOnRoutes(infra, listOf(route1.id))[0]
-        path30 = buildTrainPath(infra.rawInfra, blockInfra, block30, routeNames = listOf(route1.id))
+        path30 =
+            buildTrainPathFromBlock(
+                infra.rawInfra,
+                blockInfra,
+                block30,
+                routeNames = listOf(route1.id),
+            )
         val block60 = Helpers.getBlocksOnRoutes(infra, listOf(route2.id))[0]
-        path60 = buildTrainPath(infra.rawInfra, blockInfra, block60, routeNames = listOf(route2.id))
+        path60 =
+            buildTrainPathFromBlock(
+                infra.rawInfra,
+                blockInfra,
+                block60,
+                routeNames = listOf(route2.id),
+            )
     }
 
     private fun setUpOnNestedSwitches() {
@@ -171,7 +183,12 @@ class MRSPTest {
         fun makePathFromRoute(route: String, speed: Double): TestPath {
             val block = Helpers.getBlocksOnRoutes(infra, listOf(route)).last()
             val pathProps =
-                buildTrainPath(infra.rawInfra, infra.blockInfra, block, routeNames = listOf(route))
+                buildTrainPathFromBlock(
+                    infra.rawInfra,
+                    infra.blockInfra,
+                    block,
+                    routeNames = listOf(route),
+                )
             val pathLen = routeLen(route)
             val envelope =
                 Envelope.make(
@@ -193,7 +210,7 @@ class MRSPTest {
         val block = Helpers.getBlocksOnRoutes(infra, listOf(ROUTES[0])).last()
         pathTo1NoRoutes =
             TestPath(
-                buildTrainPath(infra.rawInfra, infra.blockInfra, block, routes = listOf()),
+                buildTrainPathFromBlock(infra.rawInfra, infra.blockInfra, block, routes = listOf()),
                 Envelope.make(
                     EnvelopeTestUtils.makeFlatPart(
                         LimitKind.SPEED_LIMIT,

--- a/core/src/test/kotlin/fr/sncf/osrd/envelope_sim_infra/MRSPTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/envelope_sim_infra/MRSPTest.kt
@@ -4,6 +4,7 @@ import fr.sncf.osrd.envelope.Envelope
 import fr.sncf.osrd.envelope.EnvelopeTestUtils
 import fr.sncf.osrd.envelope.MRSPEnvelopeBuilder.LimitKind
 import fr.sncf.osrd.envelope_sim.EnvelopeProfile.CONSTANT_SPEED
+import fr.sncf.osrd.path.implementations.buildTrainPath
 import fr.sncf.osrd.path.interfaces.PathProperties
 import fr.sncf.osrd.railjson.schema.common.RJSWaypointRef
 import fr.sncf.osrd.railjson.schema.common.graph.ApplicableDirection
@@ -19,7 +20,6 @@ import fr.sncf.osrd.train.TestTrains
 import fr.sncf.osrd.utils.Helpers
 import fr.sncf.osrd.utils.Helpers.fullInfraFromRJS
 import fr.sncf.osrd.utils.Helpers.getExampleInfra
-import fr.sncf.osrd.utils.makePathProps
 import fr.sncf.osrd.utils.units.Distance.Companion.toMeters
 import java.io.IOException
 import java.net.URISyntaxException
@@ -151,11 +151,11 @@ class MRSPTest {
         // Compute paths
         val infra = fullInfraFromRJS(rjsInfra)
         val blockInfra = infra.blockInfra
-        path = makePathProps(blockInfra, infra.rawInfra, BlockId(0U), routes = listOf())
+        path = buildTrainPath(infra.rawInfra, blockInfra, BlockId(0U), routes = listOf())
         val block30 = Helpers.getBlocksOnRoutes(infra, listOf(route1.id))[0]
-        path30 = makePathProps(blockInfra, infra.rawInfra, block30, routes = listOf(route1.id))
+        path30 = buildTrainPath(infra.rawInfra, blockInfra, block30, routeNames = listOf(route1.id))
         val block60 = Helpers.getBlocksOnRoutes(infra, listOf(route2.id))[0]
-        path60 = makePathProps(blockInfra, infra.rawInfra, block60, routes = listOf(route2.id))
+        path60 = buildTrainPath(infra.rawInfra, blockInfra, block60, routeNames = listOf(route2.id))
     }
 
     private fun setUpOnNestedSwitches() {
@@ -171,7 +171,7 @@ class MRSPTest {
         fun makePathFromRoute(route: String, speed: Double): TestPath {
             val block = Helpers.getBlocksOnRoutes(infra, listOf(route)).last()
             val pathProps =
-                makePathProps(infra.blockInfra, infra.rawInfra, block, routes = listOf(route))
+                buildTrainPath(infra.rawInfra, infra.blockInfra, block, routeNames = listOf(route))
             val pathLen = routeLen(route)
             val envelope =
                 Envelope.make(
@@ -193,7 +193,7 @@ class MRSPTest {
         val block = Helpers.getBlocksOnRoutes(infra, listOf(ROUTES[0])).last()
         pathTo1NoRoutes =
             TestPath(
-                makePathProps(infra.blockInfra, infra.rawInfra, block, routes = listOf()),
+                buildTrainPath(infra.rawInfra, infra.blockInfra, block, routes = listOf()),
                 Envelope.make(
                     EnvelopeTestUtils.makeFlatPart(
                         LimitKind.SPEED_LIMIT,

--- a/core/src/test/kotlin/fr/sncf/osrd/external_generated_inputs/ElectricalProfileMappingTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/external_generated_inputs/ElectricalProfileMappingTest.kt
@@ -49,7 +49,7 @@ class ElectricalProfileMappingTest {
         profileMap.parseRJS(rjsElectricalProfiles)
         val path =
             pathFromTracks(
-                infra.rawInfra,
+                infra,
                 listOf("TA0", "TA1"),
                 Direction.INCREASING,
                 1_000.meters,

--- a/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathPropEndpointTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathPropEndpointTest.kt
@@ -55,7 +55,8 @@ class PathPropEndpointTest : ApiTest() {
                 listOf(Electrified("1500V"), Neutral(true), Electrified("25000V")),
             ),
         )
-        assertEquals(parsed.geometry.coordinates.size, 6)
+        // The size might change, there can be repeated points
+        assertEquals(parsed.geometry.coordinates.size, 7)
         val oPs =
             listOf(
                 OperationalPointResponse(

--- a/core/src/test/kotlin/fr/sncf/osrd/pathfinding/RemainingDistanceEstimatorTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/pathfinding/RemainingDistanceEstimatorTest.kt
@@ -3,13 +3,13 @@ package fr.sncf.osrd.pathfinding
 import com.google.common.collect.Iterables
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import fr.sncf.osrd.api.FullInfra
+import fr.sncf.osrd.path.implementations.buildTrainPath
 import fr.sncf.osrd.path.interfaces.BlockPath
 import fr.sncf.osrd.path.interfaces.PathProperties
 import fr.sncf.osrd.pathfinding.Pathfinding.EdgeLocation
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.utils.Helpers
-import fr.sncf.osrd.utils.makePathProps
 import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Distance.Companion.fromMeters
 import fr.sncf.osrd.utils.units.Offset
@@ -32,7 +32,7 @@ class RemainingDistanceEstimatorTest {
     fun setUp() {
         smallInfra = Helpers.smallInfra
         block = Helpers.getBlocksOnRoutes(smallInfra!!, listOf("rt.DA2->DA5"))[0]
-        path = makePathProps(smallInfra!!.blockInfra, smallInfra!!.rawInfra, block!!)
+        path = buildTrainPath(smallInfra!!.rawInfra, smallInfra!!.blockInfra, block!!)
     }
 
     @ParameterizedTest

--- a/core/src/test/kotlin/fr/sncf/osrd/pathfinding/RemainingDistanceEstimatorTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/pathfinding/RemainingDistanceEstimatorTest.kt
@@ -3,7 +3,7 @@ package fr.sncf.osrd.pathfinding
 import com.google.common.collect.Iterables
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import fr.sncf.osrd.api.FullInfra
-import fr.sncf.osrd.path.implementations.buildTrainPath
+import fr.sncf.osrd.path.implementations.buildTrainPathFromBlock
 import fr.sncf.osrd.path.interfaces.BlockPath
 import fr.sncf.osrd.path.interfaces.PathProperties
 import fr.sncf.osrd.pathfinding.Pathfinding.EdgeLocation
@@ -32,7 +32,7 @@ class RemainingDistanceEstimatorTest {
     fun setUp() {
         smallInfra = Helpers.smallInfra
         block = Helpers.getBlocksOnRoutes(smallInfra!!, listOf("rt.DA2->DA5"))[0]
-        path = buildTrainPath(smallInfra!!.rawInfra, smallInfra!!.blockInfra, block!!)
+        path = buildTrainPathFromBlock(smallInfra!!.rawInfra, smallInfra!!.blockInfra, block!!)
     }
 
     @ParameterizedTest

--- a/core/src/test/kotlin/fr/sncf/osrd/sim_infra_adapter/EnvelopeTrainPathTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/sim_infra_adapter/EnvelopeTrainPathTest.kt
@@ -40,7 +40,7 @@ class EnvelopeTrainPathTest {
         val infra = Helpers.fullInfraFromRJS(rjsInfra)
         val path =
             pathFromTracks(
-                infra.rawInfra,
+                infra,
                 listOf("TA0", "TA1"),
                 Direction.INCREASING,
                 500.meters,
@@ -108,7 +108,7 @@ class EnvelopeTrainPathTest {
                 // Direction.INCREASING
             )
         val infra = Helpers.fullInfraFromRJS(rjsInfra)
-        val path = pathFromTracks(infra.rawInfra, tracks, direction, 500.meters, 3_600.meters)
+        val path = pathFromTracks(infra, tracks, direction, 500.meters, 3_600.meters)
         val envelopeSimPath = EnvelopeTrainPath.from(infra.rawInfra, path)
 
         assertThat(envelopeSimPath.getElectrificationMap(null, null, null)).isEqualTo(expectedMap)
@@ -168,7 +168,7 @@ class EnvelopeTrainPathTest {
         profileMap.parseRJS(rjsElectricalProfiles)
         val path =
             pathFromTracks(
-                infra.rawInfra,
+                infra,
                 listOf("TA0", "TA1"),
                 Direction.INCREASING,
                 1_000.meters,
@@ -266,7 +266,7 @@ class EnvelopeTrainPathTest {
         profileMap.parseRJS(rjsElectricalProfiles)
         val path =
             pathFromTracks(
-                infra.rawInfra,
+                infra,
                 listOf("TA2", "TA1", "TA0"),
                 Direction.DECREASING,
                 1_000.meters,

--- a/core/src/test/kotlin/fr/sncf/osrd/sim_infra_adapter/PathPropertiesTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/sim_infra_adapter/PathPropertiesTests.kt
@@ -3,6 +3,7 @@ package fr.sncf.osrd.sim_infra_adapter
 import fr.sncf.osrd.geom.LineString
 import fr.sncf.osrd.geom.Point
 import fr.sncf.osrd.parseRJSInfra
+import fr.sncf.osrd.path.implementations.buildTrainPath
 import fr.sncf.osrd.railjson.schema.common.graph.ApplicableDirection
 import fr.sncf.osrd.railjson.schema.geom.RJSLineString
 import fr.sncf.osrd.railjson.schema.infra.RJSOperationalPoint
@@ -20,7 +21,6 @@ import fr.sncf.osrd.utils.Direction
 import fr.sncf.osrd.utils.DistanceRangeMap.RangeMapEntry
 import fr.sncf.osrd.utils.Helpers
 import fr.sncf.osrd.utils.indexing.StaticIdx
-import fr.sncf.osrd.utils.makePathProps
 import fr.sncf.osrd.utils.pathFromTracks
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
@@ -495,7 +495,7 @@ class PathPropertiesTests {
             )
         rjsInfra.speedSections.add(speedSection)
         val infra = Helpers.fullInfraFromRJS(rjsInfra)
-        val path = makePathProps(infra.blockInfra, infra.rawInfra, BlockId(0U), routes = listOf())
+        val path = buildTrainPath(infra.rawInfra, infra.blockInfra, BlockId(0U), routes = listOf())
         val speedLimits = path.getSpeedLimitProperties("trainTag", null)
         assertThat(speedLimits.asList())
             .containsExactlyElementsOf(
@@ -537,11 +537,11 @@ class PathPropertiesTests {
         val routeName = "rt.DH2->buffer_stop.7"
         val blocks = Helpers.getBlocksOnRoutes(infra, listOf(routeName))
         val path =
-            makePathProps(
-                infra.blockInfra,
+            buildTrainPath(
                 infra.rawInfra,
+                infra.blockInfra,
                 blocks.last(),
-                routes = listOf("rt.DH2->buffer_stop.7"),
+                routeNames = listOf("rt.DH2->buffer_stop.7"),
             )
 
         /*

--- a/core/src/test/kotlin/fr/sncf/osrd/sim_infra_adapter/PathPropertiesTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/sim_infra_adapter/PathPropertiesTests.kt
@@ -2,7 +2,6 @@ package fr.sncf.osrd.sim_infra_adapter
 
 import fr.sncf.osrd.geom.LineString
 import fr.sncf.osrd.geom.Point
-import fr.sncf.osrd.parseRJSInfra
 import fr.sncf.osrd.path.implementations.buildTrainPathFromBlock
 import fr.sncf.osrd.railjson.schema.common.graph.ApplicableDirection
 import fr.sncf.osrd.railjson.schema.geom.RJSLineString
@@ -20,6 +19,7 @@ import fr.sncf.osrd.train.TestTrains.MAX_SPEED
 import fr.sncf.osrd.utils.Direction
 import fr.sncf.osrd.utils.DistanceRangeMap.RangeMapEntry
 import fr.sncf.osrd.utils.Helpers
+import fr.sncf.osrd.utils.Helpers.fullInfraFromRJS
 import fr.sncf.osrd.utils.indexing.StaticIdx
 import fr.sncf.osrd.utils.pathFromTracks
 import fr.sncf.osrd.utils.units.Offset
@@ -51,7 +51,7 @@ class PathPropertiesTests {
             if (track.id.equals("TA1")) // 1.950km long
              track.slopes = listOf(RJSSlope(1_000.0, 1_950.0, -5.0))
         }
-        val infra = parseRJSInfra(rjsInfra)
+        val infra = fullInfraFromRJS(rjsInfra)
 
         val path =
             pathFromTracks(
@@ -115,7 +115,7 @@ class PathPropertiesTests {
                 null,
             )
         )
-        val infra = parseRJSInfra(rjsInfra)
+        val infra = fullInfraFromRJS(rjsInfra)
         val path =
             pathFromTracks(
                 infra,
@@ -126,7 +126,7 @@ class PathPropertiesTests {
             )
         val opIdsIdxWithOffset =
             path.getOperationalPointParts().map { op ->
-                Pair(infra.getOperationalPointPartOpId(op.value), op.offset)
+                Pair(infra.rawInfra.getOperationalPointPartOpId(op.value), op.offset)
             }
         assertEquals(
             listOf(Pair("new_op_1", Offset(0.meters)), Pair("new_op_2", Offset(10_000.meters))),
@@ -189,7 +189,7 @@ class PathPropertiesTests {
                     null,
                 ),
             )
-        val infra = parseRJSInfra(rjsInfra)
+        val infra = fullInfraFromRJS(rjsInfra)
         val path =
             pathFromTracks(
                 infra,
@@ -200,7 +200,7 @@ class PathPropertiesTests {
             )
         val opIdsIdxWithOffset =
             path.getOperationalPointParts().map { op ->
-                Pair(infra.getOperationalPointPartOpId(op.value), op.offset)
+                Pair(infra.rawInfra.getOperationalPointPartOpId(op.value), op.offset)
             }
         assertEquals(
             listOf(
@@ -221,7 +221,7 @@ class PathPropertiesTests {
             )
         val opIdsIdxWithOffsetBackward =
             pathBackward.getOperationalPointParts().map { op ->
-                Pair(infra.getOperationalPointPartOpId(op.value), op.offset)
+                Pair(infra.rawInfra.getOperationalPointPartOpId(op.value), op.offset)
             }
         assertEquals(
             listOf(
@@ -252,7 +252,7 @@ class PathPropertiesTests {
         for (track in rjsInfra.trackSections) if (track.id.equals("TA0"))
             track.curves =
                 listOf(RJSCurve(0.0, 1_000.0, 5_000.0), RJSCurve(1_000.0, 2_000.0, 10_000.0))
-        val infra = parseRJSInfra(rjsInfra)
+        val infra = fullInfraFromRJS(rjsInfra)
         val pathBackward =
             pathFromTracks(infra, listOf("TA0"), Direction.DECREASING, 500.meters, 1_500.meters)
         val slopesBackward = pathBackward.getCurves()
@@ -285,7 +285,7 @@ class PathPropertiesTests {
             track.slopes = listOf(RJSSlope(0.0, 1_000.0, 5.0), RJSSlope(1_000.0, 2_000.0, 15.0))
             track.curves = listOf(RJSCurve(0.0, 1_000.0, 5_000.0))
         }
-        val infra = parseRJSInfra(rjsInfra)
+        val infra = fullInfraFromRJS(rjsInfra)
         val pathBackward =
             pathFromTracks(infra, listOf("TA0"), Direction.DECREASING, 500.meters, 1_500.meters)
         val slopesBackward = pathBackward.getGradients()
@@ -317,7 +317,7 @@ class PathPropertiesTests {
             if (track.id.equals("TA1"))
                 track.geo = RJSLineString.make(listOf(1.0, 2.0, 2.0), listOf(1.0, 1.0, 1.95))
         }
-        val infra = parseRJSInfra(rjsInfra)
+        val infra = fullInfraFromRJS(rjsInfra)
 
         val path =
             pathFromTracks(
@@ -397,7 +397,7 @@ class PathPropertiesTests {
                     ),
                 ),
             )
-        val infra = parseRJSInfra(rjsInfra)
+        val infra = fullInfraFromRJS(rjsInfra)
 
         val path =
             pathFromTracks(
@@ -457,7 +457,7 @@ class PathPropertiesTests {
                         RJSLoadingGaugeLimit(1_000.0, 1_950.0, RJSLoadingGaugeType.GC),
                     )
         }
-        val infra = parseRJSInfra(rjsInfra)
+        val infra = fullInfraFromRJS(rjsInfra)
 
         val pathBackward =
             pathFromTracks(

--- a/core/src/test/kotlin/fr/sncf/osrd/sim_infra_adapter/PathPropertiesTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/sim_infra_adapter/PathPropertiesTests.kt
@@ -3,7 +3,7 @@ package fr.sncf.osrd.sim_infra_adapter
 import fr.sncf.osrd.geom.LineString
 import fr.sncf.osrd.geom.Point
 import fr.sncf.osrd.parseRJSInfra
-import fr.sncf.osrd.path.implementations.buildTrainPath
+import fr.sncf.osrd.path.implementations.buildTrainPathFromBlock
 import fr.sncf.osrd.railjson.schema.common.graph.ApplicableDirection
 import fr.sncf.osrd.railjson.schema.geom.RJSLineString
 import fr.sncf.osrd.railjson.schema.infra.RJSOperationalPoint
@@ -495,7 +495,13 @@ class PathPropertiesTests {
             )
         rjsInfra.speedSections.add(speedSection)
         val infra = Helpers.fullInfraFromRJS(rjsInfra)
-        val path = buildTrainPath(infra.rawInfra, infra.blockInfra, BlockId(0U), routes = listOf())
+        val path =
+            buildTrainPathFromBlock(
+                infra.rawInfra,
+                infra.blockInfra,
+                BlockId(0U),
+                routes = listOf(),
+            )
         val speedLimits = path.getSpeedLimitProperties("trainTag", null)
         assertThat(speedLimits.asList())
             .containsExactlyElementsOf(
@@ -537,7 +543,7 @@ class PathPropertiesTests {
         val routeName = "rt.DH2->buffer_stop.7"
         val blocks = Helpers.getBlocksOnRoutes(infra, listOf(routeName))
         val path =
-            buildTrainPath(
+            buildTrainPathFromBlock(
                 infra.rawInfra,
                 infra.blockInfra,
                 blocks.last(),

--- a/core/src/test/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulationTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulationTest.kt
@@ -12,9 +12,8 @@ import fr.sncf.osrd.envelope_sim.allowances.AllowanceValue.TimePerDistance
 import fr.sncf.osrd.envelope_sim.pipelines.maxEffortEnvelopeFrom
 import fr.sncf.osrd.envelope_sim.pipelines.maxSpeedEnvelopeFrom
 import fr.sncf.osrd.envelope_sim_infra.computeMRSP
-import fr.sncf.osrd.path.implementations.EnvelopeTrainPath
+import fr.sncf.osrd.path.implementations.buildTrainPathFromChunkPath
 import fr.sncf.osrd.path.interfaces.TravelledPath
-import fr.sncf.osrd.path.interfaces.makePathProperties
 import fr.sncf.osrd.path.legacy_objects.ElectricalProfileMapping
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
 import fr.sncf.osrd.railjson.schema.schedule.RJSAllowanceDistribution
@@ -54,15 +53,14 @@ class StandaloneSimulationTest {
             .map { infra.blockInfra.getBlockFromName("block.${md5(it)}")!! }
 
     private val chunkPath = pathFromRoutes(infra.rawInfra, routes)
-    private val pathProps = makePathProperties(infra.rawInfra, chunkPath, routes)
-    private val pathLength = pathProps.getLength()
+    private val trainPath =
+        buildTrainPathFromChunkPath(infra.rawInfra, infra.blockInfra, chunkPath, routes)
+    private val pathLength = trainPath.getLength()
 
     // Build a reference max speed envelope
-    private val mrsp = computeMRSP(pathProps, rollingStock, true, null, null)
-    private val envelopeSimPath =
-        EnvelopeTrainPath.from(infra.rawInfra, pathProps, ElectricalProfileMapping())
+    private val mrsp = computeMRSP(trainPath, rollingStock, true, null, null)
     private val electrificationMap =
-        envelopeSimPath.getElectrificationMap(
+        trainPath.getElectrificationMap(
             rollingStock.basePowerClass,
             ImmutableRangeMap.of(),
             rollingStock.powerRestrictions,
@@ -71,7 +69,7 @@ class StandaloneSimulationTest {
     private val curvesAndConditions =
         rollingStock.mapTractiveEffortCurves(electrificationMap, Comfort.STANDARD)
     private var context =
-        EnvelopeSimContext(rollingStock, envelopeSimPath, 2.0, curvesAndConditions.curves)
+        EnvelopeSimContext(rollingStock, trainPath, 2.0, curvesAndConditions.curves)
     private val maxSpeedEnvelope = maxSpeedEnvelopeFrom(context, emptyList(), mrsp)
     private val maxEffortEnvelope = maxEffortEnvelopeFrom(context, 0.0, maxSpeedEnvelope)
 
@@ -81,7 +79,7 @@ class StandaloneSimulationTest {
         val res =
             runStandaloneSimulation(
                 infra,
-                pathProps,
+                trainPath,
                 chunkPath,
                 routes.toIdxList(),
                 blocks.toIdxList(),
@@ -217,7 +215,7 @@ class StandaloneSimulationTest {
         val res =
             runStandaloneSimulation(
                 infra,
-                pathProps,
+                trainPath,
                 chunkPath,
                 routes.toIdxList(),
                 blocks.toIdxList(),
@@ -476,7 +474,7 @@ class StandaloneSimulationTest {
             )
         val offsetEndSafetySpeed = 5_000.0
         val mrspWithSafetySpeed =
-            computeMRSP(pathProps, rollingStock, true, null, null, safetySpeeds)
+            computeMRSP(trainPath, rollingStock, true, null, null, safetySpeeds)
         assertEquals(mrsp.endPos, mrspWithSafetySpeed.endPos)
         var position = 0.0
         while (position < mrsp.endPos) {

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/FullSTDCMTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/FullSTDCMTests.kt
@@ -6,7 +6,7 @@ import fr.sncf.osrd.api.pathfinding.PathfindingBlockSuccess
 import fr.sncf.osrd.api.pathfinding.runPathfinding
 import fr.sncf.osrd.conflicts.SpacingRequirement
 import fr.sncf.osrd.envelope_sim.allowances.AllowanceValue
-import fr.sncf.osrd.path.interfaces.makePathProperties
+import fr.sncf.osrd.path.implementations.buildTrainPathFromChunkPath
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
 import fr.sncf.osrd.railjson.schema.schedule.RJSAllowanceDistribution
 import fr.sncf.osrd.sim_infra.api.RawInfra
@@ -456,7 +456,8 @@ fun makeRequirementsFromPath(
             as PathfindingBlockSuccess
 
     val chunkPath = makeChunkPath(infra.rawInfra, path.trackSectionRanges)
-    val pathProperties = makePathProperties(infra.rawInfra, chunkPath, routes = listOf())
+    val pathProperties =
+        buildTrainPathFromChunkPath(infra.rawInfra, infra.blockInfra, chunkPath, routes = listOf())
 
     val sim =
         runStandaloneSimulation(

--- a/core/src/test/kotlin/fr/sncf/osrd/utils/PathUtils.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/utils/PathUtils.kt
@@ -1,10 +1,11 @@
 package fr.sncf.osrd.utils
 
+import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.path.implementations.ChunkPath
 import fr.sncf.osrd.path.implementations.buildChunkPath
+import fr.sncf.osrd.path.implementations.buildTrainPathFromChunkPath
 import fr.sncf.osrd.path.interfaces.BlockPath
 import fr.sncf.osrd.path.interfaces.PathProperties
-import fr.sncf.osrd.path.interfaces.buildPathPropertiesFrom
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.utils.indexing.MutableDirStaticIdxArrayList
 import fr.sncf.osrd.utils.indexing.mutableDirStaticIdxArrayListOf
@@ -16,6 +17,7 @@ import fr.sncf.osrd.utils.units.meters
 /** Build a path from track ids */
 fun pathFromTracks(
     infra: RawInfra,
+    blockInfra: BlockInfra,
     trackIds: List<String>,
     dir: Direction,
     start: Distance,
@@ -26,7 +28,18 @@ fun pathFromTracks(
         .map { id -> infra.getTrackSectionFromName(id)!! }
         .flatMap { track -> infra.getTrackSectionChunks(track).dirIter(dir) }
         .forEach { dirChunk -> chunkList.add(dirChunk) }
-    return buildPathPropertiesFrom(infra, chunkList, Length(start), Length(end))
+    val chunkPath = buildChunkPath(infra, chunkList, Offset(start), Offset(end))
+    return buildTrainPathFromChunkPath(infra, blockInfra, chunkPath)
+}
+
+fun pathFromTracks(
+    infra: FullInfra,
+    trackIds: List<String>,
+    dir: Direction,
+    start: Distance,
+    end: Distance,
+): PathProperties {
+    return pathFromTracks(infra.rawInfra, infra.blockInfra, trackIds, dir, start, end)
 }
 
 /** Build a path from route ids */


### PR DESCRIPTION
Fix https://github.com/OpenRailAssociation/osrd/issues/12530
Fix parts of https://github.com/OpenRailAssociation/osrd/issues/12531

1. The new class now properly implement interfaces of the older path types (for easier transition).
2. Add builder methods, with inputs similar to the builder methods of the older types
3. All `PathProperties` instances have been replaced by `TrainPath` instances. As it implements the interface, that's a transparent change.  The building process can be a little more verbose though, as it now requires `BlockInfra`. 
4. Some `PhysicsPath` instances have been replaced by `TrainPath` instance. For the remaining one, we need to drop the old interface types.


There's no *specific* test for the new class here, but there's extensive assertions. Since we now use the new class in most tests, it did catch some bugs. 

Review by commit is **not necessarily recommended**. It gives context on how we got there, but the last commit migrating from `DistanceRangeMaps` to `ImmutableRangeMap` reverts a few changes from earlier. See https://github.com/OpenRailAssociation/osrd/issues/12828 for context. 

---

Remaining work:

1. Remove the old interface from most of the code (the actual implementation of `PathPropertiesImpl` will stay).
2. Remove remaining `PhysicsPath` instances.
3. **Use `TrainPath` elements when accessing block and route lists**, instead of parameters passed alongside the path object. This will take a while.