### PR TITLE
editoast: new openapi schema collection system

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -920,6 +920,7 @@ dependencies = [
  "core_client",
  "deadpool",
  "editoast_common",
+ "editoast_derive",
  "editoast_schemas",
  "educe",
  "futures-util",

--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -927,6 +927,7 @@ dependencies = [
  "http",
  "itertools",
  "lapin",
+ "linkme",
  "opentelemetry",
  "pretty_assertions",
  "reqwest",
@@ -1346,6 +1347,7 @@ dependencies = [
  "itertools",
  "json-patch",
  "lapin",
+ "linkme",
  "lz4_flex",
  "mime",
  "mvt",
@@ -1399,6 +1401,7 @@ dependencies = [
  "fga",
  "futures 0.3.31",
  "itertools",
+ "linkme",
  "pretty_assertions",
  "serde",
  "stdext",
@@ -1413,6 +1416,7 @@ dependencies = [
 name = "editoast_common"
 version = "0.1.0"
 dependencies = [
+ "linkme",
  "opentelemetry",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
@@ -1496,6 +1500,7 @@ dependencies = [
  "enum-map",
  "geojson",
  "iso8601",
+ "linkme",
  "rand 0.9.2",
  "regex",
  "rstest",
@@ -2720,6 +2725,26 @@ name = "libm"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+
+[[package]]
+name = "linkme"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1b1703c00b2a6a70738920544aa51652532cacddfec2e162d2e29eae01e665c"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04d55ca5d5a14363da83bf3c33874b8feaa34653e760d5216d7ef9829c88001a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
 
 [[package]]
 name = "linux-raw-sys"

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -76,6 +76,7 @@ geos = { version = "8.3.1", features = ["json"] }
 hostname = "0.4.0"
 itertools = "0.14.0"
 lapin = "2.5.3"
+linkme = "0.3.33"
 mvt = "0.10.3"
 openssl = "0.10.73"
 opentelemetry = { version = "0.30.0", default-features = false, features = [
@@ -183,6 +184,7 @@ json-patch = { version = "4.0.0", default-features = false, features = [
   "utoipa",
 ] }
 lapin.workspace = true
+linkme.workspace = true
 lz4_flex = { version = "0.11.5", default-features = false, features = [
   "frame",
 ] }

--- a/editoast/core_client/Cargo.toml
+++ b/editoast/core_client/Cargo.toml
@@ -12,6 +12,7 @@ approx.workspace = true
 chrono.workspace = true
 deadpool.workspace = true
 editoast_common = { workspace = true }
+editoast_derive.workspace = true
 editoast_schemas = { workspace = true, features = ["testing"] }
 educe.workspace = true
 futures-util.workspace = true

--- a/editoast/core_client/Cargo.toml
+++ b/editoast/core_client/Cargo.toml
@@ -19,6 +19,7 @@ hostname.workspace = true
 http = "1.3.1"
 itertools.workspace = true
 lapin.workspace = true
+linkme.workspace = true
 opentelemetry.workspace = true
 reqwest.workspace = true
 serde = { workspace = true, features = ["derive"] }

--- a/editoast/core_client/src/conflict_detection.rs
+++ b/editoast/core_client/src/conflict_detection.rs
@@ -12,11 +12,6 @@ use super::simulation::RoutingRequirement;
 use super::simulation::SpacingRequirement;
 use super::stdcm::WorkSchedule;
 
-editoast_common::schemas! {
-    ConflictDetectionResponse,
-    ConflictRequirement,
-}
-
 #[derive(Debug, Serialize)]
 pub struct ConflictDetectionRequest {
     pub infra: i64,
@@ -41,6 +36,7 @@ pub struct WorkSchedulesRequest {
     pub work_schedule_requirements: HashMap<String, WorkSchedule>,
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct ConflictDetectionResponse {
     /// List of conflicts detected
@@ -69,6 +65,7 @@ pub struct Conflict {
 ///
 /// The start and end time describe the conflicting time span (not the full
 /// requirement's time span).
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, ToSchema)]
 pub struct ConflictRequirement {
     pub zone: String,

--- a/editoast/core_client/src/etcs_braking_curves.rs
+++ b/editoast/core_client/src/etcs_braking_curves.rs
@@ -12,12 +12,6 @@ use crate::simulation::SimulationPowerRestrictionItem;
 use crate::simulation::SimulationScheduleItem;
 use crate::simulation::SpeedLimitProperties;
 
-editoast_common::schemas! {
-    Response,
-    ETCSCurves,
-    ETCSConflictCurves,
-}
-
 #[derive(Debug, Serialize)]
 pub struct Request {
     pub infra: i64,
@@ -32,6 +26,7 @@ pub struct Request {
     pub mrsp: SpeedLimitProperties,
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug, ToSchema)]
 #[schema(as = ETCSBrakingCurvesResponse)]
 pub struct Response {
@@ -46,6 +41,7 @@ pub struct Response {
     pub conflicts: Vec<ETCSConflictCurves>,
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug, ToSchema)]
 pub struct ETCSCurves {
     #[schema(inline)]
@@ -56,6 +52,7 @@ pub struct ETCSCurves {
     pub guidance: SimpleEnvelope,
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug, ToSchema)]
 pub struct ETCSConflictCurves {
     #[schema(inline)]

--- a/editoast/core_client/src/lib.rs
+++ b/editoast/core_client/src/lib.rs
@@ -25,15 +25,6 @@ use tracing::trace;
 
 pub use mq_client::RabbitMQClient;
 
-editoast_common::schemas! {
-    simulation::schemas(),
-    pathfinding::schemas(),
-    conflict_detection::schemas(),
-    stdcm::schemas(),
-    signal_projection::schemas(),
-    etcs_braking_curves::schemas(),
-}
-
 #[derive(Debug, Clone)]
 pub enum CoreClient {
     MessageQueue(RabbitMQClient),

--- a/editoast/core_client/src/pathfinding.rs
+++ b/editoast/core_client/src/pathfinding.rs
@@ -11,17 +11,6 @@ use crate::AsCoreRequest;
 use crate::Json;
 use crate::RawError;
 
-editoast_common::schemas! {
-    IncompatibleConstraints,
-    IncompatibleOffsetRangeWithValue,
-    IncompatibleOffsetRange,
-    PathfindingResultSuccess,
-    OffsetRange,
-    TrackRange,
-    PathfindingInputError,
-    PathfindingNotFound,
-}
-
 #[derive(Debug, Serialize)]
 pub struct PathfindingRequest {
     /// Infrastructure id
@@ -45,23 +34,27 @@ pub struct PathfindingRequest {
     pub rolling_stock_length: f64,
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
 pub struct OffsetRange {
     start: u64,
     end: u64,
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
 pub struct IncompatibleOffsetRangeWithValue {
     range: OffsetRange,
     value: String,
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
 pub struct IncompatibleOffsetRange {
     range: OffsetRange,
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
 pub struct IncompatibleConstraints {
     incompatible_electrification_ranges: Vec<IncompatibleOffsetRangeWithValue>,
@@ -105,6 +98,7 @@ pub enum PathfindingCoreResult {
 }
 
 /// A successful pathfinding result. This is also used for STDCM response.
+#[editoast_derive::openapi_schema]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, ToSchema)]
 #[cfg_attr(feature = "mocking_client", derive(Default))]
 pub struct PathfindingResultSuccess {
@@ -124,6 +118,7 @@ pub struct PathfindingResultSuccess {
 }
 
 // Enum for input-related errors
+#[editoast_derive::openapi_schema]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, ToSchema)]
 #[serde(tag = "error_type", rename_all = "snake_case")]
 pub enum PathfindingInputError {
@@ -139,6 +134,7 @@ pub enum PathfindingInputError {
 }
 
 // Enum for not-found results and incompatible constraints
+#[editoast_derive::openapi_schema]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, ToSchema, Default)]
 #[serde(tag = "error_type", rename_all = "snake_case")]
 pub enum PathfindingNotFound {
@@ -160,6 +156,7 @@ pub enum PathfindingNotFound {
 
 /// An oriented range on a track section.
 /// `begin` is always less than `end`.
+#[editoast_derive::openapi_schema]
 #[derive(Serialize, Deserialize, Clone, Debug, ToSchema, Hash, PartialEq, Eq)]
 pub struct TrackRange {
     /// The track section identifier.

--- a/editoast/core_client/src/signal_projection.rs
+++ b/editoast/core_client/src/signal_projection.rs
@@ -10,10 +10,6 @@ use crate::simulation::ZoneUpdate;
 
 use super::pathfinding::TrackRange;
 
-editoast_common::schemas! {
-    SignalUpdate,
-}
-
 #[derive(Debug, Serialize)]
 pub struct SignalUpdatesRequest<'a> {
     /// Infrastructure id
@@ -30,6 +26,7 @@ pub struct SignalUpdatesRequest<'a> {
     pub train_simulations: Vec<TrainSimulation<'a>>,
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
 pub struct SignalUpdate {
     /// The id of the updated signal

--- a/editoast/core_client/src/simulation.rs
+++ b/editoast/core_client/src/simulation.rs
@@ -28,16 +28,6 @@ use super::pathfinding::TrackRange;
 use crate::AsCoreRequest;
 use crate::Json;
 
-editoast_common::schemas! {
-    CompleteReportTrain,
-    RoutingRequirement,
-    SignalCriticalPosition,
-    SpacingRequirement,
-    RoutingZoneRequirement,
-    ZoneUpdate,
-    ReportTrain,
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize, Educe, ToSchema)]
 #[educe(Hash)]
 pub struct PhysicsConsist {
@@ -97,6 +87,7 @@ pub struct PhysicsConsist {
     pub raise_pantograph_time: Option<Time>,
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, Hash, PartialEq, Serialize, Deserialize, ToSchema)]
 pub struct ZoneUpdate {
     pub zone: String,
@@ -144,6 +135,7 @@ pub struct SimulationPath {
     pub path_item_positions: Vec<u64>,
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Deserialize, Default, PartialEq, Serialize, Clone, Debug, ToSchema)]
 pub struct ReportTrain {
     /// List of positions of a train
@@ -159,6 +151,7 @@ pub struct ReportTrain {
     pub path_item_times: Vec<u64>,
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Deserialize, Default, PartialEq, Serialize, Clone, Debug, ToSchema)]
 pub struct CompleteReportTrain {
     #[serde(flatten)]
@@ -169,6 +162,7 @@ pub struct CompleteReportTrain {
     pub routing_requirements: Vec<RoutingRequirement>,
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, PartialEq, Hash, Serialize, Deserialize, ToSchema)]
 /// First position (space and time) along the path where given signal must
 /// be free (sighting time or closed-signal stop ending)
@@ -181,6 +175,7 @@ pub struct SignalCriticalPosition {
     pub state: String,
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
 pub struct SpacingRequirement {
     pub zone: String,
@@ -190,6 +185,7 @@ pub struct SpacingRequirement {
     pub end_time: u64,
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
 pub struct RoutingRequirement {
     pub route: String,
@@ -198,6 +194,7 @@ pub struct RoutingRequirement {
     pub zones: Vec<RoutingZoneRequirement>,
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
 pub struct RoutingZoneRequirement {
     pub zone: String,
@@ -247,6 +244,7 @@ pub struct SpeedLimitProperty {
 }
 
 /// A MRSP computation result (Most Restrictive Speed Profile)
+
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
 pub struct SpeedLimitProperties {
     /// List of `n` boundaries of the ranges (block path).

--- a/editoast/core_client/src/stdcm.rs
+++ b/editoast/core_client/src/stdcm.rs
@@ -19,10 +19,7 @@ use super::simulation::SimulationSuccess;
 use crate::AsCoreRequest;
 use crate::Json;
 
-editoast_common::schemas! {
-    Request,
-}
-
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[schema(as = StdcmRequest)]
 pub struct Request {
@@ -103,6 +100,7 @@ pub struct WorkSchedule {
 }
 
 /// Lighter description of a work schedule with only the relevant information for core
+
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct TemporarySpeedLimit {
     /// Speed limitation in m/s

--- a/editoast/editoast_authz/Cargo.toml
+++ b/editoast/editoast_authz/Cargo.toml
@@ -9,6 +9,7 @@ derive_more.workspace = true
 fga.workspace = true
 futures.workspace = true
 itertools.workspace = true
+linkme.workspace = true
 serde = { workspace = true, features = ["derive"] }
 strum.workspace = true
 thiserror.workspace = true

--- a/editoast/editoast_common/Cargo.toml
+++ b/editoast/editoast_common/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+linkme.workspace = true
 opentelemetry.workspace = true
 opentelemetry-semantic-conventions.workspace = true
 opentelemetry_sdk.workspace = true

--- a/editoast/editoast_common/src/geometry.rs
+++ b/editoast/editoast_common/src/geometry.rs
@@ -2,21 +2,44 @@ use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
 
-crate::schemas! {
-    GeoJson,
-    GeoJsonPoint,
-    GeoJsonMultiPoint,
-    GeoJsonLineString,
-    GeoJsonMultiLineString,
-    GeoJsonPolygon,
-    GeoJsonMultiPolygon,
-    GeoJsonPointValue,
-    GeoJsonMultiPointValue,
-    GeoJsonLineStringValue,
-    GeoJsonMultiLineStringValue,
-    GeoJsonPolygonValue,
-    GeoJsonMultiPolygonValue,
-}
+#[linkme::distributed_slice(crate::OPENAPI_SCHEMAS)]
+static _GEOJSON_SLICE_ITEM: crate::OpenApiSchemaSliceItem = <GeoJson as utoipa::ToSchema>::schema;
+#[linkme::distributed_slice(crate::OPENAPI_SCHEMAS)]
+static _GEOJSONPOINT_SLICE_ITEM: crate::OpenApiSchemaSliceItem =
+    <GeoJsonPoint as utoipa::ToSchema>::schema;
+#[linkme::distributed_slice(crate::OPENAPI_SCHEMAS)]
+static _GEOJSONMULTIPOINT_SLICE_ITEM: crate::OpenApiSchemaSliceItem =
+    <GeoJsonMultiPoint as utoipa::ToSchema>::schema;
+#[linkme::distributed_slice(crate::OPENAPI_SCHEMAS)]
+static _GEOJSONLINESTRING_SLICE_ITEM: crate::OpenApiSchemaSliceItem =
+    <GeoJsonLineString as utoipa::ToSchema>::schema;
+#[linkme::distributed_slice(crate::OPENAPI_SCHEMAS)]
+static _GEOJSONMULTILINESTRING_SLICE_ITEM: crate::OpenApiSchemaSliceItem =
+    <GeoJsonMultiLineString as utoipa::ToSchema>::schema;
+#[linkme::distributed_slice(crate::OPENAPI_SCHEMAS)]
+static _GEOJSONPOLYGON_SLICE_ITEM: crate::OpenApiSchemaSliceItem =
+    <GeoJsonPolygon as utoipa::ToSchema>::schema;
+#[linkme::distributed_slice(crate::OPENAPI_SCHEMAS)]
+static _GEOJSONMULTIPOLYGON_SLICE_ITEM: crate::OpenApiSchemaSliceItem =
+    <GeoJsonMultiPolygon as utoipa::ToSchema>::schema;
+#[linkme::distributed_slice(crate::OPENAPI_SCHEMAS)]
+static _GEOJSONPOINTVALUE_SLICE_ITEM: crate::OpenApiSchemaSliceItem =
+    <GeoJsonPointValue as utoipa::ToSchema>::schema;
+#[linkme::distributed_slice(crate::OPENAPI_SCHEMAS)]
+static _GEOJSONMULTIPOINTVALUE_SLICE_ITEM: crate::OpenApiSchemaSliceItem =
+    <GeoJsonMultiPointValue as utoipa::ToSchema>::schema;
+#[linkme::distributed_slice(crate::OPENAPI_SCHEMAS)]
+static _GEOJSONLINESTRINGVALUE_SLICE_ITEM: crate::OpenApiSchemaSliceItem =
+    <GeoJsonLineStringValue as utoipa::ToSchema>::schema;
+#[linkme::distributed_slice(crate::OPENAPI_SCHEMAS)]
+static _GEOJSONMULTILINESTRINGVALUE_SLICE_ITEM: crate::OpenApiSchemaSliceItem =
+    <GeoJsonMultiLineStringValue as utoipa::ToSchema>::schema;
+#[linkme::distributed_slice(crate::OPENAPI_SCHEMAS)]
+static _GEOJSONPOLYGONVALUE_SLICE_ITEM: crate::OpenApiSchemaSliceItem =
+    <GeoJsonPolygonValue as utoipa::ToSchema>::schema;
+#[linkme::distributed_slice(crate::OPENAPI_SCHEMAS)]
+static _GEOJSONMULTIPOLYGONVALUE_SLICE_ITEM: crate::OpenApiSchemaSliceItem =
+    <GeoJsonMultiPolygonValue as utoipa::ToSchema>::schema;
 
 // Schema of a GeoJson value meant to be used **exclusively** in the OpenApi
 /// A GeoJSON geometry item

--- a/editoast/editoast_common/src/geometry.rs
+++ b/editoast/editoast_common/src/geometry.rs
@@ -45,7 +45,6 @@ static _GEOJSONMULTIPOLYGONVALUE_SLICE_ITEM: crate::OpenApiSchemaSliceItem =
 /// A GeoJSON geometry item
 #[derive(Serialize, ToSchema)]
 #[serde(untagged)]
-#[allow(unused)]
 pub enum GeoJson {
     Point(GeoJsonPoint),
     MultiPoint(GeoJsonMultiPoint),
@@ -57,66 +56,54 @@ pub enum GeoJson {
 
 #[derive(Serialize, Deserialize, ToSchema, Debug, Clone, PartialEq)]
 #[serde(tag = "type", content = "coordinates")]
-#[allow(unused)]
 pub enum GeoJsonPoint {
     Point(GeoJsonPointValue),
 }
 
 #[derive(Serialize, ToSchema)]
 #[serde(tag = "type", content = "coordinates")]
-#[allow(unused)]
 pub enum GeoJsonMultiPoint {
     MultiPoint(GeoJsonMultiPointValue),
 }
 
 #[derive(Serialize, Deserialize, PartialEq, ToSchema, Debug, Clone)]
 #[serde(tag = "type", content = "coordinates")]
-#[allow(unused)]
 pub enum GeoJsonLineString {
     LineString(GeoJsonLineStringValue),
 }
 
 #[derive(Serialize, ToSchema)]
 #[serde(tag = "type", content = "coordinates")]
-#[allow(unused)]
 pub enum GeoJsonMultiLineString {
     MultiLineString(GeoJsonMultiLineStringValue),
 }
 
 #[derive(Serialize, ToSchema)]
 #[serde(tag = "type", content = "coordinates")]
-#[allow(unused)]
 pub enum GeoJsonPolygon {
     Polygon(GeoJsonPolygonValue),
 }
 
 #[derive(Serialize, ToSchema)]
 #[serde(tag = "type", content = "coordinates")]
-#[allow(unused)]
 pub enum GeoJsonMultiPolygon {
     MultiPolygon(GeoJsonMultiPolygonValue),
 }
 
 #[derive(Serialize, Deserialize, ToSchema, Debug, Clone, PartialEq)]
-#[allow(unused)]
 pub struct GeoJsonPointValue(#[schema(min_items = 2, max_items = 2)] pub Vec<f64>);
 
 #[derive(Serialize, ToSchema)]
-#[allow(unused)]
 pub struct GeoJsonMultiPointValue(#[schema(min_items = 1)] Vec<GeoJsonPointValue>);
 
 #[derive(Serialize, Deserialize, ToSchema, Debug, Clone, PartialEq)]
-#[allow(unused)]
 pub struct GeoJsonLineStringValue(#[schema(min_items = 2)] pub Vec<GeoJsonPointValue>);
 
 #[derive(Serialize, ToSchema)]
-#[allow(unused)]
 pub struct GeoJsonMultiLineStringValue(#[schema(min_items = 1)] Vec<GeoJsonLineStringValue>);
 
 #[derive(Serialize, ToSchema)]
-#[allow(unused)]
 pub struct GeoJsonPolygonValue(#[schema(min_items = 1)] Vec<GeoJsonLineStringValue>);
 
 #[derive(Serialize, ToSchema)]
-#[allow(unused)]
 pub struct GeoJsonMultiPolygonValue(#[schema(min_items = 1)] Vec<GeoJsonPolygonValue>);

--- a/editoast/editoast_common/src/lib.rs
+++ b/editoast/editoast_common/src/lib.rs
@@ -12,10 +12,13 @@ use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
 
-schemas! {
-    geometry::schemas(),
-    Version,
-}
+pub type OpenApiSchemaSliceItem = fn() -> (
+    &'static str,
+    utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
+);
+
+#[linkme::distributed_slice]
+pub static OPENAPI_SCHEMAS: [OpenApiSchemaSliceItem];
 
 pub fn setup_tracing_for_test() {
     tracing_subscriber::fmt()
@@ -25,6 +28,9 @@ pub fn setup_tracing_for_test() {
         .try_init()
         .ok();
 }
+
+#[linkme::distributed_slice(OPENAPI_SCHEMAS)]
+static _SCHEMA: OpenApiSchemaSliceItem = <Version as utoipa::ToSchema>::schema;
 
 #[derive(ToSchema, Serialize, Deserialize)]
 pub struct Version {

--- a/editoast/editoast_derive/src/lib.rs
+++ b/editoast/editoast_derive/src/lib.rs
@@ -3,6 +3,7 @@ extern crate proc_macro;
 mod annotate_units;
 mod error;
 mod model;
+mod openapi_schema;
 mod search;
 
 use proc_macro::TokenStream;
@@ -241,8 +242,6 @@ pub fn model(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         .into()
 }
 
-#[cfg(test)]
-use test_utils::assert_macro_expansion;
 /// Annotates fields of a structs with documentation and value_type for a better utoipa schema
 ///
 /// It must be used on structs that use #[derive(ToSchema)]
@@ -260,6 +259,17 @@ pub fn annotate_units(_attr: TokenStream, input: TokenStream) -> TokenStream {
         .unwrap_or_else(darling::Error::write_errors)
         .into()
 }
+
+#[proc_macro_attribute]
+pub fn openapi_schema(_attr: TokenStream, input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    openapi_schema::openapi_schema(&input)
+        .unwrap_or_else(darling::Error::write_errors)
+        .into()
+}
+
+#[cfg(test)]
+use test_utils::assert_macro_expansion;
 
 #[cfg(test)]
 mod test_utils {

--- a/editoast/editoast_derive/src/openapi_schema.rs
+++ b/editoast/editoast_derive/src/openapi_schema.rs
@@ -1,0 +1,18 @@
+use proc_macro2::TokenStream;
+use syn::DeriveInput;
+use syn::Ident;
+
+pub(super) fn openapi_schema(input: &DeriveInput) -> darling::Result<TokenStream> {
+    let name = &input.ident;
+    let static_name = Ident::new(
+        &format!("{}_SLICE_ITEM", name.to_string().to_uppercase()),
+        name.span(),
+    );
+    Ok(quote::quote! {
+        #[doc(hidden)]
+        #[linkme::distributed_slice(editoast_common::OPENAPI_SCHEMAS)]
+        static #static_name: editoast_common::OpenApiSchemaSliceItem = <#name as utoipa::ToSchema>::schema;
+
+        #input
+    })
+}

--- a/editoast/editoast_schemas/Cargo.toml
+++ b/editoast/editoast_schemas/Cargo.toml
@@ -15,6 +15,7 @@ educe.workspace = true
 enum-map.workspace = true
 geojson.workspace = true
 iso8601 = "0.6.3"
+linkme.workspace = true
 rand.workspace = true
 regex.workspace = true
 rstest.workspace = true

--- a/editoast/editoast_schemas/src/infra.rs
+++ b/editoast/editoast_schemas/src/infra.rs
@@ -85,33 +85,3 @@ pub use track_section_extensions::TrackSectionExtensions;
 pub use track_section_sncf_extension::TrackSectionSncfExtension;
 pub use track_section_source_extension::TrackSectionSourceExtension;
 pub use waypoint::Waypoint;
-
-editoast_common::schemas! {
-    applicable_directions::schemas(),
-    applicable_directions_track_range::schemas(),
-    buffer_stop::schemas(),
-    detector::schemas(),
-    direction::schemas(),
-    directional_track_range::schemas(),
-    electrical_profiles::schemas(),
-    electrification::schemas(),
-    endpoint::schemas(),
-    infra_object::schemas(),
-    loading_gauge_limit::schemas(),
-    neutral_section::schemas(),
-    operational_point::schemas(),
-    railjson::schemas(),
-    route::schemas(),
-    side::schemas(),
-    sign::schemas(),
-    signal::schemas(),
-    speed_section::schemas(),
-    switch::schemas(),
-    switch_type::schemas(),
-    track_endpoint::schemas(),
-    track_location::schemas(),
-    track_offset::schemas(),
-    track_section::schemas(),
-    track_range::schemas(),
-    directional_track_range::schemas(),
-}

--- a/editoast/editoast_schemas/src/infra/applicable_directions.rs
+++ b/editoast/editoast_schemas/src/infra/applicable_directions.rs
@@ -2,10 +2,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
 
-editoast_common::schemas! {
-    ApplicableDirections,
-}
-
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Default, Copy, Clone, Deserialize, Serialize, PartialEq, Eq, ToSchema)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum ApplicableDirections {

--- a/editoast/editoast_schemas/src/infra/applicable_directions_track_range.rs
+++ b/editoast/editoast_schemas/src/infra/applicable_directions_track_range.rs
@@ -6,10 +6,7 @@ use utoipa::ToSchema;
 use super::ApplicableDirections;
 use crate::primitives::Identifier;
 
-editoast_common::schemas! {
-    ApplicableDirectionsTrackRange,
-}
-
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Educe, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
 #[serde(deny_unknown_fields)]
 #[educe(Default)]

--- a/editoast/editoast_schemas/src/infra/buffer_stop.rs
+++ b/editoast/editoast_schemas/src/infra/buffer_stop.rs
@@ -8,10 +8,7 @@ use crate::primitives::OSRDIdentified;
 use crate::primitives::OSRDTyped;
 use crate::primitives::ObjectType;
 
-editoast_common::schemas! {
-    BufferStop,
-}
-
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Educe, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
 #[serde(deny_unknown_fields)]
 #[educe(Default)]

--- a/editoast/editoast_schemas/src/infra/curve.rs
+++ b/editoast/editoast_schemas/src/infra/curve.rs
@@ -2,6 +2,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
 
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct Curve {

--- a/editoast/editoast_schemas/src/infra/detector.rs
+++ b/editoast/editoast_schemas/src/infra/detector.rs
@@ -8,10 +8,7 @@ use crate::primitives::OSRDIdentified;
 use crate::primitives::OSRDTyped;
 use crate::primitives::ObjectType;
 
-editoast_common::schemas! {
-    Detector,
-}
-
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Educe, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
 #[serde(deny_unknown_fields)]
 #[educe(Default)]

--- a/editoast/editoast_schemas/src/infra/direction.rs
+++ b/editoast/editoast_schemas/src/infra/direction.rs
@@ -3,10 +3,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
 
-editoast_common::schemas! {
-    Direction,
-}
-
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, Hash, ToSchema)]
 #[serde(deny_unknown_fields, rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum Direction {

--- a/editoast/editoast_schemas/src/infra/directional_track_range.rs
+++ b/editoast/editoast_schemas/src/infra/directional_track_range.rs
@@ -6,10 +6,7 @@ use utoipa::ToSchema;
 use super::Direction;
 use crate::primitives::Identifier;
 
-editoast_common::schemas! {
-    DirectionalTrackRange,
-}
-
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Educe, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
 #[serde(deny_unknown_fields)]
 #[educe(Default)]

--- a/editoast/editoast_schemas/src/infra/electrical_profiles.rs
+++ b/editoast/editoast_schemas/src/infra/electrical_profiles.rs
@@ -5,12 +5,7 @@ use utoipa::ToSchema;
 
 use super::TrackRange;
 
-editoast_common::schemas! {
-    ElectricalProfile,
-    ElectricalProfileSetData,
-    LevelValues,
-}
-
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone, ToSchema)]
 pub struct ElectricalProfile {
     #[schema(example = "A")]
@@ -20,9 +15,11 @@ pub struct ElectricalProfile {
     pub track_ranges: Vec<TrackRange>,
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone, ToSchema)]
 pub struct LevelValues(Vec<String>);
 
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone, ToSchema)]
 pub struct ElectricalProfileSetData {
     pub levels: Vec<ElectricalProfile>,

--- a/editoast/editoast_schemas/src/infra/electrification.rs
+++ b/editoast/editoast_schemas/src/infra/electrification.rs
@@ -9,10 +9,7 @@ use crate::primitives::OSRDIdentified;
 use crate::primitives::OSRDTyped;
 use crate::primitives::ObjectType;
 
-editoast_common::schemas! {
-    Electrification,
-}
-
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct Electrification {

--- a/editoast/editoast_schemas/src/infra/endpoint.rs
+++ b/editoast/editoast_schemas/src/infra/endpoint.rs
@@ -2,10 +2,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
 
-editoast_common::schemas! {
-    Endpoint,
-}
-
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, Hash, ToSchema)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum Endpoint {

--- a/editoast/editoast_schemas/src/infra/infra_object.rs
+++ b/editoast/editoast_schemas/src/infra/infra_object.rs
@@ -13,10 +13,7 @@ use crate::primitives::OSRDIdentified;
 use crate::primitives::OSRDObject;
 use crate::primitives::ObjectType;
 
-editoast_common::schemas! {
-    InfraObject,
-}
-
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, PartialEq, serde::Deserialize, serde::Serialize, utoipa::ToSchema)]
 #[serde(tag = "obj_type", deny_unknown_fields)]
 pub enum InfraObject {

--- a/editoast/editoast_schemas/src/infra/loading_gauge_limit.rs
+++ b/editoast/editoast_schemas/src/infra/loading_gauge_limit.rs
@@ -4,10 +4,7 @@ use utoipa::ToSchema;
 
 use crate::rolling_stock::LoadingGaugeType;
 
-editoast_common::schemas! {
-    LoadingGaugeLimit,
-}
-
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct LoadingGaugeLimit {

--- a/editoast/editoast_schemas/src/infra/neutral_section.rs
+++ b/editoast/editoast_schemas/src/infra/neutral_section.rs
@@ -9,15 +9,12 @@ use crate::primitives::OSRDIdentified;
 use crate::primitives::OSRDTyped;
 use crate::primitives::ObjectType;
 
-editoast_common::schemas! {
-    NeutralSection,
-}
-
 /// Neutral sections are portions of track where trains aren't allowed to pull power from electrifications. They have to rely on inertia to cross such sections.
 ///
 /// In practice, neutral sections are delimited by signs. In OSRD, neutral sections are directional to allow accounting for different sign placement depending on the direction.
 ///
 /// For more details see [the documentation](https://osrd.fr/en/docs/explanation/neutral_sections/).
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct NeutralSection {

--- a/editoast/editoast_schemas/src/infra/operational_point.rs
+++ b/editoast/editoast_schemas/src/infra/operational_point.rs
@@ -10,11 +10,7 @@ use crate::primitives::OSRDIdentified;
 use crate::primitives::OSRDTyped;
 use crate::primitives::ObjectType;
 
-editoast_common::schemas! {
-    OperationalPoint,
-    OperationalPointPart,
-}
-
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct OperationalPoint {
@@ -28,6 +24,7 @@ pub struct OperationalPoint {
     pub weight: Option<u8>,
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Educe, Clone, PartialEq, Deserialize, Serialize, ToSchema)]
 #[serde(deny_unknown_fields)]
 #[educe(Default)]
@@ -54,6 +51,7 @@ pub struct OperationalPointPartSncfExtension {
     pub kp: String,
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq, ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct OperationalPointExtensions {

--- a/editoast/editoast_schemas/src/infra/railjson.rs
+++ b/editoast/editoast_schemas/src/infra/railjson.rs
@@ -17,11 +17,8 @@ use super::TrackSection;
 
 pub const RAILJSON_VERSION: &str = "3.4.13";
 
-editoast_common::schemas! {
-    RailJson,
-}
-
 /// An infrastructure description in the RailJson format
+#[editoast_derive::openapi_schema]
 #[derive(Deserialize, Educe, Serialize, Clone, Debug, ToSchema)]
 #[educe(Default)]
 #[serde(deny_unknown_fields)]

--- a/editoast/editoast_schemas/src/infra/route.rs
+++ b/editoast/editoast_schemas/src/infra/route.rs
@@ -13,12 +13,7 @@ use crate::primitives::OSRDIdentified;
 use crate::primitives::OSRDTyped;
 use crate::primitives::ObjectType;
 
-editoast_common::schemas! {
-    Route,
-    RoutePath,
-    Waypoint,
-}
-
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Educe, Clone, Deserialize, Serialize, PartialEq, Eq, ToSchema)]
 #[serde(deny_unknown_fields)]
 #[educe(Default)]
@@ -47,6 +42,7 @@ impl OSRDIdentified for Route {
     }
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, Serialize, PartialEq, ToSchema)]
 pub struct RoutePath {
     pub track_ranges: Vec<DirectionalTrackRange>,

--- a/editoast/editoast_schemas/src/infra/side.rs
+++ b/editoast/editoast_schemas/src/infra/side.rs
@@ -2,10 +2,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
 
-editoast_common::schemas! {
-    Side,
-}
-
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq, ToSchema)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum Side {

--- a/editoast/editoast_schemas/src/infra/sign.rs
+++ b/editoast/editoast_schemas/src/infra/sign.rs
@@ -8,10 +8,7 @@ use utoipa::ToSchema;
 use super::Direction;
 use super::Side;
 
-editoast_common::schemas! {
-    Sign,
-}
-
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Educe, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
 #[educe(Default)]
 #[serde(deny_unknown_fields)]

--- a/editoast/editoast_schemas/src/infra/signal.rs
+++ b/editoast/editoast_schemas/src/infra/signal.rs
@@ -13,10 +13,7 @@ use crate::primitives::OSRDIdentified;
 use crate::primitives::OSRDTyped;
 use crate::primitives::ObjectType;
 
-editoast_common::schemas! {
-    Signal,
-}
-
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Educe, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
 #[serde(deny_unknown_fields)]
 #[educe(Default)]

--- a/editoast/editoast_schemas/src/infra/slope.rs
+++ b/editoast/editoast_schemas/src/infra/slope.rs
@@ -2,6 +2,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
 
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct Slope {

--- a/editoast/editoast_schemas/src/infra/speed_section.rs
+++ b/editoast/editoast_schemas/src/infra/speed_section.rs
@@ -13,13 +13,10 @@ use crate::primitives::OSRDIdentified;
 use crate::primitives::OSRDTyped;
 use crate::primitives::ObjectType;
 
-editoast_common::schemas! {
-    SpeedSection,
-}
-
 #[derive(Debug, Clone, Serialize, PartialEq, Copy, ToSchema)]
 pub struct Speed(pub f64);
 
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Educe, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
 #[educe(Default)]
 #[serde(deny_unknown_fields)]

--- a/editoast/editoast_schemas/src/infra/switch.rs
+++ b/editoast/editoast_schemas/src/infra/switch.rs
@@ -11,10 +11,7 @@ use crate::primitives::OSRDIdentified;
 use crate::primitives::OSRDTyped;
 use crate::primitives::ObjectType;
 
-editoast_common::schemas! {
-    Switch,
-}
-
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct Switch {

--- a/editoast/editoast_schemas/src/infra/switch_type.rs
+++ b/editoast/editoast_schemas/src/infra/switch_type.rs
@@ -15,11 +15,7 @@ type NodeType = &'static str;
 type NodePorts = &'static [&'static str];
 type NodeGroups = &'static [&'static [StaticMap]];
 
-editoast_common::schemas! {
-    SwitchType,
-    SwitchPortConnection,
-}
-
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq, ToSchema)]
 #[serde(deny_unknown_fields)]
 #[schema(example = json!(
@@ -52,6 +48,7 @@ impl OSRDIdentified for SwitchType {
     }
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq, Hash, ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct SwitchPortConnection {

--- a/editoast/editoast_schemas/src/infra/track_endpoint.rs
+++ b/editoast/editoast_schemas/src/infra/track_endpoint.rs
@@ -7,10 +7,7 @@ use super::Direction;
 use super::Endpoint;
 use crate::primitives::Identifier;
 
-editoast_common::schemas! {
-    TrackEndpoint,
-}
-
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Educe, Clone, Deserialize, Serialize, PartialEq, Eq, Hash, ToSchema)]
 #[educe(Default)]
 #[serde(deny_unknown_fields)]

--- a/editoast/editoast_schemas/src/infra/track_location.rs
+++ b/editoast/editoast_schemas/src/infra/track_location.rs
@@ -4,11 +4,8 @@ use utoipa::ToSchema;
 
 use crate::primitives::Identifier;
 
-editoast_common::schemas! {
-    TrackLocation,
-}
-
 /// A track location is a track section and an offset
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, ToSchema)]
 pub struct TrackLocation {
     /// The track section UUID

--- a/editoast/editoast_schemas/src/infra/track_offset.rs
+++ b/editoast/editoast_schemas/src/infra/track_offset.rs
@@ -4,10 +4,7 @@ use utoipa::ToSchema;
 
 use crate::primitives::Identifier;
 
-editoast_common::schemas! {
-    TrackOffset,
-}
-
+#[editoast_derive::openapi_schema]
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, ToSchema, Hash)]
 pub struct TrackOffset {
     /// Track section identifier

--- a/editoast/editoast_schemas/src/infra/track_range.rs
+++ b/editoast/editoast_schemas/src/infra/track_range.rs
@@ -4,10 +4,8 @@ use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
 
-editoast_common::schemas! {
-    TrackRange,
-}
-
+// FIXME: this TrackRange and core_client::TrackRange are used interchangeably in the openapi...
+// #[editoast_derive::openapi_schema]
 #[derive(Debug, Educe, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
 #[serde(deny_unknown_fields)]
 #[educe(Default)]

--- a/editoast/editoast_schemas/src/infra/track_section.rs
+++ b/editoast/editoast_schemas/src/infra/track_section.rs
@@ -15,12 +15,7 @@ use crate::primitives::OSRDIdentified;
 use crate::primitives::OSRDTyped;
 use crate::primitives::ObjectType;
 
-editoast_common::schemas! {
-    TrackSection,
-    Slope,
-    Curve,
-}
-
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Educe, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
 #[serde(deny_unknown_fields)]
 #[educe(Default)]

--- a/editoast/editoast_schemas/src/infra/waypoint.rs
+++ b/editoast/editoast_schemas/src/infra/waypoint.rs
@@ -7,10 +7,7 @@ use crate::primitives::OSRDObject;
 use crate::primitives::ObjectType;
 use utoipa::ToSchema;
 
-editoast_common::schemas! {
-    Waypoint,
-}
-
+#[editoast_derive::openapi_schema]
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, Hash, ToSchema)]
 #[serde(tag = "type", deny_unknown_fields)]
 pub enum Waypoint {

--- a/editoast/editoast_schemas/src/lib.rs
+++ b/editoast/editoast_schemas/src/lib.rs
@@ -11,11 +11,3 @@ pub mod fixtures;
 pub use rolling_stock::RollingStock;
 pub use rolling_stock::TowedRollingStock;
 pub use train_schedule::TrainSchedule;
-
-editoast_common::schemas! {
-    rolling_stock::schemas(),
-    train_schedule::schemas(),
-    primitives::schemas(),
-    infra::schemas(),
-    paced_train::schemas(),
-}

--- a/editoast/editoast_schemas/src/paced_train.rs
+++ b/editoast/editoast_schemas/src/paced_train.rs
@@ -24,22 +24,6 @@ use crate::train_schedule::ScheduleItem;
 use crate::train_schedule::TrainSchedule;
 use crate::train_schedule::TrainScheduleOptions;
 
-editoast_common::schemas! {
-    PacedTrain,
-    PacedTrainException,
-    TrainNameChangeGroup,
-    RollingStockChangeGroup,
-    RollingStockCategoryChangeGroup,
-    LabelsChangeGroup,
-    SpeedLimitTagChangeGroup,
-    StartTimeChangeGroup,
-    ConstraintDistributionChangeGroup,
-    InitialSpeedChangeGroup,
-    OptionsChangeGroup,
-    PathAndScheduleChangeGroup,
-    PositiveDuration,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 pub struct Paced {
     /// Duration of the paced train, an ISO 8601 format is expected
@@ -48,6 +32,7 @@ pub struct Paced {
     pub interval: PositiveDuration,
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, Serialize, PartialEq, ToSchema)]
 pub struct PacedTrain {
     #[serde(flatten)]
@@ -115,6 +100,7 @@ impl<'de> Deserialize<'de> for PacedTrain {
 /// - Created: A new occurrence manually added by the user, not originally present in the automatically generated occurrences based on the paced train.
 /// - Modified: An existing occurrence that has been changed
 #[skip_serializing_none]
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
 #[cfg_attr(feature = "testing", derive(Default))]
 pub struct PacedTrainException {
@@ -176,53 +162,63 @@ impl ToSchema<'_> for ExceptionType {
     }
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
 pub struct TrainNameChangeGroup {
     pub value: String,
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
 pub struct RollingStockChangeGroup {
     pub rolling_stock_name: String,
     pub comfort: Comfort,
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
 pub struct RollingStockCategoryChangeGroup {
     pub value: Option<TrainCategory>,
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
 pub struct LabelsChangeGroup {
     pub value: Vec<String>,
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
 pub struct SpeedLimitTagChangeGroup {
     #[schema(inline)]
     pub value: Option<NonBlankString>,
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
 pub struct StartTimeChangeGroup {
     pub value: DateTime<Utc>,
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
 pub struct ConstraintDistributionChangeGroup {
     pub value: Distribution,
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
 pub struct InitialSpeedChangeGroup {
     pub value: f64,
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
 pub struct OptionsChangeGroup {
     pub value: TrainScheduleOptions,
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
 pub struct PathAndScheduleChangeGroup {
     pub path: Vec<PathItem>,

--- a/editoast/editoast_schemas/src/primitives.rs
+++ b/editoast/editoast_schemas/src/primitives.rs
@@ -12,12 +12,6 @@ pub use non_blank_string::NonBlankString;
 pub use object_ref::ObjectRef;
 pub use object_type::ObjectType;
 
-editoast_common::schemas! {
-    object_type::schemas(),
-    bounding_box::schemas(),
-    object_ref::schemas(),
-}
-
 /// This trait should be implemented by all struct that represents an OSRD type.
 pub trait OSRDTyped {
     fn get_type() -> ObjectType;

--- a/editoast/editoast_schemas/src/primitives/bounding_box.rs
+++ b/editoast/editoast_schemas/src/primitives/bounding_box.rs
@@ -8,11 +8,8 @@ use utoipa::ToSchema;
 
 use crate::errors::GeometryError;
 
-editoast_common::schemas! {
-    BoundingBox,
-}
-
 /// A bounding box
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
 pub struct BoundingBox(pub (f64, f64), pub (f64, f64));
 

--- a/editoast/editoast_schemas/src/primitives/duration.rs
+++ b/editoast/editoast_schemas/src/primitives/duration.rs
@@ -62,6 +62,7 @@ pub enum PositiveDurationError {
 /// let err_s = r#"{"duration":"P1M"}"#; // 1 month
 /// assert!(serde_json::from_str::<MyStruct>(err_s).is_err());
 /// ```
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PositiveDuration(ChronoDuration);
 

--- a/editoast/editoast_schemas/src/primitives/object_ref.rs
+++ b/editoast/editoast_schemas/src/primitives/object_ref.rs
@@ -5,10 +5,7 @@ use utoipa::ToSchema;
 
 use super::ObjectType;
 
-editoast_common::schemas! {
-    ObjectRef,
-}
-
+#[editoast_derive::openapi_schema]
 #[derive(Deserialize, Educe, Serialize, Clone, Debug, PartialEq, Eq, Hash, ToSchema)]
 #[educe(Default)]
 #[serde(deny_unknown_fields)]

--- a/editoast/editoast_schemas/src/primitives/object_type.rs
+++ b/editoast/editoast_schemas/src/primitives/object_type.rs
@@ -5,10 +5,7 @@ use strum::Display;
 use strum::EnumIter;
 use utoipa::ToSchema;
 
-editoast_common::schemas! {
-    ObjectType,
-}
-
+#[editoast_derive::openapi_schema]
 #[derive(
     Debug,
     Clone,

--- a/editoast/editoast_schemas/src/rolling_stock.rs
+++ b/editoast/editoast_schemas/src/rolling_stock.rs
@@ -58,20 +58,6 @@ use serde::Deserialize;
 use serde::Serialize;
 use std::collections::HashMap;
 
-editoast_common::schemas! {
-    effort_curves::schemas(),
-    energy_source::schemas(),
-    etcs_brake_params::schemas(),
-    loading_gauge_type::schemas(),
-    rolling_stock_metadata::schemas(),
-    rolling_resistance::schemas(),
-    rolling_stock_livery::schemas(),
-    supported_signaling_systems::schemas(),
-    train_main_category::schemas(),
-    sub_category::schemas(),
-    train_category::schemas(),
-}
-
 pub const ROLLING_STOCK_RAILJSON_VERSION: &str = "3.3";
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]

--- a/editoast/editoast_schemas/src/rolling_stock/effort_curves.rs
+++ b/editoast/editoast_schemas/src/rolling_stock/effort_curves.rs
@@ -7,14 +7,7 @@ use utoipa::ToSchema;
 
 use crate::train_schedule::Comfort;
 
-editoast_common::schemas! {
-    ConditionalEffortCurve,
-    EffortCurve,
-    EffortCurves,
-    EffortCurveConditions,
-    ModeEffortCurves,
-}
-
+#[editoast_derive::openapi_schema]
 #[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize, ToSchema, Hash)]
 #[serde(deny_unknown_fields)]
 pub struct EffortCurves {
@@ -44,6 +37,7 @@ impl EffortCurves {
     }
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize, ToSchema, Hash)]
 #[serde(deny_unknown_fields)]
 pub struct ModeEffortCurves {
@@ -52,6 +46,7 @@ pub struct ModeEffortCurves {
     pub is_electric: bool,
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize, ToSchema, Hash)]
 #[serde(deny_unknown_fields)]
 pub struct ConditionalEffortCurve {
@@ -59,6 +54,7 @@ pub struct ConditionalEffortCurve {
     curve: EffortCurve,
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize, ToSchema, Hash)]
 #[serde(deny_unknown_fields)]
 pub struct EffortCurveConditions {
@@ -70,6 +66,7 @@ pub struct EffortCurveConditions {
     power_restriction_code: Option<String>,
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, ToSchema, Educe)]
 #[educe(Hash)]
 #[serde(deny_unknown_fields)]

--- a/editoast/editoast_schemas/src/rolling_stock/energy_source.rs
+++ b/editoast/editoast_schemas/src/rolling_stock/energy_source.rs
@@ -2,16 +2,10 @@ use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
 
-editoast_common::schemas! {
-    EnergySource,
-    EnergyStorage,
-    RefillLaw,
-    SpeedDependantPower,
-}
-
 // Energy sources schema
 
 /// energy source of a rolling stock
+#[editoast_derive::openapi_schema]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize, ToSchema)]
 #[serde(tag = "energy_source_type", deny_unknown_fields)]
 pub enum EnergySource {
@@ -40,6 +34,7 @@ pub enum EnergySource {
 }
 
 /// power-speed curve (in an energy source)
+#[editoast_derive::openapi_schema]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize, ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct SpeedDependantPower {
@@ -48,6 +43,7 @@ pub struct SpeedDependantPower {
 }
 
 /// energy storage of an energy source (of a rolling stock, can be a electrical battery or a hydrogen/fuel powerPack)
+#[editoast_derive::openapi_schema]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize, ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct EnergyStorage {
@@ -63,6 +59,7 @@ pub struct EnergyStorage {
 }
 
 /// physical law defining how the storage can be refilled
+#[editoast_derive::openapi_schema]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize, ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct RefillLaw {

--- a/editoast/editoast_schemas/src/rolling_stock/etcs_brake_params.rs
+++ b/editoast/editoast_schemas/src/rolling_stock/etcs_brake_params.rs
@@ -5,11 +5,7 @@ use serde::Serialize;
 use serde::Serializer;
 use utoipa::ToSchema;
 
-editoast_common::schemas! {
-    EtcsBrakeParams,
-    SpeedIntervalValueCurve,
-}
-
+#[editoast_derive::openapi_schema]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize, ToSchema, Educe)]
 #[educe(Hash)]
 #[serde(deny_unknown_fields)]
@@ -51,6 +47,7 @@ pub struct EtcsBrakeParams {
     pub t_be: f64,
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize, ToSchema, Educe)]
 #[educe(Hash)]
 #[serde(deny_unknown_fields, remote = "Self")]

--- a/editoast/editoast_schemas/src/rolling_stock/loading_gauge_type.rs
+++ b/editoast/editoast_schemas/src/rolling_stock/loading_gauge_type.rs
@@ -3,10 +3,7 @@ use serde::Serialize;
 use strum::FromRepr;
 use utoipa::ToSchema;
 
-editoast_common::schemas! {
-    LoadingGaugeType,
-}
-
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, ToSchema, Hash, FromRepr)]
 pub enum LoadingGaugeType {
     G1,

--- a/editoast/editoast_schemas/src/rolling_stock/rolling_resistance.rs
+++ b/editoast/editoast_schemas/src/rolling_stock/rolling_resistance.rs
@@ -10,12 +10,8 @@ use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
 
-editoast_common::schemas! {
-    RollingResistance,
-    RollingResistancePerWeight,
-}
-
 #[editoast_derive::annotate_units]
+#[editoast_derive::openapi_schema]
 #[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize, ToSchema, Educe)]
 #[educe(Hash)]
 #[serde(deny_unknown_fields)]
@@ -38,6 +34,7 @@ pub struct RollingResistance {
 }
 
 #[editoast_derive::annotate_units]
+#[editoast_derive::openapi_schema]
 #[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize, ToSchema, Educe)]
 #[educe(Hash)]
 #[serde(deny_unknown_fields)]

--- a/editoast/editoast_schemas/src/rolling_stock/rolling_stock_livery.rs
+++ b/editoast/editoast_schemas/src/rolling_stock/rolling_stock_livery.rs
@@ -2,11 +2,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
 
-editoast_common::schemas! {
-    RollingStockLivery,
-    RollingStockLiveryMetadata,
-}
-
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Deserialize, Serialize, ToSchema)]
 pub struct RollingStockLivery {
     pub id: i64,
@@ -15,6 +11,7 @@ pub struct RollingStockLivery {
     pub compound_image_id: Option<i64>,
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Deserialize, Serialize, ToSchema)]
 pub struct RollingStockLiveryMetadata {
     pub id: i64,

--- a/editoast/editoast_schemas/src/rolling_stock/rolling_stock_metadata.rs
+++ b/editoast/editoast_schemas/src/rolling_stock/rolling_stock_metadata.rs
@@ -2,10 +2,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
 
-editoast_common::schemas! {
-    RollingStockMetadata,
-}
-
+#[editoast_derive::openapi_schema]
 #[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize, ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct RollingStockMetadata {

--- a/editoast/editoast_schemas/src/rolling_stock/sub_category.rs
+++ b/editoast/editoast_schemas/src/rolling_stock/sub_category.rs
@@ -9,11 +9,7 @@ use utoipa::ToSchema;
 
 use crate::rolling_stock::TrainMainCategory;
 
-editoast_common::schemas! {
-    SubCategory,
-    SubCategoryColor,
-}
-
+#[editoast_derive::openapi_schema]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize, ToSchema)]
 pub struct SubCategory {
     pub name: String,
@@ -25,6 +21,7 @@ pub struct SubCategory {
 }
 
 /// Represents a color for a sub-category in hexadecimal format #RRGGBB.
+#[editoast_derive::openapi_schema]
 #[derive(Clone, Debug, PartialEq, Serialize, ToSchema)]
 pub struct SubCategoryColor(String);
 

--- a/editoast/editoast_schemas/src/rolling_stock/supported_signaling_systems.rs
+++ b/editoast/editoast_schemas/src/rolling_stock/supported_signaling_systems.rs
@@ -2,10 +2,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
 
-editoast_common::schemas! {
-    RollingStockSupportedSignalingSystems,
-}
-
+#[editoast_derive::openapi_schema]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize, ToSchema)]
 pub struct RollingStockSupportedSignalingSystems(pub Vec<String>);
 

--- a/editoast/editoast_schemas/src/rolling_stock/train_category.rs
+++ b/editoast/editoast_schemas/src/rolling_stock/train_category.rs
@@ -4,10 +4,7 @@ use utoipa::ToSchema;
 
 use crate::rolling_stock::TrainMainCategory;
 
-editoast_common::schemas! {
-    TrainCategory,
-}
-
+#[editoast_derive::openapi_schema]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, ToSchema)]
 #[serde(untagged)]
 pub enum TrainCategory {

--- a/editoast/editoast_schemas/src/rolling_stock/train_main_category.rs
+++ b/editoast/editoast_schemas/src/rolling_stock/train_main_category.rs
@@ -5,14 +5,10 @@ use strum::EnumString;
 use strum::IntoStaticStr;
 use utoipa::ToSchema;
 
-editoast_common::schemas! {
-    TrainMainCategory,
-    TrainMainCategories,
-}
-
 // This enum maps to a Postgres enum type, specifically `train_category`.
 // Any changes made to this enum must be reflected in the corresponding Postgres enum,
 // and vice versa, to ensure consistency between the application and the database.
+#[editoast_derive::openapi_schema]
 #[derive(
     Debug,
     Clone,
@@ -40,6 +36,7 @@ pub enum TrainMainCategory {
     WorkTrain,
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize, ToSchema)]
 pub struct TrainMainCategories(pub Vec<TrainMainCategory>);
 

--- a/editoast/editoast_schemas/src/train_schedule.rs
+++ b/editoast/editoast_schemas/src/train_schedule.rs
@@ -49,20 +49,7 @@ use utoipa::ToSchema;
 use crate::primitives::NonBlankString;
 use crate::rolling_stock::TrainCategory;
 
-editoast_common::schemas! {
-    margins::schemas(),
-    schedule_item::schemas(),
-    path_item::schemas(),
-    train_schedule_options::schemas(),
-    power_restriction_item::schemas(),
-    distribution::schemas(),
-    comfort::schemas(),
-    // TODO TrainSchedule V1 (it will be removed)
-    allowance::schemas(),
-    rjs_power_restriction_range::schemas(),
-    TrainSchedule,
-}
-
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
 #[serde(remote = "Self")]
 pub struct TrainSchedule {

--- a/editoast/editoast_schemas/src/train_schedule/allowance.rs
+++ b/editoast/editoast_schemas/src/train_schedule/allowance.rs
@@ -2,15 +2,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
 
-editoast_common::schemas! {
-    Allowance,
-    AllowanceValue,
-    AllowanceDistribution,
-    RangeAllowance,
-    EngineeringAllowance,
-    StandardAllowance,
-}
-
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
 #[serde(tag = "allowance_type", rename_all = "lowercase")]
 pub enum Allowance {
@@ -18,6 +10,7 @@ pub enum Allowance {
     Standard(StandardAllowance),
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
 
 pub struct EngineeringAllowance {
@@ -29,6 +22,7 @@ pub struct EngineeringAllowance {
     capacity_speed_limit: f64,
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
 pub struct StandardAllowance {
     default_value: AllowanceValue,
@@ -42,6 +36,7 @@ const fn default_capacity_speed_limit() -> f64 {
     -1.0
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
 #[serde(tag = "value_type")]
 pub enum AllowanceValue {
@@ -53,6 +48,7 @@ pub enum AllowanceValue {
     Percent { percentage: f64 },
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
 pub struct RangeAllowance {
     begin_position: f64,
@@ -60,6 +56,7 @@ pub struct RangeAllowance {
     value: AllowanceValue,
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum AllowanceDistribution {

--- a/editoast/editoast_schemas/src/train_schedule/comfort.rs
+++ b/editoast/editoast_schemas/src/train_schedule/comfort.rs
@@ -3,10 +3,7 @@ use serde::Serialize;
 use strum::FromRepr;
 use utoipa::ToSchema;
 
-editoast_common::schemas! {
-    Comfort,
-}
-
+#[editoast_derive::openapi_schema]
 #[derive(
     Debug, Default, PartialEq, Clone, Copy, Serialize, Deserialize, FromRepr, ToSchema, Hash,
 )]

--- a/editoast/editoast_schemas/src/train_schedule/distribution.rs
+++ b/editoast/editoast_schemas/src/train_schedule/distribution.rs
@@ -3,10 +3,7 @@ use serde::Serialize;
 use strum::FromRepr;
 use utoipa::ToSchema;
 
-editoast_common::schemas! {
-    Distribution,
-}
-
+#[editoast_derive::openapi_schema]
 #[derive(
     Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, FromRepr, ToSchema, Hash,
 )]

--- a/editoast/editoast_schemas/src/train_schedule/margins.rs
+++ b/editoast/editoast_schemas/src/train_schedule/margins.rs
@@ -6,10 +6,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
 
-editoast_common::schemas! {
-    Margins,
-}
-
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Educe, ToSchema)]
 #[serde(deny_unknown_fields)]
 #[educe(Default)]

--- a/editoast/editoast_schemas/src/train_schedule/path_item.rs
+++ b/editoast/editoast_schemas/src/train_schedule/path_item.rs
@@ -6,14 +6,8 @@ use utoipa::ToSchema;
 
 use crate::infra::TrackOffset;
 
-editoast_common::schemas! {
-    PathItem,
-    PathItemLocation,
-    OperationalPointReference,
-    TrackReference,
-}
-
 /// A location on the path of a train
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
 pub struct PathItem {
     /// The unique identifier of the path item.
@@ -46,6 +40,7 @@ impl PathItem {
 }
 
 /// The location of a path waypoint
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema, Hash)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum PathItemLocation {
@@ -53,6 +48,7 @@ pub enum PathItemLocation {
     OperationalPointReference(#[schema(inline)] OperationalPointReference),
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema, Hash)]
 pub struct OperationalPointReference {
     #[serde(flatten)]
@@ -62,6 +58,7 @@ pub struct OperationalPointReference {
     pub track_reference: Option<TrackReference>,
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema, Hash)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum TrackReference {

--- a/editoast/editoast_schemas/src/train_schedule/power_restriction_item.rs
+++ b/editoast/editoast_schemas/src/train_schedule/power_restriction_item.rs
@@ -3,10 +3,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
 
-editoast_common::schemas! {
-    PowerRestrictionItem,
-}
-
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct PowerRestrictionItem {

--- a/editoast/editoast_schemas/src/train_schedule/rjs_power_restriction_range.rs
+++ b/editoast/editoast_schemas/src/train_schedule/rjs_power_restriction_range.rs
@@ -2,11 +2,8 @@ use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
 
-editoast_common::schemas! {
-    RjsPowerRestrictionRange,
-}
-
 /// A range along the train path where a power restriction is applied.
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq)]
 #[schema(example = json!({
     "begin_position": 0.0,

--- a/editoast/editoast_schemas/src/train_schedule/schedule_item.rs
+++ b/editoast/editoast_schemas/src/train_schedule/schedule_item.rs
@@ -6,13 +6,9 @@ use utoipa::ToSchema;
 
 use crate::primitives::PositiveDuration;
 
-editoast_common::schemas! {
-    ScheduleItem,
-    ReceptionSignal,
-}
-
 /// State of the signal where the train is received for its stop.
 /// For (important) details, see <https://osrd.fr/en/docs/reference/design-docs/timetable/#modifiable-fields>.
+#[editoast_derive::openapi_schema]
 #[derive(Default, Debug, Hash, Copy, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum ReceptionSignal {
@@ -22,6 +18,7 @@ pub enum ReceptionSignal {
     ShortSlipStop,
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
 #[serde(deny_unknown_fields)]
 #[serde(remote = "Self")]

--- a/editoast/editoast_schemas/src/train_schedule/train_schedule_options.rs
+++ b/editoast/editoast_schemas/src/train_schedule/train_schedule_options.rs
@@ -3,10 +3,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
 
-editoast_common::schemas! {
-    TrainScheduleOptions,
-}
-
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Educe, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema, Hash)]
 #[serde(deny_unknown_fields)]
 #[educe(Default)]

--- a/editoast/src/views/documents.rs
+++ b/editoast/src/views/documents.rs
@@ -30,10 +30,6 @@ crate::routes! {
     },
 }
 
-editoast_common::schemas! {
-    NewDocumentResponse,
-}
-
 #[derive(Error, Debug, EditoastError)]
 #[editoast_error(base_id = "document")]
 pub enum DocumentErrors {
@@ -85,6 +81,7 @@ async fn get(
     ))
 }
 
+#[editoast_derive::openapi_schema]
 #[derive(Serialize, ToSchema)]
 struct NewDocumentResponse {
     document_key: i64,

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -123,7 +123,6 @@ crate::routes! {
 }
 
 editoast_common::schemas! {
-    editoast_schemas::schemas(),
     models::schemas(),
     generated_data::schemas(),
     authz::schemas(),

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -125,7 +125,6 @@ crate::routes! {
 editoast_common::schemas! {
     editoast_schemas::schemas(),
     models::schemas(),
-    core_client::schemas(),
     generated_data::schemas(),
     authz::schemas(),
     electrical_profiles::schemas(),

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -123,13 +123,11 @@ crate::routes! {
 }
 
 editoast_common::schemas! {
-    editoast_common::schemas(),
     editoast_schemas::schemas(),
     models::schemas(),
     core_client::schemas(),
     generated_data::schemas(),
     authz::schemas(),
-    documents::schemas(),
     electrical_profiles::schemas(),
     error::schemas(),
     infra::schemas(),

--- a/editoast/src/views/openapi.rs
+++ b/editoast/src/views/openapi.rs
@@ -476,12 +476,12 @@ impl OpenApiRoot {
         if openapi.components.is_none() {
             openapi.components = Some(Default::default());
         }
-        openapi
-            .components
-            .as_mut()
-            .unwrap()
-            .schemas
-            .extend(crate::views::schemas());
+        let schemas = &mut openapi.components.as_mut().unwrap().schemas;
+        schemas.extend(crate::views::schemas());
+        schemas.extend(editoast_common::OPENAPI_SCHEMAS.iter().map(|f| {
+            let (name, schema) = f();
+            (name.to_string(), schema)
+        }));
     }
 
     // Remove the operation_id that defaults to the endpoint function name


### PR DESCRIPTION
Leverages [`linkme`](https://crates.io/crates/linkme) to handle schema collection for us. The goal is to get rid of the `schemas!` macro. This PR does:

* add linkme dep
* setup the schema collection in editoast_common
* add an attribute macro for ergonomics
* adapt core_client and editoast_schemas

I'll do the rest later and then we'll be able to remove the schema! macro and the old schema collection system.

Downside: schema collection in editoast_common is ugly now (but we don't have much so...)
Upsides: so obvious I won't elaborate

Bug found: https://github.com/OpenRailAssociation/osrd/issues/12730