### PR TITLE
editoast: add move endpoint

### DIFF
--- a/editoast/editoast_models/src/round_trips.rs
+++ b/editoast/editoast_models/src/round_trips.rs
@@ -12,7 +12,7 @@ use crate as editoast_models;
 #[derive(Clone, Debug, Model)]
 #[model(row(derive(QueryableByName)))]
 #[model(table = database::tables::paced_train_round_trips)]
-#[model(gen(batch_ops = c))]
+#[model(gen(batch_ops = cd))]
 pub struct PacedTrainRoundTrips {
     pub id: i64,
     /// First ID of the paced train of this round trip
@@ -82,5 +82,25 @@ impl PacedTrainRoundTrips {
         .execute(conn.write().await.deref_mut())
         .await?;
         Ok(nb)
+    }
+
+    /// Retrieves a batch of paced train round trips given a list of paced train IDs
+    ///
+    /// **IMPORTANT**: This function does not take ids of round trips, but rather the IDs of the paced trains
+    pub async fn retrieve_from_paced_train_ids<I: IntoIterator<Item = i64> + Send>(
+        conn: &mut DbConnection,
+        paced_train_ids: I,
+    ) -> Result<Vec<Self>, database::DatabaseError> {
+        use database::tables::paced_train_round_trips::dsl;
+        use diesel::prelude::*;
+        use diesel_async::RunQueryDsl;
+        use std::ops::DerefMut;
+
+        let ids = paced_train_ids.into_iter().collect::<Vec<_>>();
+        let results = database::tables::paced_train_round_trips::table
+            .filter(dsl::left_id.eq_any(&ids).or(dsl::right_id.eq_any(&ids)))
+            .load::<PacedTrainRoundTripsRow>(conn.write().await.deref_mut())
+            .await?;
+        Ok(results.into_iter().map_into().collect())
     }
 }

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -2226,6 +2226,31 @@ paths:
       responses:
         '204':
           description: All paced_trains have been deleted
+  /paced_train/move:
+    patch:
+      tags:
+      - paced_train
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - paced_train_ids
+              - train_schedule_set_id
+              properties:
+                paced_train_ids:
+                  type: array
+                  items:
+                    type: integer
+                    format: int64
+                train_schedule_set_id:
+                  type: integer
+                  format: int64
+        required: true
+      responses:
+        '204':
+          description: The train schedule set is updated with the paced trains
   /paced_train/occupancy_blocks:
     post:
       tags:
@@ -6058,6 +6083,7 @@ components:
       - $ref: '#/components/schemas/EditoastPacedTrainErrorPathfindingFailed'
       - $ref: '#/components/schemas/EditoastPacedTrainErrorRollingStockNotFound'
       - $ref: '#/components/schemas/EditoastPacedTrainErrorSimulationFailed'
+      - $ref: '#/components/schemas/EditoastPacedTrainErrorTrainScheduleSetNotFound'
       - $ref: '#/components/schemas/EditoastPathfindingErrorDatabase'
       - $ref: '#/components/schemas/EditoastPathfindingErrorInfraNotFound'
       - $ref: '#/components/schemas/EditoastPathfindingViewErrorsEndingTrackLocationNotFound'
@@ -6984,6 +7010,30 @@ components:
           type: string
           enum:
           - editoast:paced_train:SimulationFailed
+    EditoastPacedTrainErrorTrainScheduleSetNotFound:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+          required:
+          - train_schedule_set_id
+          properties:
+            train_schedule_set_id:
+              type: integer
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 404
+        type:
+          type: string
+          enum:
+          - editoast:paced_train:TrainScheduleSetNotFound
     EditoastPathfindingErrorDatabase:
       type: object
       required:

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -262,6 +262,12 @@ fn service_router() -> router::DocumentedRouter {
                         post!(timetable::paced_train::simulation_summary),
                     )
                     .route(
+                        "/move",
+                        patch!(
+                            timetable::paced_train::move_paced_trains_to_another_train_schedule_set
+                        ),
+                    )
+                    .route(
                         "/track_occupancy",
                         post!(timetable::paced_train::track_occupancy),
                     )

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -16,8 +16,10 @@ use core_client::simulation::PhysicsConsist;
 use database::DbConnectionPoolV2;
 use editoast_derive::EditoastError;
 use editoast_models::prelude::*;
+use editoast_models::round_trips::PacedTrainRoundTrips;
 use itertools::Itertools;
 use itertools::izip;
+use reqwest::StatusCode;
 use schemas::paced_train::PacedTrain;
 use schemas::primitives::TimeWindow;
 use schemas::train_schedule::OperationalPointPartReference;
@@ -35,6 +37,7 @@ use crate::models;
 use crate::models::Infra;
 use crate::models::paced_train::OccurrenceId;
 use crate::models::paced_train::PacedTrainChangeset;
+use crate::models::train_schedule_set::TrainScheduleSet;
 use crate::views::AuthorizationError;
 use crate::views::infra::InfraIdQueryParam;
 use crate::views::path::path_item_cache::PathItemCache;
@@ -88,6 +91,10 @@ enum PacedTrainError {
     #[error("Simulation failed for train schedule '{paced_train_id}'")]
     #[editoast_error(status = 404)]
     SimulationFailed { paced_train_id: i64 },
+    #[error("Train schedule set '{train_schedule_set_id}', could not be found")]
+    #[editoast_error(status = 404)]
+    TrainScheduleSetNotFound { train_schedule_set_id: i64 },
+
     #[error(transparent)]
     #[editoast_error(status = 500)]
     Database(#[from] editoast_models::Error),
@@ -1341,6 +1348,96 @@ pub(in crate::views) async fn track_occupancy(
             });
 
     Ok(Json(results))
+}
+
+#[derive(Deserialize, ToSchema)]
+pub(in crate::views) struct MovePacedTrainsForm {
+    pub paced_train_ids: Vec<i64>,
+    pub train_schedule_set_id: i64,
+}
+
+#[editoast_derive::route]
+#[utoipa::path(
+    patch, path = "",
+    tag = "paced_train",
+    request_body = inline(MovePacedTrainsForm),
+    responses(
+        (status = 204, description = "The train schedule set is updated with the paced trains"),
+    ),
+)]
+pub(in crate::views) async fn move_paced_trains_to_another_train_schedule_set(
+    State(db_pool): State<Arc<DbConnectionPoolV2>>,
+    Extension(auth): AuthenticationExt,
+    Json(MovePacedTrainsForm {
+        paced_train_ids,
+        train_schedule_set_id,
+    }): Json<MovePacedTrainsForm>,
+) -> Result<impl IntoResponse> {
+    let authorized = auth
+        .check_roles([authz::Role::OperationalStudies].into())
+        .await
+        .map_err(AuthorizationError::AuthError)?;
+    if !authorized {
+        return Err(AuthorizationError::Forbidden.into());
+    }
+
+    TrainScheduleSet::exists_or_fail(&mut db_pool.get().await?, train_schedule_set_id, || {
+        PacedTrainError::TrainScheduleSetNotFound {
+            train_schedule_set_id,
+        }
+    })
+    .await?;
+
+    let paced_trains: Vec<_> = models::PacedTrain::retrieve_batch_or_fail(
+        &mut db_pool.get().await?,
+        paced_train_ids.clone(),
+        |missing| PacedTrainError::BatchNotFound {
+            count: missing.len(),
+        },
+    )
+    .await?;
+
+    // Filter paced trains ids to remove ones that are already in the provided train schedule set
+    let paced_train_ids = paced_trains
+        .into_iter()
+        .filter_map(|paced_train| {
+            if paced_train.train_schedule_set_id != train_schedule_set_id {
+                Some(paced_train.id)
+            } else {
+                None
+            }
+        })
+        .collect_vec();
+
+    // Check if some paced trains are part of a round_trips
+    let round_trips = PacedTrainRoundTrips::retrieve_from_paced_train_ids(
+        &mut db_pool.get().await?,
+        paced_train_ids.clone(),
+    )
+    .await?;
+
+    let mut to_break: Vec<i64> = vec![];
+
+    for round_trip in round_trips {
+        // We extract right_id, if it is None we skip the iteration
+        let Some(right_id) = round_trip.right_id else {
+            continue;
+        };
+        // If one of the two trains is not a train we want to move, we add the ID to to_break
+        if !paced_train_ids.contains(&right_id) || !paced_train_ids.contains(&round_trip.left_id) {
+            to_break.push(round_trip.id);
+        }
+    }
+
+    PacedTrainRoundTrips::delete_batch(&mut db_pool.get().await?, to_break).await?;
+
+    // Update the train_schedule_set_id of the paced trains
+    let _: (Vec<_>, _) = models::PacedTrain::changeset()
+        .train_schedule_set_id(train_schedule_set_id)
+        .update_batch(&mut db_pool.get().await?, paced_train_ids)
+        .await?;
+
+    Ok(StatusCode::NO_CONTENT)
 }
 
 #[cfg(test)]

--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -157,7 +157,8 @@
       "OperationalPointNotFound": "Operational point '{{operational_point_id}}' could not be found",
       "PathfindingFailed": "Pathfinding failed for paced train '{{paced_train_id}}'",
       "RollingStockNotFound": "Rolling Stock '{{rolling_stock_name}}' could not be found",
-      "SimulationFailed": "Simulation failed for paced train '{{paced_train_id}}'"
+      "SimulationFailed": "Simulation failed for paced train '{{paced_train_id}}'",
+      "TrainScheduleSetNotFound": "Train schedule set '{{train_schedule_set_id}}' could not be found"
     },
     "pathfinding": {
       "Database": "Internal error (database)",

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -157,7 +157,8 @@
       "OperationalPointNotFound": "Point remarquable '{{operational_point_id}}' non trouvé",
       "PathfindingFailed": "La recherche de chemin n'a pas abouti pour la mission '{{paced_train_id}}'",
       "RollingStockNotFound": "Matériel roulant '{{rolling_stock_name}}' non trouvé",
-      "SimulationFailed": "La simulation n'a pas abouti pour la mission '{{paced_train_id}}'"
+      "SimulationFailed": "La simulation n'a pas abouti pour la mission '{{paced_train_id}}'",
+      "TrainScheduleSetNotFound": "Paquet de train '{{train_schedule_set_id}}' non trouvé"
     },
     "pathfinding": {
       "Database": "Erreur interne (base de données)",

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -639,6 +639,13 @@ const injectedRtkApi = api
         query: (queryArg) => ({ url: `/paced_train`, method: 'DELETE', body: queryArg.body }),
         invalidatesTags: ['timetable', 'paced_train'],
       }),
+      patchPacedTrainMove: build.mutation<
+        PatchPacedTrainMoveApiResponse,
+        PatchPacedTrainMoveApiArg
+      >({
+        query: (queryArg) => ({ url: `/paced_train/move`, method: 'PATCH', body: queryArg.body }),
+        invalidatesTags: ['paced_train'],
+      }),
       postPacedTrainOccupancyBlocks: build.query<
         PostPacedTrainOccupancyBlocksApiResponse,
         PostPacedTrainOccupancyBlocksApiArg
@@ -1944,6 +1951,13 @@ export type DeletePacedTrainApiResponse = unknown;
 export type DeletePacedTrainApiArg = {
   body: {
     ids: number[];
+  };
+};
+export type PatchPacedTrainMoveApiResponse = unknown;
+export type PatchPacedTrainMoveApiArg = {
+  body: {
+    paced_train_ids: number[];
+    train_schedule_set_id: number;
   };
 };
 export type PostPacedTrainOccupancyBlocksApiResponse = /** status 200  */ {


### PR DESCRIPTION
add `PATCH /paced_train/move` endpoint that allows moving paced trains from a train_schedule_set to another.