### PR TITLE
core: migrate most endpoints to new path model

### DIFF
--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathImpl.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathImpl.kt
@@ -34,6 +34,11 @@ data class TrainPathNoBacktrack(
 
     private val cachedEnvelopeSimPath by lazy { computeEnvelopeSimPath() }
 
+    private val cachedZonePaths by lazy {
+        assert(routes!!.isNotEmpty())
+        mapSubObjects(routes, rawInfra::getRoutePath, rawInfra::getZonePathLength)
+    }
+
     init {
         // The sanity checks here are quite exhaustive and might be expensive to compute.
         // Once the path types are stable, we can remove some of the tests.
@@ -85,6 +90,8 @@ data class TrainPathNoBacktrack(
     override fun getRoutes(): List<RouteRange> = routes!!
 
     override fun getChunks(): List<DirChunkRange> = chunks
+
+    override fun getZonePaths(): List<ZonePathRange> = cachedZonePaths
 
     override val length: Double
         get() = pathProperties.getLength().meters

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/PathProperties.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/PathProperties.kt
@@ -28,7 +28,8 @@ sealed interface BlockPath
  * A marker type for Length and Offset. In TravelledPath, start refers to the real start of the head
  * of the train.
  */
-sealed interface TravelledPath
+// TODO path migration: remove TravelledPath entirely
+typealias TravelledPath = TrainPath
 
 @Suppress("INAPPLICABLE_JVM_NAME")
 interface PathProperties {

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/TrainPath.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/TrainPath.kt
@@ -48,11 +48,17 @@ interface TrainPath : PhysicsPath, PathProperties {
     fun getRoutes(): List<RouteRange>
 
     fun getChunks(): List<DirChunkRange>
+
+    fun getZonePaths(): List<ZonePathRange>
     // To be expanded as needed with other linear objects
 }
 
 fun concat(vararg paths: TrainPath): TrainPath {
     TODO("Required for actual backtracks, not necessary earlier than that")
+}
+
+fun TrainPath.getZones(rawInfra: RawInfra): List<ZoneRange> {
+    return getZonePaths().map { it.mapValue(rawInfra.getZonePathZone(it.value)) }
 }
 
 // Extension functions that help with backward compatibility.

--- a/core/src/main/kotlin/fr/sncf/osrd/api/etcs/ETCSBrakingCurvesEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/etcs/ETCSBrakingCurvesEndpoint.kt
@@ -7,14 +7,10 @@ import fr.sncf.osrd.envelope.part.EnvelopePart
 import fr.sncf.osrd.envelope_sim.EnvelopeProfile
 import fr.sncf.osrd.envelope_sim.EnvelopeSimContext
 import fr.sncf.osrd.envelope_sim.etcs.*
-import fr.sncf.osrd.path.interfaces.BlockPath
+import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.path.interfaces.TravelledPath
-import fr.sncf.osrd.path.interfaces.getLegacyBlockPath
-import fr.sncf.osrd.path.interfaces.getLegacyChunkPath
-import fr.sncf.osrd.path.interfaces.getLegacyRoutePath
 import fr.sncf.osrd.signaling.etcs_level2.ETCS_LEVEL2
 import fr.sncf.osrd.sim_infra.api.*
-import fr.sncf.osrd.standalone_sim.PathOffsetBuilder
 import fr.sncf.osrd.standalone_sim.buildSignalingRanges
 import fr.sncf.osrd.standalone_sim.getSimStops
 import fr.sncf.osrd.standalone_sim.makeETCSContext
@@ -66,9 +62,6 @@ class ETCSBrakingCurvesEndpoint(
             // Parse path.
             val trainPath =
                 request.path.toTrainPath(infra.rawInfra, infra.blockInfra, electricalProfileMap)
-            val chunkPath = trainPath.getLegacyChunkPath()
-            val routePath = trainPath.getLegacyRoutePath()
-            val blockPath = trainPath.getLegacyBlockPath()
             val powerRestrictionsLegacyMap =
                 parsePowerRestrictions(request.powerRestrictions).toRangeMap()
             val electrificationMap =
@@ -80,7 +73,7 @@ class ETCSBrakingCurvesEndpoint(
                 )
             val curvesAndConditions =
                 rollingStock.mapTractiveEffortCurves(electrificationMap, request.comfort)
-            val signalingRanges = buildSignalingRanges(infra, blockPath, chunkPath)
+            val signalingRanges = buildSignalingRanges(infra, trainPath)
             val stops = getSimStops(parseRawSimulationScheduleItems(request.schedule))
             val context =
                 EnvelopeSimContext(
@@ -88,14 +81,7 @@ class ETCSBrakingCurvesEndpoint(
                     trainPath,
                     2.0,
                     curvesAndConditions.curves,
-                    makeETCSContext(
-                        rollingStock,
-                        infra,
-                        chunkPath,
-                        routePath,
-                        blockPath,
-                        signalingRanges,
-                    ),
+                    makeETCSContext(rollingStock, infra, trainPath, signalingRanges),
                 )
 
             // Parse mrsp.
@@ -115,17 +101,11 @@ class ETCSBrakingCurvesEndpoint(
                     EoaType.STOP,
                 )
             val stopBrakingCurves = etcsSimulator.computeStopBrakingCurves(mrsp, etcsStops)
-            // Compute conflict braking curves on each of the path's ETCS signals.
-            val pathOffsetBuilder =
-                PathOffsetBuilder(
-                    trainPathBlockOffset(infra.rawInfra, infra.blockInfra, blockPath, chunkPath)
-                        .distance
-                )
-            val etcsSignals =
-                getTravelledPathSignals(infra, blockPath, pathOffsetBuilder, ETCS_LEVEL2.id)
+            val etcsSignals = getTravelledPathSignals(infra, trainPath, ETCS_LEVEL2.id)
             val etcsSignalsOnPath =
                 etcsSignals.filter {
-                    it.offset.distance > Distance.ZERO && it.offset.distance <= chunkPath.length
+                    it.offset.distance > Distance.ZERO &&
+                        it.offset.distance <= trainPath.getLength()
                 }
             val etcsSignalOffsets = etcsSignalsOnPath.map { it.offset }
             val areEtcsSignalRouteDelimiters = etcsSignalsOnPath.map { it.isRouteDelimiter }
@@ -175,13 +155,12 @@ class ETCSBrakingCurvesEndpoint(
      */
     private fun getTravelledPathSignals(
         fullInfra: FullInfra,
-        blockPath: List<BlockId>,
-        pathOffsetBuilder: PathOffsetBuilder,
+        trainPath: TrainPath,
         signalingSystemId: String? = null,
     ): List<TravelledPathSignal> {
         val res = mutableSetOf<TravelledPathSignal>()
-        var currentOffset = Offset<BlockPath>(Distance.ZERO)
-        for (block in blockPath) {
+        for (blockRange in trainPath.getBlocks()) {
+            val block = blockRange.value
             val blockSignalsPositions = fullInfra.blockInfra.getSignalsPositions(block)
             val blockSignals = fullInfra.blockInfra.getBlockSignals(block)
             assert(blockSignalsPositions.size == blockSignals.size)
@@ -189,12 +168,10 @@ class ETCSBrakingCurvesEndpoint(
                 val signSystemId = fullInfra.rawInfra.getSignalingSystemId(signal)
                 val isRouteDelimiter = fullInfra.loadedSignalInfra.getSettings(signal).getFlag("Nf")
                 if (signalingSystemId == null || signSystemId == signalingSystemId) {
-                    val signalOffset =
-                        pathOffsetBuilder.toTravelledPath(currentOffset + signalPosition.distance)
+                    val signalOffset = blockRange.offsetToTrainPath(signalPosition)
                     res.add(TravelledPathSignal(signalOffset, isRouteDelimiter))
                 }
             }
-            currentOffset += fullInfra.blockInfra.getBlockLength(block).distance
         }
         return res.sorted()
     }

--- a/core/src/main/kotlin/fr/sncf/osrd/api/standalone_sim/SimulationEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/standalone_sim/SimulationEndpoint.kt
@@ -1,9 +1,6 @@
 package fr.sncf.osrd.api.standalone_sim
 
 import fr.sncf.osrd.api.*
-import fr.sncf.osrd.path.interfaces.getLegacyBlockPath
-import fr.sncf.osrd.path.interfaces.getLegacyChunkPath
-import fr.sncf.osrd.path.interfaces.getLegacyRoutePath
 import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.standalone_sim.runStandaloneSimulation
 import fr.sncf.osrd.utils.*
@@ -59,17 +56,11 @@ class SimulationEndpoint(
             // Parse path
             val trainPath =
                 request.path.toTrainPath(infra.rawInfra, infra.blockInfra, electricalProfileMap)
-            val chunkPath = trainPath.getLegacyChunkPath()
-            val routePath = trainPath.getLegacyRoutePath()
-            val blockPath = trainPath.getLegacyBlockPath()
 
             val res =
                 runStandaloneSimulation(
                     infra,
                     trainPath,
-                    chunkPath,
-                    routePath,
-                    blockPath,
                     rollingStock,
                     request.comfort,
                     request.constraintDistribution.toRJS(),

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/SafetySpeed.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/SafetySpeed.kt
@@ -2,16 +2,12 @@ package fr.sncf.osrd.standalone_sim
 
 import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.api.standalone_sim.SimulationScheduleItem
-import fr.sncf.osrd.path.implementations.ChunkPath
-import fr.sncf.osrd.path.interfaces.BlockPath
-import fr.sncf.osrd.path.interfaces.TravelledPath
+import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop
 import fr.sncf.osrd.signaling.etcs_level2.ETCS_LEVEL2
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.utils.DistanceRangeMap
 import fr.sncf.osrd.utils.distanceRangeMapOf
-import fr.sncf.osrd.utils.getRoutePathStartOffset
-import fr.sncf.osrd.utils.indexing.StaticIdx
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.Speed
 import fr.sncf.osrd.utils.units.kilometersPerHour
@@ -21,7 +17,7 @@ import fr.sncf.osrd.utils.units.meters
  * Simple internal class representing a stop with safety speed. Makes the function logic more
  * straightforward.
  */
-private data class SafetySpeedStop(val offset: Offset<TravelledPath>, val isShortSlip: Boolean)
+private data class SafetySpeedStop(val offset: Offset<TrainPath>, val isShortSlip: Boolean)
 
 /**
  * Compute safety speed ranges, areas where the train has a lower speed limit because of a scheduled
@@ -30,15 +26,12 @@ private data class SafetySpeedStop(val offset: Offset<TravelledPath>, val isShor
  */
 fun makeSafetySpeedRanges(
     infra: FullInfra,
-    chunkPath: ChunkPath,
-    routes: List<RouteId>,
+    trainPath: TrainPath,
     schedule: List<SimulationScheduleItem>,
     signalingRanges: DistanceRangeMap<String>,
 ): DistanceRangeMap<Speed> {
     val rawInfra = infra.rawInfra
-    val zonePaths = routes.flatMap { rawInfra.getRoutePath(it) }
-    val zonePathStartOffset = getRoutePathStartOffset(rawInfra, chunkPath, routes)
-    val signalOffsets = getSignalOffsets(infra, zonePaths, zonePathStartOffset)
+    val signalOffsets = getSignalOffsets(infra, trainPath)
 
     val stopsWithSafetySpeed =
         schedule
@@ -66,7 +59,7 @@ fun makeSafetySpeedRanges(
                 ETCS_LEVEL2.id,
             )
     ) {
-        makeEndOfPathStop(rawInfra, routes, signalOffsets)?.let { stopsWithSafetySpeed.add(it) }
+        makeEndOfPathStop(rawInfra, trainPath, signalOffsets)?.let { stopsWithSafetySpeed.add(it) }
     }
 
     val res = distanceRangeMapOf<Speed>()
@@ -88,12 +81,12 @@ fun makeSafetySpeedRanges(
         }
     }
     // Safety speed areas may extend outside the path
-    return res.subMap(0.meters, chunkPath.length)
+    return res.subMap(0.meters, trainPath.getLength())
 }
 
 /** Check if a given stop is in a range of a given signaling system. */
 private fun isStopInSignalingSystemRange(
-    stopOffset: Offset<TravelledPath>,
+    stopOffset: Offset<TrainPath>,
     signalingRanges: DistanceRangeMap<String>,
     signalingSystem: String,
 ): Boolean {
@@ -106,41 +99,38 @@ private fun isStopInSignalingSystemRange(
  */
 private fun makeEndOfPathStop(
     infra: RawSignalingInfra,
-    routes: List<RouteId>,
-    signalOffsets: List<Offset<TravelledPath>>,
+    trainPath: TrainPath,
+    signalOffsets: List<Offset<TrainPath>>,
 ): SafetySpeedStop? {
-    val lastRouteExit = infra.getRouteExit(routes.last())
+    val lastRouteExit = infra.getRouteExit(trainPath.getRoutes().last().value)
     val isBufferStop = infra.isBufferStop(lastRouteExit.value)
     if (isBufferStop) return SafetySpeedStop(signalOffsets.last(), true)
     return null
 }
 
 /** Return the offsets of block-delimiting signals on the path. */
-private fun getSignalOffsets(
-    infra: FullInfra,
-    zonePaths: List<StaticIdx<ZonePath>>,
-    pathStartOffset: Offset<BlockPath>,
-): List<Offset<TravelledPath>> {
-    val res = mutableListOf<Offset<TravelledPath>>()
+private fun getSignalOffsets(infra: FullInfra, trainPath: TrainPath): List<Offset<TrainPath>> {
+    val res = mutableListOf<Offset<TrainPath>>()
     val rawInfra = infra.rawInfra
     val signalingInfra = infra.loadedSignalInfra
     var prevZonePathsLength = 0.meters
-    for (zonePath in zonePaths) {
+    for (zonePathRange in trainPath.getZonePaths()) {
+        val zonePath = zonePathRange.value
         val signalPositions = rawInfra.getSignalPositions(zonePath)
         val signals = rawInfra.getSignals(zonePath)
         for ((signal, signalPosition) in signals zip signalPositions) {
             val isDelimiter =
-                signalingInfra.getLogicalSignals(signal).any { signalingInfra.isBlockDelimiter(it) }
+                signalingInfra.getLogicalSignals(signal).any(signalingInfra::isBlockDelimiter)
             if (isDelimiter) {
-                res.add(
-                    Offset(prevZonePathsLength + signalPosition.distance - pathStartOffset.distance)
-                )
+                res.add(zonePathRange.offsetToTrainPath(signalPosition))
             }
         }
         prevZonePathsLength += rawInfra.getZonePathLength(zonePath).distance
     }
     // Add one "signal" at the end of the last route no matter what.
     // There must be either a signal or a buffer stop, on which we may end safety speed ranges.
-    res.add(Offset(prevZonePathsLength - pathStartOffset.distance))
+    val lastRouteRange = trainPath.getRoutes().last()
+    res.add(lastRouteRange.getObjectAbsolutePathEnd(rawInfra.getRouteLength(lastRouteRange.value)))
+
     return res.filter { it.distance >= 0.meters }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulation.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulation.kt
@@ -23,9 +23,11 @@ import fr.sncf.osrd.envelope_sim.pipelines.maxEffortEnvelopeFrom
 import fr.sncf.osrd.envelope_sim.pipelines.maxSpeedEnvelopeFrom
 import fr.sncf.osrd.envelope_sim_infra.HasMissingSpeedTag
 import fr.sncf.osrd.envelope_sim_infra.computeMRSP
-import fr.sncf.osrd.path.implementations.ChunkPath
 import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.path.interfaces.TravelledPath
+import fr.sncf.osrd.path.interfaces.getLegacyBlockPath
+import fr.sncf.osrd.path.interfaces.getLegacyChunkPath
+import fr.sncf.osrd.path.interfaces.getLegacyRoutePath
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
 import fr.sncf.osrd.railjson.schema.schedule.RJSAllowanceDistribution
 import fr.sncf.osrd.reporting.exceptions.ErrorType.ZeroLengthPath
@@ -39,7 +41,6 @@ import fr.sncf.osrd.utils.DistanceRangeMap
 import fr.sncf.osrd.utils.distanceRangeMapOf
 import fr.sncf.osrd.utils.entries
 import fr.sncf.osrd.utils.toRangeMap
-import fr.sncf.osrd.utils.trainPathBlockOffset
 import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
@@ -54,9 +55,6 @@ val standaloneSimLogger: Logger = LoggerFactory.getLogger("StandaloneSimulation"
 fun runStandaloneSimulation(
     infra: FullInfra,
     trainPath: TrainPath,
-    chunkPath: ChunkPath,
-    routes: List<RouteId>,
-    blockPath: List<BlockId>,
     rollingStock: RollingStock,
     comfort: Comfort,
     constraintDistribution: RJSAllowanceDistribution,
@@ -71,11 +69,10 @@ fun runStandaloneSimulation(
     pathItemPositions: List<Offset<TravelledPath>>,
     driverBehaviour: DriverBehaviour = DriverBehaviour(),
 ): SimulationSuccess {
-    if (chunkPath.length == 0.meters) throw OSRDError(ZeroLengthPath)
-    val signalingRanges = buildSignalingRanges(infra, blockPath, chunkPath)
+    if (trainPath.getLength() == 0.meters) throw OSRDError(ZeroLengthPath)
+    val signalingRanges = buildSignalingRanges(infra, trainPath)
     // MRSP & SpeedLimits
-    val safetySpeedRanges =
-        makeSafetySpeedRanges(infra, chunkPath, routes, schedule, signalingRanges)
+    val safetySpeedRanges = makeSafetySpeedRanges(infra, trainPath, schedule, signalingRanges)
     var mrsp =
         computeMRSP(
             trainPath,
@@ -110,7 +107,7 @@ fun runStandaloneSimulation(
             trainPath,
             timeStep,
             curvesAndConditions.curves,
-            makeETCSContext(rollingStock, infra, chunkPath, routes, blockPath, signalingRanges),
+            makeETCSContext(rollingStock, infra, trainPath, signalingRanges),
         )
 
     // Max speed envelope
@@ -166,10 +163,10 @@ fun runStandaloneSimulation(
         runScheduleMetadataExtractor(
             finalEnvelope,
             trainPath,
-            chunkPath,
+            trainPath.getLegacyChunkPath(), // TODO path migration
             infra,
-            routes,
-            blockPath,
+            trainPath.getLegacyRoutePath(),
+            trainPath.getLegacyBlockPath(),
             rollingStock,
             schedule,
             pathItemPositions,
@@ -185,30 +182,14 @@ fun runStandaloneSimulation(
     )
 }
 
-/** Returns the ranges where each signaling system is encountered, as travelled path offsets. */
-fun buildSignalingRanges(
-    infra: FullInfra,
-    blockPath: List<BlockId>,
-    chunkPath: ChunkPath,
-): DistanceRangeMap<String> {
+/** Returns the ranges where each signaling system is encountered. */
+fun buildSignalingRanges(infra: FullInfra, trainPath: TrainPath): DistanceRangeMap<String> {
     val blockInfra = infra.blockInfra
-    var blockStartOffset =
-        Offset<TravelledPath>(
-            trainPathBlockOffset(infra.rawInfra, infra.blockInfra, blockPath, chunkPath).distance *
-                -1.0
-        )
     val res = distanceRangeMapOf<String>()
-    for (blockId in blockPath) {
-        val blockLength = blockInfra.getBlockLength(blockId)
-        val blockEndOffset = blockStartOffset + blockLength.distance
-        val sigSystem = blockInfra.getBlockSignalingSystem(blockId)
-        val name = infra.signalingSimulator.sigModuleManager.getName(sigSystem)
-        res.put(
-            Distance.max(blockStartOffset.distance, Distance.ZERO),
-            Distance.min(blockEndOffset.distance, chunkPath.length),
-            name,
-        )
-        blockStartOffset += blockLength.distance
+    for (blockRange in trainPath.getBlocks()) {
+        val sigSystem = blockInfra.getBlockSignalingSystem(blockRange.value)
+        val sigSystemName = infra.signalingSimulator.sigModuleManager.getName(sigSystem)
+        res.put(blockRange.pathBegin.distance, blockRange.pathEnd.distance, sigSystemName)
     }
     return res
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/etcsContextBuilder.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/etcsContextBuilder.kt
@@ -2,8 +2,8 @@ package fr.sncf.osrd.standalone_sim
 
 import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.envelope_sim.EnvelopeSimContext
-import fr.sncf.osrd.path.implementations.ChunkPath
-import fr.sncf.osrd.path.interfaces.BlockPath
+import fr.sncf.osrd.path.interfaces.DirChunkRange
+import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.path.interfaces.TravelledPath
 import fr.sncf.osrd.signaling.etcs_level2.ETCS_LEVEL2
 import fr.sncf.osrd.sim_infra.api.*
@@ -18,9 +18,7 @@ import fr.sncf.osrd.utils.units.Offset
 fun makeETCSContext(
     rollingStock: RollingStock,
     infra: FullInfra,
-    chunkPath: ChunkPath,
-    routePath: List<RouteId>,
-    blockPath: List<BlockId>,
+    trainPath: TrainPath,
     signalingRanges: DistanceRangeMap<String>,
 ): EnvelopeSimContext.ETCSContext? {
     val etcsRanges = signalingRanges.mapToRangeSet { it == ETCS_LEVEL2.id }
@@ -34,8 +32,8 @@ fun makeETCSContext(
     }
     return EnvelopeSimContext.ETCSContext(
         etcsRanges,
-        buildETCSDangerPoints(infra.rawInfra, chunkPath, routePath),
-        buildETCSBlockDetectors(infra, blockPath, chunkPath),
+        buildETCSDangerPoints(infra.rawInfra, trainPath),
+        buildETCSBlockDetectors(infra, trainPath),
     )
 }
 
@@ -45,53 +43,36 @@ fun makeETCSContext(
  * May return any number of point beyond the end of the path, specifically any point covered by the
  * routes used by the path.
  */
-fun buildETCSDangerPoints(
-    infra: RawInfra,
-    chunkPath: ChunkPath,
-    routePath: List<RouteId>,
-): List<Offset<TravelledPath>> {
-    val zonePaths = routePath.flatMap { infra.getRoutePath(it) }
-    var currentZonePathStartOffset = -getRoutePathStartOffset(infra, chunkPath, routePath).distance
-
+fun buildETCSDangerPoints(infra: RawInfra, trainPath: TrainPath): List<Offset<TravelledPath>> {
     val res = mutableSetOf<Offset<TravelledPath>>()
-    for (zonePath in zonePaths) {
+    for (zonePathRange in trainPath.getZonePaths()) {
+        val zonePath = zonePathRange.value
         val movableElements = infra.getZonePathMovableElements(zonePath)
         val movableElementPositions = infra.getZonePathMovableElementsPositions(zonePath)
         for ((element, position) in movableElements zip movableElementPositions) {
             if (infra.getTrackNodeConfigs(element).size <= 1U) continue
-            res.add(Offset(position.distance + currentZonePathStartOffset))
+            res.add(zonePathRange.offsetToTrainPath(position))
         }
-        currentZonePathStartOffset += infra.getZonePathLength(zonePath).distance
     }
 
-    findLastDangerPoint(infra, chunkPath)?.let { res.add(it) }
+    findLastDangerPoint(infra, trainPath)?.let { res.add(it) }
     return res.sorted()
 }
 
 /** Builds the offset list of detectors for ETCS blocks on the block path. */
-fun buildETCSBlockDetectors(
-    infra: FullInfra,
-    blockPath: List<BlockId>,
-    chunkPath: ChunkPath,
-): List<Offset<TravelledPath>> {
-    val etcsBlockDetectors = mutableListOf<Offset<BlockPath>>()
-    var currentOffset = Offset.zero<BlockPath>()
-    for (block in blockPath) {
+fun buildETCSBlockDetectors(infra: FullInfra, trainPath: TrainPath): List<Offset<TrainPath>> {
+    val etcsBlockDetectors = mutableListOf<Offset<TrainPath>>()
+    for (blockRange in trainPath.getBlocks()) {
+        val block = blockRange.value
         if (isETCSBlock(block, infra)) {
-            // Add entry detector
-            etcsBlockDetectors.add(currentOffset)
-            currentOffset += infra.blockInfra.getBlockLength(block).distance
-            // Add exit detector
-            etcsBlockDetectors.add(currentOffset)
+            // Add entry and exit detectors
+            etcsBlockDetectors.add(blockRange.getObjectAbsolutePathStart())
+            etcsBlockDetectors.add(
+                blockRange.getObjectAbsolutePathEnd(infra.blockInfra.getBlockLength(block))
+            )
         }
     }
-    val pathOffsetBuilder =
-        PathOffsetBuilder(
-            trainPathBlockOffset(infra.rawInfra, infra.blockInfra, blockPath, chunkPath).distance
-        )
-    return etcsBlockDetectors
-        .map { pathOffsetBuilder.toTravelledPath(it) }
-        .filter { it.distance >= Distance.ZERO }
+    return etcsBlockDetectors.filter { it.distance >= Distance.ZERO }
 }
 
 private fun isETCSBlock(block: BlockId, infra: FullInfra): Boolean {
@@ -104,20 +85,18 @@ private fun isETCSBlock(block: BlockId, infra: FullInfra): Boolean {
  * Find the last danger point, which may extend beyond the end of the path. Null if tracks are
  * circular with no switch nor buffer stop.
  */
-private fun findLastDangerPoint(infra: RawInfra, chunkPath: ChunkPath): Offset<TravelledPath>? {
+private fun findLastDangerPoint(infra: RawInfra, trainPath: TrainPath): Offset<TravelledPath>? {
     // Find the offset of the last chunk on the path
-    val lastChunk = chunkPath.chunks.last()
-    var lastChunkEndOffset = Offset<TravelledPath>(chunkPath.beginOffset.distance * -1.0)
-    for (chunk in chunkPath.chunks) {
-        lastChunkEndOffset += infra.getTrackChunkLength(chunk.value).distance
-    }
-    val lastTrack = infra.getTrackFromChunk(lastChunk.value)
-    val endOfLastTrackPathOffset =
-        getEndOfLastTrackPathOffset(infra, lastTrack, lastChunk, lastChunkEndOffset)
+    val chunkRanges = trainPath.getChunks()
+    val lastChunkRange = chunkRanges.last()
+    val dirLastChunk = lastChunkRange.value
+    val lastChunk = dirLastChunk.value
+    val lastTrack = infra.getTrackFromChunk(lastChunk)
+    val endOfLastTrackPathOffset = getEndOfLastTrackPathOffset(infra, lastTrack, lastChunkRange)
 
     // Iterate on the tracks until finding either a switch or a buffer stop
     var currentTrackEndOffset = endOfLastTrackPathOffset
-    var track = DirStaticIdx(lastTrack, lastChunk.direction)
+    var track = DirStaticIdx(lastTrack, dirLastChunk.direction)
     while (true) {
         val nextTracks = infra.getNextTrackSections(track)
         val endAtDangerPoint = nextTracks.size != 1
@@ -134,18 +113,22 @@ private fun findLastDangerPoint(infra: RawInfra, chunkPath: ChunkPath): Offset<T
 private fun getEndOfLastTrackPathOffset(
     infra: RawInfra,
     lastTrack: TrackSectionId,
-    lastChunk: DirStaticIdx<TrackChunk>,
-    lastChunkEndOffset: Offset<TravelledPath>,
+    lastChunkRange: DirChunkRange,
 ): Offset<TravelledPath> {
+    // Note: this function alone doesn't quite justify it,
+    // but we could add a List<DirTrackRange> to TrainPath instead
+    val dirLastChunk = lastChunkRange.value
+    val lastChunk = dirLastChunk.value
     val lastTrackLength = infra.getTrackSectionLength(lastTrack)
-    val lastChunkLength = infra.getTrackChunkLength(lastChunk.value)
+    val lastChunkLength = infra.getTrackChunkLength(lastChunkRange.value.value)
+    val lastChunkEndOffset = lastChunkRange.getObjectAbsolutePathEnd(lastChunkLength)
 
     // As an offset on the undirected last track, where the start of the (undirected) last chunk is
     // located
-    val lastUndirectedChunkStartOffsetOnTrack = infra.getTrackChunkOffset(lastChunk.value)
+    val lastUndirectedChunkStartOffsetOnTrack = infra.getTrackChunkOffset(lastChunk)
 
     val distanceFromChunkEndToTrackEnd =
-        if (lastChunk.direction == Direction.INCREASING)
+        if (dirLastChunk.direction == Direction.INCREASING)
             lastTrackLength.distance -
                 (lastUndirectedChunkStartOffsetOnTrack.distance + lastChunkLength.distance)
         else lastUndirectedChunkStartOffsetOnTrack.distance

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
@@ -7,7 +7,9 @@ import fr.sncf.osrd.envelope_sim.pipelines.SimStop
 import fr.sncf.osrd.envelope_sim.pipelines.maxEffortEnvelopeFrom
 import fr.sncf.osrd.envelope_sim.pipelines.maxSpeedEnvelopeFrom
 import fr.sncf.osrd.envelope_sim_infra.computeMRSP
-import fr.sncf.osrd.path.implementations.buildTrainPathFromChunkPath
+import fr.sncf.osrd.path.implementations.PartialBlockRange
+import fr.sncf.osrd.path.implementations.buildRangeList
+import fr.sncf.osrd.path.implementations.buildTrainPathFromBlockRanges
 import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.pathfinding.Pathfinding
 import fr.sncf.osrd.pathfinding.Pathfinding.EdgeLocation
@@ -58,10 +60,8 @@ class STDCMPostProcessing(private val graph: STDCMGraph) {
         val blockWaypoints = makeBlockWaypoints(path)
         val chunkPath = makeChunkPathFromEdges(graph, edges)
         val routes = edges.last().infraExplorer.getExploredRoutes()
-        // TODO path migration: use a better builder here
-        val trainPath =
-            buildTrainPathFromChunkPath(infra.rawInfra, infra.blockInfra, chunkPath, routes)
-        // val departureTime = computeDepartureTime(edges, startTime)
+        val trainPath = buildTrainPath(infra, blockRanges, routes)
+
         val updatedTimeData = computeTimeData(edges)
         val stops = makeStops(edges, updatedTimeData)
         val maxSpeedEnvelope =
@@ -107,6 +107,27 @@ class STDCMPostProcessing(private val graph: STDCMGraph) {
             // as we only check the time at the start of an edge when exploring the graph
             null
         } else res
+    }
+
+    /** Build a `TrainPath` from the search result. */
+    private fun buildTrainPath(
+        infra: FullInfra,
+        blockRanges: List<EdgeRange<BlockId, Block>>,
+        routes: List<RouteId>,
+    ): TrainPath {
+        val partialRanges =
+            blockRanges.map {
+                PartialBlockRange(value = it.edge, objectBegin = it.start, objectEnd = it.end)
+            }
+        val rangeList = buildRangeList(partialRanges)
+
+        // TODO: if we want electrical profiles in STDCM, we'd need to input it there
+        return buildTrainPathFromBlockRanges(
+            infra.rawInfra,
+            infra.blockInfra,
+            rangeList,
+            routes = routes,
+        )
     }
 
     private fun makeMaxSpeedEnvelope(

--- a/core/src/test/kotlin/fr/sncf/osrd/standalone_sim/ETCSTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/standalone_sim/ETCSTests.kt
@@ -1,11 +1,8 @@
 package fr.sncf.osrd.standalone_sim
 
-import fr.sncf.osrd.path.implementations.buildChunkPath
-import fr.sncf.osrd.sim_infra.api.TrackChunk
-import fr.sncf.osrd.sim_infra.api.dirIter
 import fr.sncf.osrd.utils.Direction
 import fr.sncf.osrd.utils.Helpers.tinyInfra
-import fr.sncf.osrd.utils.indexing.mutableDirStaticIdxArrayListOf
+import fr.sncf.osrd.utils.pathFromTracks
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import kotlin.test.Test
@@ -31,16 +28,18 @@ class ETCSTests {
                 "rt.buffer_stop_a->tde.foo_a-switch_foo",
                 "rt.tde.foo_a-switch_foo->buffer_stop_c",
             )
-        val routeIdx = routesNames.map { infra.getRouteFromName(it) }
         val start = 0.meters // Path fully covers the tracks
         val end = 10_400.meters
-        val chunkList = mutableDirStaticIdxArrayListOf<TrackChunk>()
-        trackIds
-            .map { id -> infra.getTrackSectionFromName(id)!! }
-            .flatMap { track -> infra.getTrackSectionChunks(track).dirIter(Direction.INCREASING) }
-            .forEach { dirChunk -> chunkList.add(dirChunk) }
-        val chunkPath = buildChunkPath(infra, chunkList, Offset(start), Offset(end))
-        val dangerPoints = buildETCSDangerPoints(infra, chunkPath, routeIdx)
+        val trainPath =
+            pathFromTracks(
+                fullInfra,
+                trackIds,
+                Direction.INCREASING,
+                start,
+                end,
+                routeNames = routesNames,
+            )
+        val dangerPoints = buildETCSDangerPoints(infra, trainPath)
         assertEquals(listOf(Offset(200.meters), Offset(10400.meters)), dangerPoints)
     }
 
@@ -54,16 +53,18 @@ class ETCSTests {
                 "rt.buffer_stop_a->tde.foo_a-switch_foo",
                 "rt.tde.foo_a-switch_foo->buffer_stop_c",
             )
-        val routeIdx = routesNames.map { infra.getRouteFromName(it) }
         val start = 100.meters // Shifts all positions by 100.meters
         val end = 10_100.meters // Don't reach all the way until the buffer stop
-        val chunkList = mutableDirStaticIdxArrayListOf<TrackChunk>()
-        trackIds
-            .map { id -> infra.getTrackSectionFromName(id)!! }
-            .flatMap { track -> infra.getTrackSectionChunks(track).dirIter(Direction.INCREASING) }
-            .forEach { dirChunk -> chunkList.add(dirChunk) }
-        val chunkPath = buildChunkPath(infra, chunkList, Offset(start), Offset(end))
-        val dangerPoints = buildETCSDangerPoints(infra, chunkPath, routeIdx)
+        val trainPath =
+            pathFromTracks(
+                fullInfra,
+                trackIds,
+                Direction.INCREASING,
+                start,
+                end,
+                routeNames = routesNames,
+            )
+        val dangerPoints = buildETCSDangerPoints(infra, trainPath)
         assertEquals(listOf(Offset(100.meters), Offset(10_300.meters)), dangerPoints)
     }
 
@@ -78,16 +79,18 @@ class ETCSTests {
                 "rt.tde.track-bar->tde.switch_foo-track",
                 "rt.tde.switch_foo-track->buffer_stop_a",
             )
-        val routeIdx = routesNames.map { infra.getRouteFromName(it) }
         val start = 100.meters
         val end = 10_300.meters
-        val chunkList = mutableDirStaticIdxArrayListOf<TrackChunk>()
-        trackIds
-            .map { id -> infra.getTrackSectionFromName(id)!! }
-            .flatMap { track -> infra.getTrackSectionChunks(track).dirIter(Direction.DECREASING) }
-            .forEach { dirChunk -> chunkList.add(dirChunk) }
-        val chunkPath = buildChunkPath(infra, chunkList, Offset(start), Offset(end))
-        val dangerPoints = buildETCSDangerPoints(infra, chunkPath, routeIdx)
+        val trainPath =
+            pathFromTracks(
+                fullInfra,
+                trackIds,
+                Direction.DECREASING,
+                start,
+                end,
+                routeNames = routesNames,
+            )
+        val dangerPoints = buildETCSDangerPoints(infra, trainPath)
         assertEquals(listOf(Offset(10_100.meters), Offset(10_300.meters)), dangerPoints)
     }
 
@@ -98,16 +101,18 @@ class ETCSTests {
         val trackIds = listOf("ne.micro.bar_a", "ne.micro.foo_to_bar", "ne.micro.foo_a")
         val routesNames =
             listOf("rt.buffer_stop_c->tde.track-bar", "rt.tde.track-bar->tde.switch_foo-track")
-        val routeIdx = routesNames.map { infra.getRouteFromName(it) }
         val start = 100.meters
         val end = 5_000.meters
-        val chunkList = mutableDirStaticIdxArrayListOf<TrackChunk>()
-        trackIds
-            .map { id -> infra.getTrackSectionFromName(id)!! }
-            .flatMap { track -> infra.getTrackSectionChunks(track).dirIter(Direction.DECREASING) }
-            .forEach { dirChunk -> chunkList.add(dirChunk) }
-        val chunkPath = buildChunkPath(infra, chunkList, Offset(start), Offset(end))
-        val dangerPoints = buildETCSDangerPoints(infra, chunkPath, routeIdx)
+        val trainPath =
+            pathFromTracks(
+                fullInfra,
+                trackIds,
+                Direction.DECREASING,
+                start,
+                end,
+                routeNames = routesNames,
+            )
+        val dangerPoints = buildETCSDangerPoints(infra, trainPath)
         assertEquals(listOf(Offset(10_100.meters)), dangerPoints)
     }
 }

--- a/core/src/test/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulationTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulationTest.kt
@@ -12,7 +12,7 @@ import fr.sncf.osrd.envelope_sim.allowances.AllowanceValue.TimePerDistance
 import fr.sncf.osrd.envelope_sim.pipelines.maxEffortEnvelopeFrom
 import fr.sncf.osrd.envelope_sim.pipelines.maxSpeedEnvelopeFrom
 import fr.sncf.osrd.envelope_sim_infra.computeMRSP
-import fr.sncf.osrd.path.implementations.buildTrainPathFromChunkPath
+import fr.sncf.osrd.path.implementations.buildTrainPathFromBlocks
 import fr.sncf.osrd.path.interfaces.TravelledPath
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
 import fr.sncf.osrd.railjson.schema.schedule.RJSAllowanceDistribution
@@ -51,9 +51,8 @@ class StandaloneSimulationTest {
             )
             .map { infra.blockInfra.getBlockFromName("block.${md5(it)}")!! }
 
-    private val chunkPath = pathFromRoutes(infra.rawInfra, routes)
     private val trainPath =
-        buildTrainPathFromChunkPath(infra.rawInfra, infra.blockInfra, chunkPath, routes)
+        buildTrainPathFromBlocks(infra.rawInfra, infra.blockInfra, blocks, routes)
     private val pathLength = trainPath.getLength()
 
     // Build a reference max speed envelope
@@ -79,9 +78,6 @@ class StandaloneSimulationTest {
             runStandaloneSimulation(
                 infra,
                 trainPath,
-                chunkPath,
-                routes,
-                blocks,
                 rollingStock,
                 Comfort.STANDARD,
                 RJSAllowanceDistribution.LINEAR,
@@ -212,9 +208,6 @@ class StandaloneSimulationTest {
             runStandaloneSimulation(
                 infra,
                 trainPath,
-                chunkPath,
-                routes,
-                blocks,
                 rollingStock,
                 Comfort.STANDARD,
                 testCase.allowanceDistribution,
@@ -301,9 +294,8 @@ class StandaloneSimulationTest {
                 SimulationScheduleItem(Offset(10_300.meters), 42.seconds, 42.seconds, STOP),
             )
 
-        val signalingRanges = buildSignalingRanges(infra, blocks, chunkPath)
-        val safetySpeedRanges =
-            makeSafetySpeedRanges(infra, chunkPath, routes, schedule, signalingRanges)
+        val signalingRanges = buildSignalingRanges(infra, trainPath)
+        val safetySpeedRanges = makeSafetySpeedRanges(infra, trainPath, schedule, signalingRanges)
         val expected =
             distanceRangeMapOf(
                 DistanceRangeMap.RangeMapEntry(0.meters, 50.meters, 30.kilometersPerHour),
@@ -340,13 +332,13 @@ class StandaloneSimulationTest {
                 SimulationScheduleItem(Offset(10_300.meters), 42.seconds, 42.seconds, STOP),
             )
 
-        val signalingRangesBAL = buildSignalingRanges(infra, blocks, chunkPath)
+        val signalingRangesBAL = buildSignalingRanges(infra, trainPath)
 
         // ETCS_LEVEL2 range covers the first stop only: getting safetySpeed for the other stops
         val signalingRangesEtcsHappyPath = signalingRangesBAL.clone()
         signalingRangesEtcsHappyPath.put(10.meters, 1_000.meters, ETCS_LEVEL2.id)
         val safetySpeedRangesEtcsHappyPath =
-            makeSafetySpeedRanges(infra, chunkPath, routes, schedule, signalingRangesEtcsHappyPath)
+            makeSafetySpeedRanges(infra, trainPath, schedule, signalingRangesEtcsHappyPath)
         val expectedEtcsHappyPath =
             distanceRangeMapOf(
                 DistanceRangeMap.RangeMapEntry(9_950.meters, 10_050.meters, 30.kilometersPerHour),
@@ -361,7 +353,7 @@ class StandaloneSimulationTest {
         val signalingRangesEndFullEtcs = signalingRangesBAL.clone()
         signalingRangesEndFullEtcs.put(9_500.meters, 10_400.meters, ETCS_LEVEL2.id)
         val safetySpeedRangesEndFullEtcs =
-            makeSafetySpeedRanges(infra, chunkPath, routes, schedule, signalingRangesEndFullEtcs)
+            makeSafetySpeedRanges(infra, trainPath, schedule, signalingRangesEndFullEtcs)
         val expectedEndFullEtcs =
             distanceRangeMapOf(
                 DistanceRangeMap.RangeMapEntry(0.meters, 150.meters, 30.kilometersPerHour)
@@ -375,8 +367,7 @@ class StandaloneSimulationTest {
         val safetySpeedRangesEndFullEtcsExceptFinalBuffer =
             makeSafetySpeedRanges(
                 infra,
-                chunkPath,
-                routes,
+                trainPath,
                 schedule,
                 signalingRangesEndEtcsExceptFinalBuffer,
             )
@@ -401,8 +392,7 @@ class StandaloneSimulationTest {
         val safetySpeedRangesEtcsStartingBetweenPenultimateStopAndItsSignal =
             makeSafetySpeedRanges(
                 infra,
-                chunkPath,
-                routes,
+                trainPath,
                 schedule,
                 signalingRangesEtcsStartingBetweenPenultimateStopAndItsSignal,
             )
@@ -428,8 +418,7 @@ class StandaloneSimulationTest {
         val safetySpeedRangesEtcsStartingBetweenLastStopAndBuffer =
             makeSafetySpeedRanges(
                 infra,
-                chunkPath,
-                routes,
+                trainPath,
                 schedule,
                 signalingRangesEtcsStartingBetweenLastStopAndBuffer,
             )

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/FullSTDCMTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/FullSTDCMTests.kt
@@ -6,9 +6,6 @@ import fr.sncf.osrd.api.pathfinding.PathfindingBlockSuccess
 import fr.sncf.osrd.api.pathfinding.runPathfinding
 import fr.sncf.osrd.conflicts.SpacingRequirement
 import fr.sncf.osrd.envelope_sim.allowances.AllowanceValue
-import fr.sncf.osrd.path.interfaces.getLegacyBlockPath
-import fr.sncf.osrd.path.interfaces.getLegacyChunkPath
-import fr.sncf.osrd.path.interfaces.getLegacyRoutePath
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
 import fr.sncf.osrd.railjson.schema.schedule.RJSAllowanceDistribution
 import fr.sncf.osrd.sim_infra.api.RawInfra
@@ -462,9 +459,6 @@ fun makeRequirementsFromPath(
         runStandaloneSimulation(
             infra,
             trainPath,
-            trainPath.getLegacyChunkPath(),
-            trainPath.getLegacyRoutePath(),
-            trainPath.getLegacyBlockPath(),
             rollingStock,
             Comfort.STANDARD,
             RJSAllowanceDistribution.LINEAR,

--- a/core/src/test/kotlin/fr/sncf/osrd/utils/PathUtils.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/utils/PathUtils.kt
@@ -24,6 +24,7 @@ fun pathFromTracks(
     start: Distance,
     end: Distance,
     electricalProfileMapping: ElectricalProfileMapping? = null,
+    routeNames: List<String>? = null,
 ): TrainPath {
     val chunkList = mutableDirStaticIdxArrayListOf<TrackChunk>()
     trackIds
@@ -36,6 +37,7 @@ fun pathFromTracks(
         blockInfra,
         chunkPath,
         electricalProfileMapping = electricalProfileMapping,
+        routeNames = routeNames,
     )
 }
 
@@ -46,6 +48,7 @@ fun pathFromTracks(
     start: Distance,
     end: Distance,
     electricalProfileMapping: ElectricalProfileMapping? = null,
+    routeNames: List<String>? = null,
 ): TrainPath {
     return pathFromTracks(
         infra.rawInfra,
@@ -55,6 +58,7 @@ fun pathFromTracks(
         start,
         end,
         electricalProfileMapping = electricalProfileMapping,
+        routeNames = routeNames,
     )
 }
 


### PR DESCRIPTION
Part of https://github.com/OpenRailAssociation/osrd/issues/12531

I removed some `path.getLegacy...`, and replaced list of IDs with the new ranges.

Not included yet: signal projection endpoint, and schedule metadata extractor. Migrating these two files would likely include migrating incremental path and resource generation, which I'll try to do in a PR as small as possible (though likely too large still). 

Next PR: https://github.com/OpenRailAssociation/osrd/pull/13793