### PR TITLE
railway_manager_interface: update openapi

### DIFF
--- a/front/src/common/api/osrdRailwayManagerApi.ts
+++ b/front/src/common/api/osrdRailwayManagerApi.ts
@@ -389,6 +389,7 @@ export type ErrorResponse = {
 export type SendLastMinuteRequestResponse = {
   status: string;
   message: string;
+  request_identifier: string;
 };
 export type LoadingGaugeType = 'GA' | 'GB';
 export type Location = {
@@ -415,9 +416,9 @@ export type SimilarTrain = {
   /** Train name */
   name: string;
 };
-export type LinkedTrainType = 'anterior' | 'posterior';
-export type LinkedTrain = {
-  type: LinkedTrainType;
+export type SubstituteTrain = {
+  path_date: string;
+  /** Train name */
   name: string;
 };
 export type CourseType = string;
@@ -436,7 +437,11 @@ export type SimulationReport = {
   departure_time: string;
   user_message?: string | null;
   similar_train?: SimilarTrain | null;
-  linked_train?: LinkedTrain | null;
+  anterior_train_name?: string | null;
+  posterior_train_name?: string | null;
+  substitute_train?: SubstituteTrain | null;
   course_type: CourseType;
   statistical_category: string;
+  hazardous_materials?: boolean;
+  demand_category?: string | null;
 };

--- a/railway_manager_interface/openapi.yaml
+++ b/railway_manager_interface/openapi.yaml
@@ -102,24 +102,6 @@ components:
           description: Error message describing what went wrong
       required:
         - detail
-    LinkedTrain:
-      properties:
-        type:
-          $ref: '#/components/schemas/LinkedTrainType'
-        name:
-          type: string
-          title: Name
-      type: object
-      required:
-      - type
-      - name
-      title: LinkedTrain
-    LinkedTrainType:
-      type: string
-      enum:
-      - anterior
-      - posterior
-      title: LinkedTrainType
     LoadingGaugeType:
       type: string
       enum:
@@ -202,6 +184,21 @@ components:
       - name
       title: SimilarTrain
       description: Similar train to duplicate.
+    SubstituteTrain:
+      properties:
+        path_date:
+          type: string
+          format: date-time
+          title: Path Date
+        name:
+          type: string
+          title: Name
+          description: Train name
+      type: object
+      required:
+      - path_date
+      - name
+      title: SubstituteTrain
     CourseType:
       type: string
       title: CourseType
@@ -251,15 +248,33 @@ components:
           anyOf:
           - $ref: '#/components/schemas/SimilarTrain'
           - type: 'null'
-        linked_train:
+        anterior_train_name:
           anyOf:
-          - $ref: '#/components/schemas/LinkedTrain'
+          - type: string
+          - type: 'null'
+          title: Anterior Train Name
+        posterior_train_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Posterior Train Name
+        substitute_train:
+          anyOf:
+          - $ref: '#/components/schemas/SubstituteTrain'
           - type: 'null'
         course_type:
           $ref: '#/components/schemas/CourseType'
         statistical_category:
           type: string
           title: Statistical Category
+        hazardous_materials:
+          type: boolean
+          title: Hazardous Materials
+        demand_category:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Demand Category
       type: object
       required:
       - rolling_stock
@@ -283,10 +298,14 @@ components:
         message:
           type: string
           title: Message
+        request_identifier:
+          type: string
+          title: Request Identifier
       type: object
       required:
       - status
       - message
+      - request_identifier
       title: SendLastMinuteRequestResponse
       description: Response model to validate and return when a last-minute request
         has been successfully sent.

--- a/railway_manager_interface/osrd_railway_manager_interface/models.py
+++ b/railway_manager_interface/osrd_railway_manager_interface/models.py
@@ -44,16 +44,6 @@ class LabelsChangeGroup(BaseModel):
     value: list[str]
 
 
-class LinkedTrain(BaseModel):
-    type: LinkedTrainType
-    name: Annotated[str, Field(title="Name")]
-
-
-class LinkedTrainType(Enum):
-    anterior = "anterior"
-    posterior = "posterior"
-
-
 class LoadingGaugeType(Enum):
     GA = "GA"
     GB = "GB"
@@ -254,6 +244,7 @@ class SendLastMinuteRequestResponse(BaseModel):
 
     status: Annotated[str, Field(title="Status")]
     message: Annotated[str, Field(title="Message")]
+    request_identifier: Annotated[str, Field(title="Request Identifier")]
 
 
 class SimilarTrain(BaseModel):
@@ -297,9 +288,19 @@ class SimulationReport(BaseModel):
     departure_time: Annotated[AwareDatetime, Field(title="Departure Time")]
     user_message: Annotated[str | None, Field(title="User Message")] = None
     similar_train: SimilarTrain | None = None
-    linked_train: LinkedTrain | None = None
+    anterior_train_name: Annotated[str | None, Field(title="Anterior Train Name")] = (
+        None
+    )
+    posterior_train_name: Annotated[str | None, Field(title="Posterior Train Name")] = (
+        None
+    )
+    substitute_train: SubstituteTrain | None = None
     course_type: Annotated[str, Field(title="CourseType")]
     statistical_category: Annotated[str, Field(title="Statistical Category")]
+    hazardous_materials: Annotated[bool | None, Field(title="Hazardous Materials")] = (
+        None
+    )
+    demand_category: Annotated[str | None, Field(title="Demand Category")] = None
 
 
 class SpeedLimitTag(RootModel[str]):
@@ -322,6 +323,14 @@ class StepType(Enum):
     VIA = "VIA"
     DRIVER_SWITCH = "DRIVER_SWITCH"
     STOP = "STOP"
+
+
+class SubstituteTrain(BaseModel):
+    path_date: Annotated[AwareDatetime, Field(title="Path Date")]
+    name: Annotated[str, Field(title="Name")]
+    """
+    Train name
+    """
 
 
 class TimingData(BaseModel):


### PR DESCRIPTION
The railway manager's OpenAPI interface must be updated to take into account the new entries:

- The user must be able to  link a posterior train and/or an anterior train.
- The user can select the train category.
- The user can specify whether there are any hazardous materials.
- The user can request to substitute a train, specifying the train name and departure date.