### PR TITLE
editoast: remove explicit diesel_json wrapper in stdcm_search_env

### DIFF
--- a/editoast/database/src/tables.rs
+++ b/editoast/database/src/tables.rs
@@ -703,7 +703,7 @@ diesel::table! {
         temporary_speed_limit_group_id -> Nullable<Int8>,
         enabled_from -> Timestamptz,
         enabled_until -> Timestamptz,
-        active_perimeter -> Nullable<Jsonb>,
+        active_perimeter -> Jsonb,
         operational_points -> Array<Nullable<Int8>>,
         speed_limit_tags -> Jsonb,
         #[max_length = 25]

--- a/editoast/migrations/2025-10-14-124855-0000_change_active_perimeter_to_not_null_with_default/down.sql
+++ b/editoast/migrations/2025-10-14-124855-0000_change_active_perimeter_to_not_null_with_default/down.sql
@@ -1,0 +1,7 @@
+ALTER TABLE stdcm_search_environment 
+ALTER COLUMN active_perimeter DROP DEFAULT,
+ALTER COLUMN active_perimeter DROP NOT NULL;
+
+UPDATE stdcm_search_environment 
+SET active_perimeter = NULL 
+WHERE active_perimeter = 'null'::jsonb;

--- a/editoast/migrations/2025-10-14-124855-0000_change_active_perimeter_to_not_null_with_default/up.sql
+++ b/editoast/migrations/2025-10-14-124855-0000_change_active_perimeter_to_not_null_with_default/up.sql
@@ -1,0 +1,7 @@
+UPDATE stdcm_search_environment 
+SET active_perimeter = 'null'::jsonb 
+WHERE active_perimeter IS NULL;
+
+ALTER TABLE stdcm_search_environment 
+ALTER COLUMN active_perimeter SET NOT NULL,
+ALTER COLUMN active_perimeter SET DEFAULT 'null'::jsonb;

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -13984,8 +13984,9 @@ components:
       - speed_limit_tags
       properties:
         active_perimeter:
-          $ref: '#/components/schemas/GeoJson'
-          description: 'TODO: here we should not use diesel_json::Json, but the #[model(json)] instead'
+          oneOf:
+          - type: 'null'
+          - $ref: '#/components/schemas/GeoJson'
         default_speed_limit_tag:
           type:
           - string

--- a/editoast/src/client/stdcm_search_env_commands.rs
+++ b/editoast/src/client/stdcm_search_env_commands.rs
@@ -9,7 +9,6 @@ use clap::Args;
 use clap::Subcommand;
 use database::DbConnection;
 use database::DbConnectionPoolV2;
-use diesel_json::Json;
 use editoast_models::ElectricalProfileSet;
 use editoast_models::WorkScheduleGroup;
 use editoast_models::prelude::*;
@@ -58,14 +57,14 @@ where
 
 fn parse_active_perimeter(
     file_path: Option<PathBuf>,
-) -> anyhow::Result<Option<Json<geos::geojson::Geometry>>> {
+) -> anyhow::Result<Option<geos::geojson::Geometry>> {
     match file_path {
         None => Ok(None),
         Some(perimeter_path) => {
             let perimeter_file = File::open(perimeter_path)
                 .map_err(|_| anyhow::anyhow!("Perimeter file must exist"))?;
 
-            let geometry: Option<Json<geos::geojson::Geometry>> =
+            let geometry: Option<geos::geojson::Geometry> =
                 serde_json::from_reader(BufReader::new(perimeter_file))
                     .map_err(|_| anyhow::anyhow!("Perimeter file can't be read"))?;
 
@@ -303,7 +302,6 @@ mod tests {
     use chrono::Utc;
     use database::DbConnection;
     use database::DbConnectionPoolV2;
-    use diesel_json::Json;
     use geos::geojson::Geometry;
     use rstest::rstest;
     use serde_json::json;
@@ -464,8 +462,8 @@ mod tests {
                 [ -1, 47 ]
             ]]
         });
-        let perimeter: Json<Geometry> =
-            Json(serde_json::from_value(perimeter_json).expect("Failed to parse geometry"));
+        let perimeter: Geometry =
+            serde_json::from_value(perimeter_json).expect("Failed to parse geometry");
         let perimeter_file = generate_temp_file(&perimeter);
 
         let operation_points = Vec::from([1, 2, 3, 4]);

--- a/editoast/src/models/stdcm_search_environment.rs
+++ b/editoast/src/models/stdcm_search_environment.rs
@@ -77,10 +77,9 @@ pub struct StdcmSearchEnvironment {
     /// The time window end point where the environment is enabled.
     /// This value is usually lower than the `search_window_begin`, since a search is performed before the train rolls.
     pub enabled_until: DateTime<Utc>,
-    /// TODO: here we should not use diesel_json::Json, but the #[model(json)] instead
-    #[schema(value_type = GeoJson)]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub active_perimeter: Option<diesel_json::Json<geos::geojson::Geometry>>,
+    #[schema(value_type = Option<GeoJson>)]
+    #[model(json)]
+    pub active_perimeter: Option<geos::geojson::Geometry>,
     #[model(remote = "Vec<Option<i64>>")]
     pub operational_points: OperationalPoints,
     /// Map of speed limit tag with their value

--- a/editoast/src/views/stdcm_search_environment.rs
+++ b/editoast/src/views/stdcm_search_environment.rs
@@ -81,9 +81,8 @@ struct StdcmSearchEnvironmentResponse {
     search_window_end: DateTime<Utc>,
     enabled_from: DateTime<Utc>,
     enabled_until: DateTime<Utc>,
-    // TODO: diesel_json should be removed when it will be removed from the model
     #[schema(value_type = Option<common::geometry::GeoJson>)]
-    active_perimeter: Option<diesel_json::Json<geos::geojson::Geometry>>,
+    active_perimeter: Option<geos::geojson::Geometry>,
     operational_points: Option<Vec<i64>>,
     speed_limits: Option<SpeedLimits>,
 }
@@ -144,7 +143,7 @@ impl From<StdcmSearchEnvironmentCreateForm> for Changeset<StdcmSearchEnvironment
             .search_window_end(form.search_window_end)
             .enabled_from(form.enabled_from)
             .enabled_until(form.enabled_until)
-            .active_perimeter(form.active_perimeter.map(diesel_json::Json))
+            .active_perimeter(form.active_perimeter)
             .operational_points(form.operational_points.into())
             .speed_limit_tags(speed_limits.speed_limit_tags)
             .default_speed_limit_tag(speed_limits.default_speed_limit_tag)

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -4680,8 +4680,7 @@ export type StdcmSearchEnvironmentResponse = {
 };
 export type OperationalPoints = number[];
 export type StdcmSearchEnvironment = {
-  /** TODO: here we should not use diesel_json::Json, but the #[model(json)] instead */
-  active_perimeter?: GeoJson;
+  active_perimeter?: null | GeoJson;
   default_speed_limit_tag?: string | null;
   electrical_profile_set_id?: number;
   /** The time window start point where the environment is enabled. */


### PR DESCRIPTION
Remove the use of the `diesel_json::Json` wrapper and update the database schema and migrations accordingly.

* Changed the `active_perimeter` column in the `stdcm_search_environment` table to be non-nullable with a default value of `'null'::jsonb`, and updated existing null values to use this default.
* Updated the Rust model `StdcmSearchEnvironment` and related response structs to use `Option<geos::geojson::Geometry>` directly for `active_perimeter`, removing the `diesel_json::Json` wrapper and associated comments.
* Refactored code and tests to remove references to `diesel_json::Json` and use plain `geos::geojson::Geometry` for `active_perimeter`.