### PR TITLE
editoast: fga_migrations: remove useless import

### DIFF
--- a/editoast/fga_migrations/src/lib.rs
+++ b/editoast/fga_migrations/src/lib.rs
@@ -12,7 +12,6 @@ use indexmap::indexmap;
 use itertools::Either;
 use sha1::Digest;
 use sha1::Sha1;
-use tracing::error;
 use tracing::info;
 use tracing::instrument;
 


### PR DESCRIPTION
Signed-off-by: Leo Valais <leo.valais97@gmail.com>
