### PR TITLE
core: increase the precision of the etcs endpoint's braking curves

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/api/etcs/ETCSBrakingCurvesEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/etcs/ETCSBrakingCurvesEndpoint.kt
@@ -225,9 +225,11 @@ class ETCSBrakingCurvesEndpoint(
 
     private fun Envelope.buildSimpleEnvelope(): SimpleEnvelope {
         val points = this.iteratePoints().distinct()
-        // Reduce the number of points in the envelope. Epsilon = 1.0 for now, reduce its value if
-        // more precision is needed.
-        val simplifiedEnvelope = simplifyEnvelopePoints(points)
+        // Reduce the number of points in the envelope. Epsilon = 0.3 for now, divides by more than
+        // 10 the number of points for a correct response time.
+        // Decrease its value to increase precision.
+        // Increase its value to decrease response time.
+        val simplifiedEnvelope = simplifyEnvelopePoints(points, epsilon = 0.3)
         return SimpleEnvelope(
             simplifiedEnvelope.map { Offset(it.position.meters) },
             simplifiedEnvelope.map { it.time.seconds },


### PR DESCRIPTION
We simplify the curves returned by the endpoint because returning tens of curves with >100 points is just not feasible. However, we were over-simplifying them (the possible error factor was 1.0m/s), so we could see the differences between these curves and the train's simulation in the GEV (which is not so great).
New epsilon value is 0.3: we have twice the number of points, keeping a possible error under 0.3m/s between the simplified curve and the real curve, which is largely sufficient for the front-end. What's more, it doesn't increase the response time too much (still <100ms), which means it should work out for longer paths :) (Edited: it was taking longer before because I tested it with editoast_no_cache = true so ofc it would take longer, it was recomputing the simulation...).