### PR TITLE
front: fix rejected UICs in Graou imports

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/generateTrainSchedulesPayloads.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/generateTrainSchedulesPayloads.ts
@@ -13,14 +13,15 @@ function generateTrainSchedulePayload(train: GraouTrainSchedule): TrainSchedule 
     (acc, step) => {
       const stepId = uuidV4();
 
-      if (!Number.isNaN(step.uic)) {
+      const uic = Number(step.uic);
+      if (Number.isNaN(uic)) {
         throw new Error('Invalid UIC');
       }
 
       acc.path.push({
         id: stepId,
         location: {
-          operational_point: { uic: Number(step.uic), secondary_code: step.chCode },
+          operational_point: { uic, secondary_code: step.chCode },
         },
       });
 


### PR DESCRIPTION
I messed up with an inverted condition when pushing the last commit in #14203. We want to reject NaNs, not accept them.

Fixes: c8fe8ccd04f4 ("front: drop unnecessary trigram fallback in Graou import")