### PR TITLE
front: turn TimesStopsRow.stopFor into a Duration

### DIFF
--- a/front/src/modules/timesStops/TimesStopsInput.tsx
+++ b/front/src/modules/timesStops/TimesStopsInput.tsx
@@ -16,7 +16,6 @@ import {
 } from 'reducers/osrdconf/operationalStudiesConf';
 import type { PathStep } from 'reducers/osrdconf/types';
 import { useAppDispatch } from 'store';
-import { Duration } from 'utils/duration';
 
 import {
   durationSinceStartTime,
@@ -125,12 +124,11 @@ const TimesStopsInput = ({
           (row, index) =>
             !isEqual(normalizeNullablesInRow(row), normalizeNullablesInRow(rows[index]))
         )
-        .map(({ shortSlipDistance, onStopSignal, arrival, departure, stopFor, ...row }) => ({
+        .map(({ shortSlipDistance, onStopSignal, arrival, departure, ...row }) => ({
           ...row,
           arrival: durationSinceStartTime(startTime, arrival),
           departure: durationSinceStartTime(startTime, departure),
           receptionSignal: onStopSignalToReceptionSignal(onStopSignal, shortSlipDistance),
-          stopFor: stopFor ? new Duration({ seconds: Number(stopFor) }) : null,
         }));
       dispatch(upsertSeveralViasFromSuggestedOP(newVias));
     },

--- a/front/src/modules/timesStops/helpers/__tests__/scheduleData.spec.ts
+++ b/front/src/modules/timesStops/helpers/__tests__/scheduleData.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 
 import type { ReceptionSignal } from 'common/api/osrdEditoastApi';
+import { Duration } from 'utils/duration';
 
 import { formatSchedule } from '../scheduleData';
 
@@ -28,7 +29,7 @@ describe('formatScheduleTime', () => {
 
     expect(formatSchedule(arrivalTime, schedule, dateTimeLocale)).toEqual({
       calculatedDeparture: '02:04:40',
-      stopFor: '100',
+      stopFor: new Duration({ seconds: 100 }),
       shortSlipDistance: false,
       onStopSignal: false,
     });

--- a/front/src/modules/timesStops/helpers/__tests__/utils.spec.ts
+++ b/front/src/modules/timesStops/helpers/__tests__/utils.spec.ts
@@ -20,14 +20,14 @@ describe('updateRowTimesAndMargin', () => {
         name: 'Gr',
         arrival: { time: '23:40:00' },
         departure: { time: '23:50:00' },
-        stopFor: '300', // no longer correct, not yet updated by the function
+        stopFor: new Duration({ seconds: 300 }), // no longer correct, not yet updated by the function
       } as TimesStopsInputRow;
       const previousRowData = {
         opId: 'd94a2af4',
         name: 'Gr',
         arrival: { time: '23:40:00' },
         departure: { time: '23:45:00' },
-        stopFor: '300',
+        stopFor: new Duration({ seconds: 300 }),
       } as TimesStopsInputRow;
       const result = updateRowTimesAndMargin(rowData, previousRowData, whateverOperation, 4);
       expect(result).toEqual({
@@ -35,7 +35,7 @@ describe('updateRowTimesAndMargin', () => {
         name: 'Gr',
         arrival: { time: '23:40:00' },
         departure: { time: '23:50:00' },
-        stopFor: '600', // now correct with the new arrival and departure
+        stopFor: new Duration({ seconds: 600 }), // now correct with the new arrival and departure
         isMarginValid: true,
       });
     });
@@ -87,14 +87,14 @@ describe('updateRowTimesAndMargin', () => {
         name: 'Gr',
         arrival: { time: '23:40:00' },
         departure: { time: '00:20:00' },
-        stopFor: '300',
+        stopFor: new Duration({ seconds: 300 }),
       } as TimesStopsInputRow;
       const previousRowData = {
         opId: 'd94a2af4',
         name: 'Gr',
         arrival: { time: '23:40:00' },
         departure: { time: '23:45:00' },
-        stopFor: '300',
+        stopFor: new Duration({ seconds: 300 }),
       } as TimesStopsInputRow;
       const result = updateRowTimesAndMargin(rowData, previousRowData, whateverOperation, 4);
       expect(result).toEqual({
@@ -102,7 +102,7 @@ describe('updateRowTimesAndMargin', () => {
         name: 'Gr',
         arrival: { time: '23:40:00' },
         departure: { time: '00:20:00' },
-        stopFor: '2400',
+        stopFor: new Duration({ seconds: 2400 }),
         isMarginValid: true,
       });
     });
@@ -114,14 +114,14 @@ describe('updateRowTimesAndMargin', () => {
         name: 'Gr',
         arrival: undefined,
         departure: { time: '00:20:00' },
-        stopFor: '600',
+        stopFor: new Duration({ seconds: 600 }),
       } as TimesStopsInputRow;
       const previousRowData = {
         opId: 'd94a2af4',
         name: 'Gr',
         arrival: { time: '00:10:00' },
         departure: { time: '00:20:00' },
-        stopFor: '600',
+        stopFor: new Duration({ seconds: 600 }),
       } as TimesStopsInputRow;
       const result = updateRowTimesAndMargin(rowData, previousRowData, whateverOperation, 4);
       expect(result).toEqual({
@@ -129,7 +129,7 @@ describe('updateRowTimesAndMargin', () => {
         name: 'Gr',
         arrival: undefined,
         departure: undefined,
-        stopFor: '600',
+        stopFor: new Duration({ seconds: 600 }),
         isMarginValid: true,
       });
     });
@@ -139,14 +139,14 @@ describe('updateRowTimesAndMargin', () => {
         name: 'Gr',
         arrival: { time: '' },
         departure: { time: '00:20:00' },
-        stopFor: '600',
+        stopFor: new Duration({ seconds: 600 }),
       } as TimesStopsInputRow;
       const previousRowData = {
         opId: 'd94a2af4',
         name: 'Gr',
         arrival: { time: '00:10:00' },
         departure: { time: '00:20:00' },
-        stopFor: '600',
+        stopFor: new Duration({ seconds: 600 }),
       } as TimesStopsInputRow;
       const result = updateRowTimesAndMargin(rowData, previousRowData, whateverOperation, 4);
       expect(result).toEqual({
@@ -154,7 +154,7 @@ describe('updateRowTimesAndMargin', () => {
         name: 'Gr',
         arrival: { time: '' },
         departure: undefined,
-        stopFor: '600',
+        stopFor: new Duration({ seconds: 600 }),
         isMarginValid: true,
       });
     });
@@ -166,14 +166,14 @@ describe('updateRowTimesAndMargin', () => {
         name: 'Gr',
         arrival: { time: '00:10:00' },
         departure: undefined,
-        stopFor: '600',
+        stopFor: new Duration({ seconds: 600 }),
       } as TimesStopsInputRow;
       const previousRowData = {
         opId: 'd94a2af4',
         name: 'Gr',
         arrival: { time: '00:10:00' },
         departure: { time: '00:20:00' },
-        stopFor: '600',
+        stopFor: new Duration({ seconds: 600 }),
       } as TimesStopsInputRow;
       const result = updateRowTimesAndMargin(rowData, previousRowData, whateverOperation, 4);
       expect(result).toEqual({
@@ -194,14 +194,14 @@ describe('updateRowTimesAndMargin', () => {
         name: 'Gr',
         arrival: undefined,
         departure: { time: '00:20:00' },
-        stopFor: '600',
+        stopFor: new Duration({ seconds: 600 }),
       } as TimesStopsInputRow;
       const previousRowData = {
         opId: 'd94a2af4',
         name: 'Gr',
         arrival: undefined,
         departure: undefined,
-        stopFor: '600',
+        stopFor: new Duration({ seconds: 600 }),
       } as TimesStopsInputRow;
       const result = updateRowTimesAndMargin(rowData, previousRowData, whateverOperation, 4);
       expect(result).toEqual({
@@ -209,7 +209,7 @@ describe('updateRowTimesAndMargin', () => {
         name: 'Gr',
         arrival: { time: '00:10:00' },
         departure: { time: '00:20:00' },
-        stopFor: '600',
+        stopFor: new Duration({ seconds: 600 }),
         isMarginValid: true,
       });
     });
@@ -258,7 +258,7 @@ describe('updateDaySinceDeparture', () => {
           uic: 86,
           ch: 'BX',
           arrival: { time: '11:00:00' },
-          stopFor: '1800',
+          stopFor: new Duration({ seconds: 1800 }),
         },
       ] as TimesStopsInputRow[];
       const result = updateDaySinceDeparture(TimesStopsInputRows, {
@@ -280,7 +280,7 @@ describe('updateDaySinceDeparture', () => {
           ch: 'BX',
           arrival: { time: '11:00:00', daySinceDeparture: 0 },
           departure: { time: '11:30:00', daySinceDeparture: 0 },
-          stopFor: '1800',
+          stopFor: new Duration({ seconds: 1800 }),
         },
       ];
       expect(result).toEqual(expected);
@@ -547,7 +547,7 @@ describe('updateDaySinceDeparture', () => {
           uic: 84,
           ch: 'BX',
           arrival: { time: '23:55:00' },
-          stopFor: '3600',
+          stopFor: new Duration({ seconds: 3600 }),
         },
         {
           opId: 'd982df3e',
@@ -576,7 +576,7 @@ describe('updateDaySinceDeparture', () => {
           ch: 'BX',
           arrival: { time: '23:55:00', daySinceDeparture: 0 },
           departure: { time: '00:55:00', daySinceDeparture: 1, dayDisplayed: true },
-          stopFor: '3600',
+          stopFor: new Duration({ seconds: 3600 }),
         },
         {
           opId: 'd982df3e',
@@ -633,7 +633,7 @@ describe('updateDaySinceDeparture', () => {
           uic: 72,
           ch: 'BV',
           arrival: { time: '23:30:00' },
-          stopFor: '3600',
+          stopFor: new Duration({ seconds: 3600 }),
         },
       ] as TimesStopsInputRow[];
       const result = updateDaySinceDeparture(TimesStopsInputRows, {
@@ -691,7 +691,7 @@ describe('updateDaySinceDeparture', () => {
             daySinceDeparture: 2,
             dayDisplayed: true,
           },
-          stopFor: '3600',
+          stopFor: new Duration({ seconds: 3600 }),
         },
       ];
       expect(result).toEqual(expected);

--- a/front/src/modules/timesStops/helpers/scheduleData.ts
+++ b/front/src/modules/timesStops/helpers/scheduleData.ts
@@ -31,13 +31,13 @@ export const formatSchedule = (
 
   if (!arrivalTime) {
     return {
-      stopFor: `${stopFor.total('second')}`,
+      stopFor,
       calculatedDeparture: undefined,
       ...receptionSignalToSignalBooleans(schedule.reception_signal),
     };
   }
   return {
-    stopFor: `${stopFor.total('second')}`,
+    stopFor,
     calculatedDeparture: addDurationToDate(arrivalTime, stopFor).toLocaleTimeString(dateTimeLocale),
     ...receptionSignalToSignalBooleans(schedule.reception_signal),
   };

--- a/front/src/modules/timesStops/helpers/utils.ts
+++ b/front/src/modules/timesStops/helpers/utils.ts
@@ -111,7 +111,7 @@ export const formatSuggestedViasToRowVias = (
       onStopSignal,
       name: name || t('timeStopTable.waypoint', { id: filteredOp.pathStepId }),
       shortSlipDistance,
-      stopFor: stopForSeconds !== undefined ? String(stopForSeconds) : undefined,
+      stopFor,
       theoreticalMargin,
     };
   });
@@ -166,13 +166,18 @@ export function updateRowTimesAndMargin(
     !isEqual(newRowData.departure, previousRowData.departure)
   ) {
     if (newRowData.departure?.time && newRowData.arrival?.time) {
-      newRowData.stopFor = String(
-        durationInSeconds(time2sec(newRowData.arrival.time), time2sec(newRowData.departure.time))
-      );
+      newRowData.stopFor = new Duration({
+        seconds: durationInSeconds(
+          time2sec(newRowData.arrival.time),
+          time2sec(newRowData.departure.time)
+        ),
+      });
     } else if (newRowData.departure) {
       if (!previousRowData.departure) {
         newRowData.arrival = {
-          time: sec2time(time2sec(newRowData.departure.time) - Number(newRowData.stopFor)),
+          time: sec2time(
+            time2sec(newRowData.departure.time) - (newRowData.stopFor?.total('second') ?? 0)
+          ),
         };
       } else {
         newRowData.departure = undefined;
@@ -199,10 +204,6 @@ export function updateRowTimesAndMargin(
     if (!newRowData.theoreticalMargin) {
       newRowData.theoreticalMargin = '0%';
     }
-  }
-  // Remove second unit in stopFor if inputted by mistake
-  if (newRowData.stopFor && /^[0-9]+ *s$/i.test(newRowData.stopFor)) {
-    newRowData.stopFor = newRowData.stopFor.replace(/ *s$/i, '');
   }
   return newRowData;
 }
@@ -260,7 +261,7 @@ export function updateDaySinceDeparture(
     let formattedDeparture: TimeExtraDays | undefined;
 
     if (stopFor && arrivalInSeconds !== null) {
-      const departureInSeconds = (arrivalInSeconds + Number(stopFor)) % SECONDS_IN_A_DAY;
+      const departureInSeconds = (arrivalInSeconds + stopFor.total('second')) % SECONDS_IN_A_DAY;
       const isAfterMidnight = departureInSeconds < previousTime;
       const isDepartureMidnight = departureInSeconds === 0;
 

--- a/front/src/modules/timesStops/hooks/useTimesStopsColumns.tsx
+++ b/front/src/modules/timesStops/hooks/useTimesStopsColumns.tsx
@@ -10,6 +10,7 @@ import type { CellComponent } from '@sdziadkowiec/react-datasheet-grid/dist/type
 import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
 
+import { Duration } from 'utils/duration';
 import { NO_BREAK_SPACE } from 'utils/strings';
 
 import { marginRegExValidation } from '../consts';
@@ -30,6 +31,25 @@ const timeColumn = (isOutputTable: boolean) =>
     minWidth: isOutputTable ? 110 : 170,
     isCellEmpty: ({ rowData }) => !rowData,
   }) as Partial<Column<TimeExtraDays | undefined, string, string>>;
+
+function durationColumn() {
+  const format = (duration: Duration | null | undefined) => String(duration?.total('second') ?? '');
+  const parse = (text: string) => {
+    // Remove trailing "s" unit, if any
+    const seconds = Number(text.trim().replace(/ *s$/i, ''));
+    return !isNaN(seconds) ? new Duration({ seconds }) : null;
+  };
+
+  return createTextColumn<Duration | null | undefined>({
+    formatBlurredInput: format,
+    formatInputOnFocus: format,
+    formatForCopy: format,
+    parseUserInput: parse,
+    parsePastedValue: parse,
+    continuousUpdates: false,
+    alignRight: true,
+  });
+}
 
 const fixedWidth = (width: number) => ({ minWidth: width, maxWidth: width });
 
@@ -131,13 +151,7 @@ export const useTimesStopsColumns = <T extends TimesStopsRow>(
         disabled: ({ rowIndex }) => isOutputTable || rowIndex === 0,
       },
       {
-        ...keyColumn(
-          'stopFor',
-          createTextColumn({
-            continuousUpdates: false,
-            alignRight: true,
-          })
-        ),
+        ...keyColumn('stopFor', durationColumn()),
         title: t('stopTime'),
         headerClassName: 'padded-header',
         disabled: isOutputTable,

--- a/front/src/modules/timesStops/types.ts
+++ b/front/src/modules/timesStops/types.ts
@@ -1,6 +1,7 @@
 import type { TrainSchedule } from 'common/api/osrdEditoastApi';
 import type { TimeString } from 'common/types';
 import type { SuggestedOP } from 'modules/timetableItem/types';
+import type { Duration } from 'utils/duration';
 import type { ArrayElement } from 'utils/types';
 
 export type TimeExtraDays = {
@@ -18,7 +19,7 @@ export type TimesStopsRow = {
 
   arrival?: TimeExtraDays; // value asked by user
   departure?: TimeExtraDays; // value asked by user
-  stopFor?: string | null; // value asked by user
+  stopFor?: Duration | null; // value asked by user
   onStopSignal?: boolean;
   shortSlipDistance?: boolean;
   theoreticalMargin?: string; // value asked by user


### PR DESCRIPTION
This is more type-safe, and avoids manipulating strings when we need a machine-readable Duration.

See also https://github.com/OpenRailAssociation/osrd/pull/13123