### PR TITLE
editoast: add path_item_positions to simulation_summary endpoint

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -13094,6 +13094,7 @@ components:
         - path_item_times_final
         - path_item_times_provisional
         - path_item_times_base
+        - path_item_positions
         - status
         properties:
           energy_consumption:
@@ -13105,6 +13106,15 @@ components:
             format: int64
             description: Length of a path in mm
             minimum: 0
+          path_item_positions:
+            type: array
+            items:
+              type: integer
+              format: int64
+              minimum: 0
+            description: |-
+              The path offset in mm of each path item given as input of the pathfinding
+              The first value is always `0` (beginning of the path) and the last one is always equal to the `length` of the path in mm
           path_item_times_base:
             type: array
             items:

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -330,14 +330,17 @@ pub(in crate::views) async fn simulation_summary(
     let mut base_simulation = Arc::clone(&simulations[0].0);
     let results = simulation_contexts.into_iter().zip(simulations).fold(
         HashMap::<i64, PacedTrainSummaryResponse>::new(),
-        |mut map, (simulation_context, (simulation, _))| {
+        |mut map, (simulation_context, (simulation, path))| {
             if let Some(exception_key) = &simulation_context.exception_key {
                 if !Arc::ptr_eq(&base_simulation, &simulation) {
                     map.entry(simulation_context.paced_train_id)
                         .and_modify(|summary| {
                             summary.exceptions.insert(
                                 exception_key.to_string(),
-                                SummaryResponse::from(simulation.as_ref().clone()),
+                                SummaryResponse::summarize_simulation(
+                                    Arc::unwrap_or_clone(simulation),
+                                    Arc::unwrap_or_clone(path),
+                                ),
                             );
                         });
                 }
@@ -346,7 +349,10 @@ pub(in crate::views) async fn simulation_summary(
                 map.insert(
                     simulation_context.paced_train_id,
                     PacedTrainSummaryResponse {
-                        paced_train: SummaryResponse::from(Arc::unwrap_or_clone(simulation)),
+                        paced_train: SummaryResponse::summarize_simulation(
+                            Arc::unwrap_or_clone(simulation),
+                            Arc::unwrap_or_clone(path),
+                        ),
                         exceptions: HashMap::new(),
                     },
                 );
@@ -1537,7 +1543,8 @@ mod tests {
                     energy_consumption: 0.0,
                     path_item_times_final: vec![0, 1000, 2000, 3000],
                     path_item_times_provisional: vec![0, 1000, 2000, 3000],
-                    path_item_times_base: vec![0, 1000, 2000, 3000]
+                    path_item_times_base: vec![0, 1000, 2000, 3000],
+                    path_item_positions: vec![0, 1, 2, 3]
                 },
                 exceptions: [(
                     "change_initial_speed".to_string(),
@@ -1549,7 +1556,8 @@ mod tests {
                         energy_consumption: 0.0,
                         path_item_times_final: vec![0, 1000, 2000, 3000],
                         path_item_times_provisional: vec![0, 1000, 2000, 3000],
-                        path_item_times_base: vec![0, 1000, 2000, 3000]
+                        path_item_times_base: vec![0, 1000, 2000, 3000],
+                        path_item_positions: vec![0, 1, 2, 3]
                     }
                 )]
                 .into_iter()

--- a/editoast/src/views/timetable/simulation.rs
+++ b/editoast/src/views/timetable/simulation.rs
@@ -144,6 +144,9 @@ pub enum SummaryResponse {
         /// Base simulation time for each train schedule path item.
         /// The first value is always `0` (beginning of the path) and the last one, the total time of the simulation (end of the path)
         path_item_times_base: Vec<u64>,
+        /// The path offset in mm of each path item given as input of the pathfinding
+        /// The first value is always `0` (beginning of the path) and the last one is always equal to the `length` of the path in mm
+        path_item_positions: Vec<u64>,
     },
     /// Pathfinding not found
     PathfindingNotFound(PathfindingNotFound),
@@ -155,8 +158,8 @@ pub enum SummaryResponse {
     PathfindingInputError(PathfindingInputError),
 }
 
-impl From<simulation::Response> for SummaryResponse {
-    fn from(response: simulation::Response) -> Self {
+impl SummaryResponse {
+    pub fn summarize_simulation(response: simulation::Response, path: PathfindingResult) -> Self {
         match response {
             simulation::Response::Success(SimulationResponseSuccess {
                 final_output,
@@ -164,6 +167,13 @@ impl From<simulation::Response> for SummaryResponse {
                 base,
                 ..
             }) => {
+                let PathfindingResult::Success(PathfindingResultSuccess {
+                    path_item_positions,
+                    ..
+                }) = path
+                else {
+                    panic!("Pathfinding cannnot fail if the simulation has succeeded")
+                };
                 let report = final_output.report_train;
                 Self::Success {
                     length: *report.positions.last().unwrap(),
@@ -172,6 +182,7 @@ impl From<simulation::Response> for SummaryResponse {
                     path_item_times_final: report.path_item_times.clone(),
                     path_item_times_provisional: provisional.path_item_times.clone(),
                     path_item_times_base: base.path_item_times.clone(),
+                    path_item_positions: path_item_positions.clone(),
                 }
             }
             simulation::Response::PathfindingFailed { pathfinding_failed } => {

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -552,8 +552,11 @@ pub(in crate::views) async fn simulation_summary(
 
     // Transform simulations to simulation summary
     let mut simulation_summaries = HashMap::new();
-    for (train_schedule, (sim, _)) in train_schedules.iter().zip(simulations) {
-        let simulation_summary_result = SummaryResponse::from(Arc::unwrap_or_clone(sim));
+    for (train_schedule, (sim, path)) in train_schedules.iter().zip(simulations) {
+        let simulation_summary_result = SummaryResponse::summarize_simulation(
+            Arc::unwrap_or_clone(sim),
+            Arc::unwrap_or_clone(path),
+        );
         simulation_summaries.insert(train_schedule.id, simulation_summary_result);
     }
 

--- a/front/src/applications/operationalStudies/__tests__/sampleData.ts
+++ b/front/src/applications/operationalStudies/__tests__/sampleData.ts
@@ -411,6 +411,7 @@ export const trainSummaryTooFast: Extract<SimulationSummaryResult, { status: 'su
   path_item_times_final: [0, 1739394, 3069187],
   path_item_times_provisional: [0, 1834414, 3164206],
   path_item_times_base: [0, 1444453, 2491479],
+  path_item_positions: [0, 1000, 2000],
 };
 
 export const trainScheduleTooFastOnInterval: TrainScheduleWithTrainId = {
@@ -485,6 +486,7 @@ export const trainSummaryTooFastOnInterval: Extract<
   path_item_times_final: [0, 5280030, 15300915],
   path_item_times_provisional: [0, 5222392, 15267584],
   path_item_times_base: [0, 4730243, 13828795],
+  path_item_positions: [0, 1000, 2000],
 };
 
 export const trainScheduleNotHonored: TrainScheduleWithTrainId = {
@@ -551,6 +553,7 @@ export const trainSummaryNotHonored: Extract<SimulationSummaryResult, { status: 
   path_item_times_final: [0, 1425534, 2186885],
   path_item_times_provisional: [0, 1425534, 2186885],
   path_item_times_base: [0, 1425534, 2186885],
+  path_item_positions: [0, 1000, 2000],
 };
 
 export const trainScheduleHonored: TrainScheduleWithTrainId = {
@@ -622,4 +625,5 @@ export const trainSummaryHonored: Extract<SimulationSummaryResult, { status: 'su
   path_item_times_final: [0, 2186885],
   path_item_times_provisional: [0, 2186885],
   path_item_times_base: [0, 2186885],
+  path_item_positions: [0, 1000],
 };

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -3661,6 +3661,9 @@ export type SimulationSummaryResult =
       energy_consumption: number;
       /** Length of a path in mm */
       length: number;
+      /** The path offset in mm of each path item given as input of the pathfinding
+    The first value is always `0` (beginning of the path) and the last one is always equal to the `length` of the path in mm */
+      path_item_positions: number[];
       /** Base simulation time for each train schedule path item.
     The first value is always `0` (beginning of the path) and the last one, the total time of the simulation (end of the path) */
       path_item_times_base: number[];


### PR DESCRIPTION
Add path_item_positions field to simulation_summary result to allow the detection of weird_path for the data team.
osrd-data will now call only simulation_summary.