### PR TITLE
editoast: bump `axum-test` to 18.0.0 properly

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -1665,9 +1665,9 @@ dependencies = [
 
 [[package]]
 name = "expect-json"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e442be6e3db3f99c154b4e382b9455160339599e509cde07c1f9c100f3be0e86"
+checksum = "5ff2d5945f24cc4a770c57550475369efc3d72a493c9ac4305b440614d9c79b4"
 dependencies = [
  "chrono",
  "email_address",
@@ -1675,16 +1675,16 @@ dependencies = [
  "num",
  "serde",
  "serde_json",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "typetag",
  "uuid",
 ]
 
 [[package]]
 name = "expect-json-macros"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900c6fb6beb839a18150a3ec84fe2f5fc198abeb8d126b5f0476e2ebd82d030d"
+checksum = "586c187b7f4cb45daf40082c647dd9a09681da54dfd58460f4c28ba0aa86c4bd"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -139,7 +139,7 @@ axum = { version = "0.8.4", default-features = false, features = [
 axum-extra = { version = "0.10.1", default-features = false, features = [
   "typed-header",
 ] }
-axum-test = { version = "17.3.0", default-features = false }
+axum-test = { version = "18.0.0", default-features = false }
 axum-tracing-opentelemetry = { version = "0.29.0", default-features = false, features = [
   "tracing_level_info",
 ] }


### PR DESCRIPTION
I don't know why dependabot didn't in
https://github.com/OpenRailAssociation/osrd/pull/12954.

(Not really... dependable, is it? *badum tss*)

Signed-off-by: Leo Valais <leo.valais97@gmail.com>
