### PR TITLE
editoast: new endpoint to get the groups of an user

### DIFF
--- a/editoast/editoast_models/src/authn/group.rs
+++ b/editoast/editoast_models/src/authn/group.rs
@@ -1,10 +1,12 @@
-use editoast_derive::Model;
-
 use crate as editoast_models; // HACK: remove after all models are in this crate
+use editoast_derive::Model;
+use serde::Deserialize;
+use serde::Serialize;
+use utoipa::ToSchema;
 
-#[derive(Debug, Clone, Model)]
+#[derive(Debug, Clone, Model, ToSchema, Serialize, Deserialize, PartialEq, Eq)]
 #[model(table = database::tables::authn_group)]
-#[model(gen(ops = r, list))]
+#[model(gen(ops = r, list, batch_ops = r))]
 pub struct Group {
     pub id: i64,
     pub name: String,

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -101,6 +101,28 @@ paths:
                       id:
                         type: integer
                         format: int64
+  /authz/me/groups:
+    get:
+      tags:
+      - authz
+      responses:
+        '200':
+          description: Get the groups of the current user
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - id
+                  - name
+                  properties:
+                    id:
+                      type: integer
+                      format: int64
+                    name:
+                      type: string
   /authz/me/privileges:
     post:
       tags:

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -19,6 +19,7 @@ use axum::response::Json;
 use database::DbConnectionPoolV2;
 use diesel_async::scoped_futures::ScopedFutureExt;
 use editoast_derive::EditoastError;
+use editoast_models::Group;
 use editoast_models::prelude::*;
 use itertools::Itertools;
 use serde::Deserialize;
@@ -110,6 +111,40 @@ pub(in crate::views) async fn whoami(
         name: auth.user_name()?.unwrap_or_else(|| "OSRD user".to_string()),
         roles: auth.user_roles().await?.into_iter().collect(),
     }))
+}
+
+#[editoast_derive::route]
+#[utoipa::path(
+    get,
+    path = "",
+    tag = "authz",
+    responses((
+        status = 200,
+        description = "Get the groups of the current user",
+        body = inline(Vec<Group>),
+    ))
+)]
+pub(in crate::views) async fn user_groups(
+    Extension(auth): AuthenticationExt,
+    State(AppState {
+        regulator, db_pool, ..
+    }): State<AppState>,
+) -> Result<Json<Vec<Group>>> {
+    let authorizer = auth.authorizer()?;
+    let user_id = authorizer.user_id();
+    let user_groups = regulator.user_groups(&authz::User(user_id)).await?;
+    let groups_id: Vec<i64> = user_groups.iter().map(|authz::Group(id)| *id).collect();
+
+    let (result, missing_ids) =
+        editoast_models::Group::retrieve_batch(&mut db_pool.get().await?, groups_id).await?;
+
+    if !missing_ids.is_empty() {
+        tracing::warn!(missing_count = missing_ids.len(),
+            missing_groups_id = ?missing_ids,
+             "Groups not found in database");
+    }
+
+    Ok(Json(result))
 }
 
 #[derive(Debug, Serialize, ToSchema)]
@@ -1070,5 +1105,61 @@ mod tests {
             .json_into::<WhoamiResponse>();
 
         assert_eq!(roles, vec![Role::Admin]);
+    }
+
+    #[rstest]
+    async fn user_groups_test() {
+        let app = test_app!().enable_authorization(true).build();
+        let user_1 = app.user("test1", "test1").create();
+        let user_2 = app.user("test2", "test2").create();
+        let group_1 = app
+            .group("group_1")
+            .with_members([&user_1, &user_2])
+            .create();
+        let group_2 = app.group("group_2").with_members([&user_1]).create();
+
+        let request_1 = app.get("/authz/me/groups").by_user(&user_1);
+        let request_2 = app.get("/authz/me/groups").by_user(&user_2);
+
+        let mut groups_user_1 = app
+            .fetch(request_1)
+            .assert_status(StatusCode::OK)
+            .json_into::<Vec<Group>>();
+        let groups_user_2 = app
+            .fetch(request_2)
+            .assert_status(StatusCode::OK)
+            .json_into::<Vec<Group>>();
+
+        groups_user_1.sort_by_key(|g| g.id);
+
+        assert_eq!(
+            groups_user_1,
+            vec![
+                Group {
+                    id: group_1.id,
+                    name: "group_1".to_string(),
+                },
+                Group {
+                    id: group_2.id,
+                    name: "group_2".to_string(),
+                }
+            ]
+        );
+        assert_eq!(
+            groups_user_2,
+            vec![Group {
+                id: group_1.id,
+                name: "group_1".to_string(),
+            }]
+        );
+    }
+
+    #[rstest]
+    async fn user_groups_authorization_disabled() {
+        let app = test_app!().enable_authorization(false).build();
+        let user = app.user("test", "test").create();
+
+        let request = app.get("/authz/me/groups").by_user(&user);
+        app.fetch(request).assert_status(StatusCode::UNAUTHORIZED);
     }
 }

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -126,6 +126,7 @@ fn service_router() -> router::DocumentedRouter {
                     .route("/{resource_type}/{resource_id}", get!(authz::subjects_with_grant_on_resource))
                     .nests("/me", |path| {
                         path.route("/", get!(authz::whoami))
+                            .route("/groups", get!(authz::user_groups))
                             .route("/grants", post!(authz::user_grants))
                             .route("/privileges", post!(authz::user_privileges))
                     })

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -48,6 +48,10 @@ const injectedRtkApi = api
         query: (queryArg) => ({ url: `/authz/me/grants`, method: 'POST', body: queryArg.body }),
         invalidatesTags: ['authz'],
       }),
+      getAuthzMeGroups: build.query<GetAuthzMeGroupsApiResponse, GetAuthzMeGroupsApiArg>({
+        query: () => ({ url: `/authz/me/groups` }),
+        providesTags: ['authz'],
+      }),
       postAuthzMePrivileges: build.mutation<
         PostAuthzMePrivilegesApiResponse,
         PostAuthzMePrivilegesApiArg
@@ -1431,6 +1435,11 @@ export type PostAuthzMeGrantsApiArg = {
     [key: string]: number[];
   };
 };
+export type GetAuthzMeGroupsApiResponse = /** status 200 Get the groups of the current user */ {
+  id: number;
+  name: string;
+}[];
+export type GetAuthzMeGroupsApiArg = void;
 export type PostAuthzMePrivilegesApiResponse =
   /** status 200 The privileges of the user sending the request over each requested resource. */ {
     [key: string]: {


### PR DESCRIPTION
Add a new endpoint to retrieve the groups of the currently authenticated user.

* Updated the `Group` model to derive `Serialize`, `Deserialize`, `PartialEq`, `Eq`, and `ToSchema` traits.
* Added the `GET /authz/me/groups` endpoint, which returns the groups for the current user as a JSON array of group objects (`id` and `name`). 
* Added unit test to verify that the new endpoint correctly returns the groups for different users.
* Updated OpenAPI documentation and frontend API client using the corresponding scripts.