### PR TITLE
front: fix round trip modal empty when all path without ops

### DIFF
--- a/front/src/applications/operationalStudies/hooks/useTimetableItemsWithPathOps.ts
+++ b/front/src/applications/operationalStudies/hooks/useTimetableItemsWithPathOps.ts
@@ -25,10 +25,14 @@ const useTimetableItemsWithPathOps = (
     );
 
   return useMemo(() => {
-    if (!timetableItems || !timetableOperationalPoints || timetableOperationalPoints.length === 0) {
+    if (!timetableItems) {
       return [];
     }
-    return addPathOpsToTimetableItems(timetableItems, timetableOpRefs, timetableOperationalPoints);
+    return addPathOpsToTimetableItems(
+      timetableItems,
+      timetableOpRefs,
+      timetableOperationalPoints ?? []
+    );
   }, [timetableItems, timetableOperationalPoints]);
 };
 


### PR DESCRIPTION
Close [#12979](https://github.com/OpenRailAssociation/osrd/issues/12979)

Video of the behavior first on dev, then on this branch :
[Screencast_20250911_122907.webm](https://github.com/user-attachments/assets/318a04d5-641d-4067-9f0f-84defda5eb0b)
