### PR TITLE
editoast: use `ReportTrain` directly in `interpolate_arrival_time()`

### DIFF
--- a/editoast/src/views/level_crossing_occupancy.rs
+++ b/editoast/src/views/level_crossing_occupancy.rs
@@ -21,7 +21,7 @@ use chrono::DateTime;
 use chrono::Duration;
 use chrono::Utc;
 use core_client::pathfinding::TrackRange;
-use core_client::simulation::CompleteReportTrain;
+use core_client::simulation::ReportTrain;
 use database::DbConnection;
 use editoast_derive::EditoastError;
 use editoast_models::prelude::*;
@@ -225,11 +225,11 @@ fn find_level_crossing_occupancy(
     rolling_stock_length: &u64,
 ) -> Option<LevelCrossingOccupancy> {
     // Check simulation results
-    let (final_output, pathfinding_success) = match (simulation, pathfinding) {
+    let (report_train, pathfinding_success) = match (simulation, pathfinding) {
         (
             simulation::Response::Success(SimulationResponseSuccess { final_output, .. }),
             PathfindingResult::Success(pathfinding_success),
-        ) => (final_output, pathfinding_success),
+        ) => (&final_output.report_train, pathfinding_success),
         _ => return None,
     };
 
@@ -250,7 +250,7 @@ fn find_level_crossing_occupancy(
     // Compute the occupancy time window
     let time_window = find_occupancy_time_window(
         &direction,
-        final_output,
+        report_train,
         level_crossing,
         &lc_position,
         &matched_track_offset,
@@ -282,7 +282,7 @@ fn find_level_crossing_intersection(
 
 fn find_occupancy_time_window(
     direction: &Direction,
-    final_output: &CompleteReportTrain,
+    report_train: &ReportTrain,
     level_crossing: &LevelCrossing,
     lc_position: &u64,
     matched_track_offset: &TrackOffset,
@@ -294,15 +294,15 @@ fn find_occupancy_time_window(
 
     // Compute arrival and leaving times
     let lc_end_position = lc_position + level_crossing.short_zone_length + rolling_stock_length;
-    let last_train_position = *final_output.report_train.positions.last()?;
+    let last_train_position = *report_train.positions.last()?;
 
     // Check whether the train completely leaves the short zone; ignore it otherwise.
     if lc_end_position > last_train_position {
         return None;
     }
 
-    let arrival_time = interpolate_arrival_time(pedal_position, final_output);
-    let leaving_time = interpolate_arrival_time(lc_end_position, final_output);
+    let arrival_time = interpolate_arrival_time(pedal_position, report_train);
+    let leaving_time = interpolate_arrival_time(lc_end_position, report_train);
 
     Some(TimeWindow {
         time_begin: start_time + Duration::milliseconds(arrival_time),

--- a/editoast/src/views/projection.rs
+++ b/editoast/src/views/projection.rs
@@ -3,6 +3,7 @@ use core_client::CoreClient;
 use core_client::pathfinding::TrackRange;
 use core_client::pathfinding::TrainPath;
 use core_client::simulation::CompleteReportTrain;
+use core_client::simulation::ReportTrain;
 use core_client::simulation::SignalCriticalPosition;
 use core_client::simulation::ZoneUpdate;
 use database::DbConnection;
@@ -326,16 +327,16 @@ pub fn linear_interpolate(a_x: u64, b_x: u64, a_y: u64, b_y: u64, x: u64) -> u64
 ///
 /// This function finds the position in the train's trajectory and interpolates
 /// the arrival time based on the surrounding positions and times.
-pub fn interpolate_arrival_time(position: u64, final_output: &CompleteReportTrain) -> i64 {
-    let index = find_index_upper(&final_output.report_train.positions, position);
+pub fn interpolate_arrival_time(position: u64, report_train: &ReportTrain) -> i64 {
+    let index = find_index_upper(&report_train.positions, position);
     let time = if index == 0 {
-        final_output.report_train.times[0]
+        report_train.times[0]
     } else {
         linear_interpolate(
-            final_output.report_train.positions[index - 1],
-            final_output.report_train.positions[index],
-            final_output.report_train.times[index - 1],
-            final_output.report_train.times[index],
+            report_train.positions[index - 1],
+            report_train.positions[index],
+            report_train.times[index - 1],
+            report_train.times[index],
             position,
         )
     };
@@ -783,7 +784,6 @@ mod tests {
     use super::*;
     use crate::models::fixtures::create_small_infra;
     use crate::views::test_app::TestAppBuilder;
-    use core_client::simulation::ReportTrain;
     use rstest::rstest;
     use schemas::infra::Direction;
     use schemas::infra::DirectionalTrackRange;
@@ -840,12 +840,7 @@ mod tests {
             path_item_times: vec![],
         };
 
-        let final_output = CompleteReportTrain {
-            report_train,
-            ..Default::default()
-        };
-
-        let result = interpolate_arrival_time(position, &final_output);
+        let result = interpolate_arrival_time(position, &report_train);
 
         assert_eq!(result, expected_time);
     }

--- a/editoast/src/views/timetable/track_occupancy.rs
+++ b/editoast/src/views/timetable/track_occupancy.rs
@@ -1,6 +1,6 @@
 use chrono::Duration;
 use core_client::pathfinding::PathfindingResultSuccess;
-use core_client::simulation::CompleteReportTrain;
+use core_client::simulation::ReportTrain;
 use schemas::infra::TrackOffset;
 use schemas::primitives::TimeWindow;
 use schemas::train_schedule::PathItem;
@@ -22,7 +22,7 @@ pub(super) struct TrackOccupancy {
 
 /// Structure holding extracted data needed for track occupancy computation
 struct OccupancyContext<'a> {
-    final_output: Option<&'a CompleteReportTrain>,
+    report_train: Option<&'a ReportTrain>,
     pathfinding_success: Option<&'a PathfindingResultSuccess>,
     matching_index: Option<usize>,
     schedule_item: Option<&'a ScheduleItem>,
@@ -53,9 +53,9 @@ fn extract_occupancy_context<'a>(
     pathfinding: &'a PathfindingResult,
     train_schedule: &'a schemas::TrainSchedule,
 ) -> OccupancyContext<'a> {
-    let final_output = match simulation {
+    let report_train = match simulation {
         simulation::Response::Success(SimulationResponseSuccess { final_output, .. }) => {
-            Some(final_output)
+            Some(&final_output.report_train)
         }
         _ => None,
     };
@@ -76,7 +76,7 @@ fn extract_occupancy_context<'a>(
     });
 
     OccupancyContext {
-        final_output,
+        report_train,
         pathfinding_success,
         matching_index,
         schedule_item,
@@ -93,8 +93,8 @@ fn get_arrival_time(
             .then_some(0)
             .or_else(|| {
                 context
-                    .final_output
-                    .map(|output| output.report_train.path_item_times[idx] as i64)
+                    .report_train
+                    .map(|report_train| report_train.path_item_times[idx] as i64)
             })
             .or_else(|| {
                 context
@@ -103,8 +103,8 @@ fn get_arrival_time(
                     .map(|a| a.num_milliseconds())
             });
     }
-    if let (Some(final_output), Some(pathfinding_success)) =
-        (context.final_output, context.pathfinding_success)
+    if let (Some(report_train), Some(pathfinding_success)) =
+        (context.report_train, context.pathfinding_success)
     {
         let path_projection = PathProjection::new(&pathfinding_success.path.track_section_ranges);
         return operational_point_track_offsets
@@ -112,7 +112,7 @@ fn get_arrival_time(
             .find_map(|track_offset| {
                 path_projection
                     .get_position(track_offset)
-                    .map(|position| interpolate_arrival_time(position, final_output))
+                    .map(|position| interpolate_arrival_time(position, report_train))
             });
     }
     None
@@ -204,6 +204,7 @@ pub mod tests {
     use chrono::DateTime;
     use core_client::pathfinding::PathfindingNotFound;
     use core_client::pathfinding::TrackRange;
+    use core_client::simulation::CompleteReportTrain;
     use core_client::simulation::ReportTrain;
     use pretty_assertions::assert_eq;
     use reqwest::StatusCode;


### PR DESCRIPTION
Use `ReportTrain` instead of `CompleteReportTrain` in `interpolate_arrival_time`.
Adapt `track_occupancy.rs`and `level_crossing_occupancy.rs` accordingly.