### PR TITLE
core: small improvements on DistanceRangeMap

### DIFF
--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/PathPropertiesImpl.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/PathPropertiesImpl.kt
@@ -135,8 +135,7 @@ data class PathPropertiesImpl(
             if (zoneId != null) {
                 val chunkLength = infra.getTrackChunkLength(chunkId).distance
                 distanceRangeMapOf(
-                    *listOf(DistanceRangeMap.RangeMapEntry(Distance.ZERO, chunkLength, zoneId))
-                        .toTypedArray()
+                    DistanceRangeMap.RangeMapEntry(Distance.ZERO, chunkLength, zoneId)
                 )
             } else {
                 distanceRangeMapOf()

--- a/core/kt-osrd-rjs-parser/src/main/kotlin/fr/sncf/osrd/RawInfraRJSParser.kt
+++ b/core/kt-osrd-rjs-parser/src/main/kotlin/fr/sncf/osrd/RawInfraRJSParser.kt
@@ -53,8 +53,7 @@ private fun parseLineString(rjsLineString: RJSLineString?): LineString? {
 private fun getSlopes(rjsTrackSection: RJSTrackSection): DistanceRangeMap<Double> {
     val slopes =
         distanceRangeMapOf(
-            *listOf(DistanceRangeMap.RangeMapEntry(0.meters, rjsTrackSection.length.meters, 0.0))
-                .toTypedArray()
+            DistanceRangeMap.RangeMapEntry(0.meters, rjsTrackSection.length.meters, 0.0)
         )
     if (rjsTrackSection.slopes != null) {
         for (rjsSlope in rjsTrackSection.slopes) {
@@ -76,8 +75,7 @@ private fun getSlopes(rjsTrackSection: RJSTrackSection): DistanceRangeMap<Double
 private fun getCurves(rjsTrackSection: RJSTrackSection): DistanceRangeMap<Double> {
     val curves =
         distanceRangeMapOf(
-            *listOf(DistanceRangeMap.RangeMapEntry(0.meters, rjsTrackSection.length.meters, 0.0))
-                .toTypedArray()
+            listOf(DistanceRangeMap.RangeMapEntry(0.meters, rjsTrackSection.length.meters, 0.0))
         )
     if (rjsTrackSection.curves != null) {
         for (rjsCurve in rjsTrackSection.curves) {

--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/DistanceRangeMap.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/DistanceRangeMap.kt
@@ -76,6 +76,10 @@ fun <T> distanceRangeMapOf(vararg entries: DistanceRangeMap.RangeMapEntry<T>): D
     return DistanceRangeMapImpl(entries.asList())
 }
 
+fun <T> distanceRangeMapOf(entries: List<DistanceRangeMap.RangeMapEntry<T>>): DistanceRangeMap<T> {
+    return DistanceRangeMapImpl(entries)
+}
+
 /**
  * Merges all the given range maps, offsetting them by the given distances. The lists must be empty
  * or `maps` must be larger by one.
@@ -104,7 +108,7 @@ fun <T> mergeDistanceRangeMaps(
     }
 
     // Build the whole map at once to avoid redundant computations.
-    return distanceRangeMapOf(*resEntries.toTypedArray())
+    return distanceRangeMapOf(resEntries)
 }
 
 /**

--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/DistanceRangeMapImpl.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/DistanceRangeMapImpl.kt
@@ -172,11 +172,7 @@ data class DistanceRangeMapImpl<T>(
     }
 
     override fun clone(): DistanceRangeMap<T> {
-        val res = DistanceRangeMapImpl<T>()
-        for (entry in this) {
-            res.put(entry.lower, entry.upper, entry.value)
-        }
-        return res
+        return DistanceRangeMapImpl(bounds.clone(), values.toMutableList())
     }
 
     override fun subMap(lower: Distance, upper: Distance): DistanceRangeMap<T> {

--- a/core/kt-osrd-utils/src/test/kotlin/fr/sncf/osrd/utils/TestDistanceRangeMap.kt
+++ b/core/kt-osrd-utils/src/test/kotlin/fr/sncf/osrd/utils/TestDistanceRangeMap.kt
@@ -260,7 +260,7 @@ class TestDistanceRangeMap {
     @Test
     fun testMergeDistanceRangeMapsSimple() {
         val inputMap =
-            distanceRangeMapOf<Int>(
+            distanceRangeMapOf(
                 DistanceRangeMap.RangeMapEntry(Distance(0), Distance(50), 1),
                 DistanceRangeMap.RangeMapEntry(Distance(50), Distance(100), 2),
             )

--- a/core/src/main/kotlin/fr/sncf/osrd/api/CommonSchemas.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/CommonSchemas.kt
@@ -49,7 +49,7 @@ data class RangeValues<valueT>(
                 )
             )
         }
-        return distanceRangeMapOf(*rangeMapEntries.toTypedArray())
+        return distanceRangeMapOf(rangeMapEntries)
     }
 }
 

--- a/core/src/main/kotlin/fr/sncf/osrd/envelope_sim_infra/MRSP.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/envelope_sim_infra/MRSP.kt
@@ -179,9 +179,7 @@ fun makeSpeedLimitAttributes(
     baseAttrs: List<SelfTypeHolder>,
 ): DistanceRangeMap<List<SelfTypeHolder>> {
     val result: DistanceRangeMap<List<SelfTypeHolder>> =
-        distanceRangeMapOf(
-            *listOf(DistanceRangeMap.RangeMapEntry(lower, upper, baseAttrs)).toTypedArray()
-        )
+        distanceRangeMapOf(DistanceRangeMap.RangeMapEntry(lower, upper, baseAttrs))
 
     // Add important attributes from the old speed ranges
     val attrsWithMissingRange = baseAttrs.toMutableList()

--- a/core/src/test/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulationTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulationTest.kt
@@ -175,20 +175,13 @@ class StandaloneSimulationTest {
             listOf(
                 distanceRangeMapOf(),
                 distanceRangeMapOf(
-                    *listOf(
-                            DistanceRangeMap.RangeMapEntry(0.meters, pathLength / 3.0, "Restrict1"),
-                            DistanceRangeMap.RangeMapEntry(
-                                pathLength / 3.0,
-                                pathLength * 2.0 / 3.0,
-                                "Restrict2",
-                            ),
-                            DistanceRangeMap.RangeMapEntry(
-                                pathLength * 2.0 / 3.0,
-                                pathLength,
-                                "Restrict1",
-                            ),
-                        )
-                        .toTypedArray()
+                    DistanceRangeMap.RangeMapEntry(0.meters, pathLength / 3.0, "Restrict1"),
+                    DistanceRangeMap.RangeMapEntry(
+                        pathLength / 3.0,
+                        pathLength * 2.0 / 3.0,
+                        "Restrict2",
+                    ),
+                    DistanceRangeMap.RangeMapEntry(pathLength * 2.0 / 3.0, pathLength, "Restrict1"),
                 ),
             )
 
@@ -320,22 +313,11 @@ class StandaloneSimulationTest {
             makeSafetySpeedRanges(infra, chunkPath, routes.toIdxList(), schedule, signalingRanges)
         val expected =
             distanceRangeMapOf(
-                *listOf(
-                        DistanceRangeMap.RangeMapEntry(0.meters, 50.meters, 30.kilometersPerHour),
-                        DistanceRangeMap.RangeMapEntry(50.meters, 150.meters, 10.kilometersPerHour),
-                        DistanceRangeMap.RangeMapEntry(
-                            10_200.meters,
-                            10_300.meters,
-                            30.kilometersPerHour,
-                        ),
-                        // Last buffer stop short slip range
-                        DistanceRangeMap.RangeMapEntry(
-                            10_300.meters,
-                            10_400.meters,
-                            10.kilometersPerHour,
-                        ),
-                    )
-                    .toTypedArray()
+                DistanceRangeMap.RangeMapEntry(0.meters, 50.meters, 30.kilometersPerHour),
+                DistanceRangeMap.RangeMapEntry(50.meters, 150.meters, 10.kilometersPerHour),
+                DistanceRangeMap.RangeMapEntry(10_200.meters, 10_300.meters, 30.kilometersPerHour),
+                // Last buffer stop short slip range
+                DistanceRangeMap.RangeMapEntry(10_300.meters, 10_400.meters, 10.kilometersPerHour),
             )
         assertEquals(expected, safetySpeedRanges)
     }
@@ -380,29 +362,10 @@ class StandaloneSimulationTest {
             )
         val expectedEtcsHappyPath =
             distanceRangeMapOf(
-                *listOf(
-                        DistanceRangeMap.RangeMapEntry(
-                            9_950.meters,
-                            10_050.meters,
-                            30.kilometersPerHour,
-                        ),
-                        DistanceRangeMap.RangeMapEntry(
-                            10_050.meters,
-                            10_150.meters,
-                            10.kilometersPerHour,
-                        ),
-                        DistanceRangeMap.RangeMapEntry(
-                            10_200.meters,
-                            10_300.meters,
-                            30.kilometersPerHour,
-                        ),
-                        DistanceRangeMap.RangeMapEntry(
-                            10_300.meters,
-                            10_400.meters,
-                            10.kilometersPerHour,
-                        ),
-                    )
-                    .toTypedArray()
+                DistanceRangeMap.RangeMapEntry(9_950.meters, 10_050.meters, 30.kilometersPerHour),
+                DistanceRangeMap.RangeMapEntry(10_050.meters, 10_150.meters, 10.kilometersPerHour),
+                DistanceRangeMap.RangeMapEntry(10_200.meters, 10_300.meters, 30.kilometersPerHour),
+                DistanceRangeMap.RangeMapEntry(10_300.meters, 10_400.meters, 10.kilometersPerHour),
             )
         assertEquals(expectedEtcsHappyPath, safetySpeedRangesEtcsHappyPath)
 
@@ -420,8 +383,7 @@ class StandaloneSimulationTest {
             )
         val expectedEndFullEtcs =
             distanceRangeMapOf(
-                *listOf(DistanceRangeMap.RangeMapEntry(0.meters, 150.meters, 30.kilometersPerHour))
-                    .toTypedArray()
+                DistanceRangeMap.RangeMapEntry(0.meters, 150.meters, 30.kilometersPerHour)
             )
         assertEquals(expectedEndFullEtcs, safetySpeedRangesEndFullEtcs)
 
@@ -439,8 +401,7 @@ class StandaloneSimulationTest {
             )
         val expectedEndFullEtcsExceptFinalBuffer =
             distanceRangeMapOf(
-                *listOf(DistanceRangeMap.RangeMapEntry(0.meters, 150.meters, 30.kilometersPerHour))
-                    .toTypedArray()
+                DistanceRangeMap.RangeMapEntry(0.meters, 150.meters, 30.kilometersPerHour)
             )
         assertEquals(
             expectedEndFullEtcsExceptFinalBuffer,
@@ -466,20 +427,9 @@ class StandaloneSimulationTest {
             )
         val expectedEtcsStartingBetweenPenultimateStopAndItsSignal =
             distanceRangeMapOf(
-                *listOf(
-                        DistanceRangeMap.RangeMapEntry(0.meters, 150.meters, 30.kilometersPerHour),
-                        DistanceRangeMap.RangeMapEntry(
-                            9_950.meters,
-                            10_050.meters,
-                            30.kilometersPerHour,
-                        ),
-                        DistanceRangeMap.RangeMapEntry(
-                            10_050.meters,
-                            10_150.meters,
-                            10.kilometersPerHour,
-                        ),
-                    )
-                    .toTypedArray()
+                DistanceRangeMap.RangeMapEntry(0.meters, 150.meters, 30.kilometersPerHour),
+                DistanceRangeMap.RangeMapEntry(9_950.meters, 10_050.meters, 30.kilometersPerHour),
+                DistanceRangeMap.RangeMapEntry(10_050.meters, 10_150.meters, 10.kilometersPerHour),
             )
         assertEquals(
             expectedEtcsStartingBetweenPenultimateStopAndItsSignal,
@@ -504,30 +454,11 @@ class StandaloneSimulationTest {
             )
         val expectedEtcsStartingBetweenLastStopAndBuffer =
             distanceRangeMapOf(
-                *listOf(
-                        DistanceRangeMap.RangeMapEntry(0.meters, 150.meters, 30.kilometersPerHour),
-                        DistanceRangeMap.RangeMapEntry(
-                            9_950.meters,
-                            10_050.meters,
-                            30.kilometersPerHour,
-                        ),
-                        DistanceRangeMap.RangeMapEntry(
-                            10_050.meters,
-                            10_150.meters,
-                            10.kilometersPerHour,
-                        ),
-                        DistanceRangeMap.RangeMapEntry(
-                            10_200.meters,
-                            10_300.meters,
-                            30.kilometersPerHour,
-                        ),
-                        DistanceRangeMap.RangeMapEntry(
-                            10_300.meters,
-                            10_400.meters,
-                            10.kilometersPerHour,
-                        ),
-                    )
-                    .toTypedArray()
+                DistanceRangeMap.RangeMapEntry(0.meters, 150.meters, 30.kilometersPerHour),
+                DistanceRangeMap.RangeMapEntry(9_950.meters, 10_050.meters, 30.kilometersPerHour),
+                DistanceRangeMap.RangeMapEntry(10_050.meters, 10_150.meters, 10.kilometersPerHour),
+                DistanceRangeMap.RangeMapEntry(10_200.meters, 10_300.meters, 30.kilometersPerHour),
+                DistanceRangeMap.RangeMapEntry(10_300.meters, 10_400.meters, 10.kilometersPerHour),
             )
         assertEquals(
             expectedEtcsStartingBetweenLastStopAndBuffer,


### PR DESCRIPTION
* `clone` now does a basic clone, instead of rerunning all the building logic
* `distanceRangeMapOf` can now directly take a list instead of just varargs. Remove `*listOf(...).toTypedArray()`