### PR TITLE
front: fix missing trigram in NGE when OP is unknown

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/osrdToNge.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/osrdToNge.ts
@@ -292,6 +292,7 @@ export const loadAndIndexNge = async (
         const macroNode: NodeIndexed = {
           ngeId: index,
           path_item_key: key,
+          trigram: 'trigram' in pathItem ? pathItem.trigram : null,
           connection_time: 0,
           labels: [],
           // we put the nodes on a grid


### PR DESCRIPTION
Set the default value for the node trigram field when a path item is specified with a trigram. It will get overwritten in the loop right after if the OP ends up being found in the infra.

Closes: https://github.com/OpenRailAssociation/osrd/issues/13719