### PR TITLE
editoast: new endpoint to list scenario notes for nge

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -2715,6 +2715,53 @@ paths:
         '204':
           description: The macro node was deleted successfully
   /projects/{project_id}/studies/{study_id}/scenarios/{scenario_id}/macro_notes:
+    get:
+      tags:
+      - scenarios
+      parameters:
+      - name: project_id
+        in: path
+        description: The id of a project
+        required: true
+        schema:
+          type: integer
+          format: int64
+      - name: study_id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      - name: scenario_id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int64
+          default: 1
+          minimum: 1
+      - name: page_size
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int64
+          default: 100
+          maximum: 100
+          minimum: 1
+      responses:
+        '200':
+          description: List of macro notes for the requested scenario
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MacroNoteListResponse'
     post:
       tags:
       - scenarios
@@ -10164,6 +10211,17 @@ components:
         y:
           type: integer
           format: int64
+    MacroNoteListResponse:
+      allOf:
+      - $ref: '#/components/schemas/PaginationStats'
+      - type: object
+        required:
+        - results
+        properties:
+          results:
+            type: array
+            items:
+              $ref: '#/components/schemas/MacroNoteResponse'
     MacroNoteResponse:
       type: object
       required:

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -330,7 +330,8 @@ fn service_router() -> router::DocumentedRouter {
                                                                     })
                                                             })
                                                             .nests("/macro_notes", |path| {
-                                                                path.route("/", post!(scenario::macro_notes::create))
+                                                                path.route("/", get!(scenario::macro_notes::list))
+                                                                    .route("/", post!(scenario::macro_notes::create))
                                                                     .nests("/{note_id}", |path| {
                                                                     path.route("/", get!(scenario::macro_notes::get))
                                                                 })

--- a/editoast/src/views/scenario/macro_notes.rs
+++ b/editoast/src/views/scenario/macro_notes.rs
@@ -4,6 +4,7 @@ use authz::Role;
 use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
+use axum::extract::Query;
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
@@ -24,6 +25,9 @@ use crate::models::Scenario;
 use crate::models::macro_note::MacroNote;
 use crate::views::AuthenticationExt;
 use crate::views::AuthorizationError;
+use crate::views::pagination::PaginatedList;
+use crate::views::pagination::PaginationQueryParams;
+use crate::views::pagination::PaginationStats;
 use crate::views::project::ProjectError;
 use crate::views::project::ProjectIdParam;
 use crate::views::scenario::ScenarioError;
@@ -115,6 +119,57 @@ impl From<MacroNote> for MacroNoteResponse {
             labels: note.labels,
         }
     }
+}
+
+#[editoast_derive::openapi_schema]
+#[derive(Debug, Serialize, ToSchema)]
+#[cfg_attr(test, derive(Deserialize))]
+pub(in crate::views) struct MacroNoteListResponse {
+    #[serde(flatten)]
+    stats: PaginationStats,
+    results: Vec<MacroNoteResponse>,
+}
+
+#[editoast_derive::route]
+#[utoipa::path(
+    get, path = "",
+    tag = "scenarios",
+    params(ProjectIdParam, StudyIdParam, ScenarioIdParam, PaginationQueryParams<100>),
+    responses(
+        (status = 200, body = MacroNoteListResponse, description = "List of macro notes for the requested scenario"),
+    )
+)]
+pub(in crate::views) async fn list(
+    State(db_pool): State<Arc<DbConnectionPoolV2>>,
+    Extension(auth): AuthenticationExt,
+    Path((project_id, study_id, scenario_id)): Path<(i64, i64, i64)>,
+    Query(pagination_params): Query<PaginationQueryParams<100>>,
+) -> Result<Json<MacroNoteListResponse>> {
+    let authorized = auth
+        .check_roles([Role::OperationalStudies].into())
+        .await
+        .map_err(AuthorizationError::AuthError)?;
+    if !authorized {
+        return Err(AuthorizationError::Forbidden.into());
+    }
+
+    let mut conn = db_pool.get().await?;
+
+    check_project_study_scenario(conn.clone(), project_id, study_id, scenario_id).await?;
+
+    let settings = pagination_params
+        .into_selection_settings()
+        .filter(move || MacroNote::SCENARIO_ID.eq(scenario_id))
+        .order_by(move || MacroNote::ID.asc());
+    let (result, stats) = MacroNote::list_paginated(&mut conn, settings).await?;
+
+    Ok(Json(MacroNoteListResponse {
+        stats,
+        results: result
+            .into_iter()
+            .map(MacroNoteResponse::from)
+            .collect_vec(),
+    }))
 }
 
 #[editoast_derive::route]
@@ -241,6 +296,64 @@ pub mod test {
                 && self.text == other.text
                 && self.labels == other.labels
         }
+    }
+
+    #[rstest]
+    async fn list_notes() {
+        let app = TestAppBuilder::default_app();
+        let db_pool = app.db_pool();
+
+        let fixtures1 =
+            create_scenario_fixtures_set(&mut db_pool.get_ok(), "test_scenario_name").await;
+        let fixtures2 =
+            create_scenario_fixtures_set(&mut db_pool.get_ok(), "test_scenario_name2").await;
+
+        for i in 0..5 {
+            MacroNote::changeset()
+                .scenario_id(fixtures1.scenario.id)
+                .x(rng().random_range(0..100))
+                .y(rng().random_range(0..100))
+                .title(format!("Note title 1{}", i))
+                .text(format!("Note text 1{}", i))
+                .labels(Tags::new(vec!["A".to_string(), format!("Label {}", i)]))
+                .create(&mut db_pool.get_ok())
+                .await
+                .expect("Failed to create macro note");
+        }
+
+        for i in 0..5 {
+            MacroNote::changeset()
+                .scenario_id(fixtures2.scenario.id)
+                .x(rng().random_range(0..100))
+                .y(rng().random_range(0..100))
+                .title(format!("Note title 2{}", i))
+                .text(format!("Note text 2{}", i))
+                .labels(Tags::new(vec!["A".to_string(), format!("Label 2{}", i)]))
+                .create(&mut db_pool.get_ok())
+                .await
+                .expect("Failed to create macro note");
+        }
+
+        let request = app.get(&format!(
+            "/projects/{}/studies/{}/scenarios/{}/macro_notes?page=1&page_size=3",
+            fixtures1.project.id, fixtures1.study.id, fixtures1.scenario.id
+        ));
+        let response: MacroNoteListResponse =
+            app.fetch(request).assert_status(StatusCode::OK).json_into();
+
+        let ids: Vec<i64> = response.results.iter().map(|note| note.id).collect();
+        let mut sorted_ids = ids.clone();
+        sorted_ids.sort();
+
+        assert_eq!(ids, sorted_ids);
+        assert_eq!(5, response.stats.count);
+        assert_eq!(3, response.results.len());
+        assert!(
+            response
+                .results
+                .iter()
+                .all(|note| note.title.starts_with("Note title 1"))
+        );
     }
 
     #[rstest]

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -792,6 +792,19 @@ const injectedRtkApi = api
         }),
         invalidatesTags: ['scenarios'],
       }),
+      getProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotes: build.query<
+        GetProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotesApiResponse,
+        GetProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotesApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/projects/${queryArg.projectId}/studies/${queryArg.studyId}/scenarios/${queryArg.scenarioId}/macro_notes`,
+          params: {
+            page: queryArg.page,
+            page_size: queryArg.pageSize,
+          },
+        }),
+        providesTags: ['scenarios'],
+      }),
       postProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotes: build.mutation<
         PostProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotesApiResponse,
         PostProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotesApiArg
@@ -2111,6 +2124,16 @@ export type DeleteProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNo
   studyId: number;
   scenarioId: number;
   nodeId: number;
+};
+export type GetProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotesApiResponse =
+  /** status 200 List of macro notes for the requested scenario */ MacroNoteListResponse;
+export type GetProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotesApiArg = {
+  /** The id of a project */
+  projectId: number;
+  studyId: number;
+  scenarioId: number;
+  page?: number;
+  pageSize?: number;
 };
 export type PostProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotesApiResponse =
   /** status 201 Macro notes created */ MacroNoteBatchResponse;
@@ -4235,6 +4258,9 @@ export type MacroNoteResponse = {
   title: string;
   x: number;
   y: number;
+};
+export type MacroNoteListResponse = PaginationStats & {
+  results: MacroNoteResponse[];
 };
 export type MacroNoteBatchResponse = {
   macro_notes: MacroNoteResponse[];


### PR DESCRIPTION
Adds a paginated API endpoint for listing macro notes associated with a scenario :

* Added a new GET endpoint `/projects/{project_id}/studies/{study_id}/scenarios/{scenario_id}/macro_notes` for listing macro notes with pagination support.
* Implemented the `list` handler in `macro_notes.rs` to fetch, paginate, and return macro notes for a scenario, with appropriate authorization and query parameter handling.
* Updated the router to support the new GET route for macro notes.
* Added a test to verify correct pagination and scenario filtering for the new endpoint.