### PR TITLE
core: add first guess to spacing resource binary search

### DIFF
--- a/core/kt-osrd-signaling/src/main/kotlin/fr/sncf/osrd/signaling/impl/SignalingSimulatorImpl.kt
+++ b/core/kt-osrd-signaling/src/main/kotlin/fr/sncf/osrd/signaling/impl/SignalingSimulatorImpl.kt
@@ -183,7 +183,7 @@ class SignalingSimulatorImpl(override val sigModuleManager: SigSystemManager) : 
             followingZoneState,
             followingSignalState,
             followingSignalSettings,
-            trainPath.getZones().first().value,
+            trainPath.getZoneRanges().first().value,
         )
     }
 

--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/Extensions.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/Extensions.kt
@@ -1,7 +1,5 @@
 package fr.sncf.osrd.utils
 
-import fr.sncf.osrd.utils.indexing.*
-
 /** Removes consecutive duplicated values from a list. Keeps duplicates that aren't consecutive. */
 fun <T> List<T>.withoutConsecutiveDuplicates(): List<T> {
     val res = mutableListOf<T>()
@@ -13,4 +11,12 @@ fun <T> List<T>.withoutConsecutiveDuplicates(): List<T> {
         }
     }
     return res
+}
+
+/**
+ * Similar to `list.drop(n)`, but avoids copying the whole list. Returns a Sequence instead of a
+ * list.
+ */
+fun <T> List<T>.dropSeq(count: Int): Sequence<T> {
+    return asSequence().drop(count)
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/conflicts/SpacingResourceGenerator.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/conflicts/SpacingResourceGenerator.kt
@@ -385,25 +385,33 @@ data class SpacingResourceGenerator(
         // on start+20 that rarely exceeds start+40.
         // We run a binary search on that range, and iterate one by one when the solution is above.
         var lowerBound = zoneRanges.indexOfFirst { it.pathBegin >= signalData.offset }
+        if (lowerBound < 0) return zoneRanges.last().pathEnd
         val initialUpperBound = min(lowerBound + 40, lastZoneIndex)
         var upperBound = initialUpperBound
 
-        // Main loop, binary search
-        while (true) {
-            if (lowerBound == upperBound) break
-            val probedZoneIndex = (upperBound + lowerBound) / 2
+        // Attempt at the given index, updating the min/max values depending on the result.
+        fun tryAt(index: Int) {
+            if (index !in lowerBound..<upperBound) return
             val required =
-                isZoneIndexRequiredForSignal(
-                    simulationData,
-                    probedZoneIndex,
-                    signalData.signal,
-                    trainState,
-                )!!
+                isZoneIndexRequiredForSignal(simulationData, index, signalData.signal, trainState)!!
             if (required) {
-                lowerBound = probedZoneIndex + 1
+                lowerBound = index + 1
             } else {
-                upperBound = probedZoneIndex
+                upperBound = index
             }
+        }
+
+        // Initial first guess based on block sizes. We never *need* that guess to be correct, but
+        // it skips the binary search when it is. Otherwise, it still updates the min/max bounds.
+        guessZoneIndex(signalData)?.let {
+            tryAt(it + 1)
+            tryAt(it)
+        }
+
+        // Main loop, binary search
+        while (lowerBound < upperBound) {
+            val probedZoneIndex = (upperBound + lowerBound) / 2
+            tryAt(probedZoneIndex)
         }
 
         // Handle the case where the result is higher than the initial upper bound
@@ -418,6 +426,17 @@ data class SpacingResourceGenerator(
         ) lowerBound++
         val firstNonRequiredZoneIndex = lowerBound
         return zoneRanges[firstNonRequiredZoneIndex - 1].pathEnd
+    }
+
+    /**
+     * Try to guess the index of the last required zone, based on block length and common signaling
+     * patterns. A correct guess skips the binary search.
+     */
+    private fun guessZoneIndex(signalData: PendingSignalData): Int? {
+        val firstBlockIndex = blockRanges.indexOfFirst { it.pathBegin >= signalData.offset }
+        if (firstBlockIndex < 0) return null
+        val initialGuess = blockRanges.getOrNull(firstBlockIndex + 1)?.pathEnd ?: return null
+        return zoneRanges.indexOfLast { it.pathEnd <= initialGuess }
     }
 
     /**

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/StepTracker.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/StepTracker.kt
@@ -7,6 +7,7 @@ import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.stdcm.STDCMStep
 import fr.sncf.osrd.utils.AppendOnlyLinkedList
 import fr.sncf.osrd.utils.appendOnlyLinkedListOf
+import fr.sncf.osrd.utils.dropSeq
 import fr.sncf.osrd.utils.units.Offset
 
 /**
@@ -62,7 +63,7 @@ class StepTracker(
         val res = mutableListOf<LocatedStep>()
 
         val currentBlockStart: Offset<TravelledPath> = currentPathOffset - rangeStart.distance
-        for (step in inputSteps.drop(nSeenSteps)) {
+        for (step in inputSteps.dropSeq(nSeenSteps)) {
             val currentPathBlockOffset = Offset<Block>(currentPathOffset - currentBlockStart)
             val location =
                 step.locations
@@ -90,8 +91,8 @@ class StepTracker(
      * Returns the steps that are present in the lookahead (not "reached" yet by the simulation, but
      * we know their path offset)
      */
-    fun getStepsInLookahead(): List<LocatedStep> {
-        return seenSteps.toList().drop(nStepsExcludingLookahead)
+    fun getStepsInLookahead(): Sequence<LocatedStep> {
+        return seenSteps.toList().dropSeq(nStepsExcludingLookahead)
     }
 
     /** Returns all the steps excluding lookahead, in order. */

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/implementation/BlockAvailability.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/implementation/BlockAvailability.kt
@@ -12,6 +12,7 @@ import fr.sncf.osrd.standalone_sim.CLOSED_SIGNAL_RESERVATION_MARGIN
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
 import fr.sncf.osrd.stdcm.infra_exploration.LocatedStep
 import fr.sncf.osrd.stdcm.preprocessing.interfaces.BlockAvailabilityInterface
+import fr.sncf.osrd.utils.dropSeq
 import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
@@ -221,7 +222,7 @@ data class BlockAvailability(
             infraExplorer
                 .getStepTracker()
                 .getSeenSteps()
-                .drop(1) // Skip departure step
+                .dropSeq(1) // Skip departure step
                 .filter { it.originalStep.stop }
                 .map { it.travelledPathOffset }
                 .contains(startOffset)


### PR DESCRIPTION
We can easily make an educated first guess based on bal3 patterns, which can skip the binary search when correct.
Roughly -10% computation time globally on STDCM. Also helps with standalone sim, but I don't have proper tools to measure that. 

I also tried to skip that guess when the signal isn't BAL3, but it's not actually faster that way. 

(also includes a small optimization as first commit)