### PR TITLE
editoast: fix 204 status code in openapi

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -1949,7 +1949,7 @@ paths:
           type: integer
           format: int64
       responses:
-        '204':
+        '200':
           description: The requested paced train
           content:
             application/json:
@@ -2581,7 +2581,7 @@ paths:
               $ref: '#/components/schemas/ScenarioPatchForm'
         required: true
       responses:
-        '204':
+        '200':
           description: The scenario was updated successfully
           content:
             application/json:
@@ -3570,7 +3570,7 @@ paths:
         schema:
           type: string
       responses:
-        '200':
+        '204':
           description: Delete a sub category
   /temporary_speed_limit_group:
     post:
@@ -5041,7 +5041,7 @@ paths:
                   description: The timetable id to load, if any
         required: true
       responses:
-        '204':
+        '200':
           description: The worker status
           content:
             application/json:

--- a/editoast/src/views/scenario.rs
+++ b/editoast/src/views/scenario.rs
@@ -302,7 +302,7 @@ impl From<ScenarioPatchForm> for <Scenario as editoast_models::prelude::Model>::
     params(ProjectIdParam, StudyIdParam, ScenarioIdParam),
     request_body = ScenarioPatchForm,
     responses(
-        (status = 204, body = ScenarioResponse, description = "The scenario was updated successfully"),
+        (status = 200, body = ScenarioResponse, description = "The scenario was updated successfully"),
     )
 )]
 pub(in crate::views) async fn patch(

--- a/editoast/src/views/sub_categories.rs
+++ b/editoast/src/views/sub_categories.rs
@@ -144,7 +144,7 @@ struct SubCategoryCodeParam {
     tag = "sub_categories",
     params(SubCategoryCodeParam),
     responses(
-        (status = 200, description = "Delete a sub category"),
+        (status = 204, description = "Delete a sub category"),
     ),
 )]
 pub(in crate::views) async fn delete_sub_category(

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -118,7 +118,7 @@ pub(in crate::views) struct PacedTrainIdParam {
     tags = ["timetable", "paced_train"],
     params(PacedTrainIdParam),
     responses(
-        (status = 204, body = PacedTrainResponse, description = "The requested paced train")
+        (status = 200, body = PacedTrainResponse, description = "The requested paced train")
     )
 )]
 pub(in crate::views) async fn get_by_id(

--- a/editoast/src/views/worker_load.rs
+++ b/editoast/src/views/worker_load.rs
@@ -76,7 +76,7 @@ pub enum WorkerLoadError {
     tag = "worker",
     request_body = inline(WorkerLoadForm),
     responses(
-        (status = 204, description = "The worker status", body = WorkerStatus),
+        (status = 200, description = "The worker status", body = WorkerStatus),
         (status = 404, description = "The infra was not found"),
         (status = 404, description = "The timetable was not found"),
     )

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -1978,7 +1978,7 @@ export type PostPacedTrainSimulationSummaryApiArg = {
   };
 };
 export type GetPacedTrainByIdApiResponse =
-  /** status 204 The requested paced train */ PacedTrainResponse;
+  /** status 200 The requested paced train */ PacedTrainResponse;
 export type GetPacedTrainByIdApiArg = {
   id: number;
 };
@@ -2142,7 +2142,7 @@ export type DeleteProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdApiArg 
   scenarioId: number;
 };
 export type PatchProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdApiResponse =
-  /** status 204 The scenario was updated successfully */ ScenarioResponse;
+  /** status 200 The scenario was updated successfully */ ScenarioResponse;
 export type PatchProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdApiArg = {
   /** The id of a project */
   projectId: number;
@@ -2757,7 +2757,7 @@ export type PostWorkSchedulesProjectPathApiArg = {
     work_schedule_group_id: number;
   };
 };
-export type PostWorkerLoadApiResponse = /** status 204 The worker status */ WorkerStatus;
+export type PostWorkerLoadApiResponse = /** status 200 The worker status */ WorkerStatus;
 export type PostWorkerLoadApiArg = {
   body: {
     /** The infra id of the worker to load */


### PR DESCRIPTION
Documents `200 OK` for successful responses that return data, and `204 No Content` for successful responses that do not return a body.

* Changed documentation of successful responses from 204 to 200,  for endpoints in `paced train.rs` , `scenario.rs` and `worker_load.rs` 
*  Changed documentation of successful responses from 200 to 204,  for endpoint in `sub_categories.rs`
