### PR TITLE
editoast: fix track range openapi conflict

### DIFF
--- a/editoast/core_client/src/pathfinding.rs
+++ b/editoast/core_client/src/pathfinding.rs
@@ -111,6 +111,7 @@ pub struct PathfindingResultSuccess {
     /// Path description as route ids
     pub routes: Vec<Identifier>,
     /// Path description as track ranges
+    #[schema(value_type = Vec<CoreTrackRange>)]
     pub track_section_ranges: Vec<TrackRange>,
     /// Length of the path in mm
     pub length: u64,
@@ -141,10 +142,12 @@ pub enum PathfindingInputError {
 #[serde(tag = "error_type", rename_all = "snake_case")]
 pub enum PathfindingNotFound {
     NotFoundInBlocks {
+        #[schema(value_type = Vec<CoreTrackRange>)]
         track_section_ranges: Vec<TrackRange>,
         length: u64,
     },
     NotFoundInRoutes {
+        #[schema(value_type = Vec<CoreTrackRange>)]
         track_section_ranges: Vec<TrackRange>,
         length: u64,
     },
@@ -160,6 +163,7 @@ pub enum PathfindingNotFound {
 /// `begin` is always less than `end`.
 #[editoast_derive::openapi_schema]
 #[derive(Serialize, Deserialize, Clone, Debug, ToSchema, Hash, PartialEq, Eq)]
+#[schema(as = CoreTrackRange)]
 pub struct TrackRange {
     /// The track section identifier.
     #[schema(inline)]

--- a/editoast/core_client/src/stdcm.rs
+++ b/editoast/core_client/src/stdcm.rs
@@ -103,6 +103,7 @@ pub struct TemporarySpeedLimit {
     /// Speed limitation in m/s
     pub speed_limit: f64,
     /// Track ranges on which the speed limitation applies
+    #[schema(value_type = Vec<CoreTrackRange>)]
     pub track_ranges: Vec<TrackRange>,
 }
 

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -4704,7 +4704,7 @@ paths:
                 path_track_ranges:
                   type: array
                   items:
-                    $ref: '#/components/schemas/TrackRange'
+                    $ref: '#/components/schemas/CoreTrackRange'
                 work_schedule_group_id:
                   type: integer
                   format: int64
@@ -5147,6 +5147,33 @@ components:
           description: |-
             JSON-Pointer value [RFC6901](https://tools.ietf.org/html/rfc6901) that references a location
             within the target document where the operation is performed.
+    CoreTrackRange:
+      type: object
+      description: |-
+        An oriented range on a track section.
+        `begin` is always less than `end`.
+      required:
+      - track_section
+      - begin
+      - end
+      - direction
+      properties:
+        begin:
+          type: integer
+          format: int64
+          description: The beginning of the range in mm.
+          minimum: 0
+        direction:
+          $ref: '#/components/schemas/Direction'
+        end:
+          type: integer
+          format: int64
+          description: The end of the range in mm.
+          minimum: 0
+        track_section:
+          type: string
+          maxLength: 255
+          minLength: 1
     Curve:
       type: object
       required:
@@ -10086,7 +10113,7 @@ components:
             track_section_ranges:
               type: array
               items:
-                $ref: '#/components/schemas/TrackRange'
+                $ref: '#/components/schemas/CoreTrackRange'
               description: List of track ranges
               minItems: 1
     OccupancyBlocksPacedTrainResult:
@@ -10837,7 +10864,7 @@ components:
         track_section_ranges:
           type: array
           items:
-            $ref: '#/components/schemas/TrackRange'
+            $ref: '#/components/schemas/CoreTrackRange'
           description: List of track sections
     PathfindingFailure:
       oneOf:
@@ -11026,7 +11053,7 @@ components:
           track_section_ranges:
             type: array
             items:
-              $ref: '#/components/schemas/TrackRange'
+              $ref: '#/components/schemas/CoreTrackRange'
       - type: object
         required:
         - track_section_ranges
@@ -11044,7 +11071,7 @@ components:
           track_section_ranges:
             type: array
             items:
-              $ref: '#/components/schemas/TrackRange'
+              $ref: '#/components/schemas/CoreTrackRange'
       - type: object
         required:
         - error_type
@@ -11153,7 +11180,7 @@ components:
         track_section_ranges:
           type: array
           items:
-            $ref: '#/components/schemas/TrackRange'
+            $ref: '#/components/schemas/CoreTrackRange'
           description: Path description as track ranges
     PathfindingTrackLocationInput:
       type: object
@@ -13561,7 +13588,7 @@ components:
               track_ranges:
                 type: array
                 items:
-                  $ref: '#/components/schemas/TrackRange'
+                  $ref: '#/components/schemas/CoreTrackRange'
                 description: Track ranges on which the speed limitation applies
           description: List of applicable temporary speed limits between the train departure and arrival
         time_gap_after:
@@ -14234,31 +14261,21 @@ components:
           minLength: 1
     TrackRange:
       type: object
-      description: |-
-        An oriented range on a track section.
-        `begin` is always less than `end`.
       required:
-      - track_section
+      - track
       - begin
       - end
-      - direction
       properties:
         begin:
-          type: integer
-          format: int64
-          description: The beginning of the range in mm.
-          minimum: 0
-        direction:
-          $ref: '#/components/schemas/Direction'
+          type: number
+          format: double
         end:
-          type: integer
-          format: int64
-          description: The end of the range in mm.
-          minimum: 0
-        track_section:
+          type: number
+          format: double
+        track:
           type: string
-          maxLength: 255
-          minLength: 1
+          example: 01234567-89ab-cdef-0123-456789abcdef
+      additionalProperties: false
     TrackReference:
       oneOf:
       - type: object

--- a/editoast/schemas/src/infra/track_range.rs
+++ b/editoast/schemas/src/infra/track_range.rs
@@ -4,8 +4,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
 
-// FIXME: this TrackRange and core_client::TrackRange are used interchangeably in the openapi...
-// #[editoast_derive::openapi_schema]
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Educe, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
 #[serde(deny_unknown_fields)]
 #[educe(Default)]

--- a/editoast/src/views/path.rs
+++ b/editoast/src/views/path.rs
@@ -5,7 +5,6 @@ pub(super) mod properties;
 
 pub use pathfinding::pathfinding_from_train_batch;
 
-use core_client::pathfinding::TrackRange;
 use database::DbConnection;
 use editoast_derive::EditoastError;
 use thiserror::Error;

--- a/editoast/src/views/path/projection.rs
+++ b/editoast/src/views/path/projection.rs
@@ -1,9 +1,8 @@
+use core_client::pathfinding::TrackRange;
 use schemas::infra::Direction;
 use schemas::infra::TrackOffset;
 use schemas::primitives::Identifier;
 use std::collections::HashMap;
-
-use super::TrackRange;
 
 /// This object is useful to:
 /// - Get the position in the path given a location (track section and offset).

--- a/editoast/src/views/path/properties.rs
+++ b/editoast/src/views/path/properties.rs
@@ -41,6 +41,7 @@ use crate::views::path::retrieve_infra_version;
 #[derive(Debug, Serialize, Deserialize, ToSchema, Hash)]
 pub struct PathPropertiesInput {
     /// List of track sections
+    #[schema(value_type = Vec<CoreTrackRange>)]
     pub track_section_ranges: Vec<TrackRange>,
 }
 

--- a/editoast/src/views/projection.rs
+++ b/editoast/src/views/projection.rs
@@ -42,7 +42,7 @@ pub struct ProjectPathForm {
     pub infra_id: i64,
     pub electrical_profile_set_id: Option<i64>,
     pub ids: HashSet<i64>,
-    #[schema(inline)]
+    #[schema(inline, value_type = Vec<core_client::pathfinding::TrackRange>)]
     pub track_section_ranges: Vec<TrackRange>,
 }
 
@@ -61,7 +61,7 @@ pub struct ProjectPathOperationalPointForm {
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct ProjectPathInput {
     /// List of track ranges
-    #[schema(min_items = 1)]
+    #[schema(min_items = 1, value_type = Vec<CoreTrackRange>)]
     pub track_section_ranges: Vec<TrackRange>,
     /// List of route ids
     #[schema(inline, min_items = 1)]

--- a/editoast/src/views/timetable/occupancy_blocks.rs
+++ b/editoast/src/views/timetable/occupancy_blocks.rs
@@ -1,4 +1,3 @@
-use crate::views::projection::TrainSimulationDetails;
 use core_client::AsCoreRequest;
 use core_client::CoreClient;
 use core_client::pathfinding::TrackRange;
@@ -17,6 +16,7 @@ use utoipa::ToSchema;
 use crate::error::Result;
 use crate::models::infra::Infra;
 use crate::views::projection::ProjectPathInput;
+use crate::views::projection::TrainSimulationDetails;
 use crate::views::projection::extract_train_details;
 use crate::views::timetable::simulation::train_simulation_batch;
 

--- a/editoast/src/views/work_schedules.rs
+++ b/editoast/src/views/work_schedules.rs
@@ -176,7 +176,7 @@ pub(in crate::views) async fn create(
 #[derive(Serialize, Deserialize, ToSchema)]
 pub(in crate::views) struct WorkScheduleProjectForm {
     work_schedule_group_id: i64,
-    #[schema(value_type = Vec<TrackRange>)]
+    #[schema(value_type = Vec<CoreTrackRange>)]
     path_track_ranges: Vec<core_client::pathfinding::TrackRange>,
 }
 

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -2575,7 +2575,7 @@ export type PostWorkSchedulesProjectPathApiResponse =
   }[];
 export type PostWorkSchedulesProjectPathApiArg = {
   body: {
-    path_track_ranges: TrackRange[];
+    path_track_ranges: CoreTrackRange[];
     work_schedule_group_id: number;
   };
 };
@@ -2640,14 +2640,10 @@ export type LightElectricalProfileSet = {
   name: string;
 };
 export type LevelValues = string[];
-export type Direction = 'START_TO_STOP' | 'STOP_TO_START';
 export type TrackRange = {
-  /** The beginning of the range in mm. */
   begin: number;
-  direction: Direction;
-  /** The end of the range in mm. */
   end: number;
-  track_section: string;
+  track: string;
 };
 export type ElectricalProfile = {
   power_class: string;
@@ -2718,6 +2714,7 @@ export type SwitchType = {
   id: string;
   ports: string[];
 };
+export type Direction = 'START_TO_STOP' | 'STOP_TO_START';
 export type DirectionalTrackRange = {
   begin: number;
   direction: Direction;
@@ -3304,9 +3301,17 @@ export type Property =
   | 'geometry'
   | 'operational_points'
   | 'zones';
+export type CoreTrackRange = {
+  /** The beginning of the range in mm. */
+  begin: number;
+  direction: Direction;
+  /** The end of the range in mm. */
+  end: number;
+  track_section: string;
+};
 export type PathPropertiesInput = {
   /** List of track sections */
-  track_section_ranges: TrackRange[];
+  track_section_ranges: CoreTrackRange[];
 };
 export type PathfindingOutput = {
   detectors: string[];
@@ -3334,7 +3339,7 @@ export type PathfindingResultSuccess = {
   /** Path description as route ids */
   routes: string[];
   /** Path description as track ranges */
-  track_section_ranges: TrackRange[];
+  track_section_ranges: CoreTrackRange[];
 };
 export type TrackOffset = {
   /** Offset in mm */
@@ -3380,12 +3385,12 @@ export type PathfindingNotFound =
   | {
       error_type: 'not_found_in_blocks';
       length: number;
-      track_section_ranges: TrackRange[];
+      track_section_ranges: CoreTrackRange[];
     }
   | {
       error_type: 'not_found_in_routes';
       length: number;
-      track_section_ranges: TrackRange[];
+      track_section_ranges: CoreTrackRange[];
     }
   | {
       error_type: 'not_found_in_tracks';
@@ -3624,7 +3629,7 @@ export type OccupancyBlockForm = {
     /** List of route ids */
     routes: string[];
     /** List of track ranges */
-    track_section_ranges: TrackRange[];
+    track_section_ranges: CoreTrackRange[];
   };
 };
 export type SpaceTimeCurve = {
@@ -4506,7 +4511,7 @@ export type StdcmRequest = {
     /** Speed limitation in m/s */
     speed_limit: number;
     /** Track ranges on which the speed limitation applies */
-    track_ranges: TrackRange[];
+    track_ranges: CoreTrackRange[];
   }[];
   /** Gap between the created train and following trains in milliseconds */
   time_gap_after: number;

--- a/front/src/modules/pathfinding/helpers/__tests__/findTrackSectionOffset.spec.ts
+++ b/front/src/modules/pathfinding/helpers/__tests__/findTrackSectionOffset.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import type { TrackRange } from 'common/api/osrdEditoastApi';
+import type { CoreTrackRange } from 'common/api/osrdEditoastApi';
 
 import findTrackSectionOffset from '../findTrackSectionOffset';
 
@@ -13,7 +13,7 @@ describe('findTrackSectionOffset', () => {
       { track_section: 'track_2', begin: 0, end: 1000, direction: 'START_TO_STOP' },
       { track_section: 'track_3' },
       { track_section: 'track_4' },
-    ] as TrackRange[];
+    ] as CoreTrackRange[];
 
     const offsetOnPath = 2060;
     const result = findTrackSectionOffset(
@@ -33,7 +33,7 @@ describe('findTrackSectionOffset', () => {
       { track_section: 'track_2', begin: 600, end: 1600, direction: 'START_TO_STOP' },
       { track_section: 'track_3' },
       { track_section: 'track_4' },
-    ] as TrackRange[];
+    ] as CoreTrackRange[];
 
     const offsetOnPath = 2300;
     const result = findTrackSectionOffset(
@@ -53,7 +53,7 @@ describe('findTrackSectionOffset', () => {
       { track_section: 'track_2', begin: 60, end: 1060, direction: 'STOP_TO_START' },
       { track_section: 'track_3' },
       { track_section: 'track_4' },
-    ] as TrackRange[];
+    ] as CoreTrackRange[];
 
     const offsetOnPath = 2010;
     const result = findTrackSectionOffset(
@@ -71,7 +71,7 @@ describe('findTrackSectionOffset', () => {
       { track_section: 'track_0' },
       { track_section: 'track_1' },
       { track_section: 'track_2' },
-    ] as TrackRange[];
+    ] as CoreTrackRange[];
 
     const offsetOnPath = 3001;
 
@@ -88,7 +88,7 @@ describe('findTrackSectionOffset', () => {
       { track_section: 'track_2', begin: 60, end: 1060, direction: 'STOP_TO_START' },
       { track_section: 'track_3' },
       { track_section: 'track_4' },
-    ] as TrackRange[];
+    ] as CoreTrackRange[];
 
     const offsetOnPath = 900;
     const result = findTrackSectionOffset(

--- a/front/src/modules/pathfinding/helpers/__tests__/getTrackLengthCumulativeSums.spec.ts
+++ b/front/src/modules/pathfinding/helpers/__tests__/getTrackLengthCumulativeSums.spec.ts
@@ -1,19 +1,19 @@
 import { describe, it, expect } from 'vitest';
 
-import type { TrackRange } from 'common/api/osrdEditoastApi';
+import type { CoreTrackRange } from 'common/api/osrdEditoastApi';
 
 import getTrackLengthCumulativeSums from '../getTrackLengthCumulativeSums';
 
 describe('getTrackLengthCumulativeSums', () => {
   it('should return empty array for an empty input', () => {
-    const trackRanges: TrackRange[] = [];
+    const trackRanges: CoreTrackRange[] = [];
 
     const result = getTrackLengthCumulativeSums(trackRanges);
     expect(result).toEqual([]);
   });
 
   it('should return the correct cumulative sums', () => {
-    const trackRanges: TrackRange[] = [
+    const trackRanges: CoreTrackRange[] = [
       { begin: 1000, end: 1500, direction: 'START_TO_STOP', track_section: 'a' },
       { begin: 0, end: 5000, direction: 'START_TO_STOP', track_section: 'b' },
     ];

--- a/front/src/modules/pathfinding/helpers/findTrackSectionOffset.ts
+++ b/front/src/modules/pathfinding/helpers/findTrackSectionOffset.ts
@@ -1,4 +1,4 @@
-import type { TrackRange } from 'common/api/osrdEditoastApi';
+import type { CoreTrackRange } from 'common/api/osrdEditoastApi';
 
 /**
  * Return the track offset corresponding to the given position on path, composed of the track section id
@@ -7,7 +7,7 @@ import type { TrackRange } from 'common/api/osrdEditoastApi';
 const findTrackSectionOffset = (
   positionOnPath: number, // in mm
   tracksLengthCumulativeSums: number[], // in mm
-  trackRangesOnPath: TrackRange[]
+  trackRangesOnPath: CoreTrackRange[]
 ) => {
   const index = tracksLengthCumulativeSums.findIndex(
     (cumulativeSum) => positionOnPath <= cumulativeSum

--- a/front/src/modules/pathfinding/helpers/getPointOnPathCoordinates.ts
+++ b/front/src/modules/pathfinding/helpers/getPointOnPathCoordinates.ts
@@ -1,6 +1,6 @@
 import type { Position } from 'geojson';
 
-import type { TrackRange, TrackSection } from 'common/api/osrdEditoastApi';
+import type { CoreTrackRange, TrackSection } from 'common/api/osrdEditoastApi';
 import { getPointOnTrackCoordinates } from 'utils/geometry';
 import { mToMm } from 'utils/physics';
 
@@ -12,7 +12,7 @@ import findTrackSectionOffset from './findTrackSectionOffset';
  */
 const getPointOnPathCoordinates = (
   tracks: Record<string, TrackSection>,
-  trackRanges: TrackRange[],
+  trackRanges: CoreTrackRange[],
   tracksLengthCumulativeSums: number[],
   positionOnPath: number
 ): Position => {

--- a/front/src/modules/pathfinding/helpers/getTrackLengthCumulativeSums.ts
+++ b/front/src/modules/pathfinding/helpers/getTrackLengthCumulativeSums.ts
@@ -1,9 +1,9 @@
-import type { TrackRange } from 'common/api/osrdEditoastApi';
+import type { CoreTrackRange } from 'common/api/osrdEditoastApi';
 
 /**
  * Given a list of track ranges, return the array of cumulative sums of the lengths of the track ranges.
  */
-const getTrackLengthCumulativeSums = (trackRanges: TrackRange[]): number[] => {
+const getTrackLengthCumulativeSums = (trackRanges: CoreTrackRange[]): number[] => {
   const results: number[] = [];
 
   trackRanges.forEach((range, index) => {


### PR DESCRIPTION
fix #12730
Rename core_client::pathfinding::TrackRange to CoreTrackRange and fix the frontend

- [x] Fix the conflict with simple rename solution

