### PR TITLE
front: drop sec2time()

### DIFF
--- a/front/src/modules/timesStops/helpers/utils.ts
+++ b/front/src/modules/timesStops/helpers/utils.ts
@@ -23,7 +23,6 @@ import { msToS } from 'utils/physics';
 import { NO_BREAK_SPACE } from 'utils/strings';
 import {
   durationInSeconds,
-  sec2time,
   SECONDS_IN_A_DAY,
   secToHoursString,
   time2sec,
@@ -175,7 +174,7 @@ export function updateRowTimesAndMargin(
     } else if (newRowData.departure) {
       if (!previousRowData.departure) {
         newRowData.arrival = {
-          time: sec2time(
+          time: secToHoursString(
             time2sec(newRowData.departure.time) - (newRowData.stopFor?.total('second') ?? 0)
           ),
         };

--- a/front/src/utils/timeManipulation.ts
+++ b/front/src/utils/timeManipulation.ts
@@ -39,9 +39,7 @@ export function calculateTimeDifferenceInDays(datetime1?: Date, datetime2?: Date
 }
 
 /**
- * converts a value in seconds to a timeString "HH:MM"
- *
- * using the param withSeconds returns the longer format "HH:MM:SS"
+ * converts a value in seconds to a time string "HH:MM:SS"
  */
 export function secToHoursString(sec: number): TimeString {
   const date = new Date(sec * 1000);

--- a/front/src/utils/timeManipulation.ts
+++ b/front/src/utils/timeManipulation.ts
@@ -47,10 +47,7 @@ export function calculateTimeDifferenceInDays(datetime1?: Date, datetime2?: Date
  *
  * using the param withSeconds returns the longer format "HH:MM:SS"
  */
-export function secToHoursString(sec: number | null): TimeString {
-  if (!sec) {
-    return '';
-  }
+export function secToHoursString(sec: number): TimeString {
   const date = new Date(sec * 1000);
   return dayjs(date).utc().format('HH:mm:ss');
 }

--- a/front/src/utils/timeManipulation.ts
+++ b/front/src/utils/timeManipulation.ts
@@ -13,10 +13,6 @@ export function ms2sec(ms: number) {
   return ms / 1000;
 }
 
-export function sec2time(sec: number) {
-  return new Date(sec * 1000).toISOString().substr(11, 8);
-}
-
 /**
  * Given a timeString, returns the number of seconds from midnight
  *


### PR DESCRIPTION
secToHoursString() does exactly the same thing, but without manual string mungling and magic offsets.

Part of https://github.com/OpenRailAssociation/osrd/issues/10877