### PR TITLE
editoast: consider trains that do not respect times as invalid (1/2)

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -2276,7 +2276,10 @@ paths:
         ## Important:
         - **Only one train schedule per paced train is projected**.
         - The train schedule selected is the first occurrence of the paced train.
-        - Paced trains that are **invalid** (e.g., due to pathfinding or simulation failure) are **excluded** from the result.
+        - The following paced trains are **excluded** from the result:
+            - paced trains for which pathfinding fails
+            - paced trains for which the simulation fails
+            - paced trains for which the simulation does not respect schedule times
       requestBody:
         content:
           application/json:

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -2246,6 +2246,12 @@ paths:
     post:
       tags:
       - paced_train
+      summary: |-
+        ## Important:
+        The following paced trains are **excluded** from the result:
+        - paced trains for which pathfinding fails
+        - paced trains for which the simulation fails
+        - paced trains for which the simulation does not respect schedule times
       requestBody:
         content:
           application/json:
@@ -4484,6 +4490,12 @@ paths:
     post:
       tags:
       - train_schedule
+      summary: |-
+        ## Important:
+        The following paced trains are **excluded** from the result:
+        - paced trains for which pathfinding fails
+        - paced trains for which the simulation fails
+        - paced trains for which the simulation does not respect schedule times
       requestBody:
         content:
           application/json:

--- a/editoast/src/views/projection.rs
+++ b/editoast/src/views/projection.rs
@@ -369,7 +369,7 @@ pub async fn compute_projected_train_paths<T: TrainScheduleLike>(
     .await?;
 
     // 2. Extracts train simulation details and computes unique hashes for projected train paths.
-    let trains_details = extract_train_details(simulations).await;
+    let trains_details = extract_train_details(simulations, train_schedules).await;
 
     let train_hashes_to_idx: HashMap<String, Vec<usize>> = trains_details
         .iter()
@@ -743,18 +743,30 @@ fn project_train_path_op(
     projection_curves
 }
 
-pub async fn extract_train_details(
+pub async fn extract_train_details<T: TrainScheduleLike>(
     simulations: Vec<(Arc<simulation::Response>, Arc<PathfindingResult>)>,
+    train_schedules: &[T],
 ) -> Vec<Option<TrainSimulationDetails>> {
+    assert_eq!(train_schedules.len(), simulations.len());
+
     simulations
         .into_iter()
-        .map(|(sim, pathfinding_result)| {
+        .zip(train_schedules)
+        .map(|((sim, pathfinding_result), train_schedule)| {
             let simulation::Response::Success(sim) = sim.as_ref() else {
                 return None;
             };
             let PathfindingResult::Success(pathfinding_result) = pathfinding_result.as_ref() else {
                 return None;
             };
+            let respect_times = sim
+                .path_item_respect_times(train_schedule)
+                .into_iter()
+                .all(|path_item| path_item);
+            if !respect_times {
+                return None;
+            }
+
             Some(TrainSimulationDetails {
                 positions: sim.final_output.report_train.positions.clone(),
                 times: sim.final_output.report_train.times.clone(),

--- a/editoast/src/views/projection.rs
+++ b/editoast/src/views/projection.rs
@@ -1,10 +1,8 @@
 use crate::error::Result;
 use core_client::CoreClient;
-use core_client::pathfinding::PathfindingResultSuccess;
 use core_client::pathfinding::TrackRange;
 use core_client::pathfinding::TrainPath;
 use core_client::simulation::CompleteReportTrain;
-use core_client::simulation::ReportTrain;
 use core_client::simulation::SignalCriticalPosition;
 use core_client::simulation::ZoneUpdate;
 use database::DbConnection;
@@ -371,7 +369,7 @@ pub async fn compute_projected_train_paths<T: TrainScheduleLike>(
     .await?;
 
     // 2. Extracts train simulation details and computes unique hashes for projected train paths.
-    let trains_details = extract_train_details(simulations).await?;
+    let trains_details = extract_train_details(simulations).await;
 
     let train_hashes_to_idx: HashMap<String, Vec<usize>> = trains_details
         .iter()
@@ -747,54 +745,25 @@ fn project_train_path_op(
 
 pub async fn extract_train_details(
     simulations: Vec<(Arc<simulation::Response>, Arc<PathfindingResult>)>,
-) -> Result<Vec<Option<TrainSimulationDetails>>> {
-    let mut trains_details = vec![];
-
-    for (sim, pathfinding_result) in simulations {
-        let track_ranges = match pathfinding_result.as_ref() {
-            PathfindingResult::Success(PathfindingResultSuccess {
-                path:
-                    TrainPath {
-                        track_section_ranges,
-                        ..
-                    },
-                ..
-            }) => track_section_ranges,
-            _ => {
-                trains_details.push(None);
-                continue;
-            }
-        };
-
-        let CompleteReportTrain {
-            report_train,
-            signal_critical_positions,
-            zone_updates,
-            ..
-        } = match Arc::unwrap_or_clone(sim) {
-            simulation::Response::Success(SimulationResponseSuccess { final_output, .. }) => {
-                final_output
-            }
-            _ => {
-                trains_details.push(None);
-                continue;
-            }
-        };
-        let ReportTrain {
-            times, positions, ..
-        } = report_train;
-
-        let train_details = TrainSimulationDetails {
-            positions,
-            times,
-            signal_critical_positions,
-            zone_updates,
-            train_path: track_ranges.clone(),
-        };
-
-        trains_details.push(Some(train_details));
-    }
-    Ok(trains_details)
+) -> Vec<Option<TrainSimulationDetails>> {
+    simulations
+        .into_iter()
+        .map(|(sim, pathfinding_result)| {
+            let simulation::Response::Success(sim) = sim.as_ref() else {
+                return None;
+            };
+            let PathfindingResult::Success(pathfinding_result) = pathfinding_result.as_ref() else {
+                return None;
+            };
+            Some(TrainSimulationDetails {
+                positions: sim.final_output.report_train.positions.clone(),
+                times: sim.final_output.report_train.times.clone(),
+                train_path: pathfinding_result.path.track_section_ranges.clone(),
+                signal_critical_positions: sim.final_output.signal_critical_positions.clone(),
+                zone_updates: sim.final_output.zone_updates.clone(),
+            })
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -802,6 +771,7 @@ mod tests {
     use super::*;
     use crate::models::fixtures::create_small_infra;
     use crate::views::test_app::TestAppBuilder;
+    use core_client::simulation::ReportTrain;
     use rstest::rstest;
     use schemas::infra::Direction;
     use schemas::infra::DirectionalTrackRange;

--- a/editoast/src/views/timetable/occupancy_blocks.rs
+++ b/editoast/src/views/timetable/occupancy_blocks.rs
@@ -84,7 +84,7 @@ pub(super) async fn compute_occupancy_blocks<T: TrainScheduleLike>(
     .await?;
 
     // 2. Extracts train simulation details and computes unique hashes for projected train paths.
-    let trains_details = extract_train_details(simulations).await;
+    let trains_details = extract_train_details(simulations, trains_schedules).await;
 
     let train_hashes_to_idx: HashMap<String, Vec<usize>> = trains_details
         .iter()

--- a/editoast/src/views/timetable/occupancy_blocks.rs
+++ b/editoast/src/views/timetable/occupancy_blocks.rs
@@ -84,7 +84,7 @@ pub(super) async fn compute_occupancy_blocks<T: TrainScheduleLike>(
     .await?;
 
     // 2. Extracts train simulation details and computes unique hashes for projected train paths.
-    let trains_details = extract_train_details(simulations).await?;
+    let trains_details = extract_train_details(simulations).await;
 
     let train_hashes_to_idx: HashMap<String, Vec<usize>> = trains_details
         .iter()

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -1020,6 +1020,11 @@ pub struct OccupancyBlocksPacedTrainResult {
     pub exceptions: HashMap<String, OccupancyBlocks>,
 }
 
+/// ## Important:
+/// The following paced trains are **excluded** from the result:
+/// - paced trains for which pathfinding fails
+/// - paced trains for which the simulation fails
+/// - paced trains for which the simulation does not respect schedule times
 #[editoast_derive::route]
 #[utoipa::path(
     post, path = "",

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -719,7 +719,10 @@ pub struct ProjectPathPacedTrainResult {
 /// ## Important:
 /// - **Only one train schedule per paced train is projected**.
 /// - The train schedule selected is the first occurrence of the paced train.
-/// - Paced trains that are **invalid** (e.g., due to pathfinding or simulation failure) are **excluded** from the result.
+/// - The following paced trains are **excluded** from the result:
+///     - paced trains for which pathfinding fails
+///     - paced trains for which the simulation fails
+///     - paced trains for which the simulation does not respect schedule times
 #[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
@@ -2280,7 +2283,8 @@ mod tests {
         let response: HashMap<i64, OccupancyBlocksPacedTrainResult> =
             response.assert_status(StatusCode::OK).json_into();
         assert_eq!(response.len(), 1);
-        assert_eq!(response.get(&paced_train_id).unwrap().paced_train.len(), 1);
+        // TODO fix mocked simulation to return path item times that respect times
+        assert_eq!(response.get(&paced_train_id).unwrap().paced_train.len(), 0);
         assert_eq!(response.get(&paced_train_id).unwrap().exceptions.len(), 0);
     }
 

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -795,6 +795,11 @@ pub(in crate::views) async fn project_path_op(
     Ok(Json(results))
 }
 
+/// ## Important:
+/// The following paced trains are **excluded** from the result:
+/// - paced trains for which pathfinding fails
+/// - paced trains for which the simulation fails
+/// - paced trains for which the simulation does not respect schedule times
 #[editoast_derive::route]
 #[utoipa::path(
     post, path = "",

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -1474,6 +1474,6 @@ pub mod tests {
         let response: HashMap<i64, OccupancyBlocks> =
             response.assert_status(StatusCode::OK).json_into();
         assert_eq!(response.len(), 1);
-        assert_eq!(response.get(&train_schedule_id).unwrap().len(), 1);
+        assert_eq!(response.get(&train_schedule_id).unwrap().len(), 0);
     }
 }


### PR DESCRIPTION
~Depends on https://github.com/OpenRailAssociation/osrd/pull/14393~

Ref: https://github.com/OpenRailAssociation/osrd/issues/14248

This PR is best reviewed by commits!! :D

The following endpoints are affected:
- /paced_train/project_path
- ~/paced_train/track_occupancy~
- /paced_train/occupancy_blocks
(and maybe the same endpoints on train_schedule's side)

In the future the same trains will be considered invalid with regards to
conflicts as well