### PR TITLE
front: fix detector invisible editor

### DIFF
--- a/front/src/common/Map/Layers/InfraObjectLayers/Detectors.tsx
+++ b/front/src/common/Map/Layers/InfraObjectLayers/Detectors.tsx
@@ -31,13 +31,13 @@ export function getDetectorsLayerProps(params: {
     filter: params.highlightedArea ? ['within', params.highlightedArea] : true,
     paint: {
       'circle-stroke-color': chroma(params.colors.detectors.circle)
-        .alpha(params.alpha !== undefined ? params.alpha : 0)
+        .alpha(params.alpha ?? 1)
         .css(),
-      'circle-stroke-width': params.stroke !== undefined ? params.stroke : 2,
+      'circle-stroke-width': params.stroke ?? 2,
       'circle-color': chroma(params.colors.detectors.circleOther)
-        .alpha(params.alpha !== undefined ? params.alpha : 0)
+        .alpha(params.alpha ?? 1)
         .css(),
-      'circle-radius': params.radius !== undefined ? params.radius : 3,
+      'circle-radius': params.radius ?? 3,
     },
   };
 

--- a/front/src/common/Map/Layers/InfraObjectLayers/GeoJSONs.tsx
+++ b/front/src/common/Map/Layers/InfraObjectLayers/GeoJSONs.tsx
@@ -15,7 +15,11 @@ import { useMapSettings } from 'reducers/globalMap';
 import type { MapState } from 'reducers/map';
 
 import { getBufferStopsLayerProps } from './BufferStops';
-import { getDetectorsLayerProps, getDetectorsNameLayerProps } from './Detectors';
+import {
+  DETECTOR_CIRCLES_DEF,
+  getDetectorsLayerProps,
+  getDetectorsNameLayerProps,
+} from './Detectors';
 import { getElectrificationsProps, getElectrificationsTextParams } from './Electrifications';
 import {
   getPSLSpeedLineBGLayerProps,
@@ -260,8 +264,20 @@ function getElectrificationsLayers(context: LayerContext, prefix: string): Layer
 function getDetectorsLayers(context: LayerContext, prefix: string): LayerProps[] {
   return [
     {
-      ...getDetectorsLayerProps(context),
-      id: `${prefix}geo/detector-main`,
+      ...getDetectorsLayerProps({ ...context, ...DETECTOR_CIRCLES_DEF[0] }),
+      id: `${prefix}geo/detectors-3`,
+      beforeId: `${prefix}geo/detectors-2`,
+      minzoom: POINT_ENTITIES_MIN_ZOOM,
+    },
+    {
+      ...getDetectorsLayerProps({ ...context, ...DETECTOR_CIRCLES_DEF[1] }),
+      id: `${prefix}geo/detectors-2`,
+      beforeId: `${prefix}geo/detectors-1`,
+      minzoom: POINT_ENTITIES_MIN_ZOOM,
+    },
+    {
+      ...getDetectorsLayerProps({ ...context, ...DETECTOR_CIRCLES_DEF[2] }),
+      id: `${prefix}geo/detectors-1`,
       minzoom: POINT_ENTITIES_MIN_ZOOM,
     },
     {


### PR DESCRIPTION
Close #13192

The getDetectorsLayerProps got updated in #12652, and so did its usage in map, but not its usage in the infra editor. 

Thus update the usage of getDetectorsLayerProps by infra editor.

As an aside, I really dislike the fact we do everything twice, with a slightly different architecture, between the map and the infra editor. This leads to bugs like this one and many others, as well as to a lot more burden placed on the developer when working on these components. Changing this would be a lot of work though haha.