### PR TITLE
editoast: add missing service deps to README.md

### DIFF
--- a/editoast/README.md
+++ b/editoast/README.md
@@ -13,8 +13,13 @@ For both tests or run:
 - [libpq](https://www.postgresql.org/docs/current/libpq.html) (may be packaged as `libpq-dev`)
 - [openssl](https://www.openssl.org)
 - [libgeos](https://libgeos.org/usage/install/) (may be packaged as `libgeos-dev`)
-- A properly initialized postgresql database and a valkey server: `docker compose up --no-build --detach postgres valkey`
 - [fga CLI](https://github.com/openfga/cli)
+
+Additionally, editoast requires the following services to be running:
+
+```sh
+../osrd-compose up --detach openfga postgres rabbitmq valkey
+```
 
 ## Steps
 


### PR DESCRIPTION
As per [docker-compose.yml's editoast.depends_on](https://github.com/OpenRailAssociation/osrd/blob/d0367d1d650bea985b250dfbade170a1f056c210/docker-compose.yml#L118)

Signed-off-by: Hubert Hirtz <hubert@hirtz.pm>