### PR TITLE
front: fix a composition-code typo on filters

### DIFF
--- a/front/src/applications/stdcm/consts.ts
+++ b/front/src/applications/stdcm/consts.ts
@@ -22,8 +22,8 @@ export const COMPOSITION_CODES_MAX_SPEEDS: Record<string, number | undefined> = 
   ME100: 100,
   ME120: 120,
   ME140: 140,
-  ME160: 160,
   HLP: 100,
+  MV160: 160,
   MVGV: 200,
 };
 export const DEFAULT_COMPOSITION_CODE = 'MA100';


### PR DESCRIPTION
Speed-limit tag was wrong, compared to OSRD's internal [hierarchy](https://github.com/OpenRailAssociation/osrd/blob/30cf707f8d1b30086a169f02b065e17aa32aa860/assets/static_resources/speed_limit_tags.yml#L40) and most importantly to EPSF documentation (RC A-B 7a n° 1)

Typo introduced in https://github.com/OpenRailAssociation/osrd/pull/10039/files#diff-2db527ea765b5b94ecda36678021cfe496c51e9075d318d448e252615e3be92aR31 (then more widely used)