### PR TITLE
front: fix track_name on timetable for imported train

### DIFF
--- a/front/src/modules/timesStops/helpers/utils.ts
+++ b/front/src/modules/timesStops/helpers/utils.ts
@@ -13,6 +13,7 @@ import type {
   PathItemLocation,
   ReceptionSignal,
   TrackReference,
+  TrackSection,
 } from 'common/api/osrdEditoastApi';
 import type { TimeString } from 'common/types';
 import { matchPathStepAndOp } from 'modules/pathfinding/utils';
@@ -351,9 +352,15 @@ export function receptionSignalToSignalBooleans(receptionSignal?: ReceptionSigna
   return { shortSlipDistance: false, onStopSignal: false };
 }
 
-export const getTrackReferenceLabel = (trackReference?: TrackReference | null) => {
+export const getTrackReferenceLabel = (
+  trackSections: Record<string, TrackSection>,
+  trackReference?: TrackReference | null
+) => {
   if (!trackReference) return undefined;
-  return 'track_id' in trackReference ? trackReference.track_id : trackReference.track_name;
+  if ('track_name' in trackReference) return trackReference.track_name;
+  return (
+    trackSections[trackReference.track_id]?.extensions?.sncf?.track_name ?? trackReference.track_id
+  );
 };
 
 export const getOperationalPointName = (

--- a/front/src/modules/timesStops/helpers/utils.ts
+++ b/front/src/modules/timesStops/helpers/utils.ts
@@ -358,9 +358,7 @@ export const getTrackReferenceLabel = (
 ) => {
   if (!trackReference) return undefined;
   if ('track_name' in trackReference) return trackReference.track_name;
-  return (
-    trackSections[trackReference.track_id]?.extensions?.sncf?.track_name ?? trackReference.track_id
-  );
+  return trackSections[trackReference.track_id]?.extensions?.sncf?.track_name ?? '?';
 };
 
 export const getOperationalPointName = (

--- a/front/src/modules/timesStops/hooks/useOutputTableData.ts
+++ b/front/src/modules/timesStops/hooks/useOutputTableData.ts
@@ -39,7 +39,12 @@ const useOutputTableData = (
 
   const trackIds = useMemo(() => {
     const path = selectedTrain?.path || [];
-    const trackIdsInPathSteps = path.flatMap((step) => ('track' in step ? [step.track] : []));
+    const trackIdsInPathSteps = path.flatMap((step) => [
+      ...('track' in step ? [step.track] : []),
+      ...('track_reference' in step && step.track_reference && 'track_id' in step.track_reference
+        ? [step.track_reference.track_id]
+        : []),
+    ]);
     const trackIdsOnPath = (operationalPointsOnPath || []).map((op) => op.part.track);
     return [...trackIdsInPathSteps, ...trackIdsOnPath];
   }, [selectedTrain?.path, operationalPointsOnPath]);
@@ -80,7 +85,7 @@ const useOutputTableData = (
         const trackName =
           'track' in pathStep
             ? trackSections[pathStep.track]?.extensions?.sncf?.track_name
-            : getTrackReferenceLabel(pathStep.track_reference);
+            : getTrackReferenceLabel(trackSections, pathStep.track_reference);
 
         const schedule = scheduleByAt[pathStep.id];
         const computedArrival = simulatedPathItemTimes


### PR DESCRIPTION
Updates the `getTrackReferenceLabel` function to accept `trackSections` and use the SNCF extension's `track_name` instead of the track ID when available, falling back to "?" otherwise.

