### PR TITLE
core: paths: add object length to ranges

### DIFF
--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathBuilder.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathBuilder.kt
@@ -5,6 +5,7 @@ import fr.sncf.osrd.path.legacy_objects.ElectricalProfileMapping
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.utils.indexing.DirStaticIdx
 import fr.sncf.osrd.utils.indexing.StaticIdx
+import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import fr.sncf.osrd.utils.units.sumOffsets
@@ -36,6 +37,7 @@ fun buildTrainPathFromBlock(
                 endOffset,
                 Offset.zero(),
                 Offset(endOffset - beginOffset),
+                blockInfra.getBlockLength(blockId),
             )
         )
     return buildTrainPathFromBlockRanges(
@@ -68,6 +70,7 @@ fun buildTrainPathFromBlocks(
                 blockLength,
                 prevBlockFinalOffset,
                 prevBlockFinalOffset + blockLength.distance,
+                blockLength,
             )
         )
         prevBlockFinalOffset += blockLength.distance
@@ -153,7 +156,7 @@ fun buildTrainPathFromChunkPath(
         val from = if (isFirst) chunkPath.beginOffset.cast<TrackChunk>() else Offset.zero()
         var to = chunkLength
         if (isLast) to = Offset(chunkPath.endOffset.distance - prevChunkFinalOffset)
-        chunkRanges.add(PartialDirChunkRange(chunk, from, to))
+        chunkRanges.add(PartialDirChunkRange(chunk, from, to, chunkLength))
         prevChunkFinalOffset += chunkLength.distance
     }
     return buildTrainPathFromChunks(
@@ -187,6 +190,7 @@ fun <ValueType, OffsetType> buildRangeList(
                 range.objectEnd,
                 prevRangeLength,
                 prevRangeLength + range.length,
+                range.objectLength,
             )
         )
         prevRangeLength += range.length
@@ -235,7 +239,11 @@ internal fun generateRouteRanges(
             assert(routeIndex < routes.size)
             val route = routes[routeIndex]
             val res =
-                chunk.mapOuterObject<RouteId, Route>(route, rawInfra.getChunksOnRoute(route)) {
+                chunk.mapOuterObject<RouteId, Route>(
+                    route,
+                    rawInfra.getRouteLength(route),
+                    rawInfra.getChunksOnRoute(route),
+                ) {
                     rawInfra.getTrackChunkLength(it.value)
                 }
             if (res != null) return res
@@ -287,6 +295,7 @@ private fun findBlockPath(
                 block,
                 chunkOffsetOnBlock + dirChunkRange.objectBegin.distance,
                 chunkOffsetOnBlock + dirChunkRange.objectEnd.distance,
+                blockInfra.getBlockLength(block),
             )
         res.add(newRange)
     }
@@ -300,6 +309,7 @@ data class PartialGenericLinearRange<ValueType, OffsetType>(
     val value: ValueType,
     val objectBegin: Offset<OffsetType>,
     val objectEnd: Offset<OffsetType>,
+    val objectLength: Length<OffsetType>,
 ) {
     val length = objectEnd - objectBegin
 }

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathImpl.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathImpl.kt
@@ -40,7 +40,9 @@ data class TrainPathNoBacktrack(
     }
 
     private val cachedZoneRanges by lazy {
-        cachedZonePaths.map { it.mapValue<ZoneId, Zone>(rawInfra.getZonePathZone(it.value)) }
+        cachedZonePaths.map {
+            it.mapValue<ZoneId, Zone>(rawInfra.getZonePathZone(it.value), it.objectLength.cast())
+        }
     }
 
     init {
@@ -136,18 +138,19 @@ data class TrainPathNoBacktrack(
     ): List<GenericLinearRange<ValueType, OffsetType>> {
         require(from >= Offset.zero())
         require(to <= getTypedLength())
-        return list.mapNotNull { (value, objectBegin, objectEnd, pathBegin, pathEnd) ->
-            val truncatedStart = max(from, pathBegin)
-            val truncatedEnd = min(to, pathEnd)
+        return list.mapNotNull { range ->
+            val truncatedStart = max(from, range.pathBegin)
+            val truncatedEnd = min(to, range.pathEnd)
 
             if (truncatedStart > truncatedEnd) return@mapNotNull null
 
             GenericLinearRange(
-                value = value,
-                objectBegin = objectBegin + (truncatedStart - pathBegin),
-                objectEnd = objectEnd - (pathEnd - truncatedEnd),
+                value = range.value,
+                objectBegin = range.objectBegin + (truncatedStart - range.pathBegin),
+                objectEnd = range.objectEnd - (range.pathEnd - truncatedEnd),
                 pathBegin = truncatedStart - from.distance,
                 pathEnd = truncatedEnd - from.distance,
+                objectLength = range.objectLength,
             )
         }
     }

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/GenericLinearRange.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/GenericLinearRange.kt
@@ -1,14 +1,13 @@
 package fr.sncf.osrd.path.interfaces
 
 import fr.sncf.osrd.sim_infra.api.Block
-import fr.sncf.osrd.sim_infra.api.BlockInfra
-import fr.sncf.osrd.sim_infra.api.RawInfra
 import fr.sncf.osrd.sim_infra.api.Route
 import fr.sncf.osrd.sim_infra.api.TrackChunk
 import fr.sncf.osrd.sim_infra.api.Zone
 import fr.sncf.osrd.sim_infra.api.ZonePath
 import fr.sncf.osrd.utils.indexing.DirStaticIdx
 import fr.sncf.osrd.utils.indexing.StaticIdx
+import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.Offset.Companion.max
@@ -25,39 +24,60 @@ data class GenericLinearRange<ValueType, OffsetType>(
     val value: ValueType,
     /** Start of the range, compared to the start of the underlying object. */
     val objectBegin: Offset<OffsetType>,
-    /** End of the range, compared to the start of the underlying object. */
-    val objectEnd: Offset<OffsetType>,
     /** Start of the range, compared to the start of the train path. */
     val pathBegin: Offset<TrainPath>,
-    /** End of the range, compared to the start of the train path. */
-    val pathEnd: Offset<TrainPath>,
+    /** Range length. */
+    val length: Distance,
+    /** Total length of the underlying object. */
+    val objectLength: Length<OffsetType>,
 ) {
-    val length = objectEnd - objectBegin
+    constructor(
+        value: ValueType,
+        objectBegin: Offset<OffsetType>,
+        objectEnd: Offset<OffsetType>,
+        pathBegin: Offset<TrainPath>,
+        pathEnd: Offset<TrainPath>,
+        objectLength: Length<OffsetType>,
+    ) : this(value, objectBegin, pathBegin, pathEnd - pathBegin, objectLength) {
+        assert(objectEnd - objectBegin == pathEnd - pathBegin)
+    }
 
     init {
         require(length >= 0.meters)
-        require(pathEnd - pathBegin == length)
+
+        // There's currently no use case where the range can exceed the object itself, so this is an
+        // easy sanity check. These two assertions can be removed if needed.
+        require(objectEnd <= objectLength)
+        require(objectBegin >= Offset.zero())
     }
+
+    /** End of the range, compared to the start of the train path. */
+    val pathEnd: Offset<TrainPath>
+        get() = pathBegin + length
+
+    /** End of the range, compared to the start of the underlying object. */
+    val objectEnd: Offset<OffsetType>
+        get() = objectBegin + length
 
     fun isSinglePoint() = length == 0.meters
 
     /** Where the object begins on the path, not just the range. May be negative. */
-    fun getObjectAbsolutePathStart() = pathBegin - objectBegin.distance
+    val objectAbsolutePathStart
+        get() = pathBegin - objectBegin.distance
 
     /** Where the object ends on the path, not just the range. May be larger than path length. */
-    fun getObjectAbsolutePathEnd(objectLength: Length<OffsetType>): Offset<TrainPath> {
-        return getObjectAbsolutePathStart() + objectLength.distance
-    }
+    val objectAbsolutePathEnd
+        get() = objectAbsolutePathStart + objectLength.distance
 
     /** Converts a train path offset into an object offset. */
     fun offsetFromTrainPath(pathOffset: Offset<TrainPath>): Offset<OffsetType> {
-        val objectStart = getObjectAbsolutePathStart()
+        val objectStart = objectAbsolutePathStart
         return Offset(pathOffset.distance - objectStart.distance)
     }
 
     /** Converts an object offset into a train path offset. */
     fun offsetToTrainPath(objectOffset: Offset<OffsetType>): Offset<TrainPath> {
-        val objectStart = getObjectAbsolutePathStart()
+        val objectStart = objectAbsolutePathStart
         return objectStart + objectOffset.distance
     }
 
@@ -80,6 +100,7 @@ data class GenericLinearRange<ValueType, OffsetType>(
             objectEnd - removedAtEnd,
             newPathBegin,
             newPathEnd,
+            objectLength,
         )
     }
 
@@ -104,6 +125,7 @@ data class GenericLinearRange<ValueType, OffsetType>(
                     subObjectLength,
                     prevObjectEndPathOffset,
                     prevObjectEndPathOffset + subObjectLength.distance,
+                    subObjectLength,
                 )
             val truncated = subObjectRange.withTruncatedPathRange(pathBegin, pathEnd)
             if (truncated != null) res.add(truncated)
@@ -121,6 +143,7 @@ data class GenericLinearRange<ValueType, OffsetType>(
      */
     fun <OuterObjectType, OuterObjectOffset> mapOuterObject(
         outerObject: OuterObjectType,
+        outerObjectLength: Length<OuterObjectOffset>,
         subObjectList: List<ValueType>,
         getSubObjectLength: (ValueType) -> Length<OffsetType>,
     ): GenericLinearRange<OuterObjectType, OuterObjectOffset>? {
@@ -135,12 +158,29 @@ data class GenericLinearRange<ValueType, OffsetType>(
             )
         val rangeBegin = thisOffset + objectBegin.distance
         val rangeEnd = thisOffset + objectEnd.distance
-        return GenericLinearRange(outerObject, rangeBegin, rangeEnd, pathBegin, pathEnd)
+        return GenericLinearRange(
+            outerObject,
+            rangeBegin,
+            rangeEnd,
+            pathBegin,
+            pathEnd,
+            outerObjectLength,
+        )
     }
 
     /** Maps the value, while keeping all offsets identical. */
-    fun <T, NewOffsetType> mapValue(value: T): GenericLinearRange<T, NewOffsetType> {
-        return GenericLinearRange(value, objectBegin.cast(), objectEnd.cast(), pathBegin, pathEnd)
+    fun <T, NewOffsetType> mapValue(
+        value: T,
+        newObjectLength: Offset<NewOffsetType>,
+    ): GenericLinearRange<T, NewOffsetType> {
+        return GenericLinearRange(
+            value,
+            objectBegin.cast(),
+            objectEnd.cast(),
+            pathBegin,
+            pathEnd,
+            newObjectLength,
+        )
     }
 }
 
@@ -172,7 +212,7 @@ fun <ValueType, OffsetType> mergeLinearRanges(
             if (last?.value == entry.value) {
                 assert(last.pathBegin <= entry.pathBegin)
                 assert(last.objectBegin <= entry.objectBegin)
-                last = last.copy(pathEnd = entry.pathEnd, objectEnd = entry.objectEnd)
+                last = last.copy(length = entry.length + last.length)
             } else {
                 last?.let { res.add(it) }
                 last = entry
@@ -214,25 +254,10 @@ fun <ValueType, OffsetType> MutableList<GenericLinearRange<ValueType, OffsetType
                     element.objectEnd,
                     prevElement.pathBegin,
                     element.pathEnd,
+                    prevElement.objectLength,
                 )
         } else {
             add(element)
         }
     }
-}
-
-// Some extension functions to make `getObjectAbsolutePathEnd` calls less verbose. We could instead
-// put the object length in the range itself, but that would waste some memory for a value that's
-// rarely accessed in practice.
-
-fun ZonePathRange.getZonePathAbsolutePathEnd(infra: RawInfra): Offset<TrainPath> {
-    return getObjectAbsolutePathEnd(infra.getZonePathLength(value))
-}
-
-fun RouteRange.getRouteAbsolutePathEnd(infra: RawInfra): Offset<TrainPath> {
-    return getObjectAbsolutePathEnd(infra.getRouteLength(value))
-}
-
-fun BlockRange.getBlockAbsolutePathEnd(blockInfra: BlockInfra): Offset<TrainPath> {
-    return getObjectAbsolutePathEnd(blockInfra.getBlockLength(value))
 }

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/JsonTrainPath.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/JsonTrainPath.kt
@@ -46,7 +46,8 @@ data class JsonTrainPath(
         val blockRanges =
             buildRangeList(
                 blocks.map {
-                    PartialBlockRange(blockInfra.getBlockFromName(it.id)!!, it.begin, it.end)
+                    val block = blockInfra.getBlockFromName(it.id)!!
+                    PartialBlockRange(block, it.begin, it.end, blockInfra.getBlockLength(block))
                 }
             )
         return buildTrainPathFromBlockRanges(
@@ -61,7 +62,8 @@ data class JsonTrainPath(
 
 fun TrainPath.toJsonTrainPath(rawInfra: RawInfra, blockInfra: BlockInfra): JsonTrainPath {
     val tracks = mutableListOf<JsonTrainPath.TrackSectionRange>()
-    for ((dirChunk, from, to) in getChunks()) {
+    for (chunkRange in getChunks()) {
+        val dirChunk = chunkRange.value
         val track = rawInfra.getTrackFromChunk(dirChunk.value)
         val trackName = rawInfra.getTrackSectionName(track)
         val chunkStartOffset = rawInfra.getTrackChunkOffset(dirChunk.value)
@@ -71,15 +73,15 @@ fun TrainPath.toJsonTrainPath(rawInfra: RawInfra, blockInfra: BlockInfra): JsonT
             if (dirChunk.direction == Direction.INCREASING)
                 JsonTrainPath.TrackSectionRange(
                     trackName,
-                    chunkStartOffset + from.distance,
-                    chunkStartOffset + to.distance,
+                    chunkStartOffset + chunkRange.objectBegin.distance,
+                    chunkStartOffset + chunkRange.objectEnd.distance,
                     EdgeDirection.START_TO_STOP,
                 )
             else
                 JsonTrainPath.TrackSectionRange(
                     trackName,
-                    chunkEndOffset - to.distance,
-                    chunkEndOffset - from.distance,
+                    chunkEndOffset - chunkRange.objectEnd.distance,
+                    chunkEndOffset - chunkRange.objectBegin.distance,
                     EdgeDirection.STOP_TO_START,
                 )
         val lastAddedRange = tracks.lastOrNull()

--- a/core/kt-osrd-path/src/test/kotlin/fr/sncf/osrd/path/GenericLinearRangeTest.kt
+++ b/core/kt-osrd-path/src/test/kotlin/fr/sncf/osrd/path/GenericLinearRangeTest.kt
@@ -29,12 +29,13 @@ class GenericLinearRangeTest {
                 objectEnd = Offset(100.meters),
                 pathBegin = Offset(1_000.meters),
                 pathEnd = Offset(1_100.meters),
+                objectLength = Length(100.meters),
             )
 
         assertEquals(Offset(50.meters), range.offsetFromTrainPath(Offset(1_050.meters)))
         assertEquals(Offset(1_050.meters), range.offsetToTrainPath(Offset(50.meters)))
-        assertEquals(Offset(1_000.meters), range.getObjectAbsolutePathStart())
-        assertEquals(Offset(1_100.meters), range.getObjectAbsolutePathEnd(Length(100.meters)))
+        assertEquals(Offset(1_000.meters), range.objectAbsolutePathStart)
+        assertEquals(Offset(1_100.meters), range.pathEnd)
     }
 
     @Test
@@ -53,12 +54,13 @@ class GenericLinearRangeTest {
                 objectEnd = Offset(75.meters),
                 pathBegin = Offset(0.meters),
                 pathEnd = Offset(50.meters),
+                objectLength = Length(100.meters),
             )
 
         assertEquals(Offset(42.meters), range.offsetFromTrainPath(Offset(17.meters)))
         assertEquals(Offset(17.meters), range.offsetToTrainPath(Offset(42.meters)))
-        assertEquals(Offset((-25).meters), range.getObjectAbsolutePathStart())
-        assertEquals(Offset(75.meters), range.getObjectAbsolutePathEnd(Length(100.meters)))
+        assertEquals(Offset((-25).meters), range.objectAbsolutePathStart)
+        assertEquals(Offset(75.meters), range.objectAbsolutePathEnd)
     }
 
     @Test
@@ -78,6 +80,7 @@ class GenericLinearRangeTest {
                 objectEnd = Offset(750.meters),
                 pathBegin = Offset(0.meters),
                 pathEnd = Offset(500.meters),
+                objectLength = Length(1_000.meters),
             )
         val blocks = (0U..4U).map { BlockId(it) }
         val blockLengths = listOf(100, 300, 200, 200, 200).map { Length<Block>(it.meters) }
@@ -97,6 +100,7 @@ class GenericLinearRangeTest {
                     objectEnd = Offset(300.meters),
                     pathBegin = Offset(0.meters),
                     pathEnd = Offset(150.meters),
+                    objectLength = Length(300.meters),
                 ),
                 GenericLinearRange(
                     value = blocks[2],
@@ -104,6 +108,7 @@ class GenericLinearRangeTest {
                     objectEnd = Offset(200.meters),
                     pathBegin = Offset(150.meters),
                     pathEnd = Offset(350.meters),
+                    objectLength = Length(200.meters),
                 ),
                 GenericLinearRange(
                     value = blocks[3],
@@ -111,6 +116,7 @@ class GenericLinearRangeTest {
                     objectEnd = Offset(150.meters),
                     pathBegin = Offset(350.meters),
                     pathEnd = Offset(500.meters),
+                    objectLength = Length(200.meters),
                 ),
             )
         assertEquals(expectedRanges, blockRanges)

--- a/core/kt-osrd-sncf-signaling/src/test/kotlin/fr/sncf/osrd/signaling/bal/TestBALtoBAL.kt
+++ b/core/kt-osrd-sncf-signaling/src/test/kotlin/fr/sncf/osrd/signaling/bal/TestBALtoBAL.kt
@@ -182,7 +182,7 @@ class TestBALtoBAL {
                 blocks.mapIndexed { index, it ->
                     val beginOffset = if (index == 0) Offset<Block>(5.meters) else Offset.zero()
                     val endOffset = blockInfra.getBlockLength(it)
-                    PartialBlockRange(it, beginOffset, endOffset)
+                    PartialBlockRange(it, beginOffset, endOffset, blockInfra.getBlockLength(it))
                 }
             )
         val trainPath =

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/SafetySpeed.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/SafetySpeed.kt
@@ -3,7 +3,6 @@ package fr.sncf.osrd.standalone_sim
 import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.api.standalone_sim.SimulationScheduleItem
 import fr.sncf.osrd.path.interfaces.TrainPath
-import fr.sncf.osrd.path.interfaces.getRouteAbsolutePathEnd
 import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop
 import fr.sncf.osrd.signaling.etcs_level2.ETCS_LEVEL2
 import fr.sncf.osrd.sim_infra.api.*
@@ -131,7 +130,7 @@ private fun getSignalOffsets(infra: FullInfra, trainPath: TrainPath): List<Offse
     // Add one "signal" at the end of the last route no matter what.
     // There must be either a signal or a buffer stop, on which we may end safety speed ranges.
     val lastRouteRange = trainPath.getRoutes().last()
-    res.add(lastRouteRange.getRouteAbsolutePathEnd(rawInfra))
+    res.add(lastRouteRange.objectAbsolutePathEnd)
 
     return res.filter { it.distance >= 0.meters }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
@@ -23,7 +23,6 @@ import fr.sncf.osrd.path.interfaces.TravelledPath
 import fr.sncf.osrd.path.interfaces.getLegacyBlockPath
 import fr.sncf.osrd.path.interfaces.getLegacyChunkPath
 import fr.sncf.osrd.path.interfaces.getLegacyRoutePath
-import fr.sncf.osrd.path.interfaces.getZonePathAbsolutePathEnd
 import fr.sncf.osrd.signaling.SigSystemManager
 import fr.sncf.osrd.signaling.SignalingTrainState
 import fr.sncf.osrd.signaling.ZoneStatus
@@ -420,7 +419,7 @@ fun routingRequirements(
         for (zoneRange in zoneRanges) {
             val zonePath = zoneRange.value
             // the distance to the end of the zone from the start of the train path
-            val zoneEndOffset = zoneRange.getZonePathAbsolutePathEnd(rawInfra)
+            val zoneEndOffset = zoneRange.objectAbsolutePathEnd
             // the point in the train path at which the zone is released
             val exitCriticalPos = zoneEndOffset + rollingStock.length.meters
             // if the zones are never occupied by the train, no requirement is emitted
@@ -520,8 +519,7 @@ private fun getSightRouteCriticalPos(
     val zoneStates = MutableList(zoneCount) { ZoneStatus.CLEAR }
 
     // We only want the path up to the route offset of the given route
-    val subTrainPath =
-        trainPath.subPath(Offset.zero(), firstBlockRange.getObjectAbsolutePathStart())
+    val subTrainPath = trainPath.subPath(Offset.zero(), firstBlockRange.objectAbsolutePathStart)
 
     // TODO: the complexity of finding route set deadlines is currently n^2 of the
     //   number of blocks in the path. it can be improved upon by only simulating blocks

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/etcsContextBuilder.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/etcsContextBuilder.kt
@@ -5,7 +5,6 @@ import fr.sncf.osrd.envelope_sim.EnvelopeSimContext
 import fr.sncf.osrd.path.interfaces.DirChunkRange
 import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.path.interfaces.TravelledPath
-import fr.sncf.osrd.path.interfaces.getBlockAbsolutePathEnd
 import fr.sncf.osrd.signaling.etcs_level2.ETCS_LEVEL2
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.sim_infra.utils.getNextTrackSections
@@ -67,8 +66,8 @@ fun buildETCSBlockDetectors(infra: FullInfra, trainPath: TrainPath): List<Offset
         val block = blockRange.value
         if (isETCSBlock(block, infra)) {
             // Add entry and exit detectors
-            etcsBlockDetectors.add(blockRange.getObjectAbsolutePathStart())
-            etcsBlockDetectors.add(blockRange.getBlockAbsolutePathEnd(infra.blockInfra))
+            etcsBlockDetectors.add(blockRange.objectAbsolutePathStart)
+            etcsBlockDetectors.add(blockRange.objectAbsolutePathEnd)
         }
     }
     return etcsBlockDetectors.filter { it.distance >= Distance.ZERO }
@@ -120,7 +119,7 @@ private fun getEndOfLastTrackPathOffset(
     val lastChunk = dirLastChunk.value
     val lastTrackLength = infra.getTrackSectionLength(lastTrack)
     val lastChunkLength = infra.getTrackChunkLength(lastChunkRange.value.value)
-    val lastChunkEndOffset = lastChunkRange.getObjectAbsolutePathEnd(lastChunkLength)
+    val lastChunkEndOffset = lastChunkRange.objectAbsolutePathEnd
 
     // As an offset on the undirected last track, where the start of the (undirected) last chunk is
     // located

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
@@ -367,6 +367,7 @@ private class InfraExplorerImpl(
                         objectEnd = travelledPathEndBlockOffset,
                         pathBegin = rangePathBegin,
                         pathEnd = rangePathEnd,
+                        objectLength = blockLength,
                     )
                 blockRanges.add(blockRange)
 

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMHelpers.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMHelpers.kt
@@ -95,12 +95,12 @@ fun occupancyTest(
             val enterTime =
                 res.departureTime +
                     envelopeWrapper.interpolateArrivalAtClamp(
-                        (blockRange.getObjectAbsolutePathStart() + distanceStart).meters
+                        (blockRange.objectAbsolutePathStart + distanceStart).meters
                     )
             val exitTime =
                 res.departureTime +
                     envelopeWrapper.interpolateDepartureFromClamp(
-                        (blockRange.getObjectAbsolutePathStart() + distanceEnd).meters
+                        (blockRange.objectAbsolutePathStart + distanceEnd).meters
                     )
             Assertions.assertTrue(
                 enterTime + tolerance >= timeEnd || exitTime - tolerance <= timeStart


### PR DESCRIPTION
I chose earlier to not include the object length to the ranges, for "memory concerns". But I now regret that choice, especially because directed/undirected projections would be a lot easier with object lengths.

And we had redundant variables anyway, so it could fit without adding an extra one. 
