### PR TITLE
editoast: add user delete command

### DIFF
--- a/editoast/authz/src/lib.rs
+++ b/editoast/authz/src/lib.rs
@@ -374,5 +374,20 @@ mod mock_driver {
             // Mock implementation, always return true
             Ok(true)
         }
+
+        async fn delete_user(&self, user_id: i64) -> Result<bool, Self::Error> {
+            let map = self.users.lock().unwrap();
+            let user_identity = map
+                .iter()
+                .find_map(|(k, &v)| if v == user_id { Some(k) } else { None });
+
+            let mut map = self.users.lock().unwrap();
+            if let Some(identity) = user_identity {
+                map.remove(identity);
+                Ok(true)
+            } else {
+                Ok(false)
+            }
+        }
     }
 }

--- a/editoast/authz/src/regulator.rs
+++ b/editoast/authz/src/regulator.rs
@@ -94,6 +94,8 @@ pub trait StorageDriver: Clone {
         >,
     > + Send;
 
+    fn delete_user(&self, user_id: i64) -> impl Future<Output = Result<bool, Self::Error>> + Send;
+
     fn infra_exists(&self, infra_id: i64)
     -> impl Future<Output = Result<bool, Self::Error>> + Send;
 }

--- a/editoast/migrations/2025-10-30-145042-0000_modify_authn_user_delete_trigger/down.sql
+++ b/editoast/migrations/2025-10-30-145042-0000_modify_authn_user_delete_trigger/down.sql
@@ -1,0 +1,5 @@
+drop trigger if exists authn_user_delete_trigger on authn_user;
+
+create trigger authn_user_delete_trigger before
+delete on authn_user
+for each row execute function delete_associated_authn_subject ();

--- a/editoast/migrations/2025-10-30-145042-0000_modify_authn_user_delete_trigger/up.sql
+++ b/editoast/migrations/2025-10-30-145042-0000_modify_authn_user_delete_trigger/up.sql
@@ -1,0 +1,5 @@
+drop trigger if exists authn_user_delete_trigger on authn_user;
+
+create trigger authn_user_delete_trigger after
+delete on authn_user
+for each row execute function delete_associated_authn_subject ();

--- a/editoast/src/client/user.rs
+++ b/editoast/src/client/user.rs
@@ -23,6 +23,8 @@ pub enum UserCommand {
     Add(AddArgs),
     /// Get information about a user
     Info(InfoArgs),
+    /// Delete a user
+    Delete(DeleteArgs),
 }
 
 #[derive(Debug, Args)]
@@ -42,6 +44,12 @@ pub struct AddArgs {
 
 #[derive(Debug, Args)]
 pub struct InfoArgs {
+    /// Id or identity of the user
+    user: String,
+}
+
+#[derive(Debug, Args)]
+pub struct DeleteArgs {
     /// Id or identity of the user
     user: String,
 }
@@ -135,5 +143,30 @@ pub async fn user_info(
         };
         println!("- [{group_id}] {name}");
     }
+    Ok(())
+}
+
+/// Delete a user
+pub async fn delete_user(
+    DeleteArgs { user }: DeleteArgs,
+    pool: Arc<DbConnectionPoolV2>,
+) -> anyhow::Result<()> {
+    let driver = PgAuthDriver::new(pool);
+
+    let uid = if let Ok(id) = user.parse::<i64>() {
+        id
+    } else {
+        let uid = driver.get_user_id(&user).await?;
+        uid.ok_or_else(|| anyhow!("No user with identity '{user}' found"))?
+    };
+
+    let deleted = driver.delete_user(uid).await?;
+
+    if deleted {
+        tracing::info!("user '{user}' deleted");
+    } else {
+        anyhow::bail!("user '{user}' could not be deleted (not found)");
+    }
+
     Ok(())
 }

--- a/editoast/src/main.rs
+++ b/editoast/src/main.rs
@@ -217,6 +217,9 @@ async fn run() -> anyhow::Result<()> {
             UserCommand::Info(info_args) => {
                 user::user_info(info_args, openfga_config, Arc::new(db_pool)).await
             }
+            UserCommand::Delete(delete_args) => {
+                user::delete_user(delete_args, Arc::new(db_pool)).await
+            }
         },
         Commands::Healthcheck(core_config) => {
             healthcheck_cmd(db_pool.into(), valkey_config, core_config, openfga_config).await

--- a/editoast/src/models/auth_driver.rs
+++ b/editoast/src/models/auth_driver.rs
@@ -245,6 +245,15 @@ impl StorageDriver for PgAuthDriver {
     async fn infra_exists(&self, infra_id: i64) -> Result<bool, Self::Error> {
         Ok(Infra::exists(&mut self.pool.get().await?, infra_id).await?)
     }
+
+    #[tracing::instrument(skip_all, fields(%user_id), ret(level = Level::DEBUG), err)]
+    async fn delete_user(&self, user_id: i64) -> Result<bool, Self::Error> {
+        let conn = self.pool.get().await?;
+        let s = dsl::delete(authn_user::table.filter(authn_user::id.eq(user_id)))
+            .execute(&mut conn.write().await)
+            .await?;
+        Ok(s > 0)
+    }
 }
 
 #[cfg(test)]
@@ -363,5 +372,15 @@ mod tests {
             .await
             .expect("Groups should be collected successfully");
         assert_eq!(groups, vec![(friends_id, friends), (foes_id, foes)]);
+
+        match driver.delete_user(toto_id).await {
+            Ok(deleted) => assert!(deleted, "user 'toto' should be deleted"),
+            _ => unreachable!(),
+        }
+
+        match driver.delete_user(0xdeadbeef).await {
+            Ok(deleted) => assert!(!deleted, "deleting an unknown user should return false"),
+            _ => unreachable!(),
+        }
     }
 }


### PR DESCRIPTION
This PR adds a new command to delete a user using editoast CLI.

The `authn_user_delete_trigger` had to be modified to be ran after the delete operation to avoid an sql error: `tuple to be deleted was already modified by an operation triggered by the current command`

Part of https://github.com/OpenRailAssociation/osrd/issues/13856