### PR TITLE
core: separate, native tsim gradle project

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -11,6 +11,7 @@ plugins {
     alias(libs.plugins.versions)
     alias(libs.plugins.spotless)
     alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.kotlin.multiplatform) apply false
 }
 
 // region DEPENDENCIES
@@ -28,6 +29,7 @@ dependencies {
     implementation project(':envelope-sim')
     implementation project(':osrd-geom')
     implementation project(':kt-osrd-path')
+    implementation project(':tsim')
     testImplementation(testFixtures(project(":envelope-sim")))
 
     // kotlin

--- a/core/gradle/libs.versions.toml
+++ b/core/gradle/libs.versions.toml
@@ -75,6 +75,7 @@ amqp-client = { module = 'com.rabbitmq:amqp-client', version = '5.27.0' }
 # kotlin
 ksp = { id = 'com.google.devtools.ksp', version.ref = 'ksp' }
 kotlin-jvm = { id = 'org.jetbrains.kotlin.jvm', version.ref = 'kotlin' }
+kotlin-multiplatform = { id = 'org.jetbrains.kotlin.multiplatform', version.ref = 'kotlin' }
 kotlin-serialization = { id = 'org.jetbrains.kotlin.plugin.serialization', version.ref = 'kotlin' }
 
 # java

--- a/core/settings.gradle
+++ b/core/settings.gradle
@@ -14,6 +14,7 @@ include 'osrd-geom'
 include 'osrd-railjson'
 include 'envelope-sim'
 include 'osrd-reporting'
+include 'tsim'
 
 
 dependencyResolutionManagement {

--- a/core/src/main/kotlin/fr/sncf/osrd/api/standalone_sim/SimulationEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/standalone_sim/SimulationEndpoint.kt
@@ -2,7 +2,7 @@ package fr.sncf.osrd.api.standalone_sim
 
 import fr.sncf.osrd.api.*
 import fr.sncf.osrd.reporting.exceptions.OSRDError
-import fr.sncf.osrd.standalone_sim.runStandaloneSimulation
+import fr.sncf.osrd.tsim.onetrain
 import fr.sncf.osrd.utils.*
 import io.opentelemetry.api.trace.Span
 import java.io.File
@@ -58,7 +58,7 @@ class SimulationEndpoint(
                 request.path.toTrainPath(infra.rawInfra, infra.blockInfra, electricalProfileMap)
 
             val res =
-                runStandaloneSimulation(
+                onetrain(
                     infra,
                     trainPath,
                     rollingStock,

--- a/core/src/main/kotlin/fr/sncf/osrd/tsim/onetrain.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/tsim/onetrain.kt
@@ -87,19 +87,27 @@ fun onetrain(
             mrsp.putLower(Range.closed(start, end), speed)
         }
     }
-    for ((position, _) in stops) {
-        mrsp.put(Range.closed(position, position), 0.0)
-    }
+
+    val stopConstraint = TreeRangeMap.create<Meters, MetersPerSecond>()
+    val speedConstraints = OverlayingSpeedLimits(mutableListOf(mrsp, stopConstraint))
 
     val neutralZones = NeutralZonesWithPantographs() // TODO
-    val instructions = Instructions(mrsp, neutralZones)
+    val instructions = Instructions(speedConstraints, neutralZones)
 
     var time = 0.0
     var position = rollingStock.length
     var speed = initialSpeed
     val envelopePoints = mutableListOf(EnvelopePoint(time, speed, position))
     for ((stopPosition, stopDuration) in stops) {
-        while (!(stopPosition approxLowerThan position)) {
+        if (stopPosition < position) {
+            println("aoups on a dépasser un autre arrêt du coup?")
+            time += stopDuration
+            envelopePoints.add(EnvelopePoint(time, speed, position))
+            continue
+        }
+
+        stopConstraint.put(Range.atLeast(stopPosition), 0.0)
+        while (!(stopPosition approxLowerThan position) || speed != 0.0) {
             val s = step(ctx, instructions, timeStep, position, speed)
             assert(s.positionDelta > 1e-6) { "le train c stopper.... ${s.positionDelta}" }
             time += s.timeDelta
@@ -107,8 +115,14 @@ fun onetrain(
             speed = s.endSpeed
             envelopePoints.add(EnvelopePoint(time, speed, position))
         }
-        mrsp.remove(Range.closed(stopPosition, stopPosition))
+
+        if (!(stopPosition approxEqualTo position)) {
+            println("le train a depasser la position d'arrêt!!! D:")
+        }
+
+        stopConstraint.remove(Range.all())
         time += stopDuration
+        envelopePoints.add(EnvelopePoint(time, speed, position))
     }
 
     val simplifiedPoints = simplifyEnvelopePoints(envelopePoints, 5.0, 0.2)

--- a/core/src/main/kotlin/fr/sncf/osrd/tsim/onetrain.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/tsim/onetrain.kt
@@ -29,7 +29,6 @@ import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import fr.sncf.osrd.utils.units.metersPerSecond
 import fr.sncf.osrd.utils.units.seconds
-import kotlin.math.min
 
 fun onetrain(
     infra: FullInfra,
@@ -125,8 +124,10 @@ fun onetrain(
                     val position = offset.meters
                     var res = simplifiedPoints.binarySearchBy(position) { point -> point.position }
                     if (res < 0) {
-                        // TODO offset by one to have the point after arival instead of before?
-                        res = min(-res - 1, simplifiedPoints.size - 1)
+                        val insertAt = -res - 1
+                        // Get the element before where we would insert [position]
+                        // to get the arrival time
+                        res = (insertAt - 1).coerceIn(0, simplifiedPoints.size - 1)
                     }
                     simplifiedPoints[res].time.seconds
                 },

--- a/core/src/main/kotlin/fr/sncf/osrd/tsim/onetrain.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/tsim/onetrain.kt
@@ -1,0 +1,150 @@
+package fr.sncf.osrd.tsim
+
+import com.google.common.collect.Range
+import com.google.common.collect.RangeMap
+import com.google.common.collect.TreeRangeMap
+import fr.sncf.osrd.DriverBehaviour
+import fr.sncf.osrd.api.FullInfra
+import fr.sncf.osrd.api.RangeValues
+import fr.sncf.osrd.api.standalone_sim.CompleteReportTrain
+import fr.sncf.osrd.api.standalone_sim.MarginValue
+import fr.sncf.osrd.api.standalone_sim.ReportTrain
+import fr.sncf.osrd.api.standalone_sim.SimulationScheduleItem
+import fr.sncf.osrd.api.standalone_sim.SimulationSuccess
+import fr.sncf.osrd.envelope.EnvelopeTimeInterpolate.EnvelopePoint
+import fr.sncf.osrd.path.interfaces.TrainPath
+import fr.sncf.osrd.path.interfaces.TravelledPath
+import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
+import fr.sncf.osrd.railjson.schema.schedule.RJSAllowanceDistribution
+import fr.sncf.osrd.sim_infra.api.SpeedLimitProperty
+import fr.sncf.osrd.standalone_sim.buildSignalingRanges
+import fr.sncf.osrd.standalone_sim.makeElectricalProfiles
+import fr.sncf.osrd.standalone_sim.makeSafetySpeedRanges
+import fr.sncf.osrd.standalone_sim.result.ElectrificationRange
+import fr.sncf.osrd.train.RollingStock
+import fr.sncf.osrd.utils.DistanceRangeMap
+import fr.sncf.osrd.utils.simplifyEnvelopePoints
+import fr.sncf.osrd.utils.toRangeMap
+import fr.sncf.osrd.utils.units.Offset
+import fr.sncf.osrd.utils.units.meters
+import fr.sncf.osrd.utils.units.metersPerSecond
+import fr.sncf.osrd.utils.units.seconds
+
+fun onetrain(
+    infra: FullInfra,
+    trainPath: TrainPath,
+    rollingStock: RollingStock,
+    comfort: Comfort,
+    constraintDistribution: RJSAllowanceDistribution,
+    speedLimitTag: String?,
+    powerRestrictions: DistanceRangeMap<String>,
+    useElectricalProfiles: Boolean,
+    useSpeedLimits: Boolean,
+    timeStep: Double,
+    schedule: List<SimulationScheduleItem>,
+    initialSpeed: Double,
+    margins: RangeValues<MarginValue>,
+    pathItemPositions: List<Offset<TravelledPath>>,
+    driverBehaviour: DriverBehaviour = DriverBehaviour(),
+): SimulationSuccess {
+    val electrificationMap =
+        trainPath.getElectrificationMap(
+            rollingStock.basePowerClass,
+            powerRestrictions.toRangeMap(),
+            rollingStock.powerRestrictions,
+            !useElectricalProfiles,
+        )
+    val curvesAndConditions = rollingStock.mapTractiveEffortCurves(electrificationMap, comfort)
+    val effortCurveMap = curvesAndConditions.curves
+    val ctx = Context(path = trainPath, stock = rollingStock, effortCurveMap = effortCurveMap)
+
+    var mrsp: RangeMap<Meters, MetersPerSecond> = TreeRangeMap.create()
+    if (useSpeedLimits) {
+        val props = trainPath.getSpeedLimitProperties(speedLimitTag, null)
+        for (prop in props) {
+            val start = prop.lower.meters
+            val end = prop.upper.meters
+            val speed = prop.value.speed.metersPerSecond
+            if (speed != 0.0) {
+                mrsp.putLower(Range.closed(start, end), speed)
+            }
+        }
+
+        val signalingRanges = buildSignalingRanges(infra, trainPath)
+        val safetySpeedRanges = makeSafetySpeedRanges(infra, trainPath, schedule, signalingRanges)
+        for (range in safetySpeedRanges) {
+            val start = range.lower.meters
+            val end = range.upper.meters
+            val speed = range.value.metersPerSecond
+            mrsp.putLower(Range.closed(start, end), speed)
+        }
+    }
+    mrsp = mrsp.withStockLength(rollingStock.length)
+    val neutralZones = NeutralZonesWithPantographs() // TODO
+    val instructions = Instructions(mrsp, neutralZones)
+
+    var time = 0.0
+    var position = rollingStock.length
+    var speed = initialSpeed
+    val envelopePoints = mutableListOf(EnvelopePoint(time, speed, position))
+    while (position < trainPath.length) {
+        val s = step(ctx, instructions, timeStep, position, speed)
+        if (s.positionDelta < 1e-2) {
+            throw Exception("le train c stopper...")
+        }
+        time += s.timeDelta
+        position += s.positionDelta
+        speed = s.endSpeed
+        envelopePoints.add(EnvelopePoint(time, speed, position))
+    }
+
+    val simplifiedPoints = simplifyEnvelopePoints(envelopePoints, 5.0, 0.2)
+
+    val baseReport =
+        ReportTrain(
+            positions = simplifiedPoints.map { point -> Offset(point.position.meters) },
+            times = simplifiedPoints.map { point -> point.time.seconds },
+            speeds = simplifiedPoints.map { point -> point.speed },
+            energyConsumption = 0.0, // TODO
+            pathItemTimes =
+                pathItemPositions.map { offset ->
+                    val position = offset.meters
+                    var res = simplifiedPoints.binarySearchBy(position) { point -> point.position }
+                    if (res < 0) {
+                        // TODO offset by one to have the point after arival instead of before?
+                        res = -res - 1
+                    }
+                    simplifiedPoints[res].time.seconds
+                },
+        )
+
+    val completeReport =
+        CompleteReportTrain(
+            positions = baseReport.positions,
+            times = baseReport.times,
+            speeds = baseReport.speeds,
+            energyConsumption = baseReport.energyConsumption,
+            pathItemTimes = baseReport.pathItemTimes,
+            signalCriticalPositions = listOf(), // TODO
+            zoneUpdates = listOf(), // TODO
+            spacingRequirements = listOf(), // TODO
+            routingRequirements = listOf(), // TODO
+        )
+
+    val electrificationRanges =
+        ElectrificationRange.from(curvesAndConditions.conditions, electrificationMap)
+
+    return SimulationSuccess(
+        base = baseReport,
+        provisional = baseReport, // TODO margins
+        finalOutput = completeReport,
+        mrsp =
+            mrsp.toRangeValues { speed ->
+                SpeedLimitProperty(
+                    speed = (speed ?: MetersPerSecond.POSITIVE_INFINITY).metersPerSecond,
+                    source = null,
+                )
+            },
+        electricalProfiles = makeElectricalProfiles(electrificationRanges),
+    )
+}

--- a/core/src/main/kotlin/fr/sncf/osrd/tsim/onetrain.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/tsim/onetrain.kt
@@ -102,7 +102,7 @@ fun onetrain(
     val instructions = Instructions(speedConstraints, neutralZones)
 
     var time = 0.0
-    var position = rollingStock.length
+    var position = 0.0
     var speed = initialSpeed
     val envelopePoints = mutableListOf(EnvelopePoint(time, speed, position))
     for ((stopPosition, stopDuration) in stops) {

--- a/core/src/main/kotlin/fr/sncf/osrd/tsim/onetrain.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/tsim/onetrain.kt
@@ -59,6 +59,7 @@ fun onetrain(
     val ctx = Context(path = trainPath, stock = rollingStock, effortCurveMap = effortCurveMap)
 
     var mrsp: RangeMap<Meters, MetersPerSecond> = TreeRangeMap.create()
+    mrsp.put(Range.all(), rollingStock.maxSpeed)
     if (useSpeedLimits) {
         val props = trainPath.getSpeedLimitProperties(speedLimitTag, null)
         for (prop in props) {

--- a/core/src/main/kotlin/fr/sncf/osrd/tsim/onetrain.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/tsim/onetrain.kt
@@ -58,11 +58,18 @@ fun onetrain(
     val effortCurveMap = curvesAndConditions.curves
     val ctx = Context(path = trainPath, stock = rollingStock, effortCurveMap = effortCurveMap)
 
-    val stops =
-        schedule.mapNotNull { item ->
-            val stopFor = item.stopFor ?: return@mapNotNull null
-            Pair(item.pathOffset.meters, stopFor.seconds)
+    var stopSeq =
+        schedule.asSequence().mapNotNull { item ->
+            val stopFor = item.stopFor?.seconds ?: return@mapNotNull null
+            if (stopFor == 0.0) {
+                return@mapNotNull null
+            }
+            Pair(item.pathOffset.meters, stopFor)
         }
+    schedule.lastOrNull()
+        ?.takeUnless { item -> item.stopFor?.seconds != 0.0 }
+        ?.let { item -> stopSeq += sequenceOf(Pair(item.pathOffset.meters, 0.0)) }
+    val stops = stopSeq.toList()
 
     var mrsp: RangeMap<Meters, MetersPerSecond> = TreeRangeMap.create()
     mrsp.put(Range.all(), rollingStock.maxSpeed)

--- a/core/src/main/kotlin/fr/sncf/osrd/tsim/onetrain.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/tsim/onetrain.kt
@@ -29,6 +29,7 @@ import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import fr.sncf.osrd.utils.units.metersPerSecond
 import fr.sncf.osrd.utils.units.seconds
+import kotlin.math.min
 
 fun onetrain(
     infra: FullInfra,
@@ -58,6 +59,12 @@ fun onetrain(
     val effortCurveMap = curvesAndConditions.curves
     val ctx = Context(path = trainPath, stock = rollingStock, effortCurveMap = effortCurveMap)
 
+    val stops =
+        schedule.mapNotNull { item ->
+            val stopFor = item.stopFor ?: return@mapNotNull null
+            Pair(item.pathOffset.meters, stopFor.seconds)
+        }
+
     var mrsp: RangeMap<Meters, MetersPerSecond> = TreeRangeMap.create()
     mrsp.put(Range.all(), rollingStock.maxSpeed)
     if (useSpeedLimits) {
@@ -81,6 +88,10 @@ fun onetrain(
         }
     }
     mrsp = mrsp.withStockLength(rollingStock.length)
+    for ((position, _) in stops) {
+        mrsp.put(Range.closed(position, position), 0.0)
+    }
+
     val neutralZones = NeutralZonesWithPantographs() // TODO
     val instructions = Instructions(mrsp, neutralZones)
 
@@ -88,15 +99,17 @@ fun onetrain(
     var position = rollingStock.length
     var speed = initialSpeed
     val envelopePoints = mutableListOf(EnvelopePoint(time, speed, position))
-    while (position < trainPath.length) {
-        val s = step(ctx, instructions, timeStep, position, speed)
-        if (s.positionDelta < 1e-2) {
-            throw Exception("le train c stopper...")
+    for ((stopPosition, stopDuration) in stops) {
+        while (!(stopPosition approxLowerThan position)) {
+            val s = step(ctx, instructions, timeStep, position, speed)
+            assert(s.positionDelta > 1e-6) { "le train c stopper.... ${s.positionDelta}" }
+            time += s.timeDelta
+            position += s.positionDelta
+            speed = s.endSpeed
+            envelopePoints.add(EnvelopePoint(time, speed, position))
         }
-        time += s.timeDelta
-        position += s.positionDelta
-        speed = s.endSpeed
-        envelopePoints.add(EnvelopePoint(time, speed, position))
+        mrsp.remove(Range.closed(stopPosition, stopPosition))
+        time += stopDuration
     }
 
     val simplifiedPoints = simplifyEnvelopePoints(envelopePoints, 5.0, 0.2)
@@ -113,7 +126,7 @@ fun onetrain(
                     var res = simplifiedPoints.binarySearchBy(position) { point -> point.position }
                     if (res < 0) {
                         // TODO offset by one to have the point after arival instead of before?
-                        res = -res - 1
+                        res = min(-res - 1, simplifiedPoints.size - 1)
                     }
                     simplifiedPoints[res].time.seconds
                 },

--- a/core/src/main/kotlin/fr/sncf/osrd/tsim/onetrain.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/tsim/onetrain.kt
@@ -155,6 +155,15 @@ fun onetrain(
                 },
         )
 
+    val mrspReport =
+        ReportTrain(
+            positions = baseReport.positions,
+            times = baseReport.times,
+            speeds = simplifiedPoints.map { point -> mrsp.get(point.position) ?: 500.0 },
+            energyConsumption = baseReport.energyConsumption,
+            pathItemTimes = baseReport.pathItemTimes,
+        )
+
     val completeReport =
         CompleteReportTrain(
             positions = baseReport.positions,
@@ -172,7 +181,7 @@ fun onetrain(
         ElectrificationRange.from(curvesAndConditions.conditions, electrificationMap)
 
     return SimulationSuccess(
-        base = baseReport,
+        base = mrspReport,
         provisional = baseReport, // TODO margins
         finalOutput = completeReport,
         mrsp =

--- a/core/src/main/kotlin/fr/sncf/osrd/tsim/onetrain.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/tsim/onetrain.kt
@@ -77,6 +77,7 @@ fun onetrain(
                 mrsp.putLower(Range.closed(start, end), speed)
             }
         }
+        mrsp = mrsp.withStockLength(rollingStock.length)
 
         val signalingRanges = buildSignalingRanges(infra, trainPath)
         val safetySpeedRanges = makeSafetySpeedRanges(infra, trainPath, schedule, signalingRanges)
@@ -87,7 +88,6 @@ fun onetrain(
             mrsp.putLower(Range.closed(start, end), speed)
         }
     }
-    mrsp = mrsp.withStockLength(rollingStock.length)
     for ((position, _) in stops) {
         mrsp.put(Range.closed(position, position), 0.0)
     }

--- a/core/src/main/kotlin/fr/sncf/osrd/tsim/onetrain.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/tsim/onetrain.kt
@@ -132,7 +132,8 @@ fun onetrain(
         envelopePoints.add(EnvelopePoint(time, speed, position))
     }
 
-    val simplifiedPoints = simplifyEnvelopePoints(envelopePoints, 5.0, 0.2)
+    val trimedPoints = trimPoints(envelopePoints, trainPath.length)
+    val simplifiedPoints = simplifyEnvelopePoints(trimedPoints, 5.0, 0.2)
 
     val baseReport =
         ReportTrain(
@@ -175,7 +176,7 @@ fun onetrain(
         provisional = baseReport, // TODO margins
         finalOutput = completeReport,
         mrsp =
-            mrsp.toRangeValues { speed ->
+            mrsp.subRangeMap(Range.closed(0.0, trainPath.length)).toRangeValues { speed ->
                 SpeedLimitProperty(
                     speed = (speed ?: MetersPerSecond.POSITIVE_INFINITY).metersPerSecond,
                     source = null,
@@ -183,4 +184,20 @@ fun onetrain(
             },
         electricalProfiles = makeElectricalProfiles(electrificationRanges),
     )
+}
+
+private fun trimPoints(
+    envelopePoints: List<EnvelopePoint>,
+    length: Meters,
+): List<EnvelopePoint> {
+    val result = envelopePoints.binarySearchBy(length) { point -> point.position }
+    return if (result >= 0) {
+        envelopePoints.slice(0..result)
+    } else {
+        val i = -result - 1
+        val t = envelopePoints.getOrNull(i)?.time
+            ?: (envelopePoints.getOrNull(i - 1)?.time?.let { time -> time + 2.0 })
+            ?: Seconds.POSITIVE_INFINITY
+        envelopePoints.slice(0..<i) + EnvelopePoint(t, 0.0, length)
+    }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/tsim/range.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/tsim/range.kt
@@ -1,0 +1,6 @@
+package fr.sncf.osrd.tsim
+
+import com.google.common.collect.Range
+
+internal fun Range<Double>.lowerEndpointOrInf(): Double =
+    if (hasLowerBound()) lowerEndpoint() else Double.NEGATIVE_INFINITY

--- a/core/src/main/kotlin/fr/sncf/osrd/tsim/range.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/tsim/range.kt
@@ -4,3 +4,6 @@ import com.google.common.collect.Range
 
 internal fun Range<Double>.lowerEndpointOrInf(): Double =
     if (hasLowerBound()) lowerEndpoint() else Double.NEGATIVE_INFINITY
+
+internal fun Range<Double>.upperEndpointOrInf(): Double =
+    if (hasLowerBound()) lowerEndpoint() else Double.POSITIVE_INFINITY

--- a/core/src/main/kotlin/fr/sncf/osrd/tsim/range.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/tsim/range.kt
@@ -7,6 +7,7 @@ import fr.sncf.osrd.api.RangeValues
 import fr.sncf.osrd.path.interfaces.TravelledPath
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
+import kotlin.math.min
 
 internal fun Range<Double>.lowerEndpointOrInf(): Double =
     if (hasLowerBound()) lowerEndpoint() else Double.NEGATIVE_INFINITY
@@ -30,20 +31,7 @@ internal fun Range<Double>.upperEndpointOrInf(): Double =
  * ```
  */
 internal fun RangeMap<Double, Double>.putLower(range: Range<Double>, value: Double) {
-    val newSubMap = TreeRangeMap.create<Double, Double>()
-    newSubMap.put(range, value)
-
-    for (e in subRangeMap(range).asMapOfRanges()) {
-        val oldRange = e.key
-        val oldValue = e.value
-        if (oldValue < value) {
-            newSubMap.put(oldRange, oldValue)
-        }
-    }
-
-    for (e in newSubMap.asMapOfRanges()) {
-        putCoalescing(e.key, e.value)
-    }
+    merge(range, value) { old, new -> min(old, new!!) }
 }
 
 /**

--- a/core/src/main/kotlin/fr/sncf/osrd/tsim/range.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/tsim/range.kt
@@ -2,7 +2,6 @@ package fr.sncf.osrd.tsim
 
 import com.google.common.collect.Range
 import com.google.common.collect.RangeMap
-import com.google.common.collect.TreeRangeMap
 import fr.sncf.osrd.api.RangeValues
 import fr.sncf.osrd.path.interfaces.TravelledPath
 import fr.sncf.osrd.utils.units.Offset

--- a/core/src/main/kotlin/fr/sncf/osrd/tsim/range.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/tsim/range.kt
@@ -1,9 +1,89 @@
 package fr.sncf.osrd.tsim
 
 import com.google.common.collect.Range
+import com.google.common.collect.RangeMap
+import com.google.common.collect.TreeRangeMap
+import fr.sncf.osrd.api.RangeValues
+import fr.sncf.osrd.path.interfaces.TravelledPath
+import fr.sncf.osrd.utils.units.Offset
+import fr.sncf.osrd.utils.units.meters
 
 internal fun Range<Double>.lowerEndpointOrInf(): Double =
     if (hasLowerBound()) lowerEndpoint() else Double.NEGATIVE_INFINITY
 
 internal fun Range<Double>.upperEndpointOrInf(): Double =
     if (hasLowerBound()) lowerEndpoint() else Double.POSITIVE_INFINITY
+
+/**
+ * Make it so the [RangeMap] associates keys in the given [range] with the given [value], while
+ * leaving alone the sub-ranges in [range] that had associations with values lower than [value].
+ *
+ * # Example
+ *
+ * ```kotlin
+ * val map = TreeRangeMap.create<Double, Double>()
+ * map.put(Range.closed(3.0, 5.0), 42.0)
+ * map.putLower(Range.all(), 69.0)
+ *
+ * assert(map.get(4.0) == 42.0)
+ * assert(map.get(0.0) == 69.0)
+ * ```
+ */
+internal fun RangeMap<Double, Double>.putLower(range: Range<Double>, value: Double) {
+    val newSubMap = TreeRangeMap.create<Double, Double>()
+    newSubMap.put(range, value)
+
+    for (e in subRangeMap(range).asMapOfRanges()) {
+        val oldRange = e.key
+        val oldValue = e.value
+        if (oldValue < value) {
+            newSubMap.put(oldRange, oldValue)
+        }
+    }
+
+    for (e in newSubMap.asMapOfRanges()) {
+        putCoalescing(e.key, e.value)
+    }
+}
+
+/**
+ * Convert a [RangeMap] to a [RangeValues], transforming values in the process.
+ *
+ * The first and the last range of the [RangeMap] span from and to infinity respectively in the
+ * result.
+ *
+ * When the given ranges aren't connected, this function fills the gaps in between. In this case,
+ * [transform] is given a `null` argument.
+ */
+internal fun <T, U> RangeMap<Meters, T>.toRangeValues(transform: (T?) -> U): RangeValues<U> {
+    val internalBoundaries = mutableListOf<Offset<TravelledPath>>()
+    val values = mutableListOf<U>()
+
+    val iter = asDescendingMapOfRanges().iterator()
+    if (!iter.hasNext()) {
+        return RangeValues()
+    }
+
+    val first = iter.next()
+    var lastBoundary = first.key.upperEndpointOrInf()
+    values.add(transform(first.value))
+
+    while (iter.hasNext()) {
+        val e = iter.next()
+        val range = e.key
+        val value = e.value
+
+        if (lastBoundary < range.lowerEndpointOrInf()) {
+            // This range isn't connected to the last one, add the gap
+            internalBoundaries.add(Offset(lastBoundary.meters))
+            values.add(transform(null))
+            lastBoundary = range.lowerEndpointOrInf()
+        }
+
+        internalBoundaries.add(Offset(lastBoundary.meters))
+        values.add(transform(value))
+        lastBoundary = range.upperEndpointOrInf()
+    }
+
+    return RangeValues(internalBoundaries, values)
+}

--- a/core/src/main/kotlin/fr/sncf/osrd/tsim/tsim.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/tsim/tsim.kt
@@ -9,6 +9,7 @@ import fr.sncf.osrd.envelope_sim.etcs.BrakingType
 import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.train.RollingStock
 import java.util.function.BiFunction
+import kotlin.math.abs
 
 typealias Seconds = Double
 
@@ -165,6 +166,28 @@ internal class DecelerationTarget(
 )
 
 /**
+ * Given two lines, return the X coordinate where they intersect, or `null` if there is no or an
+ * infinite amount of interesection points.
+ *
+ * The first line is defined as passing through points `(x1,a1)` and `(x2,a2)`. The second line is
+ * defined as passing through points `(x1,b1)` and `(x2,b2)`.
+ */
+private fun intersectAt(
+    x1: Double,
+    x2: Double,
+    a1: Double,
+    a2: Double,
+    b1: Double,
+    b2: Double,
+): Double? {
+    if (a1 - a2 == b1 - b2) {
+        // The two lines are parallel
+        return null
+    }
+    return x1 + (x2 - x1) * (a1 - b1) / (b2 - b1 + a1 - a2)
+}
+
+/**
  * A 2D curve.
  *
  * This class represents a list of 2D points `(xs[i],ys[i])` connected by straight lines. [xs] and
@@ -300,12 +323,46 @@ fun step(
     require(position >= 0.0) { "position must be positive" }
     require(speed >= 0.0) { "speed must be positive" }
 
-    var action = Action.ACCELERATE
+    val mrsp = instructions.mrsp.subRangeMap(Range.atLeast(position))
+    val currentSpeedLimit = mrsp.get(position) ?: Double.POSITIVE_INFINITY
 
-    val mrsp = instructions.mrsp.subRangeMap(Range.greaterThan(position))
-    if ((mrsp.get(position) ?: Double.POSITIVE_INFINITY) < speed) {
-        action = Action.BRAKE
-    } else {
+    var action = Action.ACCELERATE
+    // We may choose to stop the integration early, to snap to a deceleration curve, or a point of
+    // interest where the behavior of the rolling stock may change.
+    var minDT = dt
+    var snappedStep: IntegrationStep? = null
+
+    if (speed approxLowerThan currentSpeedLimit) {
+        // The train is going slower than allowed, but may need to brake in order to
+        // respect an upcoming speed limit. Compute the deceleration curves for upcoming
+        // speed limits and check if the stock's speed is above, or accelerate.
+
+        var startSpeed = speed
+
+        if (speed approxEqualTo currentSpeedLimit && action == Action.ACCELERATE) {
+            // The stock has power to maintain its speed and it has reached its speed limit.
+            // Snap the speed to the speed limit because of floating point errors
+            action = Action.MAINTAIN
+            startSpeed = currentSpeedLimit
+            // TODO compute the time when the current speed limit expires and we can accelerate
+            // again
+        } else {
+            assert(speed < currentSpeedLimit)
+        }
+
+        // The speed and position of the train if we choose not to brake.
+        val evsimCtx = EnvelopeSimContext(ctx.stock, ctx.path, dt, ctx.effortCurveMap)
+        val s =
+            TrainPhysicsIntegrator.step(
+                evsimCtx,
+                position,
+                startSpeed,
+                action,
+                1.0,
+                BrakingType.CONSTANT,
+            )
+        assert(s.timeDelta == dt)
+        val endPosition = position + s.positionDelta
         for (speedRestriction in mrsp.asMapOfRanges()) {
             val range = speedRestriction.key
             val maxSpeed = speedRestriction.value
@@ -316,19 +373,82 @@ fun step(
                     speed = maxSpeed,
                 )
             val c = ctx.decelerationCurve(target, dt)
-            val speedLimitAtStockHead = c.lerp(position)
-            if (speed >= speedLimitAtStockHead) {
+            val speedLimit = c.lerp(position)
+            if (!(speed approxLowerThan speedLimit)) {
+                // The stock is already going too fast to reach the speed limit in time.
+                // Since all curves are done with the same [BrakingType], we can assume the stock
+                // will need to brake until at least dt anyway.
                 action = Action.BRAKE
                 break
             }
+
+            val speedAfterDT = s.endSpeed
+            val speedLimitAfterDT = c.lerp(endPosition)
+            if (speedAfterDT approxLowerThan speedLimitAfterDT) {
+                // The stock can accelerate throughout the time step and still respect the
+                // deceleration curve
+                continue
+            }
+
+            // Assume the deceleration curve is a straight line between [position] and [endPosition]
+            // [reachLimitAtPosition] is always non-null because of the earlier branches
+            val reachLimitAtPosition =
+                intersectAt(
+                    position,
+                    endPosition,
+                    speed,
+                    speedAfterDT,
+                    speedLimit,
+                    speedLimitAfterDT,
+                )!!
+
+            // Assume the position of the stock follows a straight line between now and now+[dt]
+            // It's actually a second order polynomial but we don't have a third point to
+            // interpolate 🤓
+            val reachLimitAtDT = dt * (reachLimitAtPosition - position) / s.positionDelta
+            assert(reachLimitAtDT != 0.0)
+
+            if (minDT < reachLimitAtDT) {
+                continue
+            }
+            minDT = reachLimitAtDT
+
+            // Snap the rolling stock to the deceleration curve or speed limit because of floating
+            // point errors
+            snappedStep =
+                IntegrationStep.fromNaiveStep(
+                    minDT,
+                    reachLimitAtPosition - position,
+                    startSpeed,
+                    speedLimitAfterDT,
+                    (speedLimitAfterDT - startSpeed) / minDT,
+                    1.0,
+                )
         }
+    } else {
+        // The stock is already rolling faster than allowed, brake.
+        // TODO compute when we can stop braking and trim the time step
+        action = Action.BRAKE
     }
 
-    val evsimCtx = EnvelopeSimContext(ctx.stock, ctx.path, dt, ctx.effortCurveMap)
-    val s =
-        TrainPhysicsIntegrator.step(evsimCtx, position, speed, action, 1.0, BrakingType.CONSTANT)
+    if (snappedStep == null) {
+        val evsimCtx = EnvelopeSimContext(ctx.stock, ctx.path, dt, ctx.effortCurveMap)
+        snappedStep =
+            TrainPhysicsIntegrator.step(
+                evsimCtx,
+                position,
+                speed,
+                action,
+                1.0,
+                BrakingType.CONSTANT,
+            )
+    }
 
-    // TODO correct step s according to mrsp
-
-    return s
+    return snappedStep
 }
+
+/** Whether [this] and [that] are sufficiently close to each other. */
+internal infix fun Double.approxEqualTo(that: Double): Boolean = abs(this - that) < 1e-4
+
+/** Whether [this] is lower, equal or slightly larger than [that]. */
+internal infix fun Double.approxLowerThan(that: Double): Boolean = this - that < 1e-4

--- a/core/src/main/kotlin/fr/sncf/osrd/tsim/tsim.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/tsim/tsim.kt
@@ -140,8 +140,6 @@ data class Instructions(
      * Most-Restrictive Speed Profile.
      *
      * Maps positions of the head of the train along the path to the highest allowed speed.
-     *
-     * This doesn't need to account for the train's max speed.
      */
     val mrsp: RangeMap<Meters, MetersPerSecond> = TreeRangeMap.create(),
 

--- a/core/src/main/kotlin/fr/sncf/osrd/tsim/tsim.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/tsim/tsim.kt
@@ -126,11 +126,11 @@ fun RangeMap<Meters, Boolean>.withPantographPositions(
 
 data class Instructions(
     /**
-     * Most-Restrictive Speed Profile.
+     * Ranges on the path where a speed limit is enforced.
      *
      * Maps positions of the head of the train along the path to the highest allowed speed.
      */
-    val mrsp: RangeMap<Meters, MetersPerSecond> = TreeRangeMap.create(),
+    val speedLimits: RangeMap<Meters, MetersPerSecond> = TreeRangeMap.create(),
 
     /**
      * Ranges of the path that aren't electrified.
@@ -311,8 +311,8 @@ fun step(
     require(position >= 0.0) { "position must be positive" }
     require(speed >= 0.0) { "speed must be positive" }
 
-    val mrsp = instructions.mrsp.subRangeMap(Range.atLeast(position))
-    val currentSpeedLimit = mrsp.get(position) ?: Double.POSITIVE_INFINITY
+    val speedLimits = instructions.speedLimits.subRangeMap(Range.atLeast(position))
+    val currentSpeedLimit = speedLimits.get(position) ?: Double.POSITIVE_INFINITY
 
     var action = Action.ACCELERATE
     // We may choose to stop the integration early, to snap to a deceleration curve, or a point of
@@ -351,7 +351,7 @@ fun step(
             )
         assert(s.timeDelta == dt)
         val endPosition = position + s.positionDelta
-        for (speedRestriction in mrsp.asMapOfRanges()) {
+        for (speedRestriction in speedLimits.asMapOfRanges()) {
             val range = speedRestriction.key
             val maxSpeed = speedRestriction.value
             val target =

--- a/core/src/main/kotlin/fr/sncf/osrd/tsim/tsim.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/tsim/tsim.kt
@@ -1,0 +1,222 @@
+package fr.sncf.osrd.tsim
+
+import com.google.common.collect.ImmutableRangeMap
+import com.google.common.collect.Range
+import com.google.common.collect.RangeMap
+import fr.sncf.osrd.envelope_sim.*
+import fr.sncf.osrd.envelope_sim.etcs.BrakingType
+import fr.sncf.osrd.path.interfaces.PhysicsPath
+import fr.sncf.osrd.train.RollingStock
+
+typealias Seconds = Double
+
+typealias Meters = Double
+
+typealias MetersPerSecond = Double
+
+typealias SecondArray = DoubleArray
+
+typealias MeterArray = DoubleArray
+
+typealias MeterPerSecondArray = DoubleArray
+
+data class Instructions(
+    /**
+     * Most-Restrictive Speed Profile.
+     *
+     * This doesn't need to account for the train's max speed.
+     */
+    // ?? ImmutableRangeMap inherits RangeMap and not the other way around?
+    val mrsp: RangeMap<Meters, MetersPerSecond> = ImmutableRangeMap.of(),
+
+    /**
+     * Ranges of the path that aren't electrified.
+     *
+     * Maps ranges of the path to whether the neutral zone requires lowering the pantograph.
+     */
+    val neutralZones: RangeMap<Meters, Boolean> = ImmutableRangeMap.of(),
+
+    // TODO Stop?
+)
+
+internal class DecelerationTarget(
+    /** Target position where [speed] must be reached. */
+    val position: Meters,
+
+    /** Braking type used to achieve the target [speed], or `null` if coasting */
+    val brake: BrakingType?,
+
+    /** Target speed to reach at [position] */
+    val speed: MetersPerSecond,
+)
+
+/**
+ * A 2D curve.
+ *
+ * This class represents a list of 2D points `(xs[i],ys[i])` connected by straight lines. [xs] and
+ * [ys] must have the same size. The elements of [xs] are expected to be strictly increasing.
+ */
+internal class Curve(val xs: DoubleArray, val ys: DoubleArray) {
+    init {
+        require(xs.size == ys.size) { "xs and ys must be the same size" }
+    }
+
+    val size: Int
+        get() = xs.size
+
+    /**
+     * Linear intERPolation of the Y value of the curve at the given [x] position
+     *
+     * If [x] is out of bounds, returns the first or the last value of [ys].
+     */
+    fun lerp(x: Double): Double {
+        // Edge cases where we don't have two points to interpolate
+        if (x >= xs.last()) {
+            return ys.last()
+        }
+        if (x <= xs.first()) {
+            return ys.first()
+        }
+
+        val result = xs.binarySearch(x)
+        if (result >= 0) {
+            // Landed right on a point of the curve
+            return ys[result]
+        }
+
+        // Index where `x` should be inserted in `xs` to preserve order. It is
+        // ensured to be higher than 1 and lower than `size-1`, otherwise `x`
+        // is lower than `x.first()` or higher than `xs.last()` and these cases
+        // are handled above.
+        val hi = -result - 1
+
+        val lo = hi - 1
+
+        return ys[lo] + (ys[hi] - ys[lo]) * (x - xs[lo]) / (xs[hi] - xs[lo])
+    }
+}
+
+/**
+ * Context of a simulation, caching expensive values for a given [path], rolling [stock] and
+ * tractive [effortCurveMap].
+ */
+class Context(
+    val path: PhysicsPath,
+    val stock: RollingStock,
+    val effortCurveMap: RangeMap<Meters, Array<PhysicsRollingStock.TractiveEffortPoint>>,
+) {
+    /**
+     * Maps [DecelerationTarget]s to [Curve]s that specify the highest speed the rolling [stock] can
+     * have at each given position in order to reach the speed target with the given brakes.
+     *
+     * The curve ends right on the speed target, and starts right before the speed limit is lower
+     * than the rolling stock's max speed.
+     */
+    private val decelerationCurves = mutableMapOf<DecelerationTarget, Curve>()
+
+    internal fun decelerationCurve(target: DecelerationTarget, dt: Seconds): Curve {
+        var curve = decelerationCurves[target]
+        if (curve != null) {
+            return curve
+        }
+
+        val evsimCtx = EnvelopeSimContext(stock, path, dt, effortCurveMap)
+        val action = if (target.brake != null) Action.BRAKE else Action.COAST
+
+        var position = target.position
+        var speed = target.speed
+        var stepCount = 0
+        stepCount++ // count the step (target.position, target.speed)
+        while (speed < stock.maxSpeed) {
+            val s =
+                TrainPhysicsIntegrator.step(evsimCtx, position, speed, action, -1.0, target.brake)
+            assert(s.timeDelta == dt)
+            position += s.positionDelta
+            speed = s.endSpeed
+            stepCount++
+        }
+
+        val positions = MeterArray(stepCount)
+        val speeds = MeterPerSecondArray(stepCount)
+
+        var i = stepCount - 1
+        positions[i] = target.position
+        speeds[i] = target.speed
+        while (i > 0) {
+            i--
+            val s =
+                TrainPhysicsIntegrator.step(
+                    evsimCtx,
+                    positions[i + 1],
+                    speeds[i + 1],
+                    action,
+                    -1.0,
+                    target.brake,
+                )
+            positions[i] = positions[i + 1] + s.positionDelta
+            speeds[i] = s.endSpeed
+        }
+
+        curve = Curve(positions, speeds)
+        decelerationCurves[target] = curve
+        return curve
+    }
+}
+
+/**
+ * Simulate a given rolling stock going along a given path starting at [position] and going at
+ * [speed] for a given time [dt].
+ *
+ * The context [ctx] may be reused between calls to improve performance.
+ */
+fun step(
+    ctx: Context,
+    instructions: Instructions,
+
+    /** Must be strictly positive */
+    dt: Seconds,
+
+    /** Must be positive */
+    position: Meters,
+
+    /** Must be positive */
+    speed: MetersPerSecond,
+): IntegrationStep {
+    require(dt > 0.0) { "dt must be strictly positive" }
+    require(position >= 0.0) { "position must be positive" }
+    require(speed >= 0.0) { "speed must be positive" }
+
+    // TODO update mrsp to account for the whole stock length
+
+    var action = Action.ACCELERATE
+
+    val mrsp = instructions.mrsp.subRangeMap(Range.greaterThan(position))
+    if ((mrsp.get(position) ?: Double.POSITIVE_INFINITY) < speed) {
+        action = Action.BRAKE
+    } else {
+        for (speedRestriction in mrsp.asMapOfRanges()) {
+            val range = speedRestriction.key
+            val maxSpeed = speedRestriction.value
+            val target =
+                DecelerationTarget(
+                    position = range.lowerEndpointOrInf(),
+                    brake = BrakingType.CONSTANT,
+                    speed = maxSpeed,
+                )
+            val c = ctx.decelerationCurve(target, dt)
+            val speedLimitAtStockHead = c.lerp(position)
+            if (speed >= speedLimitAtStockHead) {
+                action = Action.BRAKE
+                break
+            }
+        }
+    }
+
+    val evsimCtx = EnvelopeSimContext(ctx.stock, ctx.path, dt, ctx.effortCurveMap)
+    val s =
+        TrainPhysicsIntegrator.step(evsimCtx, position, speed, action, 1.0, BrakingType.CONSTANT)
+
+    // TODO correct step s according to mrsp
+
+    return s
+}

--- a/core/src/main/kotlin/fr/sncf/osrd/tsim/tsim.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/tsim/tsim.kt
@@ -253,6 +253,63 @@ class Curve(val xs: DoubleArray, val ys: DoubleArray) {
 
         return ys[lo] + (ys[hi] - ys[lo]) * (x - xs[lo]) / (xs[hi] - xs[lo])
     }
+
+    /**
+     * QUADratic interpolation of the Y value of the curve at the given [x] position
+     *
+     * If [x] is out of bounds, returns the first or the last value of [ys].
+     */
+    fun quad(x: Double): Double {
+        if (x <= xs.first()) {
+            return ys.first()
+        }
+        if (x >= xs.last()) {
+            return ys.last()
+        }
+        if (size < 3) {
+            return lerp(x)
+        }
+
+        val result = xs.binarySearch(x)
+        if (result >= 0) {
+            // Landed right on a point of the curve
+            return ys[result]
+        }
+
+        // Index where `x` should be inserted in `xs` to preserve order. It is
+        // ensured to be higher than 1 and lower than `size-1`, otherwise `x`
+        // is lower than `x.first()` or higher than `xs.last()` and these cases
+        // are handled above.
+        val i = -result - 1
+
+        val lo: Double
+        val mi: Double
+        val hi: Double
+        val ylo: Double
+        val ymi: Double
+        val yhi: Double
+        if (i == size-1) {
+            lo = xs[i - 2]
+            mi = xs[i - 1]
+            hi = xs[i]
+            ylo = ys[i - 2]
+            ymi = ys[i - 1]
+            yhi = ys[i]
+        } else {
+            lo = xs[i - 1]
+            mi = xs[i]
+            hi = xs[i + 1]
+            ylo = ys[i - 1]
+            ymi = ys[i]
+            yhi = ys[i + 1]
+        }
+
+        // ref: https://en.wikipedia.org/wiki/Polynomial_interpolation#Lagrange_interpolation
+        return ylo * (x - mi) * (x - hi) / (lo - mi) / (lo - hi) +
+            ymi * (x - lo) * (x - hi) / (mi - lo) / (mi - hi) +
+            yhi * (x - lo) * (x - mi) / (hi - lo) / (hi - mi)
+
+    }
 }
 
 @JvmInline
@@ -424,36 +481,29 @@ internal fun reactToSpeedConstraint(
     afterPos: Meters,
     accelerateStep: IntegrationStep,
 ): IntegrationStep {
-    val beforeSpeedLimit = constraint.lerp(beforePos)
-    if (beforeSpeed approxEqualTo beforeSpeedLimit) {
-        // The rolling stock is on the curve
-        val step = ctx.step(dt, beforePos, beforeSpeed, Action.BRAKE)
-        // TODO snap vraiment sur la courbe osef de la physique OU ALORS interpolation quad
-        //assert(constraint.lerp(beforePos + step.positionDelta) approxEqualTo step.endSpeed)
-        return step
-    }
+    val beforeSpeedLimit = constraint.quad(beforePos)
+    val afterSpeedLimit = constraint.quad(afterPos)
+    val truncatedStep = truncateStep(accelerateStep, beforeSpeedLimit, afterSpeedLimit)
 
-    if (beforeSpeed > beforeSpeedLimit) {
-        // The rolling stock is going too fast to reach the target speed in time
-
+    if (truncatedStep.timeDelta approxEqualTo 0.0 || beforeSpeed > beforeSpeedLimit) {
+        // The stock's speed is on (or above) the curve and the curve is going DOWN ↓
         var brakingStep = ctx.step(dt, beforePos, beforeSpeed, Action.BRAKE)
-        val endVMax = constraint.lerp(Meters.POSITIVE_INFINITY)
-        if (!(endVMax approxLowerThan brakingStep.endSpeed)) {
+
+        val endLimit = constraint.quad(Meters.POSITIVE_INFINITY)
+        if (!(endLimit approxLowerThan brakingStep.endSpeed)) {
             // The rolling stock doesn't have to brake during all the time step to reach the target speed
 
             brakingStep = truncateStep(brakingStep, brakingStep.endSpeed, brakingStep.endSpeed)
         }
 
+        // Assert we're sticking on the constraint if we weren't above the constraint before
+        val nextSpeedLimit = constraint.quad(beforePos + brakingStep.positionDelta)
+        //assert(brakingStep.endSpeed approxEqualTo nextSpeedLimit || !(brakingStep.startSpeed approxLowerThan beforeSpeedLimit))
+
         return brakingStep
     }
 
-    val afterSpeedLimit = constraint.lerp(afterPos)
-    if (accelerateStep.endSpeed approxLowerThan afterSpeedLimit) {
-        // The speed limit doesn't constraint the acceleration
-        return accelerateStep
-    }
-
-    return truncateStep(accelerateStep, beforeSpeedLimit, afterSpeedLimit)
+    return truncatedStep
 }
 
 /**

--- a/core/src/main/kotlin/fr/sncf/osrd/tsim/tsim.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/tsim/tsim.kt
@@ -468,7 +468,7 @@ private fun truncateStep(step: IntegrationStep, vmax0: Double, vmax1: Double): I
     val v0 = step.startSpeed
     val v1 = step.endSpeed
 
-    if (v0 - v1 == vmax0 - vmax1) {
+    if ((v0 < vmax0) == (v1 < vmax1)) {
         return step
     }
 

--- a/core/src/main/kotlin/fr/sncf/osrd/tsim/tsim.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/tsim/tsim.kt
@@ -39,21 +39,9 @@ fun RangeMap<Meters, MetersPerSecond>.withStockLength(
         val range = entry.key
         val speedLimit = entry.value
 
-        // The speed limit is enforced as long as part of the rolling stock is behind the reset sign
-        // TODO what's the name of the sign that reset a speed limit?
-        val enforcementRange =
+        val extendedRange =
             Range.closed(range.lowerEndpointOrInf(), range.upperEndpointOrInf() + stockLength)
-        val newSubMap = ImmutableRangeMap.builder<Meters, MetersPerSecond>()
-        newSubMap.put(enforcementRange, speedLimit)
-
-        // Other, more restrictive speed limits might be in place
-        for (e in map.subRangeMap(enforcementRange).asMapOfRanges()) {
-            if (e.value < speedLimit) {
-                newSubMap.put(e.key, e.value)
-            }
-        }
-
-        map.putAll(newSubMap.build())
+        map.putLower(extendedRange, speedLimit)
     }
     return map
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/tsim/tsim.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/tsim/tsim.kt
@@ -46,6 +46,58 @@ fun RangeMap<Meters, MetersPerSecond>.withStockLength(
     return map
 }
 
+interface MaxSpeedConstraint {
+    /** The speed limit at the given [position]. */
+    fun at(position: Meters): MetersPerSecond
+
+    data class MaxSpeedChange(val position: Meters, val speed: MetersPerSecond)
+
+    /** Unordered speed limit changes starting from (and excluding) the given position [from]. */
+    fun changes(from: Meters = 0.0): Sequence<MaxSpeedChange>
+}
+
+/**
+ * A max speed constraint implemented as a single [RangeMap].
+ */
+@JvmInline
+value class SpeedLimit(val map: RangeMap<Meters, MetersPerSecond> = ImmutableRangeMap.of()): MaxSpeedConstraint {
+    override fun at(position: Meters): MetersPerSecond =
+        map.get(position) ?: MetersPerSecond.POSITIVE_INFINITY
+
+    override fun changes(from: Meters): Sequence<MaxSpeedConstraint.MaxSpeedChange> =
+        map
+            .asDescendingMapOfRanges()
+            .asSequence()
+            .map { entry ->
+                val range = entry.key
+                MaxSpeedConstraint.MaxSpeedChange(
+                    position = range.lowerEndpointOrInf(),
+                    speed = entry.value
+                )
+            }
+            .takeWhile { change -> change.position > from }
+}
+
+/**
+ * A max speed constraint implemented as multiple [RangeMap]s, whose ranges may overlap each other's.
+ *
+ * The speed limit at a given position is taken from the minimum of all speed limits.
+ */
+class OverlayingSpeedLimits(val overlays: List<RangeMap<Meters, MetersPerSecond>>): MaxSpeedConstraint {
+    override fun at(position: Meters): MetersPerSecond =
+        overlays
+            .asSequence()
+            .mapNotNull { overlay -> overlay.get(position) }
+            .minOrNull()
+            ?: MetersPerSecond.POSITIVE_INFINITY
+
+    override fun changes(from: Meters): Sequence<MaxSpeedConstraint.MaxSpeedChange> =
+        overlays
+            .asSequence()
+            .flatMap { overlay -> SpeedLimit(overlay).changes(from) }
+
+}
+
 /**
  * A [RangeMap] of neutral zones accounting for the positions of the pantographs on the rolling
  * stock.
@@ -124,24 +176,6 @@ fun RangeMap<Meters, Boolean>.withPantographPositions(
     vararg positions: Meters
 ): NeutralZonesWithPantographs = NeutralZonesWithPantographs(this, *positions)
 
-data class Instructions(
-    /**
-     * Ranges on the path where a speed limit is enforced.
-     *
-     * Maps positions of the head of the train along the path to the highest allowed speed.
-     */
-    val speedLimits: RangeMap<Meters, MetersPerSecond> = TreeRangeMap.create(),
-
-    /**
-     * Ranges of the path that aren't electrified.
-     *
-     * Maps ranges of the path to whether the neutral zone requires lowering the pantograph.
-     */
-    val neutralZones: NeutralZonesWithPantographs = NeutralZonesWithPantographs(),
-
-    // TODO Stop?
-)
-
 internal class DecelerationTarget(
     /** Target position where [speed] must be reached. */
     val position: Meters,
@@ -178,12 +212,12 @@ private fun intersectAt(
 /**
  * A 2D curve.
  *
- * This class represents a list of 2D points `(xs[i],ys[i])` connected by straight lines. [xs] and
- * [ys] must have the same size. The elements of [xs] are expected to be strictly increasing.
+ * This class represents a list of 2D points `(xs[i],ys[i])`. [xs] and [ys] must have the same size. [xs] isn't supposed to be empty, and its elements are expected to be strictly increasing.
  */
-internal class Curve(val xs: DoubleArray, val ys: DoubleArray) {
+class Curve(val xs: DoubleArray, val ys: DoubleArray) {
     init {
         require(xs.size == ys.size) { "xs and ys must be the same size" }
+        require(xs.isNotEmpty()) { "curve must have at least one point" }
     }
 
     val size: Int
@@ -221,6 +255,30 @@ internal class Curve(val xs: DoubleArray, val ys: DoubleArray) {
     }
 }
 
+@JvmInline
+value class SpeedLimitedZone(val vmax: Curve) {
+    val range: Range<Meters>
+        get() = Range.closed(vmax.xs.first(), vmax.xs.last())
+}
+
+data class Instructions(
+    /**
+     * Ranges on the path where a speed limit is enforced.
+     *
+     * Maps positions of the head of the train along the path to the highest allowed speed.
+     */
+    val maxSpeed: MaxSpeedConstraint = SpeedLimit(),
+
+    /**
+     * Ranges of the path that aren't electrified.
+     *
+     * Maps ranges of the path to whether the neutral zone requires lowering the pantograph.
+     */
+    val neutralZones: NeutralZonesWithPantographs = NeutralZonesWithPantographs(),
+
+    // TODO Stop?
+)
+
 /**
  * Context of a simulation, caching expensive values for a given [path], rolling [stock] and
  * tractive [effortCurveMap].
@@ -230,6 +288,12 @@ class Context(
     val stock: RollingStock,
     val effortCurveMap: RangeMap<Meters, Array<PhysicsRollingStock.TractiveEffortPoint>>,
 ) {
+    internal fun step(dt: Seconds, position: Meters, speed: MetersPerSecond, action: Action): IntegrationStep {
+        val evsimCtx = EnvelopeSimContext(stock, path, dt, effortCurveMap)
+        val s = TrainPhysicsIntegrator.step(evsimCtx, position, speed, action, 1.0)
+        return s
+    }
+
     /**
      * Maps [DecelerationTarget]s to [Curve]s that specify the highest speed the rolling [stock] can
      * have at each given position in order to reach the speed target with the given brakes.
@@ -252,7 +316,7 @@ class Context(
         var speed = target.speed
         var stepCount = 0
         stepCount++ // count the step (target.position, target.speed)
-        while (speed < stock.maxSpeed) {
+        while (speed < stock.maxSpeed && position > 0.0) {
             val s =
                 TrainPhysicsIntegrator.step(evsimCtx, position, speed, action, -1.0, target.brake)
             assert(s.timeDelta == dt)
@@ -311,128 +375,114 @@ fun step(
     require(position >= 0.0) { "position must be positive" }
     require(speed >= 0.0) { "speed must be positive" }
 
-    val speedLimits = instructions.speedLimits.subRangeMap(Range.atLeast(position))
-    val currentSpeedLimit = speedLimits.get(position) ?: Double.POSITIVE_INFINITY
+    val currentSpeedLimit = instructions.maxSpeed.at(position)
 
-    var action = Action.ACCELERATE
-    // We may choose to stop the integration early, to snap to a deceleration curve, or a point of
-    // interest where the behavior of the rolling stock may change.
-    var minDT = dt
-    var snappedStep: IntegrationStep? = null
-
-    if (speed approxLowerThan currentSpeedLimit) {
-        // The train is going slower than allowed, but may need to brake in order to
-        // respect an upcoming speed limit. Compute the deceleration curves for upcoming
-        // speed limits and check if the stock's speed is above, or accelerate.
-
-        var startSpeed = speed
-
-        if (speed approxEqualTo currentSpeedLimit && action == Action.ACCELERATE) {
-            // The stock has power to maintain its speed and it has reached its speed limit.
-            // Snap the speed to the speed limit because of floating point errors
-            action = Action.MAINTAIN
-            startSpeed = currentSpeedLimit
-            // TODO compute the time when the current speed limit expires and we can accelerate
-            // again
-        } else {
-            assert(speed < currentSpeedLimit)
-        }
-
-        // The speed and position of the train if we choose not to brake.
-        val evsimCtx = EnvelopeSimContext(ctx.stock, ctx.path, dt, ctx.effortCurveMap)
-        val s =
-            TrainPhysicsIntegrator.step(
-                evsimCtx,
-                position,
-                startSpeed,
-                action,
-                1.0,
-                BrakingType.CONSTANT,
-            )
-        assert(s.timeDelta == dt)
-        val endPosition = position + s.positionDelta
-        for (speedRestriction in speedLimits.asMapOfRanges()) {
-            val range = speedRestriction.key
-            val maxSpeed = speedRestriction.value
-            val target =
-                DecelerationTarget(
-                    position = range.lowerEndpointOrInf(),
-                    brake = BrakingType.CONSTANT,
-                    speed = maxSpeed,
-                )
-            val c = ctx.decelerationCurve(target, dt)
-            val speedLimit = c.lerp(position)
-            if (!(speed approxLowerThan speedLimit)) {
-                // The stock is already going too fast to reach the speed limit in time.
-                // Since all curves are done with the same [BrakingType], we can assume the stock
-                // will need to brake until at least dt anyway.
-                action = Action.BRAKE
-                break
-            }
-
-            val speedAfterDT = s.endSpeed
-            val speedLimitAfterDT = c.lerp(endPosition)
-            if (speedAfterDT approxLowerThan speedLimitAfterDT) {
-                // The stock can accelerate throughout the time step and still respect the
-                // deceleration curve
-                continue
-            }
-
-            // Assume the deceleration curve is a straight line between [position] and [endPosition]
-            // [reachLimitAtPosition] is always non-null because of the earlier branches
-            val reachLimitAtPosition =
-                intersectAt(
-                    position,
-                    endPosition,
-                    speed,
-                    speedAfterDT,
-                    speedLimit,
-                    speedLimitAfterDT,
-                )!!
-
-            // Assume the position of the stock follows a straight line between now and now+[dt]
-            // It's actually a second order polynomial but we don't have a third point to
-            // interpolate 🤓
-            val reachLimitAtDT = dt * (reachLimitAtPosition - position) / s.positionDelta
-            assert(reachLimitAtDT != 0.0)
-
-            if (minDT < reachLimitAtDT) {
-                continue
-            }
-            minDT = reachLimitAtDT
-
-            // Snap the rolling stock to the deceleration curve or speed limit because of floating
-            // point errors
-            snappedStep =
-                IntegrationStep.fromNaiveStep(
-                    minDT,
-                    reachLimitAtPosition - position,
-                    startSpeed,
-                    speedLimitAfterDT,
-                    (speedLimitAfterDT - startSpeed) / minDT,
-                    1.0,
-                )
-        }
-    } else {
-        // The stock is already rolling faster than allowed, brake.
-        // TODO compute when we can stop braking and trim the time step
-        action = Action.BRAKE
+    if (!(speed approxLowerThan currentSpeedLimit)) {
+        return ctx.step(dt, position, speed, Action.BRAKE)
     }
 
-    if (snappedStep == null) {
-        val evsimCtx = EnvelopeSimContext(ctx.stock, ctx.path, dt, ctx.effortCurveMap)
-        snappedStep =
-            TrainPhysicsIntegrator.step(
-                evsimCtx,
+    val action = if (speed approxEqualTo currentSpeedLimit) {
+        // TODO compute the time when the current speed limit expires and we can accelerate again
+        Action.MAINTAIN
+    } else {
+        assert(speed < currentSpeedLimit)
+        Action.ACCELERATE
+    }
+
+    val naiveStep = ctx.step(dt, position, speed, action)
+    return instructions.maxSpeed.changes(position)
+        .map { change ->
+            val target = DecelerationTarget(
+                position = change.position,
+                brake = BrakingType.CONSTANT,
+                speed = change.speed,
+            )
+            val constraint = ctx.decelerationCurve(target, dt)
+            reactToSpeedConstraint(
+                ctx,
+                constraint,
+                naiveStep.timeDelta,
                 position,
                 speed,
-                action,
-                1.0,
-                BrakingType.CONSTANT,
+                position + naiveStep.positionDelta,
+                naiveStep,
             )
+        }
+        .minByOrNull { step -> step.acceleration }
+        ?: naiveStep
+}
+
+/**
+ * Adjust the behavior of the rolling stock according to a given speed [constraint].
+ */
+internal fun reactToSpeedConstraint(
+    ctx: Context,
+    constraint: Curve,
+    dt: Seconds,
+    beforePos: Meters,
+    beforeSpeed: MetersPerSecond,
+    afterPos: Meters,
+    accelerateStep: IntegrationStep,
+): IntegrationStep {
+    val beforeSpeedLimit = constraint.lerp(beforePos)
+    if (beforeSpeed approxEqualTo beforeSpeedLimit) {
+        // The rolling stock is on the curve
+        val step = ctx.step(dt, beforePos, beforeSpeed, Action.BRAKE)
+        // TODO snap vraiment sur la courbe osef de la physique OU ALORS interpolation quad
+        //assert(constraint.lerp(beforePos + step.positionDelta) approxEqualTo step.endSpeed)
+        return step
     }
 
-    return snappedStep
+    if (beforeSpeed > beforeSpeedLimit) {
+        // The rolling stock is going too fast to reach the target speed in time
+
+        var brakingStep = ctx.step(dt, beforePos, beforeSpeed, Action.BRAKE)
+        val endVMax = constraint.lerp(Meters.POSITIVE_INFINITY)
+        if (!(endVMax approxLowerThan brakingStep.endSpeed)) {
+            // The rolling stock doesn't have to brake during all the time step to reach the target speed
+
+            brakingStep = truncateStep(brakingStep, brakingStep.endSpeed, brakingStep.endSpeed)
+        }
+
+        return brakingStep
+    }
+
+    val afterSpeedLimit = constraint.lerp(afterPos)
+    if (accelerateStep.endSpeed approxLowerThan afterSpeedLimit) {
+        // The speed limit doesn't constraint the acceleration
+        return accelerateStep
+    }
+
+    return truncateStep(accelerateStep, beforeSpeedLimit, afterSpeedLimit)
+}
+
+/**
+ * Given a speed limit defined as a line passing through the points `(0,vmax0)` and `(step.positionDelta,vmax1)`,
+ * truncate the given [step] so that its speed ends up on the line.
+ *
+ * Assume speed and position are linear during the step.
+ *
+ * Return [step] if its speed and the speed limit are parallel.
+ */
+private fun truncateStep(step: IntegrationStep, vmax0: Double, vmax1: Double): IntegrationStep {
+    val v0 = step.startSpeed
+    val v1 = step.endSpeed
+
+    if (v0 - v1 == vmax0 - vmax1) {
+        return step
+    }
+
+    val vmid = (v1 * vmax0 - v0 * vmax1) / (v1 - v0 + vmax0 - vmax1)
+    val mix = ((vmid - v0) / (v1 - v0)).coerceIn(0.0, 1.0) // float errors
+
+    return IntegrationStep.fromNaiveStep(
+        step.timeDelta * mix,
+        step.positionDelta * mix,
+        step.startSpeed,
+        vmid,
+        step.acceleration,
+        1.0,
+    )
 }
 
 /** Whether [this] and [that] are sufficiently close to each other. */

--- a/core/src/main/kotlin/fr/sncf/osrd/tsim/tsim.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/tsim/tsim.kt
@@ -3,10 +3,12 @@ package fr.sncf.osrd.tsim
 import com.google.common.collect.ImmutableRangeMap
 import com.google.common.collect.Range
 import com.google.common.collect.RangeMap
+import com.google.common.collect.TreeRangeMap
 import fr.sncf.osrd.envelope_sim.*
 import fr.sncf.osrd.envelope_sim.etcs.BrakingType
 import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.train.RollingStock
+import java.util.function.BiFunction
 
 typealias Seconds = Double
 
@@ -20,21 +22,135 @@ typealias MeterArray = DoubleArray
 
 typealias MeterPerSecondArray = DoubleArray
 
+/**
+ * Update a [RangeMap] representing a Speed Profile, accounting for the length of the rolling stock.
+ *
+ * The given [RangeMap] contains the ranges on the path with speed limits (indicated by signs or
+ * signals). The returned [RangeMap] will report, for given positions of the rolling stock's head,
+ * ranges on the path where the rolling stock cannot exceed a certain speed limit, because even if
+ * pass the sign, as long as its tail is behind the sign the speed limit is still enforced.
+ */
+fun RangeMap<Meters, MetersPerSecond>.withStockLength(
+    stockLength: Meters
+): RangeMap<Meters, MetersPerSecond> {
+    val map = TreeRangeMap.create<Meters, MetersPerSecond>()
+    for (entry in asMapOfRanges()) {
+        val range = entry.key
+        val speedLimit = entry.value
+
+        // The speed limit is enforced as long as part of the rolling stock is behind the reset sign
+        // TODO what's the name of the sign that reset a speed limit?
+        val enforcementRange =
+            Range.closed(range.lowerEndpointOrInf(), range.upperEndpointOrInf() + stockLength)
+        val newSubMap = ImmutableRangeMap.builder<Meters, MetersPerSecond>()
+        newSubMap.put(enforcementRange, speedLimit)
+
+        // Other, more restrictive speed limits might be in place
+        for (e in map.subRangeMap(enforcementRange).asMapOfRanges()) {
+            if (e.value < speedLimit) {
+                newSubMap.put(e.key, e.value)
+            }
+        }
+
+        map.putAll(newSubMap.build())
+    }
+    return map
+}
+
+/**
+ * A [RangeMap] of neutral zones accounting for the positions of the pantographs on the rolling
+ * stock.
+ *
+ * This class will report, for given positions of its head, ranges on the path where the rolling
+ * stock isn't electrified.
+ *
+ * This is meant to be immutable (but isn't because [ImmutableRangeMap] inherits from [RangeMap] and
+ * not the other way around)
+ */
+class NeutralZonesWithPantographs(
+    /** ranges on the path with neutral zones */
+    private val inner: RangeMap<Meters, Boolean>,
+
+    /**
+     * list of positions of pantographs, where 0.0 is the head of the stock and `stock.length` is
+     * its tail
+     */
+    vararg pantographPositions: Meters,
+) : RangeMap<Meters, Boolean> {
+    private val frontPantograph: Meters = pantographPositions.maxOrNull()!!
+    private val rearPantograph: Meters = pantographPositions.minOrNull()!!
+
+    constructor() : this(inner = ImmutableRangeMap.of(), 0.0)
+
+    override fun get(head: Meters): Boolean? = getEntry(head)?.value
+
+    override fun getEntry(head: Meters): Map.Entry<Range<Meters>?, Boolean>? =
+        inner
+            .subRangeMap(Range.closed(head - frontPantograph, head - rearPantograph))
+            .asMapOfRanges()
+            .maxByOrNull { entry -> entry.value }
+
+    override fun span(): Range<Meters> = inner.span()
+
+    override fun put(range: Range<Meters>, value: Boolean): Unit =
+        throw UnsupportedOperationException()
+
+    override fun putCoalescing(range: Range<Meters>, value: Boolean): Unit =
+        throw UnsupportedOperationException()
+
+    override fun putAll(rangeMap: RangeMap<Meters, out Boolean>): Unit =
+        throw UnsupportedOperationException()
+
+    override fun clear() = inner.clear()
+
+    override fun remove(range: Range<Meters>): Unit = throw UnsupportedOperationException()
+
+    override fun merge(
+        range: Range<Meters>,
+        value: Boolean?,
+        remappingFunction: BiFunction<in Boolean, in Boolean?, out Boolean?>,
+    ): Unit = throw UnsupportedOperationException()
+
+    override fun asMapOfRanges(): Map<Range<Meters>?, Boolean> {
+        TODO("Not yet implemented")
+    }
+
+    override fun asDescendingMapOfRanges(): Map<Range<Meters>?, Boolean> {
+        TODO("Not yet implemented")
+    }
+
+    override fun subRangeMap(range: Range<Meters>): RangeMap<Meters, Boolean> =
+        NeutralZonesWithPantographs(inner.subRangeMap(range), frontPantograph, rearPantograph)
+}
+
+/**
+ * Update a [RangeMap] representing neutral zones along a path, to account for the position of the
+ * pantographs on the rolling stock.
+ *
+ * This is needed to account for neutral zones that require lowering pantographs: they must be
+ * lowered before going TODO: can they be lowered last minute, eg the pantograph is on the back, the
+ * train head is in the neutral zone and the pantograph is lowered right before it goes in too?
+ */
+fun RangeMap<Meters, Boolean>.withPantographPositions(
+    vararg positions: Meters
+): NeutralZonesWithPantographs = NeutralZonesWithPantographs(this, *positions)
+
 data class Instructions(
     /**
      * Most-Restrictive Speed Profile.
      *
+     * Maps positions of the head of the train along the path to the highest allowed speed.
+     *
      * This doesn't need to account for the train's max speed.
      */
-    // ?? ImmutableRangeMap inherits RangeMap and not the other way around?
-    val mrsp: RangeMap<Meters, MetersPerSecond> = ImmutableRangeMap.of(),
+    val mrsp: RangeMap<Meters, MetersPerSecond> = TreeRangeMap.create(),
 
     /**
      * Ranges of the path that aren't electrified.
      *
      * Maps ranges of the path to whether the neutral zone requires lowering the pantograph.
      */
-    val neutralZones: RangeMap<Meters, Boolean> = ImmutableRangeMap.of(),
+    val neutralZones: NeutralZonesWithPantographs = NeutralZonesWithPantographs(),
 
     // TODO Stop?
 )
@@ -185,8 +301,6 @@ fun step(
     require(dt > 0.0) { "dt must be strictly positive" }
     require(position >= 0.0) { "position must be positive" }
     require(speed >= 0.0) { "speed must be positive" }
-
-    // TODO update mrsp to account for the whole stock length
 
     var action = Action.ACCELERATE
 

--- a/core/src/main/kotlin/fr/sncf/osrd/tsim/tsim.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/tsim/tsim.kt
@@ -7,6 +7,7 @@ import com.google.common.collect.TreeRangeMap
 import fr.sncf.osrd.envelope_sim.*
 import fr.sncf.osrd.envelope_sim.etcs.BrakingType
 import fr.sncf.osrd.path.interfaces.PhysicsPath
+import fr.sncf.osrd.sauce
 import fr.sncf.osrd.train.RollingStock
 import java.util.function.BiFunction
 import kotlin.math.abs
@@ -431,6 +432,8 @@ fun step(
     require(dt > 0.0) { "dt must be strictly positive" }
     require(position >= 0.0) { "position must be positive" }
     require(speed >= 0.0) { "speed must be positive" }
+
+    println(sauce())
 
     val currentSpeedLimit = instructions.maxSpeed.at(position)
 

--- a/core/src/main/kotlin/fr/sncf/osrd/tsim/tsim.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/tsim/tsim.kt
@@ -447,7 +447,7 @@ fun step(
     }
 
     val naiveStep = ctx.step(dt, position, speed, action)
-    return instructions.maxSpeed.changes(position)
+    val reactions = instructions.maxSpeed.changes(position)
         .map { change ->
             val target = DecelerationTarget(
                 position = change.position,
@@ -465,8 +465,34 @@ fun step(
                 naiveStep,
             )
         }
-        .minByOrNull { step -> step.acceleration }
-        ?: naiveStep
+
+    val step = reactions
+        .minWithOrNull(
+            // Take the most restrictive reaction. First, we pick those with the
+            // the lowest acceleration: if a constraint requires the rolling
+            // stock to brake (e.g. a signal, or a speed limit), the rolling
+            // stock must decelerate. Then, amongst those -- e.g. multiple
+            // braking steps, or multiple full accelerations -- take the one
+            // with the lowest speed: if all constraints accelerate but one
+            // stops accelerating at a speed limit, we want the rolling stock to
+            // stop accelerating at the speed limit. Inversely, if a constraint
+            // makes the stock brake until a speed limit but another one makes
+            // it brake the full step, we can have the stock brake for the full
+            // step.
+            compareBy<IntegrationStep> { step -> step.acceleration }
+                .thenBy { step -> step.endSpeed }
+        )!!
+
+    // Assert the stock doesn't go above a speed limit if it wasn't above a speed limit before.
+    val nextSpeedLimit = instructions.maxSpeed.at(position + step.positionDelta)
+    if (step.endSpeed approxLowerThan nextSpeedLimit || !(step.startSpeed approxLowerThan currentSpeedLimit)) {
+        // TODO change this to an assert
+    } else {
+        println("oupsi on a dépasser à $position alant a $speed < $currentSpeedLimit vers ${step.endSpeed} > $nextSpeedLimit")
+        assert(reactions.all { step -> !(step.endSpeed approxLowerThan nextSpeedLimit) })
+    }
+
+    return step
 }
 
 /**

--- a/core/tsim/README.md
+++ b/core/tsim/README.md
@@ -1,0 +1,13 @@
+# Train simulation module
+
+Build the native library with
+
+```sh
+core$ ./gradlew :tsim:nativBinaries
+```
+
+The above command will produce debug and release binaries as well as header files in the output build directory located at:
+
+```
+./core/tsim/build/bin/nativ/
+```

--- a/core/tsim/build.gradle.kts
+++ b/core/tsim/build.gradle.kts
@@ -1,0 +1,37 @@
+plugins {
+    alias(libs.plugins.kotlin.multiplatform)
+}
+
+group = "fr.sncf.osrd"
+version = "1.0.0"
+
+repositories {
+    mavenCentral()
+}
+
+kotlin {
+    jvm {
+        withSourcesJar(true)
+    }
+
+    val hostOs = System.getProperty("os.name")
+    val isArm64 = System.getProperty("os.arch") == "aarch64"
+    val isMingwX64 = hostOs.startsWith("Windows")
+    val name = "nativ"
+    val nativeTarget = when {
+        hostOs == "Mac OS X" && isArm64 -> macosArm64(name)
+        hostOs == "Mac OS X" && !isArm64 -> macosX64(name)
+        hostOs == "Linux" && isArm64 -> linuxArm64(name)
+        hostOs == "Linux" && !isArm64 -> linuxX64(name)
+        isMingwX64 -> mingwX64(name)
+        else -> throw GradleException("Host OS is not supported in Kotlin/Native.")
+    }
+
+    nativeTarget.apply {
+        binaries {
+            sharedLib {
+                baseName = "tsim"
+            }
+        }
+    }
+}

--- a/core/tsim/src/commonMain/kotlin/Main.kt
+++ b/core/tsim/src/commonMain/kotlin/Main.kt
@@ -1,0 +1,3 @@
+package fr.sncf.osrd
+
+fun sauce(): String = "ok je vais le faire"

--- a/core/tsim/src/nativeMain/kotlin/Main.kt
+++ b/core/tsim/src/nativeMain/kotlin/Main.kt
@@ -1,0 +1,4 @@
+package fr.sncf.osrd
+
+fun sauceC(): String = ""
+


### PR DESCRIPTION
This PR doesn't target `dev`, but targets branch https://github.com/OpenRailAssociation/osrd/pull/13828

This is a scaffolding for a [Kotlin Multiplatform] module that targets both native via LLVM and the JVM. Code in `commonMain` ends up available to both targets, code in `nativeMain` is only available to native targets and we could also have code in `jvmMain` that is only available on the JVM.

Since neither code in `commonMain` and code in `nativeMain` can access JVM dependencies (i.e. all of core) we have to either import all code used by the train simulation into the kotlin multiplatform project, or convert its dependencies (and their transitive dependencies) to kotlin multiplatform projects.

Here's a list of types and modules the current train simulation in #13828 uses that we would need to migrate:

- [ ] TrainPhysicsIntegrator
- [ ] PhysicsPath
- [ ] PhysicsRollingStock
- [ ] RJSEtcsBrakeParams
- [ ] IntegrationStep
- [ ] Action
- [ ] BrakingType
- [ ] make a jvm-free RangeMap equivalent, or migrate and use DistanceRangeMap
- [ ] Envelope (not currently used, but in the future, cf. https://github.com/OpenRailAssociation/osrd/pull/13828#discussion_r2493530736)

[Kotlin Multiplatform]: https://kotlinlang.org/docs/multiplatform.html