### PR TITLE
ui-core: Adjust checkbox label position and limit input modal container width

### DIFF
--- a/front/src/applications/stdcm/styles/_railwayManagerModal.scss
+++ b/front/src/applications/stdcm/styles/_railwayManagerModal.scss
@@ -220,10 +220,6 @@
           min-height: 187px;
           resize: vertical;
         }
-
-        .ui-label-wrapper {
-          margin-bottom: 0;
-        }
       }
 
       .cs-code {

--- a/front/ui/ui-core/src/styles/inputs/checkbox.css
+++ b/front/ui/ui-core/src/styles/inputs/checkbox.css
@@ -1,8 +1,8 @@
 .ui-checkbox {
   display: block;
   position: relative;
-  padding-left: 1.938rem;
-  margin-bottom: 0.3rem;
+  padding-left: 31px;
+  margin-bottom: 4.8px;
   cursor: pointer;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -14,11 +14,11 @@
   letter-spacing: 0;
   text-align: left;
   width: fit-content;
+  height: 24px;
 
   .label {
-    line-height: 1.5rem;
-    padding-top: 0.188rem;
-    padding-right: 0.35rem;
+    line-height: 24px;
+    padding: 0 0 0 3px;
     @apply text-grey-80;
   }
 
@@ -29,16 +29,16 @@
 
   .checkmark {
     position: absolute;
-    top: 0.313rem;
-    left: 0.313rem;
-    border-radius: 0.188rem;
+    top: 2.4px;
+    left: 6.4px;
+    border-radius: 3px;
     box-sizing: content-box;
-    width: 1.125rem;
-    height: 1.125rem;
-    border: 0.125rem solid rgba(235, 235, 234, 1);
+    width: 18px;
+    height: 18px;
+    border: 2px solid rgba(235, 235, 234, 1);
     border: 2.5px solid rgba(211, 209, 207, 1);
-    border: 0.125rem solid rgba(255, 255, 255, 1);
-    border: 0.063rem solid rgba(148, 145, 142, 1);
+    border: 2px solid rgba(255, 255, 255, 1);
+    border: 1px solid rgba(148, 145, 142, 1);
     opacity: 1;
     background-image: linear-gradient(
       180deg,

--- a/front/ui/ui-core/src/styles/inputs/input-modal.css
+++ b/front/ui/ui-core/src/styles/inputs/input-modal.css
@@ -14,6 +14,7 @@
       0px 4px 7px -3px rgba(24, 68, 239, 0.19),
       0px 1px 3px rgba(49, 46, 43, 0.2);
     position: absolute;
+    width: fit-content;
 
     .close-button {
       position: absolute;


### PR DESCRIPTION
In this PR:
- The alignment of the checkbox label has been corrected. Previously, the label was too high, which created a misalignment with the checkbox.

- A size constraint has been applied to the container holding content in the InputModal. Previously, this container stretched to the full width of the screen, which caused a layout issue when displaying content in the modal.