### PR TITLE
core: improve STDCM heuristic

### DIFF
--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/PhysicsRollingStock.kt
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/PhysicsRollingStock.kt
@@ -1,8 +1,11 @@
 package fr.sncf.osrd.envelope_sim
 
+import com.google.common.collect.RangeMap
 import fr.sncf.osrd.envelope_sim.etcs.EtcsBrakeParams
 import fr.sncf.osrd.envelope_sim.etcs.M_ROTATING_MAX
 import fr.sncf.osrd.envelope_sim.etcs.M_ROTATING_MIN
+import fr.sncf.osrd.path.interfaces.Electrification
+import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
 import kotlin.math.abs
 
 interface PhysicsRollingStock {
@@ -29,10 +32,33 @@ interface PhysicsRollingStock {
     /** The maximum constant deceleration, in m/s^2 */
     val deceleration: Double
 
-    /** The maximum acceleration, in m/s^2, which can be applied at a given speed, in m/s */
-    @JvmRecord data class TractiveEffortPoint(val speed: Double, val maxEffort: Double)
+    /**
+     * Returns the tractive effort curves corresponding to the electrical conditions map. The
+     * neutral sections are not extended in this function.
+     *
+     * @param electrificationMap The map of electrification conditions to use along the path.
+     * @param comfort The comfort level to get the curves for.
+     */
+    fun mapTractiveEffortCurves(
+        electrificationMap: RangeMap<Double, Electrification>,
+        comfort: Comfort?,
+    ): CurvesAndConditions
 
-    // TODO move these static methods out of the class
+    data class CurvesAndConditions(
+        val curves: RangeMap<Double, Array<TractiveEffortPoint>>,
+        val conditions: RangeMap<Double, InfraConditions>,
+    )
+
+    @JvmRecord
+    data class InfraConditions(
+        val mode: String?,
+        val electricalProfile: String?,
+        val powerRestriction: String?,
+    )
+
+    /** The maximum acceleration, in m/s^2, which can be applied at a given speed, in m/s */
+    data class TractiveEffortPoint(val speed: Double, val maxEffort: Double)
+
     companion object {
         /** Get the effort the train can apply at a given speed, in newtons */
         fun getMaxEffort(speed: Double, tractiveEffortCurve: Array<TractiveEffortPoint>): Double {
@@ -71,7 +97,6 @@ interface PhysicsRollingStock {
          * m/s². Grade is in m/km. mRotating (Max or Min) is in %, as seen in ERA braking curves
          * simulation tool v5.1.
          */
-        @JvmStatic
         fun getGradientAcceleration(grade: Double): Double {
             val mRotating: Double = if (grade >= 0) M_ROTATING_MAX else M_ROTATING_MIN
             return -TrainPhysicsIntegrator.GRAVITY_ACCELERATION * grade /

--- a/core/envelope-sim/src/testFixtures/java/fr/sncf/osrd/envelope_sim/SimpleRollingStock.kt
+++ b/core/envelope-sim/src/testFixtures/java/fr/sncf/osrd/envelope_sim/SimpleRollingStock.kt
@@ -2,8 +2,13 @@ package fr.sncf.osrd.envelope_sim
 
 import com.google.common.collect.ImmutableRangeMap
 import com.google.common.collect.Range
+import com.google.common.collect.RangeMap
+import com.google.common.collect.TreeRangeMap
+import fr.sncf.osrd.envelope_sim.PhysicsRollingStock.CurvesAndConditions
 import fr.sncf.osrd.envelope_sim.PhysicsRollingStock.TractiveEffortPoint
 import fr.sncf.osrd.envelope_sim.etcs.EtcsBrakeParams
+import fr.sncf.osrd.path.interfaces.Electrification
+import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
 import kotlin.math.abs
 import kotlin.math.max
 
@@ -50,6 +55,13 @@ class SimpleRollingStock(
         get() = TODO()
 
     override val deceleration: Double = -constGamma
+
+    override fun mapTractiveEffortCurves(
+        electrificationMap: RangeMap<Double, Electrification>,
+        comfort: Comfort?,
+    ): CurvesAndConditions {
+        return CurvesAndConditions(TreeRangeMap.create(), TreeRangeMap.create())
+    }
 
     /**
      * The tractive effort curve shape. It can be either linear (effort proportional to speed), or

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/result/ElectrificationRange.java
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/result/ElectrificationRange.java
@@ -115,9 +115,9 @@ public class ElectrificationRange {
             if (seenCond instanceof Electrified e) {
                 return new ElectrifiedUsage(
                         e.mode,
-                        Objects.equals(usedCond.mode, e.mode),
+                        Objects.equals(usedCond.mode(), e.mode),
                         e.profile,
-                        Objects.equals(usedCond.electricalProfile, e.profile));
+                        Objects.equals(usedCond.electricalProfile(), e.profile));
             }
             if (seenCond instanceof Neutral n) {
                 if (n.isAnnouncement) {

--- a/core/src/main/java/fr/sncf/osrd/train/RollingStock.kt
+++ b/core/src/main/java/fr/sncf/osrd/train/RollingStock.kt
@@ -5,6 +5,8 @@ import com.google.common.collect.Range
 import com.google.common.collect.RangeMap
 import com.google.common.collect.TreeRangeMap
 import fr.sncf.osrd.envelope_sim.PhysicsRollingStock
+import fr.sncf.osrd.envelope_sim.PhysicsRollingStock.CurvesAndConditions
+import fr.sncf.osrd.envelope_sim.PhysicsRollingStock.InfraConditions
 import fr.sncf.osrd.envelope_sim.PhysicsRollingStock.TractiveEffortPoint
 import fr.sncf.osrd.envelope_sim.etcs.EtcsBrakeParams
 import fr.sncf.osrd.path.interfaces.Electrification
@@ -97,6 +99,24 @@ constructor(
         return B + 2 * C * speed
     }
 
+    override fun mapTractiveEffortCurves(
+        electrificationMap: RangeMap<Double, Electrification>,
+        comfort: Comfort?,
+    ): CurvesAndConditions {
+        val conditionsUsed = TreeRangeMap.create<Double, InfraConditions>()
+        val res = TreeRangeMap.create<Double, Array<TractiveEffortPoint>>()
+
+        for (elecCondEntry in electrificationMap.asMapOfRanges().entries) {
+            val curveAndCond = findTractiveEffortCurve(comfort, elecCondEntry.value)
+            res.put(elecCondEntry.key, curveAndCond.curve)
+            conditionsUsed.put(elecCondEntry.key, curveAndCond.cond)
+        }
+        return CurvesAndConditions(
+            ImmutableRangeMap.copyOf(res),
+            ImmutableRangeMap.copyOf(conditionsUsed),
+        )
+    }
+
     @JvmRecord
     data class ModeEffortCurves(
         val isElectric: Boolean,
@@ -133,22 +153,9 @@ constructor(
     }
 
     @JvmRecord
-    data class InfraConditions(
-        @JvmField val mode: String?,
-        @JvmField val electricalProfile: String?,
-        val powerRestriction: String?,
-    )
-
-    @JvmRecord
     private data class CurveAndCondition(
         val curve: Array<TractiveEffortPoint>,
         val cond: InfraConditions,
-    )
-
-    @JvmRecord
-    data class CurvesAndConditions(
-        @JvmField val curves: RangeMap<Double, Array<TractiveEffortPoint>>,
-        @JvmField val conditions: RangeMap<Double, InfraConditions>,
     )
 
     override val deceleration: Double = -constGamma
@@ -179,7 +186,7 @@ constructor(
         }
         if (electrification is NonElectrified) {
             return CurveAndCondition(
-                modes.get(defaultMode)!!.defaultCurve,
+                modes[defaultMode]!!.defaultCurve,
                 InfraConditions(defaultMode, null, null),
             )
         }
@@ -187,7 +194,7 @@ constructor(
         val electrified = electrification as Electrified
 
         val usedMode = if (modes.containsKey(electrified.mode)) electrified.mode else defaultMode
-        val mode: ModeEffortCurves = modes.get(usedMode)!!
+        val mode: ModeEffortCurves = modes[usedMode]!!
         val chosenCond =
             EffortCurveConditions(comfort, electrified.profile, electrified.powerRestriction)
         // Get first matching curve
@@ -204,31 +211,6 @@ constructor(
             }
         }
         return CurveAndCondition(mode.defaultCurve, InfraConditions(usedMode, null, null))
-    }
-
-    /**
-     * Returns the tractive effort curves corresponding to the electrical conditions map The neutral
-     * sections are not extended in this function.
-     *
-     * @param electrificationMap The map of electrification conditions to use
-     * @param comfort The comfort level to get the curves for
-     */
-    fun mapTractiveEffortCurves(
-        electrificationMap: RangeMap<Double, Electrification>,
-        comfort: Comfort?,
-    ): CurvesAndConditions {
-        val conditionsUsed = TreeRangeMap.create<Double, InfraConditions>()
-        val res = TreeRangeMap.create<Double, Array<TractiveEffortPoint>>()
-
-        for (elecCondEntry in electrificationMap.asMapOfRanges().entries) {
-            val curveAndCond = findTractiveEffortCurve(comfort, elecCondEntry.value)
-            res.put(elecCondEntry.key, curveAndCond.curve)
-            conditionsUsed.put(elecCondEntry.key, curveAndCond.cond)
-        }
-        return CurvesAndConditions(
-            ImmutableRangeMap.copyOf(res),
-            ImmutableRangeMap.copyOf(conditionsUsed),
-        )
     }
 
     /**

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/CachedBlockMaxSpeedEnvBuilder.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/CachedBlockMaxSpeedEnvBuilder.kt
@@ -1,4 +1,4 @@
-package fr.sncf.osrd.utils
+package fr.sncf.osrd.stdcm
 
 import fr.sncf.osrd.envelope.Envelope
 import fr.sncf.osrd.envelope_sim.EnvelopeSimContext
@@ -20,20 +20,24 @@ import fr.sncf.osrd.stdcm.graph.build
 import fr.sncf.osrd.stdcm.infra_exploration.ExplorerStep
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
-import kotlin.math.min
 import kotlin.math.max
+import kotlin.math.min
 
 /**
  * Used to compute block MaxSpeedEnvelopes and min time required to reach a point, with proper
  * caching.
  *
- * TODO: this ignores speed limits by route for now. It would make caching a lot less efficient though
- *   (can't just use block as key), it will have a significant performance cost. Should be supported
- *   once we import them, but not necessarily before that.
- * TODO: rare/unlikely cases could lead to pessimistic evaluation (which could lead to A* providing a solution different from optimum). Both cases could happen on the same block or different blocks.
- *   - If the path used for heuristic crosses the same stop multiple times (different OP parts) then we're applying the stop each time while the real simulation will only stop once.
- *   - Same goes on the order of stops if crossing stop places in the wrong order for heuristic, we're applying too much stops and wrongly slowing down the heuristic.
- *   /!\ Working on this requires benchmarking and evaluating possible bugs, the amount of work, technical debt.
+ * TODO: this ignores speed limits by route for now. It would make caching a lot less efficient
+ *   though (can't just use block as key), it will have a significant performance cost. Should be
+ *   supported once we import them, but not necessarily before that.
+ * TODO: rare/unlikely cases could lead to pessimistic evaluation (which could lead to A* providing
+ *   a solution different from optimum). Both cases could happen on the same block or different
+ *   blocks. /!\ Working on this requires benchmarking and evaluating possible bugs, the amount of
+ *   work, technical debt.
+ *     - If the path used for heuristic crosses the same stop multiple times (different OP parts)
+ *       then we're applying the stop each time while the real simulation will only stop once.
+ *     - Same goes on the order of stops if crossing stop places in the wrong order for heuristic,
+ *       we're applying too much stops and wrongly slowing down the heuristic.
  */
 data class CachedBlockMaxSpeedEnvBuilder(
     private val rawInfra: RawInfra,
@@ -106,7 +110,8 @@ data class CachedBlockMaxSpeedEnvBuilder(
                 if (actualEndSpeed < cachedMrsp.mrsp.endSpeed)
                     addEndBrakingPart(cachedMrsp.context, actualEndSpeed, cachedMrsp.mrsp)
                 else cachedMrsp.mrsp
-            // TODO: Look into adding accelerations to the max speed envelope and benchmark it to see if it improves the computing time.
+            // TODO: Look into adding accelerations to the max speed envelope and benchmark it to
+            // see if it improves the computing time.
             maxSpeedEnvelopeFrom(cachedMrsp.context, stops, newMrsp)
         }
     }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMHeuristic.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMHeuristic.kt
@@ -60,14 +60,14 @@ data class STDCMAStarHeuristic(
         // If we're at the destination, endSpeed should be 0.0 rather than null. However, if we are
         // at the destination, there'll be a stop which is taken into account in MaxSpeedEnvBuilder,
         // so it's fine as is.
-        var endSpeed = maxSpeedEnvBuilder.getMaxSpeedEnvelope(lastBlock).beginSpeed
+        var endSpeed = maxSpeedEnvBuilder.getMaxSpeedEnvelope(lastBlock, null).beginSpeed
         for (block in allBlocks.asReversed()) {
             timeUntilStartOfLastBlock +=
-                maxSpeedEnvBuilder.getBlockTime(block, null, allowanceValue, endSpeed)
+                maxSpeedEnvBuilder.getBlockTime(block, null, endSpeed, allowanceValue)
             endSpeed = maxSpeedEnvBuilder.getMaxSpeedEnvelope(block, endSpeed).beginSpeed
         }
         val timeSinceFirstBlock =
-            maxSpeedEnvBuilder.getBlockTime(edge.block, offset, allowanceValue)
+            maxSpeedEnvBuilder.getBlockTime(edge.block, offset, null, allowanceValue)
         timeUntilStartOfLastBlock -= timeSinceFirstBlock
 
         val remainingTime = timeUntilStartOfLastBlock + timeAfterStartOfLastBlock
@@ -154,7 +154,7 @@ class STDCMHeuristicBuilder(
                 val remainingTimeSinceBlockStart =
                     remainingTimeEstimations.first()[it.edge] ?: Double.POSITIVE_INFINITY
                 val timeSinceBlockStart =
-                    maxSpeedEnvBuilder.getBlockTime(it.edge, it.offset, allowance)
+                    maxSpeedEnvBuilder.getBlockTime(it.edge, it.offset, null, allowance)
                 remainingTimeSinceBlockStart - timeSinceBlockStart
             } ?: Double.POSITIVE_INFINITY
         logger.info(
@@ -250,7 +250,7 @@ class STDCMHeuristicBuilder(
         return PendingBlock(
             block,
             newIndex,
-            remainingTime + maxSpeedEnvBuilder.getBlockTime(block, offset, allowance, endSpeed),
+            remainingTime + maxSpeedEnvBuilder.getBlockTime(block, offset, endSpeed, allowance),
             endSpeed,
         )
     }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMHeuristic.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMHeuristic.kt
@@ -11,7 +11,7 @@ import fr.sncf.osrd.stdcm.graph.STDCMEdge
 import fr.sncf.osrd.stdcm.infra_exploration.ExplorerStep
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
 import fr.sncf.osrd.stdcm.infra_exploration.StepTracker
-import fr.sncf.osrd.utils.CachedBlockMRSPBuilder
+import fr.sncf.osrd.utils.CachedBlockMaxSpeedEnvBuilder
 import fr.sncf.osrd.utils.indexing.StaticIdx
 import fr.sncf.osrd.utils.units.Offset
 import io.opentelemetry.api.trace.SpanKind
@@ -26,7 +26,7 @@ data class STDCMAStarHeuristic(
     val blockInfra: BlockInfra,
     val remainingTimeEstimations: List<MutableMap<BlockId, Double>>,
     val nPlannedSteps: Int,
-    val mrspBuilder: CachedBlockMRSPBuilder,
+    val maxSpeedEnvBuilder: CachedBlockMaxSpeedEnvBuilder,
     val bestTravelTime: Double,
     val allowanceValue: AllowanceValue?,
     val stopDurations: List<Double>,
@@ -45,23 +45,29 @@ data class STDCMAStarHeuristic(
         // We don't consider the time of the last lookahead block to avoid issues
         // if it contains the destination, and we don't need it (the destination is
         // already locked-in).
+        val lastBlock = allBlocks.removeLast()
 
         // Account for the steps that will be passed in the lookahead
-        val expectedIndex = getExpectedStepIndex(allBlocks.dropLast(1), stepTracker)
+        val expectedIndex = getExpectedStepIndex(allBlocks, stepTracker)
         if (expectedIndex >= remainingTimeEstimations.size) return 0.0
 
         val timeAfterStartOfLastBlock =
-            remainingTimeEstimations[expectedIndex][allBlocks.last()]
-                ?: return Double.POSITIVE_INFINITY
+            remainingTimeEstimations[expectedIndex][lastBlock] ?: return Double.POSITIVE_INFINITY
 
         // Compute the time it takes from the current point until the start
-        // of the last block of the lookahead, then from that point the destination.
+        // of the last block of the lookahead, then from that point to the destination.
         var timeUntilStartOfLastBlock = 0.0
-        for (j in 0 until allBlocks.size - 1) {
+        // If we're at the destination, endSpeed should be 0.0 rather than null. However, if we are
+        // at the destination, there'll be a stop which is taken into account in MaxSpeedEnvBuilder,
+        // so it's fine as is.
+        var endSpeed = maxSpeedEnvBuilder.getMaxSpeedEnvelope(lastBlock).beginSpeed
+        for (block in allBlocks.asReversed()) {
             timeUntilStartOfLastBlock +=
-                mrspBuilder.getBlockTime(allBlocks[j], null, allowanceValue)
+                maxSpeedEnvBuilder.getBlockTime(block, null, allowanceValue, endSpeed)
+            endSpeed = maxSpeedEnvBuilder.getMaxSpeedEnvelope(block, endSpeed).beginSpeed
         }
-        val timeSinceFirstBlock = mrspBuilder.getBlockTime(edge.block, offset, allowanceValue)
+        val timeSinceFirstBlock =
+            maxSpeedEnvBuilder.getBlockTime(edge.block, offset, allowanceValue)
         timeUntilStartOfLastBlock -= timeSinceFirstBlock
 
         val remainingTime = timeUntilStartOfLastBlock + timeAfterStartOfLastBlock
@@ -104,7 +110,7 @@ class STDCMHeuristicBuilder(
     private val rawInfra: RawInfra,
     private val steps: List<ExplorerStep>,
     private val maxRunningTime: Double,
-    private val mrspBuilder: CachedBlockMRSPBuilder,
+    private val maxSpeedEnvBuilder: CachedBlockMaxSpeedEnvBuilder,
     val allowance: AllowanceValue?,
     private val constraints: ConstraintCombiner<StaticIdx<Block>>? = null,
 ) {
@@ -147,7 +153,8 @@ class STDCMHeuristicBuilder(
             steps.first().locations.minOfOrNull {
                 val remainingTimeSinceBlockStart =
                     remainingTimeEstimations.first()[it.edge] ?: Double.POSITIVE_INFINITY
-                val timeSinceBlockStart = mrspBuilder.getBlockTime(it.edge, it.offset, allowance)
+                val timeSinceBlockStart =
+                    maxSpeedEnvBuilder.getBlockTime(it.edge, it.offset, allowance)
                 remainingTimeSinceBlockStart - timeSinceBlockStart
             } ?: Double.POSITIVE_INFINITY
         logger.info(
@@ -158,7 +165,7 @@ class STDCMHeuristicBuilder(
             blockInfra,
             remainingTimeEstimations,
             steps.size,
-            mrspBuilder,
+            maxSpeedEnvBuilder,
             bestTravelTime,
             allowance,
             steps.filter { it.stop }.map { it.duration ?: 0.0 },
@@ -170,6 +177,7 @@ class STDCMHeuristicBuilder(
         val block: BlockId,
         val stepIndex: Int, // Number of steps that have been reached
         val remainingTimeAtBlockStart: Double,
+        val endSpeed: Double?,
     ) : Comparable<PendingBlock> {
         /** Used to find the lowest remaining time at block start in a priority queue. */
         override fun compareTo(other: PendingBlock): Int {
@@ -183,6 +191,12 @@ class STDCMHeuristicBuilder(
      */
     private fun getPredecessors(pendingBlock: PendingBlock): Collection<PendingBlock> {
         if (pendingBlock.remainingTimeAtBlockStart > maxRunningTime) return emptyList()
+        val predecessorEndSpeed =
+            if (maxSpeedEnvBuilder.isStopAtStartOfBlock(pendingBlock.block)) 0.0
+            else
+                maxSpeedEnvBuilder
+                    .getMaxSpeedEnvelope(pendingBlock.block, pendingBlock.endSpeed)
+                    .beginSpeed
         val detector = blockInfra.getBlockEntry(rawInfra, pendingBlock.block)
         val blocks = blockInfra.getBlocksEndingAtDetector(detector)
         val res = mutableListOf<PendingBlock>()
@@ -193,6 +207,7 @@ class STDCMHeuristicBuilder(
                     null,
                     pendingBlock.stepIndex,
                     pendingBlock.remainingTimeAtBlockStart,
+                    predecessorEndSpeed,
                 )
             newBlock?.let { res.add(it) }
         }
@@ -204,7 +219,7 @@ class STDCMHeuristicBuilder(
         val res = PriorityQueue<PendingBlock>()
         val stepCount = steps.size
         for (wp in steps[stepCount - 1].locations) {
-            makePendingBlock(wp.edge, wp.offset, stepCount - 1, 0.0)?.let { res.add(it) }
+            makePendingBlock(wp.edge, wp.offset, stepCount - 1, 0.0, 0.0)?.let { res.add(it) }
         }
         return res
     }
@@ -215,6 +230,7 @@ class STDCMHeuristicBuilder(
         offset: Offset<Block>?,
         currentIndex: Int,
         remainingTime: Double,
+        endSpeed: Double?,
     ): PendingBlock? {
         var newIndex = currentIndex
         val actualOffset = offset ?: blockInfra.getBlockLength(block)
@@ -234,7 +250,8 @@ class STDCMHeuristicBuilder(
         return PendingBlock(
             block,
             newIndex,
-            remainingTime + mrspBuilder.getBlockTime(block, offset, allowance),
+            remainingTime + maxSpeedEnvBuilder.getBlockTime(block, offset, allowance, endSpeed),
+            endSpeed,
         )
     }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMHeuristic.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMHeuristic.kt
@@ -11,7 +11,6 @@ import fr.sncf.osrd.stdcm.graph.STDCMEdge
 import fr.sncf.osrd.stdcm.infra_exploration.ExplorerStep
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
 import fr.sncf.osrd.stdcm.infra_exploration.StepTracker
-import fr.sncf.osrd.utils.CachedBlockMaxSpeedEnvBuilder
 import fr.sncf.osrd.utils.indexing.StaticIdx
 import fr.sncf.osrd.utils.units.Offset
 import io.opentelemetry.api.trace.SpanKind

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/BacktrackingManager.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/BacktrackingManager.kt
@@ -54,7 +54,6 @@ class BacktrackingManager(private val graph: STDCMGraph) {
     private fun rebuildEdgeBackward(old: STDCMEdge, endSpeed: Double): STDCMEdge? {
         val oldEnvelope =
             graph.stdcmSimulations.simulateBlock(
-                graph.rawInfra,
                 graph.rollingStock,
                 graph.comfort,
                 graph.timeStep,
@@ -68,15 +67,9 @@ class BacktrackingManager(private val graph: STDCMGraph) {
                     getNextStopOnCurrentBlock(old.infraExplorer),
                 ),
             )
-        val newEnvelope =
-            simulateBackwards(
-                graph.rawInfra,
-                old.infraExplorer,
-                endSpeed,
-                old.envelopeStartOffset,
-                oldEnvelope!!,
-                graph,
-            )
+        val path = old.infraExplorer.getCurrentEdgePathProperties(old.envelopeStartOffset, null)
+        val context = build(graph.rollingStock, path, graph.timeStep, graph.comfort)
+        val newEnvelope = addEndBrakingPart(context, endSpeed, oldEnvelope!!)
         val prevNode = old.previousNode
         return STDCMEdgeBuilder.fromNode(graph, prevNode, old.infraExplorer)
             .setEnvelope(newEnvelope)

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/EnvelopeSimContextBuilder.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/EnvelopeSimContextBuilder.kt
@@ -1,19 +1,19 @@
 package fr.sncf.osrd.stdcm.graph
 
 import fr.sncf.osrd.envelope_sim.EnvelopeSimContext
+import fr.sncf.osrd.envelope_sim.PhysicsRollingStock
 import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
-import fr.sncf.osrd.train.RollingStock
 
 /** Computes the rolling stock effort curves that will be used and creates a context */
 fun build(
-    rollingStock: RollingStock,
+    rollingStock: PhysicsRollingStock,
     path: PhysicsPath,
     timeStep: Double,
     comfort: Comfort?,
 ): EnvelopeSimContext {
     val elecCondMap =
         path.getElectrificationMap(null, null, null, true) // Only electrification modes for now
-    val curvesAndConditions = rollingStock.mapTractiveEffortCurves(elecCondMap, comfort)
-    return EnvelopeSimContext(rollingStock, path, timeStep, curvesAndConditions.curves)
+    val curves = rollingStock.mapTractiveEffortCurves(elecCondMap, comfort).curves
+    return EnvelopeSimContext(rollingStock, path, timeStep, curves)
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdgeBuilder.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdgeBuilder.kt
@@ -86,7 +86,6 @@ internal constructor(
         if (envelope == null)
             envelope =
                 graph.stdcmSimulations.simulateBlock(
-                    graph.rawInfra,
                     graph.rollingStock,
                     graph.comfort,
                     graph.timeStep,
@@ -202,7 +201,7 @@ internal constructor(
             )
         }
         val standardAllowanceSpeedRatio = graph.getStandardAllowanceSpeedRatio(envelope!!)
-        var res: STDCMEdge? =
+        val res =
             STDCMEdge(
                 prevNode.timeData.shifted(
                     timeShift = delayNeeded,
@@ -228,7 +227,7 @@ internal constructor(
                 allowanceData,
                 envelope!!,
             )
-        return graph.backtrackingManager.backtrack(res!!, envelope!!)
+        return graph.backtrackingManager.backtrack(res, envelope!!)
     }
 
     companion object {

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
@@ -20,7 +20,7 @@ import fr.sncf.osrd.stdcm.infra_exploration.ExplorerStep
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
 import fr.sncf.osrd.stdcm.preprocessing.interfaces.BlockAvailabilityInterface
 import fr.sncf.osrd.train.RollingStock
-import fr.sncf.osrd.utils.CachedBlockMRSPBuilder
+import fr.sncf.osrd.utils.CachedBlockMaxSpeedEnvBuilder
 import fr.sncf.osrd.utils.indexing.StaticIdx
 import fr.sncf.osrd.utils.units.meters
 import java.lang.Double.isFinite
@@ -42,7 +42,7 @@ class STDCMGraph(
     val comfort: Comfort?,
     val timeStep: Double,
     blockAvailability: BlockAvailabilityInterface,
-    val maxRunTime: Double,
+    maxRunTime: Double,
     minScheduleTimeStart: Double,
     steps: List<ExplorerStep>,
     val tag: String?,
@@ -58,11 +58,14 @@ class STDCMGraph(
         DelayManager(minScheduleTimeStart, maxRunTime, blockAvailability, this, timeStep)
     val allowanceManager = EngineeringAllowanceManager(rollingStock.constGamma, this)
     val backtrackingManager: BacktrackingManager = BacktrackingManager(this)
-    val mrspBuilder =
-        CachedBlockMRSPBuilder(
+    val maxSpeedEnvBuilder =
+        CachedBlockMaxSpeedEnvBuilder(
             rawInfra,
             blockInfra,
             rollingStock,
+            steps,
+            timeStep,
+            comfort,
             speedLimitTag = tag,
             temporarySpeedLimitManager = temporarySpeedLimitManager,
             addRollingStockLength = false,
@@ -72,7 +75,7 @@ class STDCMGraph(
     // TODO: this value *should* reflect twice the min delay between two trains,
     // but it seems we need it to be as small as the smallest amount of time
     // a train can occupy a block. There's an issue somewhere.
-    private val visitedNodes = VisitedNodes(30.0, fullInfra, mrspBuilder)
+    private val visitedNodes = VisitedNodes(30.0, fullInfra, maxSpeedEnvBuilder)
 
     // A* heuristic
     val remainingTimeEstimator: STDCMAStarHeuristic
@@ -89,7 +92,7 @@ class STDCMGraph(
                     fullInfra.rawInfra,
                     steps,
                     maxRunTime,
-                    mrspBuilder,
+                    maxSpeedEnvBuilder,
                     standardAllowance,
                     constraints,
                 )
@@ -146,7 +149,7 @@ class STDCMGraph(
         } else {
             val extended = extendLookaheadUntil(node.infraExplorer.clone(), 3)
             for (newPath in extended) {
-                if (newPath.getLookahead().size == 0) continue
+                if (newPath.getLookahead().isEmpty()) continue
                 newPath.moveForward()
                 visitedNodesParameters.fingerprint =
                     VisitedNodes.Fingerprint(

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
@@ -12,6 +12,7 @@ import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.ZoneId
 import fr.sncf.osrd.sim_infra.impl.TemporarySpeedLimitManager
+import fr.sncf.osrd.stdcm.CachedBlockMaxSpeedEnvBuilder
 import fr.sncf.osrd.stdcm.STDCMAStarHeuristic
 import fr.sncf.osrd.stdcm.STDCMHeuristicBuilder
 import fr.sncf.osrd.stdcm.graph.engineering_allowance.EngineeringAllowanceManager
@@ -20,7 +21,6 @@ import fr.sncf.osrd.stdcm.infra_exploration.ExplorerStep
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
 import fr.sncf.osrd.stdcm.preprocessing.interfaces.BlockAvailabilityInterface
 import fr.sncf.osrd.train.RollingStock
-import fr.sncf.osrd.utils.CachedBlockMaxSpeedEnvBuilder
 import fr.sncf.osrd.utils.indexing.StaticIdx
 import fr.sncf.osrd.utils.units.meters
 import java.lang.Double.isFinite

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMSimulations.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMSimulations.kt
@@ -9,6 +9,7 @@ import fr.sncf.osrd.envelope.part.constraints.EnvelopeConstraint
 import fr.sncf.osrd.envelope.part.constraints.EnvelopePartConstraintType
 import fr.sncf.osrd.envelope.part.constraints.SpeedConstraint
 import fr.sncf.osrd.envelope_sim.EnvelopeProfile
+import fr.sncf.osrd.envelope_sim.EnvelopeSimContext
 import fr.sncf.osrd.envelope_sim.overlays.EnvelopeDeceleration
 import fr.sncf.osrd.envelope_sim.pipelines.SimStop
 import fr.sncf.osrd.envelope_sim.pipelines.maxEffortEnvelopeFrom
@@ -19,7 +20,6 @@ import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
 import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal
 import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.sim_infra.api.Block
-import fr.sncf.osrd.sim_infra.api.RawSignalingInfra
 import fr.sncf.osrd.sim_infra.impl.TemporarySpeedLimitManager
 import fr.sncf.osrd.stdcm.BacktrackingSelfTypeHolder
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorer
@@ -42,7 +42,6 @@ class STDCMSimulations {
      * simulatedEnvelopes, otherwise computes the matching envelope and adds it to the STDCMGraph.
      */
     fun simulateBlock(
-        rawInfra: RawSignalingInfra,
         rollingStock: RollingStock,
         comfort: Comfort?,
         timeStep: Double,
@@ -55,7 +54,6 @@ class STDCMSimulations {
         if (cached != null) return cached
         val simulatedEnvelope =
             simulateBlock(
-                rawInfra,
                 infraExplorer,
                 blockParams.initialSpeed,
                 blockParams.start,
@@ -79,7 +77,6 @@ class STDCMSimulations {
      * blocks. We are missing slopes and speed limits from earlier in the path.
      */
     fun simulateBlock(
-        rawInfra: RawSignalingInfra,
         infraExplorer: InfraExplorer,
         initialSpeed: Double,
         start: Offset<Block>,
@@ -150,17 +147,12 @@ private fun makeSinglePointEnvelope(speed: Double): Envelope {
     )
 }
 
-/** returns an envelope for a block that already has an envelope, but with a different end speed */
-fun simulateBackwards(
-    rawInfra: RawSignalingInfra,
-    infraExplorer: InfraExplorer,
+/** Returns a new envelope with a different end speed. */
+fun addEndBrakingPart(
+    context: EnvelopeSimContext,
     endSpeed: Double,
-    start: Offset<Block>,
     oldEnvelope: Envelope,
-    graph: STDCMGraph,
 ): Envelope {
-    val path = infraExplorer.getCurrentEdgePathProperties(start, null)
-    val context = build(graph.rollingStock, path, graph.timeStep, graph.comfort)
     val partBuilder = EnvelopePartBuilder()
     partBuilder.setAttr(EnvelopeProfile.BRAKING)
     partBuilder.setAttr(BacktrackingSelfTypeHolder())

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/visited_node_tracking/VisitedNodes.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/visited_node_tracking/VisitedNodes.kt
@@ -10,7 +10,7 @@ import fr.sncf.osrd.stdcm.graph.visited_node_tracking.VisitedNodes.Parameters
 import fr.sncf.osrd.stdcm.infra_exploration.EdgeIdentifier
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorer
 import fr.sncf.osrd.stdcm.infra_exploration.getRemainingBlocks
-import fr.sncf.osrd.utils.CachedBlockMRSPBuilder
+import fr.sncf.osrd.utils.CachedBlockMaxSpeedEnvBuilder
 import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.meters
 import kotlin.math.min
@@ -44,7 +44,7 @@ import kotlin.math.min
 data class VisitedNodes(
     val minDelay: Double,
     val infra: FullInfra? = null,
-    val mrspBuilder: CachedBlockMRSPBuilder? = null,
+    val maxSpeedEnvBuilder: CachedBlockMaxSpeedEnvBuilder? = null,
 ) {
 
     /** Data class representing a space location. Must be usable as map key. */
@@ -111,7 +111,7 @@ data class VisitedNodes(
 
                 val minTravelTime =
                     parameters.explorer.getRemainingBlocks().sumOf {
-                        mrspBuilder!!.getBlockTime(it, null)
+                        maxSpeedEnvBuilder!!.getBlockTime(it, null)
                     }
 
                 // We compare it to a scenario with the minimum amount of added travel time, and

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/visited_node_tracking/VisitedNodes.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/visited_node_tracking/VisitedNodes.kt
@@ -111,7 +111,7 @@ data class VisitedNodes(
 
                 val minTravelTime =
                     parameters.explorer.getRemainingBlocks().sumOf {
-                        maxSpeedEnvBuilder!!.getBlockTime(it, null)
+                        maxSpeedEnvBuilder!!.getBlockTime(it, null, null)
                     }
 
                 // We compare it to a scenario with the minimum amount of added travel time, and

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/visited_node_tracking/VisitedNodes.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/visited_node_tracking/VisitedNodes.kt
@@ -5,12 +5,12 @@ import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.sim_infra.api.DirDetectorId
 import fr.sncf.osrd.sim_infra.utils.getBlockEntry
 import fr.sncf.osrd.sim_infra.utils.getBlockExit
+import fr.sncf.osrd.stdcm.CachedBlockMaxSpeedEnvBuilder
 import fr.sncf.osrd.stdcm.graph.TimeData
 import fr.sncf.osrd.stdcm.graph.visited_node_tracking.VisitedNodes.Parameters
 import fr.sncf.osrd.stdcm.infra_exploration.EdgeIdentifier
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorer
 import fr.sncf.osrd.stdcm.infra_exploration.getRemainingBlocks
-import fr.sncf.osrd.utils.CachedBlockMaxSpeedEnvBuilder
 import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.meters
 import kotlin.math.min

--- a/core/src/main/kotlin/fr/sncf/osrd/utils/CachedBlockMaxSpeedEnvBuilder.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/utils/CachedBlockMaxSpeedEnvBuilder.kt
@@ -1,6 +1,7 @@
 package fr.sncf.osrd.utils
 
 import fr.sncf.osrd.envelope.Envelope
+import fr.sncf.osrd.envelope_sim.EnvelopeSimContext
 import fr.sncf.osrd.envelope_sim.PhysicsRollingStock
 import fr.sncf.osrd.envelope_sim.allowances.AllowanceValue
 import fr.sncf.osrd.envelope_sim.pipelines.SimStop
@@ -19,15 +20,20 @@ import fr.sncf.osrd.stdcm.graph.build
 import fr.sncf.osrd.stdcm.infra_exploration.ExplorerStep
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
-import kotlin.collections.first
+import kotlin.math.min
+import kotlin.math.max
 
 /**
  * Used to compute block MaxSpeedEnvelopes and min time required to reach a point, with proper
  * caching.
  *
- * TODO: this ignores speed limits by route for now. It makes caching a lot less efficient though
+ * TODO: this ignores speed limits by route for now. It would make caching a lot less efficient though
  *   (can't just use block as key), it will have a significant performance cost. Should be supported
  *   once we import them, but not necessarily before that.
+ * TODO: rare/unlikely cases could lead to pessimistic evaluation (which could lead to A* providing a solution different from optimum). Both cases could happen on the same block or different blocks.
+ *   - If the path used for heuristic crosses the same stop multiple times (different OP parts) then we're applying the stop each time while the real simulation will only stop once.
+ *   - Same goes on the order of stops if crossing stop places in the wrong order for heuristic, we're applying too much stops and wrongly slowing down the heuristic.
+ *   /!\ Working on this requires benchmarking and evaluating possible bugs, the amount of work, technical debt.
  */
 data class CachedBlockMaxSpeedEnvBuilder(
     private val rawInfra: RawInfra,
@@ -41,8 +47,14 @@ data class CachedBlockMaxSpeedEnvBuilder(
         TemporarySpeedLimitManager(),
     private val addRollingStockLength: Boolean = true,
 ) {
-    private val maxSpeedEnvCache = mutableMapOf<BlockId, Envelope>()
+    private val maxSpeedEnvCache = mutableMapOf<CachedBlock, Envelope>()
+    private val mrspEnvCache = mutableMapOf<BlockId, CachedMrsp>()
     private val blockToStopMap = mutableMapOf<BlockId, MutableList<Offset<Block>>>()
+    private val blockToMaxSpeedMap = mutableMapOf<BlockId, Double>()
+
+    private data class CachedBlock(val block: BlockId, val endSpeed: Double?)
+
+    private data class CachedMrsp(val mrsp: Envelope, val context: EnvelopeSimContext)
 
     init {
         for (stop in steps.filter { it.stop }) {
@@ -53,35 +65,49 @@ data class CachedBlockMaxSpeedEnvBuilder(
                     blockToLocationMap[location.edge] = location.offset
             }
             blockToLocationMap.forEach { (block, stopOffset) ->
-                blockToStopMap.getOrPut(block) { mutableListOf<Offset<Block>>() }.add(stopOffset)
+                blockToStopMap.getOrPut(block) { mutableListOf() }.add(stopOffset)
             }
         }
     }
 
     /** Returns the max speed envelope/mrsp for the given block (cached). */
-    fun getMaxSpeedEnvelope(block: BlockId, endSpeed: Double? = null): Envelope {
-        return maxSpeedEnvCache.computeIfAbsent(block) {
-            // TODO: change input to infra explorers, and fetch last route there
-            val pathProps = buildTrainPathFromBlock(rawInfra, blockInfra, block, routes = listOf())
-            val mrsp =
-                computeMRSP(
-                    pathProps,
-                    rollingStock.maxSpeed,
-                    rollingStock.length,
-                    addRollingStockLength = addRollingStockLength,
-                    speedLimitTag,
-                    temporarySpeedLimitManager,
-                )
-            val context = build(rollingStock, pathProps, timeStep, comfort)
+    fun getMaxSpeedEnvelope(block: BlockId, endSpeed: Double?): Envelope {
+        if (endSpeed == null && blockToMaxSpeedMap.containsKey(block)) {
+            // Return fastest block envelope by maximising its end speed.
+            return maxSpeedEnvCache[CachedBlock(block, blockToMaxSpeedMap[block])]!!
+        }
+        val cachedMrsp =
+            mrspEnvCache.computeIfAbsent(block) {
+                // TODO: change input to infra explorers, and fetch last route there
+                val pathProps =
+                    buildTrainPathFromBlock(rawInfra, blockInfra, block, routes = listOf())
+                val context = build(rollingStock, pathProps, timeStep, comfort)
+                val mrsp =
+                    computeMRSP(
+                        pathProps,
+                        rollingStock.maxSpeed,
+                        rollingStock.length,
+                        addRollingStockLength = addRollingStockLength,
+                        speedLimitTag,
+                        temporarySpeedLimitManager,
+                    )
+                CachedMrsp(mrsp, context)
+            }
+        val actualEndSpeed = min(cachedMrsp.mrsp.endSpeed, endSpeed ?: Double.POSITIVE_INFINITY)
+        blockToMaxSpeedMap.compute(block) { _, oldSpeed ->
+            max(actualEndSpeed, oldSpeed ?: Double.NEGATIVE_INFINITY)
+        }
+        return maxSpeedEnvCache.computeIfAbsent(CachedBlock(block, actualEndSpeed)) {
             val stops =
                 blockToStopMap[block]?.map {
                     SimStop(Offset(it.distance), RJSTrainStop.RJSReceptionSignal.SHORT_SLIP_STOP)
                 } ?: listOf()
             val newMrsp =
-                if (endSpeed != null && endSpeed < mrsp.endSpeed)
-                    addEndBrakingPart(context, endSpeed, mrsp)
-                else mrsp
-            maxSpeedEnvelopeFrom(context, stops, newMrsp)
+                if (actualEndSpeed < cachedMrsp.mrsp.endSpeed)
+                    addEndBrakingPart(cachedMrsp.context, actualEndSpeed, cachedMrsp.mrsp)
+                else cachedMrsp.mrsp
+            // TODO: Look into adding accelerations to the max speed envelope and benchmark it to see if it improves the computing time.
+            maxSpeedEnvelopeFrom(cachedMrsp.context, stops, newMrsp)
         }
     }
 
@@ -89,13 +115,13 @@ data class CachedBlockMaxSpeedEnvBuilder(
     fun getBlockTime(
         block: BlockId,
         endOffset: Offset<Block>?,
+        endSpeed: Double?,
         allowanceValue: AllowanceValue? = null,
-        endSpeed: Double? = null,
     ): Double {
         if (endOffset?.distance == 0.meters) return 0.0
         val actualLength = endOffset ?: blockInfra.getBlockLength(block)
-        val maxSpeedEnvelope = getMaxSpeedEnvelope(block, endSpeed)
-        val time = maxSpeedEnvelope.interpolateArrivalAtClamp(actualLength.meters)
+        val time =
+            getMaxSpeedEnvelope(block, endSpeed).interpolateArrivalAtClamp(actualLength.meters)
         val allowanceTime = allowanceValue?.getAllowanceTime(time, actualLength.meters)
         return time + (allowanceTime ?: 0.0)
     }

--- a/core/src/main/kotlin/fr/sncf/osrd/utils/CachedBlockMaxSpeedEnvBuilder.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/utils/CachedBlockMaxSpeedEnvBuilder.kt
@@ -1,0 +1,106 @@
+package fr.sncf.osrd.utils
+
+import fr.sncf.osrd.envelope.Envelope
+import fr.sncf.osrd.envelope_sim.PhysicsRollingStock
+import fr.sncf.osrd.envelope_sim.allowances.AllowanceValue
+import fr.sncf.osrd.envelope_sim.pipelines.SimStop
+import fr.sncf.osrd.envelope_sim.pipelines.maxSpeedEnvelopeFrom
+import fr.sncf.osrd.envelope_sim_infra.computeMRSP
+import fr.sncf.osrd.path.implementations.buildTrainPathFromBlock
+import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
+import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop
+import fr.sncf.osrd.sim_infra.api.Block
+import fr.sncf.osrd.sim_infra.api.BlockId
+import fr.sncf.osrd.sim_infra.api.BlockInfra
+import fr.sncf.osrd.sim_infra.api.RawInfra
+import fr.sncf.osrd.sim_infra.impl.TemporarySpeedLimitManager
+import fr.sncf.osrd.stdcm.graph.addEndBrakingPart
+import fr.sncf.osrd.stdcm.graph.build
+import fr.sncf.osrd.stdcm.infra_exploration.ExplorerStep
+import fr.sncf.osrd.utils.units.Offset
+import fr.sncf.osrd.utils.units.meters
+import kotlin.collections.first
+
+/**
+ * Used to compute block MaxSpeedEnvelopes and min time required to reach a point, with proper
+ * caching.
+ *
+ * TODO: this ignores speed limits by route for now. It makes caching a lot less efficient though
+ *   (can't just use block as key), it will have a significant performance cost. Should be supported
+ *   once we import them, but not necessarily before that.
+ */
+data class CachedBlockMaxSpeedEnvBuilder(
+    private val rawInfra: RawInfra,
+    private val blockInfra: BlockInfra,
+    private val rollingStock: PhysicsRollingStock,
+    private val steps: List<ExplorerStep>,
+    private val timeStep: Double,
+    private val comfort: Comfort? = null,
+    private val speedLimitTag: String? = null,
+    private val temporarySpeedLimitManager: TemporarySpeedLimitManager =
+        TemporarySpeedLimitManager(),
+    private val addRollingStockLength: Boolean = true,
+) {
+    private val maxSpeedEnvCache = mutableMapOf<BlockId, Envelope>()
+    private val blockToStopMap = mutableMapOf<BlockId, MutableList<Offset<Block>>>()
+
+    init {
+        for (stop in steps.filter { it.stop }) {
+            val blockToLocationMap = mutableMapOf<BlockId, Offset<Block>>()
+            for (location in stop.locations) {
+                val currentOffset = blockToLocationMap.getOrPut(location.edge) { location.offset }
+                if (location.offset < currentOffset)
+                    blockToLocationMap[location.edge] = location.offset
+            }
+            blockToLocationMap.forEach { (block, stopOffset) ->
+                blockToStopMap.getOrPut(block) { mutableListOf<Offset<Block>>() }.add(stopOffset)
+            }
+        }
+    }
+
+    /** Returns the max speed envelope/mrsp for the given block (cached). */
+    fun getMaxSpeedEnvelope(block: BlockId, endSpeed: Double? = null): Envelope {
+        return maxSpeedEnvCache.computeIfAbsent(block) {
+            // TODO: change input to infra explorers, and fetch last route there
+            val pathProps = buildTrainPathFromBlock(rawInfra, blockInfra, block, routes = listOf())
+            val mrsp =
+                computeMRSP(
+                    pathProps,
+                    rollingStock.maxSpeed,
+                    rollingStock.length,
+                    addRollingStockLength = addRollingStockLength,
+                    speedLimitTag,
+                    temporarySpeedLimitManager,
+                )
+            val context = build(rollingStock, pathProps, timeStep, comfort)
+            val stops =
+                blockToStopMap[block]?.map {
+                    SimStop(Offset(it.distance), RJSTrainStop.RJSReceptionSignal.SHORT_SLIP_STOP)
+                } ?: listOf()
+            val newMrsp =
+                if (endSpeed != null && endSpeed < mrsp.endSpeed)
+                    addEndBrakingPart(context, endSpeed, mrsp)
+                else mrsp
+            maxSpeedEnvelopeFrom(context, stops, newMrsp)
+        }
+    }
+
+    /** Returns the time it takes to go through the given block, until `endOffset` if specified. */
+    fun getBlockTime(
+        block: BlockId,
+        endOffset: Offset<Block>?,
+        allowanceValue: AllowanceValue? = null,
+        endSpeed: Double? = null,
+    ): Double {
+        if (endOffset?.distance == 0.meters) return 0.0
+        val actualLength = endOffset ?: blockInfra.getBlockLength(block)
+        val maxSpeedEnvelope = getMaxSpeedEnvelope(block, endSpeed)
+        val time = maxSpeedEnvelope.interpolateArrivalAtClamp(actualLength.meters)
+        val allowanceTime = allowanceValue?.getAllowanceTime(time, actualLength.meters)
+        return time + (allowanceTime ?: 0.0)
+    }
+
+    fun isStopAtStartOfBlock(block: BlockId): Boolean {
+        return blockToStopMap[block]?.first() == Offset.zero<Block>()
+    }
+}

--- a/core/src/test/java/fr/sncf/osrd/train/TestRollingStock.kt
+++ b/core/src/test/java/fr/sncf/osrd/train/TestRollingStock.kt
@@ -5,11 +5,11 @@ import com.google.common.collect.Lists
 import com.google.common.collect.Range
 import com.google.common.collect.RangeMap
 import fr.sncf.osrd.envelope_sim.EnvelopeSimPathBuilder
+import fr.sncf.osrd.envelope_sim.PhysicsRollingStock.InfraConditions
 import fr.sncf.osrd.envelope_sim.PhysicsRollingStock.TractiveEffortPoint
 import fr.sncf.osrd.path.interfaces.Electrification
 import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
-import fr.sncf.osrd.train.RollingStock.InfraConditions
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/BacktrackingTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/BacktrackingTests.kt
@@ -27,7 +27,6 @@ class BacktrackingTests {
         val block = infra.addBlock("a", "b", 1000.meters)
         val firstBlockEnvelope =
             simulateBlock(
-                infra,
                 infraExplorerFromBlock(infra, infra, block),
                 0.0,
                 Offset(0.meters),
@@ -70,7 +69,6 @@ class BacktrackingTests {
         val lastBlock = infra.addBlock("d", "e", 10.meters)
         val firstBlockEnvelope =
             simulateBlock(
-                infra,
                 infraExplorerFromBlock(infra, infra, firstBlock),
                 0.0,
                 Offset(0.meters),
@@ -111,7 +109,6 @@ class BacktrackingTests {
         val secondBlock = infra.addBlock("b", "c", 100.meters, 5.0)
         val firstBlockEnvelope =
             simulateBlock(
-                infra,
                 infraExplorerFromBlock(infra, infra, firstBlock),
                 0.0,
                 Offset(0.meters),

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/DepartureTimeShiftTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/DepartureTimeShiftTests.kt
@@ -167,7 +167,6 @@ class DepartureTimeShiftTests {
         val secondBlock = infra.addBlock("b", "c")
         val firstBlockEnvelope =
             simulateBlock(
-                infra,
                 infraExplorerFromBlock(infra, infra, firstBlock),
                 0.0,
                 Offset(0.meters),

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/EngineeringAllowanceTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/EngineeringAllowanceTests.kt
@@ -40,7 +40,6 @@ class EngineeringAllowanceTests {
         val thirdBlock = infra.addBlock("c", "d", 100.meters, 30.0)
         val firstBlockEnvelope =
             simulateBlock(
-                infra,
                 infraExplorerFromBlock(infra, infra, firstBlock),
                 0.0,
                 Offset(0.meters),
@@ -53,7 +52,6 @@ class EngineeringAllowanceTests {
             )!!
         val secondBlockEnvelope =
             simulateBlock(
-                infra,
                 infraExplorerFromBlock(infra, infra, secondBlock),
                 firstBlockEnvelope.endSpeed,
                 Offset(0.meters),
@@ -122,7 +120,6 @@ class EngineeringAllowanceTests {
         val lastBlock = infra.addBlock("e", "f", 1000.meters, 20.0)
         val firstBlockEnvelope =
             simulateBlock(
-                infra,
                 infraExplorerFromBlock(infra, infra, firstBlock),
                 0.0,
                 Offset(0.meters),
@@ -135,7 +132,6 @@ class EngineeringAllowanceTests {
             )!!
         val secondBlockEnvelope =
             simulateBlock(
-                infra,
                 infraExplorerFromBlock(infra, infra, secondBlock),
                 firstBlockEnvelope.endSpeed,
                 Offset(0.meters),
@@ -207,7 +203,6 @@ class EngineeringAllowanceTests {
         val lastBlock = infra.addBlock("e", "f", 1000.meters, 20.0)
         val firstBlockEnvelope =
             simulateBlock(
-                infra,
                 infraExplorerFromBlock(infra, infra, firstBlock),
                 0.0,
                 Offset(0.meters),
@@ -220,7 +215,6 @@ class EngineeringAllowanceTests {
             )!!
         val secondBlockEnvelope =
             simulateBlock(
-                infra,
                 infraExplorerFromBlock(infra, infra, secondBlock),
                 firstBlockEnvelope.endSpeed,
                 Offset(0.meters),
@@ -637,7 +631,6 @@ class EngineeringAllowanceTests {
         val thirdBlock = infra.addBlock("c", "d", 100.meters, 0.5)
         val firstBlockEnvelope =
             simulateBlock(
-                infra,
                 infraExplorerFromBlock(infra, infra, firstBlock),
                 0.0,
                 Offset(0.meters),
@@ -650,7 +643,6 @@ class EngineeringAllowanceTests {
             )!!
         val secondBlockEnvelope =
             simulateBlock(
-                infra,
                 infraExplorerFromBlock(infra, infra, secondBlock),
                 firstBlockEnvelope.endSpeed,
                 Offset(0.meters),

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMHelpers.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMHelpers.kt
@@ -30,7 +30,6 @@ fun getBlocksRunTime(infra: FullInfra, blocks: List<BlockId>): Double {
     for (block in blocks) {
         val envelope =
             simulateBlock(
-                infra.rawInfra,
                 infraExplorerFromBlock(infra.rawInfra, infra.blockInfra, block),
                 speed,
                 Offset(0.meters),
@@ -49,7 +48,6 @@ fun getBlocksRunTime(infra: FullInfra, blocks: List<BlockId>): Double {
 
 /** Helper function to call `simulateBlock` without instantiating an `STDCMSimulations` */
 fun simulateBlock(
-    rawInfra: RawSignalingInfra,
     infraExplorer: InfraExplorer,
     initialSpeed: Double,
     start: Offset<Block>,
@@ -63,7 +61,6 @@ fun simulateBlock(
     val sim = STDCMSimulations()
     val res =
         sim.simulateBlock(
-            rawInfra,
             infraExplorer,
             initialSpeed,
             start,

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/VisitedNodesTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/VisitedNodesTests.kt
@@ -5,7 +5,6 @@ import fr.sncf.osrd.stdcm.graph.StopTimeData
 import fr.sncf.osrd.stdcm.graph.TimeData
 import fr.sncf.osrd.stdcm.graph.visited_node_tracking.VisitedNodes
 import fr.sncf.osrd.stdcm.infra_exploration.EdgeIdentifier
-import fr.sncf.osrd.utils.CachedBlockMaxSpeedEnvBuilder
 import fr.sncf.osrd.utils.DummyInfra
 import fr.sncf.osrd.utils.units.meters
 import kotlin.test.assertEquals

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/VisitedNodesTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/VisitedNodesTests.kt
@@ -1,10 +1,11 @@
 package fr.sncf.osrd.stdcm
 
+import fr.sncf.osrd.envelope_sim.SimpleRollingStock.Companion.STANDARD_TRAIN
 import fr.sncf.osrd.stdcm.graph.StopTimeData
 import fr.sncf.osrd.stdcm.graph.TimeData
 import fr.sncf.osrd.stdcm.graph.visited_node_tracking.VisitedNodes
 import fr.sncf.osrd.stdcm.infra_exploration.EdgeIdentifier
-import fr.sncf.osrd.utils.CachedBlockMRSPBuilder
+import fr.sncf.osrd.utils.CachedBlockMaxSpeedEnvBuilder
 import fr.sncf.osrd.utils.DummyInfra
 import fr.sncf.osrd.utils.units.meters
 import kotlin.test.assertEquals
@@ -294,7 +295,11 @@ class VisitedNodesTests {
                 infra.addBlock("d", "e"),
             )
         val visitedNodes =
-            VisitedNodes(0.0, infra.fullInfra(), CachedBlockMRSPBuilder(infra, infra, null))
+            VisitedNodes(
+                0.0,
+                infra.fullInfra(),
+                CachedBlockMaxSpeedEnvBuilder(infra, infra, STANDARD_TRAIN, listOf(), 2.0),
+            )
 
         // d -> e
         val lastExplorer = infraExplorerFromBlock(infra, infra, blocks.last())

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
@@ -16,7 +16,7 @@ import fr.sncf.osrd.stdcm.infra_exploration.ExplorerStep
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorer
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelopeImpl
 import fr.sncf.osrd.stdcm.infra_exploration.initInfraExplorers
-import fr.sncf.osrd.utils.CachedBlockMRSPBuilder
+import fr.sncf.osrd.utils.CachedBlockMaxSpeedEnvBuilder
 import fr.sncf.osrd.utils.DummyInfra
 import fr.sncf.osrd.utils.appendOnlyLinkedListOf
 import fr.sncf.osrd.utils.units.Distance
@@ -48,8 +48,8 @@ class STDCMHeuristicTests {
             listOf(
                 ExplorerStep(listOf(BlockLocation(blocks[0], Offset(50.meters))), null, false),
                 ExplorerStep(listOf(BlockLocation(blocks[1], Offset(25.meters))), null, false),
-                ExplorerStep(listOf(BlockLocation(blocks[1], Offset(75.meters))), null, false),
-                ExplorerStep(listOf(BlockLocation(blocks[2], Offset(0.meters))), null, false),
+                ExplorerStep(listOf(BlockLocation(blocks[1], Offset(75.meters))), null, true),
+                ExplorerStep(listOf(BlockLocation(blocks[2], Offset(0.meters))), null, true),
                 ExplorerStep(listOf(BlockLocation(blocks[3], Offset(100.meters))), 1.0, true),
             )
 
@@ -59,7 +59,8 @@ class STDCMHeuristicTests {
                     infra,
                     steps,
                     Double.POSITIVE_INFINITY,
-                    mrspBuilder = CachedBlockMRSPBuilder(infra, infra, null),
+                    maxSpeedEnvBuilder =
+                        CachedBlockMaxSpeedEnvBuilder(infra, infra, STANDARD_TRAIN, steps, 2.0),
                     allowance = null,
                 )
                 .build()
@@ -68,24 +69,41 @@ class STDCMHeuristicTests {
         var explorer =
             initInfraExplorers(infra, infra, steps.first().locations.first(), steps).single()
 
-        assertEquals(400.0 - 50.0, getLocationRemainingTime(infra, explorer, 50.meters, heuristic))
-        assertEquals(400.0 - 85.0, getLocationRemainingTime(infra, explorer, 85.meters, heuristic))
+        // Heuristic takes into account decelerations: decelerations add 1s to remaining time,
+        // because the train decelerates on 1m and takes 2s instead of 1s at constant speed.
+        val stopDelta = 1
+
+        // InfraExplorer is at start: 3 stop decelerations to take into account.
+        assertEquals(
+            400.0 - 50.0 + 3 * stopDelta,
+            getLocationRemainingTime(infra, explorer, 50.meters, heuristic),
+        )
+        assertEquals(
+            400.0 - 85.0 + 3 * stopDelta,
+            getLocationRemainingTime(infra, explorer, 85.meters, heuristic),
+        )
 
         // Current block = 1
         explorer = explorer.cloneAndExtendLookahead().single().moveForward()
+        // 3 stop decelerations to take into account
         assertEquals(
-            400.0 - 100.0 - 25.0,
+            400.0 - 100.0 - 25.0 + 3 * stopDelta,
             getLocationRemainingTime(infra, explorer, 25.meters, heuristic),
         )
+        // 2 stop deceleration to take into account
         assertEquals(
-            400.0 - 100.0 - 75.0,
+            400.0 - 100.0 - 75.0 + 2 * stopDelta,
             getLocationRemainingTime(infra, explorer, 75.meters, heuristic),
         )
 
-        // Current block = 2
+        // Current block = 2: 1 stop deceleration to take into account
         explorer = explorer.cloneAndExtendLookahead().single().moveForward()
-        assertEquals(400.0 - 200.0, getLocationRemainingTime(infra, explorer, 0.meters, heuristic))
+        assertEquals(
+            400.0 - 200.0 + stopDelta,
+            getLocationRemainingTime(infra, explorer, 0.meters, heuristic),
+        )
 
+        // Destination reached
         explorer = explorer.cloneAndExtendLookahead().single().moveForward()
         assertEquals(0.0, getLocationRemainingTime(infra, explorer, null, heuristic))
     }
@@ -114,7 +132,8 @@ class STDCMHeuristicTests {
                     infra,
                     steps,
                     Double.POSITIVE_INFINITY,
-                    mrspBuilder = CachedBlockMRSPBuilder(infra, infra, null),
+                    maxSpeedEnvBuilder =
+                        CachedBlockMaxSpeedEnvBuilder(infra, infra, STANDARD_TRAIN, steps, 2.0),
                     allowance = AllowanceValue.Percentage(100.0),
                 )
                 .build()
@@ -124,7 +143,8 @@ class STDCMHeuristicTests {
                     infra,
                     steps,
                     Double.POSITIVE_INFINITY,
-                    mrspBuilder = CachedBlockMRSPBuilder(infra, infra, null),
+                    maxSpeedEnvBuilder =
+                        CachedBlockMaxSpeedEnvBuilder(infra, infra, STANDARD_TRAIN, steps, 2.0),
                     allowance = null,
                 )
                 .build()
@@ -175,7 +195,8 @@ class STDCMHeuristicTests {
                     infra,
                     steps,
                     Double.POSITIVE_INFINITY,
-                    mrspBuilder = CachedBlockMRSPBuilder(infra, infra, null),
+                    maxSpeedEnvBuilder =
+                        CachedBlockMaxSpeedEnvBuilder(infra, infra, STANDARD_TRAIN, steps, 2.0),
                     allowance = null,
                 )
                 .build()
@@ -183,6 +204,9 @@ class STDCMHeuristicTests {
         var explorer =
             initInfraExplorers(infra, infra, steps.first().locations.first(), steps).single()
 
+        // Heuristic takes into account decelerations: decelerations add 1s to remaining time,
+        // because the train decelerates on 1m and takes 2s instead of 1s at constant speed.
+        val stopDelta = 1
         repeat(blocks.size - 1) {
             explorer =
                 explorer.cloneAndExtendLookahead().single { candidate ->
@@ -191,7 +215,7 @@ class STDCMHeuristicTests {
 
             // While the lookahead is on the right path, the remaining distance shouldn't change
             assertEquals(
-                400.0 - 50.0 - 50.0,
+                400.0 - 50.0 - 50.0 + stopDelta,
                 getLocationRemainingTime(infra, explorer, 50.meters, heuristics),
             )
         }

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
@@ -7,6 +7,7 @@ import fr.sncf.osrd.envelope.EnvelopeTestUtils
 import fr.sncf.osrd.envelope_sim.SimpleRollingStock.Companion.STANDARD_TRAIN
 import fr.sncf.osrd.envelope_sim.allowances.AllowanceValue
 import fr.sncf.osrd.pathfinding.BlockLocation
+import fr.sncf.osrd.stdcm.CachedBlockMaxSpeedEnvBuilder
 import fr.sncf.osrd.stdcm.STDCMAStarHeuristic
 import fr.sncf.osrd.stdcm.STDCMHeuristicBuilder
 import fr.sncf.osrd.stdcm.graph.STDCMEdge
@@ -16,7 +17,6 @@ import fr.sncf.osrd.stdcm.infra_exploration.ExplorerStep
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorer
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelopeImpl
 import fr.sncf.osrd.stdcm.infra_exploration.initInfraExplorers
-import fr.sncf.osrd.utils.CachedBlockMaxSpeedEnvBuilder
 import fr.sncf.osrd.utils.DummyInfra
 import fr.sncf.osrd.utils.appendOnlyLinkedListOf
 import fr.sncf.osrd.utils.units.Distance


### PR DESCRIPTION
Fixes #14492. This is the first part: consider decelerations by using MaxSpeedEnvelope instead of MRSP in STDCM heuristic.

Next part is to use this in `STDCMSimulations`.

Benchmark: reduces a little computing times all over, but the main difference is a reduce of 5% computation time for the requests which are close to time-outing (193s -> 182s):
| | time_old | result_time_old | time_new | result_time_new | time_diff |
|---|---|---|---|---|---|
| count | 12.000000 | 12.000000 | 12.000000 | 12.000000 | 12.000000 |
| mean | 43.917333 | 49513.261440 | 42.730625 | 49513.297210 | -1.186708 |
| std | 54.558683 | 23457.432424 | 51.675101 | 23457.435444 | 3.424046 |
| min | 2.289500 | 17699.761029 | 1.847000 | 17699.761029 | -10.650800 |
| 25% | 13.030275 | 31496.745417 | 13.189925 | 31496.745417 | -1.823650 |
| 50% | 23.097750 | 50661.284064 | 22.482400 | 50661.283528 | -0.615350 |
| 75% | 43.977975 | 60651.998599 | 45.392175 | 60651.990844 | 0.423825 |
| max | 193.217100 | 100938.257720 | 182.566300 | 100938.223135 | 3.062000 |

Benchmark memory: average of 10% increase:
| | mb_old | mb_new | mb_diff |
|---|---|---|---|
| count | 12.000000 | 12.000000 | 12.000000 |
| mean | 4523.050000 | 4930.083333 | 407.033333 |
| std | 1362.736983 | 1157.889604 | 806.121729 |
| min | 1595.700000 | 3102.200000 | -943.100000 |
| 25% | 3615.750000 | 3891.950000 | -92.300000 |
| 50% | 4649.550000 | 5090.700000 | 346.500000 |
| 75% | 5503.825000 | 5790.725000 | 694.150000 |
| max | 6357.500000 | 6504.000000 | 2335.800000 |