### PR TITLE
core: stdcm: reproduce and fix simulation mismatch

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
@@ -56,6 +56,7 @@ class STDCMGraph(
             rollingStock,
             speedLimitTag = tag,
             temporarySpeedLimitManager = temporarySpeedLimitManager,
+            addRollingStockLength = false,
         )
 
     // min 30s between two edges, determined empirically

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMSimulations.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMSimulations.kt
@@ -106,7 +106,7 @@ class STDCMSimulations {
         }
         val path = infraExplorer.getCurrentEdgePathProperties(start, simLength)
         val context = build(rollingStock, path, timeStep, comfort)
-        val mrsp = computeMRSP(path, rollingStock, true, trainTag, temporarySpeedLimitManager)
+        val mrsp = computeMRSP(path, rollingStock, false, trainTag, temporarySpeedLimitManager)
         return try {
             val maxSpeedEnvelope = maxSpeedEnvelopeFrom(context, stops, mrsp)
             maxEffortEnvelopeFrom(context, initialSpeed, maxSpeedEnvelope)

--- a/core/src/main/kotlin/fr/sncf/osrd/utils/CachedBlockMRSPBuilder.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/utils/CachedBlockMRSPBuilder.kt
@@ -27,6 +27,7 @@ data class CachedBlockMRSPBuilder(
     private val rsLength: Double,
     private val speedLimitTag: String? = null,
     val temporarySpeedLimitManager: TemporarySpeedLimitManager = TemporarySpeedLimitManager(),
+    val addRollingStockLength: Boolean = true,
 ) {
     private val mrspCache = mutableMapOf<BlockId, Envelope>()
 
@@ -36,6 +37,7 @@ data class CachedBlockMRSPBuilder(
         rollingStock: PhysicsRollingStock?,
         speedLimitTag: String? = null,
         temporarySpeedLimitManager: TemporarySpeedLimitManager = TemporarySpeedLimitManager(),
+        addRollingStockLength: Boolean = true,
     ) : this(
         rawInfra,
         blockInfra,
@@ -43,6 +45,7 @@ data class CachedBlockMRSPBuilder(
         rollingStock?.length ?: 0.0,
         speedLimitTag,
         temporarySpeedLimitManager,
+        addRollingStockLength,
     )
 
     /** Returns the speed limits for the given block (cached). */
@@ -54,7 +57,7 @@ data class CachedBlockMRSPBuilder(
                 pathProps,
                 rsMaxSpeed,
                 rsLength,
-                addRollingStockLength = true,
+                addRollingStockLength = addRollingStockLength,
                 speedLimitTag,
                 temporarySpeedLimitManager,
             )

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMPathfindingTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMPathfindingTests.kt
@@ -3,10 +3,15 @@ package fr.sncf.osrd.stdcm
 import com.google.common.collect.ImmutableMultimap
 import fr.sncf.osrd.pathfinding.Pathfinding.EdgeLocation
 import fr.sncf.osrd.sim_infra.api.BlockId
+import fr.sncf.osrd.sim_infra.api.SpeedLimitProperty
 import fr.sncf.osrd.stdcm.preprocessing.OccupancySegment
+import fr.sncf.osrd.train.TestTrains
+import fr.sncf.osrd.utils.DistanceRangeMap
 import fr.sncf.osrd.utils.DummyInfra
+import fr.sncf.osrd.utils.distanceRangeMapOf
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
+import fr.sncf.osrd.utils.units.metersPerSecond
 import fr.sncf.osrd.utils.units.seconds
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
@@ -784,5 +789,68 @@ class STDCMPathfindingTests {
                 .run()!!
 
         assertEquals(totalDelay, res.departureTime)
+    }
+
+    /**
+     * Reproduce https://github.com/OpenRailAssociation/osrd/issues/13628
+     *
+     * ```
+     * infra:            a ----------------> b -----> c -----> d
+     * speed limits:       [][                               ]
+     *                    1m/s             50m/s
+     * ```
+     *
+     * The train is extremely long and the speed limit *should* keep going for the entirety of the
+     * path. But for stdcm, we can't properly carry this data across blocks, so for consistency we
+     * dismiss speed limits as soon as the train head leaves it (instead of its tail).
+     *
+     * If we try to extend the speed limit, then mismatches will happen in the second block. During
+     * the exploration it will start at 1m/s, while in post-processing it will either start at high
+     * speed or remain at 1m/s for the entire path. Either way, the conflict halfway through the
+     * second block won't be properly timed.
+     */
+    @Test
+    fun reproduceMRSPMismatch() {
+        val infra = DummyInfra()
+        val firstBlockSpeedLimit =
+            distanceRangeMapOf(
+                DistanceRangeMap.RangeMapEntry(
+                    0.meters,
+                    1.meters,
+                    SpeedLimitProperty(1.0.metersPerSecond, null),
+                ),
+                DistanceRangeMap.RangeMapEntry(
+                    1.meters,
+                    10_000.meters,
+                    SpeedLimitProperty(50.0.metersPerSecond, null),
+                ),
+            )
+        val blocks =
+            listOf(
+                infra.addBlock(
+                    "a",
+                    "b",
+                    length = 10_000.meters,
+                    detailedSpeedLimits = firstBlockSpeedLimit,
+                ),
+                infra.addBlock("b", "c", length = 1_000.meters, allowedSpeed = 50.0),
+                infra.addBlock("c", "d", length = 1_000.meters, allowedSpeed = 50.0),
+            )
+        val occupancyGraph =
+            ImmutableMultimap.of(
+                blocks[1],
+                OccupancySegment(0.0, 11_000.0, 100.meters, 1_000.meters),
+            )
+        STDCMPathfindingBuilder()
+            .setInfra(infra.fullInfra())
+            .setStartLocations(
+                setOf(EdgeLocation(blocks[0], Offset(0.meters))),
+                PlannedTimingData(0.seconds, 0.seconds, 0.seconds),
+            )
+            .setEndLocations(setOf(EdgeLocation(blocks[2], Offset(1_000.meters))))
+            .setUnavailableTimes(occupancyGraph)
+            .setRollingStock(TestTrains.VERY_LONG_FAST_TRAIN)
+            .setMaxDepartureDelay(0.0)
+            .run()!!
     }
 }

--- a/core/src/test/kotlin/fr/sncf/osrd/utils/DummyInfra.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/utils/DummyInfra.kt
@@ -45,19 +45,23 @@ class DummyInfra : RawInfra, BlockInfra {
         length: Distance = 100.meters,
         allowedSpeed: Double = Double.POSITIVE_INFINITY,
         signalingSystemName: String = BAL.id,
+        detailedSpeedLimits: DistanceRangeMap<SpeedLimitProperty>? = null,
     ): BlockId {
         val name = String.format("%s->%s", entry, exit)
         val entryId = getOrCreateDetectorId(entry)
         val exitId = getOrCreateDetectorId(exit)
         val id = BlockId(blockPool.size.toUInt())
         val signalingSystemId = getSignalingSystemIdfromName(signalingSystemName)
+        val speedLimits =
+            detailedSpeedLimits
+                ?: makeRangeMap(length, SpeedLimitProperty(allowedSpeed.metersPerSecond, null))
         blockPool.add(
             DummyBlockDescriptor(
                 length,
                 name,
                 entryId,
                 exitId,
-                allowedSpeed,
+                speedLimits,
                 0.0,
                 signalingSystemId,
                 signalingSystemName,
@@ -91,7 +95,7 @@ class DummyInfra : RawInfra, BlockInfra {
         val name: String,
         val entry: DirDetectorId,
         val exit: DirDetectorId,
-        val allowedSpeed: Double,
+        val allowedSpeed: DistanceRangeMap<SpeedLimitProperty>,
         var gradient: Double,
         var signalingSystemId: SignalingSystemId,
         var signalingSystemName: String,
@@ -440,10 +444,7 @@ class DummyInfra : RawInfra, BlockInfra {
         route: String?,
     ): DistanceRangeMap<SpeedLimitProperty> {
         val desc = blockPool[trackChunk.value.index]
-        return makeRangeMap(
-            desc.length,
-            SpeedLimitProperty(desc.allowedSpeed.metersPerSecond, null),
-        )
+        return desc.allowedSpeed
     }
 
     override fun getTrackChunkGeom(trackChunk: TrackChunkId): LineString {


### PR DESCRIPTION
Fix https://github.com/OpenRailAssociation/osrd/issues/13628, and reproduce in unit test.

Identifying what was going up was *a mess*. Turns out it was likely introduced by https://github.com/OpenRailAssociation/osrd/pull/13508, which is kind of reverted here (it's fixed by never adding the rolling stock length instead of always adding it).

I explained most of what went wrong the test comment. 