### PR TITLE
editoast: remove HTTP method support in core_client

### DIFF
--- a/editoast/core_client/src/conflict_detection.rs
+++ b/editoast/core_client/src/conflict_detection.rs
@@ -93,7 +93,6 @@ pub enum ConflictType {
 }
 
 impl AsCoreRequest<Json<ConflictDetectionResponse>> for ConflictDetectionRequest {
-    const METHOD: reqwest::Method = reqwest::Method::POST;
     const URL_PATH: &'static str = "/conflict_detection";
 
     fn worker_id(&self) -> Option<String> {

--- a/editoast/core_client/src/etcs_braking_curves.rs
+++ b/editoast/core_client/src/etcs_braking_curves.rs
@@ -77,7 +77,6 @@ pub struct SimpleEnvelope {
 }
 
 impl AsCoreRequest<Json<Response>> for Request {
-    const METHOD: reqwest::Method = reqwest::Method::POST;
     const URL_PATH: &'static str = "/etcs_braking_curves";
 
     fn worker_id(&self) -> Option<String> {

--- a/editoast/core_client/src/lib.rs
+++ b/editoast/core_client/src/lib.rs
@@ -93,13 +93,11 @@ impl CoreClient {
                 todo!("TODO: handle protocol errors")
             }
             #[cfg(feature = "mocking_client")]
-            CoreClient::Mocked(client) => {
-                match client.fetch_mocked::<_, B, R>(method, path, body) {
-                    Ok(Some(response)) => Ok(response),
-                    Ok(None) => Err(Error::NoResponseContent),
-                    Err(mocking::MockingError { bytes, url }) => Err(Error::parse(&bytes, url)),
-                }
-            }
+            CoreClient::Mocked(client) => match client.fetch_mocked::<_, B, R>(path, body) {
+                Ok(Some(response)) => Ok(response),
+                Ok(None) => Err(Error::NoResponseContent),
+                Err(mocking::MockingError { bytes, url }) => Err(Error::parse(&bytes, url)),
+            },
         }
     }
 }
@@ -132,7 +130,7 @@ impl CoreClient {
 /// # let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
 /// # rt.block_on(async {
 /// #   let mut core_mock = core_client::mocking::MockingClient::default();
-/// #   core_mock.stub("/some/path").method(reqwest::Method::POST).response(reqwest::StatusCode::OK).body("{\"message\":\"YOU WON!\"}").finish();
+/// #   core_mock.stub("/some/path").response(reqwest::StatusCode::OK).body("{\"message\":\"YOU WON!\"}").finish();
 /// #   let core_client = core_mock.into();
 /// // Builds the payload, executes the request at POST /some/path and deserializes its response
 /// let response = TestReq::default().fetch(&core_client).await.unwrap();
@@ -320,7 +318,6 @@ mod tests {
         }
         let mut core = MockingClient::default();
         core.stub("/test")
-            .method(Method::GET)
             .response(StatusCode::OK)
             .body("")
             .finish();
@@ -342,7 +339,6 @@ mod tests {
         }
         let mut core = MockingClient::default();
         core.stub("/test")
-            .method(Method::GET)
             .response(StatusCode::OK)
             .body("not JSON :)")
             .finish();
@@ -377,7 +373,6 @@ mod tests {
         });
         let mut core = MockingClient::default();
         core.stub("/test")
-            .method(Method::GET)
             .response(StatusCode::NOT_FOUND)
             .body(error.to_string())
             .finish();

--- a/editoast/core_client/src/lib.rs
+++ b/editoast/core_client/src/lib.rs
@@ -122,7 +122,6 @@ impl CoreClient {
 /// }
 ///
 /// impl AsCoreRequest<Json<Response>> for TestReq {
-///     const METHOD: reqwest::Method = reqwest::Method::POST;
 ///     const URL_PATH: &'static str = "/some/path";
 ///     fn worker_id(&self) -> std::option::Option<String> { Some("42".into()) }
 /// }
@@ -142,15 +141,8 @@ where
     Self: Serialize + Sized + Sync,
     R: CoreResponse,
 {
-    /// A shorthand for [Self::method]
-    const METHOD: reqwest::Method;
     /// A shorthand for [Self::url]
     const URL_PATH: &'static str;
-
-    /// Returns the HTTP method for this request, by default returns [Self::METHOD]
-    fn method(&self) -> reqwest::Method {
-        Self::METHOD
-    }
 
     /// Returns the URL for this request, by default returns [Self::URL_PATH]
     fn url(&self) -> &str {
@@ -159,16 +151,6 @@ where
 
     /// Returns the worker id used for the request. Must be provided.
     fn worker_id(&self) -> Option<String>;
-
-    /// Returns whether or not `self` should be serialized as JSON and used as
-    /// the request body
-    ///
-    /// By default, returns true if [Self::method] returns POST, PUT, PATCH and CONNECT, and false
-    /// for every other method.
-    fn has_body(&self) -> bool {
-        use reqwest::Method;
-        [Method::POST, Method::PUT, Method::PATCH, Method::CONNECT].contains(&self.method())
-    }
 
     /// Sends this request using the given [CoreClient] and returns the response content on success
     ///
@@ -179,9 +161,9 @@ where
     /// to CoreError and a trait function handle_errors would suffice?
     async fn fetch(&self, core: &CoreClient) -> Result<R::Response, Error> {
         core.fetch::<Self, R>(
-            self.method(),
+            reqwest::Method::POST,
             self.url(),
-            if self.has_body() { Some(self) } else { None },
+            Some(self),
             self.worker_id(),
         )
         .await
@@ -293,7 +275,6 @@ mod tests {
 
     use http::StatusCode;
     use pretty_assertions::assert_eq;
-    use reqwest::Method;
     use serde::Serialize;
     use serde_json::json;
 
@@ -309,7 +290,6 @@ mod tests {
         #[derive(Serialize)]
         struct Req;
         impl AsCoreRequest<()> for Req {
-            const METHOD: Method = Method::GET;
             const URL_PATH: &'static str = "/test";
 
             fn worker_id(&self) -> Option<String> {
@@ -330,7 +310,6 @@ mod tests {
         #[derive(Serialize)]
         struct Req;
         impl AsCoreRequest<Bytes> for Req {
-            const METHOD: Method = Method::GET;
             const URL_PATH: &'static str = "/test";
 
             fn worker_id(&self) -> Option<String> {
@@ -351,7 +330,6 @@ mod tests {
         #[derive(Serialize)]
         struct Req;
         impl AsCoreRequest<()> for Req {
-            const METHOD: Method = Method::GET;
             const URL_PATH: &'static str = "/test";
 
             fn worker_id(&self) -> Option<String> {

--- a/editoast/core_client/src/mocking.rs
+++ b/editoast/core_client/src/mocking.rs
@@ -44,7 +44,6 @@ impl MockingClient {
 
     pub(super) fn fetch_mocked<P: AsRef<str>, B: Serialize, R: CoreResponse>(
         &self,
-        req_method: reqwest::Method,
         req_path: P,
         req_body: Option<&B>,
     ) -> Result<Option<R::Response>, MockingError> {
@@ -54,12 +53,8 @@ impl MockingClient {
             .stubs
             .get(&req_path)
             .and_then(|stubs| stubs.deref().lock().unwrap().pop_front())
-            .filter(|StubRequest { method, .. }| match method {
-                None => true,
-                Some(method) => method == req_method,
-            })
         else {
-            panic!("could not find stub for '{req_method}' request at PATH '{req_path}'");
+            panic!("could not find stub for request at PATH '{req_path}'");
         };
 
         match (
@@ -109,7 +104,6 @@ impl MockingClient {
 /// A stub request used to assert the validity of an incoming request to mock
 #[derive(Debug, Clone)]
 pub struct StubRequest {
-    method: Option<reqwest::Method>,
     body: Option<Arc<Body>>,
     response: Option<StubResponse>,
 }
@@ -128,7 +122,6 @@ pub struct StubResponse {
 #[derive(Debug)]
 pub struct StubRequestBuilder<'a> {
     path: String,
-    method: Option<reqwest::Method>,
     body: Option<Arc<Body>>,
     client: &'a mut MockingClient,
 }
@@ -144,19 +137,9 @@ impl<'a> StubRequestBuilder<'a> {
     fn new(path: String, client: &'a mut MockingClient) -> Self {
         Self {
             path,
-            method: None,
             body: None,
             client,
         }
-    }
-
-    /// Sets the method the stub request will mock
-    ///
-    /// If no method is set, the stub works for all methods
-    #[must_use = "call .finish() to register the stub request"]
-    pub fn method(mut self, method: reqwest::Method) -> Self {
-        self.method = Some(method);
-        self
     }
 
     /// Sets the expected body of the expected outgoing request
@@ -190,7 +173,6 @@ impl<'a> StubRequestBuilder<'a> {
             .lock()
             .unwrap()
             .push_back(StubRequest {
-                method: self.method,
                 body: self.body,
                 response: None,
             })
@@ -202,7 +184,6 @@ impl<'a> StubRequestBuilder<'a> {
             .into_iter()
             .map(Some)
             .map(|response| StubRequest {
-                method: self.method.clone(),
                 body: self.body.clone(),
                 response,
             })

--- a/editoast/core_client/src/path_properties.rs
+++ b/editoast/core_client/src/path_properties.rs
@@ -145,7 +145,6 @@ impl PropertyZoneValues {
 }
 
 impl AsCoreRequest<Json<PathPropertiesResponse>> for PathPropertiesRequest<'_> {
-    const METHOD: reqwest::Method = reqwest::Method::POST;
     const URL_PATH: &'static str = "/path_properties";
 
     fn worker_id(&self) -> Option<String> {

--- a/editoast/core_client/src/pathfinding.rs
+++ b/editoast/core_client/src/pathfinding.rs
@@ -241,7 +241,6 @@ impl TrackRangeOffset<'_> {
 }
 
 impl AsCoreRequest<Json<PathfindingCoreResult>> for PathfindingRequest {
-    const METHOD: reqwest::Method = reqwest::Method::POST;
     const URL_PATH: &'static str = "/pathfinding/blocks";
 
     fn worker_id(&self) -> Option<String> {

--- a/editoast/core_client/src/signal_projection.rs
+++ b/editoast/core_client/src/signal_projection.rs
@@ -63,7 +63,6 @@ pub struct SignalUpdatesResponse {
 }
 
 impl AsCoreRequest<Json<SignalUpdatesResponse>> for SignalUpdatesRequest<'_> {
-    const METHOD: reqwest::Method = reqwest::Method::POST;
     const URL_PATH: &'static str = "/signal_projection";
 
     fn worker_id(&self) -> Option<String> {

--- a/editoast/core_client/src/simulation.rs
+++ b/editoast/core_client/src/simulation.rs
@@ -318,7 +318,6 @@ impl Response {
 }
 
 impl AsCoreRequest<Json<Response>> for Request {
-    const METHOD: reqwest::Method = reqwest::Method::POST;
     const URL_PATH: &'static str = "/standalone_simulation";
 
     fn worker_id(&self) -> Option<String> {

--- a/editoast/core_client/src/stdcm.rs
+++ b/editoast/core_client/src/stdcm.rs
@@ -134,7 +134,6 @@ pub enum Response {
 }
 
 impl AsCoreRequest<Json<Response>> for Request {
-    const METHOD: reqwest::Method = reqwest::Method::POST;
     const URL_PATH: &'static str = "/stdcm";
 
     fn worker_id(&self) -> Option<String> {

--- a/editoast/core_client/src/version.rs
+++ b/editoast/core_client/src/version.rs
@@ -9,7 +9,6 @@ use super::Json;
 pub struct CoreVersionRequest {}
 
 impl AsCoreRequest<Json<Version>> for CoreVersionRequest {
-    const METHOD: reqwest::Method = reqwest::Method::POST;
     const URL_PATH: &'static str = "/version";
 
     fn worker_id(&self) -> Option<String> {

--- a/editoast/core_client/src/worker_load.rs
+++ b/editoast/core_client/src/worker_load.rs
@@ -12,7 +12,6 @@ pub struct WorkerLoadRequest {
 }
 
 impl AsCoreRequest<()> for WorkerLoadRequest {
-    const METHOD: reqwest::Method = reqwest::Method::POST;
     const URL_PATH: &'static str = "/worker_load";
 
     fn worker_id(&self) -> Option<String> {

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -1065,7 +1065,6 @@ mod tests {
     pub fn mocked_core_pathfinding_and_sim() -> MockingClient {
         let mut core = MockingClient::new();
         core.stub("/pathfinding/blocks")
-            .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(
                 serde_json::from_str::<serde_json::Value>(include_str!(
@@ -1075,7 +1074,6 @@ mod tests {
             )
             .finish();
         core.stub("/standalone_simulation")
-            .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(
                 serde_json::from_str::<serde_json::Value>(include_str!(
@@ -1091,7 +1089,6 @@ mod tests {
     pub fn mocked_core_pathfinding_sim_and_proj() -> MockingClient {
         let mut core = MockingClient::new();
         core.stub("/pathfinding/blocks")
-            .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(json!({
                 "blocks":[],
@@ -1103,13 +1100,11 @@ mod tests {
             }))
             .finish();
         core.stub("/standalone_simulation")
-            .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(simulation_response())
             .json(simulation_response())
             .finish();
         core.stub("/signal_projection")
-            .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(json!({
                 "signal_updates": [[{
@@ -1147,7 +1142,6 @@ mod tests {
     async fn core_version() {
         let mut core = MockingClient::new();
         core.stub("/version")
-            .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(json!({"git_describe": ""}))
             .finish();

--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -532,7 +532,6 @@ pub mod tests {
     async fn pathfinding_fails_when_core_responds_with_zero_length_path() {
         let mut core = MockingClient::new();
         core.stub("/pathfinding/blocks")
-            .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(json!({
                 "blocks":[],
@@ -668,7 +667,6 @@ pub mod tests {
     async fn pathfinding_with_valid_path_items_returns_successful_result() {
         let mut core = MockingClient::new();
         core.stub("/pathfinding/blocks")
-            .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(json!({
                 "blocks":[],

--- a/editoast/src/views/path/properties.rs
+++ b/editoast/src/views/path/properties.rs
@@ -330,7 +330,6 @@ mod tests {
         let mut core = MockingClient::new();
 
         core.stub("/path_properties")
-            .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(path_properties_response())
             .finish();

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -1650,7 +1650,6 @@ mod tests {
     async fn get_paced_train_path() {
         let mut core = MockingClient::new();
         core.stub("/pathfinding/blocks")
-            .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(json!({
                 "blocks":[],
@@ -1695,7 +1694,6 @@ mod tests {
     async fn get_paced_train_exception_path_rolling_stock_not_found() {
         let mut core = MockingClient::new();
         core.stub("/pathfinding/blocks")
-            .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(json!({
                 "blocks":[],
@@ -1749,7 +1747,6 @@ mod tests {
     async fn get_paced_train_exception_path() {
         let mut core = MockingClient::new();
         core.stub("/pathfinding/blocks")
-            .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(json!({
                 "blocks":[],

--- a/editoast/src/views/timetable/similar_trains.rs
+++ b/editoast/src/views/timetable/similar_trains.rs
@@ -913,7 +913,6 @@ mod tests {
     async fn init_test(path: Vec<PathItem>) -> InitTestResponse {
         let mut core = MockingClient::new();
         core.stub("/pathfinding/blocks")
-            .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(PathfindingResult::Success(pathfinding_result_success()))
             .finish();
@@ -925,7 +924,6 @@ mod tests {
             OperationalPointOnPath::new_test("South_station", 66, "SS"),
         ];
         core.stub("/path_properties")
-            .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(create_path_properties_response(operational_points))
             .finish();
@@ -1155,7 +1153,6 @@ mod tests {
     async fn compound_similar_trains() {
         let mut core = MockingClient::new();
         core.stub("/pathfinding/blocks")
-            .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(PathfindingResult::Success(pathfinding_result_success()))
             .json(PathfindingResult::Success(pathfinding_result_success()))
@@ -1171,7 +1168,6 @@ mod tests {
             OperationalPointOnPath::new_test("South_station", 66, "SS"),
         ];
         core.stub("/path_properties")
-            .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(create_path_properties_response(
                 operational_points_for_train_1,
@@ -1294,7 +1290,6 @@ mod tests {
     async fn test_select_single_train_without_merging_consecutive_segments() {
         let mut core = MockingClient::new();
         core.stub("/pathfinding/blocks")
-            .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(PathfindingResult::Success(pathfinding_result_success()))
             .json(PathfindingResult::Success(pathfinding_result_success()))
@@ -1318,7 +1313,6 @@ mod tests {
             OperationalPointOnPath::new_test("North_East_station", 77, "NES"),
         ];
         core.stub("/path_properties")
-            .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(create_path_properties_response(
                 operational_points_ws_mes.clone(),
@@ -1478,7 +1472,6 @@ mod tests {
     async fn no_similar_trains_for_some_segments() {
         let mut core = MockingClient::new();
         core.stub("/pathfinding/blocks")
-            .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(PathfindingResult::Success(pathfinding_result_success()))
             .json(PathfindingResult::Success(pathfinding_result_success()))
@@ -1492,7 +1485,6 @@ mod tests {
             OperationalPointOnPath::new_test("North_station", 55, "NS"),
         ];
         core.stub("/path_properties")
-            .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(create_path_properties_response(operational_points_ws_mws)) // train_1
             .json(create_path_properties_response(operational_points_mes_ns)) // train_2
@@ -1670,7 +1662,6 @@ mod tests {
     async fn test_similar_trains_by_relaxing_name_criterion() {
         let mut core = MockingClient::new();
         core.stub("/pathfinding/blocks")
-            .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(PathfindingResult::Success(pathfinding_result_success()))
             .finish();
@@ -1679,7 +1670,6 @@ mod tests {
             OperationalPointOnPath::new_test("Mid_West_station", 33, "MWS"),
         ];
         core.stub("/path_properties")
-            .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(create_path_properties_response(operational_points_ws_mws)) // train_1
             .finish();

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -549,12 +549,10 @@ mod tests {
     fn core_mocking_client() -> MockingClient {
         let mut core = MockingClient::new();
         core.stub("/pathfinding/blocks")
-            .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(PathfindingResult::Success(pathfinding_result_success()))
             .finish();
         core.stub("/standalone_simulation")
-            .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(simulation_response())
             .finish();
@@ -774,7 +772,6 @@ mod tests {
     async fn stdcm_return_success() {
         let mut core = core_mocking_client();
         core.stub("/stdcm")
-            .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(core_client::stdcm::Response::Success {
                 simulation: simulation_response().success().unwrap(),
@@ -818,7 +815,6 @@ mod tests {
     async fn stdcm_request_mass_validation() {
         let mut core = core_mocking_client();
         core.stub("/stdcm")
-            .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(core_client::stdcm::Response::Success {
                 simulation: simulation_response().success().unwrap(),
@@ -859,7 +855,6 @@ mod tests {
     async fn stdcm_request_length_validation() {
         let mut core = core_mocking_client();
         core.stub("/stdcm")
-            .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(core_client::stdcm::Response::Success {
                 simulation: simulation_response().success().unwrap(),
@@ -902,7 +897,6 @@ mod tests {
     async fn stdcm_request_validation_success() {
         let mut core = core_mocking_client();
         core.stub("/stdcm")
-            .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(core_client::stdcm::Response::Success {
                 simulation: simulation_response().success().unwrap(),
@@ -953,7 +947,6 @@ mod tests {
     async fn stdcm_fails() {
         let mut core = core_mocking_client();
         core.stub("/stdcm")
-            .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(json!({"status": "path_not_found"}))
             .finish();

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -1686,7 +1686,6 @@ pub mod tests {
 
         let mut core = MockingClient::new();
         core.stub("/pathfinding/blocks")
-            .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(json!({
                 "status": "not_found_in_tracks"


### PR DESCRIPTION
- **editoast: core_client: remove HTTP method support from mocking client**
- **editoast: core_client: remove METHOD constant from `trait AsCoreRequest`**
