### PR TITLE
front: add train settings fields in new itinerary modal

### DIFF
--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -337,7 +337,8 @@
       "opName": "Operational point name",
       "openItineraryModal": "New interface for itinerary edition",
       "secondaryCode": "Code",
-      "track": "Track"
+      "track": "Track",
+      "trainName": "Train name"
     },
     "launchPathFinding": "Launch pathfinding",
     "manageVias": "Steps management",

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -337,7 +337,8 @@
       "opName": "Nom du point remarquable",
       "openItineraryModal": "Nouvelle interface d'édition d'itinéraire",
       "secondaryCode": "CH",
-      "track": "Voie"
+      "track": "Voie",
+      "trainName": "Nom du train"
     },
     "launchPathFinding": "Lancer la recherche d'itinéraire",
     "manageVias": "Gestion des étapes",

--- a/front/src/applications/operationalStudies/views/ProjectList/styles/_projectList.scss
+++ b/front/src/applications/operationalStudies/views/ProjectList/styles/_projectList.scss
@@ -26,16 +26,18 @@
 }
 
 .alert-box {
-  width: fit-content;
-  height: 48px;
+  width: 100%;
+  min-height: 56px;
   display: flex;
   align-items: center;
-  padding: 0 16px 0 12px;
-  border: 1px solid;
+  padding: 0 24px 0 40px;
+  border-top: 1px solid;
+  border-bottom: 1px solid;
+  margin-top: -1px;
   margin-bottom: 16px;
 
   &--warning {
-    border-color: var(--warning30);
+    border-color: var(--black10);
     background-color: var(--warning5);
 
     .alert-box__icon--warning {
@@ -50,6 +52,11 @@
       color: var(--warning60);
       font-size: 16px;
       font-weight: 400;
+    }
+
+    .alert-box__close-button {
+      color: var(--warning60);
+      margin-left: auto;
     }
   }
 }

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModal.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModal.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import type { PathStepV2 } from 'reducers/osrdconf/types';
 import useModalFocusTrap from 'utils/hooks/useModalFocusTrap';
 
+import ItineraryModalFormHeader from './ItineraryModalFormHeader';
 import ItineraryModalMap from './ItineraryModalMap';
 import PathStepItem from './PathStepItem';
 
@@ -43,7 +44,9 @@ const ItineraryModal = ({ itineraryModalIsOpen, setItineraryModalIsOpen }: Itine
   return (
     <dialog ref={modalRef} className="itinerary-modal">
       <div className="itinerary-modal-form">
-        <div className="itinerary-modal-form-header"></div>
+        <div className="itinerary-modal-form-header">
+          <ItineraryModalFormHeader />
+        </div>
         <div className="itinerary-modal-form-body">
           <div className="path-step-list">
             <div className="path-step-list-header">

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModal.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModal.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from 'react';
 import { Button } from '@osrd-project/ui-core';
 import { useTranslation } from 'react-i18next';
 
+import AlertBox from 'common/AlertBox';
 import type { PathStepV2 } from 'reducers/osrdconf/types';
 import useModalFocusTrap from 'utils/hooks/useModalFocusTrap';
 
@@ -23,6 +24,7 @@ const ItineraryModal = ({ itineraryModalIsOpen, setItineraryModalIsOpen }: Itine
   const modalRef = useRef<HTMLDialogElement>(null);
 
   const [pathSteps] = useState<PathStepV2[]>([]);
+  const [categoryWarning, setCategoryWarning] = useState<string | undefined>(undefined);
 
   const openModal = () => {
     modalRef.current?.showModal();
@@ -45,9 +47,10 @@ const ItineraryModal = ({ itineraryModalIsOpen, setItineraryModalIsOpen }: Itine
     <dialog ref={modalRef} className="itinerary-modal">
       <div className="itinerary-modal-form">
         <div className="itinerary-modal-form-header">
-          <ItineraryModalFormHeader />
+          <ItineraryModalFormHeader onCategoryWarningChange={setCategoryWarning} />
         </div>
         <div className="itinerary-modal-form-body">
+          {categoryWarning && <AlertBox message={categoryWarning} closeable />}
           <div className="path-step-list">
             <div className="path-step-list-header">
               <span>{t('opName')}</span>

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModalFormHeader.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModalFormHeader.tsx
@@ -1,0 +1,130 @@
+import { ComboBox, Input, Select } from '@osrd-project/ui-core';
+import { isEqual } from 'lodash';
+import { useTranslation } from 'react-i18next';
+import { useSelector } from 'react-redux';
+
+import type { LightRollingStockWithLiveries } from 'common/api/osrdEditoastApi';
+import { useSubCategoryContext } from 'common/SubCategoryContext';
+import useStoreDataForRollingStockSelector from 'modules/rollingStock/components/RollingStockSelector/useStoreDataForRollingStockSelector';
+import isMainCategory from 'modules/rollingStock/helpers/category';
+import useCategoryOptions from 'modules/rollingStock/hooks/useCategoryOptions';
+import {
+  DEFAULT_TRAIN_PATH_COLORS,
+  TRAIN_MAIN_CATEGORY_PATH_COLORS,
+} from 'modules/simulationResult/consts';
+import { updateCategory, updateName } from 'reducers/osrdconf/operationalStudiesConf';
+import {
+  getCategory,
+  getName,
+  getOperationalStudiesRollingStockID,
+} from 'reducers/osrdconf/operationalStudiesConf/selectors';
+import { useAppDispatch } from 'store';
+
+const ItineraryModalFormHeader = () => {
+  const dispatch = useAppDispatch();
+
+  const { t } = useTranslation('operational-studies', {
+    keyPrefix: 'manageTimetableItem',
+  });
+
+  // Category
+  const categoryOptions = useCategoryOptions();
+  const category = useSelector(getCategory);
+  const subCategories = useSubCategoryContext();
+  const currentSubCategory =
+    category && !isMainCategory(category)
+      ? subCategories.find((option) => option.code === category.sub_category_code)
+      : undefined;
+  const handleCategoryChange = (option?: (typeof categoryOptions)[number]) => {
+    if (option !== undefined) {
+      dispatch(updateCategory(option.category));
+    }
+  };
+
+  // Category colors
+  let colors = DEFAULT_TRAIN_PATH_COLORS;
+  if (category && isMainCategory(category)) {
+    colors = TRAIN_MAIN_CATEGORY_PATH_COLORS[category.main_category];
+  } else if (category && !isMainCategory(category) && currentSubCategory) {
+    colors = {
+      normal: currentSubCategory.color || DEFAULT_TRAIN_PATH_COLORS.normal,
+      hovered: currentSubCategory.hovered_color || DEFAULT_TRAIN_PATH_COLORS.hovered,
+      background: currentSubCategory.background_color || DEFAULT_TRAIN_PATH_COLORS.background,
+    };
+  }
+
+  // RollingStock
+  const rollingStockId = useSelector(getOperationalStudiesRollingStockID);
+  const { rollingStock } = useStoreDataForRollingStockSelector({
+    rollingStockId,
+  });
+  const getRollingStockLabel = (option: LightRollingStockWithLiveries) => {
+    const rs = option;
+    if (!rs) return '';
+    const secondPart = rs.metadata?.series || rs.metadata?.reference || '';
+    return secondPart ? `${rs.name} - ${secondPart}` : rs.name;
+  };
+
+  // Timetable item name
+  const name = useSelector(getName);
+  const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    dispatch(updateName(e.target.value));
+  };
+
+  return (
+    <>
+      <div className="category-row">
+        <div
+          className="category-color"
+          style={{
+            backgroundColor: colors.normal,
+          }}
+        />
+        <div className="category-select">
+          <Select
+            id="itinerary-modal-category"
+            narrow
+            small
+            options={categoryOptions}
+            value={categoryOptions.find((option) => isEqual(option.category, category))}
+            getOptionLabel={(option) => option.label}
+            getOptionValue={(option) => option.id}
+            onChange={handleCategoryChange}
+            readOnly
+          ></Select>
+        </div>
+      </div>
+      <div className="rolling-stock-and-name-row">
+        <div className="rolling-stock-combobox">
+          <ComboBox
+            id="itinerary-modal-rolling-stock"
+            label={t('rollingstock')}
+            narrow
+            small
+            autoComplete="off"
+            value={rollingStock}
+            getSuggestionLabel={getRollingStockLabel}
+            onSelectSuggestion={() => {}}
+            suggestions={[]}
+            resetSuggestions={() => {}}
+            readOnly
+          />
+        </div>
+
+        <div className="train-name-input">
+          <Input
+            narrow
+            small
+            id="itinerary-modal-timetable-item-name"
+            label={t('itineraryModal.trainName')}
+            value={name}
+            onChange={handleNameChange}
+            readOnly
+          />
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default ItineraryModalFormHeader;

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModalFormHeader.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModalFormHeader.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useMemo } from 'react';
+
 import { ComboBox, Input, Select } from '@osrd-project/ui-core';
 import { isEqual } from 'lodash';
 import { useTranslation } from 'react-i18next';
@@ -20,7 +22,11 @@ import {
 } from 'reducers/osrdconf/operationalStudiesConf/selectors';
 import { useAppDispatch } from 'store';
 
-const ItineraryModalFormHeader = () => {
+type ItineraryModalFormHeaderProps = {
+  onCategoryWarningChange: (categoryWarning?: string) => void;
+};
+
+const ItineraryModalFormHeader = ({ onCategoryWarningChange }: ItineraryModalFormHeaderProps) => {
   const dispatch = useAppDispatch();
 
   const { t } = useTranslation('operational-studies', {
@@ -42,25 +48,28 @@ const ItineraryModalFormHeader = () => {
   };
 
   // Category colors
-  let colors = DEFAULT_TRAIN_PATH_COLORS;
-  if (category && isMainCategory(category)) {
-    colors = TRAIN_MAIN_CATEGORY_PATH_COLORS[category.main_category];
-  } else if (category && !isMainCategory(category) && currentSubCategory) {
-    colors = {
-      normal: currentSubCategory.color || DEFAULT_TRAIN_PATH_COLORS.normal,
-      hovered: currentSubCategory.hovered_color || DEFAULT_TRAIN_PATH_COLORS.hovered,
-      background: currentSubCategory.background_color || DEFAULT_TRAIN_PATH_COLORS.background,
-    };
-  }
+  const colors = useMemo(() => {
+    if (category && isMainCategory(category)) {
+      return TRAIN_MAIN_CATEGORY_PATH_COLORS[category.main_category];
+    }
+
+    if (category && !isMainCategory(category) && currentSubCategory) {
+      return {
+        normal: currentSubCategory.color || DEFAULT_TRAIN_PATH_COLORS.normal,
+        hovered: currentSubCategory.hovered_color || DEFAULT_TRAIN_PATH_COLORS.hovered,
+        background: currentSubCategory.background_color || DEFAULT_TRAIN_PATH_COLORS.background,
+      };
+    }
+
+    return DEFAULT_TRAIN_PATH_COLORS;
+  }, [category, currentSubCategory]);
 
   // RollingStock
   const rollingStockId = useSelector(getOperationalStudiesRollingStockID);
   const { rollingStock } = useStoreDataForRollingStockSelector({
     rollingStockId,
   });
-  const getRollingStockLabel = (option: LightRollingStockWithLiveries) => {
-    const rs = option;
-    if (!rs) return '';
+  const getRollingStockLabel = (rs: LightRollingStockWithLiveries) => {
     const secondPart = rs.metadata?.series || rs.metadata?.reference || '';
     return secondPart ? `${rs.name} - ${secondPart}` : rs.name;
   };
@@ -70,6 +79,22 @@ const ItineraryModalFormHeader = () => {
   const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     dispatch(updateName(e.target.value));
   };
+
+  // Category warning
+  const categoryWarningMessage = useMemo(() => {
+    if (!rollingStock || !category) return undefined;
+
+    const isMismatch = isMainCategory(category)
+      ? category.main_category !== rollingStock.primary_category &&
+        !rollingStock.other_categories.includes(category.main_category)
+      : currentSubCategory?.main_category !== rollingStock.primary_category;
+
+    return isMismatch ? t('categoryMismatch') : undefined;
+  }, [rollingStock, category, currentSubCategory, t]);
+
+  useEffect(() => {
+    onCategoryWarningChange(categoryWarningMessage);
+  }, [categoryWarningMessage]);
 
   return (
     <>

--- a/front/src/common/AlertBox.tsx
+++ b/front/src/common/AlertBox.tsx
@@ -1,23 +1,34 @@
-import { Alert } from '@osrd-project/ui-icons';
+import { useState } from 'react';
+
+import { Alert, X } from '@osrd-project/ui-icons';
 
 type AlertType = 'warning';
 
 type AlertBoxProps = {
   type?: AlertType;
-  message: string;
+  message?: string;
+  closeable?: boolean;
 };
 
 const iconByType = {
   warning: <Alert variant="fill" size="lg" className="alert-box__icon--warning" />,
 };
 
-const AlertBox = ({ type = 'warning', message }: AlertBoxProps) => {
+const AlertBox = ({ type = 'warning', message, closeable }: AlertBoxProps) => {
+  const [visible, setVisible] = useState(true);
   const icon = iconByType[type];
+
+  if (!visible) return null;
 
   return (
     <div className={`alert-box alert-box--${type}`}>
       {icon}
       <span className={`alert-box__text--${type}`}>{message}</span>
+      {closeable && (
+        <button className="alert-box__close-button" onClick={() => setVisible(false)} type="button">
+          <X />
+        </button>
+      )}
     </div>
   );
 };

--- a/front/src/styles/scss/applications/operationalStudies/_itineraryModal.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_itineraryModal.scss
@@ -30,8 +30,54 @@
     flex-shrink: 0;
 
     .itinerary-modal-form-header {
+      display: flex;
+      flex-direction: column;
       height: var(--header-height);
       border-bottom: 1px solid var(--gray-30);
+
+      .category-row {
+        display: flex;
+        align-items: center;
+        margin-top: 32px;
+        margin-left: 22px;
+
+        .category-color {
+          width: 6px;
+          height: 16px;
+          border-radius: 4px;
+          margin-right: 12px;
+        }
+        .category-select {
+          width: 257px;
+          height: 32px;
+        }
+      }
+
+      .rolling-stock-and-name-row {
+        display: flex;
+        align-items: center;
+        margin-top: 17px;
+        margin-left: 40px;
+
+        .rolling-stock-combobox {
+          min-width: 257px;
+          margin-right: 21px;
+          // Fix osrd-ui styles
+          label {
+            margin-bottom: 0;
+          }
+        }
+
+        .train-name-input {
+          width: 100%;
+          min-width: 257px;
+          margin-right: 39px;
+          // Fix osrd-ui styles
+          label {
+            margin-bottom: 0;
+          }
+        }
+      }
     }
 
     .itinerary-modal-form-body {

--- a/front/src/styles/scss/applications/operationalStudies/_itineraryModal.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_itineraryModal.scss
@@ -90,6 +90,10 @@
       background-color: var(--ambientB10);
       box-shadow: 0 calc(-1 * var(--footer-box-shadow-height)) 0 0 var(--black10);
 
+      .alert-box {
+        margin-top: -1px;
+      }
+
       .path-step-list {
         background-color: var(--ambientB15);
         border-radius: 8px;

--- a/front/src/styles/scss/applications/operationalStudies/_itineraryModal.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_itineraryModal.scss
@@ -62,6 +62,7 @@
         .rolling-stock-combobox {
           min-width: 257px;
           margin-right: 21px;
+          flex: 0 0 auto;
           // Fix osrd-ui styles
           label {
             margin-bottom: 0;
@@ -72,6 +73,7 @@
           width: 100%;
           min-width: 257px;
           margin-right: 39px;
+          flex: 1 1 auto;
           // Fix osrd-ui styles
           label {
             margin-bottom: 0;

--- a/front/src/styles/scss/applications/operationalStudies/_itineraryModal.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_itineraryModal.scss
@@ -213,7 +213,8 @@
 
   .itinerary-modal-map {
     width: 50%;
-    box-shadow: calc(-1 * var(--footer-box-shadow-height)) 0 0 0 var(--black25);
+    box-shadow: inset (var(--footer-box-shadow-height)) 0 0 0 var(--black25);
+    padding-left: 1px;
 
     .layers-modal {
       position: fixed;


### PR DESCRIPTION
closes #13254 

To test, you can add a timetable item name, a rolling stock and a category in the current itinerary interface, and these information should be displayed in the new itinerary modal

> [!CAUTION]
> Fields are in readonly so it is normal their styles don't match exactly the mockup 