### PR TITLE
front: set max size for Node in the script npm start

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -150,7 +150,7 @@
   },
   "scripts": {
     "compile": "tsc -b",
-    "start": "vite",
+    "start": "export NODE_OPTIONS='--max_old_space_size=4096' && vite",
     "start-container": "vite --host",
     "build": "npm run build --workspaces --if-present && vite build",
     "test": "npm run test --workspaces --if-present && vitest",


### PR DESCRIPTION
This is needed to avoid OOM when launching the stack in front dev mode.