### PR TITLE
core: migrate schedule metadata extractor + signal projection

### DIFF
--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathImpl.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathImpl.kt
@@ -39,6 +39,10 @@ data class TrainPathNoBacktrack(
         mapSubObjects(routes, rawInfra::getRoutePath, rawInfra::getZonePathLength)
     }
 
+    private val cachedZoneRanges by lazy {
+        cachedZonePaths.map { it.mapValue<ZoneId, Zone>(rawInfra.getZonePathZone(it.value)) }
+    }
+
     init {
         // The sanity checks here are quite exhaustive and might be expensive to compute.
         // Once the path types are stable, we can remove some of the tests.
@@ -92,6 +96,8 @@ data class TrainPathNoBacktrack(
     override fun getChunks(): List<DirChunkRange> = chunks
 
     override fun getZonePaths(): List<ZonePathRange> = cachedZonePaths
+
+    override fun getZoneRanges(): List<ZoneRange> = cachedZoneRanges
 
     override val length: Double
         get() = pathProperties.getLength().meters

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/GenericLinearRange.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/GenericLinearRange.kt
@@ -1,6 +1,8 @@
 package fr.sncf.osrd.path.interfaces
 
 import fr.sncf.osrd.sim_infra.api.Block
+import fr.sncf.osrd.sim_infra.api.BlockInfra
+import fr.sncf.osrd.sim_infra.api.RawInfra
 import fr.sncf.osrd.sim_infra.api.Route
 import fr.sncf.osrd.sim_infra.api.TrackChunk
 import fr.sncf.osrd.sim_infra.api.Zone
@@ -169,4 +171,20 @@ fun <ValueType, OffsetType, SubObjectType, SubObjectOffset> mapSubObjects(
         res.addAll(subRanges)
     }
     return mergeLinearRanges(res)
+}
+
+// Some extension functions to make `getObjectAbsolutePathEnd` calls less verbose. We could instead
+// put the object length in the range itself, but that would waste some memory for a value that's
+// rarely accessed in practice.
+
+fun ZonePathRange.getZonePathAbsolutePathEnd(infra: RawInfra): Offset<TrainPath> {
+    return getObjectAbsolutePathEnd(infra.getZonePathLength(value))
+}
+
+fun RouteRange.getRouteAbsolutePathEnd(infra: RawInfra): Offset<TrainPath> {
+    return getObjectAbsolutePathEnd(infra.getRouteLength(value))
+}
+
+fun BlockRange.getBlockAbsolutePathEnd(blockInfra: BlockInfra): Offset<TrainPath> {
+    return getObjectAbsolutePathEnd(blockInfra.getBlockLength(value))
 }

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/TrainPath.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/TrainPath.kt
@@ -50,15 +50,13 @@ interface TrainPath : PhysicsPath, PathProperties {
     fun getChunks(): List<DirChunkRange>
 
     fun getZonePaths(): List<ZonePathRange>
+
+    fun getZoneRanges(): List<ZoneRange>
     // To be expanded as needed with other linear objects
 }
 
 fun concat(vararg paths: TrainPath): TrainPath {
     TODO("Required for actual backtracks, not necessary earlier than that")
-}
-
-fun TrainPath.getZones(rawInfra: RawInfra): List<ZoneRange> {
-    return getZonePaths().map { it.mapValue(rawInfra.getZonePathZone(it.value)) }
 }
 
 // Extension functions that help with backward compatibility.

--- a/core/kt-osrd-signaling/build.gradle
+++ b/core/kt-osrd-signaling/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     api project(':kt-railjson-builder')
     api project(":osrd-railjson")
     api project(":osrd-reporting")
+    implementation project(":kt-osrd-path")
 
     implementation libs.kotlin.logging
     implementation libs.kotlin.stdlib

--- a/core/kt-osrd-signaling/src/main/kotlin/fr/sncf/osrd/signaling/SignalingSimulator.kt
+++ b/core/kt-osrd-signaling/src/main/kotlin/fr/sncf/osrd/signaling/SignalingSimulator.kt
@@ -1,5 +1,6 @@
 package fr.sncf.osrd.signaling
 
+import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.sim_infra.api.*
 
 /*
@@ -68,6 +69,17 @@ interface SignalingSimulator {
         fullPath: List<BlockId>,
         routes: List<RouteId>,
         evaluatedPathEnd: Int,
+        zoneStates: List<ZoneStatus>,
+        followingZoneState: ZoneStatus,
+        followingSignalState: SigState? = null,
+        followingSignalSettings: SigSettings? = null,
+    ): Map<LogicalSignalId, SigState>
+
+    fun evaluate(
+        infra: RawInfra,
+        loadedSignalInfra: LoadedSignalInfra,
+        blocks: BlockInfra,
+        trainPath: TrainPath,
         zoneStates: List<ZoneStatus>,
         followingZoneState: ZoneStatus,
         followingSignalState: SigState? = null,

--- a/core/kt-osrd-signaling/src/main/kotlin/fr/sncf/osrd/signaling/impl/SignalingSimulatorImpl.kt
+++ b/core/kt-osrd-signaling/src/main/kotlin/fr/sncf/osrd/signaling/impl/SignalingSimulatorImpl.kt
@@ -1,11 +1,13 @@
 package fr.sncf.osrd.signaling.impl
 
+import fr.sncf.osrd.path.interfaces.TrainPath
+import fr.sncf.osrd.path.interfaces.getLegacyBlockPath
+import fr.sncf.osrd.path.interfaces.getLegacyRoutePath
 import fr.sncf.osrd.signaling.*
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.sim_infra.impl.SignalParameters
 import fr.sncf.osrd.sim_infra.impl.loadedSignalInfra
 import fr.sncf.osrd.utils.LogAggregator
-import fr.sncf.osrd.utils.indexing.*
 import fr.sncf.osrd.utils.units.Distance
 import mu.KotlinLogging
 
@@ -161,6 +163,33 @@ class SignalingSimulatorImpl(override val sigModuleManager: SigSystemManager) : 
         infra: RawInfra,
         loadedSignalInfra: LoadedSignalInfra,
         blocks: BlockInfra,
+        trainPath: TrainPath,
+        zoneStates: List<ZoneStatus>,
+        followingZoneState: ZoneStatus,
+        followingSignalState: SigState?,
+        followingSignalSettings: SigSettings?,
+    ): Map<LogicalSignalId, SigState> {
+        val fullPath = trainPath.getLegacyBlockPath()
+        val routes = trainPath.getLegacyRoutePath()
+        val evaluatedPathEnd = fullPath.size
+        return evaluate(
+            infra,
+            loadedSignalInfra,
+            blocks,
+            fullPath,
+            routes,
+            evaluatedPathEnd,
+            zoneStates,
+            followingZoneState,
+            followingSignalState,
+            followingSignalSettings,
+        )
+    }
+
+    override fun evaluate(
+        infra: RawInfra,
+        loadedSignalInfra: LoadedSignalInfra,
+        blocks: BlockInfra,
         fullPath: List<BlockId>,
         routes: List<RouteId>,
         evaluatedPathEnd: Int,
@@ -169,6 +198,7 @@ class SignalingSimulatorImpl(override val sigModuleManager: SigSystemManager) : 
         followingSignalState: SigState?,
         followingSignalSettings: SigSettings?,
     ): Map<LogicalSignalId, SigState> {
+        // TODO path migration: remove this overload
         assert(evaluatedPathEnd > 0)
         assert(evaluatedPathEnd <= fullPath.size)
         val routeSet by lazy { routes.toSet() }

--- a/core/kt-osrd-sncf-signaling/build.gradle
+++ b/core/kt-osrd-sncf-signaling/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     // PLEASE ADD AND UPDATE DEPENDENCIES USING libs.versions.toml
     api project(':kt-osrd-signaling')
     api project(':osrd-reporting')
+    implementation project(":kt-osrd-path")
 
     implementation libs.kotlin.stdlib
     testImplementation libs.kotlin.test

--- a/core/kt-osrd-sncf-signaling/src/test/kotlin/fr/sncf/osrd/signaling/bal/TestBALtoBAL.kt
+++ b/core/kt-osrd-sncf-signaling/src/test/kotlin/fr/sncf/osrd/signaling/bal/TestBALtoBAL.kt
@@ -1,5 +1,6 @@
 package fr.sncf.osrd.signaling.bal
 
+import fr.sncf.osrd.path.implementations.buildTrainPathFromBlocks
 import fr.sncf.osrd.railjson.builder.begin
 import fr.sncf.osrd.railjson.builder.buildParseRJSInfra
 import fr.sncf.osrd.railjson.builder.end
@@ -7,9 +8,7 @@ import fr.sncf.osrd.railjson.schema.common.graph.EdgeDirection
 import fr.sncf.osrd.signaling.ZoneStatus
 import fr.sncf.osrd.signaling.impl.SigSystemManagerImpl
 import fr.sncf.osrd.signaling.impl.SignalingSimulatorImpl
-import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.decreasing
-import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -77,18 +76,20 @@ class TestBALtoBAL {
         val simulator = SignalingSimulatorImpl(sigSystemManager)
         val loadedSignalInfra = simulator.loadSignals(infra)
         val blockInfra = simulator.buildBlocks(infra, loadedSignalInfra)
-        val fullPath = mutableStaticIdxArrayListOf<Block>()
-        fullPath.add(blockInfra.getBlocksStartingAtDetector(detU.decreasing).first())
-        fullPath.add(blockInfra.getBlocksStartingAtDetector(detV.decreasing).first())
+        val blocks =
+            listOf(
+                blockInfra.getBlocksStartingAtDetector(detU.decreasing).first(),
+                blockInfra.getBlocksStartingAtDetector(detV.decreasing).first(),
+            )
+        val trainPath =
+            buildTrainPathFromBlocks(infra, blockInfra, blocks, routeNames = listOf("U-Z"))
         val zoneStates = mutableListOf(ZoneStatus.CLEAR, ZoneStatus.CLEAR, ZoneStatus.CLEAR)
         val res =
             simulator.evaluate(
                 infra,
                 loadedSignalInfra,
                 blockInfra,
-                fullPath,
-                listOf(), // we don't use parameters here
-                fullPath.size,
+                trainPath,
                 zoneStates,
                 ZoneStatus.INCOMPATIBLE,
             )

--- a/core/kt-osrd-sncf-signaling/src/test/kotlin/fr/sncf/osrd/signaling/bal/TestBAPRtoBAL.kt
+++ b/core/kt-osrd-sncf-signaling/src/test/kotlin/fr/sncf/osrd/signaling/bal/TestBAPRtoBAL.kt
@@ -1,5 +1,6 @@
 package fr.sncf.osrd.signaling.bal
 
+import fr.sncf.osrd.path.implementations.buildTrainPathFromBlocks
 import fr.sncf.osrd.railjson.builder.begin
 import fr.sncf.osrd.railjson.builder.buildParseRJSInfra
 import fr.sncf.osrd.railjson.builder.end
@@ -10,11 +11,9 @@ import fr.sncf.osrd.signaling.bapr.BAPRtoBAL
 import fr.sncf.osrd.signaling.bapr.BAPRtoBAPR
 import fr.sncf.osrd.signaling.impl.SigSystemManagerImpl
 import fr.sncf.osrd.signaling.impl.SignalingSimulatorImpl
-import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.LogicalSignalId
 import fr.sncf.osrd.sim_infra.api.SigState
 import fr.sncf.osrd.sim_infra.api.increasing
-import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -88,19 +87,21 @@ class TestBAPRtoBAL {
         val simulator = SignalingSimulatorImpl(sigSystemManager)
         val loadedSignalInfra = simulator.loadSignals(infra)
         val blockInfra = simulator.buildBlocks(infra, loadedSignalInfra)
-        val fullPath = mutableStaticIdxArrayListOf<Block>()
-        fullPath.add(blockInfra.getBlocksStartingAtDetector(detW.increasing).first())
-        fullPath.add(blockInfra.getBlocksStartingAtDetector(detX.increasing).first())
-        fullPath.add(blockInfra.getBlocksStartingAtDetector(detY.increasing).first())
+        val blocks =
+            listOf(
+                blockInfra.getBlocksStartingAtDetector(detW.increasing).first(),
+                blockInfra.getBlocksStartingAtDetector(detX.increasing).first(),
+                blockInfra.getBlocksStartingAtDetector(detY.increasing).first(),
+            )
         val zoneStates = mutableListOf(ZoneStatus.CLEAR, ZoneStatus.CLEAR, ZoneStatus.INCOMPATIBLE)
+        val trainPath =
+            buildTrainPathFromBlocks(infra, blockInfra, blocks, routeNames = listOf("W-Z"))
         val res =
             simulator.evaluate(
                 infra,
                 loadedSignalInfra,
                 blockInfra,
-                fullPath,
-                listOf(), // we don't use parameters here
-                fullPath.size,
+                trainPath,
                 zoneStates,
                 ZoneStatus.INCOMPATIBLE,
             )

--- a/core/kt-osrd-sncf-signaling/src/test/kotlin/fr/sncf/osrd/signaling/bal/TestTVM300toBAL.kt
+++ b/core/kt-osrd-sncf-signaling/src/test/kotlin/fr/sncf/osrd/signaling/bal/TestTVM300toBAL.kt
@@ -1,5 +1,6 @@
 package fr.sncf.osrd.signaling.bal
 
+import fr.sncf.osrd.path.implementations.buildTrainPathFromBlocks
 import fr.sncf.osrd.railjson.builder.begin
 import fr.sncf.osrd.railjson.builder.buildParseRJSInfra
 import fr.sncf.osrd.railjson.builder.end
@@ -8,11 +9,9 @@ import fr.sncf.osrd.signaling.ZoneStatus
 import fr.sncf.osrd.signaling.impl.SigSystemManagerImpl
 import fr.sncf.osrd.signaling.impl.SignalingSimulatorImpl
 import fr.sncf.osrd.signaling.tvm300.TVM300
-import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.LogicalSignalId
 import fr.sncf.osrd.sim_infra.api.SigState
 import fr.sncf.osrd.sim_infra.api.increasing
-import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -69,19 +68,21 @@ class TestTVM300toBAL {
         val simulator = SignalingSimulatorImpl(sigSystemManager)
         val loadedSignalInfra = simulator.loadSignals(infra)
         val blockInfra = simulator.buildBlocks(infra, loadedSignalInfra)
-        val fullPath = mutableStaticIdxArrayListOf<Block>()
-        fullPath.add(blockInfra.getBlocksStartingAtDetector(detectorW.increasing).first())
-        fullPath.add(blockInfra.getBlocksStartingAtDetector(detectorX.increasing).first())
-        fullPath.add(blockInfra.getBlocksStartingAtDetector(detectorY.increasing).first())
+        val blocks =
+            listOf(
+                blockInfra.getBlocksStartingAtDetector(detectorW.increasing).first(),
+                blockInfra.getBlocksStartingAtDetector(detectorX.increasing).first(),
+                blockInfra.getBlocksStartingAtDetector(detectorY.increasing).first(),
+            )
         val zoneStates = mutableListOf(ZoneStatus.CLEAR, ZoneStatus.CLEAR, ZoneStatus.INCOMPATIBLE)
+        val trainPath =
+            buildTrainPathFromBlocks(infra, blockInfra, blocks, routeNames = listOf("W-Z"))
         val res =
             simulator.evaluate(
                 infra,
                 loadedSignalInfra,
                 blockInfra,
-                fullPath,
-                listOf(), // we don't use parameters here
-                fullPath.size,
+                trainPath,
                 zoneStates,
                 ZoneStatus.INCOMPATIBLE,
             )

--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingPostProcessing.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingPostProcessing.kt
@@ -8,7 +8,6 @@ import fr.sncf.osrd.path.implementations.buildTrainPathFromBlockRanges
 import fr.sncf.osrd.path.interfaces.BlockPath
 import fr.sncf.osrd.path.interfaces.BlockRange
 import fr.sncf.osrd.path.interfaces.TravelledPath
-import fr.sncf.osrd.path.interfaces.getLegacyBlockPath
 import fr.sncf.osrd.path.interfaces.toJsonTrainPath
 import fr.sncf.osrd.pathfinding.Pathfinding
 import fr.sncf.osrd.pathfinding.Pathfinding.EdgeLocation
@@ -76,11 +75,13 @@ private fun validatePathfindingResponse(
     req: PathfindingBlockRequest,
     res: PathfindingBlockResponse,
 ) {
+    // TODO path migrations: some of those checks won't be true anymore with backtracks
     if (res !is PathfindingBlockSuccess) return
 
     val trainPath = res.path.toTrainPath(infra.rawInfra, infra.blockInfra, null)
-    val blocks = trainPath.getLegacyBlockPath()
-    for ((i, block) in blocks.withIndex()) {
+    val blocks = trainPath.getBlocks()
+    for ((i, blockRange) in blocks.withIndex()) {
+        val block = blockRange.value
         val stopAtBufferStop = infra.blockInfra.blockStopAtBufferStop(block)
         val isLastBlock = i == blocks.size - 1
         if (stopAtBufferStop && !isLastBlock) {

--- a/core/src/main/kotlin/fr/sncf/osrd/api/project_signals/SignalProjectionEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/project_signals/SignalProjectionEndpoint.kt
@@ -2,9 +2,6 @@ package fr.sncf.osrd.api.project_signals
 
 import fr.sncf.osrd.api.ExceptionHandler
 import fr.sncf.osrd.api.InfraProvider
-import fr.sncf.osrd.path.interfaces.getLegacyBlockPath
-import fr.sncf.osrd.path.interfaces.getLegacyChunkPath
-import fr.sncf.osrd.path.interfaces.getLegacyRoutePath
 import fr.sncf.osrd.signal_projection.projectSignals
 import org.takes.Request
 import org.takes.Response
@@ -33,18 +30,13 @@ class SignalProjectionEndpoint(private val infraManager: InfraProvider) : Take {
                     infra.blockInfra,
                     electricalProfileMapping = null,
                 )
-            val chunkPath = trainPath.getLegacyChunkPath()
-            val blockPath = trainPath.getLegacyBlockPath()
-            val routePath = trainPath.getLegacyRoutePath()
 
             val signalProjections = mutableListOf<List<SignalUpdate>>()
             for (trainSimulation in request.trainSimulations) {
                 val signalProjection =
                     projectSignals(
                         infra,
-                        chunkPath,
-                        blockPath,
-                        routePath,
+                        trainPath,
                         trainSimulation.signalCriticalPositions,
                         trainSimulation.zoneUpdates,
                         trainSimulation.simulationEndTime,

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
@@ -234,10 +234,7 @@ class STDCMEndpoint(
             runScheduleMetadataExtractor(
                 path.envelope,
                 path.trainPath,
-                path.chunkPath,
                 infra,
-                path.routePath,
-                path.blocks.ranges.map { it.edge },
                 rollingStock,
                 scheduleItems,
                 listOf(),

--- a/core/src/main/kotlin/fr/sncf/osrd/signal_projection/SignalProjection.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/signal_projection/SignalProjection.kt
@@ -4,17 +4,15 @@ import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.api.SignalCriticalPosition
 import fr.sncf.osrd.api.ZoneUpdate
 import fr.sncf.osrd.api.project_signals.SignalUpdate
-import fr.sncf.osrd.path.implementations.ChunkPath
+import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.path.interfaces.TravelledPath
 import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.signaling.SigSystemManager
 import fr.sncf.osrd.signaling.SignalingSimulator
 import fr.sncf.osrd.signaling.ZoneStatus
 import fr.sncf.osrd.sim_infra.api.*
-import fr.sncf.osrd.standalone_sim.PathOffsetBuilder
 import fr.sncf.osrd.standalone_sim.PathSignal
 import fr.sncf.osrd.standalone_sim.pathSignalsInRange
-import fr.sncf.osrd.utils.trainPathBlockOffset
 import fr.sncf.osrd.utils.units.Duration
 import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.TimeDelta
@@ -25,9 +23,7 @@ data class SignalAspectChangeEvent(val newAspect: String, val time: TimeDelta)
 
 fun projectSignals(
     fullInfra: FullInfra,
-    chunkPath: ChunkPath,
-    blockPath: List<BlockId>,
-    routePath: List<RouteId>,
+    trainPath: TrainPath,
     signalCriticalPositions: Collection<SignalCriticalPosition>,
     zoneUpdates: Collection<ZoneUpdate>,
     simulationEndTime: TimeDelta,
@@ -62,36 +58,19 @@ fun projectSignals(
     }
 
     val zoneMap = mutableMapOf<String, Int>()
-    var zoneCount = 0
-    for (block in blockPath) {
-        for (zonePath in blockInfra.getBlockZonePaths(block)) {
-            val zone = rawInfra.getNextZone(rawInfra.getZonePathEntry(zonePath))!!
-            val zoneName = rawInfra.getZoneName(zone)
-            zoneMap[zoneName] = zoneCount
-            zoneCount++
-        }
+    for ((i, zoneRange) in trainPath.getZoneRanges().withIndex()) {
+        val zoneName = rawInfra.getZoneName(zoneRange.value)
+        zoneMap[zoneName] = i
     }
 
     // Compute signal updates
-    val startOffset =
-        trainPathBlockOffset(fullInfra.rawInfra, fullInfra.blockInfra, blockPath, chunkPath)
-            .distance
     // Compute path signals on path
-    val pathOffsetBuilder = PathOffsetBuilder(startOffset)
-    val pathSignals =
-        pathSignalsInRange(
-            pathOffsetBuilder,
-            blockPath,
-            blockInfra,
-            0.meters,
-            chunkPath.endOffset - chunkPath.beginOffset,
-        )
+    val pathSignals = pathSignalsInRange(trainPath, blockInfra, 0.meters, trainPath.getLength())
     if (pathSignals.isEmpty()) return emptyList()
 
     val signalAspectChangeEvents =
         computeSignalAspectChangeEvents(
-            blockPath,
-            routePath,
+            trainPath,
             zoneMap,
             blockInfra,
             pathSignals,
@@ -109,15 +88,14 @@ fun projectSignals(
             sigSystemManager,
             rawInfra,
             signalCriticalPositions,
-            Length(chunkPath.endOffset - chunkPath.beginOffset),
+            trainPath.getTypedLength(),
             simulationEndTime,
         )
     return signalUpdates
 }
 
 private fun computeSignalAspectChangeEvents(
-    blockPath: List<BlockId>,
-    routePath: List<RouteId>,
+    trainPath: TrainPath,
     zoneToPathIndexMap: Map<String, Int>,
     blockInfra: BlockInfra,
     pathSignals: List<PathSignal>,
@@ -127,10 +105,8 @@ private fun computeSignalAspectChangeEvents(
     loadedSignalInfra: LoadedSignalInfra,
     leastConstrainingStates: Map<SignalingSystemId, SigState>,
 ): Map<PathSignal, MutableList<SignalAspectChangeEvent>> {
-    val routes = routePath
-    val zoneCount = blockPath.sumOf { blockInfra.getBlockZonePaths(it).size }
-    val zoneStates = ArrayList<ZoneStatus>(zoneCount)
-    for (i in 0 until zoneCount) zoneStates.add(ZoneStatus.CLEAR)
+    val zoneCount = trainPath.getZonePaths().size
+    val zoneStates = MutableList(zoneCount) { ZoneStatus.CLEAR }
 
     val signalAspects =
         pathSignals
@@ -143,8 +119,10 @@ private fun computeSignalAspectChangeEvents(
             )
             .toMutableMap()
 
-    val blockSignals = blockInfra.getBlockSignals(blockPath.last())
+    val lastBlockRange = trainPath.getBlocks().last()
+    val blockSignals = blockInfra.getBlockSignals(lastBlockRange.value)
     // We can't just `pathSignals.last().signal` as the simulation includes the whole block
+    // TODO path migration: double check that this is still relevant
     val lastSignal = blockSignals[blockSignals.size - 1]
     val lastSignalDriver = loadedSignalInfra.getDrivers(lastSignal).lastOrNull()
     val lastSignalInputSystem =
@@ -169,9 +147,7 @@ private fun computeSignalAspectChangeEvents(
                 rawInfra,
                 loadedSignalInfra,
                 blockInfra,
-                blockPath,
-                routes,
-                blockPath.size,
+                trainPath,
                 zoneStates,
                 ZoneStatus.CLEAR,
                 nextSignalState,

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/SafetySpeed.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/SafetySpeed.kt
@@ -3,6 +3,7 @@ package fr.sncf.osrd.standalone_sim
 import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.api.standalone_sim.SimulationScheduleItem
 import fr.sncf.osrd.path.interfaces.TrainPath
+import fr.sncf.osrd.path.interfaces.getRouteAbsolutePathEnd
 import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop
 import fr.sncf.osrd.signaling.etcs_level2.ETCS_LEVEL2
 import fr.sncf.osrd.sim_infra.api.*
@@ -130,7 +131,7 @@ private fun getSignalOffsets(infra: FullInfra, trainPath: TrainPath): List<Offse
     // Add one "signal" at the end of the last route no matter what.
     // There must be either a signal or a buffer stop, on which we may end safety speed ranges.
     val lastRouteRange = trainPath.getRoutes().last()
-    res.add(lastRouteRange.getObjectAbsolutePathEnd(rawInfra.getRouteLength(lastRouteRange.value)))
+    res.add(lastRouteRange.getRouteAbsolutePathEnd(rawInfra))
 
     return res.filter { it.distance >= 0.meters }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
@@ -15,16 +15,20 @@ import fr.sncf.osrd.envelope_sim.etcs.BrakingType.IND
 import fr.sncf.osrd.envelope_sim.etcs.ETCSBrakingSimulator
 import fr.sncf.osrd.envelope_sim.etcs.ETCSBrakingSimulatorImpl
 import fr.sncf.osrd.envelope_sim.etcs.EoaType
-import fr.sncf.osrd.path.implementations.ChunkPath
 import fr.sncf.osrd.path.interfaces.BlockPath
+import fr.sncf.osrd.path.interfaces.BlockRange
+import fr.sncf.osrd.path.interfaces.RouteRange
 import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.path.interfaces.TravelledPath
+import fr.sncf.osrd.path.interfaces.getLegacyBlockPath
+import fr.sncf.osrd.path.interfaces.getLegacyChunkPath
+import fr.sncf.osrd.path.interfaces.getLegacyRoutePath
+import fr.sncf.osrd.path.interfaces.getZonePathAbsolutePathEnd
 import fr.sncf.osrd.signaling.SigSystemManager
 import fr.sncf.osrd.signaling.SignalingTrainState
 import fr.sncf.osrd.signaling.ZoneStatus
 import fr.sncf.osrd.signaling.etcs_level2.ETCS_LEVEL2
 import fr.sncf.osrd.sim_infra.api.*
-import fr.sncf.osrd.sim_infra.utils.routesOnBlock
 import fr.sncf.osrd.standalone_sim.result.ResultPosition
 import fr.sncf.osrd.standalone_sim.result.ResultSpeed
 import fr.sncf.osrd.train.RollingStock
@@ -47,50 +51,11 @@ class PathOffsetBuilder(val startOffset: Distance) {
     }
 }
 
-// For a path (sequence of blocks and matching sequence of routes)
-// Wrap information about a block, to be used in a lookup table (sorted by block index in
-// block-path).
-private data class BlockInfo(
-    val block: BlockId,
-    // the index of the route in the path
-    val routeIndex: Int,
-)
-
-private fun buildBlockInfoTable(
-    blockInfra: BlockInfra,
-    rawInfra: RawInfra,
-    routePath: List<RouteId>,
-    blockPath: List<BlockId>,
-): List<BlockInfo> {
-    val detailedBlocks = mutableListOf<BlockInfo>()
-
-    var currentRouteIdx = 0
-
-    for (blockId in blockPath) {
-
-        val blockRoutes = blockInfra.routesOnBlock(rawInfra, blockId)
-        if (!blockRoutes.contains(routePath[currentRouteIdx])) {
-            currentRouteIdx++
-        }
-        assert(currentRouteIdx < routePath.size)
-        val routeId = routePath[currentRouteIdx]
-        assert(blockRoutes.contains(routeId))
-
-        val element = BlockInfo(blockId, currentRouteIdx)
-        detailedBlocks.add(element)
-    }
-
-    return detailedBlocks
-}
-
 /** Use an already computed envelope to extract various metadata about a trip. */
 fun runScheduleMetadataExtractor(
     envelope: Envelope,
     trainPath: TrainPath,
-    chunkPath: ChunkPath,
     fullInfra: FullInfra,
-    routePath: List<RouteId>,
-    blockPath: List<BlockId>,
     rollingStock: RollingStock,
     schedule: List<SimulationScheduleItem>,
     pathItemPositions: List<Offset<TravelledPath>>,
@@ -119,23 +84,25 @@ fun runScheduleMetadataExtractor(
     }
 
     // Compute signal updates
-    val startOffset = trainPathBlockOffset(rawInfra, blockInfra, blockPath, chunkPath).distance
+    // TODO path migration: remove this convertor (and this whole block).
+    //  That requires migrating IncrementalPath.
+    val startOffset =
+        trainPathBlockOffset(
+                rawInfra,
+                blockInfra,
+                trainPath.getLegacyBlockPath(),
+                trainPath.getLegacyChunkPath(),
+            )
+            .distance
     val pathOffsetBuilder = PathOffsetBuilder(startOffset)
     var blockPathLength = 0.meters
-    for (block in blockPath) blockPathLength += blockInfra.getBlockLength(block).distance
+    for (block in trainPath.getLegacyBlockPath()) blockPathLength +=
+        blockInfra.getBlockLength(block).distance
     val endOffset = blockPathLength - startOffset - (envelope.endPos - envelope.beginPos).meters
 
-    val pathSignals =
-        pathSignalsInEnvelope(pathOffsetBuilder, blockPath, blockInfra, envelopeWithStops)
+    val pathSignals = pathSignalsInEnvelope(trainPath, blockInfra, envelopeWithStops)
     val zoneOccupationChangeEvents =
-        zoneOccupationChangeEvents(
-            pathOffsetBuilder,
-            blockPath,
-            blockInfra,
-            envelopeWithStops,
-            rawInfra,
-            trainLength,
-        )
+        zoneOccupationChangeEvents(trainPath, envelopeWithStops, trainLength)
 
     val zoneUpdates =
         zoneOccupationChangeEvents.map {
@@ -149,6 +116,7 @@ fun runScheduleMetadataExtractor(
     val fragmentStops =
         pathStops.map {
             // All blocks are in the fragment, Offset<Path> == Offset<FragmentBlocks> here
+            // TODO path migration: remove this weird conversion once IncrementalPath is migrated
             val fragmentOffset = it.pathOffset.cast<FragmentBlocks>()
             FragmentStop(fragmentOffset, it.receptionSignal)
         }
@@ -243,8 +211,8 @@ fun runScheduleMetadataExtractor(
         )
     incrementalPath.extend(
         PathFragment(
-            routePath,
-            blockPath,
+            trainPath.getLegacyRoutePath(),
+            trainPath.getLegacyBlockPath(),
             fragmentStops,
             containsStart = true,
             containsEnd = true,
@@ -259,8 +227,7 @@ fun runScheduleMetadataExtractor(
         routingRequirements(
             pathOffsetBuilder,
             fullInfra,
-            routePath,
-            blockPath,
+            trainPath,
             closedSignalStops,
             envelopeWithStops,
             context,
@@ -328,26 +295,10 @@ fun makeSimpleReportTrain(
     )
 }
 
-fun getBlockOffsets(
-    blockPath: List<BlockId>,
-    pathOffsetBuilder: PathOffsetBuilder,
-    blockInfra: BlockInfra,
-): OffsetArray<TravelledPath> {
-    val blockOffsets = MutableOffsetArray(blockPath.size) { Offset.zero<TravelledPath>() }
-    var curOffset = Offset.zero<BlockPath>()
-    for (i in 0 until blockPath.size) {
-        blockOffsets[i] = pathOffsetBuilder.toTravelledPath(curOffset)
-        val blockLength = blockInfra.getBlockLength(blockPath[i])
-        curOffset += blockLength.distance
-    }
-    return blockOffsets.immutableCopyOf()
-}
-
 fun routingRequirements(
     pathOffsetBuilder: PathOffsetBuilder,
     fullInfra: FullInfra,
-    routePath: List<RouteId>,
-    blockPath: List<BlockId>,
+    trainPath: TrainPath,
     sortedClosedSignalStops: List<PathStop>,
     envelope: EnvelopeInterpolate,
     // TODO: Required for ETCS (STDCM doesn't provide it currently, will have to eventually)
@@ -357,71 +308,57 @@ fun routingRequirements(
     val rawInfra = fullInfra.rawInfra
     val blockInfra = fullInfra.blockInfra
 
-    // count the number of zones in the path
-    val zoneCount = routePath.sumOf { rawInfra.getRoutePath(it).size }
-
-    // recover blocks info from the route and block paths into a lookup table
-    val blockInfoTable = buildBlockInfoTable(blockInfra, rawInfra, routePath, blockPath)
-
-    // fill a lookup table mapping route indices to the index of the route's first block
-    val routeBlockBounds = IntArray(routePath.size + 1)
-    var lastRoute = -1
-    for (blockIndex in blockInfoTable.indices) {
-        val block = blockInfoTable[blockIndex]
-        if (block.routeIndex == lastRoute) continue
-        lastRoute = block.routeIndex
-        routeBlockBounds[lastRoute] = blockIndex
-    }
-    routeBlockBounds[routePath.size] = blockInfoTable.size
-
-    val blockOffsets = getBlockOffsets(blockPath, pathOffsetBuilder, blockInfra)
+    val blockRanges = trainPath.getBlocks()
 
     // compute the signaling train state for each signal
     data class SignalingTrainStateImpl(override val speed: Speed) : SignalingTrainState
 
     val signalingTrainStates = mutableMapOf<LogicalSignalId, SignalingTrainState>()
-    for (i in 0 until blockPath.size) {
-        val block = blockPath[i]
-        val blockOffset = blockOffsets[i]
-        val blockEndOffset =
-            Offset.min(
-                Offset(envelope.endPos.meters),
-                blockOffset + blockInfra.getBlockLength(block).distance,
-            )
-        val signals = blockInfra.getBlockSignals(blockPath[i])
+    for (blockRange in blockRanges) {
+        val block = blockRange.value
+        val signals = blockInfra.getBlockSignals(block)
+        val signalPositions = blockInfra.getSignalsPositions(block)
         val consideredSignals =
             if (blockInfra.blockStopAtBufferStop(block)) signals.size else signals.size - 1
         for (signalIndex in 0 until consideredSignals) {
             val signal = signals[signalIndex]
-            val signalOffset = blockInfra.getSignalsPositions(block)[signalIndex].distance
-            val signalPathOffset = blockOffset + signalOffset
+            val signalOffset = signalPositions[signalIndex]
+            val signalPathOffset = blockRange.offsetToTrainPath(signalOffset)
             val sightDistance = rawInfra.getSignalSightDistance(rawInfra.getPhysicalSignal(signal))
             val sightOffset = Offset.max(Offset.zero(), signalPathOffset - sightDistance)
-            if (sightOffset >= blockEndOffset) {
+            if (sightOffset >= blockRange.pathEnd) {
                 val state = SignalingTrainStateImpl(speed = 0.0.metersPerSecond)
                 signalingTrainStates[signal] = state
                 continue
             }
             val maxSpeed =
-                envelope.maxSpeedInRange(sightOffset.meters, blockEndOffset.meters).metersPerSecond
+                envelope
+                    .maxSpeedInRange(sightOffset.meters, blockRange.pathEnd.meters)
+                    .metersPerSecond
             val state = SignalingTrainStateImpl(speed = maxSpeed)
             signalingTrainStates[signal] = state
         }
     }
 
-    fun findRouteSetDeadline(routeIndex: Int): TimeDelta? {
-        if (routeIndex == 0) {
+    fun findRouteSetDeadline(routeRange: RouteRange): TimeDelta? {
+        if (routeRange.pathBegin == Offset.zero<TrainPath>()) {
             // TODO: this isn't quite true when the path starts with a stop
+            //  Actually, there should be no routing requirement at all on the first route (when
+            //  the train doesn't see any route entry signal). But the implications are weird and
+            //  counterintuitive.
             return TimeDelta.ZERO
         }
 
-        // find the first block of the route
-        val routeStartBlockIndex = routeBlockBounds[routeIndex]
-        val firstRouteBlock = blockInfoTable[routeStartBlockIndex].block
+        val firstBlockRange =
+            trainPath
+                .getBlocks()
+                .withIndex()
+                .first { it.value.pathBegin >= routeRange.pathBegin }
+                .value
 
         // find the entry signal for this route. if there is no entry signal,
         // the set deadline is the start of the simulation
-        if (blockInfra.blockStartAtBufferStop(firstRouteBlock)) return TimeDelta.ZERO
+        if (blockInfra.blockStartAtBufferStop(firstBlockRange.value)) return TimeDelta.ZERO
         val etcsSimulator = context?.let { ETCSBrakingSimulatorImpl(it) }
 
         val singleEnvelope = envelope.rawEnvelopeIfSingle
@@ -432,15 +369,11 @@ fun routingRequirements(
         val routeCriticalPos =
             getRouteCriticalPos(
                 fullInfra,
-                routePath,
-                blockPath,
-                blockOffsets,
-                zoneCount,
+                trainPath,
+                firstBlockRange,
                 signalingTrainStates,
                 singleEnvelope!!,
                 etcsSimulator,
-                routeStartBlockIndex,
-                firstRouteBlock,
             )
 
         if (routeCriticalPos == null) return null
@@ -451,8 +384,9 @@ fun routingRequirements(
         // the entry signal of the route (both position and time, as there is a time margin) in this
         // case, just move the route critical position to the stop
         val entrySignalOffset =
-            blockOffsets[routeStartBlockIndex] +
-                blockInfra.getSignalsPositions(firstRouteBlock).first().distance
+            firstBlockRange.offsetToTrainPath(
+                blockInfra.getSignalsPositions(firstBlockRange.value).first()
+            )
         for (stop in sortedClosedSignalStops.reversed()) {
             val stopTravelledOffset = pathOffsetBuilder.toTravelledPath(stop.pathOffset)
             if (stopTravelledOffset <= entrySignalOffset) {
@@ -472,29 +406,28 @@ fun routingRequirements(
     }
 
     val res = mutableListOf<RoutingRequirement>()
-    var routePathOffset = Offset.zero<BlockPath>()
     // for all routes, generate requirements
-    for (routeIndex in 0 until routePath.size) {
+    for (routeRange in trainPath.getRoutes()) {
         // start out by figuring out when the route needs to be set
         // when the route is set, signaling can allow the train to proceed
-        val routeSetDeadline = findRouteSetDeadline(routeIndex) ?: continue
+        val routeSetDeadline = findRouteSetDeadline(routeRange) ?: continue
 
         // find the release time of the last zone of each release group
-        val route = routePath[routeIndex]
+        val route = routeRange.value
         val routeZonePath = rawInfra.getRoutePath(route)
+        val zoneRanges = routeRange.mapSubObject(routeZonePath, rawInfra::getZonePathLength)
         val zoneRequirements = mutableListOf<RoutingZoneRequirement>()
-        for (zonePathIndex in 0 until routeZonePath.size) {
-            val zonePath = routeZonePath[zonePathIndex]
-            routePathOffset += rawInfra.getZonePathLength(zonePath).distance
+        for (zoneRange in zoneRanges) {
+            val zonePath = zoneRange.value
             // the distance to the end of the zone from the start of the train path
-            val travelPathOffset = pathOffsetBuilder.toTravelledPath(routePathOffset)
+            val zoneEndOffset = zoneRange.getZonePathAbsolutePathEnd(rawInfra)
             // the point in the train path at which the zone is released
-            val exitCriticalPos = travelPathOffset + rollingStock.length.meters
+            val exitCriticalPos = zoneEndOffset + rollingStock.length.meters
             // if the zones are never occupied by the train, no requirement is emitted
             // Note: the train is considered starting from a "portal", so "growing" from its start
             // offset
-            if (travelPathOffset < Offset.zero()) {
-                assert(routeIndex == 0)
+            if (zoneEndOffset < Offset.zero()) {
+                assert(routeRange.pathBegin == Offset.zero<TrainPath>())
                 continue
             }
             val exitCriticalTime =
@@ -508,20 +441,16 @@ fun routingRequirements(
 
 private fun getRouteCriticalPos(
     fullInfra: FullInfra,
-    routePath: List<RouteId>,
-    blockPath: List<BlockId>,
-    blockOffsets: OffsetArray<TravelledPath>,
-    zoneCount: Int,
+    trainPath: TrainPath,
+    firstBlockRange: BlockRange,
     signalingTrainStates: Map<LogicalSignalId, SignalingTrainState>,
     envelope: Envelope,
     etcsSimulator: ETCSBrakingSimulator?,
-    routeStartBlockIndex: Int,
-    firstRouteBlock: BlockId,
 ): Offset<TravelledPath>? {
     val blockInfra = fullInfra.blockInfra
     val simulator = fullInfra.signalingSimulator
 
-    val sigSystemId = blockInfra.getBlockSignalingSystem(firstRouteBlock)
+    val sigSystemId = blockInfra.getBlockSignalingSystem(firstBlockRange.value)
     val isCurveBased = simulator.sigModuleManager.isCurveBased(sigSystemId)
     return if (isCurveBased) {
         if (
@@ -533,40 +462,24 @@ private fun getRouteCriticalPos(
                     "ETCS_LEVEL2 and through StandaloneSimulation"
             )
         }
-        getEtcsRouteCriticalPos(
-            blockInfra,
-            blockOffsets,
-            envelope,
-            etcsSimulator,
-            routeStartBlockIndex,
-            firstRouteBlock,
-        )
+        getEtcsRouteCriticalPos(blockInfra, firstBlockRange, envelope, etcsSimulator)
     } else {
-        getSightRouteCriticalPos(
-            fullInfra,
-            routePath,
-            blockPath,
-            blockOffsets,
-            signalingTrainStates,
-            zoneCount,
-            routeStartBlockIndex,
-        )
+        getSightRouteCriticalPos(fullInfra, trainPath, firstBlockRange, signalingTrainStates)
     }
 }
 
 private fun getEtcsRouteCriticalPos(
     blockInfra: BlockInfra,
-    blockOffsets: OffsetArray<TravelledPath>,
+    firstBlockRange: BlockRange,
     envelope: Envelope,
     etcsSimulator: ETCSBrakingSimulator,
-    routeStartBlockIndex: Int,
-    firstRouteBlock: BlockId,
 ): Offset<TravelledPath> {
 
     // The braking curve targets the entry signal of the route's first block
     val signalOffset =
-        blockOffsets[routeStartBlockIndex] +
-            blockInfra.getSignalsPositions(firstRouteBlock).first().distance
+        firstBlockRange.offsetToTrainPath(
+            blockInfra.getSignalsPositions(firstBlockRange.value).first()
+        )
 
     val eoa =
         etcsSimulator
@@ -592,12 +505,9 @@ private fun getEtcsRouteCriticalPos(
 
 private fun getSightRouteCriticalPos(
     fullInfra: FullInfra,
-    routePath: List<RouteId>,
-    blockPath: List<BlockId>,
-    blockOffsets: OffsetArray<TravelledPath>,
+    trainPath: TrainPath,
+    firstBlockRange: BlockRange,
     signalingTrainStates: Map<LogicalSignalId, SignalingTrainState>,
-    zoneCount: Int,
-    routeStartBlockIndex: Int,
 ): Offset<TravelledPath>? {
     val simulator = fullInfra.signalingSimulator
     val rawInfra = fullInfra.rawInfra
@@ -606,7 +516,12 @@ private fun getSightRouteCriticalPos(
 
     // simulate signaling on the train's path with all zones free,
     // until the start of the route, which is INCOMPATIBLE
+    val zoneCount = trainPath.getZoneRanges().size
     val zoneStates = MutableList(zoneCount) { ZoneStatus.CLEAR }
+
+    // We only want the path up to the route offset of the given route
+    val subTrainPath =
+        trainPath.subPath(Offset.zero(), firstBlockRange.getObjectAbsolutePathStart())
 
     // TODO: the complexity of finding route set deadlines is currently n^2 of the
     //   number of blocks in the path. it can be improved upon by only simulating blocks
@@ -616,9 +531,7 @@ private fun getSightRouteCriticalPos(
             rawInfra,
             loadedSignalInfra,
             blockInfra,
-            blockPath,
-            routePath,
-            routeStartBlockIndex,
+            subTrainPath,
             zoneStates,
             ZoneStatus.INCOMPATIBLE,
         )
@@ -631,21 +544,19 @@ private fun getSightRouteCriticalPos(
             blockInfra,
             simulator.sigModuleManager,
             simulatedSignalStates,
-            blockPath,
-            blockOffsets,
-            routeStartBlockIndex,
+            subTrainPath,
             signalingTrainStates,
         ) ?: return null
-    val limitingBlock = blockPath[limitingSignalSpec.blockIndex]
-    val signal = blockInfra.getBlockSignals(limitingBlock)[limitingSignalSpec.signalIndex]
+    val limitingBlockRange = subTrainPath.getBlocks()[limitingSignalSpec.blockIndex]
+    val signal =
+        blockInfra.getBlockSignals(limitingBlockRange.value)[limitingSignalSpec.signalIndex]
     val limitingSignalOffsetInBlock =
-        blockInfra.getSignalsPositions(limitingBlock)[limitingSignalSpec.signalIndex].distance
+        blockInfra.getSignalsPositions(limitingBlockRange.value)[limitingSignalSpec.signalIndex]
 
-    val limitingBlockOffset = blockOffsets[limitingSignalSpec.blockIndex]
     val signalSightDistance = rawInfra.getSignalSightDistance(rawInfra.getPhysicalSignal(signal))
 
     // find the location at which establishing the route becomes necessary
-    return limitingBlockOffset + limitingSignalOffsetInBlock - signalSightDistance
+    return limitingBlockRange.offsetToTrainPath(limitingSignalOffsetInBlock - signalSightDistance)
 }
 
 /** Create a zone requirement, which embeds all needed properties for conflict detection */
@@ -677,24 +588,23 @@ private fun findLimitingSignal(
     blockInfra: BlockInfra,
     sigSystemManager: SigSystemManager,
     simulatedSignalStates: Map<LogicalSignalId, SigState>,
-    blockPath: List<BlockId>,
-    blockOffsets: OffsetArray<TravelledPath>,
-    routeStartBlockIndex: Int,
+    trainPath: TrainPath,
     signalingTrainStates: Map<LogicalSignalId, SignalingTrainState>,
 ): LimitingSignal? {
     var lastSignalBlockIndex = -1
     var lastSignalIndex = -1
-    for (curBlockIndex in (0 until routeStartBlockIndex).reversed()) {
-        val curBlock = blockPath[curBlockIndex]
+    for ((curBlockIndex, blockRange) in trainPath.getBlocks().withIndex().reversed()) {
+        if (blockRange.isSinglePoint()) continue
+        val curBlock = blockRange.value
         val blockSignals = blockInfra.getBlockSignals(curBlock)
+        val blockSignalOffsets = blockInfra.getSignalsPositions(curBlock)
         val signalIndexStart = if (curBlockIndex == 0) 0 else 1
         for (curSignalIndex in (signalIndexStart until blockSignals.size).reversed()) {
             val signal = blockSignals[curSignalIndex]
 
             // ignore unseen signals before the start of the travelled path
             val signalTravelledOffset =
-                blockOffsets[curBlockIndex] +
-                    blockInfra.getSignalsPositions(curBlock)[curSignalIndex].distance
+                blockRange.offsetToTrainPath(blockSignalOffsets[curSignalIndex])
             if (signalTravelledOffset < Offset.zero()) break
 
             val ssid = loadedSignalInfra.getSignalingSystem(signal)
@@ -706,64 +616,40 @@ private fun findLimitingSignal(
         }
     }
     // Limiting signal not found
-    if (lastSignalBlockIndex == -1 || lastSignalIndex == -1) return null
+    if (lastSignalBlockIndex == -1) return null
     return LimitingSignal(lastSignalBlockIndex, lastSignalIndex)
 }
 
 data class ZoneOccupationChangeEvent(
     val time: TimeDelta,
     val offset: Offset<TravelledPath>,
-    val zoneIndexInPath: Int,
     val isEntry: Boolean,
-    val blockIdx: Int,
     val zone: ZoneId,
 )
 
 fun zoneOccupationChangeEvents(
-    pathOffsetBuilder: PathOffsetBuilder,
-    blockPath: List<BlockId>,
-    blockInfra: BlockInfra,
+    trainPath: TrainPath,
     envelope: EnvelopeTimeInterpolate,
-    rawInfra: RawInfra,
     trainLength: Distance,
 ): MutableList<ZoneOccupationChangeEvent> {
-    var zoneCount = 0
-    var currentOffset = pathOffsetBuilder.toTravelledPath(Offset.zero())
     val zoneOccupationChangeEvents = mutableListOf<ZoneOccupationChangeEvent>()
-    for ((blockIdx, block) in blockPath.withIndex()) {
-        for (zonePath in blockInfra.getBlockZonePaths(block)) {
-            // Compute occupation change event
-            if (currentOffset.distance > envelope.endPos.meters) break
-            val entryOffset = Offset.max(Offset.zero(), currentOffset)
-            val entryTime = envelope.interpolateArrivalAtUS(entryOffset.meters).microseconds
-            val zone = rawInfra.getNextZone(rawInfra.getZonePathEntry(zonePath))!!
-            zoneOccupationChangeEvents.add(
-                ZoneOccupationChangeEvent(entryTime, entryOffset, zoneCount, true, blockIdx, zone)
-            )
-            currentOffset += rawInfra.getZonePathLength(zonePath).distance
-            if (currentOffset.distance > envelope.endPos.meters) {
-                zoneCount++
-                break
-            }
-            val exitOffset = Offset.max(Offset.zero(), currentOffset + trainLength)
-            if (exitOffset.distance <= envelope.endPos.meters) {
-                val exitTime = envelope.interpolateDepartureFromUS(exitOffset.meters).microseconds
-                zoneOccupationChangeEvents.add(
-                    ZoneOccupationChangeEvent(
-                        exitTime,
-                        exitOffset,
-                        zoneCount,
-                        false,
-                        blockIdx,
-                        zone,
-                    )
-                )
-            }
-            zoneCount++
-        }
+    for (zoneRange in trainPath.getZoneRanges()) {
+        val entryOffset = zoneRange.pathBegin
+        val exitOffset = zoneRange.pathEnd + trainLength
+        val entryTime = envelope.interpolateArrivalAtClamp(entryOffset.meters).seconds
+        val exitTime = envelope.interpolateDepartureFromClamp(exitOffset.meters).seconds
+
+        // Avoid generating entry + exit at the same time
+        if (exitTime <= entryTime) continue
+
+        zoneOccupationChangeEvents.add(
+            ZoneOccupationChangeEvent(entryTime, entryOffset, isEntry = true, zoneRange.value)
+        )
+        zoneOccupationChangeEvents.add(
+            ZoneOccupationChangeEvent(exitTime, exitOffset, isEntry = false, zoneRange.value)
+        )
     }
     zoneOccupationChangeEvents.sortBy { it.time }
-    // TODO: verify we don't generate entry and exits at the same time (especially at 0)
 
     return zoneOccupationChangeEvents
 }
@@ -776,26 +662,20 @@ data class PathSignal(
 )
 
 // Returns all the signals on the path
-fun pathSignals(
-    pathOffsetBuilder: PathOffsetBuilder,
-    blockPath: List<BlockId>,
-    blockInfra: BlockInfra,
-): List<PathSignal> {
+fun pathSignals(trainPath: TrainPath, blockInfra: BlockInfra): List<PathSignal> {
     val pathSignals = mutableListOf<PathSignal>()
-    var currentOffset = pathOffsetBuilder.toTravelledPath(Offset.zero())
-    for ((blockIdx, block) in blockPath.withIndex()) {
+    for ((blockIndex, blockRange) in trainPath.getBlocks().withIndex()) {
+        val block = blockRange.value
         val blockSignals = blockInfra.getBlockSignals(block)
         val blockSignalPositions = blockInfra.getSignalsPositions(block)
         for (signalIndex in 0 until blockSignals.size) {
-            // as consecutive blocks share a signal, skip the first signal of each block, except the
-            // first
-            // this way, each signal is only iterated on once
-            if (signalIndex == 0 && blockIdx != 0) continue
+            // As consecutive blocks share a signal, skip the first signal of each block, except the
+            // first. This way, each signal is only iterated on once
+            if (signalIndex == 0 && blockIndex != 0) continue
             val signal = blockSignals[signalIndex]
-            val position = blockSignalPositions[signalIndex].distance
-            pathSignals.add(PathSignal(signal, currentOffset + position, blockIdx))
+            val position = blockSignalPositions[signalIndex]
+            pathSignals.add(PathSignal(signal, blockRange.offsetToTrainPath(position), blockIndex))
         }
-        currentOffset += blockInfra.getBlockLength(block).distance
     }
     return pathSignals
 }
@@ -804,28 +684,20 @@ fun pathSignals(
 // The reason being that even if a train see a red signal, it won't
 // matter since the train was going to stop before it anyway
 fun pathSignalsInEnvelope(
-    pathOffsetBuilder: PathOffsetBuilder,
-    blockPath: List<BlockId>,
+    trainPath: TrainPath,
     blockInfra: BlockInfra,
     envelope: EnvelopeTimeInterpolate,
 ): List<PathSignal> {
-    return pathSignalsInRange(
-        pathOffsetBuilder,
-        blockPath,
-        blockInfra,
-        0.meters,
-        envelope.endPos.meters,
-    )
+    return pathSignalsInRange(trainPath, blockInfra, 0.meters, envelope.endPos.meters)
 }
 
 fun pathSignalsInRange(
-    pathOffsetBuilder: PathOffsetBuilder,
-    blockPath: List<BlockId>,
+    trainPath: TrainPath,
     blockInfra: BlockInfra,
     rangeStart: Distance,
     rangeEnd: Distance,
 ): List<PathSignal> {
-    return pathSignals(pathOffsetBuilder, blockPath, blockInfra).filter { signal ->
+    return pathSignals(trainPath, blockInfra).filter { signal ->
         signal.pathOffset.distance in rangeStart..rangeEnd
     }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulation.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulation.kt
@@ -25,9 +25,6 @@ import fr.sncf.osrd.envelope_sim_infra.HasMissingSpeedTag
 import fr.sncf.osrd.envelope_sim_infra.computeMRSP
 import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.path.interfaces.TravelledPath
-import fr.sncf.osrd.path.interfaces.getLegacyBlockPath
-import fr.sncf.osrd.path.interfaces.getLegacyChunkPath
-import fr.sncf.osrd.path.interfaces.getLegacyRoutePath
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
 import fr.sncf.osrd.railjson.schema.schedule.RJSAllowanceDistribution
 import fr.sncf.osrd.reporting.exceptions.ErrorType.ZeroLengthPath
@@ -163,10 +160,8 @@ fun runStandaloneSimulation(
         runScheduleMetadataExtractor(
             finalEnvelope,
             trainPath,
-            trainPath.getLegacyChunkPath(), // TODO path migration
+            // TODO path migration
             infra,
-            trainPath.getLegacyRoutePath(),
-            trainPath.getLegacyBlockPath(),
             rollingStock,
             schedule,
             pathItemPositions,

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/etcsContextBuilder.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/etcsContextBuilder.kt
@@ -5,6 +5,7 @@ import fr.sncf.osrd.envelope_sim.EnvelopeSimContext
 import fr.sncf.osrd.path.interfaces.DirChunkRange
 import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.path.interfaces.TravelledPath
+import fr.sncf.osrd.path.interfaces.getBlockAbsolutePathEnd
 import fr.sncf.osrd.signaling.etcs_level2.ETCS_LEVEL2
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.sim_infra.utils.getNextTrackSections
@@ -67,9 +68,7 @@ fun buildETCSBlockDetectors(infra: FullInfra, trainPath: TrainPath): List<Offset
         if (isETCSBlock(block, infra)) {
             // Add entry and exit detectors
             etcsBlockDetectors.add(blockRange.getObjectAbsolutePathStart())
-            etcsBlockDetectors.add(
-                blockRange.getObjectAbsolutePathEnd(infra.blockInfra.getBlockLength(block))
-            )
+            etcsBlockDetectors.add(blockRange.getBlockAbsolutePathEnd(infra.blockInfra))
         }
     }
     return etcsBlockDetectors.filter { it.distance >= Distance.ZERO }


### PR DESCRIPTION
Part of https://github.com/OpenRailAssociation/osrd/issues/12531
After https://github.com/OpenRailAssociation/osrd/pull/13763

This PR is more than simple type replacements, the process changes a bit. The goal is to remove as much of `Offset<BlockPath>` as possible. Though some remains at the interface with the signaling simulator and incremental path (not migrated yet). 

The good news is that the code is now *significantly* more concise and less complex. Dealing with id lists and managing offsets by hand was not straightforward.