### PR TITLE
editoast: core_task: add `SimulationEnv`

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -954,15 +954,19 @@ dependencies = [
  "core_client",
  "dashmap",
  "deadpool-redis",
+ "educe",
  "futures 0.3.31",
  "http",
  "itertools",
  "ordered-float",
+ "pretty_assertions",
+ "rangemap",
  "schemas",
  "serde",
  "serde_json",
  "tokio",
  "tracing",
+ "uom",
 ]
 
 [[package]]

--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -923,6 +923,7 @@ dependencies = [
  "core_client",
  "dashmap",
  "deadpool",
+ "editoast_derive",
  "educe",
  "futures-util",
  "hostname",

--- a/editoast/common/src/lib.rs
+++ b/editoast/common/src/lib.rs
@@ -25,3 +25,10 @@ pub struct Version {
     #[schema(required)] // Options are by default not required, but this one is
     pub git_describe: Option<String>,
 }
+
+/// Allows implementing Eq for floats considering all NaN values to be equal
+///
+/// Tip: provide this to Educe.
+pub fn float_eq(a: &f64, b: &f64) -> bool {
+    (a.is_nan() && b.is_nan()) || (a == b)
+}

--- a/editoast/common/src/units.rs
+++ b/editoast/common/src/units.rs
@@ -121,6 +121,10 @@ macro_rules! define_unit {
                 crate::hash_float::<5, H>(&from(*value), state);
             }
 
+            pub fn eq(a: &$quantity, b: &$quantity) -> bool {
+                $crate::float_eq(&a.get::<Unit>(), &b.get::<Unit>())
+            }
+
             pub mod option {
                 use super::*;
                 pub type ReprType = Option<super::ReprType>;
@@ -153,6 +157,13 @@ macro_rules! define_unit {
 
                 pub fn hash<H: std::hash::Hasher>(value: &Option<$quantity>, state: &mut H) {
                     super::hash(&value.unwrap_or_default(), state);
+                }
+
+                pub fn eq(a: &Option<$quantity>, b: &Option<$quantity>) -> bool {
+                    a.as_ref()
+                        .zip(b.as_ref())
+                        .map(|(a, b)| $crate::float_eq(&a.get::<Unit>(), &b.get::<Unit>()))
+                        .unwrap_or(false)
                 }
             }
 

--- a/editoast/core_client/Cargo.toml
+++ b/editoast/core_client/Cargo.toml
@@ -12,6 +12,7 @@ chrono.workspace = true
 common = { workspace = true }
 dashmap.workspace = true
 deadpool.workspace = true
+editoast_derive.workspace = true
 educe.workspace = true
 futures-util.workspace = true
 hostname.workspace = true

--- a/editoast/core_client/src/simulation.rs
+++ b/editoast/core_client/src/simulation.rs
@@ -28,58 +28,70 @@ use crate::AsCoreRequest;
 use crate::Json;
 use crate::WorkerKey;
 
-#[derive(Debug, Clone, Serialize, Deserialize, Educe, PartialEq, ToSchema)]
+#[editoast_derive::annotate_units]
+#[derive(Debug, Clone, Serialize, Deserialize, Educe, ToSchema)]
+#[educe(Hash, PartialEq, Eq)]
 #[schema(as = core::PhysicsConsist)]
-#[educe(Hash)]
 pub struct PhysicsConsist {
     pub effort_curves: EffortCurves,
     pub base_power_class: Option<String>,
-    /// Length of the rolling stock
+
     #[educe(Hash(method(units::millimeter::hash)))]
     #[serde(with = "units::millimeter::u64")]
     #[schema(value_type = u64)]
     pub length: Length,
-    /// Maximum speed of the rolling stock
+
     #[educe(Hash(method(units::meter_per_second::hash)))]
+    #[educe(PartialEq(method(units::meter_per_second::eq)))]
     #[serde(with = "units::meter_per_second")]
-    #[schema(value_type = f64)]
     pub max_speed: Velocity,
+
     #[educe(Hash(method(units::millisecond::hash)))]
     #[serde(with = "units::millisecond::u64")]
     #[schema(value_type = u64)]
     pub startup_time: Time,
+
     #[educe(Hash(method(units::meter_per_second_squared::hash)))]
+    #[educe(PartialEq(method(units::meter_per_second_squared::eq)))]
     #[serde(with = "units::meter_per_second_squared")]
-    #[schema(value_type = f64)]
     pub startup_acceleration: Acceleration,
+
     #[educe(Hash(method(units::meter_per_second_squared::hash)))]
+    #[educe(PartialEq(method(units::meter_per_second_squared::eq)))]
     #[serde(with = "units::meter_per_second_squared")]
-    #[schema(value_type = f64)]
     pub comfort_acceleration: Acceleration,
+
     /// The constant gamma braking coefficient used when NOT circulating
     /// under ETCS/ERTMS signaling system
     #[educe(Hash(method(units::meter_per_second_squared::hash)))]
+    #[educe(PartialEq(method(units::meter_per_second_squared::eq)))]
     #[serde(with = "units::meter_per_second_squared")]
-    #[schema(value_type = f64)]
     pub const_gamma: Deceleration,
+
     pub etcs_brake_params: Option<EtcsBrakeParams>,
+
     #[educe(Hash(method(common::hash_float::<5,_>)))]
+    #[educe(PartialEq(method(common::float_eq)))]
     pub inertia_coefficient: f64,
-    /// Mass of the rolling stock
+
     #[educe(Hash(method(units::kilogram::hash)))]
     #[serde(with = "units::kilogram::u64")]
     #[schema(value_type = u64)]
     pub mass: Mass,
+
     pub rolling_resistance: RollingResistance,
+
     /// Mapping of power restriction code to power class
     #[serde(default)]
     pub power_restrictions: BTreeMap<String, String>,
+
     /// The time the train takes before actually using electrical power.
     /// Is null if the train is not electric or the value not specified.
     #[educe(Hash(method(units::millisecond::option::hash)))]
     #[serde(default, with = "units::millisecond::u64::option")]
     #[schema(value_type = Option<u64>)]
     pub electrical_power_startup_time: Option<Time>,
+
     /// The time it takes to raise this train's pantograph.
     /// Is null if the train is not electric or the value not specified.
     #[educe(Hash(method(units::millisecond::option::hash)))]

--- a/editoast/core_client/src/simulation.rs
+++ b/editoast/core_client/src/simulation.rs
@@ -262,18 +262,6 @@ pub struct SpeedLimitProperties {
     #[schema(inline)]
     pub values: Vec<SpeedLimitProperty>,
 }
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct SimulationPowerRestrictionRange {
-    /// Start position in the path in mm
-    begin: u64,
-    /// End position in the path in mm
-    end: u64,
-    code: String,
-    /// Is power restriction handled during simulation
-    handled: bool,
-}
-
 #[derive(Debug, Serialize, Educe)]
 #[educe(Hash)]
 pub struct Request {

--- a/editoast/core_client/src/simulation.rs
+++ b/editoast/core_client/src/simulation.rs
@@ -111,6 +111,7 @@ pub struct ZoneUpdate {
 }
 
 #[derive(Debug, Serialize, Hash)]
+#[cfg_attr(feature = "mocking_client", derive(PartialEq))]
 pub struct SimulationScheduleItem {
     /// Position on the path in mm
     pub path_offset: u64,
@@ -123,6 +124,7 @@ pub struct SimulationScheduleItem {
 }
 
 #[derive(Debug, Serialize, Hash)]
+#[cfg_attr(feature = "mocking_client", derive(PartialEq))]
 pub struct SimulationMargins {
     /// Path offset separating margin transitions in mm
     pub boundaries: Vec<u64>,
@@ -130,6 +132,7 @@ pub struct SimulationMargins {
 }
 
 #[derive(Debug, Serialize, Hash)]
+#[cfg_attr(feature = "mocking_client", derive(PartialEq))]
 pub struct SimulationPowerRestrictionItem {
     /// Position on the path in mm
     pub from: u64,
@@ -264,6 +267,7 @@ pub struct SpeedLimitProperties {
 }
 #[derive(Debug, Serialize, Educe)]
 #[educe(Hash)]
+#[cfg_attr(feature = "mocking_client", derive(PartialEq))]
 pub struct Request {
     pub infra: i64,
     pub expected_version: i64,

--- a/editoast/core_task/Cargo.toml
+++ b/editoast/core_task/Cargo.toml
@@ -6,21 +6,26 @@ edition.workspace = true
 
 [dependencies]
 cache.workspace = true
+common.workspace = true
 core_client.workspace = true
 dashmap.workspace = true
 deadpool-redis.workspace = true # for trait AsyncCommands
+educe.workspace = true
 futures.workspace = true
 itertools.workspace = true
 ordered-float.workspace = true
+rangemap.workspace = true
 schemas.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+uom.workspace = true
 
 [dev-dependencies]
 cache = { workspace = true, features = ["mock"] }
 common.workspace = true
 core_client = { workspace = true, features = ["mocking_client"] }
 http.workspace = true
+pretty_assertions.workspace = true
 serde_json = { workspace = true, features = ["preserve_order"] }

--- a/editoast/core_task/src/envs.rs
+++ b/editoast/core_task/src/envs.rs
@@ -1,5 +1,6 @@
-pub mod core;
-pub mod pathfinding;
+pub(crate) mod core;
+pub(crate) mod pathfinding;
+pub(crate) mod simulation;
 
 /// A set of trains, a "Train" being the generic type parameter of environments
 ///

--- a/editoast/core_task/src/envs/pathfinding.rs
+++ b/editoast/core_task/src/envs/pathfinding.rs
@@ -34,8 +34,8 @@ pub struct PathfindingEnv<Train>
 where
     Train: Clone + Hash + Eq + Send + Sync + 'static,
 {
-    core_env: CoreEnv,
-    inputs: PathfindingEnvInputs<Train>,
+    pub(in crate::envs) core_env: CoreEnv,
+    pub(in crate::envs) inputs: PathfindingEnvInputs<Train>,
 }
 
 impl<Train> PathfindingEnv<Train>
@@ -128,6 +128,7 @@ pub struct PathfindingTrain {
 }
 
 #[derive(Debug)]
+#[cfg_attr(test, derive(Clone))]
 pub(crate) struct PathfindingEnvInputs<Train>
 where
     Train: Clone + Hash + Eq + Send + Sync + 'static,
@@ -251,12 +252,15 @@ where
     Train: Clone + Hash + Eq + Send + Sync + 'static,
 {
     core_env: CoreEnv,
-    pathfinding_inputs: Arc<PathfindingEnvInputs<Train>>,
+    pub(in crate::envs) pathfinding_inputs: Arc<PathfindingEnvInputs<Train>>,
     input_index: DashMap<Input, TrainSet<Train>>,
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
-pub(in crate::envs) struct Input(Arc<PathfindingConsist>, Arc<PathfindingConstraints>);
+pub(in crate::envs) struct Input(
+    pub(in crate::envs) Arc<PathfindingConsist>,
+    pub(in crate::envs) Arc<PathfindingConstraints>,
+);
 
 impl<Train> Runner<Train>
 where
@@ -416,21 +420,12 @@ impl Task for core_client::pathfinding::PathfindingRequest {
 }
 
 #[cfg(test)]
-mod tests {
-    use std::time::Duration;
-
-    use core_client::mocking::MockingClient;
-    use deadpool_redis::redis;
-    use http::StatusCode;
-    use serde_json::json;
-
-    use crate::mock_mget;
-
+pub(crate) mod test_data {
     use super::*;
 
     /// We use the length field to identify it since the content doesn't matter
-    fn path(id: usize) -> serde_json::Value {
-        let mut path = json!({
+    pub(super) fn path(id: usize) -> serde_json::Value {
+        let mut path = serde_json::json!({
             "status": "success",
             "length": id,
             "path_item_positions": [],
@@ -444,7 +439,7 @@ mod tests {
         path
     }
 
-    fn constraints(id: usize) -> PathfindingConstraints {
+    pub(crate) fn constraints(id: usize) -> PathfindingConstraints {
         PathfindingConstraints {
             path_items: vec![
                 PathWaypointAlternatives::from_iter([TrackOffset::new("id", id as u64)]),
@@ -457,7 +452,7 @@ mod tests {
         }
     }
 
-    fn consist(id: usize) -> PathfindingConsist {
+    pub(crate) fn consist(id: usize) -> PathfindingConsist {
         PathfindingConsist {
             loading_gauge: LoadingGaugeType::GB,
             thermal: true,
@@ -469,7 +464,7 @@ mod tests {
         }
     }
 
-    fn train(id: usize) -> PathfindingTrain {
+    pub(crate) fn train(id: usize) -> PathfindingTrain {
         PathfindingTrain {
             consist: consist(id),
             constraints: constraints(id),
@@ -477,13 +472,27 @@ mod tests {
     }
 
     impl PathfindingEnv<usize> {
-        fn key(&self, id: usize) -> String {
+        pub(crate) fn key(&self, id: usize) -> String {
             let input = self.inputs.train_input(&id).unwrap();
             let request = build_request(&self.core_env, &input);
             use crate::Task as _;
             request.key("")
         }
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use core_client::mocking::MockingClient;
+    use deadpool_redis::redis;
+    use http::StatusCode;
+
+    use crate::mock_mget;
+
+    use super::test_data::*;
+    use super::*;
 
     #[tokio::test]
     async fn pathfinding_env() {

--- a/editoast/core_task/src/envs/simulation.rs
+++ b/editoast/core_task/src/envs/simulation.rs
@@ -325,6 +325,7 @@ where
 #[cfg(test)]
 pub(crate) mod test_data {
     use schemas::infra::TrackOffset;
+    use schemas::primitives::NonBlankString;
     use schemas::train_schedule::MarginValue;
 
     use super::*;
@@ -426,31 +427,35 @@ pub(crate) mod test_data {
                 Default::default(),
             ),
         );
-        let start = builder.push_waypoint(
+        builder.push_waypoint(
             pathfinding::PathWaypointAlternatives::from_iter([TrackOffset::new("id", id as u64)]),
+            NonBlankString::from("start"),
             SimulationWaypointSchedule::PassBy,
         );
-        let a = builder.push_waypoint(
+        builder.push_waypoint(
             pathfinding::PathWaypointAlternatives::from_iter([TrackOffset::new("a", 42)]),
+            NonBlankString::from("a"),
             SimulationWaypointSchedule::Stop {
                 arrival_at: Some(1200),
                 stop_for: 60,
                 reception_signal: Default::default(),
             },
         );
-        let b = builder.push_waypoint(
+        builder.push_waypoint(
             pathfinding::PathWaypointAlternatives::from_iter([
                 TrackOffset::new("b", 43),
                 TrackOffset::new("bis", 34),
             ]),
+            NonBlankString::from("b"),
             SimulationWaypointSchedule::Stop {
                 arrival_at: None,
                 stop_for: 120,
                 reception_signal: Default::default(),
             },
         );
-        let finish = builder.push_waypoint(
+        builder.push_waypoint(
             pathfinding::PathWaypointAlternatives::from_iter([TrackOffset::new("finish", 44)]),
+            NonBlankString::from("finish"),
             SimulationWaypointSchedule::Stop {
                 arrival_at: Some(2400),
                 stop_for: 0,
@@ -458,9 +463,9 @@ pub(crate) mod test_data {
             },
         );
 
-        builder.set_power_restriction(start, a, "blackout".to_owned());
-        builder.set_margin(start, finish, MarginValue::Percentage(15.0));
-        builder.set_margin(a, b, MarginValue::MinPer100Km(123.4));
+        builder.set_power_restriction("start", "a", "blackout".to_owned());
+        builder.set_margin("start", "finish", MarginValue::Percentage(15.0));
+        builder.set_margin("a", "b", MarginValue::MinPer100Km(123.4));
 
         builder
     }

--- a/editoast/core_task/src/envs/simulation.rs
+++ b/editoast/core_task/src/envs/simulation.rs
@@ -1,0 +1,563 @@
+mod inputs;
+pub use inputs::*;
+
+mod request;
+use request::build_request;
+
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use futures::stream;
+use tokio::sync::Mutex;
+
+use crate::CoreEnv;
+use crate::Correlated;
+use crate::PathfindingEnv;
+use crate::TrainSet;
+use crate::envs::pathfinding;
+use crate::envs::pathfinding::PathfindingEnvInputs;
+
+// ========== Environment public API ==========
+
+/// An environment to compute and cache running simulations asynchronously
+///
+/// Provides [SimulationEnv::into_stream] to build, run,
+/// cache and return simulations computed by Core. Use [SimulationEnv::extend] to add
+/// necessary inputs to the environment through [SimulationTrain].
+///
+/// Paths are required to perform a simulation, so this environment embeds a [PathfindingEnv].
+/// Required paths will be fetched from cache when available or be computed otherwise.
+/// Any pathfinding failure is forwarded by [SimulationOutput::PathfindingFailure].
+///
+/// `Train` generic parameter is a correlation key to associate each path to a train.
+/// It will be cloned several times over internally, so this operation should be cheap.
+pub struct SimulationEnv<Train>
+where
+    Train: Clone + Hash + Eq + Send + Sync + 'static,
+{
+    pathfinding_env: PathfindingEnv<Train>,
+    inputs: SimulationInputs<Train>,
+}
+
+/// Success type for [SimulationEnv::into_stream]
+///
+/// It is necessary to obtain a path to run a simulation, but pathfinding request may fail.
+/// The error is forwarded by [SimulationOutput::PathfindingFailure].
+#[derive(Debug)]
+#[cfg_attr(test, derive(PartialEq))]
+#[expect(clippy::large_enum_variant)] // success is large, we can Box it if it becomes problematic but it's less convenient
+pub enum SimulationOutput {
+    /// Yay!
+    Success(core_client::simulation::SimulationSuccess),
+    /// The pathfinding has failed, we are unable to get the path information necessary for simulation
+    ///
+    /// FIXME: [core_client::pathfinding::PathfindingCoreResult] needs to be reworked, its `Success` variant
+    /// cannot happen here.
+    PathfindingFailure(core_client::pathfinding::PathfindingCoreResult),
+}
+
+impl<Train> SimulationEnv<Train>
+where
+    Train: Clone + Hash + Eq + Send + Sync + 'static,
+{
+    pub fn new(core_env: CoreEnv) -> Self {
+        Self {
+            pathfinding_env: PathfindingEnv::new(core_env),
+            inputs: SimulationInputs {
+                electrical_profile_set_id: None,
+                consists: Default::default(),
+                parameters: Default::default(),
+            },
+        }
+    }
+
+    pub fn new_with_electrical_profile_set(
+        core_env: CoreEnv,
+        electrical_profile_set_id: u64,
+    ) -> Self {
+        Self {
+            pathfinding_env: PathfindingEnv::new(core_env),
+            inputs: SimulationInputs {
+                electrical_profile_set_id: Some(electrical_profile_set_id),
+                consists: Default::default(),
+                parameters: Default::default(),
+            },
+        }
+    }
+
+    /// Computes running simulations or fetches them from cache asynchronously
+    ///
+    /// The returned stream yields a [TrainSet] and their corresponding simulation directly.
+    ///
+    /// TODO: `SimulationEnv::run` to be able to retrieve paths as well.
+    pub fn into_stream(
+        self,
+        vkconn: Arc<Mutex<cache::Connection>>,
+    ) -> impl stream::Stream<
+        Item = Correlated<TrainSet<Train>, Result<SimulationOutput, core_client::Error>>,
+    > {
+        use stream::StreamExt as _;
+        let runner = Arc::new(Runner::new(self));
+        runner.clone().stream(vkconn).map(
+            move |Correlated {
+                      correlation_key: input,
+                      data: sim_output,
+                  }| {
+                let trains = runner.train_set(&input);
+                Correlated::new(trains, sim_output)
+            },
+        )
+    }
+}
+
+// ========== Low-level runner ==========
+
+/// Internal context allowing running simulation tasks
+///
+/// Built from a [SimulationEnv] using [Runner::new] which builds indexes in
+/// its internal state. Do not create this struct directly.
+pub(in crate::envs) struct Runner<Train>
+where
+    Train: Clone + Hash + Eq + Send + Sync + 'static,
+{
+    core_env: CoreEnv,
+    simulation_inputs: Arc<SimulationInputs<Train>>,
+    pathfinding_runner: Arc<pathfinding::Runner<Train>>,
+
+    /// Reverse index grouping all trains that have the same simulation and pathfinding inputs
+    rev: DashMap<SimulationKey, TrainSet<Train>>,
+}
+
+#[derive(Debug, Hash, PartialEq, Eq)]
+pub(in crate::envs) struct SimulationKey(
+    Arc<SimulationConsist>,
+    Arc<SimulationTrainParameters>,
+    pathfinding::Input,
+);
+
+impl<Train> Runner<Train>
+where
+    Train: Clone + Hash + Eq + Send + Sync + 'static,
+{
+    pub(in crate::envs) fn new(
+        SimulationEnv {
+            pathfinding_env,
+            inputs,
+        }: SimulationEnv<Train>,
+    ) -> Self {
+        let core_env = pathfinding_env.core_env.clone();
+        let pathfinding_runner = Arc::new(pathfinding::Runner::new(pathfinding_env));
+        let rev = DashMap::<SimulationKey, TrainSet<Train>>::new();
+        for Correlated {
+            correlation_key: train,
+            data: sim_key,
+        } in inputs.iter(&pathfinding_runner.pathfinding_inputs)
+        {
+            rev.entry(
+                sim_key.expect("SimulationEnv and PathfindingEnv should have the same trains"),
+            )
+            .or_default()
+            .insert(train);
+        }
+        Self {
+            core_env,
+            simulation_inputs: Arc::new(inputs),
+            pathfinding_runner,
+            rev,
+        }
+    }
+
+    fn train_set(&self, key: &SimulationKey) -> TrainSet<Train> {
+        self.rev.get(key).expect("Runner::new invariant").clone()
+    }
+
+    /// Trains sharing the same pathfinding key (= inputs), therefore having the same path,
+    /// do not necessarily share the same simulation key (simulation inputs differ).
+    fn simulation_keys_of_pathfinding_key(
+        &self,
+        pathfinding_key: &pathfinding::Input,
+    ) -> impl Iterator<Item = SimulationKey> {
+        self.pathfinding_runner
+            .input_train_set(pathfinding_key)
+            .into_iter()
+            .flatten()
+            .filter_map(|train| {
+                self.simulation_inputs
+                    .train_input(&train, &self.pathfinding_runner.pathfinding_inputs)
+            })
+    }
+
+    pub(in crate::envs) fn stream(
+        self: Arc<Self>,
+        vkconn: Arc<Mutex<cache::Connection>>,
+    ) -> impl stream::Stream<
+        Item = Correlated<SimulationKey, Result<SimulationOutput, core_client::Error>>,
+    > {
+        use stream::StreamExt as _;
+        // a channel passing simulation requests
+        let (simulate_tx, simulate_rx) = futures::channel::mpsc::unbounded();
+        // the channel which receiver is the stream returned by this function
+        let (return_tx, return_rx) = futures::channel::mpsc::unbounded::<
+            Correlated<SimulationKey, Result<SimulationOutput, core_client::Error>>,
+        >();
+
+        tokio::spawn(self.pathfinding_runner.clone().stream(vkconn.clone()).fold(
+            // a trick to "move" context into the closure but keeping it AsyncFnMut
+            (self.clone(), simulate_tx, return_tx.clone()),
+            async |(runner, simulate_tx, return_tx), result| {
+                let (trains, path) = match result {
+                    Correlated {
+                        correlation_key: pf_key,
+                        data: Ok(core_client::pathfinding::PathfindingCoreResult::Success(path)),
+                    } => {
+                        let trains = runner.pathfinding_runner.input_train_set(&pf_key).expect("input provided by the runner should be valid");
+                        (trains, path)
+                    }
+                    Correlated {
+                        correlation_key: pf_key,
+                        data: Ok(failure),
+                    } => {
+                        for sim_key in runner.simulation_keys_of_pathfinding_key(&pf_key)
+                        {
+                            return_tx
+                                .unbounded_send(Correlated::new(
+                                    sim_key,
+                                    Ok(SimulationOutput::PathfindingFailure(failure.clone())),
+                                ))
+                                .ok();
+                        }
+                        return (runner, simulate_tx, return_tx);
+                    }
+                    Correlated {
+                        correlation_key: pf_key,
+                        data: Err(err),
+                    } => {
+                        for sim_key in runner.simulation_keys_of_pathfinding_key(&pf_key)
+                        {
+                            return_tx
+                                .unbounded_send(Correlated::new(sim_key, Err(err.clone())))
+                                .ok();
+                        }
+                        return (runner, simulate_tx, return_tx);
+                    }
+                };
+
+                let requests = trains
+                    .into_iter()
+                    .zip(std::iter::repeat(path))
+                    .map(|(train, path)| {
+                        let sim_key = runner
+                            .simulation_inputs
+                            .train_input(
+                                &train,
+                                &runner.pathfinding_runner.pathfinding_inputs,
+                            )
+                            .expect("provided trains must be ready to simulate");
+                        let request = build_request(
+                            &runner.core_env,
+                            runner.simulation_inputs.electrical_profile_set_id,
+                            &sim_key,
+                            path,
+                        );
+                        (sim_key, request)
+                    })
+                    .collect::<HashMap<_, _>>();
+
+                for (sim_key, request) in requests {
+                    if let Ok(request) = request {
+                        simulate_tx
+                            .unbounded_send(Correlated::new(sim_key, request))
+                            .ok();
+                    } else {
+                        // This error is sent by Core when we provide it with a single path item.
+                        // But the semantic still fits for our case and it is probably not worth having a new error variant
+                        // for an error we can't do anything about.
+                        return_tx
+                            .unbounded_send(Correlated::new(
+                                sim_key,
+                                Ok(SimulationOutput::PathfindingFailure(core_client::pathfinding::PathfindingCoreResult::NotEnoughPathItems))
+                            ))
+                            .ok();
+                    }
+                }
+                (runner, simulate_tx, return_tx)
+            },
+        ));
+
+        use crate::TaskStreamExt as _;
+        tokio::spawn(
+            simulate_rx
+                .run(vkconn, self.core_env.client.clone())
+                .map(move |result|
+                    match result {
+                        Correlated {
+                            correlation_key: sim_key,
+                            data: Ok(core_client::simulation::Response::Success(simulation)),
+                        } => {
+                            return_tx
+                                .unbounded_send(Correlated::new(sim_key, Ok(SimulationOutput::Success(simulation))))
+                                .ok();
+                        }
+                        Correlated {
+                            correlation_key: sim_key,
+                            data: Ok(core_client::simulation::Response::SimulationFailed { core_error }),
+                        } => {
+                            return_tx
+                                .unbounded_send(Correlated::new(sim_key, Err(core_client::Error::RawError(core_error))))
+                                .ok();
+                        }
+                        Correlated {
+                            correlation_key: sim_key,
+                            data: Err(err),
+                        } => {
+                            return_tx.unbounded_send(Correlated::new(sim_key, Err(err))).ok();
+                        }
+                    })
+                .collect::<Vec<_>>()
+        );
+
+        return_rx
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test_data {
+    use schemas::infra::TrackOffset;
+    use schemas::train_schedule::MarginValue;
+
+    use super::*;
+
+    /// We use the length field to identify it since the content doesn't matter
+    pub(crate) fn path(id: usize, positions_count: u64) -> serde_json::Value {
+        let response = core_client::pathfinding::PathfindingCoreResult::Success(
+            core_client::pathfinding::PathfindingResultSuccess {
+                path: core_client::pathfinding::TrainPath {
+                    blocks: Vec::new(),
+                    routes: Vec::new(),
+                    track_section_ranges: Vec::new(),
+                },
+                length: id as u64,
+                path_item_positions: (1..=positions_count).collect(),
+            },
+        );
+        let mut path = serde_json::to_value(response).unwrap();
+        path.sort_all_objects();
+        path
+    }
+
+    /// The id is put in `base.positions[0]`
+    pub(crate) fn simulation_success(id: usize) -> serde_json::Value {
+        let response = core_client::simulation::Response::Success(
+            core_client::simulation::SimulationSuccess {
+                base: core_client::simulation::ReportTrain {
+                    positions: vec![id as u64],
+                    times: vec![],
+                    speeds: vec![],
+                    energy_consumption: 0.0,
+                    path_item_times: vec![0, 10],
+                },
+                provisional: core_client::simulation::ReportTrain {
+                    positions: vec![],
+                    times: vec![0, 10],
+                    speeds: vec![],
+                    energy_consumption: 0.0,
+                    path_item_times: vec![0, 10],
+                },
+                final_output: core_client::simulation::CompleteReportTrain {
+                    report_train: core_client::simulation::ReportTrain {
+                        positions: vec![],
+                        times: vec![],
+                        speeds: vec![],
+                        energy_consumption: 0.0,
+                        path_item_times: vec![0, 10],
+                    },
+                    signal_critical_positions: vec![],
+                    zone_updates: vec![],
+                    spacing_requirements: vec![],
+                    routing_requirements: vec![],
+                },
+                mrsp: core_client::simulation::SpeedLimitProperties {
+                    boundaries: vec![],
+                    values: vec![],
+                },
+                electrical_profiles: core_client::simulation::ElectricalProfiles {
+                    boundaries: vec![],
+                    values: vec![],
+                },
+            },
+        );
+        let mut json = serde_json::to_value(response).unwrap();
+        json.sort_all_objects();
+        json
+    }
+
+    pub(crate) fn consist(id: usize) -> SimulationConsist {
+        use schemas::rolling_stock::*;
+        SimulationConsist(core_client::simulation::PhysicsConsist {
+            effort_curves: EffortCurves::default(),
+            base_power_class: Some(id.to_string()),
+            length: Default::default(),
+            max_speed: Default::default(),
+            startup_time: Default::default(),
+            startup_acceleration: Default::default(),
+            comfort_acceleration: Default::default(),
+            const_gamma: Default::default(),
+            etcs_brake_params: Default::default(),
+            inertia_coefficient: Default::default(),
+            mass: Default::default(),
+            rolling_resistance: Default::default(),
+            power_restrictions: Default::default(),
+            electrical_power_startup_time: Default::default(),
+            raise_pantograph_time: Default::default(),
+        })
+    }
+
+    pub(crate) fn train(id: usize) -> SimulationTrain {
+        let mut builder = SimulationTrain::new(
+            self::consist(id),
+            pathfinding::test_data::consist(id),
+            SimulationTrainParameters::new(
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                None,
+                Default::default(),
+            ),
+        );
+        let start = builder.push_waypoint(
+            pathfinding::PathWaypointAlternatives::from_iter([TrackOffset::new("id", id as u64)]),
+            SimulationWaypointSchedule::PassBy,
+        );
+        let a = builder.push_waypoint(
+            pathfinding::PathWaypointAlternatives::from_iter([TrackOffset::new("a", 42)]),
+            SimulationWaypointSchedule::Stop {
+                arrival_at: Some(1200),
+                stop_for: 60,
+                reception_signal: Default::default(),
+            },
+        );
+        let b = builder.push_waypoint(
+            pathfinding::PathWaypointAlternatives::from_iter([
+                TrackOffset::new("b", 43),
+                TrackOffset::new("bis", 34),
+            ]),
+            SimulationWaypointSchedule::Stop {
+                arrival_at: None,
+                stop_for: 120,
+                reception_signal: Default::default(),
+            },
+        );
+        let finish = builder.push_waypoint(
+            pathfinding::PathWaypointAlternatives::from_iter([TrackOffset::new("finish", 44)]),
+            SimulationWaypointSchedule::Stop {
+                arrival_at: Some(2400),
+                stop_for: 0,
+                reception_signal: Default::default(),
+            },
+        );
+
+        builder.set_power_restriction(start, a, "blackout".to_owned());
+        builder.set_margin(start, finish, MarginValue::Percentage(15.0));
+        builder.set_margin(a, b, MarginValue::MinPer100Km(123.4));
+
+        builder
+    }
+
+    impl SimulationEnv<usize> {
+        pub(crate) fn cache_key(&self, id: usize) -> String {
+            let path = match serde_json::from_value(path(id, 4)) {
+                Ok(core_client::pathfinding::PathfindingCoreResult::Success(path)) => path,
+                _ => unreachable!("invalid test setup"),
+            };
+            let key = self
+                .inputs
+                .train_input(&id, &self.pathfinding_env.inputs)
+                .unwrap();
+            let request = build_request(
+                &self.pathfinding_env.core_env,
+                self.inputs.electrical_profile_set_id,
+                &key,
+                path,
+            )
+            .unwrap();
+            use crate::Task as _;
+            request.key("")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core_client::mocking::MockingClient;
+    use deadpool_redis::redis;
+    use http::StatusCode;
+    use pretty_assertions::assert_eq;
+
+    use crate::mock_mget;
+
+    use super::test_data::*;
+    use super::*;
+
+    #[tokio::test]
+    async fn simulation_env_into_stream() {
+        common::setup_tracing_for_test();
+
+        let mut mock = MockingClient::new();
+        mock.stub("/pathfinding/blocks")
+            .response(StatusCode::OK)
+            .json(path(2, 4))
+            .finish();
+        mock.stub("/standalone_simulation")
+            .response(StatusCode::OK)
+            .json(simulation_success(2))
+            .finish();
+
+        let mut simenv = SimulationEnv::<usize>::new(CoreEnv::new_mock(mock));
+        simenv.extend([(1, train(1)), (2, train(2))]);
+
+        let vk = cache::Client::new_mock(
+            vec![
+                mock_mget(vec![
+                    (simenv.pathfinding_env.key(1), Some(path(1, 4))),
+                    (simenv.pathfinding_env.key(2), Some(path(2, 4))),
+                ]),
+                mock_mget(vec![
+                    (simenv.cache_key(1), Some(simulation_success(1))),
+                    (simenv.cache_key(2), None),
+                ]),
+                cache::MockCmd::new(
+                    redis::cmd("SET")
+                        .arg(simenv.cache_key(2))
+                        .arg(simulation_success(2).to_string()),
+                    Ok(redis::Value::Nil),
+                ),
+            ],
+            "",
+        );
+
+        use futures::StreamExt as _;
+        let simulations = simenv
+            .into_stream(Arc::new(Mutex::new(vk.get_connection().await.unwrap())))
+            .collect::<Vec<_>>()
+            .await;
+        assert_eq!(
+            simulations,
+            vec![
+                Correlated::new(
+                    TrainSet::from([1usize]),
+                    Ok(SimulationOutput::Success(
+                        serde_json::from_value(simulation_success(1)).unwrap()
+                    ))
+                ),
+                Correlated::new(
+                    TrainSet::from([2usize]),
+                    Ok(SimulationOutput::Success(
+                        serde_json::from_value(simulation_success(2)).unwrap()
+                    ))
+                )
+            ]
+        );
+    }
+}

--- a/editoast/core_task/src/envs/simulation/inputs.rs
+++ b/editoast/core_task/src/envs/simulation/inputs.rs
@@ -1,0 +1,299 @@
+use core_client::simulation::PhysicsConsist;
+use schemas::train_schedule::Comfort;
+use schemas::train_schedule::Distribution;
+use schemas::train_schedule::MarginValue;
+use schemas::train_schedule::ReceptionSignal;
+use schemas::train_schedule::TrainScheduleOptions;
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::Correlated;
+use crate::PathfindingConsist;
+use crate::PathfindingConstraints;
+use crate::PathfindingTrain;
+use crate::envs::pathfinding::PathWaypointAlternatives;
+
+#[derive(Debug)]
+pub(crate) struct SimulationInputs<Train>
+where
+    Train: Clone + std::hash::Hash + Eq + Send + Sync + 'static,
+{
+    pub(super) electrical_profile_set_id: Option<u64>,
+
+    // TODO: deduplicate values
+    pub(super) consists: HashMap<Train, Arc<SimulationConsist>>,
+    pub(super) parameters: HashMap<Train, Arc<SimulationTrainParameters>>,
+}
+
+#[derive(Debug, Hash, PartialEq, Eq)]
+#[cfg_attr(test, derive(Clone))]
+pub struct SimulationConsist(pub PhysicsConsist);
+
+/// Simulation parameters for [SimulationEnv](super::SimulationEnv)
+///
+/// Use [SimulationTrain] to ensure consistency with the pathfinding constraints.
+#[derive(Debug, educe::Educe)]
+#[educe(Hash, PartialEq, Eq)]
+pub struct SimulationTrainParameters {
+    schedule: Vec<SimulationWaypointSchedule>,
+    power_restrictions: rangemap::RangeMap<PathWaypointIndex, String>,
+    margins: rangemap::RangeMap<PathWaypointIndex, MarginValue>,
+
+    #[educe(Hash(method(common::units::meter_per_second::hash)))]
+    #[educe(Eq(method(common::units::meter_per_second::eq)))]
+    initial_speed: uom::si::f64::Velocity,
+    constraint_distribution: Distribution,
+    comfort: Comfort,
+    speed_limit_tag: Option<String>,
+    options: TrainScheduleOptions,
+}
+
+/// Schedule information for a path waypoint
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub enum SimulationWaypointSchedule {
+    /// No specific requirement
+    PassBy,
+    /// The train must stop at this waypoint
+    Stop {
+        stop_for: u64,
+        arrival_at: Option<u64>,
+        reception_signal: ReceptionSignal,
+    },
+}
+
+impl SimulationTrainParameters {
+    pub fn new(
+        initial_speed: uom::si::f64::Velocity,
+        constraint_distribution: Distribution,
+        comfort: Comfort,
+        speed_limit_tag: Option<String>,
+        options: TrainScheduleOptions,
+    ) -> Self {
+        Self {
+            schedule: Default::default(),
+            power_restrictions: Default::default(),
+            margins: Default::default(),
+            initial_speed,
+            constraint_distribution,
+            comfort,
+            speed_limit_tag,
+            options,
+        }
+    }
+
+    pub fn schedule(&self) -> &[SimulationWaypointSchedule] {
+        &self.schedule
+    }
+
+    pub fn power_restrictions(&self) -> &rangemap::RangeMap<PathWaypointIndex, String> {
+        &self.power_restrictions
+    }
+
+    pub fn margins(&self) -> &rangemap::RangeMap<PathWaypointIndex, MarginValue> {
+        &self.margins
+    }
+
+    pub fn initial_speed(&self) -> uom::si::f64::Velocity {
+        self.initial_speed
+    }
+
+    pub fn constraint_distribution(&self) -> Distribution {
+        self.constraint_distribution
+    }
+
+    pub fn comfort(&self) -> Comfort {
+        self.comfort
+    }
+
+    pub fn speed_limit_tag(&self) -> Option<&str> {
+        self.speed_limit_tag.as_deref()
+    }
+
+    pub fn options(&self) -> &TrainScheduleOptions {
+        &self.options
+    }
+
+    fn is_empty(&self) -> bool {
+        self.schedule.is_empty() && self.power_restrictions.is_empty() && self.margins.is_empty()
+    }
+}
+
+impl<Train> SimulationInputs<Train>
+where
+    Train: Clone + std::hash::Hash + Eq + Send + Sync + 'static,
+{
+    pub(super) fn iter(
+        &self,
+        pathfinding_inputs: &super::PathfindingEnvInputs<Train>,
+    ) -> impl Iterator<Item = Correlated<Train, Option<super::SimulationKey>>> {
+        self.consists.keys().map(|train| {
+            let simulation_key = self.train_input(train, pathfinding_inputs);
+            Correlated::new(train.clone(), simulation_key)
+        })
+    }
+
+    pub(super) fn train_input(
+        &self,
+        train: &Train,
+        pathfinding_inputs: &super::PathfindingEnvInputs<Train>,
+    ) -> Option<super::SimulationKey> {
+        let consist = self.consists.get(train)?;
+        let params = self.parameters.get(train)?;
+        let pf_input = pathfinding_inputs.train_input(train)?;
+        Some(super::SimulationKey(
+            consist.clone(),
+            params.clone(),
+            pf_input,
+        ))
+    }
+}
+
+/// The way to provide simulation and pathfinding inputs to a [SimulationEnv]
+///
+/// This builder is useful to ensure the following things are consistent:
+/// - pathfinding waypoints and schedule information ([SimulationWaypointSchedule])
+/// - power restrictions ranges
+/// - margin ranges
+///
+/// Providing a bunch of [SimulationTrain]s to a [SimulationEnv] using [Extend]
+/// fills both the [SimulationEnv] and its inner [PathfindingEnv].
+pub struct SimulationTrain {
+    pub(super) simulation_consist: SimulationConsist,
+    pub(super) pathfinding_consist: PathfindingConsist,
+    pub(super) parameters: SimulationTrainParameters,
+    pub(super) path_constraints: PathfindingConstraints,
+}
+
+pub type PathWaypointIndex = usize;
+
+impl SimulationTrain {
+    pub fn new(
+        simulation_consist: SimulationConsist,
+        pathfinding_consist: PathfindingConsist,
+        parameters: SimulationTrainParameters,
+    ) -> Self {
+        if !parameters.is_empty() {
+            // would cause inconsistencies with the empty path constraints vec below
+            panic!("cannot provide parameters with schedule, power restrictions or margins set");
+        }
+        Self {
+            simulation_consist,
+            pathfinding_consist,
+            parameters,
+            path_constraints: PathfindingConstraints {
+                path_items: Vec::new(),
+            },
+        }
+    }
+
+    fn waypoints(&self) -> usize {
+        let n = self.path_constraints.path_items.len();
+        debug_assert_eq!(n, self.parameters.schedule.len());
+        debug_assert!(
+            self.parameters
+                .power_restrictions
+                .iter()
+                .map(|(index_range, _power_restriction)| index_range.end)
+                .max()
+                <= Some(n)
+        );
+        debug_assert!(self.parameters.margins.iter().map(|e| e.0.end).max() <= Some(n));
+        n
+    }
+
+    /// Adds a waypoint to the train's path with simulation schedule information
+    ///
+    /// Returns the index of the newly added waypoint which can be later used to set
+    /// power restrictions or margins.
+    ///
+    /// Checkout [Self::set_power_restriction] and [Self::set_margin].
+    pub fn push_waypoint(
+        &mut self,
+        path_constraint: PathWaypointAlternatives,
+        point: SimulationWaypointSchedule,
+    ) -> PathWaypointIndex {
+        let index = self.parameters.schedule.len();
+        self.parameters.schedule.push(point);
+        self.path_constraints.path_items.push(path_constraint);
+        index
+    }
+
+    /// Sets a power restriction for a range of waypoints.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `begin_index` or `end_index` is out of bounds.
+    pub fn set_power_restriction(
+        &mut self,
+        begin_index: PathWaypointIndex,
+        end_index: PathWaypointIndex,
+        restriction: String,
+    ) {
+        let n = self.waypoints();
+        if begin_index >= n || end_index >= n {
+            panic!("path waypoint index out of bounds");
+        }
+        debug_assert!(begin_index < end_index);
+        self.parameters
+            .power_restrictions
+            .insert(begin_index..end_index, restriction);
+    }
+
+    /// Sets a margin for a range of waypoints.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `begin_index` or `end_index` is out of bounds.
+    pub fn set_margin(
+        &mut self,
+        begin_index: PathWaypointIndex,
+        end_index: PathWaypointIndex,
+        margin: MarginValue,
+    ) {
+        let n = self.waypoints();
+        if begin_index >= n || end_index >= n {
+            panic!("path waypoint index out of bounds");
+        }
+        debug_assert!(begin_index < end_index);
+        self.parameters
+            .margins
+            .insert(begin_index..end_index, margin);
+    }
+}
+
+impl<Train> Extend<(Train, SimulationTrain)> for super::SimulationEnv<Train>
+where
+    Train: Clone + std::hash::Hash + Eq + Send + Sync + 'static,
+{
+    fn extend<T: IntoIterator<Item = (Train, SimulationTrain)>>(&mut self, iter: T) {
+        let iter = iter.into_iter().map(
+            |(
+                train,
+                SimulationTrain {
+                    simulation_consist,
+                    pathfinding_consist,
+                    parameters,
+                    path_constraints,
+                },
+            )| {
+                (
+                    (train.clone(), Arc::new(simulation_consist)),
+                    (train.clone(), Arc::new(parameters)),
+                    (
+                        train,
+                        PathfindingTrain {
+                            consist: pathfinding_consist,
+                            constraints: path_constraints,
+                        },
+                    ),
+                )
+            },
+        );
+        let (simulation_consists, simulation_params, pathfinding_trains): (Vec<_>, Vec<_>, Vec<_>) =
+            itertools::multiunzip(iter);
+        self.pathfinding_env.extend(pathfinding_trains);
+        self.inputs.consists.extend(simulation_consists);
+        self.inputs.parameters.extend(simulation_params);
+    }
+}

--- a/editoast/core_task/src/envs/simulation/inputs.rs
+++ b/editoast/core_task/src/envs/simulation/inputs.rs
@@ -1,11 +1,14 @@
 use core_client::simulation::PhysicsConsist;
+use schemas::primitives::NonBlankString;
 use schemas::train_schedule::Comfort;
 use schemas::train_schedule::Distribution;
 use schemas::train_schedule::MarginValue;
 use schemas::train_schedule::ReceptionSignal;
 use schemas::train_schedule::TrainScheduleOptions;
 
+use std::borrow::Borrow;
 use std::collections::HashMap;
+use std::hash::Hash;
 use std::sync::Arc;
 
 use crate::Correlated;
@@ -163,9 +166,10 @@ pub struct SimulationTrain {
     pub(super) pathfinding_consist: PathfindingConsist,
     pub(super) parameters: SimulationTrainParameters,
     pub(super) path_constraints: PathfindingConstraints,
+    schedule_item_to_index: HashMap<NonBlankString, PathWaypointIndex>,
 }
 
-pub type PathWaypointIndex = usize;
+type PathWaypointIndex = usize;
 
 impl SimulationTrain {
     pub fn new(
@@ -184,6 +188,7 @@ impl SimulationTrain {
             path_constraints: PathfindingConstraints {
                 path_items: Vec::new(),
             },
+            schedule_item_to_index: HashMap::default(),
         }
     }
 
@@ -204,32 +209,41 @@ impl SimulationTrain {
 
     /// Adds a waypoint to the train's path with simulation schedule information
     ///
-    /// Returns the index of the newly added waypoint which can be later used to set
-    /// power restrictions or margins.
-    ///
-    /// Checkout [Self::set_power_restriction] and [Self::set_margin].
+    /// The label can be reused for [Self::set_power_restriction] and [Self::set_margin].
     pub fn push_waypoint(
         &mut self,
         path_constraint: PathWaypointAlternatives,
+        label: NonBlankString,
         point: SimulationWaypointSchedule,
-    ) -> PathWaypointIndex {
+    ) {
         let index = self.parameters.schedule.len();
         self.parameters.schedule.push(point);
         self.path_constraints.path_items.push(path_constraint);
-        index
+        self.schedule_item_to_index.insert(label, index);
     }
 
     /// Sets a power restriction for a range of waypoints.
     ///
+    /// Labels are used to define the range: they can be &NonBlankString, &String or &str.
+    ///
     /// # Panics
     ///
-    /// Panics if `begin_index` or `end_index` is out of bounds.
-    pub fn set_power_restriction(
-        &mut self,
-        begin_index: PathWaypointIndex,
-        end_index: PathWaypointIndex,
-        restriction: String,
-    ) {
+    /// Panics if `begin_label` or `end_label` has not been used to push a waypoint.
+    pub fn set_power_restriction<Q>(&mut self, begin_label: &Q, end_label: &Q, restriction: String)
+    where
+        NonBlankString: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        let begin_index = self
+            .schedule_item_to_index
+            .get(begin_label)
+            .copied()
+            .expect("only names already inserted through “push_waypoint” can be used");
+        let end_index = self
+            .schedule_item_to_index
+            .get(end_label)
+            .copied()
+            .expect("only names already inserted through “push_waypoint” can be used");
         let n = self.waypoints();
         if begin_index >= n || end_index >= n {
             panic!("path waypoint index out of bounds");
@@ -242,15 +256,26 @@ impl SimulationTrain {
 
     /// Sets a margin for a range of waypoints.
     ///
+    /// Labels are used to define the range: they can be &NonBlankString, &String or &str.
+    ///
     /// # Panics
     ///
-    /// Panics if `begin_index` or `end_index` is out of bounds.
-    pub fn set_margin(
-        &mut self,
-        begin_index: PathWaypointIndex,
-        end_index: PathWaypointIndex,
-        margin: MarginValue,
-    ) {
+    /// Panics if `begin_label` or `end_label` has not been used to push a waypoint.
+    pub fn set_margin<Q>(&mut self, begin_label: &Q, end_label: &Q, margin: MarginValue)
+    where
+        NonBlankString: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        let begin_index = self
+            .schedule_item_to_index
+            .get(begin_label)
+            .copied()
+            .expect("only names already inserted through “push_waypoint” can be used");
+        let end_index = self
+            .schedule_item_to_index
+            .get(end_label)
+            .copied()
+            .expect("only names already inserted through “push_waypoint” can be used");
         let n = self.waypoints();
         if begin_index >= n || end_index >= n {
             panic!("path waypoint index out of bounds");
@@ -275,6 +300,7 @@ where
                     pathfinding_consist,
                     parameters,
                     path_constraints,
+                    schedule_item_to_index: _,
                 },
             )| {
                 (

--- a/editoast/core_task/src/envs/simulation/request.rs
+++ b/editoast/core_task/src/envs/simulation/request.rs
@@ -1,0 +1,434 @@
+use std::hash::DefaultHasher;
+use std::hash::Hash;
+use std::sync::Arc;
+
+use core_client::AsCoreRequest as _;
+use core_client::CoreClient;
+
+use crate::CoreEnv;
+use crate::Task;
+use crate::envs::pathfinding;
+
+use super::SimulationKey;
+use super::SimulationWaypointSchedule;
+
+pub(super) fn build_request(
+    core_env: &CoreEnv,
+    electrical_profile_set_id: Option<u64>,
+    SimulationKey(sim_consist, params, pathfinding::Input(pf_consist, constraints)): &SimulationKey,
+    core_client::pathfinding::PathfindingResultSuccess {
+        path,
+        path_item_positions,
+        ..
+    }: core_client::pathfinding::PathfindingResultSuccess,
+) -> Result<core_client::simulation::Request, ()> {
+    if constraints.path_items.len() != path_item_positions.len() {
+        tracing::error!(
+            ?sim_consist,
+            ?pf_consist,
+            sim_params = ?params,
+            pf_constraints = ?constraints,
+            waypoint_count = constraints.path_items.len(),
+            computed_path_item_count = path_item_positions.len(),
+            "Core path does not respect pathfinding constraints. Please open a bug report."
+        );
+        return Err(());
+    }
+    // Thanks to SimulationTrain, all indexing from now on should be safe.
+    // If any indexing below goes wrong, it's a bug.
+
+    let mut power_restrictions = Vec::new();
+    for (range, restriction) in params.power_restrictions().iter() {
+        let from = path_item_positions[range.start];
+        let to = path_item_positions[range.end];
+        power_restrictions.push(core_client::simulation::SimulationPowerRestrictionItem {
+            from,
+            to,
+            value: restriction.clone(),
+        });
+    }
+
+    let mut margin_boundaries = Vec::<u64>::new();
+    let mut margin_values = Vec::new();
+    for (range, margin) in params.margins().iter() {
+        let from = path_item_positions[range.start];
+        let to = path_item_positions[range.end];
+        if margin_boundaries.is_empty() {
+            margin_boundaries.push(from);
+        }
+        margin_boundaries.push(to);
+        margin_values.push(*margin);
+    }
+    debug_assert!(
+        margin_boundaries.is_sorted(),
+        "margin boundaries should only distributed along the path, therefore in a sorted order"
+    );
+    debug_assert!(
+        margin_boundaries.is_empty() && margin_values.is_empty()
+            || margin_boundaries.len() == margin_values.len() + 1
+    );
+
+    let mut schedule = Vec::new();
+    for (i, point) in params.schedule().iter().enumerate() {
+        if let SimulationWaypointSchedule::Stop {
+            arrival_at,
+            stop_for,
+            reception_signal,
+        } = point
+        {
+            let position = path_item_positions[i];
+            schedule.push(core_client::simulation::SimulationScheduleItem {
+                path_offset: position,
+                arrival: *arrival_at,
+                stop_for: Some(*stop_for).filter(|t| *t > 0),
+                reception_signal: *reception_signal,
+            });
+        }
+    }
+
+    Ok(core_client::simulation::Request {
+        infra: core_env.infra_id as i64,
+        expected_version: core_env.infra_version,
+        electrical_profile_set_id: electrical_profile_set_id.map(|id| id as i64),
+        schedule,
+        margins: core_client::simulation::SimulationMargins {
+            boundaries: margin_boundaries,
+            values: margin_values,
+        },
+        power_restrictions,
+        initial_speed: params
+            .initial_speed()
+            .get::<uom::si::velocity::meter_per_second>(),
+        comfort: params.comfort(),
+        constraint_distribution: params.constraint_distribution(),
+        speed_limit_tag: params.speed_limit_tag().map(|s| s.to_owned()),
+        options: params.options().clone(),
+        physics_consist: sim_consist.0.clone(),
+        path,
+        path_item_positions,
+    })
+}
+
+impl Task for core_client::simulation::Request {
+    type Output = core_client::simulation::Response;
+    type Error = core_client::Error;
+    type Context = Arc<CoreClient>;
+
+    // Please adjust if you have more educated information (and adjust the comment 😉).
+    const CACHE_READS_BATCH_SIZE: usize = 25; // This value has been chosen this way: 🫳🎩
+
+    fn key(&self, app_version: &str) -> String {
+        use std::hash::Hasher as _;
+        let mut hasher = DefaultHasher::new();
+        self.hash(&mut hasher);
+        let req_hash = hasher.finish().to_string();
+        format!("editoast.{app_version}.simulation.{req_hash}")
+    }
+
+    async fn compute(self, ctx: Self::Context) -> Result<Self::Output, Self::Error> {
+        self.fetch(ctx.as_ref()).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use core_client::mocking::MockingClient;
+    use pretty_assertions::assert_eq;
+    use schemas::train_schedule::MarginValue;
+
+    use super::*;
+    use crate::envs::pathfinding;
+    use crate::envs::pathfinding::PathWaypointAlternatives;
+    use crate::envs::simulation;
+    use crate::envs::simulation::SimulationTrain;
+    use crate::envs::simulation::SimulationTrainParameters;
+    use crate::envs::simulation::SimulationWaypointSchedule;
+
+    /// Simple request with only schedule items
+    #[test]
+    fn build_request_no_power_restrictions_no_margins() {
+        let path_item_positions = vec![0u64, 10u64];
+        let path = core_client::pathfinding::TrainPath {
+            blocks: Vec::new(),
+            routes: Vec::new(),
+            track_section_ranges: Vec::new(),
+        };
+        let path_success = core_client::pathfinding::PathfindingResultSuccess {
+            path: path.clone(),
+            length: 100,
+            path_item_positions: path_item_positions.clone(),
+        };
+
+        let core_env = CoreEnv::new_mock(MockingClient::new());
+        let path_items = vec![
+            PathWaypointAlternatives::from_iter([]),
+            PathWaypointAlternatives::from_iter([]),
+        ];
+        let pf_input = pathfinding::Input(
+            Arc::new(pathfinding::test_data::consist(1)),
+            Arc::new(crate::PathfindingConstraints {
+                path_items: path_items.clone(),
+            }),
+        );
+
+        let mut builder = SimulationTrain::new(
+            simulation::test_data::consist(1),
+            pathfinding::test_data::consist(1),
+            SimulationTrainParameters::new(
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                None,
+                Default::default(),
+            ),
+        );
+        builder.push_waypoint(path_items[0].clone(), SimulationWaypointSchedule::PassBy);
+        builder.push_waypoint(
+            path_items[1].clone(),
+            SimulationWaypointSchedule::Stop {
+                arrival_at: Some(300),
+                stop_for: 0,
+                reception_signal: Default::default(),
+            },
+        );
+
+        let sim_consist = builder.simulation_consist.clone();
+        let sim_key = SimulationKey(
+            Arc::new(sim_consist.clone()),
+            Arc::new(builder.parameters),
+            pf_input,
+        );
+
+        let request = build_request(&core_env, None, &sim_key, path_success).unwrap();
+        let expected = core_client::simulation::Request {
+            infra: 1,
+            expected_version: 1,
+            electrical_profile_set_id: None,
+            schedule: vec![core_client::simulation::SimulationScheduleItem {
+                path_offset: 10,
+                arrival: Some(300),
+                stop_for: None,
+                reception_signal: Default::default(),
+            }],
+            margins: core_client::simulation::SimulationMargins {
+                // Core also accepts this form
+                boundaries: vec![],
+                values: vec![],
+            },
+            power_restrictions: vec![],
+            initial_speed: 0.0,
+            comfort: Default::default(),
+            constraint_distribution: Default::default(),
+            speed_limit_tag: None,
+            options: Default::default(),
+            physics_consist: sim_consist.0,
+            path,
+            path_item_positions,
+        };
+
+        assert_eq!(request, expected);
+    }
+
+    /// Complex case with overlapping margins and power restrictions, testing RangeMap iteration and coalescing
+    #[test]
+    fn build_request_with_overlapping_ranges() {
+        let path_item_positions = vec![0u64, 10u64, 20u64, 30u64, 40u64];
+        let path = core_client::pathfinding::TrainPath {
+            blocks: Vec::new(),
+            routes: Vec::new(),
+            track_section_ranges: Vec::new(),
+        };
+        let path_success = core_client::pathfinding::PathfindingResultSuccess {
+            path: path.clone(),
+            length: 100,
+            path_item_positions: path_item_positions.clone(),
+        };
+
+        let core_env = CoreEnv::new_mock(MockingClient::new());
+        let path_items = vec![
+            PathWaypointAlternatives::from_iter([]),
+            PathWaypointAlternatives::from_iter([]),
+            PathWaypointAlternatives::from_iter([]),
+            PathWaypointAlternatives::from_iter([]),
+            PathWaypointAlternatives::from_iter([]),
+        ];
+        let pf_input = pathfinding::Input(
+            Arc::new(pathfinding::test_data::consist(1)),
+            Arc::new(crate::PathfindingConstraints {
+                path_items: path_items.clone(),
+            }),
+        );
+
+        let mut builder = SimulationTrain::new(
+            simulation::test_data::consist(1),
+            pathfinding::test_data::consist(1),
+            SimulationTrainParameters::new(
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                None,
+                Default::default(),
+            ),
+        );
+        for (i, arrival) in [None, Some(100), Some(200), Some(300), Some(400)]
+            .iter()
+            .enumerate()
+        {
+            builder.push_waypoint(
+                path_items[i].clone(),
+                SimulationWaypointSchedule::Stop {
+                    arrival_at: *arrival,
+                    stop_for: 0,
+                    reception_signal: Default::default(),
+                },
+            );
+        }
+        builder.set_power_restriction(0, 2, "blackout".to_owned());
+        builder.set_power_restriction(1, 3, "reduced".to_owned());
+        builder.set_power_restriction(3, 4, "normal".to_owned());
+        builder.set_margin(0, 2, MarginValue::Percentage(10.0));
+        builder.set_margin(2, 4, MarginValue::MinPer100Km(50.0));
+        builder.set_margin(1, 3, MarginValue::Percentage(5.0));
+
+        let sim_consist = builder.simulation_consist.clone();
+        let sim_key = SimulationKey(
+            Arc::new(sim_consist.clone()),
+            Arc::new(builder.parameters),
+            pf_input,
+        );
+
+        let request = build_request(&core_env, None, &sim_key, path_success).unwrap();
+        let expected = core_client::simulation::Request {
+            infra: 1,
+            expected_version: 1,
+            electrical_profile_set_id: None,
+            schedule: vec![
+                core_client::simulation::SimulationScheduleItem {
+                    path_offset: 0,
+                    arrival: None,
+                    stop_for: None,
+                    reception_signal: Default::default(),
+                },
+                core_client::simulation::SimulationScheduleItem {
+                    path_offset: 10,
+                    arrival: Some(100),
+                    stop_for: None,
+                    reception_signal: Default::default(),
+                },
+                core_client::simulation::SimulationScheduleItem {
+                    path_offset: 20,
+                    arrival: Some(200),
+                    stop_for: None,
+                    reception_signal: Default::default(),
+                },
+                core_client::simulation::SimulationScheduleItem {
+                    path_offset: 30,
+                    arrival: Some(300),
+                    stop_for: None,
+                    reception_signal: Default::default(),
+                },
+                core_client::simulation::SimulationScheduleItem {
+                    path_offset: 40,
+                    arrival: Some(400),
+                    stop_for: None,
+                    reception_signal: Default::default(),
+                },
+            ],
+            margins: core_client::simulation::SimulationMargins {
+                boundaries: vec![0u64, 10u64, 30u64, 40u64],
+                values: vec![
+                    MarginValue::Percentage(10.0),
+                    MarginValue::Percentage(5.0),
+                    MarginValue::MinPer100Km(50.0),
+                ],
+            },
+            power_restrictions: vec![
+                core_client::simulation::SimulationPowerRestrictionItem {
+                    from: 0,
+                    to: 10,
+                    value: "blackout".to_owned(),
+                },
+                core_client::simulation::SimulationPowerRestrictionItem {
+                    from: 10,
+                    to: 30,
+                    value: "reduced".to_owned(),
+                },
+                core_client::simulation::SimulationPowerRestrictionItem {
+                    from: 30,
+                    to: 40,
+                    value: "normal".to_owned(),
+                },
+            ],
+            initial_speed: 0.0,
+            comfort: Default::default(),
+            constraint_distribution: Default::default(),
+            speed_limit_tag: None,
+            options: Default::default(),
+            physics_consist: sim_consist.0,
+            path,
+            path_item_positions,
+        };
+
+        assert_eq!(request, expected);
+    }
+
+    /// Error case when schedule count doesn't match path item count.
+    /// 2 schedule items but only 1 path item
+    #[test]
+    fn build_request_error_schedule_path_mismatch() {
+        let path_positions = vec![0u64];
+        let path = core_client::pathfinding::TrainPath {
+            blocks: Vec::new(),
+            routes: Vec::new(),
+            track_section_ranges: Vec::new(),
+        };
+        let path_success = core_client::pathfinding::PathfindingResultSuccess {
+            path,
+            length: 100,
+            path_item_positions: path_positions,
+        };
+
+        let core_env = CoreEnv::new_mock(MockingClient::new());
+        let pf_input = pathfinding::Input(
+            Arc::new(pathfinding::test_data::consist(1)),
+            Arc::new(crate::PathfindingConstraints { path_items: vec![] }),
+        );
+
+        let mut builder = SimulationTrain::new(
+            simulation::test_data::consist(1),
+            pathfinding::test_data::consist(1),
+            SimulationTrainParameters::new(
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                None,
+                Default::default(),
+            ),
+        );
+        builder.push_waypoint(
+            PathWaypointAlternatives::from_iter([]),
+            SimulationWaypointSchedule::PassBy,
+        );
+        builder.push_waypoint(
+            PathWaypointAlternatives::from_iter([]),
+            SimulationWaypointSchedule::Stop {
+                arrival_at: Some(300),
+                stop_for: 0,
+                reception_signal: Default::default(),
+            },
+        );
+
+        let sim_key = SimulationKey(
+            Arc::new(builder.simulation_consist.clone()),
+            Arc::new(builder.parameters),
+            pf_input,
+        );
+
+        assert_eq!(
+            build_request(&core_env, None, &sim_key, path_success),
+            Err(())
+        );
+    }
+}

--- a/editoast/core_task/src/envs/simulation/request.rs
+++ b/editoast/core_task/src/envs/simulation/request.rs
@@ -136,6 +136,7 @@ mod tests {
 
     use core_client::mocking::MockingClient;
     use pretty_assertions::assert_eq;
+    use schemas::primitives::NonBlankString;
     use schemas::train_schedule::MarginValue;
 
     use super::*;
@@ -184,9 +185,14 @@ mod tests {
                 Default::default(),
             ),
         );
-        builder.push_waypoint(path_items[0].clone(), SimulationWaypointSchedule::PassBy);
+        builder.push_waypoint(
+            path_items[0].clone(),
+            NonBlankString::from("a"),
+            SimulationWaypointSchedule::PassBy,
+        );
         builder.push_waypoint(
             path_items[1].clone(),
+            NonBlankString::from("b"),
             SimulationWaypointSchedule::Stop {
                 arrival_at: Some(300),
                 stop_for: 0,
@@ -278,6 +284,7 @@ mod tests {
         {
             builder.push_waypoint(
                 path_items[i].clone(),
+                NonBlankString::from(i.to_string()),
                 SimulationWaypointSchedule::Stop {
                     arrival_at: *arrival,
                     stop_for: 0,
@@ -285,12 +292,12 @@ mod tests {
                 },
             );
         }
-        builder.set_power_restriction(0, 2, "blackout".to_owned());
-        builder.set_power_restriction(1, 3, "reduced".to_owned());
-        builder.set_power_restriction(3, 4, "normal".to_owned());
-        builder.set_margin(0, 2, MarginValue::Percentage(10.0));
-        builder.set_margin(2, 4, MarginValue::MinPer100Km(50.0));
-        builder.set_margin(1, 3, MarginValue::Percentage(5.0));
+        builder.set_power_restriction("0", "2", "blackout".to_owned());
+        builder.set_power_restriction("1", "3", "reduced".to_owned());
+        builder.set_power_restriction("3", "4", "normal".to_owned());
+        builder.set_margin("0", "2", MarginValue::Percentage(10.0));
+        builder.set_margin("2", "4", MarginValue::MinPer100Km(50.0));
+        builder.set_margin("1", "3", MarginValue::Percentage(5.0));
 
         let sim_consist = builder.simulation_consist.clone();
         let sim_key = SimulationKey(
@@ -409,10 +416,12 @@ mod tests {
         );
         builder.push_waypoint(
             PathWaypointAlternatives::from_iter([]),
+            NonBlankString::from("a"),
             SimulationWaypointSchedule::PassBy,
         );
         builder.push_waypoint(
             PathWaypointAlternatives::from_iter([]),
+            NonBlankString::from("b"),
             SimulationWaypointSchedule::Stop {
                 arrival_at: Some(300),
                 stop_for: 0,

--- a/editoast/core_task/src/lib.rs
+++ b/editoast/core_task/src/lib.rs
@@ -11,6 +11,13 @@ pub use envs::pathfinding::PathfindingConsist;
 pub use envs::pathfinding::PathfindingConstraints;
 pub use envs::pathfinding::PathfindingEnv;
 pub use envs::pathfinding::PathfindingTrain;
+pub use envs::simulation::PathWaypointIndex;
+pub use envs::simulation::SimulationConsist;
+pub use envs::simulation::SimulationEnv;
+pub use envs::simulation::SimulationOutput;
+pub use envs::simulation::SimulationTrain;
+pub use envs::simulation::SimulationTrainParameters;
+pub use envs::simulation::SimulationWaypointSchedule;
 
 use futures::stream;
 use itertools::Itertools as _;

--- a/editoast/core_task/src/lib.rs
+++ b/editoast/core_task/src/lib.rs
@@ -11,7 +11,6 @@ pub use envs::pathfinding::PathfindingConsist;
 pub use envs::pathfinding::PathfindingConstraints;
 pub use envs::pathfinding::PathfindingEnv;
 pub use envs::pathfinding::PathfindingTrain;
-pub use envs::simulation::PathWaypointIndex;
 pub use envs::simulation::SimulationConsist;
 pub use envs::simulation::SimulationEnv;
 pub use envs::simulation::SimulationOutput;

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -15201,12 +15201,14 @@ components:
             comfort_acceleration:
               type: number
               format: double
+              description: Acceleration in m·s⁻²
             const_gamma:
               type: number
               format: double
-              description: |-
-                The constant gamma braking coefficient used when NOT circulating
-                under ETCS/ERTMS signaling system
+              description: |2-
+                 The constant gamma braking coefficient used when NOT circulating
+                 under ETCS/ERTMS signaling system
+                Acceleration in m·s⁻²
             effort_curves:
               $ref: '#/components/schemas/EffortCurves'
             electrical_power_startup_time:
@@ -15228,17 +15230,15 @@ components:
             length:
               type: integer
               format: int64
-              description: Length of the rolling stock
               minimum: 0
             mass:
               type: integer
               format: int64
-              description: Mass of the rolling stock
               minimum: 0
             max_speed:
               type: number
               format: double
-              description: Maximum speed of the rolling stock
+              description: Velocity in m·s⁻¹
             power_restrictions:
               type: object
               description: Mapping of power restriction code to power class
@@ -15260,6 +15260,7 @@ components:
             startup_acceleration:
               type: number
               format: double
+              description: Acceleration in m·s⁻²
             startup_time:
               type: integer
               format: int64

--- a/editoast/schemas/src/primitives/non_blank_string.rs
+++ b/editoast/schemas/src/primitives/non_blank_string.rs
@@ -1,3 +1,4 @@
+use std::borrow::Borrow;
 use std::fmt::Display;
 use std::ops::Deref;
 use std::ops::DerefMut;
@@ -87,6 +88,18 @@ impl Default for NonBlankString {
 impl AsRef<str> for NonBlankString {
     fn as_ref(&self) -> &str {
         self.0.as_str()
+    }
+}
+
+impl Borrow<str> for NonBlankString {
+    fn borrow(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Borrow<String> for NonBlankString {
+    fn borrow(&self) -> &String {
+        &self.0
     }
 }
 

--- a/editoast/schemas/src/train_schedule/comfort.rs
+++ b/editoast/schemas/src/train_schedule/comfort.rs
@@ -4,7 +4,7 @@ use strum::FromRepr;
 use utoipa::ToSchema;
 
 #[derive(
-    Debug, Default, PartialEq, Clone, Copy, Serialize, Deserialize, FromRepr, ToSchema, Hash,
+    Debug, Default, PartialEq, Eq, Clone, Copy, Serialize, Deserialize, FromRepr, ToSchema, Hash,
 )]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum Comfort {

--- a/editoast/schemas/src/train_schedule/margins.rs
+++ b/editoast/schemas/src/train_schedule/margins.rs
@@ -44,12 +44,16 @@ impl Serialize for Margins {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Educe, ToSchema)]
-#[educe(Hash, Default)]
+#[derive(Debug, Copy, Clone, Educe, ToSchema)]
+#[educe(Hash, Default, PartialEq, Eq)]
 pub enum MarginValue {
     #[educe(Default)]
-    Percentage(#[educe(Hash(method(common::hash_float::<3,_>)))] f64),
-    MinPer100Km(#[educe(Hash(method(common::hash_float::<3,_>)))] f64),
+    Percentage(
+        #[educe(Hash(method(common::hash_float::<3,_>)), PartialEq(method(common::float_eq)))] f64,
+    ),
+    MinPer100Km(
+        #[educe(Hash(method(common::hash_float::<3,_>)), PartialEq(method(common::float_eq)))] f64,
+    ),
 }
 
 impl<'de> Deserialize<'de> for MarginValue {

--- a/editoast/schemas/src/train_schedule/schedule_item.rs
+++ b/editoast/schemas/src/train_schedule/schedule_item.rs
@@ -9,7 +9,7 @@ use crate::primitives::PositiveDuration;
 
 /// State of the signal where the train is received for its stop.
 /// For (important) details, see <https://osrd.fr/en/docs/reference/design-docs/timetable/#modifiable-fields>.
-#[derive(Default, Debug, Hash, Copy, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[derive(Default, Debug, Hash, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum ReceptionSignal {
     #[default]

--- a/editoast/src/generated_data/signal.rs
+++ b/editoast/src/generated_data/signal.rs
@@ -30,7 +30,7 @@ fn find_sprite_id(sprite_config: &SpriteConfigs, logical_signal: &LogicalSignal)
     let sprite_config = sprite_config.get(&logical_signal.signaling_system)?;
     'sprite: for conditional_sprite in &sprite_config.sprites {
         for (cond_key, cond_value) in &conditional_sprite.conditions {
-            match logical_signal.settings.get(&cond_key.clone().into()) {
+            match logical_signal.settings.get(cond_key) {
                 Some(value) if &value.0 == cond_value => continue,
                 _ => continue 'sprite,
             }

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -4781,9 +4781,11 @@ export type CoreStdcmRequest = {
   path_items: CorePathItem[];
   physics_consist: {
     base_power_class?: string | null;
+    /** Acceleration in m·s⁻² */
     comfort_acceleration: number;
-    /** The constant gamma braking coefficient used when NOT circulating
-        under ETCS/ERTMS signaling system */
+    /**  The constant gamma braking coefficient used when NOT circulating
+         under ETCS/ERTMS signaling system
+        Acceleration in m·s⁻² */
     const_gamma: number;
     effort_curves: EffortCurves;
     /** The time the train takes before actually using electrical power.
@@ -4791,11 +4793,9 @@ export type CoreStdcmRequest = {
     electrical_power_startup_time?: number | null;
     etcs_brake_params?: null | EtcsBrakeParams;
     inertia_coefficient: number;
-    /** Length of the rolling stock */
     length: number;
-    /** Mass of the rolling stock */
     mass: number;
-    /** Maximum speed of the rolling stock */
+    /** Velocity in m·s⁻¹ */
     max_speed: number;
     /** Mapping of power restriction code to power class */
     power_restrictions?: {
@@ -4805,6 +4805,7 @@ export type CoreStdcmRequest = {
         Is null if the train is not electric or the value not specified. */
     raise_pantograph_time?: number | null;
     rolling_resistance: RollingResistance;
+    /** Acceleration in m·s⁻² */
     startup_acceleration: number;
     startup_time: number;
   };


### PR DESCRIPTION
> [!NOTE]
> Question: is there a reason to represent power restrictions and margins differently?

> [!TIP]
> 1. The last 6 commits are divided like so to help with the review but will be squashed before merging. They do not work individually and some definitions used in a given commit may be introduced in a later one. Looking at the PR as a whole is likely useful as well.
> 2. Looking at the tests helps. 
> 3. I'm available to peer review as many times as necessary. ◀️ 

> [!CAUTION]
> 1. Some functions or objects with similar purposes are named differently in `SimulationEnv` and `PathfindingEnv`. I find naming in `SimulationEnv` better: if everyone agrees, I'll make a separate renaming PR for `PathfindingEnv` to be symmetric.
> 2. A lot of lines, true, but to be fair almost half of them are documentation and tests 😬 I tried to document and divide as much as possible, moving all refactoring work to other PRs, but now the diff is basically just insertions...

---

* Adds the new `SimulationEnv` responsible for streaming simulation
results.
* Relies on `PathfindingEnv` to fetch paths to build the
simulation requests. 
* Follows the same structure as `PathfindingEnv`,
but the `run` function is left for later. 
* A few naming disparities
with `PathfindingEnv`. If they are accepted, `PathfindingEnv` naming
will be updated accordingly.

Two private submodules for organization:

`mod inputs`
-----

* Simulation parameters and consist, just like `PathfindingEnv`
* Electrical profiles are handled globally

Core requests for margins and power restrictions to be represented
differently, even though they're both essentially values between two
waypoints. The easiest way to represent that is by using a RangeMap,
making construction and iteration easy, coealescing adjacent ranges and
flattening overlapping ranges. All that simplifies both our code and
reduces the payload size. We also avoid relying on path item IDs that
only make sense in the RailJSON (present in the DB table as well), further
separating input schemas and high level representations of our objects.

Is also defined a `SimulationTrain` that ensures that pathfinding
and simulation parameters are consistent. It also helps with building
power restrictions and margins RangeMaps.

`mod request`
-----

Isolates the construction of the request requiring both the simulation
input described there above, and a path, provided by `PathfindingEnv`.

Most of the module is actually for testing the construction, even though
it's a fairly simple function thanks to the RangeMap representation.