### PR TITLE
editoast: remove usage of `paste`

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -581,9 +581,9 @@ dependencies = [
 
 [[package]]
 name = "axum-tracing-opentelemetry"
-version = "0.30.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "446fb36f90022f7d98f3a42ada9ba6b16e97ce783ca514080e1991fa801cd025"
+checksum = "dd3e188039e0e9e3dce1ad873358fd6bab72e6496e18b898bc36d72c07af4b26"
 dependencies = [
  "axum",
  "futures-core",
@@ -1411,7 +1411,6 @@ dependencies = [
  "opentelemetry_sdk",
  "ordered-float",
  "osrdyne_client",
- "paste",
  "pathfinding",
  "petgraph",
  "postgis_diesel",
@@ -1454,7 +1453,6 @@ version = "0.1.0"
 dependencies = [
  "darling 0.21.3",
  "insta",
- "paste",
  "pretty_assertions",
  "prettyplease",
  "proc-macro2",
@@ -1481,7 +1479,6 @@ dependencies = [
  "linkme",
  "openssl",
  "opentelemetry-semantic-conventions",
- "paste",
  "postgis_diesel",
  "postgres-openssl",
  "regex",
@@ -1623,7 +1620,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3345,12 +3342,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "pathfinding"
 version = "4.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4146,7 +4137,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4763,7 +4754,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.8",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5145,9 +5136,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry-instrumentation-sdk"
-version = "0.30.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bad2c5f9f4756ba524eee2722ffb18332b362283beb1d18c9692fb408fa7db"
+checksum = "a13836788f587ab71400ef44b07196430782b5e483e189933c38dddb81381574"
 dependencies = [
  "http",
  "opentelemetry",

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -87,7 +87,6 @@ opentelemetry-semantic-conventions = { version = "0.26", features = [
 ] }
 opentelemetry_sdk = { version = "0.30.0", features = ["rt-tokio", "trace"] }
 osrdyne_client = { path = "./osrdyne_client" }
-paste = "1.0.15"
 postgis_diesel = { version = "2.5.0", features = ["serde"] }
 postgres-openssl = "0.5.1"
 pretty_assertions = "1.4.1"
@@ -200,7 +199,6 @@ opentelemetry-semantic-conventions.workspace = true
 opentelemetry_sdk.workspace = true
 ordered-float = { version = "5.0.0", features = ["serde"] }
 osrdyne_client.workspace = true
-paste.workspace = true
 pathfinding = "4.14.0"
 petgraph = "0.8.2"
 postgis_diesel.workspace = true

--- a/editoast/editoast_derive/Cargo.toml
+++ b/editoast/editoast_derive/Cargo.toml
@@ -8,7 +8,6 @@ edition.workspace = true
 
 [dependencies]
 darling.workspace = true
-paste.workspace = true
 proc-macro2.workspace = true
 quote.workspace = true
 serde_json.workspace = true

--- a/editoast/editoast_derive/src/model/codegen/model_fields_impl_block.rs
+++ b/editoast/editoast_derive/src/model/codegen/model_fields_impl_block.rs
@@ -1,6 +1,19 @@
 use super::np;
+use proc_macro2::Ident;
+use proc_macro2::Span;
 use quote::ToTokens;
 use quote::quote;
+
+fn to_snake_case_upper(s: &str) -> String {
+    let mut result = String::new();
+    for c in s.chars() {
+        if c.is_uppercase() && !result.is_empty() {
+            result.push('_');
+        }
+        result.push(c.to_uppercase().next().unwrap());
+    }
+    result
+}
 
 pub(crate) struct ModelFieldsImplBlock {
     pub(super) model: syn::Ident,
@@ -25,14 +38,15 @@ impl ToTokens for ModelFieldsImplBlock {
             .iter()
             .map(|field| {
                 let ModelFieldDecl { name, ty, column } = field;
-                np!(name, ty, column)
+                let const_name =
+                    Ident::new(&to_snake_case_upper(&name.to_string()), Span::call_site());
+                np!(const_name, ty, column)
             })
             .unzip();
+
         tokens.extend(quote! {
-            paste::paste! {
-                impl #model {
-                    #(pub const [< #name:snake:upper >]: #field_wrapper<#model, #ty, #column> = #field_wrapper(core::marker::PhantomData);)*
-                }
+            impl #model {
+                #(pub const #name: #field_wrapper<#model, #ty, #column> = #field_wrapper(core::marker::PhantomData);)*
             }
         });
     }

--- a/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__construction.snap
+++ b/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__construction.snap
@@ -28,14 +28,20 @@ impl crate::prelude::Model for Document {
 }
 #[doc(hidden)]
 struct _DocumentField<M, T, Column>(core::marker::PhantomData<(M, T, Column)>);
-paste::paste! {
-    impl Document { pub const [< id_ : snake : upper >] : _DocumentField < Document, i64,
-    id > = _DocumentField(core::marker::PhantomData); pub const [< content_type : snake :
-    upper >] : _DocumentField < Document, String,
-    database::tables::osrd_infra_document::content_type > =
-    _DocumentField(core::marker::PhantomData); pub const [< data : snake : upper >] :
-    _DocumentField < Document, Vec < u8 >, database::tables::osrd_infra_document::data >
-    = _DocumentField(core::marker::PhantomData); }
+impl Document {
+    pub const ID_: _DocumentField<Document, i64, id> = _DocumentField(
+        core::marker::PhantomData,
+    );
+    pub const CONTENT_TYPE: _DocumentField<
+        Document,
+        String,
+        database::tables::osrd_infra_document::content_type,
+    > = _DocumentField(core::marker::PhantomData);
+    pub const DATA: _DocumentField<
+        Document,
+        Vec<u8>,
+        database::tables::osrd_infra_document::data,
+    > = _DocumentField(core::marker::PhantomData);
 }
 impl _DocumentField<Document, i64, id> {
     pub fn eq(&self, value: i64) -> crate::prelude::FilterSetting<Document> {

--- a/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__single_pk_model.snap
+++ b/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__single_pk_model.snap
@@ -22,10 +22,10 @@ impl crate::prelude::Model for Timetable {
 }
 #[doc(hidden)]
 struct _TimetableField<M, T, Column>(core::marker::PhantomData<(M, T, Column)>);
-paste::paste! {
-    impl Timetable { pub const [< id : snake : upper >] : _TimetableField < Timetable,
-    i64, database::tables::timetable::id > = _TimetableField(core::marker::PhantomData);
-    }
+impl Timetable {
+    pub const ID: _TimetableField<Timetable, i64, database::tables::timetable::id> = _TimetableField(
+        core::marker::PhantomData,
+    );
 }
 impl _TimetableField<Timetable, i64, database::tables::timetable::id> {
     pub fn eq(&self, value: i64) -> crate::prelude::FilterSetting<Timetable> {

--- a/editoast/editoast_models/Cargo.toml
+++ b/editoast/editoast_models/Cargo.toml
@@ -21,7 +21,6 @@ futures-util.workspace = true
 linkme.workspace = true
 openssl.workspace = true
 opentelemetry-semantic-conventions.workspace = true
-paste.workspace = true
 postgis_diesel.workspace = true
 postgres-openssl.workspace = true
 regex.workspace = true

--- a/editoast/src/infra_cache/operation/create.rs
+++ b/editoast/src/infra_cache/operation/create.rs
@@ -49,31 +49,35 @@ pub mod tests {
     use schemas::infra::TrackSection;
 
     macro_rules! test_create_object {
-        ($obj:ident) => {
-            paste::paste! {
-                #[rstest::rstest]
-                async fn [<test_create_ $obj:snake>]() {
-                    let db_pool = database::DbConnectionPoolV2::for_tests();
-                    let infra = crate::models::fixtures::create_empty_infra(&mut db_pool.get_ok()).await;
-                    let infra_object = schemas::infra::InfraObject::$obj {
-                        railjson: $obj::default(),
-                    };
-                    let result = crate::infra_cache::operation::create::apply_create_operation(&infra_object, infra.id, &mut db_pool.get_ok()).await;
-                    assert!(result.is_ok(), "Failed to create a {}", stringify!($obj));
-                }
+        ($obj:ident, $test_fn:ident) => {
+            #[rstest::rstest]
+            async fn $test_fn() {
+                let db_pool = database::DbConnectionPoolV2::for_tests();
+                let infra =
+                    crate::models::fixtures::create_empty_infra(&mut db_pool.get_ok()).await;
+                let infra_object = schemas::infra::InfraObject::$obj {
+                    railjson: $obj::default(),
+                };
+                let result = crate::infra_cache::operation::create::apply_create_operation(
+                    &infra_object,
+                    infra.id,
+                    &mut db_pool.get_ok(),
+                )
+                .await;
+                assert!(result.is_ok(), "Failed to create a {}", stringify!($obj));
             }
         };
     }
 
-    test_create_object!(TrackSection);
-    test_create_object!(Signal);
-    test_create_object!(SpeedSection);
-    test_create_object!(Switch);
-    test_create_object!(Detector);
-    test_create_object!(BufferStop);
-    test_create_object!(Route);
-    test_create_object!(OperationalPoint);
-    test_create_object!(SwitchType);
-    test_create_object!(Electrification);
-    test_create_object!(NeutralSection);
+    test_create_object!(TrackSection, test_create_track_section);
+    test_create_object!(Signal, test_create_signal);
+    test_create_object!(SpeedSection, test_create_speed_section);
+    test_create_object!(Switch, test_create_switch);
+    test_create_object!(Detector, test_create_detector);
+    test_create_object!(BufferStop, test_create_buffer_stop);
+    test_create_object!(Route, test_create_route);
+    test_create_object!(OperationalPoint, test_create_operational_point);
+    test_create_object!(SwitchType, test_create_switch_type);
+    test_create_object!(Electrification, test_create_electrification);
+    test_create_object!(NeutralSection, test_create_neutral_section);
 }

--- a/editoast/src/infra_cache/operation/delete.rs
+++ b/editoast/src/infra_cache/operation/delete.rs
@@ -86,48 +86,58 @@ mod tests {
     }
 
     macro_rules! test_delete_object {
-        ($obj:ident) => {
-            paste::paste! {
-                #[rstest::rstest]
-                async fn [<test_delete_$obj:snake>]() {
-                    use diesel_async::RunQueryDsl;
-                    use std::ops::DerefMut;
+        ($obj:ident, $test_fn:ident, $obj_name:literal) => {
+            #[rstest::rstest]
+            async fn $test_fn() {
+                use diesel_async::RunQueryDsl;
+                use std::ops::DerefMut;
 
-                    let db_pool = DbConnectionPoolV2::for_tests();
-                    let infra = crate::models::fixtures::create_empty_infra(&mut db_pool.get_ok()).await;
+                let db_pool = DbConnectionPoolV2::for_tests();
+                let infra = crate::models::fixtures::create_empty_infra(&mut db_pool.get_ok()).await;
 
-                    let railjson_object = schemas::infra::InfraObject::$obj {
-                        railjson: $obj::default(),
-                    };
-                    let result = crate::infra_cache::operation::create::apply_create_operation(&railjson_object, infra.id, &mut db_pool.get_ok()).await;
-                    assert!(result.is_ok(), "Failed to create a {}", stringify!($obj));
+                let railjson_object = schemas::infra::InfraObject::$obj {
+                    railjson: $obj::default(),
+                };
+                let result = crate::infra_cache::operation::create::apply_create_operation(&railjson_object, infra.id, &mut db_pool.get_ok()).await;
+                assert!(result.is_ok(), "Failed to create a {}", stringify!($obj));
 
-                    let object_deletion: crate::infra_cache::operation::delete::DeleteOperation = railjson_object.get_ref().into();
-                    let result = object_deletion.apply(infra.id, &mut db_pool.get_ok()).await;
-                    assert!(result.is_ok(), "Failed to delete a {}", stringify!($obj));
+                let object_deletion: crate::infra_cache::operation::delete::DeleteOperation = railjson_object.get_ref().into();
+                let result = object_deletion.apply(infra.id, &mut db_pool.get_ok()).await;
+                assert!(result.is_ok(), "Failed to delete a {}", stringify!($obj));
 
-                    let res_del = diesel::sql_query(format!(
-                            "SELECT COUNT (*) AS nb FROM infra_object_{} WHERE obj_id = '{}' AND infra_id = {}",
-                            stringify!([<$obj:snake>]),
-                            railjson_object.get_id(),
-                            infra.id
-                        ))
-                        .get_result::<Count>(&mut db_pool.get_ok().write().await.deref_mut()).await.unwrap();
+                let res_del = diesel::sql_query(format!(
+                        "SELECT COUNT (*) AS nb FROM infra_object_{} WHERE obj_id = '{}' AND infra_id = {}",
+                        $obj_name,
+                        railjson_object.get_id(),
+                        infra.id
+                    ))
+                    .get_result::<Count>(&mut db_pool.get_ok().write().await.deref_mut()).await.unwrap();
 
-                    pretty_assertions::assert_eq!(res_del.nb, 0);
-                }
+                pretty_assertions::assert_eq!(res_del.nb, 0);
             }
         };
     }
 
-    test_delete_object!(TrackSection);
-    test_delete_object!(Signal);
-    test_delete_object!(SpeedSection);
-    test_delete_object!(Switch);
-    test_delete_object!(Detector);
-    test_delete_object!(BufferStop);
-    test_delete_object!(Route);
-    test_delete_object!(OperationalPoint);
-    test_delete_object!(Electrification);
-    test_delete_object!(NeutralSection);
+    test_delete_object!(TrackSection, test_delete_track_section, "track_section");
+    test_delete_object!(Signal, test_delete_signal, "signal");
+    test_delete_object!(SpeedSection, test_delete_speed_section, "speed_section");
+    test_delete_object!(Switch, test_delete_switch, "switch");
+    test_delete_object!(Detector, test_delete_detector, "detector");
+    test_delete_object!(BufferStop, test_delete_buffer_stop, "buffer_stop");
+    test_delete_object!(Route, test_delete_route, "route");
+    test_delete_object!(
+        OperationalPoint,
+        test_delete_operational_point,
+        "operational_point"
+    );
+    test_delete_object!(
+        Electrification,
+        test_delete_electrification,
+        "electrification"
+    );
+    test_delete_object!(
+        NeutralSection,
+        test_delete_neutral_section,
+        "neutral_section"
+    );
 }

--- a/editoast/src/models/infra_objects.rs
+++ b/editoast/src/models/infra_objects.rs
@@ -297,31 +297,34 @@ mod tests_persist {
     use super::*;
 
     macro_rules! test_persist {
-        ($obj:ident) => {
-            paste::paste! {
-                #[rstest::rstest]
-                async fn [<test_persist_ $obj:snake>]() {
-                    let db_pool =  database::DbConnectionPoolV2::for_tests();
-                    let infra =  crate::models::fixtures::create_empty_infra(&mut db_pool.get_ok()).await;
-                    let schemas = (0..10).map(|_| Default::default());
-                    let changesets = $obj::from_infra_schemas(infra.id, schemas);
-                    assert!($obj::create_batch::<_, Vec<_>>(&mut db_pool.get_ok(), changesets).await.is_ok());
-                }
+        ($obj:ident, $test_fn:ident) => {
+            #[rstest::rstest]
+            async fn $test_fn() {
+                let db_pool = database::DbConnectionPoolV2::for_tests();
+                let infra =
+                    crate::models::fixtures::create_empty_infra(&mut db_pool.get_ok()).await;
+                let schemas = (0..10).map(|_| Default::default());
+                let changesets = $obj::from_infra_schemas(infra.id, schemas);
+                assert!(
+                    $obj::create_batch::<_, Vec<_>>(&mut db_pool.get_ok(), changesets)
+                        .await
+                        .is_ok()
+                );
             }
         };
     }
 
-    test_persist!(TrackSectionModel);
-    test_persist!(BufferStopModel);
-    test_persist!(ElectrificationModel);
-    test_persist!(DetectorModel);
-    test_persist!(OperationalPointModel);
-    test_persist!(RouteModel);
-    test_persist!(SignalModel);
-    test_persist!(SwitchModel);
-    test_persist!(SpeedSectionModel);
-    test_persist!(SwitchTypeModel);
-    test_persist!(NeutralSectionModel);
+    test_persist!(TrackSectionModel, test_persist_track_section_model);
+    test_persist!(BufferStopModel, test_persist_buffer_stop_model);
+    test_persist!(ElectrificationModel, test_persist_electrification_model);
+    test_persist!(DetectorModel, test_persist_detector_model);
+    test_persist!(OperationalPointModel, test_persist_operational_point_model);
+    test_persist!(RouteModel, test_persist_route_model);
+    test_persist!(SignalModel, test_persist_signal_model);
+    test_persist!(SwitchModel, test_persist_switch_model);
+    test_persist!(SpeedSectionModel, test_persist_speed_section_model);
+    test_persist!(SwitchTypeModel, test_persist_switch_type_model);
+    test_persist!(NeutralSectionModel, test_persist_neutral_section_model);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The crate `paste` isn't maintained anymore. (Bonus: now snapshots are
formatted properly.)

Signed-off-by: Leo Valais <leo.valais97@gmail.com>
