### PR TITLE
core: fix timetable concurrency

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/api/TimetableProvider.kt
+++ b/core/src/main/java/fr/sncf/osrd/api/TimetableProvider.kt
@@ -47,10 +47,14 @@ interface TimetableProvider {
     ): STDCMRequirements
 }
 
-class TimetableDownloader(baseUrl: String, authenticationHeader: String, httpClient: OkHttpClient) :
-    APIClient(baseUrl, authenticationHeader, httpClient), TimetableProvider {
+class TimetableDownloader(
+    baseUrl: String,
+    authenticationHeader: String,
+    httpClient: OkHttpClient,
+    maxParallelism: Int = 5,
+) : APIClient(baseUrl, authenticationHeader, httpClient), TimetableProvider {
 
-    val httpDispatcher = Dispatchers.IO.limitedParallelism(5)
+    val httpDispatcher = Dispatchers.IO.limitedParallelism(maxParallelism)
 
     @OptIn(ExperimentalCoroutinesApi::class)
     private fun fetchTrainRequirements(

--- a/core/src/main/java/fr/sncf/osrd/api/TimetableProvider.kt
+++ b/core/src/main/java/fr/sncf/osrd/api/TimetableProvider.kt
@@ -20,12 +20,14 @@ import kotlin.collections.flatMap
 import kotlin.io.path.Path
 import kotlin.io.path.readText
 import kotlin.math.pow
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flatMapMerge
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.runBlocking
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -48,22 +50,28 @@ interface TimetableProvider {
 class TimetableDownloader(baseUrl: String, authenticationHeader: String, httpClient: OkHttpClient) :
     APIClient(baseUrl, authenticationHeader, httpClient), TimetableProvider {
 
+    val httpDispatcher = Dispatchers.IO.limitedParallelism(5)
+
     @OptIn(ExperimentalCoroutinesApi::class)
     private fun fetchTrainRequirements(
         infraId: String,
         timetableId: TimetableId,
     ): Flow<TrainRequirementsById> = flow {
         val firstPageTrainRequirements = getTrainPaginatedRequirements(infraId, timetableId, 1)
+
         emitAll(firstPageTrainRequirements.results.asFlow())
         emitAll(
             (2..firstPageTrainRequirements.pageCount)
                 .asFlow()
                 // Limit the number of concurrent calls to the requirements endpoint.
-                .flatMapMerge(concurrency = 5) { page ->
-                    val paginatedTrainRequirements =
-                        getTrainPaginatedRequirements(infraId, timetableId, page)
-                    paginatedTrainRequirements.results.asFlow()
+                .flatMapMerge { page ->
+                    flow {
+                        val paginatedTrainRequirements =
+                            getTrainPaginatedRequirements(infraId, timetableId, page)
+                        emitAll(paginatedTrainRequirements.results.asFlow())
+                    }
                 }
+                .flowOn(httpDispatcher)
         )
     }
 
@@ -88,6 +96,9 @@ class TimetableDownloader(baseUrl: String, authenticationHeader: String, httpCli
             else {
                 logger.error("Error when getting ${request.url}: $response")
                 val nextSleepDuration = 1_000 * 2.0.pow(tryCount).toLong()
+                // Thread.sleep blocks the thread, which is usually bad in the context of
+                // coroutines. But it's on purpose here: if the server has a temporary issue, we
+                // don't want the next page to immediately take over while this one is waiting.
                 Thread.sleep(nextSleepDuration)
             }
         }

--- a/core/src/main/java/fr/sncf/osrd/api/TimetableProvider.kt
+++ b/core/src/main/java/fr/sncf/osrd/api/TimetableProvider.kt
@@ -16,6 +16,7 @@ import fr.sncf.osrd.utils.json.UnitAdapterFactory
 import java.time.Duration
 import java.time.Instant
 import java.time.ZonedDateTime
+import kotlin.collections.flatMap
 import kotlin.io.path.Path
 import kotlin.io.path.readText
 import kotlin.math.pow
@@ -50,43 +51,18 @@ class TimetableDownloader(baseUrl: String, authenticationHeader: String, httpCli
     @OptIn(ExperimentalCoroutinesApi::class)
     private fun fetchTrainRequirements(
         infraId: String,
-        infra: RawInfra,
         timetableId: TimetableId,
-    ): Flow<SpacingRequirement> = flow {
+    ): Flow<TrainRequirementsById> = flow {
         val firstPageTrainRequirements = getTrainPaginatedRequirements(infraId, timetableId, 1)
-        emitAll(
-            firstPageTrainRequirements.results
-                .flatMap {
-                    it.spacingRequirements.map { spacingReq ->
-                        SpacingRequirement.fromRJSWithAddedTime(
-                            spacingReq,
-                            infra,
-                            it.startTime.durationSinceEpoch(),
-                        )
-                    }
-                }
-                .asFlow()
-        )
+        emitAll(firstPageTrainRequirements.results.asFlow())
         emitAll(
             (2..firstPageTrainRequirements.pageCount)
                 .asFlow()
                 // Limit the number of concurrent calls to the requirements endpoint.
                 .flatMapMerge(concurrency = 5) { page ->
-                    flow {
-                        val paginatedTrainRequirements =
-                            getTrainPaginatedRequirements(infraId, timetableId, page)
-                        paginatedTrainRequirements.results
-                            .flatMap {
-                                it.spacingRequirements.map { spacingReq ->
-                                    SpacingRequirement.fromRJSWithAddedTime(
-                                        spacingReq,
-                                        infra,
-                                        it.startTime.durationSinceEpoch(),
-                                    )
-                                }
-                            }
-                            .forEach { emit(it) }
-                    }
+                    val paginatedTrainRequirements =
+                        getTrainPaginatedRequirements(infraId, timetableId, page)
+                    paginatedTrainRequirements.results.asFlow()
                 }
         )
     }
@@ -137,10 +113,18 @@ class TimetableDownloader(baseUrl: String, authenticationHeader: String, httpCli
     ): STDCMRequirements {
         return runBlocking {
             val res = mutableMapOf<ZoneId, RangeSet<Double>>()
-            val requirements = fetchTrainRequirements(infraId, infra, timetableId)
-            requirements.collect { spacingReq ->
-                val set = res.computeIfAbsent(spacingReq.zone) { TreeRangeSet.create() }
-                set.add(Range.closedOpen(spacingReq.beginTime, spacingReq.endTime))
+            val trainRequirementsById = fetchTrainRequirements(infraId, timetableId)
+            trainRequirementsById.collect { trainRequirementById ->
+                for (rjsRequirement in trainRequirementById.spacingRequirements) {
+                    val requirement =
+                        SpacingRequirement.fromRJSWithAddedTime(
+                            rjsRequirement,
+                            infra,
+                            trainRequirementById.startTime.durationSinceEpoch(),
+                        )
+                    val set = res.computeIfAbsent(requirement.zone) { TreeRangeSet.create() }
+                    set.add(Range.closedOpen(requirement.beginTime, requirement.endTime))
+                }
             }
             STDCMRequirements(res)
         }

--- a/core/src/main/java/fr/sncf/osrd/cli/WorkerCommand.kt
+++ b/core/src/main/java/fr/sncf/osrd/cli/WorkerCommand.kt
@@ -52,6 +52,7 @@ class WorkerCommand : CliCommand {
     val WORKER_ACTIVITY_EXCHANGE: String
     val ALL_INFRA: Boolean
     val WORKER_THREADS: Int
+    val MAX_CONCURRENT_TIMETABLE_REQUESTS: Int
 
     init {
         LOCAL_TIMETABLE_CACHE = System.getenv("LOCAL_TIMETABLE_CACHE")
@@ -69,6 +70,8 @@ class WorkerCommand : CliCommand {
         WORKER_THREADS =
             System.getenv("WORKER_THREADS")?.toIntOrNull()
                 ?: Runtime.getRuntime().availableProcessors()
+        MAX_CONCURRENT_TIMETABLE_REQUESTS =
+            System.getenv("MAX_CONCURRENT_TIMETABLE_REQUESTS")?.toIntOrNull() ?: 5
 
         WORKER_ID =
             if (WORKER_ID_USE_HOSTNAME) {
@@ -110,7 +113,12 @@ class WorkerCommand : CliCommand {
         val infraManager = InfraManager(editoastUrl!!, editoastAuthorization, httpClient)
         val timetableCache =
             TimetableCacheManager(
-                TimetableDownloader(editoastUrl!!, editoastAuthorization, httpClient),
+                TimetableDownloader(
+                    editoastUrl!!,
+                    editoastAuthorization,
+                    httpClient,
+                    MAX_CONCURRENT_TIMETABLE_REQUESTS,
+                ),
                 LOCAL_TIMETABLE_CACHE,
             )
         val electricalProfileSetManager =

--- a/core/src/main/java/fr/sncf/osrd/cli/WorkerCommand.kt
+++ b/core/src/main/java/fr/sncf/osrd/cli/WorkerCommand.kt
@@ -71,7 +71,7 @@ class WorkerCommand : CliCommand {
             System.getenv("WORKER_THREADS")?.toIntOrNull()
                 ?: Runtime.getRuntime().availableProcessors()
         MAX_CONCURRENT_TIMETABLE_REQUESTS =
-            System.getenv("MAX_CONCURRENT_TIMETABLE_REQUESTS")?.toIntOrNull() ?: 5
+            System.getenv("MAX_CONCURRENT_TIMETABLE_REQUESTS")?.toIntOrNull() ?: 10
 
         WORKER_ID =
             if (WORKER_ID_USE_HOSTNAME) {


### PR DESCRIPTION
First commit tidies up the parsing of the json requirements and removes that from the main coroutine loop.

Second commit actually fixes the concurrency. I've tested with `logger.info` before and after each page, not included in the PR.

Bonus: third commits adds an env variable to set the max parallelism. 