### PR TITLE
editoast: correct macro node update description

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -2746,7 +2746,7 @@ paths:
         required: true
       responses:
         '200':
-          description: The requested scenario
+          description: The updated macro note
           content:
             application/json:
               schema:

--- a/editoast/src/views/scenario/macro_nodes.rs
+++ b/editoast/src/views/scenario/macro_nodes.rs
@@ -281,7 +281,7 @@ pub(in crate::views) async fn get(
     params(ProjectIdParam, StudyIdParam, ScenarioIdParam, MacroNodeIdParam),
     request_body = MacroNodeForm,
     responses(
-        (status = 200, body = MacroNodeResponse, description = "The requested scenario"),
+        (status = 200, body = MacroNodeResponse, description = "The updated macro note"),
     )
 )]
 pub(in crate::views) async fn update(

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -2179,7 +2179,7 @@ export type GetProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNodes
   nodeId: number;
 };
 export type PutProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNodesNodeIdApiResponse =
-  /** status 200 The requested scenario */ MacroNodeResponse;
+  /** status 200 The updated macro note */ MacroNodeResponse;
 export type PutProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNodesNodeIdApiArg = {
   /** The id of a project */
   projectId: number;


### PR DESCRIPTION
Update of the description of the 200 OK response for the macro node update endpoint to clarify that it returns the updated macro node and not the requested scenario.