### PR TITLE
core: remove TravelledPath type alias

### DIFF
--- a/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/EnvelopeSimContext.kt
+++ b/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/EnvelopeSimContext.kt
@@ -2,7 +2,7 @@ package fr.sncf.osrd.envelope_sim
 
 import com.google.common.collect.RangeMap
 import fr.sncf.osrd.path.interfaces.PhysicsPath
-import fr.sncf.osrd.path.interfaces.TravelledPath
+import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.utils.DistanceRangeSet
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
@@ -29,18 +29,18 @@ constructor(
          * List of switch and buffer stop offsets on the path, up to the first switch/buffer stop
          * *after* the end of the path (or right at the end).
          */
-        val dangerPointOffsets: List<Offset<TravelledPath>>,
+        val dangerPointOffsets: List<Offset<TrainPath>>,
         /**
          * List of block-delimiting detectors (block entry/exit) offsets for every ETCS-block on the
          * path. Starts at the start of the path, can end after the end of the path.
          */
-        val detectorOffsets: List<Offset<TravelledPath>>,
+        val detectorOffsets: List<Offset<TrainPath>>,
     ) {
         /**
          * Returns the next danger point location: next buffer stop or switch, whichever is closest.
          * If there is any.
          */
-        private fun getDangerPoint(offset: Offset<TravelledPath>): Offset<TravelledPath>? {
+        private fun getDangerPoint(offset: Offset<TrainPath>): Offset<TrainPath>? {
             return dangerPointOffsets.firstOrNull { it >= offset }
         }
 
@@ -51,14 +51,14 @@ constructor(
          * infrastructure, hence we'll be conservative and place the danger point on the EoA (stop
          * location or signal).
          */
-        fun getMandatoryDangerPoint(signalOffset: Offset<TravelledPath>): Offset<TravelledPath> {
+        fun getMandatoryDangerPoint(signalOffset: Offset<TrainPath>): Offset<TrainPath> {
             val dangerPoint = getDangerPoint(signalOffset)
             return if (dangerPoint == null || dangerPoint - signalOffset > 200.meters) signalOffset
             else dangerPoint
         }
 
         /** Returns the next ETCS detector location. */
-        fun getNextDetector(offset: Offset<TravelledPath>): Offset<TravelledPath>? {
+        fun getNextDetector(offset: Offset<TrainPath>): Offset<TrainPath>? {
             return detectorOffsets.firstOrNull { it >= offset }
         }
     }

--- a/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/ETCSBrakingSimulator.kt
+++ b/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/ETCSBrakingSimulator.kt
@@ -7,7 +7,7 @@ import fr.sncf.osrd.envelope_sim.EnvelopeSimContext
 import fr.sncf.osrd.envelope_sim.etcs.BrakingType.IND
 import fr.sncf.osrd.envelope_sim.etcs.BrakingType.PS
 import fr.sncf.osrd.envelope_sim.pipelines.increase
-import fr.sncf.osrd.path.interfaces.TravelledPath
+import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.utils.arePositionsEqual
 import fr.sncf.osrd.utils.units.Offset
@@ -71,7 +71,7 @@ interface ETCSBrakingSimulator {
      */
     fun computeEoaLocations(
         envelope: Envelope,
-        offsets: List<Offset<TravelledPath>>,
+        offsets: List<Offset<TrainPath>>,
         areSignalsOnOffsetsRestrictive: List<Boolean>,
         eoaType: EoaType,
     ): List<EndOfAuthority>
@@ -85,7 +85,7 @@ typealias EOABrakingCurves = NavigableMap<EndOfAuthority, BrakingCurves>
 
 data class BrakingCurve(val brakingType: BrakingType, val brakingCurve: Envelope)
 
-data class LimitOfAuthority(val offset: Offset<TravelledPath>, val speed: Double) :
+data class LimitOfAuthority(val offset: Offset<TrainPath>, val speed: Double) :
     Comparable<LimitOfAuthority> {
     init {
         assert(speed > 0)
@@ -98,8 +98,8 @@ data class LimitOfAuthority(val offset: Offset<TravelledPath>, val speed: Double
 }
 
 data class EndOfAuthority(
-    val offsetEOA: Offset<TravelledPath>,
-    val offsetSVL: Offset<TravelledPath>?,
+    val offsetEOA: Offset<TrainPath>,
+    val offsetSVL: Offset<TrainPath>?,
     val usedCurveType: BrakingType,
     val eoaType: EoaType = EoaType.STOP,
 ) : Comparable<EndOfAuthority> {
@@ -211,7 +211,7 @@ class ETCSBrakingSimulatorImpl(override val context: EnvelopeSimContext) : ETCSB
         val cursor = EnvelopeCursor.backward(mrsp)
         val limitsOfAuthority = mutableListOf<LimitOfAuthority>()
         while (cursor.findPartTransition(::increase)) {
-            val offset = Offset<TravelledPath>(cursor.position.meters)
+            val offset = Offset<TrainPath>(cursor.position.meters)
             if (etcsRanges.contains(offset.distance)) {
                 limitsOfAuthority.add(LimitOfAuthority(offset, cursor.speed))
             }
@@ -222,7 +222,7 @@ class ETCSBrakingSimulatorImpl(override val context: EnvelopeSimContext) : ETCSB
 
     override fun computeEoaLocations(
         envelope: Envelope,
-        offsets: List<Offset<TravelledPath>>,
+        offsets: List<Offset<TrainPath>>,
         areSignalsOnOffsetsRestrictive: List<Boolean>,
         eoaType: EoaType,
     ): List<EndOfAuthority> {
@@ -267,7 +267,7 @@ class ETCSBrakingSimulatorImpl(override val context: EnvelopeSimContext) : ETCSB
 
     /** Compute the EoA for a simple stop. */
     private fun computeStopEoA(
-        stopOffset: Offset<TravelledPath>,
+        stopOffset: Offset<TrainPath>,
         isStopOnClosedSignal: Boolean,
     ): EndOfAuthority {
         return if (isStopOnClosedSignal) {
@@ -291,7 +291,7 @@ class ETCSBrakingSimulatorImpl(override val context: EnvelopeSimContext) : ETCSB
 
     /** Compute the EoA for a spacing conflict on a signal. */
     private fun computeSpacingConflictEoa(
-        signalOffset: Offset<TravelledPath>,
+        signalOffset: Offset<TrainPath>,
         isRouteDelimiter: Boolean,
         endPos: Double,
     ): EndOfAuthority? {
@@ -322,7 +322,7 @@ class ETCSBrakingSimulatorImpl(override val context: EnvelopeSimContext) : ETCSB
 
     /** Compute the EoA for a routing conflict on a signal. */
     private fun computeRoutingConflictEoa(
-        signalOffset: Offset<TravelledPath>,
+        signalOffset: Offset<TrainPath>,
         isRouteDelimiter: Boolean,
     ): EndOfAuthority? {
         return if (isRouteDelimiter) {

--- a/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/pipelines/MaxSpeedEnvelope.kt
+++ b/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/pipelines/MaxSpeedEnvelope.kt
@@ -15,7 +15,7 @@ import fr.sncf.osrd.envelope_sim.etcs.ETCSBrakingSimulatorImpl
 import fr.sncf.osrd.envelope_sim.etcs.EndOfAuthority
 import fr.sncf.osrd.envelope_sim.etcs.EoaType
 import fr.sncf.osrd.envelope_sim.overlays.EnvelopeDeceleration
-import fr.sncf.osrd.path.interfaces.TravelledPath
+import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop
 import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Offset
@@ -30,7 +30,7 @@ import fr.sncf.osrd.utils.units.Offset
  * closed/open signal flag.
  */
 data class SimStop(
-    val offset: Offset<TravelledPath>,
+    val offset: Offset<TrainPath>,
     val rjsReceptionSignal: RJSTrainStop.RJSReceptionSignal,
 )
 
@@ -130,7 +130,7 @@ private fun addStopBrakingCurves(
 private fun addConstStopBrakingCurves(
     context: EnvelopeSimContext,
     curveWithDecelerations: Envelope,
-    stops: List<Offset<TravelledPath>>,
+    stops: List<Offset<TrainPath>>,
 ): Envelope {
     var envelope = curveWithDecelerations
     for (stop in stops) {

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/PathProperties.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/PathProperties.kt
@@ -9,13 +9,6 @@ import fr.sncf.osrd.utils.units.Offset
 
 data class TrackLocation(val trackId: TrackSectionId, val offset: Offset<TrackSection>)
 
-/**
- * A marker type for Length and Offset. In TravelledPath, start refers to the real start of the head
- * of the train.
- */
-// TODO path migration: remove TravelledPath entirely
-typealias TravelledPath = TrainPath
-
 @Suppress("INAPPLICABLE_JVM_NAME")
 interface PathProperties {
     fun getSlopes(): DistanceRangeMap<Double>
@@ -43,7 +36,7 @@ interface PathProperties {
 
     fun getLength(): Length<TrainPath>
 
-    fun getTrackLocationAtOffset(pathOffset: Offset<TravelledPath>): TrackLocation
+    fun getTrackLocationAtOffset(pathOffset: Offset<TrainPath>): TrackLocation
 
     fun <T> getRangeMapFromUndirected(
         getData: (chunkId: TrackChunkId) -> DistanceRangeMap<T>

--- a/core/src/main/kotlin/fr/sncf/osrd/api/CommonSchemas.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/CommonSchemas.kt
@@ -1,7 +1,7 @@
 package fr.sncf.osrd.api
 
 import com.squareup.moshi.Json
-import fr.sncf.osrd.path.interfaces.TravelledPath
+import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.railjson.schema.common.graph.EdgeDirection
 import fr.sncf.osrd.sim_infra.api.TrackSection
 import fr.sncf.osrd.utils.DistanceRangeMap
@@ -25,13 +25,13 @@ data class TrackRange(
 data class RangeValues<valueT>(
     // List of `n` internal boundaries of the ranges along the path (excluding start and end
     // bounds).
-    @Json(name = "boundaries") val internalBoundaries: List<Offset<TravelledPath>> = listOf(),
+    @Json(name = "boundaries") val internalBoundaries: List<Offset<TrainPath>> = listOf(),
     // List of `n+1` values associated to the bounded intervals
     val values: List<valueT> = listOf(),
 ) {
     fun toDistanceRangeMap(
-        beginPos: Offset<TravelledPath>,
-        endPos: Offset<TravelledPath>,
+        beginPos: Offset<TrainPath>,
+        endPos: Offset<TrainPath>,
     ): DistanceRangeMap<valueT> {
         val boundaries = internalBoundaries.toMutableList()
         boundaries.add(0, beginPos)
@@ -58,14 +58,14 @@ class TrackLocation(val track: String, val offset: Offset<TrackSection>)
 class ZoneUpdate(
     val zone: String,
     val time: TimeDelta,
-    val position: Offset<TravelledPath>,
+    val position: Offset<TrainPath>,
     @Json(name = "is_entry") val isEntry: Boolean,
 )
 
 class SignalCriticalPosition(
     val signal: String,
     val time: TimeDelta,
-    val position: Offset<TravelledPath>,
+    val position: Offset<TrainPath>,
     val state: String,
 )
 

--- a/core/src/main/kotlin/fr/sncf/osrd/api/etcs/ETCSBrakingCurvesEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/etcs/ETCSBrakingCurvesEndpoint.kt
@@ -15,7 +15,6 @@ import fr.sncf.osrd.envelope_sim.EnvelopeProfile
 import fr.sncf.osrd.envelope_sim.EnvelopeSimContext
 import fr.sncf.osrd.envelope_sim.etcs.*
 import fr.sncf.osrd.path.interfaces.TrainPath
-import fr.sncf.osrd.path.interfaces.TravelledPath
 import fr.sncf.osrd.signaling.etcs_level2.ETCS_LEVEL2
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.standalone_sim.buildSignalingRanges
@@ -139,7 +138,7 @@ class ETCSBrakingCurvesEndpoint(
     }
 
     private data class TravelledPathSignal(
-        val offset: Offset<TravelledPath>,
+        val offset: Offset<TrainPath>,
         val isRouteDelimiter: Boolean,
     ) : Comparable<TravelledPathSignal> {
         override fun compareTo(other: TravelledPathSignal): Int {
@@ -176,8 +175,8 @@ class ETCSBrakingCurvesEndpoint(
 
     private fun parseRawMrsp(
         rawMrsp: RangeValues<SpeedLimitProperty>,
-        endPos: Offset<TravelledPath>,
-        beginPos: Offset<TravelledPath> = Offset(Distance.ZERO),
+        endPos: Offset<TrainPath>,
+        beginPos: Offset<TrainPath> = Offset(Distance.ZERO),
     ): Envelope {
         val speedLimitDistanceRangeMap = rawMrsp.toDistanceRangeMap(beginPos, endPos)
         val mrspParts = mutableListOf<EnvelopePart>()

--- a/core/src/main/kotlin/fr/sncf/osrd/api/etcs/ETCSBrakingCurvesResponse.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/etcs/ETCSBrakingCurvesResponse.kt
@@ -5,7 +5,7 @@ import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import fr.sncf.osrd.conflicts.ConflictType
-import fr.sncf.osrd.path.interfaces.TravelledPath
+import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.utils.json.UnitAdapterFactory
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.TimeDelta
@@ -30,7 +30,7 @@ data class ETCSConflictCurves(
 )
 
 data class SimpleEnvelope(
-    val positions: List<Offset<TravelledPath>>,
+    val positions: List<Offset<TrainPath>>,
     val times: List<TimeDelta>, // Times are compared to the departure time
     val speeds: List<Double>,
 )

--- a/core/src/main/kotlin/fr/sncf/osrd/api/path_properties/PathPropResponse.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/path_properties/PathPropResponse.kt
@@ -6,7 +6,7 @@ import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import fr.sncf.osrd.api.RangeValues
-import fr.sncf.osrd.path.interfaces.TravelledPath
+import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.railjson.schema.geom.RJSLineString
 import fr.sncf.osrd.utils.json.UnitAdapterFactory
 import fr.sncf.osrd.utils.units.Offset
@@ -32,7 +32,7 @@ data class OperationalPointResponse(
     val id: String,
     val part: OperationalPointPartResponse,
     val extensions: OperationalPointExtensions?,
-    val position: Offset<TravelledPath>,
+    val position: Offset<TrainPath>,
     val weight: Long?,
 )
 

--- a/core/src/main/kotlin/fr/sncf/osrd/api/path_properties/PathPropResponseConverter.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/path_properties/PathPropResponseConverter.kt
@@ -3,7 +3,6 @@ package fr.sncf.osrd.api.path_properties
 import com.google.common.collect.Range
 import fr.sncf.osrd.api.RangeValues
 import fr.sncf.osrd.path.interfaces.TrainPath
-import fr.sncf.osrd.path.interfaces.TravelledPath
 import fr.sncf.osrd.railjson.schema.geom.RJSLineString
 import fr.sncf.osrd.sim_infra.api.NeutralSection
 import fr.sncf.osrd.sim_infra.api.RawSignalingInfra
@@ -118,7 +117,7 @@ private fun <T> makeRangeValues(distanceRangeMap: DistanceRangeMap<T>): RangeVal
 }
 
 private fun <T> makeRangeValues(entries: List<DistanceRangeMap.RangeMapEntry<T>>): RangeValues<T> {
-    val boundaries = mutableListOf<Offset<TravelledPath>>()
+    val boundaries = mutableListOf<Offset<TrainPath>>()
     val values = mutableListOf<T>()
     for (entry in entries) {
         boundaries.add(Offset(entry.upper))

--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlockResponse.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlockResponse.kt
@@ -8,7 +8,7 @@ import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import fr.sncf.osrd.api.DirectionalTrackRange
 import fr.sncf.osrd.path.interfaces.JsonTrainPath
-import fr.sncf.osrd.path.interfaces.TravelledPath
+import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.pathfinding.Pathfinding
 import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.utils.json.UnitAdapterFactory
@@ -20,10 +20,10 @@ interface PathfindingBlockResponse
 
 class PathfindingBlockSuccess(
     val path: JsonTrainPath,
-    val length: Length<TravelledPath>,
+    val length: Length<TrainPath>,
 
     /** Offsets of the waypoints given as input */
-    @Json(name = "path_item_positions") val pathItemPositions: List<Offset<TravelledPath>>,
+    @Json(name = "path_item_positions") val pathItemPositions: List<Offset<TrainPath>>,
 ) : PathfindingBlockResponse {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -43,12 +43,12 @@ class PathfindingBlockSuccess(
 
 class NotFoundInBlocks(
     @Json(name = "track_section_ranges") val trackSectionRanges: List<DirectionalTrackRange>,
-    val length: Length<TravelledPath>,
+    val length: Length<TrainPath>,
 ) : PathfindingBlockResponse
 
 class NotFoundInRoutes(
     @Json(name = "track_section_ranges") val trackSectionRanges: List<DirectionalTrackRange>,
-    val length: Length<TravelledPath>,
+    val length: Length<TrainPath>,
 ) : PathfindingBlockResponse
 
 class NotFoundInTracks : PathfindingBlockResponse
@@ -66,9 +66,9 @@ data class IncompatibleConstraints(
     val incompatibleSignalingSystemRanges: List<RangeValue<String>>,
 )
 
-data class RangeValue<T>(val range: Pathfinding.Range<TravelledPath>, val value: T?) {
+data class RangeValue<T>(val range: Pathfinding.Range<TrainPath>, val value: T?) {
     @FromJson
-    fun fromJson(range: Pathfinding.Range<TravelledPath>): RangeValue<T> {
+    fun fromJson(range: Pathfinding.Range<TrainPath>): RangeValue<T> {
         return RangeValue(range, null)
     }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/api/project_signals/SignalProjectionResponse.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/project_signals/SignalProjectionResponse.kt
@@ -4,7 +4,7 @@ import com.squareup.moshi.Json
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
-import fr.sncf.osrd.path.interfaces.TravelledPath
+import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.utils.json.UnitAdapterFactory
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.TimeDelta
@@ -18,8 +18,8 @@ class SignalUpdate(
     @Json(name = "signaling_system") val signalingSystem: String,
     @Json(name = "time_start") val timeStart: TimeDelta,
     @Json(name = "time_end") val timeEnd: TimeDelta,
-    @Json(name = "position_start") val positionStart: Offset<TravelledPath>,
-    @Json(name = "position_end") val positionEnd: Offset<TravelledPath>,
+    @Json(name = "position_start") val positionStart: Offset<TrainPath>,
+    @Json(name = "position_end") val positionEnd: Offset<TrainPath>,
     val color: Int,
     val blinking: Boolean,
     @Json(name = "aspect_label") val aspectLabel: String,

--- a/core/src/main/kotlin/fr/sncf/osrd/api/standalone_sim/SimulationRequest.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/standalone_sim/SimulationRequest.kt
@@ -4,7 +4,7 @@ import com.squareup.moshi.*
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import fr.sncf.osrd.api.RangeValues
 import fr.sncf.osrd.path.interfaces.JsonTrainPath
-import fr.sncf.osrd.path.interfaces.TravelledPath
+import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
 import fr.sncf.osrd.railjson.schema.rollingstock.RJSEffortCurves.RJSModeEffortCurve
 import fr.sncf.osrd.railjson.schema.rollingstock.RJSEtcsBrakeParams
@@ -32,7 +32,7 @@ class SimulationRequest(
     val options: TrainScheduleOptions,
     @Json(name = "physics_consist") val physicsConsist: PhysicsConsistModel,
     @Json(name = "electrical_profile_set_id") val electricalProfileSetId: String?,
-    @Json(name = "path_item_positions") val pathItemPositions: List<Offset<TravelledPath>>,
+    @Json(name = "path_item_positions") val pathItemPositions: List<Offset<TrainPath>>,
 ) {
     companion object {
         val adapter: JsonAdapter<SimulationRequest> =
@@ -82,7 +82,7 @@ class EffortCurve(
 )
 
 class SimulationScheduleItem(
-    @Json(name = "path_offset") val pathOffset: Offset<TravelledPath>,
+    @Json(name = "path_offset") val pathOffset: Offset<TrainPath>,
     val arrival: TimeDelta?,
     @Json(name = "stop_for") val stopFor: Duration?,
     @Json(name = "reception_signal") val receptionSignal: RJSReceptionSignal,
@@ -130,8 +130,8 @@ class MarginValueAdapter {
 }
 
 class SimulationPowerRestrictionItem(
-    val from: Offset<TravelledPath>,
-    val to: Offset<TravelledPath>,
+    val from: Offset<TrainPath>,
+    val to: Offset<TrainPath>,
     val value: String,
 )
 

--- a/core/src/main/kotlin/fr/sncf/osrd/api/standalone_sim/SimulationResponse.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/standalone_sim/SimulationResponse.kt
@@ -6,7 +6,7 @@ import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import fr.sncf.osrd.api.*
-import fr.sncf.osrd.path.interfaces.TravelledPath
+import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.sim_infra.api.SpeedLimitProperty
 import fr.sncf.osrd.sim_infra.api.SpeedLimitSource
@@ -40,7 +40,7 @@ sealed class ElectricalProfileValue {
 }
 
 class CompleteReportTrain(
-    positions: List<Offset<TravelledPath>>,
+    positions: List<Offset<TrainPath>>,
     times: List<TimeDelta>, // Times are compared to the departure time
     speeds: List<Double>,
     @Json(name = "energy_consumption") energyConsumption: Double,
@@ -53,7 +53,7 @@ class CompleteReportTrain(
 ) : ReportTrain(positions, times, speeds, energyConsumption, pathItemTimes)
 
 open class ReportTrain(
-    val positions: List<Offset<TravelledPath>>,
+    val positions: List<Offset<TrainPath>>,
     val times: List<TimeDelta>, // Times are compared to the departure time
     val speeds: List<Double>,
     @Json(name = "energy_consumption") val energyConsumption: Double,

--- a/core/src/main/kotlin/fr/sncf/osrd/conflicts/IncrementalRequirementEnvelopeAdapter.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/conflicts/IncrementalRequirementEnvelopeAdapter.kt
@@ -3,7 +3,7 @@ package fr.sncf.osrd.conflicts
 import fr.sncf.osrd.envelope.Envelope
 import fr.sncf.osrd.envelope.EnvelopeInterpolate
 import fr.sncf.osrd.envelope_sim.PhysicsRollingStock
-import fr.sncf.osrd.path.interfaces.TravelledPath
+import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import kotlin.math.max
@@ -22,8 +22,8 @@ class IncrementalRequirementEnvelopeAdapter(
     private val infiniteLastStop: Boolean = false,
 ) : IncrementalRequirementCallbacks {
     override fun maxSpeedInRange(
-        pathBeginOff: Offset<TravelledPath>,
-        pathEndOff: Offset<TravelledPath>,
+        pathBeginOff: Offset<TrainPath>,
+        pathEndOff: Offset<TrainPath>,
     ): Double {
         if (envelopeWithStops == null) {
             return Double.POSITIVE_INFINITY
@@ -39,7 +39,7 @@ class IncrementalRequirementEnvelopeAdapter(
         )
     }
 
-    override fun departureFromStop(stopOffset: Offset<TravelledPath>): Double {
+    override fun departureFromStop(stopOffset: Offset<TrainPath>): Double {
         if (envelopeWithStops == null) {
             return Double.POSITIVE_INFINITY
         }
@@ -66,8 +66,8 @@ class IncrementalRequirementEnvelopeAdapter(
     }
 
     override fun arrivalTimeInRange(
-        pathBeginOff: Offset<TravelledPath>,
-        pathEndOff: Offset<TravelledPath>,
+        pathBeginOff: Offset<TrainPath>,
+        pathEndOff: Offset<TrainPath>,
     ): Double {
         if (envelopeWithStops == null) return Double.POSITIVE_INFINITY
         // if the head of the train enters the zone at some point, use that
@@ -86,8 +86,8 @@ class IncrementalRequirementEnvelopeAdapter(
     }
 
     override fun departureTimeFromRange(
-        pathBeginOff: Offset<TravelledPath>,
-        pathEndOff: Offset<TravelledPath>,
+        pathBeginOff: Offset<TrainPath>,
+        pathEndOff: Offset<TrainPath>,
     ): Double {
         if (envelopeWithStops == null) return Double.POSITIVE_INFINITY
         val end = pathEndOff.meters
@@ -103,7 +103,7 @@ class IncrementalRequirementEnvelopeAdapter(
         get() = envelopeWithStops?.totalTime ?: 0.0
 
     override val currentPathOffset
-        get() = Offset<TravelledPath>(envelopeWithStops?.endPos?.meters ?: 0.meters)
+        get() = Offset<TrainPath>(envelopeWithStops?.endPos?.meters ?: 0.meters)
 
     override fun clone(): IncrementalRequirementCallbacks {
         return IncrementalRequirementEnvelopeAdapter(

--- a/core/src/main/kotlin/fr/sncf/osrd/conflicts/Resources.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/conflicts/Resources.kt
@@ -1,39 +1,33 @@
 package fr.sncf.osrd.conflicts
 
 import fr.sncf.osrd.envelope.Envelope
-import fr.sncf.osrd.path.interfaces.TravelledPath
+import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.utils.units.Offset
 
 interface IncrementalRequirementCallbacks {
     // if the train never arrives in range, +inf is returned
     // a range is used rather than a point to properly handle the train appearing and disappearing
-    fun arrivalTimeInRange(
-        pathBeginOff: Offset<TravelledPath>,
-        pathEndOff: Offset<TravelledPath>,
-    ): Double
+    fun arrivalTimeInRange(pathBeginOff: Offset<TrainPath>, pathEndOff: Offset<TrainPath>): Double
 
     // the departure time from a given location, which has to take into account train length.
     // this is used to compute zone occupancy. if the train never leaves a location, +inf is
     // returned
     fun departureTimeFromRange(
-        pathBeginOff: Offset<TravelledPath>,
-        pathEndOff: Offset<TravelledPath>,
+        pathBeginOff: Offset<TrainPath>,
+        pathEndOff: Offset<TrainPath>,
     ): Double
 
     val currentTime: Double
-    val currentPathOffset: Offset<TravelledPath>
+    val currentPathOffset: Offset<TrainPath>
 
     val simulationComplete: Boolean
 
     fun clone(): IncrementalRequirementCallbacks
 
-    fun maxSpeedInRange(
-        pathBeginOff: Offset<TravelledPath>,
-        pathEndOff: Offset<TravelledPath>,
-    ): Double
+    fun maxSpeedInRange(pathBeginOff: Offset<TrainPath>, pathEndOff: Offset<TrainPath>): Double
 
     // departure time from a given stop. if the train never gets to a stop, +inf is returned
-    fun departureFromStop(stopOffset: Offset<TravelledPath>): Double
+    fun departureFromStop(stopOffset: Offset<TrainPath>): Double
 
     fun getRawEnvelopeIfSingle(): Envelope?
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/signal_projection/SignalProjection.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/signal_projection/SignalProjection.kt
@@ -5,7 +5,6 @@ import fr.sncf.osrd.api.SignalCriticalPosition
 import fr.sncf.osrd.api.ZoneUpdate
 import fr.sncf.osrd.api.project_signals.SignalUpdate
 import fr.sncf.osrd.path.interfaces.TrainPath
-import fr.sncf.osrd.path.interfaces.TravelledPath
 import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.signaling.SigSystemManager
 import fr.sncf.osrd.signaling.SignalingSimulator
@@ -171,7 +170,7 @@ private fun signalUpdates(
     sigSystemManager: SigSystemManager,
     rawInfra: RawInfra,
     signalCriticalPositions: Collection<SignalCriticalPosition>,
-    travelledPathLength: Length<TravelledPath>,
+    travelledPathLength: Length<TrainPath>,
     simulationEndTime: TimeDelta,
 ): MutableList<SignalUpdate> {
     val signalUpdates = mutableListOf<SignalUpdate>()

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
@@ -19,7 +19,6 @@ import fr.sncf.osrd.envelope_sim.etcs.EoaType
 import fr.sncf.osrd.path.interfaces.BlockRange
 import fr.sncf.osrd.path.interfaces.RouteRange
 import fr.sncf.osrd.path.interfaces.TrainPath
-import fr.sncf.osrd.path.interfaces.TravelledPath
 import fr.sncf.osrd.signaling.SigSystemManager
 import fr.sncf.osrd.signaling.SignalingTrainState
 import fr.sncf.osrd.signaling.ZoneStatus
@@ -42,7 +41,7 @@ fun runScheduleMetadataExtractor(
     fullInfra: FullInfra,
     rollingStock: RollingStock,
     schedule: List<SimulationScheduleItem>,
-    pathItemPositions: List<Offset<TravelledPath>>,
+    pathItemPositions: List<Offset<TrainPath>>,
     context: EnvelopeSimContext? = null,
 ): CompleteReportTrain {
     assert(envelope.continuous)
@@ -174,7 +173,7 @@ fun runScheduleMetadataExtractor(
     )
 }
 
-fun getStopTravelledPathOffset(pathStops: List<PathStop>, indexStop: Int): Offset<TravelledPath>? {
+fun getStopTravelledPathOffset(pathStops: List<PathStop>, indexStop: Int): Offset<TrainPath>? {
     return pathStops.getOrNull(indexStop)?.pathOffset
 }
 
@@ -183,7 +182,7 @@ fun makeSimpleReportTrain(
     trainPath: TrainPath,
     rollingStock: RollingStock,
     schedule: List<SimulationScheduleItem>,
-    pathItemPositions: List<Offset<TravelledPath>>,
+    pathItemPositions: List<Offset<TrainPath>>,
 ): ReportTrain {
     // Compute energy consumed
     val mechanicalEnergyConsumed =
@@ -197,7 +196,7 @@ fun makeSimpleReportTrain(
     val envelopeStopWrapper = EnvelopeStopWrapper(envelope, stops)
 
     val pathItemTimes =
-        pathItemPositions.map { position: Offset<TravelledPath> ->
+        pathItemPositions.map { position: Offset<TrainPath> ->
             TimeDelta.fromSeconds(envelopeStopWrapper.interpolateArrivalAt(position.meters))
         }
 
@@ -366,7 +365,7 @@ private fun getRouteCriticalPos(
     signalingTrainStates: Map<LogicalSignalId, SignalingTrainState>,
     envelope: Envelope,
     etcsSimulator: ETCSBrakingSimulator?,
-): Offset<TravelledPath>? {
+): Offset<TrainPath>? {
     val blockInfra = fullInfra.blockInfra
     val simulator = fullInfra.signalingSimulator
 
@@ -393,7 +392,7 @@ private fun getEtcsRouteCriticalPos(
     firstBlockRange: BlockRange,
     envelope: Envelope,
     etcsSimulator: ETCSBrakingSimulator,
-): Offset<TravelledPath> {
+): Offset<TrainPath> {
 
     // The braking curve targets the entry signal of the route's first block
     val signalOffset =
@@ -428,7 +427,7 @@ private fun getSightRouteCriticalPos(
     trainPath: TrainPath,
     firstBlockRange: BlockRange,
     signalingTrainStates: Map<LogicalSignalId, SignalingTrainState>,
-): Offset<TravelledPath>? {
+): Offset<TrainPath>? {
     val simulator = fullInfra.signalingSimulator
     val rawInfra = fullInfra.rawInfra
     val loadedSignalInfra = fullInfra.loadedSignalInfra
@@ -539,7 +538,7 @@ private fun findLimitingSignal(
 
 data class ZoneOccupationChangeEvent(
     val time: TimeDelta,
-    val offset: Offset<TravelledPath>,
+    val offset: Offset<TrainPath>,
     val isEntry: Boolean,
     val zone: ZoneId,
 )
@@ -573,7 +572,7 @@ fun zoneOccupationChangeEvents(
 
 data class PathSignal(
     val signal: LogicalSignalId,
-    val pathOffset: Offset<TravelledPath>,
+    val pathOffset: Offset<TrainPath>,
     // when a signal is between blocks, prefer the index of the first block
     val minBlockPathIndex: Int,
 )

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulation.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulation.kt
@@ -24,7 +24,6 @@ import fr.sncf.osrd.envelope_sim.pipelines.maxSpeedEnvelopeFrom
 import fr.sncf.osrd.envelope_sim_infra.HasMissingSpeedTag
 import fr.sncf.osrd.envelope_sim_infra.computeMRSP
 import fr.sncf.osrd.path.interfaces.TrainPath
-import fr.sncf.osrd.path.interfaces.TravelledPath
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
 import fr.sncf.osrd.railjson.schema.schedule.RJSAllowanceDistribution
 import fr.sncf.osrd.reporting.exceptions.ErrorType.ZeroLengthPath
@@ -63,7 +62,7 @@ fun runStandaloneSimulation(
     schedule: List<SimulationScheduleItem>,
     initialSpeed: Double,
     margins: RangeValues<MarginValue>,
-    pathItemPositions: List<Offset<TravelledPath>>,
+    pathItemPositions: List<Offset<TrainPath>>,
     driverBehaviour: DriverBehaviour = DriverBehaviour(),
 ): SimulationSuccess {
     if (trainPath.getLength() == Offset.zero<TrainPath>()) throw OSRDError(ZeroLengthPath)
@@ -213,14 +212,14 @@ fun makeElectricalProfiles(
     }
 
     val boundaries =
-        profileMap.entries.map { Offset<TravelledPath>(it.key.upperEndpoint().meters) }.dropLast(1)
+        profileMap.entries.map { Offset<TrainPath>(it.key.upperEndpoint().meters) }.dropLast(1)
     val values = profileMap.values
 
     return RangeValues(internalBoundaries = boundaries, values = values.toList())
 }
 
 fun makeMRSPResponse(speedLimits: Envelope): RangeValues<SpeedLimitProperty> {
-    val internalBoundaries = mutableListOf<Offset<TravelledPath>>()
+    val internalBoundaries = mutableListOf<Offset<TrainPath>>()
     val sources = mutableListOf<SpeedLimitProperty>()
     for (part in speedLimits.stream()) {
         internalBoundaries.add(Offset(part.endPos.meters))
@@ -260,13 +259,13 @@ fun buildFinalEnvelope(
     allowanceType: RJSAllowanceDistribution,
     scheduledPoints: List<SimulationScheduleItem>,
 ): Envelope {
-    fun getEnvelopeTimeAt(offset: Offset<TravelledPath>): Double {
+    fun getEnvelopeTimeAt(offset: Offset<TrainPath>): Double {
         return provisionalEnvelope.interpolateDepartureFromClamp(offset.meters)
     }
-    fun getMaxEffortEnvelopeTimeAt(offset: Offset<TravelledPath>): Double {
+    fun getMaxEffortEnvelopeTimeAt(offset: Offset<TrainPath>): Double {
         return maxEffortEnvelope.interpolateDepartureFromClamp(offset.meters)
     }
-    var prevFixedPointOffset = Offset<TravelledPath>(0.meters)
+    var prevFixedPointOffset = Offset<TrainPath>(0.meters)
     var prevFixedPointDepartureTime = 0.0
     val marginRanges = mutableListOf<AllowanceRange>()
     for (point in scheduledPoints) {
@@ -325,7 +324,7 @@ fun buildFinalEnvelope(
         }
         prevFixedPointOffset = point.pathOffset
     }
-    val pathEnd = Offset<TravelledPath>(maxEffortEnvelope.endPos.meters)
+    val pathEnd = Offset<TrainPath>(maxEffortEnvelope.endPos.meters)
     if (prevFixedPointOffset < pathEnd) {
         // Because the last margin call is based on the max effort envelope,
         // we still need to cover all ranges to keep the standard margin,
@@ -362,8 +361,8 @@ fun distributeAllowance(
     provisionalEnvelope: Envelope,
     extraTime: Double,
     margins: RangeValues<MarginValue>,
-    startOffset: Offset<TravelledPath>,
-    endOffset: Offset<TravelledPath>,
+    startOffset: Offset<TrainPath>,
+    endOffset: Offset<TrainPath>,
 ): List<AllowanceRange> {
     assert(startOffset <= endOffset)
     if (startOffset == endOffset) {
@@ -372,8 +371,8 @@ fun distributeAllowance(
         return listOf()
     }
     fun rangeTime(
-        from: Offset<TravelledPath>,
-        to: Offset<TravelledPath>,
+        from: Offset<TrainPath>,
+        to: Offset<TrainPath>,
         envelope: Envelope = provisionalEnvelope,
     ): Double {
         assert(from < to)
@@ -416,7 +415,7 @@ fun buildProvisionalEnvelope(
 ): Envelope {
     val marginRanges = mutableListOf<AllowanceRange>()
     // Add path extremities to boundaries
-    val boundaries = mutableListOf<Offset<TravelledPath>>()
+    val boundaries = mutableListOf<Offset<TrainPath>>()
     boundaries.add(Offset(Distance.ZERO))
     boundaries.addAll(rawMargins.internalBoundaries)
     boundaries.add(Offset(Distance.fromMeters(context.path.length)))

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/etcsContextBuilder.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/etcsContextBuilder.kt
@@ -4,7 +4,6 @@ import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.envelope_sim.EnvelopeSimContext
 import fr.sncf.osrd.path.interfaces.DirChunkRange
 import fr.sncf.osrd.path.interfaces.TrainPath
-import fr.sncf.osrd.path.interfaces.TravelledPath
 import fr.sncf.osrd.signaling.etcs_level2.ETCS_LEVEL2
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.sim_infra.utils.getNextTrackSections
@@ -43,8 +42,8 @@ fun makeETCSContext(
  * May return any number of point beyond the end of the path, specifically any point covered by the
  * routes used by the path.
  */
-fun buildETCSDangerPoints(infra: RawInfra, trainPath: TrainPath): List<Offset<TravelledPath>> {
-    val res = mutableSetOf<Offset<TravelledPath>>()
+fun buildETCSDangerPoints(infra: RawInfra, trainPath: TrainPath): List<Offset<TrainPath>> {
+    val res = mutableSetOf<Offset<TrainPath>>()
     for (zonePathRange in trainPath.getZonePaths()) {
         val zonePath = zonePathRange.value
         val movableElements = infra.getZonePathMovableElements(zonePath)
@@ -83,7 +82,7 @@ private fun isETCSBlock(block: BlockId, infra: FullInfra): Boolean {
  * Find the last danger point, which may extend beyond the end of the path. Null if tracks are
  * circular with no switch nor buffer stop.
  */
-private fun findLastDangerPoint(infra: RawInfra, trainPath: TrainPath): Offset<TravelledPath>? {
+private fun findLastDangerPoint(infra: RawInfra, trainPath: TrainPath): Offset<TrainPath>? {
     // Find the offset of the last chunk on the path
     val chunkRanges = trainPath.getChunks()
     val lastChunkRange = chunkRanges.last()
@@ -112,7 +111,7 @@ private fun getEndOfLastTrackPathOffset(
     infra: RawInfra,
     lastTrack: TrackSectionId,
     lastChunkRange: DirChunkRange,
-): Offset<TravelledPath> {
+): Offset<TrainPath> {
     // Note: this function alone doesn't quite justify it,
     // but we could add a List<DirTrackRange> to TrainPath instead
     val dirLastChunk = lastChunkRange.value

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/PostProcessingSimulation.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/PostProcessingSimulation.kt
@@ -8,7 +8,6 @@ import fr.sncf.osrd.envelope_sim.allowances.LinearAllowance
 import fr.sncf.osrd.envelope_sim.allowances.MarecoAllowance
 import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.path.interfaces.TrainPath
-import fr.sncf.osrd.path.interfaces.TravelledPath
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
 import fr.sncf.osrd.reporting.exceptions.ErrorType
 import fr.sncf.osrd.reporting.exceptions.OSRDError
@@ -30,7 +29,7 @@ val postProcessingLogger: Logger = LoggerFactory.getLogger("postprocessing-STDCM
 
 private data class FixedTimePoint(
     val time: Double,
-    val offset: Offset<TravelledPath>,
+    val offset: Offset<TrainPath>,
     val stopTime: Double?,
 ) : Comparable<FixedTimePoint> {
     override fun compareTo(other: FixedTimePoint): Int {
@@ -73,9 +72,7 @@ fun buildFinalEnvelope(
     val fullInfraExplorer = edges.last().infraExplorerWithNewEnvelope
 
     val pathLength =
-        Length<TravelledPath>(
-            Distance(millimeters = edges.sumOf { it.length.distance.millimeters })
-        )
+        Length<TrainPath>(Distance(millimeters = edges.sumOf { it.length.distance.millimeters }))
     val allowanceRanges = getEngineeringAllowanceRanges(edges)
     assert(fullInfraExplorer.isPathComplete)
     val fixedPoints =
@@ -187,7 +184,7 @@ fun buildFinalEnvelope(
 private fun initFixedPoints(
     edges: List<STDCMEdge>,
     stops: List<TrainStop>,
-    length: Length<TravelledPath>,
+    length: Length<TrainPath>,
     hasStandardAllowance: Boolean,
     updatedTimeData: TimeData,
     allowanceRanges: List<EngineeringAllowanceRange>,
@@ -277,8 +274,8 @@ private fun getEngineeringAllowanceRanges(edges: List<STDCMEdge>): List<Engineer
 private fun makeFixedPoint(
     fixedPoints: TreeSet<FixedTimePoint>,
     edges: List<STDCMEdge>,
-    conflictOffset: Offset<TravelledPath>,
-    pathLength: Length<TravelledPath>,
+    conflictOffset: Offset<TrainPath>,
+    pathLength: Length<TrainPath>,
     updatedTimeData: TimeData,
     allowanceRanges: List<EngineeringAllowanceRange>,
     stopDuration: Double = 0.0,
@@ -325,10 +322,10 @@ private fun makeFixedPoint(
  */
 private fun roundOffset(
     edges: List<STDCMEdge>,
-    offset: Offset<TravelledPath>,
+    offset: Offset<TrainPath>,
     roundToEnd: Boolean,
-): Offset<TravelledPath> {
-    var prevEdgesLength = Offset<TravelledPath>(0.meters)
+): Offset<TrainPath> {
+    var prevEdgesLength = Offset<TrainPath>(0.meters)
     for (edge in edges) {
         if (offset <= prevEdgesLength + edge.length.distance) {
             return if (roundToEnd) prevEdgesLength + edge.length.distance else prevEdgesLength
@@ -346,7 +343,7 @@ private fun roundOffset(
  */
 private fun getTimeOnEdges(
     edges: List<STDCMEdge>,
-    offset: Offset<TravelledPath>,
+    offset: Offset<TrainPath>,
     updatedTimeData: TimeData,
 ): Double {
     var remainingDistance = offset.distance
@@ -374,7 +371,7 @@ private fun findConflictOffsets(
     blockAvailability: BlockAvailabilityInterface,
     edges: List<STDCMEdge>,
     updatedTimeData: TimeData,
-): Offset<TravelledPath>? {
+): Offset<TrainPath>? {
     val explorer = getUpdatedExplorer(edges, envelope, updatedTimeData)
     val availability =
         blockAvailability.getAvailability(
@@ -470,7 +467,7 @@ private fun handlePostProcessingConflict(
     stops: List<TrainStop>,
     updatedTimeData: TimeData,
     fixedPoints: TreeSet<FixedTimePoint>,
-    conflictOffset: Offset<TravelledPath>,
+    conflictOffset: Offset<TrainPath>,
     isMareco: Boolean,
 ): Envelope {
     postProcessingLogger.error(

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMSimulations.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMSimulations.kt
@@ -14,7 +14,7 @@ import fr.sncf.osrd.envelope_sim.pipelines.SimStop
 import fr.sncf.osrd.envelope_sim.pipelines.maxEffortEnvelopeFrom
 import fr.sncf.osrd.envelope_sim.pipelines.maxSpeedEnvelopeFrom
 import fr.sncf.osrd.envelope_sim_infra.computeMRSP
-import fr.sncf.osrd.path.interfaces.TravelledPath
+import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
 import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal
 import fr.sncf.osrd.reporting.exceptions.OSRDError
@@ -97,7 +97,7 @@ class STDCMSimulations {
         var stops = emptyList<SimStop>()
         var simLength = blockLength.distance - start.distance
         if (stopPosition != null) {
-            val stopOffset = Offset<TravelledPath>(stopPosition - start)
+            val stopOffset = Offset<TrainPath>(stopPosition - start)
             // We presently consider all stdcm stops to be performed on closed signal by default
             // This presently only affects ETCS computations, which are not yet supported in stdcm
             // either

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelope.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelope.kt
@@ -8,7 +8,6 @@ import fr.sncf.osrd.envelope.EnvelopeTimeInterpolate
 import fr.sncf.osrd.envelope_sim.PhysicsRollingStock
 import fr.sncf.osrd.graph.PathfindingConstraint
 import fr.sncf.osrd.path.interfaces.TrainPath
-import fr.sncf.osrd.path.interfaces.TravelledPath
 import fr.sncf.osrd.pathfinding.Pathfinding.EdgeLocation
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockId
@@ -63,7 +62,7 @@ interface InfraExplorerWithEnvelope : InfraExplorer {
     fun getFullSpacingRequirements(): List<SpacingRequirement>
 
     /** Returns the length of the simulated section of the path */
-    fun getSimulatedLength(): Length<TravelledPath>
+    fun getSimulatedLength(): Length<TrainPath>
 
     /**
      * Generate a list of reached train stops, mostly for debugging purposes. Lookahead isn't

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelopeImpl.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelopeImpl.kt
@@ -9,7 +9,6 @@ import fr.sncf.osrd.envelope.EnvelopeConcat.LocatedEnvelopeInterpolate
 import fr.sncf.osrd.envelope.EnvelopeInterpolate
 import fr.sncf.osrd.envelope_sim.PhysicsRollingStock
 import fr.sncf.osrd.path.interfaces.TrainPath
-import fr.sncf.osrd.path.interfaces.TravelledPath
 import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal.SHORT_SLIP_STOP
 import fr.sncf.osrd.standalone_sim.EnvelopeStopWrapper
 import fr.sncf.osrd.stdcm.graph.StopTimeData
@@ -184,7 +183,7 @@ data class InfraExplorerWithEnvelopeImpl(
         return this
     }
 
-    override fun getSimulatedLength(): Length<TravelledPath> {
+    override fun getSimulatedLength(): Length<TrainPath> {
         if (envelopes.isEmpty()) return Length(0.meters)
         val lastEnvelope = envelopes[envelopes.size - 1]
         return Length(Distance.fromMeters(lastEnvelope.startOffset + lastEnvelope.envelope.endPos))

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/StepTracker.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/StepTracker.kt
@@ -1,6 +1,6 @@
 package fr.sncf.osrd.stdcm.infra_exploration
 
-import fr.sncf.osrd.path.interfaces.TravelledPath
+import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.pathfinding.Pathfinding.EdgeLocation
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockId
@@ -32,7 +32,7 @@ class StepTracker(
         private set
 
     // Used to compute path offsets
-    private var currentPathOffset: Offset<TravelledPath> = Offset.zero()
+    private var currentPathOffset: Offset<TrainPath> = Offset.zero()
 
     /** Returns all the steps that have been passed on the path, in order. */
     fun getSeenSteps(): List<LocatedStep> {
@@ -62,7 +62,7 @@ class StepTracker(
     ): List<LocatedStep> {
         val res = mutableListOf<LocatedStep>()
 
-        val currentBlockStart: Offset<TravelledPath> = currentPathOffset - rangeStart.distance
+        val currentBlockStart: Offset<TrainPath> = currentPathOffset - rangeStart.distance
         for (step in inputSteps.dropSeq(nSeenSteps)) {
             val currentPathBlockOffset = Offset<Block>(currentPathOffset - currentBlockStart)
             val location =
@@ -117,7 +117,7 @@ class StepTracker(
 }
 
 data class LocatedStep(
-    val travelledPathOffset: Offset<TravelledPath>,
+    val travelledPathOffset: Offset<TrainPath>,
     val location: EdgeLocation<BlockId, Block>,
     val originalStep: STDCMStep,
     val isPlanned: Boolean = true, // Set to false for overtakes (when implemented)

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/implementation/BlockAvailability.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/implementation/BlockAvailability.kt
@@ -6,7 +6,6 @@ import com.google.common.collect.TreeRangeSet
 import fr.sncf.osrd.conflicts.*
 import fr.sncf.osrd.envelope_utils.DoubleBinarySearch
 import fr.sncf.osrd.path.interfaces.TrainPath
-import fr.sncf.osrd.path.interfaces.TravelledPath
 import fr.sncf.osrd.sim_infra.api.ZoneId
 import fr.sncf.osrd.standalone_sim.CLOSED_SIGNAL_RESERVATION_MARGIN
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
@@ -34,7 +33,7 @@ data class BlockAvailability(
         startTime: Double,
     ): BlockAvailabilityInterface.Availability {
         var timeShift = 0.0
-        var firstConflictOffset: Offset<TravelledPath>? = null
+        var firstConflictOffset: Offset<TrainPath>? = null
         while (timeShift.isFinite()) {
             val shiftedStartTime = startTime + timeShift
             val pathStartTime =
@@ -99,7 +98,7 @@ data class BlockAvailability(
         pathStartTime: Double,
     ): BlockAvailabilityInterface.Availability {
         var minimumDelayToBecomeAvailable = 0.0
-        var firstUnavailabilityOffset = Offset<TravelledPath>(Double.POSITIVE_INFINITY.meters)
+        var firstUnavailabilityOffset = Offset<TrainPath>(Double.POSITIVE_INFINITY.meters)
         var maximumDelayToStayAvailable = Double.POSITIVE_INFINITY
         var timeOfNextUnavailability = Double.POSITIVE_INFINITY
 
@@ -306,7 +305,7 @@ data class BlockAvailability(
     private fun getEnvelopeOffsetFromTime(
         explorer: InfraExplorerWithEnvelope,
         time: Double,
-    ): Offset<TravelledPath> {
+    ): Offset<TrainPath> {
         if (time < 0.0) return Offset(0.meters)
         val envelope = explorer.getFullEnvelope()
         if (time > envelope.totalTime) return explorer.getSimulatedLength()
@@ -328,7 +327,7 @@ private data class AvailabilityProperties(
     // available
     val minimumDelayToBecomeAvailable: Double,
     // If a resource is unavailable, offset of that resource
-    val firstUnavailabilityOffset: Offset<TravelledPath>,
+    val firstUnavailabilityOffset: Offset<TrainPath>,
     // If everything is available, maximum delay that can be added to the train without a resource
     // becoming unavailable
     val maximumDelayToStayAvailable: Double,

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/interfaces/BlockAvailabilityInterface.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/interfaces/BlockAvailabilityInterface.kt
@@ -1,7 +1,6 @@
 package fr.sncf.osrd.stdcm.preprocessing.interfaces
 
 import fr.sncf.osrd.path.interfaces.TrainPath
-import fr.sncf.osrd.path.interfaces.TravelledPath
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
 import fr.sncf.osrd.utils.units.Offset
 
@@ -72,7 +71,7 @@ interface BlockAvailabilityInterface {
          * It's either the offset where we start using a resource before it's available, or the
          * offset where the train would have released a resource it has kept for too long.
          */
-        val firstConflictOffset: Offset<TravelledPath>,
+        val firstConflictOffset: Offset<TrainPath>,
     ) : Availability()
 
     /**

--- a/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingElectrificationTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingElectrificationTest.kt
@@ -5,7 +5,7 @@ import fr.sncf.osrd.api.TrackLocation
 import fr.sncf.osrd.api.pathfinding.IncompatibleConstraintsPathResponse
 import fr.sncf.osrd.api.pathfinding.NoPathFoundException
 import fr.sncf.osrd.api.pathfinding.runPathfinding
-import fr.sncf.osrd.path.interfaces.TravelledPath
+import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.railjson.schema.common.graph.ApplicableDirection
 import fr.sncf.osrd.railjson.schema.infra.RJSTrackSection
 import fr.sncf.osrd.railjson.schema.infra.trackranges.RJSApplicableDirectionsTrackRange
@@ -278,8 +278,8 @@ class PathfindingElectrificationTest : ApiTest() {
                 assert(resp.relaxedConstraintsPath.length.distance == 39_553.meters)
                 val incompElec =
                     resp.incompatibleConstraints.incompatibleElectrificationRanges.single()
-                assert(incompElec.range.start == Offset<TravelledPath>(0.meters))
-                assert(incompElec.range.end == Offset<TravelledPath>(39_553.meters))
+                assert(incompElec.range.start == Offset<TrainPath>(0.meters))
+                assert(incompElec.range.end == Offset<TrainPath>(39_553.meters))
                 assert(incompElec.value == "")
             })
     }

--- a/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingTest.kt
@@ -5,7 +5,7 @@ import fr.sncf.osrd.api.TrackLocation
 import fr.sncf.osrd.api.pathfinding.*
 import fr.sncf.osrd.cli.RqFake
 import fr.sncf.osrd.path.interfaces.JsonTrainPath.TrackSectionRange
-import fr.sncf.osrd.path.interfaces.TravelledPath
+import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.railjson.schema.common.graph.EdgeDirection
 import fr.sncf.osrd.railjson.schema.infra.trackranges.RJSLoadingGaugeLimit
 import fr.sncf.osrd.railjson.schema.rollingstock.RJSLoadingGaugeType
@@ -49,14 +49,14 @@ fun checkPathfindingSuccess(
     expectedTrackSectionRanges: List<TrackSectionRange>? = null,
     expectedBlocks: List<String>? = null,
     expectedRoutes: List<String>? = null,
-    expectedIntermediatePathItemPosition: List<Offset<TravelledPath>> = listOf(),
+    expectedIntermediatePathItemPosition: List<Offset<TrainPath>> = listOf(),
 ): PathfindingBlockSuccess {
     assertThat(pathResp).isExactlyInstanceOf(PathfindingBlockSuccess::class.java)
     val pathSuccess = pathResp as PathfindingBlockSuccess
 
     AssertionsForClassTypes.assertThat(pathSuccess.length.distance).isEqualTo(expectedLength)
     val expectedPathItemsPos =
-        listOf(Offset<TravelledPath>(0.meters))
+        listOf(Offset<TrainPath>(0.meters))
             .plus(expectedIntermediatePathItemPosition)
             .plusElement(Offset(pathSuccess.length.distance))
     assertEquals(expectedPathItemsPos, pathSuccess.pathItemPositions)

--- a/core/src/test/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulationTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulationTest.kt
@@ -13,7 +13,7 @@ import fr.sncf.osrd.envelope_sim.pipelines.maxEffortEnvelopeFrom
 import fr.sncf.osrd.envelope_sim.pipelines.maxSpeedEnvelopeFrom
 import fr.sncf.osrd.envelope_sim_infra.computeMRSP
 import fr.sncf.osrd.path.implementations.buildTrainPathFromBlocks
-import fr.sncf.osrd.path.interfaces.TravelledPath
+import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
 import fr.sncf.osrd.railjson.schema.schedule.RJSAllowanceDistribution
 import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal.OPEN
@@ -254,7 +254,7 @@ class StandaloneSimulationTest {
         }
 
         // Test margin values
-        val boundaries = mutableListOf<Offset<TravelledPath>>()
+        val boundaries = mutableListOf<Offset<TrainPath>>()
         boundaries.add(Offset(Distance.ZERO))
         boundaries.addAll(testCase.margins.internalBoundaries)
         boundaries.add(Offset(testCase.pathLength))
@@ -471,7 +471,7 @@ class StandaloneSimulationTest {
      * Returns the time at which the given offset is reached, interpolating linearly between points.
      */
     private fun getTimeAt(
-        offset: Offset<TravelledPath>,
+        offset: Offset<TrainPath>,
         train: ReportTrain,
         interpolateRight: Boolean,
     ): Double {
@@ -482,8 +482,8 @@ class StandaloneSimulationTest {
      * Returns the time at which the given offset is reached, interpolating linearly between points.
      */
     private fun getTimeAt(
-        offset: Offset<TravelledPath>,
-        positions: List<Offset<TravelledPath>>,
+        offset: Offset<TrainPath>,
+        positions: List<Offset<TrainPath>>,
         times: List<TimeDelta>,
         interpolateRight: Boolean,
     ): Double {


### PR DESCRIPTION
To be merged after https://github.com/OpenRailAssociation/osrd/pull/14369

This is fully automated, with the global renaming of `TravelledPath` into `TrainPath`, followed by the deletion of the type alias. 