### PR TITLE
editoast: handle out_of_range error with auto-fix for level crossings and operational points

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -9244,6 +9244,7 @@ components:
         required:
         - position
         - expected_range
+        - reference
         - error_type
         properties:
           error_type:
@@ -9258,6 +9259,8 @@ components:
           position:
             type: number
             format: double
+          reference:
+            $ref: '#/components/schemas/ObjectRef'
       - type: object
         required:
         - reference

--- a/editoast/src/generated_data/error/buffer_stops.rs
+++ b/editoast/src/generated_data/error/buffer_stops.rs
@@ -60,6 +60,7 @@ fn check_out_of_range(
             "position",
             buffer_stop.position,
             [0.0, track_cache.length],
+            ObjectRef::new(ObjectType::TrackSection, &buffer_stop.track),
         )]
     } else {
         vec![]
@@ -198,7 +199,8 @@ pub mod tests {
         let errors =
             check_out_of_range(&bf.clone().into(), &infra_cache, &Graph::load(&infra_cache));
         assert_eq!(1, errors.len());
-        let infra_error = InfraError::new_out_of_range(&bf, "position", 530., [0.0, 500.]);
+        let obj_ref = ObjectRef::new(ObjectType::TrackSection, "A");
+        let infra_error = InfraError::new_out_of_range(&bf, "position", 530., [0.0, 500.], obj_ref);
         assert_eq!(infra_error, errors[0]);
     }
 

--- a/editoast/src/generated_data/error/detectors.rs
+++ b/editoast/src/generated_data/error/detectors.rs
@@ -47,6 +47,7 @@ pub fn check_out_of_range(
             "position",
             detector.position,
             [0.0, track_cache.length],
+            ObjectRef::new(ObjectType::TrackSection, &detector.track),
         )]
     } else {
         vec![]
@@ -90,7 +91,9 @@ mod tests {
             &Graph::load(&infra_cache),
         );
         assert_eq!(1, errors.len());
-        let infra_error = InfraError::new_out_of_range(&detector, "position", 530., [0.0, 500.]);
+        let obj_ref = ObjectRef::new(ObjectType::TrackSection, "A");
+        let infra_error =
+            InfraError::new_out_of_range(&detector, "position", 530., [0.0, 500.], obj_ref);
         assert_eq!(infra_error, errors[0]);
     }
 }

--- a/editoast/src/generated_data/error/electrifications.rs
+++ b/editoast/src/generated_data/error/electrifications.rs
@@ -68,6 +68,7 @@ pub fn check_electrification_track_ranges(
                     format!("track_ranges.{index}.{field}"),
                     pos,
                     [0.0, track_cache.length],
+                    ObjectRef::new::<&String>(ObjectType::TrackSection, track_id),
                 ));
             }
         }
@@ -157,8 +158,14 @@ mod tests {
             &Graph::load(&infra_cache),
         );
         assert_eq!(1, errors.len());
-        let infra_error =
-            InfraError::new_out_of_range(&electrification, "track_ranges.0.end", 530., [0.0, 500.]);
+        let obj_ref = ObjectRef::new(ObjectType::TrackSection, "A");
+        let infra_error = InfraError::new_out_of_range(
+            &electrification,
+            "track_ranges.0.end",
+            530.,
+            [0.0, 500.],
+            obj_ref,
+        );
         assert_eq!(infra_error, errors[0]);
     }
 

--- a/editoast/src/generated_data/error/infra_error.rs
+++ b/editoast/src/generated_data/error/infra_error.rs
@@ -54,6 +54,7 @@ pub enum InfraErrorType {
     OutOfRange {
         position: f64,
         expected_range: [f64; 2],
+        reference: ObjectRef,
     },
     OverlappingElectrifications {
         reference: ObjectRef,
@@ -92,6 +93,7 @@ impl InfraError {
         field: T,
         position: f64,
         expected_range: [f64; 2],
+        reference: ObjectRef,
     ) -> Self {
         Self {
             obj_id: obj.get_id().clone(),
@@ -101,6 +103,7 @@ impl InfraError {
             sub_type: InfraErrorType::OutOfRange {
                 position,
                 expected_range,
+                reference,
             },
         }
     }

--- a/editoast/src/generated_data/error/level_crossings.rs
+++ b/editoast/src/generated_data/error/level_crossings.rs
@@ -66,6 +66,7 @@ pub fn check_parts_position(
                 format!("parts.{index}.position"),
                 level_crossing_part.position,
                 [0.0, track_cache.length],
+                ObjectRef::new(ObjectType::TrackSection, track_id),
             ));
         }
     }
@@ -133,8 +134,14 @@ mod tests {
             &Graph::load(&infra_cache),
         );
         assert_eq!(1, errors.len());
-        let infra_error =
-            InfraError::new_out_of_range(&level_crossing, "parts.0.position", 530., [0.0, 500.]);
+        let obj_ref = ObjectRef::new(ObjectType::TrackSection, "A");
+        let infra_error = InfraError::new_out_of_range(
+            &level_crossing,
+            "parts.0.position",
+            530.,
+            [0.0, 500.],
+            obj_ref,
+        );
         assert_eq!(infra_error, errors[0]);
     }
 }

--- a/editoast/src/generated_data/error/operational_points.rs
+++ b/editoast/src/generated_data/error/operational_points.rs
@@ -30,7 +30,7 @@ pub fn check_op_parts(op: &ObjectCache, infra_cache: &InfraCache, _: &Graph) -> 
         let track_id = &*part.track;
 
         if !infra_cache.track_sections().contains_key(track_id) {
-            let obj_ref = ObjectRef::new(ObjectType::TrackSection, track_id.clone());
+            let obj_ref = ObjectRef::new(ObjectType::TrackSection, track_id);
             infra_errors.push(InfraError::new_invalid_reference(
                 op,
                 format!("parts.{index}.track"),
@@ -50,6 +50,7 @@ pub fn check_op_parts(op: &ObjectCache, infra_cache: &InfraCache, _: &Graph) -> 
                 format!("parts.{index}.position"),
                 part.position,
                 [0.0, track_cache.length],
+                ObjectRef::new(ObjectType::TrackSection, track_id),
             ));
         }
     }
@@ -85,7 +86,9 @@ mod tests {
         infra_cache.add(&op).unwrap();
         let errors = check_op_parts(&op.clone().into(), &infra_cache, &Graph::load(&infra_cache));
         assert_eq!(1, errors.len());
-        let infra_error = InfraError::new_out_of_range(&op, "parts.0.position", 530., [0.0, 500.]);
+        let obj_ref = ObjectRef::new(ObjectType::TrackSection, "A");
+        let infra_error =
+            InfraError::new_out_of_range(&op, "parts.0.position", 530., [0.0, 500.], obj_ref);
         assert_eq!(infra_error, errors[0]);
     }
 }

--- a/editoast/src/generated_data/error/signals.rs
+++ b/editoast/src/generated_data/error/signals.rs
@@ -45,6 +45,7 @@ pub fn check_out_of_range(
             "position",
             signal.position,
             [0.0, track_cache.length],
+            ObjectRef::new(ObjectType::TrackSection, &signal.track),
         )]
     } else {
         vec![]
@@ -89,7 +90,9 @@ mod tests {
             &Graph::load(&infra_cache),
         );
         assert_eq!(1, errors.len());
-        let infra_error = InfraError::new_out_of_range(&signal, "position", 530., [0.0, 500.]);
+        let obj_ref = ObjectRef::new(ObjectType::TrackSection, "A");
+        let infra_error =
+            InfraError::new_out_of_range(&signal, "position", 530., [0.0, 500.], obj_ref);
         assert_eq!(infra_error, errors[0]);
     }
 }

--- a/editoast/src/generated_data/error/speed_sections.rs
+++ b/editoast/src/generated_data/error/speed_sections.rs
@@ -67,6 +67,7 @@ pub fn check_speed_section_track_ranges(
                     format!("track_ranges.{index}.{field}"),
                     pos,
                     [0.0, track_cache.length],
+                    ObjectRef::new::<&String>(ObjectType::TrackSection, track_id),
                 ));
             }
         }
@@ -184,8 +185,14 @@ mod tests {
             &Graph::load(&infra_cache),
         );
         assert_eq!(1, errors.len());
-        let infra_error =
-            InfraError::new_out_of_range(&speed_section, "track_ranges.0.end", 530., [0.0, 500.]);
+        let obj_ref = ObjectRef::new(ObjectType::TrackSection, "A");
+        let infra_error = InfraError::new_out_of_range(
+            &speed_section,
+            "track_ranges.0.end",
+            530.,
+            [0.0, 500.],
+            obj_ref,
+        );
         assert_eq!(infra_error, errors[0]);
     }
 

--- a/editoast/src/generated_data/error/track_sections.rs
+++ b/editoast/src/generated_data/error/track_sections.rs
@@ -4,6 +4,8 @@ use crate::generated_data::infra_error::InfraError;
 use crate::infra_cache::Graph;
 use crate::infra_cache::InfraCache;
 use crate::infra_cache::ObjectCache;
+use schemas::primitives::ObjectRef;
+use schemas::primitives::ObjectType;
 
 pub const OBJECT_GENERATORS: [ObjectErrorGenerator<NoContext>; 2] = [
     ObjectErrorGenerator::new(1, check_slope_out_of_range),
@@ -23,6 +25,7 @@ pub fn check_slope_out_of_range(track: &ObjectCache, _: &InfraCache, _: &Graph) 
                     format!("slopes.{index}.{field}"),
                     pos,
                     [0.0, track_length],
+                    ObjectRef::new(ObjectType::TrackSection, &track.obj_id),
                 ));
             }
         }
@@ -43,6 +46,7 @@ pub fn check_curve_out_of_range(track: &ObjectCache, _: &InfraCache, _: &Graph) 
                     format!("curves.{index}.{field}"),
                     pos,
                     [0.0, track_length],
+                    ObjectRef::new(ObjectType::TrackSection, &track.obj_id),
                 ));
             }
         }
@@ -62,6 +66,8 @@ mod tests {
     use crate::infra_cache::tests::create_track_section_cache;
     use schemas::infra::Curve;
     use schemas::infra::Slope;
+    use schemas::primitives::ObjectRef;
+    use schemas::primitives::ObjectType;
 
     #[rstest]
     #[case(50., false)]
@@ -82,7 +88,9 @@ mod tests {
         );
         if error {
             assert_eq!(errors.len(), 1);
-            let infra_error = InfraError::new_out_of_range(&track, "slopes.0.end", pos, [0., 100.]);
+            let obj_ref = ObjectRef::new(ObjectType::TrackSection, &track.obj_id);
+            let infra_error =
+                InfraError::new_out_of_range(&track, "slopes.0.end", pos, [0., 100.], obj_ref);
             assert_eq!(infra_error, errors[0]);
         } else {
             assert_eq!(errors.len(), 0);
@@ -108,7 +116,9 @@ mod tests {
         );
         if error {
             assert_eq!(errors.len(), 1);
-            let infra_error = InfraError::new_out_of_range(&track, "curves.0.end", pos, [0., 100.]);
+            let obj_ref = ObjectRef::new(ObjectType::TrackSection, &track.obj_id);
+            let infra_error =
+                InfraError::new_out_of_range(&track, "curves.0.end", pos, [0., 100.], obj_ref);
             assert_eq!(infra_error, errors[0]);
         } else {
             assert_eq!(errors.len(), 0);

--- a/editoast/src/views/infra/auto_fixes/electrifications.rs
+++ b/editoast/src/views/infra/auto_fixes/electrifications.rs
@@ -58,6 +58,9 @@ pub fn fix_electrification(
                     path: format!("/track_ranges/{track_refs}").parse().unwrap(),
                 })]),
             }),
+            OrderedOperation::UpdatePosition { .. } => {
+                panic!("We should not update electrification position")
+            }
             OrderedOperation::Delete => {
                 Operation::Delete(DeleteOperation::from(electrification.get_ref()))
             }

--- a/editoast/src/views/infra/auto_fixes/level_crossing.rs
+++ b/editoast/src/views/infra/auto_fixes/level_crossing.rs
@@ -2,10 +2,13 @@ use itertools::Itertools;
 use json_patch::Patch;
 use json_patch::PatchOperation;
 use json_patch::RemoveOperation;
+use json_patch::ReplaceOperation;
+use ordered_float::OrderedFloat;
 use schemas::primitives::OSRDIdentified;
 use schemas::primitives::OSRDObject as _;
 use schemas::primitives::ObjectRef;
 use schemas::primitives::ObjectType;
+use serde_json::json;
 use std::collections::HashMap;
 use tracing::debug;
 
@@ -20,7 +23,7 @@ use crate::infra_cache::operation::DeleteOperation;
 use crate::infra_cache::operation::Operation;
 use crate::infra_cache::operation::UpdateOperation;
 
-fn invalid_reference_to_ordered_operation(
+fn invalid_part_to_ordered_operation(
     level_crossing: &LevelCrossingCache,
     object_ref: &ObjectRef,
 ) -> Option<OrderedOperation> {
@@ -30,6 +33,26 @@ fn invalid_reference_to_ordered_operation(
         .enumerate()
         .find(|(_idx, part)| part.track.as_str() == object_ref.obj_id)?;
     Some(OrderedOperation::RemoveTrackRef { track_refs })
+}
+
+fn out_of_range_part_to_ordered_operation(
+    level_crossing: &LevelCrossingCache,
+    new_cache: &mut LevelCrossingCache,
+    object_ref: &ObjectRef,
+    expected_range: &[f64; 2],
+) -> Option<OrderedOperation> {
+    let (track_refs, part) = level_crossing
+        .parts
+        .iter()
+        .enumerate()
+        .find(|(_idx, part)| part.track.as_str() == object_ref.obj_id)?;
+    // Update cache
+    let new_position = part.position.clamp(expected_range[0], expected_range[1]);
+    new_cache.parts[track_refs].position = new_position;
+    Some(OrderedOperation::UpdatePosition {
+        track_refs,
+        new_position: OrderedFloat(new_position),
+    })
 }
 
 pub fn fix_level_crossing(
@@ -46,7 +69,19 @@ pub fn fix_level_crossing(
                 new_lc
                     .parts
                     .retain(|part| part.track.as_str() != reference.obj_id);
-                invalid_reference_to_ordered_operation(level_crossing, reference)
+                invalid_part_to_ordered_operation(level_crossing, reference)
+            }
+            InfraErrorType::OutOfRange {
+                reference,
+                expected_range,
+                ..
+            } if reference.obj_type == ObjectType::TrackSection => {
+                out_of_range_part_to_ordered_operation(
+                    level_crossing,
+                    &mut new_lc,
+                    reference,
+                    expected_range,
+                )
             }
             _ => {
                 debug!("error not (yet) fixable for '{}'", infra_error.get_type());
@@ -62,6 +97,17 @@ pub fn fix_level_crossing(
                 obj_type: level_crossing.get_type(),
                 railjson_patch: Patch(vec![PatchOperation::Remove(RemoveOperation {
                     path: format!("/parts/{track_refs}").parse().unwrap(),
+                })]),
+            }),
+            OrderedOperation::UpdatePosition {
+                track_refs,
+                new_position,
+            } => Operation::Update(UpdateOperation {
+                obj_id: level_crossing.get_id().clone(),
+                obj_type: level_crossing.get_type(),
+                railjson_patch: Patch(vec![PatchOperation::Replace(ReplaceOperation {
+                    path: format!("/parts/{track_refs}/position").parse().unwrap(),
+                    value: json!(new_position),
                 })]),
             }),
             OrderedOperation::Delete => {
@@ -187,5 +233,56 @@ mod tests {
         };
         assert_eq!(object_ref.obj_id, "level_crossing_id");
         assert_eq!(object_ref.obj_type, ObjectType::LevelCrossing);
+    }
+
+    #[test]
+    fn out_of_range_level_crossing() {
+        let lc_cache = LevelCrossingCache {
+            obj_id: "level_crossing_id".into(),
+            parts: vec![
+                LevelCrossingPartCache {
+                    track: Identifier::from("track_section_id_1"),
+                    position: 1500.0, // out of range
+                },
+                LevelCrossingPartCache {
+                    track: Identifier::from("track_section_id_2"),
+                    position: 500.0, // valid
+                },
+            ],
+        };
+        let error_lc = InfraError::new_out_of_range(
+            &lc_cache,
+            "parts.0.position",
+            1500.0,
+            [0.0, 1000.0],
+            ObjectRef::new(ObjectType::TrackSection, "track_section_id_1"),
+        );
+
+        let operations = super::fix_level_crossing(&lc_cache, vec![error_lc].into_iter());
+
+        assert_eq!(operations.len(), 1);
+
+        let (operation, cache_operation) = operations.get(&lc_cache.get_ref()).unwrap();
+        let Operation::Update(update_operation) = operation else {
+            panic!("not an `Operation::Update`");
+        };
+        assert_eq!(update_operation.obj_id, "level_crossing_id");
+        assert!(matches!(
+            update_operation.obj_type,
+            ObjectType::LevelCrossing
+        ));
+        assert_eq!(
+            update_operation.railjson_patch,
+            serde_json::from_str::<Patch>(
+                r#"[{"op":"replace","path":"/parts/0/position","value":1000.0}]"#
+            )
+            .unwrap()
+        );
+        let CacheOperation::Update(ObjectCache::LevelCrossing(lc)) = cache_operation else {
+            panic!("not a `CacheOperation::Update(ObjectCache::LevelCrossing())`");
+        };
+        assert_eq!(lc.parts.len(), 2);
+        assert_eq!(lc.parts[0].track.0, "track_section_id_1");
+        assert_eq!(lc.parts[0].position, 1000.0);
     }
 }

--- a/editoast/src/views/infra/auto_fixes/mod.rs
+++ b/editoast/src/views/infra/auto_fixes/mod.rs
@@ -894,16 +894,6 @@ mod tests {
         }
         .into();
 
-        let operational_point: InfraObject = OperationalPoint {
-            parts: vec![OperationalPointPart {
-                track: track.get_id().as_str().into(),
-                position: 1250.0,
-                ..Default::default()
-            }],
-            ..Default::default()
-        }
-        .into();
-
         let speed_section: InfraObject = SpeedSection {
             track_ranges: vec![ApplicableDirectionsTrackRange {
                 track: track.get_id().as_str().into(),
@@ -915,23 +905,7 @@ mod tests {
         }
         .into();
 
-        let level_crossing: InfraObject = LevelCrossing {
-            parts: vec![LevelCrossingPart {
-                track: track.get_id().as_str().into(),
-                position: 1250.0,
-                ..Default::default()
-            }],
-            ..Default::default()
-        }
-        .into();
-
-        for obj in [
-            &track,
-            &electrification,
-            &operational_point,
-            &speed_section,
-            &level_crossing,
-        ] {
+        for obj in [&track, &electrification, &speed_section] {
             apply_create_operation(obj, empty_infra_id, &mut db_pool.get_ok())
                 .await
                 .expect("Failed to create object");
@@ -943,13 +917,7 @@ mod tests {
             .assert_status(StatusCode::OK)
             .json_into();
 
-        for obj in [
-            &track,
-            &electrification,
-            &operational_point,
-            &speed_section,
-            &level_crossing,
-        ] {
+        for obj in [&track, &electrification, &speed_section] {
             assert!(!operations.contains(&Operation::Delete(DeleteOperation {
                 obj_id: obj.get_id().to_string(),
                 obj_type: obj.get_type(),
@@ -1021,6 +989,63 @@ mod tests {
                     obj_type: obj.get_type(),
                 })))
             }
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn out_of_range_must_be_updated() {
+        let app = TestAppBuilder::default_app();
+        let db_pool = app.db_pool();
+        let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
+        let empty_infra_id = empty_infra.id;
+
+        let track: InfraObject = TrackSection {
+            id: "test_track".into(),
+            length: 1_000.0,
+            ..Default::default()
+        }
+        .into();
+
+        let operational_point: InfraObject = OperationalPoint {
+            parts: vec![OperationalPointPart {
+                track: track.get_id().as_str().into(),
+                position: 1250.0,
+                ..Default::default()
+            }],
+            ..Default::default()
+        }
+        .into();
+
+        let level_crossing: InfraObject = LevelCrossing {
+            parts: vec![LevelCrossingPart {
+                track: track.get_id().as_str().into(),
+                position: 1250.0,
+                ..Default::default()
+            }],
+            ..Default::default()
+        }
+        .into();
+
+        for obj in [&track, &operational_point, &level_crossing] {
+            apply_create_operation(obj, empty_infra_id, &mut db_pool.get_ok())
+                .await
+                .expect("Failed to create object");
+        }
+
+        let operations: Vec<Operation> = app
+            .fetch(app.auto_fixes_request(empty_infra_id))
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
+
+        for obj in [&operational_point, &level_crossing] {
+            assert!(operations.iter().any(|op| {
+                if let Operation::Update(update_op) = op {
+                    update_op.obj_id == *obj.get_id() && update_op.obj_type == obj.get_type()
+                } else {
+                    false
+                }
+            }))
         }
     }
 

--- a/editoast/src/views/infra/auto_fixes/mod.rs
+++ b/editoast/src/views/infra/auto_fixes/mod.rs
@@ -8,6 +8,7 @@ use axum::extract::Path;
 use axum::extract::State;
 use editoast_derive::EditoastError;
 use itertools::Itertools as _;
+use ordered_float::OrderedFloat;
 use thiserror::Error;
 use tracing::debug;
 use tracing::error;
@@ -66,7 +67,13 @@ fn new_ref_fix_create_pair(object: InfraObject) -> (ObjectRef, Fix) {
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum OrderedOperation {
-    RemoveTrackRef { track_refs: usize },
+    RemoveTrackRef {
+        track_refs: usize,
+    },
+    UpdatePosition {
+        track_refs: usize,
+        new_position: OrderedFloat<f64>,
+    },
     Delete,
 }
 

--- a/editoast/src/views/infra/auto_fixes/operational_point.rs
+++ b/editoast/src/views/infra/auto_fixes/operational_point.rs
@@ -2,10 +2,13 @@ use itertools::Itertools;
 use json_patch::Patch;
 use json_patch::PatchOperation;
 use json_patch::RemoveOperation;
+use json_patch::ReplaceOperation;
+use ordered_float::OrderedFloat;
 use schemas::primitives::OSRDIdentified;
 use schemas::primitives::OSRDObject as _;
 use schemas::primitives::ObjectRef;
 use schemas::primitives::ObjectType;
+use serde_json::json;
 use std::collections::HashMap;
 use tracing::debug;
 
@@ -20,7 +23,7 @@ use crate::infra_cache::operation::DeleteOperation;
 use crate::infra_cache::operation::Operation;
 use crate::infra_cache::operation::UpdateOperation;
 
-fn invalid_reference_to_ordered_operation(
+fn invalid_part_to_ordered_operation(
     operational_point: &OperationalPointCache,
     object_ref: &ObjectRef,
 ) -> Option<OrderedOperation> {
@@ -30,6 +33,26 @@ fn invalid_reference_to_ordered_operation(
         .enumerate()
         .find(|(_idx, part)| part.track.as_str() == object_ref.obj_id)?;
     Some(OrderedOperation::RemoveTrackRef { track_refs })
+}
+
+fn out_of_range_part_to_ordered_operation(
+    operational_point: &OperationalPointCache,
+    new_cache: &mut OperationalPointCache,
+    object_ref: &ObjectRef,
+    expected_range: &[f64; 2],
+) -> Option<OrderedOperation> {
+    let (track_refs, part) = operational_point
+        .parts
+        .iter()
+        .enumerate()
+        .find(|(_idx, part)| part.track.as_str() == object_ref.obj_id)?;
+    // Update cache
+    let new_position = part.position.clamp(expected_range[0], expected_range[1]);
+    new_cache.parts[track_refs].position = new_position;
+    Some(OrderedOperation::UpdatePosition {
+        track_refs,
+        new_position: OrderedFloat(new_position),
+    })
 }
 
 pub fn fix_operational_point(
@@ -46,7 +69,19 @@ pub fn fix_operational_point(
                 new_op
                     .parts
                     .retain(|part| part.track.as_str() != reference.obj_id);
-                invalid_reference_to_ordered_operation(operational_point, reference)
+                invalid_part_to_ordered_operation(operational_point, reference)
+            }
+            InfraErrorType::OutOfRange {
+                reference,
+                expected_range,
+                ..
+            } if reference.obj_type == ObjectType::TrackSection => {
+                out_of_range_part_to_ordered_operation(
+                    operational_point,
+                    &mut new_op,
+                    reference,
+                    expected_range,
+                )
             }
             _ => {
                 debug!("error not (yet) fixable for '{}'", infra_error.get_type());
@@ -64,9 +99,17 @@ pub fn fix_operational_point(
                     path: format!("/parts/{track_refs}").parse().unwrap(),
                 })]),
             }),
-            OrderedOperation::UpdatePosition { .. } => {
-                panic!("We should not update operational point position")
-            }
+            OrderedOperation::UpdatePosition {
+                track_refs,
+                new_position,
+            } => Operation::Update(UpdateOperation {
+                obj_id: operational_point.get_id().clone(),
+                obj_type: operational_point.get_type(),
+                railjson_patch: Patch(vec![PatchOperation::Replace(ReplaceOperation {
+                    path: format!("/parts/{track_refs}/position").parse().unwrap(),
+                    value: json!(new_position),
+                })]),
+            }),
             OrderedOperation::Delete => {
                 Operation::Delete(DeleteOperation::from(operational_point.get_ref()))
             }
@@ -205,5 +248,56 @@ mod tests {
         };
         assert_eq!(object_ref.obj_id, "operational_point_id");
         assert_eq!(object_ref.obj_type, ObjectType::OperationalPoint);
+    }
+
+    #[test]
+    fn out_of_range_operational_point() {
+        let op_cache = OperationalPointCache {
+            obj_id: "operational_point_id".into(),
+            parts: vec![
+                OperationalPointPartCache {
+                    track: Identifier::from("track_section_id_1"),
+                    position: 1500.0, // out of range
+                },
+                OperationalPointPartCache {
+                    track: Identifier::from("track_section_id_2"),
+                    position: 500.0, // valid
+                },
+            ],
+        };
+        let error_op = InfraError::new_out_of_range(
+            &op_cache,
+            "parts.0.position",
+            1500.0,
+            [0.0, 1000.0],
+            ObjectRef::new(ObjectType::TrackSection, "track_section_id_1"),
+        );
+
+        let operations = super::fix_operational_point(&op_cache, vec![error_op].into_iter());
+
+        assert_eq!(operations.len(), 1);
+
+        let (operation, cache_operation) = operations.get(&op_cache.get_ref()).unwrap();
+        let Operation::Update(update_operation) = operation else {
+            panic!("not an `Operation::Update`");
+        };
+        assert_eq!(update_operation.obj_id, "operational_point_id");
+        assert!(matches!(
+            update_operation.obj_type,
+            ObjectType::OperationalPoint
+        ));
+        assert_eq!(
+            update_operation.railjson_patch,
+            serde_json::from_str::<Patch>(
+                r#"[{"op":"replace","path":"/parts/0/position","value":1000.0}]"#
+            )
+            .unwrap()
+        );
+        let CacheOperation::Update(ObjectCache::OperationalPoint(op)) = cache_operation else {
+            panic!("not a `CacheOperation::Update(ObjectCache::OperationalPoint())`");
+        };
+        assert_eq!(op.parts.len(), 2);
+        assert_eq!(op.parts[0].track.0, "track_section_id_1");
+        assert_eq!(op.parts[0].position, 1000.0);
     }
 }

--- a/editoast/src/views/infra/auto_fixes/operational_point.rs
+++ b/editoast/src/views/infra/auto_fixes/operational_point.rs
@@ -64,6 +64,9 @@ pub fn fix_operational_point(
                     path: format!("/parts/{track_refs}").parse().unwrap(),
                 })]),
             }),
+            OrderedOperation::UpdatePosition { .. } => {
+                panic!("We should not update operational point position")
+            }
             OrderedOperation::Delete => {
                 Operation::Delete(DeleteOperation::from(operational_point.get_ref()))
             }

--- a/editoast/src/views/infra/auto_fixes/speed_section.rs
+++ b/editoast/src/views/infra/auto_fixes/speed_section.rs
@@ -58,6 +58,9 @@ pub fn fix_speed_section(
                     path: format!("/track_ranges/{track_refs}").parse().unwrap(),
                 })]),
             }),
+            OrderedOperation::UpdatePosition { .. } => {
+                panic!("We should not update speed section position")
+            }
             OrderedOperation::Delete => {
                 Operation::Delete(DeleteOperation::from(speed_section.get_ref()))
             }

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -3178,6 +3178,7 @@ export type InfraErrorType =
       error_type: 'out_of_range';
       expected_range: number[];
       position: number;
+      reference: ObjectRef;
     }
   | {
       error_type: 'overlapping_electrifications';


### PR DESCRIPTION
Enables fixing `out_of_range` errors in infras with auto-fix:

- Extends the `InfraErrorType::OutOfRange` variant to include a new `reference` field
- Updates level crossings parts position that are out of range with auto-fix
- Updates operational points parts position that are out of range with auto-fix

The interaction between `InvalidRef` and `OutOfRange` errors for level crossings will be fixed in [another PR](https://github.com/OpenRailAssociation/osrd/issues/14854)