### PR TITLE
editoast: use associated type in Count and List instead of InternalError

### DIFF
--- a/editoast/editoast_derive/src/model/codegen.rs
+++ b/editoast/editoast_derive/src/model/codegen.rs
@@ -362,6 +362,7 @@ impl ModelConfig {
         CountImpl {
             model: self.model.clone(),
             table_mod: self.table.clone(),
+            error: self.errors.list.clone(),
         }
         .tokens_if(self.impl_plan.list)
     }

--- a/editoast/editoast_derive/src/model/codegen.rs
+++ b/editoast/editoast_derive/src/model/codegen.rs
@@ -354,6 +354,7 @@ impl ModelConfig {
             table_mod: self.table.clone(),
             row: self.row.name.clone(),
             columns: self.columns().cloned().collect(),
+            error: self.errors.list.clone(),
         }
         .tokens_if(self.impl_plan.list)
     }

--- a/editoast/editoast_derive/src/model/codegen/count_impl.rs
+++ b/editoast/editoast_derive/src/model/codegen/count_impl.rs
@@ -4,16 +4,23 @@ use quote::quote;
 pub(crate) struct CountImpl {
     pub(super) model: syn::Ident,
     pub(super) table_mod: syn::Path,
+    pub(super) error: syn::Path,
 }
 
 impl ToTokens for CountImpl {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        let Self { model, table_mod } = self;
+        let Self {
+            model,
+            table_mod,
+            error,
+        } = self;
         let span_name = format!("model:count<{model}>");
 
         tokens.extend(quote! {
             #[automatically_derived]
             impl crate::models::prelude::Count for #model {
+                type Error = #error;
+
                 #[tracing::instrument(name = #span_name, skip_all, ret, err, fields(
                     nb_filters = settings.filters.len(),
                     paginate_counting = settings.paginate_counting,
@@ -23,7 +30,7 @@ impl ToTokens for CountImpl {
                 async fn count(
                     conn: &mut database::DbConnection,
                     settings: crate::models::prelude::SelectionSettings<Self>,
-                ) -> crate::error::Result<u64> {
+                ) -> std::result::Result<u64, Self::Error> {
                     use diesel::QueryDsl;
                     use diesel_async::RunQueryDsl;
                     use futures_util::stream::TryStreamExt;
@@ -48,7 +55,10 @@ impl ToTokens for CountImpl {
                         }
                     }
 
-                    Ok(query.get_result::<i64>(conn.write().await.deref_mut()).await? as u64)
+                    query.get_result::<i64>(conn.write().await.deref_mut())
+                        .await
+                        .map(|count| count as u64)
+                        .map_err(|e| Self::Error::from(editoast_models::model::Error::from(e)))
                 }
             }
 

--- a/editoast/editoast_derive/src/model/codegen/list_impl.rs
+++ b/editoast/editoast_derive/src/model/codegen/list_impl.rs
@@ -6,6 +6,7 @@ pub(crate) struct ListImpl {
     pub(super) table_mod: syn::Path,
     pub(super) row: syn::Ident,
     pub(super) columns: Vec<syn::Ident>,
+    pub(super) error: syn::Path,
 }
 
 impl ToTokens for ListImpl {
@@ -15,12 +16,15 @@ impl ToTokens for ListImpl {
             table_mod,
             row,
             columns,
+            error,
         } = self;
         let span_name = format!("model:list<{model}>");
 
         tokens.extend(quote! {
             #[automatically_derived]
             impl crate::models::prelude::List for #model {
+                type Error = #error;
+
                 #[tracing::instrument(name = #span_name, skip_all, err, fields(
                     nb_filters = settings.filters.len(),
                     nb_sorts = settings.sorts.len(),
@@ -31,7 +35,7 @@ impl ToTokens for ListImpl {
                 async fn list(
                     conn: &mut database::DbConnection,
                     settings: crate::models::prelude::SelectionSettings<Self>,
-                ) -> crate::error::Result<Vec<Self>> {
+                ) -> std::result::Result<Vec<Self>, Self::Error> {
                     use diesel::QueryDsl;
                     use diesel_async::RunQueryDsl;
                     use futures_util::stream::TryStreamExt;
@@ -60,15 +64,15 @@ impl ToTokens for ListImpl {
                         query = query.offset(offset);
                     }
 
-                    let results: Vec<#model> = query
+                    query
                         .select((#(dsl::#columns,)*))
                         .load_stream::<#row>(conn.write().await.deref_mut())
-                        .await?
+                        .await
+                        .map_err(|e| Self::Error::from(editoast_models::model::Error::from(e)))?
                         .map_ok(<#model as crate::models::prelude::Model>::from_row)
-                        .try_collect()
-                        .await?;
-
-                    Ok(results)
+                        .try_collect::<Vec<_>>()
+                        .await
+                        .map_err(|e| Self::Error::from(editoast_models::model::Error::from(e)))
                 }
             }
 

--- a/editoast/editoast_derive/src/model/config.rs
+++ b/editoast/editoast_derive/src/model/config.rs
@@ -68,6 +68,7 @@ pub(crate) struct Errors {
     pub(crate) retrieve: syn::Path,
     pub(crate) update: syn::Path,
     pub(crate) delete: syn::Path,
+    pub(crate) list: syn::Path,
 }
 
 #[derive(Debug, PartialEq)]

--- a/editoast/editoast_derive/src/model/parsing.rs
+++ b/editoast/editoast_derive/src/model/parsing.rs
@@ -305,7 +305,8 @@ impl Errors {
                 create: path.clone(),
                 retrieve: path.clone(),
                 update: path.clone(),
-                delete: path,
+                delete: path.clone(),
+                list: path,
             }),
             ErrorArgs::Rw(RwErrorArgs { read, write, .. }) => {
                 let Errors {
@@ -314,10 +315,11 @@ impl Errors {
                 let read = read.unwrap_or(retrieve);
                 let write = write.unwrap_or(create);
                 Ok(Self {
-                    retrieve: read,
+                    retrieve: read.clone(),
                     create: write.clone(),
                     update: write.clone(),
                     delete: write,
+                    list: read,
                 })
             }
             ErrorArgs::Detailed(DetailedErrorArgs {
@@ -331,12 +333,14 @@ impl Errors {
                     retrieve: default_retrieve,
                     update: default_update,
                     delete: default_delete,
+                    list: default_list,
                 } = Errors::default();
                 Ok(Self {
                     retrieve: retrieve.unwrap_or(default_retrieve),
                     create: create.unwrap_or(default_create),
                     update: update.unwrap_or(default_update),
                     delete: delete.unwrap_or(default_delete),
+                    list: default_list,
                 })
             }
         }
@@ -350,6 +354,7 @@ impl Default for Errors {
             retrieve: syn::parse_quote! { editoast_models::model::Error },
             update: syn::parse_quote! { editoast_models::model::Error },
             delete: syn::parse_quote! { editoast_models::model::Error },
+            list: syn::parse_quote! { editoast_models::model::Error },
         }
     }
 }

--- a/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__construction.snap
+++ b/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__construction.snap
@@ -510,6 +510,7 @@ impl crate::models::Delete for Document {
 }
 #[automatically_derived]
 impl crate::models::prelude::List for Document {
+    type Error = editoast_models::model::Error;
     #[tracing::instrument(
         name = "model:list<Document>",
         skip_all,
@@ -525,7 +526,7 @@ impl crate::models::prelude::List for Document {
     async fn list(
         conn: &mut database::DbConnection,
         settings: crate::models::prelude::SelectionSettings<Self>,
-    ) -> crate::error::Result<Vec<Self>> {
+    ) -> std::result::Result<Vec<Self>, Self::Error> {
         use diesel::QueryDsl;
         use diesel_async::RunQueryDsl;
         use futures_util::stream::TryStreamExt;
@@ -548,14 +549,15 @@ impl crate::models::prelude::List for Document {
             tracing::Span::current().record("offset", offset);
             query = query.offset(offset);
         }
-        let results: Vec<Document> = query
+        query
             .select((dsl::id, dsl::content_type, dsl::data))
             .load_stream::<DocumentRow>(conn.write().await.deref_mut())
-            .await?
+            .await
+            .map_err(|e| Self::Error::from(editoast_models::model::Error::from(e)))?
             .map_ok(<Document as crate::models::prelude::Model>::from_row)
-            .try_collect()
-            .await?;
-        Ok(results)
+            .try_collect::<Vec<_>>()
+            .await
+            .map_err(|e| Self::Error::from(editoast_models::model::Error::from(e)))
     }
 }
 #[automatically_derived]

--- a/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__construction.snap
+++ b/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__construction.snap
@@ -560,6 +560,7 @@ impl crate::models::prelude::List for Document {
 }
 #[automatically_derived]
 impl crate::models::prelude::Count for Document {
+    type Error = editoast_models::model::Error;
     #[tracing::instrument(
         name = "model:count<Document>",
         skip_all,
@@ -575,7 +576,7 @@ impl crate::models::prelude::Count for Document {
     async fn count(
         conn: &mut database::DbConnection,
         settings: crate::models::prelude::SelectionSettings<Self>,
-    ) -> crate::error::Result<u64> {
+    ) -> std::result::Result<u64, Self::Error> {
         use diesel::QueryDsl;
         use diesel_async::RunQueryDsl;
         use futures_util::stream::TryStreamExt;
@@ -597,7 +598,11 @@ impl crate::models::prelude::Count for Document {
                 query = query.offset(offset);
             }
         }
-        Ok(query.get_result::<i64>(conn.write().await.deref_mut()).await? as u64)
+        query
+            .get_result::<i64>(conn.write().await.deref_mut())
+            .await
+            .map(|count| count as u64)
+            .map_err(|e| Self::Error::from(editoast_models::model::Error::from(e)))
     }
 }
 #[automatically_derived]

--- a/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__single_pk_model.snap
+++ b/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__single_pk_model.snap
@@ -214,6 +214,7 @@ impl crate::models::Delete for Timetable {
 }
 #[automatically_derived]
 impl crate::models::prelude::List for Timetable {
+    type Error = editoast_models::model::Error;
     #[tracing::instrument(
         name = "model:list<Timetable>",
         skip_all,
@@ -229,7 +230,7 @@ impl crate::models::prelude::List for Timetable {
     async fn list(
         conn: &mut database::DbConnection,
         settings: crate::models::prelude::SelectionSettings<Self>,
-    ) -> crate::error::Result<Vec<Self>> {
+    ) -> std::result::Result<Vec<Self>, Self::Error> {
         use diesel::QueryDsl;
         use diesel_async::RunQueryDsl;
         use futures_util::stream::TryStreamExt;
@@ -252,14 +253,15 @@ impl crate::models::prelude::List for Timetable {
             tracing::Span::current().record("offset", offset);
             query = query.offset(offset);
         }
-        let results: Vec<Timetable> = query
+        query
             .select((dsl::id,))
             .load_stream::<TimetableRow>(conn.write().await.deref_mut())
-            .await?
+            .await
+            .map_err(|e| Self::Error::from(editoast_models::model::Error::from(e)))?
             .map_ok(<Timetable as crate::models::prelude::Model>::from_row)
-            .try_collect()
-            .await?;
-        Ok(results)
+            .try_collect::<Vec<_>>()
+            .await
+            .map_err(|e| Self::Error::from(editoast_models::model::Error::from(e)))
     }
 }
 #[automatically_derived]

--- a/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__single_pk_model.snap
+++ b/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__single_pk_model.snap
@@ -264,6 +264,7 @@ impl crate::models::prelude::List for Timetable {
 }
 #[automatically_derived]
 impl crate::models::prelude::Count for Timetable {
+    type Error = editoast_models::model::Error;
     #[tracing::instrument(
         name = "model:count<Timetable>",
         skip_all,
@@ -279,7 +280,7 @@ impl crate::models::prelude::Count for Timetable {
     async fn count(
         conn: &mut database::DbConnection,
         settings: crate::models::prelude::SelectionSettings<Self>,
-    ) -> crate::error::Result<u64> {
+    ) -> std::result::Result<u64, Self::Error> {
         use diesel::QueryDsl;
         use diesel_async::RunQueryDsl;
         use futures_util::stream::TryStreamExt;
@@ -301,7 +302,11 @@ impl crate::models::prelude::Count for Timetable {
                 query = query.offset(offset);
             }
         }
-        Ok(query.get_result::<i64>(conn.write().await.deref_mut()).await? as u64)
+        query
+            .get_result::<i64>(conn.write().await.deref_mut())
+            .await
+            .map(|count| count as u64)
+            .map_err(|e| Self::Error::from(editoast_models::model::Error::from(e)))
     }
 }
 #[automatically_derived]

--- a/editoast/src/models/mod.rs
+++ b/editoast/src/models/mod.rs
@@ -68,7 +68,7 @@ mod tests {
     use super::prelude::*;
 
     #[derive(Debug, Default, Clone, Model, PartialEq, Eq)]
-    #[model(table = database::tables::document, error = DocError)]
+    #[model(table = database::tables::document, error(write = DocError))] // remporary — revert to error = DocError
     #[model(gen(ops = crud, batch_ops = crud, list))]
     struct Document {
         id: i64,

--- a/editoast/src/models/prelude/create.rs
+++ b/editoast/src/models/prelude/create.rs
@@ -4,8 +4,6 @@ use std::result::Result;
 use database::DbConnection;
 use editoast_models::model;
 
-use crate::error::EditoastError;
-
 use super::Model;
 
 /// Describes how a [Model] can be created in the database

--- a/editoast/src/models/prelude/delete.rs
+++ b/editoast/src/models/prelude/delete.rs
@@ -3,8 +3,6 @@ use std::result::Result;
 use database::DbConnection;
 use editoast_models::model;
 
-use crate::error::EditoastError;
-
 use super::Model;
 
 /// Describes how a [Model] can be deleted from the database

--- a/editoast/src/models/prelude/list.rs
+++ b/editoast/src/models/prelude/list.rs
@@ -199,11 +199,16 @@ pub trait List: Model {
 /// You can implement this type manually but it is recommended to use the `Model`
 /// derive macro instead.
 pub trait Count: Model {
+    type Error: std::error::Error
+        + From<editoast_models::model::Error>
+        + Send
+        + crate::error::EditoastError; // temporary bound
+
     /// Counts the number of objects that match the provided settings
     async fn count(
         conn: &mut DbConnection,
         settings: SelectionSettings<Self>,
-    ) -> crate::error::Result<u64>;
+    ) -> Result<u64, Self::Error>;
 }
 
 /// A trait that combines [List] and [Count] into a single function [ListAndCount::list_and_count]

--- a/editoast/src/models/prelude/list.rs
+++ b/editoast/src/models/prelude/list.rs
@@ -186,11 +186,13 @@ impl<M: Model + 'static> SelectionSettings<M> {
 /// You can implement this type manually but it is recommended to use the `Model`
 /// derive macro instead.
 pub trait List: Model {
+    type Error: std::error::Error + From<editoast_models::model::Error> + Send;
+
     /// Lists the objects that match the provided settings
     async fn list(
         conn: &mut DbConnection,
         settings: SelectionSettings<Self>,
-    ) -> crate::error::Result<Vec<Self>>;
+    ) -> Result<Vec<Self>, Self::Error>;
 }
 
 /// Describe how we can count the number of occurrences of the [Model]
@@ -199,10 +201,7 @@ pub trait List: Model {
 /// You can implement this type manually but it is recommended to use the `Model`
 /// derive macro instead.
 pub trait Count: Model {
-    type Error: std::error::Error
-        + From<editoast_models::model::Error>
-        + Send
-        + crate::error::EditoastError; // temporary bound
+    type Error: std::error::Error + From<editoast_models::model::Error> + Send;
 
     /// Counts the number of objects that match the provided settings
     async fn count(
@@ -214,7 +213,11 @@ pub trait Count: Model {
 /// A trait that combines [List] and [Count] into a single function [ListAndCount::list_and_count]
 ///
 /// This trait is automatically implemented for any type that implements both [List] and [Count].
-pub trait ListAndCount: Model {
+pub trait ListAndCount: Model + List + Count
+where
+    // in practice, they're the same when generated using derive(Model)
+    <Self as List>::Error: From<<Self as Count>::Error>,
+{
     /// Lists and counts the objects that match the provided settings
     ///
     /// # Performance
@@ -230,14 +233,17 @@ pub trait ListAndCount: Model {
     async fn list_and_count(
         conn: &mut DbConnection,
         settings: SelectionSettings<Self>,
-    ) -> crate::error::Result<(Vec<Self>, u64)>;
+    ) -> Result<(Vec<Self>, u64), <Self as List>::Error>;
 }
 
-impl<M: Model + List + Count> ListAndCount for M {
+impl<M: Model + List + Count> ListAndCount for M
+where
+    <M as List>::Error: From<<M as Count>::Error>,
+{
     async fn list_and_count(
         conn: &mut DbConnection,
         settings: SelectionSettings<Self>,
-    ) -> crate::error::Result<(Vec<Self>, u64)> {
+    ) -> Result<(Vec<Self>, u64), <Self as List>::Error> {
         let count = Self::count(conn, settings.clone()).await?;
         let list = Self::list(conn, settings).await?;
         Ok((list, count))

--- a/editoast/src/models/temporary_speed_limits.rs
+++ b/editoast/src/models/temporary_speed_limits.rs
@@ -39,8 +39,22 @@ impl From<model::Error> for TslGroupError {
     }
 }
 
+// temporary
+impl crate::error::EditoastError for TslGroupError {
+    fn get_status(&self) -> axum::http::StatusCode {
+        match self {
+            Self::NameAlreadyUsed { .. } => axum::http::StatusCode::BAD_REQUEST,
+            Self::Database(e) => e.get_status(),
+        }
+    }
+
+    fn get_type(&self) -> &str {
+        "editoast:TslGroupError"
+    }
+}
+
 #[derive(Debug, Serialize, Clone, Model)]
-#[model(table = temporary_speed_limit, error = Error)]
+#[model(table = temporary_speed_limit, error(write = Error))]
 #[model(gen(ops = cr, batch_ops = c, list))]
 pub struct TemporarySpeedLimit {
     pub id: i64,
@@ -56,6 +70,17 @@ pub struct TemporarySpeedLimit {
 #[derive(Debug, thiserror::Error)]
 #[error(transparent)]
 pub struct Error(#[from] model::Error);
+
+// temporary
+impl crate::error::EditoastError for Error {
+    fn get_status(&self) -> axum::http::StatusCode {
+        self.0.get_status()
+    }
+
+    fn get_type(&self) -> &str {
+        self.0.get_type()
+    }
+}
 
 impl From<TemporarySpeedLimit> for core_client::stdcm::TemporarySpeedLimit {
     fn from(value: TemporarySpeedLimit) -> Self {

--- a/editoast/src/models/temporary_speed_limits.rs
+++ b/editoast/src/models/temporary_speed_limits.rs
@@ -39,20 +39,6 @@ impl From<model::Error> for TslGroupError {
     }
 }
 
-// temporary
-impl crate::error::EditoastError for TslGroupError {
-    fn get_status(&self) -> axum::http::StatusCode {
-        match self {
-            Self::NameAlreadyUsed { .. } => axum::http::StatusCode::BAD_REQUEST,
-            Self::Database(e) => e.get_status(),
-        }
-    }
-
-    fn get_type(&self) -> &str {
-        "editoast:TslGroupError"
-    }
-}
-
 #[derive(Debug, Serialize, Clone, Model)]
 #[model(table = temporary_speed_limit, error(write = Error))]
 #[model(gen(ops = cr, batch_ops = c, list))]
@@ -70,17 +56,6 @@ pub struct TemporarySpeedLimit {
 #[derive(Debug, thiserror::Error)]
 #[error(transparent)]
 pub struct Error(#[from] model::Error);
-
-// temporary
-impl crate::error::EditoastError for Error {
-    fn get_status(&self) -> axum::http::StatusCode {
-        self.0.get_status()
-    }
-
-    fn get_type(&self) -> &str {
-        self.0.get_type()
-    }
-}
 
 impl From<TemporarySpeedLimit> for core_client::stdcm::TemporarySpeedLimit {
     fn from(value: TemporarySpeedLimit) -> Self {

--- a/editoast/src/views/pagination.rs
+++ b/editoast/src/views/pagination.rs
@@ -8,6 +8,8 @@ use crate::ListAndCount;
 use crate::Model;
 use crate::SelectionSettings;
 use crate::error::Result;
+use crate::models::Count;
+use crate::models::List;
 
 /// Statistics about a paginated editoast response
 ///
@@ -85,7 +87,10 @@ impl PaginationStats {
     }
 }
 
-pub trait PaginatedList: ListAndCount + 'static {
+pub trait PaginatedList: ListAndCount + 'static
+where
+    <Self as List>::Error: From<<Self as Count>::Error>,
+{
     /// Lists the models and compute [PaginationStats]
     ///
     /// See [ListAndCount::list_and_count] for more details.
@@ -101,7 +106,7 @@ pub trait PaginatedList: ListAndCount + 'static {
     async fn list_paginated(
         conn: &mut DbConnection,
         settings: SelectionSettings<Self>,
-    ) -> Result<(Vec<Self>, PaginationStats)> {
+    ) -> Result<(Vec<Self>, PaginationStats), <Self as List>::Error> {
         let (page, page_size) = settings
             .get_pagination_settings()
             .expect("the limit and the offset must be set in order to call list_paginated");
@@ -111,7 +116,12 @@ pub trait PaginatedList: ListAndCount + 'static {
     }
 }
 
-impl<T> PaginatedList for T where T: ListAndCount + 'static {}
+impl<T> PaginatedList for T
+where
+    T: ListAndCount + 'static,
+    <Self as List>::Error: From<<Self as Count>::Error>,
+{
+}
 
 #[derive(Debug, Clone, Copy)]
 pub struct PaginationQueryParams<const MAX_PAGE_SIZE: u64 = 25> {

--- a/editoast/src/views/timetable/stdcm/request.rs
+++ b/editoast/src/views/timetable/stdcm/request.rs
@@ -266,7 +266,7 @@ impl Request {
     pub(super) async fn get_work_schedules(
         &self,
         conn: &mut DbConnection,
-    ) -> Result<Vec<WorkSchedule>> {
+    ) -> Result<Vec<WorkSchedule>, <WorkSchedule as List>::Error> {
         if self.work_schedule_group_id.is_none() {
             return Ok(vec![]);
         }


### PR DESCRIPTION
- **editoast: models: remove InternalError from trait Count**
- **editoast: model: remove InternalError from trait List**
- **editoast: remove some unused EditoastError imports**
