### PR TITLE
front: fix gesico modal latency

### DIFF
--- a/front/src/applications/stdcm/components/StdcmResults/SendToRailwayManagerModal.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/SendToRailwayManagerModal.tsx
@@ -1,16 +1,15 @@
-import { useMemo, useState, useRef, useCallback, useEffect } from 'react';
+import { useEffect, useMemo, useState, useCallback, type ReactElement } from 'react';
 
 import { Button, Checkbox, DatePicker, Input, Select, TextArea } from '@osrd-project/ui-core';
 import { Download, CheckCircle } from '@osrd-project/ui-icons';
-import { PDFDownloadLink, pdf } from '@react-pdf/renderer';
+import { pdf, type DocumentProps } from '@react-pdf/renderer';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
-import {
-  type StdcmSimulationInputs,
-  type StdcmSuccessResponse,
-  type SimilarTrainWithSecondaryCode,
-  type StdcmResultsOperationalPoint,
+import type {
+  StdcmSimulationInputs,
+  StdcmSuccessResponse,
+  SimilarTrainWithSecondaryCode,
 } from 'applications/stdcm/types';
 import {
   osrdRailwayManagerApi,
@@ -31,10 +30,7 @@ import { useAppDispatch } from 'store';
 import { useDateTimeLocale } from 'utils/date';
 import { addDurationToDate, Duration, subtractDurationFromDate } from 'utils/duration';
 import { castErrorToFailure } from 'utils/error';
-import type { DeploymentSettings } from 'utils/hooks/useDeploymentSettings';
 import { kmhToMs, tToKg } from 'utils/physics';
-
-import StdcmSimulationReportSheet from './StdcmSimulationReportSheet';
 
 type SendToRailwayManagerModalProps = {
   onSuccess: (isSuccessful: boolean, request_identifier?: string) => void;
@@ -43,10 +39,9 @@ type SendToRailwayManagerModalProps = {
   stdcmData: StdcmSuccessResponse;
   linkedTrains: StdcmSimulationInputs['linkedTrains'];
   simulationReportSheetNumber: string;
-  operationalPointsList: StdcmResultsOperationalPoint[];
-  simulationSheetLogo?: string;
   similarTrains: SimilarTrainWithSecondaryCode[];
-  deploymentSettings?: DeploymentSettings;
+  pdfBlob: Blob | null;
+  pdfDocument: ReactElement<DocumentProps>;
 };
 
 type Option = { value: string; label: string };
@@ -62,10 +57,9 @@ const SendToRailwayManagerModal = ({
   stdcmData,
   linkedTrains,
   simulationReportSheetNumber,
-  operationalPointsList,
-  simulationSheetLogo,
   similarTrains,
-  deploymentSettings,
+  pdfBlob,
+  pdfDocument,
 }: SendToRailwayManagerModalProps) => {
   const { t } = useTranslation('stdcm', { keyPrefix: 'simulation.results' });
   const { t: mainT } = useTranslation('translation');
@@ -86,7 +80,6 @@ const SendToRailwayManagerModal = ({
   const [isHazardousMaterials, setIsHazardousMaterials] = useState(false);
   const [pathTypeError, setPathTypeError] = useState(false);
   const [csCodeError, setCsCodeError] = useState(false);
-  const pdfBlobRef = useRef<Blob | null>(null);
 
   const { simulationPathSteps: steps } = stdcmData;
 
@@ -165,29 +158,6 @@ const SendToRailwayManagerModal = ({
     { value: 'C', label: 'C' },
   ];
 
-  const pdfDocument = useMemo(
-    () => (
-      <StdcmSimulationReportSheet
-        stdcmLinkedTrains={linkedTrains}
-        stdcmData={stdcmData}
-        consist={consist}
-        simulationReportSheetNumber={simulationReportSheetNumber}
-        operationalPointsList={operationalPointsList}
-        simulationSheetLogo={simulationSheetLogo}
-        similarTrains={similarTrains}
-      />
-    ),
-    [
-      linkedTrains,
-      stdcmData,
-      consist,
-      simulationReportSheetNumber,
-      operationalPointsList,
-      simulationSheetLogo,
-      similarTrains,
-    ]
-  );
-
   const handleCsChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const input = e.target.value.toUpperCase();
     setCsCode(input);
@@ -234,8 +204,14 @@ const SendToRailwayManagerModal = ({
       return;
     }
 
-    const instance = pdf(pdfDocument);
-    const blobToUpload = await instance.toBlob();
+    let blobToSend: Blob;
+
+    if (pdfBlob) {
+      blobToSend = pdfBlob;
+    } else {
+      const pdfInstance = pdf(pdfDocument);
+      blobToSend = await pdfInstance.toBlob();
+    }
 
     const filename = `Last Minute Request-${simulationReportSheetNumber}`;
 
@@ -292,7 +268,7 @@ const SendToRailwayManagerModal = ({
     formData.append('simulation_report', JSON.stringify(simulationReport));
     formData.append(
       'simulation_report_sheet',
-      new File([blobToUpload], filename, { type: 'application/pdf' })
+      new File([blobToSend], filename, { type: 'application/pdf' })
     );
 
     try {
@@ -384,30 +360,22 @@ const SendToRailwayManagerModal = ({
 
           <section className="simulation">
             <h3>{t('modal.retainedSimulation')}</h3>
-
             <div>
-              <PDFDownloadLink
-                document={pdfDocument}
-                fileName={`${deploymentSettings?.stdcmName || 'Stdcm'}-${simulationReportSheetNumber}.pdf`}
-              >
-                {({ loading, blob, url }) => {
-                  if (blob) pdfBlobRef.current = blob;
-                  return (
-                    <div
-                      className="pdf-download"
-                      style={{ cursor: loading ? 'wait' : 'pointer' }}
-                      onClick={() => {
-                        if (!loading && url) window.open(url, '_blank');
-                      }}
-                      role="button"
-                      tabIndex={0}
-                    >
-                      <Download className="pdf-icon" size="lg" iconColor="var(--grey40)" />
-                      <span className="pdf-badge">{t('modal.pdf')}</span>
-                    </div>
-                  );
+              <div
+                className="pdf-download"
+                style={{ cursor: 'pointer' }}
+                onClick={() => {
+                  if (!pdfBlob) return;
+                  const url = URL.createObjectURL(pdfBlob);
+                  window.open(url, '_blank');
+                  setTimeout(() => URL.revokeObjectURL(url), 1000);
                 }}
-              </PDFDownloadLink>
+                role="button"
+                tabIndex={0}
+              >
+                <Download className="pdf-icon" size="lg" iconColor="var(--grey40)" />
+                <span className="pdf-badge">{t('modal.pdf')}</span>
+              </div>
             </div>
           </section>
         </div>

--- a/front/src/applications/stdcm/components/StdcmResults/SendToRailwayManagerModal.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/SendToRailwayManagerModal.tsx
@@ -519,7 +519,7 @@ const SendToRailwayManagerModal = ({
                   narrow: true,
                 }}
                 selectableSlot={selectableSlot}
-                value={realDepartureTime}
+                value={new Date(substituteTrain.date)}
                 onDateChange={(date) => {
                   if (date) {
                     setSubstituteTrain({ ...substituteTrain, date: date.toISOString() });

--- a/front/src/applications/stdcm/components/StdcmResults/StdcmResults.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/StdcmResults.tsx
@@ -32,11 +32,11 @@ import useDeploymentSettings from 'utils/hooks/useDeploymentSettings';
 import SendToRailwayManagerModal from './SendToRailwayManagerModal';
 import StdcmDebugResults from './StdcmDebugResults';
 import StdcmFeedback from './StdcmFeedback';
-import StcdmResultsTable from './StdcmResultsTable';
+import StdcmResultsTable from './StdcmResultsTable';
 import StdcmSimulationNavigator from './StdcmSimulationNavigator';
 import StdcmSimulationReportSheet from './StdcmSimulationReportSheet';
 
-type StcdmResultsProps = {
+type StdcmResultsProps = {
   isCalculationFailed: boolean;
   isDebugMode: boolean;
   onSelectSimulation: (simulationIndex: number) => void;
@@ -56,7 +56,7 @@ const StdcmResults = ({
   buttonsVisible,
   showStatusBanner,
   displayInfoMessage,
-}: StcdmResultsProps) => {
+}: StdcmResultsProps) => {
   const infraId = useSelector(getStdcmInfraID);
   const { openModal, closeModal } = useModal();
   const railwayManagerUrl = useSelector(getRailwayManagerInterfaceUrl);
@@ -268,7 +268,7 @@ const StdcmResults = ({
               )}
               {hasSimulationResults ? (
                 <div className="results-and-sheet">
-                  <StcdmResultsTable
+                  <StdcmResultsTable
                     stdcmData={outputs.results}
                     consist={selectedSimulation.inputs.consist}
                     isSimulationRetained={isSelectedSimulationRetained}

--- a/front/src/applications/stdcm/components/StdcmResults/StdcmResults.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/StdcmResults.tsx
@@ -63,6 +63,8 @@ const StdcmResults = ({
   const [isRailwayRequestSuccessful, setIsRailwayRequestSuccessful] = useState(false);
   const [railwayDemandId, setRailwayDemandId] = useState<string>();
 
+  const [pdfBlob, setPdfBlob] = useState<Blob | null>(null);
+
   const { t } = useTranslation('stdcm', { keyPrefix: 'simulation.results' });
   const deploymentSettings = useDeploymentSettings();
 
@@ -85,7 +87,10 @@ const StdcmResults = ({
 
   const hasSimulationResults = hasResults(outputs);
 
-  const simulationReportSheetNumber = generateCodeNumber();
+  const simulationReportSheetNumber = useMemo(
+    () => generateCodeNumber(),
+    [selectedSimulation.index]
+  );
   const isSelectedSimulationRetained =
     retainedSimulationIndex !== undefined && selectedSimulation.index === retainedSimulationIndex;
 
@@ -242,6 +247,30 @@ const StdcmResults = ({
     }
   }, [isSelectedSimulationRetained]);
 
+  const pdfDocument = useMemo(() => {
+    if (!hasSimulationResults || !isSelectedSimulationRetained || !outputs) return null;
+    return (
+      <StdcmSimulationReportSheet
+        stdcmLinkedTrains={selectedSimulation.inputs.linkedTrains}
+        stdcmData={outputs.results}
+        consist={selectedSimulation.inputs.consist}
+        simulationReportSheetNumber={simulationReportSheetNumber}
+        operationalPointsList={operationalPointsList}
+        simulationSheetLogo={deploymentSettings?.stdcmSimulationSheetLogo}
+        similarTrains={similarTrains}
+      />
+    );
+  }, [
+    outputs,
+    hasSimulationResults,
+    isSelectedSimulationRetained,
+    simulationReportSheetNumber,
+    operationalPointsList,
+    selectedSimulation.inputs,
+    deploymentSettings?.stdcmSimulationSheetLogo,
+    similarTrains,
+  ]);
+
   return (
     <>
       <StdcmSimulationNavigator
@@ -275,30 +304,25 @@ const StdcmResults = ({
                     operationalPointsList={operationalPointsList}
                     simulationIndex={selectedSimulation.index}
                   />
-                  {isSelectedSimulationRetained && (
+                  {isSelectedSimulationRetained && pdfDocument && (
                     <div className="get-simulation">
                       <div className="download-simulation" data-testid="download-simulation">
                         <PDFDownloadLink
-                          document={
-                            <StdcmSimulationReportSheet
-                              stdcmLinkedTrains={selectedSimulation.inputs.linkedTrains}
-                              stdcmData={outputs.results}
-                              consist={selectedSimulation.inputs.consist}
-                              simulationReportSheetNumber={simulationReportSheetNumber}
-                              operationalPointsList={operationalPointsList}
-                              simulationSheetLogo={deploymentSettings?.stdcmSimulationSheetLogo}
-                              similarTrains={similarTrains}
-                            />
-                          }
+                          document={pdfDocument}
                           fileName={`${deploymentSettings?.stdcmName || 'Stdcm'}-${simulationReportSheetNumber}.pdf`}
                         >
-                          <Button
-                            data-testid="download-simulation-button"
-                            label={t('downloadSimulationSheet')}
-                            onClick={() => {}}
-                            isDisabled={areSegmentsLoading}
-                            variant="Normal"
-                          />
+                          {({ blob }) => {
+                            if (blob && blob !== pdfBlob) setPdfBlob(blob);
+                            return (
+                              <Button
+                                data-testid="download-simulation-button"
+                                label={t('downloadSimulationSheet')}
+                                onClick={() => {}}
+                                isDisabled={areSegmentsLoading}
+                                variant="Normal"
+                              />
+                            );
+                          }}
                         </PDFDownloadLink>
                       </div>
                       {railwayManagerUrl &&
@@ -312,10 +336,9 @@ const StdcmResults = ({
                                   stdcmData={outputs.results}
                                   linkedTrains={selectedSimulation.inputs.linkedTrains}
                                   simulationReportSheetNumber={simulationReportSheetNumber}
-                                  operationalPointsList={operationalPointsList}
-                                  simulationSheetLogo={deploymentSettings?.stdcmSimulationSheetLogo}
                                   similarTrains={similarTrains}
-                                  deploymentSettings={deploymentSettings}
+                                  pdfBlob={pdfBlob}
+                                  pdfDocument={pdfDocument}
                                   onClose={closeModal}
                                   onSuccess={handleSubmitSuccess}
                                 />,

--- a/front/src/applications/stdcm/components/StdcmResults/StdcmResultsTable.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/StdcmResultsTable.tsx
@@ -22,7 +22,7 @@ type SimulationTableProps = {
   simulationIndex: number;
 };
 
-const StcdmResultsTable = ({
+const StdcmResultsTable = ({
   stdcmData,
   consist,
   isSimulationRetained,
@@ -154,4 +154,4 @@ const StcdmResultsTable = ({
   );
 };
 
-export default StcdmResultsTable;
+export default StdcmResultsTable;

--- a/front/src/applications/stdcm/styles/_railwayManagerModal.scss
+++ b/front/src/applications/stdcm/styles/_railwayManagerModal.scss
@@ -27,9 +27,7 @@
       margin-bottom: 16px;
     }
 
-    section:not(:last-child) {
-      margin-bottom: 32px;
-
+    section {
       h3 {
         font-family: 'IBM Plex Sans';
         font-size: 1.125rem;
@@ -37,6 +35,10 @@
         margin-bottom: 16px;
         text-wrap-mode: nowrap;
       }
+    }
+
+    section:not(:last-child) {
+      margin-bottom: 32px;
     }
   }
 


### PR DESCRIPTION
Closes #14758 

This PR fixes a performance issue causing noticeable latency when opening the request submission modal.
The cause was an unnecessary multiple generation of the simulation result PDF, which is now generated only once.

In addition, this PR includes a few minor bug fixes:
- CSS fix: ensure `<section />` elements correctly display bold text where expected

- Fix DatePicker initialization issue that prevented selecting a date other than the simulation date

- Fix typo in component name: StcdmResults → StdcmResults