### PR TITLE
editoast: fix miss cache count for log

### DIFF
--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -293,11 +293,8 @@ async fn pathfinding_blocks_batch(
 
     // Report number of hit cache
     let nb_hit = pathfinding_cached_results.values().flatten().count();
-    info!(
-        nb_hit,
-        nb_miss = pathfinding_inputs.len() - nb_hit,
-        "Hit cache"
-    );
+    let nb_miss = pathfinding_cached_results.len() - nb_hit;
+    info!(nb_hit, nb_miss, "Hit cache");
 
     // Handle miss cache:
     debug!("Extracting locations from path items");

--- a/editoast/src/views/timetable/simulation.rs
+++ b/editoast/src/views/timetable/simulation.rs
@@ -375,7 +375,7 @@ pub async fn consist_train_simulation_batch<T: TrainScheduleLike>(
         .collect();
 
     let nb_hit = cached_results.iter().flatten().count();
-    let nb_miss = to_sim.len() - nb_hit;
+    let nb_miss = cached_results.len() - nb_hit;
     info!(nb_hit, nb_miss, "Hit cache");
 
     // Compute simulation from core


### PR DESCRIPTION
We miss counted the number of miss cache. 