### PR TITLE
editoast: partial fix for stdcm payload logging

### DIFF
--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -138,7 +138,7 @@ pub(in crate::views) struct StdcmQueryParams {
     skip_all,
     err,
     fields(
-        request = serde_json::to_string(&request)?,
+        request,
         timetable_id = id,
         infra_id = query.infra,
         path_found,
@@ -164,6 +164,11 @@ pub(in crate::views) async fn stdcm(
     Query(query): Query<StdcmQueryParams>,
     Json(request): Json<Request>,
 ) -> Result<Json<StdcmResponse>> {
+    // Add serialized request to trace attributes, skipping allowed track sections
+    // (as it would make the payload too large to be saved). TODO: include search env ID
+    let mut request_copy = request.clone();
+    request_copy.allowed_track_sections = None;
+    Span::current().record("request", serde_json::to_string(&request_copy)?);
     let mut returned_request: Option<core_client::stdcm::Request> = None;
     stdcm_handler(
         state,


### PR DESCRIPTION
See https://github.com/OpenRailAssociation/osrd/issues/13988

Not an actual fix, as we need to guess the search env ID. But it's still better than nothing. 

The script that assembles the payloads back will also need to handle this as well. 