### PR TITLE
core: fix junit-platform-launcher version ref

### DIFF
--- a/core/gradle/libs.versions.toml
+++ b/core/gradle/libs.versions.toml
@@ -53,7 +53,7 @@ slf4j = { module = 'org.slf4j:slf4j-api', version = '2.0.+' } # MIT
 junit-jupiter-api = { module = 'org.junit.jupiter:junit-jupiter-api', version.ref = 'junit' } # EPL 2.0
 junit-jupiter-params = { module = 'org.junit.jupiter:junit-jupiter-params', version.ref = 'junit' } # EPL 2.0
 junit-jupiter-engine = { module = 'org.junit.jupiter:junit-jupiter-engine', version.ref = 'junit' } # EPL 2.0
-junit-platform-launcher = { module = 'org.junit.platform:junit-platform-launcher', version = 'junit' } # EPL 2.0
+junit-platform-launcher = { module = 'org.junit.platform:junit-platform-launcher', version.ref = 'junit' } # EPL 2.0
 assertj = { module = 'org.assertj:assertj-core', version = '3.27.6' } # Apache 2.0
 mockito-inline = { module = 'org.mockito:mockito-inline', version.ref = 'mockito' } # MIT
 mockito-junit-jupiter = { module = 'org.mockito:mockito-junit-jupiter', version.ref = 'mockito' } # MIT


### PR DESCRIPTION
Seems like gradle can understand it just fine without the explicit `ref`, but dependabot gets confused.