### PR TITLE
editoast: status code 201 for creation endpoints

### DIFF
--- a/editoast/src/views/project.rs
+++ b/editoast/src/views/project.rs
@@ -4,6 +4,7 @@ use axum::extract::Json;
 use axum::extract::Path;
 use axum::extract::Query;
 use axum::extract::State;
+use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use chrono::Utc;
 use database::DbConnection;
@@ -131,7 +132,7 @@ pub(in crate::views) async fn create(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
     Extension(auth): AuthenticationExt,
     Json(project_create_form): Json<ProjectCreateForm>,
-) -> Result<Json<ProjectWithStudyCount>> {
+) -> Result<impl IntoResponse> {
     let authorized = auth
         .check_roles([Role::OperationalStudies].into())
         .await
@@ -147,7 +148,7 @@ pub(in crate::views) async fn create(
     let project = project.create(conn).await.map_err(ProjectError::from)?;
     let project_with_studies = ProjectWithStudyCount::try_fetch(conn, project).await?;
 
-    Ok(Json(project_with_studies))
+    Ok((StatusCode::CREATED, Json(project_with_studies)))
 }
 
 #[derive(Serialize, ToSchema)]
@@ -280,7 +281,7 @@ pub(in crate::views) async fn delete(
         })
         .await?;
 
-    Ok(axum::http::StatusCode::NO_CONTENT)
+    Ok(StatusCode::NO_CONTENT)
 }
 
 /// Patch form for a project
@@ -394,7 +395,6 @@ pub(in crate::views) async fn patch(
 pub mod tests {
     use super::*;
 
-    use axum::http::StatusCode;
     use pretty_assertions::assert_eq;
     use rstest::rstest;
     use serde_json::json;
@@ -418,8 +418,10 @@ pub mod tests {
             "funders": "",
         }));
 
-        let response: ProjectWithStudyCount =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: ProjectWithStudyCount = app
+            .fetch(request)
+            .assert_status(StatusCode::CREATED)
+            .json_into();
 
         let project = Project::retrieve(pool.get_ok(), response.project.id)
             .await

--- a/editoast/src/views/scenario.rs
+++ b/editoast/src/views/scenario.rs
@@ -7,6 +7,7 @@ use axum::extract::Json;
 use axum::extract::Path;
 use axum::extract::Query;
 use axum::extract::State;
+use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use chrono::Utc;
 use database::DbConnection;
@@ -166,7 +167,7 @@ pub(in crate::views) async fn create(
     Extension(auth): AuthenticationExt,
     Path((project_id, study_id)): Path<(i64, i64)>,
     Json(data): Json<ScenarioCreateForm>,
-) -> Result<Json<ScenarioResponse>> {
+) -> Result<impl IntoResponse> {
     let authorized = auth
         .check_roles([Role::OperationalStudies].into())
         .await
@@ -208,7 +209,10 @@ pub(in crate::views) async fn create(
     )
     .await?;
 
-    Ok(Json(ScenarioResponse::new(details, project, study)))
+    Ok((
+        StatusCode::CREATED,
+        Json(ScenarioResponse::new(details, project, study)),
+    ))
 }
 
 /// Delete a scenario
@@ -264,7 +268,7 @@ pub(in crate::views) async fn delete(
     )
     .await?;
 
-    Ok(axum::http::StatusCode::NO_CONTENT)
+    Ok(StatusCode::NO_CONTENT)
 }
 
 /// This structure is used by the patch endpoint to patch a scenario
@@ -512,7 +516,6 @@ async fn check_project_study_scenario(
 
 #[cfg(test)]
 mod tests {
-    use axum::http::StatusCode;
     use pretty_assertions::assert_eq;
     use rstest::rstest;
     use serde_json::json;
@@ -619,8 +622,10 @@ mod tests {
             "tags": study_tags
         }));
 
-        let response: ScenarioResponse =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: ScenarioResponse = app
+            .fetch(request)
+            .assert_status(StatusCode::CREATED)
+            .json_into();
 
         assert_eq!(response.scenario.name, study_name);
         assert_eq!(response.scenario.description, study_description);

--- a/editoast/src/views/scenario/macro_nodes.rs
+++ b/editoast/src/views/scenario/macro_nodes.rs
@@ -193,7 +193,7 @@ pub(in crate::views) async fn create(
     Extension(auth): AuthenticationExt,
     Path((project_id, study_id, scenario_id)): Path<(i64, i64, i64)>,
     Json(data): Json<MacroNodeBatchForm>,
-) -> Result<Json<MacroNodeBatchResponse>> {
+) -> Result<impl IntoResponse> {
     // Checking role
     let authorized = auth
         .check_roles([Role::OperationalStudies].into())
@@ -233,9 +233,12 @@ pub(in crate::views) async fn create(
     )
     .await?;
 
-    Ok(Json(MacroNodeBatchResponse {
-        macro_nodes: created.into_iter().map_into().collect(),
-    }))
+    Ok((
+        StatusCode::CREATED,
+        Json(MacroNodeBatchResponse {
+            macro_nodes: created.into_iter().map_into().collect(),
+        }),
+    ))
 }
 
 #[editoast_derive::route]
@@ -404,7 +407,6 @@ async fn retrieve_macro_node_and_check_scenario(
 
 #[cfg(test)]
 pub mod test {
-    use axum::http::StatusCode;
     use pretty_assertions::assert_eq;
     use rand::Rng;
     use rand::distr::Alphanumeric;
@@ -468,8 +470,10 @@ pub mod test {
             .json(&MacroNodeBatchForm {
                 macro_nodes: nodes_data.clone(),
             });
-        let response: MacroNodeBatchResponse =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: MacroNodeBatchResponse = app
+            .fetch(request)
+            .assert_status(StatusCode::CREATED)
+            .json_into();
 
         let node = MacroNode::retrieve(db_pool.get_ok(), response.macro_nodes[0].id)
             .await

--- a/editoast/src/views/study.rs
+++ b/editoast/src/views/study.rs
@@ -4,6 +4,7 @@ use axum::extract::Json;
 use axum::extract::Path;
 use axum::extract::Query;
 use axum::extract::State;
+use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use chrono::NaiveDate;
 use chrono::Utc;
@@ -122,7 +123,7 @@ pub(in crate::views) async fn create(
     Extension(auth): AuthenticationExt,
     Path(project_id): Path<i64>,
     Json(data): Json<StudyCreateForm>,
-) -> Result<Json<StudyResponse>> {
+) -> Result<impl IntoResponse> {
     let authorized = auth
         .check_roles([Role::OperationalStudies].into())
         .await
@@ -154,7 +155,7 @@ pub(in crate::views) async fn create(
         project,
     };
 
-    Ok(Json(study_response))
+    Ok((StatusCode::CREATED, Json(study_response)))
 }
 
 #[derive(IntoParams)]
@@ -196,7 +197,7 @@ pub(in crate::views) async fn delete(
     })
     .await?;
 
-    Ok(axum::http::StatusCode::NO_CONTENT)
+    Ok(StatusCode::NO_CONTENT)
 }
 
 /// Return a specific study
@@ -426,7 +427,6 @@ pub(in crate::views) async fn list(
 
 #[cfg(test)]
 pub mod tests {
-    use axum::http::StatusCode;
     use pretty_assertions::assert_eq;
     use rstest::rstest;
     use serde_json::json;
@@ -454,7 +454,10 @@ pub mod tests {
                 "service_code": "",
                 "study_type": "",
             }));
-        let response: StudyResponse = app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: StudyResponse = app
+            .fetch(request)
+            .assert_status(StatusCode::CREATED)
+            .json_into();
 
         let study = Study::retrieve(db_pool.get_ok(), response.study.id)
             .await


### PR DESCRIPTION
Updates the API responses for create endpoints across several modules (`project`, `study`, `scenario`, and `scenario/macro_nodes`) to return a 201 status code for successful create operations.

* Changed the return type of create endpoints in `project.rs`, `study.rs`, `scenario.rs`, and `scenario/macro_nodes.rs` to return a tuple with `StatusCode::CREATED` (201) and the created resource, instead of just the resource with a default status.
* Modified tests to expect `StatusCode::CREATED` (201) for create endpoints instead of `StatusCode::OK` (200).
* Added imports for `axum::http::StatusCode` where needed for the new response patterns.