### PR TITLE
front: set maxHeight to ResizableSection

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/NGE/NGE.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/NGE/NGE.tsx
@@ -63,6 +63,9 @@ const NGE = ({ dto, onOperation, onLoad }: NGEProps) => {
       setNgeRootElement(ngeRoot);
 
       if (onLoad) onLoad();
+
+      // Trigger a resize event to ensure NGE's layout logic is correctly initialized
+      frame.contentWindow?.dispatchEvent(new Event('resize'));
     };
 
     frame.addEventListener('load', handleFrameLoad);
@@ -100,6 +103,18 @@ const NGE = ({ dto, onOperation, onLoad }: NGEProps) => {
     }
     return () => {};
   }, [onOperation, ngeRootElement]);
+
+  useEffect(() => {
+    const handleResize = () => {
+      frameRef.current?.contentWindow?.dispatchEvent(new Event('resize'));
+    };
+
+    const observer = new ResizeObserver(handleResize);
+    if (frameRef.current) {
+      observer.observe(frameRef.current);
+    }
+    return () => observer.disconnect();
+  }, []);
 
   return <iframe ref={frameRef} srcDoc={frameSrc} title="NGE" className="nge-iframe-container" />;
 };

--- a/front/src/common/ResizableSection.tsx
+++ b/front/src/common/ResizableSection.tsx
@@ -1,4 +1,4 @@
-import { useState, type PropsWithChildren } from 'react';
+import { useState, useEffect, type PropsWithChildren } from 'react';
 
 import { Rnd } from 'react-rnd';
 
@@ -13,6 +13,10 @@ const ResizableSection = ({
   setHeight: React.Dispatch<React.SetStateAction<number>>;
 }>) => {
   const [baseHeight, setBaseHeight] = useState(height);
+
+  useEffect(() => {
+    window.dispatchEvent(new Event('resize'));
+  }, [height]);
 
   return (
     <div className="resizable-section" style={{ height }}>


### PR DESCRIPTION


The maximum height now corresponds to the height of the page, so we can no longer extend components beyond the page, which avoids strange behavior, such as hidden elements in components. 

I'm open to any suggestion to improve/fix this code