### PR TITLE
core: add `.meters` to offset

### DIFF
--- a/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/ETCSBrakingCurves.kt
+++ b/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/ETCSBrakingCurves.kt
@@ -47,7 +47,7 @@ fun computeBrakingCurvesAtLOA(
     maxSpeedEnvelope: Envelope,
     beginPos: Double,
 ): BrakingCurves {
-    val targetPosition = limitOfAuthority.offset.distance.meters
+    val targetPosition = limitOfAuthority.offset.meters
     assert(targetPosition > 0.0)
     val targetSpeed = limitOfAuthority.speed
     assert(targetSpeed > 0.0)
@@ -70,7 +70,7 @@ fun computeBrakingCurvesAtEOA(
     maxSpeedEnvelope: Envelope,
     beginPos: Double,
 ): BrakingCurves {
-    val targetPosition = endOfAuthority.offsetEOA.distance.meters
+    val targetPosition = endOfAuthority.offsetEOA.meters
     assert(targetPosition > 0.0)
     val targetSpeed = 0.0
     val eoaBrakingCurves = computeSbdBrakingCurves(context, targetPosition, maxSpeedEnvelope)
@@ -80,7 +80,7 @@ fun computeBrakingCurvesAtEOA(
         else
             computeEbdBrakingCurves(
                 context,
-                endOfAuthority.offsetSVL.distance.meters,
+                endOfAuthority.offsetSVL.meters,
                 targetSpeed,
                 maxSpeedEnvelope,
             )

--- a/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/ETCSBrakingSimulator.kt
+++ b/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/ETCSBrakingSimulator.kt
@@ -178,7 +178,7 @@ class ETCSBrakingSimulatorImpl(override val context: EnvelopeSimContext) : ETCSB
 
             // We build EOAs along the path. We need to handle overlaps with the next EOA. To do so,
             // we shift the left position constraint, beginPos, to this EOA's target position.
-            beginPos = endOfAuthority.offsetEOA.distance.meters
+            beginPos = endOfAuthority.offsetEOA.meters
         }
         return builder.build()
     }
@@ -232,11 +232,10 @@ class ETCSBrakingSimulatorImpl(override val context: EnvelopeSimContext) : ETCSB
         for (stop in orderedStops) {
             var stopOffset = stop.first
             val isStopSignalRestrictive = stop.second
-            val isBeginPos = arePositionsEqual(stopOffset.distance.meters, envelope.beginPos)
-            val isEndPos = arePositionsEqual(stopOffset.distance.meters, envelope.endPos)
+            val isBeginPos = arePositionsEqual(stopOffset.meters, envelope.beginPos)
+            val isEndPos = arePositionsEqual(stopOffset.meters, envelope.endPos)
             val isOutOfBounds =
-                stopOffset.distance.meters < envelope.beginPos ||
-                    stopOffset.distance.meters > envelope.endPos
+                stopOffset.meters < envelope.beginPos || stopOffset.meters > envelope.endPos
             if (isBeginPos) {
                 // Offset is equal to begin position to within an epsilon.
                 continue
@@ -245,10 +244,7 @@ class ETCSBrakingSimulatorImpl(override val context: EnvelopeSimContext) : ETCSB
                 stopOffset = Offset(envelope.endPos.meters)
             } else if (isOutOfBounds) {
                 // Stop location is out of bounds of the envelope: throw exception.
-                throw OSRDError.envelopeStopOutOfBoundsError(
-                    stopOffset.distance.meters,
-                    envelope.endPos,
-                )
+                throw OSRDError.envelopeStopOutOfBoundsError(stopOffset.meters, envelope.endPos)
             }
             if (etcsRanges.contains(stopOffset.distance)) {
                 val eoa =
@@ -309,7 +305,7 @@ class ETCSBrakingSimulatorImpl(override val context: EnvelopeSimContext) : ETCSB
                 usedCurveType = IND,
                 eoaType = EoaType.SPACING,
             )
-        } else if (nextDetector.distance.meters <= endPos) {
+        } else if (nextDetector.meters <= endPos) {
             // On a non-route delimiter signal for spacing requirements, EoA = SvL = next detector.
             EndOfAuthority(
                 offsetEOA = nextDetector,

--- a/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/pipelines/MaxSpeedEnvelope.kt
+++ b/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/pipelines/MaxSpeedEnvelope.kt
@@ -142,7 +142,7 @@ private fun addConstStopBrakingCurves(
                 SpeedConstraint(0.0, EnvelopePartConstraintType.FLOOR),
                 EnvelopeConstraint(envelope, EnvelopePartConstraintType.CEILING),
             )
-        EnvelopeDeceleration.decelerate(context, stop.distance.meters, 0.0, overlayBuilder, -1.0)
+        EnvelopeDeceleration.decelerate(context, stop.meters, 0.0, overlayBuilder, -1.0)
 
         val builder = OverlayEnvelopeBuilder.backward(envelope)
         builder.addPart(partBuilder.build())

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/PathPropertiesImpl.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/PathPropertiesImpl.kt
@@ -187,7 +187,7 @@ data class PathPropertiesImpl(
             beginChunkOffset: Offset<TrackChunk>?,
             endChunkOffset: Offset<TrackChunk>?,
         ): LineString {
-            val chunkLength = infra.getTrackChunkLength(dirChunkId.value).distance.meters
+            val chunkLength = infra.getTrackChunkLength(dirChunkId.value).meters
             val beginSliceOffset = beginChunkOffset?.distance?.meters ?: 0.0
             val endSliceOffset = endChunkOffset?.distance?.meters ?: chunkLength
             return getDirData(dirChunkId)

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/PathPropertiesView.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/PathPropertiesView.kt
@@ -42,9 +42,7 @@ data class PathPropertiesView(
 
     override fun getGeo(): LineString {
         val baseLength = base.getLength().meters
-        return base
-            .getGeo()
-            .slice(startOffset.distance.meters / baseLength, endOffset.distance.meters / baseLength)
+        return base.getGeo().slice(startOffset.meters / baseLength, endOffset.meters / baseLength)
     }
 
     override fun getLoadingGauge(): DistanceRangeMap<LoadingGaugeConstraint> {

--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/units/Distance.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/units/Distance.kt
@@ -103,6 +103,9 @@ val Int.meters: Distance
  */
 @JvmInline
 value class Offset<T>(val distance: Distance) : Comparable<Offset<T>> {
+    val meters: Double
+        get() = distance.meters
+
     operator fun plus(value: Distance): Offset<T> {
         return Offset(distance + value)
     }

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/result/ResultPosition.kt
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/result/ResultPosition.kt
@@ -36,7 +36,7 @@ private constructor(time: Double, pathOffset: Double, trackSection: String?, off
                 time,
                 pathOffset,
                 rawInfra.getTrackSectionName(location.trackId),
-                location.offset.distance.meters,
+                location.offset.meters,
             )
         }
     }

--- a/core/src/main/kotlin/fr/sncf/osrd/api/RollingStockParser.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/RollingStockParser.kt
@@ -36,7 +36,7 @@ fun parseRawRollingStock(
 
     return RollingStock(
         "placeholder_name",
-        rawPhysicsConsist.length.distance.meters,
+        rawPhysicsConsist.length.meters,
         rawPhysicsConsist.mass.toDouble(),
         rawPhysicsConsist.inertiaCoefficient,
         rollingResistance.A,

--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingPostProcessing.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingPostProcessing.kt
@@ -234,8 +234,8 @@ private fun makeRJSTrackRanges(
             res.add(
                 RJSDirectionalTrackRange(
                     trackName,
-                    rangeStartOnTrack.distance.meters,
-                    rangeEndOnTrack.distance.meters,
+                    rangeStartOnTrack.meters,
+                    rangeEndOnTrack.meters,
                     direction,
                 )
             )

--- a/core/src/main/kotlin/fr/sncf/osrd/conflicts/IncrementalRequirementEnvelopeAdapter.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/conflicts/IncrementalRequirementEnvelopeAdapter.kt
@@ -28,8 +28,8 @@ class IncrementalRequirementEnvelopeAdapter(
         if (envelopeWithStops == null) {
             return Double.POSITIVE_INFINITY
         }
-        val begin = pathBeginOff.distance.meters
-        val end = pathEndOff.distance.meters
+        val begin = pathBeginOff.meters
+        val end = pathEndOff.meters
         if (max(0.0, begin) >= min(envelopeWithStops.endPos, end)) {
             return Double.POSITIVE_INFINITY // no overlap
         }
@@ -44,7 +44,7 @@ class IncrementalRequirementEnvelopeAdapter(
             return Double.POSITIVE_INFINITY
         }
         val endPos = envelopeWithStops.endPos
-        if (stopOffset.distance.meters > endPos) {
+        if (stopOffset.meters > endPos) {
             return Double.POSITIVE_INFINITY
         }
         // stop duration is included in interpolateDepartureFrom()
@@ -71,11 +71,11 @@ class IncrementalRequirementEnvelopeAdapter(
     ): Double {
         if (envelopeWithStops == null) return Double.POSITIVE_INFINITY
         // if the head of the train enters the zone at some point, use that
-        val begin = pathBeginOff.distance.meters
+        val begin = pathBeginOff.meters
         if (begin >= 0.0 && begin <= envelopeWithStops.endPos)
             return envelopeWithStops.interpolateArrivalAt(begin)
 
-        val end = pathEndOff.distance.meters
+        val end = pathEndOff.meters
 
         val trainBegin = -rollingStock.length
         val trainEnd = 0.0
@@ -90,7 +90,7 @@ class IncrementalRequirementEnvelopeAdapter(
         pathEndOff: Offset<TravelledPath>,
     ): Double {
         if (envelopeWithStops == null) return Double.POSITIVE_INFINITY
-        val end = pathEndOff.distance.meters
+        val end = pathEndOff.meters
 
         val criticalPoint = end + rollingStock.length
         if (criticalPoint >= 0.0 && criticalPoint <= envelopeWithStops.endPos)

--- a/core/src/main/kotlin/fr/sncf/osrd/pathfinding/RemainingDistanceEstimator.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/pathfinding/RemainingDistanceEstimator.kt
@@ -98,7 +98,7 @@ private fun blockOffsetToPoint(
                 chunkLength.distance - remainingOffsetOnBlock
             }
         val lineString = rawInfra.getTrackChunkGeom(chunk.value)
-        return lineString.interpolateNormalized(chunkOffset.meters / chunkLength.distance.meters)
+        return lineString.interpolateNormalized(chunkOffset.meters / chunkLength.meters)
     }
     throw RuntimeException("Unreachable (block offset outside of block)")
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
@@ -101,9 +101,7 @@ fun runScheduleMetadataExtractor(
     val legacyStops =
         schedule
             .filter { it.stopFor != null }
-            .map {
-                TrainStop(it.pathOffset.distance.meters, it.stopFor!!.seconds, it.receptionSignal)
-            }
+            .map { TrainStop(it.pathOffset.meters, it.stopFor!!.seconds, it.receptionSignal) }
 
     val rawInfra = fullInfra.rawInfra
     val loadedSignalInfra = fullInfra.loadedSignalInfra
@@ -179,7 +177,7 @@ fun runScheduleMetadataExtractor(
             signalCriticalOffset = Offset.max(signalCriticalOffset, previousSignalOffset)
         }
         var signalCriticalTime =
-            envelopeWithStops.interpolateArrivalAt(signalCriticalOffset.distance.meters).seconds
+            envelopeWithStops.interpolateArrivalAt(signalCriticalOffset.meters).seconds
 
         // advance to the first stop after sightOffset
         while (closedSignalStopOffset != null && closedSignalStopOffset <= signalCriticalOffset) {
@@ -211,9 +209,7 @@ fun runScheduleMetadataExtractor(
             }
 
             val stopDepartureTime =
-                envelopeWithStops
-                    .interpolateDepartureFrom(closedSignalStopOffset.distance.meters)
-                    .seconds
+                envelopeWithStops.interpolateDepartureFrom(closedSignalStopOffset.meters).seconds
             if (signalCriticalTime < stopDepartureTime - CLOSED_SIGNAL_RESERVATION_MARGIN.seconds) {
                 signalCriticalOffset = closedSignalStopOffset
                 signalCriticalTime = stopDepartureTime - CLOSED_SIGNAL_RESERVATION_MARGIN.seconds
@@ -309,16 +305,12 @@ fun makeSimpleReportTrain(
     val stops =
         schedule
             .filter { it.stopFor != null }
-            .map {
-                TrainStop(it.pathOffset.distance.meters, it.stopFor!!.seconds, it.receptionSignal)
-            }
+            .map { TrainStop(it.pathOffset.meters, it.stopFor!!.seconds, it.receptionSignal) }
     val envelopeStopWrapper = EnvelopeStopWrapper(envelope, stops)
 
     val pathItemTimes =
         pathItemPositions.map { position: Offset<TravelledPath> ->
-            TimeDelta.fromSeconds(
-                envelopeStopWrapper.interpolateArrivalAt(position.distance.meters)
-            )
+            TimeDelta.fromSeconds(envelopeStopWrapper.interpolateArrivalAt(position.meters))
         }
 
     // Iterate over the points and simplify the results
@@ -411,9 +403,7 @@ fun routingRequirements(
                 continue
             }
             val maxSpeed =
-                envelope
-                    .maxSpeedInRange(sightOffset.distance.meters, blockEndOffset.distance.meters)
-                    .metersPerSecond
+                envelope.maxSpeedInRange(sightOffset.meters, blockEndOffset.meters).metersPerSecond
             val state = SignalingTrainStateImpl(speed = maxSpeed)
             signalingTrainStates[signal] = state
         }
@@ -455,8 +445,7 @@ fun routingRequirements(
 
         if (routeCriticalPos == null) return null
 
-        var routeCriticalTime =
-            envelope.interpolateArrivalAtClamp(routeCriticalPos.distance.meters).seconds
+        var routeCriticalTime = envelope.interpolateArrivalAtClamp(routeCriticalPos.meters).seconds
 
         // check if an arrival on stop signal is scheduled between the route critical position and
         // the entry signal of the route (both position and time, as there is a time margin) in this
@@ -469,9 +458,7 @@ fun routingRequirements(
             if (stopTravelledOffset <= entrySignalOffset) {
                 // stop duration is included in interpolateDepartureFromClamp()
                 val stopDepartureTime =
-                    envelope
-                        .interpolateDepartureFromClamp(stopTravelledOffset.distance.meters)
-                        .seconds
+                    envelope.interpolateDepartureFromClamp(stopTravelledOffset.meters).seconds
                 if (
                     routeCriticalTime < stopDepartureTime - CLOSED_SIGNAL_RESERVATION_MARGIN.seconds
                 ) {
@@ -511,7 +498,7 @@ fun routingRequirements(
                 continue
             }
             val exitCriticalTime =
-                envelope.interpolateDepartureFromClamp(exitCriticalPos.distance.meters).seconds
+                envelope.interpolateDepartureFromClamp(exitCriticalPos.meters).seconds
             zoneRequirements.add(routingZoneRequirement(rawInfra, zonePath, exitCriticalTime))
         }
         res.add(RoutingRequirement(route, routeSetDeadline.seconds, zoneRequirements))
@@ -748,8 +735,7 @@ fun zoneOccupationChangeEvents(
             // Compute occupation change event
             if (currentOffset.distance > envelope.endPos.meters) break
             val entryOffset = Offset.max(Offset.zero(), currentOffset)
-            val entryTime =
-                envelope.interpolateArrivalAtUS(entryOffset.distance.meters).microseconds
+            val entryTime = envelope.interpolateArrivalAtUS(entryOffset.meters).microseconds
             val zone = rawInfra.getNextZone(rawInfra.getZonePathEntry(zonePath))!!
             zoneOccupationChangeEvents.add(
                 ZoneOccupationChangeEvent(entryTime, entryOffset, zoneCount, true, blockIdx, zone)
@@ -761,8 +747,7 @@ fun zoneOccupationChangeEvents(
             }
             val exitOffset = Offset.max(Offset.zero(), currentOffset + trainLength)
             if (exitOffset.distance <= envelope.endPos.meters) {
-                val exitTime =
-                    envelope.interpolateDepartureFromUS(exitOffset.distance.meters).microseconds
+                val exitTime = envelope.interpolateDepartureFromUS(exitOffset.meters).microseconds
                 zoneOccupationChangeEvents.add(
                     ZoneOccupationChangeEvent(
                         exitTime,

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulation.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulation.kt
@@ -285,10 +285,10 @@ fun buildFinalEnvelope(
     scheduledPoints: List<SimulationScheduleItem>,
 ): Envelope {
     fun getEnvelopeTimeAt(offset: Offset<TravelledPath>): Double {
-        return provisionalEnvelope.interpolateDepartureFromClamp(offset.distance.meters)
+        return provisionalEnvelope.interpolateDepartureFromClamp(offset.meters)
     }
     fun getMaxEffortEnvelopeTimeAt(offset: Offset<TravelledPath>): Double {
-        return maxEffortEnvelope.interpolateDepartureFromClamp(offset.distance.meters)
+        return maxEffortEnvelope.interpolateDepartureFromClamp(offset.meters)
     }
     var prevFixedPointOffset = Offset<TravelledPath>(0.meters)
     var prevFixedPointDepartureTime = 0.0
@@ -339,8 +339,8 @@ fun buildFinalEnvelope(
             }
             marginRanges.add(
                 AllowanceRange(
-                    prevFixedPointOffset.distance.meters,
-                    point.pathOffset.distance.meters,
+                    prevFixedPointOffset.meters,
+                    point.pathOffset.meters,
                     FixedTime(maxEffortExtraTime),
                 )
             )
@@ -401,8 +401,8 @@ fun distributeAllowance(
         envelope: Envelope = provisionalEnvelope,
     ): Double {
         assert(from < to)
-        val start = envelope.interpolateDepartureFromClamp(from.distance.meters)
-        val end = envelope.interpolateDepartureFromClamp(to.distance.meters)
+        val start = envelope.interpolateDepartureFromClamp(from.meters)
+        val end = envelope.interpolateDepartureFromClamp(to.meters)
         return end - start
     }
     val rangeEnds =
@@ -418,8 +418,8 @@ fun distributeAllowance(
             rangeTime(rangeStart, rangeEnd) - rangeTime(rangeStart, rangeEnd, maxEffortEnvelope)
         res.add(
             AllowanceRange(
-                rangeStart.distance.meters,
-                rangeEnd.distance.meters,
+                rangeStart.meters,
+                rangeEnd.meters,
                 FixedTime(baseAllowanceValue + extraTime * ratio),
             )
         )
@@ -458,7 +458,7 @@ fun buildProvisionalEnvelope(
                 is MarginValue.Percentage -> Percentage(rawValue.percentage)
                 is MarginValue.None -> Percentage(0.0)
             }
-        marginRanges.add(AllowanceRange(start.distance.meters, end.distance.meters, value))
+        marginRanges.add(AllowanceRange(start.meters, end.meters, value))
     }
     val margin =
         if (constraintDistribution == RJSAllowanceDistribution.MARECO)

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/PostProcessingSimulation.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/PostProcessingSimulation.kt
@@ -77,10 +77,8 @@ fun buildFinalEnvelope(
             stops,
             pathLength,
             standardAllowance != null &&
-                standardAllowance.getAllowanceTime(
-                    maxSpeedEnvelope.totalTime,
-                    pathLength.distance.meters,
-                ) > 0.0,
+                standardAllowance.getAllowanceTime(maxSpeedEnvelope.totalTime, pathLength.meters) >
+                    0.0,
             updatedTimeData,
         )
 
@@ -386,22 +384,18 @@ private fun makeAllowanceRanges(
     val res = ArrayList<AllowanceRange>()
     for (point in fixedPoints) {
         val baseTime =
-            envelope.interpolateArrivalAtClamp(point.offset.distance.meters) -
+            envelope.interpolateArrivalAtClamp(point.offset.meters) -
                 envelope.interpolateDepartureFromClamp(transition)
         val pointArrivalTime = transitionTime + baseTime
         val neededDelay = max(0.0, point.time - pointArrivalTime - prevAddedTime)
 
         res.add(
-            AllowanceRange(
-                transition,
-                point.offset.distance.meters,
-                AllowanceValue.FixedTime(neededDelay),
-            )
+            AllowanceRange(transition, point.offset.meters, AllowanceValue.FixedTime(neededDelay))
         )
         prevAddedTime += neededDelay
 
         transitionTime += baseTime + (point.stopTime ?: 0.0)
-        transition = point.offset.distance.meters
+        transition = point.offset.meters
     }
     if (transition < envelope.endPos)
         res.add(AllowanceRange(transition, envelope.endPos, AllowanceValue.FixedTime(0.0)))

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdge.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdge.kt
@@ -133,7 +133,7 @@ data class STDCMEdge(
     fun getApproximateTimeAtLocation(offset: Offset<STDCMEdge>, updatedTimeData: TimeData): Double {
         val updatedEarliestTime = timeData.getUpdatedEarliestReachableTime(updatedTimeData)
         if (length.distance == 0.meters) return updatedEarliestTime // Avoids division by 0
-        val offsetRatio = offset.distance.meters / length.distance.meters
+        val offsetRatio = offset.meters / length.meters
         return updatedEarliestTime + (totalTime * offsetRatio)
     }
 

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
@@ -264,7 +264,7 @@ class STDCMPostProcessing(private val graph: STDCMGraph) {
     private fun makeOpStops(trainPath: TrainPath): List<TrainStop> {
         val res = ArrayList<TrainStop>()
         for ((_, offset) in trainPath.getOperationalPointParts()) {
-            res.add(TrainStop(offset.distance.meters, 0.0, OPEN))
+            res.add(TrainStop(offset.meters, 0.0, OPEN))
         }
         return res
     }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelopeImpl.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelopeImpl.kt
@@ -68,7 +68,7 @@ data class InfraExplorerWithEnvelopeImpl(
         // We want the intersection, which is what `zip` does here.
         assert(stopDurations.size <= stopOffsets.size)
         return (stopOffsets zip stopDurations).map {
-            TrainStop(it.first.distance.meters, it.second, SHORT_SLIP_STOP)
+            TrainStop(it.first.meters, it.second, SHORT_SLIP_STOP)
         }
     }
 
@@ -117,9 +117,7 @@ data class InfraExplorerWithEnvelopeImpl(
 
     override fun interpolateDepartureFromClamp(pathOffset: Offset<BlockPath>): Double {
         return getFullEnvelope()
-            .interpolateDepartureFromClamp(
-                getIncrementalPath().toTravelledPath(pathOffset).distance.meters
-            )
+            .interpolateDepartureFromClamp(getIncrementalPath().toTravelledPath(pathOffset).meters)
     }
 
     override fun getSpacingRequirements(): List<SpacingRequirement> {

--- a/core/src/main/kotlin/fr/sncf/osrd/utils/CachedBlockMRSPBuilder.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/utils/CachedBlockMRSPBuilder.kt
@@ -73,8 +73,8 @@ data class CachedBlockMRSPBuilder(
         if (endOffset?.distance == 0.meters) return 0.0
         val actualLength = endOffset ?: blockInfra.getBlockLength(block)
         val mrsp = getMRSP(block)
-        val time = mrsp.interpolateArrivalAtClamp(actualLength.distance.meters)
-        val allowanceTime = allowanceValue?.getAllowanceTime(time, actualLength.distance.meters)
+        val time = mrsp.interpolateArrivalAtClamp(actualLength.meters)
+        val allowanceTime = allowanceValue?.getAllowanceTime(time, actualLength.meters)
         return time + (allowanceTime ?: 0.0)
     }
 

--- a/core/src/main/kotlin/fr/sncf/osrd/utils/DebugUtils.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/utils/DebugUtils.kt
@@ -41,7 +41,7 @@ class CSVLogger(filename: String, private val keys: List<String>) {
         val geo = buildTrainPathFromBlock(rawInfra, blockInfra, block).getGeo()
         val blockLength = blockInfra.getBlockLength(block)
         val offset = node.locationOnEdge ?: Offset.zero()
-        var p = geo.interpolateNormalized(offset.distance.meters / blockLength.distance.meters)
+        var p = geo.interpolateNormalized(offset.meters / blockLength.meters)
         if (p.lat.isNaN() || p.lon.isNaN()) p = geo.getPoints().first()
 
         val data = mutableMapOf(*entries)

--- a/core/src/test/kotlin/fr/sncf/osrd/envelope_sim_infra/MRSPTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/envelope_sim_infra/MRSPTest.kt
@@ -176,7 +176,7 @@ class MRSPTest {
 
         fun routeLen(route: String): Double {
             return Helpers.getBlocksOnRoutes(infra, listOf(route)).sumOf { block ->
-                infra.blockInfra.getBlockLength(block).distance.meters
+                infra.blockInfra.getBlockLength(block).meters
             }
         }
 

--- a/core/src/test/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulationTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulationTest.kt
@@ -120,17 +120,15 @@ class StandaloneSimulationTest {
             listOf(
                 SimulationScheduleItem(
                     thirdDistance,
-                    maxEffortEnvelope
-                        .interpolateDepartureFrom(thirdDistance.distance.meters)
-                        .seconds + 60.seconds,
+                    maxEffortEnvelope.interpolateDepartureFrom(thirdDistance.meters).seconds +
+                        60.seconds,
                     null,
                     OPEN,
                 ),
                 SimulationScheduleItem(
                     halfDistance,
-                    maxEffortEnvelope
-                        .interpolateDepartureFrom(halfDistance.distance.meters)
-                        .seconds + 120.seconds,
+                    maxEffortEnvelope.interpolateDepartureFrom(halfDistance.meters).seconds +
+                        120.seconds,
                     15.seconds,
                     OPEN,
                 ),

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/DepartureTimeShiftTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/DepartureTimeShiftTests.kt
@@ -36,7 +36,7 @@ class DepartureTimeShiftTests {
                 .run()!!
         val secondBlockEntryTime =
             (res.departureTime +
-                res.envelope.interpolateArrivalAt(infra.getBlockLength(firstBlock).distance.meters))
+                res.envelope.interpolateArrivalAt(infra.getBlockLength(firstBlock).meters))
         Assertions.assertTrue(secondBlockEntryTime >= 3600)
         occupancyTest(res, occupancyGraph)
     }
@@ -69,7 +69,7 @@ class DepartureTimeShiftTests {
                 .run()!!
         val secondBlockEntryTime =
             (res.departureTime +
-                res.envelope.interpolateArrivalAt(infra.getBlockLength(firstBlock).distance.meters))
+                res.envelope.interpolateArrivalAt(infra.getBlockLength(firstBlock).meters))
         Assertions.assertTrue(secondBlockEntryTime >= 3600)
         occupancyTest(res, occupancyGraph)
     }

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/StandardAllowanceTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/StandardAllowanceTests.kt
@@ -104,7 +104,7 @@ class StandardAllowanceTests {
         val secondBlockEntryTime =
             (res.withAllowance.departureTime +
                 res.withAllowance.envelope.interpolateArrivalAt(
-                    infra.getBlockLength(firstBlock).distance.meters
+                    infra.getBlockLength(firstBlock).meters
                 ))
         Assertions.assertTrue(secondBlockEntryTime >= 3600 - TIME_STEP)
         occupancyTest(res.withAllowance, occupancyGraph, TIME_STEP)

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/StopTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/StopTests.kt
@@ -87,7 +87,7 @@ class StopTests {
 
         // Check that we stop
         for (offset in stopsOffsets) Assertions.assertTrue(
-            areSpeedsEqual(0.0, res.envelope.interpolateSpeed(100.0 + offset.distance.meters))
+            areSpeedsEqual(0.0, res.envelope.interpolateSpeed(100.0 + offset.meters))
         )
     }
 

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/BlockAvailabilityTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/BlockAvailabilityTests.kt
@@ -136,8 +136,8 @@ class BlockAvailabilityTests {
         while (infraExplorer.getLookahead().size + 1 < nBlocksInPath) infraExplorer =
             infraExplorer.cloneAndExtendLookahead().find { filterExplorer(it) }!!
         for (i in 0..<nBlocksSimulated) {
-            var envelopeLength = blockLengths[i].distance.meters
-            if (i == 0) envelopeLength -= startOffset.distance.meters
+            var envelopeLength = blockLengths[i].meters
+            if (i == 0) envelopeLength -= startOffset.meters
             infraExplorer =
                 infraExplorer.addEnvelope(
                     Envelope.make(
@@ -346,7 +346,7 @@ class BlockAvailabilityTests {
                 Envelope.make(
                     EnvelopePart.generateTimes(
                         listOf(EnvelopeProfile.CONSTANT_SPEED),
-                        doubleArrayOf(0.0, blockLengths.last().distance.meters),
+                        doubleArrayOf(0.0, blockLengths.last().meters),
                         doubleArrayOf(30.0, 30.0),
                     )
                 )
@@ -377,7 +377,7 @@ class BlockAvailabilityTests {
                     Envelope.make(
                         EnvelopePart.generateTimes(
                             listOf(EnvelopeProfile.CONSTANT_SPEED),
-                            doubleArrayOf(0.0, blockLengths[1].distance.meters),
+                            doubleArrayOf(0.0, blockLengths[1].meters),
                             doubleArrayOf(30.0, 30.0),
                         )
                     )
@@ -559,7 +559,7 @@ class BlockAvailabilityTests {
                     Envelope.make(
                         EnvelopePart.generateTimes(
                             listOf(EnvelopeProfile.CONSTANT_SPEED),
-                            doubleArrayOf(0.0, blockLengths.last().distance.meters),
+                            doubleArrayOf(0.0, blockLengths.last().meters),
                             doubleArrayOf(30.0, 30.0),
                         )
                     )


### PR DESCRIPTION
Because .distance.meters is needlessly verbose.

And the migration to new path types improves strict offset typing, which makes it more common to get meters from `Offset` instead of just `Distance`. 