### PR TITLE
front, editoast: fix missing fields in scenario and study search results

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -12941,6 +12941,7 @@ components:
       - electrical_profile_set_id
       - infra_id
       - infra_name
+      - paced_trains_count
       - trains_count
       - description
       - last_modification
@@ -12969,6 +12970,10 @@ components:
           format: date-time
         name:
           type: string
+        paced_trains_count:
+          type: integer
+          format: int64
+          minimum: 0
         study_id:
           type: integer
           format: int64
@@ -13038,6 +13043,9 @@ components:
       - last_modification
       - tags
       - budget
+      - business_code
+      - service_code
+      - study_type
       properties:
         budget:
           type:
@@ -13045,6 +13053,10 @@ components:
           - 'null'
           format: int32
           minimum: 0
+        business_code:
+          type:
+          - string
+          - 'null'
         description:
           type:
           - string
@@ -13066,6 +13078,14 @@ components:
           type: integer
           format: int64
           minimum: 0
+        service_code:
+          type:
+          - string
+          - 'null'
+        study_type:
+          type:
+          - string
+          - 'null'
         tags:
           type: array
           items:

--- a/editoast/src/views/search.rs
+++ b/editoast/src/views/search.rs
@@ -679,6 +679,15 @@ pub(super) struct SearchResultItemStudy {
     #[search(sql = "study.budget")]
     #[schema(required)]
     budget: Option<u32>,
+    #[search(sql = "study.business_code")]
+    #[schema(required)]
+    business_code: Option<String>,
+    #[search(sql = "study.service_code")]
+    #[schema(required)]
+    service_code: Option<String>,
+    #[search(sql = "study.study_type")]
+    #[schema(required)]
+    study_type: Option<String>,
 }
 
 #[editoast_derive::openapi_schema]
@@ -723,6 +732,10 @@ pub(super) struct SearchResultItemScenario {
     infra_id: u64,
     #[search(sql = "infra.name")]
     infra_name: String,
+    #[search(
+        sql = "(SELECT COUNT(trains.id) FROM paced_train AS trains WHERE scenario.timetable_id = trains.timetable_id)"
+    )]
+    paced_trains_count: u64,
     #[search(
         sql = "(SELECT COUNT(trains.id) FROM train_schedule AS trains WHERE scenario.timetable_id = trains.timetable_id)"
     )]

--- a/front/src/applications/operationalStudies/types.ts
+++ b/front/src/applications/operationalStudies/types.ts
@@ -11,6 +11,10 @@ import type {
   MacroNodeForm,
   RollingStockWithLiveries,
   TrainCategory,
+  SearchResultItemStudy,
+  StudyWithScenarios,
+  ScenarioWithDetails,
+  SearchResultItemScenario,
 } from 'common/api/osrdEditoastApi';
 import type { RangedValue } from 'common/types';
 import type { PathOperationalPoint } from 'modules/simulationResult/types';
@@ -144,3 +148,7 @@ export type TimetableItemRoundTripGroups = {
   roundTrips: (readonly [TimetableItemWithPathOps, TimetableItemWithPathOps])[];
   others: TimetableItemWithPathOps[];
 };
+
+export type StudyCardDetails = SearchResultItemStudy | StudyWithScenarios;
+
+export type ScenarioCardDetails = SearchResultItemScenario | ScenarioWithDetails;

--- a/front/src/applications/operationalStudies/views/Project/ProjectView.tsx
+++ b/front/src/applications/operationalStudies/views/Project/ProjectView.tsx
@@ -12,10 +12,11 @@ import BreadCrumbs from 'applications/operationalStudies/components/BreadCrumbs'
 import FilterTextField from 'applications/operationalStudies/components/FilterTextField';
 import AddOrEditStudyModal from 'applications/operationalStudies/components/Study/AddOrEditStudyModal';
 import useMultiSelection from 'applications/operationalStudies/hooks/useMultiSelection';
+import type { StudyCardDetails } from 'applications/operationalStudies/types';
 import { getDocument } from 'common/api/documentApi';
 import {
   type PostSearchApiArg,
-  type StudyWithScenarios,
+  type SearchResultItemStudy,
   osrdEditoastApi,
 } from 'common/api/osrdEditoastApi';
 import { useModal } from 'common/BootstrapSNCF/ModalSNCF';
@@ -92,7 +93,7 @@ const ProjectView = () => {
     setItems: setStudiesList,
     toggleSelection: toggleStudySelection,
     deleteItems,
-  } = useMultiSelection<StudyWithScenarios>(async (studyId) => {
+  } = useMultiSelection<StudyCardDetails>(async (studyId) => {
     const { data: scenarios } = await getScenarios({ projectId: projectId!, studyId });
 
     deleteStudy({ projectId: projectId!, studyId });
@@ -149,7 +150,7 @@ const ProjectView = () => {
           },
         };
         try {
-          let filteredStudies = (await postSearch(payload).unwrap()) as StudyWithScenarios[];
+          let filteredStudies = (await postSearch(payload).unwrap()) as SearchResultItemStudy[];
           if (sortOption === 'LastModifiedDesc') {
             filteredStudies = [...filteredStudies].sort((a, b) =>
               b.last_modification.localeCompare(a.last_modification)

--- a/front/src/applications/operationalStudies/views/Project/StudyCard.tsx
+++ b/front/src/applications/operationalStudies/views/Project/StudyCard.tsx
@@ -3,14 +3,14 @@ import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 
+import type { StudyCardDetails } from 'applications/operationalStudies/types';
 import studyLogo from 'assets/pictures/views/study.svg';
-import type { StudyWithScenarios } from 'common/api/osrdEditoastApi';
 import { useDateTimeLocale } from 'utils/date';
 import { budgetFormat } from 'utils/numbers';
 
 type StudyCardProps = {
   setFilterChips: (filterChips: string) => void;
-  study: StudyWithScenarios;
+  study: StudyCardDetails;
   isSelected: boolean;
   toggleSelect: (id: number) => void;
 };

--- a/front/src/applications/operationalStudies/views/Study/StudyView.tsx
+++ b/front/src/applications/operationalStudies/views/Study/StudyView.tsx
@@ -8,10 +8,11 @@ import AddNewCard from 'applications/operationalStudies/components/AddNewCard';
 import BreadCrumbs from 'applications/operationalStudies/components/BreadCrumbs';
 import FilterTextField from 'applications/operationalStudies/components/FilterTextField';
 import AddOrEditStudyModal from 'applications/operationalStudies/components/Study/AddOrEditStudyModal';
+import type { ScenarioCardDetails } from 'applications/operationalStudies/types';
 import {
   type PostSearchApiArg,
   osrdEditoastApi,
-  type ScenarioWithDetails,
+  type SearchResultItemScenario,
 } from 'common/api/osrdEditoastApi';
 import { useModal } from 'common/BootstrapSNCF/ModalSNCF';
 import OptionsSNCF from 'common/BootstrapSNCF/OptionsSNCF';
@@ -97,7 +98,7 @@ const StudyView = () => {
     setItems: setScenariosList,
     toggleSelection: toggleScenarioSelection,
     deleteItems,
-  } = useMultiSelection<ScenarioWithDetails>((scenarioId) => {
+  } = useMultiSelection<ScenarioCardDetails>((scenarioId) => {
     deleteScenario({ projectId: projectId!, studyId: studyId!, scenarioId });
 
     // For each scenarios, clean the local storage if a manchette is saved
@@ -153,7 +154,9 @@ const StudyView = () => {
           },
         };
         try {
-          let filteredScenarios = (await postSearch(payload).unwrap()) as ScenarioWithDetails[];
+          let filteredScenarios = (await postSearch(
+            payload
+          ).unwrap()) as SearchResultItemScenario[];
           if (sortOption === 'LastModifiedDesc') {
             filteredScenarios = [...filteredScenarios].sort((a, b) =>
               b.last_modification.localeCompare(a.last_modification)

--- a/front/src/applications/operationalStudies/views/Study/components/ScenarioCard.tsx
+++ b/front/src/applications/operationalStudies/views/Study/components/ScenarioCard.tsx
@@ -5,13 +5,13 @@ import { MdTrain } from 'react-icons/md';
 import { RiFolderChartLine } from 'react-icons/ri';
 import { useNavigate } from 'react-router-dom';
 
+import type { ScenarioCardDetails } from 'applications/operationalStudies/types';
 import infraLogo from 'assets/pictures/components/tracks.svg';
-import type { ScenarioWithDetails } from 'common/api/osrdEditoastApi';
 import { useDateTimeLocale } from 'utils/date';
 
 type ScenarioCardProps = {
   setFilterChips: (filterChips: string) => void;
-  scenario: ScenarioWithDetails;
+  scenario: ScenarioCardDetails;
   isSelected: boolean;
   toggleSelect: (id: number) => void;
 };

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -4457,12 +4457,15 @@ export type SearchResultItemProject = {
 };
 export type SearchResultItemStudy = {
   budget: number | null;
+  business_code: string | null;
   description: string | null;
   id: number;
   last_modification: string;
   name: string;
   project_id: number;
   scenarios_count: number;
+  service_code: string | null;
+  study_type: string | null;
   tags: string[];
 };
 export type SearchResultItemScenario = {
@@ -4473,6 +4476,7 @@ export type SearchResultItemScenario = {
   infra_name: string;
   last_modification: string;
   name: string;
+  paced_trains_count: number;
   study_id: number;
   tags: string[];
   trains_count: number;


### PR DESCRIPTION
Close [#7095](https://github.com/OpenRailAssociation/osrd/issues/7095)

Paced trains count was used by the front in addition to trains count when using the search endpoint, and was present in ScenarioResponse but not SearchResultItemScenario.

Study type, business code and study code were used by the front when using the search endpoint, and were present in Study but not SearchResultItemStudy.

One thing of note is that there are many fields (ids, counts, ...) typed as u64 in search.rs but i64 in other models and views. Is there a reason for this? If not, it's probably not super important, but do you now which we should prefer?