### PR TITLE
editoast: authz: remove some `block_on` in test utils

### DIFF
--- a/editoast/authz/src/lib.rs
+++ b/editoast/authz/src/lib.rs
@@ -152,88 +152,84 @@ mod mock_driver {
         groups: Arc<Mutex<HashMap<GroupName, i64>>>,
     }
 
-    // Synchronous one-liners to setup tests concisely
+    // Concise test utilities
     impl Regulator<MockAuthDriver> {
-        pub fn create_user(&self, identity: &str, name: &str) -> model::User {
-            futures::executor::block_on(async {
-                model::User(
-                    self.driver
-                        .ensure_user(&UserInfo {
-                            identity: identity.to_owned(),
-                            name: name.to_owned(),
-                        })
-                        .await
-                        .expect("user creation should succeed")
-                        .id,
-                )
-            })
-        }
-
-        pub fn set_role(&self, user: model::User, role: Role) {
-            futures::executor::block_on(async {
-                self.grant_user_roles(&user, HashSet::from([role]))
+        pub async fn create_user(&self, identity: &str, name: &str) -> model::User {
+            model::User(
+                self.driver
+                    .ensure_user(&UserInfo {
+                        identity: identity.to_owned(),
+                        name: name.to_owned(),
+                    })
                     .await
-                    .expect("role set should succeed")
-            });
+                    .expect("user creation should succeed")
+                    .id,
+            )
         }
 
-        pub fn get_infra_grant(
+        pub async fn set_role(&self, user: model::User, role: Role) {
+            self.grant_user_roles(&user, HashSet::from([role]))
+                .await
+                .expect("role set should succeed")
+        }
+
+        pub async fn get_infra_grant(
             &self,
             user: model::User,
             infra: model::Infra,
         ) -> Option<InfraGrant> {
-            futures::executor::block_on(async {
-                self.infra_direct_grant(&user.into(), &infra)
-                    .await
-                    .expect("infra grant get should succeed")
-            })
+            self.infra_direct_grant(&user.into(), &infra)
+                .await
+                .expect("infra grant get should succeed")
         }
 
-        pub fn set_infra_grant(&self, user: model::User, infra: model::Infra, grant: InfraGrant) {
-            futures::executor::block_on(async {
-                self.give_infra_grant_unchecked(&user.into(), &infra, grant)
-                    .await
-                    .expect("infra grant set should succeed")
-            });
+        pub async fn set_infra_grant(
+            &self,
+            user: model::User,
+            infra: model::Infra,
+            grant: InfraGrant,
+        ) {
+            self.give_infra_grant_unchecked(&user.into(), &infra, grant)
+                .await
+                .expect("infra grant set should succeed")
         }
 
-        #[track_caller]
-        pub fn assert_infra_grant_eq(
+        pub async fn assert_infra_grant_eq(
             &self,
             user: model::User,
             infra: model::Infra,
             grant: Option<InfraGrant>,
         ) {
-            let actual_grant = self.get_infra_grant(user, infra);
+            let actual_grant = self.get_infra_grant(user, infra).await;
             assert_eq!(actual_grant, grant);
         }
 
         // https://en.wikipedia.org/wiki/Alice_and_Bob#Cast_of_characters
 
         /// Regular user
-        pub fn alice(&self) -> model::User {
-            self.create_user("alice", "Alice")
+        pub async fn alice(&self) -> model::User {
+            self.create_user("alice", "Alice").await
         }
 
         /// Regular user
-        pub fn bob(&self) -> model::User {
-            self.create_user("bob", "Bob")
+        pub async fn bob(&self) -> model::User {
+            self.create_user("bob", "Bob").await
         }
 
         /// Malicious user
-        pub fn chad(&self) -> model::User {
-            self.create_user("chad", "Chad")
+        pub async fn chad(&self) -> model::User {
+            self.create_user("chad", "Chad").await
         }
 
         /// Regular user
-        pub fn dave(&self) -> model::User {
-            self.create_user("dave", "Dave")
+        pub async fn dave(&self) -> model::User {
+            self.create_user("dave", "Dave").await
         }
 
         /// Admin user
-        pub fn walter(&self) -> model::User {
-            let user = self.create_user("walter", "Walter");
-            self.set_role(user, Role::Admin);
+        pub async fn walter(&self) -> model::User {
+            let user = self.create_user("walter", "Walter").await;
+            self.set_role(user, Role::Admin).await;
             user
         }
     }

--- a/editoast/authz/src/lib.rs
+++ b/editoast/authz/src/lib.rs
@@ -197,14 +197,6 @@ mod mock_driver {
             });
         }
 
-        pub fn revoke_infra_grant(&self, user: model::User, infra: model::Infra) {
-            futures::executor::block_on(async {
-                self.revoke_infra_grants_unchecked(&user.into(), &infra)
-                    .await
-                    .expect("infra grant revoke should succeed")
-            });
-        }
-
         #[track_caller]
         pub fn assert_infra_grant_eq(
             &self,

--- a/editoast/authz/src/regulator.rs
+++ b/editoast/authz/src/regulator.rs
@@ -933,10 +933,12 @@ mod tests {
     async fn admin_cannot_demote_last_owner() {
         let regulator = Regulator::new(crate::authz_client!(), MockAuthDriver::default());
         let infra = Infra(1);
-        let alice = regulator.alice();
-        let walter = regulator.walter();
+        let alice = regulator.alice().await;
+        let walter = regulator.walter().await;
 
-        regulator.set_infra_grant(alice, infra, InfraGrant::Owner);
+        regulator
+            .set_infra_grant(alice, infra, InfraGrant::Owner)
+            .await;
 
         regulator
             .give_infra_grant(&walter, &alice.into(), &infra, InfraGrant::Writer)
@@ -944,19 +946,25 @@ mod tests {
             .expect("grant operation should complete")
             .expect_denied("cannot demote the last owner");
 
-        regulator.assert_infra_grant_eq(alice, infra, Some(InfraGrant::Owner));
+        regulator
+            .assert_infra_grant_eq(alice, infra, Some(InfraGrant::Owner))
+            .await;
     }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn admin_can_promote_and_demote_anyone() {
         let regulator = Regulator::new(crate::authz_client!(), MockAuthDriver::default());
         let infra = Infra(1);
-        let alice = regulator.alice();
-        let bob = regulator.bob();
-        let walter = regulator.walter();
+        let alice = regulator.alice().await;
+        let bob = regulator.bob().await;
+        let walter = regulator.walter().await;
 
-        regulator.set_infra_grant(alice, infra, InfraGrant::Owner);
-        regulator.set_infra_grant(bob, infra, InfraGrant::Reader);
+        regulator
+            .set_infra_grant(alice, infra, InfraGrant::Owner)
+            .await;
+        regulator
+            .set_infra_grant(bob, infra, InfraGrant::Reader)
+            .await;
 
         // admin can promote anyone
         regulator
@@ -965,7 +973,9 @@ mod tests {
             .expect("grant operation should complete")
             .expect_allowed("admin can promote anyone");
 
-        regulator.assert_infra_grant_eq(bob, infra, Some(InfraGrant::Owner));
+        regulator
+            .assert_infra_grant_eq(bob, infra, Some(InfraGrant::Owner))
+            .await;
 
         // admin can demote anyone (when not last owner)
         regulator
@@ -974,16 +984,20 @@ mod tests {
             .expect("grant operation should complete")
             .expect_allowed("admin can demote anyone");
 
-        regulator.assert_infra_grant_eq(bob, infra, Some(InfraGrant::Writer));
+        regulator
+            .assert_infra_grant_eq(bob, infra, Some(InfraGrant::Writer))
+            .await;
     }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn last_owner_cannot_demote_themself() {
         let regulator = Regulator::new(crate::authz_client!(), MockAuthDriver::default());
         let infra = Infra(1);
-        let alice = regulator.alice();
+        let alice = regulator.alice().await;
 
-        regulator.set_infra_grant(alice, infra, InfraGrant::Owner);
+        regulator
+            .set_infra_grant(alice, infra, InfraGrant::Owner)
+            .await;
 
         regulator
             .give_infra_grant(&alice, &alice.into(), &infra, InfraGrant::Writer)
@@ -991,18 +1005,24 @@ mod tests {
             .expect("grant operation should complete")
             .expect_denied("cannot demote the last owner");
 
-        regulator.assert_infra_grant_eq(alice, infra, Some(InfraGrant::Owner));
+        regulator
+            .assert_infra_grant_eq(alice, infra, Some(InfraGrant::Owner))
+            .await;
     }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn owner_can_promote_and_demote_anyone() {
         let regulator = Regulator::new(crate::authz_client!(), MockAuthDriver::default());
         let infra = Infra(1);
-        let alice = regulator.alice();
-        let bob = regulator.bob();
+        let alice = regulator.alice().await;
+        let bob = regulator.bob().await;
 
-        regulator.set_infra_grant(alice, infra, InfraGrant::Owner);
-        regulator.set_infra_grant(bob, infra, InfraGrant::Reader);
+        regulator
+            .set_infra_grant(alice, infra, InfraGrant::Owner)
+            .await;
+        regulator
+            .set_infra_grant(bob, infra, InfraGrant::Reader)
+            .await;
 
         // owner can promote anyone
         regulator
@@ -1011,7 +1031,9 @@ mod tests {
             .expect("grant operation should complete")
             .expect_allowed("owner can promote anyone");
 
-        regulator.assert_infra_grant_eq(bob, infra, Some(InfraGrant::Writer));
+        regulator
+            .assert_infra_grant_eq(bob, infra, Some(InfraGrant::Writer))
+            .await;
 
         // owner can demote anyone
         regulator
@@ -1020,16 +1042,20 @@ mod tests {
             .expect("grant operation should complete")
             .expect_allowed("owner can demote anyone");
 
-        regulator.assert_infra_grant_eq(bob, infra, Some(InfraGrant::Reader));
+        regulator
+            .assert_infra_grant_eq(bob, infra, Some(InfraGrant::Reader))
+            .await;
     }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn user_can_demote_themself() {
         let regulator = Regulator::new(crate::authz_client!(), MockAuthDriver::default());
         let infra = Infra(1);
-        let alice = regulator.alice();
+        let alice = regulator.alice().await;
 
-        regulator.set_infra_grant(alice, infra, InfraGrant::Writer);
+        regulator
+            .set_infra_grant(alice, infra, InfraGrant::Writer)
+            .await;
 
         regulator
             .give_infra_grant(&alice, &alice.into(), &infra, InfraGrant::Reader)
@@ -1037,16 +1063,20 @@ mod tests {
             .expect("grant operation should complete")
             .expect_allowed("user can demote self");
 
-        regulator.assert_infra_grant_eq(alice, infra, Some(InfraGrant::Reader));
+        regulator
+            .assert_infra_grant_eq(alice, infra, Some(InfraGrant::Reader))
+            .await;
     }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn user_cannot_promote_themself() {
         let regulator = Regulator::new(crate::authz_client!(), MockAuthDriver::default());
         let infra = Infra(1);
-        let alice = regulator.alice();
+        let alice = regulator.alice().await;
 
-        regulator.set_infra_grant(alice, infra, InfraGrant::Writer);
+        regulator
+            .set_infra_grant(alice, infra, InfraGrant::Writer)
+            .await;
 
         regulator
             .give_infra_grant(&alice, &alice.into(), &infra, InfraGrant::Owner)
@@ -1054,18 +1084,24 @@ mod tests {
             .expect("grant operation should complete")
             .expect_denied("user cannot promote self");
 
-        regulator.assert_infra_grant_eq(alice, infra, Some(InfraGrant::Writer));
+        regulator
+            .assert_infra_grant_eq(alice, infra, Some(InfraGrant::Writer))
+            .await;
     }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn user_can_promote_up_to_own_level() {
         let regulator = Regulator::new(crate::authz_client!(), MockAuthDriver::default());
         let infra = Infra(1);
-        let alice = regulator.alice();
-        let bob = regulator.bob();
+        let alice = regulator.alice().await;
+        let bob = regulator.bob().await;
 
-        regulator.set_infra_grant(alice, infra, InfraGrant::Writer);
-        regulator.set_infra_grant(bob, infra, InfraGrant::Reader);
+        regulator
+            .set_infra_grant(alice, infra, InfraGrant::Writer)
+            .await;
+        regulator
+            .set_infra_grant(bob, infra, InfraGrant::Reader)
+            .await;
 
         regulator
             .give_infra_grant(&alice, &bob.into(), &infra, InfraGrant::Writer)
@@ -1073,18 +1109,24 @@ mod tests {
             .expect("grant operation should complete")
             .expect_allowed("user can promote up to own level");
 
-        regulator.assert_infra_grant_eq(bob, infra, Some(InfraGrant::Writer));
+        regulator
+            .assert_infra_grant_eq(bob, infra, Some(InfraGrant::Writer))
+            .await;
     }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn user_cannot_promote_above_own_level() {
         let regulator = Regulator::new(crate::authz_client!(), MockAuthDriver::default());
         let infra = Infra(1);
-        let alice = regulator.alice();
-        let bob = regulator.bob();
+        let alice = regulator.alice().await;
+        let bob = regulator.bob().await;
 
-        regulator.set_infra_grant(alice, infra, InfraGrant::Writer);
-        regulator.set_infra_grant(bob, infra, InfraGrant::Reader);
+        regulator
+            .set_infra_grant(alice, infra, InfraGrant::Writer)
+            .await;
+        regulator
+            .set_infra_grant(bob, infra, InfraGrant::Reader)
+            .await;
 
         regulator
             .give_infra_grant(&alice, &bob.into(), &infra, InfraGrant::Owner)
@@ -1092,7 +1134,9 @@ mod tests {
             .expect("grant operation should complete")
             .expect_denied("user cannot promote above own level");
 
-        regulator.assert_infra_grant_eq(bob, infra, Some(InfraGrant::Reader));
+        regulator
+            .assert_infra_grant_eq(bob, infra, Some(InfraGrant::Reader))
+            .await;
     }
 
     // REVOKING TESTS
@@ -1101,11 +1145,15 @@ mod tests {
     async fn only_owners_can_revoke() {
         let regulator = Regulator::new(crate::authz_client!(), MockAuthDriver::default());
         let infra = Infra(1);
-        let alice = regulator.alice();
-        let bob = regulator.bob();
+        let alice = regulator.alice().await;
+        let bob = regulator.bob().await;
 
-        regulator.set_infra_grant(alice, infra, InfraGrant::Writer);
-        regulator.set_infra_grant(bob, infra, InfraGrant::Reader);
+        regulator
+            .set_infra_grant(alice, infra, InfraGrant::Writer)
+            .await;
+        regulator
+            .set_infra_grant(bob, infra, InfraGrant::Reader)
+            .await;
 
         regulator
             .revoke_infra_grants(&alice, &bob.into(), &infra)
@@ -1113,17 +1161,21 @@ mod tests {
             .expect("revoke operation should complete")
             .expect_denied("only owners can revoke grants");
 
-        regulator.assert_infra_grant_eq(bob, infra, Some(InfraGrant::Reader));
+        regulator
+            .assert_infra_grant_eq(bob, infra, Some(InfraGrant::Reader))
+            .await;
     }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn admins_can_revoke() {
         let regulator = Regulator::new(crate::authz_client!(), MockAuthDriver::default());
         let infra = Infra(1);
-        let alice = regulator.alice();
-        let walter = regulator.walter();
+        let alice = regulator.alice().await;
+        let walter = regulator.walter().await;
 
-        regulator.set_infra_grant(alice, infra, InfraGrant::Reader);
+        regulator
+            .set_infra_grant(alice, infra, InfraGrant::Reader)
+            .await;
 
         regulator
             .revoke_infra_grants(&walter, &alice.into(), &infra)
@@ -1131,17 +1183,19 @@ mod tests {
             .expect("revoke operation should complete")
             .expect_allowed("admin can revoke grants");
 
-        regulator.assert_infra_grant_eq(alice, infra, None);
+        regulator.assert_infra_grant_eq(alice, infra, None).await;
     }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn last_owner_cannot_be_revoked_by_admin() {
         let regulator = Regulator::new(crate::authz_client!(), MockAuthDriver::default());
         let infra = Infra(1);
-        let alice = regulator.alice();
-        let walter = regulator.walter();
+        let alice = regulator.alice().await;
+        let walter = regulator.walter().await;
 
-        regulator.set_infra_grant(alice, infra, InfraGrant::Owner);
+        regulator
+            .set_infra_grant(alice, infra, InfraGrant::Owner)
+            .await;
 
         regulator
             .revoke_infra_grants(&walter, &alice.into(), &infra)
@@ -1149,18 +1203,24 @@ mod tests {
             .expect("revoke operation should complete")
             .expect_denied("last owner cannot be revoked");
 
-        regulator.assert_infra_grant_eq(alice, infra, Some(InfraGrant::Owner));
+        regulator
+            .assert_infra_grant_eq(alice, infra, Some(InfraGrant::Owner))
+            .await;
     }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn owner_cannot_revoke_another_owner() {
         let regulator = Regulator::new(crate::authz_client!(), MockAuthDriver::default());
         let infra = Infra(1);
-        let alice = regulator.alice();
-        let bob = regulator.bob();
+        let alice = regulator.alice().await;
+        let bob = regulator.bob().await;
 
-        regulator.set_infra_grant(alice, infra, InfraGrant::Owner);
-        regulator.set_infra_grant(bob, infra, InfraGrant::Owner);
+        regulator
+            .set_infra_grant(alice, infra, InfraGrant::Owner)
+            .await;
+        regulator
+            .set_infra_grant(bob, infra, InfraGrant::Owner)
+            .await;
 
         regulator
             .revoke_infra_grants(&alice, &bob.into(), &infra)
@@ -1168,6 +1228,8 @@ mod tests {
             .expect("revoke operation should complete")
             .expect_denied("owner cannot revoke another owner");
 
-        regulator.assert_infra_grant_eq(bob, infra, Some(InfraGrant::Owner));
+        regulator
+            .assert_infra_grant_eq(bob, infra, Some(InfraGrant::Owner))
+            .await;
     }
 }


### PR DESCRIPTION
These `block_on` weren't necessary and can cause deadlocks in tests in some cases.

* functions become `async`
* `await` points added where necessary

- **editoast: remove unused test function `revoke_infra_grant`**
- **editoast: authz: remove some `block_on` occurrences**
