### PR TITLE
editoast: editoast_derive: fix typo in tracing record

### DIFF
--- a/editoast/editoast_derive/src/model/codegen/retrieve_batch_impl.rs
+++ b/editoast/editoast_derive/src/model/codegen/retrieve_batch_impl.rs
@@ -87,7 +87,7 @@ impl ToTokens for RetrieveBatchImpl {
             impl crate::prelude::RetrieveBatchUnchecked<#ty> for #model {
                 type Error = #error;
 
-                #[tracing::instrument(name = #span_name, skip_all, err, fields(query_id))]
+                #[tracing::instrument(name = #span_name, skip_all, err, fields(query_ids))]
                 async fn retrieve_batch_unchecked<
                     I: std::iter::IntoIterator<Item = #ty> + Send,
                     C: Default + std::iter::Extend<#model> + Send + std::fmt::Debug,
@@ -106,7 +106,7 @@ impl ToTokens for RetrieveBatchImpl {
                     Ok({ #retrieve_loop })
                 }
 
-                #[tracing::instrument(name = #span_name_with_key, skip_all, err, fields(query_id))]
+                #[tracing::instrument(name = #span_name_with_key, skip_all, err, fields(query_ids))]
                 async fn retrieve_batch_with_key_unchecked<
                     I: std::iter::IntoIterator<Item = #ty> + Send,
                     C: Default + std::iter::Extend<(#ty, #model)> + Send + std::fmt::Debug,

--- a/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__construction.snap
+++ b/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__construction.snap
@@ -732,7 +732,7 @@ impl crate::prelude::RetrieveBatchUnchecked<(String)> for Document {
         name = "model:retrieve_batch_unchecked<Document>",
         skip_all,
         err,
-        fields(query_id)
+        fields(query_ids)
     )]
     async fn retrieve_batch_unchecked<
         I: std::iter::IntoIterator<Item = (String)> + Send,
@@ -777,7 +777,7 @@ impl crate::prelude::RetrieveBatchUnchecked<(String)> for Document {
         name = "model:retrieve_batch_with_key_unchecked<Document>",
         skip_all,
         err,
-        fields(query_id)
+        fields(query_ids)
     )]
     async fn retrieve_batch_with_key_unchecked<
         I: std::iter::IntoIterator<Item = (String)> + Send,
@@ -830,7 +830,7 @@ impl crate::prelude::RetrieveBatchUnchecked<(i64)> for Document {
         name = "model:retrieve_batch_unchecked<Document>",
         skip_all,
         err,
-        fields(query_id)
+        fields(query_ids)
     )]
     async fn retrieve_batch_unchecked<
         I: std::iter::IntoIterator<Item = (i64)> + Send,
@@ -875,7 +875,7 @@ impl crate::prelude::RetrieveBatchUnchecked<(i64)> for Document {
         name = "model:retrieve_batch_with_key_unchecked<Document>",
         skip_all,
         err,
-        fields(query_id)
+        fields(query_ids)
     )]
     async fn retrieve_batch_with_key_unchecked<
         I: std::iter::IntoIterator<Item = (i64)> + Send,

--- a/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__single_pk_model.snap
+++ b/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__single_pk_model.snap
@@ -307,7 +307,7 @@ impl crate::prelude::RetrieveBatchUnchecked<(i64)> for Timetable {
         name = "model:retrieve_batch_unchecked<Timetable>",
         skip_all,
         err,
-        fields(query_id)
+        fields(query_ids)
     )]
     async fn retrieve_batch_unchecked<
         I: std::iter::IntoIterator<Item = (i64)> + Send,
@@ -352,7 +352,7 @@ impl crate::prelude::RetrieveBatchUnchecked<(i64)> for Timetable {
         name = "model:retrieve_batch_with_key_unchecked<Timetable>",
         skip_all,
         err,
-        fields(query_id)
+        fields(query_ids)
     )]
     async fn retrieve_batch_with_key_unchecked<
         I: std::iter::IntoIterator<Item = (i64)> + Send,


### PR DESCRIPTION
One of the recorded fields in the retrieve batch codegen was not properly named. This PR just fixes it