### PR TITLE
front: fix occupancy blocks not displayed in op projection

### DIFF
--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useLazyProjectTrains.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useLazyProjectTrains.ts
@@ -63,7 +63,7 @@ const useLazyProjectTrains = ({
       loader = new TrainOpProjectionLazyLoader(
         operationalPointReferences.map(({ operational_point }) => operational_point),
         operationalPointDistances,
-        baseOptions
+        { ...baseOptions, path }
       );
     }
 


### PR DESCRIPTION
fix #14084 