### PR TITLE
front: drop @types/uuid dependency

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -114,7 +114,6 @@
         "@types/react": "^19.1.13",
         "@types/react-dom": "^19.1.9",
         "@types/tether": "^1.4.9",
-        "@types/uuid": "^11.0.0",
         "@typescript-eslint/eslint-plugin": "^8.44.0",
         "@typescript-eslint/parser": "^8.32.1",
         "@vitejs/plugin-react-swc": "^4.1.0",
@@ -6857,17 +6856,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="
-    },
-    "node_modules/@types/uuid": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-11.0.0.tgz",
-      "integrity": "sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA==",
-      "deprecated": "This is a stub types definition. uuid provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "uuid": "*"
-      }
     },
     "node_modules/@types/whatwg-mimetype": {
       "version": "3.0.2",

--- a/front/package.json
+++ b/front/package.json
@@ -110,7 +110,6 @@
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",
     "@types/tether": "^1.4.9",
-    "@types/uuid": "^11.0.0",
     "@typescript-eslint/eslint-plugin": "^8.44.0",
     "@typescript-eslint/parser": "^8.32.1",
     "@vitejs/plugin-react-swc": "^4.1.0",


### PR DESCRIPTION
This package is no longer required:

    npm warn deprecated @types/uuid@11.0.0: This is a stub types definition. uuid provides its own type definitions, so you do not need this installed.