### PR TITLE
editoast: add group delete command

### DIFF
--- a/editoast/authz/src/lib.rs
+++ b/editoast/authz/src/lib.rs
@@ -389,5 +389,21 @@ mod mock_driver {
                 Ok(false)
             }
         }
+
+        async fn delete_group(&self, group_id: i64) -> Result<bool, Self::Error> {
+            let groups = self.groups.lock().unwrap();
+
+            let group_name = groups
+                .iter()
+                .find_map(|(k, &v)| if v == group_id { Some(k) } else { None });
+
+            if let Some(name) = group_name {
+                let mut groups = self.groups.lock().unwrap();
+                groups.remove(name);
+                Ok(true)
+            } else {
+                Ok(false)
+            }
+        }
     }
 }

--- a/editoast/authz/src/regulator.rs
+++ b/editoast/authz/src/regulator.rs
@@ -96,6 +96,9 @@ pub trait StorageDriver: Clone {
 
     fn delete_user(&self, user_id: i64) -> impl Future<Output = Result<bool, Self::Error>> + Send;
 
+    fn delete_group(&self, group_id: i64)
+    -> impl Future<Output = Result<bool, Self::Error>> + Send;
+
     fn infra_exists(&self, infra_id: i64)
     -> impl Future<Output = Result<bool, Self::Error>> + Send;
 }

--- a/editoast/migrations/2025-10-31-112153_modify_authn_group_delete_trigger/down.sql
+++ b/editoast/migrations/2025-10-31-112153_modify_authn_group_delete_trigger/down.sql
@@ -1,0 +1,3 @@
+create trigger authn_group_delete_trigger before
+delete on authn_group
+for each row execute function delete_associated_authn_subject ();

--- a/editoast/migrations/2025-10-31-112153_modify_authn_group_delete_trigger/up.sql
+++ b/editoast/migrations/2025-10-31-112153_modify_authn_group_delete_trigger/up.sql
@@ -1,0 +1,1 @@
+drop trigger if exists authn_group_delete_trigger on authn_group;

--- a/editoast/src/client/group.rs
+++ b/editoast/src/client/group.rs
@@ -1,5 +1,6 @@
 use anyhow::anyhow;
 use anyhow::bail;
+use authz::Group;
 use clap::Args;
 use clap::Subcommand;
 
@@ -29,6 +30,8 @@ pub enum GroupCommand {
     Include(IncludeArgs),
     /// Remove members to a group
     Exclude(ExcludeArgs),
+    /// Delete a group
+    Delete(DeleteArgs),
 }
 
 #[derive(Debug, Args)]
@@ -57,6 +60,12 @@ pub struct ExcludeArgs {
     group_name: String,
     /// Users to remove
     users: Vec<String>,
+}
+
+#[derive(Debug, Args)]
+pub struct DeleteArgs {
+    /// Group name
+    name: String,
 }
 
 pub async fn create_group(args: CreateArgs, pool: Arc<DbConnectionPoolV2>) -> anyhow::Result<()> {
@@ -176,5 +185,33 @@ pub async fn include_group(
     regulator
         .add_members(&authz::Group(group_id), authz_users)
         .await?;
+    Ok(())
+}
+
+pub async fn delete_group(
+    DeleteArgs { name }: DeleteArgs,
+    openfga_config: OpenfgaConfig,
+    pool: Arc<DbConnectionPoolV2>,
+) -> anyhow::Result<()> {
+    let regulator = openfga_config.into_regulator(pool.clone()).await?;
+    let driver = regulator.driver();
+    let group_id = if let Some(id) = driver.get_group_id(&name).await? {
+        id
+    } else {
+        anyhow::bail!("group '{name}' could not be deleted (not found)");
+    };
+    let group = Group(group_id);
+
+    // Delete the relationships between the group to be deleted and its members
+    let users_in_group = regulator.group_members(&group).await?;
+    regulator.remove_members(&group, &users_in_group).await?;
+
+    let deleted = driver.delete_group(group_id).await?;
+    if deleted {
+        tracing::info!("group '{name}' deleted");
+    } else {
+        anyhow::bail!("group '{name}' could not be deleted (not found)");
+    }
+
     Ok(())
 }

--- a/editoast/src/main.rs
+++ b/editoast/src/main.rs
@@ -208,6 +208,9 @@ async fn run() -> anyhow::Result<()> {
             GroupCommand::Exclude(exclude_args) => {
                 group::exclude_group(exclude_args, openfga_config, Arc::new(db_pool)).await
             }
+            GroupCommand::Delete(delete_args) => {
+                group::delete_group(delete_args, openfga_config, Arc::new(db_pool)).await
+            }
         },
         Commands::User(user_command) => match user_command {
             UserCommand::List(list_args) => {

--- a/editoast/src/models/auth_driver.rs
+++ b/editoast/src/models/auth_driver.rs
@@ -242,10 +242,6 @@ impl StorageDriver for PgAuthDriver {
         Ok(groups)
     }
 
-    async fn infra_exists(&self, infra_id: i64) -> Result<bool, Self::Error> {
-        Ok(Infra::exists(&mut self.pool.get().await?, infra_id).await?)
-    }
-
     #[tracing::instrument(skip_all, fields(%user_id), ret(level = Level::DEBUG), err)]
     async fn delete_user(&self, user_id: i64) -> Result<bool, Self::Error> {
         let conn = self.pool.get().await?;
@@ -253,6 +249,31 @@ impl StorageDriver for PgAuthDriver {
             .execute(&mut conn.write().await)
             .await?;
         Ok(s > 0)
+    }
+
+    #[tracing::instrument(skip_all, fields(%group_id), ret(level = Level::DEBUG), err)]
+    async fn delete_group(&self, group_id: i64) -> Result<bool, Self::Error> {
+        let conn = self.pool.get().await?;
+
+        conn.transaction(|conn| {
+            async move {
+                let s = dsl::delete(authn_group::table.filter(authn_group::id.eq(group_id)))
+                    .execute(&mut conn.write().await)
+                    .await?;
+
+                dsl::delete(authn_subject::table.filter(authn_subject::id.eq(group_id)))
+                    .execute(&mut conn.write().await)
+                    .await?;
+
+                Ok(s > 0)
+            }
+            .scope_boxed()
+        })
+        .await
+    }
+
+    async fn infra_exists(&self, infra_id: i64) -> Result<bool, Self::Error> {
+        Ok(Infra::exists(&mut self.pool.get().await?, infra_id).await?)
     }
 }
 
@@ -382,5 +403,12 @@ mod tests {
             Ok(deleted) => assert!(!deleted, "deleting an unknown user should return false"),
             _ => unreachable!(),
         }
+
+        assert!(
+            driver
+                .delete_group(friends_id)
+                .await
+                .expect("Group 'friend' should be deleted")
+        );
     }
 }


### PR DESCRIPTION
This PR adds a new command to delete a group using editoast CLI.

The authn_group_delete_trigger had to be modified to be ran after the delete operation to avoid an sql error: `tuple to be deleted was already modified by an operation triggered by the current command`

Part of https://github.com/OpenRailAssociation/osrd/issues/13856