### PR TITLE
editoast: fix similar train's train schedules stop collection

### DIFF
--- a/editoast/schemas/src/train_schedule/path_item.rs
+++ b/editoast/schemas/src/train_schedule/path_item.rs
@@ -94,3 +94,15 @@ pub enum OperationalPointIdentifier {
         secondary_code: Option<String>,
     },
 }
+
+impl PathItemLocation {
+    pub fn identifier(&self) -> Option<&str> {
+        match self {
+            Self::OperationalPointReference(OperationalPointReference {
+                reference: OperationalPointIdentifier::OperationalPointId { operational_point },
+                ..
+            }) => Some(operational_point.as_str()),
+            _ => None,
+        }
+    }
+}

--- a/editoast/src/views/timetable/similar_trains.rs
+++ b/editoast/src/views/timetable/similar_trains.rs
@@ -595,7 +595,17 @@ async fn simulate_past_trains(
             )| {
                 let stop_ids = ts
                     .iter_stops()
-                    .map(|path_item| OperationalPoint(path_item.id.as_str().into()))
+                    .flat_map(|path_item| match path_item.location.identifier() {
+                        Some(id) => Some(OperationalPoint(id.into())),
+                        None => {
+                            tracing::warn!(
+                                ts.id,
+                                ?path_item,
+                                "ignoring non ID-referenced path item"
+                            );
+                            None
+                        }
+                    })
                     .collect::<HashSet<_>>();
                 let ops =
                     operational_points

--- a/editoast/src/views/timetable/similar_trains/new_train.rs
+++ b/editoast/src/views/timetable/similar_trains/new_train.rs
@@ -35,6 +35,7 @@ impl Waypoint {
     }
 }
 
+#[derive(Debug)]
 pub(super) struct NewTrain {
     waypoints: Vec<Waypoint>,
 }


### PR DESCRIPTION
We used to collect path items' IDs which are just a counter (`key` would
be a better name...).  Now we use the operational point ID correctly.

Signed-off-by: Leo Valais <leo.valais97@gmail.com>
