### PR TITLE
front: align conflicts display with the mockup

### DIFF
--- a/front/public/locales/de/operational-studies.json
+++ b/front/public/locales/de/operational-studies.json
@@ -56,7 +56,7 @@
       "conflictsCount_zero": "keine Konflikte",
       "filterWithSelectedTrain": "liste mit ausgewähltem Zug filtern",
       "for": "für",
-      "otherTrains": "+{{count}} weitere",
+      "otherTrains": "+{{count}}",
       "trainsInConflictTitle": "ZUG(E) IM KONFLIKT"
     },
     "description": {

--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -63,7 +63,7 @@
       "conflictsCount_zero": "no conflicts",
       "filterWithSelectedTrain": "filter list with selected train",
       "for": "for",
-      "otherTrains": "+{{count}} others",
+      "otherTrains": "+{{count}}",
       "trainsInConflictTitle": "TRAIN(S) IN CONFLICT"
     },
     "description": {

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -63,7 +63,7 @@
       "conflictsCount_zero": "aucun conflit",
       "filterWithSelectedTrain": "filtrer la liste avec le train sélectionné",
       "for": "pour",
-      "otherTrains": "+{{count}} autres",
+      "otherTrains": "+{{count}}",
       "trainsInConflictTitle": "TRAIN(S) EN CONFLIT"
     },
     "description": {

--- a/front/src/modules/conflict/components/ConflictCard.tsx
+++ b/front/src/modules/conflict/components/ConflictCard.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 import { useTranslation } from 'react-i18next';
 
@@ -10,6 +10,35 @@ import { useDateTimeLocale } from 'utils/date';
 import type { ConflictWithTrainNames } from '../types';
 import { getTrainCategoryClassName } from './../../../applications/operationalStudies/views/Scenario/components/Timetable/utils';
 
+const MAX_TAG_ROWS = 2;
+const TRAIN_NAME_TAG_GAP = 4; // must match .trains-name --tag-gap in SCSS
+const OTHER_TAG_WIDTH = 36; // width for "+NN" tag (3ch + padding)
+
+const fitsWithinRows = (widths: number[], availableWidth: number, gap: number) => {
+  let rows = 1;
+  let rowWidth = 0;
+
+  for (const width of widths) {
+    if (width > availableWidth) return false;
+
+    if (rowWidth === 0) {
+      rowWidth = width;
+      continue;
+    }
+
+    if (rowWidth + gap + width <= availableWidth) {
+      rowWidth += gap + width;
+      continue;
+    }
+
+    rows += 1;
+    if (rows > MAX_TAG_ROWS) return false;
+    rowWidth = width;
+  }
+
+  return true;
+};
+
 const ConflictCard = ({ conflict }: { conflict: ConflictWithTrainNames }) => {
   const { t } = useTranslation('operational-studies', { keyPrefix: 'main' });
   const dateTimeLocale = useDateTimeLocale();
@@ -17,13 +46,83 @@ const ConflictCard = ({ conflict }: { conflict: ConflictWithTrainNames }) => {
   const end_time = new Date(conflict.end_time).toLocaleTimeString(dateTimeLocale);
   const start_date = new Date(conflict.start_time).toLocaleDateString(dateTimeLocale);
   const totalTrains = conflict.trainsData.length;
-  const showOthers = totalTrains > 4;
-  const maxVisibleTrainTags = showOthers ? 3 : totalTrains;
+
   const [isOthersTooltipOpen, setIsOthersTooltipOpen] = useState(false);
-  const trainsContainerRef = useRef<HTMLDivElement>(null);
-  const othersTagRef = useRef<HTMLDivElement>(null);
+  const [visibleTrainCount, setVisibleTrainCount] = useState(totalTrains);
+  const [containerWidth, setContainerWidth] = useState(0);
 
   const subCategories = useSubCategoryContext();
+
+  const trainsContainerRef = useRef<HTMLDivElement>(null);
+  const othersTagRef = useRef<HTMLDivElement>(null);
+  const trainRefs = useRef<(HTMLDivElement | null)[]>([]);
+  const trainWidthsRef = useRef<number[]>([]);
+
+  trainRefs.current.length = totalTrains;
+
+  const showOthers = visibleTrainCount < totalTrains;
+  const hiddenTrains = useMemo(
+    () => (showOthers ? conflict.trainsData.slice(visibleTrainCount) : []),
+    [conflict.trainsData, showOthers, visibleTrainCount]
+  );
+
+  useEffect(() => {
+    const container = trainsContainerRef.current;
+    if (!container) return undefined;
+
+    const resizeObserver = new ResizeObserver(([entry]) => {
+      const width = Math.round(entry.contentRect.width);
+      setContainerWidth((previous) => (Math.abs(previous - width) < 1 ? previous : width));
+    });
+
+    resizeObserver.observe(container);
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, []);
+
+  useLayoutEffect(() => {
+    const container = trainsContainerRef.current;
+    if (!container || totalTrains === 0) return;
+
+    if (containerWidth === 0) {
+      const initialWidth = Math.round(container.getBoundingClientRect().width);
+      setContainerWidth(initialWidth);
+      return;
+    }
+
+    if (trainWidthsRef.current.length !== totalTrains) {
+      const widths = Array.from(
+        { length: totalTrains },
+        (_, index) => trainRefs.current[index]?.offsetWidth ?? 0
+      );
+      trainWidthsRef.current = widths;
+    }
+
+    const trainWidths = trainWidthsRef.current;
+    if (!trainWidths.length) return;
+
+    let nextVisibleCount = trainWidths.length;
+
+    if (!fitsWithinRows(trainWidths, containerWidth, TRAIN_NAME_TAG_GAP)) {
+      nextVisibleCount = 0;
+      for (let count = trainWidths.length - 1; count >= 0; count -= 1) {
+        const othersWidth = OTHER_TAG_WIDTH;
+        if (!othersWidth) continue;
+
+        const widthsToFit = [...trainWidths.slice(0, count), othersWidth];
+        if (fitsWithinRows(widthsToFit, containerWidth, TRAIN_NAME_TAG_GAP)) {
+          nextVisibleCount = count;
+          break;
+        }
+      }
+    }
+
+    if (nextVisibleCount !== visibleTrainCount) {
+      setVisibleTrainCount(nextVisibleCount);
+    }
+  }, [containerWidth, totalTrains, visibleTrainCount]);
 
   return (
     <div className="conflict-card">
@@ -44,7 +143,7 @@ const ConflictCard = ({ conflict }: { conflict: ConflictWithTrainNames }) => {
 
       <div className="trains-name" ref={trainsContainerRef}>
         {conflict.trainsData.map((train, idx) => {
-          if (idx >= maxVisibleTrainTags) return null;
+          if (idx >= visibleTrainCount) return null;
           const category = train.category;
 
           const currentSubCategory =
@@ -56,6 +155,9 @@ const ConflictCard = ({ conflict }: { conflict: ConflictWithTrainNames }) => {
             <div
               key={`train-${idx}-${train.name}`}
               className={`train-name-card ${getTrainCategoryClassName(category, 'text')}`}
+              ref={(element) => {
+                trainRefs.current[idx] = element;
+              }}
               style={{
                 color: currentSubCategory?.color,
               }}
@@ -65,7 +167,7 @@ const ConflictCard = ({ conflict }: { conflict: ConflictWithTrainNames }) => {
             </div>
           );
         })}
-        {/* Show the "Others" card if there are more than 4 trains */}
+
         {showOthers && (
           <>
             <div
@@ -74,20 +176,14 @@ const ConflictCard = ({ conflict }: { conflict: ConflictWithTrainNames }) => {
               onMouseEnter={() => setIsOthersTooltipOpen(true)}
               onMouseLeave={() => setIsOthersTooltipOpen(false)}
             >
-              <span>
-                {t('conflicts.otherTrains', {
-                  count: conflict.trainsData.length - 3,
-                })}
-              </span>
+              <span>{t('conflicts.otherTrains', { count: hiddenTrains.length })}</span>
             </div>
 
             {isOthersTooltipOpen && (
               <OSRDTooltip
                 containerRef={othersTagRef}
                 header={t('conflicts.trainsInConflictTitle')}
-                items={conflict.trainsData
-                  .filter((_, index) => index >= 3)
-                  .map((train) => train.name)}
+                items={hiddenTrains.map((train) => train.name)}
                 offsetRatio={{ top: 1.2 }}
                 reverseIfOverflow
               />

--- a/front/src/modules/conflict/hooks/useConflictsFilter.ts
+++ b/front/src/modules/conflict/hooks/useConflictsFilter.ts
@@ -63,10 +63,13 @@ const useConflictsFilter = (timetableItems: TimetableItem[], conflicts: Conflict
 
   const totalConflictsCount = useMemo(() => conflicts?.length ?? 0, [conflicts]);
 
-  const enrichedConflicts = useMemo(
-    () => (conflicts ? addTrainNamesToConflicts(conflicts, timetableItems) : []),
-    [conflicts, timetableItems]
-  );
+  const enrichedConflicts = useMemo(() => {
+    if (!conflicts) return [];
+    const sortedByStartTime = [...conflicts].sort(
+      (a, b) => new Date(a.start_time).getTime() - new Date(b.start_time).getTime()
+    );
+    return addTrainNamesToConflicts(sortedByStartTime, timetableItems);
+  }, [conflicts, timetableItems]);
 
   const selectedEnrichedConflicts = useMemo(() => {
     if (!selectedTrainName || !selectedTrainId) return [];

--- a/front/src/modules/conflict/hooks/useConflictsFilter.ts
+++ b/front/src/modules/conflict/hooks/useConflictsFilter.ts
@@ -15,7 +15,10 @@ import {
   extractOccurrenceIndexFromOccurrenceId,
 } from 'utils/trainId';
 
-import addTrainNamesToConflicts, { filterAndReorderConflict } from '../utils';
+import addTrainNamesToConflicts, {
+  filterAndReorderConflict,
+  reorderConflictTrains,
+} from '../utils';
 
 const useConflictsFilter = (timetableItems: TimetableItem[], conflicts: Conflict[] | undefined) => {
   const selectedTrainId = useSelector(getSelectedTrainId);
@@ -76,7 +79,11 @@ const useConflictsFilter = (timetableItems: TimetableItem[], conflicts: Conflict
 
   const displayedConflicts = useMemo(() => {
     if (!showOnlySelectedTrain || !selectedTrainName) {
-      return enrichedConflicts;
+      return enrichedConflicts.map((conflict) => ({
+        ...conflict,
+        // Always put selected train first, then sort remaining by name length
+        trainsData: reorderConflictTrains(conflict.trainsData, selectedTrainName),
+      }));
     }
     return selectedEnrichedConflicts;
   }, [enrichedConflicts, selectedEnrichedConflicts, showOnlySelectedTrain, selectedTrainName]);

--- a/front/src/modules/conflict/styles/_conflicts.scss
+++ b/front/src/modules/conflict/styles/_conflicts.scss
@@ -91,8 +91,8 @@
 
       .train-name-card {
         box-sizing: border-box;
-        flex: 0 0 calc((100% - var(--tag-gap)) / 2); // 2 columns layout
-        max-width: calc((100% - var(--tag-gap)) / 2); // Ensure it doesn't exceed half width
+        flex: 0 0 auto;
+        max-width: 125px;
         height: 20px;
         display: flex;
         align-items: center;
@@ -104,7 +104,6 @@
         background-color: transparent;
         position: relative;
         z-index: 1;
-        // min-width: 0;
 
         span {
           position: relative;
@@ -154,6 +153,14 @@
               0 5px
             );
             z-index: -1;
+          }
+        }
+
+        &.other-trains {
+          // Fixed width for "+NN" (3 characters) + padding (3px 5px)
+          span {
+            min-width: calc(3ch + 10px);
+            text-align: center;
           }
         }
       }

--- a/front/src/modules/conflict/utils.ts
+++ b/front/src/modules/conflict/utils.ts
@@ -102,6 +102,29 @@ export default function addTrainNamesToConflicts(
   });
 }
 
+export const reorderConflictTrains = (
+  trainsData: ConflictWithTrainNames['trainsData'],
+  selectedTrainName?: string | null
+): ConflictWithTrainNames['trainsData'] => {
+  if (!trainsData.length) return trainsData;
+  if (!selectedTrainName) {
+    return [...trainsData].sort((a, b) => a.name.length - b.name.length);
+  }
+
+  // Find the selected train
+  const selectedTrainIndex = trainsData.findIndex((train) => train.name === selectedTrainName);
+  if (selectedTrainIndex < 0) {
+    // IF not found or already first, sort by name length
+    return [...trainsData].sort((a, b) => a.name.length - b.name.length);
+  }
+
+  // Move selected train to front, then sort remaining by name length
+  const copy = [...trainsData];
+  const [selectedTrain] = copy.splice(selectedTrainIndex, 1);
+  const remainingTrains = copy.sort((a, b) => a.name.length - b.name.length);
+  return [selectedTrain, ...remainingTrains];
+};
+
 export function filterAndReorderConflict(
   conflict: ConflictWithTrainNames,
   selectedTrainId: TrainId,
@@ -112,20 +135,7 @@ export function filterAndReorderConflict(
   const isInvolved = conflict.trainsData.some((train) => train.name === selectedTrainName);
   if (!isInvolved) return null;
 
-  // If already at the front, no reorder
-  if (conflict.trainsData[0]?.name === selectedTrainName) {
-    return conflict;
-  }
-
-  // Find the selected train and move it to the front
-  const trainsData = [...conflict.trainsData];
-  const selectedTrainIndex = trainsData.findIndex((train) => train.name === selectedTrainName);
-  if (selectedTrainIndex > 0) {
-    const trainToMove = trainsData[selectedTrainIndex];
-    trainsData.splice(selectedTrainIndex, 1);
-    trainsData.unshift(trainToMove);
-  }
-
+  const trainsData = reorderConflictTrains(conflict.trainsData, selectedTrainName);
   return {
     ...conflict,
     trainsData,


### PR DESCRIPTION
## Description

This PR optimizes the display of train names in the conflicts list to show as many train names as possible.
To achieve this, the tag which shows the tooltip differs from the mockup: instead of "+ 12 others", we now display only "+ 12" to save space. seen with @thibautsailly 

Sketch below :
https://www.sketch.com/s/008d6980-d719-4bdc-bb2a-b4c2dda0dc1e/p/18F4696C-3D0D-435D-9F25-08AE364BD86E/canvas

<img width="772" height="256" alt="image" src="https://github.com/user-attachments/assets/3bdb78ac-fe02-4b02-8c73-1dd93cb9e722" />


**Edit:** Added sorting of conflicts by arrival time.




