### PR TITLE
ui-core: loding style for buttons

### DIFF
--- a/front/ui/storybook/stories/ui-core/Button.stories.tsx
+++ b/front/ui/storybook/stories/ui-core/Button.stories.tsx
@@ -35,6 +35,7 @@ type Story = StoryObj<typeof Button>;
 export const Default: Story = {
   args: {
     label: 'Click me',
+    isLoading: false,
   },
 };
 
@@ -42,6 +43,7 @@ export const Loading: Story = {
   args: {
     label: 'Loading',
     isLoading: true,
+    isDisabled: false,
   },
 };
 
@@ -49,6 +51,7 @@ export const Disabled: Story = {
   args: {
     label: 'Disabled',
     isDisabled: true,
+    isLoading: false,
   },
 };
 
@@ -56,6 +59,7 @@ export const Counter: Story = {
   args: {
     label: 'Counter',
     counter: 5,
+    isLoading: false,
   },
 };
 
@@ -63,6 +67,7 @@ export const Quiet: Story = {
   args: {
     label: 'Quiet',
     variant: 'Quiet',
+    isLoading: false,
   },
 };
 
@@ -70,6 +75,7 @@ export const Destructive: Story = {
   args: {
     label: 'Destructive',
     variant: 'Destructive',
+    isLoading: false,
   },
 };
 
@@ -77,6 +83,7 @@ export const Cancel: Story = {
   args: {
     label: 'Cancel',
     variant: 'Cancel',
+    isLoading: false,
   },
 };
 

--- a/front/ui/ui-core/src/components/Button.tsx
+++ b/front/ui/ui-core/src/components/Button.tsx
@@ -1,6 +1,5 @@
 import React, { type ButtonHTMLAttributes, type ReactNode } from 'react';
 
-import { Gear } from '@osrd-project/ui-icons';
 import cx from 'classnames';
 
 type ButtonVariant = 'Normal' | 'Cancel' | 'Quiet' | 'Destructive' | 'Primary';
@@ -52,17 +51,9 @@ const Button = ({
       onClick={handleClick}
       disabled={isDisabled || isLoading}
     >
-      {isLoading ? (
-        <span className="icon">
-          <Gear variant="fill" size="lg" />
-        </span>
-      ) : (
-        <>
-          {leadingIcon && <span className="leading-icon mr-2">{leadingIcon}</span>}
-          {label}
-          {counter !== null && <span className="counter ml-2">{counter}</span>}
-        </>
-      )}
+      {leadingIcon && <span className="leading-icon mr-2">{leadingIcon}</span>}
+      {label}
+      {counter !== null && <span className="counter ml-2">{counter}</span>}
     </button>
   );
 };

--- a/front/ui/ui-core/src/styles/button.css
+++ b/front/ui/ui-core/src/styles/button.css
@@ -141,21 +141,33 @@
     }
   }
   &.loading {
-    height: 2.625rem;
-    padding: 0.375rem 1.813rem;
-    &.medium {
-      height: 2.25rem;
-      padding: 0.313rem 1.625rem;
+    box-shadow: none !important;
+    border: none !important;
+    position: relative;
+    opacity: 1 !important;
+
+    &::before {
+      background-color: var(--color-info-5);
+      border-radius: 5px;
+      content: '';
+      position: absolute;
+      inset: 0;
     }
-    &.small {
-      height: 2rem;
-      padding: 0.063rem 1.25rem;
-    }
-    &:disabled {
-      opacity: 1;
-    }
-    .icon svg {
-      animation: spin 3s linear infinite;
+    &::after {
+      content: '';
+      position: absolute;
+      aspect-ratio: 1;
+      inset: auto 0;
+      width: 17px;
+      margin: 0 auto;
+      --_g: no-repeat radial-gradient(farthest-side, var(--color-info-60) 90%, #0000);
+      background:
+        var(--_g) 0 0,
+        var(--_g) 100% 0,
+        var(--_g) 100% 100%,
+        var(--_g) 0 100%;
+      background-size: 40% 40%;
+      animation: button-loader-animation 0.5s infinite;
     }
   }
   .counter {
@@ -177,5 +189,15 @@
   }
   &:disabled {
     opacity: 0.5;
+  }
+}
+
+@keyframes button-loader-animation {
+  100% {
+    background-position:
+      100% 0,
+      100% 100%,
+      0 100%,
+      0 0;
   }
 }


### PR DESCRIPTION
Fix ticket #14644 

IMPORTANT: it changes the style of every button when `isLoading` is set at true. Need to check again with @thibautsailly  to be certain it's the wanted behavior

NOTE: I used `::after` & `::before` to avoid additional DOM  but most important  **to keep the original size of the button**. 

Deployed storybook demo [ HERE ](https://web-preview.openrailassociation.org/osrdui-pr-14672/?path=/story/core-button--default). You have to change the `isLoading` to `true` and you can also change the label.