### PR TITLE
editoast: tooling: document VSCode config

### DIFF
--- a/editoast/README.md
+++ b/editoast/README.md
@@ -52,19 +52,6 @@ To avoid thread conflicts while accessing the database, use serial_test
 cargo test --workspace -- --test-threads=4
 ```
 
-# Debugging
-
-:warning: For improving compilation time and therefore the developer experience, the project
-choose to strip out debug information by default, resulting in [about 20%
-shorter compilation time](https://github.com/OpenRailAssociation/osrd/pull/8579).
-
-If you need to debug the project, you might want to activate the `dev-for-debug` profile
-which will build with debug information.
-
-```
-cargo build --profile dev-for-debug
-```
-
 ## Useful tools
 
 Here a list of components to help you in your development (see CI jobs if necessary):
@@ -87,6 +74,92 @@ cargo install --locked taplo-cli
 ```
 
 To setup `grcov`, please see [its documentation](https://github.com/mozilla/grcov#how-to-get-grcov)
+
+## Debugging
+
+:warning: For improving compilation time and therefore the developer experience, the project
+choose to strip out debug information by default, resulting in [about 10%
+shorter compilation time](https://github.com/OpenRailAssociation/osrd/pull/13513).
+
+If you need to debug the project, you might want to activate the `dev-for-debug` profile
+which will build with debug information.
+
+```
+cargo build --profile dev-for-debug
+```
+
+### Tooling/IDE configurations
+
+Here are some useful tips grouped by tool (click to expand).
+
+<details>
+  <summary>Visual Studio Code</summary>
+
+  First, open only `./editoast` directory in VSCode:
+  * allows finding `Cargo.toml` (it may be possible to configure work directory when necessary, though)
+  * avoids loading all the projects (multiple cargo, npm, gradle) which consume lot of RAM and processor.
+
+  Useful extensions:
+  * `rust-analyzer`
+  * `CodeLLDB` (did not try `LLDB DAP`)
+  * `Rust Syntax`
+  * `Even Better TOML`
+  * `crates`
+  * (`Rust Macro Expand`: not tested, but promising)
+
+  For step-by-step debugging under VS Code, you need to change the debug level
+  to `full` in order to get the variable content.
+
+  This can be done by changing the **profile** in debugger launch tasks. \
+  Here is an example of configurations to put in `launch.json` for `CodeLLDB` extension:
+  ```json
+          {
+              "type": "lldb",
+              "request": "launch",
+              "name": "Debug single 'cargo test'",
+              "cargo": {
+                  "args": [
+                      "test",
+                      "--profile",
+                      "dev-for-debug",
+                      "--no-run",
+                  ]
+              },
+              // optional tests name filter
+              "args": ["create_locked_rolling_stock_successfully"]
+          },
+          {
+              "type": "lldb",
+              "request": "launch",
+              "name": "Debug 'editoast runserver' no-cache/single-worker",
+              "cargo": {
+                  "args": [
+                      "build",
+                      "--profile",
+                      "dev-for-debug",
+                  ]
+              },
+              "env": {
+                  "ROOT_URL": "http://localhost:4000/api",
+                  "EDITOAST_CORE_SINGLE_WORKER": "true",
+                  "EDITOAST_NO_CACHE": "true"
+              },
+              "args": ["runserver"],
+              "cwd": "${workspaceFolder}"
+          },
+  ```
+  Here is some configuration example of workspace's `settings.json` for
+  `rust-analyzer`'s code lens (`▶️ Run Test | ⚙ Debug`):
+  ```json
+      "rust-analyzer.runnables.extraArgs": [
+          "--profile=dev-for-debug"
+      ]
+  ```
+
+  Note: it's also possible to pass environment variables to change the **debug
+  level** of the profile used, but it's a bit less clean.
+
+</details>
 
 ## No-cache mode
 


### PR DESCRIPTION
Also rectify compilation time values from https://github.com/OpenRailAssociation/osrd/pull/8579 (correct in comments, outdated in readme).

To confirm what was listed in comments of the previous PR, with a hot `sccache`, the current `limited` debug level offers me a **10%** gain (over `full` debug level) for a `build` from `clean`:
```sh
❯ hyperfine \
    --parameter-list branch 'peb/none,peb/line-tables-only,dev,peb/full' \
    --prepare 'git switch {branch} && cargo clean' \
    'cargo build --workspace'
Benchmark 1: cargo build --workspace (branch = peb/none)
  Time (mean ± σ):     159.810 s ±  8.383 s    [User: 207.930 s, System: 31.804 s]
  Range (min … max):   150.450 s … 178.398 s    10 runs

Benchmark 2: cargo build --workspace (branch = peb/line-tables-only)
  Time (mean ± σ):     163.287 s ±  6.393 s    [User: 215.276 s, System: 32.406 s]
  Range (min … max):   157.915 s … 177.369 s    10 runs

Benchmark 3: cargo build --workspace (branch = dev)
  Time (mean ± σ):     162.958 s ±  4.156 s    [User: 211.497 s, System: 32.414 s]
  Range (min … max):   158.974 s … 172.605 s    10 runs

Benchmark 4: cargo build --workspace (branch = peb/full)
  Time (mean ± σ):     179.867 s ±  5.043 s    [User: 247.191 s, System: 36.193 s]
  Range (min … max):   176.227 s … 192.350 s    10 runs

Summary
  cargo build --workspace (branch = peb/none) ran
    1.02 ± 0.06 times faster than cargo build --workspace (branch = dev)
    1.02 ± 0.07 times faster than cargo build --workspace (branch = peb/line-tables-only)
    1.13 ± 0.07 times faster than cargo build --workspace (branch = peb/full)
```

And for the link only, I get a **6.5%** gain (using `mold 2`):
```sh
❯ hyperfine --warmup 1 \
    --parameter-list branch 'peb/none,peb/line-tables-only,dev,peb/full' \
    --prepare 'git switch {branch}' \
    'touch src/main.rs && cargo build --workspace'
Benchmark 1: touch src/main.rs && cargo build --workspace (branch = peb/none)
  Time (mean ± σ):     13.828 s ±  0.405 s    [User: 11.341 s, System: 2.234 s]
  Range (min … max):   13.277 s … 14.695 s    10 runs

Benchmark 2: touch src/main.rs && cargo build --workspace (branch = peb/line-tables-only)
  Time (mean ± σ):     14.222 s ±  0.670 s    [User: 11.829 s, System: 2.226 s]
  Range (min … max):   13.347 s … 15.475 s    10 runs

Benchmark 3: touch src/main.rs && cargo build --workspace (branch = dev)
  Time (mean ± σ):     14.140 s ±  0.336 s    [User: 11.517 s, System: 2.276 s]
  Range (min … max):   13.766 s … 14.823 s    10 runs

Benchmark 4: touch src/main.rs && cargo build --workspace (branch = peb/full)
  Time (mean ± σ):     15.099 s ±  0.369 s    [User: 12.083 s, System: 2.479 s]
  Range (min … max):   14.432 s … 15.476 s    10 runs

Summary
  touch src/main.rs && cargo build --workspace (branch = peb/none) ran
    1.02 ± 0.04 times faster than touch src/main.rs && cargo build --workspace (branch = dev)
    1.03 ± 0.06 times faster than touch src/main.rs && cargo build --workspace (branch = peb/line-tables-only)
    1.09 ± 0.04 times faster than touch src/main.rs && cargo build --workspace (branch = peb/full)
```