### PR TITLE
editoast: rename `valkey` to `valkey_client`

### DIFF
--- a/editoast/src/views/infra/edition.rs
+++ b/editoast/src/views/infra/edition.rs
@@ -74,7 +74,7 @@ pub(in crate::views) async fn edit(
     State(AppState {
         db_pool,
         infra_caches,
-        valkey,
+        valkey_client,
         map_layers,
         config,
         ..
@@ -110,12 +110,12 @@ pub(in crate::views) async fn edit(
         &mut infra,
         &operations,
         &mut infra_cache,
-        valkey.clone(),
+        valkey_client.clone(),
         config.app_version.as_deref(),
     )
     .await?;
 
-    let mut conn = valkey.get_connection().await?;
+    let mut conn = valkey_client.get_connection().await?;
     map::invalidate_all(
         &mut conn,
         &map_layers.layers.keys().cloned().collect(),
@@ -142,7 +142,7 @@ pub(in crate::views) async fn split_track_section(
     State(AppState {
         db_pool,
         infra_caches,
-        valkey,
+        valkey_client,
         map_layers,
         config,
         ..
@@ -356,11 +356,11 @@ pub(in crate::views) async fn split_track_section(
         &mut infra,
         &operations,
         &mut infra_cache,
-        valkey.clone(),
+        valkey_client.clone(),
         config.app_version.as_deref(),
     )
     .await?;
-    let mut conn = valkey.get_connection().await?;
+    let mut conn = valkey_client.get_connection().await?;
     map::invalidate_all(
         &mut conn,
         &map_layers.layers.keys().cloned().collect(),
@@ -868,7 +868,7 @@ async fn apply_edit(
     infra: &mut Infra,
     operations: &[Operation],
     infra_cache: &mut InfraCache,
-    valkey: Arc<cache::Client>,
+    valkey_client: Arc<cache::Client>,
     app_version: Option<&str>,
 ) -> Result<Vec<InfraObject>> {
     let infra_id = infra.id;
@@ -912,7 +912,7 @@ async fn apply_edit(
 
                 infra_cache.infra_version = infra.version;
                 let osrd_version = app_version.unwrap_or("default");
-                let mut valkey_conn = valkey.get_connection().await?;
+                let mut valkey_conn = valkey_client.get_connection().await?;
                 let _ = valkey_conn
                     .json_zadd(
                         format!("infra_patches.{osrd_version}.{infra_id})"),

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -115,7 +115,7 @@ pub(in crate::views) struct RefreshResponse {
 pub(in crate::views) async fn refresh(
     State(AppState {
         db_pool,
-        valkey: valkey_client,
+        valkey_client,
         infra_caches,
         map_layers,
         config,

--- a/editoast/src/views/layers.rs
+++ b/editoast/src/views/layers.rs
@@ -174,7 +174,7 @@ pub(in crate::views) async fn cache_and_get_mvt_tile(
     State(AppState {
         map_layers,
         db_pool,
-        valkey,
+        valkey_client,
         config,
         ..
     }): State<AppState>,
@@ -208,7 +208,7 @@ pub(in crate::views) async fn cache_and_get_mvt_tile(
         &Tile { x, y, z },
     );
 
-    let mut valkey = valkey.get_connection().await?;
+    let mut valkey = valkey_client.get_connection().await?;
     let cached_value: Option<Vec<u8>> = valkey.get(&cache_key).await?;
 
     if let Some(value) = cached_value {

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -630,7 +630,7 @@ pub enum AppHealthError {
 async fn health(
     State(AppState {
         db_pool,
-        valkey,
+        valkey_client,
         health_check_timeout,
         core_client,
         regulator,
@@ -641,7 +641,7 @@ async fn health(
         health_check_timeout
             .to_std()
             .expect("timeout should be valid at this point"),
-        check_health(db_pool, valkey, core_client, regulator.openfga()),
+        check_health(db_pool, valkey_client, core_client, regulator.openfga()),
     )
     .await
     .map_err(|_| AppHealthError::Timeout)??;
@@ -780,7 +780,7 @@ pub type Regulator = ::authz::Regulator<PgAuthDriver>;
 pub struct AppState {
     pub config: Arc<ServerConfig>,
     pub db_pool: Arc<DbConnectionPoolV2>,
-    pub valkey: Arc<cache::Client>,
+    pub valkey_client: Arc<cache::Client>,
     pub infra_caches: Arc<DashMap<i64, InfraCache>>,
     pub map_layers: Arc<MapLayers>,
     pub speed_limit_tag_ids: Arc<SpeedLimitTagIds>,
@@ -886,7 +886,7 @@ impl AppState {
         // Synchronous operations
         let infra_caches = DashMap::<i64, InfraCache>::default().into();
         let speed_limit_tag_ids = Arc::new(SpeedLimitTagIds::load());
-        let valkey = Arc::new(cache::Client::new(
+        let valkey_client = Arc::new(cache::Client::new(
             config.valkey_config.clone(),
             config.app_version.as_deref().unwrap_or("NO_APP_VERSION"),
         ));
@@ -902,7 +902,7 @@ impl AppState {
 
         Ok(Self {
             regulator: Regulator::new(openfga, PgAuthDriver::new(db_pool.clone())),
-            valkey,
+            valkey_client,
             db_pool,
             infra_caches,
             core_client,

--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -189,7 +189,7 @@ pub enum PathfindingFailure {
 pub(in crate::views) async fn post(
     State(AppState {
         db_pool,
-        valkey,
+        valkey_client,
         core_client,
         config,
         ..
@@ -207,7 +207,7 @@ pub(in crate::views) async fn post(
     }
 
     let conn = db_pool.get().await?;
-    let mut valkey_conn = valkey.get_connection().await?;
+    let mut valkey_conn = valkey_client.get_connection().await?;
     let infra = Infra::retrieve_or_fail(conn.clone(), infra_id, || {
         PathfindingError::InfraNotFound { infra_id }
     })

--- a/editoast/src/views/path/properties.rs
+++ b/editoast/src/views/path/properties.rs
@@ -146,7 +146,7 @@ type Properties = EnumSet<Property>;
 pub(in crate::views) async fn post(
     State(AppState {
         db_pool,
-        valkey,
+        valkey_client,
         core_client,
         config,
         ..
@@ -169,7 +169,7 @@ pub(in crate::views) async fn post(
     .await?;
 
     let query_props: Properties = props.into();
-    let mut valkey_conn = valkey.get_connection().await?;
+    let mut valkey_conn = valkey_client.get_connection().await?;
 
     let request = PathPropertiesRequest {
         track_section_ranges: &path_properties_input.track_section_ranges,

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -255,7 +255,7 @@ impl TestAppBuilder {
             db_pool: db_pool_v2.clone(),
             core_client: core_client.clone(),
             osrdyne_client,
-            valkey,
+            valkey_client: valkey,
             regulator,
             infra_caches,
             map_layers: Arc::new(MapLayers::default()),
@@ -330,7 +330,7 @@ impl TestApp {
     }
 
     pub fn valkey_client(&self) -> Arc<cache::Client> {
-        self.app_state.valkey.clone()
+        self.app_state.valkey_client.clone()
     }
 
     pub fn speed_limit_tag_ids(&self) -> Arc<SpeedLimitTagIds> {

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -481,7 +481,7 @@ pub(in crate::views) async fn conflicts(
     State(AppState {
         config,
         db_pool,
-        valkey: valkey_client,
+        valkey_client,
         core_client,
         ..
     }): State<AppState>,
@@ -654,7 +654,7 @@ fn build_conflict_core_request(
 pub(in crate::views) async fn requirements(
     State(AppState {
         db_pool,
-        valkey: valkey_client,
+        valkey_client,
         core_client,
         config,
         ..

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -249,7 +249,7 @@ pub(in crate::views) async fn simulation_summary(
     State(AppState {
         config,
         db_pool,
-        valkey: valkey_client,
+        valkey_client,
         core_client,
         ..
     }): State<AppState>,
@@ -385,7 +385,7 @@ pub(in crate::views) struct ExceptionQueryParam {
 pub(in crate::views) async fn get_path(
     State(AppState {
         db_pool,
-        valkey: valkey_client,
+        valkey_client,
         core_client,
         config,
         ..
@@ -470,7 +470,7 @@ pub struct ElectricalProfileSetIdQueryParam {
 pub(in crate::views) async fn simulation(
     State(AppState {
         config,
-        valkey: valkey_client,
+        valkey_client,
         core_client,
         db_pool,
         ..
@@ -576,7 +576,7 @@ pub struct ProjectPathPacedTrainResult {
 pub(in crate::views) async fn project_path(
     State(AppState {
         db_pool,
-        valkey: valkey_client,
+        valkey_client,
         core_client,
         config,
         ..
@@ -711,7 +711,7 @@ enum BaseOrExceptionId {
 pub(in crate::views) async fn project_path_op(
     State(AppState {
         db_pool,
-        valkey: valkey_client,
+        valkey_client,
         core_client,
         config,
         ..
@@ -874,7 +874,7 @@ pub struct OccupancyBlocksPacedTrainResult {
 pub(in crate::views) async fn occupancy_blocks(
     State(AppState {
         db_pool,
-        valkey: valkey_client,
+        valkey_client,
         core_client,
         config,
         ..

--- a/editoast/src/views/timetable/similar_trains.rs
+++ b/editoast/src/views/timetable/similar_trains.rs
@@ -199,7 +199,7 @@ pub(in crate::views) async fn similar_trains(
     State(AppState {
         db_pool,
         speed_limit_tag_ids,
-        valkey,
+        valkey_client,
         core_client,
         config,
         ..
@@ -301,7 +301,7 @@ pub(in crate::views) async fn similar_trains(
 
     let selected_past_trains = simulate_past_trains(
         &mut conn,
-        valkey,
+        valkey_client,
         core_client,
         &infra,
         candidate_schedules,

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -161,7 +161,7 @@ pub(in crate::views) async fn stdcm(
     State(AppState {
         config,
         db_pool,
-        valkey: valkey_client,
+        valkey_client,
         core_client,
         ..
     }): State<AppState>,

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -276,7 +276,7 @@ pub struct ElectricalProfileSetIdQueryParam {
 pub(in crate::views) async fn simulation(
     State(AppState {
         config,
-        valkey: valkey_client,
+        valkey_client,
         core_client,
         db_pool,
         ..
@@ -349,7 +349,7 @@ pub(in crate::views) async fn simulation(
 pub(in crate::views) async fn etcs_braking_curves(
     State(AppState {
         config,
-        valkey: valkey_client,
+        valkey_client,
         core_client,
         db_pool,
         ..
@@ -487,7 +487,7 @@ pub(in crate::views) async fn simulation_summary(
     State(AppState {
         config,
         db_pool,
-        valkey: valkey_client,
+        valkey_client,
         core_client: core,
         ..
     }): State<AppState>,
@@ -568,7 +568,7 @@ pub(in crate::views) async fn get_path(
     State(AppState {
         config,
         db_pool,
-        valkey: valkey_client,
+        valkey_client,
         core_client: core,
         ..
     }): State<AppState>,
@@ -639,7 +639,7 @@ pub(in crate::views) async fn project_path(
     State(AppState {
         config,
         db_pool,
-        valkey: valkey_client,
+        valkey_client,
         core_client,
         ..
     }): State<AppState>,
@@ -713,7 +713,7 @@ pub(in crate::views) async fn project_path(
 pub(in crate::views) async fn project_path_op(
     State(AppState {
         db_pool,
-        valkey: valkey_client,
+        valkey_client,
         core_client,
         config,
         ..
@@ -816,7 +816,7 @@ pub(in crate::views) async fn project_path_op(
 pub(in crate::views) async fn occupancy_blocks(
     State(AppState {
         db_pool,
-        valkey: valkey_client,
+        valkey_client,
         core_client,
         config,
         ..
@@ -919,7 +919,7 @@ pub(in crate::views) async fn track_occupancy(
     State(AppState {
         config,
         db_pool,
-        valkey,
+        valkey_client,
         core_client,
         ..
     }): State<AppState>,
@@ -974,7 +974,7 @@ pub(in crate::views) async fn track_occupancy(
     // Retrieve simulations
     let simulations_result = train_simulation_batch(
         &mut db_pool.get().await?,
-        valkey,
+        valkey_client,
         core_client,
         &train_schedules,
         &infra,


### PR DESCRIPTION
This PR renames `valkey` to `valkey_client` in the `AppState` struct to align with the naming convention used for other clients, such as `core_client` and `osrdyne_client`.