### PR TITLE
Remove some definitions' `Valkey-` prefix in editoast cache crate

### DIFF
--- a/editoast/cache/src/client.rs
+++ b/editoast/cache/src/client.rs
@@ -5,8 +5,8 @@ use deadpool_redis::PoolError;
 use deadpool_redis::Runtime;
 use url::Url;
 
-use crate::connection::ValkeyConnection;
-use crate::connection::ValkeyConnectionInner;
+use crate::connection::Connection;
+use crate::connection::ConnectionInner;
 
 pub struct ValkeyClient {
     inner: ValkeyClientInner,
@@ -49,14 +49,14 @@ impl ValkeyClient {
         }
     }
 
-    pub async fn get_connection(&self) -> Result<ValkeyConnection, PoolError> {
+    pub async fn get_connection(&self) -> Result<Connection, PoolError> {
         match &self.inner {
-            ValkeyClientInner::Tokio(pool) => Ok(ValkeyConnection::new(
-                ValkeyConnectionInner::Tokio(pool.get().await?),
+            ValkeyClientInner::Tokio(pool) => Ok(Connection::new(
+                ConnectionInner::Tokio(pool.get().await?),
                 self.app_version.clone(),
             )),
-            ValkeyClientInner::NoCache => Ok(ValkeyConnection::new(
-                ValkeyConnectionInner::NoCache,
+            ValkeyClientInner::NoCache => Ok(Connection::new(
+                ConnectionInner::NoCache,
                 self.app_version.clone(),
             )),
         }

--- a/editoast/cache/src/client.rs
+++ b/editoast/cache/src/client.rs
@@ -1,5 +1,4 @@
 use arcstr::ArcStr;
-use deadpool_redis::Config;
 use deadpool_redis::Pool;
 use deadpool_redis::PoolError;
 use deadpool_redis::Runtime;
@@ -20,7 +19,7 @@ pub enum ClientInner {
 }
 
 #[derive(Clone)]
-pub struct ValkeyConfig {
+pub struct Config {
     /// Disables caching. This should not be used in production.
     pub no_cache: bool,
     pub valkey_url: Url,
@@ -29,11 +28,11 @@ pub struct ValkeyConfig {
 
 impl Client {
     pub fn new(
-        ValkeyConfig {
+        Config {
             no_cache,
             valkey_url,
             app_version,
-        }: ValkeyConfig,
+        }: Config,
     ) -> Self {
         Self {
             app_version: ArcStr::from(app_version),
@@ -41,7 +40,7 @@ impl Client {
                 ClientInner::NoCache
             } else {
                 ClientInner::Tokio(
-                    Config::from_url(valkey_url)
+                    deadpool_redis::Config::from_url(valkey_url)
                         .create_pool(Some(Runtime::Tokio1))
                         .unwrap(),
                 )

--- a/editoast/cache/src/client.rs
+++ b/editoast/cache/src/client.rs
@@ -8,12 +8,12 @@ use url::Url;
 use crate::connection::Connection;
 use crate::connection::ConnectionInner;
 
-pub struct ValkeyClient {
-    inner: ValkeyClientInner,
+pub struct Client {
+    inner: ClientInner,
     app_version: ArcStr,
 }
 
-pub enum ValkeyClientInner {
+pub enum ClientInner {
     Tokio(Pool),
     /// This doesn't cache anything. It has no backend.
     NoCache,
@@ -27,7 +27,7 @@ pub struct ValkeyConfig {
     pub app_version: String,
 }
 
-impl ValkeyClient {
+impl Client {
     pub fn new(
         ValkeyConfig {
             no_cache,
@@ -38,9 +38,9 @@ impl ValkeyClient {
         Self {
             app_version: ArcStr::from(app_version),
             inner: if no_cache {
-                ValkeyClientInner::NoCache
+                ClientInner::NoCache
             } else {
-                ValkeyClientInner::Tokio(
+                ClientInner::Tokio(
                     Config::from_url(valkey_url)
                         .create_pool(Some(Runtime::Tokio1))
                         .unwrap(),
@@ -51,11 +51,11 @@ impl ValkeyClient {
 
     pub async fn get_connection(&self) -> Result<Connection, PoolError> {
         match &self.inner {
-            ValkeyClientInner::Tokio(pool) => Ok(Connection::new(
+            ClientInner::Tokio(pool) => Ok(Connection::new(
                 ConnectionInner::Tokio(pool.get().await?),
                 self.app_version.clone(),
             )),
-            ValkeyClientInner::NoCache => Ok(Connection::new(
+            ClientInner::NoCache => Ok(Connection::new(
                 ConnectionInner::NoCache,
                 self.app_version.clone(),
             )),

--- a/editoast/cache/src/connection.rs
+++ b/editoast/cache/src/connection.rs
@@ -1,7 +1,6 @@
 use std::fmt::Debug;
 
 use arcstr::ArcStr;
-use deadpool_redis::Connection;
 use deadpool_redis::redis::Arg;
 use deadpool_redis::redis::AsyncCommands;
 use deadpool_redis::redis::Cmd;
@@ -21,14 +20,14 @@ use tracing::Level;
 use tracing::debug;
 use tracing::span;
 
-pub struct ValkeyConnection {
-    inner: ValkeyConnectionInner,
+pub struct Connection {
+    inner: ConnectionInner,
     #[expect(unused)]
     app_version: ArcStr,
 }
 
-pub(crate) enum ValkeyConnectionInner {
-    Tokio(Connection),
+pub(crate) enum ConnectionInner {
+    Tokio(deadpool_redis::Connection),
     NoCache,
 }
 
@@ -60,11 +59,11 @@ fn no_cache_cmd_handler(cmd: &Cmd) -> Result<Value, RedisError> {
     }
 }
 
-impl ConnectionLike for ValkeyConnection {
+impl ConnectionLike for Connection {
     fn req_packed_command<'a>(&'a mut self, cmd: &'a Cmd) -> RedisFuture<'a, Value> {
         match &mut self.inner {
-            ValkeyConnectionInner::Tokio(connection) => connection.req_packed_command(cmd),
-            ValkeyConnectionInner::NoCache => future::ready(no_cache_cmd_handler(cmd)).boxed(),
+            ConnectionInner::Tokio(connection) => connection.req_packed_command(cmd),
+            ConnectionInner::NoCache => future::ready(no_cache_cmd_handler(cmd)).boxed(),
         }
     }
 
@@ -75,10 +74,10 @@ impl ConnectionLike for ValkeyConnection {
         count: usize,
     ) -> RedisFuture<'a, Vec<Value>> {
         match &mut self.inner {
-            ValkeyConnectionInner::Tokio(connection) => {
+            ConnectionInner::Tokio(connection) => {
                 connection.req_packed_commands(cmd, offset, count)
             }
-            ValkeyConnectionInner::NoCache => {
+            ConnectionInner::NoCache => {
                 let responses = cmd
                     .cmd_iter()
                     .skip(offset)
@@ -92,8 +91,8 @@ impl ConnectionLike for ValkeyConnection {
 
     fn get_db(&self) -> i64 {
         match &self.inner {
-            ValkeyConnectionInner::Tokio(connection) => connection.get_db(),
-            ValkeyConnectionInner::NoCache => 0,
+            ConnectionInner::Tokio(connection) => connection.get_db(),
+            ConnectionInner::NoCache => 0,
         }
     }
 }
@@ -111,8 +110,8 @@ struct ZrangebyscoreWrapper<M> {
     nonce: u64,
 }
 
-impl ValkeyConnection {
-    pub(crate) fn new(inner: ValkeyConnectionInner, app_version: ArcStr) -> Self {
+impl Connection {
+    pub(crate) fn new(inner: ConnectionInner, app_version: ArcStr) -> Self {
         Self { inner, app_version }
     }
 

--- a/editoast/cache/src/lib.rs
+++ b/editoast/cache/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod client;
 pub mod connection;
 
-pub use client::ValkeyClient;
+pub use client::Client;
 pub use client::ValkeyConfig;
 pub use connection::Connection;
 pub use deadpool_redis::redis::RedisError;

--- a/editoast/cache/src/lib.rs
+++ b/editoast/cache/src/lib.rs
@@ -2,7 +2,7 @@ pub mod client;
 pub mod connection;
 
 pub use client::Client;
-pub use client::ValkeyConfig;
+pub use client::Config;
 pub use connection::Connection;
 pub use deadpool_redis::redis::RedisError;
 

--- a/editoast/cache/src/lib.rs
+++ b/editoast/cache/src/lib.rs
@@ -3,7 +3,7 @@ pub mod connection;
 
 pub use client::ValkeyClient;
 pub use client::ValkeyConfig;
-pub use connection::ValkeyConnection;
+pub use connection::Connection;
 pub use deadpool_redis::redis::RedisError;
 
 pub type Error = RedisError;

--- a/editoast/src/client/healthcheck.rs
+++ b/editoast/src/client/healthcheck.rs
@@ -5,7 +5,6 @@ use core_client::CoreClient;
 use core_client::mq_client;
 use database::DbConnectionPoolV2;
 
-use crate::ValkeyClient;
 use crate::views;
 use cache;
 
@@ -22,7 +21,7 @@ pub async fn healthcheck_cmd(
     core_config: CoreArgs,
     openfga_config: OpenfgaConfig,
 ) -> anyhow::Result<()> {
-    let valkey = ValkeyClient::new(cache::ValkeyConfig {
+    let valkey = cache::Client::new(cache::ValkeyConfig {
         app_version: "HEALTHCHECK".to_owned(),
         no_cache,
         valkey_url,

--- a/editoast/src/client/healthcheck.rs
+++ b/editoast/src/client/healthcheck.rs
@@ -21,7 +21,7 @@ pub async fn healthcheck_cmd(
     core_config: CoreArgs,
     openfga_config: OpenfgaConfig,
 ) -> anyhow::Result<()> {
-    let valkey = cache::Client::new(cache::ValkeyConfig {
+    let valkey = cache::Client::new(cache::Config {
         app_version: "HEALTHCHECK".to_owned(),
         no_cache,
         valkey_url,

--- a/editoast/src/client/infra_commands.rs
+++ b/editoast/src/client/infra_commands.rs
@@ -10,7 +10,6 @@ use database::DbConnection;
 use database::DbConnectionPoolV2;
 use schemas::infra::RailJson;
 
-use crate::ValkeyClient;
 use crate::infra_cache::InfraCache;
 use crate::map;
 use crate::map::MapLayers;
@@ -238,7 +237,7 @@ async fn build_valkey_pool_and_invalidate_all_cache(
     infra_id: i64,
     app_version: Option<&str>,
 ) -> anyhow::Result<()> {
-    let valkey = ValkeyClient::new(cache::ValkeyConfig {
+    let valkey = cache::Client::new(cache::ValkeyConfig {
         app_version: app_version.map(|v| v.to_owned()).unwrap_or_default(),
         no_cache,
         valkey_url,

--- a/editoast/src/client/infra_commands.rs
+++ b/editoast/src/client/infra_commands.rs
@@ -237,7 +237,7 @@ async fn build_valkey_pool_and_invalidate_all_cache(
     infra_id: i64,
     app_version: Option<&str>,
 ) -> anyhow::Result<()> {
-    let valkey = cache::Client::new(cache::ValkeyConfig {
+    let valkey = cache::Client::new(cache::Config {
         app_version: app_version.map(|v| v.to_owned()).unwrap_or_default(),
         no_cache,
         valkey_url,

--- a/editoast/src/client/runserver.rs
+++ b/editoast/src/client/runserver.rs
@@ -102,7 +102,7 @@ pub async fn runserver(
                 worker_pool_id,
             },
         },
-        valkey_config: cache::ValkeyConfig {
+        valkey_config: cache::Config {
             app_version: app_version.clone().unwrap_or_default(),
             no_cache,
             valkey_url,

--- a/editoast/src/main.rs
+++ b/editoast/src/main.rs
@@ -36,15 +36,13 @@ use client::user::UserCommand;
 use common::tracing::TracingConfig;
 use common::tracing::create_tracing_subscriber;
 use database::DbConnectionPoolV2;
-use tracing_subscriber::util::SubscriberInitExt;
-pub use views::AppState;
-
-pub use cache::ValkeyClient;
 use opentelemetry_otlp::WithExportConfig as _;
 use std::io::IsTerminal;
 use std::process::exit;
 use std::sync::Arc;
 use tracing::error;
+use tracing_subscriber::util::SubscriberInitExt;
+pub use views::AppState;
 
 /// The mode editoast is running in
 ///

--- a/editoast/src/main.rs
+++ b/editoast/src/main.rs
@@ -40,7 +40,6 @@ use tracing_subscriber::util::SubscriberInitExt;
 pub use views::AppState;
 
 pub use cache::ValkeyClient;
-pub use cache::ValkeyConnection;
 use opentelemetry_otlp::WithExportConfig as _;
 use std::io::IsTerminal;
 use std::process::exit;

--- a/editoast/src/map/mod.rs
+++ b/editoast/src/map/mod.rs
@@ -10,7 +10,6 @@ pub use self::layer_cache::Tile;
 pub use self::layer_cache::get_cache_tile_key;
 pub use self::layer_cache::get_layer_cache_prefix;
 pub use self::layer_cache::get_view_cache_prefix;
-use crate::ValkeyConnection;
 use crate::error::Result;
 
 /// Invalidates layer cache for a specific infra and view if provided
@@ -24,7 +23,7 @@ use crate::error::Result;
 ///
 /// Returns the number of deleted keys
 async fn invalidate_full_layer_cache(
-    valkey: &mut ValkeyConnection,
+    valkey: &mut cache::Connection,
     infra_id: i64,
     layer_name: &str,
     app_version: Option<&str>,
@@ -49,7 +48,7 @@ async fn invalidate_full_layer_cache(
 ///
 /// Panics if fail
 pub async fn invalidate_all(
-    valkey: &mut ValkeyConnection,
+    valkey: &mut cache::Connection,
     layers: &Vec<String>,
     infra_id: i64,
     app_version: Option<&str>,

--- a/editoast/src/views/infra/edition.rs
+++ b/editoast/src/views/infra/edition.rs
@@ -30,7 +30,6 @@ use tracing::info;
 use uuid::Uuid;
 
 use crate::AppState;
-use crate::ValkeyClient;
 use crate::error::Result;
 use crate::generated_data;
 use crate::infra_cache::InfraCache;
@@ -869,7 +868,7 @@ async fn apply_edit(
     infra: &mut Infra,
     operations: &[Operation],
     infra_cache: &mut InfraCache,
-    valkey: Arc<ValkeyClient>,
+    valkey: Arc<cache::Client>,
     app_version: Option<&str>,
 ) -> Result<Vec<InfraObject>> {
     let infra_id = infra.id;

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -82,7 +82,6 @@ use tracing::info;
 use tracing::warn;
 use url::Url;
 
-use crate::ValkeyClient;
 use crate::error::Result;
 use crate::generated_data::speed_limit_tags_config::SpeedLimitTagIds;
 use crate::infra_cache::InfraCache;
@@ -651,7 +650,7 @@ async fn health(
 
 pub async fn check_health(
     db_pool: Arc<DbConnectionPoolV2>,
-    valkey_client: Arc<ValkeyClient>,
+    valkey_client: Arc<cache::Client>,
     core_client: Arc<CoreClient>,
     openfga: &fga::Client,
 ) -> Result<()> {
@@ -781,7 +780,7 @@ pub type Regulator = ::authz::Regulator<PgAuthDriver>;
 pub struct AppState {
     pub config: Arc<ServerConfig>,
     pub db_pool: Arc<DbConnectionPoolV2>,
-    pub valkey: Arc<ValkeyClient>,
+    pub valkey: Arc<cache::Client>,
     pub infra_caches: Arc<DashMap<i64, InfraCache>>,
     pub map_layers: Arc<MapLayers>,
     pub speed_limit_tag_ids: Arc<SpeedLimitTagIds>,
@@ -887,7 +886,7 @@ impl AppState {
         // Synchronous operations
         let infra_caches = DashMap::<i64, InfraCache>::default().into();
         let speed_limit_tag_ids = Arc::new(SpeedLimitTagIds::load());
-        let valkey = ValkeyClient::new(config.valkey_config.clone()).into();
+        let valkey = cache::Client::new(config.valkey_config.clone()).into();
         let osrdyne_client = Arc::new(OsrdyneClient::new(
             config.osrdyne_config.osrdyne_api_url.clone(),
         ));

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -87,7 +87,6 @@ use crate::generated_data::speed_limit_tags_config::SpeedLimitTagIds;
 use crate::infra_cache::InfraCache;
 use crate::map::MapLayers;
 use crate::models::PgAuthDriver;
-use cache::ValkeyConfig;
 
 fn service_router() -> router::DocumentedRouter {
     use router::delete;
@@ -759,7 +758,7 @@ pub struct ServerConfig {
     pub enable_authorization: bool,
     pub postgres_config: PostgresConfig,
     pub osrdyne_config: OsrdyneConfig,
-    pub valkey_config: ValkeyConfig,
+    pub valkey_config: cache::Config,
     pub openfga_config: OpenfgaConfig,
     pub root_url: Url,
     pub dynamic_assets_path: PathBuf,

--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -40,7 +40,6 @@ use crate::views::AuthenticationExt;
 use crate::views::AuthorizationError;
 use crate::views::path::PathfindingError;
 use crate::views::path::path_item_cache::PathItemCache;
-use cache::ValkeyConnection;
 use editoast_models::prelude::*;
 
 /// Path input is described by some rolling stock information
@@ -238,7 +237,7 @@ pub(in crate::views) async fn post(
 /// Pathfinding computation given a path input
 async fn pathfinding_blocks(
     conn: DbConnection,
-    valkey_conn: &mut ValkeyConnection,
+    valkey_conn: &mut cache::Connection,
     core: Arc<CoreClient>,
     infra: &Infra,
     path_input: PathfindingInput,
@@ -253,7 +252,7 @@ async fn pathfinding_blocks(
 /// Pathfinding batch computation given a list of path inputs
 async fn pathfinding_blocks_batch(
     mut conn: DbConnection,
-    valkey_conn: &mut ValkeyConnection,
+    valkey_conn: &mut cache::Connection,
     core: Arc<CoreClient>,
     infra: &Infra,
     pathfinding_inputs: &[PathfindingInput],
@@ -411,7 +410,7 @@ fn build_pathfinding_request(
 /// Compute a path given a train schedule and an infrastructure.
 pub async fn pathfinding_from_train<T: TrainScheduleLike>(
     conn: DbConnection,
-    valkey: &mut ValkeyConnection,
+    valkey: &mut cache::Connection,
     core: Arc<CoreClient>,
     infra: &Infra,
     train_schedule: T,
@@ -443,7 +442,7 @@ pub async fn pathfinding_from_train<T: TrainScheduleLike>(
 /// Compute a path given a batch of trainschedule and an infrastructure.
 pub async fn pathfinding_from_train_batch<T: TrainScheduleLike>(
     conn: DbConnection,
-    valkey: &mut ValkeyConnection,
+    valkey: &mut cache::Connection,
     core: Arc<CoreClient>,
     infra: &Infra,
     train_schedules: &[T],

--- a/editoast/src/views/path/properties.rs
+++ b/editoast/src/views/path/properties.rs
@@ -33,7 +33,6 @@ use std::sync::Arc;
 use utoipa::ToSchema;
 
 use crate::AppState;
-use crate::ValkeyConnection;
 use crate::error::Result;
 use crate::views::AuthenticationExt;
 use crate::views::path::retrieve_infra_version;
@@ -194,7 +193,7 @@ pub(in crate::views) async fn post(
 /// Retrieves path properties from cache.
 #[tracing::instrument(skip_all, err)]
 async fn retrieve_path_properties_from_cache<'a>(
-    conn: &mut ValkeyConnection,
+    conn: &mut cache::Connection,
     requests: &'a [PathPropertiesRequest<'a>],
     app_version: Option<&str>,
 ) -> Result<
@@ -217,7 +216,7 @@ async fn retrieve_path_properties_from_cache<'a>(
 /// Set the cache of path properties.
 #[tracing::instrument(skip_all, err)]
 async fn cache_path_properties<'a>(
-    conn: &mut ValkeyConnection,
+    conn: &mut cache::Connection,
     properties: impl IntoIterator<
         Item = (
             &'a PathPropertiesRequest<'a>,
@@ -254,7 +253,7 @@ fn path_properties_input_hash(
 #[tracing::instrument(skip_all, err)]
 pub(in crate::views) async fn compute_path_properties_batch(
     core_client: Arc<CoreClient>,
-    conn: &mut ValkeyConnection,
+    conn: &mut cache::Connection,
     requests: &[PathPropertiesRequest<'_>],
     app_version: Option<&str>,
 ) -> Result<impl Iterator<Item = core_client::path_properties::PathPropertiesResponse>> {

--- a/editoast/src/views/projection.rs
+++ b/editoast/src/views/projection.rs
@@ -25,7 +25,7 @@ use thiserror::Error;
 use utoipa::ToSchema;
 
 use super::path::path_item_cache::PathItemCache;
-use crate::ValkeyClient;
+
 use crate::models::infra::Infra;
 use crate::views::path::pathfinding::PathfindingResult;
 use crate::views::path::projection::PathProjection;
@@ -350,7 +350,7 @@ pub fn linear_interpolate(a_x: u64, b_x: u64, a_y: u64, b_y: u64, x: u64) -> u64
 pub async fn compute_projected_train_paths<T: TrainScheduleLike>(
     conn: &mut DbConnection,
     core_client: Arc<CoreClient>,
-    valkey_client: Arc<ValkeyClient>,
+    valkey_client: Arc<cache::Client>,
     track_section_ranges: Vec<TrackRange>,
     infra: &Infra,
     train_schedules: &[T],
@@ -636,7 +636,7 @@ impl OperationalPointProjection {
 #[allow(clippy::too_many_arguments)]
 pub async fn compute_projected_train_path_op<T: TrainScheduleLike>(
     conn: &mut DbConnection,
-    valkey_client: Arc<ValkeyClient>,
+    valkey_client: Arc<cache::Client>,
     core_client: Arc<CoreClient>,
     train_schedules: &[T],
     path_item_cache: &PathItemCache,

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -36,7 +36,6 @@ use tracing_subscriber::filter::Directive;
 use url::Url;
 
 use crate::AppState;
-use crate::ValkeyClient;
 use crate::generated_data::speed_limit_tags_config::SpeedLimitTagIds;
 use crate::infra_cache::InfraCache;
 use crate::map::MapLayers;
@@ -205,7 +204,7 @@ impl TestAppBuilder {
         let tracing_guard = tracing::subscriber::set_default(sub);
 
         // Config valkey
-        let valkey = ValkeyClient::new(config.valkey_config.clone()).into();
+        let valkey = cache::Client::new(config.valkey_config.clone()).into();
 
         // Create database pool
         let db_pool_v2 = Arc::new(self.db_pool.unwrap_or_else(DbConnectionPoolV2::for_tests));
@@ -335,7 +334,7 @@ impl TestApp {
         self.app_state.db_pool.clone()
     }
 
-    pub fn valkey_client(&self) -> Arc<ValkeyClient> {
+    pub fn valkey_client(&self) -> Arc<cache::Client> {
         self.app_state.valkey.clone()
     }
 

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -41,7 +41,6 @@ use crate::infra_cache::InfraCache;
 use crate::map::MapLayers;
 use crate::models::PgAuthDriver;
 use crate::views::service_router;
-use cache::ValkeyConfig;
 use fga::client::DEFAULT_OPENFGA_MAX_CHECKS_PER_BATCH_CHECK;
 use fga::client::DEFAULT_OPENFGA_MAX_TUPLES_PER_WRITE;
 
@@ -165,7 +164,7 @@ impl TestAppBuilder {
                     worker_pool_id: "core".into(),
                 },
             },
-            valkey_config: ValkeyConfig {
+            valkey_config: cache::Config {
                 app_version: "TEST_VERSION".to_owned(),
                 no_cache: true,
                 valkey_url: Url::parse("redis://localhost:6379").unwrap(),

--- a/editoast/src/views/timetable/occupancy_blocks.rs
+++ b/editoast/src/views/timetable/occupancy_blocks.rs
@@ -14,7 +14,6 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use utoipa::ToSchema;
 
-use crate::ValkeyClient;
 use crate::error::Result;
 use crate::models::infra::Infra;
 use crate::views::projection::ProjectPathInput;
@@ -71,7 +70,7 @@ pub(super) async fn compute_batch_signal_updates<'a>(
 pub(super) async fn compute_occupancy_blocks<T: TrainScheduleLike>(
     conn: &mut DbConnection,
     core_client: Arc<CoreClient>,
-    valkey_client: Arc<ValkeyClient>,
+    valkey_client: Arc<cache::Client>,
     path: ProjectPathInput,
     infra: &Infra,
     trains_schedules: &[T],

--- a/editoast/src/views/timetable/similar_trains.rs
+++ b/editoast/src/views/timetable/similar_trains.rs
@@ -42,7 +42,6 @@ use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
 
-use crate::ValkeyClient;
 use crate::error::Result;
 use crate::generated_data::speed_limit_tags_config::SpeedLimitTagIds;
 use crate::models;
@@ -521,7 +520,7 @@ async fn search_candidate_train_schedules(
 #[tracing::instrument(skip_all, fields(infra_id = infra.id, candidate_schedules = candidate_schedules.len()), err)]
 async fn simulate_past_trains(
     conn: &mut DbConnection,
-    valkey: Arc<ValkeyClient>,
+    valkey: Arc<cache::Client>,
     core_client: Arc<CoreClient>,
     infra: &Infra,
     candidate_schedules: Vec<models::TrainSchedule>,

--- a/editoast/src/views/timetable/simulation.rs
+++ b/editoast/src/views/timetable/simulation.rs
@@ -30,7 +30,6 @@ use tracing::Instrument;
 use tracing::info;
 use utoipa::ToSchema;
 
-use crate::ValkeyClient;
 use crate::error::InternalError;
 use crate::error::Result;
 use crate::models::RollingStock;
@@ -213,7 +212,7 @@ impl SummaryResponse {
 #[allow(clippy::too_many_arguments)]
 pub async fn train_simulation_batch<T: TrainScheduleLike>(
     conn: &mut DbConnection,
-    valkey_client: Arc<ValkeyClient>,
+    valkey_client: Arc<cache::Client>,
     core: Arc<CoreClient>,
     train_schedules: &[T],
     infra: &Infra,
@@ -277,7 +276,7 @@ pub async fn train_simulation_batch<T: TrainScheduleLike>(
 #[allow(clippy::too_many_arguments)]
 pub async fn consist_train_simulation_batch<T: TrainScheduleLike>(
     conn: &mut DbConnection,
-    valkey_client: Arc<ValkeyClient>,
+    valkey_client: Arc<cache::Client>,
     core: Arc<CoreClient>,
     infra: &Infra,
     train_schedules: &[T],

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -34,7 +34,6 @@ use utoipa::IntoParams;
 use utoipa::ToSchema;
 
 use crate::AppState;
-use crate::ValkeyClient;
 use crate::error::InternalError;
 use crate::error::Result;
 use crate::models::Infra;
@@ -321,7 +320,7 @@ impl VirtualTrainRun {
     #[allow(clippy::too_many_arguments)]
     async fn simulate(
         db_pool: Arc<DbConnectionPoolV2>,
-        valkey_client: Arc<ValkeyClient>,
+        valkey_client: Arc<cache::Client>,
         core_client: Arc<CoreClient>,
         app_version: Option<&str>,
         stdcm_request: &Request,


### PR DESCRIPTION
- **editoast: cache: rename `ValkeyConnection` to `Connection`**
- **editoast: cache: rename `ValkeyClient` to `Client`**
- **editoast: cache: rename `ValkeyConfig` to `Config`**
