### PR TITLE
front: fix process xml error

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/ImportTimetableItemConfig.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/ImportTimetableItemConfig.tsx
@@ -166,16 +166,21 @@ const ImportTimetableItemConfig = ({
   }
 
   const locallyProcessXmlFile = async (fileContent: string) => {
-    const parser = new DOMParser();
-    const xmlDoc = parser.parseFromString(fileContent, 'application/xml');
-    const parserError = xmlDoc.getElementsByTagName('parsererror');
+    try {
+      const parser = new DOMParser();
+      const xmlDoc = parser.parseFromString(fileContent, 'application/xml');
+      const parserError = xmlDoc.getElementsByTagName('parsererror');
 
-    if (parserError.length > 0) {
-      throw new Error('Invalid XML');
+      if (parserError.length > 0) {
+        throw new Error('Invalid XML');
+      }
+
+      const trainData = await parseXML(xmlDoc);
+      setTrainsJsonData(trainData);
+    } catch (error: unknown) {
+      const failure = castErrorToFailure(error);
+      dispatch(setFailure(failure));
     }
-
-    const trainData = await parseXML(xmlDoc);
-    setTrainsJsonData(trainData);
   };
 
   const processXmlFile = async (file: File, fileContent: string) => {

--- a/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/parseXML.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/parseXML.ts
@@ -256,8 +256,7 @@ const parseXML = async (xmlDoc: Document): Promise<TimetableJsonPayload> => {
   const startDate = period ? period.getAttribute('startDate') : null;
 
   if (!startDate) {
-    console.error('Start Date not found in the timetablePeriod.');
-    return { train_schedules: [], paced_trains: [] };
+    throw new Error('Start Date not found in the timetablePeriod.');
   }
 
   trainParts.forEach((train) => {


### PR DESCRIPTION
As noticed by @Castavo , xml parsing errors were not surfaced to users when parsing locally. Worse, it prevented the tartine error from being displayed.

One question, is if the tartine and local import both fail, should both errors be displayed? If not, which one do we want to display?