### PR TITLE
editoast: use `core_task` for path properties

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -1299,6 +1299,7 @@ dependencies = [
  "colored",
  "common",
  "core_client",
+ "core_task",
  "dashmap",
  "database",
  "deadpool",

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -164,6 +164,7 @@ clap.workspace = true
 colored = "3.0.0"
 common = { workspace = true }
 core_client = { workspace = true, features = ["mocking_client"] }
+core_task = { path = "./core_task" }
 dashmap.workspace = true
 database.workspace = true
 deadpool.workspace = true

--- a/editoast/core_client/src/path_properties.rs
+++ b/editoast/core_client/src/path_properties.rs
@@ -15,7 +15,7 @@ use schemas::infra::OperationalPointPartExtension;
 #[cfg(feature = "mocking_client")]
 use schemas::infra::OperationalPointSncfExtension;
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Hash, Serialize)]
 pub struct PathPropertiesRequest<'a> {
     pub track_section_ranges: &'a Vec<TrackRange>,
     pub infra: i64,

--- a/editoast/core_task/src/lib.rs
+++ b/editoast/core_task/src/lib.rs
@@ -72,8 +72,12 @@ pub trait Task: Sized + Send {
                 tracing::error!(?e, key, "cache read error — computing task output");
                 None
             }) {
-            Some(value) => Ok(value),
+            Some(value) => {
+                tracing::trace!(key, "cache hit");
+                Ok(value)
+            }
             None => {
+                tracing::trace!(key, "cache miss");
                 let value = self.compute(ctx).await?;
                 match serde_json::to_string(&value) {
                     Err(e) => {

--- a/editoast/core_task/src/lib.rs
+++ b/editoast/core_task/src/lib.rs
@@ -1,4 +1,5 @@
 mod envs;
+mod path_properties;
 
 use std::iter;
 use std::sync::Arc;

--- a/editoast/core_task/src/lib.rs
+++ b/editoast/core_task/src/lib.rs
@@ -59,6 +59,7 @@ pub trait Task: Sized + Send {
     /// Should any caching error occur while reading, the task output is computed.
     /// Cache write errors are ignored. So are serde errors for caching.
     /// All errors are logged.
+    #[tracing::instrument(skip_all, err)]
     #[expect(async_fn_in_trait)] // not for public (ie. outside editoast) use, no auto traits bounds to specify on the resulting future
     async fn run(
         self,

--- a/editoast/core_task/src/path_properties.rs
+++ b/editoast/core_task/src/path_properties.rs
@@ -1,0 +1,28 @@
+use std::hash::DefaultHasher;
+use std::hash::Hash;
+use std::hash::Hasher as _;
+use std::sync::Arc;
+
+use core_client::AsCoreRequest;
+use core_client::CoreClient;
+
+use crate::Task;
+
+impl<'a> Task for core_client::path_properties::PathPropertiesRequest<'a> {
+    type Output = core_client::path_properties::PathPropertiesResponse;
+    type Error = core_client::Error;
+    type Context = Arc<CoreClient>;
+
+    const CACHE_READS_BATCH_SIZE: usize = 100; // adjust if needed
+
+    fn key(&self, app_version: &str) -> String {
+        let mut hasher = DefaultHasher::new();
+        self.hash(&mut hasher);
+        let req_hash = hasher.finish().to_string();
+        format!("editoast.{app_version}.path_properties.{req_hash}")
+    }
+
+    async fn compute(self, ctx: Self::Context) -> Result<Self::Output, Self::Error> {
+        self.fetch(&ctx).await
+    }
+}

--- a/editoast/src/views/path/properties.rs
+++ b/editoast/src/views/path/properties.rs
@@ -93,7 +93,6 @@ pub(in crate::views) async fn post(
         db_pool,
         valkey_client,
         core_client,
-        config,
         ..
     }): State<AppState>,
     Extension(auth): AuthenticationExt,
@@ -112,22 +111,15 @@ pub(in crate::views) async fn post(
     })
     .await?;
 
-    let mut valkey_conn = valkey_client.get_connection().await?;
-
-    let request = PathPropertiesRequest {
+    use core_task::Task as _;
+    let vkconn = valkey_client.get_connection().await?;
+    let path_properties = PathPropertiesRequest {
         track_section_ranges: &path_properties_input.track_section_ranges,
         infra: infra_id,
         expected_version: infra_version,
-    };
-    let path_properties = compute_path_properties_batch(
-        core_client,
-        &mut valkey_conn,
-        &[request],
-        config.app_version.as_deref(),
-    )
-    .await?
-    .next()
-    .unwrap();
+    }
+    .run(vkconn, core_client)
+    .await?;
 
     Ok(Json(PathProperties::from(path_properties)))
 }
@@ -278,7 +270,7 @@ mod tests {
         TestAppBuilder::new().core_client(core.into()).build()
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn returns_all_path_properties() {
         let app = init_test_app();
         let infra = create_small_infra(&mut app.db_pool().get_ok()).await;
@@ -307,7 +299,7 @@ mod tests {
         );
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn returns_only_requested_path_properties() {
         let app = init_test_app();
         let infra = create_small_infra(&mut app.db_pool().get_ok()).await;

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -193,7 +193,7 @@ impl TestAppBuilder {
         };
         let sub = create_tracing_subscriber(
             tracing_config,
-            tracing_subscriber::filter::LevelFilter::DEBUG,
+            tracing_subscriber::filter::LevelFilter::TRACE,
             NoopSpanExporter::new(),
         );
         let tracing_guard = tracing::subscriber::set_default(sub);


### PR DESCRIPTION
We cannot get rid of `compute_path_properties_batch` just yet because it's still used for similar trains.