### PR TITLE
chart: use stable images for stable chart

### DIFF
--- a/.github/workflows/chart-build.yml
+++ b/.github/workflows/chart-build.yml
@@ -25,6 +25,8 @@ jobs:
       - name: Set Name and Version
         run: |
           CHART_NAME="osrd-dev"
+          CHART_IMAGES_REPOSITORY="edge"
+          CHART_IMAGES_VERSION="dev"
 
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             CHART_VERSION="0.0.1-${{ github.event.pull_request.number }}-${GITHUB_SHA}"
@@ -39,6 +41,9 @@ jobs:
 
           sed -i "s/NAME_REPLACE_ME/$CHART_NAME/" ./chart/Chart.yaml
           sed -i "s/VERSION_REPLACE_ME/$CHART_VERSION/" ./chart/Chart.yaml
+          sed -i "s/APP_VERSION_REPLACE_ME/$CHART_IMAGES_VERSION/" ./chart/Chart.yaml
+          sed -i "s/REPOSITORY_VERSION_REPLACE_ME/$CHART_IMAGES_REPOSITORY/" ./chart/values.yaml
+          sed -i "s/IMAGES_VERSION_REPLACE_ME/$CHART_IMAGES_VERSION/" ./chart/values.yaml
 
       - name: Lint Helm Chart
         run: helm lint ./chart

--- a/.github/workflows/chart-publish.yml
+++ b/.github/workflows/chart-publish.yml
@@ -22,15 +22,20 @@ jobs:
       - name: Set Name and Version
         run: |
           CHART_NAME="osrd"
+          CHART_IMAGES_REPOSITORY="stable"
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             CHART_VERSION="${{ github.event.inputs.tag_name }}"
           else
             CHART_VERSION="${{ github.event.release.tag_name }}"
           fi
+          CHART_IMAGES_VERSION="${CHART_VERSION}"
           echo "CHART_NAME=$CHART_NAME" >> $GITHUB_ENV
           echo "CHART_VERSION=$CHART_VERSION" >> $GITHUB_ENV
           sed -i "s/NAME_REPLACE_ME/$CHART_NAME/" ./chart/Chart.yaml
           sed -i "s/VERSION_REPLACE_ME/$CHART_VERSION/" ./chart/Chart.yaml
+          sed -i "s/APP_VERSION_REPLACE_ME/$CHART_IMAGES_VERSION/" ./chart/Chart.yaml
+          sed -i "s/REPOSITORY_VERSION_REPLACE_ME/$CHART_IMAGES_REPOSITORY/" ./chart/values.yaml
+          sed -i "s/IMAGES_VERSION_REPLACE_ME/$CHART_IMAGES_VERSION/" ./chart/values.yaml
 
       - name: Lint Helm Chart
         run: helm lint ./chart

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for deploying OSRD
 type: application
-appVersion: "0.1.5"
 # Replaced by sed in .github/workflows/helm.yaml
+appVersion: "APP_VERSION_REPLACE_ME"
 name: NAME_REPLACE_ME
 version: VERSION_REPLACE_ME

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -27,10 +27,10 @@ endpoints:
 imagePullSecrets: []
 pullPolicy: IfNotPresent
 images:
-  editoast: ghcr.io/openrailassociation/osrd-edge/osrd-editoast:dev
-  gateway: ghcr.io/openrailassociation/osrd-edge/osrd-gateway:dev-front
-  core: ghcr.io/openrailassociation/osrd-edge/osrd-core:dev
-  osrdyne: ghcr.io/openrailassociation/osrd-edge/osrd-osrdyne:dev
+  editoast: ghcr.io/openrailassociation/osrd-REPOSITORY_VERSION_REPLACE_ME/osrd-editoast:IMAGES_VERSION_REPLACE_ME
+  gateway: ghcr.io/openrailassociation/osrd-REPOSITORY_VERSION_REPLACE_ME/osrd-gateway:IMAGES_VERSION_REPLACE_ME-front
+  core: ghcr.io/openrailassociation/osrd-REPOSITORY_VERSION_REPLACE_ME/osrd-core:IMAGES_VERSION_REPLACE_ME
+  osrdyne: ghcr.io/openrailassociation/osrd-REPOSITORY_VERSION_REPLACE_ME/osrd-osrdyne:IMAGES_VERSION_REPLACE_ME
   images: ghcr.io/openrailassociation/osrd-stable/osrd-images:v1.0.2
   openfga: openfga/openfga:v1.8.6
 


### PR DESCRIPTION
At the moment stable chart use dev images by default.
This PR does a quick fix to use stable images matching the chart version by default.
The multiple sed usage indicates image definition should be reworked to benefit from Chart.yaml appVersion field and to be able to switch repository in values.yaml which can be done in a further PR