### PR TITLE
enhance e2e tests with test.step() for clearer reporting

### DIFF
--- a/front/tests/002-project-management.spec.ts
+++ b/front/tests/002-project-management.spec.ts
@@ -21,81 +21,93 @@ test.describe('Validate the Operational Study Project workflow', () => {
 
   /** *************** Test 1 **************** */
   test('Create a new project', async ({ page }) => {
-    // Go to projects page
-    await page.goto('/operational-studies/projects');
-
-    // Define a unique project name for the test
     const projectName = generateUniqueName(projectData.name);
 
-    // Create a new project using the project page model and json data
-    await projectPage.createProject({
-      name: projectName,
-      description: projectData.description,
-      objectives: projectData.objectives,
-      funders: projectData.funders,
-      budget: projectData.budget,
-      tags: projectData.tags,
+    await test.step('Go to projects page', async () => {
+      await page.goto('/operational-studies/projects');
     });
 
-    // Validate that the project was created with the correct data
-    await projectPage.validateProjectData({
-      name: projectName,
-      description: projectData.description,
-      objectives: projectData.objectives,
-      funders: projectData.funders,
-      budget: projectData.budget,
-      tags: projectData.tags,
+    await test.step('Create project via UI', async () => {
+      await projectPage.createProject({
+        name: projectName,
+        description: projectData.description,
+        objectives: projectData.objectives,
+        funders: projectData.funders,
+        budget: projectData.budget,
+        tags: projectData.tags,
+      });
     });
 
-    // Delete the created project
-    await deleteProject(projectName);
+    await test.step('Validate created project data', async () => {
+      await projectPage.validateProjectData({
+        name: projectName,
+        description: projectData.description,
+        objectives: projectData.objectives,
+        funders: projectData.funders,
+        budget: projectData.budget,
+        tags: projectData.tags,
+      });
+    });
+
+    await test.step('Delete created project', async () => {
+      await deleteProject(projectName);
+    });
   });
 
   /** *************** Test 2 **************** */
   test('Update an existing project', async ({ page }) => {
-    // Create a project
-    project = await createProject(generateUniqueName(projectData.name));
-    await page.goto('/operational-studies/projects');
-
-    // Open the created project by name using the project page model
-    await projectPage.openProjectByTestId(project.name);
-
-    // Update the project data and save it
-    await projectPage.updateProject({
-      name: `${project.name} (updated)`,
-      description: `${project.description} (updated)`,
-      objectives: `${projectData.objectives} (updated)`,
-      funders: `${project.funders} (updated)`,
-      budget: '123456789',
-      tags: ['update-tag'],
+    await test.step('Create a base project', async () => {
+      project = await createProject(generateUniqueName(projectData.name));
     });
 
-    // Navigate back to the Operational Studies page via the home page
-    await projectPage.backToHomePage();
-    await projectPage.goToOperationalStudiesPage();
-
-    // Reopen the updated project and validate the updated data
-    await projectPage.openProjectByTestId(`${project.name} (updated)`);
-    await projectPage.validateProjectData({
-      name: `${project.name} (updated)`,
-      description: `${project.description} (updated)`,
-      objectives: `${projectData.objectives} (updated)`,
-      funders: `${project.funders} (updated)`,
-      budget: '123456789',
-      tags: ['update-tag'],
+    await test.step('Open created project from projects list', async () => {
+      await page.goto('/operational-studies/projects');
+      await projectPage.openProjectByTestId(project.name);
     });
-    // Delete the created project
-    await deleteProject(`${project.name} (updated)`);
+
+    await test.step('Update than save project details', async () => {
+      await projectPage.updateProject({
+        name: `${project.name} (updated)`,
+        description: `${project.description} (updated)`,
+        objectives: `${projectData.objectives} (updated)`,
+        funders: `${project.funders} (updated)`,
+        budget: '123456789',
+        tags: ['update-tag'],
+      });
+    });
+
+    await test.step('Navigate back to operational studies page via home page', async () => {
+      await projectPage.backToHomePage();
+      await projectPage.goToOperationalStudiesPage();
+    });
+
+    await test.step('Reopen updated project and validate data', async () => {
+      await projectPage.openProjectByTestId(`${project.name} (updated)`);
+      await projectPage.validateProjectData({
+        name: `${project.name} (updated)`,
+        description: `${project.description} (updated)`,
+        objectives: `${projectData.objectives} (updated)`,
+        funders: `${project.funders} (updated)`,
+        budget: '123456789',
+        tags: ['update-tag'],
+      });
+    });
+
+    await test.step('Delete updated project', async () => {
+      await deleteProject(`${project.name} (updated)`);
+    });
   });
 
   /** *************** Test 3 **************** */
   test('Delete a project', async ({ page }) => {
-    // Create a project
-    project = await createProject(generateUniqueName(projectData.name));
-    await page.goto('/operational-studies/projects');
+    await test.step('Create a project to delete', async () => {
+      project = await createProject(generateUniqueName(projectData.name));
+    });
 
-    // Find the project by name and delete it using the page model
-    await projectPage.openProjectByTestId(project.name);
-    await projectPage.deleteProject(project.name);
+    await test.step('Open project and delete it', async () => {
+      await page.goto('/operational-studies/projects');
+      await projectPage.openProjectByTestId(project.name);
+      await projectPage.deleteProject(project.name);
+    });
   });
 });

--- a/front/tests/003-study-management.spec.ts
+++ b/front/tests/003-study-management.spec.ts
@@ -11,17 +11,11 @@ import { formatDateToDayMonthYear } from './utils/date-utils';
 import readJsonFile from './utils/file-utils';
 import { createStudy } from './utils/setup-utils';
 import { deleteStudy } from './utils/teardown-utils';
-import type { FlatTranslations, StudyData } from './utils/types';
-
-type StudyfrTranslations = {
-  study: {
-    studyCategories: FlatTranslations;
-    studyStates: FlatTranslations;
-  };
-};
+import type { StudyData, StudyFrTranslations } from './utils/types';
 
 const studyData: StudyData = readJsonFile('tests/assets/operation-studies/study.json');
-const frTranslations: StudyfrTranslations = readJsonFile(
+
+const frTranslations: StudyFrTranslations = readJsonFile(
   'public/locales/fr/operational-studies.json'
 );
 

--- a/front/tests/003-study-management.spec.ts
+++ b/front/tests/003-study-management.spec.ts
@@ -95,38 +95,45 @@ test.describe('Validate the Study creation workflow', () => {
       tags: ['update-tag'],
     });
 
-    await studyPage.validateStudyData({
-      name: `${study.name} (updated)`,
-      description: `${study.description} (updated)`,
-      type: frTranslations.study.studyCategories.operability,
-      status: frTranslations.study.studyStates.inProgress,
-      startDate: expectedDate,
-      expectedEndDate: expectedDate,
-      endDate: expectedDate,
-      serviceCode: 'A1230',
-      businessCode: 'B1230',
-      budget: '123456789',
-      tags: ['update-tag'],
-      isUpdate: true, // Indicate that this is an update
+    await test.step('Validate updated study data', async () => {
+      await studyPage.validateStudyData({
+        name: `${study.name} (updated)`,
+        description: `${study.description} (updated)`,
+        type: frTranslations.study.studyCategories.operability,
+        status: frTranslations.study.studyStates.inProgress,
+        startDate: expectedDate,
+        expectedEndDate: expectedDate,
+        endDate: expectedDate,
+        serviceCode: 'A1230',
+        businessCode: 'B1230',
+        budget: '123456789',
+        tags: ['update-tag'],
+        isUpdate: true,
+      });
     });
 
-    // Navigate back to the project page
-    await page.goto(`/operational-studies/projects/${project.id}`);
+    await test.step('Verify updated study in project list (tags)', async () => {
+      await page.goto(`/operational-studies/projects/${project.id}`);
+      await expect(page.getByTestId(`${study.name} (updated)`).first()).toBeVisible();
+    });
 
-    await expect(page.getByTestId(`${study.name} (updated)`).first()).toBeVisible();
-
-    await deleteStudy(project.id, `${study.name} (updated)`);
+    await test.step('Delete updated study', async () => {
+      await deleteStudy(project.id, `${study.name} (updated)`);
+    });
   });
 
   /** *************** Test 3 **************** */
   test('Delete a study', async ({ page }) => {
-    // Create a study
-    study = await createStudy(project.id, generateUniqueName(studyData.name));
+    await test.step('Create a study to delete', async () => {
+      study = await createStudy(project.id, generateUniqueName(studyData.name));
+    });
 
-    // Navigate to the list of studies for the project
-    await page.goto(`/operational-studies/projects/${project.id}`);
+    await test.step('Navigate to project studies list', async () => {
+      await page.goto(`/operational-studies/projects/${project.id}`);
+    });
 
-    // Delete the study by name using the study page model
-    await studyPage.deleteStudy(study.name);
+    await test.step('Delete study by name via UI', async () => {
+      await studyPage.deleteStudy(study.name);
+    });
   });
 });

--- a/front/tests/004-scenario-management.spec.ts
+++ b/front/tests/004-scenario-management.spec.ts
@@ -52,94 +52,104 @@ test.describe('Validate the Scenario creation workflow', () => {
 
   /** *************** Test 1 **************** */
   test('Create a new scenario', async ({ page }) => {
-    // Navigate to the study page for the selected project
-    await page.goto(`/operational-studies/projects/${project.id}/studies/${study.id}`);
+    const scenarioName = generateUniqueName(scenarioData.name);
 
-    const scenarioName = generateUniqueName(scenarioData.name); // Generate a unique scenario name
-
-    // Create a new scenario using the scenario page model
-    await scenarioPage.createScenario({
-      name: scenarioName,
-      description: scenarioData.description,
-      infraName: infrastructureName,
-      tags: scenarioData.tags,
-      electricProfileName: electricalProfileSet.name,
+    await test.step('Navigate to study page', async () => {
+      await page.goto(`/operational-studies/projects/${project.id}/studies/${study.id}`);
     });
-    await waitForInfraStateToBeCached(infra.id);
 
-    // Validate that the scenario was created with the correct data
-    await scenarioPage.validateScenarioData({
-      name: scenarioName,
-      description: scenarioData.description,
-      infraName: infrastructureName,
+    await test.step('Create scenario via UI', async () => {
+      await scenarioPage.createScenario({
+        name: scenarioName,
+        description: scenarioData.description,
+        infraName: infrastructureName,
+        tags: scenarioData.tags,
+        electricProfileName: electricalProfileSet.name,
+      });
+      await waitForInfraStateToBeCached(infra.id);
     });
-    await deleteScenario(project.id, study.id, scenarioName);
+
+    await test.step('Validate created scenario data', async () => {
+      await scenarioPage.validateScenarioData({
+        name: scenarioName,
+        description: scenarioData.description,
+        infraName: infrastructureName,
+      });
+    });
+
+    await test.step('Delete created scenario', async () => {
+      await deleteScenario(project.id, study.id, scenarioName);
+    });
   });
 
   /** *************** Test 2 **************** */
   test('Update an existing scenario', async ({ page }) => {
-    // Set up a scenario
-    ({ project, study, scenario } = await createScenario());
+    await test.step('Create a base scenario', async () => {
+      ({ project, study, scenario } = await createScenario());
+    });
 
-    // Navigate to the specific scenario page
-    await page.goto(`/operational-studies/projects/${project.id}/studies/${study.id}`);
-    await scenarioPage.openScenarioByName(scenario.name);
+    await test.step('Open scenario from study page and wait infra cache', async () => {
+      await page.goto(`/operational-studies/projects/${project.id}/studies/${study.id}`);
+      await scenarioPage.openScenarioByName(scenario.name);
+      await waitForInfraStateToBeCached(scenario.infra_id);
+    });
 
-    // Wait for infra to be in 'CACHED' state before proceeding
-    await waitForInfraStateToBeCached(scenario.infra_id);
-
-    // Update the scenario with new details
     const updatedScenarioName = generateUniqueName(`${scenarioData.name}(updated)`);
-    await scenarioPage.updateScenario({
-      name: updatedScenarioName,
-      description: `${scenario.description} (updated)`,
-      tags: ['update-tag'],
+    await test.step('Update scenario details', async () => {
+      await scenarioPage.updateScenario({
+        name: updatedScenarioName,
+        description: `${scenario.description} (updated)`,
+        tags: ['update-tag'],
+      });
     });
 
-    await scenarioPage.validateScenarioData({
-      name: updatedScenarioName,
-      description: `${scenario.description} (updated)`,
-      infraName: infrastructureName,
-      isUpdating: true,
+    await test.step('Validate updated scenario (in scenario page)', async () => {
+      await scenarioPage.validateScenarioData({
+        name: updatedScenarioName,
+        description: `${scenario.description} (updated)`,
+        infraName: infrastructureName,
+        isUpdating: true,
+      });
     });
 
-    // Navigate back to the study page to verify the updated tags
-    await page.goto(`/operational-studies/projects/${project.id}/studies/${study.id}`);
-
-    // Assert that the updated tags include the new 'update-tag'
-    expect(await scenarioPage.getScenarioTags(updatedScenarioName).textContent()).toContain(
-      `${scenarioData.tags.join('')}update-tag`
-    );
-
-    // Reopen the updated scenario and validate the updated data
-    await scenarioPage.openScenarioByName(updatedScenarioName);
-    await scenarioPage.validateScenarioData({
-      name: updatedScenarioName,
-      description: `${scenario.description} (updated)`,
-      infraName: infrastructureName,
+    await test.step('Validate scenario tags in study page list', async () => {
+      await page.goto(`/operational-studies/projects/${project.id}/studies/${study.id}`);
+      expect(await scenarioPage.getScenarioTags(updatedScenarioName).textContent()).toContain(
+        `${scenarioData.tags.join('')}update-tag`
+      );
     });
 
-    // Delete the scenario
-    await deleteScenario(project.id, study.id, updatedScenarioName);
+    await test.step('Reopen updated scenario and re-validate', async () => {
+      await scenarioPage.openScenarioByName(updatedScenarioName);
+      await scenarioPage.validateScenarioData({
+        name: updatedScenarioName,
+        description: `${scenario.description} (updated)`,
+        infraName: infrastructureName,
+      });
+    });
+
+    await test.step('Delete updated scenario', async () => {
+      await deleteScenario(project.id, study.id, updatedScenarioName);
+    });
   });
 
   /** *************** Test 3 **************** */
   test('Delete a scenario', async ({ page }) => {
-    // Set up a scenario
-    ({ project, study, scenario } = await createScenario());
+    await test.step('Create a scenario to delete', async () => {
+      ({ project, study, scenario } = await createScenario());
+    });
 
-    // Navigate to the specific scenario page
-    await page.goto(`/operational-studies/projects/${project.id}/studies/${study.id}`);
-    await scenarioPage.openScenarioByName(scenario.name);
-    await waitForInfraStateToBeCached(infra.id);
-    // Initiate the deletion of the scenario
-    await scenarioPage.openScenarioEditForm();
-    await scenarioPage.deleteScenario();
+    await test.step('Open scenario and delete via edit form', async () => {
+      await page.goto(`/operational-studies/projects/${project.id}/studies/${study.id}`);
+      await scenarioPage.openScenarioByName(scenario.name);
+      await waitForInfraStateToBeCached(infra.id);
+      await scenarioPage.openScenarioEditForm();
+      await scenarioPage.deleteScenario();
+    });
 
-    // Navigate back to the study page
-    await page.goto(`/operational-studies/projects/${project.id}/studies/${study.id}`);
-
-    // Ensure that the scenario is no longer visible
-    await expect(scenarioPage.getScenarioByName(scenario.name)).not.toBeVisible();
+    await test.step('Verify scenario no longer visible in study page', async () => {
+      await page.goto(`/operational-studies/projects/${project.id}/studies/${study.id}`);
+      await expect(scenarioPage.getScenarioByName(scenario.name)).not.toBeVisible();
+    });
   });
 });

--- a/front/tests/005-rolling-stock-editor.spec.ts
+++ b/front/tests/005-rolling-stock-editor.spec.ts
@@ -12,6 +12,10 @@ import { generateUniqueName, verifyAndCheckInputById, fillAndCheckInputById } fr
 import { deleteRollingStocks } from './utils/teardown-utils';
 import type { RollingStockDetails } from './utils/types';
 
+const rollingstockDetails: RollingStockDetails = readJsonFile(
+  './tests/assets/rolling-stock/rolling-stock-details.json'
+);
+
 test.describe('Rollingstock editor page tests', () => {
   let rollingStockEditorPage: RollingstockEditorPage;
   let rollingStockSelector: RollingStockSelector;
@@ -20,18 +24,13 @@ test.describe('Rollingstock editor page tests', () => {
   let uniqueUpdatedRollingStockName: string;
   let uniqueDeletedRollingStockName: string;
 
-  const rollingstockDetails: RollingStockDetails = readJsonFile(
-    './tests/assets/rolling-stock/rolling-stock-details.json'
-  );
+  test.beforeEach(async ({ page }) => {
+    [rollingStockEditorPage, rollingStockSelector] = [
+      new RollingstockEditorPage(page),
+      new RollingStockSelector(page),
+    ];
 
-  test.beforeEach(
-    'Generate unique names and ensure all existing RS are deleted',
-    async ({ page }) => {
-      [rollingStockEditorPage, rollingStockSelector] = [
-        new RollingstockEditorPage(page),
-        new RollingStockSelector(page),
-      ];
-
+    await test.step('Generate unique names and cleanup any leftovers', async () => {
       uniqueRollingStockName = generateUniqueName('RSN');
       uniqueUpdatedRollingStockName = generateUniqueName('U_RSN');
       uniqueDeletedRollingStockName = generateUniqueName('D_RSN');
@@ -41,201 +40,235 @@ test.describe('Rollingstock editor page tests', () => {
         uniqueUpdatedRollingStockName,
         uniqueDeletedRollingStockName,
       ]);
+    });
 
-      // Navigate to the rolling stock editor page
+    await test.step('Navigate to editor and ensure first card is visible', async () => {
       await rollingStockEditorPage.navigateToRollingStockPage();
       await rollingStockEditorPage.verifyFirstRollingStockCardVisibility();
-    }
-  );
+    });
+  });
 
   /** *************** Test 1 **************** */
   test('Create a new rolling stock', async ({ page }) => {
-    // Start the rolling stock creation process
-    await rollingStockEditorPage.openNewRollingStockForm();
+    await test.step('Open creation form', async () => {
+      await rollingStockEditorPage.openNewRollingStockForm();
+    });
 
-    // Fill in the rolling stock details with a unique name
-    for (const input of rollingstockDetails.inputs) {
-      const value = input.id === 'name' ? uniqueRollingStockName : input.value;
-      await fillAndCheckInputById(page, input.id, value, input.isNumeric);
-    }
-    await rollingStockEditorPage.selectLoadingGauge('GA'); // Select loading gauge
+    await test.step('Fill base details and loading gauge', async () => {
+      for (const input of rollingstockDetails.inputs) {
+        const value = input.id === 'name' ? uniqueRollingStockName : input.value;
+        await fillAndCheckInputById(page, input.id, value, input.isNumeric);
+      }
+      await rollingStockEditorPage.selectLoadingGauge('GA');
+    });
 
-    // Select a primary category and other categories, checking each time the state of selector and checkboxes are correct
-    await rollingStockEditorPage.selectPrimaryCategory('WORK_TRAIN');
-    await rollingStockEditorPage.selectPrimaryCategory('NIGHT_TRAIN');
-    await rollingStockEditorPage.uncheckCategoryCheckbox('WORK_TRAIN');
-    await rollingStockEditorPage.selectPrimaryCategory('WORK_TRAIN');
-    await rollingStockEditorPage.selectPrimaryCategory('NIGHT_TRAIN');
-    await rollingStockEditorPage.checkCategoryCheckbox('FREIGHT_TRAIN');
-    await rollingStockEditorPage.checkCategoryCheckbox('FAST_FREIGHT_TRAIN');
-    await rollingStockEditorPage.uncheckCategoryCheckbox('FAST_FREIGHT_TRAIN');
+    await test.step('Select categories (primary + other )', async () => {
+      await rollingStockEditorPage.selectPrimaryCategory('WORK_TRAIN');
+      await rollingStockEditorPage.selectPrimaryCategory('NIGHT_TRAIN');
+      await rollingStockEditorPage.uncheckCategoryCheckbox('WORK_TRAIN');
+      await rollingStockEditorPage.selectPrimaryCategory('WORK_TRAIN');
+      await rollingStockEditorPage.selectPrimaryCategory('NIGHT_TRAIN');
+      await rollingStockEditorPage.checkCategoryCheckbox('FREIGHT_TRAIN');
+      await rollingStockEditorPage.checkCategoryCheckbox('FAST_FREIGHT_TRAIN');
+      await rollingStockEditorPage.uncheckCategoryCheckbox('FAST_FREIGHT_TRAIN');
+    });
 
-    // Submit and handle potential warnings
-    await rollingStockEditorPage.submitRollingstock();
-    await expect(rollingStockEditorPage.toastContainer).toBeVisible();
+    await test.step('Submit initial form and handle warnings', async () => {
+      await rollingStockEditorPage.submitRollingstock();
+      await expect(rollingStockEditorPage.toastContainer).toBeVisible();
+    });
 
-    // Fill in speed effort curves for Not Specified and C1 categories
-    await rollingStockEditorPage.fillSpeedEffortCurves(
-      rollingstockDetails.speedEffortData,
-      false,
-      '',
-      '1500V'
-    );
-    await rollingStockEditorPage.fillSpeedEffortCurves(
-      rollingstockDetails.speedEffortDataC1,
-      true,
-      'C1 ',
-      '1500V'
-    );
+    await test.step('Fill speed effort curves (Not specified + C1)', async () => {
+      await rollingStockEditorPage.fillSpeedEffortCurves(
+        rollingstockDetails.speedEffortData,
+        false,
+        '',
+        '1500V'
+      );
+      await rollingStockEditorPage.fillSpeedEffortCurves(
+        rollingstockDetails.speedEffortDataC1,
+        true,
+        'C1 ',
+        '1500V'
+      );
+    });
 
-    // Fill additional rolling stock details
-    await rollingStockEditorPage.fillAdditionalDetails(rollingstockDetails.additionalDetails);
+    await test.step('Fill additional details', async () => {
+      await rollingStockEditorPage.fillAdditionalDetails(rollingstockDetails.additionalDetails);
+    });
 
-    // Submit and confirm rolling stock creation
-    await rollingStockEditorPage.confirmRollingStockCreation();
-    expect(
-      rollingStockEditorPage.page.getByTestId(`rollingstock-${uniqueRollingStockName}`)
-    ).toBeDefined();
+    await test.step('Submit and confirm rolling stock creation', async () => {
+      await rollingStockEditorPage.confirmRollingStockCreation();
+      expect(
+        rollingStockEditorPage.page.getByTestId(`rollingstock-${uniqueRollingStockName}`)
+      ).toBeDefined();
+    });
 
-    // Verify rolling stock details
-    await rollingStockEditorPage.searchRollingStock(uniqueRollingStockName);
-    await rollingStockEditorPage.verifyRollingStockDetailsTable(rollingstockDetails.expectedValues);
-    await rollingStockEditorPage.editRollingStock(uniqueRollingStockName);
-    for (const input of rollingstockDetails.inputs) {
-      const value = input.id === 'name' ? uniqueRollingStockName : input.value;
-      await verifyAndCheckInputById(page, input.id, value, input.isNumeric);
-    }
+    await test.step('Search and verify rolling stock details', async () => {
+      await rollingStockEditorPage.searchRollingStock(uniqueRollingStockName);
+      await rollingStockEditorPage.verifyRollingStockDetailsTable(
+        rollingstockDetails.expectedValues
+      );
+      await rollingStockEditorPage.editRollingStock(uniqueRollingStockName);
+      for (const input of rollingstockDetails.inputs) {
+        const value = input.id === 'name' ? uniqueRollingStockName : input.value;
+        await verifyAndCheckInputById(page, input.id, value, input.isNumeric);
+      }
+    });
 
-    // Verify speed effort curves
-    await rollingStockEditorPage.openSpeedEffortCurves();
-    await rollingStockEditorPage.verifySpeedEffortCurves(
-      rollingstockDetails.speedEffortData,
-      false,
-      'C1'
-    );
-    await rollingStockEditorPage.verifySpeedEffortCurves(
-      rollingstockDetails.speedEffortDataC1,
-      true,
-      'C1'
-    );
-    await deleteRollingStocks([uniqueRollingStockName]);
+    await test.step('Verify speed effort curves values', async () => {
+      await rollingStockEditorPage.openSpeedEffortCurves();
+      await rollingStockEditorPage.verifySpeedEffortCurves(
+        rollingstockDetails.speedEffortData,
+        false,
+        'C1'
+      );
+      await rollingStockEditorPage.verifySpeedEffortCurves(
+        rollingstockDetails.speedEffortDataC1,
+        true,
+        'C1'
+      );
+    });
+
+    await test.step('Delete created rolling stock', async () => {
+      await deleteRollingStocks([uniqueRollingStockName]);
+    });
   });
 
   /** *************** Test 2 **************** */
   test('Duplicate and modify a rolling stock', async ({ page }) => {
-    // Select the existing electric rolling stock and duplicate it
-    await rollingStockEditorPage.selectRollingStock(electricRollingStockName);
-    await rollingStockEditorPage.duplicateRollingStock();
+    await test.step('Duplicate existing Electric rolling stock', async () => {
+      await rollingStockEditorPage.selectRollingStock(electricRollingStockName);
+      await rollingStockEditorPage.duplicateRollingStock();
+    });
 
-    // Update rolling stock details with a unique name
-    for (const input of rollingstockDetails.updatedInputs) {
-      const value = input.id === 'name' ? uniqueUpdatedRollingStockName : input.value;
-      await fillAndCheckInputById(page, input.id, value, input.isNumeric);
-    }
+    await test.step('Update inputs with a unique name', async () => {
+      for (const input of rollingstockDetails.updatedInputs) {
+        const value = input.id === 'name' ? uniqueUpdatedRollingStockName : input.value;
+        await fillAndCheckInputById(page, input.id, value, input.isNumeric);
+      }
+    });
 
-    // Select new categories
-    await rollingStockEditorPage.selectPrimaryCategory('WORK_TRAIN');
-    await rollingStockEditorPage.checkCategoryCheckbox('HIGH_SPEED_TRAIN');
-    await rollingStockEditorPage.uncheckCategoryCheckbox('FREIGHT_TRAIN');
+    await test.step('Select new categories', async () => {
+      await rollingStockEditorPage.selectPrimaryCategory('WORK_TRAIN');
+      await rollingStockEditorPage.checkCategoryCheckbox('HIGH_SPEED_TRAIN');
+      await rollingStockEditorPage.uncheckCategoryCheckbox('FREIGHT_TRAIN');
+    });
 
-    // Modify and verify speed effort curves
-    await rollingStockEditorPage.openSpeedEffortCurves();
-    await rollingStockEditorPage.deleteElectricalProfile('25000V');
-    await rollingStockEditorPage.fillSpeedEffortData(
-      rollingstockDetails.speedEffortDataUpdated,
-      true,
-      'C1',
-      true
-    );
+    await test.step('Modify speed effort curves', async () => {
+      await rollingStockEditorPage.openSpeedEffortCurves();
+      await rollingStockEditorPage.deleteElectricalProfile('25000V');
+      await rollingStockEditorPage.fillSpeedEffortData(
+        rollingstockDetails.speedEffortDataUpdated,
+        true,
+        'C1',
+        true
+      );
+    });
 
-    // Submit and verify modification
-    await rollingStockEditorPage.confirmRollingStockCreation();
-    await rollingStockEditorPage.searchRollingStock(uniqueUpdatedRollingStockName);
-    await rollingStockEditorPage.verifyRollingStockDetailsTable(
-      rollingstockDetails.updatedExpectedValues
-    );
-    await rollingStockEditorPage.editRollingStock(uniqueUpdatedRollingStockName);
-    await deleteRollingStocks([uniqueUpdatedRollingStockName]);
+    await test.step('Confirm and verify updated rolling stock', async () => {
+      await rollingStockEditorPage.confirmRollingStockCreation();
+      await rollingStockEditorPage.searchRollingStock(uniqueUpdatedRollingStockName);
+      await rollingStockEditorPage.verifyRollingStockDetailsTable(
+        rollingstockDetails.updatedExpectedValues
+      );
+      await rollingStockEditorPage.editRollingStock(uniqueUpdatedRollingStockName);
+    });
+
+    await test.step('Delete duplicated rolling stock', async () => {
+      await deleteRollingStocks([uniqueUpdatedRollingStockName]);
+    });
   });
 
   /** *************** Test 3 **************** */
   test('Duplicate and delete a rolling stock', async ({ page }) => {
-    // Duplicate and change the name of the rolling stock
-    await rollingStockEditorPage.selectRollingStock(electricRollingStockName);
-    await rollingStockEditorPage.duplicateRollingStock();
-    await fillAndCheckInputById(page, 'name', uniqueDeletedRollingStockName);
-    await rollingStockEditorPage.confirmRollingStockCreation();
+    await test.step('Duplicate Electric rolling stock and rename', async () => {
+      await rollingStockEditorPage.selectRollingStock(electricRollingStockName);
+      await rollingStockEditorPage.duplicateRollingStock();
+      await fillAndCheckInputById(page, 'name', uniqueDeletedRollingStockName);
+      await rollingStockEditorPage.confirmRollingStockCreation();
+    });
 
-    // Delete the duplicated rolling stock
-    await rollingStockEditorPage.deleteRollingStock(uniqueDeletedRollingStockName);
-    await expect(
-      rollingStockEditorPage.page.getByTestId(uniqueDeletedRollingStockName)
-    ).toBeHidden();
+    await test.step('Delete duplicated rolling stock and assert hidden', async () => {
+      await rollingStockEditorPage.deleteRollingStock(uniqueDeletedRollingStockName);
+      await expect(
+        rollingStockEditorPage.page.getByTestId(uniqueDeletedRollingStockName)
+      ).toBeHidden();
+    });
 
-    // Search for the deleted rolling stock
-    await rollingStockEditorPage.searchRollingStock(uniqueDeletedRollingStockName);
-
-    // Verify that the count of rolling stock is 0 (No results Found)
-    await expect(rollingStockSelector.noRollingStockResult).toBeVisible();
-    expect(await rollingStockSelector.getRollingStockSearchNumber()).toEqual(0);
+    await test.step('Search deleted rolling stock → expect no results', async () => {
+      await rollingStockEditorPage.searchRollingStock(uniqueDeletedRollingStockName);
+      await expect(rollingStockSelector.noRollingStockResult).toBeVisible();
+      expect(await rollingStockSelector.getRollingStockSearchNumber()).toEqual(0);
+    });
   });
 
   /** *************** Test 4 **************** */
   test('Filtering rolling stocks', async () => {
-    // Get the initial rolling stock count
     const initialRollingStockFoundNumber = await rollingStockSelector.getRollingStockSearchNumber();
 
-    // Filter electric rolling stocks and verify count
-    await rollingStockSelector.toggleElectricRollingStockFilter();
-    expect(await rollingStockSelector.electricRollingStockIcons.count()).toEqual(
-      await rollingStockSelector.getRollingStockSearchNumber()
-    );
-    // Clear electric filter
-    await rollingStockSelector.toggleElectricRollingStockFilter();
+    await test.step('Toggle Electric filter and verify count', async () => {
+      await rollingStockSelector.toggleElectricRollingStockFilter();
+      expect(await rollingStockSelector.electricRollingStockIcons.count()).toEqual(
+        await rollingStockSelector.getRollingStockSearchNumber()
+      );
+    });
 
-    // Filter thermal rolling stocks and verify count
-    await rollingStockSelector.toggleThermalRollingStockFilter();
-    expect(await rollingStockSelector.thermalRollingStockIcons.count()).toEqual(
-      await rollingStockSelector.getRollingStockSearchNumber()
-    );
+    await test.step('Clear Electric filter and verify initial count', async () => {
+      await rollingStockSelector.toggleElectricRollingStockFilter();
+      expect(await rollingStockSelector.rollingStockList.count()).toBeGreaterThanOrEqual(
+        initialRollingStockFoundNumber
+      );
+    });
 
-    // Filter both electric and thermal rolling stocks (dual-mode) and verify count
-    await rollingStockSelector.toggleElectricRollingStockFilter();
-    expect(await rollingStockSelector.dualModeRollingStockIcons.count()).toEqual(
-      await rollingStockSelector.getRollingStockSearchNumber()
-    );
+    await test.step('Toggle Thermal filter and verify count', async () => {
+      await rollingStockSelector.toggleThermalRollingStockFilter();
+      expect(await rollingStockSelector.thermalRollingStockIcons.count()).toEqual(
+        await rollingStockSelector.getRollingStockSearchNumber()
+      );
+    });
 
-    // Clear filters and verify the count returns to the initial number
-    await rollingStockSelector.toggleElectricRollingStockFilter();
-    await rollingStockSelector.toggleThermalRollingStockFilter();
-    expect(await rollingStockSelector.rollingStockList.count()).toEqual(
-      initialRollingStockFoundNumber
-    );
+    await test.step('Toggle Electric with Thermal on (dual-mode) and verify count', async () => {
+      await rollingStockSelector.toggleElectricRollingStockFilter();
+      expect(await rollingStockSelector.dualModeRollingStockIcons.count()).toEqual(
+        await rollingStockSelector.getRollingStockSearchNumber()
+      );
+    });
+
+    await test.step('Clear both filters and verify count resets', async () => {
+      await rollingStockSelector.toggleElectricRollingStockFilter();
+      await rollingStockSelector.toggleThermalRollingStockFilter();
+      expect(await rollingStockSelector.rollingStockList.count()).toEqual(
+        initialRollingStockFoundNumber
+      );
+    });
   });
 
   /** *************** Test 5 **************** */
   test('Search for a rolling stock', async () => {
     const initialRollingStockFoundNumber = await rollingStockSelector.getRollingStockSearchNumber();
 
-    // Search for a specific rolling stock
-    await rollingStockEditorPage.searchRollingStock(dualModeRollingStockName);
-    expect(
-      rollingStockEditorPage.page.getByTestId(`rollingstock-${dualModeRollingStockName}`)
-    ).toBeDefined();
+    await test.step('Search a specific rolling stock and verify icons', async () => {
+      await rollingStockEditorPage.searchRollingStock(dualModeRollingStockName);
+      expect(
+        rollingStockEditorPage.page.getByTestId(`rollingstock-${dualModeRollingStockName}`)
+      ).toBeDefined();
 
-    // Verify the presence of thermal and electric icons
-    await expect(rollingStockSelector.thermalRollingStockFirstIcon).toBeVisible();
-    await expect(rollingStockSelector.electricRollingStockFirstIcon).toBeVisible();
+      await expect(rollingStockSelector.thermalRollingStockFirstIcon).toBeVisible();
+      await expect(rollingStockSelector.electricRollingStockFirstIcon).toBeVisible();
+    });
 
-    // Clear the search and verify the count returns to the initial number
-    await rollingStockEditorPage.clearSearchRollingStock();
-    expect(await rollingStockSelector.rollingStockList.count()).toEqual(
-      initialRollingStockFoundNumber
-    );
+    await test.step('Clear search and verify count resets', async () => {
+      await rollingStockEditorPage.clearSearchRollingStock();
+      expect(await rollingStockSelector.rollingStockList.count()).toEqual(
+        initialRollingStockFoundNumber
+      );
+    });
 
-    // Search for a non-existent rolling stock and verify no results
-    await rollingStockEditorPage.searchRollingStock(`${dualModeRollingStockName}-no-results`);
-    await expect(rollingStockSelector.noRollingStockResult).toBeVisible();
-    expect(await rollingStockSelector.getRollingStockSearchNumber()).toEqual(0);
+    await test.step('Search a non-existent rolling stock → expect no results', async () => {
+      await rollingStockEditorPage.searchRollingStock(`${dualModeRollingStockName}-no-results`);
+      await expect(rollingStockSelector.noRollingStockResult).toBeVisible();
+      expect(await rollingStockSelector.getRollingStockSearchNumber()).toEqual(0);
+    });
   });
 });

--- a/front/tests/006-op-rolling-stock-tab.spec.ts
+++ b/front/tests/006-op-rolling-stock-tab.spec.ts
@@ -45,70 +45,72 @@ test.describe('Rolling stock Tab Verification', () => {
       new OperationalStudiesPage(page),
       new RollingStockSelector(page),
     ];
+
     await page.goto(
       `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenario.id}`
     );
-    // Wait for infra to be in 'CACHED' state before proceeding
     await waitForInfraStateToBeCached(infra.id);
     await operationalStudiesPage.openTimetableItemForm();
   });
 
   /** *************** Test 1 **************** */
   test('Select a rolling stock for operational study', async () => {
-    // Verify the presence of warnings
-    await operationalStudiesPage.verifyTabWarningPresence();
-
-    // Open the Rolling Stock Selector and search for the dual-mode rolling stock
-    await rollingStockSelector.openEmptyRollingStockSelector();
-    await rollingStockSelector.searchRollingstock(dualModeRollingStockName);
-
-    // Locate the rolling stock card and verify its inactive state
-
-    await rollingStockSelector.verifyRollingStockIsInactive(dualModeRollingStockName);
-
-    // Click on the rolling stock card to activate it
-    await rollingStockSelector.selectRollingStockCard({ name: dualModeRollingStockName });
-
-    // Select the comfort option (AIR_CONDITIONING) and confirm the selection
-    const comfortACRadioText = await rollingStockSelector.comfortACButton.innerText();
-    await rollingStockSelector.selectRollingStockCard({
-      name: dualModeRollingStockName,
-      selectComfort: true,
-      confirmSelection: true,
+    await test.step('Verify tab warnings are present', async () => {
+      await operationalStudiesPage.verifyTabWarningPresence();
     });
 
-    // Verify that the correct comfort type is displayed after selection
+    await test.step('Open selector and search dual-mode rolling stock', async () => {
+      await rollingStockSelector.openEmptyRollingStockSelector();
+      await rollingStockSelector.searchRollingstock(dualModeRollingStockName);
+    });
 
-    await rollingStockSelector.verifySelectedComfortMatches(comfortACRadioText);
+    await test.step('Verify RS card is inactive before selection', async () => {
+      await rollingStockSelector.verifyRollingStockIsInactive(dualModeRollingStockName);
+    });
+
+    await test.step('Activate RS card', async () => {
+      await rollingStockSelector.selectRollingStockCard({ name: dualModeRollingStockName });
+    });
+
+    await test.step('Select AIR_CONDITIONING comfort and confirm the new RS is displayed', async () => {
+      const comfortACRadioText = await rollingStockSelector.comfortACButton.innerText();
+      await rollingStockSelector.selectRollingStockCard({
+        name: dualModeRollingStockName,
+        selectComfort: true,
+        confirmSelection: true,
+      });
+      await rollingStockSelector.verifySelectedComfortMatches(comfortACRadioText);
+    });
   });
 
   /** *************** Test 2 **************** */
   test('Modify a rolling stock for operational study', async () => {
-    // Select the electric rolling stock
-    await rollingStockSelector.openEmptyRollingStockSelector();
-    await rollingStockSelector.searchRollingstock(electricRollingStockName);
-    await rollingStockSelector.selectRollingStockCard({
-      name: rollingStock.name,
-      confirmSelection: true,
-    });
-    expect(await rollingStockSelector.selectedRollingStockName.innerText()).toEqual(
-      electricRollingStockName
-    );
-
-    // Reopen the rolling stock selector and apply filters
-    await rollingStockSelector.openRollingstockModal();
-    await rollingStockSelector.toggleThermalRollingStockFilter();
-    await rollingStockSelector.toggleElectricRollingStockFilter();
-
-    // Select the dual-mode rolling stock and confirm the selection
-    await rollingStockSelector.selectRollingStockCard({
-      name: dualModeRollingStockName,
-      confirmSelection: true,
+    await test.step('Select electric rolling stock', async () => {
+      await rollingStockSelector.openEmptyRollingStockSelector();
+      await rollingStockSelector.searchRollingstock(electricRollingStockName);
+      await rollingStockSelector.selectRollingStockCard({
+        name: rollingStock.name,
+        confirmSelection: true,
+      });
+      expect(await rollingStockSelector.selectedRollingStockName.innerText()).toEqual(
+        electricRollingStockName
+      );
     });
 
-    // Verify that the correct dual-mode rolling stock is displayed
-    expect(await rollingStockSelector.selectedRollingStockName.innerText()).toEqual(
-      dualModeRollingStockName
-    );
+    await test.step('Open selector and toggle Thermal + Electric filters', async () => {
+      await rollingStockSelector.openRollingstockModal();
+      await rollingStockSelector.toggleThermalRollingStockFilter();
+      await rollingStockSelector.toggleElectricRollingStockFilter();
+    });
+
+    await test.step('Select dual-mode rolling stock and confirm the new RS is displayed', async () => {
+      await rollingStockSelector.selectRollingStockCard({
+        name: dualModeRollingStockName,
+        confirmSelection: true,
+      });
+      expect(await rollingStockSelector.selectedRollingStockName.innerText()).toEqual(
+        dualModeRollingStockName
+      );
+    });
   });
 });

--- a/front/tests/007-op-route-tab.spec.ts
+++ b/front/tests/007-op-route-tab.spec.ts
@@ -29,120 +29,137 @@ test.describe('Route Tab Verification', () => {
     await deleteScenario(project.id, study.id, scenario.name);
   });
 
-  test.beforeEach(
-    'Navigate to the scenario page and select the rolling stock before each test',
-    async ({ page }) => {
-      [operationalStudiesPage, rollingstockSelector, routeTab] = [
-        new OperationalStudiesPage(page),
-        new RollingStockSelector(page),
-        new RouteTab(page),
-      ];
+  test.beforeEach(async ({ page }) => {
+    [operationalStudiesPage, rollingstockSelector, routeTab] = [
+      new OperationalStudiesPage(page),
+      new RollingStockSelector(page),
+      new RouteTab(page),
+    ];
 
+    await test.step('Open scenario, wait infra cache, open form and verify tab warnings', async () => {
       await page.goto(
         `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenario.id}`
       );
-
-      // Wait for infra to be in 'CACHED' state before proceeding
       await waitForInfraStateToBeCached(infra.id);
-
-      // Click on add train button and verify tab warnings
       await operationalStudiesPage.openTimetableItemForm();
       await operationalStudiesPage.verifyTabWarningPresence();
+    });
 
-      // Select electric rolling stock and navigate to the Route Tab
+    await test.step('Select rolling stock and open the Route tab', async () => {
       await rollingstockSelector.selectRollingStock(electricRollingStockName);
       await operationalStudiesPage.openRouteTab();
-    }
-  );
+    });
+  });
 
   /** *************** Test 1 **************** */
   test('Select a route for operational study', async ({ browserName }) => {
-    // Verify that no route is initially selected
-    await routeTab.verifyNoSelectedRoute();
-
-    // Perform pathfinding by station trigrams and verify map markers in Chromium
-    await routeTab.performPathfindingByTrigram({
-      originTrigram: 'WS',
-      destinationTrigram: 'NES',
-      viaTrigram: 'MES',
+    await test.step('Verify no route selected initially', async () => {
+      await routeTab.verifyNoSelectedRoute();
     });
-    if (browserName === 'chromium') {
-      const expectedMapMarkersValues = ['West_station', 'North_East_station', 'Mid_East_station'];
-      await routeTab.verifyMapMarkers(...expectedMapMarkersValues);
-    }
 
-    // Verify that tab warnings are absent
-    await operationalStudiesPage.verifyTabWarningAbsence();
+    await test.step('Perform pathfinding by trigrams (WS → NES via MES)', async () => {
+      await routeTab.performPathfindingByTrigram({
+        originTrigram: 'WS',
+        destinationTrigram: 'NES',
+        viaTrigram: 'MES',
+      });
+    });
+
+    await test.step('Verify map markers (Chromium only)', async () => {
+      if (browserName === 'chromium') {
+        const expectedMapMarkersValues = ['West_station', 'North_East_station', 'Mid_East_station'];
+        await routeTab.verifyMapMarkers(...expectedMapMarkersValues);
+      }
+    });
+
+    await test.step('Verify tab warnings are absent', async () => {
+      await operationalStudiesPage.verifyTabWarningAbsence();
+    });
   });
 
   /** *************** Test 2 **************** */
   test('Adding waypoints to a route for operational study', async ({ browserName }) => {
-    // Perform pathfinding by station trigrams
-    await routeTab.performPathfindingByTrigram({
-      originTrigram: 'WS',
-      destinationTrigram: 'NES',
+    await test.step('Perform pathfinding by trigrams (WS → NES)', async () => {
+      await routeTab.performPathfindingByTrigram({
+        originTrigram: 'WS',
+        destinationTrigram: 'NES',
+      });
     });
 
-    // Define waypoints and add them to the route
-    const expectedViaValues = [
-      { name: 'Mid_West_station', ch: 'BV', uic: '33', km: 'KM 12.050' },
-      { name: 'Mid_East_station', ch: 'BV', uic: '44', km: 'KM 26.500' },
-    ];
-    await routeTab.addNewWaypoints(2, ['Mid_West_station', 'Mid_East_station'], expectedViaValues);
-
-    // Verify map markers in Chromium
-    if (browserName === 'chromium') {
-      const expectedMapMarkersValues = [
-        'West_station',
-        'Mid_West_station',
-        'Mid_East_station',
-        'North_East_station',
+    await test.step('Add two waypoints and verify via list', async () => {
+      const expectedViaValues = [
+        { name: 'Mid_West_station', ch: 'BV', uic: '33', km: 'KM 12.050' },
+        { name: 'Mid_East_station', ch: 'BV', uic: '44', km: 'KM 26.500' },
       ];
-      await routeTab.verifyMapMarkers(...expectedMapMarkersValues);
-    }
+      await routeTab.addNewWaypoints(
+        2,
+        ['Mid_West_station', 'Mid_East_station'],
+        expectedViaValues
+      );
+    });
 
-    // Verify that tab warnings are absent
-    await operationalStudiesPage.verifyTabWarningAbsence();
+    await test.step('Verify map markers (Chromium only)', async () => {
+      if (browserName === 'chromium') {
+        const expectedMapMarkersValues = [
+          'West_station',
+          'Mid_West_station',
+          'Mid_East_station',
+          'North_East_station',
+        ];
+        await routeTab.verifyMapMarkers(...expectedMapMarkersValues);
+      }
+    });
+
+    await test.step('Verify tab warnings are absent', async () => {
+      await operationalStudiesPage.verifyTabWarningAbsence();
+    });
   });
 
   /** *************** Test 3 **************** */
   test('Reversing and deleting waypoints in a route for operational study', async ({
     browserName,
   }) => {
-    // Perform pathfinding by station trigrams and verify map markers in Chromium
-    await routeTab.performPathfindingByTrigram({
-      originTrigram: 'WS',
-      destinationTrigram: 'SES',
-      viaTrigram: 'MWS',
-    });
     const expectedMapMarkersValues = ['West_station', 'South_East_station', 'Mid_West_station'];
-    if (browserName === 'chromium') {
-      await routeTab.verifyMapMarkers(...expectedMapMarkersValues);
-    }
 
-    // Reverse the itinerary and verify the map markers
-    await routeTab.reverseItinerary();
-    if (browserName === 'chromium') {
-      const reversedMapMarkersValues = [...expectedMapMarkersValues].reverse();
-      await routeTab.verifyMapMarkers(...reversedMapMarkersValues);
-    }
+    await test.step('Perform pathfinding WS → SES via MWS and verify markers', async () => {
+      await routeTab.performPathfindingByTrigram({
+        originTrigram: 'WS',
+        destinationTrigram: 'SES',
+        viaTrigram: 'MWS',
+      });
 
-    // Delete operational points and verify no selected route
-    await routeTab.deleteOperationPoints();
-    await routeTab.verifyNoSelectedRoute();
-
-    // Perform pathfinding again and verify map markers in Chromium
-    await routeTab.performPathfindingByTrigram({
-      originTrigram: 'WS',
-      destinationTrigram: 'SES',
-      viaTrigram: 'MWS',
+      if (browserName === 'chromium') {
+        await routeTab.verifyMapMarkers(...expectedMapMarkersValues);
+      }
     });
-    if (browserName === 'chromium') {
-      await routeTab.verifyMapMarkers(...expectedMapMarkersValues);
-    }
 
-    // Delete the itinerary and verify no selected route
-    await routeTab.deleteItinerary();
-    await routeTab.verifyNoSelectedRoute();
+    await test.step('Reverse itinerary and verify markers (Chromium only)', async () => {
+      await routeTab.reverseItinerary();
+      if (browserName === 'chromium') {
+        const reversedMapMarkersValues = [...expectedMapMarkersValues].reverse();
+        await routeTab.verifyMapMarkers(...reversedMapMarkersValues);
+      }
+    });
+
+    await test.step('Delete operation points and verify no selected route', async () => {
+      await routeTab.deleteOperationPoints();
+      await routeTab.verifyNoSelectedRoute();
+    });
+
+    await test.step('Perform pathfinding again and verify markers (Chromium only)', async () => {
+      await routeTab.performPathfindingByTrigram({
+        originTrigram: 'WS',
+        destinationTrigram: 'SES',
+        viaTrigram: 'MWS',
+      });
+      if (browserName === 'chromium') {
+        await routeTab.verifyMapMarkers(...expectedMapMarkersValues);
+      }
+    });
+
+    await test.step('Delete itinerary and verify no selected route', async () => {
+      await routeTab.deleteItinerary();
+      await routeTab.verifyNoSelectedRoute();
+    });
   });
 });

--- a/front/tests/008-op-times-and-stops-tab.spec.ts
+++ b/front/tests/008-op-times-and-stops-tab.spec.ts
@@ -22,6 +22,29 @@ const frTranslations: FlatTranslations = readJsonFile<Record<string, FlatTransla
   'public/locales/fr/translation.json'
 ).timeStopTable;
 
+// Load test data for table inputs and expected results
+const initialInputsData: CellData[] = readJsonFile(
+  './tests/assets/operation-studies/times-and-stops/initial-inputs.json'
+);
+const updatedInputsData: CellData[] = readJsonFile(
+  './tests/assets/operation-studies/times-and-stops/updated-inputs.json'
+);
+const outputExpectedCellData: StationData[] = readJsonFile(
+  './tests/assets/operation-studies/times-and-stops/expected-outputs-cells-data.json'
+);
+const inputExpectedData: JSON = readJsonFile(
+  './tests/assets/operation-studies/times-and-stops/expected-inputs-cells-data.json'
+);
+const updatedCellData: JSON = readJsonFile(
+  './tests/assets/operation-studies/times-and-stops/updated-inputs-cells-data.json'
+);
+
+// Waypoints data for route verification
+const expectedViaValues = [
+  { name: 'Mid_West_station', ch: 'BV', uic: '33', km: 'KM 12.050' },
+  { name: 'Mid_East_station', ch: 'BV', uic: '44', km: 'KM 26.500' },
+];
+
 test.describe('Times and Stops Tab Verification', () => {
   test.use({ viewport: { width: 1920, height: 1080 } });
 
@@ -36,50 +59,26 @@ test.describe('Times and Stops Tab Verification', () => {
   let scenario: Scenario;
   let infra: Infra;
 
-  // Load test data for table inputs and expected results
-  const initialInputsData: CellData[] = readJsonFile(
-    './tests/assets/operation-studies/times-and-stops/initial-inputs.json'
-  );
-  const updatedInputsData: CellData[] = readJsonFile(
-    './tests/assets/operation-studies/times-and-stops/updated-inputs.json'
-  );
-  const outputExpectedCellData: StationData[] = readJsonFile(
-    './tests/assets/operation-studies/times-and-stops/expected-outputs-cells-data.json'
-  );
-  const inputExpectedData: JSON = readJsonFile(
-    './tests/assets/operation-studies/times-and-stops/expected-inputs-cells-data.json'
-  );
-  const updatedCellData: JSON = readJsonFile(
-    './tests/assets/operation-studies/times-and-stops/updated-inputs-cells-data.json'
-  );
-
-  // Waypoints data for route verification
-  const expectedViaValues = [
-    { name: 'Mid_West_station', ch: 'BV', uic: '33', km: 'KM 12.050' },
-    { name: 'Mid_East_station', ch: 'BV', uic: '44', km: 'KM 26.500' },
-  ];
-
   test.beforeAll('Fetch infrastructure and get translation', async () => {
     infra = await getInfra();
   });
 
-  test.beforeEach(
-    'Navigate to Times and Stops tab with rolling stock and route set',
-    async ({ page }) => {
-      [
-        operationalStudiesPage,
-        routeTab,
-        rollingStockSelector,
-        timesAndStopsTab,
-        timeAndStopSimulationOutputs,
-      ] = [
-        new OperationalStudiesPage(page),
-        new RouteTab(page),
-        new RollingStockSelector(page),
-        new TimesAndStopsTab(page),
-        new TimeAndStopSimulationOutputs(page),
-      ];
+  test.beforeEach(async ({ page }) => {
+    [
+      operationalStudiesPage,
+      routeTab,
+      rollingStockSelector,
+      timesAndStopsTab,
+      timeAndStopSimulationOutputs,
+    ] = [
+      new OperationalStudiesPage(page),
+      new RouteTab(page),
+      new RollingStockSelector(page),
+      new TimesAndStopsTab(page),
+      new TimeAndStopSimulationOutputs(page),
+    ];
 
+    await test.step('Create then navigate to scenario page', async () => {
       // Set up scenario for operational study
       ({ project, study, scenario } = await createScenario());
 
@@ -90,7 +89,8 @@ test.describe('Times and Stops Tab Verification', () => {
 
       // Wait for infra to be in 'CACHED' state before proceeding
       await waitForInfraStateToBeCached(infra.id);
-
+    });
+    await test.step('Add a new train schedule, set its properties and perform pathfinding', async () => {
       // Setup train schedule configuration and schedule
       await operationalStudiesPage.openTimetableItemForm();
       await operationalStudiesPage.setTimetableItemStartTime('11:22:40');
@@ -107,115 +107,121 @@ test.describe('Times and Stops Tab Verification', () => {
       // Navigate to the Times and Stops tab and scroll to the data sheet
       await operationalStudiesPage.openTimesAndStopsTab();
       await scrollContainer(page, '.time-stops-datasheet .dsg-container');
-    }
-  );
+    });
+  });
 
   test.afterEach('Delete the created scenario', async () => {
     await deleteScenario(project.id, study.id, scenario.name);
   });
 
   test('should correctly set and display times and stops tables', async ({ page }) => {
-    const expectedColumnNames = cleanWhitespaceInArray([
-      frTranslations.name,
-      frTranslations.ch,
-      frTranslations.trackName,
-      frTranslations.arrivalTime,
-      frTranslations.stopTime,
-      frTranslations.departureTime,
-      frTranslations.receptionOnClosedSignal,
-      frTranslations.shortSlipDistance,
-      frTranslations.theoreticalMargin,
-    ]);
-
-    // Verify table headers match the expected headers
-    const actualColumnHeaders = cleanWhitespaceInArray(
-      await timesAndStopsTab.columnHeaders.allInnerTexts()
-    );
-    expect(actualColumnHeaders).toEqual(expectedColumnNames);
-
-    // Verify initial row count and fill table with input data
-    await timesAndStopsTab.verifyActiveRowsCount(2);
-    for (const cell of initialInputsData) {
-      const translatedHeader = cleanWhitespace(frTranslations[cell.header]);
-      await timesAndStopsTab.fillTableCellByStationAndHeader(
-        cell.stationName,
-        translatedHeader,
-        cell.value,
-        cell.marginForm
+    await test.step('Verify table headers', async () => {
+      const expectedColumnNames = cleanWhitespaceInArray([
+        frTranslations.name,
+        frTranslations.ch,
+        frTranslations.trackName,
+        frTranslations.arrivalTime,
+        frTranslations.stopTime,
+        frTranslations.departureTime,
+        frTranslations.receptionOnClosedSignal,
+        frTranslations.shortSlipDistance,
+        frTranslations.theoreticalMargin,
+      ]);
+      const actualColumnHeaders = cleanWhitespaceInArray(
+        await timesAndStopsTab.columnHeaders.allInnerTexts()
       );
-    }
+      expect(actualColumnHeaders).toEqual(expectedColumnNames);
+    });
 
-    // Verify changes to the input table and additional rows
-    await timesAndStopsTab.verifyActiveRowsCount(4);
-    await timesAndStopsTab.verifyClearButtons(2);
-    await timesAndStopsTab.verifyInputTableData(inputExpectedData);
+    await test.step('Fill initial inputs (2 active rows → 4 active rows)', async () => {
+      await timesAndStopsTab.verifyActiveRowsCount(2);
+      for (const cell of initialInputsData) {
+        const translatedHeader = cleanWhitespace(frTranslations[cell.header]);
+        await timesAndStopsTab.fillTableCellByStationAndHeader(
+          cell.stationName,
+          translatedHeader,
+          cell.value,
+          cell.marginForm
+        );
+      }
+    });
 
-    // Validate waypoints after switching to the Route tab
-    await operationalStudiesPage.openRouteTab();
-    for (const [viaIndex, expectedValue] of expectedViaValues.entries()) {
-      const droppedWaypoint = routeTab.droppedWaypoints.nth(viaIndex);
-      await RouteTab.validateAddedWaypoint(
-        droppedWaypoint,
-        expectedValue.name,
-        expectedValue.ch,
-        expectedValue.uic
-      );
-    }
+    await test.step('Verify input table state after fill', async () => {
+      await timesAndStopsTab.verifyActiveRowsCount(4);
+      await timesAndStopsTab.verifyClearButtons(2);
+      await timesAndStopsTab.verifyInputTableData(inputExpectedData);
+    });
 
-    // Add train schedule, verify results and output table data
-    await operationalStudiesPage.createTimetableItem();
-    await operationalStudiesPage.closeToastNotification();
-    await operationalStudiesPage.returnSimulationResult();
-    await timeAndStopSimulationOutputs.verifyTimesStopsDataSheetVisibility();
+    await test.step('Validate waypoints in Route tab', async () => {
+      await operationalStudiesPage.openRouteTab();
+      for (const [viaIndex, expectedValue] of expectedViaValues.entries()) {
+        const droppedWaypoint = routeTab.droppedWaypoints.nth(viaIndex);
+        await RouteTab.validateAddedWaypoint(
+          droppedWaypoint,
+          expectedValue.name,
+          expectedValue.ch,
+          expectedValue.uic
+        );
+      }
+    });
 
-    // Scroll and extract output table data for verification
-    await scrollContainer(page, '.time-stop-outputs .time-stops-datasheet .dsg-container');
-    await timeAndStopSimulationOutputs.getOutputTableData(outputExpectedCellData);
+    await test.step('Create timetable item, open results and verify outputs', async () => {
+      await operationalStudiesPage.createTimetableItem();
+      await operationalStudiesPage.closeToastNotification();
+      await operationalStudiesPage.returnSimulationResult();
+      await timeAndStopSimulationOutputs.verifyTimesStopsDataSheetVisibility();
+
+      await scrollContainer(page, '.time-stop-outputs .time-stops-datasheet .dsg-container');
+      await timeAndStopSimulationOutputs.getOutputTableData(outputExpectedCellData);
+    });
   });
 
   test('should correctly update and clear input table row', async () => {
-    // Fill table cells with initial input data
-    for (const cell of initialInputsData) {
-      const translatedHeader = cleanWhitespace(frTranslations[cell.header]);
-      await timesAndStopsTab.fillTableCellByStationAndHeader(
-        cell.stationName,
-        translatedHeader,
-        cell.value,
-        cell.marginForm
-      );
-    }
+    await test.step('Fill initial inputs and verify table', async () => {
+      for (const cell of initialInputsData) {
+        const translatedHeader = cleanWhitespace(frTranslations[cell.header]);
+        await timesAndStopsTab.fillTableCellByStationAndHeader(
+          cell.stationName,
+          translatedHeader,
+          cell.value,
+          cell.marginForm
+        );
+      }
+      await timesAndStopsTab.verifyInputTableData(inputExpectedData);
+    });
 
-    await timesAndStopsTab.verifyInputTableData(inputExpectedData);
+    await test.step('Update inputs (keep 4 active rows)', async () => {
+      await timesAndStopsTab.verifyActiveRowsCount(4);
+      for (const cell of updatedInputsData) {
+        const translatedHeader = cleanWhitespace(frTranslations[cell.header]);
+        await timesAndStopsTab.fillTableCellByStationAndHeader(
+          cell.stationName,
+          translatedHeader,
+          cell.value,
+          cell.marginForm
+        );
+      }
+    });
 
-    // Update table inputs with new data
-    await timesAndStopsTab.verifyActiveRowsCount(4);
-    for (const cell of updatedInputsData) {
-      const translatedHeader = cleanWhitespace(frTranslations[cell.header]);
-      await timesAndStopsTab.fillTableCellByStationAndHeader(
-        cell.stationName,
-        translatedHeader,
-        cell.value,
-        cell.marginForm
-      );
-    }
+    await test.step('Clear a row and verify new state (row count remains unchanged)', async () => {
+      await timesAndStopsTab.verifyClearButtons(2);
+      await timesAndStopsTab.clearRow(0);
+      await timesAndStopsTab.verifyActiveRowsCount(4);
+      await timesAndStopsTab.verifyClearButtons(1);
+      await timesAndStopsTab.verifyInputTableData(updatedCellData);
+    });
 
-    // Clear a row and verify changes
-    await timesAndStopsTab.verifyClearButtons(2);
-    await timesAndStopsTab.clearRow(0);
-    await timesAndStopsTab.verifyActiveRowsCount(4); // No reduction in rows after deletion
-    await timesAndStopsTab.verifyClearButtons(1);
-    await timesAndStopsTab.verifyInputTableData(updatedCellData);
-
-    // Verify waypoints after switching to the Route tab
-    await operationalStudiesPage.openRouteTab();
-    for (const [viaIndex, expectedValue] of expectedViaValues.entries()) {
-      const droppedWaypoint = routeTab.droppedWaypoints.nth(viaIndex);
-      await RouteTab.validateAddedWaypoint(
-        droppedWaypoint,
-        expectedValue.name,
-        expectedValue.ch,
-        expectedValue.uic
-      );
-    }
+    await test.step('Validate waypoints after updates (Route tab)', async () => {
+      await operationalStudiesPage.openRouteTab();
+      for (const [viaIndex, expectedValue] of expectedViaValues.entries()) {
+        const droppedWaypoint = routeTab.droppedWaypoints.nth(viaIndex);
+        await RouteTab.validateAddedWaypoint(
+          droppedWaypoint,
+          expectedValue.name,
+          expectedValue.ch,
+          expectedValue.uic
+        );
+      }
+    });
   });
 });

--- a/front/tests/009-op-simulation-settings-tab.spec.ts
+++ b/front/tests/009-op-simulation-settings-tab.spec.ts
@@ -32,6 +32,30 @@ const frTranslations = readJsonFile<Record<string, FlatTranslations>>(
   'public/locales/fr/translation.json'
 ).timeStopTable;
 
+const expectedCellDataElectricalProfileON: StationData[] = readJsonFile(
+  './tests/assets/operation-studies/simulation-settings/electrical-profiles/electrical-profile-on.json'
+);
+const expectedCellDataElectricalProfileOFF: StationData[] = readJsonFile(
+  './tests/assets/operation-studies/simulation-settings/electrical-profiles/electrical-profile-off.json'
+);
+
+const expectedCellDataCodeCompoON: StationData[] = readJsonFile(
+  './tests/assets/operation-studies/simulation-settings/speed-limit-tag/speed-limit-tag-on.json'
+);
+const expectedCellDataCodeCompoOFF: StationData[] = readJsonFile(
+  './tests/assets/operation-studies/simulation-settings/speed-limit-tag/speed-limit-tag-off.json'
+);
+
+const expectedCellDataLinearMargin: StationData[] = readJsonFile(
+  './tests/assets/operation-studies/simulation-settings/margin/linear-margin.json'
+);
+const expectedCellDataMarecoMargin: StationData[] = readJsonFile(
+  './tests/assets/operation-studies/simulation-settings/margin/mareco-margin.json'
+);
+const expectedCellDataForAllSettings: StationData[] = readJsonFile(
+  './tests/assets/operation-studies/simulation-settings/all-settings.json'
+);
+
 test.describe('Simulation Settings Tab Verification', () => {
   test.slow();
   test.use({ viewport: { width: 1920, height: 1080 } });
@@ -51,30 +75,6 @@ test.describe('Simulation Settings Tab Verification', () => {
   let study: Study;
   let scenario: Scenario;
   let infra: Infra;
-
-  const expectedCellDataElectricalProfileON: StationData[] = readJsonFile(
-    './tests/assets/operation-studies/simulation-settings/electrical-profiles/electrical-profile-on.json'
-  );
-  const expectedCellDataElectricalProfileOFF: StationData[] = readJsonFile(
-    './tests/assets/operation-studies/simulation-settings/electrical-profiles/electrical-profile-off.json'
-  );
-
-  const expectedCellDataCodeCompoON: StationData[] = readJsonFile(
-    './tests/assets/operation-studies/simulation-settings/speed-limit-tag/speed-limit-tag-on.json'
-  );
-  const expectedCellDataCodeCompoOFF: StationData[] = readJsonFile(
-    './tests/assets/operation-studies/simulation-settings/speed-limit-tag/speed-limit-tag-off.json'
-  );
-
-  const expectedCellDataLinearMargin: StationData[] = readJsonFile(
-    './tests/assets/operation-studies/simulation-settings/margin/linear-margin.json'
-  );
-  const expectedCellDataMarecoMargin: StationData[] = readJsonFile(
-    './tests/assets/operation-studies/simulation-settings/margin/mareco-margin.json'
-  );
-  const expectedCellDataForAllSettings: StationData[] = readJsonFile(
-    './tests/assets/operation-studies/simulation-settings/all-settings.json'
-  );
 
   type TranslationKeys = keyof typeof frTranslations;
 
@@ -96,31 +96,30 @@ test.describe('Simulation Settings Tab Verification', () => {
       await deleteApiRequest(`/api/electrical_profile_set/${electricalProfileSet.id}/`);
   });
 
-  test.beforeEach(
-    'Navigate to Times and Stops tab with rolling stock and route set',
-    async ({ page }) => {
-      [
-        operationalStudiesPage,
-        routeTab,
-        rollingStockSelector,
-        timesAndStopsTab,
-        timeAndStopSimulationOutputs,
-        simulationSettingsTab,
-        simulationResultPage,
-        scenarioTimetableSection,
-        scenarioPage,
-      ] = [
-        new OperationalStudiesPage(page),
-        new RouteTab(page),
-        new RollingStockSelector(page),
-        new TimesAndStopsTab(page),
-        new TimeAndStopSimulationOutputs(page),
-        new SimulationSettingsTab(page),
-        new OpSimulationResultPage(page),
-        new ScenarioTimetableSection(page),
-        new ScenarioPage(page),
-      ];
-      // Create a new scenario
+  test.beforeEach(async ({ page }) => {
+    [
+      operationalStudiesPage,
+      routeTab,
+      rollingStockSelector,
+      timesAndStopsTab,
+      timeAndStopSimulationOutputs,
+      simulationSettingsTab,
+      simulationResultPage,
+      scenarioTimetableSection,
+      scenarioPage,
+    ] = [
+      new OperationalStudiesPage(page),
+      new RouteTab(page),
+      new RollingStockSelector(page),
+      new TimesAndStopsTab(page),
+      new TimeAndStopSimulationOutputs(page),
+      new SimulationSettingsTab(page),
+      new OpSimulationResultPage(page),
+      new ScenarioTimetableSection(page),
+      new ScenarioPage(page),
+    ];
+
+    await test.step('Create then navigate to scenario page', async () => {
       ({ project, study, scenario } = await createScenario(
         undefined,
         null,
@@ -128,150 +127,151 @@ test.describe('Simulation Settings Tab Verification', () => {
         null,
         electricalProfileSet.id
       ));
-
-      // Navigate to the created scenario page
       await page.goto(
         `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenario.id}`
       );
       await operationalStudiesPage.removeViteOverlay();
-      // Wait for infra to be in 'CACHED' state before proceeding
       await waitForInfraStateToBeCached(infra.id);
-      // Add a new train schedule and set its properties
+    });
+    await test.step('Add a new train schedule, set its properties and perform pathfinding', async () => {
       await operationalStudiesPage.openTimetableItemForm();
       await operationalStudiesPage.setTimetableItemName('Train-name-e2e-test');
       await rollingStockSelector.selectRollingStock(improbableRollingStockName);
       await operationalStudiesPage.setTimetableItemStartTime('11:22:40');
 
-      // Perform pathfinding
       await operationalStudiesPage.openRouteTab();
       await routeTab.performPathfindingByTrigram({
         originTrigram: 'WS',
         destinationTrigram: 'SES',
         viaTrigram: 'MWS',
       });
-      // Navigate to the Times and Stops tab and fill in required data
       await operationalStudiesPage.openTimesAndStopsTab();
       await scrollContainer(page, '.time-stops-datasheet .dsg-container');
-    }
-  );
+    });
+  });
 
   test.afterEach('Delete the created scenario', async () => {
     await deleteScenario(project.id, study.id, scenario.name);
   });
 
   test('Activate electrical profiles', async ({ page, browserName }) => {
-    const cell: CellData = {
-      stationName: 'Mid_East_station',
-      header: 'stopTime',
-      value: '124',
-    };
-
+    const cell: CellData = { stationName: 'Mid_East_station', header: 'stopTime', value: '124' };
     const translatedHeader = cleanWhitespace(frTranslations[cell.header]);
 
-    await timesAndStopsTab.fillTableCellByStationAndHeader(
-      cell.stationName,
-      translatedHeader,
-      cell.value
-    );
-    // Activate electrical profiles
-    await operationalStudiesPage.openSimulationSettingsTab();
-    await simulationSettingsTab.checkElectricalProfile();
-    await simulationSettingsTab.checkMarecoMargin();
-    // Add the train schedule and verify output results
-    await operationalStudiesPage.createTimetableItem();
-    await operationalStudiesPage.closeToastNotification();
-    await operationalStudiesPage.returnSimulationResult();
-    await scenarioTimetableSection.getTimetableItemArrivalTime('11:48');
-    await scenarioPage.toggleTrainList();
-
-    await timeAndStopSimulationOutputs.verifyTimesStopsDataSheetVisibility();
-    await simulationResultPage.selectAllSpeedSpaceChartCheckboxes();
-    if (browserName === 'chromium') {
-      await expect(simulationResultPage.speedSpaceChart).toHaveScreenshot(
-        'SpeedSpaceChart-ElectricalProfileActivated.png'
+    await test.step('Fill Times & Stops input', async () => {
+      await timesAndStopsTab.fillTableCellByStationAndHeader(
+        cell.stationName,
+        translatedHeader,
+        cell.value
       );
-    }
-    await scrollContainer(page, '.time-stop-outputs .time-stops-datasheet .dsg-container');
-    await timeAndStopSimulationOutputs.getOutputTableData(expectedCellDataElectricalProfileON);
-    await scenarioPage.toggleTrainList(false);
-    // Deactivate electrical profiles and verify output results
-    await scenarioTimetableSection.editTimetableItem();
-    await operationalStudiesPage.openSimulationSettingsTab();
-    await simulationSettingsTab.deactivateElectricalProfile();
-    await operationalStudiesPage.submitTimetableItemEdit();
-    await scenarioPage.toggleTrainList();
+    });
 
-    await timeAndStopSimulationOutputs.verifyTimesStopsDataSheetVisibility();
-    await simulationResultPage.selectAllSpeedSpaceChartCheckboxes();
-    if (browserName === 'chromium') {
-      await expect(simulationResultPage.speedSpaceChart).toHaveScreenshot(
-        'SpeedSpaceChart-ElectricalProfileDisabled.png'
-      );
-    }
-    await timeAndStopSimulationOutputs.getOutputTableData(expectedCellDataElectricalProfileOFF);
-    await scenarioPage.toggleTrainList(false);
-    await scenarioTimetableSection.getTimetableItemArrivalTime('11:48');
+    await test.step('Activate electrical profiles + Mareco margin', async () => {
+      await operationalStudiesPage.openSimulationSettingsTab();
+      await simulationSettingsTab.checkElectricalProfile();
+      await simulationSettingsTab.checkMarecoMargin();
+    });
+
+    await test.step('Create train schedule and verify (electrical profile ON)', async () => {
+      await operationalStudiesPage.createTimetableItem();
+      await operationalStudiesPage.closeToastNotification();
+      await operationalStudiesPage.returnSimulationResult();
+      await scenarioTimetableSection.getTimetableItemArrivalTime('11:48');
+      await scenarioPage.toggleTrainList();
+
+      await timeAndStopSimulationOutputs.verifyTimesStopsDataSheetVisibility();
+      await simulationResultPage.selectAllSpeedSpaceChartCheckboxes();
+      if (browserName === 'chromium') {
+        await expect(simulationResultPage.speedSpaceChart).toHaveScreenshot(
+          'SpeedSpaceChart-ElectricalProfileActivated.png'
+        );
+      }
+      await scrollContainer(page, '.time-stop-outputs .time-stops-datasheet .dsg-container');
+      await timeAndStopSimulationOutputs.getOutputTableData(expectedCellDataElectricalProfileON);
+      await scenarioPage.toggleTrainList(false);
+    });
+
+    await test.step('Deactivate electrical profiles and verify (OFF)', async () => {
+      await scenarioTimetableSection.editTimetableItem();
+      await operationalStudiesPage.openSimulationSettingsTab();
+      await simulationSettingsTab.deactivateElectricalProfile();
+      await operationalStudiesPage.submitTimetableItemEdit();
+      await scenarioPage.toggleTrainList();
+
+      await timeAndStopSimulationOutputs.verifyTimesStopsDataSheetVisibility();
+      await simulationResultPage.selectAllSpeedSpaceChartCheckboxes();
+      if (browserName === 'chromium') {
+        await expect(simulationResultPage.speedSpaceChart).toHaveScreenshot(
+          'SpeedSpaceChart-ElectricalProfileDisabled.png'
+        );
+      }
+      await timeAndStopSimulationOutputs.getOutputTableData(expectedCellDataElectricalProfileOFF);
+      await scenarioPage.toggleTrainList(false);
+      await scenarioTimetableSection.getTimetableItemArrivalTime('11:48');
+    });
   });
-  test('Activate composition code', async ({ page, browserName }) => {
-    const cell: CellData = {
-      stationName: 'Mid_East_station',
-      header: 'stopTime',
-      value: '124',
-    };
+
+  test('Add speed limit tag', async ({ page, browserName }) => {
+    const cell: CellData = { stationName: 'Mid_East_station', header: 'stopTime', value: '124' };
     const translatedHeader = cleanWhitespace(frTranslations[cell.header]);
 
-    await timesAndStopsTab.fillTableCellByStationAndHeader(
-      cell.stationName,
-      translatedHeader,
-      cell.value
-    );
-    // Select a specific composition code option
-    await operationalStudiesPage.openSimulationSettingsTab();
-    await simulationSettingsTab.deactivateElectricalProfile();
-    await simulationSettingsTab.checkMarecoMargin();
-    await simulationSettingsTab.selectSpeedLimitTagOption('E32C');
-    // Add the train schedule and verify output results
-    await operationalStudiesPage.createTimetableItem();
-    await operationalStudiesPage.closeToastNotification();
-    await operationalStudiesPage.returnSimulationResult();
-    await scenarioTimetableSection.getTimetableItemArrivalTime('11:49');
-    await scenarioPage.toggleTrainList();
-
-    await timeAndStopSimulationOutputs.verifyTimesStopsDataSheetVisibility();
-    await simulationResultPage.selectAllSpeedSpaceChartCheckboxes();
-    if (browserName === 'chromium') {
-      await expect(simulationResultPage.speedSpaceChart).toHaveScreenshot(
-        'SpeedSpaceChart-SpeedLimitTagActivated.png'
+    await test.step('Fill Times & Stops input', async () => {
+      await timesAndStopsTab.fillTableCellByStationAndHeader(
+        cell.stationName,
+        translatedHeader,
+        cell.value
       );
-    }
-    await scrollContainer(page, '.time-stop-outputs .time-stops-datasheet .dsg-container');
-    await timeAndStopSimulationOutputs.getOutputTableData(expectedCellDataCodeCompoON);
-    await scenarioPage.toggleTrainList(false);
-    // Remove the composition code option and verify the changes
-    await scenarioTimetableSection.editTimetableItem();
-    await operationalStudiesPage.openSimulationSettingsTab();
-    await simulationSettingsTab.selectSpeedLimitTagOption('__PLACEHOLDER__');
-    await operationalStudiesPage.submitTimetableItemEdit();
-    await scenarioPage.toggleTrainList();
+    });
 
-    await timeAndStopSimulationOutputs.verifyTimesStopsDataSheetVisibility();
-    await simulationResultPage.selectAllSpeedSpaceChartCheckboxes();
-    if (browserName === 'chromium') {
-      await expect(simulationResultPage.speedSpaceChart).toHaveScreenshot(
-        'SpeedSpaceChart-SpeedLimitTagDisabled.png'
-      );
-    }
-    await timeAndStopSimulationOutputs.getOutputTableData(expectedCellDataCodeCompoOFF);
-    await scenarioPage.toggleTrainList(false);
-    await scenarioTimetableSection.getTimetableItemArrivalTime('11:48');
+    await test.step('Enable Mareco margin + speed limit tag (HLP), disable electrical profile', async () => {
+      await operationalStudiesPage.openSimulationSettingsTab();
+      await simulationSettingsTab.deactivateElectricalProfile();
+      await simulationSettingsTab.checkMarecoMargin();
+      await simulationSettingsTab.selectSpeedLimitTagOption('E32C');
+    });
+
+    await test.step('Create train schedule and verify (speed limit tag ON)', async () => {
+      await operationalStudiesPage.createTimetableItem();
+      await operationalStudiesPage.closeToastNotification();
+      await operationalStudiesPage.returnSimulationResult();
+      await scenarioTimetableSection.getTimetableItemArrivalTime('11:49');
+      await scenarioPage.toggleTrainList();
+
+      await timeAndStopSimulationOutputs.verifyTimesStopsDataSheetVisibility();
+      await simulationResultPage.selectAllSpeedSpaceChartCheckboxes();
+      if (browserName === 'chromium') {
+        await expect(simulationResultPage.speedSpaceChart).toHaveScreenshot(
+          'SpeedSpaceChart-SpeedLimitTagActivated.png'
+        );
+      }
+      await scrollContainer(page, '.time-stop-outputs .time-stops-datasheet .dsg-container');
+      await timeAndStopSimulationOutputs.getOutputTableData(expectedCellDataCodeCompoON);
+      await scenarioPage.toggleTrainList(false);
+    });
+
+    await test.step('Remove speed limit tag and verify (speed limit tag OFF)', async () => {
+      await scenarioTimetableSection.editTimetableItem();
+      await operationalStudiesPage.openSimulationSettingsTab();
+      await simulationSettingsTab.selectSpeedLimitTagOption('__PLACEHOLDER__');
+      await operationalStudiesPage.submitTimetableItemEdit();
+      await scenarioPage.toggleTrainList();
+
+      await timeAndStopSimulationOutputs.verifyTimesStopsDataSheetVisibility();
+      await simulationResultPage.selectAllSpeedSpaceChartCheckboxes();
+      if (browserName === 'chromium') {
+        await expect(simulationResultPage.speedSpaceChart).toHaveScreenshot(
+          'SpeedSpaceChart-SpeedLimitTagDisabled.png'
+        );
+      }
+      await timeAndStopSimulationOutputs.getOutputTableData(expectedCellDataCodeCompoOFF);
+      await scenarioPage.toggleTrainList(false);
+      await scenarioTimetableSection.getTimetableItemArrivalTime('11:48');
+    });
   });
+
   test('Activate linear and mareco margin', async ({ page, browserName }) => {
     const inputTableData: CellData[] = [
-      {
-        stationName: 'Mid_East_station',
-        header: 'stopTime',
-        value: '124',
-      },
+      { stationName: 'Mid_East_station', header: 'stopTime', value: '124' },
       {
         stationName: 'West_station',
         header: 'theoreticalMargin',
@@ -279,62 +279,67 @@ test.describe('Simulation Settings Tab Verification', () => {
         marginForm: '% ou min/100km',
       },
     ];
-    for (const cell of inputTableData) {
-      const translatedHeader = cleanWhitespace(frTranslations[cell.header]);
-      await timesAndStopsTab.fillTableCellByStationAndHeader(
-        cell.stationName,
-        translatedHeader,
-        cell.value,
 
-        cell.marginForm
-      );
-    }
-    // Activate the 'Linear' margin
-    await operationalStudiesPage.openSimulationSettingsTab();
-    await simulationSettingsTab.deactivateElectricalProfile();
-    await simulationSettingsTab.activateLinearMargin();
-    // Add the train schedule and verify output results
-    await operationalStudiesPage.createTimetableItem();
-    await operationalStudiesPage.closeToastNotification();
-    await operationalStudiesPage.returnSimulationResult();
-    await scenarioTimetableSection.getTimetableItemArrivalTime('11:51');
-    await scenarioPage.toggleTrainList();
+    await test.step('Fill Times & Stops inputs (stop time + theoretical margin)', async () => {
+      for (const cell of inputTableData) {
+        const translatedHeader = cleanWhitespace(frTranslations[cell.header]);
+        await timesAndStopsTab.fillTableCellByStationAndHeader(
+          cell.stationName,
+          translatedHeader,
+          cell.value,
+          cell.marginForm
+        );
+      }
+    });
 
-    await timeAndStopSimulationOutputs.verifyTimesStopsDataSheetVisibility();
-    await simulationResultPage.selectAllSpeedSpaceChartCheckboxes();
-    if (browserName === 'chromium') {
-      await expect(simulationResultPage.speedSpaceChart).toHaveScreenshot(
-        'SpeedSpaceChart-LinearMargin.png'
-      );
-    }
-    await scrollContainer(page, '.time-stop-outputs .time-stops-datasheet .dsg-container');
-    await timeAndStopSimulationOutputs.getOutputTableData(expectedCellDataLinearMargin);
-    await scenarioPage.toggleTrainList(false);
-    // Modify the margin to 'Mareco' and verify the changes
-    await scenarioTimetableSection.editTimetableItem();
-    await operationalStudiesPage.openSimulationSettingsTab();
-    await simulationSettingsTab.activateMarecoMargin();
-    await operationalStudiesPage.submitTimetableItemEdit();
-    await scenarioPage.toggleTrainList();
+    await test.step('Enable Linear margin (electrical OFF)', async () => {
+      await operationalStudiesPage.openSimulationSettingsTab();
+      await simulationSettingsTab.deactivateElectricalProfile();
+      await simulationSettingsTab.activateLinearMargin();
+    });
 
-    await timeAndStopSimulationOutputs.verifyTimesStopsDataSheetVisibility();
-    await simulationResultPage.selectAllSpeedSpaceChartCheckboxes();
-    if (browserName === 'chromium') {
-      await expect(simulationResultPage.speedSpaceChart).toHaveScreenshot(
-        'SpeedSpaceChart-MarecoMargin.png'
-      );
-    }
-    await timeAndStopSimulationOutputs.getOutputTableData(expectedCellDataMarecoMargin);
-    await scenarioPage.toggleTrainList(false);
-    await scenarioTimetableSection.getTimetableItemArrivalTime('11:51');
+    await test.step('Create train schedule and verify (Linear)', async () => {
+      await operationalStudiesPage.createTimetableItem();
+      await operationalStudiesPage.closeToastNotification();
+      await operationalStudiesPage.returnSimulationResult();
+      await scenarioTimetableSection.getTimetableItemArrivalTime('11:51');
+      await scenarioPage.toggleTrainList();
+
+      await timeAndStopSimulationOutputs.verifyTimesStopsDataSheetVisibility();
+      await simulationResultPage.selectAllSpeedSpaceChartCheckboxes();
+      if (browserName === 'chromium') {
+        await expect(simulationResultPage.speedSpaceChart).toHaveScreenshot(
+          'SpeedSpaceChart-LinearMargin.png'
+        );
+      }
+      await scrollContainer(page, '.time-stop-outputs .time-stops-datasheet .dsg-container');
+      await timeAndStopSimulationOutputs.getOutputTableData(expectedCellDataLinearMargin);
+      await scenarioPage.toggleTrainList(false);
+    });
+
+    await test.step('Edit to Mareco margin and verify', async () => {
+      await scenarioTimetableSection.editTimetableItem();
+      await operationalStudiesPage.openSimulationSettingsTab();
+      await simulationSettingsTab.activateMarecoMargin();
+      await operationalStudiesPage.submitTimetableItemEdit();
+      await scenarioPage.toggleTrainList();
+
+      await timeAndStopSimulationOutputs.verifyTimesStopsDataSheetVisibility();
+      await simulationResultPage.selectAllSpeedSpaceChartCheckboxes();
+      if (browserName === 'chromium') {
+        await expect(simulationResultPage.speedSpaceChart).toHaveScreenshot(
+          'SpeedSpaceChart-MarecoMargin.png'
+        );
+      }
+      await timeAndStopSimulationOutputs.getOutputTableData(expectedCellDataMarecoMargin);
+      await scenarioPage.toggleTrainList(false);
+      await scenarioTimetableSection.getTimetableItemArrivalTime('11:51');
+    });
   });
+
   test('Add all the simulation settings', async ({ page, browserName }) => {
     const inputTableData: CellData[] = [
-      {
-        stationName: 'Mid_East_station',
-        header: 'stopTime',
-        value: '124',
-      },
+      { stationName: 'Mid_East_station', header: 'stopTime', value: '124' },
       {
         stationName: 'West_station',
         header: 'theoreticalMargin',
@@ -342,36 +347,43 @@ test.describe('Simulation Settings Tab Verification', () => {
         marginForm: '% ou min/100km',
       },
     ];
-    for (const cell of inputTableData) {
-      const translatedHeader = cleanWhitespace(frTranslations[cell.header]);
-      await timesAndStopsTab.fillTableCellByStationAndHeader(
-        cell.stationName,
-        translatedHeader,
-        cell.value,
 
-        cell.marginForm
-      );
-    }
-    // Activate the 'Linear' margin, electrical profile and composition code
-    await operationalStudiesPage.openSimulationSettingsTab();
-    await simulationSettingsTab.checkElectricalProfile();
-    await simulationSettingsTab.activateLinearMargin();
-    await simulationSettingsTab.selectSpeedLimitTagOption('E32C');
-    // Add the train schedule and verify output results
-    await operationalStudiesPage.createTimetableItem();
-    await operationalStudiesPage.closeToastNotification();
-    await operationalStudiesPage.returnSimulationResult();
-    await scenarioPage.toggleTrainList();
-    await timeAndStopSimulationOutputs.verifyTimesStopsDataSheetVisibility();
-    await simulationResultPage.selectAllSpeedSpaceChartCheckboxes();
-    if (browserName === 'chromium') {
-      await expect(simulationResultPage.speedSpaceChart).toHaveScreenshot(
-        'SpeedSpaceChart-AllSettingsEnabled.png'
-      );
-    }
-    await scrollContainer(page, '.time-stop-outputs .time-stops-datasheet .dsg-container');
-    await timeAndStopSimulationOutputs.getOutputTableData(expectedCellDataForAllSettings);
-    await scenarioPage.toggleTrainList(false);
-    await scenarioTimetableSection.getTimetableItemArrivalTime('11:50');
+    await test.step('Fill Times & Stops inputs', async () => {
+      for (const cell of inputTableData) {
+        const translatedHeader = cleanWhitespace(frTranslations[cell.header]);
+        await timesAndStopsTab.fillTableCellByStationAndHeader(
+          cell.stationName,
+          translatedHeader,
+          cell.value,
+          cell.marginForm
+        );
+      }
+    });
+
+    await test.step('Enable Linear margin + electrical profile + speed limit tag', async () => {
+      await operationalStudiesPage.openSimulationSettingsTab();
+      await simulationSettingsTab.checkElectricalProfile();
+      await simulationSettingsTab.activateLinearMargin();
+      await simulationSettingsTab.selectSpeedLimitTagOption('E32C');
+    });
+
+    await test.step('Create train schedule and verify outputs (all settings ON)', async () => {
+      await operationalStudiesPage.createTimetableItem();
+      await operationalStudiesPage.closeToastNotification();
+      await operationalStudiesPage.returnSimulationResult();
+      await scenarioPage.toggleTrainList();
+
+      await timeAndStopSimulationOutputs.verifyTimesStopsDataSheetVisibility();
+      await simulationResultPage.selectAllSpeedSpaceChartCheckboxes();
+      if (browserName === 'chromium') {
+        await expect(simulationResultPage.speedSpaceChart).toHaveScreenshot(
+          'SpeedSpaceChart-AllSettingsEnabled.png'
+        );
+      }
+      await scrollContainer(page, '.time-stop-outputs .time-stops-datasheet .dsg-container');
+      await timeAndStopSimulationOutputs.getOutputTableData(expectedCellDataForAllSettings);
+      await scenarioPage.toggleTrainList(false);
+      await scenarioTimetableSection.getTimetableItemArrivalTime('11:50');
+    });
   });
 });

--- a/front/tests/010-stdcm.spec.ts
+++ b/front/tests/010-stdcm.spec.ts
@@ -14,8 +14,18 @@ import { waitForInfraStateToBeCached } from './utils';
 import { getInfra, setTowedRollingStock } from './utils/api-utils';
 import type { ConsistFields } from './utils/types';
 
+const consistDetails: ConsistFields = {
+  tractionEngine: electricRollingStockName,
+  tonnage: '950',
+  length: '567',
+  speedLimitTag: 'HLP',
+};
+const tractionEnginePrefilledValues = { tonnage: '900', length: '400' };
+const fastRollingStockPrefilledValues = { tonnage: '190', length: '46' };
+const towedRollingStockPrefilledValues = { tonnage: '46', length: '26' };
+
 test.describe('Verify stdcm simulation page', () => {
-  test.slow(); // Mark test as slow due to multiple steps
+  test.slow();
   test.use({ viewport: { width: 1920, height: 1080 } });
 
   let stdcmPage: STDCMPage;
@@ -28,25 +38,6 @@ test.describe('Verify stdcm simulation page', () => {
 
   let infra: Infra;
   let createdTowedRollingStock: TowedRollingStock;
-
-  const consistDetails: ConsistFields = {
-    tractionEngine: electricRollingStockName,
-    tonnage: '950',
-    length: '567',
-    speedLimitTag: 'HLP',
-  };
-  const tractionEnginePrefilledValues = {
-    tonnage: '900',
-    length: '400',
-  };
-  const fastRollingStockPrefilledValues = {
-    tonnage: '190',
-    length: '46',
-  };
-  const towedRollingStockPrefilledValues = {
-    tonnage: '46',
-    length: '26',
-  };
 
   test.beforeAll('Fetch infrastructure', async () => {
     infra = await getInfra();
@@ -79,43 +70,54 @@ test.describe('Verify stdcm simulation page', () => {
 
   /** *************** Test 1 **************** */
   test('Verify default STDCM page', async () => {
-    // Verify visibility of STDCM elements and handle default fields
+    await test.step('Verify base UI sections are visible', async () => {
+      await stdcmPage.verifyStdcmElementsVisibility();
+    });
 
-    await stdcmPage.verifyStdcmElementsVisibility();
-    await consistSection.verifyDefaultConsistFields();
-    await originSection.verifyDefaultOriginFields();
-    await destinationSection.verifyDefaultDestinationFields();
-    await viaSection.addAndDeletedDefaultVia();
-    await linkedTrainSection.addAndDeleteDefaultLinkedPath();
+    await test.step('Verify default input values', async () => {
+      await consistSection.verifyDefaultConsistFields();
+      await originSection.verifyDefaultOriginFields();
+      await destinationSection.verifyDefaultDestinationFields();
+    });
+
+    await test.step('Add/delete default via and linked path', async () => {
+      await viaSection.addAndDeletedDefaultVia();
+      await linkedTrainSection.addAndDeleteDefaultLinkedPath();
+    });
   });
 
   /** *************** Test 2 **************** */
   test('Launch STDCM simulation with all stops', async () => {
-    // Populate STDCM page with origin, destination, and via details, then verify
-    await consistSection.fillAndVerifyConsistDetails(
-      consistDetails,
-      tractionEnginePrefilledValues.tonnage,
-      tractionEnginePrefilledValues.length
-    );
-    await originSection.fillAndVerifyOriginDetails();
-    await destinationSection.fillAndVerifyDestinationDetails();
-    const viaDetails = [
-      { viaNumber: 1, ciSearchText: 'mid_west' },
-      { viaNumber: 2, ciSearchText: 'mid_east' },
-      { viaNumber: 3, ciSearchText: 'nS' },
-    ];
-
-    for (const viaDetail of viaDetails) {
-      await viaSection.fillAndVerifyViaDetails(viaDetail);
-    }
-    // Launch simulation and verify output data matches expected results
-    await stdcmPage.verifyValidSimulationLaunch();
-    await simulationResultPage.verifySimulationDetails({
-      simulationIndex: 0,
-      simulationLengthAndDuration: '51 km — 42min',
-      validSimulationNumber: 1,
+    await test.step('Fill consist, origin and destination', async () => {
+      await consistSection.fillAndVerifyConsistDetails(
+        consistDetails,
+        tractionEnginePrefilledValues.tonnage,
+        tractionEnginePrefilledValues.length
+      );
+      await originSection.fillAndVerifyOriginDetails();
+      await destinationSection.fillAndVerifyDestinationDetails();
     });
-    await simulationResultPage.verifyTableData('./tests/assets/stdcm/stdcm-all-stops.json');
+
+    await test.step('Fill three vias and verify each', async () => {
+      const viaDetails = [
+        { viaNumber: 1, ciSearchText: 'mid_west' },
+        { viaNumber: 2, ciSearchText: 'mid_east' },
+        { viaNumber: 3, ciSearchText: 'nS' },
+      ];
+      for (const viaDetail of viaDetails) {
+        await viaSection.fillAndVerifyViaDetails(viaDetail);
+      }
+    });
+
+    await test.step('Launch simulation and verify results table', async () => {
+      await stdcmPage.verifyValidSimulationLaunch();
+      await simulationResultPage.verifySimulationDetails({
+        simulationIndex: 0,
+        simulationLengthAndDuration: '51 km — 42min',
+        validSimulationNumber: 1,
+      });
+      await simulationResultPage.verifyTableData('./tests/assets/stdcm/stdcm-all-stops.json');
+    });
   });
 
   /** *************** Test 3 **************** */
@@ -125,34 +127,40 @@ test.describe('Verify stdcm simulation page', () => {
       towedRollingStock: createdTowedRollingStock.name,
     };
 
-    await consistSection.fillAndVerifyConsistDetails(
-      towedConsistDetails,
-      fastRollingStockPrefilledValues.tonnage,
-      fastRollingStockPrefilledValues.length,
-      towedRollingStockPrefilledValues.tonnage,
-      towedRollingStockPrefilledValues.length
-    );
-    await originSection.fillOriginDetailsLight(CONFLICT_ARRIVAL_TIME);
-    await destinationSection.fillDestinationDetailsLight();
-    await viaSection.fillAndVerifyViaDetails({
-      viaNumber: 1,
-      ciSearchText: 'mid_west',
+    await test.step('Fill consist section with towed RS and route', async () => {
+      await consistSection.fillAndVerifyConsistDetails(
+        towedConsistDetails,
+        fastRollingStockPrefilledValues.tonnage,
+        fastRollingStockPrefilledValues.length,
+        towedRollingStockPrefilledValues.tonnage,
+        towedRollingStockPrefilledValues.length
+      );
+      await originSection.fillOriginDetailsLight(CONFLICT_ARRIVAL_TIME);
+      await destinationSection.fillDestinationDetailsLight();
+      await viaSection.fillAndVerifyViaDetails({ viaNumber: 1, ciSearchText: 'mid_west' });
     });
-    // Run first simulation without capacity
-    await stdcmPage.verifyValidSimulationLaunch();
-    await simulationResultPage.verifySimulationDetails({
-      simulationIndex: 0,
+
+    await test.step('Launch simulation (expect alternative simulations triggered)', async () => {
+      await stdcmPage.verifyValidSimulationLaunch();
     });
-    await simulationResultPage.verifySimulationDetails({
-      simulationIndex: 1,
-      simulationLengthAndDuration: '51 km — 2h 35min',
-      validSimulationNumber: 1,
+
+    await test.step('Initial simulation result is "No capacity"', async () => {
+      await simulationResultPage.verifySimulationDetails({ simulationIndex: 0 });
     });
-    await simulationResultPage.verifyTableData(
-      './tests/assets/stdcm/towed-rolling-stock/towed-rolling-stock-table-result.json'
-    );
-    await simulationResultPage.verifySimulationDetails({
-      simulationIndex: 2,
+
+    await test.step('First alternative simulation is VALID (51 km — 2h 35min) and verify details', async () => {
+      await simulationResultPage.verifySimulationDetails({
+        simulationIndex: 1,
+        simulationLengthAndDuration: '51 km — 2h 35min',
+        validSimulationNumber: 1,
+      });
+      await simulationResultPage.verifyTableData(
+        './tests/assets/stdcm/towed-rolling-stock/towed-rolling-stock-table-result.json'
+      );
+    });
+
+    await test.step('Second alternative simulation result is "No capacity"', async () => {
+      await simulationResultPage.verifySimulationDetails({ simulationIndex: 2 });
     });
   });
 });

--- a/front/tests/011-stdcm-simulation-sheet.spec.ts
+++ b/front/tests/011-stdcm-simulation-sheet.spec.ts
@@ -16,9 +16,22 @@ import { getInfra } from './utils/api-utils';
 import { findFirstPdf, parsePdfText, verifySimulationContent } from './utils/pdf-parser';
 import type { ConsistFields, PdfSimulationContent } from './utils/types';
 
+const consistDetails: ConsistFields = {
+  tractionEngine: electricRollingStockName,
+  tonnage: '950',
+  length: '567',
+  maxSpeed: '100',
+  speedLimitTag: 'HLP',
+};
+const tractionEnginePrefilledValues = {
+  tonnage: '900',
+  length: '400',
+  maxSpeed: '288',
+};
+
 test.describe('Verify stdcm simulation page', () => {
-  test.describe.configure({ mode: 'serial' }); // Configure this block to run serially
-  test.slow(); // Mark test as slow due to multiple steps
+  test.describe.configure({ mode: 'serial' });
+  test.slow();
   test.use({ viewport: { width: 1920, height: 1080 } });
 
   let stdcmPage: STDCMPage;
@@ -29,19 +42,6 @@ test.describe('Verify stdcm simulation page', () => {
   let simulationResultPage: SimulationResultPage;
 
   let infra: Infra;
-
-  const consistDetails: ConsistFields = {
-    tractionEngine: electricRollingStockName,
-    tonnage: '950',
-    length: '567',
-    maxSpeed: '100',
-    speedLimitTag: 'HLP',
-  };
-  const tractionEnginePrefilledValues = {
-    tonnage: '900',
-    length: '400',
-    maxSpeed: '288',
-  };
 
   test.beforeAll('Fetch infrastructure', async () => {
     infra = await getInfra();
@@ -63,10 +63,9 @@ test.describe('Verify stdcm simulation page', () => {
       new DestinationSection(page),
       new SimulationResultPage(page),
     ];
+
     await page.goto('/stdcm');
     await stdcmPage.removeViteOverlay();
-
-    // Wait for infra to be in 'CACHED' state before proceeding
     await waitForInfraStateToBeCached(infra.id);
   });
 
@@ -74,62 +73,77 @@ test.describe('Verify stdcm simulation page', () => {
 
   /** *************** Test 1 **************** */
   test('Verify STDCM stops and simulation sheet', async ({ browserName, context }, testInfo) => {
-    // Populate STDCM page with origin, destination, and via details
-    await consistSection.fillAndVerifyConsistDetails(
-      consistDetails,
-      tractionEnginePrefilledValues.tonnage,
-      tractionEnginePrefilledValues.length,
-      tractionEnginePrefilledValues.maxSpeed
-    );
-    await originSection.fillOriginDetailsLight();
-    await destinationSection.fillDestinationDetailsLight();
-    await viaSection.fillAndVerifyViaDetails({
-      viaNumber: 1,
-      ciSearchText: 'mid_west',
+    await test.step('Fill consist, origin, destination and via', async () => {
+      await consistSection.fillAndVerifyConsistDetails(
+        consistDetails,
+        tractionEnginePrefilledValues.tonnage,
+        tractionEnginePrefilledValues.length,
+        tractionEnginePrefilledValues.maxSpeed
+      );
+      await originSection.fillOriginDetailsLight();
+      await destinationSection.fillDestinationDetailsLight();
+      await viaSection.fillAndVerifyViaDetails({ viaNumber: 1, ciSearchText: 'mid_west' });
     });
-    // Verify input map markers in Chromium
-    if (browserName === 'chromium') {
-      await stdcmPage.mapMarkerVisibility();
-    }
-    // Launch simulation and verify output data matches expected results
-    await stdcmPage.verifyValidSimulationLaunch();
-    // Verify map results markers in Chromium
-    if (browserName === 'chromium') {
-      await simulationResultPage.mapMarkerResultVisibility();
-    }
-    await simulationResultPage.verifyTableData('./tests/assets/stdcm/stdcm-without-all-via.json');
-    await simulationResultPage.displayAllOperationalPoints();
-    await simulationResultPage.verifyTableData('./tests/assets/stdcm/stdcm-with-all-via.json');
-    await simulationResultPage.retainSimulation();
-    downloadDir = testInfo.outputDir;
-    await simulationResultPage.downloadSimulation(downloadDir);
-    // Reset and verify empty fields
-    const [newPage] = await Promise.all([
-      context.waitForEvent('page'),
-      simulationResultPage.startNewQuery(),
-    ]);
-    await newPage.waitForLoadState();
-    const [newConsistSection, newOriginSection, newDestinationSection] = [
-      new ConsistSection(newPage),
-      new OriginSection(newPage),
-      new DestinationSection(newPage),
-    ];
-    await newConsistSection.verifyDefaultConsistFields();
-    await newOriginSection.verifyDefaultOriginFields();
-    await newDestinationSection.verifyDefaultDestinationFields();
+
+    await test.step('Verify input map markers (Chromium only)', async () => {
+      if (browserName === 'chromium') {
+        await stdcmPage.mapMarkerVisibility();
+      }
+    });
+
+    await test.step('Launch simulation', async () => {
+      await stdcmPage.verifyValidSimulationLaunch();
+    });
+
+    await test.step('Verify result map markers and tables', async () => {
+      if (browserName === 'chromium') {
+        await simulationResultPage.mapMarkerResultVisibility();
+      }
+      await simulationResultPage.verifyTableData('./tests/assets/stdcm/stdcm-without-all-via.json');
+      await simulationResultPage.displayAllOperationalPoints();
+      await simulationResultPage.verifyTableData('./tests/assets/stdcm/stdcm-with-all-via.json');
+    });
+
+    await test.step('Retain & download simulation PDF', async () => {
+      await simulationResultPage.retainSimulation();
+      downloadDir = testInfo.outputDir;
+      await simulationResultPage.downloadSimulation(downloadDir);
+    });
+
+    await test.step('Start a new query and verify fields are reset', async () => {
+      const [newPage] = await Promise.all([
+        context.waitForEvent('page'),
+        simulationResultPage.startNewQuery(),
+      ]);
+      await newPage.waitForLoadState();
+
+      const [newConsistSection, newOriginSection, newDestinationSection] = [
+        new ConsistSection(newPage),
+        new OriginSection(newPage),
+        new DestinationSection(newPage),
+      ];
+
+      await newConsistSection.verifyDefaultConsistFields();
+      await newOriginSection.verifyDefaultOriginFields();
+      await newDestinationSection.verifyDefaultDestinationFields();
+    });
   });
 
   /** *************** Test 2 *************** */
   test('Verify simulation sheet content', async () => {
-    const pdfFilePath = findFirstPdf(downloadDir!);
+    const pdfFilePath = await test.step('Find the downloaded PDF', async () => {
+      const filePath = findFirstPdf(downloadDir!);
+      if (!filePath) {
+        throw new Error(`No PDF files found in directory: ${downloadDir}`);
+      }
+      return filePath;
+    });
 
-    if (!pdfFilePath) {
-      throw new Error(`No PDF files found in directory: ${downloadDir}`);
-    }
-    // Read and parse the PDF
-    const pdfBuffer = fs.readFileSync(pdfFilePath);
-    const actualPdfSimulationContent = await parsePdfText(pdfBuffer);
-    const expectedPdfSimulationContent: PdfSimulationContent = simulationSheetDetails();
-    verifySimulationContent(actualPdfSimulationContent, expectedPdfSimulationContent);
+    await test.step('Parse PDF and compare with expected content', async () => {
+      const pdfBuffer = fs.readFileSync(pdfFilePath);
+      const actualPdfSimulationContent = await parsePdfText(pdfBuffer);
+      const expectedPdfSimulationContent: PdfSimulationContent = simulationSheetDetails();
+      verifySimulationContent(actualPdfSimulationContent, expectedPdfSimulationContent);
+    });
   });
 });

--- a/front/tests/012-stdcm-feedback-mail.spec.ts
+++ b/front/tests/012-stdcm-feedback-mail.spec.ts
@@ -13,8 +13,22 @@ import { waitForInfraStateToBeCached } from './utils';
 import { getInfra } from './utils/api-utils';
 import type { ConsistFields } from './utils/types';
 
-test.describe('FeedbackCard Tests', () => {
-  test.slow(); // Mark test as slow due to multiple steps
+const consistDetails: ConsistFields = {
+  tractionEngine: electricRollingStockName,
+  tonnage: '950',
+  length: '567',
+  maxSpeed: '100',
+  speedLimitTag: 'HLP',
+};
+
+const tractionEnginePrefilledValues = {
+  tonnage: '900',
+  length: '400',
+  maxSpeed: '288',
+};
+
+test.describe('Stdcm feedback card', () => {
+  test.slow();
   test.use({ viewport: { width: 1920, height: 1080 } });
 
   let stdcmPage: STDCMPage;
@@ -23,20 +37,6 @@ test.describe('FeedbackCard Tests', () => {
   let destinationSection: DestinationSection;
   let simulationResultPage: SimulationResultPage;
   let infra: Infra;
-
-  const consistDetails: ConsistFields = {
-    tractionEngine: electricRollingStockName,
-    tonnage: '950',
-    length: '567',
-    maxSpeed: '100',
-    speedLimitTag: 'HLP',
-  };
-
-  const tractionEnginePrefilledValues = {
-    tonnage: '900',
-    length: '400',
-    maxSpeed: '288',
-  };
 
   test.beforeAll('Fetch infrastructure', async () => {
     infra = await getInfra();
@@ -52,28 +52,41 @@ test.describe('FeedbackCard Tests', () => {
     ];
     await page.goto('/stdcm');
     await stdcmPage.removeViteOverlay();
-    // Wait for infra to be in 'CACHED' state before proceeding
     await waitForInfraStateToBeCached(infra.id);
   });
 
-  test('Verify FeedbackCard visibility and mail redirection', async () => {
-    await consistSection.fillAndVerifyConsistDetails(
-      consistDetails,
-      tractionEnginePrefilledValues.tonnage,
-      tractionEnginePrefilledValues.length,
-      tractionEnginePrefilledValues.maxSpeed
-    );
-    await originSection.fillOriginDetailsLight();
-    await destinationSection.fillDestinationDetailsLight();
-    await stdcmPage.verifyValidSimulationLaunch();
-    await simulationResultPage.verifySimulationDetails({
-      simulationIndex: 0,
-      simulationLengthAndDuration: '51 km — 33min',
-      validSimulationNumber: 1,
+  /** *************** Test 1 **************** */
+  test('Verify feedback card visibility and mail redirection', async () => {
+    await test.step('Fill consist with traction engine details and verify prefilled values', async () => {
+      await consistSection.fillAndVerifyConsistDetails(
+        consistDetails,
+        tractionEnginePrefilledValues.tonnage,
+        tractionEnginePrefilledValues.length,
+        tractionEnginePrefilledValues.maxSpeed
+      );
     });
-    await simulationResultPage.verifyFeedbackCardVisibility();
 
-    const { expectedSubject, expectedBody, expectedMail } = getMailFeedbackData();
-    await simulationResultPage.verifyMailRedirection(expectedSubject, expectedBody, expectedMail);
+    await test.step('Fill origin and destination', async () => {
+      await originSection.fillOriginDetailsLight();
+      await destinationSection.fillDestinationDetailsLight();
+    });
+
+    await test.step('Launch simulation and verify simulation details', async () => {
+      await stdcmPage.verifyValidSimulationLaunch();
+      await simulationResultPage.verifySimulationDetails({
+        simulationIndex: 0,
+        simulationLengthAndDuration: '51 km — 33min',
+        validSimulationNumber: 1,
+      });
+    });
+
+    await test.step('Verify feedback card is visible', async () => {
+      await simulationResultPage.verifyFeedbackCardVisibility();
+    });
+
+    await test.step('Verify mail redirection from feedback card', async () => {
+      const { expectedSubject, expectedBody, expectedMail } = getMailFeedbackData();
+      await simulationResultPage.verifyMailRedirection(expectedSubject, expectedBody, expectedMail);
+    });
   });
 });

--- a/front/tests/013-stdcm-linked-train.spec.ts
+++ b/front/tests/013-stdcm-linked-train.spec.ts
@@ -13,8 +13,19 @@ import { waitForInfraStateToBeCached } from './utils';
 import { getInfra, setTowedRollingStock } from './utils/api-utils';
 import type { ConsistFields } from './utils/types';
 
+const fastRollingStockPrefilledValues = {
+  tonnage: '190',
+  length: '46',
+  maxSpeed: '220',
+};
+const towedRollingStockPrefilledValues = {
+  tonnage: '46',
+  length: '26',
+  maxSpeed: '180',
+};
+
 test.describe('Verify stdcm simulation page', () => {
-  test.slow(); // Mark test as slow due to multiple steps
+  test.slow();
   test.use({ viewport: { width: 1920, height: 1080 } });
 
   let stdcmPage: STDCMPage;
@@ -28,17 +39,6 @@ test.describe('Verify stdcm simulation page', () => {
   let infra: Infra;
   let createdTowedRollingStock: TowedRollingStock;
   let towedConsistDetails: ConsistFields;
-
-  const fastRollingStockPrefilledValues = {
-    tonnage: '190',
-    length: '46',
-    maxSpeed: '220',
-  };
-  const towedRollingStockPrefilledValues = {
-    tonnage: '46',
-    length: '26',
-    maxSpeed: '180',
-  };
 
   test.beforeAll('Fetch infrastructure', async () => {
     infra = await getInfra();
@@ -67,59 +67,72 @@ test.describe('Verify stdcm simulation page', () => {
       new SimulationResultPage(page),
       new LinkedTrainSection(page),
     ];
-    // Navigate to STDCM page
+
     await page.goto('/stdcm');
     await stdcmPage.removeViteOverlay();
-
-    // Wait for infra to be in 'CACHED' state before proceeding
     await waitForInfraStateToBeCached(infra.id);
   });
 
   /** *************** Test 1 **************** */
   test('Verify STDCM anterior linked train', async ({ page: _ }, testInfo) => {
-    await consistSection.fillAndVerifyConsistDetails(
-      towedConsistDetails,
-      fastRollingStockPrefilledValues.tonnage,
-      fastRollingStockPrefilledValues.length,
-      towedRollingStockPrefilledValues.tonnage,
-      towedRollingStockPrefilledValues.length
-    );
-    await linkedTrainSection.anteriorLinkedPathDetails();
-    await destinationSection.fillDestinationDetailsLight();
-    await viaSection.fillAndVerifyViaDetails({
-      viaNumber: 1,
-      ciSearchText: 'nS',
+    await test.step('Fill consist with traction engine details + towed RS and verify prefilled values', async () => {
+      await consistSection.fillAndVerifyConsistDetails(
+        towedConsistDetails,
+        fastRollingStockPrefilledValues.tonnage,
+        fastRollingStockPrefilledValues.length,
+        towedRollingStockPrefilledValues.tonnage,
+        towedRollingStockPrefilledValues.length
+      );
     });
-    await destinationSection.fillDestinationDetailsLight();
-    await stdcmPage.verifyValidSimulationLaunch();
-    await simulationResultPage.verifyTableData(
-      './tests/assets/stdcm/linked-train/anterior-linked-train-table.json'
-    );
-    await simulationResultPage.retainSimulation();
-    await simulationResultPage.downloadSimulation(testInfo.outputDir);
+
+    await test.step('Configure anterior linked path, destinations and vias', async () => {
+      await linkedTrainSection.anteriorLinkedPathDetails();
+      await destinationSection.fillDestinationDetailsLight();
+      await viaSection.fillAndVerifyViaDetails({ viaNumber: 1, ciSearchText: 'nS' });
+      await destinationSection.fillDestinationDetailsLight();
+    });
+
+    await test.step('Launch simulation and verify outputs', async () => {
+      await stdcmPage.verifyValidSimulationLaunch();
+      await simulationResultPage.verifyTableData(
+        './tests/assets/stdcm/linked-train/anterior-linked-train-table.json'
+      );
+    });
+
+    await test.step('Retain + download simulation PDF', async () => {
+      await simulationResultPage.retainSimulation();
+      await simulationResultPage.downloadSimulation(testInfo.outputDir);
+    });
   });
 
   /** *************** Test 2 **************** */
   test('Verify STDCM posterior linked train', async ({ page: _ }, testInfo) => {
-    // Preserve the order of section filling to avoid race conditions caused by Playwright's execution speed.
-    await originSection.fillOriginDetailsLight(undefined, 'respectDestinationSchedule', true);
-    await linkedTrainSection.posteriorLinkedPathDetails();
-    await viaSection.fillAndVerifyViaDetails({
-      viaNumber: 1,
-      ciSearchText: 'mid_east',
+    await test.step('Fill origin with posterior constraints and linked path', async () => {
+      await originSection.fillOriginDetailsLight(undefined, 'respectDestinationSchedule', true);
+      await linkedTrainSection.posteriorLinkedPathDetails();
+      await viaSection.fillAndVerifyViaDetails({ viaNumber: 1, ciSearchText: 'mid_east' });
     });
-    await consistSection.fillAndVerifyConsistDetails(
-      towedConsistDetails,
-      fastRollingStockPrefilledValues.tonnage,
-      fastRollingStockPrefilledValues.length,
-      towedRollingStockPrefilledValues.tonnage,
-      towedRollingStockPrefilledValues.length
-    );
-    await stdcmPage.verifyValidSimulationLaunch();
-    await simulationResultPage.verifyTableData(
-      './tests/assets/stdcm/linked-train/posterior-linked-train-table.json'
-    );
-    await simulationResultPage.retainSimulation();
-    await simulationResultPage.downloadSimulation(testInfo.outputDir);
+
+    await test.step('Fill consist with traction engine details + towed RS and verify prefilled values', async () => {
+      await consistSection.fillAndVerifyConsistDetails(
+        towedConsistDetails,
+        fastRollingStockPrefilledValues.tonnage,
+        fastRollingStockPrefilledValues.length,
+        towedRollingStockPrefilledValues.tonnage,
+        towedRollingStockPrefilledValues.length
+      );
+    });
+
+    await test.step('Launch simulation and verify outputs', async () => {
+      await stdcmPage.verifyValidSimulationLaunch();
+      await simulationResultPage.verifyTableData(
+        './tests/assets/stdcm/linked-train/posterior-linked-train-table.json'
+      );
+    });
+
+    await test.step('Retain + download simulation PDF', async () => {
+      await simulationResultPage.retainSimulation();
+      await simulationResultPage.downloadSimulation(testInfo.outputDir);
+    });
   });
 });

--- a/front/tests/014-stdcm-missing-fields.spec.ts
+++ b/front/tests/014-stdcm-missing-fields.spec.ts
@@ -21,7 +21,6 @@ import type { StdcmTranslations } from './utils/types';
 const frTranslations: StdcmTranslations = readJsonFile('public/locales/fr/stdcm.json');
 
 test.describe('Verify stdcm missing fields', () => {
-  test.slow(); // Mark test as slow due to multiple steps
   test.use({ viewport: { width: 1920, height: 1080 } });
 
   let stdcmPage: STDCMPage;
@@ -47,77 +46,81 @@ test.describe('Verify stdcm missing fields', () => {
     await page.goto('/stdcm');
     await stdcmPage.removeViteOverlay();
 
-    // Wait for infra to be in 'CACHED' state before proceeding
     await waitForInfraStateToBeCached(infra.id);
   });
 
   /** *************** Test 1 **************** */
   test('Verify missing fields warnings when launching simulation', async () => {
-    // Step 1 — Launch simulation with all fields empty and expect all missing field warnings
-    const allMissingLabels = getFieldsLabel(ALL_MISSING_FIELDS_KEY, frTranslations);
-    await stdcmPage.verifyInvalidSimulationLaunch();
-    await stdcmPage.expectWarningBoxVisible();
-    await stdcmPage.expectWarningBoxContains(allMissingLabels);
-
-    // Step 2 — Fill origin and destination, launch again and expect only partial missing field warnings
-    await originSection.fillOriginDetailsLight();
-    await destinationSection.fillDestinationDetailsLight();
-    await stdcmPage.verifyInvalidSimulationLaunch();
-    await stdcmPage.expectWarningBoxVisible();
-    const partialMissingLabels = getFieldsLabel(PARTIAL_MISSING_FIELDS_KEYS, frTranslations);
-    const nonMissingLabels = getFieldsLabel(REMOVED_MISSING_FIELDS_KEYS, frTranslations);
-    await stdcmPage.expectWarningBoxContains(partialMissingLabels, nonMissingLabels);
-
-    // Step 3 — Launch simulation with all mandatory fields filled
-    await consistSection.fillAndVerifyConsistDetails(
-      { tractionEngine: electricRollingStockName },
-      '900',
-      '400'
-    );
-    await stdcmPage.verifyValidSimulationLaunch();
-    await stdcmPage.expectWarningBoxHidden();
-    await simulationResultPage.verifySimulationDetails({
-      simulationIndex: 0,
-      simulationLengthAndDuration: '51 km — 33min',
-      validSimulationNumber: 1,
+    await test.step('Launch simulation with all fields empty → expect all missing field warnings', async () => {
+      const allMissingLabels = getFieldsLabel(ALL_MISSING_FIELDS_KEY, frTranslations);
+      await stdcmPage.verifyInvalidSimulationLaunch();
+      await stdcmPage.expectWarningBoxVisible();
+      await stdcmPage.expectWarningBoxContains(allMissingLabels);
     });
 
-    // Step 4 — Enter invalid values for tonnage, length and max speed
-    await consistSection.setTonnage('30');
-    await consistSection.setLength('12');
-    await consistSection.setMaxSpeed('7');
-    await stdcmPage.verifyInvalidSimulationLaunch();
-    await stdcmPage.expectWarningBoxVisible();
-    await stdcmPage.expectWarningBoxContains([
-      frTranslations.stdcmErrors.invalidFields.totalMass,
-      frTranslations.stdcmErrors.invalidFields.totalLength,
-      frTranslations.stdcmErrors.invalidFields.maxSpeed,
-    ]);
+    await test.step('Fill origin and destination → expect partial missing field warnings', async () => {
+      await originSection.fillOriginDetailsLight();
+      await destinationSection.fillDestinationDetailsLight();
+      await stdcmPage.verifyInvalidSimulationLaunch();
+      await stdcmPage.expectWarningBoxVisible();
+      const partialMissingLabels = getFieldsLabel(PARTIAL_MISSING_FIELDS_KEYS, frTranslations);
+      const nonMissingLabels = getFieldsLabel(REMOVED_MISSING_FIELDS_KEYS, frTranslations);
+      await stdcmPage.expectWarningBoxContains(partialMissingLabels, nonMissingLabels);
+    });
 
-    // Step 5 — Fix tonnage, clear length and destination and expect both missing and invalid field warnings
-    await consistSection.setTonnage('900');
-    await consistSection.clearLength();
-    await destinationSection.clearDestination();
-    await stdcmPage.verifyInvalidSimulationLaunch();
-    await stdcmPage.expectWarningBoxVisible();
+    await test.step('Fill all mandatory fields → expect valid simulation', async () => {
+      await consistSection.fillAndVerifyConsistDetails(
+        { tractionEngine: electricRollingStockName },
+        '900',
+        '400'
+      );
+      await stdcmPage.verifyValidSimulationLaunch();
+      await stdcmPage.expectWarningBoxHidden();
+      await simulationResultPage.verifySimulationDetails({
+        simulationIndex: 0,
+        simulationLengthAndDuration: '51 km — 33min',
+        validSimulationNumber: 1,
+      });
+    });
 
-    await stdcmPage.expectWarningBoxContains([
-      frTranslations.stdcmErrors.missingFields.destination,
-      frTranslations.stdcmErrors.missingFields.totalLength,
-      frTranslations.stdcmErrors.invalidFields.maxSpeed,
-    ]);
+    await test.step('Enter invalid tonnage, length and max speed → expect invalid field warnings', async () => {
+      await consistSection.setTonnage('30');
+      await consistSection.setLength('12');
+      await consistSection.setMaxSpeed('7');
+      await stdcmPage.verifyInvalidSimulationLaunch();
+      await stdcmPage.expectWarningBoxVisible();
+      await stdcmPage.expectWarningBoxContains([
+        frTranslations.stdcmErrors.invalidFields.totalMass,
+        frTranslations.stdcmErrors.invalidFields.totalLength,
+        frTranslations.stdcmErrors.invalidFields.maxSpeed,
+      ]);
+    });
 
-    // Step 6 — Fill all fields with valid values and verify simulation
-    await consistSection.setLength('400');
-    await consistSection.setMaxSpeed('160');
-    await destinationSection.fillDestinationDetailsLight();
+    await test.step('Fix tonnage, clear length and destination → expect missing + invalid warnings', async () => {
+      await consistSection.setTonnage('900');
+      await consistSection.clearLength();
+      await destinationSection.clearDestination();
+      await stdcmPage.verifyInvalidSimulationLaunch();
+      await stdcmPage.expectWarningBoxVisible();
+      await stdcmPage.expectWarningBoxContains([
+        frTranslations.stdcmErrors.missingFields.destination,
+        frTranslations.stdcmErrors.missingFields.totalLength,
+        frTranslations.stdcmErrors.invalidFields.maxSpeed,
+      ]);
+    });
 
-    await stdcmPage.verifyValidSimulationLaunch();
-    await stdcmPage.expectWarningBoxHidden();
-    await simulationResultPage.verifySimulationDetails({
-      simulationIndex: 1,
-      simulationLengthAndDuration: '51 km — 22min',
-      validSimulationNumber: 2,
+    await test.step('Fill all fields with valid values → expect valid simulation', async () => {
+      await consistSection.setLength('400');
+      await consistSection.setMaxSpeed('160');
+      await destinationSection.fillDestinationDetailsLight();
+
+      await stdcmPage.verifyValidSimulationLaunch();
+      await stdcmPage.expectWarningBoxHidden();
+      await simulationResultPage.verifySimulationDetails({
+        simulationIndex: 1,
+        simulationLengthAndDuration: '51 km — 22min',
+        validSimulationNumber: 2,
+      });
     });
   });
 });

--- a/front/tests/015-train-timetable.spec.ts
+++ b/front/tests/015-train-timetable.spec.ts
@@ -69,164 +69,188 @@ test.describe('Verify train schedule elements and filters', () => {
     infra = await getInfra();
   });
 
-  test.beforeEach('Navigate to scenario page before each test', async ({ page }) => {
-    [operationalStudiesPage, scenarioTimetableSection, pacedTrainSection] = [
-      new OperationalStudiesPage(page),
-      new ScenarioTimetableSection(page),
-      new PacedTrainSection(page),
-    ];
-    await page.goto(
-      `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenario.id}`
-    );
-    await operationalStudiesPage.removeViteOverlay();
-    await waitForInfraStateToBeCached(infra.id);
-  });
+  test.beforeEach(
+    'Navigate to scenario page and wait for infrastructure to be loaded',
+    async ({ page }) => {
+      [operationalStudiesPage, scenarioTimetableSection, pacedTrainSection] = [
+        new OperationalStudiesPage(page),
+        new ScenarioTimetableSection(page),
+        new PacedTrainSection(page),
+      ];
+
+      await page.goto(
+        `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenario.id}`
+      );
+      await operationalStudiesPage.removeViteOverlay();
+      await waitForInfraStateToBeCached(infra.id);
+    }
+  );
 
   /** *************** Test 1 **************** */
-  test('Loading timetable items and verifying simulation result for trainSchedule', async () => {
-    // Verify train schedule count, invalid train schedule messages, and train schedule simulation results
-    await scenarioTimetableSection.verifyTimetableItemsCount(TOTAL_TIMETABLE_ITEMS);
-    await scenarioTimetableSection.filterValidityAndVerifyTrainCount(
-      'Valid',
-      VALID_TIMETABLE_ITEMS,
-      frTranslations
-    );
-    await scenarioTimetableSection.verifyEachTrainScheduleSimulation(VALID_TRAIN_SCHEDULE);
+  test('Loading timetable items and verifying simulation result for train schedules', async () => {
+    await test.step('Verify counts then filter valid train schedules', async () => {
+      await scenarioTimetableSection.verifyTimetableItemsCount(TOTAL_TIMETABLE_ITEMS);
+      await scenarioTimetableSection.filterValidityAndVerifyTrainCount(
+        'Valid',
+        VALID_TIMETABLE_ITEMS,
+        frTranslations
+      );
+    });
+
+    await test.step('Verify simulation results for valid train schedules', async () => {
+      await scenarioTimetableSection.verifyEachTrainScheduleSimulation(VALID_TRAIN_SCHEDULE);
+    });
   });
 
   /** *************** Test 2 **************** */
   test('Loading timetable items and verifying simulation result for paced trains', async () => {
-    // Verify paced train count, invalid paced train messages, and paced train simulation results
-    await scenarioTimetableSection.verifyTimetableItemsCount(TOTAL_TIMETABLE_ITEMS);
-    await scenarioTimetableSection.verifyInvalidTrainsMessageVisibility();
-    await scenarioTimetableSection.filterValidityAndVerifyTrainCount(
-      'Valid',
-      VALID_TIMETABLE_ITEMS,
-      frTranslations
-    );
-    await scenarioTimetableSection.verifyPacedTrainSimulations(VALID_PACED_TRAINS);
+    await test.step('Verify counts and invalid message, then filter valid paced trains', async () => {
+      await scenarioTimetableSection.verifyTimetableItemsCount(TOTAL_TIMETABLE_ITEMS);
+      await scenarioTimetableSection.verifyInvalidTrainsMessageVisibility();
+      await scenarioTimetableSection.filterValidityAndVerifyTrainCount(
+        'Valid',
+        VALID_TIMETABLE_ITEMS,
+        frTranslations
+      );
+    });
+
+    await test.step('Verify paced train simulation results', async () => {
+      await scenarioTimetableSection.verifyPacedTrainSimulations(VALID_PACED_TRAINS);
+    });
   });
 
   /** *************** Test 3 **************** */
   test('Filtering imported timetable items', async () => {
-    await scenarioTimetableSection.verifyTotalItemsLabel(frTranslations, {
-      totalPacedTrainCount: TOTAL_PACED_TRAINS,
-      totalTrainScheduleCount: TOTAL_TRAIN_SCHEDULES,
+    await test.step('Verify totals and default filter UI', async () => {
+      await scenarioTimetableSection.verifyTotalItemsLabel(frTranslations, {
+        totalPacedTrainCount: TOTAL_PACED_TRAINS,
+        totalTrainScheduleCount: TOTAL_TRAIN_SCHEDULES,
+      });
+      await scenarioTimetableSection.checkTimetableFilterVisibilityLabelDefaultValue(
+        frTranslations.timetable,
+        { inputDefaultValue: '', selectDefaultValue: 'both' }
+      );
     });
 
-    await scenarioTimetableSection.checkTimetableFilterVisibilityLabelDefaultValue(
-      frTranslations.timetable,
-      { inputDefaultValue: '', selectDefaultValue: 'both' }
-    );
+    await test.step('Filter by name / label (standard)', async () => {
+      await scenarioTimetableSection.filterNameAndVerifyTrainCount(
+        'Paced Train - Updated exception (Train name)',
+        NAME_FILTERED_TIMETABLE_ITEMS
+      );
+      await scenarioTimetableSection.filterNameAndVerifyTrainCount(
+        'Paced-Train-Tag-2',
+        LABEL_FILTERED_TIMETABLE_ITEMS
+      );
+    });
 
-    // Name and label filter
-    await scenarioTimetableSection.filterNameAndVerifyTrainCount(
-      'Paced Train - Updated exception (Train name)',
-      NAME_FILTERED_TIMETABLE_ITEMS
-    );
-    await scenarioTimetableSection.filterNameAndVerifyTrainCount(
-      'Paced-Train-Tag-2',
-      LABEL_FILTERED_TIMETABLE_ITEMS
-    );
+    await test.step('Filter by name / label (exceptions & mixed)', async () => {
+      await scenarioTimetableSection.filterNameAndVerifyTrainCount(
+        'abc',
+        NAME_FILTERED_TIMETABLE_ITEMS_EXCEPTION
+      );
+      await scenarioTimetableSection.filterNameAndVerifyTrainCount(
+        'exception',
+        NAME_LABEL_FILTERED_TIMETABLE_ITEMS_MIXED
+      );
+      await scenarioTimetableSection.filterNameAndVerifyTrainCount(
+        'exception-label',
+        LABEL_FILTERED_TIMETABLE_ITEMS_EXCEPTION
+      );
+    });
 
-    // Name and label filter for exceptions
-    await scenarioTimetableSection.filterNameAndVerifyTrainCount(
-      'abc',
-      NAME_FILTERED_TIMETABLE_ITEMS_EXCEPTION
-    );
-    await scenarioTimetableSection.filterNameAndVerifyTrainCount(
-      'exception',
-      NAME_LABEL_FILTERED_TIMETABLE_ITEMS_MIXED
-    );
-    await scenarioTimetableSection.filterNameAndVerifyTrainCount(
-      'exception-label',
-      LABEL_FILTERED_TIMETABLE_ITEMS_EXCEPTION
-    );
+    await test.step('Filter by rolling stock', async () => {
+      await scenarioTimetableSection.filterRollingStockAndVerifyTrainCount(
+        'slow_rolling_stock',
+        ROLLING_STOCK_FILTERED_TIMETABLE_ITEMS_EXCEPTION
+      );
+    });
 
-    // Rolling stock name and details filter
-    await scenarioTimetableSection.filterRollingStockAndVerifyTrainCount(
-      'slow_rolling_stock',
-      ROLLING_STOCK_FILTERED_TIMETABLE_ITEMS_EXCEPTION
-    );
+    await test.step('Filter by validity', async () => {
+      await scenarioTimetableSection.filterValidityAndVerifyTrainCount(
+        'Invalid',
+        INVALID_TIMETABLE_ITEMS,
+        frTranslations
+      );
+      await scenarioTimetableSection.filterValidityAndVerifyTrainCount(
+        'Valid',
+        VALID_TIMETABLE_ITEMS,
+        frTranslations
+      );
+    });
 
-    // Validity filter
-    await scenarioTimetableSection.filterValidityAndVerifyTrainCount(
-      'Invalid',
-      INVALID_TIMETABLE_ITEMS,
-      frTranslations
-    );
-    await scenarioTimetableSection.filterValidityAndVerifyTrainCount(
-      'Valid',
-      VALID_TIMETABLE_ITEMS,
-      frTranslations
-    );
+    await test.step('Filter by punctuality (Honored/Not honored)', async () => {
+      await scenarioTimetableSection.filterHonoredAndVerifyTrainCount(
+        'Honored',
+        HONORED_TIMETABLE_ITEMS,
+        frTranslations
+      );
+      await scenarioTimetableSection.filterHonoredAndVerifyTrainCount(
+        'Not honored',
+        NOT_HONORED_TIMETABLE_ITEMS,
+        frTranslations
+      );
+    });
 
-    // Punctuality filter
-    await scenarioTimetableSection.filterHonoredAndVerifyTrainCount(
-      'Honored',
-      HONORED_TIMETABLE_ITEMS,
-      frTranslations
-    );
-    await scenarioTimetableSection.filterHonoredAndVerifyTrainCount(
-      'Not honored',
-      NOT_HONORED_TIMETABLE_ITEMS,
-      frTranslations
-    );
+    await test.step('Filter by train type', async () => {
+      await scenarioTimetableSection.filterTrainTypeAndVerifyTrainCount(
+        'Service',
+        NOT_HONORED_PACED_TRAIN_SCHEDULE
+      );
+      await scenarioTimetableSection.filterHonoredAndVerifyTrainCount(
+        'All',
+        VALID_PACED_TRAINS,
+        frTranslations
+      );
+      await scenarioTimetableSection.filterValidityAndVerifyTrainCount(
+        'All',
+        TOTAL_PACED_TRAINS,
+        frTranslations
+      );
+      await scenarioTimetableSection.filterTrainTypeAndVerifyTrainCount(
+        'Unique train',
+        TOTAL_TRAIN_SCHEDULES
+      );
+      await scenarioTimetableSection.filterTrainTypeAndVerifyTrainCount(
+        'All',
+        TOTAL_TIMETABLE_ITEMS
+      );
+    });
 
-    // Train type filter
-    await scenarioTimetableSection.filterTrainTypeAndVerifyTrainCount(
-      'Service',
-      NOT_HONORED_PACED_TRAIN_SCHEDULE
-    );
-    await scenarioTimetableSection.filterHonoredAndVerifyTrainCount(
-      'All',
-      VALID_PACED_TRAINS,
-      frTranslations
-    );
-    await scenarioTimetableSection.filterValidityAndVerifyTrainCount(
-      'All',
-      TOTAL_PACED_TRAINS,
-      frTranslations
-    );
+    await test.step('Filter by speed limit tag and verify counts', async () => {
+      await scenarioTimetableSection.filterSpeedLimitTagAndVerifyTrainCount(
+        null,
+        TIMETABLE_ITEMS_WITH_NO_SPEED_LIMIT_TAG,
+        frTranslations
+      );
+      await scenarioTimetableSection.verifyTimetableItemsCount(TOTAL_TIMETABLE_ITEMS);
 
-    await scenarioTimetableSection.filterTrainTypeAndVerifyTrainCount(
-      'Unique train',
-      TOTAL_TRAIN_SCHEDULES
-    );
-    await scenarioTimetableSection.filterTrainTypeAndVerifyTrainCount('All', TOTAL_TIMETABLE_ITEMS);
-
-    // Verify timetable item composition filters with predefined filter codes and expected counts
-    // TODO Paced train : add a paced train with a unique compo code in https://github.com/OpenRailAssociation/osrd/issues/10615
-    await scenarioTimetableSection.filterSpeedLimitTagAndVerifyTrainCount(
-      null,
-      TIMETABLE_ITEMS_WITH_NO_SPEED_LIMIT_TAG,
-      frTranslations
-    );
-    await scenarioTimetableSection.verifyTimetableItemsCount(TOTAL_TIMETABLE_ITEMS);
-
-    // Verify timetable item composition filters with predefined filter codes and expected counts for exceptions
-    await scenarioTimetableSection.filterSpeedLimitTagAndVerifyTrainCount(
-      'HLP',
-      ITEMS_WITH_HLP_SPEED_LIMIT_TAG_EXCEPTION,
-      frTranslations
-    );
-    await scenarioTimetableSection.verifyTimetableItemsCount(TOTAL_TIMETABLE_ITEMS);
+      await scenarioTimetableSection.filterSpeedLimitTagAndVerifyTrainCount(
+        'HLP',
+        ITEMS_WITH_HLP_SPEED_LIMIT_TAG_EXCEPTION,
+        frTranslations
+      );
+      await scenarioTimetableSection.verifyTimetableItemsCount(TOTAL_TIMETABLE_ITEMS);
+    });
   });
 
   /** *************** Test 4 **************** */
   test('Loading timetable items and verifying paced trains display', async () => {
-    // Paced train data used in global setup
-    const pacedTrainsData: PacedTrain[] = readJsonFile(
-      './tests/assets/paced-train/paced_trains.json'
-    );
-
-    // Verify paced train item
-    for (let pacedTrainIndex = 0; pacedTrainIndex < pacedTrainsData.length; pacedTrainIndex += 1) {
-      await pacedTrainSection.verifyPacedTrainItemDetails(
-        IMPORTED_PACED_TRAIN_DETAILS[pacedTrainIndex],
-        pacedTrainIndex,
-        { occurrenceData: IMPORT_PACED_TRAIN_OCCURRENCES_DETAILS[pacedTrainIndex] }
+    await test.step('Verify each imported paced train card and its occurrences', async () => {
+      const pacedTrainsData: PacedTrain[] = readJsonFile(
+        './tests/assets/paced-train/paced_trains.json'
       );
-    }
+
+      for (
+        let pacedTrainIndex = 0;
+        pacedTrainIndex < pacedTrainsData.length;
+        pacedTrainIndex += 1
+      ) {
+        await pacedTrainSection.verifyPacedTrainItemDetails(
+          IMPORTED_PACED_TRAIN_DETAILS[pacedTrainIndex],
+          pacedTrainIndex,
+          { occurrenceData: IMPORT_PACED_TRAIN_OCCURRENCES_DETAILS[pacedTrainIndex] }
+        );
+      }
+    });
   });
 });

--- a/front/tests/016-train-timetable-multiselection.spec.ts
+++ b/front/tests/016-train-timetable-multiselection.spec.ts
@@ -71,28 +71,37 @@ test.describe('Verify train schedule elements and filters', () => {
     await waitForInfraStateToBeCached(infra.id);
   });
 
-  test('Duplicate and delete a paced train', async ({ page }) => {
+  /** *************** Test 1 **************** */
+  test('Select and delete all timetable items', async ({ page }) => {
     scenarioTimetableSection = new ScenarioTimetableSection(page);
 
-    // Verify total items count
-    await scenarioTimetableSection.verifyTotalItemsLabel(frTranslations, {
-      totalPacedTrainCount: TOTAL_PACED_TRAINS,
-      totalTrainScheduleCount: TOTAL_TRAIN_SCHEDULES,
+    await test.step('Verify initial totals', async () => {
+      await scenarioTimetableSection.verifyTotalItemsLabel(frTranslations, {
+        totalPacedTrainCount: TOTAL_PACED_TRAINS,
+        totalTrainScheduleCount: TOTAL_TRAIN_SCHEDULES,
+      });
     });
-    // Select all remaining items
-    await scenarioTimetableSection.selectAllTimetableItems(frTranslations, {
-      totalPacedTrainCount: TOTAL_PACED_TRAINS,
-      totalTrainScheduleCount: TOTAL_TRAIN_SCHEDULES,
+
+    await test.step('Select all timetable items', async () => {
+      await scenarioTimetableSection.selectAllTimetableItems(frTranslations, {
+        totalPacedTrainCount: TOTAL_PACED_TRAINS,
+        totalTrainScheduleCount: TOTAL_TRAIN_SCHEDULES,
+      });
     });
-    // Delete all items
-    await scenarioTimetableSection.deleteAllTimetableItems();
-    // As in other tests, checking the last notification needs to be done in a different method
-    // otherwise the received message of the last notification is empty
-    await scenarioTimetableSection.verifyAllTimetableItemsHaveBeenDeleted(
-      TOTAL_TIMETABLE_ITEMS,
-      frTranslations
-    );
-    // Verify timetable is empty and total label is empty
-    await scenarioTimetableSection.verifyTimetableIsEmpty(frTranslations.timetable.noTrain);
+
+    await test.step('Delete all selected items', async () => {
+      await scenarioTimetableSection.deleteAllTimetableItems();
+    });
+
+    await test.step('Verify deletion notifications', async () => {
+      await scenarioTimetableSection.verifyAllTimetableItemsHaveBeenDeleted(
+        TOTAL_TIMETABLE_ITEMS,
+        frTranslations
+      );
+    });
+
+    await test.step('Verify timetable is empty', async () => {
+      await scenarioTimetableSection.verifyTimetableIsEmpty(frTranslations.timetable.noTrain);
+    });
   });
 });

--- a/front/tests/017-paced-train-management.spec.ts
+++ b/front/tests/017-paced-train-management.spec.ts
@@ -100,163 +100,182 @@ test.describe('Verify simulation configuration in operational studies for train 
     await deleteScenario(project.id, study.id, scenario.name);
   });
 
-  test.beforeEach('Go to scenario page', async ({ page }) => {
-    [
-      rollingstockSelector,
-      operationalStudiesPage,
-      scenarioTimetableSection,
-      routeTab,
-      pacedTrainSection,
-      timesAndStopsTab,
-      simulationResultPage,
-      timeAndStopSimulationOutputs,
-      scenarioPage,
-    ] = [
-      new RollingStockSelector(page),
-      new OperationalStudiesPage(page),
-      new ScenarioTimetableSection(page),
-      new RouteTab(page),
-      new PacedTrainSection(page),
-      new TimesAndStopsTab(page),
-      new OpSimulationResultPage(page),
-      new TimeAndStopSimulationOutputs(page),
-      new ScenarioPage(page),
-    ];
+  test.beforeEach(
+    'Navigate to scenario page and wait for infrastructure to be loaded',
+    async ({ page }) => {
+      [
+        rollingstockSelector,
+        operationalStudiesPage,
+        scenarioTimetableSection,
+        routeTab,
+        pacedTrainSection,
+        timesAndStopsTab,
+        simulationResultPage,
+        timeAndStopSimulationOutputs,
+        scenarioPage,
+      ] = [
+        new RollingStockSelector(page),
+        new OperationalStudiesPage(page),
+        new ScenarioTimetableSection(page),
+        new RouteTab(page),
+        new PacedTrainSection(page),
+        new TimesAndStopsTab(page),
+        new OpSimulationResultPage(page),
+        new TimeAndStopSimulationOutputs(page),
+        new ScenarioPage(page),
+      ];
 
-    // Navigate to the scenario page for the given project and study
-    await page.goto(
-      `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenario.id}`
-    );
-    await operationalStudiesPage.removeViteOverlay();
-
-    await waitForInfraStateToBeCached(infra.id);
-  });
+      await page.goto(
+        `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenario.id}`
+      );
+      await operationalStudiesPage.removeViteOverlay();
+      await waitForInfraStateToBeCached(infra.id);
+    }
+  );
 
   /** *************** Test 1 **************** */
   test('Verify default behaviors with paced train mode', async () => {
-    await operationalStudiesPage.openTimetableItemForm();
+    await test.step('Open timetable item form', async () => {
+      await operationalStudiesPage.openTimetableItemForm();
+    });
 
-    // Verify that all configuration buttons and inputs are visible and have their proper default values
-    await operationalStudiesPage.checkInputsAndButtons(frTranslations, scenario.creation_date);
+    await test.step('Verify default inputs/buttons', async () => {
+      await operationalStudiesPage.checkInputsAndButtons(frTranslations, scenario.creation_date);
+    });
 
-    // Verify that all tabs are visible and their default behavior is correct
-    await operationalStudiesPage.checkTabs();
+    await test.step('Verify tabs default behavior', async () => {
+      await operationalStudiesPage.checkTabs();
+    });
 
-    // Check the define paced train checkbox
-    await operationalStudiesPage.checkPacedTrainModeAndVerifyInputs(frTranslations);
+    await test.step('Enable paced train mode and verify inputs', async () => {
+      await operationalStudiesPage.checkPacedTrainModeAndVerifyInputs(frTranslations);
+    });
 
-    // Test the paced train mode behavior
-    await operationalStudiesPage.testPacedTrainMode(frTranslations);
+    await test.step('Test paced train mode behavior', async () => {
+      await operationalStudiesPage.testPacedTrainMode(frTranslations);
+    });
   });
 
   /** *************** Test 2 **************** */
   test('Add a paced train and verify its timetable details', async ({ page, browserName }) => {
-    await operationalStudiesPage.openTimetableItemForm();
-
-    // Set the paced train inputs
-    await operationalStudiesPage.fillPacedTrainSettings(NEW_PACED_TRAIN_SETTINGS);
-
-    // Select a rolling stock
-    await rollingstockSelector.selectRollingStock(dualModeRollingStockName);
-
-    // Select an itinerary
-    await operationalStudiesPage.openRouteTab();
-    await routeTab.performPathfindingByTrigram({
-      originTrigram: 'WS',
-      destinationTrigram: 'NES',
-    });
-    await operationalStudiesPage.checkPathfindingDistance('46.050 km');
-
-    // Verify initial row count and fill table with input data
-    await operationalStudiesPage.openTimesAndStopsTab();
-    await scrollContainer(page, '.time-stops-datasheet .dsg-container');
-
-    await timesAndStopsTab.verifyActiveRowsCount(2);
-    for (const cell of initialInputsData) {
-      const translatedHeader = cleanWhitespace(frTranslations[cell.header]);
-      await timesAndStopsTab.fillTableCellByStationAndHeader(
-        cell.stationName,
-        translatedHeader,
-        cell.value,
-        cell.marginForm
-      );
-    }
-
-    // Add paced train
-    await operationalStudiesPage.createTimetableItem();
-
-    // Verify the paced train has been added and return to the simulation results and timetable
-    await operationalStudiesPage.checkToastHasBeenLaunched(frTranslations.pacedTrains.added);
-    await operationalStudiesPage.returnSimulationResult();
-
-    // Confirm that the number of paced trains added matches the expected number
-    await scenarioTimetableSection.verifyTimetableItemsCount(1); // Only one paced train can be added at a time
-
-    await pacedTrainSection.verifyPacedTrainItemDetails(NEW_PACED_TRAIN_SETTINGS, 0, {
-      occurrenceData: ADD_PACED_TRAIN_OCCURRENCES_DETAILS[0],
+    await test.step('Open timetable item form', async () => {
+      await operationalStudiesPage.openTimetableItemForm();
     });
 
-    // Click on occurrence to check its simulation results
-    await pacedTrainSection.selectOccurrence({ pacedTrainIndex: 0, occurrenceIndex: 0 });
-    await scenarioPage.toggleTrainList();
-    if (browserName === 'chromium') {
-      await expect(simulationResultPage.speedSpaceChart).toHaveScreenshot(
-        'SpeedSpaceChart-InitialInputs.png'
-      );
-    }
-    await scrollContainer(page, '.time-stop-outputs .time-stops-datasheet .dsg-container');
-    await timeAndStopSimulationOutputs.getOutputTableData(expectedOutputData);
+    await test.step('Fill paced train inputs', async () => {
+      await operationalStudiesPage.fillPacedTrainSettings(NEW_PACED_TRAIN_SETTINGS);
+    });
+
+    await test.step('Select rolling stock', async () => {
+      await rollingstockSelector.selectRollingStock(dualModeRollingStockName);
+    });
+
+    await test.step('Select itinerary and verify distance', async () => {
+      await operationalStudiesPage.openRouteTab();
+      await routeTab.performPathfindingByTrigram({
+        originTrigram: 'WS',
+        destinationTrigram: 'NES',
+      });
+      await operationalStudiesPage.checkPathfindingDistance('46.050 km');
+    });
+
+    await test.step('Fill Times & Stops table with initial inputs', async () => {
+      await operationalStudiesPage.openTimesAndStopsTab();
+      await scrollContainer(page, '.time-stops-datasheet .dsg-container');
+      await timesAndStopsTab.verifyActiveRowsCount(2);
+
+      for (const cell of initialInputsData) {
+        const translatedHeader = cleanWhitespace(frTranslations[cell.header]);
+        await timesAndStopsTab.fillTableCellByStationAndHeader(
+          cell.stationName,
+          translatedHeader,
+          cell.value,
+          cell.marginForm
+        );
+      }
+    });
+
+    await test.step('Create paced train and return to results', async () => {
+      await operationalStudiesPage.createTimetableItem();
+      await operationalStudiesPage.checkToastHasBeenLaunched(frTranslations.pacedTrains.added);
+      await operationalStudiesPage.returnSimulationResult();
+    });
+
+    await test.step('Verify list contains exactly one paced train', async () => {
+      await scenarioTimetableSection.verifyTimetableItemsCount(1);
+    });
+
+    await test.step('Verify paced train card and first occurrence details', async () => {
+      await pacedTrainSection.verifyPacedTrainItemDetails(NEW_PACED_TRAIN_SETTINGS, 0, {
+        occurrenceData: ADD_PACED_TRAIN_OCCURRENCES_DETAILS[0],
+      });
+    });
+
+    await test.step('Open first occurrence and verify its simulation results (screenshot comparison for the GEV)', async () => {
+      await pacedTrainSection.selectOccurrence({ pacedTrainIndex: 0, occurrenceIndex: 0 });
+      await scenarioPage.toggleTrainList();
+      if (browserName === 'chromium') {
+        await expect(simulationResultPage.speedSpaceChart).toHaveScreenshot(
+          'SpeedSpaceChart-InitialInputs.png'
+        );
+      }
+      await scrollContainer(page, '.time-stop-outputs .time-stops-datasheet .dsg-container');
+      await timeAndStopSimulationOutputs.getOutputTableData(expectedOutputData);
+    });
   });
 
   /** *************** Test 3 **************** */
   test('Duplicate and delete a paced train', async ({ page }) => {
-    await sendPacedTrains(scenario.timetable_id, pacedTrainsJson);
-
-    // to trigger list of paced train initialization for this e2e test, which isn't needed locally
-    await page.reload();
-
-    await scenarioTimetableSection.verifyTotalItemsLabel(frTranslations, {
-      totalPacedTrainCount: TOTAL_PACED_TRAINS,
-      totalTrainScheduleCount: 0,
+    await test.step('Set paced trains via API and reload to initialize list', async () => {
+      await sendPacedTrains(scenario.timetable_id, pacedTrainsJson);
+      await page.reload();
     });
 
-    // Duplicate the first paced train
-    await pacedTrainSection.duplicatePacedTrain();
-
-    // Verify that a toast is displayed
-    await operationalStudiesPage.checkToastHasBeenLaunched(
-      frTranslations.timetable.pacedTrainAdded
-    );
-
-    // Verify that there is one more paced train in the list
-    await scenarioTimetableSection.verifyTotalItemsLabel(frTranslations, {
-      totalPacedTrainCount: TOTAL_PACED_TRAINS + 1,
-      totalTrainScheduleCount: 0,
+    await test.step('Verify initial counters', async () => {
+      await scenarioTimetableSection.verifyTotalItemsLabel(frTranslations, {
+        totalPacedTrainCount: TOTAL_PACED_TRAINS,
+        totalTrainScheduleCount: 0,
+      });
     });
 
-    // Verify that the duplicated paced train has the proper details
-    await pacedTrainSection.verifyPacedTrainItemDetails(DUPLICATED_PACED_TRAIN_DETAILS, 1, {
-      occurrenceData: DUPLICATED_PACED_TRAIN_OCCURRENCES_DETAILS,
-      copyTranslation: frTranslations.timetable.copy,
+    await test.step('Duplicate first paced train and verify toast notification', async () => {
+      await pacedTrainSection.duplicatePacedTrain();
+      await operationalStudiesPage.checkToastHasBeenLaunched(
+        frTranslations.timetable.pacedTrainAdded
+      );
     });
 
-    // Verify global item counter has one more paced train
-    await scenarioTimetableSection.verifyTotalItemsLabel(frTranslations, {
-      totalPacedTrainCount: TOTAL_PACED_TRAINS_WITH_DUPLICATE,
-      totalTrainScheduleCount: 0,
+    await test.step('Verify counters increased by one', async () => {
+      await scenarioTimetableSection.verifyTotalItemsLabel(frTranslations, {
+        totalPacedTrainCount: TOTAL_PACED_TRAINS + 1,
+        totalTrainScheduleCount: 0,
+      });
     });
 
-    // Delete the duplicated paced train
-    await pacedTrainSection.deletePacedTrain(
-      DUPLICATED_PACED_TRAIN_INDEX,
-      frTranslations,
-      DUPLICATED_PACED_TRAIN_DETAILS
-    );
+    await test.step('Verify duplicated paced train details', async () => {
+      await pacedTrainSection.verifyPacedTrainItemDetails(DUPLICATED_PACED_TRAIN_DETAILS, 1, {
+        occurrenceData: DUPLICATED_PACED_TRAIN_OCCURRENCES_DETAILS,
+        copyTranslation: frTranslations.timetable.copy,
+      });
+    });
 
-    // Verify global item counter has one less paced train
-    await scenarioTimetableSection.verifyTotalItemsLabel(frTranslations, {
-      totalPacedTrainCount: TOTAL_PACED_TRAINS,
-      totalTrainScheduleCount: 0,
+    await test.step('Verify global counter with duplicate', async () => {
+      await scenarioTimetableSection.verifyTotalItemsLabel(frTranslations, {
+        totalPacedTrainCount: TOTAL_PACED_TRAINS_WITH_DUPLICATE,
+        totalTrainScheduleCount: 0,
+      });
+    });
+
+    await test.step('Delete duplicated paced train and verify counters', async () => {
+      await pacedTrainSection.deletePacedTrain(
+        DUPLICATED_PACED_TRAIN_INDEX,
+        frTranslations,
+        DUPLICATED_PACED_TRAIN_DETAILS
+      );
+      await scenarioTimetableSection.verifyTotalItemsLabel(frTranslations, {
+        totalPacedTrainCount: TOTAL_PACED_TRAINS,
+        totalTrainScheduleCount: 0,
+      });
     });
   });
 });

--- a/front/tests/018-train-edition.spec.ts
+++ b/front/tests/018-train-edition.spec.ts
@@ -69,7 +69,7 @@ test.describe('Edit train schedules and paced trains', () => {
   });
 
   test.beforeEach(
-    'Setup project, study, infra and create scenario with timetableItems',
+    'Setup scenario with one train schedule and one paced train',
     async ({ page }) => {
       [pacedTrainSection, scenarioTimetableSection, operationalStudiesPage] = [
         new PacedTrainSection(page),
@@ -104,58 +104,78 @@ test.describe('Edit train schedules and paced trains', () => {
     await deleteScenario(project.id, study.id, scenarioItems.name);
   });
 
+  /** *************** Test 1 **************** */
   test('Edit a paced train', async () => {
-    await pacedTrainSection.editPacedTrain();
-
-    await operationalStudiesPage.setTimeWindow(TIME_WINDOW);
-    await operationalStudiesPage.setInterval(INTERVAL);
-    await operationalStudiesPage.setTimetableItemName(EDITED_PACED_TRAIN_NAME);
-
-    await operationalStudiesPage.updateTimetableItem(frTranslations.updatePacedTrain);
-
-    await operationalStudiesPage.checkToastHasBeenLaunched(frTranslations.pacedTrainUpdated);
-
-    await scenarioTimetableSection.verifyTotalItemsLabel(frTranslations, {
-      totalPacedTrainCount: 1,
-      totalTrainScheduleCount: 1,
+    await test.step('Open paced train edition page', async () => {
+      await pacedTrainSection.openPacedTrainEditor();
     });
-    await pacedTrainSection.verifyPacedTrainItemDetails(
-      {
-        name: EDITED_PACED_TRAIN_NAME,
-        startTime: '03:00',
-        labels: [],
-        timeWindow: TIME_WINDOW,
-        interval: INTERVAL,
-        expectedOccurrencesCount: 12,
-      },
-      0,
-      { pacedTrainCardAlreadyOpen: true }
-    );
+
+    await test.step('Update paced train properties', async () => {
+      await operationalStudiesPage.setTimeWindow(TIME_WINDOW);
+      await operationalStudiesPage.setInterval(INTERVAL);
+      await operationalStudiesPage.setTimetableItemName(EDITED_PACED_TRAIN_NAME);
+    });
+
+    await test.step('Save paced train and verify toast notification', async () => {
+      await operationalStudiesPage.updateTimetableItem(frTranslations.updatePacedTrain);
+      await operationalStudiesPage.checkToastHasBeenLaunched(frTranslations.pacedTrainUpdated);
+    });
+
+    await test.step('Verify timetable labels and paced train details', async () => {
+      await scenarioTimetableSection.verifyTotalItemsLabel(frTranslations, {
+        totalPacedTrainCount: 1,
+        totalTrainScheduleCount: 1,
+      });
+      await pacedTrainSection.verifyPacedTrainItemDetails(
+        {
+          name: EDITED_PACED_TRAIN_NAME,
+          startTime: '03:00',
+          labels: [],
+          timeWindow: TIME_WINDOW,
+          interval: INTERVAL,
+          expectedOccurrencesCount: 12,
+        },
+        0,
+        { pacedTrainCardAlreadyOpen: true }
+      );
+    });
   });
 
+  /** *************** Test 2 **************** */
   test('Turn paced train into train schedule', async () => {
-    await pacedTrainSection.editPacedTrain();
+    await test.step('Edit paced train', async () => {
+      await pacedTrainSection.openPacedTrainEditor();
+    });
 
-    await operationalStudiesPage.turnPacedTrainIntoTrainSchedule(frTranslations);
+    await test.step('Convert paced train to train schedule', async () => {
+      await operationalStudiesPage.turnPacedTrainIntoTrainSchedule(frTranslations);
+      await operationalStudiesPage.checkToastHasBeenLaunched(frTranslations.pacedTrainUpdated);
+    });
 
-    await operationalStudiesPage.checkToastHasBeenLaunched(frTranslations.pacedTrainUpdated);
-
-    await scenarioTimetableSection.verifyTotalItemsLabel(frTranslations, {
-      totalPacedTrainCount: 0,
-      totalTrainScheduleCount: 2,
+    await test.step('Verify timetable labels after conversion', async () => {
+      await scenarioTimetableSection.verifyTotalItemsLabel(frTranslations, {
+        totalPacedTrainCount: 0,
+        totalTrainScheduleCount: 2,
+      });
     });
   });
 
+  /** *************** Test 3 **************** */
   test('Turn a train schedule into a paced train', async () => {
-    await scenarioTimetableSection.editTimetableItem(1);
+    await test.step('Edit train schedule at index 1', async () => {
+      await scenarioTimetableSection.editTimetableItem(1);
+    });
 
-    await operationalStudiesPage.turnTrainScheduleIntoPacedTrain(frTranslations);
+    await test.step('Convert train schedule to paced train', async () => {
+      await operationalStudiesPage.turnTrainScheduleIntoPacedTrain(frTranslations);
+      await operationalStudiesPage.checkToastHasBeenLaunched(frTranslations.trainScheduleUpdated);
+    });
 
-    await operationalStudiesPage.checkToastHasBeenLaunched(frTranslations.trainScheduleUpdated);
-
-    await scenarioTimetableSection.verifyTotalItemsLabel(frTranslations, {
-      totalPacedTrainCount: 2,
-      totalTrainScheduleCount: 0,
+    await test.step('Verify timetable labels after conversion', async () => {
+      await scenarioTimetableSection.verifyTotalItemsLabel(frTranslations, {
+        totalPacedTrainCount: 2,
+        totalTrainScheduleCount: 0,
+      });
     });
   });
 });

--- a/front/tests/019-scenario-page-synchronization.spec.ts
+++ b/front/tests/019-scenario-page-synchronization.spec.ts
@@ -1,3 +1,5 @@
+import type { Page } from '@playwright/test';
+
 import type {
   Scenario,
   Project,
@@ -44,14 +46,24 @@ const frTranslations = {
 const trainSchedulesJson = readJsonFile<TrainSchedule[]>(
   './tests/assets/train-schedule/train_schedules.json'
 );
+
 const pacedTrainsJson = readJsonFile<PacedTrain[]>('./tests/assets/paced-train/paced_trains.json');
+
+test.skip(
+  ({ browserName }) => browserName !== 'chromium',
+  'This test is only stable on Chromium due to tab sync flakiness in Firefox'
+);
+
 test.describe('Synchronize the scenario page across multiple windows', () => {
-  test.skip(
-    ({ browserName }) => browserName !== 'chromium',
-    'This test is only stable on Chromium due to tab sync flakiness in Firefox'
-  );
-  test.slow();
   test.use({ viewport: { width: 1920, height: 1080 } });
+
+  let firstPage: Page;
+  let secondPage: Page;
+  let firstTimetableSection: ScenarioTimetableSection;
+  let secondTimetableSection: ScenarioTimetableSection;
+  let pacedTrainSection: PacedTrainSection;
+  let studyPage: StudyPage;
+  let operationalStudiesPage: OperationalStudiesPage;
 
   let project: Project;
   let study: Study;
@@ -83,57 +95,70 @@ test.describe('Synchronize the scenario page across multiple windows', () => {
     }
   );
 
+  test.afterAll('Close pages', async () => {
+    await firstPage.close();
+    await secondPage.close();
+  });
+
+  /** *************** Test 1 **************** */
   test('Reflects updates across tabs', async ({ context }) => {
     const scenarioUrl = `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenarioItems.id}`;
 
-    // Open the first tab and navigate to the scenario page
-    const firstPage = await context.newPage();
-    await firstPage.goto(scenarioUrl);
-    const firstTimetableSection = new ScenarioTimetableSection(firstPage);
-    const pacedTrainSection = new PacedTrainSection(firstPage);
-    const studyPage = new StudyPage(firstPage);
-
-    await waitForInfraStateToBeCached(infra.id);
-
-    // Open the second tab and navigate to the same scenario page
-    const secondPage = await context.newPage();
-    await secondPage.goto(scenarioUrl);
-    const secondTimetableSection = new ScenarioTimetableSection(secondPage);
-    const operationalStudiesPage = new OperationalStudiesPage(secondPage);
-
-    // Delete a paced train in the first tab and verify the update
-    await firstPage.bringToFront();
-    await pacedTrainSection.deletePacedTrain(1, frTranslations);
-    await firstTimetableSection.verifyTotalItemsLabel(frTranslations, {
-      totalPacedTrainCount: 1,
-      totalTrainScheduleCount: 2,
+    await test.step('Open first tab on scenario page and wait infra cache', async () => {
+      firstPage = await context.newPage();
+      await firstPage.goto(scenarioUrl);
+      firstTimetableSection = new ScenarioTimetableSection(firstPage);
+      pacedTrainSection = new PacedTrainSection(firstPage);
+      studyPage = new StudyPage(firstPage);
+      await waitForInfraStateToBeCached(infra.id);
     });
 
-    // Switch to the second tab and verify that the deletion is reflected
-    await secondPage.bringToFront();
-    await secondTimetableSection.verifyTotalItemsLabel(frTranslations, {
-      totalPacedTrainCount: 1,
-      totalTrainScheduleCount: 2,
+    await test.step('Open second tab on same scenario page', async () => {
+      secondPage = await context.newPage();
+      await secondPage.goto(scenarioUrl);
+      secondTimetableSection = new ScenarioTimetableSection(secondPage);
+      operationalStudiesPage = new OperationalStudiesPage(secondPage);
     });
 
-    // Edit a train schedule in the second tab and verify the update
-    await secondTimetableSection.editTimetableItem(1);
-    await operationalStudiesPage.setFormattedStartTime('2025-03-15T08:35:40');
-    await operationalStudiesPage.submitTimetableItemEdit();
-    await secondTimetableSection.getTimetableItemArrivalTime('08:43', 1);
+    await test.step('Delete a paced train in first tab and verify counts', async () => {
+      await firstPage.bringToFront();
+      await pacedTrainSection.deletePacedTrain(1, frTranslations);
+      await firstTimetableSection.verifyTotalItemsLabel(frTranslations, {
+        totalPacedTrainCount: 1,
+        totalTrainScheduleCount: 2,
+      });
+    });
 
-    // Switch back to the first tab and confirm that the edit is synchronized
-    await firstPage.bringToFront();
-    await firstTimetableSection.getTimetableItemArrivalTime('08:43', 1);
+    await test.step('Verify deletion is reflected in second tab', async () => {
+      await secondPage.bringToFront();
+      await secondTimetableSection.verifyTotalItemsLabel(frTranslations, {
+        totalPacedTrainCount: 1,
+        totalTrainScheduleCount: 2,
+      });
+    });
 
-    // Navigate back to the study page, verify the train count, then delete the scenario
-    await firstPage.goto(`/operational-studies/projects/${project.id}/studies/${study.id}`);
-    await studyPage.verifyScenarioTrainCount(scenarioItems.name, '3');
-    await studyPage.deleteScenario(scenarioItems.name);
+    await test.step('Edit a train schedule in second tab and verify the update', async () => {
+      await secondTimetableSection.editTimetableItem(1);
+      await operationalStudiesPage.setFormattedStartTime('2025-03-15T08:35:40');
+      await operationalStudiesPage.submitTimetableItemEdit();
+      await secondTimetableSection.getTimetableItemArrivalTime('08:43', 1);
+    });
 
-    // Switch to the second tab and verify the scenario is no longer available
-    await secondPage.bringToFront();
-    await secondPage.reload();
-    await operationalStudiesPage.expectResourceNotFoundPage();
+    await test.step('Confirm edit is synchronized back in first tab', async () => {
+      await firstPage.bringToFront();
+      await firstTimetableSection.getTimetableItemArrivalTime('08:43', 1);
+    });
+
+    await test.step('Go to study page in first tab, verify train count, delete scenario', async () => {
+      await firstPage.goto(`/operational-studies/projects/${project.id}/studies/${study.id}`);
+      await studyPage.verifyScenarioTrainCount(scenarioItems.name, '3');
+      await studyPage.deleteScenario(scenarioItems.name);
+    });
+
+    await test.step('Reload second tab and verify scenario is gone', async () => {
+      await secondPage.bringToFront();
+      await secondPage.reload();
+      await operationalStudiesPage.expectResourceNotFoundPage();
+    });
   });
 });

--- a/front/tests/020-paced-train-exceptions.spec.ts
+++ b/front/tests/020-paced-train-exceptions.spec.ts
@@ -95,356 +95,400 @@ test.describe('Paced trains and exception management', () => {
     }
   );
 
-  test.beforeEach('Go to scenario page', async ({ page }) => {
-    [
-      pacedTrainSection,
-      scenarioTimetableSection,
-      operationalStudiesPage,
-      rollingStockSelector,
-      routeTab,
-      timesAndStopsTab,
-      simulationSettingsTab,
-    ] = [
-      new PacedTrainSection(page),
-      new ScenarioTimetableSection(page),
-      new OperationalStudiesPage(page),
-      new RollingStockSelector(page),
-      new RouteTab(page),
-      new TimesAndStopsTab(page),
-      new SimulationSettingsTab(page),
-    ];
+  test.beforeEach(
+    'Navigate to scenario page and wait for infrastructure to be loaded',
+    async ({ page }) => {
+      [
+        pacedTrainSection,
+        scenarioTimetableSection,
+        operationalStudiesPage,
+        rollingStockSelector,
+        routeTab,
+        timesAndStopsTab,
+        simulationSettingsTab,
+      ] = [
+        new PacedTrainSection(page),
+        new ScenarioTimetableSection(page),
+        new OperationalStudiesPage(page),
+        new RollingStockSelector(page),
+        new RouteTab(page),
+        new TimesAndStopsTab(page),
+        new SimulationSettingsTab(page),
+      ];
 
-    await page.goto(
-      `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenarioItems.id}`
-    );
-    await waitForInfraStateToBeCached(infra.id);
-  });
+      await page.goto(
+        `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenarioItems.id}`
+      );
+      await waitForInfraStateToBeCached(infra.id);
+    }
+  );
 
   test.afterAll('Delete the created scenario', async () => {
     await deleteScenario(project.id, study.id, scenarioItems.name);
   });
 
+  /** *************** Test 1 **************** */
   test('Edit a paced train and handle exceptions', async () => {
     const editedPacedTrainData = pacedTrainsJson[5];
 
-    await pacedTrainSection.getActionButtonsLocators({
-      itemIndex: 5,
-      itemType: 'paced-train',
-      withExceptions: true,
-      checkVisibility: true,
+    await test.step('Open action buttons for paced train at index 5', async () => {
+      await pacedTrainSection.getActionButtonsLocators({
+        itemIndex: 5,
+        itemType: 'paced-train',
+        withExceptions: true,
+        checkVisibility: true,
+      });
     });
 
-    await pacedTrainSection.editPacedTrain(5);
-    await scenarioTimetableSection.verifyEditTimetableItemButtonVisibility();
-
-    // update RS
-    await rollingStockSelector.openRollingstockModal();
-    await rollingStockSelector.searchRollingstock(fastRollingStockName);
-    await rollingStockSelector.selectRollingStockCard({
-      name: fastRollingStockName,
-      selectComfort: false,
-      confirmSelection: true,
+    await test.step('Edit the paced train', async () => {
+      await pacedTrainSection.openPacedTrainEditor(5);
+      await scenarioTimetableSection.verifyEditTimetableItemButtonVisibility();
     });
-    expect(await rollingStockSelector.selectedRollingStockName.innerText()).toEqual(
-      fastRollingStockName
-    );
 
-    // update Departure time
-    await operationalStudiesPage.setTimetableItemStartTime('12:00');
+    await test.step('Update rolling stock', async () => {
+      await rollingStockSelector.openRollingstockModal();
+      await rollingStockSelector.searchRollingstock(fastRollingStockName);
+      await rollingStockSelector.selectRollingStockCard({
+        name: fastRollingStockName,
+        selectComfort: false,
+        confirmSelection: true,
+      });
+      expect(await rollingStockSelector.selectedRollingStockName.innerText()).toEqual(
+        fastRollingStockName
+      );
+    });
 
-    await operationalStudiesPage.submitTimetableItemEdit();
+    await test.step('Update departure time and submit edit', async () => {
+      await operationalStudiesPage.setTimetableItemStartTime('12:00');
+      await operationalStudiesPage.submitTimetableItemEdit();
+      await operationalStudiesPage.checkToastHasBeenLaunched(
+        frTranslations.timetable.pacedTrainUpdated
+      );
+    });
 
-    await operationalStudiesPage.checkToastHasBeenLaunched(
-      frTranslations.timetable.pacedTrainUpdated
-    );
+    await test.step('Verify all occurrences (4 occurrences including 1 added exception )', async () => {
+      await pacedTrainSection.verifyOccurrenceDetails(
+        {
+          name: `${editedPacedTrainData.train_name}/+`,
+          startTime: '21:00',
+          arrivalTime: '21:03',
+          rollingStock: fastRollingStockName,
+        },
+        0
+      );
+      await pacedTrainSection.verifyOccurrenceDetails(
+        {
+          name: `${editedPacedTrainData.train_name} 1`,
+          startTime: '12:00',
+          arrivalTime: '12:07',
+          rollingStock: slowRollingStockName,
+        },
+        1
+      );
+      await pacedTrainSection.verifyOccurrenceDetails(
+        {
+          name: `${editedPacedTrainData.train_name} 3`,
+          startTime: '13:00',
+          arrivalTime: '13:03',
+          rollingStock: fastRollingStockName,
+        },
+        2
+      );
+      await pacedTrainSection.verifyOccurrenceDetails(
+        {
+          name: `${editedPacedTrainData.train_name} 5`,
+          startTime: '14:00',
+          arrivalTime: '14:03',
+          rollingStock: fastRollingStockName,
+        },
+        3
+      );
+    });
 
-    // first and last occurrences are exception occurrences
-    // the first is an update exception and the last is an added exception
-    // verify all occurrences (4 occurrences including 1 exception added)
+    await test.step('Reset all exceptions', async () => {
+      await pacedTrainSection.resetAllPacedTrainExceptions(5);
+      await pacedTrainSection.clickOnPacedTrain(5);
+    });
 
-    await pacedTrainSection.verifyOccurrenceDetails(
-      {
-        name: `${editedPacedTrainData.train_name}/+`,
-        startTime: '21:00',
-        arrivalTime: '21:03',
-        rollingStock: fastRollingStockName,
-      },
-      0
-    );
-    await pacedTrainSection.verifyOccurrenceDetails(
-      {
-        name: `${editedPacedTrainData.train_name} 1`,
-        startTime: '12:00',
-        arrivalTime: '12:07',
-        rollingStock: slowRollingStockName,
-      },
-      1
-    );
-    await pacedTrainSection.verifyOccurrenceDetails(
-      {
-        name: `${editedPacedTrainData.train_name} 3`,
-        startTime: '13:00',
-        arrivalTime: '13:03',
-        rollingStock: fastRollingStockName,
-      },
-      2
-    );
-    await pacedTrainSection.verifyOccurrenceDetails(
-      {
-        name: `${editedPacedTrainData.train_name} 5`,
-        startTime: '14:00',
-        arrivalTime: '14:03',
-        rollingStock: fastRollingStockName,
-      },
-      3
-    );
+    await test.step('Verify occurrences after reset', async () => {
+      await pacedTrainSection.verifyOccurrenceDetails(
+        {
+          name: `${editedPacedTrainData.train_name} 1`,
+          startTime: '12:00',
+          arrivalTime: '12:03',
+          rollingStock: editedPacedTrainData.rolling_stock_name,
+        },
+        0
+      );
+      await pacedTrainSection.verifyOccurrenceDetails(
+        {
+          name: `${editedPacedTrainData.train_name} 3`,
+          startTime: '13:00',
+          arrivalTime: '13:03',
+          rollingStock: editedPacedTrainData.rolling_stock_name,
+        },
+        1
+      );
+      await pacedTrainSection.verifyOccurrenceDetails(
+        {
+          name: `${editedPacedTrainData.train_name} 5`,
+          startTime: '14:00',
+          arrivalTime: '14:03',
+          rollingStock: editedPacedTrainData.rolling_stock_name,
+        },
+        2
+      );
+    });
 
-    // reset all exceptions
-    await pacedTrainSection.resetAllPacedTrainExceptions(5);
-
-    await pacedTrainSection.clickOnPacedTrain(5);
-
-    await pacedTrainSection.verifyOccurrenceDetails(
-      {
-        name: `${editedPacedTrainData.train_name} 1`,
-        startTime: '12:00',
-        arrivalTime: '12:03',
-        rollingStock: editedPacedTrainData.rolling_stock_name,
-      },
-      0
-    );
-    await pacedTrainSection.verifyOccurrenceDetails(
-      {
-        name: `${editedPacedTrainData.train_name} 3`,
-        startTime: '13:00',
-        arrivalTime: '13:03',
-        rollingStock: editedPacedTrainData.rolling_stock_name,
-      },
-      1
-    );
-    await pacedTrainSection.verifyOccurrenceDetails(
-      {
-        name: `${editedPacedTrainData.train_name} 5`,
-        startTime: '14:00',
-        arrivalTime: '14:03',
-        rollingStock: editedPacedTrainData.rolling_stock_name,
-      },
-      2
-    );
-
-    // check if we have 4 button instead of 5
-    await pacedTrainSection.getActionButtonsLocators({
-      itemIndex: 5,
-      itemType: 'paced-train',
-      checkVisibility: true,
+    await test.step('Check action buttons count after reset (4 buttons instead of 5)', async () => {
+      await pacedTrainSection.getActionButtonsLocators({
+        itemIndex: 5,
+        itemType: 'paced-train',
+        checkVisibility: true,
+      });
     });
   });
 
+  /** *************** Test 2 **************** */
   test('Modify a paced train and create added exception', async () => {
     const editedPacedTrainData = pacedTrainsJson[1];
 
-    await pacedTrainSection.editPacedTrain(1);
+    await test.step('Edit paced train at index 1', async () => {
+      await pacedTrainSection.openPacedTrainEditor(1);
+      await scenarioTimetableSection.verifyEditTimetableItemButtonVisibility();
+    });
 
-    await scenarioTimetableSection.verifyEditTimetableItemButtonVisibility();
+    await test.step('Check inputs before editing paced train', async () => {
+      await operationalStudiesPage.checkInputsBeforeEditingAPacedTrain(
+        frTranslations,
+        editedPacedTrainData.paced.time_window,
+        editedPacedTrainData.paced.interval
+      );
+    });
 
-    await operationalStudiesPage.checkInputsBeforeEditingAPacedTrain(
-      frTranslations,
-      editedPacedTrainData.paced.time_window,
-      editedPacedTrainData.paced.interval
-    );
+    await test.step('Add an exception for the paced train', async () => {
+      await operationalStudiesPage.createPacedTrainException('2025-08-08', '12:00:00');
+    });
 
-    await operationalStudiesPage.createPacedTrainException('2025-08-08', '12:00:00');
+    await test.step('Submit edit and verify the occurrences count (5)', async () => {
+      await operationalStudiesPage.submitTimetableItemEdit();
+      await pacedTrainSection.expectOccurrencesListLength(5);
+      await operationalStudiesPage.checkToastHasBeenLaunched(
+        frTranslations.timetable.pacedTrainUpdated
+      );
+    });
 
-    await operationalStudiesPage.submitTimetableItemEdit();
+    await test.step('Verify details of the added exception occurrence (index 4)', async () => {
+      await pacedTrainSection.verifyOccurrenceDetails(
+        {
+          name: `${editedPacedTrainData.train_name}/+`,
+          startTime: '12:00',
+          arrivalTime: '12:07',
+        },
+        4
+      );
+    });
 
-    await pacedTrainSection.expectOccurrencesListLength(5);
+    await test.step('Check tooltip and occurrence menu for added exception', async () => {
+      await pacedTrainSection.checkExceptionTooltip(
+        4,
+        frTranslations.timetable.occurrenceType.addedOccurrence,
+        frTranslations.timetable.occurrenceChangeGroup.start_time as ChangeGroup
+      );
 
-    await operationalStudiesPage.checkToastHasBeenLaunched(
-      frTranslations.timetable.pacedTrainUpdated
-    );
-
-    await pacedTrainSection.verifyOccurrenceDetails(
-      {
-        name: `${editedPacedTrainData.train_name}/+`,
-        startTime: '12:00',
-        arrivalTime: '12:07',
-      },
-      4
-    );
-
-    await pacedTrainSection.checkExceptionTooltip(
-      4,
-      frTranslations.timetable.occurrenceType.addedOccurrence,
-      frTranslations.timetable.occurrenceChangeGroup.start_time as ChangeGroup
-    );
-
-    await pacedTrainSection.checkOccurrenceMenuIcon(4);
-    await pacedTrainSection.checkOccurrenceActionMenu({
-      occurrenceIndex: 4,
-      expectedButtons: ADDED_EXCEPTION_MENU_BUTTONS,
-      translations: frTranslations,
+      await pacedTrainSection.checkOccurrenceMenuIcon(4);
+      await pacedTrainSection.checkOccurrenceActionMenu({
+        occurrenceIndex: 4,
+        expectedButtons: ADDED_EXCEPTION_MENU_BUTTONS,
+        translations: frTranslations,
+      });
     });
   });
 
+  /** *************** Test 3 **************** */
   test('Edit an indexed occurrence', async () => {
-    await pacedTrainSection.clickOnPacedTrain(0);
-    await pacedTrainSection.checkOccurrenceMenuIcon(0);
-    await pacedTrainSection.checkOccurrenceActionMenu({
-      occurrenceIndex: 0,
-      expectedButtons: CONFORM_ACTIVE_OCCURRENCE_MENU_BUTTONS,
-      translations: frTranslations,
+    await test.step('Open paced train and check initial menu (first occurrence)', async () => {
+      await pacedTrainSection.clickOnPacedTrain(0);
+      await pacedTrainSection.checkOccurrenceMenuIcon(0);
+      await pacedTrainSection.checkOccurrenceActionMenu({
+        occurrenceIndex: 0,
+        expectedButtons: CONFORM_ACTIVE_OCCURRENCE_MENU_BUTTONS,
+        translations: frTranslations,
+      });
     });
-    await pacedTrainSection.clickOccurrenceMenuButton('edit');
-    await operationalStudiesPage.setTimetableItemName(EDITED_OCCURRENCE_NAME);
-    await operationalStudiesPage.updateTimetableItem(frTranslations.pacedTrains.updatePacedTrain);
-    await operationalStudiesPage.checkToastHasBeenLaunched(
-      frTranslations.timetable.pacedTrainUpdated
-    );
 
-    await pacedTrainSection.checkExceptionTooltip(
-      0,
-      frTranslations.timetable.occurrenceType.editedOccurrence +
-        frTranslations.timetable.occurrenceChangeGroup.train_name
-    );
-    await pacedTrainSection.checkOccurrenceMenuIcon(0);
-    await pacedTrainSection.checkOccurrenceActionMenu({
-      occurrenceIndex: 0,
-      expectedButtons: EXCEPTION_ACTIVE_OCCURRENCE_MENU_BUTTONS,
-      translations: frTranslations,
+    await test.step('Edit occurrence name and save', async () => {
+      await pacedTrainSection.clickOccurrenceMenuButton('edit');
+      await operationalStudiesPage.setTimetableItemName(EDITED_OCCURRENCE_NAME);
+      await operationalStudiesPage.updateTimetableItem(frTranslations.pacedTrains.updatePacedTrain);
+      await operationalStudiesPage.checkToastHasBeenLaunched(
+        frTranslations.timetable.pacedTrainUpdated
+      );
     });
-    await pacedTrainSection.clickOccurrenceMenuButton('disable');
-    await pacedTrainSection.verifyOccurrenceName(0, EDITED_OCCURRENCE_NAME);
-    await pacedTrainSection.checkOccurrenceMenuIcon(0);
-    await pacedTrainSection.checkOccurrenceActionMenu({
-      occurrenceIndex: 0,
-      expectedButtons: DISABLED_OCCURRENCE_MENU_BUTTONS,
-      translations: frTranslations,
+
+    await test.step('Verify edited occurrence tooltip and menu', async () => {
+      await pacedTrainSection.checkExceptionTooltip(
+        0,
+        frTranslations.timetable.occurrenceType.editedOccurrence +
+          frTranslations.timetable.occurrenceChangeGroup.train_name
+      );
+      await pacedTrainSection.checkOccurrenceMenuIcon(0);
+      await pacedTrainSection.checkOccurrenceActionMenu({
+        occurrenceIndex: 0,
+        expectedButtons: EXCEPTION_ACTIVE_OCCURRENCE_MENU_BUTTONS,
+        translations: frTranslations,
+      });
     });
-    await pacedTrainSection.clickOccurrenceMenuButton('enable');
-    await pacedTrainSection.verifyOccurrenceName(0, EDITED_OCCURRENCE_NAME);
-    await pacedTrainSection.checkOccurrenceMenuIcon(0);
-    await pacedTrainSection.checkOccurrenceActionMenu({
-      occurrenceIndex: 0,
-      expectedButtons: EXCEPTION_ACTIVE_OCCURRENCE_MENU_BUTTONS,
-      translations: frTranslations,
+
+    await test.step('Disable edited occurrence and verify UI', async () => {
+      await pacedTrainSection.clickOccurrenceMenuButton('disable');
+      await pacedTrainSection.verifyOccurrenceName(0, EDITED_OCCURRENCE_NAME);
+      await pacedTrainSection.checkOccurrenceMenuIcon(0);
+      await pacedTrainSection.checkOccurrenceActionMenu({
+        occurrenceIndex: 0,
+        expectedButtons: DISABLED_OCCURRENCE_MENU_BUTTONS,
+        translations: frTranslations,
+      });
     });
-    await pacedTrainSection.clickOccurrenceMenuButton('restore');
-    await pacedTrainSection.verifyOccurrenceName(0, INITIAL_OCCURRENCE_NAME);
+
+    await test.step('Re-enable edited occurrence and verify UI', async () => {
+      await pacedTrainSection.clickOccurrenceMenuButton('enable');
+      await pacedTrainSection.verifyOccurrenceName(0, EDITED_OCCURRENCE_NAME);
+      await pacedTrainSection.checkOccurrenceMenuIcon(0);
+      await pacedTrainSection.checkOccurrenceActionMenu({
+        occurrenceIndex: 0,
+        expectedButtons: EXCEPTION_ACTIVE_OCCURRENCE_MENU_BUTTONS,
+        translations: frTranslations,
+      });
+    });
+
+    await test.step('Restore occurrence to initial model', async () => {
+      await pacedTrainSection.clickOccurrenceMenuButton('restore');
+      await pacedTrainSection.verifyOccurrenceName(0, INITIAL_OCCURRENCE_NAME);
+    });
   });
 
+  /** *************** Test 4 **************** */
   test('Edit added exception', async () => {
     const PACED_TRAIN_NUMBER = 4;
     const addedOccurrenceIndex = 1;
     const editedPacedTrainData = pacedTrainsJson[PACED_TRAIN_NUMBER];
 
-    await pacedTrainSection.clickOnPacedTrain(PACED_TRAIN_NUMBER);
-    await pacedTrainSection.checkOccurrenceMenuIcon(addedOccurrenceIndex);
-    await pacedTrainSection.checkOccurrenceActionMenu({
-      occurrenceIndex: addedOccurrenceIndex,
-      expectedButtons: ADDED_EXCEPTION_MENU_BUTTONS,
-      translations: frTranslations,
-    });
-    // 1. open exception edit menu
-    await pacedTrainSection.clickOccurrenceMenuButton('edit');
-
-    await operationalStudiesPage.checkEditOccurrenceButtonsVisibility();
-
-    // 2. modify RS, route, start time, simulation params
-    await rollingStockSelector.openRollingstockModal();
-    await rollingStockSelector.selectRollingStockCard({
-      name: electricRollingStockName,
-      confirmSelection: true,
+    await test.step('Open paced train and check initial menu state', async () => {
+      await pacedTrainSection.clickOnPacedTrain(PACED_TRAIN_NUMBER);
+      await pacedTrainSection.checkOccurrenceMenuIcon(addedOccurrenceIndex);
+      await pacedTrainSection.checkOccurrenceActionMenu({
+        occurrenceIndex: addedOccurrenceIndex,
+        expectedButtons: ADDED_EXCEPTION_MENU_BUTTONS,
+        translations: frTranslations,
+      });
     });
 
-    await operationalStudiesPage.openRouteTab();
-    await routeTab.performPathfindingByTrigram({
-      originTrigram: 'WS',
-      destinationTrigram: 'NES',
+    await test.step('Open exception edit menu', async () => {
+      await pacedTrainSection.clickOccurrenceMenuButton('edit');
+      await operationalStudiesPage.checkEditOccurrenceButtonsVisibility();
     });
 
-    await operationalStudiesPage.setTimetableItemStartTime('02:40', '2024-10-16');
+    await test.step('Modify RS, route, start time and simulation params', async () => {
+      await rollingStockSelector.openRollingstockModal();
+      await rollingStockSelector.selectRollingStockCard({
+        name: electricRollingStockName,
+        confirmSelection: true,
+      });
 
-    await operationalStudiesPage.openTimesAndStopsTab();
-    await timesAndStopsTab.fillTableCellByStationAndHeader(
-      'Mid_East_station',
-      frTranslations.timeStopTable.stopTime,
-      '18000'
-    );
+      await operationalStudiesPage.openRouteTab();
+      await routeTab.performPathfindingByTrigram({
+        originTrigram: 'WS',
+        destinationTrigram: 'NES',
+      });
 
-    await operationalStudiesPage.openSimulationSettingsTab();
-    await simulationSettingsTab.selectSpeedLimitTagOption('MA100');
+      await operationalStudiesPage.setTimetableItemStartTime('02:40', '2024-10-16');
 
-    await operationalStudiesPage.submitTimetableItemEdit();
-    await operationalStudiesPage.checkToastHasBeenLaunched(
-      frTranslations.timetable.pacedTrainUpdated
-    );
+      await operationalStudiesPage.openTimesAndStopsTab();
+      await timesAndStopsTab.fillTableCellByStationAndHeader(
+        'Mid_East_station',
+        frTranslations.timeStopTable.stopTime,
+        '18000'
+      );
 
-    // 4. hover and check exception tool tip list
-    await pacedTrainSection.checkExceptionTooltip(
-      addedOccurrenceIndex,
-      frTranslations.timetable.occurrenceType.addedOccurrence,
-      frTranslations.timetable.occurrenceChangeGroup.path_and_schedule as ChangeGroup,
-      frTranslations.timetable.occurrenceChangeGroup.rolling_stock as ChangeGroup,
-      frTranslations.timetable.occurrenceChangeGroup.speed_limit_tag as ChangeGroup,
-      frTranslations.timetable.occurrenceChangeGroup.start_time as ChangeGroup
-    );
+      await operationalStudiesPage.openSimulationSettingsTab();
+      await simulationSettingsTab.selectSpeedLimitTagOption('MA100');
 
-    // 5. open menu
-    await pacedTrainSection.checkOccurrenceMenuIcon(addedOccurrenceIndex);
-    await pacedTrainSection.checkOccurrenceActionMenu({
-      occurrenceIndex: addedOccurrenceIndex,
-      expectedButtons: ADDED_AND_MODIFIED_EXCEPTION_MENU_BUTTONS,
-      translations: frTranslations,
+      await operationalStudiesPage.submitTimetableItemEdit();
+      await operationalStudiesPage.checkToastHasBeenLaunched(
+        frTranslations.timetable.pacedTrainUpdated
+      );
+    });
+
+    await test.step('Check exception tooltip after modifications', async () => {
+      await pacedTrainSection.checkExceptionTooltip(
+        addedOccurrenceIndex,
+        frTranslations.timetable.occurrenceType.addedOccurrence,
+        frTranslations.timetable.occurrenceChangeGroup.path_and_schedule as ChangeGroup,
+        frTranslations.timetable.occurrenceChangeGroup.rolling_stock as ChangeGroup,
+        frTranslations.timetable.occurrenceChangeGroup.speed_limit_tag as ChangeGroup,
+        frTranslations.timetable.occurrenceChangeGroup.start_time as ChangeGroup
+      );
+    });
+
+    await test.step('Check occurrence menu after modifications', async () => {
+      await pacedTrainSection.checkOccurrenceMenuIcon(addedOccurrenceIndex);
+      await pacedTrainSection.checkOccurrenceActionMenu({
+        occurrenceIndex: addedOccurrenceIndex,
+        expectedButtons: ADDED_AND_MODIFIED_EXCEPTION_MENU_BUTTONS,
+        translations: frTranslations,
+      });
     });
 
     // 6. projection
     await pacedTrainSection.clickOccurrenceMenuButton('project');
     // TODO: check snapshots
 
-    // 7. restoring to model
-    await pacedTrainSection.checkOccurrenceMenuIcon(addedOccurrenceIndex);
-    await pacedTrainSection.checkOccurrenceActionMenu({
-      occurrenceIndex: addedOccurrenceIndex,
-      expectedButtons: ADDED_AND_MODIFIED_EXCEPTION_MENU_BUTTONS,
-      translations: frTranslations,
+    await test.step('Restore occurrence to model', async () => {
+      await pacedTrainSection.checkOccurrenceMenuIcon(addedOccurrenceIndex);
+      await pacedTrainSection.checkOccurrenceActionMenu({
+        occurrenceIndex: addedOccurrenceIndex,
+        expectedButtons: ADDED_AND_MODIFIED_EXCEPTION_MENU_BUTTONS,
+        translations: frTranslations,
+      });
+      await pacedTrainSection.clickOccurrenceMenuButton('restore');
+      await pacedTrainSection.verifyOccurrenceDetails(
+        {
+          name: `${editedPacedTrainData.train_name}/+`,
+          startTime: '02:40',
+          arrivalTime: '02:47',
+        },
+        addedOccurrenceIndex
+      );
+
+      await pacedTrainSection.checkOccurrenceMenuIcon(addedOccurrenceIndex);
+      await pacedTrainSection.checkOccurrenceActionMenu({
+        occurrenceIndex: addedOccurrenceIndex,
+        expectedButtons: ADDED_EXCEPTION_MENU_BUTTONS,
+        translations: frTranslations,
+      });
     });
-    await pacedTrainSection.clickOccurrenceMenuButton('restore');
-    await pacedTrainSection.verifyOccurrenceDetails(
-      {
-        name: `${editedPacedTrainData.train_name}/+`,
-        startTime: '02:40',
-        arrivalTime: '02:47',
-      },
-      addedOccurrenceIndex
-    );
 
-    await pacedTrainSection.checkOccurrenceMenuIcon(addedOccurrenceIndex);
-    await pacedTrainSection.checkOccurrenceActionMenu({
-      occurrenceIndex: addedOccurrenceIndex,
-      expectedButtons: ADDED_EXCEPTION_MENU_BUTTONS,
-      translations: frTranslations,
+    await test.step('Delete occurrence and check remaining ones', async () => {
+      await pacedTrainSection.clickOccurrenceMenuButton('delete');
+
+      await pacedTrainSection.expectOccurrencesListLength(2);
+      await pacedTrainSection.verifyOccurrenceDetails(
+        {
+          name: `${editedPacedTrainData.train_name} 1`,
+          startTime: '02:00',
+          arrivalTime: '02:07',
+        },
+        0
+      );
+      await pacedTrainSection.verifyOccurrenceDetails(
+        {
+          name: `${editedPacedTrainData.train_name} 3`,
+          startTime: '03:00',
+          arrivalTime: '03:07',
+        },
+        1
+      );
     });
-
-    // 8. delete
-    await pacedTrainSection.clickOccurrenceMenuButton('delete');
-
-    // check the non deleted stuff is unmodified
-    await pacedTrainSection.expectOccurrencesListLength(2);
-    await pacedTrainSection.verifyOccurrenceDetails(
-      {
-        name: `${editedPacedTrainData.train_name} 1`,
-        startTime: '02:00',
-        arrivalTime: '02:07',
-      },
-      0
-    );
-    await pacedTrainSection.verifyOccurrenceDetails(
-      {
-        name: `${editedPacedTrainData.train_name} 3`,
-        startTime: '03:00',
-        arrivalTime: '03:07',
-      },
-      1
-    );
   });
 });

--- a/front/tests/pages/operational-studies/paced-train-section.ts
+++ b/front/tests/pages/operational-studies/paced-train-section.ts
@@ -295,7 +295,7 @@ class PacedTrainSection extends CommonPage {
     await pacedTrainItem.click();
   }
 
-  async editPacedTrain(index: number = 0) {
+  async openPacedTrainEditor(index: number = 0) {
     const pacedTrainItem = await this.getPacedTrainToClickableZone(index);
     await expect(pacedTrainItem).toBeVisible();
     await pacedTrainItem.click();

--- a/front/tests/utils/types.ts
+++ b/front/tests/utils/types.ts
@@ -324,6 +324,13 @@ export type StdcmTranslations = {
 
 export type FlatTranslations = Record<string, string>;
 
+export type StudyFrTranslations = {
+  study: {
+    studyCategories: FlatTranslations;
+    studyStates: FlatTranslations;
+  };
+};
+
 export type ManageTimetableItemTranslations = FlatTranslations & {
   pacedTrains: FlatTranslations;
 };


### PR DESCRIPTION
Closes #11440
- Make Playwright reporter/trace readable and searchable
- Speed up triage of flaky tests by exposing intent per action.
