### PR TITLE
editoast: `match_operational_points` cleanup

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -1198,7 +1198,6 @@ paths:
                 type: object
                 required:
                 - related_operational_points
-                - track_names
                 properties:
                   related_operational_points:
                     type: array
@@ -1206,16 +1205,6 @@ paths:
                       type: array
                       items:
                         $ref: '#/components/schemas/RelatedOperationalPoint'
-                  track_names:
-                    type: object
-                    additionalProperties:
-                      type:
-                      - string
-                      - 'null'
-                    propertyNames:
-                      type: string
-                      maxLength: 255
-                      minLength: 1
   /infra/{infra_id}/objects/{object_type}:
     post:
       tags:

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -1174,24 +1174,19 @@ paths:
             schema:
               type: object
               required:
-              - operational_point_part_references
+              - operational_point_references
               properties:
-                operational_point_part_references:
+                operational_point_references:
                   type: array
                   items:
-                    $ref: '#/components/schemas/OperationalPointPartReference'
+                    $ref: '#/components/schemas/OperationalPointReference'
         required: true
       responses:
         '200':
           description: |2
 
-            Take a list of operational point references and return for each of them the list of operational
-            points that they match on a given infrastructure and a mapping between the track indentifiers of
-            the returned operational points parts their related track name.
-            If an input OperationalPointPartReference contains a track reference, that track reference is also
-            used to filter out operational points that match the input operational point identifier but do
-            not match the input track reference (i.e. operational points which do not have any part that
-            matches the input track reference).
+            Take a list of operational point references and return for each of them the list
+            of operational points that they match on a given infrastructure.
           content:
             application/json:
               schema:

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -53,7 +53,6 @@ use crate::views::AuthorizationError;
 use crate::views::pagination::PaginatedList as _;
 use crate::views::pagination::PaginationQueryParams;
 use crate::views::params;
-use crate::views::path::path_item_cache::PathItemCache;
 use crate::views::path::path_item_cache::retrieve_op_from_ids;
 use crate::views::path::path_item_cache::retrieve_op_from_trigrams;
 use crate::views::path::path_item_cache::retrieve_op_from_uic;
@@ -62,9 +61,7 @@ use schemas::infra::OperationalPoint;
 use schemas::infra::OperationalPointExtensions;
 use schemas::infra::OperationalPointPart;
 use schemas::infra::builtin_node_types_list;
-use schemas::train_schedule::OperationalPointPartReference;
 use schemas::train_schedule::OperationalPointReference;
-use schemas::train_schedule::PathItemLocation;
 
 #[derive(Debug, Error, EditoastError)]
 #[editoast_error(base_id = "infra")]
@@ -774,7 +771,7 @@ pub(in crate::views) async fn unlock(
 #[derive(Deserialize, ToSchema)]
 #[cfg_attr(test, derive(Serialize))]
 pub(in crate::views) struct MatchOperationalPointsForm {
-    operational_point_part_references: Vec<OperationalPointPartReference>,
+    operational_point_references: Vec<OperationalPointReference>,
 }
 
 #[derive(Serialize, ToSchema)]
@@ -813,13 +810,8 @@ pub(in crate::views) struct MatchOperationalPointsResponse {
     request_body = inline(MatchOperationalPointsForm),
     responses(
         (status = 200, description = "
-Take a list of operational point references and return for each of them the list of operational
-points that they match on a given infrastructure and a mapping between the track indentifiers of
-the returned operational points parts their related track name.
-If an input OperationalPointPartReference contains a track reference, that track reference is also
-used to filter out operational points that match the input operational point identifier but do
-not match the input track reference (i.e. operational points which do not have any part that
-matches the input track reference).
+Take a list of operational point references and return for each of them the list
+of operational points that they match on a given infrastructure.
 ", body = inline(MatchOperationalPointsResponse))
     ),
 )]
@@ -828,7 +820,7 @@ pub(in crate::views) async fn match_operational_points(
     Extension(auth): AuthenticationExt,
     Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
     Json(MatchOperationalPointsForm {
-        operational_point_part_references,
+        operational_point_references,
     }): Json<MatchOperationalPointsForm>,
 ) -> Result<Json<MatchOperationalPointsResponse>> {
     let authorized = auth
@@ -846,19 +838,9 @@ pub(in crate::views) async fn match_operational_points(
     .await?;
     let mut operational_points: Vec<Vec<OperationalPoint>> = vec![];
     let mut conn = db_pool.get().await?;
-    let path_item_locations = operational_point_part_references
-        .iter()
-        .map(|op_ref| PathItemLocation::OperationalPointPartReference(op_ref.clone()))
-        .collect::<Vec<_>>();
-    let path_item_cache = PathItemCache::load(
-        db_pool.get().await?,
-        infra_id,
-        &path_item_locations.iter().collect::<Vec<_>>(),
-    )
-    .await?;
-    for operational_point_reference in operational_point_part_references {
+    for operational_point_reference in operational_point_references {
         // Retrieve related OPs based on the input operational point identifier:
-        let mut related_operational_points = match operational_point_reference.operational_point {
+        let related_operational_points = match operational_point_reference {
             OperationalPointReference::Id {
                 ref operational_point,
             } => retrieve_op_from_ids(
@@ -903,18 +885,6 @@ pub(in crate::views) async fn match_operational_points(
                 })
                 .collect::<Vec<_>>(),
         };
-        // Filter OPs according to the input `TrackReference` if provided:
-        related_operational_points = related_operational_points
-            .into_iter()
-            .filter(|op| {
-                !path_item_cache
-                    .track_reference_filter(
-                        op.track_offset(),
-                        operational_point_reference.track_reference.as_ref(),
-                    )
-                    .is_empty()
-            })
-            .collect_vec();
         // Add the operational point reference related operational points to the response:
         operational_points.push(related_operational_points);
     }
@@ -1016,7 +986,6 @@ pub mod tests {
     use schemas::infra::SpeedSection;
     use schemas::infra::SwitchType;
     use schemas::primitives::ObjectType;
-    use schemas::train_schedule::TrackReference;
     use serde_json::json;
     use std::collections::HashMap;
     use std::ops::DerefMut;
@@ -1462,35 +1431,22 @@ pub mod tests {
             .refresh(db_pool.clone(), false, &infra_cache)
             .await
             .unwrap();
-        let operational_point_part_references = vec![
-            OperationalPointPartReference {
-                operational_point: OperationalPointReference::Id {
-                    operational_point: ("West_station").into(),
-                },
-                track_reference: None,
+        let operational_point_references = vec![
+            OperationalPointReference::Id {
+                operational_point: ("West_station").into(),
             },
-            OperationalPointPartReference {
-                operational_point: OperationalPointReference::Trigram {
-                    trigram: "MES".into(),
-                    secondary_code: Some("BV".into()),
-                },
-                track_reference: Some(TrackReference::Name {
-                    track_name: "V1".into(),
-                }),
+            OperationalPointReference::Trigram {
+                trigram: "MES".into(),
+                secondary_code: Some("BV".into()),
             },
-            OperationalPointPartReference {
-                operational_point: OperationalPointReference::Uic {
-                    uic: 8,
-                    secondary_code: None,
-                },
-                track_reference: Some(TrackReference::Id {
-                    track_id: "TH1".into(),
-                }),
+            OperationalPointReference::Uic {
+                uic: 8,
+                secondary_code: None,
             },
         ];
         let request = app
             .post(format!("/infra/{}/match_operational_points", infra.id).as_str())
-            .json(&json!({"operational_point_part_references": operational_point_part_references}));
+            .json(&json!({"operational_point_references": operational_point_references}));
         let response: MatchOperationalPointsResponse = app
             .fetch(request)
             .await
@@ -1520,41 +1476,23 @@ pub mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn match_operational_point_input_with_incompatible_op_id_and_track_reference_gets_filtered_out()
-     {
+    async fn match_operational_point_input_with_incompatible_op_id_gets_filtered_out() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
         let infra = create_small_infra(&mut db_pool.get_ok()).await;
-        let operational_point_part_references = vec![
-            OperationalPointPartReference {
-                operational_point: OperationalPointReference::Trigram {
-                    trigram: "MES".into(),
-                    secondary_code: None,
-                },
-                track_reference: Some(TrackReference::Name {
-                    track_name: "does_not_exist".into(),
-                }),
+        let operational_point_references = vec![
+            OperationalPointReference::Uic {
+                uic: 8,
+                secondary_code: None,
             },
-            OperationalPointPartReference {
-                operational_point: OperationalPointReference::Uic {
-                    uic: 8,
-                    secondary_code: None,
-                },
-                track_reference: Some(TrackReference::Id {
-                    track_id: "does_not_exist".into(),
-                }),
-            },
-            OperationalPointPartReference {
-                operational_point: OperationalPointReference::Trigram {
-                    trigram: "MES".into(),
-                    secondary_code: Some("PAUL".into()),
-                },
-                track_reference: None,
+            OperationalPointReference::Trigram {
+                trigram: "MES".into(),
+                secondary_code: Some("PAUL".into()),
             },
         ];
         let request = app
             .post(format!("/infra/{}/match_operational_points", infra.id).as_str())
-            .json(&json!({"operational_point_part_references": operational_point_part_references}));
+            .json(&json!({"operational_point_references": operational_point_references}));
         let response: MatchOperationalPointsResponse = app
             .fetch(request)
             .await
@@ -1565,7 +1503,7 @@ pub mod tests {
             .iter()
             .map(|op_ref| op_ref.iter().map(|op| op.id.as_str()).collect::<Vec<_>>())
             .collect::<Vec<_>>();
-        let expected_identifiers: [Vec<&str>; 3] = [vec![], vec![], vec![]];
+        let expected_identifiers: [Vec<&str>; 2] = [vec![], vec![]];
         assert_eq!(response_op_identifiers, expected_identifiers);
     }
 

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -32,7 +32,6 @@ use schemas::infra::SwitchType;
 use schemas::primitives::Identifier;
 use serde::Deserialize;
 use serde::Serialize;
-use std::collections::HashMap;
 use std::collections::HashSet;
 use thiserror::Error;
 use utoipa::IntoParams;
@@ -50,7 +49,6 @@ use crate::infra_cache::InfraCache;
 use crate::map;
 use crate::models::Infra;
 use crate::models::SwitchTypeModel;
-use crate::models::TrackSectionModel;
 use crate::views::AuthorizationError;
 use crate::views::pagination::PaginatedList as _;
 use crate::views::pagination::PaginationQueryParams;
@@ -805,7 +803,6 @@ struct RelatedOperationalPoint {
 #[cfg_attr(test, derive(Deserialize))]
 pub(in crate::views) struct MatchOperationalPointsResponse {
     related_operational_points: Vec<Vec<RelatedOperationalPoint>>,
-    track_names: HashMap<Identifier, Option<String>>,
 }
 
 #[editoast_derive::route]
@@ -923,43 +920,10 @@ pub(in crate::views) async fn match_operational_points(
     }
     let related_operational_points =
         populate_op_geo(&mut conn, infra_id, &operational_points).await?;
-    let track_names = find_track_names(
-        db_pool,
-        infra_id,
-        &operational_points.iter().flatten().collect::<Vec<_>>(),
-    )
-    .await?;
+
     Ok(Json(MatchOperationalPointsResponse {
         related_operational_points,
-        track_names,
     }))
-}
-
-/// Take a list of [OperationalPoint] and return a mapping between the identifiers of the tracks
-/// contained in their operational point parts of the name of the tracks (if any).
-async fn find_track_names(
-    db_pool: Arc<DbConnectionPoolV2>,
-    infra_id: i64,
-    operational_points: &[&OperationalPoint],
-) -> Result<HashMap<Identifier, Option<String>>> {
-    let track_ids: Vec<(i64, String)> = operational_points
-        .iter()
-        .flat_map(|op| &op.parts)
-        .map(|part| (infra_id, part.track.to_string()))
-        .collect::<Vec<_>>();
-    let (tracks, _): (Vec<_>, _) =
-        TrackSectionModel::retrieve_batch(&mut db_pool.get().await?, track_ids).await?;
-    Ok(HashMap::from_iter(tracks.into_iter().map(
-        |TrackSectionModel { schema: track, .. }| {
-            (
-                track.id.clone(),
-                track
-                    .extensions
-                    .sncf
-                    .map(|sncf_ext| sncf_ext.track_name.to_string()),
-            )
-        },
-    )))
 }
 
 fn compute_operational_point_geo(points: &[GeoJsonPoint]) -> Option<GeoJsonPoint> {
@@ -1054,6 +1018,7 @@ pub mod tests {
     use schemas::primitives::ObjectType;
     use schemas::train_schedule::TrackReference;
     use serde_json::json;
+    use std::collections::HashMap;
     use std::ops::DerefMut;
     use strum::IntoEnumIterator;
 
@@ -1552,14 +1517,6 @@ pub mod tests {
                 49.4999,
             ))))
         );
-        let expected_track_names: HashMap<Identifier, Option<String>> = HashMap::from([
-            ("TA0".into(), Some("V1".to_string())),
-            ("TA1".into(), Some("V2".to_string())),
-            ("TA2".into(), Some("A".to_string())),
-            ("TD0".into(), Some("V1".to_string())),
-            ("TD1".into(), Some("V2".to_string())),
-        ]);
-        assert_eq!(response.track_names, expected_track_names);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/front/src/applications/operationalStudies/hooks/usePathOps.ts
+++ b/front/src/applications/operationalStudies/hooks/usePathOps.ts
@@ -4,7 +4,7 @@ import { skipToken } from '@reduxjs/toolkit/query';
 
 import {
   osrdEditoastApi,
-  type OperationalPointPartReference,
+  type OperationalPointReference,
   type RelatedOperationalPoint,
 } from 'common/api/osrdEditoastApi';
 import type { Train } from 'reducers/osrdconf/types';
@@ -21,11 +21,11 @@ const usePathOps = (
     returnAllOps: boolean;
   }
 ): RelatedOperationalPoint[] => {
-  const operationalPointPartReferences: OperationalPointPartReference[] = useMemo(
+  const operationalPointReferences: OperationalPointReference[] = useMemo(
     () =>
-      (path ?? []).reduce<OperationalPointPartReference[]>((acc, pathItem) => {
+      (path ?? []).reduce<OperationalPointReference[]>((acc, pathItem) => {
         if ('operational_point' in pathItem.location) {
-          acc.push(pathItem.location);
+          acc.push(pathItem.location.operational_point);
         }
         return acc;
       }, []),
@@ -34,11 +34,11 @@ const usePathOps = (
 
   const { data: operationalPoints } =
     osrdEditoastApi.endpoints.postInfraByInfraIdMatchOperationalPoints.useQuery(
-      operationalPointPartReferences.length > 0
+      operationalPointReferences.length > 0
         ? {
             infraId,
             body: {
-              operational_point_part_references: operationalPointPartReferences,
+              operational_point_references: operationalPointReferences,
             },
           }
         : skipToken

--- a/front/src/applications/operationalStudies/hooks/usePathProjection.ts
+++ b/front/src/applications/operationalStudies/hooks/usePathProjection.ts
@@ -9,7 +9,6 @@ import { useSelector } from 'react-redux';
 import {
   osrdEditoastApi,
   type PathfindingResult,
-  type OperationalPointPartReference,
   type PathProperties,
   type OperationalPointReference,
 } from 'common/api/osrdEditoastApi';
@@ -157,11 +156,11 @@ const usePathProjection = (
     return exception?.path_and_schedule?.path ?? pacedTrain!.path;
   }, [trainIdUsedForProjection, timetableItemsById]);
 
-  const opPartRefs = useMemo(() => {
-    const refs: OperationalPointPartReference[] = [];
+  const opRefs = useMemo(() => {
+    const refs: OperationalPointReference[] = [];
     pathUsedForProjection?.forEach((step) => {
       if ('operational_point' in step.location) {
-        refs.push({ operational_point: step.location.operational_point });
+        refs.push(step.location.operational_point);
       }
     });
     return refs;
@@ -169,11 +168,11 @@ const usePathProjection = (
 
   const { data: matchedOperationalPoints } =
     osrdEditoastApi.endpoints.postInfraByInfraIdMatchOperationalPoints.useQuery(
-      opPartRefs.length > 0
+      opRefs.length > 0
         ? {
             infraId,
             body: {
-              operational_point_part_references: opPartRefs,
+              operational_point_references: opRefs,
             },
           }
         : skipToken
@@ -199,11 +198,9 @@ const usePathProjection = (
     if (pathfinding?.status === 'success' && pathProperties) {
       const { operational_points: operationalPoints } = pathProperties;
 
-      const pathfindingOpRefs: OperationalPointPartReference[] = [];
+      const pathfindingOpRefs: OperationalPointReference[] = [];
       operationalPoints.forEach((op, index) => {
-        pathfindingOpRefs.push({
-          operational_point: { operational_point: op.id, type: 'id' },
-        });
+        pathfindingOpRefs.push({ operational_point: op.id, type: 'id' });
         if (index > 0) {
           operationalPointDistances.push(op.position - operationalPoints[index - 1].position);
         }
@@ -215,7 +212,7 @@ const usePathProjection = (
         path: pathUsedForProjection,
         geometry: pathProperties.geometry,
         operationalPoints,
-        operationalPointPartReferences: pathfindingOpRefs,
+        operationalPointReferences: pathfindingOpRefs,
         projectingOnSimulatedPathException,
         operationalPointDistances,
       };
@@ -232,7 +229,7 @@ const usePathProjection = (
     // 3. If a point is not matched (e.g., NGE) → create a virtual point from the reference
     const normalizedOps: PathProperties['operational_points'] = [];
 
-    opPartRefs.forEach((opPartRef, index) => {
+    opRefs.forEach((opRef, index) => {
       const matchedOps = matchedOperationalPoints?.related_operational_points[index] || [];
       const matchedOp = getStationFromOps(matchedOps);
       const weight = 0; // Uniform weight for consistent manchette spacing
@@ -258,16 +255,7 @@ const usePathProjection = (
       } else {
         // NOT MATCHED: Point doesn't exist in infrastructure (e.g., NGE point)
         // Create virtual point from the reference
-        normalizedOps.push(
-          createVirtualOp(
-            opPartRef.operational_point,
-            index,
-            opPartRefs.length,
-            position,
-            weight,
-            t
-          )
-        );
+        normalizedOps.push(createVirtualOp(opRef, index, opRefs.length, position, weight, t));
       }
     });
 
@@ -275,7 +263,7 @@ const usePathProjection = (
       pathfindingStatus: 'failed',
       path: pathUsedForProjection,
       operationalPoints: normalizedOps,
-      operationalPointPartReferences: opPartRefs,
+      operationalPointReferences: opRefs,
       operationalPointDistances,
     };
   }, [

--- a/front/src/applications/operationalStudies/hooks/useScenarioData.ts
+++ b/front/src/applications/operationalStudies/hooks/useScenarioData.ts
@@ -75,7 +75,7 @@ const useScenarioData = (scenario: ScenarioWithDetails, infraId: number) => {
         ? projectionPath.pathfinding.path
         : undefined,
     operationalPointDistances: projectionPath?.operationalPointDistances,
-    operationalPointPartReferences: projectionPath?.operationalPointPartReferences,
+    operationalPointReferences: projectionPath?.operationalPointReferences,
   });
 
   const {

--- a/front/src/applications/operationalStudies/hooks/useTimetableItemsWithPathOps.ts
+++ b/front/src/applications/operationalStudies/hooks/useTimetableItemsWithPathOps.ts
@@ -19,7 +19,7 @@ const useTimetableItemsWithPathOps = (
 
   const { currentData: timetableOperationalPoints, isSuccess } =
     osrdEditoastApi.endpoints.matchAllOperationalPoints.useQuery(
-      timetableOpRefs.length > 0 ? { infraId, opPartRefs: timetableOpRefs } : skipToken
+      timetableOpRefs.length > 0 ? { infraId, opRefs: timetableOpRefs } : skipToken
     );
 
   return useMemo(() => {

--- a/front/src/applications/operationalStudies/types.ts
+++ b/front/src/applications/operationalStudies/types.ts
@@ -16,7 +16,7 @@ import type {
   ScenarioWithDetails,
   SearchResultItemScenario,
   PathItem,
-  OperationalPointPartReference,
+  OperationalPointReference,
   MacroNoteForm,
 } from 'common/api/osrdEditoastApi';
 import type { RangedValue } from 'common/types';
@@ -172,7 +172,7 @@ export type PathProjectionResult = {
   path: PathItem[];
   operationalPoints: PathProperties['operational_points'];
   operationalPointDistances: number[];
-  operationalPointPartReferences: OperationalPointPartReference[];
+  operationalPointReferences: OperationalPointReference[];
 } & (
   | {
       pathfindingStatus: 'succeeded';

--- a/front/src/applications/operationalStudies/utils.ts
+++ b/front/src/applications/operationalStudies/utils.ts
@@ -4,7 +4,6 @@ import { type Dictionary, isEqual } from 'lodash';
 import type {
   OperationalPoint,
   OperationalPointReference,
-  OperationalPointPartReference,
   CorePathfindingResultSuccess,
   PathItemLocation,
   PathProperties,
@@ -303,13 +302,16 @@ export const getStationFromOps = (ops: OperationalPoint[]): OperationalPoint | u
  */
 export const getUniqueOpRefsFromTimetableItems = (
   timetableItems: TimetableItem[]
-): OperationalPointPartReference[] => {
+): OperationalPointReference[] => {
   const pathItems = timetableItems.flatMap((timetableItem) => timetableItem.path);
-  const uniqueSteps = new Map<string, OperationalPointPartReference>();
+  const uniqueSteps = new Map<string, OperationalPointReference>();
   for (const pathItem of pathItems) {
     const pathItemLocation = pathItem.location;
     if (!('operational_point' in pathItemLocation)) continue;
-    uniqueSteps.set(JSON.stringify(pathItemLocation), pathItemLocation);
+    uniqueSteps.set(
+      JSON.stringify(pathItemLocation.operational_point),
+      pathItemLocation.operational_point
+    );
   }
   return [...uniqueSteps.values()];
 };
@@ -320,7 +322,7 @@ export const getUniqueOpRefsFromTimetableItems = (
  */
 export const addPathOpsToTimetableItems = (
   timetableItems: TimetableItem[],
-  timetableOpRefs: OperationalPointPartReference[],
+  timetableOpRefs: OperationalPointReference[],
   timetableOperationalPoints: RelatedOperationalPoint[][]
 ): TimetableItemWithPathOps[] => {
   if (timetableOpRefs.length !== timetableOperationalPoints.length) {
@@ -341,9 +343,10 @@ export const addPathOpsToTimetableItems = (
     // 1. if found, return the operational points
     // 2. if key exists but no operational points were found, return an empty array
     // 3. if key does not exist in opsByKey (meaning it's a track offset), return an empty array
-    const pathOps = timetableItem.path.map(
-      (pathItem) => opsByKey.get(JSON.stringify(pathItem.location)) ?? []
-    );
+    const pathOps = timetableItem.path.map((pathItem) => {
+      if (!('operational_point' in pathItem.location)) return [];
+      return opsByKey.get(JSON.stringify(pathItem.location.operational_point)) ?? [];
+    });
     return { ...timetableItem, pathOps };
   });
 };

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/osrdToNge.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/osrdToNge.ts
@@ -663,17 +663,17 @@ const fetchTimetableItemPathOps = async (
   timetableItems: TimetableItem[],
   dispatch: AppDispatch
 ): Promise<TimetableItemWithPathOps[]> => {
-  const opPartRefs = getUniqueOpRefsFromTimetableItems(timetableItems);
+  const opRefs = getUniqueOpRefsFromTimetableItems(timetableItems);
   const ops = await dispatch(
     osrdEditoastApi.endpoints.matchAllOperationalPoints.initiate(
       {
         infraId,
-        opPartRefs,
+        opRefs,
       },
       { subscribe: false }
     )
   ).unwrap();
-  return addPathOpsToTimetableItems(timetableItems, opPartRefs, ops);
+  return addPathOpsToTimetableItems(timetableItems, opRefs, ops);
 };
 
 const groupCompatibleRoundTrips = (

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/hooks/usePathStepsMetadata.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/hooks/usePathStepsMetadata.ts
@@ -7,7 +7,7 @@ import usePathOps from 'applications/operationalStudies/hooks/usePathOps';
 import { useScenarioContext } from 'applications/operationalStudies/hooks/useScenarioContext';
 import {
   osrdEditoastApi,
-  type OperationalPointPartReference,
+  type OperationalPointReference,
   type TrainSchedule,
 } from 'common/api/osrdEditoastApi';
 import type { PathStepMetadata, PathStepV2 } from 'reducers/osrdconf/types';
@@ -63,7 +63,7 @@ export const usePathStepsMetadata = (pathSteps: PathStepV2[]) => {
   // with postInfraByInfraIdMatchOperationalPoints, we need to call the endpoint again with
   // the opId corresponding uic in order to get all the possible matches and have
   // all the secondary codes and track names
-  const uicPayload: OperationalPointPartReference[] = useMemo(() => {
+  const uicPayload: OperationalPointReference[] = useMemo(() => {
     const opIds = pathSteps.reduce<string[]>((acc, step) => {
       if (
         step.location &&
@@ -77,10 +77,10 @@ export const usePathStepsMetadata = (pathSteps: PathStepV2[]) => {
 
     if (opIds.length === 0) return [];
 
-    return pathStepsOperationalPoints.reduce<OperationalPointPartReference[]>((acc, op) => {
+    return pathStepsOperationalPoints.reduce<OperationalPointReference[]>((acc, op) => {
       const uic = op.extensions?.identifier?.uic;
       if (uic && opIds.includes(op.id)) {
-        acc.push({ operational_point: { uic, type: 'uic' } });
+        acc.push({ uic, type: 'uic' });
       }
       return acc;
     }, []);
@@ -92,7 +92,7 @@ export const usePathStepsMetadata = (pathSteps: PathStepV2[]) => {
         ? {
             infraId,
             body: {
-              operational_point_part_references: uicPayload,
+              operational_point_references: uicPayload,
             },
           }
         : skipToken

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -1664,9 +1664,6 @@ not match the input track reference (i.e. operational points which do not have a
 matches the input track reference).
  */ {
   related_operational_points: RelatedOperationalPoint[][];
-  track_names: {
-    [key: string]: string | null;
-  };
 };
 export type PostInfraByInfraIdMatchOperationalPointsApiArg = {
   /** An existing infra ID */

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -1655,13 +1655,8 @@ export type PostInfraByInfraIdLockApiArg = {
   infraId: number;
 };
 export type PostInfraByInfraIdMatchOperationalPointsApiResponse = /** status 200
-Take a list of operational point references and return for each of them the list of operational
-points that they match on a given infrastructure and a mapping between the track indentifiers of
-the returned operational points parts their related track name.
-If an input OperationalPointPartReference contains a track reference, that track reference is also
-used to filter out operational points that match the input operational point identifier but do
-not match the input track reference (i.e. operational points which do not have any part that
-matches the input track reference).
+Take a list of operational point references and return for each of them the list
+of operational points that they match on a given infrastructure.
  */ {
   related_operational_points: RelatedOperationalPoint[][];
 };
@@ -1669,7 +1664,7 @@ export type PostInfraByInfraIdMatchOperationalPointsApiArg = {
   /** An existing infra ID */
   infraId: number;
   body: {
-    operational_point_part_references: OperationalPointPartReference[];
+    operational_point_references: OperationalPointReference[];
   };
 };
 export type PostInfraByInfraIdObjectsAndObjectTypeApiResponse =
@@ -3207,17 +3202,6 @@ export type OperationalPointReference =
       /** The [UIC](https://en.wikipedia.org/wiki/List_of_UIC_country_codes) code of an operational point */
       uic: number;
     };
-export type TrackReference =
-  | {
-      track_id: string;
-    }
-  | {
-      track_name: string;
-    };
-export type OperationalPointPartReference = {
-  operational_point: OperationalPointReference;
-  track_reference?: null | TrackReference;
-};
 export type GeoJsonMultiPointValue = GeoJsonPointValue[];
 export type GeoJsonMultiPoint = {
   coordinates: GeoJsonMultiPointValue;
@@ -3383,6 +3367,17 @@ export type TrackOffset = {
   offset: number;
   /** Track section identifier */
   track: string;
+};
+export type TrackReference =
+  | {
+      track_id: string;
+    }
+  | {
+      track_name: string;
+    };
+export type OperationalPointPartReference = {
+  operational_point: OperationalPointReference;
+  track_reference?: null | TrackReference;
 };
 export type PathItemLocation = TrackOffset | OperationalPointPartReference;
 export type CorePathfindingInputError =

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -13,7 +13,7 @@ import {
   type GetLightRollingStockApiResponse,
   type GetSpritesSignalingSystemsApiResponse,
   type MacroNodeResponse,
-  type OperationalPointPartReference,
+  type OperationalPointReference,
   type PacedTrainResponse,
   type PathfindingResult,
   type PostTimetableByIdStdcmApiResponse,
@@ -145,22 +145,22 @@ const osrdEditoastApi = generatedEditoastApi
       }),
       matchAllOperationalPoints: builder.query<
         RelatedOperationalPoint[][],
-        { infraId: number; opPartRefs: OperationalPointPartReference[] }
+        { infraId: number; opRefs: OperationalPointReference[] }
       >({
-        queryFn: async ({ infraId, opPartRefs }, { dispatch }) => {
+        queryFn: async ({ infraId, opRefs }, { dispatch }) => {
           const batchSize = 200;
           const result: RelatedOperationalPoint[][] = [];
 
           // Split opRefs into batches of 200
-          for (let i = 0; i < opPartRefs.length; i += batchSize) {
-            const batch = opPartRefs.slice(i, i + batchSize);
+          for (let i = 0; i < opRefs.length; i += batchSize) {
+            const batch = opRefs.slice(i, i + batchSize);
 
             const promise = dispatch(
               osrdEditoastApi.endpoints.postInfraByInfraIdMatchOperationalPoints.initiate(
                 {
                   infraId,
                   body: {
-                    operational_point_part_references: batch,
+                    operational_point_references: batch,
                   },
                 },
                 { subscribe: false }

--- a/front/src/modules/pathfinding/hooks/usePathfinding.ts
+++ b/front/src/modules/pathfinding/hooks/usePathfinding.ts
@@ -83,17 +83,17 @@ const usePathfinding = ({
     async (steps: PathStep[]) => {
       if (!infraId || !steps.length) return;
 
-      const opPartRefs = steps.flatMap((step) => {
+      const opRefs = steps.flatMap((step) => {
         const pathItemLocation = getStepLocation(step.location);
         if ('track' in pathItemLocation) return [];
-        return [pathItemLocation];
+        return [pathItemLocation.operational_point];
       });
 
       let ops: RelatedOperationalPoint[][];
       try {
         ops = await matchAllOperationalPoints({
           infraId,
-          opPartRefs,
+          opRefs,
         }).unwrap();
       } catch (error) {
         console.error('Error fetching operational points:', error);

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useLazyProjectTrains.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useLazyProjectTrains.ts
@@ -7,7 +7,7 @@ import type { ProjectionResult } from 'applications/operationalStudies/helpers/T
 import type TrainProjectionLazyLoaderAbstract from 'applications/operationalStudies/helpers/TrainProjectionLazyLoaderAbstract';
 import TrainTrackProjectionLazyLoader from 'applications/operationalStudies/helpers/TrainTrackProjectionLazyLoader';
 import upsertNewProjectedTrains from 'applications/operationalStudies/helpers/upsertNewProjectedTrains';
-import { type OperationalPointPartReference, type CoreTrainPath } from 'common/api/osrdEditoastApi';
+import { type OperationalPointReference, type CoreTrainPath } from 'common/api/osrdEditoastApi';
 import type { TrainSpaceTimeData } from 'modules/simulationResult/types';
 import type { TimetableItemId, TimetableItem } from 'reducers/osrdconf/types';
 import { getProjectionType } from 'reducers/simulationResults/selectors';
@@ -18,7 +18,7 @@ type UseLazyProjectTrainsOptions = {
   electricalProfileSetId?: number;
   path?: CoreTrainPath;
   operationalPointDistances?: number[];
-  operationalPointPartReferences?: OperationalPointPartReference[];
+  operationalPointReferences?: OperationalPointReference[];
 };
 
 const useLazyProjectTrains = ({
@@ -26,7 +26,7 @@ const useLazyProjectTrains = ({
   electricalProfileSetId,
   path,
   operationalPointDistances = [],
-  operationalPointPartReferences = [],
+  operationalPointReferences = [],
 }: UseLazyProjectTrainsOptions) => {
   const dispatch = useAppDispatch();
   const loaderRef = useRef<TrainProjectionLazyLoaderAbstract>(null);
@@ -58,10 +58,10 @@ const useLazyProjectTrains = ({
         path,
       });
     } else {
-      if (operationalPointPartReferences.length < 2) return;
+      if (operationalPointReferences.length < 2) return;
 
       loader = new TrainOpProjectionLazyLoader(
-        operationalPointPartReferences.map(({ operational_point }) => operational_point),
+        operationalPointReferences,
         operationalPointDistances,
         { ...baseOptions, path }
       );
@@ -79,7 +79,7 @@ const useLazyProjectTrains = ({
     electricalProfileSetId,
     projectionType,
     path,
-    operationalPointPartReferences,
+    operationalPointReferences,
     operationalPointDistances,
   ]);
 

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useTrackOccupancy.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useTrackOccupancy.ts
@@ -500,7 +500,7 @@ const useTrackOccupancy = ({
                 const trackPart = trackSectionByTrackId.get(part.track);
                 return {
                   id: part.track,
-                  name: data.track_names[part.track] || undefined,
+                  name: part.local_track_name || undefined,
                   line: trackPart?.extensions?.sncf?.line_code,
                 };
               }),

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useTrackOccupancy.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useTrackOccupancy.ts
@@ -6,7 +6,7 @@ import { forEach, fromPairs, isEmpty, isEqual, isFunction, keyBy, noop, uniqBy }
 import { useTranslation } from 'react-i18next';
 
 import { useScenarioContext } from 'applications/operationalStudies/hooks/useScenarioContext';
-import { type OperationalPointPartReference, osrdEditoastApi } from 'common/api/osrdEditoastApi';
+import { type OperationalPointReference, osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import computeOccurrenceName from 'modules/timetableItem/helpers/computeOccurrenceName';
 import { computeIndexedOccurrenceStartTime } from 'modules/timetableItem/helpers/pacedTrain';
 import type { PacedTrainId, TimetableItemId, TrainId } from 'reducers/osrdconf/types';
@@ -468,16 +468,14 @@ const useTrackOccupancy = ({
       (op) => !(tracksState.data || {})[op.waypointId]
     );
     const loadAllTracks = async (
-      operationalPointPartReferences: {
-        operational_point: { operational_point: string; type: 'id' };
-      }[]
+      operationalPointReferences: { operational_point: string; type: 'id' }[]
     ) => {
       setTracksState((state) => ({ type: 'loading', data: state.data || {} }));
 
       try {
         const data = await postInfraByInfraIdMatchOperationalPoints({
           infraId,
-          body: { operational_point_part_references: operationalPointPartReferences },
+          body: { operational_point_references: operationalPointReferences },
         }).unwrap();
 
         if (aborted) return;
@@ -493,7 +491,7 @@ const useTrackOccupancy = ({
         }
 
         const loadedTracks = fromPairs(
-          operationalPointPartReferences.map(({ operational_point: { operational_point } }, i) => [
+          operationalPointReferences.map(({ operational_point }, i) => [
             operational_point,
             uniqBy(
               data.related_operational_points[i][0].parts.map((part) => {
@@ -517,7 +515,7 @@ const useTrackOccupancy = ({
       }
     };
     const waypointsPayload = pathOperationalPointsWithoutTracks.flatMap((op) =>
-      op.opId ? [{ operational_point: { operational_point: op.opId, type: 'id' as const } }] : []
+      op.opId ? [{ operational_point: op.opId, type: 'id' as const }] : []
     );
     if (!waypointsPayload.length) return noop;
 
@@ -640,7 +638,7 @@ const useTrackOccupancy = ({
         const requests: {
           timetableItemId: TimetableItemId;
           side: 'origin' | 'destination';
-          opReference: OperationalPointPartReference;
+          opReference: OperationalPointReference;
         }[] = [];
 
         timetableItemsToFetch.forEach((timetableItem) => {
@@ -662,10 +660,8 @@ const useTrackOccupancy = ({
                 side,
                 timetableItemId: timetableItem.id,
                 opReference: {
-                  operational_point: {
-                    operational_point: itemLocation.operational_point.operational_point,
-                    type: 'id',
-                  },
+                  operational_point: itemLocation.operational_point.operational_point,
+                  type: 'id',
                 },
               });
             } else if (itemLocation.operational_point.type === 'trigram') {
@@ -673,11 +669,9 @@ const useTrackOccupancy = ({
                 side,
                 timetableItemId: timetableItem.id,
                 opReference: {
-                  operational_point: {
-                    trigram: itemLocation.operational_point.trigram,
-                    secondary_code: itemLocation.operational_point.secondary_code,
-                    type: 'trigram',
-                  },
+                  trigram: itemLocation.operational_point.trigram,
+                  secondary_code: itemLocation.operational_point.secondary_code,
+                  type: 'trigram',
                 },
               });
             } else if (itemLocation.operational_point.type === 'uic') {
@@ -685,11 +679,9 @@ const useTrackOccupancy = ({
                 side,
                 timetableItemId: timetableItem.id,
                 opReference: {
-                  operational_point: {
-                    uic: itemLocation.operational_point.uic,
-                    secondary_code: itemLocation.operational_point.secondary_code,
-                    type: 'uic',
-                  },
+                  uic: itemLocation.operational_point.uic,
+                  secondary_code: itemLocation.operational_point.secondary_code,
+                  type: 'uic',
                 },
               });
             }
@@ -701,7 +693,7 @@ const useTrackOccupancy = ({
         const data = await postInfraByInfraIdMatchOperationalPoints({
           infraId,
           body: {
-            operational_point_part_references: requests.map(({ opReference }) => opReference),
+            operational_point_references: requests.map(({ opReference }) => opReference),
           },
         }).unwrap();
 


### PR DESCRIPTION
This PR simplifies the `match_operational_points` endpoint by removing `track_reference` data from both the request and response.

### What changed

* Request now accepts only `OperationalPointReference[]`
* Removed `track_reference` and `OperationalPointPartReference`
* Removed `track_names` from the response (already available via `local_track_name`)
* Updated backend, OpenAPI spec, and frontend usage accordingly