### PR TITLE
editoast: core_client: remove `reqwest` dependency

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -959,7 +959,6 @@ dependencies = [
  "linkme",
  "opentelemetry",
  "pretty_assertions",
- "reqwest",
  "rstest",
  "schemas",
  "serde",

--- a/editoast/core_client/Cargo.toml
+++ b/editoast/core_client/Cargo.toml
@@ -21,7 +21,6 @@ itertools.workspace = true
 lapin.workspace = true
 linkme.workspace = true
 opentelemetry.workspace = true
-reqwest.workspace = true
 schemas = { workspace = true, features = ["testing"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true

--- a/editoast/core_client/src/lib.rs
+++ b/editoast/core_client/src/lib.rs
@@ -61,7 +61,6 @@ impl CoreClient {
     )]
     async fn fetch<B: Serialize, R: CoreResponse>(
         &self,
-        method: reqwest::Method,
         path: &str,
         body: Option<&B>,
         worker_id: Option<String>,
@@ -129,7 +128,7 @@ impl CoreClient {
 /// # let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
 /// # rt.block_on(async {
 /// #   let mut core_mock = core_client::mocking::MockingClient::default();
-/// #   core_mock.stub("/some/path").response(reqwest::StatusCode::OK).body("{\"message\":\"YOU WON!\"}").finish();
+/// #   core_mock.stub("/some/path").response(http::StatusCode::OK).body("{\"message\":\"YOU WON!\"}").finish();
 /// #   let core_client = core_mock.into();
 /// // Builds the payload, executes the request at POST /some/path and deserializes its response
 /// let response = TestReq::default().fetch(&core_client).await.unwrap();
@@ -160,13 +159,8 @@ where
     /// manage itself its expected errors. Maybe a bound error type defaulting
     /// to CoreError and a trait function handle_errors would suffice?
     async fn fetch(&self, core: &CoreClient) -> Result<R::Response, Error> {
-        core.fetch::<Self, R>(
-            reqwest::Method::POST,
-            self.url(),
-            Some(self),
-            self.worker_id(),
-        )
-        .await
+        core.fetch::<Self, R>(self.url(), Some(self), self.worker_id())
+            .await
     }
 }
 

--- a/editoast/core_client/src/mocking.rs
+++ b/editoast/core_client/src/mocking.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 use std::sync::Mutex;
 
 use http::StatusCode;
-use reqwest::Body;
 use serde::Serialize;
 
 use super::CoreClient;
@@ -59,14 +58,7 @@ impl MockingClient {
 
         match (
             req_body.map(|b| serde_json::to_string(b).expect("could not serialize request body")),
-            stub.body.as_ref().map(|b| {
-                String::from_utf8(
-                    b.as_bytes()
-                        .expect("expected request body should not be empty when specified")
-                        .to_vec(),
-                )
-                .expect("expected request body should serialize faultlessly")
-            }),
+            stub.body.as_ref().map(|b| b.as_str().to_string()),
         ) {
             (Some(actual), Some(expected)) => assert_eq!(actual, expected, "request body mismatch"),
             (None, Some(expected)) => panic!("missing request body: '{expected}'"),
@@ -76,10 +68,7 @@ impl MockingClient {
             .response
             .as_ref()
             .and_then(|r| r.body.as_ref())
-            .map(|b| {
-                b.as_bytes()
-                    .expect("mocked response body should not be empty when specified")
-            });
+            .map(|b| b.as_bytes());
         match stub.response {
             None => Ok(None),
             Some(StubResponse { code, .. }) if code.is_success() => Ok(Some(
@@ -104,7 +93,7 @@ impl MockingClient {
 /// A stub request used to assert the validity of an incoming request to mock
 #[derive(Debug, Clone)]
 pub struct StubRequest {
-    body: Option<Arc<Body>>,
+    body: Option<Arc<String>>,
     response: Option<StubResponse>,
 }
 
@@ -116,20 +105,20 @@ pub struct StubResponse {
     // properly handle response error cases (and Deserialize the error)
     #[allow(unused)]
     code: StatusCode,
-    body: Option<Arc<Body>>,
+    body: Option<Arc<String>>,
 }
 
 #[derive(Debug)]
 pub struct StubRequestBuilder<'a> {
     path: String,
-    body: Option<Arc<Body>>,
+    body: Option<Arc<String>>,
     client: &'a mut MockingClient,
 }
 
 #[derive(Debug)]
 pub struct StubResponseBuilder<'a> {
     code: StatusCode,
-    bodies: Vec<Option<Arc<Body>>>,
+    bodies: Vec<Option<Arc<String>>>,
     request_builder: StubRequestBuilder<'a>,
 }
 
@@ -147,8 +136,8 @@ impl<'a> StubRequestBuilder<'a> {
     /// If no expected body is set, the request actual body is ignored
     #[allow(unused)]
     #[must_use = "call .finish() to register the stub request"]
-    pub fn body<B: Into<Body>>(mut self, body: B) -> Self {
-        self.body = Some(Arc::new(body.into()));
+    pub fn body<B: AsRef<str>>(mut self, body: B) -> Self {
+        self.body = Some(Arc::new(body.as_ref().to_string()));
         self
     }
 
@@ -196,8 +185,8 @@ impl StubResponseBuilder<'_> {
     ///
     /// If none is set, `AsCoreRequest::fetch` will return an `Err(CoreError::NoResponseContent)`
     #[must_use = "call .finish() to register the stub request"]
-    pub fn body<B: Into<Body>>(mut self, body: B) -> Self {
-        self.bodies.push(Some(Arc::new(body.into())));
+    pub fn body<B: AsRef<str>>(mut self, body: B) -> Self {
+        self.bodies.push(Some(Arc::new(body.as_ref().to_string())));
         self
     }
 
@@ -205,7 +194,7 @@ impl StubResponseBuilder<'_> {
     #[must_use = "call .finish() to register the stub request"]
     pub fn json<T: Serialize>(mut self, body: T) -> Self {
         let json_body = serde_json::to_string(&body).expect("Failed to serialize JSON");
-        self.bodies.push(Some(Arc::new(Body::from(json_body))));
+        self.bodies.push(Some(Arc::new(json_body)));
         self
     }
 


### PR DESCRIPTION
`reqwest` is still used by `fga` and `osrdyne_client` though.

Signed-off-by: Leo Valais <leo.valais97@gmail.com>
