### PR TITLE
edtoast: fga: replace address and port by an url in ConnectionSettings

### DIFF
--- a/editoast/fga/src/client.rs
+++ b/editoast/fga/src/client.rs
@@ -15,6 +15,7 @@ pub use stores::Store;
 
 use tracing::Instrument;
 use tuples::RawTuple;
+use url::Url;
 use uuid::Uuid;
 
 use std::collections::HashMap;
@@ -51,8 +52,7 @@ pub struct Client {
 
 #[derive(Debug, Clone)]
 pub struct ConnectionSettings {
-    address: String,
-    port: u16,
+    url: Url,
     limits: Limits,
 
     /// Whether to reset the store on initialization
@@ -82,10 +82,9 @@ impl Default for Limits {
 }
 
 impl ConnectionSettings {
-    pub fn new(address: String, port: u16, limits: Limits) -> Self {
+    pub fn new(url: Url, limits: Limits) -> Self {
         Self {
-            address,
-            port,
+            url,
             limits,
             reset_store: false,
         }
@@ -906,11 +905,8 @@ impl PreparedDeletes<'_> {
 // of the OpenFGA API documentation: https://openfga.dev/api/service
 
 impl Client {
-    fn base_url(&self) -> url::Url {
-        url::Url::parse(
-            format!("http://{}:{}/", self.settings.address, self.settings.port).as_str(),
-        )
-        .unwrap()
+    fn base_url(&self) -> &url::Url {
+        &self.settings.url
     }
 }
 

--- a/editoast/fga/src/doctest_setup.rs
+++ b/editoast/fga/src/doctest_setup.rs
@@ -1,3 +1,4 @@
+use url::Url;
 use fga::model::Relation as _;
 use fga::client::Limits;
 
@@ -24,5 +25,5 @@ fga::relations! {
 }
 
 fn settings() -> fga::client::ConnectionSettings {
-    fga::client::ConnectionSettings::new("localhost".to_string(), 8091, Limits::default()).reset_store()
+    fga::client::ConnectionSettings::new(Url::parse("http://localhost:8091").unwrap(), Limits::default()).reset_store()
 }

--- a/editoast/fga/src/lib.rs
+++ b/editoast/fga/src/lib.rs
@@ -471,23 +471,24 @@ macro_rules! fga {
 
 #[cfg(any(test, feature = "test_utilities"))]
 pub mod test_utilities {
+    use url::Url;
+
     use super::*;
 
     /// The [client::ConnectionSettings] to use for unit and doc tests
     ///
-    /// Configurable through the `OPENFGA_HOST`, `OPENFGA_PORT`, `OPENFGA_MAX_CHECKS_PER_BATCH_CHECK` and
+    /// Configurable through the `FGA_API_URL`, `OPENFGA_MAX_CHECKS_PER_BATCH_CHECK` and
     /// `OPENFGA_MAX_TUPLES_PER_WRITE` environment variables.
-    /// Defaults to `localhost`, `8091` and OpenFGA default settings.
+    /// Defaults to `http://localhost:8091` and OpenFGA default settings.
     pub fn connection_settings() -> client::ConnectionSettings {
         use client::DEFAULT_OPENFGA_MAX_CHECKS_PER_BATCH_CHECK;
         use client::DEFAULT_OPENFGA_MAX_TUPLES_PER_WRITE;
         use client::Limits;
 
-        let address = std::env::var("OPENFGA_HOST").unwrap_or_else(|_| "localhost".to_string());
-        let port = std::env::var("OPENFGA_PORT")
-            .unwrap_or_else(|_| "8091".to_string())
-            .parse()
-            .expect("invalid port");
+        let openfga_url = Url::parse(
+            &std::env::var("FGA_API_URL").unwrap_or_else(|_| "http://localhost:8091".to_string()),
+        )
+        .expect("invalid FGA_API_URL");
         let max_checks_per_batch_check = std::env::var("OPENFGA_MAX_CHECKS_PER_BATCH_CHECK")
             .map(|tuple_reads| tuple_reads.parse::<u32>().expect("invalid max tuple reads"))
             .unwrap_or(DEFAULT_OPENFGA_MAX_CHECKS_PER_BATCH_CHECK);
@@ -500,8 +501,7 @@ pub mod test_utilities {
             .unwrap_or(DEFAULT_OPENFGA_MAX_TUPLES_PER_WRITE);
 
         client::ConnectionSettings::new(
-            address,
-            port,
+            openfga_url,
             Limits {
                 max_checks_per_batch_check,
                 max_tuples_per_write,

--- a/editoast/src/client/openfga_config.rs
+++ b/editoast/src/client/openfga_config.rs
@@ -46,10 +46,10 @@ impl OpenfgaConfig {
         let config: views::OpenfgaConfig = self.into();
         let mut openfga = {
             tracing::info!(url = %config.url, "connecting to OpenFGA");
-            match fga::Client::try_with_store(&config.store, config.try_as_settings()?).await {
+            match fga::Client::try_with_store(&config.store, config.as_settings()).await {
                 Err(fga::client::InitializationError::NotFound(store)) => {
                     tracing::info!(store, "store not found, creating it");
-                    fga::Client::try_new_store(&store, config.try_as_settings()?).await?
+                    fga::Client::try_new_store(&store, config.as_settings()).await?
                 }
                 result => result?,
             }

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -872,14 +872,13 @@ impl AppState {
                 tracing::info!(url = %openfga_config.url, "connecting to OpenFGA");
                 match fga::Client::try_with_store(
                     &openfga_config.store,
-                    openfga_config.try_as_settings()?,
+                    openfga_config.as_settings(),
                 )
                 .await
                 {
                     Err(fga::client::InitializationError::NotFound(store)) => {
                         tracing::info!(store, "store not found, creating it");
-                        fga::Client::try_new_store(&store, openfga_config.try_as_settings()?)
-                            .await?
+                        fga::Client::try_new_store(&store, openfga_config.as_settings()).await?
                     }
                     result => result?,
                 }
@@ -1000,23 +999,14 @@ impl Server {
 }
 
 impl OpenfgaConfig {
-    pub fn try_as_settings(&self) -> anyhow::Result<fga::client::ConnectionSettings> {
-        let address = self
-            .url
-            .host_str()
-            .ok_or_else(|| anyhow::anyhow!("Configured OpenFGA URL doesn't have a host part"))?;
-        let port = self
-            .url
-            .port_or_known_default()
-            .ok_or_else(|| anyhow::anyhow!("Configured OpenFGA URL doesn't have a port part"))?;
-        Ok(fga::client::ConnectionSettings::new(
-            address.to_owned(),
-            port,
+    pub fn as_settings(&self) -> fga::client::ConnectionSettings {
+        fga::client::ConnectionSettings::new(
+            self.url.clone(),
             Limits {
                 max_checks_per_batch_check: self.max_checks_per_batch_check,
                 max_tuples_per_write: self.max_tuples_per_write,
             },
-        ))
+        )
     }
 }
 

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -236,8 +236,11 @@ impl TestAppBuilder {
         };
         let mut openfga = block_on(fga::Client::try_new_store(
             &store_name,
-            fga::client::ConnectionSettings::new("localhost".to_owned(), 8091, Limits::default())
-                .reset_store(),
+            fga::client::ConnectionSettings::new(
+                Url::parse("http://localhost:8091").unwrap(),
+                Limits::default(),
+            )
+            .reset_store(),
         ))
         .expect("OpenFGA should be setup properly for testing");
         if let Some(model) = self.authorization_model {


### PR DESCRIPTION
`fga::ConnectionSettings` address and port fields are being built from an `url::Url`s. and are later on used to create more `url::Urls`.

Replace those fields by an `url` field for more consistency and to avoid unnecessary transformation steps.