### PR TITLE
core: stdcm: fix two possible causes for mismatches

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/train/RollingStock.java
+++ b/core/src/main/java/fr/sncf/osrd/train/RollingStock.java
@@ -13,6 +13,8 @@ import fr.sncf.osrd.path.legacy_objects.electrification.Neutral;
 import fr.sncf.osrd.path.legacy_objects.electrification.NonElectrified;
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort;
 import fr.sncf.osrd.railjson.schema.rollingstock.RJSLoadingGaugeType;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -131,7 +133,11 @@ public final class RollingStock implements PhysicsRollingStock {
     public record ModeEffortCurves(
             boolean isElectric, TractiveEffortPoint[] defaultCurve, ConditionalEffortCurve[] curves) {}
 
-    public record ConditionalEffortCurve(EffortCurveConditions cond, TractiveEffortPoint[] curve) {}
+    public record ConditionalEffortCurve(EffortCurveConditions cond, TractiveEffortPoint[] curve) {
+        public ConditionalEffortCurve scale(double lambda) {
+            return new ConditionalEffortCurve(cond, scaleCurve(curve, lambda));
+        }
+    }
 
     public record EffortCurveConditions(Comfort comfort, String electricalProfile, String powerRestriction) {
         /**
@@ -265,6 +271,44 @@ public final class RollingStock implements PhysicsRollingStock {
     /** Return whether this rolling stock's has an electric mode */
     public boolean isElectric() {
         return modes.values().stream().anyMatch(ModeEffortCurves::isElectric);
+    }
+
+    static TractiveEffortPoint[] scaleCurve(TractiveEffortPoint[] old, double lambda) {
+        return Arrays.stream(old)
+                .map(x -> new TractiveEffortPoint(x.speed(), x.maxEffort() * lambda))
+                .toArray(TractiveEffortPoint[]::new);
+    }
+
+    public RollingStock scalePower(double lambda) {
+        if (lambda == 1.0) return this;
+        var newModes = new HashMap<>(modes);
+        for (var entry : newModes.entrySet()) {
+            var value = entry.getValue();
+
+            entry.setValue(new ModeEffortCurves(
+                    value.isElectric,
+                    scaleCurve(value.defaultCurve, lambda),
+                    Arrays.stream(value.curves).map(x -> x.scale(lambda)).toArray(ConditionalEffortCurve[]::new)));
+        }
+        return new RollingStock(
+                id,
+                length,
+                mass,
+                inertiaCoefficient,
+                A,
+                B,
+                C,
+                maxSpeed,
+                startUpTime,
+                startUpAcceleration,
+                comfortAcceleration,
+                constGamma,
+                etcsBrakeParams,
+                loadingGaugeType,
+                newModes,
+                defaultMode,
+                basePowerClass,
+                supportedSignalingSystems);
     }
 
     /** Creates a new rolling stock (a physical train inventory item). */

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/PostProcessingSimulation.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/PostProcessingSimulation.kt
@@ -18,6 +18,7 @@ import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
 import fr.sncf.osrd.stdcm.preprocessing.interfaces.BlockAvailabilityInterface
 import fr.sncf.osrd.train.RollingStock
 import fr.sncf.osrd.train.TrainStop
+import fr.sncf.osrd.utils.areSpeedsEqual
 import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
@@ -76,6 +77,7 @@ fun buildFinalEnvelope(
     stops: List<TrainStop>,
     updatedTimeData: TimeData,
     isMareco: Boolean = true,
+    attempt: Int = 0,
 ): FinalEnvelopeResult {
     val context = build(rollingStock, envelopeSimPath, timeStep, comfort)
     val fullInfraExplorer = edges.last().infraExplorerWithNewEnvelope
@@ -125,6 +127,7 @@ fun buildFinalEnvelope(
                     conflictOffset,
                     isMareco,
                     allowanceRanges,
+                    attempt,
                 )
             }
             val newPoint =
@@ -480,19 +483,8 @@ private fun handlePostProcessingConflict(
     conflictOffset: Offset<TrainPath>,
     isMareco: Boolean,
     allowanceRanges: List<EngineeringAllowanceRange>,
+    attempt: Int,
 ): FinalEnvelopeResult {
-    postProcessingLogger.error(
-        "Conflicts detected in post-processing, mismatch with the exploration data"
-    )
-    postProcessingLogger.error(
-        "NOTE: look through the logs for allowance issues, they may cause mismatches."
-    )
-    val conflictTime = fixedPoints.first { it.offset == conflictOffset }.time
-    postProcessingLogger.info(
-        "    conflict happened at offset=$conflictOffset/${maxSpeedEnvelope.endPos.toInt()} " +
-            "and t=${conflictTime.toInt()}/${updatedTimeData.timeSinceDeparture.toInt()}"
-    )
-
     if (graph.searchMetadata != null) {
         val stringDebugData by lazy {
             OutputSimDebugData.adapter.toJson(
@@ -513,6 +505,18 @@ private fun handlePostProcessingConflict(
             stringDebugData
         }
     }
+
+    postProcessingLogger.error(
+        "Conflicts detected in post-processing, mismatch with the exploration data"
+    )
+    postProcessingLogger.error(
+        "NOTE: look through the logs for allowance issues, they may cause mismatches."
+    )
+    val conflictTime = fixedPoints.first { it.offset == conflictOffset }.time
+    postProcessingLogger.info(
+        "    conflict happened at offset=$conflictOffset/${maxSpeedEnvelope.endPos.toInt()} " +
+            "and t=${conflictTime.toInt()}/${updatedTimeData.timeSinceDeparture.toInt()}"
+    )
 
     var remainingDistance = conflictOffset.distance
     for ((i, edge) in edges.withIndex()) {
@@ -542,24 +546,39 @@ private fun handlePostProcessingConflict(
         remainingDistance -= edge.length.distance
     }
 
-    if (isMareco) {
+    if (attempt < 5) {
         postProcessingLogger.info(
-            "The error happened with mareco allowances, try to fallback on linear allowances"
+            "attempt $attempt: retrying after adding traction to rolling stock..."
         )
         postProcessingLogger.info("(reset of fixed time points)")
+        // First retry by removing mareco, then by increasing rolling stock traction
+        val scaleFactor = if (isMareco) 1.0 else 1.2
+        val newRollingStock = rollingStock.scalePower(scaleFactor)
+        val newMaxSpeedEnvelope =
+            makeMaxSpeedEnvelope(
+                edges.last().infraExplorer.buildFullPath(graph.rawInfra, graph.blockInfra),
+                stops,
+                newRollingStock,
+                timeStep,
+                comfort,
+                graph.tag,
+                graph.temporarySpeedLimitManager,
+                areSpeedsEqual(0.0, edges.last().endSpeed),
+            )
         return buildFinalEnvelope(
             graph,
-            maxSpeedEnvelope,
+            newMaxSpeedEnvelope,
             edges,
             standardAllowance,
             envelopeSimPath,
-            rollingStock,
+            newRollingStock,
             timeStep,
             comfort,
             blockAvailability,
             stops,
             updatedTimeData,
-            false,
+            isMareco = false,
+            attempt = attempt + 1,
         )
     } else {
         throw RuntimeException(

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/PostProcessingSimulation.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/PostProcessingSimulation.kt
@@ -9,11 +9,17 @@ import fr.sncf.osrd.envelope_sim.allowances.AllowanceRange
 import fr.sncf.osrd.envelope_sim.allowances.AllowanceValue
 import fr.sncf.osrd.envelope_sim.allowances.LinearAllowance
 import fr.sncf.osrd.envelope_sim.allowances.MarecoAllowance
+import fr.sncf.osrd.envelope_sim.pipelines.SimStop
+import fr.sncf.osrd.envelope_sim.pipelines.maxEffortEnvelopeFrom
+import fr.sncf.osrd.envelope_sim.pipelines.maxSpeedEnvelopeFrom
+import fr.sncf.osrd.envelope_sim_infra.computeMRSP
 import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
+import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal.SHORT_SLIP_STOP
 import fr.sncf.osrd.reporting.exceptions.ErrorType
 import fr.sncf.osrd.reporting.exceptions.OSRDError
+import fr.sncf.osrd.sim_infra.impl.TemporarySpeedLimitManager
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
 import fr.sncf.osrd.stdcm.preprocessing.interfaces.BlockAvailabilityInterface
 import fr.sncf.osrd.train.RollingStock
@@ -66,7 +72,6 @@ data class FinalEnvelopeResult(
  */
 fun buildFinalEnvelope(
     graph: STDCMGraph,
-    maxSpeedEnvelope: Envelope,
     edges: List<STDCMEdge>,
     standardAllowance: AllowanceValue?,
     envelopeSimPath: PhysicsPath,
@@ -81,6 +86,17 @@ fun buildFinalEnvelope(
 ): FinalEnvelopeResult {
     val context = build(rollingStock, envelopeSimPath, timeStep, comfort)
     val fullInfraExplorer = edges.last().infraExplorerWithNewEnvelope
+    val maxSpeedEnvelope =
+        makeMaxSpeedEnvelope(
+            fullInfraExplorer.buildFullPath(graph.rawInfra, graph.blockInfra),
+            stops,
+            rollingStock,
+            timeStep,
+            comfort,
+            graph.tag,
+            graph.temporarySpeedLimitManager,
+            areSpeedsEqual(0.0, edges.last().endSpeed),
+        )
 
     val pathLength =
         Length<TrainPath>(Distance(millimeters = edges.sumOf { it.length.distance.millimeters }))
@@ -178,7 +194,6 @@ fun buildFinalEnvelope(
         )
         return buildFinalEnvelope(
             graph,
-            maxSpeedEnvelope,
             edges,
             standardAllowance,
             envelopeSimPath,
@@ -554,20 +569,8 @@ private fun handlePostProcessingConflict(
         // First retry by removing mareco, then by increasing rolling stock traction
         val scaleFactor = if (isMareco) 1.0 else 1.2
         val newRollingStock = rollingStock.scalePower(scaleFactor)
-        val newMaxSpeedEnvelope =
-            makeMaxSpeedEnvelope(
-                edges.last().infraExplorer.buildFullPath(graph.rawInfra, graph.blockInfra),
-                stops,
-                newRollingStock,
-                timeStep,
-                comfort,
-                graph.tag,
-                graph.temporarySpeedLimitManager,
-                areSpeedsEqual(0.0, edges.last().endSpeed),
-            )
         return buildFinalEnvelope(
             graph,
-            newMaxSpeedEnvelope,
             edges,
             standardAllowance,
             envelopeSimPath,
@@ -586,4 +589,23 @@ private fun handlePostProcessingConflict(
                 "mismatch between exploration and postprocessing (please open a bug report)"
         )
     }
+}
+
+fun makeMaxSpeedEnvelope(
+    trainPath: TrainPath,
+    stops: List<TrainStop>,
+    rollingStock: RollingStock,
+    timeStep: Double,
+    comfort: Comfort?,
+    trainTag: String?,
+    temporarySpeedLimitManager: TemporarySpeedLimitManager?,
+    stopAtEnd: Boolean,
+): Envelope {
+    val context = build(rollingStock, trainPath, timeStep, comfort)
+    val mrsp = computeMRSP(trainPath, rollingStock, false, trainTag, temporarySpeedLimitManager)
+    val stopInfos =
+        stops.map { SimStop(Offset(it.position.meters), it.receptionSignal) }.toMutableList()
+    if (stopAtEnd) stopInfos.add(SimStop(trainPath.getLength(), SHORT_SLIP_STOP))
+    val maxSpeedEnvelope = maxSpeedEnvelopeFrom(context, stopInfos, mrsp)
+    return maxEffortEnvelopeFrom(context, 0.0, maxSpeedEnvelope)
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
@@ -1,12 +1,7 @@
 package fr.sncf.osrd.stdcm.graph
 
 import fr.sncf.osrd.api.FullInfra
-import fr.sncf.osrd.envelope.Envelope
 import fr.sncf.osrd.envelope_sim.allowances.AllowanceValue
-import fr.sncf.osrd.envelope_sim.pipelines.SimStop
-import fr.sncf.osrd.envelope_sim.pipelines.maxEffortEnvelopeFrom
-import fr.sncf.osrd.envelope_sim.pipelines.maxSpeedEnvelopeFrom
-import fr.sncf.osrd.envelope_sim_infra.computeMRSP
 import fr.sncf.osrd.path.implementations.buildTrainPathFromBlockRanges
 import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
@@ -18,9 +13,7 @@ import fr.sncf.osrd.stdcm.preprocessing.interfaces.BlockAvailabilityInterface
 import fr.sncf.osrd.train.RollingStock
 import fr.sncf.osrd.train.TrainStop
 import fr.sncf.osrd.utils.arePositionsEqual
-import fr.sncf.osrd.utils.areSpeedsEqual
 import fr.sncf.osrd.utils.isTimeStrictlyPositive
-import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.annotations.WithSpan
@@ -63,21 +56,9 @@ class STDCMPostProcessing(private val graph: STDCMGraph) {
 
         val updatedTimeData = computeTimeData(edges)
         val stops = makeStops(edges, updatedTimeData)
-        val maxSpeedEnvelope =
-            makeMaxSpeedEnvelope(
-                trainPath,
-                stops,
-                rollingStock,
-                timeStep,
-                comfort,
-                trainTag,
-                temporarySpeedLimitManager,
-                areSpeedsEqual(0.0, edges.last().endSpeed),
-            )
         val withAllowance =
             buildFinalEnvelope(
                 graph,
-                maxSpeedEnvelope,
                 edges,
                 standardAllowance,
                 trainPath,
@@ -241,23 +222,4 @@ class STDCMPostProcessing(private val graph: STDCMGraph) {
         mutStops.addAll(makeOpStops(trainPath))
         return sortAndMergeStopsDuplicates(mutStops)
     }
-}
-
-fun makeMaxSpeedEnvelope(
-    trainPath: TrainPath,
-    stops: List<TrainStop>,
-    rollingStock: RollingStock,
-    timeStep: Double,
-    comfort: Comfort?,
-    trainTag: String?,
-    temporarySpeedLimitManager: TemporarySpeedLimitManager?,
-    stopAtEnd: Boolean,
-): Envelope {
-    val context = build(rollingStock, trainPath, timeStep, comfort)
-    val mrsp = computeMRSP(trainPath, rollingStock, false, trainTag, temporarySpeedLimitManager)
-    val stopInfos =
-        stops.map { SimStop(Offset(it.position.meters), it.receptionSignal) }.toMutableList()
-    if (stopAtEnd) stopInfos.add(SimStop(trainPath.getLength(), SHORT_SLIP_STOP))
-    val maxSpeedEnvelope = maxSpeedEnvelopeFrom(context, stopInfos, mrsp)
-    return maxEffortEnvelopeFrom(context, 0.0, maxSpeedEnvelope)
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
@@ -108,25 +108,6 @@ class STDCMPostProcessing(private val graph: STDCMGraph) {
         } else res
     }
 
-    private fun makeMaxSpeedEnvelope(
-        trainPath: TrainPath,
-        stops: List<TrainStop>,
-        rollingStock: RollingStock,
-        timeStep: Double,
-        comfort: Comfort?,
-        trainTag: String?,
-        temporarySpeedLimitManager: TemporarySpeedLimitManager?,
-        stopAtEnd: Boolean,
-    ): Envelope {
-        val context = build(rollingStock, trainPath, timeStep, comfort)
-        val mrsp = computeMRSP(trainPath, rollingStock, false, trainTag, temporarySpeedLimitManager)
-        val stopInfos =
-            stops.map { SimStop(Offset(it.position.meters), it.receptionSignal) }.toMutableList()
-        if (stopAtEnd) stopInfos.add(SimStop(trainPath.getLength(), SHORT_SLIP_STOP))
-        val maxSpeedEnvelope = maxSpeedEnvelopeFrom(context, stopInfos, mrsp)
-        return maxEffortEnvelopeFrom(context, 0.0, maxSpeedEnvelope)
-    }
-
     /**
      * Compute the final TimeData to be used as reference. The main things we're looking for are the
      * train departure time and the duration of each stop.
@@ -260,4 +241,23 @@ class STDCMPostProcessing(private val graph: STDCMGraph) {
         mutStops.addAll(makeOpStops(trainPath))
         return sortAndMergeStopsDuplicates(mutStops)
     }
+}
+
+fun makeMaxSpeedEnvelope(
+    trainPath: TrainPath,
+    stops: List<TrainStop>,
+    rollingStock: RollingStock,
+    timeStep: Double,
+    comfort: Comfort?,
+    trainTag: String?,
+    temporarySpeedLimitManager: TemporarySpeedLimitManager?,
+    stopAtEnd: Boolean,
+): Envelope {
+    val context = build(rollingStock, trainPath, timeStep, comfort)
+    val mrsp = computeMRSP(trainPath, rollingStock, false, trainTag, temporarySpeedLimitManager)
+    val stopInfos =
+        stops.map { SimStop(Offset(it.position.meters), it.receptionSignal) }.toMutableList()
+    if (stopAtEnd) stopInfos.add(SimStop(trainPath.getLength(), SHORT_SLIP_STOP))
+    val maxSpeedEnvelope = maxSpeedEnvelopeFrom(context, stopInfos, mrsp)
+    return maxEffortEnvelopeFrom(context, 0.0, maxSpeedEnvelope)
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/engineering_allowance/EngineeringAllowanceManager.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/engineering_allowance/EngineeringAllowanceManager.kt
@@ -211,7 +211,7 @@ class EngineeringAllowanceManager(
             if (pureDecelerationSim.newBeginSpeed > segment.beginSpeed) {
                 // Intersection with base sim. We estimate the new time with a basic speed plateau +
                 // const deceleration, return this segment, and exit the loop.
-                if (segment.beginSpeed < endSpeed || segment.beginSpeed <= 0.0)
+                if (segment.beginSpeed <= endSpeed || segment.beginSpeed <= 0.0)
                     break // Can't run the simplified sim, there's an acceleration
                 val newTime =
                     simplifiedSpeedPlateauThenDeceleration(

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/EngineeringAllowanceTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/EngineeringAllowanceTests.kt
@@ -1,12 +1,14 @@
 package fr.sncf.osrd.stdcm
 
 import com.google.common.collect.ImmutableMultimap
+import fr.sncf.osrd.envelope_sim.allowances.AllowanceValue
 import fr.sncf.osrd.pathfinding.BlockLocation
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.stdcm.preprocessing.OccupancySegment
 import fr.sncf.osrd.train.TestTrains
+import fr.sncf.osrd.train.TestTrains.VERY_LONG_FAST_TRAIN
 import fr.sncf.osrd.utils.DummyInfra
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
@@ -680,6 +682,46 @@ class EngineeringAllowanceTests {
                 .setEndLocations(setOf(BlockLocation(thirdBlock, Offset(1.meters))))
                 .setUnavailableTimes(occupancyGraph)
                 .setTimeStep(timeStep)
+                .run()!!
+        occupancyTest(res, occupancyGraph, 2 * timeStep)
+    }
+
+    /**
+     * Reproduce a bug: this engineering allowance setup forces the train to be planned as close as
+     * possible to the unoccupied section in the first blocks. But because the gradients don't carry
+     * over block transitions, the post-processing simulation has worse gradients in the second
+     * blocks compared to the sims during the search.
+     */
+    @Test
+    fun testVeryLongTrainWithSlopes() {
+        val infra = DummyInfra()
+        val blocks =
+            listOf(
+                infra.addBlock("a", "b", 100.meters, 60.0, gradient = 40.0),
+                infra.addBlock("b", "c", 2_000.meters, 60.0),
+                infra.addBlock("c", "d", 2_000.meters, 60.0),
+                infra.addBlock("d", "e", 2_000.meters, 30.0),
+                infra.addBlock("e", "f", 100.meters, 30.0),
+            )
+        val occupancyGraph =
+            ImmutableMultimap.of(
+                blocks[0],
+                OccupancySegment(150.0, POSITIVE_INFINITY, 0.meters, 100.meters),
+                blocks[1],
+                OccupancySegment(150.0, POSITIVE_INFINITY, 0.meters, 2_000.meters),
+                blocks.last(),
+                OccupancySegment(0.0, 2 * 3600.0, 0.meters, 100.meters),
+            )
+        val timeStep = 2.0
+        val res =
+            STDCMPathfindingBuilder()
+                .setInfra(infra.fullInfra())
+                .setStartLocations(setOf(BlockLocation(blocks.first(), Offset(0.meters))))
+                .setEndLocations(setOf(BlockLocation(blocks.last(), Offset(1.meters))))
+                .setUnavailableTimes(occupancyGraph)
+                .setTimeStep(timeStep)
+                .setRollingStock(VERY_LONG_FAST_TRAIN)
+                .setStandardAllowance(AllowanceValue.Percentage(10.0))
                 .run()!!
         occupancyTest(res, occupancyGraph, 2 * timeStep)
     }

--- a/core/src/test/kotlin/fr/sncf/osrd/utils/DummyInfra.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/utils/DummyInfra.kt
@@ -53,6 +53,7 @@ class DummyInfra : RawInfra, BlockInfra {
         allowedSpeed: Double = Double.POSITIVE_INFINITY,
         signalingSystemName: String = BAL.id,
         detailedSpeedLimits: DistanceRangeMap<SpeedLimitProperty>? = null,
+        gradient: Double = 0.0,
     ): BlockId {
         val name = String.format("%s->%s", entry, exit)
         val entryId = getOrCreateDetectorId(entry)
@@ -69,7 +70,7 @@ class DummyInfra : RawInfra, BlockInfra {
                 entryId,
                 exitId,
                 speedLimits,
-                0.0,
+                gradient,
                 signalingSystemId,
                 signalingSystemName,
             )
@@ -405,7 +406,7 @@ class DummyInfra : RawInfra, BlockInfra {
     }
 
     override fun getTrackChunkSlope(trackChunk: DirTrackChunkId): DistanceRangeMap<Double> {
-        TODO("Not yet implemented")
+        return getTrackChunkGradient(trackChunk)
     }
 
     override fun getTrackChunkCurve(trackChunk: DirTrackChunkId): DistanceRangeMap<Double> {


### PR DESCRIPTION
* Fix edge case in engineering allowance: we first break if `beginSpeed < endSpeed`, then later assert that `beginSpeed > endSpeed`, resulting in an error if strictly equal
* Increase rolling stock traction if post-processing failed (up to a few times), to account for small inaccuracies and shortcomings of the standalone simulation

Contains a subset of https://github.com/OpenRailAssociation/osrd/pull/14755, but not the main change where we'd build the whole path from the start at every block. That change fixes a few cases that still fail on this branch (such as the unit test), but I'm still not convinced it's worth the extra computation time. 