### PR TITLE
front: fix exceptions tooltip positioning

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/RoundTrips/RoundTripsModalCard.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/RoundTrips/RoundTripsModalCard.tsx
@@ -169,7 +169,6 @@ const RoundTripsModalCard = ({
         {isStatusTooltipOpen && status === 'roundTrips' && pairData && (
           <OSRDTooltip
             containerRef={statusRef}
-            isOpen={isStatusTooltipOpen}
             header={t('matchedWith')}
             items={statusTooltipBody(pairData)}
             offsetRatio={{ top: 1.2, left: 0.22 }} // ratio computed based on container size and tooltip offset
@@ -210,7 +209,6 @@ const RoundTripsModalCard = ({
         {isStopsTooltipOpen && stops.length > 0 && (
           <OSRDTooltip
             containerRef={stopsRef}
-            isOpen={isStopsTooltipOpen}
             header={t('intermediateStops')}
             items={stops}
             offsetRatio={{ top: 1.2, left: 0.22 }} // ratio computed based on container size and tooltip offset

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/OccurrenceIndicator.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/OccurrenceIndicator.tsx
@@ -99,7 +99,6 @@ const OccurrenceIndicator = ({ occurrence, subCategories }: OccurrenceIndicatorP
       {isHovering && (occurrence.disabled || !isEmpty(occurrence.exceptionChangeGroups)) && (
         <OSRDTooltip
           containerRef={dotRef}
-          isOpen={isHovering}
           header={tooltipHeader()}
           items={displayedChangeGroups || []}
           offsetRatio={{ top: 0.5, left: 1 }}

--- a/front/src/common/OSRDTooltip.tsx
+++ b/front/src/common/OSRDTooltip.tsx
@@ -2,7 +2,6 @@ import React, { useLayoutEffect, useRef, useState } from 'react';
 
 type OSRDTooltipProps = {
   containerRef: React.RefObject<HTMLDivElement | null>;
-  isOpen: boolean;
   header: string;
   items: string[];
   offsetRatio?: {
@@ -16,12 +15,12 @@ const TOOLTIP_BOTTOM_MARGIN = 24;
 
 const OSRDTooltip = ({
   containerRef,
-  isOpen,
   header,
   items,
   offsetRatio,
   reverseIfOverflow,
 }: OSRDTooltipProps) => {
+  const tooltipContainerRef = useRef<HTMLDivElement>(null);
   const tooltipRef = useRef<HTMLDivElement>(null);
 
   const [position, setPosition] = useState<{
@@ -34,7 +33,9 @@ const OSRDTooltip = ({
   const offsetLeftRatio = offsetRatio?.left ?? 1;
 
   useLayoutEffect(() => {
-    if (!containerRef.current || !isOpen) return;
+    if (!tooltipContainerRef.current || !containerRef.current) return;
+
+    tooltipContainerRef.current.showPopover();
 
     const rect = containerRef.current.getBoundingClientRect();
     const tooltipRect = tooltipRef.current?.getBoundingClientRect();
@@ -75,7 +76,7 @@ const OSRDTooltip = ({
       left: tooltipLeftPosition,
       bottom: undefined,
     });
-  }, [isOpen]);
+  }, []);
 
   return (
     <div
@@ -86,6 +87,8 @@ const OSRDTooltip = ({
         left: position?.left ? position.left - window.scrollX : undefined,
         bottom: position?.bottom ? position.bottom - window.scrollY : undefined,
       }}
+      popover="hint"
+      ref={tooltipContainerRef}
     >
       <div ref={tooltipRef}>
         <span className="osrd-tooltip-header">{header}</span>

--- a/front/src/modules/conflict/components/ConflictCard.tsx
+++ b/front/src/modules/conflict/components/ConflictCard.tsx
@@ -84,7 +84,6 @@ const ConflictCard = ({ conflict }: { conflict: ConflictWithTrainNames }) => {
             {isOthersTooltipOpen && (
               <OSRDTooltip
                 containerRef={othersTagRef}
-                isOpen={isOthersTooltipOpen}
                 header={t('conflicts.trainsInConflictTitle')}
                 items={conflict.trainsData
                   .filter((_, index) => index >= 3)

--- a/front/src/styles/scss/common/components/_osrdTooltip.scss
+++ b/front/src/styles/scss/common/components/_osrdTooltip.scss
@@ -1,9 +1,9 @@
 .osrd-tooltip {
+  inset: auto;
   padding: 9px 8px 11px;
   min-width: 200px;
   max-width: 213px;
   position: fixed;
-  z-index: 10;
   background-color: var(--black85);
   border-radius: 8px;
   box-shadow: 0 4px 6px -2px var(--black28);


### PR DESCRIPTION
Close [#13438](https://github.com/OpenRailAssociation/osrd/issues/13438)

The tooltip was rendered below the viewport, as its top value was too high. Indeed, getBoundingClientRect returned a top position relative to the viewport, but fixed positioning seems to be affected by containing blocks, and not always be directly fixed relative to the viewport. Here, one parent of each exception's occurrence-indicator seems to have contain:strict.

To fix this, renders the tooltip outside of the hijacking containing block through a portal.

As the round trip modal are rendered in the top layer and use OSRDTooltip too, also detect the presence of the toplayer.

Finally, we need to bump the z-index to make sure to get voer the z-index of 9999 of the round trip modal. Since it is already in the top layer, we should also be able to reduce the round trip modal z-index, but I was not confident making that change.

We may also want to explore stopping positioning the tooltip in a fixed way.

Before :
[tooltip_positioning_before.webm](https://github.com/user-attachments/assets/d52a4612-007d-48c8-bf20-2779e20bab97)

After :
[tooltip_positioning.webm](https://github.com/user-attachments/assets/d916e5db-a68f-4460-8161-4625844d3e9d)

