### PR TITLE
front: delete defunct op map layers

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/ManageTimetableItemMap/ManageTimetableItemMap.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/ManageTimetableItemMap/ManageTimetableItemMap.tsx
@@ -26,10 +26,7 @@ import type { FeatureInfoClick } from '../types';
 
 const OPERATIONAL_POINT_LAYERS = [
   'chartis/osrd_operational_point/geo',
-  'chartis/osrd_operational_point_yardname/geo',
-  'chartis/osrd_operational_point_name_short/geo',
   'chartis/osrd_operational_point_name/geo',
-  'chartis/osrd_operational_point_kp/geo',
 ];
 
 type MapProps = {


### PR DESCRIPTION
Close #13098

These layers were deleted in the list of \<OrderedLayer\> in #12652, but not deleted in OPERATIONAL_POINT_LAYERS.