### PR TITLE
docker: move osrd-images to port 8075

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
       OPENFGA_DATASTORE_ENGINE: "postgres"
       OPENFGA_DATASTORE_URI: "postgres://osrd:password@postgres:5432/osrd?search_path=openfga"
       OPENFGA_HTTP_ADDR: "0.0.0.0:8091"
-      OPENFGA_GRPC_ADDR: "0.0.0.0:8093" # avoid squatting 8081 (used by osrd-images in pr-tests)
+      OPENFGA_GRPC_ADDR: "0.0.0.0:8093"
       OPENFGA_PLAYGROUND_PORT: 8092
     command: run
     ports:
@@ -174,8 +174,8 @@ services:
     container_name: osrd-images
     restart: unless-stopped
     environment:
-      - NGINX_PORT=8080
-    ports: [ "8080:8080" ]
+      - NGINX_PORT=8075
+    ports: [ "8075:8075" ]
 
   osrdyne:
     image: ghcr.io/openrailassociation/osrd-${RELEASE_CHANNEL-edge}/osrd-osrdyne:${TAG-dev}

--- a/docker/docker-compose.pr-tests.yml
+++ b/docker/docker-compose.pr-tests.yml
@@ -76,7 +76,7 @@ services:
       OPENFGA_DATASTORE_ENGINE: "postgres"
       OPENFGA_DATASTORE_URI: "postgres://osrd:password@postgres:5433/osrd?search_path=openfga"
       OPENFGA_HTTP_ADDR: "0.0.0.0:8191"
-      OPENFGA_GRPC_ADDR: "0.0.0.0:8193" # avoid squatting 8081 (used by osrd-images in pr-tests)
+      OPENFGA_GRPC_ADDR: "0.0.0.0:8193"
       OPENFGA_PLAYGROUND_PORT: 8192
     command: run
     ports:
@@ -185,8 +185,8 @@ services:
     platform: linux/x86_64
     restart: unless-stopped
     environment:
-      - NGINX_PORT=8081
-    ports: [ "8081:8081" ]
+      - NGINX_PORT=8076
+    ports: [ "8076:8076" ]
     networks:
       - pr-tests
 

--- a/docker/gateway.dev.front.toml
+++ b/docker/gateway.dev.front.toml
@@ -25,7 +25,7 @@ require_auth = false
 [[targets]]
 tracing_name = "images"
 prefix = "/images"
-upstream = "http://osrd-images:8080"
+upstream = "http://osrd-images:8075"
 require_auth = false
 
 [auth]

--- a/docker/gateway.dev.host-front.toml
+++ b/docker/gateway.dev.host-front.toml
@@ -24,7 +24,7 @@ require_auth = false
 [[targets]]
 tracing_name = "images"
 prefix = "/images"
-upstream = "http://localhost:8080"
+upstream = "http://localhost:8075"
 require_auth = false
 
 [auth]

--- a/docker/gateway.dev.host.toml
+++ b/docker/gateway.dev.host.toml
@@ -23,7 +23,7 @@ require_auth = true
 [[targets]]
 tracing_name = "images"
 prefix = "/images"
-upstream = "http://localhost:8080"
+upstream = "http://localhost:8075"
 require_auth = false
 
 [auth]

--- a/docker/gateway.pr-tests.simple.toml
+++ b/docker/gateway.pr-tests.simple.toml
@@ -26,7 +26,7 @@ require_auth = true
 [[targets]]
 tracing_name = "images"
 prefix = "/images"
-upstream = "http://osrd-images:8080"
+upstream = "http://osrd-images:8076"
 require_auth = false
 
 


### PR DESCRIPTION
Port 8080 is used by default by a lot of tools. Keeping it in use for
osrd-images can thus be bothering. There is no particular reason not to
use any other less common unassigned port.

(Note: d9b164542550bdc3f2bc8c616240958a8dcf0ffe is included in this PR to help with the current build issue, it should get merged beforehand)