### PR TITLE
core: etcs: make etcs envelope parts strictly monotonic

### DIFF
--- a/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/ETCSBrakingCurves.kt
+++ b/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/ETCSBrakingCurves.kt
@@ -510,7 +510,7 @@ private fun computeMinETCSBrakingCurves(
 
 /**
  * Keep the part of the full braking curve which is located underneath the overlay and intersects
- * with it or with begin position. If the braking curve has no intersection, return null.
+ * with it or with begin position. If the braking curve is fully above the overlay, return null.
  */
 private fun keepBrakingCurveUnderOverlay(
     etcsBrakingCurve: BrakingCurve?,
@@ -531,9 +531,6 @@ private fun keepBrakingCurveUnderOverlay(
     }
 
     val points = brakingCurve.iteratePoints().distinct()
-    val positions = points.map { it.position }
-    val speeds = points.map { it.speed }
-    val timeDeltas = brakingCurve.flatMap { it.getTimeDeltas() }
     val isAboveOverlay =
         // If the last point is strictly above the overlay, the lowest part of the braking curve is
         // above
@@ -542,8 +539,8 @@ private fun keepBrakingCurveUnderOverlay(
             // If the last point is on the overlay, if the second to last is above the overlay, then
             // the lowest part of the braking curve is above as well.
             (brakingCurve.endSpeed == overlay.interpolateSpeedLeftDir(brakingCurve.endPos, 1.0) &&
-                speeds[speeds.size - 2] >=
-                    overlay.interpolateSpeedLeftDir(positions[positions.size - 2], 1.0))
+                points[points.size - 2].speed >=
+                    overlay.interpolateSpeedLeftDir(points[points.size - 2].position, 1.0))
     if (isAboveOverlay) {
         // The lowest part of the braking curve is above the overlay envelope: dismiss it entirely
         // (currently considering that higher parts of the curve which would end up under the
@@ -551,20 +548,54 @@ private fun keepBrakingCurveUnderOverlay(
         return null
     }
 
+    val newBrakingParts = mutableListOf<EnvelopePart>()
+    val constrainedBeginPos = max(beginPos, brakingCurve.beginPos)
+    for (brakingCurvePart in brakingCurve.reversed().stream()) {
+        val intersectingPartUnderOverlay =
+            getIntersectingPartUnderOverlay(brakingCurvePart, overlay, constrainedBeginPos)
+        // If no intersection was found, add full braking curve part.
+        newBrakingParts.addFirst(intersectingPartUnderOverlay ?: brakingCurvePart)
+        // Break at first intersection found.
+        if (intersectingPartUnderOverlay != null) break
+    }
+    return BrakingCurve(
+        etcsBrakingCurve.brakingType,
+        Envelope.make(*newBrakingParts.toTypedArray()),
+    )
+}
+
+/**
+ * Return the section of the part under the overlay if they intersect at some point, else return
+ * null.
+ */
+private fun getIntersectingPartUnderOverlay(
+    brakingCurvePart: EnvelopePart,
+    overlay: Envelope,
+    beginPos: Double,
+): EnvelopePart? {
     val partBuilder = EnvelopePartBuilder()
-    partBuilder.setAttr(EnvelopeProfile.BRAKING)
+    partBuilder.setAttr(brakingCurvePart.getAttr(EnvelopeProfile::class.java))
     val overlayBuilder =
         ConstrainedEnvelopePartBuilder(
             partBuilder,
-            PositionConstraint(max(beginPos, brakingCurve.beginPos), overlay.endPos),
+            PositionConstraint(beginPos, overlay.endPos),
             EnvelopeConstraint(overlay, EnvelopePartConstraintType.CEILING),
         )
-    val lastIndex = positions.lastIndex
-    overlayBuilder.initEnvelopePart(positions[lastIndex], speeds[lastIndex], -1.0)
-    for (i in lastIndex - 1 downTo 0) {
-        if (!overlayBuilder.addStep(positions[i], speeds[i], timeDeltas[i])) break
+    overlayBuilder.initEnvelopePart(brakingCurvePart.endPos, brakingCurvePart.endSpeed, -1.0)
+    for (i in brakingCurvePart.pointCount() - 2 downTo 0) {
+        if (
+            !overlayBuilder.addStep(
+                brakingCurvePart.getPointPos(i),
+                brakingCurvePart.getPointSpeed(i),
+                brakingCurvePart.getStepTime(i),
+            )
+        ) {
+            // An intersection was found: new braking curve stops here.
+            return partBuilder.build()
+        }
     }
-    return BrakingCurve(etcsBrakingCurve.brakingType, Envelope.make(partBuilder.build()))
+    // No intersection: return null
+    return null
 }
 
 private data class BecParams(val dBec: Double, val vBec: Double, val speed: Double) {

--- a/tests/tests/test_train_schedule.py
+++ b/tests/tests/test_train_schedule.py
@@ -1415,6 +1415,69 @@ def test_etcs_stop_at_requirements_eoa(
     assert spacing_req_zone_stop["end_time"] == 842_038
 
 
+def test_etcs_train_schedule_with_margins(
+    etcs_scenario: Scenario, etcs_rolling_stock: int, session: Session
+):
+    """
+    Testing a valid ETCS train-schedule with margin that was failing because of
+    a tricky case of speed interpolation.
+    """
+    rolling_stock_response = session.get(
+        EDITOAST_URL + f"light_rolling_stock/{etcs_rolling_stock}"
+    )
+    etcs_rolling_stock_name = rolling_stock_response.json()["name"]
+    ts_response = session.post(
+        f"{EDITOAST_URL}timetable/{etcs_scenario.timetable}/train_schedules/",
+        json=[
+            {
+                "train_name": "etcs train with margins",
+                "labels": [],
+                "rolling_stock_name": etcs_rolling_stock_name,
+                "start_time": "2024-01-01T07:00:00Z",
+                "path": [
+                    {
+                        "id": "10a15119-eb4c-4b77-bbaa-f7960fe4e985",
+                        "location": {"track": "TB0", "offset": 280000},
+                    },
+                    {
+                        "id": "350e21af-a9a9-4944-b27b-9b9137616ce2",
+                        "location": {"track": "TD1", "offset": 18496000},
+                    },
+                    {
+                        "id": "49078a68-7a9f-4f58-a6d8-5a094295c936",
+                        "location": {"track": "TH1", "offset": 4894000},
+                    },
+                ],
+                "schedule": [
+                    {
+                        "at": "49078a68-7a9f-4f58-a6d8-5a094295c936",
+                        "reception_signal": "OPEN",
+                        "stop_for": "P0D",
+                    },
+                ],
+                "margins": {
+                    "boundaries": ["49078a68-7a9f-4f58-a6d8-5a094295c936"],
+                    "values": ["5%", "0%"],
+                },
+                "initial_speed": 0,
+                "comfort": "STANDARD",
+                "constraint_distribution": "MARECO",
+                "speed_limit_tag": "foo",
+                "power_restrictions": [],
+            }
+        ],
+    )
+
+    schedule = ts_response.json()[0]
+    schedule_id = schedule["id"]
+    ts_id_response = session.get(f"{EDITOAST_URL}train_schedule/{schedule_id}/")
+    ts_id_response.raise_for_status()
+    simu_response = session.get(
+        f"{EDITOAST_URL}train_schedule/{schedule_id}/simulation?infra_id={etcs_scenario.infra}"
+    )
+    assert simu_response.json()["status"] == "success"
+
+
 def test_etcs_schedule_braking_curves_endpoint(
     etcs_scenario: Scenario, etcs_rolling_stock: int, session: Session
 ):


### PR DESCRIPTION
Fixes https://github.com/OpenRailAssociation/osrd/issues/13804.

Fix keepBrakingCurveUnderOverlay so it does not combine the entry envelope parts into one, which made it possible for the result to not be strictly monotonous (ex: one of the entry parts is constant). This would break other parts of the code, and in this case, speed interpolation during margin computation, which can't be done on a non-strictly monotonous envelope part.

Integration test uses the train_schedule specified in the bug :)
