### PR TITLE
core: cleanup before refactor `Pathfinding.kt`

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/IncompatibleConstraintsPostProcessing.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/IncompatibleConstraintsPostProcessing.kt
@@ -4,7 +4,7 @@ import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.graph.*
 import fr.sncf.osrd.path.implementations.buildTrainPathFromBlocks
 import fr.sncf.osrd.pathfinding.Pathfinding
-import fr.sncf.osrd.pathfinding.PathfindingResultId
+import fr.sncf.osrd.pathfinding.Pathfinding.EdgeRange
 import fr.sncf.osrd.pathfinding.constraints.ElectrificationConstraints
 import fr.sncf.osrd.pathfinding.constraints.LoadingGaugeConstraints
 import fr.sncf.osrd.pathfinding.constraints.SignalingSystemConstraints
@@ -18,7 +18,7 @@ import fr.sncf.osrd.utils.units.Offset
 
 fun buildIncompatibleConstraintsResponse(
     infra: FullInfra,
-    possiblePathWithoutErrorNoConstraints: PathfindingResultId<Block>?,
+    possiblePathWithoutErrorNoConstraints: Pathfinding.Result<BlockId, Block>?,
     constraints: Collection<PathfindingConstraint<Block>>,
     initialRequest: PathfindingBlockRequest,
 ): IncompatibleConstraintsPathResponse? {
@@ -93,7 +93,7 @@ fun buildIncompatibleConstraintsResponse(
 
 private fun <T> getConstraintsDistanceRange(
     infra: FullInfra,
-    pathRanges: List<Pathfinding.EdgeRange<BlockId, Block>>,
+    pathRanges: List<EdgeRange<BlockId, Block>>,
     pathConstrainedValues: DistanceRangeMap<T>,
     constraint: PathfindingConstraint<Block>?,
 ): DistanceRangeMap<T> {
@@ -110,7 +110,7 @@ private fun <T> getConstraintsDistanceRange(
 
 private fun getBlockedRanges(
     infra: FullInfra,
-    pathRanges: List<Pathfinding.EdgeRange<BlockId, Block>>,
+    pathRanges: List<EdgeRange<BlockId, Block>>,
     currentConstraint: PathfindingConstraint<Block>,
 ): DistanceRangeMap<Boolean> {
     val blockList = pathRanges.map { it.edge }

--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlockResponse.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlockResponse.kt
@@ -9,7 +9,7 @@ import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import fr.sncf.osrd.api.DirectionalTrackRange
 import fr.sncf.osrd.path.interfaces.JsonTrainPath
 import fr.sncf.osrd.path.interfaces.TravelledPath
-import fr.sncf.osrd.pathfinding.Pathfinding.Range
+import fr.sncf.osrd.pathfinding.Pathfinding
 import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.utils.json.UnitAdapterFactory
 import fr.sncf.osrd.utils.units.Length
@@ -66,9 +66,9 @@ data class IncompatibleConstraints(
     val incompatibleSignalingSystemRanges: List<RangeValue<String>>,
 )
 
-data class RangeValue<T>(val range: Range<TravelledPath>, val value: T?) {
+data class RangeValue<T>(val range: Pathfinding.Range<TravelledPath>, val value: T?) {
     @FromJson
-    fun fromJson(range: Range<TravelledPath>): RangeValue<T> {
+    fun fromJson(range: Pathfinding.Range<TravelledPath>): RangeValue<T> {
         return RangeValue(range, null)
     }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.kt
@@ -4,13 +4,16 @@ import fr.sncf.osrd.api.ExceptionHandler
 import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.api.InfraProvider
 import fr.sncf.osrd.api.TrackLocation
-import fr.sncf.osrd.api.pathfinding.*
 import fr.sncf.osrd.graph.*
-import fr.sncf.osrd.pathfinding.*
+import fr.sncf.osrd.pathfinding.Pathfinding
 import fr.sncf.osrd.pathfinding.Pathfinding.EdgeLocation
 import fr.sncf.osrd.pathfinding.Pathfinding.EdgeRange
+import fr.sncf.osrd.pathfinding.PathfindingEdge
+import fr.sncf.osrd.pathfinding.PathfindingGraph
+import fr.sncf.osrd.pathfinding.RemainingDistanceEstimator
 import fr.sncf.osrd.pathfinding.constraints.ConstraintCombiner
 import fr.sncf.osrd.pathfinding.constraints.initConstraintsFromRSProps
+import fr.sncf.osrd.pathfinding.minDistanceBetweenSteps
 import fr.sncf.osrd.reporting.exceptions.ErrorType
 import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.sim_infra.api.*
@@ -18,7 +21,6 @@ import fr.sncf.osrd.stdcm.STDCMStep
 import fr.sncf.osrd.stdcm.graph.extendLookaheadUntil
 import fr.sncf.osrd.stdcm.infra_exploration.initInfraExplorer
 import fr.sncf.osrd.utils.*
-import fr.sncf.osrd.utils.indexing.*
 import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
@@ -98,9 +100,9 @@ class PathfindingBlocksEndpoint(private val infraManager: InfraProvider) : Take 
 @Throws(OSRDError::class)
 fun runPathfinding(infra: FullInfra, request: PathfindingBlockRequest): PathfindingBlockResponse {
     // Parse the waypoints
-    val waypoints = ArrayList<Collection<PathfindingEdgeLocationId<Block>>>()
+    val waypoints = ArrayList<Collection<EdgeLocation<BlockId, Block>>>()
     for (step in request.pathItems) {
-        val allStarts = HashSet<PathfindingEdgeLocationId<Block>>()
+        val allStarts = HashSet<EdgeLocation<BlockId, Block>>()
         for (direction in Direction.entries) {
             for (waypoint in step) allStarts.addAll(findWaypointBlocks(infra, waypoint, direction))
         }
@@ -127,12 +129,12 @@ fun runPathfinding(infra: FullInfra, request: PathfindingBlockRequest): Pathfind
 @Throws(OSRDError::class)
 private fun computePaths(
     infra: FullInfra,
-    waypoints: ArrayList<Collection<PathfindingEdgeLocationId<Block>>>,
+    waypoints: ArrayList<Collection<EdgeLocation<BlockId, Block>>>,
     constraints: List<PathfindingConstraint<Block>>,
     remainingDistanceEstimators: List<AStarHeuristic<PathfindingEdge, Block>>,
     initialRequest: PathfindingBlockRequest,
     timeout: Double?,
-): PathfindingResultId<Block> {
+): Pathfinding.Result<BlockId, Block> {
     val start = Instant.now()
     val mrspBuilder =
         CachedBlockMRSPBuilder(
@@ -147,7 +149,7 @@ private fun computePaths(
     val pathFound =
         Pathfinding(PathfindingGraph())
             .setTimeout(timeout)
-            .setEdgeToLength { Offset(it.length.distance) }
+            .setEdgeToLength { it.length }
             .setRangeCost { getRangeCost(it, mrspBuilder, infra) }
             .setRemainingDistanceEstimator(remainingDistanceEstimators)
             .setComparisonFallback { a, b -> a.block.index.compareTo(b.block.index) }
@@ -187,7 +189,7 @@ private fun computePaths(
  * Return true if the path contains a duplicated track. This kind of path is not supported by OSRD
  * yet.
  */
-fun hasDuplicateTracks(infra: FullInfra, path: PathfindingResultId<Block>): Boolean {
+fun hasDuplicateTracks(infra: FullInfra, path: Pathfinding.Result<BlockId, Block>): Boolean {
     val seenTracks = mutableSetOf<TrackSectionId>()
     var lastTrack: TrackSectionId? = null
     for (blockRange in path.ranges) {
@@ -231,7 +233,7 @@ private fun getRangeCost(
 private fun getStartLocations(
     rawInfra: RawSignalingInfra,
     blockInfra: BlockInfra,
-    waypoints: ArrayList<Collection<PathfindingEdgeLocationId<Block>>>,
+    waypoints: ArrayList<Collection<EdgeLocation<BlockId, Block>>>,
     constraints: List<PathfindingConstraint<Block>>,
 ): Collection<EdgeLocation<PathfindingEdge, Block>> {
     val res = mutableListOf<EdgeLocation<PathfindingEdge, Block>>()
@@ -256,7 +258,7 @@ private fun getStartLocations(
 }
 
 private fun getTargetsOnEdges(
-    waypoints: ArrayList<Collection<PathfindingEdgeLocationId<Block>>>
+    waypoints: ArrayList<Collection<EdgeLocation<BlockId, Block>>>
 ): List<TargetsOnEdge<PathfindingEdge, Block>> {
     val targetsOnEdges = ArrayList<TargetsOnEdge<PathfindingEdge, Block>>()
     for (i in 1 until waypoints.size) {
@@ -274,7 +276,7 @@ private fun getTargetsOnEdges(
 @WithSpan(value = "Identifying why no path was found")
 private fun throwNoPathFoundException(
     infra: FullInfra,
-    waypoints: ArrayList<Collection<PathfindingEdgeLocationId<Block>>>,
+    waypoints: ArrayList<Collection<EdgeLocation<BlockId, Block>>>,
     constraints: Collection<PathfindingConstraint<Block>>,
     mrspBuilder: CachedBlockMRSPBuilder,
     remainingDistanceEstimators: List<AStarHeuristic<PathfindingEdge, Block>>,
@@ -285,7 +287,7 @@ private fun throwNoPathFoundException(
         val possiblePathWithoutErrorNoConstraints =
             Pathfinding(PathfindingGraph())
                 .setTimeout(timeout)
-                .setEdgeToLength { edge -> Offset(edge.length.distance) }
+                .setEdgeToLength { it.length }
                 .setRangeCost { range ->
                     mrspBuilder.getBlockTime(range.edge.block, Offset(range.end.distance)) -
                         mrspBuilder.getBlockTime(range.edge.block, Offset(range.start.distance))
@@ -317,7 +319,7 @@ private fun throwNoPathFoundException(
 
 private fun makeBlockPath(
     path: Pathfinding.Result<PathfindingEdge, Block>?
-): PathfindingResultId<Block>? {
+): Pathfinding.Result<BlockId, Block>? {
     if (path == null) return null
     return Pathfinding.Result(
         path.ranges.map { EdgeRange(it.edge.block, it.start, it.end) },
@@ -336,8 +338,8 @@ fun findWaypointBlocks(
     infra: FullInfra,
     waypoint: TrackLocation,
     direction: Direction,
-): Set<PathfindingEdgeLocationId<Block>> {
-    val res = HashSet<PathfindingEdgeLocationId<Block>>()
+): Set<EdgeLocation<BlockId, Block>> {
+    val res = HashSet<EdgeLocation<BlockId, Block>>()
     val trackSectionId =
         infra.rawInfra.getTrackSectionFromName(waypoint.track)
             ?: throw OSRDError.newUnknownTrackSectionError(waypoint.track)
@@ -414,7 +416,7 @@ private fun getBlockOffset(
 @WithSpan(value = "Building heuristic")
 private fun makeHeuristicsForPathfindingEdges(
     infra: FullInfra,
-    waypoints: List<Collection<PathfindingEdgeLocationId<Block>>>,
+    waypoints: List<Collection<EdgeLocation<BlockId, Block>>>,
     rollingStockMaxSpeed: Double,
 ): ArrayList<AStarHeuristic<PathfindingEdge, Block>> {
     // Compute the minimum distance between steps

--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingPostProcessing.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingPostProcessing.kt
@@ -11,9 +11,8 @@ import fr.sncf.osrd.path.interfaces.TravelledPath
 import fr.sncf.osrd.path.interfaces.getLegacyBlockPath
 import fr.sncf.osrd.path.interfaces.toJsonTrainPath
 import fr.sncf.osrd.pathfinding.Pathfinding
-import fr.sncf.osrd.pathfinding.PathfindingEdgeLocationId
-import fr.sncf.osrd.pathfinding.PathfindingEdgeRangeId
-import fr.sncf.osrd.pathfinding.PathfindingResultId
+import fr.sncf.osrd.pathfinding.Pathfinding.EdgeLocation
+import fr.sncf.osrd.pathfinding.Pathfinding.EdgeRange
 import fr.sncf.osrd.railjson.schema.common.graph.EdgeDirection
 import fr.sncf.osrd.railjson.schema.infra.RJSRoutePath
 import fr.sncf.osrd.railjson.schema.infra.trackranges.RJSDirectionalTrackRange
@@ -25,7 +24,6 @@ import fr.sncf.osrd.sim_infra.utils.chunksToRoutes
 import fr.sncf.osrd.utils.Direction
 import fr.sncf.osrd.utils.getBlockChunkOffset
 import fr.sncf.osrd.utils.getRouteChunkOffset
-import fr.sncf.osrd.utils.indexing.StaticIdx
 import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.Offset.Companion.max
@@ -37,7 +35,7 @@ import kotlin.math.abs
 fun runPathfindingPostProcessing(
     infra: FullInfra,
     initialRequest: PathfindingBlockRequest,
-    rawPath: PathfindingResultId<Block>,
+    rawPath: Pathfinding.Result<BlockId, Block>,
 ): PathfindingBlockSuccess {
     val res = runPathfindingBlockPostProcessing(infra, rawPath)
     validatePathfindingResponse(infra, initialRequest, res)
@@ -46,7 +44,7 @@ fun runPathfindingPostProcessing(
 
 fun runPathfindingBlockPostProcessing(
     infra: FullInfra,
-    rawPath: PathfindingResultId<Block>,
+    rawPath: Pathfinding.Result<BlockId, Block>,
 ): PathfindingBlockSuccess {
     // TODO: access a `TrainPath` directly from the pathfinding result.
     // We'd get more accurate routes in the (unlikely) case of ambiguity,
@@ -105,10 +103,8 @@ private fun validatePathfindingResponse(
         throw OSRDError(ErrorType.PathHasInvalidItemPositions)
 }
 
-fun makePathItemPositions(
-    path: Pathfinding.Result<StaticIdx<Block>, Block>
-): List<Offset<TravelledPath>> {
-    val pathItemLocations = mutableMapOf<BlockId, MutableList<PathfindingEdgeLocationId<Block>>>()
+fun makePathItemPositions(path: Pathfinding.Result<BlockId, Block>): List<Offset<TravelledPath>> {
+    val pathItemLocations = mutableMapOf<BlockId, MutableList<EdgeLocation<BlockId, Block>>>()
     for (waypoint in path.waypoints) {
         val edgeWaypoints = pathItemLocations.computeIfAbsent(waypoint.edge) { mutableListOf() }
         edgeWaypoints.add(waypoint)
@@ -124,9 +120,7 @@ fun makePathItemPositions(
     return res
 }
 
-private fun makeBlocks(
-    ranges: List<Pathfinding.EdgeRange<StaticIdx<Block>, Block>>
-): List<BlockRange> {
+private fun makeBlocks(ranges: List<EdgeRange<BlockId, Block>>): List<BlockRange> {
     val blockRanges = mutableListOf<PartialBlockRange>()
     for ((blockId, start, end) in ranges) {
         val lastAddedRange = blockRanges.lastOrNull()
@@ -144,7 +138,7 @@ private fun makeBlocks(
 private fun makeRoutePath(
     blockInfra: BlockInfra,
     rawInfra: RawSignalingInfra,
-    ranges: List<PathfindingEdgeRangeId<Block>>,
+    ranges: List<EdgeRange<BlockId, Block>>,
 ): List<RJSRoutePath> {
     val blocks = ranges.stream().map { x -> x.edge }.toList()
     val chunkPath = blockInfra.chunksOnBlocks(blocks)
@@ -268,7 +262,7 @@ private fun findStartOffset(
     rawInfra: RawSignalingInfra,
     firstChunk: DirTrackChunkId,
     routeStaticIdx: RouteId,
-    range: PathfindingEdgeRangeId<Block>,
+    range: EdgeRange<BlockId, Block>,
 ): Offset<Route> {
     return getRouteChunkOffset(rawInfra, routeStaticIdx, firstChunk) -
         getBlockChunkOffset(blockInfra, rawInfra, firstChunk, range).distance + range.start.distance
@@ -280,7 +274,7 @@ private fun findEndOffset(
     rawInfra: RawSignalingInfra,
     lastChunk: DirTrackChunkId,
     routeStaticIdx: RouteId,
-    range: PathfindingEdgeRangeId<Block>,
+    range: EdgeRange<BlockId, Block>,
 ): Offset<Route> {
     return getRouteChunkOffset(rawInfra, routeStaticIdx, lastChunk) -
         getBlockChunkOffset(blockInfra, rawInfra, lastChunk, range).distance + range.end.distance

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
@@ -14,7 +14,7 @@ import fr.sncf.osrd.envelope_sim.allowances.AllowanceValue.Percentage
 import fr.sncf.osrd.envelope_sim.allowances.AllowanceValue.TimePerDistance
 import fr.sncf.osrd.envelope_sim_infra.computeMRSP
 import fr.sncf.osrd.pathfinding.Pathfinding
-import fr.sncf.osrd.pathfinding.PathfindingEdgeLocationId
+import fr.sncf.osrd.pathfinding.Pathfinding.EdgeLocation
 import fr.sncf.osrd.railjson.schema.common.graph.EdgeDirection
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
 import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop
@@ -22,6 +22,7 @@ import fr.sncf.osrd.reporting.exceptions.ErrorType
 import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.signaling.etcs_level2.ETCS_LEVEL2
 import fr.sncf.osrd.sim_infra.api.Block
+import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.sim_infra.api.DirTrackChunkId
 import fr.sncf.osrd.sim_infra.api.SpeedLimitProperty
 import fr.sncf.osrd.sim_infra.api.ZoneId
@@ -414,8 +415,8 @@ private fun parseSimulationScheduleItems(
 private fun findWaypointBlocks(
     infra: FullInfra,
     waypoints: Collection<TrackLocation>,
-): Set<PathfindingEdgeLocationId<Block>> {
-    val waypointBlocks = HashSet<PathfindingEdgeLocationId<Block>>()
+): Set<EdgeLocation<BlockId, Block>> {
+    val waypointBlocks = HashSet<EdgeLocation<BlockId, Block>>()
     for (waypoint in waypoints) {
         for (direction in Direction.entries) {
             waypointBlocks.addAll(findWaypointBlocks(infra, waypoint, direction))

--- a/core/src/main/kotlin/fr/sncf/osrd/graph/Interfaces.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/graph/Interfaces.kt
@@ -36,6 +36,4 @@ fun interface TargetsOnEdge<EdgeT, OffsetType> {
 }
 
 // Type aliases to avoid repeating `StaticIdx<T>, T` when edge types are static idx
-typealias AStarHeuristicId<T> = AStarHeuristic<StaticIdx<T>, T>
-
 typealias PathfindingConstraint<T> = EdgeToRanges<StaticIdx<T>, T>

--- a/core/src/main/kotlin/fr/sncf/osrd/graph/Interfaces.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/graph/Interfaces.kt
@@ -1,6 +1,7 @@
 package fr.sncf.osrd.graph
 
 import fr.sncf.osrd.pathfinding.Pathfinding
+import fr.sncf.osrd.pathfinding.Pathfinding.EdgeLocation
 import fr.sncf.osrd.utils.indexing.StaticIdx
 import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
@@ -32,7 +33,7 @@ fun interface EdgeToRanges<EdgeT, OffsetType> {
  * edge
  */
 fun interface TargetsOnEdge<EdgeT, OffsetType> {
-    fun apply(edge: EdgeT): Collection<Pathfinding.EdgeLocation<EdgeT, OffsetType>>
+    fun apply(edge: EdgeT): Collection<EdgeLocation<EdgeT, OffsetType>>
 }
 
 // Type aliases to avoid repeating `StaticIdx<T>, T` when edge types are static idx

--- a/core/src/main/kotlin/fr/sncf/osrd/pathfinding/Pathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/pathfinding/Pathfinding.kt
@@ -155,14 +155,6 @@ class Pathfinding<NodeT : Any, EdgeT : Any, OffsetType>(
         return this
     }
 
-    /** Sets the functor used to determine which ranges are blocked on an edge */
-    fun addBlockedRangeOnEdges(
-        f: Collection<EdgeToRanges<EdgeT, OffsetType>>
-    ): Pathfinding<NodeT, EdgeT, OffsetType> {
-        blockedRangesOnEdge.functions.addAll(f)
-        return this
-    }
-
     /** Sets the pathfinding's timeout */
     fun setTimeout(timeout: Double?): Pathfinding<NodeT, EdgeT, OffsetType> {
         if (timeout != null) this.timeout = timeout

--- a/core/src/main/kotlin/fr/sncf/osrd/pathfinding/Pathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/pathfinding/Pathfinding.kt
@@ -6,7 +6,6 @@ import fr.sncf.osrd.graph.*
 import fr.sncf.osrd.pathfinding.constraints.ConstraintCombiner
 import fr.sncf.osrd.reporting.exceptions.ErrorType
 import fr.sncf.osrd.reporting.exceptions.OSRDError
-import fr.sncf.osrd.utils.indexing.StaticIdx
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import io.opentelemetry.api.trace.SpanKind
@@ -393,10 +392,3 @@ class Pathfinding<NodeT : Any, EdgeT : Any, OffsetType>(
         const val TIMEOUT = 180.0
     }
 }
-
-// Type aliases to avoid repeating `StaticIdx<T>, T` when edge types are static idx
-typealias PathfindingResultId<T> = Pathfinding.Result<StaticIdx<T>, T>
-
-typealias PathfindingEdgeLocationId<T> = Pathfinding.EdgeLocation<StaticIdx<T>, T>
-
-typealias PathfindingEdgeRangeId<T> = Pathfinding.EdgeRange<StaticIdx<T>, T>

--- a/core/src/main/kotlin/fr/sncf/osrd/pathfinding/RemainingDistanceEstimator.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/pathfinding/RemainingDistanceEstimator.kt
@@ -1,6 +1,7 @@
 package fr.sncf.osrd.pathfinding
 
 import fr.sncf.osrd.geom.Point
+import fr.sncf.osrd.pathfinding.Pathfinding.EdgeLocation
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.sim_infra.api.BlockInfra
@@ -18,7 +19,7 @@ import kotlin.math.min
 class RemainingDistanceEstimator(
     private val blockInfra: BlockInfra,
     private val rawInfra: RawSignalingInfra,
-    edgeLocations: Collection<PathfindingEdgeLocationId<Block>>,
+    edgeLocations: Collection<EdgeLocation<BlockId, Block>>,
     private val remainingDistance: Distance,
 ) {
     private val targets: MutableCollection<Point> = ArrayList()
@@ -54,8 +55,8 @@ class RemainingDistanceEstimator(
 fun minDistanceBetweenSteps(
     blockInfra: BlockInfra,
     rawInfra: RawSignalingInfra,
-    step1: Collection<PathfindingEdgeLocationId<Block>>,
-    step2: Collection<PathfindingEdgeLocationId<Block>>,
+    step1: Collection<EdgeLocation<BlockId, Block>>,
+    step2: Collection<EdgeLocation<BlockId, Block>>,
 ): Distance {
     val step1Points = step1.map { blockOffsetToPoint(blockInfra, rawInfra, it.edge, it.offset) }
     val step2Points = step2.map { blockOffsetToPoint(blockInfra, rawInfra, it.edge, it.offset) }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMResult.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMResult.kt
@@ -3,8 +3,9 @@ package fr.sncf.osrd.stdcm
 import fr.sncf.osrd.envelope.Envelope
 import fr.sncf.osrd.path.implementations.ChunkPath
 import fr.sncf.osrd.path.interfaces.TrainPath
-import fr.sncf.osrd.pathfinding.PathfindingResultId
+import fr.sncf.osrd.pathfinding.Pathfinding
 import fr.sncf.osrd.sim_infra.api.Block
+import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.sim_infra.api.RouteId
 import fr.sncf.osrd.train.TrainStop
 
@@ -13,7 +14,7 @@ import fr.sncf.osrd.train.TrainStop
  * well as different representations of the same data that can be reused in later steps.
  */
 data class STDCMResult(
-    val blocks: PathfindingResultId<Block>,
+    val blocks: Pathfinding.Result<BlockId, Block>,
     val envelope: Envelope,
     val trainPath: TrainPath,
     val chunkPath: ChunkPath,

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMStep.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMStep.kt
@@ -1,13 +1,14 @@
 package fr.sncf.osrd.stdcm
 
-import fr.sncf.osrd.pathfinding.PathfindingEdgeLocationId
+import fr.sncf.osrd.pathfinding.Pathfinding.EdgeLocation
 import fr.sncf.osrd.sim_infra.api.Block
+import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.utils.units.Duration
 import fr.sncf.osrd.utils.units.TimeDelta
 import kotlin.math.abs
 
 data class STDCMStep(
-    val locations: Collection<PathfindingEdgeLocationId<Block>>,
+    val locations: Collection<EdgeLocation<BlockId, Block>>,
     val duration: Double? = null,
     val stop: Boolean = false,
     val plannedTimingData: PlannedTimingData? = null,

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
@@ -158,7 +158,7 @@ class STDCMPostProcessing(private val graph: STDCMGraph) {
             return timeData
         }
         // Either departure or arrival
-        val plannedNodeIndex = maybeIndex!!
+        val plannedNodeIndex = maybeIndex
         val plannedNode = nodes[plannedNodeIndex]
 
         // Figure out how much time we'd like to add

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
@@ -12,8 +12,6 @@ import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.pathfinding.Pathfinding
 import fr.sncf.osrd.pathfinding.Pathfinding.EdgeLocation
 import fr.sncf.osrd.pathfinding.Pathfinding.EdgeRange
-import fr.sncf.osrd.pathfinding.PathfindingEdgeLocationId
-import fr.sncf.osrd.pathfinding.PathfindingEdgeRangeId
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
 import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal.OPEN
 import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal.SHORT_SLIP_STOP
@@ -131,8 +129,8 @@ class STDCMPostProcessing(private val graph: STDCMGraph) {
     }
 
     /** Creates the list of waypoints on the path */
-    private fun makeBlockWaypoints(path: Result): List<PathfindingEdgeLocationId<Block>> {
-        val res = ArrayList<PathfindingEdgeLocationId<Block>>()
+    private fun makeBlockWaypoints(path: Result): List<EdgeLocation<BlockId, Block>> {
+        val res = ArrayList<EdgeLocation<BlockId, Block>>()
         for (waypoint in path.waypoints) {
             val blockOffset = waypoint.edge.blockOffsetFromEdge(waypoint.offset)
             res.add(EdgeLocation(waypoint.edge.block, blockOffset))
@@ -240,8 +238,8 @@ class STDCMPostProcessing(private val graph: STDCMGraph) {
     }
 
     /** Builds the list of block ranges, merging the ranges on the same block */
-    private fun makeBlockRanges(edges: List<STDCMEdge>): List<PathfindingEdgeRangeId<Block>> {
-        val res = ArrayList<PathfindingEdgeRangeId<Block>>()
+    private fun makeBlockRanges(edges: List<STDCMEdge>): List<EdgeRange<BlockId, Block>> {
+        val res = ArrayList<EdgeRange<BlockId, Block>>()
         var i = 0
         while (i < edges.size) {
             val edge = edges[i]

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
@@ -9,7 +9,7 @@ import fr.sncf.osrd.graph.PathfindingConstraint
 import fr.sncf.osrd.path.implementations.buildTrainPathFromBlock
 import fr.sncf.osrd.path.interfaces.BlockPath
 import fr.sncf.osrd.path.interfaces.TrainPath
-import fr.sncf.osrd.pathfinding.PathfindingEdgeLocationId
+import fr.sncf.osrd.pathfinding.Pathfinding.EdgeLocation
 import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal.SHORT_SLIP_STOP
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.sim_infra.utils.getRouteBlocks
@@ -123,7 +123,7 @@ interface EdgeIdentifier {
 fun initInfraExplorer(
     rawInfra: RawInfra,
     blockInfra: BlockInfra,
-    location: PathfindingEdgeLocationId<Block>,
+    location: EdgeLocation<BlockId, Block>,
     steps: List<STDCMStep> = listOf(),
     constraints: List<PathfindingConstraint<Block>> = listOf(),
 ): Collection<InfraExplorer> {
@@ -280,7 +280,7 @@ private class InfraExplorerImpl(
      * Otherwise, it returns false and the instance is supposed to be dropped. `blockRoutes` is
      * updated to keep track of the route used for each block.
      */
-    fun extend(route: RouteId, firstLocation: PathfindingEdgeLocationId<Block>? = null): Boolean {
+    fun extend(route: RouteId, firstLocation: EdgeLocation<BlockId, Block>? = null): Boolean {
         val routeBlocks = blockInfra.getRouteBlocks(rawInfra, route)
         var seenFirstBlock = firstLocation == null
         var nBlocksToSkip = 0

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
@@ -94,7 +94,7 @@ interface InfraExplorer {
     /** Returns a copy of the current instance. */
     fun clone(): InfraExplorer
 
-    /** Returns the list of routes that are the current exploration follows. */
+    /** Returns the list of routes that the current exploration follows. */
     fun getExploredRoutes(): List<RouteId>
 
     /** Returns the step tracker, giving data about the steps on the path (including lookahead) */
@@ -347,7 +347,7 @@ private class InfraExplorerImpl(
         for (block in addedBlocks) {
             blockRoutes[block] = route
         }
-        for (i in 0..<nBlocksToSkip) moveForward()
+        repeat(nBlocksToSkip) { moveForward() }
         for (pathFragment in pathFragments) incrementalPath.extend(pathFragment)
 
         return true

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelope.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelope.kt
@@ -10,8 +10,9 @@ import fr.sncf.osrd.envelope_sim.PhysicsRollingStock
 import fr.sncf.osrd.graph.PathfindingConstraint
 import fr.sncf.osrd.path.interfaces.BlockPath
 import fr.sncf.osrd.path.interfaces.TravelledPath
-import fr.sncf.osrd.pathfinding.PathfindingEdgeLocationId
+import fr.sncf.osrd.pathfinding.Pathfinding.EdgeLocation
 import fr.sncf.osrd.sim_infra.api.Block
+import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.stdcm.STDCMStep
 import fr.sncf.osrd.stdcm.graph.TimeData
 import fr.sncf.osrd.train.TrainStop
@@ -92,7 +93,7 @@ interface InfraExplorerWithEnvelope : InfraExplorer {
 /** Init all InfraExplorersWithEnvelope starting at the given location. */
 fun initInfraExplorerWithEnvelope(
     fullInfra: FullInfra,
-    location: PathfindingEdgeLocationId<Block>,
+    location: EdgeLocation<BlockId, Block>,
     rollingStock: PhysicsRollingStock,
     steps: List<STDCMStep> = listOf(),
     constraints: List<PathfindingConstraint<Block>> = listOf(),

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/StepTracker.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/StepTracker.kt
@@ -1,7 +1,7 @@
 package fr.sncf.osrd.stdcm.infra_exploration
 
 import fr.sncf.osrd.path.interfaces.TravelledPath
-import fr.sncf.osrd.pathfinding.PathfindingEdgeLocationId
+import fr.sncf.osrd.pathfinding.Pathfinding.EdgeLocation
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.stdcm.STDCMStep
@@ -111,7 +111,7 @@ class StepTracker(private val inputSteps: List<STDCMStep>) {
 
 data class LocatedStep(
     val travelledPathOffset: Offset<TravelledPath>,
-    val location: PathfindingEdgeLocationId<Block>,
+    val location: EdgeLocation<BlockId, Block>,
     val originalStep: STDCMStep,
     val isPlanned: Boolean = true, // Set to false for overtakes (when implemented)
 ) {

--- a/core/src/main/kotlin/fr/sncf/osrd/utils/OffsetConversions.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/utils/OffsetConversions.kt
@@ -2,7 +2,7 @@ package fr.sncf.osrd.utils
 
 import fr.sncf.osrd.path.implementations.ChunkPath
 import fr.sncf.osrd.path.interfaces.BlockPath
-import fr.sncf.osrd.pathfinding.PathfindingEdgeRangeId
+import fr.sncf.osrd.pathfinding.Pathfinding.EdgeRange
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
@@ -69,7 +69,7 @@ fun getBlockChunkOffset(
     blockInfra: BlockInfra,
     rawInfra: RawSignalingInfra,
     chunk: DirTrackChunkId,
-    range: PathfindingEdgeRangeId<Block>,
+    range: EdgeRange<BlockId, Block>,
 ): Offset<Block> {
     var offset = Offset<Block>(0.meters)
     for (dirChunkId in blockInfra.getTrackChunksFromBlock(range.edge)) {

--- a/core/src/test/java/fr/sncf/osrd/utils/graph/AStarTests.kt
+++ b/core/src/test/java/fr/sncf/osrd/utils/graph/AStarTests.kt
@@ -122,7 +122,7 @@ class AStarTests {
                     }
                 )
             )
-            .runPathfinding(listOf<Set<PathfindingEdgeLocationId<Block>>>(origin, destination))
+            .runPathfinding(listOf(origin, destination))
         Pathfinding(GraphAdapter(fullDummyInfra.blockInfra, fullDummyInfra.rawInfra))
             .setEdgeToLength { blockId -> fullDummyInfra.blockInfra.getBlockLength(blockId) }
             .setRemainingDistanceEstimator(
@@ -133,7 +133,7 @@ class AStarTests {
                     }
                 )
             )
-            .runPathfinding(listOf<Set<PathfindingEdgeLocationId<Block>>>(origin, destination))
+            .runPathfinding(listOf(origin, destination))
         Assertions.assertTrue(seenWithHeuristic.size < seenWithoutHeuristic.size)
     }
 }

--- a/core/src/test/java/fr/sncf/osrd/utils/graph/AStarTests.kt
+++ b/core/src/test/java/fr/sncf/osrd/utils/graph/AStarTests.kt
@@ -4,7 +4,7 @@ import fr.sncf.osrd.geom.Point
 import fr.sncf.osrd.graph.AStarHeuristic
 import fr.sncf.osrd.graph.GraphAdapter
 import fr.sncf.osrd.pathfinding.Pathfinding
-import fr.sncf.osrd.pathfinding.PathfindingEdgeLocationId
+import fr.sncf.osrd.pathfinding.Pathfinding.EdgeLocation
 import fr.sncf.osrd.pathfinding.RemainingDistanceEstimator
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockId
@@ -93,8 +93,8 @@ class AStarTests {
 
         // ---------- ----------- ----------
 
-        val origin = mutableSetOf(PathfindingEdgeLocationId(startBlock, Offset(0.meters)))
-        val destination = mutableSetOf(PathfindingEdgeLocationId(endBlock, Offset(100.meters)))
+        val origin = mutableSetOf(EdgeLocation(startBlock, Offset<Block>(0.meters)))
+        val destination = mutableSetOf(EdgeLocation(endBlock, Offset<Block>(100.meters)))
 
         val remainingDistanceEstimator =
             RemainingDistanceEstimator(

--- a/core/src/test/java/fr/sncf/osrd/utils/graph/PathfindingTests.kt
+++ b/core/src/test/java/fr/sncf/osrd/utils/graph/PathfindingTests.kt
@@ -6,6 +6,7 @@ import fr.sncf.osrd.graph.GraphAdapter
 import fr.sncf.osrd.graph.NetworkGraphAdapter
 import fr.sncf.osrd.pathfinding.Pathfinding
 import fr.sncf.osrd.pathfinding.Pathfinding.EdgeLocation
+import fr.sncf.osrd.pathfinding.Pathfinding.Result
 import fr.sncf.osrd.reporting.exceptions.ErrorType
 import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.utils.CachedBlockMRSPBuilder
@@ -93,7 +94,7 @@ class PathfindingTests {
         val g = builder.build()
         val res =
             Pathfinding(g)
-                .setEdgeToLength { edge -> edge.length }
+                .setEdgeToLength { it.length }
                 .runPathfindingEdgesOnly(
                     listOf(
                         listOf(builder.getEdgeLocation("0-1")),
@@ -122,7 +123,7 @@ class PathfindingTests {
         val g = builder.build()
         val res =
             Pathfinding(g)
-                .setEdgeToLength { edge -> edge.length }
+                .setEdgeToLength { it.length }
                 .runPathfindingEdgesOnly(
                     listOf(
                         listOf(builder.getEdgeLocation("0-1")),
@@ -143,7 +144,7 @@ class PathfindingTests {
         val g = builder.build()
         val res =
             Pathfinding(g)
-                .setEdgeToLength { edge -> edge.length }
+                .setEdgeToLength { it.length }
                 .runPathfindingEdgesOnly(
                     listOf(
                         listOf(builder.getEdgeLocation("0-1", 10.meters)),
@@ -177,7 +178,7 @@ class PathfindingTests {
         val g = builder.build()
         val res =
             Pathfinding(g)
-                .setEdgeToLength { edge -> edge.length }
+                .setEdgeToLength { it.length }
                 .runPathfindingEdgesOnly(
                     listOf(
                         listOf(builder.getEdgeLocation("0-1"), builder.getEdgeLocation("2-3")),
@@ -208,7 +209,7 @@ class PathfindingTests {
         val g = builder.build()
         val res =
             Pathfinding(g)
-                .setEdgeToLength { edge -> edge.length }
+                .setEdgeToLength { it.length }
                 .runPathfindingEdgesOnly(
                     listOf(
                         listOf(builder.getEdgeLocation("0-1")),
@@ -236,7 +237,7 @@ class PathfindingTests {
         val g = builder.build()
         val res =
             Pathfinding(g)
-                .setEdgeToLength { edge -> edge.length }
+                .setEdgeToLength { it.length }
                 .runPathfindingEdgesOnly(
                     listOf(
                         listOf(builder.getEdgeLocation("0-1")),
@@ -261,7 +262,7 @@ class PathfindingTests {
         val g = builder.build()
         val res =
             Pathfinding(g)
-                .setEdgeToLength { edge -> edge.length }
+                .setEdgeToLength { it.length }
                 .runPathfindingEdgesOnly(
                     listOf(
                         listOf(builder.getEdgeLocation("2-3")),
@@ -285,7 +286,7 @@ class PathfindingTests {
         val g = builder.build()
         val res =
             Pathfinding(g)
-                .setEdgeToLength { edge -> edge.length }
+                .setEdgeToLength { it.length }
                 .runPathfindingEdgesOnly(
                     listOf(
                         listOf(builder.getEdgeLocation("0-1")),
@@ -308,7 +309,7 @@ class PathfindingTests {
         val g = builder.build()
         val res =
             Pathfinding(g)
-                .setEdgeToLength { edge -> edge.length }
+                .setEdgeToLength { it.length }
                 .runPathfindingEdgesOnly(
                     listOf(
                         listOf(builder.getEdgeLocation("0-1", 60.meters)),
@@ -331,7 +332,7 @@ class PathfindingTests {
         val g = builder.build()
         val res =
             Pathfinding(g)
-                .setEdgeToLength { edge -> edge.length }
+                .setEdgeToLength { it.length }
                 .runPathfindingEdgesOnly(
                     listOf(
                         listOf(builder.getEdgeLocation("0-1", 10.meters)),
@@ -359,7 +360,7 @@ class PathfindingTests {
         val g = builder.build()
         val res =
             Pathfinding(g)
-                .setEdgeToLength { edge -> edge.length }
+                .setEdgeToLength { it.length }
                 .runPathfindingEdgesOnly(
                     listOf(
                         listOf(builder.getEdgeLocation("0-1", 60.meters)),
@@ -389,7 +390,7 @@ class PathfindingTests {
         val g = builder.build()
         val res =
             Pathfinding(g)
-                .setEdgeToLength { edge -> edge.length }
+                .setEdgeToLength { it.length }
                 .runPathfinding(
                     listOf(
                         listOf(builder.getEdgeLocation("0-1")),
@@ -429,7 +430,7 @@ class PathfindingTests {
         val g = builder.build()
         val res =
             Pathfinding(g)
-                .setEdgeToLength { edge -> edge.length }
+                .setEdgeToLength { it.length }
                 .runPathfinding(
                     listOf(
                         listOf(builder.getEdgeLocation("0-1", 5.meters)),
@@ -475,7 +476,7 @@ class PathfindingTests {
         val g = builder.build()
         val res =
             Pathfinding(g)
-                .setEdgeToLength { edge -> edge.length }
+                .setEdgeToLength { it.length }
                 .addBlockedRangeOnEdges { edge -> edge.blockedRanges }
                 .runPathfindingEdgesOnly(
                     listOf(
@@ -504,7 +505,7 @@ class PathfindingTests {
         val g = builder.build()
         val res =
             Pathfinding(g)
-                .setEdgeToLength { edge -> edge.length }
+                .setEdgeToLength { it.length }
                 .addBlockedRangeOnEdges { edge -> edge.blockedRanges }
                 .runPathfindingEdgesOnly(
                     listOf(
@@ -535,7 +536,7 @@ class PathfindingTests {
         val g = builder.build()
         val res =
             Pathfinding(g)
-                .setEdgeToLength { edge -> edge.length }
+                .setEdgeToLength { it.length }
                 .addBlockedRangeOnEdges { edge -> edge.blockedRanges }
                 .runPathfindingEdgesOnly(
                     listOf(
@@ -564,7 +565,7 @@ class PathfindingTests {
         val g = builder.build()
         val res =
             Pathfinding(g)
-                .setEdgeToLength { edge -> edge.length }
+                .setEdgeToLength { it.length }
                 .addBlockedRangeOnEdges { edge -> edge.blockedRanges }
                 .runPathfindingEdgesOnly(
                     listOf(
@@ -593,7 +594,7 @@ class PathfindingTests {
         val g = builder.build()
         val res =
             Pathfinding(g)
-                .setEdgeToLength { edge -> edge.length }
+                .setEdgeToLength { it.length }
                 .addBlockedRangeOnEdges { edge -> edge.blockedRanges }
                 .runPathfindingEdgesOnly(
                     listOf(
@@ -621,7 +622,7 @@ class PathfindingTests {
         val g = builder.build()
         val res =
             Pathfinding(g)
-                .setEdgeToLength { edge -> edge.length }
+                .setEdgeToLength { it.length }
                 .addBlockedRangeOnEdges { edge -> edge.blockedRanges }
                 .runPathfindingEdgesOnly(
                     listOf(
@@ -657,7 +658,7 @@ class PathfindingTests {
         val g = builder.build()
         val res =
             Pathfinding(g)
-                .setEdgeToLength { edge -> edge.length }
+                .setEdgeToLength { it.length }
                 .addBlockedRangeOnEdges { edge -> edge.blockedRanges }
                 .runPathfindingEdgesOnly(
                     listOf(
@@ -684,7 +685,7 @@ class PathfindingTests {
         val g = builder.build()
         val res =
             Pathfinding(g)
-                .setEdgeToLength { edge -> edge.length }
+                .setEdgeToLength { it.length }
                 .runPathfindingEdgesOnly(
                     listOf(
                         listOf(
@@ -709,7 +710,7 @@ class PathfindingTests {
         builder.makeEdge(0, 1, 100.meters)
         val g = builder.build()
         val pathfinding =
-            Pathfinding(g).setEdgeToLength { edge -> edge.length }.setTimeout(timeout?.toDouble())
+            Pathfinding(g).setEdgeToLength { it.length }.setTimeout(timeout?.toDouble())
         if (!timesOut) {
             val res =
                 pathfinding.runPathfindingEdgesOnly(listOf(listOf(builder.getEdgeLocation("0-1"))))
@@ -771,7 +772,7 @@ class PathfindingTests {
     }
 
     companion object {
-        private fun convertRes(res: Pathfinding.Result<Edge, Edge>): List<SimpleRange> {
+        private fun convertRes(res: Result<Edge, Edge>): List<SimpleRange> {
             return res.ranges
                 .stream()
                 .map { x -> SimpleRange(x.edge.label, x.start, x.end) }

--- a/core/src/test/java/fr/sncf/osrd/utils/graph/PathfindingTests.kt
+++ b/core/src/test/java/fr/sncf/osrd/utils/graph/PathfindingTests.kt
@@ -44,7 +44,7 @@ class PathfindingTests {
         }
 
         fun makeNodes(n: Int) {
-            for (i in 0 until n) makeNode()
+            repeat(n) { makeNode() }
         }
 
         fun makeEdge(

--- a/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingBlocksEndpointTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingBlocksEndpointTest.kt
@@ -29,7 +29,7 @@ class PathfindingBlocksEndpointTest {
     fun testFindWaypointBlocks(
         pathfindingWaypoint: TrackLocation,
         direction: Direction,
-        expectedEdgeLocations: Set<PathfindingEdgeLocationId<Block>>,
+        expectedEdgeLocations: Set<EdgeLocation<BlockId, Block>>,
     ) {
         val blocks = findWaypointBlocks(smallInfra, pathfindingWaypoint, direction)
         Assertions.assertThat(blocks).containsExactlyInAnyOrderElementsOf(expectedEdgeLocations)
@@ -59,7 +59,7 @@ class PathfindingBlocksEndpointTest {
                     Direction.DECREASING,
                     mutableSetOf(
                         EdgeLocation(BlockId(19U), Offset<Block>(210.meters)),
-                        EdgeLocation(BlockId(18U), Offset<Block>(210.meters)),
+                        EdgeLocation(BlockId(18U), Offset(210.meters)),
                     ),
                 ),
             )

--- a/core/src/test/kotlin/fr/sncf/osrd/pathfinding/RemainingDistanceEstimatorTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/pathfinding/RemainingDistanceEstimatorTest.kt
@@ -38,7 +38,7 @@ class RemainingDistanceEstimatorTest {
     @ParameterizedTest
     @MethodSource("testRemainingDistanceEstimatorArgs")
     fun testRemainingDistanceEstimator(
-        edgeLocations: Collection<PathfindingEdgeLocationId<Block>>,
+        edgeLocations: Collection<EdgeLocation<BlockId, Block>>,
         remainingDistance: Distance,
         expectedDistance: Distance,
         blockOffset: Offset<Block>,

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/ConditionalOccupancyTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/ConditionalOccupancyTests.kt
@@ -2,7 +2,7 @@ package fr.sncf.osrd.stdcm
 
 import com.google.common.collect.ImmutableMultimap
 import fr.sncf.osrd.api.FullInfra
-import fr.sncf.osrd.pathfinding.Pathfinding
+import fr.sncf.osrd.pathfinding.Pathfinding.EdgeLocation
 import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.stdcm.preprocessing.OccupancySegment
 import fr.sncf.osrd.utils.DummyInfra
@@ -44,16 +44,14 @@ class ConditionalOccupancyTests {
         // No conflicts
         val res1 =
             initBuilder(infra.fullInfra(), occupancyGraph, block1)
-                .setEndLocations(setOf(Pathfinding.EdgeLocation(block2, Offset(50.meters))))
+                .setEndLocations(setOf(EdgeLocation(block2, Offset(50.meters))))
                 .run()
         assertNotNull(res1)
 
         // Conflict
         val res2 =
             initBuilder(infra.fullInfra(), occupancyGraph, block1)
-                .setEndLocations(
-                    setOf(Pathfinding.EdgeLocation(unavailableBlock, Offset(50.meters)))
-                )
+                .setEndLocations(setOf(EdgeLocation(unavailableBlock, Offset(50.meters))))
                 .run()
         assertNull(res2)
     }
@@ -91,16 +89,14 @@ class ConditionalOccupancyTests {
         // No conflicts
         val res1 =
             initBuilder(infra.fullInfra(), occupancyGraph, block1)
-                .setEndLocations(setOf(Pathfinding.EdgeLocation(block2, Offset(50.meters))))
+                .setEndLocations(setOf(EdgeLocation(block2, Offset(50.meters))))
                 .run()
         assertNotNull(res1)
 
         // Conflict
         val res2 =
             initBuilder(infra.fullInfra(), occupancyGraph, block1)
-                .setEndLocations(
-                    setOf(Pathfinding.EdgeLocation(unavailableBlock, Offset(50.meters)))
-                )
+                .setEndLocations(setOf(EdgeLocation(unavailableBlock, Offset(50.meters))))
                 .run()
         assertNull(res2)
     }
@@ -179,30 +175,28 @@ class ConditionalOccupancyTests {
         // End location on b --> c: no conflict
         val res1 =
             initBuilder(infra.fullInfra(), occupancyGraph, block1)
-                .setEndLocations(setOf(Pathfinding.EdgeLocation(block2, Offset(50.meters))))
+                .setEndLocations(setOf(EdgeLocation(block2, Offset(50.meters))))
                 .run()
         assertNotNull(res1)
 
         // End location on d --> e: no conflict
         val res2 =
             initBuilder(infra.fullInfra(), occupancyGraph, block1)
-                .setEndLocations(setOf(Pathfinding.EdgeLocation(block4, Offset(50.meters))))
+                .setEndLocations(setOf(EdgeLocation(block4, Offset(50.meters))))
                 .run()
         assertNotNull(res2)
 
         // End location on g --> h: no conflict
         val res3 =
             initBuilder(infra.fullInfra(), occupancyGraph, block1)
-                .setEndLocations(setOf(Pathfinding.EdgeLocation(block7, Offset(50.meters))))
+                .setEndLocations(setOf(EdgeLocation(block7, Offset(50.meters))))
                 .run()
         assertNotNull(res3)
 
         // End location on g --> i: conflict
         val res4 =
             initBuilder(infra.fullInfra(), occupancyGraph, block1)
-                .setEndLocations(
-                    setOf(Pathfinding.EdgeLocation(unavailableBlock, Offset(50.meters)))
-                )
+                .setEndLocations(setOf(EdgeLocation(unavailableBlock, Offset(50.meters))))
                 .run()
         assertNull(res4)
     }
@@ -232,8 +226,8 @@ class ConditionalOccupancyTests {
             STDCMPathfindingBuilder()
                 .setInfra(infra.fullInfra())
                 .setUnavailableTimes(occupancyGraph)
-                .setStartLocations(setOf(Pathfinding.EdgeLocation(blocks[0], Offset(0.meters))))
-                .setEndLocations(setOf(Pathfinding.EdgeLocation(blocks[2], Offset(50.meters))))
+                .setStartLocations(setOf(EdgeLocation(blocks[0], Offset(0.meters))))
+                .setEndLocations(setOf(EdgeLocation(blocks[2], Offset(50.meters))))
                 .run()!!
         assertTrue { res.departureTime + res.envelope.totalTime >= 3600 }
     }
@@ -246,6 +240,6 @@ class ConditionalOccupancyTests {
         return STDCMPathfindingBuilder()
             .setInfra(fullInfra)
             .setUnavailableTimes(occupancyGraph)
-            .setStartLocations(setOf(Pathfinding.EdgeLocation(startBlock, Offset(0.meters))))
+            .setStartLocations(setOf(EdgeLocation(startBlock, Offset(0.meters))))
     }
 }

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMHelpers.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMHelpers.kt
@@ -4,7 +4,7 @@ import com.google.common.collect.ImmutableMultimap
 import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.conflicts.SpacingRequirement
 import fr.sncf.osrd.envelope.Envelope
-import fr.sncf.osrd.pathfinding.PathfindingEdgeLocationId
+import fr.sncf.osrd.pathfinding.Pathfinding.EdgeLocation
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.sim_infra.impl.TemporarySpeedLimitManager
@@ -118,16 +118,12 @@ fun infraExplorerFromBlock(
     blockInfra: BlockInfra,
     block: BlockId,
 ): InfraExplorer {
-    return initInfraExplorer(
-            rawInfra,
-            blockInfra,
-            PathfindingEdgeLocationId(block, Offset(0.meters)),
-        )
+    return initInfraExplorer(rawInfra, blockInfra, EdgeLocation(block, Offset(0.meters)))
         .elementAt(0)
 }
 
 fun stepsFromLocations(
-    vararg locations: PathfindingEdgeLocationId<Block>,
+    vararg locations: EdgeLocation<BlockId, Block>,
     stops: Boolean = false,
 ): List<STDCMStep> {
     val duration = if (stops) 0.0 else null

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMPathfindingBuilder.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMPathfindingBuilder.kt
@@ -5,7 +5,7 @@ import com.google.common.collect.Multimap
 import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.envelope_sim.allowances.AllowanceValue
 import fr.sncf.osrd.pathfinding.Pathfinding
-import fr.sncf.osrd.pathfinding.PathfindingEdgeLocationId
+import fr.sncf.osrd.pathfinding.Pathfinding.EdgeLocation
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockId
@@ -64,7 +64,7 @@ data class STDCMPathfindingBuilder(
      * intermediate steps
      */
     fun setStartLocations(
-        startLocations: Set<PathfindingEdgeLocationId<Block>>,
+        startLocations: Set<EdgeLocation<BlockId, Block>>,
         plannedTimingData: PlannedTimingData? = null,
     ): STDCMPathfindingBuilder {
         steps.add(0, STDCMStep(startLocations, null, false, plannedTimingData))
@@ -76,7 +76,7 @@ data class STDCMPathfindingBuilder(
      * intermediate steps
      */
     fun setEndLocations(
-        endLocations: Set<PathfindingEdgeLocationId<Block>>,
+        endLocations: Set<EdgeLocation<BlockId, Block>>,
         plannedTimingData: PlannedTimingData? = null,
     ): STDCMPathfindingBuilder {
         steps.add(STDCMStep(endLocations, 0.0, true, plannedTimingData))

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/TemporarySpeedLimitTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/TemporarySpeedLimitTests.kt
@@ -4,7 +4,7 @@ import fr.sncf.osrd.api.DirectionalTrackRange
 import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.api.stdcm.STDCMTemporarySpeedLimit
 import fr.sncf.osrd.api.stdcm.buildTemporarySpeedLimitManager
-import fr.sncf.osrd.pathfinding.Pathfinding
+import fr.sncf.osrd.pathfinding.Pathfinding.EdgeLocation
 import fr.sncf.osrd.railjson.schema.common.graph.EdgeDirection
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.utils.Direction
@@ -39,8 +39,8 @@ class TemporarySpeedLimitTests {
         val endBlock = blocksOnEnd[0]
         return STDCMPathfindingBuilder()
             .setInfra(infra)
-            .setStartLocations(setOf(Pathfinding.EdgeLocation(startBlock, Offset(Distance(0L)))))
-            .setEndLocations(setOf(Pathfinding.EdgeLocation(endBlock, Offset(Distance(0L)))))
+            .setStartLocations(setOf(EdgeLocation(startBlock, Offset(Distance(0L)))))
+            .setEndLocations(setOf(EdgeLocation(endBlock, Offset(Distance(0L)))))
             .setTemporarySpeedLimitManager(temporarySpeedLimitManager)
             .run()!!
     }

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerTests.kt
@@ -74,7 +74,7 @@ class InfraExplorerTests {
         assertFalse { explorer.getIncrementalPath().pathComplete }
 
         // Fully extend lookahead
-        for (i in 0..<3) {
+        repeat(3) {
             val extended = explorer.cloneAndExtendLookahead()
             assertEquals(1, extended.size)
             explorer = extended.first()
@@ -166,7 +166,7 @@ class InfraExplorerTests {
         )
 
         // Move forward 2 times, both explorers should be at current block d->e and no lookahead
-        for (i in 0..<2) {
+        repeat(2) {
             extendedUntilEnd[0].moveForward()
             extendedUntilEnd[1].moveForward()
         }
@@ -291,7 +291,7 @@ class InfraExplorerTests {
             Helpers.fullInfraFromRJS(Helpers.getExampleInfra("overlapping_routes/infra.json"))
         val detector =
             infra.rawInfra.detectors.first { det ->
-                infra.rawInfra.getDetectorName(det).equals("det.center.1")
+                infra.rawInfra.getDetectorName(det) == "det.center.1"
             }
         val blocks =
             infra.blockInfra.getBlocksStartingAtDetector(
@@ -331,9 +331,7 @@ class InfraExplorerTests {
             Helpers.fullInfraFromRJS(Helpers.getExampleInfra("overlapping_routes/infra.json"))
 
         val detector =
-            infra.rawInfra.detectors.first { det ->
-                infra.rawInfra.getDetectorName(det).equals("bf.a1")
-            }
+            infra.rawInfra.detectors.first { det -> infra.rawInfra.getDetectorName(det) == "bf.a1" }
         val blocks =
             infra.blockInfra.getBlocksStartingAtDetector(
                 DirDetectorId(detector, Direction.INCREASING)

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerTests.kt
@@ -1,6 +1,6 @@
 package fr.sncf.osrd.stdcm.infra_exploration
 
-import fr.sncf.osrd.pathfinding.PathfindingEdgeLocationId
+import fr.sncf.osrd.pathfinding.Pathfinding.EdgeLocation
 import fr.sncf.osrd.pathfinding.constraints.ElectrificationConstraints
 import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.sim_infra.api.DirDetectorId
@@ -33,8 +33,8 @@ class InfraExplorerTests {
             initInfraExplorer(
                 infra,
                 infra,
-                PathfindingEdgeLocationId(block, Offset(0.meters)),
-                stepsFromLocations(PathfindingEdgeLocationId(block, infra.getBlockLength(block))),
+                EdgeLocation(block, Offset(0.meters)),
+                stepsFromLocations(EdgeLocation(block, infra.getBlockLength(block))),
             )
         assertEquals(1, explorers.size)
         val explorer = explorers.first()
@@ -61,10 +61,8 @@ class InfraExplorerTests {
             initInfraExplorer(
                 infra,
                 infra,
-                PathfindingEdgeLocationId(blocks[0], Offset(0.meters)),
-                stepsFromLocations(
-                    PathfindingEdgeLocationId(blocks.last(), infra.getBlockLength(blocks.last()))
-                ),
+                EdgeLocation(blocks[0], Offset(0.meters)),
+                stepsFromLocations(EdgeLocation(blocks.last(), infra.getBlockLength(blocks.last()))),
             )
         assertEquals(1, firstExplorers.size)
         var explorer = firstExplorers.first()
@@ -121,7 +119,7 @@ class InfraExplorerTests {
 
         // a --> b
         val firstExplorers =
-            initInfraExplorer(infra, infra, PathfindingEdgeLocationId(blocks[0], Offset(0.meters)))
+            initInfraExplorer(infra, infra, EdgeLocation(blocks[0], Offset(0.meters)))
         assertEquals(1, firstExplorers.size)
         val firstExplorer = firstExplorers.first()
 
@@ -214,7 +212,7 @@ class InfraExplorerTests {
             initInfraExplorer(
                 infra,
                 infra,
-                PathfindingEdgeLocationId(blocks[0], Offset(0.meters)),
+                EdgeLocation(blocks[0], Offset(0.meters)),
                 constraints = constraints,
             )
         assertEquals(1, firstExplorers.size)
@@ -265,7 +263,7 @@ class InfraExplorerTests {
             initInfraExplorer(
                 infra.rawInfra,
                 infra.blockInfra,
-                PathfindingEdgeLocationId(firstBlock, Offset(0.meters)),
+                EdgeLocation(firstBlock, Offset(0.meters)),
             )
         assertEquals(2, firstExplorers.size) // There should be one instance per route
     }
@@ -305,7 +303,7 @@ class InfraExplorerTests {
             initInfraExplorer(
                 infra.rawInfra,
                 infra.blockInfra,
-                PathfindingEdgeLocationId(block, Offset(0.meters)),
+                EdgeLocation(block, Offset(0.meters)),
             )
         assertEquals(4, explorers.size) // There should be one instance per route
         assertFalse { allEqual(explorers.map { it.getLastEdgeIdentifier() }) }
@@ -344,7 +342,7 @@ class InfraExplorerTests {
             initInfraExplorer(
                     infra.rawInfra,
                     infra.blockInfra,
-                    PathfindingEdgeLocationId(block, Offset(0.meters)),
+                    EdgeLocation(block, Offset(0.meters)),
                 )
                 .toList()
         assertEquals(1, explorers.size)
@@ -372,12 +370,12 @@ class InfraExplorerTests {
             initInfraExplorer(
                     infra,
                     infra,
-                    PathfindingEdgeLocationId(blocks[0], Offset(50.meters)),
+                    EdgeLocation(blocks[0], Offset(50.meters)),
                     stepsFromLocations(
-                        PathfindingEdgeLocationId(blocks[0], Offset(50.meters)),
-                        PathfindingEdgeLocationId(blocks[1], Offset(50.meters)),
-                        PathfindingEdgeLocationId(blocks[2], Offset(0.meters)),
-                        PathfindingEdgeLocationId(blocks[3], Offset(50.meters)),
+                        EdgeLocation(blocks[0], Offset(50.meters)),
+                        EdgeLocation(blocks[1], Offset(50.meters)),
+                        EdgeLocation(blocks[2], Offset(0.meters)),
+                        EdgeLocation(blocks[3], Offset(50.meters)),
                         stops = true,
                     ),
                 )
@@ -411,11 +409,8 @@ class InfraExplorerTests {
             initInfraExplorer(
                     infra.rawInfra,
                     infra.blockInfra,
-                    PathfindingEdgeLocationId(block, Offset(32.meters)),
-                    stepsFromLocations(
-                        PathfindingEdgeLocationId(block, Offset(42.meters)),
-                        stops = true,
-                    ),
+                    EdgeLocation(block, Offset(32.meters)),
+                    stepsFromLocations(EdgeLocation(block, Offset(42.meters)), stops = true),
                 )
                 .first()
         val incrementalPath = explorers.getIncrementalPath()

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelopeTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelopeTests.kt
@@ -4,7 +4,7 @@ import fr.sncf.osrd.envelope.Envelope
 import fr.sncf.osrd.envelope.EnvelopeTimeInterpolate
 import fr.sncf.osrd.envelope.part.EnvelopePart
 import fr.sncf.osrd.envelope_sim.EnvelopeProfile
-import fr.sncf.osrd.pathfinding.PathfindingEdgeLocationId
+import fr.sncf.osrd.pathfinding.Pathfinding.EdgeLocation
 import fr.sncf.osrd.train.TestTrains.REALISTIC_FAST_TRAIN
 import fr.sncf.osrd.utils.DummyInfra
 import fr.sncf.osrd.utils.arePositionsEqual
@@ -42,7 +42,7 @@ class InfraExplorerWithEnvelopeTests {
         val firstExplorers =
             initInfraExplorerWithEnvelope(
                 fullInfra,
-                PathfindingEdgeLocationId(blocks[0], Offset(0.meters)),
+                EdgeLocation(blocks[0], Offset(0.meters)),
                 rollingStock = REALISTIC_FAST_TRAIN,
             )
         assertEquals(1, firstExplorers.size)
@@ -127,7 +127,7 @@ class InfraExplorerWithEnvelopeTests {
         val firstExplorers =
             initInfraExplorerWithEnvelope(
                 fullInfra,
-                PathfindingEdgeLocationId(blocks[0], Offset(0.meters)),
+                EdgeLocation(blocks[0], Offset(0.meters)),
                 rollingStock = REALISTIC_FAST_TRAIN,
             )
         assertEquals(1, firstExplorers.size)
@@ -207,7 +207,7 @@ class InfraExplorerWithEnvelopeTests {
         val firstExplorers =
             initInfraExplorerWithEnvelope(
                 fullInfra,
-                PathfindingEdgeLocationId(blocks[0], Offset(30.meters)),
+                EdgeLocation(blocks[0], Offset(30.meters)),
                 rollingStock = REALISTIC_FAST_TRAIN,
             )
         var explorer = firstExplorers.single()

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/infra_exploration/StepTrackerTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/infra_exploration/StepTrackerTests.kt
@@ -1,6 +1,6 @@
 package fr.sncf.osrd.stdcm.infra_exploration
 
-import fr.sncf.osrd.pathfinding.PathfindingEdgeLocationId
+import fr.sncf.osrd.pathfinding.Pathfinding.EdgeLocation
 import fr.sncf.osrd.stdcm.STDCMStep
 import fr.sncf.osrd.utils.DummyInfra
 import fr.sncf.osrd.utils.units.Offset
@@ -24,16 +24,16 @@ class StepTrackerTests {
             )
         val steps =
             listOf(
-                STDCMStep(listOf(PathfindingEdgeLocationId(blocks[0], Offset(50.meters)))),
+                STDCMStep(listOf(EdgeLocation(blocks[0], Offset(50.meters)))),
                 STDCMStep(
                     listOf(
-                        PathfindingEdgeLocationId(blocks[0], Offset(40.meters)),
-                        PathfindingEdgeLocationId(blocks[0], Offset(51.meters)),
+                        EdgeLocation(blocks[0], Offset(40.meters)),
+                        EdgeLocation(blocks[0], Offset(51.meters)),
                     )
                 ),
-                STDCMStep(listOf(PathfindingEdgeLocationId(blocks[1], Offset(0.meters)))),
-                STDCMStep(listOf(PathfindingEdgeLocationId(blocks[1], Offset(100.meters)))),
-                STDCMStep(listOf(PathfindingEdgeLocationId(blocks[2], Offset(100.meters)))),
+                STDCMStep(listOf(EdgeLocation(blocks[1], Offset(0.meters)))),
+                STDCMStep(listOf(EdgeLocation(blocks[1], Offset(100.meters)))),
+                STDCMStep(listOf(EdgeLocation(blocks[2], Offset(100.meters)))),
             )
         val tracker = StepTracker(steps)
 
@@ -41,11 +41,7 @@ class StepTrackerTests {
         val expectedFirstSteps =
             listOf(
                 LocatedStep(Offset(25.meters), steps[0].locations.single(), steps[0]),
-                LocatedStep(
-                    Offset(26.meters),
-                    PathfindingEdgeLocationId(blocks[0], Offset(51.meters)),
-                    steps[1],
-                ),
+                LocatedStep(Offset(26.meters), EdgeLocation(blocks[0], Offset(51.meters)), steps[1]),
             )
         assertEquals(expectedFirstSteps, firstSteps)
         val second = tracker.exploreBlockRange(blocks[1], Offset(0.meters), Offset(100.meters))

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/BlockAvailabilityTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/BlockAvailabilityTests.kt
@@ -4,7 +4,7 @@ import fr.sncf.osrd.conflicts.SpacingRequirement
 import fr.sncf.osrd.envelope.Envelope
 import fr.sncf.osrd.envelope.part.EnvelopePart
 import fr.sncf.osrd.envelope_sim.EnvelopeProfile
-import fr.sncf.osrd.pathfinding.PathfindingEdgeLocationId
+import fr.sncf.osrd.pathfinding.Pathfinding.EdgeLocation
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.sim_infra.api.DirDetectorId
@@ -117,10 +117,7 @@ class BlockAvailabilityTests {
         val steps = originalSteps.toMutableList()
         val lastStep =
             stepsFromLocations(
-                    PathfindingEdgeLocationId(
-                        blocks.last(),
-                        infra.blockInfra.getBlockLength(blocks.last()),
-                    )
+                    EdgeLocation(blocks.last(), infra.blockInfra.getBlockLength(blocks.last()))
                 )
                 .single()
         if (steps.none { it.locations == lastStep.locations }) steps.add(lastStep)
@@ -128,7 +125,7 @@ class BlockAvailabilityTests {
         var infraExplorer =
             initInfraExplorerWithEnvelope(
                     infra,
-                    PathfindingEdgeLocationId(blocks[0], startOffset),
+                    EdgeLocation(blocks[0], startOffset),
                     rollingStock,
                     steps,
                 )
@@ -583,13 +580,10 @@ class BlockAvailabilityTests {
         var explorer =
             initInfraExplorerWithEnvelope(
                     infra,
-                    PathfindingEdgeLocationId(blocks[2], Offset(50.meters)),
+                    EdgeLocation(blocks[2], Offset(50.meters)),
                     REALISTIC_FAST_TRAIN,
                     stepsFromLocations(
-                        PathfindingEdgeLocationId(
-                            blocks.last(),
-                            infra.blockInfra.getBlockLength(blocks.last()),
-                        )
+                        EdgeLocation(blocks.last(), infra.blockInfra.getBlockLength(blocks.last()))
                     ),
                 )
                 .first { filterExplorer(it) }
@@ -630,7 +624,7 @@ class BlockAvailabilityTests {
         val steps =
             listOf(
                 STDCMStep(
-                    listOf(PathfindingEdgeLocationId(blocks[0], plannedStepOffset)),
+                    listOf(EdgeLocation(blocks[0], plannedStepOffset)),
                     null,
                     false,
                     PlannedTimingData(0.seconds, 0.seconds, timeAtZoneEnd.seconds),
@@ -657,13 +651,13 @@ class BlockAvailabilityTests {
         val steps =
             listOf(
                 STDCMStep(
-                    listOf(PathfindingEdgeLocationId(blocks[0], outOfBoundsStepOffset)),
+                    listOf(EdgeLocation(blocks[0], outOfBoundsStepOffset)),
                     null,
                     false,
                     PlannedTimingData(0.seconds, 0.seconds, 0.seconds),
                 ),
                 STDCMStep(
-                    listOf(PathfindingEdgeLocationId(blocks[1], Offset(0.meters))),
+                    listOf(EdgeLocation(blocks[1], Offset(0.meters))),
                     null,
                     false,
                     PlannedTimingData(0.seconds, 0.seconds, 0.seconds),
@@ -694,7 +688,7 @@ class BlockAvailabilityTests {
         val steps =
             listOf(
                 STDCMStep(
-                    listOf(PathfindingEdgeLocationId(blocks[0], plannedStepOffset)),
+                    listOf(EdgeLocation(blocks[0], plannedStepOffset)),
                     null,
                     false,
                     PlannedTimingData(
@@ -744,7 +738,7 @@ class BlockAvailabilityTests {
         val steps =
             listOf(
                 STDCMStep(
-                    listOf(PathfindingEdgeLocationId(blocks[0], plannedStepOffset)),
+                    listOf(EdgeLocation(blocks[0], plannedStepOffset)),
                     null,
                     false,
                     PlannedTimingData(0.seconds, 0.seconds, 0.seconds),
@@ -781,7 +775,7 @@ class BlockAvailabilityTests {
         val steps =
             listOf(
                 STDCMStep(
-                    listOf(PathfindingEdgeLocationId(blocks[0], plannedStepOffset)),
+                    listOf(EdgeLocation(blocks[0], plannedStepOffset)),
                     null,
                     false,
                     PlannedTimingData(0.seconds, 0.seconds, 0.seconds),
@@ -820,7 +814,7 @@ class BlockAvailabilityTests {
         val steps =
             listOf(
                 STDCMStep(
-                    listOf(PathfindingEdgeLocationId(blocks[0], plannedStepOffset)),
+                    listOf(EdgeLocation(blocks[0], plannedStepOffset)),
                     null,
                     false,
                     PlannedTimingData(minDelay.seconds, 0.seconds, 10.seconds),
@@ -855,7 +849,7 @@ class BlockAvailabilityTests {
             listOf(
                 // We need to add delay = timeAtZoneEnd + internal margin
                 STDCMStep(
-                    listOf(PathfindingEdgeLocationId(blocks[0], plannedStepOffset)),
+                    listOf(EdgeLocation(blocks[0], plannedStepOffset)),
                     null,
                     false,
                     PlannedTimingData(
@@ -866,7 +860,7 @@ class BlockAvailabilityTests {
                 ),
                 // If we add delay = timeAtZoneEnd + internal margin, this step is not respected
                 STDCMStep(
-                    listOf(PathfindingEdgeLocationId(blocks[0], secondPlannedStepOffset)),
+                    listOf(EdgeLocation(blocks[0], secondPlannedStepOffset)),
                     null,
                     false,
                     PlannedTimingData(0.seconds, 0.seconds, timeAtZoneEnd.seconds),
@@ -905,7 +899,7 @@ class BlockAvailabilityTests {
         val steps =
             listOf(
                 STDCMStep(
-                    listOf(PathfindingEdgeLocationId(blocks[0], Offset(100.meters))),
+                    listOf(EdgeLocation(blocks[0], Offset(100.meters))),
                     null,
                     false,
                     PlannedTimingData(

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
@@ -227,7 +227,7 @@ class STDCMHeuristicTests {
         var explorer =
             initInfraExplorer(infra, infra, steps.first().locations.first(), steps).single()
 
-        for (i in 1 until blocks.size) {
+        repeat(blocks.size - 1) {
             explorer =
                 explorer.cloneAndExtendLookahead().single { candidate ->
                     candidate.getLookahead().all { blocks.contains(it) }
@@ -242,7 +242,7 @@ class STDCMHeuristicTests {
 
         var wrongPathExplorer =
             initInfraExplorer(infra, infra, steps.first().locations.first(), steps).single()
-        for (i in 0..<2) {
+        repeat(2) {
             wrongPathExplorer =
                 wrongPathExplorer.cloneAndExtendLookahead().single {
                     it.getLookahead().last() != blocks[1]

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
@@ -6,7 +6,7 @@ import fr.sncf.osrd.envelope.Envelope.Companion.make
 import fr.sncf.osrd.envelope.EnvelopeTestUtils
 import fr.sncf.osrd.envelope_sim.SimpleRollingStock.STANDARD_TRAIN
 import fr.sncf.osrd.envelope_sim.allowances.AllowanceValue
-import fr.sncf.osrd.pathfinding.PathfindingEdgeLocationId
+import fr.sncf.osrd.pathfinding.Pathfinding.EdgeLocation
 import fr.sncf.osrd.stdcm.STDCMAStarHeuristic
 import fr.sncf.osrd.stdcm.STDCMHeuristicBuilder
 import fr.sncf.osrd.stdcm.STDCMStep
@@ -46,31 +46,11 @@ class STDCMHeuristicTests {
 
         val steps =
             listOf(
-                STDCMStep(
-                    listOf(PathfindingEdgeLocationId(blocks[0], Offset(50.meters))),
-                    null,
-                    false,
-                ),
-                STDCMStep(
-                    listOf(PathfindingEdgeLocationId(blocks[1], Offset(25.meters))),
-                    null,
-                    false,
-                ),
-                STDCMStep(
-                    listOf(PathfindingEdgeLocationId(blocks[1], Offset(75.meters))),
-                    null,
-                    false,
-                ),
-                STDCMStep(
-                    listOf(PathfindingEdgeLocationId(blocks[2], Offset(0.meters))),
-                    null,
-                    false,
-                ),
-                STDCMStep(
-                    listOf(PathfindingEdgeLocationId(blocks[3], Offset(100.meters))),
-                    1.0,
-                    true,
-                ),
+                STDCMStep(listOf(EdgeLocation(blocks[0], Offset(50.meters))), null, false),
+                STDCMStep(listOf(EdgeLocation(blocks[1], Offset(25.meters))), null, false),
+                STDCMStep(listOf(EdgeLocation(blocks[1], Offset(75.meters))), null, false),
+                STDCMStep(listOf(EdgeLocation(blocks[2], Offset(0.meters))), null, false),
+                STDCMStep(listOf(EdgeLocation(blocks[3], Offset(100.meters))), 1.0, true),
             )
 
         val heuristic =
@@ -125,16 +105,8 @@ class STDCMHeuristicTests {
 
         val steps =
             listOf(
-                STDCMStep(
-                    listOf(PathfindingEdgeLocationId(blocks[0], Offset(0.meters))),
-                    null,
-                    false,
-                ),
-                STDCMStep(
-                    listOf(PathfindingEdgeLocationId(blocks[1], Offset(100.meters))),
-                    null,
-                    true,
-                ),
+                STDCMStep(listOf(EdgeLocation(blocks[0], Offset(0.meters))), null, false),
+                STDCMStep(listOf(EdgeLocation(blocks[1], Offset(100.meters))), null, true),
             )
 
         val heuristicWithAllowance =
@@ -195,21 +167,9 @@ class STDCMHeuristicTests {
 
         val steps =
             listOf(
-                STDCMStep(
-                    listOf(PathfindingEdgeLocationId(blocks[0], Offset(50.meters))),
-                    null,
-                    false,
-                ),
-                STDCMStep(
-                    listOf(PathfindingEdgeLocationId(blocks[1], Offset(50.meters))),
-                    null,
-                    false,
-                ),
-                STDCMStep(
-                    listOf(PathfindingEdgeLocationId(blocks[3], Offset(50.meters))),
-                    1.0,
-                    true,
-                ),
+                STDCMStep(listOf(EdgeLocation(blocks[0], Offset(50.meters))), null, false),
+                STDCMStep(listOf(EdgeLocation(blocks[1], Offset(50.meters))), null, false),
+                STDCMStep(listOf(EdgeLocation(blocks[3], Offset(50.meters))), 1.0, true),
             )
 
         val heuristics =

--- a/core/src/test/kotlin/fr/sncf/osrd/utils/Helpers.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/utils/Helpers.kt
@@ -7,7 +7,7 @@ import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.api.TrackLocation
 import fr.sncf.osrd.api.makeSignalingSimulator
 import fr.sncf.osrd.api.standalone_sim.PhysicsConsistModel
-import fr.sncf.osrd.pathfinding.PathfindingEdgeLocationId
+import fr.sncf.osrd.pathfinding.Pathfinding.EdgeLocation
 import fr.sncf.osrd.railjson.schema.external_generated_inputs.RJSElectricalProfileSet
 import fr.sncf.osrd.railjson.schema.infra.RJSInfra
 import fr.sncf.osrd.railjson.schema.rollingstock.RJSRollingResistance
@@ -128,7 +128,7 @@ object Helpers {
     }
 
     data class LocationPair(
-        val blockLocations: Set<PathfindingEdgeLocationId<Block>>,
+        val blockLocations: Set<EdgeLocation<BlockId, Block>>,
         val trackLocations: Set<TrackLocation>,
     )
 
@@ -137,13 +137,12 @@ object Helpers {
         infra: FullInfra,
         routeName: String,
         offset: Offset<Route>,
-    ): PathfindingEdgeLocationId<Block> {
+    ): EdgeLocation<BlockId, Block> {
         var mutOffset = offset
         val blocks = getBlocksOnRoutes(infra, listOf(routeName))
         for (block in blocks) {
             val blockLength = infra.blockInfra.getBlockLength(block)
-            if (mutOffset <= blockLength.cast())
-                return PathfindingEdgeLocationId(block, mutOffset.cast())
+            if (mutOffset <= blockLength.cast()) return EdgeLocation(block, mutOffset.cast())
             mutOffset -= blockLength.distance
         }
         throw RuntimeException("Couldn't find route location")

--- a/core/src/test/kotlin/fr/sncf/osrd/utils/Helpers.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/utils/Helpers.kt
@@ -53,7 +53,7 @@ object Helpers {
     fun getExampleElectricalProfiles(externalGeneratedInputsPath: String): RJSElectricalProfileSet {
         return deserializeResource(
             RJSElectricalProfileSet.adapter,
-            "infras/" + externalGeneratedInputsPath,
+            "infras/$externalGeneratedInputsPath",
         )
     }
 


### PR DESCRIPTION
Unify `Pathfinding.kt` uses before actual work on https://github.com/OpenRailAssociation/osrd/issues/13014.

Hoping that later moves when refactoring Pathfinding.kt will be more
similar and more restrained to imports.

The goal is an earlier merge of what's easy and could conflict.

🔍 Review by commit with message.