### PR TITLE
core: pathfinding: fix error in cost tracking on intermediate waypoints

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/pathfinding/Pathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/pathfinding/Pathfinding.kt
@@ -275,7 +275,7 @@ class Pathfinding<NodeT : Any, EdgeT : Any, OffsetType>(
                         registerStep(
                             newRange,
                             step.prev,
-                            step.totalDistance,
+                            step.prev?.totalDistance ?: 0.0,
                             newNReachedTargets,
                             stepTargets
                         )


### PR DESCRIPTION
When passing an intermediate waypoint, we'd count twice the cost of the edge on which the point is placed.

In some cases, that can result in a suboptimal path.

~~*May* fix https://github.com/OpenRailAssociation/osrd/issues/12711, but I'll need to test further.~~ edit: nope, not fixed