### PR TITLE
editoast: replace the `routes!` macro by a pure Rust builder

### DIFF
--- a/editoast/editoast_derive/src/lib.rs
+++ b/editoast/editoast_derive/src/lib.rs
@@ -4,6 +4,7 @@ mod annotate_units;
 mod error;
 mod model;
 mod openapi_schema;
+mod route;
 mod search;
 
 use proc_macro::TokenStream;
@@ -264,6 +265,14 @@ pub fn annotate_units(_attr: TokenStream, input: TokenStream) -> TokenStream {
 pub fn openapi_schema(_attr: TokenStream, input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     openapi_schema::openapi_schema(&input)
+        .unwrap_or_else(darling::Error::write_errors)
+        .into()
+}
+
+#[proc_macro_attribute]
+pub fn route(_attr: TokenStream, input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as syn::ItemFn);
+    route::route(&input)
         .unwrap_or_else(darling::Error::write_errors)
         .into()
 }

--- a/editoast/editoast_derive/src/route.rs
+++ b/editoast/editoast_derive/src/route.rs
@@ -1,0 +1,37 @@
+use std::hash::Hash as _;
+use std::hash::Hasher as _;
+
+use proc_macro2::TokenStream;
+use syn::Ident;
+use syn::ItemFn;
+
+pub(super) fn route(input: &ItemFn) -> darling::Result<TokenStream> {
+    let name = &input.sig.ident;
+    // some handlers have the same name (eg: get, create, list) which would result in duplicate
+    // static names
+    let hex_hash = {
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        quote::quote! { #input }.to_string().hash(&mut hasher);
+        let hash = hasher.finish();
+        format!("{hash:x}")
+    };
+    let static_name = Ident::new(
+        &format!(
+            "_{}_OPENAPI_ROUTE_{}",
+            name.to_string().to_uppercase(),
+            hex_hash.to_uppercase()
+        ),
+        name.span(),
+    );
+    let path_name = Ident::new(&format!("__path_{name}"), name.span());
+    Ok(quote::quote! {
+        #[doc(hidden)]
+        #[unsafe(no_mangle)]
+        #[linkme::distributed_slice(crate::views::router::OPENAPI_ROUTES)]
+        static #static_name: crate::views::router::OpenApiRouteSliceItem = |type_name: &str| {
+            (type_name == std::any::type_name_of_val(&#name)).then_some(<#path_name as utoipa::Path>::path_item)
+        };
+
+        #input
+    })
+}

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -35,18 +35,6 @@ use super::pagination::PaginatedList;
 use super::pagination::PaginationQueryParams;
 use super::pagination::PaginationStats;
 
-crate::routes! {
-    "/authz" => {
-        "/me" => {
-            whoami,
-            "/privileges" => user_privileges,
-            "/grants" => user_grants,
-        },
-        "/grants" => update_grants,
-        "/{resource_type}/{resource_id}" => subjects_with_grant_on_resource,
-    },
-}
-
 editoast_common::schemas! {
     InfraGrant,
     InfraPrivilege,
@@ -70,7 +58,7 @@ enum SubjectType {
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 #[cfg_attr(test, derive(Debug))]
-enum ResourceType {
+pub(in crate::views) enum ResourceType {
     Infra,
 }
 
@@ -106,12 +94,13 @@ impl From<AuthorizerError> for AuthzError {
 
 #[derive(Serialize, ToSchema)]
 #[cfg_attr(test, derive(Debug, Deserialize, PartialEq))]
-struct WhoamiResponse {
+pub(in crate::views) struct WhoamiResponse {
     id: i64,
     name: String,
     roles: Vec<Role>,
 }
 
+#[editoast_derive::route]
 #[utoipa::path(
     get,
     path = "",
@@ -122,7 +111,9 @@ struct WhoamiResponse {
         body = inline(WhoamiResponse),
     ))
 )]
-async fn whoami(Extension(auth): AuthenticationExt) -> Result<Json<WhoamiResponse>> {
+pub(in crate::views) async fn whoami(
+    Extension(auth): AuthenticationExt,
+) -> Result<Json<WhoamiResponse>> {
     Ok(Json(WhoamiResponse {
         // TODO: don't return -1 and a hardcoded name, return a different schema instead, requires frontend changes
         id: auth.user_id()?.unwrap_or(-1),
@@ -133,11 +124,12 @@ async fn whoami(Extension(auth): AuthenticationExt) -> Result<Json<WhoamiRespons
 
 #[derive(Debug, Serialize, ToSchema)]
 #[cfg_attr(test, derive(Deserialize, PartialEq, Eq))]
-struct ResourcePrivileges {
+pub(in crate::views) struct ResourcePrivileges {
     resource_id: i64,
     privileges: HashSet<InfraPrivilege>,
 }
 
+#[editoast_derive::route]
 #[utoipa::path(
     post,
     path = "",
@@ -152,7 +144,7 @@ struct ResourcePrivileges {
         body = inline(HashMap<ResourceType, Vec<ResourcePrivileges>>)
     )),
 )]
-async fn user_privileges(
+pub(in crate::views) async fn user_privileges(
     State(AppState { db_pool, .. }): State<AppState>,
     Extension(auth): AuthenticationExt,
     Json(body): Json<HashMap<ResourceType, Vec<i64>>>,
@@ -217,11 +209,12 @@ async fn user_privileges(
 
 #[derive(Serialize, ToSchema)]
 #[cfg_attr(test, derive(Debug, Deserialize, PartialEq))]
-struct UserResourceGrant {
+pub(in crate::views) struct UserResourceGrant {
     id: i64,
     grant: InfraGrant,
 }
 
+#[editoast_derive::route]
 #[utoipa::path(
     post,
     path = "",
@@ -236,7 +229,7 @@ struct UserResourceGrant {
         body = inline(HashMap<ResourceType, Vec<UserResourceGrant>>)
     )),
 )]
-async fn user_grants(
+pub(in crate::views) async fn user_grants(
     State(AppState { db_pool, .. }): State<AppState>,
     Extension(auth): AuthenticationExt,
     Json(body): Json<HashMap<ResourceType, Vec<i64>>>,
@@ -271,12 +264,12 @@ async fn user_grants(
 }
 
 #[derive(Deserialize, IntoParams)]
-struct ResourceTypeParam {
+pub(in crate::views) struct ResourceTypeParam {
     resource_type: ResourceType,
 }
 
 #[derive(Deserialize, IntoParams)]
-struct ResourceIdParam {
+pub(in crate::views) struct ResourceIdParam {
     resource_id: i64,
 }
 
@@ -291,12 +284,13 @@ struct SubjectGrant {
 
 #[derive(Serialize, ToSchema)]
 #[cfg_attr(test, derive(Debug, Deserialize))]
-struct SubjectsWithGrantOnResource {
+pub(in crate::views) struct SubjectsWithGrantOnResource {
     #[schema(inline)]
     subjects: Vec<SubjectGrant>,
     stats: PaginationStats,
 }
 
+#[editoast_derive::route]
 #[utoipa::path(
     get,
     path = "",
@@ -306,7 +300,7 @@ struct SubjectsWithGrantOnResource {
         (status = 200, description = "Get list of user that have a grant on the resource", body = inline(SubjectsWithGrantOnResource)),
     ),
 )]
-async fn subjects_with_grant_on_resource(
+pub(in crate::views) async fn subjects_with_grant_on_resource(
     Extension(authn): AuthenticationExt,
     State(AppState {
         db_pool, regulator, ..
@@ -444,7 +438,7 @@ async fn subjects_with_grant_on_resource(
 }
 
 #[derive(Deserialize, ToSchema)]
-struct GrantBody {
+pub(in crate::views) struct GrantBody {
     resource_type: ResourceType,
     resource_id: i64,
     subject_id: i64,
@@ -452,7 +446,7 @@ struct GrantBody {
 }
 
 #[derive(Deserialize, ToSchema)]
-struct RevokeBody {
+pub(in crate::views) struct RevokeBody {
     resource_type: ResourceType,
     resource_id: i64,
     subject_id: i64,
@@ -461,11 +455,12 @@ struct RevokeBody {
 /// `grant` XOR `revoke` is expected
 #[derive(Deserialize, ToSchema)]
 #[serde(rename_all = "lowercase")]
-enum BodyUpdateGrants {
+pub(in crate::views) enum BodyUpdateGrants {
     Grant(Vec<GrantBody>),
     Revoke(Vec<RevokeBody>),
 }
 
+#[editoast_derive::route]
 #[utoipa::path(
     post,
     path = "",
@@ -479,7 +474,7 @@ enum BodyUpdateGrants {
         (status = 204, description = "Successful revoking"),
     ),
 )]
-async fn update_grants(
+pub(in crate::views) async fn update_grants(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Json(body): Json<BodyUpdateGrants>,

--- a/editoast/src/views/documents.rs
+++ b/editoast/src/views/documents.rs
@@ -20,16 +20,6 @@ use database::DbConnectionPoolV2;
 use super::AuthenticationExt;
 use super::AuthorizationError;
 
-crate::routes! {
-    "/documents" => {
-        post,
-        "/{document_key}" => {
-            get,
-            delete,
-        },
-    },
-}
-
 #[derive(Error, Debug, EditoastError)]
 #[editoast_error(base_id = "document")]
 pub enum DocumentErrors {
@@ -42,6 +32,7 @@ pub enum DocumentErrors {
 }
 
 /// Returns a document of any type
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "documents",
@@ -53,7 +44,7 @@ pub enum DocumentErrors {
         (status = 404, description = "Document not found", body = InternalError),
     )
 )]
-async fn get(
+pub(in crate::views) async fn get(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(document_id): Path<i64>,
@@ -88,6 +79,7 @@ struct NewDocumentResponse {
 }
 
 /// Post a new document (content_type by header + binary data)
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "documents",
@@ -99,7 +91,7 @@ struct NewDocumentResponse {
         (status = 201, description = "The document was created", body = NewDocumentResponse),
     )
 )]
-async fn post(
+pub(in crate::views) async fn post(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     axum_extra::TypedHeader(content_type): axum_extra::TypedHeader<headers::ContentType>,
@@ -132,6 +124,7 @@ async fn post(
 }
 
 /// Delete an existing document
+#[editoast_derive::route]
 #[utoipa::path(
     delete, path = "",
     tag = "documents",
@@ -143,7 +136,7 @@ async fn post(
         (status = 404, description = "Document not found", body = InternalError),
     )
 )]
-async fn delete(
+pub(in crate::views) async fn delete(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(document_id): Path<i64>,

--- a/editoast/src/views/electrical_profiles.rs
+++ b/editoast/src/views/electrical_profiles.rs
@@ -26,18 +26,6 @@ use crate::models::Retrieve;
 use crate::models::electrical_profiles::ElectricalProfileSet;
 use crate::models::electrical_profiles::LightElectricalProfileSet;
 
-crate::routes! {
-    "/electrical_profile_set" => {
-        post_electrical_profile,
-        list,
-        "/{electrical_profile_set_id}" => {
-            get,
-            delete,
-            "/level_order" => get_level_order,
-        },
-    },
-}
-
 editoast_common::schemas! {
     LightElectricalProfileSet,
     ElectricalProfileSet,
@@ -50,6 +38,7 @@ pub struct ElectricalProfileSetId {
 }
 
 /// Retrieve the list of ids and names of electrical profile sets available
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "electrical_profiles",
@@ -57,7 +46,7 @@ pub struct ElectricalProfileSetId {
         (status = 200, body = Vec<LightElectricalProfileSet>, description = "The list of ids and names of electrical profile sets available"),
     )
 )]
-async fn list(
+pub(in crate::views) async fn list(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
 ) -> Result<Json<Vec<LightElectricalProfileSet>>> {
@@ -73,6 +62,7 @@ async fn list(
 }
 
 /// Return a specific set of electrical profiles
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "electrical_profiles",
@@ -82,7 +72,7 @@ async fn list(
         (status = 404, body = InternalError, description = "The requested electrical profile set was not found"),
     )
 )]
-async fn get(
+pub(in crate::views) async fn get(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(electrical_profile_set_id): Path<i64>,
@@ -106,6 +96,7 @@ async fn get(
 }
 
 /// Return the electrical profile value order for this set
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "electrical_profiles",
@@ -122,7 +113,7 @@ async fn get(
         (status = 404, body = InternalError, description = "The requested electrical profile set was not found"),
     )
 )]
-async fn get_level_order(
+pub(in crate::views) async fn get_level_order(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(electrical_profile_set_id): Path<i64>,
@@ -146,6 +137,7 @@ async fn get_level_order(
 }
 
 /// Delete an electrical profile set
+#[editoast_derive::route]
 #[utoipa::path(
     delete, path = "",
     tag = "electrical_profiles",
@@ -155,7 +147,7 @@ async fn get_level_order(
         (status = 404, body = InternalError, description = "The requested electrical profile was not found"),
     )
 )]
-async fn delete(
+pub(in crate::views) async fn delete(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(electrical_profile_set_id): Path<i64>,
@@ -178,11 +170,12 @@ async fn delete(
 
 #[derive(Deserialize, IntoParams)]
 #[into_params(parameter_in = Query)]
-struct ElectricalProfileQueryArgs {
+pub(in crate::views) struct ElectricalProfileQueryArgs {
     name: String,
 }
 
 /// import a new electrical profile set
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "electrical_profiles",
@@ -192,7 +185,7 @@ struct ElectricalProfileQueryArgs {
         (status = 200, body = ElectricalProfileSet, description = "The list of ids and names of electrical profile sets available"),
     )
 )]
-async fn post_electrical_profile(
+pub(in crate::views) async fn post_electrical_profile(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Query(ep_set_name): Query<ElectricalProfileQueryArgs>,

--- a/editoast/src/views/fonts.rs
+++ b/editoast/src/views/fonts.rs
@@ -10,10 +10,6 @@ use tower_http::services::ServeFile;
 use crate::AppState;
 use crate::error::Result;
 
-crate::routes! {
-    "/fonts/{font}/{glyph}" => fonts,
-}
-
 #[derive(Debug, Error, EditoastError)]
 #[editoast_error(base_id = "fonts")]
 enum FontErrors {
@@ -23,6 +19,7 @@ enum FontErrors {
 }
 
 /// This endpoint is used by map libre to retrieve the fonts. They are separated by font and unicode block
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "fonts",
@@ -35,7 +32,7 @@ enum FontErrors {
         (status = 404, description = "Font not found"),
     ),
 )]
-async fn fonts(
+pub(in crate::views) async fn fonts(
     Path((font, file_name)): Path<(String, String)>,
     State(AppState { config, .. }): State<AppState>,
     request: Request,

--- a/editoast/src/views/infra/attached.rs
+++ b/editoast/src/views/infra/attached.rs
@@ -19,10 +19,6 @@ use crate::views::AuthorizationError;
 use crate::views::infra::InfraApiError;
 use editoast_schemas::primitives::ObjectType;
 
-crate::routes! {
-    "/attached/{track_id}" => attached,
-}
-
 /// Objects types that can be attached to a track
 const ATTACHED_OBJECTS_TYPES: &[ObjectType] = &[
     ObjectType::Signal,
@@ -43,7 +39,7 @@ enum AttachedError {
 }
 
 #[derive(utoipa::IntoParams, Deserialize)]
-struct InfraAttachedParams {
+pub(in crate::views) struct InfraAttachedParams {
     /// An infra ID
     infra_id: i64,
     /// A track section ID
@@ -51,6 +47,7 @@ struct InfraAttachedParams {
 }
 
 /// Retrieve all objects attached to a given track
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "infra",
@@ -63,7 +60,7 @@ struct InfraAttachedParams {
         ),
     ),
 )]
-async fn attached(
+pub(in crate::views) async fn attached(
     Path(InfraAttachedParams { infra_id, track_id }): Path<InfraAttachedParams>,
     State(AppState {
         infra_caches,

--- a/editoast/src/views/infra/auto_fixes/mod.rs
+++ b/editoast/src/views/infra/auto_fixes/mod.rs
@@ -70,11 +70,9 @@ pub enum OrderedOperation {
 }
 
 // Return `/infra/<infra_id>/auto_fixes` routes
-crate::routes! {
-    "/auto_fixes" => list_auto_fixes,
-}
 
 /// Retrieve a list of operations to fix infra issues
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "infra",
@@ -83,7 +81,7 @@ crate::routes! {
         (status = 200, description = "The list of suggested operations", body = Vec<Operation>)
     )
 )]
-async fn list_auto_fixes(
+pub(in crate::views) async fn list_auto_fixes(
     Path(infra_id): Path<i64>,
     State(AppState {
         infra_caches,

--- a/editoast/src/views/infra/delimited_area.rs
+++ b/editoast/src/views/infra/delimited_area.rs
@@ -31,10 +31,6 @@ use std::result::Result as StdResult;
 use thiserror::Error;
 use utoipa::ToSchema;
 
-crate::routes! {
-    "/delimited_area" => delimited_area,
-}
-
 editoast_common::schemas! {
     DelimitedAreaResponse,
     DirectedLocation,
@@ -48,7 +44,7 @@ editoast_common::schemas! {
 const MAXIMUM_DISTANCE: f64 = 5000.;
 
 #[derive(Deserialize, ToSchema)]
-struct DelimitedAreaForm {
+pub(in crate::views) struct DelimitedAreaForm {
     #[schema(inline)]
     entries: Vec<DirectedLocation>,
     #[schema(inline)]
@@ -56,7 +52,7 @@ struct DelimitedAreaForm {
 }
 
 #[derive(Deserialize, Serialize, ToSchema)]
-struct DelimitedAreaResponse {
+pub(in crate::views) struct DelimitedAreaResponse {
     track_ranges: Vec<DirectionalTrackRange>,
 }
 
@@ -116,6 +112,7 @@ impl From<Sign> for DirectedLocation {
     }
 }
 
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "delimited_area",
@@ -131,7 +128,7 @@ impl From<Sign> for DirectedLocation {
 /// be reached from an entry before reaching an exit.
 /// To prevent a missing exit to cause the graph traversal to never stop exploring, the exploration
 /// stops when a maximum distance is reached and no exit has been found.
-async fn delimited_area(
+pub(in crate::views) async fn delimited_area(
     Extension(auth): AuthenticationExt,
     State(AppState {
         infra_caches,

--- a/editoast/src/views/infra/edition.rs
+++ b/editoast/src/views/infra/edition.rs
@@ -51,11 +51,6 @@ use crate::views::infra::InfraIdParam;
 use database::DbConnection;
 use editoast_schemas::infra::InfraObject;
 
-crate::routes! {
-    edit,
-    "/split_track_section" => split_track_section,
-}
-
 /// Edit the content of an infrastructure
 ///
 /// Takes a batch of operations. An operation is a JSON patch document that will
@@ -66,6 +61,7 @@ crate::routes! {
 ///
 /// After editing the object, the generated cartographic layers are invalidated and
 /// regenerated. The edition step fails if the regeneration fails.
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "infra",
@@ -75,7 +71,7 @@ crate::routes! {
         (status = 200, body = Vec<InfraObject>, description = "The result of the operations")
     )
 )]
-async fn edit(
+pub(in crate::views) async fn edit(
     Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
     State(AppState {
         db_pool,
@@ -131,6 +127,7 @@ async fn edit(
     Ok(Json(operation_results))
 }
 
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "infra",
@@ -140,7 +137,7 @@ async fn edit(
         (status = 200, body = inline(Vec<String>), description = "ID of the trackSections created")
     ),
 )]
-pub async fn split_track_section(
+pub(in crate::views) async fn split_track_section(
     Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
     State(AppState {
         db_pool,

--- a/editoast/src/views/infra/errors.rs
+++ b/editoast/src/views/infra/errors.rs
@@ -27,13 +27,9 @@ use database::DbConnectionPoolV2;
 
 use super::InfraApiError;
 
-crate::routes! {
-    "/errors" => list_errors,
-}
-
 #[derive(Debug, Clone, Deserialize, utoipa::IntoParams)]
 #[into_params(parameter_in = Query)]
-struct ErrorListQueryParams {
+pub(in crate::views) struct ErrorListQueryParams {
     /// Whether the response should include errors or warnings
     #[serde(default)]
     #[param(inline)]
@@ -62,6 +58,7 @@ pub(in crate::views) struct InfraErrorResponse {
 }
 
 /// A paginated list of errors related to an infra
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
      tag = "infra",
@@ -70,7 +67,7 @@ pub(in crate::views) struct InfraErrorResponse {
          (status = 200, body = inline(ErrorListResponse), description = "A paginated list of errors"),
      ),
  )]
-async fn list_errors(
+pub(in crate::views) async fn list_errors(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(InfraIdParam { infra_id }): Path<InfraIdParam>,

--- a/editoast/src/views/infra/lines.rs
+++ b/editoast/src/views/infra/lines.rs
@@ -18,10 +18,6 @@ use crate::views::AuthorizationError;
 use crate::views::infra::InfraApiError;
 use crate::views::infra::InfraIdParam;
 
-crate::routes! {
-    "/lines/{line_code}/bbox" => get_line_bbox,
-}
-
 #[derive(Debug, Error, EditoastError)]
 #[editoast_error(base_id = "infra:lines")]
 enum LinesErrors {
@@ -30,6 +26,7 @@ enum LinesErrors {
 }
 
 /// Returns the BBoxes of a line
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "infra",
@@ -41,7 +38,7 @@ enum LinesErrors {
         (status = 200, body = BoundingBox, description = "The BBox of the line"),
     )
 )]
-async fn get_line_bbox(
+pub(in crate::views) async fn get_line_bbox(
     Path((infra_id, line_code)): Path<(i64, i64)>,
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -1,13 +1,13 @@
-mod attached;
-mod auto_fixes;
-mod delimited_area;
-mod edition;
-mod errors;
-mod lines;
-mod objects;
-mod pathfinding;
-mod railjson;
-mod routes;
+pub(in crate::views) mod attached;
+pub(in crate::views) mod auto_fixes;
+pub(in crate::views) mod delimited_area;
+pub(in crate::views) mod edition;
+pub(in crate::views) mod errors;
+pub(in crate::views) mod lines;
+pub(in crate::views) mod objects;
+pub(in crate::views) mod pathfinding;
+pub(in crate::views) mod railjson;
+pub(in crate::views) mod routes;
 
 use authz;
 use authz::InfraGrant;
@@ -67,39 +67,6 @@ use editoast_schemas::train_schedule::OperationalPointIdentifier;
 use editoast_schemas::train_schedule::OperationalPointReference;
 use editoast_schemas::train_schedule::PathItemLocation;
 
-crate::routes! {
-    "/infra" => {
-        list,
-        create,
-        "/refresh" => refresh,
-        "/voltages" => get_all_voltages,
-        &railjson,
-        "/{infra_id}" => {
-            &objects,
-            &routes,
-            &lines,
-            &auto_fixes,
-            &pathfinding,
-            &attached,
-            &edition,
-            &errors,
-            &delimited_area,
-
-            get,
-            "/load" => load,
-            delete,
-            put,
-            "/clone" => clone,
-            "/lock" => lock,
-            "/unlock" => unlock,
-            "/speed_limit_tags" => get_speed_limit_tags,
-            "/voltages" => get_voltages,
-            "/switch_types" => get_switch_types,
-            "/match_operational_points" => match_operational_points,
-        },
-    },
-}
-
 editoast_common::schemas! {
     pathfinding::schemas(),
     delimited_area::schemas(),
@@ -130,7 +97,7 @@ pub(in crate::views) struct InfraIdQueryParam {
 
 #[derive(Debug, Deserialize, IntoParams)]
 #[into_params(parameter_in = Query)]
-struct RefreshQueryParams {
+pub(in crate::views) struct RefreshQueryParams {
     #[serde(default)]
     force: bool,
     /// A comma-separated list of infra IDs to refresh
@@ -142,12 +109,13 @@ struct RefreshQueryParams {
 }
 
 #[derive(Debug, Serialize, ToSchema)]
-struct RefreshResponse {
+pub(in crate::views) struct RefreshResponse {
     /// The list of infras that were refreshed successfully
     infra_refreshed: Vec<i64>,
 }
 
 /// Refresh infra generated geographic layers
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "infra",
@@ -157,7 +125,7 @@ struct RefreshResponse {
         (status = 404, description = "Invalid infra ID query parameters"),
     )
 )]
-async fn refresh(
+pub(in crate::views) async fn refresh(
     State(AppState {
         db_pool,
         valkey: valkey_client,
@@ -219,13 +187,14 @@ async fn refresh(
 }
 
 #[derive(Serialize, ToSchema)]
-struct InfraListResponse {
+pub(in crate::views) struct InfraListResponse {
     #[serde(flatten)]
     stats: PaginationStats,
     results: Vec<InfraWithState>,
 }
 
 /// Lists all infras along with their current loading state in Core
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "infra",
@@ -234,7 +203,7 @@ struct InfraListResponse {
         (status = 200, description = "All infras, paginated", body = inline(InfraListResponse))
     ),
 )]
-async fn list(
+pub(in crate::views) async fn list(
     State(AppState {
         db_pool,
         osrdyne_client,
@@ -310,7 +279,7 @@ impl From<osrdyne_client::WorkerStatus> for InfraState {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
-struct InfraWithState {
+pub(in crate::views) struct InfraWithState {
     #[serde(flatten)]
     pub infra: Infra,
     pub state: InfraState,
@@ -318,12 +287,13 @@ struct InfraWithState {
 
 #[derive(IntoParams, Deserialize)]
 #[allow(unused)]
-struct InfraIdParam {
+pub(in crate::views) struct InfraIdParam {
     /// An existing infra ID
     infra_id: i64,
 }
 
 /// Retrieve a specific infra
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "infra",
@@ -333,7 +303,7 @@ struct InfraIdParam {
         (status = 404, description = "Infra ID not found"),
     ),
 )]
-async fn get(
+pub(in crate::views) async fn get(
     State(AppState {
         db_pool,
         osrdyne_client,
@@ -385,6 +355,7 @@ impl From<InfraCreateForm> for Changeset<Infra> {
 /// Creates an empty infra
 ///
 /// The infra may be edited by batch later via the `POST /infra/ID` or `POST /infra/ID/railjson` endpoints.
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "infra",
@@ -393,7 +364,7 @@ impl From<InfraCreateForm> for Changeset<Infra> {
         (status = 201, description = "The created infra", body = Infra),
     ),
 )]
-async fn create(
+pub(in crate::views) async fn create(
     State(AppState {
         db_pool, regulator, ..
     }): State<AppState>,
@@ -428,12 +399,13 @@ async fn create(
 
 #[derive(Deserialize, IntoParams)]
 #[into_params(parameter_in = Query)]
-struct CloneQuery {
+pub(in crate::views) struct CloneQuery {
     /// The name of the new infra
     name: String,
 }
 
 /// Duplicate an infra
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "infra",
@@ -443,7 +415,7 @@ struct CloneQuery {
         (status = 404, description = "Infra ID not found"),
     ),
 )]
-async fn clone(
+pub(in crate::views) async fn clone(
     Extension(auth): AuthenticationExt,
     Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
     State(AppState {
@@ -501,6 +473,7 @@ async fn clone(
 /// You've been warned.
 ///
 /// This operation may take a while to complete.
+#[editoast_derive::route]
 #[utoipa::path(
     delete, path = "",
     tag = "infra",
@@ -510,7 +483,7 @@ async fn clone(
         (status = 404, description = "Infra ID not found"),
     ),
 )]
-async fn delete(
+pub(in crate::views) async fn delete(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
@@ -540,7 +513,7 @@ async fn delete(
 }
 
 #[derive(Serialize, Deserialize, ToSchema)]
-struct InfraPatchForm {
+pub(in crate::views) struct InfraPatchForm {
     /// The new name to give the infra
     pub name: String,
 }
@@ -552,6 +525,7 @@ impl From<InfraPatchForm> for Changeset<Infra> {
 }
 
 /// Rename an infra
+#[editoast_derive::route]
 #[utoipa::path(
     put, path = "",
     tag = "infra",
@@ -562,7 +536,7 @@ impl From<InfraPatchForm> for Changeset<Infra> {
         (status = 404, description = "Infra ID not found"),
     ),
 )]
-async fn put(
+pub(in crate::views) async fn put(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(infra): Path<i64>,
@@ -586,6 +560,7 @@ async fn put(
 }
 
 /// Return the railjson list of switch types
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "infra",
@@ -595,7 +570,7 @@ async fn put(
         (status = 404, description = "The infra was not found"),
     )
 )]
-async fn get_switch_types(
+pub(in crate::views) async fn get_switch_types(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
@@ -642,6 +617,7 @@ async fn get_switch_types(
 }
 
 /// Returns the set of speed limit tags for a given infra
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "infra",
@@ -651,7 +627,7 @@ async fn get_switch_types(
         (status = 404, description = "The infra was not found"),
     )
 )]
-async fn get_speed_limit_tags(
+pub(in crate::views) async fn get_speed_limit_tags(
     Extension(auth): AuthenticationExt,
     Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
     State(db_pool): State<DbConnectionPoolV2>,
@@ -690,13 +666,14 @@ async fn get_speed_limit_tags(
 
 #[derive(Debug, Clone, Deserialize, IntoParams)]
 #[into_params(parameter_in = Query)]
-struct GetVoltagesQueryParams {
+pub(in crate::views) struct GetVoltagesQueryParams {
     #[serde(default)]
     include_rolling_stock_modes: bool,
 }
 
 /// Returns the set of voltages for a given infra and/or rolling_stocks modes.
 /// If include_rolling_stocks_modes is true, it returns also rolling_stocks modes.
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "infra",
@@ -706,7 +683,7 @@ struct GetVoltagesQueryParams {
         (status = 404, description = "The infra was not found",),
     )
 )]
-async fn get_voltages(
+pub(in crate::views) async fn get_voltages(
     Extension(auth): AuthenticationExt,
     Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
     Query(param): Query<GetVoltagesQueryParams>,
@@ -741,6 +718,7 @@ async fn get_voltages(
 }
 
 /// Returns the set of voltages for all infras and rolling_stocks modes.
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "infra,rolling_stock",
@@ -749,7 +727,7 @@ async fn get_voltages(
         (status = 404, description = "The infra was not found",),
     )
 )]
-async fn get_all_voltages(
+pub(in crate::views) async fn get_all_voltages(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
 ) -> Result<Json<Vec<String>>> {
@@ -778,6 +756,7 @@ async fn set_locked(infra_id: i64, locked: bool, db_pool: DbConnectionPoolV2) ->
 }
 
 /// Lock an infra
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "infra",
@@ -787,7 +766,7 @@ async fn set_locked(infra_id: i64, locked: bool, db_pool: DbConnectionPoolV2) ->
         (status = 404, description = "The infra was not found",),
     )
 )]
-async fn lock(
+pub(in crate::views) async fn lock(
     Extension(auth): AuthenticationExt,
     Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
     State(db_pool): State<DbConnectionPoolV2>,
@@ -813,6 +792,7 @@ async fn lock(
 }
 
 /// Unlock an infra
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "infra",
@@ -822,7 +802,7 @@ async fn lock(
         (status = 404, description = "The infra was not found",),
     )
 )]
-async fn unlock(
+pub(in crate::views) async fn unlock(
     Extension(auth): AuthenticationExt,
     Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
     State(db_pool): State<DbConnectionPoolV2>,
@@ -849,11 +829,12 @@ async fn unlock(
 
 #[derive(Deserialize, Debug, Clone, IntoParams)]
 #[into_params(parameter_in = Query)]
-struct TimetableQueryParam {
+pub(in crate::views) struct TimetableQueryParam {
     timetable: Option<i64>,
 }
 
 /// Instructs Core to load an infra
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "infra",
@@ -863,7 +844,7 @@ struct TimetableQueryParam {
         (status = 404, description = "The infra was not found"),
     )
 )]
-async fn load(
+pub(in crate::views) async fn load(
     State(AppState {
         db_pool,
         core_client,
@@ -941,7 +922,7 @@ pub async fn fetch_all_infra_states(
 
 #[derive(Deserialize, ToSchema)]
 #[cfg_attr(test, derive(Serialize))]
-struct MatchOperationalPointsForm {
+pub(in crate::views) struct MatchOperationalPointsForm {
     operational_point_references: Vec<OperationalPointReference>,
 }
 
@@ -955,11 +936,12 @@ struct RelatedOperationalPoint {
 
 #[derive(Serialize, ToSchema)]
 #[cfg_attr(test, derive(Deserialize))]
-struct MatchOperationalPointsResponse {
+pub(in crate::views) struct MatchOperationalPointsResponse {
     related_operational_points: Vec<Vec<RelatedOperationalPoint>>,
     track_names: HashMap<Identifier, Option<String>>,
 }
 
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "infra",
@@ -977,7 +959,7 @@ matches the input track reference).
 ", body = inline(MatchOperationalPointsResponse))
     ),
 )]
-async fn match_operational_points(
+pub(in crate::views) async fn match_operational_points(
     State(AppState { db_pool, .. }): State<AppState>,
     Extension(auth): AuthenticationExt,
     Path(InfraIdParam { infra_id }): Path<InfraIdParam>,

--- a/editoast/src/views/infra/objects.rs
+++ b/editoast/src/views/infra/objects.rs
@@ -20,11 +20,6 @@ use crate::models::infra::ObjectQueryable;
 use crate::views::AuthenticationExt;
 use crate::views::AuthorizationError;
 
-crate::routes! {
-    "/objects/{object_type}" => get_objects,
-    "/objects/{object_type}/ids" => list_objects_ids,
-}
-
 #[derive(Debug, Error, EditoastError)]
 #[editoast_error(base_id = "infra:objects")]
 enum GetObjectsErrors {
@@ -40,11 +35,12 @@ fn has_unique_ids(obj_ids: &[String]) -> bool {
 }
 
 #[derive(serde::Deserialize, utoipa::IntoParams)]
-struct ObjectTypeParam {
+pub(in crate::views) struct ObjectTypeParam {
     object_type: ObjectType,
 }
 
 /// Retrieves specific infra objects
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "infra",
@@ -56,7 +52,7 @@ struct ObjectTypeParam {
         (status = 404, description = "Object ID or infra ID invalid")
     )
 )]
-async fn get_objects(
+pub(in crate::views) async fn get_objects(
     Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
     Path(object_type_param): Path<ObjectTypeParam>,
     State(db_pool): State<DbConnectionPoolV2>,
@@ -125,10 +121,11 @@ async fn get_objects(
 }
 
 #[derive(serde::Serialize, utoipa::ToSchema)]
-struct ListObjectsResponse {
+pub(in crate::views) struct ListObjectsResponse {
     ids: Vec<String>,
 }
 
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "infra",
@@ -137,7 +134,7 @@ struct ListObjectsResponse {
         (status = 200, description = "The list of objects", body = inline(ListObjectsResponse)),
     )
 )]
-async fn list_objects_ids(
+pub(in crate::views) async fn list_objects_ids(
     Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
     Path(ObjectTypeParam { object_type }): Path<ObjectTypeParam>,
     State(db_pool): State<DbConnectionPoolV2>,

--- a/editoast/src/views/infra/pathfinding.rs
+++ b/editoast/src/views/infra/pathfinding.rs
@@ -32,10 +32,6 @@ use editoast_schemas::infra::TrackEndpoint;
 use editoast_schemas::primitives::Identifier;
 use editoast_schemas::primitives::ObjectType;
 
-crate::routes! {
-    "/pathfinding" => pathfinding_view,
-}
-
 editoast_common::schemas! {
     PathfindingTrackLocationInput,
     InfraPathfindingInput,
@@ -65,13 +61,13 @@ struct PathfindingTrackLocationInput {
 }
 
 #[derive(Debug, Clone, Deserialize, ToSchema)]
-struct InfraPathfindingInput {
+pub(in crate::views) struct InfraPathfindingInput {
     starting: PathfindingTrackLocationInput,
     ending: PathfindingTrackLocationInput,
 }
 
 #[derive(Debug, Default, Clone, Serialize, ToSchema)]
-struct PathfindingOutput {
+pub(in crate::views) struct PathfindingOutput {
     track_ranges: Vec<DirectionalTrackRange>,
     #[schema(inline)]
     detectors: Vec<Identifier>,
@@ -81,11 +77,12 @@ struct PathfindingOutput {
 
 #[derive(Debug, Clone, IntoParams, Deserialize)]
 #[into_params(parameter_in = Query)]
-struct QueryParam {
+pub(in crate::views) struct QueryParam {
     number: Option<u8>,
 }
 
 /// This endpoint search path between starting and ending track locations
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "infra,pathfinding",
@@ -95,7 +92,7 @@ struct QueryParam {
         (status = 200, description = "A list of shortest paths between starting and ending track locations", body = Vec<PathfindingOutput>)
     )
 )]
-async fn pathfinding_view(
+pub(in crate::views) async fn pathfinding_view(
     State(AppState {
         db_pool,
         infra_caches,

--- a/editoast/src/views/infra/railjson.rs
+++ b/editoast/src/views/infra/railjson.rs
@@ -30,12 +30,8 @@ use crate::views::infra::InfraIdParam;
 use database::DbConnectionPoolV2;
 use editoast_schemas::primitives::ObjectType;
 
-crate::routes! {
-    "/{infra_id}/railjson" => get_railjson,
-    "/railjson" => post_railjson,
-}
-
 /// Serialize an infra
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "infra",
@@ -45,7 +41,7 @@ crate::routes! {
         (status = 404, description = "The infra was not found"),
     )
 )]
-async fn get_railjson(
+pub(in crate::views) async fn get_railjson(
     Path(infra): Path<InfraIdParam>,
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
@@ -144,7 +140,7 @@ async fn get_railjson(
 /// Represents the query parameters for a `POST /infra/railjson` request
 #[derive(Debug, Clone, Deserialize, IntoParams)]
 #[into_params(parameter_in = Query)]
-struct PostRailjsonQueryParams {
+pub(in crate::views) struct PostRailjsonQueryParams {
     /// The name of the infrastructure.
     name: String,
     /// Flag indicating whether to generate data.
@@ -153,11 +149,12 @@ struct PostRailjsonQueryParams {
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, ToSchema)]
-struct PostRailjsonResponse {
+pub(in crate::views) struct PostRailjsonResponse {
     pub infra: i64,
 }
 
 /// Import an infra from railjson
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "infra",
@@ -168,7 +165,7 @@ struct PostRailjsonResponse {
         (status = 404, description = "The infra was not found"),
     )
 )]
-async fn post_railjson(
+pub(in crate::views) async fn post_railjson(
     State(AppState {
         db_pool,
         infra_caches,

--- a/editoast/src/views/infra/routes.rs
+++ b/editoast/src/views/infra/routes.rs
@@ -25,14 +25,6 @@ use crate::views::infra::InfraApiError;
 use crate::views::infra::InfraIdParam;
 use crate::views::params::List;
 
-crate::routes! {
-    "/routes" => {
-        "/track_ranges" => get_routes_track_ranges,
-        "/{waypoint_type}/{waypoint_id}" => get_routes_from_waypoint,
-        "/nodes" => get_routes_nodes,
-    },
-}
-
 #[derive(Debug, Display, Clone, Copy, Deserialize, ToSchema)]
 enum WaypointType {
     Detector,
@@ -40,7 +32,7 @@ enum WaypointType {
 }
 
 #[derive(Debug, Deserialize, utoipa::IntoParams)]
-struct RoutesFromWaypointParams {
+pub(in crate::views) struct RoutesFromWaypointParams {
     /// Infra ID
     infra_id: i64,
     /// Type of the waypoint
@@ -51,12 +43,13 @@ struct RoutesFromWaypointParams {
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, ToSchema)]
-struct RoutesResponse {
+pub(in crate::views) struct RoutesResponse {
     starting: Vec<String>,
     ending: Vec<String>,
 }
 
 /// Retrieve all routes that starting and ending by the given waypoint (detector or buffer stop)
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "infra,routes",
@@ -65,7 +58,7 @@ struct RoutesResponse {
         (status = 200, body = inline(RoutesResponse), description = "All routes that starting and ending by the given waypoint")
     ),
 )]
-async fn get_routes_from_waypoint(
+pub(in crate::views) async fn get_routes_from_waypoint(
     Path(path): Path<RoutesFromWaypointParams>,
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
@@ -117,7 +110,7 @@ async fn get_routes_from_waypoint(
 
 #[derive(Debug, Clone, Serialize, PartialEq, ToSchema)]
 #[serde(deny_unknown_fields, tag = "type")]
-enum RouteTrackRangesResult {
+pub(in crate::views) enum RouteTrackRangesResult {
     /// RoutePath contains N track ranges with the N-1 switches found inbetween, in the order they appear on the route
     Computed(RoutePath),
     NotFound,
@@ -126,14 +119,14 @@ enum RouteTrackRangesResult {
 
 #[derive(Debug, Clone, Deserialize, utoipa::IntoParams)]
 #[into_params(parameter_in = Query)]
-struct RouteTrackRangesParams {
+pub(in crate::views) struct RouteTrackRangesParams {
     /// A list of comma-separated route ids
     #[param(value_type = String)]
     routes: List<String>,
 }
 
 #[derive(Default, Debug, Serialize, Deserialize, PartialEq, ToSchema)]
-struct RoutesFromNodesPositions {
+pub(in crate::views) struct RoutesFromNodesPositions {
     /// List of route ids crossing a selection of nodes
     routes: Vec<String>,
     /// List of available positions for each node on the corresponding routes
@@ -141,6 +134,7 @@ struct RoutesFromNodesPositions {
 }
 
 /// Compute the track ranges through which routes passes.
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "infra,routes",
@@ -153,7 +147,7 @@ struct RoutesFromNodesPositions {
         )
     ),
 )]
-async fn get_routes_track_ranges(
+pub(in crate::views) async fn get_routes_track_ranges(
     State(AppState {
         db_pool,
         infra_caches,
@@ -219,6 +213,7 @@ async fn get_routes_track_ranges(
 }
 
 /// Returns the list of routes crossing the specified nodes, along with the available positions for each of them.
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "infra,routes",
@@ -228,7 +223,7 @@ async fn get_routes_track_ranges(
         (status = 200, body = inline(RoutesFromNodesPositions), description = "A list of route IDs along with available positions for each specified node")
     ),
 )]
-async fn get_routes_nodes(
+pub(in crate::views) async fn get_routes_nodes(
     State(AppState {
         db_pool,
         infra_caches,

--- a/editoast/src/views/layers.rs
+++ b/editoast/src/views/layers.rs
@@ -28,13 +28,6 @@ use crate::models::layers::geo_json_and_data::create_and_fill_mvt_tile;
 use crate::views::AuthenticationExt;
 use crate::views::AuthorizationError;
 
-crate::routes! {
-     "/layers" => {
-        "/layer/{layer_slug}/mvt/{view_slug}" => layer_view,
-        "/tile/{layer_slug}/{view_slug}/{z}/{x}/{y}" => cache_and_get_mvt_tile,
-    },
-}
-
 #[derive(Debug, Error, EditoastError)]
 #[editoast_error(base_id = "layers", default_status = 404)]
 enum LayersError {
@@ -71,7 +64,7 @@ impl LayersError {
 
 #[derive(Deserialize, Debug, Clone, IntoParams)]
 #[into_params(parameter_in = Query)]
-struct InfraQueryParam {
+pub(in crate::views) struct InfraQueryParam {
     infra: i64,
 }
 
@@ -83,7 +76,7 @@ struct LayerViewParams {
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, ToSchema)]
-struct ViewMetadata {
+pub(in crate::views) struct ViewMetadata {
     #[serde(rename = "type")]
     data_type: String,
     #[schema(example = "track_sections")]
@@ -102,6 +95,7 @@ struct ViewMetadata {
 }
 
 /// Returns layer view metadata to query tiles
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "layers",
@@ -110,7 +104,7 @@ struct ViewMetadata {
         (status = 200, body = inline(ViewMetadata), description = "Successful Response"),
     )
 )]
-async fn layer_view(
+pub(in crate::views) async fn layer_view(
     State(AppState {
         map_layers, config, ..
     }): State<AppState>,
@@ -167,6 +161,7 @@ struct TileParams {
 }
 
 /// Mvt tile from the cache if possible, otherwise gets data from the database and caches it in valkey
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "layers",
@@ -175,7 +170,7 @@ struct TileParams {
         (status = 200, body = Vec<u8>, description = "Successful Response"),
     )
 )]
-async fn cache_and_get_mvt_tile(
+pub(in crate::views) async fn cache_and_get_mvt_tile(
     State(AppState {
         map_layers,
         db_pool,

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -13,6 +13,7 @@ pub mod project;
 pub mod projection;
 pub mod rolling_stock;
 pub mod round_trips;
+mod router;
 pub mod scenario;
 pub mod search;
 pub mod sprites;
@@ -93,16 +94,50 @@ use crate::models;
 use crate::models::PgAuthDriver;
 use crate::valkey_utils::ValkeyConfig;
 
+fn routerv2() -> router::DocumentedRouter {
+    use router::delete;
+    use router::get;
+    use router::patch;
+    use router::post;
+    use router::put;
+
+    // This whole expression has been designed to be as compact as possible, keep paths relatively aligned,
+    // while also keeping rustfmt happy.
+    // - the closure incites rustfmt to not break line after the path
+    // - the nests function name is 5 characters long to be symmetric to route (unlike axum::Router::nest)
+    // - the closure parameter is named path to incite rustfmt to keep the first route call on the same line
+    //   - a longer name would cause a line break before the first .
+    //   - a shorter name breaks alignment
+    //
+    // # Ordering
+    //
+    // - arbitrary toplevel sections
+    // - for sub routers, routes first, nests second
+    // - paths ordered by number of segments
+    // - equal number of segments in a path => alphabetical order
+    //
+    // Of course, these conventions are to be broken if they get in the way of request path resolution.
+
+    router::DocumentedRouter::root(|path| {
+        path.route("/health", get!(health))
+            .nests("/documents", |path| {
+                path.route("/", post!(documents::post))
+                    .nests("/{document_key}", |path| {
+                        path.route("/", get!(documents::get))
+                            .route("/", delete!(documents::delete))
+                    })
+            })
+    })
+}
+
 crate::routes! {
     fn router();
     fn openapi_paths();
 
-    "/health" => health,
     "/version" => version,
     "/version/core" => core_version,
 
     &authz,
-    &documents,
     &electrical_profiles,
     &fonts,
     &infra,
@@ -393,6 +428,7 @@ pub enum AppHealthError {
     Core(#[from] core_client::Error),
 }
 
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     responses(
@@ -673,6 +709,7 @@ impl Server {
 
         // Configure the axum router
         let router: Router<()> = axum::Router::<AppState>::new()
+            .merge(routerv2().router)
             .merge(router())
             .route_layer(axum::middleware::from_fn_with_state(
                 app_state.clone(),

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -94,7 +94,7 @@ use crate::models;
 use crate::models::PgAuthDriver;
 use crate::valkey_utils::ValkeyConfig;
 
-fn routerv2() -> router::DocumentedRouter {
+fn service_router() -> router::DocumentedRouter {
     use router::delete;
     use router::get;
     use router::patch;
@@ -940,7 +940,7 @@ impl Server {
 
         // Configure the axum router
         let router: Router<()> = axum::Router::<AppState>::new()
-            .merge(routerv2().router)
+            .merge(service_router().router)
             .route_layer(axum::middleware::from_fn_with_state(
                 app_state.clone(),
                 authentication_middleware,

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -119,97 +119,191 @@ fn routerv2() -> router::DocumentedRouter {
     // Of course, these conventions are to be broken if they get in the way of request path resolution.
 
     router::DocumentedRouter::root(|path| {
-        path.route("/health", get!(health))
+        path
+            // random stuff
+            .route("/health", get!(health))
             .route("/version", get!(version))
             .route("/version/core", get!(core_version))
+
+            // authorization
             .nests("/authz", |path| {
-                path.nests("/me", |path| {
-                    path.route("/privileges", post!(authz::user_privileges))
-                        .route("/grants", post!(authz::user_grants))
-                        .route("/", get!(authz::whoami))
-                })
-                .route("/grants", post!(authz::update_grants))
-                .route(
-                    "/{resource_type}/{resource_id}",
-                    get!(authz::subjects_with_grant_on_resource),
-                )
-            })
-            .nests("/documents", |path| {
-                path.route("/", post!(documents::post))
-                    .nests("/{document_key}", |path| {
-                        path.route("/", get!(documents::get))
-                            .route("/", delete!(documents::delete))
+                path.route("/grants", post!(authz::update_grants))
+                    .route("/{resource_type}/{resource_id}", get!(authz::subjects_with_grant_on_resource))
+                    .nests("/me", |path| {
+                        path.route("/", get!(authz::whoami))
+                            .route("/grants", post!(authz::user_grants))
+                            .route("/privileges", post!(authz::user_privileges))
                     })
             })
+
+            // infra & map
+            .route("/fonts/{font}/{glyph}", get!(fonts::fonts))
+            .nests("/layers", |path| {
+                path.route("/layer/{layer_slug}/mvt/{view_slug}", get!(layers::layer_view))
+                    .route("/tile/{layer_slug}/{view_slug}/{z}/{x}/{y}", get!(layers::cache_and_get_mvt_tile))
+            })
+            .nests("/sprites", |path| {
+                path.route("/signaling_systems", get!(sprites::signaling_systems))
+                    .route("/{signaling_system}/{file_name}", get!(sprites::sprites))
+            })
+            .route("/search", post!(search::search))
+            .nests("/infra", |path| {
+                path.route("/", get!(infra::list))
+                    .route("/", post!(infra::create))
+                    .route("/railjson", post!(infra::railjson::post_railjson))
+                    .route("/refresh", post!(infra::refresh))
+                    .route("/voltages", get!(infra::get_all_voltages))
+                    .nests("/{infra_id}", |path| {
+                        path.route("/", get!(infra::get))
+                            .route("/", post!(infra::edition::edit))
+                            .route("/", delete!(infra::delete))
+                            .route("/", put!(infra::put))
+                            .route("/auto_fixes", get!(infra::auto_fixes::list_auto_fixes))
+                            .route("/clone", post!(infra::clone))
+                            .route("/delimited_area", get!(infra::delimited_area::delimited_area))
+                            .route("/errors", get!(infra::errors::list_errors))
+                            .route("/load", post!(infra::load))
+                            .route("/lock", post!(infra::lock))
+                            .route("/match_operational_points", post!(infra::match_operational_points))
+                            .route("/path_properties", post!(path::properties::post))
+                            .route("/pathfinding", post!(infra::pathfinding::pathfinding_view))
+                            .route("/railjson", get!(infra::railjson::get_railjson))
+                            .route("/speed_limit_tags", get!(infra::get_speed_limit_tags))
+                            .route("/split_track_section", post!(infra::edition::split_track_section))
+                            .route("/switch_types", get!(infra::get_switch_types))
+                            .route("/unlock", post!(infra::unlock))
+                            .route("/voltages", get!(infra::get_voltages))
+                            .route("/attached/{track_id}", get!(infra::attached::attached))
+                            .nests("/lines", |path| {
+                                path.route("/{line_code}/bbox", get!(infra::lines::get_line_bbox))
+                            })
+                            .nests("/objects", |path| {
+                                path.route("/{object_type}", post!(infra::objects::get_objects))
+                                    .route("/{object_type}/ids", get!(infra::objects::list_objects_ids))
+                            })
+                            .nests("/routes", |path| {
+                                path.route("/nodes", post!(infra::routes::get_routes_nodes))
+                                    .route("/track_ranges", get!(infra::routes::get_routes_track_ranges))
+                                    .route("/{waypoint_type}/{waypoint_id}", get!(infra::routes::get_routes_from_waypoint))
+                            })
+                            .nests("/pathfinding", |path| {
+                                path.route("/blocks", post!(path::pathfinding::post))
+                            })
+                    })
+            })
+
+            // timetable & simulations
+            .nests("/timetable", |path| {
+                path.route("/", post!(timetable::post))
+                    .nests("/{id}", |path| {
+                        path.route("/", delete!(timetable::delete))
+                            .route("/conflicts", get!(timetable::conflicts))
+                            .route("/stdcm", post!(timetable::stdcm::stdcm))
+                            .nests("/paced_trains", |path| {
+                                path.route("/", get!(timetable::get_paced_trains))
+                                    .route("/", post!(timetable::post_paced_train))
+                            })
+                            .nests("/round_trips", |path| {
+                                path.nests("/train_schedules", |path| {
+                                    path.route("/", get!(round_trips::list_train_schedules))
+                                })
+                                .nests("/paced_trains", |path| {
+                                    path.route("/", get!(round_trips::list_paced_trains))
+                                })
+                            })
+                            .nests("/train_schedules", |path| {
+                                path.route("/", get!(timetable::get_train_schedules))
+                                    .route("/", post!(timetable::post_train_schedule))
+                            })
+                    })
+            })
+            .route("/similar_trains", post!(timetable::similar_trains::similar_trains)) // TODO: put under /timtable
+            .nests("/train_schedule", |path| {
+                path.route("/", delete!(timetable::train_schedule::delete))
+                    .route("/occupancy_blocks", post!(timetable::train_schedule::occupancy_blocks))
+                    .route("/project_path", post!(timetable::train_schedule::project_path))
+                    .route("/project_path_op", post!(timetable::train_schedule::project_path_op))
+                    .route("/simulation_summary", post!(timetable::train_schedule::simulation_summary))
+                    .route("/track_occupancy", post!(timetable::train_schedule::track_occupancy))
+                    .nests("/{id}", |path| {
+                        path.route("/", get!(timetable::train_schedule::get))
+                            .route("/", put!(timetable::train_schedule::put))
+                            .route("/etcs_braking_curves", get!(timetable::train_schedule::etcs_braking_curves))
+                            .route("/path", get!(timetable::train_schedule::get_path))
+                            .route("/simulation", get!(timetable::train_schedule::simulation))
+                    })
+            })
+            .nests("/paced_train", |path| {
+                path.route("/", delete!(timetable::paced_train::delete))
+                    .route("/occupancy_blocks", post!(timetable::paced_train::occupancy_blocks))
+                    .route("/project_path", post!(timetable::paced_train::project_path))
+                    .route("/project_path_op", post!(timetable::paced_train::project_path_op))
+                    .route("/simulation_summary", post!(timetable::paced_train::simulation_summary))
+                    .nests("/{id}", |path| {
+                        path.route("/", get!(timetable::paced_train::get_by_id))
+                            .route("/", put!(timetable::paced_train::update_paced_train))
+                            .route("/path", get!(timetable::paced_train::get_path))
+                            .route("/simulation", get!(timetable::paced_train::simulation))
+                    })
+            })
+            .nests("/round_trips", |path| {
+                path.nests("/train_schedules", |path| {
+                    path.route("/", post!(round_trips::post_train_schedules))
+                        .route("/delete", post!(round_trips::delete_train_schedules))
+                })
+                .nests("/paced_trains", |path| {
+                    path.route("/", post!(round_trips::post_paced_trains))
+                        .route("/delete", post!(round_trips::delete_paced_trains))
+                })
+            })
+            .nests("/sub_category", |path| {
+                path.route("/", get!(sub_categories::get_sub_categories))
+                    .route("/", post!(sub_categories::create_sub_categories))
+                    .nests("/{code}", |path| {
+                        path.route("/", delete!(sub_categories::delete_sub_category))
+                    })
+            })
+
+            // simulation environment
+            .nests("/stdcm/search_environment", |path| {
+                path.route("/", get!(stdcm_search_environment::retrieve_latest))
+                    .route("/", post!(stdcm_search_environment::create))
+                    .route("/list", get!(stdcm_search_environment::list))
+                    .route("/{env_id}", delete!(stdcm_search_environment::delete))
+            })
+            .route("/stdcm_logs", get!(stdcm_logs::list_stdcm_logs))
+            .route("/stdcm_log", get!(stdcm_logs::stdcm_log_by_id_or_trace_id))
+            .nests("/work_schedules", |path| {
+                path.route("/", post!(work_schedules::create))
+                    .route("/project_path", post!(work_schedules::project_path))
+                    .nests("/group", |path| {
+                        path.route("/", get!(work_schedules::list_groups))
+                            .route("/", post!(work_schedules::create_group))
+                            .nests("/{id}", |path| {
+                                path.route("/", get!(work_schedules::get_group))
+                                    .route("/", delete!(work_schedules::delete_group))
+                                    .route("/", put!(work_schedules::put_in_group))
+                            })
+                    })
+            })
+            .route("/temporary_speed_limit_group", post!(temporary_speed_limits::create_temporary_speed_limit_group))
             .nests("/electrical_profile_set", |path| {
-                path.route("/", post!(electrical_profiles::post_electrical_profile))
-                    .route("/", get!(electrical_profiles::list))
+                path.route("/", get!(electrical_profiles::list))
+                    .route("/", post!(electrical_profiles::post_electrical_profile))
                     .nests("/{electrical_profile_set_id}", |path| {
                         path.route("/", get!(electrical_profiles::get))
                             .route("/", delete!(electrical_profiles::delete))
                             .route("/level_order", get!(electrical_profiles::get_level_order))
                     })
             })
-            .route("/fonts/{font}/{glyph}", get!(fonts::fonts))
-            .nests("/infra", |path| {
-                path.route("/", get!(infra::list))
-                    .route("/", post!(infra::create))
-                    .route("/refresh", post!(infra::refresh))
-                    .route("/voltages", get!(infra::get_all_voltages))
-                    .route("/railjson", post!(infra::railjson::post_railjson))
-                    .nests("/{infra_id}", |path| {
-                        path.
-                            route("/", post!(infra::edition::edit)).route(
-                                "/split_track_section",
-                                post!(infra::edition::split_track_section),
-                            )
-                            .route("/railjson", get!(infra::railjson::get_railjson))
-                            .nests("/pathfinding", |path| {
-                                path.route("/blocks", post!(path::pathfinding::post))
-                            })
-                            .route("/path_properties", post!(path::properties::post))
-                            .nests("/objects", |path| {
-                                path.route("/{object_type}", post!(infra::objects::get_objects))
-                                    .route("/{object_type}/ids", get!(infra::objects::list_objects_ids))
-                            })
-                        .nests("/routes", |path| {
-                            path.route(
-                                "/track_ranges",
-                                get!(infra::routes::get_routes_track_ranges),
-                            )
-                            .route(
-                                "/{waypoint_type}/{waypoint_id}",
-                                get!(infra::routes::get_routes_from_waypoint),
-                            )
-                            .route("/nodes", post!(infra::routes::get_routes_nodes))
-                        })
-                        .nests("/lines", |path| {
-                            path.route("/{line_code}/bbox", get!(infra::lines::get_line_bbox))
-                        })
-                        .route("/auto_fixes", get!(infra::auto_fixes::list_auto_fixes))
-                        .route("/pathfinding", post!(infra::pathfinding::pathfinding_view))
-                        .route("/attached/{track_id}", get!(infra::attached::attached))
-                        .route("/errors", get!(infra::errors::list_errors))
-                        .route("/delimited_area", get!(infra::delimited_area::delimited_area))
-                        .route("/", get!(infra::get))
-                        .route("/load", post!(infra::load))
-                        .route("/", delete!(infra::delete))
-                        .route("/", put!(infra::put))
-                        .route("/clone", post!(infra::clone))
-                        .route("/lock", post!(infra::lock))
-                        .route("/unlock", post!(infra::unlock))
-                        .route("/speed_limit_tags", get!(infra::get_speed_limit_tags))
-                        .route("/voltages", get!(infra::get_voltages))
-                        .route("/switch_types", get!(infra::get_switch_types))
-                        .route(
-                            "/match_operational_points",
-                            post!(infra::match_operational_points),
-                        )
+
+            // operational studies
+            .nests("/documents", |path| {
+                path.route("/", post!(documents::post))
+                    .nests("/{document_key}", |path| {
+                        path.route("/", get!(documents::get))
+                            .route("/", delete!(documents::delete))
                     })
-            })
-            .nests("/layers", |path| {
-                path.route("/layer/{layer_slug}/mvt/{view_slug}", get!(layers::layer_view))
-                    .route("/tile/{layer_slug}/{view_slug}/{z}/{x}/{y}", get!(layers::cache_and_get_mvt_tile))
             })
             .nests("/projects", |path| {
                 path.route("/", post!(project::create))
@@ -253,12 +347,15 @@ fn routerv2() -> router::DocumentedRouter {
                             })
                     })
             })
+
+            // rolling stock
             .nests("/rolling_stock", |path| {
                 path.route("/", post!(rolling_stock::create))
                     .route(
                         "/power_restrictions",
                         get!(rolling_stock::get_power_restrictions),
                     )
+                    // /!\ Order
                     .nests("/name/{rolling_stock_name}", |path| {
                         path.route("/", get!(rolling_stock::get_by_name))
                     })
@@ -273,6 +370,7 @@ fn routerv2() -> router::DocumentedRouter {
             })
             .nests("/light_rolling_stock", |path| {
                 path.route("/", get!(rolling_stock::light::list))
+                    // /!\ Order
                     .route("/name/{rolling_stock_name}", get!(rolling_stock::light::get_by_name))
                     .route("/{rolling_stock_id}", get!(rolling_stock::light::get))
             })
@@ -285,103 +383,6 @@ fn routerv2() -> router::DocumentedRouter {
                             .route("/locked", patch!(rolling_stock::towed::patch_by_id_locked))
                     })
             })
-            .route("/search", post!(search::search))
-            .nests("/sprites", |path| {
-                path.route("/{signaling_system}/{file_name}", get!(sprites::sprites))
-                .route("/signaling_systems", get!(sprites::signaling_systems))
-            })
-            .nests("/stdcm/search_environment", |path| {
-                path.route("/", post!(stdcm_search_environment::create))
-                    .route("/", get!(stdcm_search_environment::retrieve_latest))
-                    .route("/list", get!(stdcm_search_environment::list))
-                    .route("/{env_id}", delete!(stdcm_search_environment::delete))
-            })
-            .nests("/work_schedules", |path| {
-                path.route("/", post!(work_schedules::create))
-                    .route("/project_path", post!(work_schedules::project_path))
-                    .nests("/group", |path| {
-                        path.route("/", post!(work_schedules::create_group))
-                            .route("/", get!(work_schedules::list_groups))
-                            .nests("/{id}", |path| {
-                                path.route("/", delete!(work_schedules::delete_group))
-                                    .route("/", get!(work_schedules::get_group))
-                                    .route("/", put!(work_schedules::put_in_group))
-                            })
-                    })
-            })
-            .route("/temporary_speed_limit_group", post!(temporary_speed_limits::create_temporary_speed_limit_group))
-            .nests("/timetable", |path| {
-                path.route("/", post!(timetable::post))
-                    .nests("/{id}", |path| {
-                        path.route("/", delete!(timetable::delete))
-                            .nests("/train_schedules", |path| {
-                                path.route("/", get!(timetable::get_train_schedules))
-                                    .route("/", post!(timetable::post_train_schedule))
-                            })
-                            .route("/conflicts", get!(timetable::conflicts))
-                            .nests("/paced_trains", |path| {
-                                path.route("/", get!(timetable::get_paced_trains))
-                                    .route("/", post!(timetable::post_paced_train))
-                            })
-                            .route("/stdcm", post!(timetable::stdcm::stdcm))
-                            .nests("/round_trips", |path| {
-                                path.nests("/train_schedules", |path| {
-                                    path.route("/", get!(round_trips::list_train_schedules))
-                                })
-                                .nests("/paced_trains", |path| {
-                                    path.route("/", get!(round_trips::list_paced_trains))
-                                })
-                            })
-                    })
-            })
-            .route("/stdcm_logs", get!(stdcm_logs::list_stdcm_logs))
-            .route("/stdcm_log", get!(stdcm_logs::stdcm_log_by_id_or_trace_id))
-            .nests("/round_trips", |path| {
-                path.nests("/train_schedules", |path| {
-                    path.route("/", post!(round_trips::post_train_schedules))
-                        .route("/delete", post!(round_trips::delete_train_schedules))
-                })
-                .nests("/paced_trains", |path| {
-                    path.route("/", post!(round_trips::post_paced_trains))
-                        .route("/delete", post!(round_trips::delete_paced_trains))
-                })
-            })
-            .nests("/sub_category", |path| {
-                path.route("/", get!(sub_categories::get_sub_categories))
-                    .route("/", post!(sub_categories::create_sub_categories))
-                    .nests("/{code}", |path| {
-                        path.route("/", delete!(sub_categories::delete_sub_category))
-                    })
-            })
-            .nests("/paced_train", |path| {
-                path.route("/", delete!(timetable::paced_train::delete))
-                    .route("/project_path", post!(timetable::paced_train::project_path))
-                    .route("/project_path_op", post!(timetable::paced_train::project_path_op))
-                    .route("/occupancy_blocks", post!(timetable::paced_train::occupancy_blocks))
-                    .route("/simulation_summary", post!(timetable::paced_train::simulation_summary))
-                    .nests("/{id}", |path| {
-                        path.route("/", get!(timetable::paced_train::get_by_id))
-                            .route("/", put!(timetable::paced_train::update_paced_train))
-                            .route("/path", get!(timetable::paced_train::get_path))
-                            .route("/simulation", get!(timetable::paced_train::simulation))
-                    })
-            })
-            .nests("/train_schedule", |path| {
-                path.route("/", delete!(timetable::train_schedule::delete))
-                    .route("/project_path", post!(timetable::train_schedule::project_path))
-                    .route("/project_path_op", post!(timetable::train_schedule::project_path_op))
-                    .route("/occupancy_blocks", post!(timetable::train_schedule::occupancy_blocks))
-                    .route("/track_occupancy", post!(timetable::train_schedule::track_occupancy))
-                    .route("/simulation_summary", post!(timetable::train_schedule::simulation_summary))
-                    .nests("/{id}", |path| {
-                        path.route("/", get!(timetable::train_schedule::get))
-                            .route("/", put!(timetable::train_schedule::put))
-                            .route("/simulation", get!(timetable::train_schedule::simulation))
-                            .route("/path", get!(timetable::train_schedule::get_path))
-                            .route("/etcs_braking_curves", get!(timetable::train_schedule::etcs_braking_curves))
-                    })
-            })
-            .route("/similar_trains", post!(timetable::similar_trains::similar_trains))
     })
 }
 

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -34,6 +34,7 @@ use editoast_common::Version;
 use fga::client::Limits;
 #[cfg(test)]
 pub(crate) use test_app::test_app;
+use tracing::Instrument;
 
 use ::core::str;
 use std::collections::HashSet;
@@ -914,7 +915,25 @@ impl AppState {
 impl Server {
     pub async fn new(config: ServerConfig) -> anyhow::Result<Self> {
         info!("Building server...");
-        let app_state = AppState::init(config).await?;
+        let router = tracing::debug_span!("router initialization").in_scope(|| {
+            let now = std::time::Instant::now();
+            let router = service_router().router;
+            let elapsed = now.elapsed();
+            tracing::debug!(time_ms = elapsed.as_millis(), "router initialized");
+            router
+        });
+        let app_state = tracing::info_span!("AppState initialization")
+            .in_scope(|| {
+                async move {
+                    let now = std::time::Instant::now();
+                    let app_state = AppState::init(config).await?;
+                    let elapsed = now.elapsed();
+                    tracing::debug!(time_ms = elapsed.as_millis(), "app state initialized");
+                    Ok::<_, anyhow::Error>(app_state)
+                }
+                .in_current_span()
+            })
+            .await?;
 
         // Custom Bytes and String extractor configuration
         let request_payload_limit = RequestBodyLimitLayer::new(250 * 1024 * 1024); // 250MiB
@@ -940,7 +959,7 @@ impl Server {
 
         // Configure the axum router
         let router: Router<()> = axum::Router::<AppState>::new()
-            .merge(service_router().router)
+            .merge(router)
             .route_layer(axum::middleware::from_fn_with_state(
                 app_state.clone(),
                 authentication_middleware,

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -120,6 +120,20 @@ fn routerv2() -> router::DocumentedRouter {
 
     router::DocumentedRouter::root(|path| {
         path.route("/health", get!(health))
+            .route("/version", get!(version))
+            .route("/version/core", get!(core_version))
+            .nests("/authz", |path| {
+                path.nests("/me", |path| {
+                    path.route("/privileges", post!(authz::user_privileges))
+                        .route("/grants", post!(authz::user_grants))
+                        .route("/", get!(authz::whoami))
+                })
+                .route("/grants", post!(authz::update_grants))
+                .route(
+                    "/{resource_type}/{resource_id}",
+                    get!(authz::subjects_with_grant_on_resource),
+                )
+            })
             .nests("/documents", |path| {
                 path.route("/", post!(documents::post))
                     .nests("/{document_key}", |path| {
@@ -127,34 +141,248 @@ fn routerv2() -> router::DocumentedRouter {
                             .route("/", delete!(documents::delete))
                     })
             })
+            .nests("/electrical_profile_set", |path| {
+                path.route("/", post!(electrical_profiles::post_electrical_profile))
+                    .route("/", get!(electrical_profiles::list))
+                    .nests("/{electrical_profile_set_id}", |path| {
+                        path.route("/", get!(electrical_profiles::get))
+                            .route("/", delete!(electrical_profiles::delete))
+                            .route("/level_order", get!(electrical_profiles::get_level_order))
+                    })
+            })
+            .route("/fonts/{font}/{glyph}", get!(fonts::fonts))
+            .nests("/infra", |path| {
+                path.route("/", get!(infra::list))
+                    .route("/", post!(infra::create))
+                    .route("/refresh", post!(infra::refresh))
+                    .route("/voltages", get!(infra::get_all_voltages))
+                    .route("/railjson", post!(infra::railjson::post_railjson))
+                    .nests("/{infra_id}", |path| {
+                        path.
+                            route("/", post!(infra::edition::edit)).route(
+                                "/split_track_section",
+                                post!(infra::edition::split_track_section),
+                            )
+                            .route("/railjson", get!(infra::railjson::get_railjson))
+                            .nests("/pathfinding", |path| {
+                                path.route("/blocks", post!(path::pathfinding::post))
+                            })
+                            .route("/path_properties", post!(path::properties::post))
+                            .nests("/objects", |path| {
+                                path.route("/{object_type}", post!(infra::objects::get_objects))
+                                    .route("/{object_type}/ids", get!(infra::objects::list_objects_ids))
+                            })
+                        .nests("/routes", |path| {
+                            path.route(
+                                "/track_ranges",
+                                get!(infra::routes::get_routes_track_ranges),
+                            )
+                            .route(
+                                "/{waypoint_type}/{waypoint_id}",
+                                get!(infra::routes::get_routes_from_waypoint),
+                            )
+                            .route("/nodes", post!(infra::routes::get_routes_nodes))
+                        })
+                        .nests("/lines", |path| {
+                            path.route("/{line_code}/bbox", get!(infra::lines::get_line_bbox))
+                        })
+                        .route("/auto_fixes", get!(infra::auto_fixes::list_auto_fixes))
+                        .route("/pathfinding", post!(infra::pathfinding::pathfinding_view))
+                        .route("/attached/{track_id}", get!(infra::attached::attached))
+                        .route("/errors", get!(infra::errors::list_errors))
+                        .route("/delimited_area", get!(infra::delimited_area::delimited_area))
+                        .route("/", get!(infra::get))
+                        .route("/load", post!(infra::load))
+                        .route("/", delete!(infra::delete))
+                        .route("/", put!(infra::put))
+                        .route("/clone", post!(infra::clone))
+                        .route("/lock", post!(infra::lock))
+                        .route("/unlock", post!(infra::unlock))
+                        .route("/speed_limit_tags", get!(infra::get_speed_limit_tags))
+                        .route("/voltages", get!(infra::get_voltages))
+                        .route("/switch_types", get!(infra::get_switch_types))
+                        .route(
+                            "/match_operational_points",
+                            post!(infra::match_operational_points),
+                        )
+                    })
+            })
+            .nests("/layers", |path| {
+                path.route("/layer/{layer_slug}/mvt/{view_slug}", get!(layers::layer_view))
+                    .route("/tile/{layer_slug}/{view_slug}/{z}/{x}/{y}", get!(layers::cache_and_get_mvt_tile))
+            })
+            .nests("/projects", |path| {
+                path.route("/", post!(project::create))
+                    .route("/", get!(project::list))
+                    .nests("/{project_id}", |path| {
+                        path.route("/", get!(project::get))
+                            .route("/", delete!(project::delete))
+                            .route("/", patch!(project::patch))
+                            .nests("/studies", |path| {
+                                path.route("/", post!(study::create))
+                                    .route("/", get!(study::list))
+                                    .nests("/{study_id}", |path| {
+                                        path.route("/", get!(study::get))
+                                            .route("/", delete!(study::delete))
+                                            .route("/", patch!(study::patch))
+                                            .nests("/scenarios", |path| {
+                                                path.route("/", post!(scenario::create))
+                                                    .route("/", get!(scenario::list))
+                                                    .nests("/{scenario_id}", |path| {
+                                                        path.route("/", get!(scenario::get))
+                                                            .route("/", delete!(scenario::delete))
+                                                            .route("/", patch!(scenario::patch))
+                                                            .nests("/macro_nodes", |path| {
+                                                                path.route("/", get!(scenario::macro_nodes::list))
+                                                                    .route("/", post!(scenario::macro_nodes::create))
+                                                                    .nests("/{node_id}", |path| {
+                                                                        path.route("/", get!(scenario::macro_nodes::get))
+                                                                            .route(
+                                                                                "/",
+                                                                                put!(scenario::macro_nodes::update),
+                                                                            )
+                                                                            .route(
+                                                                                "/",
+                                                                                delete!(scenario::macro_nodes::delete),
+                                                                            )
+                                                                    })
+                                                            })
+                                                    })
+                                            })
+                                    })
+                            })
+                    })
+            })
+            .nests("/rolling_stock", |path| {
+                path.route("/", post!(rolling_stock::create))
+                    .route(
+                        "/power_restrictions",
+                        get!(rolling_stock::get_power_restrictions),
+                    )
+                    .nests("/name/{rolling_stock_name}", |path| {
+                        path.route("/", get!(rolling_stock::get_by_name))
+                    })
+                    .nests("/{rolling_stock_id}", |path| {
+                        path.route("/", get!(rolling_stock::get))
+                            .route("/", patch!(rolling_stock::update))
+                            .route("/", delete!(rolling_stock::delete))
+                            .route("/locked", patch!(rolling_stock::update_locked))
+                            .route("/livery", post!(rolling_stock::create_livery))
+                            .route("/usage", get!(rolling_stock::get_usage))
+                    })
+            })
+            .nests("/light_rolling_stock", |path| {
+                path.route("/", get!(rolling_stock::light::list))
+                    .route("/name/{rolling_stock_name}", get!(rolling_stock::light::get_by_name))
+                    .route("/{rolling_stock_id}", get!(rolling_stock::light::get))
+            })
+            .nests("/towed_rolling_stock", |path| {
+                path.route("/", get!(rolling_stock::towed::get_list))
+                    .route("/", post!(rolling_stock::towed::post))
+                    .nests("/{towed_rolling_stock_id}", |path| {
+                        path.route("/", get!(rolling_stock::towed::get_by_id))
+                            .route("/", patch!(rolling_stock::towed::patch_by_id))
+                            .route("/locked", patch!(rolling_stock::towed::patch_by_id_locked))
+                    })
+            })
+            .route("/search", post!(search::search))
+            .nests("/sprites", |path| {
+                path.route("/{signaling_system}/{file_name}", get!(sprites::sprites))
+                .route("/signaling_systems", get!(sprites::signaling_systems))
+            })
+            .nests("/stdcm/search_environment", |path| {
+                path.route("/", post!(stdcm_search_environment::create))
+                    .route("/", get!(stdcm_search_environment::retrieve_latest))
+                    .route("/list", get!(stdcm_search_environment::list))
+                    .route("/{env_id}", delete!(stdcm_search_environment::delete))
+            })
+            .nests("/work_schedules", |path| {
+                path.route("/", post!(work_schedules::create))
+                    .route("/project_path", post!(work_schedules::project_path))
+                    .nests("/group", |path| {
+                        path.route("/", post!(work_schedules::create_group))
+                            .route("/", get!(work_schedules::list_groups))
+                            .nests("/{id}", |path| {
+                                path.route("/", delete!(work_schedules::delete_group))
+                                    .route("/", get!(work_schedules::get_group))
+                                    .route("/", put!(work_schedules::put_in_group))
+                            })
+                    })
+            })
+            .route("/temporary_speed_limit_group", post!(temporary_speed_limits::create_temporary_speed_limit_group))
+            .nests("/timetable", |path| {
+                path.route("/", post!(timetable::post))
+                    .nests("/{id}", |path| {
+                        path.route("/", delete!(timetable::delete))
+                            .nests("/train_schedules", |path| {
+                                path.route("/", get!(timetable::get_train_schedules))
+                                    .route("/", post!(timetable::post_train_schedule))
+                            })
+                            .route("/conflicts", get!(timetable::conflicts))
+                            .nests("/paced_trains", |path| {
+                                path.route("/", get!(timetable::get_paced_trains))
+                                    .route("/", post!(timetable::post_paced_train))
+                            })
+                            .route("/stdcm", post!(timetable::stdcm::stdcm))
+                            .nests("/round_trips", |path| {
+                                path.nests("/train_schedules", |path| {
+                                    path.route("/", get!(round_trips::list_train_schedules))
+                                })
+                                .nests("/paced_trains", |path| {
+                                    path.route("/", get!(round_trips::list_paced_trains))
+                                })
+                            })
+                    })
+            })
+            .route("/stdcm_logs", get!(stdcm_logs::list_stdcm_logs))
+            .route("/stdcm_log", get!(stdcm_logs::stdcm_log_by_id_or_trace_id))
+            .nests("/round_trips", |path| {
+                path.nests("/train_schedules", |path| {
+                    path.route("/", post!(round_trips::post_train_schedules))
+                        .route("/delete", post!(round_trips::delete_train_schedules))
+                })
+                .nests("/paced_trains", |path| {
+                    path.route("/", post!(round_trips::post_paced_trains))
+                        .route("/delete", post!(round_trips::delete_paced_trains))
+                })
+            })
+            .nests("/sub_category", |path| {
+                path.route("/", get!(sub_categories::get_sub_categories))
+                    .route("/", post!(sub_categories::create_sub_categories))
+                    .nests("/{code}", |path| {
+                        path.route("/", delete!(sub_categories::delete_sub_category))
+                    })
+            })
+            .nests("/paced_train", |path| {
+                path.route("/", delete!(timetable::paced_train::delete))
+                    .route("/project_path", post!(timetable::paced_train::project_path))
+                    .route("/project_path_op", post!(timetable::paced_train::project_path_op))
+                    .route("/occupancy_blocks", post!(timetable::paced_train::occupancy_blocks))
+                    .route("/simulation_summary", post!(timetable::paced_train::simulation_summary))
+                    .nests("/{id}", |path| {
+                        path.route("/", get!(timetable::paced_train::get_by_id))
+                            .route("/", put!(timetable::paced_train::update_paced_train))
+                            .route("/path", get!(timetable::paced_train::get_path))
+                            .route("/simulation", get!(timetable::paced_train::simulation))
+                    })
+            })
+            .nests("/train_schedule", |path| {
+                path.route("/", delete!(timetable::train_schedule::delete))
+                    .route("/project_path", post!(timetable::train_schedule::project_path))
+                    .route("/project_path_op", post!(timetable::train_schedule::project_path_op))
+                    .route("/occupancy_blocks", post!(timetable::train_schedule::occupancy_blocks))
+                    .route("/track_occupancy", post!(timetable::train_schedule::track_occupancy))
+                    .route("/simulation_summary", post!(timetable::train_schedule::simulation_summary))
+                    .nests("/{id}", |path| {
+                        path.route("/", get!(timetable::train_schedule::get))
+                            .route("/", put!(timetable::train_schedule::put))
+                            .route("/simulation", get!(timetable::train_schedule::simulation))
+                            .route("/path", get!(timetable::train_schedule::get_path))
+                            .route("/etcs_braking_curves", get!(timetable::train_schedule::etcs_braking_curves))
+                    })
+            })
+            .route("/similar_trains", post!(timetable::similar_trains::similar_trains))
     })
-}
-
-crate::routes! {
-    fn router();
-    fn openapi_paths();
-
-    "/version" => version,
-    "/version/core" => core_version,
-
-    &authz,
-    &electrical_profiles,
-    &fonts,
-    &infra,
-    &layers,
-    &project,
-    &rolling_stock,
-    &search,
-    &sprites,
-    &stdcm_search_environment,
-    &work_schedules,
-    &temporary_speed_limits,
-    &timetable,
-    &path,
-    &stdcm_logs,
-    &scenario,
-    &round_trips,
-    &sub_categories,
 }
 
 editoast_common::schemas! {
@@ -489,25 +717,27 @@ pub async fn check_health(
     Ok(())
 }
 
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     responses(
         (status = 200, description = "Return the service version", body = Version),
     ),
 )]
-async fn version() -> Json<Version> {
+pub(in crate::views) async fn version() -> Json<Version> {
     Json(Version {
         git_describe: get_app_version(),
     })
 }
 
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     responses(
         (status = 200, description = "Return the core service version", body = Version),
     ),
 )]
-async fn core_version(State(core): State<Arc<CoreClient>>) -> Json<Version> {
+pub(in crate::views) async fn core_version(State(core): State<Arc<CoreClient>>) -> Json<Version> {
     let response = CoreVersionRequest {}.fetch(&core).await;
     let response = response.unwrap_or(Version { git_describe: None });
     Json(response)
@@ -710,7 +940,6 @@ impl Server {
         // Configure the axum router
         let router: Router<()> = axum::Router::<AppState>::new()
             .merge(routerv2().router)
-            .merge(router())
             .route_layer(axum::middleware::from_fn_with_state(
                 app_state.clone(),
                 authentication_middleware,

--- a/editoast/src/views/openapi.rs
+++ b/editoast/src/views/openapi.rs
@@ -455,24 +455,19 @@ impl OpenApiRoot {
     }
 
     fn insert_routes(openapi: &mut utoipa::openapi::OpenApi) {
-        let paths = crate::views::openapi_paths()
-            .into_flat_path_list()
+        let paths = routerv2()
+            .path_trees
             .into_iter()
-            .chain(
-                routerv2()
-                    .path_trees
-                    .into_iter()
-                    .flat_map(|t| t.flatten())
-                    .map(|(parts, item)| {
-                        (
-                            parts
-                                .into_iter()
-                                .map(String::from)
-                                .fold(String::new(), concat_path),
-                            item,
-                        )
-                    }),
-            );
+            .flat_map(|t| t.flatten())
+            .map(|(parts, item)| {
+                (
+                    parts
+                        .into_iter()
+                        .map(String::from)
+                        .fold(String::new(), concat_path),
+                    item,
+                )
+            });
         for (mut path, path_item) in paths {
             // We are required by axum to have trailing slashes in the `Router`s.
             // But that's not OpenApi compliant, so we remove them here.

--- a/editoast/src/views/openapi.rs
+++ b/editoast/src/views/openapi.rs
@@ -18,6 +18,7 @@ use utoipa::openapi::schema::AnyOf;
 
 use crate::AppState;
 use crate::error::ErrorDefinition;
+use crate::views::routerv2;
 
 #[derive(Debug)]
 pub struct OpenApiPathScope {
@@ -66,6 +67,14 @@ where
     }
 }
 
+fn concat_path<A: AsRef<str>, B: AsRef<str>>(a: A, b: B) -> String {
+    let (a, b) = (a.as_ref(), b.as_ref());
+    match (a.ends_with('/'), b.starts_with('/')) {
+        (true, true) => format!("{}{}", a, &b[1..]),
+        _ => format!("{a}{b}"),
+    }
+}
+
 #[allow(unused)]
 impl OpenApiPathScope {
     pub fn new(prefix: Option<&'static str>) -> Self {
@@ -89,14 +98,6 @@ impl OpenApiPathScope {
     pub fn into_flat_path_list(self) -> Vec<(String, PathItem)> {
         let prefix = self.prefix.unwrap_or_default();
         let mut paths = Vec::new();
-
-        fn concat_path<A: AsRef<str>, B: AsRef<str>>(a: A, b: B) -> String {
-            let (a, b) = (a.as_ref(), b.as_ref());
-            match (a.ends_with('/'), b.starts_with('/')) {
-                (true, true) => format!("{}{}", a, &b[1..]),
-                _ => format!("{a}{b}"),
-            }
-        }
 
         for item in self.paths {
             match item {
@@ -454,8 +455,25 @@ impl OpenApiRoot {
     }
 
     fn insert_routes(openapi: &mut utoipa::openapi::OpenApi) {
-        let paths = crate::views::openapi_paths();
-        for (mut path, path_item) in paths.into_flat_path_list() {
+        let paths = crate::views::openapi_paths()
+            .into_flat_path_list()
+            .into_iter()
+            .chain(
+                routerv2()
+                    .path_trees
+                    .into_iter()
+                    .flat_map(|t| t.flatten())
+                    .map(|(parts, item)| {
+                        (
+                            parts
+                                .into_iter()
+                                .map(String::from)
+                                .fold(String::new(), concat_path),
+                            item,
+                        )
+                    }),
+            );
+        for (mut path, path_item) in paths {
             // We are required by axum to have trailing slashes in the `Router`s.
             // But that's not OpenApi compliant, so we remove them here.
             if path.ends_with('/') {

--- a/editoast/src/views/openapi.rs
+++ b/editoast/src/views/openapi.rs
@@ -1,6 +1,4 @@
 use std::collections::BTreeMap;
-use std::collections::VecDeque;
-use std::convert::Infallible;
 
 use itertools::Itertools as _;
 use tracing::debug;
@@ -16,101 +14,14 @@ use utoipa::openapi::Schema;
 use utoipa::openapi::path::PathItemBuilder;
 use utoipa::openapi::schema::AnyOf;
 
-use crate::AppState;
 use crate::error::ErrorDefinition;
-use crate::views::routerv2;
-
-#[derive(Debug)]
-pub struct OpenApiPathScope {
-    pub prefix: Option<&'static str>,
-    pub paths: VecDeque<Dispatch>,
-}
-
-#[allow(unused)]
-pub enum Dispatch {
-    Path(String, PathItem),
-    Scope(Box<OpenApiPathScope>),
-}
-
-impl std::fmt::Debug for Dispatch {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Dispatch::Path(p, _) => write!(f, "Path({p:?})"),
-            Dispatch::Scope(r) => write!(f, "Scope({:?})", *r),
-        }
-    }
-}
-
-/// Generates an `axum::MethodRouter` based on an HTTP method
-pub(in crate::views) fn make_method_router<P, H, T>(
-    handler: H,
-) -> axum::routing::MethodRouter<AppState, Infallible>
-where
-    P: utoipa::Path,
-    H: axum::handler::Handler<T, AppState>,
-    T: 'static,
-{
-    let path_item = P::path_item(None);
-    let method = path_item.operations.first_key_value().expect("lolz").0;
-    match *method {
-        utoipa::openapi::PathItemType::Get => axum::routing::get(handler),
-        utoipa::openapi::PathItemType::Post => axum::routing::post(handler),
-        utoipa::openapi::PathItemType::Put => axum::routing::put(handler),
-        utoipa::openapi::PathItemType::Delete => axum::routing::delete(handler),
-        utoipa::openapi::PathItemType::Options => axum::routing::options(handler),
-        utoipa::openapi::PathItemType::Head => axum::routing::head(handler),
-        utoipa::openapi::PathItemType::Patch => axum::routing::patch(handler),
-        utoipa::openapi::PathItemType::Trace => axum::routing::trace(handler),
-        utoipa::openapi::PathItemType::Connect => {
-            unimplemented!("cannot define endpoints using the CONNECT method")
-        }
-    }
-}
+use crate::views::service_router;
 
 fn concat_path<A: AsRef<str>, B: AsRef<str>>(a: A, b: B) -> String {
     let (a, b) = (a.as_ref(), b.as_ref());
     match (a.ends_with('/'), b.starts_with('/')) {
         (true, true) => format!("{}{}", a, &b[1..]),
         _ => format!("{a}{b}"),
-    }
-}
-
-#[allow(unused)]
-impl OpenApiPathScope {
-    pub fn new(prefix: Option<&'static str>) -> Self {
-        Self {
-            prefix,
-            paths: VecDeque::new(),
-        }
-    }
-
-    pub fn route<P: utoipa::Path>(mut self) -> Self {
-        self.paths
-            .push_back(Dispatch::Path(P::path(), P::path_item(None)));
-        self
-    }
-
-    pub fn scope(mut self, scope: Self) -> Self {
-        self.paths.push_back(Dispatch::Scope(Box::new(scope)));
-        self
-    }
-
-    pub fn into_flat_path_list(self) -> Vec<(String, PathItem)> {
-        let prefix = self.prefix.unwrap_or_default();
-        let mut paths = Vec::new();
-
-        for item in self.paths {
-            match item {
-                Dispatch::Path(path, pathitem) => paths.push((concat_path(prefix, path), pathitem)),
-                Dispatch::Scope(scope) => paths.extend(
-                    &mut scope
-                        .into_flat_path_list()
-                        .into_iter()
-                        .map(|(path, pathitem)| (concat_path(prefix, path), pathitem)),
-                ),
-            }
-        }
-        paths
     }
 }
 
@@ -142,133 +53,6 @@ fn merge_path_items(a: PathItem, b: PathItem) -> PathItem {
         builder = builder.operation(method, operation);
     }
     builder.build()
-}
-
-/// A macro that given a tree of routes, generates two functions. One building
-/// an `axum::Router` and another building an [OpenApiPathScope] object.
-///
-/// This macro is useful to locally define a tree of routes instead of listing
-/// them all when building the web service. Both functions can be nested
-/// using `&submodule`.
-///
-/// Also note that the order of the services will be kept the same, so you might
-/// encounter the classic issue that the first route that matches a request
-/// will be used instead of the one you expect because of the order of the services.
-///
-/// Finally, all the endpoints used in this macro **MUST** be annotated using
-/// `#[utoipa::path(method, path = "", ...)]`.
-///
-/// # /!\ Warning /!\
-///
-/// **ALL ITEMS OF THIS MACROS MUST END WITH A COMMA `,`!!!!!!!!!!!!!!!**
-///
-/// # Example
-/// ```
-/// routes! {
-///     "/infra" => {
-///         cache_status,
-///         "/{infra}" => {
-///             load,
-///             get,
-///         },
-///         &sub_module,
-///         other_endpoint,
-///     },
-/// }
-/// ```
-#[macro_export]
-macro_rules! routes {
-    // TODO: apply the same pattern than schemas! with the three item types: ident, &path and expr
-    (@utoipa_type $route:ident) => { paste::paste! { [<__path_ $route>] } };
-    (@method_of $route:ident) => {
-        $crate::views::openapi::make_method_router::<$crate::routes!(@utoipa_type $route), _, _>(
-            $route
-        )
-    };
-
-    // end of recursion, return the built expression
-    (@router [$router:expr]) => { $router };
-    (@openapi [$paths:expr]) => { $paths };
-
-    // collect the endpoint and continue
-    (@router [$router:expr] $route:ident , $($rest:tt)*) => {
-        $crate::routes!(@router
-            [$router.route("/", $crate::routes!(@method_of $route))]
-            $($rest)*
-        )
-    };
-    // retrieve the openapi data of the endpoint and continue
-    (@openapi [$paths:expr] $route:ident , $($rest:tt)*) => {
-        $crate::routes!(@openapi
-            [$paths.route::<$crate::routes!(@utoipa_type $route)>()]
-            $($rest)*
-        )
-    };
-
-    // create a scope, recurse within the scope, and continue collecting at the same level
-    (@router [$router:expr] $prefix:literal => {$($tt:tt)+} , $($rest:tt)*) => {
-        $crate::routes!(@router
-            [$router.nest(
-                &$prefix,
-                $crate::routes!(@router [axum::Router::<$crate::AppState>::new()] $($tt)+)
-            )]
-            $($rest)*
-        )
-    };
-    // ditto
-    (@openapi [$paths:expr] $prefix:literal => {$($tt:tt)+} , $($rest:tt)*) => {
-        $crate::routes!(@openapi
-            [$paths.scope(
-                $crate::routes!(@openapi
-                    [$crate::views::openapi::OpenApiPathScope::new(Some($prefix))]
-                    $($tt)+
-                )
-            )]
-            $($rest)*
-        )
-    };
-
-    // syntactic sugar for single scoped endpoint
-    (@router [$router:expr] $prefix:literal => $route:ident , $($rest:tt)*) => {
-        $crate::routes!(@router [$router] $prefix => { $route , } , $($rest)*)
-    };
-    (@openapi [$paths:expr] $prefix:literal => $route:ident , $($rest:tt)*) => {
-        $crate::routes!(@openapi [$paths] $prefix => { $route , } , $($rest)*)
-    };
-
-    // include a submodule
-    (@router [$router:expr] & $sub_module:ident , $($rest:tt)*) => {
-        $crate::routes!(@router [$router.merge($sub_module::router())] $($rest)*)
-    };
-    (@openapi [$paths:expr] & $sub_module:ident , $($rest:tt)*) => {
-        $crate::routes!(@openapi [$paths.scope($sub_module::openapi_paths())] $($rest)*)
-    };
-
-    // error handling to avoid falling back to the macro entry point and get recursion errors
-    (@router $($tt:tt)*) => { compile_error!(stringify!("routes!: could not parse @router: " $($tt)*)) };
-    (@openapi $($tt:tt)*) => { compile_error!(stringify!("routes!: could not parse @openapi: " $($tt)*)) };
-
-    // entry points
-    (
-        $router_vis:vis fn $router:ident ();
-        $openapi_paths_vis:vis fn $openapi_paths:ident ();
-        $($tt:tt)*
-    ) => {
-        $router_vis fn $router() -> axum::Router<$crate::AppState> {
-            $crate::routes!(@router [axum::Router::<$crate::AppState>::new()] $($tt)*)
-        }
-
-        $openapi_paths_vis fn $openapi_paths() -> $crate::views::openapi::OpenApiPathScope {
-            $crate::routes!(@openapi [$crate::views::openapi::OpenApiPathScope::new(None)] $($tt)*)
-        }
-    };
-    ($($tt:tt)*) => {
-        $crate::routes! {
-            pub(in $crate::views) fn router();
-            pub(in $crate::views) fn openapi_paths();
-            $($tt)*
-        }
-    }
 }
 
 fn remove_discriminator(schema: &mut RefOr<Schema>) {
@@ -455,7 +239,7 @@ impl OpenApiRoot {
     }
 
     fn insert_routes(openapi: &mut utoipa::openapi::OpenApi) {
-        let paths = routerv2()
+        let paths = service_router()
             .path_trees
             .into_iter()
             .flat_map(|t| t.flatten())

--- a/editoast/src/views/path.rs
+++ b/editoast/src/views/path.rs
@@ -14,11 +14,6 @@ use crate::error::Result;
 use crate::models::Infra;
 use crate::models::prelude::*;
 
-crate::routes! {
-    &properties,
-    &pathfinding,
-}
-
 editoast_common::schemas! {
     pathfinding::schemas(),
     projection::schemas(),

--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -44,10 +44,6 @@ use crate::views::get_app_version;
 use crate::views::path::PathfindingError;
 use crate::views::path::path_item_cache::PathItemCache;
 
-crate::routes! {
-    "/infra/{infra_id}/pathfinding/blocks" => post,
-}
-
 editoast_common::schemas! {
     PathfindingInput,
     PathfindingFailure,
@@ -57,7 +53,7 @@ editoast_common::schemas! {
 /// Path input is described by some rolling stock information
 /// and a list of path waypoints
 #[derive(Deserialize, Clone, Debug, Hash, ToSchema)]
-struct PathfindingInput {
+pub(in crate::views) struct PathfindingInput {
     /// The loading gauge of the rolling stock
     rolling_stock_loading_gauge: LoadingGaugeType,
     /// Can the rolling stock run on non-electrified tracks
@@ -176,6 +172,7 @@ pub enum PathfindingFailure {
 }
 
 /// Compute a pathfinding
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "pathfinding",
@@ -187,7 +184,7 @@ pub enum PathfindingFailure {
         (status = 200, description = "Pathfinding Result", body = PathfindingResult),
     ),
 )]
-async fn post(
+pub(in crate::views) async fn post(
     State(AppState {
         db_pool,
         valkey,

--- a/editoast/src/views/path/properties.rs
+++ b/editoast/src/views/path/properties.rs
@@ -41,10 +41,6 @@ use crate::error::Result;
 use crate::views::AuthenticationExt;
 use crate::views::path::retrieve_infra_version;
 
-crate::routes! {
-    "/infra/{infra_id}/path_properties" => post,
-}
-
 editoast_common::schemas! {
     PathProperties,
     PathPropertiesInput,
@@ -61,7 +57,7 @@ pub struct PathPropertiesInput {
 
 /// Properties along a path. Each property is optional since it depends on what the user requests.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, Default)]
-struct PathProperties {
+pub(in crate::views) struct PathProperties {
     #[schema(inline)]
     /// Slopes along the path
     slopes: Option<PropertyValuesF64>,
@@ -113,7 +109,7 @@ impl PathProperties {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-struct Props {
+pub(in crate::views) struct Props {
     props: Vec<Property>,
 }
 
@@ -130,7 +126,7 @@ impl From<Props> for Properties {
 /// Enum representing the various associated properties that can be returned
 #[derive(Debug, Serialize, Deserialize, ToSchema, EnumSetType)]
 #[serde(rename_all = "snake_case")]
-enum Property {
+pub(in crate::views) enum Property {
     Slopes,
     Curves,
     Electrifications,
@@ -142,6 +138,7 @@ enum Property {
 type Properties = EnumSet<Property>;
 
 /// Compute path properties
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "pathfinding",
@@ -154,7 +151,7 @@ type Properties = EnumSet<Property>;
         (status = 200, description = "Path properties", body = PathProperties),
     ),
 )]
-async fn post(
+pub(in crate::views) async fn post(
     State(AppState {
         db_pool,
         valkey,

--- a/editoast/src/views/project.rs
+++ b/editoast/src/views/project.rs
@@ -35,19 +35,6 @@ use crate::models::Update;
 use crate::views::AuthorizationError;
 use crate::views::pagination::PaginationQueryParams;
 
-crate::routes! {
-    "/projects" => {
-        create,
-        list,
-        "/{project_id}" => {
-            get,
-            delete,
-            patch,
-            &study,
-        },
-    },
-}
-
 editoast_common::schemas! {
     ProjectCreateForm,
     ProjectPatchForm,
@@ -76,7 +63,7 @@ pub enum ProjectError {
 
 /// Creation form for a project
 #[derive(Serialize, Deserialize, Default, ToSchema)]
-struct ProjectCreateForm {
+pub(in crate::views) struct ProjectCreateForm {
     #[schema(max_length = 128)]
     pub name: String,
     #[schema(max_length = 1024)]
@@ -144,6 +131,7 @@ impl ProjectWithStudyCount {
 }
 
 /// Create a new project
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "projects",
@@ -152,7 +140,7 @@ impl ProjectWithStudyCount {
         (status = 201, body = ProjectWithStudies, description = "The created project"),
     )
 )]
-async fn create(
+pub(in crate::views) async fn create(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Json(project_create_form): Json<ProjectCreateForm>,
@@ -177,7 +165,7 @@ async fn create(
 
 #[derive(Serialize, ToSchema)]
 #[cfg_attr(test, derive(Deserialize))]
-struct ProjectWithStudyCountList {
+pub(in crate::views) struct ProjectWithStudyCountList {
     #[schema(value_type = Vec<ProjectWithStudies>)]
     results: Vec<ProjectWithStudyCount>,
     #[serde(flatten)]
@@ -185,6 +173,7 @@ struct ProjectWithStudyCountList {
 }
 
 /// Returns a paginated list of projects
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "projects",
@@ -193,7 +182,7 @@ struct ProjectWithStudyCountList {
         (status = 200, body = inline(ProjectWithStudyCountList), description = "The list of projects"),
     )
 )]
-async fn list(
+pub(in crate::views) async fn list(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Query(pagination_params): Query<PaginationQueryParams<1000>>,
@@ -235,6 +224,7 @@ pub struct ProjectIdParam {
 }
 
 /// Retrieve a project
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "projects",
@@ -244,7 +234,7 @@ pub struct ProjectIdParam {
         (status = 404, body = InternalError, description = "The requested project was not found"),
     )
 )]
-async fn get(
+pub(in crate::views) async fn get(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(project_id): Path<i64>,
@@ -267,6 +257,7 @@ async fn get(
 }
 
 /// Delete a project
+#[editoast_derive::route]
 #[utoipa::path(
     delete, path = "",
     tag = "projects",
@@ -276,7 +267,7 @@ async fn get(
         (status = 404, body = InternalError, description = "The requested project was not found"),
     )
 )]
-async fn delete(
+pub(in crate::views) async fn delete(
     Path(project_id): Path<i64>,
     Extension(auth): AuthenticationExt,
     State(db_pool): State<DbConnectionPoolV2>,
@@ -310,7 +301,7 @@ async fn delete(
 
 /// Patch form for a project
 #[derive(Serialize, Deserialize, ToSchema)]
-struct ProjectPatchForm {
+pub(in crate::views) struct ProjectPatchForm {
     #[schema(max_length = 128)]
     pub name: Option<String>,
     #[schema(max_length = 1024)]
@@ -346,6 +337,7 @@ impl From<ProjectPatchForm> for Changeset<Project> {
 }
 
 /// Update a project
+#[editoast_derive::route]
 #[utoipa::path(
     patch, path = "",
     tag = "projects",
@@ -359,7 +351,7 @@ impl From<ProjectPatchForm> for Changeset<Project> {
         (status = 404, body = InternalError, description = "The requested project was not found"),
     )
 )]
-async fn patch(
+pub(in crate::views) async fn patch(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(project_id): Path<i64>,

--- a/editoast/src/views/rolling_stock.rs
+++ b/editoast/src/views/rolling_stock.rs
@@ -1,6 +1,6 @@
-pub mod form;
-pub mod light;
-mod towed;
+pub(in crate::views) mod form;
+pub(in crate::views) mod light;
+pub(in crate::views) mod towed;
 
 use editoast_models::model;
 pub use form::RollingStockForm;
@@ -43,24 +43,6 @@ use crate::models::rolling_stock::ScenarioReference;
 use crate::models::rolling_stock_livery::RollingStockLivery;
 use crate::views::AuthenticationExt;
 use crate::views::AuthorizationError;
-
-crate::routes! {
-    "/rolling_stock" => {
-        create,
-        "/power_restrictions" => get_power_restrictions,
-        "/name/{rolling_stock_name}" => get_by_name,
-        "/{rolling_stock_id}" => {
-            get,
-            update,
-            delete,
-            "/locked" => update_locked,
-            "/livery" => create_livery,
-            "/usage" => get_usage,
-        },
-    },
-    &light,
-    &towed,
-}
 
 editoast_common::schemas! {
     RollingStockForm,
@@ -204,6 +186,7 @@ pub struct RollingStockNameParam {
 }
 
 /// Get a rolling stock by Id
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "rolling_stock",
@@ -212,7 +195,7 @@ pub struct RollingStockNameParam {
         (status = 200, body = RollingStockWithLiveries, description = "The requested rolling stock"),
     )
 )]
-async fn get(
+pub(in crate::views) async fn get(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(rolling_stock_id): Path<i64>,
@@ -235,6 +218,7 @@ async fn get(
 }
 
 /// Get a rolling stock by name
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "rolling_stock",
@@ -243,7 +227,7 @@ async fn get(
         (status = 200, body = RollingStockWithLiveries, description = "The requested rolling stock"),
     )
 )]
-async fn get_by_name(
+pub(in crate::views) async fn get_by_name(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(rolling_stock_name): Path<String>,
@@ -267,6 +251,7 @@ async fn get_by_name(
 }
 
 /// Returns the set of power restrictions for all rolling_stocks modes.
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "rolling_stock",
@@ -274,7 +259,7 @@ async fn get_by_name(
         (status = 200, description = "Retrieve the power restrictions list", body = Vec<String>)
     )
 )]
-async fn get_power_restrictions(
+pub(in crate::views) async fn get_power_restrictions(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
 ) -> Result<Json<Vec<String>>> {
@@ -297,12 +282,13 @@ async fn get_power_restrictions(
 
 #[derive(Debug, Deserialize, IntoParams, ToSchema)]
 #[into_params(parameter_in = Query)]
-struct PostRollingStockQueryParams {
+pub(in crate::views) struct PostRollingStockQueryParams {
     #[serde(default)]
     locked: bool,
 }
 
 /// Create a rolling stock
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "rolling_stock",
@@ -312,7 +298,7 @@ struct PostRollingStockQueryParams {
         (status = 200, description = "The created rolling stock", body = RollingStock)
     )
 )]
-async fn create(
+pub(in crate::views) async fn create(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Query(query_params): Query<PostRollingStockQueryParams>,
@@ -341,6 +327,7 @@ async fn create(
 }
 
 /// Patch a rolling stock
+#[editoast_derive::route]
 #[utoipa::path(
     patch, path = "",
     tag = "rolling_stock",
@@ -350,7 +337,7 @@ async fn create(
         (status = 200, description = "The created rolling stock", body = RollingStockWithLiveries)
     )
 )]
-async fn update(
+pub(in crate::views) async fn update(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(rolling_stock_id): Path<i64>,
@@ -411,13 +398,14 @@ async fn update(
 
 #[derive(Deserialize, IntoParams, ToSchema)]
 #[into_params(parameter_in = Query)]
-struct DeleteRollingStockQueryParams {
+pub(in crate::views) struct DeleteRollingStockQueryParams {
     /// force the deletion even if it's used
     #[serde(default)]
     force: bool,
 }
 
 /// Delete a rolling_stock and all entities linked to it
+#[editoast_derive::route]
 #[utoipa::path(
     delete, path = "",
     tag = "rolling_stock",
@@ -429,7 +417,7 @@ struct DeleteRollingStockQueryParams {
         (status = 409, description = "The requested rolling stock is used"),
     )
 )]
-async fn delete(
+pub(in crate::views) async fn delete(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(rolling_stock_id): Path<i64>,
@@ -481,12 +469,13 @@ async fn delete_rolling_stock(conn: &mut DbConnection, rolling_stock_id: i64) ->
 
 #[derive(Debug, Deserialize, ToSchema)]
 #[serde(deny_unknown_fields)]
-struct RollingStockLockedUpdateForm {
+pub(in crate::views) struct RollingStockLockedUpdateForm {
     /// New locked value
     pub locked: bool,
 }
 
 /// Update rolling_stock locked field
+#[editoast_derive::route]
 #[utoipa::path(
     patch, path = "",
     tag = "rolling_stock",
@@ -496,7 +485,7 @@ struct RollingStockLockedUpdateForm {
         (status = 204, description = "No content when successful")
     )
 )]
-async fn update_locked(
+pub(in crate::views) async fn update_locked(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(rolling_stock_id): Path<i64>,
@@ -568,6 +557,7 @@ async fn parse_multipart_content(
 }
 
 /// Create a rolling stock livery
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "rolling_stock,rolling_stock_livery",
@@ -578,7 +568,7 @@ async fn parse_multipart_content(
         (status = 404, description = "The requested rolling stock was not found"),
     )
 )]
-async fn create_livery(
+pub(in crate::views) async fn create_livery(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(rolling_stock_id): Path<i64>,
@@ -637,6 +627,7 @@ async fn create_livery(
 }
 
 /// List the scenarios (and their respective studies and projects) which use a given rolling stock.
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "rolling_stock",
@@ -646,7 +637,7 @@ async fn create_livery(
         (status = 404, description = "The requested rolling stock was not found"),
     )
 )]
-pub async fn get_usage(
+pub(in crate::views) async fn get_usage(
     State(db_pool): State<DbConnectionPoolV2>,
     Path(rolling_stock_id): Path<i64>,
 ) -> Result<Json<Vec<ScenarioReference>>> {

--- a/editoast/src/views/rolling_stock/light.rs
+++ b/editoast/src/views/rolling_stock/light.rs
@@ -48,14 +48,6 @@ use serde::Deserialize;
 use super::AuthenticationExt;
 use super::AuthorizationError;
 
-crate::routes! {
-    "/light_rolling_stock" => {
-        list,
-        "/name/{rolling_stock_name}" => get_by_name,
-        "/{rolling_stock_id}" => get,
-    },
-}
-
 editoast_common::schemas! {
     LightEffortCurves,
     LightModeEffortCurves,
@@ -65,7 +57,7 @@ editoast_common::schemas! {
 
 #[derive(Debug, Serialize, ToSchema)]
 #[cfg_attr(test, derive(Deserialize))]
-struct LightRollingStockWithLiveries {
+pub(in crate::views) struct LightRollingStockWithLiveries {
     #[serde(flatten)]
     rolling_stock: LightRollingStock,
     #[schema(value_type = Vec<RollingStockLivery>)]
@@ -93,7 +85,7 @@ impl LightRollingStockWithLiveries {
 
 #[derive(Serialize, ToSchema)]
 #[cfg_attr(test, derive(Deserialize))]
-struct LightRollingStockWithLiveriesCountList {
+pub(in crate::views) struct LightRollingStockWithLiveriesCountList {
     #[schema(value_type = Vec<LightRollingStockWithLiveries>)]
     results: Vec<LightRollingStockWithLiveries>,
     #[serde(flatten)]
@@ -101,6 +93,7 @@ struct LightRollingStockWithLiveriesCountList {
 }
 
 /// Paginated list of rolling stock with a lighter response
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "rolling_stock",
@@ -109,7 +102,7 @@ struct LightRollingStockWithLiveriesCountList {
         (status = 200, body = inline(LightRollingStockWithLiveriesCountList)),
     )
 )]
-async fn list(
+pub(in crate::views) async fn list(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Query(page_settings): Query<PaginationQueryParams<1000>>,
@@ -142,6 +135,7 @@ async fn list(
 }
 
 /// Retrieve a rolling stock's light representation by its id
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "rolling_stock",
@@ -150,7 +144,7 @@ async fn list(
         (status = 200, body = LightRollingStockWithLiveries, description = "The rolling stock with their simplified effort curves"),
     )
 )]
-async fn get(
+pub(in crate::views) async fn get(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(light_rolling_stock_id): Path<i64>,
@@ -176,6 +170,7 @@ async fn get(
 }
 
 /// Retrieve a rolling stock's light representation by its name
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "rolling_stock",
@@ -184,7 +179,7 @@ async fn get(
         (status = 200, body = LightRollingStockWithLiveries, description = "The rolling stock with their simplified effort curves"),
     )
 )]
-async fn get_by_name(
+pub(in crate::views) async fn get_by_name(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(light_rolling_stock_name): Path<String>,

--- a/editoast/src/views/rolling_stock/towed.rs
+++ b/editoast/src/views/rolling_stock/towed.rs
@@ -32,18 +32,6 @@ use thiserror::Error;
 use utoipa::IntoParams;
 use utoipa::ToSchema;
 
-crate::routes! {
-    "/towed_rolling_stock" => {
-        get_list,
-        post,
-        "/{towed_rolling_stock_id}" => {
-            get_by_id,
-            patch_by_id,
-            "/locked" => patch_by_id_locked,
-        },
-    },
-}
-
 editoast_common::schemas! {
     TowedRollingStockCountList,
     TowedRollingStockForm,
@@ -108,6 +96,7 @@ impl From<TowedRollingStockForm> for Changeset<TowedRollingStock> {
 }
 
 /// Create a rolling stock
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "rolling_stock",
@@ -116,7 +105,7 @@ impl From<TowedRollingStockForm> for Changeset<TowedRollingStock> {
         (status = 200, description = "The created towed rolling stock", body = TowedRollingStock)
     )
 )]
-async fn post(
+pub(in crate::views) async fn post(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Json(towed_rolling_stock_form): Json<TowedRollingStockForm>,
@@ -138,12 +127,13 @@ async fn post(
 
 #[derive(Serialize, ToSchema)]
 #[cfg_attr(test, derive(Deserialize))]
-struct TowedRollingStockCountList {
+pub(in crate::views) struct TowedRollingStockCountList {
     results: Vec<TowedRollingStock>,
     #[serde(flatten)]
     stats: PaginationStats,
 }
 
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "rolling_stock",
@@ -152,7 +142,7 @@ struct TowedRollingStockCountList {
         (status = 200, body = inline(TowedRollingStockCountList)),
     )
 )]
-async fn get_list(
+pub(in crate::views) async fn get_list(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Query(page_settings): Query<PaginationQueryParams<50>>,
@@ -181,6 +171,7 @@ pub struct TowedRollingStockIdParam {
     towed_rolling_stock_id: i64,
 }
 
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "rolling_stock",
@@ -189,7 +180,7 @@ pub struct TowedRollingStockIdParam {
         (status = 200, body = TowedRollingStock, description = "The requested towed rolling stock"),
     )
 )]
-async fn get_by_id(
+pub(in crate::views) async fn get_by_id(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(TowedRollingStockIdParam {
@@ -216,6 +207,7 @@ async fn get_by_id(
     Ok(Json(towed_rolling_stock))
 }
 
+#[editoast_derive::route]
 #[utoipa::path(
     patch, path = "",
     tag = "rolling_stock",
@@ -225,7 +217,7 @@ async fn get_by_id(
         (status = 200, description = "The created towed rolling stock", body = TowedRollingStock)
     )
 )]
-async fn patch_by_id(
+pub(in crate::views) async fn patch_by_id(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(TowedRollingStockIdParam {
@@ -286,11 +278,12 @@ async fn patch_by_id(
 
 #[derive(Debug, Deserialize, ToSchema)]
 #[serde(deny_unknown_fields)]
-struct TowedRollingStockLockedForm {
+pub(in crate::views) struct TowedRollingStockLockedForm {
     /// New locked value
     pub locked: bool,
 }
 
+#[editoast_derive::route]
 #[utoipa::path(
     patch, path = "",
     tag = "rolling_stock",
@@ -300,7 +293,7 @@ struct TowedRollingStockLockedForm {
         (status = 204, description = "No content when successful")
     )
 )]
-async fn patch_by_id_locked(
+pub(in crate::views) async fn patch_by_id_locked(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(towed_rolling_stock_id): Path<i64>,

--- a/editoast/src/views/round_trips.rs
+++ b/editoast/src/views/round_trips.rs
@@ -12,30 +12,6 @@ use utoipa::ToSchema;
 use utoipa::openapi::RefOr;
 use utoipa::openapi::Schema;
 
-crate::routes! {
-    "/round_trips" => {
-        "/train_schedules" => {
-            post_train_schedules,
-            "/delete" => delete_train_schedules,
-        },
-        "/paced_trains" => {
-            post_paced_trains,
-            "/delete" => delete_paced_trains,
-        },
-    },
-}
-
-pub(in crate::views) mod timetable_routes {
-    use super::*;
-
-    crate::routes! {
-        "/round_trips" => {
-            "/train_schedules" => list_train_schedules,
-            "/paced_trains" => list_paced_trains,
-        },
-    }
-}
-
 editoast_common::schemas! {
     RoundTrips,
 }
@@ -73,30 +49,33 @@ fn schema_round_trips() -> RefOr<Schema> {
 }
 
 /// Upsert a list of round trips / one-way of train schedules
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "round_trips",
     request_body = RoundTrips,
     responses((status = 204, description = "Round trips were successfully upserted"))
 )]
-async fn post_train_schedules() -> Result<impl IntoResponse> {
+pub(in crate::views) async fn post_train_schedules() -> Result<impl IntoResponse> {
     // TODO: Implement this endpoint
     Ok(axum::http::StatusCode::NO_CONTENT)
 }
 
 /// Upsert a list of round trips / one-way of paced trains
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "round_trips",
     request_body = RoundTrips,
     responses((status = 204, description = "Round trips were successfully upserted"))
 )]
-async fn post_paced_trains() -> Result<impl IntoResponse> {
+pub(in crate::views) async fn post_paced_trains() -> Result<impl IntoResponse> {
     // TODO: Implement this endpoint
     Ok(axum::http::StatusCode::NO_CONTENT)
 }
 
 /// Delete a list of round trips / one-way of train schedules
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "round_trips",
@@ -106,12 +85,13 @@ async fn post_paced_trains() -> Result<impl IntoResponse> {
     ),
     responses((status = 204, description = "Round trips were successfully deleted"))
 )]
-async fn delete_train_schedules() -> Result<impl IntoResponse> {
+pub(in crate::views) async fn delete_train_schedules() -> Result<impl IntoResponse> {
     // TODO: Implement this endpoint
     Ok(axum::http::StatusCode::NO_CONTENT)
 }
 
 /// Delete a list of round trips / one-way of paced trains
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "round_trips",
@@ -121,27 +101,28 @@ async fn delete_train_schedules() -> Result<impl IntoResponse> {
     ),
     responses((status = 204, description = "Round trips were successfully deleted"))
 )]
-async fn delete_paced_trains() -> Result<impl IntoResponse> {
+pub(in crate::views) async fn delete_paced_trains() -> Result<impl IntoResponse> {
     // TODO: Implement this endpoint
     Ok(axum::http::StatusCode::NO_CONTENT)
 }
 
 /// Paginated list of round trips / one-way
 #[derive(Serialize, ToSchema)]
-struct ListRoundTripsResponse {
+pub(in crate::views) struct ListRoundTripsResponse {
     #[serde(flatten)]
     stats: PaginationStats,
     results: RoundTrips,
 }
 
 /// Upsert a list of round trips / one-way of train schedules
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "timetable,round_trips",
     params(TimetableIdParam, PaginationQueryParams<1000>),
     responses((status = 200, body = inline(ListRoundTripsResponse)))
 )]
-async fn list_train_schedules(
+pub(in crate::views) async fn list_train_schedules(
     Path(TimetableIdParam { id: _ }): Path<TimetableIdParam>,
     Query(PaginationQueryParams { page, page_size }): Query<PaginationQueryParams<1000>>,
 ) -> Result<Json<ListRoundTripsResponse>> {
@@ -153,13 +134,14 @@ async fn list_train_schedules(
 }
 
 /// Upsert a list of round trips / one-way of paced trains
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "timetable,round_trips",
     params(TimetableIdParam, PaginationQueryParams<1000>),
     responses((status = 200, body = inline(ListRoundTripsResponse)))
 )]
-async fn list_paced_trains(
+pub(in crate::views) async fn list_paced_trains(
     Path(TimetableIdParam { id: _ }): Path<TimetableIdParam>,
     Query(PaginationQueryParams { page, page_size }): Query<PaginationQueryParams<1000>>,
 ) -> Result<Json<ListRoundTripsResponse>> {

--- a/editoast/src/views/router.rs
+++ b/editoast/src/views/router.rs
@@ -1,0 +1,159 @@
+use std::collections::VecDeque;
+
+// we cannot have a tuple (*const (), fn(...) -> ...) because raw pointers are not Send or Sync
+pub(in crate::views) type OpenApiRouteSliceItem =
+    fn(&str) -> Option<fn(Option<&str>) -> utoipa::openapi::path::PathItem>;
+
+#[linkme::distributed_slice]
+pub(in crate::views) static OPENAPI_ROUTES: [OpenApiRouteSliceItem];
+
+#[derive(Debug, Default)]
+pub(super) struct DocumentedRouter {
+    pub(super) router: axum::Router<super::AppState>,
+    pub(super) path_trees: Vec<PathTree>,
+}
+
+#[derive(Debug)]
+pub(super) enum PathTree {
+    Leaf {
+        path_segment: &'static str,
+        openapi: fn(Option<&str>) -> utoipa::openapi::path::PathItem,
+    },
+    Branch {
+        path_segment: &'static str,
+        sub_paths: Vec<PathTree>,
+    },
+}
+
+impl PathTree {
+    pub(super) fn flatten(self) -> Vec<(VecDeque<&'static str>, utoipa::openapi::path::PathItem)> {
+        match self {
+            PathTree::Leaf {
+                path_segment,
+                openapi,
+            } => vec![(VecDeque::from([path_segment]), openapi(None))],
+            PathTree::Branch {
+                path_segment,
+                sub_paths,
+            } => {
+                let mut paths = Vec::new();
+                for sub_path in sub_paths {
+                    for (mut path, item) in sub_path.flatten() {
+                        path.push_front(path_segment);
+                        paths.push((path, item));
+                    }
+                }
+                paths
+            }
+        }
+    }
+}
+
+impl DocumentedRouter {
+    pub(super) fn root(f: impl FnOnce(Self) -> Self) -> Self {
+        f(Self::default())
+    }
+
+    #[track_caller] // panic at the right line of the builder to find the faulty route easily
+    pub(super) fn route(
+        mut self,
+        path: &'static str,
+        (type_name, method_router, expected_method): (
+            &str,
+            axum::routing::MethodRouter<super::AppState>,
+            utoipa::openapi::PathItemType,
+        ),
+    ) -> Self {
+        let Some(openapi) = OPENAPI_ROUTES.iter().find_map(|matcher| matcher(type_name)) else {
+            panic!("no openapi found for route {path} with type {type_name}!");
+        };
+        let operation_key = openapi(None)
+            .operations
+            .into_keys()
+            .next()
+            .expect("an utoipa path created using the path macro must have a method");
+        if operation_key != expected_method {
+            panic!(
+                "expected method {} in the router at \"{path}\" but found {} in utoipa path",
+                serde_json::to_string(&expected_method).unwrap(), // does not impl debug or display
+                serde_json::to_string(&operation_key).unwrap()
+            );
+        }
+        self.path_trees.push(PathTree::Leaf {
+            path_segment: path,
+            openapi,
+        });
+        Self {
+            router: self.router.route(path, method_router),
+            path_trees: self.path_trees,
+        }
+    }
+
+    pub(super) fn nests(mut self, path: &'static str, f: impl FnOnce(Self) -> Self) -> Self {
+        let Self { router, path_trees } = f(Self::default());
+        self.path_trees.push(PathTree::Branch {
+            path_segment: path,
+            sub_paths: path_trees,
+        });
+        Self {
+            router: self.router.nest(path, router),
+            path_trees: self.path_trees,
+        }
+    }
+}
+
+macro_rules! get {
+    ($f:path) => {
+        (
+            std::any::type_name_of_val(&$f),
+            axum::routing::get($f),
+            utoipa::openapi::PathItemType::Get,
+        )
+    };
+}
+
+macro_rules! post {
+    ($f:path) => {
+        (
+            std::any::type_name_of_val(&$f),
+            axum::routing::post($f),
+            utoipa::openapi::PathItemType::Post,
+        )
+    };
+}
+
+macro_rules! delete {
+    ($f:path) => {
+        (
+            std::any::type_name_of_val(&$f),
+            axum::routing::delete($f),
+            utoipa::openapi::PathItemType::Delete,
+        )
+    };
+}
+
+macro_rules! put {
+    ($f:path) => {
+        (
+            std::any::type_name_of_val(&$f),
+            axum::routing::put($f),
+            utoipa::openapi::PathItemType::Put,
+        )
+    };
+}
+
+macro_rules! patch {
+    ($f:path) => {
+        (
+            std::any::type_name_of_val(&$f),
+            axum::routing::patch($f),
+            utoipa::openapi::PathItemType::Patch,
+        )
+    };
+}
+
+pub(super) use delete;
+pub(super) use get;
+pub(super) use patch;
+pub(super) use post;
+pub(super) use put;

--- a/editoast/src/views/router.rs
+++ b/editoast/src/views/router.rs
@@ -1,6 +1,11 @@
 use std::collections::VecDeque;
 
-// we cannot have a tuple (*const (), fn(...) -> ...) because raw pointers are not Send or Sync
+// fn(function_type_name) -> utoipa::Path::path_item
+//
+// We can't just build a slice of tuples (&'static str, fn) because std::any::type_name_of_val
+// constness is unstable. So O(n^2) here we go...
+//
+// If this takes too long, we can always optimize it later (structure, search algorithm, featuring utoipa).
 pub(in crate::views) type OpenApiRouteSliceItem =
     fn(&str) -> Option<fn(Option<&str>) -> utoipa::openapi::path::PathItem>;
 

--- a/editoast/src/views/scenario.rs
+++ b/editoast/src/views/scenario.rs
@@ -39,19 +39,6 @@ use crate::views::project::ProjectIdParam;
 use crate::views::study::StudyError;
 use crate::views::study::StudyIdParam;
 
-crate::routes! {
-    "/projects/{project_id}/studies/{study_id}/scenarios" => {
-        create,
-        list,
-        "/{scenario_id}" => {
-            get,
-            delete,
-            patch,
-            &macro_nodes,
-        },
-    },
-}
-
 editoast_common::schemas! {
     ScenarioPatchForm,
     Scenario,
@@ -61,7 +48,7 @@ editoast_common::schemas! {
 }
 
 #[derive(IntoParams, Deserialize)]
-struct ScenarioPathParam {
+pub(in crate::views) struct ScenarioPathParam {
     project_id: i64,
     study_id: i64,
     scenario_id: i64,
@@ -75,7 +62,7 @@ pub struct ScenarioIdParam {
 
 /// This structure is used by the post endpoint to create a scenario
 #[derive(Serialize, Deserialize, Default, ToSchema)]
-struct ScenarioCreateForm {
+pub(in crate::views) struct ScenarioCreateForm {
     pub name: String,
     #[serde(default)]
     pub description: String,
@@ -170,6 +157,7 @@ impl ScenarioResponse {
 }
 
 /// Create a scenario
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "scenarios",
@@ -179,7 +167,7 @@ impl ScenarioResponse {
         (status = 201, body = ScenarioResponse, description = "The created scenario"),
     )
 )]
-async fn create(
+pub(in crate::views) async fn create(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path((project_id, study_id)): Path<(i64, i64)>,
@@ -229,6 +217,7 @@ async fn create(
 }
 
 /// Delete a scenario
+#[editoast_derive::route]
 #[utoipa::path(
     delete, path = "",
     tag = "scenarios",
@@ -238,7 +227,7 @@ async fn create(
         (status = 404, body = InternalError, description = "The requested scenario was not found"),
     )
 )]
-async fn delete(
+pub(in crate::views) async fn delete(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(ScenarioPathParam {
@@ -287,7 +276,7 @@ async fn delete(
 
 /// This structure is used by the patch endpoint to patch a scenario
 #[derive(Serialize, Deserialize, Default, ToSchema)]
-struct ScenarioPatchForm {
+pub(in crate::views) struct ScenarioPatchForm {
     pub name: Option<String>,
     pub description: Option<String>,
     pub tags: Option<Tags>,
@@ -309,6 +298,7 @@ impl From<ScenarioPatchForm> for <Scenario as crate::models::Model>::Changeset {
 }
 
 /// Update a scenario
+#[editoast_derive::route]
 #[utoipa::path(
     patch, path = "",
     tag = "scenarios",
@@ -319,7 +309,7 @@ impl From<ScenarioPatchForm> for <Scenario as crate::models::Model>::Changeset {
         (status = 404, body = InternalError, description = "The requested scenario was not found"),
     )
 )]
-async fn patch(
+pub(in crate::views) async fn patch(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(ScenarioPathParam {
@@ -373,6 +363,7 @@ async fn patch(
 }
 
 /// Return a specific scenario
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "scenarios",
@@ -382,7 +373,7 @@ async fn patch(
         (status = 404, body = InternalError, description = "The requested scenario was not found"),
     )
 )]
-async fn get(
+pub(in crate::views) async fn get(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(ScenarioPathParam {
@@ -442,13 +433,14 @@ async fn get(
 
 #[derive(Serialize, ToSchema)]
 #[cfg_attr(test, derive(Deserialize))]
-struct ListScenariosResponse {
+pub(in crate::views) struct ListScenariosResponse {
     #[serde(flatten)]
     stats: PaginationStats,
     results: Vec<ScenarioWithDetails>,
 }
 
 /// Return a list of scenarios
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "scenarios",
@@ -458,7 +450,7 @@ struct ListScenariosResponse {
         (status = 404, description = "Project or study doesn't exist")
     )
 )]
-async fn list(
+pub(in crate::views) async fn list(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path((project_id, study_id)): Path<(i64, i64)>,

--- a/editoast/src/views/scenario/macro_nodes.rs
+++ b/editoast/src/views/scenario/macro_nodes.rs
@@ -37,11 +37,6 @@ use crate::views::scenario::ScenarioIdParam;
 use crate::views::study::StudyError;
 use crate::views::study::StudyIdParam;
 
-crate::routes! {
-    "/macro_nodes" => {list, create,},
-    "/macro_nodes/{node_id}" => {get, update, delete,},
-}
-
 editoast_common::schemas! {
     MacroNodeForm,
     MacroNodeBatchForm,
@@ -70,7 +65,7 @@ struct MacroNodeIdParam {
 
 #[derive(Debug, Deserialize, ToSchema, Clone)]
 #[cfg_attr(test, derive(Serialize, PartialEq))]
-struct MacroNodeForm {
+pub(in crate::views) struct MacroNodeForm {
     position_x: i64,
     position_y: i64,
     full_name: Option<String>,
@@ -82,7 +77,7 @@ struct MacroNodeForm {
 
 #[derive(Debug, Deserialize, ToSchema)]
 #[cfg_attr(test, derive(Serialize, PartialEq))]
-struct MacroNodeBatchForm {
+pub(in crate::views) struct MacroNodeBatchForm {
     macro_nodes: Vec<MacroNodeForm>,
 }
 
@@ -102,7 +97,7 @@ impl MacroNodeForm {
 
 #[derive(Debug, Serialize, ToSchema)]
 #[cfg_attr(test, derive(Deserialize, PartialEq))]
-struct MacroNodeResponse {
+pub(in crate::views) struct MacroNodeResponse {
     id: i64,
     position_x: i64,
     position_y: i64,
@@ -115,7 +110,7 @@ struct MacroNodeResponse {
 
 #[derive(Debug, Serialize, ToSchema)]
 #[cfg_attr(test, derive(Deserialize, PartialEq))]
-struct MacroNodeBatchResponse {
+pub(in crate::views) struct MacroNodeBatchResponse {
     macro_nodes: Vec<MacroNodeResponse>,
 }
 
@@ -136,13 +131,14 @@ impl From<MacroNode> for MacroNodeResponse {
 
 #[derive(Debug, Serialize, ToSchema)]
 #[cfg_attr(test, derive(Deserialize))]
-struct MacroNodeListResponse {
+pub(in crate::views) struct MacroNodeListResponse {
     #[serde(flatten)]
     stats: PaginationStats,
     results: Vec<MacroNodeResponse>,
 }
 
 /// Get macro node list by scenario id
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "scenarios",
@@ -152,7 +148,7 @@ struct MacroNodeListResponse {
         (status = 404, body = InternalError, description = "The requested scenario was not found"),
     )
 )]
-async fn list(
+pub(in crate::views) async fn list(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path((project_id, study_id, scenario_id)): Path<(i64, i64, i64)>,
@@ -188,6 +184,7 @@ async fn list(
     }))
 }
 
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "scenarios",
@@ -197,7 +194,7 @@ async fn list(
         (status = 201, body = MacroNodeBatchResponse, description = "Macro nodes created"),
     )
 )]
-async fn create(
+pub(in crate::views) async fn create(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path((project_id, study_id, scenario_id)): Path<(i64, i64, i64)>,
@@ -247,6 +244,7 @@ async fn create(
     }))
 }
 
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "scenarios",
@@ -256,7 +254,7 @@ async fn create(
         (status = 404, body = InternalError, description = "The macro node was not found"),
     )
 )]
-async fn get(
+pub(in crate::views) async fn get(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path((project_id, study_id, scenario_id, node_id)): Path<(i64, i64, i64, i64)>,
@@ -280,6 +278,7 @@ async fn get(
     Ok(Json(MacroNodeResponse::from(macro_node)))
 }
 
+#[editoast_derive::route]
 #[utoipa::path(
     put, path = "",
     tag = "scenarios",
@@ -290,7 +289,7 @@ async fn get(
         (status = 404, body = InternalError, description = "The macro node was not found"),
     )
 )]
-async fn update(
+pub(in crate::views) async fn update(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path((project_id, study_id, scenario_id, node_id)): Path<(i64, i64, i64, i64)>,
@@ -343,6 +342,7 @@ async fn update(
     Ok(Json(MacroNodeResponse::from(updated)))
 }
 
+#[editoast_derive::route]
 #[utoipa::path(
     delete, path = "",
     tag = "scenarios",
@@ -352,7 +352,7 @@ async fn update(
         (status = 404, body = InternalError, description = "The macro node was not found"),
     )
 )]
-async fn delete(
+pub(in crate::views) async fn delete(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path((project_id, study_id, scenario_id, node_id)): Path<(i64, i64, i64, i64)>,

--- a/editoast/src/views/search.rs
+++ b/editoast/src/views/search.rs
@@ -237,10 +237,6 @@ use crate::views::AuthorizationError;
 use crate::views::pagination::PaginationQueryParams;
 use database::DbConnectionPoolV2;
 
-crate::routes! {
-    "/search" => search,
-}
-
 editoast_common::schemas! {
     SearchPayload,
     SearchQuery,
@@ -335,6 +331,7 @@ struct SearchDBResult {
 ///   `["and", ["search", ["name"], "Paris"], ["not", ["=", ["trigram"], "pno"]]]`
 ///
 /// See [search::SearchAst] for a more detailed view of the query language.
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "search",
@@ -344,7 +341,7 @@ struct SearchDBResult {
         (status = 200, body = Vec<SearchResultItem>, description = "The search results"),
     )
 )]
-async fn search(
+pub(in crate::views) async fn search(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Query(PaginationQueryParams { page, page_size }): Query<PaginationQueryParams<1000>>,

--- a/editoast/src/views/sprites.rs
+++ b/editoast/src/views/sprites.rs
@@ -12,13 +12,6 @@ use crate::AppState;
 use crate::error::Result;
 use crate::generated_data::sprite_config::SpriteConfig;
 
-crate::routes! {
-    "/sprites" => {
-        "/{signaling_system}/{file_name}" => sprites,
-        "/signaling_systems" => signaling_systems,
-    },
-}
-
 #[derive(Debug, Error, EditoastError)]
 #[editoast_error(base_id = "sprites")]
 enum SpriteErrors {
@@ -31,6 +24,7 @@ enum SpriteErrors {
 }
 
 /// This endpoint returns the list of supported signaling systems
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "sprites",
@@ -38,13 +32,14 @@ enum SpriteErrors {
         (status = 200, description = "List of supported signaling systems", body = Vec<String>, example = json!(["BAL", "TVM300"])),
     ),
 )]
-async fn signaling_systems() -> Result<Json<Vec<String>>> {
+pub(in crate::views) async fn signaling_systems() -> Result<Json<Vec<String>>> {
     let sprite_configs = SpriteConfig::load();
     let signaling_systems = sprite_configs.keys().cloned().collect();
     Ok(Json(signaling_systems))
 }
 
 /// This endpoint is used by map libre to retrieve the atlas of each signaling system
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "sprites",
@@ -57,7 +52,7 @@ async fn signaling_systems() -> Result<Json<Vec<String>>> {
         (status = 404, description = "Signaling system not found"),
     ),
 )]
-async fn sprites(
+pub(in crate::views) async fn sprites(
     Path((signaling_system, file_name)): Path<(String, String)>,
     State(AppState { config, .. }): State<AppState>,
     request: Request,

--- a/editoast/src/views/stdcm_logs.rs
+++ b/editoast/src/views/stdcm_logs.rs
@@ -21,11 +21,6 @@ use super::pagination::PaginatedList;
 use super::pagination::PaginationQueryParams;
 use super::pagination::PaginationStats;
 
-crate::routes! {
-    "/stdcm_logs" => list_stdcm_logs,
-    "/stdcm_log" => stdcm_log_by_id_or_trace_id,
-}
-
 editoast_common::schemas! {
     StdcmLogListItem,
 }
@@ -55,12 +50,13 @@ struct StdcmLogListItem {
 
 #[derive(Serialize, ToSchema)]
 #[cfg_attr(test, derive(Deserialize))]
-struct StdcmLogListResponse {
+pub(in crate::views) struct StdcmLogListResponse {
     results: Vec<StdcmLogListItem>,
     #[serde(flatten)]
     stats: PaginationStats,
 }
 
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "stdcm_log",
@@ -69,7 +65,7 @@ struct StdcmLogListResponse {
         (status = 200, body = inline(StdcmLogListResponse), description = "The list of STDCM Logs"),
     )
 )]
-async fn list_stdcm_logs(
+pub(in crate::views) async fn list_stdcm_logs(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Query(pagination_params): Query<PaginationQueryParams<25>>,
@@ -101,11 +97,12 @@ async fn list_stdcm_logs(
 
 #[derive(Debug, Deserialize, IntoParams)]
 #[into_params(parameter_in = Query)]
-struct StdcmLogParams {
+pub(in crate::views) struct StdcmLogParams {
     trace_id: Option<String>,
     id: Option<i64>,
 }
 
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     params(StdcmLogParams),
@@ -114,7 +111,7 @@ struct StdcmLogParams {
         (status = 200, body = StdcmLog, description = "The STDCM log"),
     )
 )]
-async fn stdcm_log_by_id_or_trace_id(
+pub(in crate::views) async fn stdcm_log_by_id_or_trace_id(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Query(StdcmLogParams { id, trace_id }): Query<StdcmLogParams>,

--- a/editoast/src/views/stdcm_search_environment.rs
+++ b/editoast/src/views/stdcm_search_environment.rs
@@ -32,15 +32,6 @@ use crate::models::stdcm_search_environment::StdcmSearchEnvironment;
 use crate::views::AuthenticationExt;
 use crate::views::AuthorizationError;
 
-crate::routes! {
-    "/stdcm/search_environment" => {
-        create,
-        retrieve_latest,
-        "/list" => list,
-        "/{env_id}" => delete,
-    },
-}
-
 editoast_common::schemas! {
     StdcmSearchEnvironmentCreateForm,
     StdcmSearchEnvironment,
@@ -62,7 +53,7 @@ enum StdcmSearchEnvError {
 #[derive(Deserialize, ToSchema)]
 #[serde(remote = "Self")]
 #[cfg_attr(test, derive(Serialize))]
-struct StdcmSearchEnvironmentCreateForm {
+pub(in crate::views) struct StdcmSearchEnvironmentCreateForm {
     infra_id: i64,
     electrical_profile_set_id: Option<i64>,
     work_schedule_group_id: Option<i64>,
@@ -125,6 +116,7 @@ impl From<StdcmSearchEnvironmentCreateForm> for Changeset<StdcmSearchEnvironment
     }
 }
 
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "stdcm_search_environment",
@@ -133,7 +125,7 @@ impl From<StdcmSearchEnvironmentCreateForm> for Changeset<StdcmSearchEnvironment
         (status = 201, body = StdcmSearchEnvironment),
     )
 )]
-async fn create(
+pub(in crate::views) async fn create(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Json(form): Json<StdcmSearchEnvironmentCreateForm>,
@@ -151,6 +143,7 @@ async fn create(
     Ok((StatusCode::CREATED, Json(changeset.create(conn).await?)))
 }
 
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "stdcm_search_environment",
@@ -159,7 +152,7 @@ async fn create(
         (status = 204, description = "No search environment was created")
     )
 )]
-async fn retrieve_latest(
+pub(in crate::views) async fn retrieve_latest(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
 ) -> Result<Response> {
@@ -183,11 +176,12 @@ async fn retrieve_latest(
 
 #[derive(IntoParams, Deserialize)]
 #[allow(unused)]
-struct StdcmSearchEnvIdParam {
+pub(in crate::views) struct StdcmSearchEnvIdParam {
     /// An stdcm search environment ID
     env_id: i64,
 }
 
+#[editoast_derive::route]
 #[utoipa::path(
     delete, path = "",
     tag = "stdcm_search_environment",
@@ -196,7 +190,7 @@ struct StdcmSearchEnvIdParam {
         (status = 204, description = "The stdcm search environment was deleted successfully"),
     )
 )]
-async fn delete(
+pub(in crate::views) async fn delete(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(StdcmSearchEnvIdParam { env_id }): Path<StdcmSearchEnvIdParam>,
@@ -220,13 +214,14 @@ async fn delete(
 
 #[derive(Serialize, ToSchema)]
 #[cfg_attr(test, derive(Deserialize))]
-struct SdcmSearchEnvListResponse {
+pub(in crate::views) struct SdcmSearchEnvListResponse {
     #[schema(value_type = Vec<StdcmSearchEnvironment>)]
     results: Vec<StdcmSearchEnvironment>,
     #[serde(flatten)]
     stats: PaginationStats,
 }
 
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "stdcm_search_environment",
@@ -235,7 +230,7 @@ struct SdcmSearchEnvListResponse {
         (status = 200, body = inline(SdcmSearchEnvListResponse), description = "The paginated list of all existing stdcm search environments"),
     )
 )]
-async fn list(
+pub(in crate::views) async fn list(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Query(page_settings): Query<PaginationQueryParams<1000>>,

--- a/editoast/src/views/study.rs
+++ b/editoast/src/views/study.rs
@@ -33,18 +33,6 @@ use crate::views::pagination::PaginationQueryParams;
 use crate::views::project::ProjectError;
 use crate::views::project::ProjectIdParam;
 
-crate::routes! {
-    "/studies" => {
-        create,
-        list,
-        "/{study_id}" => {
-            get,
-            delete,
-            patch,
-        },
-    },
-}
-
 editoast_common::schemas! {
     Study,
     StudyCreateForm,
@@ -89,7 +77,7 @@ impl StudyResponse {
 
 /// This structure is used by the post endpoint to create a study
 #[derive(Serialize, Deserialize, Default, ToSchema)]
-struct StudyCreateForm {
+pub(in crate::views) struct StudyCreateForm {
     pub name: String,
     pub description: Option<String>,
     pub start_date: Option<NaiveDate>,
@@ -126,6 +114,7 @@ impl StudyCreateForm {
     }
 }
 
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "studies",
@@ -135,7 +124,7 @@ impl StudyCreateForm {
         (status = 201, body = StudyResponse, description = "The created study"),
     )
 )]
-async fn create(
+pub(in crate::views) async fn create(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(project_id): Path<i64>,
@@ -182,6 +171,7 @@ pub struct StudyIdParam {
 }
 
 /// Delete a study
+#[editoast_derive::route]
 #[utoipa::path(
     delete, path = "",
     tag = "studies",
@@ -191,7 +181,7 @@ pub struct StudyIdParam {
         (status = 404, body = InternalError, description = "The requested study was not found"),
     )
 )]
-async fn delete(
+pub(in crate::views) async fn delete(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path((project_id, study_id)): Path<(i64, i64)>,
@@ -218,6 +208,7 @@ async fn delete(
 }
 
 /// Return a specific study
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "studies",
@@ -227,7 +218,7 @@ async fn delete(
         (status = 404, body = InternalError, description = "The requested study was not found"),
     )
 )]
-async fn get(
+pub(in crate::views) async fn get(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path((project_id, study_id)): Path<(i64, i64)>,
@@ -274,7 +265,7 @@ async fn get(
 
 /// This structure is used by the patch endpoint to patch a study
 #[derive(Serialize, Deserialize, Default, ToSchema)]
-struct StudyPatchForm {
+pub(in crate::views) struct StudyPatchForm {
     pub name: Option<String>,
     #[serde(default, with = "double_option")]
     pub description: Option<Option<String>>,
@@ -316,6 +307,7 @@ impl StudyPatchForm {
 }
 
 /// Update a study
+#[editoast_derive::route]
 #[utoipa::path(
     patch, path = "",
     tag = "studies",
@@ -329,7 +321,7 @@ impl StudyPatchForm {
         (status = 404, body = InternalError, description = "The requested study was not found"),
     )
 )]
-async fn patch(
+pub(in crate::views) async fn patch(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path((project_id, study_id)): Path<(i64, i64)>,
@@ -386,7 +378,7 @@ impl StudyWithScenarioCount {
 
 #[derive(Serialize, ToSchema)]
 #[cfg_attr(test, derive(Deserialize))]
-struct StudyListResponse {
+pub(in crate::views) struct StudyListResponse {
     #[schema(value_type = Vec<StudyWithScenarios>)]
     results: Vec<StudyWithScenarioCount>,
     #[serde(flatten)]
@@ -394,6 +386,7 @@ struct StudyListResponse {
 }
 
 /// Return a list of studies
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "studies",
@@ -402,7 +395,7 @@ struct StudyListResponse {
         (status = 200, body = inline(StudyListResponse), description = "The list of studies"),
     )
 )]
-async fn list(
+pub(in crate::views) async fn list(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(project_id): Path<i64>,

--- a/editoast/src/views/sub_categories.rs
+++ b/editoast/src/views/sub_categories.rs
@@ -19,14 +19,6 @@ use crate::views::AuthorizationError;
 use crate::views::pagination::PaginationQueryParams;
 use crate::views::pagination::PaginationStats;
 
-crate::routes! {
-    "/sub_category" => {
-        get_sub_categories,
-        create_sub_categories,
-        "/{code}" => delete_sub_category,
-    },
-}
-
 editoast_common::schemas! {
     SubCategoryPage,
 }
@@ -44,12 +36,13 @@ enum SubCategoryError {
 }
 
 #[derive(Debug, Serialize, ToSchema)]
-struct SubCategoryPage {
+pub(in crate::views) struct SubCategoryPage {
     results: Vec<SubCategory>,
     #[serde(flatten)]
     stats: PaginationStats,
 }
 
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "sub_categories",
@@ -58,7 +51,7 @@ struct SubCategoryPage {
         (status = 200, description = "The list of sub categories", body = SubCategoryPage),
     ),
 )]
-async fn get_sub_categories(
+pub(in crate::views) async fn get_sub_categories(
     State(_db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Query(_pagination): Query<PaginationQueryParams<1000>>,
@@ -77,6 +70,7 @@ async fn get_sub_categories(
     }))
 }
 
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "sub_categories",
@@ -85,7 +79,7 @@ async fn get_sub_categories(
         (status = 200, description = "Create sub categories", body = Vec<SubCategory>),
     ),
 )]
-async fn create_sub_categories(
+pub(in crate::views) async fn create_sub_categories(
     State(_db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Json(data): Json<Vec<SubCategory>>,
@@ -120,6 +114,7 @@ struct SubCategoryCodeParam {
     code: String,
 }
 
+#[editoast_derive::route]
 #[utoipa::path(
     delete, path = "",
     tag = "sub_categories",
@@ -128,7 +123,7 @@ struct SubCategoryCodeParam {
         (status = 200, description = "Delete a sub category"),
     ),
 )]
-async fn delete_sub_category(
+pub(in crate::views) async fn delete_sub_category(
     State(_db_pool): State<DbConnectionPoolV2>,
     Path(_code): Path<String>,
     Extension(auth): AuthenticationExt,

--- a/editoast/src/views/temporary_speed_limits.rs
+++ b/editoast/src/views/temporary_speed_limits.rs
@@ -26,10 +26,6 @@ use crate::views::AuthenticationExt;
 use crate::views::AuthorizationError;
 use authz::Role;
 
-crate::routes! {
-    "/temporary_speed_limit_group" => create_temporary_speed_limit_group,
-}
-
 #[derive(Deserialize, ToSchema)]
 #[serde(remote = "Self")]
 #[cfg_attr(test, derive(Serialize))]
@@ -43,14 +39,14 @@ struct TemporarySpeedLimitItemForm {
 
 #[derive(Deserialize, ToSchema)]
 #[cfg_attr(test, derive(Serialize))]
-struct TemporarySpeedLimitCreateForm {
+pub(in crate::views) struct TemporarySpeedLimitCreateForm {
     speed_limit_group_name: String,
     #[schema(inline)]
     speed_limits: Vec<TemporarySpeedLimitItemForm>,
 }
 
 #[derive(Serialize, Deserialize, ToSchema)]
-struct TemporarySpeedLimitCreateResponse {
+pub(in crate::views) struct TemporarySpeedLimitCreateResponse {
     group_id: i64,
 }
 
@@ -123,6 +119,7 @@ impl From<temporary_speed_limits::TslGroupError> for TemporarySpeedLimitError {
     }
 }
 
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "temporary_speed_limits",
@@ -131,7 +128,7 @@ impl From<temporary_speed_limits::TslGroupError> for TemporarySpeedLimitError {
         (status = 201, body = inline(TemporarySpeedLimitCreateResponse), description = "The id of the created temporary speed limit group." ),
     )
 )]
-async fn create_temporary_speed_limit_group(
+pub(in crate::views) async fn create_temporary_speed_limit_group(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Json(TemporarySpeedLimitCreateForm {

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -43,6 +43,7 @@ use crate::map::MapLayers;
 use crate::models;
 use crate::models::PgAuthDriver;
 use crate::valkey_utils::ValkeyConfig;
+use crate::views::routerv2;
 use fga::client::DEFAULT_OPENFGA_MAX_CHECKS_PER_BATCH_CHECK;
 use fga::client::DEFAULT_OPENFGA_MAX_TUPLES_PER_WRITE;
 
@@ -290,7 +291,7 @@ impl TestAppBuilder {
 
         // Configure the axum router
         let router: Router<()> = axum::Router::<AppState>::new()
-            .merge(crate::views::router())
+            .merge(routerv2().router)
             .route_layer(axum::middleware::from_fn_with_state(
                 app_state.clone(),
                 authentication_middleware,

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -43,7 +43,7 @@ use crate::map::MapLayers;
 use crate::models;
 use crate::models::PgAuthDriver;
 use crate::valkey_utils::ValkeyConfig;
-use crate::views::routerv2;
+use crate::views::service_router;
 use fga::client::DEFAULT_OPENFGA_MAX_CHECKS_PER_BATCH_CHECK;
 use fga::client::DEFAULT_OPENFGA_MAX_TUPLES_PER_WRITE;
 
@@ -291,7 +291,7 @@ impl TestAppBuilder {
 
         // Configure the axum router
         let router: Router<()> = axum::Router::<AppState>::new()
-            .merge(routerv2().router)
+            .merge(service_router().router)
             .route_layer(axum::middleware::from_fn_with_state(
                 app_state.clone(),
                 authentication_middleware,

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -1,6 +1,6 @@
 mod occupancy_blocks;
 pub mod paced_train;
-mod similar_trains;
+pub(in crate::views) mod similar_trains;
 pub mod simulation;
 pub mod stdcm;
 pub mod train_schedule;
@@ -70,31 +70,7 @@ use crate::models::timetable::TimetableWithTrains;
 use crate::models::train_schedule::TrainScheduleChangeset;
 use crate::views::AuthenticationExt;
 use crate::views::AuthorizationError;
-use crate::views::round_trips::timetable_routes as round_trip_timetable_routes;
 use crate::views::timetable::simulation::SimulationResponseSuccess;
-
-crate::routes! {
-    "/timetable" => {
-        post,
-        "/{id}" => {
-            delete,
-            "/train_schedules" => {
-                 get_train_schedules,
-                 post_train_schedule,
-            },
-            "/conflicts" => conflicts,
-            "/paced_trains" => {
-                get_paced_trains,
-                post_paced_train,
-            },
-            &stdcm,
-            &round_trip_timetable_routes,
-        },
-    },
-    &paced_train,
-    &train_schedule,
-    &similar_trains,
-}
 
 editoast_common::schemas! {
     Conflict,
@@ -127,7 +103,7 @@ enum TimetableError {
 /// Creation result for a Timetable
 #[derive(Debug, Default, Serialize, Deserialize, ToSchema)]
 #[cfg_attr(test, derive(PartialEq))]
-struct TimetableResult {
+pub(in crate::views) struct TimetableResult {
     pub timetable_id: i64,
 }
 
@@ -147,7 +123,7 @@ pub struct TimetableIdParam {
 
 #[derive(Serialize, ToSchema, Debug)]
 #[cfg_attr(test, derive(Deserialize))]
-struct ListTrainSchedulesResponse {
+pub(in crate::views) struct ListTrainSchedulesResponse {
     #[schema(value_type = Vec<TrainScheduleResponse>)]
     results: Vec<TrainScheduleResponse>,
     #[serde(flatten)]
@@ -155,6 +131,7 @@ struct ListTrainSchedulesResponse {
 }
 
 /// Return a specific timetable with its associated schedules
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "timetable",
@@ -164,7 +141,7 @@ struct ListTrainSchedulesResponse {
         (status = 404, description = "Timetable not found"),
     ),
 )]
-async fn get_train_schedules(
+pub(in crate::views) async fn get_train_schedules(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(TimetableIdParam { id: timetable_id }): Path<TimetableIdParam>,
@@ -195,6 +172,7 @@ async fn get_train_schedules(
 }
 
 /// Create a timetable
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "timetable",
@@ -203,7 +181,7 @@ async fn get_train_schedules(
         (status = 404, description = "Timetable not found"),
     ),
 )]
-async fn post(
+pub(in crate::views) async fn post(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
 ) -> Result<Json<TimetableResult>> {
@@ -223,6 +201,7 @@ async fn post(
 }
 
 /// Delete a timetable
+#[editoast_derive::route]
 #[utoipa::path(
     delete, path = "",
     tag = "timetable",
@@ -232,7 +211,7 @@ async fn post(
         (status = 404, description = "Timetable not found"),
     ),
 )]
-async fn delete(
+pub(in crate::views) async fn delete(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(TimetableIdParam { id: timetable_id }): Path<TimetableIdParam>,
@@ -254,6 +233,7 @@ async fn delete(
 }
 
 /// Create train schedule by batch
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "timetable,train_schedule",
@@ -263,7 +243,7 @@ async fn delete(
         (status = 200, description = "The created train schedules", body = Vec<TrainScheduleResponse>)
     )
 )]
-async fn post_train_schedule(
+pub(in crate::views) async fn post_train_schedule(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(TimetableIdParam { id: timetable_id }): Path<TimetableIdParam>,
@@ -299,6 +279,7 @@ async fn post_train_schedule(
 }
 
 /// Create paced trains by batch
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "timetable,paced_train",
@@ -308,7 +289,7 @@ async fn post_train_schedule(
         (status = 200, description = "The created paced trains", body = Vec<PacedTrainResponse>)
     )
 )]
-async fn post_paced_train(
+pub(in crate::views) async fn post_paced_train(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(TimetableIdParam { id: timetable_id }): Path<TimetableIdParam>,
@@ -342,7 +323,7 @@ async fn post_paced_train(
 
 #[derive(Serialize, ToSchema, Debug)]
 #[cfg_attr(test, derive(Deserialize))]
-struct ListPacedTrainsResponse {
+pub(in crate::views) struct ListPacedTrainsResponse {
     #[schema(value_type = Vec<PacedTrainResponse>)]
     results: Vec<PacedTrainResponse>,
     #[serde(flatten)]
@@ -350,6 +331,7 @@ struct ListPacedTrainsResponse {
 }
 
 /// Return a specific timetable with its associated paced trains
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "timetable",
@@ -359,7 +341,7 @@ struct ListPacedTrainsResponse {
         (status = 404, description = "Timetable not found"),
     ),
 )]
-async fn get_paced_trains(
+pub(in crate::views) async fn get_paced_trains(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(TimetableIdParam { id: timetable_id }): Path<TimetableIdParam>,
@@ -580,6 +562,7 @@ impl FromStr for TrainId {
 }
 
 /// Retrieve the list of conflict of the timetable (invalid trains are ignored)
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "timetable",
@@ -588,7 +571,7 @@ impl FromStr for TrainId {
         (status = 200, description = "List of conflict", body = Vec<Conflict>),
     ),
 )]
-async fn conflicts(
+pub(in crate::views) async fn conflicts(
     State(AppState {
         db_pool,
         valkey: valkey_client,

--- a/editoast/src/views/timetable/occupancy_blocks.rs
+++ b/editoast/src/views/timetable/occupancy_blocks.rs
@@ -29,7 +29,7 @@ editoast_common::schemas! {
 pub type OccupancyBlocks = Vec<SignalUpdate>;
 
 #[derive(Debug, Deserialize, ToSchema)]
-pub(super) struct OccupancyBlockForm {
+pub(in crate::views) struct OccupancyBlockForm {
     pub(super) infra_id: i64,
     pub(super) electrical_profile_set_id: Option<i64>,
     pub(super) ids: HashSet<i64>,

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -42,22 +42,6 @@ use crate::views::timetable::simulation;
 use crate::views::timetable::simulation::SummaryResponse;
 use crate::views::timetable::simulation::train_simulation_batch;
 
-crate::routes! {
-    "/paced_train" => {
-        delete,
-        "/project_path" => project_path,
-        "/project_path_op" => project_path_op,
-        "/occupancy_blocks" => occupancy_blocks,
-        "/simulation_summary" => simulation_summary,
-        "/{id}" => {
-            get_by_id,
-            update_paced_train,
-            "/path" => get_path,
-            "/simulation" => simulation,
-        },
-    },
-}
-
 editoast_common::schemas! {
     PacedTrainResponse,
     ProjectPathPacedTrainResult,
@@ -116,11 +100,12 @@ impl From<models::PacedTrain> for PacedTrainResponse {
 }
 
 #[derive(Debug, IntoParams, Deserialize)]
-struct PacedTrainIdParam {
+pub(in crate::views) struct PacedTrainIdParam {
     id: i64,
 }
 
 /// Get a paced train by its ID
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "timetable,paced_train",
@@ -129,7 +114,7 @@ struct PacedTrainIdParam {
         (status = 204, body = PacedTrainResponse, description = "The requested paced train")
     )
 )]
-async fn get_by_id(
+pub(in crate::views) async fn get_by_id(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(PacedTrainIdParam { id: paced_train_id }): Path<PacedTrainIdParam>,
@@ -156,6 +141,7 @@ async fn get_by_id(
 }
 
 /// Update a paced train
+#[editoast_derive::route]
 #[utoipa::path(
     put, path = "",
     tag = "timetable,paced_train",
@@ -165,7 +151,7 @@ async fn get_by_id(
         (status = 204, description = "The paced train has been updated")
     )
 )]
-async fn update_paced_train(
+pub(in crate::views) async fn update_paced_train(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(PacedTrainIdParam { id: paced_train_id }): Path<PacedTrainIdParam>,
@@ -191,11 +177,12 @@ async fn update_paced_train(
 }
 
 #[derive(Debug, Deserialize, ToSchema)]
-struct PacedTrainIds {
+pub(in crate::views) struct PacedTrainIds {
     ids: HashSet<i64>,
 }
 
 /// Delete a paced train
+#[editoast_derive::route]
 #[utoipa::path(
     delete, path = "",
     tag = "timetable,paced_train",
@@ -204,7 +191,7 @@ struct PacedTrainIds {
         (status = 204, description = "All paced_trains have been deleted")
     )
 )]
-async fn delete(
+pub(in crate::views) async fn delete(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Json(PacedTrainIds {
@@ -229,7 +216,7 @@ async fn delete(
 }
 
 #[derive(Debug, Clone, Deserialize, ToSchema)]
-struct SimulationBatchForm {
+pub(in crate::views) struct SimulationBatchForm {
     infra_id: i64,
     electrical_profile_set_id: Option<i64>,
     ids: HashSet<i64>,
@@ -238,7 +225,7 @@ struct SimulationBatchForm {
 #[derive(Debug, Serialize, ToSchema)]
 #[cfg_attr(test, derive(PartialEq, serde::Deserialize))]
 #[schema(as = PacedTrainSimulationSummaryResult)]
-struct PacedTrainSummaryResponse {
+pub(in crate::views) struct PacedTrainSummaryResponse {
     #[schema(value_type = SimulationSummaryResult)]
     pub paced_train: SummaryResponse,
     #[schema(value_type = HashMap<String, SimulationSummaryResult>)]
@@ -255,6 +242,7 @@ struct SimulationContext {
 
 /// Associate each paced train id with its simulation summaries response
 /// If the simulation fails, it associates the reason: pathfinding failed or running time failed
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "paced_train",
@@ -263,7 +251,7 @@ struct SimulationContext {
         (status = 200, description = "Associate each paced train id with its simulation summaries", body = HashMap<i64, PacedTrainSimulationSummaryResult>),
     ),
 )]
-async fn simulation_summary(
+pub(in crate::views) async fn simulation_summary(
     State(AppState {
         db_pool,
         valkey: valkey_client,
@@ -377,11 +365,12 @@ async fn simulation_summary(
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, IntoParams, ToSchema)]
 #[into_params(parameter_in = Query)]
-struct ExceptionQueryParam {
+pub(in crate::views) struct ExceptionQueryParam {
     exception_key: Option<String>,
 }
 
 /// Get a path from a paced train given an infrastructure id and a paced train id
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "paced_train,pathfinding",
@@ -391,7 +380,7 @@ struct ExceptionQueryParam {
         (status = 404, description = "Infrastructure or Train schedule not found")
     )
 )]
-async fn get_path(
+pub(in crate::views) async fn get_path(
     State(AppState {
         db_pool,
         valkey: valkey_client,
@@ -460,6 +449,7 @@ pub struct ElectricalProfileSetIdQueryParam {
 }
 
 /// Retrieve the space, speed and time curve of a given train
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "train_schedule",
@@ -468,7 +458,7 @@ pub struct ElectricalProfileSetIdQueryParam {
         (status = 200, description = "Simulation Output", body = SimulationResponse),
     ),
 )]
-async fn simulation(
+pub(in crate::views) async fn simulation(
     State(AppState {
         valkey: valkey_client,
         core_client,
@@ -565,6 +555,7 @@ pub struct ProjectPathPacedTrainResult {
 /// - **Only one train schedule per paced train is projected**.
 /// - The train schedule selected is the first occurrence of the paced train.
 /// - Paced trains that are **invalid** (e.g., due to pathfinding or simulation failure) are **excluded** from the result.
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "paced_train",
@@ -572,7 +563,7 @@ pub struct ProjectPathPacedTrainResult {
     responses(
         (status = 200, description = "Project Path Output", body = HashMap<i64, ProjectPathPacedTrainResult>)),
 )]
-async fn project_path(
+pub(in crate::views) async fn project_path(
     State(AppState {
         db_pool,
         valkey: valkey_client,
@@ -696,6 +687,7 @@ enum BaseOrExceptionId {
     },
 }
 
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "train_schedule",
@@ -704,7 +696,7 @@ enum BaseOrExceptionId {
         (status = 200, description = "Project paced trains on a list of operational points.", body = HashMap<i64,ProjectPathPacedTrainResult>),
     ),
 )]
-async fn project_path_op(
+pub(in crate::views) async fn project_path_op(
     State(AppState {
         db_pool,
         valkey: valkey_client,
@@ -832,6 +824,7 @@ pub struct OccupancyBlocksPacedTrainResult {
     pub exceptions: HashMap<String, OccupancyBlocks>,
 }
 
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "paced_train",
@@ -840,7 +833,7 @@ pub struct OccupancyBlocksPacedTrainResult {
         (status = 200, body = HashMap<i64, OccupancyBlocksPacedTrainResult>),
     ),
 )]
-async fn occupancy_blocks(
+pub(in crate::views) async fn occupancy_blocks(
     State(AppState {
         db_pool,
         valkey: valkey_client,

--- a/editoast/src/views/timetable/similar_trains.rs
+++ b/editoast/src/views/timetable/similar_trains.rs
@@ -76,10 +76,6 @@ editoast_common::schemas! {
     WaypointResponse,
 }
 
-crate::routes! {
-    "/similar_trains" => similar_trains,
-}
-
 #[derive(Debug, Deserialize, ToSchema)]
 #[cfg_attr(test, derive(Serialize))]
 struct RollingStockCharacteristics {
@@ -111,7 +107,7 @@ impl std::fmt::Debug for Waypoint {
 
 #[derive(Debug, Deserialize, ToSchema)]
 #[cfg_attr(test, derive(Serialize))]
-struct Request {
+pub(in crate::views) struct Request {
     #[schema(inline)]
     rolling_stock: RollingStockCharacteristics,
     #[schema(value_type = Vec<SimilarTrainWaypoint>)]
@@ -147,7 +143,7 @@ struct SimilarTrainItem {
 
 #[derive(Debug, Serialize, ToSchema)]
 #[cfg_attr(test, derive(Deserialize, PartialEq))]
-struct Response {
+pub(in crate::views) struct Response {
     #[schema(inline)]
     similar_trains: Vec<SimilarTrainItem>,
 }
@@ -181,6 +177,7 @@ enum SimilarTrainsError {
     Database(editoast_models::model::Error),
 }
 
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "similar_trains,stdcm,sncf",
@@ -193,7 +190,7 @@ enum SimilarTrainsError {
         ),
     ),
 )]
-async fn similar_trains(
+pub(in crate::views) async fn similar_trains(
     Extension(auth): AuthenticationExt,
     State(AppState {
         db_pool,

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -66,16 +66,12 @@ editoast_common::schemas! {
     StdcmResponse,
 }
 
-crate::routes! {
-    "/stdcm" => stdcm,
-}
-
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, ToSchema)]
 #[serde(tag = "status", rename_all = "snake_case")]
 // We accepted the difference of memory size taken by variants
 // Since there is only on success and others are error cases
 #[allow(clippy::large_enum_variant)]
-enum StdcmResponse {
+pub(in crate::views) enum StdcmResponse {
     Success {
         simulation: SimulationResponseSuccess,
         path: PathfindingResultSuccess,
@@ -124,7 +120,7 @@ enum StdcmError {
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, IntoParams, ToSchema)]
-struct InfraIdQueryParam {
+pub(in crate::views) struct InfraIdQueryParam {
     infra: i64,
 }
 
@@ -137,6 +133,7 @@ struct InfraIdQueryParam {
 /// If the simulation fails, the function uses a virtual train to detect conflicts
 /// with existing train schedules. It then returns both the conflict information
 /// and the pathfinding result from the virtual train's simulation.
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "stdcm",
@@ -148,7 +145,7 @@ struct InfraIdQueryParam {
         (status = 201, body = inline(StdcmResponse), description = "The simulation result"),
     )
 )]
-async fn stdcm(
+pub(in crate::views) async fn stdcm(
     State(AppState {
         config,
         db_pool,

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -71,24 +71,6 @@ use crate::views::timetable::simulation::build_sim_schedule_items;
 use super::simulation::SummaryResponse;
 use super::simulation::train_simulation_batch;
 
-crate::routes! {
-    "/train_schedule" => {
-        delete,
-        "/project_path" => project_path,
-        "/project_path_op" => project_path_op,
-        "/occupancy_blocks" => occupancy_blocks,
-        "/track_occupancy" => track_occupancy,
-        "/simulation_summary" => simulation_summary,
-        "/{id}" => {
-            get,
-            put,
-            "/simulation" => simulation,
-            "/path" => get_path,
-            "/etcs_braking_curves" => etcs_braking_curves,
-        },
-    },
-}
-
 editoast_common::schemas! {
     TrainSchedule,
     TrainScheduleForm,
@@ -128,7 +110,7 @@ pub enum TrainScheduleError {
 }
 
 #[derive(IntoParams, Deserialize)]
-struct TrainScheduleIdParam {
+pub(in crate::views) struct TrainScheduleIdParam {
     /// A train schedule ID
     id: i64,
 }
@@ -171,6 +153,7 @@ impl From<TrainScheduleForm> for TrainScheduleChangeset {
 }
 
 /// Return a specific train schedule
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "train_schedule",
@@ -179,7 +162,7 @@ impl From<TrainScheduleForm> for TrainScheduleChangeset {
         (status = 200, description = "The train schedule", body = TrainScheduleResponse)
     )
 )]
-async fn get(
+pub(in crate::views) async fn get(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(TrainScheduleIdParam {
@@ -204,11 +187,12 @@ async fn get(
 }
 
 #[derive(Debug, Deserialize, ToSchema)]
-struct TrainScheduleIds {
+pub(in crate::views) struct TrainScheduleIds {
     ids: HashSet<i64>,
 }
 
 /// Delete a train schedule and its result
+#[editoast_derive::route]
 #[utoipa::path(
     delete, path = "",
     tag = "timetable,train_schedule",
@@ -217,7 +201,7 @@ struct TrainScheduleIds {
         (status = 204, description = "All train schedules have been deleted")
     )
 )]
-async fn delete(
+pub(in crate::views) async fn delete(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Json(TrainScheduleIds { ids: train_ids }): Json<TrainScheduleIds>,
@@ -240,6 +224,7 @@ async fn delete(
 }
 
 /// Update  train schedule at once
+#[editoast_derive::route]
 #[utoipa::path(
     put, path = "",
     tag = "train_schedule,timetable",
@@ -249,7 +234,7 @@ async fn delete(
         (status = 200, description = "The train schedule have been updated", body = TrainScheduleResponse)
     )
 )]
-async fn put(
+pub(in crate::views) async fn put(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(TrainScheduleIdParam {
@@ -284,6 +269,7 @@ pub struct ElectricalProfileSetIdQueryParam {
 }
 
 /// Retrieve the space, speed and time curve of a given train
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "train_schedule",
@@ -292,7 +278,7 @@ pub struct ElectricalProfileSetIdQueryParam {
         (status = 200, description = "Simulation Output", body = SimulationResponse),
     ),
 )]
-async fn simulation(
+pub(in crate::views) async fn simulation(
     State(AppState {
         valkey: valkey_client,
         core_client,
@@ -357,6 +343,7 @@ async fn simulation(
 }
 
 /// Retrieve the etcs braking curves of an etcs train on etcs portions of the path
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "train_schedule,etcs_braking_curves",
@@ -365,7 +352,7 @@ async fn simulation(
         (status = 200, description = "ETCS Braking Curves Output", body = ETCSBrakingCurvesResponse),
     ),
 )]
-async fn etcs_braking_curves(
+pub(in crate::views) async fn etcs_braking_curves(
     State(AppState {
         valkey: valkey_client,
         core_client,
@@ -493,7 +480,7 @@ async fn etcs_braking_curves(
 }
 
 #[derive(Debug, Clone, Deserialize, ToSchema)]
-struct SimulationBatchForm {
+pub(in crate::views) struct SimulationBatchForm {
     infra_id: i64,
     electrical_profile_set_id: Option<i64>,
     ids: HashSet<i64>,
@@ -501,6 +488,7 @@ struct SimulationBatchForm {
 
 /// Associate each train id with its simulation summary response
 /// If the simulation fails, it associates the reason: pathfinding failed or running time failed
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "train_schedule",
@@ -509,7 +497,7 @@ struct SimulationBatchForm {
         (status = 200, description = "Associate each train id with its simulation summary", body = HashMap<i64, SimulationSummaryResult>),
     ),
 )]
-async fn simulation_summary(
+pub(in crate::views) async fn simulation_summary(
     State(AppState {
         db_pool,
         valkey: valkey_client,
@@ -576,6 +564,7 @@ async fn simulation_summary(
 }
 
 /// Get a path from a trainschedule given an infrastructure id and a train schedule id
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "train_schedule,pathfinding",
@@ -585,7 +574,7 @@ async fn simulation_summary(
         (status = 404, description = "Infrastructure or Train schedule not found")
     )
 )]
-async fn get_path(
+pub(in crate::views) async fn get_path(
     State(AppState {
         db_pool,
         valkey: valkey_client,
@@ -639,6 +628,7 @@ async fn get_path(
 /// - Returns 200 with a hashmap of train_id to ProjectPathTrainResult
 ///
 /// Train schedules that are invalid (pathfinding or simulation failed) are not included in the result
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "train_schedule",
@@ -647,7 +637,7 @@ async fn get_path(
         (status = 200, description = "Project Path Output", body = HashMap<i64, Vec<SpaceTimeCurve>>),
     ),
 )]
-async fn project_path(
+pub(in crate::views) async fn project_path(
     State(AppState {
         db_pool,
         valkey: valkey_client,
@@ -711,6 +701,7 @@ async fn project_path(
     Ok(Json(project_path_result))
 }
 
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "train_schedule",
@@ -719,7 +710,7 @@ async fn project_path(
         (status = 200, description = "Project train schedules on a list of operational points.", body = HashMap<i64, Vec<SpaceTimeCurve>>),
     ),
 )]
-async fn project_path_op(
+pub(in crate::views) async fn project_path_op(
     State(AppState {
         db_pool,
         valkey: valkey_client,
@@ -788,6 +779,7 @@ async fn project_path_op(
     Ok(Json(results))
 }
 
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "train_schedule",
@@ -796,7 +788,7 @@ async fn project_path_op(
         (status = 200, body = HashMap<i64, Vec<SignalUpdate>>),
     ),
 )]
-async fn occupancy_blocks(
+pub(in crate::views) async fn occupancy_blocks(
     State(AppState {
         db_pool,
         valkey: valkey_client,
@@ -864,7 +856,7 @@ async fn occupancy_blocks(
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, ToSchema)]
-struct TrackOccupancyForm {
+pub(in crate::views) struct TrackOccupancyForm {
     train_schedule_ids: Vec<i64>,
     operational_point_id: String,
     infra_id: i64,
@@ -872,7 +864,7 @@ struct TrackOccupancyForm {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
-struct TrackOccupancy {
+pub(in crate::views) struct TrackOccupancy {
     time_begin: DateTime<Utc>,
     #[schema(value_type = chrono::Duration, example = "PT5M")]
     duration: PositiveDuration,
@@ -887,6 +879,7 @@ struct TrackOccupancy {
 ///
 /// If a path item ID is provided, it uses schedule data to determine stop duration and location.
 /// If not, it infers the position and time based on track offsets and interpolation.
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "train_schedule",
@@ -895,7 +888,7 @@ struct TrackOccupancy {
         (status = 200, description = "Track section occupancy periods for a set of train schedules", body = inline(HashMap<String, Vec<TrackOccupancy>>)),
     ),
 )]
-async fn track_occupancy(
+pub(in crate::views) async fn track_occupancy(
     State(AppState {
         db_pool,
         valkey,

--- a/editoast/src/views/work_schedules.rs
+++ b/editoast/src/views/work_schedules.rs
@@ -34,22 +34,6 @@ use utoipa::IntoParams;
 use utoipa::ToSchema;
 use uuid::Uuid;
 
-crate::routes! {
-    "/work_schedules" => {
-        create,
-        "/project_path" => project_path,
-        "/group" => {
-            create_group,
-            list_groups,
-            "/{id}" => {
-                delete_group,
-                get_group,
-                put_in_group,
-            },
-        },
-    },
-}
-
 editoast_common::schemas! {
     WorkSchedule,
     WorkScheduleItemForm,
@@ -57,7 +41,7 @@ editoast_common::schemas! {
 }
 
 #[derive(IntoParams, Deserialize)]
-struct WorkScheduleGroupIdParam {
+pub(in crate::views) struct WorkScheduleGroupIdParam {
     /// A work schedule group ID
     id: i64,
 }
@@ -90,7 +74,7 @@ impl From<work_schedules::WsGroupError> for WorkScheduleError {
 
 #[derive(Serialize, Deserialize, ToSchema)]
 #[serde(remote = "Self")]
-struct WorkScheduleItemForm {
+pub(in crate::views) struct WorkScheduleItemForm {
     pub start_date_time: DateTime<Utc>,
     pub end_date_time: DateTime<Utc>,
     pub track_ranges: Vec<TrackRange>,
@@ -142,16 +126,17 @@ impl WorkScheduleItemForm {
 
 /// This structure is used by the post endpoint to create a work schedule
 #[derive(Serialize, Deserialize, ToSchema)]
-struct WorkScheduleCreateForm {
+pub(in crate::views) struct WorkScheduleCreateForm {
     work_schedule_group_name: String,
     work_schedules: Vec<WorkScheduleItemForm>,
 }
 
 #[derive(Serialize, Deserialize, ToSchema)]
-struct WorkScheduleCreateResponse {
+pub(in crate::views) struct WorkScheduleCreateResponse {
     work_schedule_group_id: i64,
 }
 
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "work_schedules",
@@ -160,7 +145,7 @@ struct WorkScheduleCreateResponse {
         (status = 201, body = inline(WorkScheduleCreateResponse), description = "The id of the created work schedule group"),
     )
 )]
-async fn create(
+pub(in crate::views) async fn create(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Json(WorkScheduleCreateForm {
@@ -196,7 +181,7 @@ async fn create(
 }
 
 #[derive(Serialize, Deserialize, ToSchema)]
-struct WorkScheduleProjectForm {
+pub(in crate::views) struct WorkScheduleProjectForm {
     work_schedule_group_id: i64,
     #[schema(value_type = Vec<TrackRange>)]
     path_track_ranges: Vec<core_client::pathfinding::TrackRange>,
@@ -204,7 +189,7 @@ struct WorkScheduleProjectForm {
 
 /// Represents the projection of a work schedule on a path.
 #[derive(Serialize, Deserialize, ToSchema, PartialEq, Debug)]
-struct WorkScheduleProjection {
+pub(in crate::views) struct WorkScheduleProjection {
     #[serde(rename = "type")]
     #[schema(inline)]
     /// The type of the work schedule.
@@ -219,6 +204,7 @@ struct WorkScheduleProjection {
     pub path_position_ranges: Vec<Intersection>,
 }
 
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "work_schedules",
@@ -231,7 +217,7 @@ struct WorkScheduleProjection {
         ),
     )
 )]
-async fn project_path(
+pub(in crate::views) async fn project_path(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Json(WorkScheduleProjectForm {
@@ -289,15 +275,16 @@ async fn project_path(
 }
 
 #[derive(Serialize, Deserialize, ToSchema)]
-struct WorkScheduleGroupCreateForm {
+pub(in crate::views) struct WorkScheduleGroupCreateForm {
     work_schedule_group_name: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, ToSchema)]
-struct WorkScheduleGroupCreateResponse {
+pub(in crate::views) struct WorkScheduleGroupCreateResponse {
     work_schedule_group_id: i64,
 }
 
+#[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "work_schedules",
@@ -306,7 +293,7 @@ struct WorkScheduleGroupCreateResponse {
         (status = 200, body = inline(WorkScheduleGroupCreateResponse), description = "The id of the created work schedule group"),
     )
 )]
-async fn create_group(
+pub(in crate::views) async fn create_group(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Json(WorkScheduleGroupCreateForm {
@@ -337,6 +324,7 @@ async fn create_group(
     }))
 }
 
+#[editoast_derive::route]
 #[utoipa::path(
     delete, path = "",
     tag = "work_schedules",
@@ -346,7 +334,7 @@ async fn create_group(
         (status = 404, description = "The work schedule group does not exist"),
     )
 )]
-async fn delete_group(
+pub(in crate::views) async fn delete_group(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(WorkScheduleGroupIdParam { id: group_id }): Path<WorkScheduleGroupIdParam>,
@@ -368,6 +356,7 @@ async fn delete_group(
     Ok(axum::http::StatusCode::NO_CONTENT)
 }
 
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "work_schedules",
@@ -375,7 +364,7 @@ async fn delete_group(
         (status = 201, body = Vec<i64>, description = "The existing work schedule group ids"),
     )
 )]
-async fn list_groups(
+pub(in crate::views) async fn list_groups(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
 ) -> Result<Json<Vec<i64>>> {
@@ -399,6 +388,7 @@ async fn list_groups(
     Ok(Json(work_schedule_group_ids))
 }
 
+#[editoast_derive::route]
 #[utoipa::path(
     put, path = "",
     tag = "work_schedules",
@@ -409,7 +399,7 @@ async fn list_groups(
         (status = 404, description = "Work schedule group not found"),
     )
 )]
-async fn put_in_group(
+pub(in crate::views) async fn put_in_group(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(WorkScheduleGroupIdParam { id: group_id }): Path<WorkScheduleGroupIdParam>,
@@ -450,7 +440,7 @@ async fn put_in_group(
 
 #[derive(Serialize, ToSchema)]
 #[cfg_attr(test, derive(Deserialize))]
-struct GroupContentResponse {
+pub(in crate::views) struct GroupContentResponse {
     #[schema(value_type = Vec<WorkSchedule>)]
     results: Vec<WorkSchedule>,
     #[serde(flatten)]
@@ -464,6 +454,7 @@ pub struct WorkScheduleOrderingParam {
     pub ordering: Ordering,
 }
 
+#[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "work_schedules",
@@ -473,7 +464,7 @@ pub struct WorkScheduleOrderingParam {
         (status = 404, description = "Work schedule group not found"),
     )
 )]
-async fn get_group(
+pub(in crate::views) async fn get_group(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(WorkScheduleGroupIdParam { id: group_id }): Path<WorkScheduleGroupIdParam>,


### PR DESCRIPTION
Replaces the `routes!` macro by a pure Rust builder. Leverages `linkme` to associate a route's function name to its generated `impl utopia::Path`. 

This PR contains:

* `DocumentedRouter`: wraps `axum::Router` and collects OpenAPI paths
* `#[editoast_derive::route]` to collect route documentation
* `crate::views::service_router()`: the function defining the router for the whole service
* each route handler has been made `pub(in crate::views)` to use it in `service_router`
* so have been all the types appearing in their signature: indeed, given `f: fn(T...) -> U`, you can only get `f as *const ()` as long as **both** `f` and `T...` and `U` are **all** accessible in the current scope
* the `DocumentedRouter` has been designed to allow featuring everything related to utopia in the future, hoping this would reduce compile times provided the number of macro expansions
* the openapi generation has been updated
* the test app as well