### PR TITLE
chart: add storageClass support for editoast pvc

### DIFF
--- a/chart/templates/editoast/pvc.yaml
+++ b/chart/templates/editoast/pvc.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   accessModes: [ReadWriteMany]
+  {{- if .Values.services.editoast.permanent_storage_class }}
+  storageClassName: {{ .Values.services.editoast.permanent_storage_class }}
+  {{- end }}
   resources:
     requests:
       storage: {{ .Values.services.editoast.permanent_storage_size }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -195,6 +195,7 @@ services:
       extend: ""
       env: []
     permanent_storage_size: null
+    permanent_storage_class: null
     labels: {}
     nodeSelector: {}
     tolerations: []


### PR DESCRIPTION
Since defautl storage class does not always support ReadWriteMany access mode, we need to be able to configure the storageClassName of the pvc