### PR TITLE
editoast: telemetry: allow to disable the batch export of spans

### DIFF
--- a/editoast/common/src/tracing.rs
+++ b/editoast/common/src/tracing.rs
@@ -22,6 +22,12 @@ pub struct TracingConfig {
     pub stream: Stream,
     pub telemetry: Option<Telemetry>,
     pub directives: Vec<tracing_subscriber::filter::Directive>,
+    pub span_uploading: SpanUploading,
+}
+
+pub enum SpanUploading {
+    Blocking,
+    BackgroundBatched,
 }
 
 pub fn create_tracing_subscriber<T: SpanExporter + 'static>(
@@ -56,11 +62,16 @@ pub fn create_tracing_subscriber<T: SpanExporter + 'static>(
             let resource = Resource::builder()
                 .with_service_name(telemetry.service_name.clone())
                 .build();
-            let otlp_tracer = opentelemetry_sdk::trace::SdkTracerProvider::builder()
-                .with_batch_exporter(exporter)
-                .with_resource(resource)
-                .build()
-                .tracer("osrd-editoast");
+
+            let otlp_tracer =
+                opentelemetry_sdk::trace::SdkTracerProvider::builder().with_resource(resource);
+            let otlp_tracer = match tracing_config.span_uploading {
+                SpanUploading::Blocking => otlp_tracer.with_simple_exporter(exporter),
+                SpanUploading::BackgroundBatched => otlp_tracer.with_batch_exporter(exporter),
+            }
+            .build()
+            .tracer("osrd-editoast");
+
             let layer = tracing_opentelemetry::OpenTelemetryLayer::new(otlp_tracer);
             opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
             Some(layer)

--- a/editoast/src/main.rs
+++ b/editoast/src/main.rs
@@ -33,6 +33,7 @@ use client::stdcm_search_env_commands::handle_stdcm_search_env_command;
 use client::timetables_commands::*;
 use client::user;
 use client::user::UserCommand;
+use common::tracing::SpanUploading;
 use common::tracing::TracingConfig;
 use common::tracing::create_tracing_subscriber;
 use database::DbConnectionPoolV2;
@@ -106,6 +107,7 @@ async fn run() -> anyhow::Result<()> {
         stream: EditoastMode::from_client(&client).into(),
         telemetry,
         directives: vec![],
+        span_uploading: SpanUploading::BackgroundBatched,
     };
     create_tracing_subscriber(
         tracing_config,

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -16,6 +16,7 @@ use axum::Router;
 use axum_test::TestRequest;
 use axum_test::TestServer;
 use axum_tracing_opentelemetry::middleware::OtelAxumLayer;
+use common::tracing::SpanUploading;
 use common::tracing::Stream;
 use common::tracing::Telemetry;
 use common::tracing::TracingConfig;
@@ -187,6 +188,7 @@ impl TestAppBuilder {
             stream: Stream::Stdout,
             telemetry,
             directives: vec![],
+            span_uploading: SpanUploading::BackgroundBatched,
         };
         let sub = create_tracing_subscriber(
             tracing_config,


### PR DESCRIPTION
Follow-up on [that comment](https://github.com/OpenRailAssociation/osrd/pull/13039#discussion_r2481210678).

Make `common::tracing::create_tracing_subscriber` take an additional parameter that allows to setup tracing to either send spans by batch (as it was always the case previously) or to send them individually in a blocking way.

Disabling batch processing of traces will prevent losing some of them when using `common::tracing` to setup the telemetry for small executables with a limited lifespan (example: executing a CLI binary).

It will be useful for https://github.com/OpenRailAssociation/osrd/pull/13039: otherwise, short-lived processes can exit without ever exporting their spans.