### PR TITLE
front: compute isTooFast on each scheduled steps interval

### DIFF
--- a/front/src/applications/operationalStudies/__tests__/sampleData.ts
+++ b/front/src/applications/operationalStudies/__tests__/sampleData.ts
@@ -413,6 +413,80 @@ export const trainSummaryTooFast: Extract<SimulationSummaryResult, { status: 'su
   path_item_times_base: [0, 1444453, 2491479],
 };
 
+export const trainScheduleTooFastOnInterval: TrainScheduleWithTrainId = {
+  id: 'trainschedule_38366' as TrainScheduleId,
+  train_name: 'tooFastOnInterval',
+  labels: [],
+  rolling_stock_name: 'rs-fictive',
+  start_time: '2026-12-13T07:25:00Z',
+  path: [
+    {
+      id: 'idA',
+      deleted: false,
+      uic: 87700000,
+      secondary_code: 'BV',
+      track_reference: null,
+    },
+    {
+      id: 'idB',
+      deleted: false,
+      uic: 87700001,
+      secondary_code: 'BV',
+      track_reference: null,
+    },
+    {
+      id: 'idC',
+      deleted: false,
+      uic: 87700002,
+      secondary_code: 'BV',
+      track_reference: null,
+    },
+  ],
+  schedule: [
+    {
+      at: 'idB',
+      arrival: 'PT5280S',
+      stop_for: null,
+      reception_signal: 'OPEN',
+      locked: false,
+    },
+    {
+      at: 'idC',
+      arrival: 'PT15300S',
+      stop_for: 'P0D',
+      reception_signal: 'OPEN',
+      locked: false,
+    },
+  ],
+  margins: {
+    boundaries: ['idC'],
+    values: ['6.5min/100km', '0%'],
+  },
+  initial_speed: 0,
+  comfort: 'STANDARD',
+  constraint_distribution: 'STANDARD',
+  speed_limit_tag: null,
+  power_restrictions: [],
+  options: {
+    use_electrical_profiles: true,
+    use_speed_limits_for_simulation: true,
+  },
+  category: null,
+};
+
+export const trainSummaryTooFastOnInterval: Extract<
+  SimulationSummaryResult,
+  { status: 'success' }
+> = {
+  status: 'success',
+  length: 544740000,
+  time: 15300915,
+  energy_consumption: 12116583709.633162,
+  path_item_times_final: [0, 5280030, 15300915],
+  path_item_times_provisional: [0, 5222392, 15267584],
+  path_item_times_base: [0, 4730243, 13828795],
+};
+
 export const trainScheduleNotHonored: TrainScheduleWithTrainId = {
   id: 'trainschedule-96' as TrainScheduleId,
   train_name: 'notHonored',

--- a/front/src/applications/operationalStudies/__tests__/utils.spec.ts
+++ b/front/src/applications/operationalStudies/__tests__/utils.spec.ts
@@ -25,9 +25,11 @@ import {
   trainScheduleNoSchedule,
   trainScheduleNotHonored,
   trainScheduleTooFast,
+  trainScheduleTooFastOnInterval,
   trainSummaryHonored,
   trainSummaryNotHonored,
   trainSummaryTooFast,
+  trainSummaryTooFastOnInterval,
 } from './sampleData';
 
 describe('transformBoundariesDataToPositionDataArray', () => {
@@ -95,6 +97,14 @@ describe('formatElectrificationRanges', () => {
 describe('isTooFast', () => {
   it('should return true if the train is too fast', () => {
     const result = isTooFast(trainScheduleTooFast, trainSummaryTooFast);
+    expect(result).toBe(true);
+  });
+
+  it('should return true if the train is too fast on an interval only', () => {
+    // Case where the final time at C is higher than the provisional time at C,
+    // and the final time at B is higher than the provisional time at B,
+    // but the final travel time from B to C is lower than the provisional travel time from B to C.
+    const result = isTooFast(trainScheduleTooFastOnInterval, trainSummaryTooFastOnInterval);
     expect(result).toBe(true);
   });
 

--- a/front/src/applications/operationalStudies/utils.ts
+++ b/front/src/applications/operationalStudies/utils.ts
@@ -263,7 +263,8 @@ export const getPathItemByIndexDict = (timetableItemResult: TimetableItem) =>
   }, {} as Dictionary<number>);
 
 /**
- * Check if the item is too fast with a timetable item and a timetable item summary
+ * Check if the item is too fast with a timetable item and a timetable item summary,
+ * meaning that it does not respect the requested margin between at least 2 scheduled steps (steps with an arrival time or a margin set)
  * @param timetableItem
  * @param timetableItemSummary
  * @returns true if the train is too fast
@@ -279,24 +280,38 @@ export const isTooFast = (
     throw new Error('Assertion failed');
   }
 
-  const toCheckPathItemIds = new Set(timetableItem.margins?.boundaries);
-  timetableItem.schedule?.forEach((schedule) => {
-    if (schedule.arrival) {
-      toCheckPathItemIds.add(schedule.at);
+  const marginBoundariesSet = new Set(timetableItem.margins?.boundaries);
+  const toCheckPathItemIds: string[] = [];
+  timetableItem.schedule?.forEach((schedule, i) => {
+    if (!i || schedule.arrival || marginBoundariesSet.has(schedule.at)) {
+      toCheckPathItemIds.push(schedule.at);
     }
   });
-  toCheckPathItemIds.add(timetableItem.path[timetableItem.path.length - 1].id);
-
-  if (toCheckPathItemIds.size === 0) return false;
+  const lastStepId = timetableItem.path[timetableItem.path.length - 1].id;
+  if (toCheckPathItemIds[toCheckPathItemIds.length - 1] !== lastStepId)
+    toCheckPathItemIds.push(lastStepId);
 
   const pathItemMap = getPathItemByIndexDict(timetableItem);
 
-  for (const pathItemId of toCheckPathItemIds) {
+  for (let j = 0; j < toCheckPathItemIds.length; j++) {
+    const pathItemId = toCheckPathItemIds[j];
     const pathItemIndex = pathItemMap[pathItemId];
     const pathItemTimeFinal = timetableItemSummary.path_item_times_final[pathItemIndex];
     const pathItemTimeProvisional = timetableItemSummary.path_item_times_provisional[pathItemIndex];
 
-    if (pathItemTimeProvisional > pathItemTimeFinal + ARRIVAL_TIME_ACCEPTABLE_ERROR.ms) return true;
+    const prevPathItemId = j ? toCheckPathItemIds[j - 1] : timetableItem.path[0].id;
+    const prevPathItemIndex = pathItemMap[prevPathItemId];
+    const prevPathItemTimeFinal = timetableItemSummary.path_item_times_final[prevPathItemIndex];
+    const prevPathItemTimeProvisional =
+      timetableItemSummary.path_item_times_provisional[prevPathItemIndex];
+
+    const intervalDurationFinal = pathItemTimeFinal - prevPathItemTimeFinal;
+    const intervalDurationProvisional = pathItemTimeProvisional - prevPathItemTimeProvisional;
+    const marginDiff = intervalDurationFinal - intervalDurationProvisional;
+
+    if (marginDiff < -ARRIVAL_TIME_ACCEPTABLE_ERROR.ms) {
+      return true;
+    }
   }
   return false;
 };

--- a/front/src/modules/timesStops/helpers/computeMargins.ts
+++ b/front/src/modules/timesStops/helpers/computeMargins.ts
@@ -77,7 +77,7 @@ function computeMargins(
     }
   }
 
-  // durations to go from the last pathStep with theorical margin to the next pathStep
+  // durations to go from the last pathStep with theoretical margin to the next pathStep
   // base = no margin
   // provisional = margins
   // final = margins + requested arrival times


### PR DESCRIPTION
Close #13126

isTooFast used to check the final time at a scheduled step was too low compared to the provisional time at that step, computed from the start to that step.

This was not coherent with the warning indicators displayed in the timetable, as they computed the difference in margins from a scheduled step to the next.

Align isTooFast with the warnings in the table, and compute the time differences on each interval.

Also fix a typo in a comment (theorical -> theoretical).