### PR TITLE
pathfinding: use speed limit tag to compute speed limits

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlockRequest.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlockRequest.kt
@@ -17,6 +17,7 @@ class PathfindingBlockRequest(
     val rollingStockSupportedSignalingSystems: List<String>,
     @Json(name = "rolling_stock_maximum_speed") val rollingStockMaximumSpeed: Double,
     @Json(name = "rolling_stock_length") val rollingStockLength: Double,
+    @Json(name = "speed_limit_tag") val speedLimitTag: String? = null,
     val timeout: Double?,
     val infra: String,
     @Json(name = "expected_version") val expectedVersion: Int?,

--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.kt
@@ -171,6 +171,7 @@ private fun computePaths(
             infra.blockInfra,
             initialRequest.rollingStockMaximumSpeed,
             initialRequest.rollingStockLength,
+            initialRequest.speedLimitTag,
         )
     val constraintCombiner = ConstraintCombiner(constraints.toMutableList())
 

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
@@ -50,7 +50,13 @@ class STDCMGraph(
     val allowanceManager = EngineeringAllowanceManager(rollingStock.constGamma, this)
     val backtrackingManager: BacktrackingManager = BacktrackingManager(this)
     val mrspBuilder =
-        CachedBlockMRSPBuilder(rawInfra, blockInfra, rollingStock, temporarySpeedLimitManager)
+        CachedBlockMRSPBuilder(
+            rawInfra,
+            blockInfra,
+            rollingStock,
+            speedLimitTag = tag,
+            temporarySpeedLimitManager = temporarySpeedLimitManager,
+        )
 
     // min 30s between two edges, determined empirically
     // TODO: this value *should* reflect twice the min delay between two trains,

--- a/core/src/main/kotlin/fr/sncf/osrd/utils/CachedBlockMRSPBuilder.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/utils/CachedBlockMRSPBuilder.kt
@@ -58,7 +58,7 @@ data class CachedBlockMRSPBuilder(
                 pathProps,
                 rsMaxSpeed,
                 rsLength,
-                useSpeedLimits = true,
+                addRollingStockLength = true,
                 speedLimitTag,
                 temporarySpeedLimitManager,
             )

--- a/core/src/main/kotlin/fr/sncf/osrd/utils/CachedBlockMRSPBuilder.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/utils/CachedBlockMRSPBuilder.kt
@@ -11,12 +11,19 @@ import fr.sncf.osrd.sim_infra.impl.TemporarySpeedLimitManager
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 
-/** Used to compute block MRSPs and min time required to reach a point, with proper caching */
+/**
+ * Used to compute block MRSPs and min time required to reach a point, with proper caching
+ *
+ * TODO: this ignores speed limits by route for now. It makes caching a lot less efficient though
+ *   (can't just use block as key), it will have a significant performance cost. Should be supported
+ *   once we import them, but not necessarily before that.
+ */
 data class CachedBlockMRSPBuilder(
     val rawInfra: RawInfra,
     val blockInfra: BlockInfra,
     private val rsMaxSpeed: Double,
     private val rsLength: Double,
+    private val speedLimitTag: String? = null,
     val temporarySpeedLimitManager: TemporarySpeedLimitManager = TemporarySpeedLimitManager(),
 ) {
     private val mrspCache = mutableMapOf<BlockId, Envelope>()
@@ -25,20 +32,36 @@ data class CachedBlockMRSPBuilder(
         rawInfra: RawInfra,
         blockInfra: BlockInfra,
         rollingStock: PhysicsRollingStock?,
+        speedLimitTag: String? = null,
         temporarySpeedLimitManager: TemporarySpeedLimitManager = TemporarySpeedLimitManager(),
     ) : this(
         rawInfra,
         blockInfra,
         rollingStock?.maxSpeed ?: DEFAULT_MAX_ROLLING_STOCK_SPEED,
         rollingStock?.length ?: 0.0,
+        speedLimitTag,
         temporarySpeedLimitManager,
     )
 
     /** Returns the speed limits for the given block (cached). */
     fun getMRSP(block: BlockId): Envelope {
         return mrspCache.computeIfAbsent(block) {
-            val pathProps = makePathProps(blockInfra, rawInfra, block, routes = listOf())
-            computeMRSP(pathProps, rsMaxSpeed, rsLength, false, null, temporarySpeedLimitManager)
+            val pathProps =
+                makePathProps(
+                    blockInfra,
+                    rawInfra,
+                    block,
+                    // TODO: change input to infra explorers, and fetch last route there
+                    routes = listOf(),
+                )
+            computeMRSP(
+                pathProps,
+                rsMaxSpeed,
+                rsLength,
+                useSpeedLimits = true,
+                speedLimitTag,
+                temporarySpeedLimitManager,
+            )
         }
     }
 

--- a/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingTest.kt
@@ -37,6 +37,7 @@ fun getPathfindingBlockRequest(
         rs.maxSpeed,
         rs.length,
         null,
+        null,
         infra,
         1,
         pathItems,

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/FullSTDCMTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/FullSTDCMTests.kt
@@ -447,6 +447,7 @@ fun makeRequirementsFromPath(
                 rollingStock.maxSpeed,
                 rollingStock.length,
                 null,
+                null,
                 "",
                 null,
                 listOf(startLocations, endLocations),

--- a/editoast/core_client/src/pathfinding.rs
+++ b/editoast/core_client/src/pathfinding.rs
@@ -32,6 +32,8 @@ pub struct PathfindingRequest {
     pub rolling_stock_maximum_speed: f64,
     /// Rolling stock length in meters:
     pub rolling_stock_length: f64,
+    /// Speed limit tag, used to estimate the max speed and travel time
+    pub speed_limit_tag: Option<String>,
 }
 
 #[editoast_derive::openapi_schema]

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -10686,6 +10686,10 @@ components:
           items:
             type: string
           description: List of supported signaling systems
+        speed_limit_tag:
+          type: string
+          description: Speed limit tag, used to estimate the travel time
+          nullable: true
     PathfindingInputError:
       oneOf:
       - type: object

--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -75,6 +75,8 @@ struct PathfindingInput {
     /// Rolling stock length
     #[schema(value_type = f64)]
     rolling_stock_length: OrderedFloat<f64>,
+    /// Speed limit tag, used to estimate the travel time
+    speed_limit_tag: Option<String>,
 }
 
 impl PathfindingInput {
@@ -392,6 +394,7 @@ fn build_pathfinding_request(
             .clone(),
         rolling_stock_maximum_speed: pathfinding_input.rolling_stock_maximum_speed.0,
         rolling_stock_length: pathfinding_input.rolling_stock_length.0,
+        speed_limit_tag: pathfinding_input.speed_limit_tag.clone(),
     })
 }
 
@@ -473,6 +476,7 @@ pub async fn pathfinding_from_train_batch<T: TrainScheduleLike>(
                 .iter()
                 .map(|item| item.location.clone())
                 .collect(),
+            speed_limit_tag: train_schedule.speed_limit_tag().cloned(),
         };
         to_compute.push(path_input);
         to_compute_index.push(index);

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -3422,6 +3422,8 @@ export type PathfindingInput = {
   rolling_stock_supported_electrifications: string[];
   /** List of supported signaling systems */
   rolling_stock_supported_signaling_systems: string[];
+  /** Speed limit tag, used to estimate the travel time */
+  speed_limit_tag?: string | null;
 };
 export type RoutePath = {
   switches_directions: (string & string)[][];


### PR DESCRIPTION
Fix https://github.com/OpenRailAssociation/osrd/issues/12711

The pathfinding looks for the shortest path (in terms of travel time at max speed), but we ignored the speed limit tags. That resulted in "wrong" results, where the train is slowed down for no good reason. 

With this PR, core can take a speed limit tag parameter. Editoast fetches it from the train schedule when simulating a train schedule, or exposes it in the API in the pure pathfinding endpoint. 
