### PR TITLE
front: import round trips from nge dtos

### DIFF
--- a/front/src/applications/operationalStudies/types.ts
+++ b/front/src/applications/operationalStudies/types.ts
@@ -29,10 +29,16 @@ export type PacedTrainFromJson = Omit<PacedTrain, 'category'> & {
   category?: TrainCategory | string | null;
 };
 
+export type RoundTripsFromJson = {
+  train_schedules: ([number, number] | [number, null])[];
+  paced_trains: ([number, number] | [number, null])[];
+};
+
 export type TimetableJsonPayload = {
   train_schedules: TrainScheduleFromJson[];
   paced_trains: PacedTrainFromJson[];
   macro_nodes?: MacroNodeForm[];
+  round_trips?: RoundTripsFromJson;
 };
 
 export type CichDictValue = {

--- a/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/ImportTimetableItemTrainsList.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/ImportTimetableItemTrainsList.tsx
@@ -5,7 +5,10 @@ import type { TFunction } from 'i18next';
 import { useTranslation } from 'react-i18next';
 
 import { useScenarioContext } from 'applications/operationalStudies/hooks/useScenarioContext';
-import type { TimetableJsonPayload } from 'applications/operationalStudies/types';
+import type {
+  RoundTripsFromJson,
+  TimetableJsonPayload,
+} from 'applications/operationalStudies/types';
 import type { GraouTrainSchedule } from 'common/api/graouApi';
 import {
   osrdEditoastApi,
@@ -25,10 +28,16 @@ import type {
   TrainScheduleWithTrainId,
 } from 'reducers/osrdconf/types';
 import { useAppDispatch } from 'store';
-import { formatEditoastIdToPacedTrainId, formatEditoastIdToTrainScheduleId } from 'utils/trainId';
+import {
+  extractEditoastIdFromPacedTrainId,
+  extractEditoastIdFromTrainScheduleId,
+  formatEditoastIdToPacedTrainId,
+  formatEditoastIdToTrainScheduleId,
+} from 'utils/trainId';
 
 import generateTrainSchedulesPayloads from './generateTrainSchedulesPayloads';
 import findValidTrainNameKey from './helpers/findValidTrainNameKey';
+import { generateRoundTripsPayload } from './helpers/generatePayloads';
 import rollingstockOpenData2OSRD from './rollingstock_opendata2osrd.json';
 
 function LoadingIfSearching({
@@ -64,6 +73,7 @@ const ImportTimetableItemTrainsList = ({
     train_schedules: trainSchedulesFromJsonData,
     paced_trains: pacedTrainsFromJsonData,
     macro_nodes: macroNodes,
+    round_trips: roundTripsFromJsonData,
   } = trainsJsonData;
 
   const subCategories = useSubCategoryContext();
@@ -155,11 +165,43 @@ const ImportTimetableItemTrainsList = ({
   const [postTrainSchedule] =
     osrdEditoastApi.endpoints.postTimetableByIdTrainSchedules.useMutation();
   const [postPacedTrain] = osrdEditoastApi.endpoints.postTimetableByIdPacedTrains.useMutation();
+  const [postTrainScheduleRoundTrips] =
+    osrdEditoastApi.endpoints.postRoundTripsTrainSchedules.useMutation();
+  const [postPacedTrainRoundTrips] =
+    osrdEditoastApi.endpoints.postRoundTripsPacedTrains.useMutation();
   const [postMacroNodes] =
     osrdEditoastApi.endpoints.postProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNodes.useMutation();
 
   const dispatch = useAppDispatch();
   const timetableId = scenario.timetable_id;
+
+  const postRoundTrips = async (
+    roundTrips: RoundTripsFromJson,
+    formattedTrainSchedules: TrainScheduleWithTrainId[],
+    formattedPacedTrains: PacedTrainWithPacedTrainId[]
+  ): Promise<void> => {
+    const requests: Promise<unknown>[] = [];
+
+    if (roundTrips.train_schedules.length > 0) {
+      const payload = generateRoundTripsPayload(
+        roundTrips.train_schedules,
+        formattedTrainSchedules,
+        extractEditoastIdFromTrainScheduleId
+      );
+      requests.push(postTrainScheduleRoundTrips(payload).unwrap());
+    }
+
+    if (roundTrips.paced_trains.length > 0) {
+      const payload = generateRoundTripsPayload(
+        roundTrips.paced_trains,
+        formattedPacedTrains,
+        extractEditoastIdFromPacedTrainId
+      );
+      requests.push(postPacedTrainRoundTrips(payload).unwrap());
+    }
+
+    await Promise.all(requests);
+  };
 
   async function generateTimetableItem() {
     try {
@@ -201,6 +243,10 @@ const ImportTimetableItemTrainsList = ({
           ...pacedTrain,
           id: formatEditoastIdToPacedTrainId(pacedTrain.id),
         }));
+      }
+
+      if (roundTripsFromJsonData) {
+        await postRoundTrips(roundTripsFromJsonData, formattedTrainSchedules, formattedPacedTrains);
       }
 
       if (macroNodes && macroNodes.length > 0) {

--- a/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/__tests__/generatePayloads.spec.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/__tests__/generatePayloads.spec.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+
+import type { TrainScheduleId, PacedTrainId } from 'reducers/osrdconf/types';
+import {
+  extractEditoastIdFromTrainScheduleId,
+  extractEditoastIdFromPacedTrainId,
+} from 'utils/trainId';
+
+import { generateRoundTripsPayload } from '../generatePayloads';
+
+describe('generateRoundTripsPayload', () => {
+  it('correctly generates payload for a mix of one-ways and round-trips train schedules', () => {
+    const trainSchedules = [
+      { id: 'trainschedule_101' as TrainScheduleId },
+      { id: 'trainschedule_102' as TrainScheduleId },
+      { id: 'trainschedule_103' as TrainScheduleId },
+    ];
+
+    const trainScheduleIndexes: ([number, number] | [number, null])[] = [
+      [0, 2],
+      [1, null],
+    ];
+
+    const trainSchedulePayload = generateRoundTripsPayload(
+      trainScheduleIndexes,
+      trainSchedules,
+      extractEditoastIdFromTrainScheduleId
+    );
+
+    expect(trainSchedulePayload).toEqual({
+      roundTrips: {
+        one_ways: [102],
+        round_trips: [[101, 103]],
+      },
+    });
+  });
+
+  const pacedTrains = [
+    { id: 'paced_7' as PacedTrainId },
+    { id: 'paced_8' as PacedTrainId },
+    { id: 'paced_9' as PacedTrainId },
+    { id: 'paced_15' as PacedTrainId },
+  ];
+
+  it('correctly generates payload for only one-ways paced trains', () => {
+    const oneWayPacedIndexes: ([number, number] | [number, null])[] = [
+      [1, null],
+      [0, null],
+      [2, null],
+      [3, null],
+    ];
+
+    const oneWayPayload = generateRoundTripsPayload(
+      oneWayPacedIndexes,
+      pacedTrains,
+      extractEditoastIdFromPacedTrainId
+    );
+
+    expect(oneWayPayload).toEqual({
+      roundTrips: {
+        one_ways: [8, 7, 9, 15],
+        round_trips: [],
+      },
+    });
+  });
+
+  it('correctly generates payload for only round-trips paced trains', () => {
+    const roundTripsPacedIndexes: ([number, number] | [number, null])[] = [
+      [1, 2],
+      [0, 3],
+    ];
+
+    const roundTripsPayload = generateRoundTripsPayload(
+      roundTripsPacedIndexes,
+      pacedTrains,
+      extractEditoastIdFromPacedTrainId
+    );
+
+    expect(roundTripsPayload).toEqual({
+      roundTrips: {
+        one_ways: [],
+        round_trips: [
+          [8, 9],
+          [7, 15],
+        ],
+      },
+    });
+  });
+});

--- a/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/generatePayloads.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/generatePayloads.ts
@@ -1,0 +1,25 @@
+export const generateRoundTripsPayload = <T>(
+  roundTripsIndexes: ([number, number] | [number, null])[],
+  trainIds: { id: T }[],
+  extractEditoastIdFromRoundTripId: (trainId: T) => number
+) => {
+  const trainScheduleOneWays: number[] = [];
+  const trainScheduleRoundTrips: [number, number][] = [];
+
+  for (const [firstIndex, secondIndex] of roundTripsIndexes) {
+    if (secondIndex === null) {
+      trainScheduleOneWays.push(extractEditoastIdFromRoundTripId(trainIds[firstIndex].id));
+    } else {
+      trainScheduleRoundTrips.push([
+        extractEditoastIdFromRoundTripId(trainIds[firstIndex].id),
+        extractEditoastIdFromRoundTripId(trainIds[secondIndex].id),
+      ]);
+    }
+  }
+  return {
+    roundTrips: {
+      one_ways: trainScheduleOneWays,
+      round_trips: trainScheduleRoundTrips,
+    },
+  };
+};

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/__tests__/ngeToOsrd-inputDto-discontinuousTrainrun.json
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/__tests__/ngeToOsrd-inputDto-discontinuousTrainrun.json
@@ -324,8 +324,8 @@
       "id": 2,
       "name": "Carotte",
       "categoryId": 1,
-      "frequencyId": 3,
-      "trainrunTimeCategoryId": 0,
+      "frequencyId": 4,
+      "trainrunTimeCategoryId": 1,
       "labelIds": [],
       "direction": "round_trip"
     }

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/__tests__/ngeToOsrd-inputDto-duplicateTrigrams.json
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/__tests__/ngeToOsrd-inputDto-duplicateTrigrams.json
@@ -211,7 +211,7 @@
       "id": 1,
       "name": "Carotte",
       "categoryId": 1,
-      "frequencyId": 3,
+      "frequencyId": 6,
       "trainrunTimeCategoryId": 0,
       "labelIds": [],
       "direction": "one_way"
@@ -371,6 +371,15 @@
         "offset": 60,
         "shortName": "120+",
         "name": "verkehrt zweistündlich (ungerade)",
+        "linePatternRef": "120"
+      },
+      {
+        "id": 6,
+        "order": 0,
+        "frequency": 1440,
+        "offset": 0,
+        "shortName": "once",
+        "name": "once a day (TrainSchedule)",
         "linePatternRef": "120"
       }
     ],

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/__tests__/ngeToOsrd-output-discontinuousTrainrun.json
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/__tests__/ngeToOsrd-output-discontinuousTrainrun.json
@@ -81,7 +81,7 @@
           "reception_signal": "OPEN"
         }
       ],
-      "paced": { "interval": "PT1H", "time_window": "PT2H" }
+      "paced": { "interval": "PT2H", "time_window": "PT2H" }
     },
     {
       "category": "InterCity",
@@ -112,7 +112,7 @@
           "reception_signal": "OPEN"
         }
       ],
-      "paced": { "interval": "PT1H", "time_window": "PT2H" }
+      "paced": { "interval": "PT2H", "time_window": "PT2H" }
     },
     {
       "category": "InterCity",
@@ -120,7 +120,7 @@
       "exceptions": [],
       "labels": [],
       "paced": {
-        "interval": "PT1H",
+        "interval": "PT2H",
         "time_window": "PT2H"
       },
       "path": [
@@ -156,7 +156,7 @@
       "exceptions": [],
       "labels": [],
       "paced": {
-        "interval": "PT1H",
+        "interval": "PT2H",
         "time_window": "PT2H"
       },
       "path": [
@@ -187,5 +187,12 @@
       "train_name": "Carotte-2"
     }
   ],
-  "train_schedules": []
+  "train_schedules": [],
+  "round_trips": {
+    "paced_trains": [
+      [0, 1],
+      [2, 3]
+    ],
+    "train_schedules": []
+  }
 }

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/__tests__/ngeToOsrd-output-duplicateTrigrams.json
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/__tests__/ngeToOsrd-output-duplicateTrigrams.json
@@ -31,12 +31,12 @@
       "path_item_key": "trigram:SS-2"
     }
   ],
-  "paced_trains": [
+  "paced_trains": [],
+  "train_schedules": [
     {
       "category": "InterCity",
       "constraint_distribution": "STANDARD",
       "rolling_stock_name": "",
-      "exceptions": [],
       "train_name": "Carotte",
       "labels": [],
       "path": [
@@ -60,9 +60,11 @@
           "locked": false,
           "reception_signal": "OPEN"
         }
-      ],
-      "paced": { "interval": "PT1H", "time_window": "PT2H" }
+      ]
     }
   ],
-  "train_schedules": []
+  "round_trips": {
+    "paced_trains": [],
+    "train_schedules": [[0, null]]
+  }
 }

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/__tests__/ngeToOsrd-output-oneWay.json
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/__tests__/ngeToOsrd-output-oneWay.json
@@ -64,5 +64,9 @@
       "paced": { "interval": "PT1H", "time_window": "PT2H" }
     }
   ],
-  "train_schedules": []
+  "train_schedules": [],
+  "round_trips": {
+    "paced_trains": [[0, null]],
+    "train_schedules": []
+  }
 }

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/__tests__/ngeToOsrd-output-roundTrip.json
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/__tests__/ngeToOsrd-output-roundTrip.json
@@ -95,5 +95,9 @@
       "paced": { "interval": "PT1H", "time_window": "PT2H" }
     }
   ],
-  "train_schedules": []
+  "train_schedules": [],
+  "round_trips": {
+    "paced_trains": [[0, 1]],
+    "train_schedules": []
+  }
 }

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/ngeToOsrd.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/ngeToOsrd.ts
@@ -996,6 +996,8 @@ export const convertNgeDtoToOsrd = (dto: NetzgrafikDto) => {
 
   const trainSchedules: TrainScheduleFromJson[] = [];
   const pacedTrains: PacedTrainFromJson[] = [];
+  const pacedTrainsRoundTrips: ([number, number] | [number, null])[] = [];
+  const trainSchedulesRoundTrips: ([number, number] | [number, null])[] = [];
   for (const trainrun of dto.trainruns) {
     const groupedTrainrunSections = getTrainrunSectionsByTrainrunId(dto, trainrun.id);
     const labels = getTrainrunLabels(dto, trainrun);
@@ -1026,21 +1028,32 @@ export const convertNgeDtoToOsrd = (dto: NetzgrafikDto) => {
             ...commonProps,
             paced,
           });
+          if (direction === TRAINRUN_DIRECTIONS.FORWARD) {
+            pacedTrainsRoundTrips.push([
+              pacedTrains.length - 1,
+              trainrun.direction === 'one_way' ? null : pacedTrains.length,
+            ]);
+          }
         } else {
           trainSchedules.push({
             ...DEFAULT_TRAIN_SCHEDULE_PAYLOAD,
             ...commonProps,
           });
+          if (direction === TRAINRUN_DIRECTIONS.FORWARD) {
+            trainSchedulesRoundTrips.push([
+              trainSchedules.length - 1,
+              trainrun.direction === 'one_way' ? null : trainSchedules.length,
+            ]);
+          }
         }
       }
     }
   }
 
-  // TODO: handle return trips by having a for example by having a return trips field in TimetableJsonPayload with [id1, id2],
-  // then calling the return trip api after creating the trains in ImportTimetableItemTrainsList
   return {
     macro_nodes: macroNodes,
     paced_trains: pacedTrains,
     train_schedules: trainSchedules,
+    round_trips: { train_schedules: trainSchedulesRoundTrips, paced_trains: pacedTrainsRoundTrips },
   };
 };


### PR DESCRIPTION
Close #13272

This has some overlap with [#osrd-confidential/1160](https://github.com/osrd-project/osrd-confidential/issues/1160) and thus #13284. A minimal implementation of round trips import was indeed required. This implementation could be expanded, overhauled  or reimplemented from scratch if desired when actually implementing #13284. #13272 was prioritized despite the overlap due to po/client request.