### PR TITLE
core: stdcm: properly add rs length to mrsp

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMSimulations.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMSimulations.kt
@@ -106,7 +106,7 @@ class STDCMSimulations {
         }
         val path = infraExplorer.getCurrentEdgePathProperties(start, simLength)
         val context = build(rollingStock, path, timeStep, comfort)
-        val mrsp = computeMRSP(path, rollingStock, false, trainTag, temporarySpeedLimitManager)
+        val mrsp = computeMRSP(path, rollingStock, true, trainTag, temporarySpeedLimitManager)
         return try {
             val maxSpeedEnvelope = maxSpeedEnvelopeFrom(context, stops, mrsp)
             maxEffortEnvelopeFrom(context, initialSpeed, maxSpeedEnvelope)


### PR DESCRIPTION
We sometimes (rarly) had a warning about "f-value decreasing", meaning that the heuristic can be pessimistic.

The cause was a mismatch on MRSP computation between [heuristic preprocessing](https://github.com/OpenRailAssociation/osrd/blob/dev/core/src/main/kotlin/fr/sncf/osrd/utils/CachedBlockMRSPBuilder.kt#L56) and [stdcm simulations](https://github.com/OpenRailAssociation/osrd/blob/dev/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMSimulations.kt#L109). In the former we didn't account for rolling stock length on speed limits. (which we can't properly add across block boundaries, but we can still add them within one block)