### PR TITLE
ui-charts: use pixelated image rendering for picking canvas

### DIFF
--- a/front/ui/ui-charts/src/spaceTimeChart/hooks/useCanvas.ts
+++ b/front/ui/ui-charts/src/spaceTimeChart/hooks/useCanvas.ts
@@ -243,6 +243,7 @@ export function useCanvas(
         canvas.style.height = size.height + 'px';
         canvas.setAttribute('width', Math.max(1, size.width * ratio) + 'px');
         canvas.setAttribute('height', Math.max(1, size.height * ratio) + 'px');
+        if (isPicking) canvas.style.imageRendering = 'pixelated';
 
         if (!isPicking) {
           // Reset the transform to identity, then apply the new scale


### PR DESCRIPTION
This makes it easier to look at the rendered canvas when debugging.

To test, inspect the picking `<canvas>` and disable the `display: none` CSS rule.

Before:

<img width="1234" height="619" alt="out" src="https://github.com/user-attachments/assets/43890c21-f00f-4f1f-ab58-a6724801f001" />

After:

<img width="1245" height="627" alt="out" src="https://github.com/user-attachments/assets/1dca6509-deff-45ba-ab2a-cfc204aeb906" />
