### PR TITLE
core: stdcm: add timetable manager for local timetables

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/api/TimetableCacheManager.kt
+++ b/core/src/main/java/fr/sncf/osrd/api/TimetableCacheManager.kt
@@ -3,43 +3,25 @@ package fr.sncf.osrd.api
 import com.google.common.collect.ImmutableRangeSet
 import com.google.common.collect.Range
 import com.google.common.collect.RangeSet
-import com.google.common.collect.TreeRangeSet
-import com.squareup.moshi.Json
-import com.squareup.moshi.JsonAdapter
-import com.squareup.moshi.Moshi
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
-import fr.sncf.osrd.api.conflicts.TrainRequirementsById
-import fr.sncf.osrd.conflicts.SpacingRequirement
 import fr.sncf.osrd.sim_infra.api.RawInfra
 import fr.sncf.osrd.sim_infra.api.ZoneId
-import fr.sncf.osrd.utils.json.UnitAdapterFactory
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.annotations.WithSpan
 import java.nio.file.Files
-import java.time.Duration
-import java.time.Instant
-import java.time.ZonedDateTime
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.io.path.Path
 import kotlin.io.path.exists
 import kotlin.io.path.readBytes
 import kotlin.io.path.writeBytes
-import kotlin.math.pow
 import kotlinx.coroutines.*
-import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.cbor.Cbor
-import okhttp3.OkHttpClient
-import okhttp3.Request
-import okhttp3.Response
 import org.slf4j.LoggerFactory
 
 typealias TimetableId = Int
-
-private const val PAGE_SIZE = 100
 
 @JvmInline
 value class STDCMRequirements(val map: Map<ZoneId, RangeSet<Double>>) :
@@ -85,11 +67,9 @@ value class STDCMRequirements(val map: Map<ZoneId, RangeSet<Double>>) :
  * EPOCH.
  */
 class TimetableCacheManager(
-    baseUrl: String,
-    authenticationHeader: String,
-    httpClient: OkHttpClient,
+    val timetableProvider: TimetableProvider,
     val localCacheLocation: String? = null,
-) : APIClient(baseUrl, authenticationHeader, httpClient) {
+) {
     private val cache = ConcurrentHashMap<TimetableId, STDCMRequirements>()
     private val mutexes = ConcurrentHashMap<TimetableId, Mutex>()
 
@@ -143,92 +123,13 @@ class TimetableCacheManager(
     ): STDCMRequirements {
         logger.info("Fetching timetable requirements for $timetableId")
 
-        val res = mutableMapOf<ZoneId, RangeSet<Double>>()
         val requirements =
             withLocalCache(localCacheLocation, "$timetableId.cbor") {
-                runBlocking {
-                    val requirements = fetchTrainRequirements(infraId, infra, timetableId)
-                    requirements.collect { spacingReq ->
-                        val set = res.computeIfAbsent(spacingReq.zone) { TreeRangeSet.create() }
-                        set.add(Range.closedOpen(spacingReq.beginTime, spacingReq.endTime))
-                    }
-                    STDCMRequirements(res)
-                }
+                timetableProvider.getTimetableRequirements(infraId, infra, timetableId)
             }
 
         logger.info("Saved timetable requirements for $timetableId")
         return requirements
-    }
-
-    @OptIn(ExperimentalCoroutinesApi::class)
-    private fun fetchTrainRequirements(
-        infraId: String,
-        infra: RawInfra,
-        timetableId: TimetableId,
-    ): Flow<SpacingRequirement> = flow {
-        val firstPageTrainRequirements = getTrainPaginatedRequirements(infraId, timetableId, 1)
-        emitAll(
-            firstPageTrainRequirements.results
-                .flatMap {
-                    it.spacingRequirements.map { spacingReq ->
-                        SpacingRequirement.fromRJSWithAddedTime(
-                            spacingReq,
-                            infra,
-                            it.startTime.durationSinceEpoch(),
-                        )
-                    }
-                }
-                .asFlow()
-        )
-        emitAll(
-            (2..firstPageTrainRequirements.pageCount)
-                .asFlow()
-                // Limit the number of concurrent calls to the requirements endpoint.
-                .flatMapMerge(concurrency = 5) { page ->
-                    flow {
-                        val paginatedTrainRequirements =
-                            getTrainPaginatedRequirements(infraId, timetableId, page)
-                        paginatedTrainRequirements.results
-                            .flatMap {
-                                it.spacingRequirements.map { spacingReq ->
-                                    SpacingRequirement.fromRJSWithAddedTime(
-                                        spacingReq,
-                                        infra,
-                                        it.startTime.durationSinceEpoch(),
-                                    )
-                                }
-                            }
-                            .forEach { emit(it) }
-                    }
-                }
-        )
-    }
-
-    private fun getTrainPaginatedRequirements(
-        infraId: String,
-        timetableId: TimetableId,
-        page: Int,
-    ): PaginatedRequirements {
-        val endpointPath = "timetable/$timetableId/requirements/"
-        val request =
-            buildRequest(endpointPath, "infra_id=$infraId&page=$page&page_size=$PAGE_SIZE")
-        val response = getWithRetries(request)
-        return paginatedRequirementsAdapter.fromJson(response.body.source())!!
-    }
-
-    /** Try to access a request, retries on error with increasing delay */
-    private fun getWithRetries(request: Request, nRetries: Int = N_RETRIES): Response {
-        var response: Response? = null
-        for (tryCount in 1..<nRetries) {
-            response = httpClient.newCall(request).execute()
-            if (response.isSuccessful) return response
-            else {
-                logger.error("Error when getting ${request.url}: $response")
-                val nextSleepDuration = 1_000 * 2.0.pow(tryCount).toLong()
-                Thread.sleep(nextSleepDuration)
-            }
-        }
-        throw UnexpectedHttpResponse(response)
     }
 
     /**
@@ -262,25 +163,4 @@ class TimetableCacheManager(
             return map
         }
     }
-
-    private data class PaginatedRequirements(
-        @Json(name = "page_count") val pageCount: Int,
-        val results: List<TrainRequirementsById>,
-    )
-
-    private val paginatedRequirementsAdapter: JsonAdapter<PaginatedRequirements> =
-        Moshi.Builder()
-            .addLast(UnitAdapterFactory())
-            .addLast(KotlinJsonAdapterFactory())
-            .build()
-            .adapter(PaginatedRequirements::class.java)
-}
-
-val EPOCH_ZONED: ZonedDateTime = Instant.EPOCH.atZone(java.time.ZoneId.of("UTC"))
-
-const val N_RETRIES = 5
-
-/** Returns the duration since EPOCH, in seconds, precise to the millisecond. */
-fun ZonedDateTime.durationSinceEpoch(): Double {
-    return Duration.between(EPOCH_ZONED, this).toMillis() / 1000.0
 }

--- a/core/src/main/java/fr/sncf/osrd/api/TimetableProvider.kt
+++ b/core/src/main/java/fr/sncf/osrd/api/TimetableProvider.kt
@@ -1,0 +1,190 @@
+package fr.sncf.osrd.api
+
+import com.google.common.collect.Range
+import com.google.common.collect.RangeSet
+import com.google.common.collect.TreeRangeSet
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import fr.sncf.osrd.api.conflicts.TrainRequirementsById
+import fr.sncf.osrd.conflicts.SpacingRequirement
+import fr.sncf.osrd.sim_infra.api.RawInfra
+import fr.sncf.osrd.sim_infra.api.ZoneId
+import fr.sncf.osrd.utils.json.UnitAdapterFactory
+import java.time.Duration
+import java.time.Instant
+import java.time.ZonedDateTime
+import kotlin.io.path.Path
+import kotlin.io.path.readText
+import kotlin.math.pow
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flatMapMerge
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.runBlocking
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import org.slf4j.LoggerFactory
+
+private const val PAGE_SIZE = 100
+private const val N_RETRIES = 5
+
+private val logger = LoggerFactory.getLogger(TimetableProvider::class.java)
+
+interface TimetableProvider {
+    fun getTimetableRequirements(
+        infraId: String,
+        infra: RawInfra,
+        timetableId: TimetableId,
+    ): STDCMRequirements
+}
+
+class TimetableDownloader(baseUrl: String, authenticationHeader: String, httpClient: OkHttpClient) :
+    APIClient(baseUrl, authenticationHeader, httpClient), TimetableProvider {
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private fun fetchTrainRequirements(
+        infraId: String,
+        infra: RawInfra,
+        timetableId: TimetableId,
+    ): Flow<SpacingRequirement> = flow {
+        val firstPageTrainRequirements = getTrainPaginatedRequirements(infraId, timetableId, 1)
+        emitAll(
+            firstPageTrainRequirements.results
+                .flatMap {
+                    it.spacingRequirements.map { spacingReq ->
+                        SpacingRequirement.fromRJSWithAddedTime(
+                            spacingReq,
+                            infra,
+                            it.startTime.durationSinceEpoch(),
+                        )
+                    }
+                }
+                .asFlow()
+        )
+        emitAll(
+            (2..firstPageTrainRequirements.pageCount)
+                .asFlow()
+                // Limit the number of concurrent calls to the requirements endpoint.
+                .flatMapMerge(concurrency = 5) { page ->
+                    flow {
+                        val paginatedTrainRequirements =
+                            getTrainPaginatedRequirements(infraId, timetableId, page)
+                        paginatedTrainRequirements.results
+                            .flatMap {
+                                it.spacingRequirements.map { spacingReq ->
+                                    SpacingRequirement.fromRJSWithAddedTime(
+                                        spacingReq,
+                                        infra,
+                                        it.startTime.durationSinceEpoch(),
+                                    )
+                                }
+                            }
+                            .forEach { emit(it) }
+                    }
+                }
+        )
+    }
+
+    private fun getTrainPaginatedRequirements(
+        infraId: String,
+        timetableId: TimetableId,
+        page: Int,
+    ): PaginatedRequirements {
+        val endpointPath = "timetable/$timetableId/requirements/"
+        val request =
+            buildRequest(endpointPath, "infra_id=$infraId&page=$page&page_size=$PAGE_SIZE")
+        val response = getWithRetries(request)
+        return paginatedRequirementsAdapter.fromJson(response.body.source())!!
+    }
+
+    /** Try to access a request, retries on error with increasing delay */
+    private fun getWithRetries(request: Request, nRetries: Int = N_RETRIES): Response {
+        var response: Response? = null
+        for (tryCount in 1..<nRetries) {
+            response = httpClient.newCall(request).execute()
+            if (response.isSuccessful) return response
+            else {
+                logger.error("Error when getting ${request.url}: $response")
+                val nextSleepDuration = 1_000 * 2.0.pow(tryCount).toLong()
+                Thread.sleep(nextSleepDuration)
+            }
+        }
+        throw UnexpectedHttpResponse(response)
+    }
+
+    private data class PaginatedRequirements(
+        @Json(name = "page_count") val pageCount: Int,
+        val results: List<TrainRequirementsById>,
+    )
+
+    private val paginatedRequirementsAdapter: JsonAdapter<PaginatedRequirements> =
+        Moshi.Builder()
+            .addLast(UnitAdapterFactory())
+            .addLast(KotlinJsonAdapterFactory())
+            .build()
+            .adapter(PaginatedRequirements::class.java)
+
+    override fun getTimetableRequirements(
+        infraId: String,
+        infra: RawInfra,
+        timetableId: TimetableId,
+    ): STDCMRequirements {
+        return runBlocking {
+            val res = mutableMapOf<ZoneId, RangeSet<Double>>()
+            val requirements = fetchTrainRequirements(infraId, infra, timetableId)
+            requirements.collect { spacingReq ->
+                val set = res.computeIfAbsent(spacingReq.zone) { TreeRangeSet.create() }
+                set.add(Range.closedOpen(spacingReq.beginTime, spacingReq.endTime))
+            }
+            STDCMRequirements(res)
+        }
+    }
+}
+
+class JsonTimetableProvider(val timetableDirectory: String) : TimetableProvider {
+    override fun getTimetableRequirements(
+        infraId: String,
+        infra: RawInfra,
+        timetableId: TimetableId,
+    ): STDCMRequirements {
+        val type = Types.newParameterizedType(List::class.java, TrainRequirementsById::class.java)
+        val adapter: JsonAdapter<List<TrainRequirementsById>> =
+            Moshi.Builder()
+                .addLast(UnitAdapterFactory())
+                .addLast(KotlinJsonAdapterFactory())
+                .build()
+                .adapter(type)
+        val filePath = Path("$timetableDirectory/$timetableId.json")
+        logger.info("Fetching timetable requirements at json file $filePath")
+        val trains = adapter.fromJson(filePath.readText())!!
+        val res = mutableMapOf<ZoneId, RangeSet<Double>>()
+        val requirements =
+            trains.flatMap {
+                it.spacingRequirements.map { spacingReq ->
+                    SpacingRequirement.fromRJSWithAddedTime(
+                        spacingReq,
+                        infra,
+                        it.startTime.durationSinceEpoch(),
+                    )
+                }
+            }
+        for (spacingReq in requirements) {
+            val set = res.computeIfAbsent(spacingReq.zone) { TreeRangeSet.create() }
+            set.add(Range.closedOpen(spacingReq.beginTime, spacingReq.endTime))
+        }
+        return STDCMRequirements(res)
+    }
+}
+
+val EPOCH_ZONED: ZonedDateTime = Instant.EPOCH.atZone(java.time.ZoneId.of("UTC"))
+
+/** Returns the duration since EPOCH, in seconds, precise to the millisecond. */
+fun ZonedDateTime.durationSinceEpoch(): Double {
+    return Duration.between(EPOCH_ZONED, this).toMillis() / 1000.0
+}

--- a/core/src/main/java/fr/sncf/osrd/cli/ReproduceRequest.kt
+++ b/core/src/main/java/fr/sncf/osrd/cli/ReproduceRequest.kt
@@ -59,6 +59,11 @@ class ReproduceRequest : CliCommand {
         description = "Path to the railjson infra file, overriding the id given in the request",
     )
     private var railjson: String? = null
+    @Parameter(
+        names = ["--timetable-dir"],
+        description = "Path to the timetable directory, must contain timetable_id.json",
+    )
+    private var timetableDirectory: String? = null
     private val logger: Logger = LoggerFactory.getLogger("ReproduceRequest")
 
     @ExcludeFromGeneratedCodeCoverage
@@ -72,6 +77,10 @@ class ReproduceRequest : CliCommand {
                     val infra = FullInfra.fromRJSInfra(rjs, signalingSimulator)
                     FileInfraProvider(infra)
                 } else InfraManager(editoastUrl, editoastAuthorization, httpClient)
+            val timetableProvider =
+                if (timetableDirectory != null) JsonTimetableProvider(timetableDirectory!!)
+                else TimetableDownloader(editoastUrl, editoastAuthorization, httpClient)
+            val cacheManager = TimetableCacheManager(timetableProvider, timetableDirectory)
 
             fun <T> loadRequest(path: String, adapter: JsonAdapter<T>): T {
                 val fileSource = Path.of(path).source()
@@ -82,7 +91,7 @@ class ReproduceRequest : CliCommand {
             val time = measureTime {
                 if (stdcmPayloadPath != null) {
                     logger.info("running stdcm request at $stdcmPayloadPath")
-                    STDCMEndpoint(infraManager, TODO("reproduce with heavy payload format"))
+                    STDCMEndpoint(infraManager, cacheManager)
                         .run(loadRequest(stdcmPayloadPath!!, stdcmRequestAdapter))
                 }
                 if (pathfindingPayloadPath != null) {

--- a/core/src/main/java/fr/sncf/osrd/cli/WorkerCommand.kt
+++ b/core/src/main/java/fr/sncf/osrd/cli/WorkerCommand.kt
@@ -112,9 +112,7 @@ class WorkerCommand : CliCommand {
         val infraManager = InfraManager(editoastUrl, editoastAuthorization, httpClient)
         val timetableCache =
             TimetableCacheManager(
-                editoastUrl!!,
-                editoastAuthorization,
-                httpClient,
+                TimetableDownloader(editoastUrl!!, editoastAuthorization, httpClient),
                 LOCAL_TIMETABLE_CACHE,
             )
         val electricalProfileSetManager =


### PR DESCRIPTION
Fix https://github.com/OpenRailAssociation/osrd/issues/12569, that's the last part

Full workflow to reproduce a request seen in prod: 

1. Find a request in datadog
2. Get the editoast input payload there
3. Call the `/stdcm` endpoint on the same service in prod), with the same payload, and `return_debug_payloads=true` query param
4. Save the `core_payload` part into a json file
5. Use `scripts/download_stdcm_requirements.py` to download that timetable requirements
6. Create a `timetables` directory (likely in `core`), put the timetable requirement file as `timetables/xxx.json`
7. Run core `reproduce-request` like before, with a new `--timetable-dir timetables` parameter

Aaand you're done.

I'll likely add or modify scripts to simplify steps 3 to 6 eventually, maybe 2 as well (if possible). Once that's done I'll update the [debugging tips](https://github.com/OpenRailAssociation/osrd/blob/dev/core/stdcm_debugging_tips.md) file. 

We need to have https://github.com/OpenRailAssociation/osrd/pull/13078 merged and deployed **before** the requests are sent, but the tooling around can be modified over time. 

