### PR TITLE
ui-charts: simplify rectangular zoom

### DIFF
--- a/front/ui/ui-charts/src/manchette/hooks/useManchetteWithSpaceTimeChart.tsx
+++ b/front/ui/ui-charts/src/manchette/hooks/useManchetteWithSpaceTimeChart.tsx
@@ -174,80 +174,77 @@ const useManchetteWithSpaceTimeChart = ({
   );
 
   useEffect(() => {
-    if (rect && !zoomMode && spaceTimeChartRef?.current) {
-      const { timeStart, timeEnd, spaceStart, spaceEnd } = rect;
-      const timeRange = Math.abs(Number(timeEnd) - Number(timeStart)); // width of rect in ms
-      const spaceRange = Math.abs(spaceEnd - spaceStart); // height of rect in mm
-
-      const chosenTimeScale = timeRange / spaceTimeChartRef.current.clientWidth;
-      const newTimeScale = clamp(chosenTimeScale, MAX_ZOOM_MS_PER_PX, MIN_ZOOM_MS_PER_PX);
-      const newXZoom = timeScaleToZoomValue(newTimeScale);
-      const newXOffset = sideOffset(
-        timeOrigin,
-        newTimeScale,
-        rect.timeStart,
-        rect.timeEnd,
-        spaceTimeChartRef.current.clientWidth
-      );
-
-      let newYZoom = yZoom;
-      let newYOffset = yOffset;
-
-      if (isProportional) {
-        const chosenSpaceScale = spaceRange / drawingHeightWithoutTopPadding;
-        const newSpaceScale = clamp(
-            chosenSpaceScale,
-            maxZoomMillimeterPerPx,
-            minZoomMillimeterPerPx
-          );
-          // we don’t need to handle this case and compute an offset
-          // this condition happens when we draw a rectangle
-          // larger than the entire chart (minus padding)
-          // that would actually zoom OUT if it wasn’t clamped.
-          if (newSpaceScale !== minZoomMillimeterPerPx) {
-            newYZoom = spaceScaleToZoomValue(
-              minZoomMillimeterPerPx,
-              maxZoomMillimeterPerPx,
-              newSpaceScale
-            );
-            newYOffset = Math.abs(
-              sideOffset(
-                spaceOrigin,
-                newSpaceScale,
-                rect.spaceStart,
-                rect.spaceEnd,
-                height,
-                verticalPadding
-              )
-            );
-          }
-      } else if (pixelRect) {
-        const currentStopHeight = BASE_WAYPOINT_HEIGHT * yZoom;
-        const { yStart, yEnd } = pixelRect;
-        const numberOfStopsInRect = Math.abs(yEnd - yStart) / currentStopHeight;
-        let newStopHeight = drawingHeightWithoutTopPadding / numberOfStopsInRect;
-        // at maximum zoom, we want 3 stops displayed
-        const maxStopHeight =
-          drawingHeightWithoutTopPadding / (2 + BASE_WAYPOINT_HEIGHT / newStopHeight);
-        newStopHeight = Math.min(newStopHeight, maxStopHeight);
-
-        newYZoom = newStopHeight / BASE_WAYPOINT_HEIGHT;
-        const rectTop = yOffset + Math.min(yStart, yEnd) - WAYPOINT_LINE_HEIGHT;
-        const numberOfStopsBeforeRectTop = rectTop / currentStopHeight;
-        newYOffset = numberOfStopsBeforeRectTop * newStopHeight;
-      }
-
-      setState((prev) =>({
-          ...prev,
-          xZoom: newXZoom,
-          yZoom: newYZoom,
-          xOffset: newXOffset,
-          yOffset: newYOffset,
-          scrollTo: newYOffset,
-          rect: null,
-          pixelRect: null,
-        }));
+    if (!rect || zoomMode || !spaceTimeChartRef?.current) {
+      return;
     }
+    const { timeStart, timeEnd, spaceStart, spaceEnd } = rect;
+    const timeRange = Math.abs(Number(timeEnd) - Number(timeStart)); // width of rect in ms
+    const spaceRange = Math.abs(spaceEnd - spaceStart); // height of rect in mm
+
+    const chosenTimeScale = timeRange / spaceTimeChartRef.current.clientWidth;
+    const newTimeScale = clamp(chosenTimeScale, MAX_ZOOM_MS_PER_PX, MIN_ZOOM_MS_PER_PX);
+    const newXZoom = timeScaleToZoomValue(newTimeScale);
+    const newXOffset = sideOffset(
+      timeOrigin,
+      newTimeScale,
+      rect.timeStart,
+      rect.timeEnd,
+      spaceTimeChartRef.current.clientWidth
+    );
+
+    let newYZoom = yZoom;
+    let newYOffset = yOffset;
+
+    if (isProportional) {
+      const chosenSpaceScale = spaceRange / drawingHeightWithoutTopPadding;
+      const newSpaceScale = clamp(chosenSpaceScale, maxZoomMillimeterPerPx, minZoomMillimeterPerPx);
+      // we don’t need to handle this case and compute an offset
+      // this condition happens when we draw a rectangle
+      // larger than the entire chart (minus padding)
+      // that would actually zoom OUT if it wasn’t clamped.
+      if (newSpaceScale !== minZoomMillimeterPerPx) {
+        newYZoom = spaceScaleToZoomValue(
+          minZoomMillimeterPerPx,
+          maxZoomMillimeterPerPx,
+          newSpaceScale
+        );
+        newYOffset = Math.abs(
+          sideOffset(
+            spaceOrigin,
+            newSpaceScale,
+            rect.spaceStart,
+            rect.spaceEnd,
+            height,
+            verticalPadding
+          )
+        );
+      }
+    } else if (pixelRect) {
+      const currentStopHeight = BASE_WAYPOINT_HEIGHT * yZoom;
+      const { yStart, yEnd } = pixelRect;
+      const numberOfStopsInRect = Math.abs(yEnd - yStart) / currentStopHeight;
+      let newStopHeight = drawingHeightWithoutTopPadding / numberOfStopsInRect;
+      // at maximum zoom, we want 3 stops displayed
+      const maxStopHeight =
+        drawingHeightWithoutTopPadding / (2 + BASE_WAYPOINT_HEIGHT / newStopHeight);
+      newStopHeight = Math.min(newStopHeight, maxStopHeight);
+
+      newYZoom = newStopHeight / BASE_WAYPOINT_HEIGHT;
+      const rectTop = yOffset + Math.min(yStart, yEnd) - WAYPOINT_LINE_HEIGHT;
+      const numberOfStopsBeforeRectTop = rectTop / currentStopHeight;
+      newYOffset = numberOfStopsBeforeRectTop * newStopHeight;
+    }
+
+    setState((prev) => ({
+      ...prev,
+      xZoom: newXZoom,
+      yZoom: newYZoom,
+      xOffset: newXOffset,
+      yOffset: newYOffset,
+      scrollTo: newYOffset,
+      rect: null,
+      pixelRect: null,
+    }));
   }, [
     state.rect,
     state.zoomMode,

--- a/front/ui/ui-charts/src/manchette/hooks/useManchetteWithSpaceTimeChart.tsx
+++ b/front/ui/ui-charts/src/manchette/hooks/useManchetteWithSpaceTimeChart.tsx
@@ -180,53 +180,22 @@ const useManchetteWithSpaceTimeChart = ({
       const spaceRange = Math.abs(spaceEnd - spaceStart); // height of rect in mm
 
       const chosenTimeScale = timeRange / spaceTimeChartRef.current.clientWidth;
-      let chosenSpaceScale: number | undefined;
-      let overrideState: Partial<State>;
+      const newTimeScale = clamp(chosenTimeScale, MAX_ZOOM_MS_PER_PX, MIN_ZOOM_MS_PER_PX);
+      const newXZoom = timeScaleToZoomValue(newTimeScale);
+      const newXOffset = sideOffset(
+        timeOrigin,
+        newTimeScale,
+        rect.timeStart,
+        rect.timeEnd,
+        spaceTimeChartRef.current.clientWidth
+      );
+
+      let newYZoom = yZoom;
+      let newYOffset = yOffset;
+
       if (isProportional) {
-        chosenSpaceScale = spaceRange / drawingHeightWithoutTopPadding;
-        overrideState = { rect: null };
-      } else if (pixelRect) {
-        const currentStopHeight = BASE_WAYPOINT_HEIGHT * yZoom;
-        const { yStart, yEnd } = pixelRect;
-        const numberOfStopsInRect = Math.abs(yEnd - yStart) / currentStopHeight;
-        let newStopHeight = drawingHeightWithoutTopPadding / numberOfStopsInRect;
-        // at maximum zoom, we want 3 stops displayed
-        const maxStopHeight =
-          drawingHeightWithoutTopPadding / (2 + BASE_WAYPOINT_HEIGHT / newStopHeight);
-        newStopHeight = Math.min(newStopHeight, maxStopHeight);
-        const newYZoom = newStopHeight / BASE_WAYPOINT_HEIGHT;
-        const rectTop = yOffset + Math.min(yStart, yEnd) - WAYPOINT_LINE_HEIGHT;
-        const numberOfStopsBeforeRectTop = rectTop / currentStopHeight;
-        const newYOffset = numberOfStopsBeforeRectTop * newStopHeight;
-
-        overrideState = {
-          rect: null,
-          pixelRect: null,
-          yZoom: newYZoom,
-          yOffset: newYOffset,
-          scrollTo: newYOffset,
-        };
-      }
-
-      setState((prev) => {
-        if (prev.zoomMode || !prev.rect || !spaceTimeChartRef?.current) {
-          return prev;
-        }
-        const newTimeScale = clamp(chosenTimeScale, MAX_ZOOM_MS_PER_PX, MIN_ZOOM_MS_PER_PX);
-        const timeZoomValue = timeScaleToZoomValue(newTimeScale);
-
-        const newXOffset = sideOffset(
-          timeOrigin,
-          newTimeScale,
-          prev.rect.timeStart,
-          prev.rect.timeEnd,
-          spaceTimeChartRef.current.clientWidth
-        );
-
-        let newYZoom = yZoom;
-        let newYOffset = yOffset;
-        if (chosenSpaceScale) {
-          const newSpaceScale = clamp(
+        const chosenSpaceScale = spaceRange / drawingHeightWithoutTopPadding;
+        const newSpaceScale = clamp(
             chosenSpaceScale,
             maxZoomMillimeterPerPx,
             minZoomMillimeterPerPx
@@ -245,25 +214,39 @@ const useManchetteWithSpaceTimeChart = ({
               sideOffset(
                 spaceOrigin,
                 newSpaceScale,
-                prev.rect.spaceStart,
-                prev.rect.spaceEnd,
+                rect.spaceStart,
+                rect.spaceEnd,
                 height,
                 verticalPadding
               )
             );
           }
-        }
+      } else if (pixelRect) {
+        const currentStopHeight = BASE_WAYPOINT_HEIGHT * yZoom;
+        const { yStart, yEnd } = pixelRect;
+        const numberOfStopsInRect = Math.abs(yEnd - yStart) / currentStopHeight;
+        let newStopHeight = drawingHeightWithoutTopPadding / numberOfStopsInRect;
+        // at maximum zoom, we want 3 stops displayed
+        const maxStopHeight =
+          drawingHeightWithoutTopPadding / (2 + BASE_WAYPOINT_HEIGHT / newStopHeight);
+        newStopHeight = Math.min(newStopHeight, maxStopHeight);
 
-        return {
+        newYZoom = newStopHeight / BASE_WAYPOINT_HEIGHT;
+        const rectTop = yOffset + Math.min(yStart, yEnd) - WAYPOINT_LINE_HEIGHT;
+        const numberOfStopsBeforeRectTop = rectTop / currentStopHeight;
+        newYOffset = numberOfStopsBeforeRectTop * newStopHeight;
+      }
+
+      setState((prev) =>({
           ...prev,
-          xZoom: timeZoomValue,
+          xZoom: newXZoom,
           yZoom: newYZoom,
           xOffset: newXOffset,
           yOffset: newYOffset,
           scrollTo: newYOffset,
-          ...overrideState,
-        };
-      });
+          rect: null,
+          pixelRect: null,
+        }));
     }
   }, [
     state.rect,

--- a/front/ui/ui-charts/src/manchette/hooks/useManchetteWithSpaceTimeChart.tsx
+++ b/front/ui/ui-charts/src/manchette/hooks/useManchetteWithSpaceTimeChart.tsx
@@ -153,7 +153,6 @@ const useManchetteWithSpaceTimeChart = ({
     panning,
     zoomMode,
     rect,
-    pixelRect,
     isProportional,
   } = state;
 
@@ -173,96 +172,93 @@ const useManchetteWithSpaceTimeChart = ({
     totalDistance
   );
 
-  useEffect(() => {
-    if (!rect || zoomMode || !spaceTimeChartRef?.current) {
-      return;
-    }
-    const { timeStart, timeEnd, spaceStart, spaceEnd } = rect;
-    const timeRange = Math.abs(Number(timeEnd) - Number(timeStart)); // width of rect in ms
-    const spaceRange = Math.abs(spaceEnd - spaceStart); // height of rect in mm
-
-    const chosenTimeScale = timeRange / spaceTimeChartRef.current.clientWidth;
-    const newTimeScale = clamp(chosenTimeScale, MAX_ZOOM_MS_PER_PX, MIN_ZOOM_MS_PER_PX);
-    const newXZoom = timeScaleToZoomValue(newTimeScale);
-    const newXOffset = sideOffset(
-      timeOrigin,
-      newTimeScale,
-      rect.timeStart,
-      rect.timeEnd,
-      spaceTimeChartRef.current.clientWidth
-    );
-
-    let newYZoom = yZoom;
-    let newYOffset = yOffset;
-
-    if (isProportional) {
-      const chosenSpaceScale = spaceRange / drawingHeightWithoutTopPadding;
-      const newSpaceScale = clamp(chosenSpaceScale, maxZoomMillimeterPerPx, minZoomMillimeterPerPx);
-      // we don’t need to handle this case and compute an offset
-      // this condition happens when we draw a rectangle
-      // larger than the entire chart (minus padding)
-      // that would actually zoom OUT if it wasn’t clamped.
-      if (newSpaceScale !== minZoomMillimeterPerPx) {
-        newYZoom = spaceScaleToZoomValue(
-          minZoomMillimeterPerPx,
-          maxZoomMillimeterPerPx,
-          newSpaceScale
-        );
-        newYOffset = Math.abs(
-          sideOffset(
-            spaceOrigin,
-            newSpaceScale,
-            rect.spaceStart,
-            rect.spaceEnd,
-            height,
-            verticalPadding
-          )
-        );
+  const handleRectZoomEnd = useCallback(
+    (prev: State) => {
+      if (!prev.rect || !spaceTimeChartRef?.current) {
+        return {};
       }
-    } else if (pixelRect) {
-      const currentStopHeight = BASE_WAYPOINT_HEIGHT * yZoom;
-      const { yStart, yEnd } = pixelRect;
-      const numberOfStopsInRect = Math.abs(yEnd - yStart) / currentStopHeight;
-      let newStopHeight = drawingHeightWithoutTopPadding / numberOfStopsInRect;
-      // at maximum zoom, we want 3 stops displayed
-      const maxStopHeight =
-        drawingHeightWithoutTopPadding / (2 + BASE_WAYPOINT_HEIGHT / newStopHeight);
-      newStopHeight = Math.min(newStopHeight, maxStopHeight);
 
-      newYZoom = newStopHeight / BASE_WAYPOINT_HEIGHT;
-      const rectTop = yOffset + Math.min(yStart, yEnd) - WAYPOINT_LINE_HEIGHT;
-      const numberOfStopsBeforeRectTop = rectTop / currentStopHeight;
-      newYOffset = numberOfStopsBeforeRectTop * newStopHeight;
-    }
+      const { timeStart, timeEnd, spaceStart, spaceEnd } = prev.rect;
+      const timeRange = Math.abs(Number(timeEnd) - Number(timeStart)); // width of rect in ms
+      const spaceRange = Math.abs(spaceEnd - spaceStart); // height of rect in mm
 
-    setState((prev) => ({
-      ...prev,
-      xZoom: newXZoom,
-      yZoom: newYZoom,
-      xOffset: newXOffset,
-      yOffset: newYOffset,
-      scrollTo: newYOffset,
-      rect: null,
-      pixelRect: null,
-    }));
-  }, [
-    state.rect,
-    state.zoomMode,
-    drawingHeightWithoutTopPadding,
-    isProportional,
-    pixelRect,
-    rect,
-    spaceTimeChartRef,
-    yOffset,
-    yZoom,
-    zoomMode,
-    timeOrigin,
-    maxZoomMillimeterPerPx,
-    minZoomMillimeterPerPx,
-    spaceOrigin,
-    height,
-    verticalPadding,
-  ]);
+      const chosenTimeScale = timeRange / spaceTimeChartRef.current.clientWidth;
+      const newTimeScale = clamp(chosenTimeScale, MAX_ZOOM_MS_PER_PX, MIN_ZOOM_MS_PER_PX);
+      const newXZoom = timeScaleToZoomValue(newTimeScale);
+      const newXOffset = sideOffset(
+        prev.timeOrigin,
+        newTimeScale,
+        prev.rect.timeStart,
+        prev.rect.timeEnd,
+        spaceTimeChartRef.current.clientWidth
+      );
+
+      let newYZoom = prev.yZoom;
+      let newYOffset = prev.yOffset;
+
+      if (prev.isProportional) {
+        const chosenSpaceScale = spaceRange / drawingHeightWithoutTopPadding;
+        const newSpaceScale = clamp(
+          chosenSpaceScale,
+          maxZoomMillimeterPerPx,
+          minZoomMillimeterPerPx
+        );
+        // we don’t need to handle this case and compute an offset
+        // this condition happens when we draw a rectangle
+        // larger than the entire chart (minus padding)
+        // that would actually zoom OUT if it wasn’t clamped.
+        if (newSpaceScale !== minZoomMillimeterPerPx) {
+          newYZoom = spaceScaleToZoomValue(
+            minZoomMillimeterPerPx,
+            maxZoomMillimeterPerPx,
+            newSpaceScale
+          );
+          newYOffset = Math.abs(
+            sideOffset(
+              prev.spaceOrigin,
+              newSpaceScale,
+              prev.rect.spaceStart,
+              prev.rect.spaceEnd,
+              height,
+              verticalPadding
+            )
+          );
+        }
+      } else if (prev.pixelRect) {
+        const currentStopHeight = BASE_WAYPOINT_HEIGHT * prev.yZoom;
+        const { yStart, yEnd } = prev.pixelRect;
+        const numberOfStopsInRect = Math.abs(yEnd - yStart) / currentStopHeight;
+        let newStopHeight = drawingHeightWithoutTopPadding / numberOfStopsInRect;
+        // at maximum zoom, we want 3 stops displayed
+        const maxStopHeight =
+          drawingHeightWithoutTopPadding / (2 + BASE_WAYPOINT_HEIGHT / newStopHeight);
+        newStopHeight = Math.min(newStopHeight, maxStopHeight);
+
+        newYZoom = newStopHeight / BASE_WAYPOINT_HEIGHT;
+        const rectTop = prev.yOffset + Math.min(yStart, yEnd) - WAYPOINT_LINE_HEIGHT;
+        const numberOfStopsBeforeRectTop = rectTop / currentStopHeight;
+        newYOffset = numberOfStopsBeforeRectTop * newStopHeight;
+      }
+
+      return {
+        xZoom: newXZoom,
+        yZoom: newYZoom,
+        xOffset: newXOffset,
+        yOffset: newYOffset,
+        scrollTo: newYOffset,
+        rect: null,
+        pixelRect: null,
+      };
+    },
+    [
+      spaceTimeChartRef,
+      drawingHeightWithoutTopPadding,
+      maxZoomMillimeterPerPx,
+      minZoomMillimeterPerPx,
+      height,
+      verticalPadding,
+    ]
+  );
 
   const zoomYIn = useCallback(() => {
     const maxZoom = isProportional
@@ -624,6 +620,7 @@ const useManchetteWithSpaceTimeChart = ({
             if (!isPanning) {
               return {
                 ...prev,
+                ...(prev.zoomMode && prev.rect ? handleRectZoomEnd(prev) : {}),
                 panning: null,
                 zoomMode: false,
               };
@@ -709,6 +706,7 @@ const useManchetteWithSpaceTimeChart = ({
       yOffset,
       waypointsToDisplay,
       splitPoints,
+      displayTimeCaptions,
       xZoom,
       xOffset,
       verticalPadding,
@@ -723,13 +721,13 @@ const useManchetteWithSpaceTimeChart = ({
       minZoomMillimeterPerPx,
       maxZoomMillimeterPerPx,
       setTimeOrigin,
-      displayTimeCaptions,
       isShiftPressed,
       panning,
+      manchetteWithSpaceTimeChartRef,
       enableTimePan,
       enableSpacePan,
+      handleRectZoomEnd,
       canvasDrawingHeight,
-      manchetteWithSpaceTimeChartRef,
     ]
   );
 };

--- a/front/ui/ui-charts/src/manchette/hooks/useManchetteWithSpaceTimeChart.tsx
+++ b/front/ui/ui-charts/src/manchette/hooks/useManchetteWithSpaceTimeChart.tsx
@@ -173,14 +173,41 @@ const useManchetteWithSpaceTimeChart = ({
     totalDistance
   );
 
-  const handleRectangleZoom = useCallback(
-    ({
-      scales: { chosenTimeScale, chosenSpaceScale },
-      overrideState,
-    }: {
-      scales: { chosenTimeScale: number; chosenSpaceScale?: number };
-      overrideState?: Partial<State>;
-    }) => {
+  useEffect(() => {
+    if (rect && !zoomMode && spaceTimeChartRef?.current) {
+      const { timeStart, timeEnd, spaceStart, spaceEnd } = rect;
+      const timeRange = Math.abs(Number(timeEnd) - Number(timeStart)); // width of rect in ms
+      const spaceRange = Math.abs(spaceEnd - spaceStart); // height of rect in mm
+
+      const chosenTimeScale = timeRange / spaceTimeChartRef.current.clientWidth;
+      let chosenSpaceScale: number | undefined;
+      let overrideState: Partial<State>;
+      if (isProportional) {
+        chosenSpaceScale = spaceRange / drawingHeightWithoutTopPadding;
+        overrideState = { rect: null };
+      } else if (pixelRect) {
+        const currentStopHeight = BASE_WAYPOINT_HEIGHT * yZoom;
+        const { yStart, yEnd } = pixelRect;
+        const numberOfStopsInRect = Math.abs(yEnd - yStart) / currentStopHeight;
+        let newStopHeight = drawingHeightWithoutTopPadding / numberOfStopsInRect;
+        // at maximum zoom, we want 3 stops displayed
+        const maxStopHeight =
+          drawingHeightWithoutTopPadding / (2 + BASE_WAYPOINT_HEIGHT / newStopHeight);
+        newStopHeight = Math.min(newStopHeight, maxStopHeight);
+        const newYZoom = newStopHeight / BASE_WAYPOINT_HEIGHT;
+        const rectTop = yOffset + Math.min(yStart, yEnd) - WAYPOINT_LINE_HEIGHT;
+        const numberOfStopsBeforeRectTop = rectTop / currentStopHeight;
+        const newYOffset = numberOfStopsBeforeRectTop * newStopHeight;
+
+        overrideState = {
+          rect: null,
+          pixelRect: null,
+          yZoom: newYZoom,
+          yOffset: newYOffset,
+          scrollTo: newYOffset,
+        };
+      }
+
       setState((prev) => {
         if (prev.zoomMode || !prev.rect || !spaceTimeChartRef?.current) {
           return prev;
@@ -237,65 +264,10 @@ const useManchetteWithSpaceTimeChart = ({
           ...overrideState,
         };
       });
-    },
-    [
-      timeOrigin,
-      spaceOrigin,
-      minZoomMillimeterPerPx,
-      maxZoomMillimeterPerPx,
-      yOffset,
-      yZoom,
-      height,
-      spaceTimeChartRef,
-      verticalPadding,
-    ]
-  );
-
-  useEffect(() => {
-    if (rect && !zoomMode && spaceTimeChartRef?.current) {
-      const { timeStart, timeEnd, spaceStart, spaceEnd } = rect;
-      const timeRange = Math.abs(Number(timeEnd) - Number(timeStart)); // width of rect in ms
-      const spaceRange = Math.abs(spaceEnd - spaceStart); // height of rect in mm
-
-      const chosenTimeScale = timeRange / spaceTimeChartRef.current.clientWidth;
-      if (isProportional) {
-        const chosenSpaceScale = spaceRange / drawingHeightWithoutTopPadding;
-        handleRectangleZoom({
-          scales: { chosenTimeScale, chosenSpaceScale },
-          overrideState: { rect: null },
-        });
-      } else if (pixelRect) {
-        const currentStopHeight = BASE_WAYPOINT_HEIGHT * yZoom;
-        const { yStart, yEnd } = pixelRect;
-        const numberOfStopsInRect = Math.abs(yEnd - yStart) / currentStopHeight;
-        let newStopHeight = drawingHeightWithoutTopPadding / numberOfStopsInRect;
-        // at maximum zoom, we want 3 stops displayed
-        const maxStopHeight =
-          drawingHeightWithoutTopPadding / (2 + BASE_WAYPOINT_HEIGHT / newStopHeight);
-        newStopHeight = Math.min(newStopHeight, maxStopHeight);
-        const newYZoom = newStopHeight / BASE_WAYPOINT_HEIGHT;
-        const rectTop = yOffset + Math.min(yStart, yEnd) - WAYPOINT_LINE_HEIGHT;
-        const numberOfStopsBeforeRectTop = rectTop / currentStopHeight;
-        const newYOffset = numberOfStopsBeforeRectTop * newStopHeight;
-
-        handleRectangleZoom({
-          scales: {
-            chosenTimeScale,
-          },
-          overrideState: {
-            rect: null,
-            pixelRect: null,
-            yZoom: newYZoom,
-            yOffset: newYOffset,
-            scrollTo: newYOffset,
-          },
-        });
-      }
     }
   }, [
     state.rect,
     state.zoomMode,
-    handleRectangleZoom,
     drawingHeightWithoutTopPadding,
     isProportional,
     pixelRect,
@@ -304,6 +276,12 @@ const useManchetteWithSpaceTimeChart = ({
     yOffset,
     yZoom,
     zoomMode,
+    timeOrigin,
+    maxZoomMillimeterPerPx,
+    minZoomMillimeterPerPx,
+    spaceOrigin,
+    height,
+    verticalPadding,
   ]);
 
   const zoomYIn = useCallback(() => {


### PR DESCRIPTION
See commits

This PR removes the useEffect used for rectangular zoom and handles it synchronously in the onPan callback.