### PR TITLE
front: fix geterrormessage too strict

### DIFF
--- a/front/src/utils/error.ts
+++ b/front/src/utils/error.ts
@@ -29,9 +29,13 @@ export function getErrorMessage(error: unknown, defaultValue?: string): string {
   // Check if it's an APIError
   if ('data' in error && 'status' in error) {
     if (isObject(error.data)) {
-      const { type, message: i18nMsg, context } = (error as ApiError).data;
-      const i18nId = type.split(':').join('.');
-      return i18n.t(i18nId, i18nMsg, { ...context, ns: 'errors' });
+      if ('type' in error.data) {
+        const { type, message: i18nMsg, context } = (error as ApiError).data;
+        const i18nId = type.split(':').join('.');
+        return i18n.t(i18nId, i18nMsg, { ...context, ns: 'errors' });
+      }
+      if ('message' in error.data) return `${error.data.message}`;
+      if ('detail' in error.data) return `${error.data.detail}`; // Format used by some implems of railway-manager-interface
     }
     if (typeof error.data === 'string') {
       // API returned a plaintext error instead of a JSON payload


### PR DESCRIPTION
Handle this type of error gracefully (as well as any error with either message or detail in the data field - after all we have poor control over the errors coming from the railway manager interface api) :

<img width="558" height="186" alt="image" src="https://github.com/user-attachments/assets/2bcd7d61-5b07-4613-b35f-a55398e36927" />

Before :

<img width="563" height="223" alt="image" src="https://github.com/user-attachments/assets/31a1a774-23cc-4201-a8c6-8294476f4453" />

and no error displayed to users.

After : 

<img width="402" height="148" alt="image" src="https://github.com/user-attachments/assets/708e7ab8-7d8d-47c2-b249-1fa93e014099" />
