### PR TITLE
editoast: conflicts train id core api communication refactor

### DIFF
--- a/editoast/core_client/src/conflict_detection.rs
+++ b/editoast/core_client/src/conflict_detection.rs
@@ -57,7 +57,7 @@ pub struct ConflictDetectionResponse {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Conflict {
     /// List of train schedule ids and paced train generated occurrences involved in the conflict
-    pub train_ids: Vec<String>,
+    pub train_ids: Vec<Uuid>,
     /// List of work schedule ids involved in the conflict
     pub work_schedule_ids: Vec<String>,
     /// Datetime of the start of the conflict

--- a/editoast/core_client/src/conflict_detection.rs
+++ b/editoast/core_client/src/conflict_detection.rs
@@ -4,6 +4,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use std::collections::HashMap;
 use utoipa::ToSchema;
+use uuid::Uuid;
 
 use crate::AsCoreRequest;
 use crate::Json;
@@ -19,7 +20,7 @@ pub struct ConflictDetectionRequest {
     /// Infrastructure expected version
     pub expected_version: i64,
     /// List of requirements for each train schedule
-    pub trains_requirements: HashMap<String, TrainRequirements>,
+    pub trains_requirements: HashMap<Uuid, TrainRequirements>,
     /// List of work schedules
     pub work_schedules: Option<WorkSchedulesRequest>,
 }

--- a/editoast/src/models/paced_train.rs
+++ b/editoast/src/models/paced_train.rs
@@ -1,5 +1,4 @@
 use std::fmt::Display;
-use std::str::FromStr;
 
 use chrono::DateTime;
 use chrono::Duration as ChronoDuration;
@@ -295,7 +294,7 @@ impl From<PacedTrain> for paced_train::PacedTrain {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
+#[derive(Debug, Clone, Hash, Serialize, Deserialize, PartialEq, ToSchema)]
 #[serde(tag = "type")]
 pub enum OccurrenceId {
     BaseOccurrence { index: u64 },
@@ -303,7 +302,7 @@ pub enum OccurrenceId {
     CreatedException { exception_key: String },
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Hash, PartialEq)]
 /// This ID is used to identify paced train occurrences and exceptions when sending them to the core API for conflict detection.
 pub enum TrainId {
     TrainSchedule(i64),
@@ -333,55 +332,6 @@ impl Display for TrainId {
                         index,
                     },
             } => write!(f, "{paced_train_id}@{exception_key}#{index}"),
-        }
-    }
-}
-
-impl FromStr for TrainId {
-    type Err = &'static str;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        // Is it a paced train exception?
-        if let Some((train_id_str, exception_str)) = s.split_once('@') {
-            let paced_train_id = train_id_str
-                .parse::<i64>()
-                .map_err(|_| "Invalid train id")?;
-            // Is it a modified paced train exception?
-            if let Some((exception_key, index_str)) = exception_str.split_once('#') {
-                let index = index_str
-                    .parse::<u64>()
-                    .map_err(|_| "Invalid exception index")?;
-                Ok(TrainId::PacedTrain {
-                    paced_train_id,
-                    occurrence_id: OccurrenceId::ModifiedException {
-                        exception_key: exception_key.to_string(),
-                        index,
-                    },
-                })
-            } else {
-                let exception_key = exception_str.to_string();
-                Ok(TrainId::PacedTrain {
-                    paced_train_id,
-                    occurrence_id: OccurrenceId::CreatedException { exception_key },
-                })
-            }
-        } else {
-            // Is it a base paced train exception?
-            if let Some((train_id_str, index_str)) = s.split_once('#') {
-                let paced_train_id = train_id_str
-                    .parse::<i64>()
-                    .map_err(|_| "Invalid train id")?;
-                let index = index_str
-                    .parse::<u64>()
-                    .map_err(|_| "Invalid occurrence index")?;
-                Ok(TrainId::PacedTrain {
-                    paced_train_id,
-                    occurrence_id: OccurrenceId::BaseOccurrence { index },
-                })
-            } else {
-                let train_id = s.parse::<i64>().map_err(|_| "Invalid train id")?;
-                Ok(TrainId::TrainSchedule(train_id))
-            }
         }
     }
 }

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -641,7 +641,7 @@ fn build_conflict_core_request(
 
     let mut trains_map: HashMap<Uuid, TrainId> = HashMap::with_capacity(train_ids.len());
 
-    let trains_requirements: HashMap<String, TrainRequirements> =
+    let trains_requirements: HashMap<Uuid, TrainRequirements> =
         izip!(start_times, train_ids, simulations)
             .flat_map(|(start_time, train_id, sim)| {
                 let CompleteReportTrain {
@@ -660,7 +660,7 @@ fn build_conflict_core_request(
                 trains_map.insert(train_id_for_core, train_id.clone());
 
                 Some((
-                    train_id_for_core.to_string(),
+                    train_id_for_core,
                     TrainRequirements {
                         start_time,
                         spacing_requirements,
@@ -1449,7 +1449,7 @@ mod tests {
 
         let simple_requirements = conflict_core_request
             .trains_requirements
-            .get(&simple_ts_train_core_id.to_string())
+            .get(&simple_ts_train_core_id)
             .unwrap();
         assert_eq!(simple_requirements.start_time, ts_start_time);
         assert_eq!(
@@ -1474,7 +1474,7 @@ mod tests {
             .unwrap();
         let paced_0_requirements = conflict_core_request
             .trains_requirements
-            .get(&paced_0_train_core_id.to_string())
+            .get(&paced_0_train_core_id)
             .unwrap();
         assert_eq!(paced_0_requirements.start_time, paced_start_time);
         assert_eq!(
@@ -1499,7 +1499,7 @@ mod tests {
             .unwrap();
         let paced_1_requirements = conflict_core_request
             .trains_requirements
-            .get(&paced_1_train_core_id.to_string())
+            .get(&paced_1_train_core_id)
             .unwrap();
         assert_eq!(
             paced_1_requirements.start_time,

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -404,44 +404,41 @@ impl Conflict {
         conflict: CoreConflict,
         trains_map: &HashMap<Uuid, TrainId>,
     ) -> Result<Self> {
-        let (train_schedule_ids, paced_train_occurrence_ids): (Vec<_>, Vec<_>) =
-            conflict.train_ids.iter().partition_map(|train_uuid| {
-                match Uuid::parse_str(train_uuid)
-                    .ok()
-                    .and_then(|train_uuid| trains_map.get(&train_uuid).cloned())
-                {
-                    Some(TrainId::TrainSchedule(id)) => Either::Left(id),
-                    Some(TrainId::PacedTrain {
-                        paced_train_id,
-                        occurrence_id: OccurrenceId::BaseOccurrence { index },
-                    }) => Either::Right(PacedTrainOccurrenceId {
-                        paced_train_id,
-                        occurrence_ref: PacedTrainOccurrenceRef::BaseOccurrence { index },
-                    }),
-                    Some(TrainId::PacedTrain {
-                        paced_train_id,
-                        occurrence_id: OccurrenceId::CreatedException { exception_key },
-                    }) => Either::Right(PacedTrainOccurrenceId {
-                        paced_train_id,
-                        occurrence_ref: PacedTrainOccurrenceRef::CreatedException { exception_key },
-                    }),
-                    Some(TrainId::PacedTrain {
-                        paced_train_id,
-                        occurrence_id:
-                            OccurrenceId::ModifiedException {
-                                exception_key,
-                                index,
-                            },
-                    }) => Either::Right(PacedTrainOccurrenceId {
-                        paced_train_id,
-                        occurrence_ref: PacedTrainOccurrenceRef::ModifiedException {
-                            index,
+        let (train_schedule_ids, paced_train_occurrence_ids): (Vec<_>, Vec<_>) = conflict
+            .train_ids
+            .iter()
+            .partition_map(|train_uuid| match trains_map.get(train_uuid).cloned() {
+                Some(TrainId::TrainSchedule(id)) => Either::Left(id),
+                Some(TrainId::PacedTrain {
+                    paced_train_id,
+                    occurrence_id: OccurrenceId::BaseOccurrence { index },
+                }) => Either::Right(PacedTrainOccurrenceId {
+                    paced_train_id,
+                    occurrence_ref: PacedTrainOccurrenceRef::BaseOccurrence { index },
+                }),
+                Some(TrainId::PacedTrain {
+                    paced_train_id,
+                    occurrence_id: OccurrenceId::CreatedException { exception_key },
+                }) => Either::Right(PacedTrainOccurrenceId {
+                    paced_train_id,
+                    occurrence_ref: PacedTrainOccurrenceRef::CreatedException { exception_key },
+                }),
+                Some(TrainId::PacedTrain {
+                    paced_train_id,
+                    occurrence_id:
+                        OccurrenceId::ModifiedException {
                             exception_key,
+                            index,
                         },
-                    }),
-                    None => {
-                        unreachable!("Unreachable case encountered while partitioning train IDs")
-                    }
+                }) => Either::Right(PacedTrainOccurrenceId {
+                    paced_train_id,
+                    occurrence_ref: PacedTrainOccurrenceRef::ModifiedException {
+                        index,
+                        exception_key,
+                    },
+                }),
+                None => {
+                    unreachable!("Unreachable case encountered while partitioning train IDs")
                 }
             });
 

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -402,42 +402,47 @@ impl Conflict {
     ///  and maps them to either a `train_schedule_id` or a `paced_train_occurrence_id` based on the provided key mapping.
     fn from_core_response(
         conflict: CoreConflict,
-        trains_map: &HashMap<String, TrainId>,
+        trains_map: &HashMap<Uuid, TrainId>,
     ) -> Result<Self> {
-        let (train_schedule_ids, paced_train_occurrence_ids): (Vec<_>, Vec<_>) = conflict
-            .train_ids
-            .iter()
-            .partition_map(|train_id| match trains_map.get(train_id).cloned() {
-                Some(TrainId::TrainSchedule(id)) => Either::Left(id),
-                Some(TrainId::PacedTrain {
-                    paced_train_id,
-                    occurrence_id: OccurrenceId::BaseOccurrence { index },
-                }) => Either::Right(PacedTrainOccurrenceId {
-                    paced_train_id,
-                    occurrence_ref: PacedTrainOccurrenceRef::BaseOccurrence { index },
-                }),
-                Some(TrainId::PacedTrain {
-                    paced_train_id,
-                    occurrence_id: OccurrenceId::CreatedException { exception_key },
-                }) => Either::Right(PacedTrainOccurrenceId {
-                    paced_train_id,
-                    occurrence_ref: PacedTrainOccurrenceRef::CreatedException { exception_key },
-                }),
-                Some(TrainId::PacedTrain {
-                    paced_train_id,
-                    occurrence_id:
-                        OccurrenceId::ModifiedException {
-                            exception_key,
+        let (train_schedule_ids, paced_train_occurrence_ids): (Vec<_>, Vec<_>) =
+            conflict.train_ids.iter().partition_map(|train_uuid| {
+                match Uuid::parse_str(train_uuid)
+                    .ok()
+                    .and_then(|train_uuid| trains_map.get(&train_uuid).cloned())
+                {
+                    Some(TrainId::TrainSchedule(id)) => Either::Left(id),
+                    Some(TrainId::PacedTrain {
+                        paced_train_id,
+                        occurrence_id: OccurrenceId::BaseOccurrence { index },
+                    }) => Either::Right(PacedTrainOccurrenceId {
+                        paced_train_id,
+                        occurrence_ref: PacedTrainOccurrenceRef::BaseOccurrence { index },
+                    }),
+                    Some(TrainId::PacedTrain {
+                        paced_train_id,
+                        occurrence_id: OccurrenceId::CreatedException { exception_key },
+                    }) => Either::Right(PacedTrainOccurrenceId {
+                        paced_train_id,
+                        occurrence_ref: PacedTrainOccurrenceRef::CreatedException { exception_key },
+                    }),
+                    Some(TrainId::PacedTrain {
+                        paced_train_id,
+                        occurrence_id:
+                            OccurrenceId::ModifiedException {
+                                exception_key,
+                                index,
+                            },
+                    }) => Either::Right(PacedTrainOccurrenceId {
+                        paced_train_id,
+                        occurrence_ref: PacedTrainOccurrenceRef::ModifiedException {
                             index,
+                            exception_key,
                         },
-                }) => Either::Right(PacedTrainOccurrenceId {
-                    paced_train_id,
-                    occurrence_ref: PacedTrainOccurrenceRef::ModifiedException {
-                        index,
-                        exception_key,
-                    },
-                }),
-                None => unreachable!("Unreachable case encountered while partitioning train IDs"),
+                    }),
+                    None => {
+                        unreachable!("Unreachable case encountered while partitioning train IDs")
+                    }
+                }
             });
 
         let work_schedule_ids = conflict
@@ -630,11 +635,11 @@ fn build_conflict_core_request(
     start_times: Vec<DateTime<Utc>>,
     train_ids: Vec<TrainId>,
     simulations: Vec<Arc<simulation::Response>>,
-) -> (HashMap<String, TrainId>, ConflictDetectionRequest) {
+) -> (HashMap<Uuid, TrainId>, ConflictDetectionRequest) {
     assert_eq!(start_times.len(), simulations.len());
     assert_eq!(train_ids.len(), simulations.len());
 
-    let mut trains_map: HashMap<String, TrainId> = HashMap::with_capacity(train_ids.len());
+    let mut trains_map: HashMap<Uuid, TrainId> = HashMap::with_capacity(train_ids.len());
 
     let trains_requirements: HashMap<String, TrainRequirements> =
         izip!(start_times, train_ids, simulations)
@@ -651,11 +656,11 @@ fn build_conflict_core_request(
                     _ => None,
                 }?;
 
-                let train_id_for_core = Uuid::new_v4().to_string();
-                trains_map.insert(train_id_for_core.clone(), train_id.clone());
+                let train_id_for_core = Uuid::new_v4();
+                trains_map.insert(train_id_for_core, train_id.clone());
 
                 Some((
-                    train_id_for_core,
+                    train_id_for_core.to_string(),
                     TrainRequirements {
                         start_time,
                         spacing_requirements,
@@ -1444,7 +1449,7 @@ mod tests {
 
         let simple_requirements = conflict_core_request
             .trains_requirements
-            .get(&simple_ts_train_core_id)
+            .get(&simple_ts_train_core_id.to_string())
             .unwrap();
         assert_eq!(simple_requirements.start_time, ts_start_time);
         assert_eq!(
@@ -1469,7 +1474,7 @@ mod tests {
             .unwrap();
         let paced_0_requirements = conflict_core_request
             .trains_requirements
-            .get(&paced_0_train_core_id)
+            .get(&paced_0_train_core_id.to_string())
             .unwrap();
         assert_eq!(paced_0_requirements.start_time, paced_start_time);
         assert_eq!(
@@ -1494,7 +1499,7 @@ mod tests {
             .unwrap();
         let paced_1_requirements = conflict_core_request
             .trains_requirements
-            .get(&paced_1_train_core_id)
+            .get(&paced_1_train_core_id.to_string())
             .unwrap();
         assert_eq!(
             paced_1_requirements.start_time,

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -1437,16 +1437,14 @@ mod tests {
         let simple_ts_train_core_id = trains_ids_map
             .iter()
             .find_map(|(core_id, train_id)| match train_id {
-                TrainId::TrainSchedule(ts_id_inner) if *ts_id_inner == ts_id => {
-                    Some(core_id.clone())
-                }
+                TrainId::TrainSchedule(ts_id_inner) if *ts_id_inner == ts_id => Some(core_id),
                 _ => None,
             })
             .unwrap();
 
         let simple_requirements = conflict_core_request
             .trains_requirements
-            .get(&simple_ts_train_core_id)
+            .get(simple_ts_train_core_id)
             .unwrap();
         assert_eq!(simple_requirements.start_time, ts_start_time);
         assert_eq!(
@@ -1465,13 +1463,13 @@ mod tests {
                 TrainId::PacedTrain {
                     paced_train_id: pt_id,
                     occurrence_id: OccurrenceId::BaseOccurrence { index },
-                } if *pt_id == paced_train_id && *index == 0 => Some(core_id.clone()),
+                } if *pt_id == paced_train_id && *index == 0 => Some(core_id),
                 _ => None,
             })
             .unwrap();
         let paced_0_requirements = conflict_core_request
             .trains_requirements
-            .get(&paced_0_train_core_id)
+            .get(paced_0_train_core_id)
             .unwrap();
         assert_eq!(paced_0_requirements.start_time, paced_start_time);
         assert_eq!(
@@ -1490,13 +1488,13 @@ mod tests {
                 TrainId::PacedTrain {
                     paced_train_id: pt_id,
                     occurrence_id: OccurrenceId::BaseOccurrence { index },
-                } if *pt_id == paced_train_id && *index == 1 => Some(core_id.clone()),
+                } if *pt_id == paced_train_id && *index == 1 => Some(core_id),
                 _ => None,
             })
             .unwrap();
         let paced_1_requirements = conflict_core_request
             .trains_requirements
-            .get(&paced_1_train_core_id)
+            .get(paced_1_train_core_id)
             .unwrap();
         assert_eq!(
             paced_1_requirements.start_time,

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -6,6 +6,7 @@ pub mod stdcm;
 mod track_occupancy;
 pub mod train_schedule;
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use authz;
@@ -34,6 +35,10 @@ use core_client::simulation::PhysicsConsist;
 use database::DbConnection;
 use database::DbConnectionPoolV2;
 use editoast_derive::EditoastError;
+use editoast_models::prelude::*;
+use editoast_models::timetable::Timetable;
+use editoast_models::timetable::TimetableWithTrains;
+use editoast_models::train_schedule::TrainScheduleChangeset;
 use itertools::Either;
 use itertools::Itertools;
 use itertools::izip;
@@ -53,6 +58,7 @@ use train_schedule::TrainScheduleForm;
 use train_schedule::TrainScheduleResponse;
 use utoipa::IntoParams;
 use utoipa::ToSchema;
+use uuid::Uuid;
 
 use super::infra::InfraIdQueryParam;
 use super::pagination::ConcatenatedPaginatedList;
@@ -70,10 +76,6 @@ use crate::models::paced_train::TrainId;
 use crate::views::AuthenticationExt;
 use crate::views::AuthorizationError;
 use crate::views::timetable::simulation::SimulationResponseSuccess;
-use editoast_models::prelude::*;
-use editoast_models::timetable::Timetable;
-use editoast_models::timetable::TimetableWithTrains;
-use editoast_models::train_schedule::TrainScheduleChangeset;
 
 #[derive(Debug, Error, EditoastError, derive_more::From)]
 #[editoast_error(base_id = "timetable")]
@@ -398,27 +400,30 @@ pub struct Conflict {
 impl Conflict {
     /// This function processes train ids from Core Response
     ///  and maps them to either a `train_schedule_id` or a `paced_train_occurrence_id` based on the provided key mapping.
-    fn from_core_response(conflict: CoreConflict) -> Result<Self> {
+    fn from_core_response(
+        conflict: CoreConflict,
+        trains_map: &HashMap<String, TrainId>,
+    ) -> Result<Self> {
         let (train_schedule_ids, paced_train_occurrence_ids): (Vec<_>, Vec<_>) = conflict
             .train_ids
             .iter()
-            .partition_map(|train_id| match train_id.parse() {
-                Ok(TrainId::TrainSchedule(id)) => Either::Left(id),
-                Ok(TrainId::PacedTrain {
+            .partition_map(|train_id| match trains_map.get(train_id).cloned() {
+                Some(TrainId::TrainSchedule(id)) => Either::Left(id),
+                Some(TrainId::PacedTrain {
                     paced_train_id,
                     occurrence_id: OccurrenceId::BaseOccurrence { index },
                 }) => Either::Right(PacedTrainOccurrenceId {
                     paced_train_id,
                     occurrence_ref: PacedTrainOccurrenceRef::BaseOccurrence { index },
                 }),
-                Ok(TrainId::PacedTrain {
+                Some(TrainId::PacedTrain {
                     paced_train_id,
                     occurrence_id: OccurrenceId::CreatedException { exception_key },
                 }) => Either::Right(PacedTrainOccurrenceId {
                     paced_train_id,
                     occurrence_ref: PacedTrainOccurrenceRef::CreatedException { exception_key },
                 }),
-                Ok(TrainId::PacedTrain {
+                Some(TrainId::PacedTrain {
                     paced_train_id,
                     occurrence_id:
                         OccurrenceId::ModifiedException {
@@ -432,7 +437,7 @@ impl Conflict {
                         exception_key,
                     },
                 }),
-                Err(_) => unreachable!("Unreachable case encountered while partitioning train IDs"),
+                None => unreachable!("Unreachable case encountered while partitioning train IDs"),
             });
 
         let work_schedule_ids = conflict
@@ -580,7 +585,7 @@ pub(in crate::views) async fn conflicts(
         .chain(simulations)
         .collect();
 
-    let conflict_detection_request =
+    let (trains_ids_map, conflict_detection_request) =
         build_conflict_core_request(infra, start_times, train_ids, simulations);
 
     // 3. Call core
@@ -588,7 +593,7 @@ pub(in crate::views) async fn conflicts(
     let conflicts = conflict_detection_response.conflicts;
     let conflicts_response: Result<Vec<Conflict>> = conflicts
         .into_iter()
-        .map(Conflict::from_core_response)
+        .map(|response| Conflict::from_core_response(response, &trains_ids_map))
         .collect();
     Ok(Json(conflicts_response?))
 }
@@ -625,39 +630,50 @@ fn build_conflict_core_request(
     start_times: Vec<DateTime<Utc>>,
     train_ids: Vec<TrainId>,
     simulations: Vec<Arc<simulation::Response>>,
-) -> ConflictDetectionRequest {
+) -> (HashMap<String, TrainId>, ConflictDetectionRequest) {
     assert_eq!(start_times.len(), simulations.len());
     assert_eq!(train_ids.len(), simulations.len());
 
-    let trains_requirements = izip!(start_times, train_ids, simulations)
-        .flat_map(|(start_time, train_id, sim)| {
-            let CompleteReportTrain {
-                spacing_requirements,
-                routing_requirements,
-                ..
-            } = match Arc::unwrap_or_clone(sim) {
-                simulation::Response::Success(SimulationResponseSuccess {
-                    final_output, ..
-                }) => Some(final_output),
-                _ => None,
-            }?;
-            Some((
-                train_id.to_string(),
-                TrainRequirements {
-                    start_time,
+    let mut trains_map: HashMap<String, TrainId> = HashMap::with_capacity(train_ids.len());
+
+    let trains_requirements: HashMap<String, TrainRequirements> =
+        izip!(start_times, train_ids, simulations)
+            .flat_map(|(start_time, train_id, sim)| {
+                let CompleteReportTrain {
                     spacing_requirements,
                     routing_requirements,
-                },
-            ))
-        })
-        .collect();
+                    ..
+                } = match Arc::unwrap_or_clone(sim) {
+                    simulation::Response::Success(SimulationResponseSuccess {
+                        final_output,
+                        ..
+                    }) => Some(final_output),
+                    _ => None,
+                }?;
 
-    ConflictDetectionRequest {
-        infra: infra.id,
-        expected_version: infra.version,
-        trains_requirements,
-        work_schedules: None,
-    }
+                let train_id_for_core = Uuid::new_v4().to_string();
+                trains_map.insert(train_id_for_core.clone(), train_id.clone());
+
+                Some((
+                    train_id_for_core,
+                    TrainRequirements {
+                        start_time,
+                        spacing_requirements,
+                        routing_requirements,
+                    },
+                ))
+            })
+            .collect();
+
+    (
+        trains_map,
+        ConflictDetectionRequest {
+            infra: infra.id,
+            expected_version: infra.version,
+            trains_requirements,
+            work_schedules: None,
+        },
+    )
 }
 
 /// Retrieve the list of requirements of the timetable (invalid trains are ignored)
@@ -1046,7 +1062,6 @@ mod tests {
     use core_client::simulation::SpacingRequirement;
     use core_client::simulation::SpeedLimitProperties;
     use pretty_assertions::assert_eq;
-    use rstest::rstest;
     use schemas::fixtures::simple_created_exception_with_change_groups;
     use schemas::fixtures::simple_modified_exception_with_change_groups;
     use schemas::fixtures::simple_rolling_stock;
@@ -1411,14 +1426,25 @@ mod tests {
         )));
 
         // When
-        let conflict_core_request =
+        let (trains_ids_map, conflict_core_request) =
             build_conflict_core_request(infra, start_times, train_ids, simulations);
 
         // Then (assert the train schedule)
         assert_eq!(conflict_core_request.trains_requirements.len(), 3);
+
+        let simple_ts_train_core_id = trains_ids_map
+            .iter()
+            .find_map(|(core_id, train_id)| match train_id {
+                TrainId::TrainSchedule(ts_id_inner) if *ts_id_inner == ts_id => {
+                    Some(core_id.clone())
+                }
+                _ => None,
+            })
+            .unwrap();
+
         let simple_requirements = conflict_core_request
             .trains_requirements
-            .get(&format!("{ts_id}"))
+            .get(&simple_ts_train_core_id)
             .unwrap();
         assert_eq!(simple_requirements.start_time, ts_start_time);
         assert_eq!(
@@ -1431,9 +1457,19 @@ mod tests {
         );
 
         // Then (assert the paced train, first occurrence)
+        let paced_0_train_core_id = trains_ids_map
+            .iter()
+            .find_map(|(core_id, train_id)| match train_id {
+                TrainId::PacedTrain {
+                    paced_train_id: pt_id,
+                    occurrence_id: OccurrenceId::BaseOccurrence { index },
+                } if *pt_id == paced_train_id && *index == 0 => Some(core_id.clone()),
+                _ => None,
+            })
+            .unwrap();
         let paced_0_requirements = conflict_core_request
             .trains_requirements
-            .get(&format!("{paced_train_id}#0"))
+            .get(&paced_0_train_core_id)
             .unwrap();
         assert_eq!(paced_0_requirements.start_time, paced_start_time);
         assert_eq!(
@@ -1446,9 +1482,19 @@ mod tests {
         );
 
         // Then (assert the paced train, second occurrence)
+        let paced_1_train_core_id = trains_ids_map
+            .iter()
+            .find_map(|(core_id, train_id)| match train_id {
+                TrainId::PacedTrain {
+                    paced_train_id: pt_id,
+                    occurrence_id: OccurrenceId::BaseOccurrence { index },
+                } if *pt_id == paced_train_id && *index == 1 => Some(core_id.clone()),
+                _ => None,
+            })
+            .unwrap();
         let paced_1_requirements = conflict_core_request
             .trains_requirements
-            .get(&format!("{paced_train_id}#1"))
+            .get(&paced_1_train_core_id)
             .unwrap();
         assert_eq!(
             paced_1_requirements.start_time,
@@ -1462,33 +1508,6 @@ mod tests {
             paced_1_requirements.routing_requirements,
             vec![routing_requirement]
         );
-    }
-
-    #[rstest]
-    #[case("42")]
-    #[case("42#10")]
-    #[case("84@exception_21")]
-    #[case("84@exception_21#7")]
-    fn train_id_parse_and_to_string_roundtrip(#[case] id: &str) {
-        assert_eq!(id.parse::<TrainId>().unwrap().to_string(), id);
-    }
-
-    #[rstest]
-    #[case("", "Invalid train id")]
-    #[case("#", "Invalid train id")]
-    #[case("@", "Invalid train id")]
-    #[case("@#", "Invalid train id")]
-    #[case("22#", "Invalid occurrence index")]
-    #[case("22@#", "Invalid exception index")]
-    #[case("22@#zero", "Invalid exception index")]
-    #[case("zero#", "Invalid train id")]
-    #[case("zero@", "Invalid train id")]
-    #[case("zero@#", "Invalid train id")]
-    #[case("22#zero", "Invalid occurrence index")]
-    #[case("22@key#", "Invalid exception index")]
-    #[case("22@key#zero", "Invalid exception index")]
-    fn train_id_parse_fails(#[case] id: &str, #[case] err: &str) {
-        assert_eq!(&id.parse::<TrainId>().unwrap_err().to_string(), err);
     }
 
     fn create_physics_consist() -> PhysicsConsistParameters {


### PR DESCRIPTION
fix #12086

This PR refactors the way IDs are communicated to the core API. Instead of parsing a string ID, we generate a new ID and store the mapping in a hash map. We send this ID to the core, receive it back, and resolve the original train id using the hash map. This removes the need for a string-parsing system.
