### PR TITLE
front: fix stuck loader when hot-reloading NGE

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
@@ -20,6 +20,7 @@ import type {
 } from 'reducers/osrdconf/types';
 import { updateSelectedTrainId } from 'reducers/simulationResults';
 import { useAppDispatch } from 'store';
+import { usePrevious } from 'utils/hooks/state';
 import {
   formatEditoastIdToExceptionId,
   formatEditoastIdToIndexedOccurrenceId,
@@ -116,9 +117,11 @@ const ScenarioContent = ({ activeBoards }: ScenarioContentProps) => {
     }
   }, [i18n.language]);
 
+  const prevMacroActive = usePrevious(activeBoards.has('macro'));
+
   useEffect(() => {
     if (activeBoards.has('macro')) {
-      setNGEIsLoading(true);
+      if (!prevMacroActive) setNGEIsLoading(true);
       refreshNge();
     }
   }, [activeBoards.has('macro')]);


### PR DESCRIPTION
During development, when NGE is hot-reloaded, the loader would get stuck. Fix this by checking if NGE was already loaded before showing the loader.

To test, open NGE, then e.g. save `ngeToOsrd.ts` without any change or with just a comment added.