### PR TITLE
ui: update anchoredMenu and Menu props types to allow null refs

### DIFF
--- a/front/ui/storybook/stories/ui-charts/manchetteWithSpaceTimeChart/AnchoredMenu.tsx
+++ b/front/ui/storybook/stories/ui-charts/manchetteWithSpaceTimeChart/AnchoredMenu.tsx
@@ -4,7 +4,7 @@ import { createPortal } from 'react-dom';
 
 type AnchoreMenuParams = {
   children?: React.ReactNode;
-  anchorRef: React.RefObject<HTMLElement>;
+  anchorRef: React.RefObject<HTMLElement | null>;
   onDismiss: () => void;
 };
 

--- a/front/ui/storybook/stories/ui-charts/manchetteWithSpaceTimeChart/Menu.tsx
+++ b/front/ui/storybook/stories/ui-charts/manchetteWithSpaceTimeChart/Menu.tsx
@@ -7,7 +7,7 @@ export type MenuItem = {
 };
 
 type MenuProps = {
-  menuRef: React.RefObject<HTMLDivElement>;
+  menuRef: React.RefObject<HTMLDivElement | null>;
   items: MenuItem[];
 };
 


### PR DESCRIPTION
This PR updates `AnchoreMenuParams` and `MenuProps` types to allow null values for the `menuRef ` and the `anchorRef`.

We actually have some errors in the `base-with-waypoint-menu.stories.tsx` file about this that are weirdly not catch by the CI checks.