### PR TITLE
front: operational-studies: unify requested-point numbers

### DIFF
--- a/front/justfile
+++ b/front/justfile
@@ -24,7 +24,10 @@ format:
 # Verify code lints without applying any fix
 lint:
     npm run lint
+    ./scripts/i18n-order-checker.sh
+    npm run i18n-checker
 
 # Fix all the lints that can be automatically applied
 fix-lint:
     npm run lint-fix
+    scripts/i18n-order-checker.sh --fix

--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -141,6 +141,8 @@
     "pacedTrain_one": "1 service",
     "pacedTrain_other": "{{count}} services",
     "pacedTrain_zero": "0 service",
+    "requestedDestination": "requested destination",
+    "requestedOrigin": "requested origin",
     "requestedPoint": "requested point ({{ count }})",
     "requestedPointUnknown": "requested point",
     "roundTripsModal": {

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -141,6 +141,8 @@
     "pacedTrain_one": "1 mission",
     "pacedTrain_other": "{{count}} missions",
     "pacedTrain_zero": "0 mission",
+    "requestedDestination": "destination demandée",
+    "requestedOrigin": "origine demandée",
     "requestedPoint": "point demandé ({{ count }})",
     "requestedPointUnknown": "point demandé",
     "roundTripsModal": {

--- a/front/src/applications/operationalStudies/__tests__/upsertMapWaypointsInOperationalPoints.spec.ts
+++ b/front/src/applications/operationalStudies/__tests__/upsertMapWaypointsInOperationalPoints.spec.ts
@@ -194,7 +194,7 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
         id: '1',
         extensions: {
           identifier: {
-            name: 't_requestedPoint',
+            name: 't_requestedOrigin',
             uic: 0,
           },
         },
@@ -239,7 +239,7 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
         id: '3',
         extensions: {
           identifier: {
-            name: 't_requestedPoint',
+            name: 't_requestedDestination',
             uic: 0,
           },
         },
@@ -281,7 +281,7 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
         id: '1',
         extensions: {
           identifier: {
-            name: 't_requestedPoint',
+            name: 't_requestedOrigin',
             uic: 0,
           },
         },
@@ -296,7 +296,7 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
         id: '2',
         extensions: {
           identifier: {
-            name: 't_requestedPoint',
+            name: 't_requestedDestination',
             uic: 0,
           },
         },

--- a/front/src/applications/operationalStudies/helpers/upsertMapWaypointsInOperationalPoints.ts
+++ b/front/src/applications/operationalStudies/helpers/upsertMapWaypointsInOperationalPoints.ts
@@ -33,10 +33,8 @@ export function upsertMapWaypointsInOperationalPoints(
   operationalPoints: (PathOperationalPoint | EditoastPathOperationalPoint)[],
   t: TFunction<'operational-studies'>
 ): (PathOperationalPoint | EditoastPathOperationalPoint)[] {
-  let waypointCounter = 1;
-
   return path.reduce(
-    (operationalPointsWithAllWaypoints, step, i) => {
+    (operationalPointsWithAllWaypoints, step, stepIndex) => {
       if ('uic' in step) {
         const matchedIndex = operationalPointsWithAllWaypoints.findIndex(
           (op) =>
@@ -58,15 +56,21 @@ export function upsertMapWaypointsInOperationalPoints(
       }
 
       if ('track' in step) {
-        const positionOnPath = pathItemsPositions[i];
+        const positionOnPath = pathItemsPositions[stepIndex];
         const indexToInsert = operationalPointsWithAllWaypoints.findIndex(
           (op) => op.position >= positionOnPath
         );
+        let stepName = t('main.requestedPoint', { count: stepIndex });
+        if (stepIndex === 0) {
+          stepName = t('main.requestedOrigin');
+        } else if (stepIndex === path.length - 1) {
+          stepName = t('main.requestedDestination');
+        }
 
         const baseFormattedStep = {
           extensions: {
             identifier: {
-              name: t('main.requestedPoint', { count: waypointCounter }),
+              name: stepName,
               uic: 0,
             },
           },
@@ -85,8 +89,6 @@ export function upsertMapWaypointsInOperationalPoints(
                 ...baseFormattedStep,
                 id: step.id,
               };
-
-        waypointCounter += 1;
 
         // If we can't find any op position greater than the current step position, we add it at the end
         if (indexToInsert === -1) {

--- a/front/src/modules/pathfinding/utils.ts
+++ b/front/src/modules/pathfinding/utils.ts
@@ -101,11 +101,16 @@ export const upsertPathStepsInOPs = (
   t: TFunction<'operational-studies'>
 ): SuggestedOP[] => {
   let updatedOPs = [...ops];
-  let waypointCounter = 1;
-  pathSteps.forEach((step) => {
+  pathSteps.map((step, stepIndex) => {
     const { arrival, stopFor, receptionSignal, theoreticalMargin } = step;
     // We check only for pathSteps added by map click
     if ('track' in step.location) {
+      let stepName = t('main.requestedPoint', { count: stepIndex });
+      if (stepIndex === 0) {
+        stepName = t('main.requestedOrigin');
+      } else if (stepIndex === pathSteps.length - 1) {
+        stepName = t('main.requestedDestination');
+      }
       const formattedStep: SuggestedOP = {
         pathStepId: step.id,
         opId: undefined,
@@ -117,9 +122,8 @@ export const upsertPathStepsInOPs = (
         arrival,
         receptionSignal,
         theoreticalMargin,
-        name: t('main.requestedPoint', { count: waypointCounter }),
+        name: stepName,
       };
-      waypointCounter += 1;
       // If it hasn't an uic, the step has been added by map click,
       // we know we have its position on path so we can insert it
       // at the good index in the existing operational points

--- a/front/src/modules/timesStops/helpers/utils.ts
+++ b/front/src/modules/timesStops/helpers/utils.ts
@@ -377,15 +377,23 @@ export const getTrackReferenceLabel = (trackReference?: TrackReference | null) =
 export const getOperationalPointName = (
   op: OperationalPoint | undefined,
   step: PathItemLocation,
-  mapWaypointCount: number,
+  stepIndex: number,
+  totalStepCount: number,
   t: TFunction<'operational-studies'>
 ) => {
   // We have a matching operational point
   if (op) return op.extensions?.identifier?.name;
 
   // TrackOffset
-  if (!isOperationalPointReference(step))
-    return t('main.requestedPoint', { count: mapWaypointCount });
+  if (!isOperationalPointReference(step)) {
+    if (stepIndex === 0) {
+      return t('main.requestedOrigin');
+    } else if (stepIndex === totalStepCount - 1) {
+      return t('main.requestedDestination');
+    } else {
+      return t('main.requestedPoint', { count: stepIndex });
+    }
+  }
 
   // Invalid step
   return getInvalidStepLabel(step);

--- a/front/src/modules/timesStops/hooks/useOutputTableData.ts
+++ b/front/src/modules/timesStops/hooks/useOutputTableData.ts
@@ -53,17 +53,16 @@ const useOutputTableData = (
 
       const startDatetime = new Date(train.start_time);
       let lastReferenceDate = startDatetime;
-      let mapWaypointCount = 0;
 
       return new Map(
-        train.path.map((pathStep, index) => {
+        train.path.map((pathStep, stepIndex) => {
           const matchingOperationalPoint = pathStepOps.find((op) => matchOpRefAndOp(op, pathStep));
 
-          if ('track' in pathStep) mapWaypointCount += 1;
           const name = getOperationalPointName(
             matchingOperationalPoint,
             pathStep,
-            mapWaypointCount,
+            stepIndex,
+            train.path.length,
             t
           );
           const trackName =
@@ -73,7 +72,7 @@ const useOutputTableData = (
 
           const schedule = scheduleByAt[pathStep.id];
           const computedArrival = simulatedPathItemTimes
-            ? new Date(startDatetime.getTime() + simulatedPathItemTimes.final[index])
+            ? new Date(startDatetime.getTime() + simulatedPathItemTimes.final[stepIndex])
             : undefined;
           const { stopFor, shortSlipDistance, onStopSignal, calculatedDeparture } = formatSchedule(
             computedArrival,
@@ -84,7 +83,7 @@ const useOutputTableData = (
             lastReferenceDate,
             schedule,
             {
-              isDeparture: index === 0,
+              isDeparture: stepIndex === 0,
             }
           );
           lastReferenceDate = refDate;
@@ -99,7 +98,7 @@ const useOutputTableData = (
             theoreticalMargins,
             train,
             scheduleByAt,
-            index,
+            stepIndex,
             simulatedPathItemTimes
           );
 

--- a/front/tests/utils/manchette.ts
+++ b/front/tests/utils/manchette.ts
@@ -13,13 +13,16 @@ export type Waypoint = {
   checked?: boolean;
 };
 
-const firstRequestedPointKey = `${frScenarioTranslations.requestedPointUnknown} (1)`;
-const secondRequestedPointKey = `${frScenarioTranslations.requestedPointUnknown} (2)`;
+const requestedDestination = frScenarioTranslations.requestedDestination;
+
+function requestedPoint(number: string): string {
+  return frScenarioTranslations.requestedPoint.replaceAll('{{ count }}', number);
+}
 
 export const expectedWaypointsPanelDataForTrainSchedule: Record<string, Partial<Waypoint>> = {
   North_East_station: { ch: 'BV', offset: '0.0', checked: true },
   Mid_East_station: { ch: 'BV', offset: '19.55', checked: true },
-  [firstRequestedPointKey]: { ch: '', offset: '22.47', checked: true },
+  [requestedPoint('2')]: { ch: '', offset: '22.47', checked: true },
   Mid_West_station: { ch: 'BV', offset: '34.0', checked: true },
   North_West_station: { ch: 'BC', offset: '47.55', checked: true },
 };
@@ -27,17 +30,17 @@ export const expectedWaypointsPanelDataForTrainSchedule: Record<string, Partial<
 export const expectedWaypointsPanelDataForPacedTrain: Record<string, Partial<Waypoint>> = {
   North_East_station: { ch: 'BV', offset: '0.0', checked: true },
   Mid_East_station: { ch: 'BV', offset: '19.55', checked: true },
-  [firstRequestedPointKey]: { ch: '', offset: '22.47', checked: true },
+  [requestedPoint('1')]: { ch: '', offset: '22.47', checked: true },
   Mid_West_station: { ch: 'BV', offset: '34.0', checked: true },
   North_West_station: { ch: 'BC', offset: '47.55', checked: true },
-  [secondRequestedPointKey]: { ch: '', offset: '47.65', checked: true },
+  [requestedDestination]: { ch: '', offset: '47.65', checked: true },
 };
 
 export const expectedWaypointsListDataForPacedTrain: Record<string, Partial<Waypoint>> = {
   North_East_station: { ch: 'BV', offset: '0' },
-  [firstRequestedPointKey]: { ch: '', offset: '22.5' },
+  [requestedPoint('1')]: { ch: '', offset: '22.5' },
   Mid_West_station: { ch: 'BV', offset: '34' },
-  [secondRequestedPointKey]: { ch: '', offset: '47.7' },
+  [requestedDestination]: { ch: '', offset: '47.7' },
 };
 
 export const expectedWaypointsListDataForTrainSchedule: Record<string, Partial<Waypoint>> = {


### PR DESCRIPTION
For edit and display pages, if the step is an OP, keep it as-is (for origin and destination as well).

But the number in non-OP steps name is now based on what's done on the maps for STD, SDD, timetable (csv, sheet), edit route, edit timetable:
- `requested origin` -> 📍 on the map
- `requested point (1)` -> 1️⃣ on the map
- `requested point (2)` -> 2️⃣ on the map
- OP-name -> 3️⃣ on the map
- `requested point (4)` -> 4️⃣ on the map
- `requested destination` -> 🏁 on the map

<details>
   <summary> 👁️ Expand to see result after PR 💻 </summary>

### Unchanged:
* display map:
  <img width="693" height="214" alt="image" src="https://github.com/user-attachments/assets/f0b4ab7b-ca38-40a4-a1f8-4557bf3df51e" />

* edit map + caption:
  <img width="1403" height="495" alt="image" src="https://github.com/user-attachments/assets/e585d465-a1f7-4bea-894e-8f6a32b09c3e" />

### Changed (unified):
* display STD:
  <img width="636" height="519" alt="image" src="https://github.com/user-attachments/assets/b327b21a-c67d-494e-b201-37b304c2dde5" />

* display SSD:
  <img width="1497" height="177" alt="image" src="https://github.com/user-attachments/assets/aa79b1aa-0755-4ee1-a8fb-753d72999e60" /><img width="335" height="166" alt="image" src="https://github.com/user-attachments/assets/d0aff602-09d9-4781-b493-8c80f0025b65" />

* display timetable:
  <img width="870" height="458" alt="image" src="https://github.com/user-attachments/assets/1290dd66-68d3-448f-8c65-284be7cdaf42" />

* timetable PDF sheet:
  <img width="577" height="538" alt="image" src="https://github.com/user-attachments/assets/e36ddfc6-fb1a-48e8-9adb-70dcb80448ee" />

* timetable CSV:
  <img width="948" height="743" alt="image" src="https://github.com/user-attachments/assets/faf374dd-9916-408f-9302-d9f4cef35a11" />

* edit timetable:
  <img width="1150" height="471" alt="image" src="https://github.com/user-attachments/assets/da9d7d7d-1e2b-4114-acca-df1aef0778ac" />

</details>