### PR TITLE
core: pad decimals in Distance.toString()

### DIFF
--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/units/Distance.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/units/Distance.kt
@@ -71,8 +71,8 @@ value class Distance(val millimeters: Long) : Comparable<Distance> {
     override fun toString(): String {
         val meters = millimeters / 1000
         val decimal = (millimeters % 1000).absoluteValue
-        if (decimal == 0L) return String.format("%sm", meters)
-        else return String.format("%s.%sm", meters, decimal)
+        if (decimal == 0L) return String.format("%dm", meters)
+        else return String.format("%d.%03dm", meters, decimal)
     }
 
     operator fun div(d: Double): Distance = Distance(Math.round(millimeters / d))


### PR DESCRIPTION
fixes distances display in debugger for distances whose decimal value is lower than a hundred. e.g. 1001 millimeters would show as `1.1m` instead of `1.001m`.

Also changed `%s` formatters to `%d` since `%s` is the general `.toString()` formatter and doesn't support zero-filled padding, see: https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/Formatter.html#syntax