### PR TITLE
front: nge: infer asymmetry from round trips

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -17,7 +17,7 @@
         "@ag-media/react-pdf-table": "^2.0.3",
         "@nivo/core": "^0.99.0",
         "@nivo/line": "^0.99.0",
-        "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.a42335db4fc8f6b18d29d59b9747deb94bd34d15",
+        "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.cb1b08f6a8889b698a6c4fda65d0d8a9eb516114",
         "@osrd-project/ui-charts": "0.0.1-dev",
         "@osrd-project/ui-core": "0.0.1-dev",
         "@osrd-project/ui-icons": "0.0.1-dev",
@@ -3463,9 +3463,9 @@
       "link": true
     },
     "node_modules/@osrd-project/netzgrafik-frontend": {
-      "version": "0.0.0-snapshot.a42335db4fc8f6b18d29d59b9747deb94bd34d15",
-      "resolved": "https://registry.npmjs.org/@osrd-project/netzgrafik-frontend/-/netzgrafik-frontend-0.0.0-snapshot.a42335db4fc8f6b18d29d59b9747deb94bd34d15.tgz",
-      "integrity": "sha512-Yf2UVEg0M8UrJP7EW8TxyT2RiAq+CQNlrYfDHnE9Gl1J32EH9J3ou0mXjSuHOJvAQ9UeXB7g7qlqwGUWJKofsA=="
+      "version": "0.0.0-snapshot.cb1b08f6a8889b698a6c4fda65d0d8a9eb516114",
+      "resolved": "https://registry.npmjs.org/@osrd-project/netzgrafik-frontend/-/netzgrafik-frontend-0.0.0-snapshot.cb1b08f6a8889b698a6c4fda65d0d8a9eb516114.tgz",
+      "integrity": "sha512-yZsSzEZo1FD4RD+TY+bHIW8t7p72H84pN5lx+KDP5ON5dmJgTR0jCjCVt4n1hOjllDxhiUNx/f/AAihT+SJbdA=="
     },
     "node_modules/@osrd-project/storybook": {
       "resolved": "ui/storybook",

--- a/front/package.json
+++ b/front/package.json
@@ -14,7 +14,7 @@
     "@ag-media/react-pdf-table": "^2.0.3",
     "@nivo/core": "^0.99.0",
     "@nivo/line": "^0.99.0",
-    "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.a42335db4fc8f6b18d29d59b9747deb94bd34d15",
+    "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.cb1b08f6a8889b698a6c4fda65d0d8a9eb516114",
     "@osrd-project/ui-charts": "0.0.1-dev",
     "@osrd-project/ui-core": "0.0.1-dev",
     "@osrd-project/ui-icons": "0.0.1-dev",

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/osrdToNge.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/osrdToNge.ts
@@ -555,6 +555,18 @@ const getNgeTrainrunSectionsWithNodes = (
           travelTime.consecutiveTime = travelTime.time;
         }
 
+        // Minute symmetry
+        const sourceSymmetry = Boolean(
+          sourceDeparture.time &&
+          sourceArrival.time &&
+          (sourceDeparture.time + sourceArrival.time) % 60 === 0
+        );
+        const targetSymmetry = Boolean(
+          targetDeparture.time &&
+          targetArrival.time &&
+          (targetDeparture.time + targetArrival.time) % 60 === 0
+        );
+
         const trainrunSection = {
           id: trainrunSectionId,
           sourceNodeId: sourceNode.id,
@@ -566,6 +578,8 @@ const getNgeTrainrunSectionsWithNodes = (
           sourceArrival,
           targetDeparture,
           targetArrival,
+          sourceSymmetry,
+          targetSymmetry,
           numberOfStops: 0,
           trainrunId: index + 1,
           resourceId: state.ngeResource.id,

--- a/front/src/applications/operationalStudies/views/Scenario/components/NGE/types.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/NGE/types.ts
@@ -73,6 +73,9 @@ export type TrainrunSectionDto = {
   targetNodeId: number;
   targetPortId: number;
 
+  sourceSymmetry: boolean;
+  targetSymmetry: boolean;
+
   sourceDeparture: TimeLockDto;
   sourceArrival: TimeLockDto;
   targetDeparture: TimeLockDto;

--- a/front/tests/pages/operational-studies/nge-page.ts
+++ b/front/tests/pages/operational-studies/nge-page.ts
@@ -64,7 +64,10 @@ class NGEPage extends OpSimulationResultPage {
   }
 
   private getTrainLabel(lineIndex: number, labelIndex: number): Locator {
-    return this.trainLabelRows.nth(lineIndex).getByTestId('edge_text').nth(labelIndex);
+    return this.trainLabelRows
+      .nth(lineIndex)
+      .locator('[data-testid="edge_text"]:not(.hidden)')
+      .nth(labelIndex);
   }
 
   async toggleTopologyEditor() {


### PR DESCRIPTION
closes https://github.com/osrd-project/osrd-confidential/issues/1293

Infers asymmetry properties from round trip schedules before building the train run section.

> [!NOTE]
> * Based on an NGE fork snapshot. package.json will need to be updated once the fork rebase will be complete.
> * For the same reason, this PR cannot be merged until that work is complete.

### E2E tests

~~I changed a few things on a test to match trainrun dom on the fork branch. I'm not sure if I was right to update the test or if NGE itself should. Lmk.~~

https://github.com/OpenRailAssociation/osrd/pull/14673#issuecomment-3806358896
