### PR TITLE
osrd_schemas: add default values for literal

### DIFF
--- a/front/src/reducers/osrdconf/infra_schema.json
+++ b/front/src/reducers/osrdconf/infra_schema.json
@@ -183,12 +183,12 @@
                 },
                 "type": {
                     "const": "BufferStop",
+                    "default": "BufferStop",
                     "title": "Type",
                     "type": "string"
                 }
             },
             "required": [
-                "type",
                 "id"
             ],
             "title": "BufferStopReference",
@@ -323,12 +323,12 @@
                 },
                 "type": {
                     "const": "Detector",
+                    "default": "Detector",
                     "title": "Type",
                     "type": "string"
                 }
             },
             "required": [
-                "type",
                 "id"
             ],
             "title": "DetectorReference",

--- a/python/osrd_schemas/osrd_schemas/infra.py
+++ b/python/osrd_schemas/osrd_schemas/infra.py
@@ -19,12 +19,12 @@ NonBlankStr = Annotated[str, StringConstraints(min_length=1)]
 
 
 class DetectorReference(BaseModel):
-    type: Literal["Detector"]
+    type: Literal["Detector"] = "Detector"
     id: Identifier = Field(description="Identifier of the detector")
 
 
 class BufferStopReference(BaseModel):
-    type: Literal["BufferStop"]
+    type: Literal["BufferStop"] = "BufferStop"
     id: Identifier = Field(description="Identifier of the buffer stop")
 
 

--- a/python/osrd_schemas/pyproject.toml
+++ b/python/osrd_schemas/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "osrd_schemas"
-version = "0.9.0"
+version = "0.9.1"
 description = ""
 authors = [{ name = "OSRD Contributors", email = "contact@osrd.fr" }]
 requires-python = ">= 3.11"

--- a/python/osrd_schemas/uv.lock
+++ b/python/osrd_schemas/uv.lock
@@ -34,7 +34,7 @@ wheels = [
 
 [[package]]
 name = "osrd-schemas"
-version = "0.9.0"
+version = "0.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "geojson-pydantic" },

--- a/python/railjson_generator/pyproject.toml
+++ b/python/railjson_generator/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "railjson_generator"
-version = "0.4.11"
+version = "0.4.12"
 description = ""
 authors = [{ name = "OSRD Contributors", email = "contact@osrd.fr" }]
 requires-python = ">= 3.11"

--- a/python/railjson_generator/uv.lock
+++ b/python/railjson_generator/uv.lock
@@ -106,7 +106,7 @@ wheels = [
 
 [[package]]
 name = "osrd-schemas"
-version = "0.9.0"
+version = "0.9.1"
 source = { editable = "../osrd_schemas" }
 dependencies = [
     { name = "geojson-pydantic" },
@@ -250,7 +250,7 @@ wheels = [
 
 [[package]]
 name = "railjson-generator"
-version = "0.4.11"
+version = "0.4.12"
 source = { editable = "." }
 dependencies = [
     { name = "osrd-schemas" },


### PR DESCRIPTION
When default values are not present, you have to declare a new Detector as `Detector(type="Detector", id="d1")`. Putting a default value makes it as simple as `Detector("d1")`.