### PR TITLE
front: fix filter rollingStock

### DIFF
--- a/front/src/modules/rollingStock/components/RollingStockSelector/RollingStockHelpers.tsx
+++ b/front/src/modules/rollingStock/components/RollingStockSelector/RollingStockHelpers.tsx
@@ -46,7 +46,7 @@ export const RollingStockInfo = ({
             </span>
             <RollingStockUnit unit={metadata?.unit || ''} detail={metadata?.detail || ''} />
             <span className="rollingstock-info-subseries">
-              {metadata?.series && metadata.series !== metadata.subseries
+              {metadata?.subseries && metadata.series !== metadata.subseries
                 ? metadata.subseries
                 : metadata?.detail || ''}
             </span>

--- a/front/src/modules/rollingStock/hooks/useFilterRollingStock.ts
+++ b/front/src/modules/rollingStock/hooks/useFilterRollingStock.ts
@@ -65,6 +65,7 @@ function rollingStockPassesSearchedStringFilter(
     metadata?.detail,
     metadata?.reference,
     metadata?.series,
+    metadata?.subseries,
     metadata?.type,
     metadata?.grouping,
   ].some(includesSearchedString);


### PR DESCRIPTION
  The RS search filter was only applied to certain metadata fields and did not include the
  “sub-series” field, which prevented certain RS from being displayed.
  In addition, the “sub-series” did not always appear in the RS record when necessary.

close [#1291](https://github.com/osrd-project/osrd-confidential/issues/1291)
