### PR TITLE
editoast: make the Error in the Result have only error variants

### DIFF
--- a/editoast/src/views/path/path_item_cache.rs
+++ b/editoast/src/views/path/path_item_cache.rs
@@ -15,9 +15,8 @@ use crate::models::TrackSectionModel;
 use editoast_models::prelude::*;
 
 use super::pathfinding::PathfindingFailure;
-use super::pathfinding::PathfindingResult;
 
-type TrackOffsetResult = std::result::Result<Vec<Vec<TrackOffset>>, PathfindingResult>;
+type TrackOffsetResult = std::result::Result<Vec<Vec<TrackOffset>>, PathfindingFailure>;
 
 /// Gather information about several path items, factorizing db calls.
 #[derive(Default, Debug)]
@@ -284,12 +283,10 @@ impl PathItemCache {
         }
 
         if !invalid_path_items.is_empty() {
-            return Err(PathfindingResult::Failure(
-                PathfindingFailure::PathfindingInputError(
-                    PathfindingInputError::InvalidPathItems {
-                        items: invalid_path_items,
-                    },
-                ),
+            return Err(PathfindingFailure::PathfindingInputError(
+                PathfindingInputError::InvalidPathItems {
+                    items: invalid_path_items,
+                },
             ));
         }
 

--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -399,7 +399,9 @@ fn build_pathfinding_request(
             PathfindingFailure::PathfindingInputError(PathfindingInputError::NotEnoughPathItems),
         ));
     }
-    let track_offsets = path_item_cache.extract_location_from_path_items(&path_items)?;
+    let track_offsets = path_item_cache
+        .extract_location_from_path_items(&path_items)
+        .map_err(PathfindingResult::Failure)?;
 
     // Create the pathfinding request
     Ok(PathfindingRequest {

--- a/editoast/src/views/timetable/stdcm/request.rs
+++ b/editoast/src/views/timetable/stdcm/request.rs
@@ -25,7 +25,6 @@ use utoipa::ToSchema;
 use crate::error::Result;
 use crate::views::path::path_item_cache::PathItemCache;
 use crate::views::path::pathfinding::PathfindingFailure;
-use crate::views::path::pathfinding::PathfindingResult;
 use editoast_models::TemporarySpeedLimit;
 use editoast_models::TowedRollingStock;
 use editoast_models::WorkSchedule;
@@ -244,9 +243,9 @@ impl Request {
         let track_offsets = path_item_cache
             .extract_location_from_path_items(&locations)
             .map_err(|path_res| match path_res {
-                PathfindingResult::Failure(PathfindingFailure::PathfindingInputError(
+                PathfindingFailure::PathfindingInputError(
                     PathfindingInputError::InvalidPathItems { items },
-                )) => StdcmError::InvalidPathItems { items },
+                ) => StdcmError::InvalidPathItems { items },
                 _ => panic!("Unexpected pathfinding result"),
             })?;
 


### PR DESCRIPTION
The `TrackOffsetResult` is an alias type of a complex `Result`. The `Error` in this `Result` was `PathfindingResult` which is actually an `enum` that can store some successful values. We actually only want to return the error of this `enum` which is `Pathfinding::Failure`. So this patch propose to change the API to use the sub-type directly.