### PR TITLE
front: fix items order when pairing items in roundtrips modal

### DIFF
--- a/front/src/modules/timetableItem/components/Timetable/RoundTrips/TodoColumn.tsx
+++ b/front/src/modules/timetableItem/components/Timetable/RoundTrips/TodoColumn.tsx
@@ -62,7 +62,12 @@ const TodoColumn = ({
       }
     }
 
-    return { suggestions, others };
+    return {
+      suggestions: suggestions.sort((a, b) =>
+        a.name.toLowerCase().localeCompare(b.name.toLowerCase())
+      ),
+      others: others.sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase())),
+    };
   }, [timetableItemsWithOpsById, pairingItemsById, itemIdToPair]);
 
   const moveItemToOneWays = (itemToMove: PairingItem) => {


### PR DESCRIPTION
fix #12815