### PR TITLE
core: basic cleanup for pathfinding constraints

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.kt
@@ -10,10 +10,7 @@ import fr.sncf.osrd.pathfinding.*
 import fr.sncf.osrd.pathfinding.Pathfinding.EdgeLocation
 import fr.sncf.osrd.pathfinding.Pathfinding.EdgeRange
 import fr.sncf.osrd.pathfinding.constraints.ConstraintCombiner
-import fr.sncf.osrd.pathfinding.constraints.ElectrificationConstraints
-import fr.sncf.osrd.pathfinding.constraints.LoadingGaugeConstraints
-import fr.sncf.osrd.pathfinding.constraints.SignalingSystemConstraints
-import fr.sncf.osrd.railjson.schema.rollingstock.RJSLoadingGaugeType
+import fr.sncf.osrd.pathfinding.constraints.initConstraintsFromRSProps
 import fr.sncf.osrd.reporting.exceptions.ErrorType
 import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.sim_infra.api.*
@@ -125,32 +122,6 @@ fun runPathfinding(infra: FullInfra, request: PathfindingBlockRequest): Pathfind
     // Compute the paths from the entry waypoint to the exit waypoint
     val path = computePaths(infra, waypoints, constraints, heuristics, request, request.timeout)
     return runPathfindingPostProcessing(infra, request, path)
-}
-
-private fun initConstraintsFromRSProps(
-    infra: FullInfra,
-    rollingStockIsThermal: Boolean,
-    rollingStockLoadingGauge: RJSLoadingGaugeType,
-    rollingStockSupportedElectrification: List<String>,
-    rollingStockSupportedSignalingSystems: List<String>,
-): List<PathfindingConstraint<Block>> {
-    val res = mutableListOf<PathfindingConstraint<Block>>()
-    if (!rollingStockIsThermal) {
-        res.add(
-            ElectrificationConstraints(
-                infra.blockInfra,
-                infra.rawInfra,
-                rollingStockSupportedElectrification,
-            )
-        )
-    }
-    res.add(LoadingGaugeConstraints(infra.blockInfra, infra.rawInfra, rollingStockLoadingGauge))
-    val sigSystemIds =
-        rollingStockSupportedSignalingSystems.mapNotNull {
-            infra.signalingSimulator.sigModuleManager.findSignalingSystem(it)
-        }
-    res.add(SignalingSystemConstraints(infra.blockInfra, listOf(sigSystemIds)))
-    return res
 }
 
 @Throws(OSRDError::class)

--- a/core/src/main/kotlin/fr/sncf/osrd/pathfinding/constraints/ConstraintCombiner.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/pathfinding/constraints/ConstraintCombiner.kt
@@ -4,6 +4,7 @@ import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.graph.EdgeToRanges
 import fr.sncf.osrd.graph.PathfindingConstraint
 import fr.sncf.osrd.pathfinding.Pathfinding
+import fr.sncf.osrd.railjson.schema.rollingstock.RJSLoadingGaugeType
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.train.RollingStock
 
@@ -22,36 +23,42 @@ class ConstraintCombiner<EdgeT, OffsetType>(
     }
 }
 
-/** Initialize the constraints used to determine whether a block can be explored of not */
+/** Initialize the constraints used to determine whether a block can be explored */
 fun initConstraints(
     fullInfra: FullInfra,
-    rollingStockList: Collection<RollingStock>,
+    rollingStock: RollingStock,
 ): List<PathfindingConstraint<Block>> {
-    if (rollingStockList.isEmpty()) return listOf()
-    assert(rollingStockList.size == 1)
-    val rollingStock = rollingStockList.first()
+    return initConstraintsFromRSProps(
+        fullInfra,
+        rollingStock.isThermal,
+        rollingStock.loadingGaugeType,
+        rollingStock.modeNames.toList(),
+        rollingStock.supportedSignalingSystems.toList(),
+    )
+}
 
-    val loadingGaugeConstraints =
-        LoadingGaugeConstraints(
-            fullInfra.blockInfra,
-            fullInfra.rawInfra,
-            rollingStock.loadingGaugeType,
-        )
-    val signalisationSystemConstraints =
-        makeSignalingSystemConstraints(
-            fullInfra.blockInfra,
-            fullInfra.signalingSimulator,
-            rollingStockList,
-        )
-
-    val res = mutableListOf(loadingGaugeConstraints, signalisationSystemConstraints)
-    if (!rollingStock.isThermal)
+fun initConstraintsFromRSProps(
+    infra: FullInfra,
+    rollingStockIsThermal: Boolean,
+    rollingStockLoadingGauge: RJSLoadingGaugeType,
+    rollingStockSupportedElectrification: List<String>,
+    rollingStockSupportedSignalingSystems: List<String>,
+): List<PathfindingConstraint<Block>> {
+    val res = mutableListOf<PathfindingConstraint<Block>>()
+    if (!rollingStockIsThermal) {
         res.add(
             ElectrificationConstraints(
-                fullInfra.blockInfra,
-                fullInfra.rawInfra,
-                rollingStock.modeNames,
+                infra.blockInfra,
+                infra.rawInfra,
+                rollingStockSupportedElectrification,
             )
         )
+    }
+    res.add(LoadingGaugeConstraints(infra.blockInfra, infra.rawInfra, rollingStockLoadingGauge))
+    val sigSystemIds =
+        rollingStockSupportedSignalingSystems.mapNotNull {
+            infra.signalingSimulator.sigModuleManager.findSignalingSystem(it)
+        }
+    res.add(SignalingSystemConstraints(infra.blockInfra, listOf(sigSystemIds)))
     return res
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/pathfinding/constraints/LoadingGaugeConstraints.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/pathfinding/constraints/LoadingGaugeConstraints.kt
@@ -6,7 +6,6 @@ import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.pathfinding.Pathfinding
 import fr.sncf.osrd.railjson.schema.rollingstock.RJSLoadingGaugeType
 import fr.sncf.osrd.sim_infra.api.*
-import fr.sncf.osrd.utils.DistanceRangeMap
 import fr.sncf.osrd.utils.units.Offset
 
 data class LoadingGaugeConstraints(
@@ -28,12 +27,8 @@ data class LoadingGaugeConstraints(
     ): Collection<Pathfinding.Range<Block>> {
         return path
             .getLoadingGauge()
-            .filter { (_, _, value): DistanceRangeMap.RangeMapEntry<LoadingGaugeConstraint> ->
-                !value.isCompatibleWith(LoadingGaugeTypeId(type.ordinal.toUInt()))
-            }
-            .map { (lower, upper): DistanceRangeMap.RangeMapEntry<LoadingGaugeConstraint> ->
-                Pathfinding.Range(Offset<Block>(lower), Offset(upper))
-            }
             .toSet()
+            .filter { !it.value.isCompatibleWith(LoadingGaugeTypeId(type.ordinal.toUInt())) }
+            .map { (lower, upper) -> Pathfinding.Range(Offset(lower), Offset(upper)) }
     }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
@@ -116,7 +116,7 @@ class STDCMPathfinding(
         runInputSanityChecks()
 
         val constraints =
-            ConstraintCombiner(initConstraints(fullInfra, listOf(rollingStock)).toMutableList())
+            ConstraintCombiner(initConstraints(fullInfra, rollingStock).toMutableList())
 
         assert(steps.last().stop) { "The last stop is supposed to be an actual stop" }
         starts = getStartNodes(graph, listOf(constraints))


### PR DESCRIPTION
Removing risky code dupliation, removing java->kt artifacts, and such