### PR TITLE
e2e:  refactor tests to rely exclusively on page object fixtures

### DIFF
--- a/front/tests/01-home/001-home-page.spec.ts
+++ b/front/tests/01-home/001-home-page.spec.ts
@@ -1,22 +1,18 @@
 import { expect } from '@playwright/test';
 
-import test from './../logging-fixture';
-import HomePage from '../pages/home-page';
+import test from './../page-object-fixture';
 import readJsonFile from '../utils/file-utils';
 import type { FlatTranslations } from '../utils/types';
 
 const frTranslations: FlatTranslations = readJsonFile('public/locales/fr/translation.json');
 
 test.describe('@home @navigation', () => {
-  let homePage: HomePage;
-
-  test.beforeEach('Navigate to the home page', async ({ page }) => {
-    homePage = new HomePage(page);
+  test.beforeEach('Navigate to the home page', async ({ homePage }) => {
     await homePage.goToHomePage();
   });
 
   /** *************** Test 1 **************** */
-  test('@smoke Verify the links for different pages in Home Page', async () => {
+  test('@smoke Verify the links for different pages in Home Page', async ({ homePage }) => {
     const expectedLinks = [
       frTranslations.operationalStudies,
       frTranslations.stdcm,
@@ -29,25 +25,25 @@ test.describe('@home @navigation', () => {
   });
 
   /** *************** Test 2 **************** */
-  test('@smoke Verify redirection to the Operational Studies page', async () => {
+  test('@smoke Verify redirection to the Operational Studies page', async ({ homePage }) => {
     await homePage.goToOperationalStudiesPage();
     await expect(homePage.page).toHaveURL(/.*\/operational-studies/);
   });
 
   /** *************** Test 3 **************** */
-  test('Verify redirection to the Map page', async () => {
+  test('Verify redirection to the Map page', async ({ homePage }) => {
     await homePage.goToCartoPage();
     await expect(homePage.page).toHaveURL(/.*\/map/);
   });
 
   /** *************** Test 4 **************** */
-  test('Verify redirection to the Infrastructure editor page', async () => {
+  test('Verify redirection to the Infrastructure editor page', async ({ homePage }) => {
     await homePage.goToEditorPage();
     await expect(homePage.page).toHaveURL(/.*\/editor\/*/);
   });
 
   /** *************** Test 5 **************** */
-  test('@smoke Verify redirection to the STDCM page', async ({ context }) => {
+  test('@smoke Verify redirection to the STDCM page', async ({ context, homePage }) => {
     const stdcmPage = await homePage.goToSTDCMPage(context);
     await expect(stdcmPage).toHaveURL(/.*\/stdcm/);
   });

--- a/front/tests/02-operational-studies/management/001-project-management.spec.ts
+++ b/front/tests/02-operational-studies/management/001-project-management.spec.ts
@@ -1,7 +1,6 @@
 import type { Project } from 'common/api/osrdEditoastApi';
 
-import test from '../../logging-fixture';
-import ProjectPage from '../../pages/operational-studies/project-page';
+import test from '../../page-object-fixture';
 import { generateUniqueName } from '../../utils';
 import readJsonFile from '../../utils/file-utils';
 import { createProject } from '../../utils/setup-utils';
@@ -11,14 +10,9 @@ import type { ProjectData } from '../../utils/types';
 const projectData: ProjectData = readJsonFile('tests/assets/operation-studies/project.json');
 
 test.describe('@op @project @management', () => {
-  let projectPage: ProjectPage;
   let project: Project;
 
   const createdProjects: string[] = [];
-
-  test.beforeEach(async ({ page }) => {
-    projectPage = new ProjectPage(page);
-  });
 
   test.afterAll(async () => {
     if (!createdProjects.length) return;
@@ -27,7 +21,7 @@ test.describe('@op @project @management', () => {
   });
 
   /** *************** Test 1 **************** */
-  test('@smoke Create a new project', async ({ page }) => {
+  test('@smoke Create a new project', async ({ page, projectPage }) => {
     const projectName = generateUniqueName(projectData.name);
     createdProjects.push(projectName);
 
@@ -59,7 +53,7 @@ test.describe('@op @project @management', () => {
   });
 
   /** *************** Test 2 **************** */
-  test('Update an existing project', async ({ page }) => {
+  test('Update an existing project', async ({ page, projectPage }) => {
     const baseName = generateUniqueName(projectData.name);
     const updatedName = `${baseName} (updated)`;
     createdProjects.push(baseName, updatedName);
@@ -103,7 +97,7 @@ test.describe('@op @project @management', () => {
   });
 
   /** *************** Test 3 **************** */
-  test('Delete a project', async ({ page }) => {
+  test('Delete a project', async ({ page, projectPage }) => {
     const projectName = generateUniqueName(projectData.name);
     createdProjects.push(projectName);
 

--- a/front/tests/02-operational-studies/management/002-study-management.spec.ts
+++ b/front/tests/02-operational-studies/management/002-study-management.spec.ts
@@ -2,8 +2,7 @@ import { expect } from '@playwright/test';
 
 import type { Project, Study } from 'common/api/osrdEditoastApi';
 
-import test from '../../logging-fixture';
-import StudyPage from '../../pages/operational-studies/study-page';
+import test from '../../page-object-fixture';
 import { generateUniqueName } from '../../utils';
 import { getProject } from '../../utils/api-utils';
 import { formatDateToDayMonthYear } from '../../utils/date-utils';
@@ -19,7 +18,6 @@ const frTranslations: StudyFrTranslations = readJsonFile(
 );
 
 test.describe('@op @study @management', () => {
-  let studyPage: StudyPage;
   let project: Project;
   let study: Study;
 
@@ -35,12 +33,8 @@ test.describe('@op @study @management', () => {
     await Promise.allSettled(studiesToDelete.map((s) => deleteStudy(s.projectId, s.name)));
   });
 
-  test.beforeEach(async ({ page }) => {
-    studyPage = new StudyPage(page);
-  });
-
   /** *************** Test 1 **************** */
-  test('@smoke Create a new study', async ({ page }) => {
+  test('@smoke Create a new study', async ({ page, studyPage }) => {
     await test.step('Navigate to project page', async () => {
       await page.goto(`/operational-studies/projects/${project.id}`);
     });
@@ -85,7 +79,7 @@ test.describe('@op @study @management', () => {
   });
 
   /** *************** Test 2 **************** */
-  test('Update an existing study', async ({ page }) => {
+  test('Update an existing study', async ({ page, studyPage }) => {
     const baseName = generateUniqueName(studyData.name);
     const updatedName = `${baseName} (updated)`;
     createdStudies.push({ projectId: project.id, name: updatedName });
@@ -138,7 +132,7 @@ test.describe('@op @study @management', () => {
   });
 
   /** *************** Test 3 **************** */
-  test('Delete a study', async ({ page }) => {
+  test('Delete a study', async ({ page, studyPage }) => {
     await test.step('Create a study to delete', async () => {
       study = await createStudy(project.id, generateUniqueName(studyData.name));
       createdStudies.push({ projectId: project.id, name: study.name });

--- a/front/tests/02-operational-studies/management/003-scenario-management.spec.ts
+++ b/front/tests/02-operational-studies/management/003-scenario-management.spec.ts
@@ -9,8 +9,7 @@ import type {
 } from 'common/api/osrdEditoastApi';
 
 import { infrastructureName } from '../../assets/constants/project-const';
-import test from '../../logging-fixture';
-import ScenarioPage from '../../pages/operational-studies/scenario-page';
+import test from '../../page-object-fixture';
 import { generateUniqueName, waitForInfraStateToBeCached } from '../../utils';
 import {
   deleteApiRequest,
@@ -27,8 +26,6 @@ import type { ScenarioData } from '../../utils/types';
 const scenarioData: ScenarioData = readJsonFile('tests/assets/operation-studies/scenario.json');
 
 test.describe('@op @scenario @management', () => {
-  let scenarioPage: ScenarioPage;
-
   let project: Project;
   let study: Study;
   let scenario: Scenario;
@@ -51,12 +48,8 @@ test.describe('@op @scenario @management', () => {
     await Promise.allSettled(scenariosToDelete.map((s) => deleteScenario(s.studyId, s.name)));
   });
 
-  test.beforeEach(async ({ page }) => {
-    scenarioPage = new ScenarioPage(page);
-  });
-
   /** *************** Test 1 **************** */
-  test('@smoke Create a new scenario', async ({ page }) => {
+  test('@smoke Create a new scenario', async ({ page, scenarioPage }) => {
     const scenarioName = generateUniqueName(scenarioData.name);
     createdScenarios.push({
       projectId: project.id,
@@ -89,7 +82,7 @@ test.describe('@op @scenario @management', () => {
   });
 
   /** *************** Test 2 **************** */
-  test('@smoke Update an existing scenario', async ({ page }) => {
+  test('@smoke Update an existing scenario', async ({ page, scenarioPage }) => {
     await test.step('Create a base scenario', async () => {
       ({ project, study, scenario } = await createScenario());
     });
@@ -142,7 +135,7 @@ test.describe('@op @scenario @management', () => {
   });
 
   /** *************** Test 3 **************** */
-  test('Delete a scenario', async ({ page }) => {
+  test('Delete a scenario', async ({ page, scenarioPage }) => {
     await test.step('Create a scenario to delete', async () => {
       ({ project, study, scenario } = await createScenario());
     });

--- a/front/tests/02-operational-studies/nge/001-osrd-nge.spec.ts
+++ b/front/tests/02-operational-studies/nge/001-osrd-nge.spec.ts
@@ -4,9 +4,7 @@ import {
   timetableItemProjectName,
   timetableItemStudyName,
 } from '../../assets/constants/project-const';
-import test from '../../logging-fixture';
-import NGEPage from '../../pages/operational-studies/nge-page';
-import ScenarioTimetableSection from '../../pages/operational-studies/scenario-timetable-section';
+import test from '../../page-object-fixture';
 import { generateUniqueName, waitForInfraStateToBeCached } from '../../utils';
 import { getInfra, getProject, getStudy } from '../../utils/api-utils';
 import readJsonFile from '../../utils/file-utils';
@@ -24,11 +22,6 @@ const frTranslations: TimetableFilterTranslations = readJsonFile<{
 }>('public/locales/fr/operational-studies.json').main;
 
 test.describe('@op @nge', () => {
-  test.use({ ignorePageErrors: true });
-
-  let ngePage: NGEPage;
-  let scenarioTimetableSection: ScenarioTimetableSection;
-
   let project: Project;
   let study: Study;
   let scenarioItems: Scenario;
@@ -40,10 +33,7 @@ test.describe('@op @nge', () => {
     infra = await getInfra();
   });
 
-  test.beforeEach('Open scenario and enable only macro view', async ({ page }) => {
-    ngePage = new NGEPage(page);
-    scenarioTimetableSection = new ScenarioTimetableSection(page);
-
+  test.beforeEach('Open scenario and enable only macro view', async ({ page, ngePage }) => {
     // scenario header is persisted in local storage, clear it before loading the scenario
     await page.addInitScript(() => {
       window.localStorage.clear();
@@ -70,7 +60,7 @@ test.describe('@op @nge', () => {
   });
 
   /** *************** Test 1 **************** */
-  test('Verify NGE train data', async () => {
+  test('Verify NGE train data', async ({ ngePage }) => {
     await test.step('Verify nodes displayed on NGE graph', async () => {
       await ngePage.expectNodes(['SWS/BV', 'MWS/BV', 'MES/BV']);
     });
@@ -113,7 +103,7 @@ test.describe('@op @nge', () => {
   });
 
   /** *************** Test 2 **************** */
-  test('Delete a train from train list', async ({ page }) => {
+  test('Delete a train from train list', async ({ page, scenarioTimetableSection, ngePage }) => {
     await test.step('Delete train from timetable list', async () => {
       await scenarioTimetableSection.deleteTimetableItem();
     });
@@ -136,7 +126,7 @@ test.describe('@op @nge', () => {
   });
 
   /** *************** Test 3 **************** */
-  test('Delete a train from NGE', async ({ page }) => {
+  test('Delete a train from NGE', async ({ page, ngePage, scenarioTimetableSection }) => {
     await test.step('Delete first node via dialog (expect 2 nodes, 1 line)', async () => {
       await ngePage.deleteNodeByIndexViaDialog(0, { nodes: 2, lines: 1 });
     });

--- a/front/tests/02-operational-studies/nge/002-nge-osrd.spec.ts
+++ b/front/tests/02-operational-studies/nge/002-nge-osrd.spec.ts
@@ -6,10 +6,7 @@ import {
   timetableItemProjectName,
   timetableItemStudyName,
 } from '../../assets/constants/project-const';
-import test from '../../logging-fixture';
-import NGEPage from '../../pages/operational-studies/nge-page';
-import RoundTripPage from '../../pages/operational-studies/round-trips-page';
-import ScenarioTimetableSection from '../../pages/operational-studies/scenario-timetable-section';
+import test from '../../page-object-fixture';
 import { generateUniqueName, waitForInfraStateToBeCached } from '../../utils';
 import { getInfra, getProject, getStudy } from '../../utils/api-utils';
 import readJsonFile from '../../utils/file-utils';
@@ -30,10 +27,6 @@ const frTranslations = {
 test.describe('@op @nge @round-trips', () => {
   test.use({ ignorePageErrors: true });
 
-  let ngePage: NGEPage;
-  let scenarioTimetableSection: ScenarioTimetableSection;
-  let roundTripPage: RoundTripPage;
-
   let project: Project;
   let study: Study;
   let scenarioItems: Scenario;
@@ -45,11 +38,7 @@ test.describe('@op @nge @round-trips', () => {
     infra = await getInfra();
   });
 
-  test.beforeEach('Open scenario and enable only macro view', async ({ page }) => {
-    ngePage = new NGEPage(page);
-    scenarioTimetableSection = new ScenarioTimetableSection(page);
-    roundTripPage = new RoundTripPage(page);
-
+  test.beforeEach('Open scenario and enable only macro view', async ({ page, ngePage }) => {
     await test.step('Create, open scenario and wait for infra to be loaded', async () => {
       scenarioItems = (
         await createScenario(generateUniqueName('nge-scenario'), project.id, study.id, infra.id)
@@ -70,7 +59,11 @@ test.describe('@op @nge @round-trips', () => {
   });
 
   /** *************** Test 1 **************** */
-  test('@smoke Add a train from NGE', async () => {
+  test('@smoke Add a train from NGE', async ({
+    ngePage,
+    scenarioTimetableSection,
+    roundTripPage,
+  }) => {
     await test.step('Create three nodes', async () => {
       await ngePage.createNode({ x: 50, y: 400 }, 'NWS', 'Origin');
       await expect(ngePage.nodeCards).toHaveCount(1);

--- a/front/tests/02-operational-studies/paced-trains/001-paced-train-management.spec.ts
+++ b/front/tests/02-operational-studies/paced-trains/001-paced-train-management.spec.ts
@@ -14,15 +14,7 @@ import {
   TOTAL_PACED_TRAINS,
   TOTAL_PACED_TRAINS_WITH_DUPLICATE,
 } from '../../assets/constants/timetable-items-count';
-import test from '../../logging-fixture';
-import OperationalStudiesPage from '../../pages/operational-studies/operational-studies-page';
-import PacedTrainSection from '../../pages/operational-studies/paced-train-section';
-import RouteTab from '../../pages/operational-studies/route-tab';
-import ScenarioTimetableSection from '../../pages/operational-studies/scenario-timetable-section';
-import OpSimulationResultPage from '../../pages/operational-studies/simulation-results-page';
-import TimeAndStopSimulationOutputs from '../../pages/operational-studies/time-stop-simulation-outputs';
-import TimesAndStopsTab from '../../pages/operational-studies/times-and-stops-tab';
-import RollingStockSelector from '../../pages/rolling-stock/rolling-stock-selector';
+import test from '../../page-object-fixture';
 import { waitForInfraStateToBeCached } from '../../utils';
 import { getInfra } from '../../utils/api-utils';
 import { cleanWhitespace } from '../../utils/data-normalizer';
@@ -71,15 +63,6 @@ const expectedOutputData: StationData[] = readJsonFile(
 const pacedTrainsJson = readJsonFile<[PacedTrain]>('./tests/assets/paced-train/paced_trains.json');
 
 test.describe('@op @paced-trains', () => {
-  let rollingstockSelector: RollingStockSelector;
-  let operationalStudiesPage: OperationalStudiesPage;
-  let scenarioTimetableSection: ScenarioTimetableSection;
-  let routeTab: RouteTab;
-  let pacedTrainSection: PacedTrainSection;
-  let timesAndStopsTab: TimesAndStopsTab;
-  let simulationResultPage: OpSimulationResultPage;
-  let timeAndStopSimulationOutputs: TimeAndStopSimulationOutputs;
-
   let project: Project;
   let study: Study;
   let scenario: Scenario;
@@ -97,26 +80,6 @@ test.describe('@op @paced-trains', () => {
   test.beforeEach(
     'Navigate to scenario page and wait for infrastructure to be loaded',
     async ({ page }) => {
-      [
-        rollingstockSelector,
-        operationalStudiesPage,
-        scenarioTimetableSection,
-        routeTab,
-        pacedTrainSection,
-        timesAndStopsTab,
-        simulationResultPage,
-        timeAndStopSimulationOutputs,
-      ] = [
-        new RollingStockSelector(page),
-        new OperationalStudiesPage(page),
-        new ScenarioTimetableSection(page),
-        new RouteTab(page),
-        new PacedTrainSection(page),
-        new TimesAndStopsTab(page),
-        new OpSimulationResultPage(page),
-        new TimeAndStopSimulationOutputs(page),
-      ];
-
       await page.goto(
         `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenario.id}`
       );
@@ -125,7 +88,7 @@ test.describe('@op @paced-trains', () => {
   );
 
   /** *************** Test 1 **************** */
-  test('Verify default behaviors with paced train mode', async () => {
+  test('Verify default behaviors with paced train mode', async ({ operationalStudiesPage }) => {
     await test.step('Open timetable item form', async () => {
       await operationalStudiesPage.openTimetableItemForm();
     });
@@ -148,7 +111,17 @@ test.describe('@op @paced-trains', () => {
   });
 
   /** *************** Test 2 **************** */
-  test('@smoke Add a paced train and verify its timetable details', async ({ browserName }) => {
+  test('@smoke Add a paced train and verify its timetable details', async ({
+    browserName,
+    operationalStudiesPage,
+    rollingStockSelector,
+    routeTab,
+    timesAndStopsTab,
+    scenarioTimetableSection,
+    pacedTrainSection,
+    opSimulationResultPage,
+    timeAndStopSimulationOutputs,
+  }) => {
     await test.step('Open timetable item form', async () => {
       await operationalStudiesPage.openTimetableItemForm();
     });
@@ -158,7 +131,7 @@ test.describe('@op @paced-trains', () => {
     });
 
     await test.step('Select rolling stock', async () => {
-      await rollingstockSelector.selectRollingStock(dualModeRollingStockName);
+      await rollingStockSelector.selectRollingStock(dualModeRollingStockName);
     });
 
     await test.step('Select itinerary and verify distance', async () => {
@@ -203,9 +176,9 @@ test.describe('@op @paced-trains', () => {
 
     await test.step('Open first occurrence and verify its simulation results (screenshot comparison for the GEV)', async () => {
       await pacedTrainSection.selectOccurrence({ pacedTrainIndex: 0, occurrenceIndex: 0 });
-      await simulationResultPage.setTrainListVisible();
+      await opSimulationResultPage.setTrainListVisible();
       if (browserName === 'chromium') {
-        await expect(simulationResultPage.speedSpaceChart).toHaveScreenshot(
+        await expect(opSimulationResultPage.speedSpaceChart).toHaveScreenshot(
           'SpeedSpaceChart-InitialInputs.png'
         );
       }
@@ -214,7 +187,12 @@ test.describe('@op @paced-trains', () => {
   });
 
   /** *************** Test 3 **************** */
-  test('Duplicate and delete a paced train', async ({ page }) => {
+  test('Duplicate and delete a paced train', async ({
+    page,
+    scenarioTimetableSection,
+    pacedTrainSection,
+    operationalStudiesPage,
+  }) => {
     await test.step('Set paced trains via API and reload to initialize list', async () => {
       await sendTrains(scenario.timetable_id, pacedTrainsJson);
       await page.reload();

--- a/front/tests/02-operational-studies/paced-trains/002-paced-train-exceptions.spec.ts
+++ b/front/tests/02-operational-studies/paced-trains/002-paced-train-exceptions.spec.ts
@@ -9,11 +9,7 @@ import {
   timetableItemStudyName,
 } from '../../assets/constants/project-const';
 import { ADDED_EXCEPTION_MENU_BUTTONS } from '../../assets/paced-train/const';
-import test from '../../logging-fixture';
-import OperationalStudiesPage from '../../pages/operational-studies/operational-studies-page';
-import PacedTrainSection from '../../pages/operational-studies/paced-train-section';
-import ScenarioTimetableSection from '../../pages/operational-studies/scenario-timetable-section';
-import RollingStockSelector from '../../pages/rolling-stock/rolling-stock-selector';
+import test from '../../page-object-fixture';
 import { generateUniqueName, waitForInfraStateToBeCached } from '../../utils';
 import { getInfra, getProject, getStudy } from '../../utils/api-utils';
 import readJsonFile from '../../utils/file-utils';
@@ -50,11 +46,6 @@ test.describe('@op @paced-trains @exceptions', () => {
   let study: Study;
   let infra: Infra;
 
-  let scenarioTimetableSection: ScenarioTimetableSection;
-  let operationalStudiesPage: OperationalStudiesPage;
-  let pacedTrainSection: PacedTrainSection;
-  let rollingStockSelector: RollingStockSelector;
-
   let scenarioItems: Scenario;
 
   test.beforeAll('Setup project, study, infra and create scenario with paced trains', async () => {
@@ -75,14 +66,6 @@ test.describe('@op @paced-trains @exceptions', () => {
   test.beforeEach(
     'Navigate to scenario page and wait for infrastructure to be loaded',
     async ({ page }) => {
-      [pacedTrainSection, scenarioTimetableSection, operationalStudiesPage, rollingStockSelector] =
-        [
-          new PacedTrainSection(page),
-          new ScenarioTimetableSection(page),
-          new OperationalStudiesPage(page),
-          new RollingStockSelector(page),
-        ];
-
       await page.goto(
         `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenarioItems.id}`
       );
@@ -95,7 +78,12 @@ test.describe('@op @paced-trains @exceptions', () => {
   });
 
   /** *************** Test 1 **************** */
-  test('@smoke Edit a paced train and handle exceptions', async () => {
+  test('@smoke Edit a paced train and handle exceptions', async ({
+    pacedTrainSection,
+    scenarioTimetableSection,
+    rollingStockSelector,
+    operationalStudiesPage,
+  }) => {
     const editedPacedTrainData = pacedTrainsJson[5];
 
     await test.step('Open action buttons for paced train at index 5', async () => {
@@ -213,7 +201,11 @@ test.describe('@op @paced-trains @exceptions', () => {
   });
 
   /** *************** Test 2 **************** */
-  test('Modify a paced train and create added exception', async () => {
+  test('Modify a paced train and create added exception', async ({
+    pacedTrainSection,
+    scenarioTimetableSection,
+    operationalStudiesPage,
+  }) => {
     const editedPacedTrainData = pacedTrainsJson[1];
 
     await test.step('Edit paced train at index 1', async () => {

--- a/front/tests/02-operational-studies/paced-trains/003-paced-train-occurrence-edition.spec.ts
+++ b/front/tests/02-operational-studies/paced-trains/003-paced-train-occurrence-edition.spec.ts
@@ -14,13 +14,7 @@ import {
   EXCEPTION_ACTIVE_OCCURRENCE_MENU_BUTTONS,
   INITIAL_OCCURRENCE_NAME,
 } from '../../assets/paced-train/const';
-import test from '../../logging-fixture';
-import OperationalStudiesPage from '../../pages/operational-studies/operational-studies-page';
-import PacedTrainSection from '../../pages/operational-studies/paced-train-section';
-import RouteTab from '../../pages/operational-studies/route-tab';
-import SimulationSettingsTab from '../../pages/operational-studies/simulation-settings-tab';
-import TimesAndStopsTab from '../../pages/operational-studies/times-and-stops-tab';
-import RollingStockSelector from '../../pages/rolling-stock/rolling-stock-selector';
+import test from '../../page-object-fixture';
 import { generateUniqueName, waitForInfraStateToBeCached } from '../../utils';
 import { getInfra, getProject, getStudy } from '../../utils/api-utils';
 import readJsonFile from '../../utils/file-utils';
@@ -57,13 +51,6 @@ test.describe('@op @paced-trains @exceptions', () => {
   let study: Study;
   let infra: Infra;
 
-  let operationalStudiesPage: OperationalStudiesPage;
-  let pacedTrainSection: PacedTrainSection;
-  let rollingStockSelector: RollingStockSelector;
-  let routeTab: RouteTab;
-  let timesAndStopsTab: TimesAndStopsTab;
-  let simulationSettingsTab: SimulationSettingsTab;
-
   let scenarioItems: Scenario;
 
   test.beforeAll('Setup project, study, infra and create scenario with paced trains', async () => {
@@ -84,22 +71,6 @@ test.describe('@op @paced-trains @exceptions', () => {
   test.beforeEach(
     'Navigate to scenario page and wait for infrastructure to be loaded',
     async ({ page }) => {
-      [
-        pacedTrainSection,
-        operationalStudiesPage,
-        rollingStockSelector,
-        routeTab,
-        timesAndStopsTab,
-        simulationSettingsTab,
-      ] = [
-        new PacedTrainSection(page),
-        new OperationalStudiesPage(page),
-        new RollingStockSelector(page),
-        new RouteTab(page),
-        new TimesAndStopsTab(page),
-        new SimulationSettingsTab(page),
-      ];
-
       await page.goto(
         `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenarioItems.id}`
       );
@@ -112,7 +83,7 @@ test.describe('@op @paced-trains @exceptions', () => {
   });
 
   /** *************** Test 1 **************** */
-  test('Edit an indexed occurrence', async () => {
+  test('Edit an indexed occurrence', async ({ pacedTrainSection, operationalStudiesPage }) => {
     await test.step('Open paced train and check initial menu (first occurrence)', async () => {
       await pacedTrainSection.expandPacedTrainOccurrenceList(0);
       await pacedTrainSection.checkOccurrenceMenuIcon(0);
@@ -175,7 +146,14 @@ test.describe('@op @paced-trains @exceptions', () => {
   });
 
   /** *************** Test 2 **************** */
-  test('Edit added exception', async () => {
+  test('Edit added exception', async ({
+    pacedTrainSection,
+    operationalStudiesPage,
+    rollingStockSelector,
+    timesAndStopsTab,
+    routeTab,
+    simulationSettingsTab,
+  }) => {
     const PACED_TRAIN_NUMBER = 4;
     const addedOccurrenceIndex = 1;
     const editedPacedTrainData = pacedTrainsJson[PACED_TRAIN_NUMBER];

--- a/front/tests/02-operational-studies/simulation-result/001-get-manchette.spec.ts
+++ b/front/tests/02-operational-studies/simulation-result/001-get-manchette.spec.ts
@@ -18,11 +18,7 @@ import {
   CONFORM_ACTIVE_OCCURRENCE_MENU_BUTTONS,
   EXCEPTION_ACTIVE_OCCURRENCE_MENU_BUTTONS,
 } from '../../assets/paced-train/const';
-import test from '../../logging-fixture';
-import GetManchetteComponent from '../../pages/operational-studies/get-manchette-component';
-import PacedTrainSection from '../../pages/operational-studies/paced-train-section';
-import ScenarioTimetableSection from '../../pages/operational-studies/scenario-timetable-section';
-import OpSimulationResultPage from '../../pages/operational-studies/simulation-results-page';
+import test from '../../page-object-fixture';
 import { generateUniqueName, waitForInfraStateToBeCached } from '../../utils';
 import { getInfra, getProject, getStudy } from '../../utils/api-utils';
 import readJsonFile from '../../utils/file-utils';
@@ -68,11 +64,6 @@ test.skip(
 );
 
 test.describe('@op @manchette @std', () => {
-  let simulationResultPage: OpSimulationResultPage;
-  let scenarioTimetableSection: ScenarioTimetableSection;
-  let pacedTrainSection: PacedTrainSection;
-  let getManchetteComponent: GetManchetteComponent;
-
   let project: Project;
   let study: Study;
   let scenarioItems: Scenario;
@@ -95,13 +86,6 @@ test.describe('@op @manchette @std', () => {
   });
 
   test.beforeEach('Open scenario and wait for infra to be loaded', async ({ page }) => {
-    [simulationResultPage, scenarioTimetableSection, pacedTrainSection, getManchetteComponent] = [
-      new OpSimulationResultPage(page),
-      new ScenarioTimetableSection(page),
-      new PacedTrainSection(page),
-      new GetManchetteComponent(page),
-    ];
-
     await page.goto(
       `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenarioItems.id}`
     );
@@ -113,10 +97,14 @@ test.describe('@op @manchette @std', () => {
   });
 
   /** *************** Test 1 **************** */
-  test('@smoke Basic checks for STD/Manchette', async () => {
+  test('@smoke Basic checks for STD/Manchette', async ({
+    scenarioTimetableSection,
+    opSimulationResultPage,
+    getManchetteComponent,
+  }) => {
     await test.step('Verify first train schedule is selected', async () => {
       await scenarioTimetableSection.verifyFirstTimetableItemIsSelected();
-      await simulationResultPage.setTrainListVisible();
+      await opSimulationResultPage.setTrainListVisible();
     });
     await test.step('Assert GET slider', async () => {
       await getManchetteComponent.assertDefaultSliderValue();
@@ -141,29 +129,34 @@ test.describe('@op @manchette @std', () => {
   });
 
   /** *************** Test 2 **************** */
-  test.skip('Space time diagram (temporarily skipped until STD snapshots are stable)', async () => {
+  test.skip('Space time diagram (temporarily skipped until STD snapshots are stable)', async ({
+    scenarioTimetableSection,
+    opSimulationResultPage,
+    getManchetteComponent,
+    pacedTrainSection,
+  }) => {
     await test.step('Project train schedule and capture GET screenshot', async () => {
       await scenarioTimetableSection.projectTrain();
       await getManchetteComponent.selectAllSpaceTimeChartCheckboxes();
       await getManchetteComponent.setRangeSliderValue('60'); // Adjust slider to show the full projection
-      await simulationResultPage.setTrainListVisible();
-      await expect(simulationResultPage.manchetteSpaceTimeChart).toHaveScreenshot(
+      await opSimulationResultPage.setTrainListVisible();
+      await expect(opSimulationResultPage.manchetteSpaceTimeChart).toHaveScreenshot(
         'TrainSchedule-Space-Time-Chart.png'
       );
     });
 
     await test.step('Project paced train and capture GET screenshot', async () => {
-      await simulationResultPage.setTrainListVisible(false);
+      await opSimulationResultPage.setTrainListVisible(false);
       await pacedTrainSection.projectPacedTrain();
       await getManchetteComponent.setRangeSliderValue('50'); // Adjust slider to show the paced train better
-      await simulationResultPage.setTrainListVisible();
-      await expect(simulationResultPage.manchetteSpaceTimeChart).toHaveScreenshot(
+      await opSimulationResultPage.setTrainListVisible();
+      await expect(opSimulationResultPage.manchetteSpaceTimeChart).toHaveScreenshot(
         'PacedTrain-Space-Time-Chart.png'
       );
     });
 
     await test.step('Project first occurrence (conform) and capture screenshot', async () => {
-      await simulationResultPage.setTrainListVisible(false);
+      await opSimulationResultPage.setTrainListVisible(false);
       await getManchetteComponent.setRangeSliderValue('60'); // Reset slider to show the full diagram
       await pacedTrainSection.clickOnOccurrence(0);
       await pacedTrainSection.checkOccurrenceMenuIcon(0);
@@ -174,14 +167,14 @@ test.describe('@op @manchette @std', () => {
       });
 
       await pacedTrainSection.clickOccurrenceMenuButton('project');
-      await simulationResultPage.setTrainListVisible();
-      await expect(simulationResultPage.manchetteSpaceTimeChart).toHaveScreenshot(
+      await opSimulationResultPage.setTrainListVisible();
+      await expect(opSimulationResultPage.manchetteSpaceTimeChart).toHaveScreenshot(
         'ConformOccurrence-Space-Time-Chart.png'
       );
     });
 
     await test.step('Project added exception and capture screenshot', async () => {
-      await simulationResultPage.setTrainListVisible(false);
+      await opSimulationResultPage.setTrainListVisible(false);
       await pacedTrainSection.clickOnOccurrence(3);
       await pacedTrainSection.checkOccurrenceMenuIcon(3);
       await pacedTrainSection.checkOccurrenceActionMenu({
@@ -191,14 +184,14 @@ test.describe('@op @manchette @std', () => {
       });
 
       await pacedTrainSection.clickOccurrenceMenuButton('project');
-      await simulationResultPage.setTrainListVisible();
-      await expect(simulationResultPage.manchetteSpaceTimeChart).toHaveScreenshot(
+      await opSimulationResultPage.setTrainListVisible();
+      await expect(opSimulationResultPage.manchetteSpaceTimeChart).toHaveScreenshot(
         'AddedOccurrence-Space-Time-Chart.png'
       );
     });
 
     await test.step('Project last occurrence (exception) and capture screenshot', async () => {
-      await simulationResultPage.setTrainListVisible(false);
+      await opSimulationResultPage.setTrainListVisible(false);
       await pacedTrainSection.clickOnOccurrence(4);
       await pacedTrainSection.checkOccurrenceMenuIcon(4);
       await pacedTrainSection.checkOccurrenceActionMenu({
@@ -207,18 +200,23 @@ test.describe('@op @manchette @std', () => {
         translations: frTranslations,
       });
       await pacedTrainSection.clickOccurrenceMenuButton('project');
-      await simulationResultPage.setTrainListVisible();
-      await expect(simulationResultPage.manchetteSpaceTimeChart).toHaveScreenshot(
+      await opSimulationResultPage.setTrainListVisible();
+      await expect(opSimulationResultPage.manchetteSpaceTimeChart).toHaveScreenshot(
         'ModifiedOccurrence-Space-Time-Chart.png'
       );
     });
   });
 
   /** *************** Test 3 **************** */
-  test('Manchette waypoints data', async () => {
+  test('Manchette waypoints data', async ({
+    scenarioTimetableSection,
+    opSimulationResultPage,
+    getManchetteComponent,
+    pacedTrainSection,
+  }) => {
     await test.step('Project train schedule and verify waypoints list', async () => {
       await scenarioTimetableSection.projectTrain();
-      await simulationResultPage.setTrainListVisible();
+      await opSimulationResultPage.setTrainListVisible();
       const actualWaypointsListData = await getManchetteComponent.getWaypointsListData(4);
       verifyWaypointsData(actualWaypointsListData, expectedWaypointsListDataForTrainSchedule);
     });
@@ -231,9 +229,9 @@ test.describe('@op @manchette @std', () => {
     });
 
     await test.step('Project paced train and verify waypoints list', async () => {
-      await simulationResultPage.setTrainListVisible(false);
+      await opSimulationResultPage.setTrainListVisible(false);
       await pacedTrainSection.projectPacedTrain();
-      await simulationResultPage.setTrainListVisible();
+      await opSimulationResultPage.setTrainListVisible();
       const actualWaypointsListData = await getManchetteComponent.getWaypointsListData(4);
       verifyWaypointsData(actualWaypointsListData, expectedWaypointsListDataForPacedTrain);
     });

--- a/front/tests/02-operational-studies/timetable/001-train-timetable.spec.ts
+++ b/front/tests/02-operational-studies/timetable/001-train-timetable.spec.ts
@@ -16,9 +16,7 @@ import {
   VALID_PACED_TRAINS,
   VALID_TRAIN_SCHEDULE,
 } from '../../assets/constants/timetable-items-count';
-import test from '../../logging-fixture';
-import PacedTrainSection from '../../pages/operational-studies/paced-train-section';
-import ScenarioTimetableSection from '../../pages/operational-studies/scenario-timetable-section';
+import test from '../../page-object-fixture';
 import { waitForInfraStateToBeCached } from '../../utils';
 import { getInfra, getProject, getScenario, getStudy } from '../../utils/api-utils';
 import readJsonFile from '../../utils/file-utils';
@@ -35,9 +33,6 @@ const frTranslations = {
 };
 
 test.describe('@op @timetable-items', () => {
-  let scenarioTimetableSection: ScenarioTimetableSection;
-  let pacedTrainSection: PacedTrainSection;
-
   let project: Project;
   let study: Study;
   let scenario: Scenario;
@@ -53,11 +48,6 @@ test.describe('@op @timetable-items', () => {
   test.beforeEach(
     'Navigate to scenario page and wait for infrastructure to be loaded',
     async ({ page }) => {
-      [scenarioTimetableSection, pacedTrainSection] = [
-        new ScenarioTimetableSection(page),
-        new PacedTrainSection(page),
-      ];
-
       await page.goto(
         `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenario.id}`
       );
@@ -66,7 +56,9 @@ test.describe('@op @timetable-items', () => {
   );
 
   /** *************** Test 1 **************** */
-  test('@smoke Loading timetable items and verifying simulation result for train schedules', async () => {
+  test('@smoke Loading timetable items and verifying simulation result for train schedules', async ({
+    scenarioTimetableSection,
+  }) => {
     await test.step('Verify counts then filter valid train schedules', async () => {
       await scenarioTimetableSection.verifyTimetableItemsCount(TOTAL_TIMETABLE_ITEMS);
       await scenarioTimetableSection.filterTrainTypeAndVerifyTrainCount(
@@ -86,7 +78,9 @@ test.describe('@op @timetable-items', () => {
   });
 
   /** *************** Test 2 **************** */
-  test('Loading timetable items and verifying simulation result for paced trains', async () => {
+  test('Loading timetable items and verifying simulation result for paced trains', async ({
+    scenarioTimetableSection,
+  }) => {
     test.slow(); // Verifying all occurrences of paced trains can take some time, this test will be reworked later to optimize it
     await test.step('Verify invalid message, then filter valid paced trains', async () => {
       await scenarioTimetableSection.verifyInvalidTrainsMessageVisibility();
@@ -107,7 +101,9 @@ test.describe('@op @timetable-items', () => {
   });
 
   /** *************** Test 3 **************** */
-  test('Loading timetable items and verifying paced trains display', async () => {
+  test('Loading timetable items and verifying paced trains display', async ({
+    pacedTrainSection,
+  }) => {
     await test.step('Verify each imported paced train card and its occurrences', async () => {
       const pacedTrainsData: PacedTrain[] = readJsonFile(
         './tests/assets/paced-train/paced_trains.json'

--- a/front/tests/02-operational-studies/timetable/002-train-timetable-filter.spec.ts
+++ b/front/tests/02-operational-studies/timetable/002-train-timetable-filter.spec.ts
@@ -24,8 +24,7 @@ import {
   VALID_TIMETABLE_ITEMS,
   VALID_PACED_TRAINS,
 } from '../../assets/constants/timetable-items-count';
-import test from '../../logging-fixture';
-import ScenarioTimetableSection from '../../pages/operational-studies/scenario-timetable-section';
+import test from '../../page-object-fixture';
 import { waitForInfraStateToBeCached } from '../../utils';
 import { getInfra, getProject, getScenario, getStudy } from '../../utils/api-utils';
 import readJsonFile from '../../utils/file-utils';
@@ -42,8 +41,6 @@ const frTranslations = {
 };
 
 test.describe('@op @timetable-items @filter', () => {
-  let scenarioTimetableSection: ScenarioTimetableSection;
-
   let project: Project;
   let study: Study;
   let scenario: Scenario;
@@ -59,8 +56,6 @@ test.describe('@op @timetable-items @filter', () => {
   test.beforeEach(
     'Navigate to scenario page and wait for infrastructure to be loaded',
     async ({ page }) => {
-      scenarioTimetableSection = new ScenarioTimetableSection(page);
-
       await page.goto(
         `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenario.id}`
       );
@@ -69,7 +64,7 @@ test.describe('@op @timetable-items @filter', () => {
   );
 
   /** *************** Test 1 **************** */
-  test('Filtering imported timetable items', async () => {
+  test('Filtering imported timetable items', async ({ scenarioTimetableSection }) => {
     await test.step('Verify totals and default filter UI', async () => {
       await scenarioTimetableSection.verifyTotalItemsLabel(frTranslations, {
         totalPacedTrainCount: TOTAL_PACED_TRAINS,

--- a/front/tests/02-operational-studies/timetable/003-train-timetable-multiselection.spec.ts
+++ b/front/tests/02-operational-studies/timetable/003-train-timetable-multiselection.spec.ts
@@ -9,8 +9,7 @@ import {
   TOTAL_PACED_TRAINS,
   TOTAL_TRAIN_SCHEDULES,
 } from '../../assets/constants/timetable-items-count';
-import test from '../../logging-fixture';
-import ScenarioTimetableSection from '../../pages/operational-studies/scenario-timetable-section';
+import test from '../../page-object-fixture';
 import { generateUniqueName, waitForInfraStateToBeCached } from '../../utils';
 import { getInfra, getProject, getStudy } from '../../utils/api-utils';
 import readJsonFile from '../../utils/file-utils';
@@ -33,8 +32,6 @@ const trainSchedulesJson: JSON = readJsonFile('./tests/assets/train-schedule/tra
 const pacedTrainsJson: JSON = readJsonFile('./tests/assets/paced-train/paced_trains.json');
 
 test.describe('@op @timetable-items @timetable-multiselection', () => {
-  let scenarioTimetableSection: ScenarioTimetableSection;
-
   let project: Project;
   let study: Study;
   let scenarioItems: Scenario;
@@ -64,8 +61,6 @@ test.describe('@op @timetable-items @timetable-multiselection', () => {
   });
 
   test.beforeEach('Go to scenario page', async ({ page }) => {
-    scenarioTimetableSection = new ScenarioTimetableSection(page);
-
     await page.goto(
       `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenarioItems.id}`
     );
@@ -73,7 +68,7 @@ test.describe('@op @timetable-items @timetable-multiselection', () => {
   });
 
   /** *************** Test 1 **************** */
-  test('Select and delete all timetable items', async () => {
+  test('Select and delete all timetable items', async ({ scenarioTimetableSection }) => {
     await test.step('Verify initial totals', async () => {
       await scenarioTimetableSection.verifyTotalItemsLabel(frTranslations, {
         totalPacedTrainCount: TOTAL_PACED_TRAINS,

--- a/front/tests/02-operational-studies/timetable/004-train-edition.spec.ts
+++ b/front/tests/02-operational-studies/timetable/004-train-edition.spec.ts
@@ -11,10 +11,7 @@ import {
   timetableItemProjectName,
   timetableItemStudyName,
 } from '../../assets/constants/project-const';
-import test from '../../logging-fixture';
-import OperationalStudiesPage from '../../pages/operational-studies/operational-studies-page';
-import PacedTrainSection from '../../pages/operational-studies/paced-train-section';
-import ScenarioTimetableSection from '../../pages/operational-studies/scenario-timetable-section';
+import test from '../../page-object-fixture';
 import { generateUniqueName, waitForInfraStateToBeCached } from '../../utils';
 import { getInfra, getProject, getStudy } from '../../utils/api-utils';
 import readJsonFile from '../../utils/file-utils';
@@ -52,10 +49,6 @@ const INTERVAL = '20';
 const EDITED_PACED_TRAIN_NAME = 'Paced train edited';
 
 test.describe('@op @paced-train @train-schedule', () => {
-  let scenarioTimetableSection: ScenarioTimetableSection;
-  let operationalStudiesPage: OperationalStudiesPage;
-  let pacedTrainSection: PacedTrainSection;
-
   let project: Project;
   let study: Study;
   let scenarioItems: Scenario;
@@ -70,11 +63,6 @@ test.describe('@op @paced-train @train-schedule', () => {
   test.beforeEach(
     'Setup scenario with one train schedule and one paced train',
     async ({ page }) => {
-      [pacedTrainSection, scenarioTimetableSection, operationalStudiesPage] = [
-        new PacedTrainSection(page),
-        new ScenarioTimetableSection(page),
-        new OperationalStudiesPage(page),
-      ];
       scenarioItems = (
         await createScenario(
           generateUniqueName('edit-train-scenario'),
@@ -104,7 +92,11 @@ test.describe('@op @paced-train @train-schedule', () => {
   });
 
   /** *************** Test 1 **************** */
-  test('Edit a paced train', async () => {
+  test('Edit a paced train', async ({
+    scenarioTimetableSection,
+    operationalStudiesPage,
+    pacedTrainSection,
+  }) => {
     await test.step('Open paced train edition page', async () => {
       await pacedTrainSection.openPacedTrainEditor();
     });
@@ -141,7 +133,11 @@ test.describe('@op @paced-train @train-schedule', () => {
   });
 
   /** *************** Test 2 **************** */
-  test('Turn paced train into train schedule', async () => {
+  test('Turn paced train into train schedule', async ({
+    scenarioTimetableSection,
+    operationalStudiesPage,
+    pacedTrainSection,
+  }) => {
     await test.step('Edit paced train', async () => {
       await pacedTrainSection.openPacedTrainEditor();
     });
@@ -160,7 +156,10 @@ test.describe('@op @paced-train @train-schedule', () => {
   });
 
   /** *************** Test 3 **************** */
-  test('Turn a train schedule into a paced train', async () => {
+  test('Turn a train schedule into a paced train', async ({
+    scenarioTimetableSection,
+    operationalStudiesPage,
+  }) => {
     await test.step('Edit train schedule at index 1', async () => {
       await scenarioTimetableSection.editTimetableItem(1);
     });

--- a/front/tests/02-operational-studies/timetable/005-timetable-import.spec.ts
+++ b/front/tests/02-operational-studies/timetable/005-timetable-import.spec.ts
@@ -9,10 +9,7 @@ import {
   PACED_DETAILS,
   TRAIN_SCHEDULE_DETAILS,
 } from '../../assets/constants/timetable-items-details';
-import test from '../../logging-fixture';
-import ImportPage from '../../pages/import-page';
-import PacedTrainSection from '../../pages/operational-studies/paced-train-section';
-import TimetableItemDetailSection from '../../pages/operational-studies/timetable-items-details-section';
+import test from '../../page-object-fixture';
 import { generateUniqueName, waitForInfraStateToBeCached } from '../../utils';
 import { getInfra, getProject, getStudy } from '../../utils/api-utils';
 import readJsonFile from '../../utils/file-utils';
@@ -31,10 +28,6 @@ const frTranslations = {
 };
 
 test.describe('@op @timetable-items @import', () => {
-  let importPage: ImportPage;
-  let timetableItemDetailSection: TimetableItemDetailSection;
-  let pacedTrainSection: PacedTrainSection;
-
   let project: Project;
   let study: Study;
   let scenario: Scenario;
@@ -47,10 +40,6 @@ test.describe('@op @timetable-items @import', () => {
   });
 
   test.beforeEach('Open scenario ', async ({ page }) => {
-    importPage = new ImportPage(page);
-    timetableItemDetailSection = new TimetableItemDetailSection(page);
-    pacedTrainSection = new PacedTrainSection(page);
-
     await test.step('Create, open scenario and wait for infra to be loaded', async () => {
       scenario = (
         await createScenario(generateUniqueName('import-scenario'), project.id, study.id, infra.id)
@@ -66,7 +55,11 @@ test.describe('@op @timetable-items @import', () => {
     await deleteScenario(study.id, scenario.name);
   });
 
-  test('Verify timetable items are imported correctly', async () => {
+  test('Verify timetable items are imported correctly', async ({
+    importPage,
+    timetableItemDetailSection,
+    pacedTrainSection,
+  }) => {
     await test.step('Verify timetable is empty', async () => {
       await importPage.verifyTimetableIsEmpty(frTranslations.timetable.noTrain);
     });

--- a/front/tests/02-operational-studies/timetable/006-round-trips.spec.ts
+++ b/front/tests/02-operational-studies/timetable/006-round-trips.spec.ts
@@ -19,8 +19,7 @@ import {
   ThirdPacedTrain,
   ThirdTrainSchedule,
 } from '../../assets/operation-studies/round-trips/round-trip-card';
-import test from '../../logging-fixture';
-import RoundTripPage from '../../pages/operational-studies/round-trips-page';
+import test from '../../page-object-fixture';
 import { generateUniqueName, waitForInfraStateToBeCached } from '../../utils';
 import { getInfra, getProject, getStudy } from '../../utils/api-utils';
 import readJsonFile from '../../utils/file-utils';
@@ -39,8 +38,6 @@ const trainSchedulesJson = readJsonFile<TrainSchedule[]>(
 const pacedTrainsJson = readJsonFile<PacedTrain[]>('./tests/assets/paced-train/paced_trains.json');
 
 test.describe('@op @timetable-items @round-trips', () => {
-  let roundTripPage: RoundTripPage;
-
   let project: Project;
   let study: Study;
   let scenarioItems: Scenario;
@@ -52,9 +49,7 @@ test.describe('@op @timetable-items @round-trips', () => {
     infra = await getInfra();
   });
 
-  test.beforeEach('Open scenario & round-trip modal', async ({ page }) => {
-    roundTripPage = new RoundTripPage(page);
-
+  test.beforeEach('Open scenario & round-trip modal', async ({ page, roundTripPage }) => {
     await test.step('Create, open scenario and wait for infra to be loaded', async () => {
       scenarioItems = (
         await createScenario(
@@ -84,7 +79,7 @@ test.describe('@op @timetable-items @round-trips', () => {
   });
 
   /** *************** Test 1 **************** */
-  test('Basic checks round trips', async () => {
+  test('Basic checks round trips', async ({ roundTripPage }) => {
     await test.step('Verify round trips elements are visible', async () => {
       await roundTripPage.verifyRoundTripsModalElements(
         frTranslations.roundTripsModal.todo,
@@ -103,7 +98,7 @@ test.describe('@op @timetable-items @round-trips', () => {
   });
 
   /** *************** Test 2 **************** */
-  test('@smoke Verify round trip cards: paced trains and schedules', async () => {
+  test('@smoke Verify round trip cards: paced trains and schedules', async ({ roundTripPage }) => {
     await test.step('First paced train - data & no tooltip', async () => {
       await roundTripPage.verifyRoundTripCardData({
         roundTripCardIndex: 0,
@@ -154,7 +149,7 @@ test.describe('@op @timetable-items @round-trips', () => {
   });
 
   /** *************** Test 3 **************** */
-  test('Cancel round trip items', async () => {
+  test('Cancel round trip items', async ({ roundTripPage }) => {
     await test.step('Move 1 item from To-do → One-way (not yet saved)', async () => {
       await roundTripPage.setTodoCardToOneWay({
         index: 3,
@@ -179,7 +174,7 @@ test.describe('@op @timetable-items @round-trips', () => {
   });
 
   /** *************** Test 4 **************** */
-  test('@smoke Save round trip items', async () => {
+  test('@smoke Save round trip items', async ({ roundTripPage }) => {
     await test.step('Move 1 item from To-do → One-way', async () => {
       await roundTripPage.setTodoCardToOneWay({
         index: 0,
@@ -204,7 +199,7 @@ test.describe('@op @timetable-items @round-trips', () => {
   });
 
   /** *************** Test 5 **************** */
-  test('Set One-way trip', async () => {
+  test('Set One-way trip', async ({ roundTripPage }) => {
     await test.step('Filter item by name → verify filtered counts', async () => {
       await roundTripPage.searchForRoundTripsCard({
         searchText: 'train19',
@@ -239,7 +234,7 @@ test.describe('@op @timetable-items @round-trips', () => {
   });
 
   /** *************** Test 6 **************** */
-  test('Create and undo Round trips', async () => {
+  test('Create and undo Round trips', async ({ roundTripPage }) => {
     await test.step('Pair first One-way with its return', async () => {
       await roundTripPage.pickReturnForOneWayCard({
         index: 2,

--- a/front/tests/02-operational-studies/timetable/007-scenario-page-synchronization.spec.ts
+++ b/front/tests/02-operational-studies/timetable/007-scenario-page-synchronization.spec.ts
@@ -1,5 +1,3 @@
-import type { Page } from '@playwright/test';
-
 import type {
   Scenario,
   Project,
@@ -13,11 +11,7 @@ import {
   timetableItemProjectName,
   timetableItemStudyName,
 } from '../../assets/constants/project-const';
-import test from '../../logging-fixture';
-import OperationalStudiesPage from '../../pages/operational-studies/operational-studies-page';
-import PacedTrainSection from '../../pages/operational-studies/paced-train-section';
-import ScenarioTimetableSection from '../../pages/operational-studies/scenario-timetable-section';
-import StudyPage from '../../pages/operational-studies/study-page';
+import test from '../../page-object-fixture';
 import { generateUniqueName, waitForInfraStateToBeCached } from '../../utils';
 import { getInfra, getProject, getStudy } from '../../utils/api-utils';
 import readJsonFile from '../../utils/file-utils';
@@ -58,14 +52,6 @@ test.skip(
 );
 
 test.describe('@op @multi-tab-sync', () => {
-  let firstPage: Page;
-  let secondPage: Page;
-  let firstTimetableSection: ScenarioTimetableSection;
-  let secondTimetableSection: ScenarioTimetableSection;
-  let pacedTrainSection: PacedTrainSection;
-  let studyPage: StudyPage;
-  let operationalStudiesPage: OperationalStudiesPage;
-
   let project: Project;
   let study: Study;
   let scenario: Scenario;
@@ -97,35 +83,34 @@ test.describe('@op @multi-tab-sync', () => {
   );
 
   test.afterAll('Close pages', async () => {
-    await firstPage.close();
-    await secondPage.close();
     await deleteScenario(study.id, scenario.name);
   });
 
   /** *************** Test 1 **************** */
-  test('Reflects updates across tabs', async ({ context }) => {
+  test('Reflects updates across tabs', async ({
+    page,
+    secondPage,
+    scenarioTimetableSection,
+    pacedTrainSection,
+    studyPage,
+    secondScenarioTimetableSection,
+    secondOperationalStudiesPage,
+  }) => {
     const scenarioUrl = `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenario.id}`;
 
     await test.step('Open first tab on scenario page and wait infra cache', async () => {
-      firstPage = await context.newPage();
-      await firstPage.goto(scenarioUrl);
-      firstTimetableSection = new ScenarioTimetableSection(firstPage);
-      pacedTrainSection = new PacedTrainSection(firstPage);
-      studyPage = new StudyPage(firstPage);
+      await page.goto(scenarioUrl);
       await waitForInfraStateToBeCached(infra.id);
     });
 
     await test.step('Open second tab on same scenario page', async () => {
-      secondPage = await context.newPage();
       await secondPage.goto(scenarioUrl);
-      secondTimetableSection = new ScenarioTimetableSection(secondPage);
-      operationalStudiesPage = new OperationalStudiesPage(secondPage);
     });
 
     await test.step('Delete a paced train in first tab and verify counts', async () => {
-      await firstPage.bringToFront();
+      await page.bringToFront();
       await pacedTrainSection.deletePacedTrain(1, frTranslations);
-      await firstTimetableSection.verifyTotalItemsLabel(frTranslations, {
+      await scenarioTimetableSection.verifyTotalItemsLabel(frTranslations, {
         totalPacedTrainCount: 1,
         totalTrainScheduleCount: 2,
       });
@@ -133,26 +118,26 @@ test.describe('@op @multi-tab-sync', () => {
 
     await test.step('Verify deletion is reflected in second tab', async () => {
       await secondPage.bringToFront();
-      await secondTimetableSection.verifyTotalItemsLabel(frTranslations, {
+      await secondScenarioTimetableSection.verifyTotalItemsLabel(frTranslations, {
         totalPacedTrainCount: 1,
         totalTrainScheduleCount: 2,
       });
     });
 
     await test.step('Edit a train schedule in second tab and verify the update', async () => {
-      await secondTimetableSection.editTimetableItem(1);
-      await operationalStudiesPage.setFormattedStartTime('2025-03-15T08:35:40');
-      await operationalStudiesPage.submitTimetableItemEdit();
-      await secondTimetableSection.getTimetableItemArrivalTime('08:43', 1);
+      await secondScenarioTimetableSection.editTimetableItem(1);
+      await secondOperationalStudiesPage.setFormattedStartTime('2025-03-15T08:35:40');
+      await secondOperationalStudiesPage.submitTimetableItemEdit();
+      await secondScenarioTimetableSection.getTimetableItemArrivalTime('08:43', 1);
     });
 
     await test.step('Confirm edit is synchronized back in first tab', async () => {
-      await firstPage.bringToFront();
-      await firstTimetableSection.getTimetableItemArrivalTime('08:43', 1);
+      await page.bringToFront();
+      await scenarioTimetableSection.getTimetableItemArrivalTime('08:43', 1);
     });
 
     await test.step('Go to study page in first tab, verify train count, delete scenario', async () => {
-      await firstPage.goto(`/operational-studies/projects/${project.id}/studies/${study.id}`);
+      await page.goto(`/operational-studies/projects/${project.id}/studies/${study.id}`);
       await studyPage.verifyScenarioTrainCount(scenario.name, '3');
       await studyPage.deleteScenario(scenario.name);
     });
@@ -160,7 +145,7 @@ test.describe('@op @multi-tab-sync', () => {
     await test.step('Reload second tab and verify scenario is gone', async () => {
       await secondPage.bringToFront();
       await secondPage.reload();
-      await operationalStudiesPage.expectResourceNotFoundPage();
+      await secondOperationalStudiesPage.expectResourceNotFoundPage();
     });
   });
 });

--- a/front/tests/02-operational-studies/train-creation-tabs/001-op-rolling-stock-tab.spec.ts
+++ b/front/tests/02-operational-studies/train-creation-tabs/001-op-rolling-stock-tab.spec.ts
@@ -12,18 +12,13 @@ import {
   dualModeRollingStockName,
   electricRollingStockName,
 } from '../../assets/constants/project-const';
-import test from '../../logging-fixture';
-import OperationalStudiesPage from '../../pages/operational-studies/operational-studies-page';
-import RollingStockSelector from '../../pages/rolling-stock/rolling-stock-selector';
+import test from '../../page-object-fixture';
 import { waitForInfraStateToBeCached } from '../../utils';
 import { getInfra, getRollingStock } from '../../utils/api-utils';
 import createScenario from '../../utils/scenario';
 import { deleteScenario } from '../../utils/teardown-utils';
 
 test.describe('@op @rs-tab', () => {
-  let operationalStudiesPage: OperationalStudiesPage;
-  let rollingStockSelector: RollingStockSelector;
-
   let project: Project;
   let study: Study;
   let scenario: Scenario;
@@ -40,21 +35,22 @@ test.describe('@op @rs-tab', () => {
     await deleteScenario(study.id, scenario.name);
   });
 
-  test.beforeEach('Navigate to the scenario page and open form', async ({ page }) => {
-    [operationalStudiesPage, rollingStockSelector] = [
-      new OperationalStudiesPage(page),
-      new RollingStockSelector(page),
-    ];
-
-    await page.goto(
-      `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenario.id}`
-    );
-    await waitForInfraStateToBeCached(infra.id);
-    await operationalStudiesPage.openTimetableItemForm();
-  });
+  test.beforeEach(
+    'Navigate to the scenario page and open form',
+    async ({ page, operationalStudiesPage }) => {
+      await page.goto(
+        `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenario.id}`
+      );
+      await waitForInfraStateToBeCached(infra.id);
+      await operationalStudiesPage.openTimetableItemForm();
+    }
+  );
 
   /** *************** Test 1 **************** */
-  test('@smoke Select a rolling stock for operational study', async () => {
+  test('@smoke Select a rolling stock for operational study', async ({
+    operationalStudiesPage,
+    rollingStockSelector,
+  }) => {
     await test.step('Verify tab warnings are present', async () => {
       await operationalStudiesPage.verifyTabWarningPresence();
     });
@@ -84,7 +80,7 @@ test.describe('@op @rs-tab', () => {
   });
 
   /** *************** Test 2 **************** */
-  test('Modify a rolling stock for operational study', async () => {
+  test('Modify a rolling stock for operational study', async ({ rollingStockSelector }) => {
     await test.step('Select electric rolling stock', async () => {
       await rollingStockSelector.openEmptyRollingStockSelector();
       await rollingStockSelector.searchRollingstock(electricRollingStockName);

--- a/front/tests/02-operational-studies/train-creation-tabs/002-op-route-tab.spec.ts
+++ b/front/tests/02-operational-studies/train-creation-tabs/002-op-route-tab.spec.ts
@@ -1,20 +1,13 @@
 import type { Infra, Project, Scenario, Study } from 'common/api/osrdEditoastApi';
 
 import { electricRollingStockName } from '../../assets/constants/project-const';
-import test from '../../logging-fixture';
-import OperationalStudiesPage from '../../pages/operational-studies/operational-studies-page';
-import RouteTab from '../../pages/operational-studies/route-tab';
-import RollingStockSelector from '../../pages/rolling-stock/rolling-stock-selector';
+import test from '../../page-object-fixture';
 import { waitForInfraStateToBeCached } from '../../utils';
 import { getInfra } from '../../utils/api-utils';
 import createScenario from '../../utils/scenario';
 import { deleteScenario } from '../../utils/teardown-utils';
 
 test.describe('@op @route-tab', () => {
-  let operationalStudiesPage: OperationalStudiesPage;
-  let rollingstockSelector: RollingStockSelector;
-  let routeTab: RouteTab;
-
   let project: Project;
   let study: Study;
   let scenario: Scenario;
@@ -29,13 +22,7 @@ test.describe('@op @route-tab', () => {
     await deleteScenario(study.id, scenario.name);
   });
 
-  test.beforeEach(async ({ page }) => {
-    [operationalStudiesPage, rollingstockSelector, routeTab] = [
-      new OperationalStudiesPage(page),
-      new RollingStockSelector(page),
-      new RouteTab(page),
-    ];
-
+  test.beforeEach(async ({ page, operationalStudiesPage, rollingStockSelector }) => {
     await test.step('Open scenario, wait infra cache, open form and verify tab warnings', async () => {
       await page.goto(
         `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenario.id}`
@@ -46,13 +33,17 @@ test.describe('@op @route-tab', () => {
     });
 
     await test.step('Select rolling stock and open the Route tab', async () => {
-      await rollingstockSelector.selectRollingStock(electricRollingStockName);
+      await rollingStockSelector.selectRollingStock(electricRollingStockName);
       await operationalStudiesPage.openRouteTab();
     });
   });
 
   /** *************** Test 1 **************** */
-  test('@smoke Select a route for operational study', async ({ browserName }) => {
+  test('@smoke Select a route for operational study', async ({
+    browserName,
+    routeTab,
+    operationalStudiesPage,
+  }) => {
     await test.step('Verify no route selected initially', async () => {
       await routeTab.verifyNoSelectedRoute();
     });
@@ -78,7 +69,11 @@ test.describe('@op @route-tab', () => {
   });
 
   /** *************** Test 2 **************** */
-  test('Adding waypoints to a route for operational study', async ({ browserName }) => {
+  test('Adding waypoints to a route for operational study', async ({
+    browserName,
+    routeTab,
+    operationalStudiesPage,
+  }) => {
     await test.step('Perform pathfinding by trigrams (WS → NES)', async () => {
       await routeTab.performPathfindingByTrigram({
         originTrigram: 'WS',
@@ -116,7 +111,7 @@ test.describe('@op @route-tab', () => {
   });
 
   /** *************** Test 3 **************** */
-  test('Reversing and deleting waypoints', async ({ browserName }) => {
+  test('Reversing and deleting waypoints', async ({ browserName, routeTab }) => {
     const expectedMapMarkersValues = ['West_station', 'South_East_station', 'Mid_West_station'];
 
     await test.step('Perform pathfinding WS → SES via MWS and verify markers', async () => {

--- a/front/tests/02-operational-studies/train-creation-tabs/003-op-times-and-stops-tab.spec.ts
+++ b/front/tests/02-operational-studies/train-creation-tabs/003-op-times-and-stops-tab.spec.ts
@@ -3,12 +3,7 @@ import { expect } from '@playwright/test';
 import type { Infra, Project, Scenario, Study } from 'common/api/osrdEditoastApi';
 
 import { dualModeRollingStockName } from '../../assets/constants/project-const';
-import test from '../../logging-fixture';
-import OperationalStudiesPage from '../../pages/operational-studies/operational-studies-page';
-import RouteTab from '../../pages/operational-studies/route-tab';
-import TimeAndStopSimulationOutputs from '../../pages/operational-studies/time-stop-simulation-outputs';
-import TimesAndStopsTab from '../../pages/operational-studies/times-and-stops-tab';
-import RollingStockSelector from '../../pages/rolling-stock/rolling-stock-selector';
+import test from '../../page-object-fixture';
 import { waitForInfraStateToBeCached } from '../../utils';
 import { getInfra } from '../../utils/api-utils';
 import { cleanWhitespace, cleanWhitespaceInArray } from '../../utils/data-normalizer';
@@ -43,12 +38,6 @@ const expectedViaValues = [
 ];
 
 test.describe('@op @times-stops-tab', () => {
-  let operationalStudiesPage: OperationalStudiesPage;
-  let rollingStockSelector: RollingStockSelector;
-  let routeTab: RouteTab;
-  let timesAndStopsTab: TimesAndStopsTab;
-  let timeAndStopSimulationOutputs: TimeAndStopSimulationOutputs;
-
   let project: Project;
   let study: Study;
   let scenario: Scenario;
@@ -58,21 +47,7 @@ test.describe('@op @times-stops-tab', () => {
     infra = await getInfra();
   });
 
-  test.beforeEach(async ({ page }) => {
-    [
-      operationalStudiesPage,
-      routeTab,
-      rollingStockSelector,
-      timesAndStopsTab,
-      timeAndStopSimulationOutputs,
-    ] = [
-      new OperationalStudiesPage(page),
-      new RouteTab(page),
-      new RollingStockSelector(page),
-      new TimesAndStopsTab(page),
-      new TimeAndStopSimulationOutputs(page),
-    ];
-
+  test.beforeEach(async ({ page, operationalStudiesPage, rollingStockSelector, routeTab }) => {
     await test.step('Create then navigate to scenario page', async () => {
       ({ project, study, scenario } = await createScenario());
 
@@ -102,7 +77,12 @@ test.describe('@op @times-stops-tab', () => {
   });
 
   /** *************** Test 1 **************** */
-  test('@smoke Set and display times and stops tables', async () => {
+  test('@smoke Set and display times and stops tables', async ({
+    timesAndStopsTab,
+    operationalStudiesPage,
+    routeTab,
+    timeAndStopSimulationOutputs,
+  }) => {
     await test.step('Verify table headers', async () => {
       const expectedColumnNames = cleanWhitespaceInArray([
         frTranslations.name,
@@ -144,7 +124,7 @@ test.describe('@op @times-stops-tab', () => {
       await operationalStudiesPage.openRouteTab();
       for (const [viaIndex, expectedValue] of expectedViaValues.entries()) {
         const droppedWaypoint = routeTab.droppedWaypoints.nth(viaIndex);
-        await RouteTab.validateAddedWaypoint(
+        await routeTab.validateAddedWaypoint(
           droppedWaypoint,
           expectedValue.name,
           expectedValue.ch,
@@ -157,13 +137,17 @@ test.describe('@op @times-stops-tab', () => {
       await operationalStudiesPage.createTimetableItem();
       await operationalStudiesPage.closeToastNotification();
       await operationalStudiesPage.returnSimulationResult();
-      await timeAndStopSimulationOutputs.verifyTimesStopsDataSheetVisibility();
+      await operationalStudiesPage.verifyTimesStopsDataSheetVisibility();
       await timeAndStopSimulationOutputs.getOutputTableData(outputExpectedCellData);
     });
   });
 
   /** *************** Test 2 **************** */
-  test('@smoke Update and clear input table row', async () => {
+  test('@smoke Update and clear input table row', async ({
+    timesAndStopsTab,
+    operationalStudiesPage,
+    routeTab,
+  }) => {
     await test.step('Fill initial inputs and verify table', async () => {
       for (const cell of initialInputsData) {
         const translatedHeader = cleanWhitespace(frTranslations[cell.header]);
@@ -202,7 +186,7 @@ test.describe('@op @times-stops-tab', () => {
       await operationalStudiesPage.openRouteTab();
       for (const [viaIndex, expectedValue] of expectedViaValues.entries()) {
         const droppedWaypoint = routeTab.droppedWaypoints.nth(viaIndex);
-        await RouteTab.validateAddedWaypoint(
+        await routeTab.validateAddedWaypoint(
           droppedWaypoint,
           expectedValue.name,
           expectedValue.ch,

--- a/front/tests/02-operational-studies/train-creation-tabs/004-op-simulation-settings-tab.spec.ts
+++ b/front/tests/02-operational-studies/train-creation-tabs/004-op-simulation-settings-tab.spec.ts
@@ -9,15 +9,7 @@ import type {
 } from 'common/api/osrdEditoastApi';
 
 import { improbableRollingStockName } from '../../assets/constants/project-const';
-import test from '../../logging-fixture';
-import OperationalStudiesPage from '../../pages/operational-studies/operational-studies-page';
-import RouteTab from '../../pages/operational-studies/route-tab';
-import ScenarioTimetableSection from '../../pages/operational-studies/scenario-timetable-section';
-import OpSimulationResultPage from '../../pages/operational-studies/simulation-results-page';
-import SimulationSettingsTab from '../../pages/operational-studies/simulation-settings-tab';
-import TimeAndStopSimulationOutputs from '../../pages/operational-studies/time-stop-simulation-outputs';
-import TimesAndStopsTab from '../../pages/operational-studies/times-and-stops-tab';
-import RollingStockSelector from '../../pages/rolling-stock/rolling-stock-selector';
+import test from '../../page-object-fixture';
 import { waitForInfraStateToBeCached } from '../../utils';
 import { deleteApiRequest, getInfra, setElectricalProfile } from '../../utils/api-utils';
 import { cleanWhitespace } from '../../utils/data-normalizer';
@@ -55,15 +47,6 @@ const expectedCellDataForAllSettings: StationData[] = readJsonFile(
 );
 
 test.describe('@op @simulation-settings-tab', () => {
-  let operationalStudiesPage: OperationalStudiesPage;
-  let rollingStockSelector: RollingStockSelector;
-  let routeTab: RouteTab;
-  let timesAndStopsTab: TimesAndStopsTab;
-  let timeAndStopSimulationOutputs: TimeAndStopSimulationOutputs;
-  let simulationSettingsTab: SimulationSettingsTab;
-  let simulationResultPage: OpSimulationResultPage;
-  let scenarioTimetableSection: ScenarioTimetableSection;
-
   let electricalProfileSet: ElectricalProfileSet;
   let project: Project;
   let study: Study;
@@ -89,27 +72,7 @@ test.describe('@op @simulation-settings-tab', () => {
       await deleteApiRequest(`/api/electrical_profile_set/${electricalProfileSet.id}/`);
   });
 
-  test.beforeEach(async ({ page }) => {
-    [
-      operationalStudiesPage,
-      routeTab,
-      rollingStockSelector,
-      timesAndStopsTab,
-      timeAndStopSimulationOutputs,
-      simulationSettingsTab,
-      simulationResultPage,
-      scenarioTimetableSection,
-    ] = [
-      new OperationalStudiesPage(page),
-      new RouteTab(page),
-      new RollingStockSelector(page),
-      new TimesAndStopsTab(page),
-      new TimeAndStopSimulationOutputs(page),
-      new SimulationSettingsTab(page),
-      new OpSimulationResultPage(page),
-      new ScenarioTimetableSection(page),
-    ];
-
+  test.beforeEach(async ({ page, operationalStudiesPage, rollingStockSelector, routeTab }) => {
     await test.step('Create then navigate to scenario page', async () => {
       ({ project, study, scenario } = await createScenario(
         undefined,
@@ -144,7 +107,15 @@ test.describe('@op @simulation-settings-tab', () => {
   });
 
   /** *************** Test 1 **************** */
-  test('Activate electrical profiles', async ({ browserName }) => {
+  test('Activate electrical profiles', async ({
+    browserName,
+    timesAndStopsTab,
+    operationalStudiesPage,
+    simulationSettingsTab,
+    scenarioTimetableSection,
+    opSimulationResultPage,
+    timeAndStopSimulationOutputs,
+  }) => {
     const cell: CellData = { stationName: 'Mid_East_station', header: 'stopTime', value: '124' };
     const translatedHeader = cleanWhitespace(frTranslations[cell.header]);
 
@@ -167,17 +138,17 @@ test.describe('@op @simulation-settings-tab', () => {
       await operationalStudiesPage.closeToastNotification();
       await operationalStudiesPage.returnSimulationResult();
       await scenarioTimetableSection.getTimetableItemArrivalTime('11:48');
-      await simulationResultPage.setTrainListVisible();
+      await opSimulationResultPage.setTrainListVisible();
 
-      await timeAndStopSimulationOutputs.verifyTimesStopsDataSheetVisibility();
-      await simulationResultPage.selectAllSpeedSpaceChartCheckboxes();
+      await operationalStudiesPage.verifyTimesStopsDataSheetVisibility();
+      await opSimulationResultPage.selectAllSpeedSpaceChartCheckboxes();
       if (browserName === 'chromium') {
-        await expect(simulationResultPage.speedSpaceChart).toHaveScreenshot(
+        await expect(opSimulationResultPage.speedSpaceChart).toHaveScreenshot(
           'SpeedSpaceChart-ElectricalProfileActivated.png'
         );
       }
       await timeAndStopSimulationOutputs.getOutputTableData(expectedCellDataElectricalProfileON);
-      await simulationResultPage.setTrainListVisible(false);
+      await opSimulationResultPage.setTrainListVisible(false);
     });
 
     await test.step('Deactivate electrical profiles and verify (OFF)', async () => {
@@ -185,23 +156,31 @@ test.describe('@op @simulation-settings-tab', () => {
       await operationalStudiesPage.openSimulationSettingsTab();
       await simulationSettingsTab.deactivateElectricalProfile();
       await operationalStudiesPage.submitTimetableItemEdit();
-      await simulationResultPage.setTrainListVisible();
+      await opSimulationResultPage.setTrainListVisible();
 
-      await timeAndStopSimulationOutputs.verifyTimesStopsDataSheetVisibility();
-      await simulationResultPage.selectAllSpeedSpaceChartCheckboxes();
+      await operationalStudiesPage.verifyTimesStopsDataSheetVisibility();
+      await opSimulationResultPage.selectAllSpeedSpaceChartCheckboxes();
       if (browserName === 'chromium') {
-        await expect(simulationResultPage.speedSpaceChart).toHaveScreenshot(
+        await expect(opSimulationResultPage.speedSpaceChart).toHaveScreenshot(
           'SpeedSpaceChart-ElectricalProfileDisabled.png'
         );
       }
       await timeAndStopSimulationOutputs.getOutputTableData(expectedCellDataElectricalProfileOFF);
-      await simulationResultPage.setTrainListVisible(false);
+      await opSimulationResultPage.setTrainListVisible(false);
       await scenarioTimetableSection.getTimetableItemArrivalTime('11:48');
     });
   });
 
   /** *************** Test 2 **************** */
-  test('Add speed limit tag', async ({ browserName }) => {
+  test('Add speed limit tag', async ({
+    browserName,
+    timesAndStopsTab,
+    operationalStudiesPage,
+    simulationSettingsTab,
+    scenarioTimetableSection,
+    opSimulationResultPage,
+    timeAndStopSimulationOutputs,
+  }) => {
     const cell: CellData = { stationName: 'Mid_East_station', header: 'stopTime', value: '124' };
     const translatedHeader = cleanWhitespace(frTranslations[cell.header]);
 
@@ -225,17 +204,17 @@ test.describe('@op @simulation-settings-tab', () => {
       await operationalStudiesPage.closeToastNotification();
       await operationalStudiesPage.returnSimulationResult();
       await scenarioTimetableSection.getTimetableItemArrivalTime('11:49');
-      await simulationResultPage.setTrainListVisible();
+      await opSimulationResultPage.setTrainListVisible();
 
-      await timeAndStopSimulationOutputs.verifyTimesStopsDataSheetVisibility();
-      await simulationResultPage.selectAllSpeedSpaceChartCheckboxes();
+      await operationalStudiesPage.verifyTimesStopsDataSheetVisibility();
+      await opSimulationResultPage.selectAllSpeedSpaceChartCheckboxes();
       if (browserName === 'chromium') {
-        await expect(simulationResultPage.speedSpaceChart).toHaveScreenshot(
+        await expect(opSimulationResultPage.speedSpaceChart).toHaveScreenshot(
           'SpeedSpaceChart-SpeedLimitTagActivated.png'
         );
       }
       await timeAndStopSimulationOutputs.getOutputTableData(expectedCellDataCodeCompoON);
-      await simulationResultPage.setTrainListVisible(false);
+      await opSimulationResultPage.setTrainListVisible(false);
     });
 
     await test.step('Remove speed limit tag and verify (speed limit tag OFF)', async () => {
@@ -243,23 +222,31 @@ test.describe('@op @simulation-settings-tab', () => {
       await operationalStudiesPage.openSimulationSettingsTab();
       await simulationSettingsTab.selectSpeedLimitTagOption('__PLACEHOLDER__');
       await operationalStudiesPage.submitTimetableItemEdit();
-      await simulationResultPage.setTrainListVisible();
+      await opSimulationResultPage.setTrainListVisible();
 
-      await timeAndStopSimulationOutputs.verifyTimesStopsDataSheetVisibility();
-      await simulationResultPage.selectAllSpeedSpaceChartCheckboxes();
+      await operationalStudiesPage.verifyTimesStopsDataSheetVisibility();
+      await opSimulationResultPage.selectAllSpeedSpaceChartCheckboxes();
       if (browserName === 'chromium') {
-        await expect(simulationResultPage.speedSpaceChart).toHaveScreenshot(
+        await expect(opSimulationResultPage.speedSpaceChart).toHaveScreenshot(
           'SpeedSpaceChart-SpeedLimitTagDisabled.png'
         );
       }
       await timeAndStopSimulationOutputs.getOutputTableData(expectedCellDataCodeCompoOFF);
-      await simulationResultPage.setTrainListVisible(false);
+      await opSimulationResultPage.setTrainListVisible(false);
       await scenarioTimetableSection.getTimetableItemArrivalTime('11:48');
     });
   });
 
   /** *************** Test 3 **************** */
-  test('Activate linear and mareco margin', async ({ browserName }) => {
+  test('Activate linear and mareco margin', async ({
+    browserName,
+    timesAndStopsTab,
+    operationalStudiesPage,
+    simulationSettingsTab,
+    scenarioTimetableSection,
+    opSimulationResultPage,
+    timeAndStopSimulationOutputs,
+  }) => {
     const inputTableData: CellData[] = [
       { stationName: 'Mid_East_station', header: 'stopTime', value: '124' },
       {
@@ -293,17 +280,17 @@ test.describe('@op @simulation-settings-tab', () => {
       await operationalStudiesPage.closeToastNotification();
       await operationalStudiesPage.returnSimulationResult();
       await scenarioTimetableSection.getTimetableItemArrivalTime('11:51');
-      await simulationResultPage.setTrainListVisible();
+      await opSimulationResultPage.setTrainListVisible();
 
-      await timeAndStopSimulationOutputs.verifyTimesStopsDataSheetVisibility();
-      await simulationResultPage.selectAllSpeedSpaceChartCheckboxes();
+      await operationalStudiesPage.verifyTimesStopsDataSheetVisibility();
+      await opSimulationResultPage.selectAllSpeedSpaceChartCheckboxes();
       if (browserName === 'chromium') {
-        await expect(simulationResultPage.speedSpaceChart).toHaveScreenshot(
+        await expect(opSimulationResultPage.speedSpaceChart).toHaveScreenshot(
           'SpeedSpaceChart-LinearMargin.png'
         );
       }
       await timeAndStopSimulationOutputs.getOutputTableData(expectedCellDataLinearMargin);
-      await simulationResultPage.setTrainListVisible(false);
+      await opSimulationResultPage.setTrainListVisible(false);
     });
 
     await test.step('Edit to Mareco margin and verify', async () => {
@@ -311,23 +298,31 @@ test.describe('@op @simulation-settings-tab', () => {
       await operationalStudiesPage.openSimulationSettingsTab();
       await simulationSettingsTab.activateMarecoMargin();
       await operationalStudiesPage.submitTimetableItemEdit();
-      await simulationResultPage.setTrainListVisible();
+      await opSimulationResultPage.setTrainListVisible();
 
-      await timeAndStopSimulationOutputs.verifyTimesStopsDataSheetVisibility();
-      await simulationResultPage.selectAllSpeedSpaceChartCheckboxes();
+      await operationalStudiesPage.verifyTimesStopsDataSheetVisibility();
+      await opSimulationResultPage.selectAllSpeedSpaceChartCheckboxes();
       if (browserName === 'chromium') {
-        await expect(simulationResultPage.speedSpaceChart).toHaveScreenshot(
+        await expect(opSimulationResultPage.speedSpaceChart).toHaveScreenshot(
           'SpeedSpaceChart-MarecoMargin.png'
         );
       }
       await timeAndStopSimulationOutputs.getOutputTableData(expectedCellDataMarecoMargin);
-      await simulationResultPage.setTrainListVisible(false);
+      await opSimulationResultPage.setTrainListVisible(false);
       await scenarioTimetableSection.getTimetableItemArrivalTime('11:51');
     });
   });
 
   /** *************** Test 4 **************** */
-  test('@smoke Add all the simulation settings', async ({ browserName }) => {
+  test('@smoke Add all the simulation settings', async ({
+    browserName,
+    timesAndStopsTab,
+    operationalStudiesPage,
+    simulationSettingsTab,
+    scenarioTimetableSection,
+    opSimulationResultPage,
+    timeAndStopSimulationOutputs,
+  }) => {
     const inputTableData: CellData[] = [
       { stationName: 'Mid_East_station', header: 'stopTime', value: '124' },
       {
@@ -361,17 +356,17 @@ test.describe('@op @simulation-settings-tab', () => {
       await operationalStudiesPage.createTimetableItem();
       await operationalStudiesPage.closeToastNotification();
       await operationalStudiesPage.returnSimulationResult();
-      await simulationResultPage.setTrainListVisible();
+      await opSimulationResultPage.setTrainListVisible();
 
-      await timeAndStopSimulationOutputs.verifyTimesStopsDataSheetVisibility();
-      await simulationResultPage.selectAllSpeedSpaceChartCheckboxes();
+      await operationalStudiesPage.verifyTimesStopsDataSheetVisibility();
+      await opSimulationResultPage.selectAllSpeedSpaceChartCheckboxes();
       if (browserName === 'chromium') {
-        await expect(simulationResultPage.speedSpaceChart).toHaveScreenshot(
+        await expect(opSimulationResultPage.speedSpaceChart).toHaveScreenshot(
           'SpeedSpaceChart-AllSettingsEnabled.png'
         );
       }
       await timeAndStopSimulationOutputs.getOutputTableData(expectedCellDataForAllSettings);
-      await simulationResultPage.setTrainListVisible(false);
+      await opSimulationResultPage.setTrainListVisible(false);
       await scenarioTimetableSection.getTimetableItemArrivalTime('11:50');
     });
   });

--- a/front/tests/03-stdcm/001-stdcm.spec.ts
+++ b/front/tests/03-stdcm/001-stdcm.spec.ts
@@ -5,14 +5,7 @@ import {
   fastRollingStockName,
 } from './../assets/constants/project-const';
 import { CONFLICT_ARRIVAL_TIME } from './../assets/constants/stdcm-const';
-import test from './../logging-fixture';
-import ConsistSection from './../pages/stdcm/consist-section';
-import DestinationSection from './../pages/stdcm/destination-section';
-import LinkedTrainSection from './../pages/stdcm/linked-train-section';
-import OriginSection from './../pages/stdcm/origin-section';
-import SimulationResultPage from './../pages/stdcm/simulation-results-page';
-import STDCMPage from './../pages/stdcm/stdcm-page';
-import ViaSection from './../pages/stdcm/via-section';
+import test from './../page-object-fixture';
 import { waitForInfraStateToBeCached } from './../utils';
 import { getInfra, setTowedRollingStock } from './../utils/api-utils';
 import type { ConsistFields } from './../utils/types';
@@ -28,14 +21,6 @@ const fastRollingStockPrefilledValues = { tonnage: '190', length: '46' };
 const towedRollingStockPrefilledValues = { tonnage: '46', length: '26' };
 
 test.describe('@stdcm', () => {
-  let stdcmPage: STDCMPage;
-  let consistSection: ConsistSection;
-  let originSection: OriginSection;
-  let viaSection: ViaSection;
-  let destinationSection: DestinationSection;
-  let linkedTrainSection: LinkedTrainSection;
-  let simulationResultPage: SimulationResultPage;
-
   let infra: Infra;
   let createdTowedRollingStock: TowedRollingStock;
 
@@ -45,30 +30,19 @@ test.describe('@stdcm', () => {
   });
 
   test.beforeEach('Navigate to the STDCM page', async ({ page }) => {
-    [
-      stdcmPage,
-      consistSection,
-      originSection,
-      viaSection,
-      destinationSection,
-      simulationResultPage,
-      linkedTrainSection,
-    ] = [
-      new STDCMPage(page),
-      new ConsistSection(page),
-      new OriginSection(page),
-      new ViaSection(page),
-      new DestinationSection(page),
-      new SimulationResultPage(page),
-      new LinkedTrainSection(page),
-    ];
-
     await page.goto('/stdcm');
     await waitForInfraStateToBeCached(infra.id);
   });
 
   /** *************** Test 1 **************** */
-  test('@smoke Verify default STDCM page', async () => {
+  test('@smoke Verify default STDCM page', async ({
+    stdcmPage,
+    consistSection,
+    originSection,
+    viaSection,
+    destinationSection,
+    linkedTrainSection,
+  }) => {
     await test.step('Verify base UI sections are visible', async () => {
       await stdcmPage.verifyStdcmElementsVisibility();
     });
@@ -86,7 +60,14 @@ test.describe('@stdcm', () => {
   });
 
   /** *************** Test 2 **************** */
-  test('@smoke Launch STDCM simulation with all stops', async () => {
+  test('@smoke Launch STDCM simulation with all stops', async ({
+    consistSection,
+    originSection,
+    destinationSection,
+    viaSection,
+    stdcmPage,
+    stdcmSimulationResultPage,
+  }) => {
     await test.step('Fill consist, origin and destination', async () => {
       await consistSection.fillAndVerifyConsistDetails(
         consistDetails,
@@ -110,17 +91,24 @@ test.describe('@stdcm', () => {
 
     await test.step('Launch simulation and verify results table', async () => {
       await stdcmPage.verifyValidSimulationLaunch();
-      await simulationResultPage.verifySimulationDetails({
+      await stdcmSimulationResultPage.verifySimulationDetails({
         simulationIndex: 0,
         simulationLengthAndDuration: '51 km — 1h 17min',
         validSimulationNumber: 1,
       });
-      await simulationResultPage.verifyTableData('./tests/assets/stdcm/stdcm-all-stops.json');
+      await stdcmSimulationResultPage.verifyTableData('./tests/assets/stdcm/stdcm-all-stops.json');
     });
   });
 
   /** *************** Test 3 **************** */
-  test('Launch simulation with and without capacity for towed rolling stock', async () => {
+  test('Launch simulation with and without capacity for towed rolling stock', async ({
+    consistSection,
+    originSection,
+    destinationSection,
+    viaSection,
+    stdcmPage,
+    stdcmSimulationResultPage,
+  }) => {
     const towedConsistDetails: ConsistFields = {
       tractionEngine: fastRollingStockName,
       towedRollingStock: createdTowedRollingStock.name,
@@ -144,22 +132,22 @@ test.describe('@stdcm', () => {
     });
 
     await test.step('Initial simulation result is "No capacity"', async () => {
-      await simulationResultPage.verifySimulationDetails({ simulationIndex: 0 });
+      await stdcmSimulationResultPage.verifySimulationDetails({ simulationIndex: 0 });
     });
 
     await test.step('First alternative simulation is VALID (51 km — 2h 35min) and verify details', async () => {
-      await simulationResultPage.verifySimulationDetails({
+      await stdcmSimulationResultPage.verifySimulationDetails({
         simulationIndex: 1,
         simulationLengthAndDuration: '51 km — 2h 35min',
         validSimulationNumber: 1,
       });
-      await simulationResultPage.verifyTableData(
+      await stdcmSimulationResultPage.verifyTableData(
         './tests/assets/stdcm/towed-rolling-stock/towed-rolling-stock-table-result.json'
       );
     });
 
     await test.step('Second alternative simulation result is "No capacity"', async () => {
-      await simulationResultPage.verifySimulationDetails({ simulationIndex: 2 });
+      await stdcmSimulationResultPage.verifySimulationDetails({ simulationIndex: 2 });
     });
   });
 });

--- a/front/tests/03-stdcm/002-stdcm-simulation-sheet.spec.ts
+++ b/front/tests/03-stdcm/002-stdcm-simulation-sheet.spec.ts
@@ -4,13 +4,10 @@ import type { Infra } from 'common/api/osrdEditoastApi';
 
 import { electricRollingStockName } from './../assets/constants/project-const';
 import simulationSheetDetails from './../assets/constants/simulation-sheet-const';
-import test from './../logging-fixture';
+import test from './../page-object-fixture';
 import ConsistSection from './../pages/stdcm/consist-section';
 import DestinationSection from './../pages/stdcm/destination-section';
 import OriginSection from './../pages/stdcm/origin-section';
-import SimulationResultPage from './../pages/stdcm/simulation-results-page';
-import STDCMPage from './../pages/stdcm/stdcm-page';
-import ViaSection from './../pages/stdcm/via-section';
 import { waitForInfraStateToBeCached } from './../utils';
 import { getInfra } from './../utils/api-utils';
 import { findFirstPdf, parsePdfText, verifySimulationContent } from './../utils/pdf-parser';
@@ -32,13 +29,6 @@ const tractionEnginePrefilledValues = {
 test.describe('@stdcm @stdcm-sheet', () => {
   test.describe.configure({ mode: 'serial' });
 
-  let stdcmPage: STDCMPage;
-  let consistSection: ConsistSection;
-  let originSection: OriginSection;
-  let viaSection: ViaSection;
-  let destinationSection: DestinationSection;
-  let simulationResultPage: SimulationResultPage;
-
   let infra: Infra;
   let downloadDir: string | undefined;
 
@@ -47,22 +37,6 @@ test.describe('@stdcm @stdcm-sheet', () => {
   });
 
   test.beforeEach('Navigate to the STDCM page', async ({ page }) => {
-    [
-      stdcmPage,
-      consistSection,
-      originSection,
-      viaSection,
-      destinationSection,
-      simulationResultPage,
-    ] = [
-      new STDCMPage(page),
-      new ConsistSection(page),
-      new OriginSection(page),
-      new ViaSection(page),
-      new DestinationSection(page),
-      new SimulationResultPage(page),
-    ];
-
     await page.goto('/stdcm');
     await waitForInfraStateToBeCached(infra.id);
   });
@@ -71,6 +45,12 @@ test.describe('@stdcm @stdcm-sheet', () => {
   test('@smoke Verify STDCM stops and simulation sheet', async ({
     browserName,
     context,
+    consistSection,
+    originSection,
+    destinationSection,
+    viaSection,
+    stdcmPage,
+    stdcmSimulationResultPage,
   }, testInfo) => {
     await test.step('Fill consist, origin, destination and via', async () => {
       await consistSection.fillAndVerifyConsistDetails(
@@ -96,23 +76,27 @@ test.describe('@stdcm @stdcm-sheet', () => {
 
     await test.step('Verify result map markers and tables', async () => {
       if (browserName === 'chromium') {
-        await simulationResultPage.mapMarkerResultVisibility();
+        await stdcmSimulationResultPage.mapMarkerResultVisibility();
       }
-      await simulationResultPage.verifyTableData('./tests/assets/stdcm/stdcm-without-all-via.json');
-      await simulationResultPage.displayAllOperationalPoints();
-      await simulationResultPage.verifyTableData('./tests/assets/stdcm/stdcm-with-all-via.json');
+      await stdcmSimulationResultPage.verifyTableData(
+        './tests/assets/stdcm/stdcm-without-all-via.json'
+      );
+      await stdcmSimulationResultPage.displayAllOperationalPoints();
+      await stdcmSimulationResultPage.verifyTableData(
+        './tests/assets/stdcm/stdcm-with-all-via.json'
+      );
     });
 
     await test.step('Retain & download simulation PDF', async () => {
-      await simulationResultPage.retainSimulation();
+      await stdcmSimulationResultPage.retainSimulation();
       downloadDir = testInfo.outputDir;
-      await simulationResultPage.downloadSimulation(downloadDir);
+      await stdcmSimulationResultPage.downloadSimulation(downloadDir);
     });
 
     await test.step('Start a new query and verify fields are reset', async () => {
       const [newPage] = await Promise.all([
         context.waitForEvent('page'),
-        simulationResultPage.startNewQuery(),
+        stdcmSimulationResultPage.startNewQuery(),
       ]);
       await newPage.waitForLoadState();
 

--- a/front/tests/03-stdcm/003-stdcm-linked-train.spec.ts
+++ b/front/tests/03-stdcm/003-stdcm-linked-train.spec.ts
@@ -1,14 +1,7 @@
 import type { Infra, TowedRollingStock } from 'common/api/osrdEditoastApi';
 
 import { fastRollingStockName } from './../assets/constants/project-const';
-import test from './../logging-fixture';
-import ConsistSection from './../pages/stdcm/consist-section';
-import DestinationSection from './../pages/stdcm/destination-section';
-import LinkedTrainSection from './../pages/stdcm/linked-train-section';
-import OriginSection from './../pages/stdcm/origin-section';
-import SimulationResultPage from './../pages/stdcm/simulation-results-page';
-import STDCMPage from './../pages/stdcm/stdcm-page';
-import ViaSection from './../pages/stdcm/via-section';
+import test from './../page-object-fixture';
 import { waitForInfraStateToBeCached } from './../utils';
 import { getInfra, setTowedRollingStock } from './../utils/api-utils';
 import type { ConsistFields } from './../utils/types';
@@ -25,14 +18,6 @@ const towedRollingStockPrefilledValues = {
 };
 
 test.describe('@stdcm @stdcm-linked-train', () => {
-  let stdcmPage: STDCMPage;
-  let consistSection: ConsistSection;
-  let originSection: OriginSection;
-  let viaSection: ViaSection;
-  let destinationSection: DestinationSection;
-  let simulationResultPage: SimulationResultPage;
-  let linkedTrainSection: LinkedTrainSection;
-
   let infra: Infra;
   let createdTowedRollingStock: TowedRollingStock;
   let towedConsistDetails: ConsistFields;
@@ -47,30 +32,19 @@ test.describe('@stdcm @stdcm-linked-train', () => {
   });
 
   test.beforeEach('Navigate to the STDCM page', async ({ page }) => {
-    [
-      stdcmPage,
-      consistSection,
-      originSection,
-      viaSection,
-      destinationSection,
-      simulationResultPage,
-      linkedTrainSection,
-    ] = [
-      new STDCMPage(page),
-      new ConsistSection(page),
-      new OriginSection(page),
-      new ViaSection(page),
-      new DestinationSection(page),
-      new SimulationResultPage(page),
-      new LinkedTrainSection(page),
-    ];
-
     await page.goto('/stdcm');
     await waitForInfraStateToBeCached(infra.id);
   });
 
   /** *************** Test 1 **************** */
-  test('Verify STDCM anterior linked train', async ({ page: _ }, testInfo) => {
+  test('Verify STDCM anterior linked train', async ({
+    consistSection,
+    linkedTrainSection,
+    destinationSection,
+    viaSection,
+    stdcmPage,
+    stdcmSimulationResultPage,
+  }, testInfo) => {
     await test.step('Fill consist with traction engine details + towed RS and verify prefilled values', async () => {
       await consistSection.fillAndVerifyConsistDetails(
         towedConsistDetails,
@@ -90,19 +64,26 @@ test.describe('@stdcm @stdcm-linked-train', () => {
 
     await test.step('Launch simulation and verify outputs', async () => {
       await stdcmPage.verifyValidSimulationLaunch();
-      await simulationResultPage.verifyTableData(
+      await stdcmSimulationResultPage.verifyTableData(
         './tests/assets/stdcm/linked-train/anterior-linked-train-table.json'
       );
     });
 
     await test.step('Retain + download simulation PDF', async () => {
-      await simulationResultPage.retainSimulation();
-      await simulationResultPage.downloadSimulation(testInfo.outputDir);
+      await stdcmSimulationResultPage.retainSimulation();
+      await stdcmSimulationResultPage.downloadSimulation(testInfo.outputDir);
     });
   });
 
   /** *************** Test 2 **************** */
-  test('Verify STDCM posterior linked train', async ({ page: _ }, testInfo) => {
+  test('Verify STDCM posterior linked train', async ({
+    originSection,
+    consistSection,
+    linkedTrainSection,
+    viaSection,
+    stdcmPage,
+    stdcmSimulationResultPage,
+  }, testInfo) => {
     await test.step('Fill origin with posterior constraints and linked path', async () => {
       await originSection.fillOriginDetailsLight(undefined, 'respectDestinationSchedule', true);
       await linkedTrainSection.posteriorLinkedPathDetails();
@@ -121,14 +102,14 @@ test.describe('@stdcm @stdcm-linked-train', () => {
 
     await test.step('Launch simulation and verify outputs', async () => {
       await stdcmPage.verifyValidSimulationLaunch();
-      await simulationResultPage.verifyTableData(
+      await stdcmSimulationResultPage.verifyTableData(
         './tests/assets/stdcm/linked-train/posterior-linked-train-table.json'
       );
     });
 
     await test.step('Retain + download simulation PDF', async () => {
-      await simulationResultPage.retainSimulation();
-      await simulationResultPage.downloadSimulation(testInfo.outputDir);
+      await stdcmSimulationResultPage.retainSimulation();
+      await stdcmSimulationResultPage.downloadSimulation(testInfo.outputDir);
     });
   });
 });

--- a/front/tests/03-stdcm/004-stdcm-missing-fields.spec.ts
+++ b/front/tests/03-stdcm/004-stdcm-missing-fields.spec.ts
@@ -7,12 +7,7 @@ import {
   REMOVED_MISSING_FIELDS_KEYS,
 } from './../assets/constants/missing-fields';
 import { electricRollingStockName } from './../assets/constants/project-const';
-import test from './../logging-fixture';
-import ConsistSection from './../pages/stdcm/consist-section';
-import DestinationSection from './../pages/stdcm/destination-section';
-import OriginSection from './../pages/stdcm/origin-section';
-import SimulationResultPage from './../pages/stdcm/simulation-results-page';
-import STDCMPage from './../pages/stdcm/stdcm-page';
+import test from './../page-object-fixture';
 import { waitForInfraStateToBeCached } from './../utils';
 import { getInfra } from './../utils/api-utils';
 import readJsonFile from './../utils/file-utils';
@@ -21,11 +16,6 @@ import type { StdcmTranslations } from './../utils/types';
 const frTranslations: StdcmTranslations = readJsonFile('public/locales/fr/stdcm.json');
 
 test.describe('@stdcm @stdcm-missing-fields', () => {
-  let stdcmPage: STDCMPage;
-  let consistSection: ConsistSection;
-  let originSection: OriginSection;
-  let destinationSection: DestinationSection;
-  let simulationResultPage: SimulationResultPage;
   let infra: Infra;
 
   test.beforeAll('Fetch infrastructure', async () => {
@@ -33,20 +23,18 @@ test.describe('@stdcm @stdcm-missing-fields', () => {
   });
 
   test.beforeEach('Navigate to the STDCM page', async ({ page }) => {
-    [stdcmPage, consistSection, originSection, destinationSection, simulationResultPage] = [
-      new STDCMPage(page),
-      new ConsistSection(page),
-      new OriginSection(page),
-      new DestinationSection(page),
-      new SimulationResultPage(page),
-    ];
-
     await page.goto('/stdcm');
     await waitForInfraStateToBeCached(infra.id);
   });
 
   /** *************** Test 1 **************** */
-  test('Verify missing fields warnings when launching simulation', async () => {
+  test('Verify missing fields warnings when launching simulation', async ({
+    stdcmPage,
+    consistSection,
+    originSection,
+    destinationSection,
+    stdcmSimulationResultPage,
+  }) => {
     await test.step('Launch simulation with all fields empty → expect all missing field warnings', async () => {
       const allMissingLabels = getFieldsLabel(ALL_MISSING_FIELDS_KEY, frTranslations);
       await stdcmPage.verifyInvalidSimulationLaunch();
@@ -72,7 +60,7 @@ test.describe('@stdcm @stdcm-missing-fields', () => {
       );
       await stdcmPage.verifyValidSimulationLaunch();
       await stdcmPage.expectWarningBoxHidden();
-      await simulationResultPage.verifySimulationDetails({
+      await stdcmSimulationResultPage.verifySimulationDetails({
         simulationIndex: 0,
         simulationLengthAndDuration: '51 km — 33min',
         validSimulationNumber: 1,
@@ -112,7 +100,7 @@ test.describe('@stdcm @stdcm-missing-fields', () => {
 
       await stdcmPage.verifyValidSimulationLaunch();
       await stdcmPage.expectWarningBoxHidden();
-      await simulationResultPage.verifySimulationDetails({
+      await stdcmSimulationResultPage.verifySimulationDetails({
         simulationIndex: 1,
         simulationLengthAndDuration: '51 km — 22min',
         validSimulationNumber: 2,

--- a/front/tests/03-stdcm/005-stdcm-feedback-mail.spec.ts
+++ b/front/tests/03-stdcm/005-stdcm-feedback-mail.spec.ts
@@ -1,14 +1,8 @@
-import { test } from '@playwright/test';
-
 import type { Infra } from 'common/api/osrdEditoastApi';
 
 import getMailFeedbackData from './../assets/constants/mail-feedback-const';
 import { electricRollingStockName } from './../assets/constants/project-const';
-import ConsistSection from './../pages/stdcm/consist-section';
-import DestinationSection from './../pages/stdcm/destination-section';
-import OriginSection from './../pages/stdcm/origin-section';
-import SimulationResultPage from './../pages/stdcm/simulation-results-page';
-import STDCMPage from './../pages/stdcm/stdcm-page';
+import test from './../page-object-fixture';
 import { waitForInfraStateToBeCached } from './../utils';
 import { getInfra } from './../utils/api-utils';
 import type { ConsistFields } from './../utils/types';
@@ -28,11 +22,6 @@ const tractionEnginePrefilledValues = {
 };
 
 test.describe('@stdcm @stdcm-feedback', () => {
-  let stdcmPage: STDCMPage;
-  let consistSection: ConsistSection;
-  let originSection: OriginSection;
-  let destinationSection: DestinationSection;
-  let simulationResultPage: SimulationResultPage;
   let infra: Infra;
 
   test.beforeAll('Fetch infrastructure', async () => {
@@ -40,19 +29,18 @@ test.describe('@stdcm @stdcm-feedback', () => {
   });
 
   test.beforeEach('Navigate to the STDCM page', async ({ page }) => {
-    [stdcmPage, consistSection, originSection, destinationSection, simulationResultPage] = [
-      new STDCMPage(page),
-      new ConsistSection(page),
-      new OriginSection(page),
-      new DestinationSection(page),
-      new SimulationResultPage(page),
-    ];
     await page.goto('/stdcm');
     await waitForInfraStateToBeCached(infra.id);
   });
 
   /** *************** Test 1 **************** */
-  test('Verify feedback card visibility and mail redirection', async () => {
+  test('Verify feedback card visibility and mail redirection', async ({
+    stdcmPage,
+    consistSection,
+    originSection,
+    destinationSection,
+    stdcmSimulationResultPage,
+  }) => {
     await test.step('Fill consist with traction engine details and verify prefilled values', async () => {
       await consistSection.fillAndVerifyConsistDetails(
         consistDetails,
@@ -69,7 +57,7 @@ test.describe('@stdcm @stdcm-feedback', () => {
 
     await test.step('Launch simulation and verify simulation details', async () => {
       await stdcmPage.verifyValidSimulationLaunch();
-      await simulationResultPage.verifySimulationDetails({
+      await stdcmSimulationResultPage.verifySimulationDetails({
         simulationIndex: 0,
         simulationLengthAndDuration: '51 km — 33min',
         validSimulationNumber: 1,
@@ -77,12 +65,16 @@ test.describe('@stdcm @stdcm-feedback', () => {
     });
 
     await test.step('Verify feedback card is visible', async () => {
-      await simulationResultPage.verifyFeedbackCardVisibility();
+      await stdcmSimulationResultPage.verifyFeedbackCardVisibility();
     });
 
     await test.step('Verify mail redirection from feedback card', async () => {
       const { expectedSubject, expectedBody, expectedMail } = getMailFeedbackData();
-      await simulationResultPage.verifyMailRedirection(expectedSubject, expectedBody, expectedMail);
+      await stdcmSimulationResultPage.verifyMailRedirection(
+        expectedSubject,
+        expectedBody,
+        expectedMail
+      );
     });
   });
 });

--- a/front/tests/04-rolling-stock-editor/001-rolling-stock-editor.spec.ts
+++ b/front/tests/04-rolling-stock-editor/001-rolling-stock-editor.spec.ts
@@ -1,8 +1,7 @@
 import { expect } from '@playwright/test';
 
 import { electricRollingStockName } from './../assets/constants/project-const';
-import test from './../logging-fixture';
-import RollingstockEditorPage from './../pages/rolling-stock/rolling-stock-editor-page';
+import test from './../page-object-fixture';
 import readJsonFile from './../utils/file-utils';
 import {
   generateUniqueName,
@@ -17,17 +16,13 @@ const rollingstockDetails: RollingStockDetails = readJsonFile(
 );
 
 test.describe('@rs-editor', () => {
-  let rollingStockEditorPage: RollingstockEditorPage;
-
   const createdRollingStocks: string[] = [];
 
   let uniqueRollingStockName: string;
   let uniqueUpdatedRollingStockName: string;
   let uniqueDeletedRollingStockName: string;
 
-  test.beforeEach(async ({ page }) => {
-    rollingStockEditorPage = new RollingstockEditorPage(page);
-
+  test.beforeEach(async ({ rollingStockEditorPage }) => {
     await test.step('Generate unique names and cleanup any leftovers', async () => {
       uniqueRollingStockName = generateUniqueName('RSN');
       uniqueUpdatedRollingStockName = generateUniqueName('U_RSN');
@@ -53,7 +48,7 @@ test.describe('@rs-editor', () => {
   });
 
   /** *************** Test 1 **************** */
-  test('@smoke Create a new rolling stock', async ({ page }) => {
+  test('@smoke Create a new rolling stock', async ({ page, rollingStockEditorPage }) => {
     createdRollingStocks.push(uniqueRollingStockName);
 
     await test.step('Open creation form', async () => {
@@ -138,7 +133,7 @@ test.describe('@rs-editor', () => {
   });
 
   /** *************** Test 2 **************** */
-  test('Duplicate and modify a rolling stock', async ({ page }) => {
+  test('Duplicate and modify a rolling stock', async ({ page, rollingStockEditorPage }) => {
     createdRollingStocks.push(uniqueUpdatedRollingStockName);
 
     await test.step('Duplicate existing Electric rolling stock', async () => {
@@ -181,7 +176,7 @@ test.describe('@rs-editor', () => {
   });
 
   /** *************** Test 3 **************** */
-  test('Duplicate and delete a rolling stock', async ({ page }) => {
+  test('Duplicate and delete a rolling stock', async ({ page, rollingStockEditorPage }) => {
     createdRollingStocks.push(uniqueDeletedRollingStockName);
 
     await test.step('Duplicate Electric rolling stock and rename', async () => {

--- a/front/tests/04-rolling-stock-editor/002-rolling-stock-filter.spec.ts
+++ b/front/tests/04-rolling-stock-editor/002-rolling-stock-filter.spec.ts
@@ -1,19 +1,15 @@
 import { expect } from '@playwright/test';
 
 import { dualModeRollingStockName } from './../assets/constants/project-const';
-import test from './../logging-fixture';
-import RollingstockEditorPage from './../pages/rolling-stock/rolling-stock-editor-page';
+import test from './../page-object-fixture';
 
 test.describe('@rs-editor @filter', () => {
-  let rollingStockEditorPage: RollingstockEditorPage;
-
-  test.beforeEach('Navigate to editor page', async ({ page }) => {
-    rollingStockEditorPage = new RollingstockEditorPage(page);
+  test.beforeEach('Navigate to editor page', async ({ rollingStockEditorPage }) => {
     await rollingStockEditorPage.navigateToRollingStockPage();
   });
 
   /** *************** Test 1 **************** */
-  test('Filtering rolling stocks', async () => {
+  test('Filtering rolling stocks', async ({ rollingStockEditorPage }) => {
     const initialRollingStockFoundNumber =
       await rollingStockEditorPage.getRollingStockSearchNumber();
 
@@ -54,7 +50,7 @@ test.describe('@rs-editor @filter', () => {
   });
 
   /** *************** Test 2 **************** */
-  test('Search for a rolling stock', async () => {
+  test('Search for a rolling stock', async ({ rollingStockEditorPage }) => {
     const initialRollingStockFoundNumber =
       await rollingStockEditorPage.getRollingStockSearchNumber();
 

--- a/front/tests/page-object-fixture.ts
+++ b/front/tests/page-object-fixture.ts
@@ -1,0 +1,171 @@
+import type { Page } from '@playwright/test';
+
+import testWithLogging from './logging-fixture';
+import HomePage from './pages/home-page';
+import GetManchetteComponent from './pages/operational-studies/get-manchette-component';
+import ImportPage from './pages/operational-studies/import-page';
+import NGEPage from './pages/operational-studies/nge-page';
+import OperationalStudiesPage from './pages/operational-studies/operational-studies-page';
+import PacedTrainSection from './pages/operational-studies/paced-train-section';
+import ProjectPage from './pages/operational-studies/project-page';
+import RoundTripPage from './pages/operational-studies/round-trips-page';
+import RouteTab from './pages/operational-studies/route-tab';
+import ScenarioPage from './pages/operational-studies/scenario-page';
+import ScenarioTimetableSection from './pages/operational-studies/scenario-timetable-section';
+import OpSimulationResultPage from './pages/operational-studies/simulation-results-page';
+import SimulationSettingsTab from './pages/operational-studies/simulation-settings-tab';
+import StudyPage from './pages/operational-studies/study-page';
+import TimeAndStopSimulationOutputs from './pages/operational-studies/time-stop-simulation-outputs';
+import TimesAndStopsTab from './pages/operational-studies/times-and-stops-tab';
+import TimetableItemDetailSection from './pages/operational-studies/timetable-items-details-section';
+import RollingstockEditorPage from './pages/rolling-stock/rolling-stock-editor-page';
+import RollingStockSelector from './pages/rolling-stock/rolling-stock-selector';
+import ConsistSection from './pages/stdcm/consist-section';
+import DestinationSection from './pages/stdcm/destination-section';
+import LinkedTrainSection from './pages/stdcm/linked-train-section';
+import OriginSection from './pages/stdcm/origin-section';
+import SimulationResultPage from './pages/stdcm/simulation-results-page';
+import STDCMPage from './pages/stdcm/stdcm-page';
+import ViaSection from './pages/stdcm/via-section';
+
+type Fixtures = {
+  // Operational studies
+  operationalStudiesPage: OperationalStudiesPage;
+  projectPage: ProjectPage;
+  studyPage: StudyPage;
+  scenarioPage: ScenarioPage;
+  routeTab: RouteTab;
+  pacedTrainSection: PacedTrainSection;
+  timesAndStopsTab: TimesAndStopsTab;
+  timeAndStopSimulationOutputs: TimeAndStopSimulationOutputs;
+  simulationSettingsTab: SimulationSettingsTab;
+  opSimulationResultPage: OpSimulationResultPage;
+  scenarioTimetableSection: ScenarioTimetableSection;
+  timetableItemDetailSection: TimetableItemDetailSection;
+  getManchetteComponent: GetManchetteComponent;
+  ngePage: NGEPage;
+  roundTripPage: RoundTripPage;
+  importPage: ImportPage;
+
+  // Rolling stock
+  rollingStockSelector: RollingStockSelector;
+  rollingStockEditorPage: RollingstockEditorPage;
+
+  // STDCM
+  stdcmPage: STDCMPage;
+  consistSection: ConsistSection;
+  originSection: OriginSection;
+  viaSection: ViaSection;
+  destinationSection: DestinationSection;
+  linkedTrainSection: LinkedTrainSection;
+  stdcmSimulationResultPage: SimulationResultPage;
+
+  // Generic
+  homePage: HomePage;
+
+  // Second page + only the POs needed for multi-tab tests
+  secondPage: Page;
+  secondOperationalStudiesPage: OperationalStudiesPage;
+  secondScenarioTimetableSection: ScenarioTimetableSection;
+};
+
+const test = testWithLogging.extend<Fixtures>({
+  // Operational studies
+  operationalStudiesPage: async ({ page }, use) => {
+    await use(new OperationalStudiesPage(page));
+  },
+  projectPage: async ({ page }, use) => {
+    await use(new ProjectPage(page));
+  },
+  studyPage: async ({ page }, use) => {
+    await use(new StudyPage(page));
+  },
+  scenarioPage: async ({ page }, use) => {
+    await use(new ScenarioPage(page));
+  },
+  routeTab: async ({ page }, use) => {
+    await use(new RouteTab(page));
+  },
+  pacedTrainSection: async ({ page }, use) => {
+    await use(new PacedTrainSection(page));
+  },
+  timesAndStopsTab: async ({ page }, use) => {
+    await use(new TimesAndStopsTab(page));
+  },
+  timeAndStopSimulationOutputs: async ({ page }, use) => {
+    await use(new TimeAndStopSimulationOutputs(page));
+  },
+  simulationSettingsTab: async ({ page }, use) => {
+    await use(new SimulationSettingsTab(page));
+  },
+  opSimulationResultPage: async ({ page }, use) => {
+    await use(new OpSimulationResultPage(page));
+  },
+  scenarioTimetableSection: async ({ page }, use) => {
+    await use(new ScenarioTimetableSection(page));
+  },
+  timetableItemDetailSection: async ({ page }, use) => {
+    await use(new TimetableItemDetailSection(page));
+  },
+  getManchetteComponent: async ({ page }, use) => {
+    await use(new GetManchetteComponent(page));
+  },
+  ngePage: async ({ page }, use) => {
+    await use(new NGEPage(page));
+  },
+  roundTripPage: async ({ page }, use) => {
+    await use(new RoundTripPage(page));
+  },
+
+  // Rolling stock
+  rollingStockSelector: async ({ page }, use) => {
+    await use(new RollingStockSelector(page));
+  },
+  rollingStockEditorPage: async ({ page }, use) => {
+    await use(new RollingstockEditorPage(page));
+  },
+
+  // STDCM
+  stdcmPage: async ({ page }, use) => {
+    await use(new STDCMPage(page));
+  },
+  consistSection: async ({ page }, use) => {
+    await use(new ConsistSection(page));
+  },
+  originSection: async ({ page }, use) => {
+    await use(new OriginSection(page));
+  },
+  viaSection: async ({ page }, use) => {
+    await use(new ViaSection(page));
+  },
+  destinationSection: async ({ page }, use) => {
+    await use(new DestinationSection(page));
+  },
+  linkedTrainSection: async ({ page }, use) => {
+    await use(new LinkedTrainSection(page));
+  },
+  stdcmSimulationResultPage: async ({ page }, use) => {
+    await use(new SimulationResultPage(page));
+  },
+  homePage: async ({ page }, use) => {
+    await use(new HomePage(page));
+  },
+  importPage: async ({ page }, use) => {
+    await use(new ImportPage(page));
+  },
+
+  // Second TAB fixtures for multi-tab tests
+  secondPage: async ({ context }, use) => {
+    const secondPage = await context.newPage();
+    await use(secondPage);
+    await secondPage.close();
+  },
+  secondOperationalStudiesPage: async ({ secondPage }, use) => {
+    await use(new OperationalStudiesPage(secondPage));
+  },
+  secondScenarioTimetableSection: async ({ secondPage }, use) => {
+    await use(new ScenarioTimetableSection(secondPage));
+  },
+});
+
+export default test;

--- a/front/tests/pages/common-page.ts
+++ b/front/tests/pages/common-page.ts
@@ -4,19 +4,12 @@ import { logger } from '../logging-fixture';
 
 class CommonPage {
   readonly page: Page;
-
   readonly toastContainer: Locator;
-
   private readonly toastTitle: Locator;
-
   private readonly tagField: Locator;
-
   private readonly closeToastButton: Locator;
-
   private readonly navigationToHomeButton: Locator;
-
   private readonly navigationBackButton: Locator;
-
   private readonly loader: Locator;
 
   constructor(page: Page) {

--- a/front/tests/pages/home-page.ts
+++ b/front/tests/pages/home-page.ts
@@ -4,21 +4,13 @@ import CommonPage from './common-page';
 
 class HomePage extends CommonPage {
   private readonly operationalStudiesLink: Locator;
-
   private readonly cartoLink: Locator;
-
   private readonly editorLink: Locator;
-
   readonly linksTitle: Locator;
-
   private readonly rollingStockEditorLink: Locator;
-
   private readonly STDCMLink: Locator;
-
   private readonly backHomeLogo: Locator;
-
   private readonly dropDown: Locator;
-
   private readonly OSRDLanguage: Locator;
 
   constructor(page: Page) {

--- a/front/tests/pages/operational-studies/get-manchette-component.ts
+++ b/front/tests/pages/operational-studies/get-manchette-component.ts
@@ -6,52 +6,29 @@ import type { Waypoint } from '../../utils/manchette';
 
 class GetManchetteComponent extends OpSimulationResultPage {
   private readonly spaceTimeChartMenuButton: Locator;
-
   private readonly spaceTimeChartCloseSettingsButton: Locator;
-
   private readonly spaceTimeChartSettingsPanel: Locator;
-
   private readonly spaceTimeChartCheckboxItems: Locator;
-
   private readonly manchetteMenuButton: Locator;
-
   private readonly manchetteVisibilityButton: Locator;
-
   private readonly waypointsList: Locator;
-
   private readonly waypointsPanel: Locator;
-
   private readonly waypointItems: Locator;
-
   private readonly waypointPanelFooter: Locator;
-
   private readonly waypointCancelButton: Locator;
-
   private readonly waypointSaveButton: Locator;
-
   private readonly speedSpaceChartZoomButton: Locator;
-
   private readonly speedSpaceChartResetButton: Locator;
-
   private readonly speedSpaceChartRangerSlider: Locator;
-
   private readonly manchetteActionsButton: Locator;
-
   private readonly manchetteZoomInButton: Locator;
-
   private readonly manchetteZoomOutButton: Locator;
-
   private readonly manchetteResetButton: Locator;
-
   private readonly manchetteKmModeButton: Locator;
-
   private readonly manchetteLinearModeButton: Locator;
-
   private readonly warpedMapButton: Locator;
-
   private readonly simulationWarpedMap: Locator;
-
-  private readonly manchetteSpacetimediagramRef: Locator;
+  private readonly manchetteSpaceTimeDiagramRef: Locator;
 
   constructor(page: Page) {
     super(page);
@@ -79,7 +56,7 @@ class GetManchetteComponent extends OpSimulationResultPage {
     this.speedSpaceChartResetButton = this.spaceTimeChart.getByTestId('zoom-reset-button');
     this.warpedMapButton = page.getByTestId('warped-map-button');
     this.simulationWarpedMap = page.getByTestId('simulation-warped-map');
-    this.manchetteSpacetimediagramRef = page.getByTestId('manchette-spacetimediagram-ref');
+    this.manchetteSpaceTimeDiagramRef = page.getByTestId('manchette-spacetimediagram-ref');
   }
 
   private getWaypointNameListLocator(index: number): Locator {
@@ -195,7 +172,7 @@ class GetManchetteComponent extends OpSimulationResultPage {
     await this.manchetteZoomInButton.click({ clickCount: 5 });
 
     await expect
-      .poll(async () => await isOverflowing(this.manchetteSpacetimediagramRef))
+      .poll(async () => await isOverflowing(this.manchetteSpaceTimeDiagramRef))
       .toBe(true);
 
     await this.expectVisibleEnabled(this.manchetteZoomOutButton);
@@ -204,7 +181,7 @@ class GetManchetteComponent extends OpSimulationResultPage {
     await this.manchetteResetButton.click();
 
     await expect
-      .poll(async () => await isOverflowing(this.manchetteSpacetimediagramRef))
+      .poll(async () => await isOverflowing(this.manchetteSpaceTimeDiagramRef))
       .toBe(false);
   }
 

--- a/front/tests/pages/operational-studies/import-page.ts
+++ b/front/tests/pages/operational-studies/import-page.ts
@@ -1,6 +1,6 @@
 import { expect, type Locator, type Page } from '@playwright/test';
 
-import OperationalStudiesPage from './operational-studies/operational-studies-page';
+import OperationalStudiesPage from './operational-studies-page';
 
 class ImportPage extends OperationalStudiesPage {
   private readonly importTimetableItemButton: Locator;

--- a/front/tests/pages/operational-studies/operational-studies-page.ts
+++ b/front/tests/pages/operational-studies/operational-studies-page.ts
@@ -12,27 +12,16 @@ import type { ManageTimetableItemTranslations, PacedTrainDetails } from '../../u
 
 class OperationalStudiesPage extends ScenarioTimetableSection {
   private readonly addTimetableItemButton: Locator;
-
   private readonly manageTimetableItemPage: Locator;
-
   private readonly rollingStockTab: Locator;
-
   private readonly routeTab: Locator;
-
   private readonly startTimeField: Locator;
-
   private readonly resultPathfindingDistance: Locator;
-
   private readonly returnSimulationResultButton: Locator;
-
   private readonly definePacedTrainCheckbox: Locator;
-
   private readonly definePacedTrainCheckboxLabel: Locator;
-
   private readonly pacedTrainTimeWindow: Locator;
-
   private readonly pacedTrainIntervalInput: Locator;
-
   private readonly pacedTrainAddException: {
     label: Locator;
     dateInput: Locator;
@@ -40,17 +29,11 @@ class OperationalStudiesPage extends ScenarioTimetableSection {
     button: Locator;
     list: Locator;
   };
-
   private readonly timetableItemNameInput: Locator;
-
   private readonly initialSpeedInput: Locator;
-
   private readonly timetableItemTagsInput: Locator;
-
   private readonly createTimetableItemButton: Locator;
-
   private readonly simulationSettingsTab: Locator;
-
   private readonly timesAndStopsTab: Locator;
 
   constructor(page: Page) {

--- a/front/tests/pages/operational-studies/paced-train-section.ts
+++ b/front/tests/pages/operational-studies/paced-train-section.ts
@@ -11,33 +11,19 @@ import CommonPage from '../common-page';
 
 class PacedTrainSection extends CommonPage {
   private readonly pacedTrainItem: Locator;
-
   private readonly testedPacedTrain: Locator;
-
   private readonly testedPacedTrainShowOccurrencesButton: Locator;
-
   private readonly testedPacedTrainName: Locator;
-
   private readonly testedPacedTrainRollingStock: Locator;
-
   private readonly testedPacedTrainInterval: Locator;
-
   private readonly testedPacedTrainOccurrences: Locator;
-
   private readonly testedOccurrenceName: Locator;
-
   private readonly testedOccurrenceStartTime: Locator;
-
   private readonly testedOccurrenceArrivalTime: Locator;
-
   private readonly occurrencesCount: Locator;
-
   private readonly manageTimetableItemPage: Locator;
-
   private readonly confirmationModalDeleteButton: Locator;
-
   private readonly confirmationModalButton: Locator;
-
   private readonly portalOccurrenceMenu: {
     disable: Locator;
     enable: Locator;

--- a/front/tests/pages/operational-studies/project-page.ts
+++ b/front/tests/pages/operational-studies/project-page.ts
@@ -6,37 +6,21 @@ import HomePage from '../home-page';
 
 class ProjectPage extends HomePage {
   private readonly projectNameLabel: Locator;
-
   private readonly updateProjectButton: Locator;
-
   private readonly projectDescriptionLabel: Locator;
-
   private readonly projectObjectivesLabel: Locator;
-
   private readonly projectFinancialInfoLabel: Locator;
-
   private readonly projectFinancialAmountLabel: Locator;
-
   private readonly projectTagsLabel: Locator;
-
   private readonly addProjectButton: Locator;
-
   private readonly projectNameInput: Locator;
-
   private readonly projectDescriptionInput: Locator;
-
   private readonly projectObjectiveInput: Locator;
-
   private readonly projectFunderInput: Locator;
-
   private readonly projectBudgetInput: Locator;
-
   private readonly updateConfirmButton: Locator;
-
   private readonly projectDeleteButton: Locator;
-
   private readonly createProjectButton: Locator;
-
   private readonly projectConfirmDeleteButton: Locator;
 
   constructor(page: Page) {

--- a/front/tests/pages/operational-studies/round-trips-page.ts
+++ b/front/tests/pages/operational-studies/round-trips-page.ts
@@ -5,65 +5,35 @@ import type { RoundTripCardExpected } from '../../utils/types';
 class RoundTripPage {
   readonly page: Page;
   private readonly manageRoundTripsButton: Locator;
-
   private readonly roundTripsModalPage: Locator;
-
   private readonly roundTripsCards: Locator;
-
   private roundTripsPairingColumn: Locator;
-
   private roundTripPairs: Locator;
-
   private oneWaysColumnCard: Locator;
-
   private toDoColumnCard: Locator;
-
   private readonly oneWaysColumnTitle: Locator;
-
   private readonly oneWaysItemCount: Locator;
-
   private readonly roundTripColumnTitle: Locator;
-
   private readonly roundTripItemCount: Locator;
-
   private readonly toDoColumnTitle: Locator;
-
   private readonly toDoItemCount: Locator;
-
   private readonly saveRoundTripsButton: Locator;
-
   private readonly cancelRoundTripsButton: Locator;
-
   private readonly roundTripFilterField: Locator;
-
   private readonly roundTripCardName: Locator;
-
   private readonly roundTripCardInterval: Locator;
-
   private readonly roundTripCardStops: Locator;
-
   private readonly roundTripCardOrigin: Locator;
-
   private readonly roundTripCardDestination: Locator;
-
   private readonly roundTripCardStartTime: Locator;
-
   private readonly roundTripCardRequestedArrivalTime: Locator;
-
   private readonly intermediateStopsTooltip: Locator;
-
   private readonly intermediateStopTooltipItem: Locator;
-
   private oneWayButton: Locator;
-
   private roundTripButton: Locator;
-
   private restoreButton: Locator;
-
   private pairingColumnCard: Locator;
-
   private pairingFilterField: Locator;
-
   private roundTripPairCards: Locator;
 
   constructor(page: Page) {

--- a/front/tests/pages/operational-studies/round-trips-page.ts
+++ b/front/tests/pages/operational-studies/round-trips-page.ts
@@ -1,9 +1,9 @@
 import { type Locator, type Page, expect } from '@playwright/test';
 
-import OperationalStudiesPage from './operational-studies-page';
 import type { RoundTripCardExpected } from '../../utils/types';
 
-class RoundTripPage extends OperationalStudiesPage {
+class RoundTripPage {
+  readonly page: Page;
   private readonly manageRoundTripsButton: Locator;
 
   private readonly roundTripsModalPage: Locator;
@@ -67,7 +67,7 @@ class RoundTripPage extends OperationalStudiesPage {
   private roundTripPairCards: Locator;
 
   constructor(page: Page) {
-    super(page);
+    this.page = page;
     this.manageRoundTripsButton = page.getByTestId('scenarios-manage-round-trips-button');
     this.roundTripsModalPage = page.getByTestId('round-trips-modal');
     this.oneWaysColumnCard = page.getByTestId('one-ways-column').getByTestId('round-trips-card');

--- a/front/tests/pages/operational-studies/route-tab.ts
+++ b/front/tests/pages/operational-studies/route-tab.ts
@@ -9,49 +9,27 @@ const frTranslations: FlatTranslations = readJsonFile<{ manageTimetableItem: Fla
 
 class RouteTab {
   readonly page: Page;
-
   private readonly noOriginChosen: Locator;
-
   private readonly noDestinationChosen: Locator;
-
   private readonly searchByTrigramButton: Locator;
-
   private readonly searchByTrigramContainer: Locator;
-
   private readonly searchByTrigramInput: Locator;
-
   private readonly searchByTrigramSubmit: Locator;
-
   private readonly resultPathfindingDone: Locator;
-
   private readonly originInfo: Locator;
-
   private readonly destinationInfo: Locator;
-
   private readonly originDeleteButton: Locator;
-
   private readonly destinationDeleteButton: Locator;
-
   private readonly viaDeleteButton: Locator;
-
   private readonly addWaypointsButton: Locator;
-
   private readonly reverseItineraryButton: Locator;
-
   private readonly deleteItineraryButton: Locator;
-
   readonly droppedWaypoints: Locator;
-
   private readonly waypointSuggestions: Locator;
-
   private readonly viaModal: Locator;
-
   private readonly closeViaModalButton: Locator;
-
   private readonly missingParamMessage: Locator;
-
   private readonly pathfindingLoader: Locator;
-
   private readonly pathfindingInProgressMessage: Locator;
 
   constructor(page: Page) {
@@ -274,7 +252,7 @@ class RouteTab {
   }
 
   // Validate the added waypoints by checking the name, CH, and UIC.
-  static async validateAddedWaypoint(
+  async validateAddedWaypoint(
     droppedWaypoint: Locator,
     expectedName: string,
     expectedCh: string,
@@ -321,7 +299,7 @@ class RouteTab {
       const droppedWaypoint = this.droppedWaypoints.nth(droppedWaypointCount);
       const expectedValue = expectedValues[droppedWaypointCount];
 
-      await RouteTab.validateAddedWaypoint(
+      await this.validateAddedWaypoint(
         droppedWaypoint,
         expectedValue.name,
         expectedValue.ch,

--- a/front/tests/pages/operational-studies/scenario-page.ts
+++ b/front/tests/pages/operational-studies/scenario-page.ts
@@ -5,49 +5,27 @@ import CommonPage from '../common-page';
 
 class ScenarioPage extends CommonPage {
   private readonly scenarioEditionModal: Locator;
-
   private readonly scenarioUpdateButton: Locator;
-
   private readonly scenarioDeleteButton: Locator;
-
   private readonly scenarioConfirmUpdateButton: Locator;
-
   private readonly scenarioNameInput: Locator;
-
   private readonly scenarioDescriptionInput: Locator;
-
   private readonly scenarioInfraList: Locator;
-
   private readonly scenarioElectricProfileSelect: Locator;
-
   private readonly scenarioName: Locator;
-
   private readonly scenarioNameContainer: Locator;
-
   private readonly scenarioDescription: Locator;
-
   private readonly scenarioInfraName: Locator;
-
   private readonly addScenarioButton: Locator;
-
   private readonly createScenarioButton: Locator;
-
   private readonly scenarioTagsLabel: Locator;
-
   private readonly scenarioConfirmDeleteButton: Locator;
-
   readonly conflictsButton: Locator;
-
   readonly trainsButton: Locator;
-
   readonly simulationMapButton: Locator;
-
   readonly timeStopsOutputsButton: Locator;
-
   readonly macroEditorButton: Locator;
-
   readonly stdButton: Locator;
-
   readonly sddButton: Locator;
 
   constructor(readonly page: Page) {

--- a/front/tests/pages/operational-studies/scenario-timetable-section.ts
+++ b/front/tests/pages/operational-studies/scenario-timetable-section.ts
@@ -19,59 +19,32 @@ const frTranslations: ScenarioTranslations = readJsonFile<{
 
 class ScenarioTimetableSection extends OpSimulationResultPage {
   private readonly invalidTimetableItemsMessage: Locator;
-
   private readonly timetableItems: Locator;
-
   private readonly timetableBoardWrapper: Locator;
-
   private readonly timetableSelectAllButton: Locator;
-
   private readonly timetableSelectOptionsButton: Locator;
-
   private readonly timetableTotalItemLabel: Locator;
-
   private readonly deleteAllTimetableItemsButton: Locator;
-
   private readonly confirmationModalDeleteButton: Locator;
-
   private readonly timetableFilterButton: Locator;
-
   private readonly timetableFilterButtonClose: Locator;
-
   private readonly timetableLabelFilterInputLabel: Locator;
-
   private readonly timetableLabelFilterInput: Locator;
-
   private readonly timetableRollingStockFilterInputLabel: Locator;
-
   private readonly timetableRollingStockFilterInput: Locator;
-
   private readonly timetableValidityFilterSelectLabel: Locator;
-
   private readonly timetableValidityFilterSelect: Locator;
-
   private readonly timetablePunctualityFilterSelectLabel: Locator;
-
   private readonly timetablePunctualityFilterSelect: Locator;
-
   private readonly timetableTrainTypeFilterSelectLabel: Locator;
-
   private readonly timetableTrainTypeFilterSelect: Locator;
-
   private readonly timetableSpeedLimitTagFilterLabel: Locator;
-
   private readonly editItemButton: Locator;
-
   private readonly projectItemButton: Locator;
-
   private readonly deleteItemButton: Locator;
-
   readonly editTimetableItemButton: Locator;
-
   private readonly timetableItemArrivalTime: Locator;
-
   private readonly timetableItemArrivalTimeLoader: Locator;
-
   private readonly invalidTimetableItemsReasons: Locator;
 
   constructor(page: Page) {

--- a/front/tests/pages/operational-studies/simulation-results-page.ts
+++ b/front/tests/pages/operational-studies/simulation-results-page.ts
@@ -5,29 +5,17 @@ import { toggleByState } from '../../utils';
 
 class OpSimulationResultPage extends ScenarioPage {
   readonly simulationResults: Locator;
-
   private readonly speedSpaceChartSettingsButton: Locator;
-
   private readonly speedSpaceChartCheckboxItems: Locator;
-
   private readonly speedSpaceChartCloseSettingsButton: Locator;
-
   readonly manchetteSpaceTimeChart: Locator;
-
   readonly spaceTimeChart: Locator;
-
   readonly speedSpaceChart: Locator;
-
   readonly timesStopsDataSheet: Locator;
-
   private readonly simulationMap: Locator;
-
   private readonly trainList: Locator;
-
   private readonly timeStopsOutputs: Locator;
-
   private readonly macroEditor: Locator;
-
   private readonly conflictsList: Locator;
 
   constructor(page: Page) {

--- a/front/tests/pages/operational-studies/simulation-settings-tab.ts
+++ b/front/tests/pages/operational-studies/simulation-settings-tab.ts
@@ -2,13 +2,9 @@ import { type Locator, type Page, expect } from '@playwright/test';
 
 class SimulationSettingsTab {
   readonly page: Page;
-
   private readonly electricalProfilesSwitch: Locator;
-
   private readonly linearMarginSwitch: Locator;
-
   private readonly marecoMarginSwitch: Locator;
-
   private readonly speedLimitTagSelector: Locator;
 
   constructor(page: Page) {

--- a/front/tests/pages/operational-studies/study-page.ts
+++ b/front/tests/pages/operational-studies/study-page.ts
@@ -5,63 +5,34 @@ import CommonPage from '../common-page';
 
 class StudyPage extends CommonPage {
   private readonly studyUpdateButton: Locator;
-
   private readonly studyName: Locator;
-
   private readonly studyDescription: Locator;
-
   private readonly studyState: Locator;
-
   private readonly studyType: Locator;
-
   private readonly studyServiceCodeInfo: Locator;
-
   private readonly studyBusinessCodeInfo: Locator;
-
   private readonly studyFinancialAmount: Locator;
-
   private readonly studyTags: Locator;
-
   private readonly addStudyButton: Locator;
-
   private readonly studyUpdateConfirmButton: Locator;
-
   private readonly studyInputName: Locator;
-
   private readonly studyTypeSelect: Locator;
-
   private readonly studyStatusSelect: Locator;
-
   private readonly studyDescriptionInput: Locator;
-
   private readonly studyStartDateInput: Locator;
-
   private readonly studyExpectedEndDateInput: Locator;
-
   private readonly studyEndDateInput: Locator;
-
   private readonly studyServiceCodeInput: Locator;
-
   private readonly studyBusinessCodeInput: Locator;
-
   private readonly studyBudgetInput: Locator;
-
   private readonly studyDeleteButton: Locator;
-
   private readonly createStudyButton: Locator;
-
   private readonly studyEditionModal: Locator;
-
   private readonly startDate: Locator;
-
   private readonly expectedEndDate: Locator;
-
   private readonly realEndDate: Locator;
-
   private readonly deleteScenarioButton: Locator;
-
   private readonly confirmDeleteScenarioButton: Locator;
-
   private readonly studyConfirmDeleteButton: Locator;
 
   constructor(page: Page) {

--- a/front/tests/pages/operational-studies/time-stop-simulation-outputs.ts
+++ b/front/tests/pages/operational-studies/time-stop-simulation-outputs.ts
@@ -1,6 +1,5 @@
 import { type Locator, type Page, expect } from '@playwright/test';
 
-import OpSimulationResultPage from './simulation-results-page';
 import { normalizeStationData } from '../../utils/data-normalizer';
 import readJsonFile from '../../utils/file-utils';
 import type { FlatTranslations, StationData } from '../../utils/types';
@@ -9,13 +8,14 @@ const frTranslations = readJsonFile<Record<string, FlatTranslations>>(
   'public/locales/fr/translation.json'
 ).timeStopTable;
 
-class TimeAndStopSimulationOutputs extends OpSimulationResultPage {
+class TimeAndStopSimulationOutputs {
+  readonly page: Page;
   private readonly columnHeaders: Locator;
 
   private readonly tableRows: Locator;
 
   constructor(page: Page) {
-    super(page);
+    this.page = page;
     this.columnHeaders = page.locator(
       '.dsg-cell.dsg-cell-header:not(.dsg-cell-gutter) .dsg-cell-header-container'
     );

--- a/front/tests/pages/operational-studies/time-stop-simulation-outputs.ts
+++ b/front/tests/pages/operational-studies/time-stop-simulation-outputs.ts
@@ -11,7 +11,6 @@ const frTranslations = readJsonFile<Record<string, FlatTranslations>>(
 class TimeAndStopSimulationOutputs {
   readonly page: Page;
   private readonly columnHeaders: Locator;
-
   private readonly tableRows: Locator;
 
   constructor(page: Page) {

--- a/front/tests/pages/operational-studies/times-and-stops-tab.ts
+++ b/front/tests/pages/operational-studies/times-and-stops-tab.ts
@@ -10,13 +10,9 @@ const frTranslations = readJsonFile<Record<string, FlatTranslations>>(
 
 class TimesAndStopsTab {
   private readonly page: Page;
-
   readonly columnHeaders: Locator;
-
   private readonly activeRows: Locator;
-
   private readonly tableRows: Locator;
-
   private readonly clearButtons: Locator;
 
   constructor(page: Page) {

--- a/front/tests/pages/operational-studies/timetable-items-details-section.ts
+++ b/front/tests/pages/operational-studies/timetable-items-details-section.ts
@@ -13,12 +13,10 @@ class TimetableItemDetailSection extends ScenarioTimetableSection {
   private readonly showItemsDetailsButton: Locator;
   private readonly pacedTrainDetailLabels: Locator;
   private readonly trainScheduleDetailLabels: Locator;
-
   private readonly pacedTrainStopsCount: Locator;
   private readonly pacedTrainPathLength: Locator;
   private readonly pacedTrainEnergyConsumed: Locator;
   private readonly pacedTrainDurationTime: Locator;
-
   private readonly trainScheduleStopsCount: Locator;
   private readonly trainSchedulePathLength: Locator;
   private readonly trainScheduleEnergyConsumed: Locator;
@@ -27,15 +25,12 @@ class TimetableItemDetailSection extends ScenarioTimetableSection {
   constructor(page: Page) {
     super(page);
     this.showItemsDetailsButton = page.getByTestId('scenarios-show-train-details-button');
-
     this.pacedTrainDetailLabels = page.getByTestId('paced-train-more-info');
     this.trainScheduleDetailLabels = page.getByTestId('train-schedule-more-info');
-
     this.pacedTrainStopsCount = page.getByTestId('paced-train-stop-count');
     this.pacedTrainPathLength = page.getByTestId('paced-train-path-length');
     this.pacedTrainEnergyConsumed = page.getByTestId('paced-train-allowance-energy-consumed');
     this.pacedTrainDurationTime = page.getByTestId('paced-train-duration-time');
-
     this.trainScheduleStopsCount = page.getByTestId('train-schedule-stop-count');
     this.trainSchedulePathLength = page.getByTestId('train-schedule-path-length');
     this.trainScheduleEnergyConsumed = page.getByTestId('train-schedule-allowance-energy-consumed');

--- a/front/tests/pages/rolling-stock/rolling-stock-editor-page.ts
+++ b/front/tests/pages/rolling-stock/rolling-stock-editor-page.ts
@@ -13,45 +13,25 @@ const frTranslations = readJsonFile<{ rollingStock: RollingStockTranslations }>(
 
 class RollingstockEditorPage extends RollingStockSelector {
   private readonly rollingstockEditorList: Locator;
-
   private readonly rollingstockCard: Locator;
-
   private readonly newRollingstockButton: Locator;
-
   private readonly submitRollingstockButton: Locator;
-
   private readonly rollingstockDetailsButton: Locator;
-
   private readonly speedEffortCurvesButton: Locator;
-
   private readonly rollingStockSpreadsheet: Locator;
-
   private readonly rollingStockSearchInput: Locator;
-
   private readonly powerRestrictionSelector: Locator;
-
   private readonly electricalProfileSelector: Locator;
-
   private readonly loadingGauge: Locator;
-
   private readonly primaryCategorySelector: Locator;
-
   private readonly tractionModeSelector: Locator;
-
   private readonly confirmModalButtonYes: Locator;
-
   private readonly addPowerRestrictionButton: Locator;
-
   private readonly powerRestrictionModalBody: Locator;
-
   private readonly selectedElectricalProfileButton: Locator;
-
   private readonly deleteSelectedElectricalProfileButton: Locator;
-
   private readonly editRollingStockButton: Locator;
-
   private readonly duplicateRollingStockButton: Locator;
-
   private readonly deleteRollingStockButton: Locator;
 
   constructor(page: Page) {

--- a/front/tests/pages/rolling-stock/rolling-stock-selector.ts
+++ b/front/tests/pages/rolling-stock/rolling-stock-selector.ts
@@ -5,41 +5,23 @@ import CommonPage from '../common-page';
 
 class RollingStockSelector extends CommonPage {
   private readonly rollingStockSelectorButton: Locator;
-
   private readonly emptyRollingStockSelector: Locator;
-
   readonly rollingStockSelectorModal: Locator;
-
   private readonly rollingStockModalSearch: Locator;
-
   private readonly rollingStockMiniCards: Locator;
-
   private readonly electricRollingStockFilter: Locator;
-
   private readonly thermalRollingStockFilter: Locator;
-
   private readonly rollingStockSearchResult: Locator;
-
   readonly thermalRollingStockIcons: Locator;
-
   readonly electricRollingStockIcons: Locator;
-
   readonly electricRollingStockFirstIcon: Locator;
-
   readonly thermalRollingStockFirstIcon: Locator;
-
   readonly rollingStockList: Locator;
-
   readonly dualModeRollingStockIcons: Locator;
-
   readonly noRollingStockResult: Locator;
-
   readonly comfortACButton: Locator;
-
   readonly selectedComfortType: Locator;
-
   readonly selectedRollingStockName: Locator;
-
   readonly rollingStockNameTab: Locator;
 
   constructor(page: Page) {

--- a/front/tests/pages/rolling-stock/rolling-stock-selector.ts
+++ b/front/tests/pages/rolling-stock/rolling-stock-selector.ts
@@ -1,9 +1,9 @@
 import { type Locator, type Page, expect } from '@playwright/test';
 
 import { extractNumberFromString } from '../../utils/index';
-import OperationalStudiesPage from '../operational-studies/operational-studies-page';
+import CommonPage from '../common-page';
 
-class RollingStockSelector extends OperationalStudiesPage {
+class RollingStockSelector extends CommonPage {
   private readonly rollingStockSelectorButton: Locator;
 
   private readonly emptyRollingStockSelector: Locator;

--- a/front/tests/pages/stdcm/consist-section.ts
+++ b/front/tests/pages/stdcm/consist-section.ts
@@ -6,17 +6,11 @@ import type { ConsistFields } from '../../utils/types';
 
 class ConsistSection {
   readonly page: Page;
-
   private readonly tractionEngineField: Locator;
-
   private readonly towedRollingStockField: Locator;
-
   private readonly tonnageField: Locator;
-
   private readonly lengthField: Locator;
-
   private readonly speedLimitTagField: Locator;
-
   private readonly maxSpeedField: Locator;
 
   constructor(page: Page) {

--- a/front/tests/pages/stdcm/destination-section.ts
+++ b/front/tests/pages/stdcm/destination-section.ts
@@ -13,27 +13,16 @@ const frTranslations: StdcmTranslations = readJsonFile('public/locales/fr/stdcm.
 
 class DestinationSection extends STDCMPage {
   private readonly destinationChField: Locator;
-
   private readonly destinationCiField: Locator;
-
   readonly destinationArrival: Locator;
-
   readonly dateDestinationArrival: Locator;
-
   readonly timeDestinationArrival: Locator;
-
   readonly toleranceDestinationArrival: Locator;
-
   readonly dynamicDestinationCh: Locator;
-
   readonly dynamicDestinationCi: Locator;
-
   private readonly suggestionSS: Locator;
-
   private readonly closeDestinationTimePickerButton: Locator;
-
   private readonly clearButton: Locator;
-
   private readonly destinationIncrementTimeButton: Locator;
 
   constructor(page: Page) {

--- a/front/tests/pages/stdcm/linked-train-section.ts
+++ b/front/tests/pages/stdcm/linked-train-section.ts
@@ -8,27 +8,16 @@ import { DEFAULT_DETAILS } from '../../assets/constants/stdcm-const';
 
 class LinkedTrainSection extends STDCMPage {
   readonly originPage: OriginSection;
-
   readonly destinationPage: DestinationSection;
-
   private readonly anteriorDeleteLinkedPathButton: Locator;
-
   private readonly anteriorLinkedTrainField: Locator;
-
   private readonly anteriorLinkedTrainDate: Locator;
-
   private readonly anteriorLinkedTrainSearchButton: Locator;
-
   private readonly anteriorLinkedTrainResultInfosButton: Locator;
-
   private readonly posteriorDeleteLinkedPathButton: Locator;
-
   private readonly posteriorLinkedTrainField: Locator;
-
   private readonly posteriorLinkedTrainDate: Locator;
-
   private readonly posteriorLinkedTrainSearchButton: Locator;
-
   private readonly posteriorLinkedTrainResultInfosButton: Locator;
 
   constructor(page: Page) {

--- a/front/tests/pages/stdcm/origin-section.ts
+++ b/front/tests/pages/stdcm/origin-section.ts
@@ -10,21 +10,13 @@ import {
 
 class OriginSection extends STDCMPage {
   private readonly originChField: Locator;
-
   private readonly originCiField: Locator;
-
   readonly dateOriginArrival: Locator;
-
   readonly originArrival: Locator;
-
   readonly timeOriginArrival: Locator;
-
   readonly toleranceOriginArrival: Locator;
-
   readonly dynamicOriginCh: Locator;
-
   readonly dynamicOriginCi: Locator;
-
   private readonly suggestionNWS: Locator;
 
   constructor(page: Page) {

--- a/front/tests/pages/stdcm/simulation-results-page.ts
+++ b/front/tests/pages/stdcm/simulation-results-page.ts
@@ -12,37 +12,21 @@ const frTranslations: StdcmTranslations = readJsonFile('public/locales/fr/stdcm.
 class SimulationResultPage {
   readonly page: Page;
   private readonly mapResultContainer: Locator;
-
   private readonly originResultMarker: Locator;
-
   private readonly destinationResultMarker: Locator;
-
   private readonly viaResultMarker: Locator;
-
   private readonly simulationResultTable: Locator;
-
   private readonly simulationTableRows: Locator;
-
   private readonly allViasButton: Locator;
-
   private readonly retainSimulationButton: Locator;
-
   private readonly downloadSimulationButton: Locator;
-
   private readonly downloadLink: Locator;
-
   private readonly startNewQueryButton: Locator;
-
   private readonly startNewQueryWithDataButton: Locator;
-
   private readonly feedbackCardContainer: Locator;
-
   private readonly feedbackTitle: Locator;
-
   private readonly feedbackDescription: Locator;
-
   private readonly feedbackButton: Locator;
-
   private readonly simulationItem: Locator;
 
   constructor(page: Page) {

--- a/front/tests/pages/stdcm/simulation-results-page.ts
+++ b/front/tests/pages/stdcm/simulation-results-page.ts
@@ -3,14 +3,14 @@ import path from 'path';
 
 import { expect, type Locator, type Page } from '@playwright/test';
 
-import STDCMPage from './stdcm-page';
 import { logger } from '../../logging-fixture';
 import readJsonFile from '../../utils/file-utils';
 import type { STDCMResultTableRow, StdcmTranslations } from '../../utils/types';
 
 const frTranslations: StdcmTranslations = readJsonFile('public/locales/fr/stdcm.json');
 
-class SimulationResultPage extends STDCMPage {
+class SimulationResultPage {
+  readonly page: Page;
   private readonly mapResultContainer: Locator;
 
   private readonly originResultMarker: Locator;
@@ -46,7 +46,7 @@ class SimulationResultPage extends STDCMPage {
   private readonly simulationItem: Locator;
 
   constructor(page: Page) {
-    super(page);
+    this.page = page;
     this.simulationItem = page.getByTestId('simulation-item-button');
     this.mapResultContainer = page.locator('#stdcm-map-result');
     this.originResultMarker = this.mapResultContainer.locator('img[alt="origin"]');

--- a/front/tests/pages/stdcm/stdcm-page.ts
+++ b/front/tests/pages/stdcm/stdcm-page.ts
@@ -8,47 +8,26 @@ const frTranslations: StdcmTranslations = readJsonFile('public/locales/fr/stdcm.
 class STDCMPage {
   readonly page: Page;
   private readonly consistCard: Locator;
-
   readonly originCard: Locator;
-
   readonly destinationCard: Locator;
-
   readonly anteriorLinkedTrainContainer: Locator;
-
   readonly anteriorAddLinkedPathButton: Locator;
-
   readonly posteriorLinkedTrainContainer: Locator;
-
   readonly posteriorAddLinkedPathButton: Locator;
-
   readonly addViaButton: Locator;
-
   readonly warningBox: Locator;
-
   private readonly debugButton: Locator;
-
   private readonly mapContainer: Locator;
-
   readonly launchSimulationButton: Locator;
-
   private readonly closeOriginTolerancePickerButton: Locator;
-
   private readonly closeDestinationTolerancePickerButton;
-
   private readonly suggestionList: Locator;
-
   readonly suggestionItems: Locator;
-
   private readonly simulationStatus: Locator;
-
   private readonly originMarker: Locator;
-
   private readonly destinationMarker: Locator;
-
   private readonly viaMarker: Locator;
-
   private readonly helpButton: Locator;
-
   private readonly pathfindingStatusMessage: Locator;
 
   constructor(page: Page) {

--- a/front/tests/pages/stdcm/stdcm-page.ts
+++ b/front/tests/pages/stdcm/stdcm-page.ts
@@ -2,11 +2,11 @@ import { expect, type Locator, type Page } from '@playwright/test';
 
 import readJsonFile from '../../utils/file-utils';
 import type { StdcmTranslations } from '../../utils/types';
-import HomePage from '../home-page';
 
 const frTranslations: StdcmTranslations = readJsonFile('public/locales/fr/stdcm.json');
 
-class STDCMPage extends HomePage {
+class STDCMPage {
+  readonly page: Page;
   private readonly consistCard: Locator;
 
   readonly originCard: Locator;
@@ -52,7 +52,7 @@ class STDCMPage extends HomePage {
   private readonly pathfindingStatusMessage: Locator;
 
   constructor(page: Page) {
-    super(page);
+    this.page = page;
     this.debugButton = page.getByTestId('stdcm-debug-button');
     this.helpButton = page.getByTestId('stdcm-help-button');
     this.mapContainer = page.locator('#stdcm-map-config');

--- a/front/tests/pages/stdcm/via-section.ts
+++ b/front/tests/pages/stdcm/via-section.ts
@@ -13,15 +13,10 @@ const frTranslations: StdcmTranslations = readJsonFile('public/locales/fr/stdcm.
 
 class ViaSection extends STDCMPage {
   private readonly viaIcon: Locator;
-
   private readonly viaDeleteButton: Locator;
-
   private readonly suggestionNS: Locator;
-
   private readonly suggestionMES: Locator;
-
   private readonly suggestionMWS: Locator;
-
   private readonly viaCard: Locator;
 
   constructor(page: Page) {


### PR DESCRIPTION
All tests now use shared Playwright fixtures instead of manual page object instantiation. This standardizes test structure, simplifies test scenarios, and improves maintainability. 
Minor formatting and extends cleanup in page object classes.