### PR TITLE
core: stdcm: add payload to span data

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
@@ -100,6 +100,7 @@ class STDCMEndpoint(
     @WithSpan(value = "Processing STDCM request", kind = SpanKind.SERVER)
     fun run(request: STDCMRequest): Response {
         val recorder = DiagnosticRecorderImpl(false)
+        Span.current().setAttribute("payload", stdcmRequestAdapter.toJson(request))
         logger.info(
             "Request received: start=${request.startTime}, max duration=${request.maximumRunTime}"
         )


### PR DESCRIPTION
Very straightforward PR, the rest is still a work in progress. I want to merge this early to make sure it shows up as expected on datadog. 

Tested locally with jaeger and opentelemetry.