### PR TITLE
editoast: add post endpoints for train_schedule_set and catalogue_entry

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -308,6 +308,23 @@ paths:
                           type: string
                         type:
                           $ref: '#/components/schemas/SubjectType'
+  /catalogue_entry:
+    post:
+      tags:
+      - catalogue_entry
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CatalogueEntryCreateForm'
+        required: true
+      responses:
+        '201':
+          description: Catalogue entry
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CatalogueEntry'
   /documents:
     post:
       tags:
@@ -4683,6 +4700,23 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SimulationResponse'
+  /train_schedule_set:
+    post:
+      tags:
+      - train_schedule_set
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TrainScheduleSetCreateForm'
+        required: true
+      responses:
+        '201':
+          description: Train schedule set
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TrainScheduleSetResponse'
   /version:
     get:
       responses:
@@ -5062,6 +5096,25 @@ components:
           maxLength: 255
           minLength: 1
       additionalProperties: false
+    CatalogueEntry:
+      type: object
+      required:
+      - id
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type:
+          - string
+          - 'null'
+    CatalogueEntryCreateForm:
+      type: object
+      properties:
+        name:
+          type:
+          - string
+          - 'null'
     Comfort:
       type: string
       enum:
@@ -14228,6 +14281,62 @@ components:
           timetable_id:
             type: integer
             format: int64
+    TrainScheduleSet:
+      type: object
+      required:
+      - id
+      - description
+      - published
+      - is_sandbox
+      properties:
+        catalogue_entry_id:
+          type:
+          - integer
+          - 'null'
+          format: int64
+        description:
+          type: string
+        id:
+          type: integer
+          format: int64
+        is_sandbox:
+          type: boolean
+        name:
+          type:
+          - string
+          - 'null'
+        published:
+          type: boolean
+    TrainScheduleSetCreateForm:
+      type: object
+      required:
+      - description
+      - published
+      properties:
+        catalogue_entry_id:
+          type:
+          - integer
+          - 'null'
+          format: int64
+        description:
+          type: string
+        name:
+          type:
+          - string
+          - 'null'
+        published:
+          type: boolean
+    TrainScheduleSetResponse:
+      allOf:
+      - $ref: '#/components/schemas/TrainScheduleSet'
+      - type: object
+        required:
+        - train_schedule_count
+        properties:
+          train_schedule_count:
+            type: integer
+            format: int64
+            minimum: 0
     Version:
       type: object
       required:

--- a/editoast/src/models/catalogue_entry.rs
+++ b/editoast/src/models/catalogue_entry.rs
@@ -1,0 +1,9 @@
+use serde::Deserialize;
+use serde::Serialize;
+use utoipa::ToSchema;
+
+#[derive(Deserialize, Serialize, ToSchema)]
+pub struct CatalogueEntry {
+    pub id: i64,
+    pub name: Option<String>,
+}

--- a/editoast/src/models/mod.rs
+++ b/editoast/src/models/mod.rs
@@ -10,6 +10,7 @@ pub mod round_trips;
 mod auth_driver;
 pub use auth_driver::PgAuthDriver;
 
+pub mod catalogue_entry;
 pub mod paced_train;
 pub mod project;
 pub mod railjson;
@@ -18,6 +19,7 @@ pub mod rolling_stock_livery;
 pub mod scenario;
 pub mod stdcm_search_environment;
 pub mod study;
+pub mod train_schedule_set;
 
 pub use infra::Infra;
 pub use infra_objects::*;

--- a/editoast/src/models/train_schedule_set.rs
+++ b/editoast/src/models/train_schedule_set.rs
@@ -1,0 +1,13 @@
+use serde::Deserialize;
+use serde::Serialize;
+use utoipa::ToSchema;
+
+#[derive(Deserialize, Serialize, ToSchema)]
+pub struct TrainScheduleSet {
+    pub id: i64,
+    pub catalogue_entry_id: Option<i64>,
+    pub name: Option<String>,
+    pub description: String,
+    pub published: bool,
+    pub is_sandbox: bool,
+}

--- a/editoast/src/views/catalogue_entry.rs
+++ b/editoast/src/views/catalogue_entry.rs
@@ -1,0 +1,47 @@
+use database::DbConnectionPoolV2;
+use utoipa::ToSchema;
+
+use crate::error::Result;
+use crate::models::catalogue_entry::CatalogueEntry;
+use crate::views::AuthenticationExt;
+use crate::views::AuthorizationError;
+use axum::Extension;
+use axum::extract::Json;
+use axum::extract::State;
+use serde::Deserialize;
+use serde::Serialize;
+use std::sync::Arc;
+
+#[derive(Serialize, Deserialize, ToSchema)]
+pub(in crate::views) struct CatalogueEntryCreateForm {
+    name: Option<String>,
+}
+
+#[editoast_derive::route]
+#[utoipa::path(
+    post, path = "",
+    tag = "catalogue_entry",
+    request_body = CatalogueEntryCreateForm,
+    responses(
+        (status = 201, description = "Catalogue entry", body = CatalogueEntry),
+    ),
+)]
+pub(in crate::views) async fn post(
+    State(_db_pool): State<Arc<DbConnectionPoolV2>>,
+    Extension(auth): AuthenticationExt,
+    Json(catalogue_entry_create_form): Json<CatalogueEntryCreateForm>,
+) -> Result<Json<CatalogueEntry>> {
+    let authorized = auth
+        .check_roles([authz::Role::OperationalStudies].into())
+        .await
+        .map_err(AuthorizationError::AuthError)?;
+    if !authorized {
+        return Err(AuthorizationError::Forbidden.into());
+    }
+    // TODO: Add database operation to create a catalogue entry
+    let catalogue_entry = CatalogueEntry {
+        id: 0,
+        name: catalogue_entry_create_form.name,
+    };
+    Ok(Json(catalogue_entry))
+}

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -1,4 +1,5 @@
 mod authz;
+mod catalogue_entry;
 mod documents;
 pub mod electrical_profiles;
 pub mod fonts;
@@ -22,6 +23,7 @@ pub mod study;
 pub mod sub_categories;
 pub mod temporary_speed_limits;
 pub mod timetable;
+mod train_schedule_set;
 pub mod work_schedules;
 mod worker_load;
 
@@ -452,6 +454,15 @@ fn service_router() -> router::DocumentedRouter {
                             .route("/", put!(rolling_stock::towed::put_by_id))
                             .route("/locked", patch!(rolling_stock::towed::patch_by_id_locked))
                     })
+            })
+            //
+            // train schedule sets & catalogue entries
+            //
+            .nests("/train_schedule_set", |path| {
+                path.route("/", post!(train_schedule_set::post))
+            })
+            .nests("/catalogue_entry", |path| {
+                path.route("/", post!(catalogue_entry::post))
             })
     })
 }

--- a/editoast/src/views/train_schedule_set.rs
+++ b/editoast/src/views/train_schedule_set.rs
@@ -1,0 +1,65 @@
+use database::DbConnectionPoolV2;
+use utoipa::ToSchema;
+
+use crate::error::Result;
+use crate::models::train_schedule_set::TrainScheduleSet;
+use crate::views::AuthenticationExt;
+use crate::views::AuthorizationError;
+use axum::Extension;
+use axum::extract::Json;
+use axum::extract::State;
+use serde::Deserialize;
+use serde::Serialize;
+use std::sync::Arc;
+
+#[derive(Serialize, Deserialize, ToSchema)]
+pub(in crate::views) struct TrainScheduleSetResponse {
+    #[serde(flatten)]
+    train_schedule_set: TrainScheduleSet,
+    train_schedule_count: u64,
+}
+
+#[derive(Serialize, Deserialize, ToSchema)]
+pub(in crate::views) struct TrainScheduleSetCreateForm {
+    catalogue_entry_id: Option<i64>,
+    name: Option<String>,
+    description: String,
+    published: bool,
+}
+
+#[editoast_derive::route]
+#[utoipa::path(
+    post, path = "",
+    tag = "train_schedule_set",
+    request_body = TrainScheduleSetCreateForm,
+    responses(
+        (status = 201, description = "Train schedule set", body = TrainScheduleSetResponse),
+    ),
+)]
+pub(in crate::views) async fn post(
+    State(_db_pool): State<Arc<DbConnectionPoolV2>>,
+    Extension(auth): AuthenticationExt,
+    Json(train_schedule_set_create_form): Json<TrainScheduleSetCreateForm>,
+) -> Result<Json<TrainScheduleSetResponse>> {
+    let authorized = auth
+        .check_roles([authz::Role::OperationalStudies].into())
+        .await
+        .map_err(AuthorizationError::AuthError)?;
+    if !authorized {
+        return Err(AuthorizationError::Forbidden.into());
+    }
+    // TODO: Add database operation to create a train schedule set
+    let train_schedule_set_response = TrainScheduleSetResponse {
+        train_schedule_set: TrainScheduleSet {
+            id: 0,
+            catalogue_entry_id: train_schedule_set_create_form.catalogue_entry_id,
+            name: train_schedule_set_create_form.name,
+            description: train_schedule_set_create_form.description,
+            published: train_schedule_set_create_form.published,
+            is_sandbox: false,
+        },
+        train_schedule_count: 0,
+    };
+
+    Ok(Json(train_schedule_set_response))
+}

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -1,6 +1,7 @@
 import { baseEditoastApi as api } from './baseGeneratedApis';
 export const addTagTypes = [
   'authz',
+  'catalogue_entry',
   'documents',
   'electrical_profiles',
   'fonts',
@@ -27,6 +28,7 @@ export const addTagTypes = [
   'studies',
   'sub_categories',
   'temporary_speed_limits',
+  'train_schedule_set',
   'work_schedules',
   'worker',
 ] as const;
@@ -75,6 +77,14 @@ const injectedRtkApi = api
           },
         }),
         providesTags: ['authz'],
+      }),
+      postCatalogueEntry: build.mutation<PostCatalogueEntryApiResponse, PostCatalogueEntryApiArg>({
+        query: (queryArg) => ({
+          url: `/catalogue_entry`,
+          method: 'POST',
+          body: queryArg.catalogueEntryCreateForm,
+        }),
+        invalidatesTags: ['catalogue_entry'],
       }),
       postDocuments: build.mutation<PostDocumentsApiResponse, PostDocumentsApiArg>({
         query: (queryArg) => ({
@@ -1359,6 +1369,17 @@ const injectedRtkApi = api
         }),
         providesTags: ['train_schedule'],
       }),
+      postTrainScheduleSet: build.mutation<
+        PostTrainScheduleSetApiResponse,
+        PostTrainScheduleSetApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/train_schedule_set`,
+          method: 'POST',
+          body: queryArg.trainScheduleSetCreateForm,
+        }),
+        invalidatesTags: ['train_schedule_set'],
+      }),
       getVersion: build.query<GetVersionApiResponse, GetVersionApiArg>({
         query: () => ({ url: `/version` }),
       }),
@@ -1515,6 +1536,10 @@ export type GetAuthzByResourceTypeAndResourceIdApiArg = {
   resourceId: number;
   page?: number;
   pageSize?: number;
+};
+export type PostCatalogueEntryApiResponse = /** status 201 Catalogue entry */ CatalogueEntry;
+export type PostCatalogueEntryApiArg = {
+  catalogueEntryCreateForm: CatalogueEntryCreateForm;
 };
 export type PostDocumentsApiResponse =
   /** status 201 The document was created */ NewDocumentResponse;
@@ -2634,6 +2659,11 @@ export type GetTrainScheduleByIdSimulationApiArg = {
   infraId: number;
   electricalProfileSetId?: number;
 };
+export type PostTrainScheduleSetApiResponse =
+  /** status 201 Train schedule set */ TrainScheduleSetResponse;
+export type PostTrainScheduleSetApiArg = {
+  trainScheduleSetCreateForm: TrainScheduleSetCreateForm;
+};
 export type GetVersionApiResponse = /** status 200 Return the service version */ Version;
 export type GetVersionApiArg = void;
 export type PostWorkSchedulesApiResponse =
@@ -2751,6 +2781,13 @@ export type PaginationStats = {
   previous: number | null;
 };
 export type SubjectType = 'User' | 'Group';
+export type CatalogueEntry = {
+  id: number;
+  name?: string | null;
+};
+export type CatalogueEntryCreateForm = {
+  name?: string | null;
+};
 export type NewDocumentResponse = {
   document_key: number;
 };
@@ -4928,6 +4965,23 @@ export type TowedRollingStockLockedForm = {
 export type TrainScheduleForm = TrainSchedule & {
   /** Timetable attached to the train schedule */
   timetable_id?: number | null;
+};
+export type TrainScheduleSet = {
+  catalogue_entry_id?: number | null;
+  description: string;
+  id: number;
+  is_sandbox: boolean;
+  name?: string | null;
+  published: boolean;
+};
+export type TrainScheduleSetResponse = TrainScheduleSet & {
+  train_schedule_count: number;
+};
+export type TrainScheduleSetCreateForm = {
+  catalogue_entry_id?: number | null;
+  description: string;
+  name?: string | null;
+  published: boolean;
 };
 export type Version = {
   git_describe: string | null;


### PR DESCRIPTION
This PR allows the frontend to use the endpoint with fake data (part of #14254)
It also implement the skeleton of post endpoints (for `train_schedule_set` and `catalogue_entry`)