### PR TITLE
front: fix isTimetableItemValid in PacedTrainItem

### DIFF
--- a/front/src/modules/timetableItem/components/Timetable/PacedTrain/PacedTrainItem.tsx
+++ b/front/src/modules/timetableItem/components/Timetable/PacedTrain/PacedTrainItem.tsx
@@ -312,7 +312,7 @@ const PacedTrainItem = ({
               'sm'
             );
           }}
-          isTimetableItemValid={summary && !summary.isValid}
+          isTimetableItemValid={summary?.isValid}
           showResetExceptionsButton={pacedTrain.exceptions.length > 0}
           resetAllExceptions={() => {
             openModal(


### PR DESCRIPTION
The condition was wrong and is now fixed.

closes #12662 