### PR TITLE
core: add timetable cache using valkey

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -99,6 +99,9 @@ dependencies {
 
     // rabbitmq
     implementation libs.amqp.client
+
+    // redis
+    implementation libs.lettuce
 }
 // endregion
 

--- a/core/gradle/libs.versions.toml
+++ b/core/gradle/libs.versions.toml
@@ -67,6 +67,7 @@ opentelemetry-instrumentation-annotations = { module = 'io.opentelemetry.instrum
 kaml = { module = 'com.charleskorn.kaml:kaml', version = '0.104.0' } # Apache 2.0
 
 amqp-client = { module = 'com.rabbitmq:amqp-client', version = '5.28.0' }
+lettuce = { module = 'io.lettuce:lettuce-core', version = '7.0.0.RELEASE' } # MIT
 
 [plugins]
 # kotlin

--- a/core/src/main/java/fr/sncf/osrd/api/TimetableCacheManager.kt
+++ b/core/src/main/java/fr/sncf/osrd/api/TimetableCacheManager.kt
@@ -3,8 +3,8 @@ package fr.sncf.osrd.api
 import com.google.common.collect.ImmutableRangeSet
 import com.google.common.collect.Range
 import com.google.common.collect.RangeSet
-import fr.sncf.osrd.sim_infra.api.RawInfra
 import fr.sncf.osrd.sim_infra.api.ZoneId
+import io.lettuce.core.api.StatefulRedisConnection
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.annotations.WithSpan
 import java.nio.file.Files
@@ -15,11 +15,14 @@ import kotlin.io.path.readBytes
 import kotlin.io.path.writeBytes
 import kotlin.time.measureTime
 import kotlinx.coroutines.*
+import kotlinx.coroutines.future.await
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.cbor.Cbor
+import kotlinx.serialization.decodeFromHexString
+import kotlinx.serialization.encodeToHexString
 import org.slf4j.LoggerFactory
 
 typealias TimetableId = Int
@@ -66,14 +69,20 @@ value class STDCMRequirements(val map: Map<ZoneId, RangeSet<Double>>) :
 /**
  * Caches train spacing requirements for STDCM. The spacing requirements times are relative to
  * EPOCH.
+ *
+ * Supports two kinds of cache: either with valkey or in a local directory. When both are set, we
+ * first look for the local file and then for a valkey entry.
  */
+@ExperimentalSerializationApi
 class TimetableCacheManager(
     val timetableProvider: TimetableProvider,
     val localCacheLocation: String? = null,
+    val valkeyConnection: StatefulRedisConnection<String, String>? = null,
     val disableAllCaching: Boolean = false,
+    val osrdGitDescribe: String,
 ) {
-    private val cache = ConcurrentHashMap<TimetableId, STDCMRequirements>()
-    private val mutexes = ConcurrentHashMap<TimetableId, Mutex>()
+    private val cache = ConcurrentHashMap<String, STDCMRequirements>()
+    private val mutexes = ConcurrentHashMap<String, Mutex>()
 
     private val fetchDispatcher = Dispatchers.IO
 
@@ -84,23 +93,24 @@ class TimetableCacheManager(
      * cached.
      */
     @WithSpan(value = "Accessing timetable content", kind = SpanKind.SERVER)
-    suspend fun get(infraId: String, infra: RawInfra, timetableId: TimetableId): STDCMRequirements =
+    suspend fun get(infra: FullInfra, timetableId: TimetableId): STDCMRequirements =
         coroutineScope {
+            val cacheKey = getCacheKey(infra, timetableId)
             if (disableAllCaching) {
                 logger.info("Cache disabled")
                 return@coroutineScope withContext(fetchDispatcher) {
-                    return@withContext fetchTimetableRequirements(infraId, infra, timetableId)
+                    return@withContext fetchTimetableRequirements(infra, timetableId, cacheKey)
                 }
             }
-            cache[timetableId]?.let {
-                logger.info("Timetable cache hit for ID $timetableId")
+            cache[cacheKey]?.let {
+                logger.debug("Timetable cache hit for ID $timetableId")
                 return@coroutineScope it
             }
 
-            val mutex = mutexes.computeIfAbsent(timetableId) { Mutex() }
+            val mutex = mutexes.computeIfAbsent(cacheKey) { Mutex() }
             mutex.withLock {
                 try {
-                    cache[timetableId]?.let {
+                    cache[cacheKey]?.let {
                         return@coroutineScope it
                     }
                     logger.info("Start computing timetable requirements")
@@ -108,34 +118,49 @@ class TimetableCacheManager(
                     val time = measureTime {
                         requirements =
                             withContext(fetchDispatcher) {
-                                fetchTimetableRequirements(infraId, infra, timetableId)
+                                fetchTimetableRequirements(infra, timetableId, cacheKey)
                             }
                     }
-                    cache[timetableId] = requirements
-                    logger.info("timetable requirements computed in ${time.inWholeSeconds} seconds")
+                    cache[cacheKey] = requirements
+                    val nEntries = requirements.entries.sumOf { it.value.asRanges().size }
+                    logger.info(
+                        "timetable requirements computed in ${time.inWholeSeconds} seconds, $nEntries map entries"
+                    )
                     return@coroutineScope requirements
                 } finally {
-                    mutexes.remove(timetableId)
+                    mutexes.remove(cacheKey)
                 }
             }
         }
 
+    /** Generates a string key for a given infra + timetable. */
+    fun getCacheKey(infra: FullInfra, timetableId: TimetableId): String {
+        val infraId = infra.metadata.name
+        val infraVersion = infra.metadata.version
+        return "$osrdGitDescribe-$infraId-$infraVersion-$timetableId"
+    }
+
     /** Load given timetable ID. */
     @WithSpan(value = "Preloading timetable content", kind = SpanKind.SERVER)
-    fun load(infraId: String, infra: RawInfra, timetableId: TimetableId) {
-        if (!disableAllCaching) runBlocking { get(infraId, infra, timetableId) }
+    fun load(infra: FullInfra, timetableId: TimetableId) {
+        if (!disableAllCaching) runBlocking { get(infra, timetableId) }
     }
 
     @WithSpan(value = "Fetching timetable content", kind = SpanKind.SERVER)
-    private fun fetchTimetableRequirements(
-        infraId: String,
-        infra: RawInfra,
+    private suspend fun fetchTimetableRequirements(
+        infra: FullInfra,
         timetableId: TimetableId,
+        cacheKey: String,
     ): STDCMRequirements {
-        val cacheFile = if (disableAllCaching) null else "$timetableId.cbor"
         val requirements =
-            withLocalCache(localCacheLocation, cacheFile) {
-                timetableProvider.getTimetableRequirements(infraId, infra, timetableId)
+            withLocalCache(localCacheLocation, cacheKey) {
+                withValkeyCache(valkeyConnection, cacheKey) {
+                    timetableProvider.getTimetableRequirements(
+                        infra.metadata.name,
+                        infra.rawInfra,
+                        timetableId,
+                    )
+                }
             }
         return requirements
     }
@@ -144,13 +169,13 @@ class TimetableCacheManager(
      * If a cache folder has been set, get the cached data if present, otherwise generate it and
      * write a new file. Directly calls the generator function if no cache folder has been set.
      */
-    @OptIn(ExperimentalSerializationApi::class)
-    private fun withLocalCache(
+    private suspend fun withLocalCache(
         cacheFolder: String?,
-        filename: String?,
-        generateData: () -> STDCMRequirements,
+        cacheKey: String?,
+        generateData: suspend () -> STDCMRequirements,
     ): STDCMRequirements {
-        if (cacheFolder == null || filename == null) return generateData()
+        if (cacheFolder == null || cacheKey == null) return generateData()
+        val filename = "$cacheKey.cbor"
         val folder = Path(cacheFolder)
         Files.createDirectories(folder)
         val file = folder.resolve(filename)
@@ -160,7 +185,7 @@ class TimetableCacheManager(
         if (file.exists()) {
             val bytes = file.readBytes()
             val serializableMap = cbor.decodeFromByteArray(serializer, bytes)
-            logger.info("local timetable file cache hit at $file")
+            logger.debug("local timetable file cache hit at {}", file)
             return serializableMap.toSTDCMRequirements()
         } else {
             val map = generateData.invoke()
@@ -170,5 +195,70 @@ class TimetableCacheManager(
             file.writeBytes(bytes)
             return map
         }
+    }
+
+    /**
+     * Try to get the cached value from valkey, returns null if the value isn't cached or if an
+     * error happened.
+     */
+    private suspend fun tryGetFromValkey(
+        valkeyConnection: StatefulRedisConnection<String, String>,
+        key: String,
+    ): STDCMRequirements? {
+        try {
+            val async = valkeyConnection.async()
+            val data = async.get(key).await() ?: return null
+            logger.debug("valkey cache hit")
+
+            val cbor = Cbor {}
+            val serializer = STDCMRequirements.SerializableMap.serializer()
+            val serializableMap = cbor.decodeFromHexString(serializer, data)
+            return serializableMap.toSTDCMRequirements()
+        } catch (e: Exception) {
+            logger.warn("error when fetching valkey cache: ${e.message}")
+            return null
+        }
+    }
+
+    /** Write the value to valkey, not blocking. */
+    private fun writeCacheToValkey(
+        valkeyConnection: StatefulRedisConnection<String, String>,
+        key: String,
+        data: STDCMRequirements,
+    ) {
+        val async = valkeyConnection.async()
+        val cbor = Cbor {}
+        val serializer = STDCMRequirements.SerializableMap.serializer()
+        val serialized = cbor.encodeToHexString(serializer, data.toSerializable())
+
+        // One day and a half. Timetables should be relevant for one day before being replaced, we
+        // keep them a little longer than that to be on the safe side.
+        val expirationMS = 36L * 60L * 60L * 1000L
+
+        async.psetex(key, expirationMS, serialized).exceptionally {
+            logger.warn("failed to send cached timetable to valkey: ", it)
+            null
+        }
+    }
+
+    /**
+     * If a valkey connection has been set, get the cached data if present, otherwise generate it
+     * and write a new entry.
+     */
+    private suspend fun withValkeyCache(
+        valkeyConnection: StatefulRedisConnection<String, String>?,
+        cacheKey: String?,
+        generateData: () -> STDCMRequirements,
+    ): STDCMRequirements {
+        if (valkeyConnection == null || cacheKey == null) {
+            return generateData()
+        }
+        val key = "core-timetable-$cacheKey"
+        tryGetFromValkey(valkeyConnection, key)?.let {
+            return it
+        }
+        val data = generateData()
+        writeCacheToValkey(valkeyConnection, key, data)
+        return data
     }
 }

--- a/core/src/main/java/fr/sncf/osrd/cli/BenchSTDCM.kt
+++ b/core/src/main/java/fr/sncf/osrd/cli/BenchSTDCM.kt
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeUnit
 import kotlin.concurrent.thread
 import kotlin.math.pow
 import kotlin.time.measureTime
+import kotlinx.serialization.ExperimentalSerializationApi
 import okhttp3.OkHttpClient
 import okio.buffer
 import okio.source
@@ -40,6 +41,7 @@ import org.slf4j.LoggerFactory
  * timetable can be input through a running editoast or with CLI parameters. Outputs are written as
  * csv, defaults to "bench_outputs/git-commit-hash.csv".
  */
+@ExperimentalSerializationApi
 @Parameters(commandDescription = "Benchmarks STDCM performances on a directory of saved payloads")
 class BenchSTDCM : CliCommand {
     @Parameter(
@@ -92,7 +94,12 @@ class BenchSTDCM : CliCommand {
             val timetableProvider =
                 if (timetableDirectory != null) JsonTimetableProvider(timetableDirectory!!)
                 else TimetableDownloader(editoastUrl, editoastAuthorization, httpClient)
-            val cacheManager = TimetableCacheManager(timetableProvider, timetableDirectory)
+            val cacheManager =
+                TimetableCacheManager(
+                    timetableProvider,
+                    timetableDirectory,
+                    osrdGitDescribe = "development",
+                )
 
             if (outputCsvPath == null) {
                 Files.createDirectories(Paths.get("bench_outputs"))

--- a/core/src/main/java/fr/sncf/osrd/cli/ReproduceRequest.kt
+++ b/core/src/main/java/fr/sncf/osrd/cli/ReproduceRequest.kt
@@ -16,6 +16,7 @@ import java.io.IOException
 import java.nio.file.Path
 import java.util.concurrent.TimeUnit
 import kotlin.time.measureTime
+import kotlinx.serialization.ExperimentalSerializationApi
 import okhttp3.OkHttpClient
 import okio.buffer
 import okio.source
@@ -65,6 +66,7 @@ class ReproduceRequest : CliCommand {
     private var timetableDirectory: String? = null
     private val logger: Logger = LoggerFactory.getLogger("ReproduceRequest")
 
+    @OptIn(ExperimentalSerializationApi::class)
     @ExcludeFromGeneratedCodeCoverage
     override fun run(): Int {
         try {
@@ -80,7 +82,12 @@ class ReproduceRequest : CliCommand {
             val timetableProvider =
                 if (timetableDirectory != null) JsonTimetableProvider(timetableDirectory!!)
                 else TimetableDownloader(editoastUrl, editoastAuthorization, httpClient)
-            val cacheManager = TimetableCacheManager(timetableProvider, timetableDirectory)
+            val cacheManager =
+                TimetableCacheManager(
+                    timetableProvider,
+                    timetableDirectory,
+                    osrdGitDescribe = "development",
+                )
 
             fun <T> loadRequest(path: String, adapter: JsonAdapter<T>): T {
                 val fileSource = Path.of(path).source()

--- a/core/src/main/java/fr/sncf/osrd/cli/WorkerCommand.kt
+++ b/core/src/main/java/fr/sncf/osrd/cli/WorkerCommand.kt
@@ -22,10 +22,12 @@ import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 import kotlin.system.exitProcess
+import kotlinx.serialization.ExperimentalSerializationApi
 import okhttp3.OkHttpClient
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
+@ExperimentalSerializationApi
 @Parameters(commandDescription = "RabbitMQ worker mode")
 class WorkerCommand : CliCommand {
 
@@ -55,6 +57,7 @@ class WorkerCommand : CliCommand {
     val MAX_CONCURRENT_TIMETABLE_REQUESTS: Int
     val DISABLE_ALL_TIMETABLE_CACHE: Boolean
     val VALKEY_URL: String?
+    val OSRD_GIT_DESCRIBE: String
 
     init {
         LOCAL_TIMETABLE_CACHE = System.getenv("LOCAL_TIMETABLE_CACHE")
@@ -85,6 +88,7 @@ class WorkerCommand : CliCommand {
             } else {
                 System.getenv("WORKER_ID")
             }
+        OSRD_GIT_DESCRIBE = System.getenv("OSRD_GIT_DESCRIBE") ?: "development"
     }
 
     private fun getBooleanEnvvar(name: String): Boolean {
@@ -125,7 +129,9 @@ class WorkerCommand : CliCommand {
                     MAX_CONCURRENT_TIMETABLE_REQUESTS,
                 ),
                 LOCAL_TIMETABLE_CACHE,
+                valkeyConnection,
                 DISABLE_ALL_TIMETABLE_CACHE,
+                OSRD_GIT_DESCRIBE,
             )
         val electricalProfileSetManager =
             ElectricalProfileSetManager(editoastUrl, editoastAuthorization, httpClient)
@@ -172,8 +178,7 @@ class WorkerCommand : CliCommand {
             if (!ALL_INFRA) {
                 try {
                     val infra = infraManager.load(infraId, null)
-                    if (timetableId != null)
-                        timetableCache.load(infraId, infra.rawInfra, timetableId)
+                    if (timetableId != null) timetableCache.load(infra, timetableId)
                 } catch (e: OSRDError) {
                     val isInfraLoadError =
                         setOf(ErrorType.InfraHardLoadingError, ErrorType.InfraSoftLoadingError)

--- a/core/src/main/java/fr/sncf/osrd/cli/WorkerCommand.kt
+++ b/core/src/main/java/fr/sncf/osrd/cli/WorkerCommand.kt
@@ -14,6 +14,7 @@ import fr.sncf.osrd.api.standalone_sim.SimulationEndpoint
 import fr.sncf.osrd.api.stdcm.STDCMEndpoint
 import fr.sncf.osrd.reporting.exceptions.ErrorType
 import fr.sncf.osrd.reporting.exceptions.OSRDError
+import io.lettuce.core.RedisClient
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.context.Context
 import io.opentelemetry.context.propagation.TextMapGetter
@@ -53,6 +54,7 @@ class WorkerCommand : CliCommand {
     val WORKER_THREADS: Int
     val MAX_CONCURRENT_TIMETABLE_REQUESTS: Int
     val DISABLE_ALL_TIMETABLE_CACHE: Boolean
+    val VALKEY_URL: String?
 
     init {
         LOCAL_TIMETABLE_CACHE = System.getenv("LOCAL_TIMETABLE_CACHE")
@@ -74,7 +76,7 @@ class WorkerCommand : CliCommand {
             System.getenv("MAX_CONCURRENT_TIMETABLE_REQUESTS")?.toIntOrNull() ?: 10
         DISABLE_ALL_TIMETABLE_CACHE =
             System.getenv("DISABLE_ALL_TIMETABLE_CACHE")?.lowercase() == "true"
-
+        VALKEY_URL = System.getenv("VALKEY_URL")
         WORKER_ID =
             if (WORKER_ID_USE_HOSTNAME) {
                 java.net.InetAddress.getLocalHost().hostName
@@ -109,6 +111,7 @@ class WorkerCommand : CliCommand {
         )
 
         val httpClient = OkHttpClient.Builder().readTimeout(120, TimeUnit.SECONDS).build()
+        val valkeyConnection = VALKEY_URL?.let { RedisClient.create(it).connect() }
 
         val infraId = WORKER_KEY.split("-").first()
         val timetableId = WORKER_KEY.split("-").getOrNull(1)?.toInt()

--- a/core/src/main/kotlin/fr/sncf/osrd/api/WorkerLoadEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/WorkerLoadEndpoint.kt
@@ -27,8 +27,7 @@ class WorkerLoadEndpoint(
 
             // load infra and timetable
             val infra = infraManager.load(request.infra, request.expectedVersion)
-            if (request.timetable != null)
-                timetableManager.load(request.infra, infra.rawInfra, request.timetable!!)
+            if (request.timetable != null) timetableManager.load(infra, request.timetable!!)
 
             return RsWithStatus(RsWithBody(""), 204)
         } catch (ex: Throwable) {

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalSerializationApi::class)
+
 package fr.sncf.osrd.api.stdcm
 
 import com.google.common.collect.ImmutableRangeMap
@@ -62,6 +64,7 @@ import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.util.TreeMap
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.ExperimentalSerializationApi
 
 class STDCMEndpoint(
     private val infraManager: InfraProvider,
@@ -370,9 +373,7 @@ fun getRequirements(
             set.add(Range.closedOpen(spacingReq.beginTime, spacingReq.endTime))
         }
 
-    val trainRequirements = runBlocking {
-        timetableCacheManager.get(request.infra, infra.rawInfra, request.timetableId)
-    }
+    val trainRequirements = runBlocking { timetableCacheManager.get(infra, request.timetableId) }
     // Cached requirements are relative to EPOCH. Add time diff with request start time
     // to these requirements.
     val searchWindowBeginEpoch = request.startTime.durationSinceEpoch()

--- a/core/src/main/resources/logback.xml
+++ b/core/src/main/resources/logback.xml
@@ -12,4 +12,6 @@
     <root level="debug">
         <appender-ref ref="COLOR"/>
     </root>
+    <logger name="io.lettuce" level="INFO"/>
+    <logger name="io.netty" level="INFO"/>
 </configuration>

--- a/core/src/test/java/fr/sncf/osrd/api/WorkerLoadingTest.kt
+++ b/core/src/test/java/fr/sncf/osrd/api/WorkerLoadingTest.kt
@@ -3,10 +3,12 @@ package fr.sncf.osrd.api
 import fr.sncf.osrd.api.WorkerLoadEndpoint.WorkerLoadRequest
 import fr.sncf.osrd.cli.RqFake
 import java.io.IOException
+import kotlinx.serialization.ExperimentalSerializationApi
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 
+@OptIn(ExperimentalSerializationApi::class)
 class WorkerLoadingTest : ApiTest() {
     @ParameterizedTest
     @CsvSource("true, 400", "false, 204")
@@ -18,7 +20,8 @@ class WorkerLoadingTest : ApiTest() {
         val request =
             if (isRequestNull) null else WorkerLoadRequest("tiny_infra/infra.json", 1, null)
         val requestBody = WorkerLoadEndpoint.adapterRequest.toJson(request)
-        val dummyCacheManager = TimetableCacheManager(JsonTimetableProvider(""), "")
+        val dummyCacheManager =
+            TimetableCacheManager(JsonTimetableProvider(""), osrdGitDescribe = "")
         val response = WorkerLoadEndpoint(infraManager, dummyCacheManager).act(RqFake(requestBody))
         Assertions.assertEquals(expectedStatusCode, response.statusCode())
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,6 +91,7 @@ services:
     container_name: osrd-core-dummy
     depends_on:
       rabbitmq: { condition: service_healthy }
+      valkey: { condition: service_healthy }
     build:
       context: core
       dockerfile: Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,6 +109,7 @@ services:
       OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: "http://jaeger:4317"
       OTEL_METRICS_EXPORTER: "none"
       OTEL_LOGS_EXPORTER: "none"
+      VALKEY_URL: "redis://valkey"
     restart: "no"
     command: "true"
 

--- a/docker/docker-compose.host.yml
+++ b/docker/docker-compose.host.yml
@@ -56,6 +56,7 @@ services:
     environment:
       CORE_EDITOAST_URL: "http://127.0.0.1:8090"
       OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: "http://127.0.0.1:4317"
+      VALKEY_URL: "redis://127.0.0.1"
 
   osrdyne:
     ports: !reset []


### PR DESCRIPTION
Fix https://github.com/OpenRailAssociation/osrd/issues/14326

When valkey url is set in core env variables, we now uses it to cache timetable contents. 

This PR only sets the env variables in docker-compose workflows. **No change is made in production environments** (yet). 

Tested by hand in a local environment. 

---

I left the file cache feature for workflows where core is run outside of containers. I sometimes flush valkey and I'd like to keep as much cache as possible for timetables. When both are set, we first look for the file and then for valkey, and write anything that had a cache miss.

Note: just like the in-memory core cache, there's no cache invalidation. Just an expiration set to one day. 