### PR TITLE
front: use npm install --save=false in dev Dockerfile

### DIFF
--- a/front/docker/Dockerfile.devel
+++ b/front/docker/Dockerfile.devel
@@ -21,4 +21,4 @@ ENV NODE_OPTIONS="--max_old_space_size=4096"
 # Start the app
 COPY docker/dev-entrypoint.sh /
 ENTRYPOINT ["/dev-entrypoint.sh"]
-CMD ["sh", "-c", "id && npm install && (npm run build-ui & npm run start-container)"]
+CMD ["sh", "-c", "id && npm install --save=false && (npm run build-ui & npm run start-container)"]


### PR DESCRIPTION
We don't want to mutate package-lock.json on container startup. Leave it up to the user to run `npm install` explicitly when dependencies are updated, just like our other generated files.

Helps with behavioral differences between npm v10 and v11.

`npm clean-install` would work too, but nukes node_modules/ which makes it more expensive.