### PR TITLE
front, e2e: add tags for the list of tests

### DIFF
--- a/front/tests/001-home-page.spec.ts
+++ b/front/tests/001-home-page.spec.ts
@@ -7,7 +7,7 @@ import type { FlatTranslations } from './utils/types';
 
 const frTranslations: FlatTranslations = readJsonFile('public/locales/fr/translation.json');
 
-test.describe('Home page OSRD', () => {
+test.describe('@home @navigation', () => {
   let homePage: HomePage;
 
   test.beforeEach('Navigate to the home page', async ({ page }) => {
@@ -16,7 +16,7 @@ test.describe('Home page OSRD', () => {
   });
 
   /** *************** Test 1 **************** */
-  test('Verify the links for different pages in Home Page', async () => {
+  test('@smoke Verify the links for different pages in Home Page', async () => {
     const expectedLinks = [
       frTranslations.operationalStudies,
       frTranslations.stdcm,
@@ -29,7 +29,7 @@ test.describe('Home page OSRD', () => {
   });
 
   /** *************** Test 2 **************** */
-  test('Verify redirection to the Operational Studies page', async () => {
+  test('@smoke Verify redirection to the Operational Studies page', async () => {
     await homePage.goToOperationalStudiesPage();
     await expect(homePage.page).toHaveURL(/.*\/operational-studies/);
   });
@@ -47,7 +47,7 @@ test.describe('Home page OSRD', () => {
   });
 
   /** *************** Test 5 **************** */
-  test('Verify redirection to the STDCM page', async ({ context }) => {
+  test('@smoke Verify redirection to the STDCM page', async ({ context }) => {
     const stdcmPage = await homePage.goToSTDCMPage(context);
     await expect(stdcmPage).toHaveURL(/.*\/stdcm/);
   });

--- a/front/tests/001-home-page.spec.ts
+++ b/front/tests/001-home-page.spec.ts
@@ -17,7 +17,6 @@ test.describe('Home page OSRD', () => {
 
   /** *************** Test 1 **************** */
   test('Verify the links for different pages in Home Page', async () => {
-    // List of expected links on the home page
     const expectedLinks = [
       frTranslations.operationalStudies,
       frTranslations.stdcm,
@@ -26,14 +25,13 @@ test.describe('Home page OSRD', () => {
       frTranslations.map,
     ];
 
-    // Verify that the displayed links match the expected ones
     await expect(homePage.linksTitle).toHaveText(expectedLinks);
   });
 
   /** *************** Test 2 **************** */
   test('Verify redirection to the Operational Studies page', async () => {
     await homePage.goToOperationalStudiesPage();
-    await expect(homePage.page).toHaveURL(/.*\/operational-studies/); // Check the URL
+    await expect(homePage.page).toHaveURL(/.*\/operational-studies/);
   });
 
   /** *************** Test 3 **************** */

--- a/front/tests/002-project-management.spec.ts
+++ b/front/tests/002-project-management.spec.ts
@@ -10,7 +10,7 @@ import type { ProjectData } from './utils/types';
 
 const projectData: ProjectData = readJsonFile('tests/assets/operation-studies/project.json');
 
-test.describe('Validate the Operational Study Project workflow', () => {
+test.describe('@op @project @management', () => {
   let projectPage: ProjectPage;
   let project: Project;
 
@@ -27,7 +27,7 @@ test.describe('Validate the Operational Study Project workflow', () => {
   });
 
   /** *************** Test 1 **************** */
-  test('Create a new project', async ({ page }) => {
+  test('@smoke Create a new project', async ({ page }) => {
     const projectName = generateUniqueName(projectData.name);
     createdProjects.push(projectName);
 

--- a/front/tests/002-project-management.spec.ts
+++ b/front/tests/002-project-management.spec.ts
@@ -73,7 +73,7 @@ test.describe('Validate the Operational Study Project workflow', () => {
       await projectPage.openProjectByTestId(project.name);
     });
 
-    await test.step('Update than save project details', async () => {
+    await test.step('Update and save project details', async () => {
       await projectPage.updateProject({
         name: updatedName,
         description: `${project.description} (updated)`,

--- a/front/tests/003-study-management.spec.ts
+++ b/front/tests/003-study-management.spec.ts
@@ -18,7 +18,7 @@ const frTranslations: StudyFrTranslations = readJsonFile(
   'public/locales/fr/operational-studies.json'
 );
 
-test.describe('Validate the Study creation workflow', () => {
+test.describe('@op @study @management', () => {
   let studyPage: StudyPage;
   let project: Project;
   let study: Study;
@@ -40,7 +40,7 @@ test.describe('Validate the Study creation workflow', () => {
   });
 
   /** *************** Test 1 **************** */
-  test('Create a new study', async ({ page }) => {
+  test('@smoke Create a new study', async ({ page }) => {
     await test.step('Navigate to project page', async () => {
       await page.goto(`/operational-studies/projects/${project.id}`);
     });

--- a/front/tests/004-scenario-management.spec.ts
+++ b/front/tests/004-scenario-management.spec.ts
@@ -26,7 +26,7 @@ import type { ScenarioData } from './utils/types';
 
 const scenarioData: ScenarioData = readJsonFile('tests/assets/operation-studies/scenario.json');
 
-test.describe('Validate the Scenario creation workflow', () => {
+test.describe('@op @scenario @management', () => {
   let scenarioPage: ScenarioPage;
 
   let project: Project;
@@ -56,7 +56,7 @@ test.describe('Validate the Scenario creation workflow', () => {
   });
 
   /** *************** Test 1 **************** */
-  test('Create a new scenario', async ({ page }) => {
+  test('@smoke Create a new scenario', async ({ page }) => {
     const scenarioName = generateUniqueName(scenarioData.name);
     createdScenarios.push({
       projectId: project.id,
@@ -89,7 +89,7 @@ test.describe('Validate the Scenario creation workflow', () => {
   });
 
   /** *************** Test 2 **************** */
-  test('Update an existing scenario', async ({ page }) => {
+  test('@smoke Update an existing scenario', async ({ page }) => {
     await test.step('Create a base scenario', async () => {
       ({ project, study, scenario } = await createScenario());
     });

--- a/front/tests/005-rolling-stock-editor.spec.ts
+++ b/front/tests/005-rolling-stock-editor.spec.ts
@@ -1,9 +1,6 @@
 import { expect } from '@playwright/test';
 
-import {
-  dualModeRollingStockName,
-  electricRollingStockName,
-} from './assets/constants/project-const';
+import { electricRollingStockName } from './assets/constants/project-const';
 import test from './logging-fixture';
 import RollingstockEditorPage from './pages/rolling-stock/rolling-stock-editor-page';
 import readJsonFile from './utils/file-utils';
@@ -199,76 +196,6 @@ test.describe('Rollingstock editor page tests', () => {
 
     await test.step('Search deleted rolling stock → expect no results', async () => {
       await rollingStockEditorPage.searchRollingStock(uniqueDeletedRollingStockName);
-      await expect(rollingStockEditorPage.noRollingStockResult).toBeVisible();
-      expect(await rollingStockEditorPage.getRollingStockSearchNumber()).toEqual(0);
-    });
-  });
-
-  /** *************** Test 4 **************** */
-  test('Filtering rolling stocks', async () => {
-    const initialRollingStockFoundNumber =
-      await rollingStockEditorPage.getRollingStockSearchNumber();
-
-    await test.step('Toggle Electric filter and verify count', async () => {
-      await rollingStockEditorPage.toggleElectricRollingStockFilter();
-      expect(await rollingStockEditorPage.electricRollingStockIcons.count()).toEqual(
-        await rollingStockEditorPage.getRollingStockSearchNumber()
-      );
-    });
-
-    await test.step('Clear Electric filter and verify initial count', async () => {
-      await rollingStockEditorPage.toggleElectricRollingStockFilter();
-      expect(await rollingStockEditorPage.rollingStockList.count()).toBeGreaterThanOrEqual(
-        initialRollingStockFoundNumber
-      );
-    });
-
-    await test.step('Toggle Thermal filter and verify count', async () => {
-      await rollingStockEditorPage.toggleThermalRollingStockFilter();
-      expect(await rollingStockEditorPage.thermalRollingStockIcons.count()).toEqual(
-        await rollingStockEditorPage.getRollingStockSearchNumber()
-      );
-    });
-
-    await test.step('Toggle Electric with Thermal on (dual-mode) and verify count', async () => {
-      await rollingStockEditorPage.toggleElectricRollingStockFilter();
-      expect(await rollingStockEditorPage.dualModeRollingStockIcons.count()).toEqual(
-        await rollingStockEditorPage.getRollingStockSearchNumber()
-      );
-    });
-
-    await test.step('Clear both filters and verify count resets', async () => {
-      await rollingStockEditorPage.toggleElectricRollingStockFilter();
-      await rollingStockEditorPage.toggleThermalRollingStockFilter();
-      const currentCount = await rollingStockEditorPage.rollingStockList.count();
-      expect(currentCount).toEqual(initialRollingStockFoundNumber);
-    });
-  });
-
-  /** *************** Test 2 **************** */
-  test('Search for a rolling stock', async () => {
-    const initialRollingStockFoundNumber =
-      await rollingStockEditorPage.getRollingStockSearchNumber();
-
-    await test.step('Search a specific rolling stock and verify icons', async () => {
-      await rollingStockEditorPage.searchRollingStock(dualModeRollingStockName);
-      expect(
-        rollingStockEditorPage.page.getByTestId(`rollingstock-${dualModeRollingStockName}`)
-      ).toBeDefined();
-
-      await expect(rollingStockEditorPage.thermalRollingStockFirstIcon).toBeVisible();
-      await expect(rollingStockEditorPage.electricRollingStockFirstIcon).toBeVisible();
-    });
-
-    await test.step('Clear search and verify count resets', async () => {
-      await rollingStockEditorPage.clearSearchRollingStock();
-      expect(await rollingStockEditorPage.rollingStockList.count()).toEqual(
-        initialRollingStockFoundNumber
-      );
-    });
-
-    await test.step('Search a non-existent rolling stock → expect no results', async () => {
-      await rollingStockEditorPage.searchRollingStock(`${dualModeRollingStockName}-no-results`);
       await expect(rollingStockEditorPage.noRollingStockResult).toBeVisible();
       expect(await rollingStockEditorPage.getRollingStockSearchNumber()).toEqual(0);
     });

--- a/front/tests/005-rolling-stock-editor.spec.ts
+++ b/front/tests/005-rolling-stock-editor.spec.ts
@@ -12,7 +12,7 @@ const rollingstockDetails: RollingStockDetails = readJsonFile(
   './tests/assets/rolling-stock/rolling-stock-details.json'
 );
 
-test.describe('Rollingstock editor page tests', () => {
+test.describe('@rs-editor', () => {
   let rollingStockEditorPage: RollingstockEditorPage;
 
   const createdRollingStocks: string[] = [];
@@ -49,7 +49,7 @@ test.describe('Rollingstock editor page tests', () => {
   });
 
   /** *************** Test 1 **************** */
-  test('Create a new rolling stock', async ({ page }) => {
+  test('@smoke Create a new rolling stock', async ({ page }) => {
     createdRollingStocks.push(uniqueRollingStockName);
 
     await test.step('Open creation form', async () => {

--- a/front/tests/006-op-rolling-stock-tab.spec.ts
+++ b/front/tests/006-op-rolling-stock-tab.spec.ts
@@ -40,7 +40,7 @@ test.describe('Rolling stock Tab Verification', () => {
     await deleteScenario(study.id, scenario.name);
   });
 
-  test.beforeEach('Navigate to the scenario page', async ({ page }) => {
+  test.beforeEach('Navigate to the scenario page and open form', async ({ page }) => {
     [operationalStudiesPage, rollingStockSelector] = [
       new OperationalStudiesPage(page),
       new RollingStockSelector(page),

--- a/front/tests/006-op-rolling-stock-tab.spec.ts
+++ b/front/tests/006-op-rolling-stock-tab.spec.ts
@@ -20,7 +20,7 @@ import { getInfra, getRollingStock } from './utils/api-utils';
 import createScenario from './utils/scenario';
 import { deleteScenario } from './utils/teardown-utils';
 
-test.describe('Rolling stock Tab Verification', () => {
+test.describe('@op @rs-tab', () => {
   let operationalStudiesPage: OperationalStudiesPage;
   let rollingStockSelector: RollingStockSelector;
 
@@ -54,7 +54,7 @@ test.describe('Rolling stock Tab Verification', () => {
   });
 
   /** *************** Test 1 **************** */
-  test('Select a rolling stock for operational study', async () => {
+  test('@smoke Select a rolling stock for operational study', async () => {
     await test.step('Verify tab warnings are present', async () => {
       await operationalStudiesPage.verifyTabWarningPresence();
     });

--- a/front/tests/007-op-route-tab.spec.ts
+++ b/front/tests/007-op-route-tab.spec.ts
@@ -10,7 +10,7 @@ import { getInfra } from './utils/api-utils';
 import createScenario from './utils/scenario';
 import { deleteScenario } from './utils/teardown-utils';
 
-test.describe('Route Tab Verification', () => {
+test.describe('@op @route-tab', () => {
   let operationalStudiesPage: OperationalStudiesPage;
   let rollingstockSelector: RollingStockSelector;
   let routeTab: RouteTab;
@@ -52,7 +52,7 @@ test.describe('Route Tab Verification', () => {
   });
 
   /** *************** Test 1 **************** */
-  test('Select a route for operational study', async ({ browserName }) => {
+  test('@smoke Select a route for operational study', async ({ browserName }) => {
     await test.step('Verify no route selected initially', async () => {
       await routeTab.verifyNoSelectedRoute();
     });

--- a/front/tests/007-op-route-tab.spec.ts
+++ b/front/tests/007-op-route-tab.spec.ts
@@ -116,9 +116,7 @@ test.describe('Route Tab Verification', () => {
   });
 
   /** *************** Test 3 **************** */
-  test('Reversing and deleting waypoints in a route for operational study', async ({
-    browserName,
-  }) => {
+  test('Reversing and deleting waypoints', async ({ browserName }) => {
     const expectedMapMarkersValues = ['West_station', 'South_East_station', 'Mid_West_station'];
 
     await test.step('Perform pathfinding WS → SES via MWS and verify markers', async () => {

--- a/front/tests/008-op-times-and-stops-tab.spec.ts
+++ b/front/tests/008-op-times-and-stops-tab.spec.ts
@@ -21,7 +21,6 @@ const frTranslations: FlatTranslations = readJsonFile<Record<string, FlatTransla
   'public/locales/fr/translation.json'
 ).timeStopTable;
 
-// Load test data for table inputs and expected results
 const initialInputsData: CellData[] = readJsonFile(
   './tests/assets/operation-studies/times-and-stops/initial-inputs.json'
 );
@@ -38,7 +37,6 @@ const updatedCellData: JSON = readJsonFile(
   './tests/assets/operation-studies/times-and-stops/updated-inputs-cells-data.json'
 );
 
-// Waypoints data for route verification
 const expectedViaValues = [
   { name: 'Mid_West_station', ch: 'BV', uic: '33', km: 'KM 12.050' },
   { name: 'Mid_East_station', ch: 'BV', uic: '44', km: 'KM 26.500' },
@@ -76,32 +74,25 @@ test.describe('Times and Stops Tab Verification', () => {
     ];
 
     await test.step('Create then navigate to scenario page', async () => {
-      // Set up scenario for operational study
       ({ project, study, scenario } = await createScenario());
 
-      // Navigate to the operational study scenario page
       await page.goto(
         `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenario.id}`
       );
-
-      // Wait for infra to be in 'CACHED' state before proceeding
       await waitForInfraStateToBeCached(infra.id);
     });
-    await test.step('Add a new train schedule, set its properties and perform pathfinding', async () => {
-      // Setup train schedule configuration and schedule
+    await test.step('Add a new train schedule and set its properties', async () => {
       await operationalStudiesPage.openTimetableItemForm();
       await operationalStudiesPage.setTimetableItemStartTime('11:22:40');
       await rollingStockSelector.selectRollingStock(dualModeRollingStockName);
       await operationalStudiesPage.setTimetableItemName('Train-name-e2e-test');
-
-      // Perform route pathfinding
+    });
+    await test.step('Perform pathfinding then navigate to Times and Stops tab', async () => {
       await operationalStudiesPage.openRouteTab();
       await routeTab.performPathfindingByTrigram({
         originTrigram: 'WS',
         destinationTrigram: 'NES',
       });
-
-      // Navigate to the Times and Stops tab and scroll to the data sheet
       await operationalStudiesPage.openTimesAndStopsTab();
     });
   });
@@ -110,7 +101,8 @@ test.describe('Times and Stops Tab Verification', () => {
     await deleteScenario(study.id, scenario.name);
   });
 
-  test('should correctly set and display times and stops tables', async () => {
+  /** *************** Test 1 **************** */
+  test('Set and display times and stops tables', async () => {
     await test.step('Verify table headers', async () => {
       const expectedColumnNames = cleanWhitespaceInArray([
         frTranslations.name,
@@ -170,7 +162,8 @@ test.describe('Times and Stops Tab Verification', () => {
     });
   });
 
-  test('should correctly update and clear input table row', async () => {
+  /** *************** Test 2 **************** */
+  test('Update and clear input table row', async () => {
     await test.step('Fill initial inputs and verify table', async () => {
       for (const cell of initialInputsData) {
         const translatedHeader = cleanWhitespace(frTranslations[cell.header]);

--- a/front/tests/008-op-times-and-stops-tab.spec.ts
+++ b/front/tests/008-op-times-and-stops-tab.spec.ts
@@ -42,7 +42,7 @@ const expectedViaValues = [
   { name: 'Mid_East_station', ch: 'BV', uic: '44', km: 'KM 26.500' },
 ];
 
-test.describe('Times and Stops Tab Verification', () => {
+test.describe('@op @times-stops-tab', () => {
   let operationalStudiesPage: OperationalStudiesPage;
   let rollingStockSelector: RollingStockSelector;
   let routeTab: RouteTab;
@@ -102,7 +102,7 @@ test.describe('Times and Stops Tab Verification', () => {
   });
 
   /** *************** Test 1 **************** */
-  test('Set and display times and stops tables', async () => {
+  test('@smoke Set and display times and stops tables', async () => {
     await test.step('Verify table headers', async () => {
       const expectedColumnNames = cleanWhitespaceInArray([
         frTranslations.name,
@@ -163,7 +163,7 @@ test.describe('Times and Stops Tab Verification', () => {
   });
 
   /** *************** Test 2 **************** */
-  test('Update and clear input table row', async () => {
+  test('@smoke Update and clear input table row', async () => {
     await test.step('Fill initial inputs and verify table', async () => {
       for (const cell of initialInputsData) {
         const translatedHeader = cleanWhitespace(frTranslations[cell.header]);

--- a/front/tests/009-op-simulation-settings-tab.spec.ts
+++ b/front/tests/009-op-simulation-settings-tab.spec.ts
@@ -54,7 +54,7 @@ const expectedCellDataForAllSettings: StationData[] = readJsonFile(
   './tests/assets/operation-studies/simulation-settings/all-settings.json'
 );
 
-test.describe('Simulation Settings Tab Verification', () => {
+test.describe('@op @simulation-settings-tab', () => {
   let operationalStudiesPage: OperationalStudiesPage;
   let rollingStockSelector: RollingStockSelector;
   let routeTab: RouteTab;
@@ -327,7 +327,7 @@ test.describe('Simulation Settings Tab Verification', () => {
   });
 
   /** *************** Test 4 **************** */
-  test('Add all the simulation settings', async ({ browserName }) => {
+  test('@smoke Add all the simulation settings', async ({ browserName }) => {
     const inputTableData: CellData[] = [
       { stationName: 'Mid_East_station', header: 'stopTime', value: '124' },
       {

--- a/front/tests/009-op-simulation-settings-tab.spec.ts
+++ b/front/tests/009-op-simulation-settings-tab.spec.ts
@@ -26,7 +26,7 @@ import createScenario from './utils/scenario';
 import { deleteScenario } from './utils/teardown-utils';
 import type { FlatTranslations, StationData } from './utils/types';
 
-const frTranslations = readJsonFile<Record<string, FlatTranslations>>(
+const frTranslations: FlatTranslations = readJsonFile<Record<string, FlatTranslations>>(
   'public/locales/fr/translation.json'
 ).timeStopTable;
 
@@ -72,7 +72,6 @@ test.describe('Simulation Settings Tab Verification', () => {
 
   type TranslationKeys = keyof typeof frTranslations;
 
-  // Define CellData type for table cell data
   type CellData = {
     stationName: string;
     header: TranslationKeys;
@@ -144,6 +143,7 @@ test.describe('Simulation Settings Tab Verification', () => {
     await deleteScenario(study.id, scenario.name);
   });
 
+  /** *************** Test 1 **************** */
   test('Activate electrical profiles', async ({ browserName }) => {
     const cell: CellData = { stationName: 'Mid_East_station', header: 'stopTime', value: '124' };
     const translatedHeader = cleanWhitespace(frTranslations[cell.header]);
@@ -200,6 +200,7 @@ test.describe('Simulation Settings Tab Verification', () => {
     });
   });
 
+  /** *************** Test 2 **************** */
   test('Add speed limit tag', async ({ browserName }) => {
     const cell: CellData = { stationName: 'Mid_East_station', header: 'stopTime', value: '124' };
     const translatedHeader = cleanWhitespace(frTranslations[cell.header]);
@@ -257,6 +258,7 @@ test.describe('Simulation Settings Tab Verification', () => {
     });
   });
 
+  /** *************** Test 3 **************** */
   test('Activate linear and mareco margin', async ({ browserName }) => {
     const inputTableData: CellData[] = [
       { stationName: 'Mid_East_station', header: 'stopTime', value: '124' },
@@ -324,6 +326,7 @@ test.describe('Simulation Settings Tab Verification', () => {
     });
   });
 
+  /** *************** Test 4 **************** */
   test('Add all the simulation settings', async ({ browserName }) => {
     const inputTableData: CellData[] = [
       { stationName: 'Mid_East_station', header: 'stopTime', value: '124' },

--- a/front/tests/010-stdcm.spec.ts
+++ b/front/tests/010-stdcm.spec.ts
@@ -24,7 +24,7 @@ const tractionEnginePrefilledValues = { tonnage: '900', length: '400' };
 const fastRollingStockPrefilledValues = { tonnage: '190', length: '46' };
 const towedRollingStockPrefilledValues = { tonnage: '46', length: '26' };
 
-test.describe('Verify stdcm simulation page', () => {
+test.describe('@stdcm', () => {
   let stdcmPage: STDCMPage;
   let consistSection: ConsistSection;
   let originSection: OriginSection;
@@ -65,7 +65,7 @@ test.describe('Verify stdcm simulation page', () => {
   });
 
   /** *************** Test 1 **************** */
-  test('Verify default STDCM page', async () => {
+  test('@smoke Verify default STDCM page', async () => {
     await test.step('Verify base UI sections are visible', async () => {
       await stdcmPage.verifyStdcmElementsVisibility();
     });
@@ -83,7 +83,7 @@ test.describe('Verify stdcm simulation page', () => {
   });
 
   /** *************** Test 2 **************** */
-  test('Launch STDCM simulation with all stops', async () => {
+  test('@smoke Launch STDCM simulation with all stops', async () => {
     await test.step('Fill consist, origin and destination', async () => {
       await consistSection.fillAndVerifyConsistDetails(
         consistDetails,

--- a/front/tests/011-stdcm-simulation-sheet.spec.ts
+++ b/front/tests/011-stdcm-simulation-sheet.spec.ts
@@ -29,7 +29,7 @@ const tractionEnginePrefilledValues = {
   maxSpeed: '288',
 };
 
-test.describe('Verify stdcm simulation page', () => {
+test.describe('@stdcm @stdcm-sheet', () => {
   test.describe.configure({ mode: 'serial' });
 
   let stdcmPage: STDCMPage;
@@ -68,7 +68,10 @@ test.describe('Verify stdcm simulation page', () => {
   });
 
   /** *************** Test 1 **************** */
-  test('Verify STDCM stops and simulation sheet', async ({ browserName, context }, testInfo) => {
+  test('@smoke Verify STDCM stops and simulation sheet', async ({
+    browserName,
+    context,
+  }, testInfo) => {
     await test.step('Fill consist, origin, destination and via', async () => {
       await consistSection.fillAndVerifyConsistDetails(
         consistDetails,
@@ -126,7 +129,7 @@ test.describe('Verify stdcm simulation page', () => {
   });
 
   /** *************** Test 2 *************** */
-  test('Verify simulation sheet content', async () => {
+  test('@smoke Verify simulation sheet content', async () => {
     const pdfFilePath = await test.step('Find the downloaded PDF', async () => {
       const filePath = findFirstPdf(downloadDir!);
       if (!filePath) {

--- a/front/tests/011-stdcm-simulation-sheet.spec.ts
+++ b/front/tests/011-stdcm-simulation-sheet.spec.ts
@@ -40,6 +40,7 @@ test.describe('Verify stdcm simulation page', () => {
   let simulationResultPage: SimulationResultPage;
 
   let infra: Infra;
+  let downloadDir: string | undefined;
 
   test.beforeAll('Fetch infrastructure', async () => {
     infra = await getInfra();
@@ -65,8 +66,6 @@ test.describe('Verify stdcm simulation page', () => {
     await page.goto('/stdcm');
     await waitForInfraStateToBeCached(infra.id);
   });
-
-  let downloadDir: string | undefined;
 
   /** *************** Test 1 **************** */
   test('Verify STDCM stops and simulation sheet', async ({ browserName, context }, testInfo) => {

--- a/front/tests/012-stdcm-feedback-mail.spec.ts
+++ b/front/tests/012-stdcm-feedback-mail.spec.ts
@@ -27,7 +27,7 @@ const tractionEnginePrefilledValues = {
   maxSpeed: '288',
 };
 
-test.describe('Stdcm feedback card', () => {
+test.describe('@stdcm @stdcm-feedback', () => {
   let stdcmPage: STDCMPage;
   let consistSection: ConsistSection;
   let originSection: OriginSection;

--- a/front/tests/013-stdcm-linked-train.spec.ts
+++ b/front/tests/013-stdcm-linked-train.spec.ts
@@ -24,7 +24,7 @@ const towedRollingStockPrefilledValues = {
   maxSpeed: '180',
 };
 
-test.describe('Verify stdcm simulation page', () => {
+test.describe('@stdcm @stdcm-linked-train', () => {
   let stdcmPage: STDCMPage;
   let consistSection: ConsistSection;
   let originSection: OriginSection;

--- a/front/tests/014-stdcm-missing-fields.spec.ts
+++ b/front/tests/014-stdcm-missing-fields.spec.ts
@@ -20,7 +20,7 @@ import type { StdcmTranslations } from './utils/types';
 
 const frTranslations: StdcmTranslations = readJsonFile('public/locales/fr/stdcm.json');
 
-test.describe('Verify stdcm missing fields', () => {
+test.describe('@stdcm @stdcm-missing-fields', () => {
   let stdcmPage: STDCMPage;
   let consistSection: ConsistSection;
   let originSection: OriginSection;

--- a/front/tests/015-train-timetable.spec.ts
+++ b/front/tests/015-train-timetable.spec.ts
@@ -1,5 +1,3 @@
-import test from '@playwright/test';
-
 import type { Scenario, Project, Study, Infra, PacedTrain } from 'common/api/osrdEditoastApi';
 
 import {
@@ -12,25 +10,13 @@ import {
   timetableItemStudyName,
 } from './assets/constants/project-const';
 import {
-  HONORED_TIMETABLE_ITEMS,
-  INVALID_TIMETABLE_ITEMS,
-  ITEMS_WITH_HLP_SPEED_LIMIT_TAG_EXCEPTION,
-  TIMETABLE_ITEMS_WITH_NO_SPEED_LIMIT_TAG,
-  LABEL_FILTERED_TIMETABLE_ITEMS,
-  LABEL_FILTERED_TIMETABLE_ITEMS_EXCEPTION,
-  NAME_FILTERED_TIMETABLE_ITEMS,
-  NAME_FILTERED_TIMETABLE_ITEMS_EXCEPTION,
-  NAME_LABEL_FILTERED_TIMETABLE_ITEMS_MIXED,
-  NOT_HONORED_TIMETABLE_ITEMS,
-  NOT_HONORED_PACED_TRAIN_SCHEDULE,
-  ROLLING_STOCK_FILTERED_TIMETABLE_ITEMS_EXCEPTION,
   TOTAL_TIMETABLE_ITEMS,
   TOTAL_PACED_TRAINS,
   TOTAL_TRAIN_SCHEDULES,
-  VALID_TIMETABLE_ITEMS,
   VALID_PACED_TRAINS,
   VALID_TRAIN_SCHEDULE,
 } from './assets/constants/timetable-items-count';
+import test from './logging-fixture';
 import PacedTrainSection from './pages/operational-studies/paced-train-section';
 import ScenarioTimetableSection from './pages/operational-studies/scenario-timetable-section';
 import { waitForInfraStateToBeCached } from './utils';
@@ -121,120 +107,6 @@ test.describe('Verify train schedule elements and filters', () => {
   });
 
   /** *************** Test 3 **************** */
-  test('Filtering imported timetable items', async () => {
-    await test.step('Verify totals and default filter UI', async () => {
-      await scenarioTimetableSection.verifyTotalItemsLabel(frTranslations, {
-        totalPacedTrainCount: TOTAL_PACED_TRAINS,
-        totalTrainScheduleCount: TOTAL_TRAIN_SCHEDULES,
-      });
-      await scenarioTimetableSection.checkTimetableFilterVisibilityLabelDefaultValue(
-        frTranslations.timetable,
-        { inputDefaultValue: '', selectDefaultValue: 'both' }
-      );
-    });
-
-    await test.step('Filter by name / label (standard)', async () => {
-      await scenarioTimetableSection.filterNameAndVerifyTrainCount(
-        'Paced Train - Updated exception (Train name)',
-        NAME_FILTERED_TIMETABLE_ITEMS
-      );
-      await scenarioTimetableSection.filterNameAndVerifyTrainCount(
-        'Paced-Train-Tag-2',
-        LABEL_FILTERED_TIMETABLE_ITEMS
-      );
-    });
-
-    await test.step('Filter by name / label (exceptions & mixed)', async () => {
-      await scenarioTimetableSection.filterNameAndVerifyTrainCount(
-        'abc',
-        NAME_FILTERED_TIMETABLE_ITEMS_EXCEPTION
-      );
-      await scenarioTimetableSection.filterNameAndVerifyTrainCount(
-        'exception',
-        NAME_LABEL_FILTERED_TIMETABLE_ITEMS_MIXED
-      );
-      await scenarioTimetableSection.filterNameAndVerifyTrainCount(
-        'exception-label',
-        LABEL_FILTERED_TIMETABLE_ITEMS_EXCEPTION
-      );
-    });
-
-    await test.step('Filter by rolling stock', async () => {
-      await scenarioTimetableSection.filterRollingStockAndVerifyTrainCount(
-        'slow_rolling_stock',
-        ROLLING_STOCK_FILTERED_TIMETABLE_ITEMS_EXCEPTION
-      );
-    });
-
-    await test.step('Filter by validity', async () => {
-      await scenarioTimetableSection.filterValidityAndVerifyTrainCount(
-        'Invalid',
-        INVALID_TIMETABLE_ITEMS,
-        frTranslations
-      );
-      await scenarioTimetableSection.filterValidityAndVerifyTrainCount(
-        'Valid',
-        VALID_TIMETABLE_ITEMS,
-        frTranslations
-      );
-    });
-
-    await test.step('Filter by punctuality (Honored/Not honored)', async () => {
-      await scenarioTimetableSection.filterHonoredAndVerifyTrainCount(
-        'Honored',
-        HONORED_TIMETABLE_ITEMS,
-        frTranslations
-      );
-      await scenarioTimetableSection.filterHonoredAndVerifyTrainCount(
-        'Not honored',
-        NOT_HONORED_TIMETABLE_ITEMS,
-        frTranslations
-      );
-    });
-
-    await test.step('Filter by train type', async () => {
-      await scenarioTimetableSection.filterTrainTypeAndVerifyTrainCount(
-        'Service',
-        NOT_HONORED_PACED_TRAIN_SCHEDULE
-      );
-      await scenarioTimetableSection.filterHonoredAndVerifyTrainCount(
-        'All',
-        VALID_PACED_TRAINS,
-        frTranslations
-      );
-      await scenarioTimetableSection.filterValidityAndVerifyTrainCount(
-        'All',
-        TOTAL_PACED_TRAINS,
-        frTranslations
-      );
-      await scenarioTimetableSection.filterTrainTypeAndVerifyTrainCount(
-        'Unique train',
-        TOTAL_TRAIN_SCHEDULES
-      );
-      await scenarioTimetableSection.filterTrainTypeAndVerifyTrainCount(
-        'All',
-        TOTAL_TIMETABLE_ITEMS
-      );
-    });
-
-    await test.step('Filter by speed limit tag and verify counts', async () => {
-      await scenarioTimetableSection.filterSpeedLimitTagAndVerifyTrainCount(
-        null,
-        TIMETABLE_ITEMS_WITH_NO_SPEED_LIMIT_TAG,
-        frTranslations
-      );
-      await scenarioTimetableSection.verifyTimetableItemsCount(TOTAL_TIMETABLE_ITEMS);
-
-      await scenarioTimetableSection.filterSpeedLimitTagAndVerifyTrainCount(
-        'HLP',
-        ITEMS_WITH_HLP_SPEED_LIMIT_TAG_EXCEPTION,
-        frTranslations
-      );
-      await scenarioTimetableSection.verifyTimetableItemsCount(TOTAL_TIMETABLE_ITEMS);
-    });
-  });
-
-  /** *************** Test 4 **************** */
   test('Loading timetable items and verifying paced trains display', async () => {
     await test.step('Verify each imported paced train card and its occurrences', async () => {
       const pacedTrainsData: PacedTrain[] = readJsonFile(
@@ -249,7 +121,9 @@ test.describe('Verify train schedule elements and filters', () => {
         await pacedTrainSection.verifyPacedTrainItemDetails(
           IMPORTED_PACED_TRAIN_DETAILS[pacedTrainIndex],
           pacedTrainIndex,
-          { occurrenceData: IMPORT_PACED_TRAIN_OCCURRENCES_DETAILS[pacedTrainIndex] }
+          {
+            occurrenceData: IMPORT_PACED_TRAIN_OCCURRENCES_DETAILS[pacedTrainIndex],
+          }
         );
       }
     });

--- a/front/tests/015-train-timetable.spec.ts
+++ b/front/tests/015-train-timetable.spec.ts
@@ -34,7 +34,7 @@ const frTranslations = {
   ...frCommonTranslations,
 };
 
-test.describe('Verify train schedule elements and filters', () => {
+test.describe('@op @timetable-items', () => {
   let scenarioTimetableSection: ScenarioTimetableSection;
   let pacedTrainSection: PacedTrainSection;
 
@@ -66,7 +66,7 @@ test.describe('Verify train schedule elements and filters', () => {
   );
 
   /** *************** Test 1 **************** */
-  test('Loading timetable items and verifying simulation result for train schedules', async () => {
+  test('@smoke Loading timetable items and verifying simulation result for train schedules', async () => {
     await test.step('Verify counts then filter valid train schedules', async () => {
       await scenarioTimetableSection.verifyTimetableItemsCount(TOTAL_TIMETABLE_ITEMS);
       await scenarioTimetableSection.filterTrainTypeAndVerifyTrainCount(

--- a/front/tests/016-train-timetable-multiselection.spec.ts
+++ b/front/tests/016-train-timetable-multiselection.spec.ts
@@ -30,7 +30,7 @@ const frTranslations = {
 const trainSchedulesJson: JSON = readJsonFile('./tests/assets/train-schedule/train_schedules.json');
 const pacedTrainsJson: JSON = readJsonFile('./tests/assets/paced-train/paced_trains.json');
 
-test.describe('Verify train schedule elements and filters', () => {
+test.describe('@op @timetable-items @timetable-multiselection', () => {
   let scenarioTimetableSection: ScenarioTimetableSection;
 
   let project: Project;

--- a/front/tests/016-train-timetable-multiselection.spec.ts
+++ b/front/tests/016-train-timetable-multiselection.spec.ts
@@ -62,6 +62,8 @@ test.describe('Verify train schedule elements and filters', () => {
   });
 
   test.beforeEach('Go to scenario page', async ({ page }) => {
+    scenarioTimetableSection = new ScenarioTimetableSection(page);
+
     await page.goto(
       `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenarioItems.id}`
     );
@@ -69,9 +71,7 @@ test.describe('Verify train schedule elements and filters', () => {
   });
 
   /** *************** Test 1 **************** */
-  test('Select and delete all timetable items', async ({ page }) => {
-    scenarioTimetableSection = new ScenarioTimetableSection(page);
-
+  test('Select and delete all timetable items', async () => {
     await test.step('Verify initial totals', async () => {
       await scenarioTimetableSection.verifyTotalItemsLabel(frTranslations, {
         totalPacedTrainCount: TOTAL_PACED_TRAINS,

--- a/front/tests/017-paced-train-management.spec.ts
+++ b/front/tests/017-paced-train-management.spec.ts
@@ -70,7 +70,7 @@ const expectedOutputData: StationData[] = readJsonFile(
 
 const pacedTrainsJson = readJsonFile<[PacedTrain]>('./tests/assets/paced-train/paced_trains.json');
 
-test.describe('Verify simulation configuration in operational studies for train schedules and paced trains', () => {
+test.describe('@op @paced-trains', () => {
   let rollingstockSelector: RollingStockSelector;
   let operationalStudiesPage: OperationalStudiesPage;
   let scenarioTimetableSection: ScenarioTimetableSection;
@@ -148,7 +148,7 @@ test.describe('Verify simulation configuration in operational studies for train 
   });
 
   /** *************** Test 2 **************** */
-  test('Add a paced train and verify its timetable details', async ({ browserName }) => {
+  test('@smoke Add a paced train and verify its timetable details', async ({ browserName }) => {
     await test.step('Open timetable item form', async () => {
       await operationalStudiesPage.openTimetableItemForm();
     });

--- a/front/tests/018-train-edition.spec.ts
+++ b/front/tests/018-train-edition.spec.ts
@@ -49,7 +49,7 @@ const TIME_WINDOW = '240';
 const INTERVAL = '20';
 const EDITED_PACED_TRAIN_NAME = 'Paced train edited';
 
-test.describe('Edit train schedules and paced trains', () => {
+test.describe('@op @paced-train @train-schedule', () => {
   let scenarioTimetableSection: ScenarioTimetableSection;
   let operationalStudiesPage: OperationalStudiesPage;
   let pacedTrainSection: PacedTrainSection;

--- a/front/tests/019-scenario-page-synchronization.spec.ts
+++ b/front/tests/019-scenario-page-synchronization.spec.ts
@@ -20,6 +20,7 @@ import { getInfra, getProject, getStudy } from './utils/api-utils';
 import readJsonFile from './utils/file-utils';
 import { sendPacedTrains } from './utils/paced-train';
 import createScenario from './utils/scenario';
+import { deleteScenario } from './utils/teardown-utils';
 import sendTrainSchedules from './utils/train-schedule';
 import type {
   CommonTranslations,
@@ -65,7 +66,7 @@ test.describe('Synchronize the scenario page across multiple windows', () => {
 
   let project: Project;
   let study: Study;
-  let scenarioItems: Scenario;
+  let scenario: Scenario;
   let infra: Infra;
 
   test.beforeAll(
@@ -74,7 +75,7 @@ test.describe('Synchronize the scenario page across multiple windows', () => {
       project = await getProject(timetableItemProjectName);
       study = await getStudy(project.id, timetableItemStudyName);
       infra = await getInfra();
-      scenarioItems = (
+      scenario = (
         await createScenario(
           generateUniqueName('scenario-page-synchronization'),
           project.id,
@@ -83,11 +84,11 @@ test.describe('Synchronize the scenario page across multiple windows', () => {
         )
       ).scenario;
       await sendTrainSchedules(
-        scenarioItems.timetable_id,
+        scenario.timetable_id,
         JSON.parse(JSON.stringify(trainSchedulesJson.slice(0, 2)))
       );
       await sendPacedTrains(
-        scenarioItems.timetable_id,
+        scenario.timetable_id,
         JSON.parse(JSON.stringify(pacedTrainsJson.slice(0, 2)))
       );
     }
@@ -96,11 +97,12 @@ test.describe('Synchronize the scenario page across multiple windows', () => {
   test.afterAll('Close pages', async () => {
     await firstPage.close();
     await secondPage.close();
+    await deleteScenario(study.id, scenario.name);
   });
 
   /** *************** Test 1 **************** */
   test('Reflects updates across tabs', async ({ context }) => {
-    const scenarioUrl = `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenarioItems.id}`;
+    const scenarioUrl = `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenario.id}`;
 
     await test.step('Open first tab on scenario page and wait infra cache', async () => {
       firstPage = await context.newPage();
@@ -149,8 +151,8 @@ test.describe('Synchronize the scenario page across multiple windows', () => {
 
     await test.step('Go to study page in first tab, verify train count, delete scenario', async () => {
       await firstPage.goto(`/operational-studies/projects/${project.id}/studies/${study.id}`);
-      await studyPage.verifyScenarioTrainCount(scenarioItems.name, '3');
-      await studyPage.deleteScenario(scenarioItems.name);
+      await studyPage.verifyScenarioTrainCount(scenario.name, '3');
+      await studyPage.deleteScenario(scenario.name);
     });
 
     await test.step('Reload second tab and verify scenario is gone', async () => {

--- a/front/tests/019-scenario-page-synchronization.spec.ts
+++ b/front/tests/019-scenario-page-synchronization.spec.ts
@@ -55,7 +55,7 @@ test.skip(
   'This test is only stable on Chromium due to tab sync flakiness in Firefox'
 );
 
-test.describe('Synchronize the scenario page across multiple windows', () => {
+test.describe('@op @multi-tab-sync', () => {
   let firstPage: Page;
   let secondPage: Page;
   let firstTimetableSection: ScenarioTimetableSection;

--- a/front/tests/020-paced-train-exceptions.spec.ts
+++ b/front/tests/020-paced-train-exceptions.spec.ts
@@ -45,7 +45,7 @@ const frTranslations = {
 
 const pacedTrainsJson: PacedTrain[] = readJsonFile('./tests/assets/paced-train/paced_trains.json');
 
-test.describe('Paced trains and exception management', () => {
+test.describe('@op @paced-trains @exceptions', () => {
   let project: Project;
   let study: Study;
   let infra: Infra;
@@ -95,7 +95,7 @@ test.describe('Paced trains and exception management', () => {
   });
 
   /** *************** Test 1 **************** */
-  test('Edit a paced train and handle exceptions', async () => {
+  test('@smoke Edit a paced train and handle exceptions', async () => {
     const editedPacedTrainData = pacedTrainsJson[5];
 
     await test.step('Open action buttons for paced train at index 5', async () => {

--- a/front/tests/020-paced-train-exceptions.spec.ts
+++ b/front/tests/020-paced-train-exceptions.spec.ts
@@ -3,28 +3,16 @@ import { expect } from '@playwright/test';
 import type { Scenario, Project, Study, Infra, PacedTrain } from 'common/api/osrdEditoastApi';
 
 import {
-  electricRollingStockName,
   fastRollingStockName,
   slowRollingStockName,
   timetableItemProjectName,
   timetableItemStudyName,
 } from './assets/constants/project-const';
-import {
-  ADDED_EXCEPTION_MENU_BUTTONS,
-  ADDED_AND_MODIFIED_EXCEPTION_MENU_BUTTONS,
-  CONFORM_ACTIVE_OCCURRENCE_MENU_BUTTONS,
-  DISABLED_OCCURRENCE_MENU_BUTTONS,
-  EDITED_OCCURRENCE_NAME,
-  EXCEPTION_ACTIVE_OCCURRENCE_MENU_BUTTONS,
-  INITIAL_OCCURRENCE_NAME,
-} from './assets/paced-train/const';
+import { ADDED_EXCEPTION_MENU_BUTTONS } from './assets/paced-train/const';
 import test from './logging-fixture';
 import OperationalStudiesPage from './pages/operational-studies/operational-studies-page';
 import PacedTrainSection from './pages/operational-studies/paced-train-section';
-import RouteTab from './pages/operational-studies/route-tab';
 import ScenarioTimetableSection from './pages/operational-studies/scenario-timetable-section';
-import SimulationSettingsTab from './pages/operational-studies/simulation-settings-tab';
-import TimesAndStopsTab from './pages/operational-studies/times-and-stops-tab';
 import RollingStockSelector from './pages/rolling-stock/rolling-stock-selector';
 import { generateUniqueName, waitForInfraStateToBeCached } from './utils';
 import { getInfra, getProject, getStudy } from './utils/api-utils';
@@ -49,15 +37,13 @@ const frScenarioTranslations: TimetableFilterTranslations = readJsonFile<{
 
 const frCommonTranslations: CommonTranslations = readJsonFile('public/locales/fr/translation.json');
 
-const frTranslations: ManageTimetableItemTranslations &
-  TimetableFilterTranslations &
-  CommonTranslations = {
+const frTranslations = {
   ...frManageTimetableItemTranslations,
   ...frScenarioTranslations,
   ...frCommonTranslations,
 };
 
-const pacedTrainsJson = readJsonFile<PacedTrain[]>('./tests/assets/paced-train/paced_trains.json');
+const pacedTrainsJson: PacedTrain[] = readJsonFile('./tests/assets/paced-train/paced_trains.json');
 
 test.describe('Paced trains and exception management', () => {
   let project: Project;
@@ -68,9 +54,6 @@ test.describe('Paced trains and exception management', () => {
   let operationalStudiesPage: OperationalStudiesPage;
   let pacedTrainSection: PacedTrainSection;
   let rollingStockSelector: RollingStockSelector;
-  let routeTab: RouteTab;
-  let timesAndStopsTab: TimesAndStopsTab;
-  let simulationSettingsTab: SimulationSettingsTab;
 
   let scenarioItems: Scenario;
 
@@ -92,23 +75,13 @@ test.describe('Paced trains and exception management', () => {
   test.beforeEach(
     'Navigate to scenario page and wait for infrastructure to be loaded',
     async ({ page }) => {
-      [
-        pacedTrainSection,
-        scenarioTimetableSection,
-        operationalStudiesPage,
-        rollingStockSelector,
-        routeTab,
-        timesAndStopsTab,
-        simulationSettingsTab,
-      ] = [
-        new PacedTrainSection(page),
-        new ScenarioTimetableSection(page),
-        new OperationalStudiesPage(page),
-        new RollingStockSelector(page),
-        new RouteTab(page),
-        new TimesAndStopsTab(page),
-        new SimulationSettingsTab(page),
-      ];
+      [pacedTrainSection, scenarioTimetableSection, operationalStudiesPage, rollingStockSelector] =
+        [
+          new PacedTrainSection(page),
+          new ScenarioTimetableSection(page),
+          new OperationalStudiesPage(page),
+          new RollingStockSelector(page),
+        ];
 
       await page.goto(
         `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenarioItems.id}`
@@ -144,7 +117,6 @@ test.describe('Paced trains and exception management', () => {
       await rollingStockSelector.searchRollingstock(fastRollingStockName);
       await rollingStockSelector.selectRollingStockCard({
         name: fastRollingStockName,
-        selectComfort: false,
         confirmSelection: true,
       });
       await expect(rollingStockSelector.selectedRollingStockName).toHaveText(fastRollingStockName);
@@ -293,183 +265,6 @@ test.describe('Paced trains and exception management', () => {
         expectedButtons: ADDED_EXCEPTION_MENU_BUTTONS,
         translations: frTranslations,
       });
-    });
-  });
-
-  /** *************** Test 3 **************** */
-  test('Edit an indexed occurrence', async () => {
-    await test.step('Open paced train and check initial menu (first occurrence)', async () => {
-      await pacedTrainSection.expandPacedTrainOccurrenceList(0);
-      await pacedTrainSection.checkOccurrenceMenuIcon(0);
-      await pacedTrainSection.checkOccurrenceActionMenu({
-        occurrenceIndex: 0,
-        expectedButtons: CONFORM_ACTIVE_OCCURRENCE_MENU_BUTTONS,
-        translations: frTranslations,
-      });
-    });
-
-    await test.step('Edit occurrence name and save', async () => {
-      await pacedTrainSection.clickOccurrenceMenuButton('edit');
-      await operationalStudiesPage.setTimetableItemName(EDITED_OCCURRENCE_NAME);
-      await operationalStudiesPage.updateTimetableItem(frTranslations.pacedTrains.updatePacedTrain);
-      await operationalStudiesPage.checkToastHasBeenLaunched(
-        frTranslations.timetable.pacedTrainUpdated
-      );
-    });
-
-    await test.step('Verify edited occurrence tooltip and menu', async () => {
-      await pacedTrainSection.checkExceptionTooltip(
-        0,
-        frTranslations.timetable.occurrenceType.editedOccurrence +
-          frTranslations.timetable.occurrenceChangeGroup.train_name
-      );
-      await pacedTrainSection.checkOccurrenceMenuIcon(0);
-      await pacedTrainSection.checkOccurrenceActionMenu({
-        occurrenceIndex: 0,
-        expectedButtons: EXCEPTION_ACTIVE_OCCURRENCE_MENU_BUTTONS,
-        translations: frTranslations,
-      });
-    });
-
-    await test.step('Disable edited occurrence and verify UI', async () => {
-      await pacedTrainSection.clickOccurrenceMenuButton('disable');
-      await pacedTrainSection.verifyOccurrenceName(0, EDITED_OCCURRENCE_NAME);
-      await pacedTrainSection.checkOccurrenceMenuIcon(0);
-      await pacedTrainSection.checkOccurrenceActionMenu({
-        occurrenceIndex: 0,
-        expectedButtons: DISABLED_OCCURRENCE_MENU_BUTTONS,
-        translations: frTranslations,
-      });
-    });
-
-    await test.step('Re-enable edited occurrence and verify UI', async () => {
-      await pacedTrainSection.clickOccurrenceMenuButton('enable');
-      await pacedTrainSection.verifyOccurrenceName(0, EDITED_OCCURRENCE_NAME);
-      await pacedTrainSection.checkOccurrenceMenuIcon(0);
-      await pacedTrainSection.checkOccurrenceActionMenu({
-        occurrenceIndex: 0,
-        expectedButtons: EXCEPTION_ACTIVE_OCCURRENCE_MENU_BUTTONS,
-        translations: frTranslations,
-      });
-    });
-
-    await test.step('Restore occurrence to initial model', async () => {
-      await pacedTrainSection.clickOccurrenceMenuButton('restore');
-      await pacedTrainSection.verifyOccurrenceName(0, INITIAL_OCCURRENCE_NAME);
-    });
-  });
-
-  /** *************** Test 4 **************** */
-  test('Edit added exception', async () => {
-    const PACED_TRAIN_NUMBER = 4;
-    const addedOccurrenceIndex = 1;
-    const editedPacedTrainData = pacedTrainsJson[PACED_TRAIN_NUMBER];
-
-    await test.step('Open paced train and check initial menu state', async () => {
-      await pacedTrainSection.expandPacedTrainOccurrenceList(PACED_TRAIN_NUMBER);
-      await pacedTrainSection.checkOccurrenceMenuIcon(addedOccurrenceIndex);
-      await pacedTrainSection.checkOccurrenceActionMenu({
-        occurrenceIndex: addedOccurrenceIndex,
-        expectedButtons: ADDED_EXCEPTION_MENU_BUTTONS,
-        translations: frTranslations,
-      });
-    });
-
-    await test.step('Open exception edit menu', async () => {
-      await pacedTrainSection.clickOccurrenceMenuButton('edit');
-      await operationalStudiesPage.checkEditOccurrenceButtonsVisibility();
-    });
-
-    await test.step('Modify RS, route, start time and simulation params', async () => {
-      await rollingStockSelector.openRollingstockModal();
-      await rollingStockSelector.selectRollingStockCard({
-        name: electricRollingStockName,
-        confirmSelection: true,
-      });
-
-      await operationalStudiesPage.openRouteTab();
-      await routeTab.performPathfindingByTrigram({
-        originTrigram: 'WS',
-        destinationTrigram: 'NES',
-      });
-
-      await operationalStudiesPage.setTimetableItemStartTime('02:40', '2024-10-16');
-
-      await operationalStudiesPage.openTimesAndStopsTab();
-      await timesAndStopsTab.fillTableCellByStationAndHeader(
-        'Mid_East_station',
-        frTranslations.timeStopTable.stopTime,
-        '18000'
-      );
-
-      await operationalStudiesPage.openSimulationSettingsTab();
-      await simulationSettingsTab.selectSpeedLimitTagOption('MA100');
-
-      await operationalStudiesPage.submitTimetableItemEdit();
-      await operationalStudiesPage.checkToastHasBeenLaunched(
-        frTranslations.timetable.pacedTrainUpdated
-      );
-    });
-
-    await test.step('Check exception tooltip after modifications', async () => {
-      await pacedTrainSection.checkExceptionTooltip(
-        addedOccurrenceIndex,
-        frTranslations.timetable.occurrenceType.addedOccurrence,
-        frTranslations.timetable.occurrenceChangeGroup.path_and_schedule as ChangeGroup,
-        frTranslations.timetable.occurrenceChangeGroup.rolling_stock as ChangeGroup,
-        frTranslations.timetable.occurrenceChangeGroup.speed_limit_tag as ChangeGroup,
-        frTranslations.timetable.occurrenceChangeGroup.start_time as ChangeGroup
-      );
-    });
-
-    await test.step('Check occurrence menu after modifications', async () => {
-      await pacedTrainSection.checkOccurrenceMenuIcon(addedOccurrenceIndex);
-      await pacedTrainSection.checkOccurrenceActionMenu({
-        occurrenceIndex: addedOccurrenceIndex,
-        expectedButtons: ADDED_AND_MODIFIED_EXCEPTION_MENU_BUTTONS,
-        translations: frTranslations,
-      });
-    });
-
-    await test.step('Restore occurrence to model', async () => {
-      await pacedTrainSection.clickOccurrenceMenuButton('restore');
-      await pacedTrainSection.verifyOccurrenceDetails(
-        {
-          name: `${editedPacedTrainData.train_name}/+`,
-          startTime: '02:40',
-          arrivalTime: '02:47',
-        },
-        addedOccurrenceIndex
-      );
-
-      await pacedTrainSection.checkOccurrenceMenuIcon(addedOccurrenceIndex);
-      await pacedTrainSection.checkOccurrenceActionMenu({
-        occurrenceIndex: addedOccurrenceIndex,
-        expectedButtons: ADDED_EXCEPTION_MENU_BUTTONS,
-        translations: frTranslations,
-      });
-    });
-
-    await test.step('Delete occurrence and check remaining ones', async () => {
-      await pacedTrainSection.clickOccurrenceMenuButton('delete');
-
-      await pacedTrainSection.expectOccurrencesListLength(2);
-      await pacedTrainSection.verifyOccurrenceDetails(
-        {
-          name: `${editedPacedTrainData.train_name} 1`,
-          startTime: '02:00',
-          arrivalTime: '02:07',
-        },
-        0
-      );
-      await pacedTrainSection.verifyOccurrenceDetails(
-        {
-          name: `${editedPacedTrainData.train_name} 3`,
-          startTime: '03:00',
-          arrivalTime: '03:07',
-        },
-        1
-      );
     });
   });
 });

--- a/front/tests/020-paced-train-exceptions.spec.ts
+++ b/front/tests/020-paced-train-exceptions.spec.ts
@@ -74,23 +74,20 @@ test.describe('Paced trains and exception management', () => {
 
   let scenarioItems: Scenario;
 
-  test.beforeAll(
-    'Setup project, study, infra and create scenario with timetableItems',
-    async () => {
-      project = await getProject(timetableItemProjectName);
-      study = await getStudy(project.id, timetableItemStudyName);
-      infra = await getInfra();
-      scenarioItems = (
-        await createScenario(
-          generateUniqueName('edit-train-scenario'),
-          project.id,
-          study.id,
-          infra.id
-        )
-      ).scenario;
-      await sendPacedTrains(scenarioItems.timetable_id, pacedTrainsJson.slice(0, 6));
-    }
-  );
+  test.beforeAll('Setup project, study, infra and create scenario with paced trains', async () => {
+    project = await getProject(timetableItemProjectName);
+    study = await getStudy(project.id, timetableItemStudyName);
+    infra = await getInfra();
+    scenarioItems = (
+      await createScenario(
+        generateUniqueName('paced-trains-scenario'),
+        project.id,
+        study.id,
+        infra.id
+      )
+    ).scenario;
+    await sendPacedTrains(scenarioItems.timetable_id, pacedTrainsJson.slice(0, 6));
+  });
 
   test.beforeEach(
     'Navigate to scenario page and wait for infrastructure to be loaded',
@@ -161,7 +158,7 @@ test.describe('Paced trains and exception management', () => {
       );
     });
 
-    await test.step('Verify all occurrences (4 occurrences including 1 added exception )', async () => {
+    await test.step('Verify all occurrences (4 occurrences including 1 added exception)', async () => {
       await pacedTrainSection.verifyOccurrenceDetails(
         {
           name: `${editedPacedTrainData.train_name}/+`,

--- a/front/tests/021-get-manchette.spec.ts
+++ b/front/tests/021-get-manchette.spec.ts
@@ -65,7 +65,7 @@ test.skip(
   'Limit to Chromium for GitHub snapshots storage optimization'
 );
 
-test.describe('Verify manchette and space time diagram', () => {
+test.describe('@op @manchette @std', () => {
   let simulationResultPage: OpSimulationResultPage;
   let scenarioTimetableSection: ScenarioTimetableSection;
   let pacedTrainSection: PacedTrainSection;
@@ -111,7 +111,7 @@ test.describe('Verify manchette and space time diagram', () => {
   });
 
   /** *************** Test 1 **************** */
-  test('Basic checks for STD/Manchette', async () => {
+  test('@smoke Basic checks for STD/Manchette', async () => {
     await test.step('Verify first train schedule is selected', async () => {
       await scenarioTimetableSection.verifyFirstTimetableItemIsSelected();
       await simulationResultPage.setTrainListVisible();

--- a/front/tests/021-get-manchette.spec.ts
+++ b/front/tests/021-get-manchette.spec.ts
@@ -64,6 +64,7 @@ test.skip(
   ({ browserName }) => browserName !== 'chromium',
   'Limit to Chromium for GitHub snapshots storage optimization'
 );
+
 test.describe('Verify manchette and space time diagram', () => {
   let simulationResultPage: OpSimulationResultPage;
   let scenarioTimetableSection: ScenarioTimetableSection;
@@ -81,7 +82,7 @@ test.describe('Verify manchette and space time diagram', () => {
     infra = await getInfra();
     scenarioItems = (
       await createScenario(
-        generateUniqueName('edit-train-scenario'),
+        generateUniqueName('std-manchette-scenario'),
         project.id,
         study.id,
         infra.id
@@ -109,6 +110,7 @@ test.describe('Verify manchette and space time diagram', () => {
     await deleteScenario(study.id, scenarioItems.name);
   });
 
+  /** *************** Test 1 **************** */
   test('Basic checks for STD/Manchette', async () => {
     await test.step('Verify first train schedule is selected', async () => {
       await scenarioTimetableSection.verifyFirstTimetableItemIsSelected();
@@ -136,6 +138,7 @@ test.describe('Verify manchette and space time diagram', () => {
     });
   });
 
+  /** *************** Test 2 **************** */
   test.skip('Space time diagram (temporarily skipped until STD snapshots are stable)', async () => {
     await test.step('Project train schedule and capture GET screenshot', async () => {
       await scenarioTimetableSection.projectTrain();
@@ -209,7 +212,8 @@ test.describe('Verify manchette and space time diagram', () => {
     });
   });
 
-  test('Manchette', async () => {
+  /** *************** Test 3 **************** */
+  test('Manchette waypoints data', async () => {
     await test.step('Project train schedule and verify waypoints list', async () => {
       await scenarioTimetableSection.projectTrain();
       await simulationResultPage.setTrainListVisible();

--- a/front/tests/022-round-trips.spec.ts
+++ b/front/tests/022-round-trips.spec.ts
@@ -52,6 +52,7 @@ test.describe('Verify round trips', () => {
 
   test.beforeEach('Open scenario & round-trip modal', async ({ page }) => {
     roundTripPage = new RoundTripPage(page);
+
     await test.step('Create, open scenario and wait for infra to be loaded', async () => {
       scenarioItems = (
         await createScenario(
@@ -80,6 +81,7 @@ test.describe('Verify round trips', () => {
     await deleteScenario(study.id, scenarioItems.name);
   });
 
+  /** *************** Test 1 **************** */
   test('Basic checks round trips', async () => {
     await test.step('Verify round trips elements are visible', async () => {
       await roundTripPage.verifyRoundTripsModalElements(
@@ -98,6 +100,7 @@ test.describe('Verify round trips', () => {
     });
   });
 
+  /** *************** Test 2 **************** */
   test('Verify round trip cards: paced trains and schedules', async () => {
     await test.step('First paced train - data & no tooltip', async () => {
       await roundTripPage.verifyRoundTripCardData({
@@ -147,6 +150,8 @@ test.describe('Verify round trips', () => {
       await roundTripPage.checkIntermediateStopsTooltip({ roundTripCardIndex: 5 });
     });
   });
+
+  /** *************** Test 3 **************** */
   test('Cancel round trip items', async () => {
     await test.step('Move 1 item from To-do → One-way (not yet saved)', async () => {
       await roundTripPage.setTodoCardToOneWay({
@@ -171,6 +176,7 @@ test.describe('Verify round trips', () => {
     });
   });
 
+  /** *************** Test 4 **************** */
   test('Save round trip items', async () => {
     await test.step('Move 1 item from To-do → One-way', async () => {
       await roundTripPage.setTodoCardToOneWay({
@@ -195,6 +201,7 @@ test.describe('Verify round trips', () => {
     });
   });
 
+  /** *************** Test 5 **************** */
   test('Set One-way trip', async () => {
     await test.step('Filter item by name → verify filtered counts', async () => {
       await roundTripPage.searchForRoundTripsCard({
@@ -229,6 +236,7 @@ test.describe('Verify round trips', () => {
     });
   });
 
+  /** *************** Test 6 **************** */
   test('Create and undo Round trips', async () => {
     await test.step('Pair first One-way with its return', async () => {
       await roundTripPage.pickReturnForOneWayCard({
@@ -252,7 +260,7 @@ test.describe('Verify round trips', () => {
       });
     });
 
-    await test.step('restore the most recent Round trip back to To-do', async () => {
+    await test.step('Restore the most recent Round trip back to To-do', async () => {
       await roundTripPage.restoreRoundTripCardsToTodo({
         index: 1,
         toDoCount: 4,
@@ -261,7 +269,7 @@ test.describe('Verify round trips', () => {
       });
     });
 
-    await test.step('restore the remaining Round trip all back to To-do', async () => {
+    await test.step('Restore the remaining Round trip all back to To-do', async () => {
       await roundTripPage.restoreRoundTripCardsToTodo({
         index: 0,
         toDoCount: 6,

--- a/front/tests/022-round-trips.spec.ts
+++ b/front/tests/022-round-trips.spec.ts
@@ -36,7 +36,7 @@ const trainSchedulesJson = readJsonFile<TrainSchedule[]>(
 );
 const pacedTrainsJson = readJsonFile<PacedTrain[]>('./tests/assets/paced-train/paced_trains.json');
 
-test.describe('Verify round trips', () => {
+test.describe('@op @timetable-items @round-trips', () => {
   let roundTripPage: RoundTripPage;
 
   let project: Project;
@@ -101,7 +101,7 @@ test.describe('Verify round trips', () => {
   });
 
   /** *************** Test 2 **************** */
-  test('Verify round trip cards: paced trains and schedules', async () => {
+  test('@smoke Verify round trip cards: paced trains and schedules', async () => {
     await test.step('First paced train - data & no tooltip', async () => {
       await roundTripPage.verifyRoundTripCardData({
         roundTripCardIndex: 0,
@@ -177,7 +177,7 @@ test.describe('Verify round trips', () => {
   });
 
   /** *************** Test 4 **************** */
-  test('Save round trip items', async () => {
+  test('@smoke Save round trip items', async () => {
     await test.step('Move 1 item from To-do → One-way', async () => {
       await roundTripPage.setTodoCardToOneWay({
         index: 0,

--- a/front/tests/023-osrd-nge.spec.ts
+++ b/front/tests/023-osrd-nge.spec.ts
@@ -20,7 +20,7 @@ const frTranslations: TimetableFilterTranslations = readJsonFile<{
   main: TimetableFilterTranslations;
 }>('public/locales/fr/operational-studies.json').main;
 
-test.describe('Verify osrd nge conversion', () => {
+test.describe('@op @nge', () => {
   test.use({ ignorePageErrors: true });
 
   let ngePage: NGEPage;

--- a/front/tests/023-osrd-nge.spec.ts
+++ b/front/tests/023-osrd-nge.spec.ts
@@ -37,9 +37,10 @@ test.describe('Verify osrd nge conversion', () => {
     infra = await getInfra();
   });
 
-  test.beforeEach('Open scenario and enable only macro view ', async ({ page }) => {
+  test.beforeEach('Open scenario and enable only macro view', async ({ page }) => {
     ngePage = new NGEPage(page);
     scenarioTimetableSection = new ScenarioTimetableSection(page);
+
     // scenario header is persisted in local storage, clear it before loading the scenario
     await page.addInitScript(() => {
       window.localStorage.clear();
@@ -65,6 +66,7 @@ test.describe('Verify osrd nge conversion', () => {
     await deleteScenario(study.id, scenarioItems.name);
   });
 
+  /** *************** Test 1 **************** */
   test('Verify NGE train data', async () => {
     await test.step('Verify nodes displayed on NGE graph', async () => {
       await ngePage.expectNodes(['SWS/BV', 'MWS/BV', 'MES/BV']);
@@ -107,6 +109,7 @@ test.describe('Verify osrd nge conversion', () => {
     });
   });
 
+  /** *************** Test 2 **************** */
   test('Delete a train from train list', async ({ page }) => {
     await test.step('Delete train from timetable list', async () => {
       await scenarioTimetableSection.deleteTimetableItem();
@@ -129,6 +132,7 @@ test.describe('Verify osrd nge conversion', () => {
     });
   });
 
+  /** *************** Test 3 **************** */
   test('Delete a train from NGE', async ({ page }) => {
     await test.step('Delete first node via dialog (expect 2 nodes, 1 line)', async () => {
       await ngePage.deleteNodeByIndexViaDialog(0, { nodes: 2, lines: 1 });

--- a/front/tests/024-nge-osrd.spec.ts
+++ b/front/tests/024-nge-osrd.spec.ts
@@ -24,7 +24,7 @@ const frTranslations = {
   ...frCommonTranslations,
 };
 
-test.describe('Verify nge osrd conversion', () => {
+test.describe('@op @nge @round-trips', () => {
   test.use({ ignorePageErrors: true });
 
   let ngePage: NGEPage;
@@ -67,7 +67,7 @@ test.describe('Verify nge osrd conversion', () => {
   });
 
   /** *************** Test 1 **************** */
-  test('Add a train from NGE', async () => {
+  test('@smoke Add a train from NGE', async () => {
     await test.step('Create three nodes', async () => {
       await ngePage.createNode({ x: 50, y: 400 }, 'NWS', 'Origin');
       await expect(ngePage.nodeCards).toHaveCount(1);

--- a/front/tests/024-nge-osrd.spec.ts
+++ b/front/tests/024-nge-osrd.spec.ts
@@ -42,7 +42,7 @@ test.describe('Verify nge osrd conversion', () => {
     infra = await getInfra();
   });
 
-  test.beforeEach('Open scenario and enable only macro view ', async ({ page }) => {
+  test.beforeEach('Open scenario and enable only macro view', async ({ page }) => {
     ngePage = new NGEPage(page);
     scenarioTimetableSection = new ScenarioTimetableSection(page);
     roundTripPage = new RoundTripPage(page);
@@ -66,7 +66,8 @@ test.describe('Verify nge osrd conversion', () => {
     await deleteScenario(study.id, scenarioItems.name);
   });
 
-  test('Add a train from nge', async () => {
+  /** *************** Test 1 **************** */
+  test('Add a train from NGE', async () => {
     await test.step('Create three nodes', async () => {
       await ngePage.createNode({ x: 50, y: 400 }, 'NWS', 'Origin');
       await expect(ngePage.nodeCards).toHaveCount(1);

--- a/front/tests/025-rolling-stock-filter.spec.ts
+++ b/front/tests/025-rolling-stock-filter.spec.ts
@@ -1,0 +1,84 @@
+import { expect } from '@playwright/test';
+
+import { dualModeRollingStockName } from './assets/constants/project-const';
+import test from './logging-fixture';
+import RollingstockEditorPage from './pages/rolling-stock/rolling-stock-editor-page';
+
+test.describe('Filtering rolling stocks', () => {
+  let rollingStockEditorPage: RollingstockEditorPage;
+
+  test.beforeEach('Navigate to editor page', async ({ page }) => {
+    rollingStockEditorPage = new RollingstockEditorPage(page);
+    await rollingStockEditorPage.navigateToRollingStockPage();
+  });
+
+  /** *************** Test 1 **************** */
+  test('Filtering rolling stocks', async () => {
+    const initialRollingStockFoundNumber =
+      await rollingStockEditorPage.getRollingStockSearchNumber();
+
+    await test.step('Toggle Electric filter and verify count', async () => {
+      await rollingStockEditorPage.toggleElectricRollingStockFilter();
+      expect(await rollingStockEditorPage.electricRollingStockIcons.count()).toEqual(
+        await rollingStockEditorPage.getRollingStockSearchNumber()
+      );
+    });
+
+    await test.step('Clear Electric filter and verify initial count', async () => {
+      await rollingStockEditorPage.toggleElectricRollingStockFilter();
+      expect(await rollingStockEditorPage.rollingStockList.count()).toBeGreaterThanOrEqual(
+        initialRollingStockFoundNumber
+      );
+    });
+
+    await test.step('Toggle Thermal filter and verify count', async () => {
+      await rollingStockEditorPage.toggleThermalRollingStockFilter();
+      expect(await rollingStockEditorPage.thermalRollingStockIcons.count()).toEqual(
+        await rollingStockEditorPage.getRollingStockSearchNumber()
+      );
+    });
+
+    await test.step('Toggle Electric with Thermal on (dual-mode) and verify count', async () => {
+      await rollingStockEditorPage.toggleElectricRollingStockFilter();
+      expect(await rollingStockEditorPage.dualModeRollingStockIcons.count()).toEqual(
+        await rollingStockEditorPage.getRollingStockSearchNumber()
+      );
+    });
+
+    await test.step('Clear both filters and verify count resets', async () => {
+      await rollingStockEditorPage.toggleElectricRollingStockFilter();
+      await rollingStockEditorPage.toggleThermalRollingStockFilter();
+      const currentCount = await rollingStockEditorPage.rollingStockList.count();
+      expect(currentCount).toEqual(initialRollingStockFoundNumber);
+    });
+  });
+
+  /** *************** Test 2 **************** */
+  test('Search for a rolling stock', async () => {
+    const initialRollingStockFoundNumber =
+      await rollingStockEditorPage.getRollingStockSearchNumber();
+
+    await test.step('Search a specific rolling stock and verify icons', async () => {
+      await rollingStockEditorPage.searchRollingStock(dualModeRollingStockName);
+      expect(
+        rollingStockEditorPage.page.getByTestId(`rollingstock-${dualModeRollingStockName}`)
+      ).toBeDefined();
+
+      await expect(rollingStockEditorPage.thermalRollingStockFirstIcon).toBeVisible();
+      await expect(rollingStockEditorPage.electricRollingStockFirstIcon).toBeVisible();
+    });
+
+    await test.step('Clear search and verify count resets', async () => {
+      await rollingStockEditorPage.clearSearchRollingStock();
+      expect(await rollingStockEditorPage.rollingStockList.count()).toEqual(
+        initialRollingStockFoundNumber
+      );
+    });
+
+    await test.step('Search a non-existent rolling stock → expect no results', async () => {
+      await rollingStockEditorPage.searchRollingStock(`${dualModeRollingStockName}-no-results`);
+      await expect(rollingStockEditorPage.noRollingStockResult).toBeVisible();
+      expect(await rollingStockEditorPage.getRollingStockSearchNumber()).toEqual(0);
+    });
+  });
+});

--- a/front/tests/025-rolling-stock-filter.spec.ts
+++ b/front/tests/025-rolling-stock-filter.spec.ts
@@ -4,7 +4,7 @@ import { dualModeRollingStockName } from './assets/constants/project-const';
 import test from './logging-fixture';
 import RollingstockEditorPage from './pages/rolling-stock/rolling-stock-editor-page';
 
-test.describe('Filtering rolling stocks', () => {
+test.describe('@rs-editor @filter', () => {
   let rollingStockEditorPage: RollingstockEditorPage;
 
   test.beforeEach('Navigate to editor page', async ({ page }) => {

--- a/front/tests/026-train-timetable-filter.spec.ts
+++ b/front/tests/026-train-timetable-filter.spec.ts
@@ -41,7 +41,7 @@ const frTranslations = {
   ...frCommonTranslations,
 };
 
-test.describe('Filtering imported timetable items', () => {
+test.describe('@op @timetable-items @filter', () => {
   let scenarioTimetableSection: ScenarioTimetableSection;
 
   let project: Project;

--- a/front/tests/026-train-timetable-filter.spec.ts
+++ b/front/tests/026-train-timetable-filter.spec.ts
@@ -1,0 +1,184 @@
+import type { Scenario, Project, Study, Infra } from 'common/api/osrdEditoastApi';
+
+import {
+  timetableItemProjectName,
+  timetableItemScenarioName,
+  timetableItemStudyName,
+} from './assets/constants/project-const';
+import {
+  HONORED_TIMETABLE_ITEMS,
+  INVALID_TIMETABLE_ITEMS,
+  ITEMS_WITH_HLP_SPEED_LIMIT_TAG_EXCEPTION,
+  TIMETABLE_ITEMS_WITH_NO_SPEED_LIMIT_TAG,
+  LABEL_FILTERED_TIMETABLE_ITEMS,
+  LABEL_FILTERED_TIMETABLE_ITEMS_EXCEPTION,
+  NAME_FILTERED_TIMETABLE_ITEMS,
+  NAME_FILTERED_TIMETABLE_ITEMS_EXCEPTION,
+  NAME_LABEL_FILTERED_TIMETABLE_ITEMS_MIXED,
+  NOT_HONORED_TIMETABLE_ITEMS,
+  NOT_HONORED_PACED_TRAIN_SCHEDULE,
+  ROLLING_STOCK_FILTERED_TIMETABLE_ITEMS_EXCEPTION,
+  TOTAL_TIMETABLE_ITEMS,
+  TOTAL_PACED_TRAINS,
+  TOTAL_TRAIN_SCHEDULES,
+  VALID_TIMETABLE_ITEMS,
+  VALID_PACED_TRAINS,
+} from './assets/constants/timetable-items-count';
+import test from './logging-fixture';
+import ScenarioTimetableSection from './pages/operational-studies/scenario-timetable-section';
+import { waitForInfraStateToBeCached } from './utils';
+import { getInfra, getProject, getScenario, getStudy } from './utils/api-utils';
+import readJsonFile from './utils/file-utils';
+import type { CommonTranslations, TimetableFilterTranslations } from './utils/types';
+
+const frScenarioTranslations: TimetableFilterTranslations = readJsonFile<{
+  main: TimetableFilterTranslations;
+}>('public/locales/fr/operational-studies.json').main;
+
+const frCommonTranslations: CommonTranslations = readJsonFile('public/locales/fr/translation.json');
+const frTranslations = {
+  ...frScenarioTranslations,
+  ...frCommonTranslations,
+};
+
+test.describe('Filtering imported timetable items', () => {
+  let scenarioTimetableSection: ScenarioTimetableSection;
+
+  let project: Project;
+  let study: Study;
+  let scenario: Scenario;
+  let infra: Infra;
+
+  test.beforeAll('Fetch project, study and scenario with train schedule', async () => {
+    project = await getProject(timetableItemProjectName);
+    study = await getStudy(project.id, timetableItemStudyName);
+    scenario = await getScenario(study.id, timetableItemScenarioName);
+    infra = await getInfra();
+  });
+
+  test.beforeEach(
+    'Navigate to scenario page and wait for infrastructure to be loaded',
+    async ({ page }) => {
+      scenarioTimetableSection = new ScenarioTimetableSection(page);
+
+      await page.goto(
+        `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenario.id}`
+      );
+      await waitForInfraStateToBeCached(infra.id);
+    }
+  );
+
+  /** *************** Test 1 **************** */
+  test('Filtering imported timetable items', async () => {
+    await test.step('Verify totals and default filter UI', async () => {
+      await scenarioTimetableSection.verifyTotalItemsLabel(frTranslations, {
+        totalPacedTrainCount: TOTAL_PACED_TRAINS,
+        totalTrainScheduleCount: TOTAL_TRAIN_SCHEDULES,
+      });
+      await scenarioTimetableSection.checkTimetableFilterVisibilityLabelDefaultValue(
+        frTranslations.timetable,
+        { inputDefaultValue: '', selectDefaultValue: 'both' }
+      );
+    });
+
+    await test.step('Filter by name / label (standard)', async () => {
+      await scenarioTimetableSection.filterNameAndVerifyTrainCount(
+        'Paced Train - Updated exception (Train name)',
+        NAME_FILTERED_TIMETABLE_ITEMS
+      );
+      await scenarioTimetableSection.filterNameAndVerifyTrainCount(
+        'Paced-Train-Tag-2',
+        LABEL_FILTERED_TIMETABLE_ITEMS
+      );
+    });
+
+    await test.step('Filter by name / label (exceptions & mixed)', async () => {
+      await scenarioTimetableSection.filterNameAndVerifyTrainCount(
+        'abc',
+        NAME_FILTERED_TIMETABLE_ITEMS_EXCEPTION
+      );
+      await scenarioTimetableSection.filterNameAndVerifyTrainCount(
+        'exception',
+        NAME_LABEL_FILTERED_TIMETABLE_ITEMS_MIXED
+      );
+      await scenarioTimetableSection.filterNameAndVerifyTrainCount(
+        'exception-label',
+        LABEL_FILTERED_TIMETABLE_ITEMS_EXCEPTION
+      );
+    });
+
+    await test.step('Filter by rolling stock', async () => {
+      await scenarioTimetableSection.filterRollingStockAndVerifyTrainCount(
+        'slow_rolling_stock',
+        ROLLING_STOCK_FILTERED_TIMETABLE_ITEMS_EXCEPTION
+      );
+    });
+
+    await test.step('Filter by validity', async () => {
+      await scenarioTimetableSection.filterValidityAndVerifyTrainCount(
+        'Invalid',
+        INVALID_TIMETABLE_ITEMS,
+        frTranslations
+      );
+      await scenarioTimetableSection.filterValidityAndVerifyTrainCount(
+        'Valid',
+        VALID_TIMETABLE_ITEMS,
+        frTranslations
+      );
+    });
+
+    await test.step('Filter by punctuality (Honored/Not honored)', async () => {
+      await scenarioTimetableSection.filterHonoredAndVerifyTrainCount(
+        'Honored',
+        HONORED_TIMETABLE_ITEMS,
+        frTranslations
+      );
+      await scenarioTimetableSection.filterHonoredAndVerifyTrainCount(
+        'Not honored',
+        NOT_HONORED_TIMETABLE_ITEMS,
+        frTranslations
+      );
+    });
+
+    await test.step('Filter by train type', async () => {
+      await scenarioTimetableSection.filterTrainTypeAndVerifyTrainCount(
+        'Service',
+        NOT_HONORED_PACED_TRAIN_SCHEDULE
+      );
+      await scenarioTimetableSection.filterHonoredAndVerifyTrainCount(
+        'All',
+        VALID_PACED_TRAINS,
+        frTranslations
+      );
+      await scenarioTimetableSection.filterValidityAndVerifyTrainCount(
+        'All',
+        TOTAL_PACED_TRAINS,
+        frTranslations
+      );
+      await scenarioTimetableSection.filterTrainTypeAndVerifyTrainCount(
+        'Unique train',
+        TOTAL_TRAIN_SCHEDULES
+      );
+      await scenarioTimetableSection.filterTrainTypeAndVerifyTrainCount(
+        'All',
+        TOTAL_TIMETABLE_ITEMS
+      );
+    });
+
+    await test.step('Filter by speed limit tag and verify counts', async () => {
+      await scenarioTimetableSection.filterSpeedLimitTagAndVerifyTrainCount(
+        null,
+        TIMETABLE_ITEMS_WITH_NO_SPEED_LIMIT_TAG,
+        frTranslations
+      );
+      await scenarioTimetableSection.verifyTimetableItemsCount(TOTAL_TIMETABLE_ITEMS);
+
+      await scenarioTimetableSection.filterSpeedLimitTagAndVerifyTrainCount(
+        'HLP',
+        ITEMS_WITH_HLP_SPEED_LIMIT_TAG_EXCEPTION,
+        frTranslations
+      );
+      await scenarioTimetableSection.verifyTimetableItemsCount(TOTAL_TIMETABLE_ITEMS);
+    });
+  });
+});

--- a/front/tests/027-paced-train-occurrence-edition.spec.ts
+++ b/front/tests/027-paced-train-occurrence-edition.spec.ts
@@ -1,0 +1,289 @@
+import type { Scenario, Project, Study, Infra, PacedTrain } from 'common/api/osrdEditoastApi';
+
+import {
+  electricRollingStockName,
+  timetableItemProjectName,
+  timetableItemStudyName,
+} from './assets/constants/project-const';
+import {
+  ADDED_EXCEPTION_MENU_BUTTONS,
+  ADDED_AND_MODIFIED_EXCEPTION_MENU_BUTTONS,
+  CONFORM_ACTIVE_OCCURRENCE_MENU_BUTTONS,
+  DISABLED_OCCURRENCE_MENU_BUTTONS,
+  EDITED_OCCURRENCE_NAME,
+  EXCEPTION_ACTIVE_OCCURRENCE_MENU_BUTTONS,
+  INITIAL_OCCURRENCE_NAME,
+} from './assets/paced-train/const';
+import test from './logging-fixture';
+import OperationalStudiesPage from './pages/operational-studies/operational-studies-page';
+import PacedTrainSection from './pages/operational-studies/paced-train-section';
+import RouteTab from './pages/operational-studies/route-tab';
+import SimulationSettingsTab from './pages/operational-studies/simulation-settings-tab';
+import TimesAndStopsTab from './pages/operational-studies/times-and-stops-tab';
+import RollingStockSelector from './pages/rolling-stock/rolling-stock-selector';
+import { generateUniqueName, waitForInfraStateToBeCached } from './utils';
+import { getInfra, getProject, getStudy } from './utils/api-utils';
+import readJsonFile from './utils/file-utils';
+import { sendPacedTrains } from './utils/paced-train';
+import createScenario from './utils/scenario';
+import { deleteScenario } from './utils/teardown-utils';
+import type {
+  ChangeGroup,
+  CommonTranslations,
+  ManageTimetableItemTranslations,
+  TimetableFilterTranslations,
+} from './utils/types';
+
+const frManageTimetableItemTranslations: ManageTimetableItemTranslations = readJsonFile<{
+  manageTimetableItem: ManageTimetableItemTranslations;
+}>('public/locales/fr/operational-studies.json').manageTimetableItem;
+
+const frScenarioTranslations: TimetableFilterTranslations = readJsonFile<{
+  main: TimetableFilterTranslations;
+}>('public/locales/fr/operational-studies.json').main;
+
+const frCommonTranslations: CommonTranslations = readJsonFile('public/locales/fr/translation.json');
+
+const frTranslations = {
+  ...frManageTimetableItemTranslations,
+  ...frScenarioTranslations,
+  ...frCommonTranslations,
+};
+
+const pacedTrainsJson: PacedTrain[] = readJsonFile('./tests/assets/paced-train/paced_trains.json');
+
+test.describe('@op @paced-trains @exceptions', () => {
+  let project: Project;
+  let study: Study;
+  let infra: Infra;
+
+  let operationalStudiesPage: OperationalStudiesPage;
+  let pacedTrainSection: PacedTrainSection;
+  let rollingStockSelector: RollingStockSelector;
+  let routeTab: RouteTab;
+  let timesAndStopsTab: TimesAndStopsTab;
+  let simulationSettingsTab: SimulationSettingsTab;
+
+  let scenarioItems: Scenario;
+
+  test.beforeAll('Setup project, study, infra and create scenario with paced trains', async () => {
+    project = await getProject(timetableItemProjectName);
+    study = await getStudy(project.id, timetableItemStudyName);
+    infra = await getInfra();
+    scenarioItems = (
+      await createScenario(
+        generateUniqueName('paced-trains-scenario'),
+        project.id,
+        study.id,
+        infra.id
+      )
+    ).scenario;
+    await sendPacedTrains(scenarioItems.timetable_id, pacedTrainsJson.slice(0, 6));
+  });
+
+  test.beforeEach(
+    'Navigate to scenario page and wait for infrastructure to be loaded',
+    async ({ page }) => {
+      [
+        pacedTrainSection,
+        operationalStudiesPage,
+        rollingStockSelector,
+        routeTab,
+        timesAndStopsTab,
+        simulationSettingsTab,
+      ] = [
+        new PacedTrainSection(page),
+        new OperationalStudiesPage(page),
+        new RollingStockSelector(page),
+        new RouteTab(page),
+        new TimesAndStopsTab(page),
+        new SimulationSettingsTab(page),
+      ];
+
+      await page.goto(
+        `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenarioItems.id}`
+      );
+      await waitForInfraStateToBeCached(infra.id);
+    }
+  );
+
+  test.afterAll('Delete the created scenario', async () => {
+    await deleteScenario(study.id, scenarioItems.name);
+  });
+
+  /** *************** Test 1 **************** */
+  test('Edit an indexed occurrence', async () => {
+    await test.step('Open paced train and check initial menu (first occurrence)', async () => {
+      await pacedTrainSection.expandPacedTrainOccurrenceList(0);
+      await pacedTrainSection.checkOccurrenceMenuIcon(0);
+      await pacedTrainSection.checkOccurrenceActionMenu({
+        occurrenceIndex: 0,
+        expectedButtons: CONFORM_ACTIVE_OCCURRENCE_MENU_BUTTONS,
+        translations: frTranslations,
+      });
+    });
+
+    await test.step('Edit occurrence name and save', async () => {
+      await pacedTrainSection.clickOccurrenceMenuButton('edit');
+      await operationalStudiesPage.setTimetableItemName(EDITED_OCCURRENCE_NAME);
+      await operationalStudiesPage.updateTimetableItem(frTranslations.pacedTrains.updatePacedTrain);
+      await operationalStudiesPage.checkToastHasBeenLaunched(
+        frTranslations.timetable.pacedTrainUpdated
+      );
+    });
+
+    await test.step('Verify edited occurrence tooltip and menu', async () => {
+      await pacedTrainSection.checkExceptionTooltip(
+        0,
+        frTranslations.timetable.occurrenceType.editedOccurrence +
+          frTranslations.timetable.occurrenceChangeGroup.train_name
+      );
+      await pacedTrainSection.checkOccurrenceMenuIcon(0);
+      await pacedTrainSection.checkOccurrenceActionMenu({
+        occurrenceIndex: 0,
+        expectedButtons: EXCEPTION_ACTIVE_OCCURRENCE_MENU_BUTTONS,
+        translations: frTranslations,
+      });
+    });
+
+    await test.step('Disable edited occurrence', async () => {
+      await pacedTrainSection.clickOccurrenceMenuButton('disable');
+      await pacedTrainSection.verifyOccurrenceName(0, EDITED_OCCURRENCE_NAME);
+      await pacedTrainSection.checkOccurrenceMenuIcon(0);
+      await pacedTrainSection.checkOccurrenceActionMenu({
+        occurrenceIndex: 0,
+        expectedButtons: DISABLED_OCCURRENCE_MENU_BUTTONS,
+        translations: frTranslations,
+      });
+    });
+
+    await test.step('Re-enable edited occurrence', async () => {
+      await pacedTrainSection.clickOccurrenceMenuButton('enable');
+      await pacedTrainSection.verifyOccurrenceName(0, EDITED_OCCURRENCE_NAME);
+      await pacedTrainSection.checkOccurrenceMenuIcon(0);
+      await pacedTrainSection.checkOccurrenceActionMenu({
+        occurrenceIndex: 0,
+        expectedButtons: EXCEPTION_ACTIVE_OCCURRENCE_MENU_BUTTONS,
+        translations: frTranslations,
+      });
+    });
+
+    await test.step('Restore occurrence to initial model', async () => {
+      await pacedTrainSection.clickOccurrenceMenuButton('restore');
+      await pacedTrainSection.verifyOccurrenceName(0, INITIAL_OCCURRENCE_NAME);
+    });
+  });
+
+  /** *************** Test 2 **************** */
+  test('Edit added exception', async () => {
+    const PACED_TRAIN_NUMBER = 4;
+    const addedOccurrenceIndex = 1;
+    const editedPacedTrainData = pacedTrainsJson[PACED_TRAIN_NUMBER];
+
+    await test.step('Open paced train and check initial menu state', async () => {
+      await pacedTrainSection.expandPacedTrainOccurrenceList(PACED_TRAIN_NUMBER);
+      await pacedTrainSection.checkOccurrenceMenuIcon(addedOccurrenceIndex);
+      await pacedTrainSection.checkOccurrenceActionMenu({
+        occurrenceIndex: addedOccurrenceIndex,
+        expectedButtons: ADDED_EXCEPTION_MENU_BUTTONS,
+        translations: frTranslations,
+      });
+    });
+
+    await test.step('Open exception edit menu', async () => {
+      await pacedTrainSection.clickOccurrenceMenuButton('edit');
+      await operationalStudiesPage.checkEditOccurrenceButtonsVisibility();
+    });
+
+    await test.step('Modify RS, route, start time and simulation params', async () => {
+      await rollingStockSelector.openRollingstockModal();
+      await rollingStockSelector.selectRollingStockCard({
+        name: electricRollingStockName,
+        confirmSelection: true,
+      });
+
+      await operationalStudiesPage.openRouteTab();
+      await routeTab.performPathfindingByTrigram({
+        originTrigram: 'WS',
+        destinationTrigram: 'NES',
+      });
+
+      await operationalStudiesPage.setTimetableItemStartTime('02:40', '2024-10-16');
+
+      await operationalStudiesPage.openTimesAndStopsTab();
+      await timesAndStopsTab.fillTableCellByStationAndHeader(
+        'Mid_East_station',
+        frTranslations.timeStopTable.stopTime,
+        '18000'
+      );
+
+      await operationalStudiesPage.openSimulationSettingsTab();
+      await simulationSettingsTab.selectSpeedLimitTagOption('MA100');
+
+      await operationalStudiesPage.submitTimetableItemEdit();
+      await operationalStudiesPage.checkToastHasBeenLaunched(
+        frTranslations.timetable.pacedTrainUpdated
+      );
+    });
+
+    await test.step('Check exception tooltip after modifications', async () => {
+      await pacedTrainSection.checkExceptionTooltip(
+        addedOccurrenceIndex,
+        frTranslations.timetable.occurrenceType.addedOccurrence,
+        frTranslations.timetable.occurrenceChangeGroup.path_and_schedule as ChangeGroup,
+        frTranslations.timetable.occurrenceChangeGroup.rolling_stock as ChangeGroup,
+        frTranslations.timetable.occurrenceChangeGroup.speed_limit_tag as ChangeGroup,
+        frTranslations.timetable.occurrenceChangeGroup.start_time as ChangeGroup
+      );
+    });
+
+    await test.step('Check occurrence menu after modifications', async () => {
+      await pacedTrainSection.checkOccurrenceMenuIcon(addedOccurrenceIndex);
+      await pacedTrainSection.checkOccurrenceActionMenu({
+        occurrenceIndex: addedOccurrenceIndex,
+        expectedButtons: ADDED_AND_MODIFIED_EXCEPTION_MENU_BUTTONS,
+        translations: frTranslations,
+      });
+    });
+
+    await test.step('Restore occurrence to model', async () => {
+      await pacedTrainSection.clickOccurrenceMenuButton('restore');
+      await pacedTrainSection.verifyOccurrenceDetails(
+        {
+          name: `${editedPacedTrainData.train_name}/+`,
+          startTime: '02:40',
+          arrivalTime: '02:47',
+        },
+        addedOccurrenceIndex
+      );
+
+      await pacedTrainSection.checkOccurrenceActionMenu({
+        occurrenceIndex: addedOccurrenceIndex,
+        expectedButtons: ADDED_EXCEPTION_MENU_BUTTONS,
+        translations: frTranslations,
+      });
+    });
+
+    await test.step('Delete occurrence and check remaining ones', async () => {
+      await pacedTrainSection.clickOccurrenceMenuButton('delete');
+
+      await pacedTrainSection.expectOccurrencesListLength(2);
+      await pacedTrainSection.verifyOccurrenceDetails(
+        {
+          name: `${editedPacedTrainData.train_name} 1`,
+          startTime: '02:00',
+          arrivalTime: '02:07',
+        },
+        0
+      );
+      await pacedTrainSection.verifyOccurrenceDetails(
+        {
+          name: `${editedPacedTrainData.train_name} 3`,
+          startTime: '03:00',
+          arrivalTime: '03:07',
+        },
+        1
+      );
+    });
+  });
+});

--- a/front/tests/028-timetable-import.spec.ts
+++ b/front/tests/028-timetable-import.spec.ts
@@ -27,7 +27,7 @@ const frTranslations = {
   ...frCommonTranslations,
 };
 
-test.describe('Verify timetable items import', () => {
+test.describe('@op @timetable-items @import', () => {
   let importPage: ImportPage;
   let timetableItemDetailSection: TimetableItemDetailSection;
   let pacedTrainSection: PacedTrainSection;

--- a/front/tests/pages/rolling-stock/rolling-stock-selector.ts
+++ b/front/tests/pages/rolling-stock/rolling-stock-selector.ts
@@ -1,9 +1,9 @@
 import { type Locator, type Page, expect } from '@playwright/test';
 
 import { extractNumberFromString } from '../../utils/index';
-import CommonPage from '../common-page';
+import OperationalStudiesPage from '../operational-studies/operational-studies-page';
 
-class RollingStockSelector extends CommonPage {
+class RollingStockSelector extends OperationalStudiesPage {
   private readonly rollingStockSelectorButton: Locator;
 
   private readonly emptyRollingStockSelector: Locator;
@@ -80,7 +80,7 @@ class RollingStockSelector extends CommonPage {
     return this.rollingStockSelectorModal.getByTestId(`rollingstock-${rollingstockName}`);
   }
 
-  static getRollingStockSearchButton(locator: Locator) {
+  private getRollingStockSearchButton(locator: Locator) {
     return locator.getByTestId('select-rolling-stock-button');
   }
 
@@ -107,7 +107,7 @@ class RollingStockSelector extends CommonPage {
     await expect(rollingstockCard).not.toHaveClass(/inactive/);
     if (selectComfort) await this.comfortACButton.click();
     if (confirmSelection) {
-      await RollingStockSelector.getRollingStockSearchButton(rollingstockCard).click();
+      await this.getRollingStockSearchButton(rollingstockCard).click();
       await expect(this.rollingStockSelectorModal).toBeHidden();
     }
   }
@@ -133,7 +133,8 @@ class RollingStockSelector extends CommonPage {
   }
 
   async getRollingStockSearchNumber(): Promise<number> {
-    return extractNumberFromString(await this.rollingStockSearchResult.innerText());
+    const rollingStockText = await this.rollingStockSearchResult.innerText();
+    return extractNumberFromString(rollingStockText);
   }
 
   async openEmptyRollingStockSelector() {


### PR DESCRIPTION

I only introduced tags and comments,/some step clean-up in this PR

➡️ It can be discussed that some tests don’t have the `@smoke` tag, unless I missed something on my side.

A new [PR](https://github.com/OpenRailAssociation/osrd/pull/14118) will be created after this one to regroup and rename the test files, following a structure like:
```
tests/
  op/                      
    tabs/
    timetable/
    paced-trains/
    simulation-result/
    round-trips/
    nge/
  stdcm/                   
  utils/                  
  reporter/               
  pages/                 
  assets/                  
```
Within each domain, tests may be incrementally numbered:

```
tests/op/timetable/
  01-train-timetable-filter.spec.ts
  02-train-timetable.spec.ts
  03-train-timetable-multi-selection.spec.ts

```

A new `README.md` file will also be added under /tests to document everything related to the tests. ➡️https://github.com/OpenRailAssociation/osrd/pull/14120
