### PR TITLE
front: fix rolling stock loader state before data is ready

### DIFF
--- a/front/src/modules/rollingStock/hooks/useFilterRollingStock.ts
+++ b/front/src/modules/rollingStock/hooks/useFilterRollingStock.ts
@@ -163,7 +163,7 @@ const useFilterRollingStock = ({ isStdcm } = { isStdcm: false }) => {
 
   const {
     data: { results: allRollingStocks } = { results: [] },
-    isSuccess,
+    isFetching,
     isError,
     error,
   } = osrdEditoastApi.endpoints.getLightRollingStock.useQuery({
@@ -216,16 +216,12 @@ const useFilterRollingStock = ({ isStdcm } = { isStdcm: false }) => {
 
   useEffect(() => {
     const newFilteredRollingStock = filterRollingStocks(usefulRollingStocks, filters);
-    setFilteredRollingStockList(newFilteredRollingStock);
-  }, [isSuccess]);
-
-  useEffect(() => {
-    const newFilteredRollingStock = filterRollingStocks(usefulRollingStocks, filters);
+    if (isFetching) return;
     setTimeout(() => {
       setFilteredRollingStockList(newFilteredRollingStock);
       setSearchIsLoading(false);
     }, 0);
-  }, [filters, usefulRollingStocks]);
+  }, [filters, usefulRollingStocks, isFetching]);
 
   return {
     filteredRollingStockList,


### PR DESCRIPTION
The rolling stock loader was hidden before the initial `/api/light_rolling_stock` request completed
As a result, the UI temporarily display "0 results" which made the e2e tests flaky
Exemple : https://github.com/OpenRailAssociation/osrd/actions/runs/21241274992/job/61120130118


The loader is now tied to the API fetch lifecycle, and a redundant filtering `useEffect` has been removed as filtering is already handled by the second `useEffect` ( Correct me If I'm wrong)
