### PR TITLE
Add token when running npm ci to avoid 429 error

### DIFF
--- a/.github/scripts/bake-metadata.py
+++ b/.github/scripts/bake-metadata.py
@@ -307,7 +307,7 @@ def generate_bake_file(event, targets):
         bake_targets[f"base-{target.name}"] = target_manifest
 
     version = event.version_string()
-    bake_targets["base"] = {"args": {"OSRD_GIT_DESCRIBE": version}}
+    bake_targets["base"] = {"args": {"OSRD_GIT_DESCRIBE": version}, "secret": ["id=NPM_TOKEN"]}
     return {"target": bake_targets}
 
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,8 @@ jobs:
       # - `httpReadSeeker: failed open:`
       #   full message: `ERROR: failed to solve: DeadlineExceeded: failed to compute cache key: failed to copy: httpReadSeeker: failed open: no active session for XXXXX: context deadline exceeded`
       - name: Build and push
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/osrd-ui-publish.yml
+++ b/.github/workflows/osrd-ui-publish.yml
@@ -32,9 +32,12 @@ jobs:
           key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}
 
       - name: Publish
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           TAG=${GITHUB_REF/refs\/tags\//}
           VERSION=${TAG/ui-v/}
           cd front
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
           npm ci
           npx lerna publish ${VERSION} --yes --no-push --no-git-tag-version --private

--- a/.github/workflows/osrd-ui-website.yml
+++ b/.github/workflows/osrd-ui-website.yml
@@ -46,8 +46,11 @@ jobs:
           key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}
 
       - name: Build
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           cd front
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
           npm ci
           npm run build --workspaces --if-present
 

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -74,6 +74,9 @@ ENV VITE_OSRD_GIT_DESCRIBE=${OSRD_GIT_DESCRIBE}
 
 COPY --from=front_src . /app
 
+# Use a readonly token to avoid 429 too many requests from npm
+RUN echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
+
 # If SKIP_FRONT is set to 1, skip the front build
 RUN --mount=type=cache,target=/root/.npm \
     if [ "$SKIP_FRONT" = "1" ]; then exit 0; else npm ci; fi


### PR DESCRIPTION
The ci fails regularly due to a rate limit on the npm side. The idea is to add a private token before executing `npm ci` in order to lift this limit.

1. Inject the token to the `.npmrc` file where needed.
2. For the build of the frontend (withing docker)
  - Add the npmrs in the Dockerfile
  - Inject the token using secret bake file

> [!NOTE]
> Here I'm injecting the secret for every images built. Ideally it should be only provide for the `gateway-front-build`.

Another solution would be to not touch the `bake-metadata.py` script and directly edit the hcl file like so: 

```diff
diff --git i/docker/docker-bake.hcl w/docker/docker-bake.hcl
index 6dca700577..0920f94a3d 100644
--- i/docker/docker-bake.hcl
+++ w/docker/docker-bake.hcl
@@ -116,6 +116,12 @@ target "gateway-front-build" {
   contexts = {
     front_src = "./front"
   }
+  secret = [
+    {
+      type ="env"
+      id = "NPM_TOKEN"
+    }
+  ]
 }
 
 target "base-gateway-front" {}
```