### PR TITLE
ci: reduce editoast tests verbosity

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -525,7 +525,7 @@ jobs:
             -e CI="true" \
             -e FGA_API_URL="http://localhost:8091" \
             ${{ fromJSON(needs.build.outputs.stable_tags).editoast-test }} \
-            /bin/sh -c "diesel migration run --locked-schema && RUST_BACKTRACE=1 cargo test --workspace --verbose -- --test-threads=4"
+            /bin/sh -c "diesel migration run --locked-schema && RUST_LOG=error RUST_BACKTRACE=1 cargo test --workspace -- --test-threads=4"
 
           exit $(docker wait editoast-test)
 


### PR DESCRIPTION
Currently, we output so much lines that github truncates the output... We probably don't need to output dozens of megabytes of logs for every test runs.