### PR TITLE
front: adapt macro for non-symmetric round trip trains

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -18,7 +18,7 @@
         "@ag-media/react-pdf-table": "^2.0.3",
         "@nivo/core": "^0.99.0",
         "@nivo/line": "^0.99.0",
-        "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.0bfdcc959dfc8d4931aed282e40d5dcf066de81d",
+        "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.528956a4709a7c469c7fc00f06fe92ea2c38cf19",
         "@osrd-project/ui-charts": "0.0.1-dev",
         "@osrd-project/ui-core": "0.0.1-dev",
         "@osrd-project/ui-icons": "0.0.1-dev",
@@ -3654,9 +3654,9 @@
       "link": true
     },
     "node_modules/@osrd-project/netzgrafik-frontend": {
-      "version": "0.0.0-snapshot.0bfdcc959dfc8d4931aed282e40d5dcf066de81d",
-      "resolved": "https://registry.npmjs.org/@osrd-project/netzgrafik-frontend/-/netzgrafik-frontend-0.0.0-snapshot.0bfdcc959dfc8d4931aed282e40d5dcf066de81d.tgz",
-      "integrity": "sha512-qqGwy7o7K5e2YTbbr4feor/hCV8kqOrSbxS1r/LuiHthRWtOsi2bJdzZUjxxwdpj0os8bhmutuoqmAhFt4xhZA=="
+      "version": "0.0.0-snapshot.528956a4709a7c469c7fc00f06fe92ea2c38cf19",
+      "resolved": "https://registry.npmjs.org/@osrd-project/netzgrafik-frontend/-/netzgrafik-frontend-0.0.0-snapshot.528956a4709a7c469c7fc00f06fe92ea2c38cf19.tgz",
+      "integrity": "sha512-5CPxVS5qcDQbBpwvt1J1FB9bx9OC6amsKu/48mW1yLlsNJPqJ4AU1hwHsmeGRnCiqlSXDL3AP8rEnCxgI3vs6Q=="
     },
     "node_modules/@osrd-project/storybook": {
       "resolved": "ui/storybook",

--- a/front/package.json
+++ b/front/package.json
@@ -14,7 +14,7 @@
     "@ag-media/react-pdf-table": "^2.0.3",
     "@nivo/core": "^0.99.0",
     "@nivo/line": "^0.99.0",
-    "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.0bfdcc959dfc8d4931aed282e40d5dcf066de81d",
+    "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.528956a4709a7c469c7fc00f06fe92ea2c38cf19",
     "@osrd-project/ui-charts": "0.0.1-dev",
     "@osrd-project/ui-core": "0.0.1-dev",
     "@osrd-project/ui-icons": "0.0.1-dev",

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/osrdToNge.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/osrdToNge.ts
@@ -555,13 +555,22 @@ const getNgeTrainrunSectionsWithNodes = (
           travelTime.consecutiveTime = travelTime.time;
         }
 
+        const backwardTravelTime = { ...DEFAULT_TIME_LOCK };
+        if (sourceArrival.consecutiveTime !== null && targetDeparture.consecutiveTime !== null) {
+          backwardTravelTime.time = sourceArrival.consecutiveTime - targetDeparture.consecutiveTime;
+          backwardTravelTime.consecutiveTime = backwardTravelTime.time;
+        }
+
         const trainrunSection = {
           id: trainrunSectionId,
           sourceNodeId: sourceNode.id,
           sourcePortId: sourcePort.id,
           targetNodeId: targetNode.id,
           targetPortId: targetPort.id,
+          sourceSymmetry: false,
+          targetSymmetry: false,
           travelTime,
+          backwardTravelTime,
           sourceDeparture,
           sourceArrival,
           targetDeparture,

--- a/front/src/applications/operationalStudies/views/Scenario/components/NGE/types.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/NGE/types.ts
@@ -73,11 +73,14 @@ export type TrainrunSectionDto = {
   targetNodeId: number;
   targetPortId: number;
 
+  sourceSymmetry: boolean;
+  targetSymmetry: boolean;
   sourceDeparture: TimeLockDto;
   sourceArrival: TimeLockDto;
   targetDeparture: TimeLockDto;
   targetArrival: TimeLockDto;
   travelTime: TimeLockDto;
+  backwardTravelTime: TimeLockDto;
 
   numberOfStops: number;
 


### PR DESCRIPTION
First draft of non-symmetric macro trains:
- completely disabling symmetry buttons in NGE
- forcing non-symmetry for all trainrun sections
- disabling non-symmetry markers

PR is still in review on NGE-side, but the behavior can already be given to OSRD (since we have ~2 month delay).

- Main PR (OpenRailAssociation - NGE-side): https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/pull/589
- Temporary branch used for OSRD, until above merge (osrd-project - fork-side): https://github.com/osrd-project/netzgrafik-editor-frontend/pull/19

In a later stage, we should bring back the symmetry, but it would probably mean storing the information (`sourceSymmetry` and `targetSymmetry`) at a `PathItem` level. 😨 

Close https://github.com/OpenRailAssociation/osrd/issues/12322
Close https://github.com/osrd-project/osrd-confidential/issues/1228