### PR TITLE
front: display paced train exceptions on inter operational point space-time-chart

### DIFF
--- a/front/src/applications/operationalStudies/helpers/TrainOpProjectionLazyLoader.ts
+++ b/front/src/applications/operationalStudies/helpers/TrainOpProjectionLazyLoader.ts
@@ -1,3 +1,5 @@
+import { isEmpty } from 'lodash';
+
 import {
   osrdEditoastApi,
   type OperationalPointReference,
@@ -159,12 +161,22 @@ export default class TrainOpProjectionLazyLoader extends TrainProjectionLazyLoad
 
     for (const [id, result] of Object.entries(rawPacedTrainResults)) {
       const pacedTrainId = formatEditoastIdToPacedTrainId(Number(id));
-      const { paced_train: space_time_curves } = result;
-      const { paced_train: signal_updates } = rawPacedTrainOccupancyBlocks[id];
-      rawResults.set(pacedTrainId, {
-        space_time_curves,
-        signal_updates,
-      });
+      const pacedTrainProjectionResult: ProjectionResult = {
+        space_time_curves: result.paced_train,
+        signal_updates: rawPacedTrainOccupancyBlocks[id].paced_train,
+      };
+
+      if (!isEmpty(result.exceptions)) {
+        pacedTrainProjectionResult.exceptions = new Map();
+        for (const [exceptionKey, exception] of Object.entries(result.exceptions)) {
+          pacedTrainProjectionResult.exceptions.set(exceptionKey, {
+            space_time_curves: exception,
+            signal_updates: [],
+          });
+        }
+      }
+
+      rawResults.set(pacedTrainId, pacedTrainProjectionResult);
     }
 
     this.options.onProgress(rawResults);

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/OccurrenceItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/OccurrenceItem.tsx
@@ -35,7 +35,7 @@ import {
 
 import OccurrenceIndicator from './OccurrenceIndicator';
 import ArrivalTimeLoader from '../ArrivalTimeLoader';
-import { formatTrainDuration, roundAndFormatToNearestMinute } from '../utils';
+import { formatTrainDuration, isValidPathfinding, roundAndFormatToNearestMinute } from '../utils';
 import type useOccurrenceActions from './hooks/useOccurrenceActions';
 
 const ConsecutiveDayDateDisplay = ({
@@ -146,6 +146,7 @@ const OccurrenceItem = ({
         closeMenu();
       },
       dataTestID: 'occurrence-project-button',
+      disabled: !isValidPathfinding(summary),
     },
     delete: {
       title: t('occurrenceMenu.delete'),

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
@@ -48,7 +48,14 @@ import type {
 import type { TimetableItemWithDetails } from 'modules/timetableItem/types';
 import type { OccurrenceId, PacedTrainId, TrainId, TrainScheduleId } from 'reducers/osrdconf/types';
 import { useAppDispatch } from 'store';
-import { isTrainId, isPacedTrainId, formatPacedTrainIdToIndexedOccurrenceId } from 'utils/trainId';
+import {
+  isTrainId,
+  isPacedTrainId,
+  formatPacedTrainIdToIndexedOccurrenceId,
+  isOccurrenceId,
+  extractPacedTrainIdFromOccurrenceId,
+  extractOccurrenceIndexFromOccurrenceId,
+} from 'utils/trainId';
 
 import getPathStyle from './helpers/getPathStyle';
 import makeProjectedItems from './helpers/makeProjectedItems';
@@ -139,9 +146,27 @@ const SpaceTimeChartWrapper = ({
   const [draggingState, setDraggingState] = useState<DraggingState>();
 
   const isTimetableItemValid = useMemo(() => {
+    const selectedItemId = isOccurrenceId(selectedProjectionId)
+      ? extractPacedTrainIdFromOccurrenceId(selectedProjectionId)
+      : selectedProjectionId;
+
     const timetableItemUsedForProjectionWithDetails = timetableItemsWithDetails?.find(
-      (item) => item.id === selectedProjectionId
+      (item) => item.id === selectedItemId
     );
+
+    if (
+      timetableItemUsedForProjectionWithDetails &&
+      'exceptions' in timetableItemUsedForProjectionWithDetails &&
+      isOccurrenceId(selectedProjectionId)
+    ) {
+      const exeptionUsedForProjection = timetableItemUsedForProjectionWithDetails.exceptions.find(
+        (exception) =>
+          exception.occurrence_index ===
+          extractOccurrenceIndexFromOccurrenceId(selectedProjectionId)
+      );
+      if (exeptionUsedForProjection?.summary) return exeptionUsedForProjection.summary.isValid;
+    }
+
     return timetableItemUsedForProjectionWithDetails?.summary?.isValid ?? false;
   }, [timetableItemsWithDetails, selectedProjectionId]);
 

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
@@ -55,6 +55,8 @@ import {
   isOccurrenceId,
   extractPacedTrainIdFromOccurrenceId,
   extractOccurrenceIndexFromOccurrenceId,
+  extractExceptionIdFromOccurrenceId,
+  isAddedExceptionId,
 } from 'utils/trainId';
 
 import getPathStyle from './helpers/getPathStyle';
@@ -161,8 +163,10 @@ const SpaceTimeChartWrapper = ({
     ) {
       const exeptionUsedForProjection = timetableItemUsedForProjectionWithDetails.exceptions.find(
         (exception) =>
-          exception.occurrence_index ===
-          extractOccurrenceIndexFromOccurrenceId(selectedProjectionId)
+          isAddedExceptionId(selectedProjectionId)
+            ? exception.key === extractExceptionIdFromOccurrenceId(selectedProjectionId)
+            : exception.occurrence_index ===
+              extractOccurrenceIndexFromOccurrenceId(selectedProjectionId)
       );
       if (exeptionUsedForProjection?.summary) return exeptionUsedForProjection.summary.isValid;
     }

--- a/front/src/utils/trainId.ts
+++ b/front/src/utils/trainId.ts
@@ -23,7 +23,8 @@ export const isPacedTrainId = (id: string): id is PacedTrainId => id.startsWith(
 export const isIndexedOccurrenceId = (id: string): id is IndexedOccurrenceId =>
   id.startsWith('indexedoccurrence_');
 
-const isAddedExceptionId = (id: string): id is AddedExceptionId => id.startsWith('exception_');
+export const isAddedExceptionId = (id: string): id is AddedExceptionId =>
+  id.startsWith('exception_');
 
 export const isOccurrenceId = (id: string): id is OccurrenceId =>
   isIndexedOccurrenceId(id) || isAddedExceptionId(id);


### PR DESCRIPTION
close #12696 

This PR allows exceptions to be displayed in the STD on inter-OP, it also fixes a bug that prevented changing the projection type for occurrences.