### PR TITLE
editoast: adding filtered operational points in stdcm env

### DIFF
--- a/editoast/database/src/tables.rs
+++ b/editoast/database/src/tables.rs
@@ -709,6 +709,7 @@ diesel::table! {
         speed_limit_tags -> Jsonb,
         #[max_length = 25]
         default_speed_limit_tag -> Nullable<Varchar>,
+        operational_points_id_filtered -> Array<Nullable<Text>>,
     }
 }
 

--- a/editoast/migrations/2025-10-09-142546_stdcm_filtered_op/down.sql
+++ b/editoast/migrations/2025-10-09-142546_stdcm_filtered_op/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE stdcm_search_environment DROP COLUMN IF EXISTS operational_points_id_filtered;

--- a/editoast/migrations/2025-10-09-142546_stdcm_filtered_op/up.sql
+++ b/editoast/migrations/2025-10-09-142546_stdcm_filtered_op/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE stdcm_search_environment ADD COLUMN IF NOT EXISTS operational_points_id_filtered text[] NOT NULL DEFAULT array[]::text[];

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -10594,6 +10594,10 @@ components:
                 type: string
             additionalProperties: false
       additionalProperties: false
+    OperationalPointIds:
+      type: array
+      items:
+        type: string
     OperationalPointPart:
       type: object
       required:
@@ -14050,6 +14054,7 @@ components:
       - enabled_until
       - operational_points
       - speed_limit_tags
+      - operational_points_id_filtered
       properties:
         active_perimeter:
           oneOf:
@@ -14080,6 +14085,8 @@ components:
           format: int64
         operational_points:
           $ref: '#/components/schemas/OperationalPoints'
+        operational_points_id_filtered:
+          $ref: '#/components/schemas/OperationalPointIds'
         search_window_begin:
           type: string
           format: date-time
@@ -14142,6 +14149,12 @@ components:
           items:
             type: integer
             format: int64
+        operational_points_id_filtered:
+          type:
+          - array
+          - 'null'
+          items:
+            type: string
         search_window_begin:
           type: string
           format: date-time
@@ -14204,6 +14217,12 @@ components:
           items:
             type: integer
             format: int64
+        operational_points_id_filtered:
+          type:
+          - array
+          - 'null'
+          items:
+            type: string
         search_window_begin:
           type: string
           format: date-time

--- a/editoast/src/client/stdcm_search_env_commands.rs
+++ b/editoast/src/client/stdcm_search_env_commands.rs
@@ -1,5 +1,6 @@
 use crate::models::Infra;
 use crate::models::Scenario;
+use crate::models::stdcm_search_environment::OperationalPointIds;
 use crate::models::stdcm_search_environment::StdcmSearchEnvironment;
 use crate::models::timetable::Timetable;
 use chrono::DateTime;
@@ -109,7 +110,10 @@ pub struct SetSTDCMSearchEnvFromScenarioArgs {
     pub search_window_end: Option<DateTime<Utc>>,
     /// List of operational points
     #[arg(long, num_args = 1.., value_delimiter = ' ')]
-    pub operation_points: Option<Vec<i64>>,
+    pub operational_points: Option<Vec<i64>>,
+    /// List of operational points uuid that are filtered in the result
+    #[arg(long, num_args = 1.., value_delimiter = ' ')]
+    pub operational_points_id_filtered: Option<Vec<String>>,
     /// List of speed limit tags defined by tag|speed. ex: `MA100|100`
     #[arg(long, num_args = 1.., value_delimiter = ' ')]
     pub speed_limit_tags: Option<Vec<String>>,
@@ -153,7 +157,10 @@ async fn set_stdcm_search_env_from_scenario(
         .active_perimeter(parse_active_perimeter(args.active_perimeter_geojson_path)?)
         .speed_limit_tags(parse_speed_limit_tags(args.speed_limit_tags)?)
         .default_speed_limit_tag(args.default_speed_limit_tag)
-        .operational_points(args.operation_points.into())
+        .operational_points(args.operational_points.into())
+        .operational_points_id_filtered(OperationalPointIds::new(
+            args.operational_points_id_filtered.unwrap_or_default(),
+        ))
         .create(conn)
         .await?;
 
@@ -177,7 +184,10 @@ pub struct SetSTDCMSearchEnvFromScratchArgs {
     pub timetable_id: i64,
     /// List of operational points
     #[arg(long, num_args = 1.., value_delimiter = ' ')]
-    pub operation_points: Option<Vec<i64>>,
+    pub operational_points: Option<Vec<i64>>,
+    /// List of operational points uuid that are filtered in the result
+    #[arg(long, num_args = 1.., value_delimiter = ' ')]
+    pub operational_points_id_filtered: Option<Vec<String>>,
     /// List of speed limit tags
     #[arg(long, num_args = 1.., value_delimiter = ' ')]
     pub speed_limit_tags: Option<Vec<String>>,
@@ -233,7 +243,10 @@ async fn set_stdcm_search_env_from_scratch(
         .search_window_end(end)
         .enabled_from(Utc::now())
         .enabled_until(Utc::now() + Duration::days(1000))
-        .operational_points(args.operation_points.into())
+        .operational_points(args.operational_points.into())
+        .operational_points_id_filtered(OperationalPointIds::new(
+            args.operational_points_id_filtered.unwrap_or_default(),
+        ))
         .active_perimeter(parse_active_perimeter(args.active_perimeter_geojson_path)?)
         .speed_limit_tags(parse_speed_limit_tags(args.speed_limit_tags)?)
         .default_speed_limit_tag(args.default_speed_limit_tag)
@@ -466,7 +479,9 @@ mod tests {
             serde_json::from_value(perimeter_json).expect("Failed to parse geometry");
         let perimeter_file = generate_temp_file(&perimeter);
 
-        let operation_points = Vec::from([1, 2, 3, 4]);
+        let operational_points = Vec::from([1, 2, 3, 4]);
+        let operational_points_id_filtered =
+            Vec::from(["uuid-1".to_string(), "uuid-2".to_string()]);
         let speed_limit_tags = Vec::from(["MA80|80".to_string(), "MA90|90".to_string()]);
         let default_speed_limit_tag = "MA90".to_string();
 
@@ -475,7 +490,8 @@ mod tests {
             work_schedule_group_id: Some(work_schedule_group.id),
             search_window_begin: None,
             search_window_end: None,
-            operation_points: Some(operation_points.clone()),
+            operational_points: Some(operational_points.clone()),
+            operational_points_id_filtered: Some(operational_points_id_filtered.clone()),
             speed_limit_tags: Some(speed_limit_tags),
             default_speed_limit_tag: Some(default_speed_limit_tag.clone()),
             active_perimeter_geojson_path: Some(perimeter_file.path().into()),
@@ -499,7 +515,11 @@ mod tests {
         );
 
         assert_eq!(search_env.active_perimeter, Some(perimeter));
-        assert_eq!(search_env.operational_points.to_vec(), operation_points);
+        assert_eq!(search_env.operational_points.to_vec(), operational_points);
+        assert_eq!(
+            search_env.operational_points_id_filtered.to_vec(),
+            operational_points_id_filtered
+        );
         assert_eq!(
             search_env.speed_limit_tags,
             vec![("MA80".to_string(), 80), ("MA90".to_string(), 90),]
@@ -528,7 +548,9 @@ mod tests {
         ];
 
         create_train_schedules_from_start_times(start_times, timetable.id, conn).await;
-        let operation_points = Vec::from([1, 2, 3, 4]);
+        let operational_points = Vec::from([1, 2, 3, 4]);
+        let operational_points_id_filtered =
+            Vec::from(["uuid-1".to_string(), "uuid-2".to_string()]);
         let speed_limit_tags = Vec::from(["MA80|80".to_string(), "MA90|90".to_string()]);
         let default_speed_limit_tag = "MA90".to_string();
 
@@ -539,7 +561,8 @@ mod tests {
             timetable_id: timetable.id,
             search_window_begin: None,
             search_window_end: None,
-            operation_points: Some(operation_points.clone()),
+            operational_points: Some(operational_points.clone()),
+            operational_points_id_filtered: Some(operational_points_id_filtered.clone()),
             speed_limit_tags: Some(speed_limit_tags),
             default_speed_limit_tag: Some(default_speed_limit_tag.clone()),
             active_perimeter_geojson_path: None,
@@ -562,7 +585,11 @@ mod tests {
             make_datetime("2000-02-03 08:00:00Z")
         );
 
-        assert_eq!(search_env.operational_points.to_vec(), operation_points);
+        assert_eq!(search_env.operational_points.to_vec(), operational_points);
+        assert_eq!(
+            search_env.operational_points_id_filtered.to_vec(),
+            operational_points_id_filtered
+        );
         assert_eq!(
             search_env.speed_limit_tags,
             vec![("MA80".to_string(), 80), ("MA90".to_string(), 90),]

--- a/editoast/src/models/stdcm_search_environment.rs
+++ b/editoast/src/models/stdcm_search_environment.rs
@@ -50,7 +50,40 @@ impl From<Option<Vec<Option<i64>>>> for OperationalPoints {
     }
 }
 
-#[derive(Debug, Clone, Model, ToSchema, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default, ToSchema)]
+pub struct OperationalPointIds(Vec<String>);
+
+impl OperationalPointIds {
+    pub fn new(value: Vec<String>) -> Self {
+        Self(value)
+    }
+    pub fn to_vec(&self) -> Vec<String> {
+        self.0.clone()
+    }
+}
+
+impl From<OperationalPointIds> for Vec<Option<String>> {
+    fn from(value: OperationalPointIds) -> Self {
+        value.0.into_iter().map(Some).collect()
+    }
+}
+impl From<Vec<Option<String>>> for OperationalPointIds {
+    fn from(value: Vec<Option<String>>) -> Self {
+        Self(value.into_iter().flatten().collect())
+    }
+}
+impl From<Option<Vec<String>>> for OperationalPointIds {
+    fn from(value: Option<Vec<String>>) -> Self {
+        Self(value.unwrap_or_default())
+    }
+}
+impl From<Option<Vec<Option<String>>>> for OperationalPointIds {
+    fn from(value: Option<Vec<Option<String>>>) -> Self {
+        Self(value.unwrap_or_default().into_iter().flatten().collect())
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Model, ToSchema)]
 #[model(table = database::tables::stdcm_search_environment)]
 #[model(gen(ops = crd, list))]
 #[cfg_attr(test, derive(Deserialize, PartialEq), model(changeset(derive(Clone))))]
@@ -86,6 +119,8 @@ pub struct StdcmSearchEnvironment {
     #[model(json)]
     pub speed_limit_tags: HashMap<String, i64>,
     pub default_speed_limit_tag: Option<String>,
+    #[model(remote = "Vec<Option<String>>")]
+    pub operational_points_id_filtered: OperationalPointIds,
 }
 
 impl StdcmSearchEnvironment {

--- a/editoast/src/views/stdcm_search_environment.rs
+++ b/editoast/src/views/stdcm_search_environment.rs
@@ -67,6 +67,8 @@ pub(in crate::views) struct StdcmSearchEnvironmentCreateForm {
     active_perimeter: Option<geos::geojson::Geometry>,
     operational_points: Option<Vec<i64>>,
     speed_limits: Option<SpeedLimits>,
+    #[serde(default)]
+    operational_points_id_filtered: Option<Vec<String>>,
 }
 
 #[derive(Serialize, Deserialize, ToSchema)]
@@ -85,6 +87,7 @@ struct StdcmSearchEnvironmentResponse {
     active_perimeter: Option<geos::geojson::Geometry>,
     operational_points: Option<Vec<i64>>,
     speed_limits: Option<SpeedLimits>,
+    operational_points_id_filtered: Option<Vec<String>>,
 }
 
 impl<'de> Deserialize<'de> for StdcmSearchEnvironmentCreateForm {
@@ -145,6 +148,7 @@ impl From<StdcmSearchEnvironmentCreateForm> for Changeset<StdcmSearchEnvironment
             .enabled_until(form.enabled_until)
             .active_perimeter(form.active_perimeter)
             .operational_points(form.operational_points.into())
+            .operational_points_id_filtered(form.operational_points_id_filtered.into())
             .speed_limit_tags(speed_limits.speed_limit_tags)
             .default_speed_limit_tag(speed_limits.default_speed_limit_tag)
     }
@@ -178,6 +182,7 @@ impl From<StdcmSearchEnvironment> for StdcmSearchEnvironmentResponse {
             } else {
                 None
             },
+            operational_points_id_filtered: Some(from.operational_points_id_filtered.to_vec()),
             speed_limits,
         }
     }
@@ -360,6 +365,8 @@ pub mod tests {
             enabled_from: Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap(),
             enabled_until: Utc.with_ymd_and_hms(2024, 1, 1, 23, 59, 59).unwrap(),
             operational_points: Some(Vec::from([1, 2, 3])),
+            operational_points_id_filtered: Vec::from(["uuid-1".to_string(), "uuid-2".to_string()])
+                .into(),
             speed_limits: Some(SpeedLimits {
                 speed_limit_tags: vec![("MA80".to_string(), 80), ("MA90".to_string(), 90)]
                     .into_iter()
@@ -412,6 +419,8 @@ pub mod tests {
             enabled_from: Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap(),
             enabled_until: Utc.with_ymd_and_hms(2024, 1, 1, 23, 59, 59).unwrap(),
             operational_points: Some(Vec::from([1, 2, 3])),
+            operational_points_id_filtered: Vec::from(["uuid-1".to_string(), "uuid-2".to_string()])
+                .into(),
             speed_limits: Some(SpeedLimits {
                 speed_limit_tags: vec![("MA80".to_string(), 80), ("MA90".to_string(), 90)]
                     .into_iter()

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -4691,6 +4691,7 @@ export type StdcmSearchEnvironmentResponse = {
   id: number;
   infra_id: number;
   operational_points?: number[] | null;
+  operational_points_id_filtered?: string[] | null;
   search_window_begin: string;
   search_window_end: string;
   speed_limits?: null | SpeedLimits;
@@ -4699,6 +4700,7 @@ export type StdcmSearchEnvironmentResponse = {
   work_schedule_group_id?: number | null;
 };
 export type OperationalPoints = number[];
+export type OperationalPointIds = string[];
 export type StdcmSearchEnvironment = {
   active_perimeter?: null | GeoJson;
   default_speed_limit_tag?: string | null;
@@ -4711,6 +4713,7 @@ export type StdcmSearchEnvironment = {
   id: number;
   infra_id: number;
   operational_points: OperationalPoints;
+  operational_points_id_filtered: OperationalPointIds;
   /** The start of the search time window.
     Usually, trains schedules from the `timetable_id` runs within this window. */
   search_window_begin: string;
@@ -4731,6 +4734,7 @@ export type StdcmSearchEnvironmentCreateForm = {
   enabled_until: string;
   infra_id: number;
   operational_points?: number[] | null;
+  operational_points_id_filtered?: string[] | null;
   search_window_begin: string;
   search_window_end: string;
   speed_limits?: null | SpeedLimits;


### PR DESCRIPTION
Be able to store on the STDCM env table, a list of operational point ID that will be filtered from simulation results

Check this issue #13305.