### PR TITLE
core: stdcm: fix some cases where we couldn't find a valid sim

### DIFF
--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/EnvelopePhysics.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/EnvelopePhysics.java
@@ -42,7 +42,10 @@ public class EnvelopePhysics {
     public static double interpolateStepTime(
             double lastPos, double nextPos, double lastSpeed, double nextSpeed, double positionDelta) {
         var acceleration = stepAcceleration(lastPos, nextPos, lastSpeed, nextSpeed);
-        if (areAccelerationsEqual(acceleration, 0.0)) return Math.abs(positionDelta / lastSpeed);
+        if (areAccelerationsEqual(acceleration, 0.0)) {
+            var averageSpeed = (lastSpeed + nextSpeed) / 2;
+            return Math.abs(positionDelta / averageSpeed);
+        }
         var interpolatedSpeed = interpolateStepSpeed(acceleration, lastSpeed, positionDelta);
         return Math.abs((interpolatedSpeed - lastSpeed) / acceleration);
     }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/PostProcessingSimulation.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/PostProcessingSimulation.kt
@@ -7,6 +7,7 @@ import fr.sncf.osrd.envelope_sim.allowances.AllowanceValue
 import fr.sncf.osrd.envelope_sim.allowances.LinearAllowance
 import fr.sncf.osrd.envelope_sim.allowances.MarecoAllowance
 import fr.sncf.osrd.path.interfaces.PhysicsPath
+import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.path.interfaces.TravelledPath
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
 import fr.sncf.osrd.reporting.exceptions.ErrorType
@@ -21,6 +22,7 @@ import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import java.util.*
 import kotlin.math.max
+import kotlin.math.min
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -35,6 +37,12 @@ private data class FixedTimePoint(
         return offset.compareTo(other.offset)
     }
 }
+
+private data class EngineeringAllowanceRange(
+    val from: Offset<TrainPath>,
+    val to: Offset<TrainPath>,
+    val addedDuration: Double,
+)
 
 /**
  * Build the final envelope, this time without any approximation. Apply the allowances properly. The
@@ -70,6 +78,7 @@ fun buildFinalEnvelope(
             Distance(millimeters = edges.sumOf { it.length.distance.millimeters })
         )
     assert(incrementalPath.pathComplete)
+    val allowanceRanges = getEngineeringAllowanceRanges(edges)
     val fixedPoints =
         initFixedPoints(
             edges,
@@ -79,6 +88,7 @@ fun buildFinalEnvelope(
                 standardAllowance.getAllowanceTime(maxSpeedEnvelope.totalTime, pathLength.meters) >
                     0.0,
             updatedTimeData,
+            allowanceRanges,
         )
 
     val maxIterations = edges.size * 2 // just to avoid infinite loops on bugs or edge cases
@@ -112,7 +122,14 @@ fun buildFinalEnvelope(
                 )
             }
             val newPoint =
-                makeFixedPoint(fixedPoints, edges, conflictOffset, pathLength, updatedTimeData)
+                makeFixedPoint(
+                    fixedPoints,
+                    edges,
+                    conflictOffset,
+                    pathLength,
+                    updatedTimeData,
+                    allowanceRanges,
+                )
             postProcessingLogger.info(
                 "Conflict when running final stdcm simulation at offset $conflictOffset, adding a fixed time point: $newPoint"
             )
@@ -174,6 +191,7 @@ private fun initFixedPoints(
     length: Length<TravelledPath>,
     hasStandardAllowance: Boolean,
     updatedTimeData: TimeData,
+    allowanceRanges: List<EngineeringAllowanceRange>,
 ): TreeSet<FixedTimePoint> {
     val res = TreeSet<FixedTimePoint>()
 
@@ -187,6 +205,7 @@ private fun initFixedPoints(
                 Offset(Distance.fromMeters(stop.position)),
                 length,
                 updatedTimeData,
+                allowanceRanges,
                 stop.duration,
             )
         )
@@ -195,27 +214,18 @@ private fun initFixedPoints(
 
     // Add one point at the end to match the standard allowance (if any)
     if (hasStandardAllowance && res.none { it.offset == length })
-        res.add(makeFixedPoint(res, edges, length, length, updatedTimeData, 0.0))
+        res.add(makeFixedPoint(res, edges, length, length, updatedTimeData, allowanceRanges))
 
     // Add points at the end of each engineering allowance
-    var edgeStartOffset = 0.meters
-    val allowanceEndOffsets = mutableSetOf<Distance>()
-    for (edge in edges) {
-        val engineeringAllowanceLength = edge.engineeringAllowance?.length
-        if (engineeringAllowanceLength != null) {
-            val engineeringAllowanceBegin = edgeStartOffset - engineeringAllowanceLength
-            val engineeringAllowanceEnd = edgeStartOffset
-
-            // Edges can have overlapping engineering allowance, only the last one is relevant.
-            // So we remove any point in the current allowance range.
-            allowanceEndOffsets.removeIf { it > engineeringAllowanceBegin }
-            allowanceEndOffsets.add(engineeringAllowanceEnd)
-        }
-        edgeStartOffset += edge.length.distance
+    val allowanceEndOffsets = mutableListOf<Offset<TrainPath>>()
+    for ((from, to, _) in allowanceRanges) {
+        // When ranges overlap, we start with just the last point
+        allowanceEndOffsets.removeIf { it > from }
+        allowanceEndOffsets.add(to)
     }
     for (offset in allowanceEndOffsets) {
-        if (res.none { it.offset.distance == offset }) {
-            res.add(makeFixedPoint(res, edges, Offset(offset), length, updatedTimeData))
+        if (res.none { it.offset == offset }) {
+            res.add(makeFixedPoint(res, edges, offset, length, updatedTimeData, allowanceRanges))
         }
     }
     logger.info("initial fixed time points:")
@@ -223,9 +233,37 @@ private fun initFixedPoints(
     return res
 }
 
+private fun getEngineeringAllowanceRanges(edges: List<STDCMEdge>): List<EngineeringAllowanceRange> {
+    var edgeStartOffset = Offset.zero<TrainPath>()
+    val res = mutableListOf<EngineeringAllowanceRange>()
+    for (edge in edges) {
+        val allowance = edge.engineeringAllowance
+        if (allowance != null) {
+            val engineeringAllowanceLength = allowance.length
+            val engineeringAllowanceBegin = edgeStartOffset - engineeringAllowanceLength
+            val engineeringAllowanceEnd = edgeStartOffset
+
+            val duration = allowance.extraDuration
+            res.add(
+                EngineeringAllowanceRange(
+                    engineeringAllowanceBegin,
+                    engineeringAllowanceEnd,
+                    duration,
+                )
+            )
+        }
+        edgeStartOffset += edge.length.distance
+    }
+    return res
+}
+
 /**
- * Create a new fixed point at a given offset **rounded to an edge transition**. The reference time
- * is fetched on the given edges.
+ * Create a new time point to best avoid the conflict at the given location.
+ *
+ * If the point is in an engineering allowance range, we add a point at the end of that range. We
+ * then try to add the point at the nearest edge transition. When trying to add a point at a
+ * location that already has a point, we move down the priority list. (allowance range end -> edge
+ * transition -> input offset). Once we have the offset, the time is fetched on the reference edges.
  *
  * The reason we round it to the start of the edge is because we don't have a reliable way to fetch
  * the time of a location on an edge, we can only make approximations. If that approximation falls
@@ -234,9 +272,8 @@ private fun initFixedPoints(
  * causes issues. It can be done but adds some complexity, it's out of scope of the current
  * refactoring.
  *
- * We first try to round the offset on the edge end, if there is already a fixed point there we use
- * the edge start instead. When a conflict happens in the middle of an edge, we *sometimes* need to
- * set both. If both are already set, we keep the conflict offset as it is.
+ * TODO: this current method doesn't seem to *always* converge to a valid solution, especially as
+ *   the standalone sim may fail to compute short allowance ranges.
  */
 private fun makeFixedPoint(
     fixedPoints: TreeSet<FixedTimePoint>,
@@ -244,8 +281,23 @@ private fun makeFixedPoint(
     conflictOffset: Offset<TravelledPath>,
     pathLength: Length<TravelledPath>,
     updatedTimeData: TimeData,
+    allowanceRanges: List<EngineeringAllowanceRange>,
     stopDuration: Double = 0.0,
 ): FixedTimePoint {
+
+    val endOfLastAllowance =
+        allowanceRanges
+            .filter { conflictOffset in it.from..it.to }
+            .map { it.to }
+            .filter { conflictOffset -> fixedPoints.none { it.offset == conflictOffset } }
+            .maxOrNull()
+    if (endOfLastAllowance != null)
+        return FixedTimePoint(
+            getTimeOnEdges(edges, endOfLastAllowance, updatedTimeData),
+            endOfLastAllowance,
+            if (stopDuration > 0) stopDuration else null,
+        )
+
     var offset = roundOffset(edges, Offset.min(conflictOffset, pathLength), true)
     if (fixedPoints.any { it.offset == offset }) {
         offset = roundOffset(edges, conflictOffset, false)
@@ -254,11 +306,9 @@ private fun makeFixedPoint(
         offset = conflictOffset
     }
     offset = Offset.min(offset, pathLength)
-    return FixedTimePoint(
-        getTimeOnEdges(edges, offset, updatedTimeData),
-        offset,
-        if (stopDuration > 0) stopDuration else null,
-    )
+
+    val time = getTimeOnEdges(edges, offset, updatedTimeData)
+    return FixedTimePoint(time, offset, if (stopDuration > 0) stopDuration else null)
 }
 
 /**

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/EngineeringAllowanceTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/EngineeringAllowanceTests.kt
@@ -4,11 +4,13 @@ import com.google.common.collect.ImmutableMultimap
 import fr.sncf.osrd.pathfinding.Pathfinding.EdgeLocation
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
 import fr.sncf.osrd.sim_infra.api.Block
+import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.stdcm.preprocessing.OccupancySegment
 import fr.sncf.osrd.train.TestTrains
 import fr.sncf.osrd.utils.DummyInfra
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
+import kotlin.Double.Companion.POSITIVE_INFINITY
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
@@ -66,7 +68,7 @@ class EngineeringAllowanceTests {
                 firstBlock,
                 OccupancySegment(
                     firstBlockEnvelope.totalTime + 10,
-                    Double.POSITIVE_INFINITY,
+                    POSITIVE_INFINITY,
                     0.meters,
                     1000.meters,
                 ),
@@ -149,7 +151,7 @@ class EngineeringAllowanceTests {
                 firstBlock,
                 OccupancySegment(
                     firstBlockEnvelope.totalTime + timeStep,
-                    Double.POSITIVE_INFINITY,
+                    POSITIVE_INFINITY,
                     0.meters,
                     1000.meters,
                 ),
@@ -236,19 +238,14 @@ class EngineeringAllowanceTests {
                 firstBlock,
                 OccupancySegment(
                     firstBlockEnvelope.totalTime + timeStep,
-                    Double.POSITIVE_INFINITY,
+                    POSITIVE_INFINITY,
                     0.meters,
                     1000.meters,
                 ),
                 lastBlock,
                 OccupancySegment(0.0, timeLastBlockFree, 0.meters, 1000.meters),
                 thirdBlock,
-                OccupancySegment(
-                    timeThirdBlockOccupied,
-                    Double.POSITIVE_INFINITY,
-                    0.meters,
-                    1000.meters,
-                ),
+                OccupancySegment(timeThirdBlockOccupied, POSITIVE_INFINITY, 0.meters, 1000.meters),
             )
         val res =
             STDCMPathfindingBuilder()
@@ -340,7 +337,7 @@ class EngineeringAllowanceTests {
                 firstBlock,
                 OccupancySegment(0.0, 600.0, 0.meters, 100.meters),
                 firstBlock,
-                OccupancySegment(2000.0, Double.POSITIVE_INFINITY, 0.meters, 100.meters),
+                OccupancySegment(2000.0, POSITIVE_INFINITY, 0.meters, 100.meters),
                 secondBlock,
                 OccupancySegment(0.0, 1200.0, 0.meters, 100.meters),
                 thirdBlock,
@@ -358,6 +355,73 @@ class EngineeringAllowanceTests {
                 .setTimeStep(timeStep)
                 .run()!!
         occupancyTest(res, occupancyGraph, 2 * timeStep)
+    }
+
+    /**
+     * Similar test as above, but values have been tweaked to reproduce #13910.
+     *
+     * There's only a short opening around the area of the first engineering allowance.
+     */
+    @Test
+    fun testSeveralDelaysWithLargeTimeDiff() {
+        /*
+        Occupancy graph is similar to this (with lots of blocks and long durations):
+
+        space
+          ^
+          |########################################
+          |######################################
+          |####################################
+          |##################################
+          |################################
+          |##########*
+          |          ^
+          |
+          |
+          start ###########################################-> time
+
+          Each block in the second half has its own engineering allowance.
+          They all extend back to the path start.
+
+          At first, there's only one fixed time point at the end.
+          Then one is added at the first conflict location, the point
+          marked with a star. It's then impossible to add an engineering
+          allowance that avoids the next conflict.
+         */
+        val infra = DummyInfra()
+        val length = 2_000.meters
+        val blocks = mutableListOf<BlockId>()
+        for (i in 0..20) {
+            blocks.add(infra.addBlock(i.toString(), (i + 1).toString(), length, 10.0))
+        }
+
+        val occupancyGraphBuilder = ImmutableMultimap.builder<BlockId, OccupancySegment>()
+        fun segment(blockIndex: Int, from: Double, to: Double) {
+            occupancyGraphBuilder.put(
+                blocks[blockIndex],
+                OccupancySegment(from, to, 0.meters, length),
+            )
+        }
+
+        // Very large values makes the error easier to reproduce
+        val t = 300_000.0
+        segment(9, 0.0, t - 20_000.0)
+        for (i in 0..10) {
+            val from = t + i * 300.0
+            segment(10 + i, 0.0, from)
+        }
+
+        val occupancyGraph = occupancyGraphBuilder.build()
+        val res =
+            STDCMPathfindingBuilder()
+                .setInfra(infra.fullInfra())
+                .setStartLocations(setOf(EdgeLocation(blocks.first(), Offset(0.meters))))
+                .setEndLocations(setOf(EdgeLocation(blocks.last(), Offset(1.meters))))
+                .setUnavailableTimes(occupancyGraph)
+                .setMaxRunTime(POSITIVE_INFINITY)
+                .setMaxDepartureDelay(0.0)
+                .run()!!
+        occupancyTest(res, occupancyGraph)
     }
 
     /**
@@ -390,7 +454,7 @@ class EngineeringAllowanceTests {
         val occupancyGraph =
             ImmutableMultimap.of(
                 firstBlock,
-                OccupancySegment(1_000.0, Double.POSITIVE_INFINITY, 0.meters, 100.meters),
+                OccupancySegment(1_000.0, POSITIVE_INFINITY, 0.meters, 100.meters),
                 secondBlock,
                 OccupancySegment(0.0, 800.0, 0.meters, 100.meters),
                 thirdBlock,
@@ -404,7 +468,7 @@ class EngineeringAllowanceTests {
                 .setStartLocations(setOf(EdgeLocation(firstBlock, Offset(0.meters))))
                 .setEndLocations(setOf(EdgeLocation(forthBlock, Offset(1.meters))))
                 .setUnavailableTimes(occupancyGraph)
-                .setMaxRunTime(Double.POSITIVE_INFINITY)
+                .setMaxRunTime(POSITIVE_INFINITY)
                 .run() ?: return // No solution found is valid here (and expected)
         // But if we find a solution there must be no conflict
         occupancyTest(res, occupancyGraph)
@@ -439,7 +503,7 @@ class EngineeringAllowanceTests {
         val occupancyGraph =
             ImmutableMultimap.of(
                 blocks[0],
-                OccupancySegment(300.0, Double.POSITIVE_INFINITY, 0.meters, 1000.meters),
+                OccupancySegment(300.0, POSITIVE_INFINITY, 0.meters, 1000.meters),
                 blocks[2],
                 OccupancySegment(0.0, 3600.0, 0.meters, 1000.meters),
             )
@@ -449,7 +513,7 @@ class EngineeringAllowanceTests {
                 .setStartLocations(setOf(EdgeLocation(blocks[0], Offset<Block>(0.meters))))
                 .setEndLocations(setOf(EdgeLocation(blocks[2], Offset<Block>(1000.meters))))
                 .setUnavailableTimes(occupancyGraph)
-                .setMaxDepartureDelay(Double.POSITIVE_INFINITY)
+                .setMaxDepartureDelay(POSITIVE_INFINITY)
                 .run()
         Assertions.assertNull(res)
     }
@@ -490,7 +554,7 @@ class EngineeringAllowanceTests {
         val occupancyGraph =
             ImmutableMultimap.of(
                 blocks[0],
-                OccupancySegment(600.0, Double.POSITIVE_INFINITY, 0.meters, 1000.meters),
+                OccupancySegment(600.0, POSITIVE_INFINITY, 0.meters, 1000.meters),
                 blocks[3],
                 OccupancySegment(0.0, 2900.0, 0.meters, 1000.meters),
                 blocks[4],
@@ -501,8 +565,8 @@ class EngineeringAllowanceTests {
             .setStartLocations(setOf(EdgeLocation(blocks[0], Offset(0.meters))))
             .setEndLocations(setOf(EdgeLocation(blocks[4], Offset(1000.meters))))
             .setUnavailableTimes(occupancyGraph)
-            .setMaxDepartureDelay(Double.POSITIVE_INFINITY)
-            .setMaxRunTime(Double.POSITIVE_INFINITY)
+            .setMaxDepartureDelay(POSITIVE_INFINITY)
+            .setMaxRunTime(POSITIVE_INFINITY)
             .run()!!
     }
 
@@ -601,7 +665,7 @@ class EngineeringAllowanceTests {
                 firstBlock,
                 OccupancySegment(
                     firstBlockEnvelope.totalTime + 10,
-                    Double.POSITIVE_INFINITY,
+                    POSITIVE_INFINITY,
                     0.meters,
                     1000.meters,
                 ),


### PR DESCRIPTION
Fix https://github.com/OpenRailAssociation/osrd/issues/13910

I don't think it fixes *every* case, but for some of the most extreme cases I don't even think there is a solution (at least until the new standalone sim). It does fix the given request, and it should be a lot more reliable now. 

The unit test reproduces the issue and fails without this commit. I had to add a different fix to `EnvelopePhysics` to avoid an infinite in time deltas, a bug that's also reproduced by that same unit test. 

The unit test itself is a good description of what was going on. 
