### PR TITLE
core: add typing elements for directed offsets

### DIFF
--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathBuilder.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathBuilder.kt
@@ -5,8 +5,10 @@ import fr.sncf.osrd.path.legacy_objects.ElectricalProfileMapping
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.utils.indexing.DirStaticIdx
 import fr.sncf.osrd.utils.indexing.StaticIdx
+import fr.sncf.osrd.utils.units.Directed
 import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
+import fr.sncf.osrd.utils.units.forceDirected
 import fr.sncf.osrd.utils.units.meters
 import fr.sncf.osrd.utils.units.sumOffsets
 
@@ -153,10 +155,11 @@ fun buildTrainPathFromChunkPath(
         val isFirst = i == 0
         val isLast = i == chunkPath.chunks.size - 1
         val chunkLength = rawInfra.getTrackChunkLength(chunk.value)
-        val from = if (isFirst) chunkPath.beginOffset.cast<TrackChunk>() else Offset.zero()
-        var to = chunkLength
+        val from =
+            if (isFirst) chunkPath.beginOffset.cast<Directed<TrackChunk>>() else Offset.zero()
+        var to = chunkLength.forceDirected()
         if (isLast) to = Offset(chunkPath.endOffset.distance - prevChunkFinalOffset)
-        chunkRanges.add(PartialDirChunkRange(chunk, from, to, chunkLength))
+        chunkRanges.add(PartialDirChunkRange(chunk, from, to, chunkLength.forceDirected()))
         prevChunkFinalOffset += chunkLength.distance
     }
     return buildTrainPathFromChunks(
@@ -208,7 +211,7 @@ private fun generateTrackChunks(
         mapSubObjects(
             blocks,
             blockInfra::getTrackChunksFromBlock,
-            { rawInfra.getTrackChunkLength(it.value) },
+            { rawInfra.getTrackChunkLength(it.value).forceDirected() },
         )
     // We need to filter out zero-length ranges that aren't first or last
     val filtered = mutableListOf<DirChunkRange>()
@@ -244,7 +247,7 @@ internal fun generateRouteRanges(
                     rawInfra.getRouteLength(route),
                     rawInfra.getChunksOnRoute(route),
                 ) {
-                    rawInfra.getTrackChunkLength(it.value)
+                    rawInfra.getTrackChunkLength(it.value).forceDirected()
                 }
             if (res != null) return res
             // If not found in the current route, move on to the next
@@ -316,7 +319,7 @@ data class PartialGenericLinearRange<ValueType, OffsetType>(
 
 typealias PartialLinearObjectRange<T> = PartialGenericLinearRange<StaticIdx<T>, T>
 
-typealias PartialLinearDirObjectRange<T> = PartialGenericLinearRange<DirStaticIdx<T>, T>
+typealias PartialLinearDirObjectRange<T> = PartialGenericLinearRange<DirStaticIdx<T>, Directed<T>>
 
 typealias PartialRouteRange = PartialLinearObjectRange<Route>
 

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathImpl.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathImpl.kt
@@ -11,6 +11,7 @@ import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.Offset.Companion.max
 import fr.sncf.osrd.utils.units.Offset.Companion.min
+import fr.sncf.osrd.utils.units.forceDirected
 import fr.sncf.osrd.utils.units.meters
 
 /**
@@ -66,7 +67,7 @@ data class TrainPathNoBacktrack(
             if (!routes.isEmpty()) checkRangeList(routes) { rawInfra.getRouteLength(it) }
         }
         checkRangeList(blocks) { blockInfra.getBlockLength(it) }
-        checkRangeList(chunks) { rawInfra.getTrackChunkLength(it.value) }
+        checkRangeList(chunks) { rawInfra.getTrackChunkLength(it.value).forceDirected() }
     }
 
     override fun subPath(from: Offset<TrainPath>?, to: Offset<TrainPath>?): TrainPath {

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/GenericLinearRange.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/GenericLinearRange.kt
@@ -7,13 +7,18 @@ import fr.sncf.osrd.sim_infra.api.Zone
 import fr.sncf.osrd.sim_infra.api.ZonePath
 import fr.sncf.osrd.utils.indexing.DirStaticIdx
 import fr.sncf.osrd.utils.indexing.StaticIdx
+import fr.sncf.osrd.utils.units.DirOffset
+import fr.sncf.osrd.utils.units.Directed
 import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.Offset.Companion.max
 import fr.sncf.osrd.utils.units.Offset.Companion.min
+import fr.sncf.osrd.utils.units.forceUndirected
 import fr.sncf.osrd.utils.units.meters
 import fr.sncf.osrd.utils.units.sumDistances
+import fr.sncf.osrd.utils.units.toDirected
+import fr.sncf.osrd.utils.units.toUndirected
 
 /**
  * Describes an object range on the train path. Located on both the object itself, and the global
@@ -186,7 +191,7 @@ data class GenericLinearRange<ValueType, OffsetType>(
 
 typealias LinearObjectRange<T> = GenericLinearRange<StaticIdx<T>, T>
 
-typealias LinearDirObjectRange<T> = GenericLinearRange<DirStaticIdx<T>, T>
+typealias LinearDirObjectRange<T> = GenericLinearRange<DirStaticIdx<T>, Directed<T>>
 
 typealias RouteRange = LinearObjectRange<Route>
 
@@ -260,4 +265,21 @@ fun <ValueType, OffsetType> MutableList<GenericLinearRange<ValueType, OffsetType
             add(element)
         }
     }
+}
+
+// Utility functions for directed ranges
+
+fun <ValueType, OffsetType> GenericLinearRange<DirStaticIdx<ValueType>, Directed<OffsetType>>
+    .offsetToUndirected(directedOffset: DirOffset<OffsetType>): Offset<OffsetType> {
+    // Object length can't really be directed, but the typing here means we have a
+    // `Length<Directed<OffsetType>>`. We'd need to add a third type parameter to
+    // `GenericLinearRange` to keep lengths undirected.
+    val undirectedObjectLength = objectLength.forceUndirected()
+    return directedOffset.toUndirected(undirectedObjectLength, value.direction)
+}
+
+fun <ValueType, OffsetType> GenericLinearRange<DirStaticIdx<ValueType>, Directed<OffsetType>>
+    .offsetToDirected(undirectedOffset: Offset<OffsetType>): DirOffset<OffsetType> {
+    val undirectedObjectLength = objectLength.forceUndirected()
+    return undirectedOffset.toDirected(undirectedObjectLength, value.direction)
 }

--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/units/Distance.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/units/Distance.kt
@@ -197,3 +197,52 @@ fun Collection<Distance>.sumDistances(): Distance {
 fun <T> Collection<Offset<T>>.sumOffsets(): Offset<T> {
     return Offset(Distance(millimeters = sumOf { it.distance.millimeters }))
 }
+
+/**
+ * Type marker used to indicate that the offset is on a *directed* version of the underlying object.
+ *
+ * e.g. [Offset<Directed<TrackRange>>], compared to [Offset<TrackRange>], indicates that the offset
+ * should be paired with a direction. It doesn't contain the direction data directly.
+ *
+ * Generally used through the type alias [DirOffset<T>], though the [Offset<Directed<T>>] version
+ * can be useful to type methods that use the underlying type.
+ */
+sealed interface Directed<T>
+
+typealias DirOffset<T> = Offset<Directed<T>>
+
+/**
+ * Converts a directed offset into an undirected offset, using the object length and a direction.
+ */
+fun <T> DirOffset<T>.toUndirected(objectLength: Length<T>, direction: Direction): Offset<T> {
+    return when (direction) {
+        Direction.INCREASING -> this.cast()
+        Direction.DECREASING -> Offset(objectLength.distance - this.distance)
+    }
+}
+
+/**
+ * Converts an undirected offset into a directed offset, using the object length and a direction.
+ */
+fun <T> Offset<T>.toDirected(objectLength: Length<T>, direction: Direction): DirOffset<T> {
+    return when (direction) {
+        Direction.INCREASING -> this.cast()
+        Direction.DECREASING -> Offset(objectLength.distance - this.distance)
+    }
+}
+
+/**
+ * Forces the conversion from <T> to <Directed<T>>. A little more type-safe than just .cast().
+ * Should generally only be used for Lengths, though as a type alias this isn't type-checked.
+ */
+fun <T> Length<T>.forceDirected(): DirOffset<T> {
+    return cast()
+}
+
+/**
+ * Forces the conversion from <Directed<T>> to <T>. A little more type-safe than just .cast().
+ * Should generally only be used for Lengths, though as a type alias this isn't type-checked.
+ */
+fun <T> Length<Directed<T>>.forceUndirected(): Offset<T> {
+    return cast()
+}


### PR DESCRIPTION
Depends on https://github.com/OpenRailAssociation/osrd/pull/14102 first

It's not actively used yet (and it adds some clutter when converting lengths). But it will help *a lot* with https://github.com/OpenRailAssociation/osrd/pull/14096. 