### PR TITLE
front: display etcs curves in speed space chart

### DIFF
--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -535,6 +535,16 @@
       "context": "Context",
       "electricalProfiles": "Electrical profiles",
       "energySource": "Energy source",
+      "etcs": {
+        "guidance": "GUI",
+        "indication": "IND",
+        "permittedSpeed": "PS",
+        "routing": "Routing",
+        "signals": "Signals",
+        "spacing": "Spacing",
+        "stopsAndTransitions": "Stops and transitions",
+        "title": "ETCS"
+      },
       "powerRestrictions": "Power restrictions",
       "reticleInfos": "Reticle infos",
       "slopes": "Slopes",

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -535,6 +535,16 @@
       "context": "Contexte",
       "electricalProfiles": "Profils électrique",
       "energySource": "Source d'énergie",
+      "etcs": {
+        "guidance": "GUI",
+        "indication": "IND",
+        "permittedSpeed": "PS",
+        "routing": "Itinéraires",
+        "signals": "Signaux",
+        "spacing": "Espacement",
+        "stopsAndTransitions": "Arrêts et transitions",
+        "title": "ETCS"
+      },
       "powerRestrictions": "Restrictions de puissance",
       "reticleInfos": "Infos réticule",
       "slopes": "Déclivités",

--- a/front/src/applications/operationalStudies/hooks/useEtcsBrakingCurves.ts
+++ b/front/src/applications/operationalStudies/hooks/useEtcsBrakingCurves.ts
@@ -1,0 +1,97 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import {
+  type EtcsBrakingCurve,
+  type EtcsBrakingCurves,
+  EtcsBrakingCurveType,
+  EtcsBrakingType,
+} from '@osrd-project/ui-charts';
+import { useSelector } from 'react-redux';
+
+import {
+  type EtcsBrakingCurvesResponse,
+  type EtcsCurves,
+  osrdEditoastApi,
+  type SimulationResponseSuccess,
+} from 'common/api/osrdEditoastApi';
+import { formatSpeedCurve } from 'modules/simulationResult/components/SpeedDistanceDiagram/helpers';
+import { findExceptionWithOccurrenceId } from 'modules/timetableItem/helpers/pacedTrain';
+import useSelectedTimetableItem from 'modules/timetableItem/hooks/useSelectedTimetableItem';
+import { getSelectedTrainId } from 'reducers/simulationResults/selectors';
+
+import { useScenarioContext } from './useScenarioContext';
+import { isPacedTrainResponseWithPacedTrainId, isTrainScheduleId } from '../../../utils/trainId';
+
+const formatEtcsCurves = (etcsBrakingCurves: EtcsBrakingCurvesResponse): EtcsBrakingCurves => {
+  const { conflicts, slowdowns, stops } = etcsBrakingCurves;
+  const toBrakingCurve = (curve: EtcsCurves): EtcsBrakingCurve => ({
+    [EtcsBrakingCurveType.IND]: curve.indication
+      ? formatSpeedCurve(curve.indication.positions, curve.indication.speeds)
+      : [],
+    [EtcsBrakingCurveType.PS]: formatSpeedCurve(
+      curve.permitted_speed.positions,
+      curve.permitted_speed.speeds
+    ),
+    [EtcsBrakingCurveType.GUI]: formatSpeedCurve(curve.guidance.positions, curve.guidance.speeds),
+  });
+
+  return {
+    [EtcsBrakingType.STOP]: stops.map(toBrakingCurve),
+    [EtcsBrakingType.SLOWDOWN]: slowdowns.map(toBrakingCurve),
+    [EtcsBrakingType.SPACING]: conflicts
+      .filter((conflict) => conflict.conflict_type == 'Spacing')
+      .map(toBrakingCurve),
+    [EtcsBrakingType.ROUTING]: conflicts
+      .filter((conflict) => conflict.conflict_type == 'Routing')
+      .map(toBrakingCurve),
+  };
+};
+
+const useEtcsBrakingCurves = (
+  isEtcs: boolean,
+  simulation: SimulationResponseSuccess | undefined
+): {
+  etcsBrakingCurves: EtcsBrakingCurves | undefined;
+  fetchEtcsBrakingCurves: (() => Promise<void>) | undefined;
+} => {
+  const [getEtcsBrakingCurves] = osrdEditoastApi.endpoints.getEtcsBrakingCurves.useLazyQuery();
+  const [etcsBrakingCurves, setEtcsBrakingCurves] = useState<EtcsBrakingCurves>();
+
+  const { infraId, electricalProfileSetId } = useScenarioContext();
+  const selectedTrainId = useSelector(getSelectedTrainId);
+  const timetableItem = useSelectedTimetableItem();
+  const exception = useMemo(() => {
+    if (!selectedTrainId || !timetableItem || !isPacedTrainResponseWithPacedTrainId(timetableItem))
+      return undefined;
+    if (isTrainScheduleId(selectedTrainId))
+      throw new Error(`trainId ${selectedTrainId} should be a occurrence id`);
+    return findExceptionWithOccurrenceId(timetableItem.exceptions, selectedTrainId);
+  }, [selectedTrainId, timetableItem]);
+
+  const fetchEtcsBrakingCurves = useCallback(async () => {
+    if (selectedTrainId) {
+      const data = await getEtcsBrakingCurves({
+        id: selectedTrainId,
+        infraId,
+        electricalProfileSetId,
+        exceptionKey: exception?.key,
+      }).unwrap();
+      setEtcsBrakingCurves(formatEtcsCurves(data));
+    } else {
+      setEtcsBrakingCurves(undefined);
+    }
+  }, [selectedTrainId, infraId, electricalProfileSetId, exception]);
+
+  // Update existing curves when simulation changes
+  useEffect(() => {
+    if (etcsBrakingCurves) {
+      fetchEtcsBrakingCurves();
+    }
+  }, [simulation]);
+
+  return isEtcs
+    ? { etcsBrakingCurves, fetchEtcsBrakingCurves }
+    : { etcsBrakingCurves: undefined, fetchEtcsBrakingCurves: undefined };
+};
+
+export default useEtcsBrakingCurves;

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
@@ -4,6 +4,7 @@ import { ChevronLeft, ChevronRight, Eye } from '@osrd-project/ui-icons';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
+import useEtcsBrakingCurves from 'applications/operationalStudies/hooks/useEtcsBrakingCurves';
 import { useScenarioContext } from 'applications/operationalStudies/hooks/useScenarioContext';
 import useSimulationResults from 'applications/operationalStudies/hooks/useSimulationResults';
 import type { Board } from 'applications/operationalStudies/types';
@@ -194,6 +195,11 @@ const SimulationResults = ({
     }
   };
 
+  const { etcsBrakingCurves, fetchEtcsBrakingCurves } = useEtcsBrakingCurves(
+    simulationResults?.rollingStock?.etcs_brake_params !== null,
+    simulationResults?.isValid ? simulationResults.simulation : undefined
+  );
+
   if (!simulationResults && !projectionData) {
     return null;
   }
@@ -298,6 +304,8 @@ const SimulationResults = ({
                         pathProperties={simulationResults.pathProperties}
                         height={SDDHeight - HIDDEN_CHART_TOP_HEIGHT}
                         setHeight={setSDDHeight}
+                        fetchEtcsBrakingCurves={fetchEtcsBrakingCurves}
+                        etcsBrakingCurves={etcsBrakingCurves}
                       />
                     </div>
                   </BoardWrapper>

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -10,6 +10,7 @@ import {
 
 import {
   generatedEditoastApi,
+  type EtcsBrakingCurvesResponse,
   type GetLightRollingStockApiResponse,
   type GetSpritesSignalingSystemsApiResponse,
   type MacroNodeResponse,
@@ -179,6 +180,46 @@ const osrdEditoastApi = generatedEditoastApi
             ).unwrap();
           }
           return { data: simulation };
+        },
+        providesTags: (_result, _error, arg) => [
+          isTrainScheduleId(arg.id) ? 'train_schedule' : 'paced_train',
+        ],
+      }),
+      getEtcsBrakingCurves: builder.query<
+        EtcsBrakingCurvesResponse,
+        { id: TrainId; infraId: number; electricalProfileSetId?: number; exceptionKey?: string }
+      >({
+        queryFn: async (
+          { id: trainId, infraId, electricalProfileSetId, exceptionKey },
+          { dispatch }
+        ) => {
+          let etcsBrakingCurves: EtcsBrakingCurvesResponse;
+          if (isTrainScheduleId(trainId)) {
+            etcsBrakingCurves = await dispatch(
+              generatedEditoastApi.endpoints.getTrainScheduleByIdEtcsBrakingCurves.initiate(
+                {
+                  id: extractEditoastIdFromTrainScheduleId(trainId),
+                  infraId,
+                  electricalProfileSetId,
+                },
+                { subscribe: false }
+              )
+            ).unwrap();
+          } else {
+            const pacedTrainId = extractPacedTrainIdFromOccurrenceId(trainId);
+            etcsBrakingCurves = await dispatch(
+              generatedEditoastApi.endpoints.getPacedTrainByIdEtcsBrakingCurves.initiate(
+                {
+                  id: extractEditoastIdFromPacedTrainId(pacedTrainId),
+                  infraId,
+                  electricalProfileSetId,
+                  exceptionKey,
+                },
+                { subscribe: false }
+              )
+            ).unwrap();
+          }
+          return { data: etcsBrakingCurves };
         },
         providesTags: (_result, _error, arg) => [
           isTrainScheduleId(arg.id) ? 'train_schedule' : 'paced_train',

--- a/front/src/modules/simulationResult/components/SpeedDistanceDiagram/SpeedDistanceDiagramWrapper.tsx
+++ b/front/src/modules/simulationResult/components/SpeedDistanceDiagram/SpeedDistanceDiagramWrapper.tsx
@@ -4,6 +4,7 @@ import {
   SpeedSpaceChart,
   type LayerData,
   type PowerRestrictionValues,
+  type EtcsBrakingCurves,
 } from '@osrd-project/ui-charts';
 import { useTranslation } from 'react-i18next';
 
@@ -22,6 +23,8 @@ export type SpeedDistanceDiagramWrapperProps = {
   height: number;
   rollingStock: RollingStockWithLiveries;
   setHeight: React.Dispatch<React.SetStateAction<number>>;
+  fetchEtcsBrakingCurves?: () => Promise<void>;
+  etcsBrakingCurves?: EtcsBrakingCurves;
 };
 
 const SPEED_DISTANCE_DIAGRAM_MIN_HEIGHT = 400;
@@ -34,6 +37,8 @@ const SpeedDistanceDiagramWrapper = ({
   height,
   rollingStock,
   setHeight,
+  fetchEtcsBrakingCurves,
+  etcsBrakingCurves,
 }: SpeedDistanceDiagramWrapperProps) => {
   const { t } = useTranslation('operational-studies', { keyPrefix: 'simulationResults' });
 
@@ -53,6 +58,7 @@ const SpeedDistanceDiagramWrapper = ({
       energySource: t('speedDistanceSettings.energySource'),
       tractionStatus: t('speedDistanceSettings.tractionStatus'),
       declivities: t('speedDistanceSettings.slopes'),
+      etcs: t('speedDistanceSettings.etcs.title'),
       electricalProfiles: t('speedDistanceSettings.electricalProfiles'),
       powerRestrictions: t('speedDistanceSettings.powerRestrictions'),
     },
@@ -65,6 +71,20 @@ const SpeedDistanceDiagramWrapper = ({
       electricalProfiles: t('speedDistanceSettings.electricalProfiles'),
       powerRestrictions: t('speedDistanceSettings.powerRestrictions'),
       speedLimitTags: t('speedDistanceSettings.speedLimitTags'),
+    },
+    etcsLayersDisplay: {
+      title: t('speedDistanceSettings.etcs.title'),
+      etcsBrakingTypes: {
+        stopsAndTransitions: t('speedDistanceSettings.etcs.stopsAndTransitions'),
+        signals: t('speedDistanceSettings.etcs.signals'),
+        spacing: t('speedDistanceSettings.etcs.spacing'),
+        routing: t('speedDistanceSettings.etcs.routing'),
+      },
+      etcsBrakingCurveTypes: {
+        indication: t('speedDistanceSettings.etcs.indication'),
+        permittedSpeed: t('speedDistanceSettings.etcs.permittedSpeed'),
+        guidance: t('speedDistanceSettings.etcs.guidance'),
+      },
     },
   };
 
@@ -102,6 +122,8 @@ const SpeedDistanceDiagramWrapper = ({
           backgroundColor={SPEED_DISTANCE_DIAGRAM_BACKGROUND_COLOR}
           data={data}
           translations={translations}
+          fetchEtcsBrakingCurves={fetchEtcsBrakingCurves}
+          etcsBrakingCurves={etcsBrakingCurves}
         />
       )}
     </div>

--- a/front/src/modules/simulationResult/components/SpeedDistanceDiagram/helpers.ts
+++ b/front/src/modules/simulationResult/components/SpeedDistanceDiagram/helpers.ts
@@ -81,14 +81,17 @@ const formatSpeedLimitTags = (
     return mergedPositions;
   }, [] as LayerData<SpeedLimitTagValues>[]);
 
-export const formatSpeeds = (simulation: ReportTrain) => {
-  const { positions, speeds } = simulation;
-  return speeds.map((value, index) => ({
+export const formatSpeedCurve = (positions: number[], speeds: number[]) =>
+  speeds.map((value, index) => ({
     position: {
       start: mmToKm(positions[index]),
     },
     value: msToKmh(value),
   }));
+
+export const formatSpeeds = (simulation: ReportTrain) => {
+  const { positions, speeds } = simulation;
+  return formatSpeedCurve(positions, speeds);
 };
 
 const formatMrsp = (mrsp: SimulationResponseSuccess['mrsp']) => ({
@@ -146,11 +149,7 @@ export const getProfileValue = (
   if (electricalProfileValue.electrical_profile_type === 'no_profile') {
     return { electricalProfile: 'neutral' };
   }
-  if (
-    !electricalProfileValue.handled ||
-    !electricalProfileValue.profile ||
-    electricalProfileValue.profile === null
-  ) {
+  if (!electricalProfileValue.handled || !electricalProfileValue.profile) {
     return {
       electricalProfile: 'incompatible',
       color:

--- a/front/tests/pages/operational-studies/simulation-results-page.ts
+++ b/front/tests/pages/operational-studies/simulation-results-page.ts
@@ -40,7 +40,7 @@ class OpSimulationResultPage extends ScenarioPage {
     this.simulationMap = page.getByTestId('simulation-map');
     this.speedSpaceChartSettingsButton = page.getByTestId('interaction-settings');
     this.speedSpaceChartCloseSettingsButton = page.getByTestId('settings-panel-close');
-    this.speedSpaceChartCheckboxItems = page.locator('#settings-panel .selection .checkmark');
+    this.speedSpaceChartCheckboxItems = page.locator('#settings-panel .checkmark');
     this.conflictsList = page.getByTestId('conflicts-list');
     this.trainList = page.getByTestId('scenario-left-column');
     this.simulationMap = page.getByTestId('simulation-map');

--- a/front/ui/storybook/stories/ui-charts/speedSpaceChart/consts.ts
+++ b/front/ui/storybook/stories/ui-charts/speedSpaceChart/consts.ts
@@ -4,6 +4,7 @@ export const defaultTranslations = {
     energySource: 'Energy Source',
     tractionStatus: 'Traction Status',
     declivities: 'Declivities',
+    etcs: 'ETCS',
     electricalProfiles: 'Electrical Profiles',
     powerRestrictions: 'Power Restrictions',
   },
@@ -16,6 +17,20 @@ export const defaultTranslations = {
     electricalProfiles: 'Electrical Profiles',
     powerRestrictions: 'Power Restrictions',
     speedLimitTags: 'Speed Limit Tags',
+  },
+  etcsLayersDisplay: {
+    title: 'ETCS',
+    etcsBrakingTypes: {
+      stopsAndTransitions: 'Stops and transitions',
+      signals: 'Signals',
+      spacing: 'Spacing',
+      routing: 'Routing',
+    },
+    etcsBrakingCurveTypes: {
+      indication: 'IND',
+      permittedSpeed: 'PS',
+      guidance: 'GUI',
+    },
   },
 };
 

--- a/front/ui/ui-charts/src/speedSpaceChart/__tests__/utils.spec.ts
+++ b/front/ui/ui-charts/src/speedSpaceChart/__tests__/utils.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { MARGINS } from '../components/const';
+import { DEFAULT_ETCS_LAYERS_DISPLAY, MARGINS } from '../components/const';
 import {
   clearCanvas,
   getGraphOffsets,
@@ -47,6 +47,7 @@ const store: Store = {
     energySource: true,
     tractionStatus: true,
     electricalProfiles: true,
+    etcs: false,
     powerRestrictions: true,
     declivities: true,
   },
@@ -58,6 +59,7 @@ const store: Store = {
     speedLimitTags: false,
     steps: true,
   },
+  etcsLayersDisplay: DEFAULT_ETCS_LAYERS_DISPLAY,
   isSettingsPanelOpened: false,
 };
 

--- a/front/ui/ui-charts/src/speedSpaceChart/components/SpeedSpaceChart.tsx
+++ b/front/ui/ui-charts/src/speedSpaceChart/components/SpeedSpaceChart.tsx
@@ -2,10 +2,10 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { Slider } from '@osrd-project/ui-core';
 
-import type { Data, Store } from '../types';
+import type { Data, EtcsBrakingCurves, Store } from '../types';
 import InteractionButtons from './common/InteractionButtons';
 import SettingsPanel from './common/SettingsPanel';
-import { LINEAR_LAYERS_HEIGHTS, MARGINS, ZOOM_CONFIG } from './const';
+import { DEFAULT_ETCS_LAYERS_DISPLAY, LINEAR_LAYERS_HEIGHTS, MARGINS, ZOOM_CONFIG } from './const';
 import { computeLeftOffsetOnZoom, resetZoom } from './helpers/layersManager';
 import {
   AxisLayerY,
@@ -21,13 +21,15 @@ import {
   TickLayerX,
   TickLayerYRight,
 } from './layers/index';
-import { clamp, getGraphOffsets } from './utils';
+import { clamp, getActiveEtcsBrakingTypes, getGraphOffsets } from './utils';
 
 export type SpeedSpaceChartProps = {
   width: number;
   height: number;
   backgroundColor: string;
   setHeight: React.Dispatch<React.SetStateAction<number>>;
+  fetchEtcsBrakingCurves?: () => Promise<void>;
+  etcsBrakingCurves?: EtcsBrakingCurves;
   data: Data;
   translations?: {
     detailsBoxDisplay: {
@@ -35,6 +37,7 @@ export type SpeedSpaceChartProps = {
       energySource: string;
       tractionStatus: string;
       declivities: string;
+      etcs: string;
       electricalProfiles: string;
       powerRestrictions: string;
     };
@@ -48,6 +51,20 @@ export type SpeedSpaceChartProps = {
       powerRestrictions: string;
       speedLimitTags: string;
     };
+    etcsLayersDisplay: {
+      title: string;
+      etcsBrakingTypes: {
+        stopsAndTransitions: string;
+        signals: string;
+        spacing: string;
+        routing: string;
+      };
+      etcsBrakingCurveTypes: {
+        indication: string;
+        permittedSpeed: string;
+        guidance: string;
+      };
+    };
   };
 };
 
@@ -58,6 +75,8 @@ const SpeedSpaceChart = ({
   data,
   setHeight,
   translations,
+  fetchEtcsBrakingCurves,
+  etcsBrakingCurves,
 }: SpeedSpaceChartProps) => {
   const [store, setStore] = useState<Store>({
     speeds: [],
@@ -80,6 +99,7 @@ const SpeedSpaceChart = ({
       energySource: true,
       tractionStatus: true,
       declivities: true,
+      etcs: false,
       electricalProfiles: true,
       powerRestrictions: true,
     },
@@ -91,6 +111,7 @@ const SpeedSpaceChart = ({
       powerRestrictions: false,
       speedLimitTags: false,
     },
+    etcsLayersDisplay: DEFAULT_ETCS_LAYERS_DISPLAY,
     isSettingsPanelOpened: false,
   });
 
@@ -186,6 +207,21 @@ const SpeedSpaceChart = ({
   );
 
   useEffect(() => {
+    const shouldFetchEtcsCurves = getActiveEtcsBrakingTypes(store.etcsLayersDisplay).length > 0;
+    if (fetchEtcsBrakingCurves && shouldFetchEtcsCurves) {
+      fetchEtcsBrakingCurves();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fetchEtcsBrakingCurves, store.etcsLayersDisplay]);
+
+  useEffect(() => {
+    setStore((prev) => ({
+      ...prev,
+      etcsBrakingCurves: etcsBrakingCurves,
+    }));
+  }, [etcsBrakingCurves]);
+
+  useEffect(() => {
     setStore((prev) => ({
       ...prev,
       ...data,
@@ -247,6 +283,7 @@ const SpeedSpaceChart = ({
             translations={translations}
             testIdPrefix="settings-panel"
             adjustHeightOnLayerChange={adjustHeightOnLayerChange}
+            displayEtcs={fetchEtcsBrakingCurves !== undefined}
           />
         </div>
       )}

--- a/front/ui/ui-charts/src/speedSpaceChart/components/common/DetailsBox.tsx
+++ b/front/ui/ui-charts/src/speedSpaceChart/components/common/DetailsBox.tsx
@@ -25,6 +25,7 @@ type DetailsBoxProps = {
   modeText: string;
 };
 
+// TODO: add ETCS details
 const DetailsBox = ({
   width,
   height,

--- a/front/ui/ui-charts/src/speedSpaceChart/components/common/SettingsPanel.tsx
+++ b/front/ui/ui-charts/src/speedSpaceChart/components/common/SettingsPanel.tsx
@@ -56,31 +56,30 @@ const SettingsPanel = ({
           <span>{translations?.layersDisplay.context || 'Context'}</span>
         </div>
         {LAYERS_SELECTION.map((selection) => (
-          <div key={selection} className="selection">
-            <Checkbox
-              data-testid={testIdPrefix ? `${testIdPrefix}-layer-${selection}` : undefined}
-              label={translations?.layersDisplay[selection] || selection}
-              checked={store.layersDisplay[selection]}
-              disabled={!isLayerActive(store, selection)}
-              onChange={() => {
-                setStore((prev) => ({
-                  ...prev,
-                  layersDisplay: {
-                    ...prev.layersDisplay,
-                    [selection]: !prev.layersDisplay[selection],
-                  },
-                }));
+          <Checkbox
+            key={selection}
+            data-testid={testIdPrefix ? `${testIdPrefix}-layer-${selection}` : undefined}
+            label={translations?.layersDisplay[selection] || selection}
+            checked={store.layersDisplay[selection]}
+            disabled={!isLayerActive(store, selection)}
+            onChange={() => {
+              setStore((prev) => ({
+                ...prev,
+                layersDisplay: {
+                  ...prev.layersDisplay,
+                  [selection]: !prev.layersDisplay[selection],
+                },
+              }));
 
-                if (
-                  selection === 'electricalProfiles' ||
-                  selection === 'powerRestrictions' ||
-                  selection === 'speedLimitTags'
-                ) {
-                  adjustHeightOnLayerChange(selection, store.layersDisplay[selection]);
-                }
-              }}
-            />
-          </div>
+              if (
+                selection === 'electricalProfiles' ||
+                selection === 'powerRestrictions' ||
+                selection === 'speedLimitTags'
+              ) {
+                adjustHeightOnLayerChange(selection, store.layersDisplay[selection]);
+              }
+            }}
+          />
         ))}
       </div>
       <div className="settings-panel-section">
@@ -88,21 +87,20 @@ const SettingsPanel = ({
           <span>{translations?.detailsBoxDisplay.reticleInfos || 'Reticle infos'}</span>
         </div>
         {DETAILS_BOX_SELECTION.map((selection) => (
-          <div key={selection} className="selection">
-            <Checkbox
-              label={translations?.detailsBoxDisplay[selection] || selection}
-              checked={store.detailsBoxDisplay[selection]}
-              onChange={() => {
-                setStore((prev) => ({
-                  ...prev,
-                  detailsBoxDisplay: {
-                    ...prev.detailsBoxDisplay,
-                    [selection]: !prev.detailsBoxDisplay[selection],
-                  },
-                }));
-              }}
-            />
-          </div>
+          <Checkbox
+            key={selection}
+            label={translations?.detailsBoxDisplay[selection] || selection}
+            checked={store.detailsBoxDisplay[selection]}
+            onChange={() => {
+              setStore((prev) => ({
+                ...prev,
+                detailsBoxDisplay: {
+                  ...prev.detailsBoxDisplay,
+                  [selection]: !prev.detailsBoxDisplay[selection],
+                },
+              }));
+            }}
+          />
         ))}
       </div>
       <button

--- a/front/ui/ui-charts/src/speedSpaceChart/components/common/SettingsPanel.tsx
+++ b/front/ui/ui-charts/src/speedSpaceChart/components/common/SettingsPanel.tsx
@@ -1,12 +1,17 @@
 import React from 'react';
 
-import { Checkbox } from '@osrd-project/ui-core';
+import { Checkbox, CheckboxesTree } from '@osrd-project/ui-core';
 import { X } from '@osrd-project/ui-icons';
 
 import type { Store } from '../../types';
-import { DETAILS_BOX_SELECTION, LAYERS_SELECTION } from '../const';
+import {
+  DETAILS_BOX_SELECTION,
+  type ETCS_BRAKING_SELECTION,
+  ETCS_CURVE_SELECTION,
+  LAYERS_SELECTION,
+} from '../const';
 import type { SpeedSpaceChartProps } from '../SpeedSpaceChart';
-import { isLayerActive } from '../utils';
+import { getActiveEtcsBrakingTypes, isLayerActive } from '../utils';
 
 const SETTINGS_PANEL_BASE_HEIGHT = 442;
 
@@ -21,6 +26,7 @@ type SettingsPanelProps = {
   ) => void;
   translations?: SpeedSpaceChartProps['translations'];
   testIdPrefix?: string;
+  displayEtcs?: boolean;
 };
 
 const SettingsPanel = ({
@@ -31,12 +37,34 @@ const SettingsPanel = ({
   adjustHeightOnLayerChange,
   translations,
   testIdPrefix,
+  displayEtcs,
 }: SettingsPanelProps) => {
   const closeSettingsPanel = () => {
     setIsMouseHoveringSettingsPanel(false);
     setStore((prev) => ({
       ...prev,
       isSettingsPanelOpened: false,
+    }));
+  };
+
+  const stopsAndTransitions: keyof typeof ETCS_BRAKING_SELECTION = 'stopsAndTransitions';
+  const otherEtcsBrakingTypes: (keyof typeof ETCS_BRAKING_SELECTION)[] = ['spacing', 'routing'];
+  const updateEtcsBrakingType = (
+    etcsBrakingType: keyof typeof ETCS_BRAKING_SELECTION,
+    newValue?: boolean
+  ) => {
+    setStore((prev) => ({
+      ...prev,
+      etcsLayersDisplay: {
+        ...prev.etcsLayersDisplay,
+        etcsBrakingTypes: {
+          ...prev.etcsLayersDisplay.etcsBrakingTypes,
+          [etcsBrakingType]:
+            newValue !== undefined
+              ? newValue
+              : !prev.etcsLayersDisplay.etcsBrakingTypes[etcsBrakingType],
+        },
+      },
     }));
   };
 
@@ -82,26 +110,119 @@ const SettingsPanel = ({
           />
         ))}
       </div>
+      {displayEtcs && (
+        <div className="settings-panel-section">
+          <div className="settings-panel-section-title">
+            <span>{translations?.etcsLayersDisplay.title || 'ETCS'}</span>
+          </div>
+          <CheckboxesTree
+            id={'etcs-braking-types'}
+            items={[
+              {
+                id: 0,
+                props: {
+                  label:
+                    translations?.etcsLayersDisplay.etcsBrakingTypes[stopsAndTransitions] ||
+                    stopsAndTransitions,
+                  checked: store.etcsLayersDisplay.etcsBrakingTypes[stopsAndTransitions],
+                  onChange: () => {
+                    updateEtcsBrakingType(stopsAndTransitions);
+                  },
+                },
+              },
+              {
+                id: 1,
+                props: {
+                  label: translations?.etcsLayersDisplay.etcsBrakingTypes.signals,
+                  checked: otherEtcsBrakingTypes.every(
+                    (key) => store.etcsLayersDisplay.etcsBrakingTypes[key]
+                  ),
+                  isIndeterminate:
+                    otherEtcsBrakingTypes.some(
+                      (key) => store.etcsLayersDisplay.etcsBrakingTypes[key]
+                    ) &&
+                    !otherEtcsBrakingTypes.every(
+                      (key) => store.etcsLayersDisplay.etcsBrakingTypes[key]
+                    ),
+                  onChange: () => {
+                    const newValue = !otherEtcsBrakingTypes.every(
+                      (key) => store.etcsLayersDisplay.etcsBrakingTypes[key]
+                    );
+                    otherEtcsBrakingTypes.map((etcsBrakingType) =>
+                      updateEtcsBrakingType(etcsBrakingType, newValue)
+                    );
+                  },
+                },
+                items: otherEtcsBrakingTypes.map((etcsBrakingType, index) => ({
+                  id: index + 2,
+                  props: {
+                    label:
+                      translations?.etcsLayersDisplay.etcsBrakingTypes[etcsBrakingType] ||
+                      etcsBrakingType,
+                    checked: store.etcsLayersDisplay.etcsBrakingTypes[etcsBrakingType],
+                    onChange: () => {
+                      updateEtcsBrakingType(etcsBrakingType);
+                    },
+                  },
+                })),
+              },
+            ]}
+          />
+          {getActiveEtcsBrakingTypes(store.etcsLayersDisplay).length > 0 && (
+            <div className="bottom-panel">
+              {(Object.keys(ETCS_CURVE_SELECTION) as (keyof typeof ETCS_CURVE_SELECTION)[]).map(
+                (selection) => (
+                  <Checkbox
+                    key={selection}
+                    label={
+                      translations?.etcsLayersDisplay.etcsBrakingCurveTypes[selection] || selection
+                    }
+                    checked={store.etcsLayersDisplay.etcsBrakingCurveTypes[selection]}
+                    onChange={() => {
+                      setStore((prev) => ({
+                        ...prev,
+                        etcsLayersDisplay: {
+                          ...prev.etcsLayersDisplay,
+                          etcsBrakingCurveTypes: {
+                            ...prev.etcsLayersDisplay.etcsBrakingCurveTypes,
+                            [selection]: !prev.etcsLayersDisplay.etcsBrakingCurveTypes[selection],
+                          },
+                        },
+                      }));
+                    }}
+                  />
+                )
+              )}
+            </div>
+          )}
+        </div>
+      )}
       <div className="settings-panel-section">
         <div className="settings-panel-section-title">
           <span>{translations?.detailsBoxDisplay.reticleInfos || 'Reticle infos'}</span>
         </div>
-        {DETAILS_BOX_SELECTION.map((selection) => (
-          <Checkbox
-            key={selection}
-            label={translations?.detailsBoxDisplay[selection] || selection}
-            checked={store.detailsBoxDisplay[selection]}
-            onChange={() => {
-              setStore((prev) => ({
-                ...prev,
-                detailsBoxDisplay: {
-                  ...prev.detailsBoxDisplay,
-                  [selection]: !prev.detailsBoxDisplay[selection],
-                },
-              }));
-            }}
-          />
-        ))}
+        {DETAILS_BOX_SELECTION.filter((detail_box) => detail_box !== 'etcs' || displayEtcs).map(
+          (selection) => (
+            <Checkbox
+              key={selection}
+              label={translations?.detailsBoxDisplay[selection] || selection}
+              checked={store.detailsBoxDisplay[selection]}
+              disabled={
+                // TODO: enable when etcs details are fixed
+                selection === 'etcs'
+              }
+              onChange={() => {
+                setStore((prev) => ({
+                  ...prev,
+                  detailsBoxDisplay: {
+                    ...prev.detailsBoxDisplay,
+                    [selection]: !prev.detailsBoxDisplay[selection],
+                  },
+                }));
+              }}
+            />
+          )
+        )}
       </div>
       <button
         id="close-settings-panel"

--- a/front/ui/ui-charts/src/speedSpaceChart/components/common/SettingsPanel.tsx
+++ b/front/ui/ui-charts/src/speedSpaceChart/components/common/SettingsPanel.tsx
@@ -83,7 +83,7 @@ const SettingsPanel = ({
           </div>
         ))}
       </div>
-      <div className="settings-panel-section right">
+      <div className="settings-panel-section">
         <div className="settings-panel-section-title">
           <span>{translations?.detailsBoxDisplay.reticleInfos || 'Reticle infos'}</span>
         </div>

--- a/front/ui/ui-charts/src/speedSpaceChart/components/const.ts
+++ b/front/ui/ui-charts/src/speedSpaceChart/components/const.ts
@@ -76,6 +76,9 @@ export const GREY_80 = chroma(49, 46, 43);
 export const LIGHT_BLUE = chroma(33, 112, 185);
 export const WARNING_30 = chroma(234, 167, 43);
 export const WHITE = chroma(255, 255, 255);
+export const BASE_SPEED_COLOR = chroma(17, 101, 180);
+export const ECO_SPEED_COLOR = chroma(7, 69, 128);
+export const BASE_SPEED_FILL_ALPHA = 0.15;
 
 /**
  * COLOR_DICTIONARY maps specific colors to their corresponding secondary colors used for speed limit tags.
@@ -93,3 +96,5 @@ export const ZOOM_CONFIG = {
   MAX_RATIO: 50,
   SLIDER_WIDTH: 100,
 };
+
+export const CURVE_LINEWIDTH = 0.5;

--- a/front/ui/ui-charts/src/speedSpaceChart/components/const.ts
+++ b/front/ui/ui-charts/src/speedSpaceChart/components/const.ts
@@ -1,6 +1,13 @@
 import chroma from 'chroma-js';
 
-import { type ColorDictionary, type Store } from '../types';
+import {
+  type ColorDictionary,
+  EtcsBrakingCurveType,
+  EtcsBrakingType,
+  type EtcsColorDictionary,
+  type EtcsLayersDisplay,
+  type Store,
+} from '../types';
 
 export const SLOPE_FILL_COLOR = '#CFDDCE';
 
@@ -33,12 +40,6 @@ export const LINEAR_LAYERS_HEIGHTS = {
   SPEED_LIMIT_TAGS_HEIGHT: 40,
 };
 
-export const LINEAR_LAYERS_HEIGHTS_BY_NAME = {
-  electricalProfiles: LINEAR_LAYERS_HEIGHTS.ELECTRICAL_PROFILES_HEIGHT,
-  powerRestrictions: LINEAR_LAYERS_HEIGHTS.POWER_RESTRICTIONS_HEIGHT,
-  speedLimitTags: LINEAR_LAYERS_HEIGHTS.SPEED_LIMIT_TAGS_HEIGHT,
-};
-
 export const LINEAR_LAYER_SEPARATOR_HEIGHT = 1;
 
 export const LINEAR_LAYERS_BACKGROUND_COLOR = {
@@ -53,6 +54,7 @@ export const DETAILS_BOX_SELECTION: Array<keyof Store['detailsBoxDisplay']> = [
   'energySource',
   'tractionStatus',
   'declivities',
+  'etcs',
   'electricalProfiles',
   'powerRestrictions',
 ];
@@ -66,6 +68,37 @@ export const LAYERS_SELECTION: Array<keyof Store['layersDisplay']> = [
   'speedLimitTags',
 ];
 
+export const DEFAULT_ETCS_LAYERS_DISPLAY = {
+  etcsBrakingTypes: {
+    stopsAndTransitions: false,
+    spacing: false,
+    routing: false,
+  },
+  etcsBrakingCurveTypes: {
+    indication: true,
+    permittedSpeed: true,
+    guidance: true,
+  },
+};
+
+export const ETCS_BRAKING_SELECTION: Record<
+  keyof EtcsLayersDisplay['etcsBrakingTypes'],
+  EtcsBrakingType[]
+> = {
+  stopsAndTransitions: [EtcsBrakingType.STOP, EtcsBrakingType.SLOWDOWN],
+  spacing: [EtcsBrakingType.SPACING],
+  routing: [EtcsBrakingType.ROUTING],
+};
+
+export const ETCS_CURVE_SELECTION: Record<
+  keyof EtcsLayersDisplay['etcsBrakingCurveTypes'],
+  EtcsBrakingCurveType
+> = {
+  indication: EtcsBrakingCurveType.IND,
+  permittedSpeed: EtcsBrakingCurveType.PS,
+  guidance: EtcsBrakingCurveType.GUI,
+};
+
 // Colors
 
 export const BLACK = chroma(0, 0, 0);
@@ -78,7 +111,20 @@ export const WARNING_30 = chroma(234, 167, 43);
 export const WHITE = chroma(255, 255, 255);
 export const BASE_SPEED_COLOR = chroma(17, 101, 180);
 export const ECO_SPEED_COLOR = chroma(7, 69, 128);
+const IND_COLOR = chroma(3, 222, 255);
+const PS_COLOR = chroma(0, 87, 218);
+const GUI_COLOR = chroma(255, 192, 3);
+const IND_ALPHA = 0.3;
+const PS_ALPHA = 0.24;
+const GUI_ALPHA = 0.4;
 export const BASE_SPEED_FILL_ALPHA = 0.15;
+
+// Etcs color dictionary
+export const ETCS_COLOR_DICTIONARY: EtcsColorDictionary = {
+  [EtcsBrakingCurveType.IND]: IND_COLOR.alpha(IND_ALPHA),
+  [EtcsBrakingCurveType.PS]: PS_COLOR.alpha(PS_ALPHA),
+  [EtcsBrakingCurveType.GUI]: GUI_COLOR.alpha(GUI_ALPHA),
+};
 
 /**
  * COLOR_DICTIONARY maps specific colors to their corresponding secondary colors used for speed limit tags.
@@ -97,4 +143,5 @@ export const ZOOM_CONFIG = {
   SLIDER_WIDTH: 100,
 };
 
-export const CURVE_LINEWIDTH = 0.5;
+export const SPEEDS_LINEWIDTH = 0.5;
+export const ETCS_LINEWIDTH = 3;

--- a/front/ui/ui-charts/src/speedSpaceChart/components/helpers/drawElements/curve.ts
+++ b/front/ui/ui-charts/src/speedSpaceChart/components/helpers/drawElements/curve.ts
@@ -1,13 +1,21 @@
-import type { DrawFunctionParams, LayerData } from '../../../types';
+import type { DrawFunctionParams, EtcsBrakingCurveType, LayerData } from '../../../types';
 import {
   BASE_SPEED_COLOR,
   BASE_SPEED_FILL_ALPHA,
   ECO_SPEED_COLOR,
-  CURVE_LINEWIDTH,
+  SPEEDS_LINEWIDTH,
   MARGINS,
   WHITE,
+  ETCS_COLOR_DICTIONARY,
+  ETCS_LINEWIDTH,
 } from '../../const';
-import { clearCanvas, maxPositionValue, maxSpeedValue } from '../../utils';
+import {
+  clearCanvas,
+  getActiveEtcsBrakingCurveTypes,
+  getActiveEtcsBrakingTypes,
+  maxPositionValue,
+  maxSpeedValue,
+} from '../../utils';
 
 const { CURVE_MARGIN_TOP, CURVE_MARGIN_SIDES } = MARGINS;
 
@@ -40,7 +48,7 @@ const computeCurvePoints = (
 };
 
 export const drawCurve = ({ ctx, width, height, store }: DrawFunctionParams) => {
-  const { speeds, ecoSpeeds, ratioX, leftOffset } = store;
+  const { speeds, ecoSpeeds, etcsBrakingCurves, ratioX, leftOffset } = store;
 
   clearCanvas(ctx, width, height);
 
@@ -63,15 +71,16 @@ export const drawCurve = ({ ctx, width, height, store }: DrawFunctionParams) => 
 
   // Curves must be drawn twice, once for the fill and once for the stroke.
   // The stroke must not draw the last two points. They're only present to close the shape but are not part of the curve.
-  ctx.lineWidth = CURVE_LINEWIDTH;
+  ctx.lineWidth = SPEEDS_LINEWIDTH;
 
+  // Fill speed curve.
   ctx.beginPath();
   ctx.fillStyle = BASE_SPEED_COLOR.alpha(BASE_SPEED_FILL_ALPHA).hex();
   curvePoints.forEach(({ x, y }) => {
     ctx.lineTo(x, y);
   });
   ctx.fill();
-
+  // Stroke speed curve.
   ctx.beginPath();
   ctx.strokeStyle = BASE_SPEED_COLOR.hex();
   curvePoints.slice(0, curvePoints.length - 2).forEach(({ x, y }) => {
@@ -79,6 +88,7 @@ export const drawCurve = ({ ctx, width, height, store }: DrawFunctionParams) => 
   });
   ctx.stroke();
 
+  // Fill eco speed curve.
   ctx.beginPath();
   ctx.fillStyle = WHITE.hex();
   ctx.globalCompositeOperation = 'destination-out';
@@ -86,7 +96,7 @@ export const drawCurve = ({ ctx, width, height, store }: DrawFunctionParams) => 
     ctx.lineTo(x, y);
   });
   ctx.fill();
-
+  // Stroke eco speed curve.
   ctx.beginPath();
   ctx.strokeStyle = ECO_SPEED_COLOR.hex();
   ctx.globalCompositeOperation = 'source-over';
@@ -94,6 +104,38 @@ export const drawCurve = ({ ctx, width, height, store }: DrawFunctionParams) => 
     ctx.lineTo(x, y);
   });
   ctx.stroke();
+
+  // Stroke etcs curves.
+  if (etcsBrakingCurves) {
+    const strokeEtcsCurve = (
+      etcsBrakingCurveType: EtcsBrakingCurveType,
+      etcsCurve: LayerData<number>[]
+    ) => {
+      const etcsCurvePoints = computeCurvePoints(
+        { width, height },
+        { maxSpeed, maxPosition, ratioX },
+        etcsCurve
+      );
+      ctx.beginPath();
+      ctx.lineWidth = ETCS_LINEWIDTH;
+      ctx.strokeStyle = ETCS_COLOR_DICTIONARY[etcsBrakingCurveType].hex();
+      etcsCurvePoints.slice(0, etcsCurvePoints.length - 2).forEach(({ x, y }) => {
+        ctx.lineTo(x, y);
+      });
+      ctx.stroke();
+    };
+
+    const activeEtcsBrakingTypes = getActiveEtcsBrakingTypes(store.etcsLayersDisplay);
+    const activeEtcsBrakingCurveTypes = getActiveEtcsBrakingCurveTypes(store.etcsLayersDisplay);
+    activeEtcsBrakingTypes.forEach((brakingType) => {
+      const etcsCurves = etcsBrakingCurves[brakingType];
+      etcsCurves.forEach((etcsCurve) => {
+        activeEtcsBrakingCurveTypes.forEach((curveType) => {
+          strokeEtcsCurve(curveType, etcsCurve[curveType]);
+        });
+      });
+    });
+  }
 
   ctx.restore();
 };

--- a/front/ui/ui-charts/src/speedSpaceChart/components/helpers/drawElements/curve.ts
+++ b/front/ui/ui-charts/src/speedSpaceChart/components/helpers/drawElements/curve.ts
@@ -1,7 +1,12 @@
-import chroma from 'chroma-js';
-
 import type { DrawFunctionParams, LayerData } from '../../../types';
-import { MARGINS } from '../../const';
+import {
+  BASE_SPEED_COLOR,
+  BASE_SPEED_FILL_ALPHA,
+  ECO_SPEED_COLOR,
+  CURVE_LINEWIDTH,
+  MARGINS,
+  WHITE,
+} from '../../const';
 import { clearCanvas, maxPositionValue, maxSpeedValue } from '../../utils';
 
 const { CURVE_MARGIN_TOP, CURVE_MARGIN_SIDES } = MARGINS;
@@ -36,8 +41,6 @@ const computeCurvePoints = (
 
 export const drawCurve = ({ ctx, width, height, store }: DrawFunctionParams) => {
   const { speeds, ecoSpeeds, ratioX, leftOffset } = store;
-  const baseSpeedColor = chroma(17, 101, 180);
-  const ecoSpeedColor = chroma(7, 69, 128);
 
   clearCanvas(ctx, width, height);
 
@@ -58,27 +61,26 @@ export const drawCurve = ({ ctx, width, height, store }: DrawFunctionParams) => 
     ecoSpeeds
   );
 
-  // Curves must be drawn twice one for the fill and one for the stroke
+  // Curves must be drawn twice, once for the fill and once for the stroke.
   // The stroke must not draw the last two points. They're only present to close the shape but are not part of the curve.
+  ctx.lineWidth = CURVE_LINEWIDTH;
 
   ctx.beginPath();
-  ctx.lineWidth = 0.5;
-  ctx.strokeStyle = baseSpeedColor.hex();
-  ctx.fillStyle = baseSpeedColor.alpha(0.15).hex();
+  ctx.fillStyle = BASE_SPEED_COLOR.alpha(BASE_SPEED_FILL_ALPHA).hex();
   curvePoints.forEach(({ x, y }) => {
     ctx.lineTo(x, y);
   });
   ctx.fill();
 
   ctx.beginPath();
+  ctx.strokeStyle = BASE_SPEED_COLOR.hex();
   curvePoints.slice(0, curvePoints.length - 2).forEach(({ x, y }) => {
     ctx.lineTo(x, y);
   });
   ctx.stroke();
 
   ctx.beginPath();
-  ctx.fillStyle = 'rgba(255, 255, 255)';
-  ctx.strokeStyle = ecoSpeedColor.hex();
+  ctx.fillStyle = WHITE.hex();
   ctx.globalCompositeOperation = 'destination-out';
   ecoCurvePoints.forEach(({ x, y }) => {
     ctx.lineTo(x, y);
@@ -86,6 +88,7 @@ export const drawCurve = ({ ctx, width, height, store }: DrawFunctionParams) => 
   ctx.fill();
 
   ctx.beginPath();
+  ctx.strokeStyle = ECO_SPEED_COLOR.hex();
   ctx.globalCompositeOperation = 'source-over';
   ecoCurvePoints.slice(0, ecoCurvePoints.length - 2).forEach(({ x, y }) => {
     ctx.lineTo(x, y);

--- a/front/ui/ui-charts/src/speedSpaceChart/components/utils.ts
+++ b/front/ui/ui-charts/src/speedSpaceChart/components/utils.ts
@@ -4,8 +4,10 @@ import {
   LINEAR_LAYERS_HEIGHTS,
   MARGINS,
   type LAYERS_SELECTION,
+  ETCS_BRAKING_SELECTION,
+  ETCS_CURVE_SELECTION,
 } from './const';
-import type { LayerData, OperationalPoints, Store } from '../types';
+import type { EtcsLayersDisplay, LayerData, OperationalPoints, Store } from '../types';
 
 type SlopesValues = {
   minGradient: number;
@@ -382,3 +384,15 @@ export const getSnappedStop = (cursorX: number, width: number, store: Store) => 
   }
   return null;
 };
+
+/** Retrieve list of active EtcsBrakingTypes. */
+export const getActiveEtcsBrakingTypes = (layers: EtcsLayersDisplay) =>
+  (Object.entries(layers.etcsBrakingTypes) as [keyof typeof ETCS_BRAKING_SELECTION, boolean][])
+    .filter(([_, isActive]) => isActive)
+    .flatMap(([key]) => ETCS_BRAKING_SELECTION[key]);
+
+/** Retrieve list of active EtcsBrakingCurveTypes. */
+export const getActiveEtcsBrakingCurveTypes = (layers: EtcsLayersDisplay) =>
+  (Object.entries(layers.etcsBrakingCurveTypes) as [keyof typeof ETCS_CURVE_SELECTION, boolean][])
+    .filter(([_, isActive]) => isActive)
+    .map(([key]) => ETCS_CURVE_SELECTION[key]);

--- a/front/ui/ui-charts/src/speedSpaceChart/index.ts
+++ b/front/ui/ui-charts/src/speedSpaceChart/index.ts
@@ -12,4 +12,7 @@ export type {
   ElectrificationValues,
   SpeedLimitTagValues,
   Data as SpeedSpaceChartData,
+  EtcsBrakingCurve,
+  EtcsBrakingCurves,
 } from './types';
+export { EtcsBrakingCurveType, EtcsBrakingType } from './types';

--- a/front/ui/ui-charts/src/speedSpaceChart/styles/main.css
+++ b/front/ui/ui-charts/src/speedSpaceChart/styles/main.css
@@ -114,7 +114,9 @@
 #settings-panel {
   position: absolute;
   display: flex;
-  width: 32.875rem;
+  min-width: 32.875rem;
+  max-width: 100%;
+  padding-left: 16px;
   margin-right: 20px;
   color: rgb(49, 46, 43);
   border-radius: 0 0.625rem 0 0;
@@ -125,13 +127,9 @@
   z-index: 10;
 
   .settings-panel-section {
-    width: 227px;
-    margin-left: 32px;
+    min-width: 227px;
     margin-top: 29px;
-
-    .right {
-      margin-left: 16px;
-    }
+    margin-left: 16px;
 
     .settings-panel-section-title {
       height: 1.5rem;
@@ -161,12 +159,10 @@
 
   #close-settings-panel {
     position: absolute;
-    align-self: flex-start;
-    height: 1rem;
-    width: 1rem;
-    margin-left: 30.625rem;
-    margin-top: 0.875rem;
-    margin-right: 0.875rem;
+    top: 14px;
+    right: 14px;
+    height: 16px;
+    width: 16px;
     border: none;
     cursor: pointer;
 

--- a/front/ui/ui-charts/src/speedSpaceChart/styles/main.css
+++ b/front/ui/ui-charts/src/speedSpaceChart/styles/main.css
@@ -123,7 +123,6 @@
   backdrop-filter: blur(0.3125rem);
   box-shadow: inset 0 0 0 0.0625rem rgb(255, 255, 255);
   border: solid 0.0625rem rgba(0, 0, 0, 0.1);
-  box-shadow: 0 0 0 0.0625rem rgb(250, 249, 245);
   z-index: 10;
 
   .settings-panel-section {
@@ -137,23 +136,6 @@
       font-size: 1rem;
       font-weight: 600;
       margin-bottom: 0.4375rem;
-    }
-  }
-
-  .selection {
-    height: 1.75rem;
-    padding-top: 0.1875rem;
-    padding-bottom: 0.3125rem;
-    margin-bottom: 0.25rem;
-
-    .selection-checkbox {
-      height: 1.125rem;
-      margin-left: 0.5rem;
-    }
-
-    .selection-label {
-      font-weight: 400;
-      margin-left: 0.5rem;
     }
   }
 

--- a/front/ui/ui-charts/src/speedSpaceChart/styles/main.css
+++ b/front/ui/ui-charts/src/speedSpaceChart/styles/main.css
@@ -116,7 +116,8 @@
   display: flex;
   min-width: 32.875rem;
   max-width: 100%;
-  padding-left: 16px;
+  padding-left: 12px;
+  padding-right: 28px;
   margin-right: 20px;
   color: rgb(49, 46, 43);
   border-radius: 0 0.625rem 0 0;
@@ -128,14 +129,22 @@
   .settings-panel-section {
     min-width: 227px;
     margin-top: 29px;
-    margin-left: 16px;
+    margin-left: 20px;
+    margin-right: 20px;
 
     .settings-panel-section-title {
-      height: 1.5rem;
-      line-height: 1.5rem;
-      font-size: 1rem;
+      height: 24px;
+      font-size: 16px;
       font-weight: 600;
-      margin-bottom: 0.4375rem;
+      margin-bottom: 7px;
+    }
+
+    .ui-feedback {
+      padding: 0 0 0 0;
+    }
+
+    .bottom-panel {
+      margin-top: 36px;
     }
   }
 

--- a/front/ui/ui-charts/src/speedSpaceChart/types.ts
+++ b/front/ui/ui-charts/src/speedSpaceChart/types.ts
@@ -1,3 +1,5 @@
+import type chroma from 'chroma-js';
+
 export type ElectricalProfileValues = {
   electricalProfile: string;
   color?: string;
@@ -54,6 +56,7 @@ type SpeedLimit = {
 export type Data = {
   speeds: LayerData<number>[];
   ecoSpeeds: LayerData<number>[];
+  etcsBrakingCurves?: EtcsBrakingCurves;
   stops: LayerData<OperationalPoints>[];
   electrifications: LayerData<ElectrificationValues>[];
   slopes: LayerData<number>[];
@@ -76,6 +79,7 @@ export type Store = Data & {
     energySource: boolean;
     tractionStatus: boolean;
     declivities: boolean;
+    etcs: boolean;
     electricalProfiles: boolean;
     powerRestrictions: boolean;
   };
@@ -87,6 +91,7 @@ export type Store = Data & {
     powerRestrictions: boolean;
     speedLimitTags: boolean;
   };
+  etcsLayersDisplay: EtcsLayersDisplay;
   isSettingsPanelOpened: boolean;
 };
 
@@ -135,3 +140,39 @@ export type tooltipInfos = {
 export type ColorDictionary = {
   [key: string]: string;
 };
+
+export type EtcsBrakingCurve = {
+  [key in EtcsBrakingCurveType]: LayerData<number>[];
+};
+
+export type EtcsBrakingCurves = {
+  [key in EtcsBrakingType]: EtcsBrakingCurve[];
+};
+
+export enum EtcsBrakingType {
+  STOP,
+  SLOWDOWN,
+  SPACING,
+  ROUTING,
+}
+
+export enum EtcsBrakingCurveType {
+  IND,
+  PS,
+  GUI,
+}
+
+export type EtcsLayersDisplay = {
+  etcsBrakingTypes: {
+    stopsAndTransitions: boolean;
+    spacing: boolean;
+    routing: boolean;
+  };
+  etcsBrakingCurveTypes: {
+    indication: boolean;
+    permittedSpeed: boolean;
+    guidance: boolean;
+  };
+};
+
+export type EtcsColorDictionary = Record<EtcsBrakingCurveType, chroma.Color>;


### PR DESCRIPTION
Fixes https://github.com/OpenRailAssociation/osrd/issues/13690 and https://github.com/OpenRailAssociation/osrd/issues/13690. To be reviewed commit by commit. To test: import etcs_infra and etcs_level2_rolling_stock from osrd/tests/data with scripts.

First few commits are:
- side quests cleanup of code and dead code
- etcs endpoint call logic in osrdEditoastApi

Last commit contains the injection of the etcs curves into the SpeedSpaceChart composant. Expected behavior:
- if rs is not etcs, nothing etcs related is visible in the SettingsPanel. They only appear for etcs rollingstocks
- the 3 type of curves' (IND, PS and GUI) corresponding checkboxes only appear if user wants to display the curves (i.e. checks one of the 4 existing checkboxes, stopsAndTransitions, signals, spacing or routing).
- the etcs curves are computed once you check an etcs checkbox (also works if an etcs box is checked and you change the simulation, i.e. path, stops, stop durations, stop on closed signal etc. => etcs curves are reloaded)
<img width="1515" height="464" alt="image" src="https://github.com/user-attachments/assets/7e0e7ea7-3296-4d6a-bfee-b8e4bfcf11c1" />

Link to the corresponding schematics: https://www.sketch.com/s/eba5c130-4a80-4325-9c9e-778069862393/p/1E404390-471E-48B6-8971-DF426172632B/canvas && https://www.sketch.com/s/eba5c130-4a80-4325-9c9e-778069862393/f/B94D4643-B9A0-41B2-80FB-A379016FE301#Inspect. The colors of the curves were directly verified with @thibautsailly.

Restriction: Etcs reticle info has not been added. The corresponding checkbox has been added but nothing happens for now. This will be done in: https://github.com/OpenRailAssociation/osrd/issues/13824.