### PR TITLE
front: fix new itinerary modal map display

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModal.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModal.tsx
@@ -66,7 +66,6 @@ const ItineraryModal = ({
   const { pathStepsMetadataById } = usePathStepsMetadata(pathSteps);
   const { launchPathfindingV2, pathProperties, pathfindingError } = usePathfindingV2();
 
-  const isMapDisabled = window.matchMedia('(max-width: 1028px)').matches;
   const hasInvalidPathStep = Array.from(pathStepsMetadataById.values()).some(
     (metadata) => metadata.isInvalid
   );
@@ -231,21 +230,19 @@ const ItineraryModal = ({
           <Button label={t('next')} variant="Primary" size="medium" onClick={closeModal} />
         </div>
       </div>
-      {!isMapDisabled && (
-        <div className="itinerary-modal-map">
-          <ItineraryModalMap
-            pathSteps={pathSteps}
-            pathStepsMetadata={pathStepsMetadataById}
-            pathProperties={pathProperties}
-          >
-            <IncompatibleConstraints
-              geometry={pathProperties?.geometry}
-              pathLength={pathProperties?.length}
-              incompatibleConstraints={pathProperties?.incompatibleConstraints}
-            />
-          </ItineraryModalMap>
-        </div>
-      )}
+      <div className="itinerary-modal-map">
+        <ItineraryModalMap
+          pathSteps={pathSteps}
+          pathStepsMetadata={pathStepsMetadataById}
+          pathProperties={pathProperties}
+        >
+          <IncompatibleConstraints
+            geometry={pathProperties?.geometry}
+            pathLength={pathProperties?.length}
+            incompatibleConstraints={pathProperties?.incompatibleConstraints}
+          />
+        </ItineraryModalMap>
+      </div>
     </dialog>
   );
 };

--- a/front/src/styles/scss/applications/operationalStudies/_itineraryModal.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_itineraryModal.scss
@@ -349,6 +349,9 @@
 }
 
 @media (max-width: 1028px) {
+  .itinerary-modal-map {
+    display: none;
+  }
   .itinerary-modal-form {
     width: 100%;
   }


### PR DESCRIPTION
closes #13700

`window.matchMedia('(max-width: 1028px)').matches` doesn't seem to work on Chrome (`isMapDisabled` doesn't re-render), we can use a CSS rule instead.