### PR TITLE
front: drop forceRefetch from rtk-query options

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/osrdToNge.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/osrdToNge.ts
@@ -664,7 +664,7 @@ export const loadNgeDto = async (
   const trainSchedulesPromise = dispatch(
     osrdEditoastApi.endpoints.getAllTimetableByIdTrainSchedules.initiate(
       { timetableId },
-      { forceRefetch: true, subscribe: false }
+      { subscribe: false }
     )
   );
   const trainSchedules = (await trainSchedulesPromise.unwrap())
@@ -677,7 +677,7 @@ export const loadNgeDto = async (
   const pacedTrainsPromise = dispatch(
     osrdEditoastApi.endpoints.getAllTimetableByIdPacedTrains.initiate(
       { timetableId },
-      { forceRefetch: true, subscribe: false }
+      { subscribe: false }
     )
   );
   const pacedTrains = (await pacedTrainsPromise.unwrap())

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/utils.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/utils.ts
@@ -172,7 +172,7 @@ export const getSavedMacroNodes = async (
           pageSize,
           page,
         },
-        { forceRefetch: true, subscribe: false }
+        { subscribe: false }
       )
     );
     // need to unsubscribe on get call to avoid cache issue

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -44,7 +44,7 @@ const osrdEditoastApi = generatedEditoastApi
                   pageSize,
                   page,
                 },
-                { forceRefetch: true, subscribe: false }
+                { subscribe: false }
               )
             );
             const { data } = await promise;
@@ -70,7 +70,7 @@ const osrdEditoastApi = generatedEditoastApi
                   pageSize,
                   page,
                 },
-                { forceRefetch: true, subscribe: false }
+                { subscribe: false }
               )
             );
             const { data } = await promise;
@@ -91,7 +91,7 @@ const osrdEditoastApi = generatedEditoastApi
                 {
                   id: extractEditoastIdFromTrainScheduleId(timetableItemId),
                 },
-                { forceRefetch: true, subscribe: false }
+                { subscribe: false }
               )
             ).unwrap();
             data = { ...trainSchedule, id: timetableItemId };
@@ -101,7 +101,7 @@ const osrdEditoastApi = generatedEditoastApi
                 {
                   id: extractEditoastIdFromPacedTrainId(timetableItemId),
                 },
-                { forceRefetch: true, subscribe: false }
+                { subscribe: false }
               )
             ).unwrap();
             data = { ...pacedTrain, id: timetableItemId };
@@ -126,7 +126,7 @@ const osrdEditoastApi = generatedEditoastApi
                   id: extractEditoastIdFromTrainScheduleId(trainId),
                   infraId,
                 },
-                { forceRefetch: true, subscribe: false }
+                { subscribe: false }
               )
             ).unwrap();
           } else {
@@ -138,7 +138,7 @@ const osrdEditoastApi = generatedEditoastApi
                   infraId,
                   exceptionKey,
                 },
-                { forceRefetch: true, subscribe: false }
+                { subscribe: false }
               )
             ).unwrap();
           }
@@ -166,7 +166,7 @@ const osrdEditoastApi = generatedEditoastApi
                   infraId,
                   electricalProfileSetId,
                 },
-                { forceRefetch: true, subscribe: false }
+                { subscribe: false }
               )
             ).unwrap();
           } else {
@@ -179,7 +179,7 @@ const osrdEditoastApi = generatedEditoastApi
                   electricalProfileSetId,
                   exceptionKey,
                 },
-                { forceRefetch: true, subscribe: false }
+                { subscribe: false }
               )
             ).unwrap();
           }
@@ -208,7 +208,7 @@ const osrdEditoastApi = generatedEditoastApi
                     operational_point_references: batch,
                   },
                 },
-                { forceRefetch: true, subscribe: false }
+                { subscribe: false }
               )
             );
 

--- a/front/src/reducers/editor/thunkActions.ts
+++ b/front/src/reducers/editor/thunkActions.ts
@@ -90,7 +90,7 @@ export function updateTotalsIssue(infraID: number | undefined) {
               pageSize: 1,
               page: 1,
             },
-            { subscribe: false, forceRefetch: true }
+            { subscribe: false }
           )
         );
         total = totalResp.data?.count || 0;
@@ -107,7 +107,7 @@ export function updateTotalsIssue(infraID: number | undefined) {
                 pageSize: 1,
                 page: 1,
               },
-              { subscribe: false, forceRefetch: true }
+              { subscribe: false }
             )
           );
           filterTotal = filterResp.data?.count || 0;


### PR DESCRIPTION
We have no need for forcing a refetch, we can use data from the cache just fine. From the [rtk-query docs][1], forceRefetch is used when a single cache key is used for different query args and the results are merged back together, but we never do this.

[1]: https://redux-toolkit.js.org/rtk-query/api/createApi#forcerefetch