### PR TITLE
editoast: similar trains

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -3042,12 +3042,7 @@ paths:
               required:
               - rolling_stock
               - waypoints
-              - infra_id
-              - timetable_id
               properties:
-                infra_id:
-                  type: integer
-                  format: int64
                 rolling_stock:
                   type: object
                   properties:
@@ -3059,9 +3054,6 @@ paths:
                       type:
                       - string
                       - 'null'
-                timetable_id:
-                  type: integer
-                  format: int64
                 waypoints:
                   type: array
                   items:
@@ -6313,11 +6305,10 @@ components:
       - $ref: '#/components/schemas/EditoastSearchApiErrorObjectType'
       - $ref: '#/components/schemas/EditoastSearchApiErrorSearchEngineError'
       - $ref: '#/components/schemas/EditoastSimilarTrainsErrorDatabase'
-      - $ref: '#/components/schemas/EditoastSimilarTrainsErrorInfraNotFound'
+      - $ref: '#/components/schemas/EditoastSimilarTrainsErrorEmptyTrainsTraffic'
       - $ref: '#/components/schemas/EditoastSimilarTrainsErrorInvalidPath'
       - $ref: '#/components/schemas/EditoastSimilarTrainsErrorRollingStockNotFound'
       - $ref: '#/components/schemas/EditoastSimilarTrainsErrorSpeedLimitNotFound'
-      - $ref: '#/components/schemas/EditoastSimilarTrainsErrorTimetableNotFound'
       - $ref: '#/components/schemas/EditoastSpriteErrorsFileNotFound'
       - $ref: '#/components/schemas/EditoastSpriteErrorsUnknownSignalingSystem'
       - $ref: '#/components/schemas/EditoastStdcmErrorDatabase'
@@ -7710,7 +7701,7 @@ components:
           type: string
           enum:
           - editoast:timetable:similar_trains:Database
-    EditoastSimilarTrainsErrorInfraNotFound:
+    EditoastSimilarTrainsErrorEmptyTrainsTraffic:
       type: object
       required:
       - type
@@ -7719,11 +7710,6 @@ components:
       properties:
         context:
           type: object
-          required:
-          - infra_id
-          properties:
-            infra_id:
-              type: integer
         message:
           type: string
         status:
@@ -7733,7 +7719,7 @@ components:
         type:
           type: string
           enum:
-          - editoast:timetable:similar_trains:InfraNotFound
+          - editoast:timetable:similar_trains:EmptyTrainsTraffic
     EditoastSimilarTrainsErrorInvalidPath:
       type: object
       required:
@@ -7801,30 +7787,6 @@ components:
           type: string
           enum:
           - editoast:timetable:similar_trains:SpeedLimitNotFound
-    EditoastSimilarTrainsErrorTimetableNotFound:
-      type: object
-      required:
-      - type
-      - status
-      - message
-      properties:
-        context:
-          type: object
-          required:
-          - timetable_id
-          properties:
-            timetable_id:
-              type: integer
-        message:
-          type: string
-        status:
-          type: integer
-          enum:
-          - 404
-        type:
-          type: string
-          enum:
-          - editoast:timetable:similar_trains:TimetableNotFound
     EditoastSpriteErrorsFileNotFound:
       type: object
       required:

--- a/editoast/src/client/mod.rs
+++ b/editoast/src/client/mod.rs
@@ -12,6 +12,7 @@ pub mod search_commands;
 pub mod stdcm_search_env_commands;
 mod telemetry_config;
 pub mod timetables_commands;
+mod trains_traffic;
 pub mod user;
 mod valkey_config;
 

--- a/editoast/src/client/runserver.rs
+++ b/editoast/src/client/runserver.rs
@@ -1,10 +1,15 @@
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use chrono::Duration;
 use clap::Args;
+use tokio::sync::RwLock;
+use tracing::Instrument;
 use url::Url;
 
+use crate::client::trains_traffic;
 use crate::views;
+use crate::views::timetable::similar_trains::trains_traffic::TrainsTrafficPool;
 
 use super::PostgresConfig;
 use super::ValkeyConfig;
@@ -52,6 +57,8 @@ pub struct RunserverArgs {
     /// The timeout to use when performing the healthcheck, in milliseconds
     #[clap(long, env = "EDITOAST_HEALTH_CHECK_TIMEOUT_MS", default_value_t = 1000)]
     health_check_timeout_ms: u64,
+    #[clap(long, env = "EDITOAST_TRAINS_TRAFFIC_PATH")]
+    trains_traffic_path: Option<PathBuf>,
 }
 
 /// Create and run the server
@@ -72,12 +79,20 @@ pub async fn runserver(
         health_check_timeout_ms,
         root_url,
         dynamic_assets_path,
+        trains_traffic_path,
     }: RunserverArgs,
     postgres: PostgresConfig,
     valkey_config: ValkeyConfig,
     openfga: OpenfgaConfig,
     app_version: Option<String>,
 ) -> anyhow::Result<()> {
+    let trains_traffic = Arc::new(RwLock::new(TrainsTrafficPool::new()));
+    if let Some(traffic_file) = trains_traffic_path.clone() {
+        tokio::spawn({
+            let trains_traffic = Arc::clone(&trains_traffic);
+            async move { trains_traffic::import_trains_traffic(trains_traffic, traffic_file).await }
+        }.in_current_span());
+    }
     let config = views::ServerConfig {
         port,
         address,
@@ -99,6 +114,7 @@ pub async fn runserver(
         root_url,
         dynamic_assets_path,
         app_version,
+        trains_traffic,
     };
 
     let server = views::Server::new(config).await?;

--- a/editoast/src/client/trains_traffic.rs
+++ b/editoast/src/client/trains_traffic.rs
@@ -1,0 +1,111 @@
+use crate::views::timetable::similar_trains::trains_traffic::TrainOperationalPoint;
+use crate::views::timetable::similar_trains::trains_traffic::TrainTraffic;
+use crate::views::timetable::similar_trains::trains_traffic::TrainsTrafficPool;
+use chrono::NaiveDate;
+use chrono::Utc;
+use serde::Deserialize;
+use std::fs::File;
+use std::io::BufRead;
+use std::io::BufReader;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Instant;
+use tokio::sync::RwLock;
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct JsonTrainTraffic {
+    pub train_name: String,
+    pub date: NaiveDate,
+    pub operational_points: Vec<TrainOperationalPoint>,
+    pub rolling_stock_name: String,
+    pub speed_limit_tag: String,
+}
+
+/// Read the  given file and do the import
+#[tracing::instrument(skip_all, level = "info", err, name = "train traffic")]
+pub async fn import_trains_traffic(
+    trains_traffic: Arc<RwLock<TrainsTrafficPool>>,
+    file_path: PathBuf,
+) -> anyhow::Result<()> {
+    let now = Instant::now();
+    let mut traffic = trains_traffic.write().await;
+    // Open the file and read it
+    let file = File::open(file_path.as_path())?;
+    let reader = BufReader::new(file);
+
+    // Read each line from the file, we have a train
+    for (index, line_result) in reader.lines().enumerate() {
+        let line = line_result?;
+        if !line.is_empty() {
+            let json_train: JsonTrainTraffic = serde_json::from_str::<JsonTrainTraffic>(&line)
+                .map_err(|err| {
+                    anyhow::anyhow!(
+                        "Failed to parse train traffic on line {}: {}",
+                        index + 1,
+                        err
+                    )
+                })?;
+            traffic
+                .add_train_traffic(TrainTraffic::new(
+                    index,
+                    json_train.train_name,
+                    json_train
+                        .date
+                        .and_hms_opt(0, 0, 0)
+                        .unwrap()
+                        .and_local_timezone(Utc)
+                        .unwrap(),
+                    json_train.rolling_stock_name,
+                    json_train.speed_limit_tag,
+                    json_train.operational_points,
+                ))
+                .map_err(|err| anyhow::anyhow!("Failed to add train traffic: {}", err))?;
+        }
+    }
+
+    tracing::Span::current().record("traffic_imported", traffic.len());
+    tracing::info!(
+        "Loading {:?} train traffics in {:?}",
+        traffic.len(),
+        now.elapsed()
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+pub mod tests {
+    use std::path::PathBuf;
+    use std::str::FromStr;
+    use std::sync::Arc;
+
+    use chrono::DateTime;
+    use chrono::Utc;
+    use tokio::sync::RwLock;
+
+    use crate::client::trains_traffic::import_trains_traffic;
+    use crate::views::timetable::similar_trains::trains_traffic::TrainsTrafficPool;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn load_traffic_file() {
+        let valid_traffic_date =
+            DateTime::<Utc>::from_str("2025-03-01T00:00:00Z").expect("Date should be valid");
+
+        let trains_traffic = Arc::new(RwLock::new(TrainsTrafficPool::new_with_date(
+            valid_traffic_date,
+        )));
+
+        // Test file has 3 train with the same path : A -> B -> C (stop)-> D (stop)
+        // And one train is outdated
+        import_trains_traffic(
+            Arc::clone(&trains_traffic),
+            PathBuf::from("src/tests/train-traffic.ndjson"),
+        )
+        .await
+        .expect("Failed to import train traffic file");
+
+        let traffic = trains_traffic.read().await;
+
+        // Checking that train traffic are loaded
+        assert_eq!(traffic.len(), 2);
+    }
+}

--- a/editoast/src/tests/train-traffic.ndjson
+++ b/editoast/src/tests/train-traffic.ndjson
@@ -1,0 +1,3 @@
+{"train_name": "TEST_123", "date": "2025-03-26", "rolling_stock_name": "RS_V1", "speed_limit_tag": "MA100", "operational_points": [{"id": "A"}, {"id": "B"}, {"id": "C", "stop":true}, {"id": "D", "stop":true}]}
+{"train_name": "TEST_321",  "date": "2025-07-14", "rolling_stock_name": "RS_V2", "speed_limit_tag": "MA100", "operational_points": [{"id": "A"}, {"id": "B"}, {"id": "C", "stop":true}, {"id": "D", "stop":true}]}
+{"train_name": "OUTDATED",  "date": "2025-02-01", "rolling_stock_name": "RS_V2", "speed_limit_tag": "MA100", "operational_points": [{"id": "A"}, {"id": "B"}, {"id": "C","stop":true}, {"id": "D", "stop":true}]}

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -41,6 +41,7 @@ use std::collections::HashSet;
 use std::env;
 use std::path::PathBuf;
 use std::sync::Arc;
+use tokio::sync::RwLock;
 
 use ::authz::Authorizer;
 use ::authz::Role;
@@ -236,7 +237,7 @@ fn service_router() -> router::DocumentedRouter {
                     })
             })
             .route(
-                "/similar_trains", // TODO: put under /timetable
+                "/similar_trains",
                 post!(timetable::similar_trains::similar_trains),
             )
             .nests("/train_schedule", |path| {
@@ -828,6 +829,7 @@ pub struct ServerConfig {
     pub root_url: Url,
     pub dynamic_assets_path: PathBuf,
     pub app_version: Option<String>,
+    pub trains_traffic: Arc<RwLock<timetable::similar_trains::trains_traffic::TrainsTrafficPool>>,
 }
 
 pub struct Server {
@@ -851,6 +853,7 @@ pub struct AppState {
     pub core_client: Arc<CoreClient>,
     pub health_check_timeout: Duration,
     pub regulator: Regulator,
+    pub trains_traffic: Arc<RwLock<timetable::similar_trains::trains_traffic::TrainsTrafficPool>>,
 }
 
 impl FromRef<AppState> for Arc<DbConnectionPoolV2> {
@@ -949,7 +952,7 @@ impl AppState {
         let (db_pool, core_client, openfga) = tokio::try_join!(
             async { db_pool_fut.await? },
             async { core_client_fut.await? },
-            async { openfga_fut.await? }
+            async { openfga_fut.await? },
         )?;
 
         Ok(Self {
@@ -961,6 +964,7 @@ impl AppState {
             map_layers: Arc::new(MapLayers::default()),
             speed_limit_tag_ids,
             health_check_timeout: config.health_check_timeout,
+            trains_traffic: config.trains_traffic.clone(),
             config: Arc::new(config),
         })
     }

--- a/editoast/src/views/path/path_item_cache.rs
+++ b/editoast/src/views/path/path_item_cache.rs
@@ -162,31 +162,6 @@ impl PathItemCache {
         self.track_ids_to_name.contains_key(track)
     }
 
-    pub fn get_from_path_location(
-        &self,
-        path_item: &PathItemLocation,
-    ) -> Option<Vec<&OperationalPointModel>> {
-        match path_item {
-            PathItemLocation::TrackOffset(_) => None,
-            PathItemLocation::OperationalPointReference(OperationalPointReference {
-                operational_point:
-                    OperationalPointIdentifier::OperationalPointId {
-                        operational_point, ..
-                    },
-                ..
-            }) => self.get_from_id(&operational_point.0).map(|op| vec![op]),
-            PathItemLocation::OperationalPointReference(OperationalPointReference {
-                operational_point:
-                    OperationalPointIdentifier::OperationalPointDescription { trigram, .. },
-                ..
-            }) => self.get_from_trigram(&trigram.0).map(|op| op.collect()),
-            PathItemLocation::OperationalPointReference(OperationalPointReference {
-                operational_point: OperationalPointIdentifier::OperationalPointUic { uic, .. },
-                ..
-            }) => self.get_from_uic(*uic).map(|op| op.collect()),
-        }
-    }
-
     /// Retrieve the operational point ID given a reference
     pub fn get_op_ref_id(&self, op_ref: &OperationalPointIdentifier) -> Option<String> {
         let (ops, secondary_code) = match op_ref {
@@ -212,19 +187,6 @@ impl PathItemCache {
             .into_iter()
             .next()
             .map(|op| op.obj_id.clone())
-    }
-
-    /// Retrieve an operational point identifier from a path item location using the cache
-    pub fn op_identifier(&self, path_item: &PathItemLocation) -> Option<String> {
-        if let PathItemLocation::OperationalPointReference(OperationalPointReference {
-            operational_point,
-            ..
-        }) = path_item
-        {
-            self.get_op_ref_id(operational_point)
-        } else {
-            None
-        }
     }
 
     /// Extract locations from path items

--- a/editoast/src/views/path/properties.rs
+++ b/editoast/src/views/path/properties.rs
@@ -11,21 +11,15 @@ use axum::extract::Json;
 use axum::extract::Path;
 use axum::extract::State;
 use common::geometry::GeoJsonLineString;
-use core_client::AsCoreRequest;
-use core_client::CoreClient;
 use core_client::path_properties::OperationalPointOnPath;
 use core_client::path_properties::PathPropertiesRequest;
 use core_client::path_properties::PropertyElectrificationValues;
 use core_client::path_properties::PropertyValuesF64;
 use core_client::path_properties::PropertyZoneValues;
 use core_client::pathfinding::TrackRange;
-use itertools::Either;
-use itertools::Itertools;
 use serde::Deserialize;
 use serde::Serialize;
-use std::collections::hash_map::DefaultHasher;
 use std::hash::Hash;
-use std::hash::Hasher;
 use std::sync::Arc;
 use utoipa::ToSchema;
 
@@ -122,104 +116,6 @@ pub(in crate::views) async fn post(
     .await?;
 
     Ok(Json(PathProperties::from(path_properties)))
-}
-
-/// Retrieves path properties from cache.
-#[tracing::instrument(skip_all, err)]
-async fn retrieve_path_properties_from_cache<'a>(
-    conn: &mut cache::Connection,
-    requests: &'a [PathPropertiesRequest<'a>],
-    app_version: Option<&str>,
-) -> Result<
-    impl Iterator<
-        Item = (
-            &'a PathPropertiesRequest<'a>,
-            Option<core_client::path_properties::PathPropertiesResponse>,
-        ),
-    >,
-> {
-    let keys = requests
-        .iter()
-        .map(|req| path_properties_input_hash(req, app_version))
-        .collect_vec();
-    // required to collect because json_get_bulk takes a slice...
-    let cached = conn.json_get_bulk(&keys).await?.collect_vec();
-    Ok(requests.iter().zip(cached.into_iter()))
-}
-
-/// Set the cache of path properties.
-#[tracing::instrument(skip_all, err)]
-async fn cache_path_properties<'a>(
-    conn: &mut cache::Connection,
-    properties: impl IntoIterator<
-        Item = (
-            &'a PathPropertiesRequest<'a>,
-            &'a core_client::path_properties::PathPropertiesResponse,
-        ),
-    >,
-    app_version: Option<&str>,
-) -> Result<()> {
-    let data = properties
-        .into_iter()
-        .map(|(req, resp)| (path_properties_input_hash(req, app_version), resp))
-        .collect_vec();
-    conn.json_set_bulk(&data).await.map_err(Into::into)
-}
-
-/// Compute path properties input hash without supported electrifications
-fn path_properties_input_hash(
-    path_properties_request: &PathPropertiesRequest<'_>,
-    app_version: Option<&str>,
-) -> String {
-    let osrd_version = app_version.unwrap_or_default();
-    let mut hasher = DefaultHasher::new();
-    path_properties_request
-        .track_section_ranges
-        .hash(&mut hasher);
-    let hash_track_ranges = hasher.finish();
-    format!(
-        "path_properties.{osrd_version}.{infra}.{infra_version}.{hash_track_ranges}",
-        infra = path_properties_request.infra,
-        infra_version = path_properties_request.expected_version
-    )
-}
-
-#[tracing::instrument(skip_all, err)]
-pub(in crate::views) async fn compute_path_properties_batch(
-    core_client: Arc<CoreClient>,
-    conn: &mut cache::Connection,
-    requests: &[PathPropertiesRequest<'_>],
-    app_version: Option<&str>,
-) -> Result<impl Iterator<Item = core_client::path_properties::PathPropertiesResponse>> {
-    let (cached, to_compute): (Vec<_>, Vec<_>) =
-        retrieve_path_properties_from_cache(conn, requests, app_version)
-            .await?
-            .partition_map(|(req, res)| match res {
-                Some(res) => Either::Left(res),
-                None => Either::Right(req),
-            });
-
-    tracing::debug!(
-        hit = cached.len(),
-        miss = to_compute.len(),
-        "retrieved path properties from cache"
-    );
-
-    let futures = to_compute.iter().map(|req| req.fetch(&core_client));
-    let computed = futures::future::try_join_all(futures).await?;
-
-    tracing::debug!(computed = computed.len(), "computed path properties");
-
-    cache_path_properties(
-        conn,
-        to_compute.into_iter().zip(computed.iter()),
-        app_version,
-    )
-    .await?;
-
-    tracing::debug!("cached path properties");
-
-    Ok(cached.into_iter().chain(computed.into_iter()))
 }
 
 #[cfg(test)]

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
+use tokio::sync::RwLock;
 
 use authz::InfraGrant;
 use authz::Role;
@@ -39,6 +40,8 @@ use crate::generated_data::speed_limit_tags_config::SpeedLimitTagIds;
 use crate::infra_cache::InfraCache;
 use crate::models::PgAuthDriver;
 use crate::views::service_router;
+use crate::views::timetable::similar_trains::trains_traffic::TrainTraffic;
+use crate::views::timetable::similar_trains::trains_traffic::TrainsTrafficPool;
 use editoast_models::map::MapLayers;
 use fga::client::DEFAULT_OPENFGA_MAX_CHECKS_PER_BATCH_CHECK;
 use fga::client::DEFAULT_OPENFGA_MAX_TUPLES_PER_WRITE;
@@ -85,6 +88,7 @@ pub(crate) struct TestAppBuilder {
     enable_authorization: bool,
     enable_telemetry: bool,
     root_url: Option<Url>,
+    trains_traffic: TrainsTrafficPool,
 }
 
 impl TestAppBuilder {
@@ -96,6 +100,7 @@ impl TestAppBuilder {
             enable_authorization: false,
             enable_telemetry: true,
             root_url: None,
+            trains_traffic: TrainsTrafficPool::new(),
         }
     }
 
@@ -124,6 +129,19 @@ impl TestAppBuilder {
 
     pub fn root_url(mut self, root_url: Url) -> Self {
         self.root_url = Some(root_url);
+        self
+    }
+
+    pub fn with_trains_traffic(mut self, trains_traffic: Vec<TrainTraffic>) -> Self {
+        for train in trains_traffic {
+            if let Err(e) = self.trains_traffic.add_train_traffic(train) {
+                panic!("Failed to add train traffic: {:?}", e);
+            }
+        }
+        tracing::debug!(
+            nb_traffic = self.trains_traffic.len(),
+            "Train traffic loaded"
+        );
         self
     }
 
@@ -164,6 +182,7 @@ impl TestAppBuilder {
                 max_checks_per_batch_check: DEFAULT_OPENFGA_MAX_CHECKS_PER_BATCH_CHECK,
                 max_tuples_per_write: DEFAULT_OPENFGA_MAX_TUPLES_PER_WRITE,
             },
+            trains_traffic: Arc::new(RwLock::new(self.trains_traffic)),
         };
 
         // Setup tracing
@@ -247,6 +266,7 @@ impl TestAppBuilder {
             map_layers: Arc::new(MapLayers::default()),
             speed_limit_tag_ids,
             health_check_timeout: config.health_check_timeout,
+            trains_traffic: config.trains_traffic.clone(),
             config: Arc::new(config),
         };
 

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -1,6 +1,6 @@
 mod occupancy_blocks;
 pub mod paced_train;
-pub(in crate::views) mod similar_trains;
+pub mod similar_trains;
 pub mod simulation;
 pub mod stdcm;
 mod track_occupancy;

--- a/editoast/src/views/timetable/similar_trains.rs
+++ b/editoast/src/views/timetable/similar_trains.rs
@@ -17,11 +17,11 @@
 mod graph;
 mod new_train;
 mod past_train;
+pub mod trains_traffic;
 
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::ops::Deref;
-use std::sync::Arc;
 
 use arcstr::ArcStr;
 use authz::Role;
@@ -30,29 +30,20 @@ use axum::Json;
 use axum::extract::State;
 use chrono::DateTime;
 use chrono::Utc;
-use core_client::CoreClient;
-use core_client::path_properties::OperationalPointOnPath;
-use core_client::path_properties::PathPropertiesRequest;
 use database::DbConnection;
 use derive_more::Deref;
 use derive_more::Display;
 use editoast_derive::EditoastError;
-use itertools::Itertools as _;
 use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
 
 use crate::error::Result;
 use crate::generated_data::speed_limit_tags_config::SpeedLimitTagIds;
-use crate::models;
-use crate::models::Infra;
 use crate::models::RollingStock;
-use crate::models::timetable::Timetable;
-use crate::views::path::path_item_cache::PathItemCache;
-use crate::views::path::pathfinding::PathfindingResult;
-use crate::views::path::pathfinding_from_train_batch;
 use crate::views::timetable::similar_trains::graph::AdvancementError;
 use crate::views::timetable::similar_trains::graph::AdvancementErrorKind;
+use crate::views::timetable::similar_trains::past_train::PastTrain;
 use editoast_models::prelude::*;
 
 use super::AppState;
@@ -98,8 +89,8 @@ impl Serialize for RollingStockCharacteristics {
     }
 }
 
-#[derive(Clone, Deserialize, ToSchema)]
-#[cfg_attr(test, derive(PartialEq, Serialize))]
+#[cfg_attr(test, derive(Serialize))]
+#[derive(Clone, Deserialize, Hash, Eq, PartialEq, ToSchema)]
 #[schema(as = SimilarTrainWaypoint)]
 struct Waypoint {
     #[schema(value_type = String)]
@@ -119,8 +110,6 @@ pub(in crate::views) struct Request {
     #[schema(inline)]
     rolling_stock: RollingStockCharacteristics,
     waypoints: Vec<Waypoint>,
-    infra_id: i64,
-    timetable_id: i64,
 }
 
 #[derive(Debug, Serialize, ToSchema)]
@@ -157,14 +146,6 @@ enum SimilarTrainsError {
     #[editoast_error(status = 400)]
     InvalidPath(#[from] new_train::InvalidTrain),
 
-    #[error("Infra '{infra_id}' not found")]
-    #[editoast_error(status = 404)]
-    InfraNotFound { infra_id: i64 },
-
-    #[error("Timetable '{timetable_id}' not found")]
-    #[editoast_error(status = 404)]
-    TimetableNotFound { timetable_id: i64 },
-
     #[error("Rolling stock '{rolling_stock_name}' does not exist")]
     #[editoast_error(status = 404)]
     RollingStockNotFound { rolling_stock_name: String },
@@ -172,6 +153,10 @@ enum SimilarTrainsError {
     #[error("Speed limit tag '{speed_limit_tag}' does not exist")]
     #[editoast_error(status = 404)]
     SpeedLimitNotFound { speed_limit_tag: String },
+
+    #[error("Trains traffic is empty")]
+    #[editoast_error(status = 404)]
+    EmptyTrainsTraffic,
 
     #[error("Database error")]
     #[editoast_error(status = 500)]
@@ -197,16 +182,12 @@ pub(in crate::views) async fn similar_trains(
     State(AppState {
         db_pool,
         speed_limit_tag_ids,
-        valkey_client,
-        core_client,
-        config,
+        trains_traffic,
         ..
     }): State<AppState>,
     Json(Request {
         rolling_stock,
         waypoints,
-        infra_id,
-        timetable_id,
     }): Json<Request>,
 ) -> Result<Json<Response>> {
     let authorized = auth
@@ -217,32 +198,24 @@ pub(in crate::views) async fn similar_trains(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    auth.check_authorization(async |authorizer| {
-        authorizer
-            .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanRead)
-            .await
-    })
-    .await?;
-
     let mut conn = db_pool.get().await?;
+
+    // Get trains traffic
+    let traffic = trains_traffic.read().await;
+    // If the train traffic is empty, finding a similar train is not possible
+    if traffic.len() == 0 {
+        return Err(SimilarTrainsError::EmptyTrainsTraffic.into());
+    }
 
     // Step 1: input validation and preprocessing
     // ------------------------------------------
-
     validate_rolling_stock_input(&mut conn, &rolling_stock, &speed_limit_tag_ids).await?;
 
-    if !Timetable::exists(&mut conn, timetable_id).await? {
-        return Err(SimilarTrainsError::TimetableNotFound { timetable_id }.into());
-    }
-
-    let infra = Infra::retrieve_or_fail(conn.clone(), infra_id, || {
-        SimilarTrainsError::InfraNotFound { infra_id }
-    })
-    .await?;
-
+    // Step 2: create a new train instance
+    // -----------------------------------
     let waypoints = squash_successive_waypoints(waypoints);
     let wp_count = waypoints.len();
-    let new_train_waypoints = waypoints.into_iter().map(|Waypoint { id, stop }| {
+    let new_train_waypoints = waypoints.clone().into_iter().map(|Waypoint { id, stop }| {
         if stop {
             new_train::Waypoint::stop(id)
         } else {
@@ -258,61 +231,35 @@ pub(in crate::views) async fn similar_trains(
         "pre-processing complete"
     );
 
-    // Step 2: query candidate train schedules
-    // ---------------------------------------
+    let default_response = Response {
+        similar_trains: vec![SimilarTrainItem {
+            train: None,
+            begin: new_train.begin().op.deref().clone(),
+            end: new_train.end().op.deref().clone(),
+        }],
+    };
 
-    let (candidate_schedules, path_item_cache) = search_candidate_train_schedules(
-        conn.clone(),
-        &new_train,
-        timetable_id,
-        infra_id,
-        rolling_stock,
-    )
-    .await?;
-    if candidate_schedules.is_empty() {
-        tracing::info!("no candidate train schedules found — similar trains cannot be computed");
-        return Ok(Json(Response {
-            similar_trains: vec![SimilarTrainItem {
-                train: None,
-                begin: new_train.begin().op.deref().clone(),
-                end: new_train.end().op.deref().clone(),
-            }],
-        }));
+    // Step 3: find in the previous trains traffic, compatible trains that overlap its path
+    // ------------------------------------------------------------------------------------
+    let compatible_trains = traffic.find_compatible_trains(
+        rolling_stock.name,
+        rolling_stock.speed_limit_tag,
+        waypoints.iter().map(|w| graph::Waypoint {
+            op: OperationalPoint(w.id.clone()),
+            stop: w.stop,
+        }),
+    );
+
+    tracing::debug!(nbcompatible = compatible_trains.len(), "Compatible trains");
+
+    // Early return if we found no compatible train
+    if compatible_trains.is_empty() {
+        return Ok(Json(default_response));
     }
-
-    // keep the departure date in memory in order to build the API response later on
-    let candidate_schedules_response_info = candidate_schedules
-        .iter()
-        .map(|ts| {
-            (
-                ts.id,
-                TrainInfo {
-                    train_name: ts.train_name.clone(),
-                    start_time: ts.start_time,
-                },
-            )
-        })
-        .collect::<HashMap<_, _>>();
-
-    // Step 3 : simulate candidate train schedules
-    // -------------------------------------------
-
-    let selected_past_trains = simulate_past_trains(
-        conn,
-        valkey_client,
-        core_client,
-        &infra,
-        candidate_schedules,
-        path_item_cache,
-        config.app_version.as_deref(),
-    )
-    .await?;
-
-    let pool = past_train::Pool::from_iter(selected_past_trains);
+    let pool = past_train::Pool::from_iter(compatible_trains.iter().map(|t| t.train.clone()));
 
     // Step 4: build candidate paths graph for each segment
-    // ------------------------------------------------------
-
+    // ----------------------------------------------------
     let mut graphs = Vec::new();
     for segment in new_train.into_segments() {
         let past_trains = pool.trains_in_segment(&segment);
@@ -328,13 +275,14 @@ pub(in crate::views) async fn similar_trains(
 
     // Step 5: find all candidate past trains on the path of the new train's segment
     // -----------------------------------------------------------------------------
-
     let mut trains = Vec::new();
     for (segment, graph) in graphs {
-        let begin = segment.begin().clone();
-        let end = segment.end().clone();
         #[cfg(debug_assertions)]
         std::fs::write("/tmp/dot.txt", graph.to_dot()).unwrap();
+
+        let begin = segment.begin().clone();
+        let end = segment.end().clone();
+
         let mut state = match graph::MatchingState::try_new(segment, graph) {
             Ok(state) => state,
             Err(()) => {
@@ -379,9 +327,23 @@ pub(in crate::views) async fn similar_trains(
         }
     }
 
+    // Early return if we found no train
+    if trains.is_empty() {
+        return Ok(Json(default_response));
+    }
+
     // Step 6: determine which similar train to choose for each segment
     // ----------------------------------------------------------------
-
+    tracing::debug!(trains = trains.len(), "Trains");
+    tracing::debug!(
+        trains = trains
+            .iter()
+            .map(|(_, trains)| trains)
+            .filter(|trains| !trains.is_empty())
+            .collect::<Vec<_>>()
+            .len(),
+        "Trains not empty"
+    );
     let similar_trains = decide_best_train_combination(
         trains
             .iter()
@@ -390,17 +352,22 @@ pub(in crate::views) async fn similar_trains(
             .collect::<Vec<_>>(),
     );
 
+    tracing::debug!(similar_trains = similar_trains.len(), "Similar trains");
+
     // Final step: build the API response
     // ----------------------------------
-
     let response_items = trains
         .into_iter()
         .map(|((begin, end), trains)| {
             let train_id = trains.intersection(&similar_trains).next().cloned();
+
             SimilarTrainItem {
-                train: train_id
-                    .as_ref()
-                    .and_then(|train_id| candidate_schedules_response_info.get(train_id).cloned()),
+                train: train_id.and_then(|train_id| {
+                    traffic.get_by_id(train_id).map(|t| TrainInfo {
+                        train_name: t.name,
+                        start_time: t.start_time,
+                    })
+                }),
                 begin: begin.op.deref().clone(),
                 end: end.op.deref().clone(),
             }
@@ -457,209 +424,12 @@ fn squash_successive_waypoints(waypoints: Vec<Waypoint>) -> Vec<Waypoint> {
     result
 }
 
-#[tracing::instrument(skip(conn, new_train), err)]
-async fn search_candidate_train_schedules(
-    mut conn: DbConnection,
-    new_train: &new_train::NewTrain,
-    timetable_id: i64,
-    infra_id: i64,
-    RollingStockCharacteristics {
-        name: rolling_stock_name,
-        speed_limit_tag,
-    }: RollingStockCharacteristics,
-) -> Result<(Vec<models::TrainSchedule>, PathItemCache)> {
-    let filter = SelectionSettings::new()
-        .filter(move || models::TrainSchedule::TIMETABLE_ID.eq(timetable_id))
-        .order_by(|| models::TrainSchedule::ID.asc());
-
-    let filter = if let Some(rolling_stock_name) = rolling_stock_name {
-        filter.filter(move || {
-            models::TrainSchedule::ROLLING_STOCK_NAME.eq(rolling_stock_name.clone())
-        })
-    } else {
-        filter
-    };
-
-    let filter = if let Some(speed) = speed_limit_tag {
-        filter.filter(move || models::TrainSchedule::SPEED_LIMIT_TAG.eq(Some(speed.clone())))
-    } else {
-        filter
-    };
-
-    let train_schedules = models::TrainSchedule::list(&mut conn, filter).await?;
-
-    tracing::debug!(
-        n_train_schedules = train_schedules.len(),
-        "candidate train schedules queried after applying rolling stock restrictions"
-    );
-
-    let path_locations = train_schedules
-        .iter()
-        .flat_map(models::TrainSchedule::iter_stops)
-        .map(|path_item| &path_item.location)
-        .collect_vec();
-    let path_item_cache = PathItemCache::load(conn, infra_id, &path_locations).await?;
-
-    let segments_stops = new_train
-        .segment_endpoints()
-        .map(|(stop1, stop2)| (stop1.op.clone(), stop2.op.clone()))
-        .collect::<HashSet<_>>();
-
-    let candidate_schedules =
-        tracing::debug_span!("keeping train schedules stopping at segment ends").in_scope(|| {
-            let mut candidates: Vec<models::TrainSchedule> = Default::default();
-            for train_schedule in train_schedules {
-                let retain_schedule = {
-                    let stops_ops: Vec<_> = train_schedule
-                        .iter_stops()
-                        .flat_map(|p| path_item_cache.get_from_path_location(&p.location))
-                        .collect();
-                    let mut stop_pairs_forming_a_segment = stops_ops
-                        .iter()
-                        .tuple_windows()
-                        .flat_map(|(ops1, ops2)| ops1.iter().cartesian_product(ops2.iter()))
-                        .map(|(op1, op2)| {
-                            (
-                                OperationalPoint(op1.obj_id.clone().into()),
-                                OperationalPoint(op2.obj_id.clone().into()),
-                            )
-                        })
-                        .filter(|key| segments_stops.contains(key));
-                    stop_pairs_forming_a_segment.next().is_some()
-                };
-                if retain_schedule {
-                    candidates.push(train_schedule);
-                }
-            }
-            tracing::debug!(
-                n_candidates = candidates.len(),
-                "candidate train schedules found"
-            );
-            candidates
-        });
-
-    Ok((candidate_schedules, path_item_cache))
-}
-
-#[tracing::instrument(skip_all, fields(infra_id = infra.id, candidate_schedules = candidate_schedules.len()), err)]
-async fn simulate_past_trains(
-    mut conn: DbConnection,
-    valkey: Arc<cache::Client>,
-    core_client: Arc<CoreClient>,
-    infra: &Infra,
-    candidate_schedules: Vec<models::TrainSchedule>,
-    path_item_cache: PathItemCache,
-    app_version: Option<&str>,
-) -> Result<Vec<past_train::PastTrain>> {
-    let rolling_stock_names = candidate_schedules
-        .iter()
-        .map(|ts| &ts.rolling_stock_name)
-        .cloned()
-        .collect_vec();
-    let rolling_stocks = RollingStock::list(
-        &mut conn,
-        SelectionSettings::new()
-            .filter(move || models::RollingStock::NAME.eq_any(rolling_stock_names.clone())),
-    )
-    .await?
-    .into_iter()
-    .map(schemas::RollingStock::from)
-    .collect_vec();
-
-    let paths = {
-        let paths = pathfinding_from_train_batch(
-            conn.clone(),
-            &mut valkey.get_connection().await?,
-            core_client.clone(),
-            infra,
-            &candidate_schedules,
-            &rolling_stocks,
-            app_version,
-        )
-        .await?;
-        paths
-            .into_iter()
-            .zip(candidate_schedules.iter())
-            .filter_map(|(path, ts)| match path.as_ref() {
-                PathfindingResult::Success(path) => Some(path.clone()),
-                PathfindingResult::Failure(failure) => {
-                    tracing::warn!(
-                        ?failure,
-                        train_schedule = ts.train_name,
-                        train_schedule_id = ts.id,
-                        "failed to compute path for train schedule, skipping it",
-                    );
-                    None
-                }
-            })
-            .collect_vec()
-    };
-
-    let path_properties_requests = paths
-        .iter()
-        .map(|pathfinding_result| PathPropertiesRequest {
-            track_section_ranges: &pathfinding_result.path.track_section_ranges,
-            infra: infra.id,
-            expected_version: infra.version,
-        })
-        .collect::<Vec<_>>();
-
-    let mut valkey_conn = valkey.get_connection().await?;
-    let path_properties = crate::views::path::properties::compute_path_properties_batch(
-        core_client,
-        &mut valkey_conn,
-        &path_properties_requests,
-        app_version,
-    )
-    .await?;
-
-    let selected_past_trains = path_properties
-        .zip(candidate_schedules.into_iter())
-        .map(
-            |(
-                core_client::path_properties::PathPropertiesResponse {
-                    operational_points, ..
-                },
-                ts,
-            )| {
-                let stop_ids = ts
-                    .iter_stops()
-                    .flat_map(|path_item| {
-                        match path_item_cache.op_identifier(&path_item.location) {
-                            Some(id) => Some(OperationalPoint(id.into())),
-                            None => {
-                                tracing::warn!(
-                                    ts.id,
-                                    ?path_item,
-                                    "ignoring non ID-referenced path item"
-                                );
-                                None
-                            }
-                        }
-                    })
-                    .collect::<HashSet<_>>();
-                let ops =
-                    operational_points
-                        .into_iter()
-                        .map(|OperationalPointOnPath { id, .. }| {
-                            let op = OperationalPoint(id.as_str().into());
-                            let stop = stop_ids.contains(&op);
-                            graph::Waypoint { stop, op }
-                        });
-                past_train::PastTrain::new(ts.id, ops)
-            },
-        )
-        .collect_vec();
-
-    Ok(selected_past_trains)
-}
-
 // TODO: minimize the number of trains to duplicate or minimize the disjoint segments in the simulation sheet?
 #[tracing::instrument(ret(level = "debug"))]
 fn decide_best_train_combination(
     mut segments_trains: Vec<&HashSet<past_train::Id>>,
 ) -> HashSet<past_train::Id> {
-    let mut trains = HashSet::default();
+    let mut trains: HashSet<past_train::Id> = HashSet::default();
 
     while !segments_trains.is_empty() {
         let longest_train = {
@@ -683,41 +453,23 @@ fn decide_best_train_combination(
         segments_trains.retain(|segment| !segment.contains(longest_train));
         trains.insert(*longest_train);
     }
+
     trains
 }
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
-
     use chrono::Duration;
-    use common::geometry::GeoJsonLineString;
-    use common::geometry::GeoJsonLineStringValue;
-    use common::geometry::GeoJsonPointValue;
-    use core_client::mocking::MockingClient;
-    use core_client::path_properties::PropertyElectrificationValue;
-    use core_client::path_properties::PropertyElectrificationValues;
-    use core_client::path_properties::PropertyValuesF64;
-    use core_client::path_properties::PropertyZoneValues;
-    use core_client::pathfinding::PathfindingResultSuccess;
-    use core_client::pathfinding::TrainPath;
+    use itertools::Itertools;
     use pretty_assertions::assert_eq;
     use reqwest::StatusCode;
     use rstest::rstest;
-    use schemas::train_schedule::Comfort;
-    use schemas::train_schedule::Distribution;
-    use schemas::train_schedule::Margins;
-    use schemas::train_schedule::PathItem;
-    use schemas::train_schedule::ScheduleItem;
-    use schemas::train_schedule::TrainScheduleOptions;
     use uuid::Uuid;
 
-    use crate::models::TrainSchedule;
     use crate::models::fixtures::create_fast_rolling_stock;
-    use crate::models::fixtures::create_small_infra;
-    use crate::models::fixtures::create_timetable;
     use crate::views::test_app::TestApp;
     use crate::views::test_app::TestAppBuilder;
+    use crate::views::timetable::similar_trains::trains_traffic::TrainTraffic;
 
     use super::*;
 
@@ -843,154 +595,31 @@ mod tests {
         assert_eq!(result, HashSet::from([frequent_train, less_common, thomas]));
     }
 
-    // The `/pathfinding/blocks` endpoint doesn't need a correct response.
-    // For tests, `/path_properties` must have a correct response.
-    // Since `similar_trains` calls `/pathfinding/blocks`, we need to mock this endpoint too.
-    fn pathfinding_result_success() -> PathfindingResultSuccess {
-        PathfindingResultSuccess {
-            path: TrainPath {
-                blocks: vec![],
-                routes: vec![],
-                track_section_ranges: vec![],
-            },
-            length: 1,
-            path_item_positions: vec![0, 10],
-        }
-    }
-
-    fn create_path_properties_response(
-        operational_points: Vec<OperationalPointOnPath>,
-    ) -> core_client::path_properties::PathPropertiesResponse {
-        core_client::path_properties::PathPropertiesResponse {
-            slopes: PropertyValuesF64::new(vec![0, 1], vec![0.0]),
-            curves: PropertyValuesF64::new(vec![0, 1], vec![0.0]),
-            electrifications: PropertyElectrificationValues::new(
-                vec![0, 1],
-                vec![PropertyElectrificationValue::NonElectrified],
-            ),
-            geometry: GeoJsonLineString::LineString(GeoJsonLineStringValue(vec![
-                GeoJsonPointValue(vec![0.0, 0.0]),
-            ])),
-            operational_points,
-            zones: PropertyZoneValues::new(vec![0, 1], vec!["Zone 1".into()]),
-        }
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    async fn create_train_schedule(
-        conn: &mut DbConnection,
-        timetable_id: i64,
-        rolling_stock_name: String,
-        path: Vec<PathItem>,
-        start_time: DateTime<Utc>,
-        schedule: Vec<ScheduleItem>,
-        speed_limit_tag: Option<String>,
-    ) -> String {
-        TrainSchedule::changeset()
-            .timetable_id(timetable_id)
-            .train_name(Uuid::new_v4().to_string())
-            .rolling_stock_name(rolling_stock_name)
-            .path(path)
-            .labels(Vec::new())
-            .start_time(start_time)
-            .schedule(schedule)
-            .margins(Margins::default())
-            .initial_speed(27.8)
-            .comfort(Comfort::Standard)
-            .constraint_distribution(Distribution::Mareco)
-            .power_restrictions(Vec::new())
-            .options(TrainScheduleOptions {
-                use_electrical_profiles: true,
-                use_speed_limits_for_simulation: true,
-            })
-            .speed_limit_tag(speed_limit_tag)
-            .create(conn)
-            .await
-            .expect("Failed to create train schedule")
-            .train_name
-    }
-
     struct InitTestResponse {
         app: TestApp,
-        infra_id: i64,
-        rolling_stock_names: Vec<String>,
-        timetable_id: i64,
-        train_name: String,
-        start_time: DateTime<Utc>,
     }
-    async fn init_test(path: Vec<PathItem>) -> InitTestResponse {
-        let mut core = MockingClient::new();
-        core.stub("/pathfinding/blocks")
-            .response(StatusCode::OK)
-            .json(PathfindingResult::Success(pathfinding_result_success()))
-            .finish();
-        let operational_points = vec![
-            OperationalPointOnPath::new_test("West_station", 22, "WS"),
-            OperationalPointOnPath::new_test("Mid_West_station", 33, "MWS"),
-            OperationalPointOnPath::new_test("Mid_East_station", 44, "MES"),
-            OperationalPointOnPath::new_test("North_station", 55, "NES"),
-            OperationalPointOnPath::new_test("South_station", 66, "SS"),
-        ];
-        core.stub("/path_properties")
-            .response(StatusCode::OK)
-            .json(create_path_properties_response(operational_points))
-            .finish();
-        let app = TestAppBuilder::new().core_client(core.into()).build();
+    async fn init_test(trains_traffic: Vec<TrainTraffic>) -> InitTestResponse {
+        let app = TestAppBuilder::new()
+            .with_trains_traffic(trains_traffic.clone())
+            .build();
         let db_pool = app.db_pool();
-        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
-        let timetable = create_timetable(&mut db_pool.get_ok()).await;
-        let rolling_stock =
-            create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
-        let rolling_stock_2 =
-            create_fast_rolling_stock(&mut app.db_pool().get_ok(), &Uuid::new_v4().to_string())
-                .await;
 
-        let schedule: Vec<ScheduleItem> = vec![
-            ScheduleItem::new_with_stop(
-                "Mid_West_station",
-                Duration::new(300, 0).expect("Failed to parse duration"),
-            ),
-            ScheduleItem::new_with_stop(
-                "North_station",
-                Duration::new(300, 0).expect("Failed to parse duration"),
-            ),
-            ScheduleItem::new_with_stop(
-                "South_station",
-                Duration::new(0, 0).expect("Failed to parse duration"),
-            ),
-        ];
-        let start_time =
-            DateTime::from_str("2025-01-01T10:00:00Z").expect("Failed to parse datetime");
-
-        // WS(22):stop  MWS(33):stop  MES(44):passing_by  NS(55):stop  SS(66):stop
-        let train_name = create_train_schedule(
-            &mut db_pool.get_ok(),
-            timetable.id,
-            rolling_stock.name.clone(),
-            path,
-            start_time,
-            schedule,
-            Some("MA100".to_string()),
-        )
-        .await;
-        InitTestResponse {
-            app,
-            infra_id: small_infra.id,
-            rolling_stock_names: vec![rolling_stock.name, rolling_stock_2.name],
-            timetable_id: timetable.id,
-            train_name,
-            start_time,
+        // Create rolling stock
+        let rolling_stock_names = trains_traffic
+            .iter()
+            .map(|train| train.rolling_stock.clone())
+            .collect::<HashSet<String>>();
+        for rs in rolling_stock_names.clone() {
+            create_fast_rolling_stock(&mut db_pool.get_ok(), &rs).await;
         }
+
+        InitTestResponse { app }
     }
 
     #[rstest]
     // MWS(33):stop  MES(44):passing_by  NS(55):stop
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[case(
-        vec![
-            PathItem::new_operational_point("Mid_West_station"), // MWS
-            PathItem::new_operational_point("North_station"), // NS
-        ],
         vec![
             Waypoint { id:"Mid_West_station".into(), stop:true },
             Waypoint { id:"Mid_East_station".into(), stop:false },
@@ -1003,10 +632,6 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[case(
         vec![
-            PathItem::new_operational_point("North_station"), // NS
-            PathItem::new_operational_point("South_station"), // SS
-        ],
-        vec![
             Waypoint { id:"North_station".into(), stop:true },
             Waypoint { id:"South_station".into(), stop:true },
         ],
@@ -1014,28 +639,49 @@ mod tests {
         "South_station",
     )]
     async fn one_similar_train(
-        #[case] path: Vec<PathItem>,
         #[case] waypoints: Vec<Waypoint>,
         #[case] begin: &str,
         #[case] end: &str,
     ) {
-        let InitTestResponse {
-            app,
-            infra_id,
-            rolling_stock_names,
-            timetable_id,
-            train_name,
-            start_time,
-        } = init_test(path).await;
+        let train_traffic = TrainTraffic {
+            name: Uuid::new_v4().to_string(),
+            start_time: Utc::now(),
+            rolling_stock: Uuid::new_v4().to_string(),
+            speed_limit_tag: "MA100".to_string(),
+            train: PastTrain::new(
+                1,
+                vec![
+                    graph::Waypoint {
+                        op: OperationalPoint("West_station".into()),
+                        stop: false,
+                    },
+                    graph::Waypoint {
+                        op: OperationalPoint("Mid_West_station".into()),
+                        stop: true,
+                    },
+                    graph::Waypoint {
+                        op: OperationalPoint("Mid_East_station".into()),
+                        stop: false,
+                    },
+                    graph::Waypoint {
+                        op: OperationalPoint("North_station".into()),
+                        stop: true,
+                    },
+                    graph::Waypoint {
+                        op: OperationalPoint("South_station".into()),
+                        stop: true,
+                    },
+                ],
+            ),
+        };
+        let InitTestResponse { app } = init_test(vec![train_traffic.clone()]).await;
 
         let request = Request {
             rolling_stock: RollingStockCharacteristics {
-                name: Some(rolling_stock_names[0].clone()),
+                name: Some(train_traffic.rolling_stock.clone()),
                 speed_limit_tag: None,
             },
             waypoints,
-            infra_id,
-            timetable_id,
         };
         let request = app.post("/similar_trains").json(&request);
         let response: Response = app
@@ -1047,8 +693,8 @@ mod tests {
         let expected_response = Response {
             similar_trains: vec![SimilarTrainItem {
                 train: Some(TrainInfo {
-                    train_name,
-                    start_time,
+                    train_name: train_traffic.name.clone(),
+                    start_time: train_traffic.start_time,
                 }),
                 begin: begin.into(),
                 end: end.into(),
@@ -1061,7 +707,7 @@ mod tests {
     // Different rolling stock
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[case(
-        1,
+        false,
         Some("MA100".to_string()),
         vec![
             Waypoint { id:"Mid_West_station".into(), stop:true },
@@ -1078,7 +724,7 @@ mod tests {
     // Different speed limit tag
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[case(
-        0,
+        true,
         Some("MA90".to_string()),
         vec![
             Waypoint { id:"Mid_West_station".into(), stop:true },
@@ -1096,7 +742,7 @@ mod tests {
     // MWS(33):stop  MES(44):stop  NS(55):stop
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[case(
-        0,
+        true,
         Some("MA100".to_string()),
         vec![
             Waypoint { id:"Mid_West_station".into(), stop:true },
@@ -1115,7 +761,7 @@ mod tests {
     // MWS(33):stop  MES(44):passing_by  NS(55):passing_by  SS(66):stop
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[case(
-        0,
+        true,
         Some("MA100".to_string()),
         vec![
             Waypoint { id:"Mid_West_station".into(), stop:true },
@@ -1132,34 +778,58 @@ mod tests {
         ],
     )]
     async fn no_similar_train(
-        #[case] index_rolling_stock_name: usize,
+        #[case] use_same_rolling_stock: bool,
         #[case] speed_limit_tag: Option<String>,
         #[case] waypoints: Vec<Waypoint>,
         #[case] similar_trains: Vec<SimilarTrainItem>,
     ) {
-        let path = vec![
-            PathItem::new_operational_point("West_station"), // WS
-            PathItem::new_operational_point("Mid_West_station"), // MWS
-            PathItem::new_operational_point("Mid_East_station"), // MES
-            PathItem::new_operational_point("North_station"), // NS
-            PathItem::new_operational_point("South_station"), // SS
-        ];
-        let InitTestResponse {
-            app,
-            infra_id,
-            rolling_stock_names,
-            timetable_id,
-            ..
-        } = init_test(path).await;
+        let train_traffic = TrainTraffic {
+            name: Uuid::new_v4().to_string(),
+            start_time: Utc::now(),
+            rolling_stock: Uuid::new_v4().to_string(),
+            speed_limit_tag: "MA100".to_string(),
+            train: PastTrain::new(
+                1,
+                vec![
+                    graph::Waypoint {
+                        op: OperationalPoint("West_station".into()),
+                        stop: false,
+                    },
+                    graph::Waypoint {
+                        op: OperationalPoint("Mid_West_station".into()),
+                        stop: true,
+                    },
+                    graph::Waypoint {
+                        op: OperationalPoint("Mid_East_station".into()),
+                        stop: false,
+                    },
+                    graph::Waypoint {
+                        op: OperationalPoint("North_station".into()),
+                        stop: true,
+                    },
+                    graph::Waypoint {
+                        op: OperationalPoint("South_station".into()),
+                        stop: true,
+                    },
+                ],
+            ),
+        };
+        let InitTestResponse { app } = init_test(vec![train_traffic.clone()]).await;
 
+        let request_rolling_stock = Some(if use_same_rolling_stock {
+            train_traffic.rolling_stock.clone()
+        } else {
+            let db_pool = app.db_pool();
+            let other_rolling_stock_name = Uuid::new_v4().to_string();
+            create_fast_rolling_stock(&mut db_pool.get_ok(), &other_rolling_stock_name).await;
+            other_rolling_stock_name
+        });
         let request = Request {
             rolling_stock: RollingStockCharacteristics {
-                name: Some(rolling_stock_names[index_rolling_stock_name].clone()),
+                name: request_rolling_stock,
                 speed_limit_tag,
             },
             waypoints,
-            infra_id,
-            timetable_id,
         };
         let request = app.post("/similar_trains").json(&request);
         let response: Response = app
@@ -1173,88 +843,61 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn compound_similar_trains() {
-        let mut core = MockingClient::new();
-        core.stub("/pathfinding/blocks")
-            .response(StatusCode::OK)
-            .json(PathfindingResult::Success(pathfinding_result_success()))
-            .json(PathfindingResult::Success(pathfinding_result_success()))
-            .finish();
-        let operational_points_for_train_1 = vec![
-            OperationalPointOnPath::new_test("West_station", 22, "WS"),
-            OperationalPointOnPath::new_test("Mid_West_station", 33, "MWS"),
-            OperationalPointOnPath::new_test("Mid_East_station", 44, "MES"),
-        ];
-        let operational_points_for_train_2 = vec![
-            OperationalPointOnPath::new_test("Mid_East_station", 44, "MES"),
-            OperationalPointOnPath::new_test("North_station", 55, "NES"),
-            OperationalPointOnPath::new_test("South_station", 66, "SS"),
-        ];
-        core.stub("/path_properties")
-            .response(StatusCode::OK)
-            .json(create_path_properties_response(
-                operational_points_for_train_1,
-            ))
-            .json(create_path_properties_response(
-                operational_points_for_train_2,
-            ))
-            .finish();
-        let app = TestAppBuilder::new().core_client(core.into()).build();
-        let db_pool = app.db_pool();
-        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
-        let timetable = create_timetable(&mut db_pool.get_ok()).await;
-        let rolling_stock =
-            create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
-
-        let path: Vec<PathItem> = vec![
-            PathItem::new_operational_point("West_station"), // WS
-            PathItem::new_operational_point("Mid_East_station"), // MES
-        ];
-        let schedule: Vec<ScheduleItem> = vec![ScheduleItem::new_with_stop(
-            "West_station",
-            Duration::new(0, 0).expect("Failed to parse duration"),
-        )];
-        let start_time_1 =
-            DateTime::from_str("2025-01-01T10:00:00Z").expect("Failed to parse datetime");
-
-        // WS(22):stop  MWS(33):passing_by  MES(44):stop
-        let train_1 = create_train_schedule(
-            &mut db_pool.get_ok(),
-            timetable.id,
-            rolling_stock.name.clone(),
-            path,
-            start_time_1,
-            schedule,
-            Some("MA100".to_string()),
-        )
-        .await;
-
-        let path: Vec<PathItem> = vec![
-            PathItem::new_operational_point("Mid_East_station"), // MES
-            PathItem::new_operational_point("South_station"),    // SS
-        ];
-        let schedule: Vec<ScheduleItem> = vec![ScheduleItem::new_with_stop(
-            "Mid_East_station",
-            Duration::new(0, 0).expect("Failed to parse duration"),
-        )];
-        let start_time_2 =
-            DateTime::from_str("2025-01-01T12:00:00Z").expect("Failed to parse datetime");
+        let rolling_stock_name = Uuid::new_v4().to_string();
+        let speed_limit_tag = "MA100".to_string();
+        let train_1 = TrainTraffic {
+            name: Uuid::new_v4().to_string(),
+            start_time: Utc::now(),
+            rolling_stock: rolling_stock_name.clone(),
+            speed_limit_tag: speed_limit_tag.clone(),
+            train: PastTrain::new(
+                1,
+                vec![
+                    graph::Waypoint {
+                        op: OperationalPoint("West_station".into()),
+                        stop: true,
+                    },
+                    graph::Waypoint {
+                        op: OperationalPoint("Mid_West_station".into()),
+                        stop: false,
+                    },
+                    graph::Waypoint {
+                        op: OperationalPoint("Mid_East_station".into()),
+                        stop: true,
+                    },
+                ],
+            ),
+        };
 
         // MES(44):stop  NS(55):passing_by  SS(66):stop
-        let train_2 = create_train_schedule(
-            &mut db_pool.get_ok(),
-            timetable.id,
-            rolling_stock.name.clone(),
-            path,
-            start_time_2,
-            schedule,
-            Some("MA100".to_string()),
-        )
-        .await;
+        let train_2 = TrainTraffic {
+            name: Uuid::new_v4().to_string(),
+            start_time: Utc::now(),
+            rolling_stock: rolling_stock_name.clone(),
+            speed_limit_tag: speed_limit_tag.clone(),
+            train: PastTrain::new(
+                2,
+                vec![
+                    graph::Waypoint {
+                        op: OperationalPoint("Mid_East_station".into()),
+                        stop: true,
+                    },
+                    graph::Waypoint {
+                        op: OperationalPoint("North_station".into()),
+                        stop: false,
+                    },
+                    graph::Waypoint {
+                        op: OperationalPoint("South_station".into()),
+                        stop: true,
+                    },
+                ],
+            ),
+        };
+        let InitTestResponse { app } = init_test(vec![train_1.clone(), train_2.clone()]).await;
 
-        // WS(22):stop  MWS(33):passing_by  MES(44):stop NS(55):passing_by  SS(66):stop
         let request = Request {
             rolling_stock: RollingStockCharacteristics {
-                name: Some(rolling_stock.name),
+                name: Some(rolling_stock_name),
                 speed_limit_tag: Some("MA100".to_string()),
             },
             waypoints: vec![
@@ -1279,8 +922,6 @@ mod tests {
                     stop: true,
                 },
             ],
-            infra_id: small_infra.id,
-            timetable_id: timetable.id,
         };
         let request = app.post("/similar_trains").json(&request);
         let response: Response = app
@@ -1293,16 +934,16 @@ mod tests {
             similar_trains: vec![
                 SimilarTrainItem {
                     train: Some(TrainInfo {
-                        train_name: train_1,
-                        start_time: start_time_1,
+                        train_name: train_1.name,
+                        start_time: train_1.start_time,
                     }),
                     begin: "West_station".into(),
                     end: "Mid_East_station".into(),
                 },
                 SimilarTrainItem {
                     train: Some(TrainInfo {
-                        train_name: train_2,
-                        start_time: start_time_2,
+                        train_name: train_2.name,
+                        start_time: train_2.start_time,
                     }),
                     begin: "Mid_East_station".into(),
                     end: "South_station".into(),
@@ -1314,138 +955,102 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_select_single_train_without_merging_consecutive_segments() {
-        let mut core = MockingClient::new();
-        core.stub("/pathfinding/blocks")
-            .response(StatusCode::OK)
-            .json(PathfindingResult::Success(pathfinding_result_success()))
-            .json(PathfindingResult::Success(pathfinding_result_success()))
-            .json(PathfindingResult::Success(pathfinding_result_success()))
-            .json(PathfindingResult::Success(pathfinding_result_success()))
-            .json(PathfindingResult::Success(pathfinding_result_success()))
-            .finish();
-        let operational_points_ws_nes = vec![
-            OperationalPointOnPath::new_test("West_station", 22, "WS"),
-            OperationalPointOnPath::new_test("Mid_West_station", 33, "MWS"),
-            OperationalPointOnPath::new_test("Mid_East_station", 44, "MES"),
-            OperationalPointOnPath::new_test("North_East_station", 77, "NES"),
-        ];
-        let operational_points_ws_mes = vec![
-            OperationalPointOnPath::new_test("West_station", 22, "WS"),
-            OperationalPointOnPath::new_test("Mid_West_station", 33, "MWS"),
-            OperationalPointOnPath::new_test("Mid_East_station", 44, "MES"),
-        ];
-        let operational_points_mes_nes = vec![
-            OperationalPointOnPath::new_test("Mid_East_station", 44, "MES"),
-            OperationalPointOnPath::new_test("North_East_station", 77, "NES"),
-        ];
-        core.stub("/path_properties")
-            .response(StatusCode::OK)
-            .json(create_path_properties_response(
-                operational_points_ws_mes.clone(),
-            )) // train_1
-            .json(create_path_properties_response(operational_points_ws_mes)) // train_2
-            .json(create_path_properties_response(
-                operational_points_mes_nes.clone(),
-            )) // train_3
-            .json(create_path_properties_response(operational_points_mes_nes)) // train_4
-            .json(create_path_properties_response(operational_points_ws_nes)) // train_5
-            .finish();
-        let app = TestAppBuilder::new().core_client(core.into()).build();
-        let db_pool = app.db_pool();
-        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
-        let timetable = create_timetable(&mut db_pool.get_ok()).await;
-        let rolling_stock =
-            create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
-
-        let mut hour = 10;
-        for _ in 1..3 {
-            let path: Vec<PathItem> = vec![
-                PathItem::new_operational_point("West_station"), // WS
-                PathItem::new_operational_point("Mid_West_station"), // MWS
-                PathItem::new_operational_point("Mid_East_station"), // MES
-            ];
-            let schedule: Vec<ScheduleItem> = vec![ScheduleItem::new_with_stop(
-                "Mid_East_station",
-                Duration::new(0, 0).expect("Failed to parse duration"),
-            )];
-            let start_time = DateTime::from_str(format!("2025-01-01T{hour}:00:00Z").as_str())
-                .expect("Failed to parse datetime");
-            hour += 1;
-
-            // WS(22):stop  MWS(33):passing_by  MES(44):stop
-            let _ = create_train_schedule(
-                &mut db_pool.get_ok(),
-                timetable.id,
-                rolling_stock.name.clone(),
-                path,
-                start_time,
-                schedule,
-                Some("MA100".to_string()),
-            )
-            .await;
-        }
-
-        for _ in 3..5 {
-            let path: Vec<PathItem> = vec![
-                PathItem::new_operational_point("Mid_East_station"), // MES
-                PathItem::new_operational_point("North_East_station"), // NES
-            ];
-            let schedule: Vec<ScheduleItem> = vec![ScheduleItem::new_with_stop(
-                "North_East_station",
-                Duration::new(0, 0).expect("Failed to parse duration"),
-            )];
-            let start_time = DateTime::from_str(format!("2025-01-01T{hour}:00:00Z").as_str())
-                .expect("Failed to parse datetime");
-            hour += 1;
-
-            // MES(44):stop  NES(77):stop
-            let _ = create_train_schedule(
-                &mut db_pool.get_ok(),
-                timetable.id,
-                rolling_stock.name.clone(),
-                path,
-                start_time,
-                schedule,
-                Some("MA100".to_string()),
-            )
-            .await;
-        }
-
-        let path: Vec<PathItem> = vec![
-            PathItem::new_operational_point("West_station"), // WS
-            PathItem::new_operational_point("Mid_East_station"), // MES
-            PathItem::new_operational_point("North_East_station"), // NES
-        ];
-        let schedule: Vec<ScheduleItem> = vec![
-            ScheduleItem::new_with_stop(
-                "Mid_East_station",
-                Duration::new(300, 0).expect("Failed to parse duration"),
-            ),
-            ScheduleItem::new_with_stop(
-                "North_East_station",
-                Duration::new(0, 0).expect("Failed to parse duration"),
-            ),
-        ];
-        let start_time = DateTime::from_str(format!("2025-01-01T{hour}:00:00Z").as_str())
-            .expect("Failed to parse datetime");
+        let rolling_stock_name = Uuid::new_v4().to_string();
+        let speed_limit_tag = "MA100".to_string();
+        let mut traffics = Vec::<TrainTraffic>::new();
 
         // WS(22):stop  MWS(33):passing_by  MES(44):stop  NES(77):stop
-        let train_name = create_train_schedule(
-            &mut db_pool.get_ok(),
-            timetable.id,
-            rolling_stock.name.clone(),
-            path,
-            start_time,
-            schedule,
-            Some("MA100".to_string()),
-        )
-        .await;
+        let train_targeted = TrainTraffic {
+            name: Uuid::new_v4().to_string(),
+            start_time: Utc::now(),
+            rolling_stock: rolling_stock_name.clone(),
+            speed_limit_tag: speed_limit_tag.clone(),
+            train: PastTrain::new(
+                0,
+                vec![
+                    graph::Waypoint {
+                        op: OperationalPoint("West_station".into()),
+                        stop: true,
+                    },
+                    graph::Waypoint {
+                        op: OperationalPoint("Mid_West_station".into()),
+                        stop: false,
+                    },
+                    graph::Waypoint {
+                        op: OperationalPoint("Mid_East_station".into()),
+                        stop: true,
+                    },
+                    graph::Waypoint {
+                        op: OperationalPoint("North_East_station".into()),
+                        stop: true,
+                    },
+                ],
+            ),
+        };
+        traffics.push(train_targeted.clone());
+
+        let mut hour = 10;
+        // WS(22):stop  MWS(33):passing_by  MES(44):stop
+        for index in 1..3 {
+            let start_time = Utc::now() + Duration::hours(hour);
+            hour += 1;
+            traffics.push(TrainTraffic {
+                name: Uuid::new_v4().to_string(),
+                start_time,
+                rolling_stock: rolling_stock_name.clone(),
+                speed_limit_tag: speed_limit_tag.clone(),
+                train: PastTrain::new(
+                    index,
+                    vec![
+                        graph::Waypoint {
+                            op: OperationalPoint("West_station".into()),
+                            stop: true,
+                        },
+                        graph::Waypoint {
+                            op: OperationalPoint("Mid_West_station".into()),
+                            stop: false,
+                        },
+                        graph::Waypoint {
+                            op: OperationalPoint("Mid_East_station".into()),
+                            stop: true,
+                        },
+                    ],
+                ),
+            });
+        }
+
+        // MES(44):stop  NES(77):stop
+        for index in 3..5 {
+            let start_time = Utc::now() + Duration::hours(hour);
+            hour += 1;
+            traffics.push(TrainTraffic {
+                name: Uuid::new_v4().to_string(),
+                start_time,
+                rolling_stock: rolling_stock_name.clone(),
+                speed_limit_tag: speed_limit_tag.clone(),
+                train: PastTrain::new(
+                    index,
+                    vec![
+                        graph::Waypoint {
+                            op: OperationalPoint("Mid_East_station".into()),
+                            stop: true,
+                        },
+                        graph::Waypoint {
+                            op: OperationalPoint("North_East_station".into()),
+                            stop: true,
+                        },
+                    ],
+                ),
+            });
+        }
+
+        let InitTestResponse { app } = init_test(traffics.clone()).await;
 
         // WS(22):stop  MWS(33):passing_by  MES(44):stop  NES(77):stop
         let request = Request {
             rolling_stock: RollingStockCharacteristics {
-                name: Some(rolling_stock.name),
-                speed_limit_tag: Some("MA100".to_string()),
+                name: Some(rolling_stock_name),
+                speed_limit_tag: Some(speed_limit_tag),
             },
             waypoints: vec![
                 Waypoint {
@@ -1465,8 +1070,6 @@ mod tests {
                     stop: true,
                 },
             ],
-            infra_id: small_infra.id,
-            timetable_id: timetable.id,
         };
         let request = app.post("/similar_trains").json(&request);
         let response: Response = app
@@ -1479,16 +1082,16 @@ mod tests {
             similar_trains: vec![
                 SimilarTrainItem {
                     train: Some(TrainInfo {
-                        train_name: train_name.clone(),
-                        start_time,
+                        train_name: train_targeted.name.clone(),
+                        start_time: train_targeted.start_time,
                     }),
                     begin: "West_station".into(),
                     end: "Mid_East_station".into(),
                 },
                 SimilarTrainItem {
                     train: Some(TrainInfo {
-                        train_name,
-                        start_time,
+                        train_name: train_targeted.name,
+                        start_time: train_targeted.start_time,
                     }),
                     begin: "Mid_East_station".into(),
                     end: "North_East_station".into(),
@@ -1500,82 +1103,50 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn no_similar_trains_for_some_segments() {
-        let mut core = MockingClient::new();
-        core.stub("/pathfinding/blocks")
-            .response(StatusCode::OK)
-            .json(PathfindingResult::Success(pathfinding_result_success()))
-            .json(PathfindingResult::Success(pathfinding_result_success()))
-            .finish();
-        let operational_points_ws_mws = vec![
-            OperationalPointOnPath::new_test("West_station", 22, "WS"),
-            OperationalPointOnPath::new_test("Mid_West_station", 33, "MWS"),
-        ];
-        let operational_points_mes_ns = vec![
-            OperationalPointOnPath::new_test("Mid_East_station", 44, "MES"),
-            OperationalPointOnPath::new_test("North_station", 55, "NS"),
-        ];
-        core.stub("/path_properties")
-            .response(StatusCode::OK)
-            .json(create_path_properties_response(operational_points_ws_mws)) // train_1
-            .json(create_path_properties_response(operational_points_mes_ns)) // train_2
-            .finish();
-        let app = TestAppBuilder::new().core_client(core.into()).build();
-        let db_pool = app.db_pool();
-        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
-        let timetable = create_timetable(&mut db_pool.get_ok()).await;
-        let rolling_stock =
-            create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+        let rolling_stock_name = Uuid::new_v4().to_string();
+        let train_1 = TrainTraffic {
+            name: Uuid::new_v4().to_string(),
+            start_time: Utc::now(),
+            rolling_stock: rolling_stock_name.clone(),
+            speed_limit_tag: "MA100".to_string(),
+            train: PastTrain::new(
+                1,
+                vec![
+                    graph::Waypoint {
+                        op: OperationalPoint("West_station".into()),
+                        stop: true,
+                    },
+                    graph::Waypoint {
+                        op: OperationalPoint("Mid_West_station".into()),
+                        stop: true,
+                    },
+                ],
+            ),
+        };
+        let train_2 = TrainTraffic {
+            name: Uuid::new_v4().to_string(),
+            start_time: Utc::now(),
+            rolling_stock: rolling_stock_name.clone(),
+            speed_limit_tag: "MA100".to_string(),
+            train: PastTrain::new(
+                2,
+                vec![
+                    graph::Waypoint {
+                        op: OperationalPoint("Mid_East_station".into()),
+                        stop: true,
+                    },
+                    graph::Waypoint {
+                        op: OperationalPoint("North_station".into()),
+                        stop: true,
+                    },
+                ],
+            ),
+        };
+        let InitTestResponse { app } = init_test(vec![train_1.clone(), train_2.clone()]).await;
 
-        let path: Vec<PathItem> = vec![
-            PathItem::new_operational_point("West_station"), // WS
-            PathItem::new_operational_point("Mid_West_station"), // MWS
-        ];
-        let schedule: Vec<ScheduleItem> = vec![ScheduleItem::new_with_stop(
-            "Mid_West_station",
-            Duration::new(0, 0).expect("Failed to parse duration"),
-        )];
-        let start_time_1 =
-            DateTime::from_str("2025-01-01T10:00:00Z").expect("Failed to parse datetime");
-
-        // WS(22):stop  MWS(33):stop
-        let train_1 = create_train_schedule(
-            &mut db_pool.get_ok(),
-            timetable.id,
-            rolling_stock.name.clone(),
-            path,
-            start_time_1,
-            schedule,
-            Some("MA100".to_string()),
-        )
-        .await;
-
-        let path: Vec<PathItem> = vec![
-            PathItem::new_operational_point("Mid_East_station"), // MES
-            PathItem::new_operational_point("North_station"),    // NS
-        ];
-        let schedule: Vec<ScheduleItem> = vec![ScheduleItem::new_with_stop(
-            "North_station",
-            Duration::new(0, 0).expect("Failed to parse duration"),
-        )];
-        let start_time_2 =
-            DateTime::from_str("2025-01-01T11:00:00Z").expect("Failed to parse datetime");
-
-        // MES(44):stop  NS(55):stop
-        let train_2 = create_train_schedule(
-            &mut db_pool.get_ok(),
-            timetable.id,
-            rolling_stock.name.clone(),
-            path,
-            start_time_2,
-            schedule,
-            Some("MA100".to_string()),
-        )
-        .await;
-
-        // WS(22):stop  MWS(33):stop  MES(44):stop  NS(55):stop  SS(66):stop
         let request = Request {
             rolling_stock: RollingStockCharacteristics {
-                name: Some(rolling_stock.name),
+                name: Some(rolling_stock_name),
                 speed_limit_tag: Some("MA100".to_string()),
             },
             waypoints: vec![
@@ -1600,8 +1171,6 @@ mod tests {
                     stop: true,
                 },
             ],
-            infra_id: small_infra.id,
-            timetable_id: timetable.id,
         };
         let request = app.post("/similar_trains").json(&request);
         let response: Response = app
@@ -1614,8 +1183,8 @@ mod tests {
             similar_trains: vec![
                 SimilarTrainItem {
                     train: Some(TrainInfo {
-                        train_name: train_1,
-                        start_time: start_time_1,
+                        train_name: train_1.name.clone(),
+                        start_time: train_1.start_time,
                     }),
                     begin: "West_station".into(),
                     end: "Mid_West_station".into(),
@@ -1627,8 +1196,8 @@ mod tests {
                 },
                 SimilarTrainItem {
                     train: Some(TrainInfo {
-                        train_name: train_2,
-                        start_time: start_time_2,
+                        train_name: train_2.name.clone(),
+                        start_time: train_2.start_time,
                     }),
                     begin: "Mid_East_station".into(),
                     end: "North_station".into(),
@@ -1693,57 +1262,37 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn test_similar_trains_by_relaxing_name_criterion() {
-        let mut core = MockingClient::new();
-        core.stub("/pathfinding/blocks")
-            .response(StatusCode::OK)
-            .json(PathfindingResult::Success(pathfinding_result_success()))
-            .finish();
-        let operational_points_ws_mws = vec![
-            OperationalPointOnPath::new_test("West_station", 22, "WS"),
-            OperationalPointOnPath::new_test("Mid_West_station", 33, "MWS"),
-        ];
-        core.stub("/path_properties")
-            .response(StatusCode::OK)
-            .json(create_path_properties_response(operational_points_ws_mws)) // train_1
-            .finish();
-        let app = TestAppBuilder::new().core_client(core.into()).build();
+    async fn test_similar_trains_by_relaxing_rolling_stock_criterion() {
+        let train_traffic = TrainTraffic {
+            name: Uuid::new_v4().to_string(),
+            start_time: Utc::now(),
+            rolling_stock: Uuid::new_v4().to_string(),
+            speed_limit_tag: "MA100".to_string(),
+            train: PastTrain::new(
+                1,
+                vec![
+                    graph::Waypoint {
+                        op: OperationalPoint("West_station".into()),
+                        stop: true,
+                    },
+                    graph::Waypoint {
+                        op: OperationalPoint("Mid_West_station".into()),
+                        stop: true,
+                    },
+                ],
+            ),
+        };
+        let InitTestResponse { app } = init_test(vec![train_traffic.clone()]).await;
+
+        // Request with a bad RS should return NONE
+        // Create an
         let db_pool = app.db_pool();
-        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
-        let timetable = create_timetable(&mut db_pool.get_ok()).await;
-        let rolling_stock_1 =
-            create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
-        let rolling_stock_2 =
-            create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
-
-        let path: Vec<PathItem> = vec![
-            PathItem::new_operational_point("West_station"), // WS
-            PathItem::new_operational_point("Mid_West_station"), // MWS
-        ];
-        let schedule: Vec<ScheduleItem> = vec![ScheduleItem::new_with_stop(
-            "Mid_West_station",
-            Duration::new(0, 0).expect("Failed to parse duration"),
-        )];
-        let start_time =
-            DateTime::from_str("2025-01-01T10:00:00Z").expect("Failed to parse datetime");
-
-        // WS(22):stop  MWS(33):stop
-        let train_name = create_train_schedule(
-            &mut db_pool.get_ok(),
-            timetable.id,
-            rolling_stock_2.name,
-            path,
-            start_time,
-            schedule,
-            Some("MA100".to_string()),
-        )
-        .await;
-
-        // WS(22):stop  MWS(33):stop
+        let bad_rolling_stock_name = Uuid::new_v4().to_string();
+        create_fast_rolling_stock(&mut db_pool.get_ok(), &bad_rolling_stock_name).await;
         let request = Request {
             rolling_stock: RollingStockCharacteristics {
-                name: Some(rolling_stock_1.name),
-                speed_limit_tag: Some("MA100".to_string()),
+                name: Some(bad_rolling_stock_name),
+                speed_limit_tag: Some(train_traffic.speed_limit_tag.clone()),
             },
             waypoints: vec![
                 Waypoint {
@@ -1755,8 +1304,6 @@ mod tests {
                     stop: true,
                 },
             ],
-            infra_id: small_infra.id,
-            timetable_id: timetable.id,
         };
         let request = app.post("/similar_trains").json(&request);
         let response: Response = app
@@ -1774,7 +1321,7 @@ mod tests {
         };
         assert_eq!(response, expected_response);
 
-        // WS(22):stop  MWS(33):stop
+        // Relaxing RS constraint should return a result
         let request = Request {
             rolling_stock: RollingStockCharacteristics {
                 name: None,
@@ -1790,8 +1337,6 @@ mod tests {
                     stop: true,
                 },
             ],
-            infra_id: small_infra.id,
-            timetable_id: timetable.id,
         };
         let request = app.post("/similar_trains").json(&request);
         let response: Response = app
@@ -1803,8 +1348,8 @@ mod tests {
         let expected_response = Response {
             similar_trains: vec![SimilarTrainItem {
                 train: Some(TrainInfo {
-                    train_name,
-                    start_time,
+                    train_name: train_traffic.name,
+                    start_time: train_traffic.start_time,
                 }),
                 begin: "West_station".into(),
                 end: "Mid_West_station".into(),

--- a/editoast/src/views/timetable/similar_trains/past_train.rs
+++ b/editoast/src/views/timetable/similar_trains/past_train.rs
@@ -8,9 +8,9 @@ use crate::views::timetable::similar_trains::new_train::Segment;
 
 use super::graph;
 
-pub(super) type Id = i64;
+pub(super) type Id = usize;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(super) struct PastTrain {
     id: Id,
     path: Vec<graph::Waypoint>,
@@ -28,7 +28,7 @@ impl PastTrain {
         self.id
     }
 
-    fn iter_stops(&self) -> impl Iterator<Item = &graph::Waypoint> {
+    pub(super) fn iter_stops(&self) -> impl Iterator<Item = &graph::Waypoint> {
         self.path.iter().filter(|wp| wp.stop)
     }
 

--- a/editoast/src/views/timetable/similar_trains/trains_traffic.rs
+++ b/editoast/src/views/timetable/similar_trains/trains_traffic.rs
@@ -1,0 +1,373 @@
+use crate::error::Result;
+use crate::views::timetable::similar_trains::OperationalPoint;
+use crate::views::timetable::similar_trains::PastTrain;
+use crate::views::timetable::similar_trains::past_train::Id;
+use arcstr::ArcStr;
+use chrono::DateTime;
+use chrono::Months;
+
+use chrono::Utc;
+use itertools::Itertools;
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::collections::HashSet;
+
+use super::graph;
+
+#[derive(Clone, Debug)]
+pub struct TrainTraffic {
+    pub(super) name: String,
+    pub(super) start_time: DateTime<Utc>,
+    pub(super) rolling_stock: String,
+    pub(super) speed_limit_tag: String,
+    pub(super) train: PastTrain,
+}
+
+#[derive(Debug, Deserialize, Clone, Hash, PartialEq, Eq)]
+pub struct TrainOperationalPoint {
+    pub id: String,
+    pub stop: Option<bool>,
+}
+
+impl TrainTraffic {
+    pub fn new(
+        id: Id,
+        name: String,
+        start_time: DateTime<Utc>,
+        rolling_stock: String,
+        speed_limit_tag: String,
+        waypoints: Vec<TrainOperationalPoint>,
+    ) -> Self {
+        let nb_waypoints = waypoints.len();
+        let mut waypoints_graph = Vec::<graph::Waypoint>::with_capacity(nb_waypoints);
+        for (index, waypoint) in waypoints.iter().enumerate() {
+            if let Some(prev) = waypoints_graph.last_mut()
+                && prev.op.to_string() == waypoint.id
+            {
+                prev.stop |= waypoint.stop.unwrap_or(false);
+                continue;
+            }
+            waypoints_graph.push(graph::Waypoint {
+                op: OperationalPoint(ArcStr::from(waypoint.id.clone())),
+                stop: if index == 0 || index == (nb_waypoints - 1) {
+                    true
+                } else {
+                    waypoint.stop.unwrap_or(false)
+                },
+            });
+        }
+
+        Self {
+            name,
+            start_time,
+            rolling_stock,
+            speed_limit_tag,
+            train: PastTrain::new(id, waypoints_graph),
+        }
+    }
+
+    pub fn id(&self) -> Id {
+        self.train.id()
+    }
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+struct Segment {
+    from: graph::Waypoint,
+    to: graph::Waypoint,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct TrainsTrafficPool {
+    // Date from which traffic are valid (ie. can be imported)
+    traffic_valid_from: DateTime<Utc>,
+    // Trains by speedlimit
+    trains_by_speedlimit: HashMap<String, HashSet<usize>>,
+    // Trains by rollingstock
+    trains_by_rollingstock: HashMap<String, HashSet<usize>>,
+    // Trains by segment
+    trains_by_segment: HashMap<Segment, HashSet<usize>>,
+    // Train by ID
+    trains_by_id: HashMap<Id, TrainTraffic>,
+}
+
+impl TrainsTrafficPool {
+    pub fn new() -> Self {
+        TrainsTrafficPool::new_with_date(
+            Utc::now()
+                .checked_sub_months(Months::new(6))
+                .expect("6 month ago date should be valid"),
+        )
+    }
+
+    pub fn new_with_date(traffic_valid_from: DateTime<Utc>) -> Self {
+        Self {
+            traffic_valid_from,
+            ..Default::default()
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.trains_by_id.len()
+    }
+
+    /// Retrierve a train by its id
+    pub fn get_by_id(&self, id: usize) -> Option<TrainTraffic> {
+        self.trains_by_id.get(&id).cloned()
+    }
+
+    /// Add a train traffic
+    pub fn add_train_traffic(&mut self, train_data: TrainTraffic) -> Result<()> {
+        // Only import train that have a valid start date
+        if train_data.start_time > self.traffic_valid_from {
+            // Index the train by its speedlimit
+            self.trains_by_speedlimit
+                .entry(train_data.speed_limit_tag.clone())
+                .or_default()
+                .insert(train_data.id());
+
+            // Index the train by its rollingstock
+            self.trains_by_rollingstock
+                .entry(train_data.rolling_stock.clone())
+                .or_default()
+                .insert(train_data.id());
+
+            // Index the train by segment
+            for (from, to) in train_data.train.iter_stops().tuple_windows() {
+                self.trains_by_segment
+                    .entry(Segment {
+                        from: from.clone(),
+                        to: to.clone(),
+                    })
+                    .or_default()
+                    .insert(train_data.id());
+            }
+
+            // Index the train by its id
+            if self.trains_by_id.contains_key(&train_data.id()) {
+                tracing::warn!(
+                    train_id = train_data.id(),
+                    "Train already exist, overriding it"
+                );
+            }
+            self.trains_by_id.insert(train_data.id(), train_data);
+        }
+
+        Ok(())
+    }
+
+    /// Find in the traffic a composition of trains that match the given train itinerary
+    pub(super) fn find_compatible_trains(
+        &self,
+        rolling_stock: Option<String>,
+        speed_limit_tag: Option<String>,
+        waypoints: impl IntoIterator<Item = graph::Waypoint>,
+    ) -> Vec<TrainTraffic> {
+        let mut valid_trains = HashSet::<usize>::new();
+
+        // Getting a list of valid train Ids which match the train's specifications
+        let compliant_trains = match (rolling_stock, speed_limit_tag) {
+            (Some(rs), None) => self
+                .trains_by_rollingstock
+                .get(&rs)
+                .cloned()
+                .unwrap_or_default(),
+            (None, Some(speed)) => self
+                .trains_by_speedlimit
+                .get(&speed)
+                .cloned()
+                .unwrap_or_default(),
+            (Some(rs), Some(speed)) => {
+                let rs_trains = self
+                    .trains_by_rollingstock
+                    .get(&rs)
+                    .cloned()
+                    .unwrap_or_default();
+                let speed_trains = self
+                    .trains_by_speedlimit
+                    .get(&speed)
+                    .cloned()
+                    .unwrap_or_default();
+                rs_trains.intersection(&speed_trains).cloned().collect()
+            }
+            (None, None) => unreachable!("Should not be reachable, checked at the API level"),
+        };
+
+        tracing::debug!(
+            nb_train = compliant_trains.len(),
+            "Compliant trains by specifications"
+        );
+
+        for (from, to) in waypoints.into_iter().filter(|w| w.stop).tuple_windows() {
+            let trains_in_segment = self.trains_by_segment.get(&Segment { from, to });
+            if let Some(ids) = trains_in_segment {
+                for index in ids {
+                    if compliant_trains.contains(index) {
+                        valid_trains.insert(*index);
+                    }
+                }
+            }
+        }
+
+        tracing::debug!(nb_train = valid_trains.len(), "Compliant trains");
+
+        valid_trains
+            .iter()
+            .map(|train_id| {
+                self.trains_by_id
+                    .get(train_id)
+                    .expect("Bad consistency in train traffic indices")
+                    .clone()
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use chrono::DateTime;
+    use chrono::Utc;
+    use std::str::FromStr;
+
+    use super::graph;
+    use crate::views::timetable::similar_trains::OperationalPoint;
+    use crate::views::timetable::similar_trains::PastTrain;
+    use crate::views::timetable::similar_trains::trains_traffic::Segment;
+    use crate::views::timetable::similar_trains::trains_traffic::TrainTraffic;
+
+    use super::TrainsTrafficPool;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn load_traffic_file() {
+        let valid_traffic_date =
+            DateTime::<Utc>::from_str("2025-03-01T00:00:00Z").expect("Date should be valid");
+
+        let mut traffic = TrainsTrafficPool::new_with_date(valid_traffic_date);
+        let operational_points = vec![
+            graph::Waypoint {
+                op: OperationalPoint("A".into()),
+                stop: true,
+            },
+            graph::Waypoint {
+                op: OperationalPoint("B".into()),
+                stop: false,
+            },
+            graph::Waypoint {
+                op: OperationalPoint("C".into()),
+                stop: true,
+            },
+            graph::Waypoint {
+                op: OperationalPoint("D".into()),
+                stop: true,
+            },
+        ];
+        traffic
+            .add_train_traffic(TrainTraffic {
+                name: "TEST_123".to_string(),
+                start_time: DateTime::<Utc>::from_str("2025-03-26T00:00:00Z")
+                    .expect("Date should be valid"),
+                rolling_stock: "RS_V1".to_string(),
+                speed_limit_tag: "MA100".to_string(),
+                train: PastTrain::new(0, operational_points.clone()),
+            })
+            .expect("Train TEST_123 should be imported");
+        traffic
+            .add_train_traffic(TrainTraffic {
+                name: "TEST_321".to_string(),
+                start_time: DateTime::<Utc>::from_str("2025-07-14T00:00:00Z")
+                    .expect("Date should be valid"),
+                rolling_stock: "RS_V2".to_string(),
+                speed_limit_tag: "MA100".to_string(),
+                train: PastTrain::new(1, operational_points.clone()),
+            })
+            .expect("Train TEST_321 should be imported");
+        traffic
+            .add_train_traffic(TrainTraffic {
+                name: "OUTDATED".to_string(),
+                start_time: DateTime::<Utc>::from_str("2025-02-01T00:00:00Z")
+                    .expect("Date should be valid"),
+                rolling_stock: "RS_V2".to_string(),
+                speed_limit_tag: "MA100".to_string(),
+                train: PastTrain::new(2, operational_points.clone()),
+            })
+            .expect("Train OUTDATED should be imported");
+
+        // Checking that train traffic are loaded
+        assert_eq!(traffic.len(), 2);
+
+        let train_123 = traffic.get_by_id(0).expect("TEST_123 should be imported");
+        assert_eq!(train_123.name, "TEST_123");
+        assert_eq!(train_123.rolling_stock, "RS_V1");
+        assert_eq!(train_123.speed_limit_tag, "MA100");
+        assert_eq!(
+            train_123.start_time,
+            DateTime::<Utc>::from_str("2025-03-26T00:00:00Z").expect("Date should be valid")
+        );
+
+        let train_321 = traffic.get_by_id(1).expect("TEST_321 should be imported");
+        assert_eq!(train_321.name, "TEST_321");
+        assert_eq!(train_321.rolling_stock, "RS_V2");
+        assert_eq!(train_321.speed_limit_tag, "MA100");
+        assert_eq!(
+            train_321.start_time,
+            DateTime::<Utc>::from_str("2025-07-14T00:00:00Z").expect("Date should be valid")
+        );
+
+        // Checking the inner indices
+        assert_eq!(
+            traffic.trains_by_rollingstock.get("RS_V1").unwrap().len(),
+            1
+        );
+        assert_eq!(
+            traffic.trains_by_rollingstock.get("RS_V2").unwrap().len(),
+            1
+        );
+        assert_eq!(traffic.trains_by_speedlimit.get("MA100").unwrap().len(), 2);
+
+        // trains_by_segment index should contains A->C & C->D, but not A->B
+        assert_eq!(
+            traffic
+                .trains_by_segment
+                .get(&Segment {
+                    from: graph::Waypoint {
+                        op: OperationalPoint("A".into()),
+                        stop: true
+                    },
+                    to: graph::Waypoint {
+                        op: OperationalPoint("C".into()),
+                        stop: true
+                    },
+                })
+                .expect("Segment should exist")
+                .len(),
+            2
+        );
+        assert_eq!(
+            traffic
+                .trains_by_segment
+                .get(&Segment {
+                    from: graph::Waypoint {
+                        op: OperationalPoint("C".into()),
+                        stop: true
+                    },
+                    to: graph::Waypoint {
+                        op: OperationalPoint("D".into()),
+                        stop: true
+                    },
+                })
+                .expect("Segment should exist")
+                .len(),
+            2
+        );
+        assert!(!traffic.trains_by_segment.contains_key(&Segment {
+            from: graph::Waypoint {
+                op: OperationalPoint("A".into()),
+                stop: true
+            },
+            to: graph::Waypoint {
+                op: OperationalPoint("B".into()),
+                stop: true
+            },
+        }));
+    }
+}

--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -257,11 +257,10 @@
       "ParseError": "Failed to parse train_id: '{{train_id}}'",
       "similar_trains": {
         "Database": "Internal error (database)",
-        "InfraNotFound": "Infrastructure '{{infra_id}}' does not exist",
+        "EmptyTrainsTraffic": "Trains traffic data are empty",
         "InvalidPath": "Invalid path in schedule",
         "RollingStockNotFound": "Rolling stock '{{rolling_stock_name}}' does not exist",
-        "SpeedLimitNotFound": "Speed limit tag '{{speed_limit_tag}}' does not exist",
-        "TimetableNotFound": "Timetable '{{timetable_id}}' could not be found"
+        "SpeedLimitNotFound": "Speed limit tag '{{speed_limit_tag}}' does not exist"
       }
     },
     "towedrollingstocks": {

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -257,11 +257,10 @@
       "ParseError": "Impossible de parser train_id : '{{train_id}}'",
       "similar_trains": {
         "Database": "Erreur interne (base de données)",
-        "InfraNotFound": "Infrastructure '{{infra_id}}' non trouvée",
+        "EmptyTrainsTraffic": "Les données de circulation sont vides",
         "InvalidPath": "Chemin invalide dans la circulation",
         "RollingStockNotFound": "Matériel roulant '{{rolling_stock_name}}' non trouvé",
-        "SpeedLimitNotFound": "Code de composition '{{speed_limit_tag}}' non trouvé",
-        "TimetableNotFound": "Grille horaire '{{timetable_id}}' non trouvée"
+        "SpeedLimitNotFound": "Code de composition '{{speed_limit_tag}}' non trouvé"
       }
     },
     "towedrollingstocks": {

--- a/front/src/applications/stdcm/components/StdcmResults/StdcmResults.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/StdcmResults.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 
 import { Button } from '@osrd-project/ui-core';
 import { PDFDownloadLink } from '@react-pdf/renderer';
+import { head, last } from 'lodash';
 import { useTranslation, Trans } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
@@ -24,7 +25,6 @@ import {
   getRetainedSimulationIndex,
   getSelectedSimulation,
   getStdcmInfraID,
-  getStdcmTimetableID,
 } from 'reducers/osrdconf/stdcmConf/selectors';
 import useDeploymentSettings from 'utils/hooks/useDeploymentSettings';
 
@@ -57,7 +57,6 @@ const StdcmResults = ({
   displayInfoMessage,
 }: StcdmResultsProps) => {
   const infraId = useSelector(getStdcmInfraID);
-  const timetableId = useSelector(getStdcmTimetableID);
   const { openModal, closeModal } = useModal();
   const railwayManagerUrl = useSelector(getRailwayManagerInterfaceUrl);
 
@@ -139,19 +138,13 @@ const StdcmResults = ({
           };
         });
 
-        const baseRequest = {
-          infra_id: infraId,
-          timetable_id: timetableId,
-          waypoints,
-        };
-
         const hasNullTrains = (trains: PostSimilarTrainsApiResponse['similar_trains']) =>
           trains.some((segment) => segment.train === null);
 
         // Call 1: Full criteria
         const fullCriteriaResponse = await postSimilarTrains({
           body: {
-            ...baseRequest,
+            waypoints,
             rolling_stock: {
               name: consist.tractionEngine?.name ?? '',
               speed_limit_tag: consist.speedLimitByTag,
@@ -161,13 +154,37 @@ const StdcmResults = ({
 
         const fullCriteriaSegments = fullCriteriaResponse.data?.similar_trains ?? [];
 
+        // Checking if similar train API has data or not
+        // If not, we can skip others call and set the similar train with the default value
+        if (
+          fullCriteriaResponse &&
+          fullCriteriaResponse.error &&
+          'data' in fullCriteriaResponse.error &&
+          fullCriteriaResponse.error.data.type ===
+            'editoast:timetable:similar_trains:EmptyTrainsTraffic'
+        ) {
+          const emptySimilarTrains = addSecondaryCodesToSimilarTrains(
+            [
+              {
+                train: null,
+                begin: head(waypoints)!.id,
+                end: last(waypoints)!.id,
+              },
+            ],
+            (selectedSimulation.outputs as StdcmResultsOutput).pathProperties
+              .manchetteOperationalPoints
+          );
+          setSimilarTrains(emptySimilarTrains);
+          return;
+        }
+
         // Call 2: Only speed_limit_tag (if needed)
         const segmentsWithSpeedLimitTagConstraint =
           hasNullTrains(fullCriteriaSegments) && consist.speedLimitByTag
             ? (
                 await postSimilarTrains({
                   body: {
-                    ...baseRequest,
+                    waypoints,
                     rolling_stock: { speed_limit_tag: consist.speedLimitByTag },
                   },
                 })
@@ -182,7 +199,7 @@ const StdcmResults = ({
             ? (
                 await postSimilarTrains({
                   body: {
-                    ...baseRequest,
+                    waypoints,
                     rolling_stock: { name: consist.tractionEngine.name },
                   },
                 })

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -2221,12 +2221,10 @@ export type PostSimilarTrainsApiResponse =
   };
 export type PostSimilarTrainsApiArg = {
   body: {
-    infra_id: number;
     rolling_stock: {
       name?: string | null;
       speed_limit_tag?: string | null;
     };
-    timetable_id: number;
     waypoints: SimilarTrainWaypoint[];
   };
 };


### PR DESCRIPTION
## Description 

closes #13290

At server start, loading in memory a traffic file, and use those trains traffic to find similar train.
    
On the similar endpoint, infra_id & timetable_id are not needed anymore. 
This impact the front code.

## Some notes

On the editoast CLI , you can run the server with the option `--trains-traffic-path` where its value is the path to the train traffic ndjson file (there is a sample in `tests/train-traffic.ndjson`) or by having the env variable `EDITOAST_TRAINS_TRAFFIC_PATH`. 

In the docker compose, this env variable is used. 

At startup the file is read, and loaded in a memory structure. Everything is  located in the `./src/views/timetable/similar_trains/trains_traffic.rs`

On the similar train endpoint, this memory structure is used to find good candidate. 
It replace the query to the train_schedule with the path finding.

The algo for similar train stays the same.

NB: on ther server CLI command ,I tried to put `trains_traffic_path` as an `Option`, but don't know why it doesn't work.

