### PR TITLE
core: fix path with repeated tracks

### DIFF
--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathBuilder.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathBuilder.kt
@@ -5,10 +5,7 @@ import fr.sncf.osrd.path.legacy_objects.ElectricalProfileMapping
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.utils.indexing.DirStaticIdx
 import fr.sncf.osrd.utils.indexing.StaticIdx
-import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Offset
-import fr.sncf.osrd.utils.units.Offset.Companion.max
-import fr.sncf.osrd.utils.units.Offset.Companion.min
 import fr.sncf.osrd.utils.units.meters
 import fr.sncf.osrd.utils.units.sumOffsets
 
@@ -226,32 +223,28 @@ internal fun generateRouteRanges(
     chunks: List<DirChunkRange>,
     routes: List<RouteId>,
 ): List<RouteRange> {
-    val res = mutableListOf<PartialRouteRange>()
-    val mappedChunks = chunks.associateBy { it.value }
-    for (route in routes) {
-        // We look for the first and last point where the route is used by a chunk.
-        // We assume that the chunk list is continuous and follows the route.
-        var usedRouteStart = Offset<Route>(Distance.MAX)
-        var usedRouteEnd = Offset<Route>(0.meters)
-        val chunksOnRoute = rawInfra.getChunksOnRoute(route)
-
-        var chunkOffsetOnRoute = Offset<Route>(0.meters)
-        for (chunk in chunksOnRoute) {
-            mappedChunks[chunk]?.let { locatedChunk ->
-                usedRouteStart =
-                    min(usedRouteStart, chunkOffsetOnRoute + locatedChunk.objectBegin.distance)
-                usedRouteEnd =
-                    max(usedRouteEnd, chunkOffsetOnRoute + locatedChunk.objectEnd.distance)
-            }
-            chunkOffsetOnRoute += rawInfra.getTrackChunkLength(chunk.value).distance
-        }
-
-        val usedRouteLength = usedRouteEnd - usedRouteStart
-        if (usedRouteLength > 0.meters) {
-            res.add(PartialRouteRange(route, usedRouteStart, usedRouteEnd))
+    // This implementation isn't the most optimized as we go over the chunk list several times. But
+    // the "proper" version is quite more verbose and complex. The difficult part is handling a
+    // single route that is partially used both at the start and end of the path.
+    // The profiler hints that this isn't a function worth making more complex for speed.
+    if (routes.isEmpty()) return listOf()
+    val res = mutableListOf<RouteRange>()
+    var routeIndex = 0
+    fun getRouteRange(chunk: DirChunkRange): RouteRange {
+        while (true) {
+            assert(routeIndex < routes.size)
+            val route = routes[routeIndex]
+            val res =
+                chunk.mapOuterObject<RouteId, Route>(route, rawInfra.getChunksOnRoute(route)) {
+                    rawInfra.getTrackChunkLength(it.value)
+                }
+            if (res != null) return res
+            // If not found in the current route, move on to the next
+            routeIndex++
         }
     }
-    return buildRangeList(res)
+    for (chunk in chunks) res.addLinearObjects(listOf(getRouteRange(chunk)))
+    return res
 }
 
 /**

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/GenericLinearRange.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/GenericLinearRange.kt
@@ -14,6 +14,7 @@ import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.Offset.Companion.max
 import fr.sncf.osrd.utils.units.Offset.Companion.min
 import fr.sncf.osrd.utils.units.meters
+import fr.sncf.osrd.utils.units.sumDistances
 
 /**
  * Describes an object range on the train path. Located on both the object itself, and the global
@@ -111,6 +112,32 @@ data class GenericLinearRange<ValueType, OffsetType>(
         return res
     }
 
+    /**
+     * When the given object (`this.value`) is one element in a sequence of smaller objects, this
+     * method turns an inner object range into an outer object range. Returns null if `this` is not
+     * actually part of the outer object. Properly maps path offsets.
+     *
+     * For example, this can turn a block range into a route range.
+     */
+    fun <OuterObjectType, OuterObjectOffset> mapOuterObject(
+        outerObject: OuterObjectType,
+        subObjectList: List<ValueType>,
+        getSubObjectLength: (ValueType) -> Length<OffsetType>,
+    ): GenericLinearRange<OuterObjectType, OuterObjectOffset>? {
+        val thisIndex = subObjectList.indexOf(value)
+        if (thisIndex < 0) return null
+        val thisOffset =
+            Offset<OuterObjectOffset>(
+                subObjectList
+                    .subList(0, thisIndex)
+                    .map { getSubObjectLength(it).distance }
+                    .sumDistances()
+            )
+        val rangeBegin = thisOffset + objectBegin.distance
+        val rangeEnd = thisOffset + objectEnd.distance
+        return GenericLinearRange(outerObject, rangeBegin, rangeEnd, pathBegin, pathEnd)
+    }
+
     /** Maps the value, while keeping all offsets identical. */
     fun <T, NewOffsetType> mapValue(value: T): GenericLinearRange<T, NewOffsetType> {
         return GenericLinearRange(value, objectBegin.cast(), objectEnd.cast(), pathBegin, pathEnd)
@@ -171,6 +198,27 @@ fun <ValueType, OffsetType, SubObjectType, SubObjectOffset> mapSubObjects(
         res.addAll(subRanges)
     }
     return mergeLinearRanges(res)
+}
+
+fun <ValueType, OffsetType> MutableList<GenericLinearRange<ValueType, OffsetType>>.addLinearObjects(
+    elements: List<GenericLinearRange<ValueType, OffsetType>>
+) {
+    for (element in elements) {
+        val prevElement = lastOrNull()
+        if (element.value == prevElement?.value) {
+            assert(element.pathEnd >= prevElement.pathEnd)
+            this[lastIndex] =
+                GenericLinearRange(
+                    prevElement.value,
+                    prevElement.objectBegin,
+                    element.objectEnd,
+                    prevElement.pathBegin,
+                    element.pathEnd,
+                )
+        } else {
+            add(element)
+        }
+    }
 }
 
 // Some extension functions to make `getObjectAbsolutePathEnd` calls less verbose. We could instead


### PR DESCRIPTION
Fix https://github.com/OpenRailAssociation/osrd/issues/13906

We dismiss them, but only later on. This caused errors before then. And TrainPath should be robust to those anyway.

The extra methods in `GenericLinearRange` are taken from a PR in draft, it will be reused. 