### PR TITLE
core: improve documentation for some of the project quirks

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -22,7 +22,9 @@ surroundings
 The API itself isn't extensively documented in an openapi file
 or similar (that's one big TODO). Existing endpoints are listed in
 the `WorkerCommand.kt` file, and the inputs/outputs are described
-in their respective classes.
+in their respective classes. Note: some numerical values have their
+own types, such as `Distance`. See their docstring for the
+expected unit and underlying type (generally Long and mm/ms).
 
 
 ## Getting Started
@@ -142,6 +144,10 @@ The most important interfaces/classes are the ones describing the infrastructure
 instead of nested object (the plan being to enable possible future FFI there).
 The downside is that we can't just view object properties in the debugger, but the
 functions in `DebugViewers` can map IDs to nested objects for this purpose.
+
+We do our best to type numerical values, using inlined value types such as `Distance`
+or `Duration`. Type mismatches would fail to compile. Object offsets are typed with
+the reference object, using `Offset<T>`.
 
 Requests processed by the worker can be written to disk by setting these environments
 variables to true: `LOG_STDCM_REQUESTS`, `LOG_PATHFINDING_REQUESTS`,

--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/units/Distance.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/units/Distance.kt
@@ -19,6 +19,14 @@ import fr.sncf.osrd.fast_collections.PrimitiveWrapperCollections
 import fr.sncf.osrd.utils.Direction
 import kotlin.math.absoluteValue
 
+/**
+ * Describes a distance.
+ *
+ * This is an inlined value class: the JVM sees this as a simple Long. When interfacing with Java or
+ * other languages, this is typed as a Long and the unit is millimeters.
+ *
+ * When this appears in a JSON payload, the unit is millimeters typed as a Long.
+ */
 @JvmInline
 value class Distance(val millimeters: Long) : Comparable<Distance> {
     val absoluteValue
@@ -80,6 +88,19 @@ val Double.meters: Distance
 val Int.meters: Distance
     get() = Distance(this.toLong() * 1000)
 
+/**
+ * Describes an offset on a given object. Typing is strictly enforced and mismatches will fail to
+ * compile, though `.cast<T>()` can be used.
+ *
+ * This is an inlined value class: the JVM sees this as a simple Long. When interfacing with Java or
+ * other languages, this is typed as a Long and the unit is millimeters.
+ *
+ * When this appears in a JSON payload, the unit is millimeters typed as a Long.
+ *
+ * Note: projecting an offset from one object to another is an error-prone operation when done by
+ * hand, it's recommended to heavily factorize and test such code. "Train path" classes are
+ * generally meant to handle such projection.
+ */
 @JvmInline
 value class Offset<T>(val distance: Distance) : Comparable<Offset<T>> {
     operator fun plus(value: Distance): Offset<T> {

--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/units/Duration.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/units/Duration.kt
@@ -2,6 +2,14 @@ package fr.sncf.osrd.utils.units
 
 import kotlin.math.absoluteValue
 
+/**
+ * Describes a duration.
+ *
+ * This is an inlined value class: the JVM sees this as a simple Long. When interfacing with Java or
+ * other languages, this is typed as a Long and the unit is milliseconds.
+ *
+ * When this appears in a JSON payload, the unit is milliseconds typed as a Long.
+ */
 @JvmInline
 value class Duration(val milliseconds: Long) : Comparable<Duration> {
 

--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/units/Speed.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/units/Speed.kt
@@ -2,6 +2,15 @@ package fr.sncf.osrd.utils.units
 
 private const val multiplier = 1000.0
 
+/**
+ * Describes a speed.
+ *
+ * This is an inlined value class (where the inner type is itself an inlined value class). The JVM
+ * sees this as a simple Long. When interfacing with Java or other languages, this is typed as a
+ * Long and the unit is millimeters.
+ *
+ * When this appears in a JSON payload, the unit is mm/s typed as a Long.
+ */
 @JvmInline
 value class Speed(val millimetersPerSecond: ULong) : Comparable<Speed> {
     val metersPerSecond


### PR DESCRIPTION
Some aspects of the projects can be not intuitive, and can't be deduced from context alone where they're used. Numerical types in particular.


This PR documents some of it, in the README and in docstrings of such classes. 


I thought I'd also talk about `RawInfra` / `BlockInfra` in the README, but there's already a few sentences there. 