### PR TITLE
core: add EtcsBrakeParams

### DIFF
--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/PhysicsRollingStock.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/PhysicsRollingStock.java
@@ -4,7 +4,7 @@ import static fr.sncf.osrd.envelope_sim.TrainPhysicsIntegrator.GRAVITY_ACCELERAT
 import static fr.sncf.osrd.envelope_sim.etcs.ConstantsKt.M_ROTATING_MAX;
 import static fr.sncf.osrd.envelope_sim.etcs.ConstantsKt.M_ROTATING_MIN;
 
-import fr.sncf.osrd.railjson.schema.rollingstock.RJSEtcsBrakeParams;
+import fr.sncf.osrd.envelope_sim.etcs.EtcsBrakeParams;
 
 public interface PhysicsRollingStock {
     /** The mass of the train, in kilograms */
@@ -25,7 +25,7 @@ public interface PhysicsRollingStock {
     /** The first derivative of the resistance to movement at a given speed, in kg/s */
     double getRollingResistanceDeriv(double speed);
 
-    RJSEtcsBrakeParams getRJSEtcsBrakeParams();
+    EtcsBrakeParams getEtcsBrakeParams();
 
     /** Get the effort the train can apply at a given speed, in newtons */
     static double getMaxEffort(double speed, TractiveEffortPoint[] tractiveEffortCurve) {

--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/TrainPhysicsIntegrator.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/TrainPhysicsIntegrator.java
@@ -109,15 +109,14 @@ public final class TrainPhysicsIntegrator {
         var gradientAcceleration = getGradientAcceleration(grade);
         return switch (brakingType) {
             // See Subset referenced in RJSEtcsBrakeParams: §3.13.6.2.1.3.
-            case EBD -> -rollingStock.getRJSEtcsBrakeParams().getSafeBrakingAcceleration(speed) + gradientAcceleration;
+            case EBD -> -rollingStock.getEtcsBrakeParams().getSafeBrakingAcceleration(speed) + gradientAcceleration;
             // See Subset referenced in RJSEtcsBrakeParams: §3.13.6.3.1.3.
-            case SBD ->
-                -rollingStock.getRJSEtcsBrakeParams().getServiceBrakingAcceleration(speed) + gradientAcceleration;
+            case SBD -> -rollingStock.getEtcsBrakeParams().getServiceBrakingAcceleration(speed) + gradientAcceleration;
             // See Subset referenced in RJSEtcsBrakeParams: §3.13.6.4.3.
             case GUI ->
-                -rollingStock.getRJSEtcsBrakeParams().getNormalServiceBrakingAcceleration(speed)
+                -rollingStock.getEtcsBrakeParams().getNormalServiceBrakingAcceleration(speed)
                         + gradientAcceleration
-                        + rollingStock.getRJSEtcsBrakeParams().getGradientAccelerationCorrection(grade, speed);
+                        + rollingStock.getEtcsBrakeParams().getGradientAccelerationCorrection(grade, speed);
             default -> throw new UnsupportedOperationException("Braking type not supported: " + brakingType);
         };
     }

--- a/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/ETCSBrakingCurves.kt
+++ b/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/ETCSBrakingCurves.kt
@@ -382,8 +382,8 @@ private fun computeBrakingCurvesFromRefs(
     val rollingStock = context.rollingStock
     val (sbiBrakingCurveType, tBs) =
         when (refBrakingCurve.brakingType) {
-            SBD -> Pair(SBI_1, rollingStock.rjsEtcsBrakeParams.tBs1)
-            EBI -> Pair(SBI_2, rollingStock.rjsEtcsBrakeParams.tBs2)
+            SBD -> Pair(SBI_1, rollingStock.etcsBrakeParams.tBs1)
+            EBI -> Pair(SBI_2, rollingStock.etcsBrakeParams.tBs2)
             else ->
                 throw IllegalArgumentException(
                     "Expected EBI or SBD reference braking curve type, found: ${refBrakingCurve.brakingType}"
@@ -621,8 +621,8 @@ private fun computeBecParams(
     // The time during which the traction effort is still present. See Subset: §3.13.9.3.2.3.
     val tTraction =
         max(
-            rollingStock.rjsEtcsBrakeParams.tTractionCutOff -
-                (T_WARNING + rollingStock.rjsEtcsBrakeParams.tBs2),
+            rollingStock.etcsBrakeParams.tTractionCutOff -
+                (T_WARNING + rollingStock.etcsBrakeParams.tBs2),
             0.0,
         )
     // Estimated acceleration during tTraction, worst case scenario (the train accelerates as much
@@ -647,7 +647,7 @@ private fun computeBecParams(
 
     // The remaining time during which the traction effort is not present. See Subset:
     // §3.13.9.3.2.6.
-    val tBerem = max(rollingStock.rjsEtcsBrakeParams.tBe - tTraction, 0.0)
+    val tBerem = max(rollingStock.etcsBrakeParams.tBe - tTraction, 0.0)
     // Speed correction due to the braking system not being active yet. See Subset: §3.13.9.3.2.10.
     val vDelta2 = A_EST_2 * tBerem
 

--- a/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/EtcsBrakeParams.kt
+++ b/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/EtcsBrakeParams.kt
@@ -1,0 +1,143 @@
+package fr.sncf.osrd.envelope_sim.etcs
+
+import fr.sncf.osrd.railjson.schema.rollingstock.RJSEtcsBrakeParams
+import kotlin.math.abs
+
+/**
+ * Braking parameters for ERTMS ETCS Level 2 Commented with their names in ETCS specification
+ * document `SUBSET-026-3 v400.pdf` from the file at
+ * https://www.era.europa.eu/system/files/2023-09/index004_-_SUBSET-026_v400.zip
+ */
+class EtcsBrakeParams(
+    /** A_brake_emergency: the emergency deceleration curve (values > 0 m/s²) */
+    private val gammaEmergency: SpeedIntervalValueCurve,
+    /** A_brake_service: the full service deceleration curve (values > 0 m/s²) */
+    private val gammaService: SpeedIntervalValueCurve,
+    /**
+     * A_brake_normal_service: the normal service deceleration curve used to compute guidance curve
+     * (values > 0 m/s²)
+     */
+    private val gammaNormalService: SpeedIntervalValueCurve,
+    /**
+     * Kdry_rst: the rolling stock deceleration correction factors for dry rails Boundaries should
+     * be the same as gammaEmergency Values (no unit) should be contained in [0, 1]
+     */
+    private val kDry: SpeedIntervalValueCurve,
+    /**
+     * Kwet_rst: the rolling stock deceleration correction factors for wet rails Boundaries should
+     * be the same as gammaEmergency Values (no unit) should be contained in [0, 1]
+     */
+    private val kWet: SpeedIntervalValueCurve,
+    /**
+     * Kn+: the correction acceleration factor on normal service deceleration in positive gradients
+     * Values (in m/s²) should be contained in [0, 10]
+     */
+    private val kNPos: SpeedIntervalValueCurve,
+    /**
+     * Kn-: the correction acceleration factor on normal service deceleration in negative gradients
+     * Values (in m/s²) should be contained in [0, 10]
+     */
+    private val kNNeg: SpeedIntervalValueCurve,
+    /**
+     * T_traction_cut_off: time delay in s from the traction cut-off command to the moment the
+     * acceleration due to traction is zero
+     */
+    val tTractionCutOff: Double,
+    /** T_bs1: time service break in s used for SBI1 computation */
+    val tBs1: Double,
+    /** T_bs2: time service break in s used for SBI2 computation */
+    val tBs2: Double,
+    /** T_be: safe brake build up time in s */
+    val tBe: Double,
+) {
+    /** See Subset §3.13.6.2.1.4. */
+    fun getSafeBrakingAcceleration(speed: Double): Double {
+        val aBrakeEmergency = getEmergencyBrakingDeceleration(speed)
+        val kDry = getRollingStockCorrectionFactorDry(speed)
+        val kWet = getRollingStockCorrectionFactorWet(speed)
+        return kDry * (kWet + mNvavadh * (1 - kWet)) * aBrakeEmergency
+    }
+
+    private fun getEmergencyBrakingDeceleration(speed: Double): Double {
+        return gammaEmergency.getValue(speed)
+    }
+
+    /**
+     * Corresponds to the correction factor of the emergency brake deceleration on dry tracks. The
+     * confidence level mNvebcl is the confidence level that the corresponding deceleration can be
+     * reached, but does not impact the calculation of kDry. See Subset §3.13.6.2.1.7.
+     */
+    private fun getRollingStockCorrectionFactorDry(speed: Double): Double {
+        return kDry.getValue(speed)
+    }
+
+    /** Corresponds to the correction factor of the emergency brake deceleration on wet tracks. */
+    private fun getRollingStockCorrectionFactorWet(speed: Double): Double {
+        return kWet.getValue(speed)
+    }
+
+    fun getServiceBrakingAcceleration(speed: Double): Double {
+        return gammaService.getValue(speed)
+    }
+
+    fun getNormalServiceBrakingAcceleration(speed: Double): Double {
+        return gammaNormalService.getValue(speed)
+    }
+
+    /**
+     * Gradient acceleration correction using on-board correction factors kN+ and kN-. See Subset,
+     * §3.13.6.4.2 and §3.13.6.4.3.
+     */
+    fun getGradientAccelerationCorrection(grade: Double, speed: Double): Double {
+        val k = if (grade >= 0) kNPos.getValue(speed) else kNNeg.getValue(speed)
+        return -k * grade / 1000
+    }
+
+    class SpeedIntervalValueCurve(
+        /**
+         * Speed in m/s (sorted ascending). External bounds are implicit to
+         * [0, rolling_stock.max_speed]
+         */
+        var boundaries: DoubleArray,
+        /**
+         * Interval values (unit to be made explicit at use) There must be one more value than
+         * boundaries
+         */
+        var values: DoubleArray,
+    ) {
+        fun getValue(speed: Double): Double {
+            assert(values.size == boundaries.size + 1)
+            var index = 0
+            val absSpeed = abs(speed)
+            for (boundary in boundaries) {
+                if (absSpeed <= boundary) {
+                    return values[index]
+                }
+                index++
+            }
+            return values[index]
+        }
+    }
+}
+
+/** National Default Value: Available Adhesion. Found in Subset Appendix A.3.2 table. */
+private const val mNvavadh = 0.0
+
+fun RJSEtcsBrakeParams.toEtcsBrakeParams(): EtcsBrakeParams =
+    EtcsBrakeParams(
+        gammaEmergency = gammaEmergency.toSpeedIntervalValueCurve(),
+        gammaService = gammaService.toSpeedIntervalValueCurve(),
+        gammaNormalService = gammaNormalService.toSpeedIntervalValueCurve(),
+        kDry = kDry.toSpeedIntervalValueCurve(),
+        kWet = kWet.toSpeedIntervalValueCurve(),
+        kNPos = kNPos.toSpeedIntervalValueCurve(),
+        kNNeg = kNNeg.toSpeedIntervalValueCurve(),
+        tTractionCutOff = tTractionCutOff,
+        tBs1 = tBs1,
+        tBs2 = tBs2,
+        tBe = tBe,
+    )
+
+fun RJSEtcsBrakeParams.RJSSpeedIntervalValueCurve.toSpeedIntervalValueCurve():
+    EtcsBrakeParams.SpeedIntervalValueCurve =
+    EtcsBrakeParams.SpeedIntervalValueCurve(boundaries = boundaries, values = values)

--- a/core/envelope-sim/src/testFixtures/java/fr/sncf/osrd/envelope_sim/SimpleRollingStock.java
+++ b/core/envelope-sim/src/testFixtures/java/fr/sncf/osrd/envelope_sim/SimpleRollingStock.java
@@ -3,7 +3,7 @@ package fr.sncf.osrd.envelope_sim;
 import com.google.common.collect.ImmutableRangeMap;
 import com.google.common.collect.Range;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import fr.sncf.osrd.railjson.schema.rollingstock.RJSEtcsBrakeParams;
+import fr.sncf.osrd.envelope_sim.etcs.EtcsBrakeParams;
 import java.util.ArrayList;
 
 @SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
@@ -92,7 +92,7 @@ public class SimpleRollingStock implements PhysicsRollingStock {
     }
 
     @Override
-    public RJSEtcsBrakeParams getRJSEtcsBrakeParams() {
+    public EtcsBrakeParams getEtcsBrakeParams() {
         throw new UnsupportedOperationException("To be implemented");
     }
 

--- a/core/osrd-railjson/src/main/java/fr/sncf/osrd/railjson/schema/rollingstock/RJSEtcsBrakeParams.java
+++ b/core/osrd-railjson/src/main/java/fr/sncf/osrd/railjson/schema/rollingstock/RJSEtcsBrakeParams.java
@@ -9,42 +9,39 @@ import com.squareup.moshi.Json;
  */
 public class RJSEtcsBrakeParams {
 
-    /** National Default Value: Available Adhesion. Found in Subset Appendix A.3.2 table. */
-    private static final double mNvavadh = 0.0;
-
     // A_brake_emergency: the emergency deceleration curve (values > 0 m/s²)
     @Json(name = "gamma_emergency")
-    private RJSSpeedIntervalValueCurve gammaEmergency;
+    public RJSSpeedIntervalValueCurve gammaEmergency;
 
     // A_brake_service: the full service deceleration curve (values > 0 m/s²)
     @Json(name = "gamma_service")
-    private RJSSpeedIntervalValueCurve gammaService;
+    public RJSSpeedIntervalValueCurve gammaService;
 
     // A_brake_normal_service: the normal service deceleration curve used to compute guidance curve (values > 0 m/s²)
     @Json(name = "gamma_normal_service")
-    private RJSSpeedIntervalValueCurve gammaNormalService;
+    public RJSSpeedIntervalValueCurve gammaNormalService;
 
     // Kdry_rst: the rolling stock deceleration correction factors for dry rails
     // Boundaries should be the same as gammaEmergency
     // Values (no unit) should be contained in [0, 1]
     @Json(name = "k_dry")
-    private RJSSpeedIntervalValueCurve kDry;
+    public RJSSpeedIntervalValueCurve kDry;
 
     // Kwet_rst: the rolling stock deceleration correction factors for wet rails
     // Boundaries should be the same as gammaEmergency
     // Values (no unit) should be contained in [0, 1]
     @Json(name = "k_wet")
-    private RJSSpeedIntervalValueCurve kWet;
+    public RJSSpeedIntervalValueCurve kWet;
 
     // Kn+: the correction acceleration factor on normal service deceleration in positive gradients
     // Values (in m/s²) should be contained in [0, 10]
     @Json(name = "k_n_pos")
-    private RJSSpeedIntervalValueCurve kNPos;
+    public RJSSpeedIntervalValueCurve kNPos;
 
     // Kn-: the correction acceleration factor on normal service deceleration in negative gradients
     // Values (in m/s²) should be contained in [0, 10]
     @Json(name = "k_n_neg")
-    private RJSSpeedIntervalValueCurve kNNeg;
+    public RJSSpeedIntervalValueCurve kNNeg;
 
     // T_traction_cut_off: time delay in s from the traction cut-off command to the moment the acceleration due to
     // traction is zero
@@ -88,49 +85,6 @@ public class RJSEtcsBrakeParams {
         this.tBe = tBe;
     }
 
-    /** See Subset §3.13.6.2.1.4. */
-    public double getSafeBrakingAcceleration(double speed) {
-        var aBrakeEmergency = getEmergencyBrakingDeceleration(speed);
-        var kDry = getRollingStockCorrectionFactorDry(speed);
-        var kWet = getRollingStockCorrectionFactorWet(speed);
-        return kDry * (kWet + mNvavadh * (1 - kWet)) * aBrakeEmergency;
-    }
-
-    private double getEmergencyBrakingDeceleration(double speed) {
-        return gammaEmergency.getValue(speed);
-    }
-
-    /**
-     * Corresponds to the correction factor of the emergency brake deceleration on dry tracks.
-     * The confidence level mNvebcl is the confidence level that the corresponding deceleration can be reached,
-     * but does not impact the calculation of kDry. See Subset §3.13.6.2.1.7.
-     */
-    private double getRollingStockCorrectionFactorDry(double speed) {
-        return kDry.getValue(speed);
-    }
-
-    /** Corresponds to the correction factor of the emergency brake deceleration on wet tracks. */
-    private double getRollingStockCorrectionFactorWet(double speed) {
-        return kWet.getValue(speed);
-    }
-
-    public double getServiceBrakingAcceleration(double speed) {
-        return gammaService.getValue(speed);
-    }
-
-    public double getNormalServiceBrakingAcceleration(double speed) {
-        return gammaNormalService.getValue(speed);
-    }
-
-    /**
-     * Gradient acceleration correction using on-board correction factors kN+ and kN-.
-     * See Subset, §3.13.6.4.2 and §3.13.6.4.3.
-     */
-    public double getGradientAccelerationCorrection(double grade, double speed) {
-        var k = grade >= 0 ? kNPos.getValue(speed) : kNNeg.getValue(speed);
-        return -k * grade / 1000;
-    }
-
     public static final class RJSSpeedIntervalValueCurve {
         // Speed in m/s (sorted ascending). External bounds are implicit to [0, rolling_stock.max_speed]
         public double[] boundaries;
@@ -142,21 +96,6 @@ public class RJSEtcsBrakeParams {
         public RJSSpeedIntervalValueCurve(double[] boundaries, double[] values) {
             this.boundaries = boundaries;
             this.values = values;
-        }
-
-        public double getValue(double speed) {
-            assert (boundaries != null);
-            assert (values != null);
-            assert (values.length == boundaries.length + 1);
-            int index = 0;
-            var absSpeed = Math.abs(speed);
-            for (var boundary : boundaries) {
-                if (absSpeed <= boundary) {
-                    return values[index];
-                }
-                index++;
-            }
-            return values[index];
         }
     }
 }

--- a/core/src/main/java/fr/sncf/osrd/train/RollingStock.java
+++ b/core/src/main/java/fr/sncf/osrd/train/RollingStock.java
@@ -6,12 +6,12 @@ import com.google.common.collect.RangeMap;
 import com.google.common.collect.TreeRangeMap;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import fr.sncf.osrd.envelope_sim.PhysicsRollingStock;
+import fr.sncf.osrd.envelope_sim.etcs.EtcsBrakeParams;
 import fr.sncf.osrd.path.interfaces.Electrification;
 import fr.sncf.osrd.path.legacy_objects.electrification.Electrified;
 import fr.sncf.osrd.path.legacy_objects.electrification.Neutral;
 import fr.sncf.osrd.path.legacy_objects.electrification.NonElectrified;
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort;
-import fr.sncf.osrd.railjson.schema.rollingstock.RJSEtcsBrakeParams;
 import fr.sncf.osrd.railjson.schema.rollingstock.RJSLoadingGaugeType;
 import java.util.Map;
 import java.util.Set;
@@ -35,7 +35,7 @@ public final class RollingStock implements PhysicsRollingStock {
     /** the deceleration of the train, in m/s^2 */
     public final double constGamma;
 
-    public final RJSEtcsBrakeParams etcsBrakeParams;
+    public final EtcsBrakeParams etcsBrakeParams;
 
     /** the length of the train, in meters. */
     public final double length;
@@ -123,7 +123,7 @@ public final class RollingStock implements PhysicsRollingStock {
     }
 
     @Override
-    public RJSEtcsBrakeParams getRJSEtcsBrakeParams() {
+    public EtcsBrakeParams getEtcsBrakeParams() {
         assert etcsBrakeParams != null;
         return etcsBrakeParams;
     }
@@ -281,7 +281,7 @@ public final class RollingStock implements PhysicsRollingStock {
             double startUpAcceleration,
             double comfortAcceleration,
             double constGamma,
-            RJSEtcsBrakeParams etcsBrakeParams,
+            EtcsBrakeParams etcsBrakeParams,
             RJSLoadingGaugeType loadingGaugeType,
             Map<String, ModeEffortCurves> modes,
             String defaultMode,
@@ -325,7 +325,7 @@ public final class RollingStock implements PhysicsRollingStock {
             double startUpAcceleration,
             double comfortAcceleration,
             double constGamma,
-            RJSEtcsBrakeParams etcsBrakeParams,
+            EtcsBrakeParams etcsBrakeParams,
             RJSLoadingGaugeType loadingGaugeType,
             Map<String, ModeEffortCurves> modes,
             String defaultMode,

--- a/core/src/main/kotlin/fr/sncf/osrd/api/RollingStockParser.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/RollingStockParser.kt
@@ -2,6 +2,7 @@ package fr.sncf.osrd.api
 
 import fr.sncf.osrd.api.standalone_sim.PhysicsConsistModel
 import fr.sncf.osrd.envelope_sim.PhysicsRollingStock.TractiveEffortPoint
+import fr.sncf.osrd.envelope_sim.etcs.toEtcsBrakeParams
 import fr.sncf.osrd.railjson.schema.rollingstock.RJSEffortCurves.*
 import fr.sncf.osrd.railjson.schema.rollingstock.RJSLoadingGaugeType
 import fr.sncf.osrd.railjson.schema.rollingstock.RJSRollingResistance
@@ -47,7 +48,7 @@ fun parseRawRollingStock(
         rawPhysicsConsist.startupAcceleration,
         rawPhysicsConsist.comfortAcceleration,
         rawPhysicsConsist.constGamma,
-        rawPhysicsConsist.etcsBrakeParams,
+        rawPhysicsConsist.etcsBrakeParams?.toEtcsBrakeParams(),
         loadingGaugeType,
         modes,
         rawPhysicsConsist.effortCurves.defaultMode,

--- a/core/src/test/java/fr/sncf/osrd/train/TestTrains.java
+++ b/core/src/test/java/fr/sncf/osrd/train/TestTrains.java
@@ -4,9 +4,9 @@ import static fr.sncf.osrd.envelope_sim.SimpleRollingStock.createEffortSpeedCurv
 
 import com.google.common.collect.Lists;
 import fr.sncf.osrd.envelope_sim.SimpleRollingStock.CurveShape;
+import fr.sncf.osrd.envelope_sim.etcs.EtcsBrakeParams;
+import fr.sncf.osrd.envelope_sim.etcs.EtcsBrakeParams.SpeedIntervalValueCurve;
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort;
-import fr.sncf.osrd.railjson.schema.rollingstock.RJSEtcsBrakeParams;
-import fr.sncf.osrd.railjson.schema.rollingstock.RJSEtcsBrakeParams.RJSSpeedIntervalValueCurve;
 import fr.sncf.osrd.railjson.schema.rollingstock.RJSLoadingGaugeType;
 import java.util.*;
 
@@ -179,19 +179,18 @@ public class TestTrains {
                 0.05,
                 0.25,
                 0.5,
-                new RJSEtcsBrakeParams(
-                        new RJSSpeedIntervalValueCurve(
+                new EtcsBrakeParams(
+                        new SpeedIntervalValueCurve(
                                 new double[] {8.333333, 16.666667, 55.555556, 61.111111},
                                 new double[] {1.11, 1.25, 1.34, 1.17, 0.94}),
-                        new RJSSpeedIntervalValueCurve(
+                        new SpeedIntervalValueCurve(
                                 new double[] {8.333333, 16.666667, 55.555556, 61.111111},
                                 new double[] {0.74, 0.833333, 0.983333, 0.78, 0.626667}),
-                        new RJSSpeedIntervalValueCurve(new double[] {61.111111}, new double[] {0.6, 0.35}),
-                        new RJSSpeedIntervalValueCurve(
-                                new double[] {8.333333, 61.111111}, new double[] {0.72, 0.69, 0.7}),
-                        new RJSSpeedIntervalValueCurve(new double[] {}, new double[] {0.89}),
-                        new RJSSpeedIntervalValueCurve(new double[] {}, new double[] {6.74e-3}),
-                        new RJSSpeedIntervalValueCurve(new double[] {}, new double[] {1.74e-3}),
+                        new SpeedIntervalValueCurve(new double[] {61.111111}, new double[] {0.6, 0.35}),
+                        new SpeedIntervalValueCurve(new double[] {8.333333, 61.111111}, new double[] {0.72, 0.69, 0.7}),
+                        new SpeedIntervalValueCurve(new double[] {}, new double[] {0.89}),
+                        new SpeedIntervalValueCurve(new double[] {}, new double[] {6.74e-3}),
+                        new SpeedIntervalValueCurve(new double[] {}, new double[] {1.74e-3}),
                         1,
                         2,
                         2,


### PR DESCRIPTION
This duplicates `RJSEtcsBrakeParams` into another, moshi-free class. This will allow `PhysicsRollingStock` to be moved to a Kotlin MultiPlatform (KMP) project for use by the new train simulation module. (cf #13273)

All the logic is moved to the new `EtcsBrakeParams` class, while `RJSEtcsBrakeParams` only has data and JSON annotations.

The `RJSEtcsBrakeParams` -> `EtcsBrakeParams` conversion uses extension functions, those will stay in the JVM-only gradle project while `EtcsBrakeParams` will go to the KMP project.