### PR TITLE
editoast: switch a few &Option<T> to Option<&T> in function params

### DIFF
--- a/editoast/core_client/src/lib.rs
+++ b/editoast/core_client/src/lib.rs
@@ -99,7 +99,7 @@ impl CoreClient {
                 // TODO: tracing: use correlation id
 
                 let response = client
-                    .call_with_response(worker_key.to_string(), path, &body, true, override_timeout)
+                    .call_with_response(worker_key.to_string(), path, body, true, override_timeout)
                     .await
                     .map_err(Error::MqClientError)?;
 

--- a/editoast/core_client/src/mq_client.rs
+++ b/editoast/core_client/src/mq_client.rs
@@ -401,7 +401,7 @@ impl RabbitMQClient {
         &self,
         routing_key: String,
         path: &str,
-        published_payload: &Option<T>,
+        published_payload: Option<&T>,
         mandatory: bool,
         override_timeout: Option<Duration>,
     ) -> Result<MQResponse, MqClientError>
@@ -420,7 +420,7 @@ impl RabbitMQClient {
         let channel = channel_worker.get_channel();
 
         let serialized_payload_vec =
-            to_vec(published_payload).map_err(MqClientError::Serialization)?;
+            to_vec(&published_payload).map_err(MqClientError::Serialization)?;
         let serialized_payload = serialized_payload_vec.as_slice();
 
         let options = BasicPublishOptions {

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -913,7 +913,7 @@ pub(in crate::views) async fn match_operational_points(
                 !path_item_cache
                     .track_reference_filter(
                         op.track_offset(),
-                        &operational_point_reference.track_reference,
+                        operational_point_reference.track_reference.as_ref(),
                     )
                     .is_empty()
             })

--- a/editoast/src/views/path/path_item_cache.rs
+++ b/editoast/src/views/path/path_item_cache.rs
@@ -182,7 +182,7 @@ impl PathItemCache {
                 secondary_code,
             ),
         };
-        secondary_code_filter(secondary_code, ops)
+        secondary_code_filter(secondary_code.as_ref(), ops)
             .into_iter()
             .next()
             .map(|op| op.obj_id.clone())
@@ -207,7 +207,8 @@ impl PathItemCache {
                     let mut track_offsets = vec![];
                     if let Some(op) = self.get_from_id(&operational_point.0) {
                         track_offsets = op.track_offset();
-                        track_offsets = self.track_reference_filter(track_offsets, track_reference);
+                        track_offsets =
+                            self.track_reference_filter(track_offsets, track_reference.as_ref());
                     }
                     if track_offsets.is_empty() {
                         invalid_path_items.push(InvalidPathItem {
@@ -230,9 +231,10 @@ impl PathItemCache {
                         .get_from_trigram(&trigram.0)
                         .map(|op| op.collect())
                         .unwrap_or_default();
-                    let ops = secondary_code_filter(secondary_code, ops);
+                    let ops = secondary_code_filter(secondary_code.as_ref(), ops);
                     let track_offsets = track_offsets_from_ops(ops);
-                    let track_offsets = self.track_reference_filter(track_offsets, track_reference);
+                    let track_offsets =
+                        self.track_reference_filter(track_offsets, track_reference.as_ref());
                     if track_offsets.is_empty() {
                         invalid_path_items.push(InvalidPathItem {
                             index,
@@ -254,9 +256,10 @@ impl PathItemCache {
                         .get_from_uic(*uic)
                         .map(|op| op.collect())
                         .unwrap_or_default();
-                    let ops = secondary_code_filter(secondary_code, ops);
+                    let ops = secondary_code_filter(secondary_code.as_ref(), ops);
                     let track_offsets = track_offsets_from_ops(ops);
-                    let track_offsets = self.track_reference_filter(track_offsets, track_reference);
+                    let track_offsets =
+                        self.track_reference_filter(track_offsets, track_reference.as_ref());
                     if track_offsets.is_empty() {
                         invalid_path_items.push(InvalidPathItem {
                             index,
@@ -298,7 +301,7 @@ impl PathItemCache {
     pub fn track_reference_filter(
         &self,
         track_offsets: Vec<TrackOffset>,
-        track_reference: &Option<TrackReference>,
+        track_reference: Option<&TrackReference>,
     ) -> Vec<TrackOffset> {
         match track_reference {
             Some(TrackReference::Id { track_id }) => track_offsets
@@ -397,7 +400,7 @@ fn track_offsets_from_ops<'a>(
 /// Filter operational points by secondary code
 /// If the secondary code is not provided, the original list is returned
 fn secondary_code_filter<'a>(
-    secondary_code: &Option<String>,
+    secondary_code: Option<&String>,
     ops: Vec<&'a OperationalPointModel>,
 ) -> Vec<&'a OperationalPointModel> {
     if let Some(secondary_code) = secondary_code {

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -254,7 +254,7 @@ pub(in crate::views) async fn stdcm_handler(
         .await?
         .map(From::from);
 
-    request.validate_consist(&rolling_stock, &towed_rolling_stock)?;
+    request.validate_consist(&rolling_stock, towed_rolling_stock.as_ref())?;
 
     let physics_consist_parameters = PhysicsConsistParameters {
         max_speed: request.max_speed,

--- a/editoast/src/views/timetable/stdcm/request.rs
+++ b/editoast/src/views/timetable/stdcm/request.rs
@@ -306,7 +306,7 @@ impl Request {
     pub(super) fn validate_consist(
         &self,
         traction_engine: &RollingStock,
-        towed_rolling_stock: &Option<schemas::TowedRollingStock>,
+        towed_rolling_stock: Option<&schemas::TowedRollingStock>,
     ) -> Result<()> {
         self.validate_consist_mass(traction_engine, towed_rolling_stock)?;
         self.validate_consist_length(traction_engine, towed_rolling_stock)?;
@@ -316,7 +316,7 @@ impl Request {
     fn validate_consist_mass(
         &self,
         traction_engine: &RollingStock,
-        towed_rolling_stock: &Option<schemas::TowedRollingStock>,
+        towed_rolling_stock: Option<&schemas::TowedRollingStock>,
     ) -> Result<()> {
         let consist_mass = traction_engine.mass
             + towed_rolling_stock
@@ -341,13 +341,10 @@ impl Request {
     fn validate_consist_length(
         &self,
         traction_engine: &RollingStock,
-        towed_rolling_stock: &Option<schemas::TowedRollingStock>,
+        towed_rolling_stock: Option<&schemas::TowedRollingStock>,
     ) -> Result<()> {
-        let consist_length = traction_engine.length
-            + towed_rolling_stock
-                .as_ref()
-                .map(|t| t.length)
-                .unwrap_or_default();
+        let consist_length =
+            traction_engine.length + towed_rolling_stock.map(|t| t.length).unwrap_or_default();
         let consist_length = consist_length.floor::<meter>();
 
         if let Some(request_total_length) = self.total_length

--- a/editoast/src/views/timetable/track_occupancy.rs
+++ b/editoast/src/views/timetable/track_occupancy.rs
@@ -159,7 +159,10 @@ fn get_track_section(
         };
         if track_reference.is_some() {
             return path_item_cache
-                .track_reference_filter(operational_point_track_offsets.to_vec(), track_reference)
+                .track_reference_filter(
+                    operational_point_track_offsets.to_vec(),
+                    track_reference.as_ref(),
+                )
                 .first()
                 .map(|to| to.track.to_string());
         }


### PR DESCRIPTION
A &Option<T> can always be converted to an Option<&T> (that's what as_ref() does), but the oposite isn't true: you cannot build a &Option<T> from a T without moving it into the Option.

Thus, using a &Option<T> as a parameter makes the function less general for no reason, and might even induce suboptimal code in the caller (needing to move a T in and out an Option, or even cloning it if it doesn't have the necessary ownership).