### PR TITLE
front: return undefined for simulation summary while the simulation is loading

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
@@ -141,10 +141,9 @@ const SimulationResults = ({
     const pacedTrain = timetableItemsWithDetails.find(
       (timetableItem) => timetableItem.id === extractPacedTrainIdFromOccurrenceId(selectedTrainId)
     );
-    if (!pacedTrain || !isPacedTrainWithDetails(pacedTrain)) return undefined;
-    if (!pacedTrain.paced) {
-      throw new Error(`Paced train ${pacedTrain.id} should have a paced field.`);
-    }
+    // WARNING TODO: race condition here, to fix
+    // When turning a train into a service, then pacedTrain and selectedTrainId may be desynchronized.
+    if (!pacedTrain || !isPacedTrainWithDetails(pacedTrain) || !pacedTrain.paced) return undefined;
 
     const exception = findExceptionWithOccurrenceId(pacedTrain.paced.exceptions, selectedTrainId);
     return exception?.summary ?? pacedTrain.summary;


### PR DESCRIPTION
When turning a train into a service, there is a race condition: sometimes, the new simulation may not be up-to-date, whereas the selected train is already updated. Then, an error is thrown.

Hot fix: return undefined if the simulation result and the selected train id are desynchronized. In a future PR, we should properly fix this race condition.

Fix e2e tests @Maymanaf 