### PR TITLE
github: register GitHub deployments for osrd-ui storybook

### DIFF
--- a/.github/workflows/osrd-ui-website.yml
+++ b/.github/workflows/osrd-ui-website.yml
@@ -81,6 +81,7 @@ jobs:
           linkchecker_enabled: false
           sticky_comment_enabled: false
           step_summary_enabled: true
+          gh_deployment: storybook
         env:
           HAVE_SSH_KEY: ${{ secrets.UI_WEBSITE_SSH_KEY != '' }}
         if: ${{ env.HAVE_SSH_KEY == 'true' }}


### PR DESCRIPTION
This makes it easier to access the preview.

Uses the new gh_deployment option from this PR:
https://github.com/OpenRailAssociation/web-deployment-action/pull/25