### PR TITLE
 front: ngetoosrd: fix return overwitten on update 

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/ngeToOsrd/trainrun.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/ngeToOsrd/trainrun.ts
@@ -629,27 +629,45 @@ export const handleUpdateTimetableItem = async ({
 
   if (timetableItemIds[1]) {
     // update return if already present
-    if (newForwardPacedTrain) {
-      const updatedReturnPacedTrain = {
-        ...newForwardPacedTrain,
-        ...returnPathAndSchedule,
+    const oldReturnTimetableItem = await fetchTimetableItem(timetableItemIds[1], dispatch);
+    const { id: _return_id, ...returnTimetableItemBase } = oldReturnTimetableItem;
+    const newReturnTimetableItemBase = {
+      ...returnTimetableItemBase,
+      train_name: trainrun.name,
+      labels,
+      // Reset margins because they contain references to path items
+      margins: undefined,
+      paced: undefined,
+      exceptions: undefined,
+      category,
+      ...returnPathAndSchedule,
+    };
+    if (paced) {
+      const newReturnPacedTrainBase = {
+        ...newReturnTimetableItemBase,
+        paced: {
+          ...paced,
+          exceptions: isPacedTrainResponseWithPacedTrainId(oldReturnTimetableItem)
+            ? checkChangeGroups(
+                newReturnTimetableItemBase,
+                paced,
+                oldReturnTimetableItem.paced.exceptions
+              )
+            : [],
+        },
       };
       newReturnTimetableItem = await storePacedTrain(
-        timetableItemIds[1],
-        updatedReturnPacedTrain,
+        oldReturnTimetableItem.id,
+        newReturnPacedTrainBase,
         timetableId,
         dispatch,
         addUpsertedTimetableItems,
         addDeletedTimetableItemIds
       );
     } else {
-      const updatedReturnTrainSchedule = {
-        ...newForwardTimetableItem,
-        ...returnPathAndSchedule,
-      };
       newReturnTimetableItem = await storeTrainSchedule(
-        timetableItemIds[1],
-        updatedReturnTrainSchedule,
+        oldReturnTimetableItem.id,
+        newReturnTimetableItemBase,
         timetableId,
         dispatch,
         addUpsertedTimetableItems,

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/ngeToOsrd/trainrun.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/ngeToOsrd/trainrun.ts
@@ -539,8 +539,7 @@ export const handleUpdateTimetableItem = async ({
   );
   await populateSecondaryCodesInPath(forwardPathAndSchedule.path, infraId, dispatch);
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { id, ...timetableItemBase } = oldForwardTimetableItem;
+  const { id: _id, ...timetableItemBase } = oldForwardTimetableItem;
 
   const category = getTrainCategoryFromTrainrunCategoryId(
     state.trainrunCategories,


### PR DESCRIPTION
Part of [#13034](https://github.com/OpenRailAssociation/osrd/issues/13034)

We did not fetch the return when updating it,
thus we overwrote its non-nge data (such as rolling stock)
with those of the forward trip.

Any property present in nge only once still gets overwritten,
as nge does not support partial update yet.

Before and after : 

[ngebeforeafter_returntoomuchupdated.webm](https://github.com/user-attachments/assets/a41d2694-9a12-4cd4-aeb6-f34bc21a0f4c)

