### PR TITLE
editoast: further reorganize `PathfindingEnv` to prepare `SimulationEnv`

### DIFF
--- a/editoast/core_task/src/envs/core.rs
+++ b/editoast/core_task/src/envs/core.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 /// Innermost environment to configure Core basic parameters
+#[derive(Debug, Clone)]
 pub struct CoreEnv {
     pub infra_id: u64,
     pub infra_version: i64,

--- a/editoast/core_task/src/envs/pathfinding.rs
+++ b/editoast/core_task/src/envs/pathfinding.rs
@@ -20,6 +20,8 @@ use crate::Correlated;
 use crate::Task;
 use crate::TrainSet;
 
+// ========== Environment public API ==========
+
 /// An environment to compute and cache paths asynchronously
 ///
 /// Provides [PathfindingEnv::run] and [PathfindingEnv::into_stream] to build, run,
@@ -36,98 +38,6 @@ where
     inputs: PathfindingEnvInputs<Train>,
 }
 
-#[derive(Debug)]
-pub(crate) struct PathfindingEnvInputs<Train>
-where
-    Train: Clone + Hash + Eq + Send + Sync + 'static,
-{
-    // TODO: deduplicate values
-    consists: HashMap<Train, Arc<PathfindingConsist>>,
-    constraints: HashMap<Train, Arc<PathfindingConstraints>>,
-}
-
-impl<Train> Default for PathfindingEnvInputs<Train>
-where
-    Train: Clone + Hash + Eq + Send + Sync + 'static,
-{
-    fn default() -> Self {
-        Self {
-            consists: HashMap::default(),
-            constraints: HashMap::default(),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
-pub(in crate::envs) struct Input(Arc<PathfindingConsist>, Arc<PathfindingConstraints>);
-
-/// The result of [PathfindingEnv::run]
-///
-/// Stores each pathfinding result as they arrive. So [fn PathfindingRun::get_path]
-/// might return that a result is still pending. The [TrainSet]s done being calculated
-/// can be tracked by providing a channel sender to [PathfindingEnv::run].
-///
-/// Cheap to clone.
-#[derive(Debug, Clone)]
-pub struct PathfindingRun<Train>
-where
-    Train: Clone + Hash + Eq + Send + Sync + 'static,
-{
-    inputs: Arc<PathfindingEnvInputs<Train>>,
-    // optionally deduplicate similar outputs of different inputs
-    paths: Arc<DashMap<Input, PendingPathfindingResult>>,
-}
-
-/// Ready when the pathfinding result is available and stored in [PathfindingRun], pending if the task is not yet completed
-type PendingPathfindingResult =
-    Poll<Result<Arc<core_client::pathfinding::PathfindingCoreResult>, core_client::Error>>;
-
-#[derive(Debug, Hash, PartialEq, Eq)]
-#[cfg_attr(test, derive(Clone))]
-pub struct PathfindingConsist {
-    pub loading_gauge: LoadingGaugeType,
-    /// Can the consist run on non-electrified tracks
-    pub thermal: bool,
-    /// Supported electrification modes (leave empty for unelectrified consists)
-    pub supported_electrifications: Vec<String>,
-    /// A list of supported signaling systems
-    pub supported_signaling_systems: Vec<String>,
-    pub maximum_speed: OrderedFloat<f64>,
-    /// Consist length in meters
-    pub length: OrderedFloat<f64>,
-    /// Speed limit tag to estimate maximum speed and travel time
-    pub speed_limit_tag: Option<String>,
-}
-
-#[derive(Debug, Hash, PartialEq, Eq)]
-#[cfg_attr(test, derive(Clone))]
-pub struct PathfindingConstraints {
-    /// An ordered list of waypoints the resulting path must pass through
-    pub path_items: Vec<PathWaypointAlternatives>,
-}
-
-/// A set of [TrackOffset]
-///
-/// The resulting path can cross any of these.
-#[derive(Debug, Hash, PartialEq, Eq)]
-#[cfg_attr(test, derive(Clone))]
-pub struct PathWaypointAlternatives(Vec<TrackOffset>);
-
-impl FromIterator<TrackOffset> for PathWaypointAlternatives {
-    fn from_iter<T: IntoIterator<Item = TrackOffset>>(iter: T) -> Self {
-        Self(iter.into_iter().collect())
-    }
-}
-
-impl IntoIterator for PathWaypointAlternatives {
-    type Item = TrackOffset;
-    type IntoIter = <Vec<TrackOffset> as IntoIterator>::IntoIter;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter()
-    }
-}
-
 impl<Train> PathfindingEnv<Train>
 where
     Train: Clone + Hash + Eq + Send + Sync + 'static,
@@ -142,56 +52,7 @@ where
     pub(crate) fn decompose(self) -> (CoreEnv, Arc<PathfindingEnvInputs<Train>>) {
         (self.core_env, Arc::new(self.inputs))
     }
-}
 
-impl<Train> Extend<(Train, PathfindingConsist)> for PathfindingEnv<Train>
-where
-    Train: Clone + Hash + Eq + Send + Sync + 'static,
-{
-    fn extend<T: IntoIterator<Item = (Train, PathfindingConsist)>>(&mut self, iter: T) {
-        self.inputs.consists.extend(
-            iter.into_iter()
-                .map(|(train, consist)| (train, Arc::new(consist))),
-        );
-    }
-}
-
-impl<Train> Extend<(Train, PathfindingConstraints)> for PathfindingEnv<Train>
-where
-    Train: Clone + Hash + Eq + Send + Sync + 'static,
-{
-    fn extend<T: IntoIterator<Item = (Train, PathfindingConstraints)>>(&mut self, iter: T) {
-        self.inputs.constraints.extend(
-            iter.into_iter()
-                .map(|(train, constraints)| (train, Arc::new(constraints))),
-        );
-    }
-}
-
-impl Task for core_client::pathfinding::PathfindingRequest {
-    type Output = core_client::pathfinding::PathfindingCoreResult;
-    type Error = core_client::Error;
-    type Context = Arc<CoreClient>;
-
-    // Please adjust if you have more educated information (and adjust the comment 😉).
-    const CACHE_READS_BATCH_SIZE: usize = 50; // This value has been chosen this way: 🫳🎩
-
-    fn key(&self, app_version: &str) -> String {
-        let mut hasher = DefaultHasher::new();
-        self.hash(&mut hasher);
-        let req_hash = hasher.finish().to_string();
-        format!("editoast.{app_version}.pathfinding.{req_hash}")
-    }
-
-    async fn compute(self, ctx: Self::Context) -> Result<Self::Output, Self::Error> {
-        self.fetch(ctx.as_ref()).await
-    }
-}
-
-impl<Train> PathfindingEnv<Train>
-where
-    Train: Clone + Hash + Eq + Send + Sync + 'static,
-{
     /// Computes paths or fetches them from cache asynchronously
     ///
     /// Returns a [PathfindingRun] containing the calculated paths (or errors)
@@ -263,6 +124,100 @@ where
     }
 }
 
+// ========== Input management ==========
+
+#[derive(Debug)]
+pub(crate) struct PathfindingEnvInputs<Train>
+where
+    Train: Clone + Hash + Eq + Send + Sync + 'static,
+{
+    // TODO: deduplicate values
+    consists: HashMap<Train, Arc<PathfindingConsist>>,
+    constraints: HashMap<Train, Arc<PathfindingConstraints>>,
+}
+
+impl<Train> Default for PathfindingEnvInputs<Train>
+where
+    Train: Clone + Hash + Eq + Send + Sync + 'static,
+{
+    fn default() -> Self {
+        Self {
+            consists: HashMap::default(),
+            constraints: HashMap::default(),
+        }
+    }
+}
+
+#[derive(Debug, Hash, PartialEq, Eq)]
+#[cfg_attr(test, derive(Clone))]
+pub struct PathfindingConsist {
+    pub loading_gauge: LoadingGaugeType,
+    /// Can the consist run on non-electrified tracks
+    pub thermal: bool,
+    /// Supported electrification modes (leave empty for unelectrified consists)
+    pub supported_electrifications: Vec<String>,
+    /// A list of supported signaling systems
+    pub supported_signaling_systems: Vec<String>,
+    pub maximum_speed: OrderedFloat<f64>,
+    /// Consist length in meters
+    pub length: OrderedFloat<f64>,
+    /// Speed limit tag to estimate maximum speed and travel time
+    pub speed_limit_tag: Option<String>,
+}
+
+#[derive(Debug, Hash, PartialEq, Eq)]
+#[cfg_attr(test, derive(Clone))]
+pub struct PathfindingConstraints {
+    /// An ordered list of waypoints the resulting path must pass through
+    pub path_items: Vec<PathWaypointAlternatives>,
+}
+
+/// A set of [TrackOffset]
+///
+/// The resulting path can cross any of these.
+#[derive(Debug, Hash, PartialEq, Eq)]
+#[cfg_attr(test, derive(Clone))]
+pub struct PathWaypointAlternatives(Vec<TrackOffset>);
+
+impl FromIterator<TrackOffset> for PathWaypointAlternatives {
+    fn from_iter<T: IntoIterator<Item = TrackOffset>>(iter: T) -> Self {
+        Self(iter.into_iter().collect())
+    }
+}
+
+impl IntoIterator for PathWaypointAlternatives {
+    type Item = TrackOffset;
+    type IntoIter = <Vec<TrackOffset> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<Train> Extend<(Train, PathfindingConsist)> for PathfindingEnv<Train>
+where
+    Train: Clone + Hash + Eq + Send + Sync + 'static,
+{
+    fn extend<T: IntoIterator<Item = (Train, PathfindingConsist)>>(&mut self, iter: T) {
+        self.inputs.consists.extend(
+            iter.into_iter()
+                .map(|(train, consist)| (train, Arc::new(consist))),
+        );
+    }
+}
+
+impl<Train> Extend<(Train, PathfindingConstraints)> for PathfindingEnv<Train>
+where
+    Train: Clone + Hash + Eq + Send + Sync + 'static,
+{
+    fn extend<T: IntoIterator<Item = (Train, PathfindingConstraints)>>(&mut self, iter: T) {
+        self.inputs.constraints.extend(
+            iter.into_iter()
+                .map(|(train, constraints)| (train, Arc::new(constraints))),
+        );
+    }
+}
+
 impl<Train> PathfindingEnvInputs<Train>
 where
     Train: Clone + Hash + Eq + Send + Sync + 'static,
@@ -285,6 +240,8 @@ where
     }
 }
 
+// ========== Low-level runner ==========
+
 /// Internal context allowing running pathfinding tasks
 ///
 /// Built from a [PathfindingEnv] using [Runner::new] which builds indexes in
@@ -297,6 +254,9 @@ where
     pathfinding_inputs: Arc<PathfindingEnvInputs<Train>>,
     input_index: DashMap<Input, TrainSet<Train>>,
 }
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub(in crate::envs) struct Input(Arc<PathfindingConsist>, Arc<PathfindingConstraints>);
 
 impl<Train> Runner<Train>
 where
@@ -363,29 +323,28 @@ where
     }
 }
 
-fn build_request(
-    core_env: &CoreEnv,
-    Input(consist, constraints): &Input,
-) -> core_client::pathfinding::PathfindingRequest {
-    core_client::pathfinding::PathfindingRequest {
-        infra: core_env.infra_id as i64,
-        expected_version: core_env.infra_version,
-        path_items: constraints
-            .path_items
-            .iter()
-            .map(|PathWaypointAlternatives(track_alternatives)| {
-                track_alternatives.clone().into_iter().collect()
-            })
-            .collect(),
-        rolling_stock_loading_gauge: consist.loading_gauge,
-        rolling_stock_is_thermal: consist.thermal,
-        rolling_stock_supported_electrifications: consist.supported_electrifications.clone(),
-        rolling_stock_supported_signaling_systems: consist.supported_signaling_systems.clone(),
-        rolling_stock_maximum_speed: consist.maximum_speed,
-        rolling_stock_length: consist.length,
-        speed_limit_tag: consist.speed_limit_tag.clone(),
-    }
+// ========== Stateful run ==========
+
+/// The result of [PathfindingEnv::run]
+///
+/// Stores each pathfinding result as they arrive. So [fn PathfindingRun::get_path]
+/// might return that a result is still pending. The [TrainSet]s done being calculated
+/// can be tracked by providing a channel sender to [PathfindingEnv::run].
+///
+/// Cheap to clone.
+#[derive(Debug, Clone)]
+pub struct PathfindingRun<Train>
+where
+    Train: Clone + Hash + Eq + Send + Sync + 'static,
+{
+    inputs: Arc<PathfindingEnvInputs<Train>>,
+    // optionally deduplicate similar outputs of different inputs
+    paths: Arc<DashMap<Input, PendingPathfindingResult>>,
 }
+
+/// Ready when the pathfinding result is available and stored in [PathfindingRun], pending if the task is not yet completed
+type PendingPathfindingResult =
+    Poll<Result<Arc<core_client::pathfinding::PathfindingCoreResult>, core_client::Error>>;
 
 impl<Train> PathfindingRun<Train>
 where
@@ -414,6 +373,52 @@ where
         let value_ref = self.paths.get(&input)?;
         let value = value_ref.value().clone();
         Some(value)
+    }
+}
+
+// ========== Core requests ==========
+
+fn build_request(
+    core_env: &CoreEnv,
+    Input(consist, constraints): &Input,
+) -> core_client::pathfinding::PathfindingRequest {
+    core_client::pathfinding::PathfindingRequest {
+        infra: core_env.infra_id as i64,
+        expected_version: core_env.infra_version,
+        path_items: constraints
+            .path_items
+            .iter()
+            .map(|PathWaypointAlternatives(track_alternatives)| {
+                track_alternatives.clone().into_iter().collect()
+            })
+            .collect(),
+        rolling_stock_loading_gauge: consist.loading_gauge,
+        rolling_stock_is_thermal: consist.thermal,
+        rolling_stock_supported_electrifications: consist.supported_electrifications.clone(),
+        rolling_stock_supported_signaling_systems: consist.supported_signaling_systems.clone(),
+        rolling_stock_maximum_speed: consist.maximum_speed,
+        rolling_stock_length: consist.length,
+        speed_limit_tag: consist.speed_limit_tag.clone(),
+    }
+}
+
+impl Task for core_client::pathfinding::PathfindingRequest {
+    type Output = core_client::pathfinding::PathfindingCoreResult;
+    type Error = core_client::Error;
+    type Context = Arc<CoreClient>;
+
+    // Please adjust if you have more educated information (and adjust the comment 😉).
+    const CACHE_READS_BATCH_SIZE: usize = 50; // This value has been chosen this way: 🫳🎩
+
+    fn key(&self, app_version: &str) -> String {
+        let mut hasher = DefaultHasher::new();
+        self.hash(&mut hasher);
+        let req_hash = hasher.finish().to_string();
+        format!("editoast.{app_version}.pathfinding.{req_hash}")
+    }
+
+    async fn compute(self, ctx: Self::Context) -> Result<Self::Output, Self::Error> {
+        self.fetch(ctx.as_ref()).await
     }
 }
 

--- a/editoast/core_task/src/envs/pathfinding.rs
+++ b/editoast/core_task/src/envs/pathfinding.rs
@@ -26,7 +26,7 @@ use crate::TrainSet;
 ///
 /// Provides [PathfindingEnv::run] and [PathfindingEnv::into_stream] to build, run,
 /// cache and return paths computed by Core. Use [PathfindingEnv::extend] to add train
-/// consist information and pathfinding constraints in the environment.
+/// consist information and pathfinding constraints in the environment. See [PathfindingTrain].
 ///
 /// `Train` generic parameter is a correlation key to associate each path to a train.
 /// It will be cloned several times over internally, so this operation should be cheap.
@@ -122,6 +122,13 @@ where
 
 // ========== Input management ==========
 
+/// Necessary inputs of a train to provide [PathfindingEnv]
+#[derive(Debug)]
+pub struct PathfindingTrain {
+    pub consist: PathfindingConsist,
+    pub constraints: PathfindingConstraints,
+}
+
 #[derive(Debug)]
 pub(crate) struct PathfindingEnvInputs<Train>
 where
@@ -190,27 +197,28 @@ impl IntoIterator for PathWaypointAlternatives {
     }
 }
 
-impl<Train> Extend<(Train, PathfindingConsist)> for PathfindingEnv<Train>
+impl<Train> Extend<(Train, PathfindingTrain)> for PathfindingEnv<Train>
 where
     Train: Clone + Hash + Eq + Send + Sync + 'static,
 {
-    fn extend<T: IntoIterator<Item = (Train, PathfindingConsist)>>(&mut self, iter: T) {
-        self.inputs.consists.extend(
-            iter.into_iter()
-                .map(|(train, consist)| (train, Arc::new(consist))),
+    fn extend<T: IntoIterator<Item = (Train, PathfindingTrain)>>(&mut self, iter: T) {
+        let iter = iter.into_iter().map(
+            |(
+                train,
+                PathfindingTrain {
+                    consist,
+                    constraints,
+                },
+            )| {
+                (
+                    (train.clone(), Arc::new(consist)),
+                    (train, Arc::new(constraints)),
+                )
+            },
         );
-    }
-}
-
-impl<Train> Extend<(Train, PathfindingConstraints)> for PathfindingEnv<Train>
-where
-    Train: Clone + Hash + Eq + Send + Sync + 'static,
-{
-    fn extend<T: IntoIterator<Item = (Train, PathfindingConstraints)>>(&mut self, iter: T) {
-        self.inputs.constraints.extend(
-            iter.into_iter()
-                .map(|(train, constraints)| (train, Arc::new(constraints))),
-        );
+        let (consists, constraints): (Vec<_>, Vec<_>) = iter.into_iter().unzip();
+        self.inputs.consists.extend(consists);
+        self.inputs.constraints.extend(constraints);
     }
 }
 
@@ -468,6 +476,13 @@ mod tests {
         }
     }
 
+    fn train(id: usize) -> PathfindingTrain {
+        PathfindingTrain {
+            consist: consist(id),
+            constraints: constraints(id),
+        }
+    }
+
     impl PathfindingEnv<usize> {
         fn key(&self, id: usize) -> String {
             let input = self.inputs.train_input(&id).unwrap();
@@ -488,8 +503,8 @@ mod tests {
             .finish();
 
         let mut pfenv = PathfindingEnv::<usize>::new(CoreEnv::new_mock(mock));
-        pfenv.extend([(1, constraints(1)), (2, constraints(2))]);
-        pfenv.extend([(1, consist(1)), (2, consist(2))]);
+        pfenv.extend([(1, train(1)), (2, train(2))]);
+
         let vk = cache::Client::new_mock(
             vec![
                 mock_mget(vec![(pfenv.key(1), Some(path(1))), (pfenv.key(2), None)]),

--- a/editoast/core_task/src/envs/pathfinding.rs
+++ b/editoast/core_task/src/envs/pathfinding.rs
@@ -44,9 +44,6 @@ where
     // TODO: deduplicate values
     consists: HashMap<Train, Arc<PathfindingConsist>>,
     constraints: HashMap<Train, Arc<PathfindingConstraints>>,
-
-    // Generated
-    trains: HashMap<Input, TrainSet<Train>>, // inverse index: unique input set => trains
 }
 
 impl<Train> Default for PathfindingEnvInputs<Train>
@@ -57,13 +54,12 @@ where
         Self {
             consists: HashMap::default(),
             constraints: HashMap::default(),
-            trains: HashMap::default(),
         }
     }
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
-struct Input(Arc<PathfindingConsist>, Arc<PathfindingConstraints>);
+pub(in crate::envs) struct Input(Arc<PathfindingConsist>, Arc<PathfindingConstraints>);
 
 /// The result of [PathfindingEnv::run]
 ///
@@ -157,7 +153,6 @@ where
             iter.into_iter()
                 .map(|(train, consist)| (train, Arc::new(consist))),
         );
-        self.inputs.build_input_map();
     }
 }
 
@@ -170,7 +165,6 @@ where
             iter.into_iter()
                 .map(|(train, constraints)| (train, Arc::new(constraints))),
         );
-        self.inputs.build_input_map();
     }
 }
 
@@ -214,26 +208,24 @@ where
         ready_trains_tx: Option<futures::channel::mpsc::UnboundedSender<TrainSet<Train>>>,
     ) -> PathfindingRun<Train> {
         use stream::StreamExt as _;
-        let (core_env, inputs) = self.decompose();
-        let run = PathfindingRun::new(inputs.clone());
+        let runner = Arc::new(Runner::new(self));
+        let run = PathfindingRun::new(&runner);
         let paths = run.paths.clone();
-        tokio::spawn(
-            Self::produce(vkconn, trains, core_env, inputs.clone()).fold(
-                (paths, inputs, ready_trains_tx),
-                async |(paths, inputs, ready_trains_tx),
-                       Correlated {
-                           correlation_key: input,
-                           data,
-                       }| {
-                    if let Some(tx) = ready_trains_tx.as_ref() {
-                        let trains = inputs.input_train_set(&input).clone();
-                        tx.unbounded_send(trains).ok();
-                    }
-                    paths.insert(input, Poll::Ready(data.map(Arc::new)));
-                    (paths, inputs, ready_trains_tx)
-                },
-            ),
-        );
+        tokio::spawn(runner.clone().stream(vkconn, trains).fold(
+            (paths, runner, ready_trains_tx),
+            async |(paths, runner, ready_trains_tx),
+                   Correlated {
+                       correlation_key: input,
+                       data,
+                   }| {
+                if let Some(tx) = ready_trains_tx.as_ref() {
+                    let trains = runner.input_train_set(&input).clone();
+                    tx.unbounded_send(trains).ok();
+                }
+                paths.insert(input, Poll::Ready(data.map(Arc::new)));
+                (paths, runner, ready_trains_tx)
+            },
+        ));
         run
     }
 
@@ -254,67 +246,16 @@ where
         >,
     > {
         use stream::StreamExt as _;
-        let (core_env, inputs) = self.decompose();
-        Self::produce(vkconn, trains, core_env, inputs.clone()).map(
+        let runner = Arc::new(Runner::new(self));
+        runner.clone().stream(vkconn, trains).map(
             move |Correlated {
                       correlation_key: input,
                       data: path,
                   }| {
-                let trains = inputs.input_train_set(&input).clone();
+                let trains = runner.input_train_set(&input).clone();
                 Correlated::new(trains, path)
             },
         )
-    }
-
-    fn produce(
-        vkconn: Arc<Mutex<cache::Connection>>,
-        trains: TrainSet<Train>,
-        core_env: CoreEnv,
-        inputs: Arc<PathfindingEnvInputs<Train>>,
-    ) -> impl stream::Stream<
-        Item = Correlated<
-            Input,
-            Result<core_client::pathfinding::PathfindingCoreResult, core_client::Error>,
-        >,
-    > + use<Train> {
-        use crate::TaskStreamExt as _;
-
-        let requests = trains
-            .iter()
-            .map(|train| {
-                let input = inputs
-                    .train_input(train)
-                    .expect("train map should have been built by now");
-                let request = Self::build_request(&core_env, &input);
-                Correlated::new(input, request)
-            })
-            .collect_vec();
-
-        stream::iter(requests).run(vkconn, core_env.client.clone())
-    }
-
-    fn build_request(
-        core_env: &CoreEnv,
-        Input(consist, constraints): &Input,
-    ) -> core_client::pathfinding::PathfindingRequest {
-        core_client::pathfinding::PathfindingRequest {
-            infra: core_env.infra_id as i64,
-            expected_version: core_env.infra_version,
-            path_items: constraints
-                .path_items
-                .iter()
-                .map(|PathWaypointAlternatives(track_alternatives)| {
-                    track_alternatives.clone().into_iter().collect()
-                })
-                .collect(),
-            rolling_stock_loading_gauge: consist.loading_gauge,
-            rolling_stock_is_thermal: consist.thermal,
-            rolling_stock_supported_electrifications: consist.supported_electrifications.clone(),
-            rolling_stock_supported_signaling_systems: consist.supported_signaling_systems.clone(),
-            rolling_stock_maximum_speed: consist.maximum_speed,
-            rolling_stock_length: consist.length,
-            speed_limit_tag: consist.speed_limit_tag.clone(),
-        }
     }
 
     pub fn all_trains(&self) -> TrainSet<Train> {
@@ -337,27 +278,112 @@ where
             .collect()
     }
 
-    /// Builds the [Self::trains] map using trains from both [Self::consists] and [Self::constraints]
-    ///
-    /// TODO: we should build it incrementally to avoid unnecessary complexity
-    fn build_input_map(&mut self) {
-        self.trains.clear();
-        for train in self.all_trains() {
-            let consist = self.consists.get(&train).expect("all_trains invariant");
-            let constraints = self.constraints.get(&train).expect("all_trains invariant");
-            let input = Input(consist.clone(), constraints.clone());
-            self.trains.entry(input).or_default().insert(train);
-        }
-    }
-
-    fn train_input(&self, train: &Train) -> Option<Input> {
+    pub(in crate::envs) fn train_input(&self, train: &Train) -> Option<Input> {
         let consist = self.consists.get(train)?;
         let constraints = self.constraints.get(train)?;
         Some(Input(consist.clone(), constraints.clone()))
     }
+}
 
-    fn input_train_set(&self, input: &Input) -> &TrainSet<Train> {
-        self.trains.get(input).expect("build_input_map invariant")
+/// Internal context allowing running pathfinding tasks
+///
+/// Built from a [PathfindingEnv] using [Runner::new] which builds indexes in
+/// its internal state. Do not create this struct directly.
+pub(in crate::envs) struct Runner<Train>
+where
+    Train: Clone + Hash + Eq + Send + Sync + 'static,
+{
+    core_env: CoreEnv,
+    pathfinding_inputs: Arc<PathfindingEnvInputs<Train>>,
+    input_index: DashMap<Input, TrainSet<Train>>,
+}
+
+impl<Train> Runner<Train>
+where
+    Train: Clone + Hash + Eq + Send + Sync + 'static,
+{
+    pub(in crate::envs) fn new(env: PathfindingEnv<Train>) -> Self {
+        let (core_env, pathfinding_inputs) = env.decompose();
+        let input_index = DashMap::<Input, TrainSet<Train>>::new();
+        for train in pathfinding_inputs.all_trains() {
+            let consist = pathfinding_inputs
+                .consists
+                .get(&train)
+                .expect("all_trains invariant");
+            let constraints = pathfinding_inputs
+                .constraints
+                .get(&train)
+                .expect("all_trains invariant");
+            let input = Input(consist.clone(), constraints.clone());
+            input_index.entry(input).or_default().insert(train);
+        }
+        Self {
+            core_env: core_env.clone(),
+            pathfinding_inputs,
+            input_index,
+        }
+    }
+
+    pub(in crate::envs) fn input_train_set(&self, input: &Input) -> TrainSet<Train> {
+        self.input_index
+            .get(input)
+            .expect("Runner::new invariant")
+            .clone()
+    }
+
+    fn iter_inputs(&self) -> impl Iterator<Item = Input> {
+        self.input_index.iter().map(|set| set.key().clone())
+    }
+
+    pub(in crate::envs) fn stream(
+        self: Arc<Self>,
+        vkconn: Arc<Mutex<cache::Connection>>,
+        trains: TrainSet<Train>,
+    ) -> impl stream::Stream<
+        Item = Correlated<
+            Input,
+            Result<core_client::pathfinding::PathfindingCoreResult, core_client::Error>,
+        >,
+    > {
+        use crate::TaskStreamExt as _;
+
+        let requests = trains
+            .iter()
+            .map(|train| {
+                let input = self
+                    .pathfinding_inputs
+                    .train_input(train)
+                    .expect("train map should have been built by now");
+                let request = build_request(&self.core_env, &input);
+                Correlated::new(input, request)
+            })
+            .collect_vec();
+
+        stream::iter(requests).run(vkconn, self.core_env.client.clone())
+    }
+}
+
+fn build_request(
+    core_env: &CoreEnv,
+    Input(consist, constraints): &Input,
+) -> core_client::pathfinding::PathfindingRequest {
+    core_client::pathfinding::PathfindingRequest {
+        infra: core_env.infra_id as i64,
+        expected_version: core_env.infra_version,
+        path_items: constraints
+            .path_items
+            .iter()
+            .map(|PathWaypointAlternatives(track_alternatives)| {
+                track_alternatives.clone().into_iter().collect()
+            })
+            .collect(),
+        rolling_stock_loading_gauge: consist.loading_gauge,
+        rolling_stock_is_thermal: consist.thermal,
+        rolling_stock_supported_electrifications: consist.supported_electrifications.clone(),
+        rolling_stock_supported_signaling_systems: consist.supported_signaling_systems.clone(),
+        rolling_stock_maximum_speed: consist.maximum_speed,
+        rolling_stock_length: consist.length,
+        speed_limit_tag: consist.speed_limit_tag.clone(),
     }
 }
 
@@ -365,16 +391,14 @@ impl<Train> PathfindingRun<Train>
 where
     Train: Clone + Hash + Eq + Send + Sync + 'static,
 {
-    fn new(inputs: Arc<PathfindingEnvInputs<Train>>) -> Self {
+    fn new(runner: &Runner<Train>) -> Self {
         let paths = DashMap::from_iter(
-            inputs
-                .trains
-                .keys()
-                .cloned()
+            runner
+                .iter_inputs()
                 .zip(std::iter::repeat_with(|| Poll::Pending)),
         );
         Self {
-            inputs,
+            inputs: runner.pathfinding_inputs.clone(),
             paths: Arc::new(paths),
         }
     }
@@ -450,7 +474,7 @@ mod tests {
     impl PathfindingEnv<usize> {
         fn key(&self, id: usize) -> String {
             let input = self.inputs.train_input(&id).unwrap();
-            let request = Self::build_request(&self.core_env, &input);
+            let request = build_request(&self.core_env, &input);
             use crate::Task as _;
             request.key("")
         }

--- a/editoast/core_task/src/envs/pathfinding.rs
+++ b/editoast/core_task/src/envs/pathfinding.rs
@@ -224,7 +224,7 @@ where
             .keys()
             .collect::<TrainSet<_>>()
             .intersection(&self.constraints.keys().collect())
-            .cloned()
+            .copied()
             .cloned() // not an error, it's an &&Train originally
             .collect()
     }

--- a/editoast/core_task/src/envs/pathfinding.rs
+++ b/editoast/core_task/src/envs/pathfinding.rs
@@ -49,10 +49,6 @@ where
         }
     }
 
-    pub(crate) fn decompose(self) -> (CoreEnv, Arc<PathfindingEnvInputs<Train>>) {
-        (self.core_env, Arc::new(self.inputs))
-    }
-
     /// Computes paths or fetches them from cache asynchronously
     ///
     /// Returns a [PathfindingRun] containing the calculated paths (or errors)
@@ -262,15 +258,11 @@ impl<Train> Runner<Train>
 where
     Train: Clone + Hash + Eq + Send + Sync + 'static,
 {
-    pub(in crate::envs) fn new(env: PathfindingEnv<Train>) -> Self {
-        let (core_env, pathfinding_inputs) = env.decompose();
+    pub(in crate::envs) fn new(PathfindingEnv { core_env, inputs }: PathfindingEnv<Train>) -> Self {
         let input_index = DashMap::<Input, TrainSet<Train>>::new();
-        for train in pathfinding_inputs.all_trains() {
-            let consist = pathfinding_inputs
-                .consists
-                .get(&train)
-                .expect("all_trains invariant");
-            let constraints = pathfinding_inputs
+        for train in inputs.all_trains() {
+            let consist = inputs.consists.get(&train).expect("all_trains invariant");
+            let constraints = inputs
                 .constraints
                 .get(&train)
                 .expect("all_trains invariant");
@@ -279,7 +271,7 @@ where
         }
         Self {
             core_env: core_env.clone(),
-            pathfinding_inputs,
+            pathfinding_inputs: Arc::new(inputs),
             input_index,
         }
     }

--- a/editoast/core_task/src/envs/pathfinding.rs
+++ b/editoast/core_task/src/envs/pathfinding.rs
@@ -61,14 +61,13 @@ where
     pub fn run(
         self,
         vkconn: Arc<Mutex<cache::Connection>>,
-        trains: TrainSet<Train>,
         ready_trains_tx: Option<futures::channel::mpsc::UnboundedSender<TrainSet<Train>>>,
     ) -> PathfindingRun<Train> {
         use stream::StreamExt as _;
         let runner = Arc::new(Runner::new(self));
         let run = PathfindingRun::new(&runner);
         let paths = run.paths.clone();
-        tokio::spawn(runner.clone().stream(vkconn, trains).fold(
+        tokio::spawn(runner.clone().stream(vkconn).fold(
             (paths, runner, ready_trains_tx),
             async |(paths, runner, ready_trains_tx),
                    Correlated {
@@ -95,7 +94,6 @@ where
     pub fn into_stream(
         self,
         vkconn: Arc<Mutex<cache::Connection>>,
-        trains: TrainSet<Train>,
     ) -> impl stream::Stream<
         Item = Correlated<
             TrainSet<Train>,
@@ -104,7 +102,7 @@ where
     > {
         use stream::StreamExt as _;
         let runner = Arc::new(Runner::new(self));
-        runner.clone().stream(vkconn, trains).map(
+        runner.clone().stream(vkconn).map(
             move |Correlated {
                       correlation_key: input,
                       data: path,
@@ -113,10 +111,6 @@ where
                 Correlated::new(trains, path)
             },
         )
-    }
-
-    pub fn all_trains(&self) -> TrainSet<Train> {
-        self.inputs.all_trains()
     }
 }
 
@@ -226,15 +220,13 @@ impl<Train> PathfindingEnvInputs<Train>
 where
     Train: Clone + Hash + Eq + Send + Sync + 'static,
 {
-    /// Returns all trains in the environment for which all needed information is configured
-    pub fn all_trains(&self) -> TrainSet<Train> {
-        self.consists
-            .keys()
-            .collect::<TrainSet<_>>()
-            .intersection(&self.constraints.keys().collect())
-            .copied()
-            .cloned() // not an error, it's an &&Train originally
-            .collect()
+    fn iter(&self) -> impl Iterator<Item = Correlated<Train, Input>> {
+        self.consists.keys().map(|train| {
+            let pf_key = self
+                .train_input(train)
+                .expect("PathfindingEnv::extend invariant");
+            Correlated::new(train.clone(), pf_key)
+        })
     }
 
     pub(in crate::envs) fn train_input(&self, train: &Train) -> Option<Input> {
@@ -268,13 +260,11 @@ where
 {
     pub(in crate::envs) fn new(PathfindingEnv { core_env, inputs }: PathfindingEnv<Train>) -> Self {
         let input_index = DashMap::<Input, TrainSet<Train>>::new();
-        for train in inputs.all_trains() {
-            let consist = inputs.consists.get(&train).expect("all_trains invariant");
-            let constraints = inputs
-                .constraints
-                .get(&train)
-                .expect("all_trains invariant");
-            let input = Input(consist.clone(), constraints.clone());
+        for Correlated {
+            correlation_key: train,
+            data: input,
+        } in inputs.iter()
+        {
             input_index.entry(input).or_default().insert(train);
         }
         Self {
@@ -298,7 +288,6 @@ where
     pub(in crate::envs) fn stream(
         self: Arc<Self>,
         vkconn: Arc<Mutex<cache::Connection>>,
-        trains: TrainSet<Train>,
     ) -> impl stream::Stream<
         Item = Correlated<
             Input,
@@ -307,16 +296,18 @@ where
     > {
         use crate::TaskStreamExt as _;
 
-        let requests = trains
+        let requests = self
+            .pathfinding_inputs
             .iter()
-            .map(|train| {
-                let input = self
-                    .pathfinding_inputs
-                    .train_input(train)
-                    .expect("train map should have been built by now");
-                let request = build_request(&self.core_env, &input);
-                Correlated::new(input, request)
-            })
+            .map(
+                |Correlated {
+                     correlation_key: _,
+                     data: input,
+                 }| {
+                    let request = build_request(&self.core_env, &input);
+                    Correlated::new(input, request)
+                },
+            )
             .collect_vec();
 
         stream::iter(requests).run(vkconn, self.core_env.client.clone())
@@ -516,12 +507,9 @@ mod tests {
             "",
         );
 
-        let all_trains = pfenv.all_trains();
-        assert_eq!(all_trains, TrainSet::from([1, 2]));
         let (tx, rx) = futures::channel::mpsc::unbounded();
         let pfrun = pfenv.run(
             Arc::new(Mutex::new(vk.get_connection().await.unwrap())),
-            all_trains,
             Some(tx),
         );
 

--- a/editoast/core_task/src/envs/pathfinding.rs
+++ b/editoast/core_task/src/envs/pathfinding.rs
@@ -75,7 +75,9 @@ where
                        data,
                    }| {
                 if let Some(tx) = ready_trains_tx.as_ref() {
-                    let trains = runner.input_train_set(&input).clone();
+                    let trains = runner
+                        .input_train_set(&input)
+                        .expect("input provided by the Runner should be valid");
                     tx.unbounded_send(trains).ok();
                 }
                 paths.insert(input, Poll::Ready(data.map(Arc::new)));
@@ -107,7 +109,9 @@ where
                       correlation_key: input,
                       data: path,
                   }| {
-                let trains = runner.input_train_set(&input).clone();
+                let trains = runner
+                    .input_train_set(&input)
+                    .expect("input provided by the Runner should be valid");
                 Correlated::new(trains, path)
             },
         )
@@ -274,11 +278,8 @@ where
         }
     }
 
-    pub(in crate::envs) fn input_train_set(&self, input: &Input) -> TrainSet<Train> {
-        self.input_index
-            .get(input)
-            .expect("Runner::new invariant")
-            .clone()
+    pub(in crate::envs) fn input_train_set(&self, input: &Input) -> Option<TrainSet<Train>> {
+        self.input_index.get(input).as_deref().cloned()
     }
 
     fn iter_inputs(&self) -> impl Iterator<Item = Input> {

--- a/editoast/core_task/src/lib.rs
+++ b/editoast/core_task/src/lib.rs
@@ -181,11 +181,11 @@ where
          *                      [task]
          *                      not_a_task
          *                      (comment)
-         *                                                                                            compute ------------> [write_cache]
-         *                                                +-------> [chunk_processing] ------+
-         *                                                |                                  |           ^                        |
-         *                                                |                                  |           |(cache miss)            v
-         *                                                |                                  |
+         *                                                                                            compute ---------+--> [write_cache]
+         *                                                +-------> [chunk_processing] ------+           ^             |
+         *                                                |                                  |           |             +----------+
+         *                                                |                                  |           | (cache miss)           |
+         *                                                |                                  |           |                        v
          * requests stream ----------> [cache_read] ------+-------> [chunk_processing] ------+----> [aggregation]---------> result_stream
          * (self, function                                |                                  |                   (cache hit)
          *     input)                                     |                                  |

--- a/editoast/core_task/src/lib.rs
+++ b/editoast/core_task/src/lib.rs
@@ -114,6 +114,7 @@ pub trait Task: Sized + Send {
 }
 
 /// A named tuple for a value with a correlation key
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Correlated<CorrelationKey, T> {
     pub correlation_key: CorrelationKey,
     pub data: T,

--- a/editoast/core_task/src/lib.rs
+++ b/editoast/core_task/src/lib.rs
@@ -10,6 +10,7 @@ pub use envs::core::CoreEnv;
 pub use envs::pathfinding::PathfindingConsist;
 pub use envs::pathfinding::PathfindingConstraints;
 pub use envs::pathfinding::PathfindingEnv;
+pub use envs::pathfinding::PathfindingTrain;
 
 use futures::stream;
 use itertools::Itertools as _;


### PR DESCRIPTION
Last preparatory step before the `SimulationEnv`. I already have it working locally with this PR content, I just need to make the new env look nice. 

<details open id="prdesc">

- df2697da3 *editoast: core_task: fix ascii art*
- 3d5ccb282 *editoast: core_task: extract running logic in `pahfinding::Runner`*
    ```md
    Permits a single construction of the train set index and allows better
    compostion in running context of parent environments. Also decorrelates
    input storage and index storage. This is particularily useful since only
    the former outlives the running step.
    ```
- 506d1fbc4 *editoast: core_task: reorganize `env::pathfinding`*
    ```md
    Organizes declarations order.
    ```
- 72a397575 *editoast: core_task: inline `PathfindingEnv::decompose`*
    ```md
    Destructuration is more straightforward.
    ```
- f813e2377 *editoast: core_task: derive common traits for `Correlated`*
- 6c7272b23 *editoast: core_task: use `.copied` instead of `.cloned` for references*
- 322e219cc *editoast: core_task: provide all `PathfindingEnv` at once*
    ```md
    Ensures we cannot have a train with inputs only partially provided.
    ```
- 04a352c93 *editoast: core_task: always process all trains*
    ```md
    Simplifies the process, avoids failure cases and removes a few
    assertions.
    ```
- 1174adf8f *editoast: core_task: push assertions higher in the call stack*
    ```md
    More context closer to the expect point.
    ```

</details>