### PR TITLE
Fix flaky e2e test

### DIFF
--- a/front/tests/pages/stdcm/consist-section.ts
+++ b/front/tests/pages/stdcm/consist-section.ts
@@ -59,8 +59,7 @@ class ConsistSection {
       if (!selectedValue) return;
 
       await dropdownField.fill(selectedValue);
-      await dropdownField.press('ArrowDown');
-      await dropdownField.press('Enter');
+      await this.page.getByTestId('traction-engine-item').click();
       await dropdownField.blur();
       await expect(dropdownField).toHaveValue(selectedValue);
 


### PR DESCRIPTION
Running locally the the dropdown does not have time to display suggestion before pressing ArrowDown. Which make the following tests fail.