### PR TITLE
front: fix padding below the navbar (editor and ManageTimetableItemModal)

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
@@ -149,21 +149,21 @@ const ScenarioContent = ({
 
   return (
     <EditedElementContainerProvider>
+      {displayTimetableItemManagement !== MANAGE_TIMETABLE_ITEM_TYPES.none && (
+        <ManageTimetableItemModal
+          displayTimetableItemManagement={displayTimetableItemManagement}
+          setDisplayTimetableItemManagement={setDisplayTimetableItemManagement}
+          upsertTimetableItems={upsertTimetableItemsWithNge}
+          removeTimetableItems={removeTimetableItemsWithNge}
+          infraState={infra.state}
+          timetableItemToEditData={timetableItemToEditData}
+          setTimetableItemToEditData={setTimetableItemToEditData}
+          scenario={scenario}
+          setCollapsedTimetableEdit={() => setCollapsedTimetableEdit(!collapsedTimetableEdit)}
+          collapsedTimetableEdit={collapsedTimetableEdit}
+        />
+      )}
       <main className="mastcontainer mastcontainer-no-mastnav scenario scenario-content-v2">
-        {displayTimetableItemManagement !== MANAGE_TIMETABLE_ITEM_TYPES.none && (
-          <ManageTimetableItemModal
-            displayTimetableItemManagement={displayTimetableItemManagement}
-            setDisplayTimetableItemManagement={setDisplayTimetableItemManagement}
-            upsertTimetableItems={upsertTimetableItemsWithNge}
-            removeTimetableItems={removeTimetableItemsWithNge}
-            infraState={infra.state}
-            timetableItemToEditData={timetableItemToEditData}
-            setTimetableItemToEditData={setTimetableItemToEditData}
-            scenario={scenario}
-            setCollapsedTimetableEdit={() => setCollapsedTimetableEdit(!collapsedTimetableEdit)}
-            collapsedTimetableEdit={collapsedTimetableEdit}
-          />
-        )}
         <div
           data-testid="scenario-left-column"
           className="left-column"

--- a/front/src/styles/scss/applications/editor/_editor.scss
+++ b/front/src/styles/scss/applications/editor/_editor.scss
@@ -7,7 +7,7 @@
   $white: var(--white);
   $gray: var(--coolgray5);
 
-  padding-top: 60px; // Header height
+  padding-top: 40px; // Header height
 
   .layout {
     width: 100%;


### PR DESCRIPTION
closes #12699 

Before:
<img width="1674" height="966" alt="image" src="https://github.com/user-attachments/assets/b7a92331-a9b8-4063-a61e-09147551c675" />
<img width="1674" height="966" alt="image" src="https://github.com/user-attachments/assets/8c61f993-315d-412b-a98c-290e5ba3e35f" />


After:
<img width="1674" height="966" alt="image" src="https://github.com/user-attachments/assets/64a5f432-3810-48c8-a61c-a8eb37edfdc3" />
<img width="1674" height="966" alt="image" src="https://github.com/user-attachments/assets/2850552f-7175-4024-9df8-447232b1317a" />
