### PR TITLE
editoast: hopefully reduce startup latency

### DIFF
--- a/editoast/core_client/src/lib.rs
+++ b/editoast/core_client/src/lib.rs
@@ -33,6 +33,7 @@ pub enum CoreClient {
 }
 
 impl CoreClient {
+    #[tracing::instrument(skip_all, err)]
     pub async fn new_mq(options: mq_client::Options) -> Result<Self, Error> {
         let client = RabbitMQClient::new(options)
             .await

--- a/editoast/core_client/src/mq_client.rs
+++ b/editoast/core_client/src/mq_client.rs
@@ -27,6 +27,7 @@ use tokio::sync::oneshot;
 use tokio::task;
 use tokio::time::Duration;
 use tokio::time::timeout;
+use tracing::Instrument;
 use url::Url;
 use uuid::Uuid;
 
@@ -197,6 +198,7 @@ pub struct MQResponse {
 const SINGLE_WORKER_KEY: &str = "all";
 
 impl RabbitMQClient {
+    #[tracing::instrument(skip_all, err, level = "info", name = "RabbitMQClient::new")]
     pub async fn new(options: Options) -> Result<Self, MqClientError> {
         let hostname = hostname::get()
             .map(|name| name.to_string_lossy().into_owned())
@@ -204,24 +206,36 @@ impl RabbitMQClient {
 
         let conn = Arc::new(RwLock::new(None));
 
+        // We want to be signalled when the first connection is established to avoid wasting
+        // retries and introduce unnecessary latency.
+        let (tx, rx) = tokio::sync::oneshot::channel();
         tokio::spawn(Self::connection_loop(
             options.uri,
             hostname.clone(),
             conn.clone(),
+            tx,
         ));
+        rx.instrument(tracing::info_span!("waiting for first connection signal"))
+            .await
+            .ok();
 
         // We should ensure that the connection is established at least once before creating the pool
         // since deadpool will try to create resources upfront
-        const MAX_RETRIES: usize = 10;
-        const RETRY_DELAY: Duration = Duration::from_secs(1);
+        const MAX_RETRIES: usize = 11;
+        const MAX_RETRY_DELAY: Duration = Duration::from_secs(1); // max reached after 5th attempt
+        let mut retry_delay = Duration::from_millis(25); // fails after 6800ms, ie. up to three reconnections of 2s
 
         let mut retries = 0;
         while retries < MAX_RETRIES {
-            if Self::connection_ok(&conn).await {
+            if Self::connection_ok(&conn)
+                .instrument(tracing::info_span!("RabbitMQClient::connection_ok")) // not instrumented at function-level to avoid spamming traces in connection_loop
+                .await
+            {
                 break;
             }
-            tokio::time::sleep(RETRY_DELAY).await;
+            tokio::time::sleep(retry_delay.min(MAX_RETRY_DELAY)).await;
             retries += 1;
+            retry_delay *= 2;
         }
 
         if retries == MAX_RETRIES {
@@ -274,7 +288,9 @@ impl RabbitMQClient {
         uri: Url,
         hostname: String,
         connection: Arc<RwLock<Option<Connection>>>,
+        initial_connection_ok_signal: tokio::sync::oneshot::Sender<()>,
     ) {
+        let mut tx = Some(initial_connection_ok_signal);
         loop {
             if Self::connection_ok(&connection).await {
                 tokio::time::sleep(Duration::from_secs(2)).await;
@@ -293,6 +309,9 @@ impl RabbitMQClient {
             match new_connection {
                 Ok(new_connection) => {
                     *connection.write().await = Some(new_connection);
+                    if let Some(tx) = tx.take() {
+                        tx.send(()).ok();
+                    }
                     tracing::info!("Reconnected to RabbitMQ");
                 }
                 Err(e) => {

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -726,6 +726,7 @@ pub struct OsrdyneConfig {
     pub core: CoreConfig,
 }
 
+#[derive(Clone)]
 pub struct OpenfgaConfig {
     pub url: Url,
     pub store: String,
@@ -798,80 +799,101 @@ impl FromRef<AppState> for Arc<CoreClient> {
 }
 
 impl AppState {
+    #[tracing::instrument(skip_all, level = "info", err, name = "AppState initialization")]
     async fn init(config: ServerConfig) -> anyhow::Result<Self> {
-        info!("Building application state...");
-
-        // Config database
-        let valkey = ValkeyClient::new(config.valkey_config.clone())?.into();
-
-        // Create database pool
-        let db_pool = {
-            let PostgresConfig {
+        #[tracing::instrument(skip_all, level = "info", err, name = "PostgreSQL connection")]
+        async fn connect_db(
+            PostgresConfig {
                 database_url,
                 pool_size,
-            } = config.postgres_config.clone();
+            }: PostgresConfig,
+        ) -> anyhow::Result<Arc<DbConnectionPoolV2>> {
             let pool = DbConnectionPoolV2::try_initialize(database_url, pool_size).await?;
-            Arc::new(pool)
-        };
+            Ok(Arc::new(pool))
+        }
+        let db_pool_fut =
+            tokio::spawn(connect_db(config.postgres_config.clone()).in_current_span());
 
-        // Setup infra cache map
-        let infra_caches = DashMap::<i64, InfraCache>::default().into();
-
-        // Static list of configured speed-limit tag ids
-        let speed_limit_tag_ids = Arc::new(SpeedLimitTagIds::load());
-
-        // Build Core client
-        let core_client = {
-            let CoreConfig {
+        #[tracing::instrument(skip_all, level = "info", err, name = "Core client connection")]
+        async fn connect_core_client(
+            CoreConfig {
                 timeout,
                 single_worker,
                 num_channels,
                 worker_pool_id,
-            } = config.osrdyne_config.core.clone();
+            }: CoreConfig,
+            mq_url: Url,
+        ) -> anyhow::Result<Arc<CoreClient>> {
             let options = mq_client::Options {
-                uri: config.osrdyne_config.mq_url.clone(),
+                uri: mq_url,
                 worker_pool_identifier: worker_pool_id,
                 timeout: timeout.num_seconds() as u64,
                 single_worker,
                 num_channels,
             };
-            CoreClient::new_mq(options).await?.into()
-        };
+            let client = CoreClient::new_mq(options).await?;
+            Ok(Arc::new(client))
+        }
+        let core_client_fut = tokio::spawn(
+            connect_core_client(
+                config.osrdyne_config.core.clone(),
+                config.osrdyne_config.mq_url.clone(),
+            )
+            .in_current_span(),
+        );
 
+        #[tracing::instrument(skip_all, level = "info", err, name = "OpenFGA connection")]
+        async fn connect_openfga(
+            openfga_config: OpenfgaConfig,
+            enable_authorization: bool,
+        ) -> anyhow::Result<fga::Client> {
+            let mut openfga = {
+                tracing::info!(url = %openfga_config.url, "connecting to OpenFGA");
+                match fga::Client::try_with_store(
+                    openfga_config.store.clone(),
+                    openfga_config.try_as_settings()?,
+                )
+                .await
+                {
+                    Err(fga::client::InitializationError::NotFound(store)) => {
+                        tracing::info!(store, "store not found, creating it");
+                        fga::Client::try_new_store(store, openfga_config.try_as_settings()?).await?
+                    }
+                    result => result?,
+                }
+            };
+            tracing::info!(url = %openfga_config.url, "connected to OpenFGA");
+            if enable_authorization {
+                ::authz::ensure_latest_authorization_model(&mut openfga).await?;
+            }
+            Ok(openfga)
+        }
+        let openfga_fut = tokio::spawn(
+            connect_openfga(config.openfga_config.clone(), config.enable_authorization)
+                .in_current_span(),
+        );
+
+        // Synchronous operations
+        let infra_caches = DashMap::<i64, InfraCache>::default().into();
+        let speed_limit_tag_ids = Arc::new(SpeedLimitTagIds::load());
+        let valkey = ValkeyClient::new(config.valkey_config.clone())?.into();
         let osrdyne_client = Arc::new(OsrdyneClient::new(
             config.osrdyne_config.osrdyne_api_url.clone(),
         ));
 
-        let mut openfga = {
-            tracing::info!(url = %config.openfga_config.url, "connecting to OpenFGA");
-            match fga::Client::try_with_store(
-                config.openfga_config.store.clone(),
-                config.openfga_config.try_as_settings()?,
-            )
-            .await
-            {
-                Err(fga::client::InitializationError::NotFound(store)) => {
-                    tracing::info!(store, "store not found, creating it");
-                    fga::Client::try_new_store(store, config.openfga_config.try_as_settings()?)
-                        .await?
-                }
-                result => result?,
-            }
-        };
-        tracing::info!(url = %config.openfga_config.url, "connected to OpenFGA");
-        if config.enable_authorization {
-            ::authz::ensure_latest_authorization_model(&mut openfga).await?;
-        }
-
-        let auth_driver = PgAuthDriver::new(db_pool.clone());
+        let (db_pool, core_client, openfga) = tokio::try_join!(
+            async { db_pool_fut.await? },
+            async { core_client_fut.await? },
+            async { openfga_fut.await? }
+        )?;
 
         Ok(Self {
+            regulator: Regulator::new(openfga, PgAuthDriver::new(db_pool.clone())),
             valkey,
             db_pool,
             infra_caches,
             core_client,
             osrdyne_client,
-            regulator: Regulator::new(openfga, auth_driver),
             map_layers: Arc::new(MapLayers::default()),
             speed_limit_tag_ids,
             health_check_timeout: config.health_check_timeout,
@@ -881,27 +903,13 @@ impl AppState {
 }
 
 impl Server {
+    #[tracing::instrument(skip_all, err, level = "info", name = "server initialization")]
     pub async fn new(config: ServerConfig) -> anyhow::Result<Self> {
         info!("Building server...");
-        let router = tracing::debug_span!("router initialization").in_scope(|| {
-            let now = std::time::Instant::now();
-            let router = service_router().router;
-            let elapsed = now.elapsed();
-            tracing::debug!(time_ms = elapsed.as_millis(), "router initialized");
-            router
-        });
-        let app_state = tracing::info_span!("AppState initialization")
-            .in_scope(|| {
-                async move {
-                    let now = std::time::Instant::now();
-                    let app_state = AppState::init(config).await?;
-                    let elapsed = now.elapsed();
-                    tracing::debug!(time_ms = elapsed.as_millis(), "app state initialized");
-                    Ok::<_, anyhow::Error>(app_state)
-                }
-                .in_current_span()
-            })
-            .await?;
+        let app_state_fut = tokio::spawn(AppState::init(config).in_current_span());
+        let router =
+            tracing::debug_span!("router initialization").in_scope(|| service_router().router);
+        let app_state = app_state_fut.await??;
 
         // Custom Bytes and String extractor configuration
         let request_payload_limit = RequestBodyLimitLayer::new(250 * 1024 * 1024); // 250MiB


### PR DESCRIPTION
# Industry-grade benchmarks

Environment: my machine :tm:
Sample size: 1
Control: trust me bro

Before: ~1sec
After: ~25ms
Conclusion:
<img width="128" height="128" alt="image" src="https://github.com/user-attachments/assets/7736f9c9-36e4-4163-90fa-5722244cbb4e" />

> [!CAUTION]
> We need to check that this was a widespread problem, especially in prod. I've only tested on my machine, but it's consistent.

# Traces
## Before
<img width="1744" height="1299" alt="Capture d’écran 2025-08-28 at 15 34 10" src="https://github.com/user-attachments/assets/ecacf323-1e19-4bbf-9b11-f2fca72e75ce" />

## After
<img width="1761" height="1299" alt="Capture d’écran 2025-08-28 at 15 30 00" src="https://github.com/user-attachments/assets/353d6bc1-d78a-46ee-a3bf-a2de42ed9a08" />

## For real
In this PR the router initialization (before the AppState init) is done concurrently, but I've changed that after making the screenshot, so.... 🙃 


<details open id="prdesc">

- 5a701eb19 *editoast: core_client: fix initial connection always triggering a retry*
    ```md
    When creating a new client, we start the connection loop, itself calling
    connection_ok.  The latter fails the first time since there's no
    connection open, triggering the reconnection routing to acquire the
    first connection.  However, in the meantime, the `new` function also
    probes `connection_ok`, which isn't ready yet, so we retry after one
    second, delaying the readiness of editoast.
    
    Here we just send a signal the first time the connection has been
    acquired so we don't waste the first retry and pay for the delay.
    
    While experimenting, I've implemented the exponential delay logic, which
    can't hurt so I left it ¯\_(ツ)_/¯
    ```
- e11049bbe *editoast: concurrent server initialization and improve instrumentation*
    ```md
    * Spawn asynchronous tasks before doing CPU work.
    * Everything's instrumented.
    * Single await point.
    ```

</details>