### PR TITLE
Fix incorrect “too fast” warnings and existence of flame icon 

### DIFF
--- a/front/src/applications/operationalStudies/utils.ts
+++ b/front/src/applications/operationalStudies/utils.ts
@@ -281,7 +281,7 @@ export const isTooFast = (
 
   const toCheckPathItemIds = new Set(timetableItem.margins?.boundaries);
   timetableItem.schedule?.forEach((schedule) => {
-    if (schedule.arrival || schedule.stop_for) {
+    if (schedule.arrival) {
       toCheckPathItemIds.add(schedule.at);
     }
   });


### PR DESCRIPTION
Closes [#12679](https://github.com/OpenRailAssociation/osrd/issues/12679)