### PR TITLE
editoast: consider trains that do not respect times as invalid (3/2)

### DIFF
--- a/editoast/src/views/timetable/track_occupancy.rs
+++ b/editoast/src/views/timetable/track_occupancy.rs
@@ -12,7 +12,6 @@ use crate::views::path::pathfinding::PathfindingResult;
 use crate::views::path::projection::PathProjection;
 use crate::views::projection::interpolate_arrival_time;
 use crate::views::timetable::simulation;
-use crate::views::timetable::simulation::SimulationResponseSuccess;
 
 #[derive(Debug, Clone)]
 pub(super) struct TrackOccupancy {
@@ -54,9 +53,11 @@ fn extract_occupancy_context<'a>(
     train_schedule: &'a schemas::TrainSchedule,
 ) -> OccupancyContext<'a> {
     let report_train = match simulation {
-        simulation::Response::Success(SimulationResponseSuccess { final_output, .. }) => {
-            Some(&final_output.report_train)
-        }
+        simulation::Response::Success(simulation) => simulation
+            .path_item_respect_times(train_schedule)
+            .into_iter()
+            .all(|path_item| path_item)
+            .then_some(&simulation.final_output.report_train),
         _ => None,
     };
 
@@ -201,6 +202,7 @@ pub fn find_track_occupancy_for_operational_point(
 pub mod tests {
     use crate::error::InternalError;
     use crate::views::path::pathfinding::PathfindingFailure;
+    use crate::views::timetable::simulation::SimulationResponseSuccess;
     use chrono::DateTime;
     use core_client::pathfinding::PathfindingNotFound;
     use core_client::pathfinding::TrackRange;

--- a/editoast/src/views/timetable/track_occupancy.rs
+++ b/editoast/src/views/timetable/track_occupancy.rs
@@ -259,10 +259,10 @@ pub mod tests {
 
         let report_train = ReportTrain {
             positions: vec![0, 50, 100, 150],
-            times: vec![0, expected_time, 2000, 3000],
+            times: vec![0, expected_time, 2000, 5000],
             speeds: vec![10.0; 4],
             energy_consumption: 0.0,
-            path_item_times: vec![0, expected_time, 2000],
+            path_item_times: vec![0, expected_time, 5000],
         };
 
         // Create a train schedule with path items and schedule items


### PR DESCRIPTION
Previously:
- https://github.com/OpenRailAssociation/osrd/pull/14423
- https://github.com/OpenRailAssociation/osrd/pull/14606

Ref: https://github.com/OpenRailAssociation/osrd/issues/14248

This updates the following endpoint: `/paced_train/track_occupancy`

This actually makes it so simulation results are not used to compute
track occupancy, but still lets the processing continue for the train in
question. I'm not sure if this is what was wanted originally, the change does hide invalid trains in track occupancy graphs.
