### PR TITLE
editoast: cache: make `cache::Config` an enum

### DIFF
--- a/editoast/cache/src/client.rs
+++ b/editoast/cache/src/client.rs
@@ -19,31 +19,25 @@ pub enum ClientInner {
 }
 
 #[derive(Clone)]
-pub struct Config {
+pub enum Config {
     /// Disables caching. This should not be used in production.
-    pub no_cache: bool,
-    pub valkey_url: Url,
-    pub app_version: String,
+    NoCache,
+    Valkey {
+        url: Url,
+    },
 }
 
 impl Client {
-    pub fn new(
-        Config {
-            no_cache,
-            valkey_url,
-            app_version,
-        }: Config,
-    ) -> Self {
+    pub fn new(config: Config, app_version: &str) -> Self {
         Self {
             app_version: ArcStr::from(app_version),
-            inner: if no_cache {
-                ClientInner::NoCache
-            } else {
-                ClientInner::Tokio(
-                    deadpool_redis::Config::from_url(valkey_url)
+            inner: match config {
+                Config::NoCache => ClientInner::NoCache,
+                Config::Valkey { url } => ClientInner::Tokio(
+                    deadpool_redis::Config::from_url(url)
                         .create_pool(Some(Runtime::Tokio1))
                         .unwrap(),
-                )
+                ),
             },
         }
     }

--- a/editoast/src/client/healthcheck.rs
+++ b/editoast/src/client/healthcheck.rs
@@ -14,18 +14,11 @@ use super::runserver::CoreArgs;
 
 pub async fn healthcheck_cmd(
     db_pool: Arc<DbConnectionPoolV2>,
-    ValkeyConfig {
-        no_cache,
-        valkey_url,
-    }: ValkeyConfig,
+    valkey_config: ValkeyConfig,
     core_config: CoreArgs,
     openfga_config: OpenfgaConfig,
 ) -> anyhow::Result<()> {
-    let valkey = cache::Client::new(cache::Config {
-        app_version: "HEALTHCHECK".to_owned(),
-        no_cache,
-        valkey_url,
-    });
+    let valkey = cache::Client::new(valkey_config.into_cache_config(), "HEALTHCHECK");
     let core_client = CoreClient::new_mq(mq_client::Options {
         uri: core_config.mq_url,
         worker_pool_identifier: core_config.worker_pool_id,

--- a/editoast/src/client/infra_commands.rs
+++ b/editoast/src/client/infra_commands.rs
@@ -230,18 +230,14 @@ pub async fn generate_infra(
 }
 
 async fn build_valkey_pool_and_invalidate_all_cache(
-    ValkeyConfig {
-        no_cache,
-        valkey_url,
-    }: ValkeyConfig,
+    valkey_config: ValkeyConfig,
     infra_id: i64,
     app_version: Option<&str>,
 ) -> anyhow::Result<()> {
-    let valkey = cache::Client::new(cache::Config {
-        app_version: app_version.map(|v| v.to_owned()).unwrap_or_default(),
-        no_cache,
-        valkey_url,
-    });
+    let valkey = cache::Client::new(
+        valkey_config.into_cache_config(),
+        app_version.unwrap_or_default(),
+    );
     let mut conn = valkey.get_connection().await?;
     map::invalidate_all(
         &mut conn,

--- a/editoast/src/client/runserver.rs
+++ b/editoast/src/client/runserver.rs
@@ -5,7 +5,6 @@ use clap::Args;
 use url::Url;
 
 use crate::views;
-use cache;
 
 use super::PostgresConfig;
 use super::ValkeyConfig;
@@ -78,10 +77,7 @@ pub async fn runserver(
         dynamic_assets_path,
     }: RunserverArgs,
     postgres: PostgresConfig,
-    ValkeyConfig {
-        no_cache,
-        valkey_url,
-    }: ValkeyConfig,
+    valkey_config: ValkeyConfig,
     openfga: OpenfgaConfig,
     app_version: Option<String>,
 ) -> anyhow::Result<()> {
@@ -102,11 +98,7 @@ pub async fn runserver(
                 worker_pool_id,
             },
         },
-        valkey_config: cache::Config {
-            app_version: app_version.clone().unwrap_or_default(),
-            no_cache,
-            valkey_url,
-        },
+        valkey_config: valkey_config.into_cache_config(),
         openfga_config: openfga.into(),
         root_url,
         dynamic_assets_path,

--- a/editoast/src/client/valkey_config.rs
+++ b/editoast/src/client/valkey_config.rs
@@ -13,3 +13,15 @@ pub struct ValkeyConfig {
     /// Valkey url like `redis://[:PASSWORD@]HOST[:PORT][/DATABASE]`
     pub valkey_url: Url,
 }
+
+impl ValkeyConfig {
+    pub fn into_cache_config(self) -> cache::Config {
+        if self.no_cache {
+            cache::Config::NoCache
+        } else {
+            cache::Config::Valkey {
+                url: self.valkey_url,
+            }
+        }
+    }
+}

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -885,7 +885,10 @@ impl AppState {
         // Synchronous operations
         let infra_caches = DashMap::<i64, InfraCache>::default().into();
         let speed_limit_tag_ids = Arc::new(SpeedLimitTagIds::load());
-        let valkey = cache::Client::new(config.valkey_config.clone()).into();
+        let valkey = Arc::new(cache::Client::new(
+            config.valkey_config.clone(),
+            config.app_version.as_deref().unwrap_or("NO_APP_VERSION"),
+        ));
         let osrdyne_client = Arc::new(OsrdyneClient::new(
             config.osrdyne_config.osrdyne_api_url.clone(),
         ));

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -164,11 +164,7 @@ impl TestAppBuilder {
                     worker_pool_id: "core".into(),
                 },
             },
-            valkey_config: cache::Config {
-                app_version: "TEST_VERSION".to_owned(),
-                no_cache: true,
-                valkey_url: Url::parse("redis://localhost:6379").unwrap(),
-            },
+            valkey_config: cache::Config::NoCache,
             root_url: self
                 .root_url
                 .unwrap_or_else(|| Url::parse("http://localhost:8090/").unwrap()),
@@ -203,7 +199,7 @@ impl TestAppBuilder {
         let tracing_guard = tracing::subscriber::set_default(sub);
 
         // Config valkey
-        let valkey = cache::Client::new(config.valkey_config.clone()).into();
+        let valkey = cache::Client::new(config.valkey_config.clone(), "TEST_APP").into();
 
         // Create database pool
         let db_pool_v2 = Arc::new(self.db_pool.unwrap_or_else(DbConnectionPoolV2::for_tests));


### PR DESCRIPTION
Having to provide a valid url when we disable the cache makes no sense.

Signed-off-by: Leo Valais <leo.valais97@gmail.com>
