### PR TITLE
editoast: use 'Borrow' to avoid iteration in 'HashSet'

### DIFF
--- a/editoast/schemas/src/rolling_stock.rs
+++ b/editoast/schemas/src/rolling_stock.rs
@@ -129,8 +129,9 @@ impl RollingStock {
     }
 
     pub fn get_etcs_brake_params(&self) -> Option<&EtcsBrakeParams> {
-        if let Some(SupportedSignalingSystem::EtcsLevel2 { brake_params }) =
-            self.supported_signaling_systems.get("ETCS_LEVEL2")
+        if let Some(SupportedSignalingSystem::EtcsLevel2 { brake_params }) = self
+            .supported_signaling_systems
+            .get(SupportedSignalingSystem::ETCS_LEVEL2_VARIANT_NAME)
         {
             return Some(brake_params);
         }

--- a/editoast/schemas/src/rolling_stock.rs
+++ b/editoast/schemas/src/rolling_stock.rs
@@ -129,10 +129,10 @@ impl RollingStock {
     }
 
     pub fn get_etcs_brake_params(&self) -> Option<&EtcsBrakeParams> {
-        for signaling_system in &self.supported_signaling_systems {
-            if let SupportedSignalingSystem::EtcsLevel2 { brake_params } = signaling_system {
-                return Some(brake_params);
-            }
+        if let Some(SupportedSignalingSystem::EtcsLevel2 { brake_params }) =
+            self.supported_signaling_systems.get("ETCS_LEVEL2")
+        {
+            return Some(brake_params);
         }
         None
     }

--- a/editoast/schemas/src/rolling_stock/supported_signaling_system.rs
+++ b/editoast/schemas/src/rolling_stock/supported_signaling_system.rs
@@ -17,11 +17,18 @@ pub enum SupportedSignalingSystem {
     BAPR,
     TVM300,
     TVM430,
+    // /!\ Must be the same value than [SupportedSignalingSystem::ETCS_LEVEL2_VARIANT_NAME]
     #[strum(to_string = "ETCS_LEVEL2")]
     #[serde(rename = "ETCS_LEVEL2")]
     EtcsLevel2 {
         brake_params: EtcsBrakeParams,
     },
+}
+
+impl SupportedSignalingSystem {
+    // /!\ Must be the same value than the serialization of that variant
+    // look for `#[serde(rename)]` and `#[strum(to_string)]`
+    pub const ETCS_LEVEL2_VARIANT_NAME: &str = "ETCS_LEVEL2";
 }
 
 impl Borrow<str> for SupportedSignalingSystem {

--- a/editoast/schemas/src/rolling_stock/supported_signaling_system.rs
+++ b/editoast/schemas/src/rolling_stock/supported_signaling_system.rs
@@ -1,3 +1,5 @@
+use std::borrow::Borrow;
+
 use educe::Educe;
 use serde::Deserialize;
 use serde::Serialize;
@@ -6,7 +8,7 @@ use utoipa::ToSchema;
 
 use crate::rolling_stock::EtcsBrakeParams;
 
-#[derive(Clone, Debug, Deserialize, Serialize, Display, Educe, ToSchema)]
+#[derive(Clone, Debug, Deserialize, Serialize, Display, Educe, ToSchema, strum::IntoStaticStr)]
 #[educe(Hash, Eq, PartialEq)]
 #[serde(tag = "type")]
 #[allow(clippy::large_enum_variant)]
@@ -20,4 +22,10 @@ pub enum SupportedSignalingSystem {
     EtcsLevel2 {
         brake_params: EtcsBrakeParams,
     },
+}
+
+impl Borrow<str> for SupportedSignalingSystem {
+    fn borrow(&self) -> &str {
+        self.into()
+    }
 }


### PR DESCRIPTION
Since a `HashSet` is [based on a `HashMap<T, ()>`](https://doc.rust-lang.org/std/collections/struct.HashSet.html), values in the `HashSet` are indexed. Therefore, we shouldn't need to iterate in the `HashSet` to find a value. The problem is that we would need a full `EtcsLevel2` value with the correct `brake_params` to find it. But thanks to the `Borrow` trait, we don't need a full `SupportingSignalingSystem` for finding, we can tell to only find based on the variant, not the content of the variant. And in our case, it actually makes a lot of sense since we do ignore the payload from the `Hash` implementation.