### PR TITLE
editoast: use OccurrenceId in PacedTrain::into_occurrences()

### DIFF
--- a/editoast/src/models/paced_train.rs
+++ b/editoast/src/models/paced_train.rs
@@ -136,16 +136,18 @@ impl PacedTrain {
     }
 
     /// Returns an iterator over "created" train exceptions with their IDs and schedules.
-    fn get_created_occurrences_exceptions(&self) -> impl Iterator<Item = (TrainId, TrainSchedule)> {
+    fn get_created_occurrences_exceptions(
+        &self,
+    ) -> impl Iterator<Item = (OccurrenceId, TrainSchedule)> {
         self.exceptions
             .iter()
             .filter(|exception| matches!(exception.exception_type, ExceptionType::Created { .. }))
             .map(|exception| {
                 (
-                    TrainId::PacedTrain(OccurrenceId::CreatedException {
+                    OccurrenceId::CreatedException {
                         paced_train_id: self.id,
                         exception_key: exception.key.clone(),
-                    }),
+                    },
                     self.apply_exception(exception),
                 )
             })
@@ -156,14 +158,14 @@ impl PacedTrain {
     }
 
     /// Returns all base train occurrences without any exceptions applied.
-    fn get_base_occurrences(&self) -> Vec<(TrainId, TrainSchedule)> {
+    fn get_base_occurrences(&self) -> Vec<(OccurrenceId, TrainSchedule)> {
         (0..self.num_base_occurrences())
             .map(move |occurrence_idx| {
                 let base_start_time = self.get_occurrence_start_time(occurrence_idx as i32);
-                let train_id = TrainId::PacedTrain(OccurrenceId::BaseOccurrence {
+                let train_id = OccurrenceId::BaseOccurrence {
                     paced_train_id: self.id,
                     index: occurrence_idx as u64,
-                });
+                };
                 let train_schedule = TrainSchedule {
                     start_time: base_start_time,
                     ..self.clone().into_train_schedule()
@@ -182,7 +184,7 @@ impl PacedTrain {
     /// and appends any `Created` exceptions as new trains.
     ///
     /// The result is sorted by `start_time` to reflect the chronological order of the trains.
-    pub fn iter_occurrences(&self) -> impl Iterator<Item = (TrainId, TrainSchedule)> {
+    pub fn iter_occurrences(&self) -> impl Iterator<Item = (OccurrenceId, TrainSchedule)> {
         let mut base_occurrences = self.get_base_occurrences();
 
         let modified_exceptions = self
@@ -200,12 +202,12 @@ impl PacedTrain {
                 if exception.disabled {
                     to_remove[occurrence_index as usize] = true;
                 } else {
-                    let train_id = TrainId::PacedTrain(OccurrenceId::ModifiedException {
+                    let occurrence_id = OccurrenceId::ModifiedException {
                         paced_train_id: self.id,
                         index: occurrence_index as u64,
                         exception_key: exception.key.clone(),
-                    });
-                    *occurrence = (train_id, self.apply_exception(exception));
+                    };
+                    *occurrence = (occurrence_id, self.apply_exception(exception));
                 }
             }
         }
@@ -560,7 +562,7 @@ mod tests {
 
         let paced_train =
             create_paced_train(vec![exception_1.clone(), exception_2.clone(), exception_3]);
-        let occurrences: Vec<(TrainId, schemas::TrainSchedule)> =
+        let occurrences: Vec<(OccurrenceId, schemas::TrainSchedule)> =
             paced_train.iter_occurrences().collect();
 
         assert_eq!(occurrences.len(), 4);
@@ -571,7 +573,7 @@ mod tests {
             .iter()
             .map(|(_, o)| o.train_name.clone())
             .collect();
-        let types: Vec<TrainId> = occurrences.iter().map(|(t, _)| t.clone()).collect();
+        let types: Vec<OccurrenceId> = occurrences.iter().map(|(t, _)| t.clone()).collect();
 
         assert_eq!(
             start_times,

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -552,6 +552,7 @@ pub(in crate::views) async fn conflicts(
     // Concatenate paced trains occurrences with train schedules
     let train_ids: Vec<_> = occurrence_ids
         .into_iter()
+        .map(TrainId::PacedTrain)
         .chain(trains.iter().map(|ts| TrainId::TrainSchedule(ts.id)))
         .collect();
     let start_times = occurrence_trains
@@ -712,7 +713,12 @@ pub(in crate::views) async fn requirements(
     let (train_ids, trains): (Vec<_>, Vec<_>) = trains
         .flat_map(|train| match train {
             Either::Left(ts) => vec![(TrainId::TrainSchedule(ts.id), ts.into())],
-            Either::Right(pt) => pt.iter_occurrences().collect(),
+            Either::Right(pt) => pt
+                .iter_occurrences()
+                .map(|(occurrence_id, train_schedule)| {
+                    (TrainId::PacedTrain(occurrence_id), train_schedule)
+                })
+                .collect(),
         })
         .unzip();
 

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -88,9 +88,6 @@ enum PacedTrainError {
     #[error("Simulation failed for train schedule '{paced_train_id}'")]
     #[editoast_error(status = 404)]
     SimulationFailed { paced_train_id: i64 },
-    #[error("Unexpected train schedule ID in paced train context")]
-    #[editoast_error(status = 500)]
-    UnexpectedTrainScheduleId,
     #[error(transparent)]
     #[editoast_error(status = 500)]
     Database(#[from] editoast_models::Error),
@@ -1226,7 +1223,7 @@ pub(in crate::views) async fn track_occupancy(
     .await?;
 
     // Collect all occurrences from all paced trains using iter_occurrences()
-    let train_occurrences: Vec<(models::paced_train::TrainId, schemas::TrainSchedule)> =
+    let train_occurrences: Vec<(models::paced_train::OccurrenceId, schemas::TrainSchedule)> =
         paced_trains
             .iter()
             .flat_map(|paced_train| paced_train.iter_occurrences())
@@ -1263,43 +1260,36 @@ pub(in crate::views) async fn track_occupancy(
     let all_occupancies: Vec<(String, TrackOccupancy)> = train_occurrences
         .iter()
         .zip(simulations_result)
-        .map(|((train_id, train_schedule), (simulation, pathfinding))| {
-            let occurrence_id: OccurrenceId = match train_id {
-                models::paced_train::TrainId::TrainSchedule(_) => {
-                    return Err(PacedTrainError::UnexpectedTrainScheduleId);
-                }
-                models::paced_train::TrainId::PacedTrain(occurrence_id) => occurrence_id.clone(),
-            };
-
-            Ok(track_occupancy_utils::find_track_occupancy_for_operational_point(
-                &operational_point_id,
-                &operational_point_track_offsets,
-                &path_item_cache,
-                &simulation,
-                &pathfinding,
-                train_schedule,
-            )
-            .into_iter()
-            .map(
-                move |TrackOccupancyResult {
-                          track_section,
-                          time_begin,
-                          duration,
-                      }| {
-                    (
-                        track_section,
-                        TrackOccupancy {
-                            occurrence_id: occurrence_id.clone(),
-                            time_begin,
-                            duration,
-                        },
-                    )
-                },
-            )
-            .collect::<Vec<_>>())
-        })
-        .collect::<Result<Vec<_>, _>>()?
-        .into_iter()
+        .map(
+            |((occurrence_id, train_schedule), (simulation, pathfinding))| {
+                track_occupancy_utils::find_track_occupancy_for_operational_point(
+                    &operational_point_id,
+                    &operational_point_track_offsets,
+                    &path_item_cache,
+                    &simulation,
+                    &pathfinding,
+                    train_schedule,
+                )
+                .into_iter()
+                .map(
+                    move |TrackOccupancyResult {
+                              track_section,
+                              time_begin,
+                              duration,
+                          }| {
+                        (
+                            track_section,
+                            TrackOccupancy {
+                                occurrence_id: occurrence_id.clone(),
+                                time_begin,
+                                duration,
+                            },
+                        )
+                    },
+                )
+                .collect::<Vec<_>>()
+            },
+        )
         .flatten()
         .collect();
 


### PR DESCRIPTION
Since we introduced `OccurrenceId` as a sub-`enum` of `TrainId`, `PacedTrain::into_occurrences()` should use it now. It brings a lot of changes in #13671, but I believe for good reasons.