### PR TITLE
railway_manager_interface: fix shebang of generate-types script

### DIFF
--- a/railway_manager_interface/generate-types.sh
+++ b/railway_manager_interface/generate-types.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 # Generate Python types from openapi.yaml using datamodel-codegen
 
 set -e


### PR DESCRIPTION
`/usr/bin/env bash` is more reliable and portable across different systems.