### PR TITLE
editoast: fix `mismatched_lifetime_syntaxes` warning on nightly

### DIFF
--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -381,7 +381,7 @@ impl TestApp {
         )
     }
 
-    pub fn group(&self, name: impl ToString) -> GroupBuilder {
+    pub fn group(&self, name: impl ToString) -> GroupBuilder<'_> {
         GroupBuilder::new(
             self,
             GroupInfo {


### PR DESCRIPTION
Signed-off-by: Leo Valais <leo.valais97@gmail.com>
