### PR TITLE
Replace masked TimeCell input with section-based state machine

### DIFF
--- a/front/src/modules/timesStops/TimeCell.tsx
+++ b/front/src/modules/timesStops/TimeCell.tsx
@@ -1,231 +1,513 @@
-import { useState } from 'react';
+import { useEffect, useReducer, useRef, type ChangeEvent } from 'react';
 
-const TIME_MASK = [
-  { char: '-', isEditable: true, value: 'twentyTens' },
-  { char: '-', isEditable: true, value: 'twentyUnits' },
-  { char: ':', isEditable: false },
-  { char: '-', isEditable: true, value: 'sixtyTens' },
-  { char: '-', isEditable: true, value: 'sixtyUnits' },
-  { char: ':', isEditable: false },
-  { char: '-', isEditable: true, value: 'sixtyTens' },
-  { char: '-', isEditable: true, value: 'sixtyUnits' },
-];
+import type { CellContext } from '@tanstack/react-table';
 
-// Converts a raw digit string into a masked time string
-// e.g., "123456" -> "12:34:56"
-const applyMask = (rawDigits: string): string => {
-  let result = '';
-  let digitIndex = 0;
+import type { TimesStopsRowNew } from './types';
 
-  for (const maskInfo of TIME_MASK) {
-    if (!maskInfo.isEditable) {
-      result += maskInfo.char;
-      continue;
-    }
+// Types
 
-    if (digitIndex < rawDigits.length) {
-      switch (maskInfo.value) {
-        case 'twentyTens': {
-          const tensDigit = parseInt(rawDigits[digitIndex], 10);
-          if (tensDigit > 2) {
-            result += '2';
-            digitIndex++;
-            continue;
-          }
-          break;
-        }
-        case 'twentyUnits': {
-          const tensDigit = parseInt(result[0], 10);
-          const unitDigit = parseInt(rawDigits[digitIndex], 10);
-          if (tensDigit === 2 && unitDigit > 3) {
-            result += '3';
-            digitIndex++;
-            continue;
-          }
-          break;
-        }
-        case 'sixtyTens': {
-          const tensDigit = parseInt(rawDigits[digitIndex], 10);
-          if (tensDigit > 5) {
-            result += '5';
-            digitIndex++;
-            continue;
-          }
-          break;
-        }
-        default:
-          break;
-      }
+type SectionState = string;
 
-      result += rawDigits[digitIndex];
-      digitIndex++;
-    } else {
-      result += maskInfo.char;
-      digitIndex++;
-    }
-  }
+type Section = 'hours' | 'minutes' | 'seconds';
 
-  return result;
+const SECTION_PLACEHOLDERS: Record<Section, string> = {
+  hours: 'h',
+  minutes: 'm',
+  seconds: 's',
 };
 
-// Utility to delay execution until after render
-function delayAfterRender(callback: () => void) {
-  queueMicrotask(callback);
-}
-
-// Get the next editable position in the input considering the mask
-const getNextEditablePosition = (pos: number): number => {
-  for (let i = pos; i < TIME_MASK.length; i++) {
-    if (TIME_MASK[i].isEditable) return i;
-  }
-  return TIME_MASK.length;
+type TimeState = {
+  hours: SectionState;
+  minutes: SectionState;
+  seconds: SectionState;
+  focusedSection: Section | null;
+  empty?: boolean;
 };
 
-const TimeCell = (
-  ctx: {
-    getValue: () => Date | null;
-  },
-  // Let the parent component handle the onChange if provided
-  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void,
-  props?: React.InputHTMLAttributes<HTMLInputElement>
-) => {
-  const controlledValue = ctx.getValue();
-  const [displayValue, setDisplayValue] = useState<string>(() => {
-    const date = controlledValue
-      ? controlledValue.toTimeString().slice(0, 8).replace(/:/g, '')
-      : '';
-    return applyMask(date);
+type TimeAction =
+  | { type: 'DIGIT_PRESSED'; digit: string }
+  | { type: 'BACKSPACE_PRESSED' }
+  | { type: 'ENTER_PRESSED' }
+  | { type: 'SECTION_CLICKED'; section: Section }
+  | { type: 'FOCUSED'; section: Section }
+  | { type: 'LEFT_ARROW_PRESSED' }
+  | { type: 'RIGHT_ARROW_PRESSED' }
+  | { type: 'BLURRED' };
+
+// Helpers
+
+const formatSectionDigits = (str: string, section: Section): SectionState => {
+  const digits = str.replace(/\D/g, '').slice(-2);
+  const sectionPlaceholder = SECTION_PLACEHOLDERS[section];
+
+  if (digits.length === 2) return digits;
+  if (digits.length === 1) return sectionPlaceholder + digits;
+  return sectionPlaceholder + sectionPlaceholder;
+};
+
+const parseTimeState = (date: Date | null): Omit<TimeState, 'focusedSection' | 'empty'> => {
+  if (!date)
+    return {
+      hours: formatSectionDigits('', 'hours'),
+      minutes: formatSectionDigits('', 'minutes'),
+      seconds: formatSectionDigits('', 'seconds'),
+    };
+
+  const timeStr = date.toTimeString().slice(0, 8);
+  const [hours, minutes, seconds] = timeStr.split(':');
+
+  return {
+    hours: formatSectionDigits(hours, 'hours'),
+    minutes: formatSectionDigits(minutes, 'minutes'),
+    seconds: formatSectionDigits(seconds, 'seconds'),
+  };
+};
+
+const formatDisplay = (state: TimeState): string =>
+  `${state.hours}:${state.minutes}:${state.seconds}`;
+
+const digitCount = (sectionState: SectionState): number => sectionState.replace(/\D/g, '').length;
+
+const hasAllDigits = (pair: SectionState): boolean => digitCount(pair) === 2;
+
+const hasNoDigits = (pair: SectionState): boolean => digitCount(pair) === 0;
+
+const addDigitformatSectionDigits = (
+  sectionState: SectionState,
+  digit: string,
+  section: Section
+): SectionState => {
+  switch (digitCount(sectionState)) {
+    case 0:
+      return formatSectionDigits(digit, section);
+    case 1:
+      return formatSectionDigits(sectionState[1] + digit, section);
+    case 2:
+      return sectionState;
+  }
+  return sectionState;
+};
+
+const removeDigitFromSectionState = (
+  sectionState: SectionState,
+  section: Section
+): SectionState => {
+  switch (digitCount(sectionState)) {
+    case 0:
+      return formatSectionDigits('', section);
+    case 1:
+      return formatSectionDigits('', section);
+    case 2:
+      return formatSectionDigits(sectionState[1], section);
+  }
+  return sectionState;
+};
+
+const clampTimeState = (state: TimeState): TimeState => {
+  const clampSection = (section: Section): SectionState => {
+    let max = 59;
+    if (section === 'hours') max = 23;
+
+    const digits = state[section].replace(/\D/g, '');
+
+    switch (digits.length) {
+      case 0:
+        return '00';
+      case 1:
+        if (parseInt(digits) * 10 > Math.floor(max)) {
+          return digits.padStart(2, '0');
+        }
+        return digits.padEnd(2, '0');
+      case 2:
+        if (parseInt(digits) > max) {
+          return max.toString().padStart(2, '0');
+        }
+        return digits;
+    }
+    return state[section];
+  };
+
+  return {
+    hours: clampSection('hours'),
+    minutes: clampSection('minutes'),
+    seconds: clampSection('seconds'),
+    focusedSection: state.focusedSection,
+  };
+};
+
+// Handlers
+
+// The minutes section needs special handling when overflowing
+// It allows the user to quickly enter times like 01:45 by typing 0145 even when focused on minutes
+const handleMinutesOverflow = (state: TimeState, digit: string): TimeState => {
+  if (!hasAllDigits(state.hours)) {
+    return {
+      ...state,
+      hours: state.minutes,
+      minutes: formatSectionDigits(digit, 'minutes'),
+      focusedSection: 'minutes',
+    };
+  }
+
+  if (!hasAllDigits(state.seconds)) {
+    return {
+      ...state,
+      seconds: formatSectionDigits(digit, 'seconds'),
+      focusedSection: 'seconds',
+    };
+  }
+
+  return {
+    ...state,
+    minutes: formatSectionDigits(digit, 'minutes'),
+  };
+};
+
+const handleNormalOverflow = (state: TimeState, digit: string): TimeState => {
+  const { focusedSection } = state;
+  if (!focusedSection) return state;
+
+  if (focusedSection === 'hours') {
+    if (!hasAllDigits(state.minutes)) {
+      return {
+        ...state,
+        minutes: formatSectionDigits(digit, 'minutes'),
+        focusedSection: 'minutes',
+      };
+    }
+
+    if (!hasAllDigits(state.seconds)) {
+      return {
+        ...state,
+        seconds: formatSectionDigits(digit, 'seconds'),
+        focusedSection: 'seconds',
+      };
+    }
+
+    return {
+      ...state,
+      hours: formatSectionDigits(digit, 'hours'),
+    };
+  }
+
+  if (focusedSection === 'seconds') {
+    return {
+      ...state,
+      seconds: formatSectionDigits(digit, 'seconds'),
+    };
+  }
+
+  return state;
+};
+
+const handleDigitPressed = (state: TimeState, digit: string): TimeState => {
+  const { focusedSection } = state;
+  if (!focusedSection) return state;
+
+  const currentSectionState = state[focusedSection];
+
+  // If user starts with minutes and enters a digit > 2
+  // We prevent pushing "X0" invalid hours
+  if (
+    focusedSection === 'minutes' &&
+    hasNoDigits(state.hours) &&
+    hasNoDigits(state.minutes) &&
+    parseInt(digit) > 2
+  ) {
+    return {
+      ...state,
+      hours: formatSectionDigits('00', 'hours'),
+      minutes: addDigitformatSectionDigits(currentSectionState, digit, 'minutes'),
+    };
+  }
+
+  switch (digitCount(currentSectionState)) {
+    case 0:
+      return {
+        ...state,
+        [focusedSection]: addDigitformatSectionDigits(currentSectionState, digit, focusedSection),
+      };
+    case 1: {
+      const newFocusedSection = (): Section => {
+        switch (focusedSection) {
+          case 'hours':
+            return 'minutes';
+          case 'minutes':
+            return hasNoDigits(state.hours) ? 'minutes' : 'seconds';
+          case 'seconds':
+            return 'seconds';
+        }
+      };
+      return {
+        ...state,
+        [focusedSection]: addDigitformatSectionDigits(currentSectionState, digit, focusedSection),
+        focusedSection: newFocusedSection(),
+      };
+    }
+    case 2:
+    default:
+      return focusedSection === 'minutes'
+        ? handleMinutesOverflow(state, digit)
+        : handleNormalOverflow(state, digit);
+  }
+};
+
+// When a section is emptied, we need to shift the other sections to the left
+// This way the user can quickly delete time by holding backspace
+const handleBackspaceShift = (state: TimeState, section: Section): TimeState => {
+  if (section === 'seconds') {
+    return {
+      ...state,
+      hours: formatSectionDigits('', 'hours'),
+      minutes: formatSectionDigits(state.hours, 'minutes'),
+      seconds: formatSectionDigits(state.minutes, 'seconds'),
+    };
+  } else if (section === 'minutes') {
+    return {
+      ...state,
+      hours: formatSectionDigits('', 'hours'),
+      minutes: formatSectionDigits(state.hours, 'minutes'),
+      focusedSection: hasNoDigits(state.hours) ? 'seconds' : 'minutes',
+    };
+  }
+  return {
+    ...state,
+    hours: formatSectionDigits('', 'hours'),
+    focusedSection: 'minutes',
+  };
+};
+
+const handleBackspacePressed = (state: TimeState): TimeState => {
+  const { focusedSection } = state;
+  if (!focusedSection) return state;
+
+  const currentSectionState = state[focusedSection];
+
+  if (hasNoDigits(currentSectionState)) return state;
+
+  const newSectionState = removeDigitFromSectionState(currentSectionState, focusedSection);
+
+  if (hasNoDigits(newSectionState)) {
+    return handleBackspaceShift(state, focusedSection);
+  }
+
+  return {
+    ...state,
+    [focusedSection]: newSectionState,
+  };
+};
+
+const handleBlurred = (state: TimeState): TimeState => {
+  if (hasNoDigits(state.hours) && hasNoDigits(state.minutes) && hasNoDigits(state.seconds)) {
+    return {
+      hours: 'hh',
+      minutes: 'mm',
+      seconds: 'ss',
+      focusedSection: null,
+      empty: true,
+    };
+  }
+  return clampTimeState({
+    ...state,
+    focusedSection: null,
   });
+};
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    e.preventDefault();
-    const input = e.target;
-    const rawInput = input.value;
+const handleFocused = (state: TimeState, section: Section): TimeState => ({
+  ...state,
+  focusedSection: section,
+  empty: false,
+});
 
-    const cursorPos = input.selectionStart || 0;
+const handleSectionClicked = (state: TimeState, section: Section): TimeState => ({
+  ...state,
+  focusedSection: section,
+});
 
-    if (cursorPos < 0 || cursorPos > TIME_MASK.length) return;
+const handleHorizontalArrow = (state: TimeState, direction: 'left' | 'right'): TimeState => {
+  const { focusedSection } = state;
+  if (!focusedSection) return state;
 
-    // If we are inserting characters
-    if (rawInput.length >= displayValue.length) {
-      // Removing duplicate char caused by React's controlled input behavior
-      const newRawInput = rawInput.slice(0, cursorPos) + rawInput.slice(cursorPos + 1);
-
-      const newDigits = newRawInput.replace(/[^0-9]/g, '').slice(0, 6);
-      const newDisplayValue = applyMask(newDigits);
-
-      if (onChange) {
-        onChange({ ...e, target: { ...e.target, value: newDisplayValue } });
-      } else {
-        setDisplayValue(newDisplayValue);
+  const newFocusedSection = () => {
+    if (direction === 'left') {
+      switch (focusedSection) {
+        case 'hours':
+          return 'hours';
+        case 'minutes':
+          return 'hours';
+        case 'seconds':
+          return 'minutes';
       }
-
-      delayAfterRender(() => {
-        if (input === document.activeElement) {
-          const nextPos = getNextEditablePosition(cursorPos);
-          input.setSelectionRange(nextPos, nextPos);
-        }
-      });
-    }
-    // If we are removing characters
-    else if (rawInput.length < displayValue.length) {
-      const maskInfo = TIME_MASK[cursorPos];
-
-      if (!maskInfo.isEditable) {
-        delayAfterRender(() => {
-          input.setSelectionRange(cursorPos, cursorPos);
-        });
-        return;
-      }
-
-      const newRawInput = rawInput.slice(0, cursorPos) + '0' + rawInput.slice(cursorPos);
-
-      const newDigits = newRawInput
-        .replace(/[^0-9]/g, '')
-        .slice(0, 6)
-        .padEnd(6, '0');
-      const newDisplayValue = applyMask(newDigits);
-
-      if (onChange) {
-        onChange({ ...e, target: { ...e.target, value: newDisplayValue } });
-      } else {
-        setDisplayValue(newDisplayValue);
-      }
-
-      delayAfterRender(() => {
-        if (input === document.activeElement) {
-          input.setSelectionRange(cursorPos, cursorPos);
-        }
-      });
-    }
-  };
-
-  const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
-    // If no digits were entered, reset to empty mask
-    const inputValue = e.target.value;
-    const allFilled = /[1-9]/.test(inputValue);
-
-    if (!allFilled) {
-      const newDisplayValue = applyMask('');
-      if (onChange) {
-        onChange({ ...e, target: { ...e.target, value: newDisplayValue } });
-      } else {
-        setDisplayValue(newDisplayValue);
-      }
-    }
-  };
-
-  const handlePaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
-    e.preventDefault();
-    const pasteData = e.clipboardData.getData('Text');
-    const rawDigits = pasteData.replace(/[^0-9]/g, '').slice(0, 6);
-    const newDisplayValue = applyMask(rawDigits);
-
-    if (onChange) {
-      onChange({ ...e, target: { ...(e.target as HTMLInputElement), value: newDisplayValue } });
     } else {
-      setDisplayValue(newDisplayValue);
+      switch (focusedSection) {
+        case 'hours':
+          return 'minutes';
+        case 'minutes':
+          return 'seconds';
+        case 'seconds':
+          return 'seconds';
+      }
+    }
+  };
+
+  return {
+    ...state,
+    focusedSection: newFocusedSection(),
+  };
+};
+
+// Reducer
+
+const timeReducer = (state: TimeState, action: TimeAction): TimeState => {
+  switch (action.type) {
+    case 'DIGIT_PRESSED':
+      return handleDigitPressed(state, action.digit);
+    case 'BACKSPACE_PRESSED':
+      return handleBackspacePressed(state);
+    case 'BLURRED':
+      return handleBlurred(state);
+    case 'FOCUSED':
+      return handleFocused(state, action.section);
+    case 'SECTION_CLICKED':
+      return handleSectionClicked(state, action.section);
+    case 'ENTER_PRESSED':
+      return handleBlurred(state);
+    case 'LEFT_ARROW_PRESSED':
+      return handleHorizontalArrow(state, 'left');
+    case 'RIGHT_ARROW_PRESSED':
+      return handleHorizontalArrow(state, 'right');
+    default:
+      return state;
+  }
+};
+
+const initialTimeState = (controlledValue: Date | null): TimeState => ({
+  ...parseTimeState(controlledValue),
+  focusedSection: null,
+  empty: controlledValue === null,
+});
+
+// Component
+
+const TimeCell = ({
+  getValue,
+  ...props
+}: CellContext<TimesStopsRowNew, Date | null> & React.InputHTMLAttributes<HTMLInputElement>) => {
+  const { onKeyDown, onBlur, onFocus, onChange, ...userProps } = props || {};
+
+  const controlledValue = getValue();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const [state, dispatch] = useReducer(timeReducer, controlledValue, initialTimeState);
+
+  const getSectionFromPosition = (position: number): Section => {
+    if (position <= 2) return 'hours';
+    if (position <= 5) return 'minutes';
+    return 'seconds';
+  };
+
+  const selectSection = (section: Section) => {
+    if (!inputRef.current) return;
+    const positions = {
+      hours: [0, 2],
+      minutes: [3, 5],
+      seconds: [6, 8],
+    };
+    const [start, end] = positions[section];
+    inputRef.current.setSelectionRange(start, end);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    switch (e.key) {
+      case 'Enter':
+        e.currentTarget.blur();
+        break;
+      case 'Backspace':
+        e.preventDefault();
+        dispatch({ type: 'BACKSPACE_PRESSED' });
+        break;
+      case 'ArrowLeft':
+        e.preventDefault();
+        dispatch({ type: 'LEFT_ARROW_PRESSED' });
+        break;
+      case 'ArrowRight':
+        e.preventDefault();
+        dispatch({ type: 'RIGHT_ARROW_PRESSED' });
+        break;
+      default:
+        if (/^[0-9]$/.test(e.key)) {
+          e.preventDefault();
+          dispatch({ type: 'DIGIT_PRESSED', digit: e.key });
+        }
+        if (e.key.length === 1) {
+          e.preventDefault();
+        }
     }
 
-    delayAfterRender(() => {
-      const input = e.target as HTMLInputElement;
-      const firstPos = getNextEditablePosition(0);
-      input.setSelectionRange(firstPos, firstPos);
-    });
+    onKeyDown?.(e);
+  };
+
+  const handleClick = (e: React.MouseEvent<HTMLInputElement>) => {
+    const position = e.currentTarget.selectionStart || 0;
+    const section = getSectionFromPosition(position);
+    dispatch({ type: 'SECTION_CLICKED', section });
   };
 
   const handleFocus = (e: React.FocusEvent<HTMLInputElement>) => {
-    const input = e.target;
-    const cursorPos = input.selectionStart || 0;
-
-    // On focus, if any editable position is still the placeholder, set it to '0'
-    setDisplayValue((prev) => {
-      let newValue = '';
-      for (let i = 0; i < TIME_MASK.length; i++) {
-        if (TIME_MASK[i].isEditable) {
-          newValue += prev[i] === TIME_MASK[i].char ? '0' : prev[i];
-        } else {
-          newValue += TIME_MASK[i].char;
-        }
-      }
-      return newValue;
-    });
-
-    delayAfterRender(() => {
-      const firstPos = getNextEditablePosition(cursorPos);
-      e.target.setSelectionRange(firstPos, firstPos);
-    });
+    const position = e.currentTarget.selectionStart || 0;
+    const section = getSectionFromPosition(position);
+    dispatch({ type: 'FOCUSED', section });
+    onFocus?.(e);
   };
 
+  const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+    dispatch({ type: 'BLURRED' });
+    onBlur?.(e);
+  };
+
+  useEffect(() => {
+    if (state.focusedSection) {
+      selectSection(state.focusedSection);
+    }
+  }, [state.focusedSection, state.hours, state.minutes, state.seconds]);
+
+  useEffect(() => {
+    const displayValue = formatDisplay(state);
+    onChange?.({
+      target: { value: displayValue },
+    } as ChangeEvent<HTMLInputElement>);
+  }, [state.hours, state.minutes, state.seconds, onChange]);
+
   return (
-    <input
-      value={displayValue}
-      onChange={handleChange}
-      onFocus={handleFocus}
-      onBlur={handleBlur}
-      onPaste={handlePaste}
-      {...props}
-    />
+    <div className="time-cell">
+      <input
+        ref={inputRef}
+        value={state.empty ? 'hh:mm:ss' : formatDisplay(state)}
+        className="time-cell__input"
+        onChange={(e) => e.preventDefault()}
+        onKeyDown={handleKeyDown}
+        onClick={handleClick}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        {...userProps}
+      />
+
+      {!state.empty && (
+        <div className="time-cell__display" aria-hidden="true">
+          <span className={state.hours.includes('h') ? 'placeholder' : 'value'}>{state.hours}</span>
+          <span className="separator">:</span>
+          <span className={state.minutes.includes('m') ? 'placeholder' : 'value'}>
+            {state.minutes}
+          </span>
+          <span className="separator">:</span>
+          <span className={state.seconds.includes('s') ? 'placeholder' : 'value'}>
+            {state.seconds}
+          </span>
+        </div>
+      )}
+
+      {state.empty && <span className="time-cell__placeholder">+</span>}
+    </div>
   );
 };
 

--- a/front/src/modules/timesStops/TimesStopsTable.tsx
+++ b/front/src/modules/timesStops/TimesStopsTable.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from 'react-i18next';
 import { Loader } from 'common/Loaders/Loader';
 import { formatLocalTime } from 'utils/date';
 
+import TimeCell from './TimeCell';
 import type { TimesStopsRowNew } from './types';
 
 type TimesStopsTableProps = {
@@ -50,7 +51,7 @@ const TimesStopsTable = ({ rows, dataIsLoading }: TimesStopsTableProps) => {
       }),
       columnHelper.accessor('requestedArrival', {
         header: () => t('arrivalTime'),
-        cell: (info) => (info.getValue() ? formatLocalTime(info.getValue()!) : ''),
+        cell: (info) => <TimeCell {...info} />,
       }),
       columnHelper.accessor('computedArrival', {
         header: () => t('calculatedArrivalTime'),

--- a/front/src/modules/timesStops/styles/_timeCell.scss
+++ b/front/src/modules/timesStops/styles/_timeCell.scss
@@ -1,0 +1,60 @@
+.time-cell {
+  position: relative;
+  display: inline-block;
+  font-size: 14px;
+  font-weight: 400;
+  width: 84px;
+  height: 40px;
+  line-height: 20px;
+  font-family: inherit, monospace;
+
+  &:hover {
+    background-color: rgba(255, 255, 255, 0.5);
+  }
+
+  &__input,
+  &__display {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 100%;
+    height: 100%;
+    transform: translate(-50%, -50%);
+    text-align: center;
+  }
+
+  &__display {
+    z-index: 1;
+    color: #000;
+    pointer-events: none;
+    background: transparent;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
+  &__input {
+    z-index: 2;
+    background: transparent;
+    color: transparent;
+    caret-color: #0066cc;
+    cursor: pointer;
+  }
+
+  &__placeholder {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+
+    transform: translate(-50%, -50%);
+    color: var(--primary40);
+    pointer-events: auto;
+    cursor: pointer;
+    transition: color 0.2s;
+  }
+
+  &:hover {
+    color: var(--blackAlpha100);
+    background-color: var(--primary5);
+  }
+}

--- a/front/src/modules/timesStops/styles/timesStops.scss
+++ b/front/src/modules/timesStops/styles/timesStops.scss
@@ -1,3 +1,4 @@
 @use './timesStopsDatasheet';
 @use './timeInput';
 @use './readOnlyTime';
+@use './timeCell';


### PR DESCRIPTION
## Context

The previous `TimeCell` implementation relied on a input mask and tweaks with a microTask queue.
This was not a good solution for multiple reasons, including complexity.

## What changed

The TimeCell now works with a section-based approach:
- time is represented as three sections (`hours`, `minutes`, `seconds`)
- all keyboard interactions are handled by a reducer

## How should this work

This refactor also focuses on behaviors implied by the UX/UI requirements, to ensure that [this sketch](https://www.sketch.com/s/44a4dfe4-6ef5-4f9f-92d3-72b79136e5da/v/bnr1zo/f/67EC2C06-AC5C-409A-B520-1956BB350036#Inspect) is respected here's a few test cases for those who needs to review the component.

- Typing `0145` while focused on minutes and pressing enter should display `01:45:00`
- Backspace should lead to an intuitive clear of the input
- Arrow keys shoudl correctly switch between sections
- Clicking sections should correctly handle the focus


Rewriting the integration of the timeCell also accomodates the work of linking the table with the backend process.

related to https://github.com/osrd-project/osrd-confidential/issues/1281


This closes #14277 and closes #14275 

because it will most likely be handled by the backend manipulations.