### PR TITLE
editoast: remove 'diesel-async-migrations' deprecated dependency

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -935,36 +935,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -983,22 +959,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core 0.21.3",
+ "darling_core",
  "quote",
  "syn",
 ]
@@ -1029,7 +994,6 @@ version = "0.1.0"
 dependencies = [
  "diesel",
  "diesel-async",
- "diesel_async_migrations",
  "diesel_migrations",
  "futures 0.3.31",
  "futures-util",
@@ -1167,14 +1131,15 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.2.12"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229850a212cd9b84d4f0290ad9d294afc0ae70fccaa8949dbe8b43ffafa1e20c"
+checksum = "e8496eeb328dce26ee9d9b73275d396d9bddb433fa30106cf6056dd8c3c2764c"
 dependencies = [
  "bitflags 2.9.2",
  "byteorder",
  "chrono",
  "diesel_derives",
+ "downcast-rs",
  "itoa",
  "pq-sys",
  "serde_json",
@@ -1183,13 +1148,14 @@ dependencies = [
 
 [[package]]
 name = "diesel-async"
-version = "0.5.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51a307ac00f7c23f526a04a77761a0519b9f0eb2838ebf5b905a58580095bdcb"
+checksum = "c69eded9cb72c7e112505caec23da00149d4dd49f4c96b3c83b2b63f0aa3da5f"
 dependencies = [
- "async-trait",
  "deadpool",
  "diesel",
+ "diesel_migrations",
+ "futures-core",
  "futures-util",
  "scoped-futures",
  "tokio",
@@ -1197,33 +1163,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "diesel_async_migrations"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b99915cbb9455e8fd56f12edc58f92bbdf8161e4363cb2000cf4308aa6358ff4"
-dependencies = [
- "diesel",
- "diesel-async",
- "diesel_async_migrations_macros",
- "scoped-futures",
- "tracing",
-]
-
-[[package]]
-name = "diesel_async_migrations_macros"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05de210f31e6ac18162501b03c37f839af9f9fd6dd6de2bb4031ae6691c47679"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
 name = "diesel_derives"
-version = "2.2.7"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b96984c469425cb577bf6f17121ecb3e4fe1e81de5d8f780dd372802858d756"
+checksum = "09af0e983035368439f1383011cd87c46f41da81d0f21dc3727e2857d5a43c8e"
 dependencies = [
  "diesel_table_macro_syntax",
  "dsl_auto_type",
@@ -1245,9 +1188,9 @@ dependencies = [
 
 [[package]]
 name = "diesel_migrations"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a73ce704bad4231f001bff3314d91dce4aba0770cee8b233991859abc15c1f6"
+checksum = "ee060f709c3e3b1cadd83fcd0f61711f7a8cf493348f758d3a1c1147d70b3c97"
 dependencies = [
  "diesel",
  "migrations_internals",
@@ -1256,9 +1199,9 @@ dependencies = [
 
 [[package]]
 name = "diesel_table_macro_syntax"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "209c735641a413bc68c4923a9d6ad4bcb3ca306b794edaa7eb0b3228a99ffb25"
+checksum = "fe2444076b48641147115697648dc743c2c00b61adade0f01ce67133c7babe8c"
 dependencies = [
  "syn",
 ]
@@ -1298,12 +1241,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
-name = "dsl_auto_type"
-version = "0.1.3"
+name = "downcast-rs"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ae9aca7527f85f26dd76483eb38533fd84bd571065da1739656ef71c5ff5b"
+checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
+
+[[package]]
+name = "dsl_auto_type"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd122633e4bef06db27737f21d3738fb89c8f6d5360d6d9d7635dda142a7757e"
 dependencies = [
- "darling 0.20.11",
+ "darling",
  "either",
  "heck",
  "proc-macro2",
@@ -1398,7 +1347,7 @@ dependencies = [
 name = "editoast_derive"
 version = "0.1.0"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "insta",
  "pretty_assertions",
  "prettyplease",
@@ -1690,7 +1639,7 @@ dependencies = [
 name = "fga_derive"
 version = "0.1.0"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "quote",
  "syn",
 ]
@@ -2735,9 +2684,9 @@ checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "migrations_internals"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bda1634d70d5bd53553cf15dca9842a396e8c799982a3ad22998dc44d961f24"
+checksum = "36c791ecdf977c99f45f23280405d7723727470f6689a5e6dbf513ac547ae10d"
 dependencies = [
  "serde",
  "toml",
@@ -2745,9 +2694,9 @@ dependencies = [
 
 [[package]]
 name = "migrations_macros"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb161cc72176cb37aa47f1fc520d3ef02263d67d661f44f05d05a079e1237fd"
+checksum = "36fc5ac76be324cfd2d3f2cf0fdf5d5d3c4f14ed8aaebadb09e304ba42282703"
 dependencies = [
  "migrations_internals",
  "proc-macro2",
@@ -4283,7 +4232,7 @@ version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7e6c180db0816026a61afa1cff5344fb7ebded7e4d3062772179f2501481c27"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "proc-macro2",
  "quote",
  "syn",
@@ -4798,12 +4747,10 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41ae868b5a0f67631c14589f7e250c1ea2c574ee5ba21c6c8dd4b1485705a5a1"
 dependencies = [
- "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
  "toml_parser",
- "toml_writer",
  "winnow",
 ]
 
@@ -4824,12 +4771,6 @@ checksum = "97200572db069e74c512a14117b296ba0a80a30123fbbb5aa1f4a348f639ca30"
 dependencies = [
  "winnow",
 ]
-
-[[package]]
-name = "toml_writer"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
 
 [[package]]
 name = "tonic"

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -58,15 +58,16 @@ derive_more = { version = "2.0.1", features = [
   "from",
   "from_str",
 ] }
-diesel = { version = "2.2", default-features = false, features = [
+diesel = { version = "2.3", default-features = false, features = [
   "32-column-tables",
   "chrono",
   "postgres",
   "serde_json",
   "uuid",
 ] }
-diesel-async = { version = "0.5", default-features = false, features = [
+diesel-async = { version = "0.7", default-features = false, features = [
   "deadpool",
+  "migrations",
   "postgres",
 ] }
 diesel_json = "0.3.0"

--- a/editoast/database/Cargo.toml
+++ b/editoast/database/Cargo.toml
@@ -10,7 +10,6 @@ testing = []
 [dependencies]
 diesel.workspace = true
 diesel-async.workspace = true
-diesel_async_migrations = { version = "0.15.0" }
 diesel_migrations = { version = "2.0.0" }
 futures.workspace = true
 futures-util.workspace = true

--- a/editoast/database/src/db_connection_pool.rs
+++ b/editoast/database/src/db_connection_pool.rs
@@ -34,22 +34,7 @@ pub type DbConnectionConfig = AsyncDieselConnectionManager<AsyncPgConnection>;
 static TEMPLATE_CREATION_MUTEX: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 #[cfg(any(test, feature = "testing"))]
-fn get_migrations() -> (diesel_async_migrations::EmbeddedMigrations, String) {
-    let migrations = diesel_async_migrations::embed_migrations!();
-    let mut hash_data = vec![];
-
-    for diesel_async_migrations::EmbeddedMigration { name, up, down } in migrations.migrations {
-        hash_data.push((name, up, down))
-    }
-
-    use std::hash::Hash as _;
-    use std::hash::Hasher as _;
-    let mut hasher = std::hash::DefaultHasher::new();
-    hash_data.hash(&mut hasher);
-    let hash = format!("{}", hasher.finish());
-
-    (migrations, hash)
-}
+const MIGRATIONS: diesel_migrations::EmbeddedMigrations = diesel_migrations::embed_migrations!();
 
 #[cfg(any(test, feature = "testing"))]
 async fn db_exists(url: &str) -> bool {
@@ -64,11 +49,24 @@ async fn db_exists(url: &str) -> bool {
 }
 
 #[cfg(any(test, feature = "testing"))]
-async fn template_creation(osrd_conn: DbConnection) -> Result<String, Box<dyn std::error::Error>> {
+async fn template_creation(
+    osrd_conn: DbConnection,
+) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
     // Prevents other tests from interfering during template creation and avoids conflicts
+
+    use diesel::migration::MigrationSource;
+    use diesel::pg::Pg;
+    use diesel_async::AsyncMigrationHarness;
+    use diesel_migrations::MigrationHarness as _;
+
     let _lock = TEMPLATE_CREATION_MUTEX.lock().await;
-    let (migrations, hash) = get_migrations();
-    let template_name = format!("osrd_template_{hash}");
+    let last_migration_name = MigrationSource::<Pg>::migrations(&MIGRATIONS)?
+        .last()
+        .map(|migration| migration.name())
+        .map(ToString::to_string)
+        .map(|name| name.replace('-', "_"))
+        .unwrap_or_else(|| String::from("no_migration"));
+    let template_name = format!("osrd_template_{last_migration_name}");
 
     let template_url_postgres: Url =
         format!("postgresql://postgres:password@localhost/{template_name}")
@@ -90,9 +88,10 @@ async fn template_creation(osrd_conn: DbConnection) -> Result<String, Box<dyn st
                 if let diesel::result::Error::DatabaseError(_, ref err) = e
                     && err.message().ends_with("already exists")
                 {
-                    return Ok(0);
+                    Ok(0)
+                } else {
+                    Err(e)
                 }
-                Err(e)
             })?;
 
         let template_pool = create_connection_pool(template_url_postgres.clone(), 1)?;
@@ -104,9 +103,8 @@ async fn template_creation(osrd_conn: DbConnection) -> Result<String, Box<dyn st
     }
 
     let template_pool = create_connection_pool(template_url_osrd, 1)?;
-    let mut conn = template_pool.get().await?;
-
-    migrations.run_pending_migrations(&mut conn).await?;
+    let mut migration_harness = AsyncMigrationHarness::new(template_pool.get().await?);
+    migration_harness.run_pending_migrations(MIGRATIONS)?;
 
     Ok(template_name)
 }
@@ -115,7 +113,7 @@ async fn template_creation(osrd_conn: DbConnection) -> Result<String, Box<dyn st
 async fn create_test_database(
     osrd_conn: DbConnection,
     db_name: String,
-) -> Result<(String, String), Box<dyn std::error::Error>> {
+) -> Result<(String, String), Box<dyn std::error::Error + Send + Sync>> {
     let template_name = template_creation(osrd_conn.clone()).await?;
 
     diesel::sql_query(format!(
@@ -351,7 +349,7 @@ impl DbConnectionPoolV2 {
     }
 
     #[cfg(any(test, feature = "testing"))]
-    async fn new_test(test_name: String) -> Result<Self, Box<dyn std::error::Error>> {
+    async fn new_test(test_name: String) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         let osrd_pool = Arc::new(create_connection_pool(
             "postgresql://postgres:password@localhost/osrd"
                 .parse()


### PR DESCRIPTION
Closes #13748

The bump of `diesel-async` creates duplicate versions of the dependency because `diesel-async-migrations` has not been updated... and is considered deprecated. The documentation of `diesel-async-migrations` link some example to do it with official `diesel` and `diesel_migrations`... but it only works for SQlite.

However, the [last version of `diesel-async`](https://github.com/weiznich/diesel_async/releases/tag/v0.7.0) seems to contain everything we need for running migrations thanks to `AsyncMigrationHarness`. I had to do some modifications to the way hash are calculated (based on `MigrationVersion` which should be unique per migration from what I undersand of [the documentation](https://docs.rs/diesel/2.2.12/diesel/migration/struct.MigrationVersion.html)). I also had to bump `diesel` to follow the new version of `diesel-async`.