### PR TITLE
ui-charts: avoid drawing more frames than can be displayed

### DIFF
--- a/front/ui/ui-charts/src/spaceTimeChart/hooks/useCanvas.ts
+++ b/front/ui/ui-charts/src/spaceTimeChart/hooks/useCanvas.ts
@@ -223,7 +223,7 @@ export function useCanvas(
     // Cache latest context in ref:
     stcContextRef.current = inputStcContext;
 
-    draw();
+    scheduleRendering();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [inputStcContext.fingerprint]);
 


### PR DESCRIPTION
We'd draw onto the canvas faster than the screen can display a new frame, wasting CPU/GPU cycles. Throttle redraws with requestAnimationFrame() to avoid this.

To test, open a space time chart on Chromium with this small patch to display the number of frames drawn per second, then jiggle the mouse. Before the patch it would show a number higher than the screen's refresh rate (e.g. ~120 on a ~60 Hz screen), after the patch it should max out at the screens' refresh rate. Note, Firefox throttles input events so the issue can't be easily reproduced there (but could manifest itself via another source of events).

<details>

<summary>Hack patch to display FPS</summary>

```diff
diff --git a/front/ui/ui-charts/src/spaceTimeChart/hooks/useCanvas.ts b/front/ui/ui-charts/src/spaceTimeChart/hooks/useCanvas.ts
index 411d5d4a88ff..140fbd78363c 100644
--- a/front/ui/ui-charts/src/spaceTimeChart/hooks/useCanvas.ts
+++ b/front/ui/ui-charts/src/spaceTimeChart/hooks/useCanvas.ts
@@ -112,7 +112,9 @@ export function useCanvas(
   /**
    * This function draws everything that needs to be drawn, and clears the scheduleRef state:
    */
+  const fps = useRef(0);
   const draw = useCallback(() => {
+    fps.current++;
     drawRendering(stcContextRef.current);
     drawPicking(stcContextRef.current);
 
@@ -123,6 +125,16 @@ export function useCanvas(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  useEffect(() => {
+    const id = setInterval(() => {
+      console.log('Frames per second', fps.current);
+      fps.current = 0;
+    }, 1000);
+    return () => {
+      clearInterval(id);
+    };
+  }, []);
+
   /**
    * This function schedules a full render for next frame, if no scheduling has been done yet:
    */
```

</details>