### PR TITLE
front: fix format color for osmstyle waterwayline in minimal theme

### DIFF
--- a/front/src/common/Map/theme/colors.ts
+++ b/front/src/common/Map/theme/colors.ts
@@ -467,7 +467,7 @@ const minimal: Theme = {
     waterIntermittentFill: 'rgba(217, 236, 242, 1)',
     waterwayBridgeLine: '#bbbbbb',
     waterwayIntermittentLine: 'hsl(205, 56%, 73%)',
-    waterwayLine: '"rgba(223, 241, 251, 1)"',
+    waterwayLine: 'rgba(223, 241, 251, 1)',
     waterwayTunnelLine: '#D4EEFD',
   },
   platform: {


### PR DESCRIPTION
closes #14087 