### PR TITLE
editoast: core_task: wrap Valkey connection in an `Arc<Mutex<>>`

### DIFF
--- a/editoast/core_client/src/lib.rs
+++ b/editoast/core_client/src/lib.rs
@@ -249,6 +249,7 @@ impl Clone for Error {
             Self::UnparsableErrorOutput => Self::UnparsableErrorOutput,
             Self::BrokenPipe => Self::BrokenPipe,
             Self::RawError(err) => Self::RawError(err.clone()),
+            #[cfg(feature = "mocking_client")]
             Self::NoResponseContent => Self::NoResponseContent,
             Self::MqClientError(err) => Self::MqClientError(match err {
                 MqClientError::Lapin(error) => MqClientError::Lapin(error.clone()),

--- a/editoast/core_task/src/envs/pathfinding.rs
+++ b/editoast/core_task/src/envs/pathfinding.rs
@@ -13,6 +13,7 @@ use itertools::Itertools;
 use ordered_float::OrderedFloat;
 use schemas::infra::TrackOffset;
 use schemas::rolling_stock::LoadingGaugeType;
+use tokio::sync::Mutex;
 
 use crate::CoreEnv;
 use crate::Correlated;
@@ -208,7 +209,7 @@ where
     /// Note that the receivers implement [trait futures::stream::Stream].
     pub fn run(
         self,
-        vkconn: cache::Connection,
+        vkconn: Arc<Mutex<cache::Connection>>,
         trains: TrainSet<Train>,
         ready_trains_tx: Option<futures::channel::mpsc::UnboundedSender<TrainSet<Train>>>,
     ) -> PathfindingRun<Train> {
@@ -244,7 +245,7 @@ where
     /// thus transferring ownership and allow easy path mutations.
     pub fn into_stream(
         self,
-        vkconn: cache::Connection,
+        vkconn: Arc<Mutex<cache::Connection>>,
         trains: TrainSet<Train>,
     ) -> impl stream::Stream<
         Item = Correlated<
@@ -266,7 +267,7 @@ where
     }
 
     fn produce(
-        vkconn: cache::Connection,
+        vkconn: Arc<Mutex<cache::Connection>>,
         trains: TrainSet<Train>,
         core_env: CoreEnv,
         inputs: Arc<PathfindingEnvInputs<Train>>,
@@ -482,7 +483,11 @@ mod tests {
         let all_trains = pfenv.all_trains();
         assert_eq!(all_trains, TrainSet::from([1, 2]));
         let (tx, rx) = futures::channel::mpsc::unbounded();
-        let pfrun = pfenv.run(vk.get_connection().await.unwrap(), all_trains, Some(tx));
+        let pfrun = pfenv.run(
+            Arc::new(Mutex::new(vk.get_connection().await.unwrap())),
+            all_trains,
+            Some(tx),
+        );
 
         // timeout to avoid blocking the CI if something goes wrong
         let trains = tokio::time::timeout(Duration::from_secs(1), async move {

--- a/editoast/core_task/src/lib.rs
+++ b/editoast/core_task/src/lib.rs
@@ -16,6 +16,7 @@ use itertools::Itertools as _;
 use itertools::izip;
 use serde::de::DeserializeOwned;
 use serde::ser::Serialize;
+use tokio::sync::Mutex;
 use tracing::Instrument;
 
 /// Indicates that a Core task can be performed and cached
@@ -64,17 +65,19 @@ pub trait Task: Sized + Send {
     #[expect(async_fn_in_trait)] // not for public (ie. outside editoast) use, no auto traits bounds to specify on the resulting future
     async fn run(
         self,
-        mut vkconn: cache::Connection,
+        vkconn: Arc<Mutex<cache::Connection>>,
         ctx: Self::Context,
     ) -> Result<Self::Output, Self::Error> {
-        let key = self.key(vkconn.app_version());
-        match vkconn
-            .json_get::<Self::Output, _>(&key)
-            .await
-            .unwrap_or_else(|e| {
-                tracing::error!(?e, key, "cache read error — computing task output");
-                None
-            }) {
+        let (key, cache_entry) = {
+            let mut vkconn = vkconn.lock().await;
+            let key = self.key(vkconn.app_version());
+            let entry = vkconn.json_get::<Self::Output, _>(&key).await;
+            (key, entry)
+        };
+        match cache_entry.unwrap_or_else(|e| {
+            tracing::error!(?e, key, "cache read error — computing task output");
+            None
+        }) {
             Some(value) => {
                 tracing::trace!(key, "cache hit");
                 Ok(value)
@@ -93,7 +96,12 @@ pub trait Task: Sized + Send {
                     Ok(serialized) => {
                         tokio::spawn(async move {
                             use deadpool_redis::redis::AsyncCommands as _;
-                            if let Err(e) = vkconn.set::<_, _, ()>(key.clone(), serialized).await {
+                            if let Err(e) = vkconn
+                                .lock()
+                                .await
+                                .set::<_, _, ()>(key.clone(), serialized)
+                                .await
+                            {
                                 tracing::error!(?e, key, "cache write error");
                             }
                         });
@@ -144,7 +152,7 @@ where
     /// The order of the results is not the same as the order of inputs.
     fn run(
         self,
-        vkconn: cache::Connection,
+        vkconn: Arc<Mutex<cache::Connection>>,
         ctx: T::Context,
     ) -> impl stream::Stream<
         Item = Correlated<CorrelationKey, Result<<T as Task>::Output, <T as Task>::Error>>,
@@ -161,7 +169,7 @@ where
     #[tracing::instrument(skip_all)]
     fn run(
         self,
-        vkconn: cache::Connection,
+        vkconn: Arc<Mutex<cache::Connection>>,
         ctx: <T as Task>::Context,
     ) -> impl stream::Stream<
         Item = Correlated<CorrelationKey, Result<<T as Task>::Output, <T as Task>::Error>>,
@@ -186,9 +194,6 @@ where
          *                                  (spawns several tasks
          *                                   via for_each_concurrent)
          */
-
-        // shared to several tasks
-        let vkconn = Arc::new(tokio::sync::Mutex::new(vkconn));
 
         let (cache_write_tx, mut cache_write_rx) =
             tokio::sync::mpsc::unbounded_channel::<(String, String)>();

--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -224,12 +224,17 @@ pub(in crate::views) async fn post(
         Ok(request) => request,
         Err(result) => return Ok(Json(result)),
     };
-    Ok(Json(match request.run(valkey_conn, core_client).await {
-        Ok(path) => path.into(),
-        Err(core_error) => PathfindingResult::Failure(PathfindingFailure::InternalError {
-            core_error: core_error.into(),
-        }),
-    }))
+    Ok(Json(
+        match request
+            .run(Arc::new(tokio::sync::Mutex::new(valkey_conn)), core_client)
+            .await
+        {
+            Ok(path) => path.into(),
+            Err(core_error) => PathfindingResult::Failure(PathfindingFailure::InternalError {
+                core_error: core_error.into(),
+            }),
+        },
+    ))
 }
 
 /// Pathfinding batch computation given a list of path inputs

--- a/editoast/src/views/path/properties.rs
+++ b/editoast/src/views/path/properties.rs
@@ -118,7 +118,7 @@ pub(in crate::views) async fn post(
         infra: infra_id,
         expected_version: infra_version,
     }
-    .run(vkconn, core_client)
+    .run(Arc::new(tokio::sync::Mutex::new(vkconn)), core_client)
     .await?;
 
     Ok(Json(PathProperties::from(path_properties)))


### PR DESCRIPTION
part of https://github.com/osrd-project/osrd-confidential/issues/1210
<details open id="prdesc">

- 21c82a67e *editoast: core_client: add guard in pattern matching*
- 094a1dc94 *editoast: core_task: wrap Valkey connection in `Arc<Mutex<>>`*
    ```md
    Will allow sharing the same connection in several tasks easily in the
    upcoming `SimulationEnv`.
    ```

</details>