### PR TITLE
editoast: remove unnecessary 'authn_user_delete_trigger'

### DIFF
--- a/editoast/migrations/2025-11-04-110537-0000_remove_authn_user_delete_trigger/down.sql
+++ b/editoast/migrations/2025-11-04-110537-0000_remove_authn_user_delete_trigger/down.sql
@@ -1,0 +1,11 @@
+create function delete_associated_authn_subject()
+returns trigger as $$
+begin
+    delete from authn_subject where id = old.id;
+    return old;
+end;
+$$ language plpgsql;
+
+create trigger authn_user_delete_trigger before
+delete on authn_user
+for each row execute function delete_associated_authn_subject ();

--- a/editoast/migrations/2025-11-04-110537-0000_remove_authn_user_delete_trigger/up.sql
+++ b/editoast/migrations/2025-11-04-110537-0000_remove_authn_user_delete_trigger/up.sql
@@ -1,0 +1,2 @@
+drop trigger if exists authn_user_delete_trigger on authn_user;
+drop function if exists delete_associated_authn_subject;

--- a/editoast/src/models/auth_driver.rs
+++ b/editoast/src/models/auth_driver.rs
@@ -245,10 +245,22 @@ impl StorageDriver for PgAuthDriver {
     #[tracing::instrument(skip_all, fields(%user_id), ret(level = Level::DEBUG), err)]
     async fn delete_user(&self, user_id: i64) -> Result<bool, Self::Error> {
         let conn = self.pool.get().await?;
-        let s = dsl::delete(authn_user::table.filter(authn_user::id.eq(user_id)))
-            .execute(&mut conn.write().await)
-            .await?;
-        Ok(s > 0)
+
+        conn.transaction(|conn| {
+            async move {
+                let s = dsl::delete(authn_user::table.filter(authn_user::id.eq(user_id)))
+                    .execute(&mut conn.write().await)
+                    .await?;
+
+                dsl::delete(authn_subject::table.filter(authn_subject::id.eq(user_id)))
+                    .execute(&mut conn.write().await)
+                    .await?;
+
+                Ok(s > 0)
+            }
+            .scope_boxed()
+        })
+        .await
     }
 
     #[tracing::instrument(skip_all, fields(%group_id), ret(level = Level::DEBUG), err)]


### PR DESCRIPTION
This PR removes the `authn_user_delete_trigger` and its associated function. This is done to be coherent with https://github.com/OpenRailAssociation/osrd/pull/13861#discussion_r2481953103