### PR TITLE
core: sim: fix infinite loop when allowance speed reaches 0

### DIFF
--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/part/ConstrainedEnvelopePartBuilder.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/part/ConstrainedEnvelopePartBuilder.java
@@ -8,6 +8,7 @@ import fr.sncf.osrd.envelope.EnvelopePoint;
 import fr.sncf.osrd.envelope.part.constraints.EnvelopePartConstraint;
 import fr.sncf.osrd.envelope_utils.DoubleUtils;
 import fr.sncf.osrd.utils.SelfTypeHolder;
+import java.util.Arrays;
 
 public final class ConstrainedEnvelopePartBuilder implements InteractiveEnvelopePartConsumer {
     public EnvelopePartConstraint[] constraints;
@@ -121,5 +122,13 @@ public final class ConstrainedEnvelopePartBuilder implements InteractiveEnvelope
     @Override
     public void setAttrs(Iterable<SelfTypeHolder> attrs) {
         sink.setAttrs(attrs);
+    }
+
+    @Override
+    public void checkConstraints() {
+        assert Arrays.stream(constraints).anyMatch(EnvelopePartConstraint::isFloor)
+                : "Simulation without speed floor can cause infinite loops at speed=0";
+        assert Arrays.stream(constraints).anyMatch(EnvelopePartConstraint::hasPositionConstraint)
+                : "Simulations without position constraints can cause infinite loops";
     }
 }

--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/part/InteractiveEnvelopePartConsumer.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/part/InteractiveEnvelopePartConsumer.java
@@ -32,4 +32,7 @@ public interface InteractiveEnvelopePartConsumer {
 
     /** Sets envelope part attributes */
     void setAttrs(Iterable<SelfTypeHolder> attrs);
+
+    /** Runs some assertions on the constraints, to make sure there's no risk of infinite loops. */
+    void checkConstraints();
 }

--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/part/constraints/EnvelopeConstraint.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/part/constraints/EnvelopeConstraint.java
@@ -38,6 +38,16 @@ public class EnvelopeConstraint implements EnvelopePartConstraint {
         };
     }
 
+    @Override
+    public boolean isFloor() {
+        return type != CEILING;
+    }
+
+    @Override
+    public boolean hasPositionConstraint() {
+        return true;
+    }
+
     // region INTERSECTION
 
     private enum NextPointKind {

--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/part/constraints/EnvelopePartConstraint.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/part/constraints/EnvelopePartConstraint.java
@@ -6,6 +6,12 @@ public interface EnvelopePartConstraint {
     /** Returns whether the first point of an envelope part satisfies a constraint */
     boolean initCheck(double position, double speed, double direction);
 
+    /** Returns whether the constraint sets a minimum value on the simulation speed. */
+    boolean isFloor();
+
+    /** Returns whether the constraint sets a position limit. */
+    boolean hasPositionConstraint();
+
     /** Intersects a segment (start excluded, end included) with this constraint */
     EnvelopePoint stepCheck(double startPos, double startSpeed, double endPos, double endSpeed);
 }

--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/part/constraints/PositionConstraint.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/part/constraints/PositionConstraint.java
@@ -19,6 +19,16 @@ public class PositionConstraint implements EnvelopePartConstraint {
     }
 
     @Override
+    public boolean isFloor() {
+        return false;
+    }
+
+    @Override
+    public boolean hasPositionConstraint() {
+        return true;
+    }
+
+    @Override
     @SuppressFBWarnings({"FE_FLOATING_POINT_EQUALITY"})
     public EnvelopePoint stepCheck(double startPos, double startSpeed, double endPos, double endSpeed) {
         if (endPos > rangeBegin && endPos < rangeEnd) return null;

--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/part/constraints/SpeedConstraint.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/part/constraints/SpeedConstraint.java
@@ -25,6 +25,16 @@ public class SpeedConstraint implements EnvelopePartConstraint {
     }
 
     @Override
+    public boolean isFloor() {
+        return type != EnvelopePartConstraintType.CEILING;
+    }
+
+    @Override
+    public boolean hasPositionConstraint() {
+        return false;
+    }
+
+    @Override
     public EnvelopePoint stepCheck(double startPos, double startSpeed, double endPos, double endSpeed) {
         switch (type) {
             case CEILING:

--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/overlays/EnvelopeAcceleration.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/overlays/EnvelopeAcceleration.java
@@ -13,6 +13,7 @@ public class EnvelopeAcceleration {
             double startSpeed,
             InteractiveEnvelopePartConsumer consumer,
             double direction) {
+        consumer.checkConstraints();
         if (!consumer.initEnvelopePart(startPosition, startSpeed, direction)) return;
         double position = startPosition;
         double speed = startSpeed;

--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/overlays/EnvelopeAcceleration.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/overlays/EnvelopeAcceleration.java
@@ -22,6 +22,7 @@ public class EnvelopeAcceleration {
             position += step.positionDelta;
             speed = step.endSpeed;
             if (!consumer.addStep(position, speed, step.timeDelta)) break;
+            assert (step.positionDelta != 0.0);
         }
     }
 }

--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/overlays/EnvelopeCoasting.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/overlays/EnvelopeCoasting.java
@@ -13,6 +13,7 @@ public class EnvelopeCoasting {
             double startSpeed,
             InteractiveEnvelopePartConsumer consumer,
             double directionSign) {
+        consumer.checkConstraints();
         if (!consumer.initEnvelopePart(startPosition, startSpeed, directionSign)) return;
         double position = startPosition;
         double speed = startSpeed;

--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/overlays/EnvelopeDeceleration.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/overlays/EnvelopeDeceleration.java
@@ -15,6 +15,7 @@ public class EnvelopeDeceleration {
             InteractiveEnvelopePartConsumer consumer,
             double direction,
             BrakingType brakingType) {
+        consumer.checkConstraints();
         if (!consumer.initEnvelopePart(startPosition, startSpeed, direction)) return;
         double position = startPosition;
         double speed = startSpeed;

--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/overlays/EnvelopeMaintain.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/overlays/EnvelopeMaintain.java
@@ -13,6 +13,7 @@ public class EnvelopeMaintain {
             double startSpeed,
             InteractiveEnvelopePartConsumer consumer,
             double direction) {
+        consumer.checkConstraints();
         if (!consumer.initEnvelopePart(startPosition, startSpeed, direction)) return;
         double position = startPosition;
         double speed = startSpeed;

--- a/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/allowances/AbstractAllowanceWithRanges.kt
+++ b/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/allowances/AbstractAllowanceWithRanges.kt
@@ -11,6 +11,7 @@ import fr.sncf.osrd.envelope.part.constraints.EnvelopeConstraint
 import fr.sncf.osrd.envelope.part.constraints.EnvelopePartConstraint
 import fr.sncf.osrd.envelope.part.constraints.EnvelopePartConstraintType
 import fr.sncf.osrd.envelope.part.constraints.PositionConstraint
+import fr.sncf.osrd.envelope.part.constraints.SpeedConstraint
 import fr.sncf.osrd.envelope_sim.EnvelopeProfile
 import fr.sncf.osrd.envelope_sim.EnvelopeSimContext
 import fr.sncf.osrd.envelope_sim.PhysicsRollingStock
@@ -528,6 +529,7 @@ protected constructor(
         } else if (imposedBeginSpeed < envelopeSection.beginSpeed) {
             constraints.add(EnvelopeConstraint(envelopeTarget, EnvelopePartConstraintType.CEILING))
             constraints.add(EnvelopeConstraint(envelopeSection, EnvelopePartConstraintType.CEILING))
+            constraints.add(SpeedConstraint(0.0, EnvelopePartConstraintType.FLOOR))
             val constrainedBuilder =
                 ConstrainedEnvelopePartBuilder(
                     partBuilder,
@@ -588,6 +590,7 @@ protected constructor(
             partBuilder.setAttr(EnvelopeProfile.ACCELERATING)
             lastIntersection = constrainedBuilder.lastIntersection
         } else if (imposedEndSpeed < envelopeSection.endSpeed) {
+            constraints.add(SpeedConstraint(0.0, EnvelopePartConstraintType.FLOOR))
             constraints.add(EnvelopeConstraint(envelopeTarget, EnvelopePartConstraintType.CEILING))
             val constrainedBuilder =
                 ConstrainedEnvelopePartBuilder(

--- a/core/envelope-sim/src/test/kotlin/fr/sncf/osrd/envelope_sim/TrainPhysicsIntegratorTest.kt
+++ b/core/envelope-sim/src/test/kotlin/fr/sncf/osrd/envelope_sim/TrainPhysicsIntegratorTest.kt
@@ -4,6 +4,7 @@ import fr.sncf.osrd.envelope.Envelope.Companion.make
 import fr.sncf.osrd.envelope.part.ConstrainedEnvelopePartBuilder
 import fr.sncf.osrd.envelope.part.EnvelopePartBuilder
 import fr.sncf.osrd.envelope.part.constraints.EnvelopePartConstraintType
+import fr.sncf.osrd.envelope.part.constraints.PositionConstraint
 import fr.sncf.osrd.envelope.part.constraints.SpeedConstraint
 import fr.sncf.osrd.envelope_sim.allowances.mareco_impl.CoastingGenerator.coastFromBeginning
 import fr.sncf.osrd.envelope_sim.overlays.EnvelopeDeceleration
@@ -129,6 +130,7 @@ class TrainPhysicsIntegratorTest {
             ConstrainedEnvelopePartBuilder(
                 builder,
                 SpeedConstraint(0.0, EnvelopePartConstraintType.FLOOR),
+                PositionConstraint(0.0, 10_000.0),
             )
         EnvelopeDeceleration.decelerate(context, 0.0, 10.0, constrainedBuilder, 1.0)
         builder.setAttr(EnvelopeProfile.BRAKING)


### PR DESCRIPTION
Fix https://github.com/OpenRailAssociation/osrd/issues/13712

* Add sanity checks to make sure all simulation loops have a reasonable chance of finishing at some point
* Fix the few cases where these conditions weren't met