### PR TITLE
ci: check ESLint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -741,6 +741,13 @@ jobs:
 
           exit $(docker wait front-format)
 
+      - name: Check lints
+        run: |
+          docker run --name=front-lint --net=host \
+            ${{ fromJSON(needs.build.outputs.stable_tags).front-tests }} \
+            sh -c "npm run lint"
+          exit $(docker wait front-lint)
+
       - name: Check for i18n missing keys
         run: |
           docker run --name=front-i18n-checker --net=host \
@@ -974,7 +981,7 @@ jobs:
             -e GITHUB_REPOSITORY="$GITHUB_REPOSITORY" \
             -e GITHUB_RUN_ID="$GITHUB_RUN_ID" \
             -v "$PWD/front/test-results:/app/front/test-results" \
-            osrd-playwright:latest npx tsx /app/front/tests/reporter/generate-github-summary.ts /app/front/test-results/personalized-report.json /app/front/test-results/summary.md 
+            osrd-playwright:latest npx tsx /app/front/tests/reporter/generate-github-summary.ts /app/front/test-results/personalized-report.json /app/front/test-results/summary.md
           cat front/test-results/summary.md >> $GITHUB_STEP_SUMMARY
 
       - name: Save container logs

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/PacedTrainItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/PacedTrainItem.tsx
@@ -51,12 +51,12 @@ import {
   formatPacedTrainIdToOccurrenceId,
 } from 'utils/trainId';
 
-import TimetableItemActions from '../TimetableItemActions';
-import useOccurrences from './hooks/useOccurrences';
-import OccurrenceItem from './OccurrenceItem';
 import { TIMETABLE_ITEM_DELTA } from '../consts';
+import TimetableItemActions from '../TimetableItemActions';
 import { formatTrainDuration, getTrainCategoryClassName } from '../utils';
 import useOccurrenceActions from './hooks/useOccurrenceActions';
+import useOccurrences from './hooks/useOccurrences';
+import OccurrenceItem from './OccurrenceItem';
 
 type PacedTrainItemProps = {
   isInSelection: boolean;

--- a/front/src/applications/rollingStockEditor/components/RollingStockEditorCurves.tsx
+++ b/front/src/applications/rollingStockEditor/components/RollingStockEditorCurves.tsx
@@ -9,6 +9,8 @@ import RollingStockCurve from 'modules/rollingStock/components/RollingStockCurve
 import { STANDARD_COMFORT_LEVEL, THERMAL_TRACTION_IDENTIFIER } from 'modules/rollingStock/consts';
 import { removeDuplicates } from 'utils/array';
 
+import CurveParamSelectors from './CurveParamSelectors';
+import CurveSpreadsheet from './CurveSpreadsheet';
 import { filterNullValueInCurve } from '../helpers/curves';
 import { orderElectricalProfils } from '../helpers/electricalValues';
 import {
@@ -20,8 +22,6 @@ import type {
   EffortCurveForms,
   RollingStockParametersValues,
 } from '../types';
-import CurveParamSelectors from './CurveParamSelectors';
-import CurveSpreadsheet from './CurveSpreadsheet';
 
 const EMPTY_PARAMS = {
   comfortLevels: [STANDARD_COMFORT_LEVEL],

--- a/front/src/common/authorization/components/GrantsManagerSubjects.tsx
+++ b/front/src/common/authorization/components/GrantsManagerSubjects.tsx
@@ -5,11 +5,11 @@ import { useTranslation } from 'react-i18next';
 import generateGrantSelectProps from 'common/authorization/utils/generateGrantSelectProps';
 import { LoaderFill } from 'common/Loaders';
 
+import GrantManagerAddSubjectForm from './GrantManagerAddSubjectForm';
+import GrantsManagerSubject from './GrantsManagerSubject';
 import useAuthz from '../hooks/useAuthz';
 import useResourceListSubjects from '../hooks/useResourceListUser';
 import type { Grant, Privilege, ResourceType } from '../types';
-import GrantManagerAddSubjectForm from './GrantManagerAddSubjectForm';
-import GrantsManagerSubject from './GrantsManagerSubject';
 
 type GrantsManagerSubjectsProps = {
   resourceId: number;

--- a/front/src/reducers/osrdconf/operationalStudiesConf/index.ts
+++ b/front/src/reducers/osrdconf/operationalStudiesConf/index.ts
@@ -14,10 +14,10 @@ import { Duration } from 'utils/duration';
 import { msToKmh } from 'utils/physics';
 import { isPacedTrainWithDetails } from 'utils/trainId';
 
+import itineraryReducer from './itineraryReducer';
 import powerRestrictionReducer from './powerRestrictionReducer';
 import trainSettingsReducer from './trainSettingsReducer';
 import { upsertPathStep } from '../helpers';
-import itineraryReducer from './itineraryReducer';
 
 export const operationalStudiesInitialConf: OperationalStudiesConfState = {
   ...defaultCommonConf,


### PR DESCRIPTION
We use vite-plugin-checker, which is supposed to check for ESLint
too. Unfortunately, if the build finishes before ESLint, no error
is reported.

Add an explicit step to check ESLint.