### PR TITLE
editoast, front: remove useless fields 'deleted' and 'locked' from PathItem and ScheduleItem

### DIFF
--- a/editoast/.gitignore
+++ b/editoast/.gitignore
@@ -5,3 +5,5 @@ assets/fonts/glyphs/*
 
 # allows using nightly rustfmt options locally without imposing nightly to everyone publicly
 rustfmt.toml
+
+migrations/.diesel_lock

--- a/editoast/migrations/2025-11-04-090228-0000_remove_locked_field_from_pathitem/down.sql
+++ b/editoast/migrations/2025-11-04-090228-0000_remove_locked_field_from_pathitem/down.sql
@@ -1,0 +1,14 @@
+-- This file should undo anything in `up.sql`
+UPDATE train_schedule
+SET schedule = (
+    SELECT jsonb_agg(jsonb_set(elem, '{locked}', 'true'::jsonb, true))
+    FROM jsonb_array_elements(schedule) AS elem
+)
+WHERE schedule IS NOT NULL;
+
+UPDATE train_schedule
+SET path = (
+    SELECT jsonb_agg(jsonb_set(elem, '{deleted}', 'false'::jsonb, true))
+    FROM jsonb_array_elements(path) AS elem
+)
+WHERE path IS NOT NULL;

--- a/editoast/migrations/2025-11-04-090228-0000_remove_locked_field_from_pathitem/up.sql
+++ b/editoast/migrations/2025-11-04-090228-0000_remove_locked_field_from_pathitem/up.sql
@@ -1,0 +1,14 @@
+-- Your SQL goes here
+UPDATE train_schedule
+SET schedule = (
+  SELECT jsonb_agg(elem - 'locked')
+  FROM jsonb_array_elements(schedule) AS elem
+)
+WHERE schedule IS NOT NULL;
+
+UPDATE train_schedule
+SET path = (
+  SELECT jsonb_agg(elem - 'deleted')
+  FROM jsonb_array_elements(path) AS elem
+)
+WHERE path IS NOT NULL;

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -11087,12 +11087,6 @@ components:
         required:
         - id
         properties:
-          deleted:
-            type: boolean
-            description: |-
-              Metadata given to mark a point as wishing to be deleted by the user.
-              It's useful for soft deleting the point (waiting to fix / remove all references)
-              If true, the train schedule is consider as invalid and must be edited
           id:
             oneOf:
             - type: string
@@ -12830,9 +12824,6 @@ components:
           - type: string
             minLength: 1
           description: Position on the path of the schedule item.
-        locked:
-          type: boolean
-          description: Whether the schedule item is locked (only for display purposes)
         reception_signal:
           $ref: '#/components/schemas/ReceptionSignal'
         stop_for:
@@ -15166,12 +15157,6 @@ components:
               required:
               - id
               properties:
-                deleted:
-                  type: boolean
-                  description: |-
-                    Metadata given to mark a point as wishing to be deleted by the user.
-                    It's useful for soft deleting the point (waiting to fix / remove all references)
-                    If true, the train schedule is consider as invalid and must be edited
                 id:
                   oneOf:
                   - type: string
@@ -15219,9 +15204,6 @@ components:
                 - type: string
                   minLength: 1
                 description: Position on the path of the schedule item.
-              locked:
-                type: boolean
-                description: Whether the schedule item is locked (only for display purposes)
               reception_signal:
                 $ref: '#/components/schemas/ReceptionSignal'
               stop_for:

--- a/editoast/schemas/src/tests/train_schedule_simple.json
+++ b/editoast/schemas/src/tests/train_schedule_simple.json
@@ -19,7 +19,6 @@
     },
     {
       "id": "c",
-      "deleted": true,
       "trigram": "MWS"
     },
     {
@@ -31,8 +30,7 @@
   "schedule": [
     {
       "at": "a",
-      "stop_for": "PT5M",
-      "locked": true
+      "stop_for": "PT5M"
     },
     {
       "at": "b",
@@ -45,8 +43,7 @@
     },
     {
       "at": "d",
-      "arrival": "PT50M",
-      "locked": true
+      "arrival": "PT50M"
     }
   ],
   "margins": {

--- a/editoast/schemas/src/train_schedule.rs
+++ b/editoast/schemas/src/train_schedule.rs
@@ -250,7 +250,6 @@ mod tests {
         let path_item = PathItem {
             id: "a".into(),
             location,
-            deleted: false,
         };
         let train_schedule = TrainSchedule {
             path: vec![path_item.clone(), path_item.clone()],
@@ -308,7 +307,6 @@ mod tests {
         let path_item = PathItem {
             id: "a".into(),
             location,
-            deleted: false,
         };
         let train_schedule = TrainSchedule {
             path: vec![path_item.clone(), path_item.clone()],
@@ -317,14 +315,12 @@ mod tests {
                     at: "a".into(),
                     arrival: None,
                     stop_for: None,
-                    locked: false,
                     reception_signal: ReceptionSignal::Open,
                 },
                 ScheduleItem {
                     at: "a".into(),
                     arrival: None,
                     stop_for: None,
-                    locked: false,
                     reception_signal: ReceptionSignal::Open,
                 },
             ],
@@ -346,7 +342,6 @@ mod tests {
         let path_item = PathItem {
             id: "a".into(),
             location,
-            deleted: false,
         };
         let train_schedule = TrainSchedule {
             path: vec![path_item.clone(), path_item.clone()],
@@ -354,7 +349,6 @@ mod tests {
                 at: "a".into(),
                 arrival: Some(Duration::minutes(5).try_into().unwrap()),
                 stop_for: None,
-                locked: false,
                 reception_signal: ReceptionSignal::Open,
             }],
             ..Default::default()

--- a/editoast/schemas/src/train_schedule/path_item.rs
+++ b/editoast/schemas/src/train_schedule/path_item.rs
@@ -13,11 +13,6 @@ pub struct PathItem {
     /// This is used to reference path items in the train schedule.
     #[schema(inline)]
     pub id: NonBlankString,
-    /// Metadata given to mark a point as wishing to be deleted by the user.
-    /// It's useful for soft deleting the point (waiting to fix / remove all references)
-    /// If true, the train schedule is consider as invalid and must be edited
-    #[serde(default)]
-    pub deleted: bool,
     #[serde(flatten)]
     pub location: PathItemLocation,
 }
@@ -27,7 +22,6 @@ impl PathItem {
     pub fn new_operational_point(id: &str) -> Self {
         Self {
             id: id.into(),
-            deleted: false,
             location: PathItemLocation::OperationalPointReference(OperationalPointReference {
                 reference: OperationalPointIdentifier::OperationalPointId {
                     operational_point: id.into(),

--- a/editoast/schemas/src/train_schedule/schedule_item.rs
+++ b/editoast/schemas/src/train_schedule/schedule_item.rs
@@ -33,9 +33,6 @@ pub struct ScheduleItem {
     pub stop_for: Option<PositiveDuration>,
     #[serde(default)]
     pub reception_signal: ReceptionSignal,
-    /// Whether the schedule item is locked (only for display purposes)
-    #[serde(default)]
-    pub locked: bool,
 }
 
 #[cfg(feature = "testing")]
@@ -46,7 +43,6 @@ impl ScheduleItem {
             arrival: None,
             stop_for: Some(PositiveDuration::new(duration)),
             reception_signal: ReceptionSignal::Open,
-            locked: false,
         }
     }
 }
@@ -93,7 +89,6 @@ mod tests {
             arrival: None,
             stop_for: None,
             reception_signal: ReceptionSignal::Stop,
-            locked: false,
         };
         let invalid_str = to_string(&schedule_item).unwrap();
         assert!(from_str::<ScheduleItem>(&invalid_str).is_err());

--- a/editoast/src/models/fixtures.rs
+++ b/editoast/src/models/fixtures.rs
@@ -165,7 +165,6 @@ pub fn create_created_exception_with_change_groups(key: &str) -> PacedTrainExcep
             path: vec![
                 PathItem {
                     id: "aa".into(),
-                    deleted: false,
                     location: PathItemLocation::TrackOffset(TrackOffset {
                         offset: 300,
                         track: Identifier("TC0".to_string()),
@@ -173,7 +172,6 @@ pub fn create_created_exception_with_change_groups(key: &str) -> PacedTrainExcep
                 },
                 PathItem {
                     id: "bb".into(),
-                    deleted: false,
                     location: PathItemLocation::OperationalPointReference(
                         OperationalPointReference {
                             reference: OperationalPointIdentifier::OperationalPointId {
@@ -185,7 +183,6 @@ pub fn create_created_exception_with_change_groups(key: &str) -> PacedTrainExcep
                 },
                 PathItem {
                     id: "cc".into(),
-                    deleted: false,
                     location: PathItemLocation::TrackOffset(TrackOffset {
                         offset: 300,
                         track: Identifier("TC1".to_string()),
@@ -193,7 +190,6 @@ pub fn create_created_exception_with_change_groups(key: &str) -> PacedTrainExcep
                 },
                 PathItem {
                     id: "dd".into(),
-                    deleted: false,
                     location: PathItemLocation::TrackOffset(TrackOffset {
                         offset: 300,
                         track: Identifier("TC2".to_string()),

--- a/editoast/src/tests/track_occupancy/simple_train_schedule.json
+++ b/editoast/src/tests/track_occupancy/simple_train_schedule.json
@@ -7,21 +7,18 @@
     "path": [
         {
             "id": "id8",
-            "deleted": false,
             "uic": 8711,
             "secondary_code": "BV",
             "track_reference": null
         },
         {
             "id": "id5",
-            "deleted": false,
             "uic": 8733,
             "secondary_code": "BV",
             "track_reference": null
         },
         {
             "id": "id7",
-            "deleted": false,
             "uic": 8788,
             "secondary_code": "BV",
             "track_reference": null
@@ -32,15 +29,13 @@
             "at": "id5",
             "arrival": null,
             "stop_for": "PT120S",
-            "reception_signal": "OPEN",
-            "locked": false
+            "reception_signal": "OPEN"
         },
         {
             "at": "id7",
             "arrival": null,
             "stop_for": "P0D",
-            "reception_signal": "OPEN",
-            "locked": false
+            "reception_signal": "OPEN"
         }
     ],
     "constraint_distribution": "STANDARD",

--- a/editoast/src/tests/train_schedules/simple.json
+++ b/editoast/src/tests/train_schedules/simple.json
@@ -19,7 +19,6 @@
     },
     {
       "id": "c",
-      "deleted": true,
       "trigram": "MWS"
     },
     {
@@ -31,8 +30,7 @@
   "schedule": [
     {
       "at": "a",
-      "stop_for": "PT5M",
-      "locked": true
+      "stop_for": "PT5M"
     },
     {
       "at": "b",
@@ -45,8 +43,7 @@
     },
     {
       "at": "d",
-      "arrival": "PT50M",
-      "locked": true
+      "arrival": "PT50M"
     }
   ],
   "margins": {

--- a/editoast/src/tests/train_schedules/simple_array.json
+++ b/editoast/src/tests/train_schedules/simple_array.json
@@ -20,7 +20,6 @@
           },
           {
             "id": "c",
-            "deleted": true,
             "trigram": "ABC"
           },
           {
@@ -32,8 +31,7 @@
         "schedule": [
           {
             "at": "a",
-            "stop_for": "PT5M",
-            "locked": true
+            "stop_for": "PT5M"
           },
           {
             "at": "b",
@@ -46,8 +44,7 @@
           },
           {
             "at": "d",
-            "arrival": "PT50M",
-            "locked": true
+            "arrival": "PT50M"
           }
         ],
         "margins": {

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -1224,9 +1224,10 @@ mod tests {
             .await
             .assert_status(StatusCode::UNPROCESSABLE_ENTITY)
             .bytes();
-        assert_eq!(
-            &String::from_utf8(response).unwrap(),
-            "Failed to deserialize the JSON body into the target type: [0]: Duplicate exception key: 'duplicated_key_1' at line 1 column 2452"
+        assert!(
+            String::from_utf8(response)
+                .unwrap()
+                .contains("Duplicate exception key: 'duplicated_key_1'")
         )
     }
 

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -383,7 +383,6 @@ impl VirtualTrainRun {
                 arrival: None,
                 stop_for: Some(PositiveDuration::try_from(Duration::zero()).unwrap()),
                 reception_signal: ReceptionSignal::Open,
-                locked: false,
             }],
             margins: build_single_margin(stdcm_request.margin),
             initial_speed: 0.0,

--- a/editoast/src/views/timetable/stdcm/request.rs
+++ b/editoast/src/views/timetable/stdcm/request.rs
@@ -48,7 +48,6 @@ pub(super) fn convert_steps(steps: &[PathfindingItem]) -> Vec<PathItem> {
         .iter()
         .map(|step| PathItem {
             id: Default::default(),
-            deleted: false,
             location: step.location.clone(),
         })
         .collect()

--- a/editoast/src/views/timetable/track_occupancy.rs
+++ b/editoast/src/views/timetable/track_occupancy.rs
@@ -359,7 +359,6 @@ pub mod tests {
                             track_reference: None,
                         },
                     ),
-                    deleted: false,
                 },
                 PathItem {
                     id: "path_item_2".into(),
@@ -371,7 +370,6 @@ pub mod tests {
                             track_reference: None,
                         },
                     ),
-                    deleted: false,
                 },
                 PathItem {
                     id: "path_item_invalid".into(),
@@ -383,7 +381,6 @@ pub mod tests {
                             track_reference: None,
                         },
                     ),
-                    deleted: false,
                 },
             ],
             schedule: vec![
@@ -393,7 +390,6 @@ pub mod tests {
                     stop_for: Some(
                         PositiveDuration::try_from(Duration::milliseconds(500)).unwrap(),
                     ),
-                    locked: false,
                     reception_signal: ReceptionSignal::Open,
                 },
                 ScheduleItem {
@@ -402,7 +398,6 @@ pub mod tests {
                     stop_for: Some(
                         PositiveDuration::try_from(Duration::milliseconds(300000)).unwrap(),
                     ),
-                    locked: false,
                     reception_signal: ReceptionSignal::Open,
                 },
             ],

--- a/front/src/applications/operationalStudies/__tests__/sampleData.ts
+++ b/front/src/applications/operationalStudies/__tests__/sampleData.ts
@@ -324,19 +324,16 @@ export const trainScheduleTooFast: TrainScheduleWithTrainId = {
   path: [
     {
       id: 'id440',
-      deleted: false,
       track: 'TA0',
       offset: 1299000,
     },
     {
       id: 'id935',
-      deleted: false,
       uic: 4,
       secondary_code: 'BV',
     },
     {
       id: 'id916',
-      deleted: false,
       track: 'TH1',
       offset: 4095000,
     },
@@ -347,14 +344,12 @@ export const trainScheduleTooFast: TrainScheduleWithTrainId = {
       arrival: 'PT1740S',
       stop_for: 'P0D',
       reception_signal: 'OPEN',
-      locked: false,
     },
     {
       at: 'id916',
       arrival: null,
       stop_for: 'P0D',
       reception_signal: 'OPEN',
-      locked: false,
     },
   ],
   margins: {
@@ -391,21 +386,18 @@ export const trainScheduleTooFastOnInterval: TrainScheduleWithTrainId = {
   path: [
     {
       id: 'idA',
-      deleted: false,
       uic: 87700000,
       secondary_code: 'BV',
       track_reference: null,
     },
     {
       id: 'idB',
-      deleted: false,
       uic: 87700001,
       secondary_code: 'BV',
       track_reference: null,
     },
     {
       id: 'idC',
-      deleted: false,
       uic: 87700002,
       secondary_code: 'BV',
       track_reference: null,
@@ -417,14 +409,12 @@ export const trainScheduleTooFastOnInterval: TrainScheduleWithTrainId = {
       arrival: 'PT5280S',
       stop_for: null,
       reception_signal: 'OPEN',
-      locked: false,
     },
     {
       at: 'idC',
       arrival: 'PT15300S',
       stop_for: 'P0D',
       reception_signal: 'OPEN',
-      locked: false,
     },
   ],
   margins: {
@@ -466,19 +456,16 @@ export const trainScheduleNotHonored: TrainScheduleWithTrainId = {
   path: [
     {
       id: 'id440',
-      deleted: false,
       track: 'TA0',
       offset: 1299000,
     },
     {
       id: 'id584',
-      deleted: false,
       uic: 4,
       secondary_code: 'BV',
     },
     {
       id: 'id450',
-      deleted: false,
       track: 'TG1',
       offset: 644000,
     },
@@ -489,14 +476,12 @@ export const trainScheduleNotHonored: TrainScheduleWithTrainId = {
       arrival: 'PT300S',
       stop_for: null,
       reception_signal: 'OPEN',
-      locked: false,
     },
     {
       at: 'id450',
       arrival: null,
       stop_for: 'P0D',
       reception_signal: 'OPEN',
-      locked: false,
     },
   ],
   margins: {
@@ -533,13 +518,11 @@ export const trainScheduleHonored: TrainScheduleWithTrainId = {
   path: [
     {
       id: 'id440',
-      deleted: false,
       track: 'TA0',
       offset: 1299000,
     },
     {
       id: 'id450',
-      deleted: false,
       track: 'TG1',
       offset: 644000,
     },
@@ -550,7 +533,6 @@ export const trainScheduleHonored: TrainScheduleWithTrainId = {
       arrival: null,
       stop_for: 'P0D',
       reception_signal: 'OPEN',
-      locked: false,
     },
   ],
   margins: {
@@ -580,7 +562,6 @@ export const trainScheduleNoMatch: TrainScheduleWithTrainId = {
       arrival: 'PT300S',
       stop_for: 'P0D',
       reception_signal: 'OPEN',
-      locked: false,
     },
   ],
 };

--- a/front/src/applications/operationalStudies/hooks/usePathOps.ts
+++ b/front/src/applications/operationalStudies/hooks/usePathOps.ts
@@ -25,7 +25,7 @@ const usePathOps = (
     () =>
       (path ?? []).reduce<OperationalPointReference[]>((acc, pathItem) => {
         if (isOperationalPointReference(pathItem)) {
-          const { id: _id, deleted: _deleted, ...cleanOperationalPointReference } = pathItem;
+          const { id: _id, ...cleanOperationalPointReference } = pathItem;
           acc.push(cleanOperationalPointReference);
         }
         return acc;

--- a/front/src/applications/operationalStudies/utils.ts
+++ b/front/src/applications/operationalStudies/utils.ts
@@ -314,11 +314,11 @@ export const getStationFromOps = (ops: OperationalPoint[]): OperationalPoint | u
   ops.find((op) => ['BV', '00'].includes(op.extensions?.sncf?.ch || '')) || ops.at(0);
 
 /**
- * Get a path item location (without ID and deleted fields) from a train's path
+ * Get a path item location (without ID) from a train's path
  * item.
  */
 const getPathItemLocation = (pathItem: TrainSchedule['path'][number]) => {
-  const { id: _id, deleted: _deleted, ...pathItemLocation } = pathItem;
+  const { id: _id, ...pathItemLocation } = pathItem;
   return pathItemLocation;
 };
 
@@ -427,13 +427,11 @@ export const checkRoundTripCompatible = (
       const opRefA = {
         ...pathItemA,
         id: undefined,
-        deleted: undefined,
         track_reference: undefined,
       };
       const opRefB = {
         ...pathItemB,
         id: undefined,
-        deleted: undefined,
         track_reference: undefined,
       };
 

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/__tests__/ngeToOsrd-output-discontinuousTrainrun.json
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/__tests__/ngeToOsrd-output-discontinuousTrainrun.json
@@ -60,9 +60,9 @@
       "train_name": "Carotte-1",
       "labels": [],
       "path": [
-        { "trigram": "RTR", "id": "7-0", "deleted": false, "track_reference": null },
-        { "trigram": "LTH", "id": "8-1", "deleted": false, "track_reference": null },
-        { "trigram": "SS", "id": "6-2", "deleted": false, "track_reference": null }
+        { "trigram": "RTR", "id": "7-0", "track_reference": null },
+        { "trigram": "LTH", "id": "8-1", "track_reference": null },
+        { "trigram": "SS", "id": "6-2", "track_reference": null }
       ],
       "start_time": "2025-06-25T13:00:00.000Z",
       "schedule": [
@@ -70,14 +70,12 @@
           "at": "8-1",
           "arrival": "PT1M",
           "stop_for": "PT2M",
-          "locked": false,
           "reception_signal": "OPEN"
         },
         {
           "at": "6-2",
           "arrival": "PT4M",
           "stop_for": "P0D",
-          "locked": false,
           "reception_signal": "OPEN"
         }
       ],
@@ -91,9 +89,9 @@
       "train_name": "Carotte-1",
       "labels": [],
       "path": [
-        { "trigram": "SS", "id": "6-0", "deleted": false, "track_reference": null },
-        { "trigram": "LTH", "id": "8-1", "deleted": false, "track_reference": null },
-        { "trigram": "RTR", "id": "7-2", "deleted": false, "track_reference": null }
+        { "trigram": "SS", "id": "6-0", "track_reference": null },
+        { "trigram": "LTH", "id": "8-1", "track_reference": null },
+        { "trigram": "RTR", "id": "7-2", "track_reference": null }
       ],
       "start_time": "2025-06-25T13:56:00.000Z",
       "schedule": [
@@ -101,14 +99,12 @@
           "at": "8-1",
           "arrival": "PT1M",
           "stop_for": "PT2M",
-          "locked": false,
           "reception_signal": "OPEN"
         },
         {
           "at": "7-2",
           "arrival": "PT4M",
           "stop_for": "P0D",
-          "locked": false,
           "reception_signal": "OPEN"
         }
       ],
@@ -125,13 +121,11 @@
       },
       "path": [
         {
-          "deleted": false,
           "id": "10-0",
           "track_reference": null,
           "trigram": "WLD"
         },
         {
-          "deleted": false,
           "id": "11-1",
           "track_reference": null,
           "trigram": "FLR"
@@ -142,7 +136,6 @@
         {
           "arrival": "PT2M",
           "at": "11-1",
-          "locked": false,
           "reception_signal": "OPEN",
           "stop_for": "P0D"
         }
@@ -161,13 +154,11 @@
       },
       "path": [
         {
-          "deleted": false,
           "id": "11-0",
           "track_reference": null,
           "trigram": "FLR"
         },
         {
-          "deleted": false,
           "id": "10-1",
           "track_reference": null,
           "trigram": "WLD"
@@ -178,7 +169,6 @@
         {
           "arrival": "PT1M",
           "at": "10-1",
-          "locked": false,
           "reception_signal": "OPEN",
           "stop_for": "P0D"
         }

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/__tests__/ngeToOsrd-output-duplicateTrigrams.json
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/__tests__/ngeToOsrd-output-duplicateTrigrams.json
@@ -40,9 +40,9 @@
       "train_name": "Carotte",
       "labels": [],
       "path": [
-        { "trigram": "RTR", "id": "7-0", "deleted": false, "track_reference": null },
-        { "trigram": "SS-2", "id": "8-1", "deleted": false, "track_reference": null },
-        { "trigram": "SS-1", "id": "6-2", "deleted": false, "track_reference": null }
+        { "trigram": "RTR", "id": "7-0", "track_reference": null },
+        { "trigram": "SS-2", "id": "8-1", "track_reference": null },
+        { "trigram": "SS-1", "id": "6-2", "track_reference": null }
       ],
       "start_time": "2025-06-25T13:00:00.000Z",
       "schedule": [
@@ -50,14 +50,12 @@
           "at": "8-1",
           "arrival": "PT1M",
           "stop_for": "PT2M",
-          "locked": false,
           "reception_signal": "OPEN"
         },
         {
           "at": "6-2",
           "arrival": "PT4M",
           "stop_for": "P0D",
-          "locked": false,
           "reception_signal": "OPEN"
         }
       ]

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/__tests__/ngeToOsrd-output-oneWay.json
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/__tests__/ngeToOsrd-output-oneWay.json
@@ -40,9 +40,9 @@
       "train_name": "Carotte",
       "labels": [],
       "path": [
-        { "trigram": "RTR", "id": "7-0", "deleted": false, "track_reference": null },
-        { "trigram": "LTH", "id": "8-1", "deleted": false, "track_reference": null },
-        { "trigram": "SS", "id": "6-2", "deleted": false, "track_reference": null }
+        { "trigram": "RTR", "id": "7-0", "track_reference": null },
+        { "trigram": "LTH", "id": "8-1", "track_reference": null },
+        { "trigram": "SS", "id": "6-2", "track_reference": null }
       ],
       "start_time": "2025-06-25T13:00:00.000Z",
       "schedule": [
@@ -50,14 +50,12 @@
           "at": "8-1",
           "arrival": "PT1M",
           "stop_for": "PT2M",
-          "locked": false,
           "reception_signal": "OPEN"
         },
         {
           "at": "6-2",
           "arrival": "PT4M",
           "stop_for": "P0D",
-          "locked": false,
           "reception_signal": "OPEN"
         }
       ],

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/__tests__/ngeToOsrd-output-roundTrip.json
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/__tests__/ngeToOsrd-output-roundTrip.json
@@ -40,9 +40,9 @@
       "train_name": "Carotte",
       "labels": ["Test label"],
       "path": [
-        { "trigram": "RTR", "id": "7-0", "deleted": false, "track_reference": null },
-        { "trigram": "LTH", "id": "8-1", "deleted": false, "track_reference": null },
-        { "trigram": "SS", "id": "6-2", "deleted": false, "track_reference": null }
+        { "trigram": "RTR", "id": "7-0", "track_reference": null },
+        { "trigram": "LTH", "id": "8-1", "track_reference": null },
+        { "trigram": "SS", "id": "6-2", "track_reference": null }
       ],
       "start_time": "2025-06-25T13:00:00.000Z",
       "schedule": [
@@ -50,14 +50,12 @@
           "at": "8-1",
           "arrival": "PT1M",
           "stop_for": "PT2M",
-          "locked": false,
           "reception_signal": "OPEN"
         },
         {
           "at": "6-2",
           "arrival": "PT4M",
           "stop_for": "P0D",
-          "locked": false,
           "reception_signal": "OPEN"
         }
       ],
@@ -71,9 +69,9 @@
       "train_name": "Carotte",
       "labels": ["Test label"],
       "path": [
-        { "trigram": "SS", "id": "6-0", "deleted": false, "track_reference": null },
-        { "trigram": "LTH", "id": "8-1", "deleted": false, "track_reference": null },
-        { "trigram": "RTR", "id": "7-2", "deleted": false, "track_reference": null }
+        { "trigram": "SS", "id": "6-0", "track_reference": null },
+        { "trigram": "LTH", "id": "8-1", "track_reference": null },
+        { "trigram": "RTR", "id": "7-2", "track_reference": null }
       ],
       "start_time": "2025-06-25T13:56:00.000Z",
       "schedule": [
@@ -81,14 +79,12 @@
           "at": "8-1",
           "arrival": "PT1M",
           "stop_for": "PT2M",
-          "locked": false,
           "reception_signal": "OPEN"
         },
         {
           "at": "7-2",
           "arrival": "PT4M",
           "stop_for": "P0D",
-          "locked": false,
           "reception_signal": "OPEN"
         }
       ],

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/ngeToOsrd.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/ngeToOsrd.ts
@@ -171,7 +171,6 @@ const createPathItemFromNode = (node: NodeDto, index: number) => {
     trigram,
     secondary_code: secondaryCode,
     id: `${node.id}-${index}`,
-    deleted: false,
     // TODO : handle this case in xml import refacto
     track_reference: null,
   };
@@ -280,7 +279,6 @@ const generateSchedule = (
           at: `${toNodeId}-${index + 1}`,
           stop_for: Duration.zero.toISOString(),
           // Default information
-          locked: false,
           reception_signal: 'OPEN',
         };
       }
@@ -301,7 +299,6 @@ const generateSchedule = (
       arrival: formatDateDifferenceFrom(startDate, arrival),
       stop_for,
       // Default information
-      locked: false,
       reception_signal: 'OPEN',
     };
   });

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/helpers/__tests__/formatSchedule.spec.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/helpers/__tests__/formatSchedule.spec.ts
@@ -11,7 +11,6 @@ describe('formatSchedule', () => {
       const pathSteps: PathStep[] = [
         {
           id: 'id331',
-          deleted: false,
           location: {
             uic: 8706,
             secondary_code: 'BV',
@@ -28,7 +27,6 @@ describe('formatSchedule', () => {
       const pathSteps: PathStep[] = [
         {
           id: 'id332',
-          deleted: false,
           location: {
             uic: 8737,
             secondary_code: 'BV',
@@ -38,7 +36,6 @@ describe('formatSchedule', () => {
           positionOnPath: 13116000,
           arrival: Duration.parse('PT60S'),
           stopFor: Duration.zero,
-          locked: false,
           receptionSignal: 'OPEN',
         },
       ];
@@ -47,7 +44,6 @@ describe('formatSchedule', () => {
         {
           arrival: 'PT1M',
           at: 'id332',
-          locked: false,
           reception_signal: 'OPEN',
           stop_for: 'P0D',
         },

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/helpers/__tests__/formatTimetableItemPayload.spec.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/helpers/__tests__/formatTimetableItemPayload.spec.ts
@@ -34,7 +34,6 @@ describe('formatTimetableItemPayload', () => {
     pathSteps: [
       {
         id: '0-0',
-        deleted: false,
         location: {
           uic: 2,
           trigram: 'WS',
@@ -50,7 +49,6 @@ describe('formatTimetableItemPayload', () => {
       },
       {
         id: '1-1',
-        deleted: false,
         location: {
           uic: 6,
           trigram: 'SS',
@@ -60,7 +58,6 @@ describe('formatTimetableItemPayload', () => {
         name: 'South_station',
         arrival: null,
         stopFor: null,
-        locked: false,
         receptionSignal: 'OPEN',
         positionOnPath: 49103000,
         coordinates: [-0.16408630124250465, 49.46600036530178],
@@ -103,14 +100,12 @@ describe('formatTimetableItemPayload', () => {
       path: [
         {
           id: '0-0',
-          deleted: false,
           trigram: 'WS',
           secondary_code: 'BV',
           track_reference: null,
         },
         {
           id: '1-1',
-          deleted: false,
           trigram: 'SS',
           secondary_code: 'BV',
           track_reference: null,
@@ -222,14 +217,12 @@ describe('formatTimetableItemPayload', () => {
             trigram: 'WS',
             secondary_code: 'BV',
             track_reference: null,
-            deleted: false,
           },
           {
             id: '1-1',
             trigram: 'SS',
             secondary_code: 'BV',
             track_reference: null,
-            deleted: false,
           },
         ],
         power_restrictions: [],
@@ -307,14 +300,12 @@ describe('formatTimetableItemPayload', () => {
               trigram: 'WS',
               secondary_code: 'BV',
               track_reference: null,
-              deleted: false,
             },
             {
               id: '1-1',
               trigram: 'SS',
               secondary_code: 'BV',
               track_reference: null,
-              deleted: false,
             },
           ],
           power_restrictions: [],
@@ -500,7 +491,6 @@ describe('formatTimetableItemPayload', () => {
             rawOsrdconf.pathSteps[0],
             {
               id: '1-1',
-              deleted: false,
               location: {
                 trigram: 'SS',
                 secondary_code: 'BV',
@@ -509,7 +499,6 @@ describe('formatTimetableItemPayload', () => {
               arrival: null,
               stopFor: Duration.parse('P0D'),
               receptionSignal: 'OPEN',
-              locked: false,
             },
           ],
           // This is not user change but we need to updated this value so it matches the one from the added occurrence
@@ -546,14 +535,12 @@ describe('formatTimetableItemPayload', () => {
               path: [
                 {
                   id: '0-0',
-                  deleted: false,
                   trigram: 'WS',
                   secondary_code: 'BV',
                   track_reference: null,
                 },
                 {
                   id: '1-1',
-                  deleted: false,
                   trigram: 'SS',
                   secondary_code: 'BV',
                   track_reference: null,
@@ -565,7 +552,6 @@ describe('formatTimetableItemPayload', () => {
                   arrival: undefined,
                   stop_for: 'P0D',
                   reception_signal: 'OPEN',
-                  locked: false,
                 },
               ],
               power_restrictions: [],

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/helpers/formatSchedule.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/helpers/formatSchedule.ts
@@ -9,7 +9,6 @@ const formatSchedule = (pathSteps: PathStep[]): TrainSchedule['schedule'] => {
       return {
         at: step.id,
         arrival: step.arrival?.toISOString() ?? undefined,
-        locked: step.locked,
         reception_signal: step.receptionSignal,
         stop_for: step.stopFor?.toISOString() ?? undefined,
       };

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/helpers/formatTimetableItemPayload.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/helpers/formatTimetableItemPayload.ts
@@ -44,7 +44,6 @@ export function formatTimetableItemPayload(
     path: compact(osrdconf.pathSteps).map((step) => ({
       id: step.id,
       ...getStepLocation(step.location),
-      deleted: step.deleted || false,
     })),
     power_restrictions: osrdconf.powerRestriction,
     rolling_stock_name: rollingStockName,

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -3988,10 +3988,6 @@ export type TrainSchedule = {
     use_speed_limits_for_simulation?: boolean;
   };
   path: (PathItemLocation & {
-    /** Metadata given to mark a point as wishing to be deleted by the user.
-        It's useful for soft deleting the point (waiting to fix / remove all references)
-        If true, the train schedule is consider as invalid and must be edited */
-    deleted?: boolean;
     /** The unique identifier of the path item.
         This is used to reference path items in the train schedule. */
     id: string;
@@ -4006,8 +4002,6 @@ export type TrainSchedule = {
     arrival?: null | PositiveDuration;
     /** Position on the path of the schedule item. */
     at: string;
-    /** Whether the schedule item is locked (only for display purposes) */
-    locked?: boolean;
     reception_signal?: ReceptionSignal;
     stop_for?: null | PositiveDuration;
   }[];
@@ -4038,10 +4032,6 @@ export type Margins = {
   values: string[];
 };
 export type PathItem = PathItemLocation & {
-  /** Metadata given to mark a point as wishing to be deleted by the user.
-    It's useful for soft deleting the point (waiting to fix / remove all references)
-    If true, the train schedule is consider as invalid and must be edited */
-  deleted?: boolean;
   /** The unique identifier of the path item.
     This is used to reference path items in the train schedule. */
   id: string;
@@ -4055,8 +4045,6 @@ export type ScheduleItem = {
   arrival?: null | PositiveDuration;
   /** Position on the path of the schedule item. */
   at: string;
-  /** Whether the schedule item is locked (only for display purposes) */
-  locked?: boolean;
   reception_signal?: ReceptionSignal;
   stop_for?: null | PositiveDuration;
 };

--- a/front/src/modules/pathfinding/helpers/__tests__/reversePathSteps.spec.ts
+++ b/front/src/modules/pathfinding/helpers/__tests__/reversePathSteps.spec.ts
@@ -73,7 +73,6 @@ describe('reversePathSteps', () => {
     },
     {
       id: 'id206',
-      deleted: false,
       location: {
         uic: 87447144,
         secondary_code: '00',
@@ -82,7 +81,6 @@ describe('reversePathSteps', () => {
       name: 'Carantilly-Marigny',
       arrival: new Duration({ milliseconds: 3000000 }),
       stopFor: new Duration({ milliseconds: 0 }),
-      locked: false,
       receptionSignal: 'OPEN',
       kp: '31+774',
       positionOnPath: 31750000,
@@ -93,7 +91,6 @@ describe('reversePathSteps', () => {
   const expectedReversedPathSteps: PathStep[] = [
     {
       id: 'id206',
-      deleted: false,
       location: {
         uic: 87447144,
         secondary_code: '00',
@@ -102,7 +99,6 @@ describe('reversePathSteps', () => {
       name: 'Carantilly-Marigny',
       arrival: null,
       stopFor: null,
-      locked: false,
       receptionSignal: 'OPEN',
       theoreticalMargin: '2min/100km',
       kp: '31+774',

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/__tests__/makeProjectedItems.spec.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/__tests__/makeProjectedItems.spec.ts
@@ -127,13 +127,11 @@ describe('makeProjectedItems', () => {
             id: '3e6c78c6-89a9-462f-a0b3-1e4253cb6386',
             uic: 11,
             secondary_code: 'BV',
-            deleted: false,
           },
           {
             id: '00fd1b82-32ca-43fd-a46e-24b5bc6f0fd3',
             uic: 14,
             secondary_code: 'BV',
-            deleted: false,
           },
         ],
         power_restrictions: [],

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/utils.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/utils.ts
@@ -56,7 +56,7 @@ export const getWaypointsLocalStorageKey = (
   projectionPath: TimetableItem['path'] | undefined
 ) => {
   // We need to remove the id because it can change for waypoints added by map click
-  const simplifiedPath = projectionPath?.map((waypoint) => omit(waypoint, ['id', 'deleted']));
+  const simplifiedPath = projectionPath?.map((waypoint) => omit(waypoint, ['id']));
 
   return `PathOperationalPoints-${timetableId}-${JSON.stringify(simplifiedPath)}`;
 };

--- a/front/src/modules/timetableItem/helpers/__tests__/pacedTrain.spec.ts
+++ b/front/src/modules/timetableItem/helpers/__tests__/pacedTrain.spec.ts
@@ -49,8 +49,8 @@ describe('extractOccurrenceDetailsFromPacedTrain', () => {
     rolling_stock_name: '',
     start_time: '2024-10-15T03:00:00Z',
     path: [
-      { id: 'id227', deleted: false, uic: 6, secondary_code: 'BV' },
-      { id: 'id228', deleted: false, uic: 5, secondary_code: 'BV' },
+      { id: 'id227', uic: 6, secondary_code: 'BV' },
+      { id: 'id228', uic: 5, secondary_code: 'BV' },
     ],
     schedule: [
       {
@@ -58,7 +58,6 @@ describe('extractOccurrenceDetailsFromPacedTrain', () => {
         arrival: null,
         stop_for: 'P0D',
         reception_signal: 'OPEN',
-        locked: false,
       },
     ],
     margins: { boundaries: [], values: ['0%'] },
@@ -113,8 +112,8 @@ describe('extractOccurrenceDetailsFromPacedTrain', () => {
       key: '123123',
       path_and_schedule: {
         path: [
-          { id: 'id225', deleted: false, uic: 6, secondary_code: 'BV' },
-          { id: 'id228', deleted: false, uic: 5, secondary_code: 'BV' },
+          { id: 'id225', uic: 6, secondary_code: 'BV' },
+          { id: 'id228', uic: 5, secondary_code: 'BV' },
         ],
         schedule: [
           {
@@ -122,7 +121,6 @@ describe('extractOccurrenceDetailsFromPacedTrain', () => {
             arrival: null,
             stop_for: 'P0D',
             reception_signal: 'OPEN',
-            locked: false,
           },
         ],
         margins: { boundaries: [], values: ['0%'] },

--- a/front/src/modules/timetableItem/helpers/computeBasePathStep.ts
+++ b/front/src/modules/timetableItem/helpers/computeBasePathStep.ts
@@ -23,13 +23,12 @@ const computeBasePathStep = (
   timetableItem: Pick<TrainSchedule, 'path' | 'schedule' | 'margins'>,
   pathItemIndex: number
 ): PathStep => {
-  const { id, deleted, ...location } = timetableItem.path[pathItemIndex];
+  const { id, ...location } = timetableItem.path[pathItemIndex];
   const correspondingSchedule = timetableItem.schedule?.find((schedule) => schedule.at === id);
 
   const {
     arrival,
     stop_for: stopFor,
-    locked,
     reception_signal: receptionSignal,
   } = correspondingSchedule || {};
 
@@ -49,16 +48,14 @@ const computeBasePathStep = (
 
   return {
     id,
-    deleted,
     name,
 
     location: { ...location, ...('track' in location ? { offset: mmToM(location.offset) } : null) },
     arrival: arrival ? Duration.parse(arrival) : null,
     stopFor: stopFor ? Duration.parse(stopFor) : null,
-    // If not provided, we set locked and receptionSignal to their default values
-    // in order to avoid unwanted exceptions (when not provided, editoast returns them
-    // with their default values)
-    locked: locked ?? false,
+    // If not provided, we set receptionSignal to its default value
+    // in order to avoid unwanted exceptions (when not provided, editoast returns it
+    // with its default value)
     receptionSignal: receptionSignal ?? 'OPEN',
     theoreticalMargin,
   };

--- a/front/src/modules/timetableItem/types.ts
+++ b/front/src/modules/timetableItem/types.ts
@@ -28,7 +28,6 @@ export type SuggestedOP = {
   positionOnPath: number;
   coordinates?: Position;
   arrival?: Duration | null; // value asked by user, number of seconds since departure
-  locked?: boolean;
   stopFor?: Duration | null; // value asked by user
   theoreticalMargin?: string; // value asked by user
   theoreticalMarginSeconds?: string;

--- a/front/src/reducers/osrdconf/helpers.ts
+++ b/front/src/reducers/osrdconf/helpers.ts
@@ -72,8 +72,6 @@ export function upsertPathStep(statePathSteps: (PathStep | null)[], op: Suggeste
       'name',
       'kp',
       'arrival',
-      'locked',
-      'deleted',
       'receptionSignal',
       'theoreticalMargin',
       'stopFor',

--- a/front/src/reducers/osrdconf/operationalStudiesConf/__tests__/operationalStudiesConfReducer.spec.ts
+++ b/front/src/reducers/osrdconf/operationalStudiesConf/__tests__/operationalStudiesConfReducer.spec.ts
@@ -92,7 +92,6 @@ describe('simulationConfReducer', () => {
             theoreticalMargin: '10%',
             arrival: null,
             stopFor: null,
-            locked: false,
             receptionSignal: 'OPEN',
           },
           {
@@ -104,7 +103,6 @@ describe('simulationConfReducer', () => {
             theoreticalMargin: undefined,
             arrival: null,
             stopFor: null,
-            locked: false,
             receptionSignal: 'OPEN',
           },
         ],
@@ -144,7 +142,6 @@ describe('simulationConfReducer', () => {
             theoreticalMargin: '10%',
             arrival: null,
             stopFor: null,
-            locked: false,
             receptionSignal: 'OPEN',
           },
           {
@@ -156,7 +153,6 @@ describe('simulationConfReducer', () => {
             theoreticalMargin: undefined,
             arrival: null,
             stopFor: null,
-            locked: false,
             receptionSignal: 'OPEN',
           },
         ],
@@ -239,7 +235,6 @@ describe('simulationConfReducer', () => {
         },
         stopFor: Duration.parse('PT5M'),
         coordinates: [47.99542250806296, 0.1918181738752042],
-        locked: newVia.locked,
         name: newVia.name,
       };
 

--- a/front/src/reducers/osrdconf/operationalStudiesConf/utils.ts
+++ b/front/src/reducers/osrdconf/operationalStudiesConf/utils.ts
@@ -6,7 +6,7 @@ import type { PathStep } from '../types';
 /**
  * Check if a pathStep can be removed.
  *
- * It cannot be removed if it is used in at least one power restriction range, if it is locked or has an arrival time,
+ * It cannot be removed if it is used in at least one power restriction range or has an arrival time,
  * a stop duration or a margin.
  */
 export const canRemovePathStep = (
@@ -16,13 +16,7 @@ export const canRemovePathStep = (
   const pathStepIsUsed = powerRestrictionRanges.some(
     (restriction) => restriction.from === pathStep.id || restriction.to === pathStep.id
   );
-  return (
-    !pathStepIsUsed &&
-    !pathStep.locked &&
-    !pathStep.arrival &&
-    !pathStep.stopFor &&
-    !pathStep.theoreticalMargin
-  );
+  return !pathStepIsUsed && !pathStep.arrival && !pathStep.stopFor && !pathStep.theoreticalMargin;
 };
 
 /** Remove some restrictions and update the first and second restrictions with the new path step */

--- a/front/src/reducers/osrdconf/osrdConfCommon/__tests__/commonConfBuilder.ts
+++ b/front/src/reducers/osrdconf/osrdConfCommon/__tests__/commonConfBuilder.ts
@@ -7,7 +7,6 @@ export default function commonConfBuilder() {
       {
         location: { uic: 474007 },
         id: 'brest',
-        locked: true,
         coordinates: [48.38819835024553, -4.478289762812405],
       },
       {
@@ -42,7 +41,6 @@ export default function commonConfBuilder() {
           operational_point: 'strasbourg',
         },
         id: 'strasbourg',
-        locked: true,
         coordinates: [48.58505541984412, 7.73387081978364],
       },
     ],

--- a/front/src/reducers/osrdconf/types.ts
+++ b/front/src/reducers/osrdconf/types.ts
@@ -91,12 +91,7 @@ export type OsrdStdcmConfState = OsrdConfState & {
 export type PathStep = {
   id: string;
   location: PathItemLocation;
-  /** Metadata given to mark a point as wishing to be deleted by the user.
-        It's useful for soft deleting the point (waiting to fix / remove all references)
-        If true, the train schedule is consider as invalid and must be edited */
-  deleted?: boolean;
   arrival?: Duration | null;
-  locked?: boolean;
   stopFor?: Duration | null;
   theoreticalMargin?: string;
   receptionSignal?: ReceptionSignal;

--- a/front/tests/assets/paced-train/paced_trains.json
+++ b/front/tests/assets/paced-train/paced_trains.json
@@ -5,16 +5,15 @@
     "rolling_stock_name": "SLOW_RS_E2E",
     "start_time": "2024-10-15T03:00:00Z",
     "path": [
-      { "id": "id227", "deleted": false, "uic": 8766, "secondary_code": "BV" },
-      { "id": "id228", "deleted": false, "uic": 8755, "secondary_code": "BV" }
+      { "id": "id227", "uic": 8766, "secondary_code": "BV" },
+      { "id": "id228", "uic": 8755, "secondary_code": "BV" }
     ],
     "schedule": [
       {
         "at": "id228",
         "arrival": null,
         "stop_for": "P0D",
-        "reception_signal": "OPEN",
-        "locked": false
+        "reception_signal": "OPEN"
       }
     ],
     "margins": { "boundaries": [], "values": ["0%"] },
@@ -32,16 +31,15 @@
     "rolling_stock_name": "SLOW_RS_E2E",
     "start_time": "2024-10-15T04:00:00Z",
     "path": [
-      { "id": "id227", "deleted": false, "uic": 8766, "secondary_code": "BV" },
-      { "id": "id228", "deleted": false, "uic": 8755, "secondary_code": "BV" }
+      { "id": "id227", "uic": 8766, "secondary_code": "BV" },
+      { "id": "id228", "uic": 8755, "secondary_code": "BV" }
     ],
     "schedule": [
       {
         "at": "id228",
         "arrival": null,
         "stop_for": "P0D",
-        "reception_signal": "OPEN",
-        "locked": false
+        "reception_signal": "OPEN"
       }
     ],
     "margins": { "boundaries": [], "values": ["0%"] },
@@ -70,24 +68,22 @@
     "rolling_stock_name": "DUAL-MODE_RS_E2E",
     "start_time": "2024-10-15T05:00:00Z",
     "path": [
-      { "id": "id744", "deleted": false, "uic": 8733, "secondary_code": "BV" },
-      { "id": "id765", "deleted": false, "uic": 8744, "secondary_code": "BV" },
-      { "id": "id745", "deleted": false, "uic": 8777, "secondary_code": "BV" }
+      { "id": "id744", "uic": 8733, "secondary_code": "BV" },
+      { "id": "id765", "uic": 8744, "secondary_code": "BV" },
+      { "id": "id745", "uic": 8777, "secondary_code": "BV" }
     ],
     "schedule": [
       {
         "at": "id765",
         "arrival": "PT123S",
         "stop_for": "PT120S",
-        "reception_signal": "SHORT_SLIP_STOP",
-        "locked": false
+        "reception_signal": "SHORT_SLIP_STOP"
       },
       {
         "at": "id745",
         "arrival": null,
         "stop_for": "P0D",
-        "reception_signal": "OPEN",
-        "locked": false
+        "reception_signal": "OPEN"
       }
     ],
     "margins": { "boundaries": [], "values": ["0%"] },
@@ -113,17 +109,16 @@
     "rolling_stock_name": "",
     "start_time": "2024-10-15T09:45:43Z",
     "path": [
-      { "id": "id3807", "deleted": false, "track": "TA6", "offset": 8058000 },
-      { "id": "id3822", "deleted": false, "track": "TD0", "offset": 10809000 },
-      { "id": "id3855", "deleted": false, "track": "TG2", "offset": 1686000 }
+      { "id": "id3807", "track": "TA6", "offset": 8058000 },
+      { "id": "id3822", "track": "TD0", "offset": 10809000 },
+      { "id": "id3855", "track": "TG2", "offset": 1686000 }
     ],
     "schedule": [
       {
         "at": "id3855",
         "arrival": null,
         "stop_for": "P0D",
-        "reception_signal": "OPEN",
-        "locked": false
+        "reception_signal": "OPEN"
       }
     ],
     "margins": { "boundaries": [], "values": ["0%"] },
@@ -151,14 +146,12 @@
     "path": [
       {
         "id": "id227",
-        "deleted": false,
         "uic": 8766,
         "secondary_code": "BV",
         "track_reference": null
       },
       {
         "id": "id228",
-        "deleted": false,
         "uic": 8755,
         "secondary_code": "BV",
         "track_reference": null
@@ -169,8 +162,7 @@
         "at": "id228",
         "arrival": "PT421S",
         "stop_for": "P0D",
-        "reception_signal": "OPEN",
-        "locked": false
+        "reception_signal": "OPEN"
       }
     ],
     "margins": {
@@ -209,14 +201,12 @@
           "path": [
             {
               "id": "id227",
-              "deleted": false,
               "uic": 8766,
               "secondary_code": "BV",
               "track_reference": null
             },
             {
               "id": "id228",
-              "deleted": false,
               "uic": 8755,
               "secondary_code": "BV",
               "track_reference": null
@@ -227,8 +217,7 @@
               "at": "id228",
               "arrival": "PT432S",
               "stop_for": "P0D",
-              "reception_signal": "OPEN",
-              "locked": false
+              "reception_signal": "OPEN"
             }
           ],
           "margins": {
@@ -246,16 +235,15 @@
     "rolling_stock_name": "DUAL-MODE_RS_E2E",
     "start_time": "2024-10-17T11:00:00Z",
     "path": [
-      { "id": "id227", "deleted": false, "uic": 8766, "secondary_code": "BV" },
-      { "id": "id228", "deleted": false, "uic": 8755, "secondary_code": "BV" }
+      { "id": "id227", "uic": 8766, "secondary_code": "BV" },
+      { "id": "id228", "uic": 8755, "secondary_code": "BV" }
     ],
     "schedule": [
       {
         "at": "id228",
         "arrival": null,
         "stop_for": "P0D",
-        "reception_signal": "OPEN",
-        "locked": false
+        "reception_signal": "OPEN"
       }
     ],
     "margins": { "boundaries": [], "values": ["0%"] },
@@ -291,20 +279,17 @@
     "path": [
       {
         "id": "8bf52569-50a5-46a5-8e62-b5626460cfba",
-        "deleted": false,
         "uic": 8777,
         "secondary_code": "BV",
         "track_reference": null
       },
       {
         "id": "id2492",
-        "deleted": false,
         "track": "TD0",
         "offset": 11080000
       },
       {
         "id": "3cbdab53-120e-460b-8f4b-e0ecc7cae836",
-        "deleted": false,
         "track": "TI0",
         "offset": 246000
       }
@@ -314,15 +299,13 @@
         "at": "id2492",
         "arrival": null,
         "stop_for": "PT300S",
-        "reception_signal": "STOP",
-        "locked": false
+        "reception_signal": "STOP"
       },
       {
         "at": "3cbdab53-120e-460b-8f4b-e0ecc7cae836",
         "arrival": null,
         "stop_for": "P0D",
-        "reception_signal": "OPEN",
-        "locked": false
+        "reception_signal": "OPEN"
       }
     ],
     "margins": {
@@ -360,20 +343,17 @@
           "path": [
             {
               "id": "id2458",
-              "deleted": false,
               "track": "TG4",
               "offset": 1549000
             },
             {
               "id": "id2570",
-              "deleted": false,
               "uic": 8733,
               "secondary_code": "BV",
               "track_reference": null
             },
             {
               "id": "8369cfc6-e667-4b6b-965a-79795c94dd18",
-              "deleted": false,
               "uic": 8799,
               "secondary_code": "BV",
               "track_reference": null
@@ -384,8 +364,7 @@
               "at": "8369cfc6-e667-4b6b-965a-79795c94dd18",
               "arrival": null,
               "stop_for": "P0D",
-              "reception_signal": "OPEN",
-              "locked": false
+              "reception_signal": "OPEN"
             }
           ],
           "margins": {
@@ -413,33 +392,28 @@
           "path": [
             {
               "id": "id2458",
-              "deleted": false,
               "track": "TG4",
               "offset": 1549000
             },
             {
               "id": "id2659",
-              "deleted": false,
               "uic": 8744,
               "secondary_code": "BV",
               "track_reference": null
             },
             {
               "id": "id2492",
-              "deleted": false,
               "track": "TD0",
               "offset": 11080000
             },
             {
               "id": "id2570",
-              "deleted": false,
               "uic": 8733,
               "secondary_code": "BV",
               "track_reference": null
             },
             {
               "id": "b174dfa7-f6e7-45d9-9545-469a64e675b9",
-              "deleted": false,
               "uic": 8799,
               "secondary_code": "BC",
               "track_reference": null
@@ -450,22 +424,19 @@
               "at": "id2659",
               "arrival": null,
               "stop_for": "PT124S",
-              "reception_signal": "SHORT_SLIP_STOP",
-              "locked": false
+              "reception_signal": "SHORT_SLIP_STOP"
             },
             {
               "at": "id2570",
               "arrival": "PT10554S",
               "stop_for": "PT600S",
-              "reception_signal": "OPEN",
-              "locked": false
+              "reception_signal": "OPEN"
             },
             {
               "at": "b174dfa7-f6e7-45d9-9545-469a64e675b9",
               "arrival": null,
               "stop_for": "P0D",
-              "reception_signal": "OPEN",
-              "locked": false
+              "reception_signal": "OPEN"
             }
           ],
           "margins": {

--- a/front/tests/assets/train-schedule/train_schedules.json
+++ b/front/tests/assets/train-schedule/train_schedules.json
@@ -5,16 +5,15 @@
     "rolling_stock_name": "SLOW_RS_E2E",
     "start_time": "2024-10-17T03:00:00Z",
     "path": [
-      { "id": "id227", "deleted": false, "uic": 8766, "secondary_code": "BV" },
-      { "id": "id228", "deleted": false, "uic": 8755, "secondary_code": "BV" }
+      { "id": "id227", "uic": 8766, "secondary_code": "BV" },
+      { "id": "id228", "uic": 8755, "secondary_code": "BV" }
     ],
     "schedule": [
       {
         "at": "id228",
         "arrival": null,
         "stop_for": "P0D",
-        "reception_signal": "OPEN",
-        "locked": false
+        "reception_signal": "OPEN"
       }
     ],
     "margins": { "boundaries": [], "values": ["0%"] },
@@ -31,25 +30,23 @@
     "rolling_stock_name": "ELECTRIC_RS_E2E",
     "start_time": "2024-10-17T03:15:00Z",
     "path": [
-      { "id": "id477", "deleted": false, "uic": 8722, "secondary_code": "BV" },
-      { "id": "id3522", "deleted": false, "track": "TA1", "offset": 1424000 },
-      { "id": "id498", "deleted": false, "uic": 8744, "secondary_code": "BV" },
-      { "id": "id478", "deleted": false, "uic": 8788, "secondary_code": "BV" }
+      { "id": "id477", "uic": 8722, "secondary_code": "BV" },
+      { "id": "id3522", "track": "TA1", "offset": 1424000 },
+      { "id": "id498", "uic": 8744, "secondary_code": "BV" },
+      { "id": "id478", "uic": 8788, "secondary_code": "BV" }
     ],
     "schedule": [
       {
         "at": "id498",
         "arrival": null,
         "stop_for": "PT120S",
-        "reception_signal": "STOP",
-        "locked": false
+        "reception_signal": "STOP"
       },
       {
         "at": "id478",
         "arrival": null,
         "stop_for": "P0D",
-        "reception_signal": "OPEN",
-        "locked": false
+        "reception_signal": "OPEN"
       }
     ],
     "margins": { "boundaries": [], "values": ["0%"] },
@@ -66,24 +63,22 @@
     "rolling_stock_name": "DUAL-MODE_RS_E2E",
     "start_time": "2024-10-17T05:00:00Z",
     "path": [
-      { "id": "id744", "deleted": false, "uic": 8733, "secondary_code": "BV" },
-      { "id": "id765", "deleted": false, "uic": 8744, "secondary_code": "BV" },
-      { "id": "id745", "deleted": false, "uic": 8777, "secondary_code": "BV" }
+      { "id": "id744", "uic": 8733, "secondary_code": "BV" },
+      { "id": "id765", "uic": 8744, "secondary_code": "BV" },
+      { "id": "id745", "uic": 8777, "secondary_code": "BV" }
     ],
     "schedule": [
       {
         "at": "id765",
         "arrival": "PT123S",
         "stop_for": "PT120S",
-        "reception_signal": "SHORT_SLIP_STOP",
-        "locked": false
+        "reception_signal": "SHORT_SLIP_STOP"
       },
       {
         "at": "id745",
         "arrival": null,
         "stop_for": "P0D",
-        "reception_signal": "OPEN",
-        "locked": false
+        "reception_signal": "OPEN"
       }
     ],
     "margins": { "boundaries": [], "values": ["0%"] },
@@ -100,33 +95,30 @@
     "rolling_stock_name": "ELECTRIC_RS_E2E",
     "start_time": "2024-10-17T05:15:00Z",
     "path": [
-      { "id": "id938", "deleted": false, "uic": 8722, "secondary_code": "BV" },
-      { "id": "id1939", "deleted": false, "track": "TA6", "offset": 10000 },
-      { "id": "id959", "deleted": false, "uic": 8733, "secondary_code": "BV" },
-      { "id": "id964", "deleted": false, "uic": 8744, "secondary_code": "BV" },
-      { "id": "id939", "deleted": false, "uic": 8788, "secondary_code": "BV" }
+      { "id": "id938", "uic": 8722, "secondary_code": "BV" },
+      { "id": "id1939", "track": "TA6", "offset": 10000 },
+      { "id": "id959", "uic": 8733, "secondary_code": "BV" },
+      { "id": "id964", "uic": 8744, "secondary_code": "BV" },
+      { "id": "id939", "uic": 8788, "secondary_code": "BV" }
     ],
     "schedule": [
       {
         "at": "id959",
         "arrival": "PT5400S",
         "stop_for": "PT120S",
-        "reception_signal": "STOP",
-        "locked": false
+        "reception_signal": "STOP"
       },
       {
         "at": "id964",
         "arrival": "PT6300S",
         "stop_for": "PT180S",
-        "reception_signal": "STOP",
-        "locked": false
+        "reception_signal": "STOP"
       },
       {
         "at": "id939",
         "arrival": null,
         "stop_for": "P0D",
-        "reception_signal": "OPEN",
-        "locked": false
+        "reception_signal": "OPEN"
       }
     ],
     "margins": { "boundaries": [], "values": ["0%"] },
@@ -143,24 +135,22 @@
     "rolling_stock_name": "SLOW_RS_E2E",
     "start_time": "2024-10-17T07:30:00Z",
     "path": [
-      { "id": "id1306", "deleted": false, "uic": 8711, "secondary_code": "BV" },
-      { "id": "id1327", "deleted": false, "uic": 8733, "secondary_code": "BV" },
-      { "id": "id1307", "deleted": false, "uic": 8744, "secondary_code": "BV" }
+      { "id": "id1306", "uic": 8711, "secondary_code": "BV" },
+      { "id": "id1327", "uic": 8733, "secondary_code": "BV" },
+      { "id": "id1307", "uic": 8744, "secondary_code": "BV" }
     ],
     "schedule": [
       {
         "at": "id1327",
         "arrival": "PT1320S",
         "stop_for": "PT10S",
-        "reception_signal": "OPEN",
-        "locked": false
+        "reception_signal": "OPEN"
       },
       {
         "at": "id1307",
         "arrival": null,
         "stop_for": "P0D",
-        "reception_signal": "OPEN",
-        "locked": false
+        "reception_signal": "OPEN"
       }
     ],
     "margins": { "boundaries": [], "values": ["0%"] },
@@ -177,24 +167,22 @@
     "rolling_stock_name": "DUAL-MODE_RS_E2E",
     "start_time": "2024-10-17T07:45:00Z",
     "path": [
-      { "id": "id1700", "deleted": false, "uic": 8722, "secondary_code": "BV" },
-      { "id": "id1762", "deleted": false, "uic": 8744, "secondary_code": "BV" },
-      { "id": "id1701", "deleted": false, "uic": 8755, "secondary_code": "BV" }
+      { "id": "id1700", "uic": 8722, "secondary_code": "BV" },
+      { "id": "id1762", "uic": 8744, "secondary_code": "BV" },
+      { "id": "id1701", "uic": 8755, "secondary_code": "BV" }
     ],
     "schedule": [
       {
         "at": "id1762",
         "arrival": "PT3214S",
         "stop_for": null,
-        "reception_signal": "OPEN",
-        "locked": false
+        "reception_signal": "OPEN"
       },
       {
         "at": "id1701",
         "arrival": null,
         "stop_for": "P0D",
-        "reception_signal": "OPEN",
-        "locked": false
+        "reception_signal": "OPEN"
       }
     ],
     "margins": { "boundaries": [], "values": ["0%"] },
@@ -211,17 +199,16 @@
     "rolling_stock_name": "FAST_RS_E2E",
     "start_time": "2024-10-17T08:37:00Z",
     "path": [
-      { "id": "id2121", "deleted": false, "uic": 8722, "secondary_code": "BV" },
-      { "id": "id2175", "deleted": false, "uic": 8733, "secondary_code": "BV" },
-      { "id": "id2122", "deleted": false, "uic": 8777, "secondary_code": "BV" }
+      { "id": "id2121", "uic": 8722, "secondary_code": "BV" },
+      { "id": "id2175", "uic": 8733, "secondary_code": "BV" },
+      { "id": "id2122", "uic": 8777, "secondary_code": "BV" }
     ],
     "schedule": [
       {
         "at": "id2122",
         "arrival": null,
         "stop_for": "P0D",
-        "reception_signal": "OPEN",
-        "locked": false
+        "reception_signal": "OPEN"
       }
     ],
     "margins": { "boundaries": [], "values": ["0%"] },
@@ -238,24 +225,22 @@
     "rolling_stock_name": "SLOW_RS_E2E",
     "start_time": "2024-10-17T08:56:01Z",
     "path": [
-      { "id": "id2532", "deleted": false, "uic": 8766, "secondary_code": "BV" },
-      { "id": "id2550", "deleted": false, "uic": 8755, "secondary_code": "BV" },
-      { "id": "id2533", "deleted": false, "uic": 8744, "secondary_code": "BV" }
+      { "id": "id2532", "uic": 8766, "secondary_code": "BV" },
+      { "id": "id2550", "uic": 8755, "secondary_code": "BV" },
+      { "id": "id2533", "uic": 8744, "secondary_code": "BV" }
     ],
     "schedule": [
       {
         "at": "id2550",
         "arrival": null,
         "stop_for": "PT120S",
-        "reception_signal": "STOP",
-        "locked": false
+        "reception_signal": "STOP"
       },
       {
         "at": "id2533",
         "arrival": null,
         "stop_for": "PT300S",
-        "reception_signal": "STOP",
-        "locked": false
+        "reception_signal": "STOP"
       }
     ],
     "margins": { "boundaries": [], "values": ["0%"] },
@@ -272,16 +257,15 @@
     "rolling_stock_name": "ELECTRIC_RS_E2E",
     "start_time": "2024-10-17T09:35:59Z",
     "path": [
-      { "id": "id2854", "deleted": false, "uic": 8733, "secondary_code": "BV" },
-      { "id": "id2855", "deleted": false, "uic": 8777, "secondary_code": "BV" }
+      { "id": "id2854", "uic": 8733, "secondary_code": "BV" },
+      { "id": "id2855", "uic": 8777, "secondary_code": "BV" }
     ],
     "schedule": [
       {
         "at": "id2855",
         "arrival": "PT297S",
         "stop_for": "P0D",
-        "reception_signal": "OPEN",
-        "locked": false
+        "reception_signal": "OPEN"
       }
     ],
     "margins": { "boundaries": [], "values": ["0%"] },
@@ -298,17 +282,16 @@
     "rolling_stock_name": "DUAL-MODE_RS_E2E",
     "start_time": "2024-10-17T09:45:31Z",
     "path": [
-      { "id": "id3088", "deleted": false, "uic": 8788, "secondary_code": "BV" },
-      { "id": "id3571", "deleted": false, "track": "TD3", "offset": 0 },
-      { "id": "id3089", "deleted": false, "uic": 8744, "secondary_code": "BV" }
+      { "id": "id3088", "uic": 8788, "secondary_code": "BV" },
+      { "id": "id3571", "track": "TD3", "offset": 0 },
+      { "id": "id3089", "uic": 8744, "secondary_code": "BV" }
     ],
     "schedule": [
       {
         "at": "id3089",
         "arrival": null,
         "stop_for": "PT100S",
-        "reception_signal": "OPEN",
-        "locked": false
+        "reception_signal": "OPEN"
       }
     ],
     "margins": { "boundaries": ["id3571"], "values": ["0%", "5min/100km"] },
@@ -325,17 +308,16 @@
     "rolling_stock_name": "",
     "start_time": "2024-10-17T09:45:43Z",
     "path": [
-      { "id": "id3807", "deleted": false, "track": "TA6", "offset": 8058000 },
-      { "id": "id3822", "deleted": false, "track": "TD0", "offset": 10809000 },
-      { "id": "id3855", "deleted": false, "track": "TG2", "offset": 1686000 }
+      { "id": "id3807", "track": "TA6", "offset": 8058000 },
+      { "id": "id3822", "track": "TD0", "offset": 10809000 },
+      { "id": "id3855", "track": "TG2", "offset": 1686000 }
     ],
     "schedule": [
       {
         "at": "id3855",
         "arrival": null,
         "stop_for": "P0D",
-        "reception_signal": "OPEN",
-        "locked": false
+        "reception_signal": "OPEN"
       }
     ],
     "margins": { "boundaries": [], "values": ["0%"] },
@@ -352,18 +334,17 @@
     "rolling_stock_name": "",
     "start_time": "2024-10-17T10:16:03Z",
     "path": [
-      { "id": "id130", "deleted": false, "track": "TX1", "offset": 421000 },
-      { "id": "id219", "deleted": false, "track": "TA6", "offset": 9199000 },
-      { "id": "id3822", "deleted": false, "track": "TD0", "offset": 10809000 },
-      { "id": "id188", "deleted": false, "track": "TF1", "offset": 2486000 }
+      { "id": "id130", "track": "TX1", "offset": 421000 },
+      { "id": "id219", "track": "TA6", "offset": 9199000 },
+      { "id": "id3822", "track": "TD0", "offset": 10809000 },
+      { "id": "id188", "track": "TF1", "offset": 2486000 }
     ],
     "schedule": [
       {
         "at": "id188",
         "arrival": null,
         "stop_for": "P0D",
-        "reception_signal": "OPEN",
-        "locked": false
+        "reception_signal": "OPEN"
       }
     ],
     "margins": { "boundaries": [], "values": ["0%"] },
@@ -380,24 +361,22 @@
     "rolling_stock_name": "SLOW_RS_E2E",
     "start_time": "2024-10-17T10:48:00Z",
     "path": [
-      { "id": "id354", "deleted": false, "uic": 8788, "secondary_code": "BV" },
-      { "id": "id385", "deleted": false, "uic": 8744, "secondary_code": "BV" },
-      { "id": "id355", "deleted": false, "uic": 8711, "secondary_code": "BV" }
+      { "id": "id354", "uic": 8788, "secondary_code": "BV" },
+      { "id": "id385", "uic": 8744, "secondary_code": "BV" },
+      { "id": "id355", "uic": 8711, "secondary_code": "BV" }
     ],
     "schedule": [
       {
         "at": "id385",
         "arrival": "PT776S",
         "stop_for": "PT180S",
-        "reception_signal": "STOP",
-        "locked": false
+        "reception_signal": "STOP"
       },
       {
         "at": "id355",
         "arrival": null,
         "stop_for": "P0D",
-        "reception_signal": "OPEN",
-        "locked": false
+        "reception_signal": "OPEN"
       }
     ],
     "margins": { "boundaries": [], "values": ["0%"] },
@@ -414,16 +393,15 @@
     "rolling_stock_name": "ELECTRIC_RS_E2E",
     "start_time": "2024-10-17T12:10:00Z",
     "path": [
-      { "id": "id803", "deleted": false, "uic": 8777, "secondary_code": "BV" },
-      { "id": "id804", "deleted": false, "uic": 8744, "secondary_code": "BV" }
+      { "id": "id803", "uic": 8777, "secondary_code": "BV" },
+      { "id": "id804", "uic": 8744, "secondary_code": "BV" }
     ],
     "schedule": [
       {
         "at": "id804",
         "arrival": null,
         "stop_for": "P0D",
-        "reception_signal": "OPEN",
-        "locked": false
+        "reception_signal": "OPEN"
       }
     ],
     "margins": { "boundaries": [], "values": ["0%"] },
@@ -440,17 +418,16 @@
     "rolling_stock_name": "IMPROBABLE_RS_E2E",
     "start_time": "2024-10-17T12:30:00Z",
     "path": [
-      { "id": "id1073", "deleted": false, "track": "TA6", "offset": 6609000 },
-      { "id": "id1136", "deleted": false, "track": "TE3", "offset": 1247000 },
-      { "id": "id1109", "deleted": false, "track": "TH1", "offset": 3761000 }
+      { "id": "id1073", "track": "TA6", "offset": 6609000 },
+      { "id": "id1136", "track": "TE3", "offset": 1247000 },
+      { "id": "id1109", "track": "TH1", "offset": 3761000 }
     ],
     "schedule": [
       {
         "at": "id1109",
         "arrival": null,
         "stop_for": "P0D",
-        "reception_signal": "OPEN",
-        "locked": false
+        "reception_signal": "OPEN"
       }
     ],
     "margins": { "boundaries": [], "values": ["0%"] },
@@ -467,24 +444,22 @@
     "rolling_stock_name": "DUAL-MODE_RS_E2E",
     "start_time": "2024-10-17T13:00:00Z",
     "path": [
-      { "id": "id1353", "deleted": false, "uic": 8788, "secondary_code": "BV" },
-      { "id": "id1371", "deleted": false, "uic": 8744, "secondary_code": "BV" },
-      { "id": "id1354", "deleted": false, "uic": 8722, "secondary_code": "BV" }
+      { "id": "id1353", "uic": 8788, "secondary_code": "BV" },
+      { "id": "id1371", "uic": 8744, "secondary_code": "BV" },
+      { "id": "id1354", "uic": 8722, "secondary_code": "BV" }
     ],
     "schedule": [
       {
         "at": "id1371",
         "arrival": null,
         "stop_for": "PT360S",
-        "reception_signal": "OPEN",
-        "locked": false
+        "reception_signal": "OPEN"
       },
       {
         "at": "id1354",
         "arrival": null,
         "stop_for": "P0D",
-        "reception_signal": "OPEN",
-        "locked": false
+        "reception_signal": "OPEN"
       }
     ],
     "margins": { "boundaries": [], "values": ["0%"] },
@@ -501,32 +476,29 @@
     "rolling_stock_name": "ELECTRIC_RS_E2E",
     "start_time": "2024-10-17T14:05:00Z",
     "path": [
-      { "id": "id1572", "deleted": false, "uic": 8722, "secondary_code": "BV" },
-      { "id": "id1593", "deleted": false, "uic": 8733, "secondary_code": "BV" },
-      { "id": "id1598", "deleted": false, "uic": 8744, "secondary_code": "BV" },
-      { "id": "id1573", "deleted": false, "uic": 8788, "secondary_code": "BV" }
+      { "id": "id1572", "uic": 8722, "secondary_code": "BV" },
+      { "id": "id1593", "uic": 8733, "secondary_code": "BV" },
+      { "id": "id1598", "uic": 8744, "secondary_code": "BV" },
+      { "id": "id1573", "uic": 8788, "secondary_code": "BV" }
     ],
     "schedule": [
       {
         "at": "id1593",
         "arrival": null,
         "stop_for": "PT300S",
-        "reception_signal": "OPEN",
-        "locked": false
+        "reception_signal": "OPEN"
       },
       {
         "at": "id1598",
         "arrival": null,
         "stop_for": "PT300S",
-        "reception_signal": "STOP",
-        "locked": false
+        "reception_signal": "STOP"
       },
       {
         "at": "id1573",
         "arrival": "PT6356S",
         "stop_for": "PT146S",
-        "reception_signal": "OPEN",
-        "locked": false
+        "reception_signal": "OPEN"
       }
     ],
     "margins": { "boundaries": [], "values": ["0%"] },
@@ -543,16 +515,15 @@
     "rolling_stock_name": "SLOW_RS_E2E",
     "start_time": "2024-10-17T14:15:08Z",
     "path": [
-      { "id": "id1948", "deleted": false, "uic": 8711, "secondary_code": "BV" },
-      { "id": "id1949", "deleted": false, "uic": 8733, "secondary_code": "BV" }
+      { "id": "id1948", "uic": 8711, "secondary_code": "BV" },
+      { "id": "id1949", "uic": 8733, "secondary_code": "BV" }
     ],
     "schedule": [
       {
         "at": "id1949",
         "arrival": null,
         "stop_for": "P0D",
-        "reception_signal": "OPEN",
-        "locked": false
+        "reception_signal": "OPEN"
       }
     ],
     "margins": { "boundaries": [], "values": ["0%"] },
@@ -569,16 +540,15 @@
     "rolling_stock_name": "",
     "start_time": "2024-10-17T15:55:00Z",
     "path": [
-      { "id": "id3049", "deleted": false, "track": "TG4", "offset": 1604000 },
-      { "id": "id3065", "deleted": false, "track": "TD1", "offset": 13883000 }
+      { "id": "id3049", "track": "TG4", "offset": 1604000 },
+      { "id": "id3065", "track": "TD1", "offset": 13883000 }
     ],
     "schedule": [
       {
         "at": "id3065",
         "arrival": null,
         "stop_for": "P0D",
-        "reception_signal": "OPEN",
-        "locked": false
+        "reception_signal": "OPEN"
       }
     ],
     "margins": { "boundaries": [], "values": ["0%"] },
@@ -595,22 +565,20 @@
     "rolling_stock_name": "ELECTRIC_RS_E2E",
     "start_time": "2024-10-17T15:59:29Z",
     "path": [
-      { "id": "id2078", "deleted": false, "uic": 8766, "secondary_code": "BV" },
-      { "id": "id2124", "deleted": false, "uic": 8744, "secondary_code": "BV" },
-      { "id": "id2129", "deleted": false, "uic": 8733, "secondary_code": "BV" },
-      { "id": "id2079", "deleted": false, "uic": 8722, "secondary_code": "BV" }
+      { "id": "id2078", "uic": 8766, "secondary_code": "BV" },
+      { "id": "id2124", "uic": 8744, "secondary_code": "BV" },
+      { "id": "id2129", "uic": 8733, "secondary_code": "BV" },
+      { "id": "id2079", "uic": 8722, "secondary_code": "BV" }
     ],
     "schedule": [
       {
         "at": "id2124",
         "arrival": "PT1H54S",
-        "locked": false,
         "reception_signal": "OPEN",
         "stop_for": "PT5M"
       },
       {
         "at": "id2129",
-        "locked": false,
         "reception_signal": "STOP",
         "stop_for": "PT10M"
       },
@@ -637,34 +605,29 @@
     "path": [
       {
         "id": "b4df37d0-ffe2-4166-b7b6-8c0c5a47e9b0",
-        "deleted": false,
         "uic": 8777,
         "secondary_code": "BV",
         "track_reference": null
       },
       {
         "id": "id2659",
-        "deleted": false,
         "uic": 8744,
         "secondary_code": "BV",
         "track_reference": null
       },
       {
         "id": "id2492",
-        "deleted": false,
         "track": "TD0",
         "offset": 11080000
       },
       {
         "id": "id2570",
-        "deleted": false,
         "uic": 8733,
         "secondary_code": "BV",
         "track_reference": null
       },
       {
         "id": "dbc7c80b-aee0-4835-8857-63863dae2ff1",
-        "deleted": false,
         "uic": 8799,
         "secondary_code": "BC",
         "track_reference": null
@@ -675,22 +638,19 @@
         "at": "id2659",
         "arrival": null,
         "stop_for": "PT124S",
-        "reception_signal": "SHORT_SLIP_STOP",
-        "locked": false
+        "reception_signal": "SHORT_SLIP_STOP"
       },
       {
         "at": "id2570",
         "arrival": "PT10554S",
         "stop_for": "PT600S",
-        "reception_signal": "OPEN",
-        "locked": false
+        "reception_signal": "OPEN"
       },
       {
         "at": "dbc7c80b-aee0-4835-8857-63863dae2ff1",
         "arrival": null,
         "stop_for": "P0D",
-        "reception_signal": "OPEN",
-        "locked": false
+        "reception_signal": "OPEN"
       }
     ],
     "margins": {


### PR DESCRIPTION
This PR removes unused fields, `deleted` from PathItem and `locked` from ScheduleItem.
Closes #13857 