### PR TITLE
ui-core: adding segmented control component

### DIFF
--- a/front/ui/storybook/stories/ui-core/SegmentedControl.stories.tsx
+++ b/front/ui/storybook/stories/ui-core/SegmentedControl.stories.tsx
@@ -1,0 +1,52 @@
+import React, { useState } from 'react';
+
+import { SegmentedControl, type SegmentedControlProps } from '@osrd-project/ui-core';
+import { Broadcast, DesktopDownload } from '@osrd-project/ui-icons';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import '@osrd-project/ui-core/dist/theme.css';
+
+type Option = { value: string; label: string; icon?: React.ReactNode };
+const SegmentedControlWrapper = (props: SegmentedControlProps<Option>) => {
+  const [value, setValue] = useState<Option>(props.options[0]);
+  return <SegmentedControl {...props} value={value} onChange={(v) => setValue(v)} />;
+};
+
+const options = [
+  { value: 'blue', label: 'Blue' },
+  { value: 'red', label: 'Red' },
+  { value: 'green', label: 'Green' },
+] as Option[];
+
+const optionsWithIcon = [
+  { value: 'broadcast', label: 'Broadcast', icon: <Broadcast /> },
+  { value: 'desktopDownload', label: 'DesktopDownload', icon: <DesktopDownload /> },
+] as Option[];
+
+const meta: Meta<typeof SegmentedControlWrapper> = {
+  component: SegmentedControlWrapper,
+  title: 'Core/SegmentedControl',
+  tags: ['autodocs'],
+  args: {
+    name: 'my-choice',
+    options,
+    getOptionLabel: (option: Option) => option.label,
+    getOptionValue: (option: Option) => option.value,
+    getOptionIcon: undefined,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof SegmentedControlWrapper>;
+
+export const Default: Story = {
+  args: {},
+};
+export const WithIcons: Story = {
+  args: {
+    options: optionsWithIcon,
+    getOptionLabel: (option) => option.label,
+    getOptionValue: (option) => option.value,
+    getOptionIcon: (option) => option.icon,
+  },
+};

--- a/front/ui/ui-core/src/components/inputs/SegmentedControl.tsx
+++ b/front/ui/ui-core/src/components/inputs/SegmentedControl.tsx
@@ -1,0 +1,62 @@
+import React, { useMemo } from 'react';
+
+import cx from 'classnames';
+
+export type SegmentedControlProps<T> = Omit<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  'value' | 'onChange' | 'checked'
+> & {
+  options: Array<T>;
+  onChange: (option: T) => void;
+  value: T;
+  getOptionLabel: (option: T) => string;
+  getOptionValue: (option: T) => string;
+  getOptionIcon?: (option: T) => React.ReactNode;
+};
+
+const SegmentedControl = <T,>({
+  options,
+  onChange,
+  value,
+  getOptionLabel,
+  getOptionValue,
+  getOptionIcon,
+  ...inputProps
+}: SegmentedControlProps<T>) => {
+  const opts = useMemo(
+    () =>
+      options.map((e) => ({
+        value: getOptionValue(e),
+        label: getOptionLabel(e),
+        icon: getOptionIcon ? getOptionIcon(e) : null,
+        source: e,
+      })),
+    [options, getOptionValue, getOptionLabel, getOptionIcon]
+  );
+  return (
+    <div className="segmented-control">
+      {opts.map((option) => (
+        <label
+          key={option.value}
+          className={cx(
+            'segmented-control-option',
+            option.value === getOptionValue(value) && 'checked'
+          )}
+          title={option.label}
+        >
+          <div className="segmented-control-option-content">
+            {option.icon ? option.icon : option.label}
+          </div>
+          <input
+            {...inputProps}
+            type="radio"
+            checked={option.value === getOptionValue(value)}
+            onChange={() => onChange(option.source)}
+          />
+        </label>
+      ))}
+    </div>
+  );
+};
+
+export default SegmentedControl;

--- a/front/ui/ui-core/src/index.ts
+++ b/front/ui/ui-core/src/index.ts
@@ -39,3 +39,7 @@ export {
 export { default as TokenInput, TokenInputProps } from './components/inputs/TokenInput';
 export { default as Table } from './components/Table';
 export { default as Dialog } from './components/Dialog';
+export {
+  default as SegmentedControl,
+  SegmentedControlProps,
+} from './components/inputs/SegmentedControl';

--- a/front/ui/ui-core/src/styles/inputs/index.css
+++ b/front/ui/ui-core/src/styles/inputs/index.css
@@ -4,9 +4,11 @@
 @import './fieldWrapper.css';
 @import './hint.css';
 @import './input.css';
+@import './input-modal.css';
 @import './label.css';
 @import './passwordInput.css';
 @import './radioButton.css';
+@import './segmented-control.css';
 @import './slider.css';
 @import './statusIcon.css';
 @import './statusMessage.css';
@@ -14,4 +16,3 @@
 @import './timePicker.css';
 @import './tokenInput.css';
 @import './tolerancePicker.css';
-@import './input-modal.css';

--- a/front/ui/ui-core/src/styles/inputs/segmented-control.css
+++ b/front/ui/ui-core/src/styles/inputs/segmented-control.css
@@ -1,0 +1,44 @@
+.segmented-control {
+  background-color: var(--color-black-5);
+  border-radius: calc(var(--spacing) * 2.5);
+  display: flex;
+  flex-direction: row;
+  gap: var(--spacing);
+  padding: calc(var(--spacing));
+  width: fit-content;
+
+  .segmented-control-option {
+    border-radius: calc(var(--spacing) * 1.5);
+    border: 2px solid transparent;
+    color: gray;
+    cursor: pointer;
+    height: auto;
+    margin: 0;
+    padding: var(--spacing);
+
+    svg {
+      display: block !important;
+    }
+
+    input {
+      display: none;
+    }
+
+    .segmented-control-option-content {
+      border: 2px solid transparent;
+    }
+  }
+
+  .segmented-control-option.checked {
+    background: rgba(255, 255, 255, 1);
+    border-color: var(--color-grey-40);
+    box-shadow:
+      rgba(0, 0, 0, 0.1) 0 2px 4px 0,
+      rgba(0, 0, 0, 0.2) 0 1px 1px 0;
+    color: black;
+
+    .segmented-control-option-content {
+      border-color: var(--color-white-75);
+    }
+  }
+}


### PR DESCRIPTION
A `SegmentControl` is a group of radio buttons on which we replace the display of the classic radio input by a label or an icon.

Fix #14510 