### PR TITLE
front: fix rolling stock import

### DIFF
--- a/front/src/applications/rollingStockEditor/RollingStockEditorView.tsx
+++ b/front/src/applications/rollingStockEditor/RollingStockEditorView.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 
+import { Upload } from '@osrd-project/ui-icons';
 import { useTranslation } from 'react-i18next';
 
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
@@ -7,9 +8,13 @@ import { useModal } from 'common/BootstrapSNCF/ModalSNCF';
 import { ModalProvider } from 'common/BootstrapSNCF/ModalSNCF/ModalProvider';
 import { Loader } from 'common/Loaders/Loader';
 import NavBar from 'common/NavBar';
+import UploadFileModal from 'common/uploadFileModal';
 import { RollingStockCard } from 'modules/rollingStock/components/RollingStockCard';
 import { SearchRollingStock } from 'modules/rollingStock/components/RollingStockSelector';
 import useFilterRollingStock from 'modules/rollingStock/hooks/useFilterRollingStock';
+import { setFailure, setSuccess } from 'reducers/main';
+import { useAppDispatch } from 'store';
+import { castErrorToFailure } from 'utils/error';
 
 import {
   RollingStockEditorForm,
@@ -23,9 +28,11 @@ const RollingStockEditor = () => {
   const ref2scroll = useRef<HTMLInputElement>(null);
   const [isEditing, setIsEditing] = useState(false);
   const [isAdding, setIsAdding] = useState(false);
-  const { openModal } = useModal();
+  const { openModal, closeModal } = useModal();
+  const dispatch = useAppDispatch();
 
   const [openedRollingStockCardId, setOpenedRollingStockCardId] = useState<number>();
+  const [postRollingstock] = osrdEditoastApi.endpoints.postRollingStock.useMutation();
 
   const { data: selectedRollingStock } =
     osrdEditoastApi.endpoints.getRollingStockByRollingStockId.useQuery(
@@ -130,8 +137,46 @@ const RollingStockEditor = () => {
     }
   }, [ref2scroll.current]);
 
+  const importFile = async (file: File) => {
+    closeModal();
+    const failure = (error: unknown) => {
+      dispatch(
+        setFailure(
+          castErrorToFailure(error, {
+            name: t('rollingStock.messages.failure'),
+          })
+        )
+      );
+    };
+    try {
+      const fileContent = await file.text();
+      const data = JSON.parse(fileContent);
+      postRollingstock({
+        locked: false,
+        rollingStockForm: data,
+      })
+        .unwrap()
+        .then((res) => {
+          if (setOpenedRollingStockCardId) setOpenedRollingStockCardId(res.id);
+          dispatch(
+            setSuccess({
+              title: t('rollingStock.messages.success'),
+              text: t('rollingStock.messages.rollingStockAdded'),
+            })
+          );
+        })
+        .catch((error) => {
+          console.error('Error posting rolling stock:', error);
+          failure(error);
+        });
+    } catch (error) {
+      console.error('Error reading file:', error);
+      failure(error);
+    }
+  };
+
   return (
-    <ModalProvider>
+    <>
       <NavBar appName={<>{t('rollingStockEditor')}</>} />
       <div className="d-flex rollingstock-editor">
         <div className="d-flex ml-4 flex-column rollingstock-editor-left-container">
@@ -156,10 +201,10 @@ const RollingStockEditor = () => {
               <span>{t('rollingStock.listDisabled')}</span>
             </div>
           )}
-          <div className="d-flex justify-content-center w-100">
+          <div className="d-flex items-center gap-x-8 gap-y-4 mb-4 w-100 rollingstock-editor-actions">
             <button
               type="button"
-              className="btn btn-primary mb-4"
+              className="btn btn-primary"
               data-testid="new-rollingstock-button"
               onClick={() => {
                 setIsAdding(true);
@@ -167,6 +212,18 @@ const RollingStockEditor = () => {
               }}
             >
               {t('rollingStock.addNewRollingStock')}
+            </button>
+            <button
+              type="button"
+              className="d-flex justify-content-start mb-2 py-1 px-2"
+              aria-label={t('rollingStock.importRollingStock')}
+              title={t('rollingStock.importRollingStock')}
+              onClick={() => {
+                openModal(<UploadFileModal handleSubmit={importFile} />);
+              }}
+            >
+              <Upload className="mr-2" />
+              {t('rollingStock.importRollingStock')}
             </button>
           </div>
           {isAdding && (
@@ -193,8 +250,14 @@ const RollingStockEditor = () => {
           </p>
         )}
       </div>
-    </ModalProvider>
+    </>
   );
 };
 
-export default RollingStockEditor;
+const RollingStockEditorWrapper = () => (
+  <ModalProvider>
+    <RollingStockEditor />
+  </ModalProvider>
+);
+
+export default RollingStockEditorWrapper;

--- a/front/src/applications/rollingStockEditor/components/RollingStockEditorForm.tsx
+++ b/front/src/applications/rollingStockEditor/components/RollingStockEditorForm.tsx
@@ -1,9 +1,7 @@
 import { useEffect, useState } from 'react';
 
-import { Upload } from '@osrd-project/ui-icons';
 import { useTranslation } from 'react-i18next';
 
-import { handleFileReadingError } from 'applications/operationalStudies/views/Scenario/components/ManageTimetableItem/helpers/handleParseFiles';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import type {
   RollingStock,
@@ -13,7 +11,6 @@ import type {
 import { useModal } from 'common/BootstrapSNCF/ModalSNCF';
 import Tabs from 'common/Tabs';
 import type { TabProps } from 'common/Tabs';
-import UploadFileModal from 'common/uploadFileModal';
 import RollingStock2Img from 'modules/rollingStock/components/RollingStock2Img';
 import { addFailureNotification, setFailure, setSuccess } from 'reducers/main';
 import { useAppDispatch } from 'store';
@@ -51,7 +48,7 @@ const RollingStockEditorForm = ({
   const dispatch = useAppDispatch();
   const { t } = useTranslation();
   const { t: rollingStockT } = useTranslation('translation', { keyPrefix: 'rollingStock' });
-  const { openModal, closeModal } = useModal();
+  const { openModal } = useModal();
   const [postRollingstock] = osrdEditoastApi.endpoints.postRollingStock.useMutation();
   const [putRollingStock] = osrdEditoastApi.endpoints.putRollingStockByRollingStockId.useMutation();
 
@@ -282,37 +279,12 @@ const RollingStockEditorForm = ({
     ),
   };
 
-  const importFile = async (file: File) => {
-    closeModal();
-    try {
-      const fileContent = await file.text();
-      const data = JSON.parse(fileContent);
-      setRollingStockValues(getRollingStockEditorDefaultValues(data));
-      setEffortCurves(data.effort_curves.modes);
-      setSelectedTractionMode(data.effort_curves.default_mode);
-    } catch (error) {
-      handleFileReadingError(error as Error);
-    }
-  };
-
   return (
     <form
       className="d-flex flex-column form-control rollingstock-editor-form p-0"
       onSubmit={(e) => submit(e, rollingStockValues)}
     >
-      <div>
-        <button
-          type="button"
-          className="d-flex justify-content-start mb-2 py-1 px-2"
-          aria-label={t('rollingStock.importRollingStock')}
-          title={t('rollingStock.importRollingStock')}
-          onClick={() => openModal(<UploadFileModal handleSubmit={importFile} />)}
-        >
-          <Upload className="mr-2" />
-          {t('rollingStock.importRollingStock')}
-        </button>
-        <Tabs pills fullWidth tabs={[tabRollingStockDetails, tabRollingStockCurves]} />
-      </div>
+      <Tabs pills fullWidth tabs={[tabRollingStockDetails, tabRollingStockCurves]} />
       <div className="d-flex justify-content-end mt-2">
         <div className="d-flex flex-column justify-content-end">
           {errorMessage && <p className="text-danger mb-1 p-3">{errorMessage}</p>}

--- a/front/src/applications/rollingStockEditor/components/RollingStockInformationPanel.tsx
+++ b/front/src/applications/rollingStockEditor/components/RollingStockInformationPanel.tsx
@@ -26,7 +26,8 @@ export default function RollingStockInformationPanel({
   const { t } = useTranslation();
 
   const exportRollingStock = () => {
-    const jsonString = JSON.stringify(rollingStock);
+    const { id: _id, locked: _locked, version: _version, ...exportable } = rollingStock;
+    const jsonString = JSON.stringify(exportable);
     const blob = new Blob([jsonString], { type: 'application/json' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');

--- a/front/src/applications/rollingStockEditor/helpers/defaultValues.ts
+++ b/front/src/applications/rollingStockEditor/helpers/defaultValues.ts
@@ -95,6 +95,7 @@ export const getRollingStockEditorDefaultValues = (
         basePowerClass: rollingStockData.base_power_class || null,
         powerRestrictions: rollingStockData.power_restrictions,
         supportedSignalingSystems: rollingStockData.supported_signaling_systems,
+        etcsBrakeParams: rollingStockData.etcs_brake_params || undefined,
         primaryCategory: rollingStockData.primary_category,
         categories: new Set([
           ...rollingStockData.other_categories,

--- a/front/src/applications/rollingStockEditor/styles.scss
+++ b/front/src/applications/rollingStockEditor/styles.scss
@@ -237,6 +237,10 @@
     }
   }
 
+  &-actions {
+    justify-content: space-around;
+  }
+
   &-disablelist {
     @media screen and (min-width: 767px) {
       position: fixed;
@@ -251,6 +255,8 @@
         opacity: 0.3;
         transition: opacity 0.2s;
         background-color: white;
+        padding-top: 45px;
+        padding-left: 1.5rem;
       }
     }
 

--- a/front/src/applications/rollingStockEditor/types.ts
+++ b/front/src/applications/rollingStockEditor/types.ts
@@ -4,6 +4,7 @@ import type {
   Comfort,
   RollingStock,
   TrainMainCategory,
+  EtcsBrakeParams,
 } from 'common/api/osrdEditoastApi';
 import type { MultiUnitsParameter, MultiUnit } from 'modules/rollingStock/types';
 
@@ -68,6 +69,7 @@ export type RollingStockParametersValues = {
   raisePantographTime: number | null;
   basePowerClass: string | null;
   powerRestrictions: RollingStock['power_restrictions'];
+  etcsBrakeParams?: EtcsBrakeParams;
   supportedSignalingSystems: string[];
   primaryCategory?: TrainMainCategory;
   categories: Set<TrainMainCategory>;


### PR DESCRIPTION
fix [#13088](https://github.com/OpenRailAssociation/osrd/issues/13088) and #13504

Move the “Import Rolling Stock” button to the front page.
Directly submit the imported file to the server, and if successful, select the imported rolling stock.
In case of failure, just display the error.

<img width="584" height="299" alt="Screenshot 2025-10-07 at 10-06-35 OSRD" src="https://github.com/user-attachments/assets/4c969e11-97b0-462b-bffc-dc89cf8bb6c4" />

