### PR TITLE
editoast: status code 201 for creation endpoints continuation

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -4083,7 +4083,7 @@ paths:
                   format: int64
         required: true
       responses:
-        '201':
+        '200':
           description: The simulation result
           content:
             application/json:
@@ -4815,7 +4815,7 @@ paths:
       tags:
       - work_schedules
       responses:
-        '201':
+        '200':
           description: The existing work schedule group ids
           content:
             application/json:
@@ -4978,7 +4978,7 @@ paths:
                   format: int64
         required: true
       responses:
-        '201':
+        '200':
           description: Returns a list of work schedules whose track ranges intersect the given path
           content:
             application/json:

--- a/editoast/src/views/infra/railjson.rs
+++ b/editoast/src/views/infra/railjson.rs
@@ -173,7 +173,7 @@ pub(in crate::views) async fn post_railjson(
     Extension(auth): AuthenticationExt,
     Query(params): Query<PostRailjsonQueryParams>,
     Json(railjson): Json<RailJson>,
-) -> Result<Json<PostRailjsonResponse>> {
+) -> Result<impl IntoResponse> {
     let authorized = auth
         .check_roles([authz::Role::OperationalStudies].into())
         .await?;
@@ -209,12 +209,14 @@ pub(in crate::views) async fn post_railjson(
         infra.refresh(db_pool, true, &infra_cache).await?;
     }
 
-    Ok(Json(PostRailjsonResponse { infra: infra.id }))
+    Ok((
+        StatusCode::CREATED,
+        Json(PostRailjsonResponse { infra: infra.id }),
+    ))
 }
 
 #[cfg(test)]
 mod tests {
-    use axum::http::StatusCode;
     use pretty_assertions::assert_eq;
     use rstest::rstest;
 
@@ -274,7 +276,10 @@ mod tests {
             .post("/infra/railjson?name=post_railjson_test")
             .json(&railjson);
 
-        let res: PostRailjsonResponse = app.fetch(req).assert_status(StatusCode::OK).json_into();
+        let res: PostRailjsonResponse = app
+            .fetch(req)
+            .assert_status(StatusCode::CREATED)
+            .json_into();
 
         assert!(
             Infra::delete_static(&mut db_pool.get_ok(), res.infra)

--- a/editoast/src/views/temporary_speed_limits.rs
+++ b/editoast/src/views/temporary_speed_limits.rs
@@ -1,6 +1,8 @@
 use axum::Extension;
 use axum::extract::Json;
 use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
 use chrono::DateTime;
 use chrono::Utc;
 use database::DbConnectionPoolV2;
@@ -126,7 +128,7 @@ pub(in crate::views) async fn create_temporary_speed_limit_group(
         speed_limit_group_name,
         speed_limits,
     }): Json<TemporarySpeedLimitCreateForm>,
-) -> Result<Json<TemporarySpeedLimitCreateResponse>> {
+) -> Result<impl IntoResponse> {
     let authorized = auth
         .check_roles([Role::OperationalStudies].into())
         .await
@@ -154,7 +156,10 @@ pub(in crate::views) async fn create_temporary_speed_limit_group(
         .await
         .map_err(TemporarySpeedLimitError::from)?;
 
-    Ok(Json(TemporarySpeedLimitCreateResponse { group_id }))
+    Ok((
+        StatusCode::CREATED,
+        Json(TemporarySpeedLimitCreateResponse { group_id }),
+    ))
 }
 
 #[cfg(test)]
@@ -162,7 +167,6 @@ mod tests {
     use super::*;
 
     use crate::views::test_app::TestApp;
-    use axum::http::StatusCode;
     use axum_test::TestRequest;
     use chrono::DateTime;
     use chrono::Duration;
@@ -282,8 +286,10 @@ mod tests {
 
         // Speed limit group checks
 
-        let TemporarySpeedLimitCreateResponse { group_id } =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let TemporarySpeedLimitCreateResponse { group_id } = app
+            .fetch(request)
+            .assert_status(StatusCode::CREATED)
+            .json_into();
         let created_group = TemporarySpeedLimitGroup::retrieve(pool.get_ok(), group_id)
             .await
             .expect("Failed to retrieve the created temporary speed limit group")
@@ -313,10 +319,10 @@ mod tests {
         let request = app.create_temporary_speed_limit_group_request(
             RequestParameters::new().with_group_name(group_name.clone()),
         );
-        let _ = app.fetch(request).assert_status(StatusCode::OK);
+        let _ = app.fetch(request).assert_status(StatusCode::CREATED);
 
         let request = app.create_temporary_speed_limit_group_request(RequestParameters::new());
-        let _ = app.fetch(request).assert_status(StatusCode::OK);
+        let _ = app.fetch(request).assert_status(StatusCode::CREATED);
 
         let request = app.create_temporary_speed_limit_group_request(
             RequestParameters::new().with_group_name(group_name.clone()),

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -154,7 +154,7 @@ pub(in crate::views) struct StdcmQueryParams {
         StdcmQueryParams,
     ),
     responses(
-        (status = 201, body = inline(StdcmResponse), description = "The simulation result"),
+        (status = 200, body = inline(StdcmResponse), description = "The simulation result"),
     )
 )]
 pub(in crate::views) async fn stdcm(

--- a/editoast/src/views/work_schedules.rs
+++ b/editoast/src/views/work_schedules.rs
@@ -13,6 +13,7 @@ use axum::extract::Json;
 use axum::extract::Path;
 use axum::extract::Query;
 use axum::extract::State;
+use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use chrono::DateTime;
 use chrono::Utc;
@@ -144,7 +145,7 @@ pub(in crate::views) async fn create(
         work_schedule_group_name,
         work_schedules,
     }): Json<WorkScheduleCreateForm>,
-) -> Result<Json<WorkScheduleCreateResponse>> {
+) -> Result<impl IntoResponse> {
     // Create the group (using the method for the create group endpoint)
     let work_schedule_group = create_group(
         State(db_pool.clone()),
@@ -167,9 +168,12 @@ pub(in crate::views) async fn create(
     let _work_schedules: Vec<_> =
         WorkSchedule::create_batch(conn, work_schedules_changesets).await?;
 
-    Ok(Json(WorkScheduleCreateResponse {
-        work_schedule_group_id: work_schedule_group.work_schedule_group_id,
-    }))
+    Ok((
+        StatusCode::CREATED,
+        Json(WorkScheduleCreateResponse {
+            work_schedule_group_id: work_schedule_group.work_schedule_group_id,
+        }),
+    ))
 }
 
 #[derive(Serialize, Deserialize, ToSchema)]
@@ -202,7 +206,7 @@ pub(in crate::views) struct WorkScheduleProjection {
     request_body = inline(WorkScheduleProjectForm),
     responses(
         (
-            status = 201,
+            status = 200,
             body = inline(Vec<WorkScheduleProjection>),
             description = "Returns a list of work schedules whose track ranges intersect the given path"
         ),
@@ -344,7 +348,7 @@ pub(in crate::views) async fn delete_group(
     })
     .await?;
 
-    Ok(axum::http::StatusCode::NO_CONTENT)
+    Ok(StatusCode::NO_CONTENT)
 }
 
 #[editoast_derive::route]
@@ -352,7 +356,7 @@ pub(in crate::views) async fn delete_group(
     get, path = "",
     tag = "work_schedules",
     responses(
-        (status = 201, body = Vec<i64>, description = "The existing work schedule group ids"),
+        (status = 200, body = Vec<i64>, description = "The existing work schedule group ids"),
     )
 )]
 pub(in crate::views) async fn list_groups(
@@ -494,7 +498,6 @@ pub(in crate::views) async fn get_group(
 
 #[cfg(test)]
 pub mod tests {
-    use axum::http::StatusCode;
     use chrono::NaiveDate;
     use pretty_assertions::assert_eq;
     use rstest::rstest;
@@ -524,7 +527,7 @@ pub mod tests {
         // WHEN
         let work_schedule_response = app
             .fetch(request)
-            .assert_status(StatusCode::OK)
+            .assert_status(StatusCode::CREATED)
             .json_into::<WorkScheduleCreateResponse>();
 
         // THEN

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -2460,7 +2460,7 @@ export type GetTimetableByIdRoundTripsTrainSchedulesApiArg = {
   page?: number;
   pageSize?: number;
 };
-export type PostTimetableByIdStdcmApiResponse = /** status 201 The simulation result */
+export type PostTimetableByIdStdcmApiResponse = /** status 200 The simulation result */
   | {
       core_payload?: null | StdcmRequest;
       departure_time: string;
@@ -2698,7 +2698,7 @@ export type PostWorkSchedulesApiArg = {
   };
 };
 export type GetWorkSchedulesGroupApiResponse =
-  /** status 201 The existing work schedule group ids */ number[];
+  /** status 200 The existing work schedule group ids */ number[];
 export type GetWorkSchedulesGroupApiArg = void;
 export type PostWorkSchedulesGroupApiResponse =
   /** status 200 The id of the created work schedule group */ {
@@ -2739,7 +2739,7 @@ export type DeleteWorkSchedulesGroupByIdApiArg = {
   id: number;
 };
 export type PostWorkSchedulesProjectPathApiResponse =
-  /** status 201 Returns a list of work schedules whose track ranges intersect the given path */ {
+  /** status 200 Returns a list of work schedules whose track ranges intersect the given path */ {
     /** The date and time when the work schedule ends. */
     end_date_time: string;
     /** a list of intervals `(a, b)` that represent the projections of the work schedule track ranges:


### PR DESCRIPTION
Updates the API responses for endpoints across several modules (`railjson`, `temporary_speed_limits`, `work_schedules`) to return a 201 status code for successful create operations.

* Changed the return type of create endpoints to return a tuple with StatusCode::CREATED (201) and the created resource, instead of just the resource with a default status.
* Modified tests to expect StatusCode::CREATED (201) for create endpoints instead of StatusCode::OK (200).
* Added imports for axum::http::StatusCode where needed for the new response patterns.
