### PR TITLE
Prevent crash when adding logical signal to new signal

### DIFF
--- a/front/src/applications/editor/tools/pointEdition/types.ts
+++ b/front/src/applications/editor/tools/pointEdition/types.ts
@@ -32,7 +32,7 @@ export type SignalingSystem = {
 );
 
 export type SignalingSystemForm = {
-  next_signaling_systems: Array<string | undefined>;
+  next_signaling_systems?: Array<string | undefined>;
   signaling_system: 'BAL' | 'BAPR' | 'TVM';
   settings?: { Nf?: 'true' | 'false'; distant?: 'true' | 'false'; is_430?: 'true' | 'false' };
   default_parameters?: { jaune_cli: 'true' | 'false' };

--- a/front/src/applications/editor/tools/pointEdition/utils.ts
+++ b/front/src/applications/editor/tools/pointEdition/utils.ts
@@ -87,7 +87,7 @@ function getLogicalSignalSettings(signalingSystem: SignalingSystemForm) {
 }
 
 export function formatSignalingSystem(logicalSignal: SignalingSystemForm): SignalingSystem {
-  const next_signaling_systems = logicalSignal.next_signaling_systems.map(
+  const next_signaling_systems = (logicalSignal.next_signaling_systems ?? []).map(
     (nextSignalingSystem) => nextSignalingSystem || 'BAL'
   );
 
@@ -103,10 +103,14 @@ export function formatSignalingSystem(logicalSignal: SignalingSystemForm): Signa
     } as SignalingSystem;
   }
 
-  const conditional_parameters = logicalSignal.conditional_parameters.map((conditionalParameter) =>
-    isEmpty(conditionalParameter)
-      ? { on_route: '', parameters: { jaune_cli: 'false' } }
-      : conditionalParameter
+  const conditional_parameters = (logicalSignal.conditional_parameters ?? []).map(
+    (conditionalParameter) =>
+      isEmpty(conditionalParameter)
+        ? { on_route: '', parameters: { jaune_cli: 'false' } }
+        : {
+            on_route: conditionalParameter.on_route ?? '',
+            parameters: { jaune_cli: conditionalParameter.parameters?.jaune_cli ?? 'false' },
+          }
   );
 
   return {


### PR DESCRIPTION
The editor is crashing when adding a logical signal to a new signal because the form sometimes sends incomplete items while editing.

close #14723 