### PR TITLE
editoast: implement `/level_crossing_occupancy` endpoint logic

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -1850,6 +1850,58 @@ paths:
                   type: array
                   items:
                     allOf:
+                    - oneOf:
+                      - type: object
+                        required:
+                        - id
+                        - index
+                        - type
+                        properties:
+                          id:
+                            type: integer
+                            format: int64
+                          index:
+                            type: integer
+                            minimum: 0
+                          type:
+                            type: string
+                            enum:
+                            - base
+                      - type: object
+                        required:
+                        - id
+                        - index
+                        - exception_key
+                        - type
+                        properties:
+                          exception_key:
+                            type: string
+                          id:
+                            type: integer
+                            format: int64
+                          index:
+                            type: integer
+                            minimum: 0
+                          type:
+                            type: string
+                            enum:
+                            - modified
+                      - type: object
+                        required:
+                        - id
+                        - exception_key
+                        - type
+                        properties:
+                          exception_key:
+                            type: string
+                          id:
+                            type: integer
+                            format: int64
+                          type:
+                            type: string
+                            enum:
+                            - created
+                      description: This ID is used to identify paced train occurrences and exceptions when sending them to the core API for conflict detection.
                     - type: object
                       required:
                       - time_begin
@@ -1863,14 +1915,10 @@ paths:
                           format: date-time
                     - type: object
                       required:
-                      - train_id
                       - direction
                       properties:
                         direction:
                           $ref: '#/components/schemas/Direction'
-                        train_id:
-                          type: integer
-                          format: int64
                 propertyNames:
                   type: integer
                   format: int64
@@ -6470,6 +6518,10 @@ components:
       - $ref: '#/components/schemas/EditoastInfraCacheEditoastErrorObjectNotFound'
       - $ref: '#/components/schemas/EditoastLayersErrorLayerNotFound'
       - $ref: '#/components/schemas/EditoastLayersErrorViewNotFound'
+      - $ref: '#/components/schemas/EditoastLevelCrossingErrorDatabase'
+      - $ref: '#/components/schemas/EditoastLevelCrossingErrorInfraNotFound'
+      - $ref: '#/components/schemas/EditoastLevelCrossingErrorLevelCrossingBatchNotFound'
+      - $ref: '#/components/schemas/EditoastLevelCrossingErrorTrainBatchNotFound'
       - $ref: '#/components/schemas/EditoastLinesErrorsLineNotFound'
       - $ref: '#/components/schemas/EditoastListErrorsErrorsWrongErrorTypeProvided'
       - $ref: '#/components/schemas/EditoastMacroNodeErrorDatabase'
@@ -6794,6 +6846,97 @@ components:
           type: string
           enum:
           - editoast:layers:ViewNotFound
+    EditoastLevelCrossingErrorDatabase:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 500
+        type:
+          type: string
+          enum:
+          - editoast:level_crossing:Database
+    EditoastLevelCrossingErrorInfraNotFound:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+          required:
+          - infra_id
+          properties:
+            infra_id:
+              type: integer
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 404
+        type:
+          type: string
+          enum:
+          - editoast:level_crossing:InfraNotFound
+    EditoastLevelCrossingErrorLevelCrossingBatchNotFound:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+          required:
+          - count
+          properties:
+            count:
+              type: integer
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 404
+        type:
+          type: string
+          enum:
+          - editoast:level_crossing:LevelCrossingBatchNotFound
+    EditoastLevelCrossingErrorTrainBatchNotFound:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+          required:
+          - count
+          properties:
+            count:
+              type: integer
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 404
+        type:
+          type: string
+          enum:
+          - editoast:level_crossing:TrainBatchNotFound
     EditoastLinesErrorsLineNotFound:
       type: object
       required:

--- a/editoast/schemas/src/infra/level_crossing.rs
+++ b/editoast/schemas/src/infra/level_crossing.rs
@@ -3,6 +3,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
 
+use super::TrackOffset;
 use crate::primitives::Identifier;
 use crate::primitives::OSRDIdentified;
 use crate::primitives::OSRDTyped;
@@ -42,5 +43,18 @@ impl OSRDTyped for LevelCrossing {
 impl OSRDIdentified for LevelCrossing {
     fn get_id(&self) -> &String {
         &self.id
+    }
+}
+
+impl LevelCrossing {
+    pub fn track_offset(&self) -> Vec<TrackOffset> {
+        self.parts
+            .clone()
+            .into_iter()
+            .map(|lcp| TrackOffset {
+                track: lcp.track,
+                offset: (lcp.position * 1000.0) as u64,
+            })
+            .collect()
     }
 }

--- a/editoast/src/views/level_crossing_occupancy.rs
+++ b/editoast/src/views/level_crossing_occupancy.rs
@@ -1,17 +1,59 @@
 use crate::AppState;
 use crate::error::Result;
+use crate::models::Infra;
+use crate::models::LevelCrossingModel;
+use crate::models::PacedTrain;
+use crate::models::paced_train::OccurrenceId;
 use crate::views::AuthenticationExt;
 use crate::views::AuthorizationError;
+use crate::views::path::pathfinding::PathfindingResult;
+use crate::views::path::projection::PathProjection;
+use crate::views::projection::interpolate_arrival_time;
+use crate::views::rolling_stock::RollingStockError;
+use crate::views::timetable::simulation;
+use crate::views::timetable::simulation::SimulationResponseSuccess;
+use crate::views::timetable::simulation::train_simulation_batch;
 
 use axum::Extension;
 use axum::extract::Json;
 use axum::extract::State;
+use chrono::DateTime;
+use chrono::Duration;
+use chrono::Utc;
+use core_client::pathfinding::TrackRange;
+use core_client::simulation::CompleteReportTrain;
+use database::DbConnection;
+use editoast_derive::EditoastError;
+use editoast_models::prelude::*;
+use editoast_models::rolling_stock::RollingStock;
+use itertools::Itertools;
+use schemas::TrainSchedule;
 use schemas::infra::Direction;
+use schemas::infra::LevelCrossing;
+use schemas::infra::TrackOffset;
 use schemas::primitives::TimeWindow;
 use serde::Deserialize;
 use serde::Serialize;
 use std::collections::HashMap;
+use thiserror::Error;
 use utoipa::ToSchema;
+
+#[derive(Debug, Error, EditoastError)]
+#[editoast_error(base_id = "level_crossing")]
+enum LevelCrossingError {
+    #[error("{count} level crossing(s) could not be found")]
+    #[editoast_error(status = 404)]
+    LevelCrossingBatchNotFound { count: usize },
+    #[error("{count} train(s) could not be found")]
+    #[editoast_error(status = 404)]
+    TrainBatchNotFound { count: usize },
+    #[error("Infra '{infra_id}', could not be found")]
+    #[editoast_error(status = 404)]
+    InfraNotFound { infra_id: i64 },
+    #[error(transparent)]
+    #[editoast_error(status = 500)]
+    Database(#[from] editoast_models::Error),
+}
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, ToSchema)]
 pub(in crate::views) struct LevelCrossingOccupancyForm {
@@ -23,8 +65,9 @@ pub(in crate::views) struct LevelCrossingOccupancyForm {
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub(in crate::views) struct LevelCrossingOccupancy {
-    //TODO : Replace train_id with occurence_id after merging train schedule and paced train
-    train_id: i64,
+    #[serde(flatten)]
+    #[schema(inline)]
+    occurrence_id: OccurrenceId,
     #[serde(flatten)]
     #[schema(inline)]
     time_window: TimeWindow,
@@ -43,18 +86,18 @@ pub(in crate::views) struct LevelCrossingOccupancy {
 )]
 pub(in crate::views) async fn occupancy(
     State(AppState {
-        config: _,
-        db_pool: _,
-        valkey_client: _,
-        core_client: _,
+        config,
+        db_pool,
+        valkey_client,
+        core_client,
         ..
     }): State<AppState>,
     Extension(auth): AuthenticationExt,
     Json(LevelCrossingOccupancyForm {
-        train_ids: _,
-        level_crossing_ids: _,
+        train_ids,
+        level_crossing_ids,
         infra_id,
-        electrical_profile_set_id: _,
+        electrical_profile_set_id,
     }): Json<LevelCrossingOccupancyForm>,
 ) -> Result<Json<HashMap<i64, Vec<LevelCrossingOccupancy>>>> {
     let authorized = auth
@@ -72,7 +115,491 @@ pub(in crate::views) async fn occupancy(
     })
     .await?;
 
-    //TODO: implement real logic
+    let conn = &mut db_pool.get().await?;
 
-    Ok(Json(HashMap::new()))
+    // Load infra + level_crossings + trains
+    let infra = Infra::retrieve_or_fail(conn.clone(), infra_id, || {
+        LevelCrossingError::InfraNotFound { infra_id }
+    })
+    .await?;
+
+    let level_crossings: Vec<LevelCrossingModel> =
+        LevelCrossingModel::retrieve_batch_or_fail(conn, level_crossing_ids, |missing| {
+            LevelCrossingError::LevelCrossingBatchNotFound {
+                count: missing.len(),
+            }
+        })
+        .await?;
+
+    let trains: Vec<PacedTrain> = PacedTrain::retrieve_batch_or_fail(conn, train_ids, |missing| {
+        LevelCrossingError::TrainBatchNotFound {
+            count: missing.len(),
+        }
+    })
+    .await?;
+
+    // Collect all occurrences from all trains
+    let train_occurrences = trains
+        .iter()
+        .flat_map(|train| train.iter_occurrences())
+        .collect_vec();
+
+    // Extract train schedules for simulation
+    let train_schedules = train_occurrences
+        .iter()
+        .map(|(_, train_schedule)| train_schedule.clone())
+        .collect_vec();
+
+    let simulations_result = train_simulation_batch(
+        conn,
+        valkey_client,
+        core_client,
+        &train_schedules,
+        &infra,
+        electrical_profile_set_id,
+        config.app_version.as_deref(),
+    )
+    .await?;
+
+    let rolling_stock_lengths = load_rolling_stock_lengths(&train_schedules, conn).await?;
+
+    // For each occurrence + simulation result, compute level crossing occupancy and group by level crossing id
+    let mut results: HashMap<i64, Vec<LevelCrossingOccupancy>> = HashMap::new();
+
+    for ((occurrence_id, train_schedule), (simulation, pathfinding)) in
+        train_occurrences.into_iter().zip(simulations_result)
+    {
+        let Some(rolling_stock_length) =
+            rolling_stock_lengths.get(&train_schedule.rolling_stock_name)
+        else {
+            continue;
+        };
+
+        for level_crossing in &level_crossings {
+            if let Some(occupancy) = find_level_crossing_occupancy(
+                &level_crossing.schema,
+                &occurrence_id,
+                &simulation,
+                &pathfinding,
+                train_schedule.start_time,
+                rolling_stock_length,
+            ) {
+                results
+                    .entry(level_crossing.id)
+                    .or_default()
+                    .push(occupancy);
+            }
+        }
+    }
+
+    Ok(Json(results))
+}
+
+async fn load_rolling_stock_lengths(
+    train_schedules: &[TrainSchedule],
+    conn: &mut DbConnection,
+) -> Result<HashMap<String, u64>> {
+    let rolling_stocks_names = train_schedules.iter().map(|t| t.rolling_stock_name.clone());
+
+    let rolling_stocks: Vec<_> = RollingStock::retrieve_batch_unchecked(conn, rolling_stocks_names)
+        .await
+        .map_err(RollingStockError::from)?;
+
+    Ok(rolling_stocks
+        .into_iter()
+        .map(|rs| {
+            (
+                rs.name.clone(),
+                common::units::millimeter::from(rs.length) as u64,
+            )
+        })
+        .collect())
+}
+
+fn find_level_crossing_occupancy(
+    level_crossing: &LevelCrossing,
+    occurrence_id: &OccurrenceId,
+    simulation: &simulation::Response,
+    pathfinding: &PathfindingResult,
+    start_time: DateTime<Utc>,
+    rolling_stock_length: &u64,
+) -> Option<LevelCrossingOccupancy> {
+    // Check simulation results
+    let (final_output, pathfinding_success) = match (simulation, pathfinding) {
+        (
+            simulation::Response::Success(SimulationResponseSuccess { final_output, .. }),
+            PathfindingResult::Success(pathfinding_success),
+        ) => (final_output, pathfinding_success),
+        _ => return None,
+    };
+
+    // Search for an intersection with the level crossing
+    let (lc_position, matched_track_offset) = find_level_crossing_intersection(
+        level_crossing,
+        &pathfinding_success.path.track_section_ranges,
+    )?;
+
+    // Get the direction of the train on the track section
+    let direction = pathfinding_success
+        .path
+        .track_section_ranges
+        .iter()
+        .find_map(|tr| (tr.track_section == matched_track_offset.track).then_some(tr.direction))
+        .expect("Track range should exist since position was found");
+
+    // Compute the occupancy time window
+    let time_window = find_occupancy_time_window(
+        &direction,
+        final_output,
+        level_crossing,
+        &lc_position,
+        &matched_track_offset,
+        start_time,
+        rolling_stock_length,
+    )?;
+
+    Some(LevelCrossingOccupancy {
+        occurrence_id: occurrence_id.clone(),
+        time_window,
+        direction,
+    })
+}
+
+fn find_level_crossing_intersection(
+    level_crossing: &LevelCrossing,
+    track_section_ranges: &Vec<TrackRange>,
+) -> Option<(u64, TrackOffset)> {
+    let lc_track_offsets = level_crossing.track_offset();
+
+    let path_projection = PathProjection::new(track_section_ranges);
+
+    lc_track_offsets.iter().find_map(|track_offset| {
+        path_projection
+            .get_position(track_offset)
+            .map(|position| (position, track_offset.clone()))
+    })
+}
+
+fn find_occupancy_time_window(
+    direction: &Direction,
+    final_output: &CompleteReportTrain,
+    level_crossing: &LevelCrossing,
+    lc_position: &u64,
+    matched_track_offset: &TrackOffset,
+    start_time: DateTime<Utc>,
+    rolling_stock_length: &u64,
+) -> Option<TimeWindow> {
+    let pedal_position =
+        find_pedal_position(direction, lc_position, level_crossing, matched_track_offset)?;
+
+    // Compute arrival and leaving times
+    let lc_end_position = lc_position + level_crossing.short_zone_length + rolling_stock_length;
+    let last_train_position = *final_output.report_train.positions.last()?;
+
+    // Check whether the train completely leaves the short zone; ignore it otherwise.
+    if lc_end_position > last_train_position {
+        return None;
+    }
+
+    let arrival_time = interpolate_arrival_time(pedal_position, final_output);
+    let leaving_time = interpolate_arrival_time(lc_end_position, final_output);
+
+    Some(TimeWindow {
+        time_begin: start_time + Duration::milliseconds(arrival_time),
+        duration: Duration::milliseconds(leaving_time - arrival_time)
+            .try_into()
+            .expect("leaving_time should be greater than arrival_time"),
+    })
+}
+
+fn find_pedal_position(
+    direction: &Direction,
+    lc_position: &u64,
+    level_crossing: &LevelCrossing,
+    matched_track_offset: &TrackOffset,
+) -> Option<u64> {
+    let lc_part = level_crossing
+        .parts
+        .iter()
+        .find(|part| part.track == matched_track_offset.track)
+        .expect("Part should exist since position was found");
+
+    let pedal_offset = match direction {
+        Direction::StartToStop => lc_part.pedal_upstream,
+        Direction::StopToStart => lc_part.pedal_downstream,
+    };
+    lc_position.checked_sub(pedal_offset)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::fixtures::create_fast_rolling_stock;
+    use crate::models::fixtures::create_small_infra;
+    use crate::models::fixtures::create_timetable;
+    use crate::views::test_app::TestAppBuilder;
+    use crate::views::test_app::TestResponse;
+    use chrono::TimeDelta;
+    use core_client::mocking::MockingClient;
+    use core_client::pathfinding::PathfindingResultSuccess;
+    use core_client::pathfinding::TrainPath;
+    use reqwest::StatusCode;
+    use schemas::infra::LevelCrossingPart;
+    use schemas::train_schedule::PathItem;
+
+    #[test]
+    fn test_find_level_crossing_intersection_found() {
+        let level_crossing = LevelCrossing {
+            id: "LC1".into(),
+            name: "Test LC".to_string(),
+            short_zone_length: 50000,
+            parts: vec![schemas::infra::LevelCrossingPart {
+                track: "TC1".into(),
+                position: 750.0,
+                pedal_upstream: 500000,
+                pedal_downstream: 1000000,
+            }],
+        };
+
+        let track_ranges = vec![core_client::pathfinding::TrackRange {
+            track_section: "TC1".into(),
+            begin: 50000,
+            end: 1000000,
+            direction: Direction::StartToStop,
+        }];
+
+        let result = find_level_crossing_intersection(&level_crossing, &track_ranges);
+
+        assert!(result.is_some());
+
+        let (position, track_offset) = result.unwrap();
+        assert_eq!(position, 700000);
+        assert_eq!(track_offset.track.0, "TC1");
+        assert_eq!(track_offset.offset, 750000);
+    }
+
+    #[test]
+    fn test_find_level_crossing_intersection_not_found() {
+        let level_crossing = LevelCrossing {
+            id: "LC1".into(),
+            name: "Test LC".to_string(),
+            short_zone_length: 50000,
+            parts: vec![schemas::infra::LevelCrossingPart {
+                track: "TC1".into(),
+                position: 750.0,
+                pedal_upstream: 500000,
+                pedal_downstream: 1000000,
+            }],
+        };
+
+        // Train path doesn't include TC1
+        let track_ranges = vec![core_client::pathfinding::TrackRange {
+            track_section: "TC1".into(),
+            begin: 800000,
+            end: 1000000,
+            direction: Direction::StartToStop,
+        }];
+
+        let result = find_level_crossing_intersection(&level_crossing, &track_ranges);
+        assert!(result.is_none());
+    }
+
+    fn pathfinding_result_success() -> PathfindingResultSuccess {
+        PathfindingResultSuccess {
+            path: TrainPath {
+                blocks: vec![],
+                routes: vec![],
+                track_section_ranges: vec![
+                    TrackRange::new("TC1", 550000, 1000000, Direction::StartToStop), // Mid_West_station
+                    TrackRange::new("TD0", 0, 14000000, Direction::StartToStop), // Mid_East_station
+                ],
+            },
+            length: 14450000,
+            path_item_positions: vec![0, 14450000],
+        }
+    }
+
+    fn simulation_with_realistic_positions() -> simulation::Response {
+        use crate::views::timetable::simulation::SimulationResponseSuccess;
+        use core_client::simulation::CompleteReportTrain;
+        use core_client::simulation::ElectricalProfiles;
+        use core_client::simulation::ReportTrain;
+        use core_client::simulation::SpeedLimitProperties;
+
+        // Create realistic positions covering the entire path (0 to 14450000mm)
+        let mut positions = vec![];
+        let mut times = vec![];
+        let mut speeds = vec![];
+
+        let total_length = 14450000;
+        let step = 100000;
+        let time_step = 10;
+
+        let mut pos = 0;
+        let mut time = 0;
+        while pos <= total_length {
+            positions.push(pos);
+            times.push(time);
+            speeds.push(25.0);
+            pos += step;
+            time += time_step;
+        }
+
+        simulation::Response::Success(SimulationResponseSuccess {
+            base: ReportTrain {
+                positions: vec![],
+                times: vec![],
+                speeds: vec![],
+                energy_consumption: 0.0,
+                path_item_times: vec![],
+            },
+            provisional: ReportTrain {
+                positions: vec![],
+                times: vec![],
+                speeds: vec![],
+                energy_consumption: 0.0,
+                path_item_times: vec![],
+            },
+            final_output: CompleteReportTrain {
+                report_train: ReportTrain {
+                    positions,
+                    times,
+                    speeds,
+                    energy_consumption: 100.0,
+                    path_item_times: vec![0, 1450],
+                },
+                signal_critical_positions: vec![],
+                zone_updates: vec![],
+                spacing_requirements: vec![],
+                routing_requirements: vec![],
+            },
+            mrsp: SpeedLimitProperties {
+                boundaries: vec![],
+                values: vec![],
+            },
+            electrical_profiles: ElectricalProfiles {
+                boundaries: vec![],
+                values: vec![],
+            },
+        })
+    }
+
+    async fn init_level_crossing_test(
+        lc_position: f64,
+        lc_id: &str,
+        track: &str,
+    ) -> (TestResponse, i64, PacedTrain) {
+        let mut core = MockingClient::new();
+        core.stub("/pathfinding/blocks")
+            .response(StatusCode::OK)
+            .json(PathfindingResult::Success(pathfinding_result_success()))
+            .finish();
+        core.stub("/standalone_simulation")
+            .response(StatusCode::OK)
+            .json(simulation_with_realistic_positions())
+            .finish();
+
+        create_and_fetch_occupancy(core, lc_id, track, lc_position).await
+    }
+
+    async fn create_and_fetch_occupancy(
+        core: MockingClient,
+        lc_id: &str,
+        track: &str,
+        lc_position: f64,
+    ) -> (TestResponse, i64, PacedTrain) {
+        let app = TestAppBuilder::new().core_client(core.into()).build();
+        let db_pool = app.db_pool();
+        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "simulation_rolling_stock").await;
+        let timetable = create_timetable(&mut db_pool.get_ok()).await;
+
+        // Create level crossing
+        let level_crossing = LevelCrossingModel::default()
+            .into_changeset()
+            .obj_id(lc_id.to_string())
+            .infra_id(small_infra.id)
+            .schema(LevelCrossing {
+                id: lc_id.into(),
+                name: lc_id.into(),
+                short_zone_length: 50000,
+                parts: vec![LevelCrossingPart {
+                    track: track.into(),
+                    position: lc_position,
+                    pedal_upstream: 100000,
+                    pedal_downstream: 50000,
+                }],
+            })
+            .create(&mut db_pool.get_ok())
+            .await
+            .expect("Failed to create level crossing");
+
+        let train = crate::models::PacedTrain::default()
+            .into_changeset()
+            .timetable_id(timetable.id)
+            .rolling_stock_name(rolling_stock.name)
+            .path(vec![
+                PathItem::new_operational_point("Mid_West_station"),
+                PathItem::new_operational_point("Mid_East_station"),
+            ])
+            .interval(Some(TimeDelta::minutes(15)))
+            .time_window(Some(TimeDelta::hours(1)))
+            .create(&mut db_pool.get_ok())
+            .await
+            .expect("Failed to create train");
+
+        let request = app
+            .post("/level_crossing_occupancy")
+            .json(&LevelCrossingOccupancyForm {
+                train_ids: vec![train.id],
+                level_crossing_ids: vec![level_crossing.id],
+                infra_id: small_infra.id,
+                electrical_profile_set_id: None,
+            });
+
+        (app.fetch(request).await, level_crossing.id, train)
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn test_level_crossing_occupancy_endpoint() {
+        // Level crossing at 750m on TC1 (on train path)
+        let (response, level_crossing_id, train) =
+            init_level_crossing_test(750.0, "LC_TC1", "TC1").await;
+
+        let occupancies: HashMap<i64, Vec<LevelCrossingOccupancy>> =
+            response.assert_status(StatusCode::OK).json_into();
+
+        assert!(occupancies.contains_key(&level_crossing_id));
+        let lc_occupancies = occupancies.get(&level_crossing_id).unwrap();
+        assert_eq!(lc_occupancies.len(), 4);
+
+        // Expected values:
+        // - LC position on path: 750000mm - 550000mm (TC1 begin) = 200000mm
+        // - Pedal position: 200000mm - 100000mm (pedal_upstream) = 100000mm
+        // - At 100000mm in mock : time = 10ms
+        // - LC end: 200000 + 50000 (short_zone) + 400000 (rolling_stock length) = 650000mm
+        // - At 650000mm in mock: time = 65ms
+        // - Duration: 65ms - 10ms = 55ms
+
+        let occupancy = &lc_occupancies[0];
+        assert_eq!(occupancy.direction, Direction::StartToStop);
+        assert_eq!(
+            occupancy.time_window.time_begin,
+            train.start_time + Duration::milliseconds(10)
+        );
+        assert_eq!(occupancy.time_window.duration.num_milliseconds(), 55);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn test_level_crossing_occupancy_returns_empty() {
+        // Level crossing at 750m on TX1 (not on train path)
+        let (response, level_crossing_id, ..) =
+            init_level_crossing_test(750.0, "LC_TX1", "TX1").await;
+
+        let occupancies: HashMap<i64, Vec<LevelCrossingOccupancy>> =
+            response.assert_status(StatusCode::OK).json_into();
+
+        assert!(!occupancies.contains_key(&level_crossing_id));
+    }
 }

--- a/editoast/src/views/projection.rs
+++ b/editoast/src/views/projection.rs
@@ -324,6 +324,26 @@ pub fn linear_interpolate(a_x: u64, b_x: u64, a_y: u64, b_y: u64, x: u64) -> u64
     }
 }
 
+/// Interpolates the arrival time at a given position using simulation output.
+///
+/// This function finds the position in the train's trajectory and interpolates
+/// the arrival time based on the surrounding positions and times.
+pub fn interpolate_arrival_time(position: u64, final_output: &CompleteReportTrain) -> i64 {
+    let index = find_index_upper(&final_output.report_train.positions, position);
+    let time = if index == 0 {
+        final_output.report_train.times[0]
+    } else {
+        linear_interpolate(
+            final_output.report_train.positions[index - 1],
+            final_output.report_train.positions[index],
+            final_output.report_train.times[index - 1],
+            final_output.report_train.times[index],
+            position,
+        )
+    };
+    time as i64
+}
+
 #[allow(clippy::too_many_arguments)]
 pub async fn compute_projected_train_paths<T: TrainScheduleLike>(
     conn: &mut DbConnection,
@@ -817,6 +837,35 @@ mod tests {
     fn test_find_index_lower(#[case] value: u64, #[case] expected: usize) {
         let values = vec![1, 3, 3, 4, 5, 5, 7, 8, 9, 9];
         assert_eq!(find_index_lower(&values, value), expected);
+    }
+
+    #[rstest]
+    #[case(25, vec![0, 50, 100], vec![0, 500, 1000], 250)]
+    #[case(0, vec![0, 50, 100], vec![0, 500, 1000], 0)]
+    #[case(100, vec![0, 50, 100], vec![0, 500, 1000], 1000)]
+    fn test_interpolate_arrival_time(
+        #[case] position: u64,
+        #[case] positions: Vec<u64>,
+        #[case] times: Vec<u64>,
+        #[case] expected_time: i64,
+    ) {
+        // Create a report train with given positions and times
+        let report_train = ReportTrain {
+            positions,
+            times,
+            speeds: vec![10.0; 5],
+            energy_consumption: 0.0,
+            path_item_times: vec![],
+        };
+
+        let final_output = CompleteReportTrain {
+            report_train,
+            ..Default::default()
+        };
+
+        let result = interpolate_arrival_time(position, &final_output);
+
+        assert_eq!(result, expected_time);
     }
 
     #[test]

--- a/editoast/src/views/timetable/track_occupancy.rs
+++ b/editoast/src/views/timetable/track_occupancy.rs
@@ -10,8 +10,7 @@ use schemas::train_schedule::ScheduleItem;
 use crate::views::path::path_item_cache::PathItemCache;
 use crate::views::path::pathfinding::PathfindingResult;
 use crate::views::path::projection::PathProjection;
-use crate::views::projection::find_index_upper;
-use crate::views::projection::linear_interpolate;
+use crate::views::projection::interpolate_arrival_time;
 use crate::views::timetable::simulation;
 use crate::views::timetable::simulation::SimulationResponseSuccess;
 
@@ -82,23 +81,6 @@ fn extract_occupancy_context<'a>(
         matching_index,
         schedule_item,
     }
-}
-
-/// Interpolates the arrival time at a given position using simulation output.
-fn interpolate_arrival_time(position: u64, final_output: &CompleteReportTrain) -> i64 {
-    let index = find_index_upper(&final_output.report_train.positions, position);
-    let time = if index == 0 {
-        final_output.report_train.times[0]
-    } else {
-        linear_interpolate(
-            final_output.report_train.positions[index - 1],
-            final_output.report_train.positions[index],
-            final_output.report_train.times[index - 1],
-            final_output.report_train.times[index],
-            position,
-        )
-    };
-    time as i64
 }
 
 // Returns the arrival time for an operational point, using direct match or interpolation.
@@ -422,35 +404,6 @@ pub mod tests {
             // We expect no results in failure cases
             assert_eq!(results.len(), 0);
         }
-    }
-
-    #[rstest]
-    #[case(25, vec![0, 50, 100], vec![0, 500, 1000], 250)]
-    #[case(0, vec![0, 50, 100], vec![0, 500, 1000], 0)]
-    #[case(100, vec![0, 50, 100], vec![0, 500, 1000], 1000)]
-    fn test_interpolate_arrival_time(
-        #[case] position: u64,
-        #[case] positions: Vec<u64>,
-        #[case] times: Vec<u64>,
-        #[case] expected_time: i64,
-    ) {
-        // Create a report train with given positions and times
-        let report_train = ReportTrain {
-            positions,
-            times,
-            speeds: vec![10.0; 5],
-            energy_consumption: 0.0,
-            path_item_times: vec![],
-        };
-
-        let final_output = CompleteReportTrain {
-            report_train,
-            ..Default::default()
-        };
-
-        let result = interpolate_arrival_time(position, &final_output);
-
-        assert_eq!(result, expected_time);
     }
 
     #[rstest]

--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -118,6 +118,12 @@
       "LayerNotFound": "Layer {{layer_name}} not found.",
       "ViewNotFound": "View {{view_name}} not found."
     },
+    "level_crossing": {
+      "Database": "Internal error (database)",
+      "InfraNotFound": "Infrastructure '{{infra_id}}' could not be found.",
+      "LevelCrossingBatchNotFound": "'{{count}}' level crossing(s) could not be found.",
+      "TrainBatchNotFound": "'{{count}}' paced train(s) could not be found."
+    },
     "macro_node": {
       "Database": "Internal error",
       "NotFound": "Node {{node_id}} not found.",

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -118,6 +118,12 @@
       "LayerNotFound": "Couche de données {{layer_name}} non trouvée.",
       "ViewNotFound": "View {{view_name}} non trouvé."
     },
+    "level_crossing": {
+      "Database": "Erreur interne (base de données)",
+      "InfraNotFound": "Infrastructure '{{infra_id}}' non trouvée.",
+      "LevelCrossingBatchNotFound": "'{{count}}' passage(s) à niveau introuvable(s).",
+      "TrainBatchNotFound": "'{{count}}' mission(s) introuvable(s)."
+    },
     "macro_node": {
       "Database": "Erreur interne",
       "NotFound": "Noeud {{node_id}} non trouvé",

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -1993,12 +1993,28 @@ export type GetLayersTileByLayerSlugAndViewSlugZXYApiArg = {
 };
 export type PostLevelCrossingOccupancyApiResponse =
   /** status 200 Occupancy periods of the given level crossings */ {
-    [key: string]: ({
+    [key: string]: ((
+      | {
+          id: number;
+          index: number;
+          type: 'base';
+        }
+      | {
+          exception_key: string;
+          id: number;
+          index: number;
+          type: 'modified';
+        }
+      | {
+          exception_key: string;
+          id: number;
+          type: 'created';
+        }
+    ) & {
       duration: string;
       time_begin: string;
     } & {
       direction: Direction;
-      train_id: number;
     })[];
   };
 export type PostLevelCrossingOccupancyApiArg = {


### PR DESCRIPTION
Implements full logic for `/level_crossing_occupancy/` endpoint assuming all trains are `PacedTrain`: 

- Move `interpolate_arrival_time()` from `track_occupancy.rs` to `projection.rs` to be reused for `level_crossing_occupancy`
- Add `track_offset()` method to `LevelCrossing` schema
- Implement complete occupancy calculation workflow:
  * Load infra, level crossings and trains
  * Run train pathfinding and simulation
  * Compute occupancy time windows
  * Group results by level crossing ID
  * Skip trains with missing rolling stock, failed simulations, no pedal intersection, or that do not fully traverse the short zone
 - Add i18n messages for level_crossing errors in en and fr
- Add tests

This only works for `PacedTrain` as long as the `TrainSchedule` migration has not been completed.