### PR TITLE
editoast: new endpoint to retrieve a note for nge

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -2770,6 +2770,44 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/InternalError'
+  /projects/{project_id}/studies/{study_id}/scenarios/{scenario_id}/macro_notes/{note_id}:
+    get:
+      tags:
+      - scenarios
+      summary: Return a specific note
+      parameters:
+      - name: project_id
+        in: path
+        description: The id of a project
+        required: true
+        schema:
+          type: integer
+          format: int64
+      - name: study_id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      - name: scenario_id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      - name: note_id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        '200':
+          description: The requested macro note
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MacroNoteResponse'
   /rolling_stock:
     post:
       tags:
@@ -6319,6 +6357,9 @@ components:
       - $ref: '#/components/schemas/EditoastListErrorsErrorsWrongErrorTypeProvided'
       - $ref: '#/components/schemas/EditoastMacroNodeErrorDatabase'
       - $ref: '#/components/schemas/EditoastMacroNodeErrorNotFound'
+      - $ref: '#/components/schemas/EditoastMacroNoteErrorDatabase'
+      - $ref: '#/components/schemas/EditoastMacroNoteErrorNotFound'
+      - $ref: '#/components/schemas/EditoastMacroNoteErrorWrongScenario'
       - $ref: '#/components/schemas/EditoastModelError'
       - $ref: '#/components/schemas/EditoastOperationErrorEmptyId'
       - $ref: '#/components/schemas/EditoastOperationErrorInvalidPatch'
@@ -6715,6 +6756,76 @@ components:
           type: string
           enum:
           - editoast:macro_node:NotFound
+    EditoastMacroNoteErrorDatabase:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 500
+        type:
+          type: string
+          enum:
+          - editoast:macro_note:Database
+    EditoastMacroNoteErrorNotFound:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+          required:
+          - note_id
+          properties:
+            note_id:
+              type: integer
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 404
+        type:
+          type: string
+          enum:
+          - editoast:macro_note:NotFound
+    EditoastMacroNoteErrorWrongScenario:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+          required:
+          - note_id
+          - scenario_id
+          properties:
+            note_id:
+              type: integer
+            scenario_id:
+              type: integer
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 404
+        type:
+          type: string
+          enum:
+          - editoast:macro_note:WrongScenario
     EditoastModelError:
       type: object
       required:
@@ -9947,6 +10058,31 @@ components:
         trigram:
           type: string
           nullable: true
+    MacroNoteResponse:
+      type: object
+      required:
+      - id
+      - x
+      - y
+      - title
+      - text
+      - labels
+      properties:
+        id:
+          type: integer
+          format: int64
+        labels:
+          $ref: '#/components/schemas/Tags'
+        text:
+          type: string
+        title:
+          type: string
+        x:
+          type: integer
+          format: int64
+        y:
+          type: integer
+          format: int64
     Margins:
       type: object
       required:

--- a/editoast/src/models/macro_note.rs
+++ b/editoast/src/models/macro_note.rs
@@ -1,0 +1,58 @@
+use editoast_derive::Model;
+use serde::Deserialize;
+use serde::Serialize;
+use utoipa::ToSchema;
+
+use editoast_models::tags::Tags;
+
+#[derive(Clone, Debug, Serialize, Deserialize, Model, ToSchema, PartialEq)]
+#[model(table = database::tables::macro_note)]
+#[model(gen(ops = crud, batch_ops = c, list))]
+pub struct MacroNote {
+    pub id: i64,
+    pub scenario_id: i64,
+    pub x: i64,
+    pub y: i64,
+    pub title: String,
+    pub text: String,
+    #[model(remote = "Vec<Option<String>>")]
+    pub labels: Tags,
+}
+
+#[cfg(test)]
+pub mod test {
+    use super::*;
+
+    use database::DbConnectionPoolV2;
+    use editoast_models::prelude::*;
+    use pretty_assertions::assert_eq;
+    use rstest::rstest;
+
+    use crate::models::fixtures::create_scenario_fixtures_set;
+
+    #[rstest]
+    async fn macro_note_create_and_get() {
+        let db_pool = DbConnectionPoolV2::for_tests();
+        let fixtures =
+            create_scenario_fixtures_set(&mut db_pool.get_ok(), "test_scenario_name").await;
+        // Create note
+        let created = MacroNote::changeset()
+            .scenario_id(fixtures.scenario.id)
+            .x(10)
+            .y(12)
+            .title("New note".to_string())
+            .text("Note content".to_string())
+            .labels(Tags::new(vec!["A".to_string(), "B".to_string()]))
+            .create(&mut db_pool.get_ok())
+            .await
+            .expect("Failed to create macro note");
+
+        // Retrieve the created note
+        let note = MacroNote::retrieve(db_pool.get_ok(), created.id)
+            .await
+            .expect("Failed to retrieve note")
+            .expect("Macro note not found");
+
+        assert_eq!(&created, &note);
+    }
+}

--- a/editoast/src/models/mod.rs
+++ b/editoast/src/models/mod.rs
@@ -5,6 +5,7 @@ pub mod infra;
 pub mod infra_objects;
 pub mod layers;
 pub mod macro_node;
+pub mod macro_note;
 pub mod round_trips;
 
 mod auth_driver;

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -329,6 +329,11 @@ fn service_router() -> router::DocumentedRouter {
                                                                             )
                                                                     })
                                                             })
+                                                            .nests("/macro_notes", |path| {
+                                                                path.nests("/{note_id}", |path| {
+                                                                    path.route("/", get!(scenario::macro_notes::get))
+                                                                })
+                                                            })
                                                     })
                                             })
                                     })

--- a/editoast/src/views/scenario.rs
+++ b/editoast/src/views/scenario.rs
@@ -1,4 +1,5 @@
 pub mod macro_nodes;
+pub mod macro_notes;
 
 use authz::Role;
 use axum::Extension;
@@ -484,6 +485,36 @@ pub(in crate::views) async fn list(
     let results = futures::future::try_join_all(futs).await?;
 
     Ok(Json(ListScenariosResponse { stats, results }))
+}
+
+/// Validate that the project exists, the study exists and belongs to the project and the scenarios exists and belongs to the study
+async fn check_project_study_scenario(
+    conn: DbConnection,
+    project_id: i64,
+    study_id: i64,
+    scenario_id: i64,
+) -> Result<(Project, Study, Scenario)> {
+    let project = Project::retrieve_or_fail(conn.clone(), project_id, || ProjectError::NotFound {
+        project_id,
+    })
+    .await?;
+    let study =
+        Study::retrieve_or_fail(conn.clone(), study_id, || StudyError::NotFound { study_id })
+            .await?;
+
+    if study.project_id != project_id {
+        return Err(StudyError::NotFound { study_id }.into());
+    }
+
+    let scenario = Scenario::retrieve_or_fail(conn, scenario_id, || ScenarioError::NotFound {
+        scenario_id,
+    })
+    .await?;
+    if scenario.study_id != study_id {
+        return Err(ScenarioError::NotFound { scenario_id }.into());
+    }
+
+    Ok((project, study, scenario))
 }
 
 #[cfg(test)]

--- a/editoast/src/views/scenario/macro_nodes.rs
+++ b/editoast/src/views/scenario/macro_nodes.rs
@@ -19,11 +19,10 @@ use thiserror::Error;
 use utoipa::IntoParams;
 use utoipa::ToSchema;
 
+use super::check_project_study_scenario;
 use crate::error::InternalError;
 use crate::error::Result;
-use crate::models::Project;
 use crate::models::Scenario;
-use crate::models::Study;
 use crate::models::macro_node::MacroNode;
 use crate::views::AuthenticationExt;
 use crate::views::AuthorizationError;
@@ -399,35 +398,6 @@ pub(in crate::views) async fn delete(
     Ok(StatusCode::NO_CONTENT)
 }
 
-async fn check_project_study_scenario(
-    conn: DbConnection,
-    project_id: i64,
-    study_id: i64,
-    scenario_id: i64,
-) -> Result<(Project, Study, Scenario)> {
-    let project = Project::retrieve_or_fail(conn.clone(), project_id, || ProjectError::NotFound {
-        project_id,
-    })
-    .await?;
-    let study =
-        Study::retrieve_or_fail(conn.clone(), study_id, || StudyError::NotFound { study_id })
-            .await?;
-
-    if study.project_id != project_id {
-        return Err(StudyError::NotFound { study_id }.into());
-    }
-
-    let scenario = Scenario::retrieve_or_fail(conn, scenario_id, || ScenarioError::NotFound {
-        scenario_id,
-    })
-    .await?;
-    if scenario.study_id != study_id {
-        return Err(ScenarioError::NotFound { scenario_id }.into());
-    }
-
-    Ok((project, study, scenario))
-}
-
 async fn retrieve_macro_node_and_check_scenario(
     conn: DbConnection,
     scenario_id: i64,
@@ -451,6 +421,8 @@ pub mod test {
     use rstest::rstest;
 
     use super::*;
+    use crate::models::Project;
+    use crate::models::Study;
     use crate::models::fixtures::create_scenario_fixtures_set;
     use crate::views::test_app::TestAppBuilder;
 

--- a/editoast/src/views/scenario/macro_notes.rs
+++ b/editoast/src/views/scenario/macro_notes.rs
@@ -1,0 +1,198 @@
+use std::sync::Arc;
+
+use authz::Role;
+use axum::Extension;
+use axum::extract::Json;
+use axum::extract::Path;
+use axum::extract::State;
+use database::DbConnectionPoolV2;
+use editoast_derive::EditoastError;
+use serde::Deserialize;
+use serde::Serialize;
+use thiserror::Error;
+use utoipa::IntoParams;
+use utoipa::ToSchema;
+
+use super::check_project_study_scenario;
+use crate::error::Result;
+use crate::models::macro_note::MacroNote;
+use crate::views::AuthenticationExt;
+use crate::views::AuthorizationError;
+use crate::views::project::ProjectIdParam;
+use crate::views::scenario::ScenarioIdParam;
+use crate::views::study::StudyIdParam;
+use editoast_models::prelude::*;
+use editoast_models::tags::Tags;
+
+#[derive(Debug, Error, EditoastError)]
+#[editoast_error(base_id = "macro_note")]
+enum MacroNoteError {
+    #[error("Note '{note_id}' could not be found")]
+    #[editoast_error(status = 404)]
+    NotFound { note_id: i64 },
+
+    #[error("Note '{note_id}' does not belong to scenario '{scenario_id}'")]
+    #[editoast_error(status = 404)]
+    WrongScenario { note_id: i64, scenario_id: i64 },
+
+    #[error(transparent)]
+    #[editoast_error(status = 500)]
+    Database(#[from] editoast_models::Error),
+}
+
+#[derive(IntoParams, Deserialize)]
+#[allow(unused)]
+struct MacroNoteIdParam {
+    note_id: i64,
+}
+
+#[editoast_derive::openapi_schema]
+#[derive(Debug, Serialize, ToSchema)]
+#[cfg_attr(test, derive(Deserialize, PartialEq))]
+pub(in crate::views) struct MacroNoteResponse {
+    id: i64,
+    x: i64,
+    y: i64,
+    title: String,
+    text: String,
+    labels: Tags,
+}
+
+impl From<MacroNote> for MacroNoteResponse {
+    fn from(note: MacroNote) -> Self {
+        Self {
+            id: note.id,
+            x: note.x,
+            y: note.y,
+            title: note.title,
+            text: note.text,
+            labels: note.labels,
+        }
+    }
+}
+
+/// Return a specific note
+#[editoast_derive::route]
+#[utoipa::path(
+    get, path = "",
+    tag = "scenarios",
+    params(ProjectIdParam, StudyIdParam, ScenarioIdParam, MacroNoteIdParam),
+    responses(
+        (status = 200, body = MacroNoteResponse, description = "The requested macro note"),
+    )
+)]
+pub(in crate::views) async fn get(
+    State(db_pool): State<Arc<DbConnectionPoolV2>>,
+    Extension(auth): AuthenticationExt,
+    Path((project_id, study_id, scenario_id, note_id)): Path<(i64, i64, i64, i64)>,
+) -> Result<Json<MacroNoteResponse>> {
+    // Checking role
+    let authorized = auth
+        .check_roles([Role::OperationalStudies].into())
+        .await
+        .map_err(AuthorizationError::AuthError)?;
+    if !authorized {
+        return Err(AuthorizationError::Forbidden.into());
+    }
+
+    // Check for project / study / scenario
+    let conn = db_pool.get().await?;
+    check_project_study_scenario(conn.clone(), project_id, study_id, scenario_id).await?;
+
+    // Get / check the note
+    let macro_note =
+        MacroNote::retrieve_or_fail(conn, note_id, || MacroNoteError::NotFound { note_id }).await?;
+    if macro_note.scenario_id != scenario_id {
+        return Err(MacroNoteError::WrongScenario {
+            note_id,
+            scenario_id,
+        }
+        .into());
+    }
+
+    Ok(Json(MacroNoteResponse::from(macro_note)))
+}
+
+#[cfg(test)]
+pub mod test {
+    use axum::http::StatusCode;
+    use pretty_assertions::assert_eq;
+    use rand::Rng;
+    use rand::rng;
+    use rstest::rstest;
+
+    use super::*;
+    use crate::models::fixtures::create_scenario_fixtures_set;
+    use crate::views::test_app::TestAppBuilder;
+
+    #[rstest]
+    async fn get_note() {
+        let app = TestAppBuilder::default_app();
+        let db_pool = app.db_pool();
+        let fixtures =
+            create_scenario_fixtures_set(&mut db_pool.get_ok(), "test_scenario_name").await;
+        let note = MacroNote::changeset()
+            .scenario_id(fixtures.scenario.id)
+            .x(rng().random_range(0..100))
+            .y(rng().random_range(0..100))
+            .title("Note title".to_string())
+            .text("Note text".to_string())
+            .labels(Tags::new(vec!["A".to_string(), "B".to_string()]))
+            .create(&mut db_pool.get_ok())
+            .await
+            .expect("Failed to create macro note");
+
+        let request = app.get(&format!(
+            "/projects/{}/studies/{}/scenarios/{}/macro_notes/{}",
+            fixtures.project.id, fixtures.study.id, fixtures.scenario.id, note.id
+        ));
+
+        let response: MacroNoteResponse =
+            app.fetch(request).assert_status(StatusCode::OK).json_into();
+
+        assert_eq!(MacroNoteResponse::from(note), response);
+    }
+
+    #[rstest]
+    async fn get_note_not_found() {
+        let app = TestAppBuilder::default_app();
+        let db_pool = app.db_pool();
+        let fixtures =
+            create_scenario_fixtures_set(&mut db_pool.get_ok(), "test_scenario_name").await;
+
+        let request = app.get(&format!(
+            "/projects/{}/studies/{}/scenarios/{}/macro_notes/999999",
+            fixtures.project.id, fixtures.study.id, fixtures.scenario.id
+        ));
+
+        app.fetch(request).assert_status(StatusCode::NOT_FOUND);
+    }
+
+    #[rstest]
+    async fn get_note_wrong_scenario() {
+        let app = TestAppBuilder::default_app();
+        let db_pool = app.db_pool();
+        let fixtures =
+            create_scenario_fixtures_set(&mut db_pool.get_ok(), "test_scenario_name").await;
+        let fixtures_2 =
+            create_scenario_fixtures_set(&mut db_pool.get_ok(), "test_scenario_name_2").await;
+
+        let note = MacroNote::changeset()
+            .scenario_id(fixtures.scenario.id)
+            .x(rng().random_range(0..100))
+            .y(rng().random_range(0..100))
+            .title("Note title".to_string())
+            .text("Note text".to_string())
+            .labels(Tags::new(vec!["A".to_string(), "B".to_string()]))
+            .create(&mut db_pool.get_ok())
+            .await
+            .expect("Failed to create macro note");
+
+        let request = app.get(&format!(
+            "/projects/{}/studies/{}/scenarios/{}/macro_notes/{}",
+            fixtures_2.project.id, fixtures_2.study.id, fixtures_2.scenario.id, note.id
+        ));
+
+        app.fetch(request).assert_status(StatusCode::NOT_FOUND);
+    }
+}

--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -115,6 +115,11 @@
       "Database": "Internal error",
       "NotFound": "Node {{node_id}} not found."
     },
+    "macro_note": {
+      "Database": "Internal error (database)",
+      "NotFound": "Note '{{note_id}}' not found.",
+      "WrongScenario": "Note '{note_id}' does not belong to scenario '{scenario_id}'"
+    },
     "model": {
       "ModelError": "Internal error (database query)"
     },

--- a/front/public/locales/es/errors.json
+++ b/front/public/locales/es/errors.json
@@ -58,6 +58,11 @@
         "InfraIsLocked": "Infraestructura bloqueada"
       }
     },
+    "macro_note": {
+      "Database": "Error interno (base de datos)",
+      "NotFound": "No se encontró la nota «{{note_id}}»",
+      "WrongScenario": "La nota «{note_id}» no pertenece al escenario «{scenario_id}»"
+    },
     "paced_train": {
       "Database": "Error interno (de la base de datos)",
       "InfraNotFound": "No se pudo encontrar la infraestructura «{{infra_id}}»"

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -115,6 +115,11 @@
       "Database": "Erreur interne",
       "NotFound": "Noeud {{node_id}} non trouvé."
     },
+    "macro_note": {
+      "Database": "Erreur interne (base de données)",
+      "NotFound": "Note '{{note_id}}' non trouvée.",
+      "WrongScenario": "La note '{note_id}' n'appartient pas au scénario '{scenario_id}'"
+    },
     "model": {
       "ModelError": "Erreur interne (requêtage base de données)"
     },

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -792,6 +792,15 @@ const injectedRtkApi = api
         }),
         invalidatesTags: ['scenarios'],
       }),
+      getProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotesNoteId: build.query<
+        GetProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotesNoteIdApiResponse,
+        GetProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotesNoteIdApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/projects/${queryArg.projectId}/studies/${queryArg.studyId}/scenarios/${queryArg.scenarioId}/macro_notes/${queryArg.noteId}`,
+        }),
+        providesTags: ['scenarios'],
+      }),
       postRollingStock: build.mutation<PostRollingStockApiResponse, PostRollingStockApiArg>({
         query: (queryArg) => ({
           url: `/rolling_stock`,
@@ -2088,6 +2097,15 @@ export type DeleteProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNo
   studyId: number;
   scenarioId: number;
   nodeId: number;
+};
+export type GetProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotesNoteIdApiResponse =
+  /** status 200 The requested macro note */ MacroNoteResponse;
+export type GetProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotesNoteIdApiArg = {
+  /** The id of a project */
+  projectId: number;
+  studyId: number;
+  scenarioId: number;
+  noteId: number;
 };
 export type PostRollingStockApiResponse = /** status 200 The created rolling stock */ RollingStock;
 export type PostRollingStockApiArg = {
@@ -4131,6 +4149,14 @@ export type MacroNodeForm = {
 };
 export type MacroNodeBatchForm = {
   macro_nodes: MacroNodeForm[];
+};
+export type MacroNoteResponse = {
+  id: number;
+  labels: Tags;
+  text: string;
+  title: string;
+  x: number;
+  y: number;
 };
 export type EffortCurveConditions = {
   comfort: Comfort | null;


### PR DESCRIPTION
New endpoint to retrieve a specific macro note by its id  :

* Added a new `MacroNote` model, with tests for creating and retrieving macro notes.
* Registered the new model in the models module.
* Implemented custom error types for macro note (fr, en & es traduction).
* Introduced a new GET endpoint to fetch a specific macro note by its ID.
* Integrated the endpoint into the scenario router.
* Added tests for the new endpoint, covering successful retrieval, not found, and scenario mismatch cases.
* Refactored the `check_project_study_scenario` function for reuse between macro nodes and macro notes. 
