### PR TITLE
core: stdcm: use slopes from prev edges during exploration

### DIFF
--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/TrainPhysicsIntegrator.kt
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/TrainPhysicsIntegrator.kt
@@ -139,9 +139,8 @@ private constructor(
             path: PhysicsPath,
             headPosition: Double,
         ): Double {
-            var headPosition = headPosition
-            val tailPosition = min(max(0.0, headPosition - rollingStock.length), path.length)
-            headPosition = min(max(0.0, headPosition), path.length)
+            val headPosition = headPosition
+            val tailPosition = headPosition - rollingStock.length
             return path.getAverageGrade(tailPosition, headPosition)
         }
 
@@ -159,9 +158,8 @@ private constructor(
             path: PhysicsPath,
             headPosition: Double,
         ): Double {
-            var headPosition = headPosition
-            val tailPosition = min(max(0.0, headPosition - rollingStock.length), path.length)
-            headPosition = min(max(0.0, headPosition), path.length)
+            val headPosition = headPosition
+            val tailPosition = headPosition - rollingStock.length
             return path.getMinGrade(tailPosition, headPosition)
         }
 

--- a/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/pipelines/MaxEffortEnvelope.kt
+++ b/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/pipelines/MaxEffortEnvelope.kt
@@ -16,7 +16,6 @@ import fr.sncf.osrd.envelope_sim.overlays.EnvelopeAcceleration
 import fr.sncf.osrd.envelope_sim.overlays.EnvelopeMaintain
 import fr.sncf.osrd.reporting.exceptions.ErrorType
 import fr.sncf.osrd.reporting.exceptions.OSRDError
-import kotlin.math.max
 import kotlin.math.min
 
 /**
@@ -142,9 +141,8 @@ private fun accelerate(
         val err = OSRDError(ErrorType.ImpossibleSimulationError)
         val offset = cursor.getPosition()
         err.context.put("offset", String.format("%.0fm", offset))
-        val headPosition = min(max(0.0, offset), context.path.length)
-        val tailPosition =
-            min(max(0.0, headPosition - context.rollingStock.length), context.path.length)
+        val headPosition = offset
+        val tailPosition = headPosition - context.rollingStock.length
         val grade = context.path.getAverageGrade(headPosition, tailPosition)
         err.context.put("grade", String.format("%.2fm/km", grade))
         val map = context.tractiveEffortCurveMap[cursor.getPosition()]!!

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/EnvelopeSimPath.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/EnvelopeSimPath.kt
@@ -10,6 +10,8 @@ import fr.sncf.osrd.utils.RangeMapUtils
 import fr.sncf.osrd.utils.arePositionsEqual
 import fr.sncf.osrd.utils.entries
 import java.util.Arrays
+import kotlin.math.max
+import kotlin.math.min
 
 class EnvelopeSimPath(
     length: Double,
@@ -104,12 +106,16 @@ class EnvelopeSimPath(
     }
 
     override fun getAverageGrade(begin: Double, end: Double): Double {
+        val begin = min(max(begin, 0.0), length)
+        val end = min(max(end, 0.0), length)
         if (begin == end) return getCumGrade(begin)
         return (getCumGrade(end) - getCumGrade(begin)) / (end - begin)
     }
 
     override fun getMinGrade(begin: Double, end: Double): Double {
         // TODO: Optimise method by adding in a cache.
+        val begin = min(max(begin, 0.0), length)
+        val end = min(max(end, 0.0), length)
         val indexBegin = getIndexBeforePos(begin)
         val indexEnd = getIndexBeforePos(end)
         // TODO: Remove if we extend path properties until last SvL > path.length.

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/PathViewWithFullSlopes.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/PathViewWithFullSlopes.kt
@@ -1,0 +1,152 @@
+package fr.sncf.osrd.path.implementations
+
+import com.google.common.collect.ImmutableRangeMap
+import com.google.common.collect.RangeMap
+import fr.sncf.osrd.geom.LineString
+import fr.sncf.osrd.path.interfaces.BlockRange
+import fr.sncf.osrd.path.interfaces.DirChunkRange
+import fr.sncf.osrd.path.interfaces.Electrification
+import fr.sncf.osrd.path.interfaces.GenericLinearRange
+import fr.sncf.osrd.path.interfaces.RouteRange
+import fr.sncf.osrd.path.interfaces.TrackLocation
+import fr.sncf.osrd.path.interfaces.TrainPath
+import fr.sncf.osrd.path.interfaces.ZonePathRange
+import fr.sncf.osrd.path.interfaces.ZoneRange
+import fr.sncf.osrd.sim_infra.api.LoadingGaugeConstraint
+import fr.sncf.osrd.sim_infra.api.NeutralSection
+import fr.sncf.osrd.sim_infra.api.OperationalPointPartId
+import fr.sncf.osrd.sim_infra.api.RouteId
+import fr.sncf.osrd.sim_infra.api.SpeedLimitProperty
+import fr.sncf.osrd.sim_infra.api.TrackChunkId
+import fr.sncf.osrd.sim_infra.api.ZoneId
+import fr.sncf.osrd.sim_infra.impl.TemporarySpeedLimitManager
+import fr.sncf.osrd.utils.DistanceRangeMap
+import fr.sncf.osrd.utils.units.Length
+import fr.sncf.osrd.utils.units.Offset
+
+/**
+ * This class is a view on a train path, it's very similar to `originalPath.subPath(begin, end)`.
+ * But it keeps track of the original path when accessing grade data outside the new range.
+ */
+data class PathViewWithFullSlopes(
+    val originalPath: TrainPath,
+    val begin: Offset<TrainPath>,
+    val end: Offset<TrainPath>,
+) : TrainPath {
+    override val length: Double
+        get() = (end - begin).meters
+
+    val subPath by lazy { originalPath.subPath(begin, end) }
+
+    override fun getAverageGrade(begin: Double, end: Double): Double {
+        return originalPath.getAverageGrade(begin + this.begin.meters, end + this.begin.meters)
+    }
+
+    override fun getMinGrade(begin: Double, end: Double): Double {
+        return originalPath.getMinGrade(begin + this.begin.meters, end + this.begin.meters)
+    }
+
+    override fun getElectrificationMap(
+        basePowerClass: String?,
+        powerRestrictionMap: RangeMap<Double, String>?,
+        powerRestrictionToPowerClass: Map<String, String>?,
+        ignoreElectricalProfiles: Boolean,
+    ): ImmutableRangeMap<Double, Electrification> {
+        return subPath.getElectrificationMap(
+            basePowerClass,
+            powerRestrictionMap,
+            powerRestrictionToPowerClass,
+            ignoreElectricalProfiles,
+        )
+    }
+
+    override fun subPath(from: Offset<TrainPath>?, to: Offset<TrainPath>?): TrainPath {
+        return subPath.subPath(from, to)
+    }
+
+    override fun withRoutes(routes: List<RouteId>): TrainPath {
+        return PathViewWithFullSlopes(originalPath.withRoutes(routes), begin, end)
+    }
+
+    override fun getBacktrackLocations(): List<Offset<TrainPath>> {
+        return subPath.getBacktrackLocations()
+    }
+
+    override fun getBlocks(): List<BlockRange> {
+        return subPath.getBlocks()
+    }
+
+    override fun getRoutes(): List<RouteRange> {
+        return subPath.getRoutes()
+    }
+
+    override fun getChunks(): List<DirChunkRange> {
+        return subPath.getChunks()
+    }
+
+    override fun getZonePaths(): List<ZonePathRange> {
+        return subPath.getZonePaths()
+    }
+
+    override fun getZoneRanges(): List<ZoneRange> {
+        return subPath.getZoneRanges()
+    }
+
+    override fun getSlopes(): DistanceRangeMap<Double> {
+        return subPath.getSlopes()
+    }
+
+    override fun getOperationalPointParts():
+        List<GenericLinearRange.LocatedObject<OperationalPointPartId>> {
+        return subPath.getOperationalPointParts()
+    }
+
+    override fun getGradients(): DistanceRangeMap<Double> {
+        return subPath.getGradients()
+    }
+
+    override fun getCurves(): DistanceRangeMap<Double> {
+        return subPath.getCurves()
+    }
+
+    override fun getGeo(): LineString {
+        return subPath.getGeo()
+    }
+
+    override fun getLoadingGauge(): DistanceRangeMap<LoadingGaugeConstraint> {
+        return subPath.getLoadingGauge()
+    }
+
+    override fun getElectrification(): DistanceRangeMap<Set<String>> {
+        return subPath.getElectrification()
+    }
+
+    override fun getNeutralSections(): DistanceRangeMap<NeutralSection> {
+        return subPath.getNeutralSections()
+    }
+
+    override fun getSpeedLimitProperties(
+        trainTag: String?,
+        temporarySpeedLimitManager: TemporarySpeedLimitManager?,
+    ): DistanceRangeMap<SpeedLimitProperty> {
+        return subPath.getSpeedLimitProperties(trainTag, temporarySpeedLimitManager)
+    }
+
+    override fun getZones(): DistanceRangeMap<ZoneId> {
+        return subPath.getZones()
+    }
+
+    override fun getLength(): Length<TrainPath> {
+        return subPath.getLength()
+    }
+
+    override fun getTrackLocationAtOffset(pathOffset: Offset<TrainPath>): TrackLocation {
+        return subPath.getTrackLocationAtOffset(pathOffset)
+    }
+
+    override fun <T> getRangeMapFromUndirected(
+        getData: (chunkId: TrackChunkId) -> DistanceRangeMap<T>
+    ): DistanceRangeMap<T> {
+        return subPath.getRangeMapFromUndirected(getData)
+    }
+}

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/BacktrackingManager.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/BacktrackingManager.kt
@@ -55,6 +55,7 @@ class BacktrackingManager(private val graph: STDCMGraph) {
         val oldEnvelope =
             graph.stdcmSimulations.simulateBlock(
                 graph.rawInfra,
+                graph.blockInfra,
                 graph.rollingStock,
                 graph.comfort,
                 graph.timeStep,

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdgeBuilder.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdgeBuilder.kt
@@ -87,6 +87,7 @@ internal constructor(
             envelope =
                 graph.stdcmSimulations.simulateBlock(
                     graph.rawInfra,
+                    graph.blockInfra,
                     graph.rollingStock,
                     graph.comfort,
                     graph.timeStep,

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMSimulations.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMSimulations.kt
@@ -14,11 +14,13 @@ import fr.sncf.osrd.envelope_sim.pipelines.SimStop
 import fr.sncf.osrd.envelope_sim.pipelines.maxEffortEnvelopeFrom
 import fr.sncf.osrd.envelope_sim.pipelines.maxSpeedEnvelopeFrom
 import fr.sncf.osrd.envelope_sim_infra.computeMRSP
+import fr.sncf.osrd.path.implementations.PathViewWithFullSlopes
 import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
 import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal
 import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.sim_infra.api.Block
+import fr.sncf.osrd.sim_infra.api.BlockInfra
 import fr.sncf.osrd.sim_infra.api.RawSignalingInfra
 import fr.sncf.osrd.sim_infra.impl.TemporarySpeedLimitManager
 import fr.sncf.osrd.stdcm.BacktrackingSelfTypeHolder
@@ -27,6 +29,7 @@ import fr.sncf.osrd.train.RollingStock
 import fr.sncf.osrd.utils.SelfTypeHolder
 import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Offset
+import fr.sncf.osrd.utils.units.Offset.Companion.min
 import java.lang.ref.SoftReference
 
 /** This class contains all the methods used to simulate the train behavior. */
@@ -43,6 +46,7 @@ class STDCMSimulations {
      */
     fun simulateBlock(
         rawInfra: RawSignalingInfra,
+        blockInfra: BlockInfra,
         rollingStock: RollingStock,
         comfort: Comfort?,
         timeStep: Double,
@@ -56,6 +60,7 @@ class STDCMSimulations {
         val simulatedEnvelope =
             simulateBlock(
                 rawInfra,
+                blockInfra,
                 infraExplorer,
                 blockParams.initialSpeed,
                 blockParams.start,
@@ -80,6 +85,7 @@ class STDCMSimulations {
      */
     fun simulateBlock(
         rawInfra: RawSignalingInfra,
+        blockInfra: BlockInfra,
         infraExplorer: InfraExplorer,
         initialSpeed: Double,
         start: Offset<Block>,
@@ -104,7 +110,20 @@ class STDCMSimulations {
             stops = listOf(SimStop(stopOffset, RJSReceptionSignal.SHORT_SLIP_STOP))
             simLength = Distance.min(simLength, stopOffset.distance)
         }
-        val path = infraExplorer.getCurrentEdgePathProperties(start, simLength)
+
+        // We build the entire train path, then take a subsection that still keeps track of previous
+        // slopes that part of the train may still be covering. It feels inefficient as it has
+        // quadratic scaling with path length, but surprisingly it barely shows up in profilers
+        // (compared to everything else).
+        val pathStart = infraExplorer.getCurrentBlockRange().offsetToTrainPath(start)
+        val fullPath = infraExplorer.buildFullPath(rawInfra, blockInfra)
+        val path =
+            PathViewWithFullSlopes(
+                fullPath,
+                pathStart,
+                min(pathStart + simLength, fullPath.getLength()),
+            )
+
         val context = build(rollingStock, path, timeStep, comfort)
         val mrsp = computeMRSP(path, rollingStock, false, trainTag, temporarySpeedLimitManager)
         return try {

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/engineering_allowance/EngineeringAllowanceManager.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/engineering_allowance/EngineeringAllowanceManager.kt
@@ -211,7 +211,7 @@ class EngineeringAllowanceManager(
             if (pureDecelerationSim.newBeginSpeed > segment.beginSpeed) {
                 // Intersection with base sim. We estimate the new time with a basic speed plateau +
                 // const deceleration, return this segment, and exit the loop.
-                if (segment.beginSpeed < endSpeed || segment.beginSpeed <= 0.0)
+                if (segment.beginSpeed <= endSpeed || segment.beginSpeed <= 0.0)
                     break // Can't run the simplified sim, there's an acceleration
                 val newTime =
                     simplifiedSpeedPlateauThenDeceleration(

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/EngineeringAllowanceTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/EngineeringAllowanceTests.kt
@@ -1,12 +1,14 @@
 package fr.sncf.osrd.stdcm
 
 import com.google.common.collect.ImmutableMultimap
+import fr.sncf.osrd.envelope_sim.allowances.AllowanceValue
 import fr.sncf.osrd.pathfinding.BlockLocation
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.stdcm.preprocessing.OccupancySegment
 import fr.sncf.osrd.train.TestTrains
+import fr.sncf.osrd.train.TestTrains.VERY_LONG_FAST_TRAIN
 import fr.sncf.osrd.utils.DummyInfra
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
@@ -680,6 +682,46 @@ class EngineeringAllowanceTests {
                 .setEndLocations(setOf(BlockLocation(thirdBlock, Offset(1.meters))))
                 .setUnavailableTimes(occupancyGraph)
                 .setTimeStep(timeStep)
+                .run()!!
+        occupancyTest(res, occupancyGraph, 2 * timeStep)
+    }
+
+    /**
+     * Reproduce a bug: this engineering allowance setup forces the train to be planned as close as
+     * possible to the unoccupied section in the first blocks. But because the gradients don't carry
+     * over block transitions, the post-processing simulation has worse gradients in the second
+     * blocks compared to the sims during the search.
+     */
+    @Test
+    fun testVeryLongTrainWithSlopes() {
+        val infra = DummyInfra()
+        val blocks =
+            listOf(
+                infra.addBlock("a", "b", 100.meters, 60.0, gradient = 40.0),
+                infra.addBlock("b", "c", 2_000.meters, 60.0),
+                infra.addBlock("c", "d", 2_000.meters, 60.0),
+                infra.addBlock("d", "e", 2_000.meters, 30.0),
+                infra.addBlock("e", "f", 100.meters, 30.0),
+            )
+        val occupancyGraph =
+            ImmutableMultimap.of(
+                blocks[0],
+                OccupancySegment(150.0, POSITIVE_INFINITY, 0.meters, 100.meters),
+                blocks[1],
+                OccupancySegment(150.0, POSITIVE_INFINITY, 0.meters, 2_000.meters),
+                blocks.last(),
+                OccupancySegment(0.0, 2 * 3600.0, 0.meters, 100.meters),
+            )
+        val timeStep = 2.0
+        val res =
+            STDCMPathfindingBuilder()
+                .setInfra(infra.fullInfra())
+                .setStartLocations(setOf(BlockLocation(blocks.first(), Offset(0.meters))))
+                .setEndLocations(setOf(BlockLocation(blocks.last(), Offset(1.meters))))
+                .setUnavailableTimes(occupancyGraph)
+                .setTimeStep(timeStep)
+                .setRollingStock(VERY_LONG_FAST_TRAIN)
+                .setStandardAllowance(AllowanceValue.Percentage(10.0))
                 .run()!!
         occupancyTest(res, occupancyGraph, 2 * timeStep)
     }

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/EngineeringAllowanceTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/EngineeringAllowanceTests.kt
@@ -722,7 +722,7 @@ class EngineeringAllowanceTests {
                 .setTimeStep(timeStep)
                 .setRollingStock(VERY_LONG_FAST_TRAIN)
                 .setStandardAllowance(AllowanceValue.Percentage(10.0))
-                .run()!!
+                .run() ?: return // Not finding a solution is valid (and expected)
         occupancyTest(res, occupancyGraph, 2 * timeStep)
     }
 }

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMHelpers.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMHelpers.kt
@@ -16,6 +16,7 @@ import fr.sncf.osrd.stdcm.infra_exploration.initInfraExplorers
 import fr.sncf.osrd.stdcm.preprocessing.OccupancySegment
 import fr.sncf.osrd.train.RollingStock
 import fr.sncf.osrd.train.TestTrains
+import fr.sncf.osrd.utils.DummyInfra
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import org.junit.jupiter.api.Assertions
@@ -31,6 +32,7 @@ fun getBlocksRunTime(infra: FullInfra, blocks: List<BlockId>): Double {
         val envelope =
             simulateBlock(
                 infra.rawInfra,
+                infra.blockInfra,
                 infraExplorerFromBlock(infra.rawInfra, infra.blockInfra, block),
                 speed,
                 Offset(0.meters),
@@ -47,9 +49,37 @@ fun getBlocksRunTime(infra: FullInfra, blocks: List<BlockId>): Double {
     return time
 }
 
+fun simulateBlock(
+    infra: DummyInfra,
+    infraExplorer: InfraExplorer,
+    initialSpeed: Double,
+    start: Offset<Block>,
+    rollingStock: RollingStock,
+    comfort: Comfort?,
+    timeStep: Double,
+    stopPosition: Offset<Block>?,
+    trainTag: String?,
+    temporarySpeedLimitManager: TemporarySpeedLimitManager?,
+): Envelope? {
+    return simulateBlock(
+        infra,
+        infra,
+        infraExplorer,
+        initialSpeed,
+        start,
+        rollingStock,
+        comfort,
+        timeStep,
+        stopPosition,
+        trainTag,
+        temporarySpeedLimitManager,
+    )
+}
+
 /** Helper function to call `simulateBlock` without instantiating an `STDCMSimulations` */
 fun simulateBlock(
     rawInfra: RawSignalingInfra,
+    blockInfra: BlockInfra,
     infraExplorer: InfraExplorer,
     initialSpeed: Double,
     start: Offset<Block>,
@@ -64,6 +94,7 @@ fun simulateBlock(
     val res =
         sim.simulateBlock(
             rawInfra,
+            blockInfra,
             infraExplorer,
             initialSpeed,
             start,

--- a/core/src/test/kotlin/fr/sncf/osrd/utils/DummyInfra.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/utils/DummyInfra.kt
@@ -53,6 +53,7 @@ class DummyInfra : RawInfra, BlockInfra {
         allowedSpeed: Double = Double.POSITIVE_INFINITY,
         signalingSystemName: String = BAL.id,
         detailedSpeedLimits: DistanceRangeMap<SpeedLimitProperty>? = null,
+        gradient: Double = 0.0,
     ): BlockId {
         val name = String.format("%s->%s", entry, exit)
         val entryId = getOrCreateDetectorId(entry)
@@ -69,7 +70,7 @@ class DummyInfra : RawInfra, BlockInfra {
                 entryId,
                 exitId,
                 speedLimits,
-                0.0,
+                gradient,
                 signalingSystemId,
                 signalingSystemName,
             )
@@ -405,7 +406,7 @@ class DummyInfra : RawInfra, BlockInfra {
     }
 
     override fun getTrackChunkSlope(trackChunk: DirTrackChunkId): DistanceRangeMap<Double> {
-        TODO("Not yet implemented")
+        return getTrackChunkGradient(trackChunk)
     }
 
     override fun getTrackChunkCurve(trackChunk: DirTrackChunkId): DistanceRangeMap<Double> {


### PR DESCRIPTION
Fix at least some of the "mismatch" errors, likely most/all of them. Especially the ones with very long trains and several stops.

This *feels* extremely inefficient (see comments). We build the *entire* train path from its beginning at each block. But somehow it doesn't slow things down by any noticeable amount. 

This was meant as an hypothesis check: if we brute-force the "previous slopes" issue, does it fix the problem. It does. And the brute-forcing doesn't even seems to be a problem. 

---

A more "proper" solution would be some kind of incremental path that would be smarter about the cumulative grade computations. We already have issues there even before this PR. But it would take more work and code complexity.

---

After running the fuzzer: it doesn't fix *every* broken case, but it does help. It makes things a little slower, there were a few cases that went from "crash" to "timeout" (a little better?)