### PR TITLE
core: stdcm: add optional local file cache for timetables

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -9,6 +9,7 @@ plugins {
     id 'jacoco-report-aggregation'
     alias(libs.plugins.versions)
     alias(libs.plugins.spotless)
+    alias(libs.plugins.kotlin.serialization)
 }
 
 // region DEPENDENCIES
@@ -32,6 +33,8 @@ dependencies {
     implementation libs.kotlin.logging
     implementation libs.kotlin.stdlib
     implementation libs.kotlinx.coroutines.core
+    implementation libs.kotlinx.serialization.core
+    implementation libs.kotlinx.serialization.cbor
     testImplementation libs.kotlin.test
     testImplementation libs.kotlinx.coroutines.test
 

--- a/core/gradle/libs.versions.toml
+++ b/core/gradle/libs.versions.toml
@@ -31,6 +31,8 @@ kotlin-reflect = { module = 'org.jetbrains.kotlin:kotlin-reflect', version.ref =
 kotlin-test = { module = 'org.jetbrains.kotlin:kotlin-test', version.ref = 'kotlin' } # Apache 2.0
 kotlinx-coroutines-core = { module = 'org.jetbrains.kotlinx:kotlinx-coroutines-core', version.ref = 'kotlinx-coroutines' } # Apache 2.0
 kotlinx-coroutines-test = { module = 'org.jetbrains.kotlinx:kotlinx-coroutines-test', version.ref = 'kotlinx-coroutines' } # Apache 2.0
+kotlinx-serialization-cbor = { module = 'org.jetbrains.kotlinx:kotlinx-serialization-cbor', version = '1.9.+' } # Apache 2.0
+kotlinx-serialization-core = { module = 'org.jetbrains.kotlinx:kotlinx-serialization-core', version = '1.9.+' } # Apache 2.0
 ksp-symbol-processing-api = { module = 'com.google.devtools.ksp:symbol-processing-api', version.ref = 'ksp' } # Apache 2.0
 
 # common

--- a/core/src/main/java/fr/sncf/osrd/api/TimetableCacheManager.kt
+++ b/core/src/main/java/fr/sncf/osrd/api/TimetableCacheManager.kt
@@ -1,5 +1,6 @@
 package fr.sncf.osrd.api
 
+import com.google.common.collect.ImmutableRangeSet
 import com.google.common.collect.Range
 import com.google.common.collect.RangeSet
 import com.google.common.collect.TreeRangeSet
@@ -14,15 +15,23 @@ import fr.sncf.osrd.sim_infra.api.ZoneId
 import fr.sncf.osrd.utils.json.UnitAdapterFactory
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.annotations.WithSpan
+import java.nio.file.Files
 import java.time.Duration
 import java.time.Instant
 import java.time.ZonedDateTime
 import java.util.concurrent.ConcurrentHashMap
+import kotlin.io.path.Path
+import kotlin.io.path.exists
+import kotlin.io.path.readBytes
+import kotlin.io.path.writeBytes
 import kotlin.math.pow
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.cbor.Cbor
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
@@ -30,9 +39,46 @@ import org.slf4j.LoggerFactory
 
 typealias TimetableId = Int
 
-typealias STDCMRequirements = Map<ZoneId, RangeSet<Double>>
-
 private const val PAGE_SIZE = 100
+
+@JvmInline
+value class STDCMRequirements(val map: Map<ZoneId, RangeSet<Double>>) :
+    Map<ZoneId, RangeSet<Double>> by map {
+
+    fun toSerializable(): SerializableMap {
+        return SerializableMap(
+            map.entries.associate { (key, value) ->
+                key.index to value.asRanges().map { SerializableRange.fromRange(it) }
+            }
+        )
+    }
+
+    @Serializable
+    data class SerializableMap(val map: Map<UInt, List<SerializableRange>>) {
+        fun toSTDCMRequirements(): STDCMRequirements {
+            val converted =
+                map.entries.associate { (key, value) ->
+                    ZoneId(key) to SerializableRange.rangesToRangeSet(value)
+                }
+            return STDCMRequirements(converted)
+        }
+    }
+
+    @Serializable
+    data class SerializableRange(val from: Double, val to: Double) {
+        companion object {
+            fun fromRange(range: Range<Double>): SerializableRange {
+                return SerializableRange(range.lowerEndpoint(), range.upperEndpoint())
+            }
+
+            fun rangesToRangeSet(ranges: List<SerializableRange>): RangeSet<Double> {
+                val builder = ImmutableRangeSet.Builder<Double>()
+                for (range in ranges) builder.add(Range.closed(range.from, range.to))
+                return builder.build()
+            }
+        }
+    }
+}
 
 /**
  * Caches train spacing requirements for STDCM. The spacing requirements times are relative to
@@ -42,6 +88,7 @@ class TimetableCacheManager(
     baseUrl: String,
     authenticationHeader: String,
     httpClient: OkHttpClient,
+    val localCacheLocation: String? = null,
 ) : APIClient(baseUrl, authenticationHeader, httpClient) {
     private val cache = ConcurrentHashMap<TimetableId, STDCMRequirements>()
     private val mutexes = ConcurrentHashMap<TimetableId, Mutex>()
@@ -89,7 +136,7 @@ class TimetableCacheManager(
     }
 
     @WithSpan(value = "Fetching timetable content", kind = SpanKind.SERVER)
-    private suspend fun fetchTimetableRequirements(
+    private fun fetchTimetableRequirements(
         infraId: String,
         infra: RawInfra,
         timetableId: TimetableId,
@@ -97,14 +144,20 @@ class TimetableCacheManager(
         logger.info("Fetching timetable requirements for $timetableId")
 
         val res = mutableMapOf<ZoneId, RangeSet<Double>>()
-        val requirements = fetchTrainRequirements(infraId, infra, timetableId)
-        requirements.collect { spacingReq ->
-            val set = res.computeIfAbsent(spacingReq.zone) { TreeRangeSet.create() }
-            set.add(Range.closedOpen(spacingReq.beginTime, spacingReq.endTime))
-        }
+        val requirements =
+            withLocalCache(localCacheLocation, "$timetableId.cbor") {
+                runBlocking {
+                    val requirements = fetchTrainRequirements(infraId, infra, timetableId)
+                    requirements.collect { spacingReq ->
+                        val set = res.computeIfAbsent(spacingReq.zone) { TreeRangeSet.create() }
+                        set.add(Range.closedOpen(spacingReq.beginTime, spacingReq.endTime))
+                    }
+                    STDCMRequirements(res)
+                }
+            }
 
         logger.info("Saved timetable requirements for $timetableId")
-        return res
+        return requirements
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -176,6 +229,38 @@ class TimetableCacheManager(
             }
         }
         throw UnexpectedHttpResponse(response)
+    }
+
+    /**
+     * If a cache folder has been set, get the cached data if present, otherwise generate it and
+     * write a new file. Directly calls the generator function if no cache folder has been set.
+     */
+    @OptIn(ExperimentalSerializationApi::class)
+    private fun withLocalCache(
+        cacheFolder: String?,
+        filename: String?,
+        generateData: () -> STDCMRequirements,
+    ): STDCMRequirements {
+        if (cacheFolder == null || filename == null) return generateData()
+        val folder = Path(cacheFolder)
+        Files.createDirectories(folder)
+        val file = folder.resolve(filename)
+        val cbor = Cbor {}
+        val serializer = STDCMRequirements.SerializableMap.serializer()
+
+        if (file.exists()) {
+            val bytes = file.readBytes()
+            val serializableMap = cbor.decodeFromByteArray(serializer, bytes)
+            logger.info("local timetable file cache hit at $file")
+            return serializableMap.toSTDCMRequirements()
+        } else {
+            val map = generateData.invoke()
+            logger.info("writing timetable to local file cache at $file")
+            val serializableMap = map.toSerializable()
+            val bytes = cbor.encodeToByteArray(serializer, serializableMap)
+            file.writeBytes(bytes)
+            return map
+        }
     }
 
     private data class PaginatedRequirements(

--- a/core/src/main/java/fr/sncf/osrd/cli/WorkerCommand.kt
+++ b/core/src/main/java/fr/sncf/osrd/cli/WorkerCommand.kt
@@ -42,6 +42,7 @@ class WorkerCommand : CliCommand {
     )
     private var editoastAuthorization: String = "x-osrd-skip-authz"
 
+    val LOCAL_TIMETABLE_CACHE: String?
     val WORKER_ID: String?
     val WORKER_ID_USE_HOSTNAME: Boolean
     val WORKER_KEY: String?
@@ -54,6 +55,7 @@ class WorkerCommand : CliCommand {
     val WORKER_THREADS: Int
 
     init {
+        LOCAL_TIMETABLE_CACHE = System.getenv("LOCAL_TIMETABLE_CACHE")
         WORKER_ID_USE_HOSTNAME = getBooleanEnvvar("WORKER_ID_USE_HOSTNAME")
         ALL_INFRA = getBooleanEnvvar("ALL_INFRA")
         WORKER_KEY = if (ALL_INFRA) "all" else System.getenv("WORKER_KEY")
@@ -108,7 +110,13 @@ class WorkerCommand : CliCommand {
         val timetableId = WORKER_KEY.split("-").getOrNull(1)?.toInt()
         val diagnosticRecorder = DiagnosticRecorderImpl(false)
         val infraManager = InfraManager(editoastUrl, editoastAuthorization, httpClient)
-        val timetableCache = TimetableCacheManager(editoastUrl!!, editoastAuthorization, httpClient)
+        val timetableCache =
+            TimetableCacheManager(
+                editoastUrl!!,
+                editoastAuthorization,
+                httpClient,
+                LOCAL_TIMETABLE_CACHE,
+            )
         val electricalProfileSetManager =
             ElectricalProfileSetManager(editoastUrl, editoastAuthorization, httpClient)
 


### PR DESCRIPTION
For worker command, set `LOCAL_TIMETABLE_CACHE` to some location, like `timetable_cache`. It will create a new folder if it doesn't exist yet, and store the timetable there.

---

For a timetable with 16,720 trains, on my desktop:

* Fetching the timetable normally takes 1:49.
* Writing the file takes 500ms. The file itself is 44MB large. 
* After a restart, reloading the same timetable takes **200ms**.

That's quite an improvement, we should probably look into a valkey for this as discussed earlier. (eventually)

---

(I'm also now *considering* doing the same kind of cache for infras, it would be extremely nice to avoid those ~12s at every core launch)