### PR TITLE
flake: remove useless apple_sdk frameworks

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -45,53 +45,47 @@
       with pkgs;
       {
         devShells.default = mkShell {
-          buildInputs =
-            [
-              # Rust
-              rustChan
+          buildInputs = [
+            # Rust
+            rustChan
 
-              # Libs
-              geos
-              openssl
-              pkg-config
-              postgresql
+            # Libs
+            geos
+            openssl
+            pkg-config
+            postgresql
 
-              # Tools & Libs
-              diesel-cli
-              cargo-watch
-              taplo
-              uv
-              openfga-cli
+            # Tools & Libs
+            diesel-cli
+            cargo-watch
+            taplo
+            uv
+            openfga-cli
 
-              # Core
-              gradle
-              jdk21
+            # Core
+            gradle
+            jdk21
 
-              # Front
-              fixedNode
+            # Front
+            fixedNode
 
-              # Nix formatter
-              nixfmt-rfc-style
-              nixd
+            # Nix formatter
+            nixfmt-rfc-style
+            nixd
 
-              # OSRD dev scripts
-              osrd-dev-scripts
-              jq
-            ]
-            # Section added only on Linux systems
-            ++ lib.optionals (!stdenv.isDarwin) [
-              # Linker
-              mold-wrapped
-            ]
-            # Section added only on Darwin (macOS) systems
-            ++ lib.optionals stdenv.isDarwin (
-              with pkgs.darwin.apple_sdk.frameworks;
-              [
-                CoreFoundation
-                SystemConfiguration
-                libiconv
-              ]
-            );
+            # OSRD dev scripts
+            osrd-dev-scripts
+            jq
+          ]
+          # Section added only on Linux systems
+          ++ lib.optionals (!stdenv.isDarwin) [
+            # Linker
+            mold-wrapped
+          ]
+          # Section added only on Darwin (macOS) systems
+          ++ lib.optionals stdenv.isDarwin [
+            libiconv
+          ];
 
           RUSTFLAGS = if stdenv.isDarwin then "" else "-C link-arg=-fuse-ld=mold";
         };


### PR DESCRIPTION
related to this error: darwin.apple_sdk_11_0 has been removed as it was a legacy compatibility stub

see <https://nixos.org/manual/nixpkgs/stable/#sec-darwin-legacy-frameworks>