### PR TITLE
front: reduce dayjs usage

### DIFF
--- a/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
+++ b/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
@@ -1,6 +1,5 @@
 import { useMemo } from 'react';
 
-import dayjs from 'dayjs';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
@@ -9,6 +8,7 @@ import formatPowerRestrictionRangesWithHandled from 'modules/powerRestriction/he
 import {
   extractOccurrenceDetailsFromPacedTrain,
   findExceptionWithOccurrenceId,
+  computeIndexedOccurrenceStartTime,
 } from 'modules/timetableItem/helpers/pacedTrain';
 import useSelectedTimetableItem from 'modules/timetableItem/hooks/useSelectedTimetableItem';
 import { getSelectedTrainId } from 'reducers/simulationResults/selectors';
@@ -51,10 +51,11 @@ const useSimulationResults = (): SimulationResults | undefined => {
       startTime = exception.start_time.value;
     } else {
       const selectedOccurrenceIndex = extractOccurrenceIndexFromOccurrenceId(selectedTrainId);
-      const pacedTrainIntervalInMs = Duration.parse(timetableItem.paced.interval).ms;
-      startTime = dayjs(timetableItem.start_time)
-        .add(selectedOccurrenceIndex * pacedTrainIntervalInMs, 'ms')
-        .toISOString();
+      startTime = computeIndexedOccurrenceStartTime(
+        new Date(timetableItem.start_time),
+        Duration.parse(timetableItem.paced.interval),
+        selectedOccurrenceIndex
+      ).toISOString();
     }
 
     return {

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/helpers/buildPacedTrainException.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/helpers/buildPacedTrainException.ts
@@ -1,10 +1,12 @@
-import dayjs from 'dayjs';
 import { isEmpty, isEqual, omit } from 'lodash';
 
 import type { PacedTrain, PacedTrainException, TrainSchedule } from 'common/api/osrdEditoastApi';
 import computeBasePathStep from 'modules/timetableItem/helpers/computeBasePathStep';
 import computeOccurrenceName from 'modules/timetableItem/helpers/computeOccurrenceName';
-import { findExceptionWithOccurrenceId } from 'modules/timetableItem/helpers/pacedTrain';
+import {
+  findExceptionWithOccurrenceId,
+  computeIndexedOccurrenceStartTime,
+} from 'modules/timetableItem/helpers/pacedTrain';
 import type { OccurrenceId } from 'reducers/osrdconf/types';
 import { removeElementAtIndex, replaceElementAtIndex } from 'utils/array';
 import { Duration } from 'utils/duration';
@@ -100,9 +102,11 @@ export function generatePacedTrainException(
 
   if (occurrenceIndex !== null) {
     const originalPacedTrainInterval = Duration.parse(originalPacedTrain.paced.interval);
-    originalStartTimeToTest = dayjs(originalStartTimeToTest)
-      .add(occurrenceIndex * originalPacedTrainInterval.ms, 'ms')
-      .toDate();
+    originalStartTimeToTest = computeIndexedOccurrenceStartTime(
+      originalStartTimeToTest,
+      originalPacedTrainInterval,
+      occurrenceIndex
+    );
   }
   // Remove milliseconds to avoid issues with the comparison
   originalStartTimeToTest.setMilliseconds(0);
@@ -251,9 +255,11 @@ export function checkChangeGroups(
     // their start time reset
     if (exception.start_time && exception.occurrence_index !== undefined) {
       const originalPacedTrainInterval = Duration.parse(updatedPacedTrain.paced.interval);
-      const originalStartTimeToTest = dayjs(new Date(updatedPacedTrain.start_time))
-        .add(exception.occurrence_index * originalPacedTrainInterval.ms, 'ms')
-        .toDate();
+      const originalStartTimeToTest = computeIndexedOccurrenceStartTime(
+        new Date(updatedPacedTrain.start_time),
+        originalPacedTrainInterval,
+        exception.occurrence_index
+      );
       const exceptionStartTime = new Date(exception.start_time.value);
 
       // Remove milliseconds to avoid issues with the comparison

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/hooks/useOccurrences.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/hooks/useOccurrences.ts
@@ -1,6 +1,5 @@
 import { useMemo } from 'react';
 
-import dayjs from 'dayjs';
 import { omit, sortBy } from 'lodash';
 
 import { type LightRollingStockWithLiveries } from 'common/api/osrdEditoastApi';
@@ -8,6 +7,7 @@ import computeOccurrenceName from 'modules/timetableItem/helpers/computeOccurren
 import {
   findExceptionWithOccurrenceId,
   getOccurrencesNb,
+  computeIndexedOccurrenceStartTime,
 } from 'modules/timetableItem/helpers/pacedTrain';
 import type { Occurrence, PacedTrainWithDetails } from 'modules/timetableItem/types';
 import {
@@ -49,9 +49,7 @@ const useOccurrences = (
 
       const startTime = correspondingException?.start_time?.value
         ? new Date(correspondingException.start_time.value)
-        : dayjs(pacedTrain.startTime)
-            .add(i * paced.interval.ms, 'ms')
-            .toDate();
+        : computeIndexedOccurrenceStartTime(pacedTrain.startTime, paced.interval, i);
 
       computedOccurrences.push({
         id: occurrenceId,

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TrainScheduleItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TrainScheduleItem.tsx
@@ -26,6 +26,7 @@ import {
   updateProjectionType,
 } from 'reducers/simulationResults';
 import { useAppDispatch } from 'store';
+import { useDateTimeLocale } from 'utils/date';
 import { addDurationToDate, Duration } from 'utils/duration';
 import { castErrorToFailure } from 'utils/error';
 import {
@@ -37,7 +38,6 @@ import ArrivalTimeLoader from './ArrivalTimeLoader';
 import { TIMETABLE_ITEM_DELTA } from './consts';
 import TimetableItemActions from './TimetableItemActions';
 import {
-  formatFullDate,
   formatTrainDuration,
   getTrainCategoryClassName,
   isValidPathfinding,
@@ -70,6 +70,7 @@ const TrainScheduleItem = ({
   subCategories,
 }: TrainScheduleItemProps) => {
   const { t } = useTranslation('operational-studies', { keyPrefix: 'main' });
+  const dateTimeLocale = useDateTimeLocale();
   const dispatch = useAppDispatch();
 
   const [postTrainSchedule] =
@@ -228,7 +229,7 @@ const TrainScheduleItem = ({
               <div className="status-icon after-midnight">{isAfterMidnight && <Moon />}</div>
               <div
                 className="scenario-timetable-train-times"
-                title={formatFullDate(train.startTime)}
+                title={train.startTime.toLocaleString(dateTimeLocale)}
               >
                 {roundAndFormatToNearestMinute(train.startTime)}
               </div>
@@ -244,7 +245,7 @@ const TrainScheduleItem = ({
               <div
                 data-testid="timetable-item-arrival-time"
                 className="scenario-timetable-train-times"
-                title={arrivalTime ? formatFullDate(arrivalTime) : undefined}
+                title={arrivalTime ? arrivalTime.toLocaleString(dateTimeLocale) : undefined}
               >
                 {arrivalTime ? roundAndFormatToNearestMinute(arrivalTime) : <ArrivalTimeLoader />}
               </div>

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/utils.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/utils.ts
@@ -39,8 +39,6 @@ export const extractTagCode = (tag?: string | null) => {
 export const timetableHasInvalidItem = (timetableItems: TimetableItemWithDetails[]) =>
   timetableItems.some((timetableItem) => timetableItem.summary && !timetableItem.summary.isValid);
 
-export const formatFullDate = (d: Date) => dayjs(d).format('D/MM/YYYY HH:mm:ss');
-
 export const roundAndFormatToNearestMinute = (d: Date) =>
   dayjs(d)
     .add(d.getSeconds() >= 30 ? 1 : 0, 'minute')

--- a/front/src/applications/stdcm/utils/formatConflicts.ts
+++ b/front/src/applications/stdcm/utils/formatConflicts.ts
@@ -1,5 +1,3 @@
-import dayjs from 'dayjs';
-
 import type { StdcmPathProperties } from 'applications/stdcm/types';
 import type { Conflict } from 'common/api/osrdEditoastApi';
 import type { SuggestedOP } from 'modules/timetableItem/types';
@@ -75,10 +73,10 @@ export const formatConflicts = (
 
       const formattedConflict = {
         trainIds: conflict.train_schedule_ids,
-        startDate: dayjs(conflict.start_time).format('DD/MM/YYYY'),
-        endDate: dayjs(conflict.end_time).format('DD/MM/YYYY'),
-        startTime: dayjs(conflict.start_time).format('HH:mm'),
-        endTime: dayjs(conflict.end_time).format('HH:mm'),
+        startDate: new Date(conflict.start_time).toLocaleDateString(),
+        endDate: new Date(conflict.end_time).toLocaleDateString(),
+        startTime: new Date(conflict.start_time).toLocaleString(undefined, { timeStyle: 'short' }),
+        endTime: new Date(conflict.end_time).toLocaleString(undefined, { timeStyle: 'short' }),
         waypointBefore,
         waypointAfter,
       };

--- a/front/src/modules/conflict/components/ConflictCard.tsx
+++ b/front/src/modules/conflict/components/ConflictCard.tsx
@@ -1,13 +1,11 @@
-import dayjs from 'dayjs';
 import { useTranslation } from 'react-i18next';
 
 import { getTrainCategoryClassName } from 'applications/operationalStudies/views/Scenario/components/Timetable/utils';
 import { useSubCategoryContext } from 'common/SubCategoryContext';
 import isMainCategory from 'modules/rollingStock/helpers/category';
+import { useDateTimeLocale } from 'utils/date';
 
 import type { ConflictWithTrainNames } from '../types';
-
-const formatToLocalTime = (dateString: string) => dayjs.utc(dateString).local().format('HH:mm:ss');
 
 const ConflictCard = ({
   conflict,
@@ -17,9 +15,10 @@ const ConflictCard = ({
   onConflictClick: (conflict: ConflictWithTrainNames) => void;
 }) => {
   const { t } = useTranslation('operational-studies', { keyPrefix: 'main' });
-  const start_time = formatToLocalTime(conflict.start_time);
-  const end_time = formatToLocalTime(conflict.end_time);
-  const start_date = dayjs(conflict.start_time).format('DD/MM/YYYY');
+  const dateTimeLocale = useDateTimeLocale();
+  const start_time = new Date(conflict.start_time).toLocaleTimeString(dateTimeLocale);
+  const end_time = new Date(conflict.end_time).toLocaleTimeString(dateTimeLocale);
+  const start_date = new Date(conflict.start_time).toLocaleDateString(dateTimeLocale);
 
   const subCategories = useSubCategoryContext();
 

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/configureHandlePan.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/configureHandlePan.ts
@@ -4,11 +4,11 @@ import {
   type HoveredItem,
   type SpaceTimeChartProps,
 } from '@osrd-project/ui-charts';
-import dayjs from 'dayjs';
 
 import type { TrainId } from 'reducers/osrdconf/types';
 import { updateSelectedTrainId } from 'reducers/simulationResults';
 import type { AppDispatch } from 'store';
+import { Duration, subtractDurationFromDate } from 'utils/duration';
 import {
   extractOccurrenceIndexFromOccurrenceId,
   extractPacedTrainIdFromOccurrenceId,
@@ -92,9 +92,10 @@ export function configureHandlePan({
           ({ id }) => isPacedTrainId(id) && id === pacedTrainId
         );
         if (pacedTrain && 'paced' in pacedTrain) {
-          newDepartureTime = dayjs(newDepartureTime)
-            .add(occurrencesIndex * -pacedTrain.paced.interval.ms, 'ms')
-            .toDate();
+          newDepartureTime = subtractDurationFromDate(
+            newDepartureTime,
+            new Duration({ milliseconds: occurrencesIndex * pacedTrain.paced.interval.ms })
+          );
         }
       }
 

--- a/front/src/modules/timetableItem/helpers/pacedTrain.ts
+++ b/front/src/modules/timetableItem/helpers/pacedTrain.ts
@@ -1,5 +1,3 @@
-import dayjs from 'dayjs';
-
 import type { PacedTrain, PacedTrainException } from 'common/api/osrdEditoastApi';
 import type {
   OccurrenceId,
@@ -7,7 +5,7 @@ import type {
   TimetableItem,
   TimetableItemId,
 } from 'reducers/osrdconf/types';
-import { Duration } from 'utils/duration';
+import { Duration, addDurationToDate } from 'utils/duration';
 import {
   extractExceptionIdFromOccurrenceId,
   extractOccurrenceIndexFromOccurrenceId,
@@ -29,13 +27,10 @@ export const getOccurrencesNb = ({ timeWindow, interval }: PacedTrainWithDetails
 
 /** startTime + index × interval */
 export const computeIndexedOccurrenceStartTime = (
-  pacedTrainStartTime: Date | null,
+  pacedTrainStartTime: Date,
   interval: Duration,
   index: number
-) =>
-  dayjs(pacedTrainStartTime)
-    .add(index * interval.ms, 'ms')
-    .toDate();
+) => addDurationToDate(pacedTrainStartTime, new Duration({ milliseconds: index * interval.ms }));
 
 /**
  * Based on an exception list and an occurrence id, find the corresponding exception


### PR DESCRIPTION
In some places, the JS standard library can do the job and results in better localization for non-French users (because it doesn't use fixed format strings). In other places, `Duration` can do the job, avoids the need for an external library and is very similar to the upcoming standard Temporal API.