### PR TITLE
editoast: generate level_crossing layer

### DIFF
--- a/editoast/src/generated_data/level_crossing.rs
+++ b/editoast/src/generated_data/level_crossing.rs
@@ -1,0 +1,72 @@
+use std::ops::DerefMut;
+
+use database::DbConnection;
+use database::tables::infra_layer_level_crossing::dsl;
+use diesel::delete;
+use diesel::query_dsl::methods::FilterDsl;
+use diesel::sql_query;
+use diesel::sql_types::Array;
+use diesel::sql_types::BigInt;
+use diesel::sql_types::Text;
+use diesel_async::RunQueryDsl;
+use schemas::primitives::ObjectType;
+
+use super::GeneratedData;
+use super::utils::InvolvedObjects;
+use crate::diesel::ExpressionMethods;
+use crate::error::Result;
+use crate::infra_cache::InfraCache;
+use crate::infra_cache::operation::CacheOperation;
+
+pub struct LevelCrossingLayer;
+
+impl GeneratedData for LevelCrossingLayer {
+    fn table_name() -> &'static str {
+        "infra_layer_level_crossing"
+    }
+
+    async fn generate(conn: &mut DbConnection, infra: i64, _cache: &InfraCache) -> Result<()> {
+        sql_query(include_str!("sql/generate_level_crossing_layer.sql"))
+            .bind::<BigInt, _>(infra)
+            .execute(conn.write().await.deref_mut())
+            .await?;
+        Ok(())
+    }
+
+    async fn update(
+        conn: &mut DbConnection,
+        infra: i64,
+        operations: &[CacheOperation],
+        infra_cache: &InfraCache,
+    ) -> Result<()> {
+        let involved_objects =
+            InvolvedObjects::from_operations(operations, infra_cache, ObjectType::LevelCrossing);
+
+        // Delete elements
+        if !involved_objects.is_empty() {
+            // We must delete both updated and deleted level crossings because we can only insert them and not update
+            let objs = involved_objects
+                .deleted
+                .iter()
+                .chain(involved_objects.updated.iter());
+
+            delete(
+                dsl::infra_layer_level_crossing
+                    .filter(dsl::infra_id.eq(infra))
+                    .filter(dsl::obj_id.eq_any(objs)),
+            )
+            .execute(conn.write().await.deref_mut())
+            .await?;
+        }
+
+        // Insert elements
+        if !involved_objects.updated.is_empty() {
+            sql_query(include_str!("sql/insert_level_crossing_layer.sql"))
+                .bind::<BigInt, _>(infra)
+                .bind::<Array<Text>, _>(involved_objects.updated.into_iter().collect::<Vec<_>>())
+                .execute(conn.write().await.deref_mut())
+                .await?;
+        }
+        Ok(())
+    }
+}

--- a/editoast/src/generated_data/mod.rs
+++ b/editoast/src/generated_data/mod.rs
@@ -4,6 +4,7 @@ mod buffer_stop;
 mod detector;
 mod electrification;
 mod error;
+mod level_crossing;
 mod neutral_section;
 mod neutral_sign;
 pub mod operational_point;
@@ -24,6 +25,7 @@ use electrification::ElectrificationLayer;
 use error::ErrorLayer;
 pub use error::generate_infra_errors;
 pub use error::infra_error;
+use level_crossing::LevelCrossingLayer;
 use neutral_section::NeutralSectionLayer;
 use neutral_sign::NeutralSignLayer;
 use operational_point::OperationalPointLayer;
@@ -109,6 +111,7 @@ pub async fn refresh_all(
         PSLSignLayer::refresh_pool(db_pool.clone(), infra_id, infra_cache),
         NeutralSectionLayer::refresh_pool(db_pool.clone(), infra_id, infra_cache),
         NeutralSignLayer::refresh_pool(db_pool.clone(), infra_id, infra_cache),
+        LevelCrossingLayer::refresh_pool(db_pool.clone(), infra_id, infra_cache),
     )?;
     debug!("⚙️ Infra {infra_id}: object layers is generated");
     // The error layer depends on the other layers and must be executed at the end.
@@ -131,6 +134,7 @@ pub async fn clear_all(conn: &mut DbConnection, infra: i64) -> Result<()> {
     ErrorLayer::clear(conn, infra).await?;
     NeutralSectionLayer::clear(conn, infra).await?;
     NeutralSignLayer::clear(conn, infra).await?;
+    LevelCrossingLayer::clear(conn, infra).await?;
     Ok(())
 }
 
@@ -153,6 +157,7 @@ pub async fn update_all(
     ErrorLayer::update(conn, infra, operations, infra_cache).await?;
     NeutralSectionLayer::update(conn, infra, operations, infra_cache).await?;
     NeutralSignLayer::update(conn, infra, operations, infra_cache).await?;
+    LevelCrossingLayer::update(conn, infra, operations, infra_cache).await?;
     Ok(())
 }
 

--- a/editoast/src/generated_data/sql/generate_level_crossing_layer.sql
+++ b/editoast/src/generated_data/sql/generate_level_crossing_layer.sql
@@ -1,0 +1,35 @@
+WITH lcs AS (
+    SELECT obj_id AS lc_id,
+        generate_series(0, jsonb_array_length(data->'parts') - 1) AS part_index,
+        (
+            jsonb_array_elements(data->'parts')->'position'
+        )::float AS position,
+        jsonb_array_elements(data->'parts')->>'track' AS track_id
+    FROM infra_object_level_crossing
+    WHERE infra_id = $1
+),
+collect AS (
+    SELECT lcs.lc_id,
+        ST_LineInterpolatePoint(
+            tracks_layer.geographic,
+            LEAST(
+                GREATEST(
+                    lcs.position / (tracks.data->'length')::float,
+                    0.
+                ),
+                1.
+            )
+        ) AS geo,
+        lcs.part_index AS part_index
+    FROM lcs
+        INNER JOIN infra_object_track_section AS tracks ON tracks.obj_id = lcs.track_id
+        AND tracks.infra_id = $1
+        INNER JOIN infra_layer_track_section AS tracks_layer ON tracks.obj_id = tracks_layer.obj_id
+        AND tracks.infra_id = tracks_layer.infra_id
+)
+INSERT INTO infra_layer_level_crossing (obj_id, infra_id, geographic)
+SELECT lc_id,
+    $1,
+    ST_Multi(ST_Collect(geo ORDER BY part_index)) AS geographic
+FROM collect
+GROUP BY lc_id

--- a/editoast/src/generated_data/sql/insert_level_crossing_layer.sql
+++ b/editoast/src/generated_data/sql/insert_level_crossing_layer.sql
@@ -1,0 +1,36 @@
+WITH lcs AS (
+    SELECT obj_id AS lc_id,
+        generate_series(0, jsonb_array_length(data->'parts') - 1) AS part_index,
+        (
+            jsonb_array_elements(data->'parts')->'position'
+        )::float AS position,
+        jsonb_array_elements(data->'parts')->>'track' AS track_id
+    FROM infra_object_level_crossing
+    WHERE infra_id = $1
+        AND obj_id = ANY($2)
+),
+collect AS (
+    SELECT lcs.lc_id,
+        ST_LineInterpolatePoint(
+            tracks_layer.geographic,
+            LEAST(
+                GREATEST(
+                    lcs.position / (tracks.data->'length')::float,
+                    0.
+                ),
+                1.
+            )
+        ) AS geo,
+        lcs.part_index AS part_index
+    FROM lcs
+        INNER JOIN infra_object_track_section AS tracks ON tracks.obj_id = lcs.track_id
+        AND tracks.infra_id = $1
+        INNER JOIN infra_layer_track_section AS tracks_layer ON tracks.obj_id = tracks_layer.obj_id
+        AND tracks.infra_id = tracks_layer.infra_id
+)
+INSERT INTO infra_layer_level_crossing (obj_id, infra_id, geographic)
+SELECT lc_id,
+    $1,
+    ST_Multi(ST_Collect(geo ORDER BY part_index)) AS geographic
+FROM collect
+GROUP BY lc_id


### PR DESCRIPTION
Handles level crossing layer in the generated data module :

- Add `generate_level_crossing_layer.sql` for initial layer generation
- Add `insert_level_crossing_layer.sql` for incremental updates
- Implement GeneratedData trait for LevelCrossingLayer
- Integrate layer in `refresh_all`, `clear_all`, and `update_all`

Command to add a level_crossing to `infra_object_level_crossing` table:
`docker exec -it osrd-postgres psql -U postgres -d osrd -c "INSERT INTO infra_object_level_crossing (obj_id, data, infra_id) VALUES ('PN1', '{\"name\": \"PN1_name\", \"short_zone\": 1000, \"parts\": [{\"track\": \"TA0\", \"position\": 700000, \"pedal_upstream\": 1000000, \"pedal_downstream\": 5000000},{\"track\": \"TA1\", \"position\": 500000, \"pedal_upstream\": 1000000, \"pedal_downstream\": 5000000},{\"track\": \"TA2\", \"position\": 500000, \"pedal_upstream\": 1000000, \"pedal_downstream\": 5000000}] }', 1);"`