### PR TITLE
front: stop mixing schedule and paced ids in useTrackOccupancy

### DIFF
--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/__tests__/utils.spec.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/__tests__/utils.spec.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+import { formatEditoastIdToTrainScheduleId } from 'utils/trainId';
+
 import { cutSpaceTimeRect, batchFetchTrackOccupancy } from '../utils';
 
 describe('interpolateRange', () => {
@@ -94,13 +96,16 @@ describe('batchFetch', () => {
     const fetchSpy = vi.fn().mockResolvedValueOnce(['a', 'b']).mockResolvedValueOnce(['c', 'd']);
 
     const onComplete = vi.fn();
-    batchFetchTrackOccupancy(['1', '2', '3', '4'], fetchSpy, { batchSize: 2, onComplete });
+    batchFetchTrackOccupancy([1, 2, 3, 4].map(formatEditoastIdToTrainScheduleId), fetchSpy, {
+      batchSize: 2,
+      onComplete,
+    });
 
     await vi.waitFor(() => expect(onComplete).toHaveBeenCalled());
 
     expect(fetchSpy).toHaveBeenCalledTimes(2);
-    expect(fetchSpy).toHaveBeenNthCalledWith(1, ['1', '2']);
-    expect(fetchSpy).toHaveBeenNthCalledWith(2, ['3', '4']);
+    expect(fetchSpy).toHaveBeenNthCalledWith(1, [1, 2].map(formatEditoastIdToTrainScheduleId));
+    expect(fetchSpy).toHaveBeenNthCalledWith(2, [3, 4].map(formatEditoastIdToTrainScheduleId));
     expect(onComplete).toHaveBeenCalledExactlyOnceWith(['a', 'b', 'c', 'd']);
   });
 
@@ -115,7 +120,8 @@ describe('batchFetch', () => {
     );
     const onComplete = vi.fn();
 
-    const abort = batchFetchTrackOccupancy(['1', '2', '3', '4'], fetchSpy, {
+    const ids = [1, 2, 3, 4].map(formatEditoastIdToTrainScheduleId);
+    const abort = batchFetchTrackOccupancy(ids, fetchSpy, {
       batchSize: 2,
       onComplete,
     });
@@ -138,7 +144,7 @@ describe('batchFetch', () => {
     const onProgress = vi.fn();
     const onComplete = vi.fn();
 
-    batchFetchTrackOccupancy(['1', '2', '3', '4'], fetchSpy, {
+    batchFetchTrackOccupancy([1, 2, 3, 4].map(formatEditoastIdToTrainScheduleId), fetchSpy, {
       batchSize: 2,
       onProgress,
       onComplete,
@@ -159,7 +165,10 @@ describe('batchFetch', () => {
     const onError = vi.fn();
     const onComplete = vi.fn();
 
-    batchFetchTrackOccupancy(['1', '2'], fetchSpy, { onError, onComplete });
+    batchFetchTrackOccupancy([1, 2].map(formatEditoastIdToTrainScheduleId), fetchSpy, {
+      onError,
+      onComplete,
+    });
 
     await vi.waitFor(() => expect(onError).toHaveBeenCalled());
 

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/utils.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/utils.ts
@@ -2,7 +2,12 @@ import type { Conflict, OccupancyBlock } from '@osrd-project/ui-charts';
 import { chunk, compact, noop, omit } from 'lodash';
 
 import { ASPECT_LABELS_COLORS } from 'modules/simulationResult/consts';
-import type { OccurrenceId, TimetableItem, TrainScheduleId } from 'reducers/osrdconf/types';
+import type {
+  OccurrenceId,
+  TimetableItem,
+  TimetableItemId,
+  TrainScheduleId,
+} from 'reducers/osrdconf/types';
 import { isOccurrenceId, isTrainScheduleId } from 'utils/trainId';
 
 import type { MovableOccupancyZone } from './zones';
@@ -61,8 +66,8 @@ export const getWaypointsLocalStorageKey = (
  * overwhelming the server or API.
  */
 export function batchFetchTrackOccupancy(
-  allIDs: string[],
-  fetchTrackOccupancy: (ids: string[]) => Promise<MovableOccupancyZone[]>,
+  allIDs: TimetableItemId[],
+  fetchTrackOccupancy: (ids: TimetableItemId[]) => Promise<MovableOccupancyZone[]>,
   {
     batchSize = 50,
     onProgress = noop,

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useTrackOccupancy.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useTrackOccupancy.ts
@@ -10,9 +10,7 @@ import {
   isEqual,
   isFunction,
   keyBy,
-  keys,
   noop,
-  pick,
   uniqBy,
 } from 'lodash';
 import { useTranslation } from 'react-i18next';
@@ -24,7 +22,11 @@ import {
   type PathItemLocation,
 } from 'common/api/osrdEditoastApi';
 import type { TimetableItemId, TrainId } from 'reducers/osrdconf/types';
-import { extractEditoastIdFromTimetableItemId, extractEditoastIdFromTrainId } from 'utils/trainId';
+import {
+  extractEditoastIdFromTrainScheduleId,
+  formatEditoastIdToTrainScheduleId,
+  isTrainScheduleId,
+} from 'utils/trainId';
 
 import type { PathOperationalPoint, TrainSpaceTimeData } from '../../types';
 import { batchFetchTrackOccupancy } from './helpers/utils';
@@ -120,8 +122,8 @@ const useTrackOccupancy = ({
     osrdEditoastApi.endpoints.postTrainScheduleTrackOccupancy.useMutation();
   const [postInfraByInfraIdMatchOperationalPoints] =
     osrdEditoastApi.endpoints.postInfraByInfraIdMatchOperationalPoints.useLazyQuery();
-  const timetableItemsById = useMemo(
-    () => keyBy(timetableItemProjections, ({ id }) => extractEditoastIdFromTimetableItemId(id)),
+  const timetableItemsById: Map<TimetableItemId, OccupancyTrainSpaceTimeData> = useMemo(
+    () => new Map(timetableItemProjections.map((item) => [item.id, item])),
     [timetableItemProjections]
   );
 
@@ -163,8 +165,8 @@ const useTrackOccupancy = ({
   const fetchTrackOccupancy = useCallback(
     async (
       opId: string | undefined | null,
-      trainsCollection: Record<string, TrainSpaceTimeData>
-    ) =>
+      trainsCollection: Record<TimetableItemId, TrainSpaceTimeData>
+    ): Promise<MovableOccupancyZone[]> =>
       opId
         ? flatMap(
             (
@@ -172,15 +174,21 @@ const useTrackOccupancy = ({
                 body: {
                   operational_point_id: opId,
                   infra_id: infraId,
-                  train_schedule_ids: Object.keys(trainsCollection).map((id) => +id),
+                  train_schedule_ids: Object.keys(trainsCollection)
+                    .filter((id) => isTrainScheduleId(id))
+                    .map((id) => extractEditoastIdFromTrainScheduleId(id)),
                 },
               })
             ).data,
             (entries, trackId) =>
               entries.map((entry) =>
-                getMovableOccupancyZone(trackId, entry, trainsCollection[entry.train_schedule_id])
+                getMovableOccupancyZone(
+                  trackId,
+                  entry,
+                  trainsCollection[formatEditoastIdToTrainScheduleId(entry.train_schedule_id)]
+                )
               )
-          )
+          ) // TODO : append result of postPacedTrainTrackOccupancy
         : [],
     [infraId]
   );
@@ -228,11 +236,11 @@ const useTrackOccupancy = ({
       // Start fetching data:
       if (!currentState) {
         const abort = batchFetchTrackOccupancy(
-          keys(timetableItemsById),
+          Array.from(timetableItemsById.keys()),
           (ids) =>
             fetchTrackOccupancy(
               pathOperationalPointsDict[waypointId]?.opId,
-              pick(timetableItemsById, ids)
+              Object.fromEntries(ids.map((id) => [id, timetableItemsById.get(id)!]))
             ),
           {
             batchSize: 50,
@@ -319,7 +327,7 @@ const useTrackOccupancy = ({
 
       // Fetch new occupation if dragging has stopped:
       if (stopPanning) {
-        const draggedTrainEditoastId = extractEditoastIdFromTrainId(draggedTrainId);
+        const draggedTrainEditoastId = draggedTrainId;
         await Promise.all(
           [...impactedPathOperationalPointIDs].map(async (waypointId) => {
             const newZones = await fetchTrackOccupancy(
@@ -425,16 +433,17 @@ const useTrackOccupancy = ({
     )
       return;
 
-    const previousTimetableItemsDict = keyBy(previousTimetableItems, (timetableItem) =>
-      extractEditoastIdFromTimetableItemId(timetableItem.id)
+    const previousTimetableItemsDict = keyBy(
+      previousTimetableItems,
+      (timetableItem) => timetableItem.id
     );
 
-    const addedTrainIDs = new Set<number>();
-    const removedTrainIDs = new Set<number>();
-    const modifiedTrainIDs = new Set<number>();
+    const addedTrainIDs = new Set<TimetableItemId>();
+    const removedTrainIDs = new Set<TimetableItemId>();
+    const modifiedTrainIDs = new Set<TimetableItemId>();
 
     timetableItemProjections.forEach((timetableItem) => {
-      const id = extractEditoastIdFromTimetableItemId(timetableItem.id);
+      const id = timetableItem.id;
       const previousTimetableItem = previousTimetableItemsDict[id];
       if (!previousTimetableItem) addedTrainIDs.add(id);
       else if (
@@ -459,8 +468,8 @@ const useTrackOccupancy = ({
     });
 
     previousTimetableItems.forEach((timetableItem) => {
-      const id = extractEditoastIdFromTimetableItemId(timetableItem.id);
-      if (!timetableItemsById[id]) {
+      const id = timetableItem.id;
+      if (!timetableItemsById.has(id)) {
         removedTrainIDs.add(id);
         // Remove cached station labels for this train:
         trainsStationLabelsRef.current[timetableItem.id] = undefined;
@@ -472,7 +481,9 @@ const useTrackOccupancy = ({
       forEach(pathOperationalPointsState, async (_, waypointId) => {
         const newZones = await fetchTrackOccupancy(
           pathOperationalPointsDict[waypointId]?.opId,
-          pick(timetableItemsById, [...addedTrainIDs, ...modifiedTrainIDs])
+          Object.fromEntries(
+            [...addedTrainIDs, ...modifiedTrainIDs].map((id) => [id, timetableItemsById.get(id)!])
+          )
         );
 
         if (newZones.length)
@@ -483,9 +494,7 @@ const useTrackOccupancy = ({
                   zones: {
                     ...state.zones,
                     data: (state.zones.data || [])
-                      .filter(
-                        (zone) => !modifiedTrainIDs.has(extractEditoastIdFromTrainId(zone.trainId))
-                      )
+                      .filter((zone) => !modifiedTrainIDs.has(zone.trainId))
                       .concat(newZones),
                   },
                 }
@@ -504,9 +513,7 @@ const useTrackOccupancy = ({
                 zones: {
                   ...state.zones,
                   data:
-                    state.zones.data?.filter(
-                      (zone) => !removedTrainIDs.has(extractEditoastIdFromTrainId(zone.trainId))
-                    ) || [],
+                    state.zones.data?.filter((zone) => !removedTrainIDs.has(zone.trainId)) || [],
                 },
               }
             : undefined

--- a/front/src/utils/trainId.ts
+++ b/front/src/utils/trainId.ts
@@ -13,7 +13,6 @@ import type {
   PacedTrainId,
   PacedTrainWithPacedTrainId,
   TimetableItem,
-  TimetableItemId,
   TrainId,
   TrainScheduleId,
 } from 'reducers/osrdconf/types';
@@ -215,15 +214,6 @@ export const extractEditoastIdFromTrainId = (id: TrainId): number =>
   isTrainScheduleId(id)
     ? extractEditoastIdFromTrainScheduleId(id)
     : extractEditoastIdFromPacedTrainId(extractPacedTrainIdFromOccurrenceId(id));
-
-/**
- * Given a timetable item id with a TimetableItemId format (either TrainScheduleId or PacedTrainId),
- * returns the Editoast id (used for api).
- */
-export const extractEditoastIdFromTimetableItemId = (id: TimetableItemId): number =>
-  isTrainScheduleId(id)
-    ? extractEditoastIdFromTrainScheduleId(id)
-    : extractEditoastIdFromPacedTrainId(id);
 
 /**
  * Given a occurrence id with an OccurrenceId format (used across the front),


### PR DESCRIPTION
Stop converting timetable ids to number early in useTrackOccupancy.ts, which caused paced and schedules ids to be mixed, and the  /train_schedule/track_occupancy endpoint to be called with paced trains ids.

Drop extractEditoastIdFromTimetableItemId, which is a dangerous function as it causes such mixes.

Possible enabler for [#13260](https://github.com/OpenRailAssociation/osrd/issues/13260), [#osrd-confidential/1080](https://github.com/osrd-project/osrd-confidential/issues/1080) 