### PR TITLE
front: stdcm - display operational point as muted if not in perimeter

### DIFF
--- a/front/src/applications/stdcm/components/StdcmForm/StdcmConfig.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmConfig.tsx
@@ -360,7 +360,8 @@ const StdcmConfig = ({
             mapId="stdcm-map-config"
             infraId={infra?.id}
             pathStepMarkers={markersInfo}
-            highlightedArea={activePerimeter}
+            highlightedArea={activePerimeter?.geometry}
+            highlightedOperationalPoints={activePerimeter?.operationalPoints}
             mapSettings={mapSettings}
             updateMapSettings={updateMapSettings}
           >

--- a/front/src/applications/stdcm/components/StdcmForm/StdcmMapActivePerimeter.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmMapActivePerimeter.tsx
@@ -12,7 +12,7 @@ export default () => {
 
   useEffect(() => {
     if (activePerimeter) {
-      const area = bbox(activePerimeter) as [number, number, number, number];
+      const area = bbox(activePerimeter.geometry) as [number, number, number, number];
       map.current?.fitBounds(area, { padding: 50 });
     }
   }, [map, activePerimeter]);

--- a/front/src/applications/stdcm/hooks/useStdcmEnv.tsx
+++ b/front/src/applications/stdcm/hooks/useStdcmEnv.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 
 import { useDispatch } from 'react-redux';
 
+import STDCM_PERIMETER_OPERATIONAL_POINTS from 'assets/operationStudies/stdcmPerimeterOperationalPoints';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import {
   resetStdcmSimulations,
@@ -37,7 +38,14 @@ export default function useStdcmEnvironment() {
             begin: new Date(data.search_window_begin),
             end: new Date(data.search_window_end),
           },
-          activePerimeter: data.active_perimeter,
+          activePerimeter: data.active_perimeter
+            ? {
+                geometry: data.active_perimeter,
+                // TODO: this should be removed in a near futur when the operational points for the permimeter will be stored
+                // in the database and served by the API
+                operationalPoints: STDCM_PERIMETER_OPERATIONAL_POINTS,
+              }
+            : undefined,
         })
       );
     } catch (e) {

--- a/front/src/common/Map/BaseMap.tsx
+++ b/front/src/common/Map/BaseMap.tsx
@@ -44,6 +44,7 @@ type MapProps = {
    * - OP & tracks are full displayed, but elements ouside the area are muted
    */
   highlightedArea?: Geometry;
+  highlightedOperationalPoints?: number[];
 };
 
 const BaseMap = ({
@@ -62,6 +63,7 @@ const BaseMap = ({
   onMouseMove,
   onIdle,
   highlightedArea,
+  highlightedOperationalPoints,
 }: PropsWithChildren<MapProps>) => {
   const mapBlankStyle = useMapBlankStyle();
 
@@ -153,6 +155,7 @@ const BaseMap = ({
           hoveredOperationalPointId={hoveredOperationalPointId}
           layersSettings={layersSettings}
           highlightedArea={highlightedArea}
+          highlightedOperationalPoints={highlightedOperationalPoints}
         />
       )}
 

--- a/front/src/common/Map/DefaultBaseMap.tsx
+++ b/front/src/common/Map/DefaultBaseMap.tsx
@@ -25,6 +25,7 @@ type DefaultBaseMapProps = {
   mapSettings: MapSettings;
   updateMapSettings: (mapSettings: Partial<MapSettings>) => void;
   highlightedArea?: Geometry;
+  highlightedOperationalPoints?: number[];
 };
 
 const ZOOM_DEFAULT = 5;
@@ -44,6 +45,7 @@ const DefaultBaseMap = ({
   mapSettings,
   updateMapSettings,
   highlightedArea,
+  highlightedOperationalPoints,
 }: PropsWithChildren<DefaultBaseMapProps>) => {
   const mapRef = useRef<MapRef | null>(null);
   const { viewport } = mapSettings;
@@ -110,6 +112,7 @@ const DefaultBaseMap = ({
         hideAttribution
         mapSettings={mapSettings}
         highlightedArea={highlightedArea}
+        highlightedOperationalPoints={highlightedOperationalPoints}
       >
         <ItineraryLayer
           layerOrder={LAYER_GROUPS_ORDER[LAYERS.PATH.GROUP]}

--- a/front/src/common/Map/Layers/InfraObjectLayers/InfraObjectLayers.tsx
+++ b/front/src/common/Map/Layers/InfraObjectLayers/InfraObjectLayers.tsx
@@ -22,6 +22,7 @@ type InfraObjectLayersProps = {
   hoveredOperationalPointId?: string;
   layersSettings: LayersSettings;
   highlightedArea?: Geometry;
+  highlightedOperationalPoints?: number[];
 };
 
 const InfraObjectLayers = ({
@@ -30,6 +31,7 @@ const InfraObjectLayers = ({
   hoveredOperationalPointId,
   layersSettings,
   highlightedArea,
+  highlightedOperationalPoints,
 }: InfraObjectLayersProps) => (
   <>
     <TracksGeographic
@@ -53,6 +55,7 @@ const InfraObjectLayers = ({
         operationnalPointId={hoveredOperationalPointId}
         infraID={infraId}
         highlightedArea={highlightedArea}
+        highlightedOperationalPoints={highlightedOperationalPoints}
       />
     )}
     {layersSettings.electrifications && (

--- a/front/src/common/Map/Layers/InfraObjectLayers/OperationalPoints.tsx
+++ b/front/src/common/Map/Layers/InfraObjectLayers/OperationalPoints.tsx
@@ -1,6 +1,11 @@
 import type { Geometry } from 'geojson';
 import { isNil } from 'lodash';
-import type { ExpressionSpecification } from 'maplibre-gl';
+import type {
+  ColorSpecification,
+  DataDrivenPropertyValueSpecification,
+  ExpressionSpecification,
+  FilterSpecification,
+} from 'maplibre-gl';
 import { Source, type LayerProps } from 'react-map-gl/maplibre';
 
 import { MAP_URL } from 'common/Map/const';
@@ -15,7 +20,44 @@ type OperationalPointsProps = {
   infraID: number | undefined;
   operationnalPointId?: string;
   highlightedArea?: Geometry;
+  highlightedOperationalPoints?: number[];
 };
+
+function getColorByHighlighted(data: {
+  highlightedArea?: Geometry;
+  highlightedOperationalPoints?: number[];
+  inColor: string | ExpressionSpecification;
+  outColor: string | ExpressionSpecification;
+}): DataDrivenPropertyValueSpecification<ColorSpecification> {
+  if (data.highlightedOperationalPoints && data.highlightedOperationalPoints.length > 0)
+    return [
+      'case',
+      ['in', ['get', 'extensions_sncf_ci'], ['literal', data.highlightedOperationalPoints]],
+      data.inColor,
+      data.outColor,
+    ];
+  if (data.highlightedArea)
+    return ['case', ['within', data.highlightedArea], data.inColor, data.outColor];
+  return data.inColor;
+}
+
+function getFilterHighlighted(
+  data: {
+    highlightedArea?: Geometry;
+    highlightedOperationalPoints?: number[];
+  },
+  reverseCondition = false
+): FilterSpecification {
+  let result: FilterSpecification = true;
+  if (data.highlightedOperationalPoints && data.highlightedOperationalPoints.length > 0)
+    result = ['in', ['get', 'extensions_sncf_ci'], ['literal', data.highlightedOperationalPoints]];
+  else if (data.highlightedArea) result = ['within', data.highlightedArea];
+
+  if (reverseCondition === true) {
+    return ['!=', result, true];
+  }
+  return result;
+}
 
 const OperationalPointsLayer = ({
   colors,
@@ -23,6 +65,7 @@ const OperationalPointsLayer = ({
   infraID,
   operationnalPointId,
   highlightedArea,
+  highlightedOperationalPoints,
 }: OperationalPointsProps) => {
   if (isNil(infraID)) return null;
 
@@ -33,24 +76,17 @@ const OperationalPointsLayer = ({
     paint: {
       'circle-stroke-color': colors.op.stroke,
       'circle-stroke-width': 1.5,
-      'circle-color': highlightedArea
-        ? [
-            'case',
-            ['within', highlightedArea],
-            [
-              'case',
-              ['in', ['get', 'extensions_sncf_ch'], ['literal', ['BV', '00']]],
-              colors.op.circleBV,
-              colors.op.circle,
-            ],
-            colors.muted.color,
-          ]
-        : [
-            'case',
-            ['in', ['get', 'extensions_sncf_ch'], ['literal', ['BV', '00']]],
-            colors.op.circleBV,
-            colors.op.circle,
-          ],
+      'circle-color': getColorByHighlighted({
+        highlightedArea,
+        highlightedOperationalPoints,
+        inColor: [
+          'case',
+          ['in', ['get', 'extensions_sncf_ch'], ['literal', ['BV', '00']]],
+          colors.op.circleBV,
+          colors.op.circle,
+        ],
+        outColor: colors.muted.color,
+      }),
       'circle-radius': 3,
     },
   };
@@ -58,14 +94,14 @@ const OperationalPointsLayer = ({
   // There is a bug on the color, see https://github.com/maplibre/maplibre-gl-js/issues/5833
   const LABEL_SECTIONS: Array<{
     id: string;
-    textFormat: Array<
-      | ExpressionSpecification
-      | {
-          'font-scale'?: number;
-          'text-color'?: string | ExpressionSpecification;
-          'text-font'?: ExpressionSpecification;
-        }
-    >;
+    textFormat: [
+      ExpressionSpecification,
+      {
+        'font-scale'?: number;
+        'text-font'?: ExpressionSpecification;
+        'text-color'?: string | ExpressionSpecification;
+      },
+    ];
   }> = [
     {
       id: 'pk',
@@ -73,9 +109,7 @@ const OperationalPointsLayer = ({
         ['concat', ['get', 'kp'], '\n'],
         {
           'font-scale': 1,
-          'text-color': highlightedArea
-            ? ['case', ['within', highlightedArea], colors.op.textTrigram, colors.muted.color]
-            : colors.op.textTrigram,
+          'text-color': colors.op.textTrigram,
         },
       ],
     },
@@ -96,9 +130,7 @@ const OperationalPointsLayer = ({
         ],
         {
           'font-scale': 1.1,
-          'text-color': highlightedArea
-            ? ['case', ['within', highlightedArea], colors.op.textTrigram, colors.muted.color]
-            : colors.op.textTrigram,
+          'text-color': colors.op.textTrigram,
         },
       ],
     },
@@ -108,9 +140,7 @@ const OperationalPointsLayer = ({
         ['concat', ['get', 'extensions_identifier_name'], '\n'],
         {
           'font-scale': 1.1,
-          'text-color': highlightedArea
-            ? ['case', ['within', highlightedArea], colors.op.textName, colors.muted.color]
-            : colors.op.textName,
+          'text-color': colors.op.textName,
         },
       ],
     },
@@ -125,19 +155,24 @@ const OperationalPointsLayer = ({
         ],
         {
           'font-scale': 1,
+          'text-font': ['literal', ['IBMPlexSansCondensed-Medium']],
           'text-color': highlightedArea
             ? ['case', ['within', highlightedArea], colors.op.textYard, colors.muted.color]
             : colors.op.textYard,
-          'text-font': ['literal', ['IBMPlexSansCondensed-Medium']],
         },
       ],
     },
   ];
 
-  function getText(filter?: string[]) {
-    return LABEL_SECTIONS.filter((s) => (filter ? filter?.includes(s.id) : true)).flatMap(
-      (s) => s.textFormat
-    );
+  function getText(labelsToInclude?: string[], overrideTextColor?: string) {
+    return LABEL_SECTIONS.filter((s) =>
+      labelsToInclude ? labelsToInclude?.includes(s.id) : true
+    ).flatMap((s) => {
+      const textFormat = s.textFormat;
+      if (overrideTextColor)
+        return [textFormat[0], { ...textFormat[1], 'text-color': overrideTextColor }];
+      else return textFormat;
+    });
   }
 
   const name: LayerProps = {
@@ -172,10 +207,49 @@ const OperationalPointsLayer = ({
       'text-offset': [0.75, -1],
       'text-max-width': 32,
     },
+    filter: getFilterHighlighted({ highlightedArea, highlightedOperationalPoints }),
     paint: {
-      'text-color': highlightedArea
-        ? ['case', ['within', highlightedArea], colors.op.textName, colors.muted.color]
-        : colors.op.textName,
+      'text-color': colors.op.textName,
+      'text-halo-width': DEFAULT_HALO_WIDTH,
+      'text-halo-color': colors.op.halo,
+    },
+  };
+
+  const nameMuted: LayerProps = {
+    type: 'symbol',
+    'source-layer': 'operational_points',
+    minzoom: 7,
+    layout: {
+      'text-field': [
+        'step',
+        ['zoom'],
+        ['format', ...getText(['pk', 'trigram', 'name', 'yard'], colors.muted.color)],
+        7,
+        ['format', ...getText(['trigram'], colors.muted.color)],
+        9,
+        ['format', ...getText(['pk', 'trigram'], colors.muted.color)],
+        10,
+        ['format', ...getText(['pk', 'trigram', 'name'], colors.muted.color)],
+        17,
+        ['format', ...getText(['pk', 'trigram', 'name', 'yard'], colors.muted.color)],
+      ],
+      'text-font': [
+        'case',
+        ['==', ['get', 'id'], operationnalPointId || ''],
+        ['literal', ['IBMPlexSans']],
+        ['literal', ['IBMPlexSansCondensed-Medium']],
+      ],
+      'text-letter-spacing': 0.05,
+      'text-size': getDynamicTextSize(),
+      'text-anchor': 'top-left',
+      'text-allow-overlap': getAllowOverlap(),
+      'text-justify': 'left',
+      'text-offset': [0.75, -1],
+      'text-max-width': 32,
+    },
+    filter: getFilterHighlighted({ highlightedArea, highlightedOperationalPoints }, true),
+    paint: {
+      'text-color': colors.muted.color,
       'text-halo-width': DEFAULT_HALO_WIDTH,
       'text-halo-color': colors.op.halo,
     },
@@ -193,6 +267,14 @@ const OperationalPointsLayer = ({
         id="chartis/osrd_operational_point_name/geo"
         layerOrder={layerOrder}
       />
+
+      {highlightedOperationalPoints && highlightedOperationalPoints.length > 0 && (
+        <OrderedLayer
+          {...nameMuted}
+          id="chartis/osrd_operational_point_name_muted/geo"
+          layerOrder={layerOrder}
+        />
+      )}
     </Source>
   );
 };

--- a/front/src/reducers/osrdconf/stdcmConf/stdcmConfReducers.spec.ts
+++ b/front/src/reducers/osrdconf/stdcmConf/stdcmConfReducers.spec.ts
@@ -179,20 +179,23 @@ describe('stdcmConfReducers', () => {
       expect(state.loadingGauge).toEqual('GB');
     });
     it('should handle activePerimeter', () => {
-      const geometry: Geometry = {
-        type: 'Polygon',
-        coordinates: [
-          [
-            [-1, 47],
-            [-2, 47],
-            [-2, 48],
-            [-1, 47],
+      const perimeter = {
+        geometry: {
+          type: 'Polygon',
+          coordinates: [
+            [
+              [-1, 47],
+              [-2, 47],
+              [-2, 48],
+              [-1, 47],
+            ],
           ],
-        ],
+        } as Geometry,
+        operationalPoints: [1, 2, 3, 4],
       };
-      store.dispatch(updateStdcmEnvironmentActiveArea(geometry));
+      store.dispatch(updateStdcmEnvironmentActiveArea(perimeter));
       const state = store.getState()[stdcmConfSlice.name];
-      expect(state.activePerimeter).toEqual(geometry);
+      expect(state.activePerimeter).toEqual(perimeter);
     });
   });
 

--- a/front/src/reducers/osrdconf/types.ts
+++ b/front/src/reducers/osrdconf/types.ts
@@ -82,7 +82,10 @@ export type OsrdStdcmConfState = OsrdConfState & {
   workScheduleGroupId?: number;
   temporarySpeedLimitGroupId?: number;
   searchDatetimeWindow?: StdcmSearchDatetimeWindow;
-  activePerimeter?: Geometry;
+  activePerimeter?: {
+    geometry: Geometry;
+    operationalPoints: number[];
+  };
 };
 
 export type PathStep = {


### PR DESCRIPTION
## Description

Fix #13038

The geo perimeter is computed from a list of operational points, If a point is in the geometry but not in the list of operational points it should be displayed as muted.

For now, the operational list is  static, but should be dynamic in a near futur.

## Before 

<img width="579" height="524" alt="image" src="https://github.com/user-attachments/assets/45cd2f22-b43a-4413-bba1-1328d310ad2b" />


## After 

<img width="579" height="524" alt="image" src="https://github.com/user-attachments/assets/8e0dd9ab-c083-436d-ab0d-60c62ab4b408" />
