### PR TITLE
front: use use query for searches

### DIFF
--- a/front/src/applications/operationalStudies/views/Project/ProjectView.tsx
+++ b/front/src/applications/operationalStudies/views/Project/ProjectView.tsx
@@ -54,7 +54,7 @@ const ProjectView = () => {
 
   const { projectId: urlProjectId } = useParams() as ProjectParams;
   const [deleteStudy] = osrdEditoastApi.endpoints.deleteStudiesByStudyId.useMutation();
-  const [postSearch] = osrdEditoastApi.endpoints.postSearch.useMutation();
+  const [postSearch] = osrdEditoastApi.endpoints.postSearch.useLazyQuery();
 
   const { projectId } = useMemo(
     () => ({

--- a/front/src/applications/operationalStudies/views/ProjectList/ProjectListView.tsx
+++ b/front/src/applications/operationalStudies/views/ProjectList/ProjectListView.tsx
@@ -64,7 +64,7 @@ const ProjectListView = () => {
       deleteItems();
     }
   };
-  const [postSearch] = osrdEditoastApi.endpoints.postSearch.useMutation();
+  const [postSearch] = osrdEditoastApi.endpoints.postSearch.useLazyQuery();
 
   const { data: allProjects } = osrdEditoastApi.endpoints.getProjects.useQuery({
     ordering: sortOption,

--- a/front/src/applications/operationalStudies/views/Study/StudyView.tsx
+++ b/front/src/applications/operationalStudies/views/Study/StudyView.tsx
@@ -73,7 +73,7 @@ const StudyView = () => {
       : skipToken
   );
 
-  const [postSearch] = osrdEditoastApi.endpoints.postSearch.useMutation();
+  const [postSearch] = osrdEditoastApi.endpoints.postSearch.useLazyQuery();
   const [deleteScenario] = osrdEditoastApi.endpoints.deleteScenariosByScenarioId.useMutation({});
 
   const { data: scenarios } = osrdEditoastApi.endpoints.getScenarios.useQuery(

--- a/front/src/applications/stdcm/components/StdcmForm/StdcmOperationalPoint.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmOperationalPoint.tsx
@@ -51,17 +51,12 @@ const StdcmOperationalPoint = ({
   const { t } = useTranslation('stdcm');
   const dispatch = useAppDispatch();
 
-  const {
-    searchTerm,
-    setSearchTerm,
-    searchResults,
-    setSearchResults,
-    searchOperationalPointsByTrigram,
-  } = useSearchOperationalPoint({
-    initialSearchTerm: operationalPoint?.name,
-    initialChCodeFilter: operationalPoint?.secondaryCode,
-    isStdcm: true,
-  });
+  const { searchTerm, setSearchTerm, searchResults, searchOperationalPointsByTrigram } =
+    useSearchOperationalPoint({
+      initialSearchTerm: operationalPoint?.name,
+      initialChCodeFilter: operationalPoint?.secondaryCode,
+      isStdcm: true,
+    });
 
   const [chSuggestions, setChSuggestions] = useState<StdcmOp[]>([]);
 
@@ -123,7 +118,6 @@ const StdcmOperationalPoint = ({
 
   const resetSuggestions = () => {
     if (searchTerm !== '' && !operationalPoint) {
-      setSearchResults([]);
       setSearchTerm('');
     }
   };

--- a/front/src/applications/stdcm/hooks/useLinkedTrainSearch.ts
+++ b/front/src/applications/stdcm/hooks/useLinkedTrainSearch.ts
@@ -22,7 +22,7 @@ import type { StdcmLinkedTrainResult } from '../types';
 import computeOpSchedules from '../utils/computeOpSchedules';
 
 const useLinkedTrainSearch = () => {
-  const [postSearch] = osrdEditoastApi.endpoints.postSearch.useMutation();
+  const [postSearch] = osrdEditoastApi.endpoints.postSearch.useLazyQuery();
   const [postTrainScheduleSimulationSummary] =
     osrdEditoastApi.endpoints.postTrainScheduleSimulationSummary.useLazyQuery();
 

--- a/front/src/common/Map/Search/MapSearchLine.tsx
+++ b/front/src/common/Map/Search/MapSearchLine.tsx
@@ -29,7 +29,7 @@ const MapSearchLine = ({
 
   const { t } = useTranslation();
   const { updateMapSettings } = useMapSettingsActions();
-  const [postSearch] = osrdEditoastApi.endpoints.postSearch.useMutation();
+  const [postSearch] = osrdEditoastApi.endpoints.postSearch.useLazyQuery();
   const [searchTerm, setSearchTerm] = useState<string>('');
   const [searchResults, setSearchResults] = useState<SearchResultItemTrack[]>([]);
   const [getTrackPath] =

--- a/front/src/common/Map/Search/MapSearchOperationalPoint.tsx
+++ b/front/src/common/Map/Search/MapSearchOperationalPoint.tsx
@@ -28,7 +28,6 @@ const MapSearchOperationalPoint = ({ closeMapSearchPopUp }: MapSearchOperational
     mainOperationalPointsOnly,
     setSearchTerm,
     setChCodeFilter,
-    setSearchResults,
     setMainOperationalPointsOnly,
   } = useSearchOperationalPoint({ pageSize: MAX_DISPLAYABLE_RESULTS + 1 });
 
@@ -94,7 +93,6 @@ const MapSearchOperationalPoint = ({ closeMapSearchPopUp }: MapSearchOperational
             }}
             onClear={() => {
               setSearchTerm('');
-              setSearchResults([]);
             }}
             clearButton
             noMargin

--- a/front/src/common/Map/Search/MapSearchSignal.tsx
+++ b/front/src/common/Map/Search/MapSearchSignal.tsx
@@ -96,7 +96,7 @@ const MapSearchSignal = ({ closeMapSearchPopUp }: MapSearchSignalProps) => {
     asc: true,
   });
   const dispatch = useAppDispatch();
-  const [postSearch] = osrdEditoastApi.endpoints.postSearch.useMutation();
+  const [postSearch] = osrdEditoastApi.endpoints.postSearch.useLazyQuery();
 
   const getPayload = (
     lineSearch: string,

--- a/front/src/common/Map/Search/useSearchOperationalPoint.tsx
+++ b/front/src/common/Map/Search/useSearchOperationalPoint.tsx
@@ -49,18 +49,17 @@ export default function useSearchOperationalPoint({
     return true;
   }, [stdcmOperationalPoints, isSuperUser, isStdcm]);
 
-  /* Search for operational whose trigrams start with the search query */
-  const searchOperationalPointsByTrigram = useCallback(
-    async (searchQuery: string) => {
-      const shouldSearchByTrigram = !Number.isInteger(+searchQuery) && searchQuery.length < 4;
 
-      if (!shouldSearchByTrigram || !infraID) return [];
+  /* Lazily search for operational whose trigrams exactly match the search query */
+  const lazySearchByExactTrigram = useCallback(
+    async (searchQuery: string) => {
+      if (!infraID) return [];
 
       const payload = {
         object: 'operationalpoint',
         query: [
           'and',
-          ['ilike', ['trigram'], `${searchQuery}%`],
+          ['=', ['trigram'], `${searchQuery}`],
           ['=', ['infra_id'], infraID],
           stdcmPerimeterOperationalpointsFilter,
         ],
@@ -151,7 +150,7 @@ export default function useSearchOperationalPoint({
     mainOperationalPointsOnly,
     searchResults,
     searchOperationalPoints,
-    searchOperationalPointsByTrigram,
+    searchOperationalPointsByTrigram: lazySearchByExactTrigram,
     setSearchTerm,
     setChCodeFilter,
     setSearchResults,

--- a/front/src/common/Map/Search/useSearchOperationalPoint.tsx
+++ b/front/src/common/Map/Search/useSearchOperationalPoint.tsx
@@ -1,5 +1,6 @@
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useState, useMemo, useCallback } from 'react';
 
+import { skipToken } from '@reduxjs/toolkit/query';
 import { useSelector } from 'react-redux';
 
 import { type SearchResultItemOperationalPoint, osrdEditoastApi } from 'common/api/osrdEditoastApi';
@@ -34,7 +35,6 @@ export default function useSearchOperationalPoint({
   const infraID = useInfraID();
   const [searchTerm, setSearchTerm] = useState(initialSearchTerm);
   const [chCodeFilter, setChCodeFilter] = useState(initialChCodeFilter);
-  const [searchResults, setSearchResults] = useState<SearchResultItemOperationalPoint[]>([]);
   const [mainOperationalPointsOnly, setMainOperationalPointsOnly] = useState(false);
   const stdcmOperationalPoints = useSelector(getOperationalPoints);
   const isSuperUser = useSelector(getIsSuperUser);
@@ -48,7 +48,6 @@ export default function useSearchOperationalPoint({
     }
     return true;
   }, [stdcmOperationalPoints, isSuperUser, isStdcm]);
-
 
   /* Lazily search for operational whose trigrams exactly match the search query */
   const lazySearchByExactTrigram = useCallback(
@@ -77,47 +76,73 @@ export default function useSearchOperationalPoint({
         return [];
       }
     },
-    [infraID, isStdcm, isSuperUser, stdcmPerimeterOperationalpointsFilter]
+    [infraID, stdcmPerimeterOperationalpointsFilter]
   );
 
-  /** Search for operational points whose trigrams start with the search query or whose name or UIC code (primary code) contain the search query */
-  const searchOperationalPoints = useCallback(
-    async (searchQuery: string) => {
-      if (infraID === undefined) return [];
+  const shouldSearchByTrigram =
+    infraID &&
+    debouncedSearchTerm &&
+    !Number.isInteger(+debouncedSearchTerm) &&
+    debouncedSearchTerm.length < 4;
 
-      const sortedTrigramResults = await searchOperationalPointsByTrigram(searchQuery);
-      const trigramResultsIds = new Set(sortedTrigramResults.map((op) => op.obj_id));
+  /* Operational points whose trigrams start with the search query */
+  const { data: rawTrigramResults } = osrdEditoastApi.endpoints.postSearch.useQuery(
+    shouldSearchByTrigram
+      ? {
+          searchPayload: {
+            object: 'operationalpoint',
+            query: [
+              'and',
+              ['ilike', ['trigram'], `${debouncedSearchTerm}%`],
+              ['=', ['infra_id'], infraID],
+              stdcmPerimeterOperationalpointsFilter,
+            ],
+          },
+          pageSize,
+        }
+      : skipToken
+  );
 
-      try {
-        const results = (await postSearch({
+  /* Operational points whose name or UIC code (primary code) contain the search query */
+  const { data: rawNameAndUicResults } = osrdEditoastApi.endpoints.postSearch.useQuery(
+    infraID && debouncedSearchTerm
+      ? {
           searchPayload: {
             object: 'operationalpoint',
             query: [
               'and',
               [
                 'or',
-                ['search', ['name'], searchQuery],
-                ['like', ['to_string', ['uic']], `%${searchQuery}%`],
+                ['search', ['name'], debouncedSearchTerm],
+                ['like', ['to_string', ['uic']], `%${debouncedSearchTerm}%`],
               ],
               ['=', ['infra_id'], infraID],
               stdcmPerimeterOperationalpointsFilter,
             ],
           },
           pageSize,
-        }).unwrap()) as SearchResultItemOperationalPoint[];
-        const deduplicatedResults = results.filter((item) => !trigramResultsIds.has(item.obj_id));
-        const sortedResults = [...deduplicatedResults];
-        sortedResults.sort(sortOperationalPointsFromNameAndUicSearch(searchQuery));
-
-        const allResults = [...sortedTrigramResults, ...sortedResults];
-        return allResults;
-      } catch (error) {
-        setFailure(castErrorToFailure(error));
-        return [];
-      }
-    },
-    [infraID, isStdcm, isSuperUser, stdcmPerimeterOperationalpointsFilter]
+        }
+      : skipToken
   );
+
+  const searchResults = useMemo(() => {
+    if (!debouncedSearchTerm) return [];
+
+    const trigramResults = [...((rawTrigramResults ?? []) as SearchResultItemOperationalPoint[])];
+    trigramResults.sort(sortOperationalPointsFromTrigramSearch);
+    const trigramResultsIds = new Set(trigramResults.map((op) => op.obj_id));
+
+    const nameAndUicResults = [
+      ...((rawNameAndUicResults ?? []) as SearchResultItemOperationalPoint[]),
+    ];
+    const dedupNameAndUicResults = nameAndUicResults.filter(
+      (item) => !trigramResultsIds.has(item.obj_id)
+    );
+    dedupNameAndUicResults.sort(sortOperationalPointsFromNameAndUicSearch(debouncedSearchTerm));
+
+    const allResults = [...trigramResults, ...dedupNameAndUicResults];
+    return allResults;
+  }, [debouncedSearchTerm, rawTrigramResults, rawNameAndUicResults]);
 
   /** Filter operational points on secondary code (ch), if provided */
   const searchResultsFilteredByCh = useMemo(() => {
@@ -133,27 +158,15 @@ export default function useSearchOperationalPoint({
     return searchResults.filter((result) => result.ch.toLocaleLowerCase().includes(chFilter));
   }, [searchResults, chCodeFilter, mainOperationalPointsOnly]);
 
-  useEffect(() => {
-    if (debouncedSearchTerm) {
-      searchOperationalPoints(debouncedSearchTerm).then((results) => {
-        setSearchResults(results);
-      });
-    } else if (searchResults.length !== 0) {
-      setSearchResults([]);
-    }
-  }, [debouncedSearchTerm]);
-
   return {
     searchTerm,
     chCodeFilter,
     searchResultsFilteredByCh,
     mainOperationalPointsOnly,
     searchResults,
-    searchOperationalPoints,
     searchOperationalPointsByTrigram: lazySearchByExactTrigram,
     setSearchTerm,
     setChCodeFilter,
-    setSearchResults,
     setMainOperationalPointsOnly,
   };
 }

--- a/front/src/common/Map/Search/useSearchOperationalPoint.tsx
+++ b/front/src/common/Map/Search/useSearchOperationalPoint.tsx
@@ -40,7 +40,7 @@ export default function useSearchOperationalPoint({
   const isSuperUser = useSelector(getIsSuperUser);
 
   const debouncedSearchTerm = useDebounce(searchTerm, debounceDelay);
-  const [postSearch] = osrdEditoastApi.endpoints.postSearch.useMutation();
+  const [postSearch] = osrdEditoastApi.endpoints.postSearch.useLazyQuery();
 
   const stdcmPerimeterOperationalpointsFilter = useMemo(() => {
     if (isStdcm && !isSuperUser && stdcmOperationalPoints) {

--- a/front/src/common/NavBar/UserSettings.tsx
+++ b/front/src/common/NavBar/UserSettings.tsx
@@ -22,7 +22,7 @@ import { useDebounce } from 'utils/helpers';
 import useAuth from 'utils/hooks/useAuth';
 
 const UserSettings = () => {
-  const [postSearch] = osrdEditoastApi.endpoints.postSearch.useMutation();
+  const [postSearch] = osrdEditoastApi.endpoints.postSearch.useLazyQuery();
   const [inputValue, setInputValue] = useState('');
   const [userList, setUserList] = useState<SearchResultItemUser[]>([]);
   const userPreferences = useSelector(getUserPreferences);

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -926,7 +926,7 @@ const injectedRtkApi = api
         }),
         invalidatesTags: ['scenarios'],
       }),
-      postSearch: build.mutation<PostSearchApiResponse, PostSearchApiArg>({
+      postSearch: build.query<PostSearchApiResponse, PostSearchApiArg>({
         query: (queryArg) => ({
           url: `/search`,
           method: 'POST',
@@ -936,7 +936,7 @@ const injectedRtkApi = api
             page_size: queryArg.pageSize,
           },
         }),
-        invalidatesTags: ['search'],
+        providesTags: ['search'],
       }),
       postSimilarTrains: build.mutation<PostSimilarTrainsApiResponse, PostSimilarTrainsApiArg>({
         query: (queryArg) => ({ url: `/similar_trains`, method: 'POST', body: queryArg.body }),

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -414,6 +414,23 @@ const osrdEditoastApi = generatedEditoastApi
           { type: 'scenarios', id: 'LIST' },
         ],
       },
+
+      // Search
+      postSearch: {
+        providesTags: (_result, _error, args) =>
+          (
+            ({
+              user: [],
+              study: ['studies'],
+              project: ['projects'],
+              scenario: ['scenarios'],
+              track: ['infra'],
+              signal: ['infra'],
+              operationalpoint: ['infra'],
+              trainschedule: ['train_schedule'],
+            }) as const
+          )[args.searchPayload.object] ?? [],
+      },
     },
   });
 

--- a/front/src/common/useSearchUsers.ts
+++ b/front/src/common/useSearchUsers.ts
@@ -18,7 +18,7 @@ export default function useSearchUsers() {
   const [searchedUsers, setSearchedUsers] = useState<User[]>([]);
 
   const debouncedSearchTerm = useDebounce(searchTerm, 150);
-  const [postSearch] = osrdEditoastApi.endpoints.postSearch.useMutation();
+  const [postSearch] = osrdEditoastApi.endpoints.postSearch.useLazyQuery();
 
   const searchUser = useCallback(async (searchQuery: string) => {
     try {

--- a/front/src/common/useSearchUsers.ts
+++ b/front/src/common/useSearchUsers.ts
@@ -1,4 +1,6 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useMemo } from 'react';
+
+import { skipToken } from '@reduxjs/toolkit/query';
 
 import { useDebounce } from 'utils/helpers';
 
@@ -15,46 +17,33 @@ export type User = {
 
 export default function useSearchUsers() {
   const [searchTerm, setSearchTerm] = useState('');
-  const [searchedUsers, setSearchedUsers] = useState<User[]>([]);
-
   const debouncedSearchTerm = useDebounce(searchTerm, 150);
-  const [postSearch] = osrdEditoastApi.endpoints.postSearch.useLazyQuery();
 
-  const searchUser = useCallback(async (searchQuery: string) => {
-    try {
-      const results = (await postSearch({
-        searchPayload: {
-          object: 'user',
-          query: ['search', ['name'], searchQuery],
-        },
-        pageSize: 101,
-      }).unwrap()) as SearchResultItemUser[];
+  const { data: searchedUsersData } = osrdEditoastApi.endpoints.postSearch.useQuery(
+    debouncedSearchTerm
+      ? {
+          searchPayload: {
+            object: 'user',
+            query: ['search', ['name'], debouncedSearchTerm],
+          },
+          pageSize: 101,
+        }
+      : skipToken
+  );
 
-      return results.map((result) => ({
+  const searchedUsers = useMemo(
+    () =>
+      ((searchedUsersData ?? []) as SearchResultItemUser[]).map((result) => ({
         id: result.id,
         name: result.name,
         type: SUBJECT_TYPES.USER,
-      }));
-    } catch (error) {
-      console.error(error);
-      return [];
-    }
-  }, []);
+      })),
+    [searchedUsersData]
+  );
 
   const resetSuggestions = () => {
-    setSearchedUsers([]);
     setSearchTerm('');
   };
-
-  useEffect(() => {
-    if (debouncedSearchTerm) {
-      searchUser(debouncedSearchTerm).then((results) => {
-        setSearchedUsers(results);
-      });
-    } else if (searchedUsers.length !== 0) {
-      setSearchedUsers([]);
-    }
-  }, [debouncedSearchTerm]);
 
   return {
     resetSuggestions,

--- a/front/src/config/openapi-editoast-config.cts
+++ b/front/src/config/openapi-editoast-config.cts
@@ -27,6 +27,7 @@ const config: ConfigFile = {
         'postTrainScheduleProjectPathOp',
         'postTrainScheduleOccupancyBlocks',
         'postWorkSchedulesProjectPath',
+        'postSearch',
       ],
       type: 'query',
     },

--- a/front/src/modules/pathfinding/components/Pathfinding/TypeAndPath.tsx
+++ b/front/src/modules/pathfinding/components/Pathfinding/TypeAndPath.tsx
@@ -64,7 +64,7 @@ const TypeAndPath = ({ setDisplayTypeAndPath, rollingStockId }: TypeAndPathProps
   const [inputText, setInputText] = useState('');
   const [opList, setOpList] = useState<SearchResultItemOperationalPoint[]>([]);
   const infraId = useInfraID();
-  const [postSearch] = osrdEditoastApi.endpoints.postSearch.useMutation();
+  const [postSearch] = osrdEditoastApi.endpoints.postSearch.useLazyQuery();
 
   const { t } = useTranslation('operational-studies', { keyPrefix: 'manageTimetableItem' });
 


### PR DESCRIPTION
Close [#11855](https://github.com/OpenRailAssociation/osrd/issues/11855)

- turn postSearch from a mutation to a query (and thus useMutation to useLazyQuery), as we are querying data, not mutating it, despite being a post due to having a body

- turn useLazyQuery to useQuery for users and operational points, to let rtk fully handle the query and cache process, and solve race conditions created from subsequent manual search queries. This is limited to op and users for now as a proof of concept. but if this PR is merged, this work should be extended to other objects.

- also fix an issue where when listing the possible ch for an op in stdcm ch for ops containing the current trigram were also included in the search. There was a second filter later that prevented them being actually displayed to users, but it seemed like a dirty workaround. (Can we drop this filter btw? It seems unnecessary now.) (Also we probably should not be using the search endpoint at all for this, but rather the matching endpoint, using an op reference rather than a trigram. This is out of scope for this pr.)

- finally, add rtk cache tags to the postsearch endpoint depending on the type of object queried
