### PR TITLE
chart: fix issue with secret key for gateway

### DIFF
--- a/chart/templates/gateway/configmap.yaml
+++ b/chart/templates/gateway/configmap.yaml
@@ -10,7 +10,7 @@ data:
     listen_addr = "0.0.0.0"
     port = {{ .Values.services.gateway.service.targetPort }}
     {{- if $config.secret_key }}
-    secret_key = {{ $config.secret_key }}
+    secret_key = "{{ $config.secret_key }}"
     {{- end }}
     trusted_proxies = [{{ range $index, $proxy := $config.trusted_proxies }}{{ if $index }}, {{ end }}"{{ $proxy }}"{{ end }}]
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -137,7 +137,7 @@ services:
         enabled: false
         prefix: "/railway-manager"
         upstream: ""
-      secret_key: "NOT+A+SECRET++NOT+A+SECRET++NOT+A+SECRET++NOT+A+SECRET++NOT+A+SECRET++NOT+A+SECRET++NOT+A+SECRET" # See https://github.com/OpenRailAssociation/osrd/blob/dev/gateway/README.md#config 
+      # secret_key: "NOT+A+SECRET++NOT+A+SECRET++NOT+A+SECRET++NOT+A+SECRET++NOT+A+SECRET++NOT+A+SECRET++NOT+A+SECRET" # See https://github.com/OpenRailAssociation/osrd/blob/dev/gateway/README.md#config 
       tracing:
         enabled: false
         type: ""


### PR DESCRIPTION
Change made in #13514  introduce two bugs which are fixed by this PR:
* a default for secret key was set in values.yaml whch breaks the compatibility with previous versions. I commented it for documentation purpose
* When set, the generated config lacks proper quote to work out of the box. Whereas addinf \" might do the work the UX is improved by putting quote in the template