### PR TITLE
front: use OperationalPointIdentifier instead of OperationalPointReference when it's possible

### DIFF
--- a/front/src/applications/operationalStudies/hooks/usePathProjection.ts
+++ b/front/src/applications/operationalStudies/hooks/usePathProjection.ts
@@ -11,6 +11,7 @@ import {
   type PathfindingResult,
   type OperationalPointReference,
   type PathProperties,
+  type OperationalPointIdentifier,
 } from 'common/api/osrdEditoastApi';
 import { getExceptionFromOccurrenceId } from 'modules/timetableItem/helpers/pacedTrain';
 import type { TimetableItemId, TimetableItem } from 'reducers/osrdconf/types';
@@ -38,16 +39,14 @@ import { getStationFromOps, isOperationalPointReference } from '../utils';
  * Uses trigram --> UIC --> operational_point --> position-based fallbacks in priority order.
  */
 const getVirtualOpName = (
-  opRef: OperationalPointReference,
+  opId: OperationalPointIdentifier,
   index: number,
   totalCount: number,
   t: TFunction<'operational-studies'>
 ): string => {
-  if ('trigram' in opRef.operational_point && opRef.operational_point.trigram)
-    return opRef.operational_point.trigram;
-  if ('uic' in opRef.operational_point && opRef.operational_point.uic)
-    return opRef.operational_point.uic.toString();
-  if ('operational_point' in opRef.operational_point && opRef.operational_point.operational_point)
+  if ('trigram' in opId && opId.trigram) return opId.trigram;
+  if ('uic' in opId && opId.uic) return opId.uic.toString();
+  if ('operational_point' in opId && opId.operational_point)
     return t('main.operationalPointIdentifier');
   if (index === 0) return t('main.requestedOrigin');
   if (index === totalCount - 1) return t('main.requestedDestination');
@@ -61,14 +60,14 @@ const FALLBACK_DISTANCE_MM = 100_000_000;
  * Creates a virtual operational point with complete extensions when no infrastructure match is found.
  */
 const createVirtualOp = (
-  opRef: OperationalPointReference,
+  opId: OperationalPointIdentifier,
   index: number,
   totalCount: number,
   position: number,
   weight: number,
   t: TFunction<'operational-studies'>
 ): PathProperties['operational_points'][0] => {
-  const virtualName = getVirtualOpName(opRef, index, totalCount, t);
+  const virtualName = getVirtualOpName(opId, index, totalCount, t);
   const virtualId = `virtual_op_${virtualName}`;
 
   return {
@@ -76,19 +75,14 @@ const createVirtualOp = (
     extensions: {
       identifier: {
         name: virtualName,
-        uic: ('uic' in opRef.operational_point && opRef.operational_point.uic) || 0,
+        uic: ('uic' in opId && opId.uic) || 0,
       },
       sncf: {
-        ch:
-          ('secondary_code' in opRef.operational_point && opRef.operational_point.secondary_code) ||
-          '',
+        ch: ('secondary_code' in opId && opId.secondary_code) || '',
         ch_long_label: '',
         ch_short_label: '',
-        ci:
-          'uic' in opRef.operational_point && opRef.operational_point.uic
-            ? Number(formatUicToCi(opRef.operational_point.uic))
-            : 0,
-        trigram: ('trigram' in opRef.operational_point && opRef.operational_point.trigram) || '',
+        ci: 'uic' in opId && opId.uic ? Number(formatUicToCi(opId.uic)) : 0,
+        trigram: ('trigram' in opId && opId.trigram) || '',
       },
     },
     part: { track: '', position: 0 },
@@ -268,7 +262,9 @@ const usePathProjection = (
       } else {
         // NOT MATCHED: Point doesn't exist in infrastructure (e.g., NGE point)
         // Create virtual point from the reference
-        normalizedOps.push(createVirtualOp(opRef, index, opRefs.length, position, weight, t));
+        normalizedOps.push(
+          createVirtualOp(opRef.operational_point, index, opRefs.length, position, weight, t)
+        );
       }
     });
 

--- a/front/src/applications/operationalStudies/utils.ts
+++ b/front/src/applications/operationalStudies/utils.ts
@@ -3,6 +3,7 @@ import { type Dictionary, isEqual } from 'lodash';
 
 import type {
   OperationalPoint,
+  OperationalPointIdentifier,
   OperationalPointReference,
   PathfindingResultSuccess,
   PathItemLocation,
@@ -483,10 +484,10 @@ export const groupRoundTrips = (
   return { oneWays, roundTrips, others };
 };
 
-export const getInvalidStepLabel = ({ operational_point }: OperationalPointReference) => {
-  if ('uic' in operational_point) return operational_point.uic.toString();
-  if ('trigram' in operational_point) return operational_point.trigram;
-  return operational_point.operational_point;
+export const getInvalidStepLabel = (opId: OperationalPointIdentifier) => {
+  if ('uic' in opId) return opId.uic.toString();
+  if ('trigram' in opId) return opId.trigram;
+  return opId.operational_point;
 };
 
 export const matchOpRefAndOp = (

--- a/front/src/applications/operationalStudies/views/Scenario/components/RoundTrips/utils.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/RoundTrips/utils.ts
@@ -38,7 +38,7 @@ const getStepLabels = (
       acc.push(
         !isOperationalPointReference(step.location)
           ? t('requestedPointUnknown')
-          : getInvalidStepLabel(step.location)
+          : getInvalidStepLabel(step.location.operational_point)
       );
       return acc;
     }

--- a/front/src/modules/timesStops/helpers/utils.ts
+++ b/front/src/modules/timesStops/helpers/utils.ts
@@ -386,5 +386,5 @@ export const getOperationalPointName = (
   }
 
   // Invalid step
-  return getInvalidStepLabel(step);
+  return getInvalidStepLabel(step.operational_point);
 };


### PR DESCRIPTION
close #14072 