### PR TITLE
front: handle existing macro nodes in nge import

### DIFF
--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -46,6 +46,8 @@
     "trainSchedulesFound_one": "1 train found",
     "trainSchedulesFound_other": "{{count}} trains found",
     "warningMessages": {
+      "alreadyPresentNode_one": "One macroscopic node was already present and was not updated.",
+      "alreadyPresentNode_other": "{{count}} macroscopic nodes were already present and were not updated.",
       "warning": "Warning",
       "warningFilteredStepImport": "{{trainNumbers}} invalid trains had to be modified to be successfully imported"
     }

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -46,6 +46,8 @@
     "trainSchedulesFound_one": "1 train trouvé",
     "trainSchedulesFound_other": "{{count}} trains trouvés",
     "warningMessages": {
+      "alreadyPresentNode_one": "Un noeud macroscopique était déjà présent et n'a pas été mis à jour.",
+      "alreadyPresentNode_other": "{{count}} noeuds macroscopiques étaient déjà présents et n'ont pas été mis à jour.",
       "warning": "Attention",
       "warningFilteredStepImport": "{{trainNumbers}} trains invalides ont été modifiés pour être importés avec succès"
     }

--- a/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/ImportTimetableItemTrainsList.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/ImportTimetableItemTrainsList.tsx
@@ -12,6 +12,7 @@ import type {
 import type { GraouTrainSchedule } from 'common/api/graouApi';
 import {
   osrdEditoastApi,
+  type MacroNodeForm,
   type PacedTrain,
   type TrainSchedule,
   type TrainCategory,
@@ -21,7 +22,7 @@ import { Loader } from 'common/Loaders';
 import { useSubCategoryContext } from 'common/SubCategoryContext';
 import { TrainMainCategoryDict } from 'modules/rollingStock/consts';
 import isMainCategory from 'modules/rollingStock/helpers/category';
-import { setFailure, setSuccess } from 'reducers/main';
+import { setFailure, setSuccess, setWarning } from 'reducers/main';
 import type {
   PacedTrainWithPacedTrainId,
   TimetableItem,
@@ -39,6 +40,7 @@ import generateTrainSchedulesPayloads from './generateTrainSchedulesPayloads';
 import findValidTrainNameKey from './helpers/findValidTrainNameKey';
 import { generateRoundTripsPayload } from './helpers/generatePayloads';
 import rollingstockOpenData2OSRD from './rollingstock_opendata2osrd.json';
+import { getSavedMacroNodes } from '../MacroEditor/utils';
 
 function LoadingIfSearching({
   isLoading,
@@ -203,6 +205,41 @@ const ImportTimetableItemTrainsList = ({
     await Promise.all(requests);
   };
 
+  /**
+   * Post macro nodes if their trigrams are not already present in the database.
+   * Displays a warning to the user if any nodes do not get posted.
+   */
+  const postMacroNodesIfNew = async (nodes: MacroNodeForm[]): Promise<void> => {
+    const storedNodes = await getSavedMacroNodes(
+      {
+        projectId: scenario.project.id,
+        studyId: scenario.study_id,
+        scenarioId: scenario.id,
+      },
+      dispatch
+    );
+    const storedNodesKeys = new Set(storedNodes.map((node) => node.path_item_key));
+    const newMacroNodes = nodes.filter((node) => !storedNodesKeys.has(node.path_item_key));
+    if (newMacroNodes.length > 0) {
+      await postMacroNodes({
+        projectId: scenario.project.id,
+        studyId: scenario.study_id,
+        scenarioId: scenario.id,
+        macroNodeBatchForm: { macro_nodes: newMacroNodes },
+      }).unwrap();
+    }
+    const ignoredNodesCount = nodes.length - newMacroNodes.length;
+    if (ignoredNodesCount)
+      dispatch(
+        setWarning({
+          title: t('warningMessages.warning'),
+          text: t('warningMessages.alreadyPresentNode', {
+            count: ignoredNodesCount,
+          }),
+        })
+      );
+  };
+
   async function generateTimetableItem() {
     try {
       let trainSchedulePayloads: TrainSchedule[] = [];
@@ -250,12 +287,7 @@ const ImportTimetableItemTrainsList = ({
       }
 
       if (macroNodes && macroNodes.length > 0) {
-        await postMacroNodes({
-          projectId: scenario.project.id,
-          studyId: scenario.study_id,
-          scenarioId: scenario.id,
-          macroNodeBatchForm: { macro_nodes: macroNodes },
-        }).unwrap();
+        await postMacroNodesIfNew(macroNodes);
       }
 
       upsertTimetableItems([...formattedTrainSchedules, ...formattedPacedTrains]);

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/utils.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/utils.ts
@@ -155,7 +155,7 @@ export const deleteMacroNodeByNgeId = async (
  * Get nodes of the scenario that are saved in the DB.
  */
 export const getSavedMacroNodes = async (
-  state: MacroEditorState,
+  { projectId, studyId, scenarioId }: { projectId: number; studyId: number; scenarioId: number },
   dispatch: AppDispatch
 ): Promise<MacroNodeResponse[]> => {
   const pageSize = 100;
@@ -166,9 +166,9 @@ export const getSavedMacroNodes = async (
     const promise = dispatch(
       osrdEditoastApi.endpoints.getProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNodes.initiate(
         {
-          projectId: state.projectId,
-          studyId: state.studyId,
-          scenarioId: state.scenarioId,
+          projectId,
+          studyId,
+          scenarioId,
           pageSize,
           page,
         },


### PR DESCRIPTION
Currently, importing already existing macro nodes causes a crash.

We may want to handle this. This is a first draft for how this could look like, although there are many other ways to go about this.