### PR TITLE
editoast: new endpoint to create notes for nge

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -2714,6 +2714,43 @@ paths:
       responses:
         '204':
           description: The macro node was deleted successfully
+  /projects/{project_id}/studies/{study_id}/scenarios/{scenario_id}/macro_notes:
+    post:
+      tags:
+      - scenarios
+      parameters:
+      - name: project_id
+        in: path
+        description: The id of a project
+        required: true
+        schema:
+          type: integer
+          format: int64
+      - name: study_id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      - name: scenario_id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MacroNoteBatchForm'
+        required: true
+      responses:
+        '201':
+          description: Macro notes created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MacroNoteBatchResponse'
   /projects/{project_id}/studies/{study_id}/scenarios/{scenario_id}/macro_notes/{note_id}:
     get:
       tags:
@@ -10088,6 +10125,45 @@ components:
           type:
           - string
           - 'null'
+    MacroNoteBatchForm:
+      type: object
+      required:
+      - macro_notes
+      properties:
+        macro_notes:
+          type: array
+          items:
+            $ref: '#/components/schemas/MacroNoteForm'
+    MacroNoteBatchResponse:
+      type: object
+      required:
+      - macro_notes
+      properties:
+        macro_notes:
+          type: array
+          items:
+            $ref: '#/components/schemas/MacroNoteResponse'
+    MacroNoteForm:
+      type: object
+      required:
+      - x
+      - y
+      - title
+      - text
+      - labels
+      properties:
+        labels:
+          $ref: '#/components/schemas/Tags'
+        text:
+          type: string
+        title:
+          type: string
+        x:
+          type: integer
+          format: int64
+        y:
+          type: integer
+          format: int64
     MacroNoteResponse:
       type: object
       required:

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -330,7 +330,8 @@ fn service_router() -> router::DocumentedRouter {
                                                                     })
                                                             })
                                                             .nests("/macro_notes", |path| {
-                                                                path.nests("/{note_id}", |path| {
+                                                                path.route("/", post!(scenario::macro_notes::create))
+                                                                    .nests("/{note_id}", |path| {
                                                                     path.route("/", get!(scenario::macro_notes::get))
                                                                 })
                                                             })

--- a/editoast/src/views/scenario/macro_notes.rs
+++ b/editoast/src/views/scenario/macro_notes.rs
@@ -5,8 +5,12 @@ use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
 use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
 use database::DbConnectionPoolV2;
+use diesel_async::scoped_futures::ScopedFutureExt;
 use editoast_derive::EditoastError;
+use itertools::Itertools;
 use serde::Deserialize;
 use serde::Serialize;
 use thiserror::Error;
@@ -14,12 +18,17 @@ use utoipa::IntoParams;
 use utoipa::ToSchema;
 
 use super::check_project_study_scenario;
+use crate::error::InternalError;
 use crate::error::Result;
+use crate::models::Scenario;
 use crate::models::macro_note::MacroNote;
 use crate::views::AuthenticationExt;
 use crate::views::AuthorizationError;
+use crate::views::project::ProjectError;
 use crate::views::project::ProjectIdParam;
+use crate::views::scenario::ScenarioError;
 use crate::views::scenario::ScenarioIdParam;
+use crate::views::study::StudyError;
 use crate::views::study::StudyIdParam;
 use editoast_models::prelude::*;
 use editoast_models::tags::Tags;
@@ -47,6 +56,36 @@ struct MacroNoteIdParam {
 }
 
 #[editoast_derive::openapi_schema]
+#[derive(Debug, Deserialize, ToSchema)]
+#[cfg_attr(test, derive(Serialize, PartialEq, Clone))]
+pub(in crate::views) struct MacroNoteForm {
+    x: i64,
+    y: i64,
+    title: String,
+    text: String,
+    labels: Tags,
+}
+
+#[editoast_derive::openapi_schema]
+#[derive(Debug, Deserialize, ToSchema)]
+#[cfg_attr(test, derive(Serialize, PartialEq, Clone))]
+pub(in crate::views) struct MacroNoteBatchForm {
+    macro_notes: Vec<MacroNoteForm>,
+}
+
+impl MacroNoteForm {
+    pub fn into_macro_note_changeset(self, scenario_id: i64) -> Changeset<MacroNote> {
+        MacroNote::changeset()
+            .scenario_id(scenario_id)
+            .x(self.x)
+            .y(self.y)
+            .title(self.title)
+            .text(self.text)
+            .labels(self.labels)
+    }
+}
+
+#[editoast_derive::openapi_schema]
 #[derive(Debug, Serialize, ToSchema)]
 #[cfg_attr(test, derive(Deserialize, PartialEq))]
 pub(in crate::views) struct MacroNoteResponse {
@@ -56,6 +95,13 @@ pub(in crate::views) struct MacroNoteResponse {
     title: String,
     text: String,
     labels: Tags,
+}
+
+#[editoast_derive::openapi_schema]
+#[derive(Debug, Serialize, ToSchema)]
+#[cfg_attr(test, derive(Deserialize, PartialEq))]
+pub(in crate::views) struct MacroNoteBatchResponse {
+    macro_notes: Vec<MacroNoteResponse>,
 }
 
 impl From<MacroNote> for MacroNoteResponse {
@@ -69,6 +115,68 @@ impl From<MacroNote> for MacroNoteResponse {
             labels: note.labels,
         }
     }
+}
+
+#[editoast_derive::route]
+#[utoipa::path(
+    post, path = "",
+    tag = "scenarios",
+    request_body = MacroNoteBatchForm,
+    params(ProjectIdParam, StudyIdParam, ScenarioIdParam),
+    responses(
+        (status = 201, body = MacroNoteBatchResponse, description = "Macro notes created"),
+    )
+)]
+pub(in crate::views) async fn create(
+    State(db_pool): State<Arc<DbConnectionPoolV2>>,
+    Extension(auth): AuthenticationExt,
+    Path((project_id, study_id, scenario_id)): Path<(i64, i64, i64)>,
+    Json(MacroNoteBatchForm { macro_notes }): Json<MacroNoteBatchForm>,
+) -> Result<impl IntoResponse> {
+    let authorized = auth
+        .check_roles([Role::OperationalStudies].into())
+        .await
+        .map_err(AuthorizationError::AuthError)?;
+    if !authorized {
+        return Err(AuthorizationError::Forbidden.into());
+    }
+
+    let created = Scenario::transactional_content_update(
+        db_pool.get().await?,
+        scenario_id,
+        move |mut conn, scenario, study, project| {
+            async move {
+                if project.id != project_id {
+                    return Err::<_, InternalError>(ProjectError::NotFound { project_id }.into());
+                }
+                if study.id != study_id {
+                    return Err(StudyError::NotFound { study_id }.into());
+                }
+                if scenario.id != scenario_id {
+                    return Err(ScenarioError::NotFound { scenario_id }.into());
+                }
+
+                let changesets: Vec<_> = macro_notes
+                    .into_iter()
+                    .map(|note| note.into_macro_note_changeset(scenario_id))
+                    .collect();
+
+                let created_macro_notes: Vec<_> =
+                    MacroNote::create_batch(&mut conn, changesets).await?;
+
+                Ok(created_macro_notes)
+            }
+            .scope_boxed()
+        },
+    )
+    .await?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(MacroNoteBatchResponse {
+            macro_notes: created.into_iter().map_into().collect(),
+        }),
+    ))
 }
 
 /// Return a specific note
@@ -124,6 +232,94 @@ pub mod test {
     use super::*;
     use crate::models::fixtures::create_scenario_fixtures_set;
     use crate::views::test_app::TestAppBuilder;
+
+    impl PartialEq<MacroNoteResponse> for MacroNoteForm {
+        fn eq(&self, other: &MacroNoteResponse) -> bool {
+            self.x == other.x
+                && self.y == other.y
+                && self.title == other.title
+                && self.text == other.text
+                && self.labels == other.labels
+        }
+    }
+
+    #[rstest]
+    async fn create_note() {
+        let app = TestAppBuilder::default_app();
+        let db_pool = app.db_pool();
+
+        let fixtures =
+            create_scenario_fixtures_set(&mut db_pool.get_ok(), "test_scenario_name").await;
+
+        let notes_data = vec![
+            MacroNoteForm {
+                x: 10,
+                y: 22,
+                title: "Note title 1".to_string(),
+                text: "Note text 1".to_string(),
+                labels: Tags::new(vec!["A".to_string(), "B".to_string()]),
+            },
+            MacroNoteForm {
+                x: 1,
+                y: 2,
+                title: "Note title 2".to_string(),
+                text: "Note text 2".to_string(),
+                labels: Tags::new(vec!["A".to_string(), "C".to_string()]),
+            },
+        ];
+
+        let request = app
+            .post(&format!(
+                "/projects/{}/studies/{}/scenarios/{}/macro_notes",
+                fixtures.project.id, fixtures.study.id, fixtures.scenario.id
+            ))
+            .json(&MacroNoteBatchForm {
+                macro_notes: notes_data.clone(),
+            });
+        let response: MacroNoteBatchResponse = app
+            .fetch(request)
+            .assert_status(StatusCode::CREATED)
+            .json_into();
+
+        assert_eq!(notes_data.len(), response.macro_notes.len());
+
+        for (form, response_note) in notes_data.iter().zip(&response.macro_notes) {
+            assert_eq!(form, response_note);
+            let note = MacroNote::retrieve(db_pool.get_ok(), response_note.id)
+                .await
+                .unwrap()
+                .expect("Failed to retrieve note");
+            assert_eq!(MacroNoteResponse::from(note), *response_note);
+        }
+    }
+
+    #[rstest]
+    async fn create_note_scenario_not_found() {
+        let app = TestAppBuilder::default_app();
+        let db_pool = app.db_pool();
+        let fixtures =
+            create_scenario_fixtures_set(&mut db_pool.get_ok(), "test_scenario_name").await;
+
+        let notes_data = vec![MacroNoteForm {
+            x: 10,
+            y: 22,
+            title: "Note title 1".to_string(),
+            text: "Note text 1".to_string(),
+            labels: Tags::new(vec!["A".to_string()]),
+        }];
+
+        let request = app
+            .post(&format!(
+                "/projects/{}/studies/{}/scenarios/{}/macro_notes",
+                fixtures.project.id,
+                fixtures.study.id,
+                fixtures.scenario.id + 1
+            ))
+            .json(&MacroNoteBatchForm {
+                macro_notes: notes_data.clone(),
+            });
+        app.fetch(request).assert_status(StatusCode::NOT_FOUND);
+    }
 
     #[rstest]
     async fn get_note() {

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -792,6 +792,17 @@ const injectedRtkApi = api
         }),
         invalidatesTags: ['scenarios'],
       }),
+      postProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotes: build.mutation<
+        PostProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotesApiResponse,
+        PostProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotesApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/projects/${queryArg.projectId}/studies/${queryArg.studyId}/scenarios/${queryArg.scenarioId}/macro_notes`,
+          method: 'POST',
+          body: queryArg.macroNoteBatchForm,
+        }),
+        invalidatesTags: ['scenarios'],
+      }),
       getProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotesNoteId: build.query<
         GetProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotesNoteIdApiResponse,
         GetProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotesNoteIdApiArg
@@ -2100,6 +2111,15 @@ export type DeleteProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNo
   studyId: number;
   scenarioId: number;
   nodeId: number;
+};
+export type PostProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotesApiResponse =
+  /** status 201 Macro notes created */ MacroNoteBatchResponse;
+export type PostProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotesApiArg = {
+  /** The id of a project */
+  projectId: number;
+  studyId: number;
+  scenarioId: number;
+  macroNoteBatchForm: MacroNoteBatchForm;
 };
 export type GetProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotesNoteIdApiResponse =
   /** status 200 The requested macro note */ MacroNoteResponse;
@@ -4215,6 +4235,19 @@ export type MacroNoteResponse = {
   title: string;
   x: number;
   y: number;
+};
+export type MacroNoteBatchResponse = {
+  macro_notes: MacroNoteResponse[];
+};
+export type MacroNoteForm = {
+  labels: Tags;
+  text: string;
+  title: string;
+  x: number;
+  y: number;
+};
+export type MacroNoteBatchForm = {
+  macro_notes: MacroNoteForm[];
 };
 export type EffortCurveConditions = {
   comfort: null | Comfort;


### PR DESCRIPTION
Enable batch creation of macro notes within a scenario for NGE :.

* Introduced a new POST endpoint `/projects/{project_id}/studies/{study_id}/scenarios/{scenario_id}/macro_notes` for batch creation of macro notes.
* Integrated the endpoint into the scenario router.
* Implemented `MacroNoteForm` and `MacroNoteBatchForm` structs, conversion logic, and the `create` handler for batch note creation.
* Added comprehensive tests for the batch creation endpoint, covering successful creation and scenario not found cases.