### PR TITLE
core: stdcm: log data on post processing failure

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/cli/BenchSTDCM.kt
+++ b/core/src/main/java/fr/sncf/osrd/cli/BenchSTDCM.kt
@@ -17,6 +17,7 @@ import fr.sncf.osrd.cli.ValidateInfra.parseRailJSONFromFile
 import fr.sncf.osrd.pathfinding.Pathfinding
 import fr.sncf.osrd.signaling.etcs_level2.ETCS_LEVEL2
 import fr.sncf.osrd.stdcm.STDCMResult
+import fr.sncf.osrd.stdcm.graph.STDCMGraph
 import fr.sncf.osrd.stdcm.graph.findPath
 import fr.sncf.osrd.stdcm.preprocessing.implementation.makeBlockAvailability
 import fr.sncf.osrd.utils.CSVLogger
@@ -190,6 +191,11 @@ class BenchSTDCM : CliCommand {
                             Pathfinding.TIMEOUT,
                             temporarySpeedLimitManager,
                             allowedTrackSections,
+                            STDCMGraph.SearchMetadata(
+                                request.startTime,
+                                requirements.metadata,
+                                null,
+                            ),
                         )
                     if (path != null && hasDuplicateTracks(infra, path.trainPath)) path = null
                 } catch (e: Exception) {

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/OutputSimDebugData.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/OutputSimDebugData.kt
@@ -14,16 +14,24 @@ import fr.sncf.osrd.api.standalone_sim.polymorphicElectricalProfileAdapter
 import fr.sncf.osrd.api.standalone_sim.polymorphicSimulationResponseAdapter
 import fr.sncf.osrd.api.standalone_sim.polymorphicSpeedLimitSourceAdapter
 import fr.sncf.osrd.path.interfaces.TrainPath
+import fr.sncf.osrd.sim_infra.api.BlockInfra
 import fr.sncf.osrd.sim_infra.api.RawInfra
 import fr.sncf.osrd.sim_infra.api.ZoneId
 import fr.sncf.osrd.stdcm.STDCMResult
 import fr.sncf.osrd.stdcm.graph.EngineeringAllowanceRange
+import fr.sncf.osrd.stdcm.graph.STDCMEdge
+import fr.sncf.osrd.stdcm.graph.STDCMGraph
 import fr.sncf.osrd.utils.json.UnitAdapterFactory
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.TimeDelta
 import fr.sncf.osrd.utils.units.seconds
+import java.time.Duration.ofMillis
 import java.time.ZonedDateTime
 import kotlin.math.min
+
+// Include occupancy for other train up to this amount of seconds before the new train departure and
+// after its arrival
+private const val includedOccupancyMargin = 3_600.0
 
 /**
  * Contains data describing the output stdcm simulation. Meant to contain anything that may be
@@ -33,13 +41,15 @@ import kotlin.math.min
  * For now, this whole file only meant for debugging purposes.
  */
 data class OutputSimDebugData(
-    @Json(name = "sim_output") val simOutput: SimulationSuccess,
+    @Json(name = "sim_output") val simOutput: SimulationSuccess?,
     @Json(name = "path_properties") val pathProperties: PathPropResponse,
     @Json(name = "other_requirements") val otherRequirements: List<TrainZoneRequirement>,
     @Json(name = "departure_time") val departureTime: ZonedDateTime,
     @Json(name = "engineering_allowances_ranges")
     val engineeringAllowanceRanges: List<EngineeringAllowanceRange>,
     @Json(name = "zone_locations") val zoneLocations: List<ZoneLocation>,
+    @Json(name = "train_times") val trainTimes: List<TimeDelta>,
+    @Json(name = "train_positions") val trainPositions: List<Offset<TrainPath>>,
 ) {
     companion object {
         val adapter: JsonAdapter<OutputSimDebugData> =
@@ -71,32 +81,87 @@ fun generateDebugData(
     departureTime: ZonedDateTime,
     requirements: Map<ZoneId, List<STDCMTimetableData.DetailedRequirement>>,
 ): OutputSimDebugData {
+    val minRelevantTime = -includedOccupancyMargin
+    val maxRelevantTime =
+        path.envelope.totalTime + path.stopResults.sumOf { it.duration } + includedOccupancyMargin
     return OutputSimDebugData(
         simOutput = simulationResponse,
         pathProperties = makePathPropResponse(path.trainPath, rawInfra),
-        otherRequirements = makeOtherRequirements(rawInfra, requirements, path),
+        otherRequirements =
+            makeOtherRequirements(
+                rawInfra,
+                requirements,
+                path.departureTime,
+                minRelevantTime,
+                maxRelevantTime,
+                path.trainPath,
+            ),
         departureTime = departureTime,
         engineeringAllowanceRanges = path.engineeringAllowanceRanges,
         zoneLocations =
             path.trainPath.getZoneRanges().map {
                 ZoneLocation(rawInfra.getZoneName(it.value), it.pathBegin, it.pathEnd)
             },
+        trainTimes = simulationResponse.finalOutput.times,
+        trainPositions = simulationResponse.finalOutput.positions,
+    )
+}
+
+fun generatePartialDebugData(
+    rawInfra: RawInfra,
+    blockInfra: BlockInfra,
+    edges: List<STDCMEdge>,
+    searchMetadata: STDCMGraph.SearchMetadata,
+    allowanceRanges: List<EngineeringAllowanceRange>,
+): OutputSimDebugData {
+    val lastEdge = edges.last()
+    val timeData = lastEdge.timeData
+    val trainPath = lastEdge.infraExplorer.buildFullPath(rawInfra, blockInfra)
+    val departureTime =
+        searchMetadata.originalStartTime.plus(ofMillis((timeData.departureTime * 1000).toLong()))
+    val minRelevantTime = -includedOccupancyMargin
+    val maxRelevantTime = timeData.earliestReachableTime + includedOccupancyMargin
+    return OutputSimDebugData(
+        simOutput = null,
+        pathProperties = makePathPropResponse(trainPath, rawInfra),
+        otherRequirements =
+            makeOtherRequirements(
+                rawInfra,
+                searchMetadata.requirementMetadata,
+                timeData.departureTime,
+                minRelevantTime,
+                maxRelevantTime,
+                trainPath,
+            ),
+        departureTime = departureTime,
+        engineeringAllowanceRanges = allowanceRanges,
+        zoneLocations =
+            trainPath.getZoneRanges().map {
+                ZoneLocation(rawInfra.getZoneName(it.value), it.pathBegin, it.pathEnd)
+            },
+        trainTimes =
+            edges.map {
+                (it.timeData.getUpdatedEarliestReachableTime(timeData) - timeData.departureTime)
+                    .seconds
+            },
+        trainPositions = edges.map { it.infraExplorer.getCurrentBlockRange().pathBegin },
     )
 }
 
 fun makeOtherRequirements(
     rawInfra: RawInfra,
     requirements: Map<ZoneId, List<STDCMTimetableData.DetailedRequirement>>,
-    path: STDCMResult,
+    departureTimeDelta: Double,
+    minRelevantTime: Double,
+    maxRelevantTime: Double,
+    trainPath: TrainPath,
 ): List<TrainZoneRequirement> {
     val res = mutableListOf<TrainZoneRequirement>()
-    val minRelevantTime = -3_600.0
-    val maxRelevantTime = path.envelope.totalTime + 3_600.0
-    for (zoneRange in path.trainPath.getZoneRanges()) {
+    for (zoneRange in trainPath.getZoneRanges()) {
         val metadataList = requirements[zoneRange.value] ?: continue
         for (metadata in metadataList) {
-            val beginTime = max(minRelevantTime, metadata.from - path.departureTime)
-            val endTime = min(maxRelevantTime, metadata.to - path.departureTime)
+            val beginTime = max(minRelevantTime, metadata.from - departureTimeDelta)
+            val endTime = min(maxRelevantTime, metadata.to - departureTimeDelta)
             if (endTime < beginTime) continue
             res.add(
                 TrainZoneRequirement(

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
@@ -43,6 +43,7 @@ import fr.sncf.osrd.standalone_sim.runScheduleMetadataExtractor
 import fr.sncf.osrd.stdcm.PlannedTimingData
 import fr.sncf.osrd.stdcm.STDCMResult
 import fr.sncf.osrd.stdcm.STDCMStep
+import fr.sncf.osrd.stdcm.graph.STDCMGraph
 import fr.sncf.osrd.stdcm.graph.checkPlannedStepsAndMaybeIndex
 import fr.sncf.osrd.stdcm.graph.findPath
 import fr.sncf.osrd.stdcm.graph.logger
@@ -145,6 +146,7 @@ class STDCMEndpoint(
                     Pathfinding.TIMEOUT,
                     temporarySpeedLimitManager,
                     allowedTrackSections,
+                    STDCMGraph.SearchMetadata(request.startTime, requirements.metadata, s3Context),
                 )
             if (path == null || hasDuplicateTracks(infra, path.trainPath)) {
                 val response = PathNotFound()

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/PostProcessingSimulation.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/PostProcessingSimulation.kt
@@ -1,6 +1,8 @@
 package fr.sncf.osrd.stdcm.graph
 
 import com.squareup.moshi.Json
+import fr.sncf.osrd.api.stdcm.OutputSimDebugData
+import fr.sncf.osrd.api.stdcm.generatePartialDebugData
 import fr.sncf.osrd.envelope.Envelope
 import fr.sncf.osrd.envelope_sim.EnvelopeSimContext
 import fr.sncf.osrd.envelope_sim.allowances.AllowanceRange
@@ -20,6 +22,7 @@ import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
+import java.io.File
 import java.util.*
 import kotlin.math.max
 import kotlin.math.min
@@ -121,6 +124,7 @@ fun buildFinalEnvelope(
                     fixedPoints,
                     conflictOffset,
                     isMareco,
+                    allowanceRanges,
                 )
             }
             val newPoint =
@@ -475,6 +479,7 @@ private fun handlePostProcessingConflict(
     fixedPoints: TreeSet<FixedTimePoint>,
     conflictOffset: Offset<TrainPath>,
     isMareco: Boolean,
+    allowanceRanges: List<EngineeringAllowanceRange>,
 ): FinalEnvelopeResult {
     postProcessingLogger.error(
         "Conflicts detected in post-processing, mismatch with the exploration data"
@@ -487,6 +492,27 @@ private fun handlePostProcessingConflict(
         "    conflict happened at offset=$conflictOffset/${maxSpeedEnvelope.endPos.toInt()} " +
             "and t=${conflictTime.toInt()}/${updatedTimeData.timeSinceDeparture.toInt()}"
     )
+
+    if (graph.searchMetadata != null) {
+        val stringDebugData by lazy {
+            OutputSimDebugData.adapter.toJson(
+                generatePartialDebugData(
+                    graph.rawInfra,
+                    graph.blockInfra,
+                    edges,
+                    graph.searchMetadata,
+                    allowanceRanges,
+                )
+            )
+        }
+        val filename = System.getenv("STDCM_DEBUG_DATA_FILENAME")
+        if (filename != null) {
+            File(filename).writeText(stringDebugData)
+        }
+        graph.searchMetadata.s3Context?.writeSTDCMFile("failed_simulation_data.json") {
+            stringDebugData
+        }
+    }
 
     var remainingDistance = conflictOffset.distance
     for ((i, edge) in edges.withIndex()) {

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
@@ -1,6 +1,8 @@
 package fr.sncf.osrd.stdcm.graph
 
 import fr.sncf.osrd.api.FullInfra
+import fr.sncf.osrd.api.S3Context
+import fr.sncf.osrd.api.STDCMTimetableData
 import fr.sncf.osrd.envelope.Envelope
 import fr.sncf.osrd.envelope_sim.allowances.AllowanceValue
 import fr.sncf.osrd.envelope_sim.allowances.AllowanceValue.FixedTime
@@ -8,6 +10,7 @@ import fr.sncf.osrd.graph.Graph
 import fr.sncf.osrd.pathfinding.constraints.ConstraintCombiner
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
 import fr.sncf.osrd.sim_infra.api.Block
+import fr.sncf.osrd.sim_infra.api.ZoneId
 import fr.sncf.osrd.sim_infra.impl.TemporarySpeedLimitManager
 import fr.sncf.osrd.stdcm.STDCMAStarHeuristic
 import fr.sncf.osrd.stdcm.STDCMHeuristicBuilder
@@ -22,6 +25,7 @@ import fr.sncf.osrd.utils.indexing.StaticIdx
 import fr.sncf.osrd.utils.units.meters
 import java.lang.Double.isFinite
 import java.lang.Double.isNaN
+import java.time.ZonedDateTime
 import kotlin.math.max
 import kotlin.math.min
 
@@ -45,6 +49,7 @@ class STDCMGraph(
     val standardAllowance: AllowanceValue?,
     val temporarySpeedLimitManager: TemporarySpeedLimitManager = TemporarySpeedLimitManager(),
     constraints: ConstraintCombiner<StaticIdx<Block>>,
+    val searchMetadata: SearchMetadata?,
 ) : Graph<STDCMNode, STDCMEdge> {
     val rawInfra = fullInfra.rawInfra
     val blockInfra = fullInfra.blockInfra
@@ -91,6 +96,12 @@ class STDCMGraph(
                 .build()
         bestPossibleTime = remainingTimeEstimator.bestTravelTime
     }
+
+    data class SearchMetadata(
+        val originalStartTime: ZonedDateTime,
+        val requirementMetadata: Map<ZoneId, List<STDCMTimetableData.DetailedRequirement>>,
+        val s3Context: S3Context?,
+    )
 
     /**
      * Returns the speed ratio we need to apply to the envelope to follow the given standard

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
@@ -61,6 +61,7 @@ fun findPath(
     pathfindingTimeout: Double,
     temporarySpeedLimitManager: TemporarySpeedLimitManager,
     allowedTrackSections: Set<TrackSectionId>? = null,
+    searchMetadata: STDCMGraph.SearchMetadata? = null,
 ): STDCMResult? {
     return STDCMPathfinding(
             fullInfra,
@@ -77,6 +78,7 @@ fun findPath(
             pathfindingTimeout,
             temporarySpeedLimitManager,
             allowedTrackSections,
+            searchMetadata,
         )
         .findPath()
 }
@@ -96,6 +98,7 @@ class STDCMPathfinding(
     private val pathfindingTimeout: Double = Pathfinding.TIMEOUT,
     private val temporarySpeedLimitManager: TemporarySpeedLimitManager,
     private val allowedTrackSections: Set<TrackSectionId>?,
+    private val searchMetadata: STDCMGraph.SearchMetadata?,
 ) {
 
     private var starts: Set<STDCMNode> = HashSet()
@@ -119,6 +122,7 @@ class STDCMPathfinding(
             standardAllowance,
             temporarySpeedLimitManager,
             constraints,
+            searchMetadata,
         )
 
     @WithSpan(value = "STDCM pathfinding", kind = SpanKind.SERVER)

--- a/scripts/generate-debug-space-chart.py
+++ b/scripts/generate-debug-space-chart.py
@@ -53,15 +53,16 @@ def main(input_location, output_location):
     fig.width = 900
     fig.height = 600
 
-    plot_positions(fig, data["sim_output"]["final_output"], departure_time)
-    plot_zone_updates(
-        fig, data["sim_output"]["final_output"], zone_locations, departure_time
-    )
-    plot_new_train_requirements(
-        fig, data["sim_output"]["final_output"], zone_locations, departure_time
-    )
-    plot_other_trains(fig, zone_locations, data["other_requirements"], departure_time)
+    plot_positions(fig, data, departure_time)
     plot_engineering_allowances(fig, data, departure_time)
+    if "sim_output" in data:
+        plot_zone_updates(
+            fig, data["sim_output"]["final_output"], zone_locations, departure_time
+        )
+        plot_new_train_requirements(
+            fig, data["sim_output"]["final_output"], zone_locations, departure_time
+        )
+    plot_other_trains(fig, zone_locations, data["other_requirements"], departure_time)
 
     fig.legend.click_policy = "hide"
     show_operational_points(fig, data["path_properties"]["operational_points"])
@@ -75,9 +76,9 @@ def convert_times(departure_time: datetime, times: List[int]) -> List[datetime]:
     return [departure_time + timedelta(milliseconds=x) for x in times]
 
 
-def plot_positions(fig, sim: Dict, departure_time: datetime):
-    positions = [x / 1000 for x in sim["positions"]]
-    times = convert_times(departure_time, [x for x in sim["times"]])
+def plot_positions(fig, data: Dict, departure_time: datetime):
+    positions = [x / 1000 for x in data["train_positions"]]
+    times = convert_times(departure_time, [x for x in data["train_times"]])
     fig.line(times, positions, line_width=2, legend_label="train_positions")
 
 
@@ -239,9 +240,8 @@ def plot_other_trains(
 
 def plot_engineering_allowances(fig, data, departure_time):
     engineering_allowance_ranges = data["engineering_allowances_ranges"]
-    sim = data["sim_output"]["final_output"]
-    positions = [x / 1000 for x in sim["positions"]]
-    times = [x for x in sim["times"]]
+    positions = [x / 1000 for x in data["train_positions"]]
+    times = [x for x in data["train_times"]]
 
     data = {
         "from": [],


### PR DESCRIPTION
To be merged after https://github.com/OpenRailAssociation/osrd/pull/14716

This lets us generate a full space-time chart on post-processing failures, which lets us figure out what went wrong. The zone requirements are still missing for the new trains, but it still helps. Meant to be used alongside the detailed error messages generated by core. 

In terms of architecture, it feels a little ugly, but I didn't really find any better way. I'd be open to suggestions though. 