### PR TITLE
core: untie Range from Pathfinding

### DIFF
--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/units/Distance.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/units/Distance.kt
@@ -248,3 +248,5 @@ fun <T> Length<T>.forceDirected(): DirOffset<T> {
 fun <T> Length<Directed<T>>.forceUndirected(): Offset<T> {
     return cast()
 }
+
+data class OffsetRange<T>(val start: Offset<T>, val end: Offset<T>)

--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/IncompatibleConstraintsPostProcessing.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/IncompatibleConstraintsPostProcessing.kt
@@ -3,7 +3,6 @@ package fr.sncf.osrd.api.pathfinding
 import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.graph.*
 import fr.sncf.osrd.path.interfaces.TrainPath
-import fr.sncf.osrd.pathfinding.Pathfinding
 import fr.sncf.osrd.pathfinding.constraints.ElectrificationConstraints
 import fr.sncf.osrd.pathfinding.constraints.LoadingGaugeConstraints
 import fr.sncf.osrd.pathfinding.constraints.SignalingSystemConstraints
@@ -12,6 +11,7 @@ import fr.sncf.osrd.utils.DistanceRangeMap
 import fr.sncf.osrd.utils.distanceRangeMapOf
 import fr.sncf.osrd.utils.filterIntersection
 import fr.sncf.osrd.utils.units.Offset
+import fr.sncf.osrd.utils.units.OffsetRange
 
 fun buildIncompatibleConstraintsResponse(
     infra: FullInfra,
@@ -28,7 +28,7 @@ fun buildIncompatibleConstraintsResponse(
         getConstraintsDistanceRange(path, path.getElectrification(), elecConstraints.firstOrNull())
             .map {
                 RangeValue(
-                    Pathfinding.Range(Offset(it.lower), Offset(it.upper)),
+                    OffsetRange(Offset(it.lower), Offset(it.upper)),
                     it.value.joinToString(","),
                 )
             }
@@ -37,7 +37,7 @@ fun buildIncompatibleConstraintsResponse(
     assert(gaugeConstraints.size < 2)
     val gaugeBlockedRanges =
         getConstraintsDistanceRange(path, path.getLoadingGauge(), gaugeConstraints.firstOrNull())
-            .map { RangeValue<String>(Pathfinding.Range(Offset(it.lower), Offset(it.upper)), null) }
+            .map { RangeValue<String>(OffsetRange(Offset(it.lower), Offset(it.upper)), null) }
 
     val signalingSystemConstraints = constraints.filterIsInstance<SignalingSystemConstraints>()
     assert(signalingSystemConstraints.size < 2)
@@ -48,7 +48,7 @@ fun buildIncompatibleConstraintsResponse(
                 pathSignalingSystem,
                 signalingSystemConstraints.firstOrNull(),
             )
-            .map { RangeValue(Pathfinding.Range(Offset(it.lower), Offset(it.upper)), it.value) }
+            .map { RangeValue(OffsetRange(Offset(it.lower), Offset(it.upper)), it.value) }
 
     if (
         listOf(elecBlockedRangeValues, gaugeBlockedRanges, signalingSystemBlockedRangeValues).all {

--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlockResponse.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlockResponse.kt
@@ -9,11 +9,11 @@ import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import fr.sncf.osrd.api.DirectionalTrackRange
 import fr.sncf.osrd.path.interfaces.JsonTrainPath
 import fr.sncf.osrd.path.interfaces.TrainPath
-import fr.sncf.osrd.pathfinding.Pathfinding
 import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.utils.json.UnitAdapterFactory
 import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
+import fr.sncf.osrd.utils.units.OffsetRange
 import java.util.*
 
 interface PathfindingBlockResponse
@@ -66,9 +66,9 @@ data class IncompatibleConstraints(
     val incompatibleSignalingSystemRanges: List<RangeValue<String>>,
 )
 
-data class RangeValue<T>(val range: Pathfinding.Range<TrainPath>, val value: T?) {
+data class RangeValue<T>(val range: OffsetRange<TrainPath>, val value: T?) {
     @FromJson
-    fun fromJson(range: Pathfinding.Range<TrainPath>): RangeValue<T> {
+    fun fromJson(range: OffsetRange<TrainPath>): RangeValue<T> {
         return RangeValue(range, null)
     }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/pathfinding/Pathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/pathfinding/Pathfinding.kt
@@ -7,6 +7,7 @@ import fr.sncf.osrd.pathfinding.constraints.ConstraintCombiner
 import fr.sncf.osrd.reporting.exceptions.ErrorType
 import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.utils.units.Offset
+import fr.sncf.osrd.utils.units.OffsetRange
 import fr.sncf.osrd.utils.units.meters
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.annotations.WithSpan
@@ -76,7 +77,19 @@ class Pathfinding<NodeT : Any, EdgeT : Any, OffsetType>(
     )
 
     /** A simple range with no edge attached */
-    data class Range<OffsetType>(val start: Offset<OffsetType>, val end: Offset<OffsetType>)
+    @JvmInline
+    value class Range<OffsetType>(private val r: OffsetRange<OffsetType>) {
+        constructor(
+            start: Offset<OffsetType>,
+            end: Offset<OffsetType>,
+        ) : this(OffsetRange(start, end))
+
+        val start: Offset<OffsetType>
+            get() = r.start
+
+        val end: Offset<OffsetType>
+            get() = r.end
+    }
 
     /** Step priority queue */
     private val queue = PriorityQueue<Step<EdgeT, OffsetType>>()

--- a/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingTest.kt
@@ -15,6 +15,7 @@ import fr.sncf.osrd.utils.Helpers
 import fr.sncf.osrd.utils.md5
 import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Offset
+import fr.sncf.osrd.utils.units.OffsetRange
 import fr.sncf.osrd.utils.units.meters
 import kotlin.test.assertEquals
 import org.assertj.core.api.Assertions.assertThat
@@ -184,7 +185,7 @@ class PathfindingTest : ApiTest() {
                     incompatibleElectrificationRanges =
                         listOf(
                             RangeValue(
-                                Pathfinding.Range(Offset.zero(), Offset(10250.meters)),
+                                OffsetRange(Offset.zero(), Offset(10250.meters)),
                                 "", // range not electrified
                             )
                         ),
@@ -250,37 +251,23 @@ class PathfindingTest : ApiTest() {
                 IncompatibleConstraints(
                     incompatibleElectrificationRanges =
                         listOf(
-                            RangeValue(
-                                Pathfinding.Range(Offset.zero(), Offset(1960.meters)),
-                                "1500V",
-                            ),
+                            RangeValue(OffsetRange(Offset.zero(), Offset(1960.meters)), "1500V"),
                             // neutral section in-between
                             RangeValue(
-                                Pathfinding.Range(Offset(2010.meters), Offset(4000.meters)),
+                                OffsetRange(Offset(2010.meters), Offset(4000.meters)),
                                 "25000V",
                             ),
                         ),
                     // multiple different loading gauges on the track
                     incompatibleGaugeRanges =
                         listOf(
-                            RangeValue(Pathfinding.Range(Offset.zero(), Offset(100.meters)), null),
-                            RangeValue(
-                                Pathfinding.Range(Offset(100.meters), Offset(200.meters)),
-                                null,
-                            ),
-                            RangeValue(
-                                Pathfinding.Range(Offset(200.meters), Offset(1500.meters)),
-                                null,
-                            ),
-                            RangeValue(
-                                Pathfinding.Range(Offset(1500.meters), Offset(1900.meters)),
-                                null,
-                            ),
+                            RangeValue(OffsetRange(Offset.zero(), Offset(100.meters)), null),
+                            RangeValue(OffsetRange(Offset(100.meters), Offset(200.meters)), null),
+                            RangeValue(OffsetRange(Offset(200.meters), Offset(1500.meters)), null),
+                            RangeValue(OffsetRange(Offset(1500.meters), Offset(1900.meters)), null),
                         ),
                     incompatibleSignalingSystemRanges =
-                        listOf(
-                            RangeValue(Pathfinding.Range(Offset.zero(), Offset(4000.meters)), "BAL")
-                        ),
+                        listOf(RangeValue(OffsetRange(Offset.zero(), Offset(4000.meters)), "BAL")),
                 )
         )
     }
@@ -412,7 +399,7 @@ class PathfindingTest : ApiTest() {
                 assert(
                     resp.incompatibleConstraints.incompatibleGaugeRanges.single() ==
                         RangeValue<String>(
-                            Pathfinding.Range(Offset(1100.meters), Offset(2100.meters)),
+                            OffsetRange(Offset(1100.meters), Offset(2100.meters)),
                             null,
                         )
                 )


### PR DESCRIPTION
Then:
- inline `Range` class to reuse it in `Pathfinding`
- agnostic use can now be agnostic (incompatible constraints)

The target is to separate concern later, when removing generics from `Pathfinding`.

relates to https://github.com/OpenRailAssociation/osrd/issues/13014