### PR TITLE
ui-charts: allow interactions with quadrilateral layer

### DIFF
--- a/front/ui/storybook/stories/ui-charts/spaceTimeChart/quadrilateral.stories.tsx
+++ b/front/ui/storybook/stories/ui-charts/spaceTimeChart/quadrilateral.stories.tsx
@@ -1,10 +1,13 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import {
   SpaceTimeChart,
   PathLayer,
   Quadrilateral,
   type QuadrilateralProps,
+  isQuadrilaterPickingElement,
+  type Point,
+  Tooltip,
 } from '@osrd-project/ui-charts';
 import type { Meta } from '@storybook/react-vite';
 
@@ -24,19 +27,43 @@ type WrapperProps = {
   emptyData: boolean;
 };
 
-const QuadrilateralMock: QuadrilateralProps = {
-  vertices: [
-    { time: START_DATE.getTime() + HOUR, position: 3 * KILOMETER },
-    { time: START_DATE.getTime() + HOUR * 3, position: 3 * KILOMETER },
-    { time: START_DATE.getTime() + HOUR * 2, position: 11 * KILOMETER },
-    { time: START_DATE.getTime(), position: 11 * KILOMETER },
-  ],
-  style: {
-    backgroundColor: 'lightblue',
-    borderColor: 'red',
-    borderWidth: 1,
+const QuadrilateralMocks: QuadrilateralProps[] = [
+  {
+    id: 'P1',
+    vertices: [
+      { time: START_DATE.getTime() + HOUR, position: 3 * KILOMETER },
+      { time: START_DATE.getTime() + HOUR * 3, position: 3 * KILOMETER },
+      { time: START_DATE.getTime() + HOUR * 2, position: 11 * KILOMETER },
+      { time: START_DATE.getTime(), position: 11 * KILOMETER },
+    ],
+    style: {
+      backgroundColor: 'lightblue',
+      borderColor: 'red',
+      borderWidth: 1,
+    },
   },
-};
+  {
+    id: 'P2',
+    vertices: [
+      { time: START_DATE.getTime() + HOUR * 2, position: 30 * KILOMETER },
+      { time: START_DATE.getTime() + HOUR * 1, position: 30 * KILOMETER },
+      { time: START_DATE.getTime() + HOUR * 3, position: 70 * KILOMETER },
+      { time: START_DATE.getTime() + HOUR * 4, position: 70 * KILOMETER },
+    ],
+    style: {
+      backgroundColor: 'lightblue',
+      borderColor: 'blue',
+      borderWidth: 1,
+    },
+  },
+];
+
+const QuadrilaterTooltip = ({ position, id }: { position: Point; id: string }) => (
+  <Tooltip position={position}>
+    <div>{id}</div>
+  </Tooltip>
+);
+
 /**
  * This story aims at showcasing how to render a SpaceTimeChart.
  */
@@ -48,6 +75,9 @@ const Wrapper = ({
   spaceScaleType,
   emptyData,
 }: WrapperProps) => {
+  const [hoveredQuadrilater, setHoveredQuadrilater] = useState<string>();
+  const [cursorPosition, setCursorPosition] = useState<Point>();
+
   const operationalPoints = emptyData ? [] : OPERATIONAL_POINTS;
   const spaceScales = emptyData
     ? []
@@ -80,6 +110,16 @@ const Wrapper = ({
         timeScale={60000 / xZoomLevel}
         xOffset={xOffset}
         yOffset={yOffset}
+        onHoveredChildUpdate={({ item }) => {
+          if (item && isQuadrilaterPickingElement(item.element)) {
+            setHoveredQuadrilater(item.element.id);
+          } else {
+            setHoveredQuadrilater(undefined);
+          }
+        }}
+        onMouseMove={({ position }) => {
+          setCursorPosition(position);
+        }}
       >
         {paths.map((path) => (
           <PathLayer
@@ -90,7 +130,17 @@ const Wrapper = ({
             level={path.level || 2}
           />
         ))}
-        <Quadrilateral vertices={QuadrilateralMock.vertices} style={QuadrilateralMock.style} />
+        {QuadrilateralMocks.map((quadrilateral) => (
+          <Quadrilateral
+            key={quadrilateral.id}
+            id={quadrilateral.id}
+            vertices={quadrilateral.vertices}
+            style={quadrilateral.style}
+          />
+        ))}
+        {hoveredQuadrilater && cursorPosition && (
+          <QuadrilaterTooltip position={cursorPosition} id={hoveredQuadrilater} />
+        )}
       </SpaceTimeChart>
     </div>
   );

--- a/front/ui/ui-charts/src/spaceTimeChart/components/Quadrilateral.tsx
+++ b/front/ui/ui-charts/src/spaceTimeChart/components/Quadrilateral.tsx
@@ -1,9 +1,29 @@
 import { useCallback } from 'react';
 
-import { useDraw } from '../hooks/useCanvas';
-import { type DataPoint, type DrawingFunction } from '../lib/types';
+import { useDraw, usePicking } from '../hooks/useCanvas';
+import type {
+  DataPoint,
+  DrawingFunction,
+  PickingDrawingFunction,
+  PickingElement,
+  Point,
+} from '../lib/types';
+import { drawAliasedQuadrilateral } from '../utils/canvas';
+import { hexToRgb, indexToColor } from '../utils/colors';
+
+export type QuadrilaterPickingElement = PickingElement & {
+  type: 'quadrilateral';
+  id: string;
+};
+
+export function isQuadrilaterPickingElement(
+  element: PickingElement
+): element is QuadrilaterPickingElement {
+  return element.type === 'quadrilateral';
+}
 
 export type QuadrilateralProps = {
+  id: string;
   vertices: [DataPoint, DataPoint, DataPoint, DataPoint];
   style: {
     backgroundColor: string;
@@ -21,7 +41,7 @@ export type QuadrilateralProps = {
  *     vertices[3] /________/ vertices[2]
  *
  */
-export const Quadrilateral = ({ vertices, style }: QuadrilateralProps) => {
+export const Quadrilateral = ({ id, vertices, style }: QuadrilateralProps) => {
   const drawRegion = useCallback<DrawingFunction>(
     (ctx, { getSpacePixel, getTimePixel }) => {
       ctx.save();
@@ -43,6 +63,25 @@ export const Quadrilateral = ({ vertices, style }: QuadrilateralProps) => {
     [vertices, style]
   );
   useDraw('background', drawRegion);
+
+  const drawPicking = useCallback<PickingDrawingFunction>(
+    (imageData, { registerPickingElement, getTimePixel, getSpacePixel }, scalingRatio) => {
+      const points = vertices.map(
+        (vertice): Point => ({
+          x: getTimePixel(vertice.time),
+          y: getSpacePixel(vertice.position),
+        })
+      ) as [Point, Point, Point, Point];
+
+      const pickingElement: QuadrilaterPickingElement = { type: 'quadrilateral', id };
+      const index = registerPickingElement(pickingElement);
+      const color = hexToRgb(indexToColor(index));
+
+      drawAliasedQuadrilateral(imageData, points, color, scalingRatio);
+    },
+    [id, vertices]
+  );
+  usePicking('paths', drawPicking);
 
   return null;
 };

--- a/front/ui/ui-charts/src/spaceTimeChart/utils/canvas.ts
+++ b/front/ui/ui-charts/src/spaceTimeChart/utils/canvas.ts
@@ -213,6 +213,72 @@ export function drawAliasedDisc(
   }
 }
 
+/**
+ * Draws an aliased quadrilateral
+ *
+ *      vertices[0]   ________ vertices[1]
+ *                  /        /
+ *     vertices[3] /________/ vertices[2]
+ *
+ */
+export function drawAliasedQuadrilateral(
+  imageData: ImageData,
+  points: [Point, Point, Point, Point],
+  [r, g, b]: RGBColor | RGBAColor,
+  scalingRatio: number = 1
+): void {
+  const vertices = points.map((point) => ({
+    x: Math.round(point.x * scalingRatio),
+    y: Math.round(point.y * scalingRatio),
+  }));
+
+  let { x: xmin, x: xmax, y: ymin, y: ymax } = vertices[0];
+  for (let i = 1; i < vertices.length; i++) {
+    const { x, y } = vertices[i];
+    if (x < xmin) xmin = x;
+    else if (x > xmax) xmax = x;
+
+    if (y < ymin) ymin = y;
+    else if (y > ymax) ymax = y;
+  }
+
+  xmin = clamp(xmin, 0, imageData.width - 1);
+  ymin = clamp(ymin, 0, imageData.height - 1);
+  xmax = clamp(xmax, 0, imageData.width - 1);
+  ymax = clamp(ymax, 0, imageData.height - 1);
+
+  for (let y = ymin; y < ymax; y++) {
+    for (let x = xmin; x < xmax; x++) {
+      // Compute whether the point is inside the quadrilateral
+      // using the Ray casting algorithm (see https://en.wikipedia.org/wiki/Point_in_polygon)
+      let isInside = false;
+      for (let i = 0; i < vertices.length; i++) {
+        const pointA = vertices[i];
+        const pointB = i === vertices.length - 1 ? vertices[0] : vertices[i + 1];
+
+        // Line equation from A to B: y(x) = m * x + c
+        const m = (pointB.y - pointA.y) / (pointB.x - pointA.x);
+        const c = pointB.y - m * pointB.x;
+
+        // Invert the equation: x(y) = (y - c) / m
+        // Look only for points that are on the left of the line, so for a given y, x < (y - c) / m
+        if (pointA.y > y != pointB.y > y && x < (y - c) / m) {
+          isInside = !isInside;
+        }
+      }
+
+      // If the point is inside the quadrilateral, allow interactions with it
+      if (isInside) {
+        const index = (y * imageData.width + x) * 4;
+        imageData.data[index] = r;
+        imageData.data[index + 1] = g;
+        imageData.data[index + 2] = b;
+        imageData.data[index + 3] = 255;
+      }
+    }
+  }
+}
+
 export function drawAliasedRect(
   imageData: ImageData,
   { x, y }: Point,


### PR DESCRIPTION
closes #12835 

Check the story `Quadrilateral` of the `SpaceTime` chart
<img width="1618" height="660" alt="image" src="https://github.com/user-attachments/assets/bacd7dd0-58c3-4478-838e-00f0eec527ee" />
