### PR TITLE
core: stdcm: use constraints in heuristic builder

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMHeuristic.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMHeuristic.kt
@@ -1,12 +1,11 @@
 package fr.sncf.osrd.stdcm
 
-import fr.sncf.osrd.envelope_sim.PhysicsRollingStock
 import fr.sncf.osrd.envelope_sim.allowances.AllowanceValue
+import fr.sncf.osrd.pathfinding.constraints.ConstraintCombiner
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.sim_infra.api.BlockInfra
 import fr.sncf.osrd.sim_infra.api.RawInfra
-import fr.sncf.osrd.sim_infra.impl.TemporarySpeedLimitManager
 import fr.sncf.osrd.sim_infra.utils.getBlockEntry
 import fr.sncf.osrd.stdcm.graph.STDCMEdge
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
@@ -104,11 +103,9 @@ class STDCMHeuristicBuilder(
     private val rawInfra: RawInfra,
     private val steps: List<STDCMStep>,
     private val maxRunningTime: Double,
-    private val rollingStock: PhysicsRollingStock,
-    private val temporarySpeedLimitManager: TemporarySpeedLimitManager =
-        TemporarySpeedLimitManager(),
     private val mrspBuilder: CachedBlockMRSPBuilder,
     val allowance: AllowanceValue?,
+    private val constraints: ConstraintCombiner<StaticIdx<Block>, Block>? = null,
 ) {
     private val logger: Logger = LoggerFactory.getLogger("STDCMHeuristic")
 
@@ -196,7 +193,7 @@ class STDCMHeuristicBuilder(
                     pendingBlock.stepIndex,
                     pendingBlock.remainingTimeAtBlockStart,
                 )
-            res.add(newBlock)
+            newBlock?.let { res.add(it) }
         }
         return res
     }
@@ -206,7 +203,7 @@ class STDCMHeuristicBuilder(
         val res = PriorityQueue<PendingBlock>()
         val stepCount = steps.size
         for (wp in steps[stepCount - 1].locations) {
-            res.add(makePendingBlock(wp.edge, wp.offset, stepCount - 1, 0.0))
+            makePendingBlock(wp.edge, wp.offset, stepCount - 1, 0.0)?.let { res.add(it) }
         }
         return res
     }
@@ -217,7 +214,7 @@ class STDCMHeuristicBuilder(
         offset: Offset<Block>?,
         currentIndex: Int,
         remainingTime: Double,
-    ): PendingBlock {
+    ): PendingBlock? {
         var newIndex = currentIndex
         val actualOffset = offset ?: blockInfra.getBlockLength(block)
         while (newIndex > 0) {
@@ -226,6 +223,12 @@ class STDCMHeuristicBuilder(
                 break
             }
             newIndex--
+        }
+        if (constraints != null && newIndex > 0 && remainingTime > 0.0) {
+            // We stop if there's any blocking constraint on the block,
+            // but only if not on the first or last block
+            // (as the constrained range may not be part of the path)
+            if (constraints.apply(block).isNotEmpty()) return null
         }
         return PendingBlock(
             block,

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
@@ -5,7 +5,9 @@ import fr.sncf.osrd.envelope.Envelope
 import fr.sncf.osrd.envelope_sim.allowances.AllowanceValue
 import fr.sncf.osrd.envelope_sim.allowances.AllowanceValue.FixedTime
 import fr.sncf.osrd.graph.Graph
+import fr.sncf.osrd.pathfinding.constraints.ConstraintCombiner
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
+import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.impl.TemporarySpeedLimitManager
 import fr.sncf.osrd.stdcm.STDCMAStarHeuristic
 import fr.sncf.osrd.stdcm.STDCMHeuristicBuilder
@@ -16,6 +18,7 @@ import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
 import fr.sncf.osrd.stdcm.preprocessing.interfaces.BlockAvailabilityInterface
 import fr.sncf.osrd.train.RollingStock
 import fr.sncf.osrd.utils.CachedBlockMRSPBuilder
+import fr.sncf.osrd.utils.indexing.StaticIdx
 import fr.sncf.osrd.utils.units.meters
 import java.lang.Double.isFinite
 import java.lang.Double.isNaN
@@ -41,6 +44,7 @@ class STDCMGraph(
     val tag: String?,
     val standardAllowance: AllowanceValue?,
     val temporarySpeedLimitManager: TemporarySpeedLimitManager = TemporarySpeedLimitManager(),
+    constraints: ConstraintCombiner<StaticIdx<Block>, Block>,
 ) : Graph<STDCMNode, STDCMEdge, STDCMEdge> {
     val rawInfra = fullInfra.rawInfra!!
     val blockInfra = fullInfra.blockInfra!!
@@ -80,10 +84,9 @@ class STDCMGraph(
                     fullInfra.rawInfra,
                     steps,
                     maxRunTime,
-                    rollingStock,
-                    temporarySpeedLimitManager,
                     mrspBuilder,
                     standardAllowance,
+                    constraints,
                 )
                 .build()
         bestPossibleTime = remainingTimeEstimator.bestTravelTime

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
@@ -100,6 +100,11 @@ class STDCMPathfinding(
 
     private var starts: Set<STDCMNode> = HashSet()
 
+    val constraints =
+        ConstraintCombiner(
+            initConstraints(fullInfra, rollingStock, allowedTrackSections).toMutableList()
+        )
+
     var graph: STDCMGraph =
         STDCMGraph(
             fullInfra,
@@ -113,16 +118,12 @@ class STDCMPathfinding(
             tag,
             standardAllowance,
             temporarySpeedLimitManager,
+            constraints,
         )
 
     @WithSpan(value = "STDCM pathfinding", kind = SpanKind.SERVER)
     fun findPath(): STDCMResult? {
         runInputSanityChecks()
-
-        val constraints =
-            ConstraintCombiner(
-                initConstraints(fullInfra, rollingStock, allowedTrackSections).toMutableList()
-            )
 
         assert(steps.last().stop) { "The last stop is supposed to be an actual stop" }
         starts = getStartNodes(graph, listOf(constraints))

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
@@ -59,7 +59,6 @@ class STDCMHeuristicTests {
                     infra,
                     steps,
                     Double.POSITIVE_INFINITY,
-                    STANDARD_TRAIN,
                     mrspBuilder = CachedBlockMRSPBuilder(infra, infra, null),
                     allowance = null,
                 )
@@ -115,7 +114,6 @@ class STDCMHeuristicTests {
                     infra,
                     steps,
                     Double.POSITIVE_INFINITY,
-                    STANDARD_TRAIN,
                     mrspBuilder = CachedBlockMRSPBuilder(infra, infra, null),
                     allowance = AllowanceValue.Percentage(100.0),
                 )
@@ -126,7 +124,6 @@ class STDCMHeuristicTests {
                     infra,
                     steps,
                     Double.POSITIVE_INFINITY,
-                    STANDARD_TRAIN,
                     mrspBuilder = CachedBlockMRSPBuilder(infra, infra, null),
                     allowance = null,
                 )
@@ -178,7 +175,6 @@ class STDCMHeuristicTests {
                     infra,
                     steps,
                     Double.POSITIVE_INFINITY,
-                    STANDARD_TRAIN,
                     mrspBuilder = CachedBlockMRSPBuilder(infra, infra, null),
                     allowance = null,
                 )


### PR DESCRIPTION
We build the heuristic by traversing the infra starting at the destination. It makes sense to trim out branches that are blocked by constraints (invalid electrification and such). That way, if a path can lead to the destination but only by going through a blocked range later on, it's dismissed right away.

It wasn't done before as blocked paths weren't that common. Now that only a small subset of track sections is allowed, it makes a significant difference. On my (very small) new set of 5 saved requests with track constraints, it reduced computation time by 37% on average.

(also removes two unused parameters)