### PR TITLE
front: fix NGE node ID collision

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/osrdToNge.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/osrdToNge.ts
@@ -300,11 +300,11 @@ export const loadAndIndexNge = async (
   let nbNodesIndexed = 0;
   timetableItems
     .flatMap((timetableItem) => timetableItem.path)
-    .forEach((pathItem, index) => {
+    .forEach((pathItem) => {
       const key = MacroEditorState.getPathKey(pathItem.location);
       if (!state.getNodeByKey(key)) {
         const macroNode: NodeIndexed = {
-          ngeId: index,
+          ngeId: nbNodesIndexed,
           path_item_key: key,
           trigram:
             'operational_point' in pathItem.location &&


### PR DESCRIPTION
We insert new nodes in two spots: first we iterate over all path steps from all trains, then we grab saved macro nodes from the database. The first loop uses indices as NGE IDs, while the second loop uses a counter.

If some nodes were skipped by the first loop, the last path step index would be larger than the number of new nodes. This causes a collision: the second loop would use NGE IDs already used by the first loop.

Fix this by using a counter everywhere.

Closes: https://github.com/OpenRailAssociation/osrd/issues/13608
Fixes: ec6bdc82f17a ("front: keep lonely nodes in the Macro mode")