### PR TITLE
editoast: move `TrainId` to models

### DIFF
--- a/editoast/src/models/paced_train.rs
+++ b/editoast/src/models/paced_train.rs
@@ -1,3 +1,6 @@
+use std::fmt::Display;
+use std::str::FromStr;
+
 use chrono::DateTime;
 use chrono::Duration as ChronoDuration;
 use chrono::Utc;
@@ -20,7 +23,6 @@ use schemas::train_schedule::TrainSchedule;
 use schemas::train_schedule::TrainScheduleOptions;
 
 use super::Tags;
-use crate::views::timetable::TrainId;
 use editoast_models::prelude::*;
 
 #[derive(Debug, Clone, Model)]
@@ -292,6 +294,93 @@ impl From<PacedTrain> for paced_train::PacedTrain {
     }
 }
 
+#[derive(Debug, Clone, PartialEq)]
+/// This ID is used to identify paced train occurrences and exceptions when sending them to the core API for conflict detection.
+pub enum TrainId {
+    TrainSchedule(i64),
+    PacedTrainBaseOccurrence {
+        paced_train_id: i64,
+        index: u64,
+    },
+    PacedTrainModifiedException {
+        paced_train_id: i64,
+        index: u64,
+        exception_key: String,
+    },
+    PacedTrainCreatedException {
+        paced_train_id: i64,
+        exception_key: String,
+    },
+}
+
+impl Display for TrainId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::TrainSchedule(id) => write!(f, "{id}"),
+            Self::PacedTrainBaseOccurrence {
+                paced_train_id,
+                index,
+            } => write!(f, "{paced_train_id}#{index}"),
+            Self::PacedTrainCreatedException {
+                paced_train_id,
+                exception_key,
+            } => write!(f, "{paced_train_id}@{exception_key}"),
+            Self::PacedTrainModifiedException {
+                paced_train_id,
+                exception_key,
+                index,
+            } => write!(f, "{paced_train_id}@{exception_key}#{index}"),
+        }
+    }
+}
+
+impl FromStr for TrainId {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Is it a paced train exception?
+        if let Some((train_id_str, exception_str)) = s.split_once('@') {
+            let paced_train_id = train_id_str
+                .parse::<i64>()
+                .map_err(|_| "Invalid train id")?;
+            // Is it a modified paced train exception?
+            if let Some((exception_key, index_str)) = exception_str.split_once('#') {
+                let index = index_str
+                    .parse::<u64>()
+                    .map_err(|_| "Invalid exception index")?;
+                Ok(TrainId::PacedTrainModifiedException {
+                    paced_train_id,
+                    exception_key: exception_key.to_string(),
+                    index,
+                })
+            } else {
+                let exception_key = exception_str.to_string();
+                Ok(TrainId::PacedTrainCreatedException {
+                    paced_train_id,
+                    exception_key,
+                })
+            }
+        } else {
+            // Is it a base paced train exception?
+            if let Some((train_id_str, index_str)) = s.split_once('#') {
+                let paced_train_id = train_id_str
+                    .parse::<i64>()
+                    .map_err(|_| "Invalid train id")?;
+                let index = index_str
+                    .parse::<u64>()
+                    .map_err(|_| "Invalid occurrence index")?;
+                Ok(TrainId::PacedTrainBaseOccurrence {
+                    paced_train_id,
+                    index,
+                })
+            } else {
+                let train_id = s.parse::<i64>().map_err(|_| "Invalid train id")?;
+                Ok(TrainId::TrainSchedule(train_id))
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
@@ -303,7 +392,7 @@ mod tests {
     use crate::models::fixtures::create_timetable;
     use crate::models::fixtures::simple_paced_train_changeset;
     use crate::models::fixtures::simple_sub_category;
-    use crate::views::timetable::TrainId;
+    use crate::models::paced_train::TrainId;
     use chrono::DateTime;
     use chrono::Utc;
     use database::DbConnectionPoolV2;

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -5,8 +5,6 @@ pub mod simulation;
 pub mod stdcm;
 pub mod train_schedule;
 
-use std::fmt::Display;
-use std::str::FromStr;
 use std::sync::Arc;
 
 use authz;
@@ -66,6 +64,7 @@ use crate::error::Result;
 use crate::models;
 use crate::models::Infra;
 use crate::models::paced_train::PacedTrainChangeset;
+use crate::models::paced_train::TrainId;
 use crate::models::timetable::Timetable;
 use crate::models::timetable::TimetableWithTrains;
 use crate::models::train_schedule::TrainScheduleChangeset;
@@ -466,93 +465,6 @@ enum PacedTrainOccurrenceRef {
     BaseOccurrence { index: u64 },
     ModifiedException { index: u64, exception_key: String },
     CreatedException { exception_key: String },
-}
-
-#[derive(Debug, Clone, PartialEq)]
-/// This ID is used to identify paced train occurrences and exceptions when sending them to the core API for conflict detection.
-pub enum TrainId {
-    TrainSchedule(i64),
-    PacedTrainBaseOccurrence {
-        paced_train_id: i64,
-        index: u64,
-    },
-    PacedTrainModifiedException {
-        paced_train_id: i64,
-        index: u64,
-        exception_key: String,
-    },
-    PacedTrainCreatedException {
-        paced_train_id: i64,
-        exception_key: String,
-    },
-}
-
-impl Display for TrainId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::TrainSchedule(id) => write!(f, "{id}"),
-            Self::PacedTrainBaseOccurrence {
-                paced_train_id,
-                index,
-            } => write!(f, "{paced_train_id}#{index}"),
-            Self::PacedTrainCreatedException {
-                paced_train_id,
-                exception_key,
-            } => write!(f, "{paced_train_id}@{exception_key}"),
-            Self::PacedTrainModifiedException {
-                paced_train_id,
-                exception_key,
-                index,
-            } => write!(f, "{paced_train_id}@{exception_key}#{index}"),
-        }
-    }
-}
-
-impl FromStr for TrainId {
-    type Err = &'static str;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        // Is it a paced train exception?
-        if let Some((train_id_str, exception_str)) = s.split_once('@') {
-            let paced_train_id = train_id_str
-                .parse::<i64>()
-                .map_err(|_| "Invalid train id")?;
-            // Is it a modified paced train exception?
-            if let Some((exception_key, index_str)) = exception_str.split_once('#') {
-                let index = index_str
-                    .parse::<u64>()
-                    .map_err(|_| "Invalid exception index")?;
-                Ok(TrainId::PacedTrainModifiedException {
-                    paced_train_id,
-                    exception_key: exception_key.to_string(),
-                    index,
-                })
-            } else {
-                let exception_key = exception_str.to_string();
-                Ok(TrainId::PacedTrainCreatedException {
-                    paced_train_id,
-                    exception_key,
-                })
-            }
-        } else {
-            // Is it a base paced train exception?
-            if let Some((train_id_str, index_str)) = s.split_once('#') {
-                let paced_train_id = train_id_str
-                    .parse::<i64>()
-                    .map_err(|_| "Invalid train id")?;
-                let index = index_str
-                    .parse::<u64>()
-                    .map_err(|_| "Invalid occurrence index")?;
-                Ok(TrainId::PacedTrainBaseOccurrence {
-                    paced_train_id,
-                    index,
-                })
-            } else {
-                let train_id = s.parse::<i64>().map_err(|_| "Invalid train id")?;
-                Ok(TrainId::TrainSchedule(train_id))
-            }
-        }
-    }
 }
 
 /// Retrieve the list of conflicts of the timetable (invalid trains are ignored)


### PR DESCRIPTION
I moved `TrainId` from `views` to `models` so that views depend on models, not the other way around.
This is to prepare for moving models to a separate crate later.