### PR TITLE
editoast: remove 'locked' from RollingStockForm and TowedRollingStockForm in API

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -4026,7 +4026,13 @@ paths:
     post:
       tags:
       - rolling_stock
-      summary: Create a rolling stock
+      summary: Create a towed rolling stock
+      parameters:
+      - name: locked
+        in: query
+        required: false
+        schema:
+          type: boolean
       requestBody:
         content:
           application/json:
@@ -4058,7 +4064,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TowedRollingStock'
-    patch:
+    put:
       tags:
       - rolling_stock
       parameters:
@@ -4076,7 +4082,7 @@ paths:
         required: true
       responses:
         '200':
-          description: The created towed rolling stock
+          description: The modified towed rolling stock
           content:
             application/json:
               schema:
@@ -14140,7 +14146,6 @@ components:
       required:
       - name
       - label
-      - locked
       - mass
       - length
       - comfort_acceleration
@@ -14156,7 +14161,10 @@ components:
         const_gamma:
           type: number
           format: double
-          description: Acceleration in m·s⁻²
+          description: |-
+            The constant gamma braking coefficient used when NOT circulating
+            under ETCS/ERTMS signaling system
+            Acceleration in m·s⁻²
         inertia_coefficient:
           type: number
           format: double
@@ -14166,8 +14174,6 @@ components:
           type: number
           format: double
           description: Length in m
-        locked:
-          type: boolean
         mass:
           type: number
           format: double
@@ -14179,6 +14185,9 @@ components:
           nullable: true
         name:
           type: string
+        railjson_version:
+          type: string
+          default: '3.3'
         rolling_resistance:
           $ref: '#/components/schemas/RollingResistancePerWeight'
         startup_acceleration:

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -11886,10 +11886,6 @@ components:
           description: Length in m
         loading_gauge:
           $ref: '#/components/schemas/LoadingGaugeType'
-        locked:
-          type: boolean
-          description: 'Deprecated for openapi: overwritten by query-param'
-          default: false
         mass:
           type: number
           format: double

--- a/editoast/schemas/src/fixtures.rs
+++ b/editoast/schemas/src/fixtures.rs
@@ -27,6 +27,7 @@ use crate::rolling_stock::RollingStockSupportedSignalingSystems;
 use crate::rolling_stock::TowedRollingStock;
 use crate::rolling_stock::TrainMainCategories;
 use crate::rolling_stock::TrainMainCategory;
+use crate::rolling_stock::default_rolling_stock_railjson_version;
 use crate::train_schedule::Comfort;
 use crate::train_schedule::Distribution;
 use crate::train_schedule::MarginValue;
@@ -87,7 +88,7 @@ pub fn towed_rolling_stock() -> TowedRollingStock {
         },
         const_gamma: units::meter_per_second_squared::new(0.5),
         max_speed: Some(units::meter_per_second::new(35.0)),
-        railjson_version: "3.4".to_string(),
+        railjson_version: default_rolling_stock_railjson_version(),
     }
 }
 

--- a/editoast/schemas/src/fixtures.rs
+++ b/editoast/schemas/src/fixtures.rs
@@ -49,7 +49,6 @@ pub fn simple_rolling_stock() -> RollingStock {
         energy_sources: vec![],
         const_gamma: units::meter_per_second_squared::new(1.0),
         etcs_brake_params: None,
-        locked: false,
         metadata: None,
         power_restrictions: HashMap::new(),
         railjson_version: "12".to_string(),

--- a/editoast/schemas/src/rolling_stock.rs
+++ b/editoast/schemas/src/rolling_stock.rs
@@ -72,12 +72,6 @@ fn default_rolling_stock_railjson_version() -> String {
 #[schema(as = RollingStockForm)]
 pub struct RollingStock {
     pub name: String,
-    /// Deprecated for openapi: overwritten by query-param
-    // TODO: stop exposing this param (keep only query-param)
-    // Remove it completely from the struct if possible
-    #[schema(default = false)]
-    #[serde(default)]
-    pub locked: bool,
     pub effort_curves: EffortCurves,
     #[schema(example = "5", required)]
     pub base_power_class: Option<String>,

--- a/editoast/schemas/src/rolling_stock.rs
+++ b/editoast/schemas/src/rolling_stock.rs
@@ -61,7 +61,7 @@ use utoipa::ToSchema;
 
 pub const ROLLING_STOCK_RAILJSON_VERSION: &str = "3.3";
 
-fn default_rolling_stock_railjson_version() -> String {
+pub fn default_rolling_stock_railjson_version() -> String {
     ROLLING_STOCK_RAILJSON_VERSION.to_string()
 }
 

--- a/editoast/schemas/src/rolling_stock/towed_rolling_stock.rs
+++ b/editoast/schemas/src/rolling_stock/towed_rolling_stock.rs
@@ -1,3 +1,5 @@
+use crate::rolling_stock::default_rolling_stock_railjson_version;
+
 use super::RollingResistancePerWeight;
 use common::units;
 use common::units::quantities::Acceleration;
@@ -6,10 +8,15 @@ use common::units::quantities::Length;
 use common::units::quantities::Mass;
 use common::units::quantities::Velocity;
 
-#[derive(Debug, Clone, PartialEq, serde::Deserialize, serde::Serialize)]
+#[editoast_derive::openapi_schema]
+#[editoast_derive::annotate_units]
+#[derive(Debug, Clone, PartialEq, serde::Deserialize, serde::Serialize, utoipa::ToSchema)]
+#[schema(as = TowedRollingStockForm)]
 pub struct TowedRollingStock {
     pub name: String,
     pub label: String,
+    #[schema(default = default_rolling_stock_railjson_version)]
+    #[serde(default = "default_rolling_stock_railjson_version")]
     pub railjson_version: String,
     #[serde(with = "units::kilogram")]
     pub mass: Mass,

--- a/editoast/src/models/fixtures.rs
+++ b/editoast/src/models/fixtures.rs
@@ -355,6 +355,7 @@ pub fn fast_rolling_stock_changeset(name: &str) -> Changeset<RollingStock> {
         .expect("Unable to parse example rolling stock"),
     )
     .name(name.to_owned())
+    .locked(false)
     .version(0)
 }
 
@@ -373,6 +374,7 @@ pub fn rolling_stock_with_energy_sources_changeset(name: &str) -> Changeset<Roll
         .expect("Unable to parse rolling stock with energy sources"),
     )
     .name(name.to_owned())
+    .locked(false)
     .version(1)
 }
 

--- a/editoast/src/models/rolling_stock.rs
+++ b/editoast/src/models/rolling_stock.rs
@@ -135,7 +135,6 @@ impl From<RollingStock> for schemas::RollingStock {
     fn from(rolling_stock: RollingStock) -> Self {
         schemas::RollingStock {
             railjson_version: rolling_stock.railjson_version,
-            locked: rolling_stock.locked,
             metadata: rolling_stock.metadata,
             name: rolling_stock.name,
             effort_curves: rolling_stock.effort_curves,
@@ -172,7 +171,6 @@ impl From<schemas::RollingStock> for RollingStockChangeset {
     fn from(rolling_stock: schemas::RollingStock) -> Self {
         RollingStock::changeset()
             .railjson_version(rolling_stock.railjson_version)
-            .locked(rolling_stock.locked)
             .metadata(rolling_stock.metadata)
             .name(rolling_stock.name)
             .effort_curves(rolling_stock.effort_curves)

--- a/editoast/src/tests/example_rolling_stock_1.json
+++ b/editoast/src/tests/example_rolling_stock_1.json
@@ -1,6 +1,5 @@
 {
     "railjson_version": "3.3",
-    "locked": false,
     "length": 400.0,
     "max_speed": 80.0,
     "startup_time": 10.0,

--- a/editoast/src/tests/example_rolling_stock_2_energy_sources.json
+++ b/editoast/src/tests/example_rolling_stock_2_energy_sources.json
@@ -1,6 +1,5 @@
 {
     "railjson_version": "3.3",
-    "locked": false,
     "length": 200.0,
     "max_speed": 40.0,
     "startup_time": 5.0,

--- a/editoast/src/tests/example_rolling_stock_3.json
+++ b/editoast/src/tests/example_rolling_stock_3.json
@@ -1,7 +1,6 @@
 {
     "railjson_version": "3.3",
     "version": 0,
-    "locked": false,
     "length": 200.0,
     "max_speed": 40.0,
     "startup_time": 5.0,

--- a/editoast/src/tests/example_towed_rolling_stock_1.json
+++ b/editoast/src/tests/example_towed_rolling_stock_1.json
@@ -2,7 +2,6 @@
     "name": "towed_rolling_stock",
     "label": "some towed rolling stock",
     "railjson_version": "3.3",
-    "locked": false,
     "mass": 900000.0,
     "length": 400.0,
     "comfort_acceleration": 0.25,

--- a/editoast/src/tests/example_towed_rolling_stock_1.json
+++ b/editoast/src/tests/example_towed_rolling_stock_1.json
@@ -1,4 +1,3 @@
-
 {
     "name": "towed_rolling_stock",
     "label": "some towed rolling stock",

--- a/editoast/src/tests/small_infra/stdcm/test_1/stdcm_core_payload.json
+++ b/editoast/src/tests/small_infra/stdcm/test_1/stdcm_core_payload.json
@@ -5,7 +5,6 @@
     "id": 899,
     "name": "TC64700",
     "version": "3.3",
-    "locked": true,
     "effort_curves": {
       "modes": {
         "thermal": {

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -368,7 +368,7 @@ fn service_router() -> router::DocumentedRouter {
                     .route("/", post!(rolling_stock::towed::post))
                     .nests("/{towed_rolling_stock_id}", |path| {
                         path.route("/", get!(rolling_stock::towed::get_by_id))
-                            .route("/", patch!(rolling_stock::towed::patch_by_id))
+                            .route("/", put!(rolling_stock::towed::put_by_id))
                             .route("/locked", patch!(rolling_stock::towed::patch_by_id_locked))
                     })
             })

--- a/editoast/src/views/rolling_stock/towed.rs
+++ b/editoast/src/views/rolling_stock/towed.rs
@@ -14,25 +14,18 @@ use axum::extract::Path;
 use axum::extract::Query;
 use axum::extract::State;
 use axum::http::StatusCode;
-use common::units;
-use common::units::quantities::Acceleration;
-use common::units::quantities::Deceleration;
-use common::units::quantities::Length;
-use common::units::quantities::Mass;
-use common::units::quantities::Velocity;
 use database::DbConnectionPoolV2;
 use diesel_async::scoped_futures::ScopedFutureExt as _;
 use editoast_derive::EditoastError;
 use editoast_models::TowedRollingStock;
 use editoast_models::prelude::*;
-use editoast_models::towed_rolling_stock::TowedRollingStockChangeset;
-use schemas::rolling_stock::ROLLING_STOCK_RAILJSON_VERSION;
-use schemas::rolling_stock::RollingResistancePerWeight;
 use serde::Deserialize;
 use serde::Serialize;
 use thiserror::Error;
 use utoipa::IntoParams;
 use utoipa::ToSchema;
+
+use schemas::TowedRollingStock as TowedRollingStockForm;
 
 #[derive(Debug, Error, EditoastError)]
 #[editoast_error(base_id = "towedrollingstocks")]
@@ -49,54 +42,19 @@ pub enum TowedRollingStockError {
     #[editoast_error(status = 500)]
     Database(#[from] editoast_models::Error),
 }
-
-#[editoast_derive::openapi_schema]
-#[editoast_derive::annotate_units]
-#[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
-pub struct TowedRollingStockForm {
-    pub name: String,
-    pub label: String,
-    pub locked: bool,
-
-    #[serde(with = "units::kilogram")]
-    pub mass: Mass,
-    #[serde(with = "units::meter")]
-    pub length: Length,
-    #[serde(with = "units::meter_per_second_squared")]
-    pub comfort_acceleration: Acceleration,
-    #[serde(with = "units::meter_per_second_squared")]
-    pub startup_acceleration: Acceleration,
-    pub inertia_coefficient: f64,
-    pub rolling_resistance: RollingResistancePerWeight,
-    #[serde(with = "units::meter_per_second_squared")]
-    pub const_gamma: Deceleration,
-    #[serde(default, with = "units::meter_per_second::option")]
-    pub max_speed: Option<Velocity>,
+#[derive(Debug, Deserialize, IntoParams, ToSchema)]
+#[into_params(parameter_in = Query)]
+pub(in crate::views) struct PostTowedRollingStockQueryParams {
+    #[serde(default)]
+    locked: bool,
 }
 
-impl From<TowedRollingStockForm> for TowedRollingStockChangeset {
-    fn from(towed_rolling_stock_form: TowedRollingStockForm) -> Self {
-        TowedRollingStock::changeset()
-            .railjson_version(ROLLING_STOCK_RAILJSON_VERSION.to_string())
-            .name(towed_rolling_stock_form.name)
-            .label(towed_rolling_stock_form.label)
-            .locked(towed_rolling_stock_form.locked)
-            .mass(towed_rolling_stock_form.mass)
-            .length(towed_rolling_stock_form.length)
-            .comfort_acceleration(towed_rolling_stock_form.comfort_acceleration)
-            .startup_acceleration(towed_rolling_stock_form.startup_acceleration)
-            .inertia_coefficient(towed_rolling_stock_form.inertia_coefficient)
-            .rolling_resistance(towed_rolling_stock_form.rolling_resistance)
-            .const_gamma(towed_rolling_stock_form.const_gamma)
-            .max_speed(towed_rolling_stock_form.max_speed)
-    }
-}
-
-/// Create a rolling stock
+/// Create a towed rolling stock
 #[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "rolling_stock",
+    params(PostTowedRollingStockQueryParams),
     request_body = TowedRollingStockForm,
     responses(
         (status = 200, description = "The created towed rolling stock", body = TowedRollingStock)
@@ -105,6 +63,7 @@ impl From<TowedRollingStockForm> for TowedRollingStockChangeset {
 pub(in crate::views) async fn post(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
     Extension(auth): AuthenticationExt,
+    Query(query_params): Query<PostTowedRollingStockQueryParams>,
     Json(towed_rolling_stock_form): Json<TowedRollingStockForm>,
 ) -> Result<Json<TowedRollingStock>> {
     let authorized = auth
@@ -117,7 +76,11 @@ pub(in crate::views) async fn post(
     let conn = &mut db_pool.get().await?;
     let rolling_stock_changeset: Changeset<TowedRollingStock> = towed_rolling_stock_form.into();
 
-    let rolling_stock = rolling_stock_changeset.version(0).create(conn).await?;
+    let rolling_stock = rolling_stock_changeset
+        .locked(query_params.locked)
+        .version(0)
+        .create(conn)
+        .await?;
 
     Ok(Json(rolling_stock))
 }
@@ -205,15 +168,15 @@ pub(in crate::views) async fn get_by_id(
 
 #[editoast_derive::route]
 #[utoipa::path(
-    patch, path = "",
+    put, path = "",
     tag = "rolling_stock",
     params(TowedRollingStockIdParam),
     request_body = TowedRollingStockForm,
     responses(
-        (status = 200, description = "The created towed rolling stock", body = TowedRollingStock)
+        (status = 200, description = "The modified towed rolling stock", body = TowedRollingStock)
     )
 )]
-pub(in crate::views) async fn patch_by_id(
+pub(in crate::views) async fn put_by_id(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
     Extension(auth): AuthenticationExt,
     Path(TowedRollingStockIdParam {
@@ -250,19 +213,21 @@ pub(in crate::views) async fn patch_by_id(
                     .into());
                 }
 
-                let mut new_towed_rolling_stock =
-                    Changeset::<TowedRollingStock>::from(towed_rolling_stock_form)
+                if towed_rolling_stock_form != existing_rolling_stock.clone().into() {
+                    let mut towed_rolling_stock_changeset: Changeset<TowedRollingStock> =
+                        towed_rolling_stock_form.clone().into();
+                    towed_rolling_stock_changeset.version =
+                        Some(&existing_rolling_stock.version + 1);
+                    let new_towed_rolling_stock = towed_rolling_stock_changeset
                         .update(&mut conn.clone(), towed_rolling_stock_id)
                         .await?
                         .ok_or(TowedRollingStockError::IdNotFound {
                             towed_rolling_stock_id,
                         })?;
-
-                if new_towed_rolling_stock != existing_rolling_stock {
-                    new_towed_rolling_stock.version += 1;
-                    new_towed_rolling_stock.save(&mut conn.clone()).await?;
+                    Ok(new_towed_rolling_stock)
+                } else {
+                    Ok(existing_rolling_stock)
                 }
-                Ok(new_towed_rolling_stock)
             }
             .scope_boxed()
         })
@@ -353,6 +318,7 @@ mod tests {
 
         let request = app
             .post("/towed_rolling_stock")
+            .add_query_param("locked", locked)
             .json(&towed_rolling_stock_json);
 
         app.fetch(request).assert_status(StatusCode::OK).json_into()
@@ -419,7 +385,7 @@ mod tests {
 
         let id: i64 = rand::random(); // <-- doesn't exist
         app.fetch(
-            app.patch(&format!("/towed_rolling_stock/{id}"))
+            app.put(&format!("/towed_rolling_stock/{id}"))
                 .json(&towed_rolling_stock),
         )
         .assert_status(StatusCode::NOT_FOUND);
@@ -436,7 +402,7 @@ mod tests {
         towed_rolling_stock.mass = units::kilogram::new(13000.0);
         let updated_towed_rolling_stock: TowedRollingStock = app
             .fetch(
-                app.patch(&format!("/towed_rolling_stock/{id}"))
+                app.put(&format!("/towed_rolling_stock/{id}"))
                     .json(&towed_rolling_stock),
             )
             .assert_status(StatusCode::OK)
@@ -471,7 +437,7 @@ mod tests {
         let id = towed_rolling_stock.id;
         towed_rolling_stock.mass = units::kilogram::new(13000.0);
         app.fetch(
-            app.patch(&format!("/towed_rolling_stock/{id}"))
+            app.put(&format!("/towed_rolling_stock/{id}"))
                 .json(&towed_rolling_stock),
         )
         .assert_status(StatusCode::CONFLICT);
@@ -492,7 +458,7 @@ mod tests {
         )
         .assert_status(StatusCode::NO_CONTENT);
         app.fetch(
-            app.patch(&format!("/towed_rolling_stock/{id}"))
+            app.put(&format!("/towed_rolling_stock/{id}"))
                 .json(&towed_rolling_stock),
         )
         .assert_status(StatusCode::OK);

--- a/front/public/locales/en/translation.json
+++ b/front/public/locales/en/translation.json
@@ -731,7 +731,7 @@
     },
     "export": "Export",
     "exportRollingStock": "Export rolling stock",
-    "import": "Import rolling stock",
+    "importRollingStock": "Import rolling stock",
     "inertiaCoefficient": "Factor of inertia",
     "length": "Length",
     "listDisabled": "Please quit edit mode to access the list",

--- a/front/public/locales/fr/translation.json
+++ b/front/public/locales/fr/translation.json
@@ -731,7 +731,7 @@
     },
     "export": "Exporter",
     "exportRollingStock": "Exporter le matériel roulant",
-    "import": "Importer un matériel roulant",
+    "importRollingStock": "Importer un matériel roulant",
     "inertiaCoefficient": "Coefficient d'inertie",
     "length": "Longueur",
     "listDisabled": "Veuillez quitter l'éditeur pour modifier la sélection",

--- a/front/src/applications/rollingStockEditor/components/RollingStockEditorForm.tsx
+++ b/front/src/applications/rollingStockEditor/components/RollingStockEditorForm.tsx
@@ -304,12 +304,12 @@ const RollingStockEditorForm = ({
         <button
           type="button"
           className="d-flex justify-content-start mb-2 py-1 px-2"
-          aria-label={t('rollingStock.import')}
-          title={t('rollingStock.import')}
+          aria-label={t('rollingStock.importRollingStock')}
+          title={t('rollingStock.importRollingStock')}
           onClick={() => openModal(<UploadFileModal handleSubmit={importFile} />)}
         >
           <Upload className="mr-2" />
-          {t('rollingStock.import')}
+          {t('rollingStock.importRollingStock')}
         </button>
         <Tabs pills fullWidth tabs={[tabRollingStockDetails, tabRollingStockCurves]} />
       </div>

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -1169,6 +1169,9 @@ const injectedRtkApi = api
           url: `/towed_rolling_stock`,
           method: 'POST',
           body: queryArg.towedRollingStockForm,
+          params: {
+            locked: queryArg.locked,
+          },
         }),
         invalidatesTags: ['rolling_stock'],
       }),
@@ -1179,13 +1182,13 @@ const injectedRtkApi = api
         query: (queryArg) => ({ url: `/towed_rolling_stock/${queryArg.towedRollingStockId}` }),
         providesTags: ['rolling_stock'],
       }),
-      patchTowedRollingStockByTowedRollingStockId: build.mutation<
-        PatchTowedRollingStockByTowedRollingStockIdApiResponse,
-        PatchTowedRollingStockByTowedRollingStockIdApiArg
+      putTowedRollingStockByTowedRollingStockId: build.mutation<
+        PutTowedRollingStockByTowedRollingStockIdApiResponse,
+        PutTowedRollingStockByTowedRollingStockIdApiArg
       >({
         query: (queryArg) => ({
           url: `/towed_rolling_stock/${queryArg.towedRollingStockId}`,
-          method: 'PATCH',
+          method: 'PUT',
           body: queryArg.towedRollingStockForm,
         }),
         invalidatesTags: ['rolling_stock'],
@@ -2385,6 +2388,7 @@ export type GetTowedRollingStockApiArg = {
 export type PostTowedRollingStockApiResponse =
   /** status 200 The created towed rolling stock */ TowedRollingStock;
 export type PostTowedRollingStockApiArg = {
+  locked?: boolean;
   towedRollingStockForm: TowedRollingStockForm;
 };
 export type GetTowedRollingStockByTowedRollingStockIdApiResponse =
@@ -2392,9 +2396,9 @@ export type GetTowedRollingStockByTowedRollingStockIdApiResponse =
 export type GetTowedRollingStockByTowedRollingStockIdApiArg = {
   towedRollingStockId: number;
 };
-export type PatchTowedRollingStockByTowedRollingStockIdApiResponse =
-  /** status 200 The created towed rolling stock */ TowedRollingStock;
-export type PatchTowedRollingStockByTowedRollingStockIdApiArg = {
+export type PutTowedRollingStockByTowedRollingStockIdApiResponse =
+  /** status 200 The modified towed rolling stock */ TowedRollingStock;
+export type PutTowedRollingStockByTowedRollingStockIdApiArg = {
   towedRollingStockId: number;
   towedRollingStockForm: TowedRollingStockForm;
 };
@@ -4577,18 +4581,20 @@ export type TowedRollingStock = {
 export type TowedRollingStockForm = {
   /** Acceleration in m·s⁻² */
   comfort_acceleration: number;
-  /** Acceleration in m·s⁻² */
+  /** The constant gamma braking coefficient used when NOT circulating
+    under ETCS/ERTMS signaling system
+    Acceleration in m·s⁻² */
   const_gamma: number;
   inertia_coefficient: number;
   label: string;
   /** Length in m */
   length: number;
-  locked: boolean;
   /** Mass in kg */
   mass: number;
   /** Velocity in m·s⁻¹ */
   max_speed?: number | null;
   name: string;
+  railjson_version?: string;
   rolling_resistance: RollingResistancePerWeight;
   /** Acceleration in m·s⁻² */
   startup_acceleration: number;

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -4198,8 +4198,6 @@ export type RollingStockForm = {
   /** Length in m */
   length: number;
   loading_gauge: LoadingGaugeType;
-  /** Deprecated for openapi: overwritten by query-param */
-  locked?: boolean;
   /** Mass in kg */
   mass: number;
   /** Velocity in m·s⁻¹ */

--- a/front/tests/assets/rolling-stock/dual-mode_rolling_stock.json
+++ b/front/tests/assets/rolling-stock/dual-mode_rolling_stock.json
@@ -435,7 +435,6 @@
     "C1": "3"
   },
   "energy_sources": [],
-  "locked": false,
   "electrical_power_startup_time": 6.0,
   "raise_pantograph_time": 16.0,
   "version": 1,

--- a/front/tests/assets/rolling-stock/fast_rolling_stock.json
+++ b/front/tests/assets/rolling-stock/fast_rolling_stock.json
@@ -111,7 +111,6 @@
   "loading_gauge": "G1",
   "power_restrictions": {},
   "energy_sources": [],
-  "locked": false,
   "electrical_power_startup_time": null,
   "raise_pantograph_time": null,
   "version": 1,

--- a/front/tests/assets/rolling-stock/improbable_rolling_stock.json
+++ b/front/tests/assets/rolling-stock/improbable_rolling_stock.json
@@ -933,7 +933,6 @@
     "C1": "1"
   },
   "energy_sources": [],
-  "locked": false,
   "electrical_power_startup_time": 5.0,
   "raise_pantograph_time": 15.0,
   "version": 0,

--- a/front/tests/assets/rolling-stock/slow_rolling_stock.json
+++ b/front/tests/assets/rolling-stock/slow_rolling_stock.json
@@ -70,7 +70,6 @@
   "loading_gauge": "G2",
   "power_restrictions": {},
   "energy_sources": [],
-  "locked": false,
   "electrical_power_startup_time": null,
   "raise_pantograph_time": null,
   "version": 1,

--- a/front/tests/assets/stdcm/towed-rolling-stock/towed-rolling-stock.json
+++ b/front/tests/assets/stdcm/towed-rolling-stock/towed-rolling-stock.json
@@ -2,7 +2,6 @@
   "name": "TOWED-TEST-E2E",
   "label": "",
   "railjson_version": "3.3",
-  "locked": true,
   "mass": 46000.0,
   "length": 26.4,
   "comfort_acceleration": 0.2,

--- a/front/tests/assets/stdcm/towed-rolling-stock/towed-rolling-stock.json
+++ b/front/tests/assets/stdcm/towed-rolling-stock/towed-rolling-stock.json
@@ -1,7 +1,7 @@
 {
   "name": "TOWED-TEST-E2E",
   "label": "",
-  "railjson_version": "3.2",
+  "railjson_version": "3.3",
   "locked": true,
   "mass": 46000.0,
   "length": 26.4,

--- a/python/osrd_schemas/osrd_schemas/rolling_stock.py
+++ b/python/osrd_schemas/osrd_schemas/rolling_stock.py
@@ -364,10 +364,6 @@ class TowedRollingStock(BaseModel, extra="forbid"):
     railjson_version: RAILJSON_ROLLING_STOCK_VERSION_TYPE = Field(
         default=RAILJSON_ROLLING_STOCK_VERSION
     )
-    locked: bool = Field(
-        default=False,
-        description="Whether the rolling stock can be edited/deleted or not",
-    )
     mass: NonNegativeFloat = Field(description="The mass of the train, in kg")
     length: NonNegativeFloat = Field(description="The length of the train, in m")
     max_speed: Optional[NonNegativeFloat] = Field(

--- a/python/osrd_schemas/osrd_schemas/rolling_stock.py
+++ b/python/osrd_schemas/osrd_schemas/rolling_stock.py
@@ -294,10 +294,6 @@ class RollingStock(BaseModel, extra="forbid"):
         default=RAILJSON_ROLLING_STOCK_VERSION
     )
     name: str = Field(max_length=255)
-    locked: bool = Field(
-        default=False,
-        description="Whether the rolling stock can be edited/deleted or not",
-    )
     effort_curves: EffortCurves = Field(
         description="Curves mapping speed (in m/s) to maximum traction (in newtons)"
     )

--- a/python/osrd_schemas/pyproject.toml
+++ b/python/osrd_schemas/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "osrd_schemas"
-version = "0.8.19"
+version = "0.9.0"
 description = ""
 authors = [{ name = "OSRD Contributors", email = "contact@osrd.fr" }]
 requires-python = ">= 3.11"

--- a/python/osrd_schemas/uv.lock
+++ b/python/osrd_schemas/uv.lock
@@ -34,7 +34,7 @@ wheels = [
 
 [[package]]
 name = "osrd-schemas"
-version = "0.8.19"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "geojson-pydantic" },

--- a/python/railjson_generator/uv.lock
+++ b/python/railjson_generator/uv.lock
@@ -106,7 +106,7 @@ wheels = [
 
 [[package]]
 name = "osrd-schemas"
-version = "0.8.18"
+version = "0.9.0"
 source = { editable = "../osrd_schemas" }
 dependencies = [
     { name = "geojson-pydantic" },

--- a/tests/data/rolling_stocks/electric_rolling_stock.json
+++ b/tests/data/rolling_stocks/electric_rolling_stock.json
@@ -1,6 +1,5 @@
 {
   "railjson_version": "3.3",
-  "locked": true,
   "length": 400,
   "max_speed": 80,
   "startup_time": 10,

--- a/tests/data/rolling_stocks/etcs_level2_rolling_stock.json
+++ b/tests/data/rolling_stocks/etcs_level2_rolling_stock.json
@@ -1,6 +1,5 @@
 {
   "railjson_version": "3.3",
-  "locked": true,
   "length": 400,
   "max_speed": 80,
   "startup_time": 10,

--- a/tests/data/rolling_stocks/fast_rolling_stock.json
+++ b/tests/data/rolling_stocks/fast_rolling_stock.json
@@ -1,6 +1,5 @@
 {
   "railjson_version": "3.3",
-  "locked": true,
   "length": 400,
   "max_speed": 80,
   "startup_time": 10,

--- a/tests/data/rolling_stocks/fast_rolling_stock_high_gamma.json
+++ b/tests/data/rolling_stocks/fast_rolling_stock_high_gamma.json
@@ -1,6 +1,5 @@
 {
   "railjson_version": "3.3",
-  "locked": true,
   "length": 400,
   "max_speed": 80,
   "startup_time": 10,

--- a/tests/data/rolling_stocks/realistic/commuter-train.json
+++ b/tests/data/rolling_stocks/realistic/commuter-train.json
@@ -158,7 +158,6 @@
   "loading_gauge": "G1",
   "power_restrictions": {},
   "energy_sources": [],
-  "locked": false,
   "electrical_power_startup_time": 5.0,
   "raise_pantograph_time": 25.0,
   "version": 0,

--- a/tests/data/rolling_stocks/realistic/d-tram-train.json
+++ b/tests/data/rolling_stocks/realistic/d-tram-train.json
@@ -140,7 +140,6 @@
   "loading_gauge": "G1",
   "power_restrictions": {},
   "energy_sources": [],
-  "locked": false,
   "electrical_power_startup_time": 5.0,
   "raise_pantograph_time": 25.0,
   "version": 0,

--- a/tests/data/rolling_stocks/realistic/dmu-regional-train.json
+++ b/tests/data/rolling_stocks/realistic/dmu-regional-train.json
@@ -97,7 +97,6 @@
   "loading_gauge": "G1",
   "power_restrictions": {},
   "energy_sources": [],
-  "locked": false,
   "electrical_power_startup_time": null,
   "raise_pantograph_time": null,
   "version": 0,

--- a/tests/data/rolling_stocks/realistic/e-tram-train.json
+++ b/tests/data/rolling_stocks/realistic/e-tram-train.json
@@ -140,7 +140,6 @@
   "loading_gauge": "G1",
   "power_restrictions": {},
   "energy_sources": [],
-  "locked": false,
   "electrical_power_startup_time": 5.0,
   "raise_pantograph_time": 25.0,
   "version": 0,

--- a/tests/data/rolling_stocks/realistic/emu-regional-train.json
+++ b/tests/data/rolling_stocks/realistic/emu-regional-train.json
@@ -158,7 +158,6 @@
   "loading_gauge": "G1",
   "power_restrictions": {},
   "energy_sources": [],
-  "locked": false,
   "electrical_power_startup_time": 5.0,
   "raise_pantograph_time": 25.0,
   "version": 0,

--- a/tests/data/rolling_stocks/realistic/freight-train.json
+++ b/tests/data/rolling_stocks/realistic/freight-train.json
@@ -219,7 +219,6 @@
   "loading_gauge": "G1",
   "power_restrictions": {},
   "energy_sources": [],
-  "locked": false,
   "electrical_power_startup_time": 5.0,
   "raise_pantograph_time": 25.0,
   "version": 0,

--- a/tests/data/rolling_stocks/realistic/high-speed-train.json
+++ b/tests/data/rolling_stocks/realistic/high-speed-train.json
@@ -191,7 +191,6 @@
   "loading_gauge": "FR3.3",
   "power_restrictions": {},
   "energy_sources": [],
-  "locked": false,
   "electrical_power_startup_time": 5.0,
   "raise_pantograph_time": 25.0,
   "version": 0,

--- a/tests/data/rolling_stocks/realistic/intercity-train.json
+++ b/tests/data/rolling_stocks/realistic/intercity-train.json
@@ -170,7 +170,6 @@
   "loading_gauge": "G1",
   "power_restrictions": {},
   "energy_sources": [],
-  "locked": false,
   "electrical_power_startup_time": 5.0,
   "raise_pantograph_time": 25.0,
   "version": 0,

--- a/tests/data/rolling_stocks/realistic/light-freight-train.json
+++ b/tests/data/rolling_stocks/realistic/light-freight-train.json
@@ -91,7 +91,6 @@
   "loading_gauge": "G1",
   "power_restrictions": {},
   "energy_sources": [],
-  "locked": false,
   "electrical_power_startup_time": null,
   "raise_pantograph_time": null,
   "version": 0,

--- a/tests/data/rolling_stocks/realistic/night-train.json
+++ b/tests/data/rolling_stocks/realistic/night-train.json
@@ -170,7 +170,6 @@
   "loading_gauge": "G1",
   "power_restrictions": {},
   "energy_sources": [],
-  "locked": false,
   "electrical_power_startup_time": 5.0,
   "raise_pantograph_time": 25.0,
   "version": 0,

--- a/tests/data/rolling_stocks/realistic/touristic-train.json
+++ b/tests/data/rolling_stocks/realistic/touristic-train.json
@@ -83,7 +83,6 @@
   "loading_gauge": "G1",
   "power_restrictions": {},
   "energy_sources": [],
-  "locked": false,
   "electrical_power_startup_time": null,
   "raise_pantograph_time": null,
   "version": 0,

--- a/tests/data/rolling_stocks/short_fast_rolling_stock.json
+++ b/tests/data/rolling_stocks/short_fast_rolling_stock.json
@@ -1,6 +1,5 @@
 {
   "railjson_version": "3.3",
-  "locked": true,
   "length": 15,
   "max_speed": 20,
   "startup_time": 10,

--- a/tests/data/rolling_stocks/short_slow_rolling_stock.json
+++ b/tests/data/rolling_stocks/short_slow_rolling_stock.json
@@ -1,6 +1,5 @@
 {
   "railjson_version": "3.3",
-  "locked": true,
   "length": 15,
   "max_speed": 10,
   "startup_time": 10,

--- a/tests/data/rolling_stocks/slow_rolling_stock.json
+++ b/tests/data/rolling_stocks/slow_rolling_stock.json
@@ -1,6 +1,5 @@
 {
   "railjson_version": "3.3",
-  "locked": true,
   "length": 400,
   "max_speed": 10,
   "startup_time": 10,

--- a/tests/uv.lock
+++ b/tests/uv.lock
@@ -182,7 +182,7 @@ wheels = [
 
 [[package]]
 name = "osrd-schemas"
-version = "0.8.18"
+version = "0.9.0"
 source = { editable = "../python/osrd_schemas" }
 dependencies = [
     { name = "geojson-pydantic" },


### PR DESCRIPTION
On top of https://github.com/OpenRailAssociation/osrd/pull/12904 (current one will be merged into the other PR, then all in `dev`).

Actually start using `schemas::TowedRollingStock` in place of `TowedRollingStockForm`.
'locked' is actually removed from editoast-schemas.
Add a 'locked' query-param to TowedRollingStock's creation (POST), to make it consistent with RollingStock's creation (used the same way by clients).

* no bump of rolling-stock railjson version (probably would be super neet to bump, but as we own the clients, it's OK to let it as-is)
* bump osrd-schemas version to  `0.9.0`
* update test fixtures
* modify osrd-schemas accordingly

Note: no digging into removing 'locked' field from `models::RollingStock` (output), nor from `LightRollingStock` (the front is most probably using it to filter/block edition).

🔍 please review by commit with message