### PR TITLE
 editoast: add stdcm logging and reproducibility tools (backport)

### DIFF
--- a/editoast/core_client/src/simulation.rs
+++ b/editoast/core_client/src/simulation.rs
@@ -28,7 +28,7 @@ use super::pathfinding::TrackRange;
 use crate::AsCoreRequest;
 use crate::Json;
 
-#[derive(Debug, Clone, Serialize, Deserialize, Educe, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, Educe, PartialEq, ToSchema)]
 #[educe(Hash)]
 pub struct PhysicsConsist {
     pub effort_curves: EffortCurves,

--- a/editoast/core_client/src/stdcm.rs
+++ b/editoast/core_client/src/stdcm.rs
@@ -17,7 +17,7 @@ use crate::AsCoreRequest;
 use crate::Json;
 
 #[editoast_derive::openapi_schema]
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
 #[schema(as = StdcmRequest)]
 pub struct Request {
     /// Infrastructure id
@@ -64,7 +64,7 @@ pub struct Request {
     pub temporary_speed_limits: Vec<TemporarySpeedLimit>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, PartialEq, Deserialize)]
 pub struct PathItem {
     /// The track offsets of the path item
     pub locations: Vec<TrackOffset>,
@@ -75,7 +75,7 @@ pub struct PathItem {
 }
 
 /// Contains the data of a step timing, when it is specified
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, PartialEq, Deserialize)]
 pub struct StepTimingData {
     /// Time the train should arrive at this point
     pub arrival_time: DateTime<Utc>,
@@ -86,7 +86,7 @@ pub struct StepTimingData {
 }
 
 /// Lighter description of a work schedule, with only the relevant information for core
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, PartialEq, Deserialize)]
 pub struct WorkSchedule {
     /// Start time as a time delta from the stdcm start time in ms
     pub start_time: u64,
@@ -98,7 +98,7 @@ pub struct WorkSchedule {
 
 /// Lighter description of a work schedule with only the relevant information for core
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
 pub struct TemporarySpeedLimit {
     /// Speed limitation in m/s
     pub speed_limit: f64,

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -3718,13 +3718,6 @@ paths:
         with existing train schedules. It then returns both the conflict information
         and the pathfinding result from the virtual train's simulation.
       parameters:
-      - name: infra
-        in: query
-        description: The infra id
-        required: true
-        schema:
-          type: integer
-          format: int64
       - name: id
         in: path
         description: timetable_id
@@ -3732,6 +3725,20 @@ paths:
         schema:
           type: integer
           format: int64
+      - name: infra
+        in: query
+        description: The infra id
+        required: true
+        schema:
+          type: integer
+          format: int64
+      - name: return_debug_payloads
+        in: query
+        description: If true, extra payloads are returned to help with debugging
+        required: false
+        schema:
+          type: boolean
+          nullable: true
       requestBody:
         content:
           application/json:
@@ -3858,6 +3865,10 @@ paths:
                   - departure_time
                   - status
                   properties:
+                    core_payload:
+                      allOf:
+                      - $ref: '#/components/schemas/StdcmRequest'
+                      nullable: true
                     departure_time:
                       type: string
                       format: date-time
@@ -3873,6 +3884,10 @@ paths:
                   required:
                   - status
                   properties:
+                    core_payload:
+                      allOf:
+                      - $ref: '#/components/schemas/StdcmRequest'
+                      nullable: true
                     status:
                       type: string
                       enum:
@@ -3882,6 +3897,10 @@ paths:
                   - error
                   - status
                   properties:
+                    core_payload:
+                      allOf:
+                      - $ref: '#/components/schemas/StdcmRequest'
+                      nullable: true
                     error:
                       $ref: '#/components/schemas/SimulationResponse'
                     status:
@@ -13578,6 +13597,10 @@ components:
         - departure_time
         - status
         properties:
+          core_payload:
+            allOf:
+            - $ref: '#/components/schemas/StdcmRequest'
+            nullable: true
           departure_time:
             type: string
             format: date-time
@@ -13593,6 +13616,10 @@ components:
         required:
         - status
         properties:
+          core_payload:
+            allOf:
+            - $ref: '#/components/schemas/StdcmRequest'
+            nullable: true
           status:
             type: string
             enum:
@@ -13602,6 +13629,10 @@ components:
         - error
         - status
         properties:
+          core_payload:
+            allOf:
+            - $ref: '#/components/schemas/StdcmRequest'
+            nullable: true
           error:
             $ref: '#/components/schemas/SimulationResponse'
           status:

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -13,6 +13,7 @@ use core_client::AsCoreRequest;
 use core_client::CoreClient;
 use core_client::pathfinding::InvalidPathItem;
 use core_client::pathfinding::PathfindingResultSuccess;
+use core_client::stdcm::Request as StdcmRequest;
 use database::DbConnectionPoolV2;
 use editoast_derive::EditoastError;
 use request::Request;
@@ -58,11 +59,18 @@ pub(in crate::views) enum StdcmResponse {
         simulation: SimulationResponseSuccess,
         path: PathfindingResultSuccess,
         departure_time: DateTime<Utc>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        core_payload: Option<StdcmRequest>,
     },
-    PathNotFound,
+    PathNotFound {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        core_payload: Option<StdcmRequest>,
+    },
     PreprocessingSimulationError {
         #[schema(value_type = SimulationResponse)]
         error: simulation::Response,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        core_payload: Option<StdcmRequest>,
     },
 }
 
@@ -103,8 +111,16 @@ enum StdcmError {
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, IntoParams, ToSchema)]
-pub(in crate::views) struct InfraIdQueryParam {
+#[into_params(parameter_in = Query)]
+pub(in crate::views) struct StdcmQueryParams {
+    /// The infra id
+    #[param(required = true)]
     infra: i64,
+    /// If true, extra payloads are returned to help with debugging
+    #[schema(required = false)]
+    #[serde(default)]
+    #[param(nullable)]
+    return_debug_payloads: bool,
 }
 
 /// This function computes a STDCM and returns the result.
@@ -128,8 +144,9 @@ pub(in crate::views) struct InfraIdQueryParam {
     post, path = "",
     tag = "stdcm",
     request_body = inline(Request),
-    params(("infra" = i64, Query, description = "The infra id"),
+    params(
         ("id" = i64, Path, description = "timetable_id"),
+        StdcmQueryParams,
     ),
     responses(
         (status = 201, body = inline(StdcmResponse), description = "The simulation result"),
@@ -145,7 +162,7 @@ pub(in crate::views) async fn stdcm(
     }): State<AppState>,
     Extension(auth): AuthenticationExt,
     Path(id): Path<i64>,
-    Query(query): Query<InfraIdQueryParam>,
+    Query(query): Query<StdcmQueryParams>,
     Json(request): Json<Request>,
 ) -> Result<Json<StdcmResponse>> {
     // Add serialized request to trace attributes
@@ -228,6 +245,7 @@ pub(in crate::views) async fn stdcm(
     let Some(simulation_run_time) = virtual_train_run.simulation.simulation_run_time() else {
         return Ok(Json(StdcmResponse::PreprocessingSimulationError {
             error: virtual_train_run.simulation,
+            core_payload: None,
         }));
     };
 
@@ -235,7 +253,7 @@ pub(in crate::views) async fn stdcm(
     let latest_simulation_end = request.get_latest_simulation_end(simulation_run_time);
 
     // 5. Build STDCM request
-    let stdcm_request = core_client::stdcm::Request {
+    let stdcm_request = StdcmRequest {
         infra: infra.id,
         expected_version: infra.version,
         timetable_id,
@@ -267,6 +285,7 @@ pub(in crate::views) async fn stdcm(
             })
             .collect(),
     };
+    let returned_request = query.return_debug_payloads.then_some(stdcm_request.clone());
 
     let stdcm_response: Result<core_client::stdcm::Response, InternalError> = stdcm_request
         .fetch(core_client.as_ref())
@@ -283,8 +302,11 @@ pub(in crate::views) async fn stdcm(
             simulation: simulation.into(),
             path,
             departure_time,
+            core_payload: returned_request,
         })),
-        core_client::stdcm::Response::PathNotFound => Ok(Json(StdcmResponse::PathNotFound)),
+        core_client::stdcm::Response::PathNotFound => Ok(Json(StdcmResponse::PathNotFound {
+            core_payload: returned_request,
+        })),
     }
 }
 
@@ -750,7 +772,8 @@ mod tests {
                     simulation: simulation_response().success().unwrap().into(),
                     path,
                     departure_time: DateTime::from_str("2024-01-02T00:00:00Z")
-                        .expect("Failed to parse datetime")
+                        .expect("Failed to parse datetime"),
+                    core_payload: None,
                 }
             );
         }
@@ -893,7 +916,8 @@ mod tests {
                     simulation: simulation_response().success().unwrap().into(),
                     path,
                     departure_time: DateTime::from_str("2024-01-02T00:00:00Z")
-                        .expect("Failed to parse datetime")
+                        .expect("Failed to parse datetime"),
+                    core_payload: None,
                 }
             );
         }
@@ -925,7 +949,10 @@ mod tests {
         let stdcm_response: StdcmResponse =
             app.fetch(request).assert_status(StatusCode::OK).json_into();
 
-        assert_eq!(stdcm_response, StdcmResponse::PathNotFound);
+        assert_eq!(
+            stdcm_response,
+            StdcmResponse::PathNotFound { core_payload: None }
+        );
     }
 
     #[rstest]

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -27,6 +27,7 @@ use serde::Serialize;
 use std::slice;
 use std::sync::Arc;
 use thiserror::Error;
+use tracing::Span;
 use utoipa::IntoParams;
 use utoipa::ToSchema;
 
@@ -115,6 +116,13 @@ pub(in crate::views) struct InfraIdQueryParam {
 /// If the simulation fails, the function uses a virtual train to detect conflicts
 /// with existing train schedules. It then returns both the conflict information
 /// and the pathfinding result from the virtual train's simulation.
+#[tracing::instrument(
+    target = "editoast::timetable",
+    name = "stdcm",
+    skip_all,
+    err,
+    fields(request)
+)]
 #[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
@@ -140,6 +148,9 @@ pub(in crate::views) async fn stdcm(
     Query(query): Query<InfraIdQueryParam>,
     Json(request): Json<Request>,
 ) -> Result<Json<StdcmResponse>> {
+    // Add serialized request to trace attributes
+    Span::current().record("request", serde_json::to_string(&request)?);
+
     let authorized = auth
         .check_roles([authz::Role::Stdcm].into())
         .await

--- a/front/src/applications/stdcm/utils/formatStdcmConf.ts
+++ b/front/src/applications/stdcm/utils/formatStdcmConf.ts
@@ -212,6 +212,7 @@ export const formatStdcmPayload = (
 ): PostTimetableByIdStdcmApiArg => ({
   infra: validConfig.infraId,
   id: validConfig.timetableId,
+  returnDebugPayloads: false,
   body: {
     comfort: 'STANDARD',
     margin: createMargin(validConfig.margin),

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -1119,6 +1119,7 @@ const injectedRtkApi = api
           body: queryArg.body,
           params: {
             infra: queryArg.infra,
+            return_debug_payloads: queryArg.returnDebugPayloads,
           },
         }),
         invalidatesTags: ['stdcm'],
@@ -2295,23 +2296,28 @@ export type GetTimetableByIdRoundTripsTrainSchedulesApiArg = {
 };
 export type PostTimetableByIdStdcmApiResponse = /** status 201 The simulation result */
   | {
+      core_payload?: StdcmRequest | null;
       departure_time: string;
       path: PathfindingResultSuccess;
       simulation: SimulationResponseSuccess;
       status: 'success';
     }
   | {
+      core_payload?: StdcmRequest | null;
       status: 'path_not_found';
     }
   | {
+      core_payload?: StdcmRequest | null;
       error: SimulationResponse;
       status: 'preprocessing_simulation_error';
     };
 export type PostTimetableByIdStdcmApiArg = {
-  /** The infra id */
-  infra: number;
   /** timetable_id */
   id: number;
+  /** The infra id */
+  infra: number;
+  /** If true, extra payloads are returned to help with debugging */
+  returnDebugPayloads?: boolean | null;
   body: {
     comfort: Comfort;
     electrical_profile_set_id?: number | null;
@@ -4432,6 +4438,89 @@ export type TrainRequirementsById = {
   start_time: string;
   train_id: string;
 };
+export type WorkScheduleType = 'CATENARY' | 'TRACK';
+export type WorkSchedule = {
+  end_date_time: string;
+  id: number;
+  obj_id: string;
+  start_date_time: string;
+  track_ranges: TrackRange[];
+  work_schedule_group_id: number;
+  work_schedule_type: WorkScheduleType;
+};
+export type StdcmRequest = {
+  comfort: Comfort;
+  /** Infrastructure expected version */
+  expected_version: number;
+  /** Infrastructure id */
+  infra: number;
+  margin?:
+    | (
+        | {
+            Percentage: number;
+          }
+        | {
+            MinPer100Km: number;
+          }
+      )
+    | null;
+  /** Maximum departure delay in milliseconds. */
+  maximum_departure_delay: number;
+  /** Maximum run time of the simulation in milliseconds */
+  maximum_run_time: number;
+  /** List of waypoints. Each waypoint is a list of track offset. */
+  path_items: PathItem[];
+  physics_consist: {
+    base_power_class?: string | null;
+    comfort_acceleration: number;
+    /** The constant gamma braking coefficient used when NOT circulating
+        under ETCS/ERTMS signaling system */
+    const_gamma: number;
+    effort_curves: EffortCurves;
+    /** The time the train takes before actually using electrical power.
+        Is null if the train is not electric or the value not specified. */
+    electrical_power_startup_time?: number | null;
+    etcs_brake_params?: EtcsBrakeParams | null;
+    inertia_coefficient: number;
+    /** Length of the rolling stock */
+    length: number;
+    /** Mass of the rolling stock */
+    mass: number;
+    /** Maximum speed of the rolling stock */
+    max_speed: number;
+    /** Mapping of power restriction code to power class */
+    power_restrictions?: {
+      [key: string]: string;
+    };
+    /** The time it takes to raise this train's pantograph.
+        Is null if the train is not electric or the value not specified. */
+    raise_pantograph_time?: number | null;
+    rolling_resistance: RollingResistance;
+    startup_acceleration: number;
+    startup_time: number;
+  };
+  rolling_stock_loading_gauge: LoadingGaugeType;
+  rolling_stock_supported_signaling_systems: RollingStockSupportedSignalingSystems;
+  speed_limit_tag?: string | null;
+  start_time: string;
+  /** List of applicable temporary speed limits between the train departure and arrival */
+  temporary_speed_limits: {
+    /** Speed limitation in m/s */
+    speed_limit: number;
+    /** Track ranges on which the speed limitation applies */
+    track_ranges: TrackRange[];
+  }[];
+  /** Gap between the created train and following trains in milliseconds */
+  time_gap_after: number;
+  /** Gap between the created train and previous trains in milliseconds */
+  time_gap_before: number;
+  /** Numerical integration time step in milliseconds. Use default value if not specified. */
+  time_step?: number | null;
+  /** Timetable id */
+  timetable_id: number;
+  /** List of planned work schedules */
+  work_schedules: WorkSchedule[];
+};
 export type PathfindingItem = {
   /** The stop duration in milliseconds, None if the train does not stop. */
   duration?: number | null;
@@ -4589,16 +4678,6 @@ export type WorkScheduleItemForm = {
   start_date_time: string;
   track_ranges: TrackRange[];
   work_schedule_type: 'CATENARY' | 'TRACK';
-};
-export type WorkScheduleType = 'CATENARY' | 'TRACK';
-export type WorkSchedule = {
-  end_date_time: string;
-  id: number;
-  obj_id: string;
-  start_date_time: string;
-  track_ranges: TrackRange[];
-  work_schedule_group_id: number;
-  work_schedule_type: WorkScheduleType;
 };
 export type Intersection = {
   /** Distance of the end of the intersection relative to the beginning of the path */


### PR DESCRIPTION
Backport of https://github.com/OpenRailAssociation/osrd/pull/13078, to be merged after https://github.com/OpenRailAssociation/osrd/pull/13129 (that's the first two commits)

Not a bugfix, but I believe it's *quite* important to have a way to reproduce user requests in prod environment. Especially the ones that lead to external user feedback.

~~Note: there are some small changes on the editoast part compared to the commits on dev, as we also need to handle the "conflict" case (removed since).~~ Not true anymore after rebasing on @Erashin's first PR