### PR TITLE
editoast: core_task: reorganize `PathfindingEnv` to be more borrow-checker-friendly

### DIFF
--- a/editoast/core_client/src/lib.rs
+++ b/editoast/core_client/src/lib.rs
@@ -240,6 +240,33 @@ impl Error {
     }
 }
 
+// Manually implement Clone because serde_json::Error does not
+impl Clone for Error {
+    fn clone(&self) -> Self {
+        match self {
+            Self::CoreResponseFormatError { msg } => {
+                Self::CoreResponseFormatError { msg: msg.clone() }
+            }
+            Self::UnparsableErrorOutput => Self::UnparsableErrorOutput,
+            Self::BrokenPipe => Self::BrokenPipe,
+            Self::RawError(err) => Self::RawError(err.clone()),
+            Self::NoResponseContent => Self::NoResponseContent,
+            Self::MqClientError(err) => Self::MqClientError(match err {
+                MqClientError::Lapin(error) => MqClientError::Lapin(error.clone()),
+                MqClientError::Serialization(error) => MqClientError::Serialization(
+                    // This is actually a supported behavior of serde_json that is forced to parse
+                    // its own error message to comply with serde's API.
+                    <serde_json::Error as serde::ser::Error>::custom(error.to_string()),
+                ),
+                MqClientError::StatusParsing => MqClientError::StatusParsing,
+                MqClientError::ResponseTimeout => MqClientError::ResponseTimeout,
+                MqClientError::ConnectionDoesNotExist => MqClientError::ConnectionDoesNotExist,
+                MqClientError::PoolChannelFail => MqClientError::PoolChannelFail,
+            }),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct RawError {
     #[serde(rename = "type")]

--- a/editoast/core_task/src/envs.rs
+++ b/editoast/core_task/src/envs.rs
@@ -1,2 +1,10 @@
 pub mod core;
 pub mod pathfinding;
+
+/// A set of trains, a "Train" being the generic type parameter of environments
+///
+/// Most environments will receive and yield [TrainSet]s instead of individual trains
+/// as inputs are deduplicated to avoid running the same computation multiple times.
+/// Therefore a [TrainSet] is a set of trains of which input parameters boil down
+/// to the same Core request, thus yielding a single result.
+pub type TrainSet<Train> = std::collections::HashSet<Train>;

--- a/editoast/core_task/src/envs/pathfinding.rs
+++ b/editoast/core_task/src/envs/pathfinding.rs
@@ -32,16 +32,36 @@ where
 {
     // Inputs
     core_env: CoreEnv,
+    inputs: PathfindingEnvInputs<Train>,
+
+    // Outputs
+    // optionally deduplicate similar outputs of different inputs
+    paths: DashMap<Input, Arc<core_client::pathfinding::PathfindingCoreResult>>,
+}
+
+pub(crate) struct PathfindingEnvInputs<Train>
+where
+    Train: Clone + Hash + Eq + Send + Sync + 'static,
+{
     // TODO: deduplicate values
     consists: HashMap<Train, Arc<PathfindingConsist>>,
     constraints: HashMap<Train, Arc<PathfindingConstraints>>,
 
     // Generated
     trains: HashMap<Input, HashSet<Train>>, // inverse index: unique input set => trains
+}
 
-    // Outputs
-    // optionally deduplicate similar outputs of different inputs
-    paths: DashMap<Input, Arc<core_client::pathfinding::PathfindingCoreResult>>,
+impl<Train> Default for PathfindingEnvInputs<Train>
+where
+    Train: Clone + Hash + Eq + Send + Sync + 'static,
+{
+    fn default() -> Self {
+        Self {
+            consists: HashMap::default(),
+            constraints: HashMap::default(),
+            trains: HashMap::default(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
@@ -100,9 +120,7 @@ where
     pub fn new(core_env: CoreEnv) -> Self {
         Self {
             core_env,
-            consists: HashMap::new(),
-            constraints: HashMap::new(),
-            trains: HashMap::new(),
+            inputs: PathfindingEnvInputs::default(),
             paths: DashMap::new(),
         }
     }
@@ -113,11 +131,11 @@ where
     Train: Clone + Hash + Eq + Send + Sync + 'static,
 {
     fn extend<T: IntoIterator<Item = (Train, PathfindingConsist)>>(&mut self, iter: T) {
-        self.consists.extend(
+        self.inputs.consists.extend(
             iter.into_iter()
                 .map(|(train, consist)| (train, Arc::new(consist))),
         );
-        self.build_input_map();
+        self.inputs.build_input_map();
     }
 }
 
@@ -126,11 +144,11 @@ where
     Train: Clone + Hash + Eq + Send + Sync + 'static,
 {
     fn extend<T: IntoIterator<Item = (Train, PathfindingConstraints)>>(&mut self, iter: T) {
-        self.constraints.extend(
+        self.inputs.constraints.extend(
             iter.into_iter()
                 .map(|(train, constraints)| (train, Arc::new(constraints))),
         );
-        self.build_input_map();
+        self.inputs.build_input_map();
     }
 }
 
@@ -184,6 +202,7 @@ where
                       data: path,
                   }| {
                 let trains = self
+                    .inputs
                     .trains
                     .get(&input)
                     .expect("deduplicate_inputs invariant")
@@ -218,6 +237,7 @@ where
                       data: path,
                   }| {
                 let trains = self
+                    .inputs
                     .trains
                     .get(&input)
                     .expect("deduplicate_inputs invariant")
@@ -225,17 +245,6 @@ where
                 (trains, path)
             },
         )
-    }
-
-    /// Returns all trains in the environment for which all needed information is configured
-    pub fn all_trains(&self) -> HashSet<Train> {
-        self.consists
-            .keys()
-            .collect::<HashSet<_>>()
-            .intersection(&self.constraints.keys().collect())
-            .cloned()
-            .cloned() // not an error, it's an &&Train originally
-            .collect()
     }
 
     /// Returns the path for a given train
@@ -251,22 +260,9 @@ where
         &self,
         train: &Train,
     ) -> Option<Arc<core_client::pathfinding::PathfindingCoreResult>> {
-        let input = self.train_input(train)?;
+        let input = self.inputs.train_input(train)?;
         let value_ref = self.paths.get(&input)?;
         Some(value_ref.value().clone())
-    }
-
-    /// Builds the [Self::trains] map using trains from both [Self::consists] and [Self::constraints]
-    ///
-    /// TODO: we should build it incrementally to avoid unnecessary complexity
-    fn build_input_map(&mut self) {
-        self.trains.clear();
-        for train in self.all_trains() {
-            let consist = self.consists.get(&train).expect("all_trains invariant");
-            let constraints = self.constraints.get(&train).expect("all_trains invariant");
-            let input = Input(consist.clone(), constraints.clone());
-            self.trains.entry(input).or_default().insert(train);
-        }
     }
 
     fn paths_stream(
@@ -280,7 +276,8 @@ where
         use crate::TaskStreamExt as _;
 
         let inputs = trains.iter().map(|train| {
-            self.train_input(train)
+            self.inputs
+                .train_input(train)
                 .expect("train map should have been built by now")
         });
         let requests = inputs
@@ -314,6 +311,39 @@ where
             rolling_stock_maximum_speed: consist.maximum_speed,
             rolling_stock_length: consist.length,
             speed_limit_tag: consist.speed_limit_tag.clone(),
+        }
+    }
+
+    pub fn all_trains(&self) -> HashSet<Train> {
+        self.inputs.all_trains()
+    }
+}
+
+impl<Train> PathfindingEnvInputs<Train>
+where
+    Train: Clone + Hash + Eq + Send + Sync + 'static,
+{
+    /// Returns all trains in the environment for which all needed information is configured
+    pub fn all_trains(&self) -> HashSet<Train> {
+        self.consists
+            .keys()
+            .collect::<HashSet<_>>()
+            .intersection(&self.constraints.keys().collect())
+            .cloned()
+            .cloned() // not an error, it's an &&Train originally
+            .collect()
+    }
+
+    /// Builds the [Self::trains] map using trains from both [Self::consists] and [Self::constraints]
+    ///
+    /// TODO: we should build it incrementally to avoid unnecessary complexity
+    fn build_input_map(&mut self) {
+        self.trains.clear();
+        for train in self.all_trains() {
+            let consist = self.consists.get(&train).expect("all_trains invariant");
+            let constraints = self.constraints.get(&train).expect("all_trains invariant");
+            let input = Input(consist.clone(), constraints.clone());
+            self.trains.entry(input).or_default().insert(train);
         }
     }
 
@@ -379,7 +409,7 @@ mod tests {
 
     impl PathfindingEnv<usize> {
         fn key(&self, id: usize) -> String {
-            let input = self.train_input(&id).unwrap();
+            let input = self.inputs.train_input(&id).unwrap();
             let request = self.build_request(&input);
             use crate::Task as _;
             request.key("")

--- a/editoast/core_task/src/envs/pathfinding.rs
+++ b/editoast/core_task/src/envs/pathfinding.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::collections::HashSet;
 use std::hash::DefaultHasher;
 use std::hash::Hash;
 use std::hash::Hasher as _;
@@ -18,6 +17,7 @@ use schemas::rolling_stock::LoadingGaugeType;
 use crate::CoreEnv;
 use crate::Correlated;
 use crate::Task;
+use crate::TrainSet;
 
 /// An environment to compute and cache paths asynchronously
 ///
@@ -45,7 +45,7 @@ where
     constraints: HashMap<Train, Arc<PathfindingConstraints>>,
 
     // Generated
-    trains: HashMap<Input, HashSet<Train>>, // inverse index: unique input set => trains
+    trains: HashMap<Input, TrainSet<Train>>, // inverse index: unique input set => trains
 }
 
 impl<Train> Default for PathfindingEnvInputs<Train>
@@ -67,7 +67,7 @@ struct Input(Arc<PathfindingConsist>, Arc<PathfindingConstraints>);
 /// The result of [PathfindingEnv::run]
 ///
 /// Stores each pathfinding result as they arrive. So [fn PathfindingRun::get_path]
-/// might return that a result is still pending. The train sets done being calculated
+/// might return that a result is still pending. The [TrainSet]s done being calculated
 /// can be tracked by providing a channel sender to [PathfindingEnv::run].
 ///
 /// Cheap to clone.
@@ -200,17 +200,17 @@ where
     /// Computes paths or fetches them from cache asynchronously
     ///
     /// Returns a [PathfindingRun] containing the calculated paths (or errors)
-    /// of each train set. They are pushed in the object progressively as the results
+    /// of each [TrainSet]. They are pushed in the object progressively as the results
     /// arrive. Hence why [fn PathfindingRun::get_path] returns a [Poll].
     ///
     /// To follow what's been calculated, this function accepts a channel sender
-    /// to notify each time a train set is done processing.
+    /// to notify each time a [TrainSet] is done processing.
     /// Note that the receivers implement [trait futures::stream::Stream].
     pub fn run(
         self,
         vkconn: cache::Connection,
-        trains: HashSet<Train>,
-        ready_trains_tx: Option<futures::channel::mpsc::UnboundedSender<HashSet<Train>>>,
+        trains: TrainSet<Train>,
+        ready_trains_tx: Option<futures::channel::mpsc::UnboundedSender<TrainSet<Train>>>,
     ) -> PathfindingRun<Train> {
         use stream::StreamExt as _;
         let (core_env, inputs) = self.decompose();
@@ -239,16 +239,16 @@ where
     /// Computes paths or fetches them from cache asynchronously
     ///
     /// Doesn't store the paths unlike [PathfindingEnv::run].
-    /// The returned stream yields a set of trains and their corresponding path directly,
+    /// The returned stream yields a [TrainSet] and their corresponding path directly,
     /// avoiding the caller to deal with the `Arc` returned by [PathfindingEnv::get_path],
     /// thus transferring ownership and allow easy path mutations.
     pub fn into_stream(
         self,
         vkconn: cache::Connection,
-        trains: HashSet<Train>,
+        trains: TrainSet<Train>,
     ) -> impl stream::Stream<
         Item = Correlated<
-            HashSet<Train>,
+            TrainSet<Train>,
             Result<core_client::pathfinding::PathfindingCoreResult, core_client::Error>,
         >,
     > {
@@ -271,7 +271,7 @@ where
 
     fn produce(
         vkconn: cache::Connection,
-        trains: HashSet<Train>,
+        trains: TrainSet<Train>,
         core_env: CoreEnv,
         inputs: Arc<PathfindingEnvInputs<Train>>,
     ) -> impl stream::Stream<
@@ -320,7 +320,7 @@ where
         }
     }
 
-    pub fn all_trains(&self) -> HashSet<Train> {
+    pub fn all_trains(&self) -> TrainSet<Train> {
         self.inputs.all_trains()
     }
 }
@@ -330,10 +330,10 @@ where
     Train: Clone + Hash + Eq + Send + Sync + 'static,
 {
     /// Returns all trains in the environment for which all needed information is configured
-    pub fn all_trains(&self) -> HashSet<Train> {
+    pub fn all_trains(&self) -> TrainSet<Train> {
         self.consists
             .keys()
-            .collect::<HashSet<_>>()
+            .collect::<TrainSet<_>>()
             .intersection(&self.constraints.keys().collect())
             .cloned()
             .cloned() // not an error, it's an &&Train originally
@@ -477,17 +477,20 @@ mod tests {
             "",
         );
         let all_trains = pfenv.all_trains();
-        assert_eq!(all_trains, HashSet::from([1, 2]));
+        assert_eq!(all_trains, TrainSet::from([1, 2]));
         let (tx, rx) = futures::channel::mpsc::unbounded();
         let pfrun = pfenv.run(vk.get_connection().await.unwrap(), all_trains, Some(tx));
         // timeout to avoid blocking the CI if something goes wrong
         let trains = tokio::time::timeout(Duration::from_secs(1), async move {
             use stream::StreamExt as _;
-            rx.map(stream::iter).flatten().collect::<HashSet<_>>().await
+            rx.map(stream::iter)
+                .flatten()
+                .collect::<TrainSet<_>>()
+                .await
         })
         .await
         .unwrap();
-        assert_eq!(trains, HashSet::from([1, 2]));
+        assert_eq!(trains, TrainSet::from([1, 2]));
         assert_eq!(
             pfrun.get_path(&1),
             Some(Poll::Ready(Ok(serde_json::from_value(path(1)).unwrap())))

--- a/editoast/core_task/src/envs/pathfinding.rs
+++ b/editoast/core_task/src/envs/pathfinding.rs
@@ -225,7 +225,7 @@ where
                            data,
                        }| {
                     if let Some(tx) = ready_trains_tx.as_ref() {
-                        let trains = inputs.trains.get(&input).expect("lolz").clone();
+                        let trains = inputs.input_train_set(&input).clone();
                         tx.unbounded_send(trains).ok();
                     }
                     paths.insert(input, Poll::Ready(data.map(Arc::new)));
@@ -259,11 +259,7 @@ where
                       correlation_key: input,
                       data: path,
                   }| {
-                let trains = inputs
-                    .trains
-                    .get(&input)
-                    .expect("deduplicate_inputs invariant")
-                    .clone();
+                let trains = inputs.input_train_set(&input).clone();
                 Correlated::new(trains, path)
             },
         )
@@ -357,6 +353,10 @@ where
         let consist = self.consists.get(train)?;
         let constraints = self.constraints.get(train)?;
         Some(Input(consist.clone(), constraints.clone()))
+    }
+
+    fn input_train_set(&self, input: &Input) -> &TrainSet<Train> {
+        self.trains.get(input).expect("build_input_map invariant")
     }
 }
 

--- a/editoast/core_task/src/envs/pathfinding.rs
+++ b/editoast/core_task/src/envs/pathfinding.rs
@@ -458,11 +458,13 @@ mod tests {
     #[tokio::test]
     async fn pathfinding_env() {
         common::setup_tracing_for_test();
+
         let mut mock = MockingClient::new();
         mock.stub("/pathfinding/blocks")
             .response(StatusCode::OK)
             .json(path(2))
             .finish();
+
         let mut pfenv = PathfindingEnv::<usize>::new(CoreEnv::new_mock(mock));
         pfenv.extend([(1, constraints(1)), (2, constraints(2))]);
         pfenv.extend([(1, consist(1)), (2, consist(2))]);
@@ -476,10 +478,12 @@ mod tests {
             ],
             "",
         );
+
         let all_trains = pfenv.all_trains();
         assert_eq!(all_trains, TrainSet::from([1, 2]));
         let (tx, rx) = futures::channel::mpsc::unbounded();
         let pfrun = pfenv.run(vk.get_connection().await.unwrap(), all_trains, Some(tx));
+
         // timeout to avoid blocking the CI if something goes wrong
         let trains = tokio::time::timeout(Duration::from_secs(1), async move {
             use stream::StreamExt as _;
@@ -491,6 +495,7 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(trains, TrainSet::from([1, 2]));
+
         assert_eq!(
             pfrun.get_path(&1),
             Some(Poll::Ready(Ok(serde_json::from_value(path(1)).unwrap())))

--- a/editoast/core_task/src/envs/pathfinding.rs
+++ b/editoast/core_task/src/envs/pathfinding.rs
@@ -195,12 +195,13 @@ where
         trains: HashSet<Train>,
     ) -> impl stream::TryStream<Ok = HashSet<Train>, Error = core_client::Error> + use<'a, Train>
     {
-        use stream::TryStreamExt as _;
-        self.paths_stream(vkconn, trains).map_ok(
+        use stream::StreamExt as _;
+        self.paths_stream(vkconn, trains).map(
             move |Correlated {
                       correlation_key: input,
-                      data: path,
+                      data,
                   }| {
+                let path = data?;
                 let trains = self
                     .inputs
                     .trains
@@ -208,7 +209,7 @@ where
                     .expect("deduplicate_inputs invariant")
                     .clone();
                 self.paths.insert(input, Arc::new(path));
-                trains
+                Ok(trains)
             },
         )
     }
@@ -223,15 +224,14 @@ where
         &self,
         vkconn: cache::Connection,
         trains: HashSet<Train>,
-    ) -> impl stream::TryStream<
-        Ok = (
+    ) -> impl stream::Stream<
+        Item = Correlated<
             HashSet<Train>,
-            core_client::pathfinding::PathfindingCoreResult,
-        ),
-        Error = core_client::Error,
+            Result<core_client::pathfinding::PathfindingCoreResult, core_client::Error>,
+        >,
     > {
-        use stream::TryStreamExt as _;
-        self.paths_stream(vkconn, trains).map_ok(
+        use stream::StreamExt as _;
+        self.paths_stream(vkconn, trains).map(
             move |Correlated {
                       correlation_key: input,
                       data: path,
@@ -242,7 +242,7 @@ where
                     .get(&input)
                     .expect("deduplicate_inputs invariant")
                     .clone();
-                (trains, path)
+                Correlated::new(trains, path)
             },
         )
     }
@@ -269,9 +269,11 @@ where
         &self,
         vkconn: cache::Connection,
         trains: HashSet<Train>,
-    ) -> impl stream::TryStream<
-        Ok = Correlated<Input, core_client::pathfinding::PathfindingCoreResult>,
-        Error = core_client::Error,
+    ) -> impl stream::Stream<
+        Item = Correlated<
+            Input,
+            Result<core_client::pathfinding::PathfindingCoreResult, core_client::Error>,
+        >,
     > + use<Train> {
         use crate::TaskStreamExt as _;
 

--- a/editoast/core_task/src/envs/pathfinding.rs
+++ b/editoast/core_task/src/envs/pathfinding.rs
@@ -4,6 +4,7 @@ use std::hash::DefaultHasher;
 use std::hash::Hash;
 use std::hash::Hasher as _;
 use std::sync::Arc;
+use std::task::Poll;
 
 use core_client::AsCoreRequest as _;
 use core_client::CoreClient;
@@ -30,15 +31,11 @@ pub struct PathfindingEnv<Train>
 where
     Train: Clone + Hash + Eq + Send + Sync + 'static,
 {
-    // Inputs
     core_env: CoreEnv,
     inputs: PathfindingEnvInputs<Train>,
-
-    // Outputs
-    // optionally deduplicate similar outputs of different inputs
-    paths: DashMap<Input, Arc<core_client::pathfinding::PathfindingCoreResult>>,
 }
 
+#[derive(Debug)]
 pub(crate) struct PathfindingEnvInputs<Train>
 where
     Train: Clone + Hash + Eq + Send + Sync + 'static,
@@ -66,6 +63,27 @@ where
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 struct Input(Arc<PathfindingConsist>, Arc<PathfindingConstraints>);
+
+/// The result of [PathfindingEnv::run]
+///
+/// Stores each pathfinding result as they arrive. So [fn PathfindingRun::get_path]
+/// might return that a result is still pending. The train sets done being calculated
+/// can be tracked by providing a channel sender to [PathfindingEnv::run].
+///
+/// Cheap to clone.
+#[derive(Debug, Clone)]
+pub struct PathfindingRun<Train>
+where
+    Train: Clone + Hash + Eq + Send + Sync + 'static,
+{
+    inputs: Arc<PathfindingEnvInputs<Train>>,
+    // optionally deduplicate similar outputs of different inputs
+    paths: Arc<DashMap<Input, PendingPathfindingResult>>,
+}
+
+/// Ready when the pathfinding result is available and stored in [PathfindingRun], pending if the task is not yet completed
+type PendingPathfindingResult =
+    Poll<Result<Arc<core_client::pathfinding::PathfindingCoreResult>, core_client::Error>>;
 
 #[derive(Debug, Hash, PartialEq, Eq)]
 #[cfg_attr(test, derive(Clone))]
@@ -121,8 +139,11 @@ where
         Self {
             core_env,
             inputs: PathfindingEnvInputs::default(),
-            paths: DashMap::new(),
         }
+    }
+
+    pub(crate) fn decompose(self) -> (CoreEnv, Arc<PathfindingEnvInputs<Train>>) {
+        (self.core_env, Arc::new(self.inputs))
     }
 }
 
@@ -178,50 +199,51 @@ where
 {
     /// Computes paths or fetches them from cache asynchronously
     ///
-    /// Returns a stream of trains that have been processed. Stream items are
-    /// a set of trains because similar requests are deduplicated to avoid
-    /// unnecessary computations. All the trains in the set have the same path.
+    /// Returns a [PathfindingRun] containing the calculated paths (or errors)
+    /// of each train set. They are pushed in the object progressively as the results
+    /// arrive. Hence why [fn PathfindingRun::get_path] returns a [Poll].
     ///
-    /// The path itself can be fetched using [PathfindingEnv::get_path].
-    ///
-    /// Note that while the paths are stored in the environment, the latter does **not**
-    /// act as a cache layer. If we `run([1, 2, 3])` and then `run([1, 2])`, the
-    /// environment will try to fetch the path for `1` and `2` from cache *even though*
-    /// they are already stored in the environment. Paths are stored in the environment
-    /// only for API ergonomics.
-    pub fn run<'a>(
-        &'a self,
+    /// To follow what's been calculated, this function accepts a channel sender
+    /// to notify each time a train set is done processing.
+    /// Note that the receivers implement [trait futures::stream::Stream].
+    pub fn run(
+        self,
         vkconn: cache::Connection,
         trains: HashSet<Train>,
-    ) -> impl stream::TryStream<Ok = HashSet<Train>, Error = core_client::Error> + use<'a, Train>
-    {
+        ready_trains_tx: Option<futures::channel::mpsc::UnboundedSender<HashSet<Train>>>,
+    ) -> PathfindingRun<Train> {
         use stream::StreamExt as _;
-        self.paths_stream(vkconn, trains).map(
-            move |Correlated {
-                      correlation_key: input,
-                      data,
-                  }| {
-                let path = data?;
-                let trains = self
-                    .inputs
-                    .trains
-                    .get(&input)
-                    .expect("deduplicate_inputs invariant")
-                    .clone();
-                self.paths.insert(input, Arc::new(path));
-                Ok(trains)
-            },
-        )
+        let (core_env, inputs) = self.decompose();
+        let run = PathfindingRun::new(inputs.clone());
+        let paths = run.paths.clone();
+        tokio::spawn(
+            Self::produce(vkconn, trains, core_env, inputs.clone()).fold(
+                (paths, inputs, ready_trains_tx),
+                async |(paths, inputs, ready_trains_tx),
+                       Correlated {
+                           correlation_key: input,
+                           data,
+                       }| {
+                    if let Some(tx) = ready_trains_tx.as_ref() {
+                        let trains = inputs.trains.get(&input).expect("lolz").clone();
+                        tx.unbounded_send(trains).ok();
+                    }
+                    paths.insert(input, Poll::Ready(data.map(Arc::new)));
+                    (paths, inputs, ready_trains_tx)
+                },
+            ),
+        );
+        run
     }
 
     /// Computes paths or fetches them from cache asynchronously
     ///
-    /// Doesn't store the paths in the environment unlike [PathfindingEnv::run].
+    /// Doesn't store the paths unlike [PathfindingEnv::run].
     /// The returned stream yields a set of trains and their corresponding path directly,
     /// avoiding the caller to deal with the `Arc` returned by [PathfindingEnv::get_path],
     /// thus transferring ownership and allow easy path mutations.
     pub fn into_stream(
-        &self,
+        self,
         vkconn: cache::Connection,
         trains: HashSet<Train>,
     ) -> impl stream::Stream<
@@ -231,13 +253,13 @@ where
         >,
     > {
         use stream::StreamExt as _;
-        self.paths_stream(vkconn, trains).map(
+        let (core_env, inputs) = self.decompose();
+        Self::produce(vkconn, trains, core_env, inputs.clone()).map(
             move |Correlated {
                       correlation_key: input,
                       data: path,
                   }| {
-                let trains = self
-                    .inputs
+                let trains = inputs
                     .trains
                     .get(&input)
                     .expect("deduplicate_inputs invariant")
@@ -247,28 +269,11 @@ where
         )
     }
 
-    /// Returns the path for a given train
-    ///
-    /// A `None` value can indicate several things:
-    ///
-    /// - The train is not in the environment
-    /// - The train is not ready (either missing consist or constraints)
-    /// - The train's path is being computed but its path is not yet available
-    ///
-    /// NOTE: we should probably expose a better result type for these three cases
-    pub fn get_path(
-        &self,
-        train: &Train,
-    ) -> Option<Arc<core_client::pathfinding::PathfindingCoreResult>> {
-        let input = self.inputs.train_input(train)?;
-        let value_ref = self.paths.get(&input)?;
-        Some(value_ref.value().clone())
-    }
-
-    fn paths_stream(
-        &self,
+    fn produce(
         vkconn: cache::Connection,
         trains: HashSet<Train>,
+        core_env: CoreEnv,
+        inputs: Arc<PathfindingEnvInputs<Train>>,
     ) -> impl stream::Stream<
         Item = Correlated<
             Input,
@@ -277,28 +282,27 @@ where
     > + use<Train> {
         use crate::TaskStreamExt as _;
 
-        let inputs = trains.iter().map(|train| {
-            self.inputs
-                .train_input(train)
-                .expect("train map should have been built by now")
-        });
-        let requests = inputs
-            .map(|input| {
-                let request = self.build_request(&input);
+        let requests = trains
+            .iter()
+            .map(|train| {
+                let input = inputs
+                    .train_input(train)
+                    .expect("train map should have been built by now");
+                let request = Self::build_request(&core_env, &input);
                 Correlated::new(input, request)
             })
             .collect_vec();
 
-        stream::iter(requests).run(vkconn, self.core_env.client.clone())
+        stream::iter(requests).run(vkconn, core_env.client.clone())
     }
 
     fn build_request(
-        &self,
+        core_env: &CoreEnv,
         Input(consist, constraints): &Input,
     ) -> core_client::pathfinding::PathfindingRequest {
         core_client::pathfinding::PathfindingRequest {
-            infra: self.core_env.infra_id as i64,
-            expected_version: self.core_env.infra_version,
+            infra: core_env.infra_id as i64,
+            expected_version: core_env.infra_version,
             path_items: constraints
                 .path_items
                 .iter()
@@ -356,11 +360,44 @@ where
     }
 }
 
+impl<Train> PathfindingRun<Train>
+where
+    Train: Clone + Hash + Eq + Send + Sync + 'static,
+{
+    fn new(inputs: Arc<PathfindingEnvInputs<Train>>) -> Self {
+        let paths = DashMap::from_iter(
+            inputs
+                .trains
+                .keys()
+                .cloned()
+                .zip(std::iter::repeat_with(|| Poll::Pending)),
+        );
+        Self {
+            inputs,
+            paths: Arc::new(paths),
+        }
+    }
+
+    /// Returns the path for a given train
+    ///
+    /// A `None` value can either mean that:
+    ///
+    /// - the train is not in the [PathfindingEnv]
+    /// - the train is not ready (either missing consist or constraints)
+    pub fn get_path(&self, train: &Train) -> Option<PendingPathfindingResult> {
+        let input = self.inputs.train_input(train)?;
+        let value_ref = self.paths.get(&input)?;
+        let value = value_ref.value().clone();
+        Some(value)
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use core_client::mocking::MockingClient;
     use deadpool_redis::redis;
-    use futures::TryStreamExt as _;
     use http::StatusCode;
     use serde_json::json;
 
@@ -412,7 +449,7 @@ mod tests {
     impl PathfindingEnv<usize> {
         fn key(&self, id: usize) -> String {
             let input = self.inputs.train_input(&id).unwrap();
-            let request = self.build_request(&input);
+            let request = Self::build_request(&self.core_env, &input);
             use crate::Task as _;
             request.key("")
         }
@@ -441,18 +478,24 @@ mod tests {
         );
         let all_trains = pfenv.all_trains();
         assert_eq!(all_trains, HashSet::from([1, 2]));
-        let _trains = pfenv
-            .run(vk.get_connection().await.unwrap(), all_trains)
-            .try_collect::<Vec<_>>()
-            .await
-            .expect("should go well");
+        let (tx, rx) = futures::channel::mpsc::unbounded();
+        let pfrun = pfenv.run(vk.get_connection().await.unwrap(), all_trains, Some(tx));
+        // timeout to avoid blocking the CI if something goes wrong
+        let trains = tokio::time::timeout(Duration::from_secs(1), async move {
+            use stream::StreamExt as _;
+            rx.map(stream::iter).flatten().collect::<HashSet<_>>().await
+        })
+        .await
+        .unwrap();
+        assert_eq!(trains, HashSet::from([1, 2]));
         assert_eq!(
-            pfenv.get_path(&1),
-            Some(serde_json::from_value(path(1)).unwrap())
+            pfrun.get_path(&1),
+            Some(Poll::Ready(Ok(serde_json::from_value(path(1)).unwrap())))
         );
         assert_eq!(
-            pfenv.get_path(&2),
-            Some(serde_json::from_value(path(2)).unwrap())
+            pfrun.get_path(&2),
+            Some(Poll::Ready(Ok(serde_json::from_value(path(2)).unwrap())))
         );
+        assert_eq!(pfrun.get_path(&3), None);
     }
 }

--- a/editoast/core_task/src/lib.rs
+++ b/editoast/core_task/src/lib.rs
@@ -5,6 +5,7 @@ use std::iter;
 use std::sync::Arc;
 
 // Crate-level exports
+pub use envs::TrainSet;
 pub use envs::core::CoreEnv;
 pub use envs::pathfinding::PathfindingConsist;
 pub use envs::pathfinding::PathfindingConstraints;

--- a/editoast/core_task/src/lib.rs
+++ b/editoast/core_task/src/lib.rs
@@ -145,7 +145,9 @@ where
         self,
         vkconn: cache::Connection,
         ctx: T::Context,
-    ) -> impl stream::TryStream<Ok = Correlated<CorrelationKey, T::Output>, Error = T::Error> + Send;
+    ) -> impl stream::Stream<
+        Item = Correlated<CorrelationKey, Result<<T as Task>::Output, <T as Task>::Error>>,
+    > + Send;
 }
 
 impl<T, InputStream, CorrelationKey> TaskStreamExt<T, CorrelationKey> for InputStream
@@ -160,9 +162,8 @@ where
         self,
         vkconn: cache::Connection,
         ctx: <T as Task>::Context,
-    ) -> impl stream::TryStream<
-        Ok = Correlated<CorrelationKey, <T as Task>::Output>,
-        Error = <T as Task>::Error,
+    ) -> impl stream::Stream<
+        Item = Correlated<CorrelationKey, Result<<T as Task>::Output, <T as Task>::Error>>,
     > + Send {
         use stream::StreamExt as _;
 
@@ -280,7 +281,7 @@ where
         }
 
         let (results_tx, results_rx) = futures::channel::mpsc::unbounded::<
-            Result<Correlated<CorrelationKey, T::Output>, T::Error>,
+            Correlated<CorrelationKey, Result<T::Output, T::Error>>,
         >();
         {
             // 'aggregation' task, receives requests and potential cached task outputs. If cached,
@@ -292,7 +293,7 @@ where
                 {
                     if let Some(cached_value) = cache_entry {
                         results_tx
-                            .unbounded_send(Ok(Correlated::new(correlation_key, cached_value)))
+                            .unbounded_send(Correlated::new(correlation_key, Ok(cached_value)))
                             .ok();
                     } else {
                         match input.compute(ctx.clone()).await {
@@ -307,11 +308,13 @@ where
                                 };
                                 cache_write_tx.send((cache_key, serialized)).ok();
                                 results_tx
-                                    .unbounded_send(Ok(Correlated::new(correlation_key, value)))
+                                    .unbounded_send(Correlated::new(correlation_key, Ok(value)))
                                     .ok();
                             }
                             Err(err) => {
-                                results_tx.unbounded_send(Err(err)).ok();
+                                results_tx
+                                    .unbounded_send(Correlated::new(correlation_key, Err(err)))
+                                    .ok();
                             }
                         };
                     }


### PR DESCRIPTION
Borrow-checker related changes:

* `run` and `into_stream` now consume the environment
* inputs now live in their own type, allowing it to be `Arc`-ed and shared in multiple tasks
* paths are no longer stored in the environment to avoid relying on `self` for long
* paths are now written in `PathfindingRun`, a structure progressively filled as computation results arrive
* progression can still be tracked using a channel
* inputs are still referenced in the `PathfindingRun`

Benefits:

* environments are now short-lived
* we can run `into_stream` and lookup inputs in the stream (we couldn't do that because `&env` was captured by `env.into_stream`, preventing us from using it afterwards)
* better composability with the upcoming `SimulationEnv`

Additional changes:

* task errors are now correlated to the request trains in `TaskStreamExt::run`
* `impl Clone for core_client::Core`: looks hacky (it is), but it is supported (cf. sources at https://docs.rs/serde_json/1.0.145/src/serde_json/error.rs.html#458-494)
* cosmetic and documentation changes

<details open id="prdesc">

- 7de017a44 *editoast: core_task: move pathfinding inputs in their own type*
- f1794c192 *editoast: core_task: correlate errors as well in `TaskStreamExt`*
    ```md
    Otherwise we cannot know which set of trains' results in an error.
    ```
- 861c4bf1f *editoast: core_task: push results in `PathfindingRun`*
    ```md
    Outputs are moved in another type because interior mutability for envs
    is problematic for several reasons. One of them being the inability to
    build a stream — which holds a reference to env — and use said env
    inside, or after its construction.
    
    `run` and `into_stream` now consume the environment.
    ```
- 07705d3d6 *editoast: core_task: use alias `TrainSet` to document deduplication*
- d802bf216 *editoast: core_task: line breaks to unpack test*
- 0bc0a9d0e *editoast: core_task: factorize `pathfinding input => train set` lookups*

</details>