### PR TITLE
ui, ci: fix ui tests and run them in the ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -753,7 +753,7 @@ jobs:
         run: |
           docker run --name=front-test --net=host \
             ${{ fromJSON(needs.build.outputs.stable_tags).front-tests }} \
-            sh -c "npx vitest run"
+            sh -c "npm run test"
 
           exit $(docker wait front-test)
 

--- a/front/ui/ui-core/src/components/inputs/datePicker/__tests__/useDatePicker.spec.ts
+++ b/front/ui/ui-core/src/components/inputs/datePicker/__tests__/useDatePicker.spec.ts
@@ -120,7 +120,7 @@ describe('useDatePicker', () => {
             status: 'error',
             message: 'Invalid input',
           });
-          expect(onDayChange).not.toBeCalled();
+          expect(onDayChange).toHaveBeenCalledWith(undefined);
         }
       );
 
@@ -140,7 +140,7 @@ describe('useDatePicker', () => {
 
         expect(result.current.inputValue).toBe('3/04/24');
         expect(result.current.statusWithMessage).toBe(undefined);
-        expect(onDayChange).not.toBeCalled();
+        expect(onDayChange).toHaveBeenCalledWith(undefined);
       });
 
       it('should show an error if the date is not within the selectable slot', () => {
@@ -163,7 +163,7 @@ describe('useDatePicker', () => {
           status: 'error',
           message: 'Invalid date',
         });
-        expect(onDayChange).not.toBeCalled();
+        expect(onDayChange).toHaveBeenCalledWith(undefined);
       });
 
       it('should update the parent value is the date is valid', () => {


### PR DESCRIPTION
Close #13540

With just the second commit, the tests now correctly fail in the same way as they do locally:
<img width="1356" height="939" alt="image" src="https://github.com/user-attachments/assets/74e1d425-5ae1-4b3f-aa56-94db3fdbc516" />
 
 Tests fixed assuming  #13011 is correct.