### PR TITLE
editoast: fix some tests deadlocking with `#[tokio::test]`

### DIFF
--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -627,6 +627,7 @@ mod tests {
                        "infra": [infra1, infra2, infra3, infra4]
                     })),
             )
+            .await
             .assert_status(StatusCode::OK)
             .json_into::<HashMap<ResourceType, Vec<ResourcePrivileges>>>()
             .remove(&ResourceType::Infra)
@@ -693,6 +694,7 @@ mod tests {
                        "infra": [infra1, infra2, infra3, infra4]
                     })),
             )
+            .await
             .assert_status(StatusCode::OK)
             .json_into::<HashMap<ResourceType, Vec<ResourcePrivileges>>>()
             .remove(&ResourceType::Infra)
@@ -736,6 +738,7 @@ mod tests {
             .fetch(app.post("/authz/me/privileges").json(&json!({
                "infra": [infra]
             })))
+            .await
             .assert_status(StatusCode::OK)
             .json_into::<HashMap<ResourceType, Vec<ResourcePrivileges>>>()
             .remove(&ResourceType::Infra)
@@ -776,8 +779,11 @@ mod tests {
         let request = app.post("/authz/me/grants").by_user(&user).json(&json!({
             "infra": [infra.id],
         }));
-        let response: HashMap<ResourceType, Vec<UserResourceGrant>> =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: HashMap<ResourceType, Vec<UserResourceGrant>> = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         // Check the direct grant is there
         assert_eq!(
@@ -798,8 +804,11 @@ mod tests {
         let request = app.post("/authz/me/grants").by_user(&user).json(&json!({
             "infra": [infra.id],
         }));
-        let response: HashMap<ResourceType, Vec<UserResourceGrant>> =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: HashMap<ResourceType, Vec<UserResourceGrant>> = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         // Check the inherited grant from the group has overridden by the user's direct grant
         assert_eq!(
@@ -842,6 +851,7 @@ mod tests {
             .by_user(&user);
         let SubjectsWithGrantOnResource { subjects, .. } = app
             .fetch(request_all)
+            .await
             .assert_status(StatusCode::OK)
             .json_into();
         assert_eq!(subjects.len(), 6);
@@ -856,6 +866,7 @@ mod tests {
             .by_user(&user);
         let SubjectsWithGrantOnResource { subjects, .. } = app
             .fetch(request_all)
+            .await
             .assert_status(StatusCode::OK)
             .json_into();
         assert_eq!(subjects.len(), 1);
@@ -896,6 +907,7 @@ mod tests {
                 app.get(&format!("/authz/{}/{}", ResourceType::Infra, infra.id))
                     .by_user(&alice),
             )
+            .await
             .assert_status(StatusCode::OK)
             .json_into();
 
@@ -938,7 +950,9 @@ mod tests {
                 }
             ]
         }));
-        app.fetch(request_grant).assert_status(StatusCode::CREATED);
+        app.fetch(request_grant)
+            .await
+            .assert_status(StatusCode::CREATED);
 
         // Check that the new user has the good grant
         app.assert_infra_direct_grant(infra.id, writer.id, Some(InfraGrant::Writer));
@@ -954,6 +968,7 @@ mod tests {
             ]
         }));
         app.fetch(request_revoke)
+            .await
             .assert_status(StatusCode::NO_CONTENT);
 
         // Check that the new user has the good grant
@@ -990,6 +1005,7 @@ mod tests {
                 }
             ]
         })))
+        .await
         .assert_status(StatusCode::CREATED);
 
         app.assert_infra_direct_grant(infra.id, alice.id, Some(InfraGrant::Owner)); // still owner
@@ -1008,6 +1024,7 @@ mod tests {
                 }
             ]
         })))
+        .await
         .assert_status(StatusCode::NO_CONTENT);
 
         app.assert_infra_direct_grant(infra.id, alice_and_bob.id, None); // group grant removed
@@ -1036,7 +1053,9 @@ mod tests {
                 }
             ]
         }));
-        app.fetch(request_revoke).assert_status(StatusCode::CREATED);
+        app.fetch(request_revoke)
+            .await
+            .assert_status(StatusCode::CREATED);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -1063,6 +1082,7 @@ mod tests {
             ]
         }));
         app.fetch(request_grant)
+            .await
             .assert_status(StatusCode::NO_CONTENT);
     }
 
@@ -1077,6 +1097,7 @@ mod tests {
         let request = app.get("/authz/me").by_user(&user);
         let user_data = app
             .fetch(request)
+            .await
             .assert_status(StatusCode::OK)
             .json_into::<WhoamiResponse>();
 
@@ -1098,6 +1119,7 @@ mod tests {
         let request = app.get("/authz/me").by_user(&user);
         let WhoamiResponse { roles, .. } = app
             .fetch(request)
+            .await
             .assert_status(StatusCode::OK)
             .json_into::<WhoamiResponse>();
 
@@ -1120,10 +1142,12 @@ mod tests {
 
         let mut groups_user_1 = app
             .fetch(request_1)
+            .await
             .assert_status(StatusCode::OK)
             .json_into::<Vec<Group>>();
         let groups_user_2 = app
             .fetch(request_2)
+            .await
             .assert_status(StatusCode::OK)
             .json_into::<Vec<Group>>();
 
@@ -1157,6 +1181,8 @@ mod tests {
         let user = app.user("test", "test").create();
 
         let request = app.get("/authz/me/groups").by_user(&user);
-        app.fetch(request).assert_status(StatusCode::UNAUTHORIZED);
+        app.fetch(request)
+            .await
+            .assert_status(StatusCode::UNAUTHORIZED);
     }
 }

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -764,7 +764,7 @@ mod tests {
         );
     }
 
-    #[rstest] // TODO: fix deadlock with tokio::test
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn user_me_grants() {
         let app = test_app!().enable_authorization(true).build();
         let db_pool = app.db_pool();
@@ -924,7 +924,7 @@ mod tests {
         assert_eq!(grants.get(&tom_and_jerry.id), None); // no group grant (not even there in the response)
     }
 
-    #[rstest] // TODO: fix deadlock with tokio::test
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn grants_test() {
         // This test starts with a user that is the owner of an infra.
         // Then it creates a new user and adds it as a writer to the infra.
@@ -975,7 +975,7 @@ mod tests {
         app.assert_infra_direct_grant(infra.id, writer.id, None);
     }
 
-    #[rstest] // TODO: fix deadlock with tokio::test
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn give_grant_to_groups() {
         let app = test_app!().enable_authorization(true).build();
         let infra = create_small_infra(&mut app.db_pool().get_ok()).await;
@@ -1086,7 +1086,7 @@ mod tests {
             .assert_status(StatusCode::NO_CONTENT);
     }
 
-    #[rstest] // TODO: fix deadlock with tokio::test
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn whoami_test() {
         let app = test_app!().enable_authorization(true).build();
         let user = app

--- a/editoast/src/views/fonts.rs
+++ b/editoast/src/views/fonts.rs
@@ -58,7 +58,7 @@ mod tests {
     async fn test_font() {
         let app = TestAppBuilder::default_app();
         let request = app.get("/fonts/IBMPlexSans/0-255.pbf");
-        let response = app.fetch(request).assert_status(StatusCode::OK);
+        let response = app.fetch(request).await.assert_status(StatusCode::OK);
         assert_eq!("application/octet-stream", response.content_type());
         let response = response.bytes();
         let expected = std::fs::read(
@@ -74,6 +74,8 @@ mod tests {
     async fn test_font_not_found() {
         let app = TestAppBuilder::default_app();
         let request = app.get("/fonts/Comic%20Sans/0-255.pbf");
-        app.fetch(request).assert_status(StatusCode::NOT_FOUND);
+        app.fetch(request)
+            .await
+            .assert_status(StatusCode::NOT_FOUND);
     }
 }

--- a/editoast/src/views/infra/attached.rs
+++ b/editoast/src/views/infra/attached.rs
@@ -162,7 +162,7 @@ mod tests {
         let req =
             app.get(format!("/infra/{}/attached/{}/", empty_infra.id, track.get_id()).as_str());
 
-        let response: HashMap<ObjectType, Vec<String>> = app.fetch(req).json_into();
+        let response: HashMap<ObjectType, Vec<String>> = app.fetch(req).await.json_into();
         assert_eq!(response.get(&ObjectType::Detector).unwrap().len(), 1);
     }
 }

--- a/editoast/src/views/infra/auto_fixes/mod.rs
+++ b/editoast/src/views/infra/auto_fixes/mod.rs
@@ -390,6 +390,7 @@ mod tests {
 
         let operations: Vec<Operation> = app
             .fetch(app.auto_fixes_request(small_infra_id))
+            .await
             .assert_status(StatusCode::OK)
             .json_into();
 
@@ -446,6 +447,7 @@ mod tests {
         // WHEN
         let operations: Vec<Operation> = app
             .fetch(app.auto_fixes_request(small_infra_id))
+            .await
             .assert_status(StatusCode::OK)
             .json_into();
 
@@ -489,6 +491,7 @@ mod tests {
 
         let operations: Vec<Operation> = app
             .fetch(app.auto_fixes_request(small_infra_id))
+            .await
             .assert_status(StatusCode::OK)
             .json_into();
 
@@ -732,6 +735,7 @@ mod tests {
 
         let operations: Vec<Operation> = app
             .fetch(app.auto_fixes_request(small_infra_id))
+            .await
             .assert_status(StatusCode::OK)
             .json_into();
 
@@ -784,6 +788,7 @@ mod tests {
 
         let operations: Vec<Operation> = app
             .fetch(app.auto_fixes_request(empty_infra_id))
+            .await
             .assert_status(StatusCode::OK)
             .json_into();
 
@@ -812,6 +817,7 @@ mod tests {
 
         let operations: Vec<Operation> = app
             .fetch(app.auto_fixes_request(empty_infra_id))
+            .await
             .assert_status(StatusCode::OK)
             .json_into();
 
@@ -882,6 +888,7 @@ mod tests {
 
         let operations: Vec<Operation> = app
             .fetch(app.auto_fixes_request(empty_infra_id))
+            .await
             .assert_status(StatusCode::OK)
             .json_into();
 
@@ -943,6 +950,7 @@ mod tests {
 
         let operations: Vec<Operation> = app
             .fetch(app.auto_fixes_request(empty_infra_id))
+            .await
             .assert_status(StatusCode::OK)
             .json_into();
 
@@ -979,6 +987,7 @@ mod tests {
         // WHEN
         let operations: Vec<Operation> = app
             .fetch(app.auto_fixes_request(empty_infra_id))
+            .await
             .assert_status(StatusCode::OK)
             .json_into();
 

--- a/editoast/src/views/infra/delimited_area.rs
+++ b/editoast/src/views/infra/delimited_area.rs
@@ -539,8 +539,11 @@ mod tests {
                 "exits": exits,
             }
             ));
-        let DelimitedAreaResponse { track_ranges } =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let DelimitedAreaResponse { track_ranges } = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
         track_ranges
     }
 

--- a/editoast/src/views/infra/edition.rs
+++ b/editoast/src/views/infra/edition.rs
@@ -961,7 +961,6 @@ enum EditionError {
 pub mod tests {
     use axum::http::StatusCode;
     use pretty_assertions::assert_eq;
-    use rstest::rstest;
 
     use super::*;
     use crate::generated_data::infra_error::InfraError;
@@ -1032,7 +1031,8 @@ pub mod tests {
             .assert_status(StatusCode::BAD_REQUEST);
     }
 
-    #[rstest] // TODO: fix deadlock with tokio::test
+    #[rstest::rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[case("TA0", 1000000)]
     #[case("TD1", 15500000)]
     async fn split_track_section_should_work(#[case] track: &str, #[case] offset: u64) {

--- a/editoast/src/views/infra/edition.rs
+++ b/editoast/src/views/infra/edition.rs
@@ -985,7 +985,9 @@ pub mod tests {
             }));
 
         // Check that we receive a 404
-        app.fetch(request).assert_status(StatusCode::NOT_FOUND);
+        app.fetch(request)
+            .await
+            .assert_status(StatusCode::NOT_FOUND);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -1004,7 +1006,9 @@ pub mod tests {
             }));
 
         // Check that we receive a 404
-        app.fetch(request).assert_status(StatusCode::NOT_FOUND);
+        app.fetch(request)
+            .await
+            .assert_status(StatusCode::NOT_FOUND);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -1023,7 +1027,9 @@ pub mod tests {
             }));
 
         // Check that we receive an error
-        app.fetch(request).assert_status(StatusCode::BAD_REQUEST);
+        app.fetch(request)
+            .await
+            .assert_status(StatusCode::BAD_REQUEST);
     }
 
     #[rstest] // TODO: fix deadlock with tokio::test
@@ -1038,7 +1044,7 @@ pub mod tests {
         // Refresh the infra to get the good number of infra errors
         let req_refresh =
             app.post(format!("/infra/refresh/?infras={}&force=true", small_infra.id).as_str());
-        app.fetch(req_refresh).assert_status(StatusCode::OK);
+        app.fetch(req_refresh).await.assert_status(StatusCode::OK);
 
         // Get infra errors
         let (init_errors, _) = query_errors(&mut db_pool.get_ok(), &small_infra).await;
@@ -1050,7 +1056,11 @@ pub mod tests {
                 "track": track,
                 "offset": offset,
             }));
-        let res: Vec<String> = app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let res: Vec<String> = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         // Check the response
         assert_eq!(res.len(), 2);

--- a/editoast/src/views/infra/errors.rs
+++ b/editoast/src/views/infra/errors.rs
@@ -159,6 +159,6 @@ mod tests {
             )
             .as_str(),
         );
-        app.fetch(req).assert_status(StatusCode::OK);
+        app.fetch(req).await.assert_status(StatusCode::OK);
     }
 }

--- a/editoast/src/views/infra/lines.rs
+++ b/editoast/src/views/infra/lines.rs
@@ -137,8 +137,11 @@ mod tests {
 
         let request =
             app.get(format!("/infra/{}/lines/{line_code}/bbox/", empty_infra.id).as_str());
-        let bounding_box: BoundingBox =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let bounding_box: BoundingBox = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
         assert_eq!(
             bounding_box,
             BoundingBox {
@@ -164,6 +167,8 @@ mod tests {
             )
             .as_str(),
         );
-        app.fetch(request).assert_status(StatusCode::BAD_REQUEST);
+        app.fetch(request)
+            .await
+            .assert_status(StatusCode::BAD_REQUEST);
     }
 }

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -1194,7 +1194,7 @@ pub mod tests {
         infra_refreshed: Vec<i64>,
     }
 
-    #[rstest] // TODO: fix deadlock with tokio::test
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn infra_refresh() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
@@ -1210,7 +1210,7 @@ pub mod tests {
         assert_eq!(refreshed_infras.infra_refreshed, vec![empty_infra.id]);
     }
 
-    #[rstest] // TODO: fix deadlock with tokio::test
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     // Slow test
     // PostgreSQL deadlock can happen in this test, see section `Deadlock` of [DbConnectionPoolV2::get] for more information
     async fn infra_refresh_force() {

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -1013,7 +1013,11 @@ pub mod tests {
         let request =
             app.post(format!("/infra/{}/clone/?name=cloned_infra", empty_infra.id).as_str());
 
-        let cloned_infra_id: i64 = app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let cloned_infra_id: i64 = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
         let cloned_infra = Infra::retrieve(db_pool.get_ok(), cloned_infra_id)
             .await
             .unwrap()
@@ -1055,6 +1059,7 @@ pub mod tests {
 
         let cloned_infra_id: i64 = app
             .fetch(req_clone)
+            .await
             .assert_status(StatusCode::OK)
             .json_into();
 
@@ -1111,9 +1116,11 @@ pub mod tests {
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 
         app.fetch(app.delete_infra_request(empty_infra.id))
+            .await
             .assert_status(StatusCode::NO_CONTENT);
 
         app.fetch(app.delete_infra_request(empty_infra.id))
+            .await
             .assert_status(StatusCode::NOT_FOUND);
     }
 
@@ -1121,7 +1128,7 @@ pub mod tests {
     async fn infra_list() {
         let app = TestAppBuilder::default_app();
         let request = app.get("/infra/");
-        app.fetch(request).assert_status(StatusCode::OK);
+        app.fetch(request).await.assert_status(StatusCode::OK);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -1133,6 +1140,7 @@ pub mod tests {
             .json(&json!({ "name": "create_infra_test" }));
         let infra: Infra = app
             .fetch(request)
+            .await
             .assert_status(StatusCode::CREATED)
             .json_into();
 
@@ -1153,13 +1161,13 @@ pub mod tests {
 
         let req = app.get(format!("/infra/{}", empty_infra.id).as_str());
 
-        app.fetch(req).assert_status(StatusCode::OK);
+        app.fetch(req).await.assert_status(StatusCode::OK);
 
         empty_infra.delete(&mut db_pool.get_ok()).await.unwrap();
 
         let req = app.get(format!("/infra/{}", empty_infra.id).as_str());
 
-        app.fetch(req).assert_status(StatusCode::NOT_FOUND);
+        app.fetch(req).await.assert_status(StatusCode::NOT_FOUND);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -1172,7 +1180,11 @@ pub mod tests {
             .put(format!("/infra/{}", empty_infra.id).as_str())
             .json(&json!({"name": "rename_test"}));
 
-        let infra: Infra = app.fetch(req).assert_status(StatusCode::OK).json_into();
+        let infra: Infra = app
+            .fetch(req)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         assert_eq!(infra.name, "rename_test");
     }
@@ -1190,8 +1202,11 @@ pub mod tests {
 
         let req = app.post(format!("/infra/refresh/?infras={}", empty_infra.id).as_str());
 
-        let refreshed_infras: InfraRefreshedResponse =
-            app.fetch(req).assert_status(StatusCode::OK).json_into();
+        let refreshed_infras: InfraRefreshedResponse = app
+            .fetch(req)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
         assert_eq!(refreshed_infras.infra_refreshed, vec![empty_infra.id]);
     }
 
@@ -1205,8 +1220,11 @@ pub mod tests {
 
         let req =
             app.post(format!("/infra/refresh/?infras={}&force=true", empty_infra.id).as_str());
-        let refreshed_infras: InfraRefreshedResponse =
-            app.fetch(req).assert_status(StatusCode::OK).json_into();
+        let refreshed_infras: InfraRefreshedResponse = app
+            .fetch(req)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
         assert!(refreshed_infras.infra_refreshed.contains(&empty_infra.id));
     }
 
@@ -1228,8 +1246,11 @@ pub mod tests {
 
         let req = app.get(format!("/infra/{}/speed_limit_tags/", empty_infra.id).as_str());
 
-        let mut speed_limit_tags: Vec<String> =
-            app.fetch(req).assert_status(StatusCode::OK).json_into();
+        let mut speed_limit_tags: Vec<String> = app
+            .fetch(req)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         let mut test_tags = builtin_tags.0.clone();
         test_tags.push("test_tag".to_string());
@@ -1274,7 +1295,11 @@ pub mod tests {
 
         let req = app.get("/infra/voltages/");
 
-        let voltages: Vec<String> = app.fetch(req).assert_status(StatusCode::OK).json_into();
+        let voltages: Vec<String> = app
+            .fetch(req)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         assert!(voltages.len() >= 3);
         assert!(voltages.contains(&String::from("0V")));
@@ -1318,11 +1343,19 @@ pub mod tests {
         );
 
         if !include_rolling_stock_modes {
-            let voltages: Vec<String> = app.fetch(req).assert_status(StatusCode::OK).json_into();
+            let voltages: Vec<String> = app
+                .fetch(req)
+                .await
+                .assert_status(StatusCode::OK)
+                .json_into();
             assert_eq!(voltages[0], "0");
             assert_eq!(voltages.len(), 1);
         } else {
-            let voltages: Vec<String> = app.fetch(req).assert_status(StatusCode::OK).json_into();
+            let voltages: Vec<String> = app
+                .fetch(req)
+                .await
+                .assert_status(StatusCode::OK)
+                .json_into();
             assert!(voltages.contains(&String::from("25000V")));
             assert!(voltages.len() >= 2);
         }
@@ -1336,8 +1369,11 @@ pub mod tests {
 
         let req = app.get(format!("/infra/{}/switch_types/", empty_infra.id).as_str());
 
-        let switch_types: Vec<SwitchType> =
-            app.fetch(req).assert_status(StatusCode::OK).json_into();
+        let switch_types: Vec<SwitchType> = app
+            .fetch(req)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         assert_eq!(switch_types.len(), 5);
     }
@@ -1353,7 +1389,7 @@ pub mod tests {
         // Lock infra
         let req = app.post(format!("/infra/{}/lock/", empty_infra.id).as_str());
 
-        app.fetch(req).assert_status(StatusCode::NO_CONTENT);
+        app.fetch(req).await.assert_status(StatusCode::NO_CONTENT);
 
         // Check lock
         let infra = Infra::retrieve(db_pool.get_ok(), empty_infra.id)
@@ -1365,7 +1401,7 @@ pub mod tests {
         // Unlock infra
         let req = app.post(format!("/infra/{}/unlock/", empty_infra.id).as_str());
 
-        app.fetch(req).assert_status(StatusCode::NO_CONTENT);
+        app.fetch(req).await.assert_status(StatusCode::NO_CONTENT);
 
         // Check lock
         let infra = Infra::retrieve(db_pool.get_ok(), empty_infra.id)
@@ -1416,8 +1452,11 @@ pub mod tests {
         let request = app
             .post(format!("/infra/{}/match_operational_points", infra.id).as_str())
             .json(&json!({"operational_point_references": operational_point_references}));
-        let response: MatchOperationalPointsResponse =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: MatchOperationalPointsResponse = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
         let response_op_identifiers = response
             .related_operational_points
             .iter()
@@ -1483,8 +1522,11 @@ pub mod tests {
         let request = app
             .post(format!("/infra/{}/match_operational_points", infra.id).as_str())
             .json(&json!({"operational_point_references": operational_point_references}));
-        let response: MatchOperationalPointsResponse =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: MatchOperationalPointsResponse = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
         let response_op_identifiers = response
             .related_operational_points
             .iter()

--- a/editoast/src/views/infra/objects.rs
+++ b/editoast/src/views/infra/objects.rs
@@ -196,7 +196,9 @@ mod tests {
             .post(format!("/infra/{}/objects/TrackSection", empty_infra.id).as_str())
             .json(&["invalid_id"]);
 
-        app.fetch(request).assert_status(StatusCode::BAD_REQUEST);
+        app.fetch(request)
+            .await
+            .assert_status(StatusCode::BAD_REQUEST);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -209,7 +211,7 @@ mod tests {
             .post(format!("/infra/{}/objects/TrackSection", empty_infra.id).as_str())
             .json(&vec![""; 0]);
 
-        app.fetch(request).assert_status(StatusCode::OK);
+        app.fetch(request).await.assert_status(StatusCode::OK);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -238,8 +240,11 @@ mod tests {
             .json(&vec!["switch_001"]);
 
         // THEN
-        let switch_object: Vec<ObjectQueryable> =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let switch_object: Vec<ObjectQueryable> = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
         let expected_switch_object = vec![ObjectQueryable {
             obj_id: switch.get_id().to_string(),
             railjson: json!({
@@ -266,7 +271,9 @@ mod tests {
             .post(format!("/infra/{}/objects/TrackSection", empty_infra.id).as_str())
             .json(&vec!["id"; 2]);
 
-        app.fetch(request).assert_status(StatusCode::BAD_REQUEST);
+        app.fetch(request)
+            .await
+            .assert_status(StatusCode::BAD_REQUEST);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -289,8 +296,11 @@ mod tests {
             .post(format!("/infra/{}/objects/SwitchType", empty_infra.id).as_str())
             .json(&vec![switch_type.id.clone()]);
 
-        let switch_type_object: Vec<ObjectQueryable> =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let switch_type_object: Vec<ObjectQueryable> = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
         let expected_switch_type_object = vec![ObjectQueryable {
             obj_id: switch_type.get_id().to_string(),
             railjson: json!({
@@ -330,6 +340,7 @@ mod tests {
 
         let response = app
             .fetch(request)
+            .await
             .assert_status(StatusCode::OK)
             .json_into::<JsonValue>();
 

--- a/editoast/src/views/infra/railjson.rs
+++ b/editoast/src/views/infra/railjson.rs
@@ -243,7 +243,11 @@ mod tests {
 
         let request = app.get(&format!("/infra/{}/railjson", empty_infra.id));
 
-        let railjson: RailJson = app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let railjson: RailJson = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         assert_eq!(railjson.version, RAILJSON_VERSION);
         assert_eq!(railjson.extended_switch_types.len(), 1);
@@ -275,6 +279,7 @@ mod tests {
 
         let res: PostRailjsonResponse = app
             .fetch(req)
+            .await
             .assert_status(StatusCode::CREATED)
             .json_into();
 

--- a/editoast/src/views/infra/routes.rs
+++ b/editoast/src/views/infra/routes.rs
@@ -440,8 +440,11 @@ mod tests {
                 .json(&params);
             println!("{request:?}  body:\n    {params}");
 
-            let got: RoutesFromNodesPositions =
-                app.fetch(request).assert_status(StatusCode::OK).json_into();
+            let got: RoutesFromNodesPositions = app
+                .fetch(request)
+                .await
+                .assert_status(StatusCode::OK)
+                .json_into();
             compare_result(got, expected_result)
         }
     }
@@ -505,7 +508,11 @@ mod tests {
         let request =
             app.get(format!("/infra/{empty_infra_id}/routes/{waypoint_type}/bs_stop").as_str());
 
-        let routes: RoutesResponse = app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let routes: RoutesResponse = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         assert_eq!(
             routes,
@@ -520,7 +527,11 @@ mod tests {
         let request = app
             .get(format!("/infra/{empty_infra_id}/routes/{waypoint_type}/detector_001").as_str());
 
-        let routes: RoutesResponse = app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let routes: RoutesResponse = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         assert_eq!(
             routes,
@@ -546,7 +557,11 @@ mod tests {
             .as_str(),
         );
 
-        let routes: RoutesResponse = app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let routes: RoutesResponse = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         assert_eq!(
             routes,

--- a/editoast/src/views/layers.rs
+++ b/editoast/src/views/layers.rs
@@ -253,6 +253,7 @@ mod tests {
         let request = app.get("/layers/layer/track_sections/mvt/does_not_exist?infra=2");
         let body: InternalError = app
             .fetch(request)
+            .await
             .assert_status(StatusCode::NOT_FOUND)
             .json_into();
         assert_eq!(body, error);
@@ -283,7 +284,11 @@ mod tests {
 
         let app = test_app!().root_url(root_url).build();
         let request = app.get("/layers/layer/track_sections/mvt/geo?infra=2");
-        let body: ViewMetadata = app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let body: ViewMetadata = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
         assert_eq!(expected_body, body);
     }
 }

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -1143,14 +1143,14 @@ mod tests {
     async fn health() {
         let app = TestAppBuilder::default_app();
         let request = app.get("/health");
-        app.fetch(request).assert_status(StatusCode::OK);
+        app.fetch(request).await.assert_status(StatusCode::OK);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn version() {
         let app = TestAppBuilder::default_app();
         let request = app.get("/version");
-        let response: HashMap<String, Option<String>> = app.fetch(request).json_into();
+        let response: HashMap<String, Option<String>> = app.fetch(request).await.json_into();
         assert!(response.contains_key("git_describe"));
     }
 
@@ -1166,7 +1166,7 @@ mod tests {
             .db_pool(DbConnectionPoolV2::for_tests())
             .build();
         let request = app.get("/version/core");
-        let response: HashMap<String, Option<String>> = app.fetch(request).json_into();
+        let response: HashMap<String, Option<String>> = app.fetch(request).await.json_into();
         assert!(response.contains_key("git_describe"));
     }
 }

--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -561,8 +561,11 @@ pub mod tests {
                 "rolling_stock_length":26.00
             }));
 
-        let pathfinding_result: PathfindingResult =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let pathfinding_result: PathfindingResult = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
         assert_eq!(
             pathfinding_result,
             PathfindingResult::Failure(PathfindingFailure::PathfindingInputError(
@@ -593,8 +596,11 @@ pub mod tests {
                 "rolling_stock_length":26.00
             }));
 
-        let pathfinding_result: PathfindingResult =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let pathfinding_result: PathfindingResult = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
         assert_eq!(
             pathfinding_result,
             PathfindingResult::Failure(PathfindingFailure::PathfindingInputError(
@@ -638,8 +644,11 @@ pub mod tests {
                 "rolling_stock_length":26.00
             }));
 
-        let pathfinding_result: PathfindingResult =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let pathfinding_result: PathfindingResult = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
         assert_eq!(
             pathfinding_result,
             PathfindingResult::Failure(PathfindingFailure::PathfindingInputError(
@@ -698,8 +707,11 @@ pub mod tests {
                 "rolling_stock_length":26.00
             }));
 
-        let pathfinding_result: PathfindingResult =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let pathfinding_result: PathfindingResult = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
         assert_eq!(
             pathfinding_result,
             PathfindingResult::Success(PathfindingResultSuccess {

--- a/editoast/src/views/path/properties.rs
+++ b/editoast/src/views/path/properties.rs
@@ -291,7 +291,11 @@ mod tests {
         let request = app.post(&url).json(&json!(
             {"track_section_ranges": [{ "track_section": "TD0", "begin": 0, "end": 20000, "direction": "START_TO_STOP" }]})
         );
-        let response: PathProperties = app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: PathProperties = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
         let path_properties_response = path_properties_response();
         assert_eq!(response.slopes, Some(path_properties_response.slopes));
         assert_eq!(response.curves, Some(path_properties_response.curves));
@@ -316,7 +320,11 @@ mod tests {
         let request = app.post(&url).json(&json!(
             {"track_section_ranges": [{ "track_section": "TD0", "begin": 0, "end": 20000, "direction": "START_TO_STOP" }]})
         );
-        let response: PathProperties = app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: PathProperties = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
         let path_properties_response = path_properties_response();
         assert_eq!(response.slopes, Some(path_properties_response.slopes));
         assert_eq!(response.curves, Some(path_properties_response.curves));

--- a/editoast/src/views/project.rs
+++ b/editoast/src/views/project.rs
@@ -421,6 +421,7 @@ pub mod tests {
 
         let response: ProjectWithStudyCount = app
             .fetch(request)
+            .await
             .assert_status(StatusCode::CREATED)
             .json_into();
 
@@ -445,7 +446,9 @@ pub mod tests {
         }));
 
         // OpsWrite is required to complete this request successfully.
-        app.fetch(request).assert_status(StatusCode::FORBIDDEN);
+        app.fetch(request)
+            .await
+            .assert_status(StatusCode::FORBIDDEN);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -457,8 +460,11 @@ pub mod tests {
 
         let request = app.get("/projects/");
 
-        let response: ProjectWithStudyCountList =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: ProjectWithStudyCountList = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         let project_retrieved = response
             .results
@@ -478,8 +484,11 @@ pub mod tests {
 
         let request = app.get(format!("/projects/{}", created_project.id).as_str());
 
-        let response: ProjectWithStudyCount =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: ProjectWithStudyCount = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         assert_eq!(response.project, created_project);
     }
@@ -493,7 +502,9 @@ pub mod tests {
 
         let request = app.delete(format!("/projects/{}", created_project.id).as_str());
 
-        app.fetch(request).assert_status(StatusCode::NO_CONTENT);
+        app.fetch(request)
+            .await
+            .assert_status(StatusCode::NO_CONTENT);
 
         let exists = Project::exists(&mut db_pool.get_ok(), created_project.id)
             .await
@@ -519,8 +530,11 @@ pub mod tests {
                 "budget": updated_budget
             }));
 
-        let response: ProjectWithStudyCount =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: ProjectWithStudyCount = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         let project = Project::retrieve(db_pool.get_ok(), response.project.id)
             .await
@@ -587,7 +601,7 @@ pub mod tests {
             .json(&json!({
                 "image": image.id
             }));
-        app.fetch(request).assert_status(StatusCode::OK);
+        app.fetch(request).await.assert_status(StatusCode::OK);
 
         check_image(db_pool.get_ok(), Some(image.id)).await;
 
@@ -605,7 +619,7 @@ pub mod tests {
             .json(&json!({
                 "image": new_image.id
             }));
-        app.fetch(request).assert_status(StatusCode::OK);
+        app.fetch(request).await.assert_status(StatusCode::OK);
 
         check_image(db_pool.get_ok(), Some(new_image.id)).await;
         assert!(
@@ -620,7 +634,7 @@ pub mod tests {
             .json(&json!({
                 "image": null
             }));
-        app.fetch(request).assert_status(StatusCode::OK);
+        app.fetch(request).await.assert_status(StatusCode::OK);
 
         check_image(db_pool.get_ok(), None).await;
         assert!(

--- a/editoast/src/views/rolling_stock.rs
+++ b/editoast/src/views/rolling_stock.rs
@@ -805,7 +805,7 @@ pub mod tests {
         let request = app.rolling_stock_create_request(&fast_rolling_stock_form);
 
         // WHEN
-        let raw_response = app.fetch(request);
+        let raw_response = app.fetch(request).await;
 
         // THEN
         let response: RollingStock = raw_response.assert_status(StatusCode::OK).json_into();
@@ -836,7 +836,7 @@ pub mod tests {
             .json(&locked_fast_rolling_stock_form);
 
         // WHEN
-        let raw_response = app.fetch(request);
+        let raw_response = app.fetch(request).await;
 
         // THEN
         let response: RollingStock = raw_response.assert_status(StatusCode::OK).json_into();
@@ -863,6 +863,7 @@ pub mod tests {
 
         let response: InternalError = app
             .fetch(request)
+            .await
             .assert_status(StatusCode::BAD_REQUEST)
             .json_into();
 
@@ -878,10 +879,17 @@ pub mod tests {
         let stock_name = Uuid::new_v4().to_string();
         let rolling_stock = fast_rolling_stock_form(stock_name.as_str());
         let request = app.rolling_stock_create_request(&rolling_stock);
-        let RollingStock { id, .. } = app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let RollingStock { id, .. } = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
         let request = app.get(&format!("/rolling_stock/{id}/usage"));
-        let related_schedules: Vec<ScenarioReference> =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let related_schedules: Vec<ScenarioReference> = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
         assert!(related_schedules.is_empty());
     }
 
@@ -894,12 +902,14 @@ pub mod tests {
             app.rolling_stock_create_request(&fast_rolling_stock_form(&Uuid::new_v4().to_string()));
         let rolling_stock: RollingStock = app
             .fetch(create_rolling_stock_request)
+            .await
             .assert_status(StatusCode::OK)
             .json_into();
         let create_other_rolling_stock_request =
             app.rolling_stock_create_request(&fast_rolling_stock_form(&Uuid::new_v4().to_string()));
         let other_rolling_stock: RollingStock = app
             .fetch(create_other_rolling_stock_request)
+            .await
             .assert_status(StatusCode::OK)
             .json_into();
 
@@ -957,8 +967,11 @@ pub mod tests {
             .unwrap();
 
         let request = app.get(&format!("/rolling_stock/{}/usage", rolling_stock.id));
-        let related_scenarios: Vec<ScenarioReference> =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let related_scenarios: Vec<ScenarioReference> = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
         let expected_scenarios = [
             ScenarioReference {
                 project_id: project.id,
@@ -990,7 +1003,9 @@ pub mod tests {
         let _ = RollingStock::delete_static(&mut db_pool.get_ok(), 1).await;
 
         let request = app.get("/rolling_stock/1/usage");
-        app.fetch(request).assert_status(StatusCode::NOT_FOUND);
+        app.fetch(request)
+            .await
+            .assert_status(StatusCode::NOT_FOUND);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -1005,7 +1020,7 @@ pub mod tests {
         let request = app.rolling_stock_create_request(&fast_rolling_stock_form);
 
         // WHEN
-        let raw_response = app.fetch(request);
+        let raw_response = app.fetch(request).await;
 
         // THEN
         let response: InternalError = raw_response
@@ -1033,6 +1048,7 @@ pub mod tests {
             .bytes(invalid_payload.into());
 
         app.fetch(request)
+            .await
             .assert_status(StatusCode::UNPROCESSABLE_ENTITY);
     }
 
@@ -1048,7 +1064,7 @@ pub mod tests {
         let request = app.rolling_stock_get_by_id_request(fast_rolling_stock.id);
 
         // WHEN
-        let raw_response = app.fetch(request);
+        let raw_response = app.fetch(request).await;
 
         // THEN
         let response: RollingStock = raw_response.assert_status(StatusCode::OK).json_into();
@@ -1068,7 +1084,7 @@ pub mod tests {
         let request = app.get(format!("/rolling_stock/name/{rs_name}").as_str());
 
         // WHEN
-        let raw_response = app.fetch(request);
+        let raw_response = app.fetch(request).await;
 
         // THEN
         let response: RollingStock = raw_response.assert_status(StatusCode::OK).json_into();
@@ -1082,7 +1098,9 @@ pub mod tests {
 
         let request = app.rolling_stock_get_by_id_request(0);
 
-        app.fetch(request).assert_status(StatusCode::NOT_FOUND);
+        app.fetch(request)
+            .await
+            .assert_status(StatusCode::NOT_FOUND);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -1092,7 +1110,9 @@ pub mod tests {
         let request =
             app.get(format!("/rolling_stock/name/{}", "unexisting_rolling_stock_name").as_str());
 
-        app.fetch(request).assert_status(StatusCode::NOT_FOUND);
+        app.fetch(request)
+            .await
+            .assert_status(StatusCode::NOT_FOUND);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -1114,7 +1134,7 @@ pub mod tests {
             .json(&&rolling_stock_form);
 
         // WHEN
-        let raw_response = app.fetch(request);
+        let raw_response = app.fetch(request).await;
 
         // THEN
         raw_response.assert_status(StatusCode::OK);
@@ -1165,7 +1185,7 @@ pub mod tests {
             .json(&&rolling_stock_form);
 
         // WHEN
-        let raw_response = app.fetch(request);
+        let raw_response = app.fetch(request).await;
 
         // THEN
         raw_response.assert_status(StatusCode::OK);
@@ -1212,7 +1232,7 @@ pub mod tests {
             .json(&&rolling_stock_form);
 
         // WHEN
-        let raw_response = app.fetch(request);
+        let raw_response = app.fetch(request).await;
 
         // THEN
         let response = raw_response
@@ -1253,7 +1273,7 @@ pub mod tests {
             .json(&second_fast_rolling_stock_form);
 
         // WHEN
-        let raw_response = app.fetch(request);
+        let raw_response = app.fetch(request).await;
 
         // THEN
         let response: InternalError = raw_response
@@ -1291,7 +1311,7 @@ pub mod tests {
             .json(&second_fast_rolling_stock_form);
 
         // WHEN
-        let raw_response = app.fetch(request);
+        let raw_response = app.fetch(request).await;
 
         // THEN
         let response: InternalError = raw_response.assert_status(StatusCode::CONFLICT).json_into();
@@ -1307,7 +1327,9 @@ pub mod tests {
             .patch(&format!("/rolling_stock/{id}/locked"))
             .json(&json!({ "locked": true }));
 
-        app.fetch(request).assert_status(StatusCode::NOT_FOUND);
+        app.fetch(request)
+            .await
+            .assert_status(StatusCode::NOT_FOUND);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -1324,7 +1346,9 @@ pub mod tests {
             .patch(format!("/rolling_stock/{}/locked", fast_rolling_stock.id).as_str())
             .json(&json!({ "locked": true }));
 
-        app.fetch(request).assert_status(StatusCode::NO_CONTENT);
+        app.fetch(request)
+            .await
+            .assert_status(StatusCode::NO_CONTENT);
 
         let fast_rolling_stock: RollingStock =
             RollingStock::retrieve(db_pool.get_ok(), fast_rolling_stock.id)
@@ -1353,7 +1377,9 @@ pub mod tests {
             .patch(format!("/rolling_stock/{}/locked", locked_fast_rolling_stock.id).as_str())
             .json(&json!({ "locked": false }));
 
-        app.fetch(request).assert_status(StatusCode::NO_CONTENT);
+        app.fetch(request)
+            .await
+            .assert_status(StatusCode::NO_CONTENT);
 
         let fast_rolling_stock: RollingStock =
             RollingStock::retrieve(db_pool.get_ok(), locked_fast_rolling_stock.id)
@@ -1377,7 +1403,7 @@ pub mod tests {
         let request = app.get("/rolling_stock/power_restrictions");
 
         // WHEN
-        let raw_response = app.fetch(request);
+        let raw_response = app.fetch(request).await;
 
         // THEN
         let response: Vec<String> = raw_response.assert_status(StatusCode::OK).json_into();
@@ -1407,7 +1433,7 @@ pub mod tests {
             app.delete(format!("/rolling_stock/{}", locked_fast_rolling_stock.id).as_str());
 
         // WHEN
-        let raw_response = app.fetch(request);
+        let raw_response = app.fetch(request).await;
 
         // THEN
         let response: InternalError = raw_response.assert_status(StatusCode::CONFLICT).json_into();
@@ -1435,7 +1461,7 @@ pub mod tests {
         let request = app.delete(format!("/rolling_stock/{}", fast_rolling_stock.id).as_str());
 
         // WHEN
-        let raw_response = app.fetch(request);
+        let raw_response = app.fetch(request).await;
 
         // THEN
         raw_response.assert_status(StatusCode::NO_CONTENT);
@@ -1486,7 +1512,7 @@ pub mod tests {
             app.delete(format!("/rolling_stock/{}?force=true", fast_rolling_stock.id).as_str());
 
         // WHEN
-        let raw_response = app.fetch(request);
+        let raw_response = app.fetch(request).await;
 
         // THEN
         let response: InternalError = raw_response.assert_status(StatusCode::CONFLICT).json_into();
@@ -1500,7 +1526,7 @@ pub mod tests {
         assert!(rolling_stock_exists);
 
         // WHEN
-        let raw_response_forced = app.fetch(request_forced);
+        let raw_response_forced = app.fetch(request_forced).await;
 
         // THEN
         raw_response_forced.assert_status(StatusCode::NO_CONTENT);

--- a/editoast/src/views/rolling_stock/light.rs
+++ b/editoast/src/views/rolling_stock/light.rs
@@ -360,7 +360,7 @@ mod tests {
     async fn list_light_rolling_stock() {
         let app = TestAppBuilder::default_app();
         let request = app.get("/light_rolling_stock");
-        app.fetch(request).assert_status(StatusCode::OK);
+        app.fetch(request).await.assert_status(StatusCode::OK);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -375,8 +375,11 @@ mod tests {
         let request = app.get(format!("/light_rolling_stock/{}", fast_rolling_stock.id).as_str());
 
         // WHEN
-        let response: LightRollingStockWithLiveries =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: LightRollingStockWithLiveries = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         // THEN
         assert_eq!(response.rolling_stock.id, fast_rolling_stock.id);
@@ -394,8 +397,11 @@ mod tests {
         let request = app.get(format!("/light_rolling_stock/name/{rs_name}").as_str());
 
         // WHEN
-        let response: LightRollingStockWithLiveries =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: LightRollingStockWithLiveries = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         // THEN
         assert_eq!(response.rolling_stock.id, fast_rolling_stock.id);
@@ -408,7 +414,9 @@ mod tests {
 
         let request = app.get(format!("/light_rolling_stock/{}", -1).as_str());
 
-        app.fetch(request).assert_status(StatusCode::NOT_FOUND);
+        app.fetch(request)
+            .await
+            .assert_status(StatusCode::NOT_FOUND);
     }
 
     #[rstest] // TODO: fix deadlock with tokio::test
@@ -438,13 +446,19 @@ mod tests {
             .collect::<HashSet<_>>();
 
         let request = app.get("/light_rolling_stock/");
-        let response: LightRollingStockWithLiveriesCountList =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: LightRollingStockWithLiveriesCountList = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
         let count = response.stats.count;
         let uri = format!("/light_rolling_stock/?page_size={count}");
         let request = app.get(&uri);
-        let response: LightRollingStockWithLiveriesCountList =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: LightRollingStockWithLiveriesCountList = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         // Ensure that AT LEAST all the rolling stocks create above are returned, in order
         let vec_ids = response
@@ -465,6 +479,8 @@ mod tests {
 
         let request = app.get("/light_rolling_stock/?page_size=1010");
 
-        app.fetch(request).assert_status(StatusCode::BAD_REQUEST);
+        app.fetch(request)
+            .await
+            .assert_status(StatusCode::BAD_REQUEST);
     }
 }

--- a/editoast/src/views/rolling_stock/light.rs
+++ b/editoast/src/views/rolling_stock/light.rs
@@ -338,7 +338,6 @@ mod tests {
 
     use axum::http::StatusCode;
     use pretty_assertions::assert_eq;
-    use rstest::rstest;
 
     use super::LightRollingStockWithLiveries;
     use super::LightRollingStockWithLiveriesCountList;
@@ -419,7 +418,7 @@ mod tests {
             .assert_status(StatusCode::NOT_FOUND);
     }
 
-    #[rstest] // TODO: fix deadlock with tokio::test
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn list_light_rolling_stock_increasing_ids() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();

--- a/editoast/src/views/rolling_stock/towed.rs
+++ b/editoast/src/views/rolling_stock/towed.rs
@@ -295,7 +295,11 @@ mod tests {
     const LOCKED: bool = true;
     const UNLOCKED: bool = false;
 
-    fn create_towed_rolling_stock(app: &TestApp, name: &str, locked: bool) -> TowedRollingStock {
+    async fn create_towed_rolling_stock(
+        app: &TestApp,
+        name: &str,
+        locked: bool,
+    ) -> TowedRollingStock {
         let towed_rolling_stock_json = json!({
             "name": name,
             "label": name,
@@ -319,7 +323,10 @@ mod tests {
             .add_query_param("locked", locked)
             .json(&towed_rolling_stock_json);
 
-        app.fetch(request).assert_status(StatusCode::OK).json_into()
+        app.fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into()
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -327,13 +334,14 @@ mod tests {
         let app = TestAppBuilder::default_app();
 
         let name = Uuid::new_v4().to_string();
-        let towed_rolling_stock = create_towed_rolling_stock(&app, &name, LOCKED);
+        let towed_rolling_stock = create_towed_rolling_stock(&app, &name, LOCKED).await;
 
         let towed_rolling_stocks: TowedRollingStockCountList = app
             .fetch(
                 app.get("/towed_rolling_stock")
                     .add_query_param("page_size", 50),
             )
+            .await
             .assert_status(StatusCode::OK)
             .json_into();
 
@@ -352,6 +360,7 @@ mod tests {
         let id: i64 = rand::random();
 
         app.fetch(app.get(&format!("/towed_rolling_stock/{id}")))
+            .await
             .assert_status(StatusCode::NOT_FOUND);
     }
 
@@ -360,7 +369,7 @@ mod tests {
         let app = TestAppBuilder::default_app();
 
         let name = Uuid::new_v4().to_string();
-        let created_towed_rolling_stock = create_towed_rolling_stock(&app, &name, LOCKED);
+        let created_towed_rolling_stock = create_towed_rolling_stock(&app, &name, LOCKED).await;
 
         assert_eq!(created_towed_rolling_stock.name, name);
 
@@ -368,6 +377,7 @@ mod tests {
 
         let get_towed_rolling_stock: TowedRollingStock = app
             .fetch(app.get(&format!("/towed_rolling_stock/{id}")))
+            .await
             .assert_status(StatusCode::OK)
             .json_into();
 
@@ -379,13 +389,14 @@ mod tests {
         let app = TestAppBuilder::default_app();
 
         let name = Uuid::new_v4().to_string();
-        let towed_rolling_stock = create_towed_rolling_stock(&app, &name, UNLOCKED);
+        let towed_rolling_stock = create_towed_rolling_stock(&app, &name, UNLOCKED).await;
 
         let id: i64 = rand::random(); // <-- doesn't exist
         app.fetch(
             app.put(&format!("/towed_rolling_stock/{id}"))
                 .json(&towed_rolling_stock),
         )
+        .await
         .assert_status(StatusCode::NOT_FOUND);
     }
 
@@ -394,7 +405,7 @@ mod tests {
         let app = TestAppBuilder::default_app();
 
         let name = Uuid::new_v4().to_string();
-        let mut towed_rolling_stock = create_towed_rolling_stock(&app, &name, UNLOCKED);
+        let mut towed_rolling_stock = create_towed_rolling_stock(&app, &name, UNLOCKED).await;
 
         let id = towed_rolling_stock.id;
         towed_rolling_stock.mass = units::kilogram::new(13000.0);
@@ -403,6 +414,7 @@ mod tests {
                 app.put(&format!("/towed_rolling_stock/{id}"))
                     .json(&towed_rolling_stock),
             )
+            .await
             .assert_status(StatusCode::OK)
             .json_into();
 
@@ -422,6 +434,7 @@ mod tests {
             app.patch(&format!("/towed_rolling_stock/{id}/locked"))
                 .json(&json!({ "locked": false })),
         )
+        .await
         .assert_status(StatusCode::NOT_FOUND);
     }
 
@@ -430,7 +443,7 @@ mod tests {
         let app = TestAppBuilder::default_app();
 
         let name = Uuid::new_v4().to_string();
-        let mut towed_rolling_stock = create_towed_rolling_stock(&app, &name, LOCKED);
+        let mut towed_rolling_stock = create_towed_rolling_stock(&app, &name, LOCKED).await;
 
         let id = towed_rolling_stock.id;
         towed_rolling_stock.mass = units::kilogram::new(13000.0);
@@ -438,6 +451,7 @@ mod tests {
             app.put(&format!("/towed_rolling_stock/{id}"))
                 .json(&towed_rolling_stock),
         )
+        .await
         .assert_status(StatusCode::CONFLICT);
     }
 
@@ -446,7 +460,7 @@ mod tests {
         let app = TestAppBuilder::default_app();
 
         let name = Uuid::new_v4().to_string();
-        let mut towed_rolling_stock = create_towed_rolling_stock(&app, &name, LOCKED);
+        let mut towed_rolling_stock = create_towed_rolling_stock(&app, &name, LOCKED).await;
 
         let id = towed_rolling_stock.id;
         towed_rolling_stock.mass = units::kilogram::new(13000.0);
@@ -454,11 +468,13 @@ mod tests {
             app.patch(&format!("/towed_rolling_stock/{id}/locked"))
                 .json(&json!({ "locked": false })),
         )
+        .await
         .assert_status(StatusCode::NO_CONTENT);
         app.fetch(
             app.put(&format!("/towed_rolling_stock/{id}"))
                 .json(&towed_rolling_stock),
         )
+        .await
         .assert_status(StatusCode::OK);
     }
 }

--- a/editoast/src/views/scenario.rs
+++ b/editoast/src/views/scenario.rs
@@ -551,8 +551,11 @@ mod tests {
         );
         let request = app.get(&url);
 
-        let response: ScenarioResponse =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: ScenarioResponse = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         assert_eq!(response.scenario, fixtures.scenario);
     }
@@ -567,8 +570,11 @@ mod tests {
         let url = scenario_url(fixtures.project.id, fixtures.study.id, None);
         let request = app.get(&url);
 
-        let mut response: ListScenariosResponse =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let mut response: ListScenariosResponse = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         assert!(!response.results.is_empty());
         assert_eq!(
@@ -592,7 +598,9 @@ mod tests {
 
         let request = app.get(&url);
 
-        app.fetch(request).assert_status(StatusCode::NOT_FOUND);
+        app.fetch(request)
+            .await
+            .assert_status(StatusCode::NOT_FOUND);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -624,6 +632,7 @@ mod tests {
 
         let response: ScenarioResponse = app
             .fetch(request)
+            .await
             .assert_status(StatusCode::CREATED)
             .json_into();
 
@@ -668,8 +677,11 @@ mod tests {
             "description": study_description,
             "tags": study_tags
         }));
-        let response: ScenarioResponse =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: ScenarioResponse = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         assert_eq!(response.scenario.name, study_name);
         assert_eq!(response.scenario.description, study_description);
@@ -695,7 +707,9 @@ mod tests {
             "infra_id": 999999999,
         }));
 
-        app.fetch(request).assert_status(StatusCode::NOT_FOUND);
+        app.fetch(request)
+            .await
+            .assert_status(StatusCode::NOT_FOUND);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -722,8 +736,11 @@ mod tests {
             "name": study_name,
             "infra_id": study_other_infra_id,
         }));
-        let response: ScenarioResponse =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: ScenarioResponse = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         assert_eq!(response.scenario.infra_id, study_other_infra_id);
         assert_eq!(response.scenario.name, study_name);
@@ -743,7 +760,9 @@ mod tests {
         );
         let request = app.delete(&url);
 
-        app.fetch(request).assert_status(StatusCode::NO_CONTENT);
+        app.fetch(request)
+            .await
+            .assert_status(StatusCode::NO_CONTENT);
 
         let exists = Scenario::exists(&mut pool.get_ok(), fixtures.scenario.id)
             .await

--- a/editoast/src/views/scenario/macro_nodes.rs
+++ b/editoast/src/views/scenario/macro_nodes.rs
@@ -471,6 +471,7 @@ pub mod test {
             });
         let response: MacroNodeBatchResponse = app
             .fetch(request)
+            .await
             .assert_status(StatusCode::CREATED)
             .json_into();
 
@@ -504,8 +505,11 @@ pub mod test {
                 fixtures.project.id, fixtures.study.id, fixtures.scenario.id, fixtures.nodes[0].id
             ))
             .json(&node_data);
-        let response: MacroNodeResponse =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: MacroNodeResponse = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         let node = MacroNode::retrieve(db_pool.get_ok(), fixtures.nodes[0].id)
             .await
@@ -526,8 +530,11 @@ pub mod test {
             "/projects/{}/studies/{}/scenarios/{}/macro_nodes/{}",
             fixtures.project.id, fixtures.study.id, fixtures.scenario.id, fixtures.nodes[0].id
         ));
-        let response: MacroNodeResponse =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: MacroNodeResponse = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         assert!(fixtures.nodes[0] == response);
     }
@@ -542,8 +549,11 @@ pub mod test {
             "/projects/{}/studies/{}/scenarios/{}/macro_nodes?page=1&page_size=5",
             fixtures.project.id, fixtures.study.id, fixtures.scenario.id
         ));
-        let response: MacroNodeListResponse =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: MacroNodeListResponse = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         assert_eq!(10, response.stats.count);
         assert_eq!(5, response.results.len());
@@ -559,7 +569,9 @@ pub mod test {
             "/projects/{}/studies/{}/scenarios/{}/macro_nodes/{}",
             fixtures.project.id, fixtures.study.id, fixtures.scenario.id, fixtures.nodes[0].id
         ));
-        app.fetch(request).assert_status(StatusCode::NO_CONTENT);
+        app.fetch(request)
+            .await
+            .assert_status(StatusCode::NO_CONTENT);
 
         let found = MacroNode::exists(&mut db_pool.get_ok(), fixtures.nodes[0].id)
             .await

--- a/editoast/src/views/scenario/macro_notes.rs
+++ b/editoast/src/views/scenario/macro_notes.rs
@@ -455,8 +455,11 @@ pub mod test {
             "/projects/{}/studies/{}/scenarios/{}/macro_notes?page=1&page_size=3",
             fixtures1.project.id, fixtures1.study.id, fixtures1.scenario.id
         ));
-        let response: MacroNoteListResponse =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: MacroNoteListResponse = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         let ids: Vec<i64> = response.results.iter().map(|note| note.id).collect();
         let mut sorted_ids = ids.clone();
@@ -508,6 +511,7 @@ pub mod test {
             });
         let response: MacroNoteBatchResponse = app
             .fetch(request)
+            .await
             .assert_status(StatusCode::CREATED)
             .json_into();
 
@@ -548,7 +552,9 @@ pub mod test {
             .json(&MacroNoteBatchForm {
                 macro_notes: notes_data.clone(),
             });
-        app.fetch(request).assert_status(StatusCode::NOT_FOUND);
+        app.fetch(request)
+            .await
+            .assert_status(StatusCode::NOT_FOUND);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -573,8 +579,11 @@ pub mod test {
             fixtures.project.id, fixtures.study.id, fixtures.scenario.id, note.id
         ));
 
-        let response: MacroNoteResponse =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: MacroNoteResponse = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         assert_eq!(MacroNoteResponse::from(note), response);
     }
@@ -591,7 +600,9 @@ pub mod test {
             fixtures.project.id, fixtures.study.id, fixtures.scenario.id
         ));
 
-        app.fetch(request).assert_status(StatusCode::NOT_FOUND);
+        app.fetch(request)
+            .await
+            .assert_status(StatusCode::NOT_FOUND);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -619,7 +630,9 @@ pub mod test {
             fixtures_2.project.id, fixtures_2.study.id, fixtures_2.scenario.id, note.id
         ));
 
-        app.fetch(request).assert_status(StatusCode::NOT_FOUND);
+        app.fetch(request)
+            .await
+            .assert_status(StatusCode::NOT_FOUND);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -654,8 +667,11 @@ pub mod test {
             ))
             .json(&update);
 
-        let response: MacroNoteResponse =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: MacroNoteResponse = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         let note = MacroNote::retrieve(db_pool.get_ok(), note.id)
             .await
@@ -688,7 +704,9 @@ pub mod test {
             ))
             .json(&update);
 
-        app.fetch(request).assert_status(StatusCode::NOT_FOUND);
+        app.fetch(request)
+            .await
+            .assert_status(StatusCode::NOT_FOUND);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -714,7 +732,9 @@ pub mod test {
             fixtures.project.id, fixtures.study.id, fixtures.scenario.id, note.id
         ));
 
-        app.fetch(request).assert_status(StatusCode::NO_CONTENT);
+        app.fetch(request)
+            .await
+            .assert_status(StatusCode::NO_CONTENT);
 
         let still_exists = MacroNote::exists(&mut db_pool.get_ok(), note.id)
             .await
@@ -734,6 +754,8 @@ pub mod test {
             fixtures.project.id, fixtures.study.id, fixtures.scenario.id
         ));
 
-        app.fetch(request).assert_status(StatusCode::NOT_FOUND);
+        app.fetch(request)
+            .await
+            .assert_status(StatusCode::NOT_FOUND);
     }
 }

--- a/editoast/src/views/search.rs
+++ b/editoast/src/views/search.rs
@@ -827,8 +827,11 @@ pub mod tests {
                              ["=", ["timetable_id"], timetable_id]],
         }));
 
-        let response: Vec<SearchResultItemTrainSchedule> =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: Vec<SearchResultItemTrainSchedule> = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         assert_eq!(response.len(), 1);
         assert_eq!(response[0].train_name, train.train_name);
@@ -855,8 +858,11 @@ pub mod tests {
                              ["=", ["timetable_id"], timetable_id]],
         }));
 
-        let response: Vec<SearchResultItemTrainSchedule> =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: Vec<SearchResultItemTrainSchedule> = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         assert_eq!(response.len(), 0);
     }

--- a/editoast/src/views/sprites.rs
+++ b/editoast/src/views/sprites.rs
@@ -82,7 +82,11 @@ mod tests {
     async fn test_signaling_systems() {
         let app = TestAppBuilder::default_app();
         let request = app.get("/sprites/signaling_systems");
-        let response: Vec<String> = app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: Vec<String> = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         assert!(response.contains(&"BAL".to_string()));
         assert!(response.contains(&"BAPR".to_string()));
@@ -95,7 +99,7 @@ mod tests {
     async fn test_sprites() {
         let app = TestAppBuilder::default_app();
         let request = app.get("/sprites/TVM300/REP%20TGV.svg");
-        let response = app.fetch(request).assert_status(StatusCode::OK);
+        let response = app.fetch(request).await.assert_status(StatusCode::OK);
         assert_eq!("image/svg+xml", response.content_type());
         let response = response.bytes();
         let expected = std::fs::read(
@@ -111,6 +115,8 @@ mod tests {
     async fn test_sprites_not_found() {
         let app = TestAppBuilder::default_app();
         let request = app.get("/sprites/TVM300/NOT_A_THING.svg");
-        app.fetch(request).assert_status(StatusCode::NOT_FOUND);
+        app.fetch(request)
+            .await
+            .assert_status(StatusCode::NOT_FOUND);
     }
 }

--- a/editoast/src/views/stdcm_search_environment.rs
+++ b/editoast/src/views/stdcm_search_environment.rs
@@ -375,6 +375,7 @@ pub mod tests {
         // WHEN
         let stdcm_search_env = app
             .fetch(request)
+            .await
             .assert_status(StatusCode::CREATED)
             .json_into::<StdcmSearchEnvironment>();
 
@@ -425,6 +426,7 @@ pub mod tests {
 
         // WHEN
         app.fetch(request)
+            .await
             .assert_status(StatusCode::UNPROCESSABLE_ENTITY);
     }
 
@@ -478,6 +480,7 @@ pub mod tests {
         // WHEN
         let stdcm_search_env = app
             .fetch(request)
+            .await
             .assert_status(StatusCode::OK)
             .json_into::<StdcmSearchEnvironmentResponse>();
 
@@ -498,7 +501,7 @@ pub mod tests {
 
         // WHEN
         let request = app.get("/stdcm/search_environment");
-        let response = app.fetch(request);
+        let response = app.fetch(request).await;
 
         // THEN
         response.assert_status(StatusCode::NO_CONTENT);
@@ -535,7 +538,9 @@ pub mod tests {
         let request = app.delete(&format!("/stdcm/search_environment/{}", env.id));
 
         // WHEN
-        app.fetch(request).assert_status(StatusCode::NO_CONTENT);
+        app.fetch(request)
+            .await
+            .assert_status(StatusCode::NO_CONTENT);
 
         // THEN
         let deleted_env_exists = StdcmSearchEnvironment::exists(&mut pool.get_ok(), env.id)
@@ -593,6 +598,7 @@ pub mod tests {
         // WHEN
         let stdcm_search_env_response = app
             .fetch(request)
+            .await
             .assert_status(StatusCode::OK)
             .json_into::<SdcmSearchEnvListResponse>();
 

--- a/editoast/src/views/study.rs
+++ b/editoast/src/views/study.rs
@@ -456,6 +456,7 @@ pub mod tests {
             }));
         let response: StudyResponse = app
             .fetch(request)
+            .await
             .assert_status(StatusCode::CREATED)
             .json_into();
 
@@ -480,8 +481,11 @@ pub mod tests {
 
         let request = app.get(&format!("/projects/{}/studies/", created_project.id));
 
-        let response: StudyListResponse =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: StudyListResponse = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         let studies_retrieved = response
             .results
@@ -507,7 +511,11 @@ pub mod tests {
             created_project.id, created_study.id
         ));
 
-        let response: StudyResponse = app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: StudyResponse = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         assert_eq!(response.study, created_study);
         assert_eq!(response.study.project_id, created_project.id);
@@ -530,7 +538,9 @@ pub mod tests {
             created_study.id + 1000
         ));
 
-        app.fetch(request).assert_status(StatusCode::NOT_FOUND);
+        app.fetch(request)
+            .await
+            .assert_status(StatusCode::NOT_FOUND);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -548,7 +558,9 @@ pub mod tests {
             created_project.id, created_study.id
         ));
 
-        app.fetch(request).assert_status(StatusCode::NO_CONTENT);
+        app.fetch(request)
+            .await
+            .assert_status(StatusCode::NO_CONTENT);
 
         let exists = Study::exists(&mut db_pool.get_ok(), created_study.id)
             .await
@@ -580,7 +592,7 @@ pub mod tests {
                 "budget": study_budget,
             }));
 
-        app.fetch(request).assert_status(StatusCode::OK);
+        app.fetch(request).await.assert_status(StatusCode::OK);
 
         let updated_study = Study::retrieve(db_pool.get_ok(), created_study.id)
             .await

--- a/editoast/src/views/sub_categories.rs
+++ b/editoast/src/views/sub_categories.rs
@@ -260,8 +260,11 @@ pub mod tests {
             }
         ]));
 
-        let response: Vec<SubCategory> =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: Vec<SubCategory> = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
         let created_sub_category1 = response.first().unwrap();
 
         let sub_category_1 = editoast_models::SubCategory::retrieve(
@@ -311,7 +314,9 @@ pub mod tests {
             }
         ]));
 
-        app.fetch(request).assert_status(StatusCode::BAD_REQUEST);
+        app.fetch(request)
+            .await
+            .assert_status(StatusCode::BAD_REQUEST);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -336,8 +341,11 @@ pub mod tests {
         .expect("Failed to create sub category");
 
         let request = app.get("/sub_category");
-        let response: SubCategoryPage =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: SubCategoryPage = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
         assert_eq!(
             response.results,
             vec![created_sub_category_1.into(), created_sub_category_2.into()]
@@ -395,7 +403,9 @@ pub mod tests {
             "/sub_category/{}",
             created_sub_category.code.clone()
         ));
-        app.fetch(request).assert_status(StatusCode::NO_CONTENT);
+        app.fetch(request)
+            .await
+            .assert_status(StatusCode::NO_CONTENT);
 
         let paced_train_1 = models::PacedTrain::retrieve(db_pool.get_ok(), paced_train_1.id)
             .await

--- a/editoast/src/views/temporary_speed_limits.rs
+++ b/editoast/src/views/temporary_speed_limits.rs
@@ -288,6 +288,7 @@ mod tests {
 
         let TemporarySpeedLimitCreateResponse { group_id } = app
             .fetch(request)
+            .await
             .assert_status(StatusCode::CREATED)
             .json_into();
         let created_group = TemporarySpeedLimitGroup::retrieve(pool.get_ok(), group_id)
@@ -319,15 +320,18 @@ mod tests {
         let request = app.create_temporary_speed_limit_group_request(
             RequestParameters::new().with_group_name(group_name.clone()),
         );
-        let _ = app.fetch(request).assert_status(StatusCode::CREATED);
+        let _ = app.fetch(request).await.assert_status(StatusCode::CREATED);
 
         let request = app.create_temporary_speed_limit_group_request(RequestParameters::new());
-        let _ = app.fetch(request).assert_status(StatusCode::CREATED);
+        let _ = app.fetch(request).await.assert_status(StatusCode::CREATED);
 
         let request = app.create_temporary_speed_limit_group_request(
             RequestParameters::new().with_group_name(group_name.clone()),
         );
-        let _ = app.fetch(request).assert_status(StatusCode::BAD_REQUEST);
+        let _ = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::BAD_REQUEST);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -345,6 +349,7 @@ mod tests {
 
         let _ = app
             .fetch(request)
+            .await
             .assert_status(StatusCode::UNPROCESSABLE_ENTITY);
     }
 
@@ -359,6 +364,7 @@ mod tests {
 
         let _ = app
             .fetch(request)
+            .await
             .assert_status(StatusCode::UNPROCESSABLE_ENTITY);
     }
 }

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -360,12 +360,10 @@ impl TestApp {
         )
     }
 
-    pub fn fetch(&self, req: TestRequest) -> TestResponse {
-        futures::executor::block_on(async move {
-            tracing::trace!(request = ?req);
-            let response = req.await;
-            TestResponse::new(response)
-        })
+    pub async fn fetch(&self, req: TestRequest) -> TestResponse {
+        tracing::trace!(request = ?req);
+        let response = req.await;
+        TestResponse::new(response)
     }
 
     pub fn get(&self, path: &str) -> TestRequest {

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -994,8 +994,11 @@ mod tests {
 
         let request = app.get(&format!("/timetable/{}/train_schedules", timetable.id));
 
-        let timetable_from_response: ListTrainSchedulesResponse =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let timetable_from_response: ListTrainSchedulesResponse = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
         assert_eq!(timetable_from_response.results.len(), 0);
     }
 
@@ -1003,7 +1006,9 @@ mod tests {
     async fn get_unexisting_timetable() {
         let app = TestAppBuilder::default_app();
         let request = app.get(&format!("/timetable/{}/train_schedules", 0));
-        app.fetch(request).assert_status(StatusCode::NOT_FOUND);
+        app.fetch(request)
+            .await
+            .assert_status(StatusCode::NOT_FOUND);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -1014,8 +1019,11 @@ mod tests {
         // Insert timetable
         let request = app.post("/timetable");
 
-        let created_timetable: TimetableResult =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let created_timetable: TimetableResult = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         let retrieved_timetable =
             Timetable::retrieve(pool.get_ok(), created_timetable.timetable_id)
@@ -1035,7 +1043,9 @@ mod tests {
 
         let request = app.delete(format!("/timetable/{}", timetable.id).as_str());
 
-        app.fetch(request).assert_status(StatusCode::NO_CONTENT);
+        app.fetch(request)
+            .await
+            .assert_status(StatusCode::NO_CONTENT);
 
         let exists = Timetable::exists(&mut pool.get_ok(), timetable.id)
             .await
@@ -1099,8 +1109,11 @@ mod tests {
             .post(format!("/timetable/{}/paced_trains", timetable.id).as_str())
             .json(&vec![paced_train_1.clone()]);
 
-        let _: Vec<PacedTrainResponse> =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let _: Vec<PacedTrainResponse> = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         let settings = SelectionSettings::default()
             .filter(move || models::PacedTrain::TIMETABLE_ID.eq(timetable.id))
@@ -1134,6 +1147,7 @@ mod tests {
 
         let response = app
             .fetch(request)
+            .await
             .assert_status(StatusCode::UNPROCESSABLE_ENTITY)
             .bytes();
         assert_eq!(
@@ -1159,8 +1173,11 @@ mod tests {
             .post(format!("/timetable/{}/paced_trains", timetable.id).as_str())
             .json(&paced_trains);
 
-        let response: Vec<PacedTrainResponse> =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: Vec<PacedTrainResponse> = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         assert!(response.len() == 2);
 
@@ -1204,8 +1221,11 @@ mod tests {
                 .expect("Failed to create paced trains");
 
         let request = app.get(format!("/timetable/{}/paced_trains", timetable.id).as_str());
-        let list: ListPacedTrainsResponse =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let list: ListPacedTrainsResponse = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         assert_eq!(list.results.len(), 2);
     }
@@ -1216,6 +1236,7 @@ mod tests {
         let request = app.get(format!("/timetable/{}/paced_trains", 0).as_str());
         let response: InternalError = app
             .fetch(request)
+            .await
             .assert_status(StatusCode::NOT_FOUND)
             .json_into();
         assert_eq!(&response.error_type, "editoast:timetable:NotFound")

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -1201,8 +1201,11 @@ mod tests {
             .post(format!("/timetable/{}/paced_trains", timetable.id).as_str())
             .json(&json!(vec![paced_train_base]));
 
-        let response: Vec<PacedTrainResponse> =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: Vec<PacedTrainResponse> = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
         assert_eq!(response.len(), 1);
     }
 
@@ -1230,8 +1233,11 @@ mod tests {
             .post(format!("/timetable/{}/paced_trains", timetable.id).as_str())
             .json(&json!(vec![paced_train_base]));
 
-        let response: Vec<PacedTrainResponse> =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: Vec<PacedTrainResponse> = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         assert_eq!(response.len(), 1);
 
@@ -1278,7 +1284,9 @@ mod tests {
             .put(format!("/paced_train/{}", simple_paced_train.id).as_str())
             .json(&json!(&paced_train));
 
-        app.fetch(request).assert_status(StatusCode::NO_CONTENT);
+        app.fetch(request)
+            .await
+            .assert_status(StatusCode::NO_CONTENT);
 
         let created_paced_train =
             models::PacedTrain::retrieve(pool.get_ok(), simple_paced_train.id)
@@ -1309,7 +1317,9 @@ mod tests {
             .put(format!("/paced_train/{}", paced_train.id).as_str())
             .json(&json!(&paced_train_base));
 
-        app.fetch(request).assert_status(StatusCode::NO_CONTENT);
+        app.fetch(request)
+            .await
+            .assert_status(StatusCode::NO_CONTENT);
 
         let updated_paced_train = models::PacedTrain::retrieve(pool.get_ok(), paced_train.id)
             .await
@@ -1341,6 +1351,7 @@ mod tests {
 
         let response = app
             .fetch(request)
+            .await
             .assert_status(StatusCode::UNPROCESSABLE_ENTITY)
             .bytes();
         assert_eq!(
@@ -1369,6 +1380,7 @@ mod tests {
 
         let response = app
             .fetch(request)
+            .await
             .assert_status(StatusCode::UNPROCESSABLE_ENTITY)
             .bytes();
 
@@ -1390,7 +1402,10 @@ mod tests {
             .delete("/paced_train/")
             .json(&json!({"ids": vec![paced_train.id]}));
 
-        let _ = app.fetch(request).assert_status(StatusCode::NO_CONTENT);
+        let _ = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::NO_CONTENT);
 
         let exists = models::PacedTrain::exists(&mut pool.get_ok(), paced_train.id)
             .await
@@ -1406,6 +1421,7 @@ mod tests {
 
         let response: InternalError = app
             .fetch(request)
+            .await
             .assert_status(StatusCode::NOT_FOUND)
             .json_into();
 
@@ -1424,6 +1440,7 @@ mod tests {
 
         let response = app
             .fetch(request)
+            .await
             .assert_status(StatusCode::OK)
             .json_into::<PacedTrainResponse>();
 
@@ -1471,8 +1488,11 @@ mod tests {
         let request = app.get(
             format!("/paced_train/{train_schedule_id}/simulation/?infra_id={infra_id}").as_str(),
         );
-        let response: core_client::simulation::Response =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: core_client::simulation::Response = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         assert_eq!(
             response,
@@ -1528,6 +1548,7 @@ mod tests {
         );
         let response: InternalError = app
             .fetch(request)
+            .await
             .assert_status(StatusCode::NOT_FOUND)
             .json_into();
 
@@ -1544,8 +1565,11 @@ mod tests {
         let request = app.get(
             format!("/paced_train/{train_schedule_id}/simulation/?infra_id={infra_id}&exception_key=created_exception_key").as_str(),
         );
-        let response: simulation::Response =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: simulation::Response = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         assert_eq!(
             response,
@@ -1595,8 +1619,11 @@ mod tests {
         let (app, infra_id, train_schedule_id) =
             app_infra_id_paced_train_id_for_simulation_tests().await;
         let request = app.get(format!("/paced_train/{train_schedule_id}").as_str());
-        let mut paced_train_response: PacedTrainResponse =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let mut paced_train_response: PacedTrainResponse = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
         paced_train_response.paced_train.exceptions[0].rolling_stock =
             Some(RollingStockChangeGroup {
                 rolling_stock_name: "R2D2".into(),
@@ -1605,13 +1632,18 @@ mod tests {
         let request = app
             .put(format!("/paced_train/{train_schedule_id}").as_str())
             .json(&json!(paced_train_response.paced_train));
-        app.fetch(request).assert_status(StatusCode::NO_CONTENT);
+        app.fetch(request)
+            .await
+            .assert_status(StatusCode::NO_CONTENT);
         // WHEN
         let request = app.get(
             format!("/paced_train/{train_schedule_id}/simulation/?infra_id={infra_id}&exception_key=created_exception_key").as_str(),
         );
-        let response: simulation::Response =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: simulation::Response = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         // THEN
         assert_eq!(
@@ -1635,6 +1667,7 @@ mod tests {
 
         let response: InternalError = app
             .fetch(request)
+            .await
             .assert_status(StatusCode::NOT_FOUND)
             .json_into();
 
@@ -1646,8 +1679,11 @@ mod tests {
         let (app, infra_id, paced_train_id) =
             app_infra_id_paced_train_id_for_simulation_tests().await;
         let request = app.get(format!("/paced_train/{paced_train_id}").as_str());
-        let mut paced_train_response: PacedTrainResponse =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let mut paced_train_response: PacedTrainResponse = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
         // First remove all already generated exceptions
         paced_train_response.paced_train.exceptions.clear();
         // Add one exception which will not change the simulation from base
@@ -1674,14 +1710,19 @@ mod tests {
         let request = app
             .put(format!("/paced_train/{paced_train_id}").as_str())
             .json(&json!(paced_train_response.paced_train));
-        app.fetch(request).assert_status(StatusCode::NO_CONTENT);
+        app.fetch(request)
+            .await
+            .assert_status(StatusCode::NO_CONTENT);
         let request = app.post("/paced_train/simulation_summary").json(&json!({
             "infra_id": infra_id,
             "ids": vec![paced_train_id],
         }));
 
-        let response: HashMap<i64, PacedTrainSummaryResponse> =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: HashMap<i64, PacedTrainSummaryResponse> = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
         assert_eq!(response.len(), 1);
         assert_eq!(
             *response.get(&paced_train_id).unwrap(),
@@ -1725,6 +1766,7 @@ mod tests {
         }));
         let response: InternalError = app
             .fetch(request)
+            .await
             .assert_status(StatusCode::NOT_FOUND)
             .json_into();
 
@@ -1745,6 +1787,7 @@ mod tests {
 
         let response: InternalError = app
             .fetch(request)
+            .await
             .assert_status(StatusCode::NOT_FOUND)
             .json_into();
 
@@ -1764,6 +1807,7 @@ mod tests {
 
         let response: InternalError = app
             .fetch(request)
+            .await
             .assert_status(StatusCode::NOT_FOUND)
             .json_into();
 
@@ -1786,6 +1830,7 @@ mod tests {
         );
         let response: InternalError = app
             .fetch(request)
+            .await
             .assert_status(StatusCode::NOT_FOUND)
             .json_into();
 
@@ -1826,6 +1871,7 @@ mod tests {
 
         let response = app
             .fetch(request)
+            .await
             .assert_status(StatusCode::OK)
             .json_into::<PathfindingResult>();
 
@@ -1883,6 +1929,7 @@ mod tests {
 
         let response = app
             .fetch(request)
+            .await
             .assert_status(StatusCode::OK)
             .json_into::<PathfindingResult>();
 
@@ -1934,6 +1981,7 @@ mod tests {
 
         let response = app
             .fetch(request)
+            .await
             .assert_status(StatusCode::OK)
             .json_into::<PathfindingResult>();
 
@@ -1988,8 +2036,11 @@ mod tests {
                 }
             ],
         }));
-        let response: HashMap<i64, ProjectPathPacedTrainResult> =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: HashMap<i64, ProjectPathPacedTrainResult> = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
         // EXPECT
         // TODO: improve this test
         assert_eq!(response.len(), 2);
@@ -2001,8 +2052,11 @@ mod tests {
             app_infra_id_paced_train_id_for_simulation_tests().await;
 
         let request = app.get(format!("/paced_train/{paced_train_id}").as_str());
-        let mut paced_train_response: PacedTrainResponse =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let mut paced_train_response: PacedTrainResponse = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
         // First remove all already generated exceptions
         paced_train_response.paced_train.exceptions.clear();
 
@@ -2030,7 +2084,9 @@ mod tests {
         let request = app
             .put(format!("/paced_train/{paced_train_id}").as_str())
             .json(&json!(paced_train_response.paced_train));
-        app.fetch(request).assert_status(StatusCode::NO_CONTENT);
+        app.fetch(request)
+            .await
+            .assert_status(StatusCode::NO_CONTENT);
 
         let request =
             app.post("/paced_train/occupancy_blocks")
@@ -2047,7 +2103,7 @@ mod tests {
                         "blocks":[],
                     },
                 }));
-        let response = app.fetch(request);
+        let response = app.fetch(request).await;
         let response: HashMap<i64, OccupancyBlocksPacedTrainResult> =
             response.assert_status(StatusCode::OK).json_into();
         assert_eq!(response.len(), 1);

--- a/editoast/src/views/timetable/similar_trains.rs
+++ b/editoast/src/views/timetable/similar_trains.rs
@@ -1030,7 +1030,11 @@ mod tests {
             timetable_id,
         };
         let request = app.post("/similar_trains").json(&request);
-        let response: Response = app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: Response = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         let expected_response = Response {
             similar_trains: vec![SimilarTrainItem {
@@ -1147,7 +1151,11 @@ mod tests {
             timetable_id,
         };
         let request = app.post("/similar_trains").json(&request);
-        let response: Response = app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: Response = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         assert_eq!(response, Response { similar_trains });
     }
@@ -1264,7 +1272,11 @@ mod tests {
             timetable_id: timetable.id,
         };
         let request = app.post("/similar_trains").json(&request);
-        let response: Response = app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: Response = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         let expected_response = Response {
             similar_trains: vec![
@@ -1446,7 +1458,11 @@ mod tests {
             timetable_id: timetable.id,
         };
         let request = app.post("/similar_trains").json(&request);
-        let response: Response = app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: Response = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         let expected_response = Response {
             similar_trains: vec![
@@ -1577,7 +1593,11 @@ mod tests {
             timetable_id: timetable.id,
         };
         let request = app.post("/similar_trains").json(&request);
-        let response: Response = app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: Response = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         let expected_response = Response {
             similar_trains: vec![
@@ -1728,7 +1748,11 @@ mod tests {
             timetable_id: timetable.id,
         };
         let request = app.post("/similar_trains").json(&request);
-        let response: Response = app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: Response = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         let expected_response = Response {
             similar_trains: vec![SimilarTrainItem {
@@ -1759,7 +1783,11 @@ mod tests {
             timetable_id: timetable.id,
         };
         let request = app.post("/similar_trains").json(&request);
-        let response: Response = app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: Response = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         let expected_response = Response {
             similar_trains: vec![SimilarTrainItem {

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -831,8 +831,11 @@ mod tests {
             .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
             .json(&get_stdcm_payload(rolling_stock.id, None, None, None));
 
-        let stdcm_response: StdcmResponse =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let stdcm_response: StdcmResponse = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         if let PathfindingResult::Success(path) =
             PathfindingResult::Success(pathfinding_result_success())
@@ -877,6 +880,7 @@ mod tests {
 
         let stdcm_response: InternalError = app
             .fetch(request)
+            .await
             .assert_status(StatusCode::BAD_REQUEST)
             .json_into();
 
@@ -922,6 +926,7 @@ mod tests {
 
         let stdcm_response: InternalError = app
             .fetch(request)
+            .await
             .assert_status(StatusCode::BAD_REQUEST)
             .json_into();
 
@@ -963,8 +968,11 @@ mod tests {
                 total_length,
             ));
 
-        let stdcm_response: StdcmResponse =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let stdcm_response: StdcmResponse = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         if let PathfindingResult::Success(path) =
             PathfindingResult::Success(pathfinding_result_success())
@@ -1001,8 +1009,11 @@ mod tests {
             .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
             .json(&get_stdcm_payload(rolling_stock.id, None, None, None));
 
-        let stdcm_response: StdcmResponse =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let stdcm_response: StdcmResponse = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         assert_eq!(
             stdcm_response,

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -1270,6 +1270,7 @@ pub mod tests {
 
         let response = app
             .fetch(request)
+            .await
             .assert_status(StatusCode::OK)
             .json_into::<TrainScheduleResponse>();
 
@@ -1294,8 +1295,11 @@ pub mod tests {
             .post(format!("/timetable/{}/train_schedules", timetable.id).as_str())
             .json(&json!(vec![train_schedule_base]));
 
-        let response: Vec<TrainScheduleResponse> =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: Vec<TrainScheduleResponse> = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
         assert_eq!(response.len(), 1);
     }
 
@@ -1323,8 +1327,11 @@ pub mod tests {
             .post(format!("/timetable/{}/train_schedules", timetable.id).as_str())
             .json(&json!(vec![train_schedule_base]));
 
-        let response: Vec<TrainScheduleResponse> =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: Vec<TrainScheduleResponse> = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         assert_eq!(response.len(), 1);
 
@@ -1360,7 +1367,10 @@ pub mod tests {
             .delete("/train_schedule/")
             .json(&json!({"ids": vec![train_schedule.id]}));
 
-        let _ = app.fetch(request).assert_status(StatusCode::NO_CONTENT);
+        let _ = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::NO_CONTENT);
 
         let exists = models::TrainSchedule::exists(&mut pool.get_ok(), train_schedule.id)
             .await
@@ -1389,8 +1399,11 @@ pub mod tests {
             .put(format!("/train_schedule/{}", train_schedule.id).as_str())
             .json(&json!(update_train_schedule_form));
 
-        let response: TrainScheduleResponse =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: TrainScheduleResponse = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
         assert_eq!(
             response.train_schedule.rolling_stock_name,
             update_train_schedule_form.train_schedule.rolling_stock_name
@@ -1434,8 +1447,11 @@ pub mod tests {
             .put(format!("/train_schedule/{train_schedule_id}").as_str())
             .json(&json!(update_train_schedule_form));
 
-        let response: TrainScheduleResponse =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: TrainScheduleResponse = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
         assert_eq!(
             response.train_schedule.category,
             update_train_schedule_form.train_schedule.category
@@ -1477,8 +1493,11 @@ pub mod tests {
             .put(format!("/train_schedule/{train_schedule_id}").as_str())
             .json(&json!(update_train_schedule_form));
 
-        let response: TrainScheduleResponse =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: TrainScheduleResponse = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         let updated_train_schedule = models::TrainSchedule::retrieve(pool.get_ok(), response.id)
             .await
@@ -1524,7 +1543,7 @@ pub mod tests {
         let request = app.get(
             format!("/train_schedule/{train_schedule_id}/simulation/?infra_id={infra_id}").as_str(),
         );
-        app.fetch(request).assert_status(StatusCode::OK);
+        app.fetch(request).await.assert_status(StatusCode::OK);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -1535,7 +1554,7 @@ pub mod tests {
             "infra_id": infra_id,
             "ids": vec![train_schedule_id],
         }));
-        app.fetch(request).assert_status(StatusCode::OK);
+        app.fetch(request).await.assert_status(StatusCode::OK);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -1597,8 +1616,11 @@ pub mod tests {
                 },
             ],
         }));
-        let response: HashMap<i64, Vec<SpaceTimeCurve>> =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: HashMap<i64, Vec<SpaceTimeCurve>> = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         // EXPECT
         // TODO: improve this test
@@ -1644,7 +1666,9 @@ pub mod tests {
             }),
         );
 
-        app.fetch(request).assert_status(StatusCode::NOT_FOUND);
+        app.fetch(request)
+            .await
+            .assert_status(StatusCode::NOT_FOUND);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -1691,8 +1715,11 @@ pub mod tests {
                 "infra_id": small_infra.id
             }),
         );
-        let response: HashMap<String, Vec<TrackOccupancy>> =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        let response: HashMap<String, Vec<TrackOccupancy>> = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
         assert_eq!(response.len(), 0);
     }
 
@@ -1886,7 +1913,7 @@ pub mod tests {
                         "blocks":[],
                     },
                 }));
-        let response = app.fetch(request);
+        let response = app.fetch(request).await;
         let response: HashMap<i64, OccupancyBlocks> =
             response.assert_status(StatusCode::OK).json_into();
         assert_eq!(response.len(), 1);

--- a/editoast/src/views/work_schedules.rs
+++ b/editoast/src/views/work_schedules.rs
@@ -527,6 +527,7 @@ pub mod tests {
         // WHEN
         let work_schedule_response = app
             .fetch(request)
+            .await
             .assert_status(StatusCode::CREATED)
             .json_into::<WorkScheduleCreateResponse>();
 
@@ -556,6 +557,7 @@ pub mod tests {
         }));
 
         app.fetch(request)
+            .await
             .assert_status(StatusCode::UNPROCESSABLE_ENTITY);
     }
 
@@ -585,6 +587,7 @@ pub mod tests {
 
         let work_schedule_response = app
             .fetch(request)
+            .await
             .assert_status(StatusCode::BAD_REQUEST)
             .json_into::<crate::error::InternalError>();
 
@@ -710,6 +713,7 @@ pub mod tests {
         // WHEN
         let work_schedule_project_response = app
             .fetch(request)
+            .await
             .assert_status(StatusCode::OK)
             .json_into::<Vec<WorkScheduleProjection>>();
 
@@ -739,6 +743,7 @@ pub mod tests {
         let create_group_request = app.post("/work_schedules/group").json(&json!({}));
         let group_creation_response = app
             .fetch(create_group_request)
+            .await
             .assert_status(StatusCode::OK)
             .json_into::<WorkScheduleGroupCreateResponse>();
         let group_id = group_creation_response.work_schedule_group_id;
@@ -754,12 +759,13 @@ pub mod tests {
                 "work_schedule_type": "CATENARY"
             }]
         ));
-        app.fetch(request).assert_status(StatusCode::OK);
+        app.fetch(request).await.assert_status(StatusCode::OK);
 
         // Get the content of the group
         let request = app.get(&work_schedule_url);
         let response = app
             .fetch(request)
+            .await
             .assert_status(StatusCode::OK)
             .json_into::<GroupContentResponse>();
         let work_schedules = response.results;
@@ -768,10 +774,14 @@ pub mod tests {
 
         // Delete it
         let request = app.delete(&work_schedule_url);
-        app.fetch(request).assert_status(StatusCode::NO_CONTENT);
+        app.fetch(request)
+            .await
+            .assert_status(StatusCode::NO_CONTENT);
 
         // Try to access it
         let request = app.get(&work_schedule_url);
-        app.fetch(request).assert_status(StatusCode::NOT_FOUND);
+        app.fetch(request)
+            .await
+            .assert_status(StatusCode::NOT_FOUND);
     }
 }

--- a/editoast/src/views/worker_load.rs
+++ b/editoast/src/views/worker_load.rs
@@ -182,7 +182,11 @@ mod tests {
             infra_id: empty_infra.id,
             timetable_id: None,
         });
-        let response: WorkerStatus = app.fetch(req).assert_status(StatusCode::OK).json_into();
+        let response: WorkerStatus = app
+            .fetch(req)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
         assert_eq!(response, WorkerStatus::Ready);
     }
 }


### PR DESCRIPTION
4 tests left before removing `async-std`.

<details open id="prdesc">

- e0bf97680 *editoast: make `TestApp::fetch` async*
    ```md
    Its `block_on` used to make some tests deadlock.
    ```
- 09c2d44bc *editoast: remove some more `<hashtag>[rstest]`*
    ```md
    4 tests deadlocking with `tokio::test` left.
    ```

</details>