### PR TITLE
editoast: level_crossing infra_cache completion

### DIFF
--- a/editoast/src/infra_cache/operation/create.rs
+++ b/editoast/src/infra_cache/operation/create.rs
@@ -39,6 +39,7 @@ pub mod tests {
     use schemas::infra::BufferStop;
     use schemas::infra::Detector;
     use schemas::infra::Electrification;
+    use schemas::infra::LevelCrossing;
     use schemas::infra::NeutralSection;
     use schemas::infra::OperationalPoint;
     use schemas::infra::Route;
@@ -80,4 +81,5 @@ pub mod tests {
     test_create_object!(SwitchType, test_create_switch_type);
     test_create_object!(Electrification, test_create_electrification);
     test_create_object!(NeutralSection, test_create_neutral_section);
+    test_create_object!(LevelCrossing, test_create_level_crossing);
 }

--- a/editoast/src/infra_cache/operation/delete.rs
+++ b/editoast/src/infra_cache/operation/delete.rs
@@ -69,6 +69,7 @@ mod tests {
     use schemas::infra::BufferStop;
     use schemas::infra::Detector;
     use schemas::infra::Electrification;
+    use schemas::infra::LevelCrossing;
     use schemas::infra::NeutralSection;
     use schemas::infra::OperationalPoint;
     use schemas::infra::Route;
@@ -140,4 +141,5 @@ mod tests {
         test_delete_neutral_section,
         "neutral_section"
     );
+    test_delete_object!(LevelCrossing, test_delete_level_crossing, "level_crossing");
 }

--- a/editoast/src/views/infra/attached.rs
+++ b/editoast/src/views/infra/attached.rs
@@ -28,6 +28,7 @@ const ATTACHED_OBJECTS_TYPES: &[ObjectType] = &[
     ObjectType::BufferStop,
     ObjectType::OperationalPoint,
     ObjectType::Electrification,
+    ObjectType::LevelCrossing,
 ];
 
 #[derive(Debug, Error, EditoastError)]


### PR DESCRIPTION
Adds elements that were missed in the [previous](https://github.com/OpenRailAssociation/osrd/pull/14437) LevelCrossing infra_cache integration, including:
– Two additional tests
– `LevelCrossing` in `ATTACHED_OBJECTS_TYPES`