### PR TITLE
core: remove old path object instanciations from non-path code

### DIFF
--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/EnvelopeTrainPath.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/EnvelopeTrainPath.kt
@@ -5,8 +5,8 @@ import com.google.common.collect.ImmutableRangeMap
 import com.google.common.collect.Range
 import com.google.common.collect.TreeRangeMap
 import fr.sncf.osrd.path.interfaces.Electrification
-import fr.sncf.osrd.path.interfaces.PathProperties
 import fr.sncf.osrd.path.interfaces.PhysicsPath
+import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.path.legacy_objects.ElectricalProfileMapping
 import fr.sncf.osrd.path.legacy_objects.buildElectrificationMap
 import fr.sncf.osrd.sim_infra.api.RawSignalingInfra
@@ -17,7 +17,7 @@ object EnvelopeTrainPath {
     /** Create EnvelopePath from a path and a ElectricalProfileMapping */
     fun from(
         infra: RawSignalingInfra,
-        path: PathProperties,
+        path: TrainPath,
         electricalProfileMapping: ElectricalProfileMapping? = null,
     ): PhysicsPath {
         val gradePositions = DoubleArrayList()

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathBuilder.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathBuilder.kt
@@ -247,7 +247,7 @@ private fun generateTrackChunks(
  * Generate the route ranges from given chunk ranges, with actual route IDs given as input. This
  * just maps the offsets and precise ranges.
  */
-private fun generateRouteRanges(
+internal fun generateRouteRanges(
     rawInfra: RawInfra,
     chunks: LinearObjectMap<DirChunkRange>,
     routes: List<RouteId>,

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathImpl.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathImpl.kt
@@ -113,7 +113,7 @@ data class TrainPathNoBacktrack(
     }
 
     private fun computeEnvelopeSimPath(): PhysicsPath {
-        return EnvelopeTrainPath.from(rawInfra, pathProperties, electricalProfileMapping)
+        return EnvelopeTrainPath.from(rawInfra, this, electricalProfileMapping)
     }
 
     /** Truncate the distance range maps of linear objects, updating the underlying object range */
@@ -122,42 +122,46 @@ data class TrainPathNoBacktrack(
         from: Offset<TrainPath>,
         to: Offset<TrainPath>,
     ): LinearObjectMap<GenericLinearRange<ValueType, OffsetType>> {
+        require(from >= Offset.zero())
+        require(to <= getTypedLength())
         val newMapEntries =
-            map.asMapOfRanges().mapValues { (key, value) ->
-                var value = value
+            map.asMapOfRanges().mapNotNull { (key, value) ->
                 val lower = key.lowerEndpoint()
                 val upper = key.upperEndpoint()
-                val truncatedStartDist = from.distance - lower.distance
-                val truncatedEndDist = upper.distance - to.distance
+                val truncatedStart = max(from, lower)
+                val truncatedEnd = min(to, upper)
 
-                if (truncatedStartDist > 0.meters) {
-                    value = value.copy(from = value.from + truncatedStartDist)
-                }
-                if (truncatedEndDist > 0.meters) {
-                    value = value.copy(to = value.to - truncatedStartDist)
-                }
-                value
+                if (truncatedStart > truncatedEnd) return@mapNotNull null
+
+                val value =
+                    value.copy(
+                        from = value.from + (truncatedStart - lower),
+                        to = value.to - (upper - truncatedEnd),
+                    )
+                val key =
+                    Range.range(
+                        truncatedStart - from.distance,
+                        key.lowerBoundType(),
+                        truncatedEnd - from.distance,
+                        key.upperBoundType(),
+                    )
+                if (key.isEmpty) return@mapNotNull null
+                Pair(key, value)
             }
         val builder =
             ImmutableRangeMap.builder<
                 Offset<TrainPath>,
                 GenericLinearRange<ValueType, OffsetType>,
             >()
-        for (entry in newMapEntries) {
-            val lower = max(entry.key.lowerEndpoint() - from.distance, Offset.zero())
-            val upper = min(entry.key.lowerEndpoint() - from.distance, getTypedLength())
-            if (lower <= upper) {
-                val newKey =
-                    Range.range(
-                        lower,
-                        entry.key.lowerBoundType(),
-                        upper,
-                        entry.key.upperBoundType(),
-                    )
-                builder.put(newKey, entry.value)
-            }
+        for ((key, value) in newMapEntries) {
+            builder.put(key, value)
         }
         return builder.build()
+    }
+
+    override fun withRoutes(routes: List<RouteId>): TrainPath {
+        val routeRanges = generateRouteRanges(rawInfra, chunks, routes)
+        return copy(routes = routeRanges, pathProperties = pathProperties.withRoutes(routes))
     }
 
     /** *Debugging purpose*. We try to find the actual names of underlying objects. */

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/TrainPath.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/TrainPath.kt
@@ -42,6 +42,9 @@ interface TrainPath : PhysicsPath, PathProperties {
 
     fun getTypedLength(): Length<TrainPath>
 
+    /** Returns a copy with the specified routes instead */
+    override fun withRoutes(routes: List<RouteId>): TrainPath
+
     fun getBlocks(): LinearObjectMap<BlockRange>
 
     fun getRoutes(): LinearObjectMap<RouteRange>

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/legacy_objects/ElectricalProfileMapping.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/legacy_objects/ElectricalProfileMapping.kt
@@ -1,6 +1,6 @@
 package fr.sncf.osrd.path.legacy_objects
 
-import fr.sncf.osrd.path.interfaces.PathProperties
+import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.railjson.schema.external_generated_inputs.RJSElectricalProfileSet
 import fr.sncf.osrd.sim_infra.api.RawInfra
 import fr.sncf.osrd.sim_infra.api.TrackChunkId
@@ -44,7 +44,7 @@ class ElectricalProfileMapping {
     /** Returns the electrical profiles encountered on a path */
     fun getProfilesOnPath(
         infra: RawInfra,
-        path: PathProperties,
+        path: TrainPath,
     ): HashMap<String, DistanceRangeMap<String>> {
         val res = HashMap<String, DistanceRangeMap<String>>()
         for (entry in mapping.entries) {

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/legacy_objects/EnvelopeTrainPathUtils.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/legacy_objects/EnvelopeTrainPathUtils.kt
@@ -1,7 +1,7 @@
 package fr.sncf.osrd.path.legacy_objects
 
 import fr.sncf.osrd.path.interfaces.Electrification
-import fr.sncf.osrd.path.interfaces.PathProperties
+import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.path.legacy_objects.electrification.Electrified
 import fr.sncf.osrd.path.legacy_objects.electrification.Neutral
 import fr.sncf.osrd.path.legacy_objects.electrification.NonElectrified
@@ -11,7 +11,7 @@ import fr.sncf.osrd.utils.DistanceRangeMapImpl
 import fr.sncf.osrd.utils.units.Distance
 
 /** Builds the ElectrificationMap */
-fun buildElectrificationMap(path: PathProperties): DistanceRangeMap<Electrification> {
+fun buildElectrificationMap(path: TrainPath): DistanceRangeMap<Electrification> {
     val res: DistanceRangeMap<Electrification> = DistanceRangeMapImpl()
     res.put(Distance.ZERO, path.getLength(), NonElectrified())
     res.updateMapIntersection(path.getElectrification()) {

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/result/ResultPosition.kt
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/result/ResultPosition.kt
@@ -1,7 +1,7 @@
 package fr.sncf.osrd.standalone_sim.result
 
 import com.squareup.moshi.Json
-import fr.sncf.osrd.path.interfaces.PathProperties
+import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.sim_infra.api.RawSignalingInfra
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
@@ -28,7 +28,7 @@ private constructor(time: Double, pathOffset: Double, trackSection: String?, off
         fun from(
             time: Double,
             pathOffset: Double,
-            path: PathProperties,
+            path: TrainPath,
             rawInfra: RawSignalingInfra,
         ): ResultPosition {
             val location = path.getTrackLocationAtOffset(Offset(pathOffset.meters))

--- a/core/src/main/kotlin/fr/sncf/osrd/api/path_properties/PathPropEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/path_properties/PathPropEndpoint.kt
@@ -2,7 +2,8 @@ package fr.sncf.osrd.api.path_properties
 
 import fr.sncf.osrd.api.ExceptionHandler
 import fr.sncf.osrd.api.InfraProvider
-import fr.sncf.osrd.utils.makePathProps
+import fr.sncf.osrd.path.implementations.buildTrainPathFromChunkPath
+import fr.sncf.osrd.utils.makeChunkPath
 import org.takes.Request
 import org.takes.Response
 import org.takes.Take
@@ -23,8 +24,8 @@ class PathPropEndpoint(private val infraManager: InfraProvider) : Take {
             // Load infra
             val infra = infraManager.getInfra(request.infra, request.expectedVersion)
 
-            val pathProps =
-                makePathProps(infra.rawInfra, infra.blockInfra, request.trackSectionRanges)
+            val chunkPath = makeChunkPath(infra.rawInfra, request.trackSectionRanges)
+            val pathProps = buildTrainPathFromChunkPath(infra.rawInfra, infra.blockInfra, chunkPath)
             val res = makePathPropResponse(pathProps, infra.rawInfra)
 
             RsJson(RsWithBody(pathPropResponseAdapter.toJson(res)))

--- a/core/src/main/kotlin/fr/sncf/osrd/api/path_properties/PathPropResponseConverter.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/path_properties/PathPropResponseConverter.kt
@@ -2,7 +2,7 @@ package fr.sncf.osrd.api.path_properties
 
 import com.google.common.collect.Range
 import fr.sncf.osrd.api.RangeValues
-import fr.sncf.osrd.path.interfaces.PathProperties
+import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.path.interfaces.TravelledPath
 import fr.sncf.osrd.railjson.schema.geom.RJSLineString
 import fr.sncf.osrd.sim_infra.api.NeutralSection
@@ -11,10 +11,7 @@ import fr.sncf.osrd.utils.DistanceRangeMap
 import fr.sncf.osrd.utils.DistanceRangeMapImpl
 import fr.sncf.osrd.utils.units.Offset
 
-fun makePathPropResponse(
-    pathProperties: PathProperties,
-    rawInfra: RawSignalingInfra,
-): PathPropResponse {
+fun makePathPropResponse(pathProperties: TrainPath, rawInfra: RawSignalingInfra): PathPropResponse {
     return PathPropResponse(
         makeSlopes(pathProperties),
         makeCurves(pathProperties),
@@ -25,15 +22,15 @@ fun makePathPropResponse(
     )
 }
 
-private fun makeSlopes(pathProperties: PathProperties): RangeValues<Double> {
+private fun makeSlopes(pathProperties: TrainPath): RangeValues<Double> {
     return makeRangeValues(pathProperties.getSlopes())
 }
 
-private fun makeCurves(pathProperties: PathProperties): RangeValues<Double> {
+private fun makeCurves(pathProperties: TrainPath): RangeValues<Double> {
     return makeRangeValues(pathProperties.getCurves())
 }
 
-private fun makeElectrifications(pathProperties: PathProperties): RangeValues<Electrification> {
+private fun makeElectrifications(pathProperties: TrainPath): RangeValues<Electrification> {
     val electrifications = makeElectrificationMap(pathProperties.getElectrification())
     val neutralSections = makeElectrificationMap(pathProperties.getNeutralSections())
     val mergedMap = DistanceRangeMapImpl.toRangeMap(electrifications)
@@ -49,7 +46,7 @@ private fun makeElectrifications(pathProperties: PathProperties): RangeValues<El
     return makeRangeValues(DistanceRangeMapImpl.from(mergedMap))
 }
 
-private fun makeGeographic(path: PathProperties): RJSLineString {
+private fun makeGeographic(path: TrainPath): RJSLineString {
     val lineString = path.getGeo()
     val coordinates = ArrayList<List<Double>>()
     for (p in lineString.getPoints()) coordinates.add(listOf(p.lon, p.lat))
@@ -57,7 +54,7 @@ private fun makeGeographic(path: PathProperties): RJSLineString {
 }
 
 private fun makeOperationalPoints(
-    path: PathProperties,
+    path: TrainPath,
     rawInfra: RawSignalingInfra,
 ): List<OperationalPointResponse> {
     val res = mutableListOf<OperationalPointResponse>()
@@ -111,7 +108,7 @@ private fun makeOperationalPoints(
     return res
 }
 
-private fun makeZones(path: PathProperties, rawInfra: RawSignalingInfra): RangeValues<String> {
+private fun makeZones(path: TrainPath, rawInfra: RawSignalingInfra): RangeValues<String> {
     val zoneIds = makeRangeValues(path.getZones())
     return RangeValues(zoneIds.internalBoundaries, zoneIds.values.map { rawInfra.getZoneName(it) })
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/api/standalone_sim/SimulationEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/standalone_sim/SimulationEndpoint.kt
@@ -63,6 +63,7 @@ class SimulationEndpoint(
                     infra.blockInfra,
                     chunkPath,
                     routePath.toList(),
+                    electricalProfileMapping = electricalProfileMap,
                 )
             val blockPath = convertBlockPath(infra.blockInfra, request.path.blocks)
 

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
@@ -13,7 +13,6 @@ import fr.sncf.osrd.envelope_sim.allowances.AllowanceValue
 import fr.sncf.osrd.envelope_sim.allowances.AllowanceValue.Percentage
 import fr.sncf.osrd.envelope_sim.allowances.AllowanceValue.TimePerDistance
 import fr.sncf.osrd.envelope_sim_infra.computeMRSP
-import fr.sncf.osrd.path.implementations.EnvelopeTrainPath
 import fr.sncf.osrd.pathfinding.Pathfinding
 import fr.sncf.osrd.pathfinding.PathfindingEdgeLocationId
 import fr.sncf.osrd.railjson.schema.common.graph.EdgeDirection
@@ -268,20 +267,18 @@ class STDCMEndpoint(
             provisional = simpleReportTrain,
             finalOutput = reportTrain,
             mrsp = makeMRSPResponse(speedLimits),
-            electricalProfiles = buildSTDCMElectricalProfiles(infra, path, rollingStock, comfort),
+            electricalProfiles = buildSTDCMElectricalProfiles(path, rollingStock, comfort),
         )
     }
 
     /** Build the electrical profiles from the path */
     private fun buildSTDCMElectricalProfiles(
-        infra: FullInfra,
         path: STDCMResult,
         rollingStock: RollingStock,
         comfort: Comfort,
     ): RangeValues<ElectricalProfileValue> {
-        val envelopeSimPath = EnvelopeTrainPath.from(infra.rawInfra, path.trainPath, null)
         val electrificationMap =
-            envelopeSimPath.getElectrificationMap(
+            path.trainPath.getElectrificationMap(
                 rollingStock.basePowerClass,
                 ImmutableRangeMap.of(),
                 rollingStock.powerRestrictions,

--- a/core/src/main/kotlin/fr/sncf/osrd/envelope_sim_infra/MRSP.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/envelope_sim_infra/MRSP.kt
@@ -5,7 +5,7 @@ import fr.sncf.osrd.envelope.MRSPEnvelopeBuilder
 import fr.sncf.osrd.envelope.part.EnvelopePart
 import fr.sncf.osrd.envelope_sim.EnvelopeProfile
 import fr.sncf.osrd.envelope_sim.PhysicsRollingStock
-import fr.sncf.osrd.path.interfaces.PathProperties
+import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.sim_infra.api.SpeedLimitProperty
 import fr.sncf.osrd.sim_infra.api.SpeedLimitSource.UnknownTag
 import fr.sncf.osrd.sim_infra.impl.TemporarySpeedLimitManager
@@ -35,7 +35,7 @@ import kotlin.math.min
  * @return the corresponding MRSP as an Envelope.
  */
 fun computeMRSP(
-    path: PathProperties,
+    path: TrainPath,
     rollingStock: PhysicsRollingStock,
     addRollingStockLength: Boolean,
     trainTag: String?,
@@ -71,7 +71,7 @@ fun computeMRSP(
  * @return the corresponding MRSP as an Envelope.
  */
 fun computeMRSP(
-    path: PathProperties,
+    path: TrainPath,
     rsMaxSpeed: Double,
     rsLength: Double,
     addRollingStockLength: Boolean,

--- a/core/src/main/kotlin/fr/sncf/osrd/pathfinding/constraints/ElectrificationConstraints.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/pathfinding/constraints/ElectrificationConstraints.kt
@@ -5,7 +5,7 @@ import com.google.common.collect.RangeSet
 import com.google.common.collect.TreeRangeSet
 import fr.sncf.osrd.graph.PathfindingConstraint
 import fr.sncf.osrd.path.implementations.buildTrainPathFromBlock
-import fr.sncf.osrd.path.interfaces.PathProperties
+import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.pathfinding.Pathfinding
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.utils.DistanceRangeMap
@@ -30,7 +30,7 @@ data class ElectrificationConstraints(
          * some range
          */
         private fun getBlockedRanges(
-            path: PathProperties,
+            path: TrainPath,
             compatibleElectrification: Collection<String>,
         ): Set<Pathfinding.Range<Block>> {
             val res = HashSet<Pathfinding.Range<Block>>()

--- a/core/src/main/kotlin/fr/sncf/osrd/pathfinding/constraints/LoadingGaugeConstraints.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/pathfinding/constraints/LoadingGaugeConstraints.kt
@@ -2,13 +2,12 @@ package fr.sncf.osrd.pathfinding.constraints
 
 import fr.sncf.osrd.graph.PathfindingConstraint
 import fr.sncf.osrd.path.implementations.buildTrainPathFromBlock
-import fr.sncf.osrd.path.interfaces.PathProperties
+import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.pathfinding.Pathfinding
 import fr.sncf.osrd.railjson.schema.rollingstock.RJSLoadingGaugeType
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.utils.DistanceRangeMap
 import fr.sncf.osrd.utils.units.Offset
-import java.util.stream.Collectors
 
 data class LoadingGaugeConstraints(
     val blockInfra: BlockInfra,
@@ -25,18 +24,16 @@ data class LoadingGaugeConstraints(
     /** Returns the sections of the given block that can't be used by the given rolling stock */
     private fun getBlockedRanges(
         type: RJSLoadingGaugeType,
-        path: PathProperties,
+        path: TrainPath,
     ): Collection<Pathfinding.Range<Block>> {
         return path
             .getLoadingGauge()
-            .asList()
-            .stream()
             .filter { (_, _, value): DistanceRangeMap.RangeMapEntry<LoadingGaugeConstraint> ->
                 !value.isCompatibleWith(LoadingGaugeTypeId(type.ordinal.toUInt()))
             }
             .map { (lower, upper): DistanceRangeMap.RangeMapEntry<LoadingGaugeConstraint> ->
                 Pathfinding.Range(Offset<Block>(lower), Offset(upper))
             }
-            .collect(Collectors.toSet())
+            .toSet()
     }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
@@ -14,7 +14,7 @@ import fr.sncf.osrd.envelope_sim.EnvelopeSimContext
 import fr.sncf.osrd.path.implementations.ChunkPath
 import fr.sncf.osrd.path.implementations.EnvelopeTrainPath
 import fr.sncf.osrd.path.interfaces.BlockPath
-import fr.sncf.osrd.path.interfaces.PathProperties
+import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.path.interfaces.TravelledPath
 import fr.sncf.osrd.signaling.SigSystemManager
 import fr.sncf.osrd.signaling.SignalingSimulator
@@ -84,7 +84,7 @@ private fun buildBlockInfoTable(
 /** Use an already computed envelope to extract various metadata about a trip. */
 fun runScheduleMetadataExtractor(
     envelope: Envelope,
-    trainPath: PathProperties,
+    trainPath: TrainPath,
     chunkPath: ChunkPath,
     fullInfra: FullInfra,
     routePath: StaticIdxList<Route>,
@@ -304,7 +304,7 @@ fun getStopTravelledPathOffset(
 fun makeSimpleReportTrain(
     fullInfra: FullInfra,
     envelope: Envelope,
-    trainPath: PathProperties,
+    trainPath: TrainPath,
     rollingStock: RollingStock,
     schedule: List<SimulationScheduleItem>,
     pathItemPositions: List<Offset<TravelledPath>>,

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
@@ -12,7 +12,6 @@ import fr.sncf.osrd.envelope.EnvelopePhysics
 import fr.sncf.osrd.envelope.EnvelopeTimeInterpolate
 import fr.sncf.osrd.envelope_sim.EnvelopeSimContext
 import fr.sncf.osrd.path.implementations.ChunkPath
-import fr.sncf.osrd.path.implementations.EnvelopeTrainPath
 import fr.sncf.osrd.path.interfaces.BlockPath
 import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.path.interfaces.TravelledPath
@@ -310,9 +309,8 @@ fun makeSimpleReportTrain(
     pathItemPositions: List<Offset<TravelledPath>>,
 ): ReportTrain {
     // Compute energy consumed
-    val envelopePath = EnvelopeTrainPath.from(fullInfra.rawInfra, trainPath)
     val mechanicalEnergyConsumed =
-        EnvelopePhysics.getMechanicalEnergyConsumed(envelope, envelopePath, rollingStock)
+        EnvelopePhysics.getMechanicalEnergyConsumed(envelope, trainPath, rollingStock)
 
     // Account for stop durations
     val stops =

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulation.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulation.kt
@@ -25,7 +25,7 @@ import fr.sncf.osrd.envelope_sim_infra.HasMissingSpeedTag
 import fr.sncf.osrd.envelope_sim_infra.computeMRSP
 import fr.sncf.osrd.path.implementations.ChunkPath
 import fr.sncf.osrd.path.implementations.EnvelopeTrainPath
-import fr.sncf.osrd.path.interfaces.PathProperties
+import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.path.interfaces.TravelledPath
 import fr.sncf.osrd.path.legacy_objects.ElectricalProfileMapping
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
@@ -54,7 +54,7 @@ val standaloneSimLogger: Logger = LoggerFactory.getLogger("StandaloneSimulation"
 /** Run a simulation for a single train. */
 fun runStandaloneSimulation(
     infra: FullInfra,
-    pathProps: PathProperties,
+    trainPath: TrainPath,
     chunkPath: ChunkPath,
     routes: StaticIdxList<Route>,
     blockPath: StaticIdxList<Block>,
@@ -80,7 +80,7 @@ fun runStandaloneSimulation(
         makeSafetySpeedRanges(infra, chunkPath, routes, schedule, signalingRanges)
     var mrsp =
         computeMRSP(
-            pathProps,
+            trainPath,
             rollingStock,
             true,
             speedLimitTag,
@@ -92,10 +92,10 @@ fun runStandaloneSimulation(
     // We don't use speed safety ranges in the MRSP displayed in the front
     // (just like we don't add the train length)
     val speedLimits =
-        computeMRSP(pathProps, rollingStock, false, speedLimitTag, null, null, useSpeedLimits)
+        computeMRSP(trainPath, rollingStock, false, speedLimitTag, null, null, useSpeedLimits)
 
     // Build paths and contexts
-    val envelopeSimPath = EnvelopeTrainPath.from(infra.rawInfra, pathProps, electricalProfileMap)
+    val envelopeSimPath = EnvelopeTrainPath.from(infra.rawInfra, trainPath, electricalProfileMap)
     val powerRestrictionsLegacyMap = powerRestrictions.toRangeMap()
     val electrificationMap =
         envelopeSimPath.getElectrificationMap(
@@ -153,7 +153,7 @@ fun runStandaloneSimulation(
         makeSimpleReportTrain(
             infra,
             maxEffortEnvelope,
-            pathProps,
+            trainPath,
             rollingStock,
             schedule,
             pathItemPositions,
@@ -162,7 +162,7 @@ fun runStandaloneSimulation(
         makeSimpleReportTrain(
             infra,
             provisionalEnvelope,
-            pathProps,
+            trainPath,
             rollingStock,
             schedule,
             pathItemPositions,
@@ -170,7 +170,7 @@ fun runStandaloneSimulation(
     val finalEnvelopeResult =
         runScheduleMetadataExtractor(
             finalEnvelope,
-            pathProps,
+            trainPath,
             chunkPath,
             infra,
             routes,

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulation.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulation.kt
@@ -24,7 +24,6 @@ import fr.sncf.osrd.envelope_sim.pipelines.maxSpeedEnvelopeFrom
 import fr.sncf.osrd.envelope_sim_infra.HasMissingSpeedTag
 import fr.sncf.osrd.envelope_sim_infra.computeMRSP
 import fr.sncf.osrd.path.implementations.ChunkPath
-import fr.sncf.osrd.path.implementations.EnvelopeTrainPath
 import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.path.interfaces.TravelledPath
 import fr.sncf.osrd.path.legacy_objects.ElectricalProfileMapping
@@ -95,10 +94,9 @@ fun runStandaloneSimulation(
         computeMRSP(trainPath, rollingStock, false, speedLimitTag, null, null, useSpeedLimits)
 
     // Build paths and contexts
-    val envelopeSimPath = EnvelopeTrainPath.from(infra.rawInfra, trainPath, electricalProfileMap)
     val powerRestrictionsLegacyMap = powerRestrictions.toRangeMap()
     val electrificationMap =
-        envelopeSimPath.getElectrificationMap(
+        trainPath.getElectrificationMap(
             rollingStock.basePowerClass,
             powerRestrictionsLegacyMap,
             rollingStock.powerRestrictions,
@@ -110,7 +108,7 @@ fun runStandaloneSimulation(
     var context =
         EnvelopeSimContext(
             rollingStock,
-            envelopeSimPath,
+            trainPath,
             timeStep,
             curvesAndConditions.curves,
             makeETCSContext(rollingStock, infra, chunkPath, routes, blockPath, signalingRanges),

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
@@ -8,7 +8,6 @@ import fr.sncf.osrd.envelope_sim.pipelines.maxEffortEnvelopeFrom
 import fr.sncf.osrd.envelope_sim.pipelines.maxSpeedEnvelopeFrom
 import fr.sncf.osrd.envelope_sim_infra.computeMRSP
 import fr.sncf.osrd.path.implementations.buildTrainPathFromChunkPath
-import fr.sncf.osrd.path.interfaces.PathProperties
 import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.pathfinding.Pathfinding
 import fr.sncf.osrd.pathfinding.Pathfinding.EdgeLocation
@@ -261,7 +260,7 @@ class STDCMPostProcessing(private val graph: STDCMGraph) {
     }
 
     /** Builds the list of stops from OP */
-    private fun makeOpStops(trainPath: PathProperties): List<TrainStop> {
+    private fun makeOpStops(trainPath: TrainPath): List<TrainStop> {
         val res = ArrayList<TrainStop>()
         for ((_, offset) in trainPath.getOperationalPointParts()) {
             res.add(TrainStop(offset.distance.meters, 0.0, OPEN))
@@ -289,7 +288,7 @@ class STDCMPostProcessing(private val graph: STDCMGraph) {
      * Make the path's ordered list of stops, in order. Both user-defined stops and operational
      * points.
      */
-    private fun makePathStops(stops: List<TrainStop>, trainPath: PathProperties): List<TrainStop> {
+    private fun makePathStops(stops: List<TrainStop>, trainPath: TrainPath): List<TrainStop> {
         val mutStops = stops.toMutableList()
         mutStops.addAll(makeOpStops(trainPath))
         return sortAndMergeStopsDuplicates(mutStops)

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMSimulations.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMSimulations.kt
@@ -14,7 +14,6 @@ import fr.sncf.osrd.envelope_sim.pipelines.SimStop
 import fr.sncf.osrd.envelope_sim.pipelines.maxEffortEnvelopeFrom
 import fr.sncf.osrd.envelope_sim.pipelines.maxSpeedEnvelopeFrom
 import fr.sncf.osrd.envelope_sim_infra.computeMRSP
-import fr.sncf.osrd.path.implementations.EnvelopeTrainPath
 import fr.sncf.osrd.path.interfaces.TravelledPath
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
 import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal
@@ -106,8 +105,7 @@ class STDCMSimulations {
             simLength = Distance.min(simLength, stopOffset.distance)
         }
         val path = infraExplorer.getCurrentEdgePathProperties(start, simLength)
-        val envelopePath = EnvelopeTrainPath.from(rawInfra, path)
-        val context = build(rollingStock, envelopePath, timeStep, comfort)
+        val context = build(rollingStock, path, timeStep, comfort)
         val mrsp = computeMRSP(path, rollingStock, false, trainTag, temporarySpeedLimitManager)
         return try {
             val maxSpeedEnvelope = maxSpeedEnvelopeFrom(context, stops, mrsp)
@@ -162,8 +160,7 @@ fun simulateBackwards(
     graph: STDCMGraph,
 ): Envelope {
     val path = infraExplorer.getCurrentEdgePathProperties(start, null)
-    val envelopePath = EnvelopeTrainPath.from(rawInfra, path)
-    val context = build(graph.rollingStock, envelopePath, graph.timeStep, graph.comfort)
+    val context = build(graph.rollingStock, path, graph.timeStep, graph.comfort)
     val partBuilder = EnvelopePartBuilder()
     partBuilder.setAttr(EnvelopeProfile.BRAKING)
     partBuilder.setAttr(BacktrackingSelfTypeHolder())

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/engineering_allowance/SimulationSegment.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/engineering_allowance/SimulationSegment.kt
@@ -8,7 +8,6 @@ import fr.sncf.osrd.envelope.part.constraints.PositionConstraint
 import fr.sncf.osrd.envelope.part.constraints.SpeedConstraint
 import fr.sncf.osrd.envelope_sim.EnvelopeProfile
 import fr.sncf.osrd.envelope_sim.overlays.EnvelopeAcceleration
-import fr.sncf.osrd.path.implementations.EnvelopeTrainPath
 import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.stdcm.graph.STDCMEdge
 import fr.sncf.osrd.stdcm.graph.STDCMGraph
@@ -117,11 +116,10 @@ private fun computeAcceleration(
 
     // TODO: building an EnvelopeTrainPath each time is very expensive, we should really cache them
     // over blocks and implement views for block segments.
-    val envelopePath = EnvelopeTrainPath.from(graph.rawInfra, pathProperties)
     val context =
         fr.sncf.osrd.stdcm.graph.build(
             graph.rollingStock,
-            envelopePath,
+            pathProperties,
             graph.timeStep,
             graph.comfort,
         )

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/engineering_allowance/SimulationSegment.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/engineering_allowance/SimulationSegment.kt
@@ -9,7 +9,7 @@ import fr.sncf.osrd.envelope.part.constraints.SpeedConstraint
 import fr.sncf.osrd.envelope_sim.EnvelopeProfile
 import fr.sncf.osrd.envelope_sim.overlays.EnvelopeAcceleration
 import fr.sncf.osrd.path.implementations.EnvelopeTrainPath
-import fr.sncf.osrd.path.interfaces.PathProperties
+import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.stdcm.graph.STDCMEdge
 import fr.sncf.osrd.stdcm.graph.STDCMGraph
 import fr.sncf.osrd.utils.units.Distance
@@ -107,7 +107,7 @@ fun generatePreviousSimulationSegments(
  * Compute a full acceleration for a given edge. The end speed is fixed and we simulate backwards.
  */
 private fun computeAcceleration(
-    pathProperties: PathProperties,
+    pathProperties: TrainPath,
     endSpeed: Double,
     graph: STDCMGraph,
 ): SummarizedSimulationResult {

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
@@ -6,10 +6,9 @@ import fr.sncf.osrd.conflicts.IncrementalPath
 import fr.sncf.osrd.conflicts.PathFragment
 import fr.sncf.osrd.conflicts.incrementalPathOf
 import fr.sncf.osrd.graph.PathfindingConstraint
-import fr.sncf.osrd.path.implementations.PathPropertiesView
 import fr.sncf.osrd.path.implementations.buildTrainPathFromBlock
 import fr.sncf.osrd.path.interfaces.BlockPath
-import fr.sncf.osrd.path.interfaces.PathProperties
+import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.pathfinding.PathfindingEdgeLocationId
 import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal.SHORT_SLIP_STOP
 import fr.sncf.osrd.sim_infra.api.*
@@ -57,7 +56,7 @@ interface InfraExplorer {
      * Get the path properties for the current edge only, starting at the given offset and for the
      * given length. If no length is given, the path covers the rest of the block.
      */
-    fun getCurrentEdgePathProperties(offset: Offset<Block>, length: Distance?): PathProperties
+    fun getCurrentEdgePathProperties(offset: Offset<Block>, length: Distance?): TrainPath
 
     /**
      * Returns an object that can be used to identify edges. The last edge contains the current
@@ -131,7 +130,7 @@ fun initInfraExplorer(
 ): Collection<InfraExplorer> {
     val infraExplorers = mutableListOf<InfraExplorer>()
     val block = location.edge
-    val pathProps: PathProperties = buildTrainPathFromBlock(rawInfra, blockInfra, block)
+    val pathProps = buildTrainPathFromBlock(rawInfra, blockInfra, block)
     val blockToPathProperties = mutableMapOf(block to pathProps)
     val routes = blockInfra.routesOnBlock(rawInfra, block)
 
@@ -164,7 +163,7 @@ private class InfraExplorerImpl(
     private var blockRoutes: AppendOnlyMap<BlockId, RouteId>,
     private var lastTrack: TrackSectionId?,
     private var incrementalPath: IncrementalPath,
-    private var pathPropertiesCache: MutableMap<BlockId, PathProperties>,
+    private var trainPathCache: MutableMap<BlockId, TrainPath>,
     private var currentIndex: Int = 0,
     private var stepTracker: StepTracker,
     private var predecessorLength: Length<BlockPath> = Length(0.meters), // to avoid re-computing it
@@ -175,31 +174,29 @@ private class InfraExplorerImpl(
         return incrementalPath
     }
 
-    override fun getCurrentEdgePathProperties(
-        offset: Offset<Block>,
-        length: Distance?,
-    ): PathProperties {
+    override fun getCurrentEdgePathProperties(offset: Offset<Block>, length: Distance?): TrainPath {
         // We re-compute the routes of the current path since the cache may be incorrect
         // because of a previous iteration.
         // We also can't set a first route for sure in initInfraExplorer, but we set the first cache
         // entry.
         // So we have to correct that here now that we now which route we're on.
         val path =
-            pathPropertiesCache.getOrElse(getCurrentBlock()) {
+            trainPathCache.getOrElse(getCurrentBlock()) {
                 val res = buildTrainPathFromBlock(rawInfra, blockInfra, getCurrentBlock())
-                pathPropertiesCache[getCurrentBlock()] = res
+                trainPathCache[getCurrentBlock()] = res
                 res
             }
         val route = blockRoutes[getCurrentBlock()]!!
-        val blockPathProperties = path.withRoutes(listOf(route))
+
+        val pathWithRoutes = path.withRoutes(listOf(route))
 
         val blockLength = blockInfra.getBlockLength(getCurrentBlock())
         val endOffset: Offset<Block> = if (length == null) blockLength else offset.plus(length)
         if (offset.distance == 0.meters && endOffset == blockLength) {
-            return blockPathProperties
+            return pathWithRoutes
         }
         // In that case, start of the block is start of the travelled path
-        return PathPropertiesView(blockPathProperties, offset.cast(), endOffset.cast())
+        return pathWithRoutes.subPath(offset.cast(), endOffset.cast())
     }
 
     override fun getLastEdgeIdentifier(): EdgeIdentifier {
@@ -263,7 +260,7 @@ private class InfraExplorerImpl(
             this.blockRoutes.shallowCopy(),
             this.lastTrack,
             this.incrementalPath.clone(),
-            this.pathPropertiesCache,
+            this.trainPathCache,
             this.currentIndex,
             this.stepTracker.clone(),
             this.predecessorLength,

--- a/core/src/main/kotlin/fr/sncf/osrd/utils/DebugUtils.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/utils/DebugUtils.kt
@@ -2,6 +2,7 @@ package fr.sncf.osrd.utils
 
 import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.api.pathfinding.PathfindingBlockSuccess
+import fr.sncf.osrd.path.implementations.buildTrainPathFromChunkPath
 import java.io.BufferedWriter
 import java.io.File
 
@@ -14,14 +15,26 @@ fun exportPathGeo(infra: FullInfra, res: PathfindingBlockSuccess) {
     File("$name-tracks.csv").printWriter().use { out ->
         out.println("index;linestring;id")
         for ((i, track) in res.trackSectionRanges.withIndex()) {
-            val geo =
-                makePathProps(infra.rawInfra, infra.blockInfra, listOf(track), routes = listOf())
-                    .getGeo()
+            val chunkPath = makeChunkPath(infra.rawInfra, listOf(track))
+            val pathProps =
+                buildTrainPathFromChunkPath(
+                    infra.rawInfra,
+                    infra.blockInfra,
+                    chunkPath,
+                    routes = listOf(),
+                )
+            val geo = pathProps.getGeo()
             out.println("$i;$geo;${track.trackSection}")
         }
     }
+    val fullChunkPath = makeChunkPath(infra.rawInfra, res.trackSectionRanges)
     val fullPath =
-        makePathProps(infra.rawInfra, infra.blockInfra, res.trackSectionRanges, routes = listOf())
+        buildTrainPathFromChunkPath(
+            infra.rawInfra,
+            infra.blockInfra,
+            fullChunkPath,
+            routes = listOf(),
+        )
     val lineString = fullPath.getGeo()
     File("$name-points.csv").printWriter().use { out ->
         out.println("index;x;y")

--- a/core/src/main/kotlin/fr/sncf/osrd/utils/PathPropUtils.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/utils/PathPropUtils.kt
@@ -3,10 +3,6 @@ package fr.sncf.osrd.utils
 import fr.sncf.osrd.api.DirectionalTrackRange
 import fr.sncf.osrd.path.implementations.ChunkPath
 import fr.sncf.osrd.path.implementations.buildChunkPath
-import fr.sncf.osrd.path.implementations.buildRangeMap
-import fr.sncf.osrd.path.implementations.buildTrainPathFromChunks
-import fr.sncf.osrd.path.interfaces.DirChunkRange
-import fr.sncf.osrd.path.interfaces.PathProperties
 import fr.sncf.osrd.railjson.schema.common.graph.EdgeDirection
 import fr.sncf.osrd.reporting.exceptions.ErrorType
 import fr.sncf.osrd.reporting.exceptions.OSRDError
@@ -15,37 +11,7 @@ import fr.sncf.osrd.utils.indexing.DirStaticIdx
 import fr.sncf.osrd.utils.indexing.MutableDirStaticIdxArrayList
 import fr.sncf.osrd.utils.indexing.StaticIdxList
 import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
-import fr.sncf.osrd.utils.units.Distance.Companion.max
-import fr.sncf.osrd.utils.units.Distance.Companion.min
 import fr.sncf.osrd.utils.units.Offset
-import fr.sncf.osrd.utils.units.meters
-
-/** Builds a PathProperties from a List<TrackRange> */
-fun makePathProps(
-    rawInfra: RawSignalingInfra,
-    blockInfra: BlockInfra,
-    trackRanges: List<DirectionalTrackRange>,
-    routes: List<RouteId>? = null,
-): PathProperties {
-    val chunkPath = makeChunkPath(rawInfra, trackRanges)
-
-    val chunkRanges = mutableListOf<DirChunkRange>()
-    var prevChunksLength = 0.meters
-    for (chunk in chunkPath.chunks) {
-        val chunkLength = rawInfra.getTrackChunkLength(chunk.value)
-        val start = max(chunkPath.beginOffset.distance - prevChunksLength, 0.meters)
-        val end = min(chunkPath.endOffset.distance - prevChunksLength, chunkLength.distance)
-        val range = DirChunkRange(chunk, Offset(start), Offset(end))
-        chunkRanges.add(range)
-        prevChunksLength += chunkLength.distance
-    }
-    return buildTrainPathFromChunks(
-        rawInfra,
-        blockInfra,
-        buildRangeMap(chunkRanges),
-        routes = routes,
-    )
-}
 
 fun makeChunkPath(
     rawInfra: RawSignalingInfra,

--- a/core/src/test/java/fr/sncf/osrd/DriverBehaviourTest.kt
+++ b/core/src/test/java/fr/sncf/osrd/DriverBehaviourTest.kt
@@ -2,7 +2,6 @@ package fr.sncf.osrd
 
 import fr.sncf.osrd.envelope_sim_infra.computeMRSP
 import fr.sncf.osrd.path.implementations.buildTrainPathFromBlocks
-import fr.sncf.osrd.path.interfaces.PathProperties
 import fr.sncf.osrd.train.TestTrains
 import fr.sncf.osrd.utils.DistanceRangeMap
 import fr.sncf.osrd.utils.DummyInfra
@@ -21,7 +20,7 @@ class DriverBehaviourTest {
                 infra.addBlock("b", "c", 100.meters, 10.0),
                 infra.addBlock("c", "d", 100.meters, 20.0),
             )
-        val path: PathProperties = buildTrainPathFromBlocks(infra, infra, blocks, routes = listOf())
+        val path = buildTrainPathFromBlocks(infra, infra, blocks, routes = listOf())
         val testRollingStock = TestTrains.VERY_SHORT_FAST_TRAIN
         val driverBehaviour = DriverBehaviour(2.0, 3.0)
         var mrsp = computeMRSP(path, testRollingStock, true, null, null)

--- a/core/src/test/kotlin/fr/sncf/osrd/envelope_sim_infra/MRSPTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/envelope_sim_infra/MRSPTest.kt
@@ -5,7 +5,7 @@ import fr.sncf.osrd.envelope.EnvelopeTestUtils
 import fr.sncf.osrd.envelope.MRSPEnvelopeBuilder.LimitKind
 import fr.sncf.osrd.envelope_sim.EnvelopeProfile.CONSTANT_SPEED
 import fr.sncf.osrd.path.implementations.buildTrainPathFromBlock
-import fr.sncf.osrd.path.interfaces.PathProperties
+import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.railjson.schema.common.RJSWaypointRef
 import fr.sncf.osrd.railjson.schema.common.graph.ApplicableDirection
 import fr.sncf.osrd.railjson.schema.common.graph.EdgeDirection
@@ -33,9 +33,9 @@ import org.junit.jupiter.params.provider.MethodSource
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class MRSPTest {
     // Small_infra paths
-    private var path: PathProperties? = null
-    private var path30: PathProperties? = null
-    private var path60: PathProperties? = null
+    private var path: TrainPath? = null
+    private var path30: TrainPath? = null
+    private var path60: TrainPath? = null
 
     // Nested_switches paths
     private var pathTo1: TestPath? = null
@@ -232,7 +232,7 @@ class MRSPTest {
     @ParameterizedTest
     @MethodSource("testComputeMRSPArgs")
     fun testComputeMRSP(
-        path: PathProperties,
+        path: TrainPath,
         rollingStock: RollingStock,
         addRollingStockLength: Boolean,
         trainTag: String?,
@@ -398,7 +398,7 @@ class MRSPTest {
         // On nested_switches
         private val ROUTES = listOf("1 -> 1'", "1 -> 2", "1 -> 3", "1 -> 4", "1 -> 4'")
 
-        private data class TestPath(val path: PathProperties, val envelope: Envelope) {
+        private data class TestPath(val path: TrainPath, val envelope: Envelope) {
             fun makeArguments(): Arguments {
                 return Arguments.of(path, TestTrains.REALISTIC_FAST_TRAIN, false, null, envelope)
             }

--- a/core/src/test/kotlin/fr/sncf/osrd/pathfinding/RemainingDistanceEstimatorTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/pathfinding/RemainingDistanceEstimatorTest.kt
@@ -5,7 +5,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.path.implementations.buildTrainPathFromBlock
 import fr.sncf.osrd.path.interfaces.BlockPath
-import fr.sncf.osrd.path.interfaces.PathProperties
+import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.pathfinding.Pathfinding.EdgeLocation
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockId
@@ -26,7 +26,7 @@ import org.junit.jupiter.params.provider.MethodSource
 class RemainingDistanceEstimatorTest {
     private var smallInfra: FullInfra? = null
     private var block: BlockId? = null
-    private var path: PathProperties? = null
+    private var path: TrainPath? = null
 
     @BeforeAll
     fun setUp() {

--- a/core/src/test/kotlin/fr/sncf/osrd/sim_infra_adapter/EnvelopeTrainPathTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/sim_infra_adapter/EnvelopeTrainPathTest.kt
@@ -2,7 +2,6 @@ package fr.sncf.osrd.sim_infra_adapter
 
 import com.google.common.collect.ImmutableRangeMap
 import com.google.common.collect.Range
-import fr.sncf.osrd.path.implementations.EnvelopeTrainPath
 import fr.sncf.osrd.path.interfaces.Electrification
 import fr.sncf.osrd.path.legacy_objects.ElectricalProfileMapping
 import fr.sncf.osrd.path.legacy_objects.electrification.Electrified
@@ -46,13 +45,12 @@ class EnvelopeTrainPathTest {
                 500.meters,
                 3_500.meters,
             )
-        val envelopeSimPath = EnvelopeTrainPath.from(infra.rawInfra, path)
-        Assertions.assertEquals(5.0, envelopeSimPath.getAverageGrade(0.0, 500.0))
-        Assertions.assertEquals(15.0, envelopeSimPath.getAverageGrade(500.0, 1500.0))
-        Assertions.assertEquals(10.0, envelopeSimPath.getAverageGrade(1500.0, 2500.0))
-        Assertions.assertEquals(25.0, envelopeSimPath.getAverageGrade(2500.0, 3000.0))
-        Assertions.assertEquals(11.0, envelopeSimPath.getAverageGrade(0.0, 2500.0))
-        Assertions.assertEquals(10.0, envelopeSimPath.getAverageGrade(300.0, 700.0))
+        Assertions.assertEquals(5.0, path.getAverageGrade(0.0, 500.0))
+        Assertions.assertEquals(15.0, path.getAverageGrade(500.0, 1500.0))
+        Assertions.assertEquals(10.0, path.getAverageGrade(1500.0, 2500.0))
+        Assertions.assertEquals(25.0, path.getAverageGrade(2500.0, 3000.0))
+        Assertions.assertEquals(11.0, path.getAverageGrade(0.0, 2500.0))
+        Assertions.assertEquals(10.0, path.getAverageGrade(300.0, 700.0))
     }
 
     @ParameterizedTest
@@ -109,9 +107,8 @@ class EnvelopeTrainPathTest {
             )
         val infra = Helpers.fullInfraFromRJS(rjsInfra)
         val path = pathFromTracks(infra, tracks, direction, 500.meters, 3_600.meters)
-        val envelopeSimPath = EnvelopeTrainPath.from(infra.rawInfra, path)
 
-        assertThat(envelopeSimPath.getElectrificationMap(null, null, null)).isEqualTo(expectedMap)
+        assertThat(path.getElectrificationMap(null, null, null)).isEqualTo(expectedMap)
     }
 
     @Test
@@ -173,9 +170,9 @@ class EnvelopeTrainPathTest {
                 Direction.INCREASING,
                 1_000.meters,
                 3_500.meters,
+                electricalProfileMapping = profileMap,
             )
-        val envelopeSimPath = EnvelopeTrainPath.from(infra.rawInfra, path, profileMap)
-        val electrificationByPowerClass = envelopeSimPath.getElectrificationMap("1", null, null)
+        val electrificationByPowerClass = path.getElectrificationMap("1", null, null)
         val expected = ImmutableRangeMap.Builder<Double, Electrification>()
 
         putInElectrificationMapByPowerClass(expected, 0.0, 500.0, NonElectrified(), "A", false)
@@ -271,9 +268,9 @@ class EnvelopeTrainPathTest {
                 Direction.DECREASING,
                 1_000.meters,
                 5_000.meters,
+                electricalProfileMapping = profileMap,
             )
-        val envelopeSimPath = EnvelopeTrainPath.from(infra.rawInfra, path, profileMap)
-        val electrificationPowerClass1 = envelopeSimPath.getElectrificationMap("1", null, null)
+        val electrificationPowerClass1 = path.getElectrificationMap("1", null, null)
         val expectedElectrificationPowerClass1 =
             ImmutableRangeMap.Builder<Double, Electrification>()
         putInElectrificationMapByPowerClass(
@@ -327,7 +324,7 @@ class EnvelopeTrainPathTest {
 
         assertThat(electrificationPowerClass1).isEqualTo(expectedElectrificationPowerClass1.build())
 
-        val electrificationPowerClass2 = envelopeSimPath.getElectrificationMap("2", null, null)
+        val electrificationPowerClass2 = path.getElectrificationMap("2", null, null)
         val expectedElectrificationPowerClass2 =
             ImmutableRangeMap.Builder<Double, Electrification>()
         putInElectrificationMapByPowerClass(

--- a/core/src/test/kotlin/fr/sncf/osrd/utils/PathUtils.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/utils/PathUtils.kt
@@ -6,6 +6,7 @@ import fr.sncf.osrd.path.implementations.buildChunkPath
 import fr.sncf.osrd.path.implementations.buildTrainPathFromChunkPath
 import fr.sncf.osrd.path.interfaces.BlockPath
 import fr.sncf.osrd.path.interfaces.TrainPath
+import fr.sncf.osrd.path.legacy_objects.ElectricalProfileMapping
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.utils.indexing.MutableDirStaticIdxArrayList
 import fr.sncf.osrd.utils.indexing.mutableDirStaticIdxArrayListOf
@@ -22,6 +23,7 @@ fun pathFromTracks(
     dir: Direction,
     start: Distance,
     end: Distance,
+    electricalProfileMapping: ElectricalProfileMapping? = null,
 ): TrainPath {
     val chunkList = mutableDirStaticIdxArrayListOf<TrackChunk>()
     trackIds
@@ -29,7 +31,12 @@ fun pathFromTracks(
         .flatMap { track -> infra.getTrackSectionChunks(track).dirIter(dir) }
         .forEach { dirChunk -> chunkList.add(dirChunk) }
     val chunkPath = buildChunkPath(infra, chunkList, Offset(start), Offset(end))
-    return buildTrainPathFromChunkPath(infra, blockInfra, chunkPath)
+    return buildTrainPathFromChunkPath(
+        infra,
+        blockInfra,
+        chunkPath,
+        electricalProfileMapping = electricalProfileMapping,
+    )
 }
 
 fun pathFromTracks(
@@ -38,8 +45,17 @@ fun pathFromTracks(
     dir: Direction,
     start: Distance,
     end: Distance,
+    electricalProfileMapping: ElectricalProfileMapping? = null,
 ): TrainPath {
-    return pathFromTracks(infra.rawInfra, infra.blockInfra, trackIds, dir, start, end)
+    return pathFromTracks(
+        infra.rawInfra,
+        infra.blockInfra,
+        trackIds,
+        dir,
+        start,
+        end,
+        electricalProfileMapping = electricalProfileMapping,
+    )
 }
 
 /** Build a path from route ids */

--- a/core/src/test/kotlin/fr/sncf/osrd/utils/PathUtils.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/utils/PathUtils.kt
@@ -5,7 +5,7 @@ import fr.sncf.osrd.path.implementations.ChunkPath
 import fr.sncf.osrd.path.implementations.buildChunkPath
 import fr.sncf.osrd.path.implementations.buildTrainPathFromChunkPath
 import fr.sncf.osrd.path.interfaces.BlockPath
-import fr.sncf.osrd.path.interfaces.PathProperties
+import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.utils.indexing.MutableDirStaticIdxArrayList
 import fr.sncf.osrd.utils.indexing.mutableDirStaticIdxArrayListOf
@@ -22,7 +22,7 @@ fun pathFromTracks(
     dir: Direction,
     start: Distance,
     end: Distance,
-): PathProperties {
+): TrainPath {
     val chunkList = mutableDirStaticIdxArrayListOf<TrackChunk>()
     trackIds
         .map { id -> infra.getTrackSectionFromName(id)!! }
@@ -38,7 +38,7 @@ fun pathFromTracks(
     dir: Direction,
     start: Distance,
     end: Distance,
-): PathProperties {
+): TrainPath {
     return pathFromTracks(infra.rawInfra, infra.blockInfra, trackIds, dir, start, end)
 }
 


### PR DESCRIPTION
Part of https://github.com/OpenRailAssociation/osrd/issues/12531

`TrainPath.subPath()` is now actually used. It did require some fixes. 

So I tried to add tests, but `DummyInfra` is part of the main module, so that's a pain. It's very hard to move to a different module. 