### PR TITLE
core: stdcm: fix min simulation time

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMNode.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMNode.kt
@@ -209,6 +209,7 @@ data class STDCMNode(
 
     fun getMinTotalSimulationTime(heuristic: STDCMAStarHeuristic): Double {
         return timeData.totalRunningTime +
+            timeData.totalStopDuration +
             remainingTimeEstimation +
             heuristic.minRemainingStopTime(infraExplorer)
     }


### PR DESCRIPTION
We used the stop duration in the remaining time, but not the ones we've actually simulated.

I figured that one out by checking the generated maps, the value wasn't meant to go down after a stop. 