### PR TITLE
front: fix board wrapper timetable output for small screen

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/BoardWrapper.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/BoardWrapper.tsx
@@ -51,7 +51,7 @@ const BoardWrapper = ({
         {children}
       </div>
       {customFooter}
-      {withFooter && <div className="board-footer" />}
+      {withFooter && !customFooter && <div className="board-footer" />}
     </div>
   );
 };

--- a/front/src/applications/operationalStudies/views/Scenario/components/BoardWrapper.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/BoardWrapper.tsx
@@ -7,6 +7,7 @@ import type { OSRDMenuItem } from 'common/OSRDMenu';
 
 type BoardWrapperProps = {
   children: React.ReactNode;
+  customFooter?: React.ReactNode;
   hidden?: boolean;
   name: string;
   items?: OSRDMenuItem[];
@@ -21,6 +22,7 @@ const BoardWrapper = ({
   items = [],
   withFooter = false,
   dataTestId,
+  customFooter,
 }: BoardWrapperProps) => {
   if (hidden) {
     return null;
@@ -48,6 +50,7 @@ const BoardWrapper = ({
       >
         {children}
       </div>
+      {customFooter}
       {withFooter && <div className="board-footer" />}
     </div>
   );

--- a/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
@@ -113,6 +113,11 @@ const ScenarioContent = ({ activeBoards }: ScenarioContentProps) => {
     [updateTrainDepartureTime, refreshNge]
   );
 
+  const simulationResultBoards = ['map', 'tables', 'std', 'sdd'] as Board[];
+  const isBoardSimulationResultsActive = simulationResultBoards.some((board) =>
+    activeBoards.has(board)
+  );
+
   // To update dynamic translations in NGE when language changes
   useEffect(() => {
     refreshNge();
@@ -201,7 +206,7 @@ const ScenarioContent = ({ activeBoards }: ScenarioContentProps) => {
               <ScenarioLoaderMessage />
             )}
           <div className="scenario-results">
-            {isInfraLoaded && (
+            {isInfraLoaded && isBoardSimulationResultsActive && (
               <SimulationResults
                 scenarioData={{ name: scenario.name, infraName: scenario.infra_name }}
                 projectionData={projectionData}

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
@@ -351,6 +351,22 @@ const SimulationResults = ({
                 },
               },
             ]}
+            customFooter={
+              simulationResults?.isValid && (
+                <div className="time-stop-outputs">
+                  {/* SIMULATION EXPORT BUTTONS */}
+                  <SimulationResultsExport
+                    path={simulationResults.path}
+                    scenarioData={scenarioData}
+                    train={simulationResults.train}
+                    simulation={simulationResults.simulation}
+                    pathProperties={simulationResults.pathProperties}
+                    rollingStock={simulationResults.rollingStock}
+                    mapCanvas={mapCanvas}
+                  />
+                </div>
+              )
+            }
           >
             <div data-testid="time-stop-outputs" className="time-stop-outputs">
               <TimesStopsOutput
@@ -366,21 +382,6 @@ const SimulationResults = ({
                   : { isValid: false })}
               />
             </div>
-
-            {simulationResults?.isValid && (
-              <div className="time-stop-outputs">
-                {/* SIMULATION EXPORT BUTTONS */}
-                <SimulationResultsExport
-                  path={simulationResults.path}
-                  scenarioData={scenarioData}
-                  train={simulationResults.train}
-                  simulation={simulationResults.simulation}
-                  pathProperties={simulationResults.pathProperties}
-                  rollingStock={simulationResults.rollingStock}
-                  mapCanvas={mapCanvas}
-                />
-              </div>
-            )}
           </BoardWrapper>
         </>
       )}

--- a/front/src/modules/timesStops/TimesStops.tsx
+++ b/front/src/modules/timesStops/TimesStops.tsx
@@ -59,7 +59,6 @@ const TimesStops = <T extends TimesStopsRow>({
       }}
       stickyRightColumn={stickyRightColumn}
       lockRows
-      height={600}
       headerRowHeight={headerRowHeight}
       rowClassName={({ rowData, rowIndex }) =>
         cx({

--- a/front/src/modules/timesStops/styles/_timesStopsDatasheet.scss
+++ b/front/src/modules/timesStops/styles/_timesStopsDatasheet.scss
@@ -64,6 +64,7 @@
   }
 
   .dsg-container {
+    height: 100% !important;
     border-top-left-radius: 10px;
     border-top-right-radius: 10px;
     border: none;

--- a/front/src/styles/scss/applications/operationalStudies/_boardWrapper.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_boardWrapper.scss
@@ -59,7 +59,7 @@
     height: 100%;
     width: 100%;
     border-top: 1px solid white;
-    overflow: hidden;
+    overflow-y: auto;
     background-color: var(--ambientB10);
 
     &.with-rounded-corners {

--- a/front/src/styles/scss/applications/operationalStudies/_scenario.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_scenario.scss
@@ -691,6 +691,7 @@
     width: 100%;
     display: flex;
     flex-direction: column;
+    gap: 16px;
   }
 }
 

--- a/front/src/styles/scss/applications/operationalStudies/_simulationresults.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_simulationresults.scss
@@ -4,10 +4,6 @@
     flex-direction: column;
     gap: 16px;
 
-    > :last-child {
-      margin-bottom: 16px;
-    }
-
     /*
      * Temporary style while waiting for the STD style to be updated
     */


### PR DESCRIPTION
On a small screen, the download buttons for the simulation sheet are not visible.
The bug was also caused by the custom footer being rendered inside the BoardWrapper body instead of as a footer.
The BoardWrapper now accepts a `customFooter` prop that replaces the default footer.

close #14095 