### PR TITLE
editoast: simulation: add `PathfindingEnv` and simulation streams

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -859,6 +859,7 @@ dependencies = [
  "itertools",
  "lapin",
  "opentelemetry",
+ "ordered-float",
  "pretty_assertions",
  "schemas",
  "serde",
@@ -877,7 +878,19 @@ name = "core_task"
 version = "0.1.0"
 dependencies = [
  "cache",
+ "common",
  "core_client",
+ "dashmap",
+ "deadpool-redis",
+ "futures 0.3.31",
+ "http",
+ "itertools",
+ "ordered-float",
+ "schemas",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -4237,6 +4250,7 @@ version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "ryu",

--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -873,6 +873,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "core_task"
+version = "0.1.0"
+dependencies = [
+ "cache",
+ "core_client",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -43,6 +43,7 @@ common = { path = "./common" }
 core_client = { path = "./core_client" }
 core_task = { path = "./core_task" }
 darling = "0.21"
+dashmap = "6.1.0"
 database = { path = "./database" }
 deadpool = { version = "0.12.3", default-features = false, features = [
   "managed",
@@ -162,7 +163,7 @@ clap.workspace = true
 colored = "3.0.0"
 common = { workspace = true }
 core_client = { workspace = true, features = ["mocking_client"] }
-dashmap = "6.1.0"
+dashmap.workspace = true
 database.workspace = true
 deadpool.workspace = true
 deadpool-redis.workspace = true

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -99,6 +99,7 @@ opentelemetry_sdk = { version = "0.31.0", default-features = false, features = [
   "rt-tokio",
   "trace",
 ] }
+ordered-float = { version = "5.0.0", features = ["serde"] }
 osrdyne_client = { path = "./osrdyne_client" }
 postgis_diesel = { version = "2.5.0", features = ["serde"] }
 postgres-openssl = "0.5.2"
@@ -203,7 +204,7 @@ opentelemetry-otlp = { version = "0.31.0", default-features = false, features = 
 ] }
 opentelemetry-semantic-conventions.workspace = true
 opentelemetry_sdk.workspace = true
-ordered-float = { version = "5.0.0", features = ["serde"] }
+ordered-float.workspace = true
 osrdyne_client.workspace = true
 pathfinding = "4.14.0"
 petgraph = "0.8.2"

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -82,6 +82,7 @@ futures-util = "0.3.30"
 geojson = { version = "0.24", default-features = false }
 geos = { version = "8.3.1", features = ["json"] }
 hostname = "0.4.0"
+http = "1.3.1"
 itertools = "0.14.0"
 lapin = "2.5.5"
 linkme = "0.3.35"

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -11,6 +11,7 @@ members = [
   "cache",
   "common",
   "core_client",
+  "core_task",
   "database",
   "editoast_derive",
   "editoast_models",
@@ -40,6 +41,7 @@ chrono = { version = "0.4.42", default-features = false, features = ["serde"] }
 clap = { version = "4.5", features = ["derive", "env"] }
 common = { path = "./common" }
 core_client = { path = "./core_client" }
+core_task = { path = "./core_task" }
 darling = "0.21"
 database = { path = "./database" }
 deadpool = { version = "0.12.3", default-features = false, features = [

--- a/editoast/cache/src/connection.rs
+++ b/editoast/cache/src/connection.rs
@@ -22,7 +22,6 @@ use tracing::span;
 
 pub struct Connection {
     inner: ConnectionInner,
-    #[expect(unused)]
     app_version: ArcStr,
 }
 
@@ -137,6 +136,10 @@ struct ZrangebyscoreWrapper<M> {
 impl Connection {
     pub(crate) fn new(inner: ConnectionInner, app_version: ArcStr) -> Self {
         Self { inner, app_version }
+    }
+
+    pub fn app_version(&self) -> &str {
+        &self.app_version
     }
 
     /// Get a deserializable value from valkey

--- a/editoast/core_client/Cargo.toml
+++ b/editoast/core_client/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 
 [features]
-mocking_client = []
+mocking_client = ["dep:http"]
 
 [dependencies]
 approx.workspace = true
@@ -16,7 +16,7 @@ editoast_derive.workspace = true
 educe.workspace = true
 futures-util.workspace = true
 hostname.workspace = true
-http = "1.3.1"
+http = { workspace = true, optional = true }
 itertools.workspace = true
 lapin.workspace = true
 opentelemetry.workspace = true

--- a/editoast/core_client/Cargo.toml
+++ b/editoast/core_client/Cargo.toml
@@ -20,6 +20,7 @@ http = { workspace = true, optional = true }
 itertools.workspace = true
 lapin.workspace = true
 opentelemetry.workspace = true
+ordered-float.workspace = true
 schemas = { workspace = true, features = ["testing"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true

--- a/editoast/core_client/src/path_properties.rs
+++ b/editoast/core_client/src/path_properties.rs
@@ -1,8 +1,6 @@
 use common::geometry::GeoJsonLineString;
 use schemas::infra::OperationalPointExtensions;
 use schemas::infra::OperationalPointPart;
-use schemas::infra::OperationalPointPartExtension;
-use schemas::infra::OperationalPointSncfExtension;
 use schemas::primitives::Identifier;
 use serde::Deserialize;
 use serde::Serialize;
@@ -11,6 +9,11 @@ use utoipa::ToSchema;
 use crate::AsCoreRequest;
 use crate::Json;
 use crate::pathfinding::TrackRange;
+
+#[cfg(feature = "mocking_client")]
+use schemas::infra::OperationalPointPartExtension;
+#[cfg(feature = "mocking_client")]
+use schemas::infra::OperationalPointSncfExtension;
 
 #[derive(Debug, Serialize)]
 pub struct PathPropertiesRequest<'a> {

--- a/editoast/core_client/src/pathfinding.rs
+++ b/editoast/core_client/src/pathfinding.rs
@@ -1,3 +1,4 @@
+use ordered_float::OrderedFloat;
 use schemas::infra::Direction;
 use schemas::infra::TrackOffset;
 use schemas::primitives::Identifier;
@@ -11,7 +12,7 @@ use crate::AsCoreRequest;
 use crate::Json;
 use crate::RawError;
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Hash, Serialize)]
 pub struct PathfindingRequest {
     /// Infrastructure id
     pub infra: i64,
@@ -29,9 +30,9 @@ pub struct PathfindingRequest {
     /// List of supported signaling systems
     pub rolling_stock_supported_signaling_systems: Vec<String>,
     /// Maximum speed of the rolling stock
-    pub rolling_stock_maximum_speed: f64,
+    pub rolling_stock_maximum_speed: OrderedFloat<f64>,
     /// Rolling stock length in meters:
-    pub rolling_stock_length: f64,
+    pub rolling_stock_length: OrderedFloat<f64>,
     /// Speed limit tag, used to estimate the max speed and travel time
     pub speed_limit_tag: Option<String>,
 }

--- a/editoast/core_task/Cargo.toml
+++ b/editoast/core_task/Cargo.toml
@@ -7,3 +7,20 @@ edition.workspace = true
 [dependencies]
 cache.workspace = true
 core_client.workspace = true
+dashmap.workspace = true
+deadpool-redis.workspace = true # for trait AsyncCommands
+futures.workspace = true
+itertools.workspace = true
+ordered-float.workspace = true
+schemas.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+cache = { workspace = true, features = ["mock"] }
+common.workspace = true
+core_client = { workspace = true, features = ["mocking_client"] }
+http.workspace = true
+serde_json = { workspace = true, features = ["preserve_order"] }

--- a/editoast/core_task/Cargo.toml
+++ b/editoast/core_task/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "core_task"
+license.workspace = true
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+cache.workspace = true
+core_client.workspace = true

--- a/editoast/core_task/src/envs.rs
+++ b/editoast/core_task/src/envs.rs
@@ -1,0 +1,1 @@
+pub mod core;

--- a/editoast/core_task/src/envs.rs
+++ b/editoast/core_task/src/envs.rs
@@ -1,1 +1,2 @@
 pub mod core;
+pub mod pathfinding;

--- a/editoast/core_task/src/envs/core.rs
+++ b/editoast/core_task/src/envs/core.rs
@@ -1,0 +1,8 @@
+use std::sync::Arc;
+
+/// Innermost simulation environment to configure Core basic parameters
+pub struct CoreEnv {
+    pub infra_id: u64,
+    pub infra_version: i64,
+    pub client: Arc<core_client::CoreClient>,
+}

--- a/editoast/core_task/src/envs/core.rs
+++ b/editoast/core_task/src/envs/core.rs
@@ -1,8 +1,19 @@
 use std::sync::Arc;
 
-/// Innermost simulation environment to configure Core basic parameters
+/// Innermost environment to configure Core basic parameters
 pub struct CoreEnv {
     pub infra_id: u64,
     pub infra_version: i64,
     pub client: Arc<core_client::CoreClient>,
+}
+
+#[cfg(test)]
+impl CoreEnv {
+    pub(crate) fn new_mock(mock: core_client::mocking::MockingClient) -> Self {
+        Self {
+            infra_id: 1,
+            infra_version: 1,
+            client: Arc::new(mock.into()),
+        }
+    }
 }

--- a/editoast/core_task/src/envs/pathfinding.rs
+++ b/editoast/core_task/src/envs/pathfinding.rs
@@ -1,0 +1,426 @@
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::hash::DefaultHasher;
+use std::hash::Hash;
+use std::hash::Hasher as _;
+use std::sync::Arc;
+
+use core_client::AsCoreRequest as _;
+use core_client::CoreClient;
+use dashmap::DashMap;
+use futures::stream;
+use itertools::Itertools;
+use ordered_float::OrderedFloat;
+use schemas::infra::TrackOffset;
+use schemas::rolling_stock::LoadingGaugeType;
+
+use crate::CoreEnv;
+use crate::Correlated;
+use crate::Task;
+
+/// An environment to compute and cache paths asynchronously
+///
+/// Provides [PathfindingEnv::run] and [PathfindingEnv::into_stream] to build, run,
+/// cache and return paths computed by Core. Use [PathfindingEnv::extend] to add train
+/// consist information and pathfinding constraints in the environment.
+///
+/// `Train` generic parameter is a correlation key to associate each path to a train.
+/// It will be cloned several times over internally, so this operation should be cheap.
+pub struct PathfindingEnv<Train>
+where
+    Train: Clone + Hash + Eq + Send + Sync + 'static,
+{
+    // Inputs
+    core_env: CoreEnv,
+    // TODO: deduplicate values
+    consists: HashMap<Train, Arc<PathfindingConsist>>,
+    constraints: HashMap<Train, Arc<PathfindingConstraints>>,
+
+    // Generated
+    trains: HashMap<Input, HashSet<Train>>, // inverse index: unique input set => trains
+
+    // Outputs
+    // optionally deduplicate similar outputs of different inputs
+    paths: DashMap<Input, Arc<core_client::pathfinding::PathfindingCoreResult>>,
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+struct Input(Arc<PathfindingConsist>, Arc<PathfindingConstraints>);
+
+#[derive(Debug, Hash, PartialEq, Eq)]
+#[cfg_attr(test, derive(Clone))]
+pub struct PathfindingConsist {
+    pub loading_gauge: LoadingGaugeType,
+    /// Can the consist run on non-electrified tracks
+    pub thermal: bool,
+    /// Supported electrification modes (leave empty for unelectrified consists)
+    pub supported_electrifications: Vec<String>,
+    /// A list of supported signaling systems
+    pub supported_signaling_systems: Vec<String>,
+    pub maximum_speed: OrderedFloat<f64>,
+    /// Consist length in meters
+    pub length: OrderedFloat<f64>,
+    /// Speed limit tag to estimate maximum speed and travel time
+    pub speed_limit_tag: Option<String>,
+}
+
+#[derive(Debug, Hash, PartialEq, Eq)]
+#[cfg_attr(test, derive(Clone))]
+pub struct PathfindingConstraints {
+    /// An ordered list of waypoints the resulting path must pass through
+    pub path_items: Vec<PathWaypointAlternatives>,
+}
+
+/// A set of [TrackOffset]
+///
+/// The resulting path can cross any of these.
+#[derive(Debug, Hash, PartialEq, Eq)]
+#[cfg_attr(test, derive(Clone))]
+pub struct PathWaypointAlternatives(Vec<TrackOffset>);
+
+impl FromIterator<TrackOffset> for PathWaypointAlternatives {
+    fn from_iter<T: IntoIterator<Item = TrackOffset>>(iter: T) -> Self {
+        Self(iter.into_iter().collect())
+    }
+}
+
+impl IntoIterator for PathWaypointAlternatives {
+    type Item = TrackOffset;
+    type IntoIter = <Vec<TrackOffset> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<Train> PathfindingEnv<Train>
+where
+    Train: Clone + Hash + Eq + Send + Sync + 'static,
+{
+    pub fn new(core_env: CoreEnv) -> Self {
+        Self {
+            core_env,
+            consists: HashMap::new(),
+            constraints: HashMap::new(),
+            trains: HashMap::new(),
+            paths: DashMap::new(),
+        }
+    }
+}
+
+impl<Train> Extend<(Train, PathfindingConsist)> for PathfindingEnv<Train>
+where
+    Train: Clone + Hash + Eq + Send + Sync + 'static,
+{
+    fn extend<T: IntoIterator<Item = (Train, PathfindingConsist)>>(&mut self, iter: T) {
+        self.consists.extend(
+            iter.into_iter()
+                .map(|(train, consist)| (train, Arc::new(consist))),
+        );
+        self.build_input_map();
+    }
+}
+
+impl<Train> Extend<(Train, PathfindingConstraints)> for PathfindingEnv<Train>
+where
+    Train: Clone + Hash + Eq + Send + Sync + 'static,
+{
+    fn extend<T: IntoIterator<Item = (Train, PathfindingConstraints)>>(&mut self, iter: T) {
+        self.constraints.extend(
+            iter.into_iter()
+                .map(|(train, constraints)| (train, Arc::new(constraints))),
+        );
+        self.build_input_map();
+    }
+}
+
+impl Task for core_client::pathfinding::PathfindingRequest {
+    type Output = core_client::pathfinding::PathfindingCoreResult;
+    type Error = core_client::Error;
+    type Context = Arc<CoreClient>;
+
+    // Please adjust if you have more educated information (and adjust the comment 😉).
+    const CACHE_READS_BATCH_SIZE: usize = 50; // This value has been chosen this way: 🫳🎩
+
+    fn key(&self, app_version: &str) -> String {
+        let mut hasher = DefaultHasher::new();
+        self.hash(&mut hasher);
+        let req_hash = hasher.finish().to_string();
+        format!("editoast.{app_version}.pathfinding.{req_hash}")
+    }
+
+    async fn compute(self, ctx: Self::Context) -> Result<Self::Output, Self::Error> {
+        self.fetch(ctx.as_ref()).await
+    }
+}
+
+impl<Train> PathfindingEnv<Train>
+where
+    Train: Clone + Hash + Eq + Send + Sync + 'static,
+{
+    /// Computes paths or fetches them from cache asynchronously
+    ///
+    /// Returns a stream of trains that have been processed. Stream items are
+    /// a set of trains because similar requests are deduplicated to avoid
+    /// unnecessary computations. All the trains in the set have the same path.
+    ///
+    /// The path itself can be fetched using [PathfindingEnv::get_path].
+    ///
+    /// Note that while the paths are stored in the environment, the latter does **not**
+    /// act as a cache layer. If we `run([1, 2, 3])` and then `run([1, 2])`, the
+    /// environment will try to fetch the path for `1` and `2` from cache *even though*
+    /// they are already stored in the environment. Paths are stored in the environment
+    /// only for API ergonomics.
+    pub fn run<'a>(
+        &'a self,
+        vkconn: cache::Connection,
+        trains: HashSet<Train>,
+    ) -> impl stream::TryStream<Ok = HashSet<Train>, Error = core_client::Error> + use<'a, Train>
+    {
+        use stream::TryStreamExt as _;
+        self.paths_stream(vkconn, trains).map_ok(
+            move |Correlated {
+                      correlation_key: input,
+                      data: path,
+                  }| {
+                let trains = self
+                    .trains
+                    .get(&input)
+                    .expect("deduplicate_inputs invariant")
+                    .clone();
+                self.paths.insert(input, Arc::new(path));
+                trains
+            },
+        )
+    }
+
+    /// Computes paths or fetches them from cache asynchronously
+    ///
+    /// Doesn't store the paths in the environment unlike [PathfindingEnv::run].
+    /// The returned stream yields a set of trains and their corresponding path directly,
+    /// avoiding the caller to deal with the `Arc` returned by [PathfindingEnv::get_path],
+    /// thus transferring ownership and allow easy path mutations.
+    pub fn into_stream(
+        &self,
+        vkconn: cache::Connection,
+        trains: HashSet<Train>,
+    ) -> impl stream::TryStream<
+        Ok = (
+            HashSet<Train>,
+            core_client::pathfinding::PathfindingCoreResult,
+        ),
+        Error = core_client::Error,
+    > {
+        use stream::TryStreamExt as _;
+        self.paths_stream(vkconn, trains).map_ok(
+            move |Correlated {
+                      correlation_key: input,
+                      data: path,
+                  }| {
+                let trains = self
+                    .trains
+                    .get(&input)
+                    .expect("deduplicate_inputs invariant")
+                    .clone();
+                (trains, path)
+            },
+        )
+    }
+
+    /// Returns all trains in the environment for which all needed information is configured
+    pub fn all_trains(&self) -> HashSet<Train> {
+        self.consists
+            .keys()
+            .collect::<HashSet<_>>()
+            .intersection(&self.constraints.keys().collect())
+            .cloned()
+            .cloned() // not an error, it's an &&Train originally
+            .collect()
+    }
+
+    /// Returns the path for a given train
+    ///
+    /// A `None` value can indicate several things:
+    ///
+    /// - The train is not in the environment
+    /// - The train is not ready (either missing consist or constraints)
+    /// - The train's path is being computed but its path is not yet available
+    ///
+    /// NOTE: we should probably expose a better result type for these three cases
+    pub fn get_path(
+        &self,
+        train: &Train,
+    ) -> Option<Arc<core_client::pathfinding::PathfindingCoreResult>> {
+        let input = self.train_input(train)?;
+        let value_ref = self.paths.get(&input)?;
+        Some(value_ref.value().clone())
+    }
+
+    /// Builds the [Self::trains] map using trains from both [Self::consists] and [Self::constraints]
+    ///
+    /// TODO: we should build it incrementally to avoid unnecessary complexity
+    fn build_input_map(&mut self) {
+        self.trains.clear();
+        for train in self.all_trains() {
+            let consist = self.consists.get(&train).expect("all_trains invariant");
+            let constraints = self.constraints.get(&train).expect("all_trains invariant");
+            let input = Input(consist.clone(), constraints.clone());
+            self.trains.entry(input).or_default().insert(train);
+        }
+    }
+
+    fn paths_stream(
+        &self,
+        vkconn: cache::Connection,
+        trains: HashSet<Train>,
+    ) -> impl stream::TryStream<
+        Ok = Correlated<Input, core_client::pathfinding::PathfindingCoreResult>,
+        Error = core_client::Error,
+    > + use<Train> {
+        use crate::TaskStreamExt as _;
+
+        let inputs = trains.iter().map(|train| {
+            self.train_input(train)
+                .expect("train map should have been built by now")
+        });
+        let requests = inputs
+            .map(|input| {
+                let request = self.build_request(&input);
+                Correlated::new(input, request)
+            })
+            .collect_vec();
+
+        stream::iter(requests).run(vkconn, self.core_env.client.clone())
+    }
+
+    fn build_request(
+        &self,
+        Input(consist, constraints): &Input,
+    ) -> core_client::pathfinding::PathfindingRequest {
+        core_client::pathfinding::PathfindingRequest {
+            infra: self.core_env.infra_id as i64,
+            expected_version: self.core_env.infra_version,
+            path_items: constraints
+                .path_items
+                .iter()
+                .map(|PathWaypointAlternatives(track_alternatives)| {
+                    track_alternatives.clone().into_iter().collect()
+                })
+                .collect(),
+            rolling_stock_loading_gauge: consist.loading_gauge,
+            rolling_stock_is_thermal: consist.thermal,
+            rolling_stock_supported_electrifications: consist.supported_electrifications.clone(),
+            rolling_stock_supported_signaling_systems: consist.supported_signaling_systems.clone(),
+            rolling_stock_maximum_speed: consist.maximum_speed,
+            rolling_stock_length: consist.length,
+            speed_limit_tag: consist.speed_limit_tag.clone(),
+        }
+    }
+
+    fn train_input(&self, train: &Train) -> Option<Input> {
+        let consist = self.consists.get(train)?;
+        let constraints = self.constraints.get(train)?;
+        Some(Input(consist.clone(), constraints.clone()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core_client::mocking::MockingClient;
+    use deadpool_redis::redis;
+    use futures::TryStreamExt as _;
+    use http::StatusCode;
+    use serde_json::json;
+
+    use crate::mock_mget;
+
+    use super::*;
+
+    /// We use the length field to identify it since the content doesn't matter
+    fn path(id: usize) -> serde_json::Value {
+        let mut path = json!({
+            "status": "success",
+            "length": id,
+            "path_item_positions": [],
+            "path": {
+                "blocks": [],
+                "routes": [],
+                "track_section_ranges": []
+            }
+        });
+        path.sort_all_objects();
+        path
+    }
+
+    fn constraints(id: usize) -> PathfindingConstraints {
+        PathfindingConstraints {
+            path_items: vec![
+                PathWaypointAlternatives::from_iter([TrackOffset::new("id", id as u64)]),
+                PathWaypointAlternatives::from_iter([
+                    TrackOffset::new("tr1", 100),
+                    TrackOffset::new("tr1bis", 100),
+                ]),
+                PathWaypointAlternatives::from_iter([TrackOffset::new("tr2", 200)]),
+            ],
+        }
+    }
+
+    fn consist(id: usize) -> PathfindingConsist {
+        PathfindingConsist {
+            loading_gauge: LoadingGaugeType::GB,
+            thermal: true,
+            supported_electrifications: vec![],
+            supported_signaling_systems: vec!["BAPR".to_owned()],
+            maximum_speed: OrderedFloat::from(100.0),
+            length: OrderedFloat::from(id as f64),
+            speed_limit_tag: Some("MA100".to_owned()),
+        }
+    }
+
+    impl PathfindingEnv<usize> {
+        fn key(&self, id: usize) -> String {
+            let input = self.train_input(&id).unwrap();
+            let request = self.build_request(&input);
+            use crate::Task as _;
+            request.key("")
+        }
+    }
+
+    #[tokio::test]
+    async fn pathfinding_env() {
+        common::setup_tracing_for_test();
+        let mut mock = MockingClient::new();
+        mock.stub("/pathfinding/blocks")
+            .response(StatusCode::OK)
+            .json(path(2))
+            .finish();
+        let mut pfenv = PathfindingEnv::<usize>::new(CoreEnv::new_mock(mock));
+        pfenv.extend([(1, constraints(1)), (2, constraints(2))]);
+        pfenv.extend([(1, consist(1)), (2, consist(2))]);
+        let vk = cache::Client::new_mock(
+            vec![
+                mock_mget(vec![(pfenv.key(1), Some(path(1))), (pfenv.key(2), None)]),
+                cache::MockCmd::new(
+                    redis::cmd("SET").arg(pfenv.key(2)).arg(path(2).to_string()),
+                    Ok(redis::Value::Nil),
+                ),
+            ],
+            "",
+        );
+        let all_trains = pfenv.all_trains();
+        assert_eq!(all_trains, HashSet::from([1, 2]));
+        let _trains = pfenv
+            .run(vk.get_connection().await.unwrap(), all_trains)
+            .try_collect::<Vec<_>>()
+            .await
+            .expect("should go well");
+        assert_eq!(
+            pfenv.get_path(&1),
+            Some(serde_json::from_value(path(1)).unwrap())
+        );
+        assert_eq!(
+            pfenv.get_path(&2),
+            Some(serde_json::from_value(path(2)).unwrap())
+        );
+    }
+}

--- a/editoast/core_task/src/lib.rs
+++ b/editoast/core_task/src/lib.rs
@@ -1,3 +1,341 @@
 mod envs;
 
+use std::iter;
+use std::sync::Arc;
+
+// Crate-level exports
 pub use envs::core::CoreEnv;
+pub use envs::pathfinding::PathfindingConsist;
+pub use envs::pathfinding::PathfindingConstraints;
+pub use envs::pathfinding::PathfindingEnv;
+
+use futures::stream;
+use itertools::Itertools as _;
+use itertools::izip;
+use serde::de::DeserializeOwned;
+use serde::ser::Serialize;
+use tracing::Instrument;
+
+/// Indicates that a Core task can be performed and cached
+///
+/// This trait is meant to be implemented for [Task] requests.
+///
+/// Features:
+/// - [fn Task::run] that runs a single task
+/// - [trait TaskStreamExt] to batch tasks (requires additional [type Task::Context] bounds)
+pub trait Task: Sized + Send {
+    /// Task output
+    type Output: DeserializeOwned + Serialize + Send;
+    /// Computation error when running a task for cache misses
+    type Error: std::error::Error + Send;
+    /// Context required for task
+    ///
+    /// Additional bounds are required on this to batch tasks, cf. [trait TaskStreamExt].
+    type Context: Send;
+
+    /// Number of cache entry read attempts per batch
+    ///
+    /// Choose this value based on the size of task results and acceptable latency considering all reads hit.
+    const CACHE_READS_BATCH_SIZE: usize;
+
+    /// Computes the cache key based on task inputs
+    fn key(&self, app_version: &str) -> String;
+
+    /// Computes the task output according to inputs and context
+    ///
+    /// This function does **not** need to handle any caching concerns.
+    fn compute(
+        self,
+        ctx: Self::Context,
+    ) -> impl Future<Output = Result<Self::Output, Self::Error>> + Send;
+
+    /// Retrieves the task result from cache or computes it
+    ///
+    /// To batch tasks, check out [trait TaskStreamExt].
+    ///
+    /// # Errors
+    ///
+    /// Should any caching error occur while reading, the task output is computed.
+    /// Cache write errors are ignored. So are serde errors for caching.
+    /// All errors are logged.
+    #[expect(async_fn_in_trait)] // not for public (ie. outside editoast) use, no auto traits bounds to specify on the resulting future
+    async fn run(
+        self,
+        mut vkconn: cache::Connection,
+        ctx: Self::Context,
+    ) -> Result<Self::Output, Self::Error> {
+        let key = self.key(vkconn.app_version());
+        match vkconn
+            .json_get::<Self::Output, _>(&key)
+            .await
+            .unwrap_or_else(|e| {
+                tracing::error!(?e, key, "cache read error — computing task output");
+                None
+            }) {
+            Some(value) => Ok(value),
+            None => {
+                let value = self.compute(ctx).await?;
+                match serde_json::to_string(&value) {
+                    Err(e) => {
+                        tracing::error!(
+                            ?e,
+                            key,
+                            "serialization error before cache write — skipping cache write"
+                        );
+                    }
+                    Ok(serialized) => {
+                        tokio::spawn(async move {
+                            use deadpool_redis::redis::AsyncCommands as _;
+                            if let Err(e) = vkconn.set::<_, _, ()>(key.clone(), serialized).await {
+                                tracing::error!(?e, key, "cache write error");
+                            }
+                        });
+                    }
+                };
+                Ok(value)
+            }
+        }
+    }
+}
+
+/// A named tuple for a value with a correlation key
+pub struct Correlated<CorrelationKey, T> {
+    pub correlation_key: CorrelationKey,
+    pub data: T,
+}
+
+impl<CorrelationKey, T> Correlated<CorrelationKey, T> {
+    pub fn new(correlation_key: CorrelationKey, data: T) -> Self {
+        Self {
+            correlation_key,
+            data,
+        }
+    }
+}
+
+impl<CorrelationKey, T> From<Correlated<CorrelationKey, T>> for (CorrelationKey, T) {
+    fn from(correlated: Correlated<CorrelationKey, T>) -> Self {
+        (correlated.correlation_key, correlated.data)
+    }
+}
+
+/// Extends streams to provide [TaskStreamExt::run]
+///
+/// The stream must contain [Correlated] task requests. In practice, the `CorrelationKey`
+/// is the `Train` generic parameter of task environments.
+///
+/// Differs from [Task::run] as it operates on a stream of inputs instead of a single one.
+pub trait TaskStreamExt<T, CorrelationKey>
+where
+    CorrelationKey: Send + 'static,
+    T: Task + 'static,
+    T::Context: Clone + Send + Sync,
+    Self: stream::Stream<Item = Correlated<CorrelationKey, T>> + Send + 'static,
+{
+    /// Returns a stream of task results fetched from cache or computed concurrently
+    ///
+    /// The order of the results is not the same as the order of inputs.
+    fn run(
+        self,
+        vkconn: cache::Connection,
+        ctx: T::Context,
+    ) -> impl stream::TryStream<Ok = Correlated<CorrelationKey, T::Output>, Error = T::Error> + Send;
+}
+
+impl<T, InputStream, CorrelationKey> TaskStreamExt<T, CorrelationKey> for InputStream
+where
+    CorrelationKey: Send + 'static,
+    T: Task + 'static,
+    T::Context: Clone + Send + Sync,
+    InputStream: stream::Stream<Item = Correlated<CorrelationKey, T>> + Send + 'static,
+{
+    #[tracing::instrument(skip_all)]
+    fn run(
+        self,
+        vkconn: cache::Connection,
+        ctx: <T as Task>::Context,
+    ) -> impl stream::TryStream<
+        Ok = Correlated<CorrelationKey, <T as Task>::Output>,
+        Error = <T as Task>::Error,
+    > + Send {
+        use stream::StreamExt as _;
+
+        /* The implementation spawns several Tokio tasks which interact in the following way:
+         *
+         *                      [task]
+         *                      not_a_task
+         *                      (comment)
+         *                                                                                            compute ------------> [write_cache]
+         *                                                +-------> [chunk_processing] ------+
+         *                                                |                                  |           ^                        |
+         *                                                |                                  |           |(cache miss)            v
+         *                                                |                                  |
+         * requests stream ----------> [cache_read] ------+-------> [chunk_processing] ------+----> [aggregation]---------> result_stream
+         * (self, function                                |                                  |                   (cache hit)
+         *     input)                                     |                                  |
+         *                                                |                                  |
+         *                                                +--------> ... --------------------+
+         *                                  (spawns several tasks
+         *                                   via for_each_concurrent)
+         */
+
+        // shared to several tasks
+        let vkconn = Arc::new(tokio::sync::Mutex::new(vkconn));
+
+        let (cache_write_tx, mut cache_write_rx) =
+            tokio::sync::mpsc::unbounded_channel::<(String, String)>();
+        {
+            let vkconn = vkconn.clone();
+            // 'write_cache' task, writes input key-value pairs to cache, logging errors
+            tokio::spawn(
+                async move {
+                    use deadpool_redis::redis::AsyncCommands as _;
+                    while let Some((key, serialized_value)) = cache_write_rx.recv().await {
+                        if let Err(e) = vkconn
+                            .lock()
+                            .await
+                            .set::<_, _, ()>(key.clone(), serialized_value)
+                            .await
+                        {
+                            tracing::error!(?e, key, "task stream: cache write failure")
+                        }
+                    }
+                }
+                .in_current_span(),
+            );
+        }
+
+        let (cache_read_tx, mut cache_read_rx) = tokio::sync::mpsc::unbounded_channel::<(
+            T, // input
+            CorrelationKey,
+            String,            // cache key
+            Option<T::Output>, // maybe a cached task output
+        )>();
+        {
+            // 'cache_read' task, consumes input stream (self), chunks cache reads,
+            // processes each chunk in a dedicated task 'chunk_processing' (spawned by for_each_concurrent),
+            // and sends a bunch of data to the 'aggregation' task
+            tokio::spawn(
+                self.chunks(T::CACHE_READS_BATCH_SIZE)
+                    .zip(stream::iter(iter::repeat(vkconn.clone())))
+                    .zip(stream::iter(iter::repeat(cache_read_tx)))
+                    .for_each_concurrent(None, async move |((inputs, vkconn), cache_read_tx)| {
+                        let mut vk = vkconn.lock().await;
+
+                        // We sort the keys so that unit tests can predictably mock redis requests.
+                        // That's because redis-test doesn't find a matching request in the list, but
+                        // just pops the first one and asserts.
+                        #[cfg(test)]
+                        let inputs = inputs
+                            .into_iter()
+                            .map(|input| {
+                                let key = input.data.key(vk.app_version());
+                                (input, key)
+                            })
+                            .sorted_by_key(|(_, key)| key.clone())
+                            .map(|(input, _)| input)
+                            .collect_vec();
+
+                        let (correlation_keys, inputs) = inputs
+                            .into_iter()
+                            .map_into()
+                            .unzip::<_, _, Vec<_>, Vec<_>>();
+                        let cache_keys = inputs
+                            .iter()
+                            .map(|input| input.key(vk.app_version()))
+                            .collect_vec();
+
+                        // we have to clone because of json_get_bulk's API x Rust 2024 new rules
+                        let keys = cache_keys.clone();
+
+                        // Fetch from valkey or compute and write to valkey
+                        match vk.json_get_bulk::<T::Output, _>(keys.as_slice()).await {
+                            Ok(cached_values) => {
+                                for (value, correlation, key, input) in
+                                    izip!(cached_values, correlation_keys, cache_keys, inputs)
+                                {
+                                    cache_read_tx.send((input, correlation, key, value)).ok();
+                                }
+                            }
+                            Err(e) => {
+                                tracing::error!(
+                                    ?e,
+                                    "task stream: cache read error — computing task output"
+                                );
+                                for (key, correlation, input) in
+                                    izip!(cache_keys, correlation_keys, inputs)
+                                {
+                                    cache_read_tx.send((input, correlation, key, None)).ok();
+                                }
+                            }
+                        };
+                    }),
+            );
+        }
+
+        let (results_tx, results_rx) = futures::channel::mpsc::unbounded::<
+            Result<Correlated<CorrelationKey, T::Output>, T::Error>,
+        >();
+        {
+            // 'aggregation' task, receives requests and potential cached task outputs. If cached,
+            // directly send the value to the result stream, otherwise compute the value (send a request to Core),
+            // send it to the 'write_cache' task and to the result stream.
+            tokio::spawn(async move {
+                while let Some((input, correlation_key, cache_key, cache_entry)) =
+                    cache_read_rx.recv().await
+                {
+                    if let Some(cached_value) = cache_entry {
+                        results_tx
+                            .unbounded_send(Ok(Correlated::new(correlation_key, cached_value)))
+                            .ok();
+                    } else {
+                        match input.compute(ctx.clone()).await {
+                            Ok(value) => {
+                                #[cfg(not(test))]
+                                let serialized = serde_json::to_string(&value).unwrap();
+                                #[cfg(test)]
+                                let serialized = {
+                                    let mut serialized = serde_json::to_value(&value).unwrap();
+                                    serialized.sort_all_objects();
+                                    serialized.to_string()
+                                };
+                                cache_write_tx.send((cache_key, serialized)).ok();
+                                results_tx
+                                    .unbounded_send(Ok(Correlated::new(correlation_key, value)))
+                                    .ok();
+                            }
+                            Err(err) => {
+                                results_tx.unbounded_send(Err(err)).ok();
+                            }
+                        };
+                    }
+                }
+            });
+        }
+
+        // The receiver implements Stream
+        results_rx
+    }
+}
+
+#[cfg(test)]
+/// Builds an `MGET` mocked command with sorted keys and ordered JSON keys for determinism
+fn mock_mget(mut values: Vec<(String, Option<serde_json::Value>)>) -> cache::MockCmd {
+    values.sort_by_key(|(k, _)| k.clone());
+    let (keys, values): (Vec<_>, Vec<_>) = values.into_iter().unzip();
+    cache::MockCmd::new(
+        deadpool_redis::redis::cmd("MGET").arg(keys),
+        Ok(deadpool_redis::redis::Value::Array(
+            values
+                .into_iter()
+                .map(|v| match v {
+                    Some(mut v) => {
+                        v.sort_all_objects();
+                        deadpool_redis::redis::Value::SimpleString(v.to_string())
+                    }
+                    None => deadpool_redis::redis::Value::Nil,
+                })
+                .collect(),
+        )),
+    )
+}

--- a/editoast/core_task/src/lib.rs
+++ b/editoast/core_task/src/lib.rs
@@ -1,0 +1,3 @@
+mod envs;
+
+pub use envs::core::CoreEnv;

--- a/editoast/editoast_models/src/map/geo_json_and_data.rs
+++ b/editoast/editoast_models/src/map/geo_json_and_data.rs
@@ -101,7 +101,16 @@ fn geometry_into_mvt_geom_type(geometry: &Geometry) -> GeomType {
 /// * `feature` - Feature on which tags must be added
 /// * `tags` - JsonValue containing tags to add
 /// * `key` - Name of the tag
-fn add_tags_to_feature(feature: &mut Feature, tags: JsonValue, tag_name: String) {
+fn add_tags_to_feature(
+    feature: &mut Feature,
+    #[cfg(not(test))] tags: JsonValue,
+    #[cfg(test)] mut tags: JsonValue,
+    tag_name: String,
+) {
+    // Other editoast crates rely on 'preserve_order' feature of serde_json which then cascades to this crate.
+    // Then we need to sort them in order to deterministically generate the snapshot used in tests below.
+    #[cfg(test)]
+    tags.sort_all_objects();
     match tags {
         JsonValue::Bool(bool) => feature.add_tag_bool(&tag_name, bool),
         JsonValue::Number(number) => {

--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -395,8 +395,8 @@ fn build_pathfinding_request(
         rolling_stock_supported_signaling_systems: pathfinding_input
             .rolling_stock_supported_signaling_systems
             .clone(),
-        rolling_stock_maximum_speed: pathfinding_input.rolling_stock_maximum_speed.0,
-        rolling_stock_length: pathfinding_input.rolling_stock_length.0,
+        rolling_stock_maximum_speed: pathfinding_input.rolling_stock_maximum_speed,
+        rolling_stock_length: pathfinding_input.rolling_stock_length,
         speed_limit_tag: pathfinding_input.speed_limit_tag.clone(),
     })
 }


### PR DESCRIPTION
- Adds basic `Simulation` and `SimulationStreamExt` traits to encapsulate
  caching or computing logic.
- Adds `PathfindingEnv` with
    - pathfinding inputs
    - input deduplication
    - owned / non-owned results streams
    - paths can be stored in the env, but that doesn't act as a cache
      layer
- A few test utils, especially key and JSON object sorting for
  determinism. There's a lot to improve in this area, especially the
  redis mocking where requests arrive asynchronously but `redis-mock`
  only pops from the vec.