### PR TITLE
osrdyne: support service_account_name for kube deployments

### DIFF
--- a/chart/templates/osrdyne/configmap.yaml
+++ b/chart/templates/osrdyne/configmap.yaml
@@ -62,6 +62,10 @@ data:
             value: "{{ $redis }}"
             {{- end -}}
 
+        {{- if .Values.services.core.service_account_name }}
+        service_account_name: {{ .Values.services.core.service_account_name }}
+        {{- end }}
+
         {{- with .Values.services.core.resources }}
         resources:
           {{- toYaml . | nindent 10 }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -106,6 +106,8 @@ services:
     tolerations: []
     affinity: {}
     resources: {}
+    # -- (string) Service account name to mount in case of kubernetes deployment
+    service_account_name: null
     env: []
     config:
       telemetry: null

--- a/osrdyne/src/drivers/kubernetes.rs
+++ b/osrdyne/src/drivers/kubernetes.rs
@@ -97,6 +97,9 @@ pub struct KubernetesDeploymentOptions {
     /// The resources to allocate to the worker (passthrough to kubernetes deployment)
     pub resources: Option<ResourceRequirements>,
 
+    /// The service account name which will be mounted by core (passthrough to kubernetes deployment)
+    pub service_account_name: Option<String>,
+
     /// The node selector to use for the worker (passthrough to kubernetes deployment)
     pub node_selector: Option<BTreeMap<String, String>>,
 
@@ -488,6 +491,11 @@ impl WorkerDriver for KubernetesDriver {
                         }),
                         spec: Some(PodSpec {
                             image_pull_secrets: self.options.image_pull_secrets.clone(),
+                            service_account_name: self
+                                .options
+                                .kube_deployment_options
+                                .service_account_name
+                                .clone(),
                             containers: vec![Container {
                                 name: worker_deployment_name.clone(),
                                 image: Some(self.options.container_image.clone()),


### PR DESCRIPTION
In order to grant core access to resources based on its service account we need to be able to provide a specific `service_account_name` to its deployment.
This PRs allows it both in osrdyne, and adds the matching configuration in the chart