### PR TITLE
ui-icons: drop UiIcon

### DIFF
--- a/front/ui/storybook/stories/ui-icons/SearchIcons.tsx
+++ b/front/ui/storybook/stories/ui-icons/SearchIcons.tsx
@@ -2,22 +2,27 @@ import React, { useCallback, useMemo, useState, useRef } from 'react';
 
 import { Input } from '@osrd-project/ui-core';
 import * as Icons from '@osrd-project/ui-icons';
-import type { UiIcon } from '@osrd-project/ui-icons';
 
 import { ErrorBoundary } from './ErrorBoundary';
 
-const ICONS: Array<{ name: string; icon: UiIcon }> = Object.keys(Icons).map((name) => ({
-  name,
-  // eslint-disable-next-line import/namespace
-  icon: Icons[name] as UiIcon,
-}));
-
-export const SearchIcons: {
+type IconProps = {
   size: 'sm' | 'lg';
   variant: 'base' | 'fill';
   title?: string;
   iconColor: string;
-} = (args) => {
+};
+
+type IconEntry = {
+  name: string;
+  icon: React.ComponentType<IconProps>;
+};
+
+const ICONS: IconEntry[] = Object.keys(Icons).map((name) => ({
+  name,
+  icon: (Icons as Record<string, IconEntry['icon']>)[name],
+}));
+
+export const SearchIcons = (args: IconProps) => {
   // eslint-disable-next-line no-console
   console.log(args);
   const [search, setSearch] = useState('');
@@ -33,7 +38,7 @@ export const SearchIcons: {
     },
     [debounceTimer]
   );
-  const icons: Array<{ name: string; icon: UiIcon }> = useMemo(
+  const icons = useMemo(
     () => ICONS.filter((i) => i.name.toLowerCase().includes(search.toLowerCase())),
     [search]
   );

--- a/front/ui/ui-icons/scripts/build.js
+++ b/front/ui/ui-icons/scripts/build.js
@@ -140,7 +140,6 @@ const sizesContent = `export default ${JSON.stringify(sizes, null, 2)};\n`;
 writeFileSync(sizesFile, sizesContent);
 
 // Loop over the representation to generate React component files for each icon
-let typeNames = [];
 for (const [name, currentData] of Object.entries(representation)) {
   const supportedVariants = Object.keys(currentData);
 
@@ -176,9 +175,6 @@ for (const [name, currentData] of Object.entries(representation)) {
   // Append the current icon's export statement to the index file
   appendFileSync(
     indexFile,
-    `export { ${name} } from "./components/${name}";\n` +
-      `import type { ${name}Icon } from "./components/${name}";\n`
+    `export { ${name} } from "./components/${name}";\n`
   );
-  typeNames.push(`${name}Icon`);
 }
-appendFileSync(indexFile, `export type UiIcon = ${typeNames.join(' | ')};\n`);


### PR DESCRIPTION
This is a union containing a large number of entries. This makes the TypeScript compiler hit an out-of-memory error.

Before this change, running `npx tsc --noEmit` inside storybook would OOM. Now it correctly reports some errors.