### PR TITLE
editoast, front: Simplify operational studies URL schema

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -1723,6 +1723,226 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/LightRollingStockWithLiveries'
+  /macro_nodes:
+    get:
+      tags:
+      - scenarios
+      summary: Get macro node list by scenario id
+      parameters:
+      - name: scenario_id
+        in: query
+        required: true
+        schema:
+          type: integer
+          format: int64
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int64
+          default: 1
+          minimum: 1
+      - name: page_size
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int64
+          default: 100
+          maximum: 100
+          minimum: 1
+      responses:
+        '200':
+          description: List of macro nodes for the requested scenario
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MacroNodeListResponse'
+    post:
+      tags:
+      - scenarios
+      summary: Create macro nodes in batch
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MacroNodeBatchForm'
+        required: true
+      responses:
+        '201':
+          description: Macro nodes created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MacroNodeBatchResponse'
+  /macro_nodes/{node_id}:
+    get:
+      tags:
+      - scenarios
+      summary: Retrieve a macro node by id
+      parameters:
+      - name: node_id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        '200':
+          description: The requested Macro node
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MacroNodeResponse'
+    put:
+      tags:
+      - scenarios
+      summary: Update a macro node
+      parameters:
+      - name: node_id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MacroNodeForm'
+        required: true
+      responses:
+        '200':
+          description: The updated macro node
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MacroNodeResponse'
+    delete:
+      tags:
+      - scenarios
+      summary: Delete a macro node
+      parameters:
+      - name: node_id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        '204':
+          description: The macro node was deleted successfully
+  /macro_notes:
+    get:
+      tags:
+      - scenarios
+      summary: Return a list of notes for a given scenario
+      parameters:
+      - name: scenario_id
+        in: query
+        required: true
+        schema:
+          type: integer
+          format: int64
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int64
+          default: 1
+          minimum: 1
+      - name: page_size
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int64
+          default: 100
+          maximum: 100
+          minimum: 1
+      responses:
+        '200':
+          description: List of macro notes for the requested scenario
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MacroNoteListResponse'
+    post:
+      tags:
+      - scenarios
+      summary: Create a note in batch
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MacroNoteBatchForm'
+        required: true
+      responses:
+        '201':
+          description: Macro notes created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MacroNoteBatchResponse'
+  /macro_notes/{note_id}:
+    get:
+      tags:
+      - scenarios
+      summary: Return a specific note
+      parameters:
+      - name: note_id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        '200':
+          description: The requested macro note
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MacroNoteResponse'
+    put:
+      tags:
+      - scenarios
+      summary: Update a note
+      parameters:
+      - name: note_id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MacroNoteForm'
+        required: true
+      responses:
+        '200':
+          description: The updated macro note
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MacroNoteResponse'
+    delete:
+      tags:
+      - scenarios
+      summary: Delete a note
+      parameters:
+      - name: note_id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        '204':
+          description: The macro note was deleted successfully
   /paced_train:
     delete:
       tags:
@@ -2334,752 +2554,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProjectWithStudies'
-  /projects/{project_id}/studies:
-    get:
-      tags:
-      - studies
-      summary: Return a list of studies
-      parameters:
-      - name: project_id
-        in: path
-        description: The id of a project
-        required: true
-        schema:
-          type: integer
-          format: int64
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int64
-          default: 1
-          minimum: 1
-      - name: page_size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int64
-          default: 1000
-          maximum: 1000
-          minimum: 1
-      - name: ordering
-        in: query
-        required: false
-        schema:
-          type: string
-          enum:
-          - NameAsc
-          - NameDesc
-          - CreationDateAsc
-          - CreationDateDesc
-          - LastModifiedDesc
-          - LastModifiedAsc
-      responses:
-        '200':
-          description: The list of studies
-          content:
-            application/json:
-              schema:
-                allOf:
-                - $ref: '#/components/schemas/PaginationStats'
-                - type: object
-                  required:
-                  - results
-                  properties:
-                    results:
-                      type: array
-                      items:
-                        $ref: '#/components/schemas/StudyWithScenarios'
-    post:
-      tags:
-      - studies
-      parameters:
-      - name: project_id
-        in: path
-        description: The id of a project
-        required: true
-        schema:
-          type: integer
-          format: int64
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/StudyCreateForm'
-        required: true
-      responses:
-        '201':
-          description: The created study
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StudyResponse'
-  /projects/{project_id}/studies/{study_id}:
-    get:
-      tags:
-      - studies
-      summary: Return a specific study
-      parameters:
-      - name: project_id
-        in: path
-        description: The id of a project
-        required: true
-        schema:
-          type: integer
-          format: int64
-      - name: study_id
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
-      responses:
-        '200':
-          description: The requested study
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StudyResponse'
-    delete:
-      tags:
-      - studies
-      summary: Delete a study
-      parameters:
-      - name: project_id
-        in: path
-        description: The id of a project
-        required: true
-        schema:
-          type: integer
-          format: int64
-      - name: study_id
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
-      responses:
-        '204':
-          description: The study was deleted successfully
-    patch:
-      tags:
-      - studies
-      summary: Update a study
-      parameters:
-      - name: project_id
-        in: path
-        description: The id of a project
-        required: true
-        schema:
-          type: integer
-          format: int64
-      - name: study_id
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
-      requestBody:
-        description: The fields to update
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/StudyPatchForm'
-        required: true
-      responses:
-        '200':
-          description: The updated study
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StudyResponse'
-  /projects/{project_id}/studies/{study_id}/scenarios:
-    get:
-      tags:
-      - scenarios
-      summary: Return a list of scenarios
-      parameters:
-      - name: project_id
-        in: path
-        description: The id of a project
-        required: true
-        schema:
-          type: integer
-          format: int64
-      - name: study_id
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int64
-          default: 1
-          minimum: 1
-      - name: page_size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int64
-          default: 1000
-          maximum: 1000
-          minimum: 1
-      - name: ordering
-        in: query
-        required: false
-        schema:
-          type: string
-          enum:
-          - NameAsc
-          - NameDesc
-          - CreationDateAsc
-          - CreationDateDesc
-          - LastModifiedDesc
-          - LastModifiedAsc
-      responses:
-        '200':
-          description: A paginated list of scenarios
-          content:
-            application/json:
-              schema:
-                allOf:
-                - $ref: '#/components/schemas/PaginationStats'
-                - type: object
-                  required:
-                  - results
-                  properties:
-                    results:
-                      type: array
-                      items:
-                        $ref: '#/components/schemas/ScenarioWithDetails'
-        '404':
-          description: Project or study doesn't exist
-    post:
-      tags:
-      - scenarios
-      summary: Create a scenario
-      parameters:
-      - name: project_id
-        in: path
-        description: The id of a project
-        required: true
-        schema:
-          type: integer
-          format: int64
-      - name: study_id
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ScenarioCreateForm'
-        required: true
-      responses:
-        '201':
-          description: The created scenario
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ScenarioResponse'
-  /projects/{project_id}/studies/{study_id}/scenarios/{scenario_id}:
-    get:
-      tags:
-      - scenarios
-      summary: Return a specific scenario
-      parameters:
-      - name: project_id
-        in: path
-        description: The id of a project
-        required: true
-        schema:
-          type: integer
-          format: int64
-      - name: study_id
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
-      - name: scenario_id
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
-      responses:
-        '200':
-          description: The requested scenario
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ScenarioResponse'
-    delete:
-      tags:
-      - scenarios
-      summary: Delete a scenario
-      parameters:
-      - name: project_id
-        in: path
-        description: The id of a project
-        required: true
-        schema:
-          type: integer
-          format: int64
-      - name: study_id
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
-      - name: scenario_id
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
-      responses:
-        '204':
-          description: The scenario was deleted successfully
-    patch:
-      tags:
-      - scenarios
-      summary: Update a scenario
-      parameters:
-      - name: project_id
-        in: path
-        description: The id of a project
-        required: true
-        schema:
-          type: integer
-          format: int64
-      - name: study_id
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
-      - name: scenario_id
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ScenarioPatchForm'
-        required: true
-      responses:
-        '200':
-          description: The scenario was updated successfully
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ScenarioResponse'
-  /projects/{project_id}/studies/{study_id}/scenarios/{scenario_id}/macro_nodes:
-    get:
-      tags:
-      - scenarios
-      summary: Get macro node list by scenario id
-      parameters:
-      - name: project_id
-        in: path
-        description: The id of a project
-        required: true
-        schema:
-          type: integer
-          format: int64
-      - name: study_id
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
-      - name: scenario_id
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int64
-          default: 1
-          minimum: 1
-      - name: page_size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int64
-          default: 100
-          maximum: 100
-          minimum: 1
-      responses:
-        '200':
-          description: List of macro nodes for the requested scenario
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MacroNodeListResponse'
-    post:
-      tags:
-      - scenarios
-      parameters:
-      - name: project_id
-        in: path
-        description: The id of a project
-        required: true
-        schema:
-          type: integer
-          format: int64
-      - name: study_id
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
-      - name: scenario_id
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/MacroNodeBatchForm'
-        required: true
-      responses:
-        '201':
-          description: Macro nodes created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MacroNodeBatchResponse'
-  /projects/{project_id}/studies/{study_id}/scenarios/{scenario_id}/macro_nodes/{node_id}:
-    get:
-      tags:
-      - scenarios
-      parameters:
-      - name: project_id
-        in: path
-        description: The id of a project
-        required: true
-        schema:
-          type: integer
-          format: int64
-      - name: study_id
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
-      - name: scenario_id
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
-      - name: node_id
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
-      responses:
-        '200':
-          description: The requested Macro node
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MacroNodeResponse'
-    put:
-      tags:
-      - scenarios
-      parameters:
-      - name: project_id
-        in: path
-        description: The id of a project
-        required: true
-        schema:
-          type: integer
-          format: int64
-      - name: study_id
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
-      - name: scenario_id
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
-      - name: node_id
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/MacroNodeForm'
-        required: true
-      responses:
-        '200':
-          description: The updated macro node
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MacroNodeResponse'
-    delete:
-      tags:
-      - scenarios
-      parameters:
-      - name: project_id
-        in: path
-        description: The id of a project
-        required: true
-        schema:
-          type: integer
-          format: int64
-      - name: study_id
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
-      - name: scenario_id
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
-      - name: node_id
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
-      responses:
-        '204':
-          description: The macro node was deleted successfully
-  /projects/{project_id}/studies/{study_id}/scenarios/{scenario_id}/macro_notes:
-    get:
-      tags:
-      - scenarios
-      parameters:
-      - name: project_id
-        in: path
-        description: The id of a project
-        required: true
-        schema:
-          type: integer
-          format: int64
-      - name: study_id
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
-      - name: scenario_id
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int64
-          default: 1
-          minimum: 1
-      - name: page_size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int64
-          default: 100
-          maximum: 100
-          minimum: 1
-      responses:
-        '200':
-          description: List of macro notes for the requested scenario
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MacroNoteListResponse'
-    post:
-      tags:
-      - scenarios
-      parameters:
-      - name: project_id
-        in: path
-        description: The id of a project
-        required: true
-        schema:
-          type: integer
-          format: int64
-      - name: study_id
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
-      - name: scenario_id
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/MacroNoteBatchForm'
-        required: true
-      responses:
-        '201':
-          description: Macro notes created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MacroNoteBatchResponse'
-  /projects/{project_id}/studies/{study_id}/scenarios/{scenario_id}/macro_notes/{note_id}:
-    get:
-      tags:
-      - scenarios
-      summary: Return a specific note
-      parameters:
-      - name: project_id
-        in: path
-        description: The id of a project
-        required: true
-        schema:
-          type: integer
-          format: int64
-      - name: study_id
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
-      - name: scenario_id
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
-      - name: note_id
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
-      responses:
-        '200':
-          description: The requested macro note
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MacroNoteResponse'
-    put:
-      tags:
-      - scenarios
-      parameters:
-      - name: project_id
-        in: path
-        description: The id of a project
-        required: true
-        schema:
-          type: integer
-          format: int64
-      - name: study_id
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
-      - name: scenario_id
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
-      - name: note_id
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/MacroNoteForm'
-        required: true
-      responses:
-        '200':
-          description: The updated macro note
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MacroNoteResponse'
-    delete:
-      tags:
-      - scenarios
-      parameters:
-      - name: project_id
-        in: path
-        description: The id of a project
-        required: true
-        schema:
-          type: integer
-          format: int64
-      - name: study_id
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
-      - name: scenario_id
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
-      - name: note_id
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
-      responses:
-        '204':
-          description: The macro note was deleted successfully
   /rolling_stock:
     post:
       tags:
@@ -3340,6 +2814,139 @@ paths:
       responses:
         '204':
           description: Round trips were successfully deleted
+  /scenarios:
+    get:
+      tags:
+      - scenarios
+      summary: Return a list of scenarios
+      parameters:
+      - name: study_id
+        in: query
+        required: true
+        schema:
+          type: integer
+          format: int64
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int64
+          default: 1
+          minimum: 1
+      - name: page_size
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int64
+          default: 1000
+          maximum: 1000
+          minimum: 1
+      - name: ordering
+        in: query
+        required: false
+        schema:
+          type: string
+          enum:
+          - NameAsc
+          - NameDesc
+          - CreationDateAsc
+          - CreationDateDesc
+          - LastModifiedDesc
+          - LastModifiedAsc
+      responses:
+        '200':
+          description: A paginated list of scenarios
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/PaginationStats'
+                - type: object
+                  required:
+                  - results
+                  properties:
+                    results:
+                      type: array
+                      items:
+                        $ref: '#/components/schemas/ScenarioWithDetails'
+        '404':
+          description: Project or study doesn't exist
+    post:
+      tags:
+      - scenarios
+      summary: Create a scenario
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScenarioCreateForm'
+        required: true
+      responses:
+        '201':
+          description: The created scenario
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScenarioWithDetails'
+  /scenarios/{scenario_id}:
+    get:
+      tags:
+      - scenarios
+      summary: Return a specific scenario
+      parameters:
+      - name: scenario_id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        '200':
+          description: The requested scenario
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScenarioResponse'
+    delete:
+      tags:
+      - scenarios
+      summary: Delete a scenario
+      parameters:
+      - name: scenario_id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        '204':
+          description: The scenario was deleted successfully
+    patch:
+      tags:
+      - scenarios
+      summary: Update a scenario
+      parameters:
+      - name: scenario_id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScenarioPatchForm'
+        required: true
+      responses:
+        '200':
+          description: The scenario was updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScenarioWithDetails'
   /search:
     post:
       tags:
@@ -3617,6 +3224,138 @@ paths:
       responses:
         '204':
           description: The stdcm search environment was deleted successfully
+  /studies:
+    get:
+      tags:
+      - studies
+      summary: Return a list of studies
+      parameters:
+      - name: project_id
+        in: query
+        required: true
+        schema:
+          type: integer
+          format: int64
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int64
+          default: 1
+          minimum: 1
+      - name: page_size
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int64
+          default: 1000
+          maximum: 1000
+          minimum: 1
+      - name: ordering
+        in: query
+        required: false
+        schema:
+          type: string
+          enum:
+          - NameAsc
+          - NameDesc
+          - CreationDateAsc
+          - CreationDateDesc
+          - LastModifiedDesc
+          - LastModifiedAsc
+      responses:
+        '200':
+          description: The list of studies
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/PaginationStats'
+                - type: object
+                  required:
+                  - results
+                  properties:
+                    results:
+                      type: array
+                      items:
+                        $ref: '#/components/schemas/StudyWithScenarios'
+    post:
+      tags:
+      - studies
+      summary: Create a new study
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StudyCreateForm'
+        required: true
+      responses:
+        '201':
+          description: The created study
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StudyWithScenarios'
+  /studies/{study_id}:
+    get:
+      tags:
+      - studies
+      summary: Return a specific study
+      parameters:
+      - name: study_id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        '200':
+          description: The requested study
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StudyResponse'
+    delete:
+      tags:
+      - studies
+      summary: Delete a study
+      parameters:
+      - name: study_id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        '204':
+          description: The study was deleted successfully
+    patch:
+      tags:
+      - studies
+      summary: Update a study
+      parameters:
+      - name: study_id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      requestBody:
+        description: The fields to update
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StudyPatchForm'
+        required: true
+      responses:
+        '200':
+          description: The updated study
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StudyWithScenarios'
   /sub_category:
     get:
       tags:
@@ -6523,7 +6262,6 @@ components:
       - $ref: '#/components/schemas/EditoastMacroNodeErrorNotFound'
       - $ref: '#/components/schemas/EditoastMacroNoteErrorDatabase'
       - $ref: '#/components/schemas/EditoastMacroNoteErrorNotFound'
-      - $ref: '#/components/schemas/EditoastMacroNoteErrorWrongScenario'
       - $ref: '#/components/schemas/EditoastModelError'
       - $ref: '#/components/schemas/EditoastOperationErrorEmptyId'
       - $ref: '#/components/schemas/EditoastOperationErrorInvalidPatch'
@@ -6966,33 +6704,6 @@ components:
           type: string
           enum:
           - editoast:macro_note:NotFound
-    EditoastMacroNoteErrorWrongScenario:
-      type: object
-      required:
-      - type
-      - status
-      - message
-      properties:
-        context:
-          type: object
-          required:
-          - note_id
-          - scenario_id
-          properties:
-            note_id:
-              type: integer
-            scenario_id:
-              type: integer
-        message:
-          type: string
-        status:
-          type: integer
-          enum:
-          - 404
-        type:
-          type: string
-          enum:
-          - editoast:macro_note:WrongScenario
     EditoastModelError:
       type: object
       required:
@@ -10167,11 +9878,15 @@ components:
       type: object
       required:
       - macro_nodes
+      - scenario_id
       properties:
         macro_nodes:
           type: array
           items:
             $ref: '#/components/schemas/MacroNodeForm'
+        scenario_id:
+          type: integer
+          format: int64
     MacroNodeBatchResponse:
       type: object
       required:
@@ -10260,11 +9975,15 @@ components:
       type: object
       required:
       - macro_notes
+      - scenario_id
       properties:
         macro_notes:
           type: array
           items:
             $ref: '#/components/schemas/MacroNoteForm'
+        scenario_id:
+          type: integer
+          format: int64
     MacroNoteBatchResponse:
       type: object
       required:
@@ -12692,6 +12411,7 @@ components:
       - name
       - infra_id
       - timetable_id
+      - study_id
       properties:
         description:
           type: string
@@ -12705,6 +12425,9 @@ components:
           format: int64
         name:
           type: string
+        study_id:
+          type: integer
+          format: int64
         tags:
           $ref: '#/components/schemas/Tags'
         timetable_id:
@@ -12790,8 +12513,8 @@ components:
       - type: object
         required:
         - infra_name
-        - trains_count
         - paced_trains_count
+        - trains_count
         properties:
           infra_name:
             type: string
@@ -14495,6 +14218,7 @@ components:
       required:
       - name
       - state
+      - project_id
       properties:
         actual_end_date:
           type:
@@ -14521,6 +14245,9 @@ components:
           format: date
         name:
           type: string
+        project_id:
+          type: integer
+          format: int64
         service_code:
           type:
           - string

--- a/editoast/src/models/fixtures.rs
+++ b/editoast/src/models/fixtures.rs
@@ -318,8 +318,6 @@ pub async fn create_scenario(
 }
 
 pub struct ScenarioFixtureSet {
-    pub project: Project,
-    pub study: Study,
     pub scenario: Scenario,
     pub timetable: Timetable,
     pub infra: Infra,
@@ -329,14 +327,12 @@ pub async fn create_scenario_fixtures_set(
     conn: &mut DbConnection,
     name: &str,
 ) -> ScenarioFixtureSet {
-    let project = create_project(conn, &format!("project_test_name_with_{name}")).await;
-    let study = create_study(conn, &format!("study_test_name_with_{name}"), project.id).await;
     let infra = create_empty_infra(conn).await;
     let timetable = create_timetable(conn).await;
+    let project = create_project(conn, &format!("project_test_name_with_{name}")).await;
+    let study = create_study(conn, &format!("study_test_name_with_{name}"), project.id).await;
     let scenario = create_scenario(conn, name, study.id, timetable.id, infra.id).await;
     ScenarioFixtureSet {
-        project,
-        study,
         scenario,
         timetable,
         infra,

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -112,15 +112,21 @@ fn service_router() -> router::DocumentedRouter {
 
     router::DocumentedRouter::root(|path| {
         path
+            //
             // random stuff
+            //
             .route("/health", get!(health))
             .route("/version", get!(version))
             .route("/worker_load", post!(worker_load::worker_load))
-
+            //
             // authorization
+            //
             .nests("/authz", |path| {
                 path.route("/grants", post!(authz::update_grants))
-                    .route("/{resource_type}/{resource_id}", get!(authz::subjects_with_grant_on_resource))
+                    .route(
+                        "/{resource_type}/{resource_id}",
+                        get!(authz::subjects_with_grant_on_resource),
+                    )
                     .nests("/me", |path| {
                         path.route("/", get!(authz::whoami))
                             .route("/groups", get!(authz::user_groups))
@@ -128,12 +134,19 @@ fn service_router() -> router::DocumentedRouter {
                             .route("/privileges", post!(authz::user_privileges))
                     })
             })
-
+            //
             // infra & map
+            //
             .route("/fonts/{font}/{glyph}", get!(fonts::fonts))
             .nests("/layers", |path| {
-                path.route("/layer/{layer_slug}/mvt/{view_slug}", get!(layers::layer_view))
-                    .route("/tile/{layer_slug}/{view_slug}/{z}/{x}/{y}", get!(layers::cache_and_get_mvt_tile))
+                path.route(
+                    "/layer/{layer_slug}/mvt/{view_slug}",
+                    get!(layers::layer_view),
+                )
+                .route(
+                    "/tile/{layer_slug}/{view_slug}/{z}/{x}/{y}",
+                    get!(layers::cache_and_get_mvt_tile),
+                )
             })
             .nests("/sprites", |path| {
                 path.route("/signaling_systems", get!(sprites::signaling_systems))
@@ -153,27 +166,42 @@ fn service_router() -> router::DocumentedRouter {
                             .route("/", put!(infra::put))
                             .route("/auto_fixes", get!(infra::auto_fixes::list_auto_fixes))
                             .route("/clone", post!(infra::clone))
-                            .route("/delimited_area", get!(infra::delimited_area::delimited_area))
+                            .route(
+                                "/delimited_area",
+                                get!(infra::delimited_area::delimited_area),
+                            )
                             .route("/errors", get!(infra::errors::list_errors))
                             .route("/lock", post!(infra::lock))
-                            .route("/match_operational_points", post!(infra::match_operational_points))
+                            .route(
+                                "/match_operational_points",
+                                post!(infra::match_operational_points),
+                            )
                             .route("/path_properties", post!(path::properties::post))
                             .route("/railjson", get!(infra::railjson::get_railjson))
                             .route("/speed_limit_tags", get!(infra::get_speed_limit_tags))
-                            .route("/split_track_section", post!(infra::edition::split_track_section))
+                            .route(
+                                "/split_track_section",
+                                post!(infra::edition::split_track_section),
+                            )
                             .route("/switch_types", get!(infra::get_switch_types))
                             .route("/unlock", post!(infra::unlock))
                             .route("/voltages", get!(infra::get_voltages))
                             .route("/attached/{track_id}", get!(infra::attached::attached))
-                            .route("/lines/{line_code}/bbox",  get!(infra::lines::get_line_bbox))
+                            .route("/lines/{line_code}/bbox", get!(infra::lines::get_line_bbox))
                             .nests("/pathfinding", |path| {
                                 path.route("/", post!(infra::pathfinding::pathfinding_view))
                                     .route("/blocks", post!(path::pathfinding::post))
                             })
                             .nests("/routes", |path| {
                                 path.route("/nodes", post!(infra::routes::get_routes_nodes))
-                                    .route("/track_ranges", get!(infra::routes::get_routes_track_ranges))
-                                    .route("/{waypoint_type}/{waypoint_id}", get!(infra::routes::get_routes_from_waypoint))
+                                    .route(
+                                        "/track_ranges",
+                                        get!(infra::routes::get_routes_track_ranges),
+                                    )
+                                    .route(
+                                        "/{waypoint_type}/{waypoint_id}",
+                                        get!(infra::routes::get_routes_from_waypoint),
+                                    )
                             })
                             .nests("/objects/{object_type}", |path| {
                                 path.route("/", post!(infra::objects::get_objects))
@@ -181,8 +209,9 @@ fn service_router() -> router::DocumentedRouter {
                             })
                     })
             })
-
+            //
             // timetable & simulations
+            //
             .nests("/timetable", |path| {
                 path.route("/", post!(timetable::post))
                     .nests("/{id}", |path| {
@@ -196,7 +225,10 @@ fn service_router() -> router::DocumentedRouter {
                             })
                             .nests("/round_trips", |path| {
                                 path.route("/paced_trains", get!(round_trips::list_paced_trains))
-                                    .route("/train_schedules", get!(round_trips::list_train_schedules))
+                                    .route(
+                                        "/train_schedules",
+                                        get!(round_trips::list_train_schedules),
+                                    )
                             })
                             .nests("/train_schedules", |path| {
                                 path.route("/", get!(timetable::get_train_schedules))
@@ -204,33 +236,69 @@ fn service_router() -> router::DocumentedRouter {
                             })
                     })
             })
-            .route("/similar_trains", post!(timetable::similar_trains::similar_trains)) // TODO: put under /timtable
+            .route(
+                "/similar_trains", // TODO: put under /timetable
+                post!(timetable::similar_trains::similar_trains),
+            )
             .nests("/train_schedule", |path| {
                 path.route("/", delete!(timetable::train_schedule::delete))
-                    .route("/occupancy_blocks", post!(timetable::train_schedule::occupancy_blocks))
-                    .route("/project_path", post!(timetable::train_schedule::project_path))
-                    .route("/project_path_op", post!(timetable::train_schedule::project_path_op))
-                    .route("/simulation_summary", post!(timetable::train_schedule::simulation_summary))
-                    .route("/track_occupancy", post!(timetable::train_schedule::track_occupancy))
+                    .route(
+                        "/occupancy_blocks",
+                        post!(timetable::train_schedule::occupancy_blocks),
+                    )
+                    .route(
+                        "/project_path",
+                        post!(timetable::train_schedule::project_path),
+                    )
+                    .route(
+                        "/project_path_op",
+                        post!(timetable::train_schedule::project_path_op),
+                    )
+                    .route(
+                        "/simulation_summary",
+                        post!(timetable::train_schedule::simulation_summary),
+                    )
+                    .route(
+                        "/track_occupancy",
+                        post!(timetable::train_schedule::track_occupancy),
+                    )
                     .nests("/{id}", |path| {
                         path.route("/", get!(timetable::train_schedule::get))
                             .route("/", put!(timetable::train_schedule::put))
-                            .route("/etcs_braking_curves", get!(timetable::train_schedule::etcs_braking_curves))
+                            .route(
+                                "/etcs_braking_curves",
+                                get!(timetable::train_schedule::etcs_braking_curves),
+                            )
                             .route("/path", get!(timetable::train_schedule::get_path))
                             .route("/simulation", get!(timetable::train_schedule::simulation))
                     })
             })
             .nests("/paced_train", |path| {
                 path.route("/", delete!(timetable::paced_train::delete))
-                    .route("/occupancy_blocks", post!(timetable::paced_train::occupancy_blocks))
+                    .route(
+                        "/occupancy_blocks",
+                        post!(timetable::paced_train::occupancy_blocks),
+                    )
                     .route("/project_path", post!(timetable::paced_train::project_path))
-                    .route("/project_path_op", post!(timetable::paced_train::project_path_op))
-                    .route("/simulation_summary", post!(timetable::paced_train::simulation_summary))
-                    .route("/track_occupancy", post!(timetable::paced_train::track_occupancy))
+                    .route(
+                        "/project_path_op",
+                        post!(timetable::paced_train::project_path_op),
+                    )
+                    .route(
+                        "/simulation_summary",
+                        post!(timetable::paced_train::simulation_summary),
+                    )
+                    .route(
+                        "/track_occupancy",
+                        post!(timetable::paced_train::track_occupancy),
+                    )
                     .nests("/{id}", |path| {
                         path.route("/", get!(timetable::paced_train::get_by_id))
                             .route("/", put!(timetable::paced_train::update_paced_train))
-                            .route("/etcs_braking_curves", get!(timetable::paced_train::etcs_braking_curves))
+                            .route(
+                                "/etcs_braking_curves",
+                                get!(timetable::paced_train::etcs_braking_curves),
+                            )
                             .route("/path", get!(timetable::paced_train::get_path))
                             .route("/simulation", get!(timetable::paced_train::simulation))
                     })
@@ -252,8 +320,9 @@ fn service_router() -> router::DocumentedRouter {
                         path.route("/", delete!(sub_categories::delete_sub_category))
                     })
             })
-
+            //
             // simulation environment
+            //
             .nests("/stdcm/search_environment", |path| {
                 path.route("/", get!(stdcm_search_environment::retrieve_latest))
                     .route("/", post!(stdcm_search_environment::create))
@@ -273,7 +342,10 @@ fn service_router() -> router::DocumentedRouter {
                             })
                     })
             })
-            .route("/temporary_speed_limit_group", post!(temporary_speed_limits::create_temporary_speed_limit_group))
+            .route(
+                "/temporary_speed_limit_group",
+                post!(temporary_speed_limits::create_temporary_speed_limit_group),
+            )
             .nests("/electrical_profile_set", |path| {
                 path.route("/", get!(electrical_profiles::list))
                     .route("/", post!(electrical_profiles::post_electrical_profile))
@@ -283,8 +355,9 @@ fn service_router() -> router::DocumentedRouter {
                             .route("/level_order", get!(electrical_profiles::get_level_order))
                     })
             })
-
+            //
             // operational studies
+            //
             .nests("/documents", |path| {
                 path.route("/", post!(documents::post))
                     .nests("/{document_key}", |path| {
@@ -299,52 +372,47 @@ fn service_router() -> router::DocumentedRouter {
                         path.route("/", get!(project::get))
                             .route("/", delete!(project::delete))
                             .route("/", patch!(project::patch))
-                            .nests("/studies", |path| {
-                                path.route("/", post!(study::create))
-                                    .route("/", get!(study::list))
-                                    .nests("/{study_id}", |path| {
-                                        path.route("/", get!(study::get))
-                                            .route("/", delete!(study::delete))
-                                            .route("/", patch!(study::patch))
-                                            .nests("/scenarios", |path| {
-                                                path.route("/", post!(scenario::create))
-                                                    .route("/", get!(scenario::list))
-                                                    .nests("/{scenario_id}", |path| {
-                                                        path.route("/", get!(scenario::get))
-                                                            .route("/", delete!(scenario::delete))
-                                                            .route("/", patch!(scenario::patch))
-                                                            .nests("/macro_nodes", |path| {
-                                                                path.route("/", get!(scenario::macro_nodes::list))
-                                                                    .route("/", post!(scenario::macro_nodes::create))
-                                                                    .nests("/{node_id}", |path| {
-                                                                        path.route("/", get!(scenario::macro_nodes::get))
-                                                                            .route(
-                                                                                "/",
-                                                                                put!(scenario::macro_nodes::update),
-                                                                            )
-                                                                            .route(
-                                                                                "/",
-                                                                                delete!(scenario::macro_nodes::delete),
-                                                                            )
-                                                                    })
-                                                            })
-                                                            .nests("/macro_notes", |path| {
-                                                                path.route("/", get!(scenario::macro_notes::list))
-                                                                    .route("/", post!(scenario::macro_notes::create))
-                                                                    .nests("/{note_id}", |path| {
-                                                                    path.route("/", get!(scenario::macro_notes::get))
-                                                                        .route("/", put!(scenario::macro_notes::update))
-                                                                        .route("/", delete!(scenario::macro_notes::delete))
-                                                                })
-                                                            })
-                                                    })
-                                            })
-                                    })
-                            })
                     })
             })
-
+            .nests("/studies", |path| {
+                path.route("/", post!(study::create))
+                    .route("/", get!(study::list))
+                    .nests("/{study_id}", |path| {
+                        path.route("/", get!(study::get))
+                            .route("/", delete!(study::delete))
+                            .route("/", patch!(study::patch))
+                    })
+            })
+            .nests("/scenarios", |path| {
+                path.route("/", post!(scenario::create))
+                    .route("/", get!(scenario::list))
+                    .nests("/{scenario_id}", |path| {
+                        path.route("/", get!(scenario::get))
+                            .route("/", delete!(scenario::delete))
+                            .route("/", patch!(scenario::patch))
+                    })
+            })
+            .nests("/macro_nodes", |path| {
+                path.route("/", get!(scenario::macro_nodes::list))
+                    .route("/", post!(scenario::macro_nodes::create))
+                    .nests("/{node_id}", |path| {
+                        path.route("/", get!(scenario::macro_nodes::get))
+                            .route("/", put!(scenario::macro_nodes::update))
+                            .route("/", delete!(scenario::macro_nodes::delete))
+                    })
+            })
+            .nests("/macro_notes", |path| {
+                path.route("/", get!(scenario::macro_notes::list))
+                    .route("/", post!(scenario::macro_notes::create))
+                    .nests("/{note_id}", |path| {
+                        path.route("/", get!(scenario::macro_notes::get))
+                            .route("/", put!(scenario::macro_notes::update))
+                            .route("/", delete!(scenario::macro_notes::delete))
+                    })
+            })
+            //
             // rolling stock
+            //
             .nests("/rolling_stock", |path| {
                 path.route("/", post!(rolling_stock::create))
                     .route(
@@ -367,7 +435,10 @@ fn service_router() -> router::DocumentedRouter {
             .nests("/light_rolling_stock", |path| {
                 path.route("/", get!(rolling_stock::light::list))
                     // /!\ Order
-                    .route("/name/{rolling_stock_name}", get!(rolling_stock::light::get_by_name))
+                    .route(
+                        "/name/{rolling_stock_name}",
+                        get!(rolling_stock::light::get_by_name),
+                    )
                     .route("/{rolling_stock_id}", get!(rolling_stock::light::get))
             })
             .nests("/towed_rolling_stock", |path| {

--- a/editoast/src/views/project.rs
+++ b/editoast/src/views/project.rs
@@ -205,7 +205,7 @@ pub(in crate::views) async fn list(
 // Documentation struct
 #[derive(IntoParams)]
 #[allow(unused)]
-pub struct ProjectIdParam {
+pub(in crate::views) struct ProjectIdParam {
     /// The id of a project
     project_id: i64,
 }

--- a/editoast/src/views/scenario.rs
+++ b/editoast/src/views/scenario.rs
@@ -37,21 +37,11 @@ use crate::views::pagination::PaginatedList as _;
 use crate::views::pagination::PaginationQueryParams;
 use crate::views::pagination::PaginationStats;
 use crate::views::project::ProjectError;
-use crate::views::project::ProjectIdParam;
 use crate::views::study::StudyError;
-use crate::views::study::StudyIdParam;
 use editoast_models::tags::Tags;
 
 #[derive(IntoParams, Deserialize)]
-pub(in crate::views) struct ScenarioPathParam {
-    project_id: i64,
-    study_id: i64,
-    scenario_id: i64,
-}
-
-#[derive(IntoParams)]
-#[allow(unused)]
-pub struct ScenarioIdParam {
+pub(in crate::views) struct ScenarioIdParam {
     scenario_id: i64,
 }
 
@@ -63,6 +53,7 @@ pub(in crate::views) struct ScenarioCreateForm {
     pub description: String,
     pub infra_id: i64,
     pub timetable_id: i64,
+    pub study_id: i64,
     #[serde(default)]
     pub tags: Tags,
     pub electrical_profile_set_id: Option<i64>,
@@ -79,6 +70,7 @@ impl From<ScenarioCreateForm> for Changeset<Scenario> {
             .timetable_id(scenario.timetable_id)
             .tags(scenario.tags)
             .electrical_profile_set_id(scenario.electrical_profile_set_id)
+            .study_id(scenario.study_id)
     }
 }
 
@@ -108,8 +100,8 @@ pub struct ScenarioWithDetails {
     #[serde(flatten)]
     pub scenario: Scenario,
     pub infra_name: String,
-    pub trains_count: i64,
     pub paced_trains_count: i64,
+    pub trains_count: i64,
 }
 
 impl ScenarioWithDetails {
@@ -156,16 +148,14 @@ impl ScenarioResponse {
 #[utoipa::path(
     post, path = "",
     tag = "scenarios",
-    params(ProjectIdParam, StudyIdParam),
     request_body = ScenarioCreateForm,
     responses(
-        (status = 201, body = ScenarioResponse, description = "The created scenario"),
+        (status = 201, body = ScenarioWithDetails, description = "The created scenario"),
     )
 )]
 pub(in crate::views) async fn create(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
     Extension(auth): AuthenticationExt,
-    Path((project_id, study_id)): Path<(i64, i64)>,
     Json(data): Json<ScenarioCreateForm>,
 ) -> Result<impl IntoResponse> {
     let authorized = auth
@@ -178,17 +168,14 @@ pub(in crate::views) async fn create(
 
     let timetable_id = data.timetable_id;
     let infra_id = data.infra_id;
+    let study_id = data.study_id;
     let scenario_cs: Changeset<Scenario> = data.into();
 
-    let (details, study, project) = Study::transactional_content_update(
+    let details = Study::transactional_content_update(
         db_pool.get().await?,
         study_id,
-        move |mut conn, study, project| {
+        move |mut conn, study, _project| {
             async move {
-                if project.id != project_id {
-                    return Err::<_, InternalError>(ProjectError::NotFound { project_id }.into());
-                }
-
                 Timetable::exists_or_fail(&mut conn, timetable_id, || {
                     ScenarioError::TimetableNotFound { timetable_id }
                 })
@@ -202,17 +189,14 @@ pub(in crate::views) async fn create(
                 let scenario = scenario_cs.study_id(study.id).create(&mut conn).await?;
 
                 let details = ScenarioWithDetails::from_scenario(scenario, &mut conn).await?;
-                Ok((details, study, project))
+                Ok::<_, InternalError>(details)
             }
             .scope_boxed()
         },
     )
     .await?;
 
-    Ok((
-        StatusCode::CREATED,
-        Json(ScenarioResponse::new(details, project, study)),
-    ))
+    Ok((StatusCode::CREATED, Json(details)))
 }
 
 /// Delete a scenario
@@ -220,7 +204,7 @@ pub(in crate::views) async fn create(
 #[utoipa::path(
     delete, path = "",
     tag = "scenarios",
-    params(ProjectIdParam, StudyIdParam, ScenarioIdParam),
+    params(ScenarioIdParam),
     responses(
         (status = 204, description = "The scenario was deleted successfully"),
     )
@@ -228,11 +212,7 @@ pub(in crate::views) async fn create(
 pub(in crate::views) async fn delete(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
     Extension(auth): AuthenticationExt,
-    Path(ScenarioPathParam {
-        project_id,
-        study_id,
-        scenario_id,
-    }): Path<ScenarioPathParam>,
+    Path(ScenarioIdParam { scenario_id }): Path<ScenarioIdParam>,
 ) -> Result<impl IntoResponse> {
     let authorized = auth
         .check_roles([Role::OperationalStudies].into())
@@ -242,30 +222,32 @@ pub(in crate::views) async fn delete(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    Study::transactional_content_update(
-        db_pool.get().await?,
-        study_id,
-        move |mut conn, study, project| {
-            async move {
-                if project.id != project_id {
-                    return Err::<_, InternalError>(ProjectError::NotFound { project_id }.into());
-                }
+    let conn = db_pool.get().await?;
 
-                let scenario = Scenario::retrieve_or_fail(conn.clone(), scenario_id, || {
-                    ScenarioError::NotFound { scenario_id }
-                })
-                .await?;
+    conn.transaction(|conn| {
+        async move {
+            let scenario = Scenario::retrieve_or_fail(conn.clone(), scenario_id, || {
+                ScenarioError::NotFound { scenario_id }
+            })
+            .await?;
 
-                if scenario.study_id != study.id {
-                    return Err(ScenarioError::NotFound { scenario_id }.into());
-                }
+            Study::transactional_content_update(
+                conn,
+                scenario.study_id,
+                move |mut conn, _study, _project| {
+                    async move {
+                        scenario.delete(&mut conn).await?;
+                        Ok::<_, ScenarioError>(())
+                    }
+                    .scope_boxed()
+                },
+            )
+            .await?;
 
-                scenario.delete(&mut conn).await?;
-                Ok::<_, InternalError>(())
-            }
-            .scope_boxed()
-        },
-    )
+            Ok::<_, InternalError>(())
+        }
+        .scope_boxed()
+    })
     .await?;
 
     Ok(StatusCode::NO_CONTENT)
@@ -299,22 +281,18 @@ impl From<ScenarioPatchForm> for <Scenario as editoast_models::prelude::Model>::
 #[utoipa::path(
     patch, path = "",
     tag = "scenarios",
-    params(ProjectIdParam, StudyIdParam, ScenarioIdParam),
+    params(ScenarioIdParam),
     request_body = ScenarioPatchForm,
     responses(
-        (status = 200, body = ScenarioResponse, description = "The scenario was updated successfully"),
+        (status = 200, body = ScenarioWithDetails, description = "The scenario was updated successfully"),
     )
 )]
 pub(in crate::views) async fn patch(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
     Extension(auth): AuthenticationExt,
-    Path(ScenarioPathParam {
-        project_id,
-        study_id,
-        scenario_id,
-    }): Path<ScenarioPathParam>,
+    Path(ScenarioIdParam { scenario_id }): Path<ScenarioIdParam>,
     Json(form): Json<ScenarioPatchForm>,
-) -> Result<Json<ScenarioResponse>> {
+) -> Result<impl IntoResponse> {
     let authorized = auth
         .check_roles([Role::OperationalStudies].into())
         .await
@@ -323,17 +301,11 @@ pub(in crate::views) async fn patch(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    let (details, study, project) = Scenario::transactional_content_update(
+    let details = Scenario::transactional_content_update(
         db_pool.get().await?,
         scenario_id,
-        move |mut conn, _scenario, study, project| {
+        move |mut conn, _scenario, _study, _project| {
             async move {
-                if project.id != project_id {
-                    return Err::<_, InternalError>(ProjectError::NotFound { project_id }.into());
-                }
-                if study.id != study_id {
-                    return Err(StudyError::NotFound { study_id }.into());
-                }
                 if let Some(infra_id) = form.infra_id {
                     Infra::exists_or_fail(&mut conn, infra_id, || ScenarioError::InfraNotFound {
                         infra_id,
@@ -349,14 +321,14 @@ pub(in crate::views) async fn patch(
                     .await?;
 
                 let details = ScenarioWithDetails::from_scenario(scenario, &mut conn).await?;
-                Ok((details, study, project))
+                Ok::<_, InternalError>(details)
             }
             .scope_boxed()
         },
     )
     .await?;
 
-    Ok(Json(ScenarioResponse::new(details, project, study)))
+    Ok(Json(details))
 }
 
 /// Return a specific scenario
@@ -364,7 +336,7 @@ pub(in crate::views) async fn patch(
 #[utoipa::path(
     get, path = "",
     tag = "scenarios",
-    params(ProjectIdParam, StudyIdParam, ScenarioIdParam),
+    params(ScenarioIdParam),
     responses(
         (status = 200, body = ScenarioResponse, description = "The requested scenario"),
     )
@@ -372,11 +344,7 @@ pub(in crate::views) async fn patch(
 pub(in crate::views) async fn get(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
     Extension(auth): AuthenticationExt,
-    Path(ScenarioPathParam {
-        project_id,
-        study_id,
-        scenario_id,
-    }): Path<ScenarioPathParam>,
+    Path(ScenarioIdParam { scenario_id }): Path<ScenarioIdParam>,
 ) -> Result<Json<ScenarioResponse>> {
     let authorized = auth
         .check_roles([Role::OperationalStudies].into())
@@ -386,35 +354,32 @@ pub(in crate::views) async fn get(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    let (details, study, project) = db_pool
+    let (details, project, study) = db_pool
         .get()
         .await?
         .transaction(|mut conn| {
             async move {
-                let project = Project::retrieve_or_fail(conn.clone(), project_id, || {
-                    ProjectError::NotFound { project_id }
-                })
-                .await?;
-                let study = Study::retrieve_or_fail(conn.clone(), study_id, || {
-                    StudyError::NotFound { study_id }
-                })
-                .await?;
-                if study.project_id != project.id {
-                    return Err::<_, InternalError>(ProjectError::NotFound { project_id }.into());
-                }
-
                 let scenario = Scenario::retrieve_or_fail(conn.clone(), scenario_id, || {
                     ScenarioError::NotFound { scenario_id }
                 })
                 .await?;
-                if scenario.study_id != study_id {
-                    return Err(ScenarioError::NotFound { scenario_id }.into());
-                }
+                let study = Study::retrieve_or_fail(conn.clone(), scenario.study_id, || {
+                    StudyError::NotFound {
+                        study_id: scenario.study_id,
+                    }
+                })
+                .await?;
+                let project = Project::retrieve_or_fail(conn.clone(), study.project_id, || {
+                    ProjectError::NotFound {
+                        project_id: study.project_id,
+                    }
+                })
+                .await?;
 
                 Ok::<_, InternalError>((
                     ScenarioWithDetails::from_scenario(scenario, &mut conn).await?,
-                    study,
                     project,
+                    study,
                 ))
             }
             .scope_boxed()
@@ -432,12 +397,19 @@ pub(in crate::views) struct ListScenariosResponse {
     results: Vec<ScenarioWithDetails>,
 }
 
+#[derive(IntoParams, Deserialize)]
+#[into_params(parameter_in = Query)]
+pub(in crate::views) struct ListScenariosQueryParams {
+    #[param(inline)]
+    study_id: i64,
+}
+
 /// Return a list of scenarios
 #[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "scenarios",
-    params(ProjectIdParam, StudyIdParam, PaginationQueryParams<1000>, OperationalStudiesOrderingParam),
+    params(ListScenariosQueryParams, PaginationQueryParams<1000>, OperationalStudiesOrderingParam),
     responses(
         (status = 200, description = "A paginated list of scenarios", body = inline(ListScenariosResponse)),
         (status = 404, description = "Project or study doesn't exist")
@@ -446,7 +418,7 @@ pub(in crate::views) struct ListScenariosResponse {
 pub(in crate::views) async fn list(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
     Extension(auth): AuthenticationExt,
-    Path((project_id, study_id)): Path<(i64, i64)>,
+    Query(ListScenariosQueryParams { study_id }): Query<ListScenariosQueryParams>,
     Query(pagination_params): Query<PaginationQueryParams<1000>>,
     Query(OperationalStudiesOrderingParam { ordering }): Query<OperationalStudiesOrderingParam>,
 ) -> Result<Json<ListScenariosResponse>> {
@@ -459,13 +431,6 @@ pub(in crate::views) async fn list(
     }
 
     let conn = &mut db_pool.get().await?;
-
-    let study =
-        Study::retrieve_or_fail(conn.clone(), study_id, || StudyError::NotFound { study_id })
-            .await?;
-    if study.project_id != project_id {
-        return Err(ProjectError::NotFound { project_id }.into());
-    }
 
     let settings = pagination_params
         .into_selection_settings()
@@ -484,36 +449,6 @@ pub(in crate::views) async fn list(
     Ok(Json(ListScenariosResponse { stats, results }))
 }
 
-/// Validate that the project exists, the study exists and belongs to the project and the scenarios exists and belongs to the study
-async fn check_project_study_scenario(
-    conn: DbConnection,
-    project_id: i64,
-    study_id: i64,
-    scenario_id: i64,
-) -> Result<(Project, Study, Scenario)> {
-    let project = Project::retrieve_or_fail(conn.clone(), project_id, || ProjectError::NotFound {
-        project_id,
-    })
-    .await?;
-    let study =
-        Study::retrieve_or_fail(conn.clone(), study_id, || StudyError::NotFound { study_id })
-            .await?;
-
-    if study.project_id != project_id {
-        return Err(StudyError::NotFound { study_id }.into());
-    }
-
-    let scenario = Scenario::retrieve_or_fail(conn, scenario_id, || ScenarioError::NotFound {
-        scenario_id,
-    })
-    .await?;
-    if scenario.study_id != study_id {
-        return Err(ScenarioError::NotFound { scenario_id }.into());
-    }
-
-    Ok((project, study, scenario))
-}
-
 #[cfg(test)]
 mod tests {
     use pretty_assertions::assert_eq;
@@ -528,11 +463,9 @@ mod tests {
     use crate::models::fixtures::create_timetable;
     use crate::views::test_app::TestAppBuilder;
 
-    pub fn scenario_url(project_id: i64, study_id: i64, scenario_id: Option<i64>) -> String {
+    pub fn scenario_url(scenario_id: Option<i64>) -> String {
         format!(
-            "/projects/{}/studies/{}/scenarios/{}",
-            project_id,
-            study_id,
+            "/scenarios/{}",
             scenario_id.map_or_else(|| "".to_owned(), |v| v.to_string())
         )
     }
@@ -544,11 +477,7 @@ mod tests {
 
         let fixtures = create_scenario_fixtures_set(&mut pool.get_ok(), "test_scenario_name").await;
 
-        let url = scenario_url(
-            fixtures.project.id,
-            fixtures.study.id,
-            Some(fixtures.scenario.id),
-        );
+        let url = scenario_url(Some(fixtures.scenario.id));
         let request = app.get(&url);
 
         let response: ScenarioResponse = app
@@ -567,8 +496,10 @@ mod tests {
 
         let fixtures = create_scenario_fixtures_set(&mut pool.get_ok(), "test_scenario_name").await;
 
-        let url = scenario_url(fixtures.project.id, fixtures.study.id, None);
-        let request = app.get(&url);
+        let url = scenario_url(None);
+        let request = app
+            .get(&url)
+            .add_query_params(json!({"study_id": fixtures.scenario.study_id}));
 
         let mut response: ListScenariosResponse = app
             .fetch(request)
@@ -588,22 +519,6 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn get_scenarios_with_wrong_study() {
-        let app = TestAppBuilder::default_app();
-        let pool = app.db_pool();
-
-        let fixtures = create_scenario_fixtures_set(&mut pool.get_ok(), "test_scenario_name").await;
-
-        let url = scenario_url(fixtures.project.id, 99999999, Some(fixtures.scenario.id));
-
-        let request = app.get(&url);
-
-        app.fetch(request)
-            .await
-            .assert_status(StatusCode::NOT_FOUND);
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn post_scenario() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
@@ -613,45 +528,48 @@ mod tests {
         let infra = create_empty_infra(&mut pool.get_ok()).await;
         let timetable = create_timetable(&mut pool.get_ok()).await;
 
-        let url = scenario_url(project.id, study.id, None);
+        let url = scenario_url(None);
 
-        let study_name = "new created scenario";
-        let study_description = "new created scenario description";
-        let study_timetable_id = timetable.id;
-        let study_infra_id = infra.id;
-        let study_tags = Tags::new(vec!["tag1".to_string(), "tag2".to_string()]);
+        let scenario_name = "new created scenario";
+        let scenario_description = "new created scenario description";
+        let scenario_timetable_id = timetable.id;
+        let scenario_infra_id = infra.id;
+        let scenario_tags = Tags::new(vec!["tag1".to_string(), "tag2".to_string()]);
 
         // Insert scenario
         let request = app.post(&url).json(&json!({
-            "name": study_name,
-            "description": study_description,
-            "infra_id": study_infra_id,
-            "timetable_id": study_timetable_id,
-            "tags": study_tags
+            "name": scenario_name,
+            "description": scenario_description,
+            "infra_id": scenario_infra_id,
+            "timetable_id": scenario_timetable_id,
+            "tags": scenario_tags,
+            "study_id": study.id
         }));
 
-        let response: ScenarioResponse = app
+        let response: ScenarioWithDetails = app
             .fetch(request)
             .await
             .assert_status(StatusCode::CREATED)
             .json_into();
 
-        assert_eq!(response.scenario.name, study_name);
-        assert_eq!(response.scenario.description, study_description);
-        assert_eq!(response.scenario.infra_id, study_infra_id);
-        assert_eq!(response.scenario.timetable_id, study_timetable_id);
-        assert_eq!(response.scenario.tags, study_tags);
+        assert_eq!(response.scenario.name, scenario_name);
+        assert_eq!(response.scenario.description, scenario_description);
+        assert_eq!(response.scenario.infra_id, scenario_infra_id);
+        assert_eq!(response.scenario.timetable_id, scenario_timetable_id);
+        assert_eq!(response.scenario.tags, scenario_tags);
+        assert_eq!(response.scenario.study_id, study.id);
 
         let created_scenario = Scenario::retrieve(pool.get_ok(), response.scenario.id)
             .await
             .expect("Failed to retrieve scenario")
             .expect("Scenario not found");
 
-        assert_eq!(created_scenario.name, study_name);
-        assert_eq!(created_scenario.description, study_description);
-        assert_eq!(created_scenario.infra_id, study_infra_id);
-        assert_eq!(created_scenario.timetable_id, study_timetable_id);
-        assert_eq!(created_scenario.tags, study_tags);
+        assert_eq!(created_scenario.name, scenario_name);
+        assert_eq!(created_scenario.description, scenario_description);
+        assert_eq!(created_scenario.infra_id, scenario_infra_id);
+        assert_eq!(created_scenario.timetable_id, scenario_timetable_id);
+        assert_eq!(created_scenario.tags, scenario_tags);
+        assert_eq!(created_scenario.study_id, study.id);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -661,31 +579,27 @@ mod tests {
 
         let fixtures = create_scenario_fixtures_set(&mut pool.get_ok(), "test_scenario_name").await;
 
-        let url = scenario_url(
-            fixtures.project.id,
-            fixtures.study.id,
-            Some(fixtures.scenario.id),
-        );
+        let url = scenario_url(Some(fixtures.scenario.id));
 
-        let study_name = "new patched scenario";
-        let study_description = "new patched scenario description";
-        let study_tags = Tags::new(vec!["patched_tag1".to_string(), "patched_tag2".to_string()]);
+        let scenario_name = "new patched scenario";
+        let scenario_description = "new patched scenario description";
+        let scenario_tags = Tags::new(vec!["patched_tag1".to_string(), "patched_tag2".to_string()]);
 
         // Update scenario
         let request = app.patch(&url).json(&json!({
-            "name": study_name,
-            "description": study_description,
-            "tags": study_tags
+            "name": scenario_name,
+            "description": scenario_description,
+            "tags": scenario_tags
         }));
-        let response: ScenarioResponse = app
+        let response: ScenarioWithDetails = app
             .fetch(request)
             .await
             .assert_status(StatusCode::OK)
             .json_into();
 
-        assert_eq!(response.scenario.name, study_name);
-        assert_eq!(response.scenario.description, study_description);
-        assert_eq!(response.scenario.tags, study_tags);
+        assert_eq!(response.scenario.name, scenario_name);
+        assert_eq!(response.scenario.description, scenario_description);
+        assert_eq!(response.scenario.tags, scenario_tags);
         assert!(response.scenario.last_modification > fixtures.scenario.last_modification);
     }
 
@@ -696,11 +610,7 @@ mod tests {
 
         let fixtures = create_scenario_fixtures_set(&mut pool.get_ok(), "test_scenario_name").await;
 
-        let url = scenario_url(
-            fixtures.project.id,
-            fixtures.study.id,
-            Some(fixtures.scenario.id),
-        );
+        let url = scenario_url(Some(fixtures.scenario.id));
 
         // Update scenario
         let request = app.patch(&url).json(&json!({
@@ -723,27 +633,23 @@ mod tests {
         assert_eq!(fixtures.scenario.infra_id, fixtures.infra.id);
         assert_ne!(fixtures.scenario.infra_id, other_infra.id);
 
-        let url = scenario_url(
-            fixtures.project.id,
-            fixtures.study.id,
-            Some(fixtures.scenario.id),
-        );
+        let url = scenario_url(Some(fixtures.scenario.id));
 
-        let study_name = "new patched scenario V2";
-        let study_other_infra_id = other_infra.id;
+        let scenario_name = "new patched scenario V2";
+        let scenario_other_infra_id = other_infra.id;
 
         let request = app.patch(&url).json(&json!({
-            "name": study_name,
-            "infra_id": study_other_infra_id,
+            "name": scenario_name,
+            "infra_id": scenario_other_infra_id,
         }));
-        let response: ScenarioResponse = app
+        let response: ScenarioWithDetails = app
             .fetch(request)
             .await
             .assert_status(StatusCode::OK)
             .json_into();
 
-        assert_eq!(response.scenario.infra_id, study_other_infra_id);
-        assert_eq!(response.scenario.name, study_name);
+        assert_eq!(response.scenario.infra_id, scenario_other_infra_id);
+        assert_eq!(response.scenario.name, scenario_name);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -753,11 +659,7 @@ mod tests {
 
         let fixtures = create_scenario_fixtures_set(&mut pool.get_ok(), "test_scenario_name").await;
 
-        let url = scenario_url(
-            fixtures.project.id,
-            fixtures.study.id,
-            Some(fixtures.scenario.id),
-        );
+        let url = scenario_url(Some(fixtures.scenario.id));
         let request = app.delete(&url);
 
         app.fetch(request)

--- a/editoast/src/views/scenario/macro_nodes.rs
+++ b/editoast/src/views/scenario/macro_nodes.rs
@@ -8,7 +8,6 @@ use axum::extract::Query;
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
-use database::DbConnection;
 use database::DbConnectionPoolV2;
 use diesel_async::scoped_futures::ScopedFutureExt;
 use editoast_derive::EditoastError;
@@ -19,7 +18,6 @@ use thiserror::Error;
 use utoipa::IntoParams;
 use utoipa::ToSchema;
 
-use super::check_project_study_scenario;
 use crate::error::InternalError;
 use crate::error::Result;
 use crate::models::Scenario;
@@ -29,12 +27,6 @@ use crate::views::AuthorizationError;
 use crate::views::pagination::PaginatedList;
 use crate::views::pagination::PaginationQueryParams;
 use crate::views::pagination::PaginationStats;
-use crate::views::project::ProjectError;
-use crate::views::project::ProjectIdParam;
-use crate::views::scenario::ScenarioError;
-use crate::views::scenario::ScenarioIdParam;
-use crate::views::study::StudyError;
-use crate::views::study::StudyIdParam;
 use editoast_models::prelude::*;
 use editoast_models::tags::Tags;
 
@@ -51,8 +43,7 @@ enum MacroNodeError {
 }
 
 #[derive(IntoParams, Deserialize)]
-#[allow(unused)]
-struct MacroNodeIdParam {
+pub(in crate::views) struct MacroNodeIdParam {
     node_id: i64,
 }
 
@@ -72,6 +63,7 @@ pub(in crate::views) struct MacroNodeForm {
 #[cfg_attr(test, derive(Serialize, PartialEq))]
 pub(in crate::views) struct MacroNodeBatchForm {
     macro_nodes: Vec<MacroNodeForm>,
+    scenario_id: i64,
 }
 
 impl MacroNodeForm {
@@ -130,12 +122,19 @@ pub(in crate::views) struct MacroNodeListResponse {
     results: Vec<MacroNodeResponse>,
 }
 
+#[derive(IntoParams, Deserialize)]
+#[into_params(parameter_in = Query)]
+pub(in crate::views) struct ListMacroNodesQueryParams {
+    #[param(inline)]
+    scenario_id: i64,
+}
+
 /// Get macro node list by scenario id
 #[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "scenarios",
-    params(ProjectIdParam, StudyIdParam, ScenarioIdParam, PaginationQueryParams<100>),
+    params(ListMacroNodesQueryParams, PaginationQueryParams<100>),
     responses(
         (status = 200, body = MacroNodeListResponse, description = "List of macro nodes for the requested scenario"),
     )
@@ -143,7 +142,7 @@ pub(in crate::views) struct MacroNodeListResponse {
 pub(in crate::views) async fn list(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
     Extension(auth): AuthenticationExt,
-    Path((project_id, study_id, scenario_id)): Path<(i64, i64, i64)>,
+    Query(ListMacroNodesQueryParams { scenario_id }): Query<ListMacroNodesQueryParams>,
     Query(pagination_params): Query<PaginationQueryParams<100>>,
 ) -> Result<Json<MacroNodeListResponse>> {
     // Checking role
@@ -156,9 +155,6 @@ pub(in crate::views) async fn list(
     }
 
     let mut conn = db_pool.get().await?;
-
-    // Check for project / study / scenario
-    check_project_study_scenario(conn.clone(), project_id, study_id, scenario_id).await?;
 
     // Ask the db
     let settings = pagination_params
@@ -178,12 +174,12 @@ pub(in crate::views) async fn list(
     }))
 }
 
+/// Create macro nodes in batch
 #[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "scenarios",
     request_body = MacroNodeBatchForm,
-    params(ProjectIdParam, StudyIdParam, ScenarioIdParam),
     responses(
         (status = 201, body = MacroNodeBatchResponse, description = "Macro nodes created"),
     )
@@ -191,8 +187,10 @@ pub(in crate::views) async fn list(
 pub(in crate::views) async fn create(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
     Extension(auth): AuthenticationExt,
-    Path((project_id, study_id, scenario_id)): Path<(i64, i64, i64)>,
-    Json(data): Json<MacroNodeBatchForm>,
+    Json(MacroNodeBatchForm {
+        macro_nodes,
+        scenario_id,
+    }): Json<MacroNodeBatchForm>,
 ) -> Result<impl IntoResponse> {
     // Checking role
     let authorized = auth
@@ -206,27 +204,16 @@ pub(in crate::views) async fn create(
     let created = Scenario::transactional_content_update(
         db_pool.get().await?,
         scenario_id,
-        move |mut conn, scenario, study, project| {
+        move |mut conn, _scenario, _study, _project| {
             async move {
-                if project.id != project_id {
-                    return Err::<_, InternalError>(ProjectError::NotFound { project_id }.into());
-                }
-                if study.id != study_id {
-                    return Err(StudyError::NotFound { study_id }.into());
-                }
-                if scenario.id != scenario_id {
-                    return Err(ScenarioError::NotFound { scenario_id }.into());
-                }
-
-                let changesets: Vec<_> = data
-                    .macro_nodes
+                let changesets: Vec<_> = macro_nodes
                     .into_iter()
                     .map(|node| node.into_macro_node_changeset(scenario_id))
                     .collect();
 
                 let macro_nodes: Vec<_> = MacroNode::create_batch(&mut conn, changesets).await?;
 
-                Ok(macro_nodes)
+                Ok::<_, InternalError>(macro_nodes)
             }
             .scope_boxed()
         },
@@ -241,11 +228,12 @@ pub(in crate::views) async fn create(
     ))
 }
 
+/// Retrieve a macro node by id
 #[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "scenarios",
-    params(ProjectIdParam, StudyIdParam, ScenarioIdParam, MacroNodeIdParam),
+    params(MacroNodeIdParam),
     responses(
         (status = 200, body = MacroNodeResponse, description = "The requested Macro node"),
     )
@@ -253,7 +241,7 @@ pub(in crate::views) async fn create(
 pub(in crate::views) async fn get(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
     Extension(auth): AuthenticationExt,
-    Path((project_id, study_id, scenario_id, node_id)): Path<(i64, i64, i64, i64)>,
+    Path(MacroNodeIdParam { node_id }): Path<MacroNodeIdParam>,
 ) -> Result<Json<MacroNodeResponse>> {
     // Checking role
     let authorized = auth
@@ -264,21 +252,21 @@ pub(in crate::views) async fn get(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    // Check for project / study / scenario
     let conn = db_pool.get().await?;
-    check_project_study_scenario(conn.clone(), project_id, study_id, scenario_id).await?;
 
-    // Get / check the node
-    let macro_node = retrieve_macro_node_and_check_scenario(conn, scenario_id, node_id).await?;
+    // Get the node
+    let macro_node =
+        MacroNode::retrieve_or_fail(conn, node_id, || MacroNodeError::NotFound { node_id }).await?;
 
     Ok(Json(MacroNodeResponse::from(macro_node)))
 }
 
+/// Update a macro node
 #[editoast_derive::route]
 #[utoipa::path(
     put, path = "",
     tag = "scenarios",
-    params(ProjectIdParam, StudyIdParam, ScenarioIdParam, MacroNodeIdParam),
+    params(MacroNodeIdParam),
     request_body = MacroNodeForm,
     responses(
         (status = 200, body = MacroNodeResponse, description = "The updated macro node"),
@@ -287,7 +275,7 @@ pub(in crate::views) async fn get(
 pub(in crate::views) async fn update(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
     Extension(auth): AuthenticationExt,
-    Path((project_id, study_id, scenario_id, node_id)): Path<(i64, i64, i64, i64)>,
+    Path(MacroNodeIdParam { node_id }): Path<MacroNodeIdParam>,
     Json(data): Json<MacroNodeForm>,
 ) -> Result<Json<MacroNodeResponse>> {
     let authorized = auth
@@ -298,49 +286,50 @@ pub(in crate::views) async fn update(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    let updated = Scenario::transactional_content_update(
-        db_pool.get().await?,
-        scenario_id,
-        move |mut conn, scenario, study, project| {
+    let conn = db_pool.get().await?;
+
+    let updated_macro_node = conn
+        .transaction(|conn| {
             async move {
                 let node = MacroNode::retrieve_or_fail(conn.clone(), node_id, || {
                     MacroNodeError::NotFound { node_id }
                 })
                 .await?;
 
-                if project.id != project_id {
-                    return Err::<_, InternalError>(ProjectError::NotFound { project_id }.into());
-                }
-                if study.id != study_id {
-                    return Err(StudyError::NotFound { study_id }.into());
-                }
-                if scenario.id != scenario_id {
-                    return Err(ScenarioError::NotFound { scenario_id }.into());
-                }
-                if node.scenario_id != scenario_id {
-                    return Err(MacroNodeError::NotFound { node_id }.into());
-                }
+                let updated_macro_node = Scenario::transactional_content_update(
+                    conn,
+                    node.scenario_id,
+                    move |mut conn, scenario, _study, _project| {
+                        async move {
+                            let node = data
+                                .into_macro_node_changeset(scenario.id)
+                                .update_or_fail(&mut conn, node_id, || MacroNodeError::NotFound {
+                                    node_id,
+                                })
+                                .await?;
 
-                let node = data
-                    .into_macro_node_changeset(scenario_id)
-                    .update_or_fail(&mut conn, node_id, || MacroNodeError::NotFound { node_id })
-                    .await?;
+                            Ok::<_, InternalError>(node)
+                        }
+                        .scope_boxed()
+                    },
+                )
+                .await?;
 
-                Ok(node)
+                Ok::<_, InternalError>(updated_macro_node)
             }
             .scope_boxed()
-        },
-    )
-    .await?;
+        })
+        .await?;
 
-    Ok(Json(MacroNodeResponse::from(updated)))
+    Ok(Json(MacroNodeResponse::from(updated_macro_node)))
 }
 
+/// Delete a macro node
 #[editoast_derive::route]
 #[utoipa::path(
     delete, path = "",
     tag = "scenarios",
-    params(ProjectIdParam, StudyIdParam, ScenarioIdParam, MacroNodeIdParam),
+    params(MacroNodeIdParam),
     responses(
         (status = 204, description = "The macro node was deleted successfully"),
     )
@@ -348,7 +337,7 @@ pub(in crate::views) async fn update(
 pub(in crate::views) async fn delete(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
     Extension(auth): AuthenticationExt,
-    Path((project_id, study_id, scenario_id, node_id)): Path<(i64, i64, i64, i64)>,
+    Path(MacroNodeIdParam { node_id }): Path<MacroNodeIdParam>,
 ) -> Result<impl IntoResponse> {
     let authorized = auth
         .check_roles([Role::OperationalStudies].into())
@@ -358,51 +347,35 @@ pub(in crate::views) async fn delete(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    Scenario::transactional_content_update(
-        db_pool.get().await?,
-        scenario_id,
-        move |mut conn, scenario, study, project| {
-            async move {
-                let node = MacroNode::retrieve_or_fail(conn.clone(), node_id, || {
-                    MacroNodeError::NotFound { node_id }
-                })
-                .await?;
+    let conn = db_pool.get().await?;
 
-                if project.id != project_id {
-                    return Err::<_, InternalError>(ProjectError::NotFound { project_id }.into());
-                }
-                if study.id != study_id {
-                    return Err(StudyError::NotFound { study_id }.into());
-                }
-                if scenario.id != scenario_id {
-                    return Err(ScenarioError::NotFound { scenario_id }.into());
-                }
-                if node.scenario_id != scenario_id {
-                    return Err(MacroNodeError::NotFound { node_id }.into());
-                }
+    conn.transaction(|conn| {
+        async move {
+            let node = MacroNode::retrieve_or_fail(conn.clone(), node_id, || {
+                MacroNodeError::NotFound { node_id }
+            })
+            .await?;
 
-                node.delete(&mut conn).await?;
-                Ok(())
-            }
-            .scope_boxed()
-        },
-    )
+            Scenario::transactional_content_update(
+                conn,
+                node.scenario_id,
+                move |mut conn, _scenario, _study, _project| {
+                    async move {
+                        node.delete(&mut conn).await?;
+                        Ok::<_, InternalError>(())
+                    }
+                    .scope_boxed()
+                },
+            )
+            .await?;
+
+            Ok::<_, InternalError>(())
+        }
+        .scope_boxed()
+    })
     .await?;
 
     Ok(StatusCode::NO_CONTENT)
-}
-
-async fn retrieve_macro_node_and_check_scenario(
-    conn: DbConnection,
-    scenario_id: i64,
-    node_id: i64,
-) -> Result<MacroNode> {
-    let node =
-        MacroNode::retrieve_or_fail(conn, node_id, || MacroNodeError::NotFound { node_id }).await?;
-    if node.scenario_id != scenario_id {
-        return Err(MacroNodeError::NotFound { node_id }.into());
-    }
-    Ok(node)
 }
 
 #[cfg(test)]
@@ -413,8 +386,6 @@ pub mod test {
     use rand::rng;
 
     use super::*;
-    use crate::models::Project;
-    use crate::models::Study;
     use crate::models::fixtures::create_scenario_fixtures_set;
     use crate::views::test_app::TestAppBuilder;
 
@@ -461,14 +432,10 @@ pub mod test {
             path_item_key: "->".to_string(),
         }];
 
-        let request = app
-            .post(&format!(
-                "/projects/{}/studies/{}/scenarios/{}/macro_nodes",
-                fixtures.project.id, fixtures.study.id, fixtures.scenario.id
-            ))
-            .json(&MacroNodeBatchForm {
-                macro_nodes: nodes_data.clone(),
-            });
+        let request = app.post("/macro_nodes").json(&MacroNodeBatchForm {
+            macro_nodes: nodes_data.clone(),
+            scenario_id: fixtures.scenario.id,
+        });
         let response: MacroNodeBatchResponse = app
             .fetch(request)
             .await
@@ -500,10 +467,7 @@ pub mod test {
             path_item_key: "A->B".to_string(),
         };
         let request = app
-            .put(&format!(
-                "/projects/{}/studies/{}/scenarios/{}/macro_nodes/{}",
-                fixtures.project.id, fixtures.study.id, fixtures.scenario.id, fixtures.nodes[0].id
-            ))
+            .put(&format!("/macro_nodes/{}", fixtures.nodes[0].id))
             .json(&node_data);
         let response: MacroNodeResponse = app
             .fetch(request)
@@ -526,10 +490,7 @@ pub mod test {
         let db_pool = app.db_pool();
         let fixtures = create_macro_node_fixtures_set(&mut db_pool.get_ok(), 1).await;
 
-        let request = app.get(&format!(
-            "/projects/{}/studies/{}/scenarios/{}/macro_nodes/{}",
-            fixtures.project.id, fixtures.study.id, fixtures.scenario.id, fixtures.nodes[0].id
-        ));
+        let request = app.get(&format!("/macro_nodes/{}", fixtures.nodes[0].id));
         let response: MacroNodeResponse = app
             .fetch(request)
             .await
@@ -540,14 +501,25 @@ pub mod test {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn get_node_not_found() {
+        let app = TestAppBuilder::default_app();
+
+        let request = app.get("/macro_nodes/999999");
+
+        app.fetch(request)
+            .await
+            .assert_status(StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn list() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
         let fixtures = create_macro_node_fixtures_set(&mut db_pool.get_ok(), 10).await;
 
         let request = app.get(&format!(
-            "/projects/{}/studies/{}/scenarios/{}/macro_nodes?page=1&page_size=5",
-            fixtures.project.id, fixtures.study.id, fixtures.scenario.id
+            "/macro_nodes?page=1&page_size=5&scenario_id={}",
+            fixtures.scenario.id
         ));
         let response: MacroNodeListResponse = app
             .fetch(request)
@@ -565,10 +537,7 @@ pub mod test {
         let db_pool = app.db_pool();
         let fixtures = create_macro_node_fixtures_set(&mut db_pool.get_ok(), 1).await;
 
-        let request = app.delete(&format!(
-            "/projects/{}/studies/{}/scenarios/{}/macro_nodes/{}",
-            fixtures.project.id, fixtures.study.id, fixtures.scenario.id, fixtures.nodes[0].id
-        ));
+        let request = app.delete(&format!("/macro_nodes/{}", fixtures.nodes[0].id));
         app.fetch(request)
             .await
             .assert_status(StatusCode::NO_CONTENT);
@@ -577,22 +546,6 @@ pub mod test {
             .await
             .unwrap();
         assert_eq!(false, found)
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn retrieve_with_bad_scenario() {
-        let app = TestAppBuilder::default_app();
-        let db_pool = app.db_pool();
-        let fixtures = create_macro_node_fixtures_set(&mut db_pool.get_ok(), 1).await;
-
-        let result = retrieve_macro_node_and_check_scenario(
-            db_pool.get_ok(),
-            fixtures.scenario.id + 1,
-            fixtures.nodes[0].id,
-        )
-        .await;
-
-        assert!(result.is_err());
     }
 
     fn random_string(n: usize) -> String {
@@ -604,14 +557,12 @@ pub mod test {
     }
 
     struct MacroNodeFixtureSet {
-        project: Project,
-        study: Study,
         scenario: Scenario,
         nodes: Vec<MacroNode>,
     }
 
     async fn create_macro_node_fixtures_set(
-        conn: &mut DbConnection,
+        conn: &mut database::DbConnection,
         number: usize,
     ) -> MacroNodeFixtureSet {
         let mut rng = rand::rng();
@@ -637,8 +588,6 @@ pub mod test {
         }
 
         MacroNodeFixtureSet {
-            project: fixtures.project,
-            study: fixtures.study,
             scenario: fixtures.scenario,
             nodes,
         }

--- a/editoast/src/views/scenario/macro_notes.rs
+++ b/editoast/src/views/scenario/macro_notes.rs
@@ -18,7 +18,6 @@ use thiserror::Error;
 use utoipa::IntoParams;
 use utoipa::ToSchema;
 
-use super::check_project_study_scenario;
 use crate::error::InternalError;
 use crate::error::Result;
 use crate::models::Scenario;
@@ -28,12 +27,6 @@ use crate::views::AuthorizationError;
 use crate::views::pagination::PaginatedList;
 use crate::views::pagination::PaginationQueryParams;
 use crate::views::pagination::PaginationStats;
-use crate::views::project::ProjectError;
-use crate::views::project::ProjectIdParam;
-use crate::views::scenario::ScenarioError;
-use crate::views::scenario::ScenarioIdParam;
-use crate::views::study::StudyError;
-use crate::views::study::StudyIdParam;
 use editoast_models::prelude::*;
 use editoast_models::tags::Tags;
 
@@ -44,18 +37,13 @@ enum MacroNoteError {
     #[editoast_error(status = 404)]
     NotFound { note_id: i64 },
 
-    #[error("Note '{note_id}' does not belong to scenario '{scenario_id}'")]
-    #[editoast_error(status = 404)]
-    WrongScenario { note_id: i64, scenario_id: i64 },
-
     #[error(transparent)]
     #[editoast_error(status = 500)]
     Database(#[from] editoast_models::Error),
 }
 
 #[derive(IntoParams, Deserialize)]
-#[allow(unused)]
-struct MacroNoteIdParam {
+pub(in crate::views) struct MacroNoteIdParam {
     note_id: i64,
 }
 
@@ -73,6 +61,7 @@ pub(in crate::views) struct MacroNoteForm {
 #[cfg_attr(test, derive(Serialize, PartialEq, Clone))]
 pub(in crate::views) struct MacroNoteBatchForm {
     macro_notes: Vec<MacroNoteForm>,
+    scenario_id: i64,
 }
 
 impl MacroNoteForm {
@@ -125,11 +114,19 @@ pub(in crate::views) struct MacroNoteListResponse {
     results: Vec<MacroNoteResponse>,
 }
 
+#[derive(IntoParams, Deserialize)]
+#[into_params(parameter_in = Query)]
+pub(in crate::views) struct ListMacroNotesQueryParams {
+    #[param(inline)]
+    scenario_id: i64,
+}
+
+/// Return a list of notes for a given scenario
 #[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "scenarios",
-    params(ProjectIdParam, StudyIdParam, ScenarioIdParam, PaginationQueryParams<100>),
+    params(ListMacroNotesQueryParams, PaginationQueryParams<100>),
     responses(
         (status = 200, body = MacroNoteListResponse, description = "List of macro notes for the requested scenario"),
     )
@@ -137,7 +134,7 @@ pub(in crate::views) struct MacroNoteListResponse {
 pub(in crate::views) async fn list(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
     Extension(auth): AuthenticationExt,
-    Path((project_id, study_id, scenario_id)): Path<(i64, i64, i64)>,
+    Query(ListMacroNotesQueryParams { scenario_id }): Query<ListMacroNotesQueryParams>,
     Query(pagination_params): Query<PaginationQueryParams<100>>,
 ) -> Result<Json<MacroNoteListResponse>> {
     let authorized = auth
@@ -149,8 +146,6 @@ pub(in crate::views) async fn list(
     }
 
     let mut conn = db_pool.get().await?;
-
-    check_project_study_scenario(conn.clone(), project_id, study_id, scenario_id).await?;
 
     let settings = pagination_params
         .into_selection_settings()
@@ -167,12 +162,12 @@ pub(in crate::views) async fn list(
     }))
 }
 
+/// Create a note in batch
 #[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "scenarios",
     request_body = MacroNoteBatchForm,
-    params(ProjectIdParam, StudyIdParam, ScenarioIdParam),
     responses(
         (status = 201, body = MacroNoteBatchResponse, description = "Macro notes created"),
     )
@@ -180,8 +175,10 @@ pub(in crate::views) async fn list(
 pub(in crate::views) async fn create(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
     Extension(auth): AuthenticationExt,
-    Path((project_id, study_id, scenario_id)): Path<(i64, i64, i64)>,
-    Json(MacroNoteBatchForm { macro_notes }): Json<MacroNoteBatchForm>,
+    Json(MacroNoteBatchForm {
+        macro_notes,
+        scenario_id,
+    }): Json<MacroNoteBatchForm>,
 ) -> Result<impl IntoResponse> {
     let authorized = auth
         .check_roles([Role::OperationalStudies].into())
@@ -194,18 +191,8 @@ pub(in crate::views) async fn create(
     let created = Scenario::transactional_content_update(
         db_pool.get().await?,
         scenario_id,
-        move |mut conn, scenario, study, project| {
+        move |mut conn, _scenario, _study, _project| {
             async move {
-                if project.id != project_id {
-                    return Err::<_, InternalError>(ProjectError::NotFound { project_id }.into());
-                }
-                if study.id != study_id {
-                    return Err(StudyError::NotFound { study_id }.into());
-                }
-                if scenario.id != scenario_id {
-                    return Err(ScenarioError::NotFound { scenario_id }.into());
-                }
-
                 let changesets: Vec<_> = macro_notes
                     .into_iter()
                     .map(|note| note.into_macro_note_changeset(scenario_id))
@@ -214,7 +201,7 @@ pub(in crate::views) async fn create(
                 let created_macro_notes: Vec<_> =
                     MacroNote::create_batch(&mut conn, changesets).await?;
 
-                Ok(created_macro_notes)
+                Ok::<_, InternalError>(created_macro_notes)
             }
             .scope_boxed()
         },
@@ -234,7 +221,7 @@ pub(in crate::views) async fn create(
 #[utoipa::path(
     get, path = "",
     tag = "scenarios",
-    params(ProjectIdParam, StudyIdParam, ScenarioIdParam, MacroNoteIdParam),
+    params(MacroNoteIdParam),
     responses(
         (status = 200, body = MacroNoteResponse, description = "The requested macro note"),
     )
@@ -242,7 +229,7 @@ pub(in crate::views) async fn create(
 pub(in crate::views) async fn get(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
     Extension(auth): AuthenticationExt,
-    Path((project_id, study_id, scenario_id, note_id)): Path<(i64, i64, i64, i64)>,
+    Path(MacroNoteIdParam { note_id }): Path<MacroNoteIdParam>,
 ) -> Result<Json<MacroNoteResponse>> {
     // Checking role
     let authorized = auth
@@ -253,30 +240,22 @@ pub(in crate::views) async fn get(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    // Check for project / study / scenario
     let conn = db_pool.get().await?;
-    check_project_study_scenario(conn.clone(), project_id, study_id, scenario_id).await?;
 
-    // Get / check the note
+    // Get the note
     let macro_note =
         MacroNote::retrieve_or_fail(conn, note_id, || MacroNoteError::NotFound { note_id }).await?;
-    if macro_note.scenario_id != scenario_id {
-        return Err(MacroNoteError::WrongScenario {
-            note_id,
-            scenario_id,
-        }
-        .into());
-    }
 
     Ok(Json(MacroNoteResponse::from(macro_note)))
 }
 
+/// Update a note
 #[editoast_derive::route]
 #[utoipa::path(
     put, path = "",
     tag = "scenarios",
     request_body = MacroNoteForm,
-    params(ProjectIdParam, StudyIdParam, ScenarioIdParam, MacroNoteIdParam),
+    params(MacroNoteIdParam),
     responses(
         (status = 200, body = MacroNoteResponse, description = "The updated macro note"),
     )
@@ -284,7 +263,7 @@ pub(in crate::views) async fn get(
 pub(in crate::views) async fn update(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
     Extension(auth): AuthenticationExt,
-    Path((project_id, study_id, scenario_id, note_id)): Path<(i64, i64, i64, i64)>,
+    Path(MacroNoteIdParam { note_id }): Path<MacroNoteIdParam>,
     Json(note_form): Json<MacroNoteForm>,
 ) -> Result<Json<MacroNoteResponse>> {
     let authorized = auth
@@ -295,59 +274,58 @@ pub(in crate::views) async fn update(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    let updated = Scenario::transactional_content_update(
-        db_pool.get().await?,
-        scenario_id,
-        move |mut conn, scenario, study, project| {
+    let conn = db_pool.get().await?;
+
+    let updated_macro_note = conn
+        .transaction(|conn| {
             async move {
                 let note = MacroNote::retrieve_or_fail(conn.clone(), note_id, || {
                     MacroNoteError::NotFound { note_id }
                 })
                 .await?;
 
-                if project.id != project_id {
-                    return Err::<_, InternalError>(ProjectError::NotFound { project_id }.into());
-                }
-                if study.id != study_id {
-                    return Err(StudyError::NotFound { study_id }.into());
-                }
-                if scenario.id != scenario_id {
-                    return Err(ScenarioError::NotFound { scenario_id }.into());
-                }
-                if note.scenario_id != scenario_id {
-                    return Err(MacroNoteError::WrongScenario {
-                        note_id,
-                        scenario_id,
-                    }
-                    .into());
-                }
+                let updated_macro_note = Scenario::transactional_content_update(
+                    conn,
+                    note.scenario_id,
+                    move |mut conn, scenario, _study, _project| {
+                        async move {
+                            let updated_note = note_form
+                                .into_macro_note_changeset(scenario.id)
+                                .update_or_fail(&mut conn, note_id, || MacroNoteError::NotFound {
+                                    note_id,
+                                })
+                                .await?;
 
-                let updated_note = note_form
-                    .into_macro_note_changeset(scenario_id)
-                    .update_or_fail(&mut conn, note_id, || MacroNoteError::NotFound { note_id })
-                    .await?;
+                            Ok::<_, InternalError>(updated_note)
+                        }
+                        .scope_boxed()
+                    },
+                )
+                .await?;
 
-                Ok(updated_note)
+                Ok::<_, InternalError>(updated_macro_note)
             }
             .scope_boxed()
-        },
-    )
-    .await?;
+        })
+        .await?;
 
-    Ok(Json(MacroNoteResponse::from(updated)))
+    Ok(Json(MacroNoteResponse::from(updated_macro_note)))
 }
 
+/// Delete a note
 #[editoast_derive::route]
 #[utoipa::path(
     delete, path = "",
     tag = "scenarios",
-    params(ProjectIdParam, StudyIdParam, ScenarioIdParam, MacroNoteIdParam),
-    responses((status = 204, description = "The macro note was deleted successfully"),)
+    params(MacroNoteIdParam),
+    responses(
+        (status = 204, description = "The macro note was deleted successfully"),
+    )
 )]
 pub(in crate::views) async fn delete(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
     Extension(auth): AuthenticationExt,
-    Path((project_id, study_id, scenario_id, note_id)): Path<(i64, i64, i64, i64)>,
+    Path(MacroNoteIdParam { note_id }): Path<MacroNoteIdParam>,
 ) -> Result<impl IntoResponse> {
     let authorized = auth
         .check_roles([Role::OperationalStudies].into())
@@ -357,39 +335,32 @@ pub(in crate::views) async fn delete(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    Scenario::transactional_content_update(
-        db_pool.get().await?,
-        scenario_id,
-        move |mut conn, scenario, study, project| {
-            async move {
-                let note = MacroNote::retrieve_or_fail(conn.clone(), note_id, || {
-                    MacroNoteError::NotFound { note_id }
-                })
-                .await?;
+    let conn = db_pool.get().await?;
 
-                if project.id != project_id {
-                    return Err::<_, InternalError>(ProjectError::NotFound { project_id }.into());
-                }
-                if study.id != study_id {
-                    return Err(StudyError::NotFound { study_id }.into());
-                }
-                if scenario.id != scenario_id {
-                    return Err(ScenarioError::NotFound { scenario_id }.into());
-                }
-                if note.scenario_id != scenario_id {
-                    return Err(MacroNoteError::WrongScenario {
-                        note_id,
-                        scenario_id,
+    conn.transaction(|conn| {
+        async move {
+            let note = MacroNote::retrieve_or_fail(conn.clone(), note_id, || {
+                MacroNoteError::NotFound { note_id }
+            })
+            .await?;
+
+            Scenario::transactional_content_update(
+                conn,
+                note.scenario_id,
+                move |mut conn, _scenario, _study, _project| {
+                    async move {
+                        note.delete(&mut conn).await?;
+                        Ok::<_, InternalError>(())
                     }
-                    .into());
-                }
+                    .scope_boxed()
+                },
+            )
+            .await?;
 
-                note.delete(&mut conn).await?;
-                Ok(())
-            }
-            .scope_boxed()
-        },
-    )
+            Ok::<_, InternalError>(())
+        }
+        .scope_boxed()
+    })
     .await?;
 
     Ok(StatusCode::NO_CONTENT)
@@ -453,8 +424,8 @@ pub mod test {
         }
 
         let request = app.get(&format!(
-            "/projects/{}/studies/{}/scenarios/{}/macro_notes?page=1&page_size=3",
-            fixtures1.project.id, fixtures1.study.id, fixtures1.scenario.id
+            "/macro_notes?page=1&page_size=3&scenario_id={}",
+            fixtures1.scenario.id
         ));
         let response: MacroNoteListResponse = app
             .fetch(request)
@@ -502,14 +473,10 @@ pub mod test {
             },
         ];
 
-        let request = app
-            .post(&format!(
-                "/projects/{}/studies/{}/scenarios/{}/macro_notes",
-                fixtures.project.id, fixtures.study.id, fixtures.scenario.id
-            ))
-            .json(&MacroNoteBatchForm {
-                macro_notes: notes_data.clone(),
-            });
+        let request = app.post("/macro_notes").json(&MacroNoteBatchForm {
+            macro_notes: notes_data.clone(),
+            scenario_id: fixtures.scenario.id,
+        });
         let response: MacroNoteBatchResponse = app
             .fetch(request)
             .await
@@ -543,16 +510,10 @@ pub mod test {
             labels: Tags::new(vec!["A".to_string()]),
         }];
 
-        let request = app
-            .post(&format!(
-                "/projects/{}/studies/{}/scenarios/{}/macro_notes",
-                fixtures.project.id,
-                fixtures.study.id,
-                fixtures.scenario.id + 1
-            ))
-            .json(&MacroNoteBatchForm {
-                macro_notes: notes_data.clone(),
-            });
+        let request = app.post("/macro_notes").json(&MacroNoteBatchForm {
+            macro_notes: notes_data.clone(),
+            scenario_id: fixtures.scenario.id + 1,
+        });
         app.fetch(request)
             .await
             .assert_status(StatusCode::NOT_FOUND);
@@ -575,10 +536,7 @@ pub mod test {
             .await
             .expect("Failed to create macro note");
 
-        let request = app.get(&format!(
-            "/projects/{}/studies/{}/scenarios/{}/macro_notes/{}",
-            fixtures.project.id, fixtures.study.id, fixtures.scenario.id, note.id
-        ));
+        let request = app.get(&format!("/macro_notes/{}", note.id));
 
         let response: MacroNoteResponse = app
             .fetch(request)
@@ -592,44 +550,8 @@ pub mod test {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_note_not_found() {
         let app = TestAppBuilder::default_app();
-        let db_pool = app.db_pool();
-        let fixtures =
-            create_scenario_fixtures_set(&mut db_pool.get_ok(), "test_scenario_name").await;
 
-        let request = app.get(&format!(
-            "/projects/{}/studies/{}/scenarios/{}/macro_notes/999999",
-            fixtures.project.id, fixtures.study.id, fixtures.scenario.id
-        ));
-
-        app.fetch(request)
-            .await
-            .assert_status(StatusCode::NOT_FOUND);
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn get_note_wrong_scenario() {
-        let app = TestAppBuilder::default_app();
-        let db_pool = app.db_pool();
-        let fixtures =
-            create_scenario_fixtures_set(&mut db_pool.get_ok(), "test_scenario_name").await;
-        let fixtures_2 =
-            create_scenario_fixtures_set(&mut db_pool.get_ok(), "test_scenario_name_2").await;
-
-        let note = MacroNote::changeset()
-            .scenario_id(fixtures.scenario.id)
-            .x(rng().random_range(0..100))
-            .y(rng().random_range(0..100))
-            .title("Note title".to_string())
-            .text("Note text".to_string())
-            .labels(Tags::new(vec!["A".to_string(), "B".to_string()]))
-            .create(&mut db_pool.get_ok())
-            .await
-            .expect("Failed to create macro note");
-
-        let request = app.get(&format!(
-            "/projects/{}/studies/{}/scenarios/{}/macro_notes/{}",
-            fixtures_2.project.id, fixtures_2.study.id, fixtures_2.scenario.id, note.id
-        ));
+        let request = app.get("/macro_notes/999999");
 
         app.fetch(request)
             .await
@@ -661,12 +583,7 @@ pub mod test {
             labels: Tags::new(vec!["New label".to_string(), "B".to_string()]),
         };
 
-        let request = app
-            .put(&format!(
-                "/projects/{}/studies/{}/scenarios/{}/macro_notes/{}",
-                fixtures.project.id, fixtures.study.id, fixtures.scenario.id, note.id
-            ))
-            .json(&update);
+        let request = app.put(&format!("/macro_notes/{}", note.id)).json(&update);
 
         let response: MacroNoteResponse = app
             .fetch(request)
@@ -686,9 +603,6 @@ pub mod test {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn update_note_not_found() {
         let app = TestAppBuilder::default_app();
-        let db_pool = app.db_pool();
-        let fixtures =
-            create_scenario_fixtures_set(&mut db_pool.get_ok(), "test_scenario_name").await;
 
         let update = MacroNoteForm {
             x: 30,
@@ -698,12 +612,7 @@ pub mod test {
             labels: Tags::new(vec!["New label".to_string(), "B".to_string()]),
         };
 
-        let request = app
-            .put(&format!(
-                "/projects/{}/studies/{}/scenarios/{}/macro_notes/999999",
-                fixtures.project.id, fixtures.study.id, fixtures.scenario.id
-            ))
-            .json(&update);
+        let request = app.put("/macro_notes/999999999").json(&update);
 
         app.fetch(request)
             .await
@@ -728,10 +637,7 @@ pub mod test {
             .await
             .expect("Failed to create macro note");
 
-        let request = app.delete(&format!(
-            "/projects/{}/studies/{}/scenarios/{}/macro_notes/{}",
-            fixtures.project.id, fixtures.study.id, fixtures.scenario.id, note.id
-        ));
+        let request = app.delete(&format!("/macro_notes/{}", note.id));
 
         app.fetch(request)
             .await
@@ -746,14 +652,8 @@ pub mod test {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn delete_note_not_found() {
         let app = TestAppBuilder::default_app();
-        let db_pool = app.db_pool();
-        let fixtures =
-            create_scenario_fixtures_set(&mut db_pool.get_ok(), "test_scenario_name").await;
 
-        let request = app.delete(&format!(
-            "/projects/{}/studies/{}/scenarios/{}/macro_notes/999999",
-            fixtures.project.id, fixtures.study.id, fixtures.scenario.id
-        ));
+        let request = app.delete("/macro_notes/999999");
 
         app.fetch(request)
             .await

--- a/editoast/src/views/study.rs
+++ b/editoast/src/views/study.rs
@@ -31,7 +31,6 @@ use crate::models::Study;
 use crate::views::pagination::PaginatedList as _;
 use crate::views::pagination::PaginationQueryParams;
 use crate::views::project::ProjectError;
-use crate::views::project::ProjectIdParam;
 use editoast_models::prelude::*;
 use editoast_models::tags::Tags;
 
@@ -99,6 +98,7 @@ pub(in crate::views) struct StudyCreateForm {
     pub tags: Tags,
     pub state: String,
     pub study_type: Option<String>,
+    pub project_id: i64,
 }
 
 impl<'de> Deserialize<'de> for StudyCreateForm {
@@ -118,8 +118,8 @@ impl<'de> Deserialize<'de> for StudyCreateForm {
 }
 
 impl StudyCreateForm {
-    pub fn into_study_changeset(self, project_id: i64) -> Result<Changeset<Study>> {
-        let study_changeset = Study::changeset()
+    pub fn into_study_changeset(self) -> Changeset<Study> {
+        Study::changeset()
             .name(self.name)
             .description(self.description)
             .business_code(self.business_code)
@@ -133,25 +133,23 @@ impl StudyCreateForm {
             .tags(self.tags)
             .state(self.state)
             .study_type(self.study_type)
-            .project_id(project_id);
-        Ok(study_changeset)
+            .project_id(self.project_id)
     }
 }
 
+/// Create a new study
 #[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
     tag = "studies",
-    params(ProjectIdParam),
     request_body = StudyCreateForm,
     responses(
-        (status = 201, body = StudyResponse, description = "The created study"),
+        (status = 201, body = StudyWithScenarioCount, description = "The created study"),
     )
 )]
 pub(in crate::views) async fn create(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
     Extension(auth): AuthenticationExt,
-    Path(project_id): Path<i64>,
     Json(data): Json<StudyCreateForm>,
 ) -> Result<impl IntoResponse> {
     let authorized = auth
@@ -162,16 +160,13 @@ pub(in crate::views) async fn create(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    let (study, project) = Project::transactional_content_update(
+    let study = Project::transactional_content_update(
         db_pool.get().await?,
-        project_id,
-        |mut conn, project| {
+        data.project_id,
+        |mut conn, _project| {
             async move {
-                let study = data
-                    .into_study_changeset(project.id)?
-                    .create(&mut conn)
-                    .await?;
-                Ok::<_, InternalError>((study, project))
+                let study = data.into_study_changeset().create(&mut conn).await?;
+                Ok::<_, InternalError>(study)
             }
             .scope_boxed()
         },
@@ -179,18 +174,16 @@ pub(in crate::views) async fn create(
     .await?;
 
     // Return study with list of scenarios
-    let study_response = StudyResponse {
+    let study_response = StudyWithScenarioCount {
         study,
         scenarios_count: 0,
-        project,
     };
 
     Ok((StatusCode::CREATED, Json(study_response)))
 }
 
-#[derive(IntoParams)]
-#[allow(unused)]
-pub struct StudyIdParam {
+#[derive(IntoParams, Deserialize)]
+pub(in crate::views) struct StudyIdParam {
     study_id: i64,
 }
 
@@ -199,7 +192,7 @@ pub struct StudyIdParam {
 #[utoipa::path(
     delete, path = "",
     tag = "studies",
-    params(ProjectIdParam, StudyIdParam),
+    params(StudyIdParam),
     responses(
         (status = 204, description = "The study was deleted successfully"),
     )
@@ -207,7 +200,7 @@ pub struct StudyIdParam {
 pub(in crate::views) async fn delete(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
     Extension(auth): AuthenticationExt,
-    Path((project_id, study_id)): Path<(i64, i64)>,
+    Path(StudyIdParam { study_id }): Path<StudyIdParam>,
 ) -> Result<impl IntoResponse> {
     let authorized = auth
         .check_roles([Role::OperationalStudies].into())
@@ -217,11 +210,28 @@ pub(in crate::views) async fn delete(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    Project::transactional_content_update(db_pool.get().await?, project_id, |mut conn, _| {
+    let conn = db_pool.get().await?;
+
+    conn.transaction(|conn| {
         async move {
-            Study::delete_static_or_fail(&mut conn, study_id, || StudyError::NotFound { study_id })
-                .await?;
-            Ok::<_, StudyError>(())
+            let study = Study::retrieve_or_fail(conn.clone(), study_id, || StudyError::NotFound {
+                study_id,
+            })
+            .await?;
+
+            Project::transactional_content_update(conn, study.project_id, |mut conn, _| {
+                async move {
+                    Study::delete_static_or_fail(&mut conn, study_id, || StudyError::NotFound {
+                        study_id,
+                    })
+                    .await?;
+                    Ok::<_, StudyError>(())
+                }
+                .scope_boxed()
+            })
+            .await?;
+
+            Ok::<_, InternalError>(())
         }
         .scope_boxed()
     })
@@ -235,7 +245,7 @@ pub(in crate::views) async fn delete(
 #[utoipa::path(
     get, path = "",
     tag = "studies",
-    params(ProjectIdParam, StudyIdParam),
+    params(StudyIdParam),
     responses(
         (status = 200, body = StudyResponse, description = "The requested study"),
     )
@@ -243,7 +253,7 @@ pub(in crate::views) async fn delete(
 pub(in crate::views) async fn get(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
     Extension(auth): AuthenticationExt,
-    Path((project_id, study_id)): Path<(i64, i64)>,
+    Path(StudyIdParam { study_id }): Path<StudyIdParam>,
 ) -> Result<Json<StudyResponse>> {
     let authorized = auth
         .check_roles([Role::OperationalStudies].into())
@@ -253,27 +263,24 @@ pub(in crate::views) async fn get(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    let (project, study_scenarios) = db_pool
+    let (study_scenarios, project) = db_pool
         .get()
         .await?
         .transaction(|mut conn| {
             async move {
-                let project = Project::retrieve_or_fail(conn.clone(), project_id, || {
-                    ProjectError::NotFound { project_id }
-                })
-                .await?;
                 let study = Study::retrieve_or_fail(conn.clone(), study_id, || {
                     StudyError::NotFound { study_id }
                 })
                 .await?;
-
-                // Check if the study belongs to the project
-                if study.project_id != project_id {
-                    return Err::<_, InternalError>(StudyError::NotFound { study_id }.into());
-                }
+                let project = Project::retrieve_or_fail(conn.clone(), study.project_id, || {
+                    ProjectError::NotFound {
+                        project_id: study.project_id,
+                    }
+                })
+                .await?;
 
                 let study_scenarios = StudyWithScenarioCount::try_fetch(&mut conn, study).await?;
-                Ok((project, study_scenarios))
+                Ok::<_, InternalError>((study_scenarios, project))
             }
             .scope_boxed()
         })
@@ -347,21 +354,21 @@ impl StudyPatchForm {
 #[utoipa::path(
     patch, path = "",
     tag = "studies",
-    params(ProjectIdParam, StudyIdParam),
+    params(StudyIdParam),
     request_body(
         content = StudyPatchForm,
         description = "The fields to update"
     ),
     responses(
-        (status = 200, body = StudyResponse, description = "The updated study"),
+        (status = 200, body = StudyWithScenarioCount, description = "The updated study"),
     )
 )]
 pub(in crate::views) async fn patch(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
     Extension(auth): AuthenticationExt,
-    Path((project_id, study_id)): Path<(i64, i64)>,
+    Path(StudyIdParam { study_id }): Path<StudyIdParam>,
     Json(data): Json<StudyPatchForm>,
-) -> Result<Json<StudyResponse>> {
+) -> Result<Json<StudyWithScenarioCount>> {
     let authorized = auth
         .check_roles([Role::OperationalStudies].into())
         .await
@@ -370,27 +377,24 @@ pub(in crate::views) async fn patch(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    let (response, project) = Study::transactional_content_update(
+    let response = Study::transactional_content_update(
         db_pool.get().await?,
         study_id,
-        move |mut conn, _study, project| {
+        move |mut conn, _study, _project| {
             async move {
-                if project.id != project_id {
-                    return Err::<_, InternalError>(StudyError::NotFound { study_id }.into());
-                }
                 let study = data
                     .into_study_changeset()?
                     .update_or_fail(&mut conn, study_id, || StudyError::NotFound { study_id })
                     .await?;
                 let study_scenarios = StudyWithScenarioCount::try_fetch(&mut conn, study).await?;
-                Ok::<_, InternalError>((study_scenarios, project))
+                Ok::<_, InternalError>(study_scenarios)
             }
             .scope_boxed()
         },
     )
     .await?;
 
-    Ok(Json(StudyResponse::new(response, project)))
+    Ok(Json(response))
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
@@ -422,12 +426,19 @@ pub(in crate::views) struct StudyListResponse {
     stats: PaginationStats,
 }
 
+#[derive(IntoParams, Deserialize)]
+#[into_params(parameter_in = Query)]
+pub(in crate::views) struct ListStudiesQueryParams {
+    #[param(inline)]
+    project_id: i64,
+}
+
 /// Return a list of studies
 #[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tag = "studies",
-    params(ProjectIdParam, PaginationQueryParams<1000>, OperationalStudiesOrderingParam),
+    params(ListStudiesQueryParams, PaginationQueryParams<1000>, OperationalStudiesOrderingParam),
     responses(
         (status = 200, body = inline(StudyListResponse), description = "The list of studies"),
     )
@@ -435,7 +446,7 @@ pub(in crate::views) struct StudyListResponse {
 pub(in crate::views) async fn list(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
     Extension(auth): AuthenticationExt,
-    Path(project_id): Path<i64>,
+    Query(ListStudiesQueryParams { project_id }): Query<ListStudiesQueryParams>,
     Query(pagination_params): Query<PaginationQueryParams<1000>>,
     Query(ordering_params): Query<OperationalStudiesOrderingParam>,
 ) -> Result<Json<StudyListResponse>> {
@@ -490,17 +501,16 @@ pub mod tests {
 
         let created_project = create_project(&mut db_pool.get_ok(), "test_project_name").await;
 
-        let request = app
-            .post(&format!("/projects/{}/studies/", created_project.id))
-            .json(&json!({
-                "name": "study_test",
-                "description": "Study description",
-                "state": "Starting",
-                "business_code": "",
-                "service_code": "",
-                "study_type": "",
-            }));
-        let response: StudyResponse = app
+        let request = app.post("/studies/").json(&json!({
+            "name": "study_test",
+            "description": "Study description",
+            "state": "Starting",
+            "business_code": "",
+            "service_code": "",
+            "study_type": "",
+            "project_id": created_project.id,
+        }));
+        let response: StudyWithScenarioCount = app
             .fetch(request)
             .await
             .assert_status(StatusCode::CREATED)
@@ -525,7 +535,9 @@ pub mod tests {
         let created_study =
             create_study(&mut db_pool.get_ok(), "test_study_name", created_project.id).await;
 
-        let request = app.get(&format!("/projects/{}/studies/", created_project.id));
+        let request = app
+            .get("/studies")
+            .add_query_param("project_id", created_project.id);
 
         let response: StudyListResponse = app
             .fetch(request)
@@ -552,10 +564,7 @@ pub mod tests {
         let created_study =
             create_study(&mut db_pool.get_ok(), "test_study_name", created_project.id).await;
 
-        let request = app.get(&format!(
-            "/projects/{}/studies/{}",
-            created_project.id, created_study.id
-        ));
+        let request = app.get(&format!("/studies/{}", created_study.id));
 
         let response: StudyResponse = app
             .fetch(request)
@@ -565,7 +574,6 @@ pub mod tests {
 
         assert_eq!(response.study, created_study);
         assert_eq!(response.study.project_id, created_project.id);
-        assert_eq!(response.project, created_project);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -578,11 +586,7 @@ pub mod tests {
         let created_study =
             create_study(&mut db_pool.get_ok(), "test_study_name", created_project.id).await;
 
-        let request = app.get(&format!(
-            "/projects/{}/studies/{}",
-            created_project.id,
-            created_study.id + 1000
-        ));
+        let request = app.get(&format!("/studies/{}", created_study.id + 1000));
 
         app.fetch(request)
             .await
@@ -599,10 +603,7 @@ pub mod tests {
         let created_study =
             create_study(&mut db_pool.get_ok(), "test_study_name", created_project.id).await;
 
-        let request = app.delete(&format!(
-            "/projects/{}/studies/{}",
-            created_project.id, created_study.id
-        ));
+        let request = app.delete(&format!("/studies/{}", created_study.id));
 
         app.fetch(request)
             .await
@@ -629,10 +630,7 @@ pub mod tests {
         let study_budget = 20000;
 
         let request = app
-            .patch(&format!(
-                "/projects/{}/studies/{}",
-                created_project.id, created_study.id
-            ))
+            .patch(&format!("/studies/{}", created_study.id))
             .json(&json!({
                 "name": study_name,
                 "budget": study_budget,

--- a/front/src/applications/operationalStudies/components/Study/AddOrEditStudyModal.tsx
+++ b/front/src/applications/operationalStudies/components/Study/AddOrEditStudyModal.tsx
@@ -35,7 +35,7 @@ import useOutsideClick from 'utils/hooks/useOutsideClick';
 
 import { createSelectOptions, checkStudyFields } from './utils';
 
-export type StudyForm = StudyCreateForm & {
+export type StudyForm = Omit<StudyCreateForm, 'project_id'> & {
   id?: number;
 };
 
@@ -67,18 +67,18 @@ const AddOrEditStudyModal = ({ editionMode, study, scenarios }: AddOrEditStudyMo
   const { t } = useTranslation(['operational-studies', 'translation']);
   const { openModal } = useModal();
   const { closeModal, isOpen } = useContext(ModalContext);
+  const { projectId } = useParams() as StudyParams;
   const [currentStudy, setCurrentStudy] = useState<StudyForm>(study || emptyStudy);
   const [displayErrors, setDisplayErrors] = useState(false);
-  const { projectId } = useParams() as StudyParams;
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
 
   const [createStudies, { error: createStudyError }] =
-    osrdEditoastApi.endpoints.postProjectsByProjectIdStudies.useMutation();
+    osrdEditoastApi.endpoints.postStudies.useMutation();
   const [patchStudies, { error: patchStudyError }] =
-    osrdEditoastApi.endpoints.patchProjectsByProjectIdStudiesAndStudyId.useMutation();
+    osrdEditoastApi.endpoints.patchStudiesByStudyId.useMutation();
   const [deleteStudies, { error: deleteStudyError }] =
-    osrdEditoastApi.endpoints.deleteProjectsByProjectIdStudiesAndStudyId.useMutation();
+    osrdEditoastApi.endpoints.deleteStudiesByStudyId.useMutation();
 
   const studyStateOptions = createSelectOptions(t, studyStates);
 
@@ -115,8 +115,7 @@ const AddOrEditStudyModal = ({ editionMode, study, scenarios }: AddOrEditStudyMo
       setDisplayErrors(true);
     } else {
       createStudies({
-        projectId: +projectId,
-        studyCreateForm: currentStudy,
+        studyCreateForm: { ...currentStudy, project_id: parseInt(projectId, 10) },
       })
         .unwrap()
         .then((createdStudy) => {
@@ -131,7 +130,6 @@ const AddOrEditStudyModal = ({ editionMode, study, scenarios }: AddOrEditStudyMo
       setDisplayErrors(true);
     } else if (study?.id && projectId) {
       patchStudies({
-        projectId: +projectId,
         studyId: study.id,
         studyPatchForm: currentStudy,
       })
@@ -151,7 +149,6 @@ const AddOrEditStudyModal = ({ editionMode, study, scenarios }: AddOrEditStudyMo
   const deleteStudy = () => {
     if (study?.id && projectId) {
       deleteStudies({
-        projectId: +projectId,
         studyId: study.id,
       })
         .unwrap()

--- a/front/src/applications/operationalStudies/hooks/useScenario.ts
+++ b/front/src/applications/operationalStudies/hooks/useScenario.ts
@@ -10,8 +10,6 @@ import { useAppDispatch } from 'store';
 import { parseNumber } from 'utils/strings';
 
 type SimulationParams = {
-  projectId: string;
-  studyId: string;
   scenarioId: string;
 };
 
@@ -19,30 +17,17 @@ const useScenario = () => {
   const dispatch = useAppDispatch();
   const { updateInfraID } = useOsrdConfActions();
 
-  const {
-    projectId: urlProjectId,
-    studyId: urlStudyId,
-    scenarioId: urlScenarioId,
-  } = useParams() as SimulationParams;
+  const { scenarioId: urlScenarioId } = useParams() as SimulationParams;
 
-  const { projectId, studyId, scenarioId } = useMemo(
-    () => ({
-      projectId: parseNumber(urlProjectId),
-      studyId: parseNumber(urlStudyId),
-      scenarioId: parseNumber(urlScenarioId),
-    }),
-    [urlStudyId, urlProjectId, urlScenarioId]
-  );
+  const scenarioId = useMemo(() => parseNumber(urlScenarioId), [urlScenarioId]);
 
   const {
     data: scenario,
     isError: isScenarioError,
     error: errorScenario,
-  } = osrdEditoastApi.endpoints.getProjectsByProjectIdStudiesAndStudyIdScenariosScenarioId.useQuery(
-    projectId && studyId && scenarioId
+  } = osrdEditoastApi.endpoints.getScenariosByScenarioId.useQuery(
+    scenarioId
       ? {
-          projectId: projectId,
-          studyId: studyId,
           scenarioId: scenarioId,
         }
       : skipToken
@@ -62,10 +47,10 @@ const useScenario = () => {
   }, [isScenarioError, errorScenario]);
 
   useEffect(() => {
-    if (!projectId || !studyId || !scenarioId) {
-      throw new Error('Missing projectId, studyId or scenarioId');
+    if (!scenarioId) {
+      throw new Error('Missing scenarioId');
     }
-  }, [projectId, studyId, scenarioId]);
+  }, [scenarioId]);
 
   return { scenario };
 };

--- a/front/src/applications/operationalStudies/hooks/useScenarioData.ts
+++ b/front/src/applications/operationalStudies/hooks/useScenarioData.ts
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useMemo, useState, useRef } from 'react';
 import { skipToken } from '@reduxjs/toolkit/query';
 import { keyBy, sortBy } from 'lodash';
 
-import { osrdEditoastApi, type ScenarioResponse } from 'common/api/osrdEditoastApi';
+import { osrdEditoastApi, type ScenarioWithDetails } from 'common/api/osrdEditoastApi';
 import { useRollingStockContext } from 'common/RollingStockContext';
 import useLazyProjectTrains from 'modules/simulationResult/components/SpaceTimeChartWrapper/useLazyProjectTrains';
 import {
@@ -31,7 +31,7 @@ type ScenarioBroadcastMessage =
   | { type: 'removeTimetableItems'; timetableItemIds: TimetableItemId[] }
   | { type: 'setTimetableItemDepartureTime'; timetableItemId: TimetableItemId; newDeparture: Date };
 
-const useScenarioData = (scenario: ScenarioResponse, infraId: number) => {
+const useScenarioData = (scenario: ScenarioWithDetails, infraId: number) => {
   const dispatch = useAppDispatch();
 
   const [timetableItems, setTimetableItems] = useState<TimetableItem[]>();

--- a/front/src/applications/operationalStudies/views/Project/ProjectView.tsx
+++ b/front/src/applications/operationalStudies/views/Project/ProjectView.tsx
@@ -53,8 +53,7 @@ const ProjectView = () => {
   const [isLoading, setIsLoading] = useState(true);
 
   const { projectId: urlProjectId } = useParams() as ProjectParams;
-  const [deleteStudy] =
-    osrdEditoastApi.endpoints.deleteProjectsByProjectIdStudiesAndStudyId.useMutation();
+  const [deleteStudy] = osrdEditoastApi.endpoints.deleteStudiesByStudyId.useMutation();
   const [postSearch] = osrdEditoastApi.endpoints.postSearch.useMutation();
 
   const { projectId } = useMemo(
@@ -72,7 +71,7 @@ const ProjectView = () => {
     projectId ? { projectId: +projectId } : skipToken
   );
 
-  const { data: projectStudies } = osrdEditoastApi.endpoints.getProjectsByProjectIdStudies.useQuery(
+  const { data: projectStudies } = osrdEditoastApi.endpoints.getStudies.useQuery(
     projectId
       ? {
           projectId: Number(projectId),
@@ -82,8 +81,7 @@ const ProjectView = () => {
       : skipToken
   );
 
-  const [getScenarios] =
-    osrdEditoastApi.endpoints.getProjectsByProjectIdStudiesAndStudyIdScenarios.useLazyQuery();
+  const [getScenarios] = osrdEditoastApi.endpoints.getScenarios.useLazyQuery();
 
   const {
     selectedItemIds: selectedStudyIds,
@@ -93,9 +91,9 @@ const ProjectView = () => {
     toggleSelection: toggleStudySelection,
     deleteItems,
   } = useMultiSelection<StudyCardDetails>(async (studyId) => {
-    const { data: scenarios } = await getScenarios({ projectId: projectId!, studyId });
+    const { data: scenarios } = await getScenarios({ studyId });
 
-    deleteStudy({ projectId: projectId!, studyId });
+    deleteStudy({ studyId });
 
     // For each scenario in the selected studies, clean the local storage if a manchette is saved
     if (scenarios) {

--- a/front/src/applications/operationalStudies/views/ProjectList/ProjectListView.tsx
+++ b/front/src/applications/operationalStudies/views/ProjectList/ProjectListView.tsx
@@ -40,7 +40,7 @@ const ProjectListView = () => {
   const [filterChips, setFilterChips] = useState('');
   const [deleteProject] = osrdEditoastApi.endpoints.deleteProjectsByProjectId.useMutation();
 
-  const [getStudies] = osrdEditoastApi.endpoints.getProjectsByProjectIdStudies.useLazyQuery();
+  const [getStudies] = osrdEditoastApi.endpoints.getStudies.useLazyQuery();
 
   const {
     selectedItemIds: selectedProjectIds,
@@ -53,7 +53,7 @@ const ProjectListView = () => {
     // For each scenario in the selected projects, clean the local storage if a manchette is saved
     const { data: studies } = await getStudies({ projectId });
     if (studies) {
-      cleanLocalStorageByProject(projectId, studies.results, dispatch);
+      cleanLocalStorageByProject(studies.results, dispatch);
     }
 
     deleteProject({ projectId });

--- a/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/ImportTimetableItemTrainsList.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/ImportTimetableItemTrainsList.tsx
@@ -168,10 +168,8 @@ const ImportTimetableItemTrainsList = ({
     osrdEditoastApi.endpoints.postRoundTripsTrainSchedules.useMutation();
   const [postPacedTrainRoundTrips] =
     osrdEditoastApi.endpoints.postRoundTripsPacedTrains.useMutation();
-  const [postMacroNodes] =
-    osrdEditoastApi.endpoints.postProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNodes.useMutation();
-  const [postMacroNotes] =
-    osrdEditoastApi.endpoints.postProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotes.useMutation();
+  const [postMacroNodes] = osrdEditoastApi.endpoints.postMacroNodes.useMutation();
+  const [postMacroNotes] = osrdEditoastApi.endpoints.postMacroNotes.useMutation();
 
   const timetableId = scenario.timetable_id;
 
@@ -211,8 +209,6 @@ const ImportTimetableItemTrainsList = ({
     const storedNodes = await dispatch(
       osrdEditoastApi.endpoints.getAllMacroNodes.initiate(
         {
-          projectId: scenario.project.id,
-          studyId: scenario.study_id,
           scenarioId: scenario.id,
         },
         { subscribe: false }
@@ -222,10 +218,7 @@ const ImportTimetableItemTrainsList = ({
     const newMacroNodes = nodes.filter((node) => !storedNodesKeys.has(node.path_item_key));
     if (newMacroNodes.length > 0) {
       await postMacroNodes({
-        projectId: scenario.project.id,
-        studyId: scenario.study_id,
-        scenarioId: scenario.id,
-        macroNodeBatchForm: { macro_nodes: newMacroNodes },
+        macroNodeBatchForm: { macro_nodes: newMacroNodes, scenario_id: scenario.id },
       }).unwrap();
     }
     const ignoredNodesCount = nodes.length - newMacroNodes.length;
@@ -272,10 +265,7 @@ const ImportTimetableItemTrainsList = ({
 
       if (macroNotes && macroNotes.length > 0) {
         await postMacroNotes({
-          projectId: scenario.project.id,
-          studyId: scenario.study_id,
-          scenarioId: scenario.id,
-          macroNoteBatchForm: { macro_notes: macroNotes },
+          macroNoteBatchForm: { macro_notes: macroNotes, scenario_id: scenario.id },
         }).unwrap();
       }
 

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/MacroEditorState.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/MacroEditorState.ts
@@ -27,16 +27,6 @@ export default class MacroEditorState {
   scenarioId: number;
 
   /**
-   * Study id
-   */
-  studyId: number;
-
-  /**
-   * Project id
-   */
-  projectId: number;
-
-  /**
    * Nodes storage
    * Type null is here due to deletion, to avoid recomputing indices.
    * We are not building a db engine, so we can afford to have some null values.
@@ -96,7 +86,7 @@ export default class MacroEditorState {
   /**
    * Default constructor
    */
-  constructor(infraId: number, scenarioId: number, studyId: number, projectId: number) {
+  constructor(infraId: number, scenarioId: number) {
     this.nodeLabels = new Set<string>([]);
     this.trainrunLabels = new Set<string>([]);
     this.noteLabels = new Set<string>([]);
@@ -106,8 +96,6 @@ export default class MacroEditorState {
     this.ngeNoteIdToDbId = new Map();
     this.infraId = infraId;
     this.scenarioId = scenarioId;
-    this.studyId = studyId;
-    this.projectId = projectId;
     this.trainrunFrequencies = [];
     this.trainrunCategories = [];
     this.ngeResource = { id: 1, capacity: 0 };

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/ngeToOsrd.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/ngeToOsrd.ts
@@ -853,16 +853,12 @@ export const createMacroNote = async (
   note: FreeFloatingTextDto
 ) => {
   const response = await dispatch(
-    osrdEditoastApi.endpoints.postProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotes.initiate(
-      {
-        projectId: state.projectId,
-        studyId: state.studyId,
-        scenarioId: state.scenarioId,
-        macroNoteBatchForm: {
-          macro_notes: [castNgeNoteToOsrd(note, netzgrafikDto)],
-        },
-      }
-    )
+    osrdEditoastApi.endpoints.postMacroNotes.initiate({
+      macroNoteBatchForm: {
+        scenario_id: state.scenarioId,
+        macro_notes: [castNgeNoteToOsrd(note, netzgrafikDto)],
+      },
+    })
   ).unwrap();
 
   const createdNote = response.macro_notes[0];
@@ -879,15 +875,10 @@ export const updateMacroNote = async (
   if (!dbId) throw new Error(`Note ${note.id} is not saved in the DB`);
 
   await dispatch(
-    osrdEditoastApi.endpoints.putProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotesNoteId.initiate(
-      {
-        projectId: state.projectId,
-        studyId: state.studyId,
-        scenarioId: state.scenarioId,
-        noteId: dbId,
-        macroNoteForm: castNgeNoteToOsrd(note, netzgrafikDto),
-      }
-    )
+    osrdEditoastApi.endpoints.putMacroNotesByNoteId.initiate({
+      noteId: dbId,
+      macroNoteForm: castNgeNoteToOsrd(note, netzgrafikDto),
+    })
   ).unwrap();
 };
 
@@ -900,14 +891,9 @@ export const deleteMacroNote = async (
   if (!noteId) throw new Error(`Note ${ngeId} is not saved in the DB`);
 
   await dispatch(
-    osrdEditoastApi.endpoints.deleteProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotesNoteId.initiate(
-      {
-        projectId: state.projectId,
-        studyId: state.studyId,
-        scenarioId: state.scenarioId,
-        noteId: noteId,
-      }
-    )
+    osrdEditoastApi.endpoints.deleteMacroNotesByNoteId.initiate({
+      noteId: noteId,
+    })
   ).unwrap();
 
   state.removeNoteMapping(ngeId);

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/osrdToNge.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/osrdToNge.ts
@@ -333,11 +333,7 @@ export const loadAndIndexNge = async (
   // This can happen if we delete a timetableItem on which a node was saved.
   const savedNodes = await dispatch(
     osrdEditoastApi.endpoints.getAllMacroNodes.initiate(
-      {
-        projectId: state.projectId,
-        studyId: state.studyId,
-        scenarioId: state.scenarioId,
-      },
+      { scenarioId: state.scenarioId },
       { subscribe: false }
     )
   ).unwrap();
@@ -701,10 +697,8 @@ export const loadNgeDto = async (
   t: TFunction<'operational-studies'>
 ): Promise<NetzgrafikDto> => {
   const notesResult = await dispatch(
-    osrdEditoastApi.endpoints.getProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotes.initiate(
+    osrdEditoastApi.endpoints.getMacroNotes.initiate(
       {
-        projectId: state.projectId,
-        studyId: state.studyId,
         scenarioId: state.scenarioId,
       },
       { subscribe: false }

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/utils.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/utils.ts
@@ -67,14 +67,9 @@ export const createMacroNode = async (
   ngeNodeId: number
 ) => {
   const createPromise = dispatch(
-    osrdEditoastApi.endpoints.postProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNodes.initiate(
-      {
-        projectId: state.projectId,
-        studyId: state.studyId,
-        scenarioId: state.scenarioId,
-        macroNodeBatchForm: { macro_nodes: [node] },
-      }
-    )
+    osrdEditoastApi.endpoints.postMacroNodes.initiate({
+      macroNodeBatchForm: { macro_nodes: [node], scenario_id: state.scenarioId },
+    })
   );
   const result = await createPromise.unwrap();
   const newNode = result.macro_nodes[0];
@@ -95,33 +90,19 @@ export const updateMacroNode = async (
   if (!indexedNode.dbId) throw new Error(`Node ${node.ngeId} is not saved in the DB`);
 
   await dispatch(
-    osrdEditoastApi.endpoints.putProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNodesNodeId.initiate(
-      {
-        projectId: state.projectId,
-        studyId: state.studyId,
-        scenarioId: state.scenarioId,
-        nodeId: indexedNode.dbId,
-        macroNodeForm: node,
-      }
-    )
+    osrdEditoastApi.endpoints.putMacroNodesByNodeId.initiate({
+      nodeId: indexedNode.dbId,
+      macroNodeForm: node,
+    })
   );
   state.indexNodeByKey(indexedNode.path_item_key, node);
 };
 
-export const deleteMacroNodeByDbId = async (
-  state: MacroEditorState,
-  dispatch: AppDispatch,
-  dbId: number
-) => {
+export const deleteMacroNodeByDbId = async (dispatch: AppDispatch, dbId: number) => {
   await dispatch(
-    osrdEditoastApi.endpoints.deleteProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNodesNodeId.initiate(
-      {
-        projectId: state.projectId,
-        studyId: state.studyId,
-        scenarioId: state.scenarioId,
-        nodeId: dbId,
-      }
-    )
+    osrdEditoastApi.endpoints.deleteMacroNodesByNodeId.initiate({
+      nodeId: dbId,
+    })
   );
 };
 
@@ -131,7 +112,7 @@ export const deleteMacroNodeByNgeId = async (
   ngeId: number
 ) => {
   const indexedNode = state.getNodeByNgeId(ngeId);
-  if (indexedNode?.dbId) await deleteMacroNodeByDbId(state, dispatch, indexedNode.dbId);
+  if (indexedNode?.dbId) await deleteMacroNodeByDbId(dispatch, indexedNode.dbId);
   state.deleteNodeByNgeId(ngeId);
 };
 

--- a/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
@@ -82,25 +82,12 @@ const ScenarioContent = ({ activeBoards }: ScenarioContentProps) => {
 
   const refreshNge = useCallback(async () => {
     if (!activeBoards.has('macro')) return;
-    const state = new MacroEditorState(
-      infraId,
-      scenario.id,
-      scenario.study_id,
-      scenario.project.id
-    );
+    const state = new MacroEditorState(infraId, scenario.id);
 
     const dto = await loadNgeDto(state, scenario.timetable_id, dispatch, t);
     macroEditorState.current = state;
     setNgeDto(dto);
-  }, [
-    dispatch,
-    infraId,
-    scenario.study_id,
-    scenario.project.id,
-    scenario.id,
-    scenario.timetable_id,
-    activeBoards.has('macro'),
-  ]);
+  }, [dispatch, infraId, scenario.id, scenario.timetable_id, activeBoards.has('macro')]);
 
   const upsertTimetableItemsWithNge = useCallback(
     (updatedTimetableItems: TimetableItem[]) => {

--- a/front/src/applications/operationalStudies/views/Scenario/components/ScenarioHeader.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ScenarioHeader.tsx
@@ -55,7 +55,7 @@ const ScenarioHeader = ({ activeBoards, toggleBoard }: ScenarioHeaderProps) => {
   };
 
   const closeScenario = () => {
-    navigate(`/operational-studies/projects/${scenario.project.id}/studies/${scenario.study.id}`);
+    navigate(`/operational-studies/projects/${scenario.project.id}/studies/${scenario.study_id}`);
   };
 
   useEffect(() => {

--- a/front/src/applications/operationalStudies/views/Study/StudyView.tsx
+++ b/front/src/applications/operationalStudies/views/Study/StudyView.tsx
@@ -65,32 +65,26 @@ const StudyView = () => {
     data: study,
     isError: isCurrentStudyError,
     error: studyError,
-  } = osrdEditoastApi.endpoints.getProjectsByProjectIdStudiesAndStudyId.useQuery(
-    projectId && studyId
+  } = osrdEditoastApi.endpoints.getStudiesByStudyId.useQuery(
+    studyId
       ? {
-          projectId,
-          studyId,
+          studyId: studyId,
         }
       : skipToken
   );
 
   const [postSearch] = osrdEditoastApi.endpoints.postSearch.useMutation();
-  const [deleteScenario] =
-    osrdEditoastApi.endpoints.deleteProjectsByProjectIdStudiesAndStudyIdScenariosScenarioId.useMutation(
-      {}
-    );
+  const [deleteScenario] = osrdEditoastApi.endpoints.deleteScenariosByScenarioId.useMutation({});
 
-  const { data: scenarios } =
-    osrdEditoastApi.endpoints.getProjectsByProjectIdStudiesAndStudyIdScenarios.useQuery(
-      projectId && studyId
-        ? {
-            projectId,
-            studyId,
-            ordering: sortOption,
-            pageSize: 1000,
-          }
-        : skipToken
-    );
+  const { data: scenarios } = osrdEditoastApi.endpoints.getScenarios.useQuery(
+    studyId
+      ? {
+          studyId: studyId,
+          ordering: sortOption,
+          pageSize: 1000,
+        }
+      : skipToken
+  );
 
   const {
     selectedItemIds: selectedScenarioIds,
@@ -100,7 +94,7 @@ const StudyView = () => {
     toggleSelection: toggleScenarioSelection,
     deleteItems,
   } = useMultiSelection<ScenarioCardDetails>((scenarioId) => {
-    deleteScenario({ projectId: projectId!, studyId: studyId!, scenarioId });
+    deleteScenario({ scenarioId });
 
     // For each scenarios, clean the local storage if a manchette is saved
     const deletedScenario = scenarios!.results.find((scenario) => scenario.id === scenarioId);
@@ -284,7 +278,6 @@ const StudyView = () => {
                   <div className="study-details-state">
                     {studyStates.map(
                       (state, idx) =>
-                        study.project.id &&
                         study.id &&
                         study.state && (
                           <StateStep

--- a/front/src/applications/operationalStudies/views/Study/components/StateStep.tsx
+++ b/front/src/applications/operationalStudies/views/Study/components/StateStep.tsx
@@ -1,14 +1,14 @@
 import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
 
-import { osrdEditoastApi, type StudyResponse } from 'common/api/osrdEditoastApi';
+import { osrdEditoastApi, type StudyWithScenarios } from 'common/api/osrdEditoastApi';
 import { setSuccess } from 'reducers/main';
 import { useAppDispatch } from 'store';
 
 import type { StudyState } from '../consts';
 
 type Props = {
-  study: StudyResponse;
+  study: StudyWithScenarios;
   number: number;
   state: StudyState;
   done: boolean;
@@ -17,15 +17,13 @@ type Props = {
 export default function StateStep({ study, number, state, done }: Props) {
   const { t } = useTranslation('operational-studies');
   const dispatch = useAppDispatch();
-  const [patchStudy] =
-    osrdEditoastApi.endpoints.patchProjectsByProjectIdStudiesAndStudyId.useMutation();
+  const [patchStudy] = osrdEditoastApi.endpoints.patchStudiesByStudyId.useMutation();
 
   const changeStudyState = async () => {
     try {
       const actual_end_date =
         state === 'finish' ? new Date().toISOString().split('T')[0] : study.actual_end_date;
       await patchStudy({
-        projectId: study.project.id,
         studyId: study.id,
         studyPatchForm: { actual_end_date, state },
       });

--- a/front/src/applications/stdcm/components/ScenarioExplorer/ScenarioExplorer.tsx
+++ b/front/src/applications/stdcm/components/ScenarioExplorer/ScenarioExplorer.tsx
@@ -32,26 +32,20 @@ const ScenarioExplorer = ({
     globalProjectId ? { projectId: globalProjectId } : skipToken
   );
 
-  const { data: studyDetails } =
-    osrdEditoastApi.endpoints.getProjectsByProjectIdStudiesAndStudyId.useQuery(
-      globalProjectId && globalStudyId
-        ? { projectId: globalProjectId, studyId: globalStudyId }
-        : skipToken
-    );
+  const { data: studyDetails } = osrdEditoastApi.endpoints.getStudiesByStudyId.useQuery(
+    globalStudyId ? { studyId: globalStudyId } : skipToken
+  );
 
-  const { currentData: scenario } =
-    osrdEditoastApi.endpoints.getProjectsByProjectIdStudiesAndStudyIdScenariosScenarioId.useQuery(
-      globalProjectId && globalStudyId && globalScenarioId
-        ? {
-            projectId: globalProjectId,
-            studyId: globalStudyId,
-            scenarioId: globalScenarioId,
-          }
-        : skipToken,
-      {
-        refetchOnMountOrArgChange: true,
-      }
-    );
+  const { currentData: scenario } = osrdEditoastApi.endpoints.getScenariosByScenarioId.useQuery(
+    globalScenarioId
+      ? {
+          scenarioId: globalScenarioId,
+        }
+      : skipToken,
+    {
+      refetchOnMountOrArgChange: true,
+    }
+  );
 
   const getProjectImage = async (imageId: number) => {
     try {

--- a/front/src/applications/stdcm/components/ScenarioExplorer/ScenarioExplorerModal.tsx
+++ b/front/src/applications/stdcm/components/ScenarioExplorer/ScenarioExplorerModal.tsx
@@ -53,9 +53,8 @@ const ScenarioExplorerModal = ({
     }
   );
 
-  const [getStudiesList] = osrdEditoastApi.endpoints.getProjectsByProjectIdStudies.useLazyQuery();
-  const [getScenariosList] =
-    osrdEditoastApi.endpoints.getProjectsByProjectIdStudiesAndStudyIdScenarios.useLazyQuery();
+  const [getStudiesList] = osrdEditoastApi.endpoints.getStudies.useLazyQuery();
+  const [getScenariosList] = osrdEditoastApi.endpoints.getScenarios.useLazyQuery();
 
   useEffect(() => {
     if (isProjectsError) {
@@ -80,7 +79,6 @@ const ScenarioExplorerModal = ({
   useEffect(() => {
     if (projectID && studyID && !isProjectsError) {
       getScenariosList({
-        projectId: projectID,
         studyId: studyID,
         ordering: 'LastModifiedDesc',
         pageSize: 1000,

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -10,13 +10,12 @@ export const addTagTypes = [
   'pathfinding',
   'routes',
   'layers',
+  'scenarios',
   'timetable',
   'paced_train',
   'train_schedule',
   'etcs_braking_curves',
   'projects',
-  'studies',
-  'scenarios',
   'rolling_stock_livery',
   'round_trips',
   'search',
@@ -25,6 +24,7 @@ export const addTagTypes = [
   'sncf',
   'sprites',
   'stdcm_search_environment',
+  'studies',
   'sub_categories',
   'temporary_speed_limits',
   'work_schedules',
@@ -494,6 +494,94 @@ const injectedRtkApi = api
         query: (queryArg) => ({ url: `/light_rolling_stock/${queryArg.rollingStockId}` }),
         providesTags: ['rolling_stock'],
       }),
+      getMacroNodes: build.query<GetMacroNodesApiResponse, GetMacroNodesApiArg>({
+        query: (queryArg) => ({
+          url: `/macro_nodes`,
+          params: {
+            scenario_id: queryArg.scenarioId,
+            page: queryArg.page,
+            page_size: queryArg.pageSize,
+          },
+        }),
+        providesTags: ['scenarios'],
+      }),
+      postMacroNodes: build.mutation<PostMacroNodesApiResponse, PostMacroNodesApiArg>({
+        query: (queryArg) => ({
+          url: `/macro_nodes`,
+          method: 'POST',
+          body: queryArg.macroNodeBatchForm,
+        }),
+        invalidatesTags: ['scenarios'],
+      }),
+      getMacroNodesByNodeId: build.query<
+        GetMacroNodesByNodeIdApiResponse,
+        GetMacroNodesByNodeIdApiArg
+      >({
+        query: (queryArg) => ({ url: `/macro_nodes/${queryArg.nodeId}` }),
+        providesTags: ['scenarios'],
+      }),
+      putMacroNodesByNodeId: build.mutation<
+        PutMacroNodesByNodeIdApiResponse,
+        PutMacroNodesByNodeIdApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/macro_nodes/${queryArg.nodeId}`,
+          method: 'PUT',
+          body: queryArg.macroNodeForm,
+        }),
+        invalidatesTags: ['scenarios'],
+      }),
+      deleteMacroNodesByNodeId: build.mutation<
+        DeleteMacroNodesByNodeIdApiResponse,
+        DeleteMacroNodesByNodeIdApiArg
+      >({
+        query: (queryArg) => ({ url: `/macro_nodes/${queryArg.nodeId}`, method: 'DELETE' }),
+        invalidatesTags: ['scenarios'],
+      }),
+      getMacroNotes: build.query<GetMacroNotesApiResponse, GetMacroNotesApiArg>({
+        query: (queryArg) => ({
+          url: `/macro_notes`,
+          params: {
+            scenario_id: queryArg.scenarioId,
+            page: queryArg.page,
+            page_size: queryArg.pageSize,
+          },
+        }),
+        providesTags: ['scenarios'],
+      }),
+      postMacroNotes: build.mutation<PostMacroNotesApiResponse, PostMacroNotesApiArg>({
+        query: (queryArg) => ({
+          url: `/macro_notes`,
+          method: 'POST',
+          body: queryArg.macroNoteBatchForm,
+        }),
+        invalidatesTags: ['scenarios'],
+      }),
+      getMacroNotesByNoteId: build.query<
+        GetMacroNotesByNoteIdApiResponse,
+        GetMacroNotesByNoteIdApiArg
+      >({
+        query: (queryArg) => ({ url: `/macro_notes/${queryArg.noteId}` }),
+        providesTags: ['scenarios'],
+      }),
+      putMacroNotesByNoteId: build.mutation<
+        PutMacroNotesByNoteIdApiResponse,
+        PutMacroNotesByNoteIdApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/macro_notes/${queryArg.noteId}`,
+          method: 'PUT',
+          body: queryArg.macroNoteForm,
+        }),
+        invalidatesTags: ['scenarios'],
+      }),
+      deleteMacroNotesByNoteId: build.mutation<
+        DeleteMacroNotesByNoteIdApiResponse,
+        DeleteMacroNotesByNoteIdApiArg
+      >({
+        query: (queryArg) => ({ url: `/macro_notes/${queryArg.noteId}`, method: 'DELETE' }),
+        invalidatesTags: ['scenarios'],
+      }),
       deletePacedTrain: build.mutation<DeletePacedTrainApiResponse, DeletePacedTrainApiArg>({
         query: (queryArg) => ({ url: `/paced_train`, method: 'DELETE', body: queryArg.body }),
         invalidatesTags: ['timetable', 'paced_train'],
@@ -650,224 +738,6 @@ const injectedRtkApi = api
         }),
         invalidatesTags: ['projects'],
       }),
-      getProjectsByProjectIdStudies: build.query<
-        GetProjectsByProjectIdStudiesApiResponse,
-        GetProjectsByProjectIdStudiesApiArg
-      >({
-        query: (queryArg) => ({
-          url: `/projects/${queryArg.projectId}/studies`,
-          params: {
-            page: queryArg.page,
-            page_size: queryArg.pageSize,
-            ordering: queryArg.ordering,
-          },
-        }),
-        providesTags: ['studies'],
-      }),
-      postProjectsByProjectIdStudies: build.mutation<
-        PostProjectsByProjectIdStudiesApiResponse,
-        PostProjectsByProjectIdStudiesApiArg
-      >({
-        query: (queryArg) => ({
-          url: `/projects/${queryArg.projectId}/studies`,
-          method: 'POST',
-          body: queryArg.studyCreateForm,
-        }),
-        invalidatesTags: ['studies'],
-      }),
-      getProjectsByProjectIdStudiesAndStudyId: build.query<
-        GetProjectsByProjectIdStudiesAndStudyIdApiResponse,
-        GetProjectsByProjectIdStudiesAndStudyIdApiArg
-      >({
-        query: (queryArg) => ({
-          url: `/projects/${queryArg.projectId}/studies/${queryArg.studyId}`,
-        }),
-        providesTags: ['studies'],
-      }),
-      deleteProjectsByProjectIdStudiesAndStudyId: build.mutation<
-        DeleteProjectsByProjectIdStudiesAndStudyIdApiResponse,
-        DeleteProjectsByProjectIdStudiesAndStudyIdApiArg
-      >({
-        query: (queryArg) => ({
-          url: `/projects/${queryArg.projectId}/studies/${queryArg.studyId}`,
-          method: 'DELETE',
-        }),
-        invalidatesTags: ['studies'],
-      }),
-      patchProjectsByProjectIdStudiesAndStudyId: build.mutation<
-        PatchProjectsByProjectIdStudiesAndStudyIdApiResponse,
-        PatchProjectsByProjectIdStudiesAndStudyIdApiArg
-      >({
-        query: (queryArg) => ({
-          url: `/projects/${queryArg.projectId}/studies/${queryArg.studyId}`,
-          method: 'PATCH',
-          body: queryArg.studyPatchForm,
-        }),
-        invalidatesTags: ['studies'],
-      }),
-      getProjectsByProjectIdStudiesAndStudyIdScenarios: build.query<
-        GetProjectsByProjectIdStudiesAndStudyIdScenariosApiResponse,
-        GetProjectsByProjectIdStudiesAndStudyIdScenariosApiArg
-      >({
-        query: (queryArg) => ({
-          url: `/projects/${queryArg.projectId}/studies/${queryArg.studyId}/scenarios`,
-          params: {
-            page: queryArg.page,
-            page_size: queryArg.pageSize,
-            ordering: queryArg.ordering,
-          },
-        }),
-        providesTags: ['scenarios'],
-      }),
-      postProjectsByProjectIdStudiesAndStudyIdScenarios: build.mutation<
-        PostProjectsByProjectIdStudiesAndStudyIdScenariosApiResponse,
-        PostProjectsByProjectIdStudiesAndStudyIdScenariosApiArg
-      >({
-        query: (queryArg) => ({
-          url: `/projects/${queryArg.projectId}/studies/${queryArg.studyId}/scenarios`,
-          method: 'POST',
-          body: queryArg.scenarioCreateForm,
-        }),
-        invalidatesTags: ['scenarios'],
-      }),
-      getProjectsByProjectIdStudiesAndStudyIdScenariosScenarioId: build.query<
-        GetProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdApiResponse,
-        GetProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdApiArg
-      >({
-        query: (queryArg) => ({
-          url: `/projects/${queryArg.projectId}/studies/${queryArg.studyId}/scenarios/${queryArg.scenarioId}`,
-        }),
-        providesTags: ['scenarios'],
-      }),
-      deleteProjectsByProjectIdStudiesAndStudyIdScenariosScenarioId: build.mutation<
-        DeleteProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdApiResponse,
-        DeleteProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdApiArg
-      >({
-        query: (queryArg) => ({
-          url: `/projects/${queryArg.projectId}/studies/${queryArg.studyId}/scenarios/${queryArg.scenarioId}`,
-          method: 'DELETE',
-        }),
-        invalidatesTags: ['scenarios'],
-      }),
-      patchProjectsByProjectIdStudiesAndStudyIdScenariosScenarioId: build.mutation<
-        PatchProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdApiResponse,
-        PatchProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdApiArg
-      >({
-        query: (queryArg) => ({
-          url: `/projects/${queryArg.projectId}/studies/${queryArg.studyId}/scenarios/${queryArg.scenarioId}`,
-          method: 'PATCH',
-          body: queryArg.scenarioPatchForm,
-        }),
-        invalidatesTags: ['scenarios'],
-      }),
-      getProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNodes: build.query<
-        GetProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNodesApiResponse,
-        GetProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNodesApiArg
-      >({
-        query: (queryArg) => ({
-          url: `/projects/${queryArg.projectId}/studies/${queryArg.studyId}/scenarios/${queryArg.scenarioId}/macro_nodes`,
-          params: {
-            page: queryArg.page,
-            page_size: queryArg.pageSize,
-          },
-        }),
-        providesTags: ['scenarios'],
-      }),
-      postProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNodes: build.mutation<
-        PostProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNodesApiResponse,
-        PostProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNodesApiArg
-      >({
-        query: (queryArg) => ({
-          url: `/projects/${queryArg.projectId}/studies/${queryArg.studyId}/scenarios/${queryArg.scenarioId}/macro_nodes`,
-          method: 'POST',
-          body: queryArg.macroNodeBatchForm,
-        }),
-        invalidatesTags: ['scenarios'],
-      }),
-      getProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNodesNodeId: build.query<
-        GetProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNodesNodeIdApiResponse,
-        GetProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNodesNodeIdApiArg
-      >({
-        query: (queryArg) => ({
-          url: `/projects/${queryArg.projectId}/studies/${queryArg.studyId}/scenarios/${queryArg.scenarioId}/macro_nodes/${queryArg.nodeId}`,
-        }),
-        providesTags: ['scenarios'],
-      }),
-      putProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNodesNodeId: build.mutation<
-        PutProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNodesNodeIdApiResponse,
-        PutProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNodesNodeIdApiArg
-      >({
-        query: (queryArg) => ({
-          url: `/projects/${queryArg.projectId}/studies/${queryArg.studyId}/scenarios/${queryArg.scenarioId}/macro_nodes/${queryArg.nodeId}`,
-          method: 'PUT',
-          body: queryArg.macroNodeForm,
-        }),
-        invalidatesTags: ['scenarios'],
-      }),
-      deleteProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNodesNodeId: build.mutation<
-        DeleteProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNodesNodeIdApiResponse,
-        DeleteProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNodesNodeIdApiArg
-      >({
-        query: (queryArg) => ({
-          url: `/projects/${queryArg.projectId}/studies/${queryArg.studyId}/scenarios/${queryArg.scenarioId}/macro_nodes/${queryArg.nodeId}`,
-          method: 'DELETE',
-        }),
-        invalidatesTags: ['scenarios'],
-      }),
-      getProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotes: build.query<
-        GetProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotesApiResponse,
-        GetProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotesApiArg
-      >({
-        query: (queryArg) => ({
-          url: `/projects/${queryArg.projectId}/studies/${queryArg.studyId}/scenarios/${queryArg.scenarioId}/macro_notes`,
-          params: {
-            page: queryArg.page,
-            page_size: queryArg.pageSize,
-          },
-        }),
-        providesTags: ['scenarios'],
-      }),
-      postProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotes: build.mutation<
-        PostProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotesApiResponse,
-        PostProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotesApiArg
-      >({
-        query: (queryArg) => ({
-          url: `/projects/${queryArg.projectId}/studies/${queryArg.studyId}/scenarios/${queryArg.scenarioId}/macro_notes`,
-          method: 'POST',
-          body: queryArg.macroNoteBatchForm,
-        }),
-        invalidatesTags: ['scenarios'],
-      }),
-      getProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotesNoteId: build.query<
-        GetProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotesNoteIdApiResponse,
-        GetProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotesNoteIdApiArg
-      >({
-        query: (queryArg) => ({
-          url: `/projects/${queryArg.projectId}/studies/${queryArg.studyId}/scenarios/${queryArg.scenarioId}/macro_notes/${queryArg.noteId}`,
-        }),
-        providesTags: ['scenarios'],
-      }),
-      putProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotesNoteId: build.mutation<
-        PutProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotesNoteIdApiResponse,
-        PutProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotesNoteIdApiArg
-      >({
-        query: (queryArg) => ({
-          url: `/projects/${queryArg.projectId}/studies/${queryArg.studyId}/scenarios/${queryArg.scenarioId}/macro_notes/${queryArg.noteId}`,
-          method: 'PUT',
-          body: queryArg.macroNoteForm,
-        }),
-        invalidatesTags: ['scenarios'],
-      }),
-      deleteProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotesNoteId: build.mutation<
-        DeleteProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotesNoteIdApiResponse,
-        DeleteProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotesNoteIdApiArg
-      >({
-        query: (queryArg) => ({
-          url: `/projects/${queryArg.projectId}/studies/${queryArg.studyId}/scenarios/${queryArg.scenarioId}/macro_notes/${queryArg.noteId}`,
-          method: 'DELETE',
-        }),
-        invalidatesTags: ['scenarios'],
-      }),
       postRollingStock: build.mutation<PostRollingStockApiResponse, PostRollingStockApiArg>({
         query: (queryArg) => ({
           url: `/rolling_stock`,
@@ -997,6 +867,51 @@ const injectedRtkApi = api
         }),
         invalidatesTags: ['round_trips'],
       }),
+      getScenarios: build.query<GetScenariosApiResponse, GetScenariosApiArg>({
+        query: (queryArg) => ({
+          url: `/scenarios`,
+          params: {
+            study_id: queryArg.studyId,
+            page: queryArg.page,
+            page_size: queryArg.pageSize,
+            ordering: queryArg.ordering,
+          },
+        }),
+        providesTags: ['scenarios'],
+      }),
+      postScenarios: build.mutation<PostScenariosApiResponse, PostScenariosApiArg>({
+        query: (queryArg) => ({
+          url: `/scenarios`,
+          method: 'POST',
+          body: queryArg.scenarioCreateForm,
+        }),
+        invalidatesTags: ['scenarios'],
+      }),
+      getScenariosByScenarioId: build.query<
+        GetScenariosByScenarioIdApiResponse,
+        GetScenariosByScenarioIdApiArg
+      >({
+        query: (queryArg) => ({ url: `/scenarios/${queryArg.scenarioId}` }),
+        providesTags: ['scenarios'],
+      }),
+      deleteScenariosByScenarioId: build.mutation<
+        DeleteScenariosByScenarioIdApiResponse,
+        DeleteScenariosByScenarioIdApiArg
+      >({
+        query: (queryArg) => ({ url: `/scenarios/${queryArg.scenarioId}`, method: 'DELETE' }),
+        invalidatesTags: ['scenarios'],
+      }),
+      patchScenariosByScenarioId: build.mutation<
+        PatchScenariosByScenarioIdApiResponse,
+        PatchScenariosByScenarioIdApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/scenarios/${queryArg.scenarioId}`,
+          method: 'PATCH',
+          body: queryArg.scenarioPatchForm,
+        }),
+        invalidatesTags: ['scenarios'],
+      }),
       postSearch: build.mutation<PostSearchApiResponse, PostSearchApiArg>({
         query: (queryArg) => ({
           url: `/search`,
@@ -1067,6 +982,44 @@ const injectedRtkApi = api
           method: 'DELETE',
         }),
         invalidatesTags: ['stdcm_search_environment'],
+      }),
+      getStudies: build.query<GetStudiesApiResponse, GetStudiesApiArg>({
+        query: (queryArg) => ({
+          url: `/studies`,
+          params: {
+            project_id: queryArg.projectId,
+            page: queryArg.page,
+            page_size: queryArg.pageSize,
+            ordering: queryArg.ordering,
+          },
+        }),
+        providesTags: ['studies'],
+      }),
+      postStudies: build.mutation<PostStudiesApiResponse, PostStudiesApiArg>({
+        query: (queryArg) => ({ url: `/studies`, method: 'POST', body: queryArg.studyCreateForm }),
+        invalidatesTags: ['studies'],
+      }),
+      getStudiesByStudyId: build.query<GetStudiesByStudyIdApiResponse, GetStudiesByStudyIdApiArg>({
+        query: (queryArg) => ({ url: `/studies/${queryArg.studyId}` }),
+        providesTags: ['studies'],
+      }),
+      deleteStudiesByStudyId: build.mutation<
+        DeleteStudiesByStudyIdApiResponse,
+        DeleteStudiesByStudyIdApiArg
+      >({
+        query: (queryArg) => ({ url: `/studies/${queryArg.studyId}`, method: 'DELETE' }),
+        invalidatesTags: ['studies'],
+      }),
+      patchStudiesByStudyId: build.mutation<
+        PatchStudiesByStudyIdApiResponse,
+        PatchStudiesByStudyIdApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/studies/${queryArg.studyId}`,
+          method: 'PATCH',
+          body: queryArg.studyPatchForm,
+        }),
+        invalidatesTags: ['studies'],
       }),
       getSubCategory: build.query<GetSubCategoryApiResponse, GetSubCategoryApiArg>({
         query: (queryArg) => ({
@@ -1926,6 +1879,60 @@ export type GetLightRollingStockByRollingStockIdApiResponse =
 export type GetLightRollingStockByRollingStockIdApiArg = {
   rollingStockId: number;
 };
+export type GetMacroNodesApiResponse =
+  /** status 200 List of macro nodes for the requested scenario */ MacroNodeListResponse;
+export type GetMacroNodesApiArg = {
+  scenarioId: number;
+  page?: number;
+  pageSize?: number;
+};
+export type PostMacroNodesApiResponse =
+  /** status 201 Macro nodes created */ MacroNodeBatchResponse;
+export type PostMacroNodesApiArg = {
+  macroNodeBatchForm: MacroNodeBatchForm;
+};
+export type GetMacroNodesByNodeIdApiResponse =
+  /** status 200 The requested Macro node */ MacroNodeResponse;
+export type GetMacroNodesByNodeIdApiArg = {
+  nodeId: number;
+};
+export type PutMacroNodesByNodeIdApiResponse =
+  /** status 200 The updated macro node */ MacroNodeResponse;
+export type PutMacroNodesByNodeIdApiArg = {
+  nodeId: number;
+  macroNodeForm: MacroNodeForm;
+};
+export type DeleteMacroNodesByNodeIdApiResponse = unknown;
+export type DeleteMacroNodesByNodeIdApiArg = {
+  nodeId: number;
+};
+export type GetMacroNotesApiResponse =
+  /** status 200 List of macro notes for the requested scenario */ MacroNoteListResponse;
+export type GetMacroNotesApiArg = {
+  scenarioId: number;
+  page?: number;
+  pageSize?: number;
+};
+export type PostMacroNotesApiResponse =
+  /** status 201 Macro notes created */ MacroNoteBatchResponse;
+export type PostMacroNotesApiArg = {
+  macroNoteBatchForm: MacroNoteBatchForm;
+};
+export type GetMacroNotesByNoteIdApiResponse =
+  /** status 200 The requested macro note */ MacroNoteResponse;
+export type GetMacroNotesByNoteIdApiArg = {
+  noteId: number;
+};
+export type PutMacroNotesByNoteIdApiResponse =
+  /** status 200 The updated macro note */ MacroNoteResponse;
+export type PutMacroNotesByNoteIdApiArg = {
+  noteId: number;
+  macroNoteForm: MacroNoteForm;
+};
+export type DeleteMacroNotesByNoteIdApiResponse = unknown;
+export type DeleteMacroNotesByNoteIdApiArg = {
+  noteId: number;
+};
 export type DeletePacedTrainApiResponse = unknown;
 export type DeletePacedTrainApiArg = {
   body: {
@@ -2094,196 +2101,6 @@ export type PatchProjectsByProjectIdApiArg = {
   /** The fields to update */
   projectPatchForm: ProjectPatchForm;
 };
-export type GetProjectsByProjectIdStudiesApiResponse =
-  /** status 200 The list of studies */ PaginationStats & {
-    results: StudyWithScenarios[];
-  };
-export type GetProjectsByProjectIdStudiesApiArg = {
-  /** The id of a project */
-  projectId: number;
-  page?: number;
-  pageSize?: number;
-  ordering?:
-    | 'NameAsc'
-    | 'NameDesc'
-    | 'CreationDateAsc'
-    | 'CreationDateDesc'
-    | 'LastModifiedDesc'
-    | 'LastModifiedAsc';
-};
-export type PostProjectsByProjectIdStudiesApiResponse =
-  /** status 201 The created study */ StudyResponse;
-export type PostProjectsByProjectIdStudiesApiArg = {
-  /** The id of a project */
-  projectId: number;
-  studyCreateForm: StudyCreateForm;
-};
-export type GetProjectsByProjectIdStudiesAndStudyIdApiResponse =
-  /** status 200 The requested study */ StudyResponse;
-export type GetProjectsByProjectIdStudiesAndStudyIdApiArg = {
-  /** The id of a project */
-  projectId: number;
-  studyId: number;
-};
-export type DeleteProjectsByProjectIdStudiesAndStudyIdApiResponse = unknown;
-export type DeleteProjectsByProjectIdStudiesAndStudyIdApiArg = {
-  /** The id of a project */
-  projectId: number;
-  studyId: number;
-};
-export type PatchProjectsByProjectIdStudiesAndStudyIdApiResponse =
-  /** status 200 The updated study */ StudyResponse;
-export type PatchProjectsByProjectIdStudiesAndStudyIdApiArg = {
-  /** The id of a project */
-  projectId: number;
-  studyId: number;
-  /** The fields to update */
-  studyPatchForm: StudyPatchForm;
-};
-export type GetProjectsByProjectIdStudiesAndStudyIdScenariosApiResponse =
-  /** status 200 A paginated list of scenarios */ PaginationStats & {
-    results: ScenarioWithDetails[];
-  };
-export type GetProjectsByProjectIdStudiesAndStudyIdScenariosApiArg = {
-  /** The id of a project */
-  projectId: number;
-  studyId: number;
-  page?: number;
-  pageSize?: number;
-  ordering?:
-    | 'NameAsc'
-    | 'NameDesc'
-    | 'CreationDateAsc'
-    | 'CreationDateDesc'
-    | 'LastModifiedDesc'
-    | 'LastModifiedAsc';
-};
-export type PostProjectsByProjectIdStudiesAndStudyIdScenariosApiResponse =
-  /** status 201 The created scenario */ ScenarioResponse;
-export type PostProjectsByProjectIdStudiesAndStudyIdScenariosApiArg = {
-  /** The id of a project */
-  projectId: number;
-  studyId: number;
-  scenarioCreateForm: ScenarioCreateForm;
-};
-export type GetProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdApiResponse =
-  /** status 200 The requested scenario */ ScenarioResponse;
-export type GetProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdApiArg = {
-  /** The id of a project */
-  projectId: number;
-  studyId: number;
-  scenarioId: number;
-};
-export type DeleteProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdApiResponse = unknown;
-export type DeleteProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdApiArg = {
-  /** The id of a project */
-  projectId: number;
-  studyId: number;
-  scenarioId: number;
-};
-export type PatchProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdApiResponse =
-  /** status 200 The scenario was updated successfully */ ScenarioResponse;
-export type PatchProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdApiArg = {
-  /** The id of a project */
-  projectId: number;
-  studyId: number;
-  scenarioId: number;
-  scenarioPatchForm: ScenarioPatchForm;
-};
-export type GetProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNodesApiResponse =
-  /** status 200 List of macro nodes for the requested scenario */ MacroNodeListResponse;
-export type GetProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNodesApiArg = {
-  /** The id of a project */
-  projectId: number;
-  studyId: number;
-  scenarioId: number;
-  page?: number;
-  pageSize?: number;
-};
-export type PostProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNodesApiResponse =
-  /** status 201 Macro nodes created */ MacroNodeBatchResponse;
-export type PostProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNodesApiArg = {
-  /** The id of a project */
-  projectId: number;
-  studyId: number;
-  scenarioId: number;
-  macroNodeBatchForm: MacroNodeBatchForm;
-};
-export type GetProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNodesNodeIdApiResponse =
-  /** status 200 The requested Macro node */ MacroNodeResponse;
-export type GetProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNodesNodeIdApiArg = {
-  /** The id of a project */
-  projectId: number;
-  studyId: number;
-  scenarioId: number;
-  nodeId: number;
-};
-export type PutProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNodesNodeIdApiResponse =
-  /** status 200 The updated macro node */ MacroNodeResponse;
-export type PutProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNodesNodeIdApiArg = {
-  /** The id of a project */
-  projectId: number;
-  studyId: number;
-  scenarioId: number;
-  nodeId: number;
-  macroNodeForm: MacroNodeForm;
-};
-export type DeleteProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNodesNodeIdApiResponse =
-  unknown;
-export type DeleteProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNodesNodeIdApiArg = {
-  /** The id of a project */
-  projectId: number;
-  studyId: number;
-  scenarioId: number;
-  nodeId: number;
-};
-export type GetProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotesApiResponse =
-  /** status 200 List of macro notes for the requested scenario */ MacroNoteListResponse;
-export type GetProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotesApiArg = {
-  /** The id of a project */
-  projectId: number;
-  studyId: number;
-  scenarioId: number;
-  page?: number;
-  pageSize?: number;
-};
-export type PostProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotesApiResponse =
-  /** status 201 Macro notes created */ MacroNoteBatchResponse;
-export type PostProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotesApiArg = {
-  /** The id of a project */
-  projectId: number;
-  studyId: number;
-  scenarioId: number;
-  macroNoteBatchForm: MacroNoteBatchForm;
-};
-export type GetProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotesNoteIdApiResponse =
-  /** status 200 The requested macro note */ MacroNoteResponse;
-export type GetProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotesNoteIdApiArg = {
-  /** The id of a project */
-  projectId: number;
-  studyId: number;
-  scenarioId: number;
-  noteId: number;
-};
-export type PutProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotesNoteIdApiResponse =
-  /** status 200 The updated macro note */ MacroNoteResponse;
-export type PutProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotesNoteIdApiArg = {
-  /** The id of a project */
-  projectId: number;
-  studyId: number;
-  scenarioId: number;
-  noteId: number;
-  macroNoteForm: MacroNoteForm;
-};
-export type DeleteProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotesNoteIdApiResponse =
-  unknown;
-export type DeleteProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNotesNoteIdApiArg = {
-  /** The id of a project */
-  projectId: number;
-  studyId: number;
-  scenarioId: number;
-  noteId: number;
-};
 export type PostRollingStockApiResponse = /** status 200 The created rolling stock */ RollingStock;
 export type PostRollingStockApiArg = {
   locked?: boolean;
@@ -2348,6 +2165,41 @@ export type PostRoundTripsTrainSchedulesDeleteApiArg = {
   /** IDs of train schedules to remove from round trips or one-way. */
   body: number[];
 };
+export type GetScenariosApiResponse =
+  /** status 200 A paginated list of scenarios */ PaginationStats & {
+    results: ScenarioWithDetails[];
+  };
+export type GetScenariosApiArg = {
+  studyId: number;
+  page?: number;
+  pageSize?: number;
+  ordering?:
+    | 'NameAsc'
+    | 'NameDesc'
+    | 'CreationDateAsc'
+    | 'CreationDateDesc'
+    | 'LastModifiedDesc'
+    | 'LastModifiedAsc';
+};
+export type PostScenariosApiResponse = /** status 201 The created scenario */ ScenarioWithDetails;
+export type PostScenariosApiArg = {
+  scenarioCreateForm: ScenarioCreateForm;
+};
+export type GetScenariosByScenarioIdApiResponse =
+  /** status 200 The requested scenario */ ScenarioResponse;
+export type GetScenariosByScenarioIdApiArg = {
+  scenarioId: number;
+};
+export type DeleteScenariosByScenarioIdApiResponse = unknown;
+export type DeleteScenariosByScenarioIdApiArg = {
+  scenarioId: number;
+};
+export type PatchScenariosByScenarioIdApiResponse =
+  /** status 200 The scenario was updated successfully */ ScenarioWithDetails;
+export type PatchScenariosByScenarioIdApiArg = {
+  scenarioId: number;
+  scenarioPatchForm: ScenarioPatchForm;
+};
 export type PostSearchApiResponse = /** status 200 The search results */ SearchResultItem[];
 export type PostSearchApiArg = {
   page?: number;
@@ -2407,6 +2259,40 @@ export type DeleteStdcmSearchEnvironmentByEnvIdApiResponse = unknown;
 export type DeleteStdcmSearchEnvironmentByEnvIdApiArg = {
   /** An stdcm search environment ID */
   envId: number;
+};
+export type GetStudiesApiResponse = /** status 200 The list of studies */ PaginationStats & {
+  results: StudyWithScenarios[];
+};
+export type GetStudiesApiArg = {
+  projectId: number;
+  page?: number;
+  pageSize?: number;
+  ordering?:
+    | 'NameAsc'
+    | 'NameDesc'
+    | 'CreationDateAsc'
+    | 'CreationDateDesc'
+    | 'LastModifiedDesc'
+    | 'LastModifiedAsc';
+};
+export type PostStudiesApiResponse = /** status 201 The created study */ StudyWithScenarios;
+export type PostStudiesApiArg = {
+  studyCreateForm: StudyCreateForm;
+};
+export type GetStudiesByStudyIdApiResponse = /** status 200 The requested study */ StudyResponse;
+export type GetStudiesByStudyIdApiArg = {
+  studyId: number;
+};
+export type DeleteStudiesByStudyIdApiResponse = unknown;
+export type DeleteStudiesByStudyIdApiArg = {
+  studyId: number;
+};
+export type PatchStudiesByStudyIdApiResponse =
+  /** status 200 The updated study */ StudyWithScenarios;
+export type PatchStudiesByStudyIdApiArg = {
+  studyId: number;
+  /** The fields to update */
+  studyPatchForm: StudyPatchForm;
 };
 export type GetSubCategoryApiResponse =
   /** status 200 The list of sub categories */ SubCategoryPage;
@@ -3850,6 +3736,61 @@ export type RollingStockLivery = {
 export type LightRollingStockWithLiveries = LightRollingStock & {
   liveries: RollingStockLivery[];
 };
+export type Tags = string[];
+export type MacroNodeResponse = {
+  connection_time: number;
+  full_name?: string | null;
+  id: number;
+  labels: Tags;
+  path_item_key: string;
+  position_x: number;
+  position_y: number;
+  trigram?: string | null;
+};
+export type MacroNodeListResponse = PaginationStats & {
+  results: MacroNodeResponse[];
+};
+export type MacroNodeBatchResponse = {
+  macro_nodes: MacroNodeResponse[];
+};
+export type MacroNodeForm = {
+  connection_time: number;
+  full_name?: string | null;
+  labels: Tags;
+  path_item_key: string;
+  position_x: number;
+  position_y: number;
+  trigram?: string | null;
+};
+export type MacroNodeBatchForm = {
+  macro_nodes: MacroNodeForm[];
+  scenario_id: number;
+};
+export type MacroNoteResponse = {
+  id: number;
+  labels: Tags;
+  text: string;
+  title: string;
+  x: number;
+  y: number;
+};
+export type MacroNoteListResponse = PaginationStats & {
+  results: MacroNoteResponse[];
+};
+export type MacroNoteBatchResponse = {
+  macro_notes: MacroNoteResponse[];
+};
+export type MacroNoteForm = {
+  labels: Tags;
+  text: string;
+  title: string;
+  x: number;
+  y: number;
+};
+export type MacroNoteBatchForm = {
+  macro_notes: MacroNoteForm[];
+  scenario_id: number;
+};
 export type SignalUpdate = {
   /** The labels of the new aspect */
   aspect_label: string;
@@ -4284,7 +4225,6 @@ export type SimulationResponse =
       core_error: InternalError;
       status: 'simulation_failed';
     };
-export type Tags = string[];
 export type Project = {
   budget?: number | null;
   creation_date: string;
@@ -4319,147 +4259,6 @@ export type ProjectPatchForm = {
   name?: string | null;
   objectives?: string | null;
   tags?: null | Tags;
-};
-export type Study = {
-  actual_end_date?: string | null;
-  budget?: number | null;
-  business_code?: string | null;
-  creation_date: string;
-  description?: string | null;
-  expected_end_date?: string | null;
-  id: number;
-  last_modification: string;
-  name: string;
-  project_id: number;
-  service_code?: string | null;
-  start_date?: string | null;
-  state: string;
-  study_type?: string | null;
-  tags: Tags;
-};
-export type StudyWithScenarios = Study & {
-  scenarios_count: number;
-};
-export type StudyResponse = Study & {
-  project: Project;
-  scenarios_count: number;
-};
-export type StudyCreateForm = {
-  actual_end_date?: string | null;
-  budget?: number | null;
-  business_code?: string | null;
-  description?: string | null;
-  expected_end_date?: string | null;
-  name: string;
-  service_code?: string | null;
-  start_date?: string | null;
-  state: string;
-  study_type?: string | null;
-  tags?: Tags;
-};
-export type StudyPatchForm = {
-  actual_end_date?: string | null;
-  budget?: number | null;
-  business_code?: string | null;
-  description?: string | null;
-  expected_end_date?: string | null;
-  name?: string | null;
-  service_code?: string | null;
-  start_date?: string | null;
-  state?: string | null;
-  study_type?: string | null;
-  tags?: null | Tags;
-};
-export type Scenario = {
-  creation_date: string;
-  description: string;
-  electrical_profile_set_id?: number;
-  id: number;
-  infra_id: number;
-  last_modification: string;
-  name: string;
-  study_id: number;
-  tags: Tags;
-  timetable_id: number;
-};
-export type ScenarioWithDetails = Scenario & {
-  infra_name: string;
-  paced_trains_count: number;
-  trains_count: number;
-};
-export type ScenarioResponse = Scenario & {
-  infra_name: string;
-  paced_trains_count: number;
-  project: Project;
-  study: Study;
-  trains_count: number;
-};
-export type ScenarioCreateForm = {
-  description?: string;
-  electrical_profile_set_id?: number | null;
-  infra_id: number;
-  name: string;
-  tags?: Tags;
-  timetable_id: number;
-};
-export type ScenarioPatchForm = {
-  description?: string | null;
-  electrical_profile_set_id?: number | null;
-  infra_id?: number | null;
-  name?: string | null;
-  tags?: null | Tags;
-};
-export type MacroNodeResponse = {
-  connection_time: number;
-  full_name?: string | null;
-  id: number;
-  labels: Tags;
-  path_item_key: string;
-  position_x: number;
-  position_y: number;
-  trigram?: string | null;
-};
-export type MacroNodeListResponse = PaginationStats & {
-  results: MacroNodeResponse[];
-};
-export type MacroNodeBatchResponse = {
-  macro_nodes: MacroNodeResponse[];
-};
-export type MacroNodeForm = {
-  connection_time: number;
-  full_name?: string | null;
-  labels: Tags;
-  path_item_key: string;
-  position_x: number;
-  position_y: number;
-  trigram?: string | null;
-};
-export type MacroNodeBatchForm = {
-  macro_nodes: MacroNodeForm[];
-};
-export type MacroNoteResponse = {
-  id: number;
-  labels: Tags;
-  text: string;
-  title: string;
-  x: number;
-  y: number;
-};
-export type MacroNoteListResponse = PaginationStats & {
-  results: MacroNoteResponse[];
-};
-export type MacroNoteBatchResponse = {
-  macro_notes: MacroNoteResponse[];
-};
-export type MacroNoteForm = {
-  labels: Tags;
-  text: string;
-  title: string;
-  x: number;
-  y: number;
-};
-export type MacroNoteBatchForm = {
-  macro_notes: MacroNoteForm[];
 };
 export type EffortCurveConditions = {
   comfort: null | Comfort;
@@ -4593,6 +4392,63 @@ export type RoundTrips = {
   one_ways?: number[];
   /** List of round trips, each represented by a tuple */
   round_trips?: number[][];
+};
+export type Scenario = {
+  creation_date: string;
+  description: string;
+  electrical_profile_set_id?: number;
+  id: number;
+  infra_id: number;
+  last_modification: string;
+  name: string;
+  study_id: number;
+  tags: Tags;
+  timetable_id: number;
+};
+export type ScenarioWithDetails = Scenario & {
+  infra_name: string;
+  paced_trains_count: number;
+  trains_count: number;
+};
+export type ScenarioCreateForm = {
+  description?: string;
+  electrical_profile_set_id?: number | null;
+  infra_id: number;
+  name: string;
+  study_id: number;
+  tags?: Tags;
+  timetable_id: number;
+};
+export type Study = {
+  actual_end_date?: string | null;
+  budget?: number | null;
+  business_code?: string | null;
+  creation_date: string;
+  description?: string | null;
+  expected_end_date?: string | null;
+  id: number;
+  last_modification: string;
+  name: string;
+  project_id: number;
+  service_code?: string | null;
+  start_date?: string | null;
+  state: string;
+  study_type?: string | null;
+  tags: Tags;
+};
+export type ScenarioResponse = Scenario & {
+  infra_name: string;
+  paced_trains_count: number;
+  project: Project;
+  study: Study;
+  trains_count: number;
+};
+export type ScenarioPatchForm = {
+  description?: string | null;
+  electrical_profile_set_id?: number | null;
+  infra_id?: number | null;
+  name?: string | null;
+  tags?: null | Tags;
 };
 export type SearchResultItemTrack = {
   infra_id: number;
@@ -4789,6 +4645,40 @@ export type StdcmSearchEnvironmentCreateForm = {
   temporary_speed_limit_group_id?: number | null;
   timetable_id: number;
   work_schedule_group_id?: number | null;
+};
+export type StudyWithScenarios = Study & {
+  scenarios_count: number;
+};
+export type StudyCreateForm = {
+  actual_end_date?: string | null;
+  budget?: number | null;
+  business_code?: string | null;
+  description?: string | null;
+  expected_end_date?: string | null;
+  name: string;
+  project_id: number;
+  service_code?: string | null;
+  start_date?: string | null;
+  state: string;
+  study_type?: string | null;
+  tags?: Tags;
+};
+export type StudyResponse = Study & {
+  project: Project;
+  scenarios_count: number;
+};
+export type StudyPatchForm = {
+  actual_end_date?: string | null;
+  budget?: number | null;
+  business_code?: string | null;
+  description?: string | null;
+  expected_end_date?: string | null;
+  name?: string | null;
+  service_code?: string | null;
+  start_date?: string | null;
+  state?: string | null;
+  study_type?: string | null;
+  tags?: null | Tags;
 };
 export type SubCategoryColor = string;
 export type SubCategory = {

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -257,21 +257,16 @@ const osrdEditoastApi = generatedEditoastApi
         },
         providesTags: ['infra'],
       }),
-      getAllMacroNodes: builder.query<
-        MacroNodeResponse[],
-        { projectId: number; studyId: number; scenarioId: number }
-      >({
-        queryFn: async ({ projectId, studyId, scenarioId }, { dispatch }) => {
+      getAllMacroNodes: builder.query<MacroNodeResponse[], { scenarioId: number }>({
+        queryFn: async ({ scenarioId }, { dispatch }) => {
           const pageSize = 100;
           let page = 1;
           let reachEnd = false;
           const result: MacroNodeResponse[] = [];
           while (!reachEnd) {
             const data = await dispatch(
-              osrdEditoastApi.endpoints.getProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdMacroNodes.initiate(
+              osrdEditoastApi.endpoints.getMacroNodes.initiate(
                 {
-                  projectId,
-                  studyId,
                   scenarioId,
                   pageSize,
                   page,
@@ -339,7 +334,7 @@ const osrdEditoastApi = generatedEditoastApi
       },
 
       // Studies handling
-      getProjectsByProjectIdStudies: {
+      getStudies: {
         providesTags: (result) => [
           { type: 'studies', id: 'LIST' },
           ...(result?.results || []).map(({ id }) => ({
@@ -348,30 +343,30 @@ const osrdEditoastApi = generatedEditoastApi
           })),
         ],
       },
-      getProjectsByProjectIdStudiesAndStudyId: {
+      getStudiesByStudyId: {
         providesTags: (_result, _error, args) => [{ type: 'studies', id: args.studyId }],
       },
-      postProjectsByProjectIdStudies: {
-        invalidatesTags: (_result, _error, args) => [
-          { type: 'projects', id: args.projectId },
+      postStudies: {
+        invalidatesTags: () => [
+          { type: 'projects', id: 'LIST' },
           { type: 'studies', id: 'LIST' },
         ],
       },
-      patchProjectsByProjectIdStudiesAndStudyId: {
+      patchStudiesByStudyId: {
         invalidatesTags: (_result, _error, args) => [
-          { type: 'projects', id: args.projectId },
+          { type: 'projects', id: 'LIST' },
           { type: 'studies', id: args.studyId },
         ],
       },
-      deleteProjectsByProjectIdStudiesAndStudyId: {
-        invalidatesTags: (_result, _error, args) => [
-          { type: 'projects', id: args.projectId },
+      deleteStudiesByStudyId: {
+        invalidatesTags: () => [
+          { type: 'projects', id: 'LIST' },
           { type: 'studies', id: 'LIST' },
         ],
       },
 
       // Scenari handling
-      getProjectsByProjectIdStudiesAndStudyIdScenarios: {
+      getScenarios: {
         providesTags: (result) => [
           { type: 'scenarios', id: 'LIST' },
           ...(result?.results || []).map(({ id }) => ({
@@ -380,24 +375,24 @@ const osrdEditoastApi = generatedEditoastApi
           })),
         ],
       },
-      getProjectsByProjectIdStudiesAndStudyIdScenariosScenarioId: {
+      getScenariosByScenarioId: {
         providesTags: (_result, _error, args) => [{ type: 'scenarios', id: args.scenarioId }],
       },
-      postProjectsByProjectIdStudiesAndStudyIdScenarios: {
-        invalidatesTags: (_result, _error, args) => [
-          { type: 'studies', id: args.studyId },
+      postScenarios: {
+        invalidatesTags: () => [
+          { type: 'studies', id: 'LIST' },
           { type: 'scenarios', id: 'LIST' },
         ],
       },
-      patchProjectsByProjectIdStudiesAndStudyIdScenariosScenarioId: {
+      patchScenariosByScenarioId: {
         invalidatesTags: (_result, _error, args) => [
-          { type: 'studies', id: args.studyId },
+          { type: 'studies', id: 'LIST' },
           { type: 'scenarios', id: args.scenarioId },
         ],
       },
-      deleteProjectsByProjectIdStudiesAndStudyIdScenariosScenarioId: {
-        invalidatesTags: (_result, _error, args) => [
-          { type: 'studies', id: args.studyId },
+      deleteScenariosByScenarioId: {
+        invalidatesTags: () => [
+          { type: 'studies', id: 'LIST' },
           { type: 'scenarios', id: 'LIST' },
         ],
       },

--- a/front/src/modules/project/components/AddOrEditProjectModal.tsx
+++ b/front/src/modules/project/components/AddOrEditProjectModal.tsx
@@ -213,7 +213,7 @@ export default function AddOrEditProjectModal({
   const removeProject = async () => {
     if (projectStudies) {
       // For each scenario in the project, clean the local storage if a manchette is saved
-      cleanLocalStorageByProject(project!.id, projectStudies, dispatch);
+      cleanLocalStorageByProject(projectStudies, dispatch);
     }
 
     await deleteProject({ projectId: project!.id })

--- a/front/src/modules/project/helpers/cleanLocalStorageByProject.ts
+++ b/front/src/modules/project/helpers/cleanLocalStorageByProject.ts
@@ -3,14 +3,12 @@ import { cleanScenarioLocalStorage } from 'modules/scenario/helpers/utils';
 import type { AppDispatch } from 'store';
 
 const cleanLocalStorageByProject = async (
-  projectId: number,
   projectStudies: StudyWithScenarios[],
   dispatch: AppDispatch
 ) => {
   const promisedScenarios = projectStudies.map(async (study) => {
     const data = await dispatch(
-      osrdEditoastApi.endpoints.getProjectsByProjectIdStudiesAndStudyIdScenarios.initiate({
-        projectId,
+      osrdEditoastApi.endpoints.getScenarios.initiate({
         studyId: study.id,
       })
     ).unwrap();

--- a/front/src/modules/scenario/components/AddOrEditScenarioModal.tsx
+++ b/front/src/modules/scenario/components/AddOrEditScenarioModal.tsx
@@ -12,7 +12,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import {
   osrdEditoastApi,
   type ScenarioPatchForm,
-  type ScenarioResponse,
+  type ScenarioWithDetails,
 } from 'common/api/osrdEditoastApi';
 import ChipsSNCF from 'common/BootstrapSNCF/ChipsSNCF';
 import InputSNCF from 'common/BootstrapSNCF/InputSNCF';
@@ -36,7 +36,6 @@ import useOutsideClick from 'utils/hooks/useOutsideClick';
 import { checkScenarioFields, cleanScenarioLocalStorage } from '../helpers/utils';
 
 // TODO: use ScenarioCreateForm from osrdEditoastApi to harmonize with study and project
-// and then change checkNameInvalidity
 export type ScenarioForm = ScenarioPatchForm & {
   id?: number;
   infra_id?: number;
@@ -45,7 +44,7 @@ export type ScenarioForm = ScenarioPatchForm & {
 
 type AddOrEditScenarioModalProps = {
   editionMode?: boolean;
-  scenario?: ScenarioResponse;
+  scenario?: ScenarioWithDetails;
 };
 
 type createScenarioParams = {
@@ -87,16 +86,9 @@ const AddOrEditScenarioModal = ({ editionMode = false, scenario }: AddOrEditScen
   );
 
   const [postTimetable] = osrdEditoastApi.endpoints.postTimetable.useMutation({});
-  const [postScenario] =
-    osrdEditoastApi.endpoints.postProjectsByProjectIdStudiesAndStudyIdScenarios.useMutation({});
-  const [patchScenario] =
-    osrdEditoastApi.endpoints.patchProjectsByProjectIdStudiesAndStudyIdScenariosScenarioId.useMutation(
-      {}
-    );
-  const [deleteScenario] =
-    osrdEditoastApi.endpoints.deleteProjectsByProjectIdStudiesAndStudyIdScenariosScenarioId.useMutation(
-      {}
-    );
+  const [postScenario] = osrdEditoastApi.endpoints.postScenarios.useMutation({});
+  const [patchScenario] = osrdEditoastApi.endpoints.patchScenariosByScenarioId.useMutation({});
+  const [deleteScenario] = osrdEditoastApi.endpoints.deleteScenariosByScenarioId.useMutation({});
 
   const { electricalProfilOptions = [] } =
     osrdEditoastApi.endpoints.getElectricalProfileSet.useQuery(undefined, {
@@ -160,14 +152,13 @@ const AddOrEditScenarioModal = ({ editionMode = false, scenario }: AddOrEditScen
     if (!currentScenario.infra_id || hasErrors) {
       setDisplayErrors(true);
     } else if (projectId && studyId && currentScenario && currentScenario.name) {
-      const ids = { projectId, studyId };
       const timetable = await postTimetable().unwrap();
       postScenario({
-        ...ids,
         scenarioCreateForm: {
           description: currentScenario.description || '',
           infra_id: currentScenario.infra_id,
           name: currentScenario.name,
+          study_id: studyId,
           tags: currentScenario.tags || [],
           timetable_id: timetable.timetable_id,
           electrical_profile_set_id: currentScenario.electrical_profile_set_id,
@@ -187,11 +178,9 @@ const AddOrEditScenarioModal = ({ editionMode = false, scenario }: AddOrEditScen
   const updateScenario = () => {
     if (hasErrors) {
       setDisplayErrors(true);
-    } else if (scenario && projectId && studyId && scenario.id) {
-      const ids = { projectId, studyId, scenarioId: scenario.id };
-
+    } else if (scenario) {
       patchScenario({
-        ...ids,
+        scenarioId: scenario.id,
         scenarioPatchForm: {
           description: currentScenario.description,
           infra_id: currentScenario.infra_id,
@@ -217,7 +206,7 @@ const AddOrEditScenarioModal = ({ editionMode = false, scenario }: AddOrEditScen
 
   const removeScenario = () => {
     if (projectId && studyId && scenario?.id) {
-      deleteScenario({ projectId, studyId, scenarioId: scenario.id })
+      deleteScenario({ scenarioId: scenario.id })
         .unwrap()
         .then(() => {
           cleanScenarioLocalStorage(scenario.timetable_id);

--- a/front/tests/004-scenario-management.spec.ts
+++ b/front/tests/004-scenario-management.spec.ts
@@ -78,7 +78,7 @@ test.describe('Validate the Scenario creation workflow', () => {
     });
 
     await test.step('Delete created scenario', async () => {
-      await deleteScenario(project.id, study.id, scenarioName);
+      await deleteScenario(study.id, scenarioName);
     });
   });
 
@@ -129,7 +129,7 @@ test.describe('Validate the Scenario creation workflow', () => {
     });
 
     await test.step('Delete updated scenario', async () => {
-      await deleteScenario(project.id, study.id, updatedScenarioName);
+      await deleteScenario(study.id, updatedScenarioName);
     });
   });
 

--- a/front/tests/006-op-rolling-stock-tab.spec.ts
+++ b/front/tests/006-op-rolling-stock-tab.spec.ts
@@ -37,7 +37,7 @@ test.describe('Rolling stock Tab Verification', () => {
   });
 
   test.afterAll('Delete the created scenario', async () => {
-    await deleteScenario(project.id, study.id, scenario.name);
+    await deleteScenario(study.id, scenario.name);
   });
 
   test.beforeEach('Navigate to the scenario page', async ({ page }) => {

--- a/front/tests/007-op-route-tab.spec.ts
+++ b/front/tests/007-op-route-tab.spec.ts
@@ -26,7 +26,7 @@ test.describe('Route Tab Verification', () => {
   });
 
   test.afterAll('Delete the created scenario', async () => {
-    await deleteScenario(project.id, study.id, scenario.name);
+    await deleteScenario(study.id, scenario.name);
   });
 
   test.beforeEach(async ({ page }) => {

--- a/front/tests/008-op-times-and-stops-tab.spec.ts
+++ b/front/tests/008-op-times-and-stops-tab.spec.ts
@@ -107,7 +107,7 @@ test.describe('Times and Stops Tab Verification', () => {
   });
 
   test.afterEach('Delete the created scenario', async () => {
-    await deleteScenario(project.id, study.id, scenario.name);
+    await deleteScenario(study.id, scenario.name);
   });
 
   test('should correctly set and display times and stops tables', async () => {

--- a/front/tests/009-op-simulation-settings-tab.spec.ts
+++ b/front/tests/009-op-simulation-settings-tab.spec.ts
@@ -141,7 +141,7 @@ test.describe('Simulation Settings Tab Verification', () => {
   });
 
   test.afterEach('Delete the created scenario', async () => {
-    await deleteScenario(project.id, study.id, scenario.name);
+    await deleteScenario(study.id, scenario.name);
   });
 
   test('Activate electrical profiles', async ({ browserName }) => {

--- a/front/tests/015-train-timetable.spec.ts
+++ b/front/tests/015-train-timetable.spec.ts
@@ -60,7 +60,7 @@ test.describe('Verify train schedule elements and filters', () => {
   test.beforeAll('Fetch project, study and scenario with train schedule', async () => {
     project = await getProject(timetableItemProjectName);
     study = await getStudy(project.id, timetableItemStudyName);
-    scenario = await getScenario(project.id, study.id, timetableItemScenarioName);
+    scenario = await getScenario(study.id, timetableItemScenarioName);
     infra = await getInfra();
   });
 

--- a/front/tests/016-train-timetable-multiselection.spec.ts
+++ b/front/tests/016-train-timetable-multiselection.spec.ts
@@ -58,7 +58,7 @@ test.describe('Verify train schedule elements and filters', () => {
   );
 
   test.afterAll('Delete the created scenario', async () => {
-    await deleteScenario(project.id, study.id, scenarioItems.name);
+    await deleteScenario(study.id, scenarioItems.name);
   });
 
   test.beforeEach('Go to scenario page', async ({ page }) => {

--- a/front/tests/017-paced-train-management.spec.ts
+++ b/front/tests/017-paced-train-management.spec.ts
@@ -91,7 +91,7 @@ test.describe('Verify simulation configuration in operational studies for train 
   });
 
   test.afterAll('Delete the created scenario', async () => {
-    await deleteScenario(project.id, study.id, scenario.name);
+    await deleteScenario(study.id, scenario.name);
   });
 
   test.beforeEach(

--- a/front/tests/018-train-edition.spec.ts
+++ b/front/tests/018-train-edition.spec.ts
@@ -98,7 +98,7 @@ test.describe('Edit train schedules and paced trains', () => {
   );
 
   test.afterEach('Delete the created scenario', async () => {
-    await deleteScenario(project.id, study.id, scenarioItems.name);
+    await deleteScenario(study.id, scenarioItems.name);
   });
 
   /** *************** Test 1 **************** */

--- a/front/tests/020-paced-train-exceptions.spec.ts
+++ b/front/tests/020-paced-train-exceptions.spec.ts
@@ -121,7 +121,7 @@ test.describe('Paced trains and exception management', () => {
   );
 
   test.afterAll('Delete the created scenario', async () => {
-    await deleteScenario(project.id, study.id, scenarioItems.name);
+    await deleteScenario(study.id, scenarioItems.name);
   });
 
   /** *************** Test 1 **************** */

--- a/front/tests/021-get-manchette.spec.ts
+++ b/front/tests/021-get-manchette.spec.ts
@@ -106,7 +106,7 @@ test.describe('Verify manchette and space time diagram', () => {
   });
 
   test.afterAll('Delete the created scenario', async () => {
-    await deleteScenario(project.id, study.id, scenarioItems.name);
+    await deleteScenario(study.id, scenarioItems.name);
   });
 
   test('Basic checks for STD/Manchette', async () => {

--- a/front/tests/022-round-trips.spec.ts
+++ b/front/tests/022-round-trips.spec.ts
@@ -77,7 +77,7 @@ test.describe('Verify round trips', () => {
   });
 
   test.afterEach('Delete the created scenario', async () => {
-    await deleteScenario(project.id, study.id, scenarioItems.name);
+    await deleteScenario(study.id, scenarioItems.name);
   });
 
   test('Basic checks round trips', async () => {

--- a/front/tests/023-osrd-nge.spec.ts
+++ b/front/tests/023-osrd-nge.spec.ts
@@ -62,7 +62,7 @@ test.describe('Verify osrd nge conversion', () => {
   });
 
   test.afterEach('Delete the created scenario', async () => {
-    await deleteScenario(project.id, study.id, scenarioItems.name);
+    await deleteScenario(study.id, scenarioItems.name);
   });
 
   test('Verify NGE train data', async () => {

--- a/front/tests/024-nge-osrd.spec.ts
+++ b/front/tests/024-nge-osrd.spec.ts
@@ -63,7 +63,7 @@ test.describe('Verify nge osrd conversion', () => {
   });
 
   test.afterEach('Delete the created scenario', async () => {
-    await deleteScenario(project.id, study.id, scenarioItems.name);
+    await deleteScenario(study.id, scenarioItems.name);
   });
 
   test('Add a train from nge', async () => {

--- a/front/tests/assets/operation-studies/study.json
+++ b/front/tests/assets/operation-studies/study.json
@@ -7,7 +7,7 @@
   "start_date": "2023-02-02",
   "expected_end_date": "2023-02-02",
   "actual_end_date": "2023-02-02",
-  "state": "Démarrage",
-  "study_type": "Débit",
+  "state": "started",
+  "study_type": "flowRate",
   "tags": ["tag1", "tag2", "tag3"]
 }

--- a/front/tests/utils/api-utils.ts
+++ b/front/tests/utils/api-utils.ts
@@ -4,8 +4,6 @@ import { v4 as uuidv4 } from 'uuid';
 import type {
   ElectricalProfileSet,
   GetProjectsApiResponse,
-  GetProjectsByProjectIdStudiesApiResponse,
-  GetProjectsByProjectIdStudiesAndStudyIdScenariosApiResponse,
   LightElectricalProfileSet,
   GetInfraApiResponse,
   ProjectWithStudies,
@@ -22,6 +20,8 @@ import type {
   PaginationStats,
   WorkerStatus,
   StdcmSearchEnvironmentCreateForm,
+  GetStudiesApiResponse,
+  GetScenariosApiResponse,
 } from 'common/api/osrdEditoastApi';
 
 import {
@@ -189,28 +189,24 @@ export const getProject = async (projectName = globalProjectName): Promise<Proje
  * @returns {Promise<Study>} - The matching study data.
  */
 export const getStudy = async (projectId: number, studyName = globalStudyName): Promise<Study> => {
-  const studies: GetProjectsByProjectIdStudiesApiResponse = await getApiRequest(
-    `/api/projects/${projectId}/studies`
+  const studies: GetStudiesApiResponse = await getApiRequest(
+    `/api/studies?project_id=${projectId}`
   );
   const study = studies.results.find((s: StudyWithScenarios) => s.name === studyName);
   return study as Study;
 };
 
 /**
- * Retrieve scenario data by project ID, study ID, and scenario name.
+ * Retrieve scenario data by study ID, and scenario name.
  *
- * @param projectId - The ID of the project.
  * @param studyId - The ID of the study.
  * @param scenarioName - The name of the scenario to retrieve.
  * @returns {Promise<Scenario>} - The matching scenario data.
  */
-export const getScenario = async (
-  projectId: number,
-  studyId: number,
-  scenarioName: string
-): Promise<Scenario> => {
-  const scenarios: GetProjectsByProjectIdStudiesAndStudyIdScenariosApiResponse =
-    await getApiRequest(`/api/projects/${projectId}/studies/${studyId}/scenarios`);
+export const getScenario = async (studyId: number, scenarioName: string): Promise<Scenario> => {
+  const scenarios: GetScenariosApiResponse = await getApiRequest(
+    `/api/scenarios?study_id=${studyId}`
+  );
   const scenario = scenarios.results.find((s: ScenarioWithDetails) => s.name === scenarioName);
   return scenario as Scenario;
 };

--- a/front/tests/utils/scenario.ts
+++ b/front/tests/utils/scenario.ts
@@ -47,9 +47,10 @@ export default async function createScenario(
 
   // Create a new scenario with the provided or generated name
   const scenario: Scenario = await postApiRequest(
-    `/api/projects/${project.id}/studies/${study.id}/scenarios`,
+    `/api/scenarios`,
     {
       ...scenarioData,
+      study_id: study.id,
       name: scenarioNameFinal,
       infra_id: mediumInfra.id,
       timetable_id: timetableResult.timetable_id,

--- a/front/tests/utils/setup-utils.ts
+++ b/front/tests/utils/setup-utils.ts
@@ -138,9 +138,10 @@ export async function createProject(projectName = globalProjectName): Promise<Pr
  */
 export async function createStudy(projectId: number, studyName = globalStudyName): Promise<Study> {
   const study: Study = await postApiRequest(
-    `/api/projects/${projectId}/studies`,
+    `/api/studies`,
     {
       ...studyData,
+      project_id: projectId,
       name: studyName,
       budget: 1234567890,
     } as StudyCreateForm,

--- a/front/tests/utils/teardown-utils.ts
+++ b/front/tests/utils/teardown-utils.ts
@@ -45,37 +45,41 @@ export async function deleteRollingStocks(rollingStockNames: string[]): Promise<
 }
 
 /**
- * Delete a study by name if it exists.
+ * Deletes a study by name within a given project, if it exists.
  *
+ * The function uses the provided `projectId` to retrieve all scenarios for that study,
+ * finds the one matching `studyName`, and deletes it if found.
+ * Logs a warning if no matching study is found.
+ *
+ * @param projectId - The ID of the project containing the study.
  * @param studyName - The name of the study to delete.
- * @returns {Promise<void>} - A promise that resolves when the study is deleted or if not found.
+ * @returns {Promise<void>} - Resolves once the study is deleted or if not found.
  */
 export async function deleteStudy(projectId: number, studyName: string): Promise<void> {
   const study = await getStudy(projectId, studyName);
 
   if (study) {
-    await deleteApiRequest(`/api/projects/${projectId}/studies/${study.id}`);
+    await deleteApiRequest(`/api/studies/${study.id}`);
   } else {
     logger.warn(`Study "${studyName}" not found for deletion.`);
   }
 }
 
 /**
- * Delete a scenario by name if it exists.
+ * Deletes a scenario by name within a given study, if it exists.
  *
+ * The function uses the provided `studyId` to retrieve all scenarios for that study,
+ * finds the one matching `scenarioName`, and deletes it if found.
+ * Logs a warning if no matching scenario is found.
+ *
+ * @param studyId - The ID of the study containing the scenario.
  * @param scenarioName - The name of the scenario to delete.
- * @returns {Promise<void>} - A promise that resolves when the scenario is deleted or if not found.
+ * @returns {Promise<void>} - Resolves once the scenario is deleted or if not found.
  */
-export async function deleteScenario(
-  projectId: number,
-  studyId: number,
-  scenarioName: string
-): Promise<void> {
-  const scenario = await getScenario(projectId, studyId, scenarioName);
+export async function deleteScenario(studyId: number, scenarioName: string): Promise<void> {
+  const scenario = await getScenario(studyId, scenarioName);
   if (scenario?.id) {
-    await deleteApiRequest(
-      `/api/projects/${projectId}/studies/${studyId}/scenarios/${scenario.id}`
-    );
+    await deleteApiRequest(`/api/scenarios/${scenario.id}`);
   } else {
     logger.warn(`Scenario "${scenarioName}" not found for deletion.`);
   }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,15 +92,14 @@ def foo_project_id(session: Session) -> Iterator[int]:
 @pytest.fixture
 def foo_study_id(foo_project_id: int, session: Session) -> Iterator[int]:
     payload = {
+        "project_id": foo_project_id,
         "name": "_@Test integration study",
         "state": "Starting",
         "service_code": "AAA",
         "business_code": "BBB",
         "tags": [],
     }
-    res = session.post(
-        EDITOAST_URL + f"projects/{foo_project_id}/studies/", json=payload
-    )
+    res = session.post(EDITOAST_URL + "studies/", json=payload)
     yield res.json()["id"]
 
 
@@ -109,7 +108,7 @@ def tiny_scenario(
     tiny_infra: Infra, foo_project_id: int, foo_study_id: int, session: Session
 ) -> Iterator[Scenario]:
     scenario_id, timetable_id = create_scenario(
-        EDITOAST_URL, tiny_infra.id, foo_project_id, foo_study_id, session
+        EDITOAST_URL, tiny_infra.id, foo_study_id, session
     )
     yield Scenario(
         foo_project_id, foo_study_id, scenario_id, tiny_infra.id, timetable_id
@@ -121,7 +120,7 @@ def small_scenario(
     small_infra: Infra, foo_project_id: int, foo_study_id: int, session: Session
 ) -> Iterator[Scenario]:
     scenario_id, timetable_id = create_scenario(
-        EDITOAST_URL, small_infra.id, foo_project_id, foo_study_id, session
+        EDITOAST_URL, small_infra.id, foo_study_id, session
     )
     yield Scenario(
         foo_project_id, foo_study_id, scenario_id, small_infra.id, timetable_id
@@ -133,7 +132,7 @@ def etcs_scenario(
     etcs_infra: Infra, foo_project_id: int, foo_study_id: int, session: Session
 ) -> Iterator[Scenario]:
     scenario_id, timetable_id = create_scenario(
-        EDITOAST_URL, etcs_infra.id, foo_project_id, foo_study_id, session
+        EDITOAST_URL, etcs_infra.id, foo_study_id, session
     )
     yield Scenario(
         foo_project_id, foo_study_id, scenario_id, etcs_infra.id, timetable_id

--- a/tests/tests/test_scenario.py
+++ b/tests/tests/test_scenario.py
@@ -59,10 +59,7 @@ class _ScenarioResponse:
 
 
 def test_get_scenario(small_scenario: Scenario, session: Session):
-    response = session.get(
-        EDITOAST_URL
-        + f"/projects/{small_scenario.project}/studies/{small_scenario.op_study}/scenarios/{small_scenario.scenario}/"
-    )
+    response = session.get(EDITOAST_URL + f"scenarios/{small_scenario.scenario}/")
     assert response.status_code == 200
     res = response.json()
     project, study = res.get("project"), res.get("study")

--- a/tests/tests/test_stdcm.py
+++ b/tests/tests/test_stdcm.py
@@ -54,9 +54,7 @@ def test_empty_timetable(
     session: Session,
 ):
     op_study = create_op_study(EDITOAST_URL, foo_project_id, session)
-    _, timetable = create_scenario(
-        EDITOAST_URL, small_infra.id, foo_project_id, op_study, session
-    )
+    _, timetable = create_scenario(EDITOAST_URL, small_infra.id, op_study, session)
     payload = {
         "rolling_stock_id": fast_rolling_stock,
         "timetable_id": timetable,
@@ -85,9 +83,7 @@ def test_empty_timetable_with_stop(
     session: Session,
 ):
     op_study = create_op_study(EDITOAST_URL, foo_project_id, session)
-    _, timetable = create_scenario(
-        EDITOAST_URL, small_infra.id, foo_project_id, op_study, session
-    )
+    _, timetable = create_scenario(EDITOAST_URL, small_infra.id, op_study, session)
     payload = {
         "rolling_stock_id": fast_rolling_stock,
         "timetable_id": timetable,

--- a/tests/tests/utils/timetable.py
+++ b/tests/tests/utils/timetable.py
@@ -5,12 +5,13 @@ from requests import Session
 
 def create_op_study(editoast_url, project_id: int, session: Session) -> int:
     payload = {
+        "project_id": project_id,
         "name": "foo",
         "state": "Starting",
         "service_code": "AAA",
         "business_code": "BBB",
     }
-    res = session.post(editoast_url + f"projects/{project_id}/studies/", json=payload)
+    res = session.post(editoast_url + "studies/", json=payload)
     if res.status_code // 100 != 2:
         err = f"Error creating operational study {res.status_code}: {res.content}, payload={json.dumps(payload)}"
         raise RuntimeError(err)
@@ -20,7 +21,6 @@ def create_op_study(editoast_url, project_id: int, session: Session) -> int:
 def create_scenario(
     editoast_url: str,
     infra_id: int,
-    project_id: int,
     op_study_id: int,
     session: Session,
 ) -> tuple[int, int]:
@@ -36,9 +36,10 @@ def create_scenario(
         "name": "_@Test integration scenario",
         "infra_id": infra_id,
         "timetable_id": timetable_id,
+        "study_id": op_study_id,
     }
     r = session.post(
-        editoast_url + f"/projects/{project_id}/studies/{op_study_id}/scenarios/",
+        editoast_url + "scenarios/",
         json=scenario_payload,
     )
     r.raise_for_status()


### PR DESCRIPTION
Closes #13257 

### Changes overview

- **Resource creation:**
When creating a new study or scenario, the parent resource ID (e.g., project ID or study ID) is now included in the request **form data** instead of being passed in the URL.

- **Resource listing:**
When retrieving a list of studies or scenarios, the parent resource ID is now provided as a URL query parameter, together with pagination parameters.
→ Example: /api/studies?project_id={id}&page=1&page_size=20

- **Other endpoints:**
For all other cases (retrieving, updating, or deleting a specific resource), the resource’s own ID remains part of the URL path.
→ Example: /api/scenarios/{id}