### PR TITLE
core: fix deprecations preventing update to gradle 9.0

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    id 'base'
     id 'java'
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.ksp) apply false
@@ -119,7 +120,7 @@ application {
     mainClass = 'fr.sncf.osrd.App'
 }
 
-archivesBaseName = "osrd"
+base.archivesName = "osrd"
 
 run {
     enableAssertions = true

--- a/core/gradle/libs.versions.toml
+++ b/core/gradle/libs.versions.toml
@@ -80,5 +80,5 @@ kotlin-serialization = { id = 'org.jetbrains.kotlin.plugin.serialization', versi
 # java
 spotbugs = { id = 'com.github.spotbugs', version = '6.0.9' }
 spotless = { id = 'com.diffplug.spotless', version = '8.0.0' }
-shadow = { id = 'com.github.johnrengelman.shadow', version = '8.1.1' }
+shadow = { id = 'com.gradleup.shadow', version = '8.3.9' }
 versions = { id = 'com.github.ben-manes.versions', version = '0.52.0' }


### PR DESCRIPTION
two commits to fix two deprecation warnings shown by e.g. `./gradlew knows --warning-mode all`

the first one introduced by the base plugin. it prevents upgrade to gradle 9.0
https://docs.gradle.org/8.10/userguide/upgrading_version_8.html#base_convention_deprecation

the second by the shadow plugin, fixed by an upgrade (see commit message for details)
https://docs.gradle.org/8.10/userguide/upgrading_version_8.html#unix_file_permissions_deprecated