### PR TITLE
editoast: core openapi schema namespacing

### DIFF
--- a/editoast/core_client/src/conflict_detection.rs
+++ b/editoast/core_client/src/conflict_detection.rs
@@ -23,7 +23,7 @@ pub struct ConflictDetectionRequest {
     pub work_schedules: Option<WorkSchedulesRequest>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TrainRequirements {
     pub start_time: DateTime<Utc>,
     pub spacing_requirements: Vec<SpacingRequirement>,
@@ -32,6 +32,7 @@ pub struct TrainRequirements {
 
 // TODO: use struct in conflict detection instead of a Map<String, TrainRequirements>.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[schema(as = core::TrainRequirementsById)]
 pub struct TrainRequirementsById {
     pub train_id: String,
     pub start_time: DateTime<Utc>,
@@ -45,14 +46,13 @@ pub struct WorkSchedulesRequest {
     pub work_schedule_requirements: HashMap<String, WorkSchedule>,
 }
 
-#[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ConflictDetectionResponse {
     /// List of conflicts detected
-    #[schema(inline)]
     pub conflicts: Vec<Conflict>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Conflict {
     /// List of train schedule ids and paced train generated occurrences involved in the conflict
     pub train_ids: Vec<String>,
@@ -63,7 +63,6 @@ pub struct Conflict {
     /// Datetime of the end of the conflict
     pub end_time: DateTime<Utc>,
     /// Type of the conflict
-    #[schema(inline)]
     pub conflict_type: ConflictType,
     /// List of requirements causing the conflict
     pub requirements: Vec<ConflictRequirement>,
@@ -74,6 +73,7 @@ pub struct Conflict {
 /// The start and end time describe the conflicting time span (not the full
 /// requirement's time span).
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, ToSchema)]
+#[schema(as = core::ConflictRequirement)]
 pub struct ConflictRequirement {
     pub zone: String,
     pub start_time: DateTime<Utc>,
@@ -81,6 +81,7 @@ pub struct ConflictRequirement {
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, ToSchema, PartialEq)]
+#[schema(as = core::ConflictType)]
 pub enum ConflictType {
     /// Conflict caused by two trains being too close to each other, or between a train and a work schedule
     Spacing,

--- a/editoast/core_client/src/etcs_braking_curves.rs
+++ b/editoast/core_client/src/etcs_braking_curves.rs
@@ -27,7 +27,7 @@ pub struct Request {
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug, ToSchema)]
-#[schema(as = ETCSBrakingCurvesResponse)]
+#[schema(as = core::ETCSBrakingCurvesResponse)]
 pub struct Response {
     /// List of ETCS braking curves associated to the train schedule's ETCS slowdowns
     pub slowdowns: Vec<ETCSCurves>,
@@ -41,6 +41,7 @@ pub struct Response {
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug, ToSchema)]
+#[schema(as = core::ETCSCurves)]
 pub struct ETCSCurves {
     #[schema(inline)]
     pub indication: Option<SimpleEnvelope>,
@@ -51,6 +52,7 @@ pub struct ETCSCurves {
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug, ToSchema)]
+#[schema(as = core::ETCSConflictCurves)]
 pub struct ETCSConflictCurves {
     #[schema(inline)]
     pub indication: SimpleEnvelope,
@@ -63,6 +65,7 @@ pub struct ETCSConflictCurves {
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug, ToSchema)]
+#[schema(as = core::SimpleEnvelope)]
 pub struct SimpleEnvelope {
     /// List of positions of a train
     /// Both positions (in mm) and times (in ms) must have the same length

--- a/editoast/core_client/src/path_properties.rs
+++ b/editoast/core_client/src/path_properties.rs
@@ -41,6 +41,7 @@ pub struct PathPropertiesResponse {
 
 /// Property f64 values along a path. Each value is associated to a range of the path.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[schema(as = core::PropertyValuesF64)]
 #[cfg_attr(feature = "mocking_client", derive(PartialEq))]
 pub struct PropertyValuesF64 {
     /// List of `n` boundaries of the ranges.
@@ -60,6 +61,7 @@ impl PropertyValuesF64 {
 
 /// Electrification property along a path. Each value is associated to a range of the path.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[schema(as = core::PropertyElectrificationValues)]
 #[cfg_attr(feature = "mocking_client", derive(PartialEq))]
 pub struct PropertyElectrificationValues {
     /// List of `n` boundaries of the ranges.
@@ -79,6 +81,7 @@ impl PropertyElectrificationValues {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[schema(as = core::PropertyElectrificationValue)]
 #[cfg_attr(feature = "mocking_client", derive(PartialEq))]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum PropertyElectrificationValue {
@@ -92,6 +95,7 @@ pub enum PropertyElectrificationValue {
 
 /// Operational point along a path.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[schema(as = core::OperationalPointOnPath)]
 #[cfg_attr(feature = "mocking_client", derive(PartialEq))]
 pub struct OperationalPointOnPath {
     /// Id of the operational point
@@ -131,6 +135,7 @@ impl OperationalPointOnPath {
 
 /// Zones along a path. Each value is associated to a range of the path.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[schema(as = core::PropertyZoneValues)]
 pub struct PropertyZoneValues {
     /// List of `n` boundaries of the ranges.
     /// A boundary is a distance from the beginning of the path in mm.

--- a/editoast/core_client/src/pathfinding.rs
+++ b/editoast/core_client/src/pathfinding.rs
@@ -38,23 +38,27 @@ pub struct PathfindingRequest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
+#[schema(as = core::OffsetRange)]
 pub struct OffsetRange {
     start: u64,
     end: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
+#[schema(as = core::IncompatibleOffsetRangeWithValue)]
 pub struct IncompatibleOffsetRangeWithValue {
     range: OffsetRange,
     value: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
+#[schema(as = core::IncompatibleOffsetRange)]
 pub struct IncompatibleOffsetRange {
     range: OffsetRange,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
+#[schema(as = core::IncompatibleConstraints)]
 pub struct IncompatibleConstraints {
     incompatible_electrification_ranges: Vec<IncompatibleOffsetRangeWithValue>,
     incompatible_gauge_ranges: Vec<IncompatibleOffsetRange>,
@@ -62,6 +66,7 @@ pub struct IncompatibleConstraints {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, ToSchema)]
+#[schema(as = core::InvalidPathItem)]
 pub struct InvalidPathItem {
     pub index: usize,
     pub path_item: PathItemLocation,
@@ -98,6 +103,7 @@ pub enum PathfindingCoreResult {
 
 /// A successful pathfinding result. This is also used for STDCM response.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, ToSchema)]
+#[schema(as = core::PathfindingResultSuccess)]
 #[cfg_attr(feature = "mocking_client", derive(Default))]
 pub struct PathfindingResultSuccess {
     /// Full description of the path data
@@ -111,6 +117,7 @@ pub struct PathfindingResultSuccess {
 
 // Enum for input-related errors
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, ToSchema)]
+#[schema(as = core::PathfindingInputError)]
 #[serde(tag = "error_type", rename_all = "snake_case")]
 pub enum PathfindingInputError {
     InvalidPathItems {
@@ -126,6 +133,7 @@ pub enum PathfindingInputError {
 
 // Enum for not-found results and incompatible constraints
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, ToSchema, Default)]
+#[schema(as = core::PathfindingNotFound)]
 #[serde(tag = "error_type", rename_all = "snake_case")]
 pub enum PathfindingNotFound {
     NotFoundInBlocks {
@@ -147,7 +155,7 @@ pub enum PathfindingNotFound {
 /// An oriented range on a track section.
 /// `begin` is always less than `end`.
 #[derive(Serialize, Deserialize, Clone, Debug, ToSchema, Hash, PartialEq, Eq)]
-#[schema(as = CoreTrackRange)]
+#[schema(as = core::TrackRange)]
 pub struct TrackRange {
     /// The track section identifier.
     #[schema(inline)]
@@ -174,6 +182,7 @@ impl TrackRange {
 
 /// A range on a linear object (usually block or route)
 #[derive(Serialize, Deserialize, Clone, Debug, ToSchema, Hash, PartialEq, Eq)]
+#[schema(as = core::ObjectRange)]
 pub struct ObjectRange {
     /// The object identifier.
     #[schema(inline)]
@@ -187,6 +196,7 @@ pub struct ObjectRange {
 /// A valid train path, as returned from the pathfinding.
 /// Can be used as-is as input for other endpoints.
 #[derive(Serialize, Deserialize, Clone, Debug, ToSchema, Hash, PartialEq, Eq, Default)]
+#[schema(as = core::TrainPath)]
 pub struct TrainPath {
     /// Block ranges, in order.
     pub blocks: Vec<ObjectRange>,

--- a/editoast/core_client/src/signal_projection.rs
+++ b/editoast/core_client/src/signal_projection.rs
@@ -22,6 +22,7 @@ pub struct SignalUpdatesRequest<'a> {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
+#[schema(as = core::SignalUpdate)]
 pub struct SignalUpdate {
     /// The id of the updated signal
     pub signal_id: String,
@@ -51,7 +52,7 @@ pub struct TrainSimulation<'a> {
     pub simulation_end_time: u64,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SignalUpdatesResponse {
     pub signal_updates: Vec<Vec<SignalUpdate>>,
 }

--- a/editoast/core_client/src/simulation.rs
+++ b/editoast/core_client/src/simulation.rs
@@ -28,6 +28,7 @@ use crate::AsCoreRequest;
 use crate::Json;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Educe, PartialEq, ToSchema)]
+#[schema(as = core::PhysicsConsist)]
 #[educe(Hash)]
 pub struct PhysicsConsist {
     pub effort_curves: EffortCurves,
@@ -87,6 +88,7 @@ pub struct PhysicsConsist {
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Serialize, Deserialize, ToSchema)]
+#[schema(as = core::ZoneUpdate)]
 pub struct ZoneUpdate {
     pub zone: String,
     // Time in ms
@@ -124,6 +126,7 @@ pub struct SimulationPowerRestrictionItem {
 }
 
 #[derive(Deserialize, Default, PartialEq, Serialize, Clone, Debug, ToSchema)]
+#[schema(as = core::ReportTrain)]
 pub struct ReportTrain {
     /// List of positions of a train
     /// Both positions (in mm) and times (in ms) must have the same length
@@ -139,6 +142,7 @@ pub struct ReportTrain {
 }
 
 #[derive(Deserialize, Default, PartialEq, Serialize, Clone, Debug, ToSchema)]
+#[schema(as = core::CompleteReportTrain)]
 pub struct CompleteReportTrain {
     #[serde(flatten)]
     pub report_train: ReportTrain,
@@ -149,6 +153,7 @@ pub struct CompleteReportTrain {
 }
 
 #[derive(Debug, Clone, PartialEq, Hash, Serialize, Deserialize, ToSchema)]
+#[schema(as = core::SignalCriticalPosition)]
 /// First position (space and time) along the path where given signal must
 /// be free (sighting time or closed-signal stop ending)
 pub struct SignalCriticalPosition {
@@ -161,6 +166,7 @@ pub struct SignalCriticalPosition {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[schema(as = core::SpacingRequirement)]
 pub struct SpacingRequirement {
     pub zone: String,
     // Time in ms
@@ -170,6 +176,7 @@ pub struct SpacingRequirement {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[schema(as = core::RoutingRequirement)]
 pub struct RoutingRequirement {
     pub route: String,
     /// Time in ms
@@ -178,6 +185,7 @@ pub struct RoutingRequirement {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[schema(as = core::RoutingZoneRequirement)]
 pub struct RoutingZoneRequirement {
     pub zone: String,
     pub entry_detector: String,
@@ -188,6 +196,7 @@ pub struct RoutingZoneRequirement {
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[schema(as = core::ElectricalProfiles)]
 pub struct ElectricalProfiles {
     /// List of `n` boundaries of the ranges (block path).
     /// A boundary is a distance from the beginning of the path in mm.
@@ -198,6 +207,7 @@ pub struct ElectricalProfiles {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[schema(as = core::ElectricalProfileValue)]
 #[serde(tag = "electrical_profile_type", rename_all = "snake_case")]
 pub enum ElectricalProfileValue {
     NoProfile,
@@ -208,6 +218,7 @@ pub enum ElectricalProfileValue {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[schema(as = core::SpeedLimitSource)]
 #[serde(tag = "speed_limit_source_type", rename_all = "snake_case")]
 #[allow(clippy::enum_variant_names)]
 pub enum SpeedLimitSource {
@@ -217,6 +228,7 @@ pub enum SpeedLimitSource {
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[schema(as = core::SpeedLimitProperty)]
 pub struct SpeedLimitProperty {
     /// in meters per second
     pub speed: f64,
@@ -228,6 +240,7 @@ pub struct SpeedLimitProperty {
 /// A MRSP computation result (Most Restrictive Speed Profile)
 
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[schema(as = core::SpeedLimitProperties)]
 pub struct SpeedLimitProperties {
     /// List of `n` boundaries of the ranges (block path).
     /// A boundary is a distance from the beginning of the path in mm.
@@ -237,7 +250,7 @@ pub struct SpeedLimitProperties {
     pub values: Vec<SpeedLimitProperty>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SimulationPowerRestrictionRange {
     /// Start position in the path in mm
     begin: u64,

--- a/editoast/core_client/src/stdcm.rs
+++ b/editoast/core_client/src/stdcm.rs
@@ -18,7 +18,7 @@ use crate::AsCoreRequest;
 use crate::Json;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
-#[schema(as = StdcmRequest)]
+#[schema(as = core::StdcmRequest)]
 pub struct Request {
     /// Infrastructure id
     pub infra: i64,
@@ -29,7 +29,7 @@ pub struct Request {
 
     // Pathfinding inputs
     /// List of waypoints. Each waypoint is a list of track offset.
-    pub path_items: Vec<PathItem>, // FIXME: the schema is referenced in the openapi, not the struct below
+    pub path_items: Vec<PathItem>,
     /// The loading gauge of the rolling stock
     pub rolling_stock_loading_gauge: LoadingGaugeType,
     /// Set of authorized track section ids for the current request
@@ -60,13 +60,14 @@ pub struct Request {
     #[schema(inline)]
     pub margin: Option<MarginValue>,
     /// List of planned work schedules
-    pub work_schedules: Vec<WorkSchedule>, // FIXME: the schema is referenced in the openapi, not the struct below
+    pub work_schedules: Vec<WorkSchedule>,
     /// List of applicable temporary speed limits between the train departure and arrival
     #[schema(inline)]
-    pub temporary_speed_limits: Vec<TemporarySpeedLimit>, // FIXME: the schema is referenced in the openapi, not the struct below
+    pub temporary_speed_limits: Vec<TemporarySpeedLimit>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Deserialize, ToSchema)]
+#[schema(as = core::PathItem)]
 pub struct PathItem {
     /// The track offsets of the path item
     pub locations: Vec<TrackOffset>,
@@ -78,6 +79,7 @@ pub struct PathItem {
 
 /// Contains the data of a step timing, when it is specified
 #[derive(Debug, Clone, Serialize, PartialEq, Deserialize, ToSchema)]
+#[schema(as = core::StepTimingData)]
 pub struct StepTimingData {
     /// Time the train should arrive at this point
     pub arrival_time: DateTime<Utc>,
@@ -89,6 +91,7 @@ pub struct StepTimingData {
 
 /// Lighter description of a work schedule, with only the relevant information for core
 #[derive(Debug, Clone, Serialize, PartialEq, Deserialize, ToSchema)]
+#[schema(as = core::WorkSchedule)]
 pub struct WorkSchedule {
     /// Start time as a time delta from the stdcm start time in ms
     pub start_time: u64,
@@ -100,6 +103,7 @@ pub struct WorkSchedule {
 
 /// Lighter description of a work schedule with only the relevant information for core
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
+#[schema(as = core::TemporarySpeedLimit)]
 pub struct TemporarySpeedLimit {
     /// Speed limitation in m/s
     pub speed_limit: f64,
@@ -110,6 +114,7 @@ pub struct TemporarySpeedLimit {
 /// A range on a track section.
 /// `begin` is always less than `end`.
 #[derive(Serialize, Deserialize, Clone, Debug, ToSchema, Hash, PartialEq, Eq)]
+#[schema(as = core::UndirectedTrackRange)]
 pub struct UndirectedTrackRange {
     /// The track section identifier.
     pub track_section: String,

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -3950,7 +3950,7 @@ paths:
                     core_payload:
                       oneOf:
                       - type: 'null'
-                      - $ref: '#/components/schemas/StdcmRequest'
+                      - $ref: '#/components/schemas/core.StdcmRequest'
                     departure_time:
                       type: string
                       format: date-time
@@ -3969,7 +3969,7 @@ paths:
                     core_payload:
                       oneOf:
                       - type: 'null'
-                      - $ref: '#/components/schemas/StdcmRequest'
+                      - $ref: '#/components/schemas/core.StdcmRequest'
                     status:
                       type: string
                       enum:
@@ -3982,7 +3982,7 @@ paths:
                     core_payload:
                       oneOf:
                       - type: 'null'
-                      - $ref: '#/components/schemas/StdcmRequest'
+                      - $ref: '#/components/schemas/core.StdcmRequest'
                     error:
                       $ref: '#/components/schemas/SimulationResponse'
                     status:
@@ -12996,222 +12996,6 @@ components:
         value:
           type: string
           format: date-time
-    StdcmRequest:
-      type: object
-      required:
-      - infra
-      - expected_version
-      - timetable_id
-      - path_items
-      - rolling_stock_loading_gauge
-      - rolling_stock_supported_signaling_systems
-      - comfort
-      - physics_consist
-      - start_time
-      - maximum_departure_delay
-      - maximum_run_time
-      - time_gap_before
-      - time_gap_after
-      - work_schedules
-      - temporary_speed_limits
-      properties:
-        allowed_track_sections:
-          type:
-          - array
-          - 'null'
-          items:
-            type: string
-          description: Set of authorized track section ids for the current request
-          uniqueItems: true
-        comfort:
-          $ref: '#/components/schemas/Comfort'
-          description: The comfort of the train
-        expected_version:
-          type: integer
-          format: int64
-          description: Infrastructure expected version
-        infra:
-          type: integer
-          format: int64
-          description: Infrastructure id
-        margin:
-          oneOf:
-          - type: 'null'
-          - oneOf:
-            - type: object
-              required:
-              - Percentage
-              properties:
-                Percentage:
-                  type: number
-                  format: double
-            - type: object
-              required:
-              - MinPer100Km
-              properties:
-                MinPer100Km:
-                  type: number
-                  format: double
-          description: Margin to apply to the whole train
-        maximum_departure_delay:
-          type: integer
-          format: int64
-          description: Maximum departure delay in milliseconds.
-          minimum: 0
-        maximum_run_time:
-          type: integer
-          format: int64
-          description: Maximum run time of the simulation in milliseconds
-          minimum: 0
-        path_items:
-          type: array
-          items:
-            $ref: '#/components/schemas/PathItem'
-          description: List of waypoints. Each waypoint is a list of track offset.
-        physics_consist:
-          type: object
-          required:
-          - effort_curves
-          - length
-          - max_speed
-          - startup_time
-          - startup_acceleration
-          - comfort_acceleration
-          - const_gamma
-          - inertia_coefficient
-          - mass
-          - rolling_resistance
-          properties:
-            base_power_class:
-              type:
-              - string
-              - 'null'
-            comfort_acceleration:
-              type: number
-              format: double
-            const_gamma:
-              type: number
-              format: double
-              description: |-
-                The constant gamma braking coefficient used when NOT circulating
-                under ETCS/ERTMS signaling system
-            effort_curves:
-              $ref: '#/components/schemas/EffortCurves'
-            electrical_power_startup_time:
-              type:
-              - integer
-              - 'null'
-              format: int64
-              description: |-
-                The time the train takes before actually using electrical power.
-                Is null if the train is not electric or the value not specified.
-              minimum: 0
-            etcs_brake_params:
-              oneOf:
-              - type: 'null'
-              - $ref: '#/components/schemas/EtcsBrakeParams'
-            inertia_coefficient:
-              type: number
-              format: double
-            length:
-              type: integer
-              format: int64
-              description: Length of the rolling stock
-              minimum: 0
-            mass:
-              type: integer
-              format: int64
-              description: Mass of the rolling stock
-              minimum: 0
-            max_speed:
-              type: number
-              format: double
-              description: Maximum speed of the rolling stock
-            power_restrictions:
-              type: object
-              description: Mapping of power restriction code to power class
-              additionalProperties:
-                type: string
-              propertyNames:
-                type: string
-            raise_pantograph_time:
-              type:
-              - integer
-              - 'null'
-              format: int64
-              description: |-
-                The time it takes to raise this train's pantograph.
-                Is null if the train is not electric or the value not specified.
-              minimum: 0
-            rolling_resistance:
-              $ref: '#/components/schemas/RollingResistance'
-            startup_acceleration:
-              type: number
-              format: double
-            startup_time:
-              type: integer
-              format: int64
-              minimum: 0
-        rolling_stock_loading_gauge:
-          $ref: '#/components/schemas/LoadingGaugeType'
-          description: The loading gauge of the rolling stock
-        rolling_stock_supported_signaling_systems:
-          type: array
-          items:
-            type: string
-          description: List of supported signaling systems
-        speed_limit_tag:
-          type:
-          - string
-          - 'null'
-        start_time:
-          type: string
-          format: date-time
-        temporary_speed_limits:
-          type: array
-          items:
-            type: object
-            description: Lighter description of a work schedule with only the relevant information for core
-            required:
-            - speed_limit
-            - track_ranges
-            properties:
-              speed_limit:
-                type: number
-                format: double
-                description: Speed limitation in m/s
-              track_ranges:
-                type: array
-                items:
-                  $ref: '#/components/schemas/core.TrackRange'
-                description: Track ranges on which the speed limitation applies
-          description: List of applicable temporary speed limits between the train departure and arrival
-        time_gap_after:
-          type: integer
-          format: int64
-          description: Gap between the created train and following trains in milliseconds
-          minimum: 0
-        time_gap_before:
-          type: integer
-          format: int64
-          description: Gap between the created train and previous trains in milliseconds
-          minimum: 0
-        time_step:
-          type:
-          - integer
-          - 'null'
-          format: int64
-          description: Numerical integration time step in milliseconds. Use default value if not specified.
-          minimum: 0
-        timetable_id:
-          type: integer
-          format: int64
-          description: Timetable id
-        work_schedules:
-          type: array
-          items:
-            $ref: '#/components/schemas/WorkSchedule'
-          description: List of planned work schedules
     StdcmSearchEnvironment:
       type: object
       required:
@@ -13448,28 +13232,6 @@ components:
           - integer
           - 'null'
           format: int64
-    StepTimingData:
-      type: object
-      description: Contains the data of a step timing, when it is specified
-      required:
-      - arrival_time
-      - arrival_time_tolerance_before
-      - arrival_time_tolerance_after
-      properties:
-        arrival_time:
-          type: string
-          format: date-time
-          description: Time the train should arrive at this point
-        arrival_time_tolerance_after:
-          type: integer
-          format: int64
-          description: Tolerance for the arrival time, when it arrives after the expected time, in ms
-          minimum: 0
-        arrival_time_tolerance_before:
-          type: integer
-          format: int64
-          description: Tolerance for the arrival time, when it arrives before the expected time, in ms
-          minimum: 0
     Study:
       type: object
       required:
@@ -14231,29 +13993,6 @@ components:
           timetable_id:
             type: integer
             format: int64
-    UndirectedTrackRange:
-      type: object
-      description: |-
-        A range on a track section.
-        `begin` is always less than `end`.
-      required:
-      - track_section
-      - begin
-      - end
-      properties:
-        begin:
-          type: integer
-          format: int64
-          description: The beginning of the range in mm.
-          minimum: 0
-        end:
-          type: integer
-          format: int64
-          description: The end of the range in mm.
-          minimum: 0
-        track_section:
-          type: string
-          description: The track section identifier.
     Version:
       type: object
       required:
@@ -14293,27 +14032,35 @@ components:
             - Detector
     WorkSchedule:
       type: object
-      description: Lighter description of a work schedule, with only the relevant information for core
       required:
-      - start_time
-      - end_time
+      - id
+      - start_date_time
+      - end_date_time
       - track_ranges
+      - obj_id
+      - work_schedule_type
+      - work_schedule_group_id
       properties:
-        end_time:
+        end_date_time:
+          type: string
+          format: date-time
+        id:
           type: integer
           format: int64
-          description: End time as a time delta from the stdcm start time in ms
-          minimum: 0
-        start_time:
-          type: integer
-          format: int64
-          description: Start time as a time delta from the stdcm start time in ms
-          minimum: 0
+        obj_id:
+          type: string
+        start_date_time:
+          type: string
+          format: date-time
         track_ranges:
           type: array
           items:
-            $ref: '#/components/schemas/UndirectedTrackRange'
-          description: List of unavailable track ranges
+            $ref: '#/components/schemas/TrackRange'
+        work_schedule_group_id:
+          type: integer
+          format: int64
+        work_schedule_type:
+          $ref: '#/components/schemas/WorkScheduleType'
     WorkScheduleItemForm:
       type: object
       required:
@@ -14667,6 +14414,28 @@ components:
           type: integer
           format: int64
           minimum: 0
+    core.PathItem:
+      type: object
+      required:
+      - locations
+      properties:
+        locations:
+          type: array
+          items:
+            $ref: '#/components/schemas/TrackOffset'
+          description: The track offsets of the path item
+        step_timing_data:
+          oneOf:
+          - type: 'null'
+          - $ref: '#/components/schemas/core.StepTimingData'
+            description: If specified, describes when the train may arrive at the location
+        stop_duration:
+          type:
+          - integer
+          - 'null'
+          format: int64
+          description: Stop duration in milliseconds. None if the train does not stop at this path item.
+          minimum: 0
     core.PathfindingInputError:
       oneOf:
       - type: object
@@ -14983,6 +14752,244 @@ components:
           minimum: 0
         zone:
           type: string
+    core.StdcmRequest:
+      type: object
+      required:
+      - infra
+      - expected_version
+      - timetable_id
+      - path_items
+      - rolling_stock_loading_gauge
+      - rolling_stock_supported_signaling_systems
+      - comfort
+      - physics_consist
+      - start_time
+      - maximum_departure_delay
+      - maximum_run_time
+      - time_gap_before
+      - time_gap_after
+      - work_schedules
+      - temporary_speed_limits
+      properties:
+        allowed_track_sections:
+          type:
+          - array
+          - 'null'
+          items:
+            type: string
+          description: Set of authorized track section ids for the current request
+          uniqueItems: true
+        comfort:
+          $ref: '#/components/schemas/Comfort'
+          description: The comfort of the train
+        expected_version:
+          type: integer
+          format: int64
+          description: Infrastructure expected version
+        infra:
+          type: integer
+          format: int64
+          description: Infrastructure id
+        margin:
+          oneOf:
+          - type: 'null'
+          - oneOf:
+            - type: object
+              required:
+              - Percentage
+              properties:
+                Percentage:
+                  type: number
+                  format: double
+            - type: object
+              required:
+              - MinPer100Km
+              properties:
+                MinPer100Km:
+                  type: number
+                  format: double
+          description: Margin to apply to the whole train
+        maximum_departure_delay:
+          type: integer
+          format: int64
+          description: Maximum departure delay in milliseconds.
+          minimum: 0
+        maximum_run_time:
+          type: integer
+          format: int64
+          description: Maximum run time of the simulation in milliseconds
+          minimum: 0
+        path_items:
+          type: array
+          items:
+            $ref: '#/components/schemas/core.PathItem'
+          description: List of waypoints. Each waypoint is a list of track offset.
+        physics_consist:
+          type: object
+          required:
+          - effort_curves
+          - length
+          - max_speed
+          - startup_time
+          - startup_acceleration
+          - comfort_acceleration
+          - const_gamma
+          - inertia_coefficient
+          - mass
+          - rolling_resistance
+          properties:
+            base_power_class:
+              type:
+              - string
+              - 'null'
+            comfort_acceleration:
+              type: number
+              format: double
+            const_gamma:
+              type: number
+              format: double
+              description: |-
+                The constant gamma braking coefficient used when NOT circulating
+                under ETCS/ERTMS signaling system
+            effort_curves:
+              $ref: '#/components/schemas/EffortCurves'
+            electrical_power_startup_time:
+              type:
+              - integer
+              - 'null'
+              format: int64
+              description: |-
+                The time the train takes before actually using electrical power.
+                Is null if the train is not electric or the value not specified.
+              minimum: 0
+            etcs_brake_params:
+              oneOf:
+              - type: 'null'
+              - $ref: '#/components/schemas/EtcsBrakeParams'
+            inertia_coefficient:
+              type: number
+              format: double
+            length:
+              type: integer
+              format: int64
+              description: Length of the rolling stock
+              minimum: 0
+            mass:
+              type: integer
+              format: int64
+              description: Mass of the rolling stock
+              minimum: 0
+            max_speed:
+              type: number
+              format: double
+              description: Maximum speed of the rolling stock
+            power_restrictions:
+              type: object
+              description: Mapping of power restriction code to power class
+              additionalProperties:
+                type: string
+              propertyNames:
+                type: string
+            raise_pantograph_time:
+              type:
+              - integer
+              - 'null'
+              format: int64
+              description: |-
+                The time it takes to raise this train's pantograph.
+                Is null if the train is not electric or the value not specified.
+              minimum: 0
+            rolling_resistance:
+              $ref: '#/components/schemas/RollingResistance'
+            startup_acceleration:
+              type: number
+              format: double
+            startup_time:
+              type: integer
+              format: int64
+              minimum: 0
+        rolling_stock_loading_gauge:
+          $ref: '#/components/schemas/LoadingGaugeType'
+          description: The loading gauge of the rolling stock
+        rolling_stock_supported_signaling_systems:
+          type: array
+          items:
+            type: string
+          description: List of supported signaling systems
+        speed_limit_tag:
+          type:
+          - string
+          - 'null'
+        start_time:
+          type: string
+          format: date-time
+        temporary_speed_limits:
+          type: array
+          items:
+            type: object
+            description: Lighter description of a work schedule with only the relevant information for core
+            required:
+            - speed_limit
+            - track_ranges
+            properties:
+              speed_limit:
+                type: number
+                format: double
+                description: Speed limitation in m/s
+              track_ranges:
+                type: array
+                items:
+                  $ref: '#/components/schemas/core.TrackRange'
+                description: Track ranges on which the speed limitation applies
+          description: List of applicable temporary speed limits between the train departure and arrival
+        time_gap_after:
+          type: integer
+          format: int64
+          description: Gap between the created train and following trains in milliseconds
+          minimum: 0
+        time_gap_before:
+          type: integer
+          format: int64
+          description: Gap between the created train and previous trains in milliseconds
+          minimum: 0
+        time_step:
+          type:
+          - integer
+          - 'null'
+          format: int64
+          description: Numerical integration time step in milliseconds. Use default value if not specified.
+          minimum: 0
+        timetable_id:
+          type: integer
+          format: int64
+          description: Timetable id
+        work_schedules:
+          type: array
+          items:
+            $ref: '#/components/schemas/core.WorkSchedule'
+          description: List of planned work schedules
+    core.StepTimingData:
+      type: object
+      description: Contains the data of a step timing, when it is specified
+      required:
+      - arrival_time
+      - arrival_time_tolerance_before
+      - arrival_time_tolerance_after
+      properties:
+        arrival_time:
+          type: string
+          format: date-time
+          description: Time the train should arrive at this point
+        arrival_time_tolerance_after:
+          type: integer
+          format: int64
+          description: Tolerance for the arrival time, when it arrives after the expected time, in ms
+          minimum: 0
+        arrival_time_tolerance_before:
+          type: integer
+          format: int64
+          description: Tolerance for the arrival time, when it arrives before the expected time, in ms
+          minimum: 0
     core.TrackRange:
       type: object
       description: |-
@@ -15059,6 +15066,52 @@ components:
           format: date-time
         train_id:
           type: string
+    core.UndirectedTrackRange:
+      type: object
+      description: |-
+        A range on a track section.
+        `begin` is always less than `end`.
+      required:
+      - track_section
+      - begin
+      - end
+      properties:
+        begin:
+          type: integer
+          format: int64
+          description: The beginning of the range in mm.
+          minimum: 0
+        end:
+          type: integer
+          format: int64
+          description: The end of the range in mm.
+          minimum: 0
+        track_section:
+          type: string
+          description: The track section identifier.
+    core.WorkSchedule:
+      type: object
+      description: Lighter description of a work schedule, with only the relevant information for core
+      required:
+      - start_time
+      - end_time
+      - track_ranges
+      properties:
+        end_time:
+          type: integer
+          format: int64
+          description: End time as a time delta from the stdcm start time in ms
+          minimum: 0
+        start_time:
+          type: integer
+          format: int64
+          description: Start time as a time delta from the stdcm start time in ms
+          minimum: 0
+        track_ranges:
+          type: array
+          items:
+            $ref: '#/components/schemas/core.UndirectedTrackRange'
+          description: List of unavailable track ranges
     core.ZoneUpdate:
       type: object
       required:

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -4233,7 +4233,7 @@ paths:
                 additionalProperties:
                   type: array
                   items:
-                    $ref: '#/components/schemas/SignalUpdate'
+                    $ref: '#/components/schemas/core.SignalUpdate'
                 propertyNames:
                   type: integer
                   format: int64
@@ -9897,13 +9897,13 @@ components:
           additionalProperties:
             type: array
             items:
-              $ref: '#/components/schemas/SignalUpdate'
+              $ref: '#/components/schemas/core.SignalUpdate'
           propertyNames:
             type: string
         paced_train:
           type: array
           items:
-            $ref: '#/components/schemas/SignalUpdate'
+            $ref: '#/components/schemas/core.SignalUpdate'
           description: Paced train
     Operation:
       oneOf:
@@ -12615,57 +12615,6 @@ components:
           format: int64
           description: Time in ms
           minimum: 0
-    SignalUpdate:
-      type: object
-      required:
-      - signal_id
-      - signaling_system
-      - time_start
-      - time_end
-      - position_start
-      - position_end
-      - color
-      - blinking
-      - aspect_label
-      properties:
-        aspect_label:
-          type: string
-          description: The labels of the new aspect
-        blinking:
-          type: boolean
-          description: Whether the signal is blinking
-        color:
-          type: integer
-          format: int32
-          description: |-
-            The color of the aspect
-            (Bits 24-31 are alpha, 16-23 are red, 8-15 are green, 0-7 are blue)
-        position_end:
-          type: integer
-          format: int64
-          description: The route ends at this position in mm on the train path
-          minimum: 0
-        position_start:
-          type: integer
-          format: int64
-          description: The route starts at this position in mm on the train path
-          minimum: 0
-        signal_id:
-          type: string
-          description: The id of the updated signal
-        signaling_system:
-          type: string
-          description: The name of the signaling system of the signal
-        time_end:
-          type: integer
-          format: int64
-          description: The aspects stop being displayed at this time (number of ms since `departure_time`)
-          minimum: 0
-        time_start:
-          type: integer
-          format: int64
-          description: The aspects start being displayed at this time (number of ms since `departure_time`)
-          minimum: 0
     SimilarTrainWaypoint:
       type: object
       required:
@@ -15003,6 +14952,57 @@ components:
           description: |-
             The path offset in mm of each path item given as input of the pathfinding
             The first value is always `0` (beginning of the path) and the last one is always equal to the `length` of the path in mm
+    core.SignalUpdate:
+      type: object
+      required:
+      - signal_id
+      - signaling_system
+      - time_start
+      - time_end
+      - position_start
+      - position_end
+      - color
+      - blinking
+      - aspect_label
+      properties:
+        aspect_label:
+          type: string
+          description: The labels of the new aspect
+        blinking:
+          type: boolean
+          description: Whether the signal is blinking
+        color:
+          type: integer
+          format: int32
+          description: |-
+            The color of the aspect
+            (Bits 24-31 are alpha, 16-23 are red, 8-15 are green, 0-7 are blue)
+        position_end:
+          type: integer
+          format: int64
+          description: The route ends at this position in mm on the train path
+          minimum: 0
+        position_start:
+          type: integer
+          format: int64
+          description: The route starts at this position in mm on the train path
+          minimum: 0
+        signal_id:
+          type: string
+          description: The id of the updated signal
+        signaling_system:
+          type: string
+          description: The name of the signaling system of the signal
+        time_end:
+          type: integer
+          format: int64
+          description: The aspects stop being displayed at this time (number of ms since `departure_time`)
+          minimum: 0
+        time_start:
+          type: integer
+          format: int64
+          description: The aspects start being displayed at this time (number of ms since `departure_time`)
+          minimum: 0
     core.TrackRange:
       type: object
       description: |-

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -2358,7 +2358,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ETCSBrakingCurvesResponse'
+                $ref: '#/components/schemas/core.ETCSBrakingCurvesResponse'
   /paced_train/{id}/path:
     get:
       tags:
@@ -4556,7 +4556,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ETCSBrakingCurvesResponse'
+                $ref: '#/components/schemas/core.ETCSBrakingCurvesResponse'
   /train_schedule/{id}/path:
     get:
       tags:
@@ -5202,227 +5202,6 @@ components:
       enum:
       - STANDARD
       - MARECO
-    ETCSBrakingCurvesResponse:
-      type: object
-      required:
-      - slowdowns
-      - stops
-      - conflicts
-      properties:
-        conflicts:
-          type: array
-          items:
-            $ref: '#/components/schemas/ETCSConflictCurves'
-          description: |-
-            List of ETCS conflict braking curves associated to the train schedule's ETCS signals.
-            For each non-route delimiter (F) signal, the associated spacing conflict curve is returned.
-            For each route delimiter (Nf) signal, 2 sets of curves are returned, associated to the
-            corresponding potential spacing or routing conflict.
-        slowdowns:
-          type: array
-          items:
-            $ref: '#/components/schemas/ETCSCurves'
-          description: List of ETCS braking curves associated to the train schedule's ETCS slowdowns
-        stops:
-          type: array
-          items:
-            $ref: '#/components/schemas/ETCSCurves'
-          description: List of ETCS braking curves associated to the train schedule's ETCS stops
-    ETCSConflictCurves:
-      type: object
-      required:
-      - indication
-      - permitted_speed
-      - guidance
-      - conflict_type
-      properties:
-        conflict_type:
-          type: string
-          enum:
-          - Spacing
-          - Routing
-        guidance:
-          type: object
-          required:
-          - positions
-          - times
-          - speeds
-          properties:
-            positions:
-              type: array
-              items:
-                type: integer
-                format: int64
-                minimum: 0
-              description: |-
-                List of positions of a train
-                Both positions (in mm) and times (in ms) must have the same length
-            speeds:
-              type: array
-              items:
-                type: number
-                format: double
-              description: List of speeds (in m/s) associated to a position
-            times:
-              type: array
-              items:
-                type: integer
-                format: int64
-                minimum: 0
-              description: List of times (in ms) associated to a position
-        indication:
-          type: object
-          required:
-          - positions
-          - times
-          - speeds
-          properties:
-            positions:
-              type: array
-              items:
-                type: integer
-                format: int64
-                minimum: 0
-              description: |-
-                List of positions of a train
-                Both positions (in mm) and times (in ms) must have the same length
-            speeds:
-              type: array
-              items:
-                type: number
-                format: double
-              description: List of speeds (in m/s) associated to a position
-            times:
-              type: array
-              items:
-                type: integer
-                format: int64
-                minimum: 0
-              description: List of times (in ms) associated to a position
-        permitted_speed:
-          type: object
-          required:
-          - positions
-          - times
-          - speeds
-          properties:
-            positions:
-              type: array
-              items:
-                type: integer
-                format: int64
-                minimum: 0
-              description: |-
-                List of positions of a train
-                Both positions (in mm) and times (in ms) must have the same length
-            speeds:
-              type: array
-              items:
-                type: number
-                format: double
-              description: List of speeds (in m/s) associated to a position
-            times:
-              type: array
-              items:
-                type: integer
-                format: int64
-                minimum: 0
-              description: List of times (in ms) associated to a position
-    ETCSCurves:
-      type: object
-      required:
-      - permitted_speed
-      - guidance
-      properties:
-        guidance:
-          type: object
-          required:
-          - positions
-          - times
-          - speeds
-          properties:
-            positions:
-              type: array
-              items:
-                type: integer
-                format: int64
-                minimum: 0
-              description: |-
-                List of positions of a train
-                Both positions (in mm) and times (in ms) must have the same length
-            speeds:
-              type: array
-              items:
-                type: number
-                format: double
-              description: List of speeds (in m/s) associated to a position
-            times:
-              type: array
-              items:
-                type: integer
-                format: int64
-                minimum: 0
-              description: List of times (in ms) associated to a position
-        indication:
-          oneOf:
-          - type: 'null'
-          - type: object
-            required:
-            - positions
-            - times
-            - speeds
-            properties:
-              positions:
-                type: array
-                items:
-                  type: integer
-                  format: int64
-                  minimum: 0
-                description: |-
-                  List of positions of a train
-                  Both positions (in mm) and times (in ms) must have the same length
-              speeds:
-                type: array
-                items:
-                  type: number
-                  format: double
-                description: List of speeds (in m/s) associated to a position
-              times:
-                type: array
-                items:
-                  type: integer
-                  format: int64
-                  minimum: 0
-                description: List of times (in ms) associated to a position
-        permitted_speed:
-          type: object
-          required:
-          - positions
-          - times
-          - speeds
-          properties:
-            positions:
-              type: array
-              items:
-                type: integer
-                format: int64
-                minimum: 0
-              description: |-
-                List of positions of a train
-                Both positions (in mm) and times (in ms) must have the same length
-            speeds:
-              type: array
-              items:
-                type: number
-                format: double
-              description: List of speeds (in m/s) associated to a position
-            times:
-              type: array
-              items:
-                type: integer
-                format: int64
-                minimum: 0
-              description: List of times (in ms) associated to a position
     EditoastAppHealthErrorCore:
       type: object
       required:
@@ -14793,6 +14572,227 @@ components:
           format: date-time
         zone:
           type: string
+    core.ETCSBrakingCurvesResponse:
+      type: object
+      required:
+      - slowdowns
+      - stops
+      - conflicts
+      properties:
+        conflicts:
+          type: array
+          items:
+            $ref: '#/components/schemas/core.ETCSConflictCurves'
+          description: |-
+            List of ETCS conflict braking curves associated to the train schedule's ETCS signals.
+            For each non-route delimiter (F) signal, the associated spacing conflict curve is returned.
+            For each route delimiter (Nf) signal, 2 sets of curves are returned, associated to the
+            corresponding potential spacing or routing conflict.
+        slowdowns:
+          type: array
+          items:
+            $ref: '#/components/schemas/core.ETCSCurves'
+          description: List of ETCS braking curves associated to the train schedule's ETCS slowdowns
+        stops:
+          type: array
+          items:
+            $ref: '#/components/schemas/core.ETCSCurves'
+          description: List of ETCS braking curves associated to the train schedule's ETCS stops
+    core.ETCSConflictCurves:
+      type: object
+      required:
+      - indication
+      - permitted_speed
+      - guidance
+      - conflict_type
+      properties:
+        conflict_type:
+          type: string
+          enum:
+          - Spacing
+          - Routing
+        guidance:
+          type: object
+          required:
+          - positions
+          - times
+          - speeds
+          properties:
+            positions:
+              type: array
+              items:
+                type: integer
+                format: int64
+                minimum: 0
+              description: |-
+                List of positions of a train
+                Both positions (in mm) and times (in ms) must have the same length
+            speeds:
+              type: array
+              items:
+                type: number
+                format: double
+              description: List of speeds (in m/s) associated to a position
+            times:
+              type: array
+              items:
+                type: integer
+                format: int64
+                minimum: 0
+              description: List of times (in ms) associated to a position
+        indication:
+          type: object
+          required:
+          - positions
+          - times
+          - speeds
+          properties:
+            positions:
+              type: array
+              items:
+                type: integer
+                format: int64
+                minimum: 0
+              description: |-
+                List of positions of a train
+                Both positions (in mm) and times (in ms) must have the same length
+            speeds:
+              type: array
+              items:
+                type: number
+                format: double
+              description: List of speeds (in m/s) associated to a position
+            times:
+              type: array
+              items:
+                type: integer
+                format: int64
+                minimum: 0
+              description: List of times (in ms) associated to a position
+        permitted_speed:
+          type: object
+          required:
+          - positions
+          - times
+          - speeds
+          properties:
+            positions:
+              type: array
+              items:
+                type: integer
+                format: int64
+                minimum: 0
+              description: |-
+                List of positions of a train
+                Both positions (in mm) and times (in ms) must have the same length
+            speeds:
+              type: array
+              items:
+                type: number
+                format: double
+              description: List of speeds (in m/s) associated to a position
+            times:
+              type: array
+              items:
+                type: integer
+                format: int64
+                minimum: 0
+              description: List of times (in ms) associated to a position
+    core.ETCSCurves:
+      type: object
+      required:
+      - permitted_speed
+      - guidance
+      properties:
+        guidance:
+          type: object
+          required:
+          - positions
+          - times
+          - speeds
+          properties:
+            positions:
+              type: array
+              items:
+                type: integer
+                format: int64
+                minimum: 0
+              description: |-
+                List of positions of a train
+                Both positions (in mm) and times (in ms) must have the same length
+            speeds:
+              type: array
+              items:
+                type: number
+                format: double
+              description: List of speeds (in m/s) associated to a position
+            times:
+              type: array
+              items:
+                type: integer
+                format: int64
+                minimum: 0
+              description: List of times (in ms) associated to a position
+        indication:
+          oneOf:
+          - type: 'null'
+          - type: object
+            required:
+            - positions
+            - times
+            - speeds
+            properties:
+              positions:
+                type: array
+                items:
+                  type: integer
+                  format: int64
+                  minimum: 0
+                description: |-
+                  List of positions of a train
+                  Both positions (in mm) and times (in ms) must have the same length
+              speeds:
+                type: array
+                items:
+                  type: number
+                  format: double
+                description: List of speeds (in m/s) associated to a position
+              times:
+                type: array
+                items:
+                  type: integer
+                  format: int64
+                  minimum: 0
+                description: List of times (in ms) associated to a position
+        permitted_speed:
+          type: object
+          required:
+          - positions
+          - times
+          - speeds
+          properties:
+            positions:
+              type: array
+              items:
+                type: integer
+                format: int64
+                minimum: 0
+              description: |-
+                List of positions of a train
+                Both positions (in mm) and times (in ms) must have the same length
+            speeds:
+              type: array
+              items:
+                type: number
+                format: double
+              description: List of speeds (in m/s) associated to a position
+            times:
+              type: array
+              items:
+                type: integer
+                format: int64
+                minimum: 0
+              description: List of times (in ms) associated to a position
     core.IncompatibleConstraints:
       type: object
       required:

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -3669,7 +3669,7 @@ paths:
                     results:
                       type: array
                       items:
-                        $ref: '#/components/schemas/TrainRequirementsById'
+                        $ref: '#/components/schemas/core.TrainRequirementsById'
   /timetable/{id}/round_trips/paced_trains:
     get:
       tags:
@@ -5079,7 +5079,7 @@ components:
         requirements:
           type: array
           items:
-            $ref: '#/components/schemas/ConflictRequirement'
+            $ref: '#/components/schemas/core.ConflictRequirement'
           description: List of requirements causing the conflict
         start_time:
           type: string
@@ -5097,26 +5097,6 @@ components:
             type: integer
             format: int64
           description: List of work schedule ids involved in the conflict
-    ConflictRequirement:
-      type: object
-      description: |-
-        Unmet requirement causing a conflict.
-
-        The start and end time describe the conflicting time span (not the full
-        requirement's time span).
-      required:
-      - zone
-      - start_time
-      - end_time
-      properties:
-        end_time:
-          type: string
-          format: date-time
-        start_time:
-          type: string
-          format: date-time
-        zone:
-          type: string
     ConstraintDistributionChangeGroup:
       type: object
       required:
@@ -14553,27 +14533,6 @@ components:
       properties:
         value:
           type: string
-    TrainRequirementsById:
-      type: object
-      required:
-      - train_id
-      - start_time
-      - spacing_requirements
-      - routing_requirements
-      properties:
-        routing_requirements:
-          type: array
-          items:
-            $ref: '#/components/schemas/RoutingRequirement'
-        spacing_requirements:
-          type: array
-          items:
-            $ref: '#/components/schemas/SpacingRequirement'
-        start_time:
-          type: string
-          format: date-time
-        train_id:
-          type: string
     TrainSchedule:
       type: object
       required:
@@ -14812,6 +14771,26 @@ components:
           type: integer
           format: int64
           minimum: 0
+        zone:
+          type: string
+    core.ConflictRequirement:
+      type: object
+      description: |-
+        Unmet requirement causing a conflict.
+
+        The start and end time describe the conflicting time span (not the full
+        requirement's time span).
+      required:
+      - zone
+      - start_time
+      - end_time
+      properties:
+        end_time:
+          type: string
+          format: date-time
+        start_time:
+          type: string
+          format: date-time
         zone:
           type: string
     core.IncompatibleConstraints:
@@ -15079,3 +15058,24 @@ components:
           items:
             $ref: '#/components/schemas/core.TrackRange'
           description: Track section ranges, in order.
+    core.TrainRequirementsById:
+      type: object
+      required:
+      - train_id
+      - start_time
+      - spacing_requirements
+      - routing_requirements
+      properties:
+        routing_requirements:
+          type: array
+          items:
+            $ref: '#/components/schemas/RoutingRequirement'
+        spacing_requirements:
+          type: array
+          items:
+            $ref: '#/components/schemas/SpacingRequirement'
+        start_time:
+          type: string
+          format: date-time
+        train_id:
+          type: string

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -3955,7 +3955,7 @@ paths:
                       type: string
                       format: date-time
                     pathfinding_result:
-                      $ref: '#/components/schemas/PathfindingResultSuccess'
+                      $ref: '#/components/schemas/core.PathfindingResultSuccess'
                     simulation:
                       $ref: '#/components/schemas/SimulationResponseSuccess'
                     status:
@@ -4823,7 +4823,7 @@ paths:
                 path_track_ranges:
                   type: array
                   items:
-                    $ref: '#/components/schemas/CoreTrackRange'
+                    $ref: '#/components/schemas/core.TrackRange'
                 work_schedule_group_id:
                   type: integer
                   format: int64
@@ -5141,36 +5141,6 @@ components:
           description: |-
             JSON-Pointer value [RFC6901](https://tools.ietf.org/html/rfc6901) that references a location
             within the target document where the operation is performed.
-    CoreTrackRange:
-      type: object
-      description: |-
-        An oriented range on a track section.
-        `begin` is always less than `end`.
-      required:
-      - track_section
-      - begin
-      - end
-      - direction
-      properties:
-        begin:
-          type: integer
-          format: int64
-          description: The beginning of the range in mm.
-          minimum: 0
-        direction:
-          $ref: '#/components/schemas/Direction'
-          description: The direction of the range.
-        end:
-          type: integer
-          format: int64
-          description: The end of the range in mm.
-          minimum: 0
-        track_section:
-          oneOf:
-          - type: string
-            maxLength: 255
-            minLength: 1
-          description: The track section identifier.
     Curve:
       type: object
       required:
@@ -9177,42 +9147,6 @@ components:
         subject_id:
           type: integer
           format: int64
-    IncompatibleConstraints:
-      type: object
-      required:
-      - incompatible_electrification_ranges
-      - incompatible_gauge_ranges
-      - incompatible_signaling_system_ranges
-      properties:
-        incompatible_electrification_ranges:
-          type: array
-          items:
-            $ref: '#/components/schemas/IncompatibleOffsetRangeWithValue'
-        incompatible_gauge_ranges:
-          type: array
-          items:
-            $ref: '#/components/schemas/IncompatibleOffsetRange'
-        incompatible_signaling_system_ranges:
-          type: array
-          items:
-            $ref: '#/components/schemas/IncompatibleOffsetRangeWithValue'
-    IncompatibleOffsetRange:
-      type: object
-      required:
-      - range
-      properties:
-        range:
-          $ref: '#/components/schemas/OffsetRange'
-    IncompatibleOffsetRangeWithValue:
-      type: object
-      required:
-      - range
-      - value
-      properties:
-        range:
-          $ref: '#/components/schemas/OffsetRange'
-        value:
-          type: string
     Infra:
       type: object
       required:
@@ -10143,30 +10077,6 @@ components:
         document_key:
           type: integer
           format: int64
-    ObjectRange:
-      type: object
-      description: A range on a linear object (usually block or route)
-      required:
-      - id
-      - begin
-      - end
-      properties:
-        begin:
-          type: integer
-          format: int64
-          description: The beginning of the range in mm.
-          minimum: 0
-        end:
-          type: integer
-          format: int64
-          description: The end of the range in mm.
-          minimum: 0
-        id:
-          oneOf:
-          - type: string
-            maxLength: 255
-            minLength: 1
-          description: The object identifier.
     ObjectRef:
       type: object
       required:
@@ -10214,7 +10124,7 @@ components:
           type: integer
           format: int64
         path:
-          $ref: '#/components/schemas/TrainPath'
+          $ref: '#/components/schemas/core.TrainPath'
     OccupancyBlocksPacedTrainResult:
       type: object
       description: Occupancy blocks output is described by blocks (signal updates)
@@ -10236,20 +10146,6 @@ components:
           items:
             $ref: '#/components/schemas/SignalUpdate'
           description: Paced train
-    OffsetRange:
-      type: object
-      required:
-      - start
-      - end
-      properties:
-        end:
-          type: integer
-          format: int64
-          minimum: 0
-        start:
-          type: integer
-          format: int64
-          minimum: 0
     Operation:
       oneOf:
       - allOf:
@@ -10978,12 +10874,12 @@ components:
         track_section_ranges:
           type: array
           items:
-            $ref: '#/components/schemas/CoreTrackRange'
+            $ref: '#/components/schemas/core.TrackRange'
           description: List of track sections
     PathfindingFailure:
       oneOf:
       - allOf:
-        - $ref: '#/components/schemas/PathfindingInputError'
+        - $ref: '#/components/schemas/core.PathfindingInputError'
         - type: object
           required:
           - failed_status
@@ -10993,7 +10889,7 @@ components:
               enum:
               - pathfinding_input_error
       - allOf:
-        - $ref: '#/components/schemas/PathfindingNotFound'
+        - $ref: '#/components/schemas/core.PathfindingNotFound'
         - type: object
           required:
           - failed_status
@@ -11063,57 +10959,6 @@ components:
           - string
           - 'null'
           description: Speed limit tag, used to estimate the travel time
-    PathfindingInputError:
-      oneOf:
-      - type: object
-        required:
-        - items
-        - error_type
-        properties:
-          error_type:
-            type: string
-            enum:
-            - invalid_path_items
-          items:
-            type: array
-            items:
-              type: object
-              required:
-              - index
-              - path_item
-              properties:
-                index:
-                  type: integer
-                  minimum: 0
-                path_item:
-                  $ref: '#/components/schemas/PathItemLocation'
-      - type: object
-        required:
-        - error_type
-        properties:
-          error_type:
-            type: string
-            enum:
-            - not_enough_path_items
-      - type: object
-        required:
-        - rolling_stock_name
-        - error_type
-        properties:
-          error_type:
-            type: string
-            enum:
-            - rolling_stock_not_found
-          rolling_stock_name:
-            type: string
-      - type: object
-        required:
-        - error_type
-        properties:
-          error_type:
-            type: string
-            enum:
-            - zero_length_path
     PathfindingItem:
       type: object
       required:
@@ -11153,66 +10998,6 @@ components:
                 description: The train may arrive up to this duration before the expected arrival time
                 minimum: 0
           description: Time at which the train should arrive at the location, if specified
-    PathfindingNotFound:
-      oneOf:
-      - type: object
-        required:
-        - track_section_ranges
-        - length
-        - error_type
-        properties:
-          error_type:
-            type: string
-            enum:
-            - not_found_in_blocks
-          length:
-            type: integer
-            format: int64
-            minimum: 0
-          track_section_ranges:
-            type: array
-            items:
-              $ref: '#/components/schemas/CoreTrackRange'
-      - type: object
-        required:
-        - track_section_ranges
-        - length
-        - error_type
-        properties:
-          error_type:
-            type: string
-            enum:
-            - not_found_in_routes
-          length:
-            type: integer
-            format: int64
-            minimum: 0
-          track_section_ranges:
-            type: array
-            items:
-              $ref: '#/components/schemas/CoreTrackRange'
-      - type: object
-        required:
-        - error_type
-        properties:
-          error_type:
-            type: string
-            enum:
-            - not_found_in_tracks
-      - type: object
-        required:
-        - relaxed_constraints_path
-        - incompatible_constraints
-        - error_type
-        properties:
-          error_type:
-            type: string
-            enum:
-            - incompatible_constraints
-          incompatible_constraints:
-            $ref: '#/components/schemas/IncompatibleConstraints'
-          relaxed_constraints_path:
-            $ref: '#/components/schemas/PathfindingResultSuccess'
     PathfindingOutput:
       type: object
       required:
@@ -11243,7 +11028,7 @@ components:
     PathfindingResult:
       oneOf:
       - allOf:
-        - $ref: '#/components/schemas/PathfindingResultSuccess'
+        - $ref: '#/components/schemas/core.PathfindingResultSuccess'
         - type: object
           required:
           - status
@@ -11262,31 +11047,6 @@ components:
               type: string
               enum:
               - failure
-    PathfindingResultSuccess:
-      type: object
-      description: A successful pathfinding result. This is also used for STDCM response.
-      required:
-      - path
-      - length
-      - path_item_positions
-      properties:
-        length:
-          type: integer
-          format: int64
-          description: Length of the path in mm
-          minimum: 0
-        path:
-          $ref: '#/components/schemas/TrainPath'
-          description: Full description of the path data
-        path_item_positions:
-          type: array
-          items:
-            type: integer
-            format: int64
-            minimum: 0
-          description: |-
-            The path offset in mm of each path item given as input of the pathfinding
-            The first value is always `0` (beginning of the path) and the last one is always equal to the `length` of the path in mm
     PathfindingTrackLocationInput:
       type: object
       required:
@@ -13409,7 +13169,7 @@ components:
             description: Travel time in ms
             minimum: 0
       - allOf:
-        - $ref: '#/components/schemas/PathfindingNotFound'
+        - $ref: '#/components/schemas/core.PathfindingNotFound'
           description: Pathfinding not found
         - type: object
           required:
@@ -13445,7 +13205,7 @@ components:
             enum:
             - simulation_failed
       - allOf:
-        - $ref: '#/components/schemas/PathfindingInputError'
+        - $ref: '#/components/schemas/core.PathfindingInputError'
           description: InputError
         - type: object
           required:
@@ -13844,7 +13604,7 @@ components:
               track_ranges:
                 type: array
                 items:
-                  $ref: '#/components/schemas/CoreTrackRange'
+                  $ref: '#/components/schemas/core.TrackRange'
                 description: Track ranges on which the speed limitation applies
           description: List of applicable temporary speed limits between the train departure and arrival
         time_gap_after:
@@ -14793,31 +14553,6 @@ components:
       properties:
         value:
           type: string
-    TrainPath:
-      type: object
-      description: |-
-        A valid train path, as returned from the pathfinding.
-        Can be used as-is as input for other endpoints.
-      required:
-      - blocks
-      - routes
-      - track_section_ranges
-      properties:
-        blocks:
-          type: array
-          items:
-            $ref: '#/components/schemas/ObjectRange'
-          description: Block ranges, in order.
-        routes:
-          type: array
-          items:
-            $ref: '#/components/schemas/ObjectRange'
-          description: Route ranges, in order.
-        track_section_ranges:
-          type: array
-          items:
-            $ref: '#/components/schemas/CoreTrackRange'
-          description: Track section ranges, in order.
     TrainRequirementsById:
       type: object
       required:
@@ -15079,3 +14814,268 @@ components:
           minimum: 0
         zone:
           type: string
+    core.IncompatibleConstraints:
+      type: object
+      required:
+      - incompatible_electrification_ranges
+      - incompatible_gauge_ranges
+      - incompatible_signaling_system_ranges
+      properties:
+        incompatible_electrification_ranges:
+          type: array
+          items:
+            $ref: '#/components/schemas/core.IncompatibleOffsetRangeWithValue'
+        incompatible_gauge_ranges:
+          type: array
+          items:
+            $ref: '#/components/schemas/core.IncompatibleOffsetRange'
+        incompatible_signaling_system_ranges:
+          type: array
+          items:
+            $ref: '#/components/schemas/core.IncompatibleOffsetRangeWithValue'
+    core.IncompatibleOffsetRange:
+      type: object
+      required:
+      - range
+      properties:
+        range:
+          $ref: '#/components/schemas/core.OffsetRange'
+    core.IncompatibleOffsetRangeWithValue:
+      type: object
+      required:
+      - range
+      - value
+      properties:
+        range:
+          $ref: '#/components/schemas/core.OffsetRange'
+        value:
+          type: string
+    core.ObjectRange:
+      type: object
+      description: A range on a linear object (usually block or route)
+      required:
+      - id
+      - begin
+      - end
+      properties:
+        begin:
+          type: integer
+          format: int64
+          description: The beginning of the range in mm.
+          minimum: 0
+        end:
+          type: integer
+          format: int64
+          description: The end of the range in mm.
+          minimum: 0
+        id:
+          oneOf:
+          - type: string
+            maxLength: 255
+            minLength: 1
+          description: The object identifier.
+    core.OffsetRange:
+      type: object
+      required:
+      - start
+      - end
+      properties:
+        end:
+          type: integer
+          format: int64
+          minimum: 0
+        start:
+          type: integer
+          format: int64
+          minimum: 0
+    core.PathfindingInputError:
+      oneOf:
+      - type: object
+        required:
+        - items
+        - error_type
+        properties:
+          error_type:
+            type: string
+            enum:
+            - invalid_path_items
+          items:
+            type: array
+            items:
+              type: object
+              required:
+              - index
+              - path_item
+              properties:
+                index:
+                  type: integer
+                  minimum: 0
+                path_item:
+                  $ref: '#/components/schemas/PathItemLocation'
+      - type: object
+        required:
+        - error_type
+        properties:
+          error_type:
+            type: string
+            enum:
+            - not_enough_path_items
+      - type: object
+        required:
+        - rolling_stock_name
+        - error_type
+        properties:
+          error_type:
+            type: string
+            enum:
+            - rolling_stock_not_found
+          rolling_stock_name:
+            type: string
+      - type: object
+        required:
+        - error_type
+        properties:
+          error_type:
+            type: string
+            enum:
+            - zero_length_path
+    core.PathfindingNotFound:
+      oneOf:
+      - type: object
+        required:
+        - track_section_ranges
+        - length
+        - error_type
+        properties:
+          error_type:
+            type: string
+            enum:
+            - not_found_in_blocks
+          length:
+            type: integer
+            format: int64
+            minimum: 0
+          track_section_ranges:
+            type: array
+            items:
+              $ref: '#/components/schemas/core.TrackRange'
+      - type: object
+        required:
+        - track_section_ranges
+        - length
+        - error_type
+        properties:
+          error_type:
+            type: string
+            enum:
+            - not_found_in_routes
+          length:
+            type: integer
+            format: int64
+            minimum: 0
+          track_section_ranges:
+            type: array
+            items:
+              $ref: '#/components/schemas/core.TrackRange'
+      - type: object
+        required:
+        - error_type
+        properties:
+          error_type:
+            type: string
+            enum:
+            - not_found_in_tracks
+      - type: object
+        required:
+        - relaxed_constraints_path
+        - incompatible_constraints
+        - error_type
+        properties:
+          error_type:
+            type: string
+            enum:
+            - incompatible_constraints
+          incompatible_constraints:
+            $ref: '#/components/schemas/core.IncompatibleConstraints'
+          relaxed_constraints_path:
+            $ref: '#/components/schemas/core.PathfindingResultSuccess'
+    core.PathfindingResultSuccess:
+      type: object
+      description: A successful pathfinding result. This is also used for STDCM response.
+      required:
+      - path
+      - length
+      - path_item_positions
+      properties:
+        length:
+          type: integer
+          format: int64
+          description: Length of the path in mm
+          minimum: 0
+        path:
+          $ref: '#/components/schemas/core.TrainPath'
+          description: Full description of the path data
+        path_item_positions:
+          type: array
+          items:
+            type: integer
+            format: int64
+            minimum: 0
+          description: |-
+            The path offset in mm of each path item given as input of the pathfinding
+            The first value is always `0` (beginning of the path) and the last one is always equal to the `length` of the path in mm
+    core.TrackRange:
+      type: object
+      description: |-
+        An oriented range on a track section.
+        `begin` is always less than `end`.
+      required:
+      - track_section
+      - begin
+      - end
+      - direction
+      properties:
+        begin:
+          type: integer
+          format: int64
+          description: The beginning of the range in mm.
+          minimum: 0
+        direction:
+          $ref: '#/components/schemas/Direction'
+          description: The direction of the range.
+        end:
+          type: integer
+          format: int64
+          description: The end of the range in mm.
+          minimum: 0
+        track_section:
+          oneOf:
+          - type: string
+            maxLength: 255
+            minLength: 1
+          description: The track section identifier.
+    core.TrainPath:
+      type: object
+      description: |-
+        A valid train path, as returned from the pathfinding.
+        Can be used as-is as input for other endpoints.
+      required:
+      - blocks
+      - routes
+      - track_section_ranges
+      properties:
+        blocks:
+          type: array
+          items:
+            $ref: '#/components/schemas/core.ObjectRange'
+          description: Block ranges, in order.
+        routes:
+          type: array
+          items:
+            $ref: '#/components/schemas/core.ObjectRange'
+          description: Route ranges, in order.
+        track_section_ranges:
+          type: array
+          items:
+            $ref: '#/components/schemas/core.TrackRange'
+          description: Track section ranges, in order.

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -11252,49 +11252,6 @@ components:
             within the target document where the operation is performed.
         value:
           description: Value to replace with.
-    ReportTrain:
-      type: object
-      required:
-      - positions
-      - times
-      - speeds
-      - energy_consumption
-      - path_item_times
-      properties:
-        energy_consumption:
-          type: number
-          format: double
-          description: Total energy consumption
-        path_item_times:
-          type: array
-          items:
-            type: integer
-            format: int64
-            minimum: 0
-          description: |-
-            Time in ms of each path item given as input of the pathfinding
-            The first value is always `0` (beginning of the path) and the last one, the total time of the simulation (end of the path)
-        positions:
-          type: array
-          items:
-            type: integer
-            format: int64
-            minimum: 0
-          description: |-
-            List of positions of a train
-            Both positions (in mm) and times (in ms) must have the same length
-        speeds:
-          type: array
-          items:
-            type: number
-            format: double
-          description: List of speeds associated to a position
-        times:
-          type: array
-          items:
-            type: integer
-            format: int64
-            minimum: 0
     ResourceType:
       type: string
       enum:
@@ -11821,50 +11778,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/DirectionalTrackRange'
-    RoutingRequirement:
-      type: object
-      required:
-      - route
-      - begin_time
-      - zones
-      properties:
-        begin_time:
-          type: integer
-          format: int64
-          description: Time in ms
-          minimum: 0
-        route:
-          type: string
-        zones:
-          type: array
-          items:
-            $ref: '#/components/schemas/RoutingZoneRequirement'
-    RoutingZoneRequirement:
-      type: object
-      required:
-      - zone
-      - entry_detector
-      - exit_detector
-      - switches
-      - end_time
-      properties:
-        end_time:
-          type: integer
-          format: int64
-          description: Time in ms
-          minimum: 0
-        entry_detector:
-          type: string
-        exit_detector:
-          type: string
-        switches:
-          type: object
-          additionalProperties:
-            type: string
-          propertyNames:
-            type: string
-        zone:
-          type: string
     Scenario:
       type: object
       required:
@@ -12590,31 +12503,6 @@ components:
           maxLength: 255
           minLength: 1
       additionalProperties: false
-    SignalCriticalPosition:
-      type: object
-      description: |-
-        First position (space and time) along the path where given signal must
-        be free (sighting time or closed-signal stop ending)
-      required:
-      - signal
-      - time
-      - position
-      - state
-      properties:
-        position:
-          type: integer
-          format: int64
-          description: Position in mm
-          minimum: 0
-        signal:
-          type: string
-        state:
-          type: string
-        time:
-          type: integer
-          format: int64
-          description: Time in ms
-          minimum: 0
     SimilarTrainWaypoint:
       type: object
       required:
@@ -12669,7 +12557,7 @@ components:
       - electrical_profiles
       properties:
         base:
-          $ref: '#/components/schemas/ReportTrain'
+          $ref: '#/components/schemas/core.ReportTrain'
           description: Simulation without any regularity margins
         electrical_profiles:
           type: object
@@ -12717,7 +12605,7 @@ components:
         final_output:
           oneOf:
           - allOf:
-            - $ref: '#/components/schemas/ReportTrain'
+            - $ref: '#/components/schemas/core.ReportTrain'
             - type: object
               required:
               - signal_critical_positions
@@ -12728,19 +12616,19 @@ components:
                 routing_requirements:
                   type: array
                   items:
-                    $ref: '#/components/schemas/RoutingRequirement'
+                    $ref: '#/components/schemas/core.RoutingRequirement'
                 signal_critical_positions:
                   type: array
                   items:
-                    $ref: '#/components/schemas/SignalCriticalPosition'
+                    $ref: '#/components/schemas/core.SignalCriticalPosition'
                 spacing_requirements:
                   type: array
                   items:
-                    $ref: '#/components/schemas/SpacingRequirement'
+                    $ref: '#/components/schemas/core.SpacingRequirement'
                 zone_updates:
                   type: array
                   items:
-                    $ref: '#/components/schemas/ZoneUpdate'
+                    $ref: '#/components/schemas/core.ZoneUpdate'
           description: 'User-selected simulation: can be base or provisional'
         mrsp:
           type: object
@@ -12806,7 +12694,7 @@ components:
                     description: in meters per second
               description: List of `n+1` values associated to the ranges
         provisional:
-          $ref: '#/components/schemas/ReportTrain'
+          $ref: '#/components/schemas/core.ReportTrain'
           description: Simulation that takes into account the regularity margins
     SimulationSummaryResult:
       oneOf:
@@ -12965,23 +12853,6 @@ components:
             minimum: 0
           description: List of times in ms since `departure_time` associated to a position
           minItems: 1
-    SpacingRequirement:
-      type: object
-      required:
-      - zone
-      - begin_time
-      - end_time
-      properties:
-        begin_time:
-          type: integer
-          format: int64
-          minimum: 0
-        end_time:
-          type: integer
-          format: int64
-          minimum: 0
-        zone:
-          type: string
     SpeedDependantPower:
       type: object
       description: power-speed curve (in an energy source)
@@ -14481,26 +14352,6 @@ components:
       - LOADING
       - READY
       - ERROR
-    ZoneUpdate:
-      type: object
-      required:
-      - zone
-      - time
-      - position
-      - is_entry
-      properties:
-        is_entry:
-          type: boolean
-        position:
-          type: integer
-          format: int64
-          minimum: 0
-        time:
-          type: integer
-          format: int64
-          minimum: 0
-        zone:
-          type: string
     core.ConflictRequirement:
       type: object
       description: |-
@@ -14952,6 +14803,118 @@ components:
           description: |-
             The path offset in mm of each path item given as input of the pathfinding
             The first value is always `0` (beginning of the path) and the last one is always equal to the `length` of the path in mm
+    core.ReportTrain:
+      type: object
+      required:
+      - positions
+      - times
+      - speeds
+      - energy_consumption
+      - path_item_times
+      properties:
+        energy_consumption:
+          type: number
+          format: double
+          description: Total energy consumption
+        path_item_times:
+          type: array
+          items:
+            type: integer
+            format: int64
+            minimum: 0
+          description: |-
+            Time in ms of each path item given as input of the pathfinding
+            The first value is always `0` (beginning of the path) and the last one, the total time of the simulation (end of the path)
+        positions:
+          type: array
+          items:
+            type: integer
+            format: int64
+            minimum: 0
+          description: |-
+            List of positions of a train
+            Both positions (in mm) and times (in ms) must have the same length
+        speeds:
+          type: array
+          items:
+            type: number
+            format: double
+          description: List of speeds associated to a position
+        times:
+          type: array
+          items:
+            type: integer
+            format: int64
+            minimum: 0
+    core.RoutingRequirement:
+      type: object
+      required:
+      - route
+      - begin_time
+      - zones
+      properties:
+        begin_time:
+          type: integer
+          format: int64
+          description: Time in ms
+          minimum: 0
+        route:
+          type: string
+        zones:
+          type: array
+          items:
+            $ref: '#/components/schemas/core.RoutingZoneRequirement'
+    core.RoutingZoneRequirement:
+      type: object
+      required:
+      - zone
+      - entry_detector
+      - exit_detector
+      - switches
+      - end_time
+      properties:
+        end_time:
+          type: integer
+          format: int64
+          description: Time in ms
+          minimum: 0
+        entry_detector:
+          type: string
+        exit_detector:
+          type: string
+        switches:
+          type: object
+          additionalProperties:
+            type: string
+          propertyNames:
+            type: string
+        zone:
+          type: string
+    core.SignalCriticalPosition:
+      type: object
+      description: |-
+        First position (space and time) along the path where given signal must
+        be free (sighting time or closed-signal stop ending)
+      required:
+      - signal
+      - time
+      - position
+      - state
+      properties:
+        position:
+          type: integer
+          format: int64
+          description: Position in mm
+          minimum: 0
+        signal:
+          type: string
+        state:
+          type: string
+        time:
+          type: integer
+          format: int64
+          description: Time in ms
+          minimum: 0
     core.SignalUpdate:
       type: object
       required:
@@ -15003,6 +14966,23 @@ components:
           format: int64
           description: The aspects start being displayed at this time (number of ms since `departure_time`)
           minimum: 0
+    core.SpacingRequirement:
+      type: object
+      required:
+      - zone
+      - begin_time
+      - end_time
+      properties:
+        begin_time:
+          type: integer
+          format: int64
+          minimum: 0
+        end_time:
+          type: integer
+          format: int64
+          minimum: 0
+        zone:
+          type: string
     core.TrackRange:
       type: object
       description: |-
@@ -15069,13 +15049,33 @@ components:
         routing_requirements:
           type: array
           items:
-            $ref: '#/components/schemas/RoutingRequirement'
+            $ref: '#/components/schemas/core.RoutingRequirement'
         spacing_requirements:
           type: array
           items:
-            $ref: '#/components/schemas/SpacingRequirement'
+            $ref: '#/components/schemas/core.SpacingRequirement'
         start_time:
           type: string
           format: date-time
         train_id:
+          type: string
+    core.ZoneUpdate:
+      type: object
+      required:
+      - zone
+      - time
+      - position
+      - is_entry
+      properties:
+        is_entry:
+          type: boolean
+        position:
+          type: integer
+          format: int64
+          minimum: 0
+        time:
+          type: integer
+          format: int64
+          minimum: 0
+        zone:
           type: string

--- a/front/src/applications/operationalStudies/helpers/TrainProjectionLazyLoaderAbstract.ts
+++ b/front/src/applications/operationalStudies/helpers/TrainProjectionLazyLoaderAbstract.ts
@@ -1,4 +1,8 @@
-import { type SignalUpdate, type SpaceTimeCurve, type TrainPath } from 'common/api/osrdEditoastApi';
+import {
+  type SignalUpdate,
+  type SpaceTimeCurve,
+  type CoreTrainPath,
+} from 'common/api/osrdEditoastApi';
 import type { TimetableItemId } from 'reducers/osrdconf/types';
 import type { AppDispatch } from 'store';
 
@@ -13,7 +17,7 @@ export type ProjectionResult = {
 export type TrainProjectionLazyLoaderOptions = {
   dispatch: AppDispatch;
   infraId: number;
-  path?: TrainPath;
+  path?: CoreTrainPath;
   electricalProfileSetId?: number;
   onProgress: (results: Map<TimetableItemId, ProjectionResult>) => void;
 };

--- a/front/src/applications/operationalStudies/helpers/TrainProjectionLazyLoaderAbstract.ts
+++ b/front/src/applications/operationalStudies/helpers/TrainProjectionLazyLoaderAbstract.ts
@@ -1,5 +1,5 @@
 import {
-  type SignalUpdate,
+  type CoreSignalUpdate,
   type SpaceTimeCurve,
   type CoreTrainPath,
 } from 'common/api/osrdEditoastApi';
@@ -10,8 +10,11 @@ const BATCH_SIZE = 20;
 
 export type ProjectionResult = {
   space_time_curves: SpaceTimeCurve[];
-  signal_updates?: SignalUpdate[];
-  exceptions?: Map<string, { space_time_curves: SpaceTimeCurve[]; signal_updates: SignalUpdate[] }>;
+  signal_updates?: CoreSignalUpdate[];
+  exceptions?: Map<
+    string,
+    { space_time_curves: SpaceTimeCurve[]; signal_updates: CoreSignalUpdate[] }
+  >;
 };
 
 export type TrainProjectionLazyLoaderOptions = {

--- a/front/src/applications/operationalStudies/helpers/TrainTrackProjectionLazyLoader.ts
+++ b/front/src/applications/operationalStudies/helpers/TrainTrackProjectionLazyLoader.ts
@@ -6,7 +6,7 @@ import {
   type PostTrainScheduleOccupancyBlocksApiResponse,
   type PostPacedTrainProjectPathApiResponse,
   type PostPacedTrainOccupancyBlocksApiResponse,
-  type TrainPath,
+  type CoreTrainPath,
 } from 'common/api/osrdEditoastApi';
 import type { TimetableItemId } from 'reducers/osrdconf/types';
 import {
@@ -27,7 +27,7 @@ export type TrainTrackProjectionLazyLoaderOptions = Omit<
   TrainProjectionLazyLoaderOptions,
   'path'
 > & {
-  path: TrainPath;
+  path: CoreTrainPath;
 };
 
 export default class TrainTrackProjectionLazyLoader extends TrainProjectionLazyLoaderAbstract {

--- a/front/src/applications/operationalStudies/helpers/upsertMapWaypointsInOperationalPoints.ts
+++ b/front/src/applications/operationalStudies/helpers/upsertMapWaypointsInOperationalPoints.ts
@@ -1,6 +1,6 @@
 import type { TFunction } from 'i18next';
 
-import type { PathfindingResultSuccess, TrainSchedule } from 'common/api/osrdEditoastApi';
+import type { CorePathfindingResultSuccess, TrainSchedule } from 'common/api/osrdEditoastApi';
 import type {
   PathOperationalPoint,
   EditoastPathOperationalPoint,
@@ -14,21 +14,21 @@ const HIGHEST_PRIORITY_WEIGHT = 100;
 export function upsertMapWaypointsInOperationalPoints(
   type: 'PathOperationalPoint',
   path: TrainSchedule['path'],
-  pathItemsPositions: PathfindingResultSuccess['path_item_positions'],
+  pathItemsPositions: CorePathfindingResultSuccess['path_item_positions'],
   operationalPoints: PathOperationalPoint[],
   t: TFunction<'operational-studies'>
 ): PathOperationalPoint[];
 export function upsertMapWaypointsInOperationalPoints(
   type: 'EditoastPathOperationalPoint',
   path: TrainSchedule['path'],
-  pathItemsPositions: PathfindingResultSuccess['path_item_positions'],
+  pathItemsPositions: CorePathfindingResultSuccess['path_item_positions'],
   operationalPoints: EditoastPathOperationalPoint[],
   t: TFunction<'operational-studies'>
 ): EditoastPathOperationalPoint[];
 export function upsertMapWaypointsInOperationalPoints(
   type: 'PathOperationalPoint' | 'EditoastPathOperationalPoint',
   path: TrainSchedule['path'],
-  pathItemsPositions: PathfindingResultSuccess['path_item_positions'],
+  pathItemsPositions: CorePathfindingResultSuccess['path_item_positions'],
   operationalPoints: (PathOperationalPoint | EditoastPathOperationalPoint)[],
   t: TFunction<'operational-studies'>
 ): (PathOperationalPoint | EditoastPathOperationalPoint)[] {

--- a/front/src/applications/operationalStudies/hooks/useEtcsBrakingCurves.ts
+++ b/front/src/applications/operationalStudies/hooks/useEtcsBrakingCurves.ts
@@ -9,8 +9,8 @@ import {
 import { useSelector } from 'react-redux';
 
 import {
-  type EtcsBrakingCurvesResponse,
-  type EtcsCurves,
+  type CoreEtcsBrakingCurvesResponse,
+  type CoreEtcsCurves,
   osrdEditoastApi,
   type SimulationResponseSuccess,
 } from 'common/api/osrdEditoastApi';
@@ -22,9 +22,9 @@ import { getSelectedTrainId } from 'reducers/simulationResults/selectors';
 import { useScenarioContext } from './useScenarioContext';
 import { isPacedTrainResponseWithPacedTrainId, isTrainScheduleId } from '../../../utils/trainId';
 
-const formatEtcsCurves = (etcsBrakingCurves: EtcsBrakingCurvesResponse): EtcsBrakingCurves => {
+const formatEtcsCurves = (etcsBrakingCurves: CoreEtcsBrakingCurvesResponse): EtcsBrakingCurves => {
   const { conflicts, slowdowns, stops } = etcsBrakingCurves;
-  const toBrakingCurve = (curve: EtcsCurves): EtcsBrakingCurve => ({
+  const toBrakingCurve = (curve: CoreEtcsCurves): EtcsBrakingCurve => ({
     [EtcsBrakingCurveType.IND]: curve.indication
       ? formatSpeedCurve(curve.indication.positions, curve.indication.speeds)
       : [],

--- a/front/src/applications/operationalStudies/types.ts
+++ b/front/src/applications/operationalStudies/types.ts
@@ -1,10 +1,10 @@
 import type { LayerData, PowerRestrictionValues } from '@osrd-project/ui-charts';
 
 import type {
-  IncompatibleConstraints,
+  CoreIncompatibleConstraints,
   PacedTrain,
   PathProperties,
-  PathfindingResultSuccess,
+  CorePathfindingResultSuccess,
   SimulationResponse,
   SimulationResponseSuccess,
   TrainSchedule,
@@ -61,8 +61,8 @@ export type ManageTimetableItemPathProperties = {
   geometry: NonNullable<PathProperties['geometry']>;
   suggestedOperationalPoints: SuggestedOP[];
   length: number;
-  trackSectionRanges: NonNullable<PathfindingResultSuccess['path']['track_section_ranges']>;
-  incompatibleConstraints?: IncompatibleConstraints;
+  trackSectionRanges: NonNullable<CorePathfindingResultSuccess['path']['track_section_ranges']>;
+  incompatibleConstraints?: CoreIncompatibleConstraints;
 };
 
 export type MapPathProperties = Pick<ManageTimetableItemPathProperties, 'length' | 'geometry'>;
@@ -128,7 +128,7 @@ export type SimulationResults =
       train: Train;
       rollingStock: RollingStockWithLiveries;
       simulation: SimulationResponseSuccess;
-      path: PathfindingResultSuccess;
+      path: CorePathfindingResultSuccess;
       pathProperties: PathPropertiesFormatted;
       powerRestrictions: LayerData<PowerRestrictionValues>[];
     };
@@ -161,7 +161,7 @@ export type CategoryColors = { normal: string; hovered: string; background: stri
 
 export type ItineraryPathProperties = PathProperties & {
   length: number;
-  incompatibleConstraints?: IncompatibleConstraints;
+  incompatibleConstraints?: CoreIncompatibleConstraints;
 };
 export type PathProjectionResult = {
   path: PathItem[];
@@ -171,7 +171,7 @@ export type PathProjectionResult = {
 } & (
   | {
       pathfindingStatus: 'succeeded';
-      pathfinding: PathfindingResultSuccess;
+      pathfinding: CorePathfindingResultSuccess;
       geometry: PathProperties['geometry'];
       projectingOnSimulatedPathException: boolean | undefined;
     }

--- a/front/src/applications/operationalStudies/utils.ts
+++ b/front/src/applications/operationalStudies/utils.ts
@@ -5,7 +5,7 @@ import type {
   OperationalPoint,
   OperationalPointIdentifier,
   OperationalPointReference,
-  PathfindingResultSuccess,
+  CorePathfindingResultSuccess,
   PathItemLocation,
   PathProperties,
   RelatedOperationalPoint,
@@ -159,7 +159,7 @@ export const transformElectricalBoundariesToRanges = (
 export const preparePathPropertiesData = (
   electricalProfiles: SimulationResponseSuccess['electrical_profiles'],
   { slopes, curves, electrifications, operational_points, geometry }: PathProperties,
-  { path_item_positions, length }: PathfindingResultSuccess,
+  { path_item_positions, length }: CorePathfindingResultSuccess,
   trainSchedulePath: TrainSchedule['path'],
   t: TFunction<'operational-studies'>
 ): PathPropertiesFormatted => {

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResultsExport/SimulationResultsExport.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResultsExport/SimulationResultsExport.tsx
@@ -9,7 +9,7 @@ import type {
   PathPropertiesFormatted,
 } from 'applications/operationalStudies/types';
 import type {
-  PathfindingResultSuccess,
+  CorePathfindingResultSuccess,
   RollingStockWithLiveries,
   SimulationResponseSuccess,
 } from 'common/api/osrdEditoastApi';
@@ -20,7 +20,7 @@ import exportTrainCSV from './exportTrainCSV';
 import useFormattedOperationalPoints from './useFormattedOperationalPoints';
 
 const exportTrainPDF = async (
-  path: PathfindingResultSuccess,
+  path: CorePathfindingResultSuccess,
   scenarioData: { name: string; infraName: string },
   train: Train,
   simulation: SimulationResponseSuccess,
@@ -63,7 +63,7 @@ const exportTrainPDF = async (
 };
 
 type SimulationResultsExportProps = {
-  path: PathfindingResultSuccess;
+  path: CorePathfindingResultSuccess;
   scenarioData: { name: string; infraName: string };
   train: Train;
   simulation: SimulationResponseSuccess;

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResultsExport/exportTrainCSV.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResultsExport/exportTrainCSV.ts
@@ -2,7 +2,7 @@ import type {
   ElectrificationRange,
   OperationalPointWithTimeAndSpeed,
 } from 'applications/operationalStudies/types';
-import type { ReportTrain, SimulationResponseSuccess } from 'common/api/osrdEditoastApi';
+import type { CoreReportTrain, SimulationResponseSuccess } from 'common/api/osrdEditoastApi';
 import { interpolateValue } from 'modules/simulationResult/helpers/utils';
 import type { Train } from 'reducers/osrdconf/types';
 import type { PositionSpeedTime, SpeedRanges } from 'reducers/simulationResults/types';
@@ -56,7 +56,7 @@ const compareOldActualValues = (old?: string, actual?: string) =>
 // Add OPs inside speedsteps array, gather speedlimit with stop position, add electrification ranges,
 // and sort the array along position before return
 const overloadSteps = (
-  trainRegime: ReportTrain,
+  trainRegime: CoreReportTrain,
   operationalPoints: OperationalPointWithTimeAndSpeed[],
   speedLimits: SpeedRanges,
   electrificationRanges: ElectrificationRange[]
@@ -194,7 +194,7 @@ export default function exportTrainCSV(
   electrificationRanges: ElectrificationRange[],
   train: Train
 ) {
-  const trainRegimeWithAccurateTime: ReportTrain = {
+  const trainRegimeWithAccurateTime: CoreReportTrain = {
     ...simulatedTrain.final_output,
     times: simulatedTrain.final_output.times.map(
       (time) => new Date(train.start_time).getTime() + time

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResultsExport/utils.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResultsExport/utils.ts
@@ -3,7 +3,7 @@ import type {
   PathPropertiesFormatted,
 } from 'applications/operationalStudies/types';
 import {
-  type ReportTrain,
+  type CoreReportTrain,
   type TrackSection,
   type SimulationResponseSuccess,
 } from 'common/api/osrdEditoastApi';
@@ -51,7 +51,7 @@ export function getActualVmaxs(givenPosition: number, vmax: SpeedRanges) {
 }
 
 const getTimeAndSpeed = (
-  simulationReport: ReportTrain,
+  simulationReport: CoreReportTrain,
   op: PathPropertiesFormatted['operationalPoints'][number]
 ) => {
   const matchingReportTrainIndex = simulationReport.positions.findIndex(

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResultsMap.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResultsMap.tsx
@@ -8,7 +8,7 @@ import captureMap from 'applications/operationalStudies/helpers/captureMap';
 import { useScenarioContext } from 'applications/operationalStudies/hooks/useScenarioContext';
 import type { PathPropertiesFormatted } from 'applications/operationalStudies/types';
 import { MARKER_TYPE } from 'applications/operationalStudies/views/Scenario/components/ManageTimetableItem/ManageTimetableItemMap/ItineraryMarkers';
-import type { PathfindingResultSuccess } from 'common/api/osrdEditoastApi';
+import type { CorePathfindingResultSuccess } from 'common/api/osrdEditoastApi';
 import BaseMap from 'common/Map/BaseMap';
 import MapButtons from 'common/Map/Buttons/MapButtons';
 import MapMarkers, { type MapMarker } from 'common/Map/components/MapMarkers';
@@ -25,7 +25,7 @@ import { useAppDispatch } from 'store';
 const MAP_ID = 'simulation-result-map';
 
 type SimulationResultMapProps = {
-  pathfindingResult?: PathfindingResultSuccess;
+  pathfindingResult?: CorePathfindingResultSuccess;
   geometry?: PathPropertiesFormatted['geometry'];
   setMapCanvas?: (mapCanvas: string) => void;
 };
@@ -55,7 +55,7 @@ const SimulationResultMap = ({
     const getPathItemsCoordinates = async ({
       path,
       path_item_positions,
-    }: PathfindingResultSuccess) => {
+    }: CorePathfindingResultSuccess) => {
       const trackIds = path.track_section_ranges.map((range) => range.track_section);
       const tracks = await getTrackSectionsByIds(trackIds);
       const tracksLengthCumulativeSums = getTrackLengthCumulativeSums(path.track_section_ranges);

--- a/front/src/applications/stdcm/utils/fetchPathProperties.ts
+++ b/front/src/applications/stdcm/utils/fetchPathProperties.ts
@@ -5,7 +5,7 @@ import type { TrackSectionEntity } from 'applications/editor/tools/trackEdition/
 import type { StdcmPathProperties } from 'applications/stdcm/types';
 import type {
   PostInfraByInfraIdPathPropertiesApiArg,
-  PathfindingResultSuccess,
+  CorePathfindingResultSuccess,
 } from 'common/api/osrdEditoastApi';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import { formatSuggestedOperationalPoints } from 'modules/pathfinding/utils';
@@ -17,7 +17,7 @@ import type { AppDispatch } from 'store';
  *  Function to fetch and format path properties
  */
 const fetchPathProperties = async (
-  pathfinding_result: PathfindingResultSuccess,
+  pathfinding_result: CorePathfindingResultSuccess,
   infraId: number,
   dispatch: AppDispatch
 ): Promise<StdcmPathProperties> => {

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -2356,7 +2356,7 @@ export type PostTimetableByIdPacedTrainsApiArg = {
 };
 export type GetTimetableByIdRequirementsApiResponse =
   /** status 200 The paginated list of timetable requirements */ PaginationStats & {
-    results: TrainRequirementsById[];
+    results: CoreTrainRequirementsById[];
   };
 export type GetTimetableByIdRequirementsApiArg = {
   /** A timetable ID */
@@ -4675,7 +4675,7 @@ export type SubCategoryPage = PaginationStats & {
 export type TimetableResult = {
   timetable_id: number;
 };
-export type ConflictRequirement = {
+export type CoreConflictRequirement = {
   end_time: string;
   start_time: string;
   zone: string;
@@ -4702,7 +4702,7 @@ export type Conflict = {
     paced_train_id: number;
   })[];
   /** List of requirements causing the conflict */
-  requirements: ConflictRequirement[];
+  requirements: CoreConflictRequirement[];
   /** Datetime of the start of the conflict */
   start_time: string;
   /** List of train schedule ids involved in the conflict */
@@ -4710,7 +4710,7 @@ export type Conflict = {
   /** List of work schedule ids involved in the conflict */
   work_schedule_ids: number[];
 };
-export type TrainRequirementsById = {
+export type CoreTrainRequirementsById = {
   routing_requirements: RoutingRequirement[];
   spacing_requirements: SpacingRequirement[];
   start_time: string;

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -2508,7 +2508,7 @@ export type DeleteTrainScheduleApiArg = {
   };
 };
 export type PostTrainScheduleOccupancyBlocksApiResponse = /** status 200  */ {
-  [key: string]: SignalUpdate[];
+  [key: string]: CoreSignalUpdate[];
 };
 export type PostTrainScheduleOccupancyBlocksApiArg = {
   occupancyBlockForm: OccupancyBlockForm;
@@ -3788,7 +3788,7 @@ export type MacroNoteBatchForm = {
   macro_notes: MacroNoteForm[];
   scenario_id: number;
 };
-export type SignalUpdate = {
+export type CoreSignalUpdate = {
   /** The labels of the new aspect */
   aspect_label: string;
   /** Whether the signal is blinking */
@@ -3812,10 +3812,10 @@ export type SignalUpdate = {
 export type OccupancyBlocksPacedTrainResult = {
   /** Exceptions whose blocks are different from the paced train */
   exceptions: {
-    [key: string]: SignalUpdate[];
+    [key: string]: CoreSignalUpdate[];
   };
   /** Paced train */
-  paced_train: SignalUpdate[];
+  paced_train: CoreSignalUpdate[];
 };
 export type OccupancyBlockForm = {
   electrical_profile_set_id?: number | null;

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -2043,7 +2043,7 @@ export type PutPacedTrainByIdApiArg = {
   };
 };
 export type GetPacedTrainByIdEtcsBrakingCurvesApiResponse =
-  /** status 200 ETCS Braking Curves Output */ EtcsBrakingCurvesResponse;
+  /** status 200 ETCS Braking Curves Output */ CoreEtcsBrakingCurvesResponse;
 export type GetPacedTrainByIdEtcsBrakingCurvesApiArg = {
   id: number;
   infraId: number;
@@ -2592,7 +2592,7 @@ export type PutTrainScheduleByIdApiArg = {
   trainScheduleForm: TrainScheduleForm;
 };
 export type GetTrainScheduleByIdEtcsBrakingCurvesApiResponse =
-  /** status 200 ETCS Braking Curves Output */ EtcsBrakingCurvesResponse;
+  /** status 200 ETCS Braking Curves Output */ CoreEtcsBrakingCurvesResponse;
 export type GetTrainScheduleByIdEtcsBrakingCurvesApiArg = {
   /** A train schedule ID */
   id: number;
@@ -4019,7 +4019,7 @@ export type PacedTrainResponse = PacedTrain & {
   id: number;
   timetable_id: number;
 };
-export type EtcsConflictCurves = {
+export type CoreEtcsConflictCurves = {
   conflict_type: 'Spacing' | 'Routing';
   guidance: {
     /** List of positions of a train
@@ -4049,7 +4049,7 @@ export type EtcsConflictCurves = {
     times: number[];
   };
 };
-export type EtcsCurves = {
+export type CoreEtcsCurves = {
   guidance: {
     /** List of positions of a train
         Both positions (in mm) and times (in ms) must have the same length */
@@ -4078,16 +4078,16 @@ export type EtcsCurves = {
     times: number[];
   };
 };
-export type EtcsBrakingCurvesResponse = {
+export type CoreEtcsBrakingCurvesResponse = {
   /** List of ETCS conflict braking curves associated to the train schedule's ETCS signals.
     For each non-route delimiter (F) signal, the associated spacing conflict curve is returned.
     For each route delimiter (Nf) signal, 2 sets of curves are returned, associated to the
     corresponding potential spacing or routing conflict. */
-  conflicts: EtcsConflictCurves[];
+  conflicts: CoreEtcsConflictCurves[];
   /** List of ETCS braking curves associated to the train schedule's ETCS slowdowns */
-  slowdowns: EtcsCurves[];
+  slowdowns: CoreEtcsCurves[];
   /** List of ETCS braking curves associated to the train schedule's ETCS stops */
-  stops: EtcsCurves[];
+  stops: CoreEtcsCurves[];
 };
 export type ReportTrain = {
   /** Total energy consumption */

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -2388,18 +2388,18 @@ export type GetTimetableByIdRoundTripsTrainSchedulesApiArg = {
 };
 export type PostTimetableByIdStdcmApiResponse = /** status 200 The simulation result */
   | {
-      core_payload?: null | StdcmRequest;
+      core_payload?: null | CoreStdcmRequest;
       departure_time: string;
       pathfinding_result: CorePathfindingResultSuccess;
       simulation: SimulationResponseSuccess;
       status: 'success';
     }
   | {
-      core_payload?: null | StdcmRequest;
+      core_payload?: null | CoreStdcmRequest;
       status: 'path_not_found';
     }
   | {
-      core_payload?: null | StdcmRequest;
+      core_payload?: null | CoreStdcmRequest;
       error: SimulationResponse;
       status: 'preprocessing_simulation_error';
     };
@@ -4716,7 +4716,22 @@ export type CoreTrainRequirementsById = {
   start_time: string;
   train_id: string;
 };
-export type UndirectedTrackRange = {
+export type CoreStepTimingData = {
+  /** Time the train should arrive at this point */
+  arrival_time: string;
+  /** Tolerance for the arrival time, when it arrives after the expected time, in ms */
+  arrival_time_tolerance_after: number;
+  /** Tolerance for the arrival time, when it arrives before the expected time, in ms */
+  arrival_time_tolerance_before: number;
+};
+export type CorePathItem = {
+  /** The track offsets of the path item */
+  locations: TrackOffset[];
+  step_timing_data?: null | CoreStepTimingData;
+  /** Stop duration in milliseconds. None if the train does not stop at this path item. */
+  stop_duration?: number | null;
+};
+export type CoreUndirectedTrackRange = {
   /** The beginning of the range in mm. */
   begin: number;
   /** The end of the range in mm. */
@@ -4724,15 +4739,15 @@ export type UndirectedTrackRange = {
   /** The track section identifier. */
   track_section: string;
 };
-export type WorkSchedule = {
+export type CoreWorkSchedule = {
   /** End time as a time delta from the stdcm start time in ms */
   end_time: number;
   /** Start time as a time delta from the stdcm start time in ms */
   start_time: number;
   /** List of unavailable track ranges */
-  track_ranges: UndirectedTrackRange[];
+  track_ranges: CoreUndirectedTrackRange[];
 };
-export type StdcmRequest = {
+export type CoreStdcmRequest = {
   /** Set of authorized track section ids for the current request */
   allowed_track_sections?: string[] | null;
   /** The comfort of the train */
@@ -4757,7 +4772,7 @@ export type StdcmRequest = {
   /** Maximum run time of the simulation in milliseconds */
   maximum_run_time: number;
   /** List of waypoints. Each waypoint is a list of track offset. */
-  path_items: PathItem[];
+  path_items: CorePathItem[];
   physics_consist: {
     base_power_class?: string | null;
     comfort_acceleration: number;
@@ -4809,7 +4824,7 @@ export type StdcmRequest = {
   /** Timetable id */
   timetable_id: number;
   /** List of planned work schedules */
-  work_schedules: WorkSchedule[];
+  work_schedules: CoreWorkSchedule[];
 };
 export type PathfindingItem = {
   /** The stop duration in milliseconds, None if the train does not stop. */
@@ -4902,6 +4917,16 @@ export type WorkScheduleItemForm = {
   start_date_time: string;
   track_ranges: TrackRange[];
   work_schedule_type: 'CATENARY' | 'TRACK';
+};
+export type WorkScheduleType = 'CATENARY' | 'TRACK';
+export type WorkSchedule = {
+  end_date_time: string;
+  id: number;
+  obj_id: string;
+  start_date_time: string;
+  track_ranges: TrackRange[];
+  work_schedule_group_id: number;
+  work_schedule_type: WorkScheduleType;
 };
 export type Intersection = {
   /** Distance of the end of the intersection relative to the beginning of the path */

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -4089,7 +4089,7 @@ export type CoreEtcsBrakingCurvesResponse = {
   /** List of ETCS braking curves associated to the train schedule's ETCS stops */
   stops: CoreEtcsCurves[];
 };
-export type ReportTrain = {
+export type CoreReportTrain = {
   /** Total energy consumption */
   energy_consumption: number;
   /** Time in ms of each path item given as input of the pathfinding
@@ -4102,7 +4102,7 @@ export type ReportTrain = {
   speeds: number[];
   times: number[];
 };
-export type RoutingZoneRequirement = {
+export type CoreRoutingZoneRequirement = {
   /** Time in ms */
   end_time: number;
   entry_detector: string;
@@ -4112,13 +4112,13 @@ export type RoutingZoneRequirement = {
   };
   zone: string;
 };
-export type RoutingRequirement = {
+export type CoreRoutingRequirement = {
   /** Time in ms */
   begin_time: number;
   route: string;
-  zones: RoutingZoneRequirement[];
+  zones: CoreRoutingZoneRequirement[];
 };
-export type SignalCriticalPosition = {
+export type CoreSignalCriticalPosition = {
   /** Position in mm */
   position: number;
   signal: string;
@@ -4126,12 +4126,12 @@ export type SignalCriticalPosition = {
   /** Time in ms */
   time: number;
 };
-export type SpacingRequirement = {
+export type CoreSpacingRequirement = {
   begin_time: number;
   end_time: number;
   zone: string;
 };
-export type ZoneUpdate = {
+export type CoreZoneUpdate = {
   is_entry: boolean;
   position: number;
   time: number;
@@ -4139,7 +4139,7 @@ export type ZoneUpdate = {
 };
 export type SimulationResponseSuccess = {
   /** Simulation without any regularity margins */
-  base: ReportTrain;
+  base: CoreReportTrain;
   electrical_profiles: {
     /** List of `n` boundaries of the ranges (block path).
         A boundary is a distance from the beginning of the path in mm. */
@@ -4157,11 +4157,11 @@ export type SimulationResponseSuccess = {
     )[];
   };
   /** User-selected simulation: can be base or provisional */
-  final_output: ReportTrain & {
-    routing_requirements: RoutingRequirement[];
-    signal_critical_positions: SignalCriticalPosition[];
-    spacing_requirements: SpacingRequirement[];
-    zone_updates: ZoneUpdate[];
+  final_output: CoreReportTrain & {
+    routing_requirements: CoreRoutingRequirement[];
+    signal_critical_positions: CoreSignalCriticalPosition[];
+    spacing_requirements: CoreSpacingRequirement[];
+    zone_updates: CoreZoneUpdate[];
   };
   /** A MRSP computation result (Most Restrictive Speed Profile) */
   mrsp: {
@@ -4191,7 +4191,7 @@ export type SimulationResponseSuccess = {
     }[];
   };
   /** Simulation that takes into account the regularity margins */
-  provisional: ReportTrain;
+  provisional: CoreReportTrain;
 };
 export type SimulationResponse =
   | (SimulationResponseSuccess & {
@@ -4711,8 +4711,8 @@ export type Conflict = {
   work_schedule_ids: number[];
 };
 export type CoreTrainRequirementsById = {
-  routing_requirements: RoutingRequirement[];
-  spacing_requirements: SpacingRequirement[];
+  routing_requirements: CoreRoutingRequirement[];
+  spacing_requirements: CoreSpacingRequirement[];
   start_time: string;
   train_id: string;
 };

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -2390,7 +2390,7 @@ export type PostTimetableByIdStdcmApiResponse = /** status 200 The simulation re
   | {
       core_payload?: null | StdcmRequest;
       departure_time: string;
-      pathfinding_result: PathfindingResultSuccess;
+      pathfinding_result: CorePathfindingResultSuccess;
       simulation: SimulationResponseSuccess;
       status: 'success';
     }
@@ -3436,7 +3436,7 @@ export type InfraPathfindingInput = {
   ending: PathfindingTrackLocationInput;
   starting: PathfindingTrackLocationInput;
 };
-export type ObjectRange = {
+export type CoreObjectRange = {
   /** The beginning of the range in mm. */
   begin: number;
   /** The end of the range in mm. */
@@ -3444,19 +3444,19 @@ export type ObjectRange = {
   /** The object identifier. */
   id: string;
 };
-export type TrainPath = {
+export type CoreTrainPath = {
   /** Block ranges, in order. */
-  blocks: ObjectRange[];
+  blocks: CoreObjectRange[];
   /** Route ranges, in order. */
-  routes: ObjectRange[];
+  routes: CoreObjectRange[];
   /** Track section ranges, in order. */
   track_section_ranges: CoreTrackRange[];
 };
-export type PathfindingResultSuccess = {
+export type CorePathfindingResultSuccess = {
   /** Length of the path in mm */
   length: number;
   /** Full description of the path data */
-  path: TrainPath;
+  path: CoreTrainPath;
   /** The path offset in mm of each path item given as input of the pathfinding
     The first value is always `0` (beginning of the path) and the last one is always equal to the `length` of the path in mm */
   path_item_positions: number[];
@@ -3468,7 +3468,7 @@ export type TrackOffset = {
   track: string;
 };
 export type PathItemLocation = TrackOffset | OperationalPointReference;
-export type PathfindingInputError =
+export type CorePathfindingInputError =
   | {
       error_type: 'invalid_path_items';
       items: {
@@ -3486,23 +3486,23 @@ export type PathfindingInputError =
   | {
       error_type: 'zero_length_path';
     };
-export type OffsetRange = {
+export type CoreOffsetRange = {
   end: number;
   start: number;
 };
-export type IncompatibleOffsetRangeWithValue = {
-  range: OffsetRange;
+export type CoreIncompatibleOffsetRangeWithValue = {
+  range: CoreOffsetRange;
   value: string;
 };
-export type IncompatibleOffsetRange = {
-  range: OffsetRange;
+export type CoreIncompatibleOffsetRange = {
+  range: CoreOffsetRange;
 };
-export type IncompatibleConstraints = {
-  incompatible_electrification_ranges: IncompatibleOffsetRangeWithValue[];
-  incompatible_gauge_ranges: IncompatibleOffsetRange[];
-  incompatible_signaling_system_ranges: IncompatibleOffsetRangeWithValue[];
+export type CoreIncompatibleConstraints = {
+  incompatible_electrification_ranges: CoreIncompatibleOffsetRangeWithValue[];
+  incompatible_gauge_ranges: CoreIncompatibleOffsetRange[];
+  incompatible_signaling_system_ranges: CoreIncompatibleOffsetRangeWithValue[];
 };
-export type PathfindingNotFound =
+export type CorePathfindingNotFound =
   | {
       error_type: 'not_found_in_blocks';
       length: number;
@@ -3518,8 +3518,8 @@ export type PathfindingNotFound =
     }
   | {
       error_type: 'incompatible_constraints';
-      incompatible_constraints: IncompatibleConstraints;
-      relaxed_constraints_path: PathfindingResultSuccess;
+      incompatible_constraints: CoreIncompatibleConstraints;
+      relaxed_constraints_path: CorePathfindingResultSuccess;
     };
 export type InternalError = {
   context: {
@@ -3530,10 +3530,10 @@ export type InternalError = {
   type: string;
 };
 export type PathfindingFailure =
-  | (PathfindingInputError & {
+  | (CorePathfindingInputError & {
       failed_status: 'pathfinding_input_error';
     })
-  | (PathfindingNotFound & {
+  | (CorePathfindingNotFound & {
       failed_status: 'pathfinding_not_found';
     })
   | {
@@ -3541,7 +3541,7 @@ export type PathfindingFailure =
       failed_status: 'internal_error';
     };
 export type PathfindingResult =
-  | (PathfindingResultSuccess & {
+  | (CorePathfindingResultSuccess & {
       status: 'success';
     })
   | (PathfindingFailure & {
@@ -3821,7 +3821,7 @@ export type OccupancyBlockForm = {
   electrical_profile_set_id?: number | null;
   ids: number[];
   infra_id: number;
-  path: TrainPath;
+  path: CoreTrainPath;
 };
 export type SpaceTimeCurve = {
   /** List of positions of a train in mm
@@ -3875,7 +3875,7 @@ export type SimulationSummaryResult =
       /** Travel time in ms */
       time: number;
     }
-  | (PathfindingNotFound & {
+  | (CorePathfindingNotFound & {
       status: 'pathfinding_not_found';
     })
   | {
@@ -3886,7 +3886,7 @@ export type SimulationSummaryResult =
       error_type: string;
       status: 'simulation_failed';
     }
-  | (PathfindingInputError & {
+  | (CorePathfindingInputError & {
       status: 'pathfinding_input_error';
     });
 export type PacedTrainSimulationSummaryResult = {

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -10,7 +10,7 @@ import {
 
 import {
   generatedEditoastApi,
-  type EtcsBrakingCurvesResponse,
+  type CoreEtcsBrakingCurvesResponse,
   type GetLightRollingStockApiResponse,
   type GetSpritesSignalingSystemsApiResponse,
   type MacroNodeResponse,
@@ -186,14 +186,14 @@ const osrdEditoastApi = generatedEditoastApi
         ],
       }),
       getEtcsBrakingCurves: builder.query<
-        EtcsBrakingCurvesResponse,
+        CoreEtcsBrakingCurvesResponse,
         { id: TrainId; infraId: number; electricalProfileSetId?: number; exceptionKey?: string }
       >({
         queryFn: async (
           { id: trainId, infraId, electricalProfileSetId, exceptionKey },
           { dispatch }
         ) => {
-          let etcsBrakingCurves: EtcsBrakingCurvesResponse;
+          let etcsBrakingCurves: CoreEtcsBrakingCurvesResponse;
           if (isTrainScheduleId(trainId)) {
             etcsBrakingCurves = await dispatch(
               generatedEditoastApi.endpoints.getTrainScheduleByIdEtcsBrakingCurves.initiate(

--- a/front/src/modules/SimulationReportSheet/SimulationReportSheet.tsx
+++ b/front/src/modules/SimulationReportSheet/SimulationReportSheet.tsx
@@ -4,7 +4,7 @@ import { Page, Text, Image, Document, View } from '@react-pdf/renderer';
 import type { TFunction } from 'i18next';
 
 import type { OperationalPointWithTimeAndSpeed } from 'applications/operationalStudies/types';
-import type { PathfindingResultSuccess } from 'common/api/osrdEditoastApi';
+import type { CorePathfindingResultSuccess } from 'common/api/osrdEditoastApi';
 import { timeToLocaleStringRounded, useDateTimeLocale } from 'utils/date';
 import { msToKmh, kgToT } from 'utils/physics';
 
@@ -16,7 +16,7 @@ import type { RouteTableRow, SimulationSheetData } from './types';
 import { formatOperationalStudiesDataForSimulationTable } from './utils/formatSimulationTable';
 
 type SimulationReportSheetProps = {
-  path: PathfindingResultSuccess;
+  path: CorePathfindingResultSuccess;
   scenarioData: { name: string; infraName: string };
   trainData: SimulationSheetData;
   mapCanvas?: string;

--- a/front/src/modules/SimulationReportSheet/utils/formatSimulationTable.ts
+++ b/front/src/modules/SimulationReportSheet/utils/formatSimulationTable.ts
@@ -3,7 +3,7 @@ import type { TFunction } from 'i18next';
 
 import type { OperationalPointWithTimeAndSpeed } from 'applications/operationalStudies/types';
 import type { StdcmSuccessResponse, StdcmResultsOperationalPoint } from 'applications/stdcm/types';
-import type { PathfindingResultSuccess } from 'common/api/osrdEditoastApi';
+import type { CorePathfindingResultSuccess } from 'common/api/osrdEditoastApi';
 import { timeToLocaleStringRounded } from 'utils/date';
 import { addDurationToDate, Duration } from 'utils/duration';
 import { kgToT } from 'utils/physics';
@@ -116,7 +116,7 @@ export const formatStdcmDataForSimulationTable = (
 
 export const formatOperationalStudiesDataForSimulationTable = (
   operationalPointsList: OperationalPointWithTimeAndSpeed[],
-  pathItemPositions: PathfindingResultSuccess['path_item_positions'],
+  pathItemPositions: CorePathfindingResultSuccess['path_item_positions'],
   rollingStock: { mass: number; name: string },
   t: TFunction<'stdcm'>,
   dateTimeLocale: Intl.Locale

--- a/front/src/modules/pathfinding/components/IncompatibleConstraints/IncompatibleConstraints.tsx
+++ b/front/src/modules/pathfinding/components/IncompatibleConstraints/IncompatibleConstraints.tsx
@@ -12,7 +12,7 @@ import { useMap, type MapLayerMouseEvent } from 'react-map-gl/maplibre';
 
 import type {
   GeoJsonLineString,
-  IncompatibleConstraints as IncompatibleConstraintsType,
+  CoreIncompatibleConstraints as IncompatibleConstraintsType,
 } from 'common/api/osrdEditoastApi';
 import Collapsable from 'common/Collapsable';
 import { getMapMouseEventNearestFeature } from 'utils/mapHelper';

--- a/front/src/modules/pathfinding/components/IncompatibleConstraints/types.ts
+++ b/front/src/modules/pathfinding/components/IncompatibleConstraints/types.ts
@@ -1,10 +1,12 @@
 import type {
-  IncompatibleConstraints as ApiIncompatibleConstraints,
-  IncompatibleOffsetRange,
-  IncompatibleOffsetRangeWithValue,
+  CoreIncompatibleConstraints as ApiIncompatibleConstraints,
+  CoreIncompatibleOffsetRange,
+  CoreIncompatibleOffsetRangeWithValue,
 } from 'common/api/osrdEditoastApi';
 
-export type IncompatibleConstraint = IncompatibleOffsetRange | IncompatibleOffsetRangeWithValue;
+export type IncompatibleConstraint =
+  | CoreIncompatibleOffsetRange
+  | CoreIncompatibleOffsetRangeWithValue;
 
 export type IncompatibleConstraintType = keyof ApiIncompatibleConstraints;
 

--- a/front/src/modules/pathfinding/hooks/usePathfinding.ts
+++ b/front/src/modules/pathfinding/hooks/usePathfinding.ts
@@ -7,9 +7,9 @@ import { useSelector } from 'react-redux';
 import { useScenarioContext } from 'applications/operationalStudies/hooks/useScenarioContext';
 import type { ManageTimetableItemPathProperties } from 'applications/operationalStudies/types';
 import type {
-  IncompatibleConstraints,
-  PathfindingInputError,
-  PathfindingResultSuccess,
+  CoreIncompatibleConstraints,
+  CorePathfindingInputError,
+  CorePathfindingResultSuccess,
   PostInfraByInfraIdPathPropertiesApiArg,
   RelatedOperationalPoint,
 } from 'common/api/osrdEditoastApi';
@@ -130,7 +130,10 @@ const usePathfinding = ({
 
   const handleInvalidPathItems = (
     steps: PathStep[],
-    invalidPathItems: Extract<PathfindingInputError, { error_type: 'invalid_path_items' }>['items']
+    invalidPathItems: Extract<
+      CorePathfindingInputError,
+      { error_type: 'invalid_path_items' }
+    >['items']
   ) => {
     const updatedPathSteps = steps.map((step, index) => ({
       ...step,
@@ -147,8 +150,8 @@ const usePathfinding = ({
 
   const populateStoreWithPathfinding = async (
     pathStepsInput: PathStep[],
-    pathResult: PathfindingResultSuccess,
-    incompatibleConstraints?: IncompatibleConstraints
+    pathResult: CorePathfindingResultSuccess,
+    incompatibleConstraints?: CoreIncompatibleConstraints
   ) => {
     const pathPropertiesParams: PostInfraByInfraIdPathPropertiesApiArg = {
       infraId,

--- a/front/src/modules/powerRestriction/helpers/formatPowerRestrictionRangesWithHandled.ts
+++ b/front/src/modules/powerRestriction/helpers/formatPowerRestrictionRangesWithHandled.ts
@@ -3,7 +3,7 @@ import { compact } from 'lodash';
 
 import type { PathPropertiesFormatted } from 'applications/operationalStudies/types';
 import type {
-  PathfindingResultSuccess,
+  CorePathfindingResultSuccess,
   RollingStock,
   TrainSchedule,
 } from 'common/api/osrdEditoastApi';
@@ -18,7 +18,7 @@ import { mmToKm, mToMm } from 'utils/physics';
 export const formatPowerRestrictionRanges = (
   powerRestrictions: NonNullable<TrainSchedule['power_restrictions']>,
   path: TrainSchedule['path'],
-  stepsPathPositions: PathfindingResultSuccess['path_item_positions']
+  stepsPathPositions: CorePathfindingResultSuccess['path_item_positions']
 ): LayerData<Omit<PowerRestrictionValues, 'handled'>>[] =>
   compact(
     powerRestrictions.map((powerRestriction) => {
@@ -81,7 +81,7 @@ const formatPowerRestrictionRangesWithHandled = ({
 }: {
   selectedTimetableItem: Pick<TimetableItem, 'path' | 'power_restrictions'>;
   selectedTrainRollingStock?: RollingStock;
-  pathfindingResult: PathfindingResultSuccess;
+  pathfindingResult: CorePathfindingResultSuccess;
   pathProperties: PathPropertiesFormatted;
 }) => {
   if (powerRestrictions && selectedTrainRollingStock) {

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useGetProjectedTrainOperationalPoints.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useGetProjectedTrainOperationalPoints.ts
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
 import { upsertMapWaypointsInOperationalPoints } from 'applications/operationalStudies/helpers/upsertMapWaypointsInOperationalPoints';
-import { type PathfindingResultSuccess } from 'common/api/osrdEditoastApi';
+import { type CorePathfindingResultSuccess } from 'common/api/osrdEditoastApi';
 import { isStation } from 'modules/pathfinding/utils';
 import type { PathOperationalPoint, ProjectionData } from 'modules/simulationResult/types';
 import type { TimetableItem } from 'reducers/osrdconf/types';
@@ -22,7 +22,7 @@ const useGetProjectedTrainOperationalPoints = ({
   infraId: number;
   timetableId: number | undefined;
   path?: TimetableItem['path'];
-  pathfinding?: PathfindingResultSuccess;
+  pathfinding?: CorePathfindingResultSuccess;
   projectedOperationalPoints?: ProjectionData['operationalPoints'];
 }) => {
   const { t } = useTranslation('operational-studies');

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useLazyProjectTrains.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useLazyProjectTrains.ts
@@ -7,7 +7,7 @@ import type { ProjectionResult } from 'applications/operationalStudies/helpers/T
 import type TrainProjectionLazyLoaderAbstract from 'applications/operationalStudies/helpers/TrainProjectionLazyLoaderAbstract';
 import TrainTrackProjectionLazyLoader from 'applications/operationalStudies/helpers/TrainTrackProjectionLazyLoader';
 import upsertNewProjectedTrains from 'applications/operationalStudies/helpers/upsertNewProjectedTrains';
-import { type OperationalPointReference, type TrainPath } from 'common/api/osrdEditoastApi';
+import { type OperationalPointReference, type CoreTrainPath } from 'common/api/osrdEditoastApi';
 import type { TrainSpaceTimeData } from 'modules/simulationResult/types';
 import type { TimetableItemId, TimetableItem } from 'reducers/osrdconf/types';
 import { getProjectionType } from 'reducers/simulationResults/selectors';
@@ -16,7 +16,7 @@ import { useAppDispatch } from 'store';
 type UseLazyProjectTrainsOptions = {
   infraId: number;
   electricalProfileSetId?: number;
-  path?: TrainPath;
+  path?: CoreTrainPath;
   operationalPointDistances?: number[];
   operationalPointReferences?: OperationalPointReference[];
 };

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useProjectedConflicts.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useProjectedConflicts.ts
@@ -4,14 +4,14 @@ import type {
   Conflict,
   ConflictRequirement,
   PathProperties,
-  PathfindingResultSuccess,
+  CorePathfindingResultSuccess,
 } from 'common/api/osrdEditoastApi';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 
 const useProjectedConflicts = (
   infraId: number,
   conflicts: Conflict[],
-  path: PathfindingResultSuccess | undefined
+  path: CorePathfindingResultSuccess | undefined
 ) => {
   const [postPathProperties] =
     osrdEditoastApi.endpoints.postInfraByInfraIdPathProperties.useLazyQuery();
@@ -20,7 +20,7 @@ const useProjectedConflicts = (
   useEffect(() => {
     const fetchProjectedZones = async ({
       path: { track_section_ranges },
-    }: PathfindingResultSuccess) => {
+    }: CorePathfindingResultSuccess) => {
       const { zones } = await postPathProperties({
         infraId,
         pathPropertiesInput: {

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useProjectedConflicts.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useProjectedConflicts.ts
@@ -2,7 +2,7 @@ import { useEffect, useState, useMemo } from 'react';
 
 import type {
   Conflict,
-  ConflictRequirement,
+  CoreConflictRequirement,
   PathProperties,
   CorePathfindingResultSuccess,
 } from 'common/api/osrdEditoastApi';
@@ -38,7 +38,7 @@ const useProjectedConflicts = (
 
   const conflictReqsByZone = useMemo(() => {
     const reqs = conflicts.flatMap((conflict) => conflict.requirements);
-    const reqsMap = new Map<string, ConflictRequirement[]>();
+    const reqsMap = new Map<string, CoreConflictRequirement[]>();
     // With paced trains, one zone can appear multiple times so we need to handle that.
     reqs.forEach((req) => {
       if (!reqsMap.has(req.zone)) {

--- a/front/src/modules/simulationResult/components/SpeedDistanceDiagram/helpers.ts
+++ b/front/src/modules/simulationResult/components/SpeedDistanceDiagram/helpers.ts
@@ -8,7 +8,7 @@ import type {
 } from '@osrd-project/ui-charts';
 
 import type { PathPropertiesFormatted, PositionData } from 'applications/operationalStudies/types';
-import type { ReportTrain, SimulationResponseSuccess } from 'common/api/osrdEditoastApi';
+import type { CoreReportTrain, SimulationResponseSuccess } from 'common/api/osrdEditoastApi';
 import { TAG_COLORS } from 'modules/simulationResult/consts';
 import type { SpeedLimitTagValue } from 'modules/simulationResult/types';
 import { mmToKm, msToKmh, mToKm } from 'utils/physics';
@@ -88,7 +88,7 @@ export const formatSpeedCurve = (positions: number[], speeds: number[]) =>
     value: msToKmh(value),
   }));
 
-export const formatSpeeds = (simulation: ReportTrain) => {
+export const formatSpeeds = (simulation: CoreReportTrain) => {
   const { positions, speeds } = simulation;
   return formatSpeedCurve(positions, speeds);
 };

--- a/front/src/modules/simulationResult/types.ts
+++ b/front/src/modules/simulationResult/types.ts
@@ -8,7 +8,7 @@ import type {
 } from 'applications/operationalStudies/types';
 import type {
   PacedTrainException,
-  SignalUpdate,
+  CoreSignalUpdate,
   PathProperties,
   RollingStockWithLiveries,
   SimulationResponseSuccess,
@@ -40,7 +40,7 @@ export type BaseTrainProjection = {
     positions: number[];
     times: number[];
   }[];
-  signalUpdates: SignalUpdate[];
+  signalUpdates: CoreSignalUpdate[];
 };
 
 export type TrainSpaceTimeData = {

--- a/front/src/modules/timesStops/TimesStopsOutput.tsx
+++ b/front/src/modules/timesStops/TimesStopsOutput.tsx
@@ -2,7 +2,7 @@ import cx from 'classnames';
 
 import type { PathPropertiesFormatted } from 'applications/operationalStudies/types';
 import type {
-  PathfindingResultSuccess,
+  CorePathfindingResultSuccess,
   SimulationResponseSuccess,
 } from 'common/api/osrdEditoastApi';
 import type { SimulationSummary } from 'modules/timetableItem/types';
@@ -18,7 +18,7 @@ type TimesStopsOutputProps = {
   isValid: boolean;
   selectedTrain?: Train;
   simulatedTrain?: SimulationResponseSuccess['final_output'];
-  simulatedPath?: PathfindingResultSuccess;
+  simulatedPath?: CorePathfindingResultSuccess;
   simulatedPathItemTimes?: Extract<SimulationSummary, { isValid: true }>['pathItemTimes'];
   operationalPointsOnPath?: PathPropertiesFormatted['operationalPoints'];
 };

--- a/front/src/modules/timetableItem/types.ts
+++ b/front/src/modules/timetableItem/types.ts
@@ -4,8 +4,8 @@ import type {
   TrainCategory,
   LightRollingStockWithLiveries,
   PacedTrainException,
-  PathfindingInputError,
-  PathfindingNotFound,
+  CorePathfindingInputError,
+  CorePathfindingNotFound,
   ReceptionSignal,
   SimulationSummaryResult,
   TrainScheduleResponse,
@@ -76,8 +76,8 @@ export type TimetableItemWithSummaries = Omit<
 
 export type InvalidReason =
   | Extract<SimulationSummaryResult['status'], 'pathfinding_failure' | 'simulation_failed'>
-  | PathfindingNotFound['error_type']
-  | PathfindingInputError['error_type'];
+  | CorePathfindingNotFound['error_type']
+  | CorePathfindingInputError['error_type'];
 
 export type TrainScheduleWithDetails = TimetableItemWithSummaries & {
   id: TrainScheduleId;


### PR DESCRIPTION
This PR aims to avoid name collision in OpenAPI due to generic struct names across modules.

* Add #[schema(as = ...)] to all structs and enums in `editoast/core_client/*` implementing ToSchema
* Remove useless `ToSchema` from a few types
* Update frontend accordingly