### PR TITLE
front: fix left column width inconsistency with rolling stock

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
@@ -161,19 +161,19 @@ const ScenarioContent = ({ activeBoards }: ScenarioContentProps) => {
 
   return (
     <EditedElementContainerProvider>
-      {displayTimetableItemManagement !== MANAGE_TIMETABLE_ITEM_TYPES.none && (
-        <ManageTimetableItemModal
-          displayTimetableItemManagement={displayTimetableItemManagement}
-          setDisplayTimetableItemManagement={setDisplayTimetableItemManagement}
-          upsertTimetableItems={upsertTimetableItemsWithNge}
-          removeTimetableItems={removeTimetableItemsWithNge}
-          timetableItemToEditData={timetableItemToEditData}
-          setTimetableItemToEditData={setTimetableItemToEditData}
-          setCollapsedTimetableEdit={() => setCollapsedTimetableEdit(!collapsedTimetableEdit)}
-          collapsedTimetableEdit={collapsedTimetableEdit}
-        />
-      )}
       <main className="mastcontainer mastcontainer-no-mastnav scenario scenario-content-v2">
+        {displayTimetableItemManagement !== MANAGE_TIMETABLE_ITEM_TYPES.none && (
+          <ManageTimetableItemModal
+            displayTimetableItemManagement={displayTimetableItemManagement}
+            setDisplayTimetableItemManagement={setDisplayTimetableItemManagement}
+            upsertTimetableItems={upsertTimetableItemsWithNge}
+            removeTimetableItems={removeTimetableItemsWithNge}
+            timetableItemToEditData={timetableItemToEditData}
+            setTimetableItemToEditData={setTimetableItemToEditData}
+            setCollapsedTimetableEdit={() => setCollapsedTimetableEdit(!collapsedTimetableEdit)}
+            collapsedTimetableEdit={collapsedTimetableEdit}
+          />
+        )}
         <div
           data-testid="scenario-left-column"
           className="left-column"


### PR DESCRIPTION
closes [#13191](https://github.com/OpenRailAssociation/osrd/issues/13191)

The className `left-column` was not applied.