### PR TITLE
front: fix translations (speedLimitByTagAbbrev in English, UnknownResource error in French)

### DIFF
--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -429,7 +429,7 @@
     "rollingstock": "Rolling stock",
     "saving": "Saving… please wait",
     "showTrainSettings": "Show",
-    "speedLimitByTagAbbrev": "Code compo.",
+    "speedLimitByTagAbbrev": "Comp. code",
     "tabs": {
       "pathFinding": "Route",
       "rollingStock": "Rolling stock",

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -37,7 +37,7 @@
       "NoSuchUser": "Utilisateur inconnu",
       "Unauthorized": "Utilisateur non authentifié",
       "UnknownIdentity": "Identité inconnue '{{identity}}'",
-      "UnknownResource": "Resource inconnue",
+      "UnknownResource": "Ressource inconnue",
       "UnknownResourceType": "Type de ressource inconnu",
       "UnknownSubject": "Sujet inconnu",
       "UnknownUser": "Utilisateur inconnu '{{id}}'"


### PR DESCRIPTION
- speedLimitByTag should probably not be "composition code" in English, but I'm not sure what would be better.  In the meantime, we should use a proper abbreviation for it.

- "ressource" has 2 s in French