### PR TITLE
front: fix osm track and 3d layers never displayed

### DIFF
--- a/front/src/applications/editor/Map.tsx
+++ b/front/src/applications/editor/Map.tsx
@@ -81,6 +81,8 @@ const MapUnplugged = ({
   const editorState = useSelector(getEditorState);
   const {
     showOSM,
+    showOSM3dBuildings,
+    showOSMtracksections,
     terrain3DExaggeration,
     mapSearchMarker,
     lineSearchCode,
@@ -293,7 +295,13 @@ const MapUnplugged = ({
             }}
           />
 
-          <OSMLayers mapStyle={mapStyle} showOSM={showOSM} hidePlatforms />
+          <OSMLayers
+            mapStyle={mapStyle}
+            showOSM={showOSM}
+            showOSM3dBuildings={showOSM3dBuildings}
+            showOSMtracksections={showOSMtracksections}
+            hidePlatforms
+          />
           <IGNLayers
             showIGNBDORTHO={showIGNBDORTHO}
             showIGNCadastre={showIGNCadastre}

--- a/front/src/common/Map/BaseMap.tsx
+++ b/front/src/common/Map/BaseMap.tsx
@@ -76,6 +76,8 @@ const BaseMap = ({
     mapStyle,
     layersSettings,
     showOSM,
+    showOSM3dBuildings,
+    showOSMtracksections,
     terrain3DExaggeration,
     mapSearchMarker,
     lineSearchCode,
@@ -163,6 +165,8 @@ const BaseMap = ({
         hidePlatforms={!layersSettings.platforms}
         mapStyle={mapStyle}
         showOSM={showOSM && mapIsLoaded}
+        showOSM3dBuildings={showOSM3dBuildings && mapIsLoaded}
+        showOSMtracksections={showOSMtracksections && mapIsLoaded}
       />
       <IGNLayers
         showIGNBDORTHO={showIGNBDORTHO}

--- a/front/src/common/Map/Layers/OSMLayers/OSM.tsx
+++ b/front/src/common/Map/Layers/OSMLayers/OSM.tsx
@@ -10,7 +10,7 @@ type OSMProps = {
   mapIsLoaded?: boolean;
   layerOrder?: number;
   mapStyle: MapStyle;
-  showOSM3dBuildings?: boolean;
+  showOSM3dBuildings: boolean;
 };
 
 type FullLayerProps = OrderedLayerProps & { key?: string };

--- a/front/src/common/Map/Layers/OSMLayers/OSMLayers.tsx
+++ b/front/src/common/Map/Layers/OSMLayers/OSMLayers.tsx
@@ -13,10 +13,18 @@ import TracksOSM from './TracksOSM';
 type OSMLayersProps = {
   mapStyle: MapStyle;
   showOSM: boolean;
-  hidePlatforms?: boolean;
+  showOSM3dBuildings: boolean;
+  showOSMtracksections: boolean;
+  hidePlatforms: boolean;
 };
 
-const OSMLayers = ({ mapStyle, showOSM, hidePlatforms }: OSMLayersProps) => (
+const OSMLayers = ({
+  mapStyle,
+  showOSM,
+  showOSM3dBuildings,
+  showOSMtracksections,
+  hidePlatforms,
+}: OSMLayersProps) => (
   <>
     <OpenStreetMapSource />
     <TerrainSource />
@@ -33,11 +41,19 @@ const OSMLayers = ({ mapStyle, showOSM, hidePlatforms }: OSMLayersProps) => (
       />
     )}
 
-    <TracksOSM colors={colors[mapStyle]} layerOrder={LAYER_GROUPS_ORDER[LAYERS.TRACKS_OSM.GROUP]} />
+    <TracksOSM
+      colors={colors[mapStyle]}
+      layerOrder={LAYER_GROUPS_ORDER[LAYERS.TRACKS_OSM.GROUP]}
+      showOSMtracksections={showOSMtracksections}
+    />
 
     {!showOSM ? null : (
       <>
-        <OSM mapStyle={mapStyle} layerOrder={LAYER_GROUPS_ORDER[LAYERS.BACKGROUND.GROUP]} />
+        <OSM
+          mapStyle={mapStyle}
+          layerOrder={LAYER_GROUPS_ORDER[LAYERS.BACKGROUND.GROUP]}
+          showOSM3dBuildings={showOSM3dBuildings}
+        />
         <Hillshade mapStyle={mapStyle} layerOrder={LAYER_GROUPS_ORDER[LAYERS.BACKGROUND.GROUP]} />
       </>
     )}

--- a/front/src/common/Map/Layers/OSMLayers/TracksOSM.tsx
+++ b/front/src/common/Map/Layers/OSMLayers/TracksOSM.tsx
@@ -7,7 +7,7 @@ import OrderedLayer from '../OrderedLayer';
 type TracksOSMProps = {
   colors: Theme;
   layerOrder: number;
-  showOSMtracksections?: boolean;
+  showOSMtracksections: boolean;
 };
 
 function TracksOSM({ colors, layerOrder, showOSMtracksections }: TracksOSMProps) {

--- a/front/src/common/Map/theme/OSMStyle.ts
+++ b/front/src/common/Map/theme/OSMStyle.ts
@@ -290,6 +290,28 @@ export function getOSMStyle(mapStyle: MapStyle): LayerProps[] {
       },
     },
     {
+      id: 'building-3d',
+      type: 'fill-extrusion',
+      source: 'openmaptiles',
+      'source-layer': 'building',
+      minzoom: 17,
+      layout: {
+        visibility: 'visible',
+      },
+      paint: {
+        'fill-extrusion-color': 'rgba(239, 236, 236, 1)',
+        'fill-extrusion-height': {
+          type: 'identity',
+          property: 'render_height',
+        },
+        'fill-extrusion-base': {
+          property: 'render_min_height',
+          type: 'identity',
+        },
+        'fill-extrusion-opacity': 0.8,
+      },
+    },
+    {
       id: 'housenumber',
       type: 'symbol',
       source: 'openmaptiles',


### PR DESCRIPTION
Close #13421
Close #13423

The osm track and osm layer components were not passed the boolean props toggling on the osm track and 3d building layers.

Fix this, and make the props non optional to avoid this issue popping up again.