### PR TITLE
editoast: use simplified empty simulation response

### DIFF
--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -1016,56 +1016,11 @@ mod tests {
 
     use axum::http::StatusCode;
     use core_client::mocking::MockingClient;
-    use core_client::simulation::CompleteReportTrain;
-    use core_client::simulation::ElectricalProfiles;
-    use core_client::simulation::ReportTrain;
-    use core_client::simulation::SimulationSuccess;
-    use core_client::simulation::SpeedLimitProperties;
     use database::DbConnectionPoolV2;
-
     use serde_json::json;
 
     use super::test_app::TestAppBuilder;
-
-    fn simulation_response() -> core_client::simulation::Response {
-        core_client::simulation::Response::Success(SimulationSuccess {
-            base: ReportTrain {
-                positions: vec![],
-                times: vec![],
-                speeds: vec![],
-                energy_consumption: 0.0,
-                path_item_times: vec![0, 1000, 2000, 3000],
-            },
-            provisional: ReportTrain {
-                positions: vec![],
-                times: vec![],
-                speeds: vec![],
-                energy_consumption: 0.0,
-                path_item_times: vec![0, 1000, 2000, 3000],
-            },
-            final_output: CompleteReportTrain {
-                report_train: ReportTrain {
-                    positions: vec![0],
-                    times: vec![0],
-                    speeds: vec![],
-                    energy_consumption: 0.0,
-                    path_item_times: vec![0, 1000, 2000, 3000],
-                },
-                signal_critical_positions: vec![],
-                zone_updates: vec![],
-                spacing_requirements: vec![],
-                routing_requirements: vec![],
-            },
-            mrsp: SpeedLimitProperties {
-                boundaries: vec![],
-                values: vec![],
-            },
-            electrical_profiles: ElectricalProfiles {
-                boundaries: vec![],
-                values: vec![],
-            },
-        })
-    }
+    use crate::views::timetable::simulation_empty_response;
 
     #[cfg(test)]
     pub fn mocked_core_pathfinding_and_sim() -> MockingClient {
@@ -1109,8 +1064,8 @@ mod tests {
             .finish();
         core.stub("/standalone_simulation")
             .response(StatusCode::OK)
-            .json(simulation_response())
-            .json(simulation_response())
+            .json(simulation_empty_response())
+            .json(simulation_empty_response())
             .finish();
         core.stub("/signal_projection")
             .response(StatusCode::OK)

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -30,13 +30,7 @@ use core_client::conflict_detection::ConflictType;
 use core_client::conflict_detection::TrainRequirements;
 use core_client::conflict_detection::TrainRequirementsById;
 use core_client::simulation::CompleteReportTrain;
-#[cfg(test)]
-use core_client::simulation::ElectricalProfiles;
 use core_client::simulation::PhysicsConsist;
-#[cfg(test)]
-use core_client::simulation::ReportTrain;
-#[cfg(test)]
-use core_client::simulation::SpeedLimitProperties;
 use database::DbConnection;
 use database::DbConnectionPoolV2;
 use editoast_derive::EditoastError;
@@ -985,26 +979,32 @@ impl From<PhysicsConsistParameters> for PhysicsConsist {
 }
 
 #[cfg(test)]
-fn simulation_empty_response() -> core_client::simulation::Response {
-    core_client::simulation::Response::Success(core_client::simulation::SimulationSuccess {
+pub(in crate::views) fn simulation_empty_response() -> core_client::simulation::Response {
+    use core_client::simulation::CompleteReportTrain;
+    use core_client::simulation::ElectricalProfiles;
+    use core_client::simulation::ReportTrain;
+    use core_client::simulation::SimulationSuccess;
+    use core_client::simulation::SpeedLimitProperties;
+
+    core_client::simulation::Response::Success(SimulationSuccess {
         base: ReportTrain {
             positions: vec![],
-            times: vec![],
+            times: vec![0],
             speeds: vec![],
             energy_consumption: 0.0,
             path_item_times: vec![0, 1],
         },
         provisional: ReportTrain {
             positions: vec![],
-            times: vec![],
+            times: vec![0],
             speeds: vec![],
             energy_consumption: 0.0,
             path_item_times: vec![0, 1],
         },
         final_output: CompleteReportTrain {
             report_train: ReportTrain {
-                positions: vec![],
-                times: vec![],
+                positions: vec![0],
+                times: vec![0],
                 speeds: vec![],
                 energy_consumption: 0.0,
                 path_item_times: vec![0, 1],

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -1323,7 +1323,6 @@ mod tests {
     use core_client::simulation::CompleteReportTrain;
     use core_client::simulation::ElectricalProfiles;
     use core_client::simulation::ReportTrain;
-    use core_client::simulation::SimulationSuccess;
     use core_client::simulation::SpeedLimitProperties;
     use database::DbConnectionPoolV2;
     use editoast_models::prelude::*;
@@ -1681,46 +1680,7 @@ mod tests {
             .assert_status(StatusCode::OK)
             .json_into();
 
-        assert_eq!(
-            response,
-            core_client::simulation::Response::Success(SimulationSuccess {
-                base: ReportTrain {
-                    positions: vec![],
-                    times: vec![],
-                    speeds: vec![],
-                    energy_consumption: 0.0,
-                    path_item_times: vec![0, 1000, 2000, 3000]
-                },
-                provisional: ReportTrain {
-                    positions: vec![],
-                    times: vec![],
-                    speeds: vec![],
-                    energy_consumption: 0.0,
-                    path_item_times: vec![0, 1000, 2000, 3000]
-                },
-                final_output: CompleteReportTrain {
-                    report_train: ReportTrain {
-                        positions: vec![0],
-                        times: vec![0],
-                        speeds: vec![],
-                        energy_consumption: 0.0,
-                        path_item_times: vec![0, 1000, 2000, 3000]
-                    },
-                    signal_critical_positions: vec![],
-                    zone_updates: vec![],
-                    spacing_requirements: vec![],
-                    routing_requirements: vec![]
-                },
-                mrsp: SpeedLimitProperties {
-                    boundaries: vec![],
-                    values: vec![]
-                },
-                electrical_profiles: ElectricalProfiles {
-                    boundaries: vec![],
-                    values: vec![]
-                }
-            })
-        );
+        assert_eq!(response, simulation_empty_response());
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -1763,17 +1723,17 @@ mod tests {
             simulation::Response::Success(SimulationResponseSuccess {
                 base: ReportTrain {
                     positions: vec![],
-                    times: vec![],
+                    times: vec![0],
                     speeds: vec![],
                     energy_consumption: 0.0,
-                    path_item_times: vec![0, 1000, 2000, 3000]
+                    path_item_times: vec![0, 1]
                 },
                 provisional: ReportTrain {
                     positions: vec![],
-                    times: vec![],
+                    times: vec![0],
                     speeds: vec![],
                     energy_consumption: 0.0,
-                    path_item_times: vec![0, 1000, 2000, 3000]
+                    path_item_times: vec![0, 1]
                 },
                 final_output: CompleteReportTrain {
                     report_train: ReportTrain {
@@ -1781,7 +1741,7 @@ mod tests {
                         times: vec![0],
                         speeds: vec![],
                         energy_consumption: 0.0,
-                        path_item_times: vec![0, 1000, 2000, 3000]
+                        path_item_times: vec![0, 1]
                     },
                     signal_critical_positions: vec![],
                     zone_updates: vec![],
@@ -1916,11 +1876,11 @@ mod tests {
             PacedTrainSummaryResponse {
                 paced_train: SummaryResponse::Success {
                     length: 0,
-                    time: 3000,
+                    time: 1,
                     energy_consumption: 0.0,
-                    path_item_times_final: vec![0, 1000, 2000, 3000],
-                    path_item_times_provisional: vec![0, 1000, 2000, 3000],
-                    path_item_times_base: vec![0, 1000, 2000, 3000],
+                    path_item_times_final: vec![0, 1],
+                    path_item_times_provisional: vec![0, 1],
+                    path_item_times_base: vec![0, 1],
                     path_item_positions: vec![0, 1, 2, 3]
                 },
                 exceptions: [(
@@ -1929,11 +1889,11 @@ mod tests {
                     // because all simulation results from core are identical stubs
                     SummaryResponse::Success {
                         length: 0,
-                        time: 3000,
+                        time: 1,
                         energy_consumption: 0.0,
-                        path_item_times_final: vec![0, 1000, 2000, 3000],
-                        path_item_times_provisional: vec![0, 1000, 2000, 3000],
-                        path_item_times_base: vec![0, 1000, 2000, 3000],
+                        path_item_times_final: vec![0, 1],
+                        path_item_times_provisional: vec![0, 1],
+                        path_item_times_base: vec![0, 1],
                         path_item_positions: vec![0, 1, 2, 3]
                     }
                 )]

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -473,7 +473,10 @@ mod tests {
     use axum::http::StatusCode;
     use chrono::DateTime;
     use common::units;
-    use core_client::simulation::SimulationSuccess;
+    use core_client;
+    use core_client::mocking::MockingClient;
+    use core_client::pathfinding::TrainPath;
+    use core_client::simulation::PhysicsConsist;
     use pretty_assertions::assert_eq;
     use rstest::rstest;
     use schemas::fixtures::simple_rolling_stock;
@@ -497,17 +500,10 @@ mod tests {
     use crate::models::fixtures::create_timetable;
     use crate::views::path::pathfinding::PathfindingResult;
     use crate::views::test_app::TestAppBuilder;
+    use crate::views::timetable::simulation_empty_response;
     use crate::views::timetable::stdcm::Request;
     use crate::views::timetable::stdcm::request::PathfindingItem;
     use crate::views::timetable::stdcm::request::StepTimingData;
-    use core_client;
-    use core_client::mocking::MockingClient;
-    use core_client::pathfinding::TrainPath;
-    use core_client::simulation::CompleteReportTrain;
-    use core_client::simulation::ElectricalProfiles;
-    use core_client::simulation::PhysicsConsist;
-    use core_client::simulation::ReportTrain;
-    use core_client::simulation::SpeedLimitProperties;
 
     use super::*;
 
@@ -593,49 +589,9 @@ mod tests {
             .finish();
         core.stub("/standalone_simulation")
             .response(StatusCode::OK)
-            .json(simulation_response())
+            .json(simulation_empty_response())
             .finish();
         core
-    }
-
-    fn simulation_response() -> core_client::simulation::Response {
-        core_client::simulation::Response::Success(SimulationSuccess {
-            base: ReportTrain {
-                positions: vec![],
-                times: vec![],
-                speeds: vec![],
-                energy_consumption: 0.0,
-                path_item_times: vec![0, 10],
-            },
-            provisional: ReportTrain {
-                positions: vec![],
-                times: vec![0, 10],
-                speeds: vec![],
-                energy_consumption: 0.0,
-                path_item_times: vec![0, 10],
-            },
-            final_output: CompleteReportTrain {
-                report_train: ReportTrain {
-                    positions: vec![],
-                    times: vec![],
-                    speeds: vec![],
-                    energy_consumption: 0.0,
-                    path_item_times: vec![0, 10],
-                },
-                signal_critical_positions: vec![],
-                zone_updates: vec![],
-                spacing_requirements: vec![],
-                routing_requirements: vec![],
-            },
-            mrsp: SpeedLimitProperties {
-                boundaries: vec![],
-                values: vec![],
-            },
-            electrical_profiles: ElectricalProfiles {
-                boundaries: vec![],
-                values: vec![],
-            },
-        })
     }
 
     #[test]
@@ -813,7 +769,7 @@ mod tests {
         core.stub("/stdcm")
             .response(StatusCode::OK)
             .json(core_client::stdcm::Response::Success {
-                simulation: simulation_response().success().unwrap(),
+                simulation: simulation_empty_response().success().unwrap(),
                 path: pathfinding_result_success(),
                 departure_time: DateTime::from_str("2024-01-02T00:00:00Z")
                     .expect("Failed to parse datetime"),
@@ -843,7 +799,7 @@ mod tests {
             assert_eq!(
                 stdcm_response,
                 StdcmResponse::Success {
-                    simulation: simulation_response().success().unwrap().into(),
+                    simulation: simulation_empty_response().success().unwrap().into(),
                     pathfinding_result: path,
                     departure_time: DateTime::from_str("2024-01-02T00:00:00Z")
                         .expect("Failed to parse datetime"),
@@ -859,7 +815,7 @@ mod tests {
         core.stub("/stdcm")
             .response(StatusCode::OK)
             .json(core_client::stdcm::Response::Success {
-                simulation: simulation_response().success().unwrap(),
+                simulation: simulation_empty_response().success().unwrap(),
                 path: pathfinding_result_success(),
                 departure_time: DateTime::from_str("2024-01-02T00:00:00Z")
                     .expect("Failed to parse datetime"),
@@ -900,7 +856,7 @@ mod tests {
         core.stub("/stdcm")
             .response(StatusCode::OK)
             .json(core_client::stdcm::Response::Success {
-                simulation: simulation_response().success().unwrap(),
+                simulation: simulation_empty_response().success().unwrap(),
                 path: pathfinding_result_success(),
                 departure_time: DateTime::from_str("2024-01-02T00:00:00Z")
                     .expect("Failed to parse datetime"),
@@ -943,7 +899,7 @@ mod tests {
         core.stub("/stdcm")
             .response(StatusCode::OK)
             .json(core_client::stdcm::Response::Success {
-                simulation: simulation_response().success().unwrap(),
+                simulation: simulation_empty_response().success().unwrap(),
                 path: pathfinding_result_success(),
                 departure_time: DateTime::from_str("2024-01-02T00:00:00Z")
                     .expect("Failed to parse datetime"),
@@ -980,7 +936,7 @@ mod tests {
             assert_eq!(
                 stdcm_response,
                 StdcmResponse::Success {
-                    simulation: simulation_response().success().unwrap().into(),
+                    simulation: simulation_empty_response().success().unwrap().into(),
                     pathfinding_result: path,
                     departure_time: DateTime::from_str("2024-01-02T00:00:00Z")
                         .expect("Failed to parse datetime"),


### PR DESCRIPTION
closes https://github.com/OpenRailAssociation/osrd/issues/13764

Updated the simulation response mock in tests to use a single simplified `simulation_empty_response()` function, reducing redundancy and improving maintainability of tests.