### PR TITLE
front: fix mm converted too early to m in csv export

### DIFF
--- a/front/src/modules/simulationResult/SimulationResultExport/exportTrainCSV.ts
+++ b/front/src/modules/simulationResult/SimulationResultExport/exportTrainCSV.ts
@@ -118,10 +118,10 @@ const overloadSteps = (
   }));
 
   const formattedElectricalProfiles = electricalProfiles.values.map((value, index) => {
-    const position = mmToM(electricalProfiles.boundaries[index - 1]) || 0;
+    const position = electricalProfiles.boundaries[index - 1] || 0;
     const currentTrainRegime = {
       speed: interpolateValue(trainRegime, position, 'speeds'),
-      position,
+      position: mmToM(position),
       time: interpolateValue(trainRegime, position, 'times'),
     };
     return {


### PR DESCRIPTION
Close #12365

It would be nice to have some kind of wrapping type to avoid such mistakes in the future.