### PR TITLE
chart: fix small issues on the gateway part of the chart

### DIFF
--- a/.github/workflows/chart-publish.yml
+++ b/.github/workflows/chart-publish.yml
@@ -39,5 +39,5 @@ jobs:
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
           helm package ./chart
-          echo "Pushing to oci://ghcr.io/openrailassociation/${CHART_NAME}:${CHART_VERSION}"
+          echo "Pushing to oci://ghcr.io/openrailassociation/osrd-charts/${CHART_NAME}:${CHART_VERSION}"
           helm push ${CHART_NAME}-${CHART_VERSION}.tgz oci://ghcr.io/openrailassociation/osrd-charts

--- a/chart/templates/gateway/configmap.yaml
+++ b/chart/templates/gateway/configmap.yaml
@@ -89,7 +89,6 @@ data:
     provider_id = "{{ $provider.provider_id }}"
     {{- if eq $provider.type "Mocked" }}
     username = "{{ $provider.username }}"
-    require_login = {{ $provider.require_login }}
     {{- else if eq $provider.type "Bearer" }}
     [auth.providers.tokens]
     {{- range $key, $value := $provider.tokens }}

--- a/chart/templates/gateway/ingress.yaml
+++ b/chart/templates/gateway/ingress.yaml
@@ -37,7 +37,9 @@ spec:
       {{- with .Values.services.gateway.ingress.domains }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
+    {{- if .Values.services.gateway.ingress.secretName }}
     secretName: {{ .Values.services.gateway.ingress.secretName }}
+    {{- end }}
   {{- end }}
 
   rules:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -133,7 +133,6 @@ services:
           - type: "Mocked"
             provider_id: "mocked"
             username: "osrd-admin"
-            require_login: false
       railway_manager_interface:
         enabled: false
         prefix: "/railway-manager"


### PR DESCRIPTION
This PR fixes three things
* When seting up a tls ingress for the gateway, a secretName was mandatory to store the tls certificate. Turns out that in some setup like for example traefik with let's encrypt it's not necessary and breaks the setup. This PR makes it optional
* In the mock auth provider of the gateway a require_login was added and is in fact deprecated. This PR removes it
* The echo-ed path of the chart in the CD was wrong, which might be confusing for users