### PR TITLE
front: realign tracks in their column in simulation output

### DIFF
--- a/front/src/applications/stdcm/styles/_results.scss
+++ b/front/src/applications/stdcm/styles/_results.scss
@@ -222,6 +222,7 @@
             }
             .track {
               width: 64px;
+              justify-content: flex-start;
             }
             .stop {
               font-size: 0.875rem;

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/styles/main.css
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/styles/main.css
@@ -38,51 +38,50 @@
   .waypoint-separator::after {
     height: 0;
   }
+  .track {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+
+    &.track-line {
+      margin-right: 16px;
+      font-family: 'IBM Plex Sans';
+      font-weight: 400;
+      font-size: 12px;
+      @apply text-grey-50;
+    }
+
+    &.track-name {
+      height: 24px;
+      @apply bg-grey-70;
+      border-radius: 4px;
+      box-shadow:
+        0 0 0 2px rgb(255, 255, 255),
+        0 0 0 2.5px rgb(182, 178, 175);
+      padding: 2px 6px;
+      font-weight: 600;
+      font-size: 14px;
+      line-height: 20px;
+      @apply text-white-100;
+    }
+
+    &.track-rail {
+      align-self: center;
+      height: 9px;
+      width: 17px;
+      margin-left: 2.5px;
+      margin-right: 1px;
+      @apply bg-white-50;
+      border-top: solid 1px rgb(211, 209, 207);
+      border-bottom: solid 1px rgb(211, 209, 207);
+    }
+  }
 }
 
 .close-track-occupancy-panel {
   position: absolute;
   right: 0;
   margin: 0.875rem;
-}
-
-.track {
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-
-  &.track-line {
-    margin-right: 16px;
-    font-family: 'IBM Plex Sans';
-    font-weight: 400;
-    font-size: 12px;
-    @apply text-grey-50;
-  }
-
-  &.track-name {
-    height: 24px;
-    @apply bg-grey-70;
-    border-radius: 4px;
-    box-shadow:
-      0 0 0 2px rgb(255, 255, 255),
-      0 0 0 2.5px rgb(182, 178, 175);
-    padding: 2px 6px;
-    font-weight: 600;
-    font-size: 14px;
-    line-height: 20px;
-    @apply text-white-100;
-  }
-
-  &.track-rail {
-    align-self: center;
-    height: 9px;
-    width: 17px;
-    margin-left: 2.5px;
-    margin-right: 1px;
-    @apply bg-white-50;
-    border-top: solid 1px rgb(211, 209, 207);
-    border-bottom: solid 1px rgb(211, 209, 207);
-  }
 }
 
 #tracks-layer,


### PR DESCRIPTION
I aligned the tracks column as shown in the sketch below:
https://www.sketch.com/s/15e0909c-f17d-4200-a770-b9fc1154fa7e/p/4AB93BD9-B68A-4C2C-8089-E750DD80D1FB/canvas#Inspect
<img width="1023" height="327" alt="image" src="https://github.com/user-attachments/assets/2bd4aabd-5b02-4f37-a4be-58f8d1830498" />


close #13786 