### PR TITLE
core: save relevant request metadata in s3 storage

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -99,6 +99,9 @@ dependencies {
 
     // redis
     implementation libs.lettuce
+
+    // s3
+    implementation libs.s3
 }
 // endregion
 

--- a/core/gradle/libs.versions.toml
+++ b/core/gradle/libs.versions.toml
@@ -68,6 +68,7 @@ kaml = { module = 'com.charleskorn.kaml:kaml', version = '0.104.0' } # Apache 2.
 
 amqp-client = { module = 'com.rabbitmq:amqp-client', version = '5.28.0' }
 lettuce = { module = 'io.lettuce:lettuce-core', version = '7.2.1.RELEASE' } # MIT
+s3 = { module = 'software.amazon.awssdk:s3', version = '2.41.1' } # Apache 2.0
 
 [plugins]
 # kotlin

--- a/core/src/main/java/fr/sncf/osrd/api/S3Context.kt
+++ b/core/src/main/java/fr/sncf/osrd/api/S3Context.kt
@@ -1,0 +1,66 @@
+package fr.sncf.osrd.api
+
+import io.opentelemetry.api.trace.Span
+import java.net.URI
+import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.S3Configuration
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
+
+data class S3Context(val s3Client: S3Client, val bucketName: String) {
+    /** Write a new file for a given stdcm request. */
+    fun writeSTDCMFile(fileName: String, content: String) {
+        val traceId = Span.current().spanContext.traceId
+        val putObjectRequest =
+            PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key("stdcm/requests/$traceId/$fileName")
+                .build()
+
+        s3Client.putObject(putObjectRequest, RequestBody.fromString(content))
+    }
+
+    /**
+     * Write a new file for a given stdcm request, with a dedicated function to generate the
+     * content. Used for safe call syntax (?.) that doesn't generate the data if the S3Context is
+     * null
+     */
+    fun writeSTDCMFile(fileName: String, generateContent: () -> String) {
+        writeSTDCMFile(fileName, generateContent())
+    }
+
+    /** Returns true if the file exists. */
+    fun fileExists(fileName: String): Boolean {
+        return try {
+            val headRequest = HeadObjectRequest.builder().bucket(bucketName).key(fileName).build()
+            s3Client.headObject(headRequest)
+            true
+        } catch (_: NoSuchKeyException) {
+            false
+        }
+    }
+}
+
+/** Returns an S3 context (client + bucket name), or null if the env variables aren't set. */
+fun makeS3Context(): S3Context? {
+    val url = System.getenv("AWS_ENDPOINT_URL_S3") ?: return null
+    val bucket = System.getenv("BUCKET_NAME") ?: return null
+    if (url == "" || bucket == "") return null
+
+    val s3Config =
+        S3Configuration.builder().chunkedEncodingEnabled(false).pathStyleAccessEnabled(true).build()
+
+    val s3Client =
+        S3Client.builder()
+            // A region needs to be set, but it's not used with an endpoint override
+            .region(Region.EU_WEST_1)
+            .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
+            .endpointOverride(URI.create(url))
+            .serviceConfiguration(s3Config)
+            .build()
+    return S3Context(s3Client, bucket)
+}

--- a/core/src/main/java/fr/sncf/osrd/api/TimetableCacheManager.kt
+++ b/core/src/main/java/fr/sncf/osrd/api/TimetableCacheManager.kt
@@ -6,6 +6,7 @@ import com.google.common.collect.RangeSet
 import com.google.common.collect.TreeRangeSet
 import fr.sncf.osrd.sim_infra.api.ZoneId
 import io.lettuce.core.api.StatefulRedisConnection
+import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.annotations.WithSpan
 import java.nio.file.Files
@@ -25,6 +26,8 @@ import kotlinx.serialization.cbor.Cbor
 import kotlinx.serialization.decodeFromHexString
 import kotlinx.serialization.encodeToHexString
 import org.slf4j.LoggerFactory
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
 
 typealias TimetableId = Int
 
@@ -79,6 +82,7 @@ class TimetableCacheManager(
     val valkeyConnection: StatefulRedisConnection<String, String>? = null,
     val disableAllCaching: Boolean = false,
     val osrdGitDescribe: String,
+    val s3Context: S3Context? = null,
 ) {
     private val cache = ConcurrentHashMap<String, STDCMTimetableData>()
     private val mutexes = ConcurrentHashMap<String, Mutex>()
@@ -95,6 +99,7 @@ class TimetableCacheManager(
     suspend fun get(infra: FullInfra, timetableId: TimetableId): STDCMTimetableData =
         coroutineScope {
             val cacheKey = getCacheKey(infra, timetableId)
+            Span.current()?.setAttribute("timetable-cache-key", cacheKey)
             if (disableAllCaching) {
                 logger.info("Cache disabled")
                 return@coroutineScope withContext(fetchDispatcher) {
@@ -161,6 +166,10 @@ class TimetableCacheManager(
                     )
                 }
             }
+
+        // Once the requirements are loaded, we save them to s3 as well for reproducibility
+        saveToS3(cacheKey, requirements)
+
         return requirements
     }
 
@@ -259,5 +268,23 @@ class TimetableCacheManager(
         val data = generateData()
         writeCacheToValkey(valkeyConnection, key, data)
         return data
+    }
+
+    /** If there's no file yet with the given cache key, save the timetable in the s3 storage. */
+    private fun saveToS3(cacheKey: String, requirements: STDCMTimetableData) {
+        if (s3Context == null) return
+
+        val objectPath = "stdcm/saved_timetables/$cacheKey.cbor"
+        if (s3Context.fileExists(objectPath)) return
+
+        val putObjectRequest =
+            PutObjectRequest.builder().bucket(s3Context.bucketName).key(objectPath).build()
+
+        val serializable = requirements.toSerializable()
+        val cbor = Cbor {}
+        val serializer = STDCMTimetableData.SerializableMap.serializer()
+        val bytes = cbor.encodeToByteArray(serializer, serializable)
+
+        s3Context.s3Client.putObject(putObjectRequest, RequestBody.fromBytes(bytes))
     }
 }

--- a/core/src/main/java/fr/sncf/osrd/cli/WorkerCommand.kt
+++ b/core/src/main/java/fr/sncf/osrd/cli/WorkerCommand.kt
@@ -133,6 +133,7 @@ class WorkerCommand : CliCommand {
                 valkeyConnection,
                 DISABLE_ALL_TIMETABLE_CACHE,
                 OSRD_GIT_DESCRIBE,
+                s3Context,
             )
         val electricalProfileSetManager =
             ElectricalProfileSetManager(editoastUrl, editoastAuthorization, httpClient)
@@ -155,7 +156,7 @@ class WorkerCommand : CliCommand {
                 "/conflict_detection" to ConflictDetectionEndpoint(infraManager),
                 "/etcs_braking_curves" to
                     ETCSBrakingCurvesEndpoint(infraManager, electricalProfileSetManager),
-                "/stdcm" to STDCMEndpoint(infraManager, timetableCache),
+                "/stdcm" to STDCMEndpoint(infraManager, timetableCache, s3Context),
                 "/worker_load" to WorkerLoadEndpoint(infraManager, timetableCache),
             )
 

--- a/core/src/main/java/fr/sncf/osrd/cli/WorkerCommand.kt
+++ b/core/src/main/java/fr/sncf/osrd/cli/WorkerCommand.kt
@@ -116,6 +116,7 @@ class WorkerCommand : CliCommand {
 
         val httpClient = OkHttpClient.Builder().readTimeout(120, TimeUnit.SECONDS).build()
         val valkeyConnection = VALKEY_URL?.let { RedisClient.create(it).connect() }
+        val s3Context = makeS3Context()
 
         val infraId = WORKER_KEY.split("-").first()
         val timetableId = WORKER_KEY.split("-").getOrNull(1)?.toInt()

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
@@ -70,6 +70,7 @@ import kotlinx.serialization.ExperimentalSerializationApi
 class STDCMEndpoint(
     private val infraManager: InfraProvider,
     private val timetableCacheManager: TimetableCacheManager,
+    private val s3Context: S3Context? = null,
 ) : Take {
     @Throws(OSRDError::class)
     override fun act(req: Request): Response {
@@ -86,6 +87,8 @@ class STDCMEndpoint(
                 it.println(stdcmRequestAdapter.indent("    ").toJson(request))
             }
         }
+
+        s3Context?.writeSTDCMFile("input_payload.json") { stdcmRequestAdapter.toJson(request) }
 
         return run(request)
     }
@@ -190,10 +193,18 @@ class STDCMEndpoint(
         departureTime: ZonedDateTime,
         requirements: Map<ZoneId, List<STDCMTimetableData.DetailedRequirement>>,
     ) {
-        val filename = System.getenv("STDCM_DEBUG_DATA_FILENAME") ?: return
-        val debugData =
-            generateDebugData(infra, path, simulationResponse, departureTime, requirements)
-        File(filename).writeText(OutputSimDebugData.adapter.indent("  ").toJson(debugData))
+        val stringDebugData by lazy {
+            OutputSimDebugData.adapter.toJson(
+                generateDebugData(infra, path, simulationResponse, departureTime, requirements)
+            )
+        }
+
+        val filename = System.getenv("STDCM_DEBUG_DATA_FILENAME")
+        if (filename != null) {
+            File(filename).writeText(stringDebugData)
+        }
+
+        s3Context?.writeSTDCMFile("output_simulation_data.json") { stringDebugData }
     }
 
     /** Build the simulation part of the response */

--- a/core/src/main/resources/logback.xml
+++ b/core/src/main/resources/logback.xml
@@ -6,12 +6,10 @@
         </encoder>
     </appender>
 
-    <logger name="fr.sncf.osrd.utils.graph.BiDijkstra" level="TRACE"/>
-    <logger name="fr.sncf.osrd.train.events.TrainCreatedEvent" level="TRACE"/>
-
     <root level="debug">
         <appender-ref ref="COLOR"/>
     </root>
     <logger name="io.lettuce" level="INFO"/>
     <logger name="io.netty" level="INFO"/>
+    <logger name="software.amazon.awssdk" level="INFO"/>
 </configuration>


### PR DESCRIPTION
Fix https://github.com/OpenRailAssociation/osrd/issues/13988
Also part of https://github.com/osrd-project/osrd-confidential/issues/1298

S3 structure would look like this:

```
osrd/
    - stdcm/
        - requests/
            - trace_id_1/
                - input_payload.json
                - output_simulation_data.json
            - trace_id_2/
                - input_payload.json
            - ...
        - saved_timetables/
            - cache_key.cbor
            - ...
```

Notes:

* `output_simulation_data.json` is only present if the search was successful.
* Timetable cache key is accessible through span attributes. They're made of: git describe, infra id, infra version, timetable id. They contain input data that isn't part of the input payload.
* The .cbor files can only be used by core, but once https://github.com/OpenRailAssociation/osrd/pull/14493 is merged it should include enough metadata to follow along.

Tested locally with RustFS / Jaeger. Not tested on prod environments.

Does not include new script tooling, I'll wait to have a populated S3 in prod environments for that. 