### PR TITLE
core: dump debug data for output simulation into a json file

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/api/path_properties/PathPropResponse.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/path_properties/PathPropResponse.kt
@@ -61,7 +61,7 @@ data class OperationalPointPartExtension(val sncf: OperationalPointPartSncfExten
 
 data class OperationalPointPartSncfExtension(val kp: String)
 
-val polymorphicAdapter: PolymorphicJsonAdapterFactory<Electrification> =
+val polymorphicElectrificationAdapter: PolymorphicJsonAdapterFactory<Electrification> =
     PolymorphicJsonAdapterFactory.of(Electrification::class.java, "type")
         .withSubtype(Electrified::class.java, "electrification")
         .withSubtype(Neutral::class.java, "neutral_section")
@@ -69,7 +69,7 @@ val polymorphicAdapter: PolymorphicJsonAdapterFactory<Electrification> =
 
 val pathPropResponseAdapter: JsonAdapter<PathPropResponse> =
     Moshi.Builder()
-        .add(polymorphicAdapter)
+        .add(polymorphicElectrificationAdapter)
         .addLast(UnitAdapterFactory())
         .addLast(KotlinJsonAdapterFactory())
         .build()

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/OutputSimDebugData.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/OutputSimDebugData.kt
@@ -1,0 +1,111 @@
+package fr.sncf.osrd.api.stdcm
+
+import com.google.common.primitives.Doubles.max
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import fr.sncf.osrd.api.path_properties.PathPropResponse
+import fr.sncf.osrd.api.path_properties.makePathPropResponse
+import fr.sncf.osrd.api.path_properties.polymorphicElectrificationAdapter
+import fr.sncf.osrd.api.standalone_sim.SimulationSuccess
+import fr.sncf.osrd.api.standalone_sim.polymorphicElectricalProfileAdapter
+import fr.sncf.osrd.api.standalone_sim.polymorphicSimulationResponseAdapter
+import fr.sncf.osrd.api.standalone_sim.polymorphicSpeedLimitSourceAdapter
+import fr.sncf.osrd.conflicts.ParsedRequirements
+import fr.sncf.osrd.path.interfaces.TrainPath
+import fr.sncf.osrd.sim_infra.api.RawInfra
+import fr.sncf.osrd.stdcm.STDCMResult
+import fr.sncf.osrd.stdcm.graph.EngineeringAllowanceRange
+import fr.sncf.osrd.utils.json.UnitAdapterFactory
+import fr.sncf.osrd.utils.units.Offset
+import fr.sncf.osrd.utils.units.TimeDelta
+import fr.sncf.osrd.utils.units.seconds
+import java.time.ZonedDateTime
+import kotlin.math.min
+
+/**
+ * Contains data describing the output stdcm simulation. Meant to contain anything that may be
+ * relevant to debug a past simulation without running it entirely again. Can be stored in an object
+ * storage or similar.
+ *
+ * For now, this whole file only meant for debugging purposes.
+ */
+data class OutputSimDebugData(
+    @Json(name = "sim_output") val simOutput: SimulationSuccess,
+    @Json(name = "path_properties") val pathProperties: PathPropResponse,
+    @Json(name = "other_requirements") val otherRequirements: List<TrainZoneRequirement>,
+    @Json(name = "departure_time") val departureTime: ZonedDateTime,
+    @Json(name = "engineering_allowances_ranges")
+    val engineeringAllowanceRanges: List<EngineeringAllowanceRange>,
+    @Json(name = "zone_locations") val zoneLocations: List<ZoneLocation>,
+) {
+    companion object {
+        val adapter: JsonAdapter<OutputSimDebugData> =
+            Moshi.Builder()
+                .add(polymorphicSimulationResponseAdapter)
+                .add(polymorphicElectricalProfileAdapter)
+                .add(polymorphicSpeedLimitSourceAdapter)
+                .add(polymorphicElectrificationAdapter)
+                .addLast(UnitAdapterFactory())
+                .addLast(KotlinJsonAdapterFactory())
+                .build()
+                .adapter(OutputSimDebugData::class.java)
+    }
+}
+
+data class TrainZoneRequirement(
+    @Json(name = "zone_name") val zoneName: String,
+    @Json(name = "begin_time") val beginTime: TimeDelta,
+    @Json(name = "end_time") val endTime: TimeDelta,
+    @Json(name = "train_name") val trainName: String?,
+)
+
+data class ZoneLocation(val name: String, val from: Offset<TrainPath>, val to: Offset<TrainPath>)
+
+fun generateDebugData(
+    rawInfra: RawInfra,
+    path: STDCMResult,
+    simulationResponse: SimulationSuccess,
+    departureTime: ZonedDateTime,
+    requirements: ParsedRequirements,
+): OutputSimDebugData {
+    return OutputSimDebugData(
+        simOutput = simulationResponse,
+        pathProperties = makePathPropResponse(path.trainPath, rawInfra),
+        otherRequirements = makeOtherRequirements(rawInfra, requirements, path),
+        departureTime = departureTime,
+        engineeringAllowanceRanges = path.engineeringAllowanceRanges,
+        zoneLocations =
+            path.trainPath.getZoneRanges().map {
+                ZoneLocation(rawInfra.getZoneName(it.value), it.pathBegin, it.pathEnd)
+            },
+    )
+}
+
+fun makeOtherRequirements(
+    rawInfra: RawInfra,
+    requirements: ParsedRequirements,
+    path: STDCMResult,
+): List<TrainZoneRequirement> {
+    val res = mutableListOf<TrainZoneRequirement>()
+    val minRelevantTime = -3_600.0
+    val maxRelevantTime = path.envelope.totalTime + 3_600.0
+    for (zoneRange in path.trainPath.getZoneRanges()) {
+        val timeRanges = requirements[zoneRange.value] ?: continue
+        for (timeRange in timeRanges.values) {
+            val beginTime = max(minRelevantTime, timeRange.lowerEndpoint() - path.departureTime)
+            val endTime = min(maxRelevantTime, timeRange.upperEndpoint() - path.departureTime)
+            if (endTime < beginTime) continue
+            res.add(
+                TrainZoneRequirement(
+                    zoneName = rawInfra.getZoneName(zoneRange.value),
+                    beginTime = beginTime.seconds,
+                    endTime = endTime.seconds,
+                    trainName = null, // TODO: would be very useful, but hard to get
+                )
+            )
+        }
+    }
+    return res
+}

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
@@ -31,6 +31,7 @@ import fr.sncf.osrd.reporting.exceptions.ErrorType
 import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.signaling.etcs_level2.ETCS_LEVEL2
 import fr.sncf.osrd.sim_infra.api.DirTrackChunkId
+import fr.sncf.osrd.sim_infra.api.RawInfra
 import fr.sncf.osrd.sim_infra.api.SpeedLimitProperty
 import fr.sncf.osrd.sim_infra.api.TrackSectionId
 import fr.sncf.osrd.sim_infra.api.ZoneId
@@ -161,11 +162,32 @@ class STDCMEndpoint(
 
             val departureTime =
                 request.startTime.plus(ofMillis((path.departureTime * 1000).toLong()))
+
+            logDebugData(infra.rawInfra, path, simulationResponse, departureTime, requirements)
+
             val response = STDCMSuccess(simulationResponse, pathfindingResponse, departureTime)
             RsJson(RsWithBody(stdcmResponseAdapter.toJson(response)))
         } catch (ex: Throwable) {
             ExceptionHandler.handle(ex)
         }
+    }
+
+    /**
+     * If the env variable is set, dump a json file there with all data that may be relevant for
+     * debug. The feature and env variable isn't properly documented yet, it should soon be linked
+     * to an object storage.
+     */
+    private fun logDebugData(
+        infra: RawInfra,
+        path: STDCMResult,
+        simulationResponse: SimulationSuccess,
+        departureTime: ZonedDateTime,
+        requirements: ParsedRequirements,
+    ) {
+        val filename = System.getenv("STDCM_DEBUG_DATA_FILENAME") ?: return
+        val debugData =
+            generateDebugData(infra, path, simulationResponse, departureTime, requirements)
+        File(filename).writeText(OutputSimDebugData.adapter.indent("  ").toJson(debugData))
     }
 
     /** Build the simulation part of the response */

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMResult.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMResult.kt
@@ -3,6 +3,7 @@ package fr.sncf.osrd.stdcm
 import fr.sncf.osrd.envelope.Envelope
 import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.sim_infra.api.RouteId
+import fr.sncf.osrd.stdcm.graph.EngineeringAllowanceRange
 import fr.sncf.osrd.train.TrainStop
 import fr.sncf.osrd.utils.units.Offset
 
@@ -17,4 +18,5 @@ data class STDCMResult(
     val departureTime: Double,
     val stopResults: List<TrainStop>,
     val waypointOffsets: List<Offset<TrainPath>>,
+    val engineeringAllowanceRanges: List<EngineeringAllowanceRange>,
 )

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/PostProcessingSimulation.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/PostProcessingSimulation.kt
@@ -1,5 +1,6 @@
 package fr.sncf.osrd.stdcm.graph
 
+import com.squareup.moshi.Json
 import fr.sncf.osrd.envelope.Envelope
 import fr.sncf.osrd.envelope_sim.EnvelopeSimContext
 import fr.sncf.osrd.envelope_sim.allowances.AllowanceRange
@@ -37,10 +38,15 @@ private data class FixedTimePoint(
     }
 }
 
-private data class EngineeringAllowanceRange(
+data class EngineeringAllowanceRange(
     val from: Offset<TrainPath>,
     val to: Offset<TrainPath>,
-    val addedDuration: Double,
+    @Json(name = "added_duration") val addedDuration: Double,
+)
+
+data class FinalEnvelopeResult(
+    val envelope: Envelope,
+    val engineeringAllowanceRanges: List<EngineeringAllowanceRange>,
 )
 
 /**
@@ -67,7 +73,7 @@ fun buildFinalEnvelope(
     stops: List<TrainStop>,
     updatedTimeData: TimeData,
     isMareco: Boolean = true,
-): Envelope {
+): FinalEnvelopeResult {
     val context = build(rollingStock, envelopeSimPath, timeStep, comfort)
     val fullInfraExplorer = edges.last().infraExplorerWithNewEnvelope
 
@@ -94,7 +100,7 @@ fun buildFinalEnvelope(
                 runSimulationWithFixedPoints(maxSpeedEnvelope, fixedPoints, context, isMareco)
             val conflictOffset =
                 findConflictOffsets(newEnvelope, blockAvailability, edges, updatedTimeData)
-                    ?: return newEnvelope
+                    ?: return FinalEnvelopeResult(newEnvelope, allowanceRanges)
             if (fixedPoints.any { it.offset == conflictOffset }) {
                 // Error case: a conflict prevents us from finding a solution,
                 // despite the exploration data identifying a valid opening.
@@ -469,7 +475,7 @@ private fun handlePostProcessingConflict(
     fixedPoints: TreeSet<FixedTimePoint>,
     conflictOffset: Offset<TrainPath>,
     isMareco: Boolean,
-): Envelope {
+): FinalEnvelopeResult {
     postProcessingLogger.error(
         "Conflicts detected in post-processing, mismatch with the exploration data"
     )

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
@@ -90,7 +90,7 @@ class STDCMPostProcessing(private val graph: STDCMGraph) {
             )
         val res =
             STDCMResult(
-                withAllowance,
+                withAllowance.envelope,
                 trainPath,
                 routes,
                 updatedTimeData.departureTime,
@@ -99,6 +99,7 @@ class STDCMPostProcessing(private val graph: STDCMGraph) {
                 // after the redesign of simulation data models
                 makePathStops(stops, trainPath),
                 lastExplorer.getStepTracker().getSeenSteps().map { it.travelledPathOffset },
+                withAllowance.engineeringAllowanceRanges,
             )
         return if (res.envelope.totalTime > maxRunTime) {
             // This can happen if the destination is one edge away from being reachable in time,


### PR DESCRIPTION
Part of https://github.com/OpenRailAssociation/osrd/issues/13831

With this PR, we export some debug data when an env var is set. Soon it will be exported to an object storage directly. This will let us see a space-time chart and some other very useful information without having to rerun full simulations locally. 

I'll have a second PR that adds a python script to generate a basic space-time chart from the file, and another one that adds train IDs. If having the full context helps with the review, I can also open one large PR. 

