### PR TITLE
front: upgrade virtua to v0.48

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -96,7 +96,7 @@
         "reselect": "^5.1.0",
         "uuid": "^13.0.0",
         "viewport-mercator-project": "^7.0.4",
-        "virtua": "^0.45.3"
+        "virtua": "^0.48.2"
       },
       "devDependencies": {
         "@apidevtools/swagger-parser": "^12.1.0",
@@ -24878,9 +24878,9 @@
       }
     },
     "node_modules/virtua": {
-      "version": "0.45.3",
-      "resolved": "https://registry.npmjs.org/virtua/-/virtua-0.45.3.tgz",
-      "integrity": "sha512-+nW3VOwXhlte3m4jbS9gVMked/cZo95IKChH0qol+XUApQVZpPaLDGee1BC/rVng0tsMfxs0vJPEPEUAAfKpkw==",
+      "version": "0.48.2",
+      "resolved": "https://registry.npmjs.org/virtua/-/virtua-0.48.2.tgz",
+      "integrity": "sha512-z8zko7BRnSruf3pYMjhfKIdz138quGVRxSNSZJ7rcrhnxd03mRhGIWNZULE1Dz0VMdRVVaBeT6Ow8ynayHW3Jg==",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=16.14.0",

--- a/front/package.json
+++ b/front/package.json
@@ -92,7 +92,7 @@
     "reselect": "^5.1.0",
     "uuid": "^13.0.0",
     "viewport-mercator-project": "^7.0.4",
-    "virtua": "^0.45.3"
+    "virtua": "^0.48.2"
   },
   "devDependencies": {
     "@apidevtools/swagger-parser": "^12.1.0",

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/Timetable.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/Timetable.tsx
@@ -157,7 +157,7 @@ const Timetable = ({
           timetableItems={timetableItems}
           isInSelection={selectedTimetableItemIds.length > 0}
         />
-        <Virtualizer overscan={15}>
+        <Virtualizer>
           {filteredTimetableItems.map((timetableItem, index) => (
             <div key={`timetable-train-card-${timetableItem.id}`} data-train-id={timetableItem.id}>
               {showDepartureDates[index] && (


### PR DESCRIPTION
overscan has been removed. It has been superseded by bufferSize, but let's just use [the default value (200 pixels)](https://github.com/inokawa/virtua/blob/main/docs/react/interfaces/VListProps.md#buffersize), it should be more than enough performance-wise.