### PR TITLE
editoast: update deprecated retrieve calls

### DIFF
--- a/editoast/editoast_derive/src/model/codegen/retrieve_impl.rs
+++ b/editoast/editoast_derive/src/model/codegen/retrieve_impl.rs
@@ -36,7 +36,7 @@ impl ToTokens for RetrieveImpl {
                 type Error = #error;
 
                 #[tracing::instrument(name = #span_name, skip_all, err, fields(query_id))]
-                async fn retrieve_real(
+                async fn retrieve(
                     conn: database::DbConnection,
                     #id_ident: #ty,
                 ) -> std::result::Result<Option<#model>, Self::Error> {

--- a/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__construction.snap
+++ b/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__construction.snap
@@ -298,7 +298,7 @@ impl crate::models::Retrieve<(String)> for Document {
         err,
         fields(query_id)
     )]
-    async fn retrieve_real(
+    async fn retrieve(
         conn: database::DbConnection,
         content_type: (String),
     ) -> std::result::Result<Option<Document>, Self::Error> {
@@ -327,7 +327,7 @@ impl crate::models::Retrieve<(i64)> for Document {
         err,
         fields(query_id)
     )]
-    async fn retrieve_real(
+    async fn retrieve(
         conn: database::DbConnection,
         id_: (i64),
     ) -> std::result::Result<Option<Document>, Self::Error> {

--- a/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__single_pk_model.snap
+++ b/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__single_pk_model.snap
@@ -121,7 +121,7 @@ impl crate::models::Retrieve<(i64)> for Timetable {
         err,
         fields(query_id)
     )]
-    async fn retrieve_real(
+    async fn retrieve(
         conn: database::DbConnection,
         id: (i64),
     ) -> std::result::Result<Option<Timetable>, Self::Error> {

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -6159,6 +6159,25 @@ components:
           type: string
           enum:
           - editoast:infra:edition:SplitTrackSectionBadOffset
+    EditoastElectricalProfilesErrorDatabase:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 500
+        type:
+          type: string
+          enum:
+          - editoast:electrical_profiles:Database
     EditoastElectricalProfilesErrorNotFound:
       type: object
       required:
@@ -6217,6 +6236,7 @@ components:
       - $ref: '#/components/schemas/EditoastDocumentErrorsNotFound'
       - $ref: '#/components/schemas/EditoastEditionErrorInfraIsLocked'
       - $ref: '#/components/schemas/EditoastEditionErrorSplitTrackSectionBadOffset'
+      - $ref: '#/components/schemas/EditoastElectricalProfilesErrorDatabase'
       - $ref: '#/components/schemas/EditoastElectricalProfilesErrorNotFound'
       - $ref: '#/components/schemas/EditoastFontErrorsFileNotFound'
       - $ref: '#/components/schemas/EditoastGeometryErrorUnexpectedGeometry'
@@ -6244,6 +6264,7 @@ components:
       - $ref: '#/components/schemas/EditoastPacedTrainErrorExceptionNotFound'
       - $ref: '#/components/schemas/EditoastPacedTrainErrorInfraNotFound'
       - $ref: '#/components/schemas/EditoastPacedTrainErrorNotFound'
+      - $ref: '#/components/schemas/EditoastPathfindingErrorDatabase'
       - $ref: '#/components/schemas/EditoastPathfindingErrorInfraNotFound'
       - $ref: '#/components/schemas/EditoastPathfindingViewErrorsEndingTrackLocationNotFound'
       - $ref: '#/components/schemas/EditoastPathfindingViewErrorsInvalidNumberOfPaths'
@@ -6276,6 +6297,7 @@ components:
       - $ref: '#/components/schemas/EditoastSimilarTrainsErrorTimetableNotFound'
       - $ref: '#/components/schemas/EditoastSpriteErrorsFileNotFound'
       - $ref: '#/components/schemas/EditoastSpriteErrorsUnknownSignalingSystem'
+      - $ref: '#/components/schemas/EditoastStdcmErrorDatabase'
       - $ref: '#/components/schemas/EditoastStdcmErrorInfraNotFound'
       - $ref: '#/components/schemas/EditoastStdcmErrorInvalidConsistLength'
       - $ref: '#/components/schemas/EditoastStdcmErrorInvalidConsistMass'
@@ -6284,6 +6306,7 @@ components:
       - $ref: '#/components/schemas/EditoastStdcmErrorTimetableNotFound'
       - $ref: '#/components/schemas/EditoastStdcmErrorTowedRollingStockNotFound'
       - $ref: '#/components/schemas/EditoastStdcmErrorTrainSimulationFail'
+      - $ref: '#/components/schemas/EditoastStdcmLogErrorDatabase'
       - $ref: '#/components/schemas/EditoastStdcmLogErrorMissingIdAndTraceId'
       - $ref: '#/components/schemas/EditoastStdcmLogErrorNotFound'
       - $ref: '#/components/schemas/EditoastStdcmLogErrorTraceIdNotFound'
@@ -6910,6 +6933,25 @@ components:
           type: string
           enum:
           - editoast:paced_train:NotFound
+    EditoastPathfindingErrorDatabase:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 500
+        type:
+          type: string
+          enum:
+          - editoast:pathfinding:Database
     EditoastPathfindingErrorInfraNotFound:
       type: object
       required:
@@ -7627,6 +7669,25 @@ components:
           type: string
           enum:
           - editoast:sprites:UnknownSignalingSystem
+    EditoastStdcmErrorDatabase:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 400
+        type:
+          type: string
+          enum:
+          - editoast:stdcm:Database
     EditoastStdcmErrorInfraNotFound:
       type: object
       required:
@@ -7820,6 +7881,25 @@ components:
           type: string
           enum:
           - editoast:stdcm:TrainSimulationFail
+    EditoastStdcmLogErrorDatabase:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 500
+        type:
+          type: string
+          enum:
+          - editoast:stdcm_log:Database
     EditoastStdcmLogErrorMissingIdAndTraceId:
       type: object
       required:

--- a/editoast/src/client/import_rolling_stock.rs
+++ b/editoast/src/client/import_rolling_stock.rs
@@ -45,7 +45,7 @@ pub async fn import_rolling_stock(
                         .bold()
                 );
                 let existing_rolling_stock =
-                    RollingStock::retrieve_real(conn.clone(), rolling_stock_name.clone()).await?;
+                    RollingStock::retrieve(conn.clone(), rolling_stock_name.clone()).await?;
                 match (existing_rolling_stock, args.force) {
                     (Some(_), true) => {
                         let rolling_stock = rolling_stock
@@ -199,7 +199,7 @@ mod tests {
                 "import should succeed, as raise_panto and startup are not required for non electric",
             );
             let created_rs =
-                RollingStock::retrieve_real(db_pool.get_ok(), rolling_stock_name.to_string())
+                RollingStock::retrieve(db_pool.get_ok(), rolling_stock_name.to_string())
                     .await
                     .unwrap();
             assert!(created_rs.is_some());
@@ -226,7 +226,7 @@ mod tests {
             // THEN
             assert!(result.is_ok(), "import should succeed");
             let created_rs =
-                RollingStock::retrieve_real(db_pool.get_ok(), rolling_stock_name.to_string())
+                RollingStock::retrieve(db_pool.get_ok(), rolling_stock_name.to_string())
                     .await
                     .expect("failed to retrieve rolling stock")
                     .unwrap();
@@ -263,7 +263,7 @@ mod tests {
                 "import should fail, as raise_panto and startup are required for electric"
             );
             let created_rs =
-                RollingStock::retrieve_real(db_pool.get_ok(), rolling_stock_name.to_string())
+                RollingStock::retrieve(db_pool.get_ok(), rolling_stock_name.to_string())
                     .await
                     .unwrap();
             assert!(created_rs.is_none());
@@ -288,7 +288,7 @@ mod tests {
             // THEN
             assert!(result.is_ok(), "import should succeed");
             let created_rs =
-                RollingStock::retrieve_real(db_pool.get_ok(), rolling_stock_name.to_string())
+                RollingStock::retrieve(db_pool.get_ok(), rolling_stock_name.to_string())
                     .await
                     .expect("Failed to retrieve rolling stock")
                     .unwrap();
@@ -335,12 +335,10 @@ mod tests {
                 result.is_ok(),
                 "import should succeed, but result as skipped, as a rolling stock already exists and --force is disabled"
             );
-            let rolling_stock = RollingStock::retrieve_real(
-                db_pool.get_ok(),
-                existing_rolling_stock_name.to_string(),
-            )
-            .await
-            .unwrap();
+            let rolling_stock =
+                RollingStock::retrieve(db_pool.get_ok(), existing_rolling_stock_name.to_string())
+                    .await
+                    .unwrap();
             assert!(rolling_stock.is_some());
             assert!(rolling_stock.unwrap().length == units::meter::new(400.0));
         }
@@ -378,12 +376,10 @@ mod tests {
                 result.is_ok(),
                 "import should succeed, but result as skipped, as a rolling stock already exists and --force is disabled"
             );
-            let rolling_stock = RollingStock::retrieve_real(
-                db_pool.get_ok(),
-                existing_rolling_stock_name.to_string(),
-            )
-            .await
-            .unwrap();
+            let rolling_stock =
+                RollingStock::retrieve(db_pool.get_ok(), existing_rolling_stock_name.to_string())
+                    .await
+                    .unwrap();
             assert!(rolling_stock.is_some());
             assert!(rolling_stock.unwrap().length == units::meter::new(100.0));
         }
@@ -434,12 +430,10 @@ mod tests {
 
             // THEN
             assert!(result.is_ok());
-            let created_rs = TowedRollingStock::retrieve_real(
-                db_pool.get_ok(),
-                towed_rolling_stock_name.to_string(),
-            )
-            .await
-            .unwrap();
+            let created_rs =
+                TowedRollingStock::retrieve(db_pool.get_ok(), towed_rolling_stock_name.to_string())
+                    .await
+                    .unwrap();
             assert!(created_rs.is_some());
         }
     }

--- a/editoast/src/client/infra_commands.rs
+++ b/editoast/src/client/infra_commands.rs
@@ -72,7 +72,7 @@ pub async fn clone_infra(
     infra_args: InfraCloneArgs,
     db_pool: Arc<DbConnectionPoolV2>,
 ) -> anyhow::Result<()> {
-    let infra = Infra::retrieve_real_or_fail(db_pool.get().await?, infra_args.id as i64, || {
+    let infra = Infra::retrieve_or_fail(db_pool.get().await?, infra_args.id as i64, || {
         anyhow::anyhow!("Infrastructure not found, ID: {}", infra_args.id)
     })
     .await?;

--- a/editoast/src/client/stdcm_search_env_commands.rs
+++ b/editoast/src/client/stdcm_search_env_commands.rs
@@ -85,7 +85,7 @@ async fn set_stdcm_search_env_from_scenario(
             .await?;
     }
 
-    let scenario = Scenario::retrieve_real_or_fail(conn.clone(), args.scenario_id, || {
+    let scenario = Scenario::retrieve_or_fail(conn.clone(), args.scenario_id, || {
         anyhow::anyhow!("Scenario not found, id: {}", args.scenario_id)
     })
     .await?;

--- a/editoast/src/client/timetables_commands.rs
+++ b/editoast/src/client/timetables_commands.rs
@@ -83,7 +83,7 @@ pub async fn trains_import(
 
     let timetable = match args.id {
         Some(timetable) => {
-            Timetable::retrieve_real_or_fail(db_pool.get().await?, timetable, || {
+            Timetable::retrieve_or_fail(db_pool.get().await?, timetable, || {
                 anyhow::anyhow!("Timetable not found, id: {}", timetable)
             })
             .await?

--- a/editoast/src/models/macro_node.rs
+++ b/editoast/src/models/macro_node.rs
@@ -52,8 +52,7 @@ pub mod test {
             .expect("Failed to create macro node");
 
         // Retrieve the created node
-        #[expect(deprecated)]
-        let node = MacroNode::retrieve(&mut db_pool.get_ok(), created.id)
+        let node = MacroNode::retrieve_real(db_pool.get_ok(), created.id)
             .await
             .expect("Failed to retrieve node")
             .expect("Macro node not found");

--- a/editoast/src/models/macro_node.rs
+++ b/editoast/src/models/macro_node.rs
@@ -52,7 +52,7 @@ pub mod test {
             .expect("Failed to create macro node");
 
         // Retrieve the created node
-        let node = MacroNode::retrieve_real(db_pool.get_ok(), created.id)
+        let node = MacroNode::retrieve(db_pool.get_ok(), created.id)
             .await
             .expect("Failed to retrieve node")
             .expect("Macro node not found");

--- a/editoast/src/models/mod.rs
+++ b/editoast/src/models/mod.rs
@@ -208,7 +208,7 @@ mod tests {
 
         let ids = docs.iter().map(|d| d.id).collect::<Vec<_>>();
         assert_eq!(
-            Document::retrieve_real(pool.get_ok(), ids[0])
+            Document::retrieve(pool.get_ok(), ids[0])
                 .await
                 .expect("Failed to retrieve document")
                 .expect("Document not found")
@@ -216,7 +216,7 @@ mod tests {
             Data::Prefixed(0x43)
         );
         assert_eq!(
-            Document::retrieve_real(pool.get_ok(), ids[1])
+            Document::retrieve(pool.get_ok(), ids[1])
                 .await
                 .expect("Failed to retrieve document")
                 .expect("Document not found")

--- a/editoast/src/models/prelude/retrieve.rs
+++ b/editoast/src/models/prelude/retrieve.rs
@@ -3,10 +3,6 @@ use std::fmt::Debug;
 use axum::http::StatusCode;
 use database::DbConnection;
 
-use crate::error::EditoastError;
-use crate::error::InternalError;
-use crate::error::Result;
-
 use super::Model;
 
 /// Describes how a [Model] can be retrieved from the database
@@ -20,46 +16,16 @@ where
 {
     type Error: std::error::Error + From<editoast_models::model::Error> + Send;
 
-    #[deprecated = "use Retrieve::retrieve_real instead"]
-    async fn retrieve(conn: &mut DbConnection, id: K) -> Result<Option<Self>> {
-        match Self::retrieve_real(conn.clone(), id).await {
-            Ok(model) => Ok(model),
-            // TODO: this is a temporary hack to ease the Retrieve error migration
-            // This implementation will be removed in the future and `retrieve_real`
-            // will become `retrieve`.
-            Err(model_error) => Err(InternalError {
-                status: StatusCode::INTERNAL_SERVER_ERROR,
-                error_type: "editoast:model:retrieve".to_owned(),
-                context: Default::default(),
-                message: model_error.to_string(),
-            }),
-        }
-    }
-
     /// Retrieves the row #`id` and deserializes it as a model instance
-    async fn retrieve_real(conn: DbConnection, id: K) -> Result<Option<Self>, Self::Error>;
-
-    #[deprecated = "use Retrieve::retrieve_real_or_fail instead"]
-    async fn retrieve_or_fail<E, F>(conn: &mut DbConnection, id: K, fail: F) -> Result<Self>
-    where
-        E: EditoastError,
-        F: FnOnce() -> E + Send,
-    {
-        #[expect(deprecated)]
-        match Self::retrieve(conn, id).await {
-            Ok(Some(obj)) => Ok(obj),
-            Ok(None) => Err(fail().into()),
-            Err(e) => Err(e),
-        }
-    }
+    async fn retrieve(conn: DbConnection, id: K) -> Result<Option<Self>, Self::Error>;
 
     /// Just like [Retrieve::retrieve] but returns `Err(fail())` if the row was not found
-    async fn retrieve_real_or_fail<E, F>(conn: DbConnection, id: K, fail: F) -> Result<Self, E>
+    async fn retrieve_or_fail<E, F>(conn: DbConnection, id: K, fail: F) -> Result<Self, E>
     where
         E: From<Self::Error>,
         F: FnOnce() -> E + Send,
     {
-        match Self::retrieve_real(conn, id).await {
+        match Self::retrieve(conn, id).await {
             Ok(Some(obj)) => Ok(obj),
             Ok(None) => Err(fail()),
             Err(e) => Err(E::from(e)),

--- a/editoast/src/models/project.rs
+++ b/editoast/src/models/project.rs
@@ -203,8 +203,7 @@ pub mod tests {
         let created_project = create_project(&mut db_pool.get_ok(), "test_project_name").await;
 
         // Get a project
-        #[expect(deprecated)]
-        let project = Project::retrieve(&mut db_pool.get_ok(), created_project.id)
+        let project = Project::retrieve_real(db_pool.get_ok(), created_project.id)
             .await
             .expect("Failed to retrieve project")
             .expect("Project not found");
@@ -229,8 +228,7 @@ pub mod tests {
             .await
             .expect("Failed to update project");
 
-        #[expect(deprecated)]
-        let project = Project::retrieve(&mut db_pool.get_ok(), created_project.id)
+        let project = Project::retrieve_real(db_pool.get_ok(), created_project.id)
             .await
             .expect("Failed to retrieve project")
             .expect("Project not found");

--- a/editoast/src/models/project.rs
+++ b/editoast/src/models/project.rs
@@ -157,7 +157,7 @@ impl Project {
     {
         conn.transaction(|mut conn| {
             async move {
-                let mut project = Self::retrieve_real_or_fail(conn.clone(), project_id, || {
+                let mut project = Self::retrieve_or_fail(conn.clone(), project_id, || {
                     ProjectError::NotFound { project_id }
                 })
                 .await?;
@@ -203,7 +203,7 @@ pub mod tests {
         let created_project = create_project(&mut db_pool.get_ok(), "test_project_name").await;
 
         // Get a project
-        let project = Project::retrieve_real(db_pool.get_ok(), created_project.id)
+        let project = Project::retrieve(db_pool.get_ok(), created_project.id)
             .await
             .expect("Failed to retrieve project")
             .expect("Project not found");
@@ -228,7 +228,7 @@ pub mod tests {
             .await
             .expect("Failed to update project");
 
-        let project = Project::retrieve_real(db_pool.get_ok(), created_project.id)
+        let project = Project::retrieve(db_pool.get_ok(), created_project.id)
             .await
             .expect("Failed to retrieve project")
             .expect("Project not found");

--- a/editoast/src/models/rolling_stock_livery.rs
+++ b/editoast/src/models/rolling_stock_livery.rs
@@ -70,16 +70,12 @@ pub mod tests {
             create_rolling_stock_livery_fixture(&mut db_pool.get_ok(), "rs_livery_name").await;
 
         assert!(
-            RollingStockLivery::retrieve_real(db_pool.get_ok(), rs_livery.id)
+            RollingStockLivery::retrieve(db_pool.get_ok(), rs_livery.id)
                 .await
                 .is_ok()
         );
 
-        assert!(
-            Document::retrieve_real(db_pool.get_ok(), image.id)
-                .await
-                .is_ok()
-        );
+        assert!(Document::retrieve(db_pool.get_ok(), image.id).await.is_ok());
 
         assert!(
             rs_livery
@@ -89,14 +85,14 @@ pub mod tests {
         );
 
         assert!(
-            RollingStockLivery::retrieve_real(db_pool.get_ok(), rs_livery.id)
+            RollingStockLivery::retrieve(db_pool.get_ok(), rs_livery.id)
                 .await
                 .expect("Failed to retrieve rolling stock livery")
                 .is_none()
         );
 
         assert!(
-            Document::retrieve_real(db_pool.get_ok(), image.id)
+            Document::retrieve(db_pool.get_ok(), image.id)
                 .await
                 .expect("Failed to retrieve document")
                 .is_none()

--- a/editoast/src/models/scenario.rs
+++ b/editoast/src/models/scenario.rs
@@ -93,8 +93,7 @@ impl Scenario {
     {
         conn.transaction(|mut conn| {
             async move {
-                #[expect(deprecated)]
-                let mut scenario = Self::retrieve_or_fail(&mut conn, scenario_id, || {
+                let mut scenario = Self::retrieve_real_or_fail(conn.clone(), scenario_id, || {
                     ScenarioError::NotFound { scenario_id }
                 })
                 .await?;

--- a/editoast/src/models/scenario.rs
+++ b/editoast/src/models/scenario.rs
@@ -93,7 +93,7 @@ impl Scenario {
     {
         conn.transaction(|mut conn| {
             async move {
-                let mut scenario = Self::retrieve_real_or_fail(conn.clone(), scenario_id, || {
+                let mut scenario = Self::retrieve_or_fail(conn.clone(), scenario_id, || {
                     ScenarioError::NotFound { scenario_id }
                 })
                 .await?;

--- a/editoast/src/models/study.rs
+++ b/editoast/src/models/study.rs
@@ -93,7 +93,7 @@ impl Study {
     {
         conn.transaction(|mut conn| {
             async move {
-                let mut study = Self::retrieve_real_or_fail(conn.clone(), study_id, || {
+                let mut study = Self::retrieve_or_fail(conn.clone(), study_id, || {
                     StudyError::NotFound { study_id }
                 })
                 .await?;
@@ -152,7 +152,7 @@ pub mod tests {
             create_study(&mut db_pool.get_ok(), study_name, created_project.id).await;
 
         // Retrieve a study
-        let study = Study::retrieve_real(db_pool.get_ok(), created_study.id)
+        let study = Study::retrieve(db_pool.get_ok(), created_study.id)
             .await
             .expect("Failed to retrieve study")
             .expect("Study not found");

--- a/editoast/src/models/study.rs
+++ b/editoast/src/models/study.rs
@@ -93,8 +93,7 @@ impl Study {
     {
         conn.transaction(|mut conn| {
             async move {
-                #[expect(deprecated)]
-                let mut study = Self::retrieve_or_fail(&mut conn, study_id, || {
+                let mut study = Self::retrieve_real_or_fail(conn.clone(), study_id, || {
                     StudyError::NotFound { study_id }
                 })
                 .await?;
@@ -153,8 +152,7 @@ pub mod tests {
             create_study(&mut db_pool.get_ok(), study_name, created_project.id).await;
 
         // Retrieve a study
-        #[expect(deprecated)]
-        let study = Study::retrieve(&mut db_pool.get_ok(), created_study.id)
+        let study = Study::retrieve_real(db_pool.get_ok(), created_study.id)
             .await
             .expect("Failed to retrieve study")
             .expect("Study not found");

--- a/editoast/src/views/documents.rs
+++ b/editoast/src/views/documents.rs
@@ -57,11 +57,10 @@ pub(in crate::views) async fn get(
         return Err(AuthorizationError::Forbidden.into());
     }
     let conn = &mut db_pool.get().await?;
-    let doc =
-        Document::retrieve_real_or_fail(conn.clone(), document_id, || DocumentErrors::NotFound {
-            document_key: document_id,
-        })
-        .await?;
+    let doc = Document::retrieve_or_fail(conn.clone(), document_id, || DocumentErrors::NotFound {
+        document_key: document_id,
+    })
+    .await?;
     Ok((
         StatusCode::OK,
         [
@@ -190,7 +189,7 @@ mod tests {
         let new_doc = response.json::<PostDocumentResponse>().document_key;
 
         // Get create document
-        let document = Document::retrieve_real(pool.get_ok(), new_doc)
+        let document = Document::retrieve(pool.get_ok(), new_doc)
             .await
             .expect("Failed to retrieve document")
             .expect("Document not found");

--- a/editoast/src/views/documents.rs
+++ b/editoast/src/views/documents.rs
@@ -57,11 +57,11 @@ pub(in crate::views) async fn get(
         return Err(AuthorizationError::Forbidden.into());
     }
     let conn = &mut db_pool.get().await?;
-    #[expect(deprecated)]
-    let doc = Document::retrieve_or_fail(conn, document_id, || DocumentErrors::NotFound {
-        document_key: document_id,
-    })
-    .await?;
+    let doc =
+        Document::retrieve_real_or_fail(conn.clone(), document_id, || DocumentErrors::NotFound {
+            document_key: document_id,
+        })
+        .await?;
     Ok((
         StatusCode::OK,
         [
@@ -190,8 +190,7 @@ mod tests {
         let new_doc = response.json::<PostDocumentResponse>().document_key;
 
         // Get create document
-        #[expect(deprecated)]
-        let document = Document::retrieve(&mut pool.get_ok(), new_doc)
+        let document = Document::retrieve_real(pool.get_ok(), new_doc)
             .await
             .expect("Failed to retrieve document")
             .expect("Document not found");

--- a/editoast/src/views/electrical_profiles.rs
+++ b/editoast/src/views/electrical_profiles.rs
@@ -79,13 +79,13 @@ pub(in crate::views) async fn get(
     if !authorized {
         return Err(AuthorizationError::Forbidden.into());
     }
-    let conn = &mut db_pool.get().await?;
-    #[expect(deprecated)]
-    let ep_set = ElectricalProfileSet::retrieve_or_fail(conn, electrical_profile_set_id, || {
-        ElectricalProfilesError::NotFound {
+    let ep_set = ElectricalProfileSet::retrieve_real_or_fail(
+        db_pool.get().await?,
+        electrical_profile_set_id,
+        || ElectricalProfilesError::NotFound {
             electrical_profile_set_id,
-        }
-    })
+        },
+    )
     .await?;
     Ok(Json(ep_set.data))
 }
@@ -120,13 +120,13 @@ pub(in crate::views) async fn get_level_order(
     if !authorized {
         return Err(AuthorizationError::Forbidden.into());
     }
-    let conn = &mut db_pool.get().await?;
-    #[expect(deprecated)]
-    let ep_set = ElectricalProfileSet::retrieve_or_fail(conn, electrical_profile_set_id, || {
-        ElectricalProfilesError::NotFound {
+    let ep_set = ElectricalProfileSet::retrieve_real_or_fail(
+        db_pool.get().await?,
+        electrical_profile_set_id,
+        || ElectricalProfilesError::NotFound {
             electrical_profile_set_id,
-        }
-    })
+        },
+    )
     .await?;
     Ok(Json(ep_set.data.level_order))
 }
@@ -207,6 +207,9 @@ pub enum ElectricalProfilesError {
     #[error("Electrical Profile Set '{electrical_profile_set_id}', could not be found")]
     #[editoast_error(status = 404)]
     NotFound { electrical_profile_set_id: i64 },
+    #[error(transparent)]
+    #[editoast_error(status = 500)]
+    Database(#[from] editoast_models::model::Error),
 }
 
 #[cfg(test)]
@@ -343,8 +346,7 @@ mod tests {
         response.assert_status(StatusCode::OK);
         let created_ep: ElectricalProfileSet = response.json();
 
-        #[expect(deprecated)]
-        let created_ep = ElectricalProfileSet::retrieve(&mut pool.get_ok(), created_ep.id)
+        let created_ep = ElectricalProfileSet::retrieve_real(pool.get_ok(), created_ep.id)
             .await
             .expect("Failed to retrieve created electrical profile set")
             .expect("Electrical profile set not found");

--- a/editoast/src/views/electrical_profiles.rs
+++ b/editoast/src/views/electrical_profiles.rs
@@ -79,7 +79,7 @@ pub(in crate::views) async fn get(
     if !authorized {
         return Err(AuthorizationError::Forbidden.into());
     }
-    let ep_set = ElectricalProfileSet::retrieve_real_or_fail(
+    let ep_set = ElectricalProfileSet::retrieve_or_fail(
         db_pool.get().await?,
         electrical_profile_set_id,
         || ElectricalProfilesError::NotFound {
@@ -120,7 +120,7 @@ pub(in crate::views) async fn get_level_order(
     if !authorized {
         return Err(AuthorizationError::Forbidden.into());
     }
-    let ep_set = ElectricalProfileSet::retrieve_real_or_fail(
+    let ep_set = ElectricalProfileSet::retrieve_or_fail(
         db_pool.get().await?,
         electrical_profile_set_id,
         || ElectricalProfilesError::NotFound {
@@ -346,7 +346,7 @@ mod tests {
         response.assert_status(StatusCode::OK);
         let created_ep: ElectricalProfileSet = response.json();
 
-        let created_ep = ElectricalProfileSet::retrieve_real(pool.get_ok(), created_ep.id)
+        let created_ep = ElectricalProfileSet::retrieve(pool.get_ok(), created_ep.id)
             .await
             .expect("Failed to retrieve created electrical profile set")
             .expect("Electrical profile set not found");

--- a/editoast/src/views/infra/attached.rs
+++ b/editoast/src/views/infra/attached.rs
@@ -80,7 +80,7 @@ pub(in crate::views) async fn attached(
     // Check that infra exists
     let mut conn = db_pool.get().await?;
     // TODO: lock for share
-    let infra = Infra::retrieve_real_or_fail(conn.clone(), infra_id, || InfraApiError::NotFound {
+    let infra = Infra::retrieve_or_fail(conn.clone(), infra_id, || InfraApiError::NotFound {
         infra_id,
     })
     .await?;

--- a/editoast/src/views/infra/attached.rs
+++ b/editoast/src/views/infra/attached.rs
@@ -80,10 +80,10 @@ pub(in crate::views) async fn attached(
     // Check that infra exists
     let mut conn = db_pool.get().await?;
     // TODO: lock for share
-    #[expect(deprecated)]
-    let infra =
-        Infra::retrieve_or_fail(&mut conn, infra_id, || InfraApiError::NotFound { infra_id })
-            .await?;
+    let infra = Infra::retrieve_real_or_fail(conn.clone(), infra_id, || InfraApiError::NotFound {
+        infra_id,
+    })
+    .await?;
 
     // Check user privilege on infra
     auth.check_authorization(async |authorizer| {

--- a/editoast/src/views/infra/auto_fixes/mod.rs
+++ b/editoast/src/views/infra/auto_fixes/mod.rs
@@ -314,7 +314,7 @@ fn reduce_operation(
 #[editoast_error(base_id = "auto_fixes")]
 pub enum AutoFixesEditoastError {
     #[error(
-        "Reached maximum number of iterations to fix infra without providing every possible fixe"
+        "Reached maximum number of iterations to fix infra without providing every possible fix"
     )]
     #[editoast_error(status = 500)]
     MaximumIterationReached,

--- a/editoast/src/views/infra/auto_fixes/mod.rs
+++ b/editoast/src/views/infra/auto_fixes/mod.rs
@@ -99,7 +99,7 @@ pub(in crate::views) async fn list_auto_fixes(
     }
 
     let mut conn = db_pool.get().await?;
-    let infra = Infra::retrieve_real_or_fail(conn.clone(), infra_id, || InfraApiError::NotFound {
+    let infra = Infra::retrieve_or_fail(conn.clone(), infra_id, || InfraApiError::NotFound {
         infra_id,
     })
     .await?;

--- a/editoast/src/views/infra/auto_fixes/mod.rs
+++ b/editoast/src/views/infra/auto_fixes/mod.rs
@@ -98,11 +98,11 @@ pub(in crate::views) async fn list_auto_fixes(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    let conn = &mut db_pool.get().await?;
-
-    #[expect(deprecated)]
-    let infra =
-        Infra::retrieve_or_fail(conn, infra_id, || InfraApiError::NotFound { infra_id }).await?;
+    let mut conn = db_pool.get().await?;
+    let infra = Infra::retrieve_real_or_fail(conn.clone(), infra_id, || InfraApiError::NotFound {
+        infra_id,
+    })
+    .await?;
 
     // Check user privilege on infra
     auth.check_authorization(async |authorizer| {
@@ -113,7 +113,7 @@ pub(in crate::views) async fn list_auto_fixes(
     .await?;
 
     // accepting the early release of ReadGuard as it's anyway released when sending the suggestions (so before edit)
-    let mut infra_cache_clone = InfraCache::get_or_load(conn, &infra_caches, &infra)
+    let mut infra_cache_clone = InfraCache::get_or_load(&mut conn, &infra_caches, &infra)
         .await?
         .clone();
 

--- a/editoast/src/views/infra/delimited_area.rs
+++ b/editoast/src/views/infra/delimited_area.rs
@@ -147,7 +147,7 @@ pub(in crate::views) async fn delimited_area(
 
     // Retrieve the infra
     let mut conn = db_pool.get().await?;
-    let infra = Infra::retrieve_real_or_fail(conn.clone(), infra_id, || InfraApiError::NotFound {
+    let infra = Infra::retrieve_or_fail(conn.clone(), infra_id, || InfraApiError::NotFound {
         infra_id,
     })
     .await?;

--- a/editoast/src/views/infra/delimited_area.rs
+++ b/editoast/src/views/infra/delimited_area.rs
@@ -146,10 +146,11 @@ pub(in crate::views) async fn delimited_area(
     }
 
     // Retrieve the infra
-    let conn = &mut db_pool.get().await?;
-    #[expect(deprecated)]
-    let infra =
-        Infra::retrieve_or_fail(conn, infra_id, || InfraApiError::NotFound { infra_id }).await?;
+    let mut conn = db_pool.get().await?;
+    let infra = Infra::retrieve_real_or_fail(conn.clone(), infra_id, || InfraApiError::NotFound {
+        infra_id,
+    })
+    .await?;
 
     // Check user privilege on infra
     auth.check_authorization(async |authorizer| {
@@ -159,7 +160,7 @@ pub(in crate::views) async fn delimited_area(
     })
     .await?;
 
-    let infra_cache = InfraCache::get_or_load(conn, &infra_caches, &infra).await?;
+    let infra_cache = InfraCache::get_or_load(&mut conn, &infra_caches, &infra).await?;
     let graph = Graph::load(&infra_cache);
 
     // Validate user input

--- a/editoast/src/views/infra/delimited_area.rs
+++ b/editoast/src/views/infra/delimited_area.rs
@@ -86,7 +86,7 @@ enum InputError {
 #[derive(Debug, Error, Serialize, Deserialize)]
 enum TrackRangeConstructionError {
     #[error("Track identifiers do not match")]
-    TrackIdentifierMissmatch,
+    TrackIdentifierMismatch,
     #[error("The input directions or locations on track do not allow to build a valid track range")]
     InvalidRelativeLocations,
     #[error("The location is not on track")]
@@ -430,7 +430,7 @@ fn track_range_between_two_locations(
     if entry.direction != exit.direction || exit_before_entry {
         Err(TrackRangeConstructionError::InvalidRelativeLocations)
     } else if entry.track != exit.track {
-        Err(TrackRangeConstructionError::TrackIdentifierMissmatch)
+        Err(TrackRangeConstructionError::TrackIdentifierMismatch)
     } else {
         Ok(DirectionalTrackRange {
             track: entry.track.clone(),
@@ -463,7 +463,7 @@ fn track_range_between_endpoint_and_location(
     if !location_on_correct_direction {
         Err(TrackRangeConstructionError::InvalidRelativeLocations)
     } else if !same_track {
-        Err(TrackRangeConstructionError::TrackIdentifierMissmatch)
+        Err(TrackRangeConstructionError::TrackIdentifierMismatch)
     } else if !location_inside_track {
         Err(TrackRangeConstructionError::LocationNotOnTrack)
     } else {

--- a/editoast/src/views/infra/edition.rs
+++ b/editoast/src/views/infra/edition.rs
@@ -91,8 +91,7 @@ pub(in crate::views) async fn edit(
     }
 
     // TODO: lock for update
-    #[expect(deprecated)]
-    let mut infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra_id, || {
+    let mut infra = Infra::retrieve_real_or_fail(db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
     })
     .await?;
@@ -164,8 +163,7 @@ pub(in crate::views) async fn split_track_section(
     );
 
     // Check the infra
-    #[expect(deprecated)]
-    let mut infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra_id, || {
+    let mut infra = Infra::retrieve_real_or_fail(db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
     })
     .await?;

--- a/editoast/src/views/infra/edition.rs
+++ b/editoast/src/views/infra/edition.rs
@@ -91,7 +91,7 @@ pub(in crate::views) async fn edit(
     }
 
     // TODO: lock for update
-    let mut infra = Infra::retrieve_real_or_fail(db_pool.get().await?, infra_id, || {
+    let mut infra = Infra::retrieve_or_fail(db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
     })
     .await?;
@@ -163,7 +163,7 @@ pub(in crate::views) async fn split_track_section(
     );
 
     // Check the infra
-    let mut infra = Infra::retrieve_real_or_fail(db_pool.get().await?, infra_id, || {
+    let mut infra = Infra::retrieve_or_fail(db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
     })
     .await?;

--- a/editoast/src/views/infra/errors.rs
+++ b/editoast/src/views/infra/errors.rs
@@ -92,10 +92,11 @@ pub(in crate::views) async fn list_errors(
         None => None,
     };
 
-    let conn = &mut db_pool.get().await?;
-    #[expect(deprecated)]
-    let infra =
-        Infra::retrieve_or_fail(conn, infra_id, || InfraApiError::NotFound { infra_id }).await?;
+    let mut conn = db_pool.get().await?;
+    let infra = Infra::retrieve_real_or_fail(conn.clone(), infra_id, || InfraApiError::NotFound {
+        infra_id,
+    })
+    .await?;
 
     // Check user privilege on infra
     auth.check_authorization(async |authorizer| {
@@ -106,7 +107,7 @@ pub(in crate::views) async fn list_errors(
     .await?;
 
     let (results, total_count) = infra
-        .get_paginated_errors(conn, level, error_type, object_id, page, page_size)
+        .get_paginated_errors(&mut conn, level, error_type, object_id, page, page_size)
         .await?;
     let results = results
         .into_iter()

--- a/editoast/src/views/infra/errors.rs
+++ b/editoast/src/views/infra/errors.rs
@@ -93,7 +93,7 @@ pub(in crate::views) async fn list_errors(
     };
 
     let mut conn = db_pool.get().await?;
-    let infra = Infra::retrieve_real_or_fail(conn.clone(), infra_id, || InfraApiError::NotFound {
+    let infra = Infra::retrieve_or_fail(conn.clone(), infra_id, || InfraApiError::NotFound {
         infra_id,
     })
     .await?;

--- a/editoast/src/views/infra/lines.rs
+++ b/editoast/src/views/infra/lines.rs
@@ -54,7 +54,7 @@ pub(in crate::views) async fn get_line_bbox(
     let line_code: i32 = line_code.try_into().unwrap();
 
     let mut conn = db_pool.get().await?;
-    let infra = Infra::retrieve_real_or_fail(conn.clone(), infra_id, || InfraApiError::NotFound {
+    let infra = Infra::retrieve_or_fail(conn.clone(), infra_id, || InfraApiError::NotFound {
         infra_id,
     })
     .await?;

--- a/editoast/src/views/infra/lines.rs
+++ b/editoast/src/views/infra/lines.rs
@@ -53,10 +53,11 @@ pub(in crate::views) async fn get_line_bbox(
 
     let line_code: i32 = line_code.try_into().unwrap();
 
-    let conn = &mut db_pool.get().await?;
-    #[expect(deprecated)]
-    let infra =
-        Infra::retrieve_or_fail(conn, infra_id, || InfraApiError::NotFound { infra_id }).await?;
+    let mut conn = db_pool.get().await?;
+    let infra = Infra::retrieve_real_or_fail(conn.clone(), infra_id, || InfraApiError::NotFound {
+        infra_id,
+    })
+    .await?;
 
     // Check user privilege on infra
     auth.check_authorization(async |authorizer| {
@@ -69,7 +70,7 @@ pub(in crate::views) async fn get_line_bbox(
     let mut bbox = BoundingBox::default();
     let selection_settings =
         SelectionSettings::new().filter(move || TrackSectionModel::INFRA_ID.eq(infra.id));
-    let tracksections_model = TrackSectionModel::list(conn, selection_settings).await?;
+    let tracksections_model = TrackSectionModel::list(&mut conn, selection_settings).await?;
     let mut tracksections = tracksections_model
         .into_iter()
         .map(TrackSection::from)

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -315,8 +315,7 @@ pub(in crate::views) async fn get(
     }
 
     let infra_id = infra.infra_id;
-    #[expect(deprecated)]
-    let infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra_id, || {
+    let infra = Infra::retrieve_real_or_fail(db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
     })
     .await?;
@@ -426,11 +425,11 @@ pub(in crate::views) async fn clone(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    let conn = &mut db_pool.get().await?;
-
-    #[expect(deprecated)]
-    let infra =
-        Infra::retrieve_or_fail(conn, infra_id, || InfraApiError::NotFound { infra_id }).await?;
+    let mut conn = db_pool.get().await?;
+    let infra = Infra::retrieve_real_or_fail(conn.clone(), infra_id, || InfraApiError::NotFound {
+        infra_id,
+    })
+    .await?;
 
     // Check user privilege on infra
     auth.clone()
@@ -441,7 +440,7 @@ pub(in crate::views) async fn clone(
         })
         .await?;
 
-    let cloned_infra = infra.clone(conn, name).await?;
+    let cloned_infra = infra.clone(&mut conn, name).await?;
 
     // Assign OWNER to the user on the infra if authz is enabled
     // NOTE: we use the regulator here instead of the one in the authorizer to bypass the checks on grant_infra_owner
@@ -577,11 +576,12 @@ pub(in crate::views) async fn get_switch_types(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    let conn = &mut db_pool.get().await?;
+    let mut conn = db_pool.get().await?;
 
-    #[expect(deprecated)]
-    let infra =
-        Infra::retrieve_or_fail(conn, infra_id, || InfraApiError::NotFound { infra_id }).await?;
+    let infra = Infra::retrieve_real_or_fail(conn.clone(), infra_id, || InfraApiError::NotFound {
+        infra_id,
+    })
+    .await?;
 
     // Check user privilege on infra
     auth.check_authorization(async |authorizer| {
@@ -593,7 +593,7 @@ pub(in crate::views) async fn get_switch_types(
 
     let selection_settings =
         SelectionSettings::new().filter(move || SwitchTypeModel::INFRA_ID.eq(infra.id));
-    let switch_types_model = SwitchTypeModel::list(conn, selection_settings).await?;
+    let switch_types_model = SwitchTypeModel::list(&mut conn, selection_settings).await?;
 
     let extended_switch_types = switch_types_model
         .into_iter()
@@ -635,11 +635,12 @@ pub(in crate::views) async fn get_speed_limit_tags(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    let conn = &mut db_pool.get().await?;
+    let mut conn = db_pool.get().await?;
 
-    #[expect(deprecated)]
-    let infra =
-        Infra::retrieve_or_fail(conn, infra_id, || InfraApiError::NotFound { infra_id }).await?;
+    let infra = Infra::retrieve_real_or_fail(conn.clone(), infra_id, || InfraApiError::NotFound {
+        infra_id,
+    })
+    .await?;
 
     // Check user privilege on infra
     auth.check_authorization(async |authorizer| {
@@ -649,7 +650,7 @@ pub(in crate::views) async fn get_speed_limit_tags(
     })
     .await?;
 
-    let infra_tags = infra.get_speed_limit_tags(conn).await?;
+    let infra_tags = infra.get_speed_limit_tags(&mut conn).await?;
     let union_tags: HashSet<String> = infra_tags
         .into_iter()
         .map(|el| el.tag)
@@ -691,8 +692,7 @@ pub(in crate::views) async fn get_voltages(
     }
 
     let include_rolling_stock_modes = param.include_rolling_stock_modes;
-    #[expect(deprecated)]
-    let infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra_id, || {
+    let infra = Infra::retrieve_real_or_fail(db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
     })
     .await?;
@@ -738,8 +738,7 @@ pub(in crate::views) async fn get_all_voltages(
 }
 
 async fn set_locked(infra_id: i64, locked: bool, db_pool: DbConnectionPoolV2) -> Result<()> {
-    #[expect(deprecated)]
-    let mut infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra_id, || {
+    let mut infra = Infra::retrieve_real_or_fail(db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
     })
     .await?;
@@ -856,8 +855,7 @@ pub(in crate::views) async fn load(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    #[expect(deprecated)]
-    let infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra_id, || {
+    let infra = Infra::retrieve_real_or_fail(db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
     })
     .await?;
@@ -1161,8 +1159,7 @@ pub mod tests {
             app.post(format!("/infra/{}/clone/?name=cloned_infra", empty_infra.id).as_str());
 
         let cloned_infra_id: i64 = app.fetch(request).assert_status(StatusCode::OK).json_into();
-        #[expect(deprecated)]
-        let cloned_infra = Infra::retrieve(&mut db_pool.get_ok(), cloned_infra_id)
+        let cloned_infra = Infra::retrieve_real(db_pool.get_ok(), cloned_infra_id)
             .await
             .unwrap()
             .expect("infra was not cloned");
@@ -1207,8 +1204,7 @@ pub mod tests {
             .assert_status(StatusCode::OK)
             .json_into();
 
-        #[expect(deprecated)]
-        let _cloned_infra = Infra::retrieve(&mut db_pool.get_ok(), cloned_infra_id)
+        let _cloned_infra = Infra::retrieve_real(db_pool.get_ok(), cloned_infra_id)
             .await
             .unwrap()
             .expect("infra was not cloned");
@@ -1512,8 +1508,7 @@ pub mod tests {
         app.fetch(req).assert_status(StatusCode::NO_CONTENT);
 
         // Check lock
-        #[expect(deprecated)]
-        let infra = Infra::retrieve(&mut db_pool.get_ok(), empty_infra.id)
+        let infra = Infra::retrieve_real(db_pool.get_ok(), empty_infra.id)
             .await
             .unwrap()
             .expect("infra was not cloned");
@@ -1525,8 +1520,7 @@ pub mod tests {
         app.fetch(req).assert_status(StatusCode::NO_CONTENT);
 
         // Check lock
-        #[expect(deprecated)]
-        let infra = Infra::retrieve(&mut db_pool.get_ok(), empty_infra.id)
+        let infra = Infra::retrieve_real(db_pool.get_ok(), empty_infra.id)
             .await
             .unwrap()
             .expect("infra was not cloned");

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -315,7 +315,7 @@ pub(in crate::views) async fn get(
     }
 
     let infra_id = infra.infra_id;
-    let infra = Infra::retrieve_real_or_fail(db_pool.get().await?, infra_id, || {
+    let infra = Infra::retrieve_or_fail(db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
     })
     .await?;
@@ -426,7 +426,7 @@ pub(in crate::views) async fn clone(
     }
 
     let mut conn = db_pool.get().await?;
-    let infra = Infra::retrieve_real_or_fail(conn.clone(), infra_id, || InfraApiError::NotFound {
+    let infra = Infra::retrieve_or_fail(conn.clone(), infra_id, || InfraApiError::NotFound {
         infra_id,
     })
     .await?;
@@ -578,7 +578,7 @@ pub(in crate::views) async fn get_switch_types(
 
     let mut conn = db_pool.get().await?;
 
-    let infra = Infra::retrieve_real_or_fail(conn.clone(), infra_id, || InfraApiError::NotFound {
+    let infra = Infra::retrieve_or_fail(conn.clone(), infra_id, || InfraApiError::NotFound {
         infra_id,
     })
     .await?;
@@ -637,7 +637,7 @@ pub(in crate::views) async fn get_speed_limit_tags(
 
     let mut conn = db_pool.get().await?;
 
-    let infra = Infra::retrieve_real_or_fail(conn.clone(), infra_id, || InfraApiError::NotFound {
+    let infra = Infra::retrieve_or_fail(conn.clone(), infra_id, || InfraApiError::NotFound {
         infra_id,
     })
     .await?;
@@ -692,7 +692,7 @@ pub(in crate::views) async fn get_voltages(
     }
 
     let include_rolling_stock_modes = param.include_rolling_stock_modes;
-    let infra = Infra::retrieve_real_or_fail(db_pool.get().await?, infra_id, || {
+    let infra = Infra::retrieve_or_fail(db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
     })
     .await?;
@@ -738,7 +738,7 @@ pub(in crate::views) async fn get_all_voltages(
 }
 
 async fn set_locked(infra_id: i64, locked: bool, db_pool: DbConnectionPoolV2) -> Result<()> {
-    let mut infra = Infra::retrieve_real_or_fail(db_pool.get().await?, infra_id, || {
+    let mut infra = Infra::retrieve_or_fail(db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
     })
     .await?;
@@ -855,7 +855,7 @@ pub(in crate::views) async fn load(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    let infra = Infra::retrieve_real_or_fail(db_pool.get().await?, infra_id, || {
+    let infra = Infra::retrieve_or_fail(db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
     })
     .await?;
@@ -1159,7 +1159,7 @@ pub mod tests {
             app.post(format!("/infra/{}/clone/?name=cloned_infra", empty_infra.id).as_str());
 
         let cloned_infra_id: i64 = app.fetch(request).assert_status(StatusCode::OK).json_into();
-        let cloned_infra = Infra::retrieve_real(db_pool.get_ok(), cloned_infra_id)
+        let cloned_infra = Infra::retrieve(db_pool.get_ok(), cloned_infra_id)
             .await
             .unwrap()
             .expect("infra was not cloned");
@@ -1204,7 +1204,7 @@ pub mod tests {
             .assert_status(StatusCode::OK)
             .json_into();
 
-        let _cloned_infra = Infra::retrieve_real(db_pool.get_ok(), cloned_infra_id)
+        let _cloned_infra = Infra::retrieve(db_pool.get_ok(), cloned_infra_id)
             .await
             .unwrap()
             .expect("infra was not cloned");
@@ -1508,7 +1508,7 @@ pub mod tests {
         app.fetch(req).assert_status(StatusCode::NO_CONTENT);
 
         // Check lock
-        let infra = Infra::retrieve_real(db_pool.get_ok(), empty_infra.id)
+        let infra = Infra::retrieve(db_pool.get_ok(), empty_infra.id)
             .await
             .unwrap()
             .expect("infra was not cloned");
@@ -1520,7 +1520,7 @@ pub mod tests {
         app.fetch(req).assert_status(StatusCode::NO_CONTENT);
 
         // Check lock
-        let infra = Infra::retrieve_real(db_pool.get_ok(), empty_infra.id)
+        let infra = Infra::retrieve(db_pool.get_ok(), empty_infra.id)
             .await
             .unwrap()
             .expect("infra was not cloned");

--- a/editoast/src/views/infra/objects.rs
+++ b/editoast/src/views/infra/objects.rs
@@ -71,7 +71,7 @@ pub(in crate::views) async fn get_objects(
         return Err(GetObjectsErrors::DuplicateIdsProvided.into());
     }
 
-    let infra = Infra::retrieve_real_or_fail(db_pool.get().await?, infra_id, || {
+    let infra = Infra::retrieve_or_fail(db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
     })
     .await?;
@@ -148,7 +148,7 @@ pub(in crate::views) async fn list_objects_ids(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    let infra = Infra::retrieve_real_or_fail(db_pool.get().await?, infra_id, || {
+    let infra = Infra::retrieve_or_fail(db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
     })
     .await?;

--- a/editoast/src/views/infra/objects.rs
+++ b/editoast/src/views/infra/objects.rs
@@ -71,8 +71,7 @@ pub(in crate::views) async fn get_objects(
         return Err(GetObjectsErrors::DuplicateIdsProvided.into());
     }
 
-    #[expect(deprecated)]
-    let infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra_id, || {
+    let infra = Infra::retrieve_real_or_fail(db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
     })
     .await?;
@@ -149,8 +148,7 @@ pub(in crate::views) async fn list_objects_ids(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    #[expect(deprecated)]
-    let infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra_id, || {
+    let infra = Infra::retrieve_real_or_fail(db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
     })
     .await?;

--- a/editoast/src/views/infra/pathfinding.rs
+++ b/editoast/src/views/infra/pathfinding.rs
@@ -119,7 +119,7 @@ pub(in crate::views) async fn pathfinding_view(
     }
 
     // TODO: lock for share
-    let infra = Infra::retrieve_real_or_fail(db_pool.get().await?, infra_id, || {
+    let infra = Infra::retrieve_or_fail(db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
     })
     .await?;

--- a/editoast/src/views/infra/pathfinding.rs
+++ b/editoast/src/views/infra/pathfinding.rs
@@ -119,8 +119,7 @@ pub(in crate::views) async fn pathfinding_view(
     }
 
     // TODO: lock for share
-    #[expect(deprecated)]
-    let infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra_id, || {
+    let infra = Infra::retrieve_real_or_fail(db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
     })
     .await?;

--- a/editoast/src/views/infra/railjson.rs
+++ b/editoast/src/views/infra/railjson.rs
@@ -55,7 +55,7 @@ pub(in crate::views) async fn get_railjson(
     }
 
     let infra_id = infra.infra_id;
-    let infra_meta = Infra::retrieve_real_or_fail(db_pool.get().await?, infra_id, || {
+    let infra_meta = Infra::retrieve_or_fail(db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
     })
     .await?;

--- a/editoast/src/views/infra/railjson.rs
+++ b/editoast/src/views/infra/railjson.rs
@@ -55,8 +55,7 @@ pub(in crate::views) async fn get_railjson(
     }
 
     let infra_id = infra.infra_id;
-    #[expect(deprecated)]
-    let infra_meta = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra_id, || {
+    let infra_meta = Infra::retrieve_real_or_fail(db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
     })
     .await?;

--- a/editoast/src/views/infra/routes.rs
+++ b/editoast/src/views/infra/routes.rs
@@ -71,13 +71,12 @@ pub(in crate::views) async fn get_routes_from_waypoint(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    let conn = &mut db_pool.get().await?;
-
-    #[expect(deprecated)]
-    let infra = Infra::retrieve_or_fail(conn, path.infra_id, || InfraApiError::NotFound {
-        infra_id: path.infra_id,
-    })
-    .await?;
+    let mut conn = db_pool.get().await?;
+    let infra =
+        Infra::retrieve_real_or_fail(conn.clone(), path.infra_id, || InfraApiError::NotFound {
+            infra_id: path.infra_id,
+        })
+        .await?;
 
     // Check user privilege on infra
     auth.check_authorization(async |authorizer| {
@@ -88,7 +87,7 @@ pub(in crate::views) async fn get_routes_from_waypoint(
     .await?;
 
     let routes = infra
-        .get_routes_from_waypoint(conn, &path.waypoint_id, path.waypoint_type.to_string())
+        .get_routes_from_waypoint(&mut conn, &path.waypoint_id, path.waypoint_type.to_string())
         .await?;
 
     // Split routes depending if they are entry or exit points
@@ -169,8 +168,7 @@ pub(in crate::views) async fn get_routes_track_ranges(
     let db_pool = db_pool.clone();
     let infra_caches = infra_caches.clone();
     let infra_id = infra;
-    #[expect(deprecated)]
-    let infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra_id, || {
+    let infra = Infra::retrieve_real_or_fail(db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
     })
     .await?;
@@ -241,8 +239,7 @@ pub(in crate::views) async fn get_routes_nodes(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    #[expect(deprecated)]
-    let infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra_id, || {
+    let infra = Infra::retrieve_real_or_fail(db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
     })
     .await?;

--- a/editoast/src/views/infra/routes.rs
+++ b/editoast/src/views/infra/routes.rs
@@ -72,11 +72,10 @@ pub(in crate::views) async fn get_routes_from_waypoint(
     }
 
     let mut conn = db_pool.get().await?;
-    let infra =
-        Infra::retrieve_real_or_fail(conn.clone(), path.infra_id, || InfraApiError::NotFound {
-            infra_id: path.infra_id,
-        })
-        .await?;
+    let infra = Infra::retrieve_or_fail(conn.clone(), path.infra_id, || InfraApiError::NotFound {
+        infra_id: path.infra_id,
+    })
+    .await?;
 
     // Check user privilege on infra
     auth.check_authorization(async |authorizer| {
@@ -168,7 +167,7 @@ pub(in crate::views) async fn get_routes_track_ranges(
     let db_pool = db_pool.clone();
     let infra_caches = infra_caches.clone();
     let infra_id = infra;
-    let infra = Infra::retrieve_real_or_fail(db_pool.get().await?, infra_id, || {
+    let infra = Infra::retrieve_or_fail(db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
     })
     .await?;
@@ -239,7 +238,7 @@ pub(in crate::views) async fn get_routes_nodes(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    let infra = Infra::retrieve_real_or_fail(db_pool.get().await?, infra_id, || {
+    let infra = Infra::retrieve_or_fail(db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
     })
     .await?;

--- a/editoast/src/views/path.rs
+++ b/editoast/src/views/path.rs
@@ -26,7 +26,7 @@ pub enum PathfindingError {
 }
 
 async fn retrieve_infra_version(conn: &mut DbConnection, infra_id: i64) -> Result<i64> {
-    let infra = Infra::retrieve_real_or_fail(conn.clone(), infra_id, || {
+    let infra = Infra::retrieve_or_fail(conn.clone(), infra_id, || {
         PathfindingError::InfraNotFound { infra_id }
     })
     .await?;

--- a/editoast/src/views/path.rs
+++ b/editoast/src/views/path.rs
@@ -20,12 +20,14 @@ pub enum PathfindingError {
     #[error("Infra '{infra_id}', could not be found")]
     #[editoast_error(status = 404)]
     InfraNotFound { infra_id: i64 },
+    #[error(transparent)]
+    #[editoast_error(status = 500)]
+    Database(#[from] editoast_models::model::Error),
 }
 
 async fn retrieve_infra_version(conn: &mut DbConnection, infra_id: i64) -> Result<i64> {
-    #[expect(deprecated)]
-    let infra = Infra::retrieve_or_fail(conn, infra_id, || PathfindingError::InfraNotFound {
-        infra_id,
+    let infra = Infra::retrieve_real_or_fail(conn.clone(), infra_id, || {
+        PathfindingError::InfraNotFound { infra_id }
     })
     .await?;
     Ok(infra.version)

--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -204,7 +204,7 @@ pub(in crate::views) async fn post(
 
     let conn = db_pool.get().await?;
     let mut valkey_conn = valkey.get_connection().await?;
-    let infra = Infra::retrieve_real_or_fail(conn.clone(), infra_id, || {
+    let infra = Infra::retrieve_or_fail(conn.clone(), infra_id, || {
         PathfindingError::InfraNotFound { infra_id }
     })
     .await?;
@@ -400,7 +400,7 @@ pub async fn pathfinding_from_train<T: TrainScheduleLike>(
     train_schedule: T,
 ) -> Result<PathfindingResult> {
     let rolling_stock: Vec<_> =
-        RollingStock::retrieve_real(conn.clone(), train_schedule.rolling_stock_name().to_owned())
+        RollingStock::retrieve(conn.clone(), train_schedule.rolling_stock_name().to_owned())
             .await?
             .into_iter()
             .map_into()

--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -202,11 +202,10 @@ pub(in crate::views) async fn post(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    let conn = &mut db_pool.get().await?;
+    let conn = db_pool.get().await?;
     let mut valkey_conn = valkey.get_connection().await?;
-    #[expect(deprecated)]
-    let infra = Infra::retrieve_or_fail(conn, infra_id, || PathfindingError::InfraNotFound {
-        infra_id,
+    let infra = Infra::retrieve_real_or_fail(conn.clone(), infra_id, || {
+        PathfindingError::InfraNotFound { infra_id }
     })
     .await?;
 
@@ -225,7 +224,7 @@ pub(in crate::views) async fn post(
 
 /// Pathfinding computation given a path input
 async fn pathfinding_blocks(
-    conn: &mut DbConnection,
+    conn: DbConnection,
     valkey_conn: &mut ValkeyConnection,
     core: Arc<CoreClient>,
     infra: &Infra,
@@ -237,7 +236,7 @@ async fn pathfinding_blocks(
 
 /// Pathfinding batch computation given a list of path inputs
 async fn pathfinding_blocks_batch(
-    conn: &mut DbConnection,
+    mut conn: DbConnection,
     valkey_conn: &mut ValkeyConnection,
     core: Arc<CoreClient>,
     infra: &Infra,
@@ -291,7 +290,7 @@ async fn pathfinding_blocks_batch(
         .filter(|(_, res)| res.is_none())
         .flat_map(|(hash, _)| &path_request_map[*hash].path_items)
         .collect();
-    let path_item_cache = PathItemCache::load(conn, infra.id, &path_items).await?;
+    let path_item_cache = PathItemCache::load(&mut conn, infra.id, &path_items).await?;
 
     debug!(
         nb_path_items = path_items.len(),
@@ -394,15 +393,14 @@ fn build_pathfinding_request(
 
 /// Compute a path given a train schedule and an infrastructure.
 pub async fn pathfinding_from_train<T: TrainScheduleLike>(
-    conn: &mut DbConnection,
+    conn: DbConnection,
     valkey: &mut ValkeyConnection,
     core: Arc<CoreClient>,
     infra: &Infra,
     train_schedule: T,
 ) -> Result<PathfindingResult> {
-    #[expect(deprecated)]
     let rolling_stock: Vec<_> =
-        RollingStock::retrieve(conn, train_schedule.rolling_stock_name().to_string())
+        RollingStock::retrieve_real(conn.clone(), train_schedule.rolling_stock_name().to_owned())
             .await?
             .into_iter()
             .map_into()
@@ -418,7 +416,7 @@ pub async fn pathfinding_from_train<T: TrainScheduleLike>(
 
 /// Compute a path given a batch of trainschedule and an infrastructure.
 pub async fn pathfinding_from_train_batch<T: TrainScheduleLike>(
-    conn: &mut DbConnection,
+    conn: DbConnection,
     valkey: &mut ValkeyConnection,
     core: Arc<CoreClient>,
     infra: &Infra,

--- a/editoast/src/views/project.rs
+++ b/editoast/src/views/project.rs
@@ -89,9 +89,8 @@ impl From<ProjectCreateForm> for Changeset<Project> {
 }
 
 async fn check_image_content(conn: &mut DbConnection, document_key: i64) -> Result<()> {
-    #[expect(deprecated)]
-    let doc = Document::retrieve_or_fail(conn, document_key, || ProjectError::ImageNotFound {
-        document_key,
+    let doc = Document::retrieve_real_or_fail(conn.clone(), document_key, || {
+        ProjectError::ImageNotFound { document_key }
     })
     .await?;
 
@@ -434,8 +433,7 @@ pub mod tests {
         let response: ProjectWithStudyCount =
             app.fetch(request).assert_status(StatusCode::OK).json_into();
 
-        #[expect(deprecated)]
-        let project = Project::retrieve(&mut pool.get_ok(), response.project.id)
+        let project = Project::retrieve_real(pool.get_ok(), response.project.id)
             .await
             .expect("Failed to retrieve project")
             .expect("Project not found");
@@ -533,8 +531,7 @@ pub mod tests {
         let response: ProjectWithStudyCount =
             app.fetch(request).assert_status(StatusCode::OK).json_into();
 
-        #[expect(deprecated)]
-        let project = Project::retrieve(&mut db_pool.get_ok(), response.project.id)
+        let project = Project::retrieve_real(db_pool.get_ok(), response.project.id)
             .await
             .expect("Failed to retrieve project")
             .expect("Project not found");
@@ -552,9 +549,8 @@ pub mod tests {
         // no image by default
         let project = create_project(&mut db_pool.get_ok(), &app.name("project")).await;
 
-        let check_image = |mut conn: DbConnection, image_id: Option<i64>| async move {
-            #[expect(deprecated)]
-            let p = Project::retrieve(&mut conn, project.id)
+        let check_image = |conn: DbConnection, image_id: Option<i64>| async move {
+            let p = Project::retrieve_real(conn, project.id)
                 .await
                 .expect("Failed to retrieve project")
                 .expect("Project not found");

--- a/editoast/src/views/project.rs
+++ b/editoast/src/views/project.rs
@@ -89,7 +89,7 @@ impl From<ProjectCreateForm> for Changeset<Project> {
 }
 
 async fn check_image_content(conn: &mut DbConnection, document_key: i64) -> Result<()> {
-    let doc = Document::retrieve_real_or_fail(conn.clone(), document_key, || {
+    let doc = Document::retrieve_or_fail(conn.clone(), document_key, || {
         ProjectError::ImageNotFound { document_key }
     })
     .await?;
@@ -240,8 +240,8 @@ pub(in crate::views) async fn get(
         return Err(AuthorizationError::Forbidden.into());
     }
     let mut conn = db_pool.get().await?;
-    let project = Project::retrieve_real_or_fail(conn.clone(), project_id, || {
-        ProjectError::NotFound { project_id }
+    let project = Project::retrieve_or_fail(conn.clone(), project_id, || ProjectError::NotFound {
+        project_id,
     })
     .await?;
     Ok(Json(
@@ -278,7 +278,7 @@ pub(in crate::views) async fn delete(
         .await?
         .transaction(|mut conn| {
             async move {
-                let project = Project::retrieve_real_or_fail(conn.clone(), project_id, || {
+                let project = Project::retrieve_or_fail(conn.clone(), project_id, || {
                     ProjectError::NotFound { project_id }
                 })
                 .await?;
@@ -433,7 +433,7 @@ pub mod tests {
         let response: ProjectWithStudyCount =
             app.fetch(request).assert_status(StatusCode::OK).json_into();
 
-        let project = Project::retrieve_real(pool.get_ok(), response.project.id)
+        let project = Project::retrieve(pool.get_ok(), response.project.id)
             .await
             .expect("Failed to retrieve project")
             .expect("Project not found");
@@ -531,7 +531,7 @@ pub mod tests {
         let response: ProjectWithStudyCount =
             app.fetch(request).assert_status(StatusCode::OK).json_into();
 
-        let project = Project::retrieve_real(db_pool.get_ok(), response.project.id)
+        let project = Project::retrieve(db_pool.get_ok(), response.project.id)
             .await
             .expect("Failed to retrieve project")
             .expect("Project not found");
@@ -550,7 +550,7 @@ pub mod tests {
         let project = create_project(&mut db_pool.get_ok(), &app.name("project")).await;
 
         let check_image = |conn: DbConnection, image_id: Option<i64>| async move {
-            let p = Project::retrieve_real(conn, project.id)
+            let p = Project::retrieve(conn, project.id)
                 .await
                 .expect("Failed to retrieve project")
                 .expect("Project not found");

--- a/editoast/src/views/rolling_stock.rs
+++ b/editoast/src/views/rolling_stock.rs
@@ -350,7 +350,7 @@ pub(in crate::views) async fn update(
         .transaction::<_, InternalError, _>(|conn| {
             async move {
                 let previous_rolling_stock =
-                    RollingStock::retrieve_real_or_fail(conn.clone(), rolling_stock_id, || {
+                    RollingStock::retrieve_or_fail(conn.clone(), rolling_stock_id, || {
                         RollingStockError::KeyNotFound {
                             rolling_stock_key: RollingStockKey::Id(rolling_stock_id),
                         }
@@ -422,7 +422,7 @@ pub(in crate::views) async fn delete(
     }
     let conn = &mut db_pool.get().await?;
 
-    let rolling_stock = RollingStock::retrieve_real_or_fail(conn.clone(), rolling_stock_id, || {
+    let rolling_stock = RollingStock::retrieve_or_fail(conn.clone(), rolling_stock_id, || {
         RollingStockError::KeyNotFound {
             rolling_stock_key: RollingStockKey::Id(rolling_stock_id),
         }
@@ -635,7 +635,7 @@ pub(in crate::views) async fn get_usage(
 ) -> Result<Json<Vec<ScenarioReference>>> {
     let mut conn = db_pool.get().await?;
 
-    let rolling_stock = RollingStock::retrieve_real_or_fail(conn.clone(), rolling_stock_id, || {
+    let rolling_stock = RollingStock::retrieve_or_fail(conn.clone(), rolling_stock_id, || {
         RollingStockError::KeyNotFound {
             rolling_stock_key: RollingStockKey::Id(rolling_stock_id),
         }
@@ -654,16 +654,14 @@ pub async fn retrieve_existing_rolling_stock(
 ) -> Result<RollingStock, RollingStockError> {
     match rolling_stock_key.clone() {
         RollingStockKey::Id(id) => {
-            RollingStock::retrieve_real_or_fail(conn.clone(), id, || {
-                RollingStockError::KeyNotFound {
-                    rolling_stock_key: rolling_stock_key.clone(),
-                }
+            RollingStock::retrieve_or_fail(conn.clone(), id, || RollingStockError::KeyNotFound {
+                rolling_stock_key: rolling_stock_key.clone(),
             })
             .await
         }
         RollingStockKey::Name(name) => {
-            RollingStock::retrieve_real_or_fail(conn.clone(), name, || {
-                RollingStockError::KeyNotFound { rolling_stock_key }
+            RollingStock::retrieve_or_fail(conn.clone(), name, || RollingStockError::KeyNotFound {
+                rolling_stock_key,
             })
             .await
         }
@@ -823,7 +821,7 @@ pub mod tests {
         // THEN
         let response: RollingStock = raw_response.assert_status(StatusCode::OK).json_into();
         // Check if the rolling stock was created in the database
-        let rolling_stock = RollingStock::retrieve_real(db_pool.get_ok(), response.id)
+        let rolling_stock = RollingStock::retrieve(db_pool.get_ok(), response.id)
             .await
             .expect("Failed to retrieve rolling stock")
             .expect("Rolling stock not found");
@@ -854,7 +852,7 @@ pub mod tests {
         // THEN
         let response: RollingStock = raw_response.assert_status(StatusCode::OK).json_into();
         // Check if the rolling stock was created in the database with locked = true
-        let rolling_stock = RollingStock::retrieve_real(db_pool.get_ok(), response.id)
+        let rolling_stock = RollingStock::retrieve(db_pool.get_ok(), response.id)
             .await
             .expect("Failed to retrieve rolling stock")
             .expect("Rolling stock not found");
@@ -1133,7 +1131,7 @@ pub mod tests {
         raw_response.assert_status(StatusCode::OK);
 
         let updated_rolling_stock: RollingStock =
-            RollingStock::retrieve_real(db_pool.get_ok(), fast_rolling_stock.id)
+            RollingStock::retrieve(db_pool.get_ok(), fast_rolling_stock.id)
                 .await
                 .expect("Failed to retrieve rolling stock")
                 .expect("Rolling stock not found");
@@ -1184,7 +1182,7 @@ pub mod tests {
         raw_response.assert_status(StatusCode::OK);
 
         let updated_rolling_stock: RollingStock =
-            RollingStock::retrieve_real(db_pool.get_ok(), fast_rolling_stock.id)
+            RollingStock::retrieve(db_pool.get_ok(), fast_rolling_stock.id)
                 .await
                 .expect("Failed to retrieve rolling stock")
                 .expect("Rolling stock not found");
@@ -1232,7 +1230,7 @@ pub mod tests {
         );
 
         let updated_rolling_stock: RollingStock =
-            RollingStock::retrieve_real(db_pool.get_ok(), fast_rolling_stock.id)
+            RollingStock::retrieve(db_pool.get_ok(), fast_rolling_stock.id)
                 .await
                 .expect("Failed to retrieve rolling stock")
                 .expect("Rolling stock not found");
@@ -1336,7 +1334,7 @@ pub mod tests {
         app.fetch(request).assert_status(StatusCode::NO_CONTENT);
 
         let fast_rolling_stock: RollingStock =
-            RollingStock::retrieve_real(db_pool.get_ok(), fast_rolling_stock.id)
+            RollingStock::retrieve(db_pool.get_ok(), fast_rolling_stock.id)
                 .await
                 .expect("Failed to retrieve rolling stock")
                 .expect("Rolling stock not found");
@@ -1366,7 +1364,7 @@ pub mod tests {
         app.fetch(request).assert_status(StatusCode::NO_CONTENT);
 
         let fast_rolling_stock: RollingStock =
-            RollingStock::retrieve_real(db_pool.get_ok(), locked_fast_rolling_stock.id)
+            RollingStock::retrieve(db_pool.get_ok(), locked_fast_rolling_stock.id)
                 .await
                 .expect("Failed to retrieve rolling stock")
                 .expect("Rolling stock not found");

--- a/editoast/src/views/rolling_stock.rs
+++ b/editoast/src/views/rolling_stock.rs
@@ -349,9 +349,8 @@ pub(in crate::views) async fn update(
         .await?
         .transaction::<_, InternalError, _>(|conn| {
             async move {
-                #[expect(deprecated)]
                 let previous_rolling_stock =
-                    RollingStock::retrieve_or_fail(&mut conn.clone(), rolling_stock_id, || {
+                    RollingStock::retrieve_real_or_fail(conn.clone(), rolling_stock_id, || {
                         RollingStockError::KeyNotFound {
                             rolling_stock_key: RollingStockKey::Id(rolling_stock_id),
                         }
@@ -423,12 +422,12 @@ pub(in crate::views) async fn delete(
     }
     let conn = &mut db_pool.get().await?;
 
-    #[expect(deprecated)]
-    let rolling_stock =
-        RollingStock::retrieve_or_fail(conn, rolling_stock_id, || RollingStockError::KeyNotFound {
+    let rolling_stock = RollingStock::retrieve_real_or_fail(conn.clone(), rolling_stock_id, || {
+        RollingStockError::KeyNotFound {
             rolling_stock_key: RollingStockKey::Id(rolling_stock_id),
-        })
-        .await?;
+        }
+    })
+    .await?;
     assert_rolling_stock_unlocked(&rolling_stock)?;
 
     if force {
@@ -636,8 +635,7 @@ pub(in crate::views) async fn get_usage(
 ) -> Result<Json<Vec<ScenarioReference>>> {
     let mut conn = db_pool.get().await?;
 
-    #[expect(deprecated)]
-    let rolling_stock = RollingStock::retrieve_or_fail(&mut conn, rolling_stock_id, || {
+    let rolling_stock = RollingStock::retrieve_real_or_fail(conn.clone(), rolling_stock_id, || {
         RollingStockError::KeyNotFound {
             rolling_stock_key: RollingStockKey::Id(rolling_stock_id),
         }
@@ -653,21 +651,19 @@ pub(in crate::views) async fn get_usage(
 pub async fn retrieve_existing_rolling_stock(
     conn: &mut DbConnection,
     rolling_stock_key: RollingStockKey,
-) -> Result<RollingStock> {
+) -> Result<RollingStock, RollingStockError> {
     match rolling_stock_key.clone() {
-        RollingStockKey::Id(id) =>
-        {
-            #[expect(deprecated)]
-            RollingStock::retrieve_or_fail(conn, id, || RollingStockError::KeyNotFound {
-                rolling_stock_key: rolling_stock_key.clone(),
+        RollingStockKey::Id(id) => {
+            RollingStock::retrieve_real_or_fail(conn.clone(), id, || {
+                RollingStockError::KeyNotFound {
+                    rolling_stock_key: rolling_stock_key.clone(),
+                }
             })
             .await
         }
-        RollingStockKey::Name(name) =>
-        {
-            #[expect(deprecated)]
-            RollingStock::retrieve_or_fail(conn, name, || RollingStockError::KeyNotFound {
-                rolling_stock_key,
+        RollingStockKey::Name(name) => {
+            RollingStock::retrieve_real_or_fail(conn.clone(), name, || {
+                RollingStockError::KeyNotFound { rolling_stock_key }
             })
             .await
         }
@@ -827,8 +823,7 @@ pub mod tests {
         // THEN
         let response: RollingStock = raw_response.assert_status(StatusCode::OK).json_into();
         // Check if the rolling stock was created in the database
-        #[expect(deprecated)]
-        let rolling_stock = RollingStock::retrieve(&mut db_pool.get_ok(), response.id)
+        let rolling_stock = RollingStock::retrieve_real(db_pool.get_ok(), response.id)
             .await
             .expect("Failed to retrieve rolling stock")
             .expect("Rolling stock not found");
@@ -859,8 +854,7 @@ pub mod tests {
         // THEN
         let response: RollingStock = raw_response.assert_status(StatusCode::OK).json_into();
         // Check if the rolling stock was created in the database with locked = true
-        #[expect(deprecated)]
-        let rolling_stock = RollingStock::retrieve(&mut db_pool.get_ok(), response.id)
+        let rolling_stock = RollingStock::retrieve_real(db_pool.get_ok(), response.id)
             .await
             .expect("Failed to retrieve rolling stock")
             .expect("Rolling stock not found");
@@ -1138,9 +1132,8 @@ pub mod tests {
         // THEN
         raw_response.assert_status(StatusCode::OK);
 
-        #[expect(deprecated)]
         let updated_rolling_stock: RollingStock =
-            RollingStock::retrieve(&mut db_pool.get_ok(), fast_rolling_stock.id)
+            RollingStock::retrieve_real(db_pool.get_ok(), fast_rolling_stock.id)
                 .await
                 .expect("Failed to retrieve rolling stock")
                 .expect("Rolling stock not found");
@@ -1190,9 +1183,8 @@ pub mod tests {
         // THEN
         raw_response.assert_status(StatusCode::OK);
 
-        #[expect(deprecated)]
         let updated_rolling_stock: RollingStock =
-            RollingStock::retrieve(&mut db_pool.get_ok(), fast_rolling_stock.id)
+            RollingStock::retrieve_real(db_pool.get_ok(), fast_rolling_stock.id)
                 .await
                 .expect("Failed to retrieve rolling stock")
                 .expect("Rolling stock not found");
@@ -1239,9 +1231,8 @@ pub mod tests {
             "The primary_category cannot be listed in other_categories for rolling stocks."
         );
 
-        #[expect(deprecated)]
         let updated_rolling_stock: RollingStock =
-            RollingStock::retrieve(&mut db_pool.get_ok(), fast_rolling_stock.id)
+            RollingStock::retrieve_real(db_pool.get_ok(), fast_rolling_stock.id)
                 .await
                 .expect("Failed to retrieve rolling stock")
                 .expect("Rolling stock not found");
@@ -1344,9 +1335,8 @@ pub mod tests {
 
         app.fetch(request).assert_status(StatusCode::NO_CONTENT);
 
-        #[expect(deprecated)]
         let fast_rolling_stock: RollingStock =
-            RollingStock::retrieve(&mut db_pool.get_ok(), fast_rolling_stock.id)
+            RollingStock::retrieve_real(db_pool.get_ok(), fast_rolling_stock.id)
                 .await
                 .expect("Failed to retrieve rolling stock")
                 .expect("Rolling stock not found");
@@ -1375,9 +1365,8 @@ pub mod tests {
 
         app.fetch(request).assert_status(StatusCode::NO_CONTENT);
 
-        #[expect(deprecated)]
         let fast_rolling_stock: RollingStock =
-            RollingStock::retrieve(&mut db_pool.get_ok(), locked_fast_rolling_stock.id)
+            RollingStock::retrieve_real(db_pool.get_ok(), locked_fast_rolling_stock.id)
                 .await
                 .expect("Failed to retrieve rolling stock")
                 .expect("Rolling stock not found");

--- a/editoast/src/views/rolling_stock/light.rs
+++ b/editoast/src/views/rolling_stock/light.rs
@@ -150,9 +150,8 @@ pub(in crate::views) async fn get(
     if !authorized {
         return Err(AuthorizationError::Forbidden.into());
     }
-    #[expect(deprecated)]
     let rolling_stock =
-        RollingStock::retrieve_or_fail(&mut db_pool.get().await?, light_rolling_stock_id, || {
+        RollingStock::retrieve_real_or_fail(db_pool.get().await?, light_rolling_stock_id, || {
             RollingStockError::KeyNotFound {
                 rolling_stock_key: RollingStockKey::Id(light_rolling_stock_id),
             }
@@ -185,9 +184,8 @@ pub(in crate::views) async fn get_by_name(
     if !authorized {
         return Err(AuthorizationError::Forbidden.into());
     }
-    #[expect(deprecated)]
-    let rolling_stock = RollingStock::retrieve_or_fail(
-        &mut db_pool.get().await?,
+    let rolling_stock = RollingStock::retrieve_real_or_fail(
+        db_pool.get().await?,
         light_rolling_stock_name.clone(),
         || RollingStockError::KeyNotFound {
             rolling_stock_key: RollingStockKey::Name(light_rolling_stock_name),

--- a/editoast/src/views/rolling_stock/light.rs
+++ b/editoast/src/views/rolling_stock/light.rs
@@ -151,7 +151,7 @@ pub(in crate::views) async fn get(
         return Err(AuthorizationError::Forbidden.into());
     }
     let rolling_stock =
-        RollingStock::retrieve_real_or_fail(db_pool.get().await?, light_rolling_stock_id, || {
+        RollingStock::retrieve_or_fail(db_pool.get().await?, light_rolling_stock_id, || {
             RollingStockError::KeyNotFound {
                 rolling_stock_key: RollingStockKey::Id(light_rolling_stock_id),
             }
@@ -184,7 +184,7 @@ pub(in crate::views) async fn get_by_name(
     if !authorized {
         return Err(AuthorizationError::Forbidden.into());
     }
-    let rolling_stock = RollingStock::retrieve_real_or_fail(
+    let rolling_stock = RollingStock::retrieve_or_fail(
         db_pool.get().await?,
         light_rolling_stock_name.clone(),
         || RollingStockError::KeyNotFound {

--- a/editoast/src/views/rolling_stock/towed.rs
+++ b/editoast/src/views/rolling_stock/towed.rs
@@ -191,14 +191,13 @@ pub(in crate::views) async fn get_by_id(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    let towed_rolling_stock = TowedRollingStock::retrieve_real_or_fail(
-        db_pool.get().await?,
-        towed_rolling_stock_id,
-        || TowedRollingStockError::IdNotFound {
-            towed_rolling_stock_id,
-        },
-    )
-    .await?;
+    let towed_rolling_stock =
+        TowedRollingStock::retrieve_or_fail(db_pool.get().await?, towed_rolling_stock_id, || {
+            TowedRollingStockError::IdNotFound {
+                towed_rolling_stock_id,
+            }
+        })
+        .await?;
     Ok(Json(towed_rolling_stock))
 }
 
@@ -233,7 +232,7 @@ pub(in crate::views) async fn patch_by_id(
         .await?
         .transaction::<_, InternalError, _>(|conn| {
             async move {
-                let existing_rolling_stock = TowedRollingStock::retrieve_real_or_fail(
+                let existing_rolling_stock = TowedRollingStock::retrieve_or_fail(
                     conn.clone(),
                     towed_rolling_stock_id,
                     || TowedRollingStockError::IdNotFound {

--- a/editoast/src/views/rolling_stock/towed.rs
+++ b/editoast/src/views/rolling_stock/towed.rs
@@ -191,9 +191,8 @@ pub(in crate::views) async fn get_by_id(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    #[expect(deprecated)]
-    let towed_rolling_stock = TowedRollingStock::retrieve_or_fail(
-        &mut db_pool.get().await?,
+    let towed_rolling_stock = TowedRollingStock::retrieve_real_or_fail(
+        db_pool.get().await?,
         towed_rolling_stock_id,
         || TowedRollingStockError::IdNotFound {
             towed_rolling_stock_id,
@@ -234,9 +233,8 @@ pub(in crate::views) async fn patch_by_id(
         .await?
         .transaction::<_, InternalError, _>(|conn| {
             async move {
-                #[expect(deprecated)]
-                let existing_rolling_stock = TowedRollingStock::retrieve_or_fail(
-                    &mut conn.clone(),
+                let existing_rolling_stock = TowedRollingStock::retrieve_real_or_fail(
+                    conn.clone(),
                     towed_rolling_stock_id,
                     || TowedRollingStockError::IdNotFound {
                         towed_rolling_stock_id,

--- a/editoast/src/views/scenario.rs
+++ b/editoast/src/views/scenario.rs
@@ -248,8 +248,7 @@ pub(in crate::views) async fn delete(
                     return Err(ProjectError::NotFound { project_id }.into());
                 }
 
-                #[expect(deprecated)]
-                let scenario = Scenario::retrieve_or_fail(&mut conn, scenario_id, || {
+                let scenario = Scenario::retrieve_real_or_fail(conn.clone(), scenario_id, || {
                     ScenarioError::NotFound { scenario_id }
                 })
                 .await?;
@@ -391,22 +390,19 @@ pub(in crate::views) async fn get(
         .await?
         .transaction(|mut conn| {
             async move {
-                #[expect(deprecated)]
-                let project = Project::retrieve_or_fail(&mut conn, project_id, || {
+                let project = Project::retrieve_real_or_fail(conn.clone(), project_id, || {
                     ProjectError::NotFound { project_id }
                 })
                 .await?;
-                #[expect(deprecated)]
-                let study = Study::retrieve_or_fail(&mut conn, study_id, || StudyError::NotFound {
-                    study_id,
+                let study = Study::retrieve_real_or_fail(conn.clone(), study_id, || {
+                    StudyError::NotFound { study_id }
                 })
                 .await?;
                 if study.project_id != project.id {
                     return Err(ProjectError::NotFound { project_id }.into());
                 }
 
-                #[expect(deprecated)]
-                let scenario = Scenario::retrieve_or_fail(&mut conn, scenario_id, || {
+                let scenario = Scenario::retrieve_real_or_fail(conn.clone(), scenario_id, || {
                     ScenarioError::NotFound { scenario_id }
                 })
                 .await?;
@@ -463,9 +459,9 @@ pub(in crate::views) async fn list(
 
     let conn = &mut db_pool.get().await?;
 
-    #[expect(deprecated)]
     let study =
-        Study::retrieve_or_fail(conn, study_id, || StudyError::NotFound { study_id }).await?;
+        Study::retrieve_real_or_fail(conn.clone(), study_id, || StudyError::NotFound { study_id })
+            .await?;
     if study.project_id != project_id {
         return Err(ProjectError::NotFound { project_id }.into());
     }
@@ -605,8 +601,7 @@ mod tests {
         assert_eq!(response.scenario.timetable_id, study_timetable_id);
         assert_eq!(response.scenario.tags, study_tags);
 
-        #[expect(deprecated)]
-        let created_scenario = Scenario::retrieve(&mut pool.get_ok(), response.scenario.id)
+        let created_scenario = Scenario::retrieve_real(pool.get_ok(), response.scenario.id)
             .await
             .expect("Failed to retrieve scenario")
             .expect("Scenario not found");

--- a/editoast/src/views/scenario.rs
+++ b/editoast/src/views/scenario.rs
@@ -248,7 +248,7 @@ pub(in crate::views) async fn delete(
                     return Err(ProjectError::NotFound { project_id }.into());
                 }
 
-                let scenario = Scenario::retrieve_real_or_fail(conn.clone(), scenario_id, || {
+                let scenario = Scenario::retrieve_or_fail(conn.clone(), scenario_id, || {
                     ScenarioError::NotFound { scenario_id }
                 })
                 .await?;
@@ -390,11 +390,11 @@ pub(in crate::views) async fn get(
         .await?
         .transaction(|mut conn| {
             async move {
-                let project = Project::retrieve_real_or_fail(conn.clone(), project_id, || {
+                let project = Project::retrieve_or_fail(conn.clone(), project_id, || {
                     ProjectError::NotFound { project_id }
                 })
                 .await?;
-                let study = Study::retrieve_real_or_fail(conn.clone(), study_id, || {
+                let study = Study::retrieve_or_fail(conn.clone(), study_id, || {
                     StudyError::NotFound { study_id }
                 })
                 .await?;
@@ -402,7 +402,7 @@ pub(in crate::views) async fn get(
                     return Err(ProjectError::NotFound { project_id }.into());
                 }
 
-                let scenario = Scenario::retrieve_real_or_fail(conn.clone(), scenario_id, || {
+                let scenario = Scenario::retrieve_or_fail(conn.clone(), scenario_id, || {
                     ScenarioError::NotFound { scenario_id }
                 })
                 .await?;
@@ -460,7 +460,7 @@ pub(in crate::views) async fn list(
     let conn = &mut db_pool.get().await?;
 
     let study =
-        Study::retrieve_real_or_fail(conn.clone(), study_id, || StudyError::NotFound { study_id })
+        Study::retrieve_or_fail(conn.clone(), study_id, || StudyError::NotFound { study_id })
             .await?;
     if study.project_id != project_id {
         return Err(ProjectError::NotFound { project_id }.into());
@@ -601,7 +601,7 @@ mod tests {
         assert_eq!(response.scenario.timetable_id, study_timetable_id);
         assert_eq!(response.scenario.tags, study_tags);
 
-        let created_scenario = Scenario::retrieve_real(pool.get_ok(), response.scenario.id)
+        let created_scenario = Scenario::retrieve(pool.get_ok(), response.scenario.id)
             .await
             .expect("Failed to retrieve scenario")
             .expect("Scenario not found");

--- a/editoast/src/views/scenario/macro_nodes.rs
+++ b/editoast/src/views/scenario/macro_nodes.rs
@@ -160,16 +160,16 @@ pub(in crate::views) async fn list(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    let conn = &mut db_pool.get().await?;
+    let mut conn = db_pool.get().await?;
 
     // Check for project / study / scenario
-    check_project_study_scenario(conn, project_id, study_id, scenario_id).await?;
+    check_project_study_scenario(conn.clone(), project_id, study_id, scenario_id).await?;
 
     // Ask the db
     let settings = pagination_params
         .into_selection_settings()
         .filter(move || MacroNode::SCENARIO_ID.eq(scenario_id));
-    let (result, stats) = MacroNode::list_paginated(conn, settings).await?;
+    let (result, stats) = MacroNode::list_paginated(&mut conn, settings).await?;
 
     // Produce the response
     Ok(Json(MacroNodeListResponse {
@@ -266,8 +266,8 @@ pub(in crate::views) async fn get(
     }
 
     // Check for project / study / scenario
-    let conn = &mut db_pool.get().await?;
-    check_project_study_scenario(conn, project_id, study_id, scenario_id).await?;
+    let conn = db_pool.get().await?;
+    check_project_study_scenario(conn.clone(), project_id, study_id, scenario_id).await?;
 
     // Get / check the node
     let macro_node = retrieve_macro_node_and_check_scenario(conn, scenario_id, node_id).await?;
@@ -305,8 +305,7 @@ pub(in crate::views) async fn update(
         scenario_id,
         move |mut conn, scenario, study, project| {
             async move {
-                #[expect(deprecated)]
-                let node = MacroNode::retrieve_or_fail(&mut conn, node_id, || {
+                let node = MacroNode::retrieve_real_or_fail(conn.clone(), node_id, || {
                     MacroNodeError::NotFound { node_id }
                 })
                 .await?;
@@ -367,8 +366,7 @@ pub(in crate::views) async fn delete(
         scenario_id,
         move |mut conn, scenario, study, project| {
             async move {
-                #[expect(deprecated)]
-                let node = MacroNode::retrieve_or_fail(&mut conn, node_id, || {
+                let node = MacroNode::retrieve_real_or_fail(conn.clone(), node_id, || {
                     MacroNodeError::NotFound { node_id }
                 })
                 .await?;
@@ -398,25 +396,24 @@ pub(in crate::views) async fn delete(
 }
 
 async fn check_project_study_scenario(
-    conn: &mut DbConnection,
+    conn: DbConnection,
     project_id: i64,
     study_id: i64,
     scenario_id: i64,
 ) -> Result<(Project, Study, Scenario)> {
-    #[expect(deprecated)]
-    let project =
-        Project::retrieve_or_fail(conn, project_id, || ProjectError::NotFound { project_id })
-            .await?;
-    #[expect(deprecated)]
+    let project = Project::retrieve_real_or_fail(conn.clone(), project_id, || {
+        ProjectError::NotFound { project_id }
+    })
+    .await?;
     let study =
-        Study::retrieve_or_fail(conn, study_id, || StudyError::NotFound { study_id }).await?;
+        Study::retrieve_real_or_fail(conn.clone(), study_id, || StudyError::NotFound { study_id })
+            .await?;
 
     if study.project_id != project_id {
         return Err(StudyError::NotFound { study_id }.into());
     }
 
-    #[expect(deprecated)]
-    let scenario = Scenario::retrieve_or_fail(conn, scenario_id, || ScenarioError::NotFound {
+    let scenario = Scenario::retrieve_real_or_fail(conn, scenario_id, || ScenarioError::NotFound {
         scenario_id,
     })
     .await?;
@@ -428,15 +425,13 @@ async fn check_project_study_scenario(
 }
 
 async fn retrieve_macro_node_and_check_scenario(
-    conn: &mut DbConnection,
+    conn: DbConnection,
     scenario_id: i64,
     node_id: i64,
 ) -> Result<MacroNode> {
-    #[expect(deprecated)]
-    let node = MacroNode::retrieve_or_fail(&mut conn.clone(), node_id, || {
-        MacroNodeError::NotFound { node_id }
-    })
-    .await?;
+    let node =
+        MacroNode::retrieve_real_or_fail(conn, node_id, || MacroNodeError::NotFound { node_id })
+            .await?;
     if node.scenario_id != scenario_id {
         return Err(MacroNodeError::NotFound { node_id }.into());
     }
@@ -510,14 +505,9 @@ pub mod test {
         let response: MacroNodeBatchResponse =
             app.fetch(request).assert_status(StatusCode::OK).json_into();
 
-        #[expect(deprecated)]
-        let node =
-            MacroNode::retrieve_or_fail(&mut db_pool.get_ok(), response.macro_nodes[0].id, || {
-                MacroNodeError::NotFound {
-                    node_id: response.macro_nodes[0].id,
-                }
-            })
+        let node = MacroNode::retrieve_real(db_pool.get_ok(), response.macro_nodes[0].id)
             .await
+            .unwrap()
             .expect("Failed to retrieve node");
 
         assert_eq!(nodes_data, response.macro_nodes);
@@ -548,14 +538,10 @@ pub mod test {
         let response: MacroNodeResponse =
             app.fetch(request).assert_status(StatusCode::OK).json_into();
 
-        #[expect(deprecated)]
-        let node = MacroNode::retrieve_or_fail(&mut db_pool.get_ok(), fixtures.nodes[0].id, || {
-            MacroNodeError::NotFound {
-                node_id: response.id,
-            }
-        })
-        .await
-        .expect("Failed to retrieve node");
+        let node = MacroNode::retrieve_real(db_pool.get_ok(), fixtures.nodes[0].id)
+            .await
+            .unwrap()
+            .expect("Failed to retrieve node");
 
         assert_eq!(node_data, response);
         assert_eq!(node, response);
@@ -619,7 +605,7 @@ pub mod test {
         let fixtures = create_macro_node_fixtures_set(&mut db_pool.get_ok(), 1).await;
 
         let result = retrieve_macro_node_and_check_scenario(
-            &mut db_pool.get_ok(),
+            db_pool.get_ok(),
             fixtures.scenario.id + 1,
             fixtures.nodes[0].id,
         )

--- a/editoast/src/views/scenario/macro_nodes.rs
+++ b/editoast/src/views/scenario/macro_nodes.rs
@@ -305,7 +305,7 @@ pub(in crate::views) async fn update(
         scenario_id,
         move |mut conn, scenario, study, project| {
             async move {
-                let node = MacroNode::retrieve_real_or_fail(conn.clone(), node_id, || {
+                let node = MacroNode::retrieve_or_fail(conn.clone(), node_id, || {
                     MacroNodeError::NotFound { node_id }
                 })
                 .await?;
@@ -366,7 +366,7 @@ pub(in crate::views) async fn delete(
         scenario_id,
         move |mut conn, scenario, study, project| {
             async move {
-                let node = MacroNode::retrieve_real_or_fail(conn.clone(), node_id, || {
+                let node = MacroNode::retrieve_or_fail(conn.clone(), node_id, || {
                     MacroNodeError::NotFound { node_id }
                 })
                 .await?;
@@ -401,19 +401,19 @@ async fn check_project_study_scenario(
     study_id: i64,
     scenario_id: i64,
 ) -> Result<(Project, Study, Scenario)> {
-    let project = Project::retrieve_real_or_fail(conn.clone(), project_id, || {
-        ProjectError::NotFound { project_id }
+    let project = Project::retrieve_or_fail(conn.clone(), project_id, || ProjectError::NotFound {
+        project_id,
     })
     .await?;
     let study =
-        Study::retrieve_real_or_fail(conn.clone(), study_id, || StudyError::NotFound { study_id })
+        Study::retrieve_or_fail(conn.clone(), study_id, || StudyError::NotFound { study_id })
             .await?;
 
     if study.project_id != project_id {
         return Err(StudyError::NotFound { study_id }.into());
     }
 
-    let scenario = Scenario::retrieve_real_or_fail(conn, scenario_id, || ScenarioError::NotFound {
+    let scenario = Scenario::retrieve_or_fail(conn, scenario_id, || ScenarioError::NotFound {
         scenario_id,
     })
     .await?;
@@ -430,8 +430,7 @@ async fn retrieve_macro_node_and_check_scenario(
     node_id: i64,
 ) -> Result<MacroNode> {
     let node =
-        MacroNode::retrieve_real_or_fail(conn, node_id, || MacroNodeError::NotFound { node_id })
-            .await?;
+        MacroNode::retrieve_or_fail(conn, node_id, || MacroNodeError::NotFound { node_id }).await?;
     if node.scenario_id != scenario_id {
         return Err(MacroNodeError::NotFound { node_id }.into());
     }
@@ -505,7 +504,7 @@ pub mod test {
         let response: MacroNodeBatchResponse =
             app.fetch(request).assert_status(StatusCode::OK).json_into();
 
-        let node = MacroNode::retrieve_real(db_pool.get_ok(), response.macro_nodes[0].id)
+        let node = MacroNode::retrieve(db_pool.get_ok(), response.macro_nodes[0].id)
             .await
             .unwrap()
             .expect("Failed to retrieve node");
@@ -538,7 +537,7 @@ pub mod test {
         let response: MacroNodeResponse =
             app.fetch(request).assert_status(StatusCode::OK).json_into();
 
-        let node = MacroNode::retrieve_real(db_pool.get_ok(), fixtures.nodes[0].id)
+        let node = MacroNode::retrieve(db_pool.get_ok(), fixtures.nodes[0].id)
             .await
             .unwrap()
             .expect("Failed to retrieve node");

--- a/editoast/src/views/stdcm_logs.rs
+++ b/editoast/src/views/stdcm_logs.rs
@@ -128,19 +128,18 @@ pub(in crate::views) async fn stdcm_log_by_id_or_trace_id(
     let conn = db_pool.get().await?;
 
     if id.is_some() {
-        let stdcm_log = StdcmLog::retrieve_real_or_fail(conn, id.unwrap(), || {
-            StdcmLogError::NotFound { id: id.unwrap() }
+        let stdcm_log = StdcmLog::retrieve_or_fail(conn, id.unwrap(), || StdcmLogError::NotFound {
+            id: id.unwrap(),
         })
         .await?;
         Ok(Json(stdcm_log))
     } else if trace_id.is_some() {
-        let stdcm_log =
-            StdcmLog::retrieve_real_or_fail(conn, Some(trace_id.clone().unwrap()), || {
-                StdcmLogError::TraceIdNotFound {
-                    trace_id: trace_id.unwrap(),
-                }
-            })
-            .await?;
+        let stdcm_log = StdcmLog::retrieve_or_fail(conn, Some(trace_id.clone().unwrap()), || {
+            StdcmLogError::TraceIdNotFound {
+                trace_id: trace_id.unwrap(),
+            }
+        })
+        .await?;
         Ok(Json(stdcm_log))
     } else {
         Err(StdcmLogError::MissingIdAndTraceId.into())

--- a/editoast/src/views/stdcm_logs.rs
+++ b/editoast/src/views/stdcm_logs.rs
@@ -35,6 +35,10 @@ enum StdcmLogError {
     #[error("STDCM log entry could not be found without specifying an 'id' or 'trace_id'")]
     #[editoast_error(status = 400)]
     MissingIdAndTraceId,
+
+    #[error(transparent)]
+    #[editoast_error(status = 500)]
+    Database(#[from] editoast_models::model::Error),
 }
 
 #[editoast_derive::openapi_schema]
@@ -121,23 +125,22 @@ pub(in crate::views) async fn stdcm_log_by_id_or_trace_id(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    let conn = &mut db_pool.get().await?;
+    let conn = db_pool.get().await?;
 
     if id.is_some() {
-        #[expect(deprecated)]
-        let stdcm_log = StdcmLog::retrieve_or_fail(conn, id.unwrap(), || StdcmLogError::NotFound {
-            id: id.unwrap(),
+        let stdcm_log = StdcmLog::retrieve_real_or_fail(conn, id.unwrap(), || {
+            StdcmLogError::NotFound { id: id.unwrap() }
         })
         .await?;
         Ok(Json(stdcm_log))
     } else if trace_id.is_some() {
-        #[expect(deprecated)]
-        let stdcm_log = StdcmLog::retrieve_or_fail(conn, Some(trace_id.clone().unwrap()), || {
-            StdcmLogError::TraceIdNotFound {
-                trace_id: trace_id.unwrap(),
-            }
-        })
-        .await?;
+        let stdcm_log =
+            StdcmLog::retrieve_real_or_fail(conn, Some(trace_id.clone().unwrap()), || {
+                StdcmLogError::TraceIdNotFound {
+                    trace_id: trace_id.unwrap(),
+                }
+            })
+            .await?;
         Ok(Json(stdcm_log))
     } else {
         Err(StdcmLogError::MissingIdAndTraceId.into())

--- a/editoast/src/views/stdcm_search_environment.rs
+++ b/editoast/src/views/stdcm_search_environment.rs
@@ -304,7 +304,7 @@ pub mod tests {
 
         // THEN
         let stdcm_search_env_in_db =
-            StdcmSearchEnvironment::retrieve_real(pool.get_ok(), stdcm_search_env.id)
+            StdcmSearchEnvironment::retrieve(pool.get_ok(), stdcm_search_env.id)
                 .await
                 .expect("Failed to retrieve stdcm search environment")
                 .expect("Stdcm search environment not found");

--- a/editoast/src/views/study.rs
+++ b/editoast/src/views/study.rs
@@ -230,11 +230,11 @@ pub(in crate::views) async fn get(
         .await?
         .transaction(|mut conn| {
             async move {
-                let project = Project::retrieve_real_or_fail(conn.clone(), project_id, || {
+                let project = Project::retrieve_or_fail(conn.clone(), project_id, || {
                     ProjectError::NotFound { project_id }
                 })
                 .await?;
-                let study = Study::retrieve_real_or_fail(conn.clone(), study_id, || {
+                let study = Study::retrieve_or_fail(conn.clone(), study_id, || {
                     StudyError::NotFound { study_id }
                 })
                 .await?;
@@ -460,7 +460,7 @@ pub mod tests {
             }));
         let response: StudyResponse = app.fetch(request).assert_status(StatusCode::OK).json_into();
 
-        let study = Study::retrieve_real(db_pool.get_ok(), response.study.id)
+        let study = Study::retrieve(db_pool.get_ok(), response.study.id)
             .await
             .expect("Failed to retrieve study")
             .expect("Study not found");
@@ -583,12 +583,12 @@ pub mod tests {
 
         app.fetch(request).assert_status(StatusCode::OK);
 
-        let updated_study = Study::retrieve_real(db_pool.get_ok(), created_study.id)
+        let updated_study = Study::retrieve(db_pool.get_ok(), created_study.id)
             .await
             .expect("Failed to retrieve study")
             .expect("Study not found");
 
-        let updated_project = Project::retrieve_real(db_pool.get_ok(), created_project.id)
+        let updated_project = Project::retrieve(db_pool.get_ok(), created_project.id)
             .await
             .expect("Failed to retrieve project")
             .expect("Project not found");

--- a/editoast/src/views/study.rs
+++ b/editoast/src/views/study.rs
@@ -230,14 +230,12 @@ pub(in crate::views) async fn get(
         .await?
         .transaction(|mut conn| {
             async move {
-                #[expect(deprecated)]
-                let project = Project::retrieve_or_fail(&mut conn, project_id, || {
+                let project = Project::retrieve_real_or_fail(conn.clone(), project_id, || {
                     ProjectError::NotFound { project_id }
                 })
                 .await?;
-                #[expect(deprecated)]
-                let study = Study::retrieve_or_fail(&mut conn, study_id, || StudyError::NotFound {
-                    study_id,
+                let study = Study::retrieve_real_or_fail(conn.clone(), study_id, || {
+                    StudyError::NotFound { study_id }
                 })
                 .await?;
 
@@ -462,8 +460,7 @@ pub mod tests {
             }));
         let response: StudyResponse = app.fetch(request).assert_status(StatusCode::OK).json_into();
 
-        #[expect(deprecated)]
-        let study = Study::retrieve(&mut db_pool.get_ok(), response.study.id)
+        let study = Study::retrieve_real(db_pool.get_ok(), response.study.id)
             .await
             .expect("Failed to retrieve study")
             .expect("Study not found");
@@ -586,14 +583,12 @@ pub mod tests {
 
         app.fetch(request).assert_status(StatusCode::OK);
 
-        #[expect(deprecated)]
-        let updated_study = Study::retrieve(&mut db_pool.get_ok(), created_study.id)
+        let updated_study = Study::retrieve_real(db_pool.get_ok(), created_study.id)
             .await
             .expect("Failed to retrieve study")
             .expect("Study not found");
 
-        #[expect(deprecated)]
-        let updated_project = Project::retrieve(&mut db_pool.get_ok(), created_project.id)
+        let updated_project = Project::retrieve_real(db_pool.get_ok(), created_project.id)
             .await
             .expect("Failed to retrieve project")
             .expect("Project not found");

--- a/editoast/src/views/sub_categories.rs
+++ b/editoast/src/views/sub_categories.rs
@@ -170,11 +170,10 @@ async fn delete_sub_category_and_fallback_to_main(
     conn: &mut DbConnection,
     code: String,
 ) -> Result<()> {
-    let sub_category =
-        models::SubCategory::retrieve_real_or_fail(conn.clone(), code.clone(), || {
-            SubCategoryError::NotFound { code: code.clone() }
-        })
-        .await?;
+    let sub_category = models::SubCategory::retrieve_or_fail(conn.clone(), code.clone(), || {
+        SubCategoryError::NotFound { code: code.clone() }
+    })
+    .await?;
 
     let sub_category_code = Some(sub_category.code.clone());
     let paced_trains_ids: Vec<i64> = models::PacedTrain::list(
@@ -259,26 +258,22 @@ pub mod tests {
             app.fetch(request).assert_status(StatusCode::OK).json_into();
         let created_sub_category1 = response.first().unwrap();
 
-        let sub_category_1 = models::SubCategory::retrieve_real(
-            db_pool.get_ok(),
-            created_sub_category1.code.clone(),
-        )
-        .await
-        .expect("Failed to retrieve sub category")
-        .expect("Sub category not found")
-        .into();
+        let sub_category_1 =
+            models::SubCategory::retrieve(db_pool.get_ok(), created_sub_category1.code.clone())
+                .await
+                .expect("Failed to retrieve sub category")
+                .expect("Sub category not found")
+                .into();
 
         assert_eq!(created_sub_category1, &sub_category_1);
 
         let created_sub_category2 = response.get(1).unwrap();
-        let sub_category_2 = models::SubCategory::retrieve_real(
-            db_pool.get_ok(),
-            created_sub_category2.code.clone(),
-        )
-        .await
-        .expect("Failed to retrieve sub category")
-        .expect("Sub category not found")
-        .into();
+        let sub_category_2 =
+            models::SubCategory::retrieve(db_pool.get_ok(), created_sub_category2.code.clone())
+                .await
+                .expect("Failed to retrieve sub category")
+                .expect("Sub category not found")
+                .into();
 
         assert_eq!(created_sub_category2, &sub_category_2);
     }
@@ -392,12 +387,12 @@ pub mod tests {
         ));
         app.fetch(request).assert_status(StatusCode::NO_CONTENT);
 
-        let paced_train_1 = models::PacedTrain::retrieve_real(db_pool.get_ok(), paced_train_1.id)
+        let paced_train_1 = models::PacedTrain::retrieve(db_pool.get_ok(), paced_train_1.id)
             .await
             .expect("Failed to retrieve paced train")
             .expect("Paced train 1 not found");
 
-        let paced_train_2 = models::PacedTrain::retrieve_real(db_pool.get_ok(), paced_train_2.id)
+        let paced_train_2 = models::PacedTrain::retrieve(db_pool.get_ok(), paced_train_2.id)
             .await
             .expect("Failed to retrieve paced train")
             .expect("Paced train 2 not found");
@@ -419,13 +414,13 @@ pub mod tests {
         );
 
         let train_schedule_1 =
-            models::TrainSchedule::retrieve_real(db_pool.get_ok(), train_schedule_1.id)
+            models::TrainSchedule::retrieve(db_pool.get_ok(), train_schedule_1.id)
                 .await
                 .expect("Failed to retrieve train schedule")
                 .expect("Train schedule 1 not found");
 
         let train_schedule_2 =
-            models::TrainSchedule::retrieve_real(db_pool.get_ok(), train_schedule_2.id)
+            models::TrainSchedule::retrieve(db_pool.get_ok(), train_schedule_2.id)
                 .await
                 .expect("Failed to retrieve train schedule")
                 .expect("Train schedule 2 not found");

--- a/editoast/src/views/temporary_speed_limits.rs
+++ b/editoast/src/views/temporary_speed_limits.rs
@@ -294,8 +294,7 @@ mod tests {
 
         let TemporarySpeedLimitCreateResponse { group_id } =
             app.fetch(request).assert_status(StatusCode::OK).json_into();
-        #[expect(deprecated)]
-        let created_group = TemporarySpeedLimitGroup::retrieve(&mut pool.get_ok(), group_id)
+        let created_group = TemporarySpeedLimitGroup::retrieve_real(pool.get_ok(), group_id)
             .await
             .expect("Failed to retrieve the created temporary speed limit group")
             .expect("No temporary speed limit group matches the group identifier of the endpoint response");

--- a/editoast/src/views/temporary_speed_limits.rs
+++ b/editoast/src/views/temporary_speed_limits.rs
@@ -294,7 +294,7 @@ mod tests {
 
         let TemporarySpeedLimitCreateResponse { group_id } =
             app.fetch(request).assert_status(StatusCode::OK).json_into();
-        let created_group = TemporarySpeedLimitGroup::retrieve_real(pool.get_ok(), group_id)
+        let created_group = TemporarySpeedLimitGroup::retrieve(pool.get_ok(), group_id)
             .await
             .expect("Failed to retrieve the created temporary speed limit group")
             .expect("No temporary speed limit group matches the group identifier of the endpoint response");

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -603,15 +603,15 @@ pub(in crate::views) async fn conflicts(
     let (trains, paced_trains) = retrieve_trains_and_paced_trains(conn, timetable_id).await?;
 
     // Flatten paced trains occurrences
-    let (occurance_ids, occurance_trains): (Vec<_>, Vec<_>) = paced_trains
+    let (occurrence_ids, occurrence_trains): (Vec<_>, Vec<_>) = paced_trains
         .iter()
         .flat_map(|pt| pt.iter_occurrences())
         .unzip();
-    let occurance_simulations: Vec<_> = train_simulation_batch(
+    let occurrence_simulations: Vec<_> = train_simulation_batch(
         &mut db_pool.get().await?,
         valkey_client.clone(),
         core_client.clone(),
-        &occurance_trains,
+        &occurrence_trains,
         &infra,
         electrical_profile_set_id,
     )
@@ -633,16 +633,16 @@ pub(in crate::views) async fn conflicts(
     .collect();
 
     // Concatenate paced trains occurrences with train schedules
-    let train_ids: Vec<_> = occurance_ids
+    let train_ids: Vec<_> = occurrence_ids
         .into_iter()
         .chain(trains.iter().map(|ts| TrainId::TrainSchedule(ts.id)))
         .collect();
-    let start_times = occurance_trains
+    let start_times = occurrence_trains
         .iter()
         .map(|ts| ts.start_time())
         .chain(trains.iter().map(|ts| ts.start_time()))
         .collect::<Vec<_>>();
-    let simulations: Vec<_> = occurance_simulations
+    let simulations: Vec<_> = occurrence_simulations
         .into_iter()
         .chain(simulations)
         .collect();

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -587,8 +587,8 @@ pub(in crate::views) async fn conflicts(
 
     let conn = db_pool.get().await?;
 
-    let infra = Infra::retrieve_real_or_fail(conn.clone(), infra_id, || {
-        TimetableError::InfraNotFound { infra_id }
+    let infra = Infra::retrieve_or_fail(conn.clone(), infra_id, || TimetableError::InfraNotFound {
+        infra_id,
     })
     .await?;
 
@@ -975,7 +975,7 @@ mod tests {
             app.fetch(request).assert_status(StatusCode::OK).json_into();
 
         let retrieved_timetable =
-            Timetable::retrieve_real(pool.get_ok(), created_timetable.timetable_id)
+            Timetable::retrieve(pool.get_ok(), created_timetable.timetable_id)
                 .await
                 .expect("Failed to retrieve timetable")
                 .expect("Timetable not found");

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -585,11 +585,10 @@ pub(in crate::views) async fn conflicts(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    let mut conn = db_pool.get().await?;
+    let conn = db_pool.get().await?;
 
-    #[expect(deprecated)]
-    let infra = Infra::retrieve_or_fail(&mut conn, infra_id, || TimetableError::InfraNotFound {
-        infra_id,
+    let infra = Infra::retrieve_real_or_fail(conn.clone(), infra_id, || {
+        TimetableError::InfraNotFound { infra_id }
     })
     .await?;
 
@@ -975,9 +974,8 @@ mod tests {
         let created_timetable: TimetableResult =
             app.fetch(request).assert_status(StatusCode::OK).json_into();
 
-        #[expect(deprecated)]
         let retrieved_timetable =
-            Timetable::retrieve(&mut pool.get_ok(), created_timetable.timetable_id)
+            Timetable::retrieve_real(pool.get_ok(), created_timetable.timetable_id)
                 .await
                 .expect("Failed to retrieve timetable")
                 .expect("Timetable not found");

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -123,11 +123,11 @@ pub(in crate::views) async fn get_by_id(
 
     let conn = &mut db_pool.get().await?;
 
-    #[expect(deprecated)]
-    let paced_train = models::PacedTrain::retrieve_or_fail(conn, paced_train_id, || {
-        PacedTrainError::NotFound { paced_train_id }
-    })
-    .await?;
+    let paced_train =
+        models::PacedTrain::retrieve_real_or_fail(conn.clone(), paced_train_id, || {
+            PacedTrainError::NotFound { paced_train_id }
+        })
+        .await?;
 
     let paced_train: PacedTrainResponse = paced_train.into();
 
@@ -270,9 +270,8 @@ pub(in crate::views) async fn simulation_summary(
 
     let conn = &mut db_pool.get().await?;
 
-    #[expect(deprecated)]
-    let infra = Infra::retrieve_or_fail(conn, infra_id, || PacedTrainError::InfraNotFound {
-        infra_id,
+    let infra = Infra::retrieve_real_or_fail(conn.clone(), infra_id, || {
+        PacedTrainError::InfraNotFound { infra_id }
     })
     .await?;
 
@@ -398,9 +397,8 @@ pub(in crate::views) async fn get_path(
     let conn = &mut db_pool.get().await?;
     let mut valkey_conn = valkey_client.get_connection().await?;
 
-    #[expect(deprecated)]
-    let infra = Infra::retrieve_or_fail(conn, infra_id, || PacedTrainError::InfraNotFound {
-        infra_id,
+    let infra = Infra::retrieve_real_or_fail(conn.clone(), infra_id, || {
+        PacedTrainError::InfraNotFound { infra_id }
     })
     .await?;
 
@@ -412,11 +410,11 @@ pub(in crate::views) async fn get_path(
     })
     .await?;
 
-    #[expect(deprecated)]
-    let paced_train = models::PacedTrain::retrieve_or_fail(conn, paced_train_id, || {
-        PacedTrainError::NotFound { paced_train_id }
-    })
-    .await?;
+    let paced_train =
+        models::PacedTrain::retrieve_real_or_fail(conn.clone(), paced_train_id, || {
+            PacedTrainError::NotFound { paced_train_id }
+        })
+        .await?;
 
     let train_schedule = match exception_key {
         Some(exception_key) => {
@@ -434,7 +432,14 @@ pub(in crate::views) async fn get_path(
     };
 
     Ok(Json(
-        pathfinding_from_train(conn, &mut valkey_conn, core_client, &infra, train_schedule).await?,
+        pathfinding_from_train(
+            db_pool.get().await?,
+            &mut valkey_conn,
+            core_client,
+            &infra,
+            train_schedule,
+        )
+        .await?,
     ))
 }
 
@@ -478,8 +483,7 @@ pub(in crate::views) async fn simulation(
     }
 
     // Retrieve infra or fail
-    #[expect(deprecated)]
-    let infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra_id, || {
+    let infra = Infra::retrieve_real_or_fail(db_pool.get().await?, infra_id, || {
         PacedTrainError::InfraNotFound { infra_id }
     })
     .await?;
@@ -493,9 +497,8 @@ pub(in crate::views) async fn simulation(
     .await?;
 
     // Retrieve paced_train or fail
-    #[expect(deprecated)]
     let paced_train =
-        models::PacedTrain::retrieve_or_fail(&mut db_pool.get().await?, paced_train_id, || {
+        models::PacedTrain::retrieve_real_or_fail(db_pool.get().await?, paced_train_id, || {
             PacedTrainError::NotFound { paced_train_id }
         })
         .await?;

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -123,11 +123,10 @@ pub(in crate::views) async fn get_by_id(
 
     let conn = &mut db_pool.get().await?;
 
-    let paced_train =
-        models::PacedTrain::retrieve_real_or_fail(conn.clone(), paced_train_id, || {
-            PacedTrainError::NotFound { paced_train_id }
-        })
-        .await?;
+    let paced_train = models::PacedTrain::retrieve_or_fail(conn.clone(), paced_train_id, || {
+        PacedTrainError::NotFound { paced_train_id }
+    })
+    .await?;
 
     let paced_train: PacedTrainResponse = paced_train.into();
 
@@ -270,7 +269,7 @@ pub(in crate::views) async fn simulation_summary(
 
     let conn = &mut db_pool.get().await?;
 
-    let infra = Infra::retrieve_real_or_fail(conn.clone(), infra_id, || {
+    let infra = Infra::retrieve_or_fail(conn.clone(), infra_id, || {
         PacedTrainError::InfraNotFound { infra_id }
     })
     .await?;
@@ -397,7 +396,7 @@ pub(in crate::views) async fn get_path(
     let conn = &mut db_pool.get().await?;
     let mut valkey_conn = valkey_client.get_connection().await?;
 
-    let infra = Infra::retrieve_real_or_fail(conn.clone(), infra_id, || {
+    let infra = Infra::retrieve_or_fail(conn.clone(), infra_id, || {
         PacedTrainError::InfraNotFound { infra_id }
     })
     .await?;
@@ -410,11 +409,10 @@ pub(in crate::views) async fn get_path(
     })
     .await?;
 
-    let paced_train =
-        models::PacedTrain::retrieve_real_or_fail(conn.clone(), paced_train_id, || {
-            PacedTrainError::NotFound { paced_train_id }
-        })
-        .await?;
+    let paced_train = models::PacedTrain::retrieve_or_fail(conn.clone(), paced_train_id, || {
+        PacedTrainError::NotFound { paced_train_id }
+    })
+    .await?;
 
     let train_schedule = match exception_key {
         Some(exception_key) => {
@@ -483,7 +481,7 @@ pub(in crate::views) async fn simulation(
     }
 
     // Retrieve infra or fail
-    let infra = Infra::retrieve_real_or_fail(db_pool.get().await?, infra_id, || {
+    let infra = Infra::retrieve_or_fail(db_pool.get().await?, infra_id, || {
         PacedTrainError::InfraNotFound { infra_id }
     })
     .await?;
@@ -498,7 +496,7 @@ pub(in crate::views) async fn simulation(
 
     // Retrieve paced_train or fail
     let paced_train =
-        models::PacedTrain::retrieve_real_or_fail(db_pool.get().await?, paced_train_id, || {
+        models::PacedTrain::retrieve_or_fail(db_pool.get().await?, paced_train_id, || {
             PacedTrainError::NotFound { paced_train_id }
         })
         .await?;
@@ -578,7 +576,7 @@ pub(in crate::views) async fn project_path(
         electrical_profile_set_id,
     }): Json<ProjectPathForm>,
 ) -> Result<Json<HashMap<i64, ProjectPathPacedTrainResult>>> {
-    let infra = &Infra::retrieve_real_or_fail(db_pool.get().await?, infra_id, || {
+    let infra = &Infra::retrieve_or_fail(db_pool.get().await?, infra_id, || {
         PacedTrainError::InfraNotFound { infra_id }
     })
     .await?;
@@ -712,7 +710,7 @@ pub(in crate::views) async fn project_path_op(
         operational_points_distances,
     }): Json<ProjectPathOperationalPointForm>,
 ) -> Result<Json<HashMap<i64, ProjectPathPacedTrainResult>>> {
-    let infra = &Infra::retrieve_real_or_fail(db_pool.get().await?, infra_id, || {
+    let infra = &Infra::retrieve_or_fail(db_pool.get().await?, infra_id, || {
         PacedTrainError::InfraNotFound { infra_id }
     })
     .await?;
@@ -887,7 +885,7 @@ pub(in crate::views) async fn occupancy_blocks(
     })
     .await?;
 
-    let infra = &Infra::retrieve_real_or_fail(db_pool.get().await?, infra_id, || {
+    let infra = &Infra::retrieve_or_fail(db_pool.get().await?, infra_id, || {
         PacedTrainError::InfraNotFound { infra_id }
     })
     .await?;
@@ -1071,7 +1069,7 @@ mod tests {
         assert_eq!(response.len(), 1);
 
         let created_paced_train =
-            models::PacedTrain::retrieve_real(pool.get_ok(), response.first().unwrap().id)
+            models::PacedTrain::retrieve(pool.get_ok(), response.first().unwrap().id)
                 .await
                 .expect("Failed to retrieve updated paced train")
                 .expect("Updated paced train not found");
@@ -1117,7 +1115,7 @@ mod tests {
         app.fetch(request).assert_status(StatusCode::NO_CONTENT);
 
         let created_paced_train =
-            models::PacedTrain::retrieve_real(pool.get_ok(), simple_paced_train.id)
+            models::PacedTrain::retrieve(pool.get_ok(), simple_paced_train.id)
                 .await
                 .expect("Failed to retrieve updated paced train")
                 .expect("Updated paced train not found");
@@ -1147,7 +1145,7 @@ mod tests {
 
         app.fetch(request).assert_status(StatusCode::NO_CONTENT);
 
-        let updated_paced_train = models::PacedTrain::retrieve_real(pool.get_ok(), paced_train.id)
+        let updated_paced_train = models::PacedTrain::retrieve(pool.get_ok(), paced_train.id)
             .await
             .expect("Failed to retrieve updated paced train")
             .expect("Updated paced train not found");

--- a/editoast/src/views/timetable/similar_trains.rs
+++ b/editoast/src/views/timetable/similar_trains.rs
@@ -585,7 +585,7 @@ async fn simulate_past_trains(
 
     let paths = {
         let paths = pathfinding_from_train_batch(
-            conn,
+            conn.clone(),
             &mut valkey.get_connection().await?,
             core_client.clone(),
             infra,

--- a/editoast/src/views/timetable/similar_trains.rs
+++ b/editoast/src/views/timetable/similar_trains.rs
@@ -245,7 +245,7 @@ pub(in crate::views) async fn similar_trains(
         return Err(SimilarTrainsError::TimetableNotFound { timetable_id }.into());
     }
 
-    let infra = Infra::retrieve_real_or_fail(conn.clone(), infra_id, || {
+    let infra = Infra::retrieve_or_fail(conn.clone(), infra_id, || {
         SimilarTrainsError::InfraNotFound { infra_id }
     })
     .await?;

--- a/editoast/src/views/timetable/simulation.rs
+++ b/editoast/src/views/timetable/simulation.rs
@@ -272,7 +272,7 @@ pub async fn consist_train_simulation_batch<T: TrainScheduleLike>(
     let mut valkey_conn = valkey_client.get_connection().await?;
 
     let pathfinding_results = pathfinding_from_train_batch(
-        conn,
+        conn.clone(),
         &mut valkey_conn,
         core.clone(),
         infra,

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -181,8 +181,8 @@ pub(in crate::views) async fn stdcm(
 
     // 1.  Infra / Timetable / Trains / Simulation / Rolling Stock
 
-    let infra = Infra::retrieve_real_or_fail(conn.clone(), infra_id, || {
-        StdcmError::InfraNotFound { infra_id }
+    let infra = Infra::retrieve_or_fail(conn.clone(), infra_id, || StdcmError::InfraNotFound {
+        infra_id,
     })
     .await?;
 
@@ -196,7 +196,7 @@ pub(in crate::views) async fn stdcm(
         .await?;
 
     let rolling_stock =
-        RollingStock::retrieve_real_or_fail(conn.clone(), stdcm_request.rolling_stock_id, || {
+        RollingStock::retrieve_or_fail(conn.clone(), stdcm_request.rolling_stock_id, || {
             StdcmError::RollingStockNotFound {
                 rolling_stock_id: stdcm_request.rolling_stock_id,
             }
@@ -241,7 +241,7 @@ pub(in crate::views) async fn stdcm(
     let earliest_departure_time = stdcm_request.get_earliest_departure_time(simulation_run_time);
     let latest_simulation_end = stdcm_request.get_latest_simulation_end(simulation_run_time);
 
-    let timetable = Timetable::retrieve_real_or_fail(conn.clone(), timetable_id, || {
+    let timetable = Timetable::retrieve_or_fail(conn.clone(), timetable_id, || {
         StdcmError::TimetableNotFound { timetable_id }
     })
     .await?;

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -83,7 +83,7 @@ pub(in crate::views) enum StdcmResponse {
     },
 }
 
-#[derive(Debug, Error, EditoastError, Serialize)]
+#[derive(Debug, Error, EditoastError, Serialize, derive_more::From)]
 #[editoast_error(base_id = "stdcm")]
 enum StdcmError {
     #[error("Infrastrcture {infra_id} does not exist")]
@@ -113,6 +113,10 @@ enum StdcmError {
         provided_consist_length: f64,
         expected_min: f64,
     },
+    #[error(transparent)]
+    #[from(forward)]
+    #[serde(skip)]
+    Database(editoast_models::model::Error),
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, IntoParams, ToSchema)]
@@ -177,9 +181,8 @@ pub(in crate::views) async fn stdcm(
 
     // 1.  Infra / Timetable / Trains / Simulation / Rolling Stock
 
-    #[expect(deprecated)]
-    let infra = Infra::retrieve_or_fail(&mut conn, infra_id, || StdcmError::InfraNotFound {
-        infra_id,
+    let infra = Infra::retrieve_real_or_fail(conn.clone(), infra_id, || {
+        StdcmError::InfraNotFound { infra_id }
     })
     .await?;
 
@@ -192,9 +195,8 @@ pub(in crate::views) async fn stdcm(
         })
         .await?;
 
-    #[expect(deprecated)]
     let rolling_stock =
-        RollingStock::retrieve_or_fail(&mut conn, stdcm_request.rolling_stock_id, || {
+        RollingStock::retrieve_real_or_fail(conn.clone(), stdcm_request.rolling_stock_id, || {
             StdcmError::RollingStockNotFound {
                 rolling_stock_id: stdcm_request.rolling_stock_id,
             }
@@ -239,8 +241,7 @@ pub(in crate::views) async fn stdcm(
     let earliest_departure_time = stdcm_request.get_earliest_departure_time(simulation_run_time);
     let latest_simulation_end = stdcm_request.get_latest_simulation_end(simulation_run_time);
 
-    #[expect(deprecated)]
-    let timetable = Timetable::retrieve_or_fail(&mut conn, timetable_id, || {
+    let timetable = Timetable::retrieve_real_or_fail(conn.clone(), timetable_id, || {
         StdcmError::TimetableNotFound { timetable_id }
     })
     .await?;

--- a/editoast/src/views/timetable/stdcm/request.rs
+++ b/editoast/src/views/timetable/stdcm/request.rs
@@ -288,7 +288,7 @@ impl Request {
 
         let towed_rolling_stock_id = self.towed_rolling_stock_id.unwrap();
         let towed_rolling_stock =
-            TowedRollingStock::retrieve_real_or_fail(conn.clone(), towed_rolling_stock_id, || {
+            TowedRollingStock::retrieve_or_fail(conn.clone(), towed_rolling_stock_id, || {
                 StdcmError::TowedRollingStockNotFound {
                     towed_rolling_stock_id,
                 }

--- a/editoast/src/views/timetable/stdcm/request.rs
+++ b/editoast/src/views/timetable/stdcm/request.rs
@@ -287,9 +287,8 @@ impl Request {
         }
 
         let towed_rolling_stock_id = self.towed_rolling_stock_id.unwrap();
-        #[expect(deprecated)]
         let towed_rolling_stock =
-            TowedRollingStock::retrieve_or_fail(conn, towed_rolling_stock_id, || {
+            TowedRollingStock::retrieve_real_or_fail(conn.clone(), towed_rolling_stock_id, || {
                 StdcmError::TowedRollingStockNotFound {
                     towed_rolling_stock_id,
                 }

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -174,7 +174,7 @@ pub(in crate::views) async fn get(
 
     let conn = &mut db_pool.get().await?;
     let train_schedule =
-        models::TrainSchedule::retrieve_real_or_fail(conn.clone(), train_schedule_id, || {
+        models::TrainSchedule::retrieve_or_fail(conn.clone(), train_schedule_id, || {
             TrainScheduleError::NotFound { train_schedule_id }
         })
         .await?;
@@ -299,7 +299,7 @@ pub(in crate::views) async fn simulation(
     }
 
     // Retrieve infra or fail
-    let infra = Infra::retrieve_real_or_fail(db_pool.get().await?, infra_id, || {
+    let infra = Infra::retrieve_or_fail(db_pool.get().await?, infra_id, || {
         TrainScheduleError::InfraNotFound { infra_id }
     })
     .await?;
@@ -313,12 +313,11 @@ pub(in crate::views) async fn simulation(
     .await?;
 
     // Retrieve train_schedule or fail
-    let train_schedule = models::TrainSchedule::retrieve_real_or_fail(
-        db_pool.get().await?,
-        train_schedule_id,
-        || TrainScheduleError::NotFound { train_schedule_id },
-    )
-    .await?;
+    let train_schedule =
+        models::TrainSchedule::retrieve_or_fail(db_pool.get().await?, train_schedule_id, || {
+            TrainScheduleError::NotFound { train_schedule_id }
+        })
+        .await?;
 
     // Compute simulation of a train schedule
     let (simulation, _) = train_simulation_batch(
@@ -371,7 +370,7 @@ pub(in crate::views) async fn etcs_braking_curves(
     }
 
     // Retrieve infra or fail
-    let infra = Infra::retrieve_real_or_fail(db_pool.get().await?, infra_id, || {
+    let infra = Infra::retrieve_or_fail(db_pool.get().await?, infra_id, || {
         TrainScheduleError::InfraNotFound { infra_id }
     })
     .await?;
@@ -385,12 +384,11 @@ pub(in crate::views) async fn etcs_braking_curves(
     .await?;
 
     // Retrieve train_schedule or fail
-    let train_schedule = models::TrainSchedule::retrieve_real_or_fail(
-        db_pool.get().await?,
-        train_schedule_id,
-        || TrainScheduleError::NotFound { train_schedule_id },
-    )
-    .await?;
+    let train_schedule =
+        models::TrainSchedule::retrieve_or_fail(db_pool.get().await?, train_schedule_id, || {
+            TrainScheduleError::NotFound { train_schedule_id }
+        })
+        .await?;
 
     // Compute simulation of a train schedule
     let (simulation_result, pathfinding_result) = train_simulation_batch(
@@ -433,7 +431,7 @@ pub(in crate::views) async fn etcs_braking_curves(
     };
 
     // Build physics consist
-    let rs = RollingStock::retrieve_real_or_fail(
+    let rs = RollingStock::retrieve_or_fail(
         db_pool.get().await?,
         train_schedule.rolling_stock_name.clone(),
         || TrainScheduleError::RollingStockNotFound {
@@ -515,7 +513,7 @@ pub(in crate::views) async fn simulation_summary(
 
     let conn = &mut db_pool.get().await?;
 
-    let infra = Infra::retrieve_real_or_fail(conn.clone(), infra_id, || {
+    let infra = Infra::retrieve_or_fail(conn.clone(), infra_id, || {
         TrainScheduleError::InfraNotFound { infra_id }
     })
     .await?;
@@ -591,7 +589,7 @@ pub(in crate::views) async fn get_path(
     let conn = db_pool.get().await?;
     let mut valkey_conn = valkey_client.get_connection().await?;
 
-    let infra = Infra::retrieve_real_or_fail(conn.clone(), infra_id, || {
+    let infra = Infra::retrieve_or_fail(conn.clone(), infra_id, || {
         PathfindingError::InfraNotFound { infra_id }
     })
     .await?;
@@ -605,7 +603,7 @@ pub(in crate::views) async fn get_path(
     .await?;
 
     let train_schedule =
-        models::TrainSchedule::retrieve_real_or_fail(conn.clone(), train_schedule_id, || {
+        models::TrainSchedule::retrieve_or_fail(conn.clone(), train_schedule_id, || {
             TrainScheduleError::NotFound { train_schedule_id }
         })
         .await?;
@@ -644,7 +642,7 @@ pub(in crate::views) async fn project_path(
         electrical_profile_set_id,
     }): Json<ProjectPathForm>,
 ) -> Result<Json<HashMap<i64, SpaceTimeCurves>>> {
-    let infra = &Infra::retrieve_real_or_fail(db_pool.get().await?, infra_id, || {
+    let infra = &Infra::retrieve_or_fail(db_pool.get().await?, infra_id, || {
         TrainScheduleError::InfraNotFound { infra_id }
     })
     .await?;
@@ -718,7 +716,7 @@ pub(in crate::views) async fn project_path_op(
         operational_points_distances,
     }): Json<ProjectPathOperationalPointForm>,
 ) -> Result<Json<HashMap<i64, Arc<SpaceTimeCurves>>>> {
-    let infra = &Infra::retrieve_real_or_fail(db_pool.get().await?, infra_id, || {
+    let infra = &Infra::retrieve_or_fail(db_pool.get().await?, infra_id, || {
         TrainScheduleError::InfraNotFound { infra_id }
     })
     .await?;
@@ -833,7 +831,7 @@ pub(in crate::views) async fn occupancy_blocks(
     })
     .await?;
 
-    let infra = &Infra::retrieve_real_or_fail(db_pool.get().await?, infra_id, || {
+    let infra = &Infra::retrieve_or_fail(db_pool.get().await?, infra_id, || {
         TrainScheduleError::InfraNotFound { infra_id }
     })
     .await?;
@@ -934,7 +932,7 @@ pub(in crate::views) async fn track_occupancy(
     .await?;
 
     // Retrieve infra / train_schedules / operational points
-    let infra = Infra::retrieve_real_or_fail(db_pool.get().await?, infra_id, || {
+    let infra = Infra::retrieve_or_fail(db_pool.get().await?, infra_id, || {
         TrainScheduleError::InfraNotFound { infra_id }
     })
     .await?;
@@ -949,7 +947,7 @@ pub(in crate::views) async fn track_occupancy(
         )
         .await?;
 
-    let operational_point = OperationalPointModel::retrieve_real_or_fail(
+    let operational_point = OperationalPointModel::retrieve_or_fail(
         db_pool.get().await?,
         (infra_id, operational_point_id.clone()),
         || TrainScheduleError::OperationalPointNotFound {
@@ -1342,7 +1340,7 @@ pub mod tests {
         assert_eq!(response.len(), 1);
 
         let created_train_schedule =
-            models::TrainSchedule::retrieve_real(pool.get_ok(), response.first().unwrap().id)
+            models::TrainSchedule::retrieve(pool.get_ok(), response.first().unwrap().id)
                 .await
                 .expect("Failed to retrieve updated train schedule")
                 .expect("Updated train schedule not found");

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -173,11 +173,11 @@ pub(in crate::views) async fn get(
     }
 
     let conn = &mut db_pool.get().await?;
-    #[expect(deprecated)]
-    let train_schedule = models::TrainSchedule::retrieve_or_fail(conn, train_schedule_id, || {
-        TrainScheduleError::NotFound { train_schedule_id }
-    })
-    .await?;
+    let train_schedule =
+        models::TrainSchedule::retrieve_real_or_fail(conn.clone(), train_schedule_id, || {
+            TrainScheduleError::NotFound { train_schedule_id }
+        })
+        .await?;
     Ok(Json(train_schedule.into()))
 }
 
@@ -299,8 +299,7 @@ pub(in crate::views) async fn simulation(
     }
 
     // Retrieve infra or fail
-    #[expect(deprecated)]
-    let infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra_id, || {
+    let infra = Infra::retrieve_real_or_fail(db_pool.get().await?, infra_id, || {
         TrainScheduleError::InfraNotFound { infra_id }
     })
     .await?;
@@ -314,9 +313,8 @@ pub(in crate::views) async fn simulation(
     .await?;
 
     // Retrieve train_schedule or fail
-    #[expect(deprecated)]
-    let train_schedule = models::TrainSchedule::retrieve_or_fail(
-        &mut db_pool.get().await?,
+    let train_schedule = models::TrainSchedule::retrieve_real_or_fail(
+        db_pool.get().await?,
         train_schedule_id,
         || TrainScheduleError::NotFound { train_schedule_id },
     )
@@ -517,9 +515,8 @@ pub(in crate::views) async fn simulation_summary(
 
     let conn = &mut db_pool.get().await?;
 
-    #[expect(deprecated)]
-    let infra = Infra::retrieve_or_fail(conn, infra_id, || TrainScheduleError::InfraNotFound {
-        infra_id,
+    let infra = Infra::retrieve_real_or_fail(conn.clone(), infra_id, || {
+        TrainScheduleError::InfraNotFound { infra_id }
     })
     .await?;
 
@@ -591,12 +588,11 @@ pub(in crate::views) async fn get_path(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    let conn = &mut db_pool.get().await?;
+    let conn = db_pool.get().await?;
     let mut valkey_conn = valkey_client.get_connection().await?;
 
-    #[expect(deprecated)]
-    let infra = Infra::retrieve_or_fail(conn, infra_id, || PathfindingError::InfraNotFound {
-        infra_id,
+    let infra = Infra::retrieve_real_or_fail(conn.clone(), infra_id, || {
+        PathfindingError::InfraNotFound { infra_id }
     })
     .await?;
 
@@ -608,11 +604,11 @@ pub(in crate::views) async fn get_path(
     })
     .await?;
 
-    #[expect(deprecated)]
-    let train_schedule = models::TrainSchedule::retrieve_or_fail(conn, train_schedule_id, || {
-        TrainScheduleError::NotFound { train_schedule_id }
-    })
-    .await?;
+    let train_schedule =
+        models::TrainSchedule::retrieve_real_or_fail(conn.clone(), train_schedule_id, || {
+            TrainScheduleError::NotFound { train_schedule_id }
+        })
+        .await?;
     Ok(Json(
         pathfinding_from_train(conn, &mut valkey_conn, core, &infra, train_schedule).await?,
     ))

--- a/editoast/src/views/work_schedules.rs
+++ b/editoast/src/views/work_schedules.rs
@@ -413,7 +413,7 @@ pub(in crate::views) async fn put_in_group(
     conn.transaction(|conn| {
         Box::pin(async move {
             // Check that the group exists
-            WorkScheduleGroup::retrieve_real_or_fail(conn.clone(), group_id, || {
+            WorkScheduleGroup::retrieve_or_fail(conn.clone(), group_id, || {
                 WorkScheduleError::WorkScheduleGroupNotFound { id: group_id }
             })
             .await?;
@@ -482,7 +482,7 @@ pub(in crate::views) async fn get_group(
     let conn = &mut db_pool.get().await?;
 
     // Check that the group exists
-    WorkScheduleGroup::retrieve_real_or_fail(conn.clone(), group_id, || {
+    WorkScheduleGroup::retrieve_or_fail(conn.clone(), group_id, || {
         WorkScheduleError::WorkScheduleGroupNotFound { id: group_id }
     })
     .await?;
@@ -531,7 +531,7 @@ pub mod tests {
             .json_into::<WorkScheduleCreateResponse>();
 
         // THEN
-        let created_group = WorkScheduleGroup::retrieve_real(
+        let created_group = WorkScheduleGroup::retrieve(
             pool.get_ok(),
             work_schedule_response.work_schedule_group_id,
         )

--- a/editoast/src/views/work_schedules.rs
+++ b/editoast/src/views/work_schedules.rs
@@ -23,6 +23,7 @@ use chrono::DateTime;
 use chrono::Utc;
 use database::DbConnectionPoolV2;
 use editoast_derive::EditoastError;
+use editoast_models::model;
 use editoast_schemas::infra::Direction;
 use editoast_schemas::infra::TrackRange;
 use serde::Deserialize;
@@ -51,8 +52,7 @@ enum WorkScheduleError {
     WorkScheduleGroupNotFound { id: i64 },
     #[error(transparent)]
     #[editoast_error(status = 500)]
-    #[from(editoast_models::model::Error)]
-    Database(work_schedules::WsGroupError),
+    Database(model::Error),
 }
 
 impl From<work_schedules::WsGroupError> for WorkScheduleError {
@@ -61,7 +61,7 @@ impl From<work_schedules::WsGroupError> for WorkScheduleError {
             work_schedules::WsGroupError::NameAlreadyUsed { name } => {
                 WorkScheduleError::NameAlreadyUsed { name }
             }
-            e => WorkScheduleError::Database(e),
+            work_schedules::WsGroupError::Database(e) => WorkScheduleError::Database(e),
         }
     }
 }
@@ -413,8 +413,7 @@ pub(in crate::views) async fn put_in_group(
     conn.transaction(|conn| {
         Box::pin(async move {
             // Check that the group exists
-            #[expect(deprecated)]
-            WorkScheduleGroup::retrieve_or_fail(&mut conn.clone(), group_id, || {
+            WorkScheduleGroup::retrieve_real_or_fail(conn.clone(), group_id, || {
                 WorkScheduleError::WorkScheduleGroupNotFound { id: group_id }
             })
             .await?;
@@ -483,8 +482,7 @@ pub(in crate::views) async fn get_group(
     let conn = &mut db_pool.get().await?;
 
     // Check that the group exists
-    #[expect(deprecated)]
-    WorkScheduleGroup::retrieve_or_fail(conn, group_id, || {
+    WorkScheduleGroup::retrieve_real_or_fail(conn.clone(), group_id, || {
         WorkScheduleError::WorkScheduleGroupNotFound { id: group_id }
     })
     .await?;
@@ -533,9 +531,8 @@ pub mod tests {
             .json_into::<WorkScheduleCreateResponse>();
 
         // THEN
-        #[expect(deprecated)]
-        let created_group = WorkScheduleGroup::retrieve(
-            &mut pool.get_ok(),
+        let created_group = WorkScheduleGroup::retrieve_real(
+            pool.get_ok(),
             work_schedule_response.work_schedule_group_id,
         )
         .await

--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -69,6 +69,7 @@
       "NotFound": "Document '{{document_key}}' not found"
     },
     "electrical_profiles": {
+      "Database": "Internal error (database)",
       "NotFound": "Electrical Profile Set '{{electrical_profile_set_id}}', could not be found"
     },
     "fonts": {
@@ -135,6 +136,7 @@
       "NotFound": "Paced train '{{paced_train_id}}' could not be found"
     },
     "pathfinding": {
+      "Database": "Internal error (database)",
       "ElectricalProfilesOverlap": "Electrical Profile overlaps with others",
       "ElectrificationOverlap": "Electrification '{{electrification_id}}' overlaps with other electrifications",
       "InfraNotFound": "Infrastructure '{{infra_id}}' does not exist",
@@ -205,6 +207,7 @@
       "UnknownSignalingSystem": "Unknown signaling system"
     },
     "stdcm": {
+      "Database": "Internal error (database)",
       "InfraNotFound": "Infrastructure '{{infra_id}}' does not exist",
       "InvalidConsistLength": "Invalid consist length {{provided_consist_length}}: it should be greater than '{{expected_min}}'",
       "InvalidConsistMass": "Invalid consist mass {{provided_consist_mass}}: it should be greater than '{{expected_min}}'",
@@ -215,6 +218,7 @@
       "TrainSimulationFail": "Train simulation failed"
     },
     "stdcm_log": {
+      "Database": "Internal error (database)",
       "MissingIdAndTraceId": "STDCM log entry could not be found without specifying an 'id' or 'trace_id'",
       "NotFound": "STDCM log entry '{{id}}' could not be found",
       "TraceIdNotFound": "STDCM log entry '{{trace_id}}' could not be found"

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -69,6 +69,7 @@
       "NotFound": "Document '{{document_key}}' non trouvé"
     },
     "electrical_profiles": {
+      "Database": "Erreur interne (base de données)",
       "NotFound": "Profil électrique '{{electrical_profile_set_id}}' non trouvé"
     },
     "fonts": {
@@ -135,6 +136,7 @@
       "NotFound": "Mission '{{paced_train_id}}' non trouvée"
     },
     "pathfinding": {
+      "Database": "Erreur interne (base de données)",
       "ElectricalProfilesOverlap": "Des profils électriques se chevauchent",
       "ElectrificationOverlap": "Electrification {{electrification_id}} se supperpose avec d'autres",
       "InfraNotFound": "Infrastructure '{{infra_id}}' non trouvée",
@@ -205,6 +207,7 @@
       "UnknownSignalingSystem": "Système de signalisation inconnu"
     },
     "stdcm": {
+      "Database": "Erreur interne (base de données)",
       "InfraNotFound": "Infrastructure '{{infra_id}}' non trouvée",
       "InvalidConsistLength": "Longueur du convoi invalide {{provided_consist_length}} : doit être supérieure à '{{expected_min}}'",
       "InvalidConsistMass": "Masse du convoi invalide {{provided_consist_mass}} : elle doit être supérieure à '{{expected_min}}",
@@ -215,6 +218,7 @@
       "TrainSimulationFail": "Échec de la simulation du train"
     },
     "stdcm_log": {
+      "Database": "Erreur interne (base de données)",
       "MissingIdAndTraceId": "STDCM Log n'a pas pu être trouvée sans spécifier un 'id' ou un 'trace_id'",
       "NotFound": "STDCM Log '{{id}}' n'a pas pu être trouvée",
       "TraceIdNotFound": "STDCM Log '{{trace_id}}' n'a pas pu être trouvée"


### PR DESCRIPTION
- **editost: remove deprecated retrieve calls**
- **editoast: typos**
- **editoast: models: substitute retrieve_real by retrieve**
