### PR TITLE
front, e2e: optimize github summary report error display

### DIFF
--- a/front/tests/reporter/generate-github-summary.ts
+++ b/front/tests/reporter/generate-github-summary.ts
@@ -111,10 +111,32 @@ await (async () => {
 - 📦 [Download Traces](${traceUrl})
 - 🎥 [Download Videos and screenshots](${mediaUrl})
 
-| Failed Test | Status | Error |
-|-------------|--------|-------|
+| Test Suite | Failed Test | Status | Error |
+|------------|-------------|:------:|-------|
 ${failedTests
-  .map((t) => `| ${t.name} | ❌ failed | ${(t.message ?? 'No message').replace(/\n/g, ' ')} |`)
+  .map((t) => {
+    const message = String(t.message ?? '');
+    const trace = String(t.trace ?? '');
+    const raw = message && trace ? `${message}\n${trace}` : message || trace || 'No message';
+    const clean = raw.replace(/\n/g, '<br>');
+
+    if (clean.length > 1000) {
+      // Find last space before index 1000
+      const cutIndex = clean.lastIndexOf(' ', 1000);
+
+      // If no space was found, fallback to 1000
+      const splitAt = cutIndex > 0 ? cutIndex : 1000;
+
+      const preview = clean.slice(0, splitAt);
+      const rest = clean.slice(splitAt);
+
+      const details = `${preview} <details><summary>Show more</summary>${rest}</details>`;
+
+      return `| ${t.suite} | ${t.name} | ❌ failed | ${details} |`;
+    }
+
+    return `| ${t.suite} | ${t.name} | ❌ failed | ${clean} |`;
+  })
   .join('\n')}
 `;
   }

--- a/front/tests/reporter/generate-personalized-report.ts
+++ b/front/tests/reporter/generate-personalized-report.ts
@@ -229,8 +229,13 @@ class GenerateReport implements Reporter {
     const segments: string[] = [];
     let suite: Suite | undefined = test.parent;
 
+    const browsers = new Set(['chromium', 'firefox', 'webkit']);
+
     while (suite) {
-      if (suite.title) segments.unshift(suite.title);
+      // Skip browser suite titles
+      if (suite.title && !browsers.has(suite.title)) {
+        segments.unshift(suite.title);
+      }
       suite = suite.parent;
     }
 

--- a/front/tests/reporter/playwright-report-types.ts
+++ b/front/tests/reporter/playwright-report-types.ts
@@ -96,10 +96,12 @@ export type Attachment = {
 export type GithubTestSummary = {
   name: string;
   status: string;
+  trace?: string;
   message?: string;
   duration?: number;
   flaky?: boolean;
   browser?: string;
+  suite?: string;
 };
 
 /**


### PR DESCRIPTION
This PR adds a new column to display the test suite in the failed test report.
It also includes error traces in the error message and improves error message readability by adding a `Show more `toggle when the content exceeds 1000 characters
<img width="1302" height="1170" alt="image" src="https://github.com/user-attachments/assets/4e041727-c21f-49e9-98d0-e2bd4dbb77f4" />

**Note:** The second commit should be ignored, as I intentionally forced some tests to fail for testing purposes
