### PR TITLE
front : add nge  e2e tests

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
@@ -233,6 +233,7 @@ const ScenarioContent = ({ activeBoards }: ScenarioContentProps) => {
                 <BoardWrapper name="MACRO">
                   <div className="osrd-simulation-container">
                     <div
+                      data-testid="macro-editor"
                       className="chart-container"
                       style={{
                         height: `${macroBoardHeight - HIDDEN_CHART_TOP_HEIGHT}px`,

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
@@ -333,7 +333,7 @@ const SimulationResults = ({
               },
             ]}
           >
-            <div className="time-stop-outputs">
+            <div data-testid="time-stop-outputs" className="time-stop-outputs">
               <TimesStopsOutput
                 infraId={infraId}
                 selectedTrain={simulationResults?.train}

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/PacedTrainItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/PacedTrainItem.tsx
@@ -336,7 +336,7 @@ const PacedTrainItem = ({
           </div>
         )}
         {summary && !summary.isValid && (
-          <div className="invalid-reason">
+          <div data-testid="invalid-reason" className="invalid-reason">
             <span title={t(`timetable.invalid.${summary.invalidReason}`)}>
               {t(`timetable.invalid.${summary.invalidReason}`)}
             </span>

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TrainScheduleItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TrainScheduleItem.tsx
@@ -261,7 +261,11 @@ const TrainScheduleItem = ({
             </div>
           )}
           {summary && !summary.isValid && (
-            <div className="invalid-reason" title={t(`timetable.invalid.${summary.invalidReason}`)}>
+            <div
+              data-testid="invalid-reason"
+              className="invalid-reason"
+              title={t(`timetable.invalid.${summary.invalidReason}`)}
+            >
               <span>{t(`timetable.invalid.${summary.invalidReason}`)}</span>
             </div>
           )}

--- a/front/tests/009-op-simulation-settings-tab.spec.ts
+++ b/front/tests/009-op-simulation-settings-tab.spec.ts
@@ -173,7 +173,7 @@ test.describe('Simulation Settings Tab Verification', () => {
       await operationalStudiesPage.closeToastNotification();
       await operationalStudiesPage.returnSimulationResult();
       await scenarioTimetableSection.getTimetableItemArrivalTime('11:48');
-      await simulationResultPage.toggleTrainList();
+      await simulationResultPage.setTrainListVisible();
 
       await timeAndStopSimulationOutputs.verifyTimesStopsDataSheetVisibility();
       await simulationResultPage.selectAllSpeedSpaceChartCheckboxes();
@@ -184,7 +184,7 @@ test.describe('Simulation Settings Tab Verification', () => {
       }
       await scrollContainer(page, '.time-stop-outputs .time-stops-datasheet .dsg-container');
       await timeAndStopSimulationOutputs.getOutputTableData(expectedCellDataElectricalProfileON);
-      await simulationResultPage.toggleTrainList(false);
+      await simulationResultPage.setTrainListVisible(false);
     });
 
     await test.step('Deactivate electrical profiles and verify (OFF)', async () => {
@@ -192,7 +192,7 @@ test.describe('Simulation Settings Tab Verification', () => {
       await operationalStudiesPage.openSimulationSettingsTab();
       await simulationSettingsTab.deactivateElectricalProfile();
       await operationalStudiesPage.submitTimetableItemEdit();
-      await simulationResultPage.toggleTrainList();
+      await simulationResultPage.setTrainListVisible();
 
       await timeAndStopSimulationOutputs.verifyTimesStopsDataSheetVisibility();
       await simulationResultPage.selectAllSpeedSpaceChartCheckboxes();
@@ -202,7 +202,7 @@ test.describe('Simulation Settings Tab Verification', () => {
         );
       }
       await timeAndStopSimulationOutputs.getOutputTableData(expectedCellDataElectricalProfileOFF);
-      await simulationResultPage.toggleTrainList(false);
+      await simulationResultPage.setTrainListVisible(false);
       await scenarioTimetableSection.getTimetableItemArrivalTime('11:48');
     });
   });
@@ -231,7 +231,7 @@ test.describe('Simulation Settings Tab Verification', () => {
       await operationalStudiesPage.closeToastNotification();
       await operationalStudiesPage.returnSimulationResult();
       await scenarioTimetableSection.getTimetableItemArrivalTime('11:49');
-      await simulationResultPage.toggleTrainList();
+      await simulationResultPage.setTrainListVisible();
 
       await timeAndStopSimulationOutputs.verifyTimesStopsDataSheetVisibility();
       await simulationResultPage.selectAllSpeedSpaceChartCheckboxes();
@@ -242,7 +242,7 @@ test.describe('Simulation Settings Tab Verification', () => {
       }
       await scrollContainer(page, '.time-stop-outputs .time-stops-datasheet .dsg-container');
       await timeAndStopSimulationOutputs.getOutputTableData(expectedCellDataCodeCompoON);
-      await simulationResultPage.toggleTrainList(false);
+      await simulationResultPage.setTrainListVisible(false);
     });
 
     await test.step('Remove speed limit tag and verify (speed limit tag OFF)', async () => {
@@ -250,7 +250,7 @@ test.describe('Simulation Settings Tab Verification', () => {
       await operationalStudiesPage.openSimulationSettingsTab();
       await simulationSettingsTab.selectSpeedLimitTagOption('__PLACEHOLDER__');
       await operationalStudiesPage.submitTimetableItemEdit();
-      await simulationResultPage.toggleTrainList();
+      await simulationResultPage.setTrainListVisible();
 
       await timeAndStopSimulationOutputs.verifyTimesStopsDataSheetVisibility();
       await simulationResultPage.selectAllSpeedSpaceChartCheckboxes();
@@ -260,7 +260,7 @@ test.describe('Simulation Settings Tab Verification', () => {
         );
       }
       await timeAndStopSimulationOutputs.getOutputTableData(expectedCellDataCodeCompoOFF);
-      await simulationResultPage.toggleTrainList(false);
+      await simulationResultPage.setTrainListVisible(false);
       await scenarioTimetableSection.getTimetableItemArrivalTime('11:48');
     });
   });
@@ -299,7 +299,7 @@ test.describe('Simulation Settings Tab Verification', () => {
       await operationalStudiesPage.closeToastNotification();
       await operationalStudiesPage.returnSimulationResult();
       await scenarioTimetableSection.getTimetableItemArrivalTime('11:51');
-      await simulationResultPage.toggleTrainList();
+      await simulationResultPage.setTrainListVisible();
 
       await timeAndStopSimulationOutputs.verifyTimesStopsDataSheetVisibility();
       await simulationResultPage.selectAllSpeedSpaceChartCheckboxes();
@@ -310,7 +310,7 @@ test.describe('Simulation Settings Tab Verification', () => {
       }
       await scrollContainer(page, '.time-stop-outputs .time-stops-datasheet .dsg-container');
       await timeAndStopSimulationOutputs.getOutputTableData(expectedCellDataLinearMargin);
-      await simulationResultPage.toggleTrainList(false);
+      await simulationResultPage.setTrainListVisible(false);
     });
 
     await test.step('Edit to Mareco margin and verify', async () => {
@@ -318,7 +318,7 @@ test.describe('Simulation Settings Tab Verification', () => {
       await operationalStudiesPage.openSimulationSettingsTab();
       await simulationSettingsTab.activateMarecoMargin();
       await operationalStudiesPage.submitTimetableItemEdit();
-      await simulationResultPage.toggleTrainList();
+      await simulationResultPage.setTrainListVisible();
 
       await timeAndStopSimulationOutputs.verifyTimesStopsDataSheetVisibility();
       await simulationResultPage.selectAllSpeedSpaceChartCheckboxes();
@@ -328,7 +328,7 @@ test.describe('Simulation Settings Tab Verification', () => {
         );
       }
       await timeAndStopSimulationOutputs.getOutputTableData(expectedCellDataMarecoMargin);
-      await simulationResultPage.toggleTrainList(false);
+      await simulationResultPage.setTrainListVisible(false);
       await scenarioTimetableSection.getTimetableItemArrivalTime('11:51');
     });
   });
@@ -367,7 +367,7 @@ test.describe('Simulation Settings Tab Verification', () => {
       await operationalStudiesPage.createTimetableItem();
       await operationalStudiesPage.closeToastNotification();
       await operationalStudiesPage.returnSimulationResult();
-      await simulationResultPage.toggleTrainList();
+      await simulationResultPage.setTrainListVisible();
 
       await timeAndStopSimulationOutputs.verifyTimesStopsDataSheetVisibility();
       await simulationResultPage.selectAllSpeedSpaceChartCheckboxes();
@@ -378,7 +378,7 @@ test.describe('Simulation Settings Tab Verification', () => {
       }
       await scrollContainer(page, '.time-stop-outputs .time-stops-datasheet .dsg-container');
       await timeAndStopSimulationOutputs.getOutputTableData(expectedCellDataForAllSettings);
-      await simulationResultPage.toggleTrainList(false);
+      await simulationResultPage.setTrainListVisible(false);
       await scenarioTimetableSection.getTimetableItemArrivalTime('11:50');
     });
   });

--- a/front/tests/009-op-simulation-settings-tab.spec.ts
+++ b/front/tests/009-op-simulation-settings-tab.spec.ts
@@ -12,7 +12,6 @@ import { improbableRollingStockName } from './assets/constants/project-const';
 import test from './logging-fixture';
 import OperationalStudiesPage from './pages/operational-studies/operational-studies-page';
 import RouteTab from './pages/operational-studies/route-tab';
-import ScenarioPage from './pages/operational-studies/scenario-page';
 import ScenarioTimetableSection from './pages/operational-studies/scenario-timetable-section';
 import OpSimulationResultPage from './pages/operational-studies/simulation-results-page';
 import SimulationSettingsTab from './pages/operational-studies/simulation-settings-tab';
@@ -68,7 +67,6 @@ test.describe('Simulation Settings Tab Verification', () => {
   let simulationSettingsTab: SimulationSettingsTab;
   let simulationResultPage: OpSimulationResultPage;
   let scenarioTimetableSection: ScenarioTimetableSection;
-  let scenarioPage: ScenarioPage;
 
   let electricalProfileSet: ElectricalProfileSet;
   let project: Project;
@@ -106,7 +104,6 @@ test.describe('Simulation Settings Tab Verification', () => {
       simulationSettingsTab,
       simulationResultPage,
       scenarioTimetableSection,
-      scenarioPage,
     ] = [
       new OperationalStudiesPage(page),
       new RouteTab(page),
@@ -116,7 +113,6 @@ test.describe('Simulation Settings Tab Verification', () => {
       new SimulationSettingsTab(page),
       new OpSimulationResultPage(page),
       new ScenarioTimetableSection(page),
-      new ScenarioPage(page),
     ];
 
     await test.step('Create then navigate to scenario page', async () => {
@@ -177,7 +173,7 @@ test.describe('Simulation Settings Tab Verification', () => {
       await operationalStudiesPage.closeToastNotification();
       await operationalStudiesPage.returnSimulationResult();
       await scenarioTimetableSection.getTimetableItemArrivalTime('11:48');
-      await scenarioPage.toggleTrainList();
+      await simulationResultPage.toggleTrainList();
 
       await timeAndStopSimulationOutputs.verifyTimesStopsDataSheetVisibility();
       await simulationResultPage.selectAllSpeedSpaceChartCheckboxes();
@@ -188,7 +184,7 @@ test.describe('Simulation Settings Tab Verification', () => {
       }
       await scrollContainer(page, '.time-stop-outputs .time-stops-datasheet .dsg-container');
       await timeAndStopSimulationOutputs.getOutputTableData(expectedCellDataElectricalProfileON);
-      await scenarioPage.toggleTrainList(false);
+      await simulationResultPage.toggleTrainList(false);
     });
 
     await test.step('Deactivate electrical profiles and verify (OFF)', async () => {
@@ -196,7 +192,7 @@ test.describe('Simulation Settings Tab Verification', () => {
       await operationalStudiesPage.openSimulationSettingsTab();
       await simulationSettingsTab.deactivateElectricalProfile();
       await operationalStudiesPage.submitTimetableItemEdit();
-      await scenarioPage.toggleTrainList();
+      await simulationResultPage.toggleTrainList();
 
       await timeAndStopSimulationOutputs.verifyTimesStopsDataSheetVisibility();
       await simulationResultPage.selectAllSpeedSpaceChartCheckboxes();
@@ -206,7 +202,7 @@ test.describe('Simulation Settings Tab Verification', () => {
         );
       }
       await timeAndStopSimulationOutputs.getOutputTableData(expectedCellDataElectricalProfileOFF);
-      await scenarioPage.toggleTrainList(false);
+      await simulationResultPage.toggleTrainList(false);
       await scenarioTimetableSection.getTimetableItemArrivalTime('11:48');
     });
   });
@@ -235,7 +231,7 @@ test.describe('Simulation Settings Tab Verification', () => {
       await operationalStudiesPage.closeToastNotification();
       await operationalStudiesPage.returnSimulationResult();
       await scenarioTimetableSection.getTimetableItemArrivalTime('11:49');
-      await scenarioPage.toggleTrainList();
+      await simulationResultPage.toggleTrainList();
 
       await timeAndStopSimulationOutputs.verifyTimesStopsDataSheetVisibility();
       await simulationResultPage.selectAllSpeedSpaceChartCheckboxes();
@@ -246,7 +242,7 @@ test.describe('Simulation Settings Tab Verification', () => {
       }
       await scrollContainer(page, '.time-stop-outputs .time-stops-datasheet .dsg-container');
       await timeAndStopSimulationOutputs.getOutputTableData(expectedCellDataCodeCompoON);
-      await scenarioPage.toggleTrainList(false);
+      await simulationResultPage.toggleTrainList(false);
     });
 
     await test.step('Remove speed limit tag and verify (speed limit tag OFF)', async () => {
@@ -254,7 +250,7 @@ test.describe('Simulation Settings Tab Verification', () => {
       await operationalStudiesPage.openSimulationSettingsTab();
       await simulationSettingsTab.selectSpeedLimitTagOption('__PLACEHOLDER__');
       await operationalStudiesPage.submitTimetableItemEdit();
-      await scenarioPage.toggleTrainList();
+      await simulationResultPage.toggleTrainList();
 
       await timeAndStopSimulationOutputs.verifyTimesStopsDataSheetVisibility();
       await simulationResultPage.selectAllSpeedSpaceChartCheckboxes();
@@ -264,7 +260,7 @@ test.describe('Simulation Settings Tab Verification', () => {
         );
       }
       await timeAndStopSimulationOutputs.getOutputTableData(expectedCellDataCodeCompoOFF);
-      await scenarioPage.toggleTrainList(false);
+      await simulationResultPage.toggleTrainList(false);
       await scenarioTimetableSection.getTimetableItemArrivalTime('11:48');
     });
   });
@@ -303,7 +299,7 @@ test.describe('Simulation Settings Tab Verification', () => {
       await operationalStudiesPage.closeToastNotification();
       await operationalStudiesPage.returnSimulationResult();
       await scenarioTimetableSection.getTimetableItemArrivalTime('11:51');
-      await scenarioPage.toggleTrainList();
+      await simulationResultPage.toggleTrainList();
 
       await timeAndStopSimulationOutputs.verifyTimesStopsDataSheetVisibility();
       await simulationResultPage.selectAllSpeedSpaceChartCheckboxes();
@@ -314,7 +310,7 @@ test.describe('Simulation Settings Tab Verification', () => {
       }
       await scrollContainer(page, '.time-stop-outputs .time-stops-datasheet .dsg-container');
       await timeAndStopSimulationOutputs.getOutputTableData(expectedCellDataLinearMargin);
-      await scenarioPage.toggleTrainList(false);
+      await simulationResultPage.toggleTrainList(false);
     });
 
     await test.step('Edit to Mareco margin and verify', async () => {
@@ -322,7 +318,7 @@ test.describe('Simulation Settings Tab Verification', () => {
       await operationalStudiesPage.openSimulationSettingsTab();
       await simulationSettingsTab.activateMarecoMargin();
       await operationalStudiesPage.submitTimetableItemEdit();
-      await scenarioPage.toggleTrainList();
+      await simulationResultPage.toggleTrainList();
 
       await timeAndStopSimulationOutputs.verifyTimesStopsDataSheetVisibility();
       await simulationResultPage.selectAllSpeedSpaceChartCheckboxes();
@@ -332,7 +328,7 @@ test.describe('Simulation Settings Tab Verification', () => {
         );
       }
       await timeAndStopSimulationOutputs.getOutputTableData(expectedCellDataMarecoMargin);
-      await scenarioPage.toggleTrainList(false);
+      await simulationResultPage.toggleTrainList(false);
       await scenarioTimetableSection.getTimetableItemArrivalTime('11:51');
     });
   });
@@ -371,7 +367,7 @@ test.describe('Simulation Settings Tab Verification', () => {
       await operationalStudiesPage.createTimetableItem();
       await operationalStudiesPage.closeToastNotification();
       await operationalStudiesPage.returnSimulationResult();
-      await scenarioPage.toggleTrainList();
+      await simulationResultPage.toggleTrainList();
 
       await timeAndStopSimulationOutputs.verifyTimesStopsDataSheetVisibility();
       await simulationResultPage.selectAllSpeedSpaceChartCheckboxes();
@@ -382,7 +378,7 @@ test.describe('Simulation Settings Tab Verification', () => {
       }
       await scrollContainer(page, '.time-stop-outputs .time-stops-datasheet .dsg-container');
       await timeAndStopSimulationOutputs.getOutputTableData(expectedCellDataForAllSettings);
-      await scenarioPage.toggleTrainList(false);
+      await simulationResultPage.toggleTrainList(false);
       await scenarioTimetableSection.getTimetableItemArrivalTime('11:50');
     });
   });

--- a/front/tests/017-paced-train-management.spec.ts
+++ b/front/tests/017-paced-train-management.spec.ts
@@ -209,7 +209,7 @@ test.describe('Verify simulation configuration in operational studies for train 
 
     await test.step('Open first occurrence and verify its simulation results (screenshot comparison for the GEV)', async () => {
       await pacedTrainSection.selectOccurrence({ pacedTrainIndex: 0, occurrenceIndex: 0 });
-      await simulationResultPage.toggleTrainList();
+      await simulationResultPage.setTrainListVisible();
       if (browserName === 'chromium') {
         await expect(simulationResultPage.speedSpaceChart).toHaveScreenshot(
           'SpeedSpaceChart-InitialInputs.png'

--- a/front/tests/017-paced-train-management.spec.ts
+++ b/front/tests/017-paced-train-management.spec.ts
@@ -18,7 +18,6 @@ import test from './logging-fixture';
 import OperationalStudiesPage from './pages/operational-studies/operational-studies-page';
 import PacedTrainSection from './pages/operational-studies/paced-train-section';
 import RouteTab from './pages/operational-studies/route-tab';
-import ScenarioPage from './pages/operational-studies/scenario-page';
 import ScenarioTimetableSection from './pages/operational-studies/scenario-timetable-section';
 import OpSimulationResultPage from './pages/operational-studies/simulation-results-page';
 import TimeAndStopSimulationOutputs from './pages/operational-studies/time-stop-simulation-outputs';
@@ -84,7 +83,6 @@ test.describe('Verify simulation configuration in operational studies for train 
   let timesAndStopsTab: TimesAndStopsTab;
   let simulationResultPage: OpSimulationResultPage;
   let timeAndStopSimulationOutputs: TimeAndStopSimulationOutputs;
-  let scenarioPage: ScenarioPage;
 
   let project: Project;
   let study: Study;
@@ -112,7 +110,6 @@ test.describe('Verify simulation configuration in operational studies for train 
         timesAndStopsTab,
         simulationResultPage,
         timeAndStopSimulationOutputs,
-        scenarioPage,
       ] = [
         new RollingStockSelector(page),
         new OperationalStudiesPage(page),
@@ -122,7 +119,6 @@ test.describe('Verify simulation configuration in operational studies for train 
         new TimesAndStopsTab(page),
         new OpSimulationResultPage(page),
         new TimeAndStopSimulationOutputs(page),
-        new ScenarioPage(page),
       ];
 
       await page.goto(
@@ -213,7 +209,7 @@ test.describe('Verify simulation configuration in operational studies for train 
 
     await test.step('Open first occurrence and verify its simulation results (screenshot comparison for the GEV)', async () => {
       await pacedTrainSection.selectOccurrence({ pacedTrainIndex: 0, occurrenceIndex: 0 });
-      await scenarioPage.toggleTrainList();
+      await simulationResultPage.toggleTrainList();
       if (browserName === 'chromium') {
         await expect(simulationResultPage.speedSpaceChart).toHaveScreenshot(
           'SpeedSpaceChart-InitialInputs.png'

--- a/front/tests/021-get-manchette.spec.ts
+++ b/front/tests/021-get-manchette.spec.ts
@@ -18,7 +18,6 @@ import {
 import test from './logging-fixture';
 import GetManchetteComponent from './pages/operational-studies/get-manchette-component';
 import PacedTrainSection from './pages/operational-studies/paced-train-section';
-import ScenarioPage from './pages/operational-studies/scenario-page';
 import ScenarioTimetableSection from './pages/operational-studies/scenario-timetable-section';
 import OpSimulationResultPage from './pages/operational-studies/simulation-results-page';
 import { generateUniqueName, waitForInfraStateToBeCached } from './utils';
@@ -71,7 +70,6 @@ test.describe('Verify manchette and space time diagram', () => {
 
   let simulationResultPage: OpSimulationResultPage;
   let scenarioTimetableSection: ScenarioTimetableSection;
-  let scenarioPage: ScenarioPage;
   let pacedTrainSection: PacedTrainSection;
   let getManchetteComponent: GetManchetteComponent;
 
@@ -97,16 +95,9 @@ test.describe('Verify manchette and space time diagram', () => {
   });
 
   test.beforeEach('Open scenario and wait for infra to be loaded', async ({ page }) => {
-    [
-      simulationResultPage,
-      scenarioTimetableSection,
-      scenarioPage,
-      pacedTrainSection,
-      getManchetteComponent,
-    ] = [
+    [simulationResultPage, scenarioTimetableSection, pacedTrainSection, getManchetteComponent] = [
       new OpSimulationResultPage(page),
       new ScenarioTimetableSection(page),
-      new ScenarioPage(page),
       new PacedTrainSection(page),
       new GetManchetteComponent(page),
     ];
@@ -114,7 +105,7 @@ test.describe('Verify manchette and space time diagram', () => {
     await page.goto(
       `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenarioItems.id}`
     );
-    await scenarioPage.removeViteOverlay();
+    await simulationResultPage.removeViteOverlay();
     await waitForInfraStateToBeCached(infra.id);
   });
 
@@ -125,7 +116,7 @@ test.describe('Verify manchette and space time diagram', () => {
   test('Basic checks for STD/Manchette', async () => {
     await test.step('Verify first train schedule is selected', async () => {
       await scenarioTimetableSection.verifyFirstTimetableItemIsSelected();
-      await scenarioPage.toggleTrainList();
+      await simulationResultPage.toggleTrainList();
     });
     await test.step('Assert GET slider', async () => {
       await getManchetteComponent.assertDefaultSliderValue();
@@ -154,24 +145,24 @@ test.describe('Verify manchette and space time diagram', () => {
       await scenarioTimetableSection.projectTrain();
       await getManchetteComponent.selectAllSpaceTimeChartCheckboxes();
       await getManchetteComponent.setRangeSliderValue('60'); // Adjust slider to show the full projection
-      await scenarioPage.toggleTrainList();
+      await simulationResultPage.toggleTrainList();
       await expect(simulationResultPage.manchetteSpaceTimeChart).toHaveScreenshot(
         'TrainSchedule-Space-Time-Chart.png'
       );
     });
 
     await test.step('Project paced train and capture GET screenshot', async () => {
-      await scenarioPage.toggleTrainList(false);
+      await simulationResultPage.toggleTrainList(false);
       await pacedTrainSection.projectPacedTrain();
       await getManchetteComponent.setRangeSliderValue('50'); // Adjust slider to show the paced train better
-      await scenarioPage.toggleTrainList();
+      await simulationResultPage.toggleTrainList();
       await expect(simulationResultPage.manchetteSpaceTimeChart).toHaveScreenshot(
         'PacedTrain-Space-Time-Chart.png'
       );
     });
 
     await test.step('Project first occurrence (conform) and capture screenshot', async () => {
-      await scenarioPage.toggleTrainList(false);
+      await simulationResultPage.toggleTrainList(false);
       await getManchetteComponent.setRangeSliderValue('60'); // Reset slider to show the full diagram
       await pacedTrainSection.clickOnOccurrence(0);
       await pacedTrainSection.checkOccurrenceMenuIcon(0);
@@ -182,14 +173,14 @@ test.describe('Verify manchette and space time diagram', () => {
       });
 
       await pacedTrainSection.clickOccurrenceMenuButton('project');
-      await scenarioPage.toggleTrainList();
+      await simulationResultPage.toggleTrainList();
       await expect(simulationResultPage.manchetteSpaceTimeChart).toHaveScreenshot(
         'ConformOccurrence-Space-Time-Chart.png'
       );
     });
 
     await test.step('Project added exception and capture screenshot', async () => {
-      await scenarioPage.toggleTrainList(false);
+      await simulationResultPage.toggleTrainList(false);
       await pacedTrainSection.clickOnOccurrence(3);
       await pacedTrainSection.checkOccurrenceMenuIcon(3);
       await pacedTrainSection.checkOccurrenceActionMenu({
@@ -199,14 +190,14 @@ test.describe('Verify manchette and space time diagram', () => {
       });
 
       await pacedTrainSection.clickOccurrenceMenuButton('project');
-      await scenarioPage.toggleTrainList();
+      await simulationResultPage.toggleTrainList();
       await expect(simulationResultPage.manchetteSpaceTimeChart).toHaveScreenshot(
         'AddedOccurrence-Space-Time-Chart.png'
       );
     });
 
     await test.step('Project last occurrence (exception) and capture screenshot', async () => {
-      await scenarioPage.toggleTrainList(false);
+      await simulationResultPage.toggleTrainList(false);
       await pacedTrainSection.clickOnOccurrence(4);
       await pacedTrainSection.checkOccurrenceMenuIcon(4);
       await pacedTrainSection.checkOccurrenceActionMenu({
@@ -215,7 +206,7 @@ test.describe('Verify manchette and space time diagram', () => {
         translations: frTranslations,
       });
       await pacedTrainSection.clickOccurrenceMenuButton('project');
-      await scenarioPage.toggleTrainList();
+      await simulationResultPage.toggleTrainList();
       await expect(simulationResultPage.manchetteSpaceTimeChart).toHaveScreenshot(
         'ModifiedOccurrence-Space-Time-Chart.png'
       );
@@ -225,7 +216,7 @@ test.describe('Verify manchette and space time diagram', () => {
   test('Manchette', async () => {
     await test.step('Project train schedule and verify waypoints list', async () => {
       await scenarioTimetableSection.projectTrain();
-      await scenarioPage.toggleTrainList();
+      await simulationResultPage.toggleTrainList();
       const actualWaypointsListData = await getManchetteComponent.getWaypointsListData(4);
       verifyWaypointsData(actualWaypointsListData, expectedWaypointsListDataForTrainSchedule);
     });
@@ -238,9 +229,9 @@ test.describe('Verify manchette and space time diagram', () => {
     });
 
     await test.step('Project paced train and verify waypoints list', async () => {
-      await scenarioPage.toggleTrainList(false);
+      await simulationResultPage.toggleTrainList(false);
       await pacedTrainSection.projectPacedTrain();
-      await scenarioPage.toggleTrainList();
+      await simulationResultPage.toggleTrainList();
       const actualWaypointsListData = await getManchetteComponent.getWaypointsListData(4);
       verifyWaypointsData(actualWaypointsListData, expectedWaypointsListDataForPacedTrain);
     });

--- a/front/tests/021-get-manchette.spec.ts
+++ b/front/tests/021-get-manchette.spec.ts
@@ -116,7 +116,7 @@ test.describe('Verify manchette and space time diagram', () => {
   test('Basic checks for STD/Manchette', async () => {
     await test.step('Verify first train schedule is selected', async () => {
       await scenarioTimetableSection.verifyFirstTimetableItemIsSelected();
-      await simulationResultPage.toggleTrainList();
+      await simulationResultPage.setTrainListVisible();
     });
     await test.step('Assert GET slider', async () => {
       await getManchetteComponent.assertDefaultSliderValue();
@@ -145,24 +145,24 @@ test.describe('Verify manchette and space time diagram', () => {
       await scenarioTimetableSection.projectTrain();
       await getManchetteComponent.selectAllSpaceTimeChartCheckboxes();
       await getManchetteComponent.setRangeSliderValue('60'); // Adjust slider to show the full projection
-      await simulationResultPage.toggleTrainList();
+      await simulationResultPage.setTrainListVisible();
       await expect(simulationResultPage.manchetteSpaceTimeChart).toHaveScreenshot(
         'TrainSchedule-Space-Time-Chart.png'
       );
     });
 
     await test.step('Project paced train and capture GET screenshot', async () => {
-      await simulationResultPage.toggleTrainList(false);
+      await simulationResultPage.setTrainListVisible(false);
       await pacedTrainSection.projectPacedTrain();
       await getManchetteComponent.setRangeSliderValue('50'); // Adjust slider to show the paced train better
-      await simulationResultPage.toggleTrainList();
+      await simulationResultPage.setTrainListVisible();
       await expect(simulationResultPage.manchetteSpaceTimeChart).toHaveScreenshot(
         'PacedTrain-Space-Time-Chart.png'
       );
     });
 
     await test.step('Project first occurrence (conform) and capture screenshot', async () => {
-      await simulationResultPage.toggleTrainList(false);
+      await simulationResultPage.setTrainListVisible(false);
       await getManchetteComponent.setRangeSliderValue('60'); // Reset slider to show the full diagram
       await pacedTrainSection.clickOnOccurrence(0);
       await pacedTrainSection.checkOccurrenceMenuIcon(0);
@@ -173,14 +173,14 @@ test.describe('Verify manchette and space time diagram', () => {
       });
 
       await pacedTrainSection.clickOccurrenceMenuButton('project');
-      await simulationResultPage.toggleTrainList();
+      await simulationResultPage.setTrainListVisible();
       await expect(simulationResultPage.manchetteSpaceTimeChart).toHaveScreenshot(
         'ConformOccurrence-Space-Time-Chart.png'
       );
     });
 
     await test.step('Project added exception and capture screenshot', async () => {
-      await simulationResultPage.toggleTrainList(false);
+      await simulationResultPage.setTrainListVisible(false);
       await pacedTrainSection.clickOnOccurrence(3);
       await pacedTrainSection.checkOccurrenceMenuIcon(3);
       await pacedTrainSection.checkOccurrenceActionMenu({
@@ -190,14 +190,14 @@ test.describe('Verify manchette and space time diagram', () => {
       });
 
       await pacedTrainSection.clickOccurrenceMenuButton('project');
-      await simulationResultPage.toggleTrainList();
+      await simulationResultPage.setTrainListVisible();
       await expect(simulationResultPage.manchetteSpaceTimeChart).toHaveScreenshot(
         'AddedOccurrence-Space-Time-Chart.png'
       );
     });
 
     await test.step('Project last occurrence (exception) and capture screenshot', async () => {
-      await simulationResultPage.toggleTrainList(false);
+      await simulationResultPage.setTrainListVisible(false);
       await pacedTrainSection.clickOnOccurrence(4);
       await pacedTrainSection.checkOccurrenceMenuIcon(4);
       await pacedTrainSection.checkOccurrenceActionMenu({
@@ -206,7 +206,7 @@ test.describe('Verify manchette and space time diagram', () => {
         translations: frTranslations,
       });
       await pacedTrainSection.clickOccurrenceMenuButton('project');
-      await simulationResultPage.toggleTrainList();
+      await simulationResultPage.setTrainListVisible();
       await expect(simulationResultPage.manchetteSpaceTimeChart).toHaveScreenshot(
         'ModifiedOccurrence-Space-Time-Chart.png'
       );
@@ -216,7 +216,7 @@ test.describe('Verify manchette and space time diagram', () => {
   test('Manchette', async () => {
     await test.step('Project train schedule and verify waypoints list', async () => {
       await scenarioTimetableSection.projectTrain();
-      await simulationResultPage.toggleTrainList();
+      await simulationResultPage.setTrainListVisible();
       const actualWaypointsListData = await getManchetteComponent.getWaypointsListData(4);
       verifyWaypointsData(actualWaypointsListData, expectedWaypointsListDataForTrainSchedule);
     });
@@ -229,9 +229,9 @@ test.describe('Verify manchette and space time diagram', () => {
     });
 
     await test.step('Project paced train and verify waypoints list', async () => {
-      await simulationResultPage.toggleTrainList(false);
+      await simulationResultPage.setTrainListVisible(false);
       await pacedTrainSection.projectPacedTrain();
-      await simulationResultPage.toggleTrainList();
+      await simulationResultPage.setTrainListVisible();
       const actualWaypointsListData = await getManchetteComponent.getWaypointsListData(4);
       verifyWaypointsData(actualWaypointsListData, expectedWaypointsListDataForPacedTrain);
     });

--- a/front/tests/023-osrd-nge.spec.ts
+++ b/front/tests/023-osrd-nge.spec.ts
@@ -3,21 +3,29 @@ import type { Scenario, Project, Study, Infra, TrainSchedule } from 'common/api/
 import { timetableItemProjectName, timetableItemStudyName } from './assets/constants/project-const';
 import test from './logging-fixture';
 import NGEPage from './pages/operational-studies/nge-page';
+import ScenarioTimetableSection from './pages/operational-studies/scenario-timetable-section';
 import { generateUniqueName, waitForInfraStateToBeCached } from './utils';
 import { getInfra, getProject, getStudy } from './utils/api-utils';
 import readJsonFile from './utils/file-utils';
 import createScenario from './utils/scenario';
 import { deleteScenario } from './utils/teardown-utils';
 import sendTrainSchedules from './utils/train-schedule';
+import type { TimetableFilterTranslations } from './utils/types';
 
 const trainSchedulesJson = readJsonFile<TrainSchedule[]>(
   './tests/assets/train-schedule/train_schedules.json'
 );
 
+const frTranslations: TimetableFilterTranslations = readJsonFile<{
+  main: TimetableFilterTranslations;
+}>('public/locales/fr/operational-studies.json').main;
+
 test.describe('Verify osrd nge conversion', () => {
   test.use({ viewport: { width: 1920, height: 1080 } });
+  test.use({ ignorePageErrors: true });
 
   let ngePage: NGEPage;
+  let scenarioTimetableSection: ScenarioTimetableSection;
 
   let project: Project;
   let study: Study;
@@ -32,12 +40,14 @@ test.describe('Verify osrd nge conversion', () => {
 
   test.beforeEach('Open scenario and enable only macro view ', async ({ page }) => {
     ngePage = new NGEPage(page);
+    scenarioTimetableSection = new ScenarioTimetableSection(page);
     await test.step('Create, open scenario and wait for infra to be loaded', async () => {
       scenarioItems = (
         await createScenario(generateUniqueName('nge-scenario'), project.id, study.id, infra.id)
       ).scenario;
 
       await sendTrainSchedules(scenarioItems.timetable_id, trainSchedulesJson.slice(4, 5));
+
       await page.goto(
         `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenarioItems.id}`
       );
@@ -92,6 +102,56 @@ test.describe('Verify osrd nge conversion', () => {
       await ngePage.openTrainDetailsFromLine(1);
       await ngePage.expectDialogHeaderTrainName('Train5');
       await ngePage.expectStationsTabShows(['Mid_East_station', 'Mid_West_station']);
+    });
+  });
+
+  test('Delete a train from train list', async ({ page }) => {
+    await test.step('Delete train from timetable list', async () => {
+      await scenarioTimetableSection.deleteTimetableItem();
+    });
+
+    await test.step('Reload page to refresh timetable state', async () => {
+      await page.reload(); // Should be removed once issue #13758 is resolved
+    });
+
+    await test.step('Verify timetable is empty (UI message)', async () => {
+      await scenarioTimetableSection.verifyTimetableIsEmpty(frTranslations.timetable.noTrain);
+    });
+
+    await test.step('Enable macro view while keeping the default train list visible', async () => {
+      await ngePage.enableMacroViewWithDefaultTrainList();
+    });
+
+    await test.step('Verify NGE graph is empty (no nodes or train lines)', async () => {
+      await ngePage.verifyNodeAndLinesCount({ nodes: 0, lines: 0 });
+    });
+  });
+
+  test('Delete a train from NGE', async ({ page }) => {
+    await test.step('Delete first node via dialog (expect 2 nodes, 1 line)', async () => {
+      await ngePage.deleteNodeByIndexViaDialog(0, { nodes: 2, lines: 1 });
+    });
+
+    await test.step('Delete next node via dialog (expect 1 node, 0 line)', async () => {
+      await ngePage.deleteNodeByIndexViaDialog(0, { nodes: 1, lines: 0 });
+    });
+
+    await test.step('Delete last node using keyboard (expect 0 nodes, 0 line)', async () => {
+      await ngePage.deleteFocusedNodeWithKeyboard({ nodes: 0, lines: 0 });
+    });
+
+    await test.step('Verify timetable is empty (UI)', async () => {
+      await scenarioTimetableSection.verifyTimetableIsEmpty(frTranslations.timetable.noTrain);
+    });
+
+    await test.step('Reload and re-assert timetable is empty', async () => {
+      await page.reload();
+      await scenarioTimetableSection.verifyTimetableIsEmpty(frTranslations.timetable.noTrain);
+    });
+
+    await test.step('Re-toggle macro layout and re-assert graph is empty', async () => {
+      await ngePage.enableMacroViewWithDefaultTrainList();
+      await ngePage.verifyNodeAndLinesCount({ nodes: 0, lines: 0 });
     });
   });
 });

--- a/front/tests/023-osrd-nge.spec.ts
+++ b/front/tests/023-osrd-nge.spec.ts
@@ -2,8 +2,7 @@ import type { Scenario, Project, Study, Infra, TrainSchedule } from 'common/api/
 
 import { timetableItemProjectName, timetableItemStudyName } from './assets/constants/project-const';
 import test from './logging-fixture';
-import ScenarioTimetableSection from './pages/operational-studies/scenario-timetable-section';
-import OpSimulationResultPage from './pages/operational-studies/simulation-results-page';
+import NGEPage from './pages/operational-studies/nge-page';
 import { generateUniqueName, waitForInfraStateToBeCached } from './utils';
 import { getInfra, getProject, getStudy } from './utils/api-utils';
 import readJsonFile from './utils/file-utils';
@@ -18,8 +17,7 @@ const trainSchedulesJson = readJsonFile<TrainSchedule[]>(
 test.describe('Verify osrd nge conversion', () => {
   test.use({ viewport: { width: 1920, height: 1080 } });
 
-  let scenarioTimetableSection: ScenarioTimetableSection;
-  let simulationResultPage: OpSimulationResultPage;
+  let ngePage: NGEPage;
 
   let project: Project;
   let study: Study;
@@ -33,10 +31,7 @@ test.describe('Verify osrd nge conversion', () => {
   });
 
   test.beforeEach('Open scenario and enable only macro view ', async ({ page }) => {
-    [simulationResultPage, scenarioTimetableSection] = [
-      new OpSimulationResultPage(page),
-      new ScenarioTimetableSection(page),
-    ];
+    ngePage = new NGEPage(page);
     await test.step('Create, open scenario and wait for infra to be loaded', async () => {
       scenarioItems = (
         await createScenario(generateUniqueName('nge-scenario'), project.id, study.id, infra.id)
@@ -46,20 +41,57 @@ test.describe('Verify osrd nge conversion', () => {
       await page.goto(
         `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenarioItems.id}`
       );
-      await scenarioTimetableSection.removeViteOverlay();
+      await ngePage.removeViteOverlay();
       await waitForInfraStateToBeCached(infra.id);
     });
     await test.step('Enable macro view while keeping the default train list visible', async () => {
-      await simulationResultPage.toggleStd();
-      await simulationResultPage.toggleMap();
-      await simulationResultPage.toggleSdd();
-      await simulationResultPage.toggleTableOutput();
-      await simulationResultPage.toggleMacro(false);
-      await simulationResultPage.waitForLoaderToDisappear();
+      await ngePage.enableMacroViewWithDefaultTrainList();
     });
   });
 
   test.afterEach('Delete the created scenario', async () => {
     await deleteScenario(project.id, study.id, scenarioItems.name);
+  });
+
+  test('Verify NGE train data', async () => {
+    await test.step('Verify nodes displayed on NGE graph', async () => {
+      await ngePage.expectNodes(['SWS/BV', 'MWS/BV', 'MES/BV']);
+    });
+
+    await test.step('Verify train rows labels', async () => {
+      await ngePage.expectTrainLineLabels(0, ['30', '52', "22'", 'Train5']);
+      await ngePage.expectTrainLineLabels(1, ['52', '?', '?', 'Train5']);
+    });
+
+    await test.step('Open first train and verify all details (stations, tags, and one-way tab)', async () => {
+      await test.step('Open first train details dialog and verify header name is Train5', async () => {
+        await ngePage.openTrainDetailsFromLine(0);
+        await ngePage.expectDialogHeaderTrainName('Train5');
+      });
+
+      await test.step('Verify stations tab shows Mid_West_station and South_West_station', async () => {
+        await ngePage.expectStationsTabShows(['Mid_West_station', 'South_West_station']);
+      });
+
+      await test.step('Verify tags tab lists Tag-5 and SWE-MES', async () => {
+        await ngePage.openTagsTabAndExpect(['Tag-5', 'SWE-MES']);
+      });
+
+      await test.step('Verify one-way tab shows SWS/BV (South_West_station) → MES/BV (Mid_East_station)', async () => {
+        const oneWayRegex =
+          /SWS\/BV\s*\(South_West_station\)[\s\S]*?30[\s\S]*?MES\/BV\s*\(Mid_East_station\)/i;
+        await ngePage.openOneWayTabAndExpect(oneWayRegex);
+      });
+
+      await test.step('Close train details dialog if visible', async () => {
+        await ngePage.closeDetailsDialogIfVisible();
+      });
+    });
+
+    await test.step('Open second train details and verify stations', async () => {
+      await ngePage.openTrainDetailsFromLine(1);
+      await ngePage.expectDialogHeaderTrainName('Train5');
+      await ngePage.expectStationsTabShows(['Mid_East_station', 'Mid_West_station']);
+    });
   });
 });

--- a/front/tests/023-osrd-nge.spec.ts
+++ b/front/tests/023-osrd-nge.spec.ts
@@ -1,0 +1,65 @@
+import type { Scenario, Project, Study, Infra, TrainSchedule } from 'common/api/osrdEditoastApi';
+
+import { timetableItemProjectName, timetableItemStudyName } from './assets/constants/project-const';
+import test from './logging-fixture';
+import ScenarioTimetableSection from './pages/operational-studies/scenario-timetable-section';
+import OpSimulationResultPage from './pages/operational-studies/simulation-results-page';
+import { generateUniqueName, waitForInfraStateToBeCached } from './utils';
+import { getInfra, getProject, getStudy } from './utils/api-utils';
+import readJsonFile from './utils/file-utils';
+import createScenario from './utils/scenario';
+import { deleteScenario } from './utils/teardown-utils';
+import sendTrainSchedules from './utils/train-schedule';
+
+const trainSchedulesJson = readJsonFile<TrainSchedule[]>(
+  './tests/assets/train-schedule/train_schedules.json'
+);
+
+test.describe('Verify osrd nge conversion', () => {
+  test.use({ viewport: { width: 1920, height: 1080 } });
+
+  let scenarioTimetableSection: ScenarioTimetableSection;
+  let simulationResultPage: OpSimulationResultPage;
+
+  let project: Project;
+  let study: Study;
+  let scenarioItems: Scenario;
+  let infra: Infra;
+
+  test.beforeAll('Fetch project, study and infrastructure', async () => {
+    project = await getProject(timetableItemProjectName);
+    study = await getStudy(project.id, timetableItemStudyName);
+    infra = await getInfra();
+  });
+
+  test.beforeEach('Open scenario and enable only macro view ', async ({ page }) => {
+    [simulationResultPage, scenarioTimetableSection] = [
+      new OpSimulationResultPage(page),
+      new ScenarioTimetableSection(page),
+    ];
+    await test.step('Create, open scenario and wait for infra to be loaded', async () => {
+      scenarioItems = (
+        await createScenario(generateUniqueName('nge-scenario'), project.id, study.id, infra.id)
+      ).scenario;
+
+      await sendTrainSchedules(scenarioItems.timetable_id, trainSchedulesJson.slice(4, 5));
+      await page.goto(
+        `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenarioItems.id}`
+      );
+      await scenarioTimetableSection.removeViteOverlay();
+      await waitForInfraStateToBeCached(infra.id);
+    });
+    await test.step('Enable macro view while keeping the default train list visible', async () => {
+      await simulationResultPage.toggleStd();
+      await simulationResultPage.toggleMap();
+      await simulationResultPage.toggleSdd();
+      await simulationResultPage.toggleTableOutput();
+      await simulationResultPage.toggleMacro(false);
+      await simulationResultPage.waitForLoaderToDisappear();
+    });
+  });
+
+  test.afterEach('Delete the created scenario', async () => {
+    await deleteScenario(project.id, study.id, scenarioItems.name);
+  });
+});

--- a/front/tests/024-nge-osrd.spec.ts
+++ b/front/tests/024-nge-osrd.spec.ts
@@ -1,0 +1,115 @@
+import { expect } from '@playwright/test';
+
+import type { Scenario, Project, Study, Infra } from 'common/api/osrdEditoastApi';
+
+import { timetableItemProjectName, timetableItemStudyName } from './assets/constants/project-const';
+import test from './logging-fixture';
+import NGEPage from './pages/operational-studies/nge-page';
+import RoundTripPage from './pages/operational-studies/round-trips-page';
+import ScenarioTimetableSection from './pages/operational-studies/scenario-timetable-section';
+import { generateUniqueName, waitForInfraStateToBeCached } from './utils';
+import { getInfra, getProject, getStudy } from './utils/api-utils';
+import readJsonFile from './utils/file-utils';
+import createScenario from './utils/scenario';
+import { deleteScenario } from './utils/teardown-utils';
+import type { CommonTranslations, TimetableFilterTranslations } from './utils/types';
+
+const frScenarioTranslations: TimetableFilterTranslations = readJsonFile<{
+  main: TimetableFilterTranslations;
+}>('public/locales/fr/operational-studies.json').main;
+
+const frCommonTranslations: CommonTranslations = readJsonFile('public/locales/fr/translation.json');
+const frTranslations = {
+  ...frScenarioTranslations,
+  ...frCommonTranslations,
+};
+
+test.describe('Verify nge osrd conversion', () => {
+  test.use({ viewport: { width: 1920, height: 1080 } });
+  test.use({ ignorePageErrors: true });
+
+  let ngePage: NGEPage;
+  let scenarioTimetableSection: ScenarioTimetableSection;
+  let roundTripPage: RoundTripPage;
+
+  let project: Project;
+  let study: Study;
+  let scenarioItems: Scenario;
+  let infra: Infra;
+
+  test.beforeAll('Fetch project, study and infrastructure', async () => {
+    project = await getProject(timetableItemProjectName);
+    study = await getStudy(project.id, timetableItemStudyName);
+    infra = await getInfra();
+  });
+
+  test.beforeEach('Open scenario and enable only macro view ', async ({ page }) => {
+    ngePage = new NGEPage(page);
+    scenarioTimetableSection = new ScenarioTimetableSection(page);
+    roundTripPage = new RoundTripPage(page);
+
+    await test.step('Create, open scenario and wait for infra to be loaded', async () => {
+      scenarioItems = (
+        await createScenario(generateUniqueName('nge-scenario'), project.id, study.id, infra.id)
+      ).scenario;
+      await page.goto(
+        `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenarioItems.id}`
+      );
+      await ngePage.removeViteOverlay();
+      await waitForInfraStateToBeCached(infra.id);
+    });
+
+    await test.step('Enable macro view while keeping the default train list visible', async () => {
+      await ngePage.enableMacroViewWithDefaultTrainList();
+    });
+  });
+
+  test.afterEach('Delete the created scenario', async () => {
+    await deleteScenario(project.id, study.id, scenarioItems.name);
+  });
+
+  test('Add a train from nge', async () => {
+    await test.step('Create three nodes', async () => {
+      await ngePage.createNode({ x: 50, y: 400 }, 'NWS', 'Origin');
+      await expect(ngePage.nodeCards).toHaveCount(1);
+
+      await ngePage.createNode({ x: 250, y: 400 }, 'MWS', 'OP');
+      await expect(ngePage.nodeCards).toHaveCount(2);
+
+      await ngePage.createNode({ x: 450, y: 400 }, 'SS', 'Destination');
+      await expect(ngePage.nodeCards).toHaveCount(3);
+    });
+
+    await test.step('Connect Origin → OP and create Train1', async () => {
+      await ngePage.connectNodesByIndex(0, 1);
+      await expect(ngePage.trainDetailsGroup).toBeVisible();
+      await ngePage.setTrainBasics({ name: 'Train1', isFrequency30: true });
+      await ngePage.closeDetailsDialogIfVisible();
+      await expect(ngePage.trainDetailsGroup).toBeHidden();
+      await expect(ngePage.trainLines).toHaveCount(1);
+    });
+
+    await test.step('Connect OP → Destination', async () => {
+      await ngePage.connectNodesByIndex(1, 2);
+      await expect(ngePage.trainDetailsGroup).toBeHidden();
+      await expect(ngePage.trainLines).toHaveCount(2);
+    });
+
+    await test.step('Validate timetable list and round-trip modal', async () => {
+      await scenarioTimetableSection.verifyTotalItemsLabel(frTranslations, {
+        totalPacedTrainCount: 2,
+        totalTrainScheduleCount: 0,
+      });
+      await expect(scenarioTimetableSection.getItemInvalidReason()).toBeVisible();
+      const invalidReason = await scenarioTimetableSection.getItemInvalidReason().innerText();
+      expect(invalidReason).toBe(frTranslations.timetable.invalid.rolling_stock_not_found);
+
+      await roundTripPage.openRoundTripModal();
+      await roundTripPage.assertRoundTripColumnCounts({
+        expectedToDoCount: 0,
+        expectedOneWayCount: 0,
+        expectedRoundTripCount: 1,
+      });
+    });
+  });
+});

--- a/front/tests/logging-fixture.ts
+++ b/front/tests/logging-fixture.ts
@@ -9,8 +9,9 @@ export const logger = {
 };
 
 // Extend baseTest with logging inside the test hooks
-const testWithLogging = baseTest.extend<{ page: Page }>({
-  page: async ({ page, browserName }, use, testInfo) => {
+const testWithLogging = baseTest.extend<{ page: Page; ignorePageErrors: boolean }>({
+  ignorePageErrors: [false, { option: true }],
+  page: async ({ page, browserName, ignorePageErrors }, use, testInfo) => {
     const startTime = Date.now(); // Record the start time
 
     // Log before the test starts
@@ -25,12 +26,14 @@ const testWithLogging = baseTest.extend<{ page: Page }>({
     });
 
     // Handle uncaught exceptions
-    page.on('pageerror', (exception) => {
-      logger.error('🚨Uncaught page error:', exception);
-      throw new Error(
-        `Test failed due to uncaught exception:\n${exception.message}\n${exception.stack}`
-      );
-    });
+    if (!ignorePageErrors) {
+      page.on('pageerror', (exception) => {
+        logger.error('🚨Uncaught page error:', exception);
+        throw new Error(
+          `Test failed due to uncaught exception:\n${exception.message}\n${exception.stack}`
+        );
+      });
+    }
 
     // Run the actual test
     await use(page);

--- a/front/tests/pages/common-page.ts
+++ b/front/tests/pages/common-page.ts
@@ -87,10 +87,10 @@ class CommonPage {
     await expect(this.navigationBackButton).toBeVisible();
   }
 
-  async waitForLoaderToDisappear() {
+  async waitForLoaderToDisappear({ timeout }: { timeout?: number } = {}): Promise<void> {
     const count = await this.loader.count();
     if (count > 0) {
-      await expect(this.loader).not.toBeVisible({ timeout: 120000 });
+      await expect(this.loader).not.toBeVisible({ timeout });
     }
   }
 }

--- a/front/tests/pages/common-page.ts
+++ b/front/tests/pages/common-page.ts
@@ -90,7 +90,7 @@ class CommonPage {
   async waitForLoaderToDisappear() {
     const count = await this.loader.count();
     if (count > 0) {
-      await expect(this.loader).not.toBeVisible();
+      await expect(this.loader).not.toBeVisible({ timeout: 120000 });
     }
   }
 }

--- a/front/tests/pages/operational-studies/nge-page.ts
+++ b/front/tests/pages/operational-studies/nge-page.ts
@@ -13,6 +13,7 @@ class NGEPage extends OpSimulationResultPage {
   private readonly ngeFrame;
   private readonly nodeCards: Locator;
   private readonly nodeTexts: Locator;
+  private readonly trainLines: Locator;
   private readonly trainLabelRows: Locator;
   private readonly trainDetailTabs: Locator;
   private readonly activeTabPanel: Locator;
@@ -32,17 +33,18 @@ class NGEPage extends OpSimulationResultPage {
     this.ngeFrame = page.frameLocator('iframe[title="NGE"]');
     this.nodeCards = this.ngeFrame.locator('.root_container_nodes');
     this.nodeTexts = this.nodeCards.locator('.node_text');
+    this.trainLines = this.ngeFrame.locator('.edge.Lines');
     this.trainLabelRows = this.ngeFrame.locator('.edge.Labels');
     this.trainDetailTabs = this.ngeFrame.getByRole('tab');
     this.activeTabPanel = this.ngeFrame.getByRole('tabpanel');
     this.trainDetailsGroup = this.ngeFrame.locator('.TrainrunTabGrupe');
     this.oneWayCardMuted = this.ngeFrame.locator('.OneWayCard.muted');
     this.oneWayCardSelected = this.ngeFrame.locator('.OneWayCard.selected');
-    this.nodeSummaryTitle = this.dialog.locator('.SummaryTitle');
-    this.deleteNodeButton = this.dialog.locator(
+    this.nodeSummaryTitle = this.ngeFrame.locator('.SummaryTitle');
+    this.deleteNodeButton = this.ngeFrame.locator(
       'button[sbb-secondary-button][svgicon="trash-small"]'
     );
-    this.confirmDeleteButton = this.dialog.locator(
+    this.confirmDeleteButton = this.ngeFrame.locator(
       'button.sbb-button[tabindex="0"][type="button"]'
     );
     this.closeDialogButton = this.ngeFrame.getByRole('img', { name: 'Close Dialog' });
@@ -135,6 +137,31 @@ class NGEPage extends OpSimulationResultPage {
   async closeDetailsDialogIfVisible() {
     const visible = await this.trainDetailsGroup.isVisible().catch(() => false);
     if (visible) await this.closeDialogButton.click();
+  }
+
+  async verifyNodeAndLinesCount(expected: { nodes: number; lines: number }) {
+    await expect(this.nodeCards).toHaveCount(expected.nodes);
+    await expect(this.trainLines).toHaveCount(expected.lines);
+  }
+
+  async deleteNodeByIndexViaDialog(index: number, expected: { nodes: number; lines: number }) {
+    await this.nodeTexts.nth(index).dblclick();
+    await expect(this.nodeSummaryTitle).toBeVisible();
+
+    await expect(this.deleteNodeButton).toBeEnabled();
+    await this.deleteNodeButton.click();
+
+    await expect(this.confirmDeleteButton).toBeEnabled();
+    await this.confirmDeleteButton.click();
+
+    await this.verifyNodeAndLinesCount(expected);
+  }
+
+  async deleteFocusedNodeWithKeyboard(expected: { nodes: number; lines: number }) {
+    await this.nodeTexts.first().hover();
+    await this.page.keyboard.press('Delete');
+
+    await this.verifyNodeAndLinesCount(expected);
   }
 }
 

--- a/front/tests/pages/operational-studies/nge-page.ts
+++ b/front/tests/pages/operational-studies/nge-page.ts
@@ -1,0 +1,141 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+
+import OpSimulationResultPage from './simulation-results-page';
+
+enum TrainTabs {
+  Overview = 0,
+  Stations = 1,
+  Tags = 2,
+  OneWay = 3,
+}
+
+class NGEPage extends OpSimulationResultPage {
+  private readonly ngeFrame;
+  private readonly nodeCards: Locator;
+  private readonly nodeTexts: Locator;
+  private readonly trainLabelRows: Locator;
+  private readonly trainDetailTabs: Locator;
+  private readonly activeTabPanel: Locator;
+  private readonly trainDetailsGroup: Locator;
+  private readonly oneWayCardMuted: Locator;
+  private readonly oneWayCardSelected: Locator;
+  private readonly nodeSummaryTitle: Locator;
+  private readonly deleteNodeButton: Locator;
+  private readonly confirmDeleteButton: Locator;
+  private readonly closeDialogButton: Locator;
+
+  private readonly stationLeftArrow: Locator;
+  private readonly stationRightArrow: Locator;
+  constructor(page: Page) {
+    super(page);
+
+    this.ngeFrame = page.frameLocator('iframe[title="NGE"]');
+    this.nodeCards = this.ngeFrame.locator('.root_container_nodes');
+    this.nodeTexts = this.nodeCards.locator('.node_text');
+    this.trainLabelRows = this.ngeFrame.locator('.edge.Labels');
+    this.trainDetailTabs = this.ngeFrame.getByRole('tab');
+    this.activeTabPanel = this.ngeFrame.getByRole('tabpanel');
+    this.trainDetailsGroup = this.ngeFrame.locator('.TrainrunTabGrupe');
+    this.oneWayCardMuted = this.ngeFrame.locator('.OneWayCard.muted');
+    this.oneWayCardSelected = this.ngeFrame.locator('.OneWayCard.selected');
+    this.nodeSummaryTitle = this.dialog.locator('.SummaryTitle');
+    this.deleteNodeButton = this.dialog.locator(
+      'button[sbb-secondary-button][svgicon="trash-small"]'
+    );
+    this.confirmDeleteButton = this.dialog.locator(
+      'button.sbb-button[tabindex="0"][type="button"]'
+    );
+    this.closeDialogButton = this.ngeFrame.getByRole('img', { name: 'Close Dialog' });
+    this.stationLeftArrow = this.ngeFrame.locator('[data-sbb-icon-name="arrow-left-medium"]');
+    this.stationRightArrow = this.ngeFrame.locator('[data-sbb-icon-name="arrow-right-medium"]');
+  }
+
+  private getNodeNameByIndex(index: number): Locator {
+    return this.nodeTexts.nth(index);
+  }
+
+  private getTrainLabel(lineIndex: number, labelIndex: number): Locator {
+    return this.trainLabelRows.nth(lineIndex).locator('.edge_text').nth(labelIndex);
+  }
+
+  async toggleTopologyEditor() {
+    await this.topologyEditorToggle.click();
+  }
+
+  async clickGraphAt(position: { x: number; y: number }) {
+    await this.graphContainer.click({ position });
+  }
+
+  async fillNodeDetails(trigram: string, name: string) {
+    await this.textInputs.first().fill(trigram);
+    await this.textInputs.nth(1).fill(name);
+  }
+
+  async closeAside() {
+    await this.closeAsideButton.click();
+  }
+
+  async expectNodes([origin, op, destination]: [string, string, string]) {
+    await expect(this.nodeCards).toHaveCount(3);
+    await expect(this.getNodeNameByIndex(0)).toHaveText(origin);
+    await expect(this.getNodeNameByIndex(1)).toHaveText(op);
+    await expect(this.getNodeNameByIndex(2)).toHaveText(destination);
+  }
+
+  async expectTrainLineLabels(lineIndex: number, expected: string[]) {
+    for (let labelIndex = 0; labelIndex < expected.length; labelIndex++) {
+      await expect(this.getTrainLabel(lineIndex, labelIndex)).toHaveText(expected[labelIndex]);
+    }
+  }
+
+  async openTrainDetailsFromLine(rowIndex: number) {
+    await this.getTrainLabel(rowIndex, 3).click();
+    await expect(this.trainDetailsGroup).toBeVisible();
+    await expect(this.trainDetailTabs).toHaveCount(4);
+  }
+
+  async expectDialogHeaderTrainName(name: string) {
+    await expect(this.trainDetailTabs.nth(TrainTabs.Overview)).toHaveText(name);
+  }
+
+  async expectStationsTabShows([leftStation, rightStation]: [string, string]) {
+    const stationsTab = this.trainDetailTabs.nth(TrainTabs.Stations);
+    const stationSpans = stationsTab.locator('span');
+
+    await expect(stationSpans).toHaveCount(2);
+
+    const hasLeftArrow = await this.stationLeftArrow.isVisible().catch(() => false);
+    const hasRightArrow = await this.stationRightArrow.isVisible().catch(() => false);
+
+    if (hasLeftArrow) {
+      await expect(stationSpans.nth(0)).toHaveText(leftStation);
+      await expect(this.stationLeftArrow).toBeVisible();
+      await expect(stationSpans.nth(1)).toHaveText(rightStation);
+    } else if (hasRightArrow) {
+      await expect(stationSpans.nth(0)).toHaveText(rightStation);
+      await expect(this.stationRightArrow).toBeVisible();
+      await expect(stationSpans.nth(1)).toHaveText(leftStation);
+    }
+  }
+
+  async openTagsTabAndExpect(tags: string[]) {
+    await this.trainDetailTabs.nth(TrainTabs.Tags).click();
+    const listbox = this.activeTabPanel.getByRole('listbox');
+    const options = listbox.getByRole('option');
+    await expect(listbox).toBeVisible();
+    await expect(options).toHaveText(tags);
+  }
+
+  async openOneWayTabAndExpect(regex: RegExp) {
+    await this.trainDetailTabs.nth(TrainTabs.OneWay).click();
+    await expect(this.oneWayCardMuted).toContainText(regex);
+    await expect(this.oneWayCardSelected).toContainText(regex);
+  }
+
+  async closeDetailsDialogIfVisible() {
+    const visible = await this.trainDetailsGroup.isVisible().catch(() => false);
+    if (visible) await this.closeDialogButton.click();
+  }
+}
+
+export default NGEPage;

--- a/front/tests/pages/operational-studies/nge-page.ts
+++ b/front/tests/pages/operational-studies/nge-page.ts
@@ -11,20 +11,25 @@ enum TrainTabs {
 
 class NGEPage extends OpSimulationResultPage {
   private readonly ngeFrame;
-  private readonly nodeCards: Locator;
+  readonly nodeCards: Locator;
   private readonly nodeTexts: Locator;
-  private readonly trainLines: Locator;
+  readonly trainLines: Locator;
   private readonly trainLabelRows: Locator;
   private readonly trainDetailTabs: Locator;
   private readonly activeTabPanel: Locator;
-  private readonly trainDetailsGroup: Locator;
+  readonly trainDetailsGroup: Locator;
   private readonly oneWayCardMuted: Locator;
   private readonly oneWayCardSelected: Locator;
   private readonly nodeSummaryTitle: Locator;
   private readonly deleteNodeButton: Locator;
   private readonly confirmDeleteButton: Locator;
   private readonly closeDialogButton: Locator;
-
+  private readonly topologyEditorToggle: Locator;
+  private readonly graphContainer: Locator;
+  private readonly textInputs: Locator;
+  private readonly closeAsideButton: Locator;
+  private readonly trainTitleField: Locator;
+  private readonly frequency30Btn: Locator;
   private readonly stationLeftArrow: Locator;
   private readonly stationRightArrow: Locator;
   constructor(page: Page) {
@@ -48,6 +53,13 @@ class NGEPage extends OpSimulationResultPage {
       'button.sbb-button[tabindex="0"][type="button"]'
     );
     this.closeDialogButton = this.ngeFrame.getByRole('img', { name: 'Close Dialog' });
+    this.topologyEditorToggle = this.ngeFrame.locator('.ButtonTopologieEditor.NetzgrafikEditing');
+    this.graphContainer = this.ngeFrame.locator('#graphContainer');
+    this.textInputs = this.ngeFrame.locator('.sbb-input-element');
+    this.closeAsideButton = this.ngeFrame.locator('#cd-layout-close-aside');
+
+    this.trainTitleField = this.ngeFrame.locator('#trainrunTitleField');
+    this.frequency30Btn = this.ngeFrame.locator('.Frequency.Frequency_30');
     this.stationLeftArrow = this.ngeFrame.locator('[data-sbb-icon-name="arrow-left-medium"]');
     this.stationRightArrow = this.ngeFrame.locator('[data-sbb-icon-name="arrow-right-medium"]');
   }
@@ -162,6 +174,36 @@ class NGEPage extends OpSimulationResultPage {
     await this.page.keyboard.press('Delete');
 
     await this.verifyNodeAndLinesCount(expected);
+  }
+
+  async connectNodesByIndex(fromIndex: number, toIndex: number) {
+    const from = this.nodeCards.nth(fromIndex);
+    const to = this.nodeCards.nth(toIndex);
+
+    await Promise.all([expect(from).toBeVisible(), expect(to).toBeVisible()]);
+
+    const fromBox = await from.boundingBox();
+    const toBox = await to.boundingBox();
+    if (!fromBox || !toBox) throw new Error('Element not visible on screen');
+
+    await this.page.mouse.move(fromBox.x + fromBox.width / 2, fromBox.y + fromBox.height / 2);
+    await this.page.mouse.down();
+    await this.page.mouse.move(toBox.x + toBox.width / 2, toBox.y + toBox.height / 2, {
+      steps: 15,
+    });
+    await this.page.mouse.up();
+  }
+
+  async createNode(position: { x: number; y: number }, trigram: string, name: string) {
+    await this.toggleTopologyEditor();
+    await this.clickGraphAt(position);
+    await this.fillNodeDetails(trigram, name);
+    await this.closeAside();
+  }
+
+  async setTrainBasics({ name, isFrequency30 }: { name: string; isFrequency30?: boolean }) {
+    await this.trainTitleField.fill(name);
+    if (isFrequency30) await this.frequency30Btn.click();
   }
 }
 

--- a/front/tests/pages/operational-studies/scenario-page.ts
+++ b/front/tests/pages/operational-studies/scenario-page.ts
@@ -34,15 +34,21 @@ class ScenarioPage extends CommonPage {
 
   private readonly scenarioTagsLabel: Locator;
 
-  private readonly conflictsButton: Locator;
-
-  private readonly conflictsList: Locator;
-
-  private readonly trainsButton: Locator;
-
-  private readonly trainList: Locator;
-
   private readonly scenarioConfirmDeleteButton: Locator;
+
+  readonly conflictsButton: Locator;
+
+  readonly trainsButton: Locator;
+
+  readonly simulationMapButton: Locator;
+
+  readonly timeStopsOutputsButton: Locator;
+
+  readonly macroEditorButton: Locator;
+
+  readonly stdButton: Locator;
+
+  readonly sddButton: Locator;
 
   constructor(readonly page: Page) {
     super(page);
@@ -62,11 +68,14 @@ class ScenarioPage extends CommonPage {
     this.scenarioConfirmUpdateButton = this.scenarioEditionModal.getByTestId('update-scenario');
     this.createScenarioButton = page.getByTestId('create-scenario');
     this.scenarioTagsLabel = page.getByTestId('scenario-details-tag');
-    this.conflictsButton = page.getByTestId('conflicts-button');
-    this.conflictsList = page.getByTestId('conflicts-list');
-    this.trainsButton = page.getByTestId('trains-button');
-    this.trainList = page.getByTestId('scenario-left-column');
     this.scenarioConfirmDeleteButton = page.getByTestId('confirm-delete-button');
+    this.conflictsButton = page.getByTestId('conflicts-button');
+    this.trainsButton = page.getByTestId('trains-button');
+    this.simulationMapButton = page.getByTestId('map-button');
+    this.timeStopsOutputsButton = page.getByTestId('tables-button');
+    this.macroEditorButton = page.getByTestId('macro-button');
+    this.stdButton = page.getByTestId('std-button');
+    this.sddButton = page.getByTestId('sdd-button');
   }
 
   // Create a scenario based on the provided details.
@@ -140,24 +149,6 @@ class ScenarioPage extends CommonPage {
     expect(await this.scenarioInfraName.textContent()).toContain(infraName);
     if (tags) {
       expect(await this.scenarioTagsLabel.textContent()).toContain(tags.join(''));
-    }
-  }
-
-  async toggleConflictsList(isOpen: boolean = false) {
-    await this.conflictsButton.click();
-    if (isOpen) {
-      await expect(this.conflictsList).not.toBeVisible();
-    } else {
-      await expect(this.conflictsList).toBeVisible();
-    }
-  }
-
-  async toggleTrainList(isOpen: boolean = true) {
-    await this.trainsButton.click();
-    if (isOpen) {
-      await expect(this.trainList).not.toBeVisible();
-    } else {
-      await expect(this.trainList).toBeVisible();
     }
   }
 

--- a/front/tests/pages/operational-studies/scenario-timetable-section.ts
+++ b/front/tests/pages/operational-studies/scenario-timetable-section.ts
@@ -64,6 +64,8 @@ class ScenarioTimetableSection extends OpSimulationResultPage {
 
   private readonly projectItemButton: Locator;
 
+  private readonly deleteItemButton: Locator;
+
   readonly editTimetableItemButton: Locator;
 
   private readonly timetableItemArrivalTime: Locator;
@@ -106,6 +108,7 @@ class ScenarioTimetableSection extends OpSimulationResultPage {
     );
     this.editItemButton = page.getByTestId('edit-item');
     this.projectItemButton = page.getByTestId('project-item');
+    this.deleteItemButton = page.getByTestId('delete-item');
     this.editTimetableItemButton = page.getByTestId('submit-edit-timetable-item');
     this.timetableItemArrivalTime = page.getByTestId('timetable-item-arrival-time');
     this.timetableItemArrivalTimeLoader = page.getByTestId('arrival-time-loader');
@@ -121,6 +124,10 @@ class ScenarioTimetableSection extends OpSimulationResultPage {
 
   static getOccurrences(pacedTrain: Locator): Locator {
     return pacedTrain.getByTestId('occurrence-item');
+  }
+
+  getItemInvalidlyReason(itemIndex = 0): Locator {
+    return this.timetableItems.nth(itemIndex).getByTestId('invalidity-reason');
   }
 
   async verifyInvalidTrainsMessageVisibility(): Promise<void> {
@@ -346,6 +353,12 @@ class ScenarioTimetableSection extends OpSimulationResultPage {
     await expect(this.timetableItems.nth(index)).toBeVisible();
     await this.timetableItems.nth(index).click();
     await this.editItemButton.nth(index).click();
+  }
+
+  async deleteTimetableItem(index = 0) {
+    await expect(this.timetableItems.nth(index)).toBeVisible();
+    await this.timetableItems.nth(index).click();
+    await this.deleteItemButton.nth(index).click();
   }
 
   async projectTrain(index = 0) {

--- a/front/tests/pages/operational-studies/scenario-timetable-section.ts
+++ b/front/tests/pages/operational-studies/scenario-timetable-section.ts
@@ -126,8 +126,8 @@ class ScenarioTimetableSection extends OpSimulationResultPage {
     return pacedTrain.getByTestId('occurrence-item');
   }
 
-  getItemInvalidlyReason(itemIndex = 0): Locator {
-    return this.timetableItems.nth(itemIndex).getByTestId('invalidity-reason');
+  getItemInvalidReason(itemIndex = 0): Locator {
+    return this.timetableItems.nth(itemIndex).getByTestId('invalid-reason');
   }
 
   async verifyInvalidTrainsMessageVisibility(): Promise<void> {

--- a/front/tests/pages/operational-studies/simulation-results-page.ts
+++ b/front/tests/pages/operational-studies/simulation-results-page.ts
@@ -119,7 +119,7 @@ class OpSimulationResultPage extends ScenarioPage {
     await this.setSddVisible();
     await this.setTableOutputVisible();
     await this.setMacroVisible();
-    await this.waitForLoaderToDisappear();
+    await this.waitForLoaderToDisappear({ timeout: 15_000 });
   }
 }
 

--- a/front/tests/pages/operational-studies/simulation-results-page.ts
+++ b/front/tests/pages/operational-studies/simulation-results-page.ts
@@ -1,8 +1,9 @@
 import { expect, type Locator, type Page } from '@playwright/test';
 
-import CommonPage from '../common-page';
+import ScenarioPage from './scenario-page';
+import { toggleByState } from '../../utils';
 
-class OpSimulationResultPage extends CommonPage {
+class OpSimulationResultPage extends ScenarioPage {
   readonly simulationResults: Locator;
 
   private readonly speedSpaceChartSettingsButton: Locator;
@@ -21,6 +22,14 @@ class OpSimulationResultPage extends CommonPage {
 
   private readonly simulationMap: Locator;
 
+  private readonly trainList: Locator;
+
+  private readonly timeStopsOutputs: Locator;
+
+  private readonly macroEditor: Locator;
+
+  private readonly conflictsList: Locator;
+
   constructor(page: Page) {
     super(page);
     this.simulationResults = page.getByTestId('simulation-results');
@@ -32,6 +41,11 @@ class OpSimulationResultPage extends CommonPage {
     this.speedSpaceChartSettingsButton = page.getByTestId('interaction-settings');
     this.speedSpaceChartCloseSettingsButton = page.getByTestId('settings-panel-close');
     this.speedSpaceChartCheckboxItems = page.locator('#settings-panel .selection .checkmark');
+    this.conflictsList = page.getByTestId('conflicts-list');
+    this.trainList = page.getByTestId('scenario-left-column');
+    this.simulationMap = page.getByTestId('simulation-map');
+    this.timeStopsOutputs = page.getByTestId('time-stop-outputs');
+    this.macroEditor = page.getByTestId('macro-editor');
   }
 
   private async openSettingsPanel(): Promise<void> {
@@ -65,6 +79,47 @@ class OpSimulationResultPage extends CommonPage {
     await Promise.all(checkboxes.map((checkbox) => checkbox.setChecked(true, { force: true })));
     await this.closeSettingsPanel();
     await this.speedSpaceChartSettingsButton.hover(); // Hover over the element to prevent the tooltip from displaying
+  }
+
+  async setConflictsListVisible(isVisible = false) {
+    await toggleByState(this.conflictsButton, this.conflictsList, isVisible);
+  }
+
+  async setTrainListVisible(isVisible = true) {
+    await toggleByState(this.trainsButton, this.trainList, isVisible);
+  }
+
+  async setStdVisible(isVisible = true) {
+    await toggleByState(
+      this.stdButton,
+      [this.spaceTimeChart, this.manchetteSpaceTimeChart],
+      isVisible
+    );
+  }
+
+  async setSddVisible(isVisible = true) {
+    await toggleByState(this.sddButton, this.speedSpaceChart, isVisible);
+  }
+
+  async setMapVisible(isVisible = true) {
+    await toggleByState(this.simulationMapButton, this.simulationMap, isVisible);
+  }
+
+  async setTableOutputVisible(isVisible = true) {
+    await toggleByState(this.timeStopsOutputsButton, this.timeStopsOutputs, isVisible);
+  }
+
+  async setMacroVisible(isVisible = false) {
+    await toggleByState(this.macroEditorButton, this.macroEditor, isVisible);
+  }
+
+  async enableMacroViewWithDefaultTrainList(): Promise<void> {
+    await this.setStdVisible();
+    await this.setMapVisible();
+    await this.setSddVisible();
+    await this.setTableOutputVisible();
+    await this.setMacroVisible();
+    await this.waitForLoaderToDisappear();
   }
 }
 

--- a/front/tests/utils/index.ts
+++ b/front/tests/utils/index.ts
@@ -134,3 +134,25 @@ export async function isGreyed(locator: Locator): Promise<boolean> {
 export async function isOverflowing(locator: Locator): Promise<boolean> {
   return locator.evaluate((el) => el.scrollHeight > el.clientHeight);
 }
+
+/**
+ * Generic toggle helper for visibility-based UI components.
+ * @param button - The locator of the toggle button to click.
+ * @param targetLocators - One or multiple locators whose visibility changes when toggled.
+ * @param isOpen - Whether the panel is currently open (true) or closed (false).
+ */
+export async function toggleByState(
+  button: Locator,
+  targetLocators: Locator | Locator[],
+  isOpen: boolean
+): Promise<void> {
+  const list = Array.isArray(targetLocators) ? targetLocators : [targetLocators];
+
+  await button.click();
+
+  const assertFn = isOpen
+    ? (t: Locator) => expect(t).toBeHidden()
+    : (t: Locator) => expect(t).toBeVisible();
+
+  await Promise.all(list.map(assertFn));
+}

--- a/front/tests/utils/types.ts
+++ b/front/tests/utils/types.ts
@@ -344,6 +344,7 @@ export type TimetableFilterTranslations = FlatTranslations & {
   timetable: FlatTranslations & {
     occurrenceType: FlatTranslations;
     occurrenceChangeGroup: FlatTranslations;
+    invalid: FlatTranslations;
   };
   occurrenceMenu: FlatTranslations;
 };


### PR DESCRIPTION
closes #13268

This PR is ready for review by commit.
The locators in `nge-page `will be updated in a separate commit, as a dedicated PR is currently in progress in NGE to add` data-testid` attributes : https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/pull/574