### PR TITLE
editoast: openfga tuples gc

### DIFF
--- a/editoast/fga/src/client.rs
+++ b/editoast/fga/src/client.rs
@@ -12,9 +12,12 @@ use queries::BatchCheckSingleResult;
 use queries::RawUser;
 use queries::UserFilter;
 pub use stores::Store;
+use tuples::RawTuple;
+pub use tuples::UntypedTuple;
+pub use tuples::UntypedUserSet;
+pub use tuples::UserOrUserSet;
 
 use tracing::Instrument;
-use tuples::RawTuple;
 use url::Url;
 use uuid::Uuid;
 
@@ -320,6 +323,28 @@ impl Client {
             )
             .await?;
         Ok(!tuples.is_empty())
+    }
+
+    pub fn list_tuples(
+        &self,
+    ) -> impl stream::TryStream<Ok = UntypedTuple, Error = RequestFailure> + '_ {
+        Continuation::stream(move |continuation| {
+            async move {
+                let (tuples, continuation_str) = self
+                    .get_stores_read(
+                        &self.store.id,
+                        None,
+                        Some(100),
+                        self.authorization_model_id.as_deref(),
+                        None,
+                        continuation.as_option().map(|s| s.to_string()),
+                    )
+                    .await?;
+                let typed_tuples = tuples.into_iter().map(UntypedTuple::from).collect();
+                Ok((typed_tuples, Continuation::from(continuation_str)))
+            }
+            .in_current_span()
+        })
     }
 
     /// Writes up to `n` tuples in OpenFGA, with `n` the maximum number of tuple writes
@@ -866,6 +891,10 @@ pub struct PreparedDeletes<'a> {
 
 impl PreparedDeletes<'_> {
     pub fn push<R: Relation, U: AsUser<User = R::User>>(&mut self, tuple: &Tuple<'_, R, U>) {
+        self.deletes.push(RawTuple::from(tuple));
+    }
+
+    pub fn push_untyped(&mut self, tuple: UntypedTuple) {
         self.deletes.push(RawTuple::from(tuple));
     }
 

--- a/editoast/fga/src/client/tuples.rs
+++ b/editoast/fga/src/client/tuples.rs
@@ -4,6 +4,7 @@ use crate::model::AsUser;
 use crate::model::Object as _;
 use crate::model::Relation;
 use crate::model::Tuple;
+use crate::model::Type;
 
 use super::Client;
 use super::Consistency;
@@ -14,6 +15,89 @@ pub(super) struct RawTuple {
     pub(super) user: String,
     pub(super) relation: String,
     pub(super) object: String,
+}
+
+/// Untyped tuple that can be cast to a typed relation
+#[derive(Debug, Clone)]
+pub struct UntypedTuple {
+    user: String,
+    relation: String,
+    object: String,
+}
+
+#[derive(Debug, Clone)]
+pub enum UserOrUserSet<R: Relation> {
+    /// Direct user
+    User(R::User),
+    /// Userset `"type:id#relation"`
+    UserSet(UntypedUserSet),
+}
+
+/// A userset reference extracted from an untyped tuple
+#[derive(Debug, Clone)]
+pub struct UntypedUserSet {
+    type_name: String,
+    id: String,
+}
+
+impl UntypedUserSet {
+    /// Tries to parse the userset's object as a specific type `T`
+    pub fn as_type<T: Type>(&self) -> Option<T> {
+        if self.type_name != T::NAMESPACE {
+            return None;
+        }
+        self.id.parse().ok()
+    }
+}
+
+impl UntypedTuple {
+    /// Casts the untyped tuple to a typed relation.
+    pub fn as_relation<R: Relation>(&self, _relation: R) -> Option<(UserOrUserSet<R>, R::Object)> {
+        if self.relation != R::NAME {
+            return None;
+        }
+
+        let object = self
+            .object
+            .strip_prefix(&format!("{}:", R::Object::NAMESPACE))?
+            .parse()
+            .ok()?;
+
+        let user = if let Some((object_part, _relation)) = self.user.split_once('#') {
+            let (type_name, id) = object_part.split_once(':')?;
+            UserOrUserSet::UserSet(UntypedUserSet {
+                type_name: type_name.to_string(),
+                id: id.to_string(),
+            })
+        } else {
+            let id_str = self
+                .user
+                .strip_prefix(&format!("{}:", R::User::NAMESPACE))?;
+            UserOrUserSet::User(id_str.parse().ok()?)
+        };
+
+        Some((user, object))
+    }
+}
+
+impl From<RawTuple> for UntypedTuple {
+    fn from(raw: RawTuple) -> Self {
+        UntypedTuple {
+            user: raw.user,
+            relation: raw.relation,
+            object: raw.object,
+        }
+    }
+}
+
+impl From<UntypedTuple> for RawTuple {
+    fn from(untyped: UntypedTuple) -> Self {
+        RawTuple {
+            user: untyped.user,
+            relation: untyped.relation,
+            object: untyped.object,
+        }
+    }
 }
 
 impl<'a, R: Relation, U: AsUser<User = R::User>> From<&Tuple<'a, R, U>> for RawTuple {

--- a/editoast/src/client/garbage_collector.rs
+++ b/editoast/src/client/garbage_collector.rs
@@ -4,9 +4,29 @@ use std::sync::Arc;
 
 use crate::models::train_schedule_set::TrainScheduleSet;
 
-pub async fn run_garbage_collector(db_pool: Arc<DbConnectionPoolV2>) -> anyhow::Result<()> {
+use crate::client::OpenfgaConfig;
+use crate::models::infra::Infra;
+use editoast_models::Group;
+use editoast_models::User;
+use editoast_models::prelude::*;
+use fga::client::UntypedTuple;
+use fga::client::UserOrUserSet;
+use futures::TryStreamExt as _;
+use std::collections::HashSet;
+
+struct ExistingEntities {
+    users: HashSet<i64>,
+    groups: HashSet<i64>,
+    infras: HashSet<i64>,
+}
+
+pub async fn run_garbage_collector(
+    db_pool: Arc<DbConnectionPoolV2>,
+    openfga_config: OpenfgaConfig,
+) -> anyhow::Result<()> {
     clean_orphaned_timetables(&db_pool).await?;
     clean_orphaned_train_schedule_sets(&db_pool).await?;
+    clean_orphaned_openfga_tuples(&db_pool, openfga_config).await?;
     Ok(())
 }
 
@@ -45,14 +65,158 @@ async fn clean_orphaned_train_schedule_sets(
     Ok(())
 }
 
+/// Deletes OpenFGA tuples that are not related to any existing infra, group or user
+async fn clean_orphaned_openfga_tuples(
+    db_pool: &Arc<DbConnectionPoolV2>,
+    openfga_config: OpenfgaConfig,
+) -> anyhow::Result<()> {
+    println!("🧹 Removing orphaned openfga tuples...");
+    let regulator = openfga_config.into_regulator(db_pool.clone()).await?;
+    let deleted_count = delete_orphaned_tuples(regulator.openfga(), db_pool).await?;
+
+    if deleted_count == 0 {
+        println!("✨ No orphaned openfga tuples found");
+    } else {
+        println!("✅ {} orphaned openfga tuple(s) deleted", deleted_count);
+    }
+    Ok(())
+}
+
+async fn delete_orphaned_tuples(
+    client: &fga::Client,
+    db_pool: &Arc<DbConnectionPoolV2>,
+) -> anyhow::Result<usize> {
+    let entities = load_existing_entities(db_pool).await?;
+
+    let mut deletes = client.prepare_deletes();
+    let mut stream = client
+        .list_tuples()
+        .try_filter(|untyped| futures::future::ready(is_tuple_orphaned(untyped, &entities)));
+    let mut count = 0;
+    while let Some(untyped) = stream.try_next().await? {
+        deletes.push_untyped(untyped);
+        count += 1;
+    }
+    deletes.execute().await?;
+    Ok(count)
+}
+
+async fn load_existing_entities(
+    db_pool: &Arc<DbConnectionPoolV2>,
+) -> anyhow::Result<ExistingEntities> {
+    let conn = &mut db_pool.get().await?;
+
+    let users = User::list(conn, SelectionSettings::new())
+        .await?
+        .into_iter()
+        .map(|user| user.id)
+        .collect();
+
+    let groups = Group::list(conn, SelectionSettings::new())
+        .await?
+        .into_iter()
+        .map(|group| group.id)
+        .collect();
+
+    let infras = Infra::list(conn, SelectionSettings::new())
+        .await?
+        .into_iter()
+        .map(|infra| infra.id)
+        .collect();
+
+    Ok(ExistingEntities {
+        users,
+        groups,
+        infras,
+    })
+}
+
+fn is_userset_orphaned(userset: &fga::client::UntypedUserSet, entities: &ExistingEntities) -> bool {
+    if let Some(group) = userset.as_type::<authz::Group>() {
+        !entities.groups.contains(&group.0)
+    } else if let Some(user) = userset.as_type::<authz::User>() {
+        !entities.users.contains(&user.0)
+    } else {
+        tracing::warn!(userset = ?userset, "OpenFGA GC: unrecognized userset type, kept for safety");
+        false
+    }
+}
+
+fn is_orphaned_infra_relation<R>(
+    untyped: &UntypedTuple,
+    relation: R,
+    entities: &ExistingEntities,
+) -> Option<bool>
+where
+    R: fga::model::Relation<User = authz::User, Object = authz::Infra>,
+{
+    let (user, infra) = untyped.as_relation(relation)?;
+    if !entities.infras.contains(&infra.0) {
+        return Some(true);
+    }
+    Some(match user {
+        UserOrUserSet::User(user) => !entities.users.contains(&user.0),
+        UserOrUserSet::UserSet(userset) => is_userset_orphaned(&userset, entities),
+    })
+}
+
+/// Checks if a tuple references orphaned entities
+fn is_tuple_orphaned(untyped: &UntypedTuple, entities: &ExistingEntities) -> bool {
+    // Infra relations
+    if let Some(is_orphaned) = is_orphaned_infra_relation(untyped, authz::Infra::reader(), entities)
+        .or_else(|| is_orphaned_infra_relation(untyped, authz::Infra::writer(), entities))
+        .or_else(|| is_orphaned_infra_relation(untyped, authz::Infra::owner(), entities))
+    {
+        return is_orphaned;
+    }
+
+    // User relations
+    if let Some(is_orphaned) = untyped
+        .as_relation(authz::User::role())
+        .map(|(_, user)| !entities.users.contains(&user.0))
+        .or_else(|| {
+            let (group, user) = untyped.as_relation(authz::User::group())?;
+            let group_orphaned = match group {
+                UserOrUserSet::User(group) => !entities.groups.contains(&group.0),
+                UserOrUserSet::UserSet(userset) => is_userset_orphaned(&userset, entities),
+            };
+            Some(!entities.users.contains(&user.0) || group_orphaned)
+        })
+    {
+        return is_orphaned;
+    }
+
+    // Group relations
+    if let Some(is_orphaned) = untyped
+        .as_relation(authz::Group::role())
+        .map(|(_, group)| !entities.groups.contains(&group.0))
+        .or_else(|| {
+            let (member, group) = untyped.as_relation(authz::Group::member())?;
+            let member_orphaned = match member {
+                UserOrUserSet::User(user) => !entities.users.contains(&user.0),
+                UserOrUserSet::UserSet(userset) => is_userset_orphaned(&userset, entities),
+            };
+            Some(!entities.groups.contains(&group.0) || member_orphaned)
+        })
+    {
+        return is_orphaned;
+    }
+
+    tracing::warn!(tuple = ?untyped, "OpenFGA GC: unrecognized relation, tuple kept for safety");
+    false
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::models::fixtures::create_empty_infra;
     use crate::models::fixtures::create_scenario_fixtures_set;
     use crate::models::fixtures::create_timetable;
     use crate::models::stdcm_search_environment::StdcmSearchEnvironment;
     use crate::models::stdcm_search_environment::tests::stdcm_search_env_fixtures;
-    use editoast_models::prelude::*;
+    use authz::StorageDriver;
+    use authz::identity::GroupInfo;
+    use editoast_models::PgAuthDriver;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_clean_orphaned_timetables() {
@@ -132,5 +296,136 @@ mod tests {
             .await
             .unwrap();
         assert!(found, "Train schedule set should exist")
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn test_clean_orphaned_openfga_tuples() {
+        use fga::model::Relation;
+
+        // Setup FGA client with migrations
+        let client = fga::test_client!("authz@");
+        fga_migrations::run_migrations(
+            client.clone(),
+            fga::test_client!("migrations@"),
+            fga_migrations::TargetMigration::Latest,
+        )
+        .await
+        .expect("FGA migrations should succeed");
+
+        // Create entities in DB
+        let db_pool = Arc::new(DbConnectionPoolV2::for_tests());
+        let driver = PgAuthDriver::new(db_pool.clone());
+
+        let (fga_infra, orphan_infra) = {
+            let conn = &mut db_pool.get_ok();
+            let existing = create_empty_infra(conn).await;
+            let orphan = create_empty_infra(conn).await;
+            (authz::Infra(existing.id), authz::Infra(orphan.id))
+        };
+        let existing_user = authz::User(
+            driver
+                .ensure_user(&"alice".into(), &"alice".into())
+                .await
+                .unwrap()
+                .id,
+        );
+        let orphan_user = authz::User(
+            driver
+                .ensure_user(&"bob".into(), &"bob".into())
+                .await
+                .unwrap()
+                .id,
+        );
+        let existing_group = authz::Group(
+            driver
+                .ensure_group(&GroupInfo {
+                    name: "existing-group".into(),
+                })
+                .await
+                .unwrap(),
+        );
+        let orphan_group = authz::Group(
+            driver
+                .ensure_group(&GroupInfo {
+                    name: "orphan-group".into(),
+                })
+                .await
+                .unwrap(),
+        );
+
+        // Write tuples: direct users + group usersets, on both the existing and orphan infra
+        client
+            .prepare_writes()
+            .write(&authz::Infra::reader().tuple(&existing_user, &fga_infra))
+            .write(&authz::Infra::reader().tuple(&orphan_user, &fga_infra))
+            .write(
+                &authz::Infra::reader()
+                    .tuple(authz::Group::member().userset(&existing_group), &fga_infra),
+            )
+            .write(
+                &authz::Infra::reader()
+                    .tuple(authz::Group::member().userset(&orphan_group), &fga_infra),
+            )
+            .write(&authz::Infra::reader().tuple(&existing_user, &orphan_infra))
+            .execute()
+            .await
+            .unwrap();
+
+        // Delete orphan entities from DB
+        driver.delete_user(orphan_user.0).await.unwrap();
+        driver.delete_group(orphan_group.0).await.unwrap();
+        {
+            let conn = &mut db_pool.get_ok();
+            Infra::delete_static(conn, orphan_infra.0).await.unwrap();
+        }
+
+        // Run GC — 2 orphaned by user/group deletion + 1 orphaned by infra deletion
+        let deleted = delete_orphaned_tuples(&client, &db_pool).await.unwrap();
+        assert_eq!(deleted, 3, "should delete exactly the 3 orphaned tuples");
+
+        // Existing tuples should remain
+        assert!(
+            client
+                .tuple_exists(authz::Infra::reader().tuple(&existing_user, &fga_infra))
+                .await
+                .unwrap(),
+            "tuple for existing user should remain"
+        );
+        assert!(
+            client
+                .tuple_exists(
+                    authz::Infra::reader()
+                        .tuple(authz::Group::member().userset(&existing_group), &fga_infra,)
+                )
+                .await
+                .unwrap(),
+            "tuple for existing group should remain"
+        );
+
+        // Orphaned tuples should be gone
+        assert!(
+            !client
+                .tuple_exists(authz::Infra::reader().tuple(&orphan_user, &fga_infra))
+                .await
+                .unwrap(),
+            "tuple for deleted user should be removed"
+        );
+        assert!(
+            !client
+                .tuple_exists(
+                    authz::Infra::reader()
+                        .tuple(authz::Group::member().userset(&orphan_group), &fga_infra,)
+                )
+                .await
+                .unwrap(),
+            "tuple for deleted group should be removed"
+        );
+        assert!(
+            !client
+                .tuple_exists(authz::Infra::reader().tuple(&existing_user, &orphan_infra))
+                .await
+                .unwrap(),
+            "tuple for deleted infra should be removed"
+        );
     }
 }

--- a/editoast/src/client/mod.rs
+++ b/editoast/src/client/mod.rs
@@ -94,7 +94,11 @@ pub enum Commands {
     User(UserCommand),
     #[command(about, long_about = "Healthcheck")]
     Healthcheck(CoreArgs),
-    #[command(about, long_about = "Garbage collector")]
+    #[command(
+        about,
+        long_about = "Garbage collector.\nWarning: tuple deletions in OpenFGA are not idempotent, 
+        so do not run this command multiple times concurrently or setup some external locking."
+    )]
     Gc,
 }
 

--- a/editoast/src/main.rs
+++ b/editoast/src/main.rs
@@ -230,6 +230,8 @@ async fn run() -> anyhow::Result<()> {
         Commands::Healthcheck(core_config) => {
             healthcheck_cmd(db_pool.into(), valkey_config, core_config, openfga_config).await
         }
-        Commands::Gc => garbage_collector::run_garbage_collector(db_pool.into()).await,
+        Commands::Gc => {
+            garbage_collector::run_garbage_collector(db_pool.into(), openfga_config).await
+        }
     }
 }


### PR DESCRIPTION
Add a garbage collection mechanism to clean up OpenFGA authorization tuples
that reference deleted entities (users, groups, or infrastructures).

- Add `Client::list_tuples()` returning a paginated stream of `UntypedTuple`
- Add `UntypedTuple::as_relation<R: Relation>()` to cast untyped tuples
  to typed relations
- Integrate OpenFGA tuple GC into `cargo run gc` command