### PR TITLE
STD refacto - fix paths index and renaming 

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults.tsx
@@ -117,7 +117,7 @@ const SimulationResults = ({
   const {
     toggleWaypoint,
     deployedWaypoints,
-    handleTrainDrag: handleTrainDragInTrackOccupancy,
+    updateTrackOccupanciesOnDrag: handleTrainDragInTrackOccupancy,
   } = useTrackOccupancy({
     infraId,
     pathOperationalPoints: filteredOperationalPoints,
@@ -253,7 +253,7 @@ const SimulationResults = ({
                         toggleDeployedWaypoint: toggleWaypoint,
                         timetableId,
                       }}
-                      occupancyZonesLayers={deployedWaypoints}
+                      trackOccupancyDiagramsData={deployedWaypoints}
                       onCloseOccupancyLayer={(waypointId: string) =>
                         toggleWaypoint(waypointId, false)
                       }

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
@@ -52,10 +52,6 @@ import { useAppDispatch } from 'store';
 import {
   isTrainId,
   extractPacedTrainIdFromOccurrenceId,
-  isOccurrenceId,
-  isTrainScheduleId,
-  extractEditoastIdFromTrainScheduleId,
-  extractEditoastIdFromPacedTrainId,
   extractOccurrenceIndexFromOccurrenceId,
   isPacedTrainId,
   formatPacedTrainIdToIndexedOccurrenceId,
@@ -197,15 +193,8 @@ const SpaceTimeChartWrapper = ({
     allTrainsProjected
   );
 
-  const extractTrainId = useCallback((id: string) => {
-    if (isTrainScheduleId(id)) return extractEditoastIdFromTrainScheduleId(id);
-    if (isOccurrenceId(id))
-      return extractEditoastIdFromPacedTrainId(extractPacedTrainIdFromOccurrenceId(id));
-    return id;
-  }, []);
-
   const splitPoints = useMemo<SplitPoint[]>(() => {
-    const pathsIndex = keyBy(paths, ({ id }) => extractTrainId(id));
+    const pathsIndex = keyBy(paths, ({ id }) => id);
 
     return (
       sortBy(
@@ -229,7 +218,7 @@ const SpaceTimeChartWrapper = ({
               position={operationalPointPosition}
               tracks={tracks || []}
               occupancyZones={(zones || []).map((zone) => {
-                const path = pathsIndex[extractTrainId(zone.trainId)];
+                const path = pathsIndex[zone.trainId];
                 if (!path) return zone;
                 const pathStyle = getPathStyle(
                   hoveredItem,

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
@@ -32,13 +32,13 @@ import {
 import { Slider } from '@osrd-project/ui-core';
 import { Sliders, Iterations, ZoomIn } from '@osrd-project/ui-icons';
 import cx from 'classnames';
-import dayjs from 'dayjs';
 import { keyBy, sortBy } from 'lodash';
 import { createPortal } from 'react-dom';
 
 import upward from 'assets/pictures/workSchedules/ScheduledMaintenanceUp.svg';
 import { type PostWorkSchedulesProjectPathApiResponse } from 'common/api/osrdEditoastApi';
 import { useSubCategoryContext } from 'common/SubCategoryContext';
+import { configureHandlePan } from 'modules/simulationResult/components/SpaceTimeChartWrapper/helpers/configureHandlePan';
 import type {
   PathOperationalPoint,
   TrainSpaceTimeData,
@@ -47,23 +47,12 @@ import type {
 } from 'modules/simulationResult/types';
 import type { TimetableItemWithDetails } from 'modules/timetableItem/components/Timetable/types';
 import type { OccurrenceId, PacedTrainId, TrainId, TrainScheduleId } from 'reducers/osrdconf/types';
-import { updateSelectedTrainId } from 'reducers/simulationResults';
 import { useAppDispatch } from 'store';
-import {
-  isTrainId,
-  extractPacedTrainIdFromOccurrenceId,
-  extractOccurrenceIndexFromOccurrenceId,
-  isPacedTrainId,
-  formatPacedTrainIdToIndexedOccurrenceId,
-} from 'utils/trainId';
+import { isTrainId, isPacedTrainId, formatPacedTrainIdToIndexedOccurrenceId } from 'utils/trainId';
 
 import getPathStyle from './helpers/getPathStyle';
 import makeProjectedItems from './helpers/makeProjectedItems';
-import {
-  cutSpaceTimeChart,
-  getOccupancyBlocks,
-  isIndividualOccurrenceProjection,
-} from './helpers/utils';
+import { cutSpaceTimeChart, getOccupancyBlocks } from './helpers/utils';
 import ProjectionLoadingMessage from './ProjectionLoadingMessage';
 import SettingsPanel from './SettingsPanel';
 import useWaypointMenu from './useWaypointMenu';
@@ -319,97 +308,6 @@ const SpaceTimeChartWrapper = ({
 
   const occupancyBlocks = getOccupancyBlocks(cutProjectedTrains);
 
-  const onPanOverloaded: SpaceTimeChartProps['onPan'] = async (payload) => {
-    const { isPanning } = payload;
-
-    if (!handleTrainDrag) {
-      // if no handleTrainDrag, we pan normally
-      spaceTimeChartProps.onPan?.(payload);
-      return;
-    }
-
-    // if dragging
-    if (draggingState) {
-      const { draggedTrain, initialDepartureTime } = draggingState;
-
-      if (draggedTrain.id !== selectedTrainId) {
-        dispatch(updateSelectedTrainId(draggedTrain.id));
-      }
-
-      const timeDiff = payload.data.time - payload.initialData.time;
-
-      let newDepartureTime = new Date(initialDepartureTime.getTime() + timeDiff);
-
-      // if the dragged train is an occurrence, we need to update the first occurrence because the others are based on it
-      if (
-        isIndividualOccurrenceProjection(draggedTrain) &&
-        (!draggedTrain.exception || !draggedTrain.exception.start_time)
-      ) {
-        const occurrencesIndex = extractOccurrenceIndexFromOccurrenceId(draggedTrain.id);
-        const pacedTrainId = extractPacedTrainIdFromOccurrenceId(draggedTrain.id);
-        const pacedTrain = projectPathTrainResult.find(
-          ({ id }) => isPacedTrainId(id) && id === pacedTrainId
-        );
-        if (pacedTrain && 'paced' in pacedTrain) {
-          newDepartureTime = dayjs(newDepartureTime)
-            .add(occurrencesIndex * -pacedTrain.paced.interval.ms, 'ms')
-            .toDate();
-        }
-      }
-
-      // stop dragging if necessary
-      if (!isPanning) {
-        setDraggingState(undefined);
-      }
-
-      await handleTrainDrag({
-        draggedTrainId: draggedTrain.id,
-        initialDepartureTime,
-        newDepartureTime,
-        stopPanning: !isPanning,
-      });
-      return;
-    }
-
-    // if not dragging, we check if we should start dragging
-    // Only a mouse hover that starts already over a path should register
-    // if we start panning, and then the mouse hovers over the path,
-    // it should continue just sliding the chart, not start dragging the train path
-    if (
-      isPanning &&
-      !previousPanning &&
-      !zoomMode &&
-      hoveredItem &&
-      (isSegmentPickingElement(hoveredItem.element) || isPointPickingElement(hoveredItem.element))
-    ) {
-      const hoveredTrainId = hoveredItem.element.pathId;
-      if (!isTrainId(hoveredTrainId)) return;
-
-      const train = projectedTrains.find((projectedTrain) => projectedTrain.id === hoveredTrainId);
-      if (!train) {
-        console.error(`No train found with id ${hoveredTrainId}`);
-        return;
-      }
-
-      // disable start time exception for now
-      const isStartTimeException =
-        isIndividualOccurrenceProjection(train) && !!train.exception?.start_time;
-      if (isStartTimeException) return;
-
-      setDraggingState({
-        draggedTrain: train,
-        initialDepartureTime: train.departureTime,
-      });
-    }
-
-    // if no hovered train, we pan normally
-    spaceTimeChartProps.onPan?.(payload);
-
-    if (isPanning !== previousPanning) {
-      setPreviousPanning(isPanning);
-    }
-  };
-
   const manchettePropsWithWaypointMenu = useMemo(
     () => ({
       ...manchetteProps,
@@ -425,6 +323,31 @@ const SpaceTimeChartWrapper = ({
       activeWaypointRef,
     }),
     [manchetteProps, activeWaypointId, handleWaypointClick]
+  );
+
+  const handlePan = useCallback(
+    configureHandlePan({
+      spaceTimeChartOnPan: spaceTimeChartProps.onPan,
+      handleTrainDrag,
+      draggingState,
+      setDraggingState,
+      hoveredItem,
+      previousPanning,
+      setPreviousPanning,
+      zoomMode,
+      projectPathTrainResult,
+      dispatch,
+    }),
+    [
+      spaceTimeChartProps.onPan,
+      handleTrainDrag,
+      draggingState,
+      hoveredItem,
+      previousPanning,
+      zoomMode,
+      projectPathTrainResult,
+      dispatch,
+    ]
   );
 
   const handleHoveredChildUpdate: SpaceTimeChartProps['onHoveredChildUpdate'] = useCallback(
@@ -528,7 +451,7 @@ const SpaceTimeChartWrapper = ({
             className="inset-0 absolute h-full"
             height={height}
             {...spaceTimeChartProps}
-            onPan={onPanOverloaded}
+            onPan={handlePan}
             onClick={handleClick}
             onHoveredChildUpdate={handleHoveredChildUpdate}
             spaceOrigin={

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
@@ -76,7 +76,7 @@ type SpaceTimeChartWrapperBaseProps = {
   selectedTrainId?: TrainId;
   conflicts?: Conflict[];
   workSchedules?: PostWorkSchedulesProjectPathApiResponse;
-  occupancyZonesLayers?: {
+  trackOccupancyDiagramsData?: {
     waypointId: string;
     operationalPointId: string;
     operationalPointPosition: number;
@@ -129,7 +129,7 @@ const SpaceTimeChartWrapper = ({
   waypointsPanelData,
   conflicts = [],
   workSchedules,
-  occupancyZonesLayers,
+  trackOccupancyDiagramsData,
   onCloseOccupancyLayer,
   projectionLoaderData: { totalTrains, allTrainsProjected },
   height = MANCHETTE_WITH_SPACE_TIME_CHART_DEFAULT_HEIGHT,
@@ -198,7 +198,7 @@ const SpaceTimeChartWrapper = ({
 
     return (
       sortBy(
-        occupancyZonesLayers || [],
+        trackOccupancyDiagramsData || [],
         ({ operationalPointPosition }) => operationalPointPosition
       ).map(
         ({
@@ -267,7 +267,7 @@ const SpaceTimeChartWrapper = ({
       ) || []
     );
   }, [
-    occupancyZonesLayers,
+    trackOccupancyDiagramsData,
     activeWaypointId,
     timetableItemsWithDetails,
     selectedTrainId,

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/configureHandlePan.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/configureHandlePan.ts
@@ -1,0 +1,140 @@
+import {
+  isPointPickingElement,
+  isSegmentPickingElement,
+  type HoveredItem,
+  type SpaceTimeChartProps,
+} from '@osrd-project/ui-charts';
+import dayjs from 'dayjs';
+
+import type { TrainId } from 'reducers/osrdconf/types';
+import { updateSelectedTrainId } from 'reducers/simulationResults';
+import type { AppDispatch } from 'store';
+import {
+  extractOccurrenceIndexFromOccurrenceId,
+  extractPacedTrainIdFromOccurrenceId,
+  isOccurrenceId,
+  isTrainId,
+} from 'utils/trainId';
+
+import type { IndividualTrainProjection, TrainSpaceTimeData } from '../../../types';
+
+type DraggingState =
+  | {
+      draggedTrain: IndividualTrainProjection;
+      initialDepartureTime: Date;
+    }
+  | undefined;
+
+type ConfigureHandlePanParams = {
+  spaceTimeChartOnPan?: SpaceTimeChartProps['onPan'];
+  handleTrainDrag?: (args: {
+    draggedTrainId: TrainId;
+    initialDepartureTime: Date;
+    newDepartureTime: Date;
+    stopPanning: boolean;
+  }) => Promise<void>;
+  draggingState: DraggingState;
+  setDraggingState: (s: DraggingState) => void;
+  hoveredItem: HoveredItem | null;
+  previousPanning: boolean;
+  setPreviousPanning: (v: boolean) => void;
+  zoomMode: boolean;
+  projectPathTrainResult: TrainSpaceTimeData[];
+  dispatch: AppDispatch;
+};
+
+export function configureHandlePan({
+  spaceTimeChartOnPan,
+  handleTrainDrag,
+  draggingState,
+  setDraggingState,
+  hoveredItem,
+  previousPanning,
+  setPreviousPanning,
+  zoomMode,
+  projectPathTrainResult,
+  dispatch,
+}: ConfigureHandlePanParams): NonNullable<SpaceTimeChartProps['onPan']> {
+  return async (payload) => {
+    const { isPanning } = payload;
+
+    if (!handleTrainDrag) {
+      // if no handleTrainDrag, we pan normally
+      spaceTimeChartOnPan?.(payload);
+      return;
+    }
+
+    // If dragging
+    if (draggingState) {
+      const { draggedTrain, initialDepartureTime } = draggingState;
+      dispatch(updateSelectedTrainId(draggedTrain.id));
+
+      const timeDiff = payload.data.time - payload.initialData.time;
+
+      let newDepartureTime = new Date(initialDepartureTime.getTime() + timeDiff);
+      let draggedTrainId = draggedTrain.id;
+
+      // if the dragged train is an occurrence, we need to update the first occurrence because the others are based on it
+      if (isOccurrenceId(draggedTrain.id)) {
+        const occurrencesIndex = extractOccurrenceIndexFromOccurrenceId(draggedTrain.id);
+        const pacedTrainId = extractPacedTrainIdFromOccurrenceId(draggedTrain.id);
+        const firstOccurrence = projectPathTrainResult.find(
+          ({ id }) => isOccurrenceId(id) && extractPacedTrainIdFromOccurrenceId(id) === pacedTrainId
+        );
+        if (firstOccurrence && 'paced' in firstOccurrence) {
+          newDepartureTime = dayjs(newDepartureTime)
+            .add(occurrencesIndex * -firstOccurrence.paced.interval.ms, 'ms')
+            .toDate();
+          if (isOccurrenceId(firstOccurrence.id)) {
+            draggedTrainId = firstOccurrence.id;
+          }
+        }
+      }
+
+      // stop dragging if necessary
+      if (!isPanning) {
+        setDraggingState(undefined);
+      }
+
+      await handleTrainDrag({
+        draggedTrainId,
+        initialDepartureTime,
+        newDepartureTime,
+        stopPanning: !isPanning,
+      });
+      return;
+    }
+
+    // if not dragging, we check if we should start dragging
+    // Only a mouse hover that starts already over a path should register
+    // if we start panning, and then the mouse hovers over the path,
+    // it should continue just sliding the chart, not start dragging the train path
+    if (
+      isPanning &&
+      !previousPanning &&
+      !zoomMode &&
+      hoveredItem &&
+      (isSegmentPickingElement(hoveredItem.element) || isPointPickingElement(hoveredItem.element))
+    ) {
+      const hoveredTrainId = hoveredItem.element.pathId;
+      if (!isTrainId(hoveredTrainId)) return;
+      const train = projectPathTrainResult.find(
+        (projectedTrain) => projectedTrain.id === hoveredTrainId
+      );
+      // Only set dragging state if train is an occurrence (IndividualTrainProjection)
+      if (train && isOccurrenceId(train.id)) {
+        setDraggingState({
+          draggedTrain: train as IndividualTrainProjection,
+          initialDepartureTime: train.departureTime,
+        });
+      }
+    }
+
+    // if no hovered train, we pan normally
+    spaceTimeChartOnPan?.(payload);
+
+    if (isPanning !== previousPanning) {
+      setPreviousPanning(isPanning);
+    }
+  };
+}

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useTrackOccupancy.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useTrackOccupancy.ts
@@ -94,7 +94,7 @@ const useTrackOccupancy = ({
 }): {
   deployedWaypoints: DeployedWaypoint[];
   toggleWaypoint: (waypointId: string, selectedState?: boolean) => void;
-  handleTrainDrag: ({
+  updateTrackOccupanciesOnDrag: ({
     draggedTrainId,
     newTrainData,
     initialDepartureTime,
@@ -285,7 +285,7 @@ const useTrackOccupancy = ({
     ]
   );
 
-  const handleTrainDrag = useCallback(
+  const updateTrackOccupanciesOnDrag = useCallback(
     async ({
       draggedTrainId,
       newTrainData,
@@ -598,7 +598,7 @@ const useTrackOccupancy = ({
     fetchOperationalPoints();
   }, [timetableItemProjections, i18n.language]);
 
-  return { deployedWaypoints, toggleWaypoint, handleTrainDrag };
+  return { deployedWaypoints, toggleWaypoint, updateTrackOccupanciesOnDrag };
 };
 
 export default useTrackOccupancy;


### PR DESCRIPTION
part of #12708 

- extractTrainId: return values collide because a train schedule can have the
same numerical ID as a paced train. Change pathsIndex to just use the
string ID, which is guaranteed unique.

- occupancyZonesLayers: rename to something better, e.g.
trackOccupancyDiagramsData

- handleTrainDrag in useTrackOccupancy: rename to ???

- onPanOverloaded: rename to handlePan, consider moving pan/drag related
logic into separate hook