### PR TITLE
front: fix simulation-sheet not downloading on chrome

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResultsExport/SimulationResultsExport.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResultsExport/SimulationResultsExport.tsx
@@ -49,8 +49,17 @@ const exportTrainPDF = async (
 
   const blob = await pdf(doc).toBlob();
   const url = URL.createObjectURL(blob);
-  window.open(url, '_blank');
-  URL.revokeObjectURL(url);
+
+  // Create a temporary link element for better browser compatibility
+  const link = document.createElement('a');
+  link.href = url;
+  link.target = '_blank';
+  link.rel = 'noreferrer';
+  link.click();
+
+  // Keep the blob alive so Chrome viewer can download it later
+  const onPageHide = () => URL.revokeObjectURL(url);
+  window.addEventListener('pagehide', onPageHide, { once: true });
 };
 
 type SimulationResultsExportProps = {


### PR DESCRIPTION
The blob URL was revoked too early, so the PDF viewer could open it but the user couldn't download it afterward.
We know keep the blob URL alive and revoke it only when the user leaves the page (on `pagehide`).

close #13698 