### PR TITLE
front: remove ui from prettierignore

### DIFF
--- a/front/.prettierignore
+++ b/front/.prettierignore
@@ -7,5 +7,4 @@ src/common/api/osrdGatewayApi.ts
 src/common/NavBar/json/licenses.json
 src/reducers/osrdconf/infra_schema.json
 src/utils/__tests__/assets/*.json
-/ui
 node_modules


### PR DESCRIPTION
Simply remove `/ui` from the `.prettierignore` file, which is not needed anymore.
The CI front task already check the prettier compatibility of the `ui` part and it's OK (see [here](https://github.com/OpenRailAssociation/osrd/blob/dev/.github/workflows/build.yml#L760)).