### PR TITLE
ui: update storybook URL to new home

### DIFF
--- a/front/ui/README.md
+++ b/front/ui/README.md
@@ -2,7 +2,7 @@
 
 Icons, fonts, colors, components and all user interface items for OSRD project.
 
-A [live storybook](https://openrailassociation.github.io/osrd-ui/) showcases all components.
+A [live storybook](https://ui.osrd.fr/) showcases all components.
 
 ## Building
 

--- a/front/ui/ui-charts/README.md
+++ b/front/ui/ui-charts/README.md
@@ -24,9 +24,9 @@ state management, including paths, offsets, scales, and zoom levels, must be han
 component.
 
 You can have a look at its stories
-[here](https://openrailassociation.github.io/osrd-ui/?path=/story/spacetimechart-rendering--default-args)
+[here](https://ui.osrd.fr/?path=/story/spacetimechart-rendering--default-args)
 or
-[here](https://openrailassociation.github.io/osrd-ui/?path=/story/manchette-with-spacetimechart-rendering--waypoint-menu)
+[here](https://ui.osrd.fr/?path=/story/manchette-with-spacetimechart-rendering--waypoint-menu)
 with its manchette.
 
 ## Speed Space Chart
@@ -36,7 +36,7 @@ a path. It also allow to visualize some data along the path, such as the electri
 max speed profile, the power restrictions, etc.
 
 You can have a look at its stories
-[here](https://openrailassociation.github.io/osrd-ui/?path=/story/trackoccupancydiagram-rendering--track-occupancy-diagram-story-default).
+[here](https://ui.osrd.fr/?path=/story/trackoccupancydiagram-rendering--track-occupancy-diagram-story-default).
 
 ## Track Occupancy Diagram
 
@@ -44,7 +44,7 @@ The `TrackOccupancyDiagram` is a React component designed to visualize the track
 station.
 
 You can have a look at its story
-[here](https://openrailassociation.github.io/osrd-ui/?path=/story/trackoccupancydiagram-rendering--track-occupancy-diagram-story-default).
+[here](https://ui.osrd.fr/?path=/story/trackoccupancydiagram-rendering--track-occupancy-diagram-story-default).
 
 ## Resources
 

--- a/front/ui/ui-charts/src/speedSpaceChart/README.md
+++ b/front/ui/ui-charts/src/speedSpaceChart/README.md
@@ -118,7 +118,7 @@ const yourTranslations = {
 ## Visualization
 
 The `ui-speedspacechart` component can be observed and manipulated on Storybook at this address:
-[storybook/speedspacechart](https://openrailassociation.github.io/osrd-ui/?path=/story/speedspacechart-rendering--speed-space-chart-default)
+[storybook/speedspacechart](https://ui.osrd.fr/?path=/story/speedspacechart-rendering--speed-space-chart-default)
 
 ## Contributing
 


### PR DESCRIPTION
We've moved osrd-ui's storybook to ui.osrd.fr. Update all references to the new URL.