### PR TITLE
front: clean code related to trainSchedules

### DIFF
--- a/front/src/applications/operationalStudies/__tests__/sampleData.ts
+++ b/front/src/applications/operationalStudies/__tests__/sampleData.ts
@@ -8,7 +8,7 @@ import type {
   PositionData,
 } from 'applications/operationalStudies/types';
 import type { SimulationSummaryResult } from 'common/api/osrdEditoastApi';
-import type { PacedTrainId, PacedTrainWithPacedTrainId } from 'reducers/osrdconf/types';
+import type { PacedTrainId, TimetableItem } from 'reducers/osrdconf/types';
 
 export const pathLength = 4000;
 export const pathLengthLong = 6000;
@@ -315,7 +315,7 @@ export const electrificationRangesSingleSegment: ElectrificationRange[] = [
  * Data for isTooFast
  */
 
-export const trainScheduleTooFast: PacedTrainWithPacedTrainId = {
+export const trainScheduleTooFast: TimetableItem = {
   id: 'paced_98' as PacedTrainId,
   train_name: 'tooFast',
   labels: [],
@@ -384,7 +384,7 @@ export const trainSummaryTooFast: Extract<SimulationSummaryResult, { status: 'su
   path_item_positions: [0, 1000, 2000],
 };
 
-export const trainScheduleTooFastOnInterval: PacedTrainWithPacedTrainId = {
+export const trainScheduleTooFastOnInterval: TimetableItem = {
   id: 'trainschedule_38366' as PacedTrainId,
   train_name: 'tooFastOnInterval',
   labels: [],
@@ -456,7 +456,7 @@ export const trainSummaryTooFastOnInterval: Extract<
   path_item_positions: [0, 1000, 2000],
 };
 
-export const trainScheduleNotHonored: PacedTrainWithPacedTrainId = {
+export const trainScheduleNotHonored: TimetableItem = {
   id: 'paced_96' as PacedTrainId,
   train_name: 'notHonored',
   labels: [],
@@ -525,7 +525,7 @@ export const trainSummaryNotHonored: Extract<SimulationSummaryResult, { status: 
   path_item_positions: [0, 1000, 2000],
 };
 
-export const trainScheduleHonored: PacedTrainWithPacedTrainId = {
+export const trainScheduleHonored: TimetableItem = {
   id: 'paced_95' as PacedTrainId,
   train_name: 'normal',
   labels: [],
@@ -569,12 +569,12 @@ export const trainScheduleHonored: PacedTrainWithPacedTrainId = {
   },
 };
 
-export const trainScheduleNoSchedule: PacedTrainWithPacedTrainId = {
+export const trainScheduleNoSchedule: TimetableItem = {
   ...trainScheduleHonored,
   schedule: undefined,
 };
 
-export const trainScheduleNoMatch: PacedTrainWithPacedTrainId = {
+export const trainScheduleNoMatch: TimetableItem = {
   ...trainScheduleHonored,
   schedule: [
     {

--- a/front/src/applications/operationalStudies/__tests__/sampleData.ts
+++ b/front/src/applications/operationalStudies/__tests__/sampleData.ts
@@ -8,7 +8,7 @@ import type {
   PositionData,
 } from 'applications/operationalStudies/types';
 import type { SimulationSummaryResult } from 'common/api/osrdEditoastApi';
-import type { TrainScheduleId, TrainScheduleWithTrainId } from 'reducers/osrdconf/types';
+import type { PacedTrainId, PacedTrainWithPacedTrainId } from 'reducers/osrdconf/types';
 
 export const pathLength = 4000;
 export const pathLengthLong = 6000;
@@ -315,8 +315,8 @@ export const electrificationRangesSingleSegment: ElectrificationRange[] = [
  * Data for isTooFast
  */
 
-export const trainScheduleTooFast: TrainScheduleWithTrainId = {
-  id: 'trainschedule-98' as TrainScheduleId,
+export const trainScheduleTooFast: PacedTrainWithPacedTrainId = {
+  id: 'paced_98' as PacedTrainId,
   train_name: 'tooFast',
   labels: [],
   rolling_stock_name: 'TC64700',
@@ -384,8 +384,8 @@ export const trainSummaryTooFast: Extract<SimulationSummaryResult, { status: 'su
   path_item_positions: [0, 1000, 2000],
 };
 
-export const trainScheduleTooFastOnInterval: TrainScheduleWithTrainId = {
-  id: 'trainschedule_38366' as TrainScheduleId,
+export const trainScheduleTooFastOnInterval: PacedTrainWithPacedTrainId = {
+  id: 'trainschedule_38366' as PacedTrainId,
   train_name: 'tooFastOnInterval',
   labels: [],
   rolling_stock_name: 'rs-fictive',
@@ -456,8 +456,8 @@ export const trainSummaryTooFastOnInterval: Extract<
   path_item_positions: [0, 1000, 2000],
 };
 
-export const trainScheduleNotHonored: TrainScheduleWithTrainId = {
-  id: 'trainschedule-96' as TrainScheduleId,
+export const trainScheduleNotHonored: PacedTrainWithPacedTrainId = {
+  id: 'paced_96' as PacedTrainId,
   train_name: 'notHonored',
   labels: [],
   rolling_stock_name: 'TC64700',
@@ -525,8 +525,8 @@ export const trainSummaryNotHonored: Extract<SimulationSummaryResult, { status: 
   path_item_positions: [0, 1000, 2000],
 };
 
-export const trainScheduleHonored: TrainScheduleWithTrainId = {
-  id: 'trainschedule-95' as TrainScheduleId,
+export const trainScheduleHonored: PacedTrainWithPacedTrainId = {
+  id: 'paced_95' as PacedTrainId,
   train_name: 'normal',
   labels: [],
   rolling_stock_name: 'TC64700',
@@ -569,12 +569,12 @@ export const trainScheduleHonored: TrainScheduleWithTrainId = {
   },
 };
 
-export const trainScheduleNoSchedule: TrainScheduleWithTrainId = {
+export const trainScheduleNoSchedule: PacedTrainWithPacedTrainId = {
   ...trainScheduleHonored,
   schedule: undefined,
 };
 
-export const trainScheduleNoMatch: TrainScheduleWithTrainId = {
+export const trainScheduleNoMatch: PacedTrainWithPacedTrainId = {
   ...trainScheduleHonored,
   schedule: [
     {

--- a/front/src/applications/operationalStudies/helpers/TrainOpProjectionLazyLoader.ts
+++ b/front/src/applications/operationalStudies/helpers/TrainOpProjectionLazyLoader.ts
@@ -7,11 +7,7 @@ import {
   type PostPacedTrainProjectPathOpApiResponse,
 } from 'common/api/osrdEditoastApi';
 import type { TimetableItemId } from 'reducers/osrdconf/types';
-import {
-  extractEditoastIdFromPacedTrainId,
-  formatEditoastIdToPacedTrainId,
-  isTrainScheduleId,
-} from 'utils/trainId';
+import { extractEditoastIdFromPacedTrainId, formatEditoastIdToPacedTrainId } from 'utils/trainId';
 
 import TrainProjectionLazyLoaderAbstract, {
   type ProjectionResult,
@@ -41,27 +37,19 @@ export default class TrainOpProjectionLazyLoader extends TrainProjectionLazyLoad
       return;
     }
 
-    const rawPacedTrainIds = [];
-
-    for (const id of batch) {
-      if (isTrainScheduleId(id)) {
-        throw new Error('TrainSchedules are not handled anymore.');
-      } else {
-        rawPacedTrainIds.push(extractEditoastIdFromPacedTrainId(id));
-      }
-    }
+    const editoastIds = batch.map((id) => extractEditoastIdFromPacedTrainId(id));
 
     let pacedTrainPromise: Promise<PostPacedTrainProjectPathOpApiResponse> = Promise.resolve({});
     let pacedTrainOccupancyBlocksPromise: Promise<PostPacedTrainOccupancyBlocksApiResponse> =
       Promise.resolve({});
-    if (rawPacedTrainIds.length > 0) {
+    if (editoastIds.length > 0) {
       pacedTrainPromise = this.options
         .dispatch(
           osrdEditoastApi.endpoints.postPacedTrainProjectPathOp.initiate(
             {
               body: {
                 infra_id: infraId,
-                train_ids: rawPacedTrainIds,
+                train_ids: editoastIds,
                 operational_points_refs: this.opRefs,
                 operational_points_distances: this.opDistances,
               },
@@ -80,7 +68,7 @@ export default class TrainOpProjectionLazyLoader extends TrainProjectionLazyLoad
                 occupancyBlockForm: {
                   infra_id: infraId,
                   path,
-                  ids: rawPacedTrainIds,
+                  ids: editoastIds,
                   electrical_profile_set_id: electricalProfileSetId,
                 },
               },

--- a/front/src/applications/operationalStudies/helpers/TrainSimulationLazyLoader.ts
+++ b/front/src/applications/operationalStudies/helpers/TrainSimulationLazyLoader.ts
@@ -5,11 +5,7 @@ import {
 } from 'common/api/osrdEditoastApi';
 import type { PacedTrainId, TimetableItemId } from 'reducers/osrdconf/types';
 import type { AppDispatch } from 'store';
-import {
-  formatEditoastIdToPacedTrainId,
-  extractEditoastIdFromPacedTrainId,
-  isTrainScheduleId,
-} from 'utils/trainId';
+import { formatEditoastIdToPacedTrainId, extractEditoastIdFromPacedTrainId } from 'utils/trainId';
 
 const BATCH_SIZE = 20;
 
@@ -72,26 +68,19 @@ export default class TrainSimulationLazyLoader {
   }
 
   async processBatch(batch: TimetableItemId[]) {
-    const rawPacedTrainIds = [];
-    for (const id of batch) {
-      if (isTrainScheduleId(id)) {
-        throw new Error('TrainSchedules are not handled anymore.');
-      } else {
-        rawPacedTrainIds.push(extractEditoastIdFromPacedTrainId(id));
-      }
-    }
+    const editoastIds = batch.map((id) => extractEditoastIdFromPacedTrainId(id));
 
     let pacedTrainPromise: Promise<PostPacedTrainSimulationSummaryApiResponse> = Promise.resolve(
       {}
     );
-    if (rawPacedTrainIds.length > 0) {
+    if (editoastIds.length > 0) {
       pacedTrainPromise = this.options
         .dispatch(
           osrdEditoastApi.endpoints.postPacedTrainSimulationSummary.initiate(
             {
               body: {
                 infra_id: this.options.infraId,
-                ids: rawPacedTrainIds,
+                ids: editoastIds,
                 electrical_profile_set_id: this.options.electricalProfileSetId,
               },
             },

--- a/front/src/applications/operationalStudies/helpers/TrainTrackProjectionLazyLoader.ts
+++ b/front/src/applications/operationalStudies/helpers/TrainTrackProjectionLazyLoader.ts
@@ -7,11 +7,7 @@ import {
   type CoreTrainPath,
 } from 'common/api/osrdEditoastApi';
 import type { TimetableItemId } from 'reducers/osrdconf/types';
-import {
-  extractEditoastIdFromPacedTrainId,
-  formatEditoastIdToPacedTrainId,
-  isTrainScheduleId,
-} from 'utils/trainId';
+import { extractEditoastIdFromPacedTrainId, formatEditoastIdToPacedTrainId } from 'utils/trainId';
 
 import TrainProjectionLazyLoaderAbstract from './TrainProjectionLazyLoaderAbstract';
 import type {
@@ -40,19 +36,12 @@ export default class TrainTrackProjectionLazyLoader extends TrainProjectionLazyL
   async processBatch(batch: TimetableItemId[]) {
     const { infraId, path, electricalProfileSetId } = this.options;
 
-    const rawPacedTrainIds = [];
-    for (const id of batch) {
-      if (isTrainScheduleId(id)) {
-        throw new Error('TrainSchedules are not handled anymore.');
-      } else {
-        rawPacedTrainIds.push(extractEditoastIdFromPacedTrainId(id));
-      }
-    }
+    const editoastIds = batch.map((id) => extractEditoastIdFromPacedTrainId(id));
 
     let pacedTrainPromise: Promise<PostPacedTrainProjectPathApiResponse> = Promise.resolve({});
     let pacedTrainOccupancyBlocksPromise: Promise<PostPacedTrainOccupancyBlocksApiResponse> =
       Promise.resolve({});
-    if (rawPacedTrainIds.length > 0) {
+    if (editoastIds.length > 0) {
       pacedTrainPromise = this.options
         .dispatch(
           osrdEditoastApi.endpoints.postPacedTrainProjectPath.initiate(
@@ -60,7 +49,7 @@ export default class TrainTrackProjectionLazyLoader extends TrainProjectionLazyL
               projectPathForm: {
                 infra_id: infraId,
                 track_section_ranges: path.track_section_ranges,
-                ids: rawPacedTrainIds,
+                ids: editoastIds,
                 electrical_profile_set_id: electricalProfileSetId,
               },
             },
@@ -76,7 +65,7 @@ export default class TrainTrackProjectionLazyLoader extends TrainProjectionLazyL
               occupancyBlockForm: {
                 infra_id: infraId,
                 path,
-                ids: rawPacedTrainIds,
+                ids: editoastIds,
                 electrical_profile_set_id: electricalProfileSetId,
               },
             },

--- a/front/src/applications/operationalStudies/helpers/upsertNewProjectedTrains.ts
+++ b/front/src/applications/operationalStudies/helpers/upsertNewProjectedTrains.ts
@@ -1,7 +1,6 @@
 import type { BaseTrainProjection, TrainSpaceTimeData } from 'modules/simulationResult/types';
 import type { TimetableItem, TimetableItemId } from 'reducers/osrdconf/types';
 import { Duration } from 'utils/duration';
-import { isPacedTrainResponseWithPacedTrainId } from 'utils/trainId';
 
 import type { ProjectionResult } from './TrainProjectionLazyLoaderAbstract';
 
@@ -37,23 +36,18 @@ const upsertNewProjectedTrains = (
       signalUpdates: trainData.signal_updates || [],
     };
 
-    let projectedTrain: TrainSpaceTimeData;
-    if (!isPacedTrainResponseWithPacedTrainId(matchingTrain)) {
-      projectedTrain = { ...base, id: matchingTrain.id };
-    } else {
-      projectedTrain = {
-        ...base,
-        id: matchingTrain.id,
-        paced: matchingTrain.paced
-          ? {
-              timeWindow: Duration.parse(matchingTrain.paced.time_window),
-              interval: Duration.parse(matchingTrain.paced.interval),
-              exceptions: matchingTrain.paced.exceptions,
-              exceptionProjections,
-            }
-          : undefined,
-      };
-    }
+    const projectedTrain: TrainSpaceTimeData = {
+      ...base,
+      id: matchingTrain.id,
+      paced: matchingTrain.paced
+        ? {
+            timeWindow: Duration.parse(matchingTrain.paced.time_window),
+            interval: Duration.parse(matchingTrain.paced.interval),
+            exceptions: matchingTrain.paced.exceptions,
+            exceptionProjections,
+          }
+        : undefined,
+    };
 
     newProjectedTrains.set(trainIdKey, projectedTrain);
   }

--- a/front/src/applications/operationalStudies/hooks/useAutoSelectTrainIds.ts
+++ b/front/src/applications/operationalStudies/hooks/useAutoSelectTrainIds.ts
@@ -18,7 +18,6 @@ import {
   isOccurrenceId,
   isPacedTrainId,
   isPacedTrainWithDetails,
-  isTrainScheduleId,
 } from 'utils/trainId';
 
 type SimulationParams = {
@@ -92,13 +91,13 @@ const useAutoSelectTrainIds = (
     const projectionFromUrl = getParamFromUrlOrStorage('projection');
     if (
       selectedTrainFromUrl &&
-      (isTrainScheduleId(selectedTrainFromUrl) || isOccurrenceId(selectedTrainFromUrl))
+      (isOccurrenceId(selectedTrainFromUrl) || isPacedTrainId(selectedTrainFromUrl))
     ) {
       dispatch(updateSelectedTrainId(selectedTrainFromUrl));
     }
     if (
       projectionFromUrl &&
-      (isTrainScheduleId(projectionFromUrl) || isPacedTrainId(projectionFromUrl))
+      (isOccurrenceId(projectionFromUrl) || isPacedTrainId(projectionFromUrl))
     ) {
       dispatch(updateTrainIdUsedForProjection(projectionFromUrl));
     }

--- a/front/src/applications/operationalStudies/hooks/useAutoSelectTrainIds.ts
+++ b/front/src/applications/operationalStudies/hooks/useAutoSelectTrainIds.ts
@@ -17,7 +17,6 @@ import {
   formatPacedTrainIdToIndexedOccurrenceId,
   isOccurrenceId,
   isPacedTrainId,
-  isPacedTrainWithDetails,
 } from 'utils/trainId';
 
 type SimulationParams = {
@@ -158,10 +157,7 @@ const useAutoSelectTrainIds = (
     if (firstTrainCanBeUsedForProjection) {
       dispatch(updateTrainIdUsedForProjection(firstTrainCanBeUsedForProjection.id));
       let newTrainIdToSelect: TrainId;
-      if (
-        !isPacedTrainWithDetails(firstTrainCanBeUsedForProjection) ||
-        !firstTrainCanBeUsedForProjection.paced
-      ) {
+      if (!firstTrainCanBeUsedForProjection.paced) {
         newTrainIdToSelect = firstTrainCanBeUsedForProjection.id;
       } else {
         newTrainIdToSelect = formatPacedTrainIdToIndexedOccurrenceId(

--- a/front/src/applications/operationalStudies/hooks/useEtcsBrakingCurves.ts
+++ b/front/src/applications/operationalStudies/hooks/useEtcsBrakingCurves.ts
@@ -17,7 +17,7 @@ import {
 import { formatSpeedCurve } from 'modules/simulationResult/components/SpeedDistanceDiagram/helpers';
 import {
   findExceptionWithOccurrenceId,
-  isPacedTrainResponseWithPaced,
+  isPacedTrain,
 } from 'modules/timetableItem/helpers/pacedTrain';
 import useSelectedTimetableItem from 'modules/timetableItem/hooks/useSelectedTimetableItem';
 import { getSelectedTrainId } from 'reducers/simulationResults/selectors';
@@ -64,8 +64,7 @@ const useEtcsBrakingCurves = (
   const selectedTrainId = useSelector(getSelectedTrainId);
   const timetableItem = useSelectedTimetableItem();
   const exception = useMemo(() => {
-    if (!selectedTrainId || !timetableItem || !isPacedTrainResponseWithPaced(timetableItem))
-      return undefined;
+    if (!selectedTrainId || !timetableItem || !isPacedTrain(timetableItem)) return undefined;
     if (!isOccurrenceId(selectedTrainId))
       throw new Error(`trainId ${selectedTrainId} should be a occurrence id`);
     return findExceptionWithOccurrenceId(timetableItem.paced.exceptions, selectedTrainId);

--- a/front/src/applications/operationalStudies/hooks/usePathProjection.ts
+++ b/front/src/applications/operationalStudies/hooks/usePathProjection.ts
@@ -27,7 +27,6 @@ import {
   extractPacedTrainIdFromOccurrenceId,
   isOccurrenceId,
   isPacedTrainId,
-  isTrainScheduleId,
 } from 'utils/trainId';
 
 import type { PathProjectionResult } from '../types';
@@ -115,9 +114,7 @@ const usePathProjection = (
   let rawPacedTrainId: number | undefined;
   let exceptionKey: string | undefined;
   if (trainIdUsedForProjection) {
-    if (isTrainScheduleId(trainIdUsedForProjection)) {
-      throw new Error('TrainSchedules are not handled anymore.');
-    } else if (isPacedTrainId(trainIdUsedForProjection)) {
+    if (isPacedTrainId(trainIdUsedForProjection)) {
       rawPacedTrainId = extractEditoastIdFromPacedTrainId(trainIdUsedForProjection);
     } else {
       const pacedTrainId = extractPacedTrainIdFromOccurrenceId(trainIdUsedForProjection);

--- a/front/src/applications/operationalStudies/hooks/useScenarioData.ts
+++ b/front/src/applications/operationalStudies/hooks/useScenarioData.ts
@@ -6,17 +6,10 @@ import { keyBy, sortBy } from 'lodash';
 import { osrdEditoastApi, type ScenarioWithDetails } from 'common/api/osrdEditoastApi';
 import { useRollingStockContext } from 'common/RollingStockContext';
 import useLazyProjectTrains from 'modules/simulationResult/components/SpaceTimeChartWrapper/useLazyProjectTrains';
-import {
-  formatPacedTrainWithDetails,
-  formatTrainScheduleWithDetails,
-} from 'modules/timetableItem/helpers/formatTimetableItemWithDetails';
+import { formatPacedTrainWithDetails } from 'modules/timetableItem/helpers/formatTimetableItemWithDetails';
 import type { TimetableItemId, TimetableItem } from 'reducers/osrdconf/types';
 import { useAppDispatch } from 'store';
-import {
-  formatEditoastIdToPacedTrainId,
-  extractEditoastIdFromPacedTrainId,
-  isPacedTrainResponseWithPacedTrainId,
-} from 'utils/trainId';
+import { formatEditoastIdToPacedTrainId, extractEditoastIdFromPacedTrainId } from 'utils/trainId';
 import { mapBy } from 'utils/types';
 
 import useAutoSelectTrainIds from './useAutoSelectTrainIds';
@@ -116,9 +109,7 @@ const useScenarioData = (scenario: ScenarioWithDetails, infraId: number) => {
       const simulatedTrain = simulatedTrainsById.get(timetableItem.id);
       if (simulatedTrain) return simulatedTrain;
       const rollingStock = rollingStocksByName.get(timetableItem.rolling_stock_name);
-      return isPacedTrainResponseWithPacedTrainId(timetableItem)
-        ? formatPacedTrainWithDetails(timetableItem, rollingStock)
-        : formatTrainScheduleWithDetails(timetableItem, rollingStock);
+      return formatPacedTrainWithDetails(timetableItem, rollingStock);
     });
     return sortBy(items, ['startTime', 'name', 'id']);
   }, [timetableItems, rollingStocksByName, simulatedTrainsById]);
@@ -207,19 +198,15 @@ const useScenarioData = (scenario: ScenarioWithDetails, infraId: number) => {
         throw new Error(`Timetable item "${timetableItemId}" not found`);
       }
 
-      if (isPacedTrainResponseWithPacedTrainId(timetableItem)) {
-        const editoastPacedTrainId = extractEditoastIdFromPacedTrainId(timetableItem.id);
+      const editoastPacedTrainId = extractEditoastIdFromPacedTrainId(timetableItem.id);
 
-        await putPacedTrainById({
-          id: editoastPacedTrainId,
-          body: {
-            ...timetableItem,
-            start_time: newDeparture.toISOString(),
-          },
-        }).unwrap();
-      } else {
-        throw new Error('TrainSchedules are not handled anymore.');
-      }
+      await putPacedTrainById({
+        id: editoastPacedTrainId,
+        body: {
+          ...timetableItem,
+          start_time: newDeparture.toISOString(),
+        },
+      }).unwrap();
 
       setTimetableItemDepartureTime(timetableItemId, newDeparture);
     },

--- a/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
+++ b/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
@@ -10,7 +10,6 @@ import {
   extractOccurrenceDetailsFromPacedTrain,
   findExceptionWithOccurrenceId,
   computeIndexedOccurrenceStartTime,
-  isPacedTrainResponseWithPaced,
 } from 'modules/timetableItem/helpers/pacedTrain';
 import useSelectedTimetableItem from 'modules/timetableItem/hooks/useSelectedTimetableItem';
 import type { Train } from 'reducers/osrdconf/types';
@@ -35,12 +34,8 @@ const useSimulationResults = (): SimulationResults | undefined => {
 
   const train: Train | undefined = useMemo(() => {
     if (!selectedTrainId || !timetableItem) return undefined;
-    if (!isPacedTrainResponseWithPaced(timetableItem)) {
+    if (!isOccurrenceId(selectedTrainId) || !timetableItem.paced) {
       return timetableItem;
-    }
-
-    if (!isOccurrenceId(selectedTrainId)) {
-      throw new Error(`trainId ${selectedTrainId} should be a occurrence id`);
     }
 
     const exception = findExceptionWithOccurrenceId(
@@ -70,10 +65,8 @@ const useSimulationResults = (): SimulationResults | undefined => {
   }, [selectedTrainId, timetableItem]);
 
   const exception = useMemo(() => {
-    if (!selectedTrainId || !timetableItem || !isPacedTrainResponseWithPaced(timetableItem))
+    if (!selectedTrainId || !isOccurrenceId(selectedTrainId) || !timetableItem?.paced)
       return undefined;
-    if (!isOccurrenceId(selectedTrainId))
-      throw new Error(`trainId ${selectedTrainId} should be a occurrence id`);
     return findExceptionWithOccurrenceId(timetableItem.paced.exceptions, selectedTrainId);
   }, [selectedTrainId, timetableItem]);
 

--- a/front/src/applications/operationalStudies/utils.ts
+++ b/front/src/applications/operationalStudies/utils.ts
@@ -16,7 +16,7 @@ import type {
 } from 'common/api/osrdEditoastApi';
 import getPathVoltages from 'modules/pathfinding/helpers/getPathVoltages';
 import { ARRIVAL_TIME_ACCEPTABLE_ERROR } from 'modules/timesStops/consts';
-import { isPacedTrainResponseWithPaced } from 'modules/timetableItem/helpers/pacedTrain';
+import { isPacedTrain } from 'modules/timetableItem/helpers/pacedTrain';
 import type {
   TimetableItem,
   TimetableItemId,
@@ -357,14 +357,12 @@ export const checkRoundTripCompatible = (
   timetableItemA: TimetableItemWithPathOps,
   timetableItemB: TimetableItemWithPathOps
 ): boolean => {
-  if (
-    isPacedTrainResponseWithPaced(timetableItemA) !== isPacedTrainResponseWithPaced(timetableItemB)
-  ) {
+  if (isPacedTrain(timetableItemA) !== isPacedTrain(timetableItemB)) {
     return false;
   }
   if (
-    isPacedTrainResponseWithPaced(timetableItemA) &&
-    isPacedTrainResponseWithPaced(timetableItemB) &&
+    isPacedTrain(timetableItemA) &&
+    isPacedTrain(timetableItemB) &&
     Duration.parse(timetableItemA.paced.interval).ms !==
       Duration.parse(timetableItemB.paced.interval).ms
   ) {

--- a/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/ImportTimetableItemTrainsList.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/ImportTimetableItemTrainsList.tsx
@@ -23,7 +23,7 @@ import { useSubCategoryContext } from 'common/SubCategoryContext';
 import { TrainMainCategoryDict } from 'modules/rollingStock/consts';
 import isMainCategory from 'modules/rollingStock/helpers/category';
 import { setFailure, setSuccess, setWarning } from 'reducers/main';
-import type { PacedTrainWithPacedTrainId, TimetableItem } from 'reducers/osrdconf/types';
+import type { TimetableItem } from 'reducers/osrdconf/types';
 import { useAppDispatch } from 'store';
 import { extractEditoastIdFromPacedTrainId } from 'utils/trainId';
 
@@ -166,7 +166,7 @@ const ImportTimetableItemTrainsList = ({
 
   const postRoundTrips = async (
     roundTrips: RoundTripsFromJson,
-    formattedPacedTrains: PacedTrainWithPacedTrainId[]
+    formattedPacedTrains: TimetableItem[]
   ): Promise<void> => {
     if (roundTrips.paced_trains.length > 0) {
       const payload = generateRoundTripsPayload(

--- a/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/__tests__/generatePayloads.spec.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/__tests__/generatePayloads.spec.ts
@@ -1,30 +1,27 @@
 import { describe, it, expect } from 'vitest';
 
-import type { TrainScheduleId, PacedTrainId } from 'reducers/osrdconf/types';
-import {
-  extractEditoastIdFromTrainScheduleId,
-  extractEditoastIdFromPacedTrainId,
-} from 'utils/trainId';
+import type { PacedTrainId } from 'reducers/osrdconf/types';
+import { extractEditoastIdFromPacedTrainId } from 'utils/trainId';
 
 import { generateRoundTripsPayload } from '../generatePayloads';
 
 describe('generateRoundTripsPayload', () => {
-  it('correctly generates payload for a mix of one-ways and round-trips train schedules', () => {
-    const trainSchedules = [
-      { id: 'trainschedule_101' as TrainScheduleId },
-      { id: 'trainschedule_102' as TrainScheduleId },
-      { id: 'trainschedule_103' as TrainScheduleId },
+  it('correctly generates payload for a mix of one-ways and round-trips paced trains', () => {
+    const pacedTrains = [
+      { id: 'paced_101' as PacedTrainId },
+      { id: 'paced_102' as PacedTrainId },
+      { id: 'paced_103' as PacedTrainId },
     ];
 
-    const trainScheduleIndexes: ([number, number] | [number, null])[] = [
+    const pacedTrainIndexes: ([number, number] | [number, null])[] = [
       [0, 2],
       [1, null],
     ];
 
     const trainSchedulePayload = generateRoundTripsPayload(
-      trainScheduleIndexes,
-      trainSchedules,
-      extractEditoastIdFromTrainScheduleId
+      pacedTrainIndexes,
+      pacedTrains,
+      extractEditoastIdFromPacedTrainId
     );
 
     expect(trainSchedulePayload).toEqual({

--- a/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/postTimetableItems.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/postTimetableItems.ts
@@ -1,5 +1,5 @@
 import { osrdEditoastApi, type PacedTrain } from 'common/api/osrdEditoastApi';
-import type { PacedTrainWithPacedTrainId } from 'reducers/osrdconf/types';
+import type { TimetableItem } from 'reducers/osrdconf/types';
 import type { AppDispatch } from 'store';
 import { formatEditoastIdToPacedTrainId } from 'utils/trainId';
 
@@ -8,7 +8,7 @@ const postTimetableItems = async (
   payloads: PacedTrain[],
   dispatch: AppDispatch
 ) => {
-  let timetableItems: PacedTrainWithPacedTrainId[] = [];
+  let timetableItems: TimetableItem[] = [];
   if (payloads.length) {
     const rawTimetableItems = await dispatch(
       osrdEditoastApi.endpoints.postTimetableByIdPacedTrains.initiate({

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/ngeToOsrd/trainrun.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/ngeToOsrd/trainrun.ts
@@ -7,7 +7,7 @@ import {
   type PathItemLocation,
   type PacedTrainException,
 } from 'common/api/osrdEditoastApi';
-import { isPacedTrainResponseWithPaced } from 'modules/timetableItem/helpers/pacedTrain';
+import { isPacedTrain } from 'modules/timetableItem/helpers/pacedTrain';
 import {
   createPacedTrain,
   deletePacedTrains,
@@ -573,7 +573,7 @@ export const handleUpdateTimetableItem = async ({
     updatedForwardTrainId = updatedTrainSchedule.id;
   } else {
     let exceptions: PacedTrainException[] = [];
-    if (isPacedTrainResponseWithPaced(oldForwardTimetableItem)) {
+    if (isPacedTrain(oldForwardTimetableItem)) {
       paced.time_window = oldForwardTimetableItem.paced.time_window;
       exceptions = checkChangeGroups(
         newForwardTimetableItem,
@@ -643,7 +643,7 @@ export const handleUpdateTimetableItem = async ({
         ...newReturnTimetableItemBase,
         paced: {
           ...paced,
-          exceptions: isPacedTrainResponseWithPaced(oldReturnTimetableItem)
+          exceptions: isPacedTrain(oldReturnTimetableItem)
             ? checkChangeGroups(
                 newReturnTimetableItemBase,
                 paced,

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/ngeToOsrd/trainrun.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/ngeToOsrd/trainrun.ts
@@ -15,9 +15,8 @@ import {
   storePacedTrain,
 } from 'modules/timetableItem/helpers/updateTimetableItemHelpers';
 import type {
-  PacedTrainWithPacedTrainId,
-  TimetableItemId,
   TimetableItem,
+  TimetableItemId,
   TrainScheduleId,
   PacedTrainId,
 } from 'reducers/osrdconf/types';
@@ -459,11 +458,11 @@ const handleCreateTimetableItem = async (
     })
   ).unwrap();
 
-  const newPacedTrain: PacedTrainWithPacedTrainId = {
+  const newPacedTrain: TimetableItem = {
     ...newTimetableItems[0],
     id: formatEditoastIdToPacedTrainId(newTimetableItems[0].id),
   };
-  const newReturnPacedTrain: PacedTrainWithPacedTrainId = {
+  const newReturnPacedTrain: TimetableItem = {
     ...newTimetableItems[1],
     id: formatEditoastIdToPacedTrainId(newTimetableItems[1].id),
   };

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/osrdToNge.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/osrdToNge.ts
@@ -14,7 +14,7 @@ import {
   type SubCategory,
   type MacroNoteResponse,
 } from 'common/api/osrdEditoastApi';
-import { isPacedTrainResponseWithPaced } from 'modules/timetableItem/helpers/pacedTrain';
+import { isPacedTrain } from 'modules/timetableItem/helpers/pacedTrain';
 import type { TimetableItem, TimetableItemWithPathOps } from 'reducers/osrdconf/types';
 import type { AppDispatch } from 'store';
 import { Duration, addDurationToDate } from 'utils/duration';
@@ -64,7 +64,7 @@ const getNgeTrainrunFrequencies = (
 
   // Add the unknown frequencies from the PacedTrains
   timetableItems.forEach((timetableItem) => {
-    if (isPacedTrainResponseWithPaced(timetableItem)) {
+    if (isPacedTrain(timetableItem)) {
       const intervalInMinutes = Duration.parse(timetableItem.paced.interval).total('minute');
       if (!trainrunFrequencies.find((f) => f.frequency === intervalInMinutes)) {
         const newFrequency: TrainrunFrequency = {

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/utils.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/utils.ts
@@ -13,7 +13,7 @@ import { isPacedTrainResponseWithPaced } from 'modules/timetableItem/helpers/pac
 import type { TimetableItem, PacedTrainId } from 'reducers/osrdconf/types';
 import type { AppDispatch } from 'store';
 import { Duration } from 'utils/duration';
-import { extractEditoastIdFromPacedTrainId, isPacedTrainId } from 'utils/trainId';
+import { extractEditoastIdFromPacedTrainId } from 'utils/trainId';
 
 import {
   CUSTOM_TRAINRUN_TIME_CATEGORY,
@@ -92,33 +92,23 @@ export const storeRoundTrip = async (
   forwardId: PacedTrainId,
   returnId?: PacedTrainId
 ) => {
-  if (isPacedTrainId(forwardId)) {
-    let roundTrips;
-    if (returnId) {
-      if (!isPacedTrainId(returnId)) {
-        throw new Error('Type mismatch: forward is PacedTrain but return is not');
-      }
-      roundTrips = {
-        round_trips: [
-          [
-            extractEditoastIdFromPacedTrainId(forwardId),
-            extractEditoastIdFromPacedTrainId(returnId),
-          ],
-        ],
-      };
-    } else {
-      roundTrips = {
-        one_ways: [extractEditoastIdFromPacedTrainId(forwardId)],
-      };
-    }
-    await dispatch(
-      osrdEditoastApi.endpoints.postRoundTripsPacedTrains.initiate({
-        roundTrips,
-      })
-    ).unwrap();
+  let roundTrips;
+  if (returnId) {
+    roundTrips = {
+      round_trips: [
+        [extractEditoastIdFromPacedTrainId(forwardId), extractEditoastIdFromPacedTrainId(returnId)],
+      ],
+    };
   } else {
-    throw new Error('TrainSchedules are not handled anymore');
+    roundTrips = {
+      one_ways: [extractEditoastIdFromPacedTrainId(forwardId)],
+    };
   }
+  await dispatch(
+    osrdEditoastApi.endpoints.postRoundTripsPacedTrains.initiate({
+      roundTrips,
+    })
+  ).unwrap();
 };
 
 /**

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/utils.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/utils.ts
@@ -9,7 +9,7 @@ import {
   type TrainCategory,
 } from 'common/api/osrdEditoastApi';
 import isMainCategory from 'modules/rollingStock/helpers/category';
-import { isPacedTrainResponseWithPaced } from 'modules/timetableItem/helpers/pacedTrain';
+import { isPacedTrain } from 'modules/timetableItem/helpers/pacedTrain';
 import type { TimetableItem, PacedTrainId } from 'reducers/osrdconf/types';
 import type { AppDispatch } from 'store';
 import { Duration } from 'utils/duration';
@@ -179,7 +179,7 @@ export const getTrainrunFrequencyFromTimetableItem = (
   timetableItem: TimetableItem,
   state: MacroEditorState
 ): TrainrunFrequency => {
-  if (!isPacedTrainResponseWithPaced(timetableItem)) {
+  if (!isPacedTrain(timetableItem)) {
     return getFrequencyFromFrequencyId(state.trainrunFrequencies, TRAIN_SCHEDULE_FREQUENCY_ID);
   }
   const intervalInMinutes = Duration.parse(timetableItem.paced.interval).total('minute');

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/CreateTimetableItemButton.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/CreateTimetableItemButton.tsx
@@ -8,7 +8,7 @@ import { useStoreDataForRollingStockSelector } from 'modules/rollingStock/compon
 import { setFailure, setSuccess } from 'reducers/main';
 import { clearAddedExceptionsList } from 'reducers/osrdconf/operationalStudiesConf';
 import { getOperationalStudiesConf } from 'reducers/osrdconf/operationalStudiesConf/selectors';
-import type { PacedTrainWithPacedTrainId, TimetableItem } from 'reducers/osrdconf/types';
+import type { TimetableItem } from 'reducers/osrdconf/types';
 import { useAppDispatch } from 'store';
 import { castErrorToFailure } from 'utils/error';
 import { formatEditoastIdToPacedTrainId } from 'utils/trainId';
@@ -62,7 +62,7 @@ const CreateTimetableItemButton = ({
       }).unwrap();
 
       // We can only add one paced train at a time
-      const formattedNewPacedTrain: PacedTrainWithPacedTrainId = {
+      const formattedNewPacedTrain: TimetableItem = {
         ...newTimetableItem.at(0)!,
         id: formatEditoastIdToPacedTrainId(newTimetableItem.at(0)!.id),
       };

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/helpers/formatTimetableItemPayload.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/helpers/formatTimetableItemPayload.ts
@@ -6,7 +6,7 @@ import type { PacedTrain, TrainSchedule } from 'common/api/osrdEditoastApi';
 import getStepLocation from 'modules/pathfinding/helpers/getStepLocation';
 import {
   findExceptionWithOccurrenceId,
-  isPacedTrainWithPaced,
+  isPacedTrainBase,
 } from 'modules/timetableItem/helpers/pacedTrain';
 import type { PacedTrainWithDetails } from 'modules/timetableItem/types';
 import type {
@@ -132,7 +132,7 @@ export function formatPacedTrainPayload(
     const originalPacedTrain = formatPacedTrainWithDetailsToPacedTrainPayload(
       timetableItemToEditData.originalPacedTrain
     );
-    if (!isPacedTrainWithPaced(originalPacedTrain))
+    if (!isPacedTrainBase(originalPacedTrain))
       throw new Error(
         `PacedTrain payload (built from train ${timetableItemToEditData.originalPacedTrain.id}) should have a paced field.`
       );

--- a/front/src/applications/operationalStudies/views/Scenario/components/RoundTrips/TodoColumn.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/RoundTrips/TodoColumn.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 
 import { checkRoundTripCompatible } from 'applications/operationalStudies/utils';
 import type { SubCategory } from 'common/api/osrdEditoastApi';
-import { isPacedTrainWithPaced } from 'modules/timetableItem/helpers/pacedTrain';
+import { isPacedTrainBase } from 'modules/timetableItem/helpers/pacedTrain';
 import type { TimetableItemId, TimetableItemWithPathOps } from 'reducers/osrdconf/types';
 
 import RoundTripsModalCard from './RoundTripsModalCard';
@@ -49,7 +49,7 @@ const TodoColumn = ({
     for (const candidate of timetableItemsWithOpsById.values()) {
       if (
         candidate.id === itemIdToPair ||
-        isPacedTrainWithPaced(timetableItemToPair) !== isPacedTrainWithPaced(candidate)
+        isPacedTrainBase(timetableItemToPair) !== isPacedTrainBase(candidate)
       )
         continue;
 

--- a/front/src/applications/operationalStudies/views/Scenario/components/RoundTrips/utils.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/RoundTrips/utils.ts
@@ -7,7 +7,7 @@ import {
   getStationFromOps,
 } from 'applications/operationalStudies/utils';
 import type { OperationalPoint, TrainSchedule, RoundTrips } from 'common/api/osrdEditoastApi';
-import { isPacedTrainResponseWithPaced } from 'modules/timetableItem/helpers/pacedTrain';
+import { isPacedTrain } from 'modules/timetableItem/helpers/pacedTrain';
 import type { TimetableItemWithPathOps } from 'reducers/osrdconf/types';
 import { addDurationToDate, Duration } from 'utils/duration';
 import { extractEditoastIdFromPacedTrainId } from 'utils/trainId';
@@ -70,7 +70,7 @@ const formatBasePairingItem = (
     id: item.id,
     name: item.train_name,
     category: item.category,
-    interval: isPacedTrainResponseWithPaced(item) ? Duration.parse(item.paced.interval) : null,
+    interval: isPacedTrain(item) ? Duration.parse(item.paced.interval) : null,
     origin: stepLabels.at(0)!,
     stops: stepLabels.slice(1, -1),
     destination: stepLabels.at(-1)!,

--- a/front/src/applications/operationalStudies/views/Scenario/components/RoundTrips/utils.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/RoundTrips/utils.ts
@@ -10,7 +10,7 @@ import type { OperationalPoint, TrainSchedule, RoundTrips } from 'common/api/osr
 import { isPacedTrainResponseWithPaced } from 'modules/timetableItem/helpers/pacedTrain';
 import type { TimetableItemWithPathOps } from 'reducers/osrdconf/types';
 import { addDurationToDate, Duration } from 'utils/duration';
-import { extractEditoastIdFromPacedTrainId, isPacedTrainId } from 'utils/trainId';
+import { extractEditoastIdFromPacedTrainId } from 'utils/trainId';
 
 import type { PairingItem } from './types';
 
@@ -133,24 +133,22 @@ export const buildRoundTripsPayload = (pairingItems: PairingItem[], roundTrips: 
   const roundTripsIds: number[][] = [];
 
   for (const item of pairingItems) {
-    if (isPacedTrainId(item.id)) {
-      const itemRawId = extractEditoastIdFromPacedTrainId(item.id);
-      const initialStatus = getItemInitialStatus(itemRawId, roundTrips);
+    const itemRawId = extractEditoastIdFromPacedTrainId(item.id);
+    const initialStatus = getItemInitialStatus(itemRawId, roundTrips);
 
-      if (
-        item.status === 'roundTrips' &&
-        initialStatus !== item.status &&
-        !roundTripsIds.flat().includes(itemRawId)
-      ) {
-        const pairedItemRawId = extractEditoastIdFromPacedTrainId(item.pairedItemId);
-        roundTripsIds.push([itemRawId, pairedItemRawId]);
-      }
-      if (item.status === 'oneWays' && initialStatus !== item.status) {
-        oneWaysIds.push(itemRawId);
-      }
-      if (item.status === 'todo' && initialStatus !== item.status) {
-        idsToDelete.push(itemRawId);
-      }
+    if (
+      item.status === 'roundTrips' &&
+      initialStatus !== item.status &&
+      !roundTripsIds.flat().includes(itemRawId)
+    ) {
+      const pairedItemRawId = extractEditoastIdFromPacedTrainId(item.pairedItemId);
+      roundTripsIds.push([itemRawId, pairedItemRawId]);
+    }
+    if (item.status === 'oneWays' && initialStatus !== item.status) {
+      oneWaysIds.push(itemRawId);
+    }
+    if (item.status === 'todo' && initialStatus !== item.status) {
+      idsToDelete.push(itemRawId);
     }
   }
 

--- a/front/src/applications/operationalStudies/views/Scenario/components/RoundTrips/utils.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/RoundTrips/utils.ts
@@ -10,11 +10,7 @@ import type { OperationalPoint, TrainSchedule, RoundTrips } from 'common/api/osr
 import { isPacedTrainResponseWithPaced } from 'modules/timetableItem/helpers/pacedTrain';
 import type { TimetableItemWithPathOps } from 'reducers/osrdconf/types';
 import { addDurationToDate, Duration } from 'utils/duration';
-import {
-  extractEditoastIdFromPacedTrainId,
-  isPacedTrainId,
-  isTrainScheduleId,
-} from 'utils/trainId';
+import { extractEditoastIdFromPacedTrainId, isPacedTrainId } from 'utils/trainId';
 
 import type { PairingItem } from './types';
 
@@ -146,11 +142,6 @@ export const buildRoundTripsPayload = (pairingItems: PairingItem[], roundTrips: 
         initialStatus !== item.status &&
         !roundTripsIds.flat().includes(itemRawId)
       ) {
-        if (isTrainScheduleId(item.pairedItemId)) {
-          throw new Error(
-            'a paced train round trip item can only be paired with another paced train'
-          );
-        }
         const pairedItemRawId = extractEditoastIdFromPacedTrainId(item.pairedItemId);
         roundTripsIds.push([itemRawId, pairedItemRawId]);
       }

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
@@ -31,11 +31,7 @@ import {
   getTrainIdUsedForProjection,
 } from 'reducers/simulationResults/selectors';
 import { useAppDispatch } from 'store';
-import {
-  extractPacedTrainIdFromOccurrenceId,
-  isOccurrenceId,
-  isPacedTrainWithDetails,
-} from 'utils/trainId';
+import { extractPacedTrainIdFromOccurrenceId, isOccurrenceId } from 'utils/trainId';
 import { mapBy } from 'utils/types';
 
 import BoardWrapper from '../BoardWrapper';
@@ -143,7 +139,7 @@ const SimulationResults = ({
     );
     // WARNING TODO: race condition here, to fix
     // When turning a train into a service, then pacedTrain and selectedTrainId may be desynchronized.
-    if (!pacedTrain || !isPacedTrainWithDetails(pacedTrain) || !pacedTrain.paced) return undefined;
+    if (!pacedTrain || !pacedTrain.paced) return undefined;
 
     const exception = findExceptionWithOccurrenceId(pacedTrain.paced.exceptions, selectedTrainId);
     return exception?.summary ?? pacedTrain.summary;

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/CalendarTrainList.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/CalendarTrainList.tsx
@@ -19,7 +19,6 @@ import {
 } from 'reducers/simulationResults/selectors';
 import { useAppDispatch } from 'store';
 import { useDateTimeLocale } from 'utils/date';
-import { isPacedTrainWithDetails } from 'utils/trainId';
 
 import PacedTrainItem from './PacedTrain/PacedTrainItem';
 import TrainScheduleItem from './TrainScheduleItem';
@@ -123,16 +122,12 @@ const CalendarTrainList = ({
       occurrenceId?: OccurrenceId
     ) => {
       dispatch(selectTrainToEdit({ item: itemToEdit, isOccurrence: !!occurrenceId }));
-      const editData = isPacedTrainWithDetails(itemToEdit)
-        ? {
-            timetableItemId: itemToEdit.id,
-            // param originalPacedTrain is defined only when editing an occurrence
-            originalPacedTrain: originalPacedTrain ?? itemToEdit,
-            occurrenceId,
-          }
-        : {
-            timetableItemId: itemToEdit.id,
-          };
+      const editData = {
+        timetableItemId: itemToEdit.id,
+        // param originalPacedTrain is defined only when editing an occurrence
+        originalPacedTrain: originalPacedTrain ?? itemToEdit,
+        occurrenceId,
+      };
       setTimetableItemToEditData(editData);
       setDisplayTimetableItemManagement(MANAGE_TIMETABLE_ITEM_TYPES.edit);
     },

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/CalendarTrainList.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/CalendarTrainList.tsx
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux';
 
 import { useScenarioContext } from 'applications/operationalStudies/hooks/useScenarioContext';
 import { useSubCategoryContext } from 'common/SubCategoryContext';
-import { isPacedTrainWithPacedWithDetails } from 'modules/timetableItem/helpers/pacedTrain';
+import { isPacedTrainWithDetails } from 'modules/timetableItem/helpers/pacedTrain';
 import type { PacedTrainWithDetails, TimetableItemWithDetails } from 'modules/timetableItem/types';
 import { selectTrainToEdit } from 'reducers/osrdconf/operationalStudiesConf';
 import type {
@@ -142,7 +142,7 @@ const CalendarTrainList = ({
           {timetableMode === 'calendar' && showDepartureDates[index] && (
             <div className="scenario-timetable-departure-date">{currentDepartureDates[index]}</div>
           )}
-          {!isPacedTrainWithPacedWithDetails(timetableItem) ? (
+          {!isPacedTrainWithDetails(timetableItem) ? (
             <TrainScheduleItem
               isInSelection={selectedTimetableItemIds.includes(timetableItem.id)}
               handleSelectTrain={handleSelectTimetableItem}

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/PacedTrainItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/PacedTrainItem.tsx
@@ -46,7 +46,6 @@ import {
   formatEditoastIdToPacedTrainId,
   extractEditoastIdFromPacedTrainId,
   extractPacedTrainIdFromOccurrenceId,
-  isTrainScheduleId,
   isPacedTrainId,
   formatPacedTrainIdToOccurrenceId,
 } from 'utils/trainId';
@@ -109,7 +108,7 @@ const PacedTrainItem = ({
   const trainIdUsedForProjection = useSelector(getTrainIdUsedForProjection);
 
   const { showPacedTrainProjectionIcon, pathUsedForProjectionIsException } = useMemo(() => {
-    if (!trainIdUsedForProjection || isTrainScheduleId(trainIdUsedForProjection))
+    if (!trainIdUsedForProjection)
       return { showPacedTrainProjectionIcon: false, pathUsedForProjectionIsException: false };
     if (isPacedTrainId(trainIdUsedForProjection))
       return {

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/PacedTrainItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/PacedTrainItem.tsx
@@ -31,9 +31,8 @@ import type { PacedTrainWithPacedWithDetails } from 'modules/timetableItem/types
 import { setFailure, setSuccess } from 'reducers/main';
 import type {
   PacedTrainId,
-  PacedTrainWithPacedTrainId,
-  TimetableItemId,
   TimetableItem,
+  TimetableItemId,
   TrainId,
   OccurrenceId,
 } from 'reducers/osrdconf/types';
@@ -223,7 +222,7 @@ const PacedTrainItem = ({
       return;
     }
 
-    const formattedPacedTrainResponse: PacedTrainWithPacedTrainId = {
+    const formattedPacedTrainResponse: TimetableItem = {
       ...pacedTrainResult,
       id: formatEditoastIdToPacedTrainId(pacedTrainResult.id),
     };

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TimetableBoardWrapper.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TimetableBoardWrapper.tsx
@@ -11,7 +11,6 @@ import { deletePacedTrains } from 'modules/timetableItem/helpers/updateTimetable
 import type { TimetableItemWithDetails } from 'modules/timetableItem/types';
 import { setFailure, setSuccess } from 'reducers/main';
 import type {
-  PacedTrainId,
   TimetableItem,
   TimetableItemId,
   TimetableItemToEditData,
@@ -91,7 +90,7 @@ const TimetableBoardWrapper = ({
       },
       { selectedTrainScheduleIds: [], selectedPacedTrainIds: [] } as {
         selectedTrainScheduleIds: TimetableItemId[];
-        selectedPacedTrainIds: PacedTrainId[];
+        selectedPacedTrainIds: TimetableItemId[];
       }
     );
   }, [selectedTimetableItemIds]);

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TimetableBoardWrapper.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TimetableBoardWrapper.tsx
@@ -16,17 +16,11 @@ import type {
   TimetableItemId,
   TimetableItemToEditData,
   TrainId,
-  TrainScheduleId,
 } from 'reducers/osrdconf/types';
 import { updateSelectedTrainId } from 'reducers/simulationResults';
 import { getSelectedTrainId } from 'reducers/simulationResults/selectors';
 import { useAppDispatch } from 'store';
 import { castErrorToFailure } from 'utils/error';
-import {
-  isPacedTrainResponseWithPacedTrainId,
-  isPacedTrainWithDetails,
-  isTrainScheduleId,
-} from 'utils/trainId';
 import { mapBy } from 'utils/types';
 
 import Timetable from './Timetable';
@@ -73,7 +67,7 @@ const TimetableBoardWrapper = ({
     () =>
       timetableItems.reduce(
         (acc, timetableItem) => {
-          if (!isPacedTrainResponseWithPacedTrainId(timetableItem) || !timetableItem.paced) {
+          if (!timetableItem.paced) {
             acc.totalTrainScheduleCount += 1;
           } else {
             acc.totalPacedTrainCount += 1;
@@ -89,16 +83,10 @@ const TimetableBoardWrapper = ({
     const timetableItemsById = mapBy(timetableItemsWithDetails, 'id');
     return selectedTimetableItemIds.reduce(
       (acc, timetableItemId) => {
-        if (isTrainScheduleId(timetableItemId)) {
-          acc.selectedTrainScheduleIds.push(timetableItemId);
-        } else {
-          const pacedTrain = timetableItemsById.get(timetableItemId);
-          if (!pacedTrain || !isPacedTrainWithDetails(pacedTrain)) {
-            throw new Error(`TimetableItem ${timetableItemId} should be a pacedTrain`);
-          }
-          if (!pacedTrain.paced) acc.selectedTrainScheduleIds.push(timetableItemId);
-          else acc.selectedPacedTrainIds.push(timetableItemId);
-        }
+        const pacedTrain = timetableItemsById.get(timetableItemId);
+        if (!pacedTrain) throw new Error(`No timetableItem found for id ${timetableItemId}`);
+        if (!pacedTrain.paced) acc.selectedTrainScheduleIds.push(timetableItemId);
+        else acc.selectedPacedTrainIds.push(timetableItemId);
         return acc;
       },
       { selectedTrainScheduleIds: [], selectedPacedTrainIds: [] } as {
@@ -171,9 +159,7 @@ const TimetableBoardWrapper = ({
     const isSelectedTimetableItemInSelection =
       currentSelectedTrainId !== undefined &&
       selectedTimetableItemIds.some((timetableItemId) =>
-        isTrainScheduleId(timetableItemId)
-          ? timetableItemId === currentSelectedTrainId
-          : currentSelectedTrainId.includes(timetableItemId)
+        currentSelectedTrainId.includes(timetableItemId)
       );
 
     if (isSelectedTimetableItemInSelection) {
@@ -182,19 +168,9 @@ const TimetableBoardWrapper = ({
       dispatch(updateSelectedTrainId(undefined));
     }
 
-    const trainScheduleIds: TrainScheduleId[] = [];
-    const pacedTrainIds: PacedTrainId[] = [];
-    for (const id of selectedTimetableItemIds) {
-      if (isTrainScheduleId(id)) trainScheduleIds.push(id);
-      else pacedTrainIds.push(id);
-    }
-
     try {
-      if (trainScheduleIds.length > 0) {
-        throw new Error('TrainSchedules are not handled anymore.');
-      }
-      if (pacedTrainIds.length > 0) {
-        await deletePacedTrains(dispatch, pacedTrainIds);
+      if (selectedTimetableItemIds.length > 0) {
+        await deletePacedTrains(dispatch, selectedTimetableItemIds);
       }
 
       removeAndUnselectTrains(selectedTimetableItemIds);

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TrainScheduleItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TrainScheduleItem.tsx
@@ -29,11 +29,7 @@ import { useAppDispatch } from 'store';
 import { timeToLocaleStringRounded, useDateTimeLocale } from 'utils/date';
 import { addDurationToDate, Duration } from 'utils/duration';
 import { castErrorToFailure } from 'utils/error';
-import {
-  extractEditoastIdFromPacedTrainId,
-  formatEditoastIdToPacedTrainId,
-  isTrainScheduleId,
-} from 'utils/trainId';
+import { extractEditoastIdFromPacedTrainId, formatEditoastIdToPacedTrainId } from 'utils/trainId';
 
 import ArrivalTimeLoader from './ArrivalTimeLoader';
 import { TIMETABLE_ITEM_DELTA } from './consts';
@@ -83,10 +79,6 @@ const TrainScheduleItem = ({
   };
 
   const deleteTrain = async () => {
-    if (isTrainScheduleId(train.id)) {
-      throw new Error('TrainSchedules are not handled anymore');
-    }
-
     deletePacedTrains(dispatch, [train.id])
       .then(() => {
         removeTrains([train.id]);
@@ -108,10 +100,6 @@ const TrainScheduleItem = ({
 
   const duplicateTrain = async () => {
     const trainName = `${train.name} (${t('timetable.copy')})`;
-
-    if (isTrainScheduleId(train.id)) {
-      throw new Error('TrainSchedules are not handled anymore');
-    }
 
     try {
       const editoastTrainId = extractEditoastIdFromPacedTrainId(train.id);

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TrainScheduleItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TrainScheduleItem.tsx
@@ -14,12 +14,7 @@ import isMainCategory from 'modules/rollingStock/helpers/category';
 import { deletePacedTrains } from 'modules/timetableItem/helpers/updateTimetableItemHelpers';
 import type { TimetableItemWithDetails } from 'modules/timetableItem/types';
 import { setFailure, setSuccess } from 'reducers/main';
-import type {
-  PacedTrainWithPacedTrainId,
-  TimetableItem,
-  TimetableItemId,
-  TrainId,
-} from 'reducers/osrdconf/types';
+import type { TimetableItem, TimetableItemId, TrainId } from 'reducers/osrdconf/types';
 import {
   updateTrainIdUsedForProjection,
   updateSelectedTrainId,
@@ -122,7 +117,7 @@ const TrainScheduleItem = ({
         id: trainDetail.timetable_id,
         body: [newTrain],
       }).unwrap();
-      const formattedTrainScheduleResponse: PacedTrainWithPacedTrainId = {
+      const formattedTrainScheduleResponse: TimetableItem = {
         ...newTimetableItem,
         id: formatEditoastIdToPacedTrainId(newTimetableItem.id),
       };

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/useFilterTimetableItems.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/useFilterTimetableItems.ts
@@ -4,7 +4,7 @@ import { uniq } from 'lodash';
 
 import { useRollingStockContext } from 'common/RollingStockContext';
 import isMainCategory from 'modules/rollingStock/helpers/category';
-import { isPacedTrainWithPacedWithDetails } from 'modules/timetableItem/helpers/pacedTrain';
+import { isPacedTrainWithDetails } from 'modules/timetableItem/helpers/pacedTrain';
 import type { TimetableItemWithDetails } from 'modules/timetableItem/types';
 import { useDebounce } from 'utils/helpers';
 
@@ -43,7 +43,7 @@ const useFilterTimetableItems = (
     () =>
       uniq(
         timetableItems.reduce<string[]>((acc, timetableItem) => {
-          if (isPacedTrainWithPacedWithDetails(timetableItem)) {
+          if (isPacedTrainWithDetails(timetableItem)) {
             timetableItem.paced.exceptions.forEach((exception) => {
               if (exception.speed_limit_tag) {
                 acc.push(extractTagCode(exception.speed_limit_tag.value));
@@ -149,7 +149,7 @@ const useFilterTimetableItems = (
   const filteredTimetableItems: TimetableItemWithDetails[] = useMemo(
     () =>
       timetableItems.filter((timetableItem) => {
-        if (!isPacedTrainWithPacedWithDetails(timetableItem)) {
+        if (!isPacedTrainWithDetails(timetableItem)) {
           if (trainTypeFilter === 'pacedTrain') return false;
           return filterTimetableItem(timetableItem);
         }

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/utils.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/utils.ts
@@ -14,10 +14,7 @@ import isMainCategory from 'modules/rollingStock/helpers/category';
 import type { SimulationSummary, TimetableItemWithDetails } from 'modules/timetableItem/types';
 import type { TimetableItem, TimetableItemId } from 'reducers/osrdconf/types';
 import type { Duration } from 'utils/duration';
-import {
-  extractEditoastIdFromPacedTrainId,
-  isPacedTrainResponseWithPacedTrainId,
-} from 'utils/trainId';
+import { extractEditoastIdFromPacedTrainId } from 'utils/trainId';
 
 import { specialCodeDictionary, TRAIN_MAIN_CATEGORY_CLASS } from './consts';
 
@@ -57,13 +54,9 @@ const formatTimetableItems = (
   const pacedTrains = timetableItems
     .filter(({ id }) => selectedTimeTableIdsFromClick.includes(id))
     .reduce<PacedTrain[]>((acc, timetableItem) => {
-      if (isPacedTrainResponseWithPacedTrainId(timetableItem)) {
-        const pacedTrainEditoastId = extractEditoastIdFromPacedTrainId(timetableItem.id);
-        pacedTrainIndexByEditoastId.set(pacedTrainEditoastId, acc.length);
-        acc.push(omit(timetableItem, ['id']));
-      } else {
-        throw new Error('TrainSchedules are not handled anymore');
-      }
+      const pacedTrainEditoastId = extractEditoastIdFromPacedTrainId(timetableItem.id);
+      pacedTrainIndexByEditoastId.set(pacedTrainEditoastId, acc.length);
+      acc.push(omit(timetableItem, ['id']));
       return acc;
     }, []);
 

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/utils.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/utils.ts
@@ -6,7 +6,6 @@ import type {
   PacedTrain,
   SubCategory,
   TrainMainCategory,
-  TrainSchedule,
   RoundTrips,
   TrainScheduleSet,
 } from 'common/api/osrdEditoastApi';
@@ -45,7 +44,7 @@ export const timetableHasInvalidItem = (timetableItems: TimetableItemWithDetails
 export const formatTrainDuration = (duration: Duration) =>
   dayjs.duration(duration.ms).format('HH[h]mm');
 
-const formatTimetableItems = (
+const formatTimetableItemsForExport = (
   timetableItems: TimetableItem[],
   selectedTimeTableIdsFromClick: TimetableItemId[]
 ) => {
@@ -61,7 +60,7 @@ const formatTimetableItems = (
     }, []);
 
   return {
-    formattedTimetableItems: { train_schedules: [], paced_trains: pacedTrains },
+    formattedTimetableItems: pacedTrains,
     pacedTrainIndexByEditoastId,
   };
 };
@@ -70,11 +69,11 @@ export const copyTimetableItemsToClipboard = async (
   selectedTimeTableIdsFromClick: TimetableItemId[],
   timetableItems: TimetableItem[]
 ) => {
-  const { formattedTimetableItems } = formatTimetableItems(
+  const { formattedTimetableItems } = formatTimetableItemsForExport(
     timetableItems,
     selectedTimeTableIdsFromClick
   );
-  const jsonString = JSON.stringify(formattedTimetableItems);
+  const jsonString = JSON.stringify({ pacedTrains: formattedTimetableItems });
   const blob = new Blob([jsonString], { type: 'text/plain' });
   const clipboardItem = new ClipboardItem({ [blob.type]: blob });
   await navigator.clipboard.write([clipboardItem]);
@@ -123,8 +122,7 @@ function mapRoundTripsToIndexes(
 }
 
 type TimetableExportPayload = {
-  train_schedules: TrainSchedule[];
-  paced_trains: PacedTrain[];
+  trains: PacedTrain[];
   round_trips?: RoundTripsFromJson;
 };
 
@@ -133,7 +131,7 @@ export const buildTimetableExportPayload = (
   selectedTimeTableIdsFromClick: TimetableItemId[],
   pacedTrainRoundTrips?: RoundTrips
 ): TimetableExportPayload => {
-  const { formattedTimetableItems, pacedTrainIndexByEditoastId } = formatTimetableItems(
+  const { formattedTimetableItems, pacedTrainIndexByEditoastId } = formatTimetableItemsForExport(
     timetableItems,
     selectedTimeTableIdsFromClick
   );
@@ -144,10 +142,10 @@ export const buildTimetableExportPayload = (
   };
 
   if (roundTrips.train_schedules.length === 0 && roundTrips.paced_trains.length === 0) {
-    return formattedTimetableItems;
+    return { trains: formattedTimetableItems };
   }
 
-  return { ...formattedTimetableItems, round_trips: roundTrips };
+  return { trains: formattedTimetableItems, round_trips: roundTrips };
 };
 
 export const exportTimetableItems = (

--- a/front/src/applications/stdcm/consts.ts
+++ b/front/src/applications/stdcm/consts.ts
@@ -1,4 +1,4 @@
-import { formatEditoastIdToTrainScheduleId } from 'utils/trainId';
+import { formatEditoastIdToPacedTrainId } from 'utils/trainId';
 
 import type { ConsistErrors } from './types';
 
@@ -12,7 +12,7 @@ export const STDCM_REQUEST_STATUS = Object.freeze({
   pending_additional: 'PENDING_ADDITIONAL',
 });
 
-export const STDCM_TRAIN_ID = -10;
-export const STDCM_TRAIN_TIMETABLE_ID = formatEditoastIdToTrainScheduleId(STDCM_TRAIN_ID);
+const STDCM_TRAIN_ID = -10;
+export const STDCM_TRAIN_TIMETABLE_ID = formatEditoastIdToPacedTrainId(STDCM_TRAIN_ID);
 
 export const consistErrorFields: (keyof ConsistErrors)[] = ['totalMass', 'totalLength', 'maxSpeed'];

--- a/front/src/applications/stdcm/hooks/useStdcm.ts
+++ b/front/src/applications/stdcm/hooks/useStdcm.ts
@@ -5,11 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { v4 as uuidV4 } from 'uuid';
 
-import {
-  STDCM_REQUEST_STATUS,
-  STDCM_TRAIN_ID,
-  STDCM_TRAIN_TIMETABLE_ID,
-} from 'applications/stdcm/consts';
+import { STDCM_REQUEST_STATUS, STDCM_TRAIN_TIMETABLE_ID } from 'applications/stdcm/consts';
 import type {
   StdcmRequestStatus,
   StdcmSimulation,
@@ -30,7 +26,6 @@ import { updateSelectedTrainId } from 'reducers/simulationResults';
 import { useAppDispatch } from 'store';
 import { useDateTimeLocale } from 'utils/date';
 import { castErrorToFailure } from 'utils/error';
-import { formatEditoastIdToTrainScheduleId } from 'utils/trainId';
 
 import useStdcmForm from './useStdcmForm';
 import { adjustInputByDirection, adjustPayloadByDirection } from '../utils/adjustSimulationInputs';
@@ -101,7 +96,7 @@ const useStdcm = ({
         dispatch
       );
       const stdcmTrain: TimetableItem = {
-        id: formatEditoastIdToTrainScheduleId(STDCM_TRAIN_ID),
+        id: STDCM_TRAIN_TIMETABLE_ID,
         comfort: payload.body.comfort,
         constraint_distribution: 'MARECO',
         path: payload.body.steps.map((step) => ({ location: step.location, id: uuidV4() })),

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -5,7 +5,6 @@ import {
   extractEditoastIdFromPacedTrainId,
   extractPacedTrainIdFromOccurrenceId,
   isOccurrenceId,
-  isTrainScheduleId,
 } from 'utils/trainId';
 
 import {
@@ -57,56 +56,40 @@ const osrdEditoastApi = generatedEditoastApi
       }),
       getTimetableItemById: builder.query<TimetableItem, { id: TimetableItemId }>({
         queryFn: async ({ id: timetableItemId }, { dispatch }) => {
-          let data: TimetableItem;
-          if (isTrainScheduleId(timetableItemId)) {
-            throw new Error('TrainSchedules are not handled anymore.');
-          } else {
-            const pacedTrain = await dispatch(
-              generatedEditoastApi.endpoints.getPacedTrainById.initiate(
-                {
-                  id: extractEditoastIdFromPacedTrainId(timetableItemId),
-                },
-                { subscribe: false }
-              )
-            ).unwrap();
-            data = { ...pacedTrain, id: timetableItemId };
-          }
+          const pacedTrain = await dispatch(
+            generatedEditoastApi.endpoints.getPacedTrainById.initiate(
+              {
+                id: extractEditoastIdFromPacedTrainId(timetableItemId),
+              },
+              { subscribe: false }
+            )
+          ).unwrap();
+          const data: TimetableItem = { ...pacedTrain, id: timetableItemId };
           return { data };
         },
-        providesTags: (_result, _error, arg) => [
-          'timetable',
-          isTrainScheduleId(arg.id) ? 'train_schedule' : 'paced_train',
-        ],
+        providesTags: ['timetable', 'paced_train'],
       }),
       getTrainPath: builder.query<
         PathfindingResult,
         { id: TrainId; infraId: number; exceptionKey?: string }
       >({
         queryFn: async ({ id: trainId, infraId, exceptionKey }, { dispatch }) => {
-          let path: PathfindingResult;
-          if (isTrainScheduleId(trainId)) {
-            throw new Error('TrainSchedules are not handled anymore.');
-          } else {
-            const pacedTrainId = isOccurrenceId(trainId)
-              ? extractPacedTrainIdFromOccurrenceId(trainId)
-              : trainId;
-            path = await dispatch(
-              generatedEditoastApi.endpoints.getPacedTrainByIdPath.initiate(
-                {
-                  id: extractEditoastIdFromPacedTrainId(pacedTrainId),
-                  infraId,
-                  exceptionKey,
-                },
-                { subscribe: false }
-              )
-            ).unwrap();
-          }
+          const pacedTrainId = isOccurrenceId(trainId)
+            ? extractPacedTrainIdFromOccurrenceId(trainId)
+            : trainId;
+          const path: PathfindingResult = await dispatch(
+            generatedEditoastApi.endpoints.getPacedTrainByIdPath.initiate(
+              {
+                id: extractEditoastIdFromPacedTrainId(pacedTrainId),
+                infraId,
+                exceptionKey,
+              },
+              { subscribe: false }
+            )
+          ).unwrap();
           return { data: path };
         },
-        providesTags: (_result, _error, arg) => [
-          'pathfinding',
-          isTrainScheduleId(arg.id) ? 'train_schedule' : 'paced_train',
-        ],
+        providesTags: ['pathfinding', 'paced_train'],
       }),
       getTrainSimulation: builder.query<
         SimulationResponse,
@@ -116,30 +99,23 @@ const osrdEditoastApi = generatedEditoastApi
           { id: trainId, infraId, electricalProfileSetId, exceptionKey },
           { dispatch }
         ) => {
-          let simulation: SimulationResponse;
-          if (isTrainScheduleId(trainId)) {
-            throw new Error('TrainSchedules are not handled anymore.');
-          } else {
-            const pacedTrainId = isOccurrenceId(trainId)
-              ? extractPacedTrainIdFromOccurrenceId(trainId)
-              : trainId;
-            simulation = await dispatch(
-              generatedEditoastApi.endpoints.getPacedTrainByIdSimulation.initiate(
-                {
-                  id: extractEditoastIdFromPacedTrainId(pacedTrainId),
-                  infraId,
-                  electricalProfileSetId,
-                  exceptionKey,
-                },
-                { subscribe: false }
-              )
-            ).unwrap();
-          }
+          const pacedTrainId = isOccurrenceId(trainId)
+            ? extractPacedTrainIdFromOccurrenceId(trainId)
+            : trainId;
+          const simulation = await dispatch(
+            generatedEditoastApi.endpoints.getPacedTrainByIdSimulation.initiate(
+              {
+                id: extractEditoastIdFromPacedTrainId(pacedTrainId),
+                infraId,
+                electricalProfileSetId,
+                exceptionKey,
+              },
+              { subscribe: false }
+            )
+          ).unwrap();
           return { data: simulation };
         },
-        providesTags: (_result, _error, arg) => [
-          isTrainScheduleId(arg.id) ? 'train_schedule' : 'paced_train',
-        ],
+        providesTags: ['paced_train'],
       }),
       getEtcsBrakingCurves: builder.query<
         CoreEtcsBrakingCurvesResponse,
@@ -149,30 +125,23 @@ const osrdEditoastApi = generatedEditoastApi
           { id: trainId, infraId, electricalProfileSetId, exceptionKey },
           { dispatch }
         ) => {
-          let etcsBrakingCurves: CoreEtcsBrakingCurvesResponse;
-          if (isTrainScheduleId(trainId)) {
-            throw new Error('TrainSchedules are not handled anymore.');
-          } else {
-            const pacedTrainId = isOccurrenceId(trainId)
-              ? extractPacedTrainIdFromOccurrenceId(trainId)
-              : trainId;
-            etcsBrakingCurves = await dispatch(
-              generatedEditoastApi.endpoints.getPacedTrainByIdEtcsBrakingCurves.initiate(
-                {
-                  id: extractEditoastIdFromPacedTrainId(pacedTrainId),
-                  infraId,
-                  electricalProfileSetId,
-                  exceptionKey,
-                },
-                { subscribe: false }
-              )
-            ).unwrap();
-          }
+          const pacedTrainId = isOccurrenceId(trainId)
+            ? extractPacedTrainIdFromOccurrenceId(trainId)
+            : trainId;
+          const etcsBrakingCurves = await dispatch(
+            generatedEditoastApi.endpoints.getPacedTrainByIdEtcsBrakingCurves.initiate(
+              {
+                id: extractEditoastIdFromPacedTrainId(pacedTrainId),
+                infraId,
+                electricalProfileSetId,
+                exceptionKey,
+              },
+              { subscribe: false }
+            )
+          ).unwrap();
           return { data: etcsBrakingCurves };
         },
-        providesTags: (_result, _error, arg) => [
-          isTrainScheduleId(arg.id) ? 'train_schedule' : 'paced_train',
-        ],
+        providesTags: ['paced_train'],
       }),
       matchAllOperationalPoints: builder.query<
         RelatedOperationalPoint[][],

--- a/front/src/modules/conflict/hooks/useConflictsFilter.ts
+++ b/front/src/modules/conflict/hooks/useConflictsFilter.ts
@@ -6,7 +6,7 @@ import type { Conflict } from 'common/api/osrdEditoastApi';
 import computeOccurrenceName from 'modules/timetableItem/helpers/computeOccurrenceName';
 import {
   findExceptionWithOccurrenceId,
-  isPacedTrainResponseWithPaced,
+  isPacedTrain,
 } from 'modules/timetableItem/helpers/pacedTrain';
 import type { TimetableItem, TimetableItemId } from 'reducers/osrdconf/types';
 import { getSelectedTrainId } from 'reducers/simulationResults/selectors';
@@ -43,11 +43,7 @@ const useConflictsFilter = (timetableItems: TimetableItem[], conflicts: Conflict
       : selectedTrainId;
     const selectedTrain = timetableItemById.get(timetableItemId);
 
-    if (
-      !selectedTrain ||
-      !isOccurrenceId(selectedTrainId) ||
-      !isPacedTrainResponseWithPaced(selectedTrain)
-    )
+    if (!selectedTrain || !isOccurrenceId(selectedTrainId) || !isPacedTrain(selectedTrain))
       return selectedTrain?.train_name || null;
 
     // Occurrence with a name change group

--- a/front/src/modules/conflict/utils.ts
+++ b/front/src/modules/conflict/utils.ts
@@ -1,6 +1,6 @@
 import type { Conflict, TrainCategory } from 'common/api/osrdEditoastApi';
 import computeOccurrenceName from 'modules/timetableItem/helpers/computeOccurrenceName';
-import { isPacedTrainWithPaced } from 'modules/timetableItem/helpers/pacedTrain';
+import { isPacedTrainBase } from 'modules/timetableItem/helpers/pacedTrain';
 import type { TimetableItem, TimetableItemId, TrainId } from 'reducers/osrdconf/types';
 import { formatEditoastIdToPacedTrainId } from 'utils/trainId';
 
@@ -24,7 +24,7 @@ function getConflictTrainNames(
       return;
     }
 
-    if (!isPacedTrainWithPaced(pacedTrain))
+    if (!isPacedTrainBase(pacedTrain))
       throw new Error(`Train with id ${train.id} should be a paced train`);
 
     if (train.type === 'modified') {

--- a/front/src/modules/conflict/utils.ts
+++ b/front/src/modules/conflict/utils.ts
@@ -2,10 +2,7 @@ import type { Conflict, TrainCategory } from 'common/api/osrdEditoastApi';
 import computeOccurrenceName from 'modules/timetableItem/helpers/computeOccurrenceName';
 import { isPacedTrainWithPaced } from 'modules/timetableItem/helpers/pacedTrain';
 import type { TimetableItem, TimetableItemId, TrainId } from 'reducers/osrdconf/types';
-import {
-  formatEditoastIdToPacedTrainId,
-  isPacedTrainResponseWithPacedTrainId,
-} from 'utils/trainId';
+import { formatEditoastIdToPacedTrainId } from 'utils/trainId';
 
 import type { ConflictWithTrainNames } from './types';
 
@@ -17,9 +14,6 @@ function getConflictTrainNames(
   conflict.train_ids.forEach((train) => {
     const pacedTrain = trainMap.get(formatEditoastIdToPacedTrainId(train.id));
     if (!pacedTrain) return;
-
-    if (!isPacedTrainResponseWithPacedTrainId(pacedTrain))
-      throw new Error(`Train with id ${train.id} is an old trainSchedule`);
 
     if (train.type === 'base') {
       trainNames.push(

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
@@ -34,7 +34,7 @@ import type {
   WaypointsPanelData,
   DraggingState,
 } from 'modules/simulationResult/types';
-import { isPacedTrainWithPacedWithDetails } from 'modules/timetableItem/helpers/pacedTrain';
+import { isPacedTrainWithDetails } from 'modules/timetableItem/helpers/pacedTrain';
 import type { TimetableItemWithDetails } from 'modules/timetableItem/types';
 import type {
   OccurrenceId,
@@ -157,7 +157,7 @@ const SpaceTimeChartWrapper = ({
 
     if (
       timetableItemUsedForProjectionWithDetails &&
-      isPacedTrainWithPacedWithDetails(timetableItemUsedForProjectionWithDetails) &&
+      isPacedTrainWithDetails(timetableItemUsedForProjectionWithDetails) &&
       isOccurrenceId(selectedProjectionId)
     ) {
       const exceptionUsedForProjection =

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/__tests__/utils.spec.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/__tests__/utils.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-import { formatEditoastIdToTrainScheduleId } from 'utils/trainId';
+import { formatEditoastIdToPacedTrainId } from 'utils/trainId';
 
 import { cutSpaceTimeRect, batchFetchTrackOccupancy } from '../utils';
 
@@ -96,7 +96,7 @@ describe('batchFetch', () => {
     const fetchSpy = vi.fn().mockResolvedValueOnce(['a', 'b']).mockResolvedValueOnce(['c', 'd']);
 
     const onComplete = vi.fn();
-    batchFetchTrackOccupancy([1, 2, 3, 4].map(formatEditoastIdToTrainScheduleId), fetchSpy, {
+    batchFetchTrackOccupancy([1, 2, 3, 4].map(formatEditoastIdToPacedTrainId), fetchSpy, {
       batchSize: 2,
       onComplete,
     });
@@ -104,8 +104,8 @@ describe('batchFetch', () => {
     await vi.waitFor(() => expect(onComplete).toHaveBeenCalled());
 
     expect(fetchSpy).toHaveBeenCalledTimes(2);
-    expect(fetchSpy).toHaveBeenNthCalledWith(1, [1, 2].map(formatEditoastIdToTrainScheduleId));
-    expect(fetchSpy).toHaveBeenNthCalledWith(2, [3, 4].map(formatEditoastIdToTrainScheduleId));
+    expect(fetchSpy).toHaveBeenNthCalledWith(1, [1, 2].map(formatEditoastIdToPacedTrainId));
+    expect(fetchSpy).toHaveBeenNthCalledWith(2, [3, 4].map(formatEditoastIdToPacedTrainId));
     expect(onComplete).toHaveBeenCalledExactlyOnceWith(['a', 'b', 'c', 'd']);
   });
 
@@ -120,7 +120,7 @@ describe('batchFetch', () => {
     );
     const onComplete = vi.fn();
 
-    const ids = [1, 2, 3, 4].map(formatEditoastIdToTrainScheduleId);
+    const ids = [1, 2, 3, 4].map(formatEditoastIdToPacedTrainId);
     const abort = batchFetchTrackOccupancy(ids, fetchSpy, {
       batchSize: 2,
       onComplete,
@@ -144,7 +144,7 @@ describe('batchFetch', () => {
     const onProgress = vi.fn();
     const onComplete = vi.fn();
 
-    batchFetchTrackOccupancy([1, 2, 3, 4].map(formatEditoastIdToTrainScheduleId), fetchSpy, {
+    batchFetchTrackOccupancy([1, 2, 3, 4].map(formatEditoastIdToPacedTrainId), fetchSpy, {
       batchSize: 2,
       onProgress,
       onComplete,
@@ -165,7 +165,7 @@ describe('batchFetch', () => {
     const onError = vi.fn();
     const onComplete = vi.fn();
 
-    batchFetchTrackOccupancy([1, 2].map(formatEditoastIdToTrainScheduleId), fetchSpy, {
+    batchFetchTrackOccupancy([1, 2].map(formatEditoastIdToPacedTrainId), fetchSpy, {
       onError,
       onComplete,
     });

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/configureHandlePan.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/configureHandlePan.ts
@@ -16,7 +16,7 @@ import {
   isTrainId,
 } from 'utils/trainId';
 
-import { isIndividualOccurrenceProjection, isTrainScheduleProjection } from './utils';
+import { isIndividualOccurrenceProjection } from './utils';
 import type { IndividualTrainProjection, TrainSpaceTimeData } from '../../../types';
 
 type DraggingState =
@@ -91,7 +91,7 @@ export function configureHandlePan({
         const pacedTrain = projectPathTrainResult.find(
           ({ id }) => isPacedTrainId(id) && id === pacedTrainId
         );
-        if (pacedTrain && !isTrainScheduleProjection(pacedTrain) && pacedTrain.paced) {
+        if (pacedTrain?.paced) {
           newDepartureTime = subtractDurationFromDate(
             newDepartureTime,
             new Duration({ milliseconds: occurrencesIndex * pacedTrain.paced.interval.ms })

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/configureHandlePan.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/configureHandlePan.ts
@@ -12,7 +12,6 @@ import { Duration, subtractDurationFromDate } from 'utils/duration';
 import {
   extractOccurrenceIndexFromOccurrenceId,
   extractPacedTrainIdFromOccurrenceId,
-  isPacedTrainId,
   isTrainId,
 } from 'utils/trainId';
 
@@ -88,9 +87,7 @@ export function configureHandlePan({
       ) {
         const occurrencesIndex = extractOccurrenceIndexFromOccurrenceId(draggedTrain.id);
         const pacedTrainId = extractPacedTrainIdFromOccurrenceId(draggedTrain.id);
-        const pacedTrain = projectPathTrainResult.find(
-          ({ id }) => isPacedTrainId(id) && id === pacedTrainId
-        );
+        const pacedTrain = projectPathTrainResult.find(({ id }) => id === pacedTrainId);
         if (pacedTrain?.paced) {
           newDepartureTime = subtractDurationFromDate(
             newDepartureTime,

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/getPathStyle.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/getPathStyle.ts
@@ -8,7 +8,7 @@ import type { SubCategory } from 'common/api/osrdEditoastApi';
 import isMainCategory from 'modules/rollingStock/helpers/category';
 import {
   findExceptionWithOccurrenceId,
-  isPacedTrainWithPacedWithDetails,
+  isPacedTrainWithDetails,
 } from 'modules/timetableItem/helpers/pacedTrain';
 import type { SimulatedException, TimetableItemWithDetails } from 'modules/timetableItem/types';
 import type { TrainId } from 'reducers/osrdconf/types';
@@ -38,7 +38,7 @@ const getPathStyle = (
   const item = timetableItemsWithDetails?.find((t) => t.id === timetableItemId);
 
   let exception: SimulatedException | null = null;
-  if (item && isPacedTrainWithPacedWithDetails(item) && isOccurrenceId(train.id)) {
+  if (item && isPacedTrainWithDetails(item) && isOccurrenceId(train.id)) {
     exception = findExceptionWithOccurrenceId(item.paced.exceptions, train.id) ?? null;
   }
   const category = exception?.rolling_stock_category?.value ?? item?.category;

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/makeProjectedItems.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/makeProjectedItems.ts
@@ -13,15 +13,13 @@ import {
   extractEditoastIdFromPacedTrainId,
 } from 'utils/trainId';
 
-import { isTrainScheduleProjection } from './utils';
-
 /**
  * Turns trainSpaceTimeData (trainSchedules + pacedTrains) into individual train projection.
  * Extracts everything into one flat array.
  */
 const makeProjectedItems = (projectPathTrainResult: TrainSpaceTimeData[]) =>
   projectPathTrainResult.flatMap<IndividualTrainProjection>((projectedItem) => {
-    if (isTrainScheduleProjection(projectedItem) || !projectedItem.paced) {
+    if (!projectedItem.paced) {
       return projectedItem;
     }
 

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/utils.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/utils.ts
@@ -2,13 +2,8 @@ import type { Conflict, OccupancyBlock } from '@osrd-project/ui-charts';
 import { chunk, compact, noop, omit } from 'lodash';
 
 import { ASPECT_LABELS_COLORS } from 'modules/simulationResult/consts';
-import type {
-  OccurrenceId,
-  TimetableItem,
-  TimetableItemId,
-  TrainScheduleId,
-} from 'reducers/osrdconf/types';
-import { isOccurrenceId, isTrainScheduleId } from 'utils/trainId';
+import type { OccurrenceId, TimetableItem, TimetableItemId } from 'reducers/osrdconf/types';
+import { isOccurrenceId } from 'utils/trainId';
 
 import type { MovableOccupancyZone } from './zones';
 import type {
@@ -16,7 +11,6 @@ import type {
   IndividualTrainProjection,
   LayerRangeData,
   PathOperationalPoint,
-  TrainSpaceTimeData,
   WaypointsPanelData,
 } from '../../../types';
 
@@ -112,15 +106,6 @@ export function batchFetchTrackOccupancy(
 
   return handleAbort;
 }
-
-/**
- * Check if the given timetable item is a TrainScheduleProjection.
- * @param timetableItem - The timetable item to check.
- */
-export const isTrainScheduleProjection = (
-  timetableItem: TrainSpaceTimeData
-): timetableItem is Extract<TrainSpaceTimeData, { id: TrainScheduleId }> =>
-  isTrainScheduleId(timetableItem.id);
 
 export const isIndividualOccurrenceProjection = (
   trainProjection: IndividualTrainProjection

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useTrackOccupancy.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useTrackOccupancy.ts
@@ -22,11 +22,10 @@ import {
   formatPacedTrainIdToIndexedOccurrenceId,
   isOccurrenceId,
   isPacedTrainId,
-  isTrainScheduleId,
 } from 'utils/trainId';
 
 import type { PathOperationalPoint, TrainSpaceTimeData } from '../../types';
-import { batchFetchTrackOccupancy, isTrainScheduleProjection } from './helpers/utils';
+import { batchFetchTrackOccupancy } from './helpers/utils';
 import { getMovableOccupancyZone, type MovableOccupancyZone } from './helpers/zones';
 import { usePrevious } from '../../../../utils/hooks/state';
 
@@ -198,8 +197,6 @@ const useTrackOccupancy = ({
             const train = trainsCollection[pacedId];
 
             if (!train) throw new Error(`No train found for id ${pacedId}`);
-            if (isTrainScheduleProjection(train))
-              throw new Error(`TrainSchedule projection found for id ${pacedId}`);
 
             if (occupation.type === 'base') {
               zones.push(
@@ -420,10 +417,9 @@ const useTrackOccupancy = ({
         if (opState.selected) {
           forEach(opState.zones.data, (zone) => {
             if (
-              (isTrainScheduleId(zone.trainId) && zone.trainId === draggedTrainId) ||
-              (isOccurrenceId(zone.trainId) &&
-                extractPacedTrainIdFromOccurrenceId(zone.trainId) === draggedTimetableItemId &&
-                !zone.isStartTimeException)
+              isOccurrenceId(zone.trainId) &&
+              extractPacedTrainIdFromOccurrenceId(zone.trainId) === draggedTimetableItemId &&
+              !zone.isStartTimeException
             ) {
               impactedPathOperationalPointIDs.add(waypointId);
               const offset = newTrainData.departureTime.getTime() - initialDepartureTime.getTime();

--- a/front/src/modules/simulationResult/helpers/formatTimetableItemSummaries.ts
+++ b/front/src/modules/simulationResult/helpers/formatTimetableItemSummaries.ts
@@ -1,30 +1,16 @@
 import type {
   LightRollingStockWithLiveries,
   PacedTrainSimulationSummaryResult,
-  SimulationSummaryResult,
 } from 'common/api/osrdEditoastApi';
-import {
-  formatPacedTrainWithDetails,
-  formatTrainScheduleWithDetails,
-} from 'modules/timetableItem/helpers/formatTimetableItemWithDetails';
+import { formatPacedTrainWithDetails } from 'modules/timetableItem/helpers/formatTimetableItemWithDetails';
 import type { TimetableItemWithDetails } from 'modules/timetableItem/types';
-import type {
-  TimetableItemId,
-  TimetableItem,
-  TrainScheduleId,
-  PacedTrainId,
-} from 'reducers/osrdconf/types';
-import { isPacedTrainId, isPacedTrainResponseWithPacedTrainId } from 'utils/trainId';
+import type { TimetableItemId, TimetableItem, PacedTrainId } from 'reducers/osrdconf/types';
 import { mapBy } from 'utils/types';
 
-type SummaryWithCorrespondingTimetableItemId =
-  | { timetableItemId: TrainScheduleId; summary: SimulationSummaryResult }
-  | { timetableItemId: PacedTrainId; summary: PacedTrainSimulationSummaryResult };
-
-const isPacedTrainInputs = (
-  inputs: SummaryWithCorrespondingTimetableItemId
-): inputs is Extract<SummaryWithCorrespondingTimetableItemId, { timetableItemId: PacedTrainId }> =>
-  isPacedTrainId(inputs.timetableItemId);
+type SummaryWithCorrespondingTimetableItemId = {
+  timetableItemId: PacedTrainId;
+  summary: PacedTrainSimulationSummaryResult;
+};
 
 const formatTimetableItemWithDetails = (
   inputs: SummaryWithCorrespondingTimetableItemId,
@@ -36,14 +22,7 @@ const formatTimetableItemWithDetails = (
     throw new Error('Missing timetable item');
   }
   const rollingStock = rollingStocks.find((rs) => rs.name === timetableItem.rolling_stock_name);
-
-  if (isPacedTrainResponseWithPacedTrainId(timetableItem) && isPacedTrainInputs(inputs)) {
-    return formatPacedTrainWithDetails(timetableItem, rollingStock, inputs.summary);
-  }
-  if (isPacedTrainInputs(inputs) || isPacedTrainResponseWithPacedTrainId(timetableItem)) {
-    throw new Error('Mismatch between timetableItemId and timetableItem');
-  }
-  return formatTrainScheduleWithDetails(timetableItem, rollingStock, inputs.summary);
+  return formatPacedTrainWithDetails(timetableItem, rollingStock, inputs.summary);
 };
 
 /** Format the timetable items with their simulation summaries */

--- a/front/src/modules/simulationResult/types.ts
+++ b/front/src/modules/simulationResult/types.ts
@@ -15,7 +15,7 @@ import type {
   TrainSchedule,
 } from 'common/api/osrdEditoastApi';
 import type { PacedTrainWithDetails } from 'modules/timetableItem/types';
-import type { OccurrenceId, PacedTrainId, TrainScheduleId } from 'reducers/osrdconf/types';
+import type { OccurrenceId, PacedTrainId } from 'reducers/osrdconf/types';
 import type { ArrayElement } from 'utils/types';
 
 // This alias refers to an operational point, in the context of a given path, from Edistoast:
@@ -44,18 +44,13 @@ export type BaseTrainProjection = {
 };
 
 export type TrainSpaceTimeData = {
+  id: PacedTrainId;
   name: string;
   departureTime: Date;
-} & BaseTrainProjection &
-  (
-    | { id: TrainScheduleId }
-    | {
-        id: PacedTrainId;
-        paced?: PacedTrainWithDetails['paced'] & {
-          exceptionProjections: Map<string, BaseTrainProjection>;
-        };
-      }
-  );
+  paced?: PacedTrainWithDetails['paced'] & {
+    exceptionProjections: Map<string, BaseTrainProjection>;
+  };
+} & BaseTrainProjection;
 
 /** Contains an individual projection, either of a trainSchedule or an occurrence */
 export type IndividualTrainProjection = {
@@ -63,7 +58,7 @@ export type IndividualTrainProjection = {
   departureTime: Date;
 } & BaseTrainProjection &
   (
-    | { id: TrainScheduleId | PacedTrainId }
+    | { id: PacedTrainId }
     | {
         id: OccurrenceId;
         exception?: PacedTrainException;

--- a/front/src/modules/timetableItem/helpers/formatTimetableItemWithDetails.ts
+++ b/front/src/modules/timetableItem/helpers/formatTimetableItemWithDetails.ts
@@ -9,11 +9,7 @@ import type {
   SimulationSummary,
   TimetableItemWithDetails,
 } from 'modules/timetableItem/types';
-import type {
-  PacedTrainWithPacedTrainId,
-  TimetableItem,
-  TrainScheduleWithTrainId,
-} from 'reducers/osrdconf/types';
+import type { PacedTrainWithPacedTrainId, TimetableItem } from 'reducers/osrdconf/types';
 import { Duration } from 'utils/duration';
 import { jouleToKwh } from 'utils/physics';
 import { formatKmValue } from 'utils/strings';
@@ -70,28 +66,6 @@ const extractBaseTimetableItemProps = (timetableItem: TimetableItem) => ({
   speedLimitTag: timetableItem.speed_limit_tag ?? null,
   labels: timetableItem.labels ?? [],
 });
-
-export const formatTrainScheduleWithDetails = (
-  trainSchedule: TrainScheduleWithTrainId,
-  rollingStock?: LightRollingStockWithLiveries,
-  summary?: SimulationSummaryResult
-): TimetableItemWithDetails => {
-  // we omit the following props since they're not expected in TimetableItemWithDetails
-  const {
-    train_name: _,
-    start_time: __,
-    speed_limit_tag: ___,
-    rolling_stock_name: ____,
-    ...trainScheduleProps
-  } = trainSchedule;
-
-  return {
-    ...trainScheduleProps,
-    ...extractBaseTimetableItemProps(trainSchedule),
-    rollingStock,
-    summary: formatSummary(trainSchedule, summary),
-  };
-};
 
 export const formatPacedTrainWithDetails = (
   pacedTrain: PacedTrainWithPacedTrainId,

--- a/front/src/modules/timetableItem/helpers/formatTimetableItemWithDetails.ts
+++ b/front/src/modules/timetableItem/helpers/formatTimetableItemWithDetails.ts
@@ -9,7 +9,7 @@ import type {
   SimulationSummary,
   TimetableItemWithDetails,
 } from 'modules/timetableItem/types';
-import type { PacedTrainWithPacedTrainId, TimetableItem } from 'reducers/osrdconf/types';
+import type { TimetableItem } from 'reducers/osrdconf/types';
 import { Duration } from 'utils/duration';
 import { jouleToKwh } from 'utils/physics';
 import { formatKmValue } from 'utils/strings';
@@ -68,7 +68,7 @@ const extractBaseTimetableItemProps = (timetableItem: TimetableItem) => ({
 });
 
 export const formatPacedTrainWithDetails = (
-  pacedTrain: PacedTrainWithPacedTrainId,
+  pacedTrain: TimetableItem,
   rollingStock?: LightRollingStockWithLiveries,
   pacedTrainSummary?: PacedTrainSimulationSummaryResult
 ): TimetableItemWithDetails => {

--- a/front/src/modules/timetableItem/helpers/pacedTrain.ts
+++ b/front/src/modules/timetableItem/helpers/pacedTrain.ts
@@ -17,7 +17,6 @@ import {
   formatPacedTrainIdToExceptionId,
   formatPacedTrainIdToIndexedOccurrenceId,
   isIndexedOccurrenceId,
-  isPacedTrainWithDetails,
 } from 'utils/trainId';
 
 import type {
@@ -36,8 +35,7 @@ export const isPacedTrainResponseWithPaced = (
 
 export const isPacedTrainWithPacedWithDetails = (
   timetableItem: TimetableItemWithDetails
-): timetableItem is PacedTrainWithPacedWithDetails =>
-  isPacedTrainWithDetails(timetableItem) && !!timetableItem.paced;
+): timetableItem is PacedTrainWithPacedWithDetails => !!timetableItem.paced;
 
 export const getOccurrencesNb = ({
   timeWindow,

--- a/front/src/modules/timetableItem/helpers/pacedTrain.ts
+++ b/front/src/modules/timetableItem/helpers/pacedTrain.ts
@@ -29,7 +29,7 @@ import type {
 export const isPacedTrainBase = (pacedTrain: PacedTrain): pacedTrain is PacedTrainWithPaced =>
   !!pacedTrain.paced;
 
-export const isPacedTrainResponseWithPaced = (
+export const isPacedTrain = (
   timetableItem: TimetableItem
 ): timetableItem is PacedTrainResponseWithPaced => !!timetableItem.paced;
 
@@ -160,7 +160,7 @@ export const getExceptionFromOccurrenceId = (
 ) => {
   const pacedTrainId = extractPacedTrainIdFromOccurrenceId(occurrenceId);
   const pacedTrain = timetableItemsById.get(pacedTrainId);
-  if (!pacedTrain || !isPacedTrainResponseWithPaced(pacedTrain))
+  if (!pacedTrain || !isPacedTrain(pacedTrain))
     throw new Error(`No paced train found for id ${pacedTrainId}`);
 
   let exception: PacedTrainException | undefined;

--- a/front/src/modules/timetableItem/helpers/pacedTrain.ts
+++ b/front/src/modules/timetableItem/helpers/pacedTrain.ts
@@ -26,7 +26,7 @@ import type {
   TimetableItemWithDetails,
 } from '../types';
 
-export const isPacedTrainWithPaced = (pacedTrain: PacedTrain): pacedTrain is PacedTrainWithPaced =>
+export const isPacedTrainBase = (pacedTrain: PacedTrain): pacedTrain is PacedTrainWithPaced =>
   !!pacedTrain.paced;
 
 export const isPacedTrainResponseWithPaced = (

--- a/front/src/modules/timetableItem/helpers/pacedTrain.ts
+++ b/front/src/modules/timetableItem/helpers/pacedTrain.ts
@@ -33,7 +33,7 @@ export const isPacedTrain = (
   timetableItem: TimetableItem
 ): timetableItem is PacedTrainResponseWithPaced => !!timetableItem.paced;
 
-export const isPacedTrainWithPacedWithDetails = (
+export const isPacedTrainWithDetails = (
   timetableItem: TimetableItemWithDetails
 ): timetableItem is PacedTrainWithPacedWithDetails => !!timetableItem.paced;
 

--- a/front/src/modules/timetableItem/helpers/pacedTrain.ts
+++ b/front/src/modules/timetableItem/helpers/pacedTrain.ts
@@ -17,7 +17,6 @@ import {
   formatPacedTrainIdToExceptionId,
   formatPacedTrainIdToIndexedOccurrenceId,
   isIndexedOccurrenceId,
-  isPacedTrainResponseWithPacedTrainId,
   isPacedTrainWithDetails,
 } from 'utils/trainId';
 
@@ -33,8 +32,7 @@ export const isPacedTrainWithPaced = (pacedTrain: PacedTrain): pacedTrain is Pac
 
 export const isPacedTrainResponseWithPaced = (
   timetableItem: TimetableItem
-): timetableItem is PacedTrainResponseWithPaced =>
-  isPacedTrainResponseWithPacedTrainId(timetableItem) && !!timetableItem.paced;
+): timetableItem is PacedTrainResponseWithPaced => !!timetableItem.paced;
 
 export const isPacedTrainWithPacedWithDetails = (
   timetableItem: TimetableItemWithDetails

--- a/front/src/modules/timetableItem/helpers/updateTimetableItemHelpers.ts
+++ b/front/src/modules/timetableItem/helpers/updateTimetableItemHelpers.ts
@@ -14,7 +14,6 @@ import {
   extractEditoastIdFromPacedTrainId,
   formatEditoastIdToPacedTrainId,
   isPacedTrainId,
-  isTrainScheduleId,
 } from 'utils/trainId';
 
 import { getOcurrencesIds, isPacedTrainWithPaced } from './pacedTrain';
@@ -76,10 +75,6 @@ export async function storePacedTrain(
   dispatch: AppDispatch,
   upsertTimetableItems: (timetableItems: TimetableItem[]) => void
 ): Promise<PacedTrainWithPacedTrainId> {
-  if (isTrainScheduleId(timetableItemIdToUpdate)) {
-    throw new Error('TrainSchedules are not handled anymore.');
-  }
-
   if (isPacedTrainWithPaced(pacedTrain)) {
     dispatch(
       unsetTrainIdsMatchingMissingOccurencesOf({

--- a/front/src/modules/timetableItem/helpers/updateTimetableItemHelpers.ts
+++ b/front/src/modules/timetableItem/helpers/updateTimetableItemHelpers.ts
@@ -16,7 +16,7 @@ import {
   isPacedTrainId,
 } from 'utils/trainId';
 
-import { getOcurrencesIds, isPacedTrainWithPaced } from './pacedTrain';
+import { getOcurrencesIds, isPacedTrainBase } from './pacedTrain';
 
 export async function fetchTimetableItem(
   timetableItemId: TimetableItemId,
@@ -75,7 +75,7 @@ export async function storePacedTrain(
   dispatch: AppDispatch,
   upsertTimetableItems: (timetableItems: TimetableItem[]) => void
 ): Promise<PacedTrainWithPacedTrainId> {
-  if (isPacedTrainWithPaced(pacedTrain)) {
+  if (isPacedTrainBase(pacedTrain)) {
     dispatch(
       unsetTrainIdsMatchingMissingOccurencesOf({
         pacedTrainId: timetableItemIdToUpdate,

--- a/front/src/modules/timetableItem/helpers/updateTimetableItemHelpers.ts
+++ b/front/src/modules/timetableItem/helpers/updateTimetableItemHelpers.ts
@@ -1,10 +1,5 @@
 import { osrdEditoastApi, type PacedTrain } from 'common/api/osrdEditoastApi';
-import type {
-  PacedTrainId,
-  PacedTrainWithPacedTrainId,
-  TimetableItemId,
-  TimetableItem,
-} from 'reducers/osrdconf/types';
+import type { PacedTrainId, TimetableItem, TimetableItemId } from 'reducers/osrdconf/types';
 import {
   unsetTrainIdsMatching,
   unsetTrainIdsMatchingMissingOccurencesOf,
@@ -40,7 +35,7 @@ export async function createPacedTrain(
   dispatch: AppDispatch,
   timetableId: number,
   pacedTrain: PacedTrain
-): Promise<PacedTrainWithPacedTrainId> {
+): Promise<TimetableItem> {
   const newPacedTrains = await dispatch(
     osrdEditoastApi.endpoints.postTimetableByIdPacedTrains.initiate({
       id: timetableId,
@@ -74,7 +69,7 @@ export async function storePacedTrain(
   timetableId: number,
   dispatch: AppDispatch,
   upsertTimetableItems: (timetableItems: TimetableItem[]) => void
-): Promise<PacedTrainWithPacedTrainId> {
+): Promise<TimetableItem> {
   if (isPacedTrainBase(pacedTrain)) {
     dispatch(
       unsetTrainIdsMatchingMissingOccurencesOf({

--- a/front/src/modules/timetableItem/types.ts
+++ b/front/src/modules/timetableItem/types.ts
@@ -10,7 +10,7 @@ import type {
   SimulationSummaryResult,
   TrainScheduleResponse,
 } from 'common/api/osrdEditoastApi';
-import type { OccurrenceId, PacedTrainId, TrainScheduleId } from 'reducers/osrdconf/types';
+import type { OccurrenceId, PacedTrainId } from 'reducers/osrdconf/types';
 import type { Duration } from 'utils/duration';
 
 export type SuggestedOP = {
@@ -78,10 +78,6 @@ export type InvalidReason =
   | Extract<SimulationSummaryResult['status'], 'pathfinding_failure' | 'simulation_failed'>
   | CorePathfindingNotFound['error_type']
   | CorePathfindingInputError['error_type'];
-
-export type TrainScheduleWithDetails = TimetableItemWithSummaries & {
-  id: TrainScheduleId;
-};
 
 export type SimulatedException = PacedTrainException & { summary?: SimulationSummary };
 

--- a/front/src/modules/timetableItem/types.ts
+++ b/front/src/modules/timetableItem/types.ts
@@ -104,7 +104,7 @@ export type PacedTrainWithPacedWithDetails = TimetableItemWithSummaries & {
   };
 };
 
-export type TimetableItemWithDetails = TrainScheduleWithDetails | PacedTrainWithDetails;
+export type TimetableItemWithDetails = PacedTrainWithDetails;
 
 export type ExceptionChangeGroups = Omit<
   PacedTrainException,

--- a/front/src/reducers/osrdconf/operationalStudiesConf/__tests__/operationalStudiesConfReducer.spec.ts
+++ b/front/src/reducers/osrdconf/operationalStudiesConf/__tests__/operationalStudiesConfReducer.spec.ts
@@ -5,7 +5,6 @@ import type {
   PacedTrainWithDetails,
   SuggestedOP,
   TimetableItemWithSummaries,
-  TrainScheduleWithDetails,
 } from 'modules/timetableItem/types';
 import {
   operationalStudiesConfSlice,
@@ -13,12 +12,7 @@ import {
 } from 'reducers/osrdconf/operationalStudiesConf';
 import commonConfBuilder from 'reducers/osrdconf/osrdConfCommon/__tests__/commonConfBuilder';
 import testCommonConfReducers from 'reducers/osrdconf/osrdConfCommon/__tests__/utils';
-import type {
-  OperationalStudiesConfState,
-  PacedTrainId,
-  PathStep,
-  TrainScheduleId,
-} from 'reducers/osrdconf/types';
+import type { OperationalStudiesConfState, PacedTrainId, PathStep } from 'reducers/osrdconf/types';
 import { createStoreWithoutMiddleware } from 'store';
 import { Duration } from 'utils/duration';
 
@@ -63,53 +57,6 @@ describe('simulationConfReducer', () => {
   });
 
   describe('selectTrainToEdit', () => {
-    it('train schedule case', () => {
-      const trainSchedule: TrainScheduleWithDetails = {
-        ...baseTimetableItemWithSummary,
-        id: 'trainschedule_1' as TrainScheduleId,
-      };
-
-      const store = createStore();
-      store.dispatch(
-        operationalStudiesConfSlice.actions.selectTrainToEdit({ item: trainSchedule })
-      );
-
-      const state = store.getState()[operationalStudiesConfSlice.name];
-      expect(state).toEqual({
-        ...operationalStudiesInitialConf,
-        usingElectricalProfiles: false,
-        labels: ['label1'],
-        rollingStockID: 1,
-        speedLimitByTag: 'MA100',
-        name: 'train1',
-        pathSteps: [
-          {
-            id: 'id1',
-            location: {
-              operational_point: { uic: 123, type: 'uic' },
-            },
-            name: '123',
-            theoreticalMargin: '10%',
-            arrival: null,
-            stopFor: null,
-            receptionSignal: 'OPEN',
-          },
-          {
-            id: 'id2',
-            location: {
-              operational_point: { uic: 234, type: 'uic' },
-            },
-            name: '234',
-            theoreticalMargin: undefined,
-            arrival: null,
-            stopFor: null,
-            receptionSignal: 'OPEN',
-          },
-        ],
-        startTime: new Date('2021-01-01T00:00:00+00:00'),
-      });
-    });
-
     it('paced train case', () => {
       const pacedTrain: PacedTrainWithDetails = {
         ...baseTimetableItemWithSummary,

--- a/front/src/reducers/osrdconf/operationalStudiesConf/index.ts
+++ b/front/src/reducers/osrdconf/operationalStudiesConf/index.ts
@@ -3,11 +3,7 @@ import { v4 as uuidV4 } from 'uuid';
 
 import computeBasePathStep from 'modules/timetableItem/helpers/computeBasePathStep';
 import { isPacedTrainWithPacedWithDetails } from 'modules/timetableItem/helpers/pacedTrain';
-import type {
-  PacedTrainWithDetails,
-  SuggestedOP,
-  TrainScheduleWithDetails,
-} from 'modules/timetableItem/types';
+import type { SuggestedOP, TimetableItemWithDetails } from 'modules/timetableItem/types';
 import { buildMapStateReducer } from 'reducers/commonMap';
 import { defaultCommonConf, buildCommonConfReducers } from 'reducers/osrdconf/osrdConfCommon';
 import type { OperationalStudiesConfState } from 'reducers/osrdconf/types';
@@ -53,7 +49,7 @@ export const operationalStudiesConfSlice = createSlice({
     selectTrainToEdit(
       state: Draft<OperationalStudiesConfState>,
       action: PayloadAction<{
-        item: TrainScheduleWithDetails | PacedTrainWithDetails;
+        item: TimetableItemWithDetails;
         isOccurrence?: boolean;
       }>
     ) {

--- a/front/src/reducers/osrdconf/operationalStudiesConf/index.ts
+++ b/front/src/reducers/osrdconf/operationalStudiesConf/index.ts
@@ -2,7 +2,7 @@ import { createSlice, type Draft, type PayloadAction } from '@reduxjs/toolkit';
 import { v4 as uuidV4 } from 'uuid';
 
 import computeBasePathStep from 'modules/timetableItem/helpers/computeBasePathStep';
-import { isPacedTrainWithPacedWithDetails } from 'modules/timetableItem/helpers/pacedTrain';
+import { isPacedTrainWithDetails } from 'modules/timetableItem/helpers/pacedTrain';
 import type { SuggestedOP, TimetableItemWithDetails } from 'modules/timetableItem/types';
 import { buildMapStateReducer } from 'reducers/commonMap';
 import { defaultCommonConf, buildCommonConfReducers } from 'reducers/osrdconf/osrdConfCommon';
@@ -83,7 +83,7 @@ export const operationalStudiesConfSlice = createSlice({
       state.powerRestriction = power_restrictions || [];
       state.constraintDistribution = constraint_distribution || 'STANDARD';
 
-      if (isPacedTrainWithPacedWithDetails(action.payload.item)) {
+      if (isPacedTrainWithDetails(action.payload.item)) {
         state.editingItemType = action.payload.isOccurrence ? 'occurrence' : 'pacedTrain';
         state.timeWindow = action.payload.item.paced.timeWindow;
         state.interval = action.payload.item.paced.interval;

--- a/front/src/reducers/osrdconf/types.ts
+++ b/front/src/reducers/osrdconf/types.ts
@@ -204,17 +204,13 @@ export type OccurrenceId = IndexedOccurrenceId | AddedExceptionId;
  */
 export type PacedTrainId = string & { readonly __type: unique symbol };
 
-export type TrainId = TrainScheduleId | OccurrenceId | PacedTrainId;
-export type TimetableItemId = TrainScheduleId | PacedTrainId;
-export type TimetableItemToEditData =
-  | {
-      timetableItemId: TrainScheduleId;
-    }
-  | {
-      timetableItemId: PacedTrainId;
-      originalPacedTrain: PacedTrainWithDetails;
-      occurrenceId?: OccurrenceId;
-    };
+export type TrainId = OccurrenceId | PacedTrainId;
+export type TimetableItemId = PacedTrainId;
+export type TimetableItemToEditData = {
+  timetableItemId: PacedTrainId;
+  originalPacedTrain: PacedTrainWithDetails;
+  occurrenceId?: OccurrenceId;
+};
 
 export type TrainScheduleWithTrainId = TrainSchedule & {
   id: TrainScheduleId;
@@ -230,10 +226,7 @@ export type TrainBaseWithOccurrenceId = TrainSchedule & {
   id: OccurrenceId;
 };
 
-export type TimetableItem = TrainScheduleWithTrainId | PacedTrainWithPacedTrainId;
-export type Train =
-  | TrainScheduleWithTrainId
-  | TrainBaseWithPacedTrainId
-  | TrainBaseWithOccurrenceId;
+export type TimetableItem = PacedTrainWithPacedTrainId;
+export type Train = TrainBaseWithPacedTrainId | TrainBaseWithOccurrenceId;
 
 export type TimetableItemWithPathOps = TimetableItem & { pathOps: RelatedOperationalPoint[][] };

--- a/front/src/reducers/osrdconf/types.ts
+++ b/front/src/reducers/osrdconf/types.ts
@@ -212,7 +212,7 @@ export type TimetableItemToEditData = {
   occurrenceId?: OccurrenceId;
 };
 
-export type PacedTrainWithPacedTrainId = PacedTrain & {
+export type TimetableItem = PacedTrain & {
   id: PacedTrainId;
 };
 export type TrainBaseWithPacedTrainId = TrainSchedule & {
@@ -222,7 +222,6 @@ export type TrainBaseWithOccurrenceId = TrainSchedule & {
   id: OccurrenceId;
 };
 
-export type TimetableItem = PacedTrainWithPacedTrainId;
 export type Train = TrainBaseWithPacedTrainId | TrainBaseWithOccurrenceId;
 
 export type TimetableItemWithPathOps = TimetableItem & { pathOps: RelatedOperationalPoint[][] };

--- a/front/src/reducers/osrdconf/types.ts
+++ b/front/src/reducers/osrdconf/types.ts
@@ -212,10 +212,6 @@ export type TimetableItemToEditData = {
   occurrenceId?: OccurrenceId;
 };
 
-export type TrainScheduleWithTrainId = TrainSchedule & {
-  id: TrainScheduleId;
-};
-
 export type PacedTrainWithPacedTrainId = PacedTrain & {
   id: PacedTrainId;
 };

--- a/front/src/reducers/simulationResults/index.ts
+++ b/front/src/reducers/simulationResults/index.ts
@@ -28,7 +28,7 @@ export const simulationResultsSlice = createSlice({
     },
     updateTrainIdUsedForProjection(
       state: Draft<SimulationResultsState>,
-      action: PayloadAction<TrainScheduleId | PacedTrainId | OccurrenceId | undefined>
+      action: PayloadAction<TrainId | undefined>
     ) {
       state.trainIdUsedForProjection = action.payload;
     },
@@ -38,15 +38,11 @@ export const simulationResultsSlice = createSlice({
     ) {
       state.projectionType = action.payload;
     },
-    unsetTrainIdsMatching(
-      state: Draft<SimulationResultsState>,
-      action: PayloadAction<TrainScheduleId | PacedTrainId | OccurrenceId>
-    ) {
+    unsetTrainIdsMatching(state: Draft<SimulationResultsState>, action: PayloadAction<TrainId>) {
       const idToUnset = action.payload;
 
-      const isIdMatchingOccurence = (
-        id: TrainScheduleId | OccurrenceId | PacedTrainId | undefined
-      ) => id && isOccurrenceId(id) && extractPacedTrainIdFromOccurrenceId(id) === idToUnset;
+      const isIdMatchingOccurence = (id: TrainId | undefined) =>
+        id && isOccurrenceId(id) && extractPacedTrainIdFromOccurrenceId(id) === idToUnset;
 
       if (
         state.trainIdUsedForProjection === idToUnset ||

--- a/front/src/reducers/simulationResults/simulationResultsReducer.spec.ts
+++ b/front/src/reducers/simulationResults/simulationResultsReducer.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import type { OccurrenceId, PacedTrainId, TrainScheduleId } from 'reducers/osrdconf/types';
+import type { OccurrenceId, PacedTrainId } from 'reducers/osrdconf/types';
 import { createStoreWithoutMiddleware } from 'store';
 
 import {
@@ -26,12 +26,12 @@ describe('simulationResultsReducer', () => {
     expect(state).toEqual(simulationResultsInitialState);
   });
 
-  it('should handle updateSelectedTrainId with a train schedule', () => {
+  it('should handle updateSelectedTrainId with a paced train', () => {
     const store = createStore();
-    store.dispatch(updateSelectedTrainId('trainschedule-1' as TrainScheduleId));
+    store.dispatch(updateSelectedTrainId('paced_1' as PacedTrainId));
 
     const state = store.getState()[simulationResultsSlice.name];
-    expect(state.selectedTrainId).toBe('trainschedule-1');
+    expect(state.selectedTrainId).toBe('paced_1');
   });
 
   it('should handle updateSelectedTrainId with a paced train occurrence', () => {
@@ -40,14 +40,6 @@ describe('simulationResultsReducer', () => {
 
     const state = store.getState()[simulationResultsSlice.name];
     expect(state.selectedTrainId).toBe('paced-1-occurrence-2');
-  });
-
-  it('should handle updateTrainIdUsedForProjection with a train schedule', () => {
-    const store = createStore();
-    store.dispatch(updateTrainIdUsedForProjection('trainschedule-1' as TrainScheduleId));
-
-    const state = store.getState()[simulationResultsSlice.name];
-    expect(state.trainIdUsedForProjection).toBe('trainschedule-1');
   });
 
   it('should handle updateTrainIdUsedForProjection with a paced train', () => {

--- a/front/src/reducers/simulationResults/types.ts
+++ b/front/src/reducers/simulationResults/types.ts
@@ -1,6 +1,6 @@
 import type { ScaleTime, ScaleLinear } from 'd3-scale';
 
-import type { OccurrenceId, PacedTrainId, TrainId, TrainScheduleId } from 'reducers/osrdconf/types';
+import type { TrainId } from 'reducers/osrdconf/types';
 
 type SimulationD3Scale = ScaleTime<number, number> | ScaleLinear<number, number>;
 
@@ -33,7 +33,7 @@ export type ProjectionType = 'trackProjection' | 'operationalPointProjection';
 export type SimulationResultsState = {
   chart?: Chart;
   selectedTrainId?: TrainId;
-  trainIdUsedForProjection?: TrainScheduleId | PacedTrainId | OccurrenceId;
+  trainIdUsedForProjection?: TrainId;
   projectionType: ProjectionType;
   displayOnlyPathSteps: boolean;
 };

--- a/front/src/utils/__tests__/trainId.spec.ts
+++ b/front/src/utils/__tests__/trainId.spec.ts
@@ -1,12 +1,11 @@
 import { describe, it, expect } from 'vitest';
 
-import type { TrainScheduleId, OccurrenceId, PacedTrainId } from 'reducers/osrdconf/types';
+import type { OccurrenceId, PacedTrainId } from 'reducers/osrdconf/types';
 
 import {
   formatEditoastIdToTrainScheduleId,
   formatEditoastIdToIndexedOccurrenceId,
   formatPacedTrainIdToIndexedOccurrenceId,
-  extractEditoastIdFromTrainScheduleId,
   formatEditoastIdToPacedTrainId,
   extractEditoastIdFromPacedTrainId,
   extractOccurrenceIndexFromOccurrenceId,
@@ -47,28 +46,6 @@ describe('formatEditoastIdToExceptionId', () => {
     const exceptionId = 'exception-uuid';
     const result = formatEditoastIdToExceptionId({ pacedTrainId, exceptionId });
     expect(result).toBe(`exception_${pacedTrainId}_${exceptionId}`);
-  });
-});
-
-describe('extractEditoastIdFromTrainScheduleId', () => {
-  it('should return a valid editoast id', () => {
-    const trainScheduleId = 'trainschedule_123' as TrainScheduleId;
-    const result = extractEditoastIdFromTrainScheduleId(trainScheduleId);
-    expect(result).toBe(123);
-  });
-
-  it("should throw an error if the trainScheduleId doesn't start correctly", () => {
-    const trainScheduleId = 'invalid_123' as TrainScheduleId;
-    expect(() => extractEditoastIdFromTrainScheduleId(trainScheduleId)).toThrow(
-      'The train schedule id should start with "trainschedule_"'
-    );
-  });
-
-  it("should throw an error if the return train id isn't a number", () => {
-    const trainScheduleId = 'trainschedule_onetwo' as TrainScheduleId;
-    expect(() => extractEditoastIdFromTrainScheduleId(trainScheduleId)).toThrow(
-      `Invalid train ID: ${trainScheduleId}`
-    );
   });
 });
 

--- a/front/src/utils/__tests__/trainId.spec.ts
+++ b/front/src/utils/__tests__/trainId.spec.ts
@@ -3,7 +3,6 @@ import { describe, it, expect } from 'vitest';
 import type { OccurrenceId, PacedTrainId } from 'reducers/osrdconf/types';
 
 import {
-  formatEditoastIdToTrainScheduleId,
   formatEditoastIdToIndexedOccurrenceId,
   formatPacedTrainIdToIndexedOccurrenceId,
   formatEditoastIdToPacedTrainId,
@@ -14,14 +13,6 @@ import {
   extractExceptionIdFromOccurrenceId,
   formatPacedTrainIdToExceptionId,
 } from '../trainId';
-
-describe('formatEditoastIdToTrainScheduleId', () => {
-  it('should format to a TrainScheduleId', () => {
-    const trainId = 123;
-    const result = formatEditoastIdToTrainScheduleId(trainId);
-    expect(result).toEqual(`trainschedule_${trainId}`);
-  });
-});
 
 describe('formatEditoastIdToPacedTrainId', () => {
   it('should format to a PacedTrainId', () => {

--- a/front/src/utils/trainId.ts
+++ b/front/src/utils/trainId.ts
@@ -64,13 +64,6 @@ export const isPacedTrainWithDetails = (
 
 /**
  * Given a train id in the Editoast format (used for api),
- * returns the train id with a TrainScheduleId format (used across the front).
- */
-export const formatEditoastIdToTrainScheduleId = (trainId: number): TrainScheduleId =>
-  `trainschedule_${trainId}` as TrainScheduleId;
-
-/**
- * Given a train id in the Editoast format (used for api),
  * returns the paced train id with a PacedTrainId format (used across the front).
  */
 export const formatEditoastIdToPacedTrainId = (trainId: number): PacedTrainId =>

--- a/front/src/utils/trainId.ts
+++ b/front/src/utils/trainId.ts
@@ -1,11 +1,7 @@
 import { isEmpty } from 'lodash';
 
 import type { PacedTrainException } from 'common/api/osrdEditoastApi';
-import type {
-  TimetableItemWithDetails,
-  PacedTrainWithDetails,
-  Occurrence,
-} from 'modules/timetableItem/types';
+import type { Occurrence } from 'modules/timetableItem/types';
 import type {
   AddedExceptionId,
   IndexedOccurrenceId,
@@ -57,10 +53,6 @@ export const isExceptionFromPathOrSimulation = ({ exceptionChangeGroups }: Occur
     exceptionChangeGroups.speed_limit_tag ||
     exceptionChangeGroups.initial_speed ||
     exceptionChangeGroups.rolling_stock);
-
-export const isPacedTrainWithDetails = (
-  timetableItem: TimetableItemWithDetails
-): timetableItem is PacedTrainWithDetails => isPacedTrainId(timetableItem.id);
 
 /**
  * Given a train id in the Editoast format (used for api),

--- a/front/src/utils/trainId.ts
+++ b/front/src/utils/trainId.ts
@@ -11,10 +11,7 @@ import type {
   IndexedOccurrenceId,
   OccurrenceId,
   PacedTrainId,
-  PacedTrainWithPacedTrainId,
-  TimetableItem,
   TrainId,
-  TrainScheduleId,
 } from 'reducers/osrdconf/types';
 
 export const isPacedTrainId = (id: string): id is PacedTrainId => id.startsWith('paced_');
@@ -28,11 +25,7 @@ export const isAddedExceptionId = (id: string): id is AddedExceptionId =>
 export const isOccurrenceId = (id: string): id is OccurrenceId =>
   isIndexedOccurrenceId(id) || isAddedExceptionId(id);
 
-export const isTrainScheduleId = (id: string): id is TrainScheduleId =>
-  id.startsWith('trainschedule_');
-
-export const isTrainId = (id: string): id is TrainId =>
-  isOccurrenceId(id) || isTrainScheduleId(id) || isPacedTrainId(id);
+export const isTrainId = (id: string): id is TrainId => isOccurrenceId(id) || isPacedTrainId(id);
 
 /**
  * Given an occurrence id, return the type of the exception.
@@ -64,10 +57,6 @@ export const isExceptionFromPathOrSimulation = ({ exceptionChangeGroups }: Occur
     exceptionChangeGroups.speed_limit_tag ||
     exceptionChangeGroups.initial_speed ||
     exceptionChangeGroups.rolling_stock);
-
-export const isPacedTrainResponseWithPacedTrainId = (
-  timetableItem: TimetableItem
-): timetableItem is PacedTrainWithPacedTrainId => isPacedTrainId(timetableItem.id);
 
 export const isPacedTrainWithDetails = (
   timetableItem: TimetableItemWithDetails
@@ -111,23 +100,6 @@ export const formatEditoastIdToExceptionId = ({
   pacedTrainId: number;
   exceptionId: string;
 }): AddedExceptionId => `exception_${pacedTrainId}_${exceptionId}` as AddedExceptionId;
-
-/**
- * Given a train id with a TrainScheduleId format (used across the front),
- * returns the train id in the Editoast format (used for api).
- */
-export const extractEditoastIdFromTrainScheduleId = (trainId: TrainScheduleId): number => {
-  if (!isTrainScheduleId(trainId)) {
-    throw new Error('The train schedule id should start with "trainschedule_"');
-  }
-  const formattedTrainId = Number(trainId.split('_')[1]);
-
-  if (Number.isNaN(formattedTrainId)) {
-    throw new Error(`Invalid train ID: ${trainId}`);
-  }
-
-  return formattedTrainId;
-};
 
 /**
  * Given a paced train id with a PacedTrainId format (used across the front),


### PR DESCRIPTION
See commits

In this PR, I don't use the new namings defined in the last workship. I only simplifed some namings, even with names that we will drop very soon (PacedTrain or TimetableItem).

The new namings will be implemented in a future PR.