### PR TITLE
front: fix out-of-sync package-lock.json once again

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -16270,9 +16270,9 @@
       }
     },
     "node_modules/maplibre-gl": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.7.2.tgz",
-      "integrity": "sha512-SU6VlQ1tPskqzcTrwrvOarj2m5HuSkZARSzxbGUAym6h93ygqP6iwofbkzyIr1u6iv82BYK+dCV6avkUDAtwXg==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.7.3.tgz",
+      "integrity": "sha512-T6XsjwcSfOr0vtAt4GTzx4m/vD6nrbR0+61MgMzZ9REQwILSEnhqwNpFuFbDedX6LC3ZWjZWnxN7fN/I66WoDQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@mapbox/geojson-rewind": "^0.5.2",
@@ -16282,7 +16282,7 @@
         "@mapbox/unitbezier": "^0.0.1",
         "@mapbox/vector-tile": "^2.0.4",
         "@mapbox/whoots-js": "^3.1.0",
-        "@maplibre/maplibre-gl-style-spec": "^24.1.0",
+        "@maplibre/maplibre-gl-style-spec": "^24.1.1",
         "@maplibre/vt-pbf": "^4.0.3",
         "@types/geojson": "^7946.0.16",
         "@types/geojson-vt": "3.2.5",
@@ -16324,9 +16324,9 @@
       }
     },
     "node_modules/maplibre-gl/node_modules/@maplibre/maplibre-gl-style-spec": {
-      "version": "24.1.0",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-24.1.0.tgz",
-      "integrity": "sha512-VLmx4+ceP9XKwPvkjqfnwuHGzgp2MHGpRSWLisvotx6bnUgZLiIfwlVv5nVUlwK/IQoj1KFkrvppzVameZnRhA==",
+      "version": "24.1.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-24.1.1.tgz",
+      "integrity": "sha512-xErR4lvMdzPNTxmglGEhSZxeyG55OusHjGhcPSrdZUnskBMPliVBQBxuzevmkQkb8gnl/UGDCYR+Byy3rkAgYQ==",
       "license": "ISC",
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",


### PR DESCRIPTION
`npm clean-install` freaks out:

    npm error Invalid: lock file's maplibre-gl@5.7.2 does not satisfy maplibre-gl@5.7.3
    npm error Invalid: lock file's @maplibre/maplibre-gl-style-spec@24.1.0 does not satisfy @maplibre/maplibre-gl-style-spec@24.1.1

Curious, since there is no `package.json` change between the last CI success (4d6c0e2498e0615da31b6f93e8bf48d2ff387ba9) and the first CI error (9fb0083da0841bc35b2220c0f71ca0a01bfa3afc).

We already hit something similar a few days ago: https://github.com/OpenRailAssociation/osrd/pull/13309