### PR TITLE
editoast: cleanup unnecessary dependencies in Cargo.toml files

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -349,11 +349,9 @@ version = "0.1.0"
 dependencies = [
  "common",
  "derive_more",
- "editoast_derive",
  "fga",
  "fga_migrations",
  "futures 0.3.31",
- "itertools 0.14.0",
  "pretty_assertions",
  "serde",
  "stdext",
@@ -650,7 +648,6 @@ name = "cache"
 version = "0.1.0"
 dependencies = [
  "arcstr",
- "deadpool",
  "deadpool-redis",
  "futures 0.3.31",
  "lz4_flex",
@@ -834,12 +831,10 @@ name = "common"
 version = "0.1.0"
 dependencies = [
  "opentelemetry",
- "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "rangemap",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -921,12 +916,10 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 name = "core_client"
 version = "0.1.0"
 dependencies = [
- "approx",
  "chrono",
  "common",
  "core_client",
  "deadpool",
- "editoast_derive",
  "educe",
  "futures-util",
  "hostname",
@@ -1377,7 +1370,6 @@ dependencies = [
  "core_task",
  "dashmap",
  "database",
- "deadpool",
  "deadpool-redis",
  "derive_more",
  "diesel",
@@ -1393,18 +1385,12 @@ dependencies = [
  "futures-util",
  "geos",
  "headers",
- "hostname",
  "image",
  "inventory",
  "itertools 0.14.0",
  "json-patch",
- "lapin",
  "linkme",
- "mime",
- "mvt",
- "opentelemetry",
  "opentelemetry-otlp",
- "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "ordered-float",
  "osrdyne_client",
@@ -1414,7 +1400,6 @@ dependencies = [
  "pretty_assertions",
  "rand 0.9.2",
  "rangemap",
- "regex",
  "reqwest",
  "rstest",
  "schemas",
@@ -1429,11 +1414,9 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.17",
  "tokio",
- "tokio-util",
  "tower",
  "tower-http",
  "tracing",
- "tracing-opentelemetry",
  "tracing-subscriber",
  "uom",
  "url",
@@ -4842,7 +4825,6 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
- "tracing",
 ]
 
 [[package]]

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -174,7 +174,6 @@ core_client = { workspace = true, features = ["mocking_client"] }
 core_task = { path = "./core_task" }
 dashmap.workspace = true
 database.workspace = true
-deadpool.workspace = true
 deadpool-redis.workspace = true
 derive_more.workspace = true
 diesel.workspace = true
@@ -190,7 +189,6 @@ futures.workspace = true
 futures-util.workspace = true
 geos.workspace = true
 headers = "0.4.1"
-hostname.workspace = true
 image = { version = "0.25.9", default-features = false, features = [
   "bmp",
   "gif",
@@ -204,13 +202,8 @@ itertools.workspace = true
 json-patch = { version = "4.1.0", default-features = false, features = [
   "utoipa",
 ] }
-lapin.workspace = true
 linkme.workspace = true
-mime = "0.3.17"
-mvt.workspace = true
-opentelemetry.workspace = true
 opentelemetry-otlp.workspace = true
-opentelemetry-semantic-conventions.workspace = true
 opentelemetry_sdk.workspace = true
 ordered-float.workspace = true
 osrdyne_client.workspace = true
@@ -219,7 +212,6 @@ petgraph = "0.8.2"
 postgis_diesel.workspace = true
 rand.workspace = true
 rangemap.workspace = true
-regex.workspace = true
 reqwest.workspace = true
 schemas.workspace = true
 search = { workspace = true }
@@ -231,7 +223,6 @@ sha1.workspace = true
 strum.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
-tokio-util = { version = "0.7.16", features = ["io", "tracing"] }
 tower = "0.5.2"
 tower-http = { version = "0.6.6", features = [
   "cors",
@@ -241,7 +232,6 @@ tower-http = { version = "0.6.6", features = [
   "trace",
 ] }
 tracing.workspace = true
-tracing-opentelemetry.workspace = true
 tracing-subscriber.workspace = true
 uom.workspace = true
 url.workspace = true

--- a/editoast/authz/Cargo.toml
+++ b/editoast/authz/Cargo.toml
@@ -7,11 +7,9 @@ edition.workspace = true
 [dependencies]
 common.workspace = true
 derive_more.workspace = true
-editoast_derive.workspace = true
 fga.workspace = true
 fga_migrations = { workspace = true, features = ["test_utilities"] }
 futures.workspace = true
-itertools.workspace = true
 serde = { workspace = true, features = ["derive"] }
 strum.workspace = true
 thiserror.workspace = true

--- a/editoast/cache/Cargo.toml
+++ b/editoast/cache/Cargo.toml
@@ -9,7 +9,6 @@ mock = ["redis-test"]
 
 [dependencies]
 arcstr.workspace = true
-deadpool.workspace = true
 deadpool-redis.workspace = true
 futures.workspace = true
 lz4_flex = { version = "0.12.0", default-features = false, features = [

--- a/editoast/common/Cargo.toml
+++ b/editoast/common/Cargo.toml
@@ -8,12 +8,10 @@ edition.workspace = true
 
 [dependencies]
 opentelemetry.workspace = true
-opentelemetry-semantic-conventions.workspace = true
 opentelemetry_sdk.workspace = true
 rangemap.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
-thiserror.workspace = true
 tracing.workspace = true
 tracing-opentelemetry.workspace = true
 tracing-subscriber.workspace = true

--- a/editoast/core_client/Cargo.toml
+++ b/editoast/core_client/Cargo.toml
@@ -8,11 +8,9 @@ license.workspace = true
 mocking_client = ["dep:http"]
 
 [dependencies]
-approx.workspace = true
 chrono.workspace = true
 common = { workspace = true }
 deadpool.workspace = true
-editoast_derive.workspace = true
 educe.workspace = true
 futures-util.workspace = true
 hostname.workspace = true


### PR DESCRIPTION
Thanks to `cargo-shear`.

Signed-off-by: Leo Valais <leo.valais97@gmail.com>
