### PR TITLE
helm: Add secret_key to gateway config

### DIFF
--- a/chart/templates/gateway/configmap.yaml
+++ b/chart/templates/gateway/configmap.yaml
@@ -9,6 +9,9 @@ data:
     {{- $config := .Values.services.gateway.config }}
     listen_addr = "0.0.0.0"
     port = {{ .Values.services.gateway.service.targetPort }}
+    {{- if $config.secret_key }}
+    secret_key = {{ $config.secret_key }}
+    {{- end }}
     trusted_proxies = [{{ range $index, $proxy := $config.trusted_proxies }}{{ if $index }}, {{ end }}"{{ $proxy }}"{{ end }}]
 
     [static_files]

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -138,6 +138,7 @@ services:
         enabled: false
         prefix: "/railway-manager"
         upstream: ""
+      secret_key: "NOT+A+SECRET++NOT+A+SECRET++NOT+A+SECRET++NOT+A+SECRET++NOT+A+SECRET++NOT+A+SECRET++NOT+A+SECRET" # See https://github.com/OpenRailAssociation/osrd/blob/dev/gateway/README.md#config 
       tracing:
         enabled: false
         type: ""


### PR DESCRIPTION
Since the secret_key is mandatory for gateway to run, adding it to gateway config might help new user to be onboarded on the project.
Value is not mandatory in order not to break deployment relaying on environment variable.