### PR TITLE
front: fix space above the macro editor being too large

### DIFF
--- a/front/src/styles/scss/applications/operationalStudies/_scenario.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_scenario.scss
@@ -685,10 +685,8 @@
   .scenario-results {
     position: relative;
     width: 100%;
-    height: 100%;
     display: flex;
     flex-direction: column;
-    gap: 16px;
   }
 }
 


### PR DESCRIPTION
closes https://github.com/OpenRailAssociation/osrd/issues/13049