### PR TITLE
core: document the differences between reports in the API

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/api/standalone_sim/SimulationResponse.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/standalone_sim/SimulationResponse.kt
@@ -17,8 +17,14 @@ import fr.sncf.osrd.utils.units.TimeDelta
 interface SimulationResponse
 
 class SimulationSuccess(
+    /** Report where the train goes as fast as possible. */
     val base: ReportTrain,
+    /** Report where the train tries to respect the margins. */
     val provisional: ReportTrain,
+    /**
+     * Report where the train tries to respect the margins as well as the arrival times at scheduled
+     * points.
+     */
     @Json(name = "final_output") val finalOutput: CompleteReportTrain,
     val mrsp: RangeValues<SpeedLimitProperty>,
     @Json(name = "electrical_profiles") val electricalProfiles: RangeValues<ElectricalProfileValue>,
@@ -52,9 +58,17 @@ class CompleteReportTrain(
     @Json(name = "routing_requirements") val routingRequirements: List<RJSRoutingRequirement>,
 ) : ReportTrain(positions, times, speeds, energyConsumption, pathItemTimes)
 
+/**
+ * A simulation report, containing the [times] and the [speeds] for each position in [positions].
+ *
+ * [positions], [times] and [speeds] have the same length.
+ *
+ * [positions] is sorted.
+ */
 open class ReportTrain(
     val positions: List<Offset<TrainPath>>,
-    val times: List<TimeDelta>, // Times are compared to the departure time
+    /** Times are compared to departure time */
+    val times: List<TimeDelta>,
     val speeds: List<Double>,
     @Json(name = "energy_consumption") val energyConsumption: Double,
     @Json(name = "path_item_times") val pathItemTimes: List<TimeDelta>,


### PR DESCRIPTION
since it's not that obvious, other parts of the project end up documenting `SimulationSuccess`, and sometimes get it wrong:

https://github.com/OpenRailAssociation/osrd/blob/e629d2dc6d2e0e219eebfc03b304eac50b44728a/editoast/core_client/src/simulation.rs#L292-L293 https://github.com/OpenRailAssociation/osrd/blob/e629d2dc6d2e0e219eebfc03b304eac50b44728a/front/src/modules/timesStops/helpers/computeMargins.ts#L81-L84

Also moving regular comments to doc comments, so that some day core can have API docs like editoast's:
https://osrd.fr/en/docs/reference/apis/editoast/