### PR TITLE
docker: wait for dev front container to be healthy

### DIFF
--- a/docker/docker-compose.front.yml
+++ b/docker/docker-compose.front.yml
@@ -27,6 +27,10 @@ services:
     ports: [ "3000:3000" ]
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:3000" ]
-      start_period: 4s
+      start_period: 5m
       interval: 5s
       retries: 6
+
+  wait-healthy:
+    depends_on:
+      front: { condition: service_healthy }

--- a/front/docker/Dockerfile.devel
+++ b/front/docker/Dockerfile.devel
@@ -7,6 +7,8 @@ RUN gcc -std=c99 -static -o /exec-as exec-as.c
 
 FROM node:24-alpine
 
+RUN apk add --no-cache curl
+
 COPY --from=exec_as_builder /exec-as /
 
 WORKDIR /app

--- a/front/docker/Dockerfile.devel
+++ b/front/docker/Dockerfile.devel
@@ -1,6 +1,6 @@
 FROM alpine AS exec_as_builder
 
-RUN apk add build-base
+RUN apk add --no-cache build-base
 COPY docker/exec-as.c .
 RUN gcc -std=c99 -static -o /exec-as exec-as.c
 


### PR DESCRIPTION
_See individual commits._

The development frontend container might take a while to start, because it installs dependencies and builds osrd-ui.

This might confuse users because the gateway will throw an HTTP error while the front container is starting up:

    Failed to connect to host: Connection refused (os error 111)

Make it clear that the development setup is not fully started by waiting for the front container to be healthy.

Bump the start_period because 4s is definitely not enough for the front container to download all dependencies and build osrd-ui.