### PR TITLE
front: use innerText with proper timeout in expect.poll

### DIFF
--- a/front/tests/pages/operational-studies/scenario-timetable-section.ts
+++ b/front/tests/pages/operational-studies/scenario-timetable-section.ts
@@ -365,7 +365,9 @@ class ScenarioTimetableSection extends OpSimulationResultPage {
     await expect(this.timetableItemArrivalTime.nth(index)).toBeVisible();
     await expect(this.timetableItemArrivalTimeLoader).toBeHidden();
     await expect
-      .poll(async () => this.timetableItemArrivalTime.nth(index).textContent())
+      .poll(async () => await this.timetableItemArrivalTime.nth(index).innerText(), {
+        timeout: 30_000,
+      })
       .toBe(expectedArrivalTime);
   }
 


### PR DESCRIPTION
Fix flaky test 019 
Exemple : https://github.com/OpenRailAssociation/osrd/actions/runs/17608182134