### PR TITLE
front: upgrade eslint-plugin-react-hooks to v5

### DIFF
--- a/front/.eslintrc
+++ b/front/.eslintrc
@@ -187,7 +187,8 @@
     {
       "files": ["tests/**/*.ts", "tests/**/*.tsx"],
       "rules": {
-        "@typescript-eslint/no-floating-promises": "error"
+        "@typescript-eslint/no-floating-promises": "error",
+        "react-hooks/rules-of-hooks": "off"
       }
     }
   ]

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -131,7 +131,7 @@
         "eslint-plugin-only-warn": "^1.1.0",
         "eslint-plugin-prettier": "^5.4.1",
         "eslint-plugin-react": "^7.37.5",
-        "eslint-plugin-react-hooks": "^4.6.0",
+        "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-vitest": "^0.3.21",
         "glob": "^11.0.3",
         "happy-dom": "^18.0.1",
@@ -12064,16 +12064,16 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
-      "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
+      "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
       }
     },
     "node_modules/eslint-plugin-react/node_modules/resolve": {
@@ -26958,7 +26958,7 @@
         "eslint-plugin-only-warn": "^1.1.0",
         "eslint-plugin-prettier": "^5.4.1",
         "eslint-plugin-react": "^7.35.0",
-        "eslint-plugin-react-hooks": "^4.6.0",
+        "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-storybook": "^9.0.12",
         "postcss": "^8.5.6",
         "postcss-assets": "^6.0.0",

--- a/front/package.json
+++ b/front/package.json
@@ -127,7 +127,7 @@
     "eslint-plugin-only-warn": "^1.1.0",
     "eslint-plugin-prettier": "^5.4.1",
     "eslint-plugin-react": "^7.37.5",
-    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-vitest": "^0.3.21",
     "glob": "^11.0.3",
     "happy-dom": "^18.0.1",

--- a/front/ui/base/package.json
+++ b/front/ui/base/package.json
@@ -23,7 +23,7 @@
     "eslint-plugin-only-warn": "^1.1.0",
     "eslint-plugin-prettier": "^5.4.1",
     "eslint-plugin-react": "^7.35.0",
-    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-storybook": "^9.0.12",
     "postcss": "^8.5.6",
     "postcss-assets": "^6.0.0",


### PR DESCRIPTION
We need to disable react-hooks/rules-of-hooks for E2E tests because eslint-plugin-react-hooks does not leverage TypeScript and [is not able to tell the difference between React's use() and playwright's use()][1]:

    /app/tests/logging-fixture.ts
      36:11  warning  React Hook "use" is called in function "page" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use"  react-hooks/rules-of-hooks

[1]: https://github.com/facebook/react/issues/31237