### PR TITLE
Adapt core and editoast infra load endpoint

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/api/WorkerLoadEndpoint.java
+++ b/core/src/main/java/fr/sncf/osrd/api/WorkerLoadEndpoint.java
@@ -9,14 +9,16 @@ import org.takes.Take;
 import org.takes.rq.RqPrint;
 import org.takes.rs.*;
 
-public class InfraLoadEndpoint implements Take {
+public class WorkerLoadEndpoint implements Take {
     private final InfraManager infraManager;
+    private final TimetableCacheManager timetableManager;
 
-    public static final JsonAdapter<InfraLoadRequest> adapterRequest =
-            new Moshi.Builder().build().adapter(InfraLoadRequest.class);
+    public static final JsonAdapter<WorkerLoadRequest> adapterRequest =
+            new Moshi.Builder().build().adapter(WorkerLoadRequest.class);
 
-    public InfraLoadEndpoint(InfraManager infraManager) {
+    public WorkerLoadEndpoint(InfraManager infraManager, TimetableCacheManager timetableManager) {
         this.infraManager = infraManager;
+        this.timetableManager = timetableManager;
     }
 
     @Override
@@ -27,8 +29,9 @@ public class InfraLoadEndpoint implements Take {
             var request = adapterRequest.fromJson(body);
             if (request == null) return new RsWithStatus(new RsText("missing request body"), 400);
 
-            // load infra
-            infraManager.load(request.infra, request.expectedVersion);
+            // load infra and timetable
+            var infra = infraManager.load(request.infra, request.expectedVersion);
+            if (request.timetable != null) timetableManager.load(request.infra, infra.rawInfra(), request.timetable);
 
             return new RsWithStatus(204);
         } catch (Throwable ex) {
@@ -37,7 +40,7 @@ public class InfraLoadEndpoint implements Take {
         }
     }
 
-    public static final class InfraLoadRequest {
+    public static final class WorkerLoadRequest {
         /** Infra id */
         public String infra;
 
@@ -45,10 +48,14 @@ public class InfraLoadEndpoint implements Take {
         @Json(name = "expected_version")
         public int expectedVersion;
 
+        /** Timetable ID */
+        public Integer timetable;
+
         /** Create InfraLoadRequest */
-        public InfraLoadRequest(String infra, int expectedVersion) {
+        public WorkerLoadRequest(String infra, int expectedVersion, Integer timetable) {
             this.infra = infra;
             this.expectedVersion = expectedVersion;
+            this.timetable = timetable;
         }
     }
 }

--- a/core/src/main/java/fr/sncf/osrd/cli/WorkerCommand.kt
+++ b/core/src/main/java/fr/sncf/osrd/cli/WorkerCommand.kt
@@ -136,7 +136,7 @@ class WorkerCommand : CliCommand {
                     ETCSBrakingCurvesEndpoint(infraManager, electricalProfileSetManager),
                 "/version" to VersionEndpoint(),
                 "/stdcm" to STDCMEndpoint(infraManager, timetableCache),
-                "/infra_load" to InfraLoadEndpoint(infraManager),
+                "/worker_load" to WorkerLoadEndpoint(infraManager, timetableCache),
             )
 
         val executor =

--- a/core/src/test/java/fr/sncf/osrd/api/WorkerLoadingTest.java
+++ b/core/src/test/java/fr/sncf/osrd/api/WorkerLoadingTest.java
@@ -8,15 +8,15 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.takes.rq.RqFake;
 
-public class InfraLoadingTest extends ApiTest {
+public class WorkerLoadingTest extends ApiTest {
     @ParameterizedTest
     @CsvSource({"true, 400", "false, 204"})
     public void infraLoadEndpoint_act_request_returns_correct_responses(
             boolean isRequestNull, String expectedStatusCode) throws IOException {
-        var request = isRequestNull ? null : new InfraLoadEndpoint.InfraLoadRequest("tiny_infra/infra.json", 1);
-        var requestBody = InfraLoadEndpoint.adapterRequest.toJson(request);
+        var request = isRequestNull ? null : new WorkerLoadEndpoint.WorkerLoadRequest("tiny_infra/infra.json", 1, null);
+        var requestBody = WorkerLoadEndpoint.adapterRequest.toJson(request);
         var list = readHeadResponse(
-                new InfraLoadEndpoint(infraManager).act(new RqFake("POST", "/infra_load", requestBody)));
+                new WorkerLoadEndpoint(infraManager, null).act(new RqFake("POST", "/worker_load", requestBody)));
         assertTrue(list.get(0).contains(expectedStatusCode));
     }
 }

--- a/editoast/core_client/src/lib.rs
+++ b/editoast/core_client/src/lib.rs
@@ -1,6 +1,5 @@
 pub mod conflict_detection;
 pub mod etcs_braking_curves;
-pub mod infra_loading;
 pub mod mq_client;
 pub mod path_properties;
 pub mod pathfinding;
@@ -8,6 +7,7 @@ pub mod signal_projection;
 pub mod simulation;
 pub mod stdcm;
 pub mod version;
+pub mod worker_load;
 
 #[cfg(feature = "mocking_client")]
 pub mod mocking;

--- a/editoast/core_client/src/worker_load.rs
+++ b/editoast/core_client/src/worker_load.rs
@@ -4,16 +4,16 @@ use super::AsCoreRequest;
 
 /// A Core infra load request
 #[derive(Debug, Serialize)]
-pub struct InfraLoadRequest {
+pub struct WorkerLoadRequest {
     pub infra: i64,
+    pub expected_version: i64,
     /// If provided, will load a core with this infra and this timetable loaded in cache
     pub timetable: Option<i64>,
-    pub expected_version: i64,
 }
 
-impl AsCoreRequest<()> for InfraLoadRequest {
+impl AsCoreRequest<()> for WorkerLoadRequest {
     const METHOD: reqwest::Method = reqwest::Method::POST;
-    const URL_PATH: &'static str = "/infra_load";
+    const URL_PATH: &'static str = "/worker_load";
 
     fn worker_id(&self) -> Option<String> {
         match self.timetable {

--- a/editoast/src/views/worker_load.rs
+++ b/editoast/src/views/worker_load.rs
@@ -2,7 +2,7 @@ use axum::Extension;
 use axum::extract::Json;
 use axum::extract::State;
 use core_client::AsCoreRequest;
-use core_client::infra_loading::InfraLoadRequest;
+use core_client::worker_load::WorkerLoadRequest;
 use editoast_derive::EditoastError;
 use editoast_models::prelude::*;
 use serde::Deserialize;
@@ -136,7 +136,7 @@ pub(in crate::views) async fn worker_load(
         .into();
 
     if status == WorkerStatus::Error || status == WorkerStatus::NotReady {
-        let infra_request = InfraLoadRequest {
+        let infra_request = WorkerLoadRequest {
             infra: infra.id,
             expected_version: infra.version,
             timetable: timetable_id,


### PR DESCRIPTION
- [x] Rename `infra_load` into `worker_load`
- [x] Handle loading the timetable when the id is provided