### PR TITLE
editoast: add path_item_respect_{time,margin} to simulation summaries

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -13320,6 +13320,7 @@ components:
               minimum: 0
             description: |-
               The path offset in mm of each path item given as input of the pathfinding
+              The length of this array is the number of path items in the train schedule used as input for the simulation.
               The first value is always `0` (beginning of the path) and the last one is always equal to the `length` of the path in mm
           path_item_times_base:
             type: array
@@ -13329,6 +13330,7 @@ components:
               minimum: 0
             description: |-
               Base simulation time for each train schedule path item.
+              The length of this array is the number of path items in the train schedule used as input for the simulation.
               The first value is always `0` (beginning of the path) and the last one, the total time of the simulation (end of the path)
           path_item_times_final:
             type: array
@@ -13338,6 +13340,7 @@ components:
               minimum: 0
             description: |-
               Final simulation time for each train schedule path item.
+              The length of this array is the number of path items in the train schedule used as input for the simulation.
               The first value is always `0` (beginning of the path) and the last one, the total time of the simulation (end of the path)
           path_item_times_provisional:
             type: array
@@ -13347,6 +13350,7 @@ components:
               minimum: 0
             description: |-
               Provisional simulation time for each train schedule path item.
+              The length of this array is the number of path items in the train schedule used as input for the simulation.
               The first value is always `0` (beginning of the path) and the last one, the total time of the simulation (end of the path)
           status:
             type: string

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -13300,6 +13300,8 @@ components:
         - path_item_times_final
         - path_item_times_provisional
         - path_item_times_base
+        - path_item_respect_times
+        - path_item_respect_margins
         - path_item_positions
         - status
         properties:
@@ -13322,6 +13324,22 @@ components:
               The path offset in mm of each path item given as input of the pathfinding
               The length of this array is the number of path items in the train schedule used as input for the simulation.
               The first value is always `0` (beginning of the path) and the last one is always equal to the `length` of the path in mm
+          path_item_respect_margins:
+            type: array
+            items:
+              type: boolean
+            description: |-
+              Whether the final path times respect the input margins for each train schedule path item.
+              The length of this array is the number of path items in the train schedule used as input for the simulation.
+              Important: `true` means the provisional time is acceptable margin-wise, not *precisely* respecting the margin.
+          path_item_respect_times:
+            type: array
+            items:
+              type: boolean
+            description: |-
+              Whether each path item in the train schedule is reached on time.
+              The length of this array is the number of path items in the train schedule used as input for the simulation.
+              Important: `true` doesn't mean the path item has been reached *precisely* at the requested time. Instead, it means it reached the path item at an acceptable time.
           path_item_times_base:
             type: array
             items:

--- a/editoast/schemas/src/primitives/duration.rs
+++ b/editoast/schemas/src/primitives/duration.rs
@@ -61,7 +61,7 @@ pub enum PositiveDurationError {
 /// let err_s = r#"{"duration":"P1M"}"#; // 1 month
 /// assert!(serde_json::from_str::<MyStruct>(err_s).is_err());
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PositiveDuration(ChronoDuration);
 
 #[cfg(feature = "testing")]

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -1011,14 +1011,14 @@ pub(in crate::views) fn simulation_empty_response() -> core_client::simulation::
             times: vec![0],
             speeds: vec![],
             energy_consumption: 0.0,
-            path_item_times: vec![0, 1],
+            path_item_times: vec![0, 1, 2, 3],
         },
         provisional: ReportTrain {
             positions: vec![0],
             times: vec![0],
             speeds: vec![],
             energy_consumption: 0.0,
-            path_item_times: vec![0, 1],
+            path_item_times: vec![0, 1, 2, 3],
         },
         final_output: CompleteReportTrain {
             report_train: ReportTrain {
@@ -1026,7 +1026,7 @@ pub(in crate::views) fn simulation_empty_response() -> core_client::simulation::
                 times: vec![0],
                 speeds: vec![],
                 energy_consumption: 0.0,
-                path_item_times: vec![0, 1],
+                path_item_times: vec![0, 1, 2, 3],
             },
             signal_critical_positions: vec![],
             zone_updates: vec![],

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -1007,14 +1007,14 @@ pub(in crate::views) fn simulation_empty_response() -> core_client::simulation::
 
     core_client::simulation::Response::Success(SimulationSuccess {
         base: ReportTrain {
-            positions: vec![],
+            positions: vec![0],
             times: vec![0],
             speeds: vec![],
             energy_consumption: 0.0,
             path_item_times: vec![0, 1],
         },
         provisional: ReportTrain {
-            positions: vec![],
+            positions: vec![0],
             times: vec![0],
             speeds: vec![],
             energy_consumption: 0.0,

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -352,6 +352,7 @@ pub(in crate::views) async fn simulation_summary(
                                 SummaryResponse::summarize_simulation(
                                     Arc::unwrap_or_clone(simulation),
                                     Arc::unwrap_or_clone(path),
+                                    &simulation_context.train_schedule,
                                 ),
                             );
                         });
@@ -364,6 +365,7 @@ pub(in crate::views) async fn simulation_summary(
                         paced_train: SummaryResponse::summarize_simulation(
                             Arc::unwrap_or_clone(simulation),
                             Arc::unwrap_or_clone(path),
+                            &simulation_context.train_schedule,
                         ),
                         exceptions: HashMap::new(),
                     },
@@ -1883,6 +1885,8 @@ mod tests {
                     path_item_times_final: vec![0, 1, 2, 3],
                     path_item_times_provisional: vec![0, 1, 2, 3],
                     path_item_times_base: vec![0, 1, 2, 3],
+                    path_item_respect_times: vec![true, false, true, false],
+                    path_item_respect_margins: vec![true, true, true, true],
                     path_item_positions: vec![0, 1, 2, 3]
                 },
                 exceptions: [(
@@ -1896,6 +1900,8 @@ mod tests {
                         path_item_times_final: vec![0, 1, 2, 3],
                         path_item_times_provisional: vec![0, 1, 2, 3],
                         path_item_times_base: vec![0, 1, 2, 3],
+                        path_item_respect_times: vec![true, false, true, false],
+                        path_item_respect_margins: vec![true, true, true, true],
                         path_item_positions: vec![0, 1, 2, 3]
                     }
                 )]

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -1726,14 +1726,14 @@ mod tests {
                     times: vec![0],
                     speeds: vec![],
                     energy_consumption: 0.0,
-                    path_item_times: vec![0, 1]
+                    path_item_times: vec![0, 1, 2, 3]
                 },
                 provisional: ReportTrain {
                     positions: vec![0],
                     times: vec![0],
                     speeds: vec![],
                     energy_consumption: 0.0,
-                    path_item_times: vec![0, 1]
+                    path_item_times: vec![0, 1, 2, 3]
                 },
                 final_output: CompleteReportTrain {
                     report_train: ReportTrain {
@@ -1741,7 +1741,7 @@ mod tests {
                         times: vec![0],
                         speeds: vec![],
                         energy_consumption: 0.0,
-                        path_item_times: vec![0, 1]
+                        path_item_times: vec![0, 1, 2, 3]
                     },
                     signal_critical_positions: vec![],
                     zone_updates: vec![],
@@ -1878,11 +1878,11 @@ mod tests {
             PacedTrainSummaryResponse {
                 paced_train: SummaryResponse::Success {
                     length: 0,
-                    time: 1,
+                    time: 3,
                     energy_consumption: 0.0,
-                    path_item_times_final: vec![0, 1],
-                    path_item_times_provisional: vec![0, 1],
-                    path_item_times_base: vec![0, 1],
+                    path_item_times_final: vec![0, 1, 2, 3],
+                    path_item_times_provisional: vec![0, 1, 2, 3],
+                    path_item_times_base: vec![0, 1, 2, 3],
                     path_item_positions: vec![0, 1, 2, 3]
                 },
                 exceptions: [(
@@ -1891,11 +1891,11 @@ mod tests {
                     // because all simulation results from core are identical stubs
                     SummaryResponse::Success {
                         length: 0,
-                        time: 1,
+                        time: 3,
                         energy_consumption: 0.0,
-                        path_item_times_final: vec![0, 1],
-                        path_item_times_provisional: vec![0, 1],
-                        path_item_times_base: vec![0, 1],
+                        path_item_times_final: vec![0, 1, 2, 3],
+                        path_item_times_provisional: vec![0, 1, 2, 3],
+                        path_item_times_base: vec![0, 1, 2, 3],
                         path_item_positions: vec![0, 1, 2, 3]
                     }
                 )]

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -1722,14 +1722,14 @@ mod tests {
             response,
             simulation::Response::Success(SimulationResponseSuccess {
                 base: ReportTrain {
-                    positions: vec![],
+                    positions: vec![0],
                     times: vec![0],
                     speeds: vec![],
                     energy_consumption: 0.0,
                     path_item_times: vec![0, 1]
                 },
                 provisional: ReportTrain {
-                    positions: vec![],
+                    positions: vec![0],
                     times: vec![0],
                     speeds: vec![],
                     energy_consumption: 0.0,

--- a/editoast/src/views/timetable/simulation.rs
+++ b/editoast/src/views/timetable/simulation.rs
@@ -132,15 +132,19 @@ pub enum SummaryResponse {
         /// Total energy consumption of a train in kWh
         energy_consumption: f64,
         /// Final simulation time for each train schedule path item.
+        /// The length of this array is the number of path items in the train schedule used as input for the simulation.
         /// The first value is always `0` (beginning of the path) and the last one, the total time of the simulation (end of the path)
         path_item_times_final: Vec<u64>,
         /// Provisional simulation time for each train schedule path item.
+        /// The length of this array is the number of path items in the train schedule used as input for the simulation.
         /// The first value is always `0` (beginning of the path) and the last one, the total time of the simulation (end of the path)
         path_item_times_provisional: Vec<u64>,
         /// Base simulation time for each train schedule path item.
+        /// The length of this array is the number of path items in the train schedule used as input for the simulation.
         /// The first value is always `0` (beginning of the path) and the last one, the total time of the simulation (end of the path)
         path_item_times_base: Vec<u64>,
         /// The path offset in mm of each path item given as input of the pathfinding
+        /// The length of this array is the number of path items in the train schedule used as input for the simulation.
         /// The first value is always `0` (beginning of the path) and the last one is always equal to the `length` of the path in mm
         path_item_positions: Vec<u64>,
     },

--- a/editoast/src/views/timetable/simulation.rs
+++ b/editoast/src/views/timetable/simulation.rs
@@ -1,3 +1,4 @@
+use chrono::Duration;
 use core_client::AsCoreRequest;
 use core_client::pathfinding::PathfindingInputError;
 use core_client::pathfinding::PathfindingNotFound;
@@ -42,8 +43,17 @@ use crate::views::timetable::PhysicsConsistParameters;
 use crate::views::timetable::simulation;
 use editoast_models::prelude::*;
 use editoast_models::rolling_stock::RollingStock;
+use schemas::primitives::NonBlankString;
+use schemas::primitives::PositiveDuration;
 
 pub const TRAIN_SIZE_BATCH: usize = 100;
+
+/// Approximate time values from simulations to two seconds.
+///
+/// Used when computing whether path items respect times and margins of a simulation.
+///
+/// This value is chosen because core hard-codes a timestep of two seconds for standalone simulations.
+const TIME_APPROX_ERROR: Duration = Duration::seconds(2);
 
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug, ToSchema)]
 pub struct SimulationResponseSuccess {
@@ -58,6 +68,129 @@ pub struct SimulationResponseSuccess {
     pub mrsp: SpeedLimitProperties,
     #[schema(inline)]
     pub electrical_profiles: ElectricalProfiles,
+}
+
+impl SimulationResponseSuccess {
+    /// Compute whether the simulation response respects the times on each path item.
+    ///
+    /// # Panics
+    ///
+    /// This function can panic in the following cases:
+    /// - the simulation response isn't derived from the given train schedule,
+    /// - some of the final path item times exceed `i64::MAX`
+    pub fn path_item_respect_times<T: TrainScheduleLike>(&self, train_schedule: &T) -> Vec<bool> {
+        let path_item_id_to_index: HashMap<&NonBlankString, usize> = train_schedule
+            .path()
+            .iter()
+            .enumerate()
+            .map(|(i, path_item)| (&path_item.id, i))
+            .collect();
+
+        let path_item_times_final = &*self.final_output.report_train.path_item_times;
+        let mut res = vec![true; path_item_times_final.len()];
+
+        for schedule_item in train_schedule.schedule() {
+            let Some(arrival): Option<PositiveDuration> = schedule_item.arrival else {
+                continue;
+            };
+            let arrival = Duration::from(arrival);
+
+            let path_item_index = path_item_id_to_index[&schedule_item.at];
+            let path_item_time = i64::try_from(path_item_times_final[path_item_index]).unwrap();
+            let path_item_time = Duration::milliseconds(path_item_time);
+
+            res[path_item_index] = (path_item_time - arrival).abs() < TIME_APPROX_ERROR;
+        }
+
+        res
+    }
+
+    /// Compute whether the simulation response respects the margins on each path item.
+    ///
+    /// This function assumes items in `train_schedule.schedule()` have increasing
+    /// indices in `train_schedule.path()` (a property which should uphold for all
+    /// train schedule editoast produces)...
+    ///
+    /// # Panics
+    ///
+    /// This function can panic in the following cases:
+    /// - the simulation response isn't derived from the given train schedule,
+    /// - some of the final or provisional path item times exceed `i64::MAX`
+    pub fn path_item_respect_margins<T: TrainScheduleLike>(&self, train_schedule: &T) -> Vec<bool> {
+        let path_item_times_final = &*self.final_output.report_train.path_item_times;
+        let path_item_times_provisional = &*self.provisional.path_item_times;
+        let margin_boundary_set = &*train_schedule.margins().boundaries;
+
+        let path_item_id_to_index: HashMap<&NonBlankString, usize> = train_schedule
+            .path()
+            .iter()
+            .enumerate()
+            .map(|(i, path_item)| (&path_item.id, i))
+            .collect();
+
+        let mut res = vec![true; path_item_times_final.len()];
+
+        let path_item_ids_to_check = train_schedule
+            .path()
+            .first() // unconditionally include, will filter later down
+            .map(|first_path_item| &first_path_item.id)
+            .into_iter()
+            .chain(
+                train_schedule
+                    .schedule()
+                    .iter()
+                    .enumerate()
+                    .filter(|(i, schedule_item)| {
+                        *i == 0
+                            || schedule_item.arrival.is_some()
+                            || margin_boundary_set.contains(&schedule_item.at)
+                    })
+                    .map(|(_, schedule_item)| &schedule_item.at),
+            )
+            .chain(
+                train_schedule
+                    .path()
+                    .last() // unconditionally include, will filter later down
+                    .map(|last_path_item| &last_path_item.id),
+            )
+            // TODO use https://doc.rust-lang.org/stable/std/iter/trait.Iterator.html#method.map_windows
+            .collect::<Vec<&NonBlankString>>();
+        path_item_ids_to_check
+            .windows(2)
+            .for_each(|path_item_id_couple| {
+                let [prev_path_item_id, path_item_id] = *path_item_id_couple else {
+                    // TODO use https://doc.rust-lang.org/stable/std/primitive.slice.html#method.array_windows
+                    unreachable!()
+                };
+                if prev_path_item_id == path_item_id {
+                    // Because we unconditionally iterate over the first and last item of the path,
+                    // in case they are not present in the train schedule, we might end up with
+                    // prev_path_item and path_item being the same, so we filter this case here.
+                    return;
+                }
+
+                let path_item_index = path_item_id_to_index[path_item_id];
+                let path_item_time_final =
+                    i64::try_from(path_item_times_final[path_item_index]).unwrap();
+                let path_item_time_provisional =
+                    i64::try_from(path_item_times_provisional[path_item_index]).unwrap();
+
+                let prev_path_item_index = path_item_id_to_index[prev_path_item_id];
+                let prev_path_item_time_final =
+                    i64::try_from(path_item_times_final[prev_path_item_index]).unwrap();
+                let prev_path_item_time_provisional =
+                    i64::try_from(path_item_times_provisional[prev_path_item_index]).unwrap();
+
+                let interval_duration_final = path_item_time_final - prev_path_item_time_final;
+                let interval_duration_provisional =
+                    path_item_time_provisional - prev_path_item_time_provisional;
+                let margin_diff = interval_duration_final - interval_duration_provisional;
+
+                res[path_item_index] = margin_diff >= -TIME_APPROX_ERROR.num_milliseconds();
+            });
+
+        res
+    }
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug, ToSchema)]
@@ -143,6 +276,14 @@ pub enum SummaryResponse {
         /// The length of this array is the number of path items in the train schedule used as input for the simulation.
         /// The first value is always `0` (beginning of the path) and the last one, the total time of the simulation (end of the path)
         path_item_times_base: Vec<u64>,
+        /// Whether each path item in the train schedule is reached on time.
+        /// The length of this array is the number of path items in the train schedule used as input for the simulation.
+        /// Important: `true` doesn't mean the path item has been reached *precisely* at the requested time. Instead, it means it reached the path item at an acceptable time.
+        path_item_respect_times: Vec<bool>,
+        /// Whether the final path times respect the input margins for each train schedule path item.
+        /// The length of this array is the number of path items in the train schedule used as input for the simulation.
+        /// Important: `true` means the provisional time is acceptable margin-wise, not *precisely* respecting the margin.
+        path_item_respect_margins: Vec<bool>,
         /// The path offset in mm of each path item given as input of the pathfinding
         /// The length of this array is the number of path items in the train schedule used as input for the simulation.
         /// The first value is always `0` (beginning of the path) and the last one is always equal to the `length` of the path in mm
@@ -159,14 +300,13 @@ pub enum SummaryResponse {
 }
 
 impl SummaryResponse {
-    pub fn summarize_simulation(response: simulation::Response, path: PathfindingResult) -> Self {
+    pub fn summarize_simulation<T: TrainScheduleLike>(
+        response: simulation::Response,
+        path: PathfindingResult,
+        train_schedule: &T,
+    ) -> Self {
         match response {
-            simulation::Response::Success(SimulationResponseSuccess {
-                final_output,
-                provisional,
-                base,
-                ..
-            }) => {
+            simulation::Response::Success(sim) => {
                 let PathfindingResult::Success(PathfindingResultSuccess {
                     path_item_positions,
                     ..
@@ -174,14 +314,26 @@ impl SummaryResponse {
                 else {
                     panic!("Pathfinding cannnot fail if the simulation has succeeded")
                 };
-                let report = final_output.report_train;
+
+                let path_item_respect_times = sim.path_item_respect_times(train_schedule);
+                let path_item_respect_margins = sim.path_item_respect_margins(train_schedule);
+
+                let SimulationResponseSuccess {
+                    final_output: CompleteReportTrain { report_train, .. },
+                    provisional,
+                    base,
+                    ..
+                } = sim;
+
                 Self::Success {
-                    length: *report.positions.last().unwrap(),
-                    time: *report.path_item_times.last().unwrap(),
-                    energy_consumption: report.energy_consumption,
-                    path_item_times_final: report.path_item_times.clone(),
-                    path_item_times_provisional: provisional.path_item_times.clone(),
+                    length: *report_train.positions.last().unwrap(),
+                    time: *report_train.path_item_times.last().unwrap(),
+                    energy_consumption: report_train.energy_consumption,
+                    path_item_times_final: report_train.path_item_times,
+                    path_item_times_provisional: provisional.path_item_times,
                     path_item_times_base: base.path_item_times.clone(),
+                    path_item_respect_times,
+                    path_item_respect_margins,
                     path_item_positions: path_item_positions.clone(),
                 }
             }
@@ -530,4 +682,175 @@ fn compute_train_simulation_hash_with_versioning(
     simulation_input.hash(&mut hasher);
     let hash_simulation_input = hasher.finish();
     format!("simulation_{osrd_version}.{infra_id}.{infra_version}.{hash_simulation_input}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use schemas::TrainSchedule;
+
+    // Test data
+    // The simulation responses contain just enough data to compute
+    // `path_items_respect_{times,margins}`.
+
+    fn train_schedule_too_fast() -> TrainSchedule {
+        const JSON: &str = include_str!("tests/train_schedule_too_fast.json");
+        serde_json::from_str(JSON).unwrap()
+    }
+
+    fn train_schedule_too_fast_on_interval() -> TrainSchedule {
+        const JSON: &str = include_str!("tests/train_schedule_too_fast_on_interval.json");
+        serde_json::from_str(JSON).unwrap()
+    }
+
+    fn train_schedule_not_honored() -> TrainSchedule {
+        const JSON: &str = include_str!("tests/train_schedule_not_honored.json");
+        serde_json::from_str(JSON).unwrap()
+    }
+
+    fn train_schedule_honored() -> TrainSchedule {
+        const JSON: &str = include_str!("tests/train_schedule_honored.json");
+        serde_json::from_str(JSON).unwrap()
+    }
+
+    fn train_schedule_no_schedule() -> TrainSchedule {
+        const JSON: &str = include_str!("tests/train_schedule_no_schedule.json");
+        serde_json::from_str(JSON).unwrap()
+    }
+
+    fn shallow_sim_too_fast() -> SimulationResponseSuccess {
+        SimulationResponseSuccess {
+            base: ReportTrain {
+                path_item_times: vec![0, 1_444_453, 2_491_479],
+                ..Default::default()
+            },
+            provisional: ReportTrain {
+                path_item_times: vec![0, 1_834_414, 3_164_206],
+                ..Default::default()
+            },
+            final_output: CompleteReportTrain {
+                report_train: ReportTrain {
+                    path_item_times: vec![0, 1_739_394, 3_069_187],
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            mrsp: Default::default(),
+            electrical_profiles: Default::default(),
+        }
+    }
+
+    fn shallow_sim_too_fast_on_interval() -> SimulationResponseSuccess {
+        SimulationResponseSuccess {
+            base: ReportTrain {
+                path_item_times: vec![0, 4_730_243, 13_828_795],
+                ..Default::default()
+            },
+            provisional: ReportTrain {
+                path_item_times: vec![0, 5_222_392, 15_267_584],
+                ..Default::default()
+            },
+            final_output: CompleteReportTrain {
+                report_train: ReportTrain {
+                    path_item_times: vec![0, 5_280_030, 15_300_915],
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            mrsp: Default::default(),
+            electrical_profiles: Default::default(),
+        }
+    }
+
+    fn shallow_sim_honored() -> SimulationResponseSuccess {
+        SimulationResponseSuccess {
+            base: ReportTrain {
+                path_item_times: vec![0, 2_186_885],
+                ..Default::default()
+            },
+            provisional: ReportTrain {
+                path_item_times: vec![0, 2_186_885],
+                ..Default::default()
+            },
+            final_output: CompleteReportTrain {
+                report_train: ReportTrain {
+                    path_item_times: vec![0, 2_186_885],
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            mrsp: Default::default(),
+            electrical_profiles: Default::default(),
+        }
+    }
+
+    fn shallow_sim_not_honored() -> SimulationResponseSuccess {
+        SimulationResponseSuccess {
+            base: ReportTrain {
+                path_item_times: vec![0, 1_425_534, 2_186_885],
+                ..Default::default()
+            },
+            provisional: ReportTrain {
+                path_item_times: vec![0, 1_425_534, 2_186_885],
+                ..Default::default()
+            },
+            final_output: CompleteReportTrain {
+                report_train: ReportTrain {
+                    path_item_times: vec![0, 1_425_534, 2_186_885],
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            mrsp: Default::default(),
+            electrical_profiles: Default::default(),
+        }
+    }
+
+    #[test]
+    fn test_too_fast() {
+        let schedule = train_schedule_too_fast();
+        let sim = shallow_sim_too_fast();
+        let respect = sim.path_item_respect_margins(&schedule);
+        assert_eq!(*respect, [true, false, true]);
+    }
+
+    #[test]
+    fn test_too_fast_on_interval() {
+        let schedule = train_schedule_too_fast_on_interval();
+        let sim = shallow_sim_too_fast_on_interval();
+        let respect = sim.path_item_respect_margins(&schedule);
+        assert_eq!(*respect, [true, true, false]);
+    }
+
+    #[test]
+    fn test_not_too_fast_if_honored() {
+        let schedule = train_schedule_honored();
+        let sim = shallow_sim_honored();
+        let respect = sim.path_item_respect_margins(&schedule);
+        assert_eq!(*respect, [true, true]);
+    }
+
+    #[test]
+    fn test_times_honored() {
+        let schedule = train_schedule_honored();
+        let sim = shallow_sim_honored();
+        let respect: Vec<bool> = sim.path_item_respect_times(&schedule);
+        assert_eq!(*respect, [true, true]);
+    }
+
+    #[test]
+    fn test_times_no_schedule() {
+        let schedule = train_schedule_no_schedule();
+        let sim = shallow_sim_honored();
+        let respect: Vec<bool> = sim.path_item_respect_times(&schedule);
+        assert_eq!(*respect, [true, true]);
+    }
+
+    #[test]
+    fn test_times_not_honored() {
+        let schedule = train_schedule_not_honored();
+        let sim = shallow_sim_not_honored();
+        let respect: Vec<bool> = sim.path_item_respect_times(&schedule);
+        assert_eq!(*respect, [true, false, true]);
+    }
 }

--- a/editoast/src/views/timetable/tests/train_schedule_honored.json
+++ b/editoast/src/views/timetable/tests/train_schedule_honored.json
@@ -1,0 +1,45 @@
+{
+    "id": "trainschedule-95",
+    "train_name": "normal",
+    "labels": [],
+    "rolling_stock_name": "TC64700",
+    "start_time": "2024-08-02T12:00:00Z",
+    "path": [
+        {
+            "id": "id440",
+            "location": {
+                "track": "TA0",
+                "offset": 1299000
+            }
+        },
+        {
+            "id": "id450",
+            "location": {
+                "track": "TG1",
+                "offset": 644000
+            }
+        }
+    ],
+    "schedule": [
+        {
+            "at": "id450",
+            "arrival": null,
+            "stop_for": "P0D",
+            "reception_signal": "OPEN"
+        }
+    ],
+    "margins": {
+        "boundaries": [],
+        "values": [
+            "0%"
+        ]
+    },
+    "initial_speed": 0,
+    "comfort": "STANDARD",
+    "constraint_distribution": "MARECO",
+    "speed_limit_tag": null,
+    "power_restrictions": [],
+    "options": {
+        "use_electrical_profiles": true
+    }
+}

--- a/editoast/src/views/timetable/tests/train_schedule_no_schedule.json
+++ b/editoast/src/views/timetable/tests/train_schedule_no_schedule.json
@@ -1,0 +1,37 @@
+{
+    "id": "trainschedule-95",
+    "train_name": "normal",
+    "labels": [],
+    "rolling_stock_name": "TC64700",
+    "start_time": "2024-08-02T12:00:00Z",
+    "path": [
+        {
+            "id": "id440",
+            "location": {
+                "track": "TA0",
+                "offset": 1299000
+            }
+        },
+        {
+            "id": "id450",
+            "location": {
+                "track": "TG1",
+                "offset": 644000
+            }
+        }
+    ],
+    "margins": {
+        "boundaries": [],
+        "values": [
+            "0%"
+        ]
+    },
+    "initial_speed": 0,
+    "comfort": "STANDARD",
+    "constraint_distribution": "MARECO",
+    "speed_limit_tag": null,
+    "power_restrictions": [],
+    "options": {
+        "use_electrical_profiles": true
+    }
+}

--- a/editoast/src/views/timetable/tests/train_schedule_not_honored.json
+++ b/editoast/src/views/timetable/tests/train_schedule_not_honored.json
@@ -1,0 +1,61 @@
+{
+    "id": "trainschedule-96",
+    "train_name": "notHonored",
+    "labels": [],
+    "rolling_stock_name": "TC64700",
+    "start_time": "2024-08-02T12:00:00Z",
+    "path": [
+        {
+            "id": "id440",
+            "location": {
+                "track": "TA0",
+                "offset": 1299000
+            }
+        },
+        {
+            "id": "id584",
+            "location": {
+                "operational_point": {
+                    "uic": 4,
+                    "secondary_code": "BV",
+                    "type": "uic"
+                }
+            }
+        },
+        {
+            "id": "id450",
+            "location": {
+                "track": "TG1",
+                "offset": 644000
+            }
+        }
+    ],
+    "schedule": [
+        {
+            "at": "id584",
+            "arrival": "PT300S",
+            "stop_for": null,
+            "reception_signal": "OPEN"
+        },
+        {
+            "at": "id450",
+            "arrival": null,
+            "stop_for": "P0D",
+            "reception_signal": "OPEN"
+        }
+    ],
+    "margins": {
+        "boundaries": [],
+        "values": [
+            "0%"
+        ]
+    },
+    "initial_speed": 0,
+    "comfort": "STANDARD",
+    "constraint_distribution": "MARECO",
+    "speed_limit_tag": null,
+    "power_restrictions": [],
+    "options": {
+        "use_electrical_profiles": true
+    }
+}

--- a/editoast/src/views/timetable/tests/train_schedule_too_fast.json
+++ b/editoast/src/views/timetable/tests/train_schedule_too_fast.json
@@ -1,0 +1,64 @@
+{
+    "id": "trainschedule-98",
+    "train_name": "tooFast",
+    "labels": [],
+    "rolling_stock_name": "TC64700",
+    "start_time": "2024-08-02T12:00:00Z",
+    "path": [
+        {
+            "id": "id440",
+            "location": {
+                "track": "TA0",
+                "offset": 1299000
+            }
+        },
+        {
+            "id": "id935",
+            "location": {
+                "operational_point": {
+                    "uic": 4,
+                    "secondary_code": "BV",
+                    "type": "uic"
+                }
+            }
+        },
+        {
+            "id": "id916",
+            "location": {
+                "track": "TH1",
+                "offset": 4095000
+            }
+        }
+    ],
+    "schedule": [
+        {
+            "at": "id935",
+            "arrival": "PT1740S",
+            "stop_for": "P0D",
+            "reception_signal": "OPEN"
+        },
+        {
+            "at": "id916",
+            "arrival": null,
+            "stop_for": "P0D",
+            "reception_signal": "OPEN"
+        }
+    ],
+    "margins": {
+        "boundaries": [
+            "id916"
+        ],
+        "values": [
+            "27%",
+            "0%"
+        ]
+    },
+    "initial_speed": 0,
+    "comfort": "STANDARD",
+    "constraint_distribution": "MARECO",
+    "speed_limit_tag": null,
+    "power_restrictions": [],
+    "options": {
+        "use_electrical_profiles": true
+    }
+}

--- a/editoast/src/views/timetable/tests/train_schedule_too_fast_on_interval.json
+++ b/editoast/src/views/timetable/tests/train_schedule_too_fast_on_interval.json
@@ -1,0 +1,70 @@
+{
+    "id": "trainschedule_38366",
+    "train_name": "tooFastOnInterval",
+    "labels": [],
+    "rolling_stock_name": "rs-fictive",
+    "start_time": "2026-12-13T07:25:00Z",
+    "path": [
+        {
+            "id": "idA",
+            "location": {
+                "operational_point": {
+                    "uic": 87700000,
+                    "secondary_code": "BV",
+                    "type": "uic"
+                }
+            }
+        },
+        {
+            "id": "idB",
+            "location": {
+                "operational_point": {
+                    "uic": 87700001,
+                    "secondary_code": "BV",
+                    "type": "uic"
+                }
+            }
+        },
+        {
+            "id": "idC",
+            "location": {
+                "operational_point": {
+                    "uic": 87700002,
+                    "secondary_code": "BV",
+                    "type": "uic"
+                }
+            }
+        }
+    ],
+    "schedule": [
+        {
+            "at": "idB",
+            "arrival": "PT5280S",
+            "stop_for": null,
+            "reception_signal": "OPEN"
+        },
+        {
+            "at": "idC",
+            "arrival": "PT15300S",
+            "stop_for": "P0D",
+            "reception_signal": "OPEN"
+        }
+    ],
+    "margins": {
+        "boundaries": ["idC"],
+        "values": [
+            "6.5min/100km",
+            "0%"
+        ]
+    },
+    "initial_speed": 0,
+    "comfort": "STANDARD",
+    "constraint_distribution": "STANDARD",
+    "speed_limit_tag": null,
+    "power_restrictions": [],
+    "options": {
+        "use_electrical_profiles": true,
+        "use_speed_limits_for_simulation": true
+    },
+    "category": null
+}

--- a/editoast/src/views/timetable/track_occupancy.rs
+++ b/editoast/src/views/timetable/track_occupancy.rs
@@ -204,7 +204,7 @@ pub fn find_track_occupancy_for_operational_point(
 
     let stop_duration = context
         .schedule_item
-        .and_then(|item| item.stop_for.clone())
+        .and_then(|item| item.stop_for)
         .unwrap_or_default();
 
     if let Some(track_section) = get_track_section(

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -534,6 +534,7 @@ pub(in crate::views) async fn simulation_summary(
         let simulation_summary_result = SummaryResponse::summarize_simulation(
             Arc::unwrap_or_clone(sim),
             Arc::unwrap_or_clone(path),
+            train_schedule,
         );
         simulation_summaries.insert(train_schedule.id, simulation_summary_result);
     }

--- a/front/src/applications/operationalStudies/__tests__/sampleData.ts
+++ b/front/src/applications/operationalStudies/__tests__/sampleData.ts
@@ -379,6 +379,8 @@ export const trainSummaryTooFast: Extract<SimulationSummaryResult, { status: 'su
   path_item_times_final: [0, 1739394, 3069187],
   path_item_times_provisional: [0, 1834414, 3164206],
   path_item_times_base: [0, 1444453, 2491479],
+  path_item_respect_times: [true, true, true],
+  path_item_respect_margins: [true, false, true],
   path_item_positions: [0, 1000, 2000],
 };
 
@@ -449,6 +451,8 @@ export const trainSummaryTooFastOnInterval: Extract<
   path_item_times_final: [0, 5280030, 15300915],
   path_item_times_provisional: [0, 5222392, 15267584],
   path_item_times_base: [0, 4730243, 13828795],
+  path_item_respect_times: [true, true, true],
+  path_item_respect_margins: [true, true, false],
   path_item_positions: [0, 1000, 2000],
 };
 
@@ -516,6 +520,8 @@ export const trainSummaryNotHonored: Extract<SimulationSummaryResult, { status: 
   path_item_times_final: [0, 1425534, 2186885],
   path_item_times_provisional: [0, 1425534, 2186885],
   path_item_times_base: [0, 1425534, 2186885],
+  path_item_respect_times: [true, false, true],
+  path_item_respect_margins: [true, true, true],
   path_item_positions: [0, 1000, 2000],
 };
 
@@ -588,5 +594,7 @@ export const trainSummaryHonored: Extract<SimulationSummaryResult, { status: 'su
   path_item_times_final: [0, 2186885],
   path_item_times_provisional: [0, 2186885],
   path_item_times_base: [0, 2186885],
+  path_item_respect_times: [true, true],
+  path_item_respect_margins: [true, true],
   path_item_positions: [0, 1000],
 };

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -4088,6 +4088,14 @@ export type SimulationSummaryResult =
     The length of this array is the number of path items in the train schedule used as input for the simulation.
     The first value is always `0` (beginning of the path) and the last one is always equal to the `length` of the path in mm */
       path_item_positions: number[];
+      /** Whether the final path times respect the input margins for each train schedule path item.
+    The length of this array is the number of path items in the train schedule used as input for the simulation.
+    Important: `true` means the provisional time is acceptable margin-wise, not *precisely* respecting the margin. */
+      path_item_respect_margins: boolean[];
+      /** Whether each path item in the train schedule is reached on time.
+    The length of this array is the number of path items in the train schedule used as input for the simulation.
+    Important: `true` doesn't mean the path item has been reached *precisely* at the requested time. Instead, it means it reached the path item at an acceptable time. */
+      path_item_respect_times: boolean[];
       /** Base simulation time for each train schedule path item.
     The length of this array is the number of path items in the train schedule used as input for the simulation.
     The first value is always `0` (beginning of the path) and the last one, the total time of the simulation (end of the path) */

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -4085,15 +4085,19 @@ export type SimulationSummaryResult =
       /** Length of a path in mm */
       length: number;
       /** The path offset in mm of each path item given as input of the pathfinding
+    The length of this array is the number of path items in the train schedule used as input for the simulation.
     The first value is always `0` (beginning of the path) and the last one is always equal to the `length` of the path in mm */
       path_item_positions: number[];
       /** Base simulation time for each train schedule path item.
+    The length of this array is the number of path items in the train schedule used as input for the simulation.
     The first value is always `0` (beginning of the path) and the last one, the total time of the simulation (end of the path) */
       path_item_times_base: number[];
       /** Final simulation time for each train schedule path item.
+    The length of this array is the number of path items in the train schedule used as input for the simulation.
     The first value is always `0` (beginning of the path) and the last one, the total time of the simulation (end of the path) */
       path_item_times_final: number[];
       /** Provisional simulation time for each train schedule path item.
+    The length of this array is the number of path items in the train schedule used as input for the simulation.
     The first value is always `0` (beginning of the path) and the last one, the total time of the simulation (end of the path) */
       path_item_times_provisional: number[];
       status: 'success';


### PR DESCRIPTION
Ref: https://github.com/osrd-project/osrd-confidential/issues/1263
Closes: #14256

The idea is to have editoast check whether the simulation respects margins and times of each schedule point in the simulation summary, instead of the frontend

Ports of the following functions from /front:

- https://github.com/OpenRailAssociation/osrd/blob/ec1964b55bf18db61b439d7628e3c05e648497bc/front/src/applications/operationalStudies/utils.ts#L254
- https://github.com/OpenRailAssociation/osrd/blob/ec1964b55bf18db61b439d7628e3c05e648497bc/front/src/applications/operationalStudies/utils.ts#L208

Ported the tests from
https://github.com/OpenRailAssociation/osrd/blob/ec1964b55bf18db61b439d7628e3c05e648497bc/front/src/applications/operationalStudies/__tests__/sampleData.ts#L318

using JSON so it's easier to copy over.

The functions will be used in the future to check if trains are valid (e.g. in conflicts)