### PR TITLE
ui-charts: prevents undefined hoveredItem cases

### DIFF
--- a/front/ui/ui-charts/src/spaceTimeChart/hooks/useCanvas.ts
+++ b/front/ui/ui-charts/src/spaceTimeChart/hooks/useCanvas.ts
@@ -274,12 +274,25 @@ export function useCanvas(
         if (a === 255) {
           const color = rgbToHex(r, g, b);
           const index = colorToIndex(color);
-          const element = stcContextRef.current.pickingElements[index];
-          newHoveredItem = {
-            layer,
-            element,
-          };
-          return true;
+          const element = stcContextRef.current.pickingElements.at(index);
+
+          // Sometimes, because of some race conditions between the update lifecycle of the
+          // pickingElements array and the React + useCanvas lifecycle, here the pickingElements
+          // array can be empty. We must check that element is non-nil before updating
+          // newHoveredItem:
+          if (element) {
+            newHoveredItem = {
+              layer,
+              element,
+            };
+            return true;
+          }
+          // If element is undefined but pickingElements is not empty, let's throw a specific error:
+          else if (stcContextRef.current.pickingElements.length > 0) {
+            throw new Error(
+              `Picking index is out of bounds (index: ${index}, registered picking elements: ${stcContextRef.current.pickingElements.length})`
+            );
+          }
         }
       }
 


### PR DESCRIPTION
This commit fixes #13408.

The best solution would be to find and solve the cause for the cases where `pickingElements` is empty in `useCanvas`.

Because I did not find this cause indeed, this commit simply mitigates this issue, by ignoring the cases where it happens, and commenting the code for future brave maintainers.