### PR TITLE
editoast: create level_crossing_occupancy endpoint (skeleton)

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -1830,6 +1830,75 @@ paths:
             application/octet-stream:
               schema:
                 type: string
+  /level_crossing_occupancy:
+    post:
+      tags:
+      - level_crossing
+      summary: Get the occupancy of a set of level crossings for a set of trains
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - train_ids
+              - level_crossing_ids
+              - infra_id
+              properties:
+                electrical_profile_set_id:
+                  type:
+                  - integer
+                  - 'null'
+                  format: int64
+                infra_id:
+                  type: integer
+                  format: int64
+                level_crossing_ids:
+                  type: array
+                  items:
+                    type: integer
+                    format: int64
+                train_ids:
+                  type: array
+                  items:
+                    type: integer
+                    format: int64
+        required: true
+      responses:
+        '200':
+          description: Occupancy periods of the given level crossings
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: array
+                  items:
+                    allOf:
+                    - type: object
+                      required:
+                      - time_begin
+                      - duration
+                      properties:
+                        duration:
+                          type: string
+                          example: PT5M
+                        time_begin:
+                          type: string
+                          format: date-time
+                    - type: object
+                      required:
+                      - train_id
+                      - direction
+                      properties:
+                        direction:
+                          $ref: '#/components/schemas/Direction'
+                        train_id:
+                          type: integer
+                          format: int64
+                propertyNames:
+                  type: integer
+                  format: int64
   /light_rolling_stock:
     get:
       tags:

--- a/editoast/schemas/src/primitives.rs
+++ b/editoast/schemas/src/primitives.rs
@@ -4,6 +4,7 @@ mod identifier;
 mod non_blank_string;
 mod object_ref;
 mod object_type;
+mod time_window;
 
 pub use bounding_box::BoundingBox;
 pub use duration::PositiveDuration;
@@ -11,6 +12,7 @@ pub use identifier::Identifier;
 pub use non_blank_string::NonBlankString;
 pub use object_ref::ObjectRef;
 pub use object_type::ObjectType;
+pub use time_window::TimeWindow;
 
 /// This trait should be implemented by all struct that represents an OSRD type.
 pub trait OSRDTyped {

--- a/editoast/schemas/src/primitives/time_window.rs
+++ b/editoast/schemas/src/primitives/time_window.rs
@@ -1,0 +1,13 @@
+use super::PositiveDuration;
+use chrono::DateTime;
+use chrono::Utc;
+use serde::Deserialize;
+use serde::Serialize;
+use utoipa::ToSchema;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
+pub struct TimeWindow {
+    pub time_begin: DateTime<Utc>,
+    #[schema(value_type = chrono::Duration, example = "PT5M")]
+    pub duration: PositiveDuration,
+}

--- a/editoast/src/views/level_crossing_occupancy.rs
+++ b/editoast/src/views/level_crossing_occupancy.rs
@@ -1,0 +1,78 @@
+use crate::AppState;
+use crate::error::Result;
+use crate::views::AuthenticationExt;
+use crate::views::AuthorizationError;
+
+use axum::Extension;
+use axum::extract::Json;
+use axum::extract::State;
+use schemas::infra::Direction;
+use schemas::primitives::TimeWindow;
+use serde::Deserialize;
+use serde::Serialize;
+use std::collections::HashMap;
+use utoipa::ToSchema;
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, ToSchema)]
+pub(in crate::views) struct LevelCrossingOccupancyForm {
+    train_ids: Vec<i64>,
+    level_crossing_ids: Vec<i64>,
+    infra_id: i64,
+    electrical_profile_set_id: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub(in crate::views) struct LevelCrossingOccupancy {
+    //TODO : Replace train_id with occurence_id after merging train schedule and paced train
+    train_id: i64,
+    #[serde(flatten)]
+    #[schema(inline)]
+    time_window: TimeWindow,
+    direction: Direction,
+}
+
+/// Get the occupancy of a set of level crossings for a set of trains
+#[editoast_derive::route]
+#[utoipa::path(
+    post, path = "",
+    tag = "level_crossing",
+    request_body = inline(LevelCrossingOccupancyForm),
+    responses(
+        (status = 200, description = "Occupancy periods of the given level crossings", body = inline(HashMap<i64, Vec<LevelCrossingOccupancy>>)),
+    ),
+)]
+pub(in crate::views) async fn occupancy(
+    State(AppState {
+        config: _,
+        db_pool: _,
+        valkey_client: _,
+        core_client: _,
+        ..
+    }): State<AppState>,
+    Extension(auth): AuthenticationExt,
+    Json(LevelCrossingOccupancyForm {
+        train_ids: _,
+        level_crossing_ids: _,
+        infra_id,
+        electrical_profile_set_id: _,
+    }): Json<LevelCrossingOccupancyForm>,
+) -> Result<Json<HashMap<i64, Vec<LevelCrossingOccupancy>>>> {
+    let authorized = auth
+        .check_roles([authz::Role::OperationalStudies].into())
+        .await
+        .map_err(AuthorizationError::AuthError)?;
+    if !authorized {
+        return Err(AuthorizationError::Forbidden.into());
+    }
+
+    auth.check_authorization(async |authorizer| {
+        authorizer
+            .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanRead)
+            .await
+    })
+    .await?;
+
+    //TODO: implement real logic
+
+    Ok(Json(HashMap::new()))
+}

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -5,6 +5,7 @@ pub mod electrical_profiles;
 pub mod fonts;
 pub mod infra;
 mod layers;
+mod level_crossing_occupancy;
 mod openapi;
 pub mod operational_studies;
 pub mod pagination;
@@ -477,6 +478,13 @@ fn service_router() -> router::DocumentedRouter {
                             .route("/", delete!(catalogue_entry::delete))
                     })
             })
+            //
+            // level_crossings
+            //
+            .route(
+                "/level_crossing_occupancy",
+                post!(level_crossing_occupancy::occupancy),
+            )
     })
 }
 

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -18,6 +18,7 @@ use editoast_derive::EditoastError;
 use editoast_models::prelude::*;
 use itertools::Itertools;
 use schemas::paced_train::PacedTrain;
+use schemas::primitives::TimeWindow;
 use schemas::train_schedule::OperationalPointReference;
 use schemas::train_schedule::PathItemLocation;
 use serde::Deserialize;
@@ -1151,7 +1152,7 @@ pub(in crate::views) struct TrackOccupancy {
     occurrence_id: OccurrenceId,
     #[serde(flatten)]
     #[schema(inline)]
-    time_window: track_occupancy::TimeWindow,
+    time_window: TimeWindow,
 }
 
 #[editoast_derive::route]

--- a/editoast/src/views/timetable/track_occupancy.rs
+++ b/editoast/src/views/timetable/track_occupancy.rs
@@ -1,16 +1,11 @@
-use chrono::DateTime;
 use chrono::Duration;
-use chrono::Utc;
 use core_client::pathfinding::PathfindingResultSuccess;
 use core_client::simulation::CompleteReportTrain;
 use schemas::infra::TrackOffset;
-use schemas::primitives::PositiveDuration;
+use schemas::primitives::TimeWindow;
 use schemas::train_schedule::PathItem;
 use schemas::train_schedule::PathItemLocation;
 use schemas::train_schedule::ScheduleItem;
-use serde::Deserialize;
-use serde::Serialize;
-use utoipa::ToSchema;
 
 use crate::views::path::path_item_cache::PathItemCache;
 use crate::views::path::pathfinding::PathfindingResult;
@@ -19,13 +14,6 @@ use crate::views::projection::find_index_upper;
 use crate::views::projection::linear_interpolate;
 use crate::views::timetable::simulation;
 use crate::views::timetable::simulation::SimulationResponseSuccess;
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
-pub(super) struct TimeWindow {
-    pub(super) time_begin: DateTime<Utc>,
-    #[schema(value_type = chrono::Duration, example = "PT5M")]
-    pub(super) duration: PositiveDuration,
-}
 
 #[derive(Debug, Clone)]
 pub(super) struct TrackOccupancy {
@@ -228,6 +216,7 @@ pub fn find_track_occupancy_for_operational_point(
 pub mod tests {
     use crate::error::InternalError;
     use crate::views::path::pathfinding::PathfindingFailure;
+    use chrono::DateTime;
     use core_client::pathfinding::PathfindingNotFound;
     use core_client::pathfinding::TrackRange;
     use core_client::simulation::ReportTrain;
@@ -237,6 +226,7 @@ pub mod tests {
     use schemas::infra::Direction;
     use schemas::infra::TrackOffset;
     use schemas::primitives::Identifier;
+    use schemas::primitives::PositiveDuration;
     use schemas::train_schedule::OperationalPointIdentifier;
     use schemas::train_schedule::OperationalPointReference;
     use schemas::train_schedule::ReceptionSignal;

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -17,6 +17,7 @@ use database::DbConnectionPoolV2;
 use editoast_derive::EditoastError;
 use editoast_models::prelude::*;
 use editoast_models::train_schedule::TrainScheduleChangeset;
+use schemas::primitives::TimeWindow;
 use schemas::train_schedule::OperationalPointReference;
 use schemas::train_schedule::PathItemLocation;
 use schemas::train_schedule::TrainSchedule;
@@ -884,7 +885,7 @@ pub(in crate::views) struct TrackOccupancy {
     train_schedule_id: i64,
     #[serde(flatten)]
     #[schema(inline)]
-    time_window: track_occupancy::TimeWindow,
+    time_window: TimeWindow,
 }
 
 /// Calculates when and for how long trains occupy track sections at a specific operational point.

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -11,6 +11,7 @@ export const addTagTypes = [
   'pathfinding',
   'routes',
   'layers',
+  'level_crossing',
   'scenarios',
   'timetable',
   'paced_train',
@@ -515,6 +516,17 @@ const injectedRtkApi = api
           },
         }),
         providesTags: ['layers'],
+      }),
+      postLevelCrossingOccupancy: build.mutation<
+        PostLevelCrossingOccupancyApiResponse,
+        PostLevelCrossingOccupancyApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/level_crossing_occupancy`,
+          method: 'POST',
+          body: queryArg.body,
+        }),
+        invalidatesTags: ['level_crossing'],
       }),
       getLightRollingStock: build.query<
         GetLightRollingStockApiResponse,
@@ -2001,6 +2013,24 @@ export type GetLayersTileByLayerSlugAndViewSlugZXYApiArg = {
   x: number;
   y: number;
   z: number;
+};
+export type PostLevelCrossingOccupancyApiResponse =
+  /** status 200 Occupancy periods of the given level crossings */ {
+    [key: string]: ({
+      duration: string;
+      time_begin: string;
+    } & {
+      direction: Direction;
+      train_id: number;
+    })[];
+  };
+export type PostLevelCrossingOccupancyApiArg = {
+  body: {
+    electrical_profile_set_id?: number | null;
+    infra_id: number;
+    level_crossing_ids: number[];
+    train_ids: number[];
+  };
 };
 export type GetLightRollingStockApiResponse = /** status 200  */ PaginationStats & {
   results: LightRollingStockWithLiveries[];


### PR DESCRIPTION
Introduces the skeleton of the new endpoint `/level_crossing_occupancy/` : 

- Move TimeWindow from `track_occupancy` to `schemas/src/primitives` to be reused for `level_crossing_occupancy`
- Create  `/level_crossing_occupancy/` skeleton