### PR TITLE
editoast: openapi: specify PositiveDuration's string format as duration

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -11620,6 +11620,7 @@ components:
       additionalProperties: false
     PositiveDuration:
       type: string
+      format: duration
       description: Duration in ISO 8601 format (e.g. PT2H for 2 hours)
       examples:
       - PT2H

--- a/editoast/schemas/src/primitives/duration.rs
+++ b/editoast/schemas/src/primitives/duration.rs
@@ -93,6 +93,9 @@ impl utoipa::PartialSchema for PositiveDuration {
             .schema_type(utoipa::openapi::schema::SchemaType::Type(
                 utoipa::openapi::schema::Type::String,
             ))
+            .format(Some(utoipa::openapi::SchemaFormat::KnownFormat(
+                utoipa::openapi::KnownFormat::Duration,
+            )))
             .description(Some("Duration in ISO 8601 format (e.g. PT2H for 2 hours)"))
             .examples([serde_json::Value::String("PT2H".to_string())])
             .build()


### PR DESCRIPTION
Is there a reason why the format wasn't specified ?

This then allows for the generation of python models from the openAPI which use `datetime.timedelta` instead of `str`