### PR TITLE
chart: editoast-cron fix wrong indentation in pull secrets

### DIFF
--- a/chart/templates/editoast/cronjob.yaml
+++ b/chart/templates/editoast/cronjob.yaml
@@ -27,7 +27,7 @@ spec:
         spec:
           {{- with .Values.imagePullSecrets }}
           imagePullSecrets:
-            {{- toYaml . | nindent 8 }}
+            {{- toYaml . | nindent 10 }}
           {{- end }}
           containers:
           - name: {{ include "osrd.name" . }}-editoast-cronjob


### PR DESCRIPTION
When using pull secrets chart failed to set cron properly. This PR fixes the root cause which is an indentation problem