### PR TITLE
front: allow to hide/display intermediate waypoints in output table

### DIFF
--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -482,6 +482,7 @@
   },
   "simulationResults": {
     "departureTime": "Departure",
+    "displayWaypoints": "Display intermediate waypoints",
     "electricalProfiles": {
       "incompatible": "incompatible",
       "incompatibleMode": "Incompatible mode",
@@ -496,6 +497,7 @@
     "errorMessages": {
       "errorLoadingInfra": "Infrastructure loading error"
     },
+    "hideWaypoints": "Hide intermediate waypoints",
     "infraLoading": "Infrastructure is loading",
     "manchetteSettings": {
       "waypointsVisibility": "show/hide OP"

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -482,6 +482,7 @@
   },
   "simulationResults": {
     "departureTime": "Départ",
+    "displayWaypoints": "Afficher les points de passage intermédiaires",
     "electricalProfiles": {
       "incompatible": "incompatible",
       "incompatibleMode": "Mode incompatible",
@@ -496,6 +497,7 @@
     "errorMessages": {
       "errorLoadingInfra": "Erreur de chargement de l'infrastructure"
     },
+    "hideWaypoints": "Masquer les points de passage intermédiaires",
     "infraLoading": "Infrastructure en cours de chargement",
     "manchetteSettings": {
       "waypointsVisibility": "Modifier la visibilité des PRs"

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
@@ -24,8 +24,11 @@ import TimesStopsOutput from 'modules/timesStops/TimesStopsOutput';
 import { findExceptionWithOccurrenceId } from 'modules/timetableItem/helpers/pacedTrain';
 import type { TimetableItemWithDetails } from 'modules/timetableItem/types';
 import type { TimetableItemId, TrainId } from 'reducers/osrdconf/types';
-import { updateSelectedTrainId } from 'reducers/simulationResults';
-import { getTrainIdUsedForProjection } from 'reducers/simulationResults/selectors';
+import { toggleDisplayOnlyPathSteps, updateSelectedTrainId } from 'reducers/simulationResults';
+import {
+  getTrainIdUsedForProjection,
+  getDisplayOnlyPathSteps,
+} from 'reducers/simulationResults/selectors';
 import { useAppDispatch } from 'store';
 import {
   extractPacedTrainIdFromOccurrenceId,
@@ -66,6 +69,7 @@ const SimulationResults = ({
   const simulationResults = useSimulationResults();
   const selectedTrainId = simulationResults?.train.id;
 
+  const displayOnlyPathSteps = useSelector(getDisplayOnlyPathSteps);
   const trainIdUsedForProjection = useSelector(getTrainIdUsedForProjection);
 
   const [showWarpedMap, setShowWarpedMap] = useState(false);
@@ -323,6 +327,17 @@ const SimulationResults = ({
           <BoardWrapper
             hidden={!activeBoards.has('tables')}
             name={t('simulationResults.timetableOutput')}
+            items={[
+              {
+                title: displayOnlyPathSteps
+                  ? t('simulationResults.displayWaypoints')
+                  : t('simulationResults.hideWaypoints'),
+                icon: <Eye />,
+                onClick: () => {
+                  dispatch(toggleDisplayOnlyPathSteps());
+                },
+              },
+            ]}
           >
             <div className="time-stop-outputs">
               <TimesStopsOutput

--- a/front/src/modules/timesStops/hooks/useOutputTableData.ts
+++ b/front/src/modules/timesStops/hooks/useOutputTableData.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 
 import { keyBy } from 'lodash';
 import { useTranslation } from 'react-i18next';
+import { useSelector } from 'react-redux';
 
 import { useScenarioContext } from 'applications/operationalStudies/hooks/useScenarioContext';
 import useTrainOps from 'applications/operationalStudies/hooks/useTrainOps';
@@ -11,6 +12,7 @@ import { matchPathStepAndOp } from 'modules/pathfinding/utils';
 import { interpolateValue } from 'modules/simulationResult/helpers/utils';
 import type { SimulationSummary } from 'modules/timetableItem/types';
 import type { Train } from 'reducers/osrdconf/types';
+import { getDisplayOnlyPathSteps } from 'reducers/simulationResults/selectors';
 import { useDateTimeLocale } from 'utils/date';
 import { Duration } from 'utils/duration';
 
@@ -32,6 +34,7 @@ const useOutputTableData = (
   const { t } = useTranslation('operational-studies');
   const dateTimeLocale = useDateTimeLocale();
   const { getTrackSectionsByIds } = useScenarioContext();
+  const displayOnlyPathSteps = useSelector(getDisplayOnlyPathSteps);
 
   const pathStepOps = useTrainOps(infraId, selectedTrain);
 
@@ -147,14 +150,14 @@ const useOutputTableData = (
 
       const pathStepRowsById = await formatPathStepRows(selectedTrain);
 
-      let formattedRows = Array.from(pathStepRowsById.values());
+      let formattedRows: TimesStopsRow[] = [];
 
       // For valid trains, complete the rows with the simulated path's operational points and tracks information
       if (isValid && simulatedTrain && operationalPointsOnPath) {
         const trackIds = operationalPointsOnPath.map((op) => op.part.track);
         const trackSectionsOnPath = await getTrackSectionsByIds(trackIds);
 
-        formattedRows = operationalPointsOnPath.map((op): TimesStopsRow => {
+        for (const op of operationalPointsOnPath) {
           const trackName = trackSectionsOnPath[op.part.track]?.extensions?.sncf?.track_name;
 
           // early return if the op matches a pathStep (handled in formatPathStepRows)
@@ -173,38 +176,46 @@ const useOutputTableData = (
             ? pathStepRowsById.get(matchingPathStep.id)
             : undefined;
           if (matchingPathStepRow) {
-            return {
+            formattedRows.push({
               ...matchingPathStepRow,
               trackName,
-            };
+            });
+          } else if (!displayOnlyPathSteps) {
+            // Compute arrival time when the operational point comes from the simulation
+            const matchingReportTrainIndex = simulatedTrain.positions.findIndex(
+              (position) => position === op.position
+            );
+            const time =
+              matchingReportTrainIndex === -1
+                ? interpolateValue(simulatedTrain, op.position, 'times')
+                : simulatedTrain.times[matchingReportTrainIndex];
+            const calculatedArrival = new Date(new Date(selectedTrain.start_time).getTime() + time);
+
+            formattedRows.push({
+              opId: op.id,
+              pathStepId: undefined,
+              name: op.extensions?.identifier?.name,
+              ch: op.extensions?.sncf?.ch,
+              trackName,
+              calculatedArrival: calculatedArrival.toLocaleTimeString(dateTimeLocale),
+            });
           }
-
-          // Compute arrival time when the operational point comes from the simulation
-          const matchingReportTrainIndex = simulatedTrain.positions.findIndex(
-            (position) => position === op.position
-          );
-          const time =
-            matchingReportTrainIndex === -1
-              ? interpolateValue(simulatedTrain, op.position, 'times')
-              : simulatedTrain.times[matchingReportTrainIndex];
-          const calculatedArrival = new Date(new Date(selectedTrain.start_time).getTime() + time);
-
-          return {
-            pathStepId: undefined,
-            opId: op.id,
-            name: op.extensions?.identifier?.name,
-            ch: op.extensions?.sncf?.ch,
-            trackName,
-            calculatedArrival: calculatedArrival.toLocaleTimeString(dateTimeLocale),
-          };
-        });
+        }
+      } else {
+        formattedRows = Array.from(pathStepRowsById.values());
       }
 
       setRows(formattedRows);
     };
 
     formatRows();
-  }, [pathStepOps, operationalPointsOnPath, simulatedTrain, getTrackSectionsByIds]);
+  }, [
+    pathStepOps,
+    operationalPointsOnPath,
+    simulatedTrain,
+    getTrackSectionsByIds,
+    displayOnlyPathSteps,
+  ]);
 
   return rows;
 };

--- a/front/src/reducers/simulationResults/index.ts
+++ b/front/src/reducers/simulationResults/index.ts
@@ -10,12 +10,16 @@ export const simulationResultsInitialState: SimulationResultsState = {
   selectedTrainId: undefined,
   trainIdUsedForProjection: undefined,
   projectionType: 'trackProjection',
+  displayOnlyPathSteps: false,
 };
 
 export const simulationResultsSlice = createSlice({
   name: 'simulation',
   initialState: simulationResultsInitialState,
   reducers: {
+    toggleDisplayOnlyPathSteps(state: Draft<SimulationResultsState>) {
+      state.displayOnlyPathSteps = !state.displayOnlyPathSteps;
+    },
     updateSelectedTrainId(
       state: Draft<SimulationResultsState>,
       action: PayloadAction<TrainId | undefined>
@@ -79,6 +83,7 @@ export const simulationResultsSlice = createSlice({
 });
 
 export const {
+  toggleDisplayOnlyPathSteps,
   updateSelectedTrainId,
   updateTrainIdUsedForProjection,
   updateProjectionType,

--- a/front/src/reducers/simulationResults/selectors.ts
+++ b/front/src/reducers/simulationResults/selectors.ts
@@ -7,6 +7,7 @@ export const getSimulationResults = (state: RootState) => state.simulation;
 
 const makeOsrdSimulationSelector = makeSubSelector<SimulationResultsState>(getSimulationResults);
 
+export const getDisplayOnlyPathSteps = makeOsrdSimulationSelector('displayOnlyPathSteps');
 export const getSelectedTrainId = makeOsrdSimulationSelector('selectedTrainId');
 export const getTrainIdUsedForProjection = makeOsrdSimulationSelector('trainIdUsedForProjection');
 export const getProjectionType = makeOsrdSimulationSelector('projectionType');

--- a/front/src/reducers/simulationResults/types.ts
+++ b/front/src/reducers/simulationResults/types.ts
@@ -35,4 +35,5 @@ export type SimulationResultsState = {
   selectedTrainId?: TrainId;
   trainIdUsedForProjection?: TrainScheduleId | PacedTrainId | OccurrenceId;
   projectionType: ProjectionType;
+  displayOnlyPathSteps: boolean;
 };


### PR DESCRIPTION
[Capture vidéo du 2025-09-11 17-07-41.webm](https://github.com/user-attachments/assets/521aa9a3-c643-4b87-9a2d-952064eeb720)

note: I didn't change the number of each row because it comes from the library DataSheetGrid. We might enhance this later.