### PR TITLE
core: paths: migrate from RangeMaps to lists of range

### DIFF
--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathBuilder.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathBuilder.kt
@@ -1,19 +1,16 @@
 package fr.sncf.osrd.path.implementations
 
-import com.google.common.collect.BoundType
-import com.google.common.collect.ImmutableRangeMap
-import com.google.common.collect.Range
 import fr.sncf.osrd.path.interfaces.*
 import fr.sncf.osrd.path.legacy_objects.ElectricalProfileMapping
 import fr.sncf.osrd.sim_infra.api.*
-import fr.sncf.osrd.utils.entries
+import fr.sncf.osrd.utils.indexing.DirStaticIdx
+import fr.sncf.osrd.utils.indexing.StaticIdx
 import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.Offset.Companion.max
 import fr.sncf.osrd.utils.units.Offset.Companion.min
 import fr.sncf.osrd.utils.units.meters
 import fr.sncf.osrd.utils.units.sumOffsets
-import fr.sncf.osrd.utils.values
 
 /**
  * This file lists all usual builder functions to generate train paths, with useful private methods
@@ -34,15 +31,20 @@ fun buildTrainPathFromBlock(
     routeNames: List<String>? = null,
     electricalProfileMapping: ElectricalProfileMapping? = null,
 ): TrainPath {
-    val blockMap =
-        ImmutableRangeMap.of(
-            Range.closed(Offset<TrainPath>(0.meters), Offset(endOffset - beginOffset)),
-            BlockRange(blockId, beginOffset, endOffset),
+    val blockList =
+        listOf(
+            BlockRange(
+                blockId,
+                beginOffset,
+                endOffset,
+                Offset.zero(),
+                Offset(endOffset - beginOffset),
+            )
         )
     return buildTrainPathFromBlockRanges(
         rawInfra,
         blockInfra,
-        blockMap,
+        blockList,
         routes,
         routeNames,
         electricalProfileMapping,
@@ -59,20 +61,24 @@ fun buildTrainPathFromBlocks(
     electricalProfileMapping: ElectricalProfileMapping? = null,
 ): TrainPath {
     var prevBlockFinalOffset: Offset<TrainPath> = Offset.zero()
-    val builder = ImmutableRangeMap.builder<Offset<TrainPath>, BlockRange>()
+    val blockRanges = mutableListOf<BlockRange>()
     for (block in blocks) {
         val blockLength = blockInfra.getBlockLength(block)
-        builder.put(
-            Range.closedOpen(prevBlockFinalOffset, prevBlockFinalOffset + blockLength.distance),
-            BlockRange(block, Offset.zero(), blockLength),
+        blockRanges.add(
+            BlockRange(
+                block,
+                Offset.zero(),
+                blockLength,
+                prevBlockFinalOffset,
+                prevBlockFinalOffset + blockLength.distance,
+            )
         )
         prevBlockFinalOffset += blockLength.distance
     }
-    val blockMap = builder.build()
     return buildTrainPathFromBlockRanges(
         rawInfra,
         blockInfra,
-        blockMap,
+        blockRanges,
         routes,
         routeNames,
         electricalProfileMapping,
@@ -83,23 +89,23 @@ fun buildTrainPathFromBlocks(
 fun buildTrainPathFromBlockRanges(
     rawInfra: RawInfra,
     blockInfra: BlockInfra,
-    blockRanges: LinearObjectMap<BlockRange>,
+    blockRanges: List<BlockRange>,
     routes: List<RouteId>? = null,
     routeNames: List<String>? = null,
     electricalProfileMapping: ElectricalProfileMapping? = null,
     haveApproximateBlocks: Boolean = false,
 ): TrainPath {
     require(routes == null || routeNames == null)
-    val chunkMap = generateTrackChunks(rawInfra, blockInfra, blockRanges)
+    val chunks = generateTrackChunks(rawInfra, blockInfra, blockRanges)
     val routeIds = routes ?: routeNames?.map { rawInfra.getRouteFromName(it) }
-    val routeMap = routeIds?.let { generateRouteRanges(rawInfra, chunkMap, it) }
+    val routes = routeIds?.let { generateRouteRanges(rawInfra, chunks, it) }
     return TrainPathNoBacktrack(
         rawInfra,
         blockInfra,
-        makePathProperties(rawInfra, buildChunkPath(rawInfra, chunkMap), routeIds),
-        routeMap,
+        makePathProperties(rawInfra, buildChunkPath(rawInfra, chunks), routeIds),
+        routes,
         blockRanges,
-        chunkMap,
+        chunks,
         electricalProfileMapping,
         haveApproximateBlocks = haveApproximateBlocks,
     )
@@ -112,7 +118,7 @@ fun buildTrainPathFromBlockRanges(
 fun buildTrainPathFromChunks(
     rawInfra: RawInfra,
     blockInfra: BlockInfra,
-    chunkRanges: LinearObjectMap<DirChunkRange>,
+    chunkRanges: List<DirChunkRange>,
     routes: List<RouteId>? = null,
     routeNames: List<String>? = null,
     electricalProfileMapping: ElectricalProfileMapping? = null,
@@ -141,7 +147,7 @@ fun buildTrainPathFromChunkPath(
     routeNames: List<String>? = null,
     electricalProfileMapping: ElectricalProfileMapping? = null,
 ): TrainPath {
-    val chunkRanges = mutableListOf<DirChunkRange>()
+    val chunkRanges = mutableListOf<PartialDirChunkRange>()
     var prevChunkFinalOffset = 0.meters
     for ((i, chunk) in chunkPath.chunks.withIndex()) {
         val isFirst = i == 0
@@ -150,85 +156,72 @@ fun buildTrainPathFromChunkPath(
         val from = if (isFirst) chunkPath.beginOffset.cast<TrackChunk>() else Offset.zero()
         var to = chunkLength
         if (isLast) to = Offset(chunkPath.endOffset.distance - prevChunkFinalOffset)
-        chunkRanges.add(DirChunkRange(chunk, from, to))
+        chunkRanges.add(PartialDirChunkRange(chunk, from, to))
         prevChunkFinalOffset += chunkLength.distance
     }
     return buildTrainPathFromChunks(
         rawInfra,
         blockInfra,
-        buildRangeMap(chunkRanges),
+        buildRangeList(chunkRanges),
         routes,
         routeNames,
         electricalProfileMapping,
     )
 }
 
-/** Create a range map from list of ranges, mapping them to the path offset (starting at 0). */
-fun <ValueType, OffsetType> buildRangeMap(
-    ranges: List<GenericLinearRange<ValueType, OffsetType>>
-): LinearObjectMap<GenericLinearRange<ValueType, OffsetType>> {
+/** Create a list of ranges from a list of partial ranges, mapping path offsets (starting at 0). */
+fun <ValueType, OffsetType> buildRangeList(
+    ranges: List<PartialGenericLinearRange<ValueType, OffsetType>>
+): List<GenericLinearRange<ValueType, OffsetType>> {
     // Merge adjacent ranges of the same object
-    val merged = mutableListOf<GenericLinearRange<ValueType, OffsetType>>()
+    val merged = mutableListOf<PartialGenericLinearRange<ValueType, OffsetType>>()
     for (range in ranges) {
         if (merged.isEmpty() || merged.last().value != range.value) merged.add(range)
-        else merged[merged.size - 1] = merged.last().copy(to = range.to)
-    }
-
-    // We need to adjust which intervals are closed or open to keep 0-length ranges
-    val zeroLengthIndexes = merged.map { it.from == it.to }
-    for ((i, isZeroLength) in zeroLengthIndexes.withIndex()) {
-        // This case *could* be supported, but it's a sign something is likely to be wrong.
-        // The test can be removed if we need to support it, in the meantime it's a good smoke test.
-        assert(!isZeroLength || i == 0 || i == zeroLengthIndexes.size - 1) {
-            "Zero length range that isn't first or last"
-        }
+        else merged[merged.lastIndex] = merged.last().copy(objectEnd = range.objectEnd)
     }
 
     var prevRangeLength: Offset<TrainPath> = Offset.zero()
-    val builder =
-        ImmutableRangeMap.builder<Offset<TrainPath>, GenericLinearRange<ValueType, OffsetType>>()
-    for ((i, value) in merged.withIndex()) {
-        // In normal cases, we always include lower bound and never include upper bound.
-        // Exceptions: the very first and last bounds are included, and a zero-length range is
-        // included in both directions. The next range then needs to have its lower bound excluded.
-        // Two consecutive zero-length ranges are not supported.
-        val includeLowerEndpoint = i == 0 || !zeroLengthIndexes[i - 1]
-        val includeUpperEndpoint = i == merged.size - 1 || zeroLengthIndexes[i]
-        fun mapBoundType(included: Boolean) = if (included) BoundType.CLOSED else BoundType.OPEN
-        val range =
-            Range.range(
+    val res = mutableListOf<GenericLinearRange<ValueType, OffsetType>>()
+    for (range in merged) {
+        res.add(
+            GenericLinearRange(
+                range.value,
+                range.objectBegin,
+                range.objectEnd,
                 prevRangeLength,
-                mapBoundType(includeLowerEndpoint),
-                prevRangeLength + value.length,
-                mapBoundType(includeUpperEndpoint),
+                prevRangeLength + range.length,
             )
-        builder.put(range, value)
-        prevRangeLength += value.length
+        )
+        prevRangeLength += range.length
     }
-    return builder.build()
+    return res
 }
 
 /** Generate the chunk ranges from given block ranges. */
 private fun generateTrackChunks(
     rawInfra: RawInfra,
     blockInfra: BlockInfra,
-    blocks: LinearObjectMap<BlockRange>,
-): LinearObjectMap<DirChunkRange> {
-    val res = mutableListOf<DirChunkRange>()
-    for (blockRange in blocks.values) {
+    blocks: List<BlockRange>,
+): List<DirChunkRange> {
+    val res = mutableListOf<PartialDirChunkRange>()
+    for (blockRange in blocks) {
         var currentChunkOffset = Offset<Block>(0.meters)
         for (chunk in blockInfra.getTrackChunksFromBlock(blockRange.value)) {
             val chunkLength = rawInfra.getTrackChunkLength(chunk.value)
 
-            val chunkStart = Offset<TrackChunk>(blockRange.from - currentChunkOffset)
-            val chunkEnd = Offset<TrackChunk>(blockRange.to - currentChunkOffset)
+            val chunkStart = Offset<TrackChunk>(blockRange.objectBegin - currentChunkOffset)
+            val chunkEnd = Offset<TrackChunk>(blockRange.objectEnd - currentChunkOffset)
             if (
                 chunkStart <= chunkEnd &&
                     Offset.zero<TrackChunk>() <= chunkEnd &&
                     chunkStart <= chunkLength
             ) {
                 val chunkRange =
-                    DirChunkRange(chunk, max(chunkStart, Offset.zero()), min(chunkEnd, chunkLength))
+                    PartialDirChunkRange(
+                        chunk,
+                        max(chunkStart, Offset.zero()),
+                        min(chunkEnd, chunkLength),
+                    )
                 res.add(chunkRange)
             }
 
@@ -237,11 +230,11 @@ private fun generateTrackChunks(
     }
 
     // We need to filter out zero-length ranges that aren't first or last
-    val filtered = mutableListOf<DirChunkRange>()
+    val filtered = mutableListOf<PartialDirChunkRange>()
     for ((i, chunkRange) in res.withIndex()) {
         if (i == 0 || i == res.size - 1 || chunkRange.length > 0.meters) filtered.add(chunkRange)
     }
-    return buildRangeMap(filtered)
+    return buildRangeList(filtered)
 }
 
 /**
@@ -250,11 +243,11 @@ private fun generateTrackChunks(
  */
 internal fun generateRouteRanges(
     rawInfra: RawInfra,
-    chunks: LinearObjectMap<DirChunkRange>,
+    chunks: List<DirChunkRange>,
     routes: List<RouteId>,
-): LinearObjectMap<RouteRange> {
-    val res = mutableListOf<RouteRange>()
-    val mappedChunks = chunks.values.associateBy { it.value }
+): List<RouteRange> {
+    val res = mutableListOf<PartialRouteRange>()
+    val mappedChunks = chunks.associateBy { it.value }
     for (route in routes) {
         // We look for the first and last point where the route is used by a chunk.
         // We assume that the chunk list is continuous and follows the route.
@@ -266,30 +259,29 @@ internal fun generateRouteRanges(
         for (chunk in chunksOnRoute) {
             mappedChunks[chunk]?.let { locatedChunk ->
                 usedRouteStart =
-                    min(usedRouteStart, chunkOffsetOnRoute + locatedChunk.from.distance)
-                usedRouteEnd = max(usedRouteEnd, chunkOffsetOnRoute + locatedChunk.to.distance)
+                    min(usedRouteStart, chunkOffsetOnRoute + locatedChunk.objectBegin.distance)
+                usedRouteEnd =
+                    max(usedRouteEnd, chunkOffsetOnRoute + locatedChunk.objectEnd.distance)
             }
             chunkOffsetOnRoute += rawInfra.getTrackChunkLength(chunk.value).distance
         }
 
         val usedRouteLength = usedRouteEnd - usedRouteStart
         if (usedRouteLength > 0.meters) {
-            res.add(RouteRange(route, usedRouteStart, usedRouteEnd))
+            res.add(PartialRouteRange(route, usedRouteStart, usedRouteEnd))
         }
     }
-    return buildRangeMap(res)
+    return buildRangeList(res)
 }
 
 /**
  * Build a ChunkPath from the given chunk ranges. Used to instantiate the internal `PathProperties`
  * instance.
  */
-private fun buildChunkPath(infra: RawInfra, chunkMap: LinearObjectMap<DirChunkRange>): ChunkPath {
-    val chunkRanges = chunkMap.values
-    val chunkIds = chunkRanges.map { it.value }
-    val beginOffset = chunkRanges.first().from
-    val endOffset =
-        beginOffset + (chunkMap.span().upperEndpoint() - chunkMap.span().lowerEndpoint())
+private fun buildChunkPath(infra: RawInfra, chunks: List<DirChunkRange>): ChunkPath {
+    val chunkIds = chunks.map { it.value }
+    val beginOffset = chunks.first().objectBegin
+    val endOffset = beginOffset + (chunks.last().pathEnd - chunks.first().pathBegin)
     return buildChunkPath(infra, chunkIds, beginOffset.cast(), endOffset.cast())
 }
 
@@ -303,11 +295,10 @@ private fun buildChunkPath(infra: RawInfra, chunkMap: LinearObjectMap<DirChunkRa
 private fun findBlockPath(
     infra: RawInfra,
     blockInfra: BlockInfra,
-    chunks: LinearObjectMap<DirChunkRange>,
-): LinearObjectMap<BlockRange> {
-    val res = mutableListOf<BlockRange>()
-    for (chunkEntry in chunks.entries) {
-        val dirChunkRange = chunkEntry.value
+    chunks: List<DirChunkRange>,
+): List<BlockRange> {
+    val res = mutableListOf<PartialBlockRange>()
+    for (dirChunkRange in chunks) {
         val dirChunkId = dirChunkRange.value
         val block =
             blockInfra.getBlocksFromTrackChunk(dirChunkId.value, dirChunkId.direction).first()
@@ -319,12 +310,33 @@ private fun findBlockPath(
                 .sumOffsets()
                 .cast<Block>()
         val newRange =
-            BlockRange(
+            PartialBlockRange(
                 block,
-                chunkOffsetOnBlock + dirChunkRange.from.distance,
-                chunkOffsetOnBlock + dirChunkRange.to.distance,
+                chunkOffsetOnBlock + dirChunkRange.objectBegin.distance,
+                chunkOffsetOnBlock + dirChunkRange.objectEnd.distance,
             )
         res.add(newRange)
     }
-    return buildRangeMap(res)
+    return buildRangeList(res)
 }
+
+/**
+ * Intermediate object used to build lists of `GenericLinearRange`. The path offsets aren't set yet.
+ */
+data class PartialGenericLinearRange<ValueType, OffsetType>(
+    val value: ValueType,
+    val objectBegin: Offset<OffsetType>,
+    val objectEnd: Offset<OffsetType>,
+) {
+    val length = objectEnd - objectBegin
+}
+
+typealias PartialLinearObjectRange<T> = PartialGenericLinearRange<StaticIdx<T>, T>
+
+typealias PartialLinearDirObjectRange<T> = PartialGenericLinearRange<DirStaticIdx<T>, T>
+
+typealias PartialRouteRange = PartialLinearObjectRange<Route>
+
+typealias PartialBlockRange = PartialLinearObjectRange<Block>
+
+typealias PartialDirChunkRange = PartialLinearDirObjectRange<TrackChunk>

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathBuilder.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathBuilder.kt
@@ -203,38 +203,18 @@ private fun generateTrackChunks(
     blockInfra: BlockInfra,
     blocks: List<BlockRange>,
 ): List<DirChunkRange> {
-    val res = mutableListOf<PartialDirChunkRange>()
-    for (blockRange in blocks) {
-        var currentChunkOffset = Offset<Block>(0.meters)
-        for (chunk in blockInfra.getTrackChunksFromBlock(blockRange.value)) {
-            val chunkLength = rawInfra.getTrackChunkLength(chunk.value)
-
-            val chunkStart = Offset<TrackChunk>(blockRange.objectBegin - currentChunkOffset)
-            val chunkEnd = Offset<TrackChunk>(blockRange.objectEnd - currentChunkOffset)
-            if (
-                chunkStart <= chunkEnd &&
-                    Offset.zero<TrackChunk>() <= chunkEnd &&
-                    chunkStart <= chunkLength
-            ) {
-                val chunkRange =
-                    PartialDirChunkRange(
-                        chunk,
-                        max(chunkStart, Offset.zero()),
-                        min(chunkEnd, chunkLength),
-                    )
-                res.add(chunkRange)
-            }
-
-            currentChunkOffset += chunkLength.distance
-        }
-    }
-
+    val res =
+        mapSubObjects(
+            blocks,
+            blockInfra::getTrackChunksFromBlock,
+            { rawInfra.getTrackChunkLength(it.value) },
+        )
     // We need to filter out zero-length ranges that aren't first or last
-    val filtered = mutableListOf<PartialDirChunkRange>()
+    val filtered = mutableListOf<DirChunkRange>()
     for ((i, chunkRange) in res.withIndex()) {
         if (i == 0 || i == res.size - 1 || chunkRange.length > 0.meters) filtered.add(chunkRange)
     }
-    return buildRangeList(filtered)
+    return filtered
 }
 
 /**

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathImpl.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathImpl.kt
@@ -1,13 +1,11 @@
 package fr.sncf.osrd.path.implementations
 
 import com.google.common.collect.ImmutableRangeMap
-import com.google.common.collect.Range
 import com.google.common.collect.RangeMap
 import fr.sncf.osrd.path.interfaces.*
 import fr.sncf.osrd.path.legacy_objects.ElectricalProfileMapping
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.sim_infra.impl.makeDirChunk
-import fr.sncf.osrd.utils.entries
 import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
@@ -23,9 +21,9 @@ data class TrainPathNoBacktrack(
     private val rawInfra: RawInfra,
     private val blockInfra: BlockInfra,
     private val pathProperties: PathProperties,
-    private val routes: LinearObjectMap<RouteRange>?,
-    private val blocks: LinearObjectMap<BlockRange>,
-    private val chunks: LinearObjectMap<DirChunkRange>,
+    private val routes: List<RouteRange>?,
+    private val blocks: List<BlockRange>,
+    private val chunks: List<DirChunkRange>,
     private val electricalProfileMapping: ElectricalProfileMapping?,
     // Set to true if the blocks have been generated from the track path. Throws an error if the
     // routes are read. Note: we may eventually want to turn the error into a warning, if we do want
@@ -39,24 +37,25 @@ data class TrainPathNoBacktrack(
     init {
         // The sanity checks here are quite exhaustive and might be expensive to compute.
         // Once the path types are stable, we can remove some of the tests.
-        fun <ValueType, OffsetType> checkRangeMap(
-            map: LinearObjectMap<GenericLinearRange<ValueType, OffsetType>>,
+        fun <ValueType, OffsetType> checkRangeList(
+            list: List<GenericLinearRange<ValueType, OffsetType>>,
             objectLength: (ValueType) -> Length<OffsetType>,
         ) {
-            for ((key, value) in map.entries) {
-                require(value.length == (key.upperEndpoint() - key.lowerEndpoint()))
-                require(value.from >= Offset.zero())
-                require(value.to <= objectLength(value.value))
+            var previousRange: GenericLinearRange<ValueType, OffsetType>? = null
+            for (range in list) {
+                previousRange?.let { require(range.pathBegin == it.pathEnd) }
+                require(range.objectBegin >= Offset.zero())
+                require(range.objectEnd <= objectLength(range.value))
+                previousRange = range
             }
-            require(map.span().lowerEndpoint() == Offset.zero<TrainPath>())
-            require(map.span().upperEndpoint() == getTypedLength())
+            require(list.first().pathBegin == Offset.zero<TrainPath>())
+            require(list.last().pathEnd == getTypedLength())
         }
         routes?.let {
-            if (!routes.asMapOfRanges().isEmpty())
-                checkRangeMap(routes) { rawInfra.getRouteLength(it) }
+            if (!routes.isEmpty()) checkRangeList(routes) { rawInfra.getRouteLength(it) }
         }
-        checkRangeMap(blocks) { blockInfra.getBlockLength(it) }
-        checkRangeMap(chunks) { rawInfra.getTrackChunkLength(it.value) }
+        checkRangeList(blocks) { blockInfra.getBlockLength(it) }
+        checkRangeList(chunks) { rawInfra.getTrackChunkLength(it.value) }
     }
 
     override fun subPath(from: Offset<TrainPath>?, to: Offset<TrainPath>?): TrainPath {
@@ -66,9 +65,9 @@ data class TrainPathNoBacktrack(
             rawInfra = rawInfra,
             blockInfra = blockInfra,
             pathProperties = PathPropertiesView(pathProperties, fromDist.cast(), toDist.cast()),
-            routes = routes?.let { linearObjectSubMap(it, fromDist, toDist) },
-            blocks = linearObjectSubMap(blocks, fromDist, toDist),
-            chunks = linearObjectSubMap(chunks, fromDist, toDist),
+            routes = routes?.let { linearObjectListSubRange(it, fromDist, toDist) },
+            blocks = linearObjectListSubRange(blocks, fromDist, toDist),
+            chunks = linearObjectListSubRange(chunks, fromDist, toDist),
             electricalProfileMapping = electricalProfileMapping,
             haveApproximateBlocks = haveApproximateBlocks,
         )
@@ -78,14 +77,14 @@ data class TrainPathNoBacktrack(
         return Length(getLength())
     }
 
-    override fun getBlocks(): LinearObjectMap<BlockRange> {
+    override fun getBlocks(): List<BlockRange> {
         require(!haveApproximateBlocks)
         return blocks
     }
 
-    override fun getRoutes(): LinearObjectMap<RouteRange> = routes!!
+    override fun getRoutes(): List<RouteRange> = routes!!
 
-    override fun getChunks(): LinearObjectMap<DirChunkRange> = chunks
+    override fun getChunks(): List<DirChunkRange> = chunks
 
     override val length: Double
         get() = pathProperties.getLength().meters
@@ -116,47 +115,28 @@ data class TrainPathNoBacktrack(
         return EnvelopeTrainPath.from(rawInfra, this, electricalProfileMapping)
     }
 
-    /** Truncate the distance range maps of linear objects, updating the underlying object range */
-    private fun <ValueType, OffsetType> linearObjectSubMap(
-        map: LinearObjectMap<GenericLinearRange<ValueType, OffsetType>>,
+    /** Truncate the list of linear objects, updating the underlying object ranges */
+    private fun <ValueType, OffsetType> linearObjectListSubRange(
+        list: List<GenericLinearRange<ValueType, OffsetType>>,
         from: Offset<TrainPath>,
         to: Offset<TrainPath>,
-    ): LinearObjectMap<GenericLinearRange<ValueType, OffsetType>> {
+    ): List<GenericLinearRange<ValueType, OffsetType>> {
         require(from >= Offset.zero())
         require(to <= getTypedLength())
-        val newMapEntries =
-            map.entries.mapNotNull { (key, value) ->
-                val lower = key.lowerEndpoint()
-                val upper = key.upperEndpoint()
-                val truncatedStart = max(from, lower)
-                val truncatedEnd = min(to, upper)
+        return list.mapNotNull { (value, objectBegin, objectEnd, pathBegin, pathEnd) ->
+            val truncatedStart = max(from, pathBegin)
+            val truncatedEnd = min(to, pathEnd)
 
-                if (truncatedStart > truncatedEnd) return@mapNotNull null
+            if (truncatedStart > truncatedEnd) return@mapNotNull null
 
-                val value =
-                    value.copy(
-                        from = value.from + (truncatedStart - lower),
-                        to = value.to - (upper - truncatedEnd),
-                    )
-                val key =
-                    Range.range(
-                        truncatedStart - from.distance,
-                        key.lowerBoundType(),
-                        truncatedEnd - from.distance,
-                        key.upperBoundType(),
-                    )
-                if (key.isEmpty) return@mapNotNull null
-                Pair(key, value)
-            }
-        val builder =
-            ImmutableRangeMap.builder<
-                Offset<TrainPath>,
-                GenericLinearRange<ValueType, OffsetType>,
-            >()
-        for ((key, value) in newMapEntries) {
-            builder.put(key, value)
+            GenericLinearRange(
+                value = value,
+                objectBegin = objectBegin + (truncatedStart - pathBegin),
+                objectEnd = objectEnd - (pathEnd - truncatedEnd),
+                pathBegin = truncatedStart - from.distance,
+                pathEnd = truncatedEnd - from.distance,
+            )
         }
-        return builder.build()
     }
 
     override fun withRoutes(routes: List<RouteId>): TrainPath {
@@ -166,28 +146,36 @@ data class TrainPathNoBacktrack(
 
     /** *Debugging purpose*. We try to find the actual names of underlying objects. */
     override fun toString(): String {
-        data class PrintableRange<T>(val from: Distance, val to: Distance, val value: T) {
+        data class PrintableRange<T>(
+            val objectBegin: Distance,
+            val objectEnd: Distance,
+            val pathBegin: Distance,
+            val pathEnd: Distance,
+            val value: T,
+        ) {
             override fun toString(): String {
-                return "($value[$from,$to])"
+                return "(path[$pathBegin;$pathEnd]:$value[$objectBegin,$objectEnd])"
             }
         }
-        fun <T, U> mapToPrintable(
-            map: LinearObjectMap<GenericLinearRange<T, U>>?,
+        fun <T, U> listToPrintable(
+            list: List<GenericLinearRange<T, U>>?,
             toPrintable: (T) -> String,
         ): String {
-            return map?.asMapOfRanges()
-                ?.mapValues {
+            return list
+                ?.map {
                     PrintableRange(
-                        it.value.from.distance,
-                        it.value.to.distance,
-                        toPrintable(it.value.value),
+                        it.objectBegin.distance,
+                        it.objectEnd.distance,
+                        it.pathBegin.distance,
+                        it.pathEnd.distance,
+                        toPrintable(it.value),
                     )
                 }
                 .toString()
         }
-        val chunks = mapToPrintable(chunks) { makeDirChunk(rawInfra, it).toString() }
-        val blocks = mapToPrintable(blocks) { "block=${it.index.toInt()}" }
-        val routes = mapToPrintable(routes) { rawInfra.getRouteName(it) }
+        val chunks = listToPrintable(chunks) { makeDirChunk(rawInfra, it).toString() }
+        val blocks = listToPrintable(blocks) { "block=${it.index.toInt()}" }
+        val routes = listToPrintable(routes) { rawInfra.getRouteName(it) }
         return "$chunks ; blocks=$blocks ; routes=$routes"
     }
 }

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/GenericLinearRange.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/GenericLinearRange.kt
@@ -1,0 +1,172 @@
+package fr.sncf.osrd.path.interfaces
+
+import fr.sncf.osrd.sim_infra.api.Block
+import fr.sncf.osrd.sim_infra.api.Route
+import fr.sncf.osrd.sim_infra.api.TrackChunk
+import fr.sncf.osrd.sim_infra.api.Zone
+import fr.sncf.osrd.sim_infra.api.ZonePath
+import fr.sncf.osrd.utils.indexing.DirStaticIdx
+import fr.sncf.osrd.utils.indexing.StaticIdx
+import fr.sncf.osrd.utils.units.Length
+import fr.sncf.osrd.utils.units.Offset
+import fr.sncf.osrd.utils.units.Offset.Companion.max
+import fr.sncf.osrd.utils.units.Offset.Companion.min
+import fr.sncf.osrd.utils.units.meters
+
+/**
+ * Describes an object range on the train path. Located on both the object itself, and the global
+ * train path. Can be used to convert offsets back and forth.
+ */
+data class GenericLinearRange<ValueType, OffsetType>(
+    /** Underlying object ID. Generally `StaticIdx<T>` or `DirStaticIdx<T>`. */
+    val value: ValueType,
+    /** Start of the range, compared to the start of the underlying object. */
+    val objectBegin: Offset<OffsetType>,
+    /** End of the range, compared to the start of the underlying object. */
+    val objectEnd: Offset<OffsetType>,
+    /** Start of the range, compared to the start of the train path. */
+    val pathBegin: Offset<TrainPath>,
+    /** End of the range, compared to the start of the train path. */
+    val pathEnd: Offset<TrainPath>,
+) {
+    val length = objectEnd - objectBegin
+
+    init {
+        require(length >= 0.meters)
+        require(pathEnd - pathBegin == length)
+    }
+
+    fun isSinglePoint() = length == 0.meters
+
+    /** Where the object begins on the path, not just the range. May be negative. */
+    fun getObjectAbsolutePathStart() = pathBegin - objectBegin.distance
+
+    /** Where the object ends on the path, not just the range. May be larger than path length. */
+    fun getObjectAbsolutePathEnd(objectLength: Length<OffsetType>): Offset<TrainPath> {
+        return getObjectAbsolutePathStart() + objectLength.distance
+    }
+
+    /** Converts a train path offset into an object offset. */
+    fun offsetFromTrainPath(pathOffset: Offset<TrainPath>): Offset<OffsetType> {
+        val objectStart = getObjectAbsolutePathStart()
+        return Offset(pathOffset.distance - objectStart.distance)
+    }
+
+    /** Converts an object offset into a train path offset. */
+    fun offsetToTrainPath(objectOffset: Offset<OffsetType>): Offset<TrainPath> {
+        val objectStart = getObjectAbsolutePathStart()
+        return objectStart + objectOffset.distance
+    }
+
+    /**
+     * Truncates the range. Returns a new instance only containing the intersection with the given
+     * train path range.
+     */
+    fun withTruncatedPathRange(
+        from: Offset<TrainPath>,
+        to: Offset<TrainPath>,
+    ): GenericLinearRange<ValueType, OffsetType>? {
+        val newPathBegin = max(from, pathBegin)
+        val newPathEnd = min(to, pathEnd)
+        if (newPathBegin > newPathEnd) return null
+        val removedAtStart = newPathBegin - pathBegin
+        val removedAtEnd = pathEnd - newPathEnd
+        return GenericLinearRange(
+            value,
+            objectBegin + removedAtStart,
+            objectEnd - removedAtEnd,
+            newPathBegin,
+            newPathEnd,
+        )
+    }
+
+    /**
+     * When the given object (`this.value`) can be seen as a sequence of smaller objects, this
+     * method turns an outer object range into a list of inner object ranges.
+     *
+     * For example, this can turn a route range into a list of block ranges.
+     */
+    fun <SubObjectType, SubObjectOffset> mapSubObject(
+        subObjectList: List<SubObjectType>,
+        getSubObjectLength: (SubObjectType) -> Offset<SubObjectOffset>,
+    ): List<GenericLinearRange<SubObjectType, SubObjectOffset>> {
+        var prevObjectEndPathOffset: Offset<TrainPath> = pathBegin - objectBegin.distance
+        val res = mutableListOf<GenericLinearRange<SubObjectType, SubObjectOffset>>()
+        for (subObject in subObjectList) {
+            val subObjectLength = getSubObjectLength(subObject)
+            val subObjectRange =
+                GenericLinearRange(
+                    subObject,
+                    Offset.zero(),
+                    subObjectLength,
+                    prevObjectEndPathOffset,
+                    prevObjectEndPathOffset + subObjectLength.distance,
+                )
+            val truncated = subObjectRange.withTruncatedPathRange(pathBegin, pathEnd)
+            if (truncated != null) res.add(truncated)
+            prevObjectEndPathOffset += subObjectLength.distance
+        }
+        return res
+    }
+
+    /** Maps the value, while keeping all offsets identical. */
+    fun <T, NewOffsetType> mapValue(value: T): GenericLinearRange<T, NewOffsetType> {
+        return GenericLinearRange(value, objectBegin.cast(), objectEnd.cast(), pathBegin, pathEnd)
+    }
+}
+
+typealias LinearObjectRange<T> = GenericLinearRange<StaticIdx<T>, T>
+
+typealias LinearDirObjectRange<T> = GenericLinearRange<DirStaticIdx<T>, T>
+
+typealias RouteRange = LinearObjectRange<Route>
+
+typealias BlockRange = LinearObjectRange<Block>
+
+typealias ZoneRange = LinearObjectRange<Zone>
+
+typealias ZonePathRange = LinearObjectRange<ZonePath>
+
+typealias DirChunkRange = LinearDirObjectRange<TrackChunk>
+
+/**
+ * Takes a list of ranges, returns a new list of ranges where adjacent ranges of the same object
+ * have been merged together.
+ */
+fun <ValueType, OffsetType> mergeLinearRanges(
+    vararg rangeLists: List<GenericLinearRange<ValueType, OffsetType>>
+): List<GenericLinearRange<ValueType, OffsetType>> {
+    val res = mutableListOf<GenericLinearRange<ValueType, OffsetType>>()
+    var last: GenericLinearRange<ValueType, OffsetType>? = null
+    for (rangeList in rangeLists) {
+        for (entry in rangeList) {
+            if (last?.value == entry.value) {
+                assert(last.pathBegin <= entry.pathBegin)
+                assert(last.objectBegin <= entry.objectBegin)
+                last = last.copy(pathEnd = entry.pathEnd, objectEnd = entry.objectEnd)
+            } else {
+                last?.let { res.add(it) }
+                last = entry
+            }
+        }
+    }
+    last?.let { res.add(it) }
+    return res
+}
+
+/**
+ * When an outer object can be mapped to a list of inner objects (e.g. route to list of zone paths):
+ * this takes a list of outer object ranges, and maps it to a list of inner object ranges.
+ */
+fun <ValueType, OffsetType, SubObjectType, SubObjectOffset> mapSubObjects(
+    outerObjectRanges: List<GenericLinearRange<ValueType, OffsetType>>,
+    listSubObject: (ValueType) -> List<SubObjectType>,
+    subObjectLength: (SubObjectType) -> Offset<SubObjectOffset>,
+): List<GenericLinearRange<SubObjectType, SubObjectOffset>> {
+    val res = mutableListOf<GenericLinearRange<SubObjectType, SubObjectOffset>>()
+    for (range in outerObjectRanges) {
+        val subRanges = range.mapSubObject(listSubObject(range.value), subObjectLength)
+        res.addAll(subRanges)
+    }
+    return mergeLinearRanges(res)
+}

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/JsonTrainPath.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/JsonTrainPath.kt
@@ -1,7 +1,8 @@
 package fr.sncf.osrd.path.interfaces
 
 import com.squareup.moshi.Json
-import fr.sncf.osrd.path.implementations.buildRangeMap
+import fr.sncf.osrd.path.implementations.PartialBlockRange
+import fr.sncf.osrd.path.implementations.buildRangeList
 import fr.sncf.osrd.path.implementations.buildTrainPathFromBlockRanges
 import fr.sncf.osrd.path.legacy_objects.ElectricalProfileMapping
 import fr.sncf.osrd.railjson.schema.common.graph.EdgeDirection
@@ -14,7 +15,6 @@ import fr.sncf.osrd.utils.Direction
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.Offset.Companion.max
 import fr.sncf.osrd.utils.units.Offset.Companion.min
-import fr.sncf.osrd.utils.values
 
 data class JsonTrainPath(
     val blocks: List<ObjectRange<Block>>,
@@ -44,8 +44,10 @@ data class JsonTrainPath(
         electricalProfileMapping: ElectricalProfileMapping?,
     ): TrainPath {
         val blockRanges =
-            buildRangeMap(
-                blocks.map { BlockRange(blockInfra.getBlockFromName(it.id)!!, it.begin, it.end) }
+            buildRangeList(
+                blocks.map {
+                    PartialBlockRange(blockInfra.getBlockFromName(it.id)!!, it.begin, it.end)
+                }
             )
         return buildTrainPathFromBlockRanges(
             rawInfra,
@@ -59,7 +61,7 @@ data class JsonTrainPath(
 
 fun TrainPath.toJsonTrainPath(rawInfra: RawInfra, blockInfra: BlockInfra): JsonTrainPath {
     val tracks = mutableListOf<JsonTrainPath.TrackSectionRange>()
-    for ((dirChunk, from, to) in getChunks().values) {
+    for ((dirChunk, from, to) in getChunks()) {
         val track = rawInfra.getTrackFromChunk(dirChunk.value)
         val trackName = rawInfra.getTrackSectionName(track)
         val chunkStartOffset = rawInfra.getTrackChunkOffset(dirChunk.value)
@@ -100,11 +102,15 @@ fun TrainPath.toJsonTrainPath(rawInfra: RawInfra, blockInfra: BlockInfra): JsonT
         }
     }
     return JsonTrainPath(
-        getBlocks().values.map {
-            JsonTrainPath.ObjectRange(blockInfra.getBlockName(it.value), it.from, it.to)
+        getBlocks().map {
+            JsonTrainPath.ObjectRange(
+                blockInfra.getBlockName(it.value),
+                it.objectBegin,
+                it.objectEnd,
+            )
         },
-        getRoutes().values.map {
-            JsonTrainPath.ObjectRange(rawInfra.getRouteName(it.value), it.from, it.to)
+        getRoutes().map {
+            JsonTrainPath.ObjectRange(rawInfra.getRouteName(it.value), it.objectBegin, it.objectEnd)
         },
         tracks,
     )

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/TrainPath.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/TrainPath.kt
@@ -2,12 +2,8 @@ package fr.sncf.osrd.path.interfaces
 
 import fr.sncf.osrd.path.implementations.ChunkPath
 import fr.sncf.osrd.sim_infra.api.*
-import fr.sncf.osrd.utils.indexing.DirStaticIdx
-import fr.sncf.osrd.utils.indexing.StaticIdx
-import fr.sncf.osrd.utils.isSingleton
 import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
-import fr.sncf.osrd.utils.units.meters
 import fr.sncf.osrd.utils.units.sumDistances
 
 /**
@@ -59,33 +55,6 @@ fun concat(vararg paths: TrainPath): TrainPath {
     TODO("Required for actual backtracks, not necessary earlier than that")
 }
 
-data class GenericLinearRange<ValueType, OffsetType>(
-    val value: ValueType,
-    val objectBegin: Offset<OffsetType>,
-    val objectEnd: Offset<OffsetType>,
-    val pathBegin: Offset<TrainPath>,
-    val pathEnd: Offset<TrainPath>,
-) {
-    val length = objectEnd - objectBegin
-
-    init {
-        require(length >= 0.meters)
-        require(pathEnd - pathBegin == length)
-    }
-
-    fun isSingleton() = length == 0.meters
-}
-
-typealias LinearObjectRange<T> = GenericLinearRange<StaticIdx<T>, T>
-
-typealias LinearDirObjectRange<T> = GenericLinearRange<DirStaticIdx<T>, T>
-
-typealias RouteRange = LinearObjectRange<Route>
-
-typealias BlockRange = LinearObjectRange<Block>
-
-typealias DirChunkRange = LinearDirObjectRange<TrackChunk>
-
 // Extension functions that help with backward compatibility.
 // These should only exist during the migration to enable more local changes,
 // to allow partial migration while still having a working core.
@@ -107,10 +76,10 @@ fun TrainPath.getLegacyChunkPath(): ChunkPath {
 
 fun TrainPath.getLegacyBlockPath(): List<BlockId> {
     // Legacy block list excluded blocks that were only used in 0-length segments
-    return getBlocks().filter { !it.isSingleton() }.map { it.value }
+    return getBlocks().filter { !it.isSinglePoint() }.map { it.value }
 }
 
 fun TrainPath.getLegacyRoutePath(): List<RouteId> {
     // Legacy route list excluded routes that were only used in 0-length segments
-    return getRoutes().filter { !it.isSingleton() }.map { it.value }
+    return getRoutes().filter { !it.isSinglePoint() }.map { it.value }
 }

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/TrainPath.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/TrainPath.kt
@@ -1,9 +1,7 @@
 package fr.sncf.osrd.path.interfaces
 
-import com.google.common.collect.RangeMap
 import fr.sncf.osrd.path.implementations.ChunkPath
 import fr.sncf.osrd.sim_infra.api.*
-import fr.sncf.osrd.utils.entries
 import fr.sncf.osrd.utils.indexing.DirStaticIdx
 import fr.sncf.osrd.utils.indexing.StaticIdx
 import fr.sncf.osrd.utils.isSingleton
@@ -11,7 +9,6 @@ import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import fr.sncf.osrd.utils.units.sumDistances
-import fr.sncf.osrd.utils.values
 
 /**
  * A `TrainPath` describes the path taken by a train and its properties. It is built in a way that
@@ -50,11 +47,11 @@ interface TrainPath : PhysicsPath, PathProperties {
     /** Returns a copy with the specified routes instead */
     override fun withRoutes(routes: List<RouteId>): TrainPath
 
-    fun getBlocks(): LinearObjectMap<BlockRange>
+    fun getBlocks(): List<BlockRange>
 
-    fun getRoutes(): LinearObjectMap<RouteRange>
+    fun getRoutes(): List<RouteRange>
 
-    fun getChunks(): LinearObjectMap<DirChunkRange>
+    fun getChunks(): List<DirChunkRange>
     // To be expanded as needed with other linear objects
 }
 
@@ -64,20 +61,20 @@ fun concat(vararg paths: TrainPath): TrainPath {
 
 data class GenericLinearRange<ValueType, OffsetType>(
     val value: ValueType,
-    val from: Offset<OffsetType>,
-    val to: Offset<OffsetType>,
+    val objectBegin: Offset<OffsetType>,
+    val objectEnd: Offset<OffsetType>,
+    val pathBegin: Offset<TrainPath>,
+    val pathEnd: Offset<TrainPath>,
 ) {
-    val length = to - from
+    val length = objectEnd - objectBegin
 
     init {
         require(length >= 0.meters)
+        require(pathEnd - pathBegin == length)
     }
-}
 
-// We'd normally use `DistanceRangeMap` here, but supporting zero-length ranges is required.
-// Note: kotlin doesn't allow type arguments on type parameters, so we can't easily make it explicit
-// that T is meant to be a `GenericLinearRange` without having repeated parameters
-typealias LinearObjectMap<T> = RangeMap<Offset<TrainPath>, T>
+    fun isSingleton() = length == 0.meters
+}
 
 typealias LinearObjectRange<T> = GenericLinearRange<StaticIdx<T>, T>
 
@@ -96,8 +93,8 @@ typealias DirChunkRange = LinearDirObjectRange<TrackChunk>
 // TODO path migration: remove these.
 
 fun TrainPath.getLegacyChunkPath(): ChunkPath {
-    val chunkRanges = getChunks().values
-    val beginOffset = chunkRanges.first().from.cast<BlockPath>()
+    val chunkRanges = getChunks()
+    val beginOffset = chunkRanges.first().objectBegin.cast<BlockPath>()
     // Poorly optimized, we could avoid the loop if we had infra access.
     // Should be good enough for short-lived backward compatibility method.
     val endOffset = beginOffset + chunkRanges.map { it.length }.sumDistances()
@@ -110,10 +107,10 @@ fun TrainPath.getLegacyChunkPath(): ChunkPath {
 
 fun TrainPath.getLegacyBlockPath(): List<BlockId> {
     // Legacy block list excluded blocks that were only used in 0-length segments
-    return getBlocks().entries.filter { !it.key.isSingleton }.map { it.value.value }
+    return getBlocks().filter { !it.isSingleton() }.map { it.value }
 }
 
 fun TrainPath.getLegacyRoutePath(): List<RouteId> {
     // Legacy route list excluded routes that were only used in 0-length segments
-    return getRoutes().entries.filter { !it.key.isSingleton }.map { it.value.value }
+    return getRoutes().filter { !it.isSingleton() }.map { it.value }
 }

--- a/core/kt-osrd-path/src/test/kotlin/fr/sncf/osrd/path/GenericLinearRangeTest.kt
+++ b/core/kt-osrd-path/src/test/kotlin/fr/sncf/osrd/path/GenericLinearRangeTest.kt
@@ -1,0 +1,118 @@
+package fr.sncf.osrd.path
+
+import fr.sncf.osrd.path.interfaces.GenericLinearRange
+import fr.sncf.osrd.path.interfaces.mapSubObjects
+import fr.sncf.osrd.sim_infra.api.Block
+import fr.sncf.osrd.sim_infra.api.BlockId
+import fr.sncf.osrd.sim_infra.api.Route
+import fr.sncf.osrd.sim_infra.api.RouteId
+import fr.sncf.osrd.utils.units.Length
+import fr.sncf.osrd.utils.units.Offset
+import fr.sncf.osrd.utils.units.meters
+import kotlin.test.assertEquals
+import org.junit.Test
+
+class GenericLinearRangeTest {
+    @Test
+    fun testProjectionFullRange() {
+        /*
+        block offset (m)        0       50       100
+        block:                  |---------------->
+        projected offset:       |        x
+        path:           --------|---------------->
+        path offset (m)       1_000    1_050   1_100
+         */
+        val range =
+            GenericLinearRange(
+                value = BlockId(0U),
+                objectBegin = Offset<Block>(0.meters),
+                objectEnd = Offset(100.meters),
+                pathBegin = Offset(1_000.meters),
+                pathEnd = Offset(1_100.meters),
+            )
+
+        assertEquals(Offset(50.meters), range.offsetFromTrainPath(Offset(1_050.meters)))
+        assertEquals(Offset(1_050.meters), range.offsetToTrainPath(Offset(50.meters)))
+        assertEquals(Offset(1_000.meters), range.getObjectAbsolutePathStart())
+        assertEquals(Offset(1_100.meters), range.getObjectAbsolutePathEnd(Length(100.meters)))
+    }
+
+    @Test
+    fun testProjectionPartialRange() {
+        /*
+        block offset (m)      0   25     42    75      100
+        block:                |----|------------|------->
+                                          x
+        path:                      |------------>
+        path offset (m)            0     17    50
+         */
+        val range =
+            GenericLinearRange(
+                value = BlockId(0U),
+                objectBegin = Offset<Block>(25.meters),
+                objectEnd = Offset(75.meters),
+                pathBegin = Offset(0.meters),
+                pathEnd = Offset(50.meters),
+            )
+
+        assertEquals(Offset(42.meters), range.offsetFromTrainPath(Offset(17.meters)))
+        assertEquals(Offset(17.meters), range.offsetToTrainPath(Offset(42.meters)))
+        assertEquals(Offset((-25).meters), range.getObjectAbsolutePathStart())
+        assertEquals(Offset(75.meters), range.getObjectAbsolutePathEnd(Length(100.meters)))
+    }
+
+    @Test
+    fun testMapSubRange() {
+        /*
+        route offset (m)      0    100   250    400     600   750  800    1000
+        route:                |-----+-----+------+-------+-----+----+------>
+        path:                 +     +     |------+-------+----->    +      +
+        path offset (m)     -250  -150    0     150     350   500  550    750
+        blocks:               |----->|----+------>|------>|----+---->|----->
+        block offsets         0    100   150    300     200   150  200    200
+         */
+        val range =
+            GenericLinearRange(
+                value = RouteId(0U),
+                objectBegin = Offset<Route>(250.meters),
+                objectEnd = Offset(750.meters),
+                pathBegin = Offset(0.meters),
+                pathEnd = Offset(500.meters),
+            )
+        val blocks = (0U..4U).map { BlockId(it) }
+        val blockLengths = listOf(100, 300, 200, 200, 200).map { Length<Block>(it.meters) }
+
+        val blockRanges =
+            mapSubObjects(
+                listOf(range),
+                listSubObject = { blocks },
+                subObjectLength = { blockLengths[it.index.toInt()] },
+            )
+
+        val expectedRanges =
+            listOf(
+                GenericLinearRange(
+                    value = blocks[1],
+                    objectBegin = Offset<Block>(150.meters),
+                    objectEnd = Offset(300.meters),
+                    pathBegin = Offset(0.meters),
+                    pathEnd = Offset(150.meters),
+                ),
+                GenericLinearRange(
+                    value = blocks[2],
+                    objectBegin = Offset(0.meters),
+                    objectEnd = Offset(200.meters),
+                    pathBegin = Offset(150.meters),
+                    pathEnd = Offset(350.meters),
+                ),
+                GenericLinearRange(
+                    value = blocks[3],
+                    objectBegin = Offset(0.meters),
+                    objectEnd = Offset(150.meters),
+                    pathBegin = Offset(350.meters),
+                    pathEnd = Offset(500.meters),
+                ),
+            )
+        assertEquals(expectedRanges, blockRanges)
+    }
+}

--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingPostProcessing.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingPostProcessing.kt
@@ -2,11 +2,11 @@ package fr.sncf.osrd.api.pathfinding
 
 import com.google.common.collect.Iterables
 import fr.sncf.osrd.api.FullInfra
-import fr.sncf.osrd.path.implementations.buildRangeMap
+import fr.sncf.osrd.path.implementations.PartialBlockRange
+import fr.sncf.osrd.path.implementations.buildRangeList
 import fr.sncf.osrd.path.implementations.buildTrainPathFromBlockRanges
 import fr.sncf.osrd.path.interfaces.BlockPath
 import fr.sncf.osrd.path.interfaces.BlockRange
-import fr.sncf.osrd.path.interfaces.LinearObjectMap
 import fr.sncf.osrd.path.interfaces.TravelledPath
 import fr.sncf.osrd.path.interfaces.getLegacyBlockPath
 import fr.sncf.osrd.path.interfaces.toJsonTrainPath
@@ -126,18 +126,18 @@ fun makePathItemPositions(
 
 private fun makeBlocks(
     ranges: List<Pathfinding.EdgeRange<StaticIdx<Block>, Block>>
-): LinearObjectMap<BlockRange> {
-    val blockRanges = mutableListOf<BlockRange>()
+): List<BlockRange> {
+    val blockRanges = mutableListOf<PartialBlockRange>()
     for ((blockId, start, end) in ranges) {
         val lastAddedRange = blockRanges.lastOrNull()
         if (lastAddedRange == null || lastAddedRange.value != blockId) {
-            blockRanges.add(BlockRange(blockId, start, end))
+            blockRanges.add(PartialBlockRange(blockId, start, end))
         } else {
-            require(lastAddedRange.to == start)
-            blockRanges[blockRanges.lastIndex] = lastAddedRange.copy(to = end)
+            require(lastAddedRange.objectEnd == start)
+            blockRanges[blockRanges.lastIndex] = lastAddedRange.copy(objectEnd = end)
         }
     }
-    return buildRangeMap(blockRanges)
+    return buildRangeList(blockRanges)
 }
 
 /** Returns the route path, from the raw block pathfinding result */


### PR DESCRIPTION
Part of https://github.com/OpenRailAssociation/osrd/issues/12531

Range maps introduced a large amount of complexity, especially when dealing with incremental paths, linked lists, and such. And we never actually used any kind of `get(offset)` (which we could implement if needed). Also, merging what was once key + value into one object enables some nice utility methods. 

I first wanted to see where https://github.com/OpenRailAssociation/osrd/pull/13598 would go before merging this part. It's not *done* yet, switching to the new version and testing it takes a lot more plumbing. But it's going well enough that I feel confident in this PR.

I'll open several small PRs soon to prepare for it. 