### PR TITLE
front: fix package lock out of sync

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -15687,9 +15687,9 @@
       }
     },
     "node_modules/maplibre-gl": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.7.1.tgz",
-      "integrity": "sha512-iCOQB6W/EGgQx8aU4SyfU5a5/GR2E+ELF92NMsqYfs3x+vnY+8mARmz4gor6XZHCz3tv19mnotVDRlRTMNKyGw==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.7.2.tgz",
+      "integrity": "sha512-SU6VlQ1tPskqzcTrwrvOarj2m5HuSkZARSzxbGUAym6h93ygqP6iwofbkzyIr1u6iv82BYK+dCV6avkUDAtwXg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@mapbox/geojson-rewind": "^0.5.2",
@@ -15699,7 +15699,7 @@
         "@mapbox/unitbezier": "^0.0.1",
         "@mapbox/vector-tile": "^2.0.4",
         "@mapbox/whoots-js": "^3.1.0",
-        "@maplibre/maplibre-gl-style-spec": "^23.3.0",
+        "@maplibre/maplibre-gl-style-spec": "^24.1.0",
         "@maplibre/vt-pbf": "^4.0.3",
         "@types/geojson": "^7946.0.16",
         "@types/geojson-vt": "3.2.5",
@@ -15741,9 +15741,9 @@
       }
     },
     "node_modules/maplibre-gl/node_modules/@maplibre/maplibre-gl-style-spec": {
-      "version": "23.3.0",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-23.3.0.tgz",
-      "integrity": "sha512-IGJtuBbaGzOUgODdBRg66p8stnwj9iDXkgbYKoYcNiiQmaez5WVRfXm4b03MCDwmZyX93csbfHFWEJJYHnn5oA==",
+      "version": "24.1.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-24.1.0.tgz",
+      "integrity": "sha512-VLmx4+ceP9XKwPvkjqfnwuHGzgp2MHGpRSWLisvotx6bnUgZLiIfwlVv5nVUlwK/IQoj1KFkrvppzVameZnRhA==",
       "license": "ISC",
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",


### PR DESCRIPTION
npm ci fails on dev right now, and thus so do all prs in the ci, with a package.json/package-lock.json out of sync error:

>   `#22 3.046 npm error 'npm ci' can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync. Please update your lock file with 'npm install' before continuing.`

I'm not sure why we would need to upgrade map libre for npm ci to work, since our package.json specifies ^5.7.1 and not 5.7.2. Upgrading it does solve the issue though.