### PR TITLE
front: fix pan error in reference map

### DIFF
--- a/front/src/applications/referenceMap/Map.tsx
+++ b/front/src/applications/referenceMap/Map.tsx
@@ -22,9 +22,12 @@ const Map = () => {
 
   const mapRef = useRef<MapRef | null>(null);
 
-  const updateViewportChange = useCallback((value: Partial<Viewport>) => {
-    dispatch(updateMapViewerViewport(value));
-  }, []);
+  const updateViewportChange = useCallback(
+    (value: Partial<Viewport>, { updateRouter } = { updateRouter: false }) => {
+      dispatch(updateMapViewerViewport(value, updateRouter));
+    },
+    []
+  );
 
   const resetPitchBearing = () => {
     updateViewportChange({

--- a/front/src/reducers/mapViewer/index.ts
+++ b/front/src/reducers/mapViewer/index.ts
@@ -25,9 +25,11 @@ export const mapViewerSlice = createSlice({
   },
 });
 
-export function updateMapViewerViewport(viewport: Partial<Viewport>) {
+export function updateMapViewerViewport(viewport: Partial<Viewport>, updateRouter = false) {
   return (dispatch: Dispatch, getState: () => { mapViewer: MapViewerState }) => {
     dispatch(mapViewerSlice.actions.updateViewport(viewport));
+
+    if (!updateRouter) return;
 
     const {
       mapViewer: { mapSettings },


### PR DESCRIPTION
fix #13089 

In PR #11282, the `updateRouter` param has disappeared introducing history update more than necessary. 
See diff https://github.com/OpenRailAssociation/osrd/pull/11282/files#diff-71d4382e2a186675ab5ef9f1995f8ad9811b5b131beff795899d3894330bc90eL26