### PR TITLE
editoast: follow-up on errors of Model::List (#12793)

### DIFF
--- a/editoast/editoast_derive/src/model/args.rs
+++ b/editoast/editoast_derive/src/model/args.rs
@@ -92,6 +92,7 @@ pub(super) struct DetailedErrorArgs {
     pub(super) retrieve: Option<syn::Path>,
     pub(super) update: Option<syn::Path>,
     pub(super) delete: Option<syn::Path>,
+    pub(super) list: Option<syn::Path>,
 }
 
 #[derive(FromMeta, Default, Debug, PartialEq)]

--- a/editoast/editoast_derive/src/model/parsing.rs
+++ b/editoast/editoast_derive/src/model/parsing.rs
@@ -327,6 +327,7 @@ impl Errors {
                 retrieve,
                 update,
                 delete,
+                list,
             }) => {
                 let Errors {
                     create: default_create,
@@ -340,7 +341,7 @@ impl Errors {
                     create: create.unwrap_or(default_create),
                     update: update.unwrap_or(default_update),
                     delete: delete.unwrap_or(default_delete),
-                    list: default_list,
+                    list: list.unwrap_or(default_list),
                 })
             }
         }

--- a/editoast/src/models/mod.rs
+++ b/editoast/src/models/mod.rs
@@ -68,7 +68,7 @@ mod tests {
     use super::prelude::*;
 
     #[derive(Debug, Default, Clone, Model, PartialEq, Eq)]
-    #[model(table = database::tables::document, error(write = DocError))] // remporary — revert to error = DocError
+    #[model(table = database::tables::document, error = DocError)]
     #[model(gen(ops = crud, batch_ops = crud, list))]
     struct Document {
         id: i64,


### PR DESCRIPTION
Because grep doesn't match typos somehow...
