### PR TITLE
front: drop editorLayers

### DIFF
--- a/front/public/locales/en/translation.json
+++ b/front/public/locales/en/translation.json
@@ -625,6 +625,7 @@
       "buffer_stops": "Buffer stops",
       "detectors": "Detectors",
       "electrifications": "Electrification",
+      "errors": "Errors",
       "level_crossings": "Level crossings",
       "neutral_sections": "Neutral sections",
       "operational_points": "Operational points",

--- a/front/public/locales/en/translation.json
+++ b/front/public/locales/en/translation.json
@@ -135,14 +135,13 @@
       "neutral_sections": "Neutral sections",
       "operational_points": "Operational points",
       "platforms": "Platforms",
-      "psl-psl_signs": "Permanent speed limits",
       "routes": "Routes",
       "signals": "Signals",
       "sncf_psl": "Permanent speed limits",
       "speed_limits": "Speed limits",
       "speed_sections": "Speed limits",
       "switches": "Switches",
-      "track_sections": "Track sections"
+      "tvds": "Track sections"
     },
     "layers-modal": {
       "frozen-layer": "needed for the active tool",

--- a/front/public/locales/fr/translation.json
+++ b/front/public/locales/fr/translation.json
@@ -625,6 +625,7 @@
       "buffer_stops": "Heurtoirs",
       "detectors": "Détecteurs",
       "electrifications": "Électrification",
+      "errors": "Erreurs",
       "level_crossings": "Passages à niveau",
       "neutral_sections": "BP/CC",
       "operational_points": "Points remarquables",

--- a/front/public/locales/fr/translation.json
+++ b/front/public/locales/fr/translation.json
@@ -135,14 +135,13 @@
       "neutral_sections": "BP/CC",
       "operational_points": "Points remarquables",
       "platforms": "Quais",
-      "psl-psl_signs": "Limitations permanentes de vitesse",
       "routes": "Itinéraires",
       "signals": "Signaux",
       "sncf_psl": "Limitations permanentes de vitesse",
       "speed_limits": "Vitesses de ligne",
       "speed_sections": "Vitesses de ligne",
       "switches": "Aiguillages",
-      "track_sections": "Sections de voie"
+      "tvds": "Sections de voie"
     },
     "layers-modal": {
       "frozen-layer": "nécessaire pour l'outil actif",

--- a/front/src/applications/editor/Editor.tsx
+++ b/front/src/applications/editor/Editor.tsx
@@ -40,9 +40,10 @@ import { getIsLoading } from 'reducers/main/mainSelector';
 import { useAppDispatch } from 'store';
 import { castErrorToFailure } from 'utils/error';
 
-import type { EditoastType, Layer } from './consts';
+import type { EditoastType } from './consts';
 import type { EditorContextType, ExtendedEditorContextType, FullTool, Reducer } from './types';
 import type { EditorEntity } from './typesEditorEntity';
+import { getLayerSettingNameFromEditorLayer } from './utils';
 
 const Editor = () => {
   const [showPanelContainer, setShowPanelContainer] = useState(true);
@@ -50,7 +51,7 @@ const Editor = () => {
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
   const { openModal, closeModal } = useModal();
-  const { updateInfraID, selectLayers } = useOsrdActions() as EditorSliceActions;
+  const { updateInfraID } = useOsrdActions() as EditorSliceActions;
 
   const { updateMapSettings: updateMapSettingsAction, updateViewport: updateViewportAction } =
     useMapSettingsActions();
@@ -315,13 +316,16 @@ const Editor = () => {
 
     const { requiredLayers, incompatibleLayers } = toolAndState.tool;
     if (requiredLayers || incompatibleLayers) {
-      const newLayers: Set<Layer> = new Set([
-        ...editorState.editorLayers,
-        ...(requiredLayers ?? []),
-      ]);
-
-      if (incompatibleLayers) incompatibleLayers.forEach((l) => newLayers.delete(l));
-      dispatch(selectLayers(newLayers));
+      const newLayersSettings = { ...mapSettings.layersSettings };
+      (requiredLayers ?? []).forEach((editorLayer) => {
+        const layer = getLayerSettingNameFromEditorLayer(editorLayer);
+        if (layer && layer !== 'speedlimittag') newLayersSettings[layer] = true;
+      });
+      (incompatibleLayers ?? []).forEach((editorLayer) => {
+        const layer = getLayerSettingNameFromEditorLayer(editorLayer);
+        if (layer && layer !== 'speedlimittag') newLayersSettings[layer] = true;
+      });
+      updateMapSettings({ layersSettings: newLayersSettings });
     }
 
     return () => {
@@ -511,7 +515,7 @@ const Editor = () => {
                 />
 
                 {mapRef.current &&
-                  editorState.editorLayers.has('errors') &&
+                  mapSettings.layersSettings.errors &&
                   editorState.issues.total > 0 && (
                     <div className="error-box">
                       <InfraErrorMapControl mapRef={mapRef.current} switchTool={switchTool} />

--- a/front/src/applications/editor/Map.tsx
+++ b/front/src/applications/editor/Map.tsx
@@ -31,7 +31,7 @@ import {
 import LevelCrossingsLayer from 'common/Map/Layers/InfraObjectLayers/LevelCrossing';
 import { colors } from 'common/Map/theme';
 import { LAYER_GROUPS_ORDER, LAYERS } from 'config/layerOrder';
-import { useMapSettings, useMapSettingsActions } from 'reducers/commonMap';
+import { useMapSettingsActions } from 'reducers/commonMap';
 import type { MapStyle, Viewport } from 'reducers/commonMap/types';
 import { getEditorState } from 'reducers/editor/selectors';
 import { useAppDispatch } from 'store';
@@ -82,13 +82,15 @@ const MapUnplugged = ({
   const editorState = useSelector(getEditorState);
 
   const {
-    showOSM,
-    showOSM3dBuildings,
-    showOSMtracksections,
-    terrain3DExaggeration,
-    mapSearchMarker,
-    lineSearchCode,
-  } = useMapSettings();
+    mapSettings: {
+      showOSM,
+      showOSM3dBuildings,
+      showOSMtracksections,
+      terrain3DExaggeration,
+      mapSearchMarker,
+      lineSearchCode,
+    },
+  } = editorState;
 
   const extendedContext = useMemo<ExtendedEditorContextType<CommonToolState>>(
     () => ({

--- a/front/src/applications/editor/Map.tsx
+++ b/front/src/applications/editor/Map.tsx
@@ -310,28 +310,28 @@ const MapUnplugged = ({
             lineSearchCode={lineSearchCode}
           />
 
-          {editorState.editorLayers.has('platforms') && (
+          {editorState.mapSettings.layersSettings.platforms && (
             <Platforms
               colors={colors[mapStyle]}
               layerOrder={LAYER_GROUPS_ORDER[LAYERS.PLATFORMS.GROUP]}
             />
           )}
 
-          {editorState.editorLayers.has('neutral_sections') && (
+          {editorState.mapSettings.layersSettings.neutral_sections && (
             <NeutralSectionsLayer
               colors={colors[mapStyle]}
               layerOrder={LAYER_GROUPS_ORDER[LAYERS.NEUTRAL_SECTIONS.GROUP]}
             />
           )}
 
-          {editorState.editorLayers.has('operational_points') && (
+          {editorState.mapSettings.layersSettings.operational_points && (
             <OperationalPointsLayer
               colors={colors[mapStyle]}
               layerOrder={LAYER_GROUPS_ORDER[LAYERS.OPERATIONAL_POINTS.GROUP]}
             />
           )}
 
-          {editorState.editorLayers.has('level_crossings') && (
+          {editorState.mapSettings.layersSettings.level_crossings && (
             <LevelCrossingsLayer
               colors={colors[mapStyle]}
               layerOrder={LAYER_GROUPS_ORDER[LAYERS.LEVEL_CROSSINGS.GROUP]}

--- a/front/src/applications/editor/components/EditorLayersModal.tsx
+++ b/front/src/applications/editor/components/EditorLayersModal.tsx
@@ -1,14 +1,13 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 
 import { skipToken } from '@reduxjs/toolkit/query';
-import { groupBy, mapKeys, mapValues, sum, isString, isArray, uniq } from 'lodash';
+import { groupBy, sum, isString, isArray, uniq } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { GiElectric, GiUnplugged } from 'react-icons/gi';
 import { MdSpeed } from 'react-icons/md';
 import { TbRectangleVerticalFilled } from 'react-icons/tb';
 
 import { EDITOAST_TO_LAYER_DICT } from 'applications/editor/consts';
-import type { Layer, EditoastType } from 'applications/editor/consts';
 import type { EditorEntity } from 'applications/editor/typesEditorEntity';
 import bufferStopIcon from 'assets/pictures/layersicons/bufferstop.svg';
 import detectorsIcon from 'assets/pictures/layersicons/detectors.svg';
@@ -26,49 +25,42 @@ import { Icon2SVG } from 'common/Map/Settings/MapSettingsLayers';
 import MapSettingsMapStyle from 'common/Map/Settings/MapSettingsMapStyle';
 import { useInfraID } from 'common/osrdContext';
 import { useMapSettings, useMapSettingsActions } from 'reducers/commonMap';
-import { editorSliceActions } from 'reducers/editor';
+import type { LayersSettings } from 'reducers/commonMap/types';
 import { useAppDispatch } from 'store';
 
-export const LAYERS: Array<{ layers: Layer[]; icon: string | React.JSX.Element }> = [
-  { layers: ['track_sections'], icon: trackSectionsIcon },
-  { layers: ['signals'], icon: signalsIcon },
-  { layers: ['buffer_stops'], icon: bufferStopIcon },
-  { layers: ['detectors'], icon: detectorsIcon },
-  { layers: ['switches'], icon: switchesIcon },
-  { layers: ['speed_sections'], icon: <MdSpeed style={{ width: '20px' }} className="mx-2" /> },
-  { layers: ['psl', 'psl_signs'], icon: pslsIcon },
-  { layers: ['electrifications'], icon: <GiElectric style={{ width: '20px' }} className="mx-2" /> },
+import { getLayerSettingNameFromEditorLayer } from '../utils';
+
+const LAYERS: { layer: keyof LayersSettings; icon: string | React.JSX.Element }[] = [
+  { layer: 'tvds', icon: trackSectionsIcon },
+  { layer: 'signals', icon: signalsIcon },
+  { layer: 'buffer_stops', icon: bufferStopIcon },
+  { layer: 'detectors', icon: detectorsIcon },
+  { layer: 'switches', icon: switchesIcon },
+  { layer: 'sncf_psl', icon: pslsIcon },
+  { layer: 'electrifications', icon: <GiElectric className="mx-2" style={{ width: '20px' }} /> },
+  { layer: 'neutral_sections', icon: <GiUnplugged className="mx-2" style={{ width: '20px' }} /> },
   {
-    layers: ['platforms'],
-    icon: <TbRectangleVerticalFilled style={{ width: '20px' }} className="mx-2" />,
+    layer: 'platforms',
+    icon: <TbRectangleVerticalFilled className="mx-2" style={{ width: '20px' }} />,
   },
   {
-    layers: ['neutral_sections'],
-    icon: <GiUnplugged style={{ width: '20px' }} className="mx-2" />,
-  },
-  {
-    layers: ['operational_points'],
+    layer: 'operational_points',
     icon: <Icon2SVG file={OPsSVGFile} style={{ width: '20px' }} className="mx-2" />,
   },
   {
-    layers: ['level_crossings'],
+    layer: 'level_crossings',
     icon: <Icon2SVG file={levelCrossingIcon} style={{ width: '20px' }} className="mx-2" />,
   },
+  { layer: 'speed_limits', icon: <MdSpeed style={{ width: '20px' }} className="mx-2" /> },
 ];
 
 type EditorLayersModalProps = {
-  initialLayers: Set<Layer>;
   selection?: EditorEntity[];
-  frozenLayers?: Set<Layer>;
-  onChange: (args: { newLayers: Set<Layer> }) => void;
+  frozenLayers?: LayersSettings;
+  onChange: (newLayersSettings: LayersSettings) => void;
 };
 
-const EditorLayersModal = ({
-  initialLayers,
-  selection,
-  frozenLayers,
-  onChange,
-}: EditorLayersModalProps) => {
+const EditorLayersModal = ({ selection, frozenLayers, onChange }: EditorLayersModalProps) => {
   const dispatch = useAppDispatch();
   const { t } = useTranslation();
 
@@ -77,7 +69,7 @@ const EditorLayersModal = ({
   const { layersSettings } = mapSettings;
   const { updateLayersSettings } = useMapSettingsActions();
 
-  const [selectedLayers, setSelectedLayers] = useState<Set<Layer>>(initialLayers);
+  const [selectedLayers, setSelectedLayers] = useState<LayersSettings>(layersSettings);
 
   const { data: speedLimitTagsByInfraId } =
     osrdEditoastApi.endpoints.getInfraByInfraIdSpeedLimitTags.useQuery(
@@ -87,48 +79,29 @@ const EditorLayersModal = ({
   const allSpeedLimitTagsOrdered = useMemo(() => allSpeedLimitTags.sort(), [allSpeedLimitTags]);
 
   const DEFAULT_SPEED_LIMIT_TAG = useMemo(() => t('mapSettings.noSpeedLimitByTag'), [t]);
-  const selectionCounts = useMemo(
-    () =>
-      selection
-        ? mapKeys(
-            // TODO: ATM we don't know if a selected speed section should be considered as SpeedSection or PSL,
-            // which are two different layers.
-            mapValues(groupBy(selection, 'objType'), (values) => values.length),
-            (_values, key) => EDITOAST_TO_LAYER_DICT[key as EditoastType]
-          )
-        : {},
-    [selection]
-  );
 
-  /**
-   * When selection changed, we check that all needed layers are enabled.
-   * This is mainly used for the error modal
-   */
-  useEffect(() => {
-    // compute the set of layer needed by the selection
-    const layersMustBeEnabled = (selection || []).reduce((acc, curr) => {
-      const layerTypes = EDITOAST_TO_LAYER_DICT[curr.objType as EditoastType] || [];
-      layerTypes.forEach((layerType) => {
-        if (layerType && !acc.has(layerType)) acc.add(layerType);
-      });
-      return acc;
-    }, new Set<Layer>());
+  const selectionCounts = useMemo(() => {
+    const countsByObjType = new Map<keyof LayersSettings, number>();
+    if (!selection) return countsByObjType;
 
-    // enable all the layers
-    setSelectedLayers((set) => {
-      const newSet = new Set(set);
-      layersMustBeEnabled.forEach((id) => {
-        if (!newSet.has(id)) newSet.add(id);
-      });
-      return newSet;
+    const selectionByObjType = groupBy(selection, 'objType');
+    Object.values(selectionByObjType).forEach((selectedObjects) => {
+      const objType = selectedObjects[0].objType;
+      if (objType !== 'SwitchType' && objType !== 'LevelCrossing') {
+        const layerSettingName = getLayerSettingNameFromEditorLayer(
+          EDITOAST_TO_LAYER_DICT[objType][0]
+        );
+        if (layerSettingName) countsByObjType.set(layerSettingName, selectedObjects.length);
+      }
     });
+    return countsByObjType;
   }, [selection]);
 
   const unselectCount = useMemo(
     () =>
       sum(
-        LAYERS.filter((layer) => layer.layers.some((id) => !selectedLayers.has(id))).flatMap(
-          (layer) => layer.layers.map((id) => selectionCounts[id] || 0)
+        LAYERS.filter(({ layer }) => !layersSettings[layer]).map(
+          ({ layer }) => selectionCounts.get(layer) || 0
         )
       ),
     [selectedLayers, selectionCounts]
@@ -146,30 +119,26 @@ const EditorLayersModal = ({
           <h4>{t('Editor.nav.osrd-layers')}</h4>
         </div>
         <div className="row">
-          {LAYERS.map(({ layers, icon }) => {
-            const layerKey = layers.join('-');
-            const count = sum(layers.map((id) => selectionCounts[id] || 0));
-            const disabled = frozenLayers && layers.some((id) => frozenLayers.has(id));
-            const checked = layers.every((id) => selectedLayers.has(id));
+          {LAYERS.map(({ layer, icon }) => {
+            if (layer === 'speedlimittag') return null;
             return (
-              <div className="col-lg-6" key={`${layerKey}-${count}-${disabled}`}>
+              <div className="col-lg-6" key={layer}>
                 <div className="d-flex align-items-center mt-2">
                   <SwitchSNCF
                     type="switch"
                     onChange={() => {
-                      const newSelectedLayersList = layers.reduce((result, layer) => {
-                        if (result.has(layer)) result.delete(layer);
-                        else result.add(layer);
-                        return result;
-                      }, new Set(selectedLayers));
-                      setSelectedLayers(newSelectedLayersList);
-                      dispatch(editorSliceActions.selectLayers(newSelectedLayersList));
-                      onChange({ newLayers: newSelectedLayersList });
+                      const newLayersSettings = {
+                        ...layersSettings,
+                        [layer]: !layersSettings[layer],
+                      };
+                      setSelectedLayers(newLayersSettings);
+                      dispatch(updateLayersSettings(newLayersSettings));
+                      onChange(newLayersSettings);
                     }}
-                    name={`editor-layer-${layerKey}`}
-                    id={`editor-layer-${layerKey}`}
-                    checked={checked}
-                    disabled={disabled}
+                    name={`editor-layer-${layer}`}
+                    id={`editor-layer-${layer}`}
+                    checked={selectedLayers[layer]}
+                    disabled={frozenLayers?.[layer]}
                   />
                   {isString(icon) ? (
                     <img className="layer-modal-img mx-2" src={icon} alt="" />
@@ -177,15 +146,15 @@ const EditorLayersModal = ({
                     <div>{icon}</div>
                   )}
                   <div className="d-flex flex-column">
-                    <div>{t(`Editor.layers.${layerKey}`)}</div>
-                    {!!count && checked && (
+                    <div>{t(`Editor.layers.${layer}`)}</div>
+                    {selectedLayers[layer] && !!selectionCounts.get(layer) && (
                       <div className="small text-muted font-italic">
                         {t('Editor.layers-modal.layer-selected-items', {
-                          count,
+                          count: selectionCounts.get(layer),
                         })}
                       </div>
                     )}
-                    {disabled && (
+                    {frozenLayers?.[layer] && (
                       <div className="small text-muted font-italic">
                         {t('Editor.layers-modal.frozen-layer')}
                       </div>
@@ -203,7 +172,7 @@ const EditorLayersModal = ({
             id="speedLimitTag"
             className="form-control"
             value={layersSettings.speedlimittag || DEFAULT_SPEED_LIMIT_TAG}
-            disabled={!isArray(allSpeedLimitTags) || !selectedLayers.has('speed_sections')}
+            disabled={!isArray(allSpeedLimitTags) || !layersSettings.speed_limits}
             onChange={(e) => {
               const newTag = e.target.value !== DEFAULT_SPEED_LIMIT_TAG ? e.target.value : null;
               dispatch(

--- a/front/src/applications/editor/tools/pointEdition/components/PointEditionLayers.tsx
+++ b/front/src/applications/editor/tools/pointEdition/components/PointEditionLayers.tsx
@@ -4,7 +4,6 @@ import { featureCollection } from '@turf/helpers';
 import { isEqual } from 'lodash';
 import type { Map } from 'maplibre-gl';
 import { Popup } from 'react-map-gl/maplibre';
-import { useSelector } from 'react-redux';
 
 import EntitySumUp from 'applications/editor/components/EntitySumUp';
 import EditorContext from 'applications/editor/context';
@@ -13,11 +12,10 @@ import { POINT_LAYER_ID } from 'applications/editor/tools/pointEdition/consts';
 import type { PointEditionState } from 'applications/editor/tools/pointEdition/types';
 import type { ExtendedEditorContextType } from 'applications/editor/types';
 import type { EditorEntity } from 'applications/editor/typesEditorEntity';
+import { getEditorLayersFromLayersSetting } from 'applications/editor/utils';
 import { GeoJSONs, EditorSource, SourcesDefinitionsIndex } from 'common/Map/Layers';
 import { colors } from 'common/Map/theme';
 import { useInfraID } from 'common/osrdContext';
-import { useMapSettings } from 'reducers/commonMap';
-import { getEditorState } from 'reducers/editor/selectors';
 import { NULL_GEOMETRY } from 'types';
 
 type BasePointEditionLayersProps = {
@@ -37,13 +35,11 @@ export const BasePointEditionLayers = ({
   const {
     renderingFingerprint,
     state: { nearestPoint, mousePosition, entity, objType },
-    editorState: { editorLayers },
+    editorState: {
+      issuesSettings,
+      mapSettings: { mapStyle, layersSettings },
+    },
   } = useContext(EditorContext) as ExtendedEditorContextType<PointEditionState<EditorEntity>>;
-  const {
-    mapSettings: { layersSettings },
-    issuesSettings,
-  } = useSelector(getEditorState);
-  const { mapStyle } = useMapSettings();
 
   const [showPopup, setShowPopup] = useState(true);
 
@@ -100,7 +96,7 @@ export const BasePointEditionLayers = ({
       <GeoJSONs
         colors={colors[mapStyle]}
         hidden={entity.properties.id !== NEW_ENTITY_ID ? [entity.properties.id] : undefined}
-        layers={editorLayers}
+        layers={getEditorLayersFromLayersSetting(layersSettings)}
         fingerprint={renderingFingerprint}
         layersSettings={layersSettings}
         issuesSettings={issuesSettings}

--- a/front/src/applications/editor/tools/pointEdition/tool-factory.tsx
+++ b/front/src/applications/editor/tools/pointEdition/tool-factory.tsx
@@ -15,6 +15,7 @@ import { DEFAULT_COMMON_TOOL_STATE } from 'applications/editor/tools/consts';
 import type { TrackSectionEntity } from 'applications/editor/tools/trackEdition/types';
 import { calculateDistanceAlongTrack } from 'applications/editor/tools/utils';
 import type { Tool } from 'applications/editor/types';
+import { getLayerSettingNameFromEditorLayer } from 'applications/editor/utils';
 import { ConfirmModal } from 'common/BootstrapSNCF/ModalSNCF';
 import { save } from 'reducers/editor/thunkActions';
 import { NULL_GEOMETRY } from 'types';
@@ -58,9 +59,17 @@ function getPointEditionTool<T extends EditorPoint>({
     icon,
     labelTranslationKey: `Editor.tools.${id}-edition.label`,
     requiredLayers: new Set([layer, 'track_sections']),
-    isDisabled({ editorState }) {
+    isDisabled({
+      editorState: {
+        mapSettings: { layersSettings },
+      },
+    }) {
+      const layerSettingName = getLayerSettingNameFromEditorLayer(layer);
       return (
-        !editorState.editorLayers.has('track_sections') || !editorState.editorLayers.has(layer)
+        !layersSettings.tvds ||
+        !layerSettingName ||
+        layerSettingName === 'speedlimittag' ||
+        !layersSettings[layerSettingName]
       );
     },
     getInitialState,

--- a/front/src/applications/editor/tools/rangeEdition/electrification/ElectrificationEditionLayers.tsx
+++ b/front/src/applications/editor/tools/rangeEdition/electrification/ElectrificationEditionLayers.tsx
@@ -19,6 +19,7 @@ import type {
 import { getTrackRangeFeatures, isOnModeMove } from 'applications/editor/tools/rangeEdition/utils';
 import type { TrackSectionEntity } from 'applications/editor/tools/trackEdition/types';
 import type { ExtendedEditorContextType } from 'applications/editor/types';
+import { getEditorLayersFromLayersSetting } from 'applications/editor/utils';
 import { GeoJSONs, SourcesDefinitionsIndex } from 'common/Map/Layers';
 import { colors } from 'common/Map/theme';
 import { useInfraID } from 'common/osrdContext';
@@ -30,7 +31,9 @@ export const ElectrificationEditionLayers = () => {
   const dispatch = useAppDispatch();
   const { t } = useTranslation();
   const {
-    editorState: { editorLayers },
+    editorState: {
+      mapSettings: { layersSettings },
+    },
     renderingFingerprint,
     state: { entity, trackSectionsCache, hoveredItem, interactionState, mousePosition },
     setState,
@@ -38,10 +41,7 @@ export const ElectrificationEditionLayers = () => {
     RangeEditionState<ElectrificationEntity>
   >;
 
-  const {
-    mapSettings: { layersSettings },
-    issuesSettings,
-  } = useSelector(getEditorState);
+  const { issuesSettings } = useSelector(getEditorState);
   const { mapStyle, showIGNBDORTHO } = useMapSettings();
 
   const infraID = useInfraID();
@@ -182,7 +182,7 @@ export const ElectrificationEditionLayers = () => {
     <>
       <GeoJSONs
         colors={colors[mapStyle]}
-        layers={editorLayers}
+        layers={getEditorLayersFromLayersSetting(layersSettings)}
         selection={selection}
         fingerprint={renderingFingerprint}
         layersSettings={layersSettings}

--- a/front/src/applications/editor/tools/rangeEdition/electrification/ElectrificationEditionLayers.tsx
+++ b/front/src/applications/editor/tools/rangeEdition/electrification/ElectrificationEditionLayers.tsx
@@ -5,7 +5,6 @@ import type { Feature, FeatureCollection, LineString, Point } from 'geojson';
 import { mapValues } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { Layer, Popup, Source } from 'react-map-gl/maplibre';
-import { useSelector } from 'react-redux';
 
 import EntitySumUp from 'applications/editor/components/EntitySumUp';
 import EditorContext from 'applications/editor/context';
@@ -23,8 +22,6 @@ import { getEditorLayersFromLayersSetting } from 'applications/editor/utils';
 import { GeoJSONs, SourcesDefinitionsIndex } from 'common/Map/Layers';
 import { colors } from 'common/Map/theme';
 import { useInfraID } from 'common/osrdContext';
-import { useMapSettings } from 'reducers/commonMap';
-import { getEditorState } from 'reducers/editor/selectors';
 import { useAppDispatch } from 'store';
 
 export const ElectrificationEditionLayers = () => {
@@ -32,7 +29,8 @@ export const ElectrificationEditionLayers = () => {
   const { t } = useTranslation();
   const {
     editorState: {
-      mapSettings: { layersSettings },
+      issuesSettings,
+      mapSettings: { layersSettings, mapStyle, showIGNBDORTHO },
     },
     renderingFingerprint,
     state: { entity, trackSectionsCache, hoveredItem, interactionState, mousePosition },
@@ -40,9 +38,6 @@ export const ElectrificationEditionLayers = () => {
   } = useContext(EditorContext) as ExtendedEditorContextType<
     RangeEditionState<ElectrificationEntity>
   >;
-
-  const { issuesSettings } = useSelector(getEditorState);
-  const { mapStyle, showIGNBDORTHO } = useMapSettings();
 
   const infraID = useInfraID();
   const selection = useMemo(() => {

--- a/front/src/applications/editor/tools/rangeEdition/speedSection/SpeedSectionEditionLayers.tsx
+++ b/front/src/applications/editor/tools/rangeEdition/speedSection/SpeedSectionEditionLayers.tsx
@@ -28,6 +28,7 @@ import {
 import type { TrackSectionEntity } from 'applications/editor/tools/trackEdition/types';
 import type { ExtendedEditorContextType } from 'applications/editor/types';
 import type { EditorEntity } from 'applications/editor/typesEditorEntity';
+import { getEditorLayersFromLayersSetting } from 'applications/editor/utils';
 import { GeoJSONs, SourcesDefinitionsIndex } from 'common/Map/Layers';
 import { colors } from 'common/Map/theme';
 import { useInfraID } from 'common/osrdContext';
@@ -41,7 +42,9 @@ export const SpeedSectionEditionLayers = () => {
   const dispatch = useAppDispatch();
   const { t } = useTranslation();
   const {
-    editorState: { editorLayers },
+    editorState: {
+      mapSettings: { layersSettings },
+    },
     renderingFingerprint,
     state: {
       entity,
@@ -59,10 +62,7 @@ export const SpeedSectionEditionLayers = () => {
   const isPermanentSpeedLimit = speedSectionIsPsl(entity);
   const isSpeedRestriction = speedSectionIsSpeedRestriction(entity);
 
-  const {
-    mapSettings: { layersSettings },
-    issuesSettings,
-  } = useSelector(getEditorState);
+  const { issuesSettings } = useSelector(getEditorState);
   const { mapStyle, showIGNBDORTHO } = useMapSettings();
   const infraID = useInfraID();
   const selection = useMemo(() => {
@@ -280,7 +280,7 @@ export const SpeedSectionEditionLayers = () => {
     <>
       <GeoJSONs
         colors={colors[mapStyle]}
-        layers={editorLayers}
+        layers={getEditorLayersFromLayersSetting(layersSettings)}
         selection={selection}
         fingerprint={renderingFingerprint}
         hidden={entity.properties.id ? [entity.properties.id] : undefined}

--- a/front/src/applications/editor/tools/rangeEdition/speedSection/SpeedSectionEditionLayers.tsx
+++ b/front/src/applications/editor/tools/rangeEdition/speedSection/SpeedSectionEditionLayers.tsx
@@ -5,7 +5,6 @@ import type { Feature, FeatureCollection, LineString, Point } from 'geojson';
 import { mapValues, pick } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { Layer, Popup, Source } from 'react-map-gl/maplibre';
-import { useSelector } from 'react-redux';
 
 import EntitySumUp from 'applications/editor/components/EntitySumUp';
 import EditorContext from 'applications/editor/context';
@@ -32,8 +31,6 @@ import { getEditorLayersFromLayersSetting } from 'applications/editor/utils';
 import { GeoJSONs, SourcesDefinitionsIndex } from 'common/Map/Layers';
 import { colors } from 'common/Map/theme';
 import { useInfraID } from 'common/osrdContext';
-import { useMapSettings } from 'reducers/commonMap';
-import { getEditorState } from 'reducers/editor/selectors';
 import { useAppDispatch } from 'store';
 
 const emptyFeatureCollection = featureCollection([]);
@@ -43,7 +40,8 @@ export const SpeedSectionEditionLayers = () => {
   const { t } = useTranslation();
   const {
     editorState: {
-      mapSettings: { layersSettings },
+      issuesSettings,
+      mapSettings: { mapStyle, showIGNBDORTHO, layersSettings },
     },
     renderingFingerprint,
     state: {
@@ -62,8 +60,6 @@ export const SpeedSectionEditionLayers = () => {
   const isPermanentSpeedLimit = speedSectionIsPsl(entity);
   const isSpeedRestriction = speedSectionIsSpeedRestriction(entity);
 
-  const { issuesSettings } = useSelector(getEditorState);
-  const { mapStyle, showIGNBDORTHO } = useMapSettings();
   const infraID = useInfraID();
   const selection = useMemo(() => {
     const res: string[] = [entity.properties.id];

--- a/front/src/applications/editor/tools/routeEdition/components/RouteEditionLayers.tsx
+++ b/front/src/applications/editor/tools/routeEdition/components/RouteEditionLayers.tsx
@@ -7,7 +7,6 @@ import { useTranslation } from 'react-i18next';
 import { BsArrowBarRight } from 'react-icons/bs';
 import { FaFlagCheckered } from 'react-icons/fa';
 import { Layer, Popup, Source, type LineLayerSpecification } from 'react-map-gl/maplibre';
-import { useSelector } from 'react-redux';
 
 import EntitySumUp from 'applications/editor/components/EntitySumUp';
 import EditorContext from 'applications/editor/context';
@@ -31,8 +30,6 @@ import {
 } from 'common/Map/Layers/InfraObjectLayers';
 import { colors } from 'common/Map/theme';
 import { useInfraID } from 'common/osrdContext';
-import { useMapSettings } from 'reducers/commonMap';
-import { getEditorState } from 'reducers/editor/selectors';
 import { useAppDispatch } from 'store';
 import { NULL_GEOMETRY, type OmitLayer, type NullGeometry } from 'types';
 
@@ -41,12 +38,11 @@ const RouteEditionLayers = () => {
     state,
     renderingFingerprint,
     editorState: {
-      mapSettings: { layersSettings },
+      issuesSettings,
+      mapSettings: { layersSettings, mapStyle },
     },
   } = useContext(EditorContext) as ExtendedEditorContextType<RouteEditionState>;
 
-  const { issuesSettings } = useSelector(getEditorState);
-  const { mapStyle } = useMapSettings();
   const infraID = useInfraID();
 
   const selectedRouteIndex =

--- a/front/src/applications/editor/tools/routeEdition/components/RouteEditionLayers.tsx
+++ b/front/src/applications/editor/tools/routeEdition/components/RouteEditionLayers.tsx
@@ -22,6 +22,7 @@ import {
 } from 'applications/editor/tools/routeEdition/utils';
 import type { ExtendedEditorContextType } from 'applications/editor/types';
 import type { EditorEntity } from 'applications/editor/typesEditorEntity';
+import { getEditorLayersFromLayersSetting } from 'applications/editor/utils';
 import {
   GeoJSONs,
   getRoutesLineLayerProps,
@@ -39,13 +40,12 @@ const RouteEditionLayers = () => {
   const {
     state,
     renderingFingerprint,
-    editorState: { editorLayers },
+    editorState: {
+      mapSettings: { layersSettings },
+    },
   } = useContext(EditorContext) as ExtendedEditorContextType<RouteEditionState>;
 
-  const {
-    mapSettings: { layersSettings },
-    issuesSettings,
-  } = useSelector(getEditorState);
+  const { issuesSettings } = useSelector(getEditorState);
   const { mapStyle } = useMapSettings();
   const infraID = useInfraID();
 
@@ -191,7 +191,7 @@ const RouteEditionLayers = () => {
       <GeoJSONs
         selection={selectionList.length > 1 ? selectionList : undefined}
         colors={colors[mapStyle]}
-        layers={editorLayers}
+        layers={getEditorLayersFromLayersSetting(layersSettings)}
         fingerprint={renderingFingerprint}
         layersSettings={layersSettings}
         issuesSettings={issuesSettings}

--- a/front/src/applications/editor/tools/selection/components/SelectionLayers.tsx
+++ b/front/src/applications/editor/tools/selection/components/SelectionLayers.tsx
@@ -7,6 +7,7 @@ import EntitySumUp from 'applications/editor/components/EntitySumUp';
 import EditorContext from 'applications/editor/context';
 import type { SelectionState } from 'applications/editor/tools/selection/types';
 import type { ExtendedEditorContextType } from 'applications/editor/types';
+import { getEditorLayersFromLayersSetting } from 'applications/editor/utils';
 import { GeoJSONs } from 'common/Map/Layers';
 import { colors } from 'common/Map/theme';
 import { useInfraID } from 'common/osrdContext';
@@ -24,13 +25,12 @@ const SelectionZone = ({ newZone }: { newZone: Zone }) => (
 const SelectionLayers = () => {
   const {
     state,
-    editorState: { editorLayers },
+    editorState: {
+      mapSettings: { layersSettings },
+    },
     renderingFingerprint,
   } = useContext(EditorContext) as ExtendedEditorContextType<SelectionState>;
-  const {
-    mapSettings: { layersSettings },
-    issuesSettings,
-  } = useSelector(getEditorState);
+  const { issuesSettings } = useSelector(getEditorState);
   const { mapStyle } = useMapSettings();
 
   const infraID = useInfraID();
@@ -59,7 +59,7 @@ const SelectionLayers = () => {
       <GeoJSONs
         colors={colors[mapStyle]}
         selection={state.selection.map((e) => e.properties.id)}
-        layers={editorLayers}
+        layers={getEditorLayersFromLayersSetting(layersSettings)}
         fingerprint={renderingFingerprint}
         layersSettings={layersSettings}
         issuesSettings={issuesSettings}

--- a/front/src/applications/editor/tools/selection/components/SelectionLayers.tsx
+++ b/front/src/applications/editor/tools/selection/components/SelectionLayers.tsx
@@ -1,7 +1,6 @@
 import { useContext } from 'react';
 
 import { Layer, Popup, Source } from 'react-map-gl/maplibre';
-import { useSelector } from 'react-redux';
 
 import EntitySumUp from 'applications/editor/components/EntitySumUp';
 import EditorContext from 'applications/editor/context';
@@ -11,8 +10,6 @@ import { getEditorLayersFromLayersSetting } from 'applications/editor/utils';
 import { GeoJSONs } from 'common/Map/Layers';
 import { colors } from 'common/Map/theme';
 import { useInfraID } from 'common/osrdContext';
-import { useMapSettings } from 'reducers/commonMap';
-import { getEditorState } from 'reducers/editor/selectors';
 import type { Zone } from 'types';
 import { zoneToFeature } from 'utils/mapHelper';
 
@@ -26,12 +23,11 @@ const SelectionLayers = () => {
   const {
     state,
     editorState: {
-      mapSettings: { layersSettings },
+      issuesSettings,
+      mapSettings: { layersSettings, mapStyle },
     },
     renderingFingerprint,
   } = useContext(EditorContext) as ExtendedEditorContextType<SelectionState>;
-  const { issuesSettings } = useSelector(getEditorState);
-  const { mapStyle } = useMapSettings();
 
   const infraID = useInfraID();
 

--- a/front/src/applications/editor/tools/switchEdition/components/SwitchEditionLayers.tsx
+++ b/front/src/applications/editor/tools/switchEdition/components/SwitchEditionLayers.tsx
@@ -18,6 +18,7 @@ import type {
 import useSwitch from 'applications/editor/tools/switchEdition/useSwitch';
 import type { TrackSectionEntity } from 'applications/editor/tools/trackEdition/types';
 import type { ExtendedEditorContextType } from 'applications/editor/types';
+import { getEditorLayersFromLayersSetting } from 'applications/editor/utils';
 import {
   GeoJSONs,
   getSwitchesLayerProps,
@@ -38,15 +39,14 @@ const SwitchEditionLayers = () => {
     renderingFingerprint,
     state,
     setState,
-    editorState: { editorLayers },
+    editorState: {
+      mapSettings: { layersSettings },
+    },
   } = useContext(EditorContext) as ExtendedEditorContextType<SwitchEditionState>;
   const { entity, hovered, portEditionState, mousePosition } = state;
 
   const { switchType } = useSwitch();
-  const {
-    mapSettings: { layersSettings },
-    issuesSettings,
-  } = useSelector(getEditorState);
+  const { issuesSettings } = useSelector(getEditorState);
   const { mapStyle } = useMapSettings();
   const layerProps = useMemo(
     () =>
@@ -169,7 +169,7 @@ const SwitchEditionLayers = () => {
       <GeoJSONs
         colors={colors[mapStyle]}
         hidden={entity?.properties?.id ? [entity.properties.id] : undefined}
-        layers={editorLayers}
+        layers={getEditorLayersFromLayersSetting(layersSettings)}
         fingerprint={renderingFingerprint}
         layersSettings={layersSettings}
         issuesSettings={issuesSettings}

--- a/front/src/applications/editor/tools/switchEdition/components/SwitchEditionLayers.tsx
+++ b/front/src/applications/editor/tools/switchEdition/components/SwitchEditionLayers.tsx
@@ -5,7 +5,6 @@ import nearestPoint from '@turf/nearest-point';
 import { first, last } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { Layer, Popup, Source } from 'react-map-gl/maplibre';
-import { useSelector } from 'react-redux';
 
 import EntitySumUp from 'applications/editor/components/EntitySumUp';
 import EditorContext from 'applications/editor/context';
@@ -26,8 +25,6 @@ import {
 } from 'common/Map/Layers/InfraObjectLayers';
 import { colors } from 'common/Map/theme';
 import { useInfraID } from 'common/osrdContext';
-import { useMapSettings } from 'reducers/commonMap';
-import { getEditorState } from 'reducers/editor/selectors';
 import { useAppDispatch } from 'store';
 import { castErrorToFailure } from 'utils/error';
 
@@ -40,14 +37,13 @@ const SwitchEditionLayers = () => {
     state,
     setState,
     editorState: {
-      mapSettings: { layersSettings },
+      issuesSettings,
+      mapSettings: { layersSettings, mapStyle },
     },
   } = useContext(EditorContext) as ExtendedEditorContextType<SwitchEditionState>;
   const { entity, hovered, portEditionState, mousePosition } = state;
 
   const { switchType } = useSwitch();
-  const { issuesSettings } = useSelector(getEditorState);
-  const { mapStyle } = useMapSettings();
   const layerProps = useMemo(
     () =>
       getSwitchesLayerProps({

--- a/front/src/applications/editor/tools/switchEdition/tool.tsx
+++ b/front/src/applications/editor/tools/switchEdition/tool.tsx
@@ -35,10 +35,12 @@ const SwitchEditionTool: Tool<SwitchEditionState> = {
   icon: TbSwitch2,
   labelTranslationKey: 'Editor.tools.switch-edition.label',
   requiredLayers: new Set(['switches', 'track_sections']),
-  isDisabled({ editorState }) {
-    return (
-      !editorState.editorLayers.has('switches') || !editorState.editorLayers.has('track_sections')
-    );
+  isDisabled({
+    editorState: {
+      mapSettings: { layersSettings },
+    },
+  }) {
+    return !layersSettings.switches || !layersSettings.tvds;
   },
   getInitialState,
   actions: [

--- a/front/src/applications/editor/tools/trackEdition/components/TrackEditionLayers.tsx
+++ b/front/src/applications/editor/tools/trackEdition/components/TrackEditionLayers.tsx
@@ -3,7 +3,6 @@ import { useContext } from 'react';
 import type { Position } from 'geojson';
 import { last } from 'lodash';
 import { Layer, Source } from 'react-map-gl/maplibre';
-import { useSelector } from 'react-redux';
 
 import EditorContext from 'applications/editor/context';
 import { POINTS_LAYER_ID, TRACK_LAYER_ID } from 'applications/editor/tools/trackEdition/consts';
@@ -13,8 +12,6 @@ import { getEditorLayersFromLayersSetting } from 'applications/editor/utils';
 import { GeoJSONs } from 'common/Map/Layers';
 import { colors } from 'common/Map/theme';
 import { useInfraID } from 'common/osrdContext';
-import { useMapSettings } from 'reducers/commonMap';
-import { getEditorState } from 'reducers/editor/selectors';
 
 export const TRACK_COLOR = '#666';
 export const TRACK_STYLE = { 'line-color': TRACK_COLOR, 'line-dasharray': [2, 1], 'line-width': 2 };
@@ -24,11 +21,10 @@ const TrackEditionLayers = () => {
     state,
     renderingFingerprint,
     editorState: {
-      mapSettings: { layersSettings },
+      issuesSettings,
+      mapSettings: { layersSettings, mapStyle },
     },
   } = useContext(EditorContext) as ExtendedEditorContextType<TrackEditionState>;
-  const { issuesSettings } = useSelector(getEditorState);
-  const { mapStyle } = useMapSettings();
 
   const infraID = useInfraID();
 

--- a/front/src/applications/editor/tools/trackEdition/components/TrackEditionLayers.tsx
+++ b/front/src/applications/editor/tools/trackEdition/components/TrackEditionLayers.tsx
@@ -9,6 +9,7 @@ import EditorContext from 'applications/editor/context';
 import { POINTS_LAYER_ID, TRACK_LAYER_ID } from 'applications/editor/tools/trackEdition/consts';
 import type { TrackEditionState } from 'applications/editor/tools/trackEdition/types';
 import type { ExtendedEditorContextType } from 'applications/editor/types';
+import { getEditorLayersFromLayersSetting } from 'applications/editor/utils';
 import { GeoJSONs } from 'common/Map/Layers';
 import { colors } from 'common/Map/theme';
 import { useInfraID } from 'common/osrdContext';
@@ -22,12 +23,11 @@ const TrackEditionLayers = () => {
   const {
     state,
     renderingFingerprint,
-    editorState: { editorLayers },
+    editorState: {
+      mapSettings: { layersSettings },
+    },
   } = useContext(EditorContext) as ExtendedEditorContextType<TrackEditionState>;
-  const {
-    mapSettings: { layersSettings },
-    issuesSettings,
-  } = useSelector(getEditorState);
+  const { issuesSettings } = useSelector(getEditorState);
   const { mapStyle } = useMapSettings();
 
   const infraID = useInfraID();
@@ -75,7 +75,7 @@ const TrackEditionLayers = () => {
       <GeoJSONs
         colors={colors[mapStyle]}
         hidden={state.track.properties.id ? [state.track.properties.id] : undefined}
-        layers={editorLayers}
+        layers={getEditorLayersFromLayersSetting(layersSettings)}
         fingerprint={renderingFingerprint}
         layersSettings={layersSettings}
         issuesSettings={issuesSettings}

--- a/front/src/applications/editor/tools/trackEdition/tool.tsx
+++ b/front/src/applications/editor/tools/trackEdition/tool.tsx
@@ -27,8 +27,12 @@ const TrackEditionTool: Tool<TrackEditionState> = {
   icon: MdShowChart,
   labelTranslationKey: 'Editor.tools.track-edition.label',
   requiredLayers: new Set(['track_sections']),
-  isDisabled({ editorState }) {
-    return !editorState.editorLayers.has('track_sections');
+  isDisabled({
+    editorState: {
+      mapSettings: { layersSettings },
+    },
+  }) {
+    return !layersSettings.tvds;
   },
   isHidden({ activeTool }) {
     return activeTool.id === TOOL_NAMES.TRACK_SPLIT;

--- a/front/src/applications/editor/tools/trackSplit/components/TrackSplitLayers.tsx
+++ b/front/src/applications/editor/tools/trackSplit/components/TrackSplitLayers.tsx
@@ -4,7 +4,6 @@ import along from '@turf/along';
 import length from '@turf/length';
 import type { Feature, Point } from 'geojson';
 import { Layer, Source } from 'react-map-gl/maplibre';
-import { useSelector } from 'react-redux';
 
 import EditorContext from 'applications/editor/context';
 import {
@@ -13,11 +12,10 @@ import {
 } from 'applications/editor/tools/trackEdition/components/TrackEditionLayers';
 import { TRACK_LAYER_ID, POINTS_LAYER_ID } from 'applications/editor/tools/trackEdition/consts';
 import type { ExtendedEditorContextType } from 'applications/editor/types';
+import { getEditorLayersFromLayersSetting } from 'applications/editor/utils';
 import { GeoJSONs } from 'common/Map/Layers';
 import { colors } from 'common/Map/theme';
 import { useInfraID } from 'common/osrdContext';
-import { useMapSettings } from 'reducers/commonMap';
-import { getEditorState } from 'reducers/editor/selectors';
 
 import type { TrackSplitState } from '../types';
 import { isOffsetValid } from '../utils';
@@ -40,16 +38,14 @@ function getSplitPoint(state: TrackSplitState): Feature<Point> {
 }
 
 const TrackSplitLayers = () => {
-  const {
-    mapSettings: { layersSettings },
-    issuesSettings,
-  } = useSelector(getEditorState);
-  const { mapStyle } = useMapSettings();
   const infraID = useInfraID();
   const {
     state,
     renderingFingerprint,
-    editorState: { editorLayers },
+    editorState: {
+      issuesSettings,
+      mapSettings: { mapStyle, layersSettings },
+    },
   } = useContext(EditorContext) as ExtendedEditorContextType<TrackSplitState>;
 
   const splitPoint = getSplitPoint(state);
@@ -60,7 +56,7 @@ const TrackSplitLayers = () => {
       <GeoJSONs
         colors={colors[mapStyle]}
         hidden={state.track.properties.id ? [state.track.properties.id] : undefined}
-        layers={editorLayers}
+        layers={getEditorLayersFromLayersSetting(layersSettings)}
         fingerprint={renderingFingerprint}
         layersSettings={layersSettings}
         issuesSettings={issuesSettings}

--- a/front/src/applications/editor/tools/utils.ts
+++ b/front/src/applications/editor/tools/utils.ts
@@ -34,6 +34,8 @@ import type { AppDispatch } from 'store';
 import type { Bbox } from 'types';
 import { nearestPointOnLine } from 'utils/geometry';
 
+import { getLayerSettingNameFromEditorLayer } from '../utils';
+
 /**
  * Since Turf and Editoast do not compute the lengths the same way (see #1751)
  * we can have data "end" being larger than Turf's computed length, which
@@ -131,28 +133,29 @@ export function selectEntities(
     editorState: EditorState;
   }
 ): void {
-  const { switchTool, dispatch, editorState } = context;
+  const {
+    switchTool,
+    dispatch,
+    editorState: {
+      mapSettings: { layersSettings },
+    },
+  } = context;
   // call the switch tool
   switchTool({
     toolType: TOOL_NAMES.SELECTION,
     toolState: { selection: entities },
   });
 
-  // enable the needed layer
-  const actualLayers = editorState.editorLayers;
+  // iterate over needed layers to activate them if needed
+  const neededEditorLayers = getNeededLayers(entities);
 
-  // create the next list of layer
-  const nextLayers = new Set(actualLayers);
-
-  const neededLayers = getNeededLayers(entities);
-
-  // iterate over needed layer
-  neededLayers.forEach((l) => {
-    if (!nextLayers.has(l)) nextLayers.add(l);
+  const newLayers = { ...layersSettings };
+  neededEditorLayers.forEach((editorLayer) => {
+    const layer = getLayerSettingNameFromEditorLayer(editorLayer);
+    if (layer && layer !== 'speedlimittag') newLayers[layer] = true;
   });
 
-  // dispatch the new layers
-  if (actualLayers.size !== nextLayers.size) dispatch(editorSliceActions.selectLayers(nextLayers));
+  dispatch(editorSliceActions.updateMapSettings({ layersSettings: newLayers }));
 }
 
 /**

--- a/front/src/applications/editor/utils.ts
+++ b/front/src/applications/editor/utils.ts
@@ -1,0 +1,67 @@
+import { defaultMapSettings } from 'reducers/commonMap';
+import type { LayersSettings } from 'reducers/commonMap/types';
+
+import type { Layer } from './consts';
+
+export const getLayerSettingNameFromEditorLayer = (
+  editorLayer: Layer
+): keyof LayersSettings | null => {
+  switch (editorLayer) {
+    case 'psl':
+    case 'psl_signs':
+      return 'sncf_psl';
+    case 'speed_sections':
+      return 'speed_limits';
+    case 'track_sections':
+      return 'tvds';
+    default:
+      return editorLayer;
+  }
+};
+
+export const getLayersSettingsFromEditorLayers = (
+  editorLayers: Set<Layer> | undefined
+): LayersSettings => {
+  const layersSettings = { ...defaultMapSettings.layersSettings, operational_points: false };
+  editorLayers?.forEach((layer) => {
+    const layerSetting = getLayerSettingNameFromEditorLayer(layer);
+    if (layerSetting && layerSetting !== 'speedlimittag') {
+      layersSettings[layerSetting] = true;
+    }
+  });
+  return layersSettings;
+};
+
+export const getEditorLayersFromLayersSetting = (layersSettings: LayersSettings): Set<Layer> => {
+  const layers: Layer[] = [];
+
+  (
+    [
+      'buffer_stops',
+      'electrifications',
+      'detectors',
+      'routes',
+      'signals',
+      'switches',
+      'platforms',
+      'neutral_sections',
+      'operational_points',
+      'errors',
+    ] as const
+  ).forEach((key) => {
+    if (layersSettings[key]) layers.push(key);
+  });
+
+  if (layersSettings.speed_limits) {
+    layers.push('speed_sections');
+  }
+  if (layersSettings.tvds) {
+    layers.push('track_sections');
+  }
+  if (layersSettings.sncf_psl) {
+    layers.push('psl');
+    layers.push('psl_signs');
+  }
+
+  return new Set(layers);
+};

--- a/front/src/common/Map/Buttons/ButtonMapInfraErrors.tsx
+++ b/front/src/common/Map/Buttons/ButtonMapInfraErrors.tsx
@@ -2,7 +2,6 @@ import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { BsExclamationOctagon } from 'react-icons/bs';
 
-import type { Layer } from 'applications/editor/consts';
 import { type EditorState, editorSliceActions } from 'reducers/editor';
 import { useAppDispatch } from 'store';
 
@@ -10,22 +9,30 @@ type ButtonMapInfraErrorsProps = {
   editorState: EditorState;
 };
 
-const ButtonMapInfraErrors = ({ editorState }: ButtonMapInfraErrorsProps) => {
+const ButtonMapInfraErrors = ({
+  editorState: {
+    mapSettings: { layersSettings },
+  },
+}: ButtonMapInfraErrorsProps) => {
   const dispatch = useAppDispatch();
   const { t } = useTranslation('translation');
 
   const toggleInfraErrors = () => {
-    const newSet = new Set<Layer>(editorState.editorLayers);
-    if (newSet.has('errors')) newSet.delete('errors');
-    else newSet.add('errors');
-    dispatch(editorSliceActions.selectLayers(newSet));
+    dispatch(
+      editorSliceActions.updateMapSettings({
+        layersSettings: {
+          ...layersSettings,
+          errors: !layersSettings.errors,
+        },
+      })
+    );
   };
 
   return (
     <button
       type="button"
       className={cx('editor-btn btn-rounded', {
-        active: editorState.editorLayers.has('errors'),
+        active: layersSettings.errors,
       })}
       aria-label={t('common.toggleInfraErrors')}
       title={t('common.toggleInfraErrors')}

--- a/front/src/common/Map/Buttons/MapButtons.tsx
+++ b/front/src/common/Map/Buttons/MapButtons.tsx
@@ -19,6 +19,10 @@ import { EDITOAST_TO_LAYER_DICT, type EditoastType } from 'applications/editor/c
 import type { SelectionState } from 'applications/editor/tools/selection/types';
 import type { CommonToolState } from 'applications/editor/tools/types';
 import type { PartialOrReducer, Tool } from 'applications/editor/types';
+import {
+  getEditorLayersFromLayersSetting,
+  getLayersSettingsFromEditorLayers,
+} from 'applications/editor/utils';
 import { ModalContext } from 'common/BootstrapSNCF/ModalSNCF/ModalProvider';
 import ButtonMapInfras from 'common/Map/Buttons/ButtonMapInfras';
 import LayersModal from 'common/Map/components/LayersModal';
@@ -101,7 +105,7 @@ export default function MapButtons({
 
   const openMapSettingsModal = useCallback(() => {
     if (editorProps) {
-      const { activeTool, setToolState, editorState, toolState } = editorProps;
+      const { activeTool, setToolState, toolState } = editorProps;
       openModal(
         <MapContextProvider
           infraId={infraId}
@@ -109,14 +113,14 @@ export default function MapButtons({
           updateMapSettings={updateMapSettings}
         >
           <EditorLayersModal
-            initialLayers={editorState.editorLayers}
-            frozenLayers={activeTool.requiredLayers}
+            frozenLayers={getLayersSettingsFromEditorLayers(activeTool.requiredLayers)}
             selection={
               activeTool.id === 'select-items' ? (toolState as SelectionState).selection : undefined
             }
-            onChange={({ newLayers }) => {
+            onChange={(newLayersSettings) => {
               if (activeTool.id === 'select-items') {
                 const currentState = toolState as SelectionState;
+                const newLayers = getEditorLayersFromLayersSetting(newLayersSettings);
                 setToolState({
                   ...currentState,
                   selection: currentState.selection.filter((entity) =>

--- a/front/src/reducers/commonMap/index.ts
+++ b/front/src/reducers/commonMap/index.ts
@@ -30,7 +30,7 @@ export const defaultMapSettings: MapSettings = {
     speed_limits: false,
     speedlimittag: null,
     switches: false,
-    tvds: false,
+    tvds: true,
     platforms: false,
     errors: false,
   },

--- a/front/src/reducers/commonMap/index.ts
+++ b/front/src/reducers/commonMap/index.ts
@@ -32,6 +32,7 @@ export const defaultMapSettings: MapSettings = {
     switches: false,
     tvds: false,
     platforms: false,
+    errors: false,
   },
   viewport: {
     latitude: 48.32,

--- a/front/src/reducers/commonMap/types.ts
+++ b/front/src/reducers/commonMap/types.ts
@@ -32,6 +32,7 @@ export type LayersSettings = {
   switches: boolean;
   platforms: boolean;
   tvds: boolean;
+  errors: boolean;
 };
 
 export type Viewport = ViewState & {

--- a/front/src/reducers/editor/__tests__/editorReducer.spec.ts
+++ b/front/src/reducers/editor/__tests__/editorReducer.spec.ts
@@ -5,7 +5,7 @@ import { createStoreWithoutMiddleware } from 'store';
 
 import editorTestDataBuilder from './editorTestDataBuilder';
 
-const { selectLayers, loadDataModelAction, updateTotalsIssueAction, updateFiltersIssueAction } =
+const { loadDataModelAction, updateTotalsIssueAction, updateFiltersIssueAction } =
   editorSliceActions;
 
 const createStore = () =>
@@ -24,13 +24,6 @@ describe('editorReducer', () => {
   it('should return initial state', () => {
     const editorState = store.getState()[editorSlice.name];
     expect(editorState).toEqual(editorInitialState);
-  });
-
-  it('should handle selectLayers', () => {
-    const editorLayers = testDataBuilder.buildEditorLayers(['electrifications', 'routes']);
-    store.dispatch(selectLayers(editorLayers));
-    const editorState = store.getState()[editorSlice.name];
-    expect(editorState.editorLayers).toEqual(new Set(['electrifications', 'routes']));
   });
 
   it('should handle loadDataModelAction and update editorSchema', () => {

--- a/front/src/reducers/editor/__tests__/editorTestDataBuilder.ts
+++ b/front/src/reducers/editor/__tests__/editorTestDataBuilder.ts
@@ -1,9 +1,7 @@
-import type { Layer } from 'applications/editor/consts';
 import type { EditorState } from 'reducers/editor';
 
 export default function editorTestDataBuilder() {
   return {
-    buildEditorLayers: (layers: Array<Layer>): EditorState['editorLayers'] => new Set(layers),
     buildEditorSchema: (): EditorState['editorSchema'] => [
       { layer: 'layerA', objType: 'BufferStop', schema: {} },
       { layer: 'layerA', objType: 'Route', schema: {} },

--- a/front/src/reducers/editor/index.ts
+++ b/front/src/reducers/editor/index.ts
@@ -3,7 +3,6 @@ import type { PayloadAction } from '@reduxjs/toolkit';
 
 import type { InfraErrorLevel } from 'applications/editor/components/InfraErrors';
 import type { InfraErrorTypeLabel } from 'applications/editor/components/InfraErrors/types';
-import type { Layer } from 'applications/editor/consts';
 import type { EditorSchema } from 'applications/editor/typesEditorEntity';
 import { buildMapStateReducer, defaultMapSettings } from 'reducers/commonMap';
 import type { MapSettings, Viewport } from 'reducers/commonMap/types';
@@ -12,7 +11,6 @@ import { type InfraState, buildInfraStateReducers, infraState } from 'reducers/i
 export type EditorState = InfraState & {
   editorSchema: EditorSchema;
   mapSettings: MapSettings;
-  editorLayers: Set<Layer>;
   issuesSettings?: {
     types: Array<InfraErrorTypeLabel>;
   };
@@ -28,8 +26,6 @@ export const editorInitialState: EditorState = {
   // Definition of entities (json schema)
   editorSchema: [],
   mapSettings: defaultMapSettings,
-  // ID of selected layers on which we are working
-  editorLayers: new Set(['operational_points', 'track_sections']),
   // Editor issue management
   issues: {
     total: 0,
@@ -51,9 +47,6 @@ export const editorSlice = createSlice({
     },
     updateIssuesSettings: (state, action: PayloadAction<EditorState['issuesSettings']>) => {
       state.issuesSettings = action.payload;
-    },
-    selectLayers(state, action: PayloadAction<EditorState['editorLayers']>) {
-      state.editorLayers = action.payload;
     },
     loadDataModelAction(state, action: PayloadAction<EditorState['editorSchema']>) {
       state.editorSchema = action.payload;
@@ -82,7 +75,6 @@ export const editorSliceActions = editorSlice.actions;
 
 export const {
   updateIssuesSettings,
-  selectLayers,
   loadDataModelAction,
   updateTotalsIssueAction,
   updateFiltersIssueAction,

--- a/front/src/reducers/editor/selectors.ts
+++ b/front/src/reducers/editor/selectors.ts
@@ -14,7 +14,6 @@ const selectors = {
   ...buildInfraStateSelectors(editorSlice),
   getEditorState,
   getEditorIssues,
-  getEditorLayers: makeEditorSelector('editorLayers'),
   getEditorSchema: makeEditorSelector('editorSchema'),
   getInfraLockStatus,
   getMapSettings: makeEditorSelector('mapSettings'),


### PR DESCRIPTION
Layers settings were duplicated in the infrastructure editor, with editorLayers
and mapSettings.layersSettings.

We keep only layersSettings as it is already used in the rest of the application.

:warning: check that the display of level crossings still works correctly