### PR TITLE
editoast: create garbage-collector CLI command to delete orphaned timetables

### DIFF
--- a/editoast/src/client/garbage_collector.rs
+++ b/editoast/src/client/garbage_collector.rs
@@ -1,0 +1,76 @@
+use crate::models::timetable::Timetable;
+use database::DbConnectionPoolV2;
+use std::sync::Arc;
+
+pub async fn run_garbage_collector(db_pool: Arc<DbConnectionPoolV2>) -> anyhow::Result<()> {
+    clean_orphaned_timetables(&db_pool).await?;
+    Ok(())
+}
+
+/// Deletes timetables that are not referenced by any Scenario or StdcmSearchEnvironment
+async fn clean_orphaned_timetables(db_pool: &Arc<DbConnectionPoolV2>) -> anyhow::Result<()> {
+    let conn = &mut db_pool.get().await?;
+
+    println!("🧹 Removing orphaned timetables...");
+    let deleted_count = Timetable::delete_orphaned(conn).await?;
+
+    if deleted_count == 0 {
+        println!("✨ No orphaned timetables found");
+    } else {
+        println!("✅ {} orphaned timetable(s) deleted", deleted_count);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::fixtures::create_scenario_fixtures_set;
+    use crate::models::fixtures::create_timetable;
+    use crate::models::stdcm_search_environment::StdcmSearchEnvironment;
+    use crate::models::stdcm_search_environment::tests::stdcm_search_env_fixtures;
+    use editoast_models::prelude::*;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn test_clean_orphaned_timetables() {
+        let db_pool = Arc::new(DbConnectionPoolV2::for_tests());
+        let conn = &mut db_pool.get_ok();
+
+        // Timetable referenced by Scenario
+        let scenario_set = create_scenario_fixtures_set(conn, "test_scenario").await;
+
+        // Timetable referenced by StdcmSearchEnvironment
+        let (infra, _timetable, work_schedule_group, temp_speed_limit_group, eps) =
+            stdcm_search_env_fixtures(conn).await;
+        let timetable_with_stdcm = create_timetable(conn).await;
+        let _stdcm_env = StdcmSearchEnvironment::changeset()
+            .infra_id(infra.id)
+            .electrical_profile_set_id(Some(eps.id))
+            .work_schedule_group_id(Some(work_schedule_group.id))
+            .temporary_speed_limit_group_id(Some(temp_speed_limit_group.id))
+            .timetable_id(timetable_with_stdcm.id)
+            .search_window_begin(chrono::Utc::now())
+            .search_window_end(chrono::Utc::now() + chrono::Duration::hours(1))
+            .enabled_from(chrono::Utc::now())
+            .enabled_until(chrono::Utc::now() + chrono::Duration::hours(1))
+            .create(conn)
+            .await
+            .expect("Failed to create StdcmSearchEnvironment");
+
+        // Orphaned timetables
+        let orphaned1 = create_timetable(conn).await;
+        let orphaned2 = create_timetable(conn).await;
+
+        clean_orphaned_timetables(&db_pool).await.unwrap();
+
+        for orphaned_id in &[orphaned1.id, orphaned2.id] {
+            let found = Timetable::exists(conn, *orphaned_id).await.unwrap();
+            assert!(!found, "Timetable should not exists anymore")
+        }
+
+        for kept_id in &[scenario_set.timetable.id, timetable_with_stdcm.id] {
+            let found = Timetable::exists(conn, *kept_id).await.unwrap();
+            assert!(found, "Timetable should exist")
+        }
+    }
+}

--- a/editoast/src/client/mod.rs
+++ b/editoast/src/client/mod.rs
@@ -1,4 +1,5 @@
 pub mod electrical_profiles_commands;
+pub mod garbage_collector;
 pub mod group;
 pub mod healthcheck;
 pub mod import_rolling_stock;
@@ -96,6 +97,8 @@ pub enum Commands {
     User(UserCommand),
     #[command(about, long_about = "Healthcheck")]
     Healthcheck(CoreArgs),
+    #[command(about, long_about = "Garbage collector")]
+    Gc,
 }
 
 /// Prints the OpenApi to stdout

--- a/editoast/src/main.rs
+++ b/editoast/src/main.rs
@@ -19,6 +19,7 @@ use client::Client;
 use client::Color;
 use client::Commands;
 use client::electrical_profiles_commands::*;
+use client::garbage_collector;
 use client::group;
 use client::group::GroupCommand;
 use client::healthcheck::healthcheck_cmd;
@@ -229,5 +230,6 @@ async fn run() -> anyhow::Result<()> {
         Commands::Healthcheck(core_config) => {
             healthcheck_cmd(db_pool.into(), valkey_config, core_config, openfga_config).await
         }
+        Commands::Gc => garbage_collector::run_garbage_collector(db_pool.into()).await,
     }
 }

--- a/editoast/src/models/timetable.rs
+++ b/editoast/src/models/timetable.rs
@@ -109,6 +109,28 @@ impl Timetable {
         .await;
         train_schedules.map_err(|e| e.into())
     }
+
+    /// Deletes timetables that are not referenced by any Scenario or StdcmSearchEnvironment
+    /// Returns the number of deleted timetables
+    pub async fn delete_orphaned(
+        conn: &mut DbConnection,
+    ) -> Result<usize, database::DatabaseError> {
+        use database::tables::scenario::dsl as scenario_dsl;
+        use database::tables::stdcm_search_environment::dsl as stdcm_dsl;
+        use database::tables::timetable::dsl as timetable_dsl;
+
+        diesel::delete(timetable_dsl::timetable)
+            .filter(diesel::dsl::not(diesel::dsl::exists(
+                scenario_dsl::scenario.filter(scenario_dsl::timetable_id.eq(timetable_dsl::id)),
+            )))
+            .filter(diesel::dsl::not(diesel::dsl::exists(
+                stdcm_dsl::stdcm_search_environment
+                    .filter(stdcm_dsl::timetable_id.eq(timetable_dsl::id)),
+            )))
+            .execute(conn.write().await.deref_mut())
+            .await
+            .map_err(Into::into)
+    }
 }
 
 /// Should be used to retrieve a timetable with its trains


### PR DESCRIPTION
Introduces a new `gc` command to the CLI, enabling the cleanup of orphaned timetables (not referenced by any `Scenario` or `StdcmSearchEnvironment`):

* Added `garbage_collector` module with `run_garbage_collector` function that deletes orphaned timetables
* Added a method `delete_orphaned` to the `Timetable` model to perform the actual database deletion of orphaned timetables
* Registered the `GarbageCollector` command in the CLI
* Integrated the garbage collector command into the main application flow