### PR TITLE
editoast, gateway, osrdyne: move cargo home

### DIFF
--- a/editoast/Dockerfile
+++ b/editoast/Dockerfile
@@ -3,6 +3,8 @@
 ##############
 FROM lukemathwalker/cargo-chef:0.1.71-rust-1.88-alpine3.22 AS chef
 WORKDIR /editoast
+ENV CARGO_HOME=/cargo_editoast
+ENV PATH="/cargo_editoast/bin:$PATH"
 
 #######################
 # Cargo chef : Recipe #
@@ -68,11 +70,11 @@ COPY --from=planner /editoast/recipe.json recipe.json
 COPY --from=planner /editoast/editoast_derive/ editoast_derive
 ARG CARGO_PROFILE=release
 ARG CARGO_FEATURES
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
+RUN --mount=type=cache,target=/cargo_editoast/registry \
     --mount=type=cache,target=/editoast/target \
     cargo chef cook --profile="${CARGO_PROFILE}" --recipe-path recipe.json
 COPY . .
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
+RUN --mount=type=cache,target=/cargo_editoast/registry \
     --mount=type=cache,target=/editoast/target \
     cargo install --profile="${CARGO_PROFILE}" --locked --path .
 
@@ -82,9 +84,9 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 FROM alpine:3.22 AS running_env
 RUN apk add --no-cache jemalloc curl ca-certificates geos libpq openssl postgresql16-client
 
-COPY --from=run_builder /usr/local/cargo/bin/editoast /usr/local/bin/editoast
+COPY --from=run_builder /cargo_editoast/bin/editoast /usr/local/bin/editoast
 COPY --from=run_builder /editoast/migrations /migrations
-COPY --from=base_builder /usr/local/cargo/bin/diesel /usr/local/bin/diesel
+COPY --from=base_builder /cargo_editoast/bin/diesel /usr/local/bin/diesel
 COPY --from=base_builder /usr/local/bin/fga /usr/local/bin/fga
 COPY --from=editoast_assets /assets /assets
 

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -5,6 +5,8 @@
 ##############
 FROM lukemathwalker/cargo-chef:0.1.71-rust-1.88-alpine3.22 AS chef
 WORKDIR /gateway
+ENV CARGO_HOME=/cargo_gateway
+ENV PATH="/cargo_editoast/bin:$PATH"
 
 #######################
 # Cargo chef : Recipe #
@@ -21,11 +23,11 @@ RUN apk add --no-cache musl-dev build-base jemalloc-dev openssl-dev mold
 ENV RUSTFLAGS="-C link-arg=-fuse-ld=mold"
 COPY --from=planner /gateway/recipe.json recipe.json
 ARG CARGO_PROFILE=release
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
+RUN --mount=type=cache,target=/cargo_gateway/registry \
     --mount=type=cache,target=/gateway/target \
     cargo chef cook --profile ${CARGO_PROFILE} --recipe-path recipe.json
 COPY . .
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
+RUN --mount=type=cache,target=/cargo_gateway/registry \
     --mount=type=cache,target=/gateway/target \
     cargo install --profile ${CARGO_PROFILE} --locked --path .
 
@@ -48,7 +50,7 @@ COPY . .
 #######################
 FROM alpine:3.22 AS running_env
 RUN apk add --no-cache curl ca-certificates bind-tools jq
-COPY --from=run_builder /usr/local/cargo/bin/osrd_gateway /usr/local/bin/osrd_gateway
+COPY --from=run_builder /cargo_gateway/bin/osrd_gateway /usr/local/bin/osrd_gateway
 
 ARG OSRD_GIT_DESCRIBE
 ENV OSRD_GIT_DESCRIBE=${OSRD_GIT_DESCRIBE}

--- a/osrdyne/Dockerfile
+++ b/osrdyne/Dockerfile
@@ -5,6 +5,8 @@
 ##############
 FROM lukemathwalker/cargo-chef:0.1.71-rust-1.88-alpine3.22 AS chef
 WORKDIR /osrdyne
+ENV CARGO_HOME=/cargo_osrdyne
+ENV PATH="/cargo_editoast/bin:$PATH"
 
 #######################
 # Cargo chef : Recipe #
@@ -21,11 +23,11 @@ RUN apk add --no-cache musl-dev build-base jemalloc-dev mold
 ENV RUSTFLAGS="-C link-arg=-fuse-ld=mold"
 COPY --from=planner /osrdyne/recipe.json recipe.json
 ARG CARGO_PROFILE=release
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
+RUN --mount=type=cache,target=/cargo_osrdyne/registry \
     --mount=type=cache,target=/osrdyne/target \
     cargo chef cook --profile ${CARGO_PROFILE} --recipe-path recipe.json
 COPY . .
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
+RUN --mount=type=cache,target=/cargo_osrdyne/registry \
     --mount=type=cache,target=/osrdyne/target \
     cargo install --profile ${CARGO_PROFILE} --locked --path .
 
@@ -48,7 +50,7 @@ COPY . .
 #######################
 FROM alpine:3.22 AS running_env
 RUN apk add --no-cache curl ca-certificates bind-tools
-COPY --from=run_builder /usr/local/cargo/bin/osrdyne /usr/local/bin/osrdyne
+COPY --from=run_builder /cargo_osrdyne/bin/osrdyne /usr/local/bin/osrdyne
 
 ARG OSRD_GIT_DESCRIBE
 ENV OSRD_GIT_DESCRIBE=${OSRD_GIT_DESCRIBE}


### PR DESCRIPTION
Seems like cargo doesn't play nice with buildx cachemounts when shared by containers built in parallel. Moving CARGO_HOME to have a distinct path for each container will separate the caches.