### PR TITLE
front: set default stop time (2') from reticular creation

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/consts.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/consts.ts
@@ -18,13 +18,18 @@ export enum TRAINRUN_DIRECTIONS {
   BACKWARD = 'backward',
 }
 
+/**
+ * Used to compute the default stop time on a trainrun section creation and for using the propagation arrows.
+ * If the haltezeit is 2' and the arrival at a node is at 16', then the departure of this node will be 18'.
+ * TrainrunCategory.fachCategory should refer to one of these values. Currently, only HaltezeitUncategorized is used in osrdToNge.ts.
+ */
 export const TRAINRUN_CATEGORY_HALTEZEITEN = {
   HaltezeitIPV: { haltezeit: 0, no_halt: false },
   HaltezeitA: { haltezeit: 0, no_halt: false },
   HaltezeitB: { haltezeit: 0, no_halt: false },
   HaltezeitC: { haltezeit: 0, no_halt: false },
   HaltezeitD: { haltezeit: 0, no_halt: false },
-  HaltezeitUncategorized: { haltezeit: 0, no_halt: false },
+  HaltezeitUncategorized: { haltezeit: 2, no_halt: false },
 };
 
 export const TRAINRUN_LABEL_GROUP: LabelGroupDto = {


### PR DESCRIPTION
Fixes a bug (no issue to refer to): on a trainrun section creation (= extending the train's path), the newly created subsequent transition is a non-stop one. It should be a stop one.

NGE's behavior:

https://github.com/user-attachments/assets/500c901c-f44f-4398-80ce-20c4a38cfeec

Current OSRD's behavior (forces non-stop + 0' minute stop):

https://github.com/user-attachments/assets/93537279-2302-4b94-98dd-1c6ef23ad8f1

Fixed OSRD's behavior (using 2' stop for all trains, ***for now***):

https://github.com/user-attachments/assets/e34aba55-49c6-4c23-b7c2-a55374ff3e11


The times propagation arrows are also affected by this change.

This value (2') is temporary and is only a mid-term fix. Later, we intend to set custom values depending on the train category (OSRD-speaking)