### PR TITLE
front: adapt usePathStepsMetadata for the new op combobox

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModalMap.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModalMap.tsx
@@ -180,11 +180,8 @@ const ItineraryModalMap = ({
                 const matchedOp = pathProperties.operational_points.find((op) =>
                   matchOpRefAndOp(pathStepLocation, op)
                 );
-                const secondaryCodeMetadata = pathStepMetadata.locationsBySecondaryCode.get(
-                  matchedOp?.extensions?.sncf?.ch || ''
-                );
-                const trackMetadata = secondaryCodeMetadata?.find(
-                  (metadata) => metadata.trackId === matchedOp?.part.track
+                const trackMetadata = pathStepMetadata.parts.find(
+                  (part) => part.trackId === matchedOp?.part.track
                 );
                 coordinates = trackMetadata?.coordinates;
               }

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/PathStepItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/PathStepItem.tsx
@@ -78,10 +78,10 @@ const PathStepItem = ({
     if (!isOpRefMetadata(pathStepMetadata)) return [];
     return [
       { label: '', id: '' },
-      ...Array.from(pathStepMetadata.locationsBySecondaryCode.keys()).map((key) => ({
-        label: key,
-        id: key,
-      })),
+      {
+        label: pathStepMetadata.secondaryCode || '',
+        id: pathStepMetadata.secondaryCode || '',
+      },
     ];
   }, [pathStepMetadata]);
 
@@ -96,17 +96,12 @@ const PathStepItem = ({
 
   const trackNameSuggestions = useMemo(() => {
     const selectedSecondaryCode = selectedSecondaryCodeOption.id;
-    if (!selectedSecondaryCode) return [];
+    if (!selectedSecondaryCode || !isOpRefMetadata(pathStepMetadata)) return [];
 
-    const selectedSecondaryCodeLocations =
-      (isOpRefMetadata(pathStepMetadata) &&
-        pathStepMetadata.locationsBySecondaryCode.get(selectedSecondaryCode)) ||
-      [];
-
-    const sortedSuggestions = selectedSecondaryCodeLocations
-      .map((location, i) => ({
-        label: location.trackName,
-        id: `${location.trackId}-${i}`,
+    const sortedSuggestions = (pathStepMetadata?.parts || [])
+      .map((part, i) => ({
+        label: part.trackName,
+        id: `${part.trackId}-${i}`,
       }))
       // Sort with numbers first in ascending order, then alphabetically
       .sort((a, b) => {

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/hooks/usePathStepsMetadata.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/hooks/usePathStepsMetadata.ts
@@ -8,7 +8,6 @@ import { useScenarioContext } from 'applications/operationalStudies/hooks/useSce
 import {
   osrdEditoastApi,
   type OperationalPointReference,
-  type RelatedOperationalPoint,
   type TrainSchedule,
 } from 'common/api/osrdEditoastApi';
 import type { PathStepMetadata, PathStepV2 } from 'reducers/osrdconf/types';
@@ -111,21 +110,11 @@ export const usePathStepsMetadata = (pathSteps: PathStepV2[]) => {
   useEffect(() => {
     const fetchAndSetMetadata = async () => {
       // 4. Get all track ids of all matched operational points to get all tracks metadata
-      // and regroup ops by uic to easily get all secondary codes and track names for each path step
       const matchedTrackIds = new Set<string>();
-      const opsByUic = new Map<number, RelatedOperationalPoint[]>();
       allOps.forEach((op) => {
         op.parts.forEach((part) => {
           matchedTrackIds.add(part.track);
         });
-        const uic = op.extensions?.identifier?.uic;
-        if (uic) {
-          if (!opsByUic.has(uic)) {
-            opsByUic.set(uic, [op]);
-          } else {
-            opsByUic.get(uic)!.push(op);
-          }
-        }
       });
       const allTrackIds = Array.from(matchedTrackIds);
 
@@ -210,33 +199,15 @@ export const usePathStepsMetadata = (pathSteps: PathStepV2[]) => {
           return;
         }
 
-        // Get the ops with the same uic to get all its secondary codes and track names
-        // to display in the form
-        const opsWithSameUic = opsByUic.get(matchedOp.extensions?.identifier?.uic ?? -1) ?? [];
-
-        const locationsBySecondaryCode: Extract<
-          PathStepMetadata,
-          { isInvalid: false; type: 'opRef' }
-        >['locationsBySecondaryCode'] = new Map();
-
-        opsWithSameUic.forEach((op) => {
-          const metadata: {
-            trackId: string;
-            trackName: string;
-            lineName: string;
-            coordinates: Position;
-          }[] = [];
-          op.parts.forEach((part) => {
+        const parts: Extract<PathStepMetadata, { isInvalid: false; type: 'opRef' }>['parts'] =
+          matchedOp.parts.map((part) => {
             const correspondingTrack = trackSectionsById[part.track];
-            metadata.push({
+            return {
               trackId: correspondingTrack?.id ?? '',
               trackName: correspondingTrack?.extensions?.sncf?.track_name ?? '',
-              lineName: correspondingTrack?.extensions?.sncf?.line_name ?? '',
               coordinates: part.geo?.coordinates as Position,
-            });
+            };
           });
-          locationsBySecondaryCode.set(op.extensions?.sncf?.ch ?? '', metadata);
-        });
 
         // Get the track name in case the path step has a track_reference with track_id
         let correspondingTrackName: string | undefined;
@@ -254,7 +225,7 @@ export const usePathStepsMetadata = (pathSteps: PathStepV2[]) => {
           uic: matchedOp.extensions?.identifier?.uic,
           secondaryCode: matchedOp.extensions?.sncf?.ch,
           trackName: correspondingTrackName,
-          locationsBySecondaryCode,
+          parts,
         });
       });
 

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/utils.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/utils.ts
@@ -9,17 +9,14 @@ export const computePathStepCoordinates = (pathStepMetadata: PathStepMetadata) =
     return [pathStepMetadata.coordinates];
   }
   if (pathStepMetadata.secondaryCode && pathStepMetadata.trackName) {
-    const locationMetadata = pathStepMetadata.locationsBySecondaryCode
-      .get(pathStepMetadata.secondaryCode)
-      ?.find((loc) => loc.trackName === pathStepMetadata.trackName);
-    return locationMetadata ? [locationMetadata.coordinates] : [];
+    const foundPart = pathStepMetadata.parts.find(
+      (part) => part.trackName === pathStepMetadata.trackName
+    );
+    return foundPart ? [foundPart.coordinates] : [];
   }
   if (pathStepMetadata.secondaryCode) {
-    const locationMetadata = pathStepMetadata.locationsBySecondaryCode.get(
-      pathStepMetadata.secondaryCode
-    );
-    return (locationMetadata ?? []).map((loc) => loc.coordinates);
+    return pathStepMetadata.parts.map((part) => part.coordinates);
   }
-  const allMetadata = Array.from(pathStepMetadata.locationsBySecondaryCode.values()).flat();
-  return allMetadata.map((metadata) => metadata.coordinates);
+  // If the path step has no secondary code, don't display its marker on the map
+  return [];
 };

--- a/front/src/reducers/osrdconf/types.ts
+++ b/front/src/reducers/osrdconf/types.ts
@@ -151,16 +151,9 @@ export type PathStepMetadata =
        */
       trackName?: string;
       /**
-       * An OperationalPoint is not unique by its UIC but by its UIC + secondary code.
-       *
-       * However, it can contains multiple parts since it can be referenced on multiple tracks.
-       *
-       * This Map stores all possible locations for a given op's secondary code.
+       * Data of all parts (tracks) of the path step (name + ch)
        */
-      locationsBySecondaryCode: Map<
-        string,
-        { trackId: string; trackName: string; lineName: string; coordinates: Position }[]
-      >;
+      parts: { trackId: string; trackName: string; coordinates: Position }[];
     };
 
 export type StdcmPathStep = {


### PR DESCRIPTION
Since the new combobox will contain both the op name and the CH code, remove the logic to fetch all CH of the path step. We display only the ch if one has been assigned (will be later displayed in the new combobox). The new combobox will handle the fetch of the ch list with the search endpoint.

> [!NOTE]
> With this change, it's no longer possible to put a map parker for a path step with no `secondary_code` (can happen in imports) but we already decided to set the path step as invalid when that was the case

close #14292 