### PR TITLE
front: store the pathStep offset in mm

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/PowerRestrictionsSelector/helpers/createPathStep.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/PowerRestrictionsSelector/helpers/createPathStep.ts
@@ -17,8 +17,8 @@ import { mmToM, mToMm } from 'utils/physics';
 export const cutRange = (
   allRanges: IntervalItem[],
   customRanges: IntervalItem[],
-  pathLength: number,
-  newCutPosition: number
+  pathLength: number, // in m
+  newCutPosition: number // in m
 ) => {
   if (newCutPosition >= pathLength) {
     throw Error('Invalid cut position: can not properly insert the new range');
@@ -81,11 +81,7 @@ const createPathStep = (
     id: uuidV4(),
     positionOnPath,
     coordinates,
-    location: {
-      ...trackOffset,
-      // TODO: we should return the offset in mm once it is stored in mm in the store
-      offset: mmToM(trackOffset.offset),
-    },
+    location: trackOffset,
     isFromPowerRestriction: true,
   };
 };
@@ -132,11 +128,7 @@ export const createCutAtPathStep = (
     positionOnPath: cutAtPosition,
     coordinates: coordinatesAtCut,
     isFromPowerRestriction: true,
-    location: {
-      ...trackOffset,
-      // TODO: we should return the offset in mm once it is stored in mm in the store
-      offset: mmToM(trackOffset.offset),
-    },
+    location: trackOffset,
   };
 };
 

--- a/front/src/modules/pathfinding/helpers/getStepLocation.ts
+++ b/front/src/modules/pathfinding/helpers/getStepLocation.ts
@@ -1,11 +1,8 @@
 import type { PathItemLocation } from 'common/api/osrdEditoastApi';
-import { mToMm } from 'utils/physics';
 
 const getStepLocation = (step: PathItemLocation): PathItemLocation => {
   if ('track' in step) {
-    // TODO: step offset should be in mm in the store /!\
-    // pathfinding blocks endpoint requires offsets in mm
-    return { track: step.track, offset: mToMm(step.offset) };
+    return { track: step.track, offset: step.offset };
   }
   if (step.operational_point.type === 'id') {
     return {

--- a/front/src/modules/timetableItem/helpers/computeBasePathStep.ts
+++ b/front/src/modules/timetableItem/helpers/computeBasePathStep.ts
@@ -1,7 +1,6 @@
 import type { TrainSchedule } from 'common/api/osrdEditoastApi';
 import type { PathStep } from 'reducers/osrdconf/types';
 import { Duration } from 'utils/duration';
-import { mmToM } from 'utils/physics';
 
 const findCorrespondingMargin = (
   stepId: string,
@@ -55,10 +54,7 @@ const computeBasePathStep = (
   return {
     id,
     name,
-    location: {
-      ...location,
-      ...('track' in location ? { offset: mmToM(location.offset) } : null),
-    },
+    location,
     arrival: arrival ? Duration.parse(arrival) : null,
     stopFor: stopFor ? Duration.parse(stopFor) : null,
     // If not provided, we set receptionSignal to its default value


### PR DESCRIPTION
All the distances coming from the backend are in mm, but for historical reasons, we stored them in m in the frontend and in the store.
Now all the distances are stored in mm everywhere.

To test:
- create a train with track offsets and check that the train is correctly created/displayed on map
- play with the power restrictions selector

Closes #8788