### PR TITLE
front: install dependencies with --ignore-scripts

### DIFF
--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -75,8 +75,10 @@ ENV VITE_OSRD_GIT_DESCRIBE=${OSRD_GIT_DESCRIBE}
 COPY --from=front_src . /app
 
 # If SKIP_FRONT is set to 1, skip the front build
+# Ignore scripts to ensure none of our dependencies need to run code at
+# install time, because this is a common attack vector
 RUN --mount=type=cache,target=/root/.npm \
-    if [ "$SKIP_FRONT" = "1" ]; then exit 0; else npm ci; fi
+    if [ "$SKIP_FRONT" = "1" ]; then exit 0; else npm ci --ignore-scripts; fi
 
 # Generate the licenses file and build
 ENV NODE_OPTIONS="--max_old_space_size=4096"


### PR DESCRIPTION
NPM packages can specify a script to be run at install time. This is a common attack vector for compromised NPM packages.

Ignore scripts in CI to ensure none of our dependencies rely on install scripts and allow developers to globally turn off NPM scripts:

    echo "ignore-scripts=true" >>~/.npmrc