### PR TITLE
front: handle subcategories in timetable filter

### DIFF
--- a/front/src/modules/timetableItem/components/Timetable/FilterPanel.tsx
+++ b/front/src/modules/timetableItem/components/Timetable/FilterPanel.tsx
@@ -3,11 +3,8 @@ import { X } from '@osrd-project/ui-icons';
 import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
 
-import type { TrainMainCategory } from 'common/api/osrdEditoastApi';
-import {
-  getMainCategoryOptions,
-  type MainCategoryOptionWithId,
-} from 'modules/rollingStock/hooks/getMainCategoryOptions';
+import type { SubCategory, TrainMainCategories } from 'common/api/osrdEditoastApi';
+import useCategoryOptions from 'modules/rollingStock/hooks/useCategoryOptions';
 
 import type {
   ValidityFilter,
@@ -15,6 +12,7 @@ import type {
   TimetableFilters,
   TrainTypeFilter,
 } from './types';
+import { extractCategoryId } from './utils';
 
 type FilterPanelProps = {
   toggleFilterPanel: () => void;
@@ -23,8 +21,7 @@ type FilterPanelProps = {
 
 const FilterPanel = ({ toggleFilterPanel, timetableFilters }: FilterPanelProps) => {
   const { t } = useTranslation('operational-studies', { keyPrefix: 'main' });
-  const { t: translation } = useTranslation('translation', { keyPrefix: 'rollingStock' });
-  const categoryOptions = getMainCategoryOptions(translation, false);
+  const categoryOptions = useCategoryOptions(false);
 
   const {
     nameLabelFilter,
@@ -63,13 +60,13 @@ const FilterPanel = ({ toggleFilterPanel, timetableFilters }: FilterPanelProps) 
   ];
 
   const formattedCategoryOptions: {
-    id: 'all' | 'noCategory' | TrainMainCategory;
+    id: 'all' | 'noCategory' | (TrainMainCategories | SubCategory['code']);
     label: string;
   }[] = [
     { id: 'all', label: t('timetable.showAllCategories') },
     { id: 'noCategory', label: t('timetable.showTrainsWithNoCategory') },
     ...categoryOptions.map((option) => ({
-      id: (option as MainCategoryOptionWithId).id,
+      id: extractCategoryId(option.id),
       label: option.label,
     })),
   ];

--- a/front/src/modules/timetableItem/components/Timetable/types.ts
+++ b/front/src/modules/timetableItem/components/Timetable/types.ts
@@ -5,8 +5,9 @@ import type {
   PathfindingInputError,
   PathfindingNotFound,
   SimulationSummaryResult,
-  TrainMainCategory,
+  TrainMainCategories,
   TrainScheduleResponse,
+  SubCategory,
 } from 'common/api/osrdEditoastApi';
 import type {
   OccurrenceId,
@@ -22,7 +23,10 @@ export type ScheduledPointsHonoredFilter = 'both' | 'honored' | 'notHonored';
 
 export type TrainTypeFilter = 'both' | 'pacedTrain' | 'trainSchedule';
 
-export type TrainCategoryFilter = 'all' | 'noCategory' | TrainMainCategory;
+export type TrainCategoryFilter =
+  | 'all'
+  | 'noCategory'
+  | (TrainMainCategories | SubCategory['code']);
 
 type SimulationSummaryResultSuccess = Extract<SimulationSummaryResult, { status: 'success' }>;
 

--- a/front/src/modules/timetableItem/components/Timetable/useFilterTimetableItems.ts
+++ b/front/src/modules/timetableItem/components/Timetable/useFilterTimetableItems.ts
@@ -121,14 +121,15 @@ const useFilterTimetableItems = (
       // Apply train category filter
       if (trainCategoryFilter !== 'all') {
         if (trainCategoryFilter === 'noCategory') {
-          if (category) {
-            return false;
+          if (category) return false;
+        } else {
+          if (!category) return false;
+
+          if (isMainCategory(category)) {
+            if (category.main_category !== trainCategoryFilter) return false;
+          } else {
+            if (category.sub_category_code !== trainCategoryFilter) return false;
           }
-        } else if (
-          !category ||
-          (isMainCategory(category) && category.main_category !== trainCategoryFilter)
-        ) {
-          return false;
         }
       }
 

--- a/front/src/modules/timetableItem/components/Timetable/utils.ts
+++ b/front/src/modules/timetableItem/components/Timetable/utils.ts
@@ -1,7 +1,12 @@
 import dayjs from 'dayjs';
 import { omit } from 'lodash';
 
-import type { PacedTrain, TrainSchedule } from 'common/api/osrdEditoastApi';
+import type {
+  PacedTrain,
+  SubCategory,
+  TrainMainCategories,
+  TrainSchedule,
+} from 'common/api/osrdEditoastApi';
 import type { TimetableItem, TimetableItemId } from 'reducers/osrdconf/types';
 import type { Duration } from 'utils/duration';
 import { isPacedTrainResponseWithPacedTrainId } from 'utils/trainId';
@@ -74,3 +79,13 @@ export const exportTimetableItems = (
   a.download = 'timetable.json';
   a.click();
 };
+
+export function extractCategoryId(fullId: string): TrainMainCategories | SubCategory['code'] {
+  const [prefix, code] = fullId.split(':');
+
+  if (prefix === 'main' || prefix === 'sub') {
+    return code;
+  }
+
+  throw new Error(`Unknown category prefix: ${prefix}`);
+}


### PR DESCRIPTION
closes #12740 

to test it : 
```
curl -X POST 'http://localhost:4000/api/sub_category' -H 'content-type: application/json' -d '[{"code": "tjv", "name": "TJV", "main_category": "HIGH_SPEED_TRAIN", "color": "#FF0000", "background_color": "#FF0000", "hovered_color": "#FF0000"}]'
```