### PR TITLE
front: temporarily skip space-time diagram snapshot e2e test

### DIFF
--- a/front/tests/021-get-manchette.spec.ts
+++ b/front/tests/021-get-manchette.spec.ts
@@ -149,7 +149,7 @@ test.describe('Verify manchette and space time diagram', () => {
     });
   });
 
-  test('Space time diagram', async () => {
+  test.skip('Space time diagram (temporarily skipped until STD snapshots are stable)', async () => {
     await test.step('Project train schedule and capture GET screenshot', async () => {
       await scenarioTimetableSection.projectTrain();
       await getManchetteComponent.selectAllSpaceTimeChartCheckboxes();


### PR DESCRIPTION
In the past two days, we regenerated the STD snapshots twice: 

- https://github.com/OpenRailAssociation/osrd/commit/c2b7365ae5cf8bf2bf7feae2f93d1a92402e4d93
- https://github.com/OpenRailAssociation/osrd/commit/9ef085da1472a375bf460f4507019186e9cc7895

and more commits are coming with new changes: 

- https://github.com/OpenRailAssociation/osrd/pull/13490

-> We will temporarily skip the STD snapshot tests until they are more stable and it is confirmed that no future UI changes will affect them.