### PR TITLE
editoast: activate OpenTelemetry by default

### DIFF
--- a/editoast/src/client/telemetry_config.rs
+++ b/editoast/src/client/telemetry_config.rs
@@ -6,7 +6,7 @@ use url::Url;
 #[derive(Args, Debug, Educe, Clone)]
 #[educe(Default)]
 pub struct TelemetryConfig {
-    #[educe(Default = TelemetryKind::None)]
+    #[educe(Default = TelemetryKind::Opentelemetry)]
     #[clap(long, env, default_value_t)]
     pub telemetry_kind: TelemetryKind,
     #[educe(Default = "osrd-editoast".into())]
@@ -29,7 +29,7 @@ impl From<TelemetryConfig> for common::tracing::Telemetry {
 #[derive(Default, ValueEnum, Debug, Clone, strum::Display)]
 #[strum(serialize_all = "lowercase")]
 pub enum TelemetryKind {
-    #[default]
     None,
+    #[default]
     Opentelemetry,
 }


### PR DESCRIPTION
It happened a few times that developers lost time testing some telemetry functionality, forgetting that the telemetry is not activated by default. Let’s activate it by default. It’s still not failing the application if no service is up to receive the traces (something like Jaeger), it will only produce `ERROR` message which should help better understanding what is going on (compare to the current situation where nothing happen when telemetry is off, and therefore, it’s hard to debug).