### PR TITLE
front: bump netzgrafik-frontend

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -18,7 +18,7 @@
         "@ag-media/react-pdf-table": "^2.0.3",
         "@nivo/core": "^0.99.0",
         "@nivo/line": "^0.99.0",
-        "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.45d96f2cefefad6c46839360632f3f45dbebbbd7",
+        "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.0f52186cbe7ecaa24d59d763f89a190f6f0de3de",
         "@osrd-project/ui-charts": "0.0.1-dev",
         "@osrd-project/ui-core": "0.0.1-dev",
         "@osrd-project/ui-icons": "0.0.1-dev",
@@ -3593,9 +3593,9 @@
       "link": true
     },
     "node_modules/@osrd-project/netzgrafik-frontend": {
-      "version": "0.0.0-snapshot.45d96f2cefefad6c46839360632f3f45dbebbbd7",
-      "resolved": "https://registry.npmjs.org/@osrd-project/netzgrafik-frontend/-/netzgrafik-frontend-0.0.0-snapshot.45d96f2cefefad6c46839360632f3f45dbebbbd7.tgz",
-      "integrity": "sha512-quG8+zG9oY+lUIAnEJ+p1GbC4kpC3jaXsJoP/G9GJQzbpL0e+ULDQVBp7+K8eFtAoT2207FkBYyos5+xgI2xMw=="
+      "version": "0.0.0-snapshot.0f52186cbe7ecaa24d59d763f89a190f6f0de3de",
+      "resolved": "https://registry.npmjs.org/@osrd-project/netzgrafik-frontend/-/netzgrafik-frontend-0.0.0-snapshot.0f52186cbe7ecaa24d59d763f89a190f6f0de3de.tgz",
+      "integrity": "sha512-GUL3fslDrMNaSVn87E/Q+A4Jr4lCCDroZ3YRfomeRefG6jNB6zUZi6vxQ3uF1aLDlzMXemokckrujBHmOIDSlg=="
     },
     "node_modules/@osrd-project/storybook": {
       "resolved": "ui/storybook",
@@ -13259,6 +13259,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/front/package.json
+++ b/front/package.json
@@ -14,7 +14,7 @@
     "@ag-media/react-pdf-table": "^2.0.3",
     "@nivo/core": "^0.99.0",
     "@nivo/line": "^0.99.0",
-    "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.45d96f2cefefad6c46839360632f3f45dbebbbd7",
+    "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.0f52186cbe7ecaa24d59d763f89a190f6f0de3de",
     "@osrd-project/ui-charts": "0.0.1-dev",
     "@osrd-project/ui-core": "0.0.1-dev",
     "@osrd-project/ui-icons": "0.0.1-dev",


### PR DESCRIPTION
##  Description 

Bump `@osrd-project/netzgrafik-frontend` to `0.0.0-snapshot.0f52186cbe7ecaa24d59d763f89a190f6f0de3de` to pick up the latest changes merged in NGE.

The extra diff in front/package-lock.json comes from npm install rewriting lockfile metadata (only peer flags and formatting).