### PR TITLE
front: avoid sending empty nodes in storeTrainPathNodes()

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/utils.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/utils.ts
@@ -153,7 +153,7 @@ export const storeRoundTrip = async (
  * If not we persist them.
  */
 export const storeTrainPathNodes = async (state: MacroEditorState, dispatch: AppDispatch) => {
-  const allNodes = state.nodes.filter((n) => !n?.dbId);
+  const allNodes = state.nodes.filter((n) => n && !n.dbId);
 
   if (!allNodes.length) return;
 


### PR DESCRIPTION
MacroEditorState.nodes includes null entries in case some nodes got dedup'ed. The filter() condition retains these null nodes, resulting in empty objects sent to editoast and a 400 HTTP error when opening the macro editor.

Ignore null nodes in the filter() condition to fix this.

Fixes: fb24ab4ce207 ("front: persist nodes from file import in nge")
Closes: https://github.com/OpenRailAssociation/osrd/issues/14425