### PR TITLE
github: add eslint-plugin-storybook to storybook dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,6 +60,7 @@ updates:
         patterns:
           - "storybook"
           - "@storybook/*"
+          - "eslint-plugin-storybook"
       turf:
         patterns:
           - "@turf/*"


### PR DESCRIPTION
eslint-plugin-storybook lives in the storybook monorepo and is published in lockstep with other storybook packages: https://github.com/storybookjs/storybook/tree/HEAD/code/lib/eslint-plugin