### PR TITLE
front: connect train schedule sets to back end part 1 (fetching)

### DIFF
--- a/front/src/applications/operationalStudies/__tests__/sampleData.ts
+++ b/front/src/applications/operationalStudies/__tests__/sampleData.ts
@@ -355,6 +355,7 @@ export const trainSummaryNotHonored: Extract<SimulationSummaryResult, { status: 
 
 export const trainScheduleHonored: TimetableItem = {
   id: 'paced_95' as PacedTrainId,
+  train_schedule_set_id: 1000,
   train_name: 'normal',
   labels: [],
   rolling_stock_name: 'TC64700',

--- a/front/src/applications/operationalStudies/hooks/useScenarioTrainScheduleSet.ts
+++ b/front/src/applications/operationalStudies/hooks/useScenarioTrainScheduleSet.ts
@@ -1,8 +1,12 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { maxBy } from 'lodash';
 
-import type { CatalogEntry, TrainScheduleSet } from 'common/api/osrdEditoastApi';
+import {
+  osrdEditoastApi,
+  type CatalogEntry,
+  type TrainScheduleSet,
+} from 'common/api/osrdEditoastApi';
 import type { TimetableItemWithDetails } from 'modules/timetableItem/types';
 
 import { useScenarioContext } from './useScenarioContext';
@@ -63,31 +67,16 @@ export default function useScenarioTrainScheduleSet(
   }, [timetableItemsWithDetails]);
 
   /**
-   * Retrieve all TrainScheduleSets
+   * Retrieve all TrainScheduleSets of the timetable
    */
-  const getAllTrainScheduleSets = useCallback(
-    () =>
-      new Promise<TrainScheduleSet[]>((resolve) => {
-        setTimeout(() => {
-          console.warn('Mocked: getAllTrainScheduleSets');
-          resolve(mockStore.trainScheduleSets);
-        }, 1000);
-      }),
-    [mockStore.trainScheduleSets]
-  );
+  const { currentData: trainScheduleSets } =
+    osrdEditoastApi.endpoints.getTimetableByIdTrainScheduleSets.useQuery({ id: timetableId });
 
   /**
    * Retrieve all catalog entries
    */
-  const getCatalogEntries = useCallback(
-    () =>
-      new Promise<CatalogEntry[]>((resolve) => {
-        setTimeout(() => {
-          console.warn('Mocked: getAllCatalogEntries');
-          resolve(mockStore.catalog);
-        }, 1000);
-      }),
-    [mockStore.catalog]
+  const { currentData: catalogEntries } = osrdEditoastApi.endpoints.getAllCatalogEntries.useQuery(
+    {}
   );
 
   /**
@@ -109,51 +98,44 @@ export default function useScenarioTrainScheduleSet(
 
   /**
    * Given a list of TimetableItem, returns the associates list of TranscheduleSet,
-   * each one associates with its list of TimetableItem.
-   *
-   * NB: on unmock, this function should be reviewed for better performances:
-   * - keep track of catalog and trainsScheduleSet with a cache mecansim ?
-   * - calling the full catalog in one query (even if we need only one). Same for TSS.
+   * each one associates with its list of timetable item and its catalog entry.
    */
-  const getTrainScheduleSetsFromTimetableItems = useCallback(
-    async (items: TimetableItemWithDetailsAndTrainScheduleSet[]) => {
-      console.warn('Mocked: getTrainScheduleSetsFromTimetableItems');
+  const timetableItemsByTrainScheduleSets = useMemo(() => {
+    if (!trainScheduleSets) return null;
 
-      // We group trains by trainScheduleSet
-      const trainsByTrainScheduleSetId = new Map<number, TimetableItemWithDetails[]>();
-      for (const item of items) {
-        const itemInIndex = trainsByTrainScheduleSetId.get(item.train_schedule_set_id);
-        if (!itemInIndex) {
-          trainsByTrainScheduleSetId.set(item.train_schedule_set_id, [item]);
-        } else {
-          trainsByTrainScheduleSetId.set(item.train_schedule_set_id, [...itemInIndex, item]);
-        }
+    // We group trains by trainScheduleSet
+    const trainsByTrainScheduleSetId = new Map<number, TimetableItemWithDetails[]>();
+    for (const item of timetableItemsWithDetails) {
+      const itemInIndex = trainsByTrainScheduleSetId.get(item.train_schedule_set_id);
+      if (!itemInIndex) {
+        trainsByTrainScheduleSetId.set(item.train_schedule_set_id, [item]);
+      } else {
+        trainsByTrainScheduleSetId.set(item.train_schedule_set_id, [...itemInIndex, item]);
       }
+    }
 
-      // Calling the API to get TrainScheduleSet data and build an index
-      const trainScheduleSets = await getAllTrainScheduleSets();
-      const trainScheduleSetsById = new Map<number, TrainScheduleSet>();
-      for (const trainScheduleSet of trainScheduleSets) {
-        trainScheduleSetsById.set(trainScheduleSet.id, trainScheduleSet);
-      }
+    const trainScheduleSetsById = new Map<number, TrainScheduleSet>();
+    for (const trainScheduleSet of trainScheduleSets) {
+      trainScheduleSetsById.set(trainScheduleSet.id, trainScheduleSet);
+    }
 
-      // Calling the API to get Catalog data
-      const catalogEntries = await getCatalogEntries();
-      const catalogEntriesIndex = new Map<number, CatalogEntry>();
+    const catalogEntriesIndex = new Map<number, CatalogEntry>();
+    if (catalogEntries) {
       for (const catalogEntry of catalogEntries) {
         catalogEntriesIndex.set(catalogEntry.id, catalogEntry);
       }
+    }
 
-      return Array.from(trainScheduleSetsById.values())
-        .sort((a, b) => sortTrainScheduleSets(a, b, catalogEntriesIndex))
-        .map((trainScheduleSet) => ({
-          trainScheduleSet,
-          trains: trainsByTrainScheduleSetId.get(trainScheduleSet.id) || [],
-          catalog: catalogEntriesIndex.get(trainScheduleSet.catalog_entry_id!)!,
-        }));
-    },
-    [getAllTrainScheduleSets, getCatalogEntries]
-  );
+    return Array.from(trainScheduleSetsById.values())
+      .sort((a, b) => sortTrainScheduleSets(a, b, catalogEntriesIndex))
+      .map((trainScheduleSet) => ({
+        trainScheduleSet,
+        trains: trainsByTrainScheduleSetId.get(trainScheduleSet.id) || [],
+        catalog: trainScheduleSet.catalog_entry_id
+          ? catalogEntriesIndex.get(trainScheduleSet.catalog_entry_id)
+          : undefined, // can happen if it's the sandbox
+      }));
+  }, [trainScheduleSets, catalogEntries, timetableItemsWithDetails]);
 
   /**
    * Retrieve a TainScheduleSet via its ID.
@@ -372,8 +354,8 @@ export default function useScenarioTrainScheduleSet(
 
   return {
     timetableItemsWithDetails: mockStore.timetableItemsWithDetails,
-    getCatalogEntries,
-    getTrainScheduleSetsFromTimetableItems,
+    catalogEntries: catalogEntries ?? [],
+    timetableItemsByTrainScheduleSets,
     getTrainScheduleSet,
     createTrainScheduleSet,
     updateTrainScheduleSet,

--- a/front/src/applications/operationalStudies/types.ts
+++ b/front/src/applications/operationalStudies/types.ts
@@ -18,6 +18,7 @@ import type {
   PathItem,
   OperationalPointReference,
   MacroNoteForm,
+  PacedTrainResponse,
 } from 'common/api/osrdEditoastApi';
 import type { RangedValue } from 'common/types';
 import type { PathOperationalPoint } from 'modules/simulationResult/types';
@@ -28,7 +29,10 @@ import type { ArrayElement } from 'utils/types';
 
 export type Board = 'trains' | 'map' | 'macro' | 'std' | 'sdd' | 'tables' | 'conflicts';
 
-export type PacedTrainWithPaced = TrainSchedule & { paced: NonNullable<PacedTrain['paced']> };
+export type PacedTrainWithPaced = Omit<PacedTrainResponse, 'id' | 'paced'> & {
+  paced: NonNullable<PacedTrainResponse['paced']>;
+};
+
 export type PacedTrainResponseWithPaced = PacedTrainWithPaced & {
   id: PacedTrainId;
 };

--- a/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/parseXML.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/parseXML.ts
@@ -23,7 +23,7 @@ const trainScheduleToPacedTrain = (
   pacedTrainId: string,
   intervalDuration: Duration,
   timeWindowDuration: Duration
-): PacedTrainWithPaced => ({
+): Omit<PacedTrainWithPaced, 'train_schedule_set_id'> => ({
   ...trainSchedule,
   train_name: pacedTrainId,
   paced: {

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/ngeToOsrd/trainrun.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/ngeToOsrd/trainrun.ts
@@ -4,6 +4,7 @@ import {
   type PacedTrain,
   type TrainSchedule,
   type PathItemLocation,
+  type PacedTrainResponse,
 } from 'common/api/osrdEditoastApi';
 import {
   createPacedTrains,
@@ -532,7 +533,7 @@ export const handleUpdateTimetableItem = async ({
 
   const paced = createPacedAttributesFromTrainrun(trainrun, netzgrafikDto);
 
-  const newForwardTrainBase: PacedTrain = {
+  const newForwardTrainBase: Omit<PacedTrainResponse, 'id'> = {
     ...timetableItemBase,
     train_name: trainrun.name,
     labels,
@@ -589,14 +590,13 @@ export const handleUpdateTimetableItem = async ({
     // update return if already present
     const oldReturnTimetableItem = await fetchTimetableItem(timetableItemIds[1], dispatch);
     const { id: _return_id, ...oldReturnTrainBase } = oldReturnTimetableItem;
-    const newReturnTrainBase = {
+    const newReturnTrainBase: Omit<PacedTrainResponse, 'id'> = {
       ...oldReturnTrainBase,
       train_name: trainrun.name,
       labels,
       // Reset margins because they contain references to path items
       margins: undefined,
       paced: returnPaced,
-      exceptions: undefined,
       category,
       ...returnPathAndSchedule,
     };
@@ -619,8 +619,13 @@ export const handleUpdateTimetableItem = async ({
     );
   } else {
     // otherwise create return
-    const returnPacedTrain = {
-      ...newForwardTrainBase,
+
+    // Remove train_schedule_set_id before creating paced train as we don't want to pass it in the payload
+    const { train_schedule_set_id: _trainScheduleSetId, ...pacedTrainWithoutTrainScheduleSetId } =
+      newForwardTrainBase;
+
+    const returnPacedTrain: PacedTrain = {
+      ...pacedTrainWithoutTrainScheduleSetId,
       ...returnPathAndSchedule,
       paced: returnPaced,
     };

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/helpers/__tests__/formatTimetableItemPayload.spec.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/helpers/__tests__/formatTimetableItemPayload.spec.ts
@@ -119,6 +119,7 @@ describe('formatTimetableItemPayload', () => {
       schedule: [],
       speed_limit_tag: null,
       id: 'paced_238' as PacedTrainId,
+      train_schedule_set_id: 1000,
       name: 'test',
       startTime: new Date('2025-06-02T12:45:00.000Z'),
       stopsCount: 1,

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/helpers/buildPacedTrainException.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/helpers/buildPacedTrainException.ts
@@ -24,7 +24,7 @@ import {
  */
 export function generatePacedTrainException(
   updatedOccurrence: TrainSchedule,
-  originalPacedTrain: PacedTrainWithPaced,
+  originalPacedTrain: Omit<PacedTrainWithPaced, 'train_schedule_set_id'>,
   occurrenceIndex: number | null = null
 ): Omit<PacedTrainException, 'key' | 'occurrence_index'> {
   const exception: Omit<PacedTrainException, 'key' | 'occurrence_index'> = {};

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/helpers/formatTimetableItemPayload.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/helpers/formatTimetableItemPayload.ts
@@ -115,7 +115,7 @@ export function formatPacedTrainPayload(
     key,
     start_time: { value: startTime.toISOString() },
   }));
-  let newPacedTrain: PacedTrainWithPaced = {
+  let newPacedTrain: Omit<PacedTrainWithPaced, 'train_schedule_set_id'> = {
     ...baseTrain,
     paced: {
       time_window: osrdconf.timeWindow.toISOString(),

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/hooks/useUpdateTimetableItem.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/hooks/useUpdateTimetableItem.ts
@@ -61,7 +61,10 @@ const useUpdateTimetableItem = (
       // The user has modified some fields that have been saved in the store (simulationConf).
       // The function will compare these original paced train informations with the one
       // from the store and save the differences in the exception property of the original paced train.
-      formatPacedTrainPayload(simulationConf, rollingStock!.name, timetableItemToEditData),
+      {
+        ...formatPacedTrainPayload(simulationConf, rollingStock!.name, timetableItemToEditData),
+        train_schedule_set_id: timetableItemToEditData.originalPacedTrain.train_schedule_set_id,
+      },
       dispatch,
       upsertTimetableItems
     );

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/PacedTrainItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/PacedTrainItem.tsx
@@ -175,7 +175,12 @@ const PacedTrainItem = ({
       paced: { ...pacedTrain.paced, exceptions: [] },
     });
 
-    await storePacedTrain(pacedTrain.id, updatedPacedTrainPayload, dispatch, upsertTimetableItems);
+    await storePacedTrain(
+      pacedTrain.id,
+      { ...updatedPacedTrainPayload, train_schedule_set_id: pacedTrain.train_schedule_set_id },
+      dispatch,
+      upsertTimetableItems
+    );
 
     closeModal();
   }

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/hooks/useOccurrenceActions.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/hooks/useOccurrenceActions.ts
@@ -126,7 +126,12 @@ const useOccurrenceActions = ({
         paced: { ...pacedTrain.paced, exceptions: updatedExceptions },
       });
 
-      storePacedTrain(pacedTrain.id, formattedPacedTrain, dispatch, upsertTimetableItems);
+      storePacedTrain(
+        pacedTrain.id,
+        { ...formattedPacedTrain, train_schedule_set_id: pacedTrain.train_schedule_set_id },
+        dispatch,
+        upsertTimetableItems
+      );
 
       // If we are disabling the selected occurrence, we want to put the selection
       // on the first enabled occurrence chronologically
@@ -182,7 +187,12 @@ const useOccurrenceActions = ({
         paced: { ...pacedTrain.paced, exceptions: updatedExceptions },
       });
 
-      storePacedTrain(pacedTrain.id, formattedPacedTrain, dispatch, upsertTimetableItems);
+      storePacedTrain(
+        pacedTrain.id,
+        { ...formattedPacedTrain, train_schedule_set_id: pacedTrain.train_schedule_set_id },
+        dispatch,
+        upsertTimetableItems
+      );
     },
     [pacedTrain]
   );
@@ -196,7 +206,12 @@ const useOccurrenceActions = ({
         paced: { ...pacedTrain.paced, exceptions: newExceptions },
       });
 
-      storePacedTrain(pacedTrain.id, updatedPacedTrainPayload, dispatch, upsertTimetableItems);
+      storePacedTrain(
+        pacedTrain.id,
+        { ...updatedPacedTrainPayload, train_schedule_set_id: pacedTrain.train_schedule_set_id },
+        dispatch,
+        upsertTimetableItems
+      );
     },
     [pacedTrain.paced.exceptions]
   );

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/Timetable.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/Timetable.tsx
@@ -4,9 +4,7 @@ import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { Virtualizer } from 'virtua';
 
-import useScenarioTrainScheduleSet, {
-  type TimetableItemWithDetailsAndTrainScheduleSet,
-} from 'applications/operationalStudies/hooks/useScenarioTrainScheduleSet';
+import useScenarioTrainScheduleSet from 'applications/operationalStudies/hooks/useScenarioTrainScheduleSet';
 import { Loader } from 'common/Loaders';
 import type { TimetableItemWithDetails } from 'modules/timetableItem/types';
 import type {
@@ -14,7 +12,6 @@ import type {
   TimetableItem,
   TimetableItemToEditData,
 } from 'reducers/osrdconf/types';
-import { useAsyncMemo } from 'utils/useAsyncMemo';
 
 import CalendarTrainList from './CalendarTrainList';
 import TimetableToolbar from './TimetableToolbar';
@@ -61,9 +58,8 @@ const Timetable = ({
   const [showTrainScheduleSetDialog, setShowTrainScheduleSetDialog] = useState(false);
 
   const {
-    timetableItemsWithDetails: mockedTimetableItemsWithDetails,
-    getTrainScheduleSetsFromTimetableItems,
-    getCatalogEntries,
+    timetableItemsByTrainScheduleSets,
+    catalogEntries,
     createTrainScheduleSet,
     publishTrainScheduleSet,
     getTrainScheduleSetByCatalogAndName,
@@ -72,9 +68,8 @@ const Timetable = ({
     removeTrainScheduleSet,
   } = useScenarioTrainScheduleSet(timetableItemsWithDetails);
 
-  const { filteredTimetableItems, ...timetableFilters } = useFilterTimetableItems(
-    mockedTimetableItemsWithDetails
-  );
+  const { filteredTimetableItems, ...timetableFilters } =
+    useFilterTimetableItems(timetableItemsWithDetails);
 
   const handleClickTrainScheduleSet = useCallback(
     (id: number) => {
@@ -108,17 +103,6 @@ const Timetable = ({
     [selectedTimetableItemIds]
   );
 
-  // TODO: the "as unknown as" should be removed on unmock.
-  // We do it because the PacedTrainWithDetail doesn't have (yet) the `train_schedule_set_id`
-  // But here we know that is set but the `useScenarioTrainScheduleSet` hook.
-  const trainScheduleSetsData = useAsyncMemo(
-    () =>
-      getTrainScheduleSetsFromTimetableItems(
-        filteredTimetableItems as unknown as TimetableItemWithDetailsAndTrainScheduleSet[]
-      ),
-    [filteredTimetableItems, getTrainScheduleSetsFromTimetableItems]
-  );
-
   return (
     <div className="scenario-timetable">
       <div
@@ -143,7 +127,7 @@ const Timetable = ({
           setTimetableMode={setTimetableMode}
           upsertTimetableItems={upsertTimetableItems}
         />
-        {timetableMode === 'calendar' ? (
+        {timetableMode === 'calendar' && (
           <Virtualizer overscan={15}>
             <CalendarTrainList
               setDisplayTimetableItemManagement={setDisplayTimetableItemManagement}
@@ -159,67 +143,64 @@ const Timetable = ({
               timetableMode={timetableMode}
             />
           </Virtualizer>
-        ) : (
-          <>
-            {trainScheduleSetsData.type === 'ready' && (
-              <Virtualizer overscan={15}>
-                {trainScheduleSetsData.data.map(({ trainScheduleSet, catalog, trains }) => {
-                  const trainScheduleSetTrainsIds = trains.map((train) => train.id);
-                  const isSelected = trains.every((train) =>
-                    selectedTimetableItemIds.includes(train.id)
-                  );
-                  const isIndeterminate =
-                    !isSelected &&
-                    trains.some((train) => selectedTimetableItemIds.includes(train.id));
-
-                  return (
-                    <TrainScheduleSetTab
-                      key={trainScheduleSet.id}
-                      trainScheduleSet={trainScheduleSet}
-                      catalogName={catalog?.name}
-                      handleClickTrainScheduleSet={handleClickTrainScheduleSet}
-                      handleSelectTrainScheduleSet={() =>
-                        handleSelectTrainScheduleSet(trainScheduleSetTrainsIds)
-                      }
-                      isSelectMode={isSelectMode}
-                      isSelected={isSelected}
-                      isIndeterminate={isIndeterminate}
-                      isTrainListOpen={expandedTrainScheduleSetIds.has(trainScheduleSet.id)}
-                      getCatalogEntries={getCatalogEntries}
-                      publishTrainScheduleSet={publishTrainScheduleSet}
-                      getTrainScheduleSetByCatalogAndName={getTrainScheduleSetByCatalogAndName}
-                      localCopyTrainScheduleSet={localCopyTrainScheduleSet}
-                      updateTrainScheduleSet={updateTrainScheduleSet}
-                      removeTrainScheduleSet={removeTrainScheduleSet}
-                    >
-                      <CalendarTrainList
-                        setDisplayTimetableItemManagement={setDisplayTimetableItemManagement}
-                        upsertTimetableItems={upsertTimetableItems}
-                        setTimetableItemToEditData={setTimetableItemToEditData}
-                        setSelectedTimetableItemIds={setSelectedTimetableItemIds}
-                        removeAndUnselectTrains={removeAndUnselectTrains}
-                        timetableItemToEditData={timetableItemToEditData}
-                        timetableItemsWithDetails={trains}
-                        selectedTimetableItemIds={selectedTimetableItemIds}
-                        projectingOnSimulatedPathException={projectingOnSimulatedPathException}
-                        isSelectMode={isSelectMode}
-                        timetableMode={timetableMode}
-                      />
-                    </TrainScheduleSetTab>
-                  );
-                })}
-                <AddNewTrainScheduleSetTab onClick={() => setShowTrainScheduleSetDialog(true)} />
-              </Virtualizer>
-            )}
-            {trainScheduleSetsData.type === 'loading' && (
-              <Loader className="scenario-timetable-trainschedule-loader" />
-            )}
-          </>
         )}
+        {timetableMode === 'trainScheduleSet' &&
+          (timetableItemsByTrainScheduleSets ? (
+            <Virtualizer overscan={15}>
+              {timetableItemsByTrainScheduleSets.map(({ trainScheduleSet, catalog, trains }) => {
+                const trainScheduleSetTrainsIds = trains.map((train) => train.id);
+                const isSelected = trains.every((train) =>
+                  selectedTimetableItemIds.includes(train.id)
+                );
+                const isIndeterminate =
+                  !isSelected &&
+                  trains.some((train) => selectedTimetableItemIds.includes(train.id));
+
+                return (
+                  <TrainScheduleSetTab
+                    key={trainScheduleSet.id}
+                    trainScheduleSet={trainScheduleSet}
+                    catalogName={catalog?.name}
+                    handleClickTrainScheduleSet={handleClickTrainScheduleSet}
+                    handleSelectTrainScheduleSet={() =>
+                      handleSelectTrainScheduleSet(trainScheduleSetTrainsIds)
+                    }
+                    isSelectMode={isSelectMode}
+                    isSelected={isSelected}
+                    isIndeterminate={isIndeterminate}
+                    isTrainListOpen={expandedTrainScheduleSetIds.has(trainScheduleSet.id)}
+                    catalogEntries={catalogEntries}
+                    publishTrainScheduleSet={publishTrainScheduleSet}
+                    getTrainScheduleSetByCatalogAndName={getTrainScheduleSetByCatalogAndName}
+                    localCopyTrainScheduleSet={localCopyTrainScheduleSet}
+                    updateTrainScheduleSet={updateTrainScheduleSet}
+                    removeTrainScheduleSet={removeTrainScheduleSet}
+                  >
+                    <CalendarTrainList
+                      setDisplayTimetableItemManagement={setDisplayTimetableItemManagement}
+                      upsertTimetableItems={upsertTimetableItems}
+                      setTimetableItemToEditData={setTimetableItemToEditData}
+                      setSelectedTimetableItemIds={setSelectedTimetableItemIds}
+                      removeAndUnselectTrains={removeAndUnselectTrains}
+                      timetableItemToEditData={timetableItemToEditData}
+                      timetableItemsWithDetails={trains}
+                      selectedTimetableItemIds={selectedTimetableItemIds}
+                      projectingOnSimulatedPathException={projectingOnSimulatedPathException}
+                      isSelectMode={isSelectMode}
+                      timetableMode={timetableMode}
+                    />
+                  </TrainScheduleSetTab>
+                );
+              })}
+              <AddNewTrainScheduleSetTab onClick={() => setShowTrainScheduleSetDialog(true)} />
+            </Virtualizer>
+          ) : (
+            <Loader className="scenario-timetable-trainschedule-loader" />
+          ))}
       </div>
       {showTrainScheduleSetDialog && (
         <TrainScheduleSetDialog
-          getCatalogEntries={getCatalogEntries}
+          catalogEntries={catalogEntries}
           onCancel={() => setShowTrainScheduleSetDialog(false)}
           onSubmit={createTrainScheduleSet}
           labels={{

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TrainScheduleSet/TrainScheduleSetDialog.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TrainScheduleSet/TrainScheduleSetDialog.tsx
@@ -7,9 +7,7 @@ import { noop } from 'lodash';
 
 import type { TrainScheduleSetFormData } from 'applications/operationalStudies/hooks/useScenarioTrainScheduleSet';
 import type { CatalogEntry, TrainScheduleSet } from 'common/api/osrdEditoastApi';
-import { LoaderFill } from 'common/Loaders';
 import { getErrorMessage } from 'utils/error';
-import { useAsyncMemo } from 'utils/useAsyncMemo';
 
 import TrainScheduleSetForm from './TrainScheduleSetForm';
 
@@ -17,7 +15,7 @@ type TrainScheduleSetDialogProps = {
   trainScheduleSet?: TrainScheduleSet;
   onCancel: () => void;
   onSubmit: (data: TrainScheduleSetFormData) => Promise<void>;
-  getCatalogEntries: () => Promise<CatalogEntry[]>;
+  catalogEntries: CatalogEntry[];
   checkNameInCatalogIsUniq?: (name: string, catalogId: number) => Promise<boolean>;
   labels: {
     title: string;
@@ -30,11 +28,10 @@ const TrainScheduleSetDialog = ({
   trainScheduleSet,
   onSubmit,
   onCancel,
-  getCatalogEntries,
+  catalogEntries,
   checkNameInCatalogIsUniq,
   labels,
 }: TrainScheduleSetDialogProps) => {
-  const catalog = useAsyncMemo(() => getCatalogEntries(), [getCatalogEntries]);
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
   const [formHasError, setFormHasError] = useState<boolean>(false);
@@ -92,12 +89,11 @@ const TrainScheduleSetDialog = ({
       <TrainScheduleSetForm
         formId="train-schedule-set"
         trainScheduleSet={trainScheduleSet}
-        catalog={catalog.type === 'ready' ? catalog.data : []}
+        catalogEntries={catalogEntries}
         onSubmit={submit}
         onValidation={(hasError) => setFormHasError(hasError)}
         checkNameInCatalogIsUniq={checkNameInCatalogIsUniq}
       />
-      {catalog.type === 'loading' && <LoaderFill />}
     </Dialog>
   );
 };

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TrainScheduleSet/TrainScheduleSetForm.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TrainScheduleSet/TrainScheduleSetForm.tsx
@@ -14,7 +14,7 @@ export type FieldName = 'name' | 'catalog' | 'description';
 type TrainScheduleSetFormProps = {
   formId: string;
   trainScheduleSet?: TrainScheduleSet;
-  catalog: CatalogEntry[];
+  catalogEntries: CatalogEntry[];
   onSubmit: (data: TrainScheduleSetFormData) => Promise<void>;
   isCatalogEntryRequired?: boolean;
   additionalValidations?: (
@@ -27,7 +27,7 @@ type TrainScheduleSetFormProps = {
 const TrainScheduleSetForm = ({
   formId,
   trainScheduleSet,
-  catalog,
+  catalogEntries,
   onSubmit,
   onValidation,
   checkNameInCatalogIsUniq,
@@ -59,7 +59,7 @@ const TrainScheduleSetForm = ({
       if (catalogEntryMode === 'create') {
         const catalogName = value && value.type === 'create' ? value.name : '';
         // Checking that the name is free
-        if (catalog.findIndex((e) => e.name === catalogName) > -1) {
+        if (catalogEntries.findIndex((e) => e.name === catalogName) > -1) {
           return {
             status: 'error',
             message: t('duplicateCatalogEntry'),
@@ -68,7 +68,7 @@ const TrainScheduleSetForm = ({
       }
       return undefined;
     },
-    [catalog, catalogEntryMode]
+    [catalogEntryMode]
   );
   const isCatalogEntryValid = useCallback(
     (value?: TrainScheduleSetFormData['catalog']) => {
@@ -87,7 +87,7 @@ const TrainScheduleSetForm = ({
       setCatalogEntryError(error);
       return error === undefined;
     },
-    [catalog, catalogEntryMode, checkCatalogEntryIsUniq]
+    [catalogEntryMode, checkCatalogEntryIsUniq]
   );
 
   /**
@@ -117,8 +117,8 @@ const TrainScheduleSetForm = ({
    * Sort the catalog for the select
    */
   const catalogSorted = useMemo(
-    () => catalog.sort((a, b) => (a.name && b.name ? a.name.localeCompare(b.name) : 0)),
-    [catalog]
+    () => catalogEntries.sort((a, b) => (a.name && b.name ? a.name.localeCompare(b.name) : 0)),
+    [catalogEntries]
   );
 
   /**
@@ -141,10 +141,10 @@ const TrainScheduleSetForm = ({
   const catalogSelected = useMemo(() => {
     if (catalogEntry && catalogEntry.type === 'selected') {
       const catalogId = catalogEntry.id;
-      return catalog.find((e) => e.id === catalogId);
+      return catalogEntries.find((e) => e.id === catalogId);
     }
     return undefined;
-  }, [catalogEntry, catalog]);
+  }, [catalogEntry, catalogEntries]);
 
   /**
    *  Status of the package name

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TrainScheduleSet/TrainScheduleSetTab.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TrainScheduleSet/TrainScheduleSetTab.tsx
@@ -19,7 +19,7 @@ import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 
 import type useScenarioTrainScheduleSet from 'applications/operationalStudies/hooks/useScenarioTrainScheduleSet';
-import type { TrainScheduleSet } from 'common/api/osrdEditoastApi';
+import type { CatalogEntry, TrainScheduleSet } from 'common/api/osrdEditoastApi';
 import MenuTriggerButton, { type MenuProps } from 'common/MenuTriggerButton';
 
 import TrainScheduleDeleteDialog from './TrainScheduleDeleteDialog';
@@ -45,7 +45,7 @@ type TrainScheduleSetTabProps = PropsWithChildren<{
   isSelected: boolean;
   isIndeterminate: boolean;
   isTrainListOpen: boolean;
-  getCatalogEntries: ReturnType<typeof useScenarioTrainScheduleSet>['getCatalogEntries'];
+  catalogEntries: CatalogEntry[];
   publishTrainScheduleSet: ReturnType<
     typeof useScenarioTrainScheduleSet
   >['publishTrainScheduleSet'];
@@ -69,7 +69,7 @@ const TrainScheduleSetTab = ({
   isIndeterminate,
   isTrainListOpen,
   children,
-  getCatalogEntries,
+  catalogEntries,
   publishTrainScheduleSet,
   getTrainScheduleSetByCatalogAndName,
   localCopyTrainScheduleSet,
@@ -179,7 +179,7 @@ const TrainScheduleSetTab = ({
         createPortal(
           <TrainScheduleSetDialog
             trainScheduleSet={trainScheduleSet}
-            getCatalogEntries={getCatalogEntries}
+            catalogEntries={catalogEntries}
             labels={{
               title: t('publishDialogTitle'),
               submit: t('publishSubmit'),
@@ -213,7 +213,7 @@ const TrainScheduleSetTab = ({
         createPortal(
           <TrainScheduleSetDialog
             trainScheduleSet={trainScheduleSet}
-            getCatalogEntries={getCatalogEntries}
+            catalogEntries={catalogEntries}
             labels={{
               title: t(openedDialog === 'editLocal' ? 'editLocalTitle' : 'editPublishedTitle'),
               submit: t('edit'),

--- a/front/src/applications/stdcm/hooks/useStdcm.ts
+++ b/front/src/applications/stdcm/hooks/useStdcm.ts
@@ -95,7 +95,7 @@ const useStdcm = ({
         infraId,
         dispatch
       );
-      const stdcmTrain: TimetableItem = {
+      const stdcmTrain: Omit<TimetableItem, 'train_schedule_set_id'> = {
         id: STDCM_TRAIN_TIMETABLE_ID,
         comfort: payload.body.comfort,
         constraint_distribution: 'MARECO',

--- a/front/src/applications/stdcm/utils/stdcmComputeChartData.ts
+++ b/front/src/applications/stdcm/utils/stdcmComputeChartData.ts
@@ -9,7 +9,7 @@ import type { TimetableItem } from 'reducers/osrdconf/types';
 
 const computeChartData = (
   stdcmResponse: StdcmSuccessResponse,
-  stdcmTrainResult: TimetableItem,
+  stdcmTrainResult: Omit<TimetableItem, 'train_schedule_set_id'>,
   t: TFunction,
   rollingStock: RollingStockWithLiveries,
   pathProperties: PathProperties

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -9,6 +9,7 @@ import {
 
 import {
   generatedEditoastApi,
+  type CatalogEntry,
   type CoreEtcsBrakingCurvesResponse,
   type GetLightRollingStockApiResponse,
   type GetSpritesSignalingSystemsApiResponse,
@@ -199,6 +200,30 @@ const osrdEditoastApi = generatedEditoastApi
           return { data: result };
         },
         providesTags: ['scenarios'],
+      }),
+      getAllCatalogEntries: builder.query<CatalogEntry[], unknown>({
+        queryFn: async (_args, { dispatch }) => {
+          const pageSize = 100;
+          let page = 1;
+          let reachEnd = false;
+          const result: CatalogEntry[] = [];
+          while (!reachEnd) {
+            const data = await dispatch(
+              osrdEditoastApi.endpoints.getCatalogEntries.initiate(
+                {
+                  pageSize,
+                  page,
+                },
+                { subscribe: false }
+              )
+            ).unwrap();
+            result.push(...data.results);
+            reachEnd = isNil(data.next);
+            page += 1;
+          }
+          return { data: result };
+        },
+        providesTags: ['catalog_entry'],
       }),
     }),
   })

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -363,6 +363,35 @@ const osrdEditoastApi = generatedEditoastApi
             }) as const
           )[args.searchPayload.object] ?? [],
       },
+
+      // Train schedule sets handling
+      getTimetableByIdTrainScheduleSets: {
+        providesTags: () => [{ type: 'train_schedule_set', id: 'LIST' }],
+      },
+      postTimetableByIdTrainScheduleSets: {
+        invalidatesTags: () => [{ type: 'train_schedule_set', id: 'LIST' }],
+      },
+      getTrainScheduleSets: {
+        providesTags: (result) => [
+          { type: 'train_schedule_set', id: 'LIST' },
+          ...(result || []).map(({ id }) => ({
+            type: 'train_schedule_set' as const,
+            id,
+          })),
+        ],
+      },
+      getTrainScheduleSetsById: {
+        providesTags: (_result, _error, args) => [{ type: 'train_schedule_set', id: args.id }],
+      },
+      postTrainScheduleSets: {
+        invalidatesTags: () => [{ type: 'train_schedule_set', id: 'LIST' }],
+      },
+      putTrainScheduleSetsById: {
+        invalidatesTags: (_result, _error, args) => [{ type: 'train_schedule_set', id: args.id }],
+      },
+      deleteTrainScheduleSetsById: {
+        invalidatesTags: () => [{ type: 'train_schedule_set', id: 'LIST' }],
+      },
     },
   });
 

--- a/front/src/modules/timetableItem/helpers/updateTimetableItemHelpers.ts
+++ b/front/src/modules/timetableItem/helpers/updateTimetableItemHelpers.ts
@@ -1,4 +1,8 @@
-import { osrdEditoastApi, type PacedTrain } from 'common/api/osrdEditoastApi';
+import {
+  osrdEditoastApi,
+  type PacedTrain,
+  type PacedTrainResponse,
+} from 'common/api/osrdEditoastApi';
 import type { PacedTrainId, TimetableItem, TimetableItemId } from 'reducers/osrdconf/types';
 import {
   unsetTrainIdsMatching,
@@ -68,7 +72,7 @@ export async function deletePacedTrains(dispatch: AppDispatch, ids: PacedTrainId
 
 export async function storePacedTrain(
   timetableItemIdToUpdate: TimetableItemId,
-  pacedTrain: PacedTrain,
+  pacedTrain: Omit<PacedTrainResponse, 'id'>,
   dispatch: AppDispatch,
   upsertTimetableItems: (timetableItems: TimetableItem[]) => void
 ): Promise<TimetableItem> {
@@ -80,7 +84,11 @@ export async function storePacedTrain(
       })
     );
   }
-  await updatePacedTrain(dispatch, timetableItemIdToUpdate, pacedTrain);
+
+  // Remove train_schedule_set_id before updating paced train as we don't want to pass it in the payload
+  const { train_schedule_set_id: _trainScheduleSetId, ...pacedTrainWithoutTrainScheduleSetId } =
+    pacedTrain;
+  await updatePacedTrain(dispatch, timetableItemIdToUpdate, pacedTrainWithoutTrainScheduleSetId);
   const updatedPacedTrain: TimetableItem = {
     ...pacedTrain,
     id: timetableItemIdToUpdate,

--- a/front/src/modules/timetableItem/types.ts
+++ b/front/src/modules/timetableItem/types.ts
@@ -67,7 +67,7 @@ export type SimulationSummary =
 
 export type TimetableItemWithSummaries = Omit<
   PacedTrainResponse,
-  'id' | 'train_name' | 'rolling_stock_name' | 'train_schedule_set_id' | 'start_time' | 'paced'
+  'id' | 'train_name' | 'rolling_stock_name' | 'start_time' | 'paced'
 > & {
   name: string;
   startTime: Date;

--- a/front/src/reducers/osrdconf/operationalStudiesConf/__tests__/operationalStudiesConfReducer.spec.ts
+++ b/front/src/reducers/osrdconf/operationalStudiesConf/__tests__/operationalStudiesConfReducer.spec.ts
@@ -20,6 +20,7 @@ import testTrainSettingsReducer from './trainSettingsReducer';
 
 const baseTimetableItemWithSummary: TimetableItemWithSummaries = {
   name: 'train1',
+  train_schedule_set_id: 1000,
   constraint_distribution: 'MARECO',
   rollingStock: { id: 1, name: 'rollingStock1' } as LightRollingStockWithLiveries,
   path: [

--- a/front/src/reducers/osrdconf/types.ts
+++ b/front/src/reducers/osrdconf/types.ts
@@ -15,10 +15,9 @@ import type {
   Distribution,
   LoadingGaugeType,
   RelatedOperationalPoint,
-  PacedTrain,
   PathItemLocation,
   ReceptionSignal,
-  TrainSchedule,
+  PacedTrainResponse,
 } from 'common/api/osrdEditoastApi';
 import type { PacedTrainWithDetails } from 'modules/timetableItem/types';
 import type { MapSettings } from 'reducers/commonMap/types';
@@ -212,13 +211,13 @@ export type TimetableItemToEditData = {
   occurrenceId?: OccurrenceId;
 };
 
-export type TimetableItem = PacedTrain & {
+export type TimetableItem = Omit<PacedTrainResponse, 'id'> & {
   id: PacedTrainId;
 };
-export type TrainBaseWithPacedTrainId = TrainSchedule & {
+export type TrainBaseWithPacedTrainId = Omit<PacedTrainResponse, 'id'> & {
   id: PacedTrainId;
 };
-export type TrainBaseWithOccurrenceId = TrainSchedule & {
+export type TrainBaseWithOccurrenceId = Omit<PacedTrainResponse, 'id'> & {
   id: OccurrenceId;
 };
 


### PR DESCRIPTION
part of #14769 

> [!NOTE]
> After this PR, all the trains will be associated with the sandbox id
    (train schedule set without name) by default.
    Creating a new train schedule set won't display it in the timetable
    until an upcoming PR so all the other mocked actions won't be accessible for now.
 
To test : open a scenario, switch to train schedule set mode and see that the only present tab is the sand box one with all trains of the scenario inside

> [!CAUTION]
> Since a lot of types has been changed, testing can also be done on create/edit a paced train or occurrence with exceptions, as well as in macro mode. 