### PR TITLE
front: use OpenAPI-generated ScheduleItem when applicable

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/osrdToNge.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/osrdToNge.ts
@@ -10,8 +10,8 @@ import {
 } from 'applications/operationalStudies/utils';
 import {
   osrdEditoastApi,
+  type ScheduleItem,
   type SubCategory,
-  type TrainSchedule,
   type MacroNoteResponse,
 } from 'common/api/osrdEditoastApi';
 import type { TimetableItem, TimetableItemWithPathOps } from 'reducers/osrdconf/types';
@@ -52,8 +52,6 @@ import {
   type TrainrunCategory,
   type FreeFloatingTextDto,
 } from '../NGE/types';
-
-type ScheduleItem = NonNullable<TrainSchedule['schedule']>[number];
 
 /**
  * Get the TrainrunFrequencies from the TimetableItems.

--- a/front/src/modules/timesStops/helpers/__tests__/computeMargins.spec.ts
+++ b/front/src/modules/timesStops/helpers/__tests__/computeMargins.spec.ts
@@ -1,7 +1,7 @@
 import { keyBy } from 'lodash';
 import { describe, it, expect } from 'vitest';
 
-import type { ScheduleEntry } from 'modules/timesStops/types';
+import type { ScheduleItem } from 'common/api/osrdEditoastApi';
 import type { TimetableItem } from 'reducers/osrdconf/types';
 
 import computeMargins, { getTheoreticalMargins } from '../computeMargins';
@@ -72,7 +72,7 @@ describe('computeMargins', () => {
 
   it('should compute simple margin', () => {
     const train = { path, margins, schedule } as TimetableItem;
-    const scheduleByAt: Record<string, ScheduleEntry> = keyBy(train.schedule, 'at');
+    const scheduleByAt: Record<string, ScheduleItem> = keyBy(train.schedule, 'at');
     const theoreticalMargins = getTheoreticalMargins(train);
     expect(computeMargins(theoreticalMargins, train, scheduleByAt, 0, pathItemTimes)).toEqual({
       theoreticalMargin: '10 %',

--- a/front/src/modules/timesStops/helpers/arrivalTime.ts
+++ b/front/src/modules/timesStops/helpers/arrivalTime.ts
@@ -1,8 +1,9 @@
+import type { ScheduleItem } from 'common/api/osrdEditoastApi';
 import { formatLocalTime } from 'utils/date';
 import { Duration, addDurationToDate } from 'utils/duration';
 import { calculateTimeDifferenceInDays } from 'utils/timeManipulation';
 
-import type { ScheduleEntry, TimeExtraDays } from '../types';
+import type { TimeExtraDays } from '../types';
 
 const computeDayTimeFromStartTime = (
   startDatetime: Date,
@@ -25,7 +26,7 @@ const computeDayTimeFromStartTime = (
 export const computeInputDatetimes = (
   startDatetime: Date,
   lastReferenceDate: Date,
-  schedule: ScheduleEntry | undefined,
+  schedule: ScheduleItem | undefined,
   { isDeparture }: { isDeparture: boolean }
 ) => {
   let theoreticalArrival: Date | undefined;

--- a/front/src/modules/timesStops/helpers/computeMargins.ts
+++ b/front/src/modules/timesStops/helpers/computeMargins.ts
@@ -1,9 +1,10 @@
+import type { ScheduleItem } from 'common/api/osrdEditoastApi';
 import type { SimulationSummary } from 'modules/timetableItem/types';
 import type { Train } from 'reducers/osrdconf/types';
 import { ms2sec } from 'utils/timeManipulation';
 
 import { formatDigitsAndUnit } from './utils';
-import type { ScheduleEntry, TheoreticalMarginsRecord } from '../types';
+import type { TheoreticalMarginsRecord } from '../types';
 
 /** Extracts the theoretical margin for each path step in the train schedule,
  * and marks whether margins are repeated or correspond to a boundary between margin values */
@@ -32,7 +33,7 @@ export function getTheoreticalMargins(train: Pick<Train, 'margins' | 'path'>) {
 function computeMargins(
   theoreticalMargins: TheoreticalMarginsRecord | undefined,
   train: Pick<Train, 'path' | 'margins'>,
-  scheduleByAt: Record<string, ScheduleEntry>,
+  scheduleByAt: Record<string, ScheduleItem>,
   pathStepIndex: number,
   pathItemTimes: Extract<SimulationSummary, { isValid: true }>['pathItemTimes'] | undefined // in ms
 ) {

--- a/front/src/modules/timesStops/helpers/scheduleData.ts
+++ b/front/src/modules/timesStops/helpers/scheduleData.ts
@@ -1,12 +1,12 @@
+import type { ScheduleItem } from 'common/api/osrdEditoastApi';
 import { Duration, addDurationToDate } from 'utils/duration';
 
-import type { ScheduleEntry } from '../types';
 import { receptionSignalToSignalBooleans } from './utils';
 
 /** Format the stopFor, calculatedDeparture, shortSlipDistance and onStopSignal properties */
 export const formatSchedule = (
   arrivalTime: Date | undefined,
-  schedule: ScheduleEntry | undefined
+  schedule: ScheduleItem | undefined
 ) => {
   if (!schedule) {
     return {

--- a/front/src/modules/timesStops/hooks/useOutputTableData.ts
+++ b/front/src/modules/timesStops/hooks/useOutputTableData.ts
@@ -8,7 +8,11 @@ import usePathOps from 'applications/operationalStudies/hooks/usePathOps';
 import { useScenarioContext } from 'applications/operationalStudies/hooks/useScenarioContext';
 import type { PathPropertiesFormatted } from 'applications/operationalStudies/types';
 import { matchOpRefAndOp } from 'applications/operationalStudies/utils';
-import type { SimulationResponseSuccess, TrackSection } from 'common/api/osrdEditoastApi';
+import type {
+  ScheduleItem,
+  SimulationResponseSuccess,
+  TrackSection,
+} from 'common/api/osrdEditoastApi';
 import { matchPathStepAndOp } from 'modules/pathfinding/utils';
 import { interpolateValue } from 'modules/simulationResult/helpers/utils';
 import type { SimulationSummary } from 'modules/timetableItem/types';
@@ -21,7 +25,7 @@ import { computeInputDatetimes } from '../helpers/arrivalTime';
 import computeMargins, { getTheoreticalMargins } from '../helpers/computeMargins';
 import { formatSchedule } from '../helpers/scheduleData';
 import { getTrackReferenceLabel, getOperationalPointName } from '../helpers/utils';
-import { type ScheduleEntry, type TimesStopsRow } from '../types';
+import type { TimesStopsRow } from '../types';
 
 const useOutputTableData = (
   infraId: number,
@@ -67,7 +71,7 @@ const useOutputTableData = (
     }
 
     // Extract common properties between valid and invalid trains
-    const scheduleByAt: Record<string, ScheduleEntry> = keyBy(selectedTrain.schedule, 'at');
+    const scheduleByAt: Record<string, ScheduleItem> = keyBy(selectedTrain.schedule, 'at');
     const theoreticalMargins = selectedTrain && getTheoreticalMargins(selectedTrain);
 
     const startDatetime = new Date(selectedTrain.start_time);

--- a/front/src/modules/timesStops/types.ts
+++ b/front/src/modules/timesStops/types.ts
@@ -1,8 +1,6 @@
-import type { TrainSchedule } from 'common/api/osrdEditoastApi';
 import type { TimeString } from 'common/types';
 import type { SuggestedOP } from 'modules/timetableItem/types';
 import type { Duration } from 'utils/duration';
-import type { ArrayElement } from 'utils/types';
 
 export type TimeExtraDays = {
   time: TimeString;
@@ -44,8 +42,6 @@ export enum TableType {
   Input = 'Input',
   Output = 'Output',
 }
-
-export type ScheduleEntry = ArrayElement<TrainSchedule['schedule']>;
 
 export type TheoreticalMarginsRecord = Record<
   string,


### PR DESCRIPTION
We were missing this type before, so we needed to extract it from TrainSchedule['schedule']. This isn't necessary anymore.