### PR TITLE
editoast: improve and fix unit tests declaration

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -1466,7 +1466,6 @@ dependencies = [
  "serde_json",
  "serde_with",
  "serde_yaml",
- "serial_test",
  "sha1",
  "stdext",
  "strum",
@@ -4232,15 +4231,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scc"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
-dependencies = [
- "sdd",
-]
-
-[[package]]
 name = "schannel"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4298,12 +4288,6 @@ dependencies = [
  "salsa20",
  "sha2",
 ]
-
-[[package]]
-name = "sdd"
-version = "3.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "search"
@@ -4459,31 +4443,6 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
-]
-
-[[package]]
-name = "serial_test"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
-dependencies = [
- "futures 0.3.31",
- "log",
- "once_cell",
- "parking_lot",
- "scc",
- "serial_test_derive",
-]
-
-[[package]]
-name = "serial_test_derive"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
 ]
 
 [[package]]

--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -948,7 +948,6 @@ dependencies = [
  "lapin",
  "opentelemetry",
  "pretty_assertions",
- "rstest",
  "schemas",
  "serde",
  "serde_json",

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -252,7 +252,6 @@ osrdyne_client = { workspace = true, features = ["mock_client"] }
 pretty_assertions.workspace = true
 rstest.workspace = true
 schemas = { workspace = true, features = ["testing"] }
-serial_test = "3.2.0"
 stdext.workspace = true
 tempfile.workspace = true
 

--- a/editoast/README.md
+++ b/editoast/README.md
@@ -41,13 +41,6 @@ $ curl -f http://localhost:8090/health
 
 ## Tests
 
-To avoid thread conflicts while accessing the database, use serial_test
-
-```rust
-#[test]
-#[serial_test::serial]
-```
-
 ```sh
 cargo test --workspace -- --test-threads=4
 ```

--- a/editoast/core_client/Cargo.toml
+++ b/editoast/core_client/Cargo.toml
@@ -35,7 +35,6 @@ uuid.workspace = true
 async-std.workspace = true
 core_client = { path = "./", features = ["mocking_client"] }
 pretty_assertions.workspace = true
-rstest.workspace = true
 schemas = { workspace = true, features = ["testing"] }
 
 [lints]

--- a/editoast/core_client/src/lib.rs
+++ b/editoast/core_client/src/lib.rs
@@ -279,7 +279,7 @@ mod tests {
 
     use super::Error;
 
-    #[rstest::rstest]
+    #[tokio::test]
     async fn test_expected_empty_response() {
         #[derive(Serialize)]
         struct Req;
@@ -299,7 +299,7 @@ mod tests {
         Req.fetch(&core.into()).await.unwrap();
     }
 
-    #[rstest::rstest]
+    #[tokio::test]
     async fn test_bytes_response() {
         #[derive(Serialize)]
         struct Req;
@@ -319,7 +319,7 @@ mod tests {
         assert_eq!(&String::from_utf8(bytes).unwrap(), "not JSON :)");
     }
 
-    #[rstest::rstest]
+    #[tokio::test]
     async fn test_core_osrd_error() {
         #[derive(Serialize)]
         struct Req;

--- a/editoast/src/client/electrical_profiles_commands.rs
+++ b/editoast/src/client/electrical_profiles_commands.rs
@@ -105,7 +105,7 @@ mod tests {
 
     use super::*;
 
-    #[rstest::rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_electrical_profile_set_delete() {
         // GIVEN
         let db_pool = DbConnectionPoolV2::for_tests();
@@ -130,7 +130,7 @@ mod tests {
         assert!(empty);
     }
 
-    #[rstest::rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_electrical_profile_set_list_doesnt_fail() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let db_pool = Arc::new(db_pool);

--- a/editoast/src/client/import_rolling_stock.rs
+++ b/editoast/src/client/import_rolling_stock.rs
@@ -124,7 +124,6 @@ mod tests {
 
         use common::units;
         use database::DbConnectionPoolV2;
-        use rstest::rstest;
 
         fn get_fast_rolling_stock_schema(name: &str) -> schemas::RollingStock {
             let mut rolling_stock_form: schemas::RollingStock =
@@ -134,7 +133,7 @@ mod tests {
             rolling_stock_form
         }
 
-        #[rstest]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
         async fn import_rolling_stock_ko_file_not_found() {
             // GIVEN
             let db_pool = DbConnectionPoolV2::for_tests();
@@ -150,7 +149,7 @@ mod tests {
             assert!(result.is_err())
         }
 
-        #[rstest]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
         async fn import_non_electric_rs_without_startup_and_panto_values() {
             // GIVEN
             let db_pool = DbConnectionPoolV2::for_tests();
@@ -181,7 +180,7 @@ mod tests {
             assert!(created_rs.is_some());
         }
 
-        #[rstest]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
         async fn import_non_electric_rs_with_startup_and_panto_values() {
             // GIVEN
             let db_pool = DbConnectionPoolV2::for_tests();
@@ -216,7 +215,7 @@ mod tests {
             assert!(raise_pantograph_time.is_some());
         }
 
-        #[rstest]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
         async fn import_electric_rs_without_startup_and_panto_values() {
             // GIVEN
             let db_pool = DbConnectionPoolV2::for_tests();
@@ -247,7 +246,7 @@ mod tests {
             assert!(created_rs.is_none());
         }
 
-        #[rstest]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
         async fn import_electric_rs_with_startup_and_panto_values() {
             // GIVEN
             let db_pool = DbConnectionPoolV2::for_tests();
@@ -280,7 +279,7 @@ mod tests {
             assert!(raise_pantograph_time.is_some());
         }
 
-        #[rstest]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
         async fn import_existing_rolling_stock_without_force() {
             // GIVEN
             let db_pool = DbConnectionPoolV2::for_tests();
@@ -323,7 +322,7 @@ mod tests {
             assert!(rolling_stock.unwrap().length == units::meter::new(400.0));
         }
 
-        #[rstest]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
         async fn import_existing_rolling_stock_with_force() {
             // GIVEN
             let db_pool = DbConnectionPoolV2::for_tests();
@@ -372,9 +371,8 @@ mod tests {
         use crate::client::generate_temp_file;
 
         use database::DbConnectionPoolV2;
-        use rstest::rstest;
 
-        #[rstest]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
         async fn import_towed_rolling_stock_ko_file_not_found() {
             // GIVEN
             let db_pool = DbConnectionPoolV2::for_tests();
@@ -390,7 +388,7 @@ mod tests {
             assert!(result.is_err())
         }
 
-        #[rstest]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
         async fn import_valid_towed_rolling_stock() {
             // GIVEN
             let db_pool = DbConnectionPoolV2::for_tests();

--- a/editoast/src/client/infra_commands.rs
+++ b/editoast/src/client/infra_commands.rs
@@ -274,7 +274,7 @@ mod tests {
 
     use super::*;
 
-    #[rstest::rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn import_railjson_ko_file_not_found() {
         // GIVEN
         let railjson_path = "non/existing/railjson/file/location";
@@ -292,7 +292,7 @@ mod tests {
         assert!(result.is_err());
     }
 
-    #[rstest::rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn import_railjson_ok() {
         // GIVEN
         let railjson = Default::default();

--- a/editoast/src/client/stdcm_search_env_commands.rs
+++ b/editoast/src/client/stdcm_search_env_commands.rs
@@ -327,6 +327,7 @@ mod tests {
     }
 
     #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[case::both_none(
         None,
         None,
@@ -382,7 +383,7 @@ mod tests {
         assert_eq!(end, expected_end);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn fail_resolve_search_window_on_empty_timetable() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let conn = &mut db_pool.get_ok();
@@ -397,6 +398,7 @@ mod tests {
     }
 
     #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[case::both_some(
         Some(make_datetime("2000-02-01 08:00:00Z")),
         Some(make_datetime("2000-02-01 00:00:00Z"))
@@ -426,7 +428,7 @@ mod tests {
         );
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_stdcm_set_search_env_from_scenario_with_perimeter() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let conn = &mut db_pool.get_ok();
@@ -507,7 +509,7 @@ mod tests {
         );
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_set_stdcm_search_env_from_scratch() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let conn = &mut db_pool.get_ok();

--- a/editoast/src/client/timetables_commands.rs
+++ b/editoast/src/client/timetables_commands.rs
@@ -130,7 +130,7 @@ mod tests {
         include_str!("../tests/train_schedules/simple_array.json")
     }
 
-    #[rstest::rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn import_export_timetable_schedule() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let db_pool = Arc::new(db_pool);

--- a/editoast/src/generated_data/error/mod.rs
+++ b/editoast/src/generated_data/error/mod.rs
@@ -424,7 +424,6 @@ impl GeneratedData for ErrorLayer {
 
 #[cfg(test)]
 mod tests {
-    use rstest::rstest;
 
     use super::Graph;
     use super::buffer_stops;
@@ -442,7 +441,7 @@ mod tests {
     use crate::infra_cache::tests::create_small_infra_cache;
     use schemas::primitives::ObjectType;
 
-    #[rstest]
+    #[tokio::test]
     async fn small_infra_cache_validation() {
         let small_infra_cache = create_small_infra_cache();
 
@@ -561,7 +560,7 @@ mod tests {
         );
     }
 
-    #[rstest]
+    #[tokio::test]
     async fn error_priority_check() {
         let mut small_infra_cache = create_small_infra_cache();
         let bf = create_buffer_stop_cache("BF_error", "E", 530.0);

--- a/editoast/src/generated_data/mod.rs
+++ b/editoast/src/generated_data/mod.rs
@@ -169,7 +169,6 @@ pub mod tests {
     #[rstest]
     // Slow test
     // PostgreSQL deadlock can happen in this test, see section `Deadlock` of [DbConnectionPoolV2::get] for more information
-    #[serial_test::serial]
     async fn refresh_all_test() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let infra = create_empty_infra(&mut db_pool.get_ok()).await;

--- a/editoast/src/generated_data/mod.rs
+++ b/editoast/src/generated_data/mod.rs
@@ -158,7 +158,6 @@ pub async fn update_all(
 
 #[cfg(test)]
 pub mod tests {
-    use rstest::rstest;
 
     use crate::generated_data::clear_all;
     use crate::generated_data::refresh_all;
@@ -166,7 +165,7 @@ pub mod tests {
     use crate::models::fixtures::create_empty_infra;
     use database::DbConnectionPoolV2;
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     // Slow test
     // PostgreSQL deadlock can happen in this test, see section `Deadlock` of [DbConnectionPoolV2::get] for more information
     async fn refresh_all_test() {
@@ -179,7 +178,7 @@ pub mod tests {
         );
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn update_all_test() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let infra = create_empty_infra(&mut db_pool.get_ok()).await;
@@ -190,7 +189,7 @@ pub mod tests {
         );
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn clear_all_test() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let infra = create_empty_infra(&mut db_pool.get_ok()).await;

--- a/editoast/src/infra_cache/mod.rs
+++ b/editoast/src/infra_cache/mod.rs
@@ -942,7 +942,7 @@ impl From<&RailJson> for InfraCache {
 pub mod tests {
     use dashmap::DashMap;
     use pretty_assertions::assert_eq;
-    use rstest::rstest;
+
     use schemas::infra::BufferStop;
     use schemas::infra::Detector;
     use schemas::infra::Waypoint;
@@ -978,7 +978,7 @@ pub mod tests {
     use schemas::primitives::NonBlankString;
     use schemas::primitives::OSRDIdentified;
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn load_track_section() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let infra = create_empty_infra(&mut db_pool.get_ok()).await;
@@ -992,7 +992,7 @@ pub mod tests {
         assert!(infra_cache.track_sections().contains_key(track.get_id()));
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn load_signal() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let infra = create_empty_infra(&mut db_pool.get_ok()).await;
@@ -1006,7 +1006,7 @@ pub mod tests {
         assert_eq!(refs.get("InvalidRef").unwrap().len(), 1);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn load_speed_section() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let infra = create_empty_infra(&mut db_pool.get_ok()).await;
@@ -1028,7 +1028,7 @@ pub mod tests {
         assert_eq!(refs.get("InvalidRef").unwrap().len(), 1);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn load_route() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let infra = create_empty_infra(&mut db_pool.get_ok()).await;
@@ -1040,7 +1040,7 @@ pub mod tests {
         assert!(infra_cache.routes().contains_key(route.get_id()));
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn load_operational_point() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let infra = create_empty_infra(&mut db_pool.get_ok()).await;
@@ -1063,7 +1063,7 @@ pub mod tests {
         assert_eq!(refs.get("InvalidRef").unwrap().len(), 1);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn load_switch() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let infra = create_empty_infra(&mut db_pool.get_ok()).await;
@@ -1083,7 +1083,7 @@ pub mod tests {
         assert!(infra_cache.switches().contains_key(switch.get_id()));
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn load_switch_type() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let infra = create_empty_infra(&mut db_pool.get_ok()).await;
@@ -1096,7 +1096,7 @@ pub mod tests {
         assert!(infra_cache.switch_types().contains_key(s_type.get_id()));
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn load_detector() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let infra = create_empty_infra(&mut db_pool.get_ok()).await;
@@ -1111,7 +1111,7 @@ pub mod tests {
         assert_eq!(refs.get("InvalidRef").unwrap().len(), 1);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn load_buffer_stop() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let infra = create_empty_infra(&mut db_pool.get_ok()).await;
@@ -1125,7 +1125,7 @@ pub mod tests {
         assert_eq!(refs.get("InvalidRef").unwrap().len(), 1);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn load_electrification() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let infra = create_empty_infra(&mut db_pool.get_ok()).await;
@@ -1432,7 +1432,7 @@ pub mod tests {
         infra_cache
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn load_infra_cache() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let infra = create_empty_infra(&mut db_pool.get_ok()).await;
@@ -1447,7 +1447,7 @@ pub mod tests {
         assert_eq!(infra_caches.len(), 1);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn load_infra_cache_mut() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let infra = create_empty_infra(&mut db_pool.get_ok()).await;

--- a/editoast/src/infra_cache/operation/create.rs
+++ b/editoast/src/infra_cache/operation/create.rs
@@ -50,7 +50,7 @@ pub mod tests {
 
     macro_rules! test_create_object {
         ($obj:ident, $test_fn:ident) => {
-            #[rstest::rstest]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
             async fn $test_fn() {
                 let db_pool = database::DbConnectionPoolV2::for_tests();
                 let infra =

--- a/editoast/src/infra_cache/operation/delete.rs
+++ b/editoast/src/infra_cache/operation/delete.rs
@@ -87,7 +87,7 @@ mod tests {
 
     macro_rules! test_delete_object {
         ($obj:ident, $test_fn:ident, $obj_name:literal) => {
-            #[rstest::rstest]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
             async fn $test_fn() {
                 use diesel_async::RunQueryDsl;
                 use std::ops::DerefMut;

--- a/editoast/src/infra_cache/operation/update.rs
+++ b/editoast/src/infra_cache/operation/update.rs
@@ -127,7 +127,7 @@ mod tests {
     use diesel::sql_types::Text;
     use diesel_async::RunQueryDsl;
     use pretty_assertions::assert_eq;
-    use rstest::rstest;
+
     use schemas::infra::Signal;
     use schemas::infra::SpeedSection;
     use schemas::infra::Switch;
@@ -156,7 +156,7 @@ mod tests {
         label: String,
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn valid_update_track() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let infra = create_empty_infra(&mut db_pool.get_ok()).await;
@@ -190,7 +190,7 @@ mod tests {
         assert_eq!(updated_length.val, 80.0);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn invalid_update_track() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let infra = create_empty_infra(&mut db_pool.get_ok()).await;
@@ -215,7 +215,7 @@ mod tests {
         );
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn valid_update_signal() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let infra = create_empty_infra(&mut db_pool.get_ok()).await;
@@ -248,7 +248,7 @@ mod tests {
         assert_eq!(updated_length.val, 15.0);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn valid_update_switch_extension() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let infra = create_empty_infra(&mut db_pool.get_ok()).await;
@@ -281,7 +281,7 @@ mod tests {
         assert_eq!(updated_comment.label, "Switch Label");
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn valid_update_speed() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let infra = create_empty_infra(&mut db_pool.get_ok()).await;
@@ -315,7 +315,7 @@ mod tests {
         assert_eq!(updated_speed.val, 80.0);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn wrong_id_update_track() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let infra = create_empty_infra(&mut db_pool.get_ok()).await;

--- a/editoast/src/models/auth_driver.rs
+++ b/editoast/src/models/auth_driver.rs
@@ -255,7 +255,7 @@ mod tests {
     use super::*;
     use database::DbConnectionPoolV2;
 
-    #[rstest::rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_auth_driver() {
         let pool = DbConnectionPoolV2::for_tests();
         let driver = PgAuthDriver::new(pool.into());

--- a/editoast/src/models/infra.rs
+++ b/editoast/src/models/infra.rs
@@ -342,7 +342,6 @@ pub mod tests {
 
     #[rstest]
     // PostgreSQL deadlock can happen in this test, see section `Deadlock` of [DbConnectionPoolV2::get] for more information
-    #[serial_test::serial]
     async fn clone_infra_with_new_name_returns_new_cloned_infra() {
         // GIVEN
         let db_pool = DbConnectionPoolV2::for_tests();
@@ -362,7 +361,6 @@ pub mod tests {
     }
 
     #[rstest]
-    #[serial_test::serial]
     async fn persists_railjson_ko_version() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let railjson_with_invalid_version = RailJson {

--- a/editoast/src/models/infra.rs
+++ b/editoast/src/models/infra.rs
@@ -395,10 +395,6 @@ pub mod tests {
     }
 
     #[rstest]
-    // The fixture leaks the persisted infra because we explicitly opened a
-    // connection. This should be fixed by the testing utils rework. The ignore
-    // should be removed after.
-    #[ignore]
     async fn persist_railjson_ok() {
         // GIVEN
         let railjson = RailJson {

--- a/editoast/src/models/infra.rs
+++ b/editoast/src/models/infra.rs
@@ -302,7 +302,7 @@ impl Infra {
 #[cfg(test)]
 pub mod tests {
     use pretty_assertions::assert_eq;
-    use rstest::rstest;
+
     use schemas::infra::BufferStop;
     use schemas::infra::Detector;
     use schemas::infra::Electrification;
@@ -328,7 +328,7 @@ pub mod tests {
     use database::DbConnectionPoolV2;
     use editoast_models::prelude::*;
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn create_infra() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let infra = create_empty_infra(&mut db_pool.get_ok()).await;
@@ -340,7 +340,7 @@ pub mod tests {
         assert!(!infra.locked);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     // PostgreSQL deadlock can happen in this test, see section `Deadlock` of [DbConnectionPoolV2::get] for more information
     async fn clone_infra_with_new_name_returns_new_cloned_infra() {
         // GIVEN
@@ -360,7 +360,7 @@ pub mod tests {
         assert!(old_modification_date < result.modified);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn persists_railjson_ko_version() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let railjson_with_invalid_version = RailJson {
@@ -394,7 +394,7 @@ pub mod tests {
         assert!(infra.modified > old);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn persist_railjson_ok() {
         // GIVEN
         let railjson = RailJson {

--- a/editoast/src/models/infra_objects.rs
+++ b/editoast/src/models/infra_objects.rs
@@ -298,7 +298,7 @@ mod tests_persist {
 
     macro_rules! test_persist {
         ($obj:ident, $test_fn:ident) => {
-            #[rstest::rstest]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
             async fn $test_fn() {
                 let db_pool = database::DbConnectionPoolV2::for_tests();
                 let infra =
@@ -331,12 +331,11 @@ mod tests_persist {
 mod tests_retrieve {
     use database::DbConnectionPoolV2;
     use pretty_assertions::assert_eq;
-    use rstest::rstest;
 
     use super::*;
     use crate::models::fixtures::create_small_infra;
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn from_trigrams() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
@@ -353,7 +352,7 @@ mod tests_retrieve {
         assert_eq!(res.len(), 2);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn from_uic() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;

--- a/editoast/src/models/macro_node.rs
+++ b/editoast/src/models/macro_node.rs
@@ -28,11 +28,10 @@ pub mod test {
     use database::DbConnectionPoolV2;
     use editoast_models::prelude::*;
     use pretty_assertions::assert_eq;
-    use rstest::rstest;
 
     use crate::models::fixtures::create_scenario_fixtures_set;
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn macro_node_create_and_get() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let fixtures =

--- a/editoast/src/models/macro_note.rs
+++ b/editoast/src/models/macro_note.rs
@@ -26,11 +26,10 @@ pub mod test {
     use database::DbConnectionPoolV2;
     use editoast_models::prelude::*;
     use pretty_assertions::assert_eq;
-    use rstest::rstest;
 
     use crate::models::fixtures::create_scenario_fixtures_set;
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn macro_note_create_and_get() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let fixtures =

--- a/editoast/src/models/mod.rs
+++ b/editoast/src/models/mod.rs
@@ -42,7 +42,6 @@ mod tests {
     use editoast_derive::Model;
     use itertools::Itertools;
     use pretty_assertions::assert_eq;
-    use rstest::rstest;
 
     use editoast_models::prelude::*;
 
@@ -59,7 +58,7 @@ mod tests {
     #[error("oh no {0}")]
     struct DocError(#[from] editoast_models::Error);
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_batch() {
         let pool = DbConnectionPoolV2::for_tests();
 
@@ -130,7 +129,7 @@ mod tests {
         assert!(exists);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_remote() {
         #[derive(Debug, Clone, PartialEq)]
         enum Data {
@@ -204,7 +203,7 @@ mod tests {
         );
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_list() {
         // GIVEN
         let pool = DbConnectionPoolV2::for_tests();

--- a/editoast/src/models/paced_train.rs
+++ b/editoast/src/models/paced_train.rs
@@ -438,7 +438,7 @@ mod tests {
         }
     }
 
-    #[rstest]
+    #[tokio::test]
     async fn paced_train_main_category_apply_exception() {
         let mut exception = create_created_exception_with_change_groups("key_1");
 
@@ -462,6 +462,7 @@ mod tests {
     }
 
     #[rstest]
+    #[tokio::test]
     #[case::created(create_created_exception_with_change_groups("key_1"))]
     #[case::modified(create_modified_exception_with_change_groups("key_2", 0))]
     async fn paced_train_apply_exception(#[case] exception: PacedTrainException) {
@@ -524,13 +525,13 @@ mod tests {
         );
     }
 
-    #[rstest]
+    #[tokio::test]
     async fn num_base_occurrences_without_exceptions() {
         let paced_train = create_paced_train(vec![]);
         assert_eq!(paced_train.num_base_occurrences(), 4);
     }
 
-    #[rstest]
+    #[tokio::test]
     async fn num_base_occurrences_with_exceptions() {
         let paced_train = create_paced_train(vec![
             create_created_exception_with_change_groups("key_2"),
@@ -539,7 +540,7 @@ mod tests {
         assert_eq!(paced_train.num_base_occurrences(), 4);
     }
 
-    #[rstest]
+    #[tokio::test]
     async fn iter_occurrences_with_exceptions() {
         let exception_1 = create_modified_exception_with_change_groups("key_1", 1);
         let exception_2 = create_created_exception_with_change_groups("key_2");
@@ -605,7 +606,7 @@ mod tests {
         );
     }
 
-    #[rstest]
+    #[tokio::test]
     async fn iter_occurrences_with_modified_start_time_exception() {
         let mut exception_1 = create_modified_exception_with_change_groups("key_1", 1);
         exception_1.start_time = Some(StartTimeChangeGroup {
@@ -670,7 +671,7 @@ mod tests {
         );
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn paced_train_both_categories_check_post() {
         let pool = DbConnectionPoolV2::for_tests();
 

--- a/editoast/src/models/project.rs
+++ b/editoast/src/models/project.rs
@@ -183,11 +183,10 @@ pub mod tests {
 
     use database::DbConnectionPoolV2;
     use pretty_assertions::assert_eq;
-    use rstest::rstest;
 
     use crate::models::fixtures::create_project;
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn project_creation() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let project_name = "test_project_name";
@@ -195,7 +194,7 @@ pub mod tests {
         assert_eq!(created_project.name, project_name);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn project_retrieve() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let created_project = create_project(&mut db_pool.get_ok(), "test_project_name").await;
@@ -209,7 +208,7 @@ pub mod tests {
         assert_eq!(&created_project, &project);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn project_update() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let mut created_project = create_project(&mut db_pool.get_ok(), "test_project_name").await;
@@ -234,7 +233,7 @@ pub mod tests {
         assert_eq!(project.budget, project_budget);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn sort_project() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let _created_project_1 = create_project(&mut db_pool.get_ok(), "test_project_name_1").await;

--- a/editoast/src/models/rolling_stock.rs
+++ b/editoast/src/models/rolling_stock.rs
@@ -206,7 +206,6 @@ impl From<schemas::RollingStock> for RollingStockChangeset {
 pub mod tests {
     use editoast_models::rolling_stock::TrainMainCategories;
     use editoast_models::rolling_stock::TrainMainCategory;
-    use rstest::rstest;
 
     use super::RollingStock;
     use crate::models::fixtures::create_fast_rolling_stock;
@@ -216,7 +215,7 @@ pub mod tests {
     use database::DbConnectionPoolV2;
     use editoast_models::prelude::*;
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn update_rolling_stock() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let rs_name = "fast_rolling_stock_name";
@@ -242,7 +241,7 @@ pub mod tests {
         assert_eq!(updated_rolling_stock.name, rs_name_with_energy_sources_name);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn update_rolling_stock_failure_name_already_used() {
         let db_pool = DbConnectionPoolV2::for_tests();
 
@@ -271,7 +270,7 @@ pub mod tests {
         );
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_primary_category_with_empty_other_categories() {
         let db_pool = DbConnectionPoolV2::for_tests();
 
@@ -288,7 +287,7 @@ pub mod tests {
         );
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn create_rolling_stock_with_categories() {
         let db_pool = DbConnectionPoolV2::for_tests();
 

--- a/editoast/src/models/rolling_stock_livery.rs
+++ b/editoast/src/models/rolling_stock_livery.rs
@@ -59,12 +59,11 @@ pub mod tests {
     use super::*;
 
     use database::DbConnectionPoolV2;
-    use rstest::rstest;
 
     use crate::models::fixtures::create_rolling_stock_livery_fixture;
     use editoast_models::Document;
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn create_delete_rolling_stock_livery() {
         let db_pool = DbConnectionPoolV2::for_tests();
 

--- a/editoast/src/models/stdcm_search_environment.rs
+++ b/editoast/src/models/stdcm_search_environment.rs
@@ -136,7 +136,6 @@ pub mod tests {
     use chrono::TimeZone;
     use chrono::Utc;
     use pretty_assertions::assert_eq;
-    use rstest::rstest;
 
     use super::*;
     use crate::models::Infra;
@@ -175,7 +174,7 @@ pub mod tests {
         )
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_retrieve_latest() {
         let db_pool = DbConnectionPoolV2::for_tests();
 
@@ -239,7 +238,7 @@ pub mod tests {
         assert_eq!(result.enabled_until, enabled_until);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_retrieve_latest_empty() {
         let db_pool = DbConnectionPoolV2::for_tests();
         StdcmSearchEnvironment::delete_all(&mut db_pool.get_ok())

--- a/editoast/src/models/study.rs
+++ b/editoast/src/models/study.rs
@@ -134,14 +134,13 @@ pub struct StartDateAfterEndDateError;
 #[cfg(test)]
 pub mod tests {
     use pretty_assertions::assert_eq;
-    use rstest::rstest;
 
     use super::*;
     use crate::models::fixtures::create_project;
     use crate::models::fixtures::create_study;
     use database::DbConnectionPoolV2;
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn study_retrieve() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let created_project = create_project(&mut db_pool.get_ok(), "test_project_name").await;
@@ -159,7 +158,7 @@ pub mod tests {
         assert_eq!(&created_study, &study);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn sort_study() {
         let db_pool = DbConnectionPoolV2::for_tests();
 

--- a/editoast/src/models/timetable.rs
+++ b/editoast/src/models/timetable.rs
@@ -174,7 +174,7 @@ pub mod tests {
     use chrono::TimeZone;
     use chrono::Utc;
     use pretty_assertions::assert_eq;
-    use rstest::rstest;
+
     use std::collections::HashSet;
 
     use super::*;
@@ -183,7 +183,7 @@ pub mod tests {
     use crate::models::train_schedule::TrainScheduleChangeset;
     use database::DbConnectionPoolV2;
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_schedules_in_time_window() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let timetable = create_timetable(&mut db_pool.get_ok()).await;

--- a/editoast/src/models/train_schedule.rs
+++ b/editoast/src/models/train_schedule.rs
@@ -203,14 +203,13 @@ mod tests {
     use database::DbConnectionPoolV2;
     use editoast_models::rolling_stock::TrainMainCategory;
     use pretty_assertions::assert_eq;
-    use rstest::rstest;
 
     use crate::models::fixtures::create_timetable;
     use crate::models::fixtures::simple_sub_category;
     use crate::models::fixtures::simple_train_schedule_changeset;
     use editoast_models::prelude::*;
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn train_schedule_both_categories_check_post() {
         let pool = DbConnectionPoolV2::for_tests();
 

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -590,6 +590,7 @@ mod tests {
     use std::collections::HashSet;
 
     use axum::http::StatusCode;
+    use rstest::rstest;
 
     use crate::models::fixtures::create_empty_infra;
     use crate::views::test_app::test_app;
@@ -598,7 +599,7 @@ mod tests {
     use crate::models::fixtures::create_small_infra;
     use crate::views::test_app::TestRequestExt;
     use pretty_assertions::assert_eq;
-    use rstest::rstest;
+
     use serde_json::json;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -760,7 +761,7 @@ mod tests {
         );
     }
 
-    #[rstest]
+    #[rstest] // TODO: fix deadlock with tokio::test
     async fn user_me_grants() {
         let app = test_app!().enable_authorization(true).build();
         let db_pool = app.db_pool();
@@ -810,7 +811,7 @@ mod tests {
         );
     }
 
-    #[rstest]
+    #[rstest] // TODO: fix deadlock with tokio::test
     async fn users_grants_for_resource_id_test() {
         // This test start with an infra with one owner, one writer, and 5 readers
         let app = test_app!().enable_authorization(true).build();
@@ -860,7 +861,7 @@ mod tests {
         assert_eq!(subjects.len(), 1);
     }
 
-    #[rstest]
+    #[rstest] // TODO: fix deadlock with tokio::test
     async fn groups_grants_on_resource() {
         let app = test_app!().enable_authorization(true).build();
         let infra = create_small_infra(&mut app.db_pool().get_ok()).await;
@@ -911,7 +912,7 @@ mod tests {
         assert_eq!(grants.get(&tom_and_jerry.id), None); // no group grant (not even there in the response)
     }
 
-    #[rstest]
+    #[rstest] // TODO: fix deadlock with tokio::test
     async fn grants_test() {
         // This test starts with a user that is the owner of an infra.
         // Then it creates a new user and adds it as a writer to the infra.
@@ -959,7 +960,7 @@ mod tests {
         app.assert_infra_direct_grant(infra.id, writer.id, None);
     }
 
-    #[rstest]
+    #[rstest] // TODO: fix deadlock with tokio::test
     async fn give_grant_to_groups() {
         let app = test_app!().enable_authorization(true).build();
         let infra = create_small_infra(&mut app.db_pool().get_ok()).await;
@@ -1013,7 +1014,7 @@ mod tests {
         app.assert_infra_direct_grant(infra.id, bob.id, Some(InfraGrant::Reader)); // bob's direct grant is still there
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn adding_a_grant_that_already_exists() {
         let app = test_app!().enable_authorization(true).build();
         let db_pool = app.db_pool();
@@ -1038,7 +1039,7 @@ mod tests {
         app.fetch(request_revoke).assert_status(StatusCode::CREATED);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn remove_a_grant_that_doesnt_exists() {
         let app = test_app!().enable_authorization(true).build();
         let db_pool = app.db_pool();
@@ -1065,7 +1066,7 @@ mod tests {
             .assert_status(StatusCode::NO_CONTENT);
     }
 
-    #[rstest]
+    #[rstest] // TODO: fix deadlock with tokio::test
     async fn whoami_test() {
         let app = test_app!().enable_authorization(true).build();
         let user = app
@@ -1089,7 +1090,7 @@ mod tests {
         );
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn whoami_authorization_disabled() {
         let app = test_app!().enable_authorization(false).build();
         let user = app.user("test", "test").create();
@@ -1103,7 +1104,7 @@ mod tests {
         assert_eq!(roles, vec![Role::Admin]);
     }
 
-    #[rstest]
+    #[rstest] // TODO: fix deadlock with tokio::test
     async fn user_groups_test() {
         let app = test_app!().enable_authorization(true).build();
         let user_1 = app.user("test1", "test1").create();
@@ -1150,7 +1151,7 @@ mod tests {
         );
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn user_groups_authorization_disabled() {
         let app = test_app!().enable_authorization(false).build();
         let user = app.user("test", "test").create();

--- a/editoast/src/views/documents.rs
+++ b/editoast/src/views/documents.rs
@@ -163,7 +163,7 @@ pub(in crate::views) async fn delete(
 mod tests {
     use axum::http::StatusCode;
     use axum::http::header;
-    use rstest::rstest;
+
     use serde::Deserialize;
 
     use super::*;
@@ -174,7 +174,7 @@ mod tests {
         document_key: i64,
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn document_post() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
@@ -201,7 +201,7 @@ mod tests {
         assert_eq!(document.data, b"Document post test data".to_vec());
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_document() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
@@ -222,7 +222,7 @@ mod tests {
         assert_eq!(response.as_ref(), b"Document post test data");
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn document_delete() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();

--- a/editoast/src/views/electrical_profiles.rs
+++ b/editoast/src/views/electrical_profiles.rs
@@ -212,7 +212,6 @@ mod tests {
 
     use axum::http::StatusCode;
     use pretty_assertions::assert_eq;
-    use rstest::rstest;
 
     use super::*;
     use crate::models::fixtures::create_electrical_profile_set;
@@ -220,7 +219,7 @@ mod tests {
     use schemas::infra::ElectricalProfile;
     use schemas::infra::TrackRange;
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_electrical_profile_list() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
@@ -235,7 +234,7 @@ mod tests {
         assert!(response.len() >= 2);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_unexisting_electrical_profile() {
         let app = TestAppBuilder::default_app();
 
@@ -243,7 +242,7 @@ mod tests {
         response.assert_status(StatusCode::NOT_FOUND);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_electrical_profile() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
@@ -259,7 +258,7 @@ mod tests {
         response.assert_status(StatusCode::OK);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_unexisting_electrical_profile_level_order() {
         let app = TestAppBuilder::default_app();
 
@@ -267,7 +266,7 @@ mod tests {
         response.assert_status(StatusCode::NOT_FOUND);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_get_level_order_some() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
@@ -290,14 +289,14 @@ mod tests {
         );
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn delete_unexisting_electrical_profile() {
         let app = TestAppBuilder::default_app();
         let response = app.delete("/electrical_profile_set/666").await;
         response.assert_status(StatusCode::NOT_FOUND);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn delete_electrical_profile() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
@@ -319,7 +318,7 @@ mod tests {
         assert!(!exists);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_post() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();

--- a/editoast/src/views/fonts.rs
+++ b/editoast/src/views/fonts.rs
@@ -53,9 +53,8 @@ mod tests {
     use crate::views::test_app::TestAppBuilder;
 
     use axum::http::StatusCode;
-    use rstest::rstest;
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_font() {
         let app = TestAppBuilder::default_app();
         let request = app.get("/fonts/IBMPlexSans/0-255.pbf");
@@ -71,7 +70,7 @@ mod tests {
         assert_eq!(response, expected);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_font_not_found() {
         let app = TestAppBuilder::default_app();
         let request = app.get("/fonts/Comic%20Sans/0-255.pbf");

--- a/editoast/src/views/infra/attached.rs
+++ b/editoast/src/views/infra/attached.rs
@@ -122,8 +122,6 @@ pub(in crate::views) async fn attached(
 mod tests {
     use std::collections::HashMap;
 
-    use rstest::rstest;
-
     use crate::infra_cache::operation::create::apply_create_operation;
     use crate::models::Infra;
     use crate::views::test_app::TestAppBuilder;
@@ -133,7 +131,7 @@ mod tests {
     use schemas::primitives::OSRDIdentified;
     use schemas::primitives::ObjectType;
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_attached_detector() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();

--- a/editoast/src/views/infra/auto_fixes/mod.rs
+++ b/editoast/src/views/infra/auto_fixes/mod.rs
@@ -338,6 +338,7 @@ mod tests {
 
     use axum::http::StatusCode;
     use pretty_assertions::assert_eq;
+    use rstest::rstest;
     use schemas::infra::BufferStop;
     use schemas::infra::BufferStopExtension;
 
@@ -380,7 +381,7 @@ mod tests {
         }
     }
 
-    #[rstest::rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_no_fix() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -395,7 +396,7 @@ mod tests {
         assert!(operations.is_empty());
     }
 
-    #[rstest::rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_fix_invalid_ref_puntual_objects() {
         // GIVEN
         let app = TestAppBuilder::default_app();
@@ -470,7 +471,7 @@ mod tests {
         })));
     }
 
-    #[rstest::rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_fix_invalid_ref_route_entry_exit() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -524,7 +525,7 @@ mod tests {
         assert!(!infra_cache.signals().contains_key(signal.get_id()));
     }
 
-    #[rstest::rstest]
+    #[tokio::test]
     async fn test_wrong_invalid_ref_signal_fix() {
         let signal = SignalCache::new("SA0".to_string(), "TA1".to_string(), 0.0, vec![]);
         let error = InfraError::new_invalid_reference(
@@ -703,7 +704,7 @@ mod tests {
         assert!(operations.is_empty());
     }
 
-    #[rstest::rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn invalid_switch_ports() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -740,7 +741,7 @@ mod tests {
         })));
     }
 
-    #[rstest::rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn odd_buffer_stop_location() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -792,7 +793,7 @@ mod tests {
         })));
     }
 
-    #[rstest::rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn empty_object() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -822,7 +823,7 @@ mod tests {
         }
     }
 
-    #[rstest::rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn out_of_range_must_be_ignored() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -892,7 +893,8 @@ mod tests {
         }
     }
 
-    #[rstest::rstest]
+    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[case(250., 1)]
     #[case(1250., 5)]
     async fn out_of_range_must_be_deleted(#[case] pos: f64, #[case] error_count: usize) {
@@ -956,7 +958,7 @@ mod tests {
         }
     }
 
-    #[rstest::rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn missing_track_extremity_buffer_stop_fix() {
         // GIVEN
         let app = TestAppBuilder::default_app();

--- a/editoast/src/views/infra/delimited_area.rs
+++ b/editoast/src/views/infra/delimited_area.rs
@@ -514,7 +514,7 @@ mod tests {
     use crate::views::infra::delimited_area::DelimitedAreaResponse;
     use crate::views::test_app::TestAppBuilder;
     use axum::http::StatusCode;
-    use rstest::rstest;
+
     use schemas::infra::Direction;
     use schemas::infra::DirectionalTrackRange;
     use serde_json::json;
@@ -544,7 +544,7 @@ mod tests {
         track_ranges
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn same_track_start_to_stop() {
         let entries = vec![DirectedLocation {
             track: "TH1".into(),
@@ -566,7 +566,7 @@ mod tests {
         assert_eq!(expected_track_ranges, retrieved_track_ranges);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn same_track_stop_to_start() {
         let entries = vec![DirectedLocation {
             track: "TH1".into(),
@@ -588,7 +588,7 @@ mod tests {
         assert_eq!(expected_track_ranges, retrieved_track_ranges);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn tunnel_on_two_tracks() {
         let entries = vec![DirectedLocation {
             track: "TF1".into(),
@@ -618,7 +618,7 @@ mod tests {
         assert_eq!(expected_track_ranges, retrieved_track_ranges);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn both_point_switch_directions_get_explored() {
         let entries = vec![DirectedLocation {
             track: "TG1".into(),
@@ -663,7 +663,7 @@ mod tests {
         assert_eq!(expected_track_ranges, retrieved_track_ranges);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn multiple_isolated_entry_signals() {
         let entries = vec![
             DirectedLocation {
@@ -732,7 +732,7 @@ mod tests {
         assert_eq!(expected_track_ranges, retrieved_track_ranges);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn signals_facing_opposite_direction_are_ignored() {
         let entries = vec![DirectedLocation {
             track: "TF1".into(),
@@ -769,7 +769,7 @@ mod tests {
         assert_eq!(expected_track_ranges, retrieved_track_ranges);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn track_range_is_built_from_the_closest_exit() {
         let entries = vec![DirectedLocation {
             track: "TF1".into(),
@@ -806,7 +806,7 @@ mod tests {
         assert_eq!(expected_track_ranges, retrieved_track_ranges);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn exit_before_entry_is_ignored() {
         // The graph exploration should not stop if there is an exit signal on the same track
         // as the entry signal when the exit signal is behind the entry signal.
@@ -845,7 +845,7 @@ mod tests {
         assert_eq!(expected_track_ranges, retrieved_track_ranges);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn closest_exit_ignores_exits_before_entry() {
         // If the LTV is a single track range, it should ignore the signals behind it when
         // checking which one is the closest.
@@ -876,7 +876,7 @@ mod tests {
         assert_eq!(expected_track_ranges, retrieved_track_ranges);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn exploration_stops_when_resume_signal_is_missing_and_maximum_distance_is_reached() {
         let entries = vec![DirectedLocation {
             track: "TE0".into(),
@@ -909,14 +909,14 @@ mod tests {
         assert_eq!(expected_track_ranges, retrieved_track_ranges);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[ignore]
     async fn track_section_can_be_explored_in_both_directions() {
         // TODO find a way to test it on small_infra or make a specific infra for this test
         todo!()
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[ignore]
     async fn adjacent_track_ranges_are_merged() {
         // If two directional track ranges are adjacent and have the same direction,
@@ -925,7 +925,7 @@ mod tests {
         unimplemented!();
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[ignore]
     async fn request_with_invalid_locations_is_rejected() {
         // Invalid locations (invalid track number, location position not on the track...)

--- a/editoast/src/views/infra/edition.rs
+++ b/editoast/src/views/infra/edition.rs
@@ -971,7 +971,7 @@ pub mod tests {
     use crate::views::infra::errors::query_errors;
     use crate::views::test_app::TestAppBuilder;
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn split_track_section_should_return_404_with_bad_infra() {
         // Init
         let app = TestAppBuilder::default_app();
@@ -988,7 +988,7 @@ pub mod tests {
         app.fetch(request).assert_status(StatusCode::NOT_FOUND);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn split_track_section_should_return_404_with_bad_id() {
         // Init
         let app = TestAppBuilder::default_app();
@@ -1007,7 +1007,7 @@ pub mod tests {
         app.fetch(request).assert_status(StatusCode::NOT_FOUND);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn split_track_section_should_fail_with_bad_distance() {
         // Init
         let app = TestAppBuilder::default_app();
@@ -1026,7 +1026,7 @@ pub mod tests {
         app.fetch(request).assert_status(StatusCode::BAD_REQUEST);
     }
 
-    #[rstest]
+    #[rstest] // TODO: fix deadlock with tokio::test
     #[case("TA0", 1000000)]
     #[case("TD1", 15500000)]
     async fn split_track_section_should_work(#[case] track: &str, #[case] offset: u64) {
@@ -1110,7 +1110,7 @@ pub mod tests {
         assert!(small_infra.modified > old_modified);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn apply_edit_transaction_should_work() {
         // Init
         let app = TestAppBuilder::default_app();
@@ -1153,7 +1153,7 @@ pub mod tests {
         assert_eq!(1234.0, result[0].get_data()["length"]);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn apply_edit_transaction_should_rollback() {
         // Init
         let app = TestAppBuilder::default_app();

--- a/editoast/src/views/infra/errors.rs
+++ b/editoast/src/views/infra/errors.rs
@@ -139,12 +139,11 @@ pub(in crate::views) async fn query_errors(
 #[cfg(test)]
 mod tests {
     use axum::http::StatusCode;
-    use rstest::rstest;
 
     use crate::models::fixtures::create_empty_infra;
     use crate::views::test_app::TestAppBuilder;
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn list_errors_get() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();

--- a/editoast/src/views/infra/lines.rs
+++ b/editoast/src/views/infra/lines.rs
@@ -93,7 +93,7 @@ mod tests {
     use axum::http::StatusCode;
     use geos::geojson::Geometry;
     use pretty_assertions::assert_eq;
-    use rstest::rstest;
+
     use schemas::infra::TrackSectionSncfExtension;
     use schemas::primitives::Identifier;
     use serde_json::json;
@@ -106,7 +106,7 @@ mod tests {
     use schemas::infra::TrackSectionExtensions;
     use schemas::primitives::BoundingBox;
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn returns_correct_bbox_for_existing_line_code() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -150,7 +150,7 @@ mod tests {
         );
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn returns_bad_request_when_line_code_not_found() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -1005,7 +1005,6 @@ pub mod tests {
     }
 
     #[rstest]
-    #[serial_test::serial]
     async fn infra_clone_empty() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -1029,7 +1028,6 @@ pub mod tests {
     }
 
     #[rstest] // Slow test
-    #[serial_test::serial]
     async fn infra_clone() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -1200,7 +1198,6 @@ pub mod tests {
     #[rstest]
     // Slow test
     // PostgreSQL deadlock can happen in this test, see section `Deadlock` of [DbConnectionPoolV2::get] for more information
-    #[serial_test::serial]
     async fn infra_refresh_force() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -1004,7 +1004,7 @@ pub mod tests {
         }
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn infra_clone_empty() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -1027,7 +1027,7 @@ pub mod tests {
         nb: i64,
     }
 
-    #[rstest] // Slow test
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn infra_clone() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -1100,7 +1100,7 @@ pub mod tests {
         }
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn infra_delete() {
         let pool = DbConnectionPoolV2::for_tests();
         let app = TestAppBuilder::new()
@@ -1117,14 +1117,14 @@ pub mod tests {
             .assert_status(StatusCode::NOT_FOUND);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn infra_list() {
         let app = TestAppBuilder::default_app();
         let request = app.get("/infra/");
         app.fetch(request).assert_status(StatusCode::OK);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn default_infra_create() {
         let app = TestAppBuilder::default_app();
 
@@ -1143,7 +1143,7 @@ pub mod tests {
         assert!(!infra.locked);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn infra_get() {
         let core_client = CoreClient::Mocked(MockingClient::default());
 
@@ -1162,7 +1162,7 @@ pub mod tests {
         app.fetch(req).assert_status(StatusCode::NOT_FOUND);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn infra_rename() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -1182,7 +1182,7 @@ pub mod tests {
         infra_refreshed: Vec<i64>,
     }
 
-    #[rstest]
+    #[rstest] // TODO: fix deadlock with tokio::test
     async fn infra_refresh() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -1195,7 +1195,7 @@ pub mod tests {
         assert_eq!(refreshed_infras.infra_refreshed, vec![empty_infra.id]);
     }
 
-    #[rstest]
+    #[rstest] // TODO: fix deadlock with tokio::test
     // Slow test
     // PostgreSQL deadlock can happen in this test, see section `Deadlock` of [DbConnectionPoolV2::get] for more information
     async fn infra_refresh_force() {
@@ -1210,7 +1210,7 @@ pub mod tests {
         assert!(refreshed_infras.infra_refreshed.contains(&empty_infra.id));
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn infra_get_speed_limit_tags() {
         let app = TestAppBuilder::default_app();
         let builtin_tags = app.speed_limit_tag_ids();
@@ -1237,7 +1237,7 @@ pub mod tests {
         assert_eq!(speed_limit_tags.sort(), test_tags.sort());
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn infra_get_all_voltages() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -1283,6 +1283,7 @@ pub mod tests {
     }
 
     #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[case(true)]
     #[case(false)]
     async fn infra_get_voltages(#[case] include_rolling_stock_modes: bool) {
@@ -1327,7 +1328,7 @@ pub mod tests {
         }
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn infra_get_switch_types() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -1341,7 +1342,7 @@ pub mod tests {
         assert_eq!(switch_types.len(), 5);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn infra_lock() {
         let core_client = CoreClient::Mocked(MockingClient::default());
 
@@ -1374,7 +1375,7 @@ pub mod tests {
         assert!(!infra.locked);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn match_operational_points() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -1446,7 +1447,7 @@ pub mod tests {
         assert_eq!(response.track_names, expected_track_names);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn match_operational_point_input_with_incompatible_op_id_and_track_reference_gets_filtered_out()
      {
         let app = TestAppBuilder::default_app();

--- a/editoast/src/views/infra/objects.rs
+++ b/editoast/src/views/infra/objects.rs
@@ -173,7 +173,7 @@ pub(in crate::views) async fn list_objects_ids(
 mod tests {
     use axum::http::StatusCode;
     use pretty_assertions::assert_eq;
-    use rstest::rstest;
+
     use schemas::primitives::Identifier;
     use serde_json::Value as JsonValue;
     use serde_json::json;
@@ -186,7 +186,7 @@ mod tests {
     use schemas::infra::SwitchType;
     use schemas::primitives::OSRDIdentified;
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn check_invalid_ids() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -199,7 +199,7 @@ mod tests {
         app.fetch(request).assert_status(StatusCode::BAD_REQUEST);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_objects_no_ids() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -212,7 +212,7 @@ mod tests {
         app.fetch(request).assert_status(StatusCode::OK);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_objects_should_return_switch() {
         // GIVEN
         let app = TestAppBuilder::default_app();
@@ -256,7 +256,7 @@ mod tests {
         assert_eq!(switch_object, expected_switch_object);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_objects_duplicate_ids() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -269,7 +269,7 @@ mod tests {
         app.fetch(request).assert_status(StatusCode::BAD_REQUEST);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_switch_types() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -303,7 +303,7 @@ mod tests {
         assert_eq!(switch_type_object, expected_switch_type_object);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_list_ids() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();

--- a/editoast/src/views/infra/railjson.rs
+++ b/editoast/src/views/infra/railjson.rs
@@ -218,7 +218,6 @@ pub(in crate::views) async fn post_railjson(
 #[cfg(test)]
 mod tests {
     use pretty_assertions::assert_eq;
-    use rstest::rstest;
 
     use super::*;
     use crate::infra_cache::operation::create::apply_create_operation;
@@ -227,7 +226,7 @@ mod tests {
     use schemas::infra::RAILJSON_VERSION;
     use schemas::infra::SwitchType;
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     // PostgreSQL deadlock can happen in this test, see section `Deadlock` of [DbConnectionPoolV2::get] for more information
     async fn test_get_railjson() {
         let app = TestAppBuilder::default_app();
@@ -250,7 +249,7 @@ mod tests {
         assert_eq!(railjson.extended_switch_types.len(), 1);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     // PostgreSQL deadlock can happen in this test, see section `Deadlock` of [DbConnectionPoolV2::get] for more information
     async fn test_post_railjson() {
         let app = TestAppBuilder::default_app();

--- a/editoast/src/views/infra/railjson.rs
+++ b/editoast/src/views/infra/railjson.rs
@@ -229,7 +229,6 @@ mod tests {
 
     #[rstest]
     // PostgreSQL deadlock can happen in this test, see section `Deadlock` of [DbConnectionPoolV2::get] for more information
-    #[serial_test::serial]
     async fn test_get_railjson() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -253,7 +252,6 @@ mod tests {
 
     #[rstest]
     // PostgreSQL deadlock can happen in this test, see section `Deadlock` of [DbConnectionPoolV2::get] for more information
-    #[serial_test::serial]
     async fn test_post_railjson() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();

--- a/editoast/src/views/infra/routes.rs
+++ b/editoast/src/views/infra/routes.rs
@@ -311,7 +311,7 @@ pub(in crate::views) async fn get_routes_nodes(
 mod tests {
     use axum::http::StatusCode;
     use pretty_assertions::assert_eq;
-    use rstest::rstest;
+
     use serde_json::json;
     use std::collections::HashMap;
     use std::collections::HashSet;
@@ -329,7 +329,7 @@ mod tests {
     use schemas::infra::TrackSection;
     use schemas::infra::Waypoint;
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_routes_nodes() {
         let tests = vec![
             (json!({}), (vec![], vec![])),
@@ -446,7 +446,7 @@ mod tests {
         }
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_routes_should_return_routes_from_buffer_stop_and_detector() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -531,7 +531,7 @@ mod tests {
         );
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_routes_should_return_empty_response() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();

--- a/editoast/src/views/layers.rs
+++ b/editoast/src/views/layers.rs
@@ -242,7 +242,7 @@ mod tests {
     use crate::map::MapLayers;
     use crate::views::test_app;
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn layer_error_view_not_found() {
         let map_layers = MapLayers::default();
         let error: InternalError =
@@ -259,6 +259,7 @@ mod tests {
     }
 
     #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[case("http://localhost:8090", "http://localhost:8090/")]
     #[case("http://localhost:8090/", "http://localhost:8090/")]
     #[case("http://localhost:8090/test", "http://localhost:8090/test/")]

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -1030,7 +1030,7 @@ mod tests {
     use core_client::simulation::SimulationSuccess;
     use core_client::simulation::SpeedLimitProperties;
     use database::DbConnectionPoolV2;
-    use rstest::rstest;
+
     use serde_json::json;
 
     use super::test_app::TestAppBuilder;
@@ -1139,14 +1139,14 @@ mod tests {
         core
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn health() {
         let app = TestAppBuilder::default_app();
         let request = app.get("/health");
         app.fetch(request).assert_status(StatusCode::OK);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn version() {
         let app = TestAppBuilder::default_app();
         let request = app.get("/version");
@@ -1154,7 +1154,7 @@ mod tests {
         assert!(response.contains_key("git_describe"));
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn core_version() {
         let mut core = MockingClient::new();
         core.stub("/version")

--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -514,7 +514,7 @@ pub mod tests {
     use core_client::pathfinding::PathfindingResultSuccess;
     use core_client::pathfinding::TrainPath;
     use pretty_assertions::assert_eq;
-    use rstest::rstest;
+
     use schemas::train_schedule::OperationalPointIdentifier;
     use schemas::train_schedule::OperationalPointReference;
     use schemas::train_schedule::PathItemLocation;
@@ -526,7 +526,7 @@ pub mod tests {
     use crate::views::path::pathfinding::PathfindingResult;
     use crate::views::test_app::TestAppBuilder;
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn pathfinding_fails_when_core_responds_with_zero_length_path() {
         let mut core = MockingClient::new();
         core.stub("/pathfinding/blocks")
@@ -571,7 +571,7 @@ pub mod tests {
         );
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn pathfinding_with_invalid_path_items_returns_invalid_path_items() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -617,7 +617,7 @@ pub mod tests {
         );
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn pathfinding_with_invalid_path_items_due_to_track_reference() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -663,7 +663,7 @@ pub mod tests {
         );
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn pathfinding_with_valid_path_items_returns_successful_result() {
         let mut core = MockingClient::new();
         core.stub("/pathfinding/blocks")

--- a/editoast/src/views/path/properties.rs
+++ b/editoast/src/views/path/properties.rs
@@ -243,7 +243,7 @@ mod tests {
     use core_client::path_properties::PropertyValuesF64;
     use core_client::path_properties::PropertyZoneValues;
     use pretty_assertions::assert_eq;
-    use rstest::rstest;
+
     use serde_json::json;
 
     use super::PathProperties;
@@ -278,7 +278,7 @@ mod tests {
         TestAppBuilder::new().core_client(core.into()).build()
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn returns_all_path_properties() {
         let app = init_test_app();
         let infra = create_small_infra(&mut app.db_pool().get_ok()).await;
@@ -306,7 +306,7 @@ mod tests {
         );
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn returns_only_requested_path_properties() {
         let app = init_test_app();
         let infra = create_small_infra(&mut app.db_pool().get_ok()).await;

--- a/editoast/src/views/project.rs
+++ b/editoast/src/views/project.rs
@@ -397,6 +397,7 @@ pub mod tests {
 
     use pretty_assertions::assert_eq;
     use rstest::rstest;
+
     use serde_json::json;
 
     use crate::models::fixtures::create_project;
@@ -404,7 +405,7 @@ pub mod tests {
     use crate::views::test_app::TestAppBuilder;
     use crate::views::test_app::TestRequestExt;
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn project_post() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
@@ -431,7 +432,7 @@ pub mod tests {
         assert_eq!(project.name, project_name);
     }
 
-    #[rstest]
+    #[rstest] // TODO: fix deadlock with tokio::test
     async fn project_post_should_fail_when_authorization_is_enabled() {
         let app = test_app!().enable_authorization(true).build();
         let user = app.user("bob", "Bob").with_roles([Role::Stdcm]).create();
@@ -447,7 +448,7 @@ pub mod tests {
         app.fetch(request).assert_status(StatusCode::FORBIDDEN);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn project_list() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -468,7 +469,7 @@ pub mod tests {
         assert_eq!(created_project, project_retrieved.project);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn project_get() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -483,7 +484,7 @@ pub mod tests {
         assert_eq!(response.project, created_project);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn project_delete() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -501,7 +502,7 @@ pub mod tests {
         assert!(!exists);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn project_patch() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();

--- a/editoast/src/views/projection.rs
+++ b/editoast/src/views/projection.rs
@@ -820,7 +820,7 @@ mod tests {
         assert_eq!(find_index_lower(&values, value), expected);
     }
 
-    #[rstest]
+    #[test]
     fn test_compute_space_time_curves_case_1() {
         let positions: Vec<u64> = vec![0, 100, 200, 300, 400, 600, 730, 1_000_000];
         let times: Vec<u64> = vec![0, 10, 20, 30, 40, 50, 70, 90];
@@ -858,7 +858,7 @@ mod tests {
         );
     }
 
-    #[rstest]
+    #[test]
     fn test_compute_space_time_curves_case_2() {
         let positions: Vec<u64> = vec![0, 100, 200, 300, 400, 730_000];
         let times: Vec<u64> = vec![0, 10, 20, 30, 40, 70];
@@ -892,7 +892,7 @@ mod tests {
         assert_eq!(curve.times, times);
     }
 
-    #[rstest]
+    #[test]
     fn test_compute_space_time_curves_case_3() {
         let positions: Vec<u64> = vec![
             0, 100_000, 200_000, 300_000, 400_000, 450_000, 500_000, 600_000, 720_000,
@@ -984,7 +984,7 @@ mod tests {
         }
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_simple_project_train_path_op() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -1047,7 +1047,7 @@ mod tests {
         );
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_simple_reverse_project_train_path_op() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -1111,7 +1111,7 @@ mod tests {
         );
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_points_project_train_path_op() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -1170,7 +1170,7 @@ mod tests {
         assert_eq!(curves[3].positions, vec![400_000, 400_000]);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_no_matching_points_project_train_path_op() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();

--- a/editoast/src/views/rolling_stock.rs
+++ b/editoast/src/views/rolling_stock.rs
@@ -1267,7 +1267,6 @@ pub mod tests {
     }
 
     #[rstest]
-    #[serial_test::serial]
     async fn update_locked_rolling_stock_fails() {
         // GIVEN
         let app = TestAppBuilder::default_app();
@@ -1337,7 +1336,6 @@ pub mod tests {
     }
 
     #[rstest]
-    #[serial_test::serial]
     async fn patch_unlock_rolling_stock_successfully() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -1392,7 +1390,6 @@ pub mod tests {
     }
 
     #[rstest]
-    #[serial_test::serial]
     async fn delete_locked_rolling_stock_fails() {
         // GIVEN
         let app = TestAppBuilder::default_app();
@@ -1426,7 +1423,6 @@ pub mod tests {
     }
 
     #[rstest]
-    #[serial_test::serial]
     async fn delete_unlocked_unused_rolling_stock_succeeds() {
         // GIVEN
         let app = TestAppBuilder::default_app();
@@ -1452,7 +1448,6 @@ pub mod tests {
     }
 
     #[rstest]
-    #[serial_test::serial]
     async fn delete_unlocked_used_rolling_stock_requires_force_flag() {
         // GIVEN
         let app = TestAppBuilder::default_app();

--- a/editoast/src/views/rolling_stock.rs
+++ b/editoast/src/views/rolling_stock.rs
@@ -751,7 +751,7 @@ pub mod tests {
     use editoast_models::rolling_stock::TrainMainCategory;
     use itertools::Itertools;
     use pretty_assertions::assert_eq;
-    use rstest::rstest;
+
     use serde_json::json;
     use uuid::Uuid;
 
@@ -793,7 +793,7 @@ pub mod tests {
         form
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn create_rolling_stock_successfully() {
         // GIVEN
         let app = TestAppBuilder::default_app();
@@ -822,7 +822,7 @@ pub mod tests {
         );
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn create_locked_rolling_stock_successfully() {
         // GIVEN
         let app = TestAppBuilder::default_app();
@@ -850,7 +850,7 @@ pub mod tests {
         assert_eq!(rolling_stock.locked, true);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn create_rolling_stock_with_duplicate_name() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -872,7 +872,7 @@ pub mod tests {
         );
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_rolling_stock_usage_with_no_usage_returns_empty_ok() {
         let app = TestAppBuilder::default_app();
         let stock_name = Uuid::new_v4().to_string();
@@ -885,7 +885,7 @@ pub mod tests {
         assert!(related_schedules.is_empty());
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_rolling_stock_usage_with_related_schedules_returns_schedules_list() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -983,7 +983,7 @@ pub mod tests {
         );
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_invalid_rolling_stock_id_returns_404_not_found() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -993,7 +993,7 @@ pub mod tests {
         app.fetch(request).assert_status(StatusCode::NOT_FOUND);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn create_rolling_stock_with_base_power_class_empty() {
         // GIVEN
         let app = TestAppBuilder::default_app();
@@ -1018,7 +1018,7 @@ pub mod tests {
         );
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn create_rolling_stock_with_invalid_effort_curve() {
         let app = TestAppBuilder::default_app();
 
@@ -1036,7 +1036,7 @@ pub mod tests {
             .assert_status(StatusCode::UNPROCESSABLE_ENTITY);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_rolling_stock_by_id() {
         // GIVEN
         let app = TestAppBuilder::default_app();
@@ -1056,7 +1056,7 @@ pub mod tests {
         assert_eq!(response, fast_rolling_stock);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_rolling_stock_by_name() {
         // GIVEN
         let app = TestAppBuilder::default_app();
@@ -1076,7 +1076,7 @@ pub mod tests {
         assert_eq!(response, fast_rolling_stock);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_unexisting_rolling_stock_by_id() {
         let app = TestAppBuilder::default_app();
 
@@ -1085,7 +1085,7 @@ pub mod tests {
         app.fetch(request).assert_status(StatusCode::NOT_FOUND);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_unexisting_rolling_stock_by_name() {
         let app = TestAppBuilder::default_app();
 
@@ -1095,7 +1095,7 @@ pub mod tests {
         app.fetch(request).assert_status(StatusCode::NOT_FOUND);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn update_unlocked_rolling_stock() {
         // GIVEN
         let app = TestAppBuilder::default_app();
@@ -1132,7 +1132,7 @@ pub mod tests {
         );
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn update_rolling_stock_with_new_categories() {
         // GIVEN
         let app = TestAppBuilder::default_app();
@@ -1189,7 +1189,7 @@ pub mod tests {
         );
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn update_rolling_stock_categories_should_fail_when_invalid() {
         // GIVEN
         let app = TestAppBuilder::default_app();
@@ -1232,7 +1232,7 @@ pub mod tests {
         assert_eq!(updated_rolling_stock.version, fast_rolling_stock.version);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn update_rolling_stock_failure_name_already_used() {
         // GIVEN
         let app = TestAppBuilder::default_app();
@@ -1266,7 +1266,7 @@ pub mod tests {
         );
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn update_locked_rolling_stock_fails() {
         // GIVEN
         let app = TestAppBuilder::default_app();
@@ -1298,7 +1298,7 @@ pub mod tests {
         assert_eq!(response.error_type, "editoast:rollingstocks:IsLocked");
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn patch_lock_rolling_stock_failed() {
         let app = TestAppBuilder::default_app();
 
@@ -1310,7 +1310,7 @@ pub mod tests {
         app.fetch(request).assert_status(StatusCode::NOT_FOUND);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn patch_lock_rolling_stock_successfully() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -1335,7 +1335,7 @@ pub mod tests {
         assert_eq!(fast_rolling_stock.locked, true)
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn patch_unlock_rolling_stock_successfully() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -1364,7 +1364,7 @@ pub mod tests {
         assert!(!fast_rolling_stock.locked);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_power_restrictions_list() {
         // GIVEN
         let app = TestAppBuilder::default_app();
@@ -1389,7 +1389,7 @@ pub mod tests {
         assert!(response.contains(&"C5".to_string()));
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn delete_locked_rolling_stock_fails() {
         // GIVEN
         let app = TestAppBuilder::default_app();
@@ -1422,7 +1422,7 @@ pub mod tests {
         assert!(rolling_stock_exists);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn delete_unlocked_unused_rolling_stock_succeeds() {
         // GIVEN
         let app = TestAppBuilder::default_app();
@@ -1447,7 +1447,7 @@ pub mod tests {
         assert!(!rolling_stock_exists);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn delete_unlocked_used_rolling_stock_requires_force_flag() {
         // GIVEN
         let app = TestAppBuilder::default_app();

--- a/editoast/src/views/rolling_stock/light.rs
+++ b/editoast/src/views/rolling_stock/light.rs
@@ -338,7 +338,7 @@ mod tests {
 
     use axum::http::StatusCode;
     use pretty_assertions::assert_eq;
-    use rstest::*;
+    use rstest::rstest;
 
     use super::LightRollingStockWithLiveries;
     use super::LightRollingStockWithLiveriesCountList;
@@ -356,14 +356,14 @@ mod tests {
         true
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn list_light_rolling_stock() {
         let app = TestAppBuilder::default_app();
         let request = app.get("/light_rolling_stock");
         app.fetch(request).assert_status(StatusCode::OK);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_light_rolling_stock() {
         // GIVEN
         let app = TestAppBuilder::default_app();
@@ -382,7 +382,7 @@ mod tests {
         assert_eq!(response.rolling_stock.id, fast_rolling_stock.id);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_light_rolling_stock_by_name() {
         // GIVEN
         let app = TestAppBuilder::default_app();
@@ -402,7 +402,7 @@ mod tests {
         assert_eq!(response.rolling_stock.name, fast_rolling_stock.name);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_unexisting_light_rolling_stock() {
         let app = TestAppBuilder::default_app();
 
@@ -411,7 +411,7 @@ mod tests {
         app.fetch(request).assert_status(StatusCode::NOT_FOUND);
     }
 
-    #[rstest]
+    #[rstest] // TODO: fix deadlock with tokio::test
     async fn list_light_rolling_stock_increasing_ids() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -459,7 +459,7 @@ mod tests {
         assert!(expected_rs_ids.is_subset(&ids));
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn light_rolling_stock_max_page_size() {
         let app = TestAppBuilder::default_app();
 

--- a/editoast/src/views/rolling_stock/towed.rs
+++ b/editoast/src/views/rolling_stock/towed.rs
@@ -288,7 +288,7 @@ mod tests {
     use axum::http::StatusCode;
     use common::units;
     use editoast_models::TowedRollingStock;
-    use rstest::rstest;
+
     use serde_json::json;
     use uuid::Uuid;
 
@@ -322,7 +322,7 @@ mod tests {
         app.fetch(request).assert_status(StatusCode::OK).json_into()
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn create_and_list_towed_rolling_stock() {
         let app = TestAppBuilder::default_app();
 
@@ -345,7 +345,7 @@ mod tests {
         );
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_unknown_towed_rolling_stock() {
         let app = TestAppBuilder::default_app();
 
@@ -355,7 +355,7 @@ mod tests {
             .assert_status(StatusCode::NOT_FOUND);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn create_and_get_towed_rolling_stock() {
         let app = TestAppBuilder::default_app();
 
@@ -374,7 +374,7 @@ mod tests {
         assert_eq!(get_towed_rolling_stock, created_towed_rolling_stock);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn modify_unknown_towed_rolling_stock() {
         let app = TestAppBuilder::default_app();
 
@@ -389,7 +389,7 @@ mod tests {
         .assert_status(StatusCode::NOT_FOUND);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn modify_towed_rolling_stock() {
         let app = TestAppBuilder::default_app();
 
@@ -413,7 +413,7 @@ mod tests {
         );
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn modify_lock_on_unknown_towed_rolling_stock() {
         let app = TestAppBuilder::default_app();
 
@@ -425,7 +425,7 @@ mod tests {
         .assert_status(StatusCode::NOT_FOUND);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn modify_locked_towed_rolling_stock_fails() {
         let app = TestAppBuilder::default_app();
 
@@ -441,7 +441,7 @@ mod tests {
         .assert_status(StatusCode::CONFLICT);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn modify_locked_towed_rolling_stock_after_unlocked() {
         let app = TestAppBuilder::default_app();
 

--- a/editoast/src/views/scenario.rs
+++ b/editoast/src/views/scenario.rs
@@ -517,7 +517,7 @@ async fn check_project_study_scenario(
 #[cfg(test)]
 mod tests {
     use pretty_assertions::assert_eq;
-    use rstest::rstest;
+
     use serde_json::json;
 
     use super::*;
@@ -537,7 +537,7 @@ mod tests {
         )
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_scenario() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
@@ -557,7 +557,7 @@ mod tests {
         assert_eq!(response.scenario, fixtures.scenario);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_scenarios() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
@@ -581,7 +581,7 @@ mod tests {
         );
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_scenarios_with_wrong_study() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
@@ -595,7 +595,7 @@ mod tests {
         app.fetch(request).assert_status(StatusCode::NOT_FOUND);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn post_scenario() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
@@ -645,7 +645,7 @@ mod tests {
         assert_eq!(created_scenario.tags, study_tags);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn patch_scenario() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
@@ -677,7 +677,7 @@ mod tests {
         assert!(response.scenario.last_modification > fixtures.scenario.last_modification);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn patch_scenario_with_unavailable_infra() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
@@ -698,7 +698,7 @@ mod tests {
         app.fetch(request).assert_status(StatusCode::NOT_FOUND);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn patch_infra_id_scenario() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
@@ -729,7 +729,7 @@ mod tests {
         assert_eq!(response.scenario.name, study_name);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn delete_scenario() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();

--- a/editoast/src/views/scenario/macro_nodes.rs
+++ b/editoast/src/views/scenario/macro_nodes.rs
@@ -411,7 +411,6 @@ pub mod test {
     use rand::Rng;
     use rand::distr::Alphanumeric;
     use rand::rng;
-    use rstest::rstest;
 
     use super::*;
     use crate::models::Project;
@@ -444,7 +443,7 @@ pub mod test {
         }
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn create() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -484,7 +483,7 @@ pub mod test {
         assert_eq!(node, response.macro_nodes[0]);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn update() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -517,7 +516,7 @@ pub mod test {
         assert_eq!(node, response);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -533,7 +532,7 @@ pub mod test {
         assert!(fixtures.nodes[0] == response);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn list() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -550,7 +549,7 @@ pub mod test {
         assert_eq!(5, response.results.len());
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn delete() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -568,7 +567,7 @@ pub mod test {
         assert_eq!(false, found)
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn retrieve_with_bad_scenario() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();

--- a/editoast/src/views/scenario/macro_notes.rs
+++ b/editoast/src/views/scenario/macro_notes.rs
@@ -400,7 +400,6 @@ pub mod test {
     use pretty_assertions::assert_eq;
     use rand::Rng;
     use rand::rng;
-    use rstest::rstest;
 
     use super::*;
     use crate::models::fixtures::create_scenario_fixtures_set;
@@ -416,7 +415,7 @@ pub mod test {
         }
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn list_notes() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -474,7 +473,7 @@ pub mod test {
         );
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn create_note() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -524,7 +523,7 @@ pub mod test {
         }
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn create_note_scenario_not_found() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -552,7 +551,7 @@ pub mod test {
         app.fetch(request).assert_status(StatusCode::NOT_FOUND);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_note() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -580,7 +579,7 @@ pub mod test {
         assert_eq!(MacroNoteResponse::from(note), response);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_note_not_found() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -595,7 +594,7 @@ pub mod test {
         app.fetch(request).assert_status(StatusCode::NOT_FOUND);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_note_wrong_scenario() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -623,7 +622,7 @@ pub mod test {
         app.fetch(request).assert_status(StatusCode::NOT_FOUND);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn update_note() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -667,7 +666,7 @@ pub mod test {
         assert_eq!(MacroNoteResponse::from(note), response);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn update_note_not_found() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -692,7 +691,7 @@ pub mod test {
         app.fetch(request).assert_status(StatusCode::NOT_FOUND);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn delete_note() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -723,7 +722,7 @@ pub mod test {
         assert!(!still_exists);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn delete_note_not_found() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();

--- a/editoast/src/views/search.rs
+++ b/editoast/src/views/search.rs
@@ -800,7 +800,7 @@ pub mod tests {
 
     use axum::http::StatusCode;
     use pretty_assertions::assert_eq;
-    use rstest::rstest;
+
     use serde_json::json;
 
     use super::*;
@@ -808,7 +808,7 @@ pub mod tests {
     use crate::models::fixtures::create_timetable;
     use crate::views::test_app::TestAppBuilder;
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn search_trainschedule_post_found() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
@@ -834,7 +834,7 @@ pub mod tests {
         assert_eq!(response[0].train_name, train.train_name);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn search_trainschedule_post_not_found() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();

--- a/editoast/src/views/sprites.rs
+++ b/editoast/src/views/sprites.rs
@@ -77,9 +77,8 @@ mod tests {
     use crate::views::test_app::TestAppBuilder;
 
     use axum::http::StatusCode;
-    use rstest::rstest;
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_signaling_systems() {
         let app = TestAppBuilder::default_app();
         let request = app.get("/sprites/signaling_systems");
@@ -92,7 +91,7 @@ mod tests {
         assert!(response.contains(&"ETCS_LEVEL2".to_string()));
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_sprites() {
         let app = TestAppBuilder::default_app();
         let request = app.get("/sprites/TVM300/REP%20TGV.svg");
@@ -108,7 +107,7 @@ mod tests {
         assert_eq!(response, expected);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_sprites_not_found() {
         let app = TestAppBuilder::default_app();
         let request = app.get("/sprites/TVM300/NOT_A_THING.svg");

--- a/editoast/src/views/stdcm_search_environment.rs
+++ b/editoast/src/views/stdcm_search_environment.rs
@@ -331,13 +331,12 @@ pub mod tests {
     use chrono::TimeZone;
     use chrono::Utc;
     use pretty_assertions::assert_eq;
-    use rstest::rstest;
 
     use super::*;
     use crate::models::stdcm_search_environment::tests::stdcm_search_env_fixtures;
     use crate::views::test_app::TestAppBuilder;
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn create_stdcm_search_env() {
         // GIVEN
         let app = TestAppBuilder::default_app();
@@ -388,7 +387,7 @@ pub mod tests {
         assert_eq!(stdcm_search_env, stdcm_search_env_in_db);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn create_stdcm_search_env_with_bad_default_speed_limit_tag() {
         // GIVEN
         let app = TestAppBuilder::default_app();
@@ -429,7 +428,7 @@ pub mod tests {
             .assert_status(StatusCode::UNPROCESSABLE_ENTITY);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn retrieve_stdcm_search_env() {
         // GIVEN
         let app = TestAppBuilder::default_app();
@@ -487,7 +486,7 @@ pub mod tests {
         assert_eq!(stdcm_search_env.enabled_until, enabled_until);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn retrieve_stdcm_search_env_not_found() {
         // GIVEN
         let app = TestAppBuilder::default_app();
@@ -505,7 +504,7 @@ pub mod tests {
         response.assert_status(StatusCode::NO_CONTENT);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn delete_stdcm_search_env() {
         // GIVEN
         let app = TestAppBuilder::default_app();
@@ -546,7 +545,7 @@ pub mod tests {
         assert_eq!(deleted_env_exists, false);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn list_stdcm_search_env() {
         // GIVEN
         let app = TestAppBuilder::default_app();

--- a/editoast/src/views/study.rs
+++ b/editoast/src/views/study.rs
@@ -428,7 +428,7 @@ pub(in crate::views) async fn list(
 #[cfg(test)]
 pub mod tests {
     use pretty_assertions::assert_eq;
-    use rstest::rstest;
+
     use serde_json::json;
 
     use super::*;
@@ -437,7 +437,7 @@ pub mod tests {
     use crate::models::fixtures::create_study;
     use crate::views::test_app::TestAppBuilder;
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn study_post() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -468,7 +468,7 @@ pub mod tests {
         assert_eq!(study.project_id, created_project.id);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn study_list() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -492,7 +492,7 @@ pub mod tests {
         assert_eq!(studies_retrieved.study, created_study);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn study_get() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -514,7 +514,7 @@ pub mod tests {
         assert_eq!(response.project, created_project);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn study_get_not_found() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -533,7 +533,7 @@ pub mod tests {
         app.fetch(request).assert_status(StatusCode::NOT_FOUND);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn study_delete() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -557,7 +557,7 @@ pub mod tests {
         assert!(!exists);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn study_patch() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();

--- a/editoast/src/views/sub_categories.rs
+++ b/editoast/src/views/sub_categories.rs
@@ -223,7 +223,7 @@ pub mod tests {
     use axum::http::StatusCode;
     use editoast_models::rolling_stock::TrainMainCategory;
     use pretty_assertions::assert_eq;
-    use rstest::rstest;
+
     use schemas::rolling_stock::SubCategory;
     use serde_json::json;
 
@@ -236,7 +236,7 @@ pub mod tests {
     use crate::views::test_app::TestAppBuilder;
     use editoast_models::prelude::*;
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn sub_category_post() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -288,7 +288,7 @@ pub mod tests {
         assert_eq!(created_sub_category2, &sub_category_2);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn sub_category_duplicated_post() {
         let app = TestAppBuilder::default_app();
 
@@ -314,7 +314,7 @@ pub mod tests {
         app.fetch(request).assert_status(StatusCode::BAD_REQUEST);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn sub_category_get() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -344,7 +344,7 @@ pub mod tests {
         );
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn sub_category_delete() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();

--- a/editoast/src/views/temporary_speed_limits.rs
+++ b/editoast/src/views/temporary_speed_limits.rs
@@ -172,7 +172,7 @@ mod tests {
     use chrono::Duration;
     use chrono::Utc;
     use editoast_models::TemporarySpeedLimitGroup;
-    use rstest::rstest;
+
     use schemas::infra::Direction;
     use schemas::infra::DirectionalTrackRange;
     use serde_json::json;
@@ -270,7 +270,7 @@ mod tests {
         }
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn create_temporary_speed_limits_succeeds() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
@@ -311,7 +311,7 @@ mod tests {
         assert_eq!(obj_id, &request_obj_id);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn create_temporary_speed_limit_groups_with_identical_name_fails() {
         let app = TestAppBuilder::default_app();
 
@@ -330,7 +330,7 @@ mod tests {
         let _ = app.fetch(request).assert_status(StatusCode::BAD_REQUEST);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn create_ltv_with_invalid_invalid_time_period_fails() {
         let app = TestAppBuilder::default_app();
 
@@ -348,7 +348,7 @@ mod tests {
             .assert_status(StatusCode::UNPROCESSABLE_ENTITY);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[ignore] // TODO is this something we want to enforce ?
     async fn create_ltv_with_no_tracks_fails() {
         let app = TestAppBuilder::default_app();

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -985,7 +985,7 @@ mod tests {
     use crate::models::fixtures::simple_paced_train_base;
     use crate::views::test_app::TestAppBuilder;
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_timetable() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
@@ -999,14 +999,14 @@ mod tests {
         assert_eq!(timetable_from_response.results.len(), 0);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_unexisting_timetable() {
         let app = TestAppBuilder::default_app();
         let request = app.get(&format!("/timetable/{}/train_schedules", 0));
         app.fetch(request).assert_status(StatusCode::NOT_FOUND);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn timetable_post() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
@@ -1026,7 +1026,7 @@ mod tests {
         assert_eq!(created_timetable, retrieved_timetable.into());
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn timetable_delete() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
@@ -1044,7 +1044,7 @@ mod tests {
         assert!(!exists);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn create_paced_train_exceptions() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
@@ -1115,7 +1115,7 @@ mod tests {
         assert_eq!(&list_result[0].exceptions[1], &exception_2);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn create_paced_train_with_duplicated_exceptions() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
@@ -1142,7 +1142,7 @@ mod tests {
         )
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn create_paced_train() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
@@ -1177,7 +1177,7 @@ mod tests {
         assert_eq!(list_result[0].exceptions, paced_train_2.exceptions);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_timetable_paced_trains() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
@@ -1210,7 +1210,7 @@ mod tests {
         assert_eq!(list.results.len(), 2);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_not_found_timetable_paced_trains() {
         let app = TestAppBuilder::default_app();
         let request = app.get(format!("/timetable/{}/paced_trains", 0).as_str());

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -1149,7 +1149,7 @@ mod tests {
     use database::DbConnectionPoolV2;
     use editoast_models::rolling_stock::TrainMainCategory;
     use pretty_assertions::assert_eq;
-    use rstest::rstest;
+
     use schemas::fixtures::simple_created_exception_with_change_groups;
     use schemas::fixtures::simple_modified_exception_with_change_groups;
     use schemas::paced_train::InitialSpeedChangeGroup;
@@ -1189,7 +1189,7 @@ mod tests {
     use crate::views::timetable::simulation::SummaryResponse;
     use editoast_models::prelude::*;
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn paced_train_post() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
@@ -1206,7 +1206,7 @@ mod tests {
         assert_eq!(response.len(), 1);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn paced_train_with_sub_category() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
@@ -1255,7 +1255,7 @@ mod tests {
         );
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn update_paced_train_exception() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
@@ -1293,7 +1293,7 @@ mod tests {
         );
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn update_paced_train() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
@@ -1319,7 +1319,7 @@ mod tests {
         assert_eq!(paced_train_base, updated_paced_train.into());
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn update_paced_train_with_duplicated_exceptions() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
@@ -1349,7 +1349,7 @@ mod tests {
         )
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn update_paced_train_with_invalid_exceptions_occurrence_index() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
@@ -1378,7 +1378,7 @@ mod tests {
         )
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn paced_train_delete() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
@@ -1399,7 +1399,7 @@ mod tests {
         assert!(!exists);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_not_found_paced_train() {
         let app = TestAppBuilder::default_app();
         let request = app.get(&format!("/paced_train/{}", 0));
@@ -1412,7 +1412,7 @@ mod tests {
         assert_eq!(&response.error_type, "editoast:paced_train:NotFound")
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_paced_train() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
@@ -1464,7 +1464,7 @@ mod tests {
         (app, small_infra.id, paced_train.id)
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn paced_train_simulation() {
         let (app, infra_id, train_schedule_id) =
             app_infra_id_paced_train_id_for_simulation_tests().await;
@@ -1516,7 +1516,7 @@ mod tests {
         );
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn paced_train_exception_simulation_with_invalid_exception_key() {
         let (app, infra_id, train_schedule_id) =
             app_infra_id_paced_train_id_for_simulation_tests().await;
@@ -1537,7 +1537,7 @@ mod tests {
         )
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn paced_train_exception_simulation() {
         let (app, infra_id, train_schedule_id) =
             app_infra_id_paced_train_id_for_simulation_tests().await;
@@ -1589,7 +1589,7 @@ mod tests {
         );
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn paced_train_exception_simulation_with_rolling_stock_not_found() {
         // GIVEN
         let (app, infra_id, train_schedule_id) =
@@ -1626,7 +1626,7 @@ mod tests {
         );
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn paced_train_simulation_not_found() {
         let (app, infra_id, _paced_train_id) =
             app_infra_id_paced_train_id_for_simulation_tests().await;
@@ -1641,7 +1641,7 @@ mod tests {
         assert_eq!(&response.error_type, "editoast:paced_train:NotFound")
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn paced_train_simulation_summary() {
         let (app, infra_id, paced_train_id) =
             app_infra_id_paced_train_id_for_simulation_tests().await;
@@ -1715,7 +1715,7 @@ mod tests {
         );
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn paced_train_simulation_summary_not_found() {
         let (app, infra_id, _paced_train_id) =
             app_infra_id_paced_train_id_for_simulation_tests().await;
@@ -1731,7 +1731,7 @@ mod tests {
         assert_eq!(&response.error_type, "editoast:paced_train:BatchNotFound")
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_paced_train_path_infra_not_found() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
@@ -1751,7 +1751,7 @@ mod tests {
         assert_eq!(&response.error_type, "editoast:paced_train:InfraNotFound")
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_paced_train_path_not_found() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
@@ -1770,7 +1770,7 @@ mod tests {
         assert_eq!(&response.error_type, "editoast:paced_train:NotFound");
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_paced_train_path_with_invalid_exception_key() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
@@ -1795,7 +1795,7 @@ mod tests {
         )
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_paced_train_path() {
         let mut core = MockingClient::new();
         core.stub("/pathfinding/blocks")
@@ -1843,7 +1843,7 @@ mod tests {
         )
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_paced_train_exception_path_rolling_stock_not_found() {
         let mut core = MockingClient::new();
         core.stub("/pathfinding/blocks")
@@ -1896,7 +1896,7 @@ mod tests {
         )
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_paced_train_exception_path() {
         let mut core = MockingClient::new();
         core.stub("/pathfinding/blocks")
@@ -1951,7 +1951,7 @@ mod tests {
         )
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn paced_train_project_path() {
         // SETUP
         let db_pool = DbConnectionPoolV2::for_tests();
@@ -1995,7 +1995,7 @@ mod tests {
         assert_eq!(response.len(), 2);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn paced_train_occupancy_blocks() {
         let (app, infra_id, paced_train_id) =
             app_infra_id_paced_train_id_for_simulation_tests().await;

--- a/editoast/src/views/timetable/similar_trains.rs
+++ b/editoast/src/views/timetable/similar_trains.rs
@@ -977,6 +977,7 @@ mod tests {
     }
 
     #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     // MWS(33):stop  MES(44):passing_by  NS(55):stop
     #[case(
         vec![
@@ -1045,6 +1046,7 @@ mod tests {
     }
 
     #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     // Different rolling stock
     #[case(
         1,
@@ -1150,7 +1152,7 @@ mod tests {
         assert_eq!(response, Response { similar_trains });
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn compound_similar_trains() {
         let mut core = MockingClient::new();
         core.stub("/pathfinding/blocks")
@@ -1287,7 +1289,7 @@ mod tests {
         assert_eq!(response, expected_response);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_select_single_train_without_merging_consecutive_segments() {
         let mut core = MockingClient::new();
         core.stub("/pathfinding/blocks")
@@ -1469,7 +1471,7 @@ mod tests {
         assert_eq!(response, expected_response);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn no_similar_trains_for_some_segments() {
         let mut core = MockingClient::new();
         core.stub("/pathfinding/blocks")
@@ -1659,7 +1661,7 @@ mod tests {
         ));
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_similar_trains_by_relaxing_name_criterion() {
         let mut core = MockingClient::new();
         core.stub("/pathfinding/blocks")

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -807,7 +807,7 @@ mod tests {
         );
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn stdcm_return_success() {
         let mut core = core_mocking_client();
         core.stub("/stdcm")
@@ -850,7 +850,7 @@ mod tests {
         }
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn stdcm_request_mass_validation() {
         let mut core = core_mocking_client();
         core.stub("/stdcm")
@@ -890,7 +890,7 @@ mod tests {
         );
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn stdcm_request_length_validation() {
         let mut core = core_mocking_client();
         core.stub("/stdcm")
@@ -932,7 +932,7 @@ mod tests {
         assert_eq!(stdcm_response.context["expected_min"].as_f64(), Some(400.0));
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn stdcm_request_validation_success() {
         let mut core = core_mocking_client();
         core.stub("/stdcm")
@@ -982,7 +982,7 @@ mod tests {
         }
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn stdcm_fails() {
         let mut core = core_mocking_client();
         core.stub("/stdcm")

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -1257,7 +1257,7 @@ pub mod tests {
     use crate::views::tests::mocked_core_pathfinding_and_sim;
     use crate::views::tests::mocked_core_pathfinding_sim_and_proj;
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn train_schedule_get() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
@@ -1281,7 +1281,7 @@ pub mod tests {
         );
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn train_schedule_post() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
@@ -1299,7 +1299,7 @@ pub mod tests {
         assert_eq!(response.len(), 1);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn train_schedule_with_sub_category() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
@@ -1348,7 +1348,7 @@ pub mod tests {
         );
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn train_schedule_delete() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
@@ -1369,7 +1369,7 @@ pub mod tests {
         assert!(!exists);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn train_schedule_put() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
@@ -1397,7 +1397,7 @@ pub mod tests {
         )
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn train_schedule_put_with_category() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
@@ -1442,7 +1442,7 @@ pub mod tests {
         )
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn train_schedule_put_with_none_category() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
@@ -1517,7 +1517,7 @@ pub mod tests {
         (app, small_infra.id, train_schedule.id)
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn train_schedule_simulation() {
         let (app, infra_id, train_schedule_id) =
             app_infra_id_train_schedule_id_for_simulation_tests().await;
@@ -1527,7 +1527,7 @@ pub mod tests {
         app.fetch(request).assert_status(StatusCode::OK);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn train_schedule_simulation_summary() {
         let (app, infra_id, train_schedule_id) =
             app_infra_id_train_schedule_id_for_simulation_tests().await;
@@ -1538,7 +1538,7 @@ pub mod tests {
         app.fetch(request).assert_status(StatusCode::OK);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn train_schedule_project_path() {
         // SETUP
         let db_pool = DbConnectionPoolV2::for_tests();
@@ -1605,7 +1605,7 @@ pub mod tests {
         assert_eq!(response.len(), 2);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_track_occupancy_fake_operational_point_id() {
         let db_pool = DbConnectionPoolV2::for_tests();
 
@@ -1647,7 +1647,7 @@ pub mod tests {
         app.fetch(request).assert_status(StatusCode::NOT_FOUND);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_track_occupancy_pathfinding_failure() {
         let db_pool = DbConnectionPoolV2::for_tests();
 
@@ -1866,7 +1866,7 @@ pub mod tests {
         );
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_occupancy_blocks() {
         let (app, infra_id, train_schedule_id) =
             app_infra_id_train_schedule_id_for_simulation_tests().await;

--- a/editoast/src/views/work_schedules.rs
+++ b/editoast/src/views/work_schedules.rs
@@ -507,7 +507,7 @@ pub mod tests {
     use crate::models::fixtures::create_work_schedules_fixture_set;
     use crate::views::test_app::TestAppBuilder;
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn work_schedule_create() {
         // GIVEN
         let app = TestAppBuilder::default_app();
@@ -540,7 +540,7 @@ pub mod tests {
         assert!(created_group.is_some());
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn work_schedule_create_fail_start_date_after_end_date() {
         let app = TestAppBuilder::default_app();
 
@@ -559,7 +559,7 @@ pub mod tests {
             .assert_status(StatusCode::UNPROCESSABLE_ENTITY);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn work_schedule_create_fail_name_already_used() {
         // GIVEN
         let app = TestAppBuilder::default_app();
@@ -595,6 +595,7 @@ pub mod tests {
     }
 
     #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[case::one_work_schedule_with_two_track_ranges(
         vec![
             vec![
@@ -730,7 +731,7 @@ pub mod tests {
         assert_eq!(work_schedule_project_response, expected);
     }
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn work_schedule_endpoints_workflow() {
         let app = TestAppBuilder::default_app();
 

--- a/editoast/src/views/worker_load.rs
+++ b/editoast/src/views/worker_load.rs
@@ -158,12 +158,11 @@ mod tests {
     use database::DbConnectionPoolV2;
     use osrdyne_client::OsrdyneClient;
     use reqwest::StatusCode;
-    use rstest::rstest;
 
     use crate::models::fixtures::create_empty_infra;
     use crate::views::test_app::TestAppBuilder;
 
-    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn worker_load_test() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;


### PR DESCRIPTION
A first step to get rid of async-std.

<details open id="prdesc">

- 486f4e87b *editoast: remove `serial_test`*
    ```md
    Not necessary anymore since each test run in its own database.
    ```
- 8df23fb0b *editoast: run ingored test again*
- 299fb65c2 *editoast: replace most `<hashtag>[rstest]` by `<hashtag>[tokio::test]`*
    ```md
    12 tests still deadlock even with `tokio::test` configured properly.
    I suspect `block_on` in test data setup not to behave as we expect.
    ```

</details>