### PR TITLE
front: fix open round trip modal

### DIFF
--- a/front/src/applications/operationalStudies/hooks/useTimetableItemsWithPathOps.ts
+++ b/front/src/applications/operationalStudies/hooks/useTimetableItemsWithPathOps.ts
@@ -33,7 +33,7 @@ const useTimetableItemsWithPathOps = (
       timetableOpRefs,
       timetableOperationalPoints ?? []
     );
-  }, [timetableItems, timetableOperationalPoints]);
+  }, [timetableItems, timetableOperationalPoints, timetableOpRefs]);
 };
 
 export default useTimetableItemsWithPathOps;

--- a/front/src/applications/operationalStudies/hooks/useTimetableItemsWithPathOps.ts
+++ b/front/src/applications/operationalStudies/hooks/useTimetableItemsWithPathOps.ts
@@ -15,7 +15,7 @@ const useTimetableItemsWithPathOps = (
     [timetableItems]
   );
 
-  const { currentData: timetableOperationalPoints } =
+  const { currentData: timetableOperationalPoints, isSuccess } =
     osrdEditoastApi.endpoints.matchAllOperationalPoints.useQuery(
       {
         infraId,
@@ -25,15 +25,16 @@ const useTimetableItemsWithPathOps = (
     );
 
   return useMemo(() => {
-    if (!timetableItems) {
+    if (!timetableItems || (!isSuccess && timetableOpRefs.length !== 0)) {
       return [];
     }
+
     return addPathOpsToTimetableItems(
       timetableItems,
       timetableOpRefs,
       timetableOperationalPoints ?? []
     );
-  }, [timetableItems, timetableOperationalPoints, timetableOpRefs]);
+  }, [timetableItems, timetableOperationalPoints, timetableOpRefs, isSuccess]);
 };
 
 export default useTimetableItemsWithPathOps;


### PR DESCRIPTION
closes https://github.com/OpenRailAssociation/osrd/issues/13302

`addPathOpsToTimetableItems` was called twice, once with an empty array when the request had not yet arrived. 
 We need to verify that the endpoint has been launched in case `timetableOpRefs` is not empty