### PR TITLE
front: init new timesStopTable

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -30,6 +30,7 @@
         "@rjsf/validator-ajv8": "^6.1.2",
         "@sdziadkowiec/react-datasheet-grid": "^4.12.3",
         "@sncf/bootstrap-sncf.metier.reseau": "^4.3.1-r6-beta4",
+        "@tanstack/react-table": "^8.21.3",
         "@turf/along": "^7.3.1",
         "@turf/bbox": "^7.3.1",
         "@turf/bbox-clip": "^7.3.1",
@@ -5698,6 +5699,26 @@
         "tailwindcss": "4.1.18"
       }
     },
+    "node_modules/@tanstack/react-table": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
+      "integrity": "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/table-core": "8.21.3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
     "node_modules/@tanstack/react-virtual": {
       "version": "3.13.12",
       "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.12.tgz",
@@ -5712,6 +5733,19 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/table-core": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
+      "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tanstack/virtual-core": {
@@ -13259,6 +13293,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/front/package.json
+++ b/front/package.json
@@ -26,6 +26,7 @@
     "@rjsf/validator-ajv8": "^6.1.2",
     "@sdziadkowiec/react-datasheet-grid": "^4.12.3",
     "@sncf/bootstrap-sncf.metier.reseau": "^4.3.1-r6-beta4",
+    "@tanstack/react-table": "^8.21.3",
     "@turf/along": "^7.3.1",
     "@turf/bbox": "^7.3.1",
     "@turf/bbox-clip": "^7.3.1",

--- a/front/public/locales/en/translation.json
+++ b/front/public/locales/en/translation.json
@@ -666,6 +666,7 @@
     "languages": "Languages",
     "safeWord": "Safety keyword",
     "safeWordHelp": "The \"security keyword\" allows you to transparently filter the list of projects with the word you enter, used as a label. Choose a complicated word so that no-one uses it inadvertently. Add it as a label to a project; it will be automatically added when the project is created if the word is entered here.",
+    "useNewTimesStopsTable": "Use the new timetable",
     "userSettings": "User settings",
     "yourSafeWord": "Type in your word"
   },

--- a/front/public/locales/fr/translation.json
+++ b/front/public/locales/fr/translation.json
@@ -666,6 +666,7 @@
     "languages": "Langues",
     "safeWord": "Mot clé de sécurité",
     "safeWordHelp": "Le « mot-clé de sécurité » permet de filtrer de manière transparente la liste des projets avec le mot renseigné, utilisé comme une étiquette. Préférez un mot compliqué dans l'idée que personne ne l'utilise par inadvertance. Ajoutez-le comme une étiquette à un projet ; il sera automatiquement ajouté à la création de projet si le mot est renseigné ici.",
+    "useNewTimesStopsTable": "Utiliser le nouveau tableau horaire",
     "userSettings": "Paramètres utilisateur",
     "yourSafeWord": "Tapez votre mot"
   },

--- a/front/src/common/NavBar/UserSettings.tsx
+++ b/front/src/common/NavBar/UserSettings.tsx
@@ -15,6 +15,7 @@ import useAuthz from 'common/authorization/hooks/useAuthz';
 import InputSNCF from 'common/BootstrapSNCF/InputSNCF';
 import { ModalBodySNCF, ModalHeaderSNCF } from 'common/BootstrapSNCF/ModalSNCF';
 import { ModalContext } from 'common/BootstrapSNCF/ModalSNCF/ModalProvider';
+import SwitchSNCF, { SWITCH_TYPES } from 'common/BootstrapSNCF/SwitchSNCF';
 import { updateUserPreferences } from 'reducers/user';
 import { getUserPreferences } from 'reducers/user/userSelectors';
 import { useAppDispatch } from 'store';
@@ -104,6 +105,23 @@ const UserSettings = () => {
         <small id="safeWordHelpBlock" className="form-text text-muted">
           {t('nav-bar.safeWordHelp')}
         </small>
+        <div className="d-flex align-items-center mt-4">
+          <span className="mr-3">{t('nav-bar.useNewTimesStopsTable')}</span>
+          <SwitchSNCF
+            id="useNewTimesStopsTable"
+            type={SWITCH_TYPES.switch}
+            name="useNewTimesStopsTable"
+            onChange={() =>
+              dispatch(
+                updateUserPreferences({
+                  ...userPreferences,
+                  useNewTimesStopsTable: !userPreferences.useNewTimesStopsTable,
+                })
+              )
+            }
+            checked={userPreferences.useNewTimesStopsTable}
+          />
+        </div>
         {isSuperUser && !impersonatedUser && (
           <>
             <div className="font-weight-medium mb-2 mt-2">{t('nav-bar.impersonation')}</div>

--- a/front/src/modules/timesStops/TimesStopsOutput.tsx
+++ b/front/src/modules/timesStops/TimesStopsOutput.tsx
@@ -16,7 +16,7 @@ import { TableType, type TimesStopsRow } from './types';
 type TimesStopsOutputProps = {
   infraId: number;
   isValid: boolean;
-  selectedTrain?: Train;
+  selectedTrain: Train;
   simulatedTrain?: SimulationResponseSuccess['final_output'];
   simulatedPath?: CorePathfindingResultSuccess;
   simulatedPathItemTimes?: Extract<SimulationSummary, { isValid: true }>['pathItemTimes'];

--- a/front/src/modules/timesStops/TimesStopsOutput.tsx
+++ b/front/src/modules/timesStops/TimesStopsOutput.tsx
@@ -1,4 +1,5 @@
 import cx from 'classnames';
+import { useSelector } from 'react-redux';
 
 import type { PathPropertiesFormatted } from 'applications/operationalStudies/types';
 import type {
@@ -7,10 +8,13 @@ import type {
 } from 'common/api/osrdEditoastApi';
 import type { SimulationSummary } from 'modules/timetableItem/types';
 import type { Train } from 'reducers/osrdconf/types';
+import { getUseNewTimesStopsTable } from 'reducers/user/userSelectors';
 import { formatLocalTime } from 'utils/date';
 
 import useOutputTableData from './hooks/useOutputTableData';
+import useTimesStopsTableData from './hooks/useTimesStopsTableData';
 import TimesStops from './TimesStops';
+import TimesStopsTable from './TimesStopsTable';
 import { TableType, type TimesStopsRow } from './types';
 
 type TimesStopsOutputProps = {
@@ -31,17 +35,34 @@ const TimesStopsOutput = ({
   simulatedPathItemTimes,
   operationalPointsOnPath,
 }: TimesStopsOutputProps) => {
-  const rows = useOutputTableData(
+  const useNewTimesStopsTable = useSelector(getUseNewTimesStopsTable);
+
+  // Only call the hook that corresponds to the active table to avoid unnecessary computation
+  const legacyRows = useOutputTableData(
+    infraId,
+    isValid,
+    useNewTimesStopsTable ? undefined : selectedTrain,
+    useNewTimesStopsTable ? undefined : simulatedTrain,
+    useNewTimesStopsTable ? undefined : simulatedPathItemTimes,
+    useNewTimesStopsTable ? undefined : operationalPointsOnPath
+  );
+
+  const newRows = useTimesStopsTableData(
     infraId,
     isValid,
     selectedTrain,
-    simulatedTrain,
-    simulatedPathItemTimes,
-    operationalPointsOnPath
+    useNewTimesStopsTable ? simulatedTrain : undefined,
+    useNewTimesStopsTable ? simulatedPathItemTimes : undefined,
+    useNewTimesStopsTable ? operationalPointsOnPath : undefined
   );
+
+  if (useNewTimesStopsTable) {
+    return <TimesStopsTable rows={newRows} dataIsLoading={newRows.length === 0} />;
+  }
+
   return (
     <TimesStops
-      rows={rows}
+      rows={legacyRows}
       tableType={TableType.Output}
       cellClassName={({ rowData: rowData_, columnId }) => {
         const rowData = rowData_ as TimesStopsRow;
@@ -58,7 +79,7 @@ const TimesStopsOutput = ({
         });
       }}
       headerRowHeight={40}
-      dataIsLoading={!selectedTrain}
+      dataIsLoading={newRows.length === 0}
     />
   );
 };

--- a/front/src/modules/timesStops/TimesStopsTable.tsx
+++ b/front/src/modules/timesStops/TimesStopsTable.tsx
@@ -1,0 +1,128 @@
+import { useMemo } from 'react';
+
+import {
+  createColumnHelper,
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+} from '@tanstack/react-table';
+import { useTranslation } from 'react-i18next';
+
+import { Loader } from 'common/Loaders/Loader';
+import { formatLocalTime } from 'utils/date';
+
+import type { TimesStopsRowNew } from './types';
+
+type TimesStopsTableProps = {
+  rows: TimesStopsRowNew[];
+  dataIsLoading: boolean;
+};
+
+const columnHelper = createColumnHelper<TimesStopsRowNew>();
+
+const TimesStopsTable = ({ rows, dataIsLoading }: TimesStopsTableProps) => {
+  const { t } = useTranslation('translation', { keyPrefix: 'timeStopTable' });
+
+  const columns = useMemo(
+    () => [
+      columnHelper.display({
+        id: 'index',
+        header: '#',
+        cell: (info) => info.row.original.index + 1,
+      }),
+      columnHelper.accessor('name', {
+        header: () => t('name'),
+        cell: (info) => {
+          const name = info.getValue();
+          const secondaryCode = info.row.original.secondaryCode;
+          const displayName = secondaryCode ? `${name} ${secondaryCode}` : name;
+          return (
+            <span title={displayName}>
+              <span>{name}</span>
+              {secondaryCode && <span>{secondaryCode}</span>}
+            </span>
+          );
+        },
+      }),
+      columnHelper.accessor('track', {
+        header: () => t('trackName'),
+        cell: (info) => info.getValue() ?? '',
+      }),
+      columnHelper.accessor('requestedArrival', {
+        header: () => t('arrivalTime'),
+        cell: (info) => (info.getValue() ? formatLocalTime(info.getValue()!) : ''),
+      }),
+      columnHelper.accessor('computedArrival', {
+        header: () => t('calculatedArrivalTime'),
+        cell: (info) => (info.getValue() ? formatLocalTime(info.getValue()!) : ''),
+      }),
+      columnHelper.accessor('stopDuration', {
+        header: () => t('stopTime'),
+        cell: (info) => info.getValue()?.total('second') ?? '',
+      }),
+      columnHelper.accessor('requestedDeparture', {
+        header: () => t('departureTime'),
+        cell: (info) => (info.getValue() ? formatLocalTime(info.getValue()!) : ''),
+      }),
+      columnHelper.accessor('computedDeparture', {
+        header: () => t('calculatedDepartureTime'),
+        cell: (info) => (info.getValue() ? formatLocalTime(info.getValue()!) : ''),
+      }),
+    ],
+    [t]
+  );
+
+  // eslint-disable-next-line react-hooks/incompatible-library
+  const table = useReactTable({
+    data: rows,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+  });
+
+  if (dataIsLoading) {
+    return (
+      <div className="times-stops-table-new-loader">
+        <Loader />
+      </div>
+    );
+  }
+
+  if (rows.length === 0) {
+    return (
+      <div className="d-flex justify-content-center align-items-center h-100">
+        <p className="pt-1 px-5">{t('noPathLoaded')}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="times-stops-table-new">
+      <table>
+        <thead>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <tr key={headerGroup.id}>
+              {headerGroup.headers.map((header) => (
+                <th key={header.id}>
+                  {header.isPlaceholder
+                    ? null
+                    : flexRender(header.column.columnDef.header, header.getContext())}
+                </th>
+              ))}
+            </tr>
+          ))}
+        </thead>
+        <tbody>
+          {table.getRowModel().rows.map((row) => (
+            <tr key={row.id}>
+              {row.getVisibleCells().map((cell) => (
+                <td key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default TimesStopsTable;

--- a/front/src/modules/timesStops/helpers/utils.ts
+++ b/front/src/modules/timesStops/helpers/utils.ts
@@ -361,7 +361,9 @@ export const getTrackReferenceLabel = (
 ) => {
   if (!trackReference) return undefined;
   if ('track_name' in trackReference) return trackReference.track_name;
-  return trackSections[trackReference.track_id]?.extensions?.sncf?.track_name ?? '?';
+  return (
+    trackSections[trackReference.track_id]?.extensions?.sncf?.track_name ?? trackReference.track_id
+  );
 };
 
 export const getOperationalPointName = (

--- a/front/src/modules/timesStops/hooks/useTimesStopsTableData.ts
+++ b/front/src/modules/timesStops/hooks/useTimesStopsTableData.ts
@@ -1,0 +1,241 @@
+import { useEffect, useState, useMemo } from 'react';
+
+import { keyBy } from 'lodash';
+import { useTranslation } from 'react-i18next';
+import { useSelector } from 'react-redux';
+
+import usePathOps from 'applications/operationalStudies/hooks/usePathOps';
+import { useScenarioContext } from 'applications/operationalStudies/hooks/useScenarioContext';
+import type { PathPropertiesFormatted } from 'applications/operationalStudies/types';
+import { matchOpRefAndOp } from 'applications/operationalStudies/utils';
+import type {
+  SimulationResponseSuccess,
+  TrackSection,
+  ScheduleItem,
+} from 'common/api/osrdEditoastApi';
+import { matchPathStepAndOp } from 'modules/pathfinding/utils';
+import { interpolateValue } from 'modules/simulationResult/helpers/utils';
+import type { SimulationSummary } from 'modules/timetableItem/types';
+import type { Train } from 'reducers/osrdconf/types';
+import { getDisplayOnlyPathSteps } from 'reducers/simulationResults/selectors';
+import { Duration } from 'utils/duration';
+
+import { getTrackReferenceLabel, getOperationalPointName } from '../helpers/utils';
+import type { TimesStopsRowNew } from '../types';
+
+type BuildTableRowParams = {
+  id: string;
+  index: number;
+  name?: string;
+  secondaryCode?: string;
+  trackName?: string;
+  startDate: Date;
+  schedule?: ScheduleItem;
+  computedArrival?: Duration;
+};
+
+const buildTableRow = ({
+  id,
+  index,
+  name,
+  secondaryCode,
+  trackName,
+  startDate,
+  schedule,
+  computedArrival,
+}: BuildTableRowParams): TimesStopsRowNew => {
+  const requestedArrival = schedule?.arrival
+    ? new Date(startDate.getTime() + Duration.parse(schedule.arrival).ms)
+    : null;
+
+  // computedArrival is offset from startDate
+  const computedArrivalDate =
+    computedArrival !== undefined ? new Date(startDate.getTime() + computedArrival.ms) : null;
+
+  // schedule.stop_for is ISO 8601 duration
+  const stopDuration = schedule?.stop_for ? Duration.parse(schedule.stop_for) : null;
+
+  // requestedDeparture = requestedArrival + stopDuration
+  const requestedDeparture =
+    requestedArrival && stopDuration !== null
+      ? new Date(requestedArrival.getTime() + stopDuration.ms)
+      : null;
+
+  // computedDeparture = computedArrival + stopDuration
+  const computedDeparture =
+    computedArrivalDate && stopDuration !== null
+      ? new Date(computedArrivalDate.getTime() + stopDuration.ms)
+      : null;
+
+  return {
+    id,
+    index,
+    name: name ?? '',
+    secondaryCode: secondaryCode ?? '',
+    track: trackName ?? '',
+    requestedArrival,
+    computedArrival: computedArrivalDate,
+    stopDuration,
+    requestedDeparture,
+    computedDeparture,
+  };
+};
+
+/**
+ * Hook to build TableRow[] for the new Times & Stops table (TimesStopsTableNew).
+ * This is separate from useOutputTableData to keep the legacy and new logic independent.
+ * Once the new table is fully validated, useOutputTableData can be removed.
+ */
+const useTimesStopsTableData = (
+  infraId: number,
+  isValid: boolean,
+  selectedTrain: Train,
+  simulatedTrain?: SimulationResponseSuccess['final_output'],
+  simulatedPathItemTimes?: Extract<SimulationSummary, { isValid: true }>['pathItemTimes'],
+  operationalPointsOnPath?: PathPropertiesFormatted['operationalPoints']
+): TimesStopsRowNew[] => {
+  const { t } = useTranslation('operational-studies');
+  const { getTrackSectionsByIds } = useScenarioContext();
+  const displayOnlyPathSteps = useSelector(getDisplayOnlyPathSteps);
+
+  const pathStepOps = usePathOps(infraId, selectedTrain.path);
+
+  const trackIds = useMemo(() => {
+    const trackIdsInPathSteps: string[] = [];
+    for (const { location } of selectedTrain.path) {
+      if ('track' in location) trackIdsInPathSteps.push(location.track);
+      else if (location.track_reference && 'track_id' in location.track_reference)
+        trackIdsInPathSteps.push(location.track_reference.track_id);
+    }
+    const trackIdsOnPath = (operationalPointsOnPath || []).map((op) => op.part.track);
+    return [...trackIdsInPathSteps, ...trackIdsOnPath];
+  }, [selectedTrain.path, operationalPointsOnPath]);
+
+  const [trackSections, setTrackSections] = useState<Record<string, TrackSection>>({});
+  useEffect(() => {
+    const fetchTrackSections = async () => {
+      const sections = await getTrackSectionsByIds(trackIds);
+      setTrackSections(sections);
+    };
+    fetchTrackSections();
+  }, [trackIds]);
+
+  const rows = useMemo(() => {
+    const startDate = new Date(selectedTrain.start_time);
+    const scheduleByAt = keyBy(selectedTrain.schedule, 'at');
+
+    const pathStepRowsById = new Map(
+      selectedTrain.path.map((pathStep, stepIndex) => {
+        const matchingOp = pathStepOps.find((op) => matchOpRefAndOp(pathStep.location, op));
+
+        const name = getOperationalPointName(
+          matchingOp,
+          pathStep.location,
+          stepIndex,
+          selectedTrain.path.length,
+          t
+        );
+        const trackName =
+          'track' in pathStep.location
+            ? (trackSections[pathStep.location.track]?.extensions?.sncf?.track_name ??
+              pathStep.location.track)
+            : getTrackReferenceLabel(trackSections, pathStep.location.track_reference);
+
+        const schedule = scheduleByAt[pathStep.id];
+        const computedArrival =
+          simulatedPathItemTimes?.final[stepIndex] !== undefined
+            ? new Duration({ milliseconds: simulatedPathItemTimes.final[stepIndex] })
+            : undefined;
+
+        const row = buildTableRow({
+          id: pathStep.id,
+          // index is a placeholder here (-1), it will be replaced by opIndex when matching with operationalPointsOnPath
+          index: -1,
+          name,
+          secondaryCode: matchingOp?.extensions?.sncf?.ch,
+          trackName,
+          startDate,
+          schedule,
+          computedArrival,
+        });
+
+        return [pathStep.id, row];
+      })
+    );
+
+    let formattedRows: TimesStopsRowNew[] = [];
+
+    // Case 1: Valid train with simulation results
+    if (isValid && simulatedTrain && operationalPointsOnPath) {
+      operationalPointsOnPath.forEach((op, opIndex) => {
+        const trackName =
+          trackSections[op.part.track]?.extensions?.sncf?.track_name ?? op.part.track;
+
+        const matchingPathStep = selectedTrain.path.find((pathStep) =>
+          matchPathStepAndOp(pathStep.location, {
+            opId: op.id,
+            uic: op.extensions?.identifier?.uic,
+            ch: op.extensions?.sncf?.ch,
+            trigram: op.extensions?.sncf?.trigram,
+            track: op.part.track,
+            offsetOnTrack: op.part.position,
+          })
+        );
+
+        const matchingPathStepRow = matchingPathStep
+          ? pathStepRowsById.get(matchingPathStep.id)
+          : undefined;
+
+        if (matchingPathStepRow) {
+          formattedRows.push({
+            ...matchingPathStepRow,
+            track: trackName,
+            index: opIndex,
+          });
+        } else if (!displayOnlyPathSteps) {
+          const matchingReportTrainIndex = simulatedTrain.positions.findIndex(
+            (position) => position === op.position
+          );
+          const computedArrivalMs =
+            matchingReportTrainIndex === -1
+              ? interpolateValue(simulatedTrain, op.position, 'times')
+              : simulatedTrain.times[matchingReportTrainIndex];
+          const computedArrival =
+            computedArrivalMs !== undefined
+              ? new Duration({ milliseconds: computedArrivalMs })
+              : undefined;
+
+          formattedRows.push(
+            buildTableRow({
+              id: op.id,
+              index: opIndex,
+              name: op.extensions?.identifier?.name,
+              secondaryCode: op.extensions?.sncf?.ch,
+              trackName,
+              startDate,
+              computedArrival,
+            })
+          );
+        }
+      });
+    } else {
+      formattedRows = Array.from(pathStepRowsById.values());
+    }
+
+    return formattedRows;
+  }, [
+    selectedTrain,
+    isValid,
+    simulatedTrain,
+    operationalPointsOnPath,
+    simulatedPathItemTimes,
+    trackSections,
+    pathStepOps,
+    displayOnlyPathSteps,
+    t,
+  ]);
+
+  return rows;
+};
+
+export default useTimesStopsTableData;

--- a/front/src/modules/timesStops/types.ts
+++ b/front/src/modules/timesStops/types.ts
@@ -8,6 +8,19 @@ export type TimeExtraDays = {
   dayDisplayed?: boolean;
 };
 
+export type TimesStopsRowNew = {
+  id: string;
+  index: number;
+  name: string;
+  secondaryCode: string;
+  track: string;
+  requestedArrival: Date | null;
+  computedArrival: Date | null;
+  stopDuration: Duration | null;
+  requestedDeparture: Date | null;
+  computedDeparture: Date | null;
+};
+
 export type TimesStopsRow = {
   pathStepId: string | undefined;
   opId: string | undefined;

--- a/front/src/reducers/user/index.ts
+++ b/front/src/reducers/user/index.ts
@@ -3,13 +3,18 @@ import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 import type { ApiError } from 'common/api/baseGeneratedApis';
 import type { Role } from 'common/api/osrdEditoastApi';
 
+export type UserPreferences = {
+  safeWord: string;
+  useNewTimesStopsTable: boolean;
+};
+
 export type UserState = {
   isLogged: boolean;
   impersonatedUser?: UserInfo;
   loginError?: ApiError;
   userId: number;
   username: string;
-  userPreferences: { safeWord: string };
+  userPreferences: UserPreferences;
   userRoles: Role[];
   account: Record<string, string>;
 };
@@ -30,7 +35,7 @@ export const userInitialState: UserState = {
   impersonatedUser: undefined,
   loginError: undefined,
   username: '',
-  userPreferences: { safeWord: '' },
+  userPreferences: { safeWord: '', useNewTimesStopsTable: false },
   userId: -1,
   userRoles: [],
   account: {},
@@ -73,7 +78,7 @@ export const userSlice = createSlice({
         state.userId = -1;
       }
     },
-    updateUserPreferences(state, action: PayloadAction<{ safeWord: string }>) {
+    updateUserPreferences(state, action: PayloadAction<UserPreferences>) {
       state.userPreferences = action.payload;
     },
   },

--- a/front/src/reducers/user/userReducer.spec.ts
+++ b/front/src/reducers/user/userReducer.spec.ts
@@ -58,7 +58,7 @@ describe('userReducer', () => {
       ...userInitialState,
       isLogged: true,
       username: 'Test userSlice',
-      userPreferences: { safeWord: '' },
+      userPreferences: { safeWord: '', useNewTimesStopsTable: false },
     });
     store.dispatch(logoutSuccess());
     const userState = store.getState().user;
@@ -95,12 +95,15 @@ describe('userReducer', () => {
 
   it('should handle updateUserPreferences', () => {
     const store = createStore(userInitialState);
-    const action = updateUserPreferences({ safeWord: 'Test userSlice' });
+    const action = updateUserPreferences({
+      safeWord: 'Test userSlice',
+      useNewTimesStopsTable: false,
+    });
     store.dispatch(action);
     const userState = store.getState().user;
     expect(userState).toEqual({
       ...userInitialState,
-      userPreferences: { safeWord: 'Test userSlice' },
+      userPreferences: { safeWord: 'Test userSlice', useNewTimesStopsTable: false },
     });
   });
 });

--- a/front/src/reducers/user/userSelectors.ts
+++ b/front/src/reducers/user/userSelectors.ts
@@ -12,6 +12,7 @@ const makeUserPreferencesSelector =
 export const getIsUserLogged = makeUserSelector('isLogged');
 export const getLoginError = makeUserSelector('loginError');
 export const getUserSafeWord = makeUserPreferencesSelector('safeWord');
+export const getUseNewTimesStopsTable = makeUserPreferencesSelector('useNewTimesStopsTable');
 export const getUsername = makeUserSelector('username');
 export const getUserRoles = makeUserSelector('userRoles');
 export const getUserId = makeUserSelector('userId');


### PR DESCRIPTION
closes #14280

### Description

First step of the Times & Stops table. This PR introduces :
- A feature flag `useNewTimesStopsTable` to toggle between the legacy and new table
- A new read-only table using TanStack Table with the following columns:
  - Index
  - Operational Point (name + CH)
  - Track
  - Requested Arrival
  - Computed Arrival
  - Stopping Time
  - Requested Departure
  - Computed Departure

### How to test

1. Enable "Use new timetable" in User Settings
2. Open a scenario with a valid train
3. Check that the Times & Stops table displays correctly with all columns