### PR TITLE
front: fix train ids from url

### DIFF
--- a/front/src/applications/operationalStudies/hooks/useAutoSelectTrainIds.ts
+++ b/front/src/applications/operationalStudies/hooks/useAutoSelectTrainIds.ts
@@ -105,18 +105,11 @@ const useAutoSelectTrainIds = (
 
   // Update the URL and local storage on redux store change
   useEffect(() => {
-    if (selectedTrainId?.toString() !== getParamFromUrlOrStorage('selected_train')) {
+    if (parametersLoaded) {
       setParamsInUrlAndStorage('selected_train', selectedTrainId?.toString());
-    }
-    if (currentTrainIdForProjection?.toString() !== getParamFromUrlOrStorage('projection')) {
       setParamsInUrlAndStorage('projection', currentTrainIdForProjection?.toString());
     }
-  }, [
-    selectedTrainId,
-    currentTrainIdForProjection,
-    setParamsInUrlAndStorage,
-    getParamFromUrlOrStorage,
-  ]);
+  }, [parametersLoaded, selectedTrainId, currentTrainIdForProjection, setParamsInUrlAndStorage]);
 
   useEffect(() => {
     if (timetableItemIds === undefined) {


### PR DESCRIPTION
Close https://github.com/OpenRailAssociation/osrd/issues/13161 again
Close https://github.com/OpenRailAssociation/osrd/issues/12605 again

In #13218, I forgot to update the use effect in charge of setting the url to use the new parametersLoaded flag, resulting in the url possibly being set before it was read =/