### PR TITLE
github: skip osrd-ui-website workflow when missing secret

### DIFF
--- a/.github/workflows/osrd-ui-website.yml
+++ b/.github/workflows/osrd-ui-website.yml
@@ -81,3 +81,6 @@ jobs:
           linkchecker_enabled: false
           sticky_comment_enabled: false
           step_summary_enabled: true
+        env:
+          HAVE_SSH_KEY: ${{ secrets.UI_WEBSITE_SSH_KEY != '' }}
+        if: ${{ env.HAVE_PERSONAL_TOKEN == 'true' }}


### PR DESCRIPTION
When dependabot or an external contributor opens a pull request, the UI_WEBSITE_SSH_KEY secret will be unavailable. Instead of failing CI, skip the deploy step.

An env var is required to workaround GitHub limitations: https://github.com/github/docs/issues/6861

cc @mxmehl
