### PR TITLE
editoast: move `OccurrenceId` and `TrainId` to views

### DIFF
--- a/editoast/src/models/paced_train.rs
+++ b/editoast/src/models/paced_train.rs
@@ -1,6 +1,3 @@
-use std::fmt::Display;
-use std::str::FromStr;
-
 use chrono::DateTime;
 use chrono::Duration as ChronoDuration;
 use chrono::Utc;
@@ -23,9 +20,6 @@ use schemas::train_schedule::PowerRestrictionItem;
 use schemas::train_schedule::ScheduleItem;
 use schemas::train_schedule::TrainSchedule;
 use schemas::train_schedule::TrainScheduleOptions;
-use serde::Deserialize;
-use serde::Serialize;
-use utoipa::ToSchema;
 
 #[derive(Debug, Clone, Model)]
 #[cfg_attr(test, derive(Default, PartialEq))]
@@ -64,6 +58,19 @@ pub struct PacedTrain {
     pub sub_category: Option<String>,
     #[model(json)]
     pub exceptions: Vec<PacedTrainException>,
+}
+
+#[derive(Debug, Clone)]
+pub enum OccurrenceId {
+    BaseOccurrence { index: u64 },
+    ModifiedException { index: u64, exception_key: String },
+    CreatedException { exception_key: String },
+}
+
+#[derive(Debug, Clone)]
+pub struct Occurrence {
+    pub id: OccurrenceId,
+    pub train_schedule: TrainSchedule,
 }
 
 impl PacedTrain {
@@ -182,7 +189,7 @@ impl PacedTrain {
     /// and appends any `Created` exceptions as new trains.
     ///
     /// The result is sorted by `start_time` to reflect the chronological order of the trains.
-    pub fn iter_occurrences(&self) -> impl Iterator<Item = (OccurrenceId, TrainSchedule)> {
+    pub fn iter_occurrences(&self) -> impl Iterator<Item = Occurrence> {
         let mut base_occurrences = self.get_base_occurrences();
 
         let modified_exceptions = self
@@ -218,6 +225,7 @@ impl PacedTrain {
             .into_iter()
             .chain(self.get_created_occurrences_exceptions())
             .sorted_by_key(|(_, ts)| ts.start_time)
+            .map(|(id, train_schedule)| Occurrence { id, train_schedule })
     }
 
     /// Returns the number of base train occurrences within the pacing window.
@@ -295,97 +303,6 @@ impl From<PacedTrain> for paced_train::PacedTrain {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
-#[serde(tag = "type")]
-pub enum OccurrenceId {
-    BaseOccurrence { index: u64 },
-    ModifiedException { index: u64, exception_key: String },
-    CreatedException { exception_key: String },
-}
-
-#[derive(Debug, Clone, PartialEq)]
-/// This ID is used to identify paced train occurrences and exceptions when sending them to the core API for conflict detection.
-pub enum TrainId {
-    TrainSchedule(i64),
-    PacedTrain {
-        paced_train_id: i64,
-        occurrence_id: OccurrenceId,
-    },
-}
-
-impl Display for TrainId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::TrainSchedule(id) => write!(f, "{id}"),
-            Self::PacedTrain {
-                paced_train_id,
-                occurrence_id: OccurrenceId::BaseOccurrence { index },
-            } => write!(f, "{paced_train_id}#{index}"),
-            Self::PacedTrain {
-                paced_train_id,
-                occurrence_id: OccurrenceId::CreatedException { exception_key },
-            } => write!(f, "{paced_train_id}@{exception_key}"),
-            Self::PacedTrain {
-                paced_train_id,
-                occurrence_id:
-                    OccurrenceId::ModifiedException {
-                        exception_key,
-                        index,
-                    },
-            } => write!(f, "{paced_train_id}@{exception_key}#{index}"),
-        }
-    }
-}
-
-impl FromStr for TrainId {
-    type Err = &'static str;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        // Is it a paced train exception?
-        if let Some((train_id_str, exception_str)) = s.split_once('@') {
-            let paced_train_id = train_id_str
-                .parse::<i64>()
-                .map_err(|_| "Invalid train id")?;
-            // Is it a modified paced train exception?
-            if let Some((exception_key, index_str)) = exception_str.split_once('#') {
-                let index = index_str
-                    .parse::<u64>()
-                    .map_err(|_| "Invalid exception index")?;
-                Ok(TrainId::PacedTrain {
-                    paced_train_id,
-                    occurrence_id: OccurrenceId::ModifiedException {
-                        exception_key: exception_key.to_string(),
-                        index,
-                    },
-                })
-            } else {
-                let exception_key = exception_str.to_string();
-                Ok(TrainId::PacedTrain {
-                    paced_train_id,
-                    occurrence_id: OccurrenceId::CreatedException { exception_key },
-                })
-            }
-        } else {
-            // Is it a base paced train exception?
-            if let Some((train_id_str, index_str)) = s.split_once('#') {
-                let paced_train_id = train_id_str
-                    .parse::<i64>()
-                    .map_err(|_| "Invalid train id")?;
-                let index = index_str
-                    .parse::<u64>()
-                    .map_err(|_| "Invalid occurrence index")?;
-                Ok(TrainId::PacedTrain {
-                    paced_train_id,
-                    occurrence_id: OccurrenceId::BaseOccurrence { index },
-                })
-            } else {
-                let train_id = s.parse::<i64>().map_err(|_| "Invalid train id")?;
-                Ok(TrainId::TrainSchedule(train_id))
-            }
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
@@ -396,7 +313,6 @@ mod tests {
     use crate::models::fixtures::create_timetable;
     use crate::models::fixtures::simple_paced_train_changeset;
     use crate::models::fixtures::simple_sub_category;
-    use crate::models::paced_train::OccurrenceId;
     use chrono::DateTime;
     use chrono::Utc;
     use database::DbConnectionPoolV2;
@@ -407,7 +323,6 @@ mod tests {
     use rstest::rstest;
     use schemas::paced_train::PacedTrainException;
     use schemas::paced_train::RollingStockCategoryChangeGroup;
-    use schemas::paced_train::StartTimeChangeGroup;
     use schemas::train_schedule::Comfort;
     use schemas::train_schedule::Distribution;
     use schemas::train_schedule::Margins;
@@ -544,119 +459,6 @@ mod tests {
             create_modified_exception_with_change_groups("key_1", 0),
         ]);
         assert_eq!(paced_train.num_base_occurrences(), 4);
-    }
-
-    #[tokio::test]
-    async fn iter_occurrences_with_exceptions() {
-        let exception_1 = create_modified_exception_with_change_groups("key_1", 1);
-        let exception_2 = create_created_exception_with_change_groups("key_2");
-        let mut exception_3 = create_modified_exception_with_change_groups("key_3", 0);
-        exception_3.disabled = true;
-
-        let paced_train =
-            create_paced_train(vec![exception_1.clone(), exception_2.clone(), exception_3]);
-        let occurrences: Vec<(OccurrenceId, schemas::TrainSchedule)> =
-            paced_train.iter_occurrences().collect();
-
-        assert_eq!(occurrences.len(), 4);
-
-        let start_times: Vec<DateTime<Utc>> =
-            occurrences.iter().map(|(_, o)| o.start_time).collect();
-        let train_names: Vec<String> = occurrences
-            .iter()
-            .map(|(_, o)| o.train_name.clone())
-            .collect();
-        let types: Vec<OccurrenceId> = occurrences.iter().map(|(t, _)| t.clone()).collect();
-
-        assert_eq!(
-            start_times,
-            vec![
-                DateTime::<Utc>::from_str("2025-05-15T14:30:00+02:00").unwrap(),
-                DateTime::<Utc>::from_str("2025-05-15T15:00:00+02:00").unwrap(),
-                DateTime::<Utc>::from_str("2025-05-15T15:10:00+02:00").unwrap(),
-                DateTime::<Utc>::from_str("2025-05-15T15:30:00+02:00").unwrap(),
-            ]
-        );
-
-        assert_eq!(
-            train_names,
-            vec![
-                "modified_exception_train_name".to_string(),
-                "train_name".to_string(),
-                "created_exception_train_name".to_string(),
-                "train_name".to_string(),
-            ]
-        );
-
-        assert_eq!(
-            types,
-            vec![
-                OccurrenceId::ModifiedException {
-                    index: 1,
-                    exception_key: "key_1".to_string()
-                },
-                OccurrenceId::BaseOccurrence { index: 2 },
-                OccurrenceId::CreatedException {
-                    exception_key: "key_2".to_string()
-                },
-                OccurrenceId::BaseOccurrence { index: 3 },
-            ]
-        );
-    }
-
-    #[tokio::test]
-    async fn iter_occurrences_with_modified_start_time_exception() {
-        let mut exception_1 = create_modified_exception_with_change_groups("key_1", 1);
-        exception_1.start_time = Some(StartTimeChangeGroup {
-            value: DateTime::<Utc>::from_str("2025-05-15T14:31:00+02:00").unwrap(),
-        });
-
-        let paced_train = create_paced_train(vec![exception_1.clone()]);
-        let occurrences: Vec<(OccurrenceId, schemas::TrainSchedule)> =
-            paced_train.iter_occurrences().collect();
-
-        assert_eq!(occurrences.len(), 4);
-
-        let start_times: Vec<DateTime<Utc>> =
-            occurrences.iter().map(|(_, o)| o.start_time).collect();
-        let train_names: Vec<String> = occurrences
-            .iter()
-            .map(|(_, o)| o.train_name.clone())
-            .collect();
-        let types: Vec<OccurrenceId> = occurrences.iter().map(|(t, _)| t.clone()).collect();
-
-        assert_eq!(
-            start_times,
-            vec![
-                DateTime::<Utc>::from_str("2025-05-15T14:00:00+02:00").unwrap(),
-                DateTime::<Utc>::from_str("2025-05-15T14:31:00+02:00").unwrap(),
-                DateTime::<Utc>::from_str("2025-05-15T15:00:00+02:00").unwrap(),
-                DateTime::<Utc>::from_str("2025-05-15T15:30:00+02:00").unwrap(),
-            ]
-        );
-
-        assert_eq!(
-            train_names,
-            vec![
-                "train_name".to_string(),
-                "modified_exception_train_name".to_string(),
-                "train_name".to_string(),
-                "train_name".to_string(),
-            ]
-        );
-
-        assert_eq!(
-            types,
-            vec![
-                OccurrenceId::BaseOccurrence { index: 0 },
-                OccurrenceId::ModifiedException {
-                    index: 1,
-                    exception_key: "key_1".to_string()
-                },
-                OccurrenceId::BaseOccurrence { index: 2 },
-                OccurrenceId::BaseOccurrence { index: 3 },
-            ]
-        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -6,6 +6,8 @@ pub mod stdcm;
 mod track_occupancy;
 pub mod train_schedule;
 
+use std::fmt::Display;
+use std::str::FromStr;
 use std::sync::Arc;
 
 use authz;
@@ -64,9 +66,8 @@ use crate::AppState;
 use crate::error::Result;
 use crate::models;
 use crate::models::Infra;
-use crate::models::paced_train::OccurrenceId;
+use crate::models::paced_train::Occurrence;
 use crate::models::paced_train::PacedTrainChangeset;
-use crate::models::paced_train::TrainId;
 use crate::models::timetable::Timetable;
 use crate::models::timetable::TimetableWithTrains;
 use crate::models::train_schedule::TrainScheduleChangeset;
@@ -74,6 +75,117 @@ use crate::views::AuthenticationExt;
 use crate::views::AuthorizationError;
 use crate::views::timetable::simulation::SimulationResponseSuccess;
 use editoast_models::prelude::*;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
+#[serde(tag = "type")]
+pub(in crate::views::timetable) enum OccurrenceId {
+    BaseOccurrence { index: u64 },
+    ModifiedException { index: u64, exception_key: String },
+    CreatedException { exception_key: String },
+}
+
+impl From<models::paced_train::OccurrenceId> for OccurrenceId {
+    fn from(occurrence_id: models::paced_train::OccurrenceId) -> Self {
+        match occurrence_id {
+            models::paced_train::OccurrenceId::BaseOccurrence { index } => {
+                Self::BaseOccurrence { index }
+            }
+            models::paced_train::OccurrenceId::ModifiedException {
+                index,
+                exception_key,
+            } => Self::ModifiedException {
+                index,
+                exception_key,
+            },
+            models::paced_train::OccurrenceId::CreatedException { exception_key } => {
+                Self::CreatedException { exception_key }
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+/// This ID is used to identify paced train occurrences and exceptions
+pub(in crate::views::timetable) enum TrainId {
+    TrainSchedule(i64),
+    PacedTrain {
+        paced_train_id: i64,
+        occurrence_id: OccurrenceId,
+    },
+}
+
+impl Display for TrainId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::TrainSchedule(id) => write!(f, "{id}"),
+            Self::PacedTrain {
+                paced_train_id,
+                occurrence_id: OccurrenceId::BaseOccurrence { index },
+            } => write!(f, "{paced_train_id}#{index}"),
+            Self::PacedTrain {
+                paced_train_id,
+                occurrence_id: OccurrenceId::CreatedException { exception_key },
+            } => write!(f, "{paced_train_id}@{exception_key}"),
+            Self::PacedTrain {
+                paced_train_id,
+                occurrence_id:
+                    OccurrenceId::ModifiedException {
+                        exception_key,
+                        index,
+                    },
+            } => write!(f, "{paced_train_id}@{exception_key}#{index}"),
+        }
+    }
+}
+
+impl FromStr for TrainId {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Is it a paced train exception?
+        if let Some((train_id_str, exception_str)) = s.split_once('@') {
+            let paced_train_id = train_id_str
+                .parse::<i64>()
+                .map_err(|_| "Invalid train id")?;
+            // Is it a modified paced train exception?
+            if let Some((exception_key, index_str)) = exception_str.split_once('#') {
+                let index = index_str
+                    .parse::<u64>()
+                    .map_err(|_| "Invalid exception index")?;
+                Ok(TrainId::PacedTrain {
+                    paced_train_id,
+                    occurrence_id: OccurrenceId::ModifiedException {
+                        exception_key: exception_key.to_string(),
+                        index,
+                    },
+                })
+            } else {
+                let exception_key = exception_str.to_string();
+                Ok(TrainId::PacedTrain {
+                    paced_train_id,
+                    occurrence_id: OccurrenceId::CreatedException { exception_key },
+                })
+            }
+        } else {
+            // Is it a base paced train exception?
+            if let Some((train_id_str, index_str)) = s.split_once('#') {
+                let paced_train_id = train_id_str
+                    .parse::<i64>()
+                    .map_err(|_| "Invalid train id")?;
+                let index = index_str
+                    .parse::<u64>()
+                    .map_err(|_| "Invalid occurrence index")?;
+                Ok(TrainId::PacedTrain {
+                    paced_train_id,
+                    occurrence_id: OccurrenceId::BaseOccurrence { index },
+                })
+            } else {
+                let train_id = s.parse::<i64>().map_err(|_| "Invalid train id")?;
+                Ok(TrainId::TrainSchedule(train_id))
+            }
+        }
+    }
+}
 
 #[derive(Debug, Error, EditoastError, derive_more::From)]
 #[editoast_error(base_id = "timetable")]
@@ -525,11 +637,11 @@ pub(in crate::views) async fn conflicts(
         .iter()
         .flat_map(|pt| {
             pt.iter_occurrences()
-                .map(|(occurrence_id, train_schedule)| {
+                .map(|Occurrence { id, train_schedule }| {
                     (
                         TrainId::PacedTrain {
                             paced_train_id: pt.id,
-                            occurrence_id,
+                            occurrence_id: id.into(),
                         },
                         train_schedule,
                     )
@@ -728,11 +840,11 @@ pub(in crate::views) async fn requirements(
             Either::Left(ts) => vec![(TrainId::TrainSchedule(ts.id), ts.into())],
             Either::Right(pt) => pt
                 .iter_occurrences()
-                .map(|(occurrence_id, train_schedule)| {
+                .map(|Occurrence { id, train_schedule }| {
                     (
                         TrainId::PacedTrain {
                             paced_train_id: pt.id,
-                            occurrence_id,
+                            occurrence_id: id.into(),
                         },
                         train_schedule,
                     )

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -635,12 +635,13 @@ pub(in crate::views) async fn conflicts(
     // Flatten paced trains occurrences
     let (paced_train_ids, occurrence_trains): (Vec<_>, Vec<_>) = paced_trains
         .iter()
-        .flat_map(|pt| {
-            pt.iter_occurrences()
+        .flat_map(|paced_train| {
+            paced_train
+                .iter_occurrences()
                 .map(|Occurrence { id, train_schedule }| {
                     (
                         TrainId::PacedTrain {
-                            paced_train_id: pt.id,
+                            paced_train_id: paced_train.id,
                             occurrence_id: id.into(),
                         },
                         train_schedule,
@@ -837,13 +838,16 @@ pub(in crate::views) async fn requirements(
     .await?;
     let (train_ids, trains): (Vec<_>, Vec<_>) = trains
         .flat_map(|train| match train {
-            Either::Left(ts) => vec![(TrainId::TrainSchedule(ts.id), ts.into())],
-            Either::Right(pt) => pt
+            Either::Left(train_schedule) => vec![(
+                TrainId::TrainSchedule(train_schedule.id),
+                train_schedule.into(),
+            )],
+            Either::Right(paced_train) => paced_train
                 .iter_occurrences()
                 .map(|Occurrence { id, train_schedule }| {
                     (
                         TrainId::PacedTrain {
-                            paced_train_id: pt.id,
+                            paced_train_id: paced_train.id,
                             occurrence_id: id.into(),
                         },
                         train_schedule,

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -32,7 +32,7 @@ use crate::error::Result;
 use crate::models;
 use crate::models::Infra;
 use crate::models::RollingStock;
-use crate::models::paced_train::OccurrenceId;
+use crate::models::paced_train::Occurrence;
 use crate::models::paced_train::PacedTrainChangeset;
 use crate::views::AuthorizationError;
 use crate::views::infra::InfraIdQueryParam;
@@ -45,6 +45,7 @@ use crate::views::projection::ProjectPathOperationalPointForm;
 use crate::views::projection::SpaceTimeCurve;
 use crate::views::projection::compute_projected_train_path_op;
 use crate::views::projection::compute_projected_train_paths;
+use crate::views::timetable::OccurrenceId;
 use crate::views::timetable::PhysicsConsistParameters;
 use crate::views::timetable::occupancy_blocks::OccupancyBlockForm;
 use crate::views::timetable::occupancy_blocks::OccupancyBlocks;
@@ -1225,11 +1226,12 @@ pub(in crate::views) async fn track_occupancy(
     let train_occurrences = paced_trains
         .iter()
         .flat_map(|paced_train| {
-            paced_train
-                .iter_occurrences()
-                .map(|(occurrence_id, train_schedule)| {
-                    (paced_train.id, occurrence_id, train_schedule)
-                })
+            paced_train.iter_occurrences().map(
+                |Occurrence {
+                     id: occurrence_id,
+                     train_schedule,
+                 }| { (paced_train.id, occurrence_id, train_schedule) },
+            )
         })
         .collect_vec();
 
@@ -1285,7 +1287,7 @@ pub(in crate::views) async fn track_occupancy(
                             track_section,
                             TrackOccupancy {
                                 paced_train_id,
-                                occurrence_id: occurrence_id.clone(),
+                                occurrence_id: occurrence_id.clone().into(),
                                 time_window,
                             },
                         )
@@ -1311,11 +1313,13 @@ pub(in crate::views) async fn track_occupancy(
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::str::FromStr;
 
     use axum::http::StatusCode;
     use chrono::DateTime;
     use chrono::Duration;
     use chrono::TimeDelta;
+    use chrono::Utc;
     use core_client::mocking::MockingClient;
     use core_client::pathfinding::PathfindingInputError;
     use core_client::pathfinding::PathfindingResultSuccess;
@@ -1326,6 +1330,7 @@ mod tests {
     use core_client::simulation::ReportTrain;
     use core_client::simulation::SpeedLimitProperties;
     use database::DbConnectionPoolV2;
+    use editoast_models::Tags;
     use editoast_models::prelude::*;
     use editoast_models::rolling_stock::TrainMainCategory;
     use pretty_assertions::assert_eq;
@@ -1339,18 +1344,23 @@ mod tests {
     use schemas::paced_train::PacedTrain;
     use schemas::paced_train::PacedTrainException;
     use schemas::paced_train::RollingStockChangeGroup;
+    use schemas::paced_train::StartTimeChangeGroup;
     use schemas::paced_train::TrainNameChangeGroup;
     use schemas::rolling_stock::TrainCategory;
     use schemas::train_schedule::Comfort;
+    use schemas::train_schedule::Distribution;
+    use schemas::train_schedule::Margins;
     use schemas::train_schedule::PathItem;
     use schemas::train_schedule::ScheduleItem;
     use schemas::train_schedule::TrainSchedule;
+    use schemas::train_schedule::TrainScheduleOptions;
     use serde_json::json;
 
     use crate::error::InternalError;
     use crate::models;
     use crate::models::fixtures::create_created_exception_with_change_groups;
     use crate::models::fixtures::create_fast_rolling_stock;
+    use crate::models::fixtures::create_modified_exception_with_change_groups;
     use crate::models::fixtures::create_paced_train_with_exceptions;
     use crate::models::fixtures::create_simple_paced_train;
     use crate::models::fixtures::create_small_infra;
@@ -1358,6 +1368,7 @@ mod tests {
     use crate::models::fixtures::simple_paced_train_base;
     use crate::models::fixtures::simple_paced_train_changeset;
     use crate::models::fixtures::simple_sub_category;
+    use crate::models::paced_train::Occurrence;
     use crate::models::paced_train::PacedTrainChangeset;
     use crate::views::path::pathfinding::PathfindingFailure;
     use crate::views::path::pathfinding::PathfindingResult;
@@ -1365,6 +1376,7 @@ mod tests {
     use crate::views::test_app::TestAppBuilder;
     use crate::views::test_app::TestResponse;
     use crate::views::tests::mocked_core_pathfinding_sim_and_proj;
+    use crate::views::timetable::OccurrenceId;
     use crate::views::timetable::paced_train::OccupancyBlocksPacedTrainResult;
     use crate::views::timetable::paced_train::PacedTrainResponse;
     use crate::views::timetable::paced_train::PacedTrainSummaryResponse;
@@ -2356,5 +2368,186 @@ mod tests {
             response.await.assert_status(StatusCode::OK).json_into();
 
         assert!(track_occupancies.is_empty());
+    }
+
+    fn create_paced_train(exceptions: Vec<PacedTrainException>) -> models::PacedTrain {
+        models::PacedTrain {
+            id: 1,
+            timetable_id: 1,
+            train_name: "train_name".to_string(),
+            rolling_stock_name: "R2D2".to_string(),
+            comfort: Comfort::Standard,
+            initial_speed: 25.0,
+            main_category: Some(TrainMainCategory(
+                schemas::rolling_stock::TrainMainCategory::HighSpeedTrain,
+            )),
+            constraint_distribution: Distribution::Standard,
+            labels: Tags::new(vec![]),
+            margins: Margins {
+                boundaries: vec![Default::default()],
+                ..Default::default()
+            },
+            path: vec![],
+            power_restrictions: vec![],
+            schedule: vec![],
+            speed_limit_tag: None,
+            options: TrainScheduleOptions::default(),
+            start_time: DateTime::<Utc>::from_str("2025-05-15T14:00:00+02:00").unwrap(),
+            time_window: chrono::Duration::try_hours(2).unwrap(),
+            interval: chrono::Duration::try_minutes(30).unwrap(),
+            sub_category: None,
+            exceptions,
+        }
+    }
+
+    #[tokio::test]
+    async fn iter_occurrences_with_exceptions() {
+        let exception_1 = create_modified_exception_with_change_groups("key_1", 1);
+        let exception_2 = create_created_exception_with_change_groups("key_2");
+        let mut exception_3 = create_modified_exception_with_change_groups("key_3", 0);
+        exception_3.disabled = true;
+
+        let paced_train =
+            create_paced_train(vec![exception_1.clone(), exception_2.clone(), exception_3]);
+        let occurrences: Vec<Occurrence> = paced_train.iter_occurrences().collect();
+
+        assert_eq!(occurrences.len(), 4);
+
+        let start_times: Vec<DateTime<Utc>> = occurrences
+            .iter()
+            .map(
+                |Occurrence {
+                     id: _,
+                     train_schedule,
+                 }| train_schedule.start_time,
+            )
+            .collect();
+        let train_names: Vec<String> = occurrences
+            .iter()
+            .map(
+                |Occurrence {
+                     id: _,
+                     train_schedule,
+                 }| train_schedule.train_name.clone(),
+            )
+            .collect();
+        let types: Vec<OccurrenceId> = occurrences
+            .iter()
+            .map(
+                |Occurrence {
+                     id,
+                     train_schedule: _,
+                 }| id.clone().into(),
+            )
+            .collect();
+
+        assert_eq!(
+            start_times,
+            vec![
+                DateTime::<Utc>::from_str("2025-05-15T14:30:00+02:00").unwrap(),
+                DateTime::<Utc>::from_str("2025-05-15T15:00:00+02:00").unwrap(),
+                DateTime::<Utc>::from_str("2025-05-15T15:10:00+02:00").unwrap(),
+                DateTime::<Utc>::from_str("2025-05-15T15:30:00+02:00").unwrap(),
+            ]
+        );
+
+        assert_eq!(
+            train_names,
+            vec![
+                "modified_exception_train_name".to_string(),
+                "train_name".to_string(),
+                "created_exception_train_name".to_string(),
+                "train_name".to_string(),
+            ]
+        );
+
+        assert_eq!(
+            types,
+            vec![
+                OccurrenceId::ModifiedException {
+                    index: 1,
+                    exception_key: "key_1".to_string()
+                },
+                OccurrenceId::BaseOccurrence { index: 2 },
+                OccurrenceId::CreatedException {
+                    exception_key: "key_2".to_string()
+                },
+                OccurrenceId::BaseOccurrence { index: 3 },
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn iter_occurrences_with_modified_start_time_exception() {
+        let mut exception_1 = create_modified_exception_with_change_groups("key_1", 1);
+        exception_1.start_time = Some(StartTimeChangeGroup {
+            value: DateTime::<Utc>::from_str("2025-05-15T14:31:00+02:00").unwrap(),
+        });
+
+        let paced_train = create_paced_train(vec![exception_1.clone()]);
+        let occurrences: Vec<Occurrence> = paced_train.iter_occurrences().collect();
+
+        assert_eq!(occurrences.len(), 4);
+
+        let start_times: Vec<DateTime<Utc>> = occurrences
+            .iter()
+            .map(
+                |Occurrence {
+                     id: _,
+                     train_schedule,
+                 }| train_schedule.start_time,
+            )
+            .collect();
+        let train_names: Vec<String> = occurrences
+            .iter()
+            .map(
+                |Occurrence {
+                     id: _,
+                     train_schedule,
+                 }| train_schedule.train_name.clone(),
+            )
+            .collect();
+        let types: Vec<OccurrenceId> = occurrences
+            .iter()
+            .map(
+                |Occurrence {
+                     id,
+                     train_schedule: _,
+                 }| id.clone().into(),
+            )
+            .collect();
+
+        assert_eq!(
+            start_times,
+            vec![
+                DateTime::<Utc>::from_str("2025-05-15T14:00:00+02:00").unwrap(),
+                DateTime::<Utc>::from_str("2025-05-15T14:31:00+02:00").unwrap(),
+                DateTime::<Utc>::from_str("2025-05-15T15:00:00+02:00").unwrap(),
+                DateTime::<Utc>::from_str("2025-05-15T15:30:00+02:00").unwrap(),
+            ]
+        );
+
+        assert_eq!(
+            train_names,
+            vec![
+                "train_name".to_string(),
+                "modified_exception_train_name".to_string(),
+                "train_name".to_string(),
+                "train_name".to_string(),
+            ]
+        );
+
+        assert_eq!(
+            types,
+            vec![
+                OccurrenceId::BaseOccurrence { index: 0 },
+                OccurrenceId::ModifiedException {
+                    index: 1,
+                    exception_key: "key_1".to_string()
+                },
+                OccurrenceId::BaseOccurrence { index: 2 },
+                OccurrenceId::BaseOccurrence { index: 3 },
+            ]
+        );
     }
 }


### PR DESCRIPTION
closes https://github.com/OpenRailAssociation/osrd/issues/13782

These types handle API representation of train occurrences, not database persistence, so they belong in the views layer.