### PR TITLE
front, ui-icons: fix ESLint ignore rule

### DIFF
--- a/front/eslint.config.js
+++ b/front/eslint.config.js
@@ -10,6 +10,8 @@ import vitestPlugin from '@vitest/eslint-plugin';
 export default [
   {
     files: ['**/*.ts', '**/*.tsx', '**/*.js'],
+  },
+  {
     ignores: [
       'src/common/api/generatedEditoastApi.ts',
       'src/common/api/osrdGatewayApi.ts',

--- a/front/ui/eslint.config.js
+++ b/front/ui/eslint.config.js
@@ -9,6 +9,8 @@ import tseslint from 'typescript-eslint';
 export default [
   {
     files: ['**/*.ts', '**/*.tsx', '**/*.js'],
+  },
+  {
     ignores: ['ui-icons/src/'],
   },
   ...tseslint.config(js.configs.recommended, ...tseslint.configs.recommended),


### PR DESCRIPTION
ui-icons has a bunch of auto-generated files we don't want to run ESLint on. However, since the ESLint flat config migration we're analyzing these files and generating a long list of errors.

ESLint assumes that a lone { ignores } is a global ignore configuration object:
https://eslint.org/docs/latest/use/configure/configuration-files#globally-ignoring-files-with-ignores

Having a "files" field in the same object makes this a local configuration object. To fix this, split it in half.

To test:

    cd front/ui/ui-icons
    npm run build

This should not print any error.