### PR TITLE
ui-charts: fix broken CSS nested class suffixes

### DIFF
--- a/front/ui/ui-charts/src/manchette/styles/waypoint.css
+++ b/front/ui/ui-charts/src/manchette/styles/waypoint.css
@@ -6,7 +6,7 @@
   width: 315px;
   position: relative;
 
-  &.waypoint-separator {
+  .waypoint-separator {
     position: relative;
     opacity: 0.6;
     flex-grow: 1;
@@ -23,13 +23,13 @@
       @apply bg-grey-40;
     }
   }
-  &.waypoint-name {
+  .waypoint-name {
     max-width: 190px;
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
   }
-  &.waypoint-ch {
+  .waypoint-ch {
     font-size: 0.875rem;
     margin: 0 2px;
     width: 1rem;
@@ -40,7 +40,7 @@
     }
   }
 
-  &.waypoint-type {
+  .waypoint-type {
     width: 1rem;
     height: 16px;
     position: relative;
@@ -60,7 +60,7 @@
       @apply bg-grey-80;
     }
   }
-  &.waypoint-position {
+  .waypoint-position {
     @apply text-grey-50;
     font-size: 12px;
     font-weight: 400;
@@ -101,7 +101,7 @@
    * doesn't render subpixel wide lines):
    */
 
-  &.waypoint-separator::after,
+  .waypoint-separator::after,
   &::after {
     height: 0.5px;
     margin-bottom: -0.25px;

--- a/front/ui/ui-charts/src/speedSpaceChart/components/SpeedSpaceChart.tsx
+++ b/front/ui/ui-charts/src/speedSpaceChart/components/SpeedSpaceChart.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { Slider } from '@osrd-project/ui-core';
 
+import type { Data, Store } from '../types';
 import InteractionButtons from './common/InteractionButtons';
 import SettingsPanel from './common/SettingsPanel';
 import { LINEAR_LAYERS_HEIGHTS, MARGINS, ZOOM_CONFIG } from './const';
@@ -21,7 +22,6 @@ import {
   TickLayerYRight,
 } from './layers/index';
 import { clamp, getGraphOffsets } from './utils';
-import type { Data, Store } from '../types';
 
 export type SpeedSpaceChartProps = {
   width: number;

--- a/front/ui/ui-charts/src/speedSpaceChart/styles/main.css
+++ b/front/ui/ui-charts/src/speedSpaceChart/styles/main.css
@@ -133,7 +133,7 @@
       margin-left: 16px;
     }
 
-    &.settings-panel-section-title {
+    .settings-panel-section-title {
       height: 1.5rem;
       line-height: 1.5rem;
       font-size: 1rem;
@@ -148,12 +148,12 @@
     padding-bottom: 0.3125rem;
     margin-bottom: 0.25rem;
 
-    &.selection-checkbox {
+    .selection-checkbox {
       height: 1.125rem;
       margin-left: 0.5rem;
     }
 
-    &.selection-label {
+    .selection-label {
       font-weight: 400;
       margin-left: 0.5rem;
     }

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/styles/main.css
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/styles/main.css
@@ -43,7 +43,7 @@
     justify-content: flex-end;
     align-items: center;
 
-    &.track-line {
+    .track-line {
       margin-right: 16px;
       font-family: 'IBM Plex Sans';
       font-weight: 400;
@@ -51,7 +51,7 @@
       @apply text-grey-50;
     }
 
-    &.track-name {
+    .track-name {
       height: 24px;
       @apply bg-grey-70;
       border-radius: 4px;
@@ -65,7 +65,7 @@
       @apply text-white-100;
     }
 
-    &.track-rail {
+    .track-rail {
       align-self: center;
       height: 9px;
       width: 17px;


### PR DESCRIPTION
Commit 2af6499504c2 ("ui-core: bump tailwind v4") has transformed SCSS selectors from:

    .foo {
      &-bar {
        color: pink;
      }
    }

to:

    .foo {
      &.foo-bar {
        color: pink;
      }
    }

which compiles to this CSS:

    .foo.foo-bar {
      color: pink;
    }

However the correct semantic of the deprecated `&-bar` notation is:

    .foo .foo-bar {
      color: pink;
    }

Fix these by dropping the `&`.

closes [#13836](https://github.com/OpenRailAssociation/osrd/issues/13836)