### PR TITLE
front: add tooltip for acronyms in board names

### DIFF
--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -1,4 +1,8 @@
 {
+  "boardFullNames": {
+    "sdd": "Speed Distance Diagram",
+    "std": "Space Time Diagram"
+  },
   "boards": {
     "conflicts": "Conflicts",
     "macro": "Macro",

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -1,4 +1,8 @@
 {
+  "boardFullNames": {
+    "sdd": "Graphique Espace Vitesse",
+    "std": "Graphique Espace Temps"
+  },
   "boards": {
     "conflicts": "Conflits",
     "macro": "Macro",

--- a/front/src/applications/operationalStudies/views/Scenario/components/BoardWrapper.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/BoardWrapper.tsx
@@ -17,6 +17,7 @@ type BoardWrapperProps = {
   customFooter?: React.ReactNode;
   hidden?: boolean;
   name: string;
+  fullName?: string;
   items?: OSRDMenuItem[];
   withFooter?: boolean;
   dataTestId?: string;
@@ -27,6 +28,7 @@ const BoardWrapper = ({
   children,
   hidden = false,
   name,
+  fullName,
   items = [],
   withFooter = false,
   dataTestId,
@@ -40,7 +42,7 @@ const BoardWrapper = ({
   const boardContent = (
     <div className="board-wrapper" data-testid={dataTestId}>
       <div className="board-header">
-        <span className="board-header-name" data-testid="board-header-name">
+        <span className="board-header-name" data-testid="board-header-name" title={fullName}>
           {name}
         </span>
         <MenuTriggerButton

--- a/front/src/applications/operationalStudies/views/Scenario/components/ScenarioHeader.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ScenarioHeader.tsx
@@ -134,6 +134,9 @@ const ScenarioHeader = ({ activeBoards, toggleBoard }: ScenarioHeaderProps) => {
                   onClick={() => {
                     toggleBoard(board);
                   }}
+                  title={
+                    board === 'sdd' || board === 'std' ? t(`boardFullNames.${board}`) : undefined
+                  }
                 >
                   {t(`boards.${board}`)}
                 </button>

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
@@ -166,6 +166,7 @@ const SimulationResults = ({
       {activeBoards.has('std') && (
         <BoardWrapper
           name={t('simulationResults.timeSpaceChart')}
+          fullName={t('boardFullNames.std')}
           items={[
             {
               title: t('simulationResults.manchetteSettings.waypointsVisibility'),
@@ -255,6 +256,7 @@ const SimulationResults = ({
               {activeBoards.has('sdd') && (
                 <BoardWrapper
                   name={t('simulationResults.speedDistanceDiagram')}
+                  fullName={t('boardFullNames.sdd')}
                   resizable={{
                     height: SDDHeight,
                     setHeight: setSDDHeight,


### PR DESCRIPTION
It may not be immediately clear what these mean to a new user.