### PR TITLE
front: turn TimesStopsRow.calculated{Arrival,Departure} into a Date

### DIFF
--- a/front/src/modules/timesStops/TimesStopsOutput.tsx
+++ b/front/src/modules/timesStops/TimesStopsOutput.tsx
@@ -7,6 +7,7 @@ import type {
 } from 'common/api/osrdEditoastApi';
 import type { SimulationSummary } from 'modules/timetableItem/types';
 import type { Train } from 'reducers/osrdconf/types';
+import { formatLocalTime } from 'utils/date';
 
 import useOutputTableData from './hooks/useOutputTableData';
 import TimesStops from './TimesStops';
@@ -44,9 +45,10 @@ const TimesStopsOutput = ({
       tableType={TableType.Output}
       cellClassName={({ rowData: rowData_, columnId }) => {
         const rowData = rowData_ as TimesStopsRow;
+        // TODO: compare Date objects rather than strings
         const arrivalScheduleNotRespected =
           rowData.arrival?.time && rowData.calculatedArrival
-            ? rowData.calculatedArrival !== rowData.arrival.time
+            ? formatLocalTime(rowData.calculatedArrival) !== rowData.arrival.time
             : false;
         const negativeDiffMargins = rowData.diffMargins && parseInt(rowData.diffMargins) < 0;
         return cx({

--- a/front/src/modules/timesStops/helpers/__tests__/scheduleData.spec.ts
+++ b/front/src/modules/timesStops/helpers/__tests__/scheduleData.spec.ts
@@ -6,12 +6,10 @@ import { Duration } from 'utils/duration';
 import { formatSchedule } from '../scheduleData';
 
 describe('formatScheduleTime', () => {
-  const dateTimeLocale = new Intl.Locale('fr-FR');
-
   it('should return empty objecty if schedule is undefined', () => {
     const arrivalTime = new Date();
 
-    expect(formatSchedule(arrivalTime, undefined, dateTimeLocale)).toEqual({
+    expect(formatSchedule(arrivalTime, undefined)).toEqual({
       stopFor: undefined,
       shortSlipDistance: false,
       onStopSignal: false,
@@ -27,8 +25,8 @@ describe('formatScheduleTime', () => {
       reception_signal: 'OPEN' as ReceptionSignal,
     };
 
-    expect(formatSchedule(arrivalTime, schedule, dateTimeLocale)).toEqual({
-      calculatedDeparture: '02:04:40',
+    expect(formatSchedule(arrivalTime, schedule)).toEqual({
+      calculatedDeparture: new Date('2022-01-01T02:04:40'),
       stopFor: new Duration({ seconds: 100 }),
       shortSlipDistance: false,
       onStopSignal: false,

--- a/front/src/modules/timesStops/helpers/scheduleData.ts
+++ b/front/src/modules/timesStops/helpers/scheduleData.ts
@@ -7,8 +7,7 @@ import { receptionSignalToSignalBooleans } from './utils';
 /** Format the stopFor, calculatedDeparture, shortSlipDistance and onStopSignal properties */
 export const formatSchedule = (
   arrivalTime: Date | undefined,
-  schedule: ScheduleEntry | undefined,
-  dateTimeLocale: Intl.Locale
+  schedule: ScheduleEntry | undefined
 ) => {
   if (!schedule) {
     return {
@@ -38,7 +37,7 @@ export const formatSchedule = (
   }
   return {
     stopFor,
-    calculatedDeparture: addDurationToDate(arrivalTime, stopFor).toLocaleTimeString(dateTimeLocale),
+    calculatedDeparture: addDurationToDate(arrivalTime, stopFor),
     ...receptionSignalToSignalBooleans(schedule.reception_signal),
   };
 };

--- a/front/src/modules/timesStops/hooks/useOutputTableData.ts
+++ b/front/src/modules/timesStops/hooks/useOutputTableData.ts
@@ -13,7 +13,6 @@ import { interpolateValue } from 'modules/simulationResult/helpers/utils';
 import type { SimulationSummary } from 'modules/timetableItem/types';
 import type { Train } from 'reducers/osrdconf/types';
 import { getDisplayOnlyPathSteps } from 'reducers/simulationResults/selectors';
-import { useDateTimeLocale } from 'utils/date';
 import { Duration } from 'utils/duration';
 
 import { ARRIVAL_TIME_ACCEPTABLE_ERROR } from '../consts';
@@ -32,7 +31,6 @@ const useOutputTableData = (
   operationalPointsOnPath?: PathPropertiesFormatted['operationalPoints']
 ): TimesStopsRow[] => {
   const { t } = useTranslation('operational-studies');
-  const dateTimeLocale = useDateTimeLocale();
   const { getTrackSectionsByIds } = useScenarioContext();
   const displayOnlyPathSteps = useSelector(getDisplayOnlyPathSteps);
 
@@ -79,8 +77,7 @@ const useOutputTableData = (
             : undefined;
           const { stopFor, shortSlipDistance, onStopSignal, calculatedDeparture } = formatSchedule(
             computedArrival,
-            schedule,
-            dateTimeLocale
+            schedule
           );
           const { theoreticalArrival, arrival, departure, refDate } = computeInputDatetimes(
             startDatetime,
@@ -112,7 +109,9 @@ const useOutputTableData = (
                 ARRIVAL_TIME_ACCEPTABLE_ERROR
               : false;
           const calculatedArrival = computedArrival
-            ? (isOnTime ? theoreticalArrival! : computedArrival).toLocaleTimeString(dateTimeLocale)
+            ? isOnTime
+              ? theoreticalArrival!
+              : computedArrival
             : undefined;
 
           const pathStepRow = {
@@ -197,7 +196,7 @@ const useOutputTableData = (
               name: op.extensions?.identifier?.name,
               ch: op.extensions?.sncf?.ch,
               trackName,
-              calculatedArrival: calculatedArrival.toLocaleTimeString(dateTimeLocale),
+              calculatedArrival,
             });
           }
         }

--- a/front/src/modules/timesStops/hooks/useTimesStopsColumns.tsx
+++ b/front/src/modules/timesStops/hooks/useTimesStopsColumns.tsx
@@ -10,6 +10,7 @@ import type { CellComponent } from '@sdziadkowiec/react-datasheet-grid/dist/type
 import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
 
+import { useDateTimeLocale } from 'utils/date';
 import { Duration } from 'utils/duration';
 import { NO_BREAK_SPACE } from 'utils/strings';
 
@@ -51,6 +52,22 @@ function durationColumn() {
   });
 }
 
+function readOnlyTimeColumn(key: string, dateTimeLocale: Intl.Locale) {
+  const format = (date: Date | undefined) => date?.toLocaleTimeString(dateTimeLocale) ?? '';
+
+  return {
+    ...keyColumn(
+      key,
+      createTextColumn<Date | undefined>({
+        formatBlurredInput: format,
+        formatInputOnFocus: format,
+        formatForCopy: format,
+      })
+    ),
+    disabled: true,
+  };
+}
+
 const fixedWidth = (width: number) => ({ minWidth: width, maxWidth: width });
 
 function headerWithTitleTagIfShortened(shortenedHeader: string, fullHeader: string) {
@@ -63,6 +80,7 @@ export const useTimesStopsColumns = <T extends TimesStopsRow>(
   allWaypoints: T[] = []
 ) => {
   const { t } = useTranslation('translation', { keyPrefix: 'timeStopTable' });
+  const dateTimeLocale = useDateTimeLocale();
 
   const columns = useMemo<Column<T>[]>(() => {
     const isOutputTable = tableType === TableType.Output;
@@ -88,12 +106,13 @@ export const useTimesStopsColumns = <T extends TimesStopsRow>(
               ...fixedWidth(90),
             },
             {
-              ...disabledTextColumn('calculatedArrival', t('calculatedArrivalTime')),
+              ...readOnlyTimeColumn('calculatedArrival', dateTimeLocale),
+              title: t('calculatedArrivalTime'),
               headerClassName: 'padded-header',
               ...fixedWidth(105),
             },
             {
-              ...disabledTextColumn('calculatedDeparture', t('calculatedDepartureTime')),
+              ...readOnlyTimeColumn('calculatedDeparture', dateTimeLocale),
               title: headerWithTitleTagIfShortened(
                 t('calculatedDepartureTime'),
                 t('calculatedDepartureTimeFull')
@@ -237,7 +256,7 @@ export const useTimesStopsColumns = <T extends TimesStopsRow>(
       },
       ...extraOutputColumns,
     ] as Column<T>[];
-  }, [tableType, t, allWaypoints.length]);
+  }, [tableType, t, allWaypoints.length, dateTimeLocale]);
 
   return columns;
 };

--- a/front/src/modules/timesStops/types.ts
+++ b/front/src/modules/timesStops/types.ts
@@ -28,8 +28,8 @@ export type TimesStopsRow = {
   theoreticalMarginSeconds?: string;
   calculatedMargin?: string;
   diffMargins?: string;
-  calculatedArrival?: string | null;
-  calculatedDeparture?: string | null;
+  calculatedArrival?: Date | null;
+  calculatedDeparture?: Date | null;
 
   isMarginValid?: boolean;
 };

--- a/front/src/modules/timetableItem/types.ts
+++ b/front/src/modules/timetableItem/types.ts
@@ -34,8 +34,6 @@ export type SuggestedOP = {
   theoreticalMarginSeconds?: string;
   calculatedMargin?: string;
   diffMargins?: string;
-  calculatedArrival?: string | null;
-  calculatedDeparture?: string | null;
   receptionSignal?: ReceptionSignal;
   // Metadatas given by ManageTimetableItemMap click event to add origin/destination/via
   metadata?: {


### PR DESCRIPTION
This is more type-safe and pushes date formatting to the component
level, so that we don't need to interpret strings meant for human
consumption only.

Fixes all output rows being marked as missing their schedule (with
an orange background).
