### PR TITLE
core: migrate Pathfinding tests to use same generics

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.kt
@@ -14,13 +14,12 @@ import fr.sncf.osrd.pathfinding.PathfindingGraph
 import fr.sncf.osrd.pathfinding.RemainingDistanceEstimator
 import fr.sncf.osrd.pathfinding.constraints.ConstraintCombiner
 import fr.sncf.osrd.pathfinding.constraints.initConstraintsFromRSProps
+import fr.sncf.osrd.pathfinding.getStartLocations
+import fr.sncf.osrd.pathfinding.getTargetsOnEdges
 import fr.sncf.osrd.pathfinding.minDistanceBetweenSteps
 import fr.sncf.osrd.reporting.exceptions.ErrorType
 import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.sim_infra.api.*
-import fr.sncf.osrd.stdcm.STDCMStep
-import fr.sncf.osrd.stdcm.graph.extendLookaheadUntil
-import fr.sncf.osrd.stdcm.infra_exploration.initInfraExplorer
 import fr.sncf.osrd.utils.*
 import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
@@ -208,57 +207,14 @@ private fun getRangeCost(
     infra: FullInfra,
 ): Double {
     val edgeDuration =
-        mrspBuilder.getBlockTime(range.edge.block, Offset(range.end.distance)) -
-            mrspBuilder.getBlockTime(range.edge.block, Offset(range.start.distance))
+        mrspBuilder.getBlockTime(range.edge.block, range.end) -
+            mrspBuilder.getBlockTime(range.edge.block, range.start)
     val signalingSystemPenaltyFactor =
         SIGNALING_SYSTEM_COST_WEIGHTING *
             infra.signalingSimulator.sigModuleManager.getCost(
                 infra.blockInfra.getBlockSignalingSystem(range.edge.block)
             )
     return (edgeDuration) * (1 + signalingSystemPenaltyFactor)
-}
-
-private fun getStartLocations(
-    rawInfra: RawSignalingInfra,
-    blockInfra: BlockInfra,
-    waypoints: ArrayList<Collection<EdgeLocation<BlockId, Block>>>,
-    constraints: List<PathfindingConstraint<Block>>,
-): Collection<EdgeLocation<PathfindingEdge, Block>> {
-    val res = mutableListOf<EdgeLocation<PathfindingEdge, Block>>()
-    val firstStep = waypoints[0]
-    val steps = waypoints.map { STDCMStep(it) }
-    for (location in firstStep) {
-        val infraExplorers =
-            initInfraExplorer(
-                rawInfra,
-                blockInfra,
-                location,
-                steps = steps,
-                constraints = constraints,
-            )
-        val extended = infraExplorers.flatMap { extendLookaheadUntil(it, 1) }
-        for (explorer in extended) {
-            val edge = PathfindingEdge(explorer)
-            res.add(EdgeLocation(edge, location.offset))
-        }
-    }
-    return res
-}
-
-private fun getTargetsOnEdges(
-    waypoints: ArrayList<Collection<EdgeLocation<BlockId, Block>>>
-): List<TargetsOnEdge<PathfindingEdge, Block>> {
-    val targetsOnEdges = ArrayList<TargetsOnEdge<PathfindingEdge, Block>>()
-    for (i in 1 until waypoints.size) {
-        targetsOnEdges.add { edge: PathfindingEdge ->
-            val res = HashSet<EdgeLocation<PathfindingEdge, Block>>()
-            for (target in waypoints[i]) {
-                if (target.edge == edge.block) res.add(EdgeLocation(edge, target.offset))
-            }
-            res
-        }
-    }
-    return targetsOnEdges
 }
 
 @WithSpan(value = "Identifying why no path was found")
@@ -314,16 +270,6 @@ private fun processPathfindingResponse(
     val trainPath = explorer.buildFullPath(infra.rawInfra, infra.blockInfra)
     val stepOffsets = explorer.getStepTracker().getSeenSteps().map { it.travelledPathOffset }
     return ProcessedPathfindingResponse(trainPath, stepOffsets)
-}
-
-private fun makeBlockPath(
-    path: Pathfinding.Result<PathfindingEdge, Block>?
-): Pathfinding.Result<BlockId, Block>? {
-    if (path == null) return null
-    return Pathfinding.Result(
-        path.ranges.map { EdgeRange(it.edge.block, it.start, it.end) },
-        path.waypoints.map { EdgeLocation(it.edge.block, it.offset) },
-    )
 }
 
 /**

--- a/core/src/main/kotlin/fr/sncf/osrd/pathfinding/PathfindingGraph.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/pathfinding/PathfindingGraph.kt
@@ -1,9 +1,19 @@
 package fr.sncf.osrd.pathfinding
 
 import fr.sncf.osrd.graph.Graph
+import fr.sncf.osrd.graph.PathfindingConstraint
+import fr.sncf.osrd.graph.TargetsOnEdge
+import fr.sncf.osrd.pathfinding.Pathfinding.EdgeLocation
 import fr.sncf.osrd.sim_infra.api.Block
+import fr.sncf.osrd.sim_infra.api.BlockId
+import fr.sncf.osrd.sim_infra.api.BlockInfra
+import fr.sncf.osrd.sim_infra.api.RawSignalingInfra
+import fr.sncf.osrd.stdcm.STDCMStep
 import fr.sncf.osrd.stdcm.graph.extendLookaheadUntil
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorer
+import fr.sncf.osrd.stdcm.infra_exploration.initInfraExplorer
+import java.util.ArrayList
+import java.util.HashSet
 import java.util.Objects
 
 data class PathfindingEdge(val infraExplorer: InfraExplorer) {
@@ -30,17 +40,60 @@ class PathfindingGraph : Graph<PathfindingEdge, PathfindingEdge, Block> {
     override fun getAdjacentEdges(node: PathfindingEdge): Collection<PathfindingEdge> {
         val res = ArrayList<PathfindingEdge>()
         val extended = mutableListOf<InfraExplorer>()
-        if (node.infraExplorer.getLookahead().size > 0) {
+        if (node.infraExplorer.getLookahead().isNotEmpty()) {
             extended.add(node.infraExplorer.clone())
         } else {
             extended.addAll(extendLookaheadUntil(node.infraExplorer, 1))
         }
         for (newPath in extended) {
-            if (newPath.getLookahead().size == 0) continue
+            if (newPath.getLookahead().isEmpty()) continue
             newPath.moveForward()
             val newEdge = PathfindingEdge(newPath)
             res.add(newEdge)
         }
         return res
     }
+}
+
+fun getStartLocations(
+    rawInfra: RawSignalingInfra,
+    blockInfra: BlockInfra,
+    waypoints: ArrayList<Collection<EdgeLocation<BlockId, Block>>>,
+    constraints: List<PathfindingConstraint<Block>>,
+): Collection<EdgeLocation<PathfindingEdge, Block>> {
+    val res = mutableListOf<EdgeLocation<PathfindingEdge, Block>>()
+    val firstStep = waypoints[0]
+    val steps = waypoints.map { STDCMStep(it) }
+    for (location in firstStep) {
+        val infraExplorers =
+            initInfraExplorer(
+                rawInfra,
+                blockInfra,
+                location,
+                steps = steps,
+                constraints = constraints,
+            )
+        val extended = infraExplorers.flatMap { extendLookaheadUntil(it, 1) }
+        for (explorer in extended) {
+            val edge = PathfindingEdge(explorer)
+            res.add(EdgeLocation(edge, location.offset))
+        }
+    }
+    return res
+}
+
+fun getTargetsOnEdges(
+    waypoints: ArrayList<Collection<EdgeLocation<BlockId, Block>>>
+): List<TargetsOnEdge<PathfindingEdge, Block>> {
+    val targetsOnEdges = ArrayList<TargetsOnEdge<PathfindingEdge, Block>>()
+    for (i in 1 until waypoints.size) {
+        targetsOnEdges.add { edge: PathfindingEdge ->
+            val res = HashSet<EdgeLocation<PathfindingEdge, Block>>()
+            for (target in waypoints[i]) {
+                if (target.edge == edge.block) res.add(EdgeLocation(edge, target.offset))
+            }
+            res
+        }
+    }
+    return targetsOnEdges
 }

--- a/core/src/test/java/fr/sncf/osrd/utils/graph/AStarTests.kt
+++ b/core/src/test/java/fr/sncf/osrd/utils/graph/AStarTests.kt
@@ -2,10 +2,13 @@ package fr.sncf.osrd.utils.graph
 
 import fr.sncf.osrd.geom.Point
 import fr.sncf.osrd.graph.AStarHeuristic
-import fr.sncf.osrd.graph.GraphAdapter
 import fr.sncf.osrd.pathfinding.Pathfinding
 import fr.sncf.osrd.pathfinding.Pathfinding.EdgeLocation
+import fr.sncf.osrd.pathfinding.PathfindingEdge
+import fr.sncf.osrd.pathfinding.PathfindingGraph
 import fr.sncf.osrd.pathfinding.RemainingDistanceEstimator
+import fr.sncf.osrd.pathfinding.getStartLocations
+import fr.sncf.osrd.pathfinding.getTargetsOnEdges
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.utils.CachedBlockMRSPBuilder
@@ -95,6 +98,7 @@ class AStarTests {
 
         val origin = mutableSetOf(EdgeLocation(startBlock, Offset<Block>(0.meters)))
         val destination = mutableSetOf(EdgeLocation(endBlock, Offset<Block>(100.meters)))
+        val waypoints = arrayListOf<Collection<EdgeLocation<BlockId, Block>>>(origin, destination)
 
         val remainingDistanceEstimator =
             RemainingDistanceEstimator(
@@ -103,37 +107,53 @@ class AStarTests {
                 destination,
                 0.meters,
             )
-        val seenWithHeuristic = HashSet<BlockId>()
-        val seenWithoutHeuristic = HashSet<BlockId>()
+        val seenWithHeuristic = HashSet<PathfindingEdge>()
+        val seenWithoutHeuristic = HashSet<PathfindingEdge>()
         val mrspBuilder =
             CachedBlockMRSPBuilder(fullDummyInfra.rawInfra, fullDummyInfra.blockInfra, null)
-        Pathfinding(GraphAdapter(fullDummyInfra.blockInfra, fullDummyInfra.rawInfra))
-            .setEdgeToLength { blockId -> fullDummyInfra.blockInfra.getBlockLength(blockId) }
+        Pathfinding(PathfindingGraph())
+            .setEdgeToLength { it.length }
             .setRangeCost { range ->
-                mrspBuilder.getBlockTime(range.edge, range.end) -
-                    mrspBuilder.getBlockTime(range.edge, range.start)
+                mrspBuilder.getBlockTime(range.edge.block, range.end) -
+                    mrspBuilder.getBlockTime(range.edge.block, range.start)
             }
             .setRemainingDistanceEstimator(
                 listOf(
-                    AStarHeuristic { block, offset ->
-                        seenWithHeuristic.add(block)
-                        remainingDistanceEstimator.apply(block, offset).meters /
+                    AStarHeuristic { edge, offset ->
+                        seenWithHeuristic.add(edge)
+                        remainingDistanceEstimator.apply(edge.block, offset).meters /
                             DEFAULT_MAX_ROLLING_STOCK_SPEED
                     }
                 )
             )
-            .runPathfinding(listOf(origin, destination))
-        Pathfinding(GraphAdapter(fullDummyInfra.blockInfra, fullDummyInfra.rawInfra))
-            .setEdgeToLength { blockId -> fullDummyInfra.blockInfra.getBlockLength(blockId) }
+            .runPathfinding(
+                getStartLocations(
+                    dummyInfra.fullInfra().rawInfra,
+                    dummyInfra.fullInfra().blockInfra,
+                    waypoints,
+                    listOf(),
+                ),
+                getTargetsOnEdges(waypoints),
+            )
+        Pathfinding(PathfindingGraph())
+            .setEdgeToLength { it.length }
             .setRemainingDistanceEstimator(
                 listOf(
-                    AStarHeuristic { block, _ ->
-                        seenWithoutHeuristic.add(block)
+                    AStarHeuristic { edge, _ ->
+                        seenWithoutHeuristic.add(edge)
                         0.0
                     }
                 )
             )
-            .runPathfinding(listOf(origin, destination))
+            .runPathfinding(
+                getStartLocations(
+                    dummyInfra.fullInfra().rawInfra,
+                    dummyInfra.fullInfra().blockInfra,
+                    waypoints,
+                    listOf(),
+                ),
+                getTargetsOnEdges(waypoints),
+            )
         Assertions.assertTrue(seenWithHeuristic.size < seenWithoutHeuristic.size)
     }
 }

--- a/core/src/test/java/fr/sncf/osrd/utils/graph/PathfindingTests.kt
+++ b/core/src/test/java/fr/sncf/osrd/utils/graph/PathfindingTests.kt
@@ -2,13 +2,18 @@ package fr.sncf.osrd.utils.graph
 
 import com.google.common.graph.NetworkBuilder
 import fr.sncf.osrd.graph.Graph
-import fr.sncf.osrd.graph.GraphAdapter
 import fr.sncf.osrd.graph.NetworkGraphAdapter
 import fr.sncf.osrd.pathfinding.Pathfinding
 import fr.sncf.osrd.pathfinding.Pathfinding.EdgeLocation
+import fr.sncf.osrd.pathfinding.Pathfinding.EdgeRange
 import fr.sncf.osrd.pathfinding.Pathfinding.Result
+import fr.sncf.osrd.pathfinding.PathfindingGraph
+import fr.sncf.osrd.pathfinding.getStartLocations
+import fr.sncf.osrd.pathfinding.getTargetsOnEdges
 import fr.sncf.osrd.reporting.exceptions.ErrorType
 import fr.sncf.osrd.reporting.exceptions.OSRDError
+import fr.sncf.osrd.sim_infra.api.Block
+import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.utils.CachedBlockMRSPBuilder
 import fr.sncf.osrd.utils.DummyInfra
 import fr.sncf.osrd.utils.graph.PathfindingTests.SimpleGraphBuilder.Edge
@@ -750,25 +755,36 @@ class PathfindingTests {
         val secondBlock = infra.addBlock("b", "c")
         val mrspBuilder =
             CachedBlockMRSPBuilder(infra.fullInfra().rawInfra, infra.fullInfra().blockInfra, null)
+        val waypoints =
+            arrayListOf<Collection<EdgeLocation<BlockId, Block>>>(
+                listOf(EdgeLocation(slow, Offset.zero()), EdgeLocation(fast, Offset.zero())),
+                listOf(EdgeLocation(secondBlock, Offset.zero())),
+            )
         val res =
-            Pathfinding(GraphAdapter(infra.fullInfra().blockInfra, infra.fullInfra().rawInfra))
-                .setEdgeToLength { block -> infra.fullInfra().blockInfra.getBlockLength(block) }
+            Pathfinding(PathfindingGraph())
+                .setEdgeToLength { it.length }
                 .setRangeCost { range ->
-                    val start = mrspBuilder.getBlockTime(range.edge, range.start)
-                    val end = mrspBuilder.getBlockTime(range.edge, range.end)
+                    val start = mrspBuilder.getBlockTime(range.edge.block, range.start)
+                    val end = mrspBuilder.getBlockTime(range.edge.block, range.end)
                     val res = end - start
                     return@setRangeCost res
                 }
-                .runPathfindingEdgesOnly(
-                    listOf(
-                        listOf(
-                            EdgeLocation(slow, Offset(0.meters)),
-                            EdgeLocation(fast, Offset(0.meters)),
-                        ),
-                        listOf(EdgeLocation(secondBlock, Offset(0.meters))),
-                    )
+                .runPathfinding(
+                    getStartLocations(
+                        infra.fullInfra().rawInfra,
+                        infra.fullInfra().blockInfra,
+                        waypoints,
+                        listOf(),
+                    ),
+                    getTargetsOnEdges(waypoints),
                 )
-        Assertions.assertEquals(listOf(fast, secondBlock), res)
+        Assertions.assertEquals(
+            arrayListOf(
+                EdgeRange(fast, Offset.zero(), Offset<Block>(4999.meters)),
+                EdgeRange(secondBlock, Offset.zero(), Offset.zero()),
+            ),
+            res!!.ranges.map { EdgeRange(it.edge.block, it.start, it.end) },
+        )
     }
 
     companion object {


### PR DESCRIPTION
The goal will then be to remove generics (part of #13014).

On the way:
- very small refactors/cleanups
- move `getStartLocations()` & `getTargetsOnEdges()` to a reusable place
- remove `makeBlockPath()` now unused