### PR TITLE
front: show errors for NGE → OSRD conversion

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/utils.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/utils.ts
@@ -66,27 +66,23 @@ export const createMacroNode = async (
   node: Omit<MacroNodeResponse, 'id'>,
   ngeNodeId: number
 ) => {
-  try {
-    const createPromise = dispatch(
-      osrdEditoastApi.endpoints.postProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNodes.initiate(
-        {
-          projectId: state.projectId,
-          studyId: state.studyId,
-          scenarioId: state.scenarioId,
-          macroNodeBatchForm: { macro_nodes: [node] },
-        }
-      )
-    );
-    const result = await createPromise.unwrap();
-    const newNode = result.macro_nodes[0];
-    state.indexNodeByKey(newNode.path_item_key, {
-      ...omit(newNode, ['id']),
-      ngeId: ngeNodeId,
-      dbId: newNode.id,
-    });
-  } catch (e) {
-    console.error(e);
-  }
+  const createPromise = dispatch(
+    osrdEditoastApi.endpoints.postProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNodes.initiate(
+      {
+        projectId: state.projectId,
+        studyId: state.studyId,
+        scenarioId: state.scenarioId,
+        macroNodeBatchForm: { macro_nodes: [node] },
+      }
+    )
+  );
+  const result = await createPromise.unwrap();
+  const newNode = result.macro_nodes[0];
+  state.indexNodeByKey(newNode.path_item_key, {
+    ...omit(newNode, ['id']),
+    ngeId: ngeNodeId,
+    dbId: newNode.id,
+  });
 };
 
 export const updateMacroNode = async (
@@ -94,26 +90,22 @@ export const updateMacroNode = async (
   dispatch: AppDispatch,
   node: NodeIndexed
 ) => {
-  try {
-    const indexedNode = state.getNodeByNgeId(node.ngeId);
-    if (!indexedNode) throw new Error(`Node ${node.ngeId} not found`);
-    if (!indexedNode.dbId) throw new Error(`Node ${node.ngeId} is not saved in the DB`);
+  const indexedNode = state.getNodeByNgeId(node.ngeId);
+  if (!indexedNode) throw new Error(`Node ${node.ngeId} not found`);
+  if (!indexedNode.dbId) throw new Error(`Node ${node.ngeId} is not saved in the DB`);
 
-    await dispatch(
-      osrdEditoastApi.endpoints.putProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNodesNodeId.initiate(
-        {
-          projectId: state.projectId,
-          studyId: state.studyId,
-          scenarioId: state.scenarioId,
-          nodeId: indexedNode.dbId,
-          macroNodeForm: node,
-        }
-      )
-    );
-    state.indexNodeByKey(indexedNode.path_item_key, node);
-  } catch (e) {
-    console.error(e);
-  }
+  await dispatch(
+    osrdEditoastApi.endpoints.putProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNodesNodeId.initiate(
+      {
+        projectId: state.projectId,
+        studyId: state.studyId,
+        scenarioId: state.scenarioId,
+        nodeId: indexedNode.dbId,
+        macroNodeForm: node,
+      }
+    )
+  );
+  state.indexNodeByKey(indexedNode.path_item_key, node);
 };
 
 export const deleteMacroNodeByDbId = async (
@@ -121,20 +113,16 @@ export const deleteMacroNodeByDbId = async (
   dispatch: AppDispatch,
   dbId: number
 ) => {
-  try {
-    await dispatch(
-      osrdEditoastApi.endpoints.deleteProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNodesNodeId.initiate(
-        {
-          projectId: state.projectId,
-          studyId: state.studyId,
-          scenarioId: state.scenarioId,
-          nodeId: dbId,
-        }
-      )
-    );
-  } catch (e) {
-    console.error(e);
-  }
+  await dispatch(
+    osrdEditoastApi.endpoints.deleteProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNodesNodeId.initiate(
+      {
+        projectId: state.projectId,
+        studyId: state.studyId,
+        scenarioId: state.scenarioId,
+        nodeId: dbId,
+      }
+    )
+  );
 };
 
 export const deleteMacroNodeByNgeId = async (
@@ -142,13 +130,9 @@ export const deleteMacroNodeByNgeId = async (
   dispatch: AppDispatch,
   ngeId: number
 ) => {
-  try {
-    const indexedNode = state.getNodeByNgeId(ngeId);
-    if (indexedNode?.dbId) await deleteMacroNodeByDbId(state, dispatch, indexedNode.dbId);
-    state.deleteNodeByNgeId(ngeId);
-  } catch (e) {
-    console.error(e);
-  }
+  const indexedNode = state.getNodeByNgeId(ngeId);
+  if (indexedNode?.dbId) await deleteMacroNodeByDbId(state, dispatch, indexedNode.dbId);
+  state.deleteNodeByNgeId(ngeId);
 };
 
 /**

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/utils.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/utils.ts
@@ -163,7 +163,7 @@ export const getSavedMacroNodes = async (
   let reachEnd = false;
   const result: MacroNodeResponse[] = [];
   while (!reachEnd) {
-    const promise = dispatch(
+    const data = await dispatch(
       osrdEditoastApi.endpoints.getProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNodes.initiate(
         {
           projectId,
@@ -174,10 +174,8 @@ export const getSavedMacroNodes = async (
         },
         { subscribe: false }
       )
-    );
-    // need to unsubscribe on get call to avoid cache issue
-    const { data } = await promise;
-    if (data) result.push(...data.results);
+    ).unwrap();
+    result.push(...data.results);
     reachEnd = isNil(data?.next);
     page += 1;
   }

--- a/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
@@ -13,12 +13,14 @@ import ResizableSection from 'common/ResizableSection';
 import Conflicts from 'modules/conflict/components/Conflicts';
 import useConflictsFilter from 'modules/conflict/hooks/useConflictsFilter';
 import ScenarioLoaderMessage from 'modules/scenario/components/ScenarioLoaderMessage';
+import { setFailure } from 'reducers/main';
 import type {
   TimetableItemId,
   TimetableItem,
   TimetableItemToEditData,
 } from 'reducers/osrdconf/types';
 import { useAppDispatch } from 'store';
+import { castErrorToFailure } from 'utils/error';
 import { usePrevious } from 'utils/hooks/state';
 
 import { MANAGE_TIMETABLE_ITEM_TYPES } from '../consts';
@@ -133,17 +135,22 @@ const ScenarioContent = ({ activeBoards }: ScenarioContentProps) => {
     }
   }, [activeBoards.has('macro')]);
 
-  const handleNGEOperation = (event: NGEEvent, netzgrafikDto: NetzgrafikDto) => {
-    handleOperation({
-      event,
-      netzgrafikDto,
-      timetableId: scenario.timetable_id,
-      infraId,
-      state: macroEditorState.current!,
-      dispatch,
-      addUpsertedTimetableItems: upsertTimetableItems,
-      addDeletedTimetableItemIds: removeTimetableItems,
-    });
+  const handleNGEOperation = async (event: NGEEvent, netzgrafikDto: NetzgrafikDto) => {
+    try {
+      await handleOperation({
+        event,
+        netzgrafikDto,
+        timetableId: scenario.timetable_id,
+        infraId,
+        state: macroEditorState.current!,
+        dispatch,
+        addUpsertedTimetableItems: upsertTimetableItems,
+        addDeletedTimetableItemIds: removeTimetableItems,
+      });
+    } catch (err) {
+      console.error(err);
+      dispatch(setFailure(castErrorToFailure(err)));
+    }
   };
 
   const handleNGELoad = () => setNGEIsLoading(false);


### PR DESCRIPTION
If we fail to handle an NGE operation, we log something to the
browser console but don't show anything to the user. Users have
no way to know that something went wrong.

Fix this by opening an error toast. Centralize error handling to
a single spot.

Also check for errors in `getSavedMacroNodes()`.