### PR TITLE
editoast, front: adapts endpoints to allow the GET to display the input data mode without the simulations

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -2318,6 +2318,7 @@ paths:
               - train_ids
               - operational_points_refs
               - operational_points_distances
+              - use_simulation
               properties:
                 electrical_profile_set_id:
                   type:
@@ -2400,6 +2401,8 @@ paths:
                     type: integer
                     format: int64
                   uniqueItems: true
+                use_simulation:
+                  type: boolean
         required: true
       responses:
         '200':

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -2472,6 +2472,7 @@ paths:
               - paced_train_ids
               - operational_point_id
               - infra_id
+              - use_simulation
               properties:
                 electrical_profile_set_id:
                   type:
@@ -2488,6 +2489,8 @@ paths:
                   items:
                     type: integer
                     format: int64
+                use_simulation:
+                  type: boolean
         required: true
       responses:
         '200':

--- a/editoast/src/views/projection.rs
+++ b/editoast/src/views/projection.rs
@@ -51,6 +51,7 @@ pub struct ProjectPathOperationalPointForm {
     pub operational_points_refs: Vec<OperationalPointReference>,
     /// Distances between operational points in mm
     pub operational_points_distances: Vec<u64>,
+    pub use_simulation: bool,
 }
 
 #[derive(Default, Debug, Clone, Deserialize, Serialize, ToSchema)]
@@ -467,7 +468,7 @@ pub struct TrainToProjectOnOperationalPoint {
 }
 
 impl TrainToProjectOnOperationalPoint {
-    fn new<T: TrainScheduleLike>(ts: &T, sim: simulation::Response) -> Self {
+    fn new<T: TrainScheduleLike>(ts: &T) -> Self {
         let stops_input: HashMap<_, _> = ts
             .schedule()
             .iter()
@@ -479,55 +480,69 @@ impl TrainToProjectOnOperationalPoint {
             })
             .collect();
 
+        // Handle non-simulated trains
+        let arrival_inputs = ts
+            .schedule()
+            .iter()
+            .filter_map(|schedule| {
+                schedule
+                    .arrival
+                    .as_ref()
+                    .map(|arrival| (&schedule.at, arrival.num_milliseconds() as u64))
+            })
+            .collect::<HashMap<_, _>>();
+
+        let mut refs = ts.path().iter().map(|path_item| match &path_item.location {
+            PathItemLocation::OperationalPointPartReference(op_ref) => {
+                Some((&op_ref.operational_point, &path_item.id))
+            }
+            PathItemLocation::TrackOffset(_) => None,
+        });
+
+        let first_path_item = refs.next().flatten();
+
+        let refs = refs.flatten().map(|(op_ref, id)| {
+            arrival_inputs
+                .get(&id)
+                .map(|&arrival_time| OperationalPointRefAndTime {
+                    arrival_time,
+                    stop_for: stops_input.get(&id).copied().unwrap_or_default(),
+                    op_ref: op_ref.clone(),
+                })
+        });
+
+        let first_op_ref = first_path_item.map(|(op_ref, id)| OperationalPointRefAndTime {
+            arrival_time: 0,
+            stop_for: stops_input.get(&id).copied().unwrap_or_default(),
+            op_ref: op_ref.clone(),
+        });
+
+        let refs = std::iter::once(first_op_ref)
+            .chain(refs)
+            .flatten()
+            .collect();
+
+        TrainToProjectOnOperationalPoint {
+            space_time_curve: None,
+            refs,
+        }
+    }
+
+    fn new_from_simulation<T: TrainScheduleLike>(ts: &T, sim: simulation::Response) -> Self {
         let simulation::Response::Success(SimulationResponseSuccess { final_output, .. }) = sim
         else {
-            // Handle non-simulated trains
-            let arrival_inputs = ts
-                .schedule()
-                .iter()
-                .filter_map(|schedule| {
-                    schedule
-                        .arrival
-                        .as_ref()
-                        .map(|arrival| (&schedule.at, arrival.num_milliseconds() as u64))
-                })
-                .collect::<HashMap<_, _>>();
-
-            let mut refs = ts.path().iter().map(|path_item| match &path_item.location {
-                PathItemLocation::OperationalPointPartReference(op_ref) => {
-                    Some((&op_ref.operational_point, &path_item.id))
-                }
-                PathItemLocation::TrackOffset(_) => None,
-            });
-
-            let first_path_item = refs.next().flatten();
-
-            let refs = refs.flatten().map(|(op_ref, id)| {
-                arrival_inputs
-                    .get(&id)
-                    .map(|&arrival_time| OperationalPointRefAndTime {
-                        arrival_time,
-                        stop_for: stops_input.get(&id).copied().unwrap_or_default(),
-                        op_ref: op_ref.clone(),
-                    })
-            });
-
-            let first_op_ref = first_path_item.map(|(op_ref, id)| OperationalPointRefAndTime {
-                arrival_time: 0,
-                stop_for: stops_input.get(&id).copied().unwrap_or_default(),
-                op_ref: op_ref.clone(),
-            });
-
-            let refs = std::iter::once(first_op_ref)
-                .chain(refs)
-                .flatten()
-                .collect();
-
-            return TrainToProjectOnOperationalPoint {
-                space_time_curve: None,
-                refs,
-            };
+            return TrainToProjectOnOperationalPoint::new(ts);
         };
+        let stops_input: HashMap<_, _> = ts
+            .schedule()
+            .iter()
+            .filter_map(|schedule| {
+                schedule
+                    .stop_for
+                    .as_ref()
+                    .map(|stop_for| (&schedule.at, stop_for.num_milliseconds() as u64))
+            })
+            .collect();
         let CompleteReportTrain { report_train, .. } = final_output;
         let space_time_curve = Some(SpaceTimeCurve {
             positions: report_train.positions,
@@ -667,7 +682,7 @@ pub async fn compute_projected_train_path_op<T: TrainScheduleLike>(
 
     let mut results = vec![Arc::default(); train_schedules.len()];
     for (indexes, ts, sim) in to_compute.into_values() {
-        let train_to_project = TrainToProjectOnOperationalPoint::new(ts, sim);
+        let train_to_project = TrainToProjectOnOperationalPoint::new_from_simulation(ts, sim);
         let curves = Arc::new(project_train_path_op(
             &train_to_project,
             path_item_cache,
@@ -742,6 +757,24 @@ fn project_train_path_op(
         }
     }
     projection_curves
+}
+
+pub fn compute_projected_train_path_op_without_simulation<T: TrainScheduleLike>(
+    train_schedules: &[T],
+    path_item_cache: &PathItemCache,
+    operational_points_projection: OperationalPointProjection,
+) -> Vec<Arc<Vec<SpaceTimeCurve>>> {
+    train_schedules
+        .iter()
+        .map(|train_schedule| {
+            let train_to_project = TrainToProjectOnOperationalPoint::new(train_schedule);
+            Arc::new(project_train_path_op(
+                &train_to_project,
+                path_item_cache,
+                &operational_points_projection,
+            ))
+        })
+        .collect_vec()
 }
 
 pub async fn extract_train_details<T: TrainScheduleLike>(

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -45,6 +45,7 @@ use crate::views::projection::ProjectPathForm;
 use crate::views::projection::ProjectPathOperationalPointForm;
 use crate::views::projection::SpaceTimeCurve;
 use crate::views::projection::compute_projected_train_path_op;
+use crate::views::projection::compute_projected_train_path_op_without_simulation;
 use crate::views::projection::compute_projected_train_paths;
 use crate::views::timetable::PhysicsConsistParameters;
 use crate::views::timetable::occupancy_blocks::OccupancyBlockForm;
@@ -881,6 +882,7 @@ pub(in crate::views) async fn project_path_op(
         electrical_profile_set_id,
         operational_points_refs,
         operational_points_distances,
+        use_simulation,
     }): Json<ProjectPathOperationalPointForm>,
 ) -> Result<Json<HashMap<i64, ProjectPathPacedTrainResult>>> {
     let infra = &Infra::retrieve_or_fail(db_pool.get().await?, infra_id, || {
@@ -960,18 +962,26 @@ pub(in crate::views) async fn project_path_op(
         &path_item_cache,
     )?;
 
-    let projected_trains = compute_projected_train_path_op(
-        conn,
-        valkey_client,
-        core_client,
-        &train_schedules,
-        &path_item_cache,
-        operational_points_projection,
-        infra,
-        electrical_profile_set_id,
-        config.app_version.as_deref(),
-    )
-    .await?;
+    let projected_trains = if use_simulation {
+        compute_projected_train_path_op(
+            conn,
+            valkey_client,
+            core_client,
+            &train_schedules,
+            &path_item_cache,
+            operational_points_projection,
+            infra,
+            electrical_profile_set_id,
+            config.app_version.as_deref(),
+        )
+        .await?
+    } else {
+        compute_projected_train_path_op_without_simulation(
+            &train_schedules,
+            &path_item_cache,
+            operational_points_projection,
+        )
+    };
 
     let mut base_project_path = Default::default();
 

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -1162,6 +1162,7 @@ pub(in crate::views) struct TrackOccupancyForm {
     operational_point_id: String,
     infra_id: i64,
     electrical_profile_set_id: Option<i64>,
+    use_simulation: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
@@ -1199,6 +1200,7 @@ pub(in crate::views) async fn track_occupancy(
         operational_point_id,
         infra_id,
         electrical_profile_set_id,
+        use_simulation,
     }): Json<TrackOccupancyForm>,
 ) -> Result<Json<HashMap<String, Vec<TrackOccupancy>>>> {
     let authorized = auth
@@ -1248,17 +1250,6 @@ pub(in crate::views) async fn track_occupancy(
         .flat_map(|paced_train| paced_train.iter_occurrences())
         .unzip();
 
-    let simulations_result = train_simulation_batch(
-        conn,
-        valkey_client,
-        core_client,
-        &trains,
-        &infra,
-        electrical_profile_set_id,
-        config.app_version.as_deref(),
-    )
-    .await?;
-
     // Get track positions at the operational point
     let operational_point_track_offsets = operational_point.schema.track_offset();
 
@@ -1271,7 +1262,18 @@ pub(in crate::views) async fn track_occupancy(
     let path_item_cache = PathItemCache::load(db_pool.get().await?, infra_id, &path_items).await?;
 
     // For each occurrence + simulation result, compute track occupancies
-    let all_occupancies: Vec<(String, TrackOccupancy)> =
+    let all_occupancies = if use_simulation {
+        let simulations_result = train_simulation_batch(
+            conn,
+            valkey_client,
+            core_client,
+            &trains,
+            &infra,
+            electrical_profile_set_id,
+            config.app_version.as_deref(),
+        )
+        .await?;
+
         izip!(train_ids, trains, simulations_result)
             .flat_map(|(train_id, train, (simulation, pathfinding))| {
                 track_occupancy::find_track_occupancy_for_operational_point(
@@ -1299,7 +1301,35 @@ pub(in crate::views) async fn track_occupancy(
                 )
                 .collect_vec()
             })
-            .collect();
+            .collect_vec()
+    } else {
+        izip!(train_ids, trains)
+            .flat_map(|(train_id, train_schedule)| {
+                track_occupancy::find_track_occupancy_for_operational_point_without_simulation(
+                    &operational_point_id,
+                    &operational_point_track_offsets,
+                    &path_item_cache,
+                    &train_schedule,
+                )
+                .into_iter()
+                .map(
+                    |track_occupancy::TrackOccupancy {
+                         track_section,
+                         time_window,
+                     }| {
+                        (
+                            track_section,
+                            TrackOccupancy {
+                                train_id: train_id.clone(),
+                                time_window,
+                            },
+                        )
+                    },
+                )
+                .collect_vec()
+            })
+            .collect_vec()
+    };
 
     // Group occupancies by track section
     let results: HashMap<String, Vec<TrackOccupancy>> =
@@ -2363,6 +2393,7 @@ mod tests {
                 operational_point_id,
                 infra_id: small_infra.id,
                 electrical_profile_set_id: None,
+                use_simulation: true,
             });
 
         app.fetch(request).await

--- a/editoast/src/views/timetable/track_occupancy.rs
+++ b/editoast/src/views/timetable/track_occupancy.rs
@@ -66,6 +66,22 @@ fn extract_occupancy_context<'a>(
         _ => None,
     };
 
+    OccupancyContext {
+        report_train,
+        pathfinding_success,
+        ..extract_occupancy_context_without_simulation(
+            operational_point_id,
+            path_item_cache,
+            train_schedule,
+        )
+    }
+}
+
+fn extract_occupancy_context_without_simulation<'a>(
+    operational_point_id: &str,
+    path_item_cache: &PathItemCache,
+    train_schedule: &'a schemas::TrainSchedule,
+) -> OccupancyContext<'a> {
     let matching_index =
         find_matching_path_item_index(&train_schedule.path, operational_point_id, path_item_cache);
 
@@ -77,8 +93,8 @@ fn extract_occupancy_context<'a>(
     });
 
     OccupancyContext {
-        report_train,
-        pathfinding_success,
+        report_train: None,
+        pathfinding_success: None,
         matching_index,
         schedule_item,
     }
@@ -170,7 +186,39 @@ pub fn find_track_occupancy_for_operational_point(
         pathfinding,
         train_schedule,
     );
+    find_track_occupancy_for_operational_point_with_context(
+        context,
+        operational_point_track_offsets,
+        path_item_cache,
+        train_schedule,
+    )
+}
 
+pub fn find_track_occupancy_for_operational_point_without_simulation(
+    operational_point_id: &str,
+    operational_point_track_offsets: &[TrackOffset],
+    path_item_cache: &PathItemCache,
+    train_schedule: &schemas::TrainSchedule,
+) -> Vec<TrackOccupancy> {
+    let context = extract_occupancy_context_without_simulation(
+        operational_point_id,
+        path_item_cache,
+        train_schedule,
+    );
+    find_track_occupancy_for_operational_point_with_context(
+        context,
+        operational_point_track_offsets,
+        path_item_cache,
+        train_schedule,
+    )
+}
+
+fn find_track_occupancy_for_operational_point_with_context<'a>(
+    context: OccupancyContext<'a>,
+    operational_point_track_offsets: &[TrackOffset],
+    path_item_cache: &PathItemCache,
+    train_schedule: &schemas::TrainSchedule,
+) -> Vec<TrackOccupancy> {
     let arrival_time = match get_arrival_time(&context, operational_point_track_offsets) {
         Some(time) => time,
         None => return vec![],

--- a/front/src/applications/operationalStudies/helpers/TrainOpProjectionLazyLoader.ts
+++ b/front/src/applications/operationalStudies/helpers/TrainOpProjectionLazyLoader.ts
@@ -52,6 +52,7 @@ export default class TrainOpProjectionLazyLoader extends TrainProjectionLazyLoad
                 train_ids: editoastIds,
                 operational_points_refs: this.opRefs,
                 operational_points_distances: this.opDistances,
+                use_simulation: true,
               },
             },
 

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -2024,6 +2024,7 @@ export type PostPacedTrainTrackOccupancyApiArg = {
     infra_id: number;
     operational_point_id: string;
     paced_train_ids: number[];
+    use_simulation: boolean;
   };
 };
 export type GetPacedTrainByIdApiResponse =

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -1980,6 +1980,7 @@ export type PostPacedTrainProjectPathOpApiArg = {
         }
     )[];
     train_ids: number[];
+    use_simulation: boolean;
   };
 };
 export type PostPacedTrainSimulationSummaryApiResponse =

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useTrackOccupancy.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useTrackOccupancy.ts
@@ -169,6 +169,7 @@ const useTrackOccupancy = ({
               operational_point_id: opId,
               infra_id: infraId,
               paced_train_ids: pacedTrainIds.map(extractEditoastIdFromPacedTrainId),
+              use_simulation: true,
             }
           : null;
 


### PR DESCRIPTION
Closes #14250

To test this feature, you can create a study with timed points in the path and then you can try switching by hardcoding the `use_simulation` to true/false in the front 