### PR TITLE
editoast: cache: new `Mock` client using `redis-test`

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -710,6 +710,7 @@ dependencies = [
  "futures 0.3.31",
  "lz4_flex",
  "rand 0.9.2",
+ "redis-test",
  "serde",
  "serde_json",
  "tracing",
@@ -3928,11 +3929,24 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "ryu",
+ "sha1_smol",
  "socket2 0.6.0",
  "tokio",
  "tokio-native-tls",
  "tokio-util",
  "url",
+]
+
+[[package]]
+name = "redis-test"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b193b65f0e4d429e6caf18c7ca552f58df58079db6500cbb89b653ac371d0ef1"
+dependencies = [
+ "rand 0.9.2",
+ "redis",
+ "socket2 0.6.0",
+ "tempfile",
 ]
 
 [[package]]
@@ -4524,6 +4538,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4769,15 +4789,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.23.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand 2.3.0",
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.8",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -580,7 +580,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http",
- "opentelemetry 0.30.0",
+ "opentelemetry",
  "pin-project-lite",
  "tower",
  "tracing",
@@ -856,9 +856,9 @@ name = "common"
 version = "0.1.0"
 dependencies = [
  "linkme",
- "opentelemetry 0.30.0",
+ "opentelemetry",
  "opentelemetry-semantic-conventions",
- "opentelemetry_sdk 0.30.0",
+ "opentelemetry_sdk",
  "rangemap",
  "serde",
  "serde_json",
@@ -948,7 +948,7 @@ dependencies = [
  "itertools",
  "lapin",
  "linkme",
- "opentelemetry 0.30.0",
+ "opentelemetry",
  "pretty_assertions",
  "rstest",
  "schemas",
@@ -1448,10 +1448,10 @@ dependencies = [
  "linkme",
  "mime",
  "mvt",
- "opentelemetry 0.30.0",
+ "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
- "opentelemetry_sdk 0.30.0",
+ "opentelemetry_sdk",
  "ordered-float",
  "osrdyne_client",
  "pathfinding",
@@ -3216,28 +3216,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
-dependencies = [
- "futures-core",
- "futures-sink",
- "js-sys",
- "pin-project-lite",
- "thiserror 2.0.17",
-]
-
-[[package]]
 name = "opentelemetry-otlp"
-version = "0.31.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2366db2dca4d2ad033cad11e6ee42844fd727007af5ad04a1730f4cb8163bf"
+checksum = "dbee664a43e07615731afc539ca60c6d9f1a9425e25ca09c57bc36c87c55852b"
 dependencies = [
  "http",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "opentelemetry-proto",
- "opentelemetry_sdk 0.31.0",
+ "opentelemetry_sdk",
  "prost",
  "thiserror 2.0.17",
  "tokio",
@@ -3246,15 +3233,14 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.31.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+checksum = "2e046fd7660710fe5a05e8748e70d9058dc15c94ba914e7c4faa7c728f0e8ddc"
 dependencies = [
- "opentelemetry 0.31.0",
- "opentelemetry_sdk 0.31.0",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "prost",
  "tonic",
- "tonic-prost",
 ]
 
 [[package]]
@@ -3272,27 +3258,12 @@ dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "opentelemetry 0.30.0",
+ "opentelemetry",
  "percent-encoding",
  "rand 0.9.2",
  "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
-]
-
-[[package]]
-name = "opentelemetry_sdk"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
-dependencies = [
- "futures-channel",
- "futures-executor",
- "futures-util",
- "opentelemetry 0.31.0",
- "percent-encoding",
- "rand 0.9.2",
- "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -3759,9 +3730,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.14.1"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -3769,9 +3740,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.14.1"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
  "itertools",
@@ -5080,9 +5051,9 @@ checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
 
 [[package]]
 name = "tonic"
-version = "0.14.2"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7613188ce9f7df5bfe185db26c5814347d110db17920415cf2fbcad85e7203"
+checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
 dependencies = [
  "async-trait",
  "base64",
@@ -5095,24 +5066,13 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "sync_wrapper",
+ "prost",
  "tokio",
  "tokio-stream",
  "tower",
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "tonic-prost"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66bd50ad6ce1252d87ef024b3d64fe4c3cf54a86fb9ef4c631fdd0ded7aeaa67"
-dependencies = [
- "bytes",
- "prost",
- "tonic",
 ]
 
 [[package]]
@@ -5226,8 +5186,8 @@ checksum = "ddcf5959f39507d0d04d6413119c04f33b623f4f951ebcbdddddfad2d0623a9c"
 dependencies = [
  "js-sys",
  "once_cell",
- "opentelemetry 0.30.0",
- "opentelemetry_sdk 0.30.0",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "smallvec",
  "tracing",
  "tracing-core",
@@ -5243,7 +5203,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad59746664e45161625561841c0c9385565913c2d349fdd04cae89502fb5f30a"
 dependencies = [
  "http",
- "opentelemetry 0.30.0",
+ "opentelemetry",
  "tracing",
  "tracing-opentelemetry",
 ]

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -118,7 +118,7 @@ serde_with = { version = "3.15.0", default-features = false, features = [
 stdext = "0.3.3"
 strum = { version = "0.26.3", features = ["derive"] }
 syn = "2.0"
-tempfile = "3.23.0"
+tempfile = "3.20.0" # redis-test (crate cache) isn't up to date
 thiserror = "2.0.17"
 tokio = { version = "1.47.1", features = ["fs", "macros", "rt-multi-thread"] }
 tokio-postgres = "0.7.14"

--- a/editoast/cache/Cargo.toml
+++ b/editoast/cache/Cargo.toml
@@ -4,6 +4,9 @@ license.workspace = true
 version.workspace = true
 edition.workspace = true
 
+[features]
+mock = ["redis-test"]
+
 [dependencies]
 arcstr.workspace = true
 deadpool.workspace = true
@@ -13,6 +16,7 @@ lz4_flex = { version = "0.11.5", default-features = false, features = [
   "frame",
 ] }
 rand.workspace = true
+redis-test = { version = "0.12.0", optional = true } # latest version's 'redis' dependency isn't compatible with deadpool-redis re-export
 serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true

--- a/editoast/cache/src/client.rs
+++ b/editoast/cache/src/client.rs
@@ -16,6 +16,8 @@ pub enum ClientInner {
     Tokio(Pool),
     /// This doesn't cache anything. It has no backend.
     NoCache,
+    #[cfg(feature = "mock")]
+    Mock(redis_test::MockRedisConnection),
 }
 
 #[derive(Clone)]
@@ -42,6 +44,14 @@ impl Client {
         }
     }
 
+    #[cfg(feature = "mock")]
+    pub fn new_mock(commands: Vec<crate::MockCmd>, app_version: &str) -> Self {
+        Self {
+            app_version: ArcStr::from(app_version),
+            inner: ClientInner::Mock(redis_test::MockRedisConnection::new(commands)),
+        }
+    }
+
     pub async fn get_connection(&self) -> Result<Connection, PoolError> {
         match &self.inner {
             ClientInner::Tokio(pool) => Ok(Connection::new(
@@ -50,6 +60,11 @@ impl Client {
             )),
             ClientInner::NoCache => Ok(Connection::new(
                 ConnectionInner::NoCache,
+                self.app_version.clone(),
+            )),
+            #[cfg(feature = "mock")]
+            ClientInner::Mock(mock_conn) => Ok(Connection::new(
+                ConnectionInner::Mock(mock_conn.clone()),
                 self.app_version.clone(),
             )),
         }

--- a/editoast/cache/src/connection.rs
+++ b/editoast/cache/src/connection.rs
@@ -29,6 +29,8 @@ pub struct Connection {
 pub(crate) enum ConnectionInner {
     Tokio(deadpool_redis::Connection),
     NoCache,
+    #[cfg(feature = "mock")]
+    Mock(redis_test::MockRedisConnection),
 }
 
 fn no_cache_cmd_handler(cmd: &Cmd) -> Result<Value, RedisError> {
@@ -64,6 +66,14 @@ impl ConnectionLike for Connection {
         match &mut self.inner {
             ConnectionInner::Tokio(connection) => connection.req_packed_command(cmd),
             ConnectionInner::NoCache => future::ready(no_cache_cmd_handler(cmd)).boxed(),
+            #[cfg(feature = "mock")]
+            ConnectionInner::Mock(mock_conn) => {
+                let result = deadpool_redis::redis::ConnectionLike::req_packed_command(
+                    mock_conn,
+                    &cmd.get_packed_command(),
+                );
+                future::ready(result).boxed()
+            }
         }
     }
 
@@ -86,6 +96,16 @@ impl ConnectionLike for Connection {
                     .collect::<Result<_, RedisError>>();
                 future::ready(responses).boxed()
             }
+            #[cfg(feature = "mock")]
+            ConnectionInner::Mock(mock_conn) => {
+                let result = deadpool_redis::redis::ConnectionLike::req_packed_commands(
+                    mock_conn,
+                    &cmd.get_packed_pipeline(),
+                    offset,
+                    count,
+                );
+                future::ready(result).boxed()
+            }
         }
     }
 
@@ -93,6 +113,10 @@ impl ConnectionLike for Connection {
         match &self.inner {
             ConnectionInner::Tokio(connection) => connection.get_db(),
             ConnectionInner::NoCache => 0,
+            #[cfg(feature = "mock")]
+            ConnectionInner::Mock(mock_conn) => {
+                deadpool_redis::redis::ConnectionLike::get_db(mock_conn)
+            }
         }
     }
 }

--- a/editoast/cache/src/lib.rs
+++ b/editoast/cache/src/lib.rs
@@ -7,3 +7,6 @@ pub use connection::Connection;
 pub use deadpool_redis::redis::RedisError;
 
 pub type Error = RedisError;
+
+#[cfg(feature = "mock")]
+pub use redis_test::MockCmd; // re-export MockCmd to avoid having to depend on redis-test directly


### PR DESCRIPTION
Needed to test the upcoming `simulation::PathfindingEnv`.

refs #13590

---

Adds a third Client able to mock redis responses using `redis-test`
crate. A few Cargo.toml issues as of today:

- the last version of `redis-test` requires a newer `redis` than
  `deadpool-redis` (which is still a rc)
- the next-to-last version of `redis-test` requires an older version
  of `tempfile`

I figured downgrading the latter would be best. Hopefully we can
update everything when `deadpool-redis` catches up.
