### PR TITLE
editoast: remove ScopedBoxFuture and useless bound from transactions

### DIFF
--- a/editoast/database/src/db_connection_pool.rs
+++ b/editoast/database/src/db_connection_pool.rs
@@ -14,7 +14,6 @@ use diesel_async::pooled_connection::AsyncDieselConnectionManager;
 use diesel_async::pooled_connection::ManagerConfig;
 use diesel_async::pooled_connection::deadpool::Object;
 use diesel_async::pooled_connection::deadpool::Pool;
-use diesel_async::scoped_futures::ScopedBoxFuture;
 use futures::Future;
 use futures::future::BoxFuture;
 use futures_util::FutureExt as _;
@@ -152,11 +151,11 @@ impl DbConnection {
     //
     // :WARNING: If you ever need to modify this function, please take a look at the
     // original `diesel` function, they probably do it right more than us.
-    pub async fn transaction<'a, R, E, F>(&self, callback: F) -> std::result::Result<R, E>
+    pub async fn transaction<R, E, F, Fut>(&self, callback: F) -> std::result::Result<R, E>
     where
-        F: FnOnce(Self) -> ScopedBoxFuture<'a, 'a, std::result::Result<R, E>> + Send + 'a,
-        E: From<DatabaseError> + Send + 'a,
-        R: Send + 'a,
+        F: FnOnce(Self) -> Fut,
+        Fut: Future<Output = std::result::Result<R, E>>,
+        E: From<DatabaseError>,
     {
         use diesel_async::TransactionManager as _;
 

--- a/editoast/editoast_models/src/project.rs
+++ b/editoast/editoast_models/src/project.rs
@@ -1,8 +1,6 @@
 use chrono::DateTime;
 use chrono::Utc;
 use database::DbConnection;
-use diesel_async::scoped_futures::ScopedBoxFuture;
-use diesel_async::scoped_futures::ScopedFutureExt;
 use editoast_derive::Model;
 use serde::Deserialize;
 use serde::Serialize;
@@ -39,24 +37,21 @@ async fn try_delete_document(
     doc_id: i64,
 ) -> Result<(), editoast_models::Error> {
     let res = conn
-        .transaction(|mut conn| {
-            async move {
-                match Document::delete_static(&mut conn, doc_id).await {
-                    Ok(false) => unreachable!(
-                        "cannot happen as the Document has to be there because of the FK on `image`"
-                    ),
-                    Ok(true) => Ok(()),
-                    // We want the delete to occur in a transaction in order to rollback it if the deletion fails.
-                    // The deletion can fail if the document is still used by another project (FK violation). This
-                    // is acceptable, it's what this function does.
-                    // However, if a FK violation occurs, the transaction must rolloback otherwise each subsequent
-                    // query will fail. If the violation occurs, `e` is an `Err`, therefore we return it in order
-                    // to let `transaction` rollback. We then match on the error below in order to accept the
-                    // FK violation, which is not an error in our workflow.
-                    Err(e) => Err(e),
-                }
+        .transaction(async move |mut conn| {
+            match Document::delete_static(&mut conn, doc_id).await {
+                Ok(false) => unreachable!(
+                    "cannot happen as the Document has to be there because of the FK on `image`"
+                ),
+                Ok(true) => Ok(()),
+                // We want the delete to occur in a transaction in order to rollback it if the deletion fails.
+                // The deletion can fail if the document is still used by another project (FK violation). This
+                // is acceptable, it's what this function does.
+                // However, if a FK violation occurs, the transaction must rolloback otherwise each subsequent
+                // query will fail. If the violation occurs, `e` is an `Err`, therefore we return it in order
+                // to let `transaction` rollback. We then match on the error below in order to accept the
+                // FK violation, which is not an error in our workflow.
+                Err(e) => Err(e),
             }
-            .scope_boxed()
         })
         .await;
     match res {
@@ -110,19 +105,16 @@ impl Project {
         conn: &mut DbConnection,
         new_doc_id: Option<i64>,
     ) -> Result<(), editoast_models::Error> {
-        conn.transaction(|mut conn| {
-            async move {
-                let old_doc_id = self.image;
-                self.image = new_doc_id;
-                self.save(&mut conn).await?;
-                if new_doc_id != old_doc_id
-                    && let Some(old_doc_id) = old_doc_id
-                {
-                    try_delete_document(&conn, old_doc_id).await?;
-                }
-                Ok::<_, editoast_models::Error>(())
+        conn.transaction(async move |mut conn| {
+            let old_doc_id = self.image;
+            self.image = new_doc_id;
+            self.save(&mut conn).await?;
+            if new_doc_id != old_doc_id
+                && let Some(old_doc_id) = old_doc_id
+            {
+                try_delete_document(&conn, old_doc_id).await?;
             }
-            .scope_boxed()
+            Ok::<_, editoast_models::Error>(())
         })
         .await?;
         Ok(())
@@ -134,20 +126,17 @@ impl Project {
         self,
         conn: &mut DbConnection,
     ) -> Result<(), editoast_models::Error> {
-        conn.transaction(|mut conn| {
-            async move {
-                if !self.delete(&mut conn).await? {
-                    tracing::warn!(
-                        project_id = self.id,
-                        "project to delete not found, probable race condition"
-                    );
-                }
-                if let Some(doc_id) = self.image {
-                    try_delete_document(&conn, doc_id).await?;
-                }
-                Ok(())
+        conn.transaction(async move |mut conn| {
+            if !self.delete(&mut conn).await? {
+                tracing::warn!(
+                    project_id = self.id,
+                    "project to delete not found, probable race condition"
+                );
             }
-            .scope_boxed()
+            if let Some(doc_id) = self.image {
+                try_delete_document(&conn, doc_id).await?;
+            }
+            Ok(())
         })
         .await
     }
@@ -156,38 +145,33 @@ impl Project {
     ///
     /// The [Project::last_modification] field is updated to the current time after the function is called.
     #[tracing::instrument(skip(conn, f), err)]
-    pub async fn transactional_content_update<T, E, F>(
+    pub async fn transactional_content_update<T, E, F, Fut>(
         conn: DbConnection,
         project_id: i64,
         f: F,
     ) -> Result<Result<T, E>, Error>
     where
-        T: Send,
-        E: Send,
-        F: FnOnce(DbConnection, Self) -> ScopedBoxFuture<'static, 'static, Result<T, E>> + Send,
+        F: FnOnce(DbConnection, Self) -> Fut,
+        Fut: Future<Output = Result<T, E>>,
     {
-        conn.transaction(|mut conn| {
-            async move {
-                let project = Self::retrieve_or_fail(conn.clone(), project_id, || {
-                    Error::NotFound { project_id }
-                })
-                .await?;
-
-                let id = project.id;
-                let res = f(conn.clone(), project).await;
-                let res = match res {
-                    Ok(t) => t,
-                    Err(e) => return Ok(Err(e)),
-                };
-
-                Project::changeset()
-                    .last_modification(Utc::now())
-                    .update(&mut conn, id)
+        conn.transaction(async move |mut conn| {
+            let project =
+                Self::retrieve_or_fail(conn.clone(), project_id, || Error::NotFound { project_id })
                     .await?;
 
-                Ok(Ok(res))
-            }
-            .scope_boxed()
+            let id = project.id;
+            let res = f(conn.clone(), project).await;
+            let res = match res {
+                Ok(t) => t,
+                Err(e) => return Ok(Err(e)),
+            };
+
+            Project::changeset()
+                .last_modification(Utc::now())
+                .update(&mut conn, id)
+                .await?;
+
+            Ok(Ok(res))
         })
         .await
     }

--- a/editoast/editoast_models/src/scenario.rs
+++ b/editoast/editoast_models/src/scenario.rs
@@ -5,8 +5,6 @@ use chrono::Utc;
 use diesel::ExpressionMethods;
 use diesel::QueryDsl;
 use diesel_async::RunQueryDsl;
-use diesel_async::scoped_futures::ScopedBoxFuture;
-use diesel_async::scoped_futures::ScopedFutureExt as _;
 use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
@@ -93,57 +91,44 @@ impl Scenario {
     ///
     /// The last modification field of these three objects are updated before the transaction is committed.
     #[tracing::instrument(skip(conn, f), err)]
-    pub async fn transactional_content_update<T, E, F>(
+    pub async fn transactional_content_update<T, E, F, Fut>(
         conn: DbConnection,
         scenario_id: i64,
         f: F,
     ) -> Result<Result<T, E>, Error>
     where
-        T: Send,
-        E: Send,
-        F: FnOnce(
-                DbConnection,
-                Self,
-                Study,
-                Project,
-            ) -> ScopedBoxFuture<'static, 'static, Result<T, E>>
-            + Send
-            + 'static,
+        F: FnOnce(DbConnection, Self, Study, Project) -> Fut,
+        Fut: Future<Output = Result<T, E>>,
     {
-        conn.transaction(|mut conn| {
-            async move {
-                let scenario = Self::retrieve_or_fail(conn.clone(), scenario_id, || {
-                    Error::NotFound { scenario_id }
-                })
+        conn.transaction(async move |mut conn| {
+            let scenario = Self::retrieve_or_fail(conn.clone(), scenario_id, || Error::NotFound {
+                scenario_id,
+            })
+            .await?;
+
+            let id = scenario.id;
+            let t = Study::transactional_content_update(
+                conn.clone(),
+                scenario.study_id,
+                async move |conn, study, project| f(conn, scenario, study, project).await,
+            )
+            .await;
+
+            let t = match t {
+                Ok(Ok(t)) => t,
+                Ok(Err(e)) => return Ok(Err(e)),
+                Err(super::study::Error::NotFound { .. }) => {
+                    unreachable!("Database integrity error: Scenario's study not found")
+                }
+                Err(super::study::Error::Database(e)) => return Err(e.into()),
+            };
+
+            Scenario::changeset()
+                .last_modification(Utc::now())
+                .update(&mut conn, id)
                 .await?;
 
-                let id = scenario.id;
-                let t = Study::transactional_content_update(
-                    conn.clone(),
-                    scenario.study_id,
-                    |conn, study, project| {
-                        async move { f(conn, scenario, study, project).await }.scope_boxed()
-                    },
-                )
-                .await;
-
-                let t = match t {
-                    Ok(Ok(t)) => t,
-                    Ok(Err(e)) => return Ok(Err(e)),
-                    Err(super::study::Error::NotFound { .. }) => {
-                        unreachable!("Database integrity error: Scenario's study not found")
-                    }
-                    Err(super::study::Error::Database(e)) => return Err(e.into()),
-                };
-
-                Scenario::changeset()
-                    .last_modification(Utc::now())
-                    .update(&mut conn, id)
-                    .await?;
-
-                Ok(Ok(t))
-            }
-            .scope_boxed()
+            Ok(Ok(t))
         })
         .await
     }

--- a/editoast/editoast_models/src/study.rs
+++ b/editoast/editoast_models/src/study.rs
@@ -3,8 +3,6 @@ use chrono::NaiveDate;
 use chrono::Utc;
 
 use database::DbConnection;
-use diesel_async::scoped_futures::ScopedBoxFuture;
-use diesel_async::scoped_futures::ScopedFutureExt;
 use editoast_derive::Model;
 use serde::Deserialize;
 use serde::Serialize;
@@ -75,49 +73,43 @@ impl Study {
     ///
     /// The last modification field of these objects are updated before the transaction is committed.
     #[tracing::instrument(skip(conn, f), err)]
-    pub async fn transactional_content_update<T, E, F>(
+    pub async fn transactional_content_update<T, E, F, Fut>(
         conn: DbConnection,
         study_id: i64,
         f: F,
     ) -> Result<Result<T, E>, Error>
     where
-        T: Send,
-        E: Send,
-        F: FnOnce(DbConnection, Self, Project) -> ScopedBoxFuture<'static, 'static, Result<T, E>>
-            + Send
-            + 'static,
+        F: FnOnce(DbConnection, Self, Project) -> Fut,
+        Fut: Future<Output = Result<T, E>>,
     {
-        conn.transaction(|mut conn| {
-            async move {
-                let study =
-                    Self::retrieve_or_fail(conn.clone(), study_id, || Error::NotFound { study_id })
-                        .await?;
-
-                let id = study.id;
-                let t = Project::transactional_content_update(
-                    conn.clone(),
-                    study.project_id,
-                    |conn, project| async move { f(conn, study, project).await }.scope_boxed(),
-                )
-                .await;
-
-                let t = match t {
-                    Ok(Ok(t)) => t,
-                    Ok(Err(e)) => return Ok(Err(e)),
-                    Err(super::project::Error::NotFound { .. }) => {
-                        unreachable!("Database integrity error: Study's project not found")
-                    }
-                    Err(super::project::Error::Database(e)) => return Err(e.into()),
-                };
-
-                Study::changeset()
-                    .last_modification(Utc::now())
-                    .update(&mut conn, id)
+        conn.transaction(async move |mut conn| {
+            let study =
+                Self::retrieve_or_fail(conn.clone(), study_id, || Error::NotFound { study_id })
                     .await?;
 
-                Ok(Ok(t))
-            }
-            .scope_boxed()
+            let id = study.id;
+            let t = Project::transactional_content_update(
+                conn.clone(),
+                study.project_id,
+                async move |conn, project| f(conn, study, project).await,
+            )
+            .await;
+
+            let t = match t {
+                Ok(Ok(t)) => t,
+                Ok(Err(e)) => return Ok(Err(e)),
+                Err(super::project::Error::NotFound { .. }) => {
+                    unreachable!("Database integrity error: Study's project not found")
+                }
+                Err(super::project::Error::Database(e)) => return Err(e.into()),
+            };
+
+            Study::changeset()
+                .last_modification(Utc::now())
+                .update(&mut conn, id)
+                .await?;
+
+            Ok(Ok(t))
         })
         .await
     }

--- a/editoast/src/models/auth_driver.rs
+++ b/editoast/src/models/auth_driver.rs
@@ -12,7 +12,6 @@ use database::DbConnectionPoolV2;
 use diesel::dsl;
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
-use diesel_async::scoped_futures::ScopedFutureExt as _;
 use editoast_models::prelude::*;
 
 use database::tables::*;
@@ -127,41 +126,38 @@ impl StorageDriver for PgAuthDriver {
     #[tracing::instrument(skip_all, fields(%user), ret(level = Level::DEBUG), err)]
     async fn ensure_user(&self, user: &UserInfo) -> Result<User, Self::Error> {
         let conn = self.pool.get().await?;
-        conn.transaction(|conn| {
-            async move {
-                let user_info = self.get_user_info_by_identity(&user.identity).await?;
-                match user_info {
-                    Some(user_info) => {
-                        tracing::debug!(?user_info, "user already exists in db");
-                        Ok(user_info)
-                    }
+        conn.transaction(async move |conn| {
+            let user_info = self.get_user_info_by_identity(&user.identity).await?;
+            match user_info {
+                Some(user_info) => {
+                    tracing::debug!(?user_info, "user already exists in db");
+                    Ok(user_info)
+                }
 
-                    None => {
-                        tracing::info!("registering new user in db");
+                None => {
+                    tracing::info!("registering new user in db");
 
-                        let id: i64 = dsl::insert_into(authn_subject::table)
-                            .default_values()
-                            .returning(authn_subject::id)
-                            .get_result(&mut conn.clone().write().await)
-                            .await?;
+                    let id: i64 = dsl::insert_into(authn_subject::table)
+                        .default_values()
+                        .returning(authn_subject::id)
+                        .get_result(&mut conn.clone().write().await)
+                        .await?;
 
-                        dsl::insert_into(authn_user::table)
-                            .values((
-                                authn_user::id.eq(id),
-                                authn_user::identity_id.eq(&user.identity),
-                                authn_user::name.eq(&user.name),
-                            ))
-                            .execute(conn.write().await.deref_mut())
-                            .await?;
+                    dsl::insert_into(authn_user::table)
+                        .values((
+                            authn_user::id.eq(id),
+                            authn_user::identity_id.eq(&user.identity),
+                            authn_user::name.eq(&user.name),
+                        ))
+                        .execute(conn.write().await.deref_mut())
+                        .await?;
 
-                        Ok(User {
-                            id,
-                            info: user.clone(),
-                        })
-                    }
+                    Ok(User {
+                        id,
+                        info: user.clone(),
+                    })
                 }
             }
-            .scope_boxed()
         })
         .await
     }
@@ -169,39 +165,36 @@ impl StorageDriver for PgAuthDriver {
     #[tracing::instrument(skip_all, fields(%group), ret(level = Level::DEBUG), err)]
     async fn ensure_group(&self, group: &GroupInfo) -> Result<i64, Self::Error> {
         let conn = self.pool.get().await?;
-        conn.transaction(|conn| {
-            async move {
-                let group_id = authn_group::table
-                    .select(authn_group::id)
-                    .filter(authn_group::name.eq(&group.name))
-                    .first::<i64>(conn.write().await.deref_mut())
-                    .await
-                    .optional()?;
-                match group_id {
-                    Some(group_id) => {
-                        tracing::debug!(group_id, "group already exists in db");
-                        Ok(group_id)
-                    }
+        conn.transaction(async move |conn| {
+            let group_id = authn_group::table
+                .select(authn_group::id)
+                .filter(authn_group::name.eq(&group.name))
+                .first::<i64>(conn.write().await.deref_mut())
+                .await
+                .optional()?;
+            match group_id {
+                Some(group_id) => {
+                    tracing::debug!(group_id, "group already exists in db");
+                    Ok(group_id)
+                }
 
-                    None => {
-                        tracing::info!("registering new group in db");
+                None => {
+                    tracing::info!("registering new group in db");
 
-                        let id: i64 = dsl::insert_into(authn_subject::table)
-                            .default_values()
-                            .returning(authn_subject::id)
-                            .get_result(&mut conn.clone().write().await)
-                            .await?;
+                    let id: i64 = dsl::insert_into(authn_subject::table)
+                        .default_values()
+                        .returning(authn_subject::id)
+                        .get_result(&mut conn.clone().write().await)
+                        .await?;
 
-                        dsl::insert_into(authn_group::table)
-                            .values((authn_group::id.eq(id), authn_group::name.eq(&group.name)))
-                            .execute(conn.write().await.deref_mut())
-                            .await?;
+                    dsl::insert_into(authn_group::table)
+                        .values((authn_group::id.eq(id), authn_group::name.eq(&group.name)))
+                        .execute(conn.write().await.deref_mut())
+                        .await?;
 
-                        Ok(id)
-                    }
+                    Ok(id)
                 }
             }
-            .scope_boxed()
         })
         .await
     }

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -17,7 +17,6 @@ use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::response::Json;
 use database::DbConnectionPoolV2;
-use diesel_async::scoped_futures::ScopedFutureExt;
 use editoast_derive::EditoastError;
 use editoast_models::Group;
 use editoast_models::User;
@@ -505,58 +504,55 @@ pub(in crate::views) async fn subjects_with_grant_on_resource(
     let (stats, subjects_id, mut users, mut groups) = db_pool
         .get()
         .await?
-        .transaction::<_, crate::error::InternalError, _>(move |mut conn| {
-            async move {
-                // Query the subjects from the database.
-                // OpenFGA might have returned subjects that don't exist, so these will be filtered out.
-                // The pagination will be correct even in this case.
-                let (subjects, stats) = editoast_models::Subject::list_paginated(
-                    &mut conn,
-                    pagination
-                        .into_selection_settings()
-                        .filter(move || editoast_models::Subject::ID.eq_any(subjects_id.clone()))
-                        .order_by(move || editoast_models::Subject::ID.asc()),
-                )
-                .await?;
+        .transaction::<_, crate::error::InternalError, _, _>(async move |mut conn| {
+            // Query the subjects from the database.
+            // OpenFGA might have returned subjects that don't exist, so these will be filtered out.
+            // The pagination will be correct even in this case.
+            let (subjects, stats) = editoast_models::Subject::list_paginated(
+                &mut conn,
+                pagination
+                    .into_selection_settings()
+                    .filter(move || editoast_models::Subject::ID.eq_any(subjects_id.clone()))
+                    .order_by(move || editoast_models::Subject::ID.asc()),
+            )
+            .await?;
 
-                // Take the IDs of the subjects that were returned by the database — which do exist for sure now.
-                let subjects_id = subjects
-                    .into_iter()
-                    .map(|editoast_models::Subject { id }| id)
-                    .collect_vec();
-
-                // Query the database for users and groups details.
-                let users = editoast_models::User::list(
-                    &mut conn,
-                    SelectionSettings::new()
-                        .filter({
-                            let ids = subjects_id.clone();
-                            move || editoast_models::User::ID.eq_any(ids.clone())
-                        })
-                        .order_by(move || editoast_models::User::ID.asc()),
-                )
-                .await?
+            // Take the IDs of the subjects that were returned by the database — which do exist for sure now.
+            let subjects_id = subjects
                 .into_iter()
-                .map(|editoast_models::User { id, name, .. }| (id, name))
-                .collect::<HashMap<_, _>>();
+                .map(|editoast_models::Subject { id }| id)
+                .collect_vec();
 
-                let groups = editoast_models::Group::list(
-                    &mut conn,
-                    SelectionSettings::new()
-                        .filter({
-                            let ids = subjects_id.clone();
-                            move || editoast_models::Group::ID.eq_any(ids.clone())
-                        })
-                        .order_by(move || editoast_models::Group::ID.asc()),
-                )
-                .await?
-                .into_iter()
-                .map(|editoast_models::Group { id, name }| (id, name))
-                .collect::<HashMap<_, _>>();
+            // Query the database for users and groups details.
+            let users = editoast_models::User::list(
+                &mut conn,
+                SelectionSettings::new()
+                    .filter({
+                        let ids = subjects_id.clone();
+                        move || editoast_models::User::ID.eq_any(ids.clone())
+                    })
+                    .order_by(move || editoast_models::User::ID.asc()),
+            )
+            .await?
+            .into_iter()
+            .map(|editoast_models::User { id, name, .. }| (id, name))
+            .collect::<HashMap<_, _>>();
 
-                Ok((stats, subjects_id, users, groups))
-            }
-            .scope_boxed()
+            let groups = editoast_models::Group::list(
+                &mut conn,
+                SelectionSettings::new()
+                    .filter({
+                        let ids = subjects_id.clone();
+                        move || editoast_models::Group::ID.eq_any(ids.clone())
+                    })
+                    .order_by(move || editoast_models::Group::ID.asc()),
+            )
+            .await?
+            .into_iter()
+            .map(|editoast_models::Group { id, name }| (id, name))
+            .collect::<HashMap<_, _>>();
+
+            Ok((stats, subjects_id, users, groups))
         })
         .await?;
 

--- a/editoast/src/views/project.rs
+++ b/editoast/src/views/project.rs
@@ -9,7 +9,6 @@ use axum::response::IntoResponse;
 use chrono::Utc;
 use database::DbConnection;
 use database::DbConnectionPoolV2;
-use diesel_async::scoped_futures::ScopedFutureExt as _;
 use editoast_derive::EditoastError;
 use editoast_models::prelude::*;
 use serde::Deserialize;
@@ -285,16 +284,13 @@ pub(in crate::views) async fn delete(
     db_pool
         .get()
         .await?
-        .transaction(|mut conn| {
-            async move {
-                let project = Project::retrieve_or_fail(conn.clone(), project_id, || {
-                    ProjectError::NotFound { project_id }
-                })
-                .await?;
-                project.delete_and_prune_document(&mut conn).await?;
-                Ok::<_, ProjectError>(())
-            }
-            .scope_boxed()
+        .transaction(async move |mut conn| {
+            let project = Project::retrieve_or_fail(conn.clone(), project_id, || {
+                ProjectError::NotFound { project_id }
+            })
+            .await?;
+            project.delete_and_prune_document(&mut conn).await?;
+            Ok::<_, ProjectError>(())
         })
         .await?;
 
@@ -384,25 +380,25 @@ pub(in crate::views) async fn patch(
     };
     let project_changeset = form.into_changeset();
 
-    let project =
-        Project::transactional_content_update(conn.clone(), project_id, |mut conn, project| {
-            async move {
-                let mut project = project_changeset
-                    .update_or_fail(&mut conn, project.id, || ProjectError::NotFound {
-                        project_id: project.id,
-                    })
+    let project = Project::transactional_content_update(
+        conn.clone(),
+        project_id,
+        async move |mut conn, project| {
+            let mut project = project_changeset
+                .update_or_fail(&mut conn, project.id, || ProjectError::NotFound {
+                    project_id: project.id,
+                })
+                .await?;
+            if let Some(new_doc_id) = update_image {
+                project
+                    .update_and_prune_document(&mut conn, new_doc_id)
                     .await?;
-                if let Some(new_doc_id) = update_image {
-                    project
-                        .update_and_prune_document(&mut conn, new_doc_id)
-                        .await?;
-                }
-                Ok::<_, ProjectError>(project)
             }
-            .scope_boxed()
-        })
-        .await
-        .map_err(ProjectError::from)??;
+            Ok::<_, ProjectError>(project)
+        },
+    )
+    .await
+    .map_err(ProjectError::from)??;
 
     Ok(Json(
         ProjectWithStudyCount::try_fetch(&mut conn, project).await?,

--- a/editoast/src/views/rolling_stock.rs
+++ b/editoast/src/views/rolling_stock.rs
@@ -17,7 +17,6 @@ use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use database::DbConnection;
 use database::DbConnectionPoolV2;
-use diesel_async::scoped_futures::ScopedFutureExt as _;
 use editoast_derive::EditoastError;
 use image::DynamicImage;
 use image::GenericImage;
@@ -341,34 +340,31 @@ pub(in crate::views) async fn update(
     let new_rolling_stock = db_pool
         .get()
         .await?
-        .transaction::<_, InternalError, _>(|conn| {
-            async move {
-                let previous_rolling_stock =
-                    RollingStock::retrieve_or_fail(conn.clone(), rolling_stock_id, || {
-                        RollingStockError::KeyNotFound {
-                            rolling_stock_key: RollingStockKey::Id(rolling_stock_id),
-                        }
-                    })
-                    .await?;
-                assert_rolling_stock_unlocked(&previous_rolling_stock)?;
+        .transaction::<_, InternalError, _, _>(async move |conn| {
+            let previous_rolling_stock =
+                RollingStock::retrieve_or_fail(conn.clone(), rolling_stock_id, || {
+                    RollingStockError::KeyNotFound {
+                        rolling_stock_key: RollingStockKey::Id(rolling_stock_id),
+                    }
+                })
+                .await?;
+            assert_rolling_stock_unlocked(&previous_rolling_stock)?;
 
-                if rolling_stock_form != previous_rolling_stock.clone().into() {
-                    let mut rolling_stock_changeset: Changeset<RollingStock> =
-                        rolling_stock_form.clone().into();
-                    rolling_stock_changeset.version = Some(&previous_rolling_stock.version + 1);
-                    let new_rolling_stock = rolling_stock_changeset
-                        .update(&mut conn.clone(), rolling_stock_id)
-                        .await
-                        .map_err(RollingStockError::from)?
-                        .ok_or(RollingStockError::KeyNotFound {
-                            rolling_stock_key: RollingStockKey::Id(rolling_stock_id),
-                        })?;
-                    Ok(new_rolling_stock)
-                } else {
-                    Ok(previous_rolling_stock)
-                }
+            if rolling_stock_form != previous_rolling_stock.clone().into() {
+                let mut rolling_stock_changeset: Changeset<RollingStock> =
+                    rolling_stock_form.clone().into();
+                rolling_stock_changeset.version = Some(&previous_rolling_stock.version + 1);
+                let new_rolling_stock = rolling_stock_changeset
+                    .update(&mut conn.clone(), rolling_stock_id)
+                    .await
+                    .map_err(RollingStockError::from)?
+                    .ok_or(RollingStockError::KeyNotFound {
+                        rolling_stock_key: RollingStockKey::Id(rolling_stock_id),
+                    })?;
+                Ok(new_rolling_stock)
+            } else {
+                Ok(previous_rolling_stock)
             }
-            .scope_boxed()
         })
         .await?;
 

--- a/editoast/src/views/rolling_stock/towed.rs
+++ b/editoast/src/views/rolling_stock/towed.rs
@@ -15,7 +15,6 @@ use axum::extract::Query;
 use axum::extract::State;
 use axum::http::StatusCode;
 use database::DbConnectionPoolV2;
-use diesel_async::scoped_futures::ScopedFutureExt as _;
 use editoast_derive::EditoastError;
 use editoast_models::TowedRollingStock;
 use editoast_models::prelude::*;
@@ -194,41 +193,36 @@ pub(in crate::views) async fn put_by_id(
     let new_towed_rolling_stock = db_pool
         .get()
         .await?
-        .transaction::<_, InternalError, _>(|conn| {
-            async move {
-                let existing_rolling_stock = TowedRollingStock::retrieve_or_fail(
-                    conn.clone(),
-                    towed_rolling_stock_id,
-                    || TowedRollingStockError::IdNotFound {
-                        towed_rolling_stock_id,
-                    },
-                )
-                .await?;
-
-                if existing_rolling_stock.locked {
-                    return Err(TowedRollingStockError::IsLocked {
+        .transaction::<_, InternalError, _, _>(async move |conn| {
+            let existing_rolling_stock =
+                TowedRollingStock::retrieve_or_fail(conn.clone(), towed_rolling_stock_id, || {
+                    TowedRollingStockError::IdNotFound {
                         towed_rolling_stock_id,
                     }
-                    .into());
-                }
+                })
+                .await?;
 
-                if towed_rolling_stock_form != existing_rolling_stock.clone().into() {
-                    let mut towed_rolling_stock_changeset: Changeset<TowedRollingStock> =
-                        towed_rolling_stock_form.clone().into();
-                    towed_rolling_stock_changeset.version =
-                        Some(&existing_rolling_stock.version + 1);
-                    let new_towed_rolling_stock = towed_rolling_stock_changeset
-                        .update(&mut conn.clone(), towed_rolling_stock_id)
-                        .await?
-                        .ok_or(TowedRollingStockError::IdNotFound {
-                            towed_rolling_stock_id,
-                        })?;
-                    Ok(new_towed_rolling_stock)
-                } else {
-                    Ok(existing_rolling_stock)
+            if existing_rolling_stock.locked {
+                return Err(TowedRollingStockError::IsLocked {
+                    towed_rolling_stock_id,
                 }
+                .into());
             }
-            .scope_boxed()
+
+            if towed_rolling_stock_form != existing_rolling_stock.clone().into() {
+                let mut towed_rolling_stock_changeset: Changeset<TowedRollingStock> =
+                    towed_rolling_stock_form.clone().into();
+                towed_rolling_stock_changeset.version = Some(&existing_rolling_stock.version + 1);
+                let new_towed_rolling_stock = towed_rolling_stock_changeset
+                    .update(&mut conn.clone(), towed_rolling_stock_id)
+                    .await?
+                    .ok_or(TowedRollingStockError::IdNotFound {
+                        towed_rolling_stock_id,
+                    })?;
+                Ok(new_towed_rolling_stock)
+            } else {
+                Ok(existing_rolling_stock)
+            }
         })
         .await?;
 

--- a/editoast/src/views/round_trips.rs
+++ b/editoast/src/views/round_trips.rs
@@ -12,7 +12,6 @@ use axum::extract::Query;
 use axum::extract::State;
 use axum::response::IntoResponse;
 use database::DbConnectionPoolV2;
-use diesel_async::scoped_futures::ScopedFutureExt;
 use editoast_derive::EditoastError;
 use editoast_models::prelude::*;
 use editoast_models::round_trips::PacedTrainRoundTrips;
@@ -140,17 +139,11 @@ pub(in crate::views) async fn post_train_schedules(
     db_pool
         .get()
         .await?
-        .transaction::<_, crate::error::InternalError, _>(|mut conn| {
-            async move {
-                TrainScheduleRoundTrips::delete_batch_train_ids(&mut conn, to_remove).await?;
-                TrainScheduleRoundTrips::create_batch::<_, Vec<_>>(
-                    &mut conn,
-                    round_trips_changesets,
-                )
+        .transaction::<_, crate::error::InternalError, _, _>(async move |mut conn| {
+            TrainScheduleRoundTrips::delete_batch_train_ids(&mut conn, to_remove).await?;
+            TrainScheduleRoundTrips::create_batch::<_, Vec<_>>(&mut conn, round_trips_changesets)
                 .await?;
-                Ok(())
-            }
-            .scope_boxed()
+            Ok(())
         })
         .await?;
 
@@ -205,14 +198,11 @@ pub(in crate::views) async fn post_paced_trains(
     db_pool
         .get()
         .await?
-        .transaction::<_, crate::error::InternalError, _>(|mut conn| {
-            async move {
-                PacedTrainRoundTrips::delete_batch_train_ids(&mut conn, to_remove).await?;
-                PacedTrainRoundTrips::create_batch::<_, Vec<_>>(&mut conn, round_trips_changesets)
-                    .await?;
-                Ok(())
-            }
-            .scope_boxed()
+        .transaction::<_, crate::error::InternalError, _, _>(async move |mut conn| {
+            PacedTrainRoundTrips::delete_batch_train_ids(&mut conn, to_remove).await?;
+            PacedTrainRoundTrips::create_batch::<_, Vec<_>>(&mut conn, round_trips_changesets)
+                .await?;
+            Ok(())
         })
         .await?;
 

--- a/editoast/src/views/scenario.rs
+++ b/editoast/src/views/scenario.rs
@@ -12,7 +12,6 @@ use axum::response::IntoResponse;
 use chrono::Utc;
 use database::DbConnection;
 use database::DbConnectionPoolV2;
-use diesel_async::scoped_futures::ScopedFutureExt;
 use editoast_derive::EditoastError;
 use editoast_models::prelude::*;
 use serde::Deserialize;
@@ -204,24 +203,21 @@ pub(in crate::views) async fn create(
     let details = Study::transactional_content_update(
         db_pool.get().await?,
         study_id,
-        move |mut conn, study, _project| {
-            async move {
-                Timetable::exists_or_fail(&mut conn, timetable_id, || {
-                    ScenarioError::TimetableNotFound { timetable_id }
-                })
-                .await?;
+        async move |mut conn, study, _project| {
+            Timetable::exists_or_fail(&mut conn, timetable_id, || {
+                ScenarioError::TimetableNotFound { timetable_id }
+            })
+            .await?;
 
-                Infra::exists_or_fail(&mut conn, infra_id, || ScenarioError::InfraNotFound {
-                    infra_id,
-                })
-                .await?;
+            Infra::exists_or_fail(&mut conn, infra_id, || ScenarioError::InfraNotFound {
+                infra_id,
+            })
+            .await?;
 
-                let scenario = scenario_cs.study_id(study.id).create(&mut conn).await?;
+            let scenario = scenario_cs.study_id(study.id).create(&mut conn).await?;
 
-                let details = ScenarioWithDetails::from_scenario(scenario, &mut conn).await?;
-                Ok::<_, InternalError>(details)
-            }
-            .scope_boxed()
+            let details = ScenarioWithDetails::from_scenario(scenario, &mut conn).await?;
+            Ok::<_, InternalError>(details)
         },
     )
     .await
@@ -255,30 +251,24 @@ pub(in crate::views) async fn delete(
 
     let conn = db_pool.get().await?;
 
-    conn.transaction(|conn| {
-        async move {
-            let scenario = Scenario::retrieve_or_fail(conn.clone(), scenario_id, || {
-                ScenarioError::NotFound { scenario_id }
-            })
-            .await?;
+    conn.transaction(async move |conn| {
+        let scenario = Scenario::retrieve_or_fail(conn.clone(), scenario_id, || {
+            ScenarioError::NotFound { scenario_id }
+        })
+        .await?;
 
-            Study::transactional_content_update(
-                conn,
-                scenario.study_id,
-                move |mut conn, _study, _project| {
-                    async move {
-                        scenario.delete(&mut conn).await?;
-                        Ok::<_, ScenarioError>(())
-                    }
-                    .scope_boxed()
-                },
-            )
-            .await
-            .map_err(ScenarioError::from)??;
+        Study::transactional_content_update(
+            conn,
+            scenario.study_id,
+            async move |mut conn, _study, _project| {
+                scenario.delete(&mut conn).await?;
+                Ok::<_, ScenarioError>(())
+            },
+        )
+        .await
+        .map_err(ScenarioError::from)??;
 
-            Ok::<_, ScenarioError>(())
-        }
-        .scope_boxed()
+        Ok::<_, ScenarioError>(())
     })
     .await?;
 
@@ -336,26 +326,23 @@ pub(in crate::views) async fn patch(
     let details = Scenario::transactional_content_update(
         db_pool.get().await?,
         scenario_id,
-        move |mut conn, _scenario, _study, _project| {
-            async move {
-                if let Some(infra_id) = form.infra_id {
-                    Infra::exists_or_fail(&mut conn, infra_id, || ScenarioError::InfraNotFound {
-                        infra_id,
-                    })
-                    .await?;
-                }
-
-                let scenario_cs = form.into_changeset();
-                let scenario = scenario_cs
-                    .update_or_fail(&mut conn, scenario_id, || ScenarioError::NotFound {
-                        scenario_id,
-                    })
-                    .await?;
-
-                let details = ScenarioWithDetails::from_scenario(scenario, &mut conn).await?;
-                Ok::<_, ScenarioError>(details)
+        async move |mut conn, _scenario, _study, _project| {
+            if let Some(infra_id) = form.infra_id {
+                Infra::exists_or_fail(&mut conn, infra_id, || ScenarioError::InfraNotFound {
+                    infra_id,
+                })
+                .await?;
             }
-            .scope_boxed()
+
+            let scenario_cs = form.into_changeset();
+            let scenario = scenario_cs
+                .update_or_fail(&mut conn, scenario_id, || ScenarioError::NotFound {
+                    scenario_id,
+                })
+                .await?;
+
+            let details = ScenarioWithDetails::from_scenario(scenario, &mut conn).await?;
+            Ok::<_, ScenarioError>(details)
         },
     )
     .await
@@ -390,32 +377,28 @@ pub(in crate::views) async fn get(
     let (details, project, study) = db_pool
         .get()
         .await?
-        .transaction(|mut conn| {
-            async move {
-                let scenario = Scenario::retrieve_or_fail(conn.clone(), scenario_id, || {
-                    ScenarioError::NotFound { scenario_id }
+        .transaction(async move |mut conn| {
+            let scenario = Scenario::retrieve_or_fail(conn.clone(), scenario_id, || {
+                ScenarioError::NotFound { scenario_id }
+            })
+            .await?;
+            let study =
+                Study::retrieve_or_fail(conn.clone(), scenario.study_id, || StudyError::NotFound {
+                    study_id: scenario.study_id,
                 })
                 .await?;
-                let study = Study::retrieve_or_fail(conn.clone(), scenario.study_id, || {
-                    StudyError::NotFound {
-                        study_id: scenario.study_id,
-                    }
-                })
-                .await?;
-                let project = Project::retrieve_or_fail(conn.clone(), study.project_id, || {
-                    ProjectError::NotFound {
-                        project_id: study.project_id,
-                    }
-                })
-                .await?;
+            let project = Project::retrieve_or_fail(conn.clone(), study.project_id, || {
+                ProjectError::NotFound {
+                    project_id: study.project_id,
+                }
+            })
+            .await?;
 
-                Ok::<_, InternalError>((
-                    ScenarioWithDetails::from_scenario(scenario, &mut conn).await?,
-                    project,
-                    study,
-                ))
-            }
-            .scope_boxed()
+            Ok::<_, InternalError>((
+                ScenarioWithDetails::from_scenario(scenario, &mut conn).await?,
+                project,
+                study,
+            ))
         })
         .await?;
 

--- a/editoast/src/views/scenario/macro_nodes.rs
+++ b/editoast/src/views/scenario/macro_nodes.rs
@@ -9,7 +9,6 @@ use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use database::DbConnectionPoolV2;
-use diesel_async::scoped_futures::ScopedFutureExt;
 use editoast_derive::EditoastError;
 use itertools::Itertools;
 use serde::Deserialize;
@@ -219,18 +218,15 @@ pub(in crate::views) async fn create(
     let created = Scenario::transactional_content_update(
         db_pool.get().await?,
         scenario_id,
-        move |mut conn, _scenario, _study, _project| {
-            async move {
-                let changesets: Vec<_> = macro_nodes
-                    .into_iter()
-                    .map(|node| node.into_macro_node_changeset(scenario_id))
-                    .collect();
+        async move |mut conn, _scenario, _study, _project| {
+            let changesets: Vec<_> = macro_nodes
+                .into_iter()
+                .map(|node| node.into_macro_node_changeset(scenario_id))
+                .collect();
 
-                let macro_nodes: Vec<_> = MacroNode::create_batch(&mut conn, changesets).await?;
+            let macro_nodes: Vec<_> = MacroNode::create_batch(&mut conn, changesets).await?;
 
-                Ok::<_, MacroNodeError>(macro_nodes)
-            }
-            .scope_boxed()
+            Ok::<_, MacroNodeError>(macro_nodes)
         },
     )
     .await
@@ -305,36 +301,28 @@ pub(in crate::views) async fn update(
     let conn = db_pool.get().await?;
 
     let updated_macro_node = conn
-        .transaction(|conn| {
-            async move {
-                let node = MacroNode::retrieve_or_fail(conn.clone(), node_id, || {
-                    MacroNodeError::NotFound { node_id }
-                })
-                .await?;
+        .transaction(async move |conn| {
+            let node = MacroNode::retrieve_or_fail(conn.clone(), node_id, || {
+                MacroNodeError::NotFound { node_id }
+            })
+            .await?;
 
-                let updated_macro_node = Scenario::transactional_content_update(
-                    conn,
-                    node.scenario_id,
-                    move |mut conn, scenario, _study, _project| {
-                        async move {
-                            let node = data
-                                .into_macro_node_changeset(scenario.id)
-                                .update_or_fail(&mut conn, node_id, || MacroNodeError::NotFound {
-                                    node_id,
-                                })
-                                .await?;
+            let updated_macro_node = Scenario::transactional_content_update(
+                conn,
+                node.scenario_id,
+                async move |mut conn, scenario, _study, _project| {
+                    let node = data
+                        .into_macro_node_changeset(scenario.id)
+                        .update_or_fail(&mut conn, node_id, || MacroNodeError::NotFound { node_id })
+                        .await?;
 
-                            Ok::<_, MacroNodeError>(node)
-                        }
-                        .scope_boxed()
-                    },
-                )
-                .await
-                .map_err(MacroNodeError::from)??;
+                    Ok::<_, MacroNodeError>(node)
+                },
+            )
+            .await
+            .map_err(MacroNodeError::from)??;
 
-                Ok::<_, MacroNodeError>(updated_macro_node)
-            }
-            .scope_boxed()
+            Ok::<_, MacroNodeError>(updated_macro_node)
         })
         .await?;
 
@@ -366,30 +354,24 @@ pub(in crate::views) async fn delete(
 
     let conn = db_pool.get().await?;
 
-    conn.transaction(|conn| {
-        async move {
-            let node = MacroNode::retrieve_or_fail(conn.clone(), node_id, || {
-                MacroNodeError::NotFound { node_id }
-            })
-            .await?;
+    conn.transaction(async move |conn| {
+        let node = MacroNode::retrieve_or_fail(conn.clone(), node_id, || {
+            MacroNodeError::NotFound { node_id }
+        })
+        .await?;
 
-            Scenario::transactional_content_update(
-                conn,
-                node.scenario_id,
-                move |mut conn, _scenario, _study, _project| {
-                    async move {
-                        node.delete(&mut conn).await?;
-                        Ok::<_, MacroNodeError>(())
-                    }
-                    .scope_boxed()
-                },
-            )
-            .await
-            .map_err(MacroNodeError::from)??;
+        Scenario::transactional_content_update(
+            conn,
+            node.scenario_id,
+            async move |mut conn, _scenario, _study, _project| {
+                node.delete(&mut conn).await?;
+                Ok::<_, MacroNodeError>(())
+            },
+        )
+        .await
+        .map_err(MacroNodeError::from)??;
 
-            Ok::<_, MacroNodeError>(())
-        }
-        .scope_boxed()
+        Ok::<_, MacroNodeError>(())
     })
     .await?;
 

--- a/editoast/src/views/scenario/macro_notes.rs
+++ b/editoast/src/views/scenario/macro_notes.rs
@@ -9,7 +9,6 @@ use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use database::DbConnectionPoolV2;
-use diesel_async::scoped_futures::ScopedFutureExt;
 use editoast_derive::EditoastError;
 use itertools::Itertools;
 use serde::Deserialize;
@@ -206,19 +205,16 @@ pub(in crate::views) async fn create(
     let created = Scenario::transactional_content_update(
         db_pool.get().await?,
         scenario_id,
-        move |mut conn, _scenario, _study, _project| {
-            async move {
-                let changesets: Vec<_> = macro_notes
-                    .into_iter()
-                    .map(|note| note.into_macro_note_changeset(scenario_id))
-                    .collect();
+        async move |mut conn, _scenario, _study, _project| {
+            let changesets: Vec<_> = macro_notes
+                .into_iter()
+                .map(|note| note.into_macro_note_changeset(scenario_id))
+                .collect();
 
-                let created_macro_notes: Vec<_> =
-                    MacroNote::create_batch(&mut conn, changesets).await?;
+            let created_macro_notes: Vec<_> =
+                MacroNote::create_batch(&mut conn, changesets).await?;
 
-                Ok::<_, MacroNoteError>(created_macro_notes)
-            }
-            .scope_boxed()
+            Ok::<_, MacroNoteError>(created_macro_notes)
         },
     )
     .await
@@ -293,36 +289,28 @@ pub(in crate::views) async fn update(
     let conn = db_pool.get().await?;
 
     let updated_macro_note = conn
-        .transaction(|conn| {
-            async move {
-                let note = MacroNote::retrieve_or_fail(conn.clone(), note_id, || {
-                    MacroNoteError::NotFound { note_id }
-                })
-                .await?;
+        .transaction(async move |conn| {
+            let note = MacroNote::retrieve_or_fail(conn.clone(), note_id, || {
+                MacroNoteError::NotFound { note_id }
+            })
+            .await?;
 
-                let updated_macro_note = Scenario::transactional_content_update(
-                    conn,
-                    note.scenario_id,
-                    move |mut conn, scenario, _study, _project| {
-                        async move {
-                            let updated_note = note_form
-                                .into_macro_note_changeset(scenario.id)
-                                .update_or_fail(&mut conn, note_id, || MacroNoteError::NotFound {
-                                    note_id,
-                                })
-                                .await?;
+            let updated_macro_note = Scenario::transactional_content_update(
+                conn,
+                note.scenario_id,
+                async move |mut conn, scenario, _study, _project| {
+                    let updated_note = note_form
+                        .into_macro_note_changeset(scenario.id)
+                        .update_or_fail(&mut conn, note_id, || MacroNoteError::NotFound { note_id })
+                        .await?;
 
-                            Ok::<_, MacroNoteError>(updated_note)
-                        }
-                        .scope_boxed()
-                    },
-                )
-                .await
-                .map_err(MacroNoteError::from)??;
+                    Ok::<_, MacroNoteError>(updated_note)
+                },
+            )
+            .await
+            .map_err(MacroNoteError::from)??;
 
-                Ok::<_, MacroNoteError>(updated_macro_note)
-            }
-            .scope_boxed()
+            Ok::<_, MacroNoteError>(updated_macro_note)
         })
         .await?;
 
@@ -354,30 +342,24 @@ pub(in crate::views) async fn delete(
 
     let conn = db_pool.get().await?;
 
-    conn.transaction(|conn| {
-        async move {
-            let note = MacroNote::retrieve_or_fail(conn.clone(), note_id, || {
-                MacroNoteError::NotFound { note_id }
-            })
-            .await?;
+    conn.transaction(async move |conn| {
+        let note = MacroNote::retrieve_or_fail(conn.clone(), note_id, || {
+            MacroNoteError::NotFound { note_id }
+        })
+        .await?;
 
-            Scenario::transactional_content_update(
-                conn,
-                note.scenario_id,
-                move |mut conn, _scenario, _study, _project| {
-                    async move {
-                        note.delete(&mut conn).await?;
-                        Ok::<_, MacroNoteError>(())
-                    }
-                    .scope_boxed()
-                },
-            )
-            .await
-            .map_err(MacroNoteError::from)??;
+        Scenario::transactional_content_update(
+            conn,
+            note.scenario_id,
+            async move |mut conn, _scenario, _study, _project| {
+                note.delete(&mut conn).await?;
+                Ok::<_, MacroNoteError>(())
+            },
+        )
+        .await
+        .map_err(MacroNoteError::from)??;
 
-            Ok::<_, MacroNoteError>(())
-        }
-        .scope_boxed()
+        Ok::<_, MacroNoteError>(())
     })
     .await?;
 

--- a/editoast/src/views/study.rs
+++ b/editoast/src/views/study.rs
@@ -10,7 +10,6 @@ use chrono::NaiveDate;
 use chrono::Utc;
 use database::DbConnection;
 use database::DbConnectionPoolV2;
-use diesel_async::scoped_futures::ScopedFutureExt;
 use editoast_derive::EditoastError;
 use serde::Deserialize;
 use serde::Serialize;
@@ -188,12 +187,9 @@ pub(in crate::views) async fn create(
     let study = Project::transactional_content_update(
         db_pool.get().await?,
         data.project_id,
-        |mut conn, _project| {
-            async move {
-                let study = data.into_study_changeset().create(&mut conn).await?;
-                Ok::<_, InternalError>(study)
-            }
-            .scope_boxed()
+        async move |mut conn, _project| {
+            let study = data.into_study_changeset().create(&mut conn).await?;
+            Ok::<_, InternalError>(study)
         },
     )
     .await
@@ -238,29 +234,20 @@ pub(in crate::views) async fn delete(
 
     let conn = db_pool.get().await?;
 
-    conn.transaction(|conn| {
-        async move {
-            let study = Study::retrieve_or_fail(conn.clone(), study_id, || StudyError::NotFound {
-                study_id,
-            })
-            .await?;
+    conn.transaction(async move |conn| {
+        let study =
+            Study::retrieve_or_fail(conn.clone(), study_id, || StudyError::NotFound { study_id })
+                .await?;
 
-            Project::transactional_content_update(conn, study.project_id, |mut conn, _| {
-                async move {
-                    Study::delete_static_or_fail(&mut conn, study_id, || StudyError::NotFound {
-                        study_id,
-                    })
-                    .await?;
-                    Ok::<_, StudyError>(())
-                }
-                .scope_boxed()
-            })
-            .await
-            .map_err(StudyError::from)??;
-
+        Project::transactional_content_update(conn, study.project_id, async move |mut conn, _| {
+            Study::delete_static_or_fail(&mut conn, study_id, || StudyError::NotFound { study_id })
+                .await?;
             Ok::<_, StudyError>(())
-        }
-        .scope_boxed()
+        })
+        .await
+        .map_err(StudyError::from)??;
+
+        Ok::<_, StudyError>(())
     })
     .await?;
 
@@ -293,23 +280,20 @@ pub(in crate::views) async fn get(
     let (study_scenarios, project) = db_pool
         .get()
         .await?
-        .transaction(|mut conn| {
-            async move {
-                let study = Study::retrieve_or_fail(conn.clone(), study_id, || {
-                    StudyError::NotFound { study_id }
-                })
-                .await?;
-                let project = Project::retrieve_or_fail(conn.clone(), study.project_id, || {
-                    ProjectError::NotFound {
-                        project_id: study.project_id,
-                    }
-                })
-                .await?;
+        .transaction(async move |mut conn| {
+            let study = Study::retrieve_or_fail(conn.clone(), study_id, || StudyError::NotFound {
+                study_id,
+            })
+            .await?;
+            let project = Project::retrieve_or_fail(conn.clone(), study.project_id, || {
+                ProjectError::NotFound {
+                    project_id: study.project_id,
+                }
+            })
+            .await?;
 
-                let study_scenarios = StudyWithScenarioCount::try_fetch(&mut conn, study).await?;
-                Ok::<_, InternalError>((study_scenarios, project))
-            }
-            .scope_boxed()
+            let study_scenarios = StudyWithScenarioCount::try_fetch(&mut conn, study).await?;
+            Ok::<_, InternalError>((study_scenarios, project))
         })
         .await?;
 
@@ -407,16 +391,13 @@ pub(in crate::views) async fn patch(
     let response = Study::transactional_content_update(
         db_pool.get().await?,
         study_id,
-        move |mut conn, _study, _project| {
-            async move {
-                let study = data
-                    .into_study_changeset()?
-                    .update_or_fail(&mut conn, study_id, || StudyError::NotFound { study_id })
-                    .await?;
-                let study_scenarios = StudyWithScenarioCount::try_fetch(&mut conn, study).await?;
-                Ok::<_, InternalError>(study_scenarios)
-            }
-            .scope_boxed()
+        async move |mut conn, _study, _project| {
+            let study = data
+                .into_study_changeset()?
+                .update_or_fail(&mut conn, study_id, || StudyError::NotFound { study_id })
+                .await?;
+            let study_scenarios = StudyWithScenarioCount::try_fetch(&mut conn, study).await?;
+            Ok::<_, InternalError>(study_scenarios)
         },
     )
     .await


### PR DESCRIPTION
ScopedFuture are useful if you have a need to keep two different lifetime around for a future. Here, we were requiring the two lifetimes to be identical... Which is pretty much a giveway that using a normal Future would work just as well.

The core of the change is in database/src/db_connection_pool.rs, the rest is just cleanup.

Note to reviewers: that's a large diff, but it's mostly indentation changes, ignoring whitespace in the github review interface will make the review much more manageable.