### PR TITLE
core: fix error when missing traction in engineering allowances

### DIFF
--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/overlays/EnvelopeAcceleration.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/overlays/EnvelopeAcceleration.java
@@ -4,6 +4,8 @@ import fr.sncf.osrd.envelope.part.InteractiveEnvelopePartConsumer;
 import fr.sncf.osrd.envelope_sim.Action;
 import fr.sncf.osrd.envelope_sim.EnvelopeSimContext;
 import fr.sncf.osrd.envelope_sim.TrainPhysicsIntegrator;
+import fr.sncf.osrd.reporting.exceptions.ErrorType;
+import fr.sncf.osrd.reporting.exceptions.OSRDError;
 
 public class EnvelopeAcceleration {
     /** Accelerate, storing the resulting steps into consumer */
@@ -22,7 +24,7 @@ public class EnvelopeAcceleration {
             position += step.positionDelta;
             speed = step.endSpeed;
             if (!consumer.addStep(position, speed, step.timeDelta)) break;
-            assert (step.positionDelta != 0.0);
+            if (step.positionDelta == 0.0) throw new OSRDError(ErrorType.ImpossibleSimulationError);
         }
     }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/engineering_allowance/EngineeringAllowanceManager.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/engineering_allowance/EngineeringAllowanceManager.kt
@@ -96,7 +96,7 @@ class EngineeringAllowanceManager(
         val cachedSegments = backwardsSegments.cacheable()
         for ((i, segment) in cachedSegments.withIndex()) {
             val (newBeginSpeed, newTravelTime) =
-                segment.computeAccelSequenceFromEndSpeed(currentSpeed)
+                segment.computeAccelSequenceFromEndSpeed(currentSpeed) ?: break
 
             val travelTimeDiff = max(0.0, newTravelTime - segment.travelTime)
             currentAddedDelay += travelTimeDiff

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/engineering_allowance/SimulationSegment.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/engineering_allowance/SimulationSegment.kt
@@ -9,6 +9,8 @@ import fr.sncf.osrd.envelope.part.constraints.SpeedConstraint
 import fr.sncf.osrd.envelope_sim.EnvelopeProfile
 import fr.sncf.osrd.envelope_sim.overlays.EnvelopeAcceleration
 import fr.sncf.osrd.path.interfaces.TrainPath
+import fr.sncf.osrd.reporting.exceptions.ErrorType
+import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.stdcm.graph.STDCMEdge
 import fr.sncf.osrd.stdcm.graph.STDCMGraph
 import fr.sncf.osrd.utils.units.Distance
@@ -26,7 +28,7 @@ data class SimulationSegment(
     val maxAddedDelay: Double,
     // Function to compute an acceleration over this segment. Can be dummy values for tests,
     // wrap a full simulation pipeline in normal processing.
-    val computeAccelSequenceFromEndSpeed: (Double) -> SummarizedSimulationResult,
+    val computeAccelSequenceFromEndSpeed: (Double) -> SummarizedSimulationResult?,
 ) {
     init {
         positive(beginTime)
@@ -109,7 +111,7 @@ private fun computeAcceleration(
     pathProperties: TrainPath,
     endSpeed: Double,
     graph: STDCMGraph,
-): SummarizedSimulationResult {
+): SummarizedSimulationResult? {
     // TODO: we could look into using const accelerations here as well instead of using
     // envelopes. We'd need to estimate the max slope for each segment.
     // It's a performance / accuracy tradeoff.
@@ -133,13 +135,18 @@ private fun computeAcceleration(
             SpeedConstraint(0.0, EnvelopePartConstraintType.FLOOR),
             PositionConstraint(0.0, pathProperties.getLength().meters),
         )
-    EnvelopeAcceleration.accelerate(
-        context,
-        pathProperties.getLength().meters,
-        endSpeed,
-        overlayBuilder,
-        -1.0,
-    )
+    try {
+        EnvelopeAcceleration.accelerate(
+            context,
+            pathProperties.getLength().meters,
+            endSpeed,
+            overlayBuilder,
+            -1.0,
+        )
+    } catch (e: OSRDError) {
+        if (e.osrdErrorType == ErrorType.ImpossibleSimulationError) return null
+        throw e
+    }
     val speedupPart = speedupPartBuilder.build()
     val envelope = Envelope.make(speedupPart)
     val newTime = scaleAllowanceTime(graph, envelope.totalTime, pathProperties.getLength().distance)


### PR DESCRIPTION
I encountered this error on a few paths across France. We don't have enough traction to compute the "speedup" part of the engineering allowances, and that causes errors. Dismissing the faulty path can lead to actual results. 

I tried to reproduce it in a unit test but I didn't manage to, it seems to rely on extremely specific gradient and allowance configurations. 