### PR TITLE
front: use local track name

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/hooks/usePathStepsMetadata.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/hooks/usePathStepsMetadata.ts
@@ -197,14 +197,11 @@ export const usePathStepsMetadata = (pathSteps: PathStepV2[]) => {
         }
 
         const parts: Extract<PathStepMetadata, { isInvalid: false; type: 'opRef' }>['parts'] =
-          matchedOp.parts.map((part) => {
-            const correspondingTrack = trackSectionsById[part.track];
-            return {
-              trackId: correspondingTrack?.id ?? '',
-              trackName: correspondingTrack?.extensions?.sncf?.track_name ?? '',
-              coordinates: part.geo?.coordinates as Position,
-            };
-          });
+          matchedOp.parts.map((part) => ({
+            trackId: part.track,
+            trackName: part.local_track_name,
+            coordinates: part.geo?.coordinates as Position,
+          }));
 
         newPathStepsMetadataById.set(pathStep.id, {
           type: 'opRef',

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/ManageTimetableItemMap/AddPathStepPopup.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/ManageTimetableItemMap/AddPathStepPopup.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 
 import { point } from '@turf/helpers';
+import type { Position } from 'geojson';
 import { useTranslation } from 'react-i18next';
 import { IoFlag } from 'react-icons/io5';
 import { RiMapPin2Fill, RiMapPin3Fill } from 'react-icons/ri';
@@ -123,8 +124,11 @@ const AddPathStepPopup = ({
       const trackIds = operationalPoint.parts.map((part) => part.track);
       const tracks = await getTrackSectionsByIds(trackIds);
 
-      const trackPartCoordinates = operationalPoint.parts.map((part) => ({
-        trackName: tracks[part.track]?.extensions?.sncf?.track_name,
+      const trackPartCoordinates: {
+        trackName: string | undefined;
+        coordinates: Position;
+      }[] = operationalPoint.parts.map((part) => ({
+        trackName: part.local_track_name,
         coordinates: getPointOnTrackCoordinates(
           tracks[part.track]?.geo,
           tracks[part.track]?.length,

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResultsExport/utils.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResultsExport/utils.ts
@@ -127,7 +127,7 @@ export const formatOperationalPoints = (
       line_code: metadata?.line_code || null,
       track_number: metadata?.track_number || null,
       line_name: metadata?.line_name || null,
-      track_name: metadata?.track_name || null,
+      track_name: op.part.local_track_name,
       ch: op.extensions?.sncf?.ch || null,
     };
 

--- a/front/src/applications/stdcm/utils/fetchPathProperties.ts
+++ b/front/src/applications/stdcm/utils/fetchPathProperties.ts
@@ -49,7 +49,7 @@ const fetchPathProperties = async (
           ? {
               lineCode: sncf.line_code!,
               lineName: sncf.line_name!,
-              trackName: sncf.track_name!,
+              trackName: op.part.local_track_name,
               trackNumber: sncf.track_number!,
             }
           : undefined;

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useTrackOccupancy.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useTrackOccupancy.ts
@@ -501,7 +501,7 @@ const useTrackOccupancy = ({
                 const trackPart = trackSectionByTrackId.get(part.track);
                 return {
                   id: part.track,
-                  name: part.local_track_name || undefined,
+                  name: part.local_track_name,
                   line: trackPart?.extensions?.sncf?.line_code,
                 };
               }),

--- a/front/src/modules/timesStops/hooks/useOutputTableData.ts
+++ b/front/src/modules/timesStops/hooks/useOutputTableData.ts
@@ -164,7 +164,7 @@ const useOutputTableData = (
     // For valid trains, complete the rows with the simulated path's operational points and tracks information
     if (isValid && simulatedTrain && operationalPointsOnPath) {
       for (const op of operationalPointsOnPath) {
-        const trackName = trackSections[op.part.track]?.extensions?.sncf?.track_name;
+        const trackName = op.part.local_track_name;
 
         // early return if the op matches a pathStep (handled above)
         // only add the trackName which has been found by the pathfinding (if not precised in the pathStep)

--- a/front/src/modules/timesStops/hooks/useTimesStopsTableData.ts
+++ b/front/src/modules/timesStops/hooks/useTimesStopsTableData.ts
@@ -133,10 +133,12 @@ const useTimesStopsTableData = (
           selectedTrain.path.length,
           t
         );
+
         const trackName =
           'track' in pathStep.location
-            ? (trackSections[pathStep.location.track]?.extensions?.sncf?.track_name ??
-              pathStep.location.track)
+            ? matchingOp?.parts.find(
+                (part) => 'track' in pathStep.location && part.track === pathStep.location.track
+              )?.local_track_name
             : (pathStep.location.local_track_name ?? undefined);
 
         const schedule = scheduleByAt[pathStep.id];
@@ -166,8 +168,7 @@ const useTimesStopsTableData = (
     // Case 1: Valid train with simulation results
     if (isValid && simulatedTrain && operationalPointsOnPath) {
       operationalPointsOnPath.forEach((op, opIndex) => {
-        const trackName =
-          trackSections[op.part.track]?.extensions?.sncf?.track_name ?? op.part.track;
+        const trackName = op.part.local_track_name;
 
         const matchingPathStep = selectedTrain.path.find((pathStep) =>
           matchPathStepAndOp(pathStep.location, {

--- a/tests/data/infras/medium_infra/infra.json
+++ b/tests/data/infras/medium_infra/infra.json
@@ -7,7 +7,7 @@
                 {
                     "track": "TI0",
                     "position": 300.0,
-                    "local_track_name": "V1"
+                    "local_track_name": "A"
                 }
             ],
             "weight": null,
@@ -31,7 +31,7 @@
                 {
                     "track": "TI1",
                     "position": 250.0,
-                    "local_track_name": "V2"
+                    "local_track_name": "B"
                 }
             ],
             "weight": null,
@@ -65,7 +65,7 @@
                 {
                     "track": "TA2",
                     "position": 500.0,
-                    "local_track_name": "V3"
+                    "local_track_name": "A"
                 }
             ],
             "weight": null,
@@ -89,7 +89,7 @@
                 {
                     "track": "TB0",
                     "position": 500.0,
-                    "local_track_name": "V1"
+                    "local_track_name": "A"
                 }
             ],
             "weight": null,
@@ -113,22 +113,22 @@
                 {
                     "track": "TC0",
                     "position": 550.0,
-                    "local_track_name": "V1"
+                    "local_track_name": "V1bis"
                 },
                 {
                     "track": "TC1",
                     "position": 550.0,
-                    "local_track_name": "V2"
+                    "local_track_name": "V1"
                 },
                 {
                     "track": "TC2",
                     "position": 450.0,
-                    "local_track_name": "V3"
+                    "local_track_name": "V2"
                 },
                 {
                     "track": "TC3",
                     "position": 450.0,
-                    "local_track_name": "V4"
+                    "local_track_name": "V2bis"
                 }
             ],
             "weight": null,
@@ -181,12 +181,12 @@
                 {
                     "track": "TE1",
                     "position": 1000.0,
-                    "local_track_name": "V1"
+                    "local_track_name": "V1bis"
                 },
                 {
                     "track": "TE2",
                     "position": 1025.0,
-                    "local_track_name": "V2"
+                    "local_track_name": "V1"
                 }
             ],
             "weight": null,

--- a/tests/infra-scripts/medium_infra.py
+++ b/tests/infra-scripts/medium_infra.py
@@ -139,8 +139,8 @@ def create_medium_infra(signaling_system: str) -> ScenarioData:
         uic=8799,
         id="North_West_station_1",
     )
-    north_west.add_part(ti0, 300, "V1")
-    north_west_1.add_part(ti1, 250, "V2")
+    north_west.add_part(ti0, 300, "A")
+    north_west_1.add_part(ti1, 250, "B")
 
     pa0 = builder.add_point_switch(
         label="PA0",
@@ -195,7 +195,7 @@ def create_medium_infra(signaling_system: str) -> ScenarioData:
     west = builder.add_operational_point(label="West_station", trigram="WS", uic=8722)
     west.add_part(ta0, 700, "V1")
     west.add_part(ta1, 500, "V2")
-    west.add_part(ta2, 500, "V3")
+    west.add_part(ta2, 500, "A")
     # Slopes
     ta6.add_slope(begin=4000, end=4300, slope=-3)
     ta6.add_slope(begin=4300, end=4700, slope=-6)
@@ -223,7 +223,7 @@ def create_medium_infra(signaling_system: str) -> ScenarioData:
         trigram="SWS",
         uic=8711,
     )
-    south_west.add_part(tb0, 500, "V1")
+    south_west.add_part(tb0, 500, "A")
     # ================================
     #  Around station C: Mid - West
     # ================================
@@ -325,10 +325,10 @@ def create_medium_infra(signaling_system: str) -> ScenarioData:
     mid_west = builder.add_operational_point(
         label="Mid_West_station", trigram="MWS", uic=8733
     )
-    mid_west.add_part(tc0, 550, "V1")
-    mid_west.add_part(tc1, 550, "V2")
-    mid_west.add_part(tc2, 450, "V3")
-    mid_west.add_part(tc3, 450, "V4")
+    mid_west.add_part(tc0, 550, "V1bis")
+    mid_west.add_part(tc1, 550, "V1")
+    mid_west.add_part(tc2, 450, "V2")
+    mid_west.add_part(tc3, 450, "V2bis")
     # ================================
     #  Around station D: Mid-East
     # ================================
@@ -479,8 +479,8 @@ def create_medium_infra(signaling_system: str) -> ScenarioData:
     te3.set_remaining_coords([(-0.145, LAT_0 + 0.002), (-0.145, LAT_3 - 0.002)])
     # Station
     north = builder.add_operational_point(label="North_station", trigram="NS", uic=8755)
-    north.add_part(te1, 1000, "V1")
-    north.add_part(te2, 1025, "V2")
+    north.add_part(te1, 1000, "V1bis")
+    north.add_part(te2, 1025, "V1")
     # Curves
     te3.add_curve(begin=0, end=300, curve=5000)
     te3.add_curve(begin=650, end=850, curve=9000)


### PR DESCRIPTION
The new variable `local_track_name` must be used for:
 - [ ] selecting an op on the map
 - [ ] input / output simulation table
 - [ ] simulation sheet
 - [ ] STDCM result
 
close #14323 