### PR TITLE
core: stdcm: use heuristic to trim nodes that would take too long

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMHeuristic.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMHeuristic.kt
@@ -9,6 +9,7 @@ import fr.sncf.osrd.sim_infra.api.RawInfra
 import fr.sncf.osrd.sim_infra.impl.TemporarySpeedLimitManager
 import fr.sncf.osrd.sim_infra.utils.getBlockEntry
 import fr.sncf.osrd.stdcm.graph.STDCMEdge
+import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
 import fr.sncf.osrd.stdcm.infra_exploration.StepTracker
 import fr.sncf.osrd.utils.CachedBlockMRSPBuilder
 import fr.sncf.osrd.utils.indexing.StaticIdx
@@ -28,6 +29,7 @@ data class STDCMAStarHeuristic(
     val mrspBuilder: CachedBlockMRSPBuilder,
     val bestTravelTime: Double,
     val allowanceValue: AllowanceValue?,
+    val stopDurations: List<Double>,
 ) {
     /**
      * Defines a function that can be used as a heuristic for an A* pathfinding. It takes an edge,
@@ -65,6 +67,14 @@ data class STDCMAStarHeuristic(
         val remainingTime = timeUntilStartOfLastBlock + timeAfterStartOfLastBlock
 
         return remainingTime
+    }
+
+    /** Estimates the minimum remaining stop time. */
+    fun minRemainingStopTime(explorer: InfraExplorerWithEnvelope): Double {
+        val nSimulatedStops = explorer.generateReachedTrainStops().size
+        return stopDurations
+            .subList(min(nSimulatedStops, stopDurations.size), stopDurations.size)
+            .sum()
     }
 
     /** Returns the numbers of passed waypoints at the end of the block list */
@@ -153,6 +163,7 @@ class STDCMHeuristicBuilder(
             mrspBuilder,
             bestTravelTime,
             allowance,
+            steps.filter { it.stop }.map { it.duration ?: 0.0 },
         )
     }
 

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/DelayManager.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/DelayManager.kt
@@ -84,16 +84,6 @@ internal constructor(
     }
 
     /**
-     * Returns true if the total run time at the start of the edge is above the specified threshold
-     */
-    fun isRunTimeTooLong(edge: STDCMEdge): Boolean {
-        val totalRunTime = edge.timeData.timeSinceDeparture
-
-        // TODO: we should use the A* heuristic here, but that requires a small refactoring
-        return totalRunTime > maxRunTime
-    }
-
-    /**
      * Returns by how much we can shift this envelope (in time) before causing a conflict.
      *
      * e.g. if the train takes 42s to go through the block, enters the block at t=10s, and we need

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdgeBuilder.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdgeBuilder.kt
@@ -228,8 +228,7 @@ internal constructor(
                 allowanceData,
                 envelope!!,
             )
-        res = graph.backtrackingManager.backtrack(res!!, envelope!!)
-        return if (res == null || graph.delayManager.isRunTimeTooLong(res)) null else res
+        return graph.backtrackingManager.backtrack(res!!, envelope!!)
     }
 
     companion object {

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
@@ -35,7 +35,7 @@ class STDCMGraph(
     val comfort: Comfort?,
     val timeStep: Double,
     blockAvailability: BlockAvailabilityInterface,
-    maxRunTime: Double,
+    val maxRunTime: Double,
     minScheduleTimeStart: Double,
     steps: List<STDCMStep>,
     val tag: String?,

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMNode.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMNode.kt
@@ -2,6 +2,7 @@ package fr.sncf.osrd.stdcm.graph
 
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.stdcm.PlannedTimingData
+import fr.sncf.osrd.stdcm.STDCMAStarHeuristic
 import fr.sncf.osrd.stdcm.graph.engineering_allowance.generatePreviousSimulationSegments
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
 import fr.sncf.osrd.utils.SoftLazy
@@ -204,5 +205,11 @@ data class STDCMNode(
             .allowanceManager
             .generateAllowanceOpportunities(previousSimulationSegments, speed)
             .cacheable()
+    }
+
+    fun getMinTotalSimulationTime(heuristic: STDCMAStarHeuristic): Double {
+        return timeData.totalRunningTime +
+            remainingTimeEstimation +
+            heuristic.minRemainingStopTime(infraExplorer)
     }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
@@ -197,6 +197,8 @@ class STDCMPathfinding(
                 fValueLogger.logAggregatedSummary()
                 return null
             }
+            if (endNode.getMinTotalSimulationTime(graph.remainingTimeEstimator) > maxRunTime)
+                continue
 
             // Checks that the f-value (best anticipated final value on path) only goes up,
             // otherwise the A* heuristic isn't admissible


### PR DESCRIPTION
Fix https://github.com/OpenRailAssociation/osrd/issues/13686

Compared to the previous version I thought I'd give up, this reuses the previous heuristic computation instead of re-computing it (which was expensive).

And I also looked more carefully at the covered maps: it only makes a small difference, but that's because the "max running time" parameter is large enough to cover most of the infra anyway. With some tweaking it should be much better. 

Ad-hoc test: I tried a path going north-east -> south-east (long stop) -> south-west, and I artificially blocked the destination (to force it to go through every allowed possibility). It reduced the computation time and the number of visited nodes by roughly 10%. 