### PR TITLE
editoast: add requestbody to macro_note put openapi documentation

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -2934,6 +2934,12 @@ paths:
         schema:
           type: integer
           format: int64
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MacroNoteForm'
+        required: true
       responses:
         '200':
           description: The updated macro note

--- a/editoast/src/views/scenario/macro_notes.rs
+++ b/editoast/src/views/scenario/macro_notes.rs
@@ -275,6 +275,7 @@ pub(in crate::views) async fn get(
 #[utoipa::path(
     put, path = "",
     tag = "scenarios",
+    request_body = MacroNoteForm,
     params(ProjectIdParam, StudyIdParam, ScenarioIdParam, MacroNoteIdParam),
     responses(
         (status = 200, body = MacroNoteResponse, description = "The updated macro note"),

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -843,6 +843,7 @@ const injectedRtkApi = api
         query: (queryArg) => ({
           url: `/projects/${queryArg.projectId}/studies/${queryArg.studyId}/scenarios/${queryArg.scenarioId}/macro_notes/${queryArg.noteId}`,
           method: 'PUT',
+          body: queryArg.macroNoteForm,
         }),
         invalidatesTags: ['scenarios'],
       }),
@@ -2233,6 +2234,7 @@ export type PutProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotes
   studyId: number;
   scenarioId: number;
   noteId: number;
+  macroNoteForm: MacroNoteForm;
 };
 export type DeleteProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotesNoteIdApiResponse =
   unknown;


### PR DESCRIPTION
Updates the `PUT` endpoint for macro notes to specify `MacroNoteForm` as the request body in its documentation and handler.