### PR TITLE
editoast: add level crossings to railjson_generator and infra export import

### DIFF
--- a/core/osrd-railjson/src/main/java/fr/sncf/osrd/railjson/schema/infra/RJSInfra.java
+++ b/core/osrd-railjson/src/main/java/fr/sncf/osrd/railjson/schema/infra/RJSInfra.java
@@ -18,7 +18,7 @@ public class RJSInfra {
     public static final JsonAdapter<RJSInfra> adapter =
             new Moshi.Builder().add(ID.Adapter.FACTORY).build().adapter(RJSInfra.class);
 
-    public static final transient String CURRENT_VERSION = "3.4.13";
+    public static final transient String CURRENT_VERSION = "3.5.0";
 
     /** The version of the infra format used */
     public String version;

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -11942,6 +11942,7 @@ components:
       - signals
       - buffer_stops
       - detectors
+      - level_crossings
       properties:
         buffer_stops:
           type: array
@@ -11963,6 +11964,11 @@ components:
           items:
             $ref: '#/components/schemas/SwitchType'
           description: These define the types of switches available for route management.
+        level_crossings:
+          type: array
+          items:
+            $ref: '#/components/schemas/LevelCrossing'
+          description: '`LevelCrossing` is an intersections where a railway line crosses a road'
         neutral_sections:
           type: array
           items:

--- a/editoast/schemas/src/infra/railjson.rs
+++ b/editoast/schemas/src/infra/railjson.rs
@@ -15,7 +15,7 @@ use super::Switch;
 use super::SwitchType;
 use super::TrackSection;
 
-pub const RAILJSON_VERSION: &str = "3.4.13";
+pub const RAILJSON_VERSION: &str = "3.5.0";
 
 /// An infrastructure description in the RailJson format
 #[derive(Deserialize, Educe, Serialize, Clone, Debug, ToSchema)]

--- a/editoast/schemas/src/infra/railjson.rs
+++ b/editoast/schemas/src/infra/railjson.rs
@@ -6,6 +6,7 @@ use utoipa::ToSchema;
 use super::BufferStop;
 use super::Detector;
 use super::Electrification;
+use super::LevelCrossing;
 use super::NeutralSection;
 use super::OperationalPoint;
 use super::Route;
@@ -47,6 +48,8 @@ pub struct RailJson {
     pub buffer_stops: Vec<BufferStop>,
     /// `Detector` is a device that identifies the presence of a train in a TVD section (Track Vacancy Detection section), indicating when a track area is occupied.
     pub detectors: Vec<Detector>,
+    /// `LevelCrossing` is an intersections where a railway line crosses a road
+    pub level_crossings: Vec<LevelCrossing>,
 }
 
 pub fn major_version(version: &str) -> &str {

--- a/editoast/src/models/infra.rs
+++ b/editoast/src/models/infra.rs
@@ -306,6 +306,7 @@ pub mod tests {
     use schemas::infra::BufferStop;
     use schemas::infra::Detector;
     use schemas::infra::Electrification;
+    use schemas::infra::LevelCrossing;
     use schemas::infra::NeutralSection;
     use schemas::infra::OperationalPoint;
     use schemas::infra::RAILJSON_VERSION;
@@ -409,6 +410,7 @@ pub mod tests {
             signals: (0..10).map(|_| Default::default()).collect(),
             detectors: (0..10).map(|_| Default::default()).collect(),
             operational_points: (0..10).map(|_| Default::default()).collect(),
+            level_crossings: (0..10).map(|_| Default::default()).collect(),
             version: RAILJSON_VERSION.to_string(),
         };
 
@@ -473,6 +475,10 @@ pub mod tests {
         assert_eq!(
             sort::<OperationalPoint>(find_all_schemas(&mut db_pool.get_ok(), id).await.unwrap()),
             sort(railjson.operational_points)
+        );
+        assert_eq!(
+            sort::<LevelCrossing>(find_all_schemas(&mut db_pool.get_ok(), id).await.unwrap()),
+            sort(railjson.level_crossings)
         );
     }
 }

--- a/editoast/src/models/railjson.rs
+++ b/editoast/src/models/railjson.rs
@@ -40,6 +40,7 @@ pub async fn persist_railjson(
         speed_sections,
         extended_switch_types,
         neutral_sections,
+        level_crossings,
     } = railjson;
 
     if major_version(&version) != major_version(RAILJSON_VERSION) {
@@ -117,6 +118,12 @@ pub async fn persist_railjson(
                 let _ = NeutralSectionModel::create_batch::<_, Vec<_>>(
                     &mut conn.clone(),
                     NeutralSectionModel::from_infra_schemas(infra_id, neutral_sections),
+                )
+                .await?;
+
+                let _ = LevelCrossingModel::create_batch::<_, Vec<_>>(
+                    &mut conn.clone(),
+                    LevelCrossingModel::from_infra_schemas(infra_id, level_crossings),
                 )
                 .await?;
 

--- a/editoast/src/views/infra/railjson.rs
+++ b/editoast/src/views/infra/railjson.rs
@@ -108,6 +108,7 @@ pub(in crate::views) async fn get_railjson(
             "buffer_stops": {buffer_stops},
             "routes": {routes},
             "operational_points": {operational_points},
+            "level_crossings": {level_crossings},
             "electrifications": {electrifications},
             "neutral_sections": {neutral_sections}
         }}"#,
@@ -121,6 +122,7 @@ pub(in crate::views) async fn get_railjson(
         buffer_stops = res[ObjectType::BufferStop],
         routes = res[ObjectType::Route],
         operational_points = res[ObjectType::OperationalPoint],
+        level_crossings = res[ObjectType::LevelCrossing],
         electrifications = res[ObjectType::Electrification],
         neutral_sections = res[ObjectType::NeutralSection]
     );

--- a/front/public/locales/en/infraEditor.json
+++ b/front/public/locales/en/infraEditor.json
@@ -254,6 +254,49 @@
   "FlagSignalParameter": {
     "title": "Flag signal parameter"
   },
+  "LevelCrossing": {
+    "description": "This class describes the level crossings of the corresponding infra.",
+    "properties": {
+      "id": {
+        "description": "Unique identifier of the object",
+        "title": "Id"
+      },
+      "name": {
+        "description": "Name of the level crossing",
+        "title": "Name"
+      },
+      "parts": {
+        "title": "Parts"
+      },
+      "short_zone_length": {
+        "description": "Length of the short zone in mm",
+        "title": "Short zone length"
+      }
+    },
+    "title": "Level crossing"
+  },
+  "LevelCrossingPart": {
+    "description": "Level crossing part is a single point on the infrastructure.\nIt holds information about pedal offsets relative to this point.\nIt's linked to a level crossing.",
+    "properties": {
+      "pedal_downstream": {
+        "description": "Offset in mm of the downstream pedal from the main position",
+        "title": "Pedal downstream"
+      },
+      "pedal_upstream": {
+        "description": "Offset in mm of the upstream pedal from the main position",
+        "title": "Pedal upstream"
+      },
+      "position": {
+        "description": "Offset of the point in meters to the beginning of the track section",
+        "title": "Position"
+      },
+      "track": {
+        "description": "Reference to the track section on which the object is located",
+        "title": "Track"
+      }
+    },
+    "title": "Level crossing part"
+  },
   "LimitedLogicalSignal": {
     "description": "Limited list of logical signals. Used to generate a usable schema for the front editor",
     "title": "Limited logical signal"
@@ -953,6 +996,10 @@
     "extended_switch_types": {
       "description": "Switch types of the infra that can be added by the user",
       "title": "Extended switch types"
+    },
+    "level_crossings": {
+      "description": "List of level crossings of the corresponding infra",
+      "title": "Level crossings"
     },
     "neutral_sections": {
       "description": "Neutral sections of the infra",

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -3013,6 +3013,21 @@ export type SwitchType = {
   id: string;
   ports: string[];
 };
+export type LevelCrossingPart = {
+  /** Offset in mm of the downstream pedal from the main position (downstream refers to the START_TO_STOP direction of the track) */
+  pedal_downstream: number;
+  /** Offset in mm of the upstream pedal from the main position (upstream refers to the START_TO_STOP direction of the track) */
+  pedal_upstream: number;
+  position: number;
+  track: string;
+};
+export type LevelCrossing = {
+  id: string;
+  name: string;
+  parts: LevelCrossingPart[];
+  /** Short zone length in mm */
+  short_zone_length: number;
+};
 export type Direction = 'START_TO_STOP' | 'STOP_TO_START';
 export type DirectionalTrackRange = {
   begin: number;
@@ -3214,6 +3229,8 @@ export type RailJson = {
   electrifications: Electrification[];
   /** These define the types of switches available for route management. */
   extended_switch_types: SwitchType[];
+  /** `LevelCrossing` is an intersections where a railway line crosses a road */
+  level_crossings: LevelCrossing[];
   /** `NeutralSections` are designated areas of rail infrastructure where train drivers are instructed to cut the power supply to the train, primarily for safety reasons. */
   neutral_sections: NeutralSection[];
   /** Operational point is also known in French as "Point Remarquable" (PR). One `OperationalPoint` is a **collection** of points (`OperationalPointParts`) of interest. */
@@ -3230,21 +3247,6 @@ export type RailJson = {
   track_sections: TrackSection[];
   /** The version of the RailJSON format. Defaults to the current version. */
   version: string;
-};
-export type LevelCrossingPart = {
-  /** Offset in mm of the downstream pedal from the main position (downstream refers to the START_TO_STOP direction of the track) */
-  pedal_downstream: number;
-  /** Offset in mm of the upstream pedal from the main position (upstream refers to the START_TO_STOP direction of the track) */
-  pedal_upstream: number;
-  position: number;
-  track: string;
-};
-export type LevelCrossing = {
-  id: string;
-  name: string;
-  parts: LevelCrossingPart[];
-  /** Short zone length in mm */
-  short_zone_length: number;
 };
 export type InfraObject =
   | {

--- a/front/src/reducers/osrdconf/infra_schema.json
+++ b/front/src/reducers/osrdconf/infra_schema.json
@@ -482,6 +482,83 @@
             "title": "FlagSignalParameter",
             "type": "string"
         },
+        "LevelCrossing": {
+            "description": "This class describes the level crossings of the corresponding infra.",
+            "properties": {
+                "id": {
+                    "description": "Unique identifier of the object",
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Name of the level crossing",
+                    "minLength": 1,
+                    "title": "Name",
+                    "type": "string"
+                },
+                "parts": {
+                    "items": {
+                        "$ref": "#/$defs/LevelCrossingPart"
+                    },
+                    "title": "Parts",
+                    "type": "array"
+                },
+                "short_zone_length": {
+                    "description": "Length of the short zone in mm",
+                    "minimum": 0,
+                    "title": "Short Zone Length",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "id",
+                "name",
+                "short_zone_length",
+                "parts"
+            ],
+            "title": "LevelCrossing",
+            "type": "object"
+        },
+        "LevelCrossingPart": {
+            "description": "Level crossing part is a single point on the infrastructure.\nIt holds information about pedal offsets relative to this point.\nIt's linked to a level crossing.",
+            "properties": {
+                "pedal_downstream": {
+                    "description": "Offset in mm of the downstream pedal from the main position",
+                    "minimum": 0,
+                    "title": "Pedal Downstream",
+                    "type": "integer"
+                },
+                "pedal_upstream": {
+                    "description": "Offset in mm of the upstream pedal from the main position",
+                    "minimum": 0,
+                    "title": "Pedal Upstream",
+                    "type": "integer"
+                },
+                "position": {
+                    "description": "Offset of the point in meters to the beginning of the track section",
+                    "minimum": 0,
+                    "title": "Position",
+                    "type": "number"
+                },
+                "track": {
+                    "description": "Reference to the track section on which the object is located",
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "title": "Track",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "track",
+                "position",
+                "pedal_upstream",
+                "pedal_downstream"
+            ],
+            "title": "LevelCrossingPart",
+            "type": "object"
+        },
         "LimitedLogicalSignal": {
             "description": "Limited list of logical signals. Used to generate a usable schema for the front editor",
             "discriminator": {
@@ -2004,6 +2081,14 @@
             "title": "Extended Switch Types",
             "type": "array"
         },
+        "level_crossings": {
+            "description": "List of level crossings of the corresponding infra",
+            "items": {
+                "$ref": "#/$defs/LevelCrossing"
+            },
+            "title": "Level Crossings",
+            "type": "array"
+        },
         "neutral_sections": {
             "description": "Neutral sections of the infra",
             "items": {
@@ -2061,8 +2146,8 @@
             "type": "array"
         },
         "version": {
-            "const": "3.4.13",
-            "default": "3.4.13",
+            "const": "3.5.0",
+            "default": "3.5.0",
             "description": "Version of the schema",
             "title": "Version",
             "type": "string"
@@ -2070,6 +2155,7 @@
     },
     "required": [
         "operational_points",
+        "level_crossings",
         "routes",
         "switches",
         "track_sections",

--- a/python/osrd_schemas/osrd_schemas/infra.py
+++ b/python/osrd_schemas/osrd_schemas/infra.py
@@ -8,7 +8,7 @@ from pydantic.fields import FieldInfo
 
 ALL_OBJECT_TYPES = []
 
-RAILJSON_INFRA_VERSION_TYPE = Literal["3.4.13"]
+RAILJSON_INFRA_VERSION_TYPE = Literal["3.5.0"]
 RAILJSON_INFRA_VERSION = get_args(RAILJSON_INFRA_VERSION_TYPE)[0]
 
 # Traits
@@ -599,6 +599,9 @@ class RailJsonInfra(BaseModel):
     )
     operational_points: List[OperationalPoint] = Field(
         description="List of operational points of the corresponding infra"
+    )
+    level_crossings: List[LevelCrossing] = Field(
+        description="List of level crossings of the corresponding infra"
     )
     routes: List[Route] = Field(description="Routes of the infra")
     extended_switch_types: List[SwitchType] = Field(

--- a/python/osrd_schemas/pyproject.toml
+++ b/python/osrd_schemas/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "osrd_schemas"
-version = "0.10.1"
+version = "0.11.0"
 description = ""
 authors = [{ name = "OSRD Contributors", email = "contact@osrd.fr" }]
 requires-python = ">= 3.11"

--- a/python/osrd_schemas/uv.lock
+++ b/python/osrd_schemas/uv.lock
@@ -34,7 +34,7 @@ wheels = [
 
 [[package]]
 name = "osrd-schemas"
-version = "0.10.1"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "geojson-pydantic" },

--- a/python/railjson_generator/README.md
+++ b/python/railjson_generator/README.md
@@ -27,6 +27,7 @@ uv run -m railjson_generator ../../tests/data/infras ../../tests/infra-scripts/*
 
 - `__init__(self) -> InfraBuilder`: Instantiates an infra builder.
 - `add_track_section(self, length, label="track.X", waypoints=[], signals=[], operational_points=[]) -> TrackSection`: Add a track section.
+- `add_level_crossing(self, id, name="lc.X", short_zone_length=1000) -> LevelCrossing`: Add a level crossing.
 - `add_point_switch(self, base, left, right, label="switch.X", delay=0) -> Switch`: Add a point.
 - `add_crossing(self, north, south, east, west, label="switch.X", delay=0) -> Switch`: Add a cross switch.
 - `add_double_slip_switch(self, north_1, north_2, south_1, south_2, label="switch.X", delay=0) -> Switch`: Add a double cross switch.
@@ -66,6 +67,10 @@ Route can either be manually created, or generated using `generate_routes`, and 
 ### Operation point
 
 - `add_part(self, track, offset)`: Link an operational point to a position.
+
+### Level crossing
+
+- `add_part(self, track, position, pedal_upstream, pedal_downstream)`: Add a part to a level crossing.
 
 ### Infra
 

--- a/python/railjson_generator/pyproject.toml
+++ b/python/railjson_generator/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "railjson_generator"
-version = "0.4.13"
+version = "0.5.0"
 description = ""
 authors = [{ name = "OSRD Contributors", email = "contact@osrd.fr" }]
 requires-python = ">= 3.11"

--- a/python/railjson_generator/railjson_generator/infra_builder.py
+++ b/python/railjson_generator/railjson_generator/infra_builder.py
@@ -5,6 +5,7 @@ from .schema.infra.endpoint import TrackEndpoint
 from .schema.infra.infra import BufferStop, Infra, Switch, Detector
 from .schema.infra.neutral_section import NeutralSection
 from .schema.infra.operational_point import OperationalPoint
+from .schema.infra.level_crossing import LevelCrossing
 from .schema.infra.route import Route
 from .schema.infra.speed_section import SpeedSection
 from .schema.infra.switch import (
@@ -85,6 +86,16 @@ class InfraBuilder:
         _register_connection(base, right, switch.group("A_B2"))
         self.infra.switches.append(switch)
         return switch
+
+    def add_level_crossing(
+        self, id: str, name: str, short_zone_length: int
+    ) -> LevelCrossing:
+        """Build a level crossing, add it to the infra, and return it."""
+        lc = LevelCrossing(
+            id=id, name=name, short_zone_length=short_zone_length, parts=[]
+        )
+        self.infra.level_crossings.append(lc)
+        return lc
 
     def add_crossing(
         self,

--- a/python/railjson_generator/railjson_generator/schema/infra/infra.py
+++ b/python/railjson_generator/railjson_generator/schema/infra/infra.py
@@ -7,6 +7,7 @@ from osrd_schemas import infra
 from railjson_generator.schema.infra.electrification import Electrification
 from railjson_generator.schema.infra.neutral_section import NeutralSection
 from railjson_generator.schema.infra.operational_point import OperationalPoint
+from railjson_generator.schema.infra.level_crossing import LevelCrossing
 from railjson_generator.schema.infra.route import Route
 from railjson_generator.schema.infra.speed_section import SpeedSection
 from railjson_generator.schema.infra.switch import Switch
@@ -19,12 +20,13 @@ class Infra:
     track_sections: List[TrackSection] = field(default_factory=list)
     switches: List[Switch] = field(default_factory=list)
     operational_points: List[OperationalPoint] = field(default_factory=list)
+    level_crossings: List[LevelCrossing] = field(default_factory=list)
     routes: List[Route] = field(default_factory=list)
     speed_sections: List[SpeedSection] = field(default_factory=list)
     electrifications: List[Electrification] = field(default_factory=list)
     neutral_sections: List[NeutralSection] = field(default_factory=list)
 
-    VERSION = "3.4.13"
+    VERSION = "3.5.0"
 
     def add_route(self, *args, **kwargs):
         self.routes.append(Route(*args, **kwargs))
@@ -40,6 +42,7 @@ class Infra:
             buffer_stops=list(self.make_rjs_buffer_stops()),
             detectors=list(self.make_rjs_detectors()),
             operational_points=self.make_rjs_operational_points(),
+            level_crossings=[lc.to_rjs() for lc in self.level_crossings],
             extended_switch_types=[],
             speed_sections=[
                 speed_section.to_rjs() for speed_section in self.speed_sections

--- a/python/railjson_generator/railjson_generator/schema/infra/level_crossing.py
+++ b/python/railjson_generator/railjson_generator/schema/infra/level_crossing.py
@@ -1,0 +1,47 @@
+from dataclasses import dataclass
+from typing import List
+
+from osrd_schemas import infra
+
+
+@dataclass
+class LevelCrossingPart:
+    pedal_upstream: int
+    pedal_downstream: int
+    position: float
+    track: str
+
+    def to_rjs(self):
+        return infra.LevelCrossingPart(
+            track=self.track,
+            position=self.position,
+            pedal_upstream=self.pedal_upstream,
+            pedal_downstream=self.pedal_downstream,
+        )
+
+
+@dataclass
+class LevelCrossing:
+    id: str
+    name: str
+    short_zone_length: int
+    parts: List[LevelCrossingPart]
+
+    def add_part(
+        self, track: str, position: float, pedal_upstream: int, pedal_downstream: int
+    ):
+        part = LevelCrossingPart(
+            track=track,
+            position=position,
+            pedal_upstream=pedal_upstream,
+            pedal_downstream=pedal_downstream,
+        )
+        self.parts.append(part)
+
+    def to_rjs(self):
+        return infra.LevelCrossing(
+            id=self.id,
+            name=self.name,
+            short_zone_length=self.short_zone_length,
+            parts=[part.to_rjs() for part in self.parts],
+        )

--- a/python/railjson_generator/uv.lock
+++ b/python/railjson_generator/uv.lock
@@ -106,7 +106,7 @@ wheels = [
 
 [[package]]
 name = "osrd-schemas"
-version = "0.10.1"
+version = "0.11.0"
 source = { editable = "../osrd_schemas" }
 dependencies = [
     { name = "geojson-pydantic" },
@@ -295,7 +295,7 @@ wheels = [
 
 [[package]]
 name = "railjson-generator"
-version = "0.4.13"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "osrd-schemas" },

--- a/tests/data/infras/circle_infra/infra.json
+++ b/tests/data/infras/circle_infra/infra.json
@@ -1,6 +1,7 @@
 {
-    "version": "3.4.13",
+    "version": "3.5.0",
     "operational_points": [],
+    "level_crossings": [],
     "routes": [],
     "extended_switch_types": [],
     "switches": [

--- a/tests/data/infras/etcs_infra/infra.json
+++ b/tests/data/infras/etcs_infra/infra.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.4.13",
+    "version": "3.5.0",
     "operational_points": [
         {
             "id": "West_station",
@@ -216,6 +216,52 @@
                     "uic": 8788
                 }
             }
+        }
+    ],
+    "level_crossings": [
+        {
+            "id": "lc1",
+            "name": "LC1",
+            "short_zone_length": 2000,
+            "parts": [
+                {
+                    "track": "TB0",
+                    "position": 750.0,
+                    "pedal_upstream": 4000,
+                    "pedal_downstream": 4000
+                }
+            ]
+        },
+        {
+            "id": "lc2",
+            "name": "LC2",
+            "short_zone_length": 1500,
+            "parts": [
+                {
+                    "track": "TC0",
+                    "position": 125.0,
+                    "pedal_upstream": 4000,
+                    "pedal_downstream": 6000
+                },
+                {
+                    "track": "TC1",
+                    "position": 120.0,
+                    "pedal_upstream": 5000,
+                    "pedal_downstream": 5000
+                },
+                {
+                    "track": "TC2",
+                    "position": 110.0,
+                    "pedal_upstream": 5000,
+                    "pedal_downstream": 5000
+                },
+                {
+                    "track": "TC3",
+                    "position": 115.0,
+                    "pedal_upstream": 6000,
+                    "pedal_downstream": 6000
+                }
+            ]
         }
     ],
     "routes": [

--- a/tests/data/infras/example_script/infra.json
+++ b/tests/data/infras/example_script/infra.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.4.13",
+    "version": "3.5.0",
     "operational_points": [
         {
             "id": "my-op",
@@ -29,6 +29,7 @@
             }
         }
     ],
+    "level_crossings": [],
     "routes": [
         {
             "id": "rt.Custom Buffer Stop->detector.5",

--- a/tests/data/infras/medium_infra/infra.json
+++ b/tests/data/infras/medium_infra/infra.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.4.13",
+    "version": "3.5.0",
     "operational_points": [
         {
             "id": "North_West_station",
@@ -264,6 +264,7 @@
             }
         }
     ],
+    "level_crossings": [],
     "routes": [
         {
             "id": "rt.buffer_stop.0->DI0",

--- a/tests/data/infras/nested_switches/infra.json
+++ b/tests/data/infras/nested_switches/infra.json
@@ -1,6 +1,7 @@
 {
-    "version": "3.4.13",
+    "version": "3.5.0",
     "operational_points": [],
+    "level_crossings": [],
     "routes": [
         {
             "id": "BS1 -> DETECTOR",

--- a/tests/data/infras/one_line/infra.json
+++ b/tests/data/infras/one_line/infra.json
@@ -1,6 +1,7 @@
 {
-    "version": "3.4.13",
+    "version": "3.5.0",
     "operational_points": [],
+    "level_crossings": [],
     "routes": [
         {
             "id": "rt.buffer_stop.0->detector.0",

--- a/tests/data/infras/overlapping_routes/infra.json
+++ b/tests/data/infras/overlapping_routes/infra.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.4.13",
+    "version": "3.5.0",
     "operational_points": [
         {
             "id": "op.a1",
@@ -94,6 +94,7 @@
             }
         }
     ],
+    "level_crossings": [],
     "routes": [
         {
             "id": "rt.bf.a1->det.a1.nf",

--- a/tests/data/infras/small_infra/infra.json
+++ b/tests/data/infras/small_infra/infra.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.4.13",
+    "version": "3.5.0",
     "operational_points": [
         {
             "id": "West_station",
@@ -216,6 +216,52 @@
                     "uic": 8788
                 }
             }
+        }
+    ],
+    "level_crossings": [
+        {
+            "id": "lc1",
+            "name": "LC1",
+            "short_zone_length": 2000,
+            "parts": [
+                {
+                    "track": "TB0",
+                    "position": 750.0,
+                    "pedal_upstream": 4000,
+                    "pedal_downstream": 4000
+                }
+            ]
+        },
+        {
+            "id": "lc2",
+            "name": "LC2",
+            "short_zone_length": 1500,
+            "parts": [
+                {
+                    "track": "TC0",
+                    "position": 125.0,
+                    "pedal_upstream": 4000,
+                    "pedal_downstream": 6000
+                },
+                {
+                    "track": "TC1",
+                    "position": 120.0,
+                    "pedal_upstream": 5000,
+                    "pedal_downstream": 5000
+                },
+                {
+                    "track": "TC2",
+                    "position": 110.0,
+                    "pedal_upstream": 5000,
+                    "pedal_downstream": 5000
+                },
+                {
+                    "track": "TC3",
+                    "position": 115.0,
+                    "pedal_upstream": 6000,
+                    "pedal_downstream": 6000
+                }
+            ]
         }
     ],
     "routes": [

--- a/tests/data/infras/takeover/infra.json
+++ b/tests/data/infras/takeover/infra.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.4.13",
+    "version": "3.5.0",
     "operational_points": [
         {
             "id": "op.start",
@@ -94,6 +94,7 @@
             }
         }
     ],
+    "level_crossings": [],
     "routes": [
         {
             "id": "rt.bf.1->det.takeover.start.1",

--- a/tests/data/infras/three_trains/infra.json
+++ b/tests/data/infras/three_trains/infra.json
@@ -1,6 +1,7 @@
 {
-    "version": "3.4.13",
+    "version": "3.5.0",
     "operational_points": [],
+    "level_crossings": [],
     "routes": [
         {
             "id": "rt.buffer_stop.0->buffer_stop.4",

--- a/tests/data/infras/tiny_infra/infra.json
+++ b/tests/data/infras/tiny_infra/infra.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.4.13",
+    "version": "3.5.0",
     "operational_points": [
         {
             "id": "op.station_foo",
@@ -52,6 +52,7 @@
             }
         }
     ],
+    "level_crossings": [],
     "routes": [
         {
             "id": "rt.buffer_stop_a->tde.foo_a-switch_foo",

--- a/tests/data/infras/y_infra/infra.json
+++ b/tests/data/infras/y_infra/infra.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.4.13",
+    "version": "3.5.0",
     "operational_points": [
         {
             "id": "op.a",
@@ -71,6 +71,7 @@
             }
         }
     ],
+    "level_crossings": [],
     "routes": [
         {
             "id": "rt.bf.a->det.a3",

--- a/tests/infra-scripts/small_infra_creator/__init__.py
+++ b/tests/infra-scripts/small_infra_creator/__init__.py
@@ -676,6 +676,19 @@ def create_small_infra(signaling_system: str) -> ScenarioData:
         ta0, 1990, 2000, Direction.STOP_TO_START
     )
     keep_pantograph_section_4.add_track_range(ta0, 1850, 1990, Direction.STOP_TO_START)
+
+    # ================================
+    # Add level crossings
+    # ================================
+    lc1 = builder.add_level_crossing(id="lc1", name="LC1", short_zone_length=2000)
+    lc1.add_part(tb0.label, tb0.length / 4, pedal_upstream=4000, pedal_downstream=4000)
+
+    lc2 = builder.add_level_crossing(id="lc2", name="LC2", short_zone_length=1500)
+    lc2.add_part(tc0.label, 125, pedal_upstream=4000, pedal_downstream=6000)
+    lc2.add_part(tc1.label, 120, pedal_upstream=5000, pedal_downstream=5000)
+    lc2.add_part(tc2.label, 110, pedal_upstream=5000, pedal_downstream=5000)
+    lc2.add_part(tc3.label, 115, pedal_upstream=6000, pedal_downstream=6000)
+
     # ================================
     # Produce the railjson
     # ================================


### PR DESCRIPTION
fix #14252 fix #14222

This Pr add level crossing to railjson_generator and import/export of infra

- [x] Add level crossing python types to railjson_generator
- [x] Add level crossing builder function to railjson_generator
- [x] Add some examples of level crossing to small_infra
- [x] Add level crossing types to editoast import and export of infra
- [x] Bump railjson version to 4.5.0
