### PR TITLE
github: fix typo in osrd-ui deploy condition

### DIFF
--- a/.github/workflows/osrd-ui-website.yml
+++ b/.github/workflows/osrd-ui-website.yml
@@ -83,4 +83,4 @@ jobs:
           step_summary_enabled: true
         env:
           HAVE_SSH_KEY: ${{ secrets.UI_WEBSITE_SSH_KEY != '' }}
-        if: ${{ env.HAVE_PERSONAL_TOKEN == 'true' }}
+        if: ${{ env.HAVE_SSH_KEY == 'true' }}


### PR DESCRIPTION
Ooops. This caused the website to never deploy.

Fixes: 023a28a55acd ("github: skip osrd-ui-website workflow when missing secret")