### PR TITLE
front: fix arrival time constraint for RaiMI demand

### DIFF
--- a/front/src/applications/stdcm/components/StdcmResults/SendToRailwayManagerModal.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/SendToRailwayManagerModal.tsx
@@ -28,7 +28,12 @@ import { getRailwayManagerInterfaceUrl } from 'reducers/main/mainSelector';
 import type { StdcmPathStep } from 'reducers/osrdconf/types';
 import { useAppDispatch } from 'store';
 import { useDateTimeLocale } from 'utils/date';
-import { addDurationToDate, Duration, subtractDurationFromDate } from 'utils/duration';
+import {
+  addDurationToDate,
+  Duration,
+  minutesBetween,
+  subtractDurationFromDate,
+} from 'utils/duration';
 import { castErrorToFailure } from 'utils/error';
 import { kmhToMs, tToKg } from 'utils/physics';
 
@@ -114,9 +119,8 @@ const SendToRailwayManagerModal = ({
   const constraintTime = constraintOnDeparture
     ? new Date(firstStep.arrival!)
     : new Date(lastStep.arrival!);
-  const diffMinutes = new Duration({
-    minutes: Math.round((realConstraintTime.getTime() - constraintTime.getTime()) / 60000),
-  });
+
+  const diffMinutes = minutesBetween(realConstraintTime, constraintTime);
 
   const { tolerances } = constraintOnDeparture ? firstStep : lastStep;
 

--- a/front/src/utils/duration.ts
+++ b/front/src/utils/duration.ts
@@ -72,3 +72,9 @@ export const addDurationToDate = (date: Date, dur: Duration) => new Date(date.ge
 
 export const subtractDurationFromDate = (date: Date, dur: Duration) =>
   new Date(date.getTime() - dur.ms);
+
+/** Compute the difference in minutes between two dates, truncated to the minute */
+export const minutesBetween = (a: Date, b: Date) =>
+  new Duration({
+    minutes: dayjs(a).startOf('minute').diff(dayjs(b).startOf('minute'), 'minute'),
+  });


### PR DESCRIPTION
fix #14411

This PR fixes a bug in computing time differences in minutes.
```Example: 2:00:00 - 1:30:55 = 00:29:05, but the expected result is 30 minutes.```
The fix consists of removing the seconds and milliseconds from dates before computing the difference.