### PR TITLE
Add node memory limit option to avoid OOM

### DIFF
--- a/front/docker/Dockerfile.devel
+++ b/front/docker/Dockerfile.devel
@@ -14,6 +14,7 @@ WORKDIR /app
 # Fill build time values
 ARG OSRD_GIT_DESCRIBE
 ENV VITE_OSRD_GIT_DESCRIBE=${OSRD_GIT_DESCRIBE}
+ENV NODE_OPTIONS="--max_old_space_size=4096"
 
 # Start the app
 COPY docker/dev-entrypoint.sh /


### PR DESCRIPTION
> [!NOTE]
> On MacOS, using colima, 10Gb of RAM dedicated looks like enough to be able to build everything. 
> See this doc: https://osrd.fr/en/docs/guides/contribute/install-docker/