### PR TITLE
front: add input data only mode for space time chart

### DIFF
--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -636,6 +636,7 @@
     "timeSpaceChartSettings": {
       "capacity": "Capacity",
       "conflicts": "Conflicts",
+      "inputMode": "Input mode",
       "operationalPointProjection": "Onto operational point",
       "paths": "Paths",
       "projection": "Projection",

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -636,6 +636,7 @@
     "timeSpaceChartSettings": {
       "capacity": "Capacité",
       "conflicts": "Conflits",
+      "inputMode": "Non calcul",
       "operationalPointProjection": "Au point remarquable",
       "paths": "Sillons",
       "projection": "Projection",

--- a/front/src/applications/operationalStudies/helpers/TrainOpProjectionLazyLoader.ts
+++ b/front/src/applications/operationalStudies/helpers/TrainOpProjectionLazyLoader.ts
@@ -14,7 +14,13 @@ import TrainProjectionLazyLoaderAbstract, {
   type TrainProjectionLazyLoaderOptions,
 } from './TrainProjectionLazyLoaderAbstract';
 
+export type TrainOpProjectionOptions = TrainProjectionLazyLoaderOptions & {
+  isSimulationEnabled: boolean;
+};
+
 export default class TrainOpProjectionLazyLoader extends TrainProjectionLazyLoaderAbstract {
+  declare readonly options: TrainOpProjectionOptions;
+
   readonly opRefs: OperationalPointReference[];
 
   readonly opDistances: number[];
@@ -22,7 +28,7 @@ export default class TrainOpProjectionLazyLoader extends TrainProjectionLazyLoad
   constructor(
     opRefs: OperationalPointReference[],
     opDistances: number[],
-    options: TrainProjectionLazyLoaderOptions
+    options: TrainOpProjectionOptions
   ) {
     super(options);
     this.opRefs = opRefs;
@@ -52,7 +58,7 @@ export default class TrainOpProjectionLazyLoader extends TrainProjectionLazyLoad
                 train_ids: editoastIds,
                 operational_points_refs: this.opRefs,
                 operational_points_distances: this.opDistances,
-                use_simulation: true,
+                use_simulation: this.options.isSimulationEnabled,
               },
             },
 

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SettingsPanel.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SettingsPanel.tsx
@@ -5,8 +5,8 @@ import { X } from '@osrd-project/ui-icons';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
-import { updateProjectionType } from 'reducers/simulationResults';
-import { getProjectionType } from 'reducers/simulationResults/selectors';
+import { toggleSimulationEnabled, updateProjectionType } from 'reducers/simulationResults';
+import { getProjectionType, getIsSimulationEnabled } from 'reducers/simulationResults/selectors';
 import type { ProjectionType } from 'reducers/simulationResults/types';
 import { useAppDispatch } from 'store';
 
@@ -31,9 +31,14 @@ const SettingsPanel = ({
   const { t } = useTranslation('operational-studies', { keyPrefix: 'simulationResults' });
   const dispatch = useAppDispatch();
   const projectionType = useSelector(getProjectionType);
+  const isSimulationEnabled = useSelector(getIsSimulationEnabled);
 
   const handleChange = (key: keyof Settings) => (event: ChangeEvent<HTMLInputElement>) => {
     onChange({ ...settings, [key]: event.target.checked });
+  };
+
+  const handleUseSimulationChange = () => {
+    dispatch(toggleSimulationEnabled());
   };
 
   return (
@@ -52,7 +57,7 @@ const SettingsPanel = ({
           label={t('timeSpaceChartSettings.projection')}
           value={projectionType}
           onChange={(value) => dispatch(updateProjectionType(value as ProjectionType))}
-          disabled={!isTimetableItemValid}
+          disabled={!isTimetableItemValid || !isSimulationEnabled}
           options={[
             {
               label: t('timeSpaceChartSettings.trackProjection'),
@@ -64,6 +69,11 @@ const SettingsPanel = ({
             },
           ]}
         />
+        <Checkbox
+          label={t('timeSpaceChartSettings.inputMode')}
+          checked={!isSimulationEnabled}
+          onChange={handleUseSimulationChange}
+        />
       </section>
 
       <section className="pb-4">
@@ -72,6 +82,7 @@ const SettingsPanel = ({
           label={t('timeSpaceChartSettings.signalsStates')}
           checked={settings.showSignalsStates}
           onChange={handleChange('showSignalsStates')}
+          disabled={!isSimulationEnabled}
         />
       </section>
 
@@ -81,6 +92,7 @@ const SettingsPanel = ({
           label={t('timeSpaceChartSettings.conflicts')}
           checked={settings.showConflicts}
           onChange={handleChange('showConflicts')}
+          disabled={!isSimulationEnabled}
         />
       </section>
     </div>

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
@@ -21,7 +21,9 @@ import {
   isOccupancyPickingElement,
 } from '@osrd-project/ui-charts';
 import { Slider } from '@osrd-project/ui-core';
+import cx from 'classnames';
 import { createPortal } from 'react-dom';
+import { useSelector } from 'react-redux';
 
 import upward from 'assets/pictures/workSchedules/ScheduledMaintenanceUp.svg';
 import { type PostWorkSchedulesProjectPathApiResponse } from 'common/api/osrdEditoastApi';
@@ -42,6 +44,7 @@ import type {
   TrainId,
   TrainScheduleId,
 } from 'reducers/osrdconf/types';
+import { getIsSimulationEnabled } from 'reducers/simulationResults/selectors';
 import { useAppDispatch } from 'store';
 import {
   isTrainId,
@@ -141,6 +144,7 @@ const SpaceTimeChartWrapper = ({
   pathfindingHasFailed = false,
 }: SpaceTimeChartWrapperProps) => {
   const dispatch = useAppDispatch();
+  const isSimulationEnabled = useSelector(getIsSimulationEnabled);
 
   const manchetteWithSpaceTimeChartRef = useRef<HTMLDivElement>(null);
   const activeWaypointRef = useRef<HTMLDivElement>(null);
@@ -420,7 +424,9 @@ const SpaceTimeChartWrapper = ({
           )}
 
           <SpaceTimeChart
-            className="inset-0 absolute h-full"
+            className={cx('inset-0 absolute h-full', {
+              'without-train-simulation-mode': !isSimulationEnabled,
+            })}
             height={height}
             {...spaceTimeChartProps}
             onPan={handlePan}
@@ -449,9 +455,13 @@ const SpaceTimeChartWrapper = ({
                 imageUrl={upward}
               />
             )}
-            {settings.showConflicts && <ConflictLayer conflicts={cutConflicts} />}
-            {settings.showSignalsStates && (
-              <OccupancyBlockLayer occupancyBlocks={occupancyBlocks} />
+            {isSimulationEnabled && (
+              <>
+                {settings.showConflicts && <ConflictLayer conflicts={cutConflicts} />}
+                {settings.showSignalsStates && (
+                  <OccupancyBlockLayer occupancyBlocks={occupancyBlocks} />
+                )}
+              </>
             )}
           </SpaceTimeChart>
         </div>

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useLazyProjectTrains.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useLazyProjectTrains.ts
@@ -10,7 +10,7 @@ import upsertNewProjectedTrains from 'applications/operationalStudies/helpers/up
 import { type OperationalPointReference, type CoreTrainPath } from 'common/api/osrdEditoastApi';
 import type { TrainSpaceTimeData } from 'modules/simulationResult/types';
 import type { TimetableItemId, TimetableItem } from 'reducers/osrdconf/types';
-import { getProjectionType } from 'reducers/simulationResults/selectors';
+import { getProjectionType, getIsSimulationEnabled } from 'reducers/simulationResults/selectors';
 import { useAppDispatch } from 'store';
 
 type UseLazyProjectTrainsOptions = {
@@ -35,6 +35,7 @@ const useLazyProjectTrains = ({
     Map<TimetableItemId, TrainSpaceTimeData>
   >(new Map());
   const projectionType = useSelector(getProjectionType);
+  const isSimulationEnabled = useSelector(getIsSimulationEnabled);
 
   const onProgress = useCallback((results: Map<TimetableItemId, ProjectionResult>) => {
     setProjectedTrainsById((prev) =>
@@ -52,7 +53,7 @@ const useLazyProjectTrains = ({
 
     let loader: TrainProjectionLazyLoaderAbstract;
 
-    if (projectionType === 'trackProjection' && path) {
+    if (isSimulationEnabled && projectionType === 'trackProjection' && path) {
       loader = new TrainTrackProjectionLazyLoader({
         ...baseOptions,
         path,
@@ -63,7 +64,7 @@ const useLazyProjectTrains = ({
       loader = new TrainOpProjectionLazyLoader(
         operationalPointReferences,
         operationalPointDistances,
-        { ...baseOptions, path }
+        { ...baseOptions, path, isSimulationEnabled }
       );
     }
 
@@ -81,6 +82,7 @@ const useLazyProjectTrains = ({
     path,
     operationalPointReferences,
     operationalPointDistances,
+    isSimulationEnabled,
   ]);
 
   const projectTimetableItems = useCallback((timetableItems: TimetableItem[]) => {

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useTrackOccupancy.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useTrackOccupancy.ts
@@ -4,12 +4,14 @@ import type { OccupancyZone, Track } from '@osrd-project/ui-charts';
 import type { TFunction } from 'i18next';
 import { forEach, fromPairs, isEmpty, isEqual, isFunction, keyBy, noop, uniqBy } from 'lodash';
 import { useTranslation } from 'react-i18next';
+import { useSelector } from 'react-redux';
 
 import { useScenarioContext } from 'applications/operationalStudies/hooks/useScenarioContext';
 import { type OperationalPointReference, osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import computeOccurrenceName from 'modules/timetableItem/helpers/computeOccurrenceName';
 import { computeIndexedOccurrenceStartTime } from 'modules/timetableItem/helpers/pacedTrain';
 import type { PacedTrainId, TimetableItemId, TrainId } from 'reducers/osrdconf/types';
+import { getIsSimulationEnabled } from 'reducers/simulationResults/selectors';
 import {
   extractEditoastIdFromPacedTrainId,
   extractPacedTrainIdFromOccurrenceId,
@@ -107,6 +109,7 @@ const useTrackOccupancy = ({
 
   const [postPacedTrainTrackOccupancy] =
     osrdEditoastApi.endpoints.postPacedTrainTrackOccupancy.useMutation();
+  const isSimulationEnabled = useSelector(getIsSimulationEnabled);
   const [postInfraByInfraIdMatchOperationalPoints] =
     osrdEditoastApi.endpoints.postInfraByInfraIdMatchOperationalPoints.useLazyQuery();
   const timetableItemProjectionsById: Map<TimetableItemId, TrainSpaceTimeData> = useMemo(
@@ -169,7 +172,7 @@ const useTrackOccupancy = ({
               operational_point_id: opId,
               infra_id: infraId,
               paced_train_ids: pacedTrainIds.map(extractEditoastIdFromPacedTrainId),
-              use_simulation: true,
+              use_simulation: isSimulationEnabled,
             }
           : null;
 
@@ -256,7 +259,7 @@ const useTrackOccupancy = ({
 
       return zones;
     },
-    [infraId, postPacedTrainTrackOccupancy]
+    [infraId, postPacedTrainTrackOccupancy, isSimulationEnabled]
   );
 
   const deployedWaypoints = useMemo(() => {

--- a/front/src/modules/simulationResult/styles/_manchetteWithSpaceTimeChart.scss
+++ b/front/src/modules/simulationResult/styles/_manchetteWithSpaceTimeChart.scss
@@ -116,22 +116,39 @@
     section {
       // Correctly align the checkbox with the radio buttons
       .ui-checkbox {
-        margin-left: 4px;
+        margin-left: 2px;
       }
 
       // Override the default padding of the radio button wrapper
       .ui-radio-button-wrapper {
         padding-left: 0;
         padding-block: 0;
+        margin-bottom: 14px;
 
         .ui-radio-button {
           padding-left: 8px;
 
           label {
             font-weight: 400;
+            margin-bottom: 0px;
           }
         }
       }
+    }
+  }
+
+  .space-time-chart.without-train-simulation-mode {
+    position: relative;
+
+    &::before {
+      content: '';
+      position: absolute;
+      top: 26px;
+      bottom: 40px;
+      left: 0;
+      right: 0;
+      border: 12px solid rgba(0, 0, 0, 0.05);
+      z-index: 1;
     }
   }
 }

--- a/front/src/reducers/simulationResults/index.ts
+++ b/front/src/reducers/simulationResults/index.ts
@@ -11,6 +11,7 @@ export const simulationResultsInitialState: SimulationResultsState = {
   trainIdUsedForProjection: undefined,
   projectionType: 'trackProjection',
   displayOnlyPathSteps: false,
+  isSimulationEnabled: true,
 };
 
 export const simulationResultsSlice = createSlice({
@@ -37,6 +38,13 @@ export const simulationResultsSlice = createSlice({
       action: PayloadAction<ProjectionType>
     ) {
       state.projectionType = action.payload;
+    },
+    toggleSimulationEnabled(state: Draft<SimulationResultsState>) {
+      state.isSimulationEnabled = !state.isSimulationEnabled;
+      // When switching to input mode, force interPR projection
+      if (!state.isSimulationEnabled) {
+        state.projectionType = 'operationalPointProjection';
+      }
     },
     unsetTrainIdsMatching(state: Draft<SimulationResultsState>, action: PayloadAction<TrainId>) {
       const idToUnset = action.payload;
@@ -80,6 +88,7 @@ export const simulationResultsSlice = createSlice({
 
 export const {
   toggleDisplayOnlyPathSteps,
+  toggleSimulationEnabled,
   updateSelectedTrainId,
   updateTrainIdUsedForProjection,
   updateProjectionType,

--- a/front/src/reducers/simulationResults/selectors.ts
+++ b/front/src/reducers/simulationResults/selectors.ts
@@ -11,3 +11,4 @@ export const getDisplayOnlyPathSteps = makeOsrdSimulationSelector('displayOnlyPa
 export const getSelectedTrainId = makeOsrdSimulationSelector('selectedTrainId');
 export const getTrainIdUsedForProjection = makeOsrdSimulationSelector('trainIdUsedForProjection');
 export const getProjectionType = makeOsrdSimulationSelector('projectionType');
+export const getIsSimulationEnabled = makeOsrdSimulationSelector('isSimulationEnabled');

--- a/front/src/reducers/simulationResults/types.ts
+++ b/front/src/reducers/simulationResults/types.ts
@@ -36,4 +36,5 @@ export type SimulationResultsState = {
   trainIdUsedForProjection?: TrainId;
   projectionType: ProjectionType;
   displayOnlyPathSteps: boolean;
+  isSimulationEnabled: boolean;
 };

--- a/front/ui/ui-core/src/components/RadioGroup.tsx
+++ b/front/ui/ui-core/src/components/RadioGroup.tsx
@@ -1,4 +1,4 @@
-import React, { type ChangeEvent, useState } from 'react';
+import React, { type ChangeEvent, useEffect, useState } from 'react';
 
 import { RequiredInput } from '@osrd-project/ui-icons';
 import cx from 'classnames';
@@ -34,6 +34,12 @@ const RadioGroup = ({
 }: RadioGroupProps) => {
   const [selectedValue, setSelectedValue] = useState<string | undefined>(value);
 
+  useEffect(() => {
+    setSelectedValue(value);
+  }, [value]);
+
+  const statusClassname = statusWithMessage?.status ? { [statusWithMessage.status]: true } : {};
+
   const handleOptionChange = (e: ChangeEvent<HTMLInputElement>, nextOption: RadioButtonProps) => {
     if (!readOnly) {
       setSelectedValue(nextOption.value);
@@ -41,8 +47,6 @@ const RadioGroup = ({
       onChange?.(nextOption.value);
     }
   };
-
-  const statusClassname = statusWithMessage?.status ? { [statusWithMessage.status]: true } : {};
 
   return (
     <div className={cx('ui-radio-button-wrapper', statusClassname)}>


### PR DESCRIPTION
This PR depends on : https://github.com/OpenRailAssociation/osrd/pull/14677

close #14225 

### ✏️ Edit
Seen with @thibautsailly:
When enabling “input mode only”, if the user was in track projection mode, the view automatically switches to inter-PR mode.
When disabling “input mode only”, the view remains in inter-PR mode, and the user must manually switch back to track projection mode.


#### The mockup :

https://www.sketch.com/s/183fcd09-8341-47c0-9c8e-15f29c0c4437/p/C389B334-DC58-4590-B7D4-BE3E20FF14B2/canvas

<img width="1208" height="712" alt="image" src="https://github.com/user-attachments/assets/f7b2fc74-6149-43ee-908d-b68d4ae4c58a" />

<img width="407" height="820" alt="image" src="https://github.com/user-attachments/assets/090a8f2b-229a-4cb7-8275-b71932d35cf0" />

Seen with @thibautsailly "Input data only" is now "No train run simulation" ("Sans marche simulée" in french), it fits better in the settings panel.


