### PR TITLE
core: pure ETCS level 2 routing requirements

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/api/standalone_sim/SimulationEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/standalone_sim/SimulationEndpoint.kt
@@ -74,7 +74,6 @@ class SimulationEndpoint(
                     chunkPath,
                     routePath,
                     blockPath,
-                    electricalProfileMap,
                     rollingStock,
                     request.comfort,
                     request.constraintDistribution.toRJS(),

--- a/core/src/main/kotlin/fr/sncf/osrd/conflicts/SpacingResourceGenerator.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/conflicts/SpacingResourceGenerator.kt
@@ -445,7 +445,12 @@ class SpacingRequirementAutomaton(
         val curvesList = etcsSimulator.computeStopBrakingCurves(envelope, listOf(eoa))
 
         assert(curvesList.size == 1)
-        val reqPos = curvesList[eoa]!![IND]!!.brakingCurve.beginPos.meters
+        val reqPos =
+            if (curvesList[eoa]!![IND] != null) {
+                curvesList[eoa]!![IND]!!.brakingCurve.beginPos.meters
+            } else {
+                eoa.offsetEOA.distance
+            }
 
         // Find the first zone of the block protected by signal
         val firstRequiredZone = getSignalFirstProtectedZone(pathSignal)

--- a/core/src/main/kotlin/fr/sncf/osrd/conflicts/SpacingResourceGenerator.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/conflicts/SpacingResourceGenerator.kt
@@ -400,7 +400,7 @@ class SpacingRequirementAutomaton(
                     etcsSimulator == null
             ) {
                 TODO(
-                    "Spacing requirements for curve-based signal are only available for " +
+                    "Spacing requirements for curve-based signals are only available for " +
                         "ETCS_LEVEL2 and through StandaloneSimulation"
                 )
             }

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
@@ -209,7 +209,7 @@ fun runScheduleMetadataExtractor(
 
             val stopDepartureTime =
                 envelopeWithStops
-                    .interpolateDepartureFrom(closedSignalStopOffset!!.distance.meters)
+                    .interpolateDepartureFrom(closedSignalStopOffset.distance.meters)
                     .seconds
             if (signalCriticalTime < stopDepartureTime - CLOSED_SIGNAL_RESERVATION_MARGIN.seconds) {
                 signalCriticalOffset = closedSignalStopOffset
@@ -301,7 +301,6 @@ fun getStopTravelledPathOffset(
 }
 
 fun makeSimpleReportTrain(
-    fullInfra: FullInfra,
     envelope: Envelope,
     trainPath: TrainPath,
     rollingStock: RollingStock,

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
@@ -593,7 +593,15 @@ private fun getEtcsRouteCriticalPos(
             )
             .first()
     val curvesList = etcsSimulator.computeStopBrakingCurves(envelope, listOf(eoa))
-    val reqPos = curvesList[eoa]!![IND]!!.brakingCurve.beginPos.meters
+
+    assert(curvesList.size == 1)
+    val reqPos =
+        if (curvesList[eoa]!![IND] != null) {
+            curvesList[eoa]!![IND]!!.brakingCurve.beginPos.meters
+        } else {
+            eoa.offsetEOA.distance
+        }
+
     return Offset(reqPos)
 }
 

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
@@ -11,15 +11,20 @@ import fr.sncf.osrd.envelope.EnvelopeInterpolate
 import fr.sncf.osrd.envelope.EnvelopePhysics
 import fr.sncf.osrd.envelope.EnvelopeTimeInterpolate
 import fr.sncf.osrd.envelope_sim.EnvelopeSimContext
+import fr.sncf.osrd.envelope_sim.etcs.BrakingType.IND
+import fr.sncf.osrd.envelope_sim.etcs.ETCSBrakingSimulator
+import fr.sncf.osrd.envelope_sim.etcs.ETCSBrakingSimulatorImpl
+import fr.sncf.osrd.envelope_sim.etcs.EoaType
 import fr.sncf.osrd.path.implementations.ChunkPath
 import fr.sncf.osrd.path.interfaces.BlockPath
 import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.path.interfaces.TravelledPath
 import fr.sncf.osrd.signaling.SigSystemManager
-import fr.sncf.osrd.signaling.SignalingSimulator
 import fr.sncf.osrd.signaling.SignalingTrainState
 import fr.sncf.osrd.signaling.ZoneStatus
+import fr.sncf.osrd.signaling.etcs_level2.ETCS_LEVEL2
 import fr.sncf.osrd.sim_infra.api.*
+import fr.sncf.osrd.sim_infra.api.Route
 import fr.sncf.osrd.sim_infra.utils.routesOnBlock
 import fr.sncf.osrd.standalone_sim.result.ResultPosition
 import fr.sncf.osrd.standalone_sim.result.ResultSpeed
@@ -259,25 +264,16 @@ fun runScheduleMetadataExtractor(
     val routingRequirements =
         routingRequirements(
             pathOffsetBuilder,
-            simulator,
+            fullInfra,
             routePath,
             blockPath,
             closedSignalStops,
-            loadedSignalInfra,
-            blockInfra,
             envelopeWithStops,
-            rawInfra,
+            context,
             rollingStock,
         )
     val reportTrain =
-        makeSimpleReportTrain(
-            fullInfra,
-            envelope,
-            trainPath,
-            rollingStock,
-            schedule,
-            pathItemPositions,
-        )
+        makeSimpleReportTrain(envelope, trainPath, rollingStock, schedule, pathItemPositions)
     return CompleteReportTrain(
         reportTrain.positions,
         reportTrain.times,
@@ -359,16 +355,18 @@ fun getBlockOffsets(
 
 fun routingRequirements(
     pathOffsetBuilder: PathOffsetBuilder,
-    simulator: SignalingSimulator,
+    fullInfra: FullInfra,
     routePath: StaticIdxList<Route>,
     blockPath: StaticIdxList<Block>,
     sortedClosedSignalStops: List<PathStop>,
-    loadedSignalInfra: LoadedSignalInfra,
-    blockInfra: BlockInfra,
     envelope: EnvelopeInterpolate,
-    rawInfra: RawInfra,
+    // TODO: Required for ETCS (STDCM doesn't provide it currently, will have to eventually)
+    context: EnvelopeSimContext?,
     rollingStock: RollingStock,
 ): List<RoutingRequirement> {
+    val rawInfra = fullInfra.rawInfra
+    val blockInfra = fullInfra.blockInfra
+
     // count the number of zones in the path
     val zoneCount = routePath.sumOf { rawInfra.getRoutePath(it).size }
 
@@ -436,52 +434,29 @@ fun routingRequirements(
         // find the entry signal for this route. if there is no entry signal,
         // the set deadline is the start of the simulation
         if (blockInfra.blockStartAtBufferStop(firstRouteBlock)) return TimeDelta.ZERO
+        val etcsSimulator = context?.let { ETCSBrakingSimulatorImpl(it) }
 
-        // simulate signaling on the train's path with all zones free,
-        // until the start of the route, which is INCOMPATIBLE
-        val zoneStates = mutableListOf<ZoneStatus>()
-        for (i in 0 until zoneCount) zoneStates.add(ZoneStatus.CLEAR)
+        val singleEnvelope = envelope.rawEnvelopeIfSingle
+        assert(singleEnvelope != null) {
+            "A single envelope covering whole path is currently expected (used only through standalone simulation)"
+        }
 
-        // TODO: the complexity of finding route set deadlines is currently n^2 of the number of
-        //   blocks in the path. it can be improved upon by only simulating blocks which can
-        //   contain the route's limiting signal
-        val simulatedSignalStates =
-            simulator.evaluate(
-                rawInfra,
-                loadedSignalInfra,
-                blockInfra,
-                blockPath,
-                routePath.toList(),
-                routeStartBlockIndex,
-                zoneStates,
-                ZoneStatus.INCOMPATIBLE,
-            )
-
-        // find the first non-open signal on the path
-        // iterate backwards on blocks from blockIndex to 0, and on signals
-        val limitingSignalSpec =
-            findLimitingSignal(
-                loadedSignalInfra,
-                blockInfra,
-                simulator.sigModuleManager,
-                simulatedSignalStates,
+        val routeCriticalPos =
+            getRouteCriticalPos(
+                fullInfra,
+                routePath,
                 blockPath,
                 blockOffsets,
-                routeStartBlockIndex,
+                zoneCount,
                 signalingTrainStates,
-            ) ?: return null
-        val limitingBlock = blockPath[limitingSignalSpec.blockIndex]
-        val signal = blockInfra.getBlockSignals(limitingBlock)[limitingSignalSpec.signalIndex]
-        val limitingSignalOffsetInBlock =
-            blockInfra.getSignalsPositions(limitingBlock)[limitingSignalSpec.signalIndex].distance
+                singleEnvelope!!,
+                etcsSimulator,
+                routeStartBlockIndex,
+                firstRouteBlock,
+            )
 
-        val limitingBlockOffset = blockOffsets[limitingSignalSpec.blockIndex]
-        val signalSightDistance =
-            rawInfra.getSignalSightDistance(rawInfra.getPhysicalSignal(signal))
+        if (routeCriticalPos == null) return null
 
-        // find the location at which establishing the route becomes necessary
-        val routeCriticalPos =
-            limitingBlockOffset + limitingSignalOffsetInBlock - signalSightDistance
         var routeCriticalTime =
             envelope.interpolateArrivalAtClamp(routeCriticalPos.distance.meters).seconds
 
@@ -544,6 +519,140 @@ fun routingRequirements(
         res.add(RoutingRequirement(route, routeSetDeadline.seconds, zoneRequirements))
     }
     return res
+}
+
+private fun getRouteCriticalPos(
+    fullInfra: FullInfra,
+    routePath: StaticIdxList<Route>,
+    blockPath: StaticIdxList<Block>,
+    blockOffsets: OffsetArray<TravelledPath>,
+    zoneCount: Int,
+    signalingTrainStates: Map<LogicalSignalId, SignalingTrainState>,
+    envelope: Envelope,
+    etcsSimulator: ETCSBrakingSimulator?,
+    routeStartBlockIndex: Int,
+    firstRouteBlock: BlockId,
+): Offset<TravelledPath>? {
+    val blockInfra = fullInfra.blockInfra
+    val simulator = fullInfra.signalingSimulator
+
+    val sigSystemId = blockInfra.getBlockSignalingSystem(firstRouteBlock)
+    val isCurveBased = simulator.sigModuleManager.isCurveBased(sigSystemId)
+    return if (isCurveBased) {
+        if (
+            simulator.sigModuleManager.getName(sigSystemId) != ETCS_LEVEL2.id ||
+                etcsSimulator == null
+        ) {
+            TODO(
+                "Routing requirements for curve-based signals are only available for " +
+                    "ETCS_LEVEL2 and through StandaloneSimulation"
+            )
+        }
+        getEtcsRouteCriticalPos(
+            blockInfra,
+            blockOffsets,
+            envelope,
+            etcsSimulator,
+            routeStartBlockIndex,
+            firstRouteBlock,
+        )
+    } else {
+        getSightRouteCriticalPos(
+            fullInfra,
+            routePath,
+            blockPath,
+            blockOffsets,
+            signalingTrainStates,
+            zoneCount,
+            routeStartBlockIndex,
+        )
+    }
+}
+
+private fun getEtcsRouteCriticalPos(
+    blockInfra: BlockInfra,
+    blockOffsets: OffsetArray<TravelledPath>,
+    envelope: Envelope,
+    etcsSimulator: ETCSBrakingSimulator,
+    routeStartBlockIndex: Int,
+    firstRouteBlock: BlockId,
+): Offset<TravelledPath> {
+
+    // The braking curve targets the entry signal of the route's first block
+    val signalOffset =
+        blockOffsets[routeStartBlockIndex] +
+            blockInfra.getSignalsPositions(firstRouteBlock).first().distance
+
+    val eoa =
+        etcsSimulator
+            .computeEoaLocations(
+                envelope,
+                listOf(signalOffset),
+                listOf(true), // always routeDelimiter at the start of a route
+                EoaType.ROUTING,
+            )
+            .first()
+    val curvesList = etcsSimulator.computeStopBrakingCurves(envelope, listOf(eoa))
+    val reqPos = curvesList[eoa]!![IND]!!.brakingCurve.beginPos.meters
+    return Offset(reqPos)
+}
+
+private fun getSightRouteCriticalPos(
+    fullInfra: FullInfra,
+    routePath: StaticIdxList<Route>,
+    blockPath: StaticIdxList<Block>,
+    blockOffsets: OffsetArray<TravelledPath>,
+    signalingTrainStates: Map<LogicalSignalId, SignalingTrainState>,
+    zoneCount: Int,
+    routeStartBlockIndex: Int,
+): Offset<TravelledPath>? {
+    val simulator = fullInfra.signalingSimulator
+    val rawInfra = fullInfra.rawInfra
+    val loadedSignalInfra = fullInfra.loadedSignalInfra
+    val blockInfra = fullInfra.blockInfra
+
+    // simulate signaling on the train's path with all zones free,
+    // until the start of the route, which is INCOMPATIBLE
+    val zoneStates = MutableList(zoneCount) { ZoneStatus.CLEAR }
+
+    // TODO: the complexity of finding route set deadlines is currently n^2 of the
+    //   number of blocks in the path. it can be improved upon by only simulating blocks
+    //   which can contain the route's limiting signal
+    val simulatedSignalStates =
+        simulator.evaluate(
+            rawInfra,
+            loadedSignalInfra,
+            blockInfra,
+            blockPath,
+            routePath.toList(),
+            routeStartBlockIndex,
+            zoneStates,
+            ZoneStatus.INCOMPATIBLE,
+        )
+
+    // find the first non-open signal on the path
+    // iterate backwards on blocks from blockIndex to 0, and on signals
+    val limitingSignalSpec =
+        findLimitingSignal(
+            loadedSignalInfra,
+            blockInfra,
+            simulator.sigModuleManager,
+            simulatedSignalStates,
+            blockPath,
+            blockOffsets,
+            routeStartBlockIndex,
+            signalingTrainStates,
+        ) ?: return null
+    val limitingBlock = blockPath[limitingSignalSpec.blockIndex]
+    val signal = blockInfra.getBlockSignals(limitingBlock)[limitingSignalSpec.signalIndex]
+    val limitingSignalOffsetInBlock =
+        blockInfra.getSignalsPositions(limitingBlock)[limitingSignalSpec.signalIndex].distance
+
+    val limitingBlockOffset = blockOffsets[limitingSignalSpec.blockIndex]
+    val signalSightDistance = rawInfra.getSignalSightDistance(rawInfra.getPhysicalSignal(signal))
+
+    // find the location at which establishing the route becomes necessary
+    return limitingBlockOffset + limitingSignalOffsetInBlock - signalSightDistance
 }
 
 /** Create a zone requirement, which embeds all needed properties for conflict detection */

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulation.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulation.kt
@@ -26,7 +26,6 @@ import fr.sncf.osrd.envelope_sim_infra.computeMRSP
 import fr.sncf.osrd.path.implementations.ChunkPath
 import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.path.interfaces.TravelledPath
-import fr.sncf.osrd.path.legacy_objects.ElectricalProfileMapping
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
 import fr.sncf.osrd.railjson.schema.schedule.RJSAllowanceDistribution
 import fr.sncf.osrd.reporting.exceptions.ErrorType.ZeroLengthPath
@@ -57,7 +56,6 @@ fun runStandaloneSimulation(
     chunkPath: ChunkPath,
     routes: StaticIdxList<Route>,
     blockPath: StaticIdxList<Block>,
-    electricalProfileMap: ElectricalProfileMapping?,
     rollingStock: RollingStock,
     comfort: Comfort,
     constraintDistribution: RJSAllowanceDistribution,
@@ -149,7 +147,6 @@ fun runStandaloneSimulation(
     // and return a result matching the expected response format
     val maxEffortResult =
         makeSimpleReportTrain(
-            infra,
             maxEffortEnvelope,
             trainPath,
             rollingStock,
@@ -158,7 +155,6 @@ fun runStandaloneSimulation(
         )
     val provisionalResult =
         makeSimpleReportTrain(
-            infra,
             provisionalEnvelope,
             trainPath,
             rollingStock,

--- a/core/src/test/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulationTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulationTest.kt
@@ -14,7 +14,6 @@ import fr.sncf.osrd.envelope_sim.pipelines.maxSpeedEnvelopeFrom
 import fr.sncf.osrd.envelope_sim_infra.computeMRSP
 import fr.sncf.osrd.path.implementations.buildTrainPathFromChunkPath
 import fr.sncf.osrd.path.interfaces.TravelledPath
-import fr.sncf.osrd.path.legacy_objects.ElectricalProfileMapping
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
 import fr.sncf.osrd.railjson.schema.schedule.RJSAllowanceDistribution
 import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal.OPEN
@@ -83,7 +82,6 @@ class StandaloneSimulationTest {
                 chunkPath,
                 routes.toIdxList(),
                 blocks.toIdxList(),
-                ElectricalProfileMapping(),
                 rollingStock,
                 Comfort.STANDARD,
                 RJSAllowanceDistribution.LINEAR,
@@ -219,7 +217,6 @@ class StandaloneSimulationTest {
                 chunkPath,
                 routes.toIdxList(),
                 blocks.toIdxList(),
-                ElectricalProfileMapping(),
                 rollingStock,
                 Comfort.STANDARD,
                 testCase.allowanceDistribution,

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/FullSTDCMTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/FullSTDCMTests.kt
@@ -466,7 +466,6 @@ fun makeRequirementsFromPath(
             chunkPath,
             path.routes.map { infra.rawInfra.getRouteFromName(it) }.toIdxList(),
             path.blocks.map { infra.blockInfra.getBlockFromName(it)!! }.toIdxList(),
-            null,
             rollingStock,
             Comfort.STANDARD,
             RJSAllowanceDistribution.LINEAR,

--- a/tests/tests/test_train_schedule.py
+++ b/tests/tests/test_train_schedule.py
@@ -1197,6 +1197,123 @@ def test_etcs_spacing_req(
     assert spacing_req_zone_final["end_time"] == 1042849
 
 
+def test_etcs_routing_req(
+    etcs_scenario: Scenario, etcs_rolling_stock: int, session: Session
+):
+    """
+    routing requirements should:
+    * start at the same time the braking curve starts if stopping on closed signal
+      on the signal protecting said route
+    * end when leaving the zone (routes are "softly released": as soon as possible)
+    """
+    rolling_stock_response = session.get(
+        EDITOAST_URL + f"light_rolling_stock/{etcs_rolling_stock}"
+    )
+    etcs_rolling_stock_name = rolling_stock_response.json()["name"]
+    ts_response = session.post(
+        f"{EDITOAST_URL}timetable/{etcs_scenario.timetable}/train_schedules/",
+        json=[
+            {
+                "train_name": "slowdowns to respect MRSP and ETCS with intermediate stop",
+                "labels": [],
+                "rolling_stock_name": etcs_rolling_stock_name,
+                "start_time": "2024-01-01T07:00:00Z",
+                "path": [
+                    {"id": "zero", "track": "TA0", "offset": 0},
+                    {"id": "stop", "track": "TH0", "offset": 662_000},
+                    {"id": "last", "track": "TH1", "offset": 5_000_000},
+                ],
+                "schedule": [
+                    {"at": "zero", "stop_for": "P0D"},
+                    {"at": "stop", "stop_for": "PT10S", "reception_signal": "STOP"},
+                    {"at": "last", "stop_for": "P0D"},
+                ],
+                "margins": {"boundaries": [], "values": ["0%"]},
+                "initial_speed": 0,
+                "comfort": "STANDARD",
+                "constraint_distribution": "STANDARD",
+                "speed_limit_tag": "foo",
+                "power_restrictions": [],
+            }
+        ],
+    )
+
+    schedule = ts_response.json()[0]
+    schedule_id = schedule["id"]
+    ts_id_response = session.get(f"{EDITOAST_URL}train_schedule/{schedule_id}/")
+    ts_id_response.raise_for_status()
+    simu_response = session.get(
+        f"{EDITOAST_URL}train_schedule/{schedule_id}/simulation?infra_id={etcs_scenario.infra}"
+    )
+    simulation_final_output = simu_response.json()["final_output"]
+
+    assert len(simulation_final_output["positions"]) == len(
+        simulation_final_output["speeds"]
+    )
+
+    # To debug this test: please add a breakpoint then use front to display speed-space chart
+    # (activate Context for Slopes and Speed limits).
+
+    # route entry buffer_stop.0
+    routing_req_0 = simulation_final_output["routing_requirements"][0]
+    assert routing_req_0["route"] == "rt.buffer_stop.0->DA2"
+    assert routing_req_0["begin_time"] == 0
+    assert len(routing_req_0["zones"]) == 1
+    assert (
+        routing_req_0["zones"][0]["zone"]
+        == "zone.[DA2:DECREASING, buffer_stop.0:INCREASING]"
+    )
+    assert routing_req_0["zones"][0]["end_time"] == 103_241
+
+    routing_req_1 = simulation_final_output["routing_requirements"][1]
+    assert routing_req_1["route"] == "rt.DA2->DA5"
+    assert routing_req_1["begin_time"] == 65_194
+    assert len(routing_req_1["zones"]) == 7
+
+    # zone entry DA2 (triggered by SA2)
+    assert (
+        routing_req_1["zones"][0]["zone"]
+        == "zone.[DA2:INCREASING, DA3:DECREASING, DA7:INCREASING]"
+    )
+    assert routing_req_1["zones"][0]["end_time"] == 111_927
+
+    # zone entry DA3 (triggered by SA2)
+    assert (
+        routing_req_1["zones"][1]["zone"] == "zone.[DA3:INCREASING, DA6_1:DECREASING]"
+    )
+    assert routing_req_1["zones"][1]["end_time"] == 145_858
+
+    routing_req_3 = simulation_final_output["routing_requirements"][3]
+    assert routing_req_3["route"] == "rt.DC5->DD2"
+    assert routing_req_3["begin_time"] == 214_492
+    assert len(routing_req_3["zones"]) == 17
+    # zone entry DD0_8 (triggered by SC5)
+    assert (
+        routing_req_3["zones"][9]["zone"] == "zone.[DD0_8:INCREASING, DD0_9:DECREASING]"
+    )
+    assert routing_req_3["zones"][9]["end_time"] == 464_473
+
+    routing_req_6 = simulation_final_output["routing_requirements"][6]
+    assert routing_req_6["route"] == "rt.DG0->DH2"
+    # matches the start of the braking curve if stop on closed-signal SG0
+    assert routing_req_6["begin_time"] == 535_548
+    assert len(routing_req_6["zones"]) == 2
+    # zone entry DH1 (triggered by SG0)
+    assert routing_req_6["zones"][1]["zone"] == "zone.[DH1:INCREASING, DH2:DECREASING]"
+    assert routing_req_6["zones"][1]["end_time"] == 851_123
+
+    routing_req_7 = simulation_final_output["routing_requirements"][7]
+    assert routing_req_7["route"] == "rt.DH2->buffer_stop.7"
+    assert routing_req_7["begin_time"] == 813_526
+    assert len(routing_req_7["zones"]) == 4
+    # zone entry DH1_2 (triggered by SH2)
+    assert (
+        routing_req_7["zones"][3]["zone"]
+        == "zone.[DH1_2:INCREASING, buffer_stop.7:DECREASING]"
+    )
+    assert routing_req_7["zones"][3]["end_time"] == 1_042_849
+
+
 def test_etcs_schedule_braking_curves_endpoint(
     etcs_scenario: Scenario, etcs_rolling_stock: int, session: Session
 ):

--- a/tests/tests/test_train_schedule.py
+++ b/tests/tests/test_train_schedule.py
@@ -1197,6 +1197,9 @@ def test_etcs_spacing_req(
     assert spacing_req_zone_final["end_time"] == 1042849
 
 
+TIME_START_BRAKING_ETCS_FROM_BUFFER0_TO_SG0 = 535_548
+
+
 def test_etcs_routing_req(
     etcs_scenario: Scenario, etcs_rolling_stock: int, session: Session
 ):
@@ -1296,7 +1299,7 @@ def test_etcs_routing_req(
     routing_req_6 = simulation_final_output["routing_requirements"][6]
     assert routing_req_6["route"] == "rt.DG0->DH2"
     # matches the start of the braking curve if stop on closed-signal SG0
-    assert routing_req_6["begin_time"] == 535_548
+    assert routing_req_6["begin_time"] == TIME_START_BRAKING_ETCS_FROM_BUFFER0_TO_SG0
     assert len(routing_req_6["zones"]) == 2
     # zone entry DH1 (triggered by SG0)
     assert routing_req_6["zones"][1]["zone"] == "zone.[DH1:INCREASING, DH2:DECREASING]"
@@ -1312,6 +1315,104 @@ def test_etcs_routing_req(
         == "zone.[DH1_2:INCREASING, buffer_stop.7:DECREASING]"
     )
     assert routing_req_7["zones"][3]["end_time"] == 1_042_849
+
+
+def test_etcs_stop_at_requirements_eoa(
+    etcs_scenario: Scenario, etcs_rolling_stock: int, session: Session
+):
+    """
+    Stopping exactly at the EoA from routing and spacing requirements (route-delimiter signal): SG0
+
+    Reserving route/spacing at the moment of the stop (speed == 0km/h) for now.
+    Note: no specification was written on that, it could change (start of the braking curve?) when
+      the curves are a complete match.
+    """
+    rolling_stock_response = session.get(
+        EDITOAST_URL + f"light_rolling_stock/{etcs_rolling_stock}"
+    )
+    etcs_rolling_stock_name = rolling_stock_response.json()["name"]
+    ts_response = session.post(
+        f"{EDITOAST_URL}timetable/{etcs_scenario.timetable}/train_schedules/",
+        json=[
+            {
+                "train_name": "stop exactly at EoA from requirements",
+                "labels": [],
+                "rolling_stock_name": etcs_rolling_stock_name,
+                "start_time": "2024-01-01T07:00:00Z",
+                "path": [
+                    {"id": "zero", "track": "TA0", "offset": 0},
+                    {"id": "stop", "track": "TG0", "offset": 800_000},
+                    {"id": "last", "track": "TH1", "offset": 5_000_000},
+                ],
+                "schedule": [
+                    {"at": "zero", "stop_for": "P0D"},
+                    {"at": "stop", "stop_for": "PT10S", "reception_signal": "STOP"},
+                    {"at": "last", "stop_for": "P0D"},
+                ],
+                "margins": {"boundaries": [], "values": ["0%"]},
+                "initial_speed": 0,
+                "comfort": "STANDARD",
+                "constraint_distribution": "STANDARD",
+                "speed_limit_tag": "foo",
+                "power_restrictions": [],
+            }
+        ],
+    )
+
+    schedule = ts_response.json()[0]
+    schedule_id = schedule["id"]
+    ts_id_response = session.get(f"{EDITOAST_URL}train_schedule/{schedule_id}/")
+    ts_id_response.raise_for_status()
+    simu_response = session.get(
+        f"{EDITOAST_URL}train_schedule/{schedule_id}/simulation?infra_id={etcs_scenario.infra}"
+    )
+    simulation_final_output = simu_response.json()["final_output"]
+
+    assert len(simulation_final_output["positions"]) == len(
+        simulation_final_output["speeds"]
+    )
+
+    # To debug this test: please add a breakpoint then use front to display speed-space chart
+    # (activate Context for Slopes and Speed limits).
+
+    # Middle stop on SG0 braking curve
+    offset_start_brake_288_to_0 = 33_123_530
+    speed_start_brake_288_to_0 = _get_current_or_next_speed_at(
+        simulation_final_output, offset_start_brake_288_to_0
+    )
+    _assert_equal_speeds(speed_start_brake_288_to_0, MAX_SPEED_288)
+    assert (
+        _get_current_or_next_speed_at(
+            simulation_final_output, offset_start_brake_288_to_0 + 1
+        )
+        < speed_start_brake_288_to_0
+    )
+    time_start_brake_288_to_0 = _get_current_or_next_time_at(
+        simulation_final_output, offset_start_brake_288_to_0
+    )
+    # matching the reservation time for spacing and routing if no stop
+    assert time_start_brake_288_to_0 == TIME_START_BRAKING_ETCS_FROM_BUFFER0_TO_SG0
+
+    routing_req_6 = simulation_final_output["routing_requirements"][6]
+    assert routing_req_6["route"] == "rt.DG0->DH2"
+    assert routing_req_6["begin_time"] == 772_852
+    assert len(routing_req_6["zones"]) == 2
+    assert (
+        routing_req_6["zones"][0]["zone"]
+        == "zone.[DG0:INCREASING, DG1:DECREASING, DH0:INCREASING, DH1:DECREASING]"
+    )
+    assert routing_req_6["zones"][0]["end_time"] == 842_038
+    assert routing_req_6["zones"][1]["zone"] == "zone.[DH1:INCREASING, DH2:DECREASING]"
+    assert routing_req_6["zones"][1]["end_time"] == 864_137
+
+    # zone entry DG0 (triggered by SG0)
+    spacing_req_zone_stop = simulation_final_output["spacing_requirements"][31]
+    assert (
+        spacing_req_zone_stop["zone"]
+        == "zone.[DG0:INCREASING, DG1:DECREASING, DH0:INCREASING, DH1:DECREASING]"
+    )
+    assert spacing_req_zone_stop["begin_time"] == 772_852
+    assert spacing_req_zone_stop["end_time"] == 842_038
 
 
 def test_etcs_schedule_braking_curves_endpoint(
@@ -1491,3 +1592,10 @@ def _get_current_or_prev_speed_at(
         return simulation_final_output["speeds"][idx - 1]
     else:
         return simulation_final_output["speeds"][idx]
+
+
+def _get_current_or_next_time_at(
+    simulation_final_output: dict[str, Any], position: int
+) -> int:
+    idx = bisect.bisect_left(simulation_final_output["positions"], position)
+    return simulation_final_output["times"][idx]


### PR DESCRIPTION
Fix #11726

Also:
* minor refactor (first commit)
* ETCS requirements bug fix (4th commit)

🔍 review by commit should be easier

✅ Visual check by tinckering front (see diff following):
<img width="1402" height="786" alt="image" src="https://github.com/user-attachments/assets/81a7c6be-96bf-4879-ba52-ae829823d9a6" />


```diff
diff --git i/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useProjectedConflicts.ts w/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useProjectedConflicts.ts
index e0749cd66..852763c18 100644
--- i/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useProjectedConflicts.ts
+++ w/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useProjectedConflicts.ts
@@ -36,7 +36,9 @@ const useProjectedConflicts = (
   }, [path]);

   const conflictReqsByZone = useMemo(() => {
-    const reqs = conflicts.flatMap((conflict) => conflict.requirements);
+    const reqs = conflicts
+      .filter((conflict) => conflict.conflict_type == 'Routing')
+      .flatMap((conflict) => conflict.requirements);
     const reqsMap = new Map<string, ConflictRequirement[]>();
     // With paced trains, one zone can appear multiple times so we need to handle that.
     reqs.forEach((req) => {
```