### PR TITLE
front: introduce map context

### DIFF
--- a/front/src/applications/editor/Editor.tsx
+++ b/front/src/applications/editor/Editor.tsx
@@ -27,10 +27,11 @@ import { useModal } from 'common/BootstrapSNCF/ModalSNCF';
 import { LoaderState } from 'common/Loaders';
 import MapButtons from 'common/Map/Buttons/MapButtons';
 import MapSearch from 'common/Map/Search/MapSearch';
+import { MapContextProvider } from 'common/Map/useMapContext';
 import { useInfraActions, useInfraID, useOsrdActions } from 'common/osrdContext';
 import useInfra from 'modules/infra/useInfra';
 import { useMapSettings, useMapSettingsActions } from 'reducers/commonMap';
-import type { Viewport } from 'reducers/commonMap/types';
+import type { MapSettings, Viewport } from 'reducers/commonMap/types';
 import { type EditorSliceActions } from 'reducers/editor';
 import { getEditorState, getInfraLockStatus } from 'reducers/editor/selectors';
 import { loadDataModel, updateTotalsIssue } from 'reducers/editor/thunkActions';
@@ -51,7 +52,8 @@ const Editor = () => {
   const { openModal, closeModal } = useModal();
   const { updateInfraID, selectLayers } = useOsrdActions() as EditorSliceActions;
 
-  const { updateViewport: updateViewportAction } = useMapSettingsActions();
+  const { updateMapSettings: updateMapSettingsAction, updateViewport: updateViewportAction } =
+    useMapSettingsActions();
 
   const mapRef = useRef<MapRef>(null);
   const { urlInfra } = useParams();
@@ -111,7 +113,15 @@ const Editor = () => {
     forceRender();
   }, [switchTool, forceRender]);
 
-  const { mapStyle, viewport } = useMapSettings();
+  const mapSettings = useMapSettings();
+  const { mapStyle, viewport } = mapSettings;
+
+  const updateMapSettings = useCallback(
+    (value: Partial<MapSettings>) => {
+      dispatch(updateMapSettingsAction(value));
+    },
+    [dispatch]
+  );
 
   const setViewport = useCallback(
     (value: Partial<Viewport>) => {
@@ -461,49 +471,55 @@ const Editor = () => {
               </button>
             )}
             <div className="map">
-              <Map
-                {...{
-                  mapRef,
-                  mapStyle,
-                  viewport,
-                  setViewport,
-                  toolState: toolAndState.state,
-                  activeTool: toolAndState.tool,
-                  setToolState,
-                  infraID,
-                }}
-              />
-              {isSearchToolOpened && (
-                <MapSearch
-                  map={mapRef.current!}
-                  closeMapSearchPopUp={() => setIsSearchToolOpened(false)}
+              <MapContextProvider
+                infraId={infraID}
+                mapSettings={mapSettings}
+                updateMapSettings={updateMapSettings}
+              >
+                <Map
+                  {...{
+                    mapRef,
+                    mapStyle,
+                    viewport,
+                    setViewport,
+                    toolState: toolAndState.state,
+                    activeTool: toolAndState.tool,
+                    setToolState,
+                    infraID,
+                  }}
+                />
+                {isSearchToolOpened && (
+                  <MapSearch
+                    map={mapRef.current!}
+                    closeMapSearchPopUp={() => setIsSearchToolOpened(false)}
+                    mapSettings={editorState.mapSettings}
+                  />
+                )}
+
+                <MapButtons
+                  map={mapRef.current ?? undefined}
+                  resetPitchBearing={resetPitchBearing}
+                  withInfraButton
+                  bearing={viewport.bearing}
+                  editorProps={{
+                    toolState: toolAndState.state,
+                    setToolState,
+                    editorState,
+                    activeTool: toolAndState.tool,
+                  }}
+                  viewPort={viewport}
                   mapSettings={editorState.mapSettings}
                 />
-              )}
 
-              <MapButtons
-                map={mapRef.current ?? undefined}
-                resetPitchBearing={resetPitchBearing}
-                withInfraButton
-                bearing={viewport.bearing}
-                editorProps={{
-                  toolState: toolAndState.state,
-                  setToolState,
-                  editorState,
-                  activeTool: toolAndState.tool,
-                }}
-                viewPort={viewport}
-                mapSettings={editorState.mapSettings}
-              />
-
-              {mapRef.current &&
-                editorState.editorLayers.has('errors') &&
-                editorState.issues.total > 0 && (
-                  <div className="error-box">
-                    <InfraErrorMapControl mapRef={mapRef.current} switchTool={switchTool} />
-                    <InfraErrorCorrector protectedAction={protectedAction} />
-                  </div>
-                )}
+                {mapRef.current &&
+                  editorState.editorLayers.has('errors') &&
+                  editorState.issues.total > 0 && (
+                    <div className="error-box">
+                      <InfraErrorMapControl mapRef={mapRef.current} switchTool={switchTool} />
+                      <InfraErrorCorrector protectedAction={protectedAction} />
+                    </div>
+                  )}
+              </MapContextProvider>
             </div>
             <div className="messages-bar border-left">
               <div className="px-1">

--- a/front/src/applications/editor/Editor.tsx
+++ b/front/src/applications/editor/Editor.tsx
@@ -473,7 +473,7 @@ const Editor = () => {
             <div className="map">
               <MapContextProvider
                 infraId={infraID}
-                mapSettings={mapSettings}
+                mapSettings={editorState.mapSettings}
                 updateMapSettings={updateMapSettings}
               >
                 <Map
@@ -508,7 +508,6 @@ const Editor = () => {
                     activeTool: toolAndState.tool,
                   }}
                   viewPort={viewport}
-                  mapSettings={editorState.mapSettings}
                 />
 
                 {mapRef.current &&

--- a/front/src/applications/editor/Map.tsx
+++ b/front/src/applications/editor/Map.tsx
@@ -321,7 +321,6 @@ const MapUnplugged = ({
             <NeutralSectionsLayer
               colors={colors[mapStyle]}
               layerOrder={LAYER_GROUPS_ORDER[LAYERS.NEUTRAL_SECTIONS.GROUP]}
-              infraID={infraID}
             />
           )}
 
@@ -329,7 +328,6 @@ const MapUnplugged = ({
             <OperationalPointsLayer
               colors={colors[mapStyle]}
               layerOrder={LAYER_GROUPS_ORDER[LAYERS.OPERATIONAL_POINTS.GROUP]}
-              infraID={infraID}
             />
           )}
 
@@ -337,7 +335,6 @@ const MapUnplugged = ({
             <LevelCrossingsLayer
               colors={colors[mapStyle]}
               layerOrder={LAYER_GROUPS_ORDER[LAYERS.LEVEL_CROSSINGS.GROUP]}
-              infraID={infraID}
             />
           )}
 

--- a/front/src/applications/editor/Map.tsx
+++ b/front/src/applications/editor/Map.tsx
@@ -80,6 +80,7 @@ const MapUnplugged = ({
   const context = useContext(EditorContext) as EditorContextType<CommonToolState>;
   const { data: switchTypes } = useSwitchTypes(infraID);
   const editorState = useSelector(getEditorState);
+
   const {
     showOSM,
     showOSM3dBuildings,
@@ -87,10 +88,8 @@ const MapUnplugged = ({
     terrain3DExaggeration,
     mapSearchMarker,
     lineSearchCode,
-    showIGNBDORTHO,
-    showIGNCadastre,
-    showIGNSCAN25,
   } = useMapSettings();
+
   const extendedContext = useMemo<ExtendedEditorContextType<CommonToolState>>(
     () => ({
       ...context,
@@ -303,11 +302,7 @@ const MapUnplugged = ({
             showOSMtracksections={showOSMtracksections}
             hidePlatforms
           />
-          <IGNLayers
-            showIGNBDORTHO={showIGNBDORTHO}
-            showIGNCadastre={showIGNCadastre}
-            showIGNSCAN25={showIGNSCAN25}
-          />
+          <IGNLayers />
 
           <LineSearchLayer
             layerOrder={LAYER_GROUPS_ORDER[LAYERS.LINE_SEARCH.GROUP]}

--- a/front/src/applications/editor/components/EditorLayersModal.tsx
+++ b/front/src/applications/editor/components/EditorLayersModal.tsx
@@ -74,7 +74,7 @@ const EditorLayersModal = ({
 
   const infraID = useInfraID();
   const mapSettings = useMapSettings();
-  const { mapStyle, layersSettings } = mapSettings;
+  const { layersSettings } = mapSettings;
   const { updateLayersSettings } = useMapSettingsActions();
 
   const [selectedLayers, setSelectedLayers] = useState<Set<Layer>>(initialLayers);
@@ -222,8 +222,8 @@ const EditorLayersModal = ({
         <div>
           <h4>{t('Editor.nav.map-layers')}</h4>
         </div>
-        <MapSettingsMapStyle mapStyle={mapStyle} />
-        <MapSettingsBackgroundSwitches mapSettings={mapSettings} />
+        <MapSettingsMapStyle />
+        <MapSettingsBackgroundSwitches />
       </div>
 
       <div className="text-right">

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModalMap.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModalMap.tsx
@@ -159,7 +159,6 @@ const ItineraryModalMap = ({
         withMapKeyButton
         viewPort={viewport}
         isNewButtons
-        mapSettings={mapSettings}
         layersModalContainer={document.querySelector('.itinerary-modal-map')}
       />
       <BaseMap

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModalMap.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModalMap.tsx
@@ -8,11 +8,12 @@ import { matchOpRefAndOp } from 'applications/operationalStudies/utils';
 import type { PathProperties } from 'common/api/osrdEditoastApi';
 import BaseMap from 'common/Map/BaseMap';
 import MapButtons from 'common/Map/Buttons/MapButtons';
+import { MapContextProvider } from 'common/Map/useMapContext';
 import { useInfraID } from 'common/osrdContext';
 import { LAYER_GROUPS_ORDER, LAYERS } from 'config/layerOrder';
 import Itinerary from 'modules/simulationResult/components/SimulationResultsMap/RenderItinerary';
 import { useMapSettings, useMapSettingsActions } from 'reducers/commonMap';
-import type { Viewport } from 'reducers/commonMap/types';
+import type { MapSettings, Viewport } from 'reducers/commonMap/types';
 import type { PathStepMetadata, PathStepV2 } from 'reducers/osrdconf/types';
 import { useAppDispatch } from 'store';
 import { getBarycenter } from 'utils/geometry';
@@ -52,11 +53,22 @@ const ItineraryModalMap = ({
   const infraID = useInfraID();
   const mapSettings = useMapSettings();
   const { viewport, layersSettings } = mapSettings;
-  const { removeMapSearchMarker, updateViewport } = useMapSettingsActions();
+  const {
+    updateMapSettings: updateMapSettingsAction,
+    removeMapSearchMarker,
+    updateViewport,
+  } = useMapSettingsActions();
 
   const mapRef = useRef<MapRef | null>(null);
 
   const [hoveredOperationalPointId, setHoveredOperationalPointId] = useState<string>();
+
+  const updateMapSettings = useCallback(
+    (value: Partial<MapSettings>) => {
+      dispatch(updateMapSettingsAction(value));
+    },
+    [dispatch]
+  );
 
   const updateViewportChange = useCallback(
     (value: Partial<Viewport>) => {
@@ -134,7 +146,11 @@ const ItineraryModalMap = ({
   }, [layersSettings]);
 
   return (
-    <>
+    <MapContextProvider
+      infraId={infraID}
+      mapSettings={mapSettings}
+      updateMapSettings={updateMapSettings}
+    >
       <MapButtons
         map={mapRef.current ?? undefined}
         resetPitchBearing={resetPitchBearing}
@@ -222,7 +238,7 @@ const ItineraryModalMap = ({
           })}
         {children}
       </BaseMap>
-    </>
+    </MapContextProvider>
   );
 };
 

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/ManageTimetableItemMap/ManageTimetableItemMap.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/ManageTimetableItemMap/ManageTimetableItemMap.tsx
@@ -188,7 +188,6 @@ const ManageTimetableItemMap = ({
         withMapKeyButton
         viewPort={viewport}
         isNewButtons
-        mapSettings={mapSettings}
       />
       <BaseMap
         mapId="map-container"

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/ManageTimetableItemMap/ManageTimetableItemMap.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/ManageTimetableItemMap/ManageTimetableItemMap.tsx
@@ -10,12 +10,13 @@ import type { MapPathProperties } from 'applications/operationalStudies/types';
 import BaseMap from 'common/Map/BaseMap';
 import MapButtons from 'common/Map/Buttons/MapButtons';
 import { SnappedMarker } from 'common/Map/Layers';
+import { MapContextProvider } from 'common/Map/useMapContext';
 import { computeBBoxViewport } from 'common/Map/WarpedMap/core/helpers';
 import { useInfraID } from 'common/osrdContext';
 import { LAYER_GROUPS_ORDER, LAYERS } from 'config/layerOrder';
 import type { SuggestedOP } from 'modules/timetableItem/types';
 import { useMapSettings, useMapSettingsActions } from 'reducers/commonMap';
-import type { Viewport } from 'reducers/commonMap/types';
+import type { MapSettings, Viewport } from 'reducers/commonMap/types';
 import { useAppDispatch } from 'store';
 import { getMapMouseEventNearestFeature } from 'utils/mapHelper';
 
@@ -46,7 +47,11 @@ const ManageTimetableItemMap = ({
   const infraID = useInfraID();
   const mapSettings = useMapSettings();
   const { viewport, layersSettings } = mapSettings;
-  const { removeMapSearchMarker, updateViewport } = useMapSettingsActions();
+  const {
+    updateMapSettings: updateMapSettingsAction,
+    removeMapSearchMarker,
+    updateViewport,
+  } = useMapSettingsActions();
 
   const mapRef = useRef<MapRef | null>(null);
   const mapContainer = useMemo(() => mapRef.current?.getContainer(), [mapRef.current]);
@@ -55,6 +60,13 @@ const ManageTimetableItemMap = ({
 
   const [hoveredOperationalPointId, setHoveredOperationalPointId] = useState<string>();
   const [snappedPoint, setSnappedPoint] = useState<Feature<Point> | undefined>();
+
+  const updateMapSettings = useCallback(
+    (value: Partial<MapSettings>) => {
+      dispatch(updateMapSettingsAction(value));
+    },
+    [dispatch]
+  );
 
   const updateViewportChange = useCallback(
     (value: Partial<Viewport>) => {
@@ -163,7 +175,11 @@ const ManageTimetableItemMap = ({
   }, [pathGeometry, simulationPathSteps, mapContainer]);
 
   return (
-    <>
+    <MapContextProvider
+      infraId={infraID}
+      mapSettings={mapSettings}
+      updateMapSettings={updateMapSettings}
+    >
       <MapButtons
         map={mapRef.current ?? undefined}
         resetPitchBearing={resetPitchBearing}
@@ -210,7 +226,7 @@ const ManageTimetableItemMap = ({
 
         {children}
       </BaseMap>
-    </>
+    </MapContextProvider>
   );
 };
 

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResultsMap.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResultsMap.tsx
@@ -12,6 +12,7 @@ import type { CorePathfindingResultSuccess } from 'common/api/osrdEditoastApi';
 import BaseMap from 'common/Map/BaseMap';
 import MapButtons from 'common/Map/Buttons/MapButtons';
 import MapMarkers, { type MapMarker } from 'common/Map/components/MapMarkers';
+import { MapContextProvider } from 'common/Map/useMapContext';
 import { computeBBoxViewport } from 'common/Map/WarpedMap/core/helpers';
 import { useInfraID } from 'common/osrdContext';
 import { LAYER_GROUPS_ORDER, LAYERS } from 'config/layerOrder';
@@ -19,7 +20,7 @@ import getPointOnPathCoordinates from 'modules/pathfinding/helpers/getPointOnPat
 import getTrackLengthCumulativeSums from 'modules/pathfinding/helpers/getTrackLengthCumulativeSums';
 import Itinerary from 'modules/simulationResult/components/SimulationResultsMap/RenderItinerary';
 import { useMapSettings, useMapSettingsActions } from 'reducers/commonMap';
-import type { Viewport } from 'reducers/commonMap/types';
+import type { MapSettings, Viewport } from 'reducers/commonMap/types';
 import { useAppDispatch } from 'store';
 
 const MAP_ID = 'simulation-result-map';
@@ -41,7 +42,11 @@ const SimulationResultMap = ({
   const { getTrackSectionsByIds } = useScenarioContext();
 
   const mapSettings = useMapSettings();
-  const { removeMapSearchMarker, updateViewport } = useMapSettingsActions();
+  const {
+    updateMapSettings: updateMapSettingsAction,
+    removeMapSearchMarker,
+    updateViewport,
+  } = useMapSettingsActions();
   const { viewport } = mapSettings;
 
   const mapRef = React.useRef<MapRef>(null);
@@ -49,6 +54,13 @@ const SimulationResultMap = ({
   const geojsonPath = useMemo(() => geometry && lineString(geometry.coordinates), [geometry]);
 
   const [mapMarkers, setMapMarkers] = useState<MapMarker[]>([]);
+
+  const updateMapSettings = useCallback(
+    (value: Partial<MapSettings>) => {
+      dispatch(updateMapSettingsAction(value));
+    },
+    [dispatch]
+  );
 
   // Compute path items coordinates in order to place them on the map
   useEffect(() => {
@@ -113,7 +125,11 @@ const SimulationResultMap = ({
   }, [geojsonPath]);
 
   return (
-    <>
+    <MapContextProvider
+      infraId={infraID}
+      mapSettings={mapSettings}
+      updateMapSettings={updateMapSettings}
+    >
       <MapButtons
         map={mapRef.current ?? undefined}
         resetPitchBearing={resetPitchBearing}
@@ -144,7 +160,7 @@ const SimulationResultMap = ({
 
         <MapMarkers markers={mapMarkers} />
       </BaseMap>
-    </>
+    </MapContextProvider>
   );
 };
 

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResultsMap.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResultsMap.tsx
@@ -137,7 +137,6 @@ const SimulationResultMap = ({
         withMapKeyButton
         viewPort={viewport}
         isNewButtons
-        mapSettings={mapSettings}
       />
       <BaseMap
         mapId={MAP_ID}

--- a/front/src/applications/referenceMap/Map.tsx
+++ b/front/src/applications/referenceMap/Map.tsx
@@ -64,7 +64,6 @@ const Map = () => {
           viewPort={viewport}
           withInfraButton
           withMapKeyButton
-          mapSettings={mapSettings}
         />
         <BaseMap
           mapId={REFERENCE_MAP_ID}

--- a/front/src/applications/referenceMap/Map.tsx
+++ b/front/src/applications/referenceMap/Map.tsx
@@ -4,9 +4,10 @@ import type { MapRef } from 'react-map-gl/maplibre';
 
 import BaseMap from 'common/Map/BaseMap';
 import MapButtons from 'common/Map/Buttons/MapButtons';
+import { MapContextProvider } from 'common/Map/useMapContext';
 import { useInfraID } from 'common/osrdContext';
 import { useMapSettings, useMapSettingsActions } from 'reducers/commonMap';
-import type { Viewport } from 'reducers/commonMap/types';
+import type { MapSettings, Viewport } from 'reducers/commonMap/types';
 import { updateReferenceMapViewport } from 'reducers/referenceMap';
 import { useAppDispatch } from 'store';
 
@@ -16,11 +17,19 @@ const Map = () => {
   const dispatch = useAppDispatch();
   const mapSettings = useMapSettings();
   const { layersSettings, viewport } = mapSettings;
-  const { removeMapSearchMarker } = useMapSettingsActions();
+  const { updateMapSettings: updateMapSettingsAction, removeMapSearchMarker } =
+    useMapSettingsActions();
 
   const infraID = useInfraID();
 
   const mapRef = useRef<MapRef | null>(null);
+
+  const updateMapSettings = useCallback(
+    (value: Partial<MapSettings>) => {
+      dispatch(updateMapSettingsAction(value));
+    },
+    [dispatch]
+  );
 
   const updateViewportChange = useCallback(
     (value: Partial<Viewport>, { updateRouter } = { updateRouter: false }) => {
@@ -43,27 +52,33 @@ const Map = () => {
 
   return (
     <main className="mastcontainer mastcontainer-map">
-      <MapButtons
-        map={mapRef.current ?? undefined}
-        resetPitchBearing={resetPitchBearing}
-        bearing={viewport.bearing}
-        viewPort={viewport}
-        withInfraButton
-        withMapKeyButton
-        mapSettings={mapSettings}
-      />
-      <BaseMap
-        mapId={REFERENCE_MAP_ID}
-        mapRef={mapRef}
-        cursor="normal"
+      <MapContextProvider
         infraId={infraID}
-        interactiveLayerIds={interactiveLayerIds}
         mapSettings={mapSettings}
-        onClick={() => {
-          dispatch(removeMapSearchMarker());
-        }}
-        updatePartialViewPort={updateViewportChange}
-      />
+        updateMapSettings={updateMapSettings}
+      >
+        <MapButtons
+          map={mapRef.current ?? undefined}
+          resetPitchBearing={resetPitchBearing}
+          bearing={viewport.bearing}
+          viewPort={viewport}
+          withInfraButton
+          withMapKeyButton
+          mapSettings={mapSettings}
+        />
+        <BaseMap
+          mapId={REFERENCE_MAP_ID}
+          mapRef={mapRef}
+          cursor="normal"
+          infraId={infraID}
+          interactiveLayerIds={interactiveLayerIds}
+          mapSettings={mapSettings}
+          onClick={() => {
+            dispatch(removeMapSearchMarker());
+          }}
+          updatePartialViewPort={updateViewportChange}
+        />
+      </MapContextProvider>
     </main>
   );
 };

--- a/front/src/applications/stdcm/components/StdcmForm/StdcmConfig.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmConfig.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 import { Button } from '@osrd-project/ui-core';
 import cx from 'classnames';
@@ -11,8 +11,8 @@ import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import DefaultBaseMap from 'common/Map/DefaultBaseMap';
 import useWorkerStatus from 'modules/pathfinding/hooks/useWorkerStatus';
 import { useStoreDataForRollingStockSelector } from 'modules/rollingStock/components/RollingStockSelector/useStoreDataForRollingStockSelector';
-import { useMapSettings } from 'reducers/commonMap';
-import type { Viewport } from 'reducers/commonMap/types';
+import { useMapSettings, useMapSettingsActions } from 'reducers/commonMap';
+import type { MapSettings, Viewport } from 'reducers/commonMap/types';
 import { resetMargins, restoreStdcmConfig, updateStdcmPathStep } from 'reducers/osrdconf/stdcmConf';
 import {
   getOperationalPoints,
@@ -122,6 +122,14 @@ const StdcmConfig = ({
   const updateViewport = (viewport: Viewport) => {
     setStdcmConfigViewport(viewport);
   };
+
+  const { updateMapSettings: updateMapSettingsAction } = useMapSettingsActions();
+  const updateMapSettings = useCallback(
+    (value: Partial<MapSettings>) => {
+      dispatch(updateMapSettingsAction(value));
+    },
+    [dispatch]
+  );
 
   const [showMessage, setShowMessage] = useState(false);
 
@@ -380,6 +388,7 @@ const StdcmConfig = ({
                 : undefined
             }
             mapSettings={{ ...mapSettings, viewport: stdcmConfigViewport }}
+            updateMapSettings={updateMapSettings}
             updateViewport={updateViewport}
           />
         </div>

--- a/front/src/applications/stdcm/components/StdcmResults/StdcmResults.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/StdcmResults.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { Button } from '@osrd-project/ui-core';
 import { PDFDownloadLink } from '@react-pdf/renderer';
@@ -17,8 +17,8 @@ import {
   generateCodeNumber,
   getOperationalPointsWithTimes,
 } from 'modules/SimulationReportSheet/utils/formatSimulationReportSheet';
-import { useMapSettings } from 'reducers/commonMap';
-import type { Viewport } from 'reducers/commonMap/types';
+import { useMapSettings, useMapSettingsActions } from 'reducers/commonMap';
+import type { MapSettings, Viewport } from 'reducers/commonMap/types';
 import { getRailwayManagerInterfaceUrl } from 'reducers/main/mainSelector';
 import {
   getOperationalPointsIdFiltered,
@@ -26,6 +26,7 @@ import {
   getSelectedSimulation,
   getStdcmInfraID,
 } from 'reducers/osrdconf/stdcmConf/selectors';
+import { useAppDispatch } from 'store';
 import useDeploymentSettings from 'utils/hooks/useDeploymentSettings';
 
 import SendToRailwayManagerModal from './SendToRailwayManagerModal';
@@ -62,6 +63,7 @@ const StdcmResults = ({
 
   const { t } = useTranslation('stdcm', { keyPrefix: 'simulation.results' });
   const deploymentSettings = useDeploymentSettings();
+  const dispatch = useAppDispatch();
 
   const selectedSimulation = useSelector(getSelectedSimulation);
   const retainedSimulationIndex = useSelector(getRetainedSimulationIndex);
@@ -69,6 +71,14 @@ const StdcmResults = ({
   const opIdsToExclude = useSelector(getOperationalPointsIdFiltered);
 
   const mapSettings = useMapSettings();
+
+  const { updateMapSettings: updateMapSettingsAction } = useMapSettingsActions();
+  const updateMapSettings = useCallback(
+    (value: Partial<MapSettings>) => {
+      dispatch(updateMapSettingsAction(value));
+    },
+    [dispatch]
+  );
 
   // Keep local state of the viewport to keep stdcm config and stdcm results maps independent
   const [stdcmResultsViewport, setStdcmResultsViewport] = useState<Viewport>(mapSettings.viewport);
@@ -355,6 +365,7 @@ const StdcmResults = ({
                 pathStepMarkers={markersInfo}
                 isFeasible={hasSimulationResults}
                 mapSettings={{ ...mapSettings, viewport: stdcmResultsViewport }}
+                updateMapSettings={updateMapSettings}
                 updateViewport={updateViewport}
               />
             </div>

--- a/front/src/common/Map/BaseMap.tsx
+++ b/front/src/common/Map/BaseMap.tsx
@@ -44,8 +44,6 @@ type MapProps = {
    * - OP & tracks are full displayed, but elements ouside the area are muted
    */
   highlightedArea?: Geometry;
-  highlightedOperationalPoints?: number[];
-  highlightedTrackSections?: string[];
 };
 
 const BaseMap = ({
@@ -64,8 +62,6 @@ const BaseMap = ({
   onMouseMove,
   onIdle,
   highlightedArea,
-  highlightedOperationalPoints,
-  highlightedTrackSections,
 }: PropsWithChildren<MapProps>) => {
   const mapBlankStyle = useMapBlankStyle();
 
@@ -155,8 +151,6 @@ const BaseMap = ({
           hoveredOperationalPointId={hoveredOperationalPointId}
           layersSettings={layersSettings}
           highlightedArea={highlightedArea}
-          highlightedOperationalPoints={highlightedOperationalPoints}
-          highlightedTrackSections={highlightedTrackSections}
         />
       )}
 

--- a/front/src/common/Map/BaseMap.tsx
+++ b/front/src/common/Map/BaseMap.tsx
@@ -83,10 +83,8 @@ const BaseMap = ({
     terrain3DExaggeration,
     mapSearchMarker,
     lineSearchCode,
-    showIGNBDORTHO,
-    showIGNSCAN25,
-    showIGNCadastre,
   } = mapSettings;
+
   useEffect(() => {
     if (urlLat) {
       updatePartialViewPort({
@@ -170,11 +168,7 @@ const BaseMap = ({
         showOSM3dBuildings={showOSM3dBuildings && mapIsLoaded}
         showOSMtracksections={showOSMtracksections && mapIsLoaded}
       />
-      <IGNLayers
-        showIGNBDORTHO={showIGNBDORTHO}
-        showIGNCadastre={showIGNCadastre}
-        showIGNSCAN25={showIGNSCAN25}
-      />
+      <IGNLayers />
 
       <LineSearchLayer
         layerOrder={LAYER_GROUPS_ORDER[LAYERS.LINE_SEARCH.GROUP]}

--- a/front/src/common/Map/BaseMap.tsx
+++ b/front/src/common/Map/BaseMap.tsx
@@ -151,7 +151,6 @@ const BaseMap = ({
 
       {infraId && (
         <InfraObjectLayers
-          infraId={infraId}
           mapStyle={mapStyle}
           hoveredOperationalPointId={hoveredOperationalPointId}
           layersSettings={layersSettings}

--- a/front/src/common/Map/Buttons/MapButtons.tsx
+++ b/front/src/common/Map/Buttons/MapButtons.tsx
@@ -25,13 +25,14 @@ import LayersModal from 'common/Map/components/LayersModal';
 import MapKey from 'common/Map/MapKey';
 import MapSearch from 'common/Map/Search/MapSearch';
 import { useMapSettingsActions } from 'reducers/commonMap';
-import type { MapSettings, Viewport } from 'reducers/commonMap/types';
+import type { Viewport } from 'reducers/commonMap/types';
 import { type EditorState } from 'reducers/editor';
 import { useAppDispatch } from 'store';
 import useOutsideClick from 'utils/hooks/useOutsideClick';
 
 import ButtonMapInfraErrors from './ButtonMapInfraErrors';
 import MapButton from './MapButton';
+import { MapContextProvider, useMapContext } from '../useMapContext';
 
 type MapButtonsProps = {
   map?: MapRef;
@@ -53,7 +54,6 @@ type MapButtonsProps = {
   compactModal?: boolean;
   viewPort: Viewport;
   isNewButtons?: boolean;
-  mapSettings: MapSettings;
   layersModalContainer?: Element | null;
 };
 
@@ -76,12 +76,12 @@ export default function MapButtons({
   zoomOut: zoomOutProps,
   isNewButtons = false,
   compactModal = false,
-  mapSettings,
   layersModalContainer,
 }: MapButtonsProps) {
   const { t } = useTranslation('translation');
   const dispatch = useAppDispatch();
   const { updateViewport } = useMapSettingsActions();
+  const { infraId, updateMapSettings, ...mapSettings } = useMapContext();
 
   const { isOpen, openModal } = useContext(ModalContext);
   const [openedPopover, setOpenedPopover] = useState<string | undefined>(undefined);
@@ -134,9 +134,26 @@ export default function MapButtons({
     } else if (layersModalContainer) {
       setShowLayersModal(true);
     } else {
-      openModal(<LayersModal compactModal={compactModal} />, 'lg');
+      openModal(
+        <MapContextProvider
+          infraId={infraId}
+          mapSettings={mapSettings}
+          updateMapSettings={updateMapSettings}
+        >
+          <LayersModal compactModal={compactModal} />{' '}
+        </MapContextProvider>,
+        'lg'
+      );
     }
-  }, [editorProps, openModal, compactModal, layersModalContainer]);
+  }, [
+    editorProps,
+    openModal,
+    compactModal,
+    layersModalContainer,
+    mapSettings,
+    infraId,
+    updateMapSettings,
+  ]);
 
   const mapButtonsRef = useRef<HTMLDivElement>(null);
 

--- a/front/src/common/Map/Buttons/MapButtons.tsx
+++ b/front/src/common/Map/Buttons/MapButtons.tsx
@@ -103,26 +103,32 @@ export default function MapButtons({
     if (editorProps) {
       const { activeTool, setToolState, editorState, toolState } = editorProps;
       openModal(
-        <EditorLayersModal
-          initialLayers={editorState.editorLayers}
-          frozenLayers={activeTool.requiredLayers}
-          selection={
-            activeTool.id === 'select-items' ? (toolState as SelectionState).selection : undefined
-          }
-          onChange={({ newLayers }) => {
-            if (activeTool.id === 'select-items') {
-              const currentState = toolState as SelectionState;
-              setToolState({
-                ...currentState,
-                selection: currentState.selection.filter((entity) =>
-                  EDITOAST_TO_LAYER_DICT[entity.objType as EditoastType].every((layer) =>
-                    newLayers.has(layer)
-                  )
-                ),
-              } as SelectionState);
+        <MapContextProvider
+          infraId={infraId}
+          mapSettings={mapSettings}
+          updateMapSettings={updateMapSettings}
+        >
+          <EditorLayersModal
+            initialLayers={editorState.editorLayers}
+            frozenLayers={activeTool.requiredLayers}
+            selection={
+              activeTool.id === 'select-items' ? (toolState as SelectionState).selection : undefined
             }
-          }}
-        />,
+            onChange={({ newLayers }) => {
+              if (activeTool.id === 'select-items') {
+                const currentState = toolState as SelectionState;
+                setToolState({
+                  ...currentState,
+                  selection: currentState.selection.filter((entity) =>
+                    EDITOAST_TO_LAYER_DICT[entity.objType as EditoastType].every((layer) =>
+                      newLayers.has(layer)
+                    )
+                  ),
+                } as SelectionState);
+              }
+            }}
+          />
+        </MapContextProvider>,
         'lg'
       );
     } else if (layersModalContainer) {

--- a/front/src/common/Map/DefaultBaseMap.tsx
+++ b/front/src/common/Map/DefaultBaseMap.tsx
@@ -111,7 +111,6 @@ const DefaultBaseMap = ({
         viewPort={viewport}
         isNewButtons
         compactModal
-        mapSettings={mapSettings}
       />
       <BaseMap
         mapId={mapId}

--- a/front/src/common/Map/DefaultBaseMap.tsx
+++ b/front/src/common/Map/DefaultBaseMap.tsx
@@ -16,6 +16,8 @@ import { computeBBoxViewport } from 'common/Map/WarpedMap/core/helpers';
 import { LAYER_GROUPS_ORDER, LAYERS } from 'config/layerOrder';
 import type { MapSettings, Viewport } from 'reducers/commonMap/types';
 
+import { MapContextProvider } from './useMapContext';
+
 type DefaultBaseMapProps = {
   mapId: string;
   infraId?: number;
@@ -23,6 +25,7 @@ type DefaultBaseMapProps = {
   pathStepMarkers?: MarkerInformation[];
   isFeasible?: boolean;
   mapSettings: MapSettings;
+  updateMapSettings: (mapSettings: Partial<MapSettings>) => void;
   updateViewport: (viewPort: Viewport) => void;
   highlightedArea?: Geometry;
   highlightedOperationalPoints?: number[];
@@ -44,6 +47,7 @@ const DefaultBaseMap = ({
   isFeasible = true,
   children,
   mapSettings,
+  updateMapSettings,
   updateViewport,
   highlightedArea,
   highlightedOperationalPoints,
@@ -91,7 +95,11 @@ const DefaultBaseMap = ({
   }, [geometry, pathStepMarkers]);
 
   return (
-    <>
+    <MapContextProvider
+      infraId={infraId}
+      mapSettings={mapSettings}
+      updateMapSettings={updateMapSettings}
+    >
       <MapButtons
         zoomIn={zoomIn}
         zoomOut={zoomOut}
@@ -133,7 +141,7 @@ const DefaultBaseMap = ({
 
         {children}
       </BaseMap>
-    </>
+    </MapContextProvider>
   );
 };
 

--- a/front/src/common/Map/DefaultBaseMap.tsx
+++ b/front/src/common/Map/DefaultBaseMap.tsx
@@ -99,6 +99,8 @@ const DefaultBaseMap = ({
       infraId={infraId}
       mapSettings={mapSettings}
       updateMapSettings={updateMapSettings}
+      highlightedTrackSections={highlightedTrackSections}
+      highlightedOperationalPoints={highlightedOperationalPoints}
     >
       <MapButtons
         zoomIn={zoomIn}
@@ -121,8 +123,6 @@ const DefaultBaseMap = ({
         hideAttribution
         mapSettings={mapSettings}
         highlightedArea={highlightedArea}
-        highlightedOperationalPoints={highlightedOperationalPoints}
-        highlightedTrackSections={highlightedTrackSections}
       >
         <ItineraryLayer
           layerOrder={LAYER_GROUPS_ORDER[LAYERS.PATH.GROUP]}

--- a/front/src/common/Map/Layers/Hillshade.tsx
+++ b/front/src/common/Map/Layers/Hillshade.tsx
@@ -4,7 +4,6 @@ import OrderedLayer from './OrderedLayer';
 import { useMapContext } from '../useMapContext';
 
 type HillshadeProps = {
-  mapStyle: string;
   layerOrder?: number;
   display?: boolean;
 };
@@ -16,8 +15,8 @@ const hillshadeParams: LayerProps = {
   paint: {},
 };
 
-const Hillshade = ({ mapStyle, layerOrder }: HillshadeProps) => {
-  const { terrain3DExaggeration } = useMapContext();
+const Hillshade = ({ layerOrder }: HillshadeProps) => {
+  const { mapStyle, terrain3DExaggeration } = useMapContext();
   if (mapStyle !== 'normal' || !terrain3DExaggeration) {
     return null;
   }

--- a/front/src/common/Map/Layers/Hillshade.tsx
+++ b/front/src/common/Map/Layers/Hillshade.tsx
@@ -1,8 +1,7 @@
 import { type LayerProps } from 'react-map-gl/maplibre';
 
-import { useMapSettings } from 'reducers/commonMap';
-
 import OrderedLayer from './OrderedLayer';
+import { useMapContext } from '../useMapContext';
 
 type HillshadeProps = {
   mapStyle: string;
@@ -18,7 +17,7 @@ const hillshadeParams: LayerProps = {
 };
 
 const Hillshade = ({ mapStyle, layerOrder }: HillshadeProps) => {
-  const { terrain3DExaggeration } = useMapSettings();
+  const { terrain3DExaggeration } = useMapContext();
   if (mapStyle !== 'normal' || !terrain3DExaggeration) {
     return null;
   }

--- a/front/src/common/Map/Layers/IGNLayers/IGNLayers.tsx
+++ b/front/src/common/Map/Layers/IGNLayers/IGNLayers.tsx
@@ -4,28 +4,11 @@ import IGN_BD_ORTHO from './IGN_BD_ORTHO';
 import IGN_CADASTRE from './IGN_CADASTRE';
 import IGN_SCAN25 from './IGN_SCAN25';
 
-const IGNLayers = ({
-  showIGNBDORTHO,
-  showIGNSCAN25,
-  showIGNCadastre,
-}: {
-  showIGNBDORTHO: boolean;
-  showIGNSCAN25: boolean;
-  showIGNCadastre: boolean;
-}) => (
+const IGNLayers = () => (
   <>
-    <IGN_BD_ORTHO
-      layerOrder={LAYER_GROUPS_ORDER[LAYERS.BACKGROUND.GROUP]}
-      showIGNBDORTHO={showIGNBDORTHO}
-    />
-    <IGN_SCAN25
-      layerOrder={LAYER_GROUPS_ORDER[LAYERS.BACKGROUND.GROUP]}
-      showIGNSCAN25={showIGNSCAN25}
-    />
-    <IGN_CADASTRE
-      layerOrder={LAYER_GROUPS_ORDER[LAYERS.BACKGROUND.GROUP]}
-      showIGNCadastre={showIGNCadastre}
-    />
+    <IGN_BD_ORTHO layerOrder={LAYER_GROUPS_ORDER[LAYERS.BACKGROUND.GROUP]} />
+    <IGN_SCAN25 layerOrder={LAYER_GROUPS_ORDER[LAYERS.BACKGROUND.GROUP]} />
+    <IGN_CADASTRE layerOrder={LAYER_GROUPS_ORDER[LAYERS.BACKGROUND.GROUP]} />
   </>
 );
 

--- a/front/src/common/Map/Layers/IGNLayers/IGN_BD_ORTHO.tsx
+++ b/front/src/common/Map/Layers/IGNLayers/IGN_BD_ORTHO.tsx
@@ -1,13 +1,16 @@
 import { Source, type LayerProps } from 'react-map-gl/maplibre';
 
+import { useMapContext } from 'common/Map/useMapContext';
+
 import OrderedLayer from '../OrderedLayer';
 
 type IGN_BD_ORTHO_Props = {
   layerOrder?: number;
-  showIGNBDORTHO?: boolean;
 };
 
-export default function IGN_BD_ORTHO({ layerOrder, showIGNBDORTHO }: IGN_BD_ORTHO_Props) {
+export default function IGN_BD_ORTHO({ layerOrder }: IGN_BD_ORTHO_Props) {
+  const { showIGNBDORTHO } = useMapContext();
+
   const IGN_BD_ORTHO_Params: LayerProps = {
     source: 'orthophoto',
     type: 'raster',

--- a/front/src/common/Map/Layers/IGNLayers/IGN_CADASTRE.tsx
+++ b/front/src/common/Map/Layers/IGNLayers/IGN_CADASTRE.tsx
@@ -1,5 +1,7 @@
 import { Source, type LayerProps } from 'react-map-gl/maplibre';
 
+import { useMapContext } from 'common/Map/useMapContext';
+
 import OrderedLayer from '../OrderedLayer';
 
 type IGN_Cadastre_Props = {
@@ -18,8 +20,8 @@ const IGN_Cadastre_Params: LayerProps = {
   },
 };
 
-export default function IGN_CADASTRE(props: IGN_Cadastre_Props) {
-  const { layerOrder, showIGNCadastre } = props;
+export default function IGN_CADASTRE({ layerOrder }: IGN_Cadastre_Props) {
+  const { showIGNCadastre } = useMapContext();
 
   if (!showIGNCadastre) return null;
   return (

--- a/front/src/common/Map/Layers/IGNLayers/IGN_SCAN25.tsx
+++ b/front/src/common/Map/Layers/IGNLayers/IGN_SCAN25.tsx
@@ -1,13 +1,16 @@
 import { Source, type LayerProps } from 'react-map-gl/maplibre';
 
+import { useMapContext } from 'common/Map/useMapContext';
+
 import OrderedLayer from '../OrderedLayer';
 
 type IGN_SCAN25_Props = {
   layerOrder?: number;
-  showIGNSCAN25?: boolean;
 };
 
-export default function IGN_SCAN25({ layerOrder, showIGNSCAN25 }: IGN_SCAN25_Props) {
+export default function IGN_SCAN25({ layerOrder }: IGN_SCAN25_Props) {
+  const { showIGNSCAN25 } = useMapContext();
+
   const IGN_SCAN25_Params: LayerProps = {
     source: 'orthophoto',
     type: 'raster',

--- a/front/src/common/Map/Layers/InfraObjectLayers/BufferStops.tsx
+++ b/front/src/common/Map/Layers/InfraObjectLayers/BufferStops.tsx
@@ -4,6 +4,7 @@ import { Source, type SymbolLayerSpecification } from 'react-map-gl/maplibre';
 
 import { MAP_URL } from 'common/Map/const';
 import type { Theme } from 'common/Map/theme';
+import { useMapContext } from 'common/Map/useMapContext';
 import type { OmitLayer } from 'types';
 
 import { DEFAULT_HALO_WIDTH, getAllowOverlap, getDynamicTextSize } from '../commonLayers';
@@ -45,17 +46,18 @@ export function getBufferStopsLayerProps(params: {
 type BufferStopsProps = {
   colors: Theme;
   layerOrder: number;
-  infraID: number | undefined;
   highlightedArea?: Geometry;
 };
 
-const BufferStops = ({ layerOrder, infraID, highlightedArea, colors }: BufferStopsProps) => {
-  if (isNil(infraID)) return null;
+const BufferStops = ({ layerOrder, highlightedArea, colors }: BufferStopsProps) => {
+  const { infraId } = useMapContext();
+
+  if (isNil(infraId)) return null;
   return (
     <Source
       id="osrd_bufferstop_geo"
       type="vector"
-      url={`${MAP_URL}/layer/buffer_stops/mvt/geo/?infra=${infraID}`}
+      url={`${MAP_URL}/layer/buffer_stops/mvt/geo/?infra=${infraId}`}
     >
       <OrderedLayer
         {...getBufferStopsLayerProps({ sourceTable: 'buffer_stops', highlightedArea, colors })}

--- a/front/src/common/Map/Layers/InfraObjectLayers/Detectors.tsx
+++ b/front/src/common/Map/Layers/InfraObjectLayers/Detectors.tsx
@@ -6,6 +6,7 @@ import type { CircleLayerSpecification, SymbolLayerSpecification } from 'react-m
 
 import { MAP_URL } from 'common/Map/const';
 import type { Theme } from 'common/Map/theme';
+import { useMapContext } from 'common/Map/useMapContext';
 import type { OmitLayer } from 'types';
 
 import { DEFAULT_HALO_WIDTH, getAllowOverlap, getDynamicTextSize } from '../commonLayers';
@@ -76,11 +77,12 @@ export function getDetectorsNameLayerProps(params: {
 type DetectorsProps = {
   colors: Theme;
   layerOrder: number;
-  infraID: number | undefined;
   highlightedArea?: Geometry;
 };
 
-const Detectors = ({ colors, layerOrder, infraID, highlightedArea }: DetectorsProps) => {
+const Detectors = ({ colors, layerOrder, highlightedArea }: DetectorsProps) => {
+  const { infraId } = useMapContext();
+
   const layerPoint3 = getDetectorsLayerProps({
     colors,
     sourceTable: 'detectors',
@@ -105,12 +107,12 @@ const Detectors = ({ colors, layerOrder, infraID, highlightedArea }: DetectorsPr
     highlightedArea,
   });
 
-  if (isNil(infraID)) return null;
+  if (isNil(infraId)) return null;
   return (
     <Source
       id="osrd_detectors_geo"
       type="vector"
-      url={`${MAP_URL}/layer/detectors/mvt/geo/?infra=${infraID}`}
+      url={`${MAP_URL}/layer/detectors/mvt/geo/?infra=${infraId}`}
     >
       <OrderedLayer {...layerName} id="chartis/osrd_detectors_name/geo" layerOrder={layerOrder} />
       <OrderedLayer

--- a/front/src/common/Map/Layers/InfraObjectLayers/Electrifications.tsx
+++ b/front/src/common/Map/Layers/InfraObjectLayers/Electrifications.tsx
@@ -5,16 +5,10 @@ import type { LayerProps } from 'react-map-gl/maplibre';
 
 import { MAP_URL } from 'common/Map/const';
 import type { Theme } from 'common/Map/theme';
+import { useMapContext } from 'common/Map/useMapContext';
 
 import { getAllowOverlap, getDynamicTextSize } from '../commonLayers';
 import OrderedLayer from '../OrderedLayer';
-
-type ElectrificationsProps = {
-  colors: Theme;
-  layerOrder: number;
-  infraID: number | undefined;
-  highlightedArea?: Geometry;
-};
 
 export function getElectrificationsProps({
   colors,
@@ -128,12 +122,15 @@ export function getElectrificationsTextParams({
   return res;
 }
 
-export default function Electrifications({
-  colors,
-  layerOrder,
-  infraID,
-  highlightedArea,
-}: ElectrificationsProps) {
+type ElectrificationsProps = {
+  colors: Theme;
+  layerOrder: number;
+  highlightedArea?: Geometry;
+};
+
+const Electrifications = ({ colors, layerOrder, highlightedArea }: ElectrificationsProps) => {
+  const { infraId } = useMapContext();
+
   const electrificationsParams: LayerProps = getElectrificationsProps({
     colors,
     sourceTable: 'electrifications',
@@ -144,12 +141,12 @@ export default function Electrifications({
     sourceTable: 'electrifications',
     highlightedArea,
   });
-  if (isNil(infraID)) return null;
+  if (isNil(infraId)) return null;
   return (
     <Source
       id="electrifications_geo"
       type="vector"
-      url={`${MAP_URL}/layer/electrifications/mvt/geo/?infra=${infraID}`}
+      url={`${MAP_URL}/layer/electrifications/mvt/geo/?infra=${infraId}`}
     >
       <OrderedLayer
         {...electrificationsParams}
@@ -165,4 +162,6 @@ export default function Electrifications({
       />
     </Source>
   );
-}
+};
+
+export default Electrifications;

--- a/front/src/common/Map/Layers/InfraObjectLayers/GeoJSONs.tsx
+++ b/front/src/common/Map/Layers/InfraObjectLayers/GeoJSONs.tsx
@@ -9,8 +9,8 @@ import { Layer, Source } from 'react-map-gl/maplibre';
 import type { Layer as LayerType } from 'applications/editor/consts';
 import { MAP_TRACK_SOURCE, MAP_URL } from 'common/Map/const';
 import type { Theme } from 'common/Map/theme';
+import { useMapContext } from 'common/Map/useMapContext';
 import { LAYER_ENTITIES_ORDERS, LAYER_GROUPS_ORDER, LAYERS } from 'config/layerOrder';
-import { useMapSettings } from 'reducers/commonMap';
 import type { MapSettings } from 'reducers/commonMap/types';
 import type { EditorState } from 'reducers/editor';
 
@@ -486,7 +486,7 @@ const GeoJSONs = ({
       ),
     [colors]
   );
-  const { mapStyle, showIGNBDORTHO } = useMapSettings();
+  const { mapStyle, showIGNBDORTHO } = useMapContext();
   // This flag is used to unmount sources before mounting the new ones, when
   // fingerprint is updated;
   const [skipSources, setSkipSources] = useState(true);

--- a/front/src/common/Map/Layers/InfraObjectLayers/InfraObjectLayers.tsx
+++ b/front/src/common/Map/Layers/InfraObjectLayers/InfraObjectLayers.tsx
@@ -18,7 +18,6 @@ import Switches from './Switches';
 import TracksGeographic from './TracksGeographic';
 
 type InfraObjectLayersProps = {
-  infraId: number;
   mapStyle: MapStyle;
   hoveredOperationalPointId?: string;
   layersSettings: LayersSettings;
@@ -28,7 +27,6 @@ type InfraObjectLayersProps = {
 };
 
 const InfraObjectLayers = ({
-  infraId,
   mapStyle,
   hoveredOperationalPointId,
   layersSettings,
@@ -40,7 +38,6 @@ const InfraObjectLayers = ({
     <TracksGeographic
       colors={colors[mapStyle]}
       layerOrder={LAYER_GROUPS_ORDER[LAYERS.TRACKS.GROUP]}
-      infraID={infraId}
       highlightedArea={highlightedArea}
       highlightedTrackSections={highlightedTrackSections}
     />
@@ -48,7 +45,6 @@ const InfraObjectLayers = ({
       <Routes
         colors={colors[mapStyle]}
         layerOrder={LAYER_GROUPS_ORDER[LAYERS.ROUTES.GROUP]}
-        infraID={infraId}
         highlightedArea={highlightedArea}
       />
     )}
@@ -57,7 +53,6 @@ const InfraObjectLayers = ({
         colors={colors[mapStyle]}
         layerOrder={LAYER_GROUPS_ORDER[LAYERS.OPERATIONAL_POINTS.GROUP]}
         operationnalPointId={hoveredOperationalPointId}
-        infraID={infraId}
         highlightedArea={highlightedArea}
         highlightedOperationalPoints={highlightedOperationalPoints}
       />
@@ -66,7 +61,6 @@ const InfraObjectLayers = ({
       <Electrifications
         colors={colors[mapStyle]}
         layerOrder={LAYER_GROUPS_ORDER[LAYERS.ELECTRIFICATIONS.GROUP]}
-        infraID={infraId}
         highlightedArea={highlightedArea}
       />
     )}
@@ -74,7 +68,6 @@ const InfraObjectLayers = ({
       <NeutralSections
         colors={colors[mapStyle]}
         layerOrder={LAYER_GROUPS_ORDER[LAYERS.NEUTRAL_SECTIONS.GROUP]}
-        infraID={infraId}
         highlightedArea={highlightedArea}
       />
     )}
@@ -82,7 +75,6 @@ const InfraObjectLayers = ({
       <BufferStops
         colors={colors[mapStyle]}
         layerOrder={LAYER_GROUPS_ORDER[LAYERS.BUFFER_STOPS.GROUP]}
-        infraID={infraId}
         highlightedArea={highlightedArea}
       />
     )}
@@ -90,7 +82,6 @@ const InfraObjectLayers = ({
       <Detectors
         colors={colors[mapStyle]}
         layerOrder={LAYER_GROUPS_ORDER[LAYERS.DETECTORS.GROUP]}
-        infraID={infraId}
         highlightedArea={highlightedArea}
       />
     )}
@@ -98,7 +89,6 @@ const InfraObjectLayers = ({
       <Switches
         colors={colors[mapStyle]}
         layerOrder={LAYER_GROUPS_ORDER[LAYERS.SWITCHES.GROUP]}
-        infraID={infraId}
         highlightedArea={highlightedArea}
       />
     )}
@@ -107,8 +97,6 @@ const InfraObjectLayers = ({
         colors={colors[mapStyle]}
         layerOrder={LAYER_GROUPS_ORDER[LAYERS.SPEED_LIMITS.GROUP]}
         punctualLayerOrder={LAYER_GROUPS_ORDER[LAYERS.SPEED_LIMITS_PUNCTUAL.GROUP]}
-        infraID={infraId}
-        layersSettings={layersSettings}
         highlightedArea={highlightedArea}
       />
     )}
@@ -117,8 +105,6 @@ const InfraObjectLayers = ({
         colors={colors[mapStyle]}
         layerOrder={LAYER_GROUPS_ORDER[LAYERS.SPEED_LIMITS.GROUP]}
         punctualLayerOrder={LAYER_GROUPS_ORDER[LAYERS.SPEED_LIMITS_PUNCTUAL.GROUP]}
-        infraID={infraId}
-        layersSettings={layersSettings}
         highlightedArea={highlightedArea}
       />
     )}
@@ -127,7 +113,6 @@ const InfraObjectLayers = ({
         sourceTable="signals"
         colors={colors[mapStyle]}
         layerOrder={LAYER_GROUPS_ORDER[LAYERS.SIGNALS.GROUP]}
-        infraID={infraId}
         highlightedArea={highlightedArea}
       />
     )}
@@ -135,7 +120,6 @@ const InfraObjectLayers = ({
       <LevelCrossingsLayer
         colors={colors[mapStyle]}
         layerOrder={LAYER_GROUPS_ORDER[LAYERS.LEVEL_CROSSINGS.GROUP]}
-        infraID={infraId}
         highlightedArea={highlightedArea}
       />
     )}

--- a/front/src/common/Map/Layers/InfraObjectLayers/InfraObjectLayers.tsx
+++ b/front/src/common/Map/Layers/InfraObjectLayers/InfraObjectLayers.tsx
@@ -22,8 +22,6 @@ type InfraObjectLayersProps = {
   hoveredOperationalPointId?: string;
   layersSettings: LayersSettings;
   highlightedArea?: Geometry;
-  highlightedOperationalPoints?: number[];
-  highlightedTrackSections?: string[];
 };
 
 const InfraObjectLayers = ({
@@ -31,15 +29,12 @@ const InfraObjectLayers = ({
   hoveredOperationalPointId,
   layersSettings,
   highlightedArea,
-  highlightedOperationalPoints,
-  highlightedTrackSections,
 }: InfraObjectLayersProps) => (
   <>
     <TracksGeographic
       colors={colors[mapStyle]}
       layerOrder={LAYER_GROUPS_ORDER[LAYERS.TRACKS.GROUP]}
       highlightedArea={highlightedArea}
-      highlightedTrackSections={highlightedTrackSections}
     />
     {layersSettings.routes && (
       <Routes
@@ -54,7 +49,6 @@ const InfraObjectLayers = ({
         layerOrder={LAYER_GROUPS_ORDER[LAYERS.OPERATIONAL_POINTS.GROUP]}
         operationnalPointId={hoveredOperationalPointId}
         highlightedArea={highlightedArea}
-        highlightedOperationalPoints={highlightedOperationalPoints}
       />
     )}
     {layersSettings.electrifications && (

--- a/front/src/common/Map/Layers/InfraObjectLayers/LevelCrossing.tsx
+++ b/front/src/common/Map/Layers/InfraObjectLayers/LevelCrossing.tsx
@@ -4,6 +4,7 @@ import { Source, type SymbolLayerSpecification } from 'react-map-gl/maplibre';
 
 import { MAP_URL } from 'common/Map/const';
 import type { Theme } from 'common/Map/theme';
+import { useMapContext } from 'common/Map/useMapContext';
 import type { OmitLayer } from 'types';
 
 import { DEFAULT_HALO_WIDTH, getAllowOverlap, getDynamicTextSize } from '../commonLayers';
@@ -47,23 +48,19 @@ export function getLevelCrossingsLayerProps(params: {
 type LevelCrossingsProps = {
   colors: Theme;
   layerOrder: number;
-  infraID: number | undefined;
   highlightedArea?: Geometry;
 };
 
-const LevelCrossingsLayer = ({
-  layerOrder,
-  infraID,
-  highlightedArea,
-  colors,
-}: LevelCrossingsProps) => {
-  if (isNil(infraID)) return null;
+const LevelCrossingsLayer = ({ layerOrder, highlightedArea, colors }: LevelCrossingsProps) => {
+  const { infraId } = useMapContext();
+
+  if (isNil(infraId)) return null;
   const zoomLevelForGroup = 15;
   return (
     <Source
       id="osrd_levelcrossing_geo"
       type="vector"
-      url={`${MAP_URL}/layer/level_crossings/mvt/geo/?infra=${infraID}`}
+      url={`${MAP_URL}/layer/level_crossings/mvt/geo/?infra=${infraId}`}
     >
       <OrderedLayer
         {...getLevelCrossingsLayerProps({

--- a/front/src/common/Map/Layers/InfraObjectLayers/OperationalPoints.tsx
+++ b/front/src/common/Map/Layers/InfraObjectLayers/OperationalPoints.tsx
@@ -15,14 +15,6 @@ import { useMapContext } from 'common/Map/useMapContext';
 import { DEFAULT_HALO_WIDTH, getDynamicTextSize, getAllowOverlap } from '../commonLayers';
 import OrderedLayer from '../OrderedLayer';
 
-type OperationalPointsProps = {
-  colors: Theme;
-  layerOrder: number;
-  operationnalPointId?: string;
-  highlightedArea?: Geometry;
-  highlightedOperationalPoints?: number[];
-};
-
 function getColorByHighlighted(data: {
   highlightedArea?: Geometry;
   highlightedOperationalPoints?: number[];
@@ -59,14 +51,20 @@ function getFilterHighlighted(
   return result;
 }
 
+type OperationalPointsProps = {
+  colors: Theme;
+  layerOrder: number;
+  operationnalPointId?: string;
+  highlightedArea?: Geometry;
+};
+
 const OperationalPointsLayer = ({
   colors,
   layerOrder,
   operationnalPointId,
   highlightedArea,
-  highlightedOperationalPoints,
 }: OperationalPointsProps) => {
-  const { infraId } = useMapContext();
+  const { infraId, highlightedOperationalPoints } = useMapContext();
 
   if (isNil(infraId)) return null;
 

--- a/front/src/common/Map/Layers/InfraObjectLayers/OperationalPoints.tsx
+++ b/front/src/common/Map/Layers/InfraObjectLayers/OperationalPoints.tsx
@@ -10,6 +10,7 @@ import { Source, type LayerProps } from 'react-map-gl/maplibre';
 
 import { MAP_URL } from 'common/Map/const';
 import type { Theme } from 'common/Map/theme';
+import { useMapContext } from 'common/Map/useMapContext';
 
 import { DEFAULT_HALO_WIDTH, getDynamicTextSize, getAllowOverlap } from '../commonLayers';
 import OrderedLayer from '../OrderedLayer';
@@ -17,7 +18,6 @@ import OrderedLayer from '../OrderedLayer';
 type OperationalPointsProps = {
   colors: Theme;
   layerOrder: number;
-  infraID: number | undefined;
   operationnalPointId?: string;
   highlightedArea?: Geometry;
   highlightedOperationalPoints?: number[];
@@ -62,12 +62,13 @@ function getFilterHighlighted(
 const OperationalPointsLayer = ({
   colors,
   layerOrder,
-  infraID,
   operationnalPointId,
   highlightedArea,
   highlightedOperationalPoints,
 }: OperationalPointsProps) => {
-  if (isNil(infraID)) return null;
+  const { infraId } = useMapContext();
+
+  if (isNil(infraId)) return null;
 
   const point: LayerProps = {
     type: 'circle',
@@ -259,7 +260,7 @@ const OperationalPointsLayer = ({
     <Source
       id="osrd_operational_point_geo"
       type="vector"
-      url={`${MAP_URL}/layer/operational_points/mvt/geo/?infra=${infraID}`}
+      url={`${MAP_URL}/layer/operational_points/mvt/geo/?infra=${infraId}`}
     >
       <OrderedLayer {...point} id="chartis/osrd_operational_point/geo" layerOrder={layerOrder} />
       <OrderedLayer

--- a/front/src/common/Map/Layers/InfraObjectLayers/Routes.tsx
+++ b/front/src/common/Map/Layers/InfraObjectLayers/Routes.tsx
@@ -9,17 +9,11 @@ import type {
 
 import { MAP_URL } from 'common/Map/const';
 import type { Theme } from 'common/Map/theme';
+import { useMapContext } from 'common/Map/useMapContext';
 import type { OmitLayer } from 'types';
 
 import { DEFAULT_HALO_WIDTH, getAllowOverlap, getDynamicTextSize } from '../commonLayers';
 import OrderedLayer from '../OrderedLayer';
-
-type RoutesProps = {
-  colors: Theme;
-  layerOrder: number;
-  infraID: number | undefined;
-  highlightedArea?: Geometry;
-};
 
 export function getRoutesLineLayerProps(params: {
   colors: Theme;
@@ -100,21 +94,31 @@ export function getRoutesTextLayerProps(params: {
   return res;
 }
 
-export default function Routes({ colors, layerOrder, infraID, highlightedArea }: RoutesProps) {
+type RoutesProps = {
+  colors: Theme;
+  layerOrder: number;
+  highlightedArea?: Geometry;
+};
+
+const Routes = ({ colors, layerOrder, highlightedArea }: RoutesProps) => {
+  const { infraId } = useMapContext();
+
   const lineProps = getRoutesLineLayerProps({ colors, sourceTable: 'routes', highlightedArea });
   const pointProps = getRoutesPointLayerProps({ colors, sourceTable: 'routes', highlightedArea });
   const textProps = getRoutesTextLayerProps({ colors, sourceTable: 'routes', highlightedArea });
 
-  if (isNil(infraID)) return null;
+  if (isNil(infraId)) return null;
   return (
     <Source
       id="osrd_routes_geo"
       type="vector"
-      url={`${MAP_URL}/layer/routes/mvt/geo/?infra=${infraID}`}
+      url={`${MAP_URL}/layer/routes/mvt/geo/?infra=${infraId}`}
     >
       <OrderedLayer {...lineProps} id="chartis/osrd_routes_line/geo" layerOrder={layerOrder} />
       <OrderedLayer {...pointProps} id="chartis/osrd_routes_point/geo" layerOrder={layerOrder} />
       <OrderedLayer {...textProps} id="chartis/osrd_routes_text/geo" layerOrder={layerOrder} />
     </Source>
   );
-}
+};
+
+export default Routes;

--- a/front/src/common/Map/Layers/InfraObjectLayers/Signals.tsx
+++ b/front/src/common/Map/Layers/InfraObjectLayers/Signals.tsx
@@ -4,12 +4,13 @@ import { Source, type MapRef } from 'react-map-gl/maplibre';
 
 import { MAP_URL } from 'common/Map/const';
 import type { Theme } from 'common/Map/theme';
+import { useMapContext } from 'common/Map/useMapContext';
 
 import { getPointLayerProps, getSignalLayerProps } from './geoSignalsLayers';
 import getKPLabelLayerProps from './getKPLabelLayerProps';
 import getMastLayerProps from './getMastLayerProps';
 import OrderedLayer from '../OrderedLayer';
-import { type SignalContext } from '../types';
+import type { SignalContext } from '../types';
 
 type PlatformProps = {
   colors: Theme;
@@ -17,11 +18,12 @@ type PlatformProps = {
   hovered?: { id: string; layer: string };
   mapRef?: React.RefObject<MapRef>;
   layerOrder: number;
-  infraID: number | undefined;
   highlightedArea?: Geometry;
 };
 
-const Signals = ({ colors, sourceTable, layerOrder, infraID, highlightedArea }: PlatformProps) => {
+const Signals = ({ colors, sourceTable, layerOrder, highlightedArea }: PlatformProps) => {
+  const { infraId } = useMapContext();
+
   const context: SignalContext = {
     colors,
     sourceTable,
@@ -29,12 +31,12 @@ const Signals = ({ colors, sourceTable, layerOrder, infraID, highlightedArea }: 
     minzoom: 12,
   };
 
-  if (isNil(infraID)) return null;
+  if (isNil(infraId)) return null;
   return (
     <Source
       promoteId="id"
       type="vector"
-      url={`${MAP_URL}/layer/${sourceTable}/mvt/geo/?infra=${infraID}`}
+      url={`${MAP_URL}/layer/${sourceTable}/mvt/geo/?infra=${infraId}`}
     >
       <OrderedLayer
         {...getMastLayerProps({ ...context, highlightedArea })}

--- a/front/src/common/Map/Layers/InfraObjectLayers/SpeedLimits.tsx
+++ b/front/src/common/Map/Layers/InfraObjectLayers/SpeedLimits.tsx
@@ -6,20 +6,12 @@ import type { SymbolLayerSpecification, LineLayerSpecification } from 'react-map
 
 import { MAP_URL } from 'common/Map/const';
 import type { Theme } from 'common/Map/theme';
-import type { LayersSettings, MapSettings } from 'reducers/commonMap/types';
+import { useMapContext } from 'common/Map/useMapContext';
+import type { LayersSettings } from 'reducers/commonMap/types';
 import type { OmitLayer } from 'types';
 
 import { DEFAULT_HALO_WIDTH, getAllowOverlap, getDynamicTextSize } from '../commonLayers';
 import OrderedLayer from '../OrderedLayer';
-
-type SpeedLimitsProps = {
-  colors: Theme;
-  layerOrder: number;
-  punctualLayerOrder: number;
-  infraID?: number;
-  layersSettings: MapSettings['layersSettings'];
-  highlightedArea?: Geometry;
-};
 
 export function getSpeedSectionsTag({ speedlimittag }: LayersSettings): string {
   return speedlimittag !== null ? `speed_limit_by_tag_${speedlimittag}` : 'null';
@@ -175,14 +167,21 @@ export function getSpeedSectionsTextLayerProps({
   return res;
 }
 
-export default function SpeedLimits({
+type SpeedLimitsProps = {
+  colors: Theme;
+  layerOrder: number;
+  punctualLayerOrder: number;
+  highlightedArea?: Geometry;
+};
+
+const SpeedLimits = ({
   colors,
   layerOrder,
   punctualLayerOrder,
-  infraID,
-  layersSettings,
   highlightedArea,
-}: SpeedLimitsProps) {
+}: SpeedLimitsProps) => {
+  const { infraId, layersSettings } = useMapContext();
+
   const filter = getFilterBySpeedSectionsTag(layersSettings, highlightedArea);
   const lineProps = {
     ...getSpeedSectionsLineLayerProps({
@@ -209,12 +208,12 @@ export default function SpeedLimits({
     filter,
   };
 
-  if (isNil(infraID)) return null;
+  if (isNil(infraId)) return null;
   return (
     <Source
       id="osrd_speed_limit_geo"
       type="vector"
-      url={`${MAP_URL}/layer/speed_sections/mvt/geo/?infra=${infraID}`}
+      url={`${MAP_URL}/layer/speed_sections/mvt/geo/?infra=${infraId}`}
     >
       <OrderedLayer
         {...lineProps}
@@ -233,4 +232,6 @@ export default function SpeedLimits({
       />
     </Source>
   );
-}
+};
+
+export default SpeedLimits;

--- a/front/src/common/Map/Layers/InfraObjectLayers/Switches.tsx
+++ b/front/src/common/Map/Layers/InfraObjectLayers/Switches.tsx
@@ -5,6 +5,7 @@ import type { SymbolLayerSpecification, CircleLayerSpecification } from 'react-m
 
 import { MAP_URL } from 'common/Map/const';
 import type { Theme } from 'common/Map/theme';
+import { useMapContext } from 'common/Map/useMapContext';
 import type { OmitLayer } from 'types';
 
 import { DEFAULT_HALO_WIDTH, getAllowOverlap, getDynamicTextSize } from '../commonLayers';
@@ -69,20 +70,21 @@ export function getSwitchesNameLayerProps(params: {
 type SwitchesProps = {
   colors: Theme;
   layerOrder: number;
-  infraID: number | undefined;
   highlightedArea?: Geometry;
 };
 
-const Switches = ({ colors, layerOrder, infraID, highlightedArea }: SwitchesProps) => {
+const Switches = ({ colors, layerOrder, highlightedArea }: SwitchesProps) => {
+  const { infraId } = useMapContext();
+
   const layerPoint = getSwitchesLayerProps({ colors, sourceTable: 'switches', highlightedArea });
   const layerName = getSwitchesNameLayerProps({ colors, sourceTable: 'switches', highlightedArea });
 
-  if (isNil(infraID)) return null;
+  if (isNil(infraId)) return null;
   return (
     <Source
       id="osrd_switches_geo"
       type="vector"
-      url={`${MAP_URL}/layer/switches/mvt/geo/?infra=${infraID}`}
+      url={`${MAP_URL}/layer/switches/mvt/geo/?infra=${infraId}`}
     >
       <OrderedLayer {...layerPoint} id="chartis/osrd_switches/geo" layerOrder={layerOrder} />
       <OrderedLayer {...layerName} id="chartis/osrd_switches_name/geo" layerOrder={layerOrder} />

--- a/front/src/common/Map/Layers/InfraObjectLayers/TracksGeographic.tsx
+++ b/front/src/common/Map/Layers/InfraObjectLayers/TracksGeographic.tsx
@@ -14,16 +14,15 @@ type TracksGeographicProps = {
   colors: Theme;
   layerOrder?: number;
   highlightedArea?: Geometry;
-  highlightedTrackSections?: string[];
 };
 
-function TracksGeographic({
-  colors,
-  layerOrder,
-  highlightedArea,
-  highlightedTrackSections,
-}: TracksGeographicProps) {
-  const { infraId: infraID, showIGNBDORTHO, showIGNSCAN25 } = useMapContext();
+function TracksGeographic({ colors, layerOrder, highlightedArea }: TracksGeographicProps) {
+  const {
+    infraId: infraID,
+    showIGNBDORTHO,
+    showIGNSCAN25,
+    highlightedTrackSections,
+  } = useMapContext();
 
   if (isNil(infraID)) return null;
   return (

--- a/front/src/common/Map/Layers/InfraObjectLayers/TracksGeographic.tsx
+++ b/front/src/common/Map/Layers/InfraObjectLayers/TracksGeographic.tsx
@@ -13,7 +13,6 @@ import OrderedLayer from '../OrderedLayer';
 type TracksGeographicProps = {
   colors: Theme;
   layerOrder?: number;
-  infraID: number | undefined;
   highlightedArea?: Geometry;
   highlightedTrackSections?: string[];
 };
@@ -21,11 +20,10 @@ type TracksGeographicProps = {
 function TracksGeographic({
   colors,
   layerOrder,
-  infraID,
   highlightedArea,
   highlightedTrackSections,
 }: TracksGeographicProps) {
-  const { showIGNBDORTHO, showIGNSCAN25 } = useMapContext();
+  const { infraId: infraID, showIGNBDORTHO, showIGNSCAN25 } = useMapContext();
 
   if (isNil(infraID)) return null;
   return (

--- a/front/src/common/Map/Layers/InfraObjectLayers/TracksGeographic.tsx
+++ b/front/src/common/Map/Layers/InfraObjectLayers/TracksGeographic.tsx
@@ -5,7 +5,7 @@ import { Source } from 'react-map-gl/maplibre';
 import { MAP_TRACK_SOURCES, MAP_URL } from 'common/Map/const';
 import { lineNameLayer, lineNumberLayer, trackNameLayer } from 'common/Map/Layers/commonLayers';
 import type { Theme } from 'common/Map/theme';
-import { useMapSettings } from 'reducers/commonMap';
+import { useMapContext } from 'common/Map/useMapContext';
 
 import geoMainLayer from './getGeographicLayerProps';
 import OrderedLayer from '../OrderedLayer';
@@ -25,7 +25,7 @@ function TracksGeographic({
   highlightedArea,
   highlightedTrackSections,
 }: TracksGeographicProps) {
-  const { showIGNBDORTHO, showIGNSCAN25 } = useMapSettings();
+  const { showIGNBDORTHO, showIGNSCAN25 } = useMapContext();
 
   if (isNil(infraID)) return null;
   return (

--- a/front/src/common/Map/Layers/InfraObjectLayers/extensions/SNCF/NeutralSectionSigns.tsx
+++ b/front/src/common/Map/Layers/InfraObjectLayers/extensions/SNCF/NeutralSectionSigns.tsx
@@ -6,6 +6,7 @@ import { MAP_URL } from 'common/Map/const';
 import { getAllowOverlap } from 'common/Map/Layers/commonLayers';
 import type { LayerContext } from 'common/Map/Layers/types';
 import type { Theme } from 'common/Map/theme';
+import { useMapContext } from 'common/Map/useMapContext';
 
 import OrderedLayer from '../../../OrderedLayer';
 import getKPLabelLayerProps from '../../getKPLabelLayerProps';
@@ -54,7 +55,6 @@ export function getNeutralSectionSignsLayerProps({
 }
 
 type NeutralSectionSignsProps = {
-  infraID: number | undefined;
   colors: Theme;
   layerOrder?: number;
   highlightedArea?: Geometry;
@@ -64,8 +64,8 @@ type NeutralSectionSignsProps = {
  * Renders the layer for the neutral sections signs
  * https://osrd.fr/en/docs/explanation/models/neutral_sections
  */
-export default function NeutralSectionSigns(props: NeutralSectionSignsProps) {
-  const { colors, layerOrder, infraID, highlightedArea } = props;
+const NeutralSectionSigns = ({ colors, layerOrder, highlightedArea }: NeutralSectionSignsProps) => {
+  const { infraId } = useMapContext();
 
   const signsParams: LayerProps = getNeutralSectionSignsLayerProps({
     sourceTable: 'neutral_signs',
@@ -83,12 +83,12 @@ export default function NeutralSectionSigns(props: NeutralSectionSignsProps) {
     highlightedArea,
   });
 
-  if (isNil(infraID)) return null;
+  if (isNil(infraId)) return null;
   return (
     <Source
       id="osrd_sncf_neutral_signs_geo"
       type="vector"
-      url={`${MAP_URL}/layer/neutral_signs/mvt/geo/?infra=${infraID}`}
+      url={`${MAP_URL}/layer/neutral_signs/mvt/geo/?infra=${infraId}`}
     >
       <OrderedLayer {...mastsParams} layerOrder={layerOrder} />
       <OrderedLayer {...signsParams} layerOrder={layerOrder} />
@@ -99,4 +99,6 @@ export default function NeutralSectionSigns(props: NeutralSectionSignsProps) {
       />
     </Source>
   );
-}
+};
+
+export default NeutralSectionSigns;

--- a/front/src/common/Map/Layers/InfraObjectLayers/extensions/SNCF/NeutralSections.tsx
+++ b/front/src/common/Map/Layers/InfraObjectLayers/extensions/SNCF/NeutralSections.tsx
@@ -4,6 +4,7 @@ import { type LayerProps, Source } from 'react-map-gl/maplibre';
 
 import { MAP_URL } from 'common/Map/const';
 import type { Theme } from 'common/Map/theme';
+import { useMapContext } from 'common/Map/useMapContext';
 
 import NeutralSectionSigns from './NeutralSectionSigns';
 import OrderedLayer from '../../../OrderedLayer';
@@ -11,16 +12,12 @@ import OrderedLayer from '../../../OrderedLayer';
 type NeutralSectionsProps = {
   colors: Theme;
   layerOrder: number;
-  infraID: number | undefined;
   highlightedArea?: Geometry;
 };
 
-const NeutralSectionsLayer = ({
-  colors,
-  layerOrder,
-  infraID,
-  highlightedArea,
-}: NeutralSectionsProps) => {
+const NeutralSectionsLayer = ({ colors, layerOrder, highlightedArea }: NeutralSectionsProps) => {
+  const { infraId } = useMapContext();
+
   const neutralSectionsParams: LayerProps = {
     type: 'line',
     'source-layer': 'neutral_sections',
@@ -44,13 +41,13 @@ const NeutralSectionsLayer = ({
     },
   };
 
-  if (isNil(infraID)) return null;
+  if (isNil(infraId)) return null;
   return (
     <>
       <Source
         id="neutral_sections_geo"
         type="vector"
-        url={`${MAP_URL}/layer/neutral_sections/mvt/geo/?infra=${infraID}`}
+        url={`${MAP_URL}/layer/neutral_sections/mvt/geo/?infra=${infraId}`}
       >
         <OrderedLayer
           {...neutralSectionsParams}
@@ -61,7 +58,6 @@ const NeutralSectionsLayer = ({
       <NeutralSectionSigns
         colors={colors}
         layerOrder={layerOrder}
-        infraID={infraID}
         highlightedArea={highlightedArea}
       />
     </>

--- a/front/src/common/Map/Layers/InfraObjectLayers/extensions/SNCF/PSL.tsx
+++ b/front/src/common/Map/Layers/InfraObjectLayers/extensions/SNCF/PSL.tsx
@@ -12,21 +12,13 @@ import {
   getDynamicTextSize,
 } from 'common/Map/Layers/commonLayers';
 import type { Theme } from 'common/Map/theme';
-import type { LayersSettings, MapSettings } from 'reducers/commonMap/types';
+import { useMapContext } from 'common/Map/useMapContext';
+import type { LayersSettings } from 'reducers/commonMap/types';
 import type { OmitLayer } from 'types';
 
 import SNCF_PSL_Signs from './PSLSigns';
 import OrderedLayer from '../../../OrderedLayer';
 import { getSpeedSectionsName, getFilterBySpeedSectionsTag } from '../../SpeedLimits';
-
-type SNCF_PSLProps = {
-  colors: Theme;
-  layerOrder: number;
-  punctualLayerOrder: number;
-  infraID?: number;
-  layersSettings: MapSettings['layersSettings'];
-  highlightedArea?: Geometry;
-};
 
 export function getPSLSpeedValueLayerProps({
   colors,
@@ -157,15 +149,17 @@ export function getPSLSpeedLineLayerProps({
   return res;
 }
 
-const SNCF_PSL = ({
-  colors,
-  layerOrder,
-  punctualLayerOrder,
-  infraID,
-  layersSettings,
-  highlightedArea,
-}: SNCF_PSLProps) => {
+type SNCF_PSLProps = {
+  colors: Theme;
+  layerOrder: number;
+  punctualLayerOrder: number;
+  highlightedArea?: Geometry;
+};
+
+const SNCF_PSL = ({ colors, layerOrder, punctualLayerOrder, highlightedArea }: SNCF_PSLProps) => {
   const { t } = useTranslation();
+  const { infraId, layersSettings } = useMapContext();
+
   const speedSectionFilter = getFilterBySpeedSectionsTag(layersSettings, highlightedArea);
 
   const speedValueParams = {
@@ -196,13 +190,13 @@ const SNCF_PSL = ({
     filter: speedSectionFilter,
   };
 
-  if (isNil(infraID)) return null;
+  if (isNil(infraId)) return null;
   return (
     <>
       <Source
         id="osrd_sncf_psl_geo"
         type="vector"
-        url={`${MAP_URL}/layer/psl/mvt/geo/?infra=${infraID}`}
+        url={`${MAP_URL}/layer/psl/mvt/geo/?infra=${infraId}`}
       >
         <OrderedLayer
           {...speedValueParams}

--- a/front/src/common/Map/Layers/OSMLayers/OSM.tsx
+++ b/front/src/common/Map/Layers/OSMLayers/OSM.tsx
@@ -4,14 +4,8 @@ import { get } from 'lodash';
 
 import OrderedLayer, { type OrderedLayerProps } from 'common/Map/Layers/OrderedLayer';
 import { getOSMStyle } from 'common/Map/theme';
+import { useMapContext } from 'common/Map/useMapContext';
 import type { MapStyle } from 'reducers/commonMap/types';
-
-type OSMProps = {
-  mapIsLoaded?: boolean;
-  layerOrder?: number;
-  mapStyle: MapStyle;
-  showOSM3dBuildings: boolean;
-};
 
 type FullLayerProps = OrderedLayerProps & { key?: string };
 type ToggledLayers = {
@@ -56,7 +50,14 @@ export function genOSMLayers(
   ));
 }
 
-function OSM({ layerOrder, mapIsLoaded, mapStyle, showOSM3dBuildings }: OSMProps) {
+type OSMProps = {
+  mapIsLoaded?: boolean;
+  layerOrder?: number;
+};
+
+const OSM = ({ layerOrder, mapIsLoaded }: OSMProps) => {
+  const { mapStyle, showOSM3dBuildings } = useMapContext();
+
   // Hack to full reload layers to avoid glitches
   // when switching map style (see #5777)
   const [reload, setReload] = useState(true);
@@ -70,6 +71,6 @@ function OSM({ layerOrder, mapIsLoaded, mapStyle, showOSM3dBuildings }: OSMProps
 
   if (reload) return null;
   return <>{genOSMLayers(mapStyle, toggledLayers, layerOrder)}</>;
-}
+};
 
 export default OSM;

--- a/front/src/common/Map/Layers/OSMLayers/OSMLayers.tsx
+++ b/front/src/common/Map/Layers/OSMLayers/OSMLayers.tsx
@@ -18,13 +18,7 @@ type OSMLayersProps = {
   hidePlatforms: boolean;
 };
 
-const OSMLayers = ({
-  mapStyle,
-  showOSM,
-  showOSM3dBuildings,
-  showOSMtracksections,
-  hidePlatforms,
-}: OSMLayersProps) => (
+const OSMLayers = ({ mapStyle, showOSM, hidePlatforms }: OSMLayersProps) => (
   <>
     <OpenStreetMapSource />
     <TerrainSource />
@@ -41,20 +35,12 @@ const OSMLayers = ({
       />
     )}
 
-    <TracksOSM
-      colors={colors[mapStyle]}
-      layerOrder={LAYER_GROUPS_ORDER[LAYERS.TRACKS_OSM.GROUP]}
-      showOSMtracksections={showOSMtracksections}
-    />
+    <TracksOSM colors={colors[mapStyle]} layerOrder={LAYER_GROUPS_ORDER[LAYERS.TRACKS_OSM.GROUP]} />
 
     {!showOSM ? null : (
       <>
-        <OSM
-          mapStyle={mapStyle}
-          layerOrder={LAYER_GROUPS_ORDER[LAYERS.BACKGROUND.GROUP]}
-          showOSM3dBuildings={showOSM3dBuildings}
-        />
-        <Hillshade mapStyle={mapStyle} layerOrder={LAYER_GROUPS_ORDER[LAYERS.BACKGROUND.GROUP]} />
+        <OSM layerOrder={LAYER_GROUPS_ORDER[LAYERS.BACKGROUND.GROUP]} />
+        <Hillshade layerOrder={LAYER_GROUPS_ORDER[LAYERS.BACKGROUND.GROUP]} />
       </>
     )}
   </>

--- a/front/src/common/Map/Layers/OSMLayers/Platforms.tsx
+++ b/front/src/common/Map/Layers/OSMLayers/Platforms.tsx
@@ -1,7 +1,7 @@
 import { type LayerProps } from 'react-map-gl/maplibre';
 
 import type { Theme } from 'common/Map/theme';
-import { useMapSettings } from 'reducers/commonMap';
+import { useMapContext } from 'common/Map/useMapContext';
 
 import OrderedLayer from '../OrderedLayer';
 
@@ -27,7 +27,7 @@ export function Platforms(props: PlatformsProps) {
 }
 
 function PlatformsState(props: PlatformsProps) {
-  const { layersSettings } = useMapSettings();
+  const { layersSettings } = useMapContext();
 
   if (!layersSettings.platforms) return null;
   return <Platforms {...props} />;

--- a/front/src/common/Map/Layers/OSMLayers/TracksOSM.tsx
+++ b/front/src/common/Map/Layers/OSMLayers/TracksOSM.tsx
@@ -1,16 +1,18 @@
 import { type LayerProps } from 'react-map-gl/maplibre';
 
 import type { Theme } from 'common/Map/theme';
+import { useMapContext } from 'common/Map/useMapContext';
 
 import OrderedLayer from '../OrderedLayer';
 
 type TracksOSMProps = {
   colors: Theme;
   layerOrder: number;
-  showOSMtracksections: boolean;
 };
 
-function TracksOSM({ colors, layerOrder, showOSMtracksections }: TracksOSMProps) {
+const TracksOSM = ({ colors, layerOrder }: TracksOSMProps) => {
+  const { showOSMtracksections } = useMapContext();
+
   const railwayMinor: LayerProps = {
     id: 'railwayMinor',
     type: 'line',
@@ -47,6 +49,6 @@ function TracksOSM({ colors, layerOrder, showOSMtracksections }: TracksOSMProps)
       <OrderedLayer {...railwayMajor} layerOrder={layerOrder} />
     </>
   );
-}
+};
 
 export default TracksOSM;

--- a/front/src/common/Map/MapKey.tsx
+++ b/front/src/common/Map/MapKey.tsx
@@ -1,14 +1,14 @@
 import { useTranslation } from 'react-i18next';
 
 import { colors, type Theme } from 'common/Map/theme';
-import { useMapSettings } from 'reducers/commonMap';
 
 import { electrificationMapKey, type MapKeyProps, speedLimitMapKey } from './const';
 import MapModalHeader from './MapModalHeader';
+import { useMapContext } from './useMapContext';
 
 const MapSettings = ({ closeMapKeyPopUp }: MapKeyProps) => {
   const { t } = useTranslation();
-  const { mapStyle } = useMapSettings();
+  const { mapStyle } = useMapContext();
   const speedLimits = speedLimitMapKey.map((key) => (
     <div className="mapkey-item" key={key.text}>
       <div className="mapkey-icon">

--- a/front/src/common/Map/Settings/MapSettingsBackgroundSwitches.tsx
+++ b/front/src/common/Map/Settings/MapSettingsBackgroundSwitches.tsx
@@ -10,9 +10,8 @@ import iconIGNBDORTHO from 'assets/pictures/mapbuttons/mapstyle-ortho.jpg';
 import iconOSMTracks from 'assets/pictures/mapbuttons/mapstyle-osm-tracks.jpg';
 import iconIGNSCAN25 from 'assets/pictures/mapbuttons/mapstyle-scan25.jpg';
 import SwitchSNCF, { SWITCH_TYPES, type SwitchSNCFProps } from 'common/BootstrapSNCF/SwitchSNCF';
-import { useMapSettingsActions, useMapSettings } from 'reducers/commonMap';
-import type { MapSettings } from 'reducers/commonMap/types';
-import { useAppDispatch } from 'store';
+
+import { useMapContext } from '../useMapContext';
 
 type MapBackgroundSettings = {
   showIGNBDORTHO: boolean;
@@ -48,17 +47,11 @@ const FormatSwitch = ({ name, onChange, state, icon, label }: FormatSwitchProps)
 
 const MapSettingsBackgroundSwitches = () => {
   const { t } = useTranslation();
-  const dispatch = useAppDispatch();
-  const { updateMapSettings: updateMapSettingsAction } = useMapSettingsActions();
-  const { terrain3DExaggeration: initialTerrain3DExaggeration, ...initialSettings } =
-    useMapSettings();
-
-  const updateMapSettings = useCallback(
-    (value: Partial<MapSettings>) => {
-      dispatch(updateMapSettingsAction(value));
-    },
-    [dispatch, updateMapSettingsAction]
-  );
+  const {
+    updateMapSettings,
+    terrain3DExaggeration: initialTerrain3DExaggeration,
+    ...initialSettings
+  } = useMapContext();
 
   const [terrain3DExaggeration, setTerrain3DExaggeration] = useState(initialTerrain3DExaggeration);
   const [backgroundSettings, setBackgroundSettings] =

--- a/front/src/common/Map/Settings/MapSettingsBackgroundSwitches.tsx
+++ b/front/src/common/Map/Settings/MapSettingsBackgroundSwitches.tsx
@@ -1,3 +1,5 @@
+import { useCallback, useState } from 'react';
+
 import Slider from 'rc-slider';
 import { useTranslation } from 'react-i18next';
 
@@ -8,8 +10,19 @@ import iconIGNBDORTHO from 'assets/pictures/mapbuttons/mapstyle-ortho.jpg';
 import iconOSMTracks from 'assets/pictures/mapbuttons/mapstyle-osm-tracks.jpg';
 import iconIGNSCAN25 from 'assets/pictures/mapbuttons/mapstyle-scan25.jpg';
 import SwitchSNCF, { SWITCH_TYPES, type SwitchSNCFProps } from 'common/BootstrapSNCF/SwitchSNCF';
-import { useMapSettings, useMapSettingsActions } from 'reducers/commonMap';
+import { useMapSettingsActions, useMapSettings } from 'reducers/commonMap';
+import type { MapSettings } from 'reducers/commonMap/types';
 import { useAppDispatch } from 'store';
+
+type MapBackgroundSettings = {
+  showIGNBDORTHO: boolean;
+  showIGNSCAN25: boolean;
+  showIGNCadastre: boolean;
+  showOSM: boolean;
+  showOSM3dBuildings: boolean;
+  showOSMtracksections: boolean;
+  smoothTravel: boolean;
+};
 
 type FormatSwitchProps = {
   name: string;
@@ -36,7 +49,36 @@ const FormatSwitch = ({ name, onChange, state, icon, label }: FormatSwitchProps)
 const MapSettingsBackgroundSwitches = () => {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
-  const { updateMapSettings } = useMapSettingsActions();
+  const { updateMapSettings: updateMapSettingsAction } = useMapSettingsActions();
+  const { terrain3DExaggeration: initialTerrain3DExaggeration, ...initialSettings } =
+    useMapSettings();
+
+  const updateMapSettings = useCallback(
+    (value: Partial<MapSettings>) => {
+      dispatch(updateMapSettingsAction(value));
+    },
+    [dispatch, updateMapSettingsAction]
+  );
+
+  const [terrain3DExaggeration, setTerrain3DExaggeration] = useState(initialTerrain3DExaggeration);
+  const [backgroundSettings, setBackgroundSettings] =
+    useState<MapBackgroundSettings>(initialSettings);
+
+  const toggleLayer = useCallback(
+    (layer: keyof MapBackgroundSettings) => {
+      let updatedLayers: Partial<MapBackgroundSettings> = { [layer]: !backgroundSettings[layer] };
+      if (layer === 'showOSM' && backgroundSettings.showOSM) {
+        updatedLayers = { ...updatedLayers, showOSM3dBuildings: false };
+      } else if (layer === 'showOSM3dBuildings' && !backgroundSettings.showOSM3dBuildings) {
+        updatedLayers = { ...updatedLayers, showOSM: true };
+      }
+
+      setBackgroundSettings({ ...backgroundSettings, ...updatedLayers });
+      updateMapSettings(updatedLayers);
+    },
+    [backgroundSettings, updateMapSettings]
+  );
+
   const {
     showIGNBDORTHO,
     showIGNSCAN25,
@@ -45,32 +87,13 @@ const MapSettingsBackgroundSwitches = () => {
     showOSM3dBuildings,
     showOSMtracksections,
     smoothTravel,
-    terrain3DExaggeration,
-  } = useMapSettings();
-
-  const onShowOSMToggled = () => {
-    dispatch(
-      updateMapSettings({
-        showOSM: !showOSM,
-        ...(showOSM ? { showOSM3dBuildings: false } : undefined),
-      })
-    );
-  };
-
-  const onShow3dBuildingsToggled = () => {
-    dispatch(
-      updateMapSettings({
-        showOSM3dBuildings: !showOSM3dBuildings,
-        ...(!showOSM3dBuildings ? { showOSM: true } : undefined),
-      })
-    );
-  };
+  } = backgroundSettings;
 
   return (
     <>
       <FormatSwitch
         name="show-osm-switch"
-        onChange={() => onShowOSMToggled()}
+        onChange={() => toggleLayer('showOSM')}
         state={showOSM}
         icon={iconOSM}
         label={t('mapSettings.layers.showOSM')}
@@ -78,7 +101,7 @@ const MapSettingsBackgroundSwitches = () => {
       <div className="my-2" />
       <FormatSwitch
         name="show3dBuildings"
-        onChange={() => onShow3dBuildingsToggled()}
+        onChange={() => toggleLayer('showOSM3dBuildings')}
         state={showOSM3dBuildings}
         icon={icon3dBuildings}
         label={t('mapSettings.layers.showOSM3dBuildings')}
@@ -86,9 +109,7 @@ const MapSettingsBackgroundSwitches = () => {
       <div className="my-2" />
       <FormatSwitch
         name="show-osm-track-section-switch"
-        onChange={() =>
-          dispatch(updateMapSettings({ showOSMtracksections: !showOSMtracksections }))
-        }
+        onChange={() => toggleLayer('showOSMtracksections')}
         state={showOSMtracksections}
         icon={iconOSMTracks}
         label={t('mapSettings.layers.showOSMtracksections')}
@@ -96,7 +117,7 @@ const MapSettingsBackgroundSwitches = () => {
       <div className="my-2" />
       <FormatSwitch
         name="show-ign-bdortho-switch"
-        onChange={() => dispatch(updateMapSettings({ showIGNBDORTHO: !showIGNBDORTHO }))}
+        onChange={() => toggleLayer('showIGNBDORTHO')}
         state={showIGNBDORTHO}
         icon={iconIGNBDORTHO}
         label={t('mapSettings.layers.showIGNBDORTHO')}
@@ -104,7 +125,7 @@ const MapSettingsBackgroundSwitches = () => {
       <div className="my-2" />
       <FormatSwitch
         name="show-ignscan25-switch"
-        onChange={() => dispatch(updateMapSettings({ showIGNSCAN25: !showIGNSCAN25 }))}
+        onChange={() => toggleLayer('showIGNSCAN25')}
         state={showIGNSCAN25}
         icon={iconIGNSCAN25}
         label={t('mapSettings.layers.showIGNSCAN25')}
@@ -112,7 +133,7 @@ const MapSettingsBackgroundSwitches = () => {
       <div className="my-2" />
       <FormatSwitch
         name="show-ign-cadastres-witch"
-        onChange={() => dispatch(updateMapSettings({ showIGNCadastre: !showIGNCadastre }))}
+        onChange={() => toggleLayer('showIGNCadastre')}
         state={showIGNCadastre}
         icon={iconIGNCadastre}
         label={t('mapSettings.layers.showIGNCadastre')}
@@ -131,16 +152,17 @@ const MapSettingsBackgroundSwitches = () => {
             step={0.1}
             marks={{ 0: 0, 0.5: '0.5', 1: 'x1', 2: 'x2', 5: 'x5' }}
             value={terrain3DExaggeration}
-            onChange={(value) =>
-              dispatch(updateMapSettings({ terrain3DExaggeration: value as number }))
-            }
+            onChange={(value) => {
+              setTerrain3DExaggeration(value as number);
+              updateMapSettings({ terrain3DExaggeration: value as number });
+            }}
           />
         </div>
       </div>
 
       <FormatSwitch
         name="smoothTravel-switch"
-        onChange={() => dispatch(updateMapSettings({ smoothTravel: !smoothTravel }))}
+        onChange={() => toggleLayer('smoothTravel')}
         state={smoothTravel}
         icon=""
         label={t('mapSettings.layers.smoothTravel')}

--- a/front/src/common/Map/Settings/MapSettingsBackgroundSwitches.tsx
+++ b/front/src/common/Map/Settings/MapSettingsBackgroundSwitches.tsx
@@ -8,8 +8,7 @@ import iconIGNBDORTHO from 'assets/pictures/mapbuttons/mapstyle-ortho.jpg';
 import iconOSMTracks from 'assets/pictures/mapbuttons/mapstyle-osm-tracks.jpg';
 import iconIGNSCAN25 from 'assets/pictures/mapbuttons/mapstyle-scan25.jpg';
 import SwitchSNCF, { SWITCH_TYPES, type SwitchSNCFProps } from 'common/BootstrapSNCF/SwitchSNCF';
-import { useMapSettingsActions } from 'reducers/commonMap';
-import { type MapSettings } from 'reducers/commonMap/types';
+import { useMapSettings, useMapSettingsActions } from 'reducers/commonMap';
 import { useAppDispatch } from 'store';
 
 type FormatSwitchProps = {
@@ -34,7 +33,7 @@ const FormatSwitch = ({ name, onChange, state, icon, label }: FormatSwitchProps)
   </div>
 );
 
-const MapSettingsBackgroundSwitches = ({ mapSettings }: { mapSettings: MapSettings }) => {
+const MapSettingsBackgroundSwitches = () => {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
   const { updateMapSettings } = useMapSettingsActions();
@@ -47,7 +46,7 @@ const MapSettingsBackgroundSwitches = ({ mapSettings }: { mapSettings: MapSettin
     showOSMtracksections,
     smoothTravel,
     terrain3DExaggeration,
-  } = mapSettings;
+  } = useMapSettings();
 
   const onShowOSMToggled = () => {
     dispatch(

--- a/front/src/common/Map/Settings/MapSettingsLayers.tsx
+++ b/front/src/common/Map/Settings/MapSettingsLayers.tsx
@@ -11,9 +11,9 @@ import SignalsSVGFile from 'assets/pictures/layersicons/layer_signal.svg';
 import OPsSVGFile from 'assets/pictures/layersicons/ops.svg';
 import SwitchesSVGFile from 'assets/pictures/layersicons/switches.svg';
 import SwitchSNCF, { SWITCH_TYPES } from 'common/BootstrapSNCF/SwitchSNCF';
-import { useMapSettings, useMapSettingsActions } from 'reducers/commonMap';
 import type { MapSettings } from 'reducers/commonMap/types';
-import { useAppDispatch } from 'store';
+
+import { useMapContext } from '../useMapContext';
 
 type LayerSettings = MapSettings['layersSettings'];
 
@@ -25,20 +25,19 @@ type FormatSwitchProps = {
 };
 
 export const FormatSwitch = ({ name, icon, color, disabled }: FormatSwitchProps) => {
-  const dispatch = useAppDispatch();
   const { t } = useTranslation();
-  const { layersSettings } = useMapSettings();
-  const { updateLayersSettings } = useMapSettingsActions();
+  const { layersSettings, updateMapSettings } = useMapContext();
 
   const setLayerSettings = useCallback(
     (setting: keyof LayerSettings) => {
-      dispatch(
-        updateLayersSettings({
+      updateMapSettings({
+        layersSettings: {
+          ...layersSettings,
           [setting]: !layersSettings[setting],
-        })
-      );
+        },
+      });
     },
-    [dispatch, layersSettings]
+    [updateMapSettings, layersSettings]
   );
 
   return (

--- a/front/src/common/Map/Settings/MapSettingsMapStyle.tsx
+++ b/front/src/common/Map/Settings/MapSettingsMapStyle.tsx
@@ -6,17 +6,15 @@ import { useTranslation } from 'react-i18next';
 import picDarkMode from 'assets/pictures/mapbuttons/mapstyle-dark.jpg';
 import picMinimalMode from 'assets/pictures/mapbuttons/mapstyle-minimal.jpg';
 import picNormalMode from 'assets/pictures/mapbuttons/mapstyle-normal.jpg';
-import { useMapSettings, useMapSettingsActions } from 'reducers/commonMap';
-import { useAppDispatch } from 'store';
+
+import { useMapContext } from '../useMapContext';
 
 const MapSettingsMapStyle = () => {
-  const dispatch = useAppDispatch();
-  const { mapStyle: initialMapStyle } = useMapSettings();
-  const { updateMapSettings } = useMapSettingsActions();
-
+  const { mapStyle: initialMapStyle, updateMapSettings } = useMapContext();
   const [mapStyle, setMapStyle] = useState(initialMapStyle);
 
   const { t } = useTranslation();
+
   const styles = [
     { key: 'normal', image: picNormalMode, label: t('mapSettings.mapstyles.normal') },
     { key: 'minimal', image: picMinimalMode, label: t('mapSettings.mapstyles.minimal') },
@@ -32,7 +30,7 @@ const MapSettingsMapStyle = () => {
           type="button"
           onClick={() => {
             setMapStyle(key);
-            dispatch(updateMapSettings({ mapStyle: key }));
+            updateMapSettings({ mapStyle: key });
           }}
         >
           <img src={image} alt={`${key} mode`} />

--- a/front/src/common/Map/Settings/MapSettingsMapStyle.tsx
+++ b/front/src/common/Map/Settings/MapSettingsMapStyle.tsx
@@ -4,13 +4,13 @@ import { useTranslation } from 'react-i18next';
 import picDarkMode from 'assets/pictures/mapbuttons/mapstyle-dark.jpg';
 import picMinimalMode from 'assets/pictures/mapbuttons/mapstyle-minimal.jpg';
 import picNormalMode from 'assets/pictures/mapbuttons/mapstyle-normal.jpg';
-import { useMapSettingsActions } from 'reducers/commonMap';
-import type { MapStyle } from 'reducers/commonMap/types';
+import { useMapSettings, useMapSettingsActions } from 'reducers/commonMap';
 import { useAppDispatch } from 'store';
 
-const MapSettingsMapStyle = ({ mapStyle }: { mapStyle: MapStyle }) => {
+const MapSettingsMapStyle = () => {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
+  const { mapStyle } = useMapSettings();
   const { updateMapSettings } = useMapSettingsActions();
   const styles = [
     { key: 'normal', image: picNormalMode, label: t('mapSettings.mapstyles.normal') },

--- a/front/src/common/Map/Settings/MapSettingsMapStyle.tsx
+++ b/front/src/common/Map/Settings/MapSettingsMapStyle.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
 
@@ -8,10 +10,13 @@ import { useMapSettings, useMapSettingsActions } from 'reducers/commonMap';
 import { useAppDispatch } from 'store';
 
 const MapSettingsMapStyle = () => {
-  const { t } = useTranslation();
   const dispatch = useAppDispatch();
-  const { mapStyle } = useMapSettings();
+  const { mapStyle: initialMapStyle } = useMapSettings();
   const { updateMapSettings } = useMapSettingsActions();
+
+  const [mapStyle, setMapStyle] = useState(initialMapStyle);
+
+  const { t } = useTranslation();
   const styles = [
     { key: 'normal', image: picNormalMode, label: t('mapSettings.mapstyles.normal') },
     { key: 'minimal', image: picMinimalMode, label: t('mapSettings.mapstyles.minimal') },
@@ -25,7 +30,10 @@ const MapSettingsMapStyle = () => {
           key={key}
           className={cx('col-xs-4 mb-2 mapstyle-style-select', mapStyle === key && 'active')}
           type="button"
-          onClick={() => dispatch(updateMapSettings({ mapStyle: key }))}
+          onClick={() => {
+            setMapStyle(key);
+            dispatch(updateMapSettings({ mapStyle: key }));
+          }}
         >
           <img src={image} alt={`${key} mode`} />
           <span>{label}</span>

--- a/front/src/common/Map/WarpedMap/SimulationWarpedMap.tsx
+++ b/front/src/common/Map/WarpedMap/SimulationWarpedMap.tsx
@@ -18,9 +18,12 @@ import DataLoader from 'common/Map/WarpedMap/DataLoader';
 import type { WarpingFunction } from 'common/Map/WarpedMap/getWarping';
 import getWarping from 'common/Map/WarpedMap/getWarping';
 import { useInfraID } from 'common/osrdContext';
+import { useMapSettings } from 'reducers/commonMap';
 import { getSimulationResults } from 'reducers/simulationResults/selectors';
 import { useAppDispatch } from 'store';
 import { clip } from 'utils/mapHelper';
+
+import { MapContextProvider } from '../useMapContext';
 
 const WIDTH = 300;
 
@@ -75,6 +78,7 @@ const SimulationWarpedMap = ({
   const layers = useMemo(() => new Set<Layer>(['track_sections']), []);
   const [mode, setMode] = useState<'manual' | 'auto'>('auto');
   const { chart } = useSelector(getSimulationResults);
+  const mapSettings = useMapSettings();
 
   // Boundaries handling (ie zoom sync):
   const syncedBoundingBox: LngLatBoundsLike = useMemo(() => {
@@ -203,56 +207,58 @@ const SimulationWarpedMap = ({
   }, [state.type]);
 
   return (
-    <div
-      data-testid="simulation-warped-map"
-      className="warped-map position-relative d-flex flex-row"
-      style={{ width: collapsed ? 0 : WIDTH }}
-    >
-      {state.type === 'pathLoaded' && (
-        <DataLoader
-          bbox={state.pathBBox}
-          layers={layers}
-          getGeoJSONs={(osrdData, osmData) => {
-            const transformed = {
-              osm: transformDataStatePayload(osmData, state.transform) as DataStatePayload['osm'],
-              osrd: transformDataStatePayload(
-                osrdData,
-                state.transform
-              ) as DataStatePayload['osrd'],
-            };
-            setState({ ...state, ...transformed, type: 'dataLoaded' });
-          }}
-        />
-      )}
-      {state.type !== 'dataLoaded' && <LoaderFill />}
-      {state.type === 'dataLoaded' && (
-        <div
-          className="bg-white border"
-          style={{
-            width: WIDTH,
-            borderRadius: 4,
-          }}
-        >
-          <WarpedMap
-            osrdLayers={layers}
-            bbox={state.warpedBBox}
-            osrdData={state.osrd}
-            osmData={state.osm}
-            itinerary={warpedItinerary}
-            boundingBox={mode === 'auto' ? syncedBoundingBox : undefined}
+    <MapContextProvider infraId={infraID} mapSettings={mapSettings} updateMapSettings={() => {}}>
+      <div
+        data-testid="simulation-warped-map"
+        className="warped-map position-relative d-flex flex-row"
+        style={{ width: collapsed ? 0 : WIDTH }}
+      >
+        {state.type === 'pathLoaded' && (
+          <DataLoader
+            bbox={state.pathBBox}
+            layers={layers}
+            getGeoJSONs={(osrdData, osmData) => {
+              const transformed = {
+                osm: transformDataStatePayload(osmData, state.transform) as DataStatePayload['osm'],
+                osrd: transformDataStatePayload(
+                  osrdData,
+                  state.transform
+                ) as DataStatePayload['osrd'],
+              };
+              setState({ ...state, ...transformed, type: 'dataLoaded' });
+            }}
           />
-          <div className="buttons">
-            <button
-              type="button"
-              className="btn-rounded btn-rounded-white box-shadow btn-rotate"
-              onClick={() => setMode(mode === 'auto' ? 'manual' : 'auto')}
-            >
-              {mode === 'manual' ? <PiLinkBold /> : <PiLinkBreakBold />}
-            </button>
+        )}
+        {state.type !== 'dataLoaded' && <LoaderFill />}
+        {state.type === 'dataLoaded' && (
+          <div
+            className="bg-white border"
+            style={{
+              width: WIDTH,
+              borderRadius: 4,
+            }}
+          >
+            <WarpedMap
+              osrdLayers={layers}
+              bbox={state.warpedBBox}
+              osrdData={state.osrd}
+              osmData={state.osm}
+              itinerary={warpedItinerary}
+              boundingBox={mode === 'auto' ? syncedBoundingBox : undefined}
+            />
+            <div className="buttons">
+              <button
+                type="button"
+                className="btn-rounded btn-rounded-white box-shadow btn-rotate"
+                onClick={() => setMode(mode === 'auto' ? 'manual' : 'auto')}
+              >
+                {mode === 'manual' ? <PiLinkBold /> : <PiLinkBreakBold />}
+              </button>
+            </div>
           </div>
-        </div>
-      )}
-    </div>
+        )}
+      </div>
+    </MapContextProvider>
   );
 };
 

--- a/front/src/common/Map/components/LayersModal.tsx
+++ b/front/src/common/Map/components/LayersModal.tsx
@@ -55,7 +55,7 @@ const LayersModal = ({ compactModal, closePortalModal }: LayersModalProps) => {
   const dispatch = useAppDispatch();
 
   const mapSettings = useMapSettings();
-  const { layersSettings, mapStyle } = mapSettings;
+  const { layersSettings } = mapSettings;
   const [selectedLayers, setSelectedLayers] = useState<LayersSettings>(layersSettings);
   const { updateLayersSettings } = useMapSettingsActions();
 
@@ -141,8 +141,8 @@ const LayersModal = ({ compactModal, closePortalModal }: LayersModalProps) => {
         <hr />
         {!compactModal && (
           <>
-            <MapSettingsMapStyle mapStyle={mapStyle} />
-            <MapSettingsBackgroundSwitches mapSettings={mapSettings} />
+            <MapSettingsMapStyle />
+            <MapSettingsBackgroundSwitches />
           </>
         )}
       </div>

--- a/front/src/common/Map/components/LayersModal.tsx
+++ b/front/src/common/Map/components/LayersModal.tsx
@@ -20,10 +20,9 @@ import SwitchSNCF from 'common/BootstrapSNCF/SwitchSNCF/SwitchSNCF';
 import MapSettingsBackgroundSwitches from 'common/Map/Settings/MapSettingsBackgroundSwitches';
 import { Icon2SVG } from 'common/Map/Settings/MapSettingsLayers';
 import MapSettingsMapStyle from 'common/Map/Settings/MapSettingsMapStyle';
-import { useInfraID } from 'common/osrdContext';
-import { useMapSettings, useMapSettingsActions } from 'reducers/commonMap';
 import type { LayersSettings } from 'reducers/commonMap/types';
-import { useAppDispatch } from 'store';
+
+import { useMapContext } from '../useMapContext';
 
 const LAYERS = [
   { layer: 'signals', icon: signalsIcon },
@@ -52,14 +51,9 @@ type LayersModalProps = {
 
 const LayersModal = ({ compactModal, closePortalModal }: LayersModalProps) => {
   const { t } = useTranslation();
-  const dispatch = useAppDispatch();
 
-  const mapSettings = useMapSettings();
-  const { layersSettings } = mapSettings;
+  const { infraId: infraID, layersSettings, updateMapSettings } = useMapContext();
   const [selectedLayers, setSelectedLayers] = useState<LayersSettings>(layersSettings);
-  const { updateLayersSettings } = useMapSettingsActions();
-
-  const infraID = useInfraID();
 
   const { data: speedLimitTagsByInfraId } =
     osrdEditoastApi.endpoints.getInfraByInfraIdSpeedLimitTags.useQuery(
@@ -82,9 +76,9 @@ const LayersModal = ({ compactModal, closePortalModal }: LayersModalProps) => {
       };
 
       setSelectedLayers(updatedLayers);
-      dispatch(updateLayersSettings(updatedLayers));
+      updateMapSettings({ layersSettings: updatedLayers });
     },
-    [selectedLayers, dispatch, updateLayersSettings]
+    [selectedLayers, updateMapSettings]
   );
 
   return (
@@ -127,7 +121,7 @@ const LayersModal = ({ compactModal, closePortalModal }: LayersModalProps) => {
             onChange={(e) => {
               const newTag = e.target.value !== DEFAULT_SPEED_LIMIT_TAG ? e.target.value : null;
               const newLayers = { ...selectedLayers, speedlimittag: newTag };
-              dispatch(updateLayersSettings(newLayers));
+              updateMapSettings({ layersSettings: newLayers });
               setSelectedLayers(newLayers);
             }}
           >

--- a/front/src/common/Map/useMapContext.tsx
+++ b/front/src/common/Map/useMapContext.tsx
@@ -5,6 +5,7 @@ import type { MapSettings } from 'reducers/commonMap/types';
 type MapContextType =
   | ({
       infraId?: number;
+      updateMapSettings: (modifs: Partial<MapSettings>) => void;
     } & MapSettings)
   | null;
 const MapContext = createContext<MapContextType>(null);

--- a/front/src/common/Map/useMapContext.tsx
+++ b/front/src/common/Map/useMapContext.tsx
@@ -6,6 +6,8 @@ type MapContextType =
   | ({
       infraId?: number;
       updateMapSettings: (modifs: Partial<MapSettings>) => void;
+      highlightedTrackSections?: string[];
+      highlightedOperationalPoints?: number[];
     } & MapSettings)
   | null;
 const MapContext = createContext<MapContextType>(null);
@@ -13,6 +15,8 @@ const MapContext = createContext<MapContextType>(null);
 type MapContextProviderProps = {
   infraId?: number;
   mapSettings: MapSettings;
+  highlightedTrackSections?: string[];
+  highlightedOperationalPoints?: number[];
   updateMapSettings: (modifs: Partial<MapSettings>) => void;
   children: ReactNode;
 };
@@ -20,6 +24,8 @@ type MapContextProviderProps = {
 export const MapContextProvider = ({
   infraId,
   mapSettings,
+  highlightedTrackSections,
+  highlightedOperationalPoints,
   updateMapSettings,
   children,
 }: MapContextProviderProps) => {
@@ -27,6 +33,8 @@ export const MapContextProvider = ({
     () => ({
       infraId,
       ...mapSettings,
+      highlightedTrackSections,
+      highlightedOperationalPoints,
       updateMapSettings,
     }),
     [infraId, mapSettings, updateMapSettings]

--- a/front/src/common/Map/useMapContext.tsx
+++ b/front/src/common/Map/useMapContext.tsx
@@ -1,0 +1,43 @@
+import { createContext, useContext, useMemo, type ReactNode } from 'react';
+
+import type { MapSettings } from 'reducers/commonMap/types';
+
+type MapContextType =
+  | ({
+      infraId?: number;
+    } & MapSettings)
+  | null;
+const MapContext = createContext<MapContextType>(null);
+
+type MapContextProviderProps = {
+  infraId?: number;
+  mapSettings: MapSettings;
+  updateMapSettings: (modifs: Partial<MapSettings>) => void;
+  children: ReactNode;
+};
+
+export const MapContextProvider = ({
+  infraId,
+  mapSettings,
+  updateMapSettings,
+  children,
+}: MapContextProviderProps) => {
+  const providedContext = useMemo(
+    () => ({
+      infraId,
+      ...mapSettings,
+      updateMapSettings,
+    }),
+    [infraId, mapSettings, updateMapSettings]
+  );
+
+  return <MapContext.Provider value={providedContext}>{children}</MapContext.Provider>;
+};
+
+export const useMapContext = () => {
+  const context = useContext(MapContext);
+  if (!context) {
+    throw new Error('useMapContext must be used within a MapContextProvider');
+  }
+  return context;
+};


### PR DESCRIPTION
The goal of this PR is to introduce a map context to make the maps independent from the store. Each commit is atomic.

This is a first step toward map harmonization.

## Context
On the STDCM page, we have 2 maps that should not be synchronized (https://github.com/OpenRailAssociation/osrd/issues/13787). But as we currently get the mapSettings from the store, this is not possible. To solve this issue, we could:
- store 2 map settings in the store for the stdcm page, but even then, accessing the settings directly from very deep components would not be easy (how would we differentiate whether we are in the inputs or results map, for instance in the IGN layers ?)
- make all map components (common/Map) independent from the store, either by props drilling or by using a Context. The settings would be defined above the map and could come from either the store or from local state. I chose to use a Context here, as some components are quite deep

More generally, I don't think it's a good practice for deep components (and shared across several applications) to directly access the store. It can make some changes very difficult. So even without the bug, I believe it would have been a nice refacto :)