### PR TITLE
front: enable occurrence selection for path projection

### DIFF
--- a/front/src/applications/operationalStudies/hooks/usePathProjection.ts
+++ b/front/src/applications/operationalStudies/hooks/usePathProjection.ts
@@ -5,35 +5,53 @@ import { useSelector } from 'react-redux';
 
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import type { InfraWithStatus } from 'modules/infra/types';
+import { getExceptionFromOccurrenceId } from 'modules/timetableItem/helpers/pacedTrain';
+import type { TimetableItemId, TimetableItem } from 'reducers/osrdconf/types';
 import { getTrainIdUsedForProjection } from 'reducers/simulationResults/selectors';
 import {
   extractEditoastIdFromPacedTrainId,
   extractEditoastIdFromTrainScheduleId,
+  extractPacedTrainIdFromOccurrenceId,
   isPacedTrainId,
   isTrainScheduleId,
 } from 'utils/trainId';
 
-const usePathProjection = (infra: InfraWithStatus) => {
+const usePathProjection = (
+  infra: InfraWithStatus,
+  timetableItemsById: Map<TimetableItemId, TimetableItem>
+) => {
   const trainIdUsedForProjection = useSelector(getTrainIdUsedForProjection);
 
-  const trainScheduleId =
-    trainIdUsedForProjection && isTrainScheduleId(trainIdUsedForProjection)
-      ? extractEditoastIdFromTrainScheduleId(trainIdUsedForProjection)
-      : undefined;
+  let rawTrainScheduleId: number | undefined;
+  let rawPacedTrainId: number | undefined;
+  let exceptionKey: string | undefined;
+  if (trainIdUsedForProjection) {
+    if (isTrainScheduleId(trainIdUsedForProjection)) {
+      rawTrainScheduleId = extractEditoastIdFromTrainScheduleId(trainIdUsedForProjection);
+    } else if (isPacedTrainId(trainIdUsedForProjection)) {
+      rawPacedTrainId = extractEditoastIdFromPacedTrainId(trainIdUsedForProjection);
+    } else {
+      const pacedTrainId = extractPacedTrainIdFromOccurrenceId(trainIdUsedForProjection);
+      rawPacedTrainId = extractEditoastIdFromPacedTrainId(pacedTrainId);
+      exceptionKey = getExceptionFromOccurrenceId(
+        timetableItemsById,
+        trainIdUsedForProjection
+      )?.key;
+    }
+  }
 
-  const pacedTrainId =
-    trainIdUsedForProjection && isPacedTrainId(trainIdUsedForProjection)
-      ? extractEditoastIdFromPacedTrainId(trainIdUsedForProjection)
-      : undefined;
-
-  const scheduleArg = trainScheduleId ? { id: trainScheduleId, infraId: infra.id } : skipToken;
-  const pacedArg = pacedTrainId ? { id: pacedTrainId, infraId: infra.id } : skipToken;
+  const scheduleArg = rawTrainScheduleId
+    ? { id: rawTrainScheduleId, infraId: infra.id }
+    : skipToken;
+  const pacedArg = rawPacedTrainId
+    ? { id: rawPacedTrainId, infraId: infra.id, exceptionKey }
+    : skipToken;
 
   const { data: schedulePath } =
     osrdEditoastApi.endpoints.getTrainScheduleByIdPath.useQuery(scheduleArg);
   const { data: pacedPath } = osrdEditoastApi.endpoints.getPacedTrainByIdPath.useQuery(pacedArg);
 
-  const pathfinding = trainScheduleId ? schedulePath : pacedPath;
+  const pathfinding = rawTrainScheduleId ? schedulePath : pacedPath;
 
   const { data: pathProperties } =
     osrdEditoastApi.endpoints.postInfraByInfraIdPathProperties.useQuery(

--- a/front/src/applications/operationalStudies/hooks/usePathProjection.ts
+++ b/front/src/applications/operationalStudies/hooks/usePathProjection.ts
@@ -32,29 +32,29 @@ const usePathProjection = (infra: InfraWithStatus) => {
     osrdEditoastApi.endpoints.getTrainScheduleByIdPath.useQuery(scheduleArg);
   const { data: pacedPath } = osrdEditoastApi.endpoints.getPacedTrainByIdPath.useQuery(pacedArg);
 
-  const path = trainScheduleId ? schedulePath : pacedPath;
+  const pathfinding = trainScheduleId ? schedulePath : pacedPath;
 
   const { data: pathProperties } =
     osrdEditoastApi.endpoints.postInfraByInfraIdPathProperties.useQuery(
-      path?.status === 'success'
+      pathfinding?.status === 'success'
         ? {
             infraId: infra.id,
             props: ['geometry', 'operational_points'],
-            pathPropertiesInput: { track_section_ranges: path.track_section_ranges },
+            pathPropertiesInput: { track_section_ranges: pathfinding.track_section_ranges },
           }
         : skipToken
     );
 
   return useMemo(() => {
-    if (path?.status !== 'success' || !pathProperties) {
+    if (pathfinding?.status !== 'success' || !pathProperties) {
       return undefined;
     }
     return {
-      path,
+      pathfinding,
       geometry: pathProperties.geometry,
       operationalPoints: pathProperties.operational_points,
     };
-  }, [path, pathProperties]);
+  }, [pathfinding, pathProperties]);
 };
 
 export default usePathProjection;

--- a/front/src/applications/operationalStudies/hooks/usePathProjection.ts
+++ b/front/src/applications/operationalStudies/hooks/usePathProjection.ts
@@ -9,6 +9,7 @@ import { getTrainIdUsedForProjection } from 'reducers/simulationResults/selector
 import {
   extractEditoastIdFromPacedTrainId,
   extractEditoastIdFromTrainScheduleId,
+  isPacedTrainId,
   isTrainScheduleId,
 } from 'utils/trainId';
 
@@ -21,7 +22,7 @@ const usePathProjection = (infra: InfraWithStatus) => {
       : undefined;
 
   const pacedTrainId =
-    trainIdUsedForProjection && !isTrainScheduleId(trainIdUsedForProjection)
+    trainIdUsedForProjection && isPacedTrainId(trainIdUsedForProjection)
       ? extractEditoastIdFromPacedTrainId(trainIdUsedForProjection)
       : undefined;
 

--- a/front/src/applications/operationalStudies/hooks/useScenarioData.ts
+++ b/front/src/applications/operationalStudies/hooks/useScenarioData.ts
@@ -151,8 +151,9 @@ const useScenarioData = (scenario: ScenarioResponse, infra: InfraWithStatus) => 
     [projectedTrainsById]
   );
 
-  const timetableItemUsedForProjection = useMemo(
-    () => (trainIdUsedForProjection ? timetableItemsById.get(trainIdUsedForProjection) : undefined),
+  const pathUsedForProjection = useMemo(
+    () =>
+      trainIdUsedForProjection ? timetableItemsById.get(trainIdUsedForProjection)?.path : undefined,
     [trainIdUsedForProjection, timetableItems]
   );
 
@@ -352,9 +353,9 @@ const useScenarioData = (scenario: ScenarioResponse, infra: InfraWithStatus) => 
       timetableItemsWithDetails,
       timetableItems,
       projectionData:
-        timetableItemUsedForProjection && projectionPath
+        pathUsedForProjection && projectionPath
           ? {
-              timetableItem: timetableItemUsedForProjection,
+              path: pathUsedForProjection,
               ...projectionPath,
               projectedTrains,
               projectionLoaderData: {
@@ -372,7 +373,7 @@ const useScenarioData = (scenario: ScenarioResponse, infra: InfraWithStatus) => 
     [
       timetableItemsWithDetails,
       timetableItems,
-      timetableItemUsedForProjection,
+      pathUsedForProjection,
       projectionPath,
       projectedTrains,
       allTrainsProjected,

--- a/front/src/applications/operationalStudies/hooks/useScenarioData.ts
+++ b/front/src/applications/operationalStudies/hooks/useScenarioData.ts
@@ -97,7 +97,7 @@ const useScenarioData = (scenario: ScenarioResponse, infra: InfraWithStatus) => 
   } = useLazyProjectTrains({
     infraId: scenario.infra_id,
     electricalProfileSetId,
-    path: projectionPath?.path,
+    path: projectionPath?.pathfinding,
     operationalPoints: projectionPath?.operationalPoints,
   });
 

--- a/front/src/applications/operationalStudies/hooks/useScenarioData.ts
+++ b/front/src/applications/operationalStudies/hooks/useScenarioData.ts
@@ -11,6 +11,7 @@ import {
   formatPacedTrainWithDetails,
   formatTrainScheduleWithDetails,
 } from 'modules/timetableItem/helpers/formatTimetableItemWithDetails';
+import { getExceptionFromOccurrenceId } from 'modules/timetableItem/helpers/pacedTrain';
 import { getOperationalStudiesElectricalProfileSetId } from 'reducers/osrdconf/operationalStudiesConf/selectors';
 import type { TimetableItemId, TimetableItem } from 'reducers/osrdconf/types';
 import { getTrainIdUsedForProjection } from 'reducers/simulationResults/selectors';
@@ -22,6 +23,7 @@ import {
   extractEditoastIdFromPacedTrainId,
   isPacedTrainResponseWithPacedTrainId,
   isOccurrenceId,
+  extractPacedTrainIdFromOccurrenceId,
 } from 'utils/trainId';
 import { mapBy } from 'utils/types';
 
@@ -40,13 +42,14 @@ const useScenarioData = (scenario: ScenarioResponse, infra: InfraWithStatus) => 
   const trainIdUsedForProjection = useSelector(getTrainIdUsedForProjection);
 
   const [timetableItems, setTimetableItems] = useState<TimetableItem[]>();
+  const timetableItemsById = useMemo(() => mapBy(timetableItems, 'id'), [timetableItems]);
 
   const [putTrainScheduleById] = osrdEditoastApi.endpoints.putTrainScheduleById.useMutation();
   const [putPacedTrainById] = osrdEditoastApi.endpoints.putPacedTrainById.useMutation();
 
   const { rollingStocks, rollingStockMap: rollingStocksByName } = useRollingStockContext();
 
-  const projectionPath = usePathProjection(infra);
+  const projectionPath = usePathProjection(infra, timetableItemsById);
 
   useEffect(() => {
     const trainSchedulesResult = dispatch(
@@ -86,8 +89,6 @@ const useScenarioData = (scenario: ScenarioResponse, infra: InfraWithStatus) => 
       pacedTrainsResult?.unsubscribe();
     };
   }, [scenario.timetable_id]);
-
-  const timetableItemsById = useMemo(() => mapBy(timetableItems, 'id'), [timetableItems]);
 
   const {
     projectedTrainsById,
@@ -153,8 +154,15 @@ const useScenarioData = (scenario: ScenarioResponse, infra: InfraWithStatus) => 
   );
 
   const pathUsedForProjection = useMemo(() => {
-    if (!trainIdUsedForProjection || isOccurrenceId(trainIdUsedForProjection)) return undefined;
-    return timetableItemsById.get(trainIdUsedForProjection)?.path;
+    if (!trainIdUsedForProjection) return undefined;
+    if (!isOccurrenceId(trainIdUsedForProjection)) {
+      return timetableItemsById.get(trainIdUsedForProjection)?.path;
+    }
+    const pacedTrain = timetableItemsById.get(
+      extractPacedTrainIdFromOccurrenceId(trainIdUsedForProjection)
+    );
+    const exception = getExceptionFromOccurrenceId(timetableItemsById, trainIdUsedForProjection);
+    return exception?.path_and_schedule?.path ?? pacedTrain!.path;
   }, [trainIdUsedForProjection, timetableItems]);
 
   const timetableItemIds = useMemo(

--- a/front/src/applications/operationalStudies/hooks/useScenarioData.ts
+++ b/front/src/applications/operationalStudies/hooks/useScenarioData.ts
@@ -21,6 +21,7 @@ import {
   extractEditoastIdFromTrainScheduleId,
   extractEditoastIdFromPacedTrainId,
   isPacedTrainResponseWithPacedTrainId,
+  isOccurrenceId,
 } from 'utils/trainId';
 import { mapBy } from 'utils/types';
 
@@ -151,11 +152,10 @@ const useScenarioData = (scenario: ScenarioResponse, infra: InfraWithStatus) => 
     [projectedTrainsById]
   );
 
-  const pathUsedForProjection = useMemo(
-    () =>
-      trainIdUsedForProjection ? timetableItemsById.get(trainIdUsedForProjection)?.path : undefined,
-    [trainIdUsedForProjection, timetableItems]
-  );
+  const pathUsedForProjection = useMemo(() => {
+    if (!trainIdUsedForProjection || isOccurrenceId(trainIdUsedForProjection)) return undefined;
+    return timetableItemsById.get(trainIdUsedForProjection)?.path;
+  }, [trainIdUsedForProjection, timetableItems]);
 
   const timetableItemIds = useMemo(
     () => timetableItems?.map((item) => item.id) ?? [],

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults.tsx
@@ -123,7 +123,7 @@ const SimulationResults = ({
     timetableItemProjections: projectPathTrainResult,
   });
 
-  const conflictZones = useProjectedConflicts(infraId, conflicts, projectionData?.path);
+  const conflictZones = useProjectedConflicts(infraId, conflicts, projectionData?.pathfinding);
 
   const simulationSummary = useMemo(() => {
     if (!selectedTrainId) return undefined;

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults.tsx
@@ -29,7 +29,6 @@ import { getTrainIdUsedForProjection } from 'reducers/simulationResults/selector
 import { useAppDispatch } from 'store';
 import {
   extractPacedTrainIdFromOccurrenceId,
-  isOccurrenceId,
   isPacedTrainWithDetails,
   isTrainScheduleId,
 } from 'utils/trainId';
@@ -238,7 +237,7 @@ const SimulationResults = ({
               </div>
               <div className="osrd-simulation-container d-flex flex-grow-1 flex-shrink-1">
                 <div className="chart-container">
-                  {trainIdUsedForProjection && !isOccurrenceId(trainIdUsedForProjection) && (
+                  {trainIdUsedForProjection && (
                     <SpaceTimeChartWrapper
                       operationalPoints={projectedOperationalPoints}
                       projectPathTrainResult={projectPathTrainResult}

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults.tsx
@@ -29,6 +29,7 @@ import { getTrainIdUsedForProjection } from 'reducers/simulationResults/selector
 import { useAppDispatch } from 'store';
 import {
   extractPacedTrainIdFromOccurrenceId,
+  isOccurrenceId,
   isPacedTrainWithDetails,
   isTrainScheduleId,
 } from 'utils/trainId';
@@ -237,7 +238,7 @@ const SimulationResults = ({
               </div>
               <div className="osrd-simulation-container d-flex flex-grow-1 flex-shrink-1">
                 <div className="chart-container">
-                  {trainIdUsedForProjection && (
+                  {trainIdUsedForProjection && !isOccurrenceId(trainIdUsedForProjection) && (
                     <SpaceTimeChartWrapper
                       operationalPoints={projectedOperationalPoints}
                       projectPathTrainResult={projectPathTrainResult}

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults.tsx
@@ -111,6 +111,7 @@ const SimulationResults = ({
     timetableItemUsedForProjection: projectionData?.timetableItem,
     infraId,
     timetableId,
+    pathfinding: projectionData?.pathfinding,
   });
 
   const {

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults.tsx
@@ -108,7 +108,7 @@ const SimulationResults = ({
     filteredOperationalPoints,
     setFilteredOperationalPoints,
   } = useGetProjectedTrainOperationalPoints({
-    timetableItemUsedForProjection: projectionData?.timetableItem,
+    path: projectionData?.path,
     infraId,
     timetableId,
     pathfinding: projectionData?.pathfinding,
@@ -246,7 +246,7 @@ const SimulationResults = ({
                       waypointsPanelData={{
                         filteredWaypoints: filteredOperationalPoints,
                         setFilteredWaypoints: setFilteredOperationalPoints,
-                        projectionPath: projectionData.timetableItem.path,
+                        projectionPath: projectionData.path,
                         deployedWaypoints: new Set(
                           deployedWaypoints.map(({ waypointId }) => waypointId)
                         ),

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
@@ -40,13 +40,13 @@ import upward from 'assets/pictures/workSchedules/ScheduledMaintenanceUp.svg';
 import { type PostWorkSchedulesProjectPathApiResponse } from 'common/api/osrdEditoastApi';
 import { useSubCategoryContext } from 'common/SubCategoryContext';
 import type {
-  IndividualTrainProjection,
   PathOperationalPoint,
   TrainSpaceTimeData,
   WaypointsPanelData,
+  DraggingState,
 } from 'modules/simulationResult/types';
 import type { TimetableItemWithDetails } from 'modules/timetableItem/components/Timetable/types';
-import type { TimetableItemId, TrainId } from 'reducers/osrdconf/types';
+import type { OccurrenceId, PacedTrainId, TrainId, TrainScheduleId } from 'reducers/osrdconf/types';
 import { updateSelectedTrainId } from 'reducers/simulationResults';
 import { useAppDispatch } from 'store';
 import {
@@ -58,6 +58,7 @@ import {
   extractEditoastIdFromPacedTrainId,
   extractOccurrenceIndexFromOccurrenceId,
   isPacedTrainId,
+  formatPacedTrainIdToIndexedOccurrenceId,
 } from 'utils/trainId';
 
 import getPathStyle from './helpers/getPathStyle';
@@ -106,7 +107,7 @@ type SpaceTimeChartWrapperBaseProps = {
   }) => Promise<void>;
   height?: number;
   onTrainClick?: (trainId: TrainId) => void;
-  selectedProjectionId: TimetableItemId;
+  selectedProjectionId: TrainScheduleId | PacedTrainId | OccurrenceId;
   timetableItemsWithDetails?: TimetableItemWithDetails[];
 };
 
@@ -150,10 +151,7 @@ const SpaceTimeChartWrapper = ({
   const activeWaypointRef = useRef<HTMLDivElement>(null);
 
   const [hoveredItem, setHoveredItem] = useState<null | HoveredItem>(null);
-  const [draggingState, setDraggingState] = useState<{
-    draggedTrain: IndividualTrainProjection;
-    initialDepartureTime: Date;
-  }>();
+  const [draggingState, setDraggingState] = useState<DraggingState>();
 
   const isTimetableItemValid = useMemo(() => {
     const timetableItemUsedForProjectionWithDetails = timetableItemsWithDetails?.find(
@@ -309,9 +307,10 @@ const SpaceTimeChartWrapper = ({
   });
 
   useEffect(() => {
-    const trainUsedForProjection = projectPathTrainResult.find((train) =>
-      train.id.includes(selectedProjectionId)
-    );
+    const trainId = isPacedTrainId(selectedProjectionId)
+      ? formatPacedTrainIdToIndexedOccurrenceId(selectedProjectionId, 0)
+      : selectedProjectionId;
+    const trainUsedForProjection = projectedTrains.find((train) => train.id === trainId);
     if (trainUsedForProjection) {
       setTimeOrigin(+trainUsedForProjection.departureTime);
     } else {

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useGetProjectedTrainOperationalPoints.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useGetProjectedTrainOperationalPoints.ts
@@ -16,12 +16,12 @@ import { getWaypointsLocalStorageKey } from './helpers/utils';
 const useGetProjectedTrainOperationalPoints = ({
   infraId,
   timetableId,
-  timetableItemUsedForProjection,
+  path,
   pathfinding,
 }: {
   infraId: number;
   timetableId: number | undefined;
-  timetableItemUsedForProjection?: TimetableItem;
+  path?: TimetableItem['path'];
   pathfinding?: PathfindingResultSuccess;
 }) => {
   const { t } = useTranslation('operational-studies');
@@ -36,8 +36,9 @@ const useGetProjectedTrainOperationalPoints = ({
 
   useEffect(() => {
     const getOperationalPoints = async () => {
-      if (!timetableItemUsedForProjection || !pathfinding) return;
+      if (!path || !pathfinding) return;
 
+      // TODO: get the operational points from useScenarioData
       const { operational_points } = await postPathProperties({
         infraId,
         props: ['operational_points'],
@@ -57,7 +58,7 @@ const useGetProjectedTrainOperationalPoints = ({
         projectionType === 'trackProjection'
           ? upsertMapWaypointsInOperationalPoints(
               'PathOperationalPoint',
-              timetableItemUsedForProjection.path,
+              path,
               pathfinding.path_item_positions,
               operationalPointsWithUniqueIds,
               t
@@ -67,7 +68,7 @@ const useGetProjectedTrainOperationalPoints = ({
       setOperationalPoints(operationalPointsWithUniqueIds);
 
       const stringifiedSavedWaypoints = localStorage.getItem(
-        getWaypointsLocalStorageKey(timetableId, timetableItemUsedForProjection.path)
+        getWaypointsLocalStorageKey(timetableId, path)
       );
       if (stringifiedSavedWaypoints) {
         operationalPointsWithUniqueIds = JSON.parse(
@@ -91,7 +92,7 @@ const useGetProjectedTrainOperationalPoints = ({
     };
 
     getOperationalPoints();
-  }, [timetableItemUsedForProjection, pathfinding, infraId, t, projectionType]);
+  }, [path, pathfinding, infraId, t, projectionType]);
 
   return { operationalPoints, filteredOperationalPoints, setFilteredOperationalPoints };
 };

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useGetProjectedTrainOperationalPoints.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useGetProjectedTrainOperationalPoints.ts
@@ -9,9 +9,7 @@ import { osrdEditoastApi, type PathfindingResultSuccess } from 'common/api/osrdE
 import { isStation } from 'modules/pathfinding/utils';
 import type { PathOperationalPoint } from 'modules/simulationResult/types';
 import type { TimetableItem } from 'reducers/osrdconf/types';
-import {
-  getProjectionType,
-} from 'reducers/simulationResults/selectors';
+import { getProjectionType } from 'reducers/simulationResults/selectors';
 
 import { getWaypointsLocalStorageKey } from './helpers/utils';
 
@@ -40,58 +38,56 @@ const useGetProjectedTrainOperationalPoints = ({
     const getOperationalPoints = async () => {
       if (!timetableItemUsedForProjection || !pathfinding) return;
 
-      if (timetableItemUsedForProjection) {
-        const { operational_points } = await postPathProperties({
-          infraId,
-          props: ['operational_points'],
-          pathPropertiesInput: {
-            track_section_ranges: pathfinding.track_section_ranges,
-          },
-        }).unwrap();
+      const { operational_points } = await postPathProperties({
+        infraId,
+        props: ['operational_points'],
+        pathPropertiesInput: {
+          track_section_ranges: pathfinding.track_section_ranges,
+        },
+      }).unwrap();
 
-        let operationalPointsWithUniqueIds: PathOperationalPoint[] =
-          operational_points?.map((op, i) => ({
-            ...omit(op, 'id'),
-            waypointId: `${op.id}-${op.position}-${i}`,
-            opId: op.id,
-          })) || [];
+      let operationalPointsWithUniqueIds: PathOperationalPoint[] =
+        operational_points?.map((op, i) => ({
+          ...omit(op, 'id'),
+          waypointId: `${op.id}-${op.position}-${i}`,
+          opId: op.id,
+        })) || [];
 
-        operationalPointsWithUniqueIds =
-          projectionType === 'trackProjection'
-            ? upsertMapWaypointsInOperationalPoints(
-                'PathOperationalPoint',
-                timetableItemUsedForProjection.path,
-                pathfinding.path_item_positions,
-                operationalPointsWithUniqueIds,
-                t
-              )
-            : operationalPointsWithUniqueIds;
+      operationalPointsWithUniqueIds =
+        projectionType === 'trackProjection'
+          ? upsertMapWaypointsInOperationalPoints(
+              'PathOperationalPoint',
+              timetableItemUsedForProjection.path,
+              pathfinding.path_item_positions,
+              operationalPointsWithUniqueIds,
+              t
+            )
+          : operationalPointsWithUniqueIds;
 
-        setOperationalPoints(operationalPointsWithUniqueIds);
+      setOperationalPoints(operationalPointsWithUniqueIds);
 
-        const stringifiedSavedWaypoints = localStorage.getItem(
-          getWaypointsLocalStorageKey(timetableId, timetableItemUsedForProjection.path)
-        );
-        if (stringifiedSavedWaypoints) {
-          operationalPointsWithUniqueIds = JSON.parse(
-            stringifiedSavedWaypoints
-          ) as PathOperationalPoint[];
-        } else {
-          // If the manchette hasn't been saved, we want to display by default only
-          // the waypoints with CH BV/00/'' and the path steps (origin, destination, vias)
+      const stringifiedSavedWaypoints = localStorage.getItem(
+        getWaypointsLocalStorageKey(timetableId, timetableItemUsedForProjection.path)
+      );
+      if (stringifiedSavedWaypoints) {
+        operationalPointsWithUniqueIds = JSON.parse(
+          stringifiedSavedWaypoints
+        ) as PathOperationalPoint[];
+      } else {
+        // If the manchette hasn't been saved, we want to display by default only
+        // the waypoints with CH BV/00/'' and the path steps (origin, destination, vias)
 
-          const lastIndex = operationalPointsWithUniqueIds.length - 1;
-          operationalPointsWithUniqueIds = operationalPointsWithUniqueIds.filter((op, i) => {
-            if (i === 0 || i === lastIndex) return true;
-            // handle waypoints added from the map
-            if (!op.extensions?.sncf) return true;
-            // handle waypoints added from the pathfinding or operational points on path
-            return isStation(op.extensions.sncf.ch) || op.weight === 100;
-          });
-        }
-
-        setFilteredOperationalPoints(operationalPointsWithUniqueIds);
+        const lastIndex = operationalPointsWithUniqueIds.length - 1;
+        operationalPointsWithUniqueIds = operationalPointsWithUniqueIds.filter((op, i) => {
+          if (i === 0 || i === lastIndex) return true;
+          // handle waypoints added from the map
+          if (!op.extensions?.sncf) return true;
+          // handle waypoints added from the pathfinding or operational points on path
+          return isStation(op.extensions.sncf.ch) || op.weight === 100;
+        });
       }
+
+      setFilteredOperationalPoints(operationalPointsWithUniqueIds);
     };
 
     getOperationalPoints();

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useGetProjectedTrainOperationalPoints.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useGetProjectedTrainOperationalPoints.ts
@@ -5,16 +5,13 @@ import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
 import { upsertMapWaypointsInOperationalPoints } from 'applications/operationalStudies/helpers/upsertMapWaypointsInOperationalPoints';
-import { osrdEditoastApi, type PathfindingResult } from 'common/api/osrdEditoastApi';
+import { osrdEditoastApi, type PathfindingResultSuccess } from 'common/api/osrdEditoastApi';
 import { isStation } from 'modules/pathfinding/utils';
 import type { PathOperationalPoint } from 'modules/simulationResult/types';
 import type { TimetableItem } from 'reducers/osrdconf/types';
-import { getProjectionType } from 'reducers/simulationResults/selectors';
 import {
-  extractEditoastIdFromPacedTrainId,
-  extractEditoastIdFromTrainScheduleId,
-  isTrainScheduleId,
-} from 'utils/trainId';
+  getProjectionType,
+} from 'reducers/simulationResults/selectors';
 
 import { getWaypointsLocalStorageKey } from './helpers/utils';
 
@@ -22,10 +19,12 @@ const useGetProjectedTrainOperationalPoints = ({
   infraId,
   timetableId,
   timetableItemUsedForProjection,
+  pathfinding,
 }: {
   infraId: number;
   timetableId: number | undefined;
   timetableItemUsedForProjection?: TimetableItem;
+  pathfinding?: PathfindingResultSuccess;
 }) => {
   const { t } = useTranslation('operational-studies');
   const projectionType = useSelector(getProjectionType);
@@ -34,38 +33,19 @@ const useGetProjectedTrainOperationalPoints = ({
   const [filteredOperationalPoints, setFilteredOperationalPoints] =
     useState<PathOperationalPoint[]>(operationalPoints);
 
-  const [getTrainSchedulePath] = osrdEditoastApi.endpoints.getTrainScheduleByIdPath.useLazyQuery();
-  const [getPacedTrainPath] = osrdEditoastApi.endpoints.getPacedTrainByIdPath.useLazyQuery();
   const [postPathProperties] =
     osrdEditoastApi.endpoints.postInfraByInfraIdPathProperties.useLazyQuery();
 
   useEffect(() => {
     const getOperationalPoints = async () => {
-      if (!timetableItemUsedForProjection) return;
-
-      const trainIdUsedForProjection = timetableItemUsedForProjection.id;
-
-      let path: PathfindingResult;
-      if (isTrainScheduleId(trainIdUsedForProjection)) {
-        path = await getTrainSchedulePath({
-          id: extractEditoastIdFromTrainScheduleId(trainIdUsedForProjection),
-          infraId,
-        }).unwrap();
-      } else {
-        path = await getPacedTrainPath({
-          id: extractEditoastIdFromPacedTrainId(trainIdUsedForProjection),
-          infraId,
-        }).unwrap();
-      }
-
-      if (path.status !== 'success') return;
+      if (!timetableItemUsedForProjection || !pathfinding) return;
 
       if (timetableItemUsedForProjection) {
         const { operational_points } = await postPathProperties({
           infraId,
           props: ['operational_points'],
           pathPropertiesInput: {
-            track_section_ranges: path.track_section_ranges,
+            track_section_ranges: pathfinding.track_section_ranges,
           },
         }).unwrap();
 
@@ -81,7 +61,7 @@ const useGetProjectedTrainOperationalPoints = ({
             ? upsertMapWaypointsInOperationalPoints(
                 'PathOperationalPoint',
                 timetableItemUsedForProjection.path,
-                path.path_item_positions,
+                pathfinding.path_item_positions,
                 operationalPointsWithUniqueIds,
                 t
               )
@@ -115,7 +95,7 @@ const useGetProjectedTrainOperationalPoints = ({
     };
 
     getOperationalPoints();
-  }, [timetableItemUsedForProjection, infraId, t, projectionType]);
+  }, [timetableItemUsedForProjection, pathfinding, infraId, t, projectionType]);
 
   return { operationalPoints, filteredOperationalPoints, setFilteredOperationalPoints };
 };

--- a/front/src/modules/simulationResult/types.ts
+++ b/front/src/modules/simulationResult/types.ts
@@ -125,3 +125,8 @@ export type AspectLabel =
   | '160A'
   | '080A'
   | '000';
+
+export type DraggingState = {
+  draggedTrain: IndividualTrainProjection;
+  initialDepartureTime: Date;
+};

--- a/front/src/modules/simulationResult/types.ts
+++ b/front/src/modules/simulationResult/types.ts
@@ -86,7 +86,7 @@ export type SpeedDistanceDiagramData = {
 export type ProjectionData = {
   timetableItem: TimetableItem;
   projectedTrains: TrainSpaceTimeData[];
-  path: PathfindingResultSuccess;
+  pathfinding: PathfindingResultSuccess;
   geometry: PathProperties['geometry'];
   projectionLoaderData: {
     allTrainsProjected: boolean;

--- a/front/src/modules/simulationResult/types.ts
+++ b/front/src/modules/simulationResult/types.ts
@@ -84,7 +84,7 @@ export type SpeedDistanceDiagramData = {
 };
 
 export type ProjectionData = {
-  timetableItem: TimetableItem;
+  path: TimetableItem['path'];
   projectedTrains: TrainSpaceTimeData[];
   pathfinding: PathfindingResultSuccess;
   geometry: PathProperties['geometry'];

--- a/front/src/modules/timetableItem/components/Timetable/PacedTrain/OccurrenceItem.tsx
+++ b/front/src/modules/timetableItem/components/Timetable/PacedTrain/OccurrenceItem.tsx
@@ -4,6 +4,7 @@ import {
   Clock,
   Flame,
   KebabHorizontal,
+  Manchette,
   Moon,
   Pencil,
   Play,
@@ -16,11 +17,13 @@ import dayjs from 'dayjs';
 import { omit } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { GiPathDistance } from 'react-icons/gi';
+import { useSelector } from 'react-redux';
 
 import AnchoredMenu from 'common/AnchoredMenu';
 import type { SubCategory } from 'common/api/osrdEditoastApi';
 import OSRDMenu, { type OSRDMenuItem } from 'common/OSRDMenu';
 import RollingStock2Img from 'modules/rollingStock/components/RollingStock2Img';
+import { getTrainIdUsedForProjection } from 'reducers/simulationResults/selectors';
 import { addElementAtIndex } from 'utils/array';
 import { addDurationToDate } from 'utils/duration';
 import {
@@ -77,6 +80,8 @@ const OccurrenceItem = ({
   const menuRef = useRef<HTMLDivElement>(null);
   const menuButtonRef = useRef<HTMLButtonElement>(null);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  const trainIdUsedForProjection = useSelector(getTrainIdUsedForProjection);
 
   const { trainName, rollingStock, startTime, disabled, exceptionChangeGroups, summary } =
     occurrence;
@@ -209,6 +214,12 @@ const OccurrenceItem = ({
       >
         <div className="title-img">
           <div className="indicator-title">
+            {trainIdUsedForProjection === occurrence.id &&
+              !!exceptionChangeGroups?.path_and_schedule && (
+                <div className="occurrence-projected">
+                  <Manchette iconColor="var(--white100)" />
+                </div>
+              )}
             <OccurrenceIndicator occurrence={occurrence} subCategories={subCategories} />
 
             <div className="label">

--- a/front/src/modules/timetableItem/components/Timetable/PacedTrain/OccurrenceItem.tsx
+++ b/front/src/modules/timetableItem/components/Timetable/PacedTrain/OccurrenceItem.tsx
@@ -65,6 +65,7 @@ const OccurrenceItem = ({
   nextOccurrence,
   occurrenceActions: {
     selectOccurrence,
+    selectOccurrenceForProjection,
     editOccurrence,
     updateOccurrenceStatus,
     resetOccurrenceExceptions,
@@ -136,6 +137,7 @@ const OccurrenceItem = ({
       title: t('occurrenceMenu.project'),
       icon: <GiPathDistance />,
       onClick: () => {
+        selectOccurrenceForProjection(occurrence.id);
         closeMenu();
       },
       dataTestID: 'occurrence-project-button',

--- a/front/src/modules/timetableItem/components/Timetable/PacedTrain/PacedTrainItem.tsx
+++ b/front/src/modules/timetableItem/components/Timetable/PacedTrain/PacedTrainItem.tsx
@@ -37,10 +37,18 @@ import {
   updateSelectedTrainId,
   updateTrainIdUsedForProjection,
 } from 'reducers/simulationResults';
+import { getTrainIdUsedForProjection } from 'reducers/simulationResults/selectors';
 import { useAppDispatch } from 'store';
 import { addDurationToDate, Duration } from 'utils/duration';
 import { castErrorToFailure } from 'utils/error';
-import { formatEditoastIdToPacedTrainId, extractEditoastIdFromPacedTrainId } from 'utils/trainId';
+import {
+  formatEditoastIdToPacedTrainId,
+  extractEditoastIdFromPacedTrainId,
+  extractPacedTrainIdFromOccurrenceId,
+  isTrainScheduleId,
+  isPacedTrainId,
+  formatPacedTrainIdToOccurrenceId,
+} from 'utils/trainId';
 
 import TimetableItemActions from '../TimetableItemActions';
 import useOccurrences from './hooks/useOccurrences';
@@ -58,7 +66,6 @@ type PacedTrainItemProps = {
   handleOpenOccurrencesList: (pacedTrainId: PacedTrainId) => void;
   pacedTrain: PacedTrainWithDetails;
   isOnEdit: boolean;
-  isProjectionPathUsed: boolean;
   selectedTrainId?: TrainId;
   selectPacedTrainToEdit: (
     pacedTrainToEdit: PacedTrainWithDetails,
@@ -68,6 +75,7 @@ type PacedTrainItemProps = {
   upsertTimetableItems: (timetableItems: TimetableItem[]) => void;
   removePacedTrains: (pacedTrainIdsToRemove: TimetableItemId[]) => void;
   subCategories: SubCategory[];
+  infraIsCached: boolean;
 };
 
 const PacedTrainItem = ({
@@ -77,12 +85,12 @@ const PacedTrainItem = ({
   handleOpenOccurrencesList,
   pacedTrain,
   isOnEdit,
-  isProjectionPathUsed,
   selectPacedTrainToEdit,
   selectedTrainId,
   upsertTimetableItems,
   removePacedTrains,
   subCategories,
+  infraIsCached,
 }: PacedTrainItemProps) => {
   const { editedElementContainer } = useContext(EditedElementContainerContext);
   const { t } = useTranslation('operational-studies', { keyPrefix: 'main' });
@@ -90,6 +98,26 @@ const PacedTrainItem = ({
   const { openModal } = useContext(ModalContext);
   const { closeModal } = useContext(ModalContext);
   const timetableId = useSelector(getOperationalStudiesTimetableID);
+
+  const trainIdUsedForProjection = useSelector(getTrainIdUsedForProjection);
+
+  const { showPacedTrainProjectionIcon, pathUsedForProjectionIsException } = useMemo(() => {
+    if (!trainIdUsedForProjection || isTrainScheduleId(trainIdUsedForProjection))
+      return { showPacedTrainProjectionIcon: false, pathUsedForProjectionIsException: false };
+    if (isPacedTrainId(trainIdUsedForProjection))
+      return {
+        showPacedTrainProjectionIcon: pacedTrain.id === trainIdUsedForProjection,
+        pathUsedForProjectionIsException: false,
+      };
+    const exception = pacedTrain.exceptions.find(
+      (ex) => formatPacedTrainIdToOccurrenceId(pacedTrain.id, ex) === trainIdUsedForProjection
+    );
+    return {
+      showPacedTrainProjectionIcon:
+        extractPacedTrainIdFromOccurrenceId(trainIdUsedForProjection) === pacedTrain.id,
+      pathUsedForProjectionIsException: !!exception?.path_and_schedule,
+    };
+  }, [trainIdUsedForProjection, pacedTrain]);
 
   const { summary } = pacedTrain;
   const { rollingStocks } = useRollingStockContext();
@@ -254,8 +282,12 @@ const PacedTrainItem = ({
           role="button"
           tabIndex={0}
         >
-          {isProjectionPathUsed && (
-            <div className="train-projected">
+          {infraIsCached && showPacedTrainProjectionIcon && (
+            <div
+              className={cx('train-projected', {
+                grayed: pathUsedForProjectionIsException,
+              })}
+            >
               <Manchette iconColor="var(--white100)" />
             </div>
           )}

--- a/front/src/modules/timetableItem/components/Timetable/PacedTrain/hooks/useOccurrenceActions.ts
+++ b/front/src/modules/timetableItem/components/Timetable/PacedTrain/hooks/useOccurrenceActions.ts
@@ -13,7 +13,7 @@ import {
 import { storePacedTrain } from 'modules/timetableItem/helpers/updateTimetableItemHelpers';
 import { getOperationalStudiesTimetableID } from 'reducers/osrdconf/operationalStudiesConf/selectors';
 import type { OccurrenceId, TimetableItem, TimetableItemId } from 'reducers/osrdconf/types';
-import { updateSelectedTrainId } from 'reducers/simulationResults';
+import { updateSelectedTrainId, updateTrainIdUsedForProjection } from 'reducers/simulationResults';
 import { getSelectedTrainId } from 'reducers/simulationResults/selectors';
 import { useAppDispatch } from 'store';
 import { isIndexedOccurrenceId, extractExceptionIdFromOccurrenceId } from 'utils/trainId';
@@ -46,6 +46,10 @@ const useOccurrenceActions = ({
 
   const selectOccurrence = useCallback((occurrenceId: OccurrenceId) => {
     dispatch(updateSelectedTrainId(occurrenceId));
+  }, []);
+
+  const selectOccurrenceForProjection = useCallback((occurrenceId: OccurrenceId) => {
+    dispatch(updateTrainIdUsedForProjection(occurrenceId));
   }, []);
 
   // We build a new timetable item to edit with the current paced train modified with
@@ -218,6 +222,7 @@ const useOccurrenceActions = ({
 
   return {
     selectOccurrence,
+    selectOccurrenceForProjection,
     editOccurrence,
     updateOccurrenceStatus,
     resetOccurrenceExceptions,

--- a/front/src/modules/timetableItem/components/Timetable/Timetable.tsx
+++ b/front/src/modules/timetableItem/components/Timetable/Timetable.tsx
@@ -190,9 +190,7 @@ const Timetable = ({
                   selectedTrainId={selectedTrainId}
                   upsertTimetableItems={upsertTimetableItems}
                   removePacedTrains={removeAndUnselectTrains}
-                  isProjectionPathUsed={
-                    infra.status === 'READY' && trainIdUsedForProjection === timetableItem.id
-                  }
+                  infraIsCached={infra.status === 'READY'}
                   subCategories={subCategories}
                 />
               )}

--- a/front/src/modules/timetableItem/helpers/pacedTrain.ts
+++ b/front/src/modules/timetableItem/helpers/pacedTrain.ts
@@ -1,12 +1,14 @@
 import dayjs from 'dayjs';
 
 import type { PacedTrain, PacedTrainException } from 'common/api/osrdEditoastApi';
-import type { OccurrenceId } from 'reducers/osrdconf/types';
+import type { OccurrenceId, TimetableItem, TimetableItemId } from 'reducers/osrdconf/types';
 import type { Duration } from 'utils/duration';
 import {
   extractExceptionIdFromOccurrenceId,
   extractOccurrenceIndexFromOccurrenceId,
+  extractPacedTrainIdFromOccurrenceId,
   isIndexedOccurrenceId,
+  isPacedTrainResponseWithPacedTrainId,
 } from 'utils/trainId';
 
 import type { ExceptionChangeGroups, PacedTrainWithDetails } from '../components/Timetable/types';
@@ -128,4 +130,24 @@ export const getOccurrencesWorstStatus = ({
     }
   }
   return className;
+};
+
+export const getExceptionFromOccurrenceId = (
+  timetableItemsById: Map<TimetableItemId, TimetableItem>,
+  occurrenceId: OccurrenceId
+) => {
+  const pacedTrainId = extractPacedTrainIdFromOccurrenceId(occurrenceId);
+  const pacedTrain = timetableItemsById.get(pacedTrainId);
+  if (!pacedTrain || !isPacedTrainResponseWithPacedTrainId(pacedTrain))
+    throw new Error(`No paced train found for id ${pacedTrainId}`);
+
+  let exception: PacedTrainException | undefined;
+  if (isIndexedOccurrenceId(occurrenceId)) {
+    const index = extractOccurrenceIndexFromOccurrenceId(occurrenceId);
+    exception = pacedTrain.exceptions.find((e) => e.occurrence_index === index);
+  } else {
+    const key = extractExceptionIdFromOccurrenceId(occurrenceId);
+    exception = pacedTrain.exceptions.find((e) => e.key === key);
+  }
+  return exception;
 };

--- a/front/src/reducers/simulationResults/index.ts
+++ b/front/src/reducers/simulationResults/index.ts
@@ -1,7 +1,7 @@
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 import type { Draft } from 'immer';
 
-import type { TimetableItemId, TrainId } from 'reducers/osrdconf/types';
+import type { OccurrenceId, PacedTrainId, TrainId, TrainScheduleId } from 'reducers/osrdconf/types';
 import type { ProjectionType, SimulationResultsState } from 'reducers/simulationResults/types';
 
 export const simulationResultsInitialState: SimulationResultsState = {
@@ -23,7 +23,7 @@ export const simulationResultsSlice = createSlice({
     },
     updateTrainIdUsedForProjection(
       state: Draft<SimulationResultsState>,
-      action: PayloadAction<TimetableItemId | undefined>
+      action: PayloadAction<TrainScheduleId | PacedTrainId | OccurrenceId | undefined>
     ) {
       state.trainIdUsedForProjection = action.payload;
     },

--- a/front/src/reducers/simulationResults/types.ts
+++ b/front/src/reducers/simulationResults/types.ts
@@ -1,6 +1,6 @@
 import type { ScaleTime, ScaleLinear } from 'd3-scale';
 
-import type { TimetableItemId, TrainId } from 'reducers/osrdconf/types';
+import type { OccurrenceId, PacedTrainId, TrainId, TrainScheduleId } from 'reducers/osrdconf/types';
 
 type SimulationD3Scale = ScaleTime<number, number> | ScaleLinear<number, number>;
 
@@ -33,6 +33,6 @@ export type ProjectionType = 'trackProjection' | 'operationalPointProjection';
 export interface SimulationResultsState {
   chart?: Chart;
   selectedTrainId?: TrainId;
-  trainIdUsedForProjection?: TimetableItemId;
+  trainIdUsedForProjection?: TrainScheduleId | PacedTrainId | OccurrenceId;
   projectionType: ProjectionType;
 }

--- a/front/src/styles/scss/applications/operationalStudies/_pacedTrain.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_pacedTrain.scss
@@ -66,6 +66,23 @@
     z-index: 3;
   }
 
+  @mixin projected-item-icon {
+    height: 20px;
+    width: 20px;
+    margin-right: 7.5px;
+    background-color: var(--info30);
+    border-radius: 4px;
+    position: relative;
+    flex-shrink: 0;
+
+    svg {
+      position: absolute;
+      top: 0;
+      left: 0;
+      transform: translate(2px, 2px);
+    }
+  }
+
   .paced-train-main-info {
     display: flex;
     margin-left: 10.5px;
@@ -78,18 +95,10 @@
     overflow: hidden;
 
     .train-projected {
-      height: 20px;
-      width: 20px;
-      margin-right: 7.5px;
-      background-color: var(--info30);
-      border-radius: 4px;
-      position: relative;
-      flex-shrink: 0;
-      svg {
-        position: absolute;
-        top: 0;
-        left: 0;
-        transform: translate(2px, 2px);
+      @include projected-item-icon;
+
+      &.grayed {
+        background-color: var(--grey40);
       }
     }
 
@@ -220,8 +229,13 @@
 
           .indicator-title {
             display: flex;
+            align-items: center;
             position: relative;
             line-height: 24px;
+
+            .occurrence-projected {
+              @include projected-item-icon;
+            }
 
             .occurrence-indicator {
               position: relative;

--- a/front/src/utils/trainId.ts
+++ b/front/src/utils/trainId.ts
@@ -1,5 +1,6 @@
 import { isEmpty } from 'lodash';
 
+import type { PacedTrainException } from 'common/api/osrdEditoastApi';
 import type {
   TimetableItemWithDetails,
   PacedTrainWithDetails,
@@ -173,6 +174,18 @@ export const formatPacedTrainIdToExceptionId = (
     exceptionId,
   });
 };
+
+/**
+ * Given a paced train id with a PacedTrainId format (used across the front),
+ * returns the occurrence id with an OccurrenceId format (used across the front).
+ */
+export const formatPacedTrainIdToOccurrenceId = (
+  pacedTrainId: PacedTrainId,
+  exception: PacedTrainException
+): OccurrenceId =>
+  exception.occurrence_index
+    ? formatPacedTrainIdToIndexedOccurrenceId(pacedTrainId, exception.occurrence_index)
+    : formatPacedTrainIdToExceptionId(pacedTrainId, exception.key);
 
 /**
  * Given a occurrence id with an OccurrenceId format (used across the front),


### PR DESCRIPTION
closes #11476

Rework of https://github.com/OpenRailAssociation/osrd/pull/12222 (first part merged in https://github.com/OpenRailAssociation/osrd/pull/12882)


## ACs
- [ ] You can project onto an occurrence (see mockup for the icon to indicate that you are projecting onto a mission/occurrence):
  - [ ] If you project onto the model train or onto an occurrence that has the same path or schedule as the model train: blue projection icon on the mission's parent map (folded AND unfolded mode). Nothing on the occurrence
  - [ ] If we project onto an occurrence that does not have the same path or schedule as the model train: gray projection icon on the model train (folded AND unfolded mode) + blue projection icon on the occurrence onto which we are projecting
- [ ] Nothing special happens if you deactivate the occurrence used for the projection (it does not change the space time chart, except the current occurrence is hidden)

## Screenshots
<img width="406" height="450" alt="image" src="https://github.com/user-attachments/assets/9d9256dc-6ca4-472e-a951-6f50431158b9" />
