### PR TITLE
github: bump private packages dependencies when releasing osrd-ui

### DIFF
--- a/.github/workflows/osrd-ui-publish.yml
+++ b/.github/workflows/osrd-ui-publish.yml
@@ -37,4 +37,4 @@ jobs:
           VERSION=${TAG/ui-v/}
           cd front
           npm ci
-          npx lerna publish ${VERSION} --yes --no-push --no-git-tag-version
+          npx lerna publish ${VERSION} --yes --no-push --no-git-tag-version --private


### PR DESCRIPTION
We were failing because private packages such as ui/storybook were ignored and still contained "0.0.1-dev" version constraints for osrd-ui packages:
https://github.com/OpenRailAssociation/osrd/actions/runs/16746388600/job/47405832296

Fix this by passing --private to tell lerna to not ignore these.