### PR TITLE
front: fix timetable import and export, ctrl+c

### DIFF
--- a/front/public/locales/de/operational-studies.json
+++ b/front/public/locales/de/operational-studies.json
@@ -14,7 +14,6 @@
     "download": "Herunterladen",
     "errorMessages": {
       "error": "Ein Fehler ist aufgetreten",
-      "errorEmptyFile": "Leere Datei",
       "errorInvalidFile": "Ungültige Datei"
     },
     "failure": "Operation fehlgeschlagen",

--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -30,7 +30,6 @@
     "download": "Download",
     "errorMessages": {
       "error": "An error has occurred",
-      "errorEmptyFile": "Empty file",
       "errorInvalidFile": "Invalid file"
     },
     "failure": "Operation failed",

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -30,7 +30,6 @@
     "download": "Télécharger",
     "errorMessages": {
       "error": "Une erreur est survenue",
-      "errorEmptyFile": "Fichier vide",
       "errorInvalidFile": "Fichier invalide"
     },
     "failure": "L'opération a échoué",

--- a/front/src/applications/operationalStudies/types.ts
+++ b/front/src/applications/operationalStudies/types.ts
@@ -33,21 +33,15 @@ export type PacedTrainResponseWithPaced = PacedTrainWithPaced & {
   id: PacedTrainId;
 };
 
-export type TrainScheduleFromJson = Omit<TrainSchedule, 'category'> & {
-  category?: TrainCategory | string | null;
-};
-
 export type PacedTrainFromJson = Omit<PacedTrain, 'category'> & {
   category?: TrainCategory | string | null;
 };
 
 export type RoundTripsFromJson = {
-  train_schedules: ([number, number] | [number, null])[];
   paced_trains: ([number, number] | [number, null])[];
 };
 
 export type TimetableJsonPayload = {
-  train_schedules: TrainScheduleFromJson[];
   paced_trains: PacedTrainFromJson[];
   macro_nodes?: MacroNodeForm[];
   macro_notes?: MacroNoteForm[];

--- a/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/__tests__/parseJson.spec.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/__tests__/parseJson.spec.ts
@@ -2,7 +2,10 @@ import type { TFunction } from 'i18next';
 import { describe, it, expect, vi } from 'vitest';
 
 import { trainScheduleHonored } from 'applications/operationalStudies/__tests__/sampleData';
+import type { TimetableJsonPayload } from 'applications/operationalStudies/types';
+import type { RoundTrips } from 'common/api/osrdEditoastApi';
 
+import { buildTimetableExportPayload } from '../../../Timetable/utils';
 import { processJsonFile } from '../parseJson';
 
 // there seems to be no nice cast to make this mock
@@ -17,16 +20,43 @@ const buildTrainSchedule = (overrides: Record<string, unknown> = {}) => ({
 });
 
 describe('processJsonFile', () => {
-  const train0 = buildTrainSchedule({ train_name: 'train 0' });
-  const train1 = buildTrainSchedule({ train_name: 'train 1' });
+  const train0 = buildTrainSchedule({ train_name: 'train_0', id: 'paced_0' });
+  const train1 = buildTrainSchedule({ train_name: 'train_1', id: 'paced_1' });
+
+  describe('Export/Import of timetable', () => {
+    it('Should export and import timetable', () => {
+      const payloadItems = [train0, train1];
+
+      const payloadRoundTrips: RoundTrips = {
+        round_trips: [[0, 1]],
+      };
+      const exportPayload = buildTimetableExportPayload(
+        payloadItems,
+        payloadItems.map(({ id }) => id),
+        payloadRoundTrips
+      );
+      const importPayload = processJsonFile(
+        JSON.stringify(exportPayload),
+        'application/json',
+        tMock
+      );
+      expect(importPayload).toEqual(
+        expect.objectContaining({
+          paced_trains: payloadItems.map(({ id: _id, ...rest }) => rest),
+          round_trips: {
+            paced_trains: [[0, 1]],
+          },
+        })
+      );
+    });
+  });
+
   describe('round trips', () => {
     it('should keep one ways when importing valid JSON', () => {
-      const payload = {
-        train_schedules: [train0],
-        paced_trains: [],
+      const payload: TimetableJsonPayload = {
+        paced_trains: [train0],
         round_trips: {
-          train_schedules: [[0, null]],
-          paced_trains: [],
+          paced_trains: [[0, null]],
         },
       };
 
@@ -35,19 +65,16 @@ describe('processJsonFile', () => {
       expect(rawPayload).toEqual(
         expect.objectContaining({
           round_trips: {
-            train_schedules: [[0, null]],
-            paced_trains: [],
+            paced_trains: [[0, null]],
           },
         })
       );
     });
     it('should keep round trips when importing valid JSON', () => {
-      const payload = {
-        train_schedules: [train0, train1],
-        paced_trains: [],
+      const payload: TimetableJsonPayload = {
+        paced_trains: [train0, train1],
         round_trips: {
-          train_schedules: [[0, 1]],
-          paced_trains: [],
+          paced_trains: [[0, 1]],
         },
       };
 
@@ -56,8 +83,7 @@ describe('processJsonFile', () => {
       expect(rawPayload).toEqual(
         expect.objectContaining({
           round_trips: {
-            train_schedules: [[0, 1]],
-            paced_trains: [],
+            paced_trains: [[0, 1]],
           },
         })
       );
@@ -65,8 +91,7 @@ describe('processJsonFile', () => {
 
     it('should reject malformed round trip payloads', () => {
       const invalidPayload = {
-        train_schedules: [train0],
-        paced_trains: [],
+        trains: [train0],
         round_trips: 'invalid',
       };
       expect(() =>
@@ -75,11 +100,9 @@ describe('processJsonFile', () => {
     });
     it('should handle invalid json', () => {
       const invalidPayload = {
-        train_schedules: [0, 1],
-        paced_trains: [],
+        trains: [0, 1],
         round_trips: {
-          train_schedules: [[0, 1]],
-          paced_trains: [],
+          paced_trains: [[0, 1]],
         },
       };
 

--- a/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/generatePayloads.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/generatePayloads.ts
@@ -1,13 +1,9 @@
-import type {
-  PacedTrainFromJson,
-  TrainScheduleFromJson,
-} from 'applications/operationalStudies/types';
+import type { PacedTrainFromJson } from 'applications/operationalStudies/types';
 import type {
   PacedTrain,
   SubCategory,
   TrainCategory,
   TrainMainCategory,
-  TrainSchedule,
 } from 'common/api/osrdEditoastApi';
 import { TrainMainCategoryDict } from 'modules/rollingStock/consts';
 import isMainCategory from 'modules/rollingStock/helpers/category';
@@ -97,22 +93,11 @@ const buildLabels = (
 
 export function generateTrainPayloads(
   parsedPacedTrains: PacedTrainFromJson[],
-  parsedTrainSchedules: TrainScheduleFromJson[],
   allowedSubCategories: SubCategory[]
-): {
-  pacedTrainsPayload: PacedTrain[];
-  trainSchedulesPayload: TrainSchedule[];
-} {
-  return {
-    pacedTrainsPayload: parsedPacedTrains.map((pacedTrain) => ({
-      ...pacedTrain,
-      category: checkCategory(pacedTrain.category, allowedSubCategories),
-      labels: buildLabels(pacedTrain.labels, pacedTrain.category, allowedSubCategories),
-    })),
-    trainSchedulesPayload: parsedTrainSchedules.map((trainSchedule) => ({
-      ...trainSchedule,
-      category: checkCategory(trainSchedule.category, allowedSubCategories),
-      labels: buildLabels(trainSchedule.labels, trainSchedule.category, allowedSubCategories),
-    })),
-  };
+): PacedTrain[] {
+  return parsedPacedTrains.map((pacedTrain) => ({
+    ...pacedTrain,
+    category: checkCategory(pacedTrain.category, allowedSubCategories),
+    labels: buildLabels(pacedTrain.labels, pacedTrain.category, allowedSubCategories),
+  }));
 }

--- a/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/parseJson.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/parseJson.ts
@@ -2,6 +2,7 @@ import type { TFunction } from 'i18next';
 import { isObject } from 'lodash';
 
 import type {
+  PacedTrainFromJson,
   RoundTripsFromJson,
   TimetableJsonPayload,
 } from 'applications/operationalStudies/types';
@@ -17,6 +18,19 @@ const TRAIN_SCHEDULE_COMPULSORY_KEYS: (keyof TrainSchedule)[] = [
   'train_name',
 ];
 
+export type RoundTripsFromJsonCompat = RoundTripsFromJson & {
+  train_schedules?: ([number, number] | [number, null])[];
+};
+
+/**
+ * For backward compatibility
+ */
+export type TimetableJsonPayloadCompat = TimetableJsonPayload & {
+  train_schedules?: PacedTrainFromJson[];
+  trains: PacedTrainFromJson[];
+  round_trips?: RoundTripsFromJsonCompat;
+};
+
 const validateRoundTrips = (roundTrips: unknown): RoundTripsFromJson | undefined => {
   if (roundTrips === undefined || roundTrips === null) {
     return;
@@ -25,54 +39,52 @@ const validateRoundTrips = (roundTrips: unknown): RoundTripsFromJson | undefined
     throw new Error('Invalid round trips configuration');
   }
 
-  const { train_schedules: trainSchedulePairs, paced_trains: pacedTrainPairs } =
-    roundTrips as Partial<RoundTripsFromJson>;
-
-  if (trainSchedulePairs && !Array.isArray(trainSchedulePairs)) {
-    throw new Error('Invalid round trips configuration');
-  }
+  const { paced_trains: pacedTrainPairs, train_schedules: trainSchedulesPairs } =
+    roundTrips as Partial<RoundTripsFromJsonCompat>;
 
   if (pacedTrainPairs && !Array.isArray(pacedTrainPairs)) {
     throw new Error('Invalid round trips configuration');
   }
 
+  // For backward compatibility, we combine the two fields
+  const allRoundTrips = [
+    ...(pacedTrainPairs ?? []),
+    ...(Array.isArray(trainSchedulesPairs) ? trainSchedulesPairs : []),
+  ];
+
   return {
-    train_schedules: trainSchedulePairs ?? [],
-    paced_trains: pacedTrainPairs ?? [],
+    paced_trains: allRoundTrips,
   };
 };
 
-const validateTrainSchedules = (importedItems: unknown): TimetableJsonPayload => {
+export const validateTimetableJsonPayload = (importedItems: unknown): TimetableJsonPayload => {
   if (!isObject(importedItems)) {
     throw new Error('Invalid timetable payload');
   }
 
   const {
-    train_schedules: importedTrainSchedules,
     paced_trains: importedPacedTrains,
     round_trips: importedRoundTrips,
-  } = importedItems as Partial<TimetableJsonPayload>;
+    trains: importedTrains,
+    train_schedules: importedTrainSchedules,
+  } = importedItems as Partial<TimetableJsonPayloadCompat>;
 
-  if (!Array.isArray(importedTrainSchedules)) {
-    throw new Error('Invalid timetable train schedule payload');
+  // For backward compatibility, can be removed in the future
+  const allTrains = [
+    ...(Array.isArray(importedTrains) ? importedTrains : []),
+    ...(Array.isArray(importedTrainSchedules) ? importedTrainSchedules : []),
+    ...(Array.isArray(importedPacedTrains) ? importedPacedTrains : []),
+  ];
+
+  if (allTrains.length === 0) {
+    throw new Error('Invalid timetable payload');
   }
 
-  if (!Array.isArray(importedPacedTrains)) {
-    throw new Error('Invalid timetable paced train payload');
+  if (importedRoundTrips?.paced_trains && allTrains.length === 0) {
+    throw new Error('Invalid round trips configuration');
   }
 
-  const isInvalidTrainSchedules = importedTrainSchedules.some((trainSchedule) => {
-    if (
-      TRAIN_SCHEDULE_COMPULSORY_KEYS.some((key) => !(key in trainSchedule)) ||
-      !Array.isArray(trainSchedule.path)
-    ) {
-      return true;
-    }
-    const hasInvalidSteps = trainSchedule.path.some((step) => !('id' in step));
-    return hasInvalidSteps;
-  });
-
-  const isInvalidPacedTrains = importedPacedTrains.some((pacedTrain) => {
+  const isInvalidPacedTrains = allTrains.some((pacedTrain) => {
     if (
       TRAIN_SCHEDULE_COMPULSORY_KEYS.some((key) => !(key in pacedTrain)) ||
       !Array.isArray(pacedTrain.path)
@@ -83,10 +95,6 @@ const validateTrainSchedules = (importedItems: unknown): TimetableJsonPayload =>
     return hasInvalidSteps;
   });
 
-  if (isInvalidTrainSchedules) {
-    throw new Error('Invalid train schedules: some compulsory keys are missing');
-  }
-
   if (isInvalidPacedTrains) {
     throw new Error('Invalid paced trains: some compulsory keys are missing');
   }
@@ -94,8 +102,7 @@ const validateTrainSchedules = (importedItems: unknown): TimetableJsonPayload =>
   const roundTrips = validateRoundTrips(importedRoundTrips);
 
   return {
-    train_schedules: importedTrainSchedules,
-    paced_trains: importedPacedTrains,
+    paced_trains: allTrains,
     ...(roundTrips ? { round_trips: roundTrips } : {}),
   };
 };
@@ -146,17 +153,8 @@ export const processJsonFile = (
 
   // try to parse the content directly as a TimetableJsonPayload
   try {
-    const importedTrainSchedules = validateTrainSchedules(rawContent);
-    if (
-      importedTrainSchedules.train_schedules.length === 0 &&
-      importedTrainSchedules.paced_trains.length === 0
-    ) {
-      throw {
-        name: t('errorMessages.error'),
-        message: t('errorMessages.errorEmptyFile'),
-      };
-    }
-    return importedTrainSchedules;
+    const importedPayload = validateTimetableJsonPayload(rawContent);
+    return importedPayload;
   } catch {
     throw {
       name: t('errorMessages.error'),

--- a/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/parseXML.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/parseXML.ts
@@ -375,7 +375,9 @@ const parseXML = async (xmlDoc: Document): Promise<TimetableJsonPayload> => {
   const trains = Array.from(xmlDoc.getElementsByTagName('train'));
   const updatedTrainSchedules = mapTrainNames(singleTrainSchedules, trains);
 
-  return { train_schedules: updatedTrainSchedules, paced_trains: importedPacedTrains };
+  return {
+    paced_trains: [...importedPacedTrains, ...updatedTrainSchedules],
+  };
 };
 
 export const locallyProcessXmlFile = async (fileContent: string): Promise<TimetableJsonPayload> => {

--- a/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/postPayloads.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/postPayloads.ts
@@ -1,18 +1,21 @@
 import type { TFunction } from 'i18next';
 
-import type { RoundTripsFromJson } from 'applications/operationalStudies/types';
+import type {
+  RoundTripsFromJson,
+  TimetableJsonPayload,
+} from 'applications/operationalStudies/types';
 import {
   osrdEditoastApi,
   type MacroNodeForm,
-  type MacroNoteForm,
   type PacedTrain,
+  type SubCategory,
 } from 'common/api/osrdEditoastApi';
-import { setWarning, setSuccess, setFailure } from 'reducers/main';
+import { setWarning, setFailure } from 'reducers/main';
 import type { TimetableItem } from 'reducers/osrdconf/types';
 import type { AppDispatch } from 'store';
 import { extractEditoastIdFromPacedTrainId, formatEditoastIdToPacedTrainId } from 'utils/trainId';
 
-import { generateRoundTripsPayload } from './generatePayloads';
+import { generateRoundTripsPayload, generateTrainPayloads } from './generatePayloads';
 
 // TODO: delete this helper and use createPacedTrains (possibly adding if (payloads.length) to it) when the pr createPacedTrain -> createPacedTrains is merged
 export const postTimetableItems = async (
@@ -89,30 +92,30 @@ const postMacroNodesIfNew = async (
 export const postFullImportPayload = async (
   trainScheduleSetId: number,
   scenarioId: number,
-  trainPayloads: PacedTrain[],
-  roundTrips: RoundTripsFromJson | undefined,
-  macroNodes: MacroNodeForm[] | undefined,
-  macroNotes: MacroNoteForm[] | undefined,
+  timetableJsonPayload: TimetableJsonPayload,
+  subCategories: SubCategory[],
   dispatch: AppDispatch,
   t: TFunction<'operational-studies', 'importTrains'>,
   upsertTimetableItems: (items: TimetableItem[]) => void
-): Promise<void> => {
+): Promise<TimetableItem[]> => {
   try {
-    const timetableItems = await postTimetableItems(trainScheduleSetId, trainPayloads, dispatch);
+    const { round_trips, macro_nodes, macro_notes } = timetableJsonPayload;
+    const pacedTrains = generateTrainPayloads(timetableJsonPayload.paced_trains, subCategories);
+    const timetableItems = await postTimetableItems(trainScheduleSetId, pacedTrains, dispatch);
 
-    if (roundTrips) {
-      await postRoundTrips(roundTrips, timetableItems, dispatch);
+    if (round_trips) {
+      await postRoundTrips(round_trips, timetableItems, dispatch);
     }
 
-    if (macroNodes && macroNodes.length > 0) {
-      await postMacroNodesIfNew(macroNodes, scenarioId, dispatch, t);
+    if (macro_nodes && macro_nodes.length > 0) {
+      await postMacroNodesIfNew(macro_nodes, scenarioId, dispatch, t);
     }
 
-    if (macroNotes && macroNotes.length > 0) {
+    if (macro_notes && macro_notes.length > 0) {
       await dispatch(
         osrdEditoastApi.endpoints.postMacroNotes.initiate({
           macroNoteBatchForm: {
-            macro_notes: macroNotes,
+            macro_notes,
             scenario_id: scenarioId,
           },
         })
@@ -121,20 +124,13 @@ export const postFullImportPayload = async (
 
     upsertTimetableItems(timetableItems);
 
-    dispatch(
-      setSuccess({
-        title: t('success'),
-        text: t('status.successfulImport', {
-          count: trainPayloads.length,
-        }),
-      })
-    );
+    return timetableItems;
   } catch (error) {
     dispatch(
       setFailure({
         name: t('failure'),
         message: t('status.invalidTimetableItems', {
-          count: trainPayloads.length,
+          count: timetableJsonPayload.paced_trains.length,
         }),
       })
     );

--- a/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/useImportTimetableItems.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/useImportTimetableItems.ts
@@ -6,13 +6,12 @@ import { useScenarioContext } from 'applications/operationalStudies/hooks/useSce
 import type { TimetableJsonPayload } from 'applications/operationalStudies/types';
 import { osrdRailwayManagerApi } from 'common/api/osrdRailwayManagerApi';
 import { useSubCategoryContext } from 'common/SubCategoryContext';
-import { setFailure } from 'reducers/main';
+import { setFailure, setSuccess } from 'reducers/main';
 import { getRailwayManagerInterfaceUrl } from 'reducers/main/mainSelector';
 import type { TimetableItem } from 'reducers/osrdconf/types';
 import { useAppDispatch } from 'store';
 import { castErrorToFailure } from 'utils/error';
 
-import { generateTrainPayloads } from './helpers/generatePayloads';
 import { processJsonFile } from './helpers/parseJson';
 import locallyProcessXmlFile from './helpers/parseXML';
 import { postFullImportPayload } from './helpers/postPayloads';
@@ -57,30 +56,25 @@ const useImportTimetableItems = ({ upsertTimetableItems }: ImportTimetableItemsP
 
   const importFile = async (file: File) => {
     try {
-      const {
-        train_schedules: parsedTrainSchedules,
-        paced_trains: parsedPacedTrains,
-        macro_nodes: macroNodes,
-        macro_notes: macroNotes,
-        round_trips: roundTripsFromJsonData,
-      } = await processFile(file);
+      const timetableJsonPayload = await processFile(file);
 
-      const { pacedTrainsPayload, trainSchedulesPayload } = generateTrainPayloads(
-        parsedPacedTrains,
-        parsedTrainSchedules,
-        subCategories
-      );
-
-      await postFullImportPayload(
+      const importedTimetableItems = await postFullImportPayload(
         sandboxId,
         scenario.id,
-        [...trainSchedulesPayload, ...pacedTrainsPayload],
-        roundTripsFromJsonData,
-        macroNodes,
-        macroNotes,
+        timetableJsonPayload,
+        subCategories,
         dispatch,
         t,
         upsertTimetableItems
+      );
+
+      dispatch(
+        setSuccess({
+          title: t('success'),
+          text: t('status.successfulImport', {
+            count: importedTimetableItems.length,
+          }),
+        })
       );
     } catch (error: unknown) {
       dispatch(setFailure(castErrorToFailure(error)));

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/__tests__/ngeToOsrd-output-discontinuousTrainrun.json
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/__tests__/ngeToOsrd-output-discontinuousTrainrun.json
@@ -233,12 +233,10 @@
       "train_name": "Carotte-2"
     }
   ],
-  "train_schedules": [],
   "round_trips": {
     "paced_trains": [
       [0, 1],
       [2, 3]
-    ],
-    "train_schedules": []
+    ]
   }
 }

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/__tests__/ngeToOsrd-output-duplicateTrigrams.json
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/__tests__/ngeToOsrd-output-duplicateTrigrams.json
@@ -43,8 +43,7 @@
       "y": 19
     }
   ],
-  "paced_trains": [],
-  "train_schedules": [
+  "paced_trains": [
     {
       "category": {
         "main_category": "INTERCITY_TRAIN"
@@ -53,6 +52,7 @@
       "rolling_stock_name": "",
       "train_name": "Carotte",
       "labels": [],
+      "paced": null,
       "path": [
         {
           "location": {
@@ -94,7 +94,6 @@
     }
   ],
   "round_trips": {
-    "paced_trains": [],
-    "train_schedules": [[0, null]]
+    "paced_trains": [[0, null]]
   }
 }

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/__tests__/ngeToOsrd-output-oneWay.json
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/__tests__/ngeToOsrd-output-oneWay.json
@@ -83,9 +83,7 @@
       "paced": { "interval": "PT1H", "time_window": "PT2H", "exceptions": [] }
     }
   ],
-  "train_schedules": [],
   "round_trips": {
-    "paced_trains": [[0, null]],
-    "train_schedules": []
+    "paced_trains": [[0, null]]
   }
 }

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/__tests__/ngeToOsrd-output-roundTrip.json
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/__tests__/ngeToOsrd-output-roundTrip.json
@@ -144,9 +144,7 @@
       "paced": { "interval": "PT1H", "time_window": "PT2H", "exceptions": [] }
     }
   ],
-  "train_schedules": [],
   "round_trips": {
-    "paced_trains": [[0, 1]],
-    "train_schedules": []
+    "paced_trains": [[0, 1]]
   }
 }

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/ngeToOsrd/ngeToOsrd.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/ngeToOsrd/ngeToOsrd.ts
@@ -1,6 +1,6 @@
 import type {
   PacedTrainFromJson,
-  TrainScheduleFromJson,
+  TimetableJsonPayload,
 } from 'applications/operationalStudies/types';
 import { type MacroNodeForm } from 'common/api/osrdEditoastApi';
 import type { TimetableItemId, TimetableItem } from 'reducers/osrdconf/types';
@@ -162,7 +162,7 @@ export const relabelDuplicateTrigrams = (nodes: NodeDto[]): NodeDto[] => {
   });
 };
 
-export const convertNgeDtoToOsrd = (dto: NetzgrafikDto) => {
+export const convertNgeDtoToOsrd = (dto: NetzgrafikDto): TimetableJsonPayload => {
   const macroNotes = dto.freeFloatingTexts.map((note) => castNgeNoteToOsrd(note, dto));
 
   const dedupNodes = relabelDuplicateTrigrams(dto.nodes);
@@ -174,10 +174,8 @@ export const convertNgeDtoToOsrd = (dto: NetzgrafikDto) => {
     });
   }
 
-  const trainSchedules: TrainScheduleFromJson[] = [];
   const pacedTrains: PacedTrainFromJson[] = [];
   const pacedTrainsRoundTrips: ([number, number] | [number, null])[] = [];
-  const trainSchedulesRoundTrips: ([number, number] | [number, null])[] = [];
   for (const trainrun of dto.trainruns) {
     const groupedTrainrunSections = getTrainrunSectionsByTrainrunId(dto, trainrun.id);
     const labels = getTrainrunLabels(dto, trainrun);
@@ -208,29 +206,16 @@ export const convertNgeDtoToOsrd = (dto: NetzgrafikDto) => {
           ...pathAndSchedule,
         };
         const paced = createPacedAttributesFromTrainrun(trainrun, dto);
-        if (paced) {
-          pacedTrains.push({
-            ...DEFAULT_TRAIN_SCHEDULE_PAYLOAD,
-            ...commonProps,
-            paced,
-          });
-          if (direction === TRAINRUN_DIRECTIONS.FORWARD) {
-            pacedTrainsRoundTrips.push([
-              pacedTrains.length - 1,
-              trainrun.direction === 'one_way' ? null : pacedTrains.length,
-            ]);
-          }
-        } else {
-          trainSchedules.push({
-            ...DEFAULT_TRAIN_SCHEDULE_PAYLOAD,
-            ...commonProps,
-          });
-          if (direction === TRAINRUN_DIRECTIONS.FORWARD) {
-            trainSchedulesRoundTrips.push([
-              trainSchedules.length - 1,
-              trainrun.direction === 'one_way' ? null : trainSchedules.length,
-            ]);
-          }
+        pacedTrains.push({
+          ...DEFAULT_TRAIN_SCHEDULE_PAYLOAD,
+          ...commonProps,
+          paced,
+        });
+        if (direction === TRAINRUN_DIRECTIONS.FORWARD) {
+          pacedTrainsRoundTrips.push([
+            pacedTrains.length - 1,
+            trainrun.direction === 'one_way' ? null : pacedTrains.length,
+          ]);
         }
       }
     }
@@ -240,7 +225,6 @@ export const convertNgeDtoToOsrd = (dto: NetzgrafikDto) => {
     macro_nodes: macroNodes,
     macro_notes: macroNotes,
     paced_trains: pacedTrains,
-    train_schedules: trainSchedules,
-    round_trips: { train_schedules: trainSchedulesRoundTrips, paced_trains: pacedTrainsRoundTrips },
+    round_trips: { paced_trains: pacedTrainsRoundTrips },
   };
 };

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TimetableBoardWrapper.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TimetableBoardWrapper.tsx
@@ -7,6 +7,7 @@ import { useScenarioContext } from 'applications/operationalStudies/hooks/useSce
 import BoardWrapper from 'applications/operationalStudies/views/Scenario/components/BoardWrapper';
 import DeleteModal from 'common/BootstrapSNCF/ModalSNCF/DeleteModal';
 import { ModalContext } from 'common/BootstrapSNCF/ModalSNCF/ModalProvider';
+import { useSubCategoryContext } from 'common/SubCategoryContext';
 import { deletePacedTrains } from 'modules/timetableItem/helpers/updateTimetableItemHelpers';
 import type { TimetableItemWithDetails } from 'modules/timetableItem/types';
 import { setFailure, setSuccess } from 'reducers/main';
@@ -24,7 +25,8 @@ import { mapBy } from 'utils/types';
 
 import Timetable from './Timetable';
 import { copyTimetableItemsToClipboard } from './utils';
-import { postTimetableItems } from '../ImportTimetableItem/helpers/postPayloads';
+import { validateTimetableJsonPayload } from '../ImportTimetableItem/helpers/parseJson';
+import { postFullImportPayload } from '../ImportTimetableItem/helpers/postPayloads';
 
 type TimetableBoardWrapperProps = {
   setDisplayTimetableItemManagement: (mode: string) => void;
@@ -54,11 +56,13 @@ const TimetableBoardWrapper = ({
 }: TimetableBoardWrapperProps) => {
   const { openModal } = useContext(ModalContext);
 
-  const { sandboxId } = useScenarioContext();
+  const { scenario, sandboxId } = useScenarioContext();
 
   const selectedTrainId = useSelector(getSelectedTrainId);
 
   const { t } = useTranslation('operational-studies');
+
+  const subCategories = useSubCategoryContext();
 
   const dispatch = useAppDispatch();
 
@@ -215,12 +219,18 @@ const TimetableBoardWrapper = ({
     const clipboardContent = await navigator.clipboard.readText();
     try {
       data = JSON.parse(clipboardContent);
-      const newTimetableItems = await postTimetableItems(
+      const importedPayload = validateTimetableJsonPayload(data);
+
+      const newTimetableItems = await postFullImportPayload(
         sandboxId,
-        [...data.train_schedules, ...data.paced_trains],
-        dispatch
+        scenario.id,
+        importedPayload,
+        subCategories,
+        dispatch,
+        t,
+        upsertTimetableItems
       );
-      upsertTimetableItems(newTimetableItems);
+
       setSelectedTimetableItemIds(newTimetableItems.map((item) => item.id));
       dispatch(
         setSuccess({
@@ -229,8 +239,9 @@ const TimetableBoardWrapper = ({
         })
       );
     } catch (e) {
-      if (data && data.train_schedules && data.paced_trains)
+      if (data && data.paced_trains) {
         dispatch(setFailure(castErrorToFailure(e)));
+      }
     }
   }, [sandboxId]);
 

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/__tests__/utils.spec.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/__tests__/utils.spec.ts
@@ -23,7 +23,6 @@ describe('buildTimetableExportPayload', () => {
     );
 
     expect(payload.round_trips).toBeDefined();
-    expect(payload.round_trips!.train_schedules).toEqual([]);
     expect(payload.round_trips!.paced_trains).toEqual([[0, null]]);
   });
 
@@ -54,6 +53,5 @@ describe('buildTimetableExportPayload', () => {
     });
 
     expect(payload.round_trips?.paced_trains).toEqual([[0, null]]);
-    expect(payload.round_trips?.train_schedules).toEqual([]);
   });
 });

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/utils.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/utils.ts
@@ -74,7 +74,7 @@ export const copyTimetableItemsToClipboard = async (
     timetableItems,
     selectedTimeTableIdsFromClick
   );
-  const jsonString = JSON.stringify({ pacedTrains: formattedTimetableItems });
+  const jsonString = JSON.stringify({ paced_trains: formattedTimetableItems });
   const blob = new Blob([jsonString], { type: 'text/plain' });
   const clipboardItem = new ClipboardItem({ [blob.type]: blob });
   await navigator.clipboard.write([clipboardItem]);
@@ -123,7 +123,7 @@ function mapRoundTripsToIndexes(
 }
 
 type TimetableExportPayload = {
-  trains: PacedTrain[];
+  paced_trains: PacedTrain[];
   round_trips?: RoundTripsFromJson;
 };
 
@@ -138,15 +138,14 @@ export const buildTimetableExportPayload = (
   );
 
   const roundTrips: RoundTripsFromJson = {
-    train_schedules: [],
     paced_trains: mapRoundTripsToIndexes(pacedTrainRoundTrips, pacedTrainIndexByEditoastId),
   };
 
-  if (roundTrips.train_schedules.length === 0 && roundTrips.paced_trains.length === 0) {
-    return { trains: formattedTimetableItems };
+  if (roundTrips.paced_trains.length === 0) {
+    return { paced_trains: formattedTimetableItems };
   }
 
-  return { trains: formattedTimetableItems, round_trips: roundTrips };
+  return { paced_trains: formattedTimetableItems, round_trips: roundTrips };
 };
 
 export const exportTimetableItems = (

--- a/front/tests/assets/operation-studies/timetable-items.json
+++ b/front/tests/assets/operation-studies/timetable-items.json
@@ -1,5 +1,5 @@
 {
-  "train_schedules": [
+  "paced_trains": [
     {
       "train_name": "Train1",
       "labels": ["Tag-1", "SS-NS"],
@@ -372,9 +372,7 @@
       "start_time": "2024-10-17T19:05:00.000Z",
       "train_name": "Train7",
       "timetable_id": 597
-    }
-  ],
-  "paced_trains": [
+    },
     {
       "train_name": "Paced Train - Updated exception (RS)",
       "labels": ["Paced-Train-Tag-2", "MWS-NES", "Not-honored", "Valid"],


### PR DESCRIPTION
fix of #14735

This PR fix the import/export and ctrl+c import of timetables with backward compatibility