### PR TITLE
github: add cooldown for NPM dependabot upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -120,6 +120,8 @@ updates:
     directory: "/core/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 5
     commit-message:
       prefix: "core:"
     open-pull-requests-limit: 100

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,6 +46,8 @@ updates:
     directory: "/front/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 5
     groups:
       eslint:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -137,6 +137,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 5
     commit-message:
       prefix: "actions:"
     open-pull-requests-limit: 100

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -106,6 +106,8 @@ updates:
     directory: "/python/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 5
     commit-message:
       prefix: "python:"
     open-pull-requests-limit: 0
@@ -116,6 +118,8 @@ updates:
     directory: "/tests/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 5
     commit-message:
       prefix: "tests:"
     open-pull-requests-limit: 0

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/editoast/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 5
     groups:
       opentelemetry:
         patterns:
@@ -18,6 +20,8 @@ updates:
     directory: "/gateway/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 5
     groups:
       opentelemetry:
         patterns:
@@ -32,6 +36,8 @@ updates:
     directory: "/osrdyne/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 5
     groups:
       opentelemetry:
         patterns:


### PR DESCRIPTION
The NPM ecosystem is a bit of a trainwreck: regularly, some widely used NPM packages are compromised. We absolutely don't need to upgrade our dependencies as soon as a new version comes out, instead wait for a bit to allow dust to settle and security issues to be discovered.

See e.g. this article for a detailed motivation:
https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns