### PR TITLE
editoast: study dates validation at parsing

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -6402,7 +6402,6 @@ components:
       - $ref: '#/components/schemas/EditoastStdcmSearchEnvErrorNotFound'
       - $ref: '#/components/schemas/EditoastStudyErrorDatabase'
       - $ref: '#/components/schemas/EditoastStudyErrorNotFound'
-      - $ref: '#/components/schemas/EditoastStudyErrorStartDateAfterEndDate'
       - $ref: '#/components/schemas/EditoastSubCategoryErrorCodeAlreadyUsed'
       - $ref: '#/components/schemas/EditoastSubCategoryErrorDatabase'
       - $ref: '#/components/schemas/EditoastSubCategoryErrorNotFound'
@@ -8172,25 +8171,6 @@ components:
           type: string
           enum:
           - editoast:study:NotFound
-    EditoastStudyErrorStartDateAfterEndDate:
-      type: object
-      required:
-      - type
-      - status
-      - message
-      properties:
-        context:
-          type: object
-        message:
-          type: string
-        status:
-          type: integer
-          enum:
-          - 400
-        type:
-          type: string
-          enum:
-          - editoast:study:StartDateAfterEndDate
     EditoastSubCategoryErrorCodeAlreadyUsed:
       type: object
       required:

--- a/editoast/src/models/study.rs
+++ b/editoast/src/models/study.rs
@@ -63,18 +63,6 @@ impl Study {
         Ok(count)
     }
 
-    pub fn validate(study_changeset: &Changeset<Self>) -> Result<(), StartDateAfterEndDateError> {
-        if !dates_in_order(
-            study_changeset.start_date,
-            study_changeset.expected_end_date,
-        ) || !dates_in_order(study_changeset.start_date, study_changeset.actual_end_date)
-        {
-            return Err(StartDateAfterEndDateError);
-        }
-
-        Ok(())
-    }
-
     /// Opens a transaction, retrieves the [Study] and its [Project] and calls the provided closure with these
     ///
     /// The last modification field of these objects are updated before the transaction is committed.
@@ -118,18 +106,6 @@ impl Study {
         .await
     }
 }
-
-fn dates_in_order(a: Option<Option<NaiveDate>>, b: Option<Option<NaiveDate>>) -> bool {
-    match (a, b) {
-        (Some(Some(a)), Some(Some(b))) => a <= b,
-        _ => true,
-    }
-}
-
-// TODO: Remove this struct the day we add validation to the study deserialize.
-#[derive(Debug, thiserror::Error)]
-#[error("The study start date must be before the end date")]
-pub struct StartDateAfterEndDateError;
 
 #[cfg(test)]
 pub mod tests {

--- a/editoast/src/views/study.rs
+++ b/editoast/src/views/study.rs
@@ -34,6 +34,24 @@ use crate::views::project::ProjectIdParam;
 use editoast_models::prelude::*;
 use editoast_models::tags::Tags;
 
+fn validate_study_dates(
+    start: Option<NaiveDate>,
+    expected_end: Option<NaiveDate>,
+    actual_end: Option<NaiveDate>,
+) -> Result<(), &'static str> {
+    if let Some((start, expected_end)) = start.zip(expected_end)
+        && start > expected_end
+    {
+        return Err("The study start date must be before the expected end date");
+    }
+    if let Some((start, actual_end)) = start.zip(actual_end)
+        && start > actual_end
+    {
+        return Err("The study start date must be before the actual end date");
+    }
+    Ok(())
+}
+
 #[derive(Debug, Error, EditoastError)]
 #[editoast_error(base_id = "study")]
 pub enum StudyError {
@@ -41,10 +59,6 @@ pub enum StudyError {
     #[error("Study '{study_id}', could not be found")]
     #[editoast_error(status = 404)]
     NotFound { study_id: i64 },
-    // The study start and end date are in the wrong order
-    #[error("The study start date must be before the end date")]
-    #[editoast_error(status = 400)]
-    StartDateAfterEndDate,
     #[error(transparent)]
     #[editoast_error(status = 500)]
     Database(#[from] editoast_models::Error),
@@ -69,7 +83,8 @@ impl StudyResponse {
 }
 
 /// This structure is used by the post endpoint to create a study
-#[derive(Serialize, Deserialize, Default, ToSchema)]
+#[derive(Deserialize, Default, ToSchema)]
+#[serde(remote = "Self")]
 pub(in crate::views) struct StudyCreateForm {
     pub name: String,
     pub description: Option<String>,
@@ -83,6 +98,22 @@ pub(in crate::views) struct StudyCreateForm {
     pub tags: Tags,
     pub state: String,
     pub study_type: Option<String>,
+}
+
+impl<'de> Deserialize<'de> for StudyCreateForm {
+    fn deserialize<D>(deserializer: D) -> Result<StudyCreateForm, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let form = StudyCreateForm::deserialize(deserializer)?;
+        validate_study_dates(
+            form.start_date,
+            form.expected_end_date,
+            form.actual_end_date,
+        )
+        .map_err(<D::Error as serde::de::Error>::custom)?;
+        Ok(form)
+    }
 }
 
 impl StudyCreateForm {
@@ -102,7 +133,6 @@ impl StudyCreateForm {
             .state(self.state)
             .study_type(self.study_type)
             .project_id(project_id);
-        Study::validate(&study_changeset).map_err(|_| StudyError::StartDateAfterEndDate)?;
         Ok(study_changeset)
     }
 }
@@ -253,7 +283,8 @@ pub(in crate::views) async fn get(
 }
 
 /// This structure is used by the patch endpoint to patch a study
-#[derive(Serialize, Deserialize, Default, ToSchema)]
+#[derive(Deserialize, Default, ToSchema)]
+#[serde(remote = "Self")]
 pub(in crate::views) struct StudyPatchForm {
     pub name: Option<String>,
     #[serde(default, with = "double_option")]
@@ -276,6 +307,22 @@ pub(in crate::views) struct StudyPatchForm {
     pub study_type: Option<Option<String>>,
 }
 
+impl<'de> Deserialize<'de> for StudyPatchForm {
+    fn deserialize<D>(deserializer: D) -> Result<StudyPatchForm, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let form = StudyPatchForm::deserialize(deserializer)?;
+        validate_study_dates(
+            form.start_date.flatten(),
+            form.expected_end_date.flatten(),
+            form.actual_end_date.flatten(),
+        )
+        .map_err(<D::Error as serde::de::Error>::custom)?;
+        Ok(form)
+    }
+}
+
 impl StudyPatchForm {
     pub fn into_study_changeset(self) -> Result<Changeset<Study>> {
         let study_changeset = Study::changeset()
@@ -290,7 +337,6 @@ impl StudyPatchForm {
             .flat_tags(self.tags)
             .flat_state(self.state)
             .flat_study_type(self.study_type);
-        Study::validate(&study_changeset).map_err(|_| StudyError::StartDateAfterEndDate)?;
         Ok(study_changeset)
     }
 }


### PR DESCRIPTION
Replaces manual validation by a parsing check in view schemas.

Will help with the error & models migrations.
