### PR TITLE
editoast: fix nightly warnings

### DIFF
--- a/editoast/editoast_common/src/hash_rounded_float.rs
+++ b/editoast/editoast_common/src/hash_rounded_float.rs
@@ -12,7 +12,7 @@ pub fn hash_float<const T: u8, H: Hasher>(value: &f64, state: &mut H) {
 pub fn hash_float_slice<const T: u8, H: Hasher>(value: &[f64], state: &mut H) {
     let slice: Vec<_> = value
         .iter()
-        .map(|v| ((v * 10i64.pow(T as u32) as f64).round() as i64))
+        .map(|v| (v * 10i64.pow(T as u32) as f64).round() as i64)
         .collect();
     slice.hash(state);
 }

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -682,7 +682,7 @@ async fn get_speed_limit_tags(
     let infra_tags = infra.get_speed_limit_tags(conn).await?;
     let union_tags: HashSet<String> = infra_tags
         .into_iter()
-        .map(|el| (el.tag))
+        .map(|el| el.tag)
         .chain(builtin_tags.0.clone())
         .collect();
     Ok(Json(union_tags))
@@ -737,7 +737,7 @@ async fn get_voltages(
     let voltages = infra
         .get_voltages(&mut db_pool.get().await?, include_rolling_stock_modes)
         .await?;
-    Ok(Json(voltages.into_iter().map(|el| (el.voltage)).collect()))
+    Ok(Json(voltages.into_iter().map(|el| el.voltage).collect()))
 }
 
 /// Returns the set of voltages for all infras and rolling_stocks modes.
@@ -762,7 +762,7 @@ async fn get_all_voltages(
     }
 
     let voltages = Infra::get_all_voltages(&mut db_pool.get().await?).await?;
-    Ok(Json(voltages.into_iter().map(|el| (el.voltage)).collect()))
+    Ok(Json(voltages.into_iter().map(|el| el.voltage).collect()))
 }
 
 async fn set_locked(infra_id: i64, locked: bool, db_pool: DbConnectionPoolV2) -> Result<()> {

--- a/editoast/src/views/rolling_stock.rs
+++ b/editoast/src/views/rolling_stock.rs
@@ -290,7 +290,7 @@ async fn get_power_restrictions(
     Ok(Json(
         power_restrictions
             .into_iter()
-            .map(|pr| (pr.power_restriction))
+            .map(|pr| pr.power_restriction)
             .collect(),
     ))
 }

--- a/editoast/src/views/sub_categories.rs
+++ b/editoast/src/views/sub_categories.rs
@@ -33,6 +33,10 @@ editoast_common::schemas! {
 
 #[derive(Debug, Error, EditoastError)]
 #[editoast_error(base_id = "sub_categories")]
+// TODO: Remove this once it is used.
+// It cannot be an expect since older rust versions
+// don't detect it as unused.
+#[allow(dead_code)]
 enum SubCategoryError {
     #[error(transparent)]
     #[editoast_error(status = 500)]


### PR DESCRIPTION
We have some warning in nightly not present in 1.87. They are valid, so this fixes them