### PR TITLE
editoast: add trace parent data to all response headers

### DIFF
--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -54,6 +54,7 @@ use axum::extract::Request;
 use axum::middleware::Next;
 use axum::response::Response;
 use axum_tracing_opentelemetry::middleware::OtelAxumLayer;
+use axum_tracing_opentelemetry::middleware::OtelInResponseLayer;
 use chrono::Duration;
 use dashmap::DashMap;
 
@@ -1008,6 +1009,7 @@ impl Server {
                 app_state.clone(),
                 authentication_middleware,
             ))
+            .layer(OtelInResponseLayer)
             .layer(OtelAxumLayer::default())
             .layer(DefaultBodyLimit::disable())
             .layer(request_payload_limit)


### PR DESCRIPTION
Part of https://github.com/OpenRailAssociation/osrd/issues/11478, front excluded

When opentelemetry is set, responses now contain a header such as

```
traceparent: 00-e535ebd1df21be08aabe3f85f8dd8d4f-c8d72478e4619cf8-01
```

What we call the "trace id" is what's contained between the first and second `-`. I assume the rest can still be relevant for some tooling, and it doesn't hurt to include a little more context. 

I haven't looked into the front-end side yet. 

Tested manually by looking through response headers. 