### PR TITLE
editoast: front: remove serde qs and filter properties

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -580,7 +580,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http",
- "opentelemetry 0.30.0",
+ "opentelemetry",
  "pin-project-lite",
  "tower",
  "tracing",
@@ -856,9 +856,9 @@ name = "common"
 version = "0.1.0"
 dependencies = [
  "linkme",
- "opentelemetry 0.30.0",
+ "opentelemetry",
  "opentelemetry-semantic-conventions",
- "opentelemetry_sdk 0.30.0",
+ "opentelemetry_sdk",
  "rangemap",
  "serde",
  "serde_json",
@@ -948,7 +948,7 @@ dependencies = [
  "itertools",
  "lapin",
  "linkme",
- "opentelemetry 0.30.0",
+ "opentelemetry",
  "pretty_assertions",
  "rstest",
  "schemas",
@@ -1433,7 +1433,6 @@ dependencies = [
  "editoast_models",
  "educe",
  "enum-map",
- "enumset",
  "fga",
  "futures 0.3.31",
  "futures-util",
@@ -1448,10 +1447,10 @@ dependencies = [
  "linkme",
  "mime",
  "mvt",
- "opentelemetry 0.30.0",
+ "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
- "opentelemetry_sdk 0.30.0",
+ "opentelemetry_sdk",
  "ordered-float",
  "osrdyne_client",
  "pathfinding",
@@ -1467,7 +1466,6 @@ dependencies = [
  "search",
  "serde",
  "serde_json",
- "serde_qs",
  "serde_with",
  "serde_yaml",
  "serial_test",
@@ -1612,27 +1610,6 @@ version = "4.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
-name = "enumset"
-version = "1.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b07a8dfbbbfc0064c0a6bdf9edcf966de6b1c33ce344bdeca3b41615452634"
-dependencies = [
- "enumset_derive",
-]
-
-[[package]]
-name = "enumset_derive"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43e744e4ea338060faee68ed933e46e722fb7f3617e722a5772d7e856d8b3ce"
-dependencies = [
- "darling 0.21.3",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -3230,14 +3207,14 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2366db2dca4d2ad033cad11e6ee42844fd727007af5ad04a1730f4cb8163bf"
+checksum = "dbee664a43e07615731afc539ca60c6d9f1a9425e25ca09c57bc36c87c55852b"
 dependencies = [
  "http",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "opentelemetry-proto",
- "opentelemetry_sdk 0.31.0",
+ "opentelemetry_sdk",
  "prost",
  "thiserror 2.0.17",
  "tokio",
@@ -3246,15 +3223,14 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.31.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+checksum = "2e046fd7660710fe5a05e8748e70d9058dc15c94ba914e7c4faa7c728f0e8ddc"
 dependencies = [
- "opentelemetry 0.31.0",
- "opentelemetry_sdk 0.31.0",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "prost",
  "tonic",
- "tonic-prost",
 ]
 
 [[package]]
@@ -3272,7 +3248,7 @@ dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "opentelemetry 0.30.0",
+ "opentelemetry",
  "percent-encoding",
  "rand 0.9.2",
  "thiserror 2.0.17",
@@ -3759,9 +3735,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.14.1"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -3769,9 +3745,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.14.1"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
  "itertools",
@@ -4449,18 +4425,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_qs"
-version = "0.13.0"
-source = "git+https://github.com/Atrox/serde_qs?rev=2cfa3ee0#2cfa3ee0af44ad8e78ed6bd6d0e7ac913f51f382"
-dependencies = [
- "axum",
- "futures 0.3.31",
- "percent-encoding",
- "serde",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "serde_spanned"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5080,9 +5044,9 @@ checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
 
 [[package]]
 name = "tonic"
-version = "0.14.2"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7613188ce9f7df5bfe185db26c5814347d110db17920415cf2fbcad85e7203"
+checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
 dependencies = [
  "async-trait",
  "base64",
@@ -5095,24 +5059,13 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "sync_wrapper",
+ "prost",
  "tokio",
  "tokio-stream",
  "tower",
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "tonic-prost"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66bd50ad6ce1252d87ef024b3d64fe4c3cf54a86fb9ef4c631fdd0ded7aeaa67"
-dependencies = [
- "bytes",
- "prost",
- "tonic",
 ]
 
 [[package]]
@@ -5226,8 +5179,8 @@ checksum = "ddcf5959f39507d0d04d6413119c04f33b623f4f951ebcbdddddfad2d0623a9c"
 dependencies = [
  "js-sys",
  "once_cell",
- "opentelemetry 0.30.0",
- "opentelemetry_sdk 0.30.0",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "smallvec",
  "tracing",
  "tracing-core",
@@ -5243,7 +5196,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad59746664e45161625561841c0c9385565913c2d349fdd04cae89502fb5f30a"
 dependencies = [
  "http",
- "opentelemetry 0.30.0",
+ "opentelemetry",
  "tracing",
  "tracing-opentelemetry",
 ]

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -170,7 +170,6 @@ editoast_derive.workspace = true
 editoast_models.workspace = true
 educe.workspace = true
 enum-map.workspace = true
-enumset = "1.1.7"
 fga.workspace = true
 futures.workspace = true
 futures-util.workspace = true
@@ -214,11 +213,6 @@ schemas.workspace = true
 search = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
-# official serde_qs seems unmaintained. Bump to `axum:0.8` is an opened PR waiting to be merged.
-# https://github.com/samscott89/serde_qs/pull/118
-serde_qs = { version = "0.13.0", git = "https://github.com/Atrox/serde_qs", rev = "2cfa3ee0", features = [
-  "axum",
-] }
 serde_with.workspace = true
 serde_yaml = "0.9.34"
 sha1 = "0.10"

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -1123,14 +1123,6 @@ paths:
         schema:
           type: integer
           format: int64
-      - name: props
-        in: query
-        description: Path properties
-        required: true
-        schema:
-          type: array
-          items:
-            $ref: '#/components/schemas/Property'
       requestBody:
         content:
           application/json:
@@ -11778,16 +11770,6 @@ components:
             type: integer
             format: int64
             minimum: 0
-    Property:
-      type: string
-      description: Enum representing the various associated properties that can be returned
-      enum:
-      - slopes
-      - curves
-      - electrifications
-      - geometry
-      - operational_points
-      - zones
     RailJson:
       type: object
       description: An infrastructure description in the RailJson format

--- a/editoast/src/views/path/properties.rs
+++ b/editoast/src/views/path/properties.rs
@@ -19,13 +19,10 @@ use core_client::path_properties::PropertyElectrificationValues;
 use core_client::path_properties::PropertyValuesF64;
 use core_client::path_properties::PropertyZoneValues;
 use core_client::pathfinding::TrackRange;
-use enumset::EnumSet;
-use enumset::EnumSetType;
 use itertools::Either;
 use itertools::Itertools;
 use serde::Deserialize;
 use serde::Serialize;
-use serde_qs::axum::QsQuery;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::Hash;
 use std::hash::Hasher;
@@ -80,54 +77,6 @@ impl From<core_client::path_properties::PathPropertiesResponse> for PathProperti
     }
 }
 
-impl PathProperties {
-    /// Filter properties not requested
-    pub fn filter_properties(mut self, properties: Properties) -> Self {
-        let to_clear = properties.complement();
-        for property in to_clear.iter() {
-            match property {
-                Property::Slopes => self.slopes = None,
-                Property::Curves => self.curves = None,
-                Property::Electrifications => self.electrifications = None,
-                Property::Geometry => self.geometry = None,
-                Property::OperationalPoints => self.operational_points = None,
-                Property::Zones => self.zones = None,
-            }
-        }
-        self
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub(in crate::views) struct Props {
-    props: Vec<Property>,
-}
-
-impl From<Props> for Properties {
-    fn from(value: Props) -> Self {
-        value
-            .props
-            .into_iter()
-            .map_into::<Self>()
-            .fold(Self::default(), |acc, e| acc | e)
-    }
-}
-
-/// Enum representing the various associated properties that can be returned
-#[editoast_derive::openapi_schema]
-#[derive(Debug, Serialize, Deserialize, ToSchema, EnumSetType)]
-#[serde(rename_all = "snake_case")]
-pub(in crate::views) enum Property {
-    Slopes,
-    Curves,
-    Electrifications,
-    Geometry,
-    OperationalPoints,
-    Zones,
-}
-
-type Properties = EnumSet<Property>;
-
 /// Compute path properties
 #[editoast_derive::route]
 #[utoipa::path(
@@ -136,7 +85,6 @@ type Properties = EnumSet<Property>;
     request_body = PathPropertiesInput,
     params(
         ("infra_id" = i64, Path, description = "The infra id"),
-        ("props" = Vec<Property>, Query, description = "Path properties"),
     ),
     responses(
         (status = 200, description = "Path properties", body = PathProperties),
@@ -152,7 +100,6 @@ pub(in crate::views) async fn post(
     }): State<AppState>,
     Extension(auth): AuthenticationExt,
     Path(infra_id): Path<i64>,
-    QsQuery(props): QsQuery<Props>,
     Json(path_properties_input): Json<PathPropertiesInput>,
 ) -> Result<Json<PathProperties>> {
     // Extract information from parameters
@@ -167,7 +114,6 @@ pub(in crate::views) async fn post(
     })
     .await?;
 
-    let query_props: Properties = props.into();
     let mut valkey_conn = valkey_client.get_connection().await?;
 
     let request = PathPropertiesRequest {
@@ -185,9 +131,7 @@ pub(in crate::views) async fn post(
     .next()
     .unwrap();
 
-    Ok(Json(
-        PathProperties::from(path_properties).filter_properties(query_props),
-    ))
+    Ok(Json(PathProperties::from(path_properties)))
 }
 
 /// Retrieves path properties from cache.
@@ -368,10 +312,7 @@ mod tests {
     async fn returns_only_requested_path_properties() {
         let app = init_test_app();
         let infra = create_small_infra(&mut app.db_pool().get_ok()).await;
-        let url = format!(
-            "/infra/{}/path_properties?props[]=electrifications&props[]=geometry&props[]=operational_points",
-            infra.id
-        );
+        let url = format!("/infra/{}/path_properties", infra.id);
 
         // Should succeed
         let request = app.post(&url).json(&json!(
@@ -379,8 +320,8 @@ mod tests {
         );
         let response: PathProperties = app.fetch(request).assert_status(StatusCode::OK).json_into();
         let path_properties_response = path_properties_response();
-        assert!(response.slopes.is_none());
-        assert!(response.curves.is_none());
+        assert_eq!(response.slopes, Some(path_properties_response.slopes));
+        assert_eq!(response.curves, Some(path_properties_response.curves));
         assert_eq!(
             response.electrifications,
             Some(path_properties_response.electrifications)

--- a/front/src/applications/operationalStudies/hooks/usePathProjection.ts
+++ b/front/src/applications/operationalStudies/hooks/usePathProjection.ts
@@ -53,7 +53,6 @@ const usePathProjection = (
       pathfinding?.status === 'success'
         ? {
             infraId,
-            props: ['geometry', 'operational_points'],
             pathPropertiesInput: { track_section_ranges: pathfinding.path.track_section_ranges },
           }
         : skipToken

--- a/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
+++ b/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
@@ -114,7 +114,6 @@ const useSimulationResults = (): SimulationResults | undefined => {
     osrdEditoastApi.endpoints.postInfraByInfraIdPathProperties.useQuery(
       {
         infraId,
-        props: ['electrifications', 'geometry', 'operational_points', 'curves', 'slopes'],
         pathPropertiesInput: {
           track_section_ranges:
             pathfinding?.status === 'success' ? pathfinding.path.track_section_ranges : [],

--- a/front/src/applications/stdcm/utils/fetchPathProperties.ts
+++ b/front/src/applications/stdcm/utils/fetchPathProperties.ts
@@ -23,7 +23,6 @@ const fetchPathProperties = async (
 ): Promise<StdcmPathProperties> => {
   const pathPropertiesParams: PostInfraByInfraIdPathPropertiesApiArg = {
     infraId,
-    props: ['geometry', 'operational_points', 'zones', 'slopes', 'curves', 'electrifications'],
     pathPropertiesInput: {
       track_section_ranges: pathfinding_result.path.track_section_ranges,
     },

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -332,9 +332,6 @@ const injectedRtkApi = api
           url: `/infra/${queryArg.infraId}/path_properties`,
           method: 'POST',
           body: queryArg.pathPropertiesInput,
-          params: {
-            props: queryArg.props,
-          },
         }),
         providesTags: ['pathfinding'],
       }),
@@ -1724,8 +1721,6 @@ export type PostInfraByInfraIdPathPropertiesApiResponse =
 export type PostInfraByInfraIdPathPropertiesApiArg = {
   /** The infra id */
   infraId: number;
-  /** Path properties */
-  props: Property[];
   pathPropertiesInput: PathPropertiesInput;
 };
 export type PostInfraByInfraIdPathfindingApiResponse =
@@ -3380,13 +3375,6 @@ export type PathProperties = {
     values: string[];
   };
 };
-export type Property =
-  | 'slopes'
-  | 'curves'
-  | 'electrifications'
-  | 'geometry'
-  | 'operational_points'
-  | 'zones';
 export type CoreTrackRange = {
   /** The beginning of the range in mm. */
   begin: number;

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -12,7 +12,6 @@ import {
   type GetLightRollingStockApiResponse,
   type GetSpritesSignalingSystemsApiResponse,
   generatedEditoastApi,
-  type Property,
   type TrainScheduleResponse,
   type PacedTrainResponse,
   type PathfindingResult,
@@ -20,9 +19,6 @@ import {
   type RelatedOperationalPoint,
   type OperationalPointReference,
 } from './generatedEditoastApi';
-
-const formatPathPropertiesProps = (props: Property[]) =>
-  props.map((prop) => `props[]=${prop}`).join('&');
 
 const osrdEditoastApi = generatedEditoastApi
   .injectEndpoints({
@@ -234,18 +230,6 @@ const osrdEditoastApi = generatedEditoastApi
       getSpritesSignalingSystems: {
         transformResponse: (response: GetSpritesSignalingSystemsApiResponse) => response.sort(),
       },
-      // This endpoint will return only the props we ask for and the url needs to be build in a specific way
-      // See https://osrd.fr/en/docs/reference/design-docs/timetable/#path
-      postInfraByInfraIdPathProperties: {
-        query: (queryArg) => ({
-          // We currently can't build the url path the way we want with rtk query with the regular endpoint
-          // so we need to do it manually with this function and enhanced endpoint
-          url: `/infra/${queryArg.infraId}/path_properties?${formatPathPropertiesProps(queryArg.props)}`,
-          method: 'POST',
-          body: queryArg.pathPropertiesInput,
-        }),
-      },
-
       // As we always use all get trainSchedule/pacedTrain endpoints after updating the timetable,
       // we don't want to invalidate the train_schedule/paced_train tags here to prevent multiple calls
       deleteTrainSchedule: {

--- a/front/src/modules/pathfinding/hooks/usePathProperties.ts
+++ b/front/src/modules/pathfinding/hooks/usePathProperties.ts
@@ -4,14 +4,9 @@ import {
   osrdEditoastApi,
   type PathfindingResultSuccess,
   type PathProperties,
-  type Property,
 } from 'common/api/osrdEditoastApi';
 
-const usePathProperties = (
-  infraId?: number,
-  pathfindingResult?: PathfindingResultSuccess,
-  properties: Property[] = []
-) => {
+const usePathProperties = (infraId?: number, pathfindingResult?: PathfindingResultSuccess) => {
   const [pathProperties, setPathProperties] = useState<PathProperties>();
 
   const [postPathProperties] =
@@ -19,10 +14,9 @@ const usePathProperties = (
 
   useEffect(() => {
     const getPathProperties = async () => {
-      if (infraId && pathfindingResult && properties.length) {
+      if (infraId && pathfindingResult) {
         const pathPropertiesParams = {
           infraId,
-          props: properties,
           pathPropertiesInput: {
             track_section_ranges: pathfindingResult.path.track_section_ranges,
           },

--- a/front/src/modules/pathfinding/hooks/usePathfinding.ts
+++ b/front/src/modules/pathfinding/hooks/usePathfinding.ts
@@ -152,7 +152,6 @@ const usePathfinding = ({
   ) => {
     const pathPropertiesParams: PostInfraByInfraIdPathPropertiesApiArg = {
       infraId,
-      props: ['electrifications', 'geometry', 'operational_points'],
       pathPropertiesInput: {
         track_section_ranges: pathResult.path.track_section_ranges,
       },

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useProjectedConflicts.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useProjectedConflicts.ts
@@ -23,7 +23,6 @@ const useProjectedConflicts = (
     }: PathfindingResultSuccess) => {
       const { zones } = await postPathProperties({
         infraId,
-        props: ['zones'],
         pathPropertiesInput: {
           track_section_ranges,
         },


### PR DESCRIPTION
serde_qs is currently unmaintained so we decided to remove it. As a consequence, we decided to remove the properties filter