### PR TITLE
front: fix stdcm maps synchro

### DIFF
--- a/front/src/applications/stdcm/components/StdcmForm/StdcmConfig.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmConfig.tsx
@@ -10,7 +10,7 @@ import { extractMarkersInfo } from 'applications/stdcm/utils';
 import DefaultBaseMap from 'common/Map/DefaultBaseMap';
 import useInfraStatus from 'modules/pathfinding/hooks/useInfraStatus';
 import { useStoreDataForRollingStockSelector } from 'modules/rollingStock/components/RollingStockSelector/useStoreDataForRollingStockSelector';
-import { useMapSettings, useMapSettingsActions } from 'reducers/commonMap';
+import { useMapSettings } from 'reducers/commonMap';
 import type { Viewport } from 'reducers/commonMap/types';
 import { resetMargins, restoreStdcmConfig, updateStdcmPathStep } from 'reducers/osrdconf/stdcmConf';
 import {
@@ -107,10 +107,12 @@ const StdcmConfig = ({
   const activePerimeter = useSelector(getActivePerimeter);
 
   const mapSettings = useMapSettings();
-  const { updateMapSettings: updateMapSettingsAction } = useMapSettingsActions();
+
+  // Keep local state of the viewport to keep stdcm config and stdcm results maps independent
+  const [stdcmConfigViewport, setStdcmConfigViewport] = useState<Viewport>(mapSettings.viewport);
 
   const updateViewport = (viewport: Viewport) => {
-    dispatch(updateMapSettingsAction({ ...mapSettings, viewport }));
+    setStdcmConfigViewport(viewport);
   };
 
   const [showMessage, setShowMessage] = useState(false);
@@ -362,7 +364,7 @@ const StdcmConfig = ({
             pathStepMarkers={markersInfo}
             highlightedArea={activePerimeter?.geometry}
             highlightedOperationalPoints={activePerimeter?.operationalPoints}
-            mapSettings={mapSettings}
+            mapSettings={{ ...mapSettings, viewport: stdcmConfigViewport }}
             updateViewport={updateViewport}
           >
             <StdcmMapActivePerimeter />

--- a/front/src/applications/stdcm/components/StdcmForm/StdcmConfig.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmConfig.tsx
@@ -11,7 +11,7 @@ import DefaultBaseMap from 'common/Map/DefaultBaseMap';
 import useInfraStatus from 'modules/pathfinding/hooks/useInfraStatus';
 import { useStoreDataForRollingStockSelector } from 'modules/rollingStock/components/RollingStockSelector/useStoreDataForRollingStockSelector';
 import { useMapSettings, useMapSettingsActions } from 'reducers/commonMap';
-import type { MapSettings } from 'reducers/commonMap/types';
+import type { Viewport } from 'reducers/commonMap/types';
 import { resetMargins, restoreStdcmConfig, updateStdcmPathStep } from 'reducers/osrdconf/stdcmConf';
 import {
   getActivePerimeter,
@@ -109,8 +109,8 @@ const StdcmConfig = ({
   const mapSettings = useMapSettings();
   const { updateMapSettings: updateMapSettingsAction } = useMapSettingsActions();
 
-  const updateMapSettings = (partialMapSettings: Partial<MapSettings>) => {
-    dispatch(updateMapSettingsAction(partialMapSettings));
+  const updateViewport = (viewport: Viewport) => {
+    dispatch(updateMapSettingsAction({ ...mapSettings, viewport }));
   };
 
   const [showMessage, setShowMessage] = useState(false);
@@ -363,7 +363,7 @@ const StdcmConfig = ({
             highlightedArea={activePerimeter?.geometry}
             highlightedOperationalPoints={activePerimeter?.operationalPoints}
             mapSettings={mapSettings}
-            updateMapSettings={updateMapSettings}
+            updateViewport={updateViewport}
           >
             <StdcmMapActivePerimeter />
           </DefaultBaseMap>

--- a/front/src/applications/stdcm/components/StdcmResults/StdcmResults.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/StdcmResults.tsx
@@ -15,7 +15,7 @@ import {
   generateCodeNumber,
   getOperationalPointsWithTimes,
 } from 'modules/SimulationReportSheet/utils/formatSimulationReportSheet';
-import { useMapSettings, useMapSettingsActions } from 'reducers/commonMap';
+import { useMapSettings } from 'reducers/commonMap';
 import type { Viewport } from 'reducers/commonMap/types';
 import {
   getRetainedSimulationIndex,
@@ -23,7 +23,6 @@ import {
   getStdcmInfraID,
   getStdcmTimetableID,
 } from 'reducers/osrdconf/stdcmConf/selectors';
-import { useAppDispatch } from 'store';
 import useDeploymentSettings from 'utils/hooks/useDeploymentSettings';
 
 import StdcmDebugResults from './StdcmDebugResults';
@@ -55,18 +54,20 @@ const StdcmResults = ({
 }: StcdmResultsProps) => {
   const infraId = useSelector(getStdcmInfraID);
   const timetableId = useSelector(getStdcmTimetableID);
-  const dispatch = useAppDispatch();
 
   const { t } = useTranslation('stdcm', { keyPrefix: 'simulation.results' });
   const deploymentSettings = useDeploymentSettings();
 
   const selectedSimulation = useSelector(getSelectedSimulation);
   const retainedSimulationIndex = useSelector(getRetainedSimulationIndex);
+
   const mapSettings = useMapSettings();
-  const { updateMapSettings: updateMapSettingsAction } = useMapSettingsActions();
+
+  // Keep local state of the viewport to keep stdcm config and stdcm results maps independent
+  const [stdcmResultsViewport, setStdcmResultsViewport] = useState<Viewport>(mapSettings.viewport);
 
   const updateViewport = (viewport: Viewport) => {
-    dispatch(updateMapSettingsAction({ ...mapSettings, viewport }));
+    setStdcmResultsViewport(viewport);
   };
 
   const { outputs, alternativePath } = selectedSimulation;
@@ -246,7 +247,7 @@ const StdcmResults = ({
                 geometry={hasSimulationResults ? outputs?.pathProperties.geometry : undefined}
                 pathStepMarkers={markersInfo}
                 isFeasible={hasSimulationResults}
-                mapSettings={mapSettings}
+                mapSettings={{ ...mapSettings, viewport: stdcmResultsViewport }}
                 updateViewport={updateViewport}
               />
             </div>

--- a/front/src/applications/stdcm/components/StdcmResults/StdcmResults.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/StdcmResults.tsx
@@ -16,7 +16,7 @@ import {
   getOperationalPointsWithTimes,
 } from 'modules/SimulationReportSheet/utils/formatSimulationReportSheet';
 import { useMapSettings, useMapSettingsActions } from 'reducers/commonMap';
-import type { MapSettings } from 'reducers/commonMap/types';
+import type { Viewport } from 'reducers/commonMap/types';
 import {
   getRetainedSimulationIndex,
   getSelectedSimulation,
@@ -65,8 +65,8 @@ const StdcmResults = ({
   const mapSettings = useMapSettings();
   const { updateMapSettings: updateMapSettingsAction } = useMapSettingsActions();
 
-  const updateMapSettings = (partialMapSettings: Partial<MapSettings>) => {
-    dispatch(updateMapSettingsAction(partialMapSettings));
+  const updateViewport = (viewport: Viewport) => {
+    dispatch(updateMapSettingsAction({ ...mapSettings, viewport }));
   };
 
   const { outputs, alternativePath } = selectedSimulation;
@@ -247,7 +247,7 @@ const StdcmResults = ({
                 pathStepMarkers={markersInfo}
                 isFeasible={hasSimulationResults}
                 mapSettings={mapSettings}
-                updateMapSettings={updateMapSettings}
+                updateViewport={updateViewport}
               />
             </div>
           </div>

--- a/front/src/common/Map/DefaultBaseMap.tsx
+++ b/front/src/common/Map/DefaultBaseMap.tsx
@@ -23,7 +23,7 @@ type DefaultBaseMapProps = {
   pathStepMarkers?: MarkerInformation[];
   isFeasible?: boolean;
   mapSettings: MapSettings;
-  updateMapSettings: (mapSettings: Partial<MapSettings>) => void;
+  updateViewport: (viewPort: Viewport) => void;
   highlightedArea?: Geometry;
   highlightedOperationalPoints?: number[];
 };
@@ -43,7 +43,7 @@ const DefaultBaseMap = ({
   isFeasible = true,
   children,
   mapSettings,
-  updateMapSettings,
+  updateViewport,
   highlightedArea,
   highlightedOperationalPoints,
 }: PropsWithChildren<DefaultBaseMapProps>) => {
@@ -52,9 +52,9 @@ const DefaultBaseMap = ({
 
   const updateViewportChange = useCallback(
     (partialViewPort: Partial<Viewport>) => {
-      updateMapSettings({ viewport: { ...viewport, ...partialViewPort } });
+      updateViewport({ ...viewport, ...partialViewPort });
     },
-    [updateMapSettings, viewport]
+    [updateViewport, viewport]
   );
   const resetPitchBearing = () => {
     updateViewportChange({


### PR DESCRIPTION
fix #13064

> [!NOTE]
> The issue refers only about viewport synchronization but ideally it would be preferable if all settings of maps would be independent but this requires a larger refacto and can be done in another PR