### PR TITLE
editoast: add `local_track_name` field to `OperationalPointPart`

### DIFF
--- a/core/kt-osrd-rjs-parser/src/main/kotlin/fr/sncf/osrd/RawInfraRJSParser.kt
+++ b/core/kt-osrd-rjs-parser/src/main/kotlin/fr/sncf/osrd/RawInfraRJSParser.kt
@@ -777,6 +777,10 @@ fun parseRJSInfra(rjsInfra: RJSInfra): RawInfra {
                 props["weight"] = weight
             }
             if (opPart.extensions?.sncf != null) props["kp"] = opPart.extensions!!.sncf!!.kp
+            val localTrackName = opPart.localTrackName
+            if (localTrackName != null) {
+                props["local_track_name"] = localTrackName
+            }
             val partId =
                 builder.operationalPointPart(
                     operationalPointId,

--- a/core/osrd-railjson/src/main/java/fr/sncf/osrd/railjson/schema/infra/RJSInfra.java
+++ b/core/osrd-railjson/src/main/java/fr/sncf/osrd/railjson/schema/infra/RJSInfra.java
@@ -18,7 +18,7 @@ public class RJSInfra {
     public static final JsonAdapter<RJSInfra> adapter =
             new Moshi.Builder().add(ID.Adapter.FACTORY).build().adapter(RJSInfra.class);
 
-    public static final transient String CURRENT_VERSION = "3.5.0";
+    public static final transient String CURRENT_VERSION = "3.5.1";
 
     /** The version of the infra format used */
     public String version;

--- a/core/osrd-railjson/src/main/java/fr/sncf/osrd/railjson/schema/infra/trackranges/RJSOperationalPointPart.java
+++ b/core/osrd-railjson/src/main/java/fr/sncf/osrd/railjson/schema/infra/trackranges/RJSOperationalPointPart.java
@@ -1,5 +1,6 @@
 package fr.sncf.osrd.railjson.schema.infra.trackranges;
 
+import com.squareup.moshi.Json;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import fr.sncf.osrd.railjson.schema.infra.trackobjects.RJSTrackObject;
 import java.util.Objects;
@@ -7,13 +8,21 @@ import org.jetbrains.annotations.Nullable;
 
 @SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
 public class RJSOperationalPointPart extends RJSTrackObject {
+    @Json(name = "local_track_name")
+    @Nullable
+    public String localTrackName;
+
     @Nullable
     public RJSOperationalPointPartExtensions extensions;
 
     public RJSOperationalPointPart(
-            String track, double position, @Nullable RJSOperationalPointPartExtensions extensions) {
+            String track,
+            double position,
+            @Nullable String localTrackName,
+            @Nullable RJSOperationalPointPartExtensions extensions) {
         this.track = track;
         this.position = position;
+        this.localTrackName = localTrackName;
         this.extensions = extensions;
     }
 

--- a/core/src/main/kotlin/fr/sncf/osrd/api/path_properties/PathPropResponse.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/path_properties/PathPropResponse.kt
@@ -39,6 +39,7 @@ data class OperationalPointResponse(
 data class OperationalPointPartResponse(
     val track: String,
     val position: Double,
+    @Json(name = "local_track_name") val localTrackName: String,
     val extensions: OperationalPointPartExtension?,
 )
 

--- a/core/src/main/kotlin/fr/sncf/osrd/api/path_properties/PathPropResponseConverter.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/path_properties/PathPropResponseConverter.kt
@@ -67,10 +67,14 @@ private fun makeOperationalPoints(
             rawInfra.getTrackChunkOffset(rawInfra.getOperationalPointPartChunk(opPartId)).distance +
                 chunkOffset.distance
         val opPartProps = rawInfra.getOperationalPointPartProps(opPartId)
+        val localTrackName =
+            opPartProps["local_track_name"]
+                ?: throw IllegalArgumentException("Missing required 'local_track_name'")
         val opPartResult =
             OperationalPointPartResponse(
                 trackSectionName,
                 opPartTrackSectionOffset.meters,
+                localTrackName,
                 if (opPartProps["kp"] == null) null
                 else
                     OperationalPointPartExtension(

--- a/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathPropEndpointTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathPropEndpointTest.kt
@@ -58,7 +58,7 @@ class PathPropEndpointTest : ApiTest() {
             listOf(
                 OperationalPointResponse(
                     "West_station",
-                    OperationalPointPartResponse("TA0", 700.0, null),
+                    OperationalPointPartResponse("TA0", 700.0, "V1", null),
                     OperationalPointExtensions(
                         OperationalPointSncfExtension(22, "BV", "BV", "0", "WS"),
                         OperationalPointIdentifierExtension("West_station", 8722),
@@ -68,7 +68,7 @@ class PathPropEndpointTest : ApiTest() {
                 ),
                 OperationalPointResponse(
                     "West_station",
-                    OperationalPointPartResponse("TA1", 500.0, null),
+                    OperationalPointPartResponse("TA1", 500.0, "V2", null),
                     OperationalPointExtensions(
                         OperationalPointSncfExtension(22, "BV", "BV", "0", "WS"),
                         OperationalPointIdentifierExtension("West_station", 8722),

--- a/core/src/test/kotlin/fr/sncf/osrd/sim_infra_adapter/PathPropertiesTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/sim_infra_adapter/PathPropertiesTests.kt
@@ -103,7 +103,7 @@ class PathPropertiesTests {
         rjsInfra.operationalPoints.add(
             RJSOperationalPoint(
                 "new_op_1",
-                listOf(RJSOperationalPointPart("ne.micro.foo_a", 200.0, null)),
+                listOf(RJSOperationalPointPart("ne.micro.foo_a", 200.0, "V1", null)),
                 null,
                 null,
             )
@@ -111,7 +111,7 @@ class PathPropertiesTests {
         rjsInfra.operationalPoints.add(
             RJSOperationalPoint(
                 "new_op_2",
-                listOf(RJSOperationalPointPart("ne.micro.bar_a", 0.0, null)),
+                listOf(RJSOperationalPointPart("ne.micro.bar_a", 0.0, "V1", null)),
                 null,
                 null,
             )
@@ -156,6 +156,7 @@ class PathPropertiesTests {
                         RJSOperationalPointPart(
                             "TA0",
                             1_000.0,
+                            "V1",
                             RJSOperationalPointPartExtensions(
                                 RJSOperationalPointPartSncfExtension("kp1")
                             ),
@@ -163,6 +164,7 @@ class PathPropertiesTests {
                         RJSOperationalPointPart(
                             "TA0",
                             1_500.0,
+                            "V1",
                             RJSOperationalPointPartExtensions(
                                 RJSOperationalPointPartSncfExtension("kp2")
                             ),
@@ -180,11 +182,12 @@ class PathPropertiesTests {
                         RJSOperationalPointPart(
                             "TA1",
                             0.0,
+                            "V1",
                             RJSOperationalPointPartExtensions(
                                 RJSOperationalPointPartSncfExtension("kp3")
                             ),
                         ),
-                        RJSOperationalPointPart("TA1", 1_950.0, null),
+                        RJSOperationalPointPart("TA1", 1_950.0, "V1", null),
                     ),
                     null,
                     null,

--- a/editoast/core_client/src/path_properties.rs
+++ b/editoast/core_client/src/path_properties.rs
@@ -122,6 +122,7 @@ impl OperationalPointOnPath {
             part: OperationalPointPart {
                 track: Identifier("T1".to_string()),
                 position: 0.0,
+                local_track_name: "V1".into(),
                 extensions: OperationalPointPartExtension { sncf: None },
             },
             extensions: OperationalPointExtensions {

--- a/editoast/migrations/2025-12-18-145255_add_local_track_name_to_operational_point_part/down.sql
+++ b/editoast/migrations/2025-12-18-145255_add_local_track_name_to_operational_point_part/down.sql
@@ -1,0 +1,13 @@
+UPDATE infra_object_operational_point
+SET data = jsonb_set(
+    data,
+    '{parts}',
+    (
+        SELECT jsonb_agg(part - 'local_track_name')
+        FROM jsonb_array_elements(data->'parts') AS part
+    )
+)
+WHERE jsonb_array_length(data->'parts') > 0;
+
+UPDATE infra
+SET railjson_version = '3.5.0';

--- a/editoast/migrations/2025-12-18-145255_add_local_track_name_to_operational_point_part/up.sql
+++ b/editoast/migrations/2025-12-18-145255_add_local_track_name_to_operational_point_part/up.sql
@@ -1,0 +1,23 @@
+UPDATE infra_object_operational_point AS op
+SET data = jsonb_set(
+    op.data,
+    '{parts}',
+    (
+        SELECT jsonb_agg(
+            CASE
+                WHEN ts.data->'extensions'->'sncf'->>'track_name' IS NOT NULL THEN
+                    part || jsonb_build_object('local_track_name', ts.data->'extensions'->'sncf'->>'track_name')
+                ELSE
+                    part || jsonb_build_object('local_track_name', 'missing local track name')
+            END
+        )
+        FROM jsonb_array_elements(op.data->'parts') AS part
+        LEFT JOIN infra_object_track_section AS ts
+            ON ts.obj_id = part->>'track'
+            AND ts.infra_id = op.infra_id
+    )
+)
+WHERE jsonb_array_length(op.data->'parts') > 0;
+
+UPDATE infra
+SET railjson_version = '3.5.1';

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -10692,6 +10692,9 @@ components:
         document_key:
           type: integer
           format: int64
+    NonBlankString:
+      type: string
+      minLength: 1
     ObjectRef:
       type: object
       required:
@@ -10935,6 +10938,7 @@ components:
       required:
       - track
       - position
+      - local_track_name
       properties:
         extensions:
           type: object
@@ -10950,6 +10954,8 @@ components:
                     type: string
                 additionalProperties: false
           additionalProperties: false
+        local_track_name:
+          $ref: '#/components/schemas/NonBlankString'
         position:
           type: number
           format: double

--- a/editoast/osm_to_railjson/src/utils.rs
+++ b/editoast/osm_to_railjson/src/utils.rs
@@ -462,7 +462,8 @@ pub fn operational_points(
                 .flat_map(|node| {
                     nodes_to_tracks
                         .track_and_position(node)
-                        .map(|(track, position)| OperationalPointPart { track, position, extensions: Default::default() })
+                        // TODO: use the local_ref osm tag instead of this default value
+                        .map(|(track, position)| OperationalPointPart { track, position, local_track_name: "missing local track name".into(), extensions: Default::default() })
                 })
                 .collect();
             // Parts can be empty when the stop_area references stops that are not railway (e.g. bus station)

--- a/editoast/schemas/src/infra/operational_point.rs
+++ b/editoast/schemas/src/infra/operational_point.rs
@@ -23,7 +23,7 @@ pub struct OperationalPoint {
     pub weight: Option<u8>,
 }
 
-#[derive(Debug, Educe, Clone, PartialEq, Deserialize, Serialize, ToSchema)]
+#[derive(Debug, Educe, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
 #[serde(deny_unknown_fields)]
 #[educe(Default)]
 pub struct OperationalPointPart {
@@ -31,6 +31,7 @@ pub struct OperationalPointPart {
     #[schema(inline)]
     pub track: Identifier,
     pub position: f64,
+    pub local_track_name: NonBlankString,
     #[serde(default)]
     #[schema(inline)]
     pub extensions: OperationalPointPartExtension,

--- a/editoast/schemas/src/infra/railjson.rs
+++ b/editoast/schemas/src/infra/railjson.rs
@@ -16,7 +16,7 @@ use super::Switch;
 use super::SwitchType;
 use super::TrackSection;
 
-pub const RAILJSON_VERSION: &str = "3.5.0";
+pub const RAILJSON_VERSION: &str = "3.5.1";
 
 /// An infrastructure description in the RailJson format
 #[derive(Deserialize, Educe, Serialize, Clone, Debug, ToSchema)]

--- a/front/public/locales/en/infraEditor.json
+++ b/front/public/locales/en/infraEditor.json
@@ -444,6 +444,10 @@
   "OperationalPointPart": {
     "description": "Operational point part is a single point on the infrastructure. It's linked to an operational point.",
     "properties": {
+      "local_track_name": {
+        "description": "Local track name for this operational point part",
+        "title": "Local track name"
+      },
       "position": {
         "description": "Offset of the point in meters to the beginning of the track section",
         "title": "Position"

--- a/front/src/applications/operationalStudies/__tests__/upsertMapWaypointsInOperationalPoints.spec.ts
+++ b/front/src/applications/operationalStudies/__tests__/upsertMapWaypointsInOperationalPoints.spec.ts
@@ -25,6 +25,7 @@ const getOperationalPoints = (inputs: Op[]): NonNullable<PathProperties['operati
     part: {
       track: op.track,
       position: op.positionOnTrack,
+      local_track_name: 'V1',
     },
     extensions: {
       identifier: {
@@ -107,6 +108,7 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
         part: {
           track: 'TA1',
           position: 500,
+          local_track_name: 'V1',
         },
         extensions: {
           identifier: {
@@ -128,6 +130,7 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
         part: {
           track: 'TA6',
           position: 7746000,
+          local_track_name: 'V1',
         },
         position: 9246000,
         weight: 100,
@@ -137,6 +140,7 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
         part: {
           track: 'TC1',
           position: 550,
+          local_track_name: 'V1',
         },
         extensions: {
           identifier: {
@@ -152,6 +156,7 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
         part: {
           track: 'TD0',
           position: 14000,
+          local_track_name: 'V1',
         },
         extensions: {
           identifier: {
@@ -219,6 +224,7 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
         part: {
           track: 'TA6',
           position: 6481000,
+          local_track_name: 'V1',
         },
         position: 0,
         weight: 100,
@@ -228,6 +234,7 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
         part: {
           track: 'TC0',
           position: 550,
+          local_track_name: 'V1',
         },
         extensions: {
           identifier: {
@@ -249,6 +256,7 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
         part: {
           track: 'TC0',
           position: 679000,
+          local_track_name: 'V1',
         },
         position: 4198000,
         weight: 100,
@@ -264,6 +272,7 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
         part: {
           track: 'TC0',
           position: 883000,
+          local_track_name: 'V1',
         },
         position: 4402000,
         weight: 100,
@@ -310,6 +319,7 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
         part: {
           track: 'TA6',
           position: 6481000,
+          local_track_name: 'V1',
         },
         position: 0,
         weight: 100,
@@ -325,6 +335,7 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
         part: {
           track: 'TA6',
           position: 4733000,
+          local_track_name: 'V1',
         },
         position: 1748000,
         weight: 100,
@@ -381,6 +392,7 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
         part: {
           track: 'TA1',
           position: 500,
+          local_track_name: 'V1',
         },
         extensions: {
           identifier: {
@@ -396,6 +408,7 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
         part: {
           track: 'TC1',
           position: 550,
+          local_track_name: 'V1',
         },
         extensions: {
           identifier: {
@@ -411,6 +424,7 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
         part: {
           track: 'TD0',
           position: 14000,
+          local_track_name: 'V1',
         },
         extensions: {
           identifier: {

--- a/front/src/applications/operationalStudies/helpers/upsertMapWaypointsInOperationalPoints.ts
+++ b/front/src/applications/operationalStudies/helpers/upsertMapWaypointsInOperationalPoints.ts
@@ -54,7 +54,7 @@ export function upsertMapWaypointsInOperationalPoints(
               uic: 0,
             },
           },
-          part: { track: location.track, position: location.offset },
+          part: { track: location.track, position: location.offset, local_track_name: 'V1' },
           position: positionOnPath,
           weight: HIGHEST_PRIORITY_WEIGHT,
         };

--- a/front/src/applications/operationalStudies/hooks/usePathProjection.ts
+++ b/front/src/applications/operationalStudies/hooks/usePathProjection.ts
@@ -82,7 +82,7 @@ const createVirtualOp = (
         trigram: opRef.type === 'trigram' ? opRef.trigram : '',
       },
     },
-    part: { track: '', position: 0 },
+    part: { track: '', position: 0, local_track_name: 'V1' },
     position,
     weight,
   };
@@ -246,7 +246,12 @@ const usePathProjection = (
         normalizedOps.push({
           id: matchedOp.id,
           extensions: matchedOp.extensions,
-          part: matchedOp.parts.at(0) || { track: '', position: 0, extensions: undefined },
+          part: matchedOp.parts.at(0) || {
+            track: '',
+            position: 0,
+            local_track_name: 'V1',
+            extensions: undefined,
+          },
           position,
           weight,
         });

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -3059,12 +3059,14 @@ export type NeutralSection = {
   lower_pantograph: boolean;
   track_ranges: DirectionalTrackRange[];
 };
+export type NonBlankString = string;
 export type OperationalPointPart = {
   extensions?: {
     sncf?: null | {
       kp: string;
     };
   };
+  local_track_name: NonBlankString;
   position: number;
   track: string;
 };

--- a/front/src/modules/simulationResult/components/SpeedDistanceDiagram/__tests__/helpers.spec.ts
+++ b/front/src/modules/simulationResult/components/SpeedDistanceDiagram/__tests__/helpers.spec.ts
@@ -51,6 +51,7 @@ describe('formatStops', () => {
         part: {
           position: 0,
           track: 'track',
+          local_track_name: '',
         },
         weight: null,
       },

--- a/front/src/reducers/osrdconf/infra_schema.json
+++ b/front/src/reducers/osrdconf/infra_schema.json
@@ -980,6 +980,12 @@
                     "$ref": "#/$defs/OperationalPointPartExtensions",
                     "default": null
                 },
+                "local_track_name": {
+                    "description": "Local track name for this operational point part",
+                    "minLength": 1,
+                    "title": "Local Track Name",
+                    "type": "string"
+                },
                 "position": {
                     "description": "Offset of the point in meters to the beginning of the track section",
                     "minimum": 0,
@@ -996,7 +1002,8 @@
             },
             "required": [
                 "track",
-                "position"
+                "position",
+                "local_track_name"
             ],
             "title": "OperationalPointPart",
             "type": "object"
@@ -2146,8 +2153,8 @@
             "type": "array"
         },
         "version": {
-            "const": "3.5.0",
-            "default": "3.5.0",
+            "const": "3.5.1",
+            "default": "3.5.1",
             "description": "Version of the schema",
             "title": "Version",
             "type": "string"

--- a/python/osrd_schemas/osrd_schemas/infra.py
+++ b/python/osrd_schemas/osrd_schemas/infra.py
@@ -8,7 +8,7 @@ from pydantic.fields import FieldInfo
 
 ALL_OBJECT_TYPES = []
 
-RAILJSON_INFRA_VERSION_TYPE = Literal["3.5.0"]
+RAILJSON_INFRA_VERSION_TYPE = Literal["3.5.1"]
 RAILJSON_INFRA_VERSION = get_args(RAILJSON_INFRA_VERSION_TYPE)[0]
 
 # Traits
@@ -207,7 +207,9 @@ class OperationalPointPart(TrackLocationTrait):
     Operational point part is a single point on the infrastructure. It's linked to an operational point.
     """
 
-    pass
+    local_track_name: NonBlankStr = Field(
+        description="Local track name for this operational point part"
+    )
 
 
 class OperationalPoint(BaseObjectTrait):

--- a/python/railjson_generator/railjson_generator/schema/infra/infra.py
+++ b/python/railjson_generator/railjson_generator/schema/infra/infra.py
@@ -26,7 +26,7 @@ class Infra:
     electrifications: List[Electrification] = field(default_factory=list)
     neutral_sections: List[NeutralSection] = field(default_factory=list)
 
-    VERSION = "3.5.0"
+    VERSION = "3.5.1"
 
     def add_route(self, *args, **kwargs):
         self.routes.append(Route(*args, **kwargs))

--- a/python/railjson_generator/railjson_generator/schema/infra/operational_point.py
+++ b/python/railjson_generator/railjson_generator/schema/infra/operational_point.py
@@ -1,7 +1,11 @@
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import Annotated, List, Optional
+
+from pydantic import StringConstraints
 
 from osrd_schemas import infra
+
+NonBlankStr = Annotated[str, StringConstraints(min_length=1)]
 
 
 @dataclass
@@ -31,8 +35,8 @@ class OperationalPoint:
         self.id = id or label
         self.ch = ch
 
-    def add_part(self, track, offset):
-        op_part = OperationalPointPart(self, offset)
+    def add_part(self, track, offset, local_track_name):
+        op_part = OperationalPointPart(self, offset, local_track_name)
         track.operational_points.append(op_part)
         self.parts.append(op_part)
 
@@ -41,9 +45,11 @@ class OperationalPoint:
 class OperationalPointPart:
     operational_point: OperationalPoint
     position: float
+    local_track_name: str
 
     def to_rjs(self, track):
         return infra.OperationalPointPart(
             track=track.id,
             position=self.position,
+            local_track_name=self.local_track_name,
         )

--- a/tests/data/infras/circle_infra/infra.json
+++ b/tests/data/infras/circle_infra/infra.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.5.0",
+    "version": "3.5.1",
     "operational_points": [],
     "level_crossings": [],
     "routes": [],

--- a/tests/data/infras/etcs_infra/infra.json
+++ b/tests/data/infras/etcs_infra/infra.json
@@ -1,20 +1,23 @@
 {
-    "version": "3.5.0",
+    "version": "3.5.1",
     "operational_points": [
         {
             "id": "West_station",
             "parts": [
                 {
                     "track": "TA0",
-                    "position": 700.0
+                    "position": 700.0,
+                    "local_track_name": "V1"
                 },
                 {
                     "track": "TA1",
-                    "position": 500.0
+                    "position": 500.0,
+                    "local_track_name": "V2"
                 },
                 {
                     "track": "TA2",
-                    "position": 500.0
+                    "position": 500.0,
+                    "local_track_name": "V3"
                 }
             ],
             "weight": null,
@@ -37,7 +40,8 @@
             "parts": [
                 {
                     "track": "TB0",
-                    "position": 500.0
+                    "position": 500.0,
+                    "local_track_name": "V1"
                 }
             ],
             "weight": null,
@@ -60,19 +64,23 @@
             "parts": [
                 {
                     "track": "TC0",
-                    "position": 550.0
+                    "position": 550.0,
+                    "local_track_name": "V1"
                 },
                 {
                     "track": "TC1",
-                    "position": 550.0
+                    "position": 550.0,
+                    "local_track_name": "V2"
                 },
                 {
                     "track": "TC2",
-                    "position": 450.0
+                    "position": 450.0,
+                    "local_track_name": "V3"
                 },
                 {
                     "track": "TC3",
-                    "position": 450.0
+                    "position": 450.0,
+                    "local_track_name": "V4"
                 }
             ],
             "weight": null,
@@ -95,11 +103,13 @@
             "parts": [
                 {
                     "track": "TD0",
-                    "position": 14000.0
+                    "position": 14000.0,
+                    "local_track_name": "V1"
                 },
                 {
                     "track": "TD1",
-                    "position": 14000.0
+                    "position": 14000.0,
+                    "local_track_name": "V2"
                 }
             ],
             "weight": null,
@@ -122,11 +132,13 @@
             "parts": [
                 {
                     "track": "TE1",
-                    "position": 1000.0
+                    "position": 1000.0,
+                    "local_track_name": "V1"
                 },
                 {
                     "track": "TE2",
-                    "position": 1025.0
+                    "position": 1025.0,
+                    "local_track_name": "V2"
                 }
             ],
             "weight": null,
@@ -149,7 +161,8 @@
             "parts": [
                 {
                     "track": "TF1",
-                    "position": 4300.0
+                    "position": 4300.0,
+                    "local_track_name": "V1"
                 }
             ],
             "weight": null,
@@ -172,11 +185,13 @@
             "parts": [
                 {
                     "track": "TG4",
-                    "position": 1550.0
+                    "position": 1550.0,
+                    "local_track_name": "V1"
                 },
                 {
                     "track": "TG5",
-                    "position": 1500.0
+                    "position": 1500.0,
+                    "local_track_name": "V2"
                 }
             ],
             "weight": null,
@@ -199,7 +214,8 @@
             "parts": [
                 {
                     "track": "TH1",
-                    "position": 4400.0
+                    "position": 4400.0,
+                    "local_track_name": "V1"
                 }
             ],
             "weight": null,

--- a/tests/data/infras/example_script/infra.json
+++ b/tests/data/infras/example_script/infra.json
@@ -1,16 +1,18 @@
 {
-    "version": "3.5.0",
+    "version": "3.5.1",
     "operational_points": [
         {
             "id": "my-op",
             "parts": [
                 {
                     "track": "track.0",
-                    "position": 500.0
+                    "position": 500.0,
+                    "local_track_name": "V1"
                 },
                 {
                     "track": "track.1",
-                    "position": 500.0
+                    "position": 500.0,
+                    "local_track_name": "V2"
                 }
             ],
             "weight": null,

--- a/tests/data/infras/medium_infra/infra.json
+++ b/tests/data/infras/medium_infra/infra.json
@@ -1,12 +1,13 @@
 {
-    "version": "3.5.0",
+    "version": "3.5.1",
     "operational_points": [
         {
             "id": "North_West_station",
             "parts": [
                 {
                     "track": "TI0",
-                    "position": 300.0
+                    "position": 300.0,
+                    "local_track_name": "V1"
                 }
             ],
             "weight": null,
@@ -29,7 +30,8 @@
             "parts": [
                 {
                     "track": "TI1",
-                    "position": 250.0
+                    "position": 250.0,
+                    "local_track_name": "V2"
                 }
             ],
             "weight": null,
@@ -52,15 +54,18 @@
             "parts": [
                 {
                     "track": "TA0",
-                    "position": 700.0
+                    "position": 700.0,
+                    "local_track_name": "V1"
                 },
                 {
                     "track": "TA1",
-                    "position": 500.0
+                    "position": 500.0,
+                    "local_track_name": "V2"
                 },
                 {
                     "track": "TA2",
-                    "position": 500.0
+                    "position": 500.0,
+                    "local_track_name": "V3"
                 }
             ],
             "weight": null,
@@ -83,7 +88,8 @@
             "parts": [
                 {
                     "track": "TB0",
-                    "position": 500.0
+                    "position": 500.0,
+                    "local_track_name": "V1"
                 }
             ],
             "weight": null,
@@ -106,19 +112,23 @@
             "parts": [
                 {
                     "track": "TC0",
-                    "position": 550.0
+                    "position": 550.0,
+                    "local_track_name": "V1"
                 },
                 {
                     "track": "TC1",
-                    "position": 550.0
+                    "position": 550.0,
+                    "local_track_name": "V2"
                 },
                 {
                     "track": "TC2",
-                    "position": 450.0
+                    "position": 450.0,
+                    "local_track_name": "V3"
                 },
                 {
                     "track": "TC3",
-                    "position": 450.0
+                    "position": 450.0,
+                    "local_track_name": "V4"
                 }
             ],
             "weight": null,
@@ -141,11 +151,13 @@
             "parts": [
                 {
                     "track": "TD0",
-                    "position": 14000.0
+                    "position": 14000.0,
+                    "local_track_name": "V1"
                 },
                 {
                     "track": "TD1",
-                    "position": 14000.0
+                    "position": 14000.0,
+                    "local_track_name": "V2"
                 }
             ],
             "weight": null,
@@ -168,11 +180,13 @@
             "parts": [
                 {
                     "track": "TE1",
-                    "position": 1000.0
+                    "position": 1000.0,
+                    "local_track_name": "V1"
                 },
                 {
                     "track": "TE2",
-                    "position": 1025.0
+                    "position": 1025.0,
+                    "local_track_name": "V2"
                 }
             ],
             "weight": null,
@@ -195,7 +209,8 @@
             "parts": [
                 {
                     "track": "TF1",
-                    "position": 4300.0
+                    "position": 4300.0,
+                    "local_track_name": "V1"
                 }
             ],
             "weight": null,
@@ -218,11 +233,13 @@
             "parts": [
                 {
                     "track": "TG4",
-                    "position": 1550.0
+                    "position": 1550.0,
+                    "local_track_name": "V1"
                 },
                 {
                     "track": "TG5",
-                    "position": 1500.0
+                    "position": 1500.0,
+                    "local_track_name": "V2"
                 }
             ],
             "weight": null,
@@ -245,7 +262,8 @@
             "parts": [
                 {
                     "track": "TH1",
-                    "position": 4400.0
+                    "position": 4400.0,
+                    "local_track_name": "V1"
                 }
             ],
             "weight": null,

--- a/tests/data/infras/nested_switches/infra.json
+++ b/tests/data/infras/nested_switches/infra.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.5.0",
+    "version": "3.5.1",
     "operational_points": [],
     "level_crossings": [],
     "routes": [

--- a/tests/data/infras/one_line/infra.json
+++ b/tests/data/infras/one_line/infra.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.5.0",
+    "version": "3.5.1",
     "operational_points": [],
     "level_crossings": [],
     "routes": [

--- a/tests/data/infras/overlapping_routes/infra.json
+++ b/tests/data/infras/overlapping_routes/infra.json
@@ -1,12 +1,13 @@
 {
-    "version": "3.5.0",
+    "version": "3.5.1",
     "operational_points": [
         {
             "id": "op.a1",
             "parts": [
                 {
                     "track": "t_a1",
-                    "position": 0.0
+                    "position": 0.0,
+                    "local_track_name": "V1"
                 }
             ],
             "weight": null,
@@ -29,7 +30,8 @@
             "parts": [
                 {
                     "track": "t_a2",
-                    "position": 1000.0
+                    "position": 1000.0,
+                    "local_track_name": "V1"
                 }
             ],
             "weight": null,
@@ -52,7 +54,8 @@
             "parts": [
                 {
                     "track": "t_b1",
-                    "position": 0.0
+                    "position": 0.0,
+                    "local_track_name": "V1"
                 }
             ],
             "weight": null,
@@ -75,7 +78,8 @@
             "parts": [
                 {
                     "track": "t_b2",
-                    "position": 1000.0
+                    "position": 1000.0,
+                    "local_track_name": "V1"
                 }
             ],
             "weight": null,

--- a/tests/data/infras/small_infra/infra.json
+++ b/tests/data/infras/small_infra/infra.json
@@ -1,20 +1,23 @@
 {
-    "version": "3.5.0",
+    "version": "3.5.1",
     "operational_points": [
         {
             "id": "West_station",
             "parts": [
                 {
                     "track": "TA0",
-                    "position": 700.0
+                    "position": 700.0,
+                    "local_track_name": "V1"
                 },
                 {
                     "track": "TA1",
-                    "position": 500.0
+                    "position": 500.0,
+                    "local_track_name": "V2"
                 },
                 {
                     "track": "TA2",
-                    "position": 500.0
+                    "position": 500.0,
+                    "local_track_name": "V3"
                 }
             ],
             "weight": null,
@@ -37,7 +40,8 @@
             "parts": [
                 {
                     "track": "TB0",
-                    "position": 500.0
+                    "position": 500.0,
+                    "local_track_name": "V1"
                 }
             ],
             "weight": null,
@@ -60,19 +64,23 @@
             "parts": [
                 {
                     "track": "TC0",
-                    "position": 550.0
+                    "position": 550.0,
+                    "local_track_name": "V1"
                 },
                 {
                     "track": "TC1",
-                    "position": 550.0
+                    "position": 550.0,
+                    "local_track_name": "V2"
                 },
                 {
                     "track": "TC2",
-                    "position": 450.0
+                    "position": 450.0,
+                    "local_track_name": "V3"
                 },
                 {
                     "track": "TC3",
-                    "position": 450.0
+                    "position": 450.0,
+                    "local_track_name": "V4"
                 }
             ],
             "weight": null,
@@ -95,11 +103,13 @@
             "parts": [
                 {
                     "track": "TD0",
-                    "position": 14000.0
+                    "position": 14000.0,
+                    "local_track_name": "V1"
                 },
                 {
                     "track": "TD1",
-                    "position": 14000.0
+                    "position": 14000.0,
+                    "local_track_name": "V2"
                 }
             ],
             "weight": null,
@@ -122,11 +132,13 @@
             "parts": [
                 {
                     "track": "TE1",
-                    "position": 1000.0
+                    "position": 1000.0,
+                    "local_track_name": "V1"
                 },
                 {
                     "track": "TE2",
-                    "position": 1025.0
+                    "position": 1025.0,
+                    "local_track_name": "V2"
                 }
             ],
             "weight": null,
@@ -149,7 +161,8 @@
             "parts": [
                 {
                     "track": "TF1",
-                    "position": 4300.0
+                    "position": 4300.0,
+                    "local_track_name": "V1"
                 }
             ],
             "weight": null,
@@ -172,11 +185,13 @@
             "parts": [
                 {
                     "track": "TG4",
-                    "position": 1550.0
+                    "position": 1550.0,
+                    "local_track_name": "V1"
                 },
                 {
                     "track": "TG5",
-                    "position": 1500.0
+                    "position": 1500.0,
+                    "local_track_name": "V2"
                 }
             ],
             "weight": null,
@@ -199,7 +214,8 @@
             "parts": [
                 {
                     "track": "TH1",
-                    "position": 4400.0
+                    "position": 4400.0,
+                    "local_track_name": "V1"
                 }
             ],
             "weight": null,

--- a/tests/data/infras/takeover/infra.json
+++ b/tests/data/infras/takeover/infra.json
@@ -1,12 +1,13 @@
 {
-    "version": "3.5.0",
+    "version": "3.5.1",
     "operational_points": [
         {
             "id": "op.start",
             "parts": [
                 {
                     "track": "t_1",
-                    "position": 0.0
+                    "position": 0.0,
+                    "local_track_name": "V1"
                 }
             ],
             "weight": null,
@@ -29,7 +30,8 @@
             "parts": [
                 {
                     "track": "t_2",
-                    "position": 1500.0
+                    "position": 1500.0,
+                    "local_track_name": "V1"
                 }
             ],
             "weight": null,
@@ -52,7 +54,8 @@
             "parts": [
                 {
                     "track": "t_takeover",
-                    "position": 1500.0
+                    "position": 1500.0,
+                    "local_track_name": "V1"
                 }
             ],
             "weight": null,
@@ -75,7 +78,8 @@
             "parts": [
                 {
                     "track": "t_3",
-                    "position": 20000.0
+                    "position": 20000.0,
+                    "local_track_name": "V1"
                 }
             ],
             "weight": null,

--- a/tests/data/infras/three_trains/infra.json
+++ b/tests/data/infras/three_trains/infra.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.5.0",
+    "version": "3.5.1",
     "operational_points": [],
     "level_crossings": [],
     "routes": [

--- a/tests/data/infras/tiny_infra/infra.json
+++ b/tests/data/infras/tiny_infra/infra.json
@@ -1,16 +1,18 @@
 {
-    "version": "3.5.0",
+    "version": "3.5.1",
     "operational_points": [
         {
             "id": "op.station_foo",
             "parts": [
                 {
                     "track": "ne.micro.foo_a",
-                    "position": 100.0
+                    "position": 100.0,
+                    "local_track_name": "V1"
                 },
                 {
                     "track": "ne.micro.foo_b",
-                    "position": 100.0
+                    "position": 100.0,
+                    "local_track_name": "V2"
                 }
             ],
             "weight": null,
@@ -33,7 +35,8 @@
             "parts": [
                 {
                     "track": "ne.micro.bar_a",
-                    "position": 100.0
+                    "position": 100.0,
+                    "local_track_name": "V1"
                 }
             ],
             "weight": null,

--- a/tests/data/infras/y_infra/infra.json
+++ b/tests/data/infras/y_infra/infra.json
@@ -1,12 +1,13 @@
 {
-    "version": "3.5.0",
+    "version": "3.5.1",
     "operational_points": [
         {
             "id": "op.a",
             "parts": [
                 {
                     "track": "t_a",
-                    "position": 0.0
+                    "position": 0.0,
+                    "local_track_name": "V1"
                 }
             ],
             "weight": null,
@@ -29,7 +30,8 @@
             "parts": [
                 {
                     "track": "t_b",
-                    "position": 0.0
+                    "position": 0.0,
+                    "local_track_name": "V1"
                 }
             ],
             "weight": null,
@@ -52,7 +54,8 @@
             "parts": [
                 {
                     "track": "t_center",
-                    "position": 10000.0
+                    "position": 10000.0,
+                    "local_track_name": "V1"
                 }
             ],
             "weight": null,

--- a/tests/infra-scripts/example_script.py
+++ b/tests/infra-scripts/example_script.py
@@ -67,8 +67,8 @@ def _build_scenario_data():
 
     # Add operational points
     my_op = builder.add_operational_point("my-op")
-    my_op.add_part(tracks[0], 500)
-    my_op.add_part(tracks[1], 500)
+    my_op.add_part(tracks[0], 500, "V1")
+    my_op.add_part(tracks[1], 500, "V2")
 
     # Build infra: Generate BufferStops, TVDSections and Routes
     return ScenarioData(infra=builder.build())

--- a/tests/infra-scripts/medium_infra.py
+++ b/tests/infra-scripts/medium_infra.py
@@ -139,8 +139,8 @@ def create_medium_infra(signaling_system: str) -> ScenarioData:
         uic=8799,
         id="North_West_station_1",
     )
-    north_west.add_part(ti0, 300)
-    north_west_1.add_part(ti1, 250)
+    north_west.add_part(ti0, 300, "V1")
+    north_west_1.add_part(ti1, 250, "V2")
 
     pa0 = builder.add_point_switch(
         label="PA0",
@@ -193,9 +193,9 @@ def create_medium_infra(signaling_system: str) -> ScenarioData:
     )
     # Station
     west = builder.add_operational_point(label="West_station", trigram="WS", uic=8722)
-    west.add_part(ta0, 700)
-    west.add_part(ta1, 500)
-    west.add_part(ta2, 500)
+    west.add_part(ta0, 700, "V1")
+    west.add_part(ta1, 500, "V2")
+    west.add_part(ta2, 500, "V3")
     # Slopes
     ta6.add_slope(begin=4000, end=4300, slope=-3)
     ta6.add_slope(begin=4300, end=4700, slope=-6)
@@ -223,7 +223,7 @@ def create_medium_infra(signaling_system: str) -> ScenarioData:
         trigram="SWS",
         uic=8711,
     )
-    south_west.add_part(tb0, 500)
+    south_west.add_part(tb0, 500, "V1")
     # ================================
     #  Around station C: Mid - West
     # ================================
@@ -325,10 +325,10 @@ def create_medium_infra(signaling_system: str) -> ScenarioData:
     mid_west = builder.add_operational_point(
         label="Mid_West_station", trigram="MWS", uic=8733
     )
-    mid_west.add_part(tc0, 550)
-    mid_west.add_part(tc1, 550)
-    mid_west.add_part(tc2, 450)
-    mid_west.add_part(tc3, 450)
+    mid_west.add_part(tc0, 550, "V1")
+    mid_west.add_part(tc1, 550, "V2")
+    mid_west.add_part(tc2, 450, "V3")
+    mid_west.add_part(tc3, 450, "V4")
     # ================================
     #  Around station D: Mid-East
     # ================================
@@ -387,8 +387,8 @@ def create_medium_infra(signaling_system: str) -> ScenarioData:
     mid_east = builder.add_operational_point(
         label="Mid_East_station", trigram="MES", uic=8744
     )
-    mid_east.add_part(td0, 14000)
-    mid_east.add_part(td1, 14000)
+    mid_east.add_part(td0, 14000, "V1")
+    mid_east.add_part(td1, 14000, "V2")
     # Slopes
     td0.add_slope(begin=6000, end=7000, slope=3)
     td0.add_slope(begin=7000, end=8000, slope=6)
@@ -479,8 +479,8 @@ def create_medium_infra(signaling_system: str) -> ScenarioData:
     te3.set_remaining_coords([(-0.145, LAT_0 + 0.002), (-0.145, LAT_3 - 0.002)])
     # Station
     north = builder.add_operational_point(label="North_station", trigram="NS", uic=8755)
-    north.add_part(te1, 1000)
-    north.add_part(te2, 1025)
+    north.add_part(te1, 1000, "V1")
+    north.add_part(te2, 1025, "V2")
     # Curves
     te3.add_curve(begin=0, end=300, curve=5000)
     te3.add_curve(begin=650, end=850, curve=9000)
@@ -495,7 +495,7 @@ def create_medium_infra(signaling_system: str) -> ScenarioData:
     # ================================
     tf1.set_remaining_coords([(-0.172, 49.47), (-0.167, 49.466), (-0.135, 49.466)])
     south = builder.add_operational_point(label="South_station", trigram="SS", uic=8766)
-    south.add_part(tf1, 4300)
+    south.add_part(tf1, 4300, "V1")
     place_regular_signals_detectors(
         tf1, "F1", signaling_system, min_offset=200.0, max_offset=4300.0
     )
@@ -542,8 +542,8 @@ def create_medium_infra(signaling_system: str) -> ScenarioData:
     north_east = builder.add_operational_point(
         label="North_East_station", trigram="NES", uic=8777
     )
-    north_east.add_part(tg4, 1550)
-    north_east.add_part(tg5, 1500)
+    north_east.add_part(tg4, 1550, "V1")
+    north_east.add_part(tg5, 1500, "V2")
     place_regular_signals_detectors(
         tg1, "G1", signaling_system, min_offset=200.0, max_offset=-200.0
     )
@@ -618,7 +618,7 @@ def create_medium_infra(signaling_system: str) -> ScenarioData:
     south_east = builder.add_operational_point(
         label="South_East_station", trigram="SES", uic=8788
     )
-    south_east.add_part(th1, 4400)
+    south_east.add_part(th1, 4400, "V1")
     # ================================
     #  Speed sections
     # ================================

--- a/tests/infra-scripts/overlapping_routes.py
+++ b/tests/infra-scripts/overlapping_routes.py
@@ -45,10 +45,10 @@ def _build_scenario_data():
 
     # Add objects on tracks
 
-    op_a1.add_part(t_a1, 0)
-    op_b1.add_part(t_b1, 0)
-    op_a2.add_part(t_a2, 1_000)
-    op_b2.add_part(t_b2, 1_000)
+    op_a1.add_part(t_a1, 0, "V1")
+    op_b1.add_part(t_b1, 0, "V1")
+    op_a2.add_part(t_a2, 1_000, "V1")
+    op_b2.add_part(t_b2, 1_000, "V1")
     t_a1.add_buffer_stop(label="bf.a1", position=0)
     t_a2.add_buffer_stop(label="bf.a2", position=0)
     t_b1.add_buffer_stop(label="bf.b1", position=1_000)

--- a/tests/infra-scripts/small_infra_creator/__init__.py
+++ b/tests/infra-scripts/small_infra_creator/__init__.py
@@ -198,9 +198,9 @@ def create_small_infra(signaling_system: str) -> ScenarioData:
     )
     # Station
     west = builder.add_operational_point(label="West_station", trigram="WS", uic=8722)
-    west.add_part(ta0, 700)
-    west.add_part(ta1, 500)
-    west.add_part(ta2, 500)
+    west.add_part(ta0, 700, "V1")
+    west.add_part(ta1, 500, "V2")
+    west.add_part(ta2, 500, "V3")
     # Slopes
     ta6.add_slope(begin=4000, end=4300, slope=-3)
     ta6.add_slope(begin=4300, end=4700, slope=-6)
@@ -227,7 +227,7 @@ def create_small_infra(signaling_system: str) -> ScenarioData:
         trigram="SWS",
         uic=8711,
     )
-    south_west.add_part(tb0, 500)
+    south_west.add_part(tb0, 500, "V1")
     # ================================
     #  Around station C: Mid - West
     # ================================
@@ -330,10 +330,10 @@ def create_small_infra(signaling_system: str) -> ScenarioData:
     mid_west = builder.add_operational_point(
         label="Mid_West_station", trigram="MWS", uic=8733
     )
-    mid_west.add_part(tc0, 550)
-    mid_west.add_part(tc1, 550)
-    mid_west.add_part(tc2, 450)
-    mid_west.add_part(tc3, 450)
+    mid_west.add_part(tc0, 550, "V1")
+    mid_west.add_part(tc1, 550, "V2")
+    mid_west.add_part(tc2, 450, "V3")
+    mid_west.add_part(tc3, 450, "V4")
     # ================================
     #  Around station D: Mid-East
     # ================================
@@ -392,8 +392,8 @@ def create_small_infra(signaling_system: str) -> ScenarioData:
     mid_east = builder.add_operational_point(
         label="Mid_East_station", trigram="MES", uic=8744
     )
-    mid_east.add_part(td0, 14000)
-    mid_east.add_part(td1, 14000)
+    mid_east.add_part(td0, 14000, "V1")
+    mid_east.add_part(td1, 14000, "V2")
     # Slopes
     td0.add_slope(begin=6000, end=7000, slope=3)
     td0.add_slope(begin=7000, end=8000, slope=6)
@@ -484,8 +484,8 @@ def create_small_infra(signaling_system: str) -> ScenarioData:
     te3.set_remaining_coords([(-0.145, LAT_0 + 0.002), (-0.145, LAT_3 - 0.002)])
     # Station
     north = builder.add_operational_point(label="North_station", trigram="NS", uic=8755)
-    north.add_part(te1, 1000)
-    north.add_part(te2, 1025)
+    north.add_part(te1, 1000, "V1")
+    north.add_part(te2, 1025, "V2")
     # Curves
     te3.add_curve(begin=0, end=300, curve=5000)
     te3.add_curve(begin=650, end=850, curve=9000)
@@ -500,7 +500,7 @@ def create_small_infra(signaling_system: str) -> ScenarioData:
     # ================================
     tf1.set_remaining_coords([(-0.172, 49.47), (-0.167, 49.466), (-0.135, 49.466)])
     south = builder.add_operational_point(label="South_station", trigram="SS", uic=8766)
-    south.add_part(tf1, 4300)
+    south.add_part(tf1, 4300, "V1")
     place_regular_signals_detectors(
         tf1, "F1", signaling_system, min_offset=200.0, max_offset=4300.0
     )
@@ -547,8 +547,8 @@ def create_small_infra(signaling_system: str) -> ScenarioData:
     north_east = builder.add_operational_point(
         label="North_East_station", trigram="NES", uic=8777
     )
-    north_east.add_part(tg4, 1550)
-    north_east.add_part(tg5, 1500)
+    north_east.add_part(tg4, 1550, "V1")
+    north_east.add_part(tg5, 1500, "V2")
     place_regular_signals_detectors(
         tg1, "G1", signaling_system, min_offset=200.0, max_offset=-200.0
     )
@@ -623,7 +623,7 @@ def create_small_infra(signaling_system: str) -> ScenarioData:
     south_east = builder.add_operational_point(
         label="South_East_station", trigram="SES", uic=8788
     )
-    south_east.add_part(th1, 4400)
+    south_east.add_part(th1, 4400, "V1")
     # ================================
     #  Speed sections
     # ================================

--- a/tests/infra-scripts/takeover.py
+++ b/tests/infra-scripts/takeover.py
@@ -53,10 +53,10 @@ def _build_scenario_data():
 
     # Add objects on tracks
 
-    op_start.add_part(t_1, 0)
-    op_end.add_part(t_3, 20_000)
-    op_center.add_part(t_2, 1_500)
-    op_takeover.add_part(t_takeover, 1_500)
+    op_start.add_part(t_1, 0, "V1")
+    op_end.add_part(t_3, 20_000, "V1")
+    op_center.add_part(t_2, 1_500, "V1")
+    op_takeover.add_part(t_takeover, 1_500, "V1")
     t_1.add_buffer_stop(label="bf.1", position=0)
     t_3.add_buffer_stop(label="bf.3", position=20_000)
 

--- a/tests/infra-scripts/tiny_infra.py
+++ b/tests/infra-scripts/tiny_infra.py
@@ -19,7 +19,7 @@ def _build_scenario_data():
 
     ne_micro_foo_a = builder.add_track_section(length=200, label="ne.micro.foo_a")
     ne_micro_foo_a.add_curve(0, 200, 2000)
-    station_foo.add_part(ne_micro_foo_a, 100)
+    station_foo.add_part(ne_micro_foo_a, 100, "V1")
     ne_micro_foo_a.add_buffer_stop(label="buffer_stop_a", position=0)
     ne_micro_foo_a.add_detector(label="tde.foo_a-switch_foo", position=175)
     signal = ne_micro_foo_a.add_signal(
@@ -33,7 +33,7 @@ def _build_scenario_data():
     ne_micro_foo_b = builder.add_track_section(length=200, label="ne.micro.foo_b")
     ne_micro_foo_b.add_slope(0, 200, 10)
     ne_micro_foo_b.add_curve(0, 200, 2000)
-    station_foo.add_part(ne_micro_foo_b, 100)
+    station_foo.add_part(ne_micro_foo_b, 100, "V2")
     ne_micro_foo_b.add_buffer_stop(label="buffer_stop_b", position=0)
     ne_micro_foo_b.add_detector(label="tde.foo_b-switch_foo", position=175)
     signal = ne_micro_foo_b.add_signal(
@@ -45,7 +45,7 @@ def _build_scenario_data():
     signal.add_logical_signal("BAL", settings={"Nf": "true"})
 
     ne_micro_bar_a = builder.add_track_section(length=200, label="ne.micro.bar_a")
-    station_bar.add_part(ne_micro_bar_a, 100)
+    station_bar.add_part(ne_micro_bar_a, 100, "V1")
     ne_micro_bar_a.add_buffer_stop(label="buffer_stop_c", position=200)
     ne_micro_bar_a.add_detector(label="tde.track-bar", position=25)
     signal = ne_micro_bar_a.add_signal(

--- a/tests/infra-scripts/y_infra.py
+++ b/tests/infra-scripts/y_infra.py
@@ -43,9 +43,9 @@ def _build_scenario_data() -> ScenarioData:
     t_center = builder.add_track_section(length=10_000, label="t_center")
 
     # Add objects on tracks
-    op_a.add_part(t_a, 0)
-    op_b.add_part(t_b, 0)
-    op_c.add_part(t_center, 10_000)
+    op_a.add_part(t_a, 0, "V1")
+    op_b.add_part(t_b, 0, "V1")
+    op_c.add_part(t_center, 10_000, "V1")
     t_a.add_buffer_stop(label="bf.a", position=0)
     t_b.add_buffer_stop(label="bf.b", position=0)
     t_center.add_buffer_stop(label="bf.c", position=10_000)

--- a/tests/uv.lock
+++ b/tests/uv.lock
@@ -182,7 +182,7 @@ wheels = [
 
 [[package]]
 name = "osrd-schemas"
-version = "0.10.1"
+version = "0.11.0"
 source = { editable = "../python/osrd_schemas" }
 dependencies = [
     { name = "geojson-pydantic" },
@@ -372,7 +372,7 @@ wheels = [
 
 [[package]]
 name = "railjson-generator"
-version = "0.4.13"
+version = "0.5.0"
 source = { editable = "../python/railjson_generator" }
 dependencies = [
     { name = "osrd-schemas" },


### PR DESCRIPTION
closes https://github.com/OpenRailAssociation/osrd/issues/14229

## Changes
  - Add database migration
  - Add `local_track_name` string field to `OperationalPointPart` schema
  - Update Rust schemas in editoast
  - Update OpenAPI specification and generated TypeScript client
  - Update Python schemas in `osrd_schemas` and `railjson_generator`
  - Update `RawInfraRJSParser` and `path_properties` core endpoint 