### PR TITLE
front: add etcs reticle info

### DIFF
--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -566,8 +566,10 @@
         "routing": "Routing",
         "signals": "Signals",
         "spacing": "Spacing",
+        "stop": "Stop",
         "stopsAndTransitions": "Stops and transitions",
-        "title": "ETCS"
+        "title": "ETCS",
+        "transition": "Trans."
       },
       "powerRestrictions": "Power restrictions",
       "reticleInfos": "Reticle infos",

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -566,8 +566,10 @@
         "routing": "Itinéraires",
         "signals": "Signaux",
         "spacing": "Espacement",
+        "stop": "Arrêt",
         "stopsAndTransitions": "Arrêts et transitions",
-        "title": "ETCS"
+        "title": "ETCS",
+        "transition": "Trans."
       },
       "powerRestrictions": "Restrictions de puissance",
       "reticleInfos": "Infos réticule",

--- a/front/src/modules/simulationResult/components/SpeedDistanceDiagram/SpeedDistanceDiagramWrapper.tsx
+++ b/front/src/modules/simulationResult/components/SpeedDistanceDiagram/SpeedDistanceDiagramWrapper.tsx
@@ -75,6 +75,8 @@ const SpeedDistanceDiagramWrapper = ({
     etcsLayersDisplay: {
       title: t('speedDistanceSettings.etcs.title'),
       etcsBrakingTypes: {
+        stop: t('speedDistanceSettings.etcs.stop'),
+        transition: t('speedDistanceSettings.etcs.transition'),
         stopsAndTransitions: t('speedDistanceSettings.etcs.stopsAndTransitions'),
         signals: t('speedDistanceSettings.etcs.signals'),
         spacing: t('speedDistanceSettings.etcs.spacing'),

--- a/front/ui/storybook/stories/ui-charts/speedSpaceChart/consts.ts
+++ b/front/ui/storybook/stories/ui-charts/speedSpaceChart/consts.ts
@@ -21,6 +21,8 @@ export const defaultTranslations = {
   etcsLayersDisplay: {
     title: 'ETCS',
     etcsBrakingTypes: {
+      stop: 'Stop',
+      transition: 'Transition',
       stopsAndTransitions: 'Stops and transitions',
       signals: 'Signals',
       spacing: 'Spacing',

--- a/front/ui/ui-charts/src/speedSpaceChart/components/SpeedSpaceChart.tsx
+++ b/front/ui/ui-charts/src/speedSpaceChart/components/SpeedSpaceChart.tsx
@@ -54,6 +54,8 @@ export type SpeedSpaceChartProps = {
     etcsLayersDisplay: {
       title: string;
       etcsBrakingTypes: {
+        stop: string;
+        transition: string;
         stopsAndTransitions: string;
         signals: string;
         spacing: string;
@@ -327,6 +329,7 @@ const SpeedSpaceChart = ({
           width={adjustedWidthRightAxis}
           internalHeight={mainChartHeight}
           store={store}
+          translations={translations}
         />
       )}
       <FrontInteractivityLayer

--- a/front/ui/ui-charts/src/speedSpaceChart/components/common/DetailsBox.tsx
+++ b/front/ui/ui-charts/src/speedSpaceChart/components/common/DetailsBox.tsx
@@ -2,8 +2,10 @@ import React from 'react';
 
 import cx from 'classnames';
 
-import type { Store } from '../../types';
-import { MARGINS } from '../const';
+import type { EtcsBrakingCurveType, EtcsBrakingType, EtcsSpeedValue, Store } from '../../types';
+import { ETCS_COLOR_DICTIONARY, MARGINS } from '../const';
+import type { SpeedSpaceChartProps } from '../SpeedSpaceChart';
+import { getActiveEtcsBrakingCurveTypes, getActiveEtcsBrakingTypes } from '../utils';
 
 const DETAILBOX_MARGIN = 6;
 const DETAILBOX_OFFSET = 12;
@@ -17,6 +19,8 @@ type DetailsBoxProps = {
   curveY: number;
   speedText: string;
   ecoSpeedText: string;
+  etcsSpeedValues?: Record<EtcsBrakingType, Record<EtcsBrakingCurveType, EtcsSpeedValue[]>>;
+  translations?: SpeedSpaceChartProps['translations'];
   effortText: string;
   electricalModeText: string;
   electricalProfileText: string;
@@ -25,7 +29,6 @@ type DetailsBoxProps = {
   modeText: string;
 };
 
-// TODO: add ETCS details
 const DetailsBox = ({
   width,
   height,
@@ -34,6 +37,8 @@ const DetailsBox = ({
   curveY,
   speedText,
   ecoSpeedText,
+  etcsSpeedValues,
+  translations,
   effortText,
   electricalModeText,
   electricalProfileText,
@@ -64,36 +69,123 @@ const DetailsBox = ({
   const speedDifference = Number(speedText) - Number(ecoSpeedText);
   const speedDifferenceText = speedDifference !== 0 ? `-${speedDifference.toFixed(1)}` : null;
 
+  const activeEtcsBrakingTypes = getActiveEtcsBrakingTypes(store.etcsLayersDisplay);
+  const activeEtcsBrakingCurveTypes = getActiveEtcsBrakingCurveTypes(store.etcsLayersDisplay);
+  const etcsEndOfCurves = etcsSpeedValues
+    ? [
+        ...new Set(
+          activeEtcsBrakingTypes.flatMap((etcsBrakingType) =>
+            activeEtcsBrakingCurveTypes.flatMap((etcsBrakingCurveType) =>
+              etcsSpeedValues[etcsBrakingType][etcsBrakingCurveType].map(
+                (etcsValue) => etcsValue.etcsEndOfCurvePos
+              )
+            )
+          )
+        ),
+      ]
+        .sort((a, b) => a - b)
+        .map((n) => n.toFixed(1))
+    : [];
   return (
     <div
       id="details-box"
-      className={cx('absolute flex flex-col', { block: curveY, hidden: !curveY })}
+      className={cx('absolute flex flex-row', { block: curveY, hidden: !curveY })}
       style={{
         marginTop: boxY,
         marginLeft: boxX,
       }}
     >
-      <span id="base-speed-text">{speedText || '--'}</span>
-      <div>
-        <span id="mareco-speed-text">{ecoSpeedText || '--'}</span>
-        {speedDifferenceText && <span id="speed-difference-text">{speedDifferenceText}</span>}
-      </div>
-      {(energySource || tractionStatus || modeText || effortText) && <hr />}
-      {energySource && <span id="mode-text">{modeText || '--'}</span>}
-      {tractionStatus && <span id="effort-text">{effortText || '--'}</span>}
-      {electricalModeText && (
-        <div id="electrical-mode-text">
-          <span>{electricalModeText || '--'}</span>
-          {electricalProfiles && <span className="ml-2">{electricalProfileText || '--'}</span>}
+      <div className="default-details-box">
+        <span id="base-speed-text">{speedText || '--'}</span>
+        <div>
+          <span id="mareco-speed-text">{ecoSpeedText || '--'}</span>
+          {speedDifferenceText && <span id="speed-difference-text">{speedDifferenceText}</span>}
         </div>
-      )}
-      {powerRestrictions && <span id="power-restriction-text">{powerRestrictionText || '--'}</span>}
-      {declivities && (
-        <>
-          <hr />
-          <span id="previous-gradient-text">{`${previousGradientText} ‰`}</span>
-        </>
-      )}
+        {(energySource || tractionStatus || modeText || effortText) && <hr />}
+        {energySource && <span id="mode-text">{modeText || '--'}</span>}
+        {tractionStatus && <span id="effort-text">{effortText || '--'}</span>}
+        {electricalModeText && (
+          <div id="electrical-mode-text">
+            <span>{electricalModeText || '--'}</span>
+            {electricalProfiles && <span className="ml-2">{electricalProfileText || '--'}</span>}
+          </div>
+        )}
+        {powerRestrictions && (
+          <span id="power-restriction-text">{powerRestrictionText || '--'}</span>
+        )}
+        {declivities && (
+          <>
+            <hr />
+            <span id="previous-gradient-text">{`${previousGradientText} ‰`}</span>
+          </>
+        )}
+      </div>
+      {store.detailsBoxDisplay.etcs &&
+        etcsSpeedValues &&
+        activeEtcsBrakingTypes.length > 0 &&
+        activeEtcsBrakingCurveTypes.length > 0 && (
+          <div className="etcs-details-box" style={{ minHeight: detailsBoxHeight }}>
+            <div
+              className="etcs-grid"
+              style={{ gridTemplateColumns: `repeat(${etcsEndOfCurves.length + 2}, auto)` }}
+            >
+              <div className="etcs-row-group" style={{ gridColumnStart: 3 }}>
+                {etcsEndOfCurves.map((endOfCurve) => (
+                  <div key={endOfCurve} className="number-text">
+                    {endOfCurve}
+                  </div>
+                ))}
+              </div>
+              {activeEtcsBrakingTypes.map((brakingType) => {
+                const specificEtcsSpeeds = etcsSpeedValues[brakingType];
+                return (
+                  <div key={brakingType} className="etcs-row-group">
+                    {activeEtcsBrakingCurveTypes.map((brakingCurveType, index) => {
+                      const speedValues = specificEtcsSpeeds[brakingCurveType];
+                      return (
+                        <>
+                          {index === 0 && (
+                            <div
+                              style={{
+                                gridRow: `span ${activeEtcsBrakingCurveTypes.length}`,
+                              }}
+                            >
+                              {translations?.etcsLayersDisplay.etcsBrakingTypes[brakingType] ||
+                                brakingType}
+                            </div>
+                          )}
+                          <div
+                            style={{
+                              color: ETCS_COLOR_DICTIONARY[brakingCurveType].toString(),
+                            }}
+                          >
+                            {brakingCurveType}
+                          </div>
+                          {etcsEndOfCurves.map((endOfCurve) => (
+                            <div
+                              key={endOfCurve}
+                              className="number-text"
+                              style={{
+                                color: ETCS_COLOR_DICTIONARY[brakingCurveType].toString(),
+                              }}
+                            >
+                              {speedValues
+                                .find(
+                                  (speedValue) =>
+                                    speedValue.etcsEndOfCurvePos.toFixed(1) === endOfCurve
+                                )
+                                ?.etcsSpeed.toFixed(2) ?? '--'}
+                            </div>
+                          ))}
+                        </>
+                      );
+                    })}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
     </div>
   );
 };

--- a/front/ui/ui-charts/src/speedSpaceChart/components/common/SettingsPanel.tsx
+++ b/front/ui/ui-charts/src/speedSpaceChart/components/common/SettingsPanel.tsx
@@ -207,10 +207,6 @@ const SettingsPanel = ({
               key={selection}
               label={translations?.detailsBoxDisplay[selection] || selection}
               checked={store.detailsBoxDisplay[selection]}
-              disabled={
-                // TODO: enable when etcs details are fixed
-                selection === 'etcs'
-              }
               onChange={() => {
                 setStore((prev) => ({
                   ...prev,

--- a/front/ui/ui-charts/src/speedSpaceChart/components/const.ts
+++ b/front/ui/ui-charts/src/speedSpaceChart/components/const.ts
@@ -2,6 +2,7 @@ import chroma from 'chroma-js';
 
 import {
   type ColorDictionary,
+  type EtcsAlphaDictionary,
   EtcsBrakingCurveType,
   EtcsBrakingType,
   type EtcsColorDictionary,
@@ -85,7 +86,7 @@ export const ETCS_BRAKING_SELECTION: Record<
   keyof EtcsLayersDisplay['etcsBrakingTypes'],
   EtcsBrakingType[]
 > = {
-  stopsAndTransitions: [EtcsBrakingType.STOP, EtcsBrakingType.SLOWDOWN],
+  stopsAndTransitions: [EtcsBrakingType.SLOWDOWN, EtcsBrakingType.STOP],
   spacing: [EtcsBrakingType.SPACING],
   routing: [EtcsBrakingType.ROUTING],
 };
@@ -121,9 +122,16 @@ export const BASE_SPEED_FILL_ALPHA = 0.15;
 
 // Etcs color dictionary
 export const ETCS_COLOR_DICTIONARY: EtcsColorDictionary = {
-  [EtcsBrakingCurveType.IND]: IND_COLOR.alpha(IND_ALPHA),
-  [EtcsBrakingCurveType.PS]: PS_COLOR.alpha(PS_ALPHA),
-  [EtcsBrakingCurveType.GUI]: GUI_COLOR.alpha(GUI_ALPHA),
+  [EtcsBrakingCurveType.IND]: IND_COLOR,
+  [EtcsBrakingCurveType.PS]: PS_COLOR,
+  [EtcsBrakingCurveType.GUI]: GUI_COLOR,
+};
+
+// Etcs color transparency dictionary
+export const ETCS_ALPHA_DICTIONARY: EtcsAlphaDictionary = {
+  [EtcsBrakingCurveType.IND]: IND_ALPHA,
+  [EtcsBrakingCurveType.PS]: PS_ALPHA,
+  [EtcsBrakingCurveType.GUI]: GUI_ALPHA,
 };
 
 /**

--- a/front/ui/ui-charts/src/speedSpaceChart/components/helpers/drawElements/curve.ts
+++ b/front/ui/ui-charts/src/speedSpaceChart/components/helpers/drawElements/curve.ts
@@ -8,6 +8,7 @@ import {
   WHITE,
   ETCS_COLOR_DICTIONARY,
   ETCS_LINEWIDTH,
+  ETCS_ALPHA_DICTIONARY,
 } from '../../const';
 import {
   clearCanvas,
@@ -118,7 +119,9 @@ export const drawCurve = ({ ctx, width, height, store }: DrawFunctionParams) => 
       );
       ctx.beginPath();
       ctx.lineWidth = ETCS_LINEWIDTH;
-      ctx.strokeStyle = ETCS_COLOR_DICTIONARY[etcsBrakingCurveType].hex();
+      ctx.strokeStyle = ETCS_COLOR_DICTIONARY[etcsBrakingCurveType]
+        .alpha(ETCS_ALPHA_DICTIONARY[etcsBrakingCurveType])
+        .hex();
       etcsCurvePoints.slice(0, etcsCurvePoints.length - 2).forEach(({ x, y }) => {
         ctx.lineTo(x, y);
       });

--- a/front/ui/ui-charts/src/speedSpaceChart/components/helpers/drawElements/reticle.ts
+++ b/front/ui/ui-charts/src/speedSpaceChart/components/helpers/drawElements/reticle.ts
@@ -1,4 +1,11 @@
-import type { DrawFunctionParams, LayerData } from '../../../types';
+import {
+  type DrawFunctionParams,
+  type EtcsBrakingCurves,
+  EtcsBrakingCurveType,
+  EtcsBrakingType,
+  type EtcsSpeedValue,
+  type LayerData,
+} from '../../../types';
 import { WHITE, BLACK, MARGINS } from '../../const';
 import {
   clearCanvas,
@@ -25,6 +32,79 @@ const SNAPPED_STOP_TEXT_OFFSET = 36;
 const CURSOR_HEIGHT = 6;
 const SNAPPED_CURSOR_HEIGHT = 24;
 
+const getEtcsSpeedsAtPosition = (curves: EtcsBrakingCurves, position: number) => {
+  const result: Record<EtcsBrakingType, Record<EtcsBrakingCurveType, EtcsSpeedValue[]>> = {
+    [EtcsBrakingType.STOP]: {
+      [EtcsBrakingCurveType.IND]: [],
+      [EtcsBrakingCurveType.PS]: [],
+      [EtcsBrakingCurveType.GUI]: [],
+    },
+    [EtcsBrakingType.SLOWDOWN]: {
+      [EtcsBrakingCurveType.IND]: [],
+      [EtcsBrakingCurveType.PS]: [],
+      [EtcsBrakingCurveType.GUI]: [],
+    },
+    [EtcsBrakingType.SPACING]: {
+      [EtcsBrakingCurveType.IND]: [],
+      [EtcsBrakingCurveType.PS]: [],
+      [EtcsBrakingCurveType.GUI]: [],
+    },
+    [EtcsBrakingType.ROUTING]: {
+      [EtcsBrakingCurveType.IND]: [],
+      [EtcsBrakingCurveType.PS]: [],
+      [EtcsBrakingCurveType.GUI]: [],
+    },
+  };
+
+  const getEtcsSpeedAndEndOfCurveAtPosition = (
+    speeds: LayerData<number>[],
+    pos: number
+  ): EtcsSpeedValue | undefined => {
+    if (speeds.length === 0) return undefined;
+
+    const first = speeds[0];
+    const last = speeds[speeds.length - 1];
+    const firstPosition = first.position.start;
+    const lastPosition = last.position.end ? last.position.end : last.position.start;
+
+    // Reject if position is outside the curve range
+    if (pos < firstPosition || pos > lastPosition) {
+      return undefined;
+    }
+
+    const index = binarySearch(speeds, pos, (p) => p.position.start);
+    // If there is an exact match, return speed
+    if (
+      speeds[index].position.start === pos ||
+      (speeds[index].position.end && speeds[index].position.end === pos)
+    ) {
+      return { etcsSpeed: speeds[index].value, etcsEndOfCurvePos: lastPosition };
+    }
+    // Else, interpolate speed.
+    const p1 = speeds[index];
+    const p2 = speeds[index + 1];
+    return {
+      etcsSpeed: interpolate(p1.position.start, p1.value, p2.position.start, p2.value, pos),
+      etcsEndOfCurvePos: lastPosition,
+    };
+  };
+
+  for (const brakingType of Object.values(EtcsBrakingType) as EtcsBrakingType[]) {
+    const curveList = curves[brakingType] ?? [];
+    curveList.forEach((curve) => {
+      for (const curveType of Object.values(EtcsBrakingCurveType) as EtcsBrakingCurveType[]) {
+        const etcsSpeeds = curve[curveType] ?? [];
+        const value = getEtcsSpeedAndEndOfCurveAtPosition(etcsSpeeds, position);
+        if (value !== undefined) {
+          result[brakingType][curveType].push(value);
+        }
+      }
+    });
+  }
+
+  return result;
+};
+
 export const drawCursor = ({ ctx, width, height, store }: DrawFunctionParams) => {
   clearCanvas(ctx, width, height);
 
@@ -35,6 +115,7 @@ export const drawCursor = ({ ctx, width, height, store }: DrawFunctionParams) =>
     leftOffset,
     speeds,
     ecoSpeeds,
+    etcsBrakingCurves,
     electrifications,
     slopes,
     electricalProfiles,
@@ -164,6 +245,10 @@ export const drawCursor = ({ ctx, width, height, store }: DrawFunctionParams) =>
     effortText = 'decelerating';
   }
 
+  const etcsSpeedValues = etcsBrakingCurves
+    ? getEtcsSpeedsAtPosition(etcsBrakingCurves, cursorPosition)
+    : undefined;
+
   reticleY =
     cursorBoxHeight -
     (ecoSpeedValue / maxSpeed) * (cursorBoxHeight - CURVE_MARGIN_TOP) +
@@ -262,6 +347,7 @@ export const drawCursor = ({ ctx, width, height, store }: DrawFunctionParams) =>
     curveY: reticleY,
     speedText,
     ecoSpeedText,
+    etcsSpeedValues,
     effortText,
     electricalModeText,
     electricalProfileText,

--- a/front/ui/ui-charts/src/speedSpaceChart/components/layers/ReticleLayer.tsx
+++ b/front/ui/ui-charts/src/speedSpaceChart/components/layers/ReticleLayer.tsx
@@ -4,15 +4,22 @@ import type { TrainDetails, Store } from '../../types';
 import DetailsBox from '../common/DetailsBox';
 import { MARGINS } from '../const';
 import { drawCursor } from '../helpers/drawElements/reticle';
+import type { SpeedSpaceChartProps } from '../SpeedSpaceChart';
 import { clearCanvas } from '../utils';
 
 type ReticleLayerProps = {
   width: number;
   internalHeight: number;
   store: Store;
+  translations?: SpeedSpaceChartProps['translations'];
 };
 
-const ReticleLayer = ({ width, internalHeight: height, store }: ReticleLayerProps) => {
+const ReticleLayer = ({
+  width,
+  internalHeight: height,
+  store,
+  translations,
+}: ReticleLayerProps) => {
   const canvas = useRef<HTMLCanvasElement>(null);
   const [trainDetails, setTrainDetails] = useState<TrainDetails | null>(null);
 
@@ -32,7 +39,15 @@ const ReticleLayer = ({ width, internalHeight: height, store }: ReticleLayerProp
   return (
     <>
       <canvas id="cursor-layer" className="absolute" ref={canvas} width={width} height={height} />
-      {trainDetails && <DetailsBox width={width} height={height} store={store} {...trainDetails} />}
+      {trainDetails && (
+        <DetailsBox
+          width={width}
+          height={height}
+          store={store}
+          translations={translations}
+          {...trainDetails}
+        />
+      )}
     </>
   );
 };

--- a/front/ui/ui-charts/src/speedSpaceChart/styles/main.css
+++ b/front/ui/ui-charts/src/speedSpaceChart/styles/main.css
@@ -73,11 +73,11 @@
   background-color: rgb(0, 0, 0, 0.85);
   border-radius: 0.5rem;
   box-shadow: 0 0.25rem 0.375rem -0.125rem rgba(0, 0, 0, 0.28);
-  padding: 0.5rem;
   font-family: 'IBM Plex Sans';
   font-weight: 400;
-  font-size: 0.875rem;
+  font-size: 14px;
   color: rgb(255, 255, 255);
+  align-items: flex-start;
 
   span {
     height: 1.25rem;
@@ -88,6 +88,43 @@
     border-top: 0.0313rem solid rgba(255, 255, 255, 0.5);
     margin-top: 0.4375rem;
     margin-bottom: 0.1875rem;
+  }
+
+  .default-details-box {
+    display: flex;
+    flex-direction: column;
+    padding: 8px;
+  }
+
+  .etcs-details-box {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    height: 100%;
+    background-color: rgba(255, 255, 255, 0.1);
+    padding: 8px 16px 8px 12px;
+  }
+
+  .etcs-grid {
+    display: grid;
+    justify-self: start;
+    font-family: 'IBM Plex Mono', monospace;
+    line-height: 14px;
+    column-gap: 24px;
+    row-gap: 18px;
+    align-content: flex-start;
+    grid-template-rows: subgrid;
+
+    .etcs-row-group {
+      display: grid;
+      grid-column: 1 / -1;
+      grid-template-columns: subgrid;
+      row-gap: 2px;
+    }
+
+    .number-text {
+      justify-self: end;
+    }
   }
 
   #base-speed-text {

--- a/front/ui/ui-charts/src/speedSpaceChart/types.ts
+++ b/front/ui/ui-charts/src/speedSpaceChart/types.ts
@@ -123,6 +123,7 @@ export type TrainDetails = {
   curveY: number;
   speedText: string;
   ecoSpeedText: string;
+  etcsSpeedValues?: Record<EtcsBrakingType, Record<EtcsBrakingCurveType, EtcsSpeedValue[]>>;
   effortText: string;
   electricalModeText: string;
   electricalProfileText: string;
@@ -150,16 +151,16 @@ export type EtcsBrakingCurves = {
 };
 
 export enum EtcsBrakingType {
-  STOP,
-  SLOWDOWN,
-  SPACING,
-  ROUTING,
+  SLOWDOWN = 'transition',
+  STOP = 'stop',
+  SPACING = 'spacing',
+  ROUTING = 'routing',
 }
 
 export enum EtcsBrakingCurveType {
-  IND,
-  PS,
-  GUI,
+  IND = 'IND',
+  PS = 'PS',
+  GUI = 'GUI',
 }
 
 export type EtcsLayersDisplay = {
@@ -175,4 +176,10 @@ export type EtcsLayersDisplay = {
   };
 };
 
+export type EtcsSpeedValue = {
+  etcsSpeed: number;
+  etcsEndOfCurvePos: number;
+};
+
 export type EtcsColorDictionary = Record<EtcsBrakingCurveType, chroma.Color>;
+export type EtcsAlphaDictionary = Record<EtcsBrakingCurveType, number>;


### PR DESCRIPTION
Fixes #13824.

Add ETCS reticle (see image below). The component is flex: it only displays the info of the selected ETCS curves drawn on the speed-space-chart. If none are selected, it is invisible. The ETCS reticle info checkbox in the SettingsPanel is unchecked by default (might change later depending on user returns).

To compare with the image of the reticle which is on top on this page: https://www.sketch.com/s/eba5c130-4a80-4325-9c9e-778069862393/p/1E404390-471E-48B6-8971-DF426172632B/canvas#Inspect. The following distances between elements are applicable:
- spacing between columns: 24px
- row gap between rows of a same braking type (i.e. between Trans. IND and Trans. PS for ex): ~0~, to be confirmed by @thibautsailly -> should be 16px between the baselines, hence row-gap=2px
- row gap between rows of different braking types (i.e. between Trans. GUI and Stop IND): ~16px~, to be confirmed by @thibautsailly~ -> should be 32px between the baselines, hence row-gap=18px
- padding left should be 12px, right should be 16px, rest of the padding remains the default 8px

Result:
<img width="413" height="188" alt="image" src="https://github.com/user-attachments/assets/a8b01ccf-97d4-4d2c-a27f-a2d934346f9c" />

Restriction for now: The reticle is too big when everything etcs is checked, and is outside the chart's frame: for now, the fix is for the user to increase the speed space chart's size manually. For me this seems fine, as there are few cases where the user actually wants every single etcs curve to be displayed on the speed-space chart. ~To be confirmed by @thibautsailly~ -> confirmed to be fine for now. Corresponding bug has been created: https://github.com/OpenRailAssociation/osrd/issues/14336.
<img width="1275" height="455" alt="image" src="https://github.com/user-attachments/assets/0c014e7d-1444-4ecb-be89-1aa9a1ab47ac" />