### PR TITLE
github: configure dependabot and labeler for `railway_manager_interface`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -155,3 +155,15 @@ updates:
     labels:
       - "dependencies"
       - "area:ci"
+  - package-ecosystem: "uv"
+    directory: "/railway_manager_interface/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 5
+    commit-message:
+      prefix: "railway_manager_interface:"
+    open-pull-requests-limit: 0
+    labels:
+      - "dependencies"
+      - "area:railway-manager-interface"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -34,6 +34,10 @@
   - any:
       - changed-files:
           - any-glob-to-any-file: "chart/**"
+"area:railway-manager-interface":
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: "railway_manager_interface/**"
 "kind:api-change":
   - any:
       - changed-files:


### PR DESCRIPTION
This PR sets up dependabot and the github labeler for the `railway_manager_interface` project
Closes https://github.com/OpenRailAssociation/osrd/issues/14101