### PR TITLE
core: stdcm: use standard allowance in heuristic

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMHeuristic.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMHeuristic.kt
@@ -1,6 +1,7 @@
 package fr.sncf.osrd.stdcm
 
 import fr.sncf.osrd.envelope_sim.PhysicsRollingStock
+import fr.sncf.osrd.envelope_sim.allowances.AllowanceValue
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.sim_infra.api.BlockInfra
@@ -26,6 +27,7 @@ data class STDCMAStarHeuristic(
     val nPlannedSteps: Int,
     val mrspBuilder: CachedBlockMRSPBuilder,
     val bestTravelTime: Double,
+    val allowanceValue: AllowanceValue?,
 ) {
     /**
      * Defines a function that can be used as a heuristic for an A* pathfinding. It takes an edge,
@@ -54,9 +56,10 @@ data class STDCMAStarHeuristic(
         // of the last block of the lookahead, then from that point the destination.
         var timeUntilStartOfLastBlock = 0.0
         for (j in 0 until allBlocks.size - 1) {
-            timeUntilStartOfLastBlock += mrspBuilder.getBlockTime(allBlocks[j], null)
+            timeUntilStartOfLastBlock +=
+                mrspBuilder.getBlockTime(allBlocks[j], null, allowanceValue)
         }
-        val timeSinceFirstBlock = mrspBuilder.getBlockTime(edge.block, offset)
+        val timeSinceFirstBlock = mrspBuilder.getBlockTime(edge.block, offset, allowanceValue)
         timeUntilStartOfLastBlock -= timeSinceFirstBlock
 
         val remainingTime = timeUntilStartOfLastBlock + timeAfterStartOfLastBlock
@@ -95,6 +98,7 @@ class STDCMHeuristicBuilder(
     private val temporarySpeedLimitManager: TemporarySpeedLimitManager =
         TemporarySpeedLimitManager(),
     private val mrspBuilder: CachedBlockMRSPBuilder,
+    val allowance: AllowanceValue?,
 ) {
     private val logger: Logger = LoggerFactory.getLogger("STDCMHeuristic")
 
@@ -135,7 +139,7 @@ class STDCMHeuristicBuilder(
             steps.first().locations.minOfOrNull {
                 val remainingTimeSinceBlockStart =
                     remainingTimeEstimations.first()[it.edge] ?: Double.POSITIVE_INFINITY
-                val timeSinceBlockStart = mrspBuilder.getBlockTime(it.edge, it.offset)
+                val timeSinceBlockStart = mrspBuilder.getBlockTime(it.edge, it.offset, allowance)
                 remainingTimeSinceBlockStart - timeSinceBlockStart
             } ?: Double.POSITIVE_INFINITY
         logger.info(
@@ -148,6 +152,7 @@ class STDCMHeuristicBuilder(
             steps.size,
             mrspBuilder,
             bestTravelTime,
+            allowance,
         )
     }
 
@@ -214,7 +219,7 @@ class STDCMHeuristicBuilder(
         return PendingBlock(
             block,
             newIndex,
-            remainingTime + mrspBuilder.getBlockTime(block, offset),
+            remainingTime + mrspBuilder.getBlockTime(block, offset, allowance),
         )
     }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
@@ -82,6 +82,7 @@ class STDCMGraph(
                     rollingStock,
                     temporarySpeedLimitManager,
                     mrspBuilder,
+                    standardAllowance,
                 )
                 .build()
         bestPossibleTime = remainingTimeEstimator.bestTravelTime

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMNode.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMNode.kt
@@ -83,12 +83,19 @@ data class STDCMNode(
         else if (timeData.earliestReachableTime != other.timeData.earliestReachableTime)
             timeData.earliestReachableTime.compareTo(other.timeData.earliestReachableTime)
 
-        // In the end, prioritize the highest number of reached targets.
-        // This doesn't define the priority between different paths,
-        // it just minimizes the chance of evaluating redundant nodes
-        else
+        // From this point, the order doesn't define the "best solution" anymore, just which
+        // scenario is picked first by the A* loop.
+
+        // Prioritize the highest number of reached targets, to avoid paths that have missed a step
+        else if (
+            other.infraExplorer.getStepTracker().nStepsExcludingLookahead !=
+                infraExplorer.getStepTracker().nStepsExcludingLookahead
+        )
             other.infraExplorer.getStepTracker().nStepsExcludingLookahead -
                 infraExplorer.getStepTracker().nStepsExcludingLookahead
+
+        // Prioritize the path furthest from the start. Avoids exploring several paths in parallel.
+        else -timeData.timeSinceDeparture.compareTo(other.timeData.timeSinceDeparture)
     }
 
     override fun toString(): String {

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
@@ -18,6 +18,7 @@ import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
 import fr.sncf.osrd.stdcm.infra_exploration.initInfraExplorerWithEnvelope
 import fr.sncf.osrd.stdcm.preprocessing.interfaces.BlockAvailabilityInterface
 import fr.sncf.osrd.train.RollingStock
+import fr.sncf.osrd.utils.LogAggregator
 import fr.sncf.osrd.utils.units.Offset
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.annotations.WithSpan
@@ -181,6 +182,7 @@ class STDCMPathfinding(
         val queue = PriorityQueue<STDCMNode>()
 
         val progressLogger = ProgressLogger(graph)
+        val fValueLogger = LogAggregator({ logger.error(it) })
 
         for (location in starts) {
             queue.add(location)
@@ -190,14 +192,18 @@ class STDCMPathfinding(
         while (true) {
             if (Duration.between(start, Instant.now()).toSeconds() >= pathfindingTimeout)
                 throw OSRDError(ErrorType.PathfindingTimeoutError)
-            val endNode = queue.poll() ?: return null
+            val endNode = queue.poll()
+            if (endNode == null) {
+                fValueLogger.logAggregatedSummary()
+                return null
+            }
 
             // Checks that the f-value (best anticipated final value on path) only goes up,
             // otherwise the A* heuristic isn't admissible
             val fValue = endNode.timeData.totalRunningTime + endNode.remainingTimeEstimation
             if (fValue + 1.0 < lastFValue) { // Small tolerance
                 // We don't need to crash, logging an error is enough
-                logger.error("f-value decreases: new=$fValue, previous=$lastFValue")
+                fValueLogger.registerError("f-value decreases: new=$fValue, previous=$lastFValue")
             }
             lastFValue = fValue
 

--- a/core/src/main/kotlin/fr/sncf/osrd/utils/CachedBlockMRSPBuilder.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/utils/CachedBlockMRSPBuilder.kt
@@ -2,6 +2,7 @@ package fr.sncf.osrd.utils
 
 import fr.sncf.osrd.envelope.Envelope
 import fr.sncf.osrd.envelope_sim.PhysicsRollingStock
+import fr.sncf.osrd.envelope_sim.allowances.AllowanceValue
 import fr.sncf.osrd.envelope_sim_infra.computeMRSP
 import fr.sncf.osrd.path.implementations.buildTrainPathFromBlock
 import fr.sncf.osrd.sim_infra.api.Block
@@ -61,11 +62,17 @@ data class CachedBlockMRSPBuilder(
     }
 
     /** Returns the time it takes to go through the given block, until `endOffset` if specified. */
-    fun getBlockTime(block: BlockId, endOffset: Offset<Block>?): Double {
+    fun getBlockTime(
+        block: BlockId,
+        endOffset: Offset<Block>?,
+        allowanceValue: AllowanceValue? = null,
+    ): Double {
         if (endOffset?.distance == 0.meters) return 0.0
         val actualLength = endOffset ?: blockInfra.getBlockLength(block)
         val mrsp = getMRSP(block)
-        return mrsp.interpolateArrivalAtClamp(actualLength.distance.meters)
+        val time = mrsp.interpolateArrivalAtClamp(actualLength.distance.meters)
+        val allowanceTime = allowanceValue?.getAllowanceTime(time, actualLength.distance.meters)
+        return time + (allowanceTime ?: 0.0)
     }
 
     companion object {

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
@@ -5,6 +5,7 @@ import fr.sncf.osrd.conflicts.SpacingRequirementAutomaton
 import fr.sncf.osrd.envelope.Envelope.Companion.make
 import fr.sncf.osrd.envelope.EnvelopeTestUtils
 import fr.sncf.osrd.envelope_sim.SimpleRollingStock.STANDARD_TRAIN
+import fr.sncf.osrd.envelope_sim.allowances.AllowanceValue
 import fr.sncf.osrd.pathfinding.PathfindingEdgeLocationId
 import fr.sncf.osrd.stdcm.STDCMAStarHeuristic
 import fr.sncf.osrd.stdcm.STDCMHeuristicBuilder
@@ -80,6 +81,7 @@ class STDCMHeuristicTests {
                     Double.POSITIVE_INFINITY,
                     STANDARD_TRAIN,
                     mrspBuilder = CachedBlockMRSPBuilder(infra, infra, null),
+                    allowance = null,
                 )
                 .build()
 
@@ -107,6 +109,66 @@ class STDCMHeuristicTests {
 
         explorer = explorer.cloneAndExtendLookahead().single().moveForward()
         assertEquals(0.0, getLocationRemainingTime(infra, explorer, null, heuristic))
+    }
+
+    @Test
+    fun allowanceTest() {
+        /*
+        a ------> b ------> c
+         */
+        val infra = DummyInfra()
+        val blocks =
+            listOf(
+                infra.addBlock("a", "b", allowedSpeed = 1.0),
+                infra.addBlock("b", "c", allowedSpeed = 1.0),
+            )
+
+        val steps =
+            listOf(
+                STDCMStep(
+                    listOf(PathfindingEdgeLocationId(blocks[0], Offset(0.meters))),
+                    null,
+                    false,
+                ),
+                STDCMStep(
+                    listOf(PathfindingEdgeLocationId(blocks[1], Offset(100.meters))),
+                    null,
+                    true,
+                ),
+            )
+
+        val heuristicWithAllowance =
+            STDCMHeuristicBuilder(
+                    infra,
+                    infra,
+                    steps,
+                    Double.POSITIVE_INFINITY,
+                    STANDARD_TRAIN,
+                    mrspBuilder = CachedBlockMRSPBuilder(infra, infra, null),
+                    allowance = AllowanceValue.Percentage(100.0),
+                )
+                .build()
+        val heuristicWithoutAllowance =
+            STDCMHeuristicBuilder(
+                    infra,
+                    infra,
+                    steps,
+                    Double.POSITIVE_INFINITY,
+                    STANDARD_TRAIN,
+                    mrspBuilder = CachedBlockMRSPBuilder(infra, infra, null),
+                    allowance = null,
+                )
+                .build()
+
+        val explorer =
+            initInfraExplorer(infra, infra, steps.first().locations.first(), steps).single()
+
+        val resWithAllowance =
+            getLocationRemainingTime(infra, explorer, 50.meters, heuristicWithAllowance)
+        val resWithoutAllowance =
+            getLocationRemainingTime(infra, explorer, 50.meters, heuristicWithoutAllowance)
+
+        assertEquals(resWithoutAllowance * 2, resWithAllowance, 1e-5)
     }
 
     @Test
@@ -158,6 +220,7 @@ class STDCMHeuristicTests {
                     Double.POSITIVE_INFINITY,
                     STANDARD_TRAIN,
                     mrspBuilder = CachedBlockMRSPBuilder(infra, infra, null),
+                    allowance = null,
                 )
                 .build()
 
@@ -166,10 +229,9 @@ class STDCMHeuristicTests {
 
         for (i in 1 until blocks.size) {
             explorer =
-                explorer
-                    .cloneAndExtendLookahead()
-                    .filter { candidate -> candidate.getLookahead().all { blocks.contains(it) } }
-                    .single()
+                explorer.cloneAndExtendLookahead().single { candidate ->
+                    candidate.getLookahead().all { blocks.contains(it) }
+                }
 
             // While the lookahead is on the right path, the remaining distance shouldn't change
             assertEquals(


### PR DESCRIPTION
Fix https://github.com/OpenRailAssociation/osrd/issues/13568

The heuristic was always optimistic by at least the allowance value. This should bring it closer to the actual shortest time. It only makes a difference when there's an allowance, but that should always be the case in prod. 

Also included in a second commit: we now prioritize nodes that are further from the origin when everything else is equal. This avoids exploring several parallel paths at the same time.

My benchmark is weaker than before as I "lost" the payload collection from before the timetable cache refactoring. But on a smaller sample of 8 requests, average computation time went from 14 to 10s. 

Notes:

* We can also consider adding braking curves to the heuristic envelopes. It would get *really close* to the actual fastest possible path, but computing the heuristic would also be slower. 
* I've encountered some memory issues when looking for long requests. Some requests took *a lot* longer when core has the same memory limit as in prod (5gb), I've also had one actual OOM. We could investigate further.
* I've seen an "f-value increasing" error **once** and did not manage to reproduce it... In doubt, a third commit aggregates these errors, to avoid cluttering the logs if it happens in prod. 