### PR TITLE
editoast: fga: remove incorrect mentions of marker traits in the doc

### DIFF
--- a/editoast/fga/src/lib.rs
+++ b/editoast/fga/src/lib.rs
@@ -65,7 +65,7 @@
 //!     }
 //! }
 //!
-//! // marker trait indicating that a Person can appear at the USER part of an OpenFGA tuple
+//! // trait indicating that a Person can appear at the USER part of an OpenFGA tuple
 //! impl fga::model::User for Person {}
 //!
 //! // needed to build back Persons from OpenFGA's responses (such as /list-users)
@@ -88,7 +88,7 @@
 //!     }
 //! }
 //!
-//! // marker trait indicating that a Document can appear at the OBJECT part of an OpenFGA tuple
+//! // trait indicating that a Document can appear at the OBJECT part of an OpenFGA tuple
 //! impl fga::model::Object for Document {}
 //!
 //! // needed to build back Documents from OpenFGA's responses (such as /list-objects)

--- a/editoast/fga/src/model.rs
+++ b/editoast/fga/src/model.rs
@@ -84,7 +84,7 @@ pub trait Type: FromStr + Sized {
 ///     }
 /// }
 ///
-/// // can be used as a marker trait, but has functions to override
+/// // can be used with the trait methods default implementations or have them overriden
 /// impl fga::model::User for Person {}
 /// ```
 ///
@@ -294,7 +294,7 @@ pub trait Relation: fmt::Debug + Sized {
 ///     }
 /// }
 ///
-/// // can be used as a marker trait, but has functions to override
+/// // can be used with the trait methods default implementations or have them overriden
 /// impl fga::model::Object for Document {}
 /// ```
 ///

--- a/editoast/fga_derive/src/lib.rs
+++ b/editoast/fga_derive/src/lib.rs
@@ -92,7 +92,7 @@ pub fn derive_type(input: TokenStream) -> TokenStream {
     }
 }
 
-/// Derive macro for the marker trait `fga::model::User`
+/// Derive macro for the trait `fga::model::User`
 #[proc_macro_derive(User)]
 pub fn derive_user(input: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(input as DeriveInput);
@@ -103,7 +103,7 @@ pub fn derive_user(input: TokenStream) -> TokenStream {
     .into()
 }
 
-/// Derive macro for the marker trait `fga::model::Object`
+/// Derive macro for the trait `fga::model::Object`
 #[proc_macro_derive(Object)]
 pub fn derive_object(input: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(input as DeriveInput);


### PR DESCRIPTION
In the documentation examples, some traits such as `User` and `Object` are incorrectly called marker traits even though they add behavior to the objects that implement them through default implementations. Update the documentation so that it stops calling these traits `marker traits`.