### PR TITLE
front: unset selected and projected train ids when deleting the corresponding train

### DIFF
--- a/editoast/src/models/paced_train.rs
+++ b/editoast/src/models/paced_train.rs
@@ -208,12 +208,12 @@ impl PacedTrain {
             }
         }
         // Remove disabled occurrences.
-        let occurences = base_occurrences
+        let occurrences = base_occurrences
             .into_iter()
             .zip(to_remove)
             .filter_map(|(occ, disabled)| if disabled { None } else { Some(occ) });
 
-        occurences
+        occurrences
             .into_iter()
             .chain(self.get_created_occurrences_exceptions())
             .sorted_by_key(|(_, ts)| ts.start_time)

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/ngeToOsrd.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/ngeToOsrd.ts
@@ -10,8 +10,8 @@ import {
 import {
   createPacedTrain,
   createTrainSchedule,
-  deletePacedTrain,
-  deleteTrainSchedule,
+  deletePacedTrains,
+  deleteTrainSchedules,
   fetchTimetableItem,
   storePacedTrain,
   storeTrainSchedule,
@@ -465,8 +465,8 @@ const deleteTimetableItemById = async (
   dispatch: AppDispatch,
   addDeletedTimetableItemIds: (timetableItemIds: TimetableItemId[]) => void
 ) => {
-  if (isPacedTrainId(timetableItemId)) await deletePacedTrain(dispatch, timetableItemId);
-  else await deleteTrainSchedule(dispatch, timetableItemId);
+  if (isPacedTrainId(timetableItemId)) await deletePacedTrains(dispatch, [timetableItemId]);
+  else await deleteTrainSchedules(dispatch, [timetableItemId]);
 
   addDeletedTimetableItemIds([timetableItemId]);
 };

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/PacedTrainItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/PacedTrainItem.tsx
@@ -22,7 +22,10 @@ import { ModalContext } from 'common/BootstrapSNCF/ModalSNCF/ModalProvider';
 import { useRollingStockContext } from 'common/RollingStockContext';
 import isMainCategory from 'modules/rollingStock/helpers/category';
 import { getOccurrencesWorstStatus } from 'modules/timetableItem/helpers/pacedTrain';
-import { storePacedTrain } from 'modules/timetableItem/helpers/updateTimetableItemHelpers';
+import {
+  deletePacedTrains,
+  storePacedTrain,
+} from 'modules/timetableItem/helpers/updateTimetableItemHelpers';
 import type { PacedTrainWithDetails } from 'modules/timetableItem/types';
 import { setFailure, setSuccess } from 'reducers/main';
 import { getOperationalStudiesTimetableID } from 'reducers/osrdconf/operationalStudiesConf/selectors';
@@ -34,11 +37,7 @@ import type {
   TrainId,
   OccurrenceId,
 } from 'reducers/osrdconf/types';
-import {
-  updateProjectionType,
-  updateSelectedTrainId,
-  updateTrainIdUsedForProjection,
-} from 'reducers/simulationResults';
+import { updateProjectionType, updateTrainIdUsedForProjection } from 'reducers/simulationResults';
 import { getTrainIdUsedForProjection } from 'reducers/simulationResults/selectors';
 import { useAppDispatch } from 'store';
 import { addDurationToDate, Duration } from 'utils/duration';
@@ -133,25 +132,15 @@ const PacedTrainItem = ({
 
   const [postPacedTrain] = osrdEditoastApi.endpoints.postTimetableByIdPacedTrains.useMutation();
   const [getPacedTrainById] = osrdEditoastApi.endpoints.getPacedTrainById.useLazyQuery();
-  const [deletePacedTrains] = osrdEditoastApi.endpoints.deletePacedTrain.useMutation();
 
   const selectPathProjection = async () => {
     dispatch(updateTrainIdUsedForProjection(pacedTrain.id));
     if (!summary?.isValid) dispatch(updateProjectionType('operationalPointProjection'));
   };
 
-  const deletePacedTrain = async (currentSelectedTrainId?: TrainId) => {
-    const hasOccurrenceSelected = selectedTrainId?.includes(pacedTrain.id);
-    if (hasOccurrenceSelected) {
-      // we need to set selectedTrainId to undefined, otherwise just after the delete,
-      // some unvalid rtk calls are dispatched (see rollingstock request in SimulationResults)
-      dispatch(updateSelectedTrainId(undefined));
-    }
-
+  const deletePacedTrain = async () => {
     try {
-      await deletePacedTrains({
-        body: { ids: [extractEditoastIdFromPacedTrainId(pacedTrain.id)] },
-      }).unwrap();
+      await deletePacedTrains(dispatch, [pacedTrain.id]);
       removePacedTrains([pacedTrain.id]);
       dispatch(
         setSuccess({
@@ -161,9 +150,6 @@ const PacedTrainItem = ({
       );
     } catch (e) {
       dispatch(setFailure(castErrorToFailure(e)));
-      if (hasOccurrenceSelected) {
-        dispatch(updateSelectedTrainId(currentSelectedTrainId));
-      }
     }
   };
 
@@ -352,7 +338,7 @@ const PacedTrainItem = ({
           deleteTimetableItem={async () => {
             openModal(
               <DeleteModal
-                handleDelete={async () => deletePacedTrain(selectedTrainId)}
+                handleDelete={async () => deletePacedTrain()}
                 selectedPacedTrainIds={[pacedTrain.id]}
                 selectedTrainScheduleIds={[]}
               />,

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TimetableBoardWrapper.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TimetableBoardWrapper.tsx
@@ -17,9 +17,12 @@ import { useScenarioContext } from 'applications/operationalStudies/hooks/useSce
 import BoardWrapper from 'applications/operationalStudies/views/Scenario/components/BoardWrapper';
 import RoundTripsModal from 'applications/operationalStudies/views/Scenario/components/RoundTrips/RoundTripsModal';
 import { MANAGE_TIMETABLE_ITEM_TYPES } from 'applications/operationalStudies/views/Scenario/consts';
-import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import DeleteModal from 'common/BootstrapSNCF/ModalSNCF/DeleteModal';
 import { ModalContext } from 'common/BootstrapSNCF/ModalSNCF/ModalProvider';
+import {
+  deletePacedTrains,
+  deleteTrainSchedules,
+} from 'modules/timetableItem/helpers/updateTimetableItemHelpers';
 import type { TimetableItemWithDetails } from 'modules/timetableItem/types';
 import { setFailure, setSuccess } from 'reducers/main';
 import type {
@@ -34,11 +37,7 @@ import { updateSelectedTrainId } from 'reducers/simulationResults';
 import { getSelectedTrainId } from 'reducers/simulationResults/selectors';
 import { useAppDispatch } from 'store';
 import { castErrorToFailure } from 'utils/error';
-import {
-  extractEditoastIdFromPacedTrainId,
-  extractEditoastIdFromTrainScheduleId,
-  isTrainScheduleId,
-} from 'utils/trainId';
+import { isTrainScheduleId } from 'utils/trainId';
 
 import Timetable from './Timetable';
 import useFilterTimetableItems from './useFilterTimetableItems';
@@ -77,9 +76,6 @@ const TimetableBoardWrapper = ({
   const dispatch = useAppDispatch();
 
   const selectedTrainId = useSelector(getSelectedTrainId);
-
-  const [deleteTrainSchedules] = osrdEditoastApi.endpoints.deleteTrainSchedule.useMutation();
-  const [deletePacedTrains] = osrdEditoastApi.endpoints.deletePacedTrain.useMutation();
 
   const { totalPacedTrainCount, totalTrainScheduleCount } = useMemo(
     () =>
@@ -205,25 +201,14 @@ const TimetableBoardWrapper = ({
       dispatch(updateSelectedTrainId(undefined));
     }
 
-    const editoastSelectedTrainScheduleIds = selectedTrainScheduleIds.map((id) =>
-      extractEditoastIdFromTrainScheduleId(id)
-    );
-    const editoastSelectedPacedTrainIds = selectedPacedTrainIds.map((id) =>
-      extractEditoastIdFromPacedTrainId(id)
-    );
-
     try {
       let deletingTrainSchedulesPromise;
       let deletingPacedTrainsPromise;
-      if (editoastSelectedTrainScheduleIds.length > 0) {
-        deletingTrainSchedulesPromise = deleteTrainSchedules({
-          body: { ids: editoastSelectedTrainScheduleIds },
-        }).unwrap();
+      if (selectedTrainScheduleIds.length > 0) {
+        deletingTrainSchedulesPromise = deleteTrainSchedules(dispatch, selectedTrainScheduleIds);
       }
-      if (editoastSelectedPacedTrainIds.length > 0) {
-        deletingPacedTrainsPromise = deletePacedTrains({
-          body: { ids: editoastSelectedPacedTrainIds },
-        }).unwrap();
+      if (selectedPacedTrainIds.length > 0) {
+        deletingPacedTrainsPromise = deletePacedTrains(dispatch, selectedPacedTrainIds);
       }
       await Promise.all([deletingTrainSchedulesPromise, deletingPacedTrainsPromise]);
 

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TrainScheduleItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TrainScheduleItem.tsx
@@ -11,6 +11,7 @@ import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import type { SubCategory, TrainSchedule } from 'common/api/osrdEditoastApi';
 import RollingStock2Img from 'modules/rollingStock/components/RollingStock2Img';
 import isMainCategory from 'modules/rollingStock/helpers/category';
+import { deleteTrainSchedules } from 'modules/timetableItem/helpers/updateTimetableItemHelpers';
 import type { TrainScheduleWithDetails } from 'modules/timetableItem/types';
 import { setFailure, setSuccess } from 'reducers/main';
 import type {
@@ -74,7 +75,6 @@ const TrainScheduleItem = ({
   const [postTrainSchedule] =
     osrdEditoastApi.endpoints.postTimetableByIdTrainSchedules.useMutation();
   const [getTrainSchedule] = osrdEditoastApi.endpoints.getTrainScheduleById.useLazyQuery();
-  const [deleteTrainSchedule] = osrdEditoastApi.endpoints.deleteTrainSchedule.useMutation();
 
   const { summary } = train;
 
@@ -83,16 +83,7 @@ const TrainScheduleItem = ({
   };
 
   const deleteTrain = async () => {
-    if (isSelected) {
-      // we need to set selectedTrainId to undefined, otherwise just after the delete,
-      // some unvalid rtk calls are dispatched (see rollingstock request in SimulationResults)
-      dispatch(updateSelectedTrainId(undefined));
-    }
-
-    deleteTrainSchedule({
-      body: { ids: [extractEditoastIdFromTrainScheduleId(train.id)] },
-    })
-      .unwrap()
+    deleteTrainSchedules(dispatch, [train.id])
       .then(() => {
         removeTrains([train.id]);
         dispatch(

--- a/front/src/modules/timetableItem/helpers/pacedTrain.ts
+++ b/front/src/modules/timetableItem/helpers/pacedTrain.ts
@@ -1,12 +1,19 @@
 import dayjs from 'dayjs';
 
 import type { PacedTrain, PacedTrainException } from 'common/api/osrdEditoastApi';
-import type { OccurrenceId, TimetableItem, TimetableItemId } from 'reducers/osrdconf/types';
-import type { Duration } from 'utils/duration';
+import type {
+  OccurrenceId,
+  PacedTrainId,
+  TimetableItem,
+  TimetableItemId,
+} from 'reducers/osrdconf/types';
+import { Duration } from 'utils/duration';
 import {
   extractExceptionIdFromOccurrenceId,
   extractOccurrenceIndexFromOccurrenceId,
   extractPacedTrainIdFromOccurrenceId,
+  formatPacedTrainIdToExceptionId,
+  formatPacedTrainIdToIndexedOccurrenceId,
   isIndexedOccurrenceId,
   isPacedTrainResponseWithPacedTrainId,
 } from 'utils/trainId';
@@ -150,4 +157,18 @@ export const getExceptionFromOccurrenceId = (
     exception = pacedTrain.exceptions.find((e) => e.key === key);
   }
   return exception;
+};
+
+export const getOcurrencesIds = (pacedTrain: PacedTrain, pacedTrainId: PacedTrainId) => {
+  const occurrencesIds: OccurrenceId[] = pacedTrain.exceptions
+    .filter((exception) => exception.occurrence_index === undefined) // Indexed exceptions follow the regular indexed occurrence id pattern
+    .map((exception) => formatPacedTrainIdToExceptionId(pacedTrainId, exception.key));
+  const indexedOccurencesCount = getOccurrencesNb({
+    timeWindow: Duration.parse(pacedTrain.paced.time_window),
+    interval: Duration.parse(pacedTrain.paced.interval),
+  });
+  for (let i = 0; i < indexedOccurencesCount; i += 1) {
+    occurrencesIds.push(formatPacedTrainIdToIndexedOccurrenceId(pacedTrainId, i));
+  }
+  return occurrencesIds;
 };

--- a/front/src/modules/timetableItem/helpers/updateTimetableItemHelpers.ts
+++ b/front/src/modules/timetableItem/helpers/updateTimetableItemHelpers.ts
@@ -7,6 +7,10 @@ import type {
   TrainScheduleId,
   TrainScheduleWithTrainId,
 } from 'reducers/osrdconf/types';
+import {
+  unsetTrainIdsMatching,
+  unsetTrainIdsMatchingMissingOccurencesOf,
+} from 'reducers/simulationResults';
 import type { AppDispatch } from 'store';
 import {
   extractEditoastIdFromPacedTrainId,
@@ -16,6 +20,8 @@ import {
   isPacedTrainId,
   isTrainScheduleId,
 } from 'utils/trainId';
+
+import { getOcurrencesIds } from './pacedTrain';
 
 export async function fetchTimetableItem(
   timetableItemId: TimetableItemId,
@@ -97,6 +103,7 @@ async function updatePacedTrain(dispatch: AppDispatch, id: PacedTrainId, pacedTr
 }
 
 export async function deleteTrainSchedules(dispatch: AppDispatch, ids: TrainScheduleId[]) {
+  ids.forEach((id) => dispatch(unsetTrainIdsMatching(id)));
   await dispatch(
     osrdEditoastApi.endpoints.deleteTrainSchedule.initiate({
       body: { ids: ids.map((id) => extractEditoastIdFromTrainScheduleId(id)) },
@@ -105,6 +112,7 @@ export async function deleteTrainSchedules(dispatch: AppDispatch, ids: TrainSche
 }
 
 export async function deletePacedTrains(dispatch: AppDispatch, ids: PacedTrainId[]) {
+  ids.forEach((id) => dispatch(unsetTrainIdsMatching(id)));
   await dispatch(
     osrdEditoastApi.endpoints.deletePacedTrain.initiate({
       body: { ids: ids.map((id) => extractEditoastIdFromPacedTrainId(id)) },
@@ -149,6 +157,12 @@ export async function storePacedTrain(
   removeTimetableItems: (timetableItems: TimetableItemId[]) => void
 ): Promise<PacedTrainWithPacedTrainId> {
   if (isPacedTrainId(timetableItemIdToUpdate)) {
+    dispatch(
+      unsetTrainIdsMatchingMissingOccurencesOf({
+        pacedTrainId: timetableItemIdToUpdate,
+        occurrencesPresent: getOcurrencesIds(pacedTrain, timetableItemIdToUpdate),
+      })
+    );
     await updatePacedTrain(dispatch, timetableItemIdToUpdate, pacedTrain);
     const updatedPacedTrain = {
       ...pacedTrain,

--- a/front/src/modules/timetableItem/helpers/updateTimetableItemHelpers.ts
+++ b/front/src/modules/timetableItem/helpers/updateTimetableItemHelpers.ts
@@ -96,18 +96,18 @@ async function updatePacedTrain(dispatch: AppDispatch, id: PacedTrainId, pacedTr
   ).unwrap();
 }
 
-export async function deleteTrainSchedule(dispatch: AppDispatch, id: TrainScheduleId) {
+export async function deleteTrainSchedules(dispatch: AppDispatch, ids: TrainScheduleId[]) {
   await dispatch(
     osrdEditoastApi.endpoints.deleteTrainSchedule.initiate({
-      body: { ids: [extractEditoastIdFromTrainScheduleId(id)] },
+      body: { ids: ids.map((id) => extractEditoastIdFromTrainScheduleId(id)) },
     })
   ).unwrap();
 }
 
-export async function deletePacedTrain(dispatch: AppDispatch, id: PacedTrainId) {
+export async function deletePacedTrains(dispatch: AppDispatch, ids: PacedTrainId[]) {
   await dispatch(
     osrdEditoastApi.endpoints.deletePacedTrain.initiate({
-      body: { ids: [extractEditoastIdFromPacedTrainId(id)] },
+      body: { ids: ids.map((id) => extractEditoastIdFromPacedTrainId(id)) },
     })
   ).unwrap();
 }
@@ -132,7 +132,7 @@ export async function storeTrainSchedule(
   }
 
   // Turn a PacedTrain into a TrainSchedule
-  await deletePacedTrain(dispatch, timetableItemIdToUpdate);
+  await deletePacedTrains(dispatch, [timetableItemIdToUpdate]);
   const newTrainSchedule = await createTrainSchedule(dispatch, timetableId, trainSchedule);
 
   removeTimetableItems([timetableItemIdToUpdate]);
@@ -160,7 +160,7 @@ export async function storePacedTrain(
   }
 
   // Turn a TrainSchedule into a PacedTrain
-  await deleteTrainSchedule(dispatch, timetableItemIdToUpdate);
+  await deleteTrainSchedules(dispatch, [timetableItemIdToUpdate]);
   const newPacedTrain = await createPacedTrain(dispatch, timetableId, pacedTrain);
 
   removeTimetableItems([timetableItemIdToUpdate]);

--- a/front/src/reducers/simulationResults/index.ts
+++ b/front/src/reducers/simulationResults/index.ts
@@ -3,6 +3,7 @@ import type { Draft } from 'immer';
 
 import type { OccurrenceId, PacedTrainId, TrainId, TrainScheduleId } from 'reducers/osrdconf/types';
 import type { ProjectionType, SimulationResultsState } from 'reducers/simulationResults/types';
+import { extractPacedTrainIdFromOccurrenceId, isOccurrenceId } from 'utils/trainId';
 
 export const simulationResultsInitialState: SimulationResultsState = {
   chart: undefined,
@@ -33,10 +34,56 @@ export const simulationResultsSlice = createSlice({
     ) {
       state.projectionType = action.payload;
     },
+    unsetTrainIdsMatching(
+      state: Draft<SimulationResultsState>,
+      action: PayloadAction<TrainScheduleId | PacedTrainId | OccurrenceId>
+    ) {
+      const idToUnset = action.payload;
+
+      const isIdMatchingOccurence = (
+        id: TrainScheduleId | OccurrenceId | PacedTrainId | undefined
+      ) => id && isOccurrenceId(id) && extractPacedTrainIdFromOccurrenceId(id) === idToUnset;
+
+      if (
+        state.trainIdUsedForProjection === idToUnset ||
+        isIdMatchingOccurence(state.trainIdUsedForProjection)
+      ) {
+        state.trainIdUsedForProjection = undefined;
+      }
+      if (state.selectedTrainId === idToUnset || isIdMatchingOccurence(state.selectedTrainId)) {
+        state.selectedTrainId = undefined;
+      }
+    },
+    unsetTrainIdsMatchingMissingOccurencesOf(
+      state: Draft<SimulationResultsState>,
+      action: PayloadAction<{ pacedTrainId: PacedTrainId; occurrencesPresent: OccurrenceId[] }>
+    ) {
+      const { pacedTrainId, occurrencesPresent } = action.payload;
+
+      const isIdMatchingMissingOccurence = (
+        id: TrainScheduleId | OccurrenceId | PacedTrainId | undefined
+      ) =>
+        id &&
+        isOccurrenceId(id) &&
+        extractPacedTrainIdFromOccurrenceId(id) === pacedTrainId &&
+        !occurrencesPresent.includes(id);
+
+      if (isIdMatchingMissingOccurence(state.trainIdUsedForProjection)) {
+        state.trainIdUsedForProjection = undefined;
+      }
+      if (isIdMatchingMissingOccurence(state.selectedTrainId)) {
+        state.selectedTrainId = undefined;
+      }
+    },
   },
 });
 
-export const { updateSelectedTrainId, updateTrainIdUsedForProjection, updateProjectionType } =
-  simulationResultsSlice.actions;
+export const {
+  updateSelectedTrainId,
+  updateTrainIdUsedForProjection,
+  updateProjectionType,
+  unsetTrainIdsMatching,
+  unsetTrainIdsMatchingMissingOccurencesOf,
+} = simulationResultsSlice.actions;
 
 export default simulationResultsSlice.reducer;


### PR DESCRIPTION
Close #11496

The linked issue was due to the projected train id never being unset, even when deleting the corresponding train. The bug only occurred with paced trains occurences (and not train schedules or whole paced trains) because this was the only case where we actually checked that the id existed (with an exception raised otherwise).

We now properly unset both selected and projected train ids in the timetabler helpers (via store reducers), and use them everywhere over direct api calls.

Also see second commit description :

> Add reducers to check whether the selected and projected train ids in the store
> match with a given scheduled or paced train id,
> an occurence of a given paced train id,
> or an occurence of a given paced train id not listed in a list of present ids.
> 
> These will be used to properly unset selected and projected train ids when
> deleting timetable items or occurences (possibly simply by changing paced train pacing parameters)
> without needing all components that perform such operations to consume the selected and projected train ids.
> 
> Ids were currently only unset in a few places but not others,
> causing both app crashes and unintended user experience.

(Ids not being unset also meant useAutoUpdateProjection was mostly not being able to run.)

One partially bugged behavior got dropped (paced train staying selected in the case they fail to be deleted due to an api error), we can add it again more cleanly if needed - but do we then want this behavior everywhere?

The current architecture is a proposition, if you would prefer a different one, don't hesitate to say so!