### PR TITLE
exclude service track OPs from simulation PDF ans results table

### DIFF
--- a/front/src/applications/stdcm/components/StdcmResults/StdcmResults.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/StdcmResults.tsx
@@ -18,6 +18,7 @@ import {
 import { useMapSettings } from 'reducers/commonMap';
 import type { Viewport } from 'reducers/commonMap/types';
 import {
+  getOperationalPointsIdFiltered,
   getRetainedSimulationIndex,
   getSelectedSimulation,
   getStdcmInfraID,
@@ -61,6 +62,8 @@ const StdcmResults = ({
   const selectedSimulation = useSelector(getSelectedSimulation);
   const retainedSimulationIndex = useSelector(getRetainedSimulationIndex);
 
+  const opIdsToExclude = useSelector(getOperationalPointsIdFiltered);
+
   const mapSettings = useMapSettings();
 
   // Keep local state of the viewport to keep stdcm config and stdcm results maps independent
@@ -80,12 +83,13 @@ const StdcmResults = ({
 
   const operationalPointsList = useMemo(() => {
     if (!hasSimulationResults) return [];
-    return getOperationalPointsWithTimes(
-      outputs.pathProperties?.suggestedOperationalPoints || [],
-      outputs.results.simulation,
-      outputs.results.simulationPathSteps,
-      new Date(outputs.results.departure_time)
-    );
+    return getOperationalPointsWithTimes({
+      operationalPoints: outputs.pathProperties?.suggestedOperationalPoints || [],
+      opIdsToExclude,
+      simulation: outputs.results.simulation,
+      simulationPathSteps: outputs.results.simulationPathSteps,
+      departureTime: new Date(outputs.results.departure_time),
+    });
   }, [outputs]);
 
   const markersInfo = useMemo(() => {

--- a/front/src/applications/stdcm/hooks/useStdcmEnv.tsx
+++ b/front/src/applications/stdcm/hooks/useStdcmEnv.tsx
@@ -39,6 +39,7 @@ export default function useStdcmEnvironment() {
           defaultSpeedLimitTag: data.speed_limits
             ? (data.speed_limits.default_speed_limit_tag ?? undefined)
             : undefined,
+          operationalPointsIdFiltered: data.operational_points_id_filtered ?? undefined,
         })
       );
     } catch (e) {

--- a/front/src/modules/SimulationReportSheet/utils/formatSimulationReportSheet.ts
+++ b/front/src/modules/SimulationReportSheet/utils/formatSimulationReportSheet.ts
@@ -266,30 +266,50 @@ export function consolidateOvertakesToSingleSteps(
 
 /**
  * @param operationalPoints List of operational points to be formated and enriched
+ * @param opIdsToExclude List of operational point IDs to exclude from the simulation sheet (e.g., service track OPs that cannot be modeled). Exception: OPs explicitly requested by the user (origin, destination, via points, or stops) are never excluded.
  * @param simulation Simulation response containing final output positions and times
  * @param simulationPathSteps List of simulation path steps
  * @param departureTime Departure time in hh:mm format
  * @returns A list of formated operational points with times and stop durations
  */
-export function getOperationalPointsWithTimes(
-  operationalPoints: SuggestedOP[],
-  simulation: SimulationResponseSuccess,
-  simulationPathSteps: StdcmPathStep[],
-  departureTime: Date
-): StdcmResultsOperationalPoint[] {
+export function getOperationalPointsWithTimes({
+  operationalPoints,
+  opIdsToExclude,
+  simulation,
+  simulationPathSteps,
+  departureTime,
+}: {
+  operationalPoints: SuggestedOP[];
+  opIdsToExclude: string[];
+  simulation: SimulationResponseSuccess;
+  simulationPathSteps: StdcmPathStep[];
+  departureTime: Date;
+}): StdcmResultsOperationalPoint[] {
   const { positions, times, speeds } = simulation.final_output;
 
   const departureHour = departureTime.getHours();
   const departureMinute = departureTime.getMinutes();
 
-  // Map operational points with their positions, times, and stop durations
-  const formattedOps = operationalPoints.map((op) =>
-    formatOperationalPointWithTimes(
-      op,
-      { positions, times, speeds, departureHour, departureMinute },
-      simulationPathSteps
-    )
-  );
+  const formattedOps = operationalPoints
+    .filter((op) => {
+      // Keep if the OP is not in the exclusion list
+      if (!op.opId || !opIdsToExclude.includes(op.opId)) return true;
+
+      // Keep if explicitly requested by the user (origin, destination, via point or stop)
+      const isRequestedPoint = simulationPathSteps.some(
+        (step) => step.location && matchPathStepAndOp(step.location, op)
+      );
+
+      return isRequestedPoint;
+    })
+    // Map operational points with their positions, times, and stop durations
+    .map((op) =>
+      formatOperationalPointWithTimes(
+        op,
+        { positions, times, speeds, departureHour, departureMinute },
+        simulationPathSteps
+      )
+    );
 
   const stopPositions = findAllStops(positions, speeds);
   const formattedOpsWithAllStops = insertMissingStopsInOperationalPointsWithTimes(

--- a/front/src/reducers/osrdconf/stdcmConf/index.ts
+++ b/front/src/reducers/osrdconf/stdcmConf/index.ts
@@ -159,6 +159,7 @@ export const stdcmConfSlice = createSlice({
           | 'workScheduleGroupId'
           | 'temporarySpeedLimitGroupId'
           | 'searchDatetimeWindow'
+          | 'operationalPointsIdFiltered'
           | 'projectID'
           | 'studyID'
           | 'scenarioID'
@@ -185,6 +186,7 @@ export const stdcmConfSlice = createSlice({
       state.trackSectionIdsByLoadingGauge = action.payload.trackSectionIdsByLoadingGauge;
       state.speedLimitTags = action.payload.speedLimitTags;
       state.defaultSpeedLimitTag = action.payload.defaultSpeedLimitTag;
+      state.operationalPointsIdFiltered = action.payload.operationalPointsIdFiltered;
 
       // check that the arrival dates are in the search time window
       const origin = state.stdcmPathSteps.at(0) as Extract<StdcmPathStep, { isVia: false }>;

--- a/front/src/reducers/osrdconf/stdcmConf/selectors.ts
+++ b/front/src/reducers/osrdconf/stdcmConf/selectors.ts
@@ -82,9 +82,10 @@ const buildStdcmConfSelectors = () => {
     getSearchDatetimeWindow: makeOsrdConfSelector('searchDatetimeWindow', { nonNullable: true }),
     getTimetableID: makeOsrdConfSelector('timetableID', { nonNullable: true }),
     getInfraID: makeOsrdConfSelector('infraID', { nonNullable: true }),
-    getOperationalPointsIdFiltered: makeOsrdConfSelector('operationalPointsIdFiltered', {
-      nonNullable: true,
-    }),
+    getOperationalPointsIdFiltered: createSelector(
+      [makeOsrdConfSelector('operationalPointsIdFiltered')],
+      (opIds) => opIds ?? []
+    ),
   };
 };
 

--- a/front/src/reducers/osrdconf/stdcmConf/selectors.ts
+++ b/front/src/reducers/osrdconf/stdcmConf/selectors.ts
@@ -82,6 +82,9 @@ const buildStdcmConfSelectors = () => {
     getSearchDatetimeWindow: makeOsrdConfSelector('searchDatetimeWindow', { nonNullable: true }),
     getTimetableID: makeOsrdConfSelector('timetableID', { nonNullable: true }),
     getInfraID: makeOsrdConfSelector('infraID', { nonNullable: true }),
+    getOperationalPointsIdFiltered: makeOsrdConfSelector('operationalPointsIdFiltered', {
+      nonNullable: true,
+    }),
   };
 };
 
@@ -120,6 +123,7 @@ export const {
   getTrackSectionIdsByLoadingGauge,
   getSpeedLimitTags,
   getDefaultSpeedLimitTag,
+  getOperationalPointsIdFiltered,
 } = selectors;
 
 export type StdcmConfSelectors = typeof selectors;

--- a/front/src/reducers/osrdconf/types.ts
+++ b/front/src/reducers/osrdconf/types.ts
@@ -86,6 +86,7 @@ export type OsrdStdcmConfState = OsrdConfState & {
   speedLimitTags?: Record<string, number>;
   defaultSpeedLimitTag?: string;
   trackSectionIdsByLoadingGauge?: Record<string, string[]>;
+  operationalPointsIdFiltered?: string[];
 };
 
 export type PathStep = {


### PR DESCRIPTION
closes [1129](https://github.com/osrd-project/osrd-confidential/issues/1129)

Filters out operational points (OPs) from service tracks in the STDCM simulation report PDF ans results table, as we cannot properly model them without service track infrastructure data.

**Exception**: OPs explicitly requested by users (origin, destination, via points, or stops) are never filtered and will always appear in the PDF.