### PR TITLE
core: improve error robustness

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/api/S3Context.kt
+++ b/core/src/main/java/fr/sncf/osrd/api/S3Context.kt
@@ -2,6 +2,7 @@ package fr.sncf.osrd.api
 
 import io.opentelemetry.api.trace.Span
 import java.net.URI
+import mu.KotlinLogging
 import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.regions.Region
@@ -11,17 +12,30 @@ import software.amazon.awssdk.services.s3.model.HeadObjectRequest
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
 
+/**
+ * Wraps S3 data and operations into a more convenient class.
+ *
+ * Note: as this S3 is only used to generate data that helps with viewing and debugging, errors are
+ * never critical. All operations are wrapped into try/catch blocks with error logging.
+ */
 data class S3Context(val s3Client: S3Client, val bucketName: String) {
+
+    val logger = KotlinLogging.logger {}
+
     /** Write a new file for a given stdcm request. */
     fun writeSTDCMFile(fileName: String, content: String) {
-        val traceId = Span.current().spanContext.traceId
-        val putObjectRequest =
-            PutObjectRequest.builder()
-                .bucket(bucketName)
-                .key("stdcm/requests/$traceId/$fileName")
-                .build()
+        try {
+            val traceId = Span.current().spanContext.traceId
+            val putObjectRequest =
+                PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key("stdcm/requests/$traceId/$fileName")
+                    .build()
 
-        s3Client.putObject(putObjectRequest, RequestBody.fromString(content))
+            s3Client.putObject(putObjectRequest, RequestBody.fromString(content))
+        } catch (e: Exception) {
+            logger.error { e }
+        }
     }
 
     /**
@@ -40,6 +54,9 @@ data class S3Context(val s3Client: S3Client, val bucketName: String) {
             s3Client.headObject(headRequest)
             true
         } catch (_: NoSuchKeyException) {
+            false
+        } catch (e: Exception) {
+            logger.error { e }
             false
         }
     }

--- a/core/src/main/java/fr/sncf/osrd/api/TimetableCacheManager.kt
+++ b/core/src/main/java/fr/sncf/osrd/api/TimetableCacheManager.kt
@@ -191,18 +191,21 @@ class TimetableCacheManager(
         val serializer = STDCMTimetableData.SerializableMap.serializer()
 
         if (file.exists()) {
-            val bytes = file.readBytes()
-            val serializableMap = cbor.decodeFromByteArray(serializer, bytes)
-            logger.debug("local timetable file cache hit at {}", file)
-            return serializableMap.toSTDCMRequirements()
-        } else {
-            val res = generateData.invoke()
-            logger.info("writing timetable to local file cache at $file")
-            val serializableMap = res.toSerializable()
-            val bytes = cbor.encodeToByteArray(serializer, serializableMap)
-            file.writeBytes(bytes)
-            return res
+            try {
+                val bytes = file.readBytes()
+                val serializableMap = cbor.decodeFromByteArray(serializer, bytes)
+                logger.debug("local timetable file cache hit at {}", file)
+                return serializableMap.toSTDCMRequirements()
+            } catch (e: Exception) {
+                logger.warn("failed to load valkey cached timetable data, reloading", e)
+            }
         }
+        val res = generateData.invoke()
+        logger.info("writing timetable to local file cache at $file")
+        val serializableMap = res.toSerializable()
+        val bytes = cbor.encodeToByteArray(serializer, serializableMap)
+        file.writeBytes(bytes)
+        return res
     }
 
     /**

--- a/core/src/main/java/fr/sncf/osrd/api/TimetableCacheManager.kt
+++ b/core/src/main/java/fr/sncf/osrd/api/TimetableCacheManager.kt
@@ -45,7 +45,7 @@ data class STDCMTimetableData(
     val detailedRequirements: Map<ZoneId, List<DetailedRequirement>>,
 ) {
     @Serializable
-    data class DetailedRequirement(val from: Double, val to: Double, val trainName: String)
+    data class DetailedRequirement(val from: Double, val to: Double, val trainName: String?)
 
     fun toSerializable(): SerializableMap {
         return SerializableMap(detailedRequirements.mapKeys { it.key.index })

--- a/core/src/main/java/fr/sncf/osrd/api/TimetableCacheManager.kt
+++ b/core/src/main/java/fr/sncf/osrd/api/TimetableCacheManager.kt
@@ -277,14 +277,18 @@ class TimetableCacheManager(
         val objectPath = "stdcm/saved_timetables/$cacheKey.cbor"
         if (s3Context.fileExists(objectPath)) return
 
-        val putObjectRequest =
-            PutObjectRequest.builder().bucket(s3Context.bucketName).key(objectPath).build()
+        try {
+            val putObjectRequest =
+                PutObjectRequest.builder().bucket(s3Context.bucketName).key(objectPath).build()
 
-        val serializable = requirements.toSerializable()
-        val cbor = Cbor {}
-        val serializer = STDCMTimetableData.SerializableMap.serializer()
-        val bytes = cbor.encodeToByteArray(serializer, serializable)
+            val serializable = requirements.toSerializable()
+            val cbor = Cbor {}
+            val serializer = STDCMTimetableData.SerializableMap.serializer()
+            val bytes = cbor.encodeToByteArray(serializer, serializable)
 
-        s3Context.s3Client.putObject(putObjectRequest, RequestBody.fromBytes(bytes))
+            s3Context.s3Client.putObject(putObjectRequest, RequestBody.fromBytes(bytes))
+        } catch (e: Exception) {
+            logger.error("failed to save timetable to s3", e)
+        }
     }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/api/conflicts/ConflictDetectionRequest.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/conflicts/ConflictDetectionRequest.kt
@@ -48,7 +48,7 @@ open class TrainRequirementsRequest(
 // TrainRequirementsRequest>
 class TrainRequirementsById(
     @Json(name = "train_id") val trainId: String,
-    @Json(name = "train_name") val trainName: String,
+    @Json(name = "train_name") val trainName: String?,
     @Json(name = "start_time") startTime: ZonedDateTime,
     @Json(name = "spacing_requirements") spacingRequirements: Collection<RJSSpacingRequirement>,
     @Json(name = "routing_requirements") routingRequirements: Collection<RJSRoutingRequirement>,


### PR DESCRIPTION
A few small changes, each in their own commit. It should have been that way from the start but better late than never.

---


First, s3 errors are logged and otherwise ignored: they're only used to generate data that helps with viewing / debugging, errors shouldn't stop us from returning the response anyway.

Second, avoid errors if editoast doesn't include the train name in requirement responses. That should only happen on version mismatches and won't be an issue for long, but still, I had it in local and it's easy to ignore.

Third, ignore valkey cache error and reload the timetable if the cache has some issue. This can only happen in local workflows as the cache key includes git version otherwise. Still, it's likely not unusual. 