### PR TITLE
editoast: migrate to utopia 5.4

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -587,7 +587,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http",
- "opentelemetry 0.30.0",
+ "opentelemetry",
  "pin-project-lite",
  "tower",
  "tracing",
@@ -863,9 +863,9 @@ name = "common"
 version = "0.1.0"
 dependencies = [
  "linkme",
- "opentelemetry 0.30.0",
+ "opentelemetry",
  "opentelemetry-semantic-conventions",
- "opentelemetry_sdk 0.30.0",
+ "opentelemetry_sdk",
  "rangemap",
  "serde",
  "serde_json",
@@ -955,7 +955,7 @@ dependencies = [
  "itertools",
  "lapin",
  "linkme",
- "opentelemetry 0.30.0",
+ "opentelemetry",
  "pretty_assertions",
  "rstest",
  "schemas",
@@ -1455,10 +1455,10 @@ dependencies = [
  "linkme",
  "mime",
  "mvt",
- "opentelemetry 0.30.0",
+ "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
- "opentelemetry_sdk 0.30.0",
+ "opentelemetry_sdk",
  "ordered-float",
  "osrdyne_client",
  "pathfinding",
@@ -2713,9 +2713,9 @@ dependencies = [
 
 [[package]]
 name = "json-patch"
-version = "4.0.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "159294d661a039f7644cea7e4d844e6b25aaf71c1ffe9d73a96d768c24b0faf4"
+checksum = "f300e415e2134745ef75f04562dd0145405c2f7fd92065db029ac4b16b57fe90"
 dependencies = [
  "jsonptr",
  "serde",
@@ -3225,28 +3225,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
-dependencies = [
- "futures-core",
- "futures-sink",
- "js-sys",
- "pin-project-lite",
- "thiserror 2.0.16",
-]
-
-[[package]]
 name = "opentelemetry-otlp"
-version = "0.31.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2366db2dca4d2ad033cad11e6ee42844fd727007af5ad04a1730f4cb8163bf"
+checksum = "dbee664a43e07615731afc539ca60c6d9f1a9425e25ca09c57bc36c87c55852b"
 dependencies = [
  "http",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "opentelemetry-proto",
- "opentelemetry_sdk 0.31.0",
+ "opentelemetry_sdk",
  "prost",
  "thiserror 2.0.17",
  "tokio",
@@ -3255,15 +3242,14 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.31.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+checksum = "2e046fd7660710fe5a05e8748e70d9058dc15c94ba914e7c4faa7c728f0e8ddc"
 dependencies = [
- "opentelemetry 0.31.0",
- "opentelemetry_sdk 0.31.0",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "prost",
  "tonic",
- "tonic-prost",
 ]
 
 [[package]]
@@ -3281,27 +3267,12 @@ dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "opentelemetry 0.30.0",
+ "opentelemetry",
  "percent-encoding",
  "rand 0.9.2",
  "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
-]
-
-[[package]]
-name = "opentelemetry_sdk"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
-dependencies = [
- "futures-channel",
- "futures-executor",
- "futures-util",
- "opentelemetry 0.31.0",
- "percent-encoding",
- "rand 0.9.2",
- "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -3758,30 +3729,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3792,9 +3739,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.14.1"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -3802,9 +3749,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.14.1"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
  "itertools",
@@ -5114,9 +5061,9 @@ checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
 
 [[package]]
 name = "tonic"
-version = "0.14.2"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7613188ce9f7df5bfe185db26c5814347d110db17920415cf2fbcad85e7203"
+checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
 dependencies = [
  "async-trait",
  "base64",
@@ -5129,24 +5076,13 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "sync_wrapper",
+ "prost",
  "tokio",
  "tokio-stream",
  "tower",
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "tonic-prost"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66bd50ad6ce1252d87ef024b3d64fe4c3cf54a86fb9ef4c631fdd0ded7aeaa67"
-dependencies = [
- "bytes",
- "prost",
- "tonic",
 ]
 
 [[package]]
@@ -5260,8 +5196,8 @@ checksum = "ddcf5959f39507d0d04d6413119c04f33b623f4f951ebcbdddddfad2d0623a9c"
 dependencies = [
  "js-sys",
  "once_cell",
- "opentelemetry 0.30.0",
- "opentelemetry_sdk 0.30.0",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "smallvec",
  "tracing",
  "tracing-core",
@@ -5277,7 +5213,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad59746664e45161625561841c0c9385565913c2d349fdd04cae89502fb5f30a"
 dependencies = [
  "http",
- "opentelemetry 0.30.0",
+ "opentelemetry",
  "tracing",
  "tracing-opentelemetry",
 ]
@@ -5441,9 +5377,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utoipa"
-version = "4.2.3"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5afb1a60e207dca502682537fefcfd9921e71d0b83e9576060f09abc6efab23"
+checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
 dependencies = [
  "indexmap",
  "serde",
@@ -5453,11 +5389,10 @@ dependencies = [
 
 [[package]]
 name = "utoipa-gen"
-version = "4.3.1"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20c24e8ab68ff9ee746aad22d39b5535601e6416d1b0feeabf78be986a5c4392"
+checksum = "6d79d08d92ab8af4c5e8a6da20c47ae3f61a0f1dabc1997cdf2d082b757ca08b"
 dependencies = [
- "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn 2.0.106",

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -133,7 +133,7 @@ tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 uom = { version = "0.36.0", default-features = false, features = ["f64", "si"] }
 url = { version = "2.5.7", features = ["serde"] }
 urlencoding = "2.1.3"
-utoipa = { version = "4.2.3", features = ["chrono", "uuid"] }
+utoipa = { version = "5.4.0", features = ["chrono", "uuid"] }
 uuid = { version = "1.18.1", features = ["serde", "v4"] }
 
 [dependencies]
@@ -187,7 +187,7 @@ image = { version = "0.25.6", default-features = false, features = [
 ] }
 inventory = "0.3"
 itertools.workspace = true
-json-patch = { version = "4.0.0", default-features = false, features = [
+json-patch = { version = "4.1.0", default-features = false, features = [
   "utoipa",
 ] }
 lapin.workspace = true

--- a/editoast/common/src/geometry.rs
+++ b/editoast/common/src/geometry.rs
@@ -3,43 +3,96 @@ use serde::Serialize;
 use utoipa::ToSchema;
 
 #[linkme::distributed_slice(crate::OPENAPI_SCHEMAS)]
-static _GEOJSON_SLICE_ITEM: crate::OpenApiSchemaSliceItem = <GeoJson as utoipa::ToSchema>::schema;
+static _GEOJSON_SLICE_ITEM: crate::OpenApiSchemaSliceItem = || {
+    (
+        <GeoJson as utoipa::ToSchema>::name(),
+        <GeoJson as utoipa::PartialSchema>::schema(),
+    )
+};
 #[linkme::distributed_slice(crate::OPENAPI_SCHEMAS)]
-static _GEOJSONPOINT_SLICE_ITEM: crate::OpenApiSchemaSliceItem =
-    <GeoJsonPoint as utoipa::ToSchema>::schema;
+static _GEOJSONPOINT_SLICE_ITEM: crate::OpenApiSchemaSliceItem = || {
+    (
+        <GeoJsonPoint as utoipa::ToSchema>::name(),
+        <GeoJsonPoint as utoipa::PartialSchema>::schema(),
+    )
+};
 #[linkme::distributed_slice(crate::OPENAPI_SCHEMAS)]
-static _GEOJSONMULTIPOINT_SLICE_ITEM: crate::OpenApiSchemaSliceItem =
-    <GeoJsonMultiPoint as utoipa::ToSchema>::schema;
+static _GEOJSONMULTIPOINT_SLICE_ITEM: crate::OpenApiSchemaSliceItem = || {
+    (
+        <GeoJsonMultiPoint as utoipa::ToSchema>::name(),
+        <GeoJsonMultiPoint as utoipa::PartialSchema>::schema(),
+    )
+};
 #[linkme::distributed_slice(crate::OPENAPI_SCHEMAS)]
-static _GEOJSONLINESTRING_SLICE_ITEM: crate::OpenApiSchemaSliceItem =
-    <GeoJsonLineString as utoipa::ToSchema>::schema;
+static _GEOJSONLINESTRING_SLICE_ITEM: crate::OpenApiSchemaSliceItem = || {
+    (
+        <GeoJsonLineString as utoipa::ToSchema>::name(),
+        <GeoJsonLineString as utoipa::PartialSchema>::schema(),
+    )
+};
 #[linkme::distributed_slice(crate::OPENAPI_SCHEMAS)]
-static _GEOJSONMULTILINESTRING_SLICE_ITEM: crate::OpenApiSchemaSliceItem =
-    <GeoJsonMultiLineString as utoipa::ToSchema>::schema;
+static _GEOJSONMULTILINESTRING_SLICE_ITEM: crate::OpenApiSchemaSliceItem = || {
+    (
+        <GeoJsonMultiLineString as utoipa::ToSchema>::name(),
+        <GeoJsonMultiLineString as utoipa::PartialSchema>::schema(),
+    )
+};
 #[linkme::distributed_slice(crate::OPENAPI_SCHEMAS)]
-static _GEOJSONPOLYGON_SLICE_ITEM: crate::OpenApiSchemaSliceItem =
-    <GeoJsonPolygon as utoipa::ToSchema>::schema;
+static _GEOJSONPOLYGON_SLICE_ITEM: crate::OpenApiSchemaSliceItem = || {
+    (
+        <GeoJsonPolygon as utoipa::ToSchema>::name(),
+        <GeoJsonPolygon as utoipa::PartialSchema>::schema(),
+    )
+};
 #[linkme::distributed_slice(crate::OPENAPI_SCHEMAS)]
-static _GEOJSONMULTIPOLYGON_SLICE_ITEM: crate::OpenApiSchemaSliceItem =
-    <GeoJsonMultiPolygon as utoipa::ToSchema>::schema;
+static _GEOJSONMULTIPOLYGON_SLICE_ITEM: crate::OpenApiSchemaSliceItem = || {
+    (
+        <GeoJsonMultiPolygon as utoipa::ToSchema>::name(),
+        <GeoJsonMultiPolygon as utoipa::PartialSchema>::schema(),
+    )
+};
 #[linkme::distributed_slice(crate::OPENAPI_SCHEMAS)]
-static _GEOJSONPOINTVALUE_SLICE_ITEM: crate::OpenApiSchemaSliceItem =
-    <GeoJsonPointValue as utoipa::ToSchema>::schema;
+static _GEOJSONPOINTVALUE_SLICE_ITEM: crate::OpenApiSchemaSliceItem = || {
+    (
+        <GeoJsonPointValue as utoipa::ToSchema>::name(),
+        <GeoJsonPointValue as utoipa::PartialSchema>::schema(),
+    )
+};
 #[linkme::distributed_slice(crate::OPENAPI_SCHEMAS)]
-static _GEOJSONMULTIPOINTVALUE_SLICE_ITEM: crate::OpenApiSchemaSliceItem =
-    <GeoJsonMultiPointValue as utoipa::ToSchema>::schema;
+static _GEOJSONMULTIPOINTVALUE_SLICE_ITEM: crate::OpenApiSchemaSliceItem = || {
+    (
+        <GeoJsonMultiPointValue as utoipa::ToSchema>::name(),
+        <GeoJsonMultiPointValue as utoipa::PartialSchema>::schema(),
+    )
+};
 #[linkme::distributed_slice(crate::OPENAPI_SCHEMAS)]
-static _GEOJSONLINESTRINGVALUE_SLICE_ITEM: crate::OpenApiSchemaSliceItem =
-    <GeoJsonLineStringValue as utoipa::ToSchema>::schema;
+static _GEOJSONLINESTRINGVALUE_SLICE_ITEM: crate::OpenApiSchemaSliceItem = || {
+    (
+        <GeoJsonLineStringValue as utoipa::ToSchema>::name(),
+        <GeoJsonLineStringValue as utoipa::PartialSchema>::schema(),
+    )
+};
 #[linkme::distributed_slice(crate::OPENAPI_SCHEMAS)]
-static _GEOJSONMULTILINESTRINGVALUE_SLICE_ITEM: crate::OpenApiSchemaSliceItem =
-    <GeoJsonMultiLineStringValue as utoipa::ToSchema>::schema;
+static _GEOJSONMULTILINESTRINGVALUE_SLICE_ITEM: crate::OpenApiSchemaSliceItem = || {
+    (
+        <GeoJsonMultiLineStringValue as utoipa::ToSchema>::name(),
+        <GeoJsonMultiLineStringValue as utoipa::PartialSchema>::schema(),
+    )
+};
 #[linkme::distributed_slice(crate::OPENAPI_SCHEMAS)]
-static _GEOJSONPOLYGONVALUE_SLICE_ITEM: crate::OpenApiSchemaSliceItem =
-    <GeoJsonPolygonValue as utoipa::ToSchema>::schema;
+static _GEOJSONPOLYGONVALUE_SLICE_ITEM: crate::OpenApiSchemaSliceItem = || {
+    (
+        <GeoJsonPolygonValue as utoipa::ToSchema>::name(),
+        <GeoJsonPolygonValue as utoipa::PartialSchema>::schema(),
+    )
+};
 #[linkme::distributed_slice(crate::OPENAPI_SCHEMAS)]
-static _GEOJSONMULTIPOLYGONVALUE_SLICE_ITEM: crate::OpenApiSchemaSliceItem =
-    <GeoJsonMultiPolygonValue as utoipa::ToSchema>::schema;
+static _GEOJSONMULTIPOLYGONVALUE_SLICE_ITEM: crate::OpenApiSchemaSliceItem = || {
+    (
+        <GeoJsonMultiPolygonValue as utoipa::ToSchema>::name(),
+        <GeoJsonMultiPolygonValue as utoipa::PartialSchema>::schema(),
+    )
+};
 
 // Schema of a GeoJson value meant to be used **exclusively** in the OpenApi
 /// A GeoJSON geometry item
@@ -91,19 +144,19 @@ pub enum GeoJsonMultiPolygon {
 }
 
 #[derive(Serialize, Deserialize, ToSchema, Debug, Clone, PartialEq)]
-pub struct GeoJsonPointValue(#[schema(min_items = 2, max_items = 2)] pub Vec<f64>);
+pub struct GeoJsonPointValue(pub Vec<f64>);
 
 #[derive(Serialize, ToSchema)]
-pub struct GeoJsonMultiPointValue(#[schema(min_items = 1)] Vec<GeoJsonPointValue>);
+pub struct GeoJsonMultiPointValue(Vec<GeoJsonPointValue>);
 
 #[derive(Serialize, Deserialize, ToSchema, Debug, Clone, PartialEq)]
-pub struct GeoJsonLineStringValue(#[schema(min_items = 2)] pub Vec<GeoJsonPointValue>);
+pub struct GeoJsonLineStringValue(pub Vec<GeoJsonPointValue>);
 
 #[derive(Serialize, ToSchema)]
-pub struct GeoJsonMultiLineStringValue(#[schema(min_items = 1)] Vec<GeoJsonLineStringValue>);
+pub struct GeoJsonMultiLineStringValue(Vec<GeoJsonLineStringValue>);
 
 #[derive(Serialize, ToSchema)]
-pub struct GeoJsonPolygonValue(#[schema(min_items = 1)] Vec<GeoJsonLineStringValue>);
+pub struct GeoJsonPolygonValue(Vec<GeoJsonLineStringValue>);
 
 #[derive(Serialize, ToSchema)]
-pub struct GeoJsonMultiPolygonValue(#[schema(min_items = 1)] Vec<GeoJsonPolygonValue>);
+pub struct GeoJsonMultiPolygonValue(Vec<GeoJsonPolygonValue>);

--- a/editoast/common/src/lib.rs
+++ b/editoast/common/src/lib.rs
@@ -12,7 +12,7 @@ use serde::Serialize;
 use utoipa::ToSchema;
 
 pub type OpenApiSchemaSliceItem = fn() -> (
-    &'static str,
+    std::borrow::Cow<'static, str>,
     utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
 );
 
@@ -29,7 +29,12 @@ pub fn setup_tracing_for_test() {
 }
 
 #[linkme::distributed_slice(OPENAPI_SCHEMAS)]
-static _SCHEMA: OpenApiSchemaSliceItem = <Version as utoipa::ToSchema>::schema;
+static _SCHEMA: OpenApiSchemaSliceItem = || {
+    (
+        <Version as utoipa::ToSchema>::name(),
+        <Version as utoipa::PartialSchema>::schema(),
+    )
+};
 
 #[derive(ToSchema, Serialize, Deserialize)]
 pub struct Version {

--- a/editoast/core_client/src/pathfinding.rs
+++ b/editoast/core_client/src/pathfinding.rs
@@ -135,12 +135,10 @@ pub enum PathfindingInputError {
 #[serde(tag = "error_type", rename_all = "snake_case")]
 pub enum PathfindingNotFound {
     NotFoundInBlocks {
-        #[schema(value_type = Vec<CoreTrackRange>)]
         track_section_ranges: Vec<TrackRange>,
         length: u64,
     },
     NotFoundInRoutes {
-        #[schema(value_type = Vec<CoreTrackRange>)]
         track_section_ranges: Vec<TrackRange>,
         length: u64,
     },
@@ -192,7 +190,6 @@ pub struct TrainPath {
     /// Route ranges, in order.
     pub routes: Vec<ObjectRange>,
     /// Track section ranges, in order.
-    #[schema(value_type = Vec<CoreTrackRange>)]
     pub track_section_ranges: Vec<TrackRange>,
 }
 

--- a/editoast/core_client/src/stdcm.rs
+++ b/editoast/core_client/src/stdcm.rs
@@ -29,7 +29,7 @@ pub struct Request {
 
     // Pathfinding inputs
     /// List of waypoints. Each waypoint is a list of track offset.
-    pub path_items: Vec<PathItem>,
+    pub path_items: Vec<PathItem>, // FIXME: the schema is referenced in the openapi, not the struct below
     /// The loading gauge of the rolling stock
     pub rolling_stock_loading_gauge: LoadingGaugeType,
     /// List of supported signaling systems
@@ -58,13 +58,13 @@ pub struct Request {
     #[schema(inline)]
     pub margin: Option<MarginValue>,
     /// List of planned work schedules
-    pub work_schedules: Vec<WorkSchedule>,
+    pub work_schedules: Vec<WorkSchedule>, // FIXME: the schema is referenced in the openapi, not the struct below
     /// List of applicable temporary speed limits between the train departure and arrival
     #[schema(inline)]
-    pub temporary_speed_limits: Vec<TemporarySpeedLimit>,
+    pub temporary_speed_limits: Vec<TemporarySpeedLimit>, // FIXME: the schema is referenced in the openapi, not the struct below
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Deserialize)]
+#[derive(Debug, Clone, Serialize, PartialEq, Deserialize, ToSchema)]
 pub struct PathItem {
     /// The track offsets of the path item
     pub locations: Vec<TrackOffset>,
@@ -75,7 +75,7 @@ pub struct PathItem {
 }
 
 /// Contains the data of a step timing, when it is specified
-#[derive(Debug, Clone, Serialize, PartialEq, Deserialize)]
+#[derive(Debug, Clone, Serialize, PartialEq, Deserialize, ToSchema)]
 pub struct StepTimingData {
     /// Time the train should arrive at this point
     pub arrival_time: DateTime<Utc>,
@@ -86,7 +86,7 @@ pub struct StepTimingData {
 }
 
 /// Lighter description of a work schedule, with only the relevant information for core
-#[derive(Debug, Clone, Serialize, PartialEq, Deserialize)]
+#[derive(Debug, Clone, Serialize, PartialEq, Deserialize, ToSchema)]
 pub struct WorkSchedule {
     /// Start time as a time delta from the stdcm start time in ms
     pub start_time: u64,
@@ -97,13 +97,11 @@ pub struct WorkSchedule {
 }
 
 /// Lighter description of a work schedule with only the relevant information for core
-
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
 pub struct TemporarySpeedLimit {
     /// Speed limitation in m/s
     pub speed_limit: f64,
     /// Track ranges on which the speed limitation applies
-    #[schema(value_type = Vec<CoreTrackRange>)]
     pub track_ranges: Vec<TrackRange>,
 }
 

--- a/editoast/database/src/db_connection_pool.rs
+++ b/editoast/database/src/db_connection_pool.rs
@@ -1,6 +1,8 @@
 mod tracing_instrumentation;
 
-use std::hash::{DefaultHasher, Hash, Hasher};
+use std::hash::DefaultHasher;
+use std::hash::Hash;
+use std::hash::Hasher;
 use std::ops::Deref;
 use std::ops::DerefMut;
 use std::sync::Arc;

--- a/editoast/database/src/db_connection_pool.rs
+++ b/editoast/database/src/db_connection_pool.rs
@@ -1,8 +1,5 @@
 mod tracing_instrumentation;
 
-use std::hash::DefaultHasher;
-use std::hash::Hash;
-use std::hash::Hasher;
 use std::ops::Deref;
 use std::ops::DerefMut;
 use std::sync::Arc;
@@ -13,7 +10,6 @@ use diesel::sql_query;
 use diesel_async::AsyncConnection;
 use diesel_async::AsyncPgConnection;
 use diesel_async::RunQueryDsl;
-use diesel_async::SimpleAsyncConnection;
 use diesel_async::pooled_connection::AsyncDieselConnectionManager;
 use diesel_async::pooled_connection::ManagerConfig;
 use diesel_async::pooled_connection::deadpool::Object;
@@ -25,7 +21,6 @@ use futures_util::FutureExt as _;
 use openssl::ssl::SslConnector;
 use openssl::ssl::SslMethod;
 use openssl::ssl::SslVerifyMode;
-use tokio::sync::Mutex;
 use tokio::sync::OwnedRwLockWriteGuard;
 use tokio::sync::RwLock;
 use tracing::trace;
@@ -36,7 +31,7 @@ use crate::DatabaseError;
 pub type DbConnectionConfig = AsyncDieselConnectionManager<AsyncPgConnection>;
 
 #[cfg(any(test, feature = "testing"))]
-static TEMPLATE_CREATION_MUTEX: Mutex<()> = Mutex::const_new(());
+static TEMPLATE_CREATION_MUTEX: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 #[cfg(any(test, feature = "testing"))]
 fn get_migrations() -> (diesel_async_migrations::EmbeddedMigrations, String) {
@@ -47,7 +42,9 @@ fn get_migrations() -> (diesel_async_migrations::EmbeddedMigrations, String) {
         hash_data.push((name, up, down))
     }
 
-    let mut hasher = DefaultHasher::new();
+    use std::hash::Hash as _;
+    use std::hash::Hasher as _;
+    let mut hasher = std::hash::DefaultHasher::new();
     hash_data.hash(&mut hasher);
     let hash = format!("{}", hasher.finish());
 
@@ -101,6 +98,7 @@ async fn template_creation(osrd_conn: DbConnection) -> Result<String, Box<dyn st
         let template_pool = create_connection_pool(template_url_postgres.clone(), 1)?;
         let mut conn = template_pool.get().await?;
 
+        use diesel_async::SimpleAsyncConnection as _;
         let sql_content = include_str!("../sql/init_test_db.sql");
         conn.batch_execute(sql_content).await?;
     }

--- a/editoast/editoast_derive/src/openapi_schema.rs
+++ b/editoast/editoast_derive/src/openapi_schema.rs
@@ -11,7 +11,7 @@ pub(super) fn openapi_schema(input: &DeriveInput) -> darling::Result<TokenStream
     Ok(quote::quote! {
         #[doc(hidden)]
         #[linkme::distributed_slice(common::OPENAPI_SCHEMAS)]
-        static #static_name: common::OpenApiSchemaSliceItem = <#name as utoipa::ToSchema>::schema;
+        static #static_name: common::OpenApiSchemaSliceItem = || (<#name as utoipa::ToSchema>::name(), <#name as utoipa::PartialSchema>::schema());
 
         #input
     })

--- a/editoast/editoast_derive/src/route.rs
+++ b/editoast/editoast_derive/src/route.rs
@@ -28,7 +28,7 @@ pub(super) fn route(input: &ItemFn) -> darling::Result<TokenStream> {
         #[doc(hidden)]
         #[linkme::distributed_slice(crate::views::router::OPENAPI_ROUTES)]
         static #static_name: crate::views::router::OpenApiRouteSliceItem = |type_name: &str| {
-            (type_name == std::any::type_name_of_val(&#name)).then_some(|_tag: Option<&str>| {
+            (type_name == std::any::type_name_of_val(&#name)).then_some(|| {
                 use utoipa::Path;
                 use utoipa::__dev::Tags; // private API, but can't find another way :/
                 (<#path_name as Path>::methods(), <#path_name as Path>::operation(), <#path_name as Tags>::tags())

--- a/editoast/editoast_derive/src/route.rs
+++ b/editoast/editoast_derive/src/route.rs
@@ -28,7 +28,11 @@ pub(super) fn route(input: &ItemFn) -> darling::Result<TokenStream> {
         #[doc(hidden)]
         #[linkme::distributed_slice(crate::views::router::OPENAPI_ROUTES)]
         static #static_name: crate::views::router::OpenApiRouteSliceItem = |type_name: &str| {
-            (type_name == std::any::type_name_of_val(&#name)).then_some(<#path_name as utoipa::Path>::path_item)
+            (type_name == std::any::type_name_of_val(&#name)).then_some(|_tag: Option<&str>| {
+                use utoipa::Path;
+                use utoipa::__dev::Tags; // private API, but can't find another way :/
+                (<#path_name as Path>::methods(), <#path_name as Path>::operation(), <#path_name as Tags>::tags())
+            })
         };
 
         #input

--- a/editoast/editoast_models/src/rolling_stock/train_main_category.rs
+++ b/editoast/editoast_models/src/rolling_stock/train_main_category.rs
@@ -13,7 +13,9 @@ use diesel::serialize::ToSql;
 use serde::Deserialize;
 use serde::Serialize;
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, FromSqlRow, AsExpression)]
+#[derive(
+    Debug, Clone, PartialEq, Serialize, Deserialize, FromSqlRow, AsExpression, utoipa::ToSchema,
+)]
 #[diesel(sql_type = sql_types::TrainMainCategory)]
 pub struct TrainMainCategory(pub schemas::rolling_stock::TrainMainCategory);
 
@@ -42,7 +44,7 @@ impl Deref for TrainMainCategory {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, utoipa::ToSchema)]
 pub struct TrainMainCategories(pub Vec<TrainMainCategory>);
 
 impl From<Vec<Option<TrainMainCategory>>> for TrainMainCategories {

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -10898,68 +10898,8 @@ components:
       description: A location on the path of a train
     PathItemLocation:
       oneOf:
-      - type: object
-        required:
-        - track
-        - offset
-        properties:
-          offset:
-            type: integer
-            format: int64
-            description: Offset in mm
-            minimum: 0
-          track:
-            oneOf:
-            - type: string
-              maxLength: 255
-              minLength: 1
-            description: Track section identifier
-      - allOf:
-        - oneOf:
-          - type: object
-            required:
-            - operational_point
-            properties:
-              operational_point:
-                oneOf:
-                - type: string
-                  maxLength: 255
-                  minLength: 1
-                description: The object id of an operational point
-          - type: object
-            required:
-            - trigram
-            properties:
-              secondary_code:
-                type:
-                - string
-                - 'null'
-                description: An optional secondary code to identify a more specific location
-              trigram:
-                oneOf:
-                - type: string
-                  minLength: 1
-                description: The operational point trigram
-          - type: object
-            required:
-            - uic
-            properties:
-              secondary_code:
-                type:
-                - string
-                - 'null'
-                description: An optional secondary code to identify a more specific location
-              uic:
-                type: integer
-                format: int32
-                description: The [UIC](https://en.wikipedia.org/wiki/List_of_UIC_country_codes) code of an operational point
-                minimum: 0
-        - type: object
-          properties:
-            track_reference:
-              oneOf:
-              - type: 'null'
-              - $ref: '#/components/schemas/TrackReference'
+      - $ref: '#/components/schemas/TrackOffset'
+      - $ref: '#/components/schemas/OperationalPointReference'
       description: The location of a path waypoint
     PathProperties:
       type: object

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -12436,11 +12436,19 @@ components:
         switches_directions:
           type: array
           items:
-            type: array
-            items: false
-            prefixItems:
-            - type: string
-            - type: string
+            type: object
+            required:
+            - switch_id
+            - group_id
+            properties:
+              group_id:
+                type: string
+                maxLength: 255
+                minLength: 1
+              switch_id:
+                type: string
+                maxLength: 255
+                minLength: 1
         track_ranges:
           type: array
           items:

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -275,12 +275,6 @@ paths:
               schema:
                 type: string
                 format: binary
-        '404':
-          description: Document not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalError'
     delete:
       tags:
       - documents
@@ -296,12 +290,6 @@ paths:
       responses:
         '204':
           description: The document was deleted
-        '404':
-          description: Document not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalError'
   /electrical_profile_set:
     get:
       tags:
@@ -358,12 +346,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ElectricalProfileSetData'
-        '404':
-          description: The requested electrical profile set was not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalError'
     delete:
       tags:
       - electrical_profiles
@@ -378,12 +360,6 @@ paths:
       responses:
         '204':
           description: The electrical profile was deleted successfully
-        '404':
-          description: The requested electrical profile was not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalError'
   /electrical_profile_set/{electrical_profile_set_id}/level_order:
     get:
       tags:
@@ -414,12 +390,6 @@ paths:
                 - 25000V
                 - 22500V
                 - 20000V
-        '404':
-          description: The requested electrical profile set was not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalError'
   /fonts/{font}/{glyph}:
     get:
       tags:
@@ -2112,12 +2082,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProjectWithStudies'
-        '404':
-          description: The requested project was not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalError'
     delete:
       tags:
       - projects
@@ -2133,12 +2097,6 @@ paths:
       responses:
         '204':
           description: The project was deleted successfully
-        '404':
-          description: The requested project was not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalError'
     patch:
       tags:
       - projects
@@ -2165,12 +2123,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProjectWithStudies'
-        '404':
-          description: The requested project was not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalError'
   /projects/{project_id}/studies:
     get:
       tags:
@@ -2273,12 +2225,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StudyResponse'
-        '404':
-          description: The requested study was not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalError'
     delete:
       tags:
       - studies
@@ -2300,12 +2246,6 @@ paths:
       responses:
         '204':
           description: The study was deleted successfully
-        '404':
-          description: The requested study was not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalError'
     patch:
       tags:
       - studies
@@ -2338,12 +2278,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StudyResponse'
-        '404':
-          description: The requested study was not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalError'
   /projects/{project_id}/studies/{study_id}/scenarios:
     get:
       tags:
@@ -2467,12 +2401,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ScenarioResponse'
-        '404':
-          description: The requested scenario was not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalError'
     delete:
       tags:
       - scenarios
@@ -2500,12 +2428,6 @@ paths:
       responses:
         '204':
           description: The scenario was deleted successfully
-        '404':
-          description: The requested scenario was not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalError'
     patch:
       tags:
       - scenarios
@@ -2543,12 +2465,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ScenarioResponse'
-        '404':
-          description: The requested scenario was not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalError'
   /projects/{project_id}/studies/{study_id}/scenarios/{scenario_id}/macro_nodes:
     get:
       tags:
@@ -2599,12 +2515,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MacroNodeListResponse'
-        '404':
-          description: The requested scenario was not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalError'
     post:
       tags:
       - scenarios
@@ -2678,12 +2588,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MacroNodeResponse'
-        '404':
-          description: The macro node was not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalError'
     put:
       tags:
       - scenarios
@@ -2726,12 +2630,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MacroNodeResponse'
-        '404':
-          description: The macro node was not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalError'
     delete:
       tags:
       - scenarios
@@ -2764,12 +2662,6 @@ paths:
       responses:
         '204':
           description: The macro node was deleted successfully
-        '404':
-          description: The macro node was not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalError'
   /projects/{project_id}/studies/{study_id}/scenarios/{scenario_id}/macro_notes/{note_id}:
     get:
       tags:

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -4930,19 +4930,26 @@ components:
           minLength: 1
       additionalProperties: false
     BoundingBox:
-      type: array
-      items:
-        type: array
-        items: false
-        prefixItems:
-        - type: number
-          format: double
-        - type: number
-          format: double
-        description: A bounding box
+      type: object
       description: A bounding box
-      maxItems: 2
-      minItems: 2
+      required:
+      - min_lon
+      - min_lat
+      - max_lon
+      - max_lat
+      properties:
+        max_lat:
+          type: number
+          format: double
+        max_lon:
+          type: number
+          format: double
+        min_lat:
+          type: number
+          format: double
+        min_lon:
+          type: number
+          format: double
     BufferStop:
       type: object
       required:

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.3
+openapi: 3.1.0
 info:
   title: OSRD Editoast
   description: All HTTP endpoints of Editoast
@@ -80,6 +80,10 @@ paths:
                 items:
                   type: integer
                   format: int64
+              propertyNames:
+                type: string
+                enum:
+                - infra
         required: true
       responses:
         '200':
@@ -101,6 +105,10 @@ paths:
                       id:
                         type: integer
                         format: int64
+                propertyNames:
+                  type: string
+                  enum:
+                  - infra
   /authz/me/groups:
     get:
       tags:
@@ -138,6 +146,10 @@ paths:
                 items:
                   type: integer
                   format: int64
+              propertyNames:
+                type: string
+                enum:
+                - infra
         required: true
       responses:
         '200':
@@ -162,6 +174,10 @@ paths:
                       resource_id:
                         type: integer
                         format: int64
+                propertyNames:
+                  type: string
+                  enum:
+                  - infra
   /authz/{resource_type}/{resource_id}:
     get:
       tags:
@@ -193,7 +209,6 @@ paths:
           type: integer
           format: int64
           default: 100
-          nullable: true
           maximum: 100
           minimum: 1
       responses:
@@ -245,7 +260,6 @@ paths:
           application/octet-stream:
             schema:
               type: string
-              format: binary
         required: true
       responses:
         '201':
@@ -269,12 +283,11 @@ paths:
           format: int64
       responses:
         '200':
-          description: The document's binary content
+          description: Document content
           content:
             application/octet-stream:
               schema:
                 type: string
-                format: binary
     delete:
       tags:
       - documents
@@ -381,6 +394,8 @@ paths:
                 type: object
                 additionalProperties:
                   $ref: '#/components/schemas/LevelValues'
+                propertyNames:
+                  type: string
               example:
                 1500V:
                 - A
@@ -443,7 +458,6 @@ paths:
           type: integer
           format: int64
           default: 1000
-          nullable: true
           maximum: 1000
           minimum: 1
       responses:
@@ -611,6 +625,39 @@ paths:
                 $ref: '#/components/schemas/Infra'
         '404':
           description: Infra ID not found
+    put:
+      tags:
+      - infra
+      summary: Rename an infra
+      parameters:
+      - name: infra_id
+        in: path
+        description: An existing infra ID
+        required: true
+        schema:
+          type: integer
+          format: int64
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - name
+              properties:
+                name:
+                  type: string
+                  description: The new name to give the infra
+        required: true
+      responses:
+        '200':
+          description: The infra has been renamed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Infra'
+        '404':
+          description: Infra ID not found
     post:
       tags:
       - infra
@@ -649,39 +696,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/InfraObject'
-    put:
-      tags:
-      - infra
-      summary: Rename an infra
-      parameters:
-      - name: infra_id
-        in: path
-        description: An existing infra ID
-        required: true
-        schema:
-          type: integer
-          format: int64
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-              - name
-              properties:
-                name:
-                  type: string
-                  description: The new name to give the infra
-        required: true
-      responses:
-        '200':
-          description: The infra has been renamed
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Infra'
-        '404':
-          description: Infra ID not found
     delete:
       tags:
       - infra
@@ -737,6 +751,20 @@ paths:
                   type: array
                   items:
                     type: string
+                propertyNames:
+                  type: string
+                  enum:
+                  - TrackSection
+                  - Signal
+                  - SpeedSection
+                  - Detector
+                  - NeutralSection
+                  - Switch
+                  - SwitchType
+                  - BufferStop
+                  - Route
+                  - OperationalPoint
+                  - Electrification
   /infra/{infra_id}/auto_fixes:
     get:
       tags:
@@ -862,7 +890,6 @@ paths:
           type: integer
           format: int64
           default: 100
-          nullable: true
           maximum: 100
           minimum: 1
       - name: level
@@ -880,16 +907,13 @@ paths:
         description: The type of error to filter on
         required: false
         schema:
-          allOf:
-          - $ref: '#/components/schemas/InfraErrorTypeLabel'
-          nullable: true
+          $ref: '#/components/schemas/InfraErrorTypeLabel'
       - name: object_id
         in: query
         description: Filter errors and warnings related to a given object
         required: false
         schema:
           type: string
-          nullable: true
       responses:
         '200':
           description: A paginated list of errors
@@ -1009,8 +1033,13 @@ paths:
                   track_names:
                     type: object
                     additionalProperties:
+                      type:
+                      - string
+                      - 'null'
+                    propertyNames:
                       type: string
-                      nullable: true
+                      maxLength: 255
+                      minLength: 1
   /infra/{infra_id}/objects/{object_type}:
     post:
       tags:
@@ -1135,7 +1164,6 @@ paths:
         schema:
           type: integer
           format: int32
-          nullable: true
           minimum: 0
       requestBody:
         content:
@@ -1221,8 +1249,11 @@ paths:
             schema:
               type: object
               additionalProperties:
+                type:
+                - string
+                - 'null'
+              propertyNames:
                 type: string
-                nullable: true
         required: true
       responses:
         '200':
@@ -1243,6 +1274,8 @@ paths:
                       items:
                         type: string
                       uniqueItems: true
+                    propertyNames:
+                      type: string
                   routes:
                     type: array
                     items:
@@ -1279,6 +1312,7 @@ paths:
                   oneOf:
                   - allOf:
                     - $ref: '#/components/schemas/RoutePath'
+                      description: RoutePath contains N track ranges with the N-1 switches found inbetween, in the order they appear on the route
                     - type: object
                       required:
                       - type
@@ -1287,6 +1321,7 @@ paths:
                           type: string
                           enum:
                           - Computed
+                    description: RoutePath contains N track ranges with the N-1 switches found inbetween, in the order they appear on the route
                   - type: object
                     required:
                     - type
@@ -1451,8 +1486,9 @@ paths:
     get:
       tags:
       - infra
-      summary: Returns the set of voltages for a given infra and/or rolling_stocks modes.
-      description: If include_rolling_stocks_modes is true, it returns also rolling_stocks modes.
+      summary: |-
+        Returns the set of voltages for a given infra and/or rolling_stocks modes.
+        If include_rolling_stocks_modes is true, it returns also rolling_stocks modes.
       parameters:
       - name: infra_id
         in: path
@@ -1538,6 +1574,8 @@ paths:
                     type: object
                     additionalProperties:
                       type: string
+                    propertyNames:
+                      type: string
                   scheme:
                     type: string
                     example: xyz
@@ -1594,12 +1632,11 @@ paths:
           minimum: 0
       responses:
         '200':
-          description: Successful Response
+          description: ''
           content:
             application/octet-stream:
               schema:
                 type: string
-                format: binary
   /light_rolling_stock:
     get:
       tags:
@@ -1621,7 +1658,6 @@ paths:
           type: integer
           format: int64
           default: 1000
-          nullable: true
           maximum: 1000
           minimum: 1
       responses:
@@ -1720,6 +1756,9 @@ paths:
                 type: object
                 additionalProperties:
                   $ref: '#/components/schemas/OccupancyBlocksPacedTrainResult'
+                propertyNames:
+                  type: integer
+                  format: int64
   /paced_train/project_path:
     post:
       tags:
@@ -1748,6 +1787,9 @@ paths:
                 type: object
                 additionalProperties:
                   $ref: '#/components/schemas/ProjectPathPacedTrainResult'
+                propertyNames:
+                  type: integer
+                  format: int64
   /paced_train/project_path_op:
     post:
       tags:
@@ -1764,9 +1806,10 @@ paths:
               - operational_points_distances
               properties:
                 electrical_profile_set_id:
-                  type: integer
+                  type:
+                  - integer
+                  - 'null'
                   format: int64
-                  nullable: true
                 infra_id:
                   type: integer
                   format: int64
@@ -1786,28 +1829,34 @@ paths:
                       - operational_point
                       properties:
                         operational_point:
-                          type: string
-                          maxLength: 255
-                          minLength: 1
+                          oneOf:
+                          - type: string
+                            maxLength: 255
+                            minLength: 1
+                          description: The object id of an operational point
                     - type: object
                       required:
                       - trigram
                       properties:
                         secondary_code:
-                          type: string
+                          type:
+                          - string
+                          - 'null'
                           description: An optional secondary code to identify a more specific location
-                          nullable: true
                         trigram:
-                          type: string
-                          minLength: 1
+                          oneOf:
+                          - type: string
+                            minLength: 1
+                          description: The operational point trigram
                     - type: object
                       required:
                       - uic
                       properties:
                         secondary_code:
-                          type: string
+                          type:
+                          - string
+                          - 'null'
                           description: An optional secondary code to identify a more specific location
-                          nullable: true
                         uic:
                           type: integer
                           format: int32
@@ -1829,12 +1878,16 @@ paths:
                 type: object
                 additionalProperties:
                   $ref: '#/components/schemas/ProjectPathPacedTrainResult'
+                propertyNames:
+                  type: integer
+                  format: int64
   /paced_train/simulation_summary:
     post:
       tags:
       - paced_train
-      summary: Associate each paced train id with its simulation summaries response
-      description: 'If the simulation fails, it associates the reason: pathfinding failed or running time failed'
+      summary: |-
+        Associate each paced train id with its simulation summaries response
+        If the simulation fails, it associates the reason: pathfinding failed or running time failed
       requestBody:
         content:
           application/json:
@@ -1845,9 +1898,10 @@ paths:
               - ids
               properties:
                 electrical_profile_set_id:
-                  type: integer
+                  type:
+                  - integer
+                  - 'null'
                   format: int64
-                  nullable: true
                 ids:
                   type: array
                   items:
@@ -1867,6 +1921,9 @@ paths:
                 type: object
                 additionalProperties:
                   $ref: '#/components/schemas/PacedTrainSimulationSummaryResult'
+                propertyNames:
+                  type: integer
+                  format: int64
   /paced_train/{id}:
     get:
       tags:
@@ -1922,8 +1979,10 @@ paths:
                     properties:
                       interval:
                         $ref: '#/components/schemas/PositiveDuration'
+                        description: Time between two occurrences, an ISO 8601 format is expected
                       time_window:
                         $ref: '#/components/schemas/PositiveDuration'
+                        description: Duration of the paced train, an ISO 8601 format is expected
         required: true
       responses:
         '204':
@@ -1952,7 +2011,6 @@ paths:
         required: false
         schema:
           type: string
-          nullable: true
       responses:
         '200':
           description: The path
@@ -1986,13 +2044,11 @@ paths:
         schema:
           type: integer
           format: int64
-          nullable: true
       - name: exception_key
         in: query
         required: false
         schema:
           type: string
-          nullable: true
       responses:
         '200':
           description: Simulation Output
@@ -2021,7 +2077,6 @@ paths:
           type: integer
           format: int64
           default: 1000
-          nullable: true
           maximum: 1000
           minimum: 1
       - name: ordering
@@ -2151,7 +2206,6 @@ paths:
           type: integer
           format: int64
           default: 1000
-          nullable: true
           maximum: 1000
           minimum: 1
       - name: ordering
@@ -2312,7 +2366,6 @@ paths:
           type: integer
           format: int64
           default: 1000
-          nullable: true
           maximum: 1000
           minimum: 1
       - name: ordering
@@ -2505,7 +2558,6 @@ paths:
           type: integer
           format: int64
           default: 100
-          nullable: true
           maximum: 100
           minimum: 1
       responses:
@@ -2968,16 +3020,16 @@ paths:
       description: |-
         # Payload
 
-        {
-        "object": string,
-        "query": query,
-        "dry": boolean, # default: false
-        }
+            {
+                "object": string,
+                "query": query,
+                "dry": boolean, # default: false
+            }
 
         Where:
         - `object` can be any search object declared in `search.yml`
         - `query` is a JSON document which can be deserialized into a [search::SearchAst].
-        Check out examples below.
+          Check out examples below.
 
         # Response
 
@@ -3000,9 +3052,9 @@ paths:
 
         * The railway station PNO: `["=", ["trigram"], "pno"]`
         * The railway stations with either "Paris" or "Lyon" (or both) in their name:
-        `["or", ["search", ["name"], "Paris"], ["search", ["name"], "Lyon"]]`
+          `["or", ["search", ["name"], "Paris"], ["search", ["name"], "Lyon"]]`
         * All railway stations with "Paris" in their name but not PNO :
-        `["and", ["search", ["name"], "Paris"], ["not", ["=", ["trigram"], "pno"]]]`
+          `["and", ["search", ["name"], "Paris"], ["not", ["=", ["trigram"], "pno"]]]`
 
         See [search::SearchAst] for a more detailed view of the query language.
       parameters:
@@ -3021,7 +3073,6 @@ paths:
           type: integer
           format: int64
           default: 1000
-          nullable: true
           maximum: 1000
           minimum: 1
       requestBody:
@@ -3063,11 +3114,13 @@ paths:
                   type: object
                   properties:
                     name:
-                      type: string
-                      nullable: true
+                      type:
+                      - string
+                      - 'null'
                     speed_limit_tag:
-                      type: string
-                      nullable: true
+                      type:
+                      - string
+                      - 'null'
                 timetable_id:
                   type: integer
                   format: int64
@@ -3099,7 +3152,8 @@ paths:
                         end:
                           type: string
                         train:
-                          allOf:
+                          oneOf:
+                          - type: 'null'
                           - type: object
                             required:
                             - train_name
@@ -3110,7 +3164,9 @@ paths:
                                 format: date-time
                               train_name:
                                 type: string
-                          nullable: true
+                          description: |-
+                            `train` is `None` if no similar train
+                            was found for the segment; otherwise, it is `Some`.
   /sprites/signaling_systems:
     get:
       tags:
@@ -3200,7 +3256,6 @@ paths:
           type: integer
           format: int64
           default: 1000
-          nullable: true
           maximum: 1000
           minimum: 1
       responses:
@@ -3254,7 +3309,6 @@ paths:
           type: integer
           format: int64
           default: 1000
-          nullable: true
           maximum: 1000
           minimum: 1
       responses:
@@ -3409,7 +3463,6 @@ paths:
         schema:
           type: integer
           format: int64
-          nullable: true
       responses:
         '200':
           description: List of conflicts
@@ -3447,7 +3500,6 @@ paths:
           type: integer
           format: int64
           default: 200
-          nullable: true
           maximum: 200
           minimum: 1
       responses:
@@ -3526,7 +3578,6 @@ paths:
           type: integer
           format: int64
           default: 200
-          nullable: true
           maximum: 200
           minimum: 1
       - name: infra_id
@@ -3541,7 +3592,6 @@ paths:
         schema:
           type: integer
           format: int64
-          nullable: true
       responses:
         '200':
           description: The paginated list of timetable requirements
@@ -3587,7 +3637,6 @@ paths:
           type: integer
           format: int64
           default: 1000
-          nullable: true
           maximum: 1000
           minimum: 1
       responses:
@@ -3634,7 +3683,6 @@ paths:
           type: integer
           format: int64
           default: 1000
-          nullable: true
           maximum: 1000
           minimum: 1
       responses:
@@ -3656,13 +3704,13 @@ paths:
     post:
       tags:
       - stdcm
-      summary: This function computes a STDCM and returns the result.
-      description: |-
+      summary: |-
+        This function computes a STDCM and returns the result.
         It first checks user authorization, then retrieves timetable, infrastructure,
         train schedules, and rolling stock data, and runs train simulations.
         The result contains the simulation output based on the train schedules
         and infrastructure provided.
-
+      description: |-
         If the simulation fails, the function uses a virtual train to detect conflicts
         with existing train schedules. It then returns both the conflict information
         and the pathfinding result from the virtual train's simulation.
@@ -3686,8 +3734,9 @@ paths:
         description: If true, extra payloads are returned to help with debugging
         required: false
         schema:
-          type: boolean
-          nullable: true
+          type:
+          - boolean
+          - 'null'
       requestBody:
         content:
           application/json:
@@ -3702,63 +3751,71 @@ paths:
                 comfort:
                   $ref: '#/components/schemas/Comfort'
                 electrical_profile_set_id:
-                  type: integer
+                  type:
+                  - integer
+                  - 'null'
                   format: int64
-                  nullable: true
                 loading_gauge_type:
-                  allOf:
+                  oneOf:
+                  - type: 'null'
                   - $ref: '#/components/schemas/LoadingGaugeType'
-                  nullable: true
                 margin:
-                  type: string
+                  type:
+                  - string
+                  - 'null'
                   description: Can be a percentage `X%`, a time in minutes per 100 kilometer `Xmin/100km`
                   example:
                   - 5%
                   - 2min/100km
-                  nullable: true
                 max_speed:
-                  type: number
+                  type:
+                  - number
+                  - 'null'
                   format: double
-                  description: |-
-                    Maximum speed of the consist in km/h
+                  description: |2-
+                     Maximum speed of the consist in km/h
                     Velocity in m·s⁻¹
-                  nullable: true
                 maximum_departure_delay:
-                  type: integer
+                  type:
+                  - integer
+                  - 'null'
                   format: int64
                   description: |-
                     By how long we can shift the departure time in milliseconds
                     Deprecated, first step data should be used instead
-                  nullable: true
                   minimum: 0
                 maximum_run_time:
-                  type: integer
+                  type:
+                  - integer
+                  - 'null'
                   format: int64
                   description: |-
                     Specifies how long the total run time can be in milliseconds
                     Deprecated, first step data should be used instead
-                  nullable: true
                   minimum: 0
                 rolling_stock_id:
                   type: integer
                   format: int64
                 speed_limit_tags:
-                  type: string
+                  type:
+                  - string
+                  - 'null'
                   description: Train categories for speed limits
-                  nullable: true
                 start_time:
-                  type: string
+                  type:
+                  - string
+                  - 'null'
                   format: date-time
                   description: Deprecated, first step arrival time should be used instead
-                  nullable: true
                 steps:
                   type: array
                   items:
                     $ref: '#/components/schemas/PathfindingItem'
                 temporary_speed_limit_group_id:
-                  type: integer
+                  type:
+                  - integer
+                  - 'null'
                   format: int64
-                  nullable: true
                 time_gap_after:
                   type: integer
                   format: int64
@@ -3778,27 +3835,31 @@ paths:
                     available at least that many milliseconds before its passage.
                   minimum: 0
                 total_length:
-                  type: number
+                  type:
+                  - number
+                  - 'null'
                   format: double
-                  description: |-
-                    Total length of the consist in meters
+                  description: |2-
+                     Total length of the consist in meters
                     Length in m
-                  nullable: true
                 total_mass:
-                  type: number
+                  type:
+                  - number
+                  - 'null'
                   format: double
-                  description: |-
-                    Total mass of the consist
+                  description: |2-
+                     Total mass of the consist
                     Mass in kg
-                  nullable: true
                 towed_rolling_stock_id:
-                  type: integer
+                  type:
+                  - integer
+                  - 'null'
                   format: int64
-                  nullable: true
                 work_schedule_group_id:
-                  type: integer
+                  type:
+                  - integer
+                  - 'null'
                   format: int64
-                  nullable: true
         required: true
       responses:
         '201':
@@ -3815,9 +3876,9 @@ paths:
                   - status
                   properties:
                     core_payload:
-                      allOf:
+                      oneOf:
+                      - type: 'null'
                       - $ref: '#/components/schemas/StdcmRequest'
-                      nullable: true
                     departure_time:
                       type: string
                       format: date-time
@@ -3834,9 +3895,9 @@ paths:
                   - status
                   properties:
                     core_payload:
-                      allOf:
+                      oneOf:
+                      - type: 'null'
                       - $ref: '#/components/schemas/StdcmRequest'
-                      nullable: true
                     status:
                       type: string
                       enum:
@@ -3847,9 +3908,9 @@ paths:
                   - status
                   properties:
                     core_payload:
-                      allOf:
+                      oneOf:
+                      - type: 'null'
                       - $ref: '#/components/schemas/StdcmRequest'
-                      nullable: true
                     error:
                       $ref: '#/components/schemas/SimulationResponse'
                     status:
@@ -3884,7 +3945,6 @@ paths:
           type: integer
           format: int64
           default: 200
-          nullable: true
           maximum: 200
           minimum: 1
       responses:
@@ -3955,7 +4015,6 @@ paths:
           type: integer
           format: int64
           default: 50
-          nullable: true
           maximum: 50
           minimum: 1
       responses:
@@ -4103,6 +4162,9 @@ paths:
                   type: array
                   items:
                     $ref: '#/components/schemas/SignalUpdate'
+                propertyNames:
+                  type: integer
+                  format: int64
   /train_schedule/project_path:
     post:
       tags:
@@ -4130,6 +4192,9 @@ paths:
                   type: array
                   items:
                     $ref: '#/components/schemas/SpaceTimeCurve'
+                propertyNames:
+                  type: integer
+                  format: int64
   /train_schedule/project_path_op:
     post:
       tags:
@@ -4146,9 +4211,10 @@ paths:
               - operational_points_distances
               properties:
                 electrical_profile_set_id:
-                  type: integer
+                  type:
+                  - integer
+                  - 'null'
                   format: int64
-                  nullable: true
                 infra_id:
                   type: integer
                   format: int64
@@ -4168,28 +4234,34 @@ paths:
                       - operational_point
                       properties:
                         operational_point:
-                          type: string
-                          maxLength: 255
-                          minLength: 1
+                          oneOf:
+                          - type: string
+                            maxLength: 255
+                            minLength: 1
+                          description: The object id of an operational point
                     - type: object
                       required:
                       - trigram
                       properties:
                         secondary_code:
-                          type: string
+                          type:
+                          - string
+                          - 'null'
                           description: An optional secondary code to identify a more specific location
-                          nullable: true
                         trigram:
-                          type: string
-                          minLength: 1
+                          oneOf:
+                          - type: string
+                            minLength: 1
+                          description: The operational point trigram
                     - type: object
                       required:
                       - uic
                       properties:
                         secondary_code:
-                          type: string
+                          type:
+                          - string
+                          - 'null'
                           description: An optional secondary code to identify a more specific location
-                          nullable: true
                         uic:
                           type: integer
                           format: int32
@@ -4213,12 +4285,16 @@ paths:
                   type: array
                   items:
                     $ref: '#/components/schemas/SpaceTimeCurve'
+                propertyNames:
+                  type: integer
+                  format: int64
   /train_schedule/simulation_summary:
     post:
       tags:
       - train_schedule
-      summary: Associate each train id with its simulation summary response
-      description: 'If the simulation fails, it associates the reason: pathfinding failed or running time failed'
+      summary: |-
+        Associate each train id with its simulation summary response
+        If the simulation fails, it associates the reason: pathfinding failed or running time failed
       requestBody:
         content:
           application/json:
@@ -4229,9 +4305,10 @@ paths:
               - ids
               properties:
                 electrical_profile_set_id:
-                  type: integer
+                  type:
+                  - integer
+                  - 'null'
                   format: int64
-                  nullable: true
                 ids:
                   type: array
                   items:
@@ -4251,17 +4328,20 @@ paths:
                 type: object
                 additionalProperties:
                   $ref: '#/components/schemas/SimulationSummaryResult'
+                propertyNames:
+                  type: integer
+                  format: int64
   /train_schedule/track_occupancy:
     post:
       tags:
       - train_schedule
-      summary: Calculates when and for how long trains occupy track sections at a specific operational point.
-      description: |-
+      summary: |-
+        Calculates when and for how long trains occupy track sections at a specific operational point.
         Returns a map of track sections to their occupation periods, containing:
         - time_begin: Start of occupation
         - duration: Length of occupation (includes stops)
         - train_schedule_id: Train schedule ID
-
+      description: |-
         If a path item ID is provided, it uses schedule data to determine stop duration and location.
         If not, it infers the position and time based on track offsets and interpolation.
       requestBody:
@@ -4275,9 +4355,10 @@ paths:
               - infra_id
               properties:
                 electrical_profile_set_id:
-                  type: integer
+                  type:
+                  - integer
+                  - 'null'
                   format: int64
-                  nullable: true
                 infra_id:
                   type: integer
                   format: int64
@@ -4314,6 +4395,8 @@ paths:
                       train_schedule_id:
                         type: integer
                         format: int64
+                propertyNames:
+                  type: string
   /train_schedule/{id}:
     get:
       tags:
@@ -4530,8 +4613,9 @@ paths:
               type: object
               properties:
                 work_schedule_group_name:
-                  type: string
-                  nullable: true
+                  type:
+                  - string
+                  - 'null'
         required: true
       responses:
         '200':
@@ -4566,7 +4650,6 @@ paths:
           type: integer
           format: int64
           default: 100
-          nullable: true
           maximum: 100
           minimum: 1
       - name: id
@@ -4699,10 +4782,12 @@ paths:
                       format: date-time
                       description: The date and time when the work schedule takes effect.
                     type:
-                      type: string
-                      enum:
-                      - CATENARY
-                      - TRACK
+                      oneOf:
+                      - type: string
+                        enum:
+                        - CATENARY
+                        - TRACK
+                      description: The type of the work schedule.
   /worker_load:
     post:
       tags:
@@ -4721,10 +4806,11 @@ paths:
                   format: int64
                   description: The infra id of the worker to load
                 timetable_id:
-                  type: integer
+                  type:
+                  - integer
+                  - 'null'
                   format: int64
                   description: The timetable id to load, if any
-                  nullable: true
         required: true
       responses:
         '204':
@@ -4847,12 +4933,12 @@ components:
       type: array
       items:
         type: array
-        items:
-          allOf:
-          - type: number
-            format: double
-          - type: number
-            format: double
+        items: false
+        prefixItems:
+        - type: number
+          format: double
+        - type: number
+          format: double
         description: A bounding box
       description: A bounding box
       maxItems: 2
@@ -4868,7 +4954,8 @@ components:
           type: object
           properties:
             sncf:
-              allOf:
+              oneOf:
+              - type: 'null'
               - type: object
                 required:
                 - kp
@@ -4876,7 +4963,6 @@ components:
                   kp:
                     type: string
                 additionalProperties: false
-              nullable: true
           additionalProperties: false
         id:
           type: string
@@ -4945,10 +5031,12 @@ components:
       - requirements
       properties:
         conflict_type:
-          type: string
-          enum:
-          - Spacing
-          - Routing
+          oneOf:
+          - type: string
+            enum:
+            - Spacing
+            - Routing
+          description: Type of the conflict
         end_time:
           type: string
           format: date-time
@@ -5032,10 +5120,12 @@ components:
             - requirements
             properties:
               conflict_type:
-                type: string
-                enum:
-                - Spacing
-                - Routing
+                oneOf:
+                - type: string
+                  enum:
+                  - Spacing
+                  - Routing
+                description: Type of the conflict
               end_time:
                 type: string
                 format: date-time
@@ -5122,15 +5212,18 @@ components:
           minimum: 0
         direction:
           $ref: '#/components/schemas/Direction'
+          description: The direction of the range.
         end:
           type: integer
           format: int64
           description: The end of the range in mm.
           minimum: 0
         track_section:
-          type: string
-          maxLength: 255
-          minLength: 1
+          oneOf:
+          - type: string
+            maxLength: 255
+            minLength: 1
+          description: The track section identifier.
     Curve:
       type: object
       required:
@@ -5405,7 +5498,8 @@ components:
                 minimum: 0
               description: List of times (in ms) associated to a position
         indication:
-          allOf:
+          oneOf:
+          - type: 'null'
           - type: object
             required:
             - positions
@@ -5434,7 +5528,6 @@ components:
                   format: int64
                   minimum: 0
                 description: List of times (in ms) associated to a position
-          nullable: true
         permitted_speed:
           type: object
           required:
@@ -8747,15 +8840,17 @@ components:
       - power_restriction_code
       properties:
         comfort:
-          allOf:
+          oneOf:
+          - type: 'null'
           - $ref: '#/components/schemas/Comfort'
-          nullable: true
         electrical_profile_level:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         power_restriction_code:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
       additionalProperties: false
     EffortCurves:
       type: object
@@ -8769,6 +8864,8 @@ components:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ModeEffortCurves'
+          propertyNames:
+            type: string
       additionalProperties: false
     ElectricalProfile:
       type: object
@@ -8811,6 +8908,8 @@ components:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/LevelValues'
+          propertyNames:
+            type: string
         levels:
           type: array
           items:
@@ -8819,9 +8918,10 @@ components:
       type: object
       properties:
         electrical_profile_set_id:
-          type: integer
+          type:
+          - integer
+          - 'null'
           format: int64
-          nullable: true
     Electrification:
       type: object
       required:
@@ -8931,9 +9031,9 @@ components:
           type: number
           format: double
         refill_law:
-          allOf:
+          oneOf:
+          - type: 'null'
           - $ref: '#/components/schemas/RefillLaw'
-          nullable: true
         soc:
           type: number
           format: double
@@ -8984,18 +9084,35 @@ components:
       properties:
         gamma_emergency:
           $ref: '#/components/schemas/SpeedIntervalValueCurve'
+          description: 'A_brake_emergency: the emergency deceleration curve (values > 0 m/s²)'
         gamma_normal_service:
           $ref: '#/components/schemas/SpeedIntervalValueCurve'
+          description: 'A_brake_normal_service: the normal service deceleration curve used to compute guidance curve (values > 0 m/s²)'
         gamma_service:
           $ref: '#/components/schemas/SpeedIntervalValueCurve'
+          description: 'A_brake_service: the full service deceleration curve (values > 0 m/s²)'
         k_dry:
           $ref: '#/components/schemas/SpeedIntervalValueCurve'
+          description: |-
+            Kdry_rst: the rolling stock deceleration correction factors for dry rails
+            Boundaries should be the same as gammaEmergency
+            Values (no unit) should be contained in [0, 1]
         k_n_neg:
           $ref: '#/components/schemas/SpeedIntervalValueCurve'
+          description: |-
+            Kn-: the correction acceleration factor on normal service deceleration in negative gradients
+            Values (in m/s²) should be contained in [0, 10]
         k_n_pos:
           $ref: '#/components/schemas/SpeedIntervalValueCurve'
+          description: |-
+            Kn+: the correction acceleration factor on normal service deceleration in positive gradients
+            Values (in m/s²) should be contained in [0, 10]
         k_wet:
           $ref: '#/components/schemas/SpeedIntervalValueCurve'
+          description: |-
+            Kwet_rst: the rolling stock deceleration correction factors for wet rails
+            Boundaries should be the same as gammaEmergency
+            Values (no unit) should be contained in [0, 1]
         t_be:
           type: number
           format: double
@@ -9017,8 +9134,9 @@ components:
       type: object
       properties:
         exception_key:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
     GeoJson:
       oneOf:
       - $ref: '#/components/schemas/GeoJsonPoint'
@@ -9032,8 +9150,8 @@ components:
       oneOf:
       - type: object
         required:
-        - type
         - coordinates
+        - type
         properties:
           coordinates:
             $ref: '#/components/schemas/GeoJsonLineStringValue'
@@ -9049,8 +9167,8 @@ components:
       oneOf:
       - type: object
         required:
-        - type
         - coordinates
+        - type
         properties:
           coordinates:
             $ref: '#/components/schemas/GeoJsonMultiLineStringValue'
@@ -9066,8 +9184,8 @@ components:
       oneOf:
       - type: object
         required:
-        - type
         - coordinates
+        - type
         properties:
           coordinates:
             $ref: '#/components/schemas/GeoJsonMultiPointValue'
@@ -9083,8 +9201,8 @@ components:
       oneOf:
       - type: object
         required:
-        - type
         - coordinates
+        - type
         properties:
           coordinates:
             $ref: '#/components/schemas/GeoJsonMultiPolygonValue'
@@ -9100,8 +9218,8 @@ components:
       oneOf:
       - type: object
         required:
-        - type
         - coordinates
+        - type
         properties:
           coordinates:
             $ref: '#/components/schemas/GeoJsonPointValue'
@@ -9118,8 +9236,8 @@ components:
       oneOf:
       - type: object
         required:
-        - type
         - coordinates
+        - type
         properties:
           coordinates:
             $ref: '#/components/schemas/GeoJsonPolygonValue'
@@ -9201,9 +9319,10 @@ components:
           type: string
           format: date-time
         generated_version:
-          type: integer
+          type:
+          - integer
+          - 'null'
           format: int64
-          nullable: true
         id:
           type: integer
           format: int64
@@ -9230,8 +9349,9 @@ components:
         - is_warning
         properties:
           field:
-            type: string
-            nullable: true
+            type:
+            - string
+            - 'null'
           is_warning:
             type: boolean
           obj_id:
@@ -9654,6 +9774,8 @@ components:
         context:
           type: object
           additionalProperties: {}
+          propertyNames:
+            type: string
         message:
           type: string
         status:
@@ -9705,6 +9827,8 @@ components:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/LightModeEffortCurves'
+          propertyNames:
+            type: string
       additionalProperties: false
     LightElectricalProfileSet:
       type: object
@@ -9752,8 +9876,9 @@ components:
       - other_categories
       properties:
         base_power_class:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         comfort_acceleration:
           type: number
           format: double
@@ -9769,9 +9894,9 @@ components:
           items:
             $ref: '#/components/schemas/EnergySource'
         etcs_brake_params:
-          allOf:
+          oneOf:
+          - type: 'null'
           - $ref: '#/components/schemas/EtcsBrakeParams'
-          nullable: true
         id:
           type: integer
           format: int64
@@ -9795,9 +9920,9 @@ components:
           format: double
           description: Velocity in m·s⁻¹
         metadata:
-          allOf:
+          oneOf:
+          - type: 'null'
           - $ref: '#/components/schemas/RollingStockMetadata'
-          nullable: true
         name:
           type: string
         other_categories:
@@ -9805,6 +9930,8 @@ components:
         power_restrictions:
           type: object
           additionalProperties:
+            type: string
+          propertyNames:
             type: string
         primary_category:
           $ref: '#/components/schemas/TrainMainCategory'
@@ -9892,8 +10019,9 @@ components:
           type: integer
           format: int64
         full_name:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         labels:
           $ref: '#/components/schemas/Tags'
         path_item_key:
@@ -9905,8 +10033,9 @@ components:
           type: integer
           format: int64
         trigram:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
     MacroNodeListResponse:
       allOf:
       - $ref: '#/components/schemas/PaginationStats'
@@ -9932,8 +10061,9 @@ components:
           type: integer
           format: int64
         full_name:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         id:
           type: integer
           format: int64
@@ -9948,8 +10078,9 @@ components:
           type: integer
           format: int64
         trigram:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
     MacroNoteResponse:
       type: object
       required:
@@ -10052,7 +10183,8 @@ components:
           type: object
           properties:
             neutral_sncf:
-              allOf:
+              oneOf:
+              - type: 'null'
               - type: object
                 required:
                 - announcement
@@ -10075,7 +10207,6 @@ components:
                     items:
                       $ref: '#/components/schemas/Sign'
                 additionalProperties: false
-              nullable: true
           additionalProperties: false
         id:
           type: string
@@ -10115,9 +10246,11 @@ components:
           description: The end of the range in mm.
           minimum: 0
         id:
-          type: string
-          maxLength: 255
-          minLength: 1
+          oneOf:
+          - type: string
+            maxLength: 255
+            minLength: 1
+          description: The object identifier.
     ObjectRef:
       type: object
       required:
@@ -10151,9 +10284,10 @@ components:
       - path
       properties:
         electrical_profile_set_id:
-          type: integer
+          type:
+          - integer
+          - 'null'
           format: int64
-          nullable: true
         ids:
           type: array
           items:
@@ -10179,6 +10313,8 @@ components:
             type: array
             items:
               $ref: '#/components/schemas/SignalUpdate'
+          propertyNames:
+            type: string
         paced_train:
           type: array
           items:
@@ -10265,7 +10401,8 @@ components:
           type: object
           properties:
             identifier:
-              allOf:
+              oneOf:
+              - type: 'null'
               - type: object
                 required:
                 - name
@@ -10279,9 +10416,9 @@ components:
                     format: int32
                     minimum: 0
                 additionalProperties: false
-              nullable: true
             sncf:
-              allOf:
+              oneOf:
+              - type: 'null'
               - type: object
                 required:
                 - ci
@@ -10304,7 +10441,6 @@ components:
                   trigram:
                     type: string
                 additionalProperties: false
-              nullable: true
           additionalProperties: false
         id:
           type: string
@@ -10315,16 +10451,18 @@ components:
           items:
             $ref: '#/components/schemas/OperationalPointPart'
         weight:
-          type: integer
+          type:
+          - integer
+          - 'null'
           format: int32
-          nullable: true
           minimum: 0
       additionalProperties: false
     OperationalPointExtensions:
       type: object
       properties:
         identifier:
-          allOf:
+          oneOf:
+          - type: 'null'
           - type: object
             required:
             - name
@@ -10338,9 +10476,9 @@ components:
                 format: int32
                 minimum: 0
             additionalProperties: false
-          nullable: true
         sncf:
-          allOf:
+          oneOf:
+          - type: 'null'
           - type: object
             required:
             - ci
@@ -10363,7 +10501,6 @@ components:
               trigram:
                 type: string
             additionalProperties: false
-          nullable: true
       additionalProperties: false
     OperationalPointPart:
       type: object
@@ -10375,7 +10512,8 @@ components:
           type: object
           properties:
             sncf:
-              allOf:
+              oneOf:
+              - type: 'null'
               - type: object
                 required:
                 - kp
@@ -10383,7 +10521,6 @@ components:
                   kp:
                     type: string
                 additionalProperties: false
-              nullable: true
           additionalProperties: false
         position:
           type: number
@@ -10401,28 +10538,34 @@ components:
           - operational_point
           properties:
             operational_point:
-              type: string
-              maxLength: 255
-              minLength: 1
+              oneOf:
+              - type: string
+                maxLength: 255
+                minLength: 1
+              description: The object id of an operational point
         - type: object
           required:
           - trigram
           properties:
             secondary_code:
-              type: string
+              type:
+              - string
+              - 'null'
               description: An optional secondary code to identify a more specific location
-              nullable: true
             trigram:
-              type: string
-              minLength: 1
+              oneOf:
+              - type: string
+                minLength: 1
+              description: The operational point trigram
         - type: object
           required:
           - uic
           properties:
             secondary_code:
-              type: string
+              type:
+              - string
+              - 'null'
               description: An optional secondary code to identify a more specific location
-              nullable: true
             uic:
               type: integer
               format: int32
@@ -10431,9 +10574,9 @@ components:
       - type: object
         properties:
           track_reference:
-            allOf:
+            oneOf:
+            - type: 'null'
             - $ref: '#/components/schemas/TrackReference'
-            nullable: true
     OptionsChangeGroup:
       type: object
       required:
@@ -10470,8 +10613,10 @@ components:
             properties:
               interval:
                 $ref: '#/components/schemas/PositiveDuration'
+                description: Time between two occurrences, an ISO 8601 format is expected
               time_window:
                 $ref: '#/components/schemas/PositiveDuration'
+                description: Duration of the paced train, an ISO 8601 format is expected
     PacedTrainException:
       allOf:
       - type: object
@@ -10483,40 +10628,30 @@ components:
         - key
         properties:
           constraint_distribution:
-            allOf:
-            - $ref: '#/components/schemas/ConstraintDistributionChangeGroup'
+            $ref: '#/components/schemas/ConstraintDistributionChangeGroup'
           disabled:
             type: boolean
           initial_speed:
-            allOf:
-            - $ref: '#/components/schemas/InitialSpeedChangeGroup'
+            $ref: '#/components/schemas/InitialSpeedChangeGroup'
           key:
             type: string
             description: Unique key for the exception within the paced train, required and generated by the frontend.
           labels:
-            allOf:
-            - $ref: '#/components/schemas/LabelsChangeGroup'
+            $ref: '#/components/schemas/LabelsChangeGroup'
           options:
-            allOf:
-            - $ref: '#/components/schemas/OptionsChangeGroup'
+            $ref: '#/components/schemas/OptionsChangeGroup'
           path_and_schedule:
-            allOf:
-            - $ref: '#/components/schemas/PathAndScheduleChangeGroup'
+            $ref: '#/components/schemas/PathAndScheduleChangeGroup'
           rolling_stock:
-            allOf:
-            - $ref: '#/components/schemas/RollingStockChangeGroup'
+            $ref: '#/components/schemas/RollingStockChangeGroup'
           rolling_stock_category:
-            allOf:
-            - $ref: '#/components/schemas/RollingStockCategoryChangeGroup'
+            $ref: '#/components/schemas/RollingStockCategoryChangeGroup'
           speed_limit_tag:
-            allOf:
-            - $ref: '#/components/schemas/SpeedLimitTagChangeGroup'
+            $ref: '#/components/schemas/SpeedLimitTagChangeGroup'
           start_time:
-            allOf:
-            - $ref: '#/components/schemas/StartTimeChangeGroup'
+            $ref: '#/components/schemas/StartTimeChangeGroup'
           train_name:
-            allOf:
-            - $ref: '#/components/schemas/TrainNameChangeGroup'
+            $ref: '#/components/schemas/TrainNameChangeGroup'
       description: |-
         Represents an exception for a paced train occurrence.
         Occurrences are normally generated from a base paced train.
@@ -10531,10 +10666,11 @@ components:
       - type: object
         properties:
           timetable_id:
-            type: integer
+            type:
+            - integer
+            - 'null'
             format: int64
             description: Timetable attached to the paced train
-            nullable: true
     PacedTrainResponse:
       allOf:
       - $ref: '#/components/schemas/PacedTrain'
@@ -10560,6 +10696,8 @@ components:
           description: The key is the `exception_key`
           additionalProperties:
             $ref: '#/components/schemas/SimulationSummaryResult'
+          propertyNames:
+            type: string
         paced_train:
           $ref: '#/components/schemas/SimulationSummaryResult'
     PaginationStats:
@@ -10577,10 +10715,10 @@ components:
         ```
         #[derive(Serialize, ToSchema)]
         struct MyPaginatedResponse {
-        #[schema(flatten)]
-        pagination: PaginationStats,
-        result: Vec<MyData>,
-        // any other field that makes sense in a paginated response
+            #[schema(flatten)]
+            pagination: PaginationStats,
+            result: Vec<MyData>,
+            // any other field that makes sense in a paginated response
         }
         ```
 
@@ -10605,10 +10743,11 @@ components:
           description: The current page number
           minimum: 1
         next:
-          type: integer
+          type:
+          - integer
+          - 'null'
           format: int64
           description: The next page number, if any
-          nullable: true
           minimum: 1
         page_count:
           type: integer
@@ -10621,10 +10760,11 @@ components:
           description: The number of items per page
           minimum: 1
         previous:
-          type: integer
+          type:
+          - integer
+          - 'null'
           format: int64
           description: The previous page number, if any
-          nullable: true
           minimum: 1
     Patch:
       type: array
@@ -10635,6 +10775,7 @@ components:
       oneOf:
       - allOf:
         - $ref: '#/components/schemas/AddOperation'
+          description: '''add'' operation'
         - type: object
           required:
           - op
@@ -10643,8 +10784,10 @@ components:
               type: string
               enum:
               - add
+        description: '''add'' operation'
       - allOf:
         - $ref: '#/components/schemas/RemoveOperation'
+          description: '''remove'' operation'
         - type: object
           required:
           - op
@@ -10653,8 +10796,10 @@ components:
               type: string
               enum:
               - remove
+        description: '''remove'' operation'
       - allOf:
         - $ref: '#/components/schemas/ReplaceOperation'
+          description: '''replace'' operation'
         - type: object
           required:
           - op
@@ -10663,8 +10808,10 @@ components:
               type: string
               enum:
               - replace
+        description: '''replace'' operation'
       - allOf:
         - $ref: '#/components/schemas/MoveOperation'
+          description: '''move'' operation'
         - type: object
           required:
           - op
@@ -10673,8 +10820,10 @@ components:
               type: string
               enum:
               - move
+        description: '''move'' operation'
       - allOf:
         - $ref: '#/components/schemas/CopyOperation'
+          description: '''copy'' operation'
         - type: object
           required:
           - op
@@ -10683,8 +10832,10 @@ components:
               type: string
               enum:
               - copy
+        description: '''copy'' operation'
       - allOf:
         - $ref: '#/components/schemas/TestOperation'
+          description: '''test'' operation'
         - type: object
           required:
           - op
@@ -10693,6 +10844,7 @@ components:
               type: string
               enum:
               - test
+        description: '''test'' operation'
       description: JSON Patch single patch operation
     PathAndScheduleChangeGroup:
       type: object
@@ -10730,20 +10882,85 @@ components:
               It's useful for soft deleting the point (waiting to fix / remove all references)
               If true, the train schedule is consider as invalid and must be edited
           id:
-            type: string
-            minLength: 1
+            oneOf:
+            - type: string
+              minLength: 1
+            description: |-
+              The unique identifier of the path item.
+              This is used to reference path items in the train schedule.
       description: A location on the path of a train
     PathItemLocation:
       oneOf:
-      - $ref: '#/components/schemas/TrackOffset'
-      - $ref: '#/components/schemas/OperationalPointReference'
+      - type: object
+        required:
+        - track
+        - offset
+        properties:
+          offset:
+            type: integer
+            format: int64
+            description: Offset in mm
+            minimum: 0
+          track:
+            oneOf:
+            - type: string
+              maxLength: 255
+              minLength: 1
+            description: Track section identifier
+      - allOf:
+        - oneOf:
+          - type: object
+            required:
+            - operational_point
+            properties:
+              operational_point:
+                oneOf:
+                - type: string
+                  maxLength: 255
+                  minLength: 1
+                description: The object id of an operational point
+          - type: object
+            required:
+            - trigram
+            properties:
+              secondary_code:
+                type:
+                - string
+                - 'null'
+                description: An optional secondary code to identify a more specific location
+              trigram:
+                oneOf:
+                - type: string
+                  minLength: 1
+                description: The operational point trigram
+          - type: object
+            required:
+            - uic
+            properties:
+              secondary_code:
+                type:
+                - string
+                - 'null'
+                description: An optional secondary code to identify a more specific location
+              uic:
+                type: integer
+                format: int32
+                description: The [UIC](https://en.wikipedia.org/wiki/List_of_UIC_country_codes) code of an operational point
+                minimum: 0
+        - type: object
+          properties:
+            track_reference:
+              oneOf:
+              - type: 'null'
+              - $ref: '#/components/schemas/TrackReference'
       description: The location of a path waypoint
     PathProperties:
       type: object
       description: Properties along a path. Each property is optional since it depends on what the user requests.
       properties:
         curves:
-          allOf:
+          oneOf:
+          - type: 'null'
           - type: object
             description: Property f64 values along a path. Each value is associated to a range of the path.
             required:
@@ -10765,9 +10982,10 @@ components:
                   type: number
                   format: double
                 description: List of `n+1` values associated to the ranges
-          nullable: true
+          description: Curves along the path
         electrifications:
-          allOf:
+          oneOf:
+          - type: 'null'
           - type: object
             description: Electrification property along a path. Each value is associated to a range of the path.
             required:
@@ -10812,6 +11030,7 @@ components:
                         enum:
                         - neutral_section
                   - type: object
+                    description: Non electrified section
                     required:
                     - type
                     properties:
@@ -10820,13 +11039,16 @@ components:
                         enum:
                         - non_electrified
                 description: List of `n+1` values associated to the ranges
-          nullable: true
+          description: Electrification modes and neutral section along the path
         geometry:
-          allOf:
+          oneOf:
+          - type: 'null'
           - $ref: '#/components/schemas/GeoJsonLineString'
-          nullable: true
+            description: Geometry of the path
         operational_points:
-          type: array
+          type:
+          - array
+          - 'null'
           items:
             type: object
             description: Operational point along a path.
@@ -10838,28 +11060,33 @@ components:
             properties:
               extensions:
                 $ref: '#/components/schemas/OperationalPointExtensions'
+                description: Extensions associated to the operational point
               id:
-                type: string
-                maxLength: 255
-                minLength: 1
+                oneOf:
+                - type: string
+                  maxLength: 255
+                  minLength: 1
+                description: Id of the operational point
               part:
                 $ref: '#/components/schemas/OperationalPointPart'
+                description: The part along the path
               position:
                 type: integer
                 format: int64
                 description: Distance from the beginning of the path in mm
                 minimum: 0
               weight:
-                type: integer
+                type:
+                - integer
+                - 'null'
                 format: int32
                 description: Importance of the operational point
-                nullable: true
                 maximum: 100
                 minimum: 0
           description: Operational points along the path
-          nullable: true
         slopes:
-          allOf:
+          oneOf:
+          - type: 'null'
           - type: object
             description: Property f64 values along a path. Each value is associated to a range of the path.
             required:
@@ -10881,9 +11108,10 @@ components:
                   type: number
                   format: double
                 description: List of `n+1` values associated to the ranges
-          nullable: true
+          description: Slopes along the path
         zones:
-          allOf:
+          oneOf:
+          - type: 'null'
           - type: object
             description: Zones along a path. Each value is associated to a range of the path.
             required:
@@ -10904,7 +11132,7 @@ components:
                 items:
                   type: string
                 description: List of `n+1` values associated to the ranges
-          nullable: true
+          description: Zones along the path
     PathPropertiesInput:
       type: object
       required:
@@ -10976,6 +11204,7 @@ components:
           description: Rolling stock length
         rolling_stock_loading_gauge:
           $ref: '#/components/schemas/LoadingGaugeType'
+          description: The loading gauge of the rolling stock
         rolling_stock_maximum_speed:
           type: number
           format: double
@@ -10993,9 +11222,10 @@ components:
             type: string
           description: List of supported signaling systems
         speed_limit_tag:
-          type: string
+          type:
+          - string
+          - 'null'
           description: Speed limit tag, used to estimate the travel time
-          nullable: true
     PathfindingInputError:
       oneOf:
       - type: object
@@ -11053,15 +11283,18 @@ components:
       - location
       properties:
         duration:
-          type: integer
+          type:
+          - integer
+          - 'null'
           format: int64
           description: The stop duration in milliseconds, None if the train does not stop.
-          nullable: true
           minimum: 0
         location:
           $ref: '#/components/schemas/PathItemLocation'
+          description: The associated location
         timing_data:
-          allOf:
+          oneOf:
+          - type: 'null'
           - type: object
             required:
             - arrival_time
@@ -11082,7 +11315,7 @@ components:
                 format: int64
                 description: The train may arrive up to this duration before the expected arrival time
                 minimum: 0
-          nullable: true
+          description: Time at which the train should arrive at the location, if specified
     PathfindingNotFound:
       oneOf:
       - type: object
@@ -11162,6 +11395,10 @@ components:
             type: string
             maxLength: 255
             minLength: 1
+          propertyNames:
+            type: string
+            maxLength: 255
+            minLength: 1
         track_ranges:
           type: array
           items:
@@ -11203,6 +11440,7 @@ components:
           minimum: 0
         path:
           $ref: '#/components/schemas/TrainPath'
+          description: Full description of the path data
         path_item_positions:
           type: array
           items:
@@ -11229,7 +11467,8 @@ components:
     PositiveDuration:
       type: string
       description: Duration in ISO 8601 format (e.g. PT2H for 2 hours)
-      example: PT2H
+      examples:
+      - PT2H
     PowerRestriction:
       type: object
       required:
@@ -11263,33 +11502,38 @@ components:
       - tags
       properties:
         budget:
-          type: integer
+          type:
+          - integer
+          - 'null'
           format: int32
-          nullable: true
         creation_date:
           type: string
           format: date-time
         description:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         funders:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         id:
           type: integer
           format: int64
         image:
-          type: integer
+          type:
+          - integer
+          - 'null'
           format: int64
-          nullable: true
         last_modification:
           type: string
           format: date-time
         name:
           type: string
         objectives:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         tags:
           $ref: '#/components/schemas/Tags'
     ProjectCreateForm:
@@ -11299,28 +11543,33 @@ components:
       - name
       properties:
         budget:
-          type: integer
+          type:
+          - integer
+          - 'null'
           format: int32
-          nullable: true
         description:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
           maxLength: 1024
         funders:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
           maxLength: 1024
         image:
-          type: integer
+          type:
+          - integer
+          - 'null'
           format: int64
           description: The id of the image document
-          nullable: true
         name:
           type: string
           maxLength: 128
         objectives:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
           maxLength: 4096
         tags:
           $ref: '#/components/schemas/Tags'
@@ -11329,34 +11578,40 @@ components:
       description: Patch form for a project
       properties:
         budget:
-          type: integer
+          type:
+          - integer
+          - 'null'
           format: int32
-          nullable: true
         description:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
           maxLength: 1024
         funders:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
           maxLength: 1024
         image:
-          type: integer
+          type:
+          - integer
+          - 'null'
           format: int64
           description: The id of the image document
-          nullable: true
         name:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
           maxLength: 128
         objectives:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
           maxLength: 4096
         tags:
-          allOf:
+          oneOf:
+          - type: 'null'
           - $ref: '#/components/schemas/Tags'
-          nullable: true
     ProjectPathForm:
       type: object
       required:
@@ -11365,9 +11620,10 @@ components:
       - track_section_ranges
       properties:
         electrical_profile_set_id:
-          type: integer
+          type:
+          - integer
+          - 'null'
           format: int64
-          nullable: true
         ids:
           type: array
           items:
@@ -11397,15 +11653,18 @@ components:
                 minimum: 0
               direction:
                 $ref: '#/components/schemas/Direction'
+                description: The direction of the range.
               end:
                 type: integer
                 format: int64
                 description: The end of the range in mm.
                 minimum: 0
               track_section:
-                type: string
-                maxLength: 255
-                minLength: 1
+                oneOf:
+                - type: string
+                  maxLength: 255
+                  minLength: 1
+                description: The track section identifier.
     ProjectPathPacedTrainResult:
       type: object
       description: Project path output is described by time-space points and blocks
@@ -11420,6 +11679,8 @@ components:
             type: array
             items:
               $ref: '#/components/schemas/SpaceTimeCurve'
+          propertyNames:
+            type: string
         paced_train:
           type: array
           items:
@@ -11569,9 +11830,9 @@ components:
       - type: object
         properties:
           geo:
-            allOf:
+            oneOf:
+            - type: 'null'
             - $ref: '#/components/schemas/GeoJsonPoint'
-            nullable: true
     RemoveOperation:
       type: object
       description: JSON Patch 'remove' operation representation
@@ -11699,20 +11960,20 @@ components:
         A:
           type: number
           format: double
-          description: |-
-            Solid friction
+          description: |2-
+             Solid friction
             Solid Friction in N
         B:
           type: number
           format: double
-          description: |-
-            Viscosity friction in N·(m/s)⁻¹; N = kg⋅m⋅s⁻²
+          description: |2-
+             Viscosity friction in N·(m/s)⁻¹; N = kg⋅m⋅s⁻²
             Viscosity friction in kg·s⁻¹
         C:
           type: number
           format: double
-          description: |-
-            Aerodynamic drag in N·(m/s)⁻²; N = kg⋅m⋅s⁻²
+          description: |2-
+             Aerodynamic drag in N·(m/s)⁻²; N = kg⋅m⋅s⁻²
             Aerodynamic drag in kg·m⁻¹
         type:
           type: string
@@ -11728,20 +11989,20 @@ components:
         A:
           type: number
           format: double
-          description: |-
-            Solid friction in N·kg⁻¹; N = kg⋅m⋅s⁻²
+          description: |2-
+             Solid friction in N·kg⁻¹; N = kg⋅m⋅s⁻²
             Acceleration in m·s⁻²
         B:
           type: number
           format: double
-          description: |-
-            Viscosity friction in (N·kg⁻¹)·(m/s)⁻¹; N = kg⋅m⋅s⁻²
+          description: |2-
+             Viscosity friction in (N·kg⁻¹)·(m/s)⁻¹; N = kg⋅m⋅s⁻²
             Viscosity friction per weight in s⁻¹
         C:
           type: number
           format: double
-          description: |-
-            Aerodynamic drag per kg in (N·kg⁻¹)·(m/s)⁻²; N = kg⋅m⋅s⁻²
+          description: |2-
+             Aerodynamic drag per kg in (N·kg⁻¹)·(m/s)⁻²; N = kg⋅m⋅s⁻²
             Aerodynamic drag per kg in m⁻¹
         type:
           type: string
@@ -11777,8 +12038,9 @@ components:
       - other_categories
       properties:
         base_power_class:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         comfort_acceleration:
           type: number
           format: double
@@ -11790,18 +12052,19 @@ components:
         effort_curves:
           $ref: '#/components/schemas/EffortCurves'
         electrical_power_startup_time:
-          type: number
+          type:
+          - number
+          - 'null'
           format: double
           description: Duration in s
-          nullable: true
         energy_sources:
           type: array
           items:
             $ref: '#/components/schemas/EnergySource'
         etcs_brake_params:
-          allOf:
+          oneOf:
+          - type: 'null'
           - $ref: '#/components/schemas/EtcsBrakeParams'
-          nullable: true
         id:
           type: integer
           format: int64
@@ -11825,9 +12088,9 @@ components:
           format: double
           description: Velocity in m·s⁻¹
         metadata:
-          allOf:
+          oneOf:
+          - type: 'null'
           - $ref: '#/components/schemas/RollingStockMetadata'
-          nullable: true
         name:
           type: string
         other_categories:
@@ -11836,15 +12099,18 @@ components:
           type: object
           additionalProperties:
             type: string
+          propertyNames:
+            type: string
         primary_category:
           $ref: '#/components/schemas/TrainMainCategory'
         railjson_version:
           type: string
         raise_pantograph_time:
-          type: number
+          type:
+          - number
+          - 'null'
           format: double
           description: Duration in s
-          nullable: true
         rolling_resistance:
           $ref: '#/components/schemas/RollingResistance'
         startup_acceleration:
@@ -11866,9 +12132,9 @@ components:
       type: object
       properties:
         value:
-          allOf:
+          oneOf:
+          - type: 'null'
           - $ref: '#/components/schemas/TrainCategory'
-          nullable: true
     RollingStockChangeGroup:
       type: object
       required:
@@ -11901,9 +12167,10 @@ components:
       - other_categories
       properties:
         base_power_class:
-          type: string
+          type:
+          - string
+          - 'null'
           example: '5'
-          nullable: true
         comfort_acceleration:
           type: number
           format: double
@@ -11911,29 +12178,30 @@ components:
         const_gamma:
           type: number
           format: double
-          description: |-
-            The constant gamma braking coefficient used when NOT circulating
-            under ETCS/ERTMS signaling system
+          description: |2-
+             The constant gamma braking coefficient used when NOT circulating
+             under ETCS/ERTMS signaling system
             Acceleration in m·s⁻²
         effort_curves:
           $ref: '#/components/schemas/EffortCurves'
         electrical_power_startup_time:
-          type: number
+          type:
+          - number
+          - 'null'
           format: double
-          description: |-
-            The time the train takes before actually using electrical power (in seconds).
-            Is null if the train is not electric.
+          description: |2-
+             The time the train takes before actually using electrical power (in seconds).
+             Is null if the train is not electric.
             Duration in s
           example: 5.0
-          nullable: true
         energy_sources:
           type: array
           items:
             $ref: '#/components/schemas/EnergySource'
         etcs_brake_params:
-          allOf:
+          oneOf:
+          - type: 'null'
           - $ref: '#/components/schemas/EtcsBrakeParams'
-          nullable: true
         inertia_coefficient:
           type: number
           format: double
@@ -11952,9 +12220,9 @@ components:
           format: double
           description: Velocity in m·s⁻¹
         metadata:
-          allOf:
+          oneOf:
+          - type: 'null'
           - $ref: '#/components/schemas/RollingStockMetadata'
-          nullable: true
         name:
           type: string
         other_categories:
@@ -11964,20 +12232,23 @@ components:
           description: Mapping of power restriction code to power class
           additionalProperties:
             type: string
+          propertyNames:
+            type: string
         primary_category:
           $ref: '#/components/schemas/TrainMainCategory'
         railjson_version:
           type: string
           default: '3.3'
         raise_pantograph_time:
-          type: number
+          type:
+          - number
+          - 'null'
           format: double
-          description: |-
-            The time it takes to raise this train's pantograph in seconds.
-            Is null if the train is not electric.
+          description: |2-
+             The time it takes to raise this train's pantograph in seconds.
+             Is null if the train is not electric.
             Duration in s
           example: 15.0
-          nullable: true
         rolling_resistance:
           $ref: '#/components/schemas/RollingResistance'
         startup_acceleration:
@@ -11998,9 +12269,10 @@ components:
       - rolling_stock_id
       properties:
         compound_image_id:
-          type: integer
+          type:
+          - integer
+          - 'null'
           format: int64
-          nullable: true
         id:
           type: integer
           format: int64
@@ -12018,8 +12290,11 @@ components:
         images:
           type: array
           items:
-            type: string
-            format: binary
+            type: array
+            items:
+              type: integer
+              format: int32
+              minimum: 0
         name:
           type: string
     RollingStockLiveryMetadata:
@@ -12029,9 +12304,10 @@ components:
       - name
       properties:
         compound_image_id:
-          type: integer
+          type:
+          - integer
+          - 'null'
           format: int64
-          nullable: true
         id:
           type: integer
           format: int64
@@ -12146,6 +12422,10 @@ components:
             type: string
             maxLength: 255
             minLength: 1
+          propertyNames:
+            type: string
+            maxLength: 255
+            minLength: 1
       additionalProperties: false
     RoutePath:
       type: object
@@ -12157,10 +12437,10 @@ components:
           type: array
           items:
             type: array
-            items:
-              allOf:
-              - type: string
-              - type: string
+            items: false
+            prefixItems:
+            - type: string
+            - type: string
         track_ranges:
           type: array
           items:
@@ -12204,6 +12484,8 @@ components:
         switches:
           type: object
           additionalProperties:
+            type: string
+          propertyNames:
             type: string
         zone:
           type: string
@@ -12258,9 +12540,10 @@ components:
         description:
           type: string
         electrical_profile_set_id:
-          type: integer
+          type:
+          - integer
+          - 'null'
           format: int64
-          nullable: true
         infra_id:
           type: integer
           format: int64
@@ -12276,23 +12559,27 @@ components:
       description: This structure is used by the patch endpoint to patch a scenario
       properties:
         description:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         electrical_profile_set_id:
-          type: integer
+          type:
+          - integer
+          - 'null'
           format: int64
-          nullable: true
         infra_id:
-          type: integer
+          type:
+          - integer
+          - 'null'
           format: int64
-          nullable: true
         name:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         tags:
-          allOf:
+          oneOf:
+          - type: 'null'
           - $ref: '#/components/schemas/Tags'
-          nullable: true
     ScenarioReference:
       type: object
       required:
@@ -12364,21 +12651,31 @@ components:
       - at
       properties:
         arrival:
-          allOf:
+          oneOf:
+          - type: 'null'
           - $ref: '#/components/schemas/PositiveDuration'
-          nullable: true
+            description: |-
+              The expected arrival time at the stop.
+              This will be used to compute the final simulation time.
         at:
-          type: string
-          minLength: 1
+          oneOf:
+          - type: string
+            minLength: 1
+          description: Position on the path of the schedule item.
         locked:
           type: boolean
           description: Whether the schedule item is locked (only for display purposes)
         reception_signal:
           $ref: '#/components/schemas/ReceptionSignal'
         stop_for:
-          allOf:
+          oneOf:
+          - type: 'null'
           - $ref: '#/components/schemas/PositiveDuration'
-          nullable: true
+            description: |-
+              Duration of the stop.
+              Can be `None` if the train does not stop.
+              If `None`, `reception_signal` must be `Open`.
+              `Some("PT0S")` means the train stops for 0 seconds.
       additionalProperties: false
     SearchPayload:
       type: object
@@ -12398,6 +12695,7 @@ components:
           description: The object kind to query - run `editoast search list` to get all possible values
         query:
           $ref: '#/components/schemas/SearchQuery'
+          description: The query to run
       example:
         object: operationalpoint
         query:
@@ -12418,9 +12716,9 @@ components:
       - type: string
       - type: array
         items:
-          allOf:
+          oneOf:
+          - type: 'null'
           - $ref: '#/components/schemas/SearchQuery'
-          nullable: true
       description: A search query
       example:
       - and
@@ -12508,9 +12806,10 @@ components:
           format: int64
           minimum: 0
         image:
-          type: integer
+          type:
+          - integer
+          - 'null'
           format: int64
-          nullable: true
           minimum: 0
         last_modification:
           type: string
@@ -12543,9 +12842,10 @@ components:
         description:
           type: string
         electrical_profile_set_id:
-          type: integer
+          type:
+          - integer
+          - 'null'
           format: int64
-          nullable: true
           minimum: 0
         id:
           type: integer
@@ -12612,11 +12912,13 @@ components:
           items:
             type: string
         sprite:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         sprite_signaling_system:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
     SearchResultItemStudy:
       type: object
       description: A search result item for a query with `object = "study"`
@@ -12631,13 +12933,15 @@ components:
       - budget
       properties:
         budget:
-          type: integer
+          type:
+          - integer
+          - 'null'
           format: int32
-          nullable: true
           minimum: 0
         description:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         id:
           type: integer
           format: int64
@@ -12711,8 +13015,9 @@ components:
         labels:
           type: array
           items:
-            type: string
-            nullable: true
+            type:
+            - string
+            - 'null'
         margins:
           $ref: '#/components/schemas/Margins'
         options:
@@ -12732,8 +13037,9 @@ components:
           items:
             $ref: '#/components/schemas/ScheduleItem'
         speed_limit_tag:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         start_time:
           type: string
           format: date-time
@@ -12809,7 +13115,8 @@ components:
           type: object
           properties:
             sncf:
-              allOf:
+              oneOf:
+              - type: 'null'
               - type: object
                 required:
                 - label
@@ -12822,7 +13129,6 @@ components:
                   side:
                     $ref: '#/components/schemas/Side'
                 additionalProperties: false
-              nullable: true
           additionalProperties: false
         id:
           type: string
@@ -12855,9 +13161,15 @@ components:
                       additionalProperties:
                         type: string
                         minLength: 1
+                      propertyNames:
+                        type: string
+                        minLength: 1
               default_parameters:
                 type: object
                 additionalProperties:
+                  type: string
+                  minLength: 1
+                propertyNames:
                   type: string
                   minLength: 1
               next_signaling_systems:
@@ -12867,6 +13179,9 @@ components:
               settings:
                 type: object
                 additionalProperties:
+                  type: string
+                  minLength: 1
+                propertyNames:
                   type: string
                   minLength: 1
               signaling_system:
@@ -13013,6 +13328,7 @@ components:
       properties:
         base:
           $ref: '#/components/schemas/ReportTrain'
+          description: Simulation without any regularity margins
         electrical_profiles:
           type: object
           required:
@@ -13052,35 +13368,38 @@ components:
                     handled:
                       type: boolean
                     profile:
-                      type: string
-                      nullable: true
+                      type:
+                      - string
+                      - 'null'
               description: List of `n+1` values associated to the ranges
         final_output:
-          allOf:
-          - $ref: '#/components/schemas/ReportTrain'
-          - type: object
-            required:
-            - signal_critical_positions
-            - zone_updates
-            - spacing_requirements
-            - routing_requirements
-            properties:
-              routing_requirements:
-                type: array
-                items:
-                  $ref: '#/components/schemas/RoutingRequirement'
-              signal_critical_positions:
-                type: array
-                items:
-                  $ref: '#/components/schemas/SignalCriticalPosition'
-              spacing_requirements:
-                type: array
-                items:
-                  $ref: '#/components/schemas/SpacingRequirement'
-              zone_updates:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ZoneUpdate'
+          oneOf:
+          - allOf:
+            - $ref: '#/components/schemas/ReportTrain'
+            - type: object
+              required:
+              - signal_critical_positions
+              - zone_updates
+              - spacing_requirements
+              - routing_requirements
+              properties:
+                routing_requirements:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/RoutingRequirement'
+                signal_critical_positions:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/SignalCriticalPosition'
+                spacing_requirements:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/SpacingRequirement'
+                zone_updates:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/ZoneUpdate'
+          description: 'User-selected simulation: can be base or provisional'
         mrsp:
           type: object
           description: A MRSP computation result (Most Restrictive Speed Profile)
@@ -13105,7 +13424,8 @@ components:
                 - speed
                 properties:
                   source:
-                    allOf:
+                    oneOf:
+                    - type: 'null'
                     - oneOf:
                       - type: object
                         required:
@@ -13137,7 +13457,7 @@ components:
                             type: string
                             enum:
                             - unknown_tag
-                    nullable: true
+                    description: source of the speed-limit if relevant (tag used)
                   speed:
                     type: number
                     format: double
@@ -13145,6 +13465,7 @@ components:
               description: List of `n+1` values associated to the ranges
         provisional:
           $ref: '#/components/schemas/ReportTrain'
+          description: Simulation that takes into account the regularity margins
     SimulationSummaryResult:
       oneOf:
       - type: object
@@ -13215,6 +13536,7 @@ components:
             minimum: 0
       - allOf:
         - $ref: '#/components/schemas/PathfindingNotFound'
+          description: Pathfinding not found
         - type: object
           required:
           - status
@@ -13223,6 +13545,7 @@ components:
               type: string
               enum:
               - pathfinding_not_found
+        description: Pathfinding not found
       - type: object
         description: An error has occurred during pathfinding
         required:
@@ -13249,6 +13572,7 @@ components:
             - simulation_failed
       - allOf:
         - $ref: '#/components/schemas/PathfindingInputError'
+          description: InputError
         - type: object
           required:
           - status
@@ -13257,6 +13581,7 @@ components:
               type: string
               enum:
               - pathfinding_input_error
+        description: InputError
     Slope:
       type: object
       required:
@@ -13369,10 +13694,10 @@ components:
       type: object
       properties:
         value:
-          allOf:
+          oneOf:
+          - type: 'null'
           - type: string
             minLength: 1
-          nullable: true
     SpeedSection:
       type: object
       required:
@@ -13384,7 +13709,8 @@ components:
           type: object
           properties:
             psl_sncf:
-              allOf:
+              oneOf:
+              - type: 'null'
               - type: object
                 required:
                 - announcement
@@ -13402,29 +13728,32 @@ components:
                   z:
                     $ref: '#/components/schemas/Sign'
                 additionalProperties: false
-              nullable: true
           additionalProperties: false
         id:
           type: string
           maxLength: 255
           minLength: 1
         on_routes:
-          type: array
+          type:
+          - array
+          - 'null'
           items:
             type: string
             maxLength: 255
             minLength: 1
-          nullable: true
         speed_limit:
-          allOf:
+          oneOf:
+          - type: 'null'
           - type: number
             format: double
-          nullable: true
         speed_limit_by_tag:
           type: object
           additionalProperties:
             type: number
             format: double
+          propertyNames:
+            type: string
+            minLength: 1
         track_ranges:
           type: array
           items:
@@ -13477,6 +13806,7 @@ components:
       properties:
         comfort:
           $ref: '#/components/schemas/Comfort'
+          description: The comfort of the train
         expected_version:
           type: integer
           format: int64
@@ -13486,7 +13816,8 @@ components:
           format: int64
           description: Infrastructure id
         margin:
-          allOf:
+          oneOf:
+          - type: 'null'
           - oneOf:
             - type: object
               required:
@@ -13502,7 +13833,7 @@ components:
                 MinPer100Km:
                   type: number
                   format: double
-          nullable: true
+          description: Margin to apply to the whole train
         maximum_departure_delay:
           type: integer
           format: int64
@@ -13533,8 +13864,9 @@ components:
           - rolling_resistance
           properties:
             base_power_class:
-              type: string
-              nullable: true
+              type:
+              - string
+              - 'null'
             comfort_acceleration:
               type: number
               format: double
@@ -13547,17 +13879,18 @@ components:
             effort_curves:
               $ref: '#/components/schemas/EffortCurves'
             electrical_power_startup_time:
-              type: integer
+              type:
+              - integer
+              - 'null'
               format: int64
               description: |-
                 The time the train takes before actually using electrical power.
                 Is null if the train is not electric or the value not specified.
-              nullable: true
               minimum: 0
             etcs_brake_params:
-              allOf:
+              oneOf:
+              - type: 'null'
               - $ref: '#/components/schemas/EtcsBrakeParams'
-              nullable: true
             inertia_coefficient:
               type: number
               format: double
@@ -13580,13 +13913,16 @@ components:
               description: Mapping of power restriction code to power class
               additionalProperties:
                 type: string
+              propertyNames:
+                type: string
             raise_pantograph_time:
-              type: integer
+              type:
+              - integer
+              - 'null'
               format: int64
               description: |-
                 The time it takes to raise this train's pantograph.
                 Is null if the train is not electric or the value not specified.
-              nullable: true
               minimum: 0
             rolling_resistance:
               $ref: '#/components/schemas/RollingResistance'
@@ -13599,11 +13935,14 @@ components:
               minimum: 0
         rolling_stock_loading_gauge:
           $ref: '#/components/schemas/LoadingGaugeType'
+          description: The loading gauge of the rolling stock
         rolling_stock_supported_signaling_systems:
           $ref: '#/components/schemas/RollingStockSupportedSignalingSystems'
+          description: List of supported signaling systems
         speed_limit_tag:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         start_time:
           type: string
           format: date-time
@@ -13637,10 +13976,11 @@ components:
           description: Gap between the created train and previous trains in milliseconds
           minimum: 0
         time_step:
-          type: integer
+          type:
+          - integer
+          - 'null'
           format: int64
           description: Numerical integration time step in milliseconds. Use default value if not specified.
-          nullable: true
           minimum: 0
         timetable_id:
           type: integer
@@ -13661,9 +14001,9 @@ components:
         - status
         properties:
           core_payload:
-            allOf:
+            oneOf:
+            - type: 'null'
             - $ref: '#/components/schemas/StdcmRequest'
-            nullable: true
           departure_time:
             type: string
             format: date-time
@@ -13680,9 +14020,9 @@ components:
         - status
         properties:
           core_payload:
-            allOf:
+            oneOf:
+            - type: 'null'
             - $ref: '#/components/schemas/StdcmRequest'
-            nullable: true
           status:
             type: string
             enum:
@@ -13693,9 +14033,9 @@ components:
         - status
         properties:
           core_payload:
-            allOf:
+            oneOf:
+            - type: 'null'
             - $ref: '#/components/schemas/StdcmRequest'
-            nullable: true
           error:
             $ref: '#/components/schemas/SimulationResponse'
           status:
@@ -13762,14 +14102,16 @@ components:
       - search_window_end
       - enabled_from
       - enabled_until
-      - active_perimeter
       properties:
         active_perimeter:
-          $ref: '#/components/schemas/GeoJson'
+          oneOf:
+          - type: 'null'
+          - $ref: '#/components/schemas/GeoJson'
         electrical_profile_set_id:
-          type: integer
+          type:
+          - integer
+          - 'null'
           format: int64
-          nullable: true
         enabled_from:
           type: string
           format: date-time
@@ -13786,16 +14128,18 @@ components:
           type: string
           format: date-time
         temporary_speed_limit_group_id:
-          type: integer
+          type:
+          - integer
+          - 'null'
           format: int64
-          nullable: true
         timetable_id:
           type: integer
           format: int64
         work_schedule_group_id:
-          type: integer
+          type:
+          - integer
+          - 'null'
           format: int64
-          nullable: true
     Study:
       type: object
       required:
@@ -13808,26 +14152,31 @@ components:
       - project_id
       properties:
         actual_end_date:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date
-          nullable: true
         budget:
-          type: integer
+          type:
+          - integer
+          - 'null'
           format: int32
-          nullable: true
         business_code:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         creation_date:
           type: string
           format: date-time
         description:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         expected_end_date:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date
-          nullable: true
         id:
           type: integer
           format: int64
@@ -13840,17 +14189,20 @@ components:
           type: integer
           format: int64
         service_code:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         start_date:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date
-          nullable: true
         state:
           type: string
         study_type:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         tags:
           $ref: '#/components/schemas/Tags'
     StudyCreateForm:
@@ -13861,37 +14213,45 @@ components:
       - state
       properties:
         actual_end_date:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date
-          nullable: true
         budget:
-          type: integer
+          type:
+          - integer
+          - 'null'
           format: int32
-          nullable: true
         business_code:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         description:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         expected_end_date:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date
-          nullable: true
         name:
           type: string
         service_code:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         start_date:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date
-          nullable: true
         state:
           type: string
         study_type:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         tags:
           $ref: '#/components/schemas/Tags'
     StudyPatchForm:
@@ -13899,43 +14259,53 @@ components:
       description: This structure is used by the patch endpoint to patch a study
       properties:
         actual_end_date:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date
-          nullable: true
         budget:
-          type: integer
+          type:
+          - integer
+          - 'null'
           format: int32
-          nullable: true
         business_code:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         description:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         expected_end_date:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date
-          nullable: true
         name:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         service_code:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         start_date:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date
-          nullable: true
         state:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         study_type:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         tags:
-          allOf:
+          oneOf:
+          - type: 'null'
           - $ref: '#/components/schemas/Tags'
-          nullable: true
     StudyResponse:
       allOf:
       - $ref: '#/components/schemas/Study'
@@ -14014,7 +14384,8 @@ components:
           type: object
           properties:
             sncf:
-              allOf:
+              oneOf:
+              - type: 'null'
               - type: object
                 required:
                 - label
@@ -14023,7 +14394,6 @@ components:
                     type: string
                     minLength: 1
                 additionalProperties: false
-              nullable: true
           additionalProperties: false
         group_change_delay:
           type: number
@@ -14036,6 +14406,10 @@ components:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/TrackEndpoint'
+          propertyNames:
+            type: string
+            maxLength: 255
+            minLength: 1
         switch_type:
           type: string
           maxLength: 255
@@ -14069,6 +14443,10 @@ components:
             type: array
             items:
               $ref: '#/components/schemas/SwitchPortConnection'
+          propertyNames:
+            type: string
+            maxLength: 255
+            minLength: 1
         id:
           type: string
           maxLength: 255
@@ -14164,10 +14542,11 @@ components:
           format: double
           description: Mass in kg
         max_speed:
-          type: number
+          type:
+          - number
+          - 'null'
           format: double
           description: Velocity in m·s⁻¹
-          nullable: true
         name:
           type: string
         railjson_version:
@@ -14212,9 +14591,9 @@ components:
         const_gamma:
           type: number
           format: double
-          description: |-
-            The constant gamma braking coefficient used when NOT circulating
-            under ETCS/ERTMS signaling system
+          description: |2-
+             The constant gamma braking coefficient used when NOT circulating
+             under ETCS/ERTMS signaling system
             Acceleration in m·s⁻²
         inertia_coefficient:
           type: number
@@ -14230,10 +14609,11 @@ components:
           format: double
           description: Mass in kg
         max_speed:
-          type: number
+          type:
+          - number
+          - 'null'
           format: double
           description: Velocity in m·s⁻¹
-          nullable: true
         name:
           type: string
         railjson_version:
@@ -14279,9 +14659,11 @@ components:
           format: double
           description: The offset on the track section in meters
         track_section:
-          type: string
-          maxLength: 255
-          minLength: 1
+          oneOf:
+          - type: string
+            maxLength: 255
+            minLength: 1
+          description: The track section UUID
     TrackOffset:
       type: object
       required:
@@ -14294,9 +14676,11 @@ components:
           description: Offset in mm
           minimum: 0
         track:
-          type: string
-          maxLength: 255
-          minLength: 1
+          oneOf:
+          - type: string
+            maxLength: 255
+            minLength: 1
+          description: Track section identifier
     TrackRange:
       type: object
       required:
@@ -14348,7 +14732,8 @@ components:
           type: object
           properties:
             sncf:
-              allOf:
+              oneOf:
+              - type: 'null'
               - type: object
                 required:
                 - line_code
@@ -14369,9 +14754,9 @@ components:
                     type: integer
                     format: int32
                 additionalProperties: false
-              nullable: true
             source:
-              allOf:
+              oneOf:
+              - type: 'null'
               - type: object
                 required:
                 - name
@@ -14384,7 +14769,6 @@ components:
                     type: string
                     minLength: 1
                 additionalProperties: false
-              nullable: true
           additionalProperties: false
         geo:
           $ref: '#/components/schemas/GeoJsonLineString'
@@ -14516,9 +14900,9 @@ components:
       - constraint_distribution
       properties:
         category:
-          allOf:
+          oneOf:
+          - type: 'null'
           - $ref: '#/components/schemas/TrainCategory'
-          nullable: true
         comfort:
           $ref: '#/components/schemas/Comfort'
         constraint_distribution:
@@ -14576,8 +14960,12 @@ components:
                     It's useful for soft deleting the point (waiting to fix / remove all references)
                     If true, the train schedule is consider as invalid and must be edited
                 id:
-                  type: string
-                  minLength: 1
+                  oneOf:
+                  - type: string
+                    minLength: 1
+                  description: |-
+                    The unique identifier of the path item.
+                    This is used to reference path items in the train schedule.
             description: A location on the path of a train
         power_restrictions:
           type: array
@@ -14607,27 +14995,37 @@ components:
             - at
             properties:
               arrival:
-                allOf:
+                oneOf:
+                - type: 'null'
                 - $ref: '#/components/schemas/PositiveDuration'
-                nullable: true
+                  description: |-
+                    The expected arrival time at the stop.
+                    This will be used to compute the final simulation time.
               at:
-                type: string
-                minLength: 1
+                oneOf:
+                - type: string
+                  minLength: 1
+                description: Position on the path of the schedule item.
               locked:
                 type: boolean
                 description: Whether the schedule item is locked (only for display purposes)
               reception_signal:
                 $ref: '#/components/schemas/ReceptionSignal'
               stop_for:
-                allOf:
+                oneOf:
+                - type: 'null'
                 - $ref: '#/components/schemas/PositiveDuration'
-                nullable: true
+                  description: |-
+                    Duration of the stop.
+                    Can be `None` if the train does not stop.
+                    If `None`, `reception_signal` must be `Open`.
+                    `Some("PT0S")` means the train stops for 0 seconds.
             additionalProperties: false
         speed_limit_tag:
-          allOf:
+          oneOf:
+          - type: 'null'
           - type: string
             minLength: 1
-          nullable: true
         start_time:
           type: string
           format: date-time
@@ -14639,10 +15037,11 @@ components:
       - type: object
         properties:
           timetable_id:
-            type: integer
+            type:
+            - integer
+            - 'null'
             format: int64
             description: Timetable attached to the train schedule
-            nullable: true
     TrainScheduleOptions:
       type: object
       properties:
@@ -14671,8 +15070,9 @@ components:
       - git_describe
       properties:
         git_describe:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
     Waypoint:
       oneOf:
       - type: object

--- a/editoast/schemas/src/infra.rs
+++ b/editoast/schemas/src/infra.rs
@@ -58,6 +58,7 @@ pub use railjson::RailJson;
 pub use railjson::major_version;
 pub use route::Route;
 pub use route::RoutePath;
+pub use route::SwitchDirection;
 pub use side::Side;
 pub use sign::Sign;
 pub use signal::LogicalSignal;

--- a/editoast/schemas/src/infra/route.rs
+++ b/editoast/schemas/src/infra/route.rs
@@ -46,8 +46,14 @@ impl OSRDIdentified for Route {
 #[derive(Debug, Clone, Serialize, PartialEq, ToSchema)]
 pub struct RoutePath {
     pub track_ranges: Vec<DirectionalTrackRange>,
-    // ToSchema isn’t derived correctly with tuples (inline doesn’t work)
-    // so we need to specify the value_type
-    #[schema(inline, value_type = Vec<(String, String)>)]
-    pub switches_directions: Vec<(Identifier, Identifier)>,
+    #[schema(inline)]
+    pub switches_directions: Vec<SwitchDirection>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, ToSchema)]
+pub struct SwitchDirection {
+    #[schema(inline)]
+    pub switch_id: Identifier,
+    #[schema(inline)]
+    pub group_id: Identifier,
 }

--- a/editoast/schemas/src/infra/track_section.rs
+++ b/editoast/schemas/src/infra/track_section.rs
@@ -14,6 +14,7 @@ use crate::primitives::Identifier;
 use crate::primitives::OSRDIdentified;
 use crate::primitives::OSRDTyped;
 use crate::primitives::ObjectType;
+use common::geometry::GeoJsonLineString;
 
 #[editoast_derive::openapi_schema]
 #[derive(Debug, Educe, Clone, Deserialize, Serialize, PartialEq, ToSchema)]

--- a/editoast/schemas/src/infra/track_section.rs
+++ b/editoast/schemas/src/infra/track_section.rs
@@ -81,7 +81,12 @@ mod tests {
 
         assert_eq!(
             BoundingBox::from_geojson(line_string).unwrap(),
-            BoundingBox((2.4, 49.0), (3.0, 49.3))
+            BoundingBox {
+                min_lon: 2.4,
+                min_lat: 49.0,
+                max_lon: 3.0,
+                max_lat: 49.3,
+            }
         );
     }
 

--- a/editoast/schemas/src/paced_train.rs
+++ b/editoast/schemas/src/paced_train.rs
@@ -9,7 +9,6 @@ use serde_with::skip_serializing_none;
 use utoipa::ToSchema;
 use utoipa::openapi::ObjectBuilder;
 use utoipa::openapi::RefOr;
-use utoipa::openapi::SchemaType;
 use utoipa::openapi::schema::Schema;
 
 use crate::primitives::NonBlankString;
@@ -150,17 +149,21 @@ impl Default for ExceptionType {
     }
 }
 
-impl ToSchema<'_> for ExceptionType {
-    fn schema() -> (&'static str, RefOr<Schema>) {
+impl utoipa::PartialSchema for ExceptionType {
+    fn schema() -> RefOr<Schema> {
         let modified_schema = ObjectBuilder::new()
             .property(
                 "occurrence_index",
-                ObjectBuilder::new().schema_type(SchemaType::Integer),
+                ObjectBuilder::new().schema_type(utoipa::openapi::schema::SchemaType::Type(
+                    utoipa::openapi::schema::Type::Integer,
+                )),
             )
             .build();
-        ("PacedTrainExceptionType", modified_schema.into())
+        modified_schema.into()
     }
 }
+
+impl ToSchema for ExceptionType {}
 
 #[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]

--- a/editoast/schemas/src/primitives/bounding_box.rs
+++ b/editoast/schemas/src/primitives/bounding_box.rs
@@ -11,33 +11,47 @@ use crate::errors::GeometryError;
 /// A bounding box
 #[editoast_derive::openapi_schema]
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
-pub struct BoundingBox(pub (f64, f64), pub (f64, f64));
+pub struct BoundingBox {
+    pub min_lon: f64,
+    pub min_lat: f64,
+    pub max_lon: f64,
+    pub max_lat: f64,
+}
 
 impl FromIterator<(f64, f64)> for BoundingBox {
     fn from_iter<I: IntoIterator<Item = (f64, f64)>>(iter: I) -> Self {
-        let mut min: (f64, f64) = (f64::MAX, f64::MAX);
-        let mut max: (f64, f64) = (f64::MIN, f64::MIN);
+        let mut min_lon = f64::MAX;
+        let mut min_lat = f64::MAX;
+        let mut max_lon = f64::MIN;
+        let mut max_lat = f64::MIN;
 
         for (x, y) in iter {
-            min.0 = min.0.min(x);
-            max.0 = max.0.max(x);
-            min.1 = min.1.min(y);
-            max.1 = max.1.max(y);
+            min_lon = min_lon.min(x);
+            max_lon = max_lon.max(x);
+            min_lat = min_lat.min(y);
+            max_lat = max_lat.max(y);
         }
 
-        BoundingBox(min, max)
+        BoundingBox {
+            min_lon,
+            min_lat,
+            max_lon,
+            max_lat,
+        }
     }
 }
 
 impl BoundingBox {
     pub fn union(&mut self, b: &Self) -> &mut Self {
-        self.0 = (self.0.0.min(b.0.0), self.0.1.min(b.0.1));
-        self.1 = (self.1.0.max(b.1.0), self.1.1.max(b.1.1));
+        self.min_lon = self.min_lon.min(b.min_lon);
+        self.min_lat = self.min_lat.min(b.min_lat);
+        self.max_lon = self.max_lon.max(b.max_lon);
+        self.max_lat = self.max_lat.max(b.max_lat);
         self
     }
 
     pub fn is_valid(&self) -> bool {
-        self.0.0 <= self.1.0 && self.0.1 <= self.1.1
+        self.min_lon <= self.max_lon && self.min_lat <= self.max_lat
     }
 
     pub fn from_geojson(value: geojson::Value) -> Result<Self, GeometryError> {
@@ -70,7 +84,12 @@ impl BoundingBox {
     /// ```
     /// use schemas::primitives::BoundingBox;
     ///
-    /// let bbox = BoundingBox((40.0, -75.0), (42.0, -73.0));
+    /// let bbox = BoundingBox {
+    ///     min_lon: 40.0,
+    ///     min_lat: -75.0,
+    ///     max_lon: 42.0,
+    ///     max_lat: -73.0,
+    /// };
     /// let diagonal_length = bbox.diagonal_length();
     /// assert_eq!(diagonal_length, 230908.62753622115);
     /// ```
@@ -78,10 +97,10 @@ impl BoundingBox {
         // Earth's mean radius in meters
         let r: f64 = 6_378_100.0;
 
-        let a_lon = self.0.0;
-        let a_lat = self.0.1;
-        let b_lon = self.1.0;
-        let b_lat = self.1.1;
+        let a_lon = self.min_lon;
+        let a_lat = self.min_lat;
+        let b_lon = self.max_lon;
+        let b_lat = self.max_lat;
 
         // Calculate differences in longitude and latitude in radians
         let d_lon: f64 = (b_lon - a_lon).to_radians();
@@ -103,10 +122,12 @@ impl BoundingBox {
 
 impl Default for BoundingBox {
     fn default() -> Self {
-        Self(
-            (f64::INFINITY, f64::INFINITY),
-            (f64::NEG_INFINITY, f64::NEG_INFINITY),
-        )
+        Self {
+            min_lon: f64::INFINITY,
+            min_lat: f64::INFINITY,
+            max_lon: f64::NEG_INFINITY,
+            max_lat: f64::NEG_INFINITY,
+        }
     }
 }
 
@@ -116,25 +137,72 @@ mod tests {
 
     #[test]
     fn test_bounding_box_union() {
-        let mut a = BoundingBox((0., 0.), (1., 1.));
-        let b = BoundingBox((2., 2.), (3., 3.));
+        let mut a = BoundingBox {
+            min_lon: 0.,
+            min_lat: 0.,
+            max_lon: 1.,
+            max_lat: 1.,
+        };
+        let b = BoundingBox {
+            min_lon: 2.,
+            min_lat: 2.,
+            max_lon: 3.,
+            max_lat: 3.,
+        };
         a.union(&b);
-        assert_eq!(a, BoundingBox((0., 0.), (3., 3.)));
+        assert_eq!(
+            a,
+            BoundingBox {
+                min_lon: 0.,
+                min_lat: 0.,
+                max_lon: 3.,
+                max_lat: 3.,
+            }
+        );
     }
 
     #[test]
     fn test_bounding_box_min() {
         let mut min = BoundingBox::default();
-        let a = BoundingBox((0., 0.), (1., 1.));
+        let a = BoundingBox {
+            min_lon: 0.,
+            min_lat: 0.,
+            max_lon: 1.,
+            max_lat: 1.,
+        };
         min.union(&a);
         assert_eq!(min, a);
     }
 
     #[test]
     fn test_validity() {
-        assert!(BoundingBox((0., 0.), (1., 1.)).is_valid());
-        assert!(!BoundingBox((1., 0.), (0., 1.)).is_valid());
-        assert!(!BoundingBox((0., 1.), (1., 0.)).is_valid());
+        assert!(
+            BoundingBox {
+                min_lon: 0.,
+                min_lat: 0.,
+                max_lon: 1.,
+                max_lat: 1.,
+            }
+            .is_valid()
+        );
+        assert!(
+            !BoundingBox {
+                min_lon: 1.,
+                min_lat: 0.,
+                max_lon: 0.,
+                max_lat: 1.,
+            }
+            .is_valid()
+        );
+        assert!(
+            !BoundingBox {
+                min_lon: 0.,
+                min_lat: 1.,
+                max_lon: 1.,
+                max_lat: 0.,
+            }
+            .is_valid()
+        );
         assert!(!BoundingBox::default().is_valid());
     }
 }

--- a/editoast/schemas/src/primitives/duration.rs
+++ b/editoast/schemas/src/primitives/duration.rs
@@ -34,7 +34,6 @@ use utoipa::ToSchema;
 use utoipa::openapi::ObjectBuilder;
 use utoipa::openapi::RefOr;
 use utoipa::openapi::Schema;
-use utoipa::openapi::SchemaType;
 
 #[derive(Debug, Error)]
 pub enum PositiveDurationError {
@@ -89,19 +88,20 @@ impl Default for PositiveDuration {
 /// directly via `#[derive(ToSchema)]`.
 ///
 /// TODO: Upgrade `utoipa` to version 5.3.1 or later to
-impl ToSchema<'_> for PositiveDuration {
-    fn schema() -> (&'static str, RefOr<Schema>) {
-        (
-            "PositiveDuration",
-            ObjectBuilder::new()
-                .schema_type(SchemaType::String)
-                .description(Some("Duration in ISO 8601 format (e.g. PT2H for 2 hours)"))
-                .example(Some(serde_json::Value::String("PT2H".to_string())))
-                .build()
-                .into(),
-        )
+impl utoipa::PartialSchema for PositiveDuration {
+    fn schema() -> RefOr<Schema> {
+        ObjectBuilder::new()
+            .schema_type(utoipa::openapi::schema::SchemaType::Type(
+                utoipa::openapi::schema::Type::String,
+            ))
+            .description(Some("Duration in ISO 8601 format (e.g. PT2H for 2 hours)"))
+            .examples([serde_json::Value::String("PT2H".to_string())])
+            .build()
+            .into()
     }
 }
+
+impl ToSchema for PositiveDuration {}
 
 impl TryFrom<ChronoDuration> for PositiveDuration {
     type Error = PositiveDurationError;

--- a/editoast/schemas/src/primitives/identifier.rs
+++ b/editoast/schemas/src/primitives/identifier.rs
@@ -101,18 +101,19 @@ impl Display for Identifier {
     }
 }
 
-impl<'a> utoipa::ToSchema<'a> for Identifier {
-    fn schema() -> (&'a str, RefOr<Schema>) {
-        (
-            "NonBlankString",
-            ObjectBuilder::new()
-                .schema_type(utoipa::openapi::SchemaType::String)
-                .min_length(Some(1))
-                .max_length(Some(255))
-                .into(),
-        )
+impl utoipa::PartialSchema for Identifier {
+    fn schema() -> RefOr<Schema> {
+        ObjectBuilder::new()
+            .schema_type(utoipa::openapi::schema::SchemaType::Type(
+                utoipa::openapi::schema::Type::String,
+            ))
+            .min_length(Some(1))
+            .max_length(Some(255))
+            .into()
     }
 }
+
+impl utoipa::ToSchema for Identifier {}
 
 #[cfg(test)]
 mod tests {

--- a/editoast/schemas/src/primitives/non_blank_string.rs
+++ b/editoast/schemas/src/primitives/non_blank_string.rs
@@ -96,17 +96,18 @@ impl PartialEq<NonBlankString> for &str {
     }
 }
 
-impl<'a> utoipa::ToSchema<'a> for NonBlankString {
-    fn schema() -> (&'a str, RefOr<Schema>) {
-        (
-            "NonBlankString",
-            ObjectBuilder::new()
-                .schema_type(utoipa::openapi::SchemaType::String)
-                .min_length(Some(1))
-                .into(),
-        )
+impl utoipa::PartialSchema for NonBlankString {
+    fn schema() -> RefOr<Schema> {
+        ObjectBuilder::new()
+            .schema_type(utoipa::openapi::schema::SchemaType::Type(
+                utoipa::openapi::schema::Type::String,
+            ))
+            .min_length(Some(1))
+            .into()
     }
 }
+
+impl utoipa::ToSchema for NonBlankString {}
 
 #[cfg(test)]
 mod tests {

--- a/editoast/schemas/src/train_schedule/path_item.rs
+++ b/editoast/schemas/src/train_schedule/path_item.rs
@@ -44,8 +44,8 @@ impl PathItem {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema, Hash)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum PathItemLocation {
-    TrackOffset(#[schema(inline)] TrackOffset),
-    OperationalPointReference(#[schema(inline)] OperationalPointReference),
+    TrackOffset(TrackOffset),
+    OperationalPointReference(OperationalPointReference),
 }
 
 #[editoast_derive::openapi_schema]

--- a/editoast/search/src/search_object.rs
+++ b/editoast/search/src/search_object.rs
@@ -50,7 +50,7 @@ pub enum SearchType {
     Textual,
 }
 
-pub trait SearchObject: ToSchema<'static> {
+pub trait SearchObject: ToSchema {
     fn search_config() -> SearchConfig;
 }
 

--- a/editoast/src/generated_data/error/routes.rs
+++ b/editoast/src/generated_data/error/routes.rs
@@ -7,6 +7,7 @@ use crate::generated_data::infra_error::InfraError;
 use crate::infra_cache::Graph;
 use crate::infra_cache::InfraCache;
 use crate::infra_cache::ObjectCache;
+use schemas::infra::SwitchDirection;
 use schemas::infra::Waypoint;
 use schemas::primitives::Identifier;
 use schemas::primitives::OSRDIdentified;
@@ -159,7 +160,7 @@ fn check_path(
         route_path
             .switches_directions
             .iter()
-            .map(|(k, _)| k.clone()),
+            .map(|SwitchDirection { switch_id, .. }| switch_id.clone()),
     );
     // Search for switches out of the path
     let mut res = vec![];

--- a/editoast/src/infra_cache/mod.rs
+++ b/editoast/src/infra_cache/mod.rs
@@ -38,6 +38,7 @@ use schemas::infra::Route;
 use schemas::infra::RoutePath;
 use schemas::infra::SingleSlipSwitch;
 use schemas::infra::SpeedSection;
+use schemas::infra::SwitchDirection;
 use schemas::infra::SwitchType;
 use schemas::infra::TrackEndpoint;
 use schemas::infra::Waypoint;
@@ -860,7 +861,10 @@ impl InfraCache {
                 // Check we found the switch in the route
                 route.switches_directions.get(&switch_id.clone().into())?
             };
-            used_switches.push((switch_id.clone().into(), group.clone()));
+            used_switches.push(SwitchDirection {
+                switch_id: switch_id.clone().into(),
+                group_id: group.clone(),
+            });
             let next_endpoint = graph.get_neighbour(&endpoint, group)?;
 
             // Update current track section, offset and direction

--- a/editoast/src/infra_cache/object_cache/route_cache.rs
+++ b/editoast/src/infra_cache/object_cache/route_cache.rs
@@ -16,6 +16,7 @@ impl Cache for Route {
 
 #[cfg(test)]
 mod tests {
+    use schemas::infra::SwitchDirection;
 
     use crate::infra_cache::Graph;
     use crate::infra_cache::tests::create_small_infra_cache;
@@ -39,7 +40,7 @@ mod tests {
         assert!(
             path.switches_directions
                 .iter()
-                .any(|(k, _)| k == &"link".into())
+                .any(|SwitchDirection { switch_id, .. }| switch_id == &"link".into())
         );
     }
 
@@ -62,7 +63,7 @@ mod tests {
         assert!(
             path.switches_directions
                 .iter()
-                .any(|(k, _)| k == &"switch".into())
+                .any(|SwitchDirection { switch_id, .. }| switch_id == &"switch".into())
         );
     }
 }

--- a/editoast/src/infra_cache/operation/mod.rs
+++ b/editoast/src/infra_cache/operation/mod.rs
@@ -44,11 +44,8 @@ pub enum Operation {
 //   quite dependant on the current schema
 // - So we have to manually define the schema for the `Operation` to keep the current schema but without
 //   the need to declare `UpdateOperation` and `DeleteOperation` as components
-impl<'s> ToSchema<'s> for Operation {
-    fn schema() -> (
-        &'s str,
-        utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
-    ) {
+impl utoipa::PartialSchema for Operation {
+    fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
         #[derive(ToSchema, Serialize)]
         #[serde(rename_all = "UPPERCASE")]
         #[allow(unused)]
@@ -96,9 +93,11 @@ impl<'s> ToSchema<'s> for Operation {
             },
         }
 
-        Operation::schema()
+        <Operation as utoipa::PartialSchema>::schema()
     }
 }
+
+impl utoipa::ToSchema for Operation {}
 
 #[derive(Clone, Deserialize, Serialize)]
 pub enum CacheOperation {

--- a/editoast/src/models/infra/object_queryable.rs
+++ b/editoast/src/models/infra/object_queryable.rs
@@ -1,5 +1,6 @@
 use std::ops::DerefMut;
 
+use common::geometry::GeoJson;
 use database::DbConnection;
 use diesel::QueryableByName;
 use diesel::sql_query;

--- a/editoast/src/models/rolling_stock_livery.rs
+++ b/editoast/src/models/rolling_stock_livery.rs
@@ -2,6 +2,7 @@ use database::DbConnection;
 use editoast_derive::Model;
 use editoast_models::Document;
 use editoast_models::prelude::*;
+use utoipa::ToSchema;
 
 #[cfg(test)]
 use serde::Deserialize;
@@ -17,7 +18,7 @@ use serde::Deserialize;
 ///
 /// /!\ Its compound image is not deleted by cascade if the livery is removed.
 ///
-#[derive(Debug, Clone, Default, Model)]
+#[derive(Debug, Clone, Default, Model, ToSchema)]
 #[cfg_attr(test, derive(Deserialize))]
 #[model(table = database::tables::rolling_stock_livery)]
 #[model(gen(ops = crd, list))]

--- a/editoast/src/models/stdcm_search_environment.rs
+++ b/editoast/src/models/stdcm_search_environment.rs
@@ -1,5 +1,6 @@
 use chrono::DateTime;
 use chrono::Utc;
+use common::geometry::GeoJson;
 use database::DbConnection;
 use diesel::ExpressionMethods;
 use diesel::QueryDsl;

--- a/editoast/src/views/documents.rs
+++ b/editoast/src/views/documents.rs
@@ -43,7 +43,6 @@ pub enum DocumentErrors {
     ),
     responses(
         (status = 200, description = "The document's binary content", body = [u8]),
-        (status = 404, description = "Document not found", body = InternalError),
     )
 )]
 pub(in crate::views) async fn get(
@@ -134,7 +133,6 @@ pub(in crate::views) async fn post(
     ),
     responses(
         (status = 204, description = "The document was deleted"),
-        (status = 404, description = "Document not found", body = InternalError),
     )
 )]
 pub(in crate::views) async fn delete(

--- a/editoast/src/views/documents.rs
+++ b/editoast/src/views/documents.rs
@@ -42,7 +42,12 @@ pub enum DocumentErrors {
         ("document_key" = i64, Path, description = "The document's key"),
     ),
     responses(
-        (status = 200, description = "The document's binary content", body = [u8]),
+        (
+            status = 200,
+            description = "Document content",
+            content_type = "application/octet-stream",
+            body = String,
+        ),
     )
 )]
 pub(in crate::views) async fn get(
@@ -86,7 +91,7 @@ struct NewDocumentResponse {
     params(
         ("content_type" = String, Header, description = "The document's content type"),
     ),
-    request_body = [u8],
+    request_body(content_type = "application/octet-stream", content = String),
     responses(
         (status = 201, description = "The document was created", body = NewDocumentResponse),
     )

--- a/editoast/src/views/electrical_profiles.rs
+++ b/editoast/src/views/electrical_profiles.rs
@@ -62,7 +62,6 @@ pub(in crate::views) async fn list(
     params(ElectricalProfileSetId),
     responses(
         (status = 200, body = ElectricalProfileSetData, description = "The list of electrical profiles in the set"),
-        (status = 404, body = InternalError, description = "The requested electrical profile set was not found"),
     )
 )]
 pub(in crate::views) async fn get(
@@ -103,7 +102,6 @@ pub(in crate::views) async fn get(
                 "25000V": ["25000V", "22500V", "20000V"]
             })
         ),
-        (status = 404, body = InternalError, description = "The requested electrical profile set was not found"),
     )
 )]
 pub(in crate::views) async fn get_level_order(
@@ -137,7 +135,6 @@ pub(in crate::views) async fn get_level_order(
     params(ElectricalProfileSetId),
     responses(
         (status = 204, description = "The electrical profile was deleted successfully"),
-        (status = 404, body = InternalError, description = "The requested electrical profile was not found"),
     )
 )]
 pub(in crate::views) async fn delete(

--- a/editoast/src/views/infra/lines.rs
+++ b/editoast/src/views/infra/lines.rs
@@ -139,7 +139,15 @@ mod tests {
             app.get(format!("/infra/{}/lines/{line_code}/bbox/", empty_infra.id).as_str());
         let bounding_box: BoundingBox =
             app.fetch(request).assert_status(StatusCode::OK).json_into();
-        assert_eq!(bounding_box, BoundingBox((1., 2.), (3., 4.)));
+        assert_eq!(
+            bounding_box,
+            BoundingBox {
+                min_lon: 1.,
+                min_lat: 2.,
+                max_lon: 3.,
+                max_lat: 4.,
+            }
+        );
     }
 
     #[rstest]

--- a/editoast/src/views/infra/objects.rs
+++ b/editoast/src/views/infra/objects.rs
@@ -48,7 +48,7 @@ pub(in crate::views) struct ObjectTypeParam {
     params(InfraIdParam, ObjectTypeParam),
     request_body = Vec<String>,
     responses(
-        (status = 200, description = "The list of objects", body = Vec<InfraObjectWithGeometry>),
+        (status = 200, description = "The list of objects", body = Vec<ObjectQueryable>),
         (status = 400, description = "Duplicate object ids provided"),
         (status = 404, description = "Object ID or infra ID invalid")
     )

--- a/editoast/src/views/infra/routes.rs
+++ b/editoast/src/views/infra/routes.rs
@@ -192,12 +192,8 @@ pub(in crate::views) async fn get_routes_track_ranges(
         .map(|route| {
             if let Some(route) = routes_cache.get(route) {
                 let route = route.unwrap_route();
-                let route_path = infra_cache.compute_track_ranges_on_route(route, &graph);
-                if let Some(route_path) = route_path {
-                    RouteTrackRangesResult::Computed(RoutePath {
-                        track_ranges: route_path.track_ranges,
-                        switches_directions: route_path.switches_directions,
-                    })
+                if let Some(route_path) = infra_cache.compute_track_ranges_on_route(route, &graph) {
+                    RouteTrackRangesResult::Computed(route_path)
                 } else {
                     RouteTrackRangesResult::CantComputePath
                 }

--- a/editoast/src/views/layers.rs
+++ b/editoast/src/views/layers.rs
@@ -167,7 +167,7 @@ struct TileParams {
     tag = "layers",
     params(InfraQueryParam, TileParams),
     responses(
-        (status = 200, body = Vec<u8>, description = "Successful Response"),
+        (status = 200, content_type = "application/octet-stream", body = String),
     )
 )]
 pub(in crate::views) async fn cache_and_get_mvt_tile(

--- a/editoast/src/views/openapi.rs
+++ b/editoast/src/views/openapi.rs
@@ -2,17 +2,19 @@ use std::collections::BTreeMap;
 
 use itertools::Itertools as _;
 use tracing::debug;
-use tracing::warn;
 use utoipa::OpenApi;
 use utoipa::openapi::AllOf;
 use utoipa::openapi::Array;
+use utoipa::openapi::HttpMethod;
 use utoipa::openapi::Object;
 use utoipa::openapi::OneOf;
 use utoipa::openapi::PathItem;
 use utoipa::openapi::RefOr;
 use utoipa::openapi::Schema;
+use utoipa::openapi::path::Operation;
 use utoipa::openapi::path::PathItemBuilder;
 use utoipa::openapi::schema::AnyOf;
+use utoipa::openapi::schema::ArrayItems;
 
 use crate::error::ErrorDefinition;
 use crate::views::service_router;
@@ -25,7 +27,35 @@ fn concat_path<A: AsRef<str>, B: AsRef<str>>(a: A, b: B) -> String {
     }
 }
 
-fn merge_path_items(a: PathItem, b: PathItem) -> PathItem {
+fn path_item_operations(path_item: PathItem) -> BTreeMap<HttpMethod, Operation> {
+    let mut operations = BTreeMap::new();
+    operations.extend(path_item.get.map(|op| (HttpMethod::Get, op)));
+    operations.extend(path_item.put.map(|op| (HttpMethod::Put, op)));
+    operations.extend(path_item.post.map(|op| (HttpMethod::Post, op)));
+    operations.extend(path_item.delete.map(|op| (HttpMethod::Delete, op)));
+    operations.extend(path_item.options.map(|op| (HttpMethod::Options, op)));
+    operations.extend(path_item.head.map(|op| (HttpMethod::Head, op)));
+    operations.extend(path_item.patch.map(|op| (HttpMethod::Patch, op)));
+    operations.extend(path_item.trace.map(|op| (HttpMethod::Trace, op)));
+    operations
+}
+
+fn path_item_operations_mut(path_item: &mut PathItem) -> Vec<&mut Operation> {
+    let mut operations = Vec::new();
+    operations.extend(path_item.get.as_mut());
+    operations.extend(path_item.put.as_mut());
+    operations.extend(path_item.post.as_mut());
+    operations.extend(path_item.delete.as_mut());
+    operations.extend(path_item.options.as_mut());
+    operations.extend(path_item.head.as_mut());
+    operations.extend(path_item.patch.as_mut());
+    operations.extend(path_item.trace.as_mut());
+    operations
+}
+
+fn merge_path_items(mut a: PathItem, b: PathItem) -> PathItem {
+    a.merge_operations(b.clone());
+    let operations = path_item_operations(a.clone());
     let mut builder = PathItemBuilder::new()
         .summary(a.summary.or(b.summary))
         .description(a.description.or(b.description))
@@ -39,16 +69,6 @@ fn merge_path_items(a: PathItem, b: PathItem) -> PathItem {
             (Some(s), None) | (None, Some(s)) => Some(s),
             (None, None) => None,
         });
-    let mut operations: BTreeMap<_, _> = a.operations;
-    for (method, operation) in b.operations {
-        if operations.contains_key(&method) {
-            warn!(
-                "duplicate operation for method {}",
-                serde_json::to_string(&method).unwrap() // PathItemType does not implement Display or Debug :(
-            );
-        }
-        operations.insert(method, operation);
-    }
     for (method, operation) in operations {
         builder = builder.operation(method, operation);
     }
@@ -82,8 +102,11 @@ fn remove_discriminator(schema: &mut RefOr<Schema>) {
                 remove_discriminator(property);
             }
         }
-        RefOr::T(Schema::Array(Array { items, .. })) => {
-            remove_discriminator(items);
+        RefOr::T(Schema::Array(Array {
+            items: ArrayItems::RefOrSchema(schema),
+            ..
+        })) => {
+            remove_discriminator(schema.as_mut());
         }
         _ => (),
     }
@@ -114,17 +137,21 @@ impl OpenApiRoot {
     // puts it. So we remove it, even though utoipa is correct.
     fn remove_discrimators(openapi: &mut utoipa::openapi::OpenApi) {
         for (_, endpoint) in openapi.paths.paths.iter_mut() {
-            for (_, operation) in endpoint.operations.iter_mut() {
+            for operation in path_item_operations_mut(endpoint) {
                 if let Some(request_body) = operation.request_body.as_mut() {
                     for (_, content) in request_body.content.iter_mut() {
-                        remove_discriminator(&mut content.schema);
+                        if let Some(schema) = content.schema.as_mut() {
+                            remove_discriminator(schema);
+                        }
                     }
                 }
                 for (_, response) in operation.responses.responses.iter_mut() {
                     match response {
                         RefOr::T(response) => {
                             for (_, content) in response.content.iter_mut() {
-                                remove_discriminator(&mut content.schema);
+                                if let Some(schema) = content.schema.as_mut() {
+                                    remove_discriminator(schema);
+                                }
                             }
                         }
                         RefOr::Ref { .. } => panic!("editoast doesn't support response references"),
@@ -144,7 +171,7 @@ impl OpenApiRoot {
     // Split comma-separated tags into multiple tags
     fn split_tags(openapi: &mut utoipa::openapi::OpenApi) {
         for (_, endpoint) in openapi.paths.paths.iter_mut() {
-            for (_, operation) in endpoint.operations.iter_mut() {
+            for operation in path_item_operations_mut(endpoint) {
                 operation.tags = operation.tags.as_ref().map(|tags| {
                     tags.iter()
                         .flat_map(|tag| tag.split(','))
@@ -160,30 +187,20 @@ impl OpenApiRoot {
         // We write openapi properties by alpha order, to keep the same yml file
         for prop_name in error_def.get_context().keys().sorted() {
             let prop_type = &error_def.get_context()[prop_name];
+            let utoipa_type = match prop_type.as_ref() {
+                "bool" => utoipa::openapi::schema::Type::Boolean,
+                "isize" | "i8" | "i16" | "i32" | "i64" | "usize" | "u8" | "u16" | "u32" | "u64" => {
+                    utoipa::openapi::schema::Type::Integer
+                }
+                "f8" | "f16" | "f32" | "f64" => utoipa::openapi::schema::Type::Number,
+                "Vec" => utoipa::openapi::schema::Type::Array,
+                "char" | "String" => utoipa::openapi::schema::Type::String,
+                _ => utoipa::openapi::schema::Type::Object,
+            };
             context.properties.insert(
                 prop_name.clone(),
                 utoipa::openapi::ObjectBuilder::new()
-                    .schema_type(match prop_type.as_ref() {
-                        "bool" => utoipa::openapi::SchemaType::Boolean,
-                        "isize" => utoipa::openapi::SchemaType::Integer,
-                        "i8" => utoipa::openapi::SchemaType::Integer,
-                        "i16" => utoipa::openapi::SchemaType::Integer,
-                        "i32" => utoipa::openapi::SchemaType::Integer,
-                        "i64" => utoipa::openapi::SchemaType::Integer,
-                        "usize" => utoipa::openapi::SchemaType::Integer,
-                        "u8" => utoipa::openapi::SchemaType::Integer,
-                        "u16" => utoipa::openapi::SchemaType::Integer,
-                        "u32" => utoipa::openapi::SchemaType::Integer,
-                        "u64" => utoipa::openapi::SchemaType::Integer,
-                        "f8" => utoipa::openapi::SchemaType::Number,
-                        "f16" => utoipa::openapi::SchemaType::Number,
-                        "f32" => utoipa::openapi::SchemaType::Number,
-                        "f64" => utoipa::openapi::SchemaType::Number,
-                        "Vec" => utoipa::openapi::SchemaType::Array,
-                        "char" => utoipa::openapi::SchemaType::String,
-                        "String" => utoipa::openapi::SchemaType::String,
-                        _ => utoipa::openapi::SchemaType::Object,
-                    })
+                    .schema_type(utoipa::openapi::schema::SchemaType::Type(utoipa_type))
                     .into(),
             );
             context.required.push(prop_name.clone());
@@ -212,19 +229,26 @@ impl OpenApiRoot {
                     .property(
                         "type",
                         utoipa::openapi::ObjectBuilder::new()
-                            .schema_type(utoipa::openapi::SchemaType::String)
+                            .schema_type(utoipa::openapi::schema::SchemaType::Type(
+                                utoipa::openapi::schema::Type::String,
+                            ))
                             .enum_values(Some([error_def.id])),
                     )
                     .property(
                         "status",
                         utoipa::openapi::ObjectBuilder::new()
-                            .schema_type(utoipa::openapi::SchemaType::Integer)
+                            .schema_type(utoipa::openapi::schema::SchemaType::Type(
+                                utoipa::openapi::schema::Type::Integer,
+                            ))
                             .enum_values(Some([error_def.status])),
                     )
                     .property(
                         "message",
-                        utoipa::openapi::ObjectBuilder::new()
-                            .schema_type(utoipa::openapi::SchemaType::String),
+                        utoipa::openapi::ObjectBuilder::new().schema_type(
+                            utoipa::openapi::schema::SchemaType::Type(
+                                utoipa::openapi::schema::Type::String,
+                            ),
+                        ),
                     )
                     .property("context", Self::error_context_to_openapi_object(error_def))
                     .required("type")
@@ -296,7 +320,7 @@ impl OpenApiRoot {
     // so that it doesn't override the RTK methods names.
     fn remove_operation_id(openapi: &mut utoipa::openapi::OpenApi) {
         for (_, endpoint) in openapi.paths.paths.iter_mut() {
-            for (_, operation) in endpoint.operations.iter_mut() {
+            for operation in path_item_operations_mut(endpoint) {
                 operation.operation_id = None;
                 // By default utoipa adds a tag "crate" to operations that don't have
                 // any. That causes problems with RTK tag management.

--- a/editoast/src/views/pagination.rs
+++ b/editoast/src/views/pagination.rs
@@ -220,9 +220,10 @@ impl<const MAX_PAGE_SIZE: u64> utoipa::IntoParams for PaginationQueryParams<MAX_
         use utoipa::openapi::ObjectBuilder;
         use utoipa::openapi::Required;
         use utoipa::openapi::SchemaFormat;
-        use utoipa::openapi::SchemaType;
         use utoipa::openapi::path::ParameterBuilder;
         use utoipa::openapi::path::ParameterIn;
+        use utoipa::openapi::schema::SchemaType;
+        use utoipa::openapi::schema::Type;
 
         [
             ParameterBuilder::new()
@@ -231,7 +232,7 @@ impl<const MAX_PAGE_SIZE: u64> utoipa::IntoParams for PaginationQueryParams<MAX_
                 .required(Required::False)
                 .schema(Some(
                     ObjectBuilder::new()
-                        .schema_type(SchemaType::Integer)
+                        .schema_type(SchemaType::Type(Type::Integer))
                         .format(Some(SchemaFormat::KnownFormat(KnownFormat::Int64)))
                         .minimum(Some(1f64))
                         .default(Some(json!(1))),
@@ -243,12 +244,11 @@ impl<const MAX_PAGE_SIZE: u64> utoipa::IntoParams for PaginationQueryParams<MAX_
                 .required(Required::False)
                 .schema(Some(
                     ObjectBuilder::new()
-                        .schema_type(SchemaType::Integer)
+                        .schema_type(SchemaType::Type(Type::Integer))
                         .format(Some(SchemaFormat::KnownFormat(KnownFormat::Int64)))
                         .minimum(Some(1f64))
                         .maximum(Some(MAX_PAGE_SIZE as f64))
-                        .default(Some(json!(MAX_PAGE_SIZE)))
-                        .nullable(true),
+                        .default(Some(json!(MAX_PAGE_SIZE))),
                 ))
                 .build(),
         ]

--- a/editoast/src/views/path/properties.rs
+++ b/editoast/src/views/path/properties.rs
@@ -41,7 +41,6 @@ use crate::views::path::retrieve_infra_version;
 #[derive(Debug, Serialize, Deserialize, ToSchema, Hash)]
 pub struct PathPropertiesInput {
     /// List of track sections
-    #[schema(value_type = Vec<CoreTrackRange>)]
     pub track_section_ranges: Vec<TrackRange>,
 }
 

--- a/editoast/src/views/project.rs
+++ b/editoast/src/views/project.rs
@@ -126,7 +126,7 @@ impl ProjectWithStudyCount {
     tag = "projects",
     request_body = ProjectCreateForm,
     responses(
-        (status = 201, body = ProjectWithStudies, description = "The created project"),
+        (status = 201, body = ProjectWithStudyCount, description = "The created project"),
     )
 )]
 pub(in crate::views) async fn create(
@@ -155,7 +155,6 @@ pub(in crate::views) async fn create(
 #[derive(Serialize, ToSchema)]
 #[cfg_attr(test, derive(Deserialize))]
 pub(in crate::views) struct ProjectWithStudyCountList {
-    #[schema(value_type = Vec<ProjectWithStudies>)]
     results: Vec<ProjectWithStudyCount>,
     #[serde(flatten)]
     stats: PaginationStats,
@@ -219,7 +218,7 @@ pub struct ProjectIdParam {
     tag = "projects",
     params(ProjectIdParam),
     responses(
-        (status = 200, body = ProjectWithStudies, description = "The requested project"),
+        (status = 200, body = ProjectWithStudyCount, description = "The requested project"),
     )
 )]
 pub(in crate::views) async fn get(
@@ -335,7 +334,7 @@ impl From<ProjectPatchForm> for Changeset<Project> {
         description = "The fields to update"
     ),
     responses(
-        (status = 200, body = ProjectWithStudies, description = "The updated project"),
+        (status = 200, body = ProjectWithStudyCount, description = "The updated project"),
     )
 )]
 pub(in crate::views) async fn patch(

--- a/editoast/src/views/project.rs
+++ b/editoast/src/views/project.rs
@@ -220,7 +220,6 @@ pub struct ProjectIdParam {
     params(ProjectIdParam),
     responses(
         (status = 200, body = ProjectWithStudies, description = "The requested project"),
-        (status = 404, body = InternalError, description = "The requested project was not found"),
     )
 )]
 pub(in crate::views) async fn get(
@@ -253,7 +252,6 @@ pub(in crate::views) async fn get(
     params(ProjectIdParam),
     responses(
         (status = 204, description = "The project was deleted successfully"),
-        (status = 404, body = InternalError, description = "The requested project was not found"),
     )
 )]
 pub(in crate::views) async fn delete(
@@ -338,7 +336,6 @@ impl From<ProjectPatchForm> for Changeset<Project> {
     ),
     responses(
         (status = 200, body = ProjectWithStudies, description = "The updated project"),
-        (status = 404, body = InternalError, description = "The requested project was not found"),
     )
 )]
 pub(in crate::views) async fn patch(

--- a/editoast/src/views/projection.rs
+++ b/editoast/src/views/projection.rs
@@ -34,8 +34,6 @@ use crate::views::timetable::simulation;
 use crate::views::timetable::simulation::SimulationResponseSuccess;
 use crate::views::timetable::simulation::train_simulation_batch;
 
-pub type SpaceTimeCurves = Vec<SpaceTimeCurve>;
-
 #[editoast_derive::openapi_schema]
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct ProjectPathForm {
@@ -179,7 +177,7 @@ impl TrainSimulationDetails {
 fn compute_space_time_curves(
     project_path_input: &TrainSimulationDetails,
     path_projection: &PathProjection,
-) -> SpaceTimeCurves {
+) -> Vec<SpaceTimeCurve> {
     let train_path = PathProjection::new(&project_path_input.train_path);
     let intersections = path_projection.get_intersections(&project_path_input.train_path);
     let positions = &project_path_input.positions;
@@ -338,7 +336,7 @@ pub async fn compute_projected_train_paths<T: TrainScheduleLike>(
     train_schedules: &[T],
     electrical_profile_set_id: Option<i64>,
     app_version: Option<&str>,
-) -> Result<Vec<Arc<SpaceTimeCurves>>> {
+) -> Result<Vec<Arc<Vec<SpaceTimeCurve>>>> {
     let path_projection = PathProjection::new(&track_section_ranges);
     let mut valkey_conn = valkey_client.get_connection().await?;
 
@@ -384,10 +382,10 @@ pub async fn compute_projected_train_paths<T: TrainScheduleLike>(
     let cached_projections = valkey_conn
         .json_get_bulk(&train_hashes)
         .await?
-        .collect::<Vec<Option<SpaceTimeCurves>>>();
+        .collect::<Vec<Option<Vec<SpaceTimeCurve>>>>();
 
     let mut projection_request_map: HashMap<String, TrainSimulationDetails> = HashMap::new();
-    let mut project_path_result: Vec<Arc<SpaceTimeCurves>> =
+    let mut project_path_result: Vec<Arc<Vec<SpaceTimeCurve>>> =
         vec![Arc::default(); train_schedules.len()];
     for (hash, projection) in train_hashes.into_iter().zip(cached_projections) {
         if let Some(projection) = projection {
@@ -626,7 +624,7 @@ pub async fn compute_projected_train_path_op<T: TrainScheduleLike>(
     infra: &Infra,
     electrical_profile_set_id: Option<i64>,
     app_version: Option<&str>,
-) -> Result<Vec<Arc<SpaceTimeCurves>>> {
+) -> Result<Vec<Arc<Vec<SpaceTimeCurve>>>> {
     let simulations = train_simulation_batch(
         conn,
         valkey_client.clone(),
@@ -675,7 +673,7 @@ fn project_train_path_op(
     }: &TrainToProjectOnOperationalPoint,
     path_item_cache: &PathItemCache,
     projection_op_id_to_positions: &OperationalPointProjection,
-) -> SpaceTimeCurves {
+) -> Vec<SpaceTimeCurve> {
     // Match operational point references with operational point ids
     let matching_ops = refs.iter().map(|op| {
         projection_op_id_to_positions

--- a/editoast/src/views/rolling_stock.rs
+++ b/editoast/src/views/rolling_stock.rs
@@ -676,7 +676,7 @@ struct MultipartImage {
     data: Vec<u8>,
 }
 
-#[derive(Clone, Debug, ToSchema)]
+#[derive(Clone, Debug)]
 struct FormattedImages {
     compound_image_height: u32,
     compound_image_width: u32,

--- a/editoast/src/views/round_trips.rs
+++ b/editoast/src/views/round_trips.rs
@@ -78,7 +78,9 @@ fn schema_round_trips() -> RefOr<Schema> {
             utoipa::openapi::schema::ArrayBuilder::new()
                 .items(
                     utoipa::openapi::ObjectBuilder::new()
-                        .schema_type(utoipa::openapi::SchemaType::Integer)
+                        .schema_type(utoipa::openapi::schema::SchemaType::Type(
+                            utoipa::openapi::schema::Type::Integer,
+                        ))
                         .format(Some(utoipa::openapi::SchemaFormat::KnownFormat(
                             utoipa::openapi::KnownFormat::Int64,
                         )))

--- a/editoast/src/views/router.rs
+++ b/editoast/src/views/router.rs
@@ -6,23 +6,37 @@ use std::collections::VecDeque;
 // constness is unstable. So O(n^2) here we go...
 //
 // If this takes too long, we can always optimize it later (structure, search algorithm, featuring utoipa).
-pub(in crate::views) type OpenApiRouteSliceItem =
-    fn(&str) -> Option<fn(Option<&str>) -> utoipa::openapi::path::PathItem>;
+pub(in crate::views) type OpenApiRouteSliceItem = fn(
+    &str,
+) -> Option<
+    fn(
+        Option<&str>, // TODO: not necessary for utoipa 5.X, remove
+    ) -> (
+        Vec<utoipa::openapi::path::HttpMethod>,
+        utoipa::openapi::path::Operation,
+        Vec<&'static str>, // tags
+    ),
+>;
 
 #[linkme::distributed_slice]
 pub(in crate::views) static OPENAPI_ROUTES: [OpenApiRouteSliceItem];
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub(super) struct DocumentedRouter {
     pub(super) router: axum::Router<super::AppState>,
     pub(super) path_trees: Vec<PathTree>,
 }
 
-#[derive(Debug)]
 pub(super) enum PathTree {
     Leaf {
         path_segment: &'static str,
-        openapi: fn(Option<&str>) -> utoipa::openapi::path::PathItem,
+        path_item: fn(
+            Option<&str>,
+        ) -> (
+            Vec<utoipa::openapi::path::HttpMethod>,
+            utoipa::openapi::path::Operation,
+            Vec<&'static str>,
+        ),
     },
     Branch {
         path_segment: &'static str,
@@ -35,8 +49,18 @@ impl PathTree {
         match self {
             PathTree::Leaf {
                 path_segment,
-                openapi,
-            } => vec![(VecDeque::from([path_segment]), openapi(None))],
+                path_item,
+            } => {
+                let (http_methods, mut operation, tags) = path_item(None);
+                // Since utoipa 5.x, tags are provided separately and need to be added to the operation manually                                                              ║
+                // as we're not collecting using the standard OpenApi macro.
+                if !tags.is_empty() {
+                    operation.tags = Some(tags.iter().map(|s| s.to_string()).collect());
+                }
+                let path_item =
+                    utoipa::openapi::path::PathItem::from_http_methods(http_methods, operation);
+                vec![(VecDeque::from([path_segment]), path_item)]
+            }
             PathTree::Branch {
                 path_segment,
                 sub_paths,
@@ -66,27 +90,23 @@ impl DocumentedRouter {
         (type_name, method_router, expected_method): (
             &str,
             axum::routing::MethodRouter<super::AppState>,
-            utoipa::openapi::PathItemType,
+            utoipa::openapi::HttpMethod,
         ),
     ) -> Self {
-        let Some(openapi) = OPENAPI_ROUTES.iter().find_map(|matcher| matcher(type_name)) else {
+        let Some(path_item) = OPENAPI_ROUTES.iter().find_map(|matcher| matcher(type_name)) else {
             panic!("no openapi found for route {path} with type {type_name}!");
         };
-        let operation_key = openapi(None)
-            .operations
-            .into_keys()
-            .next()
-            .expect("an utoipa path created using the path macro must have a method");
-        if operation_key != expected_method {
+        let (http_methods, _, _) = path_item(None);
+        if !http_methods.contains(&expected_method) {
             panic!(
                 "expected method {} in the router at \"{path}\" but found {} in utoipa path",
                 serde_json::to_string(&expected_method).unwrap(), // does not impl debug or display
-                serde_json::to_string(&operation_key).unwrap()
+                serde_json::to_string(&http_methods).unwrap()
             );
         }
         self.path_trees.push(PathTree::Leaf {
             path_segment: path,
-            openapi,
+            path_item,
         });
         Self {
             router: self.router.route(path, method_router),
@@ -112,7 +132,7 @@ macro_rules! get {
         (
             std::any::type_name_of_val(&$f),
             axum::routing::get($f),
-            utoipa::openapi::PathItemType::Get,
+            utoipa::openapi::HttpMethod::Get,
         )
     };
 }
@@ -122,7 +142,7 @@ macro_rules! post {
         (
             std::any::type_name_of_val(&$f),
             axum::routing::post($f),
-            utoipa::openapi::PathItemType::Post,
+            utoipa::openapi::HttpMethod::Post,
         )
     };
 }
@@ -132,7 +152,7 @@ macro_rules! delete {
         (
             std::any::type_name_of_val(&$f),
             axum::routing::delete($f),
-            utoipa::openapi::PathItemType::Delete,
+            utoipa::openapi::HttpMethod::Delete,
         )
     };
 }
@@ -142,7 +162,7 @@ macro_rules! put {
         (
             std::any::type_name_of_val(&$f),
             axum::routing::put($f),
-            utoipa::openapi::PathItemType::Put,
+            utoipa::openapi::HttpMethod::Put,
         )
     };
 }
@@ -152,7 +172,7 @@ macro_rules! patch {
         (
             std::any::type_name_of_val(&$f),
             axum::routing::patch($f),
-            utoipa::openapi::PathItemType::Patch,
+            utoipa::openapi::HttpMethod::Patch,
         )
     };
 }

--- a/editoast/src/views/router.rs
+++ b/editoast/src/views/router.rs
@@ -9,12 +9,10 @@ use std::collections::VecDeque;
 pub(in crate::views) type OpenApiRouteSliceItem = fn(
     &str,
 ) -> Option<
-    fn(
-        Option<&str>, // TODO: not necessary for utoipa 5.X, remove
-    ) -> (
+    fn() -> (
         Vec<utoipa::openapi::path::HttpMethod>,
         utoipa::openapi::path::Operation,
-        Vec<&'static str>, // tags
+        Vec<&'static str>,
     ),
 >;
 
@@ -30,9 +28,7 @@ pub(super) struct DocumentedRouter {
 pub(super) enum PathTree {
     Leaf {
         path_segment: &'static str,
-        path_item: fn(
-            Option<&str>,
-        ) -> (
+        path_item: fn() -> (
             Vec<utoipa::openapi::path::HttpMethod>,
             utoipa::openapi::path::Operation,
             Vec<&'static str>,
@@ -51,7 +47,7 @@ impl PathTree {
                 path_segment,
                 path_item,
             } => {
-                let (http_methods, mut operation, tags) = path_item(None);
+                let (http_methods, mut operation, tags) = path_item();
                 // Since utoipa 5.x, tags are provided separately and need to be added to the operation manually                                                              ║
                 // as we're not collecting using the standard OpenApi macro.
                 if !tags.is_empty() {
@@ -96,7 +92,7 @@ impl DocumentedRouter {
         let Some(path_item) = OPENAPI_ROUTES.iter().find_map(|matcher| matcher(type_name)) else {
             panic!("no openapi found for route {path} with type {type_name}!");
         };
-        let (http_methods, _, _) = path_item(None);
+        let (http_methods, _, _) = path_item();
         if !http_methods.contains(&expected_method) {
             panic!(
                 "expected method {} in the router at \"{path}\" but found {} in utoipa path",

--- a/editoast/src/views/scenario.rs
+++ b/editoast/src/views/scenario.rs
@@ -222,7 +222,6 @@ pub(in crate::views) async fn create(
     params(ProjectIdParam, StudyIdParam, ScenarioIdParam),
     responses(
         (status = 204, description = "The scenario was deleted successfully"),
-        (status = 404, body = InternalError, description = "The requested scenario was not found"),
     )
 )]
 pub(in crate::views) async fn delete(
@@ -304,7 +303,6 @@ impl From<ScenarioPatchForm> for <Scenario as editoast_models::prelude::Model>::
     request_body = ScenarioPatchForm,
     responses(
         (status = 204, body = ScenarioResponse, description = "The scenario was updated successfully"),
-        (status = 404, body = InternalError, description = "The requested scenario was not found"),
     )
 )]
 pub(in crate::views) async fn patch(
@@ -369,7 +367,6 @@ pub(in crate::views) async fn patch(
     params(ProjectIdParam, StudyIdParam, ScenarioIdParam),
     responses(
         (status = 200, body = ScenarioResponse, description = "The requested scenario"),
-        (status = 404, body = InternalError, description = "The requested scenario was not found"),
     )
 )]
 pub(in crate::views) async fn get(

--- a/editoast/src/views/scenario/macro_nodes.rs
+++ b/editoast/src/views/scenario/macro_nodes.rs
@@ -143,7 +143,6 @@ pub(in crate::views) struct MacroNodeListResponse {
     params(ProjectIdParam, StudyIdParam, ScenarioIdParam, PaginationQueryParams<100>),
     responses(
         (status = 200, body = MacroNodeListResponse, description = "List of macro nodes for the requested scenario"),
-        (status = 404, body = InternalError, description = "The requested scenario was not found"),
     )
 )]
 pub(in crate::views) async fn list(
@@ -251,7 +250,6 @@ pub(in crate::views) async fn create(
     params(ProjectIdParam, StudyIdParam, ScenarioIdParam, MacroNodeIdParam),
     responses(
         (status = 200, body = MacroNodeResponse, description = "The requested Macro node"),
-        (status = 404, body = InternalError, description = "The macro node was not found"),
     )
 )]
 pub(in crate::views) async fn get(
@@ -286,7 +284,6 @@ pub(in crate::views) async fn get(
     request_body = MacroNodeForm,
     responses(
         (status = 200, body = MacroNodeResponse, description = "The requested scenario"),
-        (status = 404, body = InternalError, description = "The macro node was not found"),
     )
 )]
 pub(in crate::views) async fn update(
@@ -348,7 +345,6 @@ pub(in crate::views) async fn update(
     params(ProjectIdParam, StudyIdParam, ScenarioIdParam, MacroNodeIdParam),
     responses(
         (status = 204, description = "The macro node was deleted successfully"),
-        (status = 404, body = InternalError, description = "The macro node was not found"),
     )
 )]
 pub(in crate::views) async fn delete(

--- a/editoast/src/views/stdcm_search_environment.rs
+++ b/editoast/src/views/stdcm_search_environment.rs
@@ -56,7 +56,7 @@ pub(in crate::views) struct StdcmSearchEnvironmentCreateForm {
     search_window_end: DateTime<Utc>,
     enabled_from: DateTime<Utc>,
     enabled_until: DateTime<Utc>,
-    #[schema(value_type = GeoJson)]
+    #[schema(value_type = Option<common::geometry::GeoJson>)]
     active_perimeter: Option<geos::geojson::Geometry>,
 }
 

--- a/editoast/src/views/study.rs
+++ b/editoast/src/views/study.rs
@@ -173,7 +173,6 @@ pub struct StudyIdParam {
     params(ProjectIdParam, StudyIdParam),
     responses(
         (status = 204, description = "The study was deleted successfully"),
-        (status = 404, body = InternalError, description = "The requested study was not found"),
     )
 )]
 pub(in crate::views) async fn delete(
@@ -210,7 +209,6 @@ pub(in crate::views) async fn delete(
     params(ProjectIdParam, StudyIdParam),
     responses(
         (status = 200, body = StudyResponse, description = "The requested study"),
-        (status = 404, body = InternalError, description = "The requested study was not found"),
     )
 )]
 pub(in crate::views) async fn get(
@@ -312,7 +310,6 @@ impl StudyPatchForm {
     ),
     responses(
         (status = 200, body = StudyResponse, description = "The updated study"),
-        (status = 404, body = InternalError, description = "The requested study was not found"),
     )
 )]
 pub(in crate::views) async fn patch(

--- a/editoast/src/views/study.rs
+++ b/editoast/src/views/study.rs
@@ -374,7 +374,6 @@ impl StudyWithScenarioCount {
 #[derive(Serialize, ToSchema)]
 #[cfg_attr(test, derive(Deserialize))]
 pub(in crate::views) struct StudyListResponse {
-    #[schema(value_type = Vec<StudyWithScenarios>)]
     results: Vec<StudyWithScenarioCount>,
     #[serde(flatten)]
     stats: PaginationStats,

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -9,6 +9,7 @@ use axum::extract::Path;
 use axum::extract::Query;
 use axum::extract::State;
 use axum::response::IntoResponse;
+use core_client::signal_projection::SignalUpdate;
 use database::DbConnectionPoolV2;
 use editoast_derive::EditoastError;
 use schemas::paced_train::PacedTrain;
@@ -221,9 +222,7 @@ pub(in crate::views) struct SimulationBatchForm {
 #[cfg_attr(test, derive(PartialEq, serde::Deserialize))]
 #[schema(as = PacedTrainSimulationSummaryResult)]
 pub(in crate::views) struct PacedTrainSummaryResponse {
-    #[schema(value_type = SimulationSummaryResult)]
     pub paced_train: SummaryResponse,
-    #[schema(value_type = HashMap<String, SimulationSummaryResult>)]
     /// The key is the `exception_key`
     pub exceptions: HashMap<String, SummaryResponse>,
 }
@@ -243,7 +242,7 @@ struct SimulationContext {
     tag = "paced_train",
     request_body = inline(SimulationBatchForm),
     responses(
-        (status = 200, description = "Associate each paced train id with its simulation summaries", body = HashMap<i64, PacedTrainSimulationSummaryResult>),
+        (status = 200, description = "Associate each paced train id with its simulation summaries", body = HashMap<i64, PacedTrainSummaryResponse>),
     ),
 )]
 pub(in crate::views) async fn simulation_summary(
@@ -465,7 +464,7 @@ pub struct ElectricalProfileSetIdQueryParam {
     tag = "paced_train",
     params(PacedTrainIdParam, InfraIdQueryParam, ElectricalProfileSetIdQueryParam, ExceptionQueryParam),
     responses(
-        (status = 200, description = "Simulation Output", body = SimulationResponse),
+        (status = 200, description = "Simulation Output", body = simulation::Response),
     ),
 )]
 pub(in crate::views) async fn simulation(

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -34,7 +34,8 @@ use crate::views::path::pathfinding::pathfinding_from_train;
 use crate::views::projection::OperationalPointProjection;
 use crate::views::projection::ProjectPathForm;
 use crate::views::projection::ProjectPathOperationalPointForm;
-use crate::views::projection::SpaceTimeCurves;
+use crate::views::projection::SpaceTimeCurve;
+
 use crate::views::projection::compute_projected_train_path_op;
 use crate::views::projection::compute_projected_train_paths;
 use crate::views::timetable::occupancy_blocks::OccupancyBlockForm;
@@ -549,11 +550,9 @@ pub(in crate::views) async fn simulation(
 #[derive(Debug, Deserialize, Serialize, ToSchema)]
 pub struct ProjectPathPacedTrainResult {
     /// Paced train
-    #[schema(value_type = Vec<SpaceTimeCurve>)]
-    pub paced_train: SpaceTimeCurves,
+    pub paced_train: Vec<SpaceTimeCurve>,
     /// Exceptions whose projection is different from the paced train
-    #[schema(value_type = HashMap<String, Vec<SpaceTimeCurve>>)]
-    pub exceptions: HashMap<String, SpaceTimeCurves>,
+    pub exceptions: HashMap<String, Vec<SpaceTimeCurve>>,
 }
 
 /// Projects the space-time curves and paths of a number of paced trains onto a given path.

--- a/editoast/src/views/timetable/similar_trains.rs
+++ b/editoast/src/views/timetable/similar_trains.rs
@@ -119,7 +119,6 @@ impl std::fmt::Debug for Waypoint {
 pub(in crate::views) struct Request {
     #[schema(inline)]
     rolling_stock: RollingStockCharacteristics,
-    #[schema(value_type = Vec<SimilarTrainWaypoint>)]
     waypoints: Vec<Waypoint>,
     infra_id: i64,
     timetable_id: i64,

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -68,7 +68,6 @@ pub(in crate::views) enum StdcmResponse {
         core_payload: Option<StdcmRequest>,
     },
     PreprocessingSimulationError {
-        #[schema(value_type = SimulationResponse)]
         error: simulation::Response,
         #[serde(skip_serializing_if = "Option::is_none")]
         core_payload: Option<StdcmRequest>,

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -13,6 +13,7 @@ use chrono::Duration;
 use chrono::Utc;
 use core_client::AsCoreRequest;
 use core_client::pathfinding::PathfindingResultSuccess;
+use core_client::signal_projection::SignalUpdate;
 use core_client::simulation::PhysicsConsist;
 use core_client::simulation::ReportTrain;
 

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -271,7 +271,7 @@ pub struct ElectricalProfileSetIdQueryParam {
     tag = "train_schedule",
     params(TrainScheduleIdParam, InfraIdQueryParam, ElectricalProfileSetIdQueryParam),
     responses(
-        (status = 200, description = "Simulation Output", body = SimulationResponse),
+        (status = 200, description = "Simulation Output", body = simulation::Response),
     ),
 )]
 pub(in crate::views) async fn simulation(
@@ -344,7 +344,7 @@ pub(in crate::views) async fn simulation(
     tag = "train_schedule,etcs_braking_curves",
     params(TrainScheduleIdParam, InfraIdQueryParam, ElectricalProfileSetIdQueryParam),
     responses(
-        (status = 200, description = "ETCS Braking Curves Output", body = ETCSBrakingCurvesResponse),
+        (status = 200, description = "ETCS Braking Curves Output", body = core_client::etcs_braking_curves::Response),
     ),
 )]
 pub(in crate::views) async fn etcs_braking_curves(
@@ -481,7 +481,7 @@ pub(in crate::views) struct SimulationBatchForm {
     tag = "train_schedule",
     request_body = inline(SimulationBatchForm),
     responses(
-        (status = 200, description = "Associate each train id with its simulation summary", body = HashMap<i64, SimulationSummaryResult>),
+        (status = 200, description = "Associate each train id with its simulation summary", body = HashMap<i64, simulation::SummaryResponse>),
     ),
 )]
 pub(in crate::views) async fn simulation_summary(

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -51,7 +51,7 @@ use crate::views::path::projection::TrackLocationFromPath;
 use crate::views::projection::OperationalPointProjection;
 use crate::views::projection::ProjectPathForm;
 use crate::views::projection::ProjectPathOperationalPointForm;
-use crate::views::projection::SpaceTimeCurves;
+use crate::views::projection::SpaceTimeCurve;
 use crate::views::projection::compute_projected_train_path_op;
 use crate::views::projection::compute_projected_train_paths;
 use crate::views::projection::find_index_upper;
@@ -650,7 +650,7 @@ pub(in crate::views) async fn project_path(
         track_section_ranges,
         electrical_profile_set_id,
     }): Json<ProjectPathForm>,
-) -> Result<Json<HashMap<i64, SpaceTimeCurves>>> {
+) -> Result<Json<HashMap<i64, Vec<SpaceTimeCurve>>>> {
     let infra = &Infra::retrieve_or_fail(db_pool.get().await?, infra_id, || {
         TrainScheduleError::InfraNotFound { infra_id }
     })
@@ -726,7 +726,7 @@ pub(in crate::views) async fn project_path_op(
         operational_points_refs,
         operational_points_distances,
     }): Json<ProjectPathOperationalPointForm>,
-) -> Result<Json<HashMap<i64, Arc<SpaceTimeCurves>>>> {
+) -> Result<Json<HashMap<i64, Arc<Vec<SpaceTimeCurve>>>>> {
     let infra = &Infra::retrieve_or_fail(db_pool.get().await?, infra_id, || {
         TrainScheduleError::InfraNotFound { infra_id }
     })
@@ -1599,7 +1599,7 @@ pub mod tests {
                 },
             ],
         }));
-        let response: HashMap<i64, SpaceTimeCurves> =
+        let response: HashMap<i64, Vec<SpaceTimeCurve>> =
             app.fetch(request).assert_status(StatusCode::OK).json_into();
 
         // EXPECT

--- a/editoast/src/views/work_schedules.rs
+++ b/editoast/src/views/work_schedules.rs
@@ -176,7 +176,6 @@ pub(in crate::views) async fn create(
 #[derive(Serialize, Deserialize, ToSchema)]
 pub(in crate::views) struct WorkScheduleProjectForm {
     work_schedule_group_id: i64,
-    #[schema(value_type = Vec<CoreTrackRange>)]
     path_track_ranges: Vec<core_client::pathfinding::TrackRange>,
 }
 

--- a/front/src/applications/editor/tools/rangeEdition/utils.ts
+++ b/front/src/applications/editor/tools/rangeEdition/utils.ts
@@ -405,7 +405,7 @@ export const makeRouteElements = (
   trackRangesResults.reduce((acc, cur, index) => {
     if (cur.type === 'Computed') {
       const trackRanges = cur.track_ranges.map((trackRange) => renameDirection(trackRange));
-      const switches = cur.switches_directions.map((sw) => sw[0]);
+      const switches = cur.switches_directions.map(({ switch_id }) => switch_id);
       return {
         ...acc,
         [routes[index]]: {

--- a/front/src/common/Map/Search/MapSearchLine.tsx
+++ b/front/src/common/Map/Search/MapSearchLine.tsx
@@ -65,7 +65,10 @@ const MapSearchLine = ({
       });
   };
 
-  const coordinates = (search: BoundingBox) => search;
+  const coordinates = ({ min_lon, max_lon, min_lat, max_lat }: BoundingBox) => [
+    [min_lon, min_lat],
+    [max_lon, max_lat],
+  ];
 
   const onResultClick = async (searchResultItem: SearchResultItemTrack) => {
     if (mapSettings.mapSearchMarker) {

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -201,18 +201,18 @@ const injectedRtkApi = api
         query: (queryArg) => ({ url: `/infra/${queryArg.infraId}` }),
         providesTags: ['infra'],
       }),
-      postInfraByInfraId: build.mutation<PostInfraByInfraIdApiResponse, PostInfraByInfraIdApiArg>({
-        query: (queryArg) => ({
-          url: `/infra/${queryArg.infraId}`,
-          method: 'POST',
-          body: queryArg.body,
-        }),
-        invalidatesTags: ['infra'],
-      }),
       putInfraByInfraId: build.mutation<PutInfraByInfraIdApiResponse, PutInfraByInfraIdApiArg>({
         query: (queryArg) => ({
           url: `/infra/${queryArg.infraId}`,
           method: 'PUT',
+          body: queryArg.body,
+        }),
+        invalidatesTags: ['infra'],
+      }),
+      postInfraByInfraId: build.mutation<PostInfraByInfraIdApiResponse, PostInfraByInfraIdApiArg>({
+        query: (queryArg) => ({
+          url: `/infra/${queryArg.infraId}`,
+          method: 'POST',
           body: queryArg.body,
         }),
         invalidatesTags: ['infra'],
@@ -1476,14 +1476,14 @@ export type GetAuthzByResourceTypeAndResourceIdApiArg = {
   resourceType: ResourceType;
   resourceId: number;
   page?: number;
-  pageSize?: number | null;
+  pageSize?: number;
 };
 export type PostDocumentsApiResponse =
   /** status 201 The document was created */ NewDocumentResponse;
 export type PostDocumentsApiArg = {
   /** The document's content type */
   contentType: string;
-  body: Blob;
+  body: string;
 };
 export type GetDocumentsByDocumentKeyApiResponse = unknown;
 export type GetDocumentsByDocumentKeyApiArg = {
@@ -1534,7 +1534,7 @@ export type GetInfraApiResponse = /** status 200 All infras, paginated */ Pagina
 };
 export type GetInfraApiArg = {
   page?: number;
-  pageSize?: number | null;
+  pageSize?: number;
 };
 export type PostInfraApiResponse = /** status 201 The created infra */ Infra;
 export type PostInfraApiArg = {
@@ -1571,13 +1571,6 @@ export type GetInfraByInfraIdApiArg = {
   /** An existing infra ID */
   infraId: number;
 };
-export type PostInfraByInfraIdApiResponse =
-  /** status 200 The result of the operations */ InfraObject[];
-export type PostInfraByInfraIdApiArg = {
-  /** An existing infra ID */
-  infraId: number;
-  body: Operation[];
-};
 export type PutInfraByInfraIdApiResponse = /** status 200 The infra has been renamed */ Infra;
 export type PutInfraByInfraIdApiArg = {
   /** An existing infra ID */
@@ -1586,6 +1579,13 @@ export type PutInfraByInfraIdApiArg = {
     /** The new name to give the infra */
     name: string;
   };
+};
+export type PostInfraByInfraIdApiResponse =
+  /** status 200 The result of the operations */ InfraObject[];
+export type PostInfraByInfraIdApiArg = {
+  /** An existing infra ID */
+  infraId: number;
+  body: Operation[];
 };
 export type DeleteInfraByInfraIdApiResponse = unknown;
 export type DeleteInfraByInfraIdApiArg = {
@@ -1636,13 +1636,13 @@ export type GetInfraByInfraIdErrorsApiArg = {
   /** An existing infra ID */
   infraId: number;
   page?: number;
-  pageSize?: number | null;
+  pageSize?: number;
   /** Whether the response should include errors or warnings */
   level?: 'warnings' | 'errors' | 'all';
   /** The type of error to filter on */
-  errorType?: InfraErrorTypeLabel | null;
+  errorType?: InfraErrorTypeLabel;
   /** Filter errors and warnings related to a given object */
-  objectId?: string | null;
+  objectId?: string;
 };
 export type GetInfraByInfraIdLinesAndLineCodeBboxApiResponse =
   /** status 200 The BBox of the line */ BoundingBox;
@@ -1709,7 +1709,7 @@ export type PostInfraByInfraIdPathfindingApiResponse =
 export type PostInfraByInfraIdPathfindingApiArg = {
   /** An existing infra ID */
   infraId: number;
-  number?: number | null;
+  number?: number;
   infraPathfindingInput: InfraPathfindingInput;
 };
 export type PostInfraByInfraIdPathfindingBlocksApiResponse =
@@ -1835,7 +1835,7 @@ export type GetLightRollingStockApiResponse = /** status 200  */ PaginationStats
 };
 export type GetLightRollingStockApiArg = {
   page?: number;
-  pageSize?: number | null;
+  pageSize?: number;
 };
 export type GetLightRollingStockNameByRollingStockNameApiResponse =
   /** status 200 The rolling stock with their simplified effort curves */ LightRollingStockWithLiveries;
@@ -1877,11 +1877,13 @@ export type PostPacedTrainProjectPathOpApiArg = {
     operational_points_distances: number[];
     operational_points_refs: (
       | {
+          /** The object id of an operational point */
           operational_point: string;
         }
       | {
           /** An optional secondary code to identify a more specific location */
           secondary_code?: string | null;
+          /** The operational point trigram */
           trigram: string;
         }
       | {
@@ -1916,7 +1918,9 @@ export type PutPacedTrainByIdApiArg = {
   body: TrainSchedule & {
     exceptions: PacedTrainException[];
     paced: {
+      /** Time between two occurrences, an ISO 8601 format is expected */
       interval: PositiveDuration;
+      /** Duration of the paced train, an ISO 8601 format is expected */
       time_window: PositiveDuration;
     };
   };
@@ -1925,22 +1929,22 @@ export type GetPacedTrainByIdPathApiResponse = /** status 200 The path */ Pathfi
 export type GetPacedTrainByIdPathApiArg = {
   id: number;
   infraId: number;
-  exceptionKey?: string | null;
+  exceptionKey?: string;
 };
 export type GetPacedTrainByIdSimulationApiResponse =
   /** status 200 Simulation Output */ SimulationResponse;
 export type GetPacedTrainByIdSimulationApiArg = {
   id: number;
   infraId: number;
-  electricalProfileSetId?: number | null;
-  exceptionKey?: string | null;
+  electricalProfileSetId?: number;
+  exceptionKey?: string;
 };
 export type GetProjectsApiResponse = /** status 200 The list of projects */ PaginationStats & {
   results: ProjectWithStudies[];
 };
 export type GetProjectsApiArg = {
   page?: number;
-  pageSize?: number | null;
+  pageSize?: number;
   ordering?: Ordering;
 };
 export type PostProjectsApiResponse = /** status 201 The created project */ ProjectWithStudies;
@@ -1974,7 +1978,7 @@ export type GetProjectsByProjectIdStudiesApiArg = {
   /** The id of a project */
   projectId: number;
   page?: number;
-  pageSize?: number | null;
+  pageSize?: number;
   ordering?: Ordering;
 };
 export type PostProjectsByProjectIdStudiesApiResponse =
@@ -2015,7 +2019,7 @@ export type GetProjectsByProjectIdStudiesAndStudyIdScenariosApiArg = {
   projectId: number;
   studyId: number;
   page?: number;
-  pageSize?: number | null;
+  pageSize?: number;
   ordering?: Ordering;
 };
 export type PostProjectsByProjectIdStudiesAndStudyIdScenariosApiResponse =
@@ -2058,7 +2062,7 @@ export type GetProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNodes
   studyId: number;
   scenarioId: number;
   page?: number;
-  pageSize?: number | null;
+  pageSize?: number;
 };
 export type PostProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNodesApiResponse =
   /** status 201 Macro nodes created */ MacroNodeBatchResponse;
@@ -2173,7 +2177,7 @@ export type PostRoundTripsTrainSchedulesDeleteApiArg = {
 export type PostSearchApiResponse = /** status 200 The search results */ SearchResultItem[];
 export type PostSearchApiArg = {
   page?: number;
-  pageSize?: number | null;
+  pageSize?: number;
   searchPayload: SearchPayload;
 };
 export type PostSimilarTrainsApiResponse =
@@ -2181,10 +2185,12 @@ export type PostSimilarTrainsApiResponse =
     similar_trains: {
       begin: string;
       end: string;
-      train?: {
+      /** `train` is `None` if no similar train
+        was found for the segment; otherwise, it is `Some`. */
+      train?: null | {
         start_time: string;
         train_name: string;
-      } | null;
+      };
     }[];
   };
 export type PostSimilarTrainsApiArg = {
@@ -2220,7 +2226,7 @@ export type GetStdcmSearchEnvironmentListApiResponse =
   };
 export type GetStdcmSearchEnvironmentListApiArg = {
   page?: number;
-  pageSize?: number | null;
+  pageSize?: number;
 };
 export type DeleteStdcmSearchEnvironmentByEnvIdApiResponse = unknown;
 export type DeleteStdcmSearchEnvironmentByEnvIdApiArg = {
@@ -2231,7 +2237,7 @@ export type GetSubCategoryApiResponse =
   /** status 200 The list of sub categories */ SubCategoryPage;
 export type GetSubCategoryApiArg = {
   page?: number;
-  pageSize?: number | null;
+  pageSize?: number;
 };
 export type PostSubCategoryApiResponse = /** status 200 Create sub categories */ SubCategory[];
 export type PostSubCategoryApiArg = {
@@ -2270,7 +2276,7 @@ export type GetTimetableByIdConflictsApiArg = {
   /** A timetable ID */
   id: number;
   infraId: number;
-  electricalProfileSetId?: number | null;
+  electricalProfileSetId?: number;
 };
 export type GetTimetableByIdPacedTrainsApiResponse =
   /** status 200 Timetable with paced train ids */ PaginationStats & {
@@ -2280,7 +2286,7 @@ export type GetTimetableByIdPacedTrainsApiArg = {
   /** A timetable ID */
   id: number;
   page?: number;
-  pageSize?: number | null;
+  pageSize?: number;
 };
 export type PostTimetableByIdPacedTrainsApiResponse =
   /** status 200 The created paced trains */ PacedTrainResponse[];
@@ -2297,9 +2303,9 @@ export type GetTimetableByIdRequirementsApiArg = {
   /** A timetable ID */
   id: number;
   page?: number;
-  pageSize?: number | null;
+  pageSize?: number;
   infraId: number;
-  electricalProfileSetId?: number | null;
+  electricalProfileSetId?: number;
 };
 export type GetTimetableByIdRoundTripsPacedTrainsApiResponse =
   /** status 200  */ PaginationStats & {
@@ -2309,7 +2315,7 @@ export type GetTimetableByIdRoundTripsPacedTrainsApiArg = {
   /** A timetable ID */
   id: number;
   page?: number;
-  pageSize?: number | null;
+  pageSize?: number;
 };
 export type GetTimetableByIdRoundTripsTrainSchedulesApiResponse =
   /** status 200  */ PaginationStats & {
@@ -2319,22 +2325,22 @@ export type GetTimetableByIdRoundTripsTrainSchedulesApiArg = {
   /** A timetable ID */
   id: number;
   page?: number;
-  pageSize?: number | null;
+  pageSize?: number;
 };
 export type PostTimetableByIdStdcmApiResponse = /** status 201 The simulation result */
   | {
-      core_payload?: StdcmRequest | null;
+      core_payload?: null | StdcmRequest;
       departure_time: string;
       pathfinding_result: PathfindingResultSuccess;
       simulation: SimulationResponseSuccess;
       status: 'success';
     }
   | {
-      core_payload?: StdcmRequest | null;
+      core_payload?: null | StdcmRequest;
       status: 'path_not_found';
     }
   | {
-      core_payload?: StdcmRequest | null;
+      core_payload?: null | StdcmRequest;
       error: SimulationResponse;
       status: 'preprocessing_simulation_error';
     };
@@ -2348,10 +2354,10 @@ export type PostTimetableByIdStdcmApiArg = {
   body: {
     comfort: Comfort;
     electrical_profile_set_id?: number | null;
-    loading_gauge_type?: LoadingGaugeType | null;
+    loading_gauge_type?: null | LoadingGaugeType;
     /** Can be a percentage `X%`, a time in minutes per 100 kilometer `Xmin/100km` */
     margin?: string | null;
-    /** Maximum speed of the consist in km/h
+    /**  Maximum speed of the consist in km/h
         Velocity in m·s⁻¹ */
     max_speed?: number | null;
     /** By how long we can shift the departure time in milliseconds
@@ -2377,10 +2383,10 @@ export type PostTimetableByIdStdcmApiArg = {
         Enforces that the path used by the train should be free and
         available at least that many milliseconds before its passage. */
     time_gap_before?: number;
-    /** Total length of the consist in meters
+    /**  Total length of the consist in meters
         Length in m */
     total_length?: number | null;
-    /** Total mass of the consist
+    /**  Total mass of the consist
         Mass in kg */
     total_mass?: number | null;
     towed_rolling_stock_id?: number | null;
@@ -2395,7 +2401,7 @@ export type GetTimetableByIdTrainSchedulesApiArg = {
   /** A timetable ID */
   id: number;
   page?: number;
-  pageSize?: number | null;
+  pageSize?: number;
 };
 export type PostTimetableByIdTrainSchedulesApiResponse =
   /** status 200 The created train schedules */ TrainScheduleResponse[];
@@ -2409,7 +2415,7 @@ export type GetTowedRollingStockApiResponse = /** status 200  */ PaginationStats
 };
 export type GetTowedRollingStockApiArg = {
   page?: number;
-  pageSize?: number | null;
+  pageSize?: number;
 };
 export type PostTowedRollingStockApiResponse =
   /** status 200 The created towed rolling stock */ TowedRollingStock;
@@ -2463,11 +2469,13 @@ export type PostTrainScheduleProjectPathOpApiArg = {
     operational_points_distances: number[];
     operational_points_refs: (
       | {
+          /** The object id of an operational point */
           operational_point: string;
         }
       | {
           /** An optional secondary code to identify a more specific location */
           secondary_code?: string | null;
+          /** The operational point trigram */
           trigram: string;
         }
       | {
@@ -2574,7 +2582,7 @@ export type GetWorkSchedulesGroupByIdApiResponse =
   };
 export type GetWorkSchedulesGroupByIdApiArg = {
   page?: number;
-  pageSize?: number | null;
+  pageSize?: number;
   /** A work schedule group ID */
   id: number;
   ordering?: Ordering;
@@ -2601,6 +2609,7 @@ export type PostWorkSchedulesProjectPathApiResponse =
     path_position_ranges: Intersection[];
     /** The date and time when the work schedule takes effect. */
     start_date_time: string;
+    /** The type of the work schedule. */
     type: 'CATENARY' | 'TRACK';
   }[];
 export type PostWorkSchedulesProjectPathApiArg = {
@@ -2695,9 +2704,9 @@ export type Infra = {
 };
 export type BufferStop = {
   extensions?: {
-    sncf?: {
+    sncf?: null | {
       kp: string;
-    } | null;
+    };
   };
   id: string;
   position: number;
@@ -2756,12 +2765,12 @@ export type Sign = {
 export type NeutralSection = {
   announcement_track_ranges: DirectionalTrackRange[];
   extensions?: {
-    neutral_sncf?: {
+    neutral_sncf?: null | {
       announcement: Sign[];
       end: Sign[];
       exe: Sign;
       rev: Sign[];
-    } | null;
+    };
   };
   id: string;
   lower_pantograph: boolean;
@@ -2769,26 +2778,26 @@ export type NeutralSection = {
 };
 export type OperationalPointPart = {
   extensions?: {
-    sncf?: {
+    sncf?: null | {
       kp: string;
-    } | null;
+    };
   };
   position: number;
   track: string;
 };
 export type OperationalPoint = {
   extensions?: {
-    identifier?: {
+    identifier?: null | {
       name: string;
       uic: number;
-    } | null;
-    sncf?: {
+    };
+    sncf?: null | {
       ch: string;
       ch_long_label: string;
       ch_short_label: string;
       ci: number;
       trigram: string;
-    } | null;
+    };
   };
   id: string;
   parts: OperationalPointPart[];
@@ -2816,11 +2825,11 @@ export type Route = {
 export type Signal = {
   direction: Direction;
   extensions?: {
-    sncf?: {
+    sncf?: null | {
       kp: string;
       label: string;
       side?: Side;
-    } | null;
+    };
   };
   id: string;
   logical_signals?: {
@@ -2845,15 +2854,15 @@ export type Signal = {
 };
 export type SpeedSection = {
   extensions?: {
-    psl_sncf?: {
+    psl_sncf?: null | {
       announcement: Sign[];
       r: Sign[];
       z: Sign;
-    } | null;
+    };
   };
   id: string;
-  on_routes?: string[] | null;
-  speed_limit?: number | null;
+  on_routes?: string[];
+  speed_limit?: null | number;
   speed_limit_by_tag: {
     [key: string]: number;
   };
@@ -2866,9 +2875,9 @@ export type TrackEndpoint = {
 };
 export type Switch = {
   extensions?: {
-    sncf?: {
+    sncf?: null | {
       label: string;
-    } | null;
+    };
   };
   group_change_delay: number;
   id: string;
@@ -2911,16 +2920,16 @@ export type Slope = {
 export type TrackSection = {
   curves: Curve[];
   extensions?: {
-    sncf?: {
+    sncf?: null | {
       line_code: number;
       line_name: string;
       track_name: string;
       track_number: number;
-    } | null;
-    source?: {
+    };
+    source?: null | {
       id: string;
       name: string;
-    } | null;
+    };
   };
   geo: GeoJsonLineString;
   id: string;
@@ -3183,13 +3192,13 @@ export type InfraErrorTypeLabel =
   | 'overlapping_switches'
   | 'unknown_port_name'
   | 'unused_port';
-export type BoundingBox = (number & number)[][];
+export type BoundingBox = never[][];
 export type GeoJsonPoint = {
   coordinates: GeoJsonPointValue;
   type: 'Point';
 };
 export type RelatedOperationalPoint = OperationalPoint & {
-  geo?: GeoJsonPoint | null;
+  geo?: null | GeoJsonPoint;
 };
 export type TrackReference =
   | {
@@ -3200,11 +3209,13 @@ export type TrackReference =
     };
 export type OperationalPointReference = (
   | {
+      /** The object id of an operational point */
       operational_point: string;
     }
   | {
       /** An optional secondary code to identify a more specific location */
       secondary_code?: string | null;
+      /** The operational point trigram */
       trigram: string;
     }
   | {
@@ -3214,7 +3225,7 @@ export type OperationalPointReference = (
       uic: number;
     }
 ) & {
-  track_reference?: TrackReference | null;
+  track_reference?: null | TrackReference;
 };
 export type GeoJsonMultiPointValue = GeoJsonPointValue[];
 export type GeoJsonMultiPoint = {
@@ -3249,27 +3260,29 @@ export type InfraObjectWithGeometry = {
   railjson: object;
 };
 export type OperationalPointExtensions = {
-  identifier?: {
+  identifier?: null | {
     name: string;
     uic: number;
-  } | null;
-  sncf?: {
+  };
+  sncf?: null | {
     ch: string;
     ch_long_label: string;
     ch_short_label: string;
     ci: number;
     trigram: string;
-  } | null;
+  };
 };
 export type PathProperties = {
-  curves?: {
+  /** Curves along the path */
+  curves?: null | {
     /** List of `n` boundaries of the ranges.
         A boundary is a distance from the beginning of the path in mm. */
     boundaries: number[];
     /** List of `n+1` values associated to the ranges */
     values: number[];
-  } | null;
-  electrifications?: {
+  };
+  /** Electrification modes and neutral section along the path */
+  electrifications?: null | {
     /** List of `n` boundaries of the ranges.
         A boundary is a distance from the beginning of the path in mm. */
     boundaries: number[];
@@ -3287,34 +3300,37 @@ export type PathProperties = {
           type: 'non_electrified';
         }
     )[];
-  } | null;
-  geometry?: GeoJsonLineString | null;
+  };
+  geometry?: null | GeoJsonLineString;
   /** Operational points along the path */
-  operational_points?:
-    | {
-        extensions?: OperationalPointExtensions;
-        id: string;
-        part: OperationalPointPart;
-        /** Distance from the beginning of the path in mm */
-        position: number;
-        /** Importance of the operational point */
-        weight: number | null;
-      }[]
-    | null;
-  slopes?: {
+  operational_points?: {
+    /** Extensions associated to the operational point */
+    extensions?: OperationalPointExtensions;
+    /** Id of the operational point */
+    id: string;
+    /** The part along the path */
+    part: OperationalPointPart;
+    /** Distance from the beginning of the path in mm */
+    position: number;
+    /** Importance of the operational point */
+    weight: number | null;
+  }[];
+  /** Slopes along the path */
+  slopes?: null | {
     /** List of `n` boundaries of the ranges.
         A boundary is a distance from the beginning of the path in mm. */
     boundaries: number[];
     /** List of `n+1` values associated to the ranges */
     values: number[];
-  } | null;
-  zones?: {
+  };
+  /** Zones along the path */
+  zones?: null | {
     /** List of `n` boundaries of the ranges.
         A boundary is a distance from the beginning of the path in mm. */
     boundaries: number[];
     /** List of `n+1` values associated to the ranges */
     values: string[];
-  } | null;
+  };
 };
 export type Property =
   | 'slopes'
@@ -3326,9 +3342,11 @@ export type Property =
 export type CoreTrackRange = {
   /** The beginning of the range in mm. */
   begin: number;
+  /** The direction of the range. */
   direction: Direction;
   /** The end of the range in mm. */
   end: number;
+  /** The track section identifier. */
   track_section: string;
 };
 export type PathPropertiesInput = {
@@ -3355,6 +3373,7 @@ export type ObjectRange = {
   begin: number;
   /** The end of the range in mm. */
   end: number;
+  /** The object identifier. */
   id: string;
 };
 export type TrainPath = {
@@ -3368,17 +3387,39 @@ export type TrainPath = {
 export type PathfindingResultSuccess = {
   /** Length of the path in mm */
   length: number;
+  /** Full description of the path data */
   path: TrainPath;
   /** The path offset in mm of each path item given as input of the pathfinding
     The first value is always `0` (beginning of the path) and the last one is always equal to the `length` of the path in mm */
   path_item_positions: number[];
 };
-export type TrackOffset = {
-  /** Offset in mm */
-  offset: number;
-  track: string;
-};
-export type PathItemLocation = TrackOffset | OperationalPointReference;
+export type PathItemLocation =
+  | {
+      /** Offset in mm */
+      offset: number;
+      /** Track section identifier */
+      track: string;
+    }
+  | ((
+      | {
+          /** The object id of an operational point */
+          operational_point: string;
+        }
+      | {
+          /** An optional secondary code to identify a more specific location */
+          secondary_code?: string | null;
+          /** The operational point trigram */
+          trigram: string;
+        }
+      | {
+          /** An optional secondary code to identify a more specific location */
+          secondary_code?: string | null;
+          /** The [UIC](https://en.wikipedia.org/wiki/List_of_UIC_country_codes) code of an operational point */
+          uic: number;
+        }
+    ) & {
+      track_reference?: null | TrackReference;
+    });
 export type PathfindingInputError =
   | {
       error_type: 'invalid_path_items';
@@ -3465,6 +3506,7 @@ export type PathfindingInput = {
   rolling_stock_is_thermal: boolean;
   /** Rolling stock length */
   rolling_stock_length: number;
+  /** The loading gauge of the rolling stock */
   rolling_stock_loading_gauge: LoadingGaugeType;
   /** Rolling stock maximum speed */
   rolling_stock_maximum_speed: number;
@@ -3477,8 +3519,14 @@ export type PathfindingInput = {
   speed_limit_tag?: string | null;
 };
 export type RoutePath = {
-  switches_directions: (string & string)[][];
+  switches_directions: never[][];
   track_ranges: DirectionalTrackRange[];
+};
+export type TrackOffset = {
+  /** Offset in mm */
+  offset: number;
+  /** Track section identifier */
+  track: string;
 };
 export type LightModeEffortCurves = {
   is_electric: boolean;
@@ -3499,7 +3547,7 @@ export type RefillLaw = {
 };
 export type EnergyStorage = {
   capacity: number;
-  refill_law: RefillLaw | null;
+  refill_law: null | RefillLaw;
   soc: number;
   soc_max: number;
   soc_min: number;
@@ -3534,12 +3582,25 @@ export type SpeedIntervalValueCurve = {
   values: number[];
 };
 export type EtcsBrakeParams = {
+  /** A_brake_emergency: the emergency deceleration curve (values > 0 m/s²) */
   gamma_emergency: SpeedIntervalValueCurve;
+  /** A_brake_normal_service: the normal service deceleration curve used to compute guidance curve (values > 0 m/s²) */
   gamma_normal_service: SpeedIntervalValueCurve;
+  /** A_brake_service: the full service deceleration curve (values > 0 m/s²) */
   gamma_service: SpeedIntervalValueCurve;
+  /** Kdry_rst: the rolling stock deceleration correction factors for dry rails
+    Boundaries should be the same as gammaEmergency
+    Values (no unit) should be contained in [0, 1] */
   k_dry: SpeedIntervalValueCurve;
+  /** Kn-: the correction acceleration factor on normal service deceleration in negative gradients
+    Values (in m/s²) should be contained in [0, 10] */
   k_n_neg: SpeedIntervalValueCurve;
+  /** Kn+: the correction acceleration factor on normal service deceleration in positive gradients
+    Values (in m/s²) should be contained in [0, 10] */
   k_n_pos: SpeedIntervalValueCurve;
+  /** Kwet_rst: the rolling stock deceleration correction factors for wet rails
+    Boundaries should be the same as gammaEmergency
+    Values (no unit) should be contained in [0, 1] */
   k_wet: SpeedIntervalValueCurve;
   /** T_be: safe brake build up time in s */
   t_be: number;
@@ -3574,13 +3635,13 @@ export type TrainMainCategory =
   | 'WORK_TRAIN';
 export type TrainMainCategories = TrainMainCategory[];
 export type RollingResistance = {
-  /** Solid friction
+  /**  Solid friction
     Solid Friction in N */
   A: number;
-  /** Viscosity friction in N·(m/s)⁻¹; N = kg⋅m⋅s⁻²
+  /**  Viscosity friction in N·(m/s)⁻¹; N = kg⋅m⋅s⁻²
     Viscosity friction in kg·s⁻¹ */
   B: number;
-  /** Aerodynamic drag in N·(m/s)⁻²; N = kg⋅m⋅s⁻²
+  /**  Aerodynamic drag in N·(m/s)⁻²; N = kg⋅m⋅s⁻²
     Aerodynamic drag in kg·m⁻¹ */
   C: number;
   type: string;
@@ -3594,7 +3655,7 @@ export type LightRollingStock = {
   const_gamma: number;
   effort_curves: LightEffortCurves;
   energy_sources: EnergySource[];
-  etcs_brake_params: EtcsBrakeParams | null;
+  etcs_brake_params: null | EtcsBrakeParams;
   id: number;
   inertia_coefficient: number;
   /** Length in m */
@@ -3605,7 +3666,7 @@ export type LightRollingStock = {
   mass: number;
   /** Velocity in m·s⁻¹ */
   max_speed: number;
-  metadata: RollingStockMetadata | null;
+  metadata: null | RollingStockMetadata;
   name: string;
   other_categories: TrainMainCategories;
   power_restrictions: {
@@ -3686,9 +3747,11 @@ export type ProjectPathForm = {
   track_section_ranges: {
     /** The beginning of the range in mm. */
     begin: number;
+    /** The direction of the range. */
     direction: Direction;
     /** The end of the range in mm. */
     end: number;
+    /** The track section identifier. */
     track_section: string;
   }[];
 };
@@ -3747,7 +3810,7 @@ export type Distribution = 'STANDARD' | 'MARECO';
 export type PositiveDuration = string;
 export type ReceptionSignal = 'OPEN' | 'STOP' | 'SHORT_SLIP_STOP';
 export type TrainSchedule = {
-  category?: TrainCategory | null;
+  category?: null | TrainCategory;
   comfort?: Comfort;
   constraint_distribution: Distribution;
   initial_speed?: number;
@@ -3767,6 +3830,8 @@ export type TrainSchedule = {
         It's useful for soft deleting the point (waiting to fix / remove all references)
         If true, the train schedule is consider as invalid and must be edited */
     deleted?: boolean;
+    /** The unique identifier of the path item.
+        This is used to reference path items in the train schedule. */
     id: string;
   })[];
   power_restrictions?: {
@@ -3776,14 +3841,15 @@ export type TrainSchedule = {
   }[];
   rolling_stock_name: string;
   schedule?: {
-    arrival?: PositiveDuration | null;
+    arrival?: null | PositiveDuration;
+    /** Position on the path of the schedule item. */
     at: string;
     /** Whether the schedule item is locked (only for display purposes) */
     locked?: boolean;
     reception_signal?: ReceptionSignal;
-    stop_for?: PositiveDuration | null;
+    stop_for?: null | PositiveDuration;
   }[];
-  speed_limit_tag?: string | null;
+  speed_limit_tag?: null | string;
   start_time: string;
   train_name: string;
 };
@@ -3814,6 +3880,8 @@ export type PathItem = PathItemLocation & {
     It's useful for soft deleting the point (waiting to fix / remove all references)
     If true, the train schedule is consider as invalid and must be edited */
   deleted?: boolean;
+  /** The unique identifier of the path item.
+    This is used to reference path items in the train schedule. */
   id: string;
 };
 export type PowerRestrictionItem = {
@@ -3822,12 +3890,13 @@ export type PowerRestrictionItem = {
   value: string;
 };
 export type ScheduleItem = {
-  arrival?: PositiveDuration | null;
+  arrival?: null | PositiveDuration;
+  /** Position on the path of the schedule item. */
   at: string;
   /** Whether the schedule item is locked (only for display purposes) */
   locked?: boolean;
   reception_signal?: ReceptionSignal;
-  stop_for?: PositiveDuration | null;
+  stop_for?: null | PositiveDuration;
 };
 export type PathAndScheduleChangeGroup = {
   margins: Margins;
@@ -3840,10 +3909,10 @@ export type RollingStockChangeGroup = {
   rolling_stock_name: string;
 };
 export type RollingStockCategoryChangeGroup = {
-  value?: TrainCategory | null;
+  value?: null | TrainCategory;
 };
 export type SpeedLimitTagChangeGroup = {
-  value?: string | null;
+  value?: null | string;
 };
 export type StartTimeChangeGroup = {
   value: string;
@@ -3871,7 +3940,9 @@ export type PacedTrainException = {
 export type PacedTrain = TrainSchedule & {
   exceptions: PacedTrainException[];
   paced: {
+    /** Time between two occurrences, an ISO 8601 format is expected */
     interval: PositiveDuration;
+    /** Duration of the paced train, an ISO 8601 format is expected */
     time_window: PositiveDuration;
   };
 };
@@ -3928,6 +3999,7 @@ export type ZoneUpdate = {
   zone: string;
 };
 export type SimulationResponseSuccess = {
+  /** Simulation without any regularity margins */
   base: ReportTrain;
   electrical_profiles: {
     /** List of `n` boundaries of the ranges (block path).
@@ -3945,6 +4017,7 @@ export type SimulationResponseSuccess = {
         }
     )[];
   };
+  /** User-selected simulation: can be base or provisional */
   final_output: ReportTrain & {
     routing_requirements: RoutingRequirement[];
     signal_critical_positions: SignalCriticalPosition[];
@@ -3958,7 +4031,9 @@ export type SimulationResponseSuccess = {
     boundaries: number[];
     /** List of `n+1` values associated to the ranges */
     values: {
+      /** source of the speed-limit if relevant (tag used) */
       source?:
+        | null
         | (
             | {
                 speed_limit_source_type: 'given_train_tag';
@@ -3971,12 +4046,12 @@ export type SimulationResponseSuccess = {
             | {
                 speed_limit_source_type: 'unknown_tag';
               }
-          )
-        | null;
+          );
       /** in meters per second */
       speed: number;
     }[];
   };
+  /** Simulation that takes into account the regularity margins */
   provisional: ReportTrain;
 };
 export type SimulationResponse =
@@ -4032,7 +4107,7 @@ export type ProjectPatchForm = {
   image?: number | null;
   name?: string | null;
   objectives?: string | null;
-  tags?: Tags | null;
+  tags?: null | Tags;
 };
 export type Study = {
   actual_end_date?: string | null;
@@ -4082,7 +4157,7 @@ export type StudyPatchForm = {
   start_date?: string | null;
   state?: string | null;
   study_type?: string | null;
-  tags?: Tags | null;
+  tags?: null | Tags;
 };
 export type Scenario = {
   creation_date: string;
@@ -4121,7 +4196,7 @@ export type ScenarioPatchForm = {
   electrical_profile_set_id?: number | null;
   infra_id?: number | null;
   name?: string | null;
-  tags?: Tags | null;
+  tags?: null | Tags;
 };
 export type MacroNodeResponse = {
   connection_time: number;
@@ -4160,7 +4235,7 @@ export type MacroNoteResponse = {
   y: number;
 };
 export type EffortCurveConditions = {
-  comfort: Comfort | null;
+  comfort: null | Comfort;
   electrical_profile_level: string | null;
   power_restriction_code: string | null;
 };
@@ -4195,7 +4270,7 @@ export type RollingStock = {
   /** Duration in s */
   electrical_power_startup_time: number | null;
   energy_sources: EnergySource[];
-  etcs_brake_params: EtcsBrakeParams | null;
+  etcs_brake_params: null | EtcsBrakeParams;
   id: number;
   inertia_coefficient: number;
   /** Length in m */
@@ -4206,7 +4281,7 @@ export type RollingStock = {
   mass: number;
   /** Velocity in m·s⁻¹ */
   max_speed: number;
-  metadata: RollingStockMetadata | null;
+  metadata: null | RollingStockMetadata;
   name: string;
   other_categories: TrainMainCategories;
   power_restrictions: {
@@ -4228,17 +4303,17 @@ export type RollingStockForm = {
   base_power_class: string | null;
   /** Acceleration in m·s⁻² */
   comfort_acceleration: number;
-  /** The constant gamma braking coefficient used when NOT circulating
-    under ETCS/ERTMS signaling system
+  /**  The constant gamma braking coefficient used when NOT circulating
+     under ETCS/ERTMS signaling system
     Acceleration in m·s⁻² */
   const_gamma: number;
   effort_curves: EffortCurves;
-  /** The time the train takes before actually using electrical power (in seconds).
-    Is null if the train is not electric.
+  /**  The time the train takes before actually using electrical power (in seconds).
+     Is null if the train is not electric.
     Duration in s */
   electrical_power_startup_time?: number | null;
   energy_sources?: EnergySource[];
-  etcs_brake_params?: EtcsBrakeParams | null;
+  etcs_brake_params?: null | EtcsBrakeParams;
   inertia_coefficient: number;
   /** Length in m */
   length: number;
@@ -4247,7 +4322,7 @@ export type RollingStockForm = {
   mass: number;
   /** Velocity in m·s⁻¹ */
   max_speed: number;
-  metadata?: RollingStockMetadata | null;
+  metadata?: null | RollingStockMetadata;
   name: string;
   other_categories: TrainMainCategories;
   /** Mapping of power restriction code to power class */
@@ -4256,8 +4331,8 @@ export type RollingStockForm = {
   };
   primary_category: TrainMainCategory;
   railjson_version?: string;
-  /** The time it takes to raise this train's pantograph in seconds.
-    Is null if the train is not electric.
+  /**  The time it takes to raise this train's pantograph in seconds.
+     Is null if the train is not electric.
     Duration in s */
   raise_pantograph_time?: number | null;
   rolling_resistance: RollingResistance;
@@ -4271,7 +4346,7 @@ export type RollingStockWithLiveries = RollingStock & {
   liveries: RollingStockLivery[];
 };
 export type RollingStockLiveryCreateForm = {
-  images: Blob[];
+  images: number[][];
   name: string;
 };
 export type RollingStockLockedUpdateForm = {
@@ -4385,7 +4460,7 @@ export type SearchResultItem =
   | SearchResultItemScenario
   | SearchResultItemTrainSchedule
   | SearchResultItemUser;
-export type SearchQuery = boolean | number | number | string | (SearchQuery | null)[];
+export type SearchQuery = boolean | number | number | string | (null | SearchQuery)[];
 export type SearchPayload = {
   /** Whether to return the SQL query instead of executing it
     
@@ -4393,6 +4468,7 @@ export type SearchPayload = {
   dry?: boolean;
   /** The object kind to query - run `editoast search list` to get all possible values */
   object: string;
+  /** The query to run */
   query: SearchQuery;
 };
 export type SimilarTrainWaypoint = {
@@ -4419,7 +4495,7 @@ export type StdcmSearchEnvironment = {
   work_schedule_group_id?: number;
 };
 export type StdcmSearchEnvironmentCreateForm = {
-  active_perimeter: GeoJson;
+  active_perimeter?: null | GeoJson;
   electrical_profile_set_id?: number | null;
   enabled_from: string;
   enabled_until: string;
@@ -4451,6 +4527,7 @@ export type ConflictRequirement = {
   zone: string;
 };
 export type Conflict = {
+  /** Type of the conflict */
   conflict_type: 'Spacing' | 'Routing';
   /** Datetime of the end of the conflict */
   end_time: string;
@@ -4496,12 +4573,15 @@ export type WorkSchedule = {
   work_schedule_type: WorkScheduleType;
 };
 export type StdcmRequest = {
+  /** The comfort of the train */
   comfort: Comfort;
   /** Infrastructure expected version */
   expected_version: number;
   /** Infrastructure id */
   infra: number;
+  /** Margin to apply to the whole train */
   margin?:
+    | null
     | (
         | {
             Percentage: number;
@@ -4509,8 +4589,7 @@ export type StdcmRequest = {
         | {
             MinPer100Km: number;
           }
-      )
-    | null;
+      );
   /** Maximum departure delay in milliseconds. */
   maximum_departure_delay: number;
   /** Maximum run time of the simulation in milliseconds */
@@ -4527,7 +4606,7 @@ export type StdcmRequest = {
     /** The time the train takes before actually using electrical power.
         Is null if the train is not electric or the value not specified. */
     electrical_power_startup_time?: number | null;
-    etcs_brake_params?: EtcsBrakeParams | null;
+    etcs_brake_params?: null | EtcsBrakeParams;
     inertia_coefficient: number;
     /** Length of the rolling stock */
     length: number;
@@ -4546,7 +4625,9 @@ export type StdcmRequest = {
     startup_acceleration: number;
     startup_time: number;
   };
+  /** The loading gauge of the rolling stock */
   rolling_stock_loading_gauge: LoadingGaugeType;
+  /** List of supported signaling systems */
   rolling_stock_supported_signaling_systems: RollingStockSupportedSignalingSystems;
   speed_limit_tag?: string | null;
   start_time: string;
@@ -4571,28 +4652,30 @@ export type StdcmRequest = {
 export type PathfindingItem = {
   /** The stop duration in milliseconds, None if the train does not stop. */
   duration?: number | null;
+  /** The associated location */
   location: PathItemLocation;
-  timing_data?: {
+  /** Time at which the train should arrive at the location, if specified */
+  timing_data?: null | {
     /** Time at which the train should arrive at the location */
     arrival_time: string;
     /** The train may arrive up to this duration after the expected arrival time */
     arrival_time_tolerance_after: number;
     /** The train may arrive up to this duration before the expected arrival time */
     arrival_time_tolerance_before: number;
-  } | null;
+  };
 };
 export type TrainScheduleResponse = TrainSchedule & {
   id: number;
   timetable_id: number;
 };
 export type RollingResistancePerWeight = {
-  /** Solid friction in N·kg⁻¹; N = kg⋅m⋅s⁻²
+  /**  Solid friction in N·kg⁻¹; N = kg⋅m⋅s⁻²
     Acceleration in m·s⁻² */
   A: number;
-  /** Viscosity friction in (N·kg⁻¹)·(m/s)⁻¹; N = kg⋅m⋅s⁻²
+  /**  Viscosity friction in (N·kg⁻¹)·(m/s)⁻¹; N = kg⋅m⋅s⁻²
     Viscosity friction per weight in s⁻¹ */
   B: number;
-  /** Aerodynamic drag per kg in (N·kg⁻¹)·(m/s)⁻²; N = kg⋅m⋅s⁻²
+  /**  Aerodynamic drag per kg in (N·kg⁻¹)·(m/s)⁻²; N = kg⋅m⋅s⁻²
     Aerodynamic drag per kg in m⁻¹ */
   C: number;
   type: string;
@@ -4622,8 +4705,8 @@ export type TowedRollingStock = {
 export type TowedRollingStockForm = {
   /** Acceleration in m·s⁻² */
   comfort_acceleration: number;
-  /** The constant gamma braking coefficient used when NOT circulating
-    under ETCS/ERTMS signaling system
+  /**  The constant gamma braking coefficient used when NOT circulating
+     under ETCS/ERTMS signaling system
     Acceleration in m·s⁻² */
   const_gamma: number;
   inertia_coefficient: number;
@@ -4688,7 +4771,7 @@ export type EtcsCurves = {
     /** List of times (in ms) associated to a position */
     times: number[];
   };
-  indication?: {
+  indication?: null | {
     /** List of positions of a train
         Both positions (in mm) and times (in ms) must have the same length */
     positions: number[];
@@ -4696,7 +4779,7 @@ export type EtcsCurves = {
     speeds: number[];
     /** List of times (in ms) associated to a position */
     times: number[];
-  } | null;
+  };
   permitted_speed: {
     /** List of positions of a train
         Both positions (in mm) and times (in ms) must have the same length */

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -3519,7 +3519,10 @@ export type PathfindingInput = {
   speed_limit_tag?: string | null;
 };
 export type RoutePath = {
-  switches_directions: never[][];
+  switches_directions: {
+    group_id: string;
+    switch_id: string;
+  }[];
   track_ranges: DirectionalTrackRange[];
 };
 export type TrackOffset = {

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -1485,8 +1485,7 @@ export type PostDocumentsApiArg = {
   contentType: string;
   body: Blob;
 };
-export type GetDocumentsByDocumentKeyApiResponse =
-  /** status 200 The document's binary content */ Blob;
+export type GetDocumentsByDocumentKeyApiResponse = unknown;
 export type GetDocumentsByDocumentKeyApiArg = {
   /** The document's key */
   documentKey: number;
@@ -2658,14 +2657,6 @@ export type SubjectType = 'User' | 'Group';
 export type NewDocumentResponse = {
   document_key: number;
 };
-export type InternalError = {
-  context: {
-    [key: string]: unknown;
-  };
-  message: string;
-  status?: number;
-  type: string;
-};
 export type LightElectricalProfileSet = {
   id: number;
   name: string;
@@ -3441,6 +3432,14 @@ export type PathfindingNotFound =
       incompatible_constraints: IncompatibleConstraints;
       relaxed_constraints_path: PathfindingResultSuccess;
     };
+export type InternalError = {
+  context: {
+    [key: string]: unknown;
+  };
+  message: string;
+  status?: number;
+  type: string;
+};
 export type PathfindingFailure =
   | (PathfindingInputError & {
       failed_status: 'pathfinding_input_error';

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -3398,33 +3398,13 @@ export type PathfindingResultSuccess = {
     The first value is always `0` (beginning of the path) and the last one is always equal to the `length` of the path in mm */
   path_item_positions: number[];
 };
-export type PathItemLocation =
-  | {
-      /** Offset in mm */
-      offset: number;
-      /** Track section identifier */
-      track: string;
-    }
-  | ((
-      | {
-          /** The object id of an operational point */
-          operational_point: string;
-        }
-      | {
-          /** An optional secondary code to identify a more specific location */
-          secondary_code?: string | null;
-          /** The operational point trigram */
-          trigram: string;
-        }
-      | {
-          /** An optional secondary code to identify a more specific location */
-          secondary_code?: string | null;
-          /** The [UIC](https://en.wikipedia.org/wiki/List_of_UIC_country_codes) code of an operational point */
-          uic: number;
-        }
-    ) & {
-      track_reference?: null | TrackReference;
-    });
+export type TrackOffset = {
+  /** Offset in mm */
+  offset: number;
+  /** Track section identifier */
+  track: string;
+};
+export type PathItemLocation = TrackOffset | OperationalPointReference;
 export type PathfindingInputError =
   | {
       error_type: 'invalid_path_items';
@@ -3529,12 +3509,6 @@ export type RoutePath = {
     switch_id: string;
   }[];
   track_ranges: DirectionalTrackRange[];
-};
-export type TrackOffset = {
-  /** Offset in mm */
-  offset: number;
-  /** Track section identifier */
-  track: string;
 };
 export type LightModeEffortCurves = {
   is_electric: boolean;

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -3192,7 +3192,12 @@ export type InfraErrorTypeLabel =
   | 'overlapping_switches'
   | 'unknown_port_name'
   | 'unused_port';
-export type BoundingBox = never[][];
+export type BoundingBox = {
+  max_lat: number;
+  max_lon: number;
+  min_lat: number;
+  min_lon: number;
+};
 export type GeoJsonPoint = {
   coordinates: GeoJsonPointValue;
   type: 'Point';


### PR DESCRIPTION
closes #13367

### Changes

* OpenAPI version bump from 3.0.3 to 3.1.0
* Also bumps json-patch to 4.1 for compatibility.
* Adapts the schema and route collection mechanism.
* Simplifies a bit the OpenAPI processing.
* Adapts manual `ToSchema` implementations (becoming `PartialSchema +
  ToSchema` now).
* Types referenced in utoipa macros are now used in the expansion, so
  imports are fixed.
* There's no need to give the alias name using `value_type` now. We just
  provide the Rust type and utoipa substitutes its alias on its own. So
  all `value_type` for aliases are removed.
* Changes `utoipa::path` definitions of endpoints dealing with binary
  data. Utoipa 5 doesn't seem to infer `[u8]` as a binary blob anymore.

### Frontend changes

> [!NOTE]
> RTK failed to type a couple schemas: https://github.com/OpenRailAssociation/osrd/pull/13480#discussion_r2391812662 

Some tuples that couldn't be typed properly were turned into objects with named fields. Checkout the last two commits.

### API changes

> Changes in Schemas

Neither changed schemas are in `osrd_schemas`.

> API changes

Frontend changed, only consumer.