### PR TITLE
ci: tighten check-commit-titles some more

### DIFF
--- a/.github/scripts/check-commit-titles.sh
+++ b/.github/scripts/check-commit-titles.sh
@@ -18,7 +18,7 @@ checks='check_fixup check_forbidden_chars check_structure'
 
 # shellcheck disable=SC2329 # Called indirectly
 check_fixup() {
-    if grep -q -i '^fixup'; then
+    if grep -E -q -i '^fixup|pr comment|clippy fix'; then
         echo 'Found a fixup commit'
     fi
 }


### PR DESCRIPTION
Seems like people now tend to make their fixup commits pass the current checks. Disallow two phrases from the last batch of those that made it into dev.