### PR TITLE
editoast: update train schedule sets and catalog entry endpoints

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -283,7 +283,7 @@ paths:
                       type: string
                     type:
                       $ref: '#/components/schemas/SubjectType'
-  /catalog_entry:
+  /catalog_entries:
     get:
       tags:
       - catalog_entry
@@ -321,6 +321,7 @@ paths:
                       type: array
                       items:
                         $ref: '#/components/schemas/CatalogEntry'
+  /catalog_entry:
     post:
       tags:
       - catalog_entry
@@ -338,26 +339,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/CatalogEntry'
   /catalog_entry/{id}:
-    get:
-      tags:
-      - catalog_entry
-      parameters:
-      - name: id
-        in: path
-        description: A catalog entry ID
-        required: true
-        schema:
-          type: integer
-          format: int64
-      responses:
-        '200':
-          description: Catalog entry
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CatalogEntry'
-        '404':
-          description: Catalog entry not found
     put:
       tags:
       - catalog_entry
@@ -4379,39 +4360,6 @@ paths:
         '204':
           description: No content when successful
   /train_schedule_set:
-    get:
-      tags:
-      - train_schedule_set
-      parameters:
-      - name: catalog_entry_id
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int64
-      - name: published
-        in: query
-        required: false
-        schema:
-          type: boolean
-      responses:
-        '200':
-          description: list of train schedule sets
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  allOf:
-                  - $ref: '#/components/schemas/TrainScheduleSet'
-                  - type: object
-                    required:
-                    - train_schedule_count
-                    properties:
-                      train_schedule_count:
-                        type: integer
-                        format: int64
-                        minimum: 0
     post:
       tags:
       - train_schedule_set
@@ -4522,6 +4470,40 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/PacedTrainResponse'
+  /train_schedule_sets:
+    get:
+      tags:
+      - train_schedule_set
+      parameters:
+      - name: catalog_entry_id
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int64
+      - name: published
+        in: query
+        required: false
+        schema:
+          type: boolean
+      responses:
+        '200':
+          description: list of train schedule sets
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  allOf:
+                  - $ref: '#/components/schemas/TrainScheduleSet'
+                  - type: object
+                    required:
+                    - train_schedule_count
+                    properties:
+                      train_schedule_count:
+                        type: integer
+                        format: int64
+                        minimum: 0
   /version:
     get:
       responses:

--- a/editoast/src/models/train_schedule_set.rs
+++ b/editoast/src/models/train_schedule_set.rs
@@ -1,7 +1,12 @@
+use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use editoast_derive::Model;
 use serde::Deserialize;
 use serde::Serialize;
+use std::ops::DerefMut;
 use utoipa::ToSchema;
+
+use database::DbConnection;
 
 #[derive(Deserialize, Serialize, ToSchema, Debug, Clone, Model)]
 #[model(table = database::tables::train_schedule_set)]
@@ -13,4 +18,20 @@ pub struct TrainScheduleSet {
     pub name: Option<String>,
     pub description: String,
     pub published: bool,
+}
+
+impl TrainScheduleSet {
+    pub async fn train_schedule_count(
+        train_schedule_set_id: i64,
+        conn: &mut DbConnection,
+    ) -> Result<i64, database::DatabaseError> {
+        use database::tables::paced_train::dsl;
+
+        dsl::paced_train
+            .filter(dsl::train_schedule_set_id.eq(train_schedule_set_id))
+            .count()
+            .get_result(conn.write().await.deref_mut())
+            .await
+            .map_err(Into::into)
+    }
 }

--- a/editoast/src/views/catalog_entry.rs
+++ b/editoast/src/views/catalog_entry.rs
@@ -96,7 +96,7 @@ pub(in crate::views) struct CatalogEntryPage {
         (status = 200, description = "List of catalog entries", body = inline(CatalogEntryPage)),
     ),
 )]
-pub(in crate::views) async fn get(
+pub(in crate::views) async fn list_paginated(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
     Extension(auth): AuthenticationExt,
     Query(pagination_params): Query<PaginationQueryParams<100>>,
@@ -117,39 +117,6 @@ pub(in crate::views) async fn get(
         results: catalog_entries,
         stats,
     }))
-}
-
-#[editoast_derive::route]
-#[utoipa::path(
-        get, path = "",
-        tag = "catalog_entry",
-        params(CatalogEntryIdParam),
-    responses(
-        (status = 200, description = "Catalog entry", body = CatalogEntry),
-        (status = 404, description = "Catalog entry not found"),
-    ),
-)]
-pub(in crate::views) async fn get_by_id(
-    State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
-    Path(CatalogEntryIdParam {
-        id: catalog_entry_id,
-    }): Path<CatalogEntryIdParam>,
-) -> Result<Json<CatalogEntry>> {
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
-    let catalog_entry_result =
-        CatalogEntry::retrieve_or_fail(db_pool.get().await?, catalog_entry_id, || {
-            CatalogEntryError::NotFound { catalog_entry_id }
-        })
-        .await?;
-    Ok(Json(catalog_entry_result))
 }
 
 #[editoast_derive::route]

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -424,7 +424,6 @@ fn service_router() -> router::DocumentedRouter {
             //
             .nests("/train_schedule_set", |path| {
                 path.route("/", post!(train_schedule_set::post))
-                    .route("/", get!(train_schedule_set::get))
                     .nests("/{id}", |path| {
                         path.route("/", get!(train_schedule_set::get_by_id))
                             .route("/", put!(train_schedule_set::put))
@@ -432,14 +431,20 @@ fn service_router() -> router::DocumentedRouter {
                             .route("/paced_trains", post!(train_schedule_set::post_paced_train))
                     })
             })
+            .nests("/train_schedule_sets", |path| {
+                path.route("/", get!(train_schedule_set::get))
+            })
             .nests("/catalog_entry", |path| {
                 path.route("/", post!(catalog_entry::post))
-                    .route("/", get!(catalog_entry::get))
                     .nests("/{id}", |path| {
-                        path.route("/", get!(catalog_entry::get_by_id))
-                            .route("/", put!(catalog_entry::put))
-                            .route("/", delete!(catalog_entry::delete))
+                        {
+                            path.route("/", put!(catalog_entry::put))
+                                .route("/", delete!(catalog_entry::delete))
+                        }
                     })
+            })
+            .nests("/catalog_entries", |path| {
+                path.route("/", get!(catalog_entry::list_paginated))
             })
             //
             // level_crossings

--- a/editoast/src/views/train_schedule_set.rs
+++ b/editoast/src/views/train_schedule_set.rs
@@ -48,30 +48,14 @@ pub(in crate::views) struct TrainScheduleSetResponse {
 impl TrainScheduleSetResponse {
     pub async fn try_fetch(
         conn: &mut DbConnection,
-        published: Option<bool>,
-        catalog_entry_id: Option<i64>,
-    ) -> Result<Vec<Self>> {
-        let mut settings = SelectionSettings::new();
-
-        if let Some(catalog_entry_id) = catalog_entry_id {
-            settings = settings
-                .filter(move || TrainScheduleSet::CATALOG_ENTRY_ID.eq(Some(catalog_entry_id)));
-        }
-
-        if let Some(published) = published {
-            settings = settings.filter(move || TrainScheduleSet::PUBLISHED.eq(published));
-        }
-
-        let train_schedule_sets = TrainScheduleSet::list(conn, settings).await?;
-        Ok(train_schedule_sets
-            .into_iter()
-            .map(|train_schedule_set| Self {
-                train_schedule_set,
-                // TODO: Add database operation to get train schedule set count
-                // once paced trains and train schedules are merged
-                train_schedule_count: 0,
-            })
-            .collect())
+        train_schedule_set: TrainScheduleSet,
+    ) -> Result<Self> {
+        let train_schedule_count =
+            TrainScheduleSet::train_schedule_count(train_schedule_set.id, conn).await? as u64;
+        Ok(Self {
+            train_schedule_set,
+            train_schedule_count,
+        })
     }
 }
 #[derive(Serialize, Deserialize, ToSchema)]
@@ -126,8 +110,6 @@ pub(in crate::views) async fn post(
 
     Ok(Json(TrainScheduleSetResponse {
         train_schedule_set,
-        // TODO: Add database operation to get train schedule set count
-        // once paced trains and train schedules are merged
         train_schedule_count: 0,
     }))
 }
@@ -171,12 +153,10 @@ pub(in crate::views) async fn get_by_id(
             }
         })
         .await?;
-    Ok(Json(TrainScheduleSetResponse {
-        train_schedule_set,
-        // TODO: Add database operation to get train schedule set count
-        // once paced trains and train schedules are merged
-        train_schedule_count: 0,
-    }))
+
+    let train_schedule_set_response =
+        TrainScheduleSetResponse::try_fetch(&mut db_pool.get().await?, train_schedule_set).await?;
+    Ok(Json(train_schedule_set_response))
 }
 
 #[editoast_derive::route]
@@ -205,9 +185,29 @@ pub(in crate::views) async fn get(
     }
 
     let conn = &mut db_pool.get().await?;
-    let train_schedule_sets =
-        TrainScheduleSetResponse::try_fetch(conn, published, catalog_entry_id).await?;
-    Ok(Json(train_schedule_sets))
+
+    let mut settings = SelectionSettings::new();
+
+    if let Some(catalog_entry_id) = catalog_entry_id {
+        settings =
+            settings.filter(move || TrainScheduleSet::CATALOG_ENTRY_ID.eq(Some(catalog_entry_id)));
+    }
+
+    if let Some(published) = published {
+        settings = settings.filter(move || TrainScheduleSet::PUBLISHED.eq(published));
+    }
+
+    let train_schedule_sets = TrainScheduleSet::list(conn, settings).await?;
+
+    let results = train_schedule_sets
+        .into_iter()
+        .zip(db_pool.iter_conn())
+        .map(|(train_schedule_set, conn)| async move {
+            TrainScheduleSetResponse::try_fetch(&mut conn.await?, train_schedule_set).await
+        });
+
+    let results = futures::future::try_join_all(results).await?;
+    Ok(Json(results))
 }
 
 #[editoast_derive::route]
@@ -246,12 +246,10 @@ pub(in crate::views) async fn put(
             }
         })
         .await?;
-    let train_schedule_set_response = TrainScheduleSetResponse {
-        train_schedule_set,
-        // TODO: Add database operation to get train schedule set count
-        // once paced trains and train schedules are merged
-        train_schedule_count: 0,
-    };
+
+    let train_schedule_set_response =
+        TrainScheduleSetResponse::try_fetch(&mut db_pool.get().await?, train_schedule_set).await?;
+
     Ok(Json(train_schedule_set_response))
 }
 

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -73,9 +73,9 @@ const injectedRtkApi = api
         query: (queryArg) => ({ url: `/authz/${queryArg.resourceType}/${queryArg.resourceId}` }),
         providesTags: ['authz'],
       }),
-      getCatalogEntry: build.query<GetCatalogEntryApiResponse, GetCatalogEntryApiArg>({
+      getCatalogEntries: build.query<GetCatalogEntriesApiResponse, GetCatalogEntriesApiArg>({
         query: (queryArg) => ({
-          url: `/catalog_entry`,
+          url: `/catalog_entries`,
           params: {
             page: queryArg.page,
             page_size: queryArg.pageSize,
@@ -90,10 +90,6 @@ const injectedRtkApi = api
           body: queryArg.catalogEntryForm,
         }),
         invalidatesTags: ['catalog_entry'],
-      }),
-      getCatalogEntryById: build.query<GetCatalogEntryByIdApiResponse, GetCatalogEntryByIdApiArg>({
-        query: (queryArg) => ({ url: `/catalog_entry/${queryArg.id}` }),
-        providesTags: ['catalog_entry'],
       }),
       putCatalogEntryById: build.mutation<
         PutCatalogEntryByIdApiResponse,
@@ -1238,16 +1234,6 @@ const injectedRtkApi = api
         }),
         invalidatesTags: ['rolling_stock'],
       }),
-      getTrainScheduleSet: build.query<GetTrainScheduleSetApiResponse, GetTrainScheduleSetApiArg>({
-        query: (queryArg) => ({
-          url: `/train_schedule_set`,
-          params: {
-            catalog_entry_id: queryArg.catalogEntryId,
-            published: queryArg.published,
-          },
-        }),
-        providesTags: ['train_schedule_set'],
-      }),
       postTrainScheduleSet: build.mutation<
         PostTrainScheduleSetApiResponse,
         PostTrainScheduleSetApiArg
@@ -1294,6 +1280,19 @@ const injectedRtkApi = api
           body: queryArg.body,
         }),
         invalidatesTags: ['train_schedule_set', 'paced_train'],
+      }),
+      getTrainScheduleSets: build.query<
+        GetTrainScheduleSetsApiResponse,
+        GetTrainScheduleSetsApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/train_schedule_sets`,
+          params: {
+            catalog_entry_id: queryArg.catalogEntryId,
+            published: queryArg.published,
+          },
+        }),
+        providesTags: ['train_schedule_set'],
       }),
       getVersion: build.query<GetVersionApiResponse, GetVersionApiArg>({
         query: () => ({ url: `/version` }),
@@ -1448,22 +1447,17 @@ export type GetAuthzByResourceTypeAndResourceIdApiArg = {
   resourceType: ResourceType;
   resourceId: number;
 };
-export type GetCatalogEntryApiResponse =
+export type GetCatalogEntriesApiResponse =
   /** status 200 List of catalog entries */ PaginationStats & {
     results: CatalogEntry[];
   };
-export type GetCatalogEntryApiArg = {
+export type GetCatalogEntriesApiArg = {
   page?: number;
   pageSize?: number;
 };
 export type PostCatalogEntryApiResponse = /** status 201 Catalog entry */ CatalogEntry;
 export type PostCatalogEntryApiArg = {
   catalogEntryForm: CatalogEntryForm;
-};
-export type GetCatalogEntryByIdApiResponse = /** status 200 Catalog entry */ CatalogEntry;
-export type GetCatalogEntryByIdApiArg = {
-  /** A catalog entry ID */
-  id: number;
 };
 export type PutCatalogEntryByIdApiResponse = /** status 200 Catalog entry */ CatalogEntry;
 export type PutCatalogEntryByIdApiArg = {
@@ -2491,14 +2485,6 @@ export type PatchTowedRollingStockByTowedRollingStockIdLockedApiArg = {
   towedRollingStockId: number;
   towedRollingStockLockedForm: TowedRollingStockLockedForm;
 };
-export type GetTrainScheduleSetApiResponse =
-  /** status 200 list of train schedule sets */ (TrainScheduleSet & {
-    train_schedule_count: number;
-  })[];
-export type GetTrainScheduleSetApiArg = {
-  catalogEntryId?: number;
-  published?: boolean;
-};
 export type PostTrainScheduleSetApiResponse =
   /** status 201 Train schedule set */ TrainScheduleSetResponse;
 export type PostTrainScheduleSetApiArg = {
@@ -2528,6 +2514,14 @@ export type PostTrainScheduleSetByIdPacedTrainsApiArg = {
   /** A train schedule set ID */
   id: number;
   body: PacedTrain[];
+};
+export type GetTrainScheduleSetsApiResponse =
+  /** status 200 list of train schedule sets */ (TrainScheduleSet & {
+    train_schedule_count: number;
+  })[];
+export type GetTrainScheduleSetsApiArg = {
+  catalogEntryId?: number;
+  published?: boolean;
 };
 export type GetVersionApiResponse = /** status 200 Return the service version */ Version;
 export type GetVersionApiArg = void;


### PR DESCRIPTION
Fixed some API routes for the train schedule set and catalog_entry endpoints (first commit)

Adapt train schedule set response (second commit)