### PR TITLE
front: fix manchette ops out of date

### DIFF
--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useGetProjectedTrainOperationalPoints.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useGetProjectedTrainOperationalPoints.ts
@@ -82,7 +82,7 @@ const useGetProjectedTrainOperationalPoints = ({
     };
 
     getOperationalPoints();
-  }, [path, pathfinding, infraId, t, projectionType]);
+  }, [path, pathfinding, infraId, projectedOperationalPoints, timetableId, t, projectionType]);
 
   return { operationalPoints, filteredOperationalPoints, setFilteredOperationalPoints };
 };

--- a/front/tests/utils/manchette.ts
+++ b/front/tests/utils/manchette.ts
@@ -32,7 +32,7 @@ export const expectedWaypointsPanelDataForPacedTrain: Record<string, Partial<Way
   Mid_East_station: { ch: 'BV', offset: '19.55', checked: true },
   [requestedPoint('1')]: { ch: '', offset: '22.47', checked: true },
   Mid_West_station: { ch: 'BV', offset: '34.0', checked: true },
-  North_West_station: { ch: 'BC', offset: '47.55', checked: true },
+  North_West_station: { ch: 'BV', offset: '47.60', checked: true },
   [requestedDestination]: { ch: '', offset: '47.65', checked: true },
 };
 


### PR DESCRIPTION
Close [#13577](https://github.com/OpenRailAssociation/osrd/issues/13577)

Edit: seems like the e2e test for the manchette also expected ops from the first train it tested in the second train it tested.