### PR TITLE
core: fix crash when the path doesn't contain all block zones

### DIFF
--- a/core/kt-osrd-signaling/src/main/kotlin/fr/sncf/osrd/signaling/SignalingSimulator.kt
+++ b/core/kt-osrd-signaling/src/main/kotlin/fr/sncf/osrd/signaling/SignalingSimulator.kt
@@ -73,6 +73,7 @@ interface SignalingSimulator {
         followingZoneState: ZoneStatus,
         followingSignalState: SigState? = null,
         followingSignalSettings: SigSettings? = null,
+        firstZone: ZoneId? = null,
     ): Map<LogicalSignalId, SigState>
 
     fun evaluate(

--- a/core/kt-osrd-signaling/src/main/kotlin/fr/sncf/osrd/signaling/impl/SignalingSimulatorImpl.kt
+++ b/core/kt-osrd-signaling/src/main/kotlin/fr/sncf/osrd/signaling/impl/SignalingSimulatorImpl.kt
@@ -183,6 +183,7 @@ class SignalingSimulatorImpl(override val sigModuleManager: SigSystemManager) : 
             followingZoneState,
             followingSignalState,
             followingSignalSettings,
+            trainPath.getZones().first().value,
         )
     }
 
@@ -197,17 +198,30 @@ class SignalingSimulatorImpl(override val sigModuleManager: SigSystemManager) : 
         followingZoneState: ZoneStatus,
         followingSignalState: SigState?,
         followingSignalSettings: SigSettings?,
+        firstZone: ZoneId?,
     ): Map<LogicalSignalId, SigState> {
         // TODO path migration: remove this overload
         assert(evaluatedPathEnd > 0)
         assert(evaluatedPathEnd <= fullPath.size)
         val routeSet by lazy { routes.toSet() }
 
+        fun getZoneState(i: Int): ZoneStatus {
+            // Zones outside the path are considered clear. We can query zone status when they are
+            // not included in the path, but still part of a block included in the path.
+            return if (i in zoneStates.indices) zoneStates[i] else ZoneStatus.CLEAR
+        }
+
         // compute the offset of each block's first zone inside the partial path
         val blockZoneMap = IntArray(evaluatedPathEnd + 1)
         var blockZoneOffset = 0
+        // When the first zone is given, we look for it in the first block and adjust zone indexes.
+        // When it's not set, we include all zones in the given blocks.
+        val firstZoneOffset =
+            if (firstZone == null) 0
+            else
+                blocks.getBlockZonePaths(fullPath[0]).map(infra::getZonePathZone).indexOf(firstZone)
         for (i in 0 until evaluatedPathEnd) {
-            blockZoneMap[i] = blockZoneOffset
+            blockZoneMap[i] = blockZoneOffset - firstZoneOffset
             blockZoneOffset += blocks.getBlockZonePaths(fullPath[i]).size
         }
         blockZoneMap[evaluatedPathEnd] = blockZoneOffset
@@ -250,9 +264,10 @@ class SignalingSimulatorImpl(override val sigModuleManager: SigSystemManager) : 
                 val entrySignal = blockSignals[0]
                 val protectedZonesStart = blockZoneMap[blockIndex]
                 val protectedZonesEnd = blockZoneMap[blockIndex + 1]
-                var zoneStatus = zoneStates[protectedZonesStart]
-                for (i in protectedZonesStart + 1 until protectedZonesEnd) zoneStatus =
-                    zoneStatus.reduce(zoneStates[i])
+                var zoneStatus = getZoneState(protectedZonesStart)
+                for (i in protectedZonesStart + 1 until protectedZonesEnd) {
+                    zoneStatus = zoneStatus.reduce(getZoneState(i))
+                }
                 signalEvalSequence.add(SignalEvalTask(entrySignal, zoneStatus.toProtectionStatus()))
             }
         }

--- a/core/kt-osrd-sncf-signaling/src/test/kotlin/fr/sncf/osrd/signaling/bal/TestBALtoBAL.kt
+++ b/core/kt-osrd-sncf-signaling/src/test/kotlin/fr/sncf/osrd/signaling/bal/TestBALtoBAL.kt
@@ -1,5 +1,8 @@
 package fr.sncf.osrd.signaling.bal
 
+import fr.sncf.osrd.path.implementations.PartialBlockRange
+import fr.sncf.osrd.path.implementations.buildRangeList
+import fr.sncf.osrd.path.implementations.buildTrainPathFromBlockRanges
 import fr.sncf.osrd.path.implementations.buildTrainPathFromBlocks
 import fr.sncf.osrd.railjson.builder.begin
 import fr.sncf.osrd.railjson.builder.buildParseRJSInfra
@@ -8,7 +11,10 @@ import fr.sncf.osrd.railjson.schema.common.graph.EdgeDirection
 import fr.sncf.osrd.signaling.ZoneStatus
 import fr.sncf.osrd.signaling.impl.SigSystemManagerImpl
 import fr.sncf.osrd.signaling.impl.SignalingSimulatorImpl
+import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.decreasing
+import fr.sncf.osrd.utils.units.Offset
+import fr.sncf.osrd.utils.units.meters
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -83,6 +89,109 @@ class TestBALtoBAL {
             )
         val trainPath =
             buildTrainPathFromBlocks(infra, blockInfra, blocks, routeNames = listOf("U-Z"))
+        val zoneStates = mutableListOf(ZoneStatus.CLEAR, ZoneStatus.CLEAR, ZoneStatus.CLEAR)
+        val res =
+            simulator.evaluate(
+                infra,
+                loadedSignalInfra,
+                blockInfra,
+                trainPath,
+                zoneStates,
+                ZoneStatus.INCOMPATIBLE,
+            )
+        assertEquals(
+            "A",
+            res[loadedSignalInfra.getLogicalSignals(signalV).first()]!!.getEnum("aspect"),
+        )
+    }
+
+    @Test
+    fun testBALtoBALPartialBlock() {
+        // All "I" mark the location of detectors, which delimit zones.
+        // Compared to the test above: there's an extra detector with no signal between U and V. The
+        // train path starts after that detector, before V.
+        //
+        // u         v
+        // I---A--I--I-+
+        //              \
+        // w          x  \    y       z
+        // I---B---I--I---C---I---D---I
+        //                S
+        //  <-- reverse     normal -->
+
+        // region build the test infrastructure
+        val infra = buildParseRJSInfra {
+            val lowerLeftTrack = trackSection("lower_left", 15.0)
+            val upperLeftTrack = trackSection("upper_left", 15.0)
+            val rightTrack = trackSection("right", 15.0)
+            val switch =
+                pointSwitch("S", rightTrack.begin, lowerLeftTrack.begin, upperLeftTrack.begin, 0.01)
+            val detU = bufferStop("U", upperLeftTrack.end)
+            detector("V", upperLeftTrack.at(5.0))
+            val detW = bufferStop("W", lowerLeftTrack.end)
+            detector("X", lowerLeftTrack.at(5.0))
+            val detY = detector("Y", rightTrack.at(5.0))
+            val detZ = bufferStop("Z", rightTrack.end)
+            detector("EXTRA1", upperLeftTrack.at(14.0))
+            detector("EXTRA2", lowerLeftTrack.at(14.0))
+
+            val logicalSignalTemplate =
+                logicalSignal("BAL") {
+                    nextSignalingSystem("BAL")
+                    setting("Nf", "true")
+                    defaultParameter("jaune_cli", "false")
+                }
+
+            defaultSightDistance = 300.0
+            physicalSignal("X", lowerLeftTrack.at(7.0), EdgeDirection.STOP_TO_START) {
+                logicalSignal(logicalSignalTemplate)
+            }
+
+            physicalSignal("V", upperLeftTrack.at(7.0), EdgeDirection.STOP_TO_START) {
+                logicalSignal(logicalSignalTemplate)
+            }
+
+            route("U-Z", detU, EdgeDirection.STOP_TO_START, detZ) {
+                addSwitchDirection(switch, "A_B2")
+            }
+            route("W-Z", detW, EdgeDirection.STOP_TO_START, detZ) {
+                addReleaseDetector(detY)
+                addSwitchDirection(switch, "A_B1")
+            }
+        }
+
+        val detectors = infra.detectors.associateBy { infra.getDetectorName(it) }
+        val detU = detectors["U"]!!
+        val detV = detectors["V"]!!
+        val signals = infra.physicalSignals.associateBy { infra.getPhysicalSignalName(it) }
+        val signalV = signals["V"]!!
+
+        val sigSystemManager = SigSystemManagerImpl()
+        sigSystemManager.addSignalingSystem(BAL, 0.40)
+        sigSystemManager.addSignalDriver(BALtoBAL)
+        val simulator = SignalingSimulatorImpl(sigSystemManager)
+        val loadedSignalInfra = simulator.loadSignals(infra)
+        val blockInfra = simulator.buildBlocks(infra, loadedSignalInfra)
+        val blocks =
+            listOf(
+                blockInfra.getBlocksStartingAtDetector(detU.decreasing).first(),
+                blockInfra.getBlocksStartingAtDetector(detV.decreasing).first(),
+            )
+        val blockRanges =
+            buildRangeList(
+                blocks.mapIndexed { index, it ->
+                    val beginOffset = if (index == 0) Offset<Block>(5.meters) else Offset.zero()
+                    val endOffset = blockInfra.getBlockLength(it)
+                    PartialBlockRange(it, beginOffset, endOffset)
+                }
+            )
+        val trainPath =
+            buildTrainPathFromBlockRanges(
+                infra,
+                blockInfra,
+                blockRanges,
+                routeNames = listOf("U-Z"),
+            )
         val zoneStates = mutableListOf(ZoneStatus.CLEAR, ZoneStatus.CLEAR, ZoneStatus.CLEAR)
         val res =
             simulator.evaluate(


### PR DESCRIPTION
Fix https://github.com/OpenRailAssociation/osrd/issues/13845

`SignalingSimulator.evaluate` isn't migrated to the new path types yet, while the call site is (`ScheduleMetadataExtractor`).

I wasn't careful enough on this interface: the zone state list is built using only the zones that are part of the path, while `evaluate` expects them to include all zones included in the covered blocks. 

This doesn't properly migrate the method to the new types, it's just an quick fix to avoid the crash. 

Includes a test that did fail without the fix. 