### PR TITLE
core: worker: log errors caught in request processing

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/cli/WorkerCommand.kt
+++ b/core/src/main/java/fr/sncf/osrd/cli/WorkerCommand.kt
@@ -286,6 +286,7 @@ class WorkerCommand : CliCommand {
                         }
                     } catch (t: Throwable) {
                         span.recordException(t)
+                        logger.error("Unexpected error: ", t)
                         payload =
                             "ERROR, exception received"
                                 .toByteArray() // TODO: have a valid payload for uncaught exceptions


### PR DESCRIPTION
We already logged it in telemetry, but not printing anything on the console can make some error hard to troubleshoot