### PR TITLE
front: refacto use output table data

### DIFF
--- a/front/src/applications/operationalStudies/hooks/useTrainOps.ts
+++ b/front/src/applications/operationalStudies/hooks/useTrainOps.ts
@@ -1,9 +1,8 @@
 import { useMemo } from 'react';
 
-import type { PathPropertiesFormatted } from 'applications/operationalStudies/types';
 import {
   osrdEditoastApi,
-  type OperationalPointPart,
+  type OperationalPoint,
   type OperationalPointReference,
 } from 'common/api/osrdEditoastApi';
 import type { Train } from 'reducers/osrdconf/types';
@@ -13,20 +12,18 @@ import { getStationFromOps, isOperationalPointReference } from '../utils';
 /**
  * Given a train, return the operational points corresponding to the pathSteps of this train
  */
-const useTrainOps = (
-  infraId: number,
-  train?: Train
-): PathPropertiesFormatted['operationalPoints'] => {
-  const operationalPointReferences: OperationalPointReference[] = useMemo(() => {
-    if (!train) return [];
-    return train.path.reduce<OperationalPointReference[]>((acc, pathItem) => {
-      if (isOperationalPointReference(pathItem)) {
-        const { id: _id, deleted: _deleted, ...cleanOperationalPointReference } = pathItem;
-        acc.push(cleanOperationalPointReference);
-      }
-      return acc;
-    }, []);
-  }, [train]);
+const useTrainOps = (infraId: number, train?: Train): OperationalPoint[] => {
+  const operationalPointReferences: OperationalPointReference[] = useMemo(
+    () =>
+      (train?.path ?? []).reduce<OperationalPointReference[]>((acc, pathItem) => {
+        if (isOperationalPointReference(pathItem)) {
+          const { id: _id, deleted: _deleted, ...cleanOperationalPointReference } = pathItem;
+          acc.push(cleanOperationalPointReference);
+        }
+        return acc;
+      }, []),
+    [train]
+  );
 
   const { data: operationalPoints } =
     osrdEditoastApi.endpoints.postInfraByInfraIdMatchOperationalPoints.useQuery(
@@ -39,28 +36,17 @@ const useTrainOps = (
       { skip: operationalPointReferences.length === 0 }
     );
 
-  // Get this type will facilitate the logic in TimesStopsOutput
-  const formattedOperationalPoints: PathPropertiesFormatted['operationalPoints'] = useMemo(() => {
+  return useMemo(() => {
     if (
       !operationalPoints?.related_operational_points ||
       operationalPoints.related_operational_points.length === 0
-    ) {
+    )
       return [];
-    }
 
-    // We have at least one related operational point
     return operationalPoints.related_operational_points
       .filter((ops) => ops.length !== 0) // To remove empty arrays related to invalid step
-      .map((ops) => ({
-        ...getStationFromOps(ops)!,
-        // The following properties will not be used for invalid trains output table data
-        part: { position: 0, track: 'unknown' } as OperationalPointPart,
-        position: 0,
-        weight: null,
-      }));
+      .map((matchingOps) => getStationFromOps(matchingOps)!);
   }, [operationalPoints]);
-
-  return formattedOperationalPoints;
 };
 
 export default useTrainOps;

--- a/front/src/applications/operationalStudies/hooks/useTrainOps.ts
+++ b/front/src/applications/operationalStudies/hooks/useTrainOps.ts
@@ -10,13 +10,15 @@ import type { Train } from 'reducers/osrdconf/types';
 
 import { getStationFromOps, isOperationalPointReference } from '../utils';
 
-const useInvalidTrainOps = (
+/**
+ * Given a train, return the operational points corresponding to the pathSteps of this train
+ */
+const useTrainOps = (
   infraId: number,
-  isValid: boolean,
   train?: Train
 ): PathPropertiesFormatted['operationalPoints'] => {
   const operationalPointReferences: OperationalPointReference[] = useMemo(() => {
-    if (isValid || !train) return [];
+    if (!train) return [];
     return train.path.reduce<OperationalPointReference[]>((acc, pathItem) => {
       if (isOperationalPointReference(pathItem)) {
         const { id: _id, deleted: _deleted, ...cleanOperationalPointReference } = pathItem;
@@ -61,4 +63,4 @@ const useInvalidTrainOps = (
   return formattedOperationalPoints;
 };
 
-export default useInvalidTrainOps;
+export default useTrainOps;

--- a/front/src/applications/operationalStudies/types.ts
+++ b/front/src/applications/operationalStudies/types.ts
@@ -98,8 +98,6 @@ export type PathPropertiesFormatted = {
   voltages: RangedValue[];
 };
 
-export type PositionedOperationalPoint = PathPropertiesFormatted['operationalPoints'][number];
-
 export type PowerRestriction = ArrayElement<TrainSchedule['power_restrictions']>;
 
 export type ElectrificationVoltage = {

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults.tsx
@@ -335,8 +335,7 @@ const SimulationResults = ({
                       isValid: true,
                       simulatedTrain: simulationResults.simulation.final_output,
                       simulatedPathItemTimes: simulationSummary.pathItemTimes,
-                      simulatedOperationalPoints:
-                        simulationResults.pathProperties.operationalPoints,
+                      operationalPointsOnPath: simulationResults.pathProperties.operationalPoints,
                     }
                   : { isValid: false })}
               />

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults.tsx
@@ -334,7 +334,6 @@ const SimulationResults = ({
                   ? {
                       isValid: true,
                       simulatedTrain: simulationResults.simulation.final_output,
-                      simulatedPath: simulationResults.path,
                       simulatedPathItemTimes: simulationSummary.pathItemTimes,
                       simulatedOperationalPoints:
                         simulationResults.pathProperties.operationalPoints,

--- a/front/src/modules/timesStops/TimesStopsOutput.tsx
+++ b/front/src/modules/timesStops/TimesStopsOutput.tsx
@@ -27,7 +27,6 @@ const TimesStopsOutput = ({
   isValid,
   selectedTrain,
   simulatedTrain,
-  simulatedPath,
   simulatedPathItemTimes,
   simulatedOperationalPoints,
 }: TimesStopsOutputProps) => {
@@ -36,7 +35,6 @@ const TimesStopsOutput = ({
     isValid,
     selectedTrain,
     simulatedTrain,
-    simulatedPath,
     simulatedPathItemTimes,
     simulatedOperationalPoints
   );

--- a/front/src/modules/timesStops/TimesStopsOutput.tsx
+++ b/front/src/modules/timesStops/TimesStopsOutput.tsx
@@ -19,7 +19,7 @@ type TimesStopsOutputProps = {
   simulatedTrain?: SimulationResponseSuccess['final_output'];
   simulatedPath?: PathfindingResultSuccess;
   simulatedPathItemTimes?: Extract<SimulationSummary, { isValid: true }>['pathItemTimes'];
-  simulatedOperationalPoints?: PathPropertiesFormatted['operationalPoints'];
+  operationalPointsOnPath?: PathPropertiesFormatted['operationalPoints'];
 };
 
 const TimesStopsOutput = ({
@@ -28,7 +28,7 @@ const TimesStopsOutput = ({
   selectedTrain,
   simulatedTrain,
   simulatedPathItemTimes,
-  simulatedOperationalPoints,
+  operationalPointsOnPath,
 }: TimesStopsOutputProps) => {
   const rows = useOutputTableData(
     infraId,
@@ -36,7 +36,7 @@ const TimesStopsOutput = ({
     selectedTrain,
     simulatedTrain,
     simulatedPathItemTimes,
-    simulatedOperationalPoints
+    operationalPointsOnPath
   );
   return (
     <TimesStops

--- a/front/src/modules/timesStops/helpers/utils.ts
+++ b/front/src/modules/timesStops/helpers/utils.ts
@@ -4,12 +4,16 @@ import dayjs from 'dayjs';
 import type { TFunction } from 'i18next';
 import { round, isEqual, isNil } from 'lodash';
 
-import type { PositionedOperationalPoint } from 'applications/operationalStudies/types';
 import {
   getInvalidStepLabel,
   isOperationalPointReference,
 } from 'applications/operationalStudies/utils';
-import type { PathItemLocation, ReceptionSignal, TrackReference } from 'common/api/osrdEditoastApi';
+import type {
+  OperationalPoint,
+  PathItemLocation,
+  ReceptionSignal,
+  TrackReference,
+} from 'common/api/osrdEditoastApi';
 import type { TimeString } from 'common/types';
 import { matchPathStepAndOp } from 'modules/pathfinding/utils';
 import type { SuggestedOP } from 'modules/timetableItem/types';
@@ -347,10 +351,7 @@ export function receptionSignalToSignalBooleans(receptionSignal?: ReceptionSigna
   return { shortSlipDistance: false, onStopSignal: false };
 }
 
-export const matchOpRefAndOp = (
-  op: PositionedOperationalPoint,
-  opRef: PathItemLocation
-): boolean => {
+export const matchOpRefAndOp = (op: OperationalPoint, opRef: PathItemLocation): boolean => {
   if ('operational_point' in opRef) return op.id === opRef.operational_point;
   if ('trigram' in opRef) {
     return (
@@ -373,7 +374,7 @@ export const getTrackReferenceLabel = (trackReference?: TrackReference | null) =
 };
 
 export const getOperationalPointName = (
-  op: PositionedOperationalPoint | undefined,
+  op: OperationalPoint | undefined,
   step: PathItemLocation,
   mapWaypointCount: number,
   t: TFunction<'operational-studies'>

--- a/front/src/modules/timesStops/hooks/useOutputTableData.ts
+++ b/front/src/modules/timesStops/hooks/useOutputTableData.ts
@@ -43,21 +43,21 @@ const useOutputTableData = (
 
   // Format input path step rows
   useEffect(() => {
-    const formatPathStepRows = async (): Promise<Map<string, Partial<TimesStopsRow>>> => {
-      if (!selectedTrain) return new Map();
-
-      const trackIds = selectedTrain.path.reduce<string[]>((ids, step) => {
+    const formatPathStepRows = async (
+      train: Train
+    ): Promise<Map<string, Partial<TimesStopsRow>>> => {
+      const trackIds = train.path.reduce<string[]>((ids, step) => {
         if ('track' in step) ids.push(step.track);
         return ids;
       }, []);
       const trackSections = await getTrackSectionsByIds(trackIds);
 
-      const startDatetime = new Date(selectedTrain.start_time);
+      const startDatetime = new Date(train.start_time);
       let lastReferenceDate = startDatetime;
       let mapWaypointCount = 0;
 
       return new Map(
-        selectedTrain.path.map((pathStep, index) => {
+        train.path.map((pathStep, index) => {
           const matchingOperationalPoint = pathStepOps.find((op) => matchOpRefAndOp(op, pathStep));
 
           if ('track' in pathStep) mapWaypointCount += 1;
@@ -99,7 +99,7 @@ const useOutputTableData = (
             diffMargins,
           } = computeMargins(
             theoreticalMargins,
-            selectedTrain,
+            train,
             scheduleByAt,
             index,
             simulatedPathItemTimes
@@ -147,7 +147,7 @@ const useOutputTableData = (
         return;
       }
 
-      const pathStepRowsById = await formatPathStepRows();
+      const pathStepRowsById = await formatPathStepRows(selectedTrain);
 
       let formattedRows = Array.from(pathStepRowsById.values());
 

--- a/front/src/modules/timesStops/hooks/useOutputTableData.ts
+++ b/front/src/modules/timesStops/hooks/useOutputTableData.ts
@@ -49,101 +49,103 @@ const useOutputTableData = (
   );
 
   // Format input path step rows
-  const pathStepRowsById: Map<string, Partial<TimesStopsRow>> = useMemo(() => {
-    if (!selectedTrain || !operationalPoints || operationalPoints.length === 0) return new Map();
-
-    const startDatetime = new Date(selectedTrain.start_time);
-    let lastReferenceDate = startDatetime;
-    let mapWaypointCount = 0;
-    return new Map(
-      selectedTrain.path.map((pathStep, index) => {
-        const opPositionOnPath = simulatedPath?.path_item_positions[index];
-        const matchingOperationalPoint = operationalPoints.find((op) =>
-          opPositionOnPath ? op.position === opPositionOnPath : matchOpRefAndOp(op, pathStep)
-        );
-
-        if ('track' in pathStep) mapWaypointCount += 1;
-        const name = getOperationalPointName(
-          matchingOperationalPoint,
-          pathStep,
-          mapWaypointCount,
-          t
-        );
-
-        const schedule = scheduleByAt[pathStep.id];
-        const computedArrival = simulatedPathItemTimes
-          ? new Date(startDatetime.getTime() + simulatedPathItemTimes.final[index])
-          : undefined;
-        const { stopFor, shortSlipDistance, onStopSignal, calculatedDeparture } = formatSchedule(
-          computedArrival,
-          schedule,
-          dateTimeLocale
-        );
-        const { theoreticalArrival, arrival, departure, refDate } = computeInputDatetimes(
-          startDatetime,
-          lastReferenceDate,
-          schedule,
-          {
-            isDeparture: index === 0,
-          }
-        );
-        lastReferenceDate = refDate;
-
-        const {
-          theoreticalMargin,
-          isTheoreticalMarginBoundary,
-          theoreticalMarginSeconds,
-          calculatedMargin,
-          diffMargins,
-        } = computeMargins(
-          theoreticalMargins,
-          selectedTrain,
-          scheduleByAt,
-          index,
-          simulatedPathItemTimes
-        );
-
-        const isOnTime =
-          theoreticalArrival && computedArrival
-            ? Duration.subtractDate(theoreticalArrival, computedArrival).abs() <=
-              ARRIVAL_TIME_ACCEPTABLE_ERROR
-            : false;
-        const calculatedArrival = computedArrival
-          ? (isOnTime ? theoreticalArrival! : computedArrival).toLocaleTimeString(dateTimeLocale)
-          : undefined;
-
-        const pathStepRow = {
-          pathStepId: pathStep.id,
-          opId: matchingOperationalPoint?.id,
-          name,
-          ch: matchingOperationalPoint?.extensions?.sncf?.ch,
-
-          arrival,
-          departure,
-          stopFor,
-          onStopSignal,
-          shortSlipDistance,
-          theoreticalMargin,
-          isTheoreticalMarginBoundary,
-
-          theoreticalMarginSeconds,
-          calculatedMargin,
-          diffMargins,
-          calculatedArrival,
-          calculatedDeparture,
-        };
-
-        return [pathStepRow.pathStepId, pathStepRow];
-      })
-    );
-  }, [selectedTrain, simulatedPath, simulatedPathItemTimes, operationalPoints]);
-
   useEffect(() => {
+    const formatPathStepRows = (): Map<string, Partial<TimesStopsRow>> => {
+      if (!selectedTrain || !operationalPoints || operationalPoints.length === 0) return new Map();
+
+      const startDatetime = new Date(selectedTrain.start_time);
+      let lastReferenceDate = startDatetime;
+      let mapWaypointCount = 0;
+      return new Map(
+        selectedTrain.path.map((pathStep, index) => {
+          const opPositionOnPath = simulatedPath?.path_item_positions[index];
+          const matchingOperationalPoint = operationalPoints.find((op) =>
+            opPositionOnPath ? op.position === opPositionOnPath : matchOpRefAndOp(op, pathStep)
+          );
+
+          if ('track' in pathStep) mapWaypointCount += 1;
+          const name = getOperationalPointName(
+            matchingOperationalPoint,
+            pathStep,
+            mapWaypointCount,
+            t
+          );
+
+          const schedule = scheduleByAt[pathStep.id];
+          const computedArrival = simulatedPathItemTimes
+            ? new Date(startDatetime.getTime() + simulatedPathItemTimes.final[index])
+            : undefined;
+          const { stopFor, shortSlipDistance, onStopSignal, calculatedDeparture } = formatSchedule(
+            computedArrival,
+            schedule,
+            dateTimeLocale
+          );
+          const { theoreticalArrival, arrival, departure, refDate } = computeInputDatetimes(
+            startDatetime,
+            lastReferenceDate,
+            schedule,
+            {
+              isDeparture: index === 0,
+            }
+          );
+          lastReferenceDate = refDate;
+
+          const {
+            theoreticalMargin,
+            isTheoreticalMarginBoundary,
+            theoreticalMarginSeconds,
+            calculatedMargin,
+            diffMargins,
+          } = computeMargins(
+            theoreticalMargins,
+            selectedTrain,
+            scheduleByAt,
+            index,
+            simulatedPathItemTimes
+          );
+
+          const isOnTime =
+            theoreticalArrival && computedArrival
+              ? Duration.subtractDate(theoreticalArrival, computedArrival).abs() <=
+                ARRIVAL_TIME_ACCEPTABLE_ERROR
+              : false;
+          const calculatedArrival = computedArrival
+            ? (isOnTime ? theoreticalArrival! : computedArrival).toLocaleTimeString(dateTimeLocale)
+            : undefined;
+
+          const pathStepRow = {
+            pathStepId: pathStep.id,
+            opId: matchingOperationalPoint?.id,
+            name,
+            ch: matchingOperationalPoint?.extensions?.sncf?.ch,
+
+            arrival,
+            departure,
+            stopFor,
+            onStopSignal,
+            shortSlipDistance,
+            theoreticalMargin,
+            isTheoreticalMarginBoundary,
+
+            theoreticalMarginSeconds,
+            calculatedMargin,
+            diffMargins,
+            calculatedArrival,
+            calculatedDeparture,
+          };
+
+          return [pathStepRow.pathStepId, pathStepRow];
+        })
+      );
+    };
+
     const formatRows = async () => {
       if (!selectedTrain || !operationalPoints) {
         setRows([]);
         return;
       }
+
+      const pathStepRowsById = formatPathStepRows();
 
       let formattedRows;
 
@@ -220,7 +222,7 @@ const useOutputTableData = (
     };
 
     formatRows();
-  }, [operationalPoints, pathStepRowsById, simulatedTrain, getTrackSectionsByIds]);
+  }, [operationalPoints, simulatedTrain, getTrackSectionsByIds]);
 
   return rows;
 };

--- a/front/src/modules/timesStops/hooks/useOutputTableData.ts
+++ b/front/src/modules/timesStops/hooks/useOutputTableData.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { keyBy } from 'lodash';
 import { useTranslation } from 'react-i18next';
@@ -6,10 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { useScenarioContext } from 'applications/operationalStudies/hooks/useScenarioContext';
 import useTrainOps from 'applications/operationalStudies/hooks/useTrainOps';
 import type { PathPropertiesFormatted } from 'applications/operationalStudies/types';
-import type {
-  PathfindingResultSuccess,
-  SimulationResponseSuccess,
-} from 'common/api/osrdEditoastApi';
+import type { SimulationResponseSuccess } from 'common/api/osrdEditoastApi';
 import { matchPathStepAndOp } from 'modules/pathfinding/utils';
 import { interpolateValue } from 'modules/simulationResult/SimulationResultExport/utils';
 import type { SimulationSummary } from 'modules/timetableItem/types';
@@ -29,30 +26,25 @@ const useOutputTableData = (
   isValid: boolean,
   selectedTrain?: Train,
   simulatedTrain?: SimulationResponseSuccess['final_output'],
-  simulatedPath?: PathfindingResultSuccess,
   simulatedPathItemTimes?: Extract<SimulationSummary, { isValid: true }>['pathItemTimes'],
-  simulatedOperationalPoints?: PathPropertiesFormatted['operationalPoints']
+  operationalPointsOnPath?: PathPropertiesFormatted['operationalPoints']
 ): TimesStopsRow[] => {
   const { t } = useTranslation('operational-studies');
   const dateTimeLocale = useDateTimeLocale();
   const { getTrackSectionsByIds } = useScenarioContext();
 
-  const [rows, setRows] = useState<TimesStopsRow[]>([]);
+  const pathStepOps = useTrainOps(infraId, selectedTrain);
 
-  const trainOperationalPoints = useTrainOps(infraId, selectedTrain);
+  const [rows, setRows] = useState<TimesStopsRow[]>([]);
 
   // Extract common properties between valid and invalid trains
   const scheduleByAt: Record<string, ScheduleEntry> = keyBy(selectedTrain?.schedule, 'at');
   const theoreticalMargins = selectedTrain && getTheoreticalMargins(selectedTrain);
-  const operationalPoints = useMemo(
-    () => simulatedOperationalPoints ?? trainOperationalPoints,
-    [simulatedOperationalPoints, trainOperationalPoints]
-  );
 
   // Format input path step rows
   useEffect(() => {
     const formatPathStepRows = async (): Promise<Map<string, Partial<TimesStopsRow>>> => {
-      if (!selectedTrain || !operationalPoints || operationalPoints.length === 0) return new Map();
+      if (!selectedTrain) return new Map();
 
       const trackIds = selectedTrain.path.reduce<string[]>((ids, step) => {
         if ('track' in step) ids.push(step.track);
@@ -66,10 +58,7 @@ const useOutputTableData = (
 
       return new Map(
         selectedTrain.path.map((pathStep, index) => {
-          const opPositionOnPath = simulatedPath?.path_item_positions[index];
-          const matchingOperationalPoint = operationalPoints.find((op) =>
-            opPositionOnPath ? op.position === opPositionOnPath : matchOpRefAndOp(op, pathStep)
-          );
+          const matchingOperationalPoint = pathStepOps.find((op) => matchOpRefAndOp(op, pathStep));
 
           if ('track' in pathStep) mapWaypointCount += 1;
           const name = getOperationalPointName(
@@ -153,7 +142,7 @@ const useOutputTableData = (
     };
 
     const formatRows = async () => {
-      if (!selectedTrain || !operationalPoints) {
+      if (!selectedTrain) {
         setRows([]);
         return;
       }
@@ -163,11 +152,11 @@ const useOutputTableData = (
       let formattedRows = Array.from(pathStepRowsById.values());
 
       // For valid trains, complete the rows with the simulated path's operational points and tracks information
-      if (isValid && simulatedTrain) {
-        const trackIds = operationalPoints.map((op) => op.part.track);
+      if (isValid && simulatedTrain && operationalPointsOnPath) {
+        const trackIds = operationalPointsOnPath.map((op) => op.part.track);
         const trackSectionsOnPath = await getTrackSectionsByIds(trackIds);
 
-        formattedRows = operationalPoints.map((op) => {
+        formattedRows = operationalPointsOnPath.map((op) => {
           const trackName = trackSectionsOnPath[op.part.track]?.extensions?.sncf?.track_name;
 
           // early return if the op matches a pathStep (handled in formatPathStepRows)
@@ -216,7 +205,7 @@ const useOutputTableData = (
     };
 
     formatRows();
-  }, [operationalPoints, simulatedTrain, getTrackSectionsByIds]);
+  }, [pathStepOps, operationalPointsOnPath, simulatedTrain, getTrackSectionsByIds]);
 
   return rows;
 };

--- a/front/src/modules/timesStops/hooks/useOutputTableData.ts
+++ b/front/src/modules/timesStops/hooks/useOutputTableData.ts
@@ -50,12 +50,19 @@ const useOutputTableData = (
 
   // Format input path step rows
   useEffect(() => {
-    const formatPathStepRows = (): Map<string, Partial<TimesStopsRow>> => {
+    const formatPathStepRows = async (): Promise<Map<string, Partial<TimesStopsRow>>> => {
       if (!selectedTrain || !operationalPoints || operationalPoints.length === 0) return new Map();
+
+      const trackIds = selectedTrain.path.reduce<string[]>((ids, step) => {
+        if ('track' in step) ids.push(step.track);
+        return ids;
+      }, []);
+      const trackSections = await getTrackSectionsByIds(trackIds);
 
       const startDatetime = new Date(selectedTrain.start_time);
       let lastReferenceDate = startDatetime;
       let mapWaypointCount = 0;
+
       return new Map(
         selectedTrain.path.map((pathStep, index) => {
           const opPositionOnPath = simulatedPath?.path_item_positions[index];
@@ -70,6 +77,10 @@ const useOutputTableData = (
             mapWaypointCount,
             t
           );
+          const trackName =
+            'track' in pathStep
+              ? trackSections[pathStep.track]?.extensions?.sncf?.track_name
+              : getTrackReferenceLabel(pathStep.track_reference);
 
           const schedule = scheduleByAt[pathStep.id];
           const computedArrival = simulatedPathItemTimes
@@ -118,6 +129,7 @@ const useOutputTableData = (
             opId: matchingOperationalPoint?.id,
             name,
             ch: matchingOperationalPoint?.extensions?.sncf?.ch,
+            trackName,
 
             arrival,
             departure,
@@ -145,17 +157,20 @@ const useOutputTableData = (
         return;
       }
 
-      const pathStepRowsById = formatPathStepRows();
+      const pathStepRowsById = await formatPathStepRows();
 
-      let formattedRows;
+      let formattedRows = Array.from(pathStepRowsById.values());
 
       // For valid trains, complete the rows with the simulated path's operational points and tracks information
       if (isValid && simulatedTrain) {
         const trackIds = operationalPoints.map((op) => op.part.track);
-        const trackSections = await getTrackSectionsByIds(trackIds);
+        const trackSectionsOnPath = await getTrackSectionsByIds(trackIds);
 
         formattedRows = operationalPoints.map((op) => {
-          const trackName = trackSections[op.part.track]?.extensions?.sncf?.track_name;
+          const trackName = trackSectionsOnPath[op.part.track]?.extensions?.sncf?.track_name;
+
+          // early return if the op matches a pathStep (handled in formatPathStepRows)
+          // only add the trackName which has been found by the pathfinding (if not precised in the pathStep)
           const matchingPathStep = selectedTrain.path.find((pathStep) =>
             matchPathStepAndOp(pathStep, {
               opId: op.id,
@@ -166,11 +181,9 @@ const useOutputTableData = (
               offsetOnTrack: op.part.position,
             })
           );
-
           const matchingPathStepRow = matchingPathStep
             ? pathStepRowsById.get(matchingPathStep.id)
             : undefined;
-
           if (matchingPathStepRow) {
             return {
               ...matchingPathStepRow,
@@ -194,26 +207,6 @@ const useOutputTableData = (
             ch: op.extensions?.sncf?.ch,
             trackName,
             calculatedArrival: calculatedArrival.toLocaleTimeString(dateTimeLocale),
-          };
-        });
-      } else {
-        const trackIds = selectedTrain.path
-          .filter((step) => 'track' in step)
-          .map((step) => step.track);
-        const trackSections = await getTrackSectionsByIds(trackIds);
-
-        formattedRows = Array.from(pathStepRowsById.values()).map((pathStepRow, index) => {
-          const matchingPathStep = selectedTrain.path[index];
-
-          // We check if a specific track has been selected when clicking on the map
-          const trackName =
-            'track' in matchingPathStep
-              ? trackSections[matchingPathStep.track]?.extensions?.sncf?.track_name
-              : getTrackReferenceLabel(matchingPathStep.track_reference);
-
-          return {
-            ...pathStepRow,
-            trackName,
           };
         });
       }

--- a/front/src/modules/timesStops/hooks/useOutputTableData.ts
+++ b/front/src/modules/timesStops/hooks/useOutputTableData.ts
@@ -3,8 +3,8 @@ import { useEffect, useMemo, useState } from 'react';
 import { keyBy } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
-import useInvalidTrainOps from 'applications/operationalStudies/hooks/useInvalidTrainOps';
 import { useScenarioContext } from 'applications/operationalStudies/hooks/useScenarioContext';
+import useTrainOps from 'applications/operationalStudies/hooks/useTrainOps';
 import type { PathPropertiesFormatted } from 'applications/operationalStudies/types';
 import type {
   PathfindingResultSuccess,
@@ -39,13 +39,14 @@ const useOutputTableData = (
 
   const [rows, setRows] = useState<TimesStopsRow[]>([]);
 
+  const trainOperationalPoints = useTrainOps(infraId, selectedTrain);
+
   // Extract common properties between valid and invalid trains
   const scheduleByAt: Record<string, ScheduleEntry> = keyBy(selectedTrain?.schedule, 'at');
   const theoreticalMargins = selectedTrain && getTheoreticalMargins(selectedTrain);
-  const invalidTrainOperationalPoints = useInvalidTrainOps(infraId, isValid, selectedTrain);
   const operationalPoints = useMemo(
-    () => simulatedOperationalPoints ?? invalidTrainOperationalPoints,
-    [simulatedOperationalPoints, invalidTrainOperationalPoints]
+    () => simulatedOperationalPoints ?? trainOperationalPoints,
+    [simulatedOperationalPoints, trainOperationalPoints]
   );
 
   // Format input path step rows


### PR DESCRIPTION
The goal of this PR is to make the logic of useOutputTableData more linear:
- complete processing of rows corresponding to pathSteps
- insertion of rows corresponding to waypoints on the path

Previously, pathStep rows were processed in both the first and second steps (to add the trackName).