### PR TITLE
add cell editing to new Times stops table

### DIFF
--- a/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
+++ b/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
@@ -24,7 +24,10 @@ import { useScenarioContext } from './useScenarioContext';
 /**
  * Prepare data to be used in simulation results
  */
-const useSimulationResults = (): SimulationResults | undefined => {
+const useSimulationResults = (): {
+  results: SimulationResults | undefined;
+  isSimulationDataLoading: boolean;
+} => {
   const { t } = useTranslation('operational-studies');
 
   const { infraId, electricalProfileSetId } = useScenarioContext();
@@ -70,26 +73,28 @@ const useSimulationResults = (): SimulationResults | undefined => {
     return findExceptionWithOccurrenceId(timetableItem.paced.exceptions, selectedTrainId);
   }, [selectedTrainId, timetableItem]);
 
-  const { currentData: pathfinding } = osrdEditoastApi.endpoints.getTrainPath.useQuery(
-    selectedTrainId
-      ? {
-          id: selectedTrainId,
-          infraId,
-          exceptionKey: exception?.key,
-        }
-      : skipToken
-  );
+  const { currentData: pathfinding, isFetching: isPathfindingFetching } =
+    osrdEditoastApi.endpoints.getTrainPath.useQuery(
+      selectedTrainId
+        ? {
+            id: selectedTrainId,
+            infraId,
+            exceptionKey: exception?.key,
+          }
+        : skipToken
+    );
 
-  const { currentData: simulation } = osrdEditoastApi.endpoints.getTrainSimulation.useQuery(
-    selectedTrainId
-      ? {
-          id: selectedTrainId,
-          infraId,
-          electricalProfileSetId,
-          exceptionKey: exception?.key,
-        }
-      : skipToken
-  );
+  const { currentData: simulation, isFetching: isSimulationFetching } =
+    osrdEditoastApi.endpoints.getTrainSimulation.useQuery(
+      selectedTrainId
+        ? {
+            id: selectedTrainId,
+            infraId,
+            electricalProfileSetId,
+            exceptionKey: exception?.key,
+          }
+        : skipToken
+    );
 
   // TODO: replace this API call by extracting the rolling stock from the rolling
   // stocks list
@@ -102,7 +107,7 @@ const useSimulationResults = (): SimulationResults | undefined => {
         : skipToken
     );
 
-  const { currentData: rawPathProperties } =
+  const { currentData: rawPathProperties, isFetching: isPathPropertiesFetching } =
     osrdEditoastApi.endpoints.postInfraByInfraIdPathProperties.useQuery(
       pathfinding?.status === 'success'
         ? {
@@ -114,8 +119,11 @@ const useSimulationResults = (): SimulationResults | undefined => {
         : skipToken
     );
 
+  const isSimulationDataLoading =
+    isPathfindingFetching || isSimulationFetching || isPathPropertiesFetching;
+
   if (!train || exception?.disabled) {
-    return undefined;
+    return { results: undefined, isSimulationDataLoading };
   }
 
   if (
@@ -124,7 +132,10 @@ const useSimulationResults = (): SimulationResults | undefined => {
     !rawPathProperties ||
     !rollingStock
   ) {
-    return { isValid: false, train, rollingStock };
+    return {
+      results: { isValid: false, train, rollingStock },
+      isSimulationDataLoading,
+    };
   }
 
   const pathProperties = preparePathPropertiesData(
@@ -144,13 +155,16 @@ const useSimulationResults = (): SimulationResults | undefined => {
     }) ?? [];
 
   return {
-    isValid: true,
-    train,
-    rollingStock,
-    simulation,
-    path: pathfinding,
-    pathProperties,
-    powerRestrictions,
+    results: {
+      isValid: true,
+      train,
+      rollingStock,
+      simulation,
+      path: pathfinding,
+      pathProperties,
+      powerRestrictions,
+    },
+    isSimulationDataLoading,
   };
 };
 

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/helpers/buildPacedTrainException.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/helpers/buildPacedTrainException.ts
@@ -1,4 +1,5 @@
 import { isEmpty, isEqual, omit } from 'lodash';
+import { v4 as uuidV4 } from 'uuid';
 
 import type { PacedTrainWithPaced } from 'applications/operationalStudies/types';
 import type { TrainSchedule, PacedTrainException } from 'common/api/osrdEditoastApi';
@@ -170,6 +171,46 @@ export function updatePacedTrainExceptionsList<T extends PacedTrainException>(
   return hasExceptions
     ? replaceElementAtIndex(currentExceptions, exceptionIndex, newException)
     : removeElementAtIndex(currentExceptions, exceptionIndex);
+}
+
+/**
+ * Build a PacedTrain with an updated or new exception for a specific occurrence.
+ * This centralizes the pattern of generating an exception and updating the exceptions list.
+ */
+export function buildPacedTrainWithUpdatedException(
+  originalPacedTrain: PacedTrainWithPaced,
+  updatedOccurrence: TrainSchedule,
+  occurrenceId: OccurrenceId
+): PacedTrainWithPaced {
+  const occurrenceIndex = isIndexedOccurrenceId(occurrenceId)
+    ? extractOccurrenceIndexFromOccurrenceId(occurrenceId)
+    : undefined;
+
+  const baseException = generatePacedTrainException(
+    updatedOccurrence,
+    originalPacedTrain,
+    occurrenceIndex ?? null
+  );
+
+  const existingException = findExceptionWithOccurrenceId(
+    originalPacedTrain.paced.exceptions,
+    occurrenceId
+  );
+
+  const updatedExceptions = updatePacedTrainExceptionsList(
+    originalPacedTrain.paced.exceptions,
+    {
+      ...baseException,
+      key: existingException?.key ?? uuidV4(),
+      occurrence_index: occurrenceIndex,
+    },
+    occurrenceId
+  );
+
+  return {
+    ...originalPacedTrain,
+    paced: { ...originalPacedTrain.paced, exceptions: updatedExceptions },
+  };
 }
 
 /**

--- a/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
@@ -227,6 +227,7 @@ const ScenarioContent = ({ activeBoards }: ScenarioContentProps) => {
                 timetableItemsWithDetails={timetableItemsWithDetails}
                 activeBoards={activeBoards}
                 updateTrainDepartureTime={updateTrainDepartureTimeWithNge}
+                upsertTimetableItems={upsertTimetableItems}
               />
             )}
             {activeBoards.has('macro') && (

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
@@ -23,7 +23,7 @@ import type { ProjectionData, TrainSpaceTimeData } from 'modules/simulationResul
 import TimesStopsOutput from 'modules/timesStops/TimesStopsOutput';
 import { findExceptionWithOccurrenceId } from 'modules/timetableItem/helpers/pacedTrain';
 import type { TimetableItemWithDetails } from 'modules/timetableItem/types';
-import type { TimetableItemId } from 'reducers/osrdconf/types';
+import type { TimetableItem, TimetableItemId } from 'reducers/osrdconf/types';
 import { toggleDisplayOnlyPathSteps, updateSelectedTrainId } from 'reducers/simulationResults';
 import {
   getDisplayOnlyPathSteps,
@@ -47,6 +47,7 @@ type SimulationResultsProps = {
   conflicts?: Conflict[];
   activeBoards: Set<Board>;
   updateTrainDepartureTime: (trainId: TimetableItemId, newDepartureTime: Date) => Promise<void>;
+  upsertTimetableItems: (timetableItems: TimetableItem[]) => void;
 };
 
 const SimulationResults = ({
@@ -56,6 +57,7 @@ const SimulationResults = ({
   conflicts = [],
   activeBoards,
   updateTrainDepartureTime,
+  upsertTimetableItems,
 }: SimulationResultsProps) => {
   const { t } = useTranslation('operational-studies');
   const dispatch = useAppDispatch();
@@ -330,15 +332,16 @@ const SimulationResults = ({
               <TimesStopsOutput
                 infraId={infraId}
                 selectedTrain={simulationResults?.train}
-                {...(simulationResults?.isValid && simulationSummary?.isValid
-                  ? {
-                      isValid: true,
-                      simulatedTrain: simulationResults.simulation.final_output,
-                      simulatedPathItemTimes: simulationSummary.pathItemTimes,
-                      simulatedPathItemRespect: simulationSummary.pathItemRespect,
-                      operationalPointsOnPath: simulationResults.pathProperties.operationalPoints,
-                    }
-                  : { isValid: false })}
+                timetableItemsWithDetails={timetableItemsWithDetails}
+                upsertTimetableItems={upsertTimetableItems}
+                {...(simulationResults?.isValid &&
+                  simulationSummary?.isValid && {
+                    isValid: true,
+                    simulatedTrain: simulationResults.simulation.final_output,
+                    simulatedPathItemTimes: simulationSummary.pathItemTimes,
+                    simulatedPathItemRespect: simulationSummary.pathItemRespect,
+                    operationalPointsOnPath: simulationResults.pathProperties.operationalPoints,
+                  })}
               />
             </div>
           </BoardWrapper>

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
@@ -63,7 +63,7 @@ const SimulationResults = ({
   const dispatch = useAppDispatch();
   const { infraId, timetableId } = useScenarioContext();
 
-  const simulationResults = useSimulationResults();
+  const { results: simulationResults, isSimulationDataLoading } = useSimulationResults();
   const selectedTrainId = simulationResults?.train.id;
 
   const displayOnlyPathSteps = useSelector(getDisplayOnlyPathSteps);
@@ -334,6 +334,7 @@ const SimulationResults = ({
                 selectedTrain={simulationResults?.train}
                 timetableItemsWithDetails={timetableItemsWithDetails}
                 upsertTimetableItems={upsertTimetableItems}
+                isSimulationDataLoading={isSimulationDataLoading}
                 {...(simulationResults?.isValid &&
                   simulationSummary?.isValid && {
                     isValid: true,

--- a/front/src/modules/timesStops/DurationCell.tsx
+++ b/front/src/modules/timesStops/DurationCell.tsx
@@ -1,8 +1,10 @@
 /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
 /* eslint-disable jsx-a11y/no-static-element-interactions */
-import { useReducer, useRef, useEffect, type Dispatch } from 'react';
+import { useReducer, useRef, useLayoutEffect, useEffect, useState, type Dispatch } from 'react';
 
+import { Clear } from '@osrd-project/ui-icons';
 import type { CellContext } from '@tanstack/react-table';
+import { createPortal } from 'react-dom';
 
 import type { Duration } from 'utils/duration';
 
@@ -10,11 +12,6 @@ import CellPlaceholder from './CellPlaceholder';
 import type { TimesStopsRowNew } from './types';
 
 type ActiveUnit = 'h' | 'm' | 's';
-
-type UnitState = {
-  value: string;
-  cursor: 0 | 1;
-};
 
 const UNITS: ActiveUnit[] = ['h', 'm', 's'];
 
@@ -24,14 +21,14 @@ const clamp = (unit: ActiveUnit, value: string) => {
   return value;
 };
 
-const secondsToUnits = (seconds: number): Record<ActiveUnit, UnitState> => {
+const secondsToUnits = (seconds: number): Record<ActiveUnit, string> => {
   const h = Math.floor(seconds / 3600);
   const m = Math.floor((seconds % 3600) / 60);
   const s = seconds % 60;
   return {
-    h: { value: String(h).padStart(2, '0'), cursor: 0 },
-    m: { value: String(m).padStart(2, '0'), cursor: 0 },
-    s: { value: String(s).padStart(2, '0'), cursor: 0 },
+    h: String(h).padStart(2, '0'),
+    m: String(m).padStart(2, '0'),
+    s: String(s).padStart(2, '0'),
   };
 };
 
@@ -42,116 +39,184 @@ const parseUnitValue = (val: string) => {
   return Number(val);
 };
 
-const unitsToSeconds = (u: Record<ActiveUnit, UnitState>) =>
-  parseUnitValue(u.h.value) * 3600 + parseUnitValue(u.m.value) * 60 + parseUnitValue(u.s.value);
-
-const emptyUnits = (): Record<ActiveUnit, UnitState> => ({
-  h: { value: '00', cursor: 0 },
-  m: { value: '00', cursor: 0 },
-  s: { value: '00', cursor: 0 },
-});
+const unitsToSeconds = (u: Record<ActiveUnit, string>) =>
+  parseUnitValue(u.h) * 3600 + parseUnitValue(u.m) * 60 + parseUnitValue(u.s);
 
 const getNextUnit = (u: ActiveUnit) => UNITS[Math.min(UNITS.length - 1, UNITS.indexOf(u) + 1)];
 const getPrevUnit = (u: ActiveUnit) => UNITS[Math.max(0, UNITS.indexOf(u) - 1)];
 
-const parseBuffer = (
-  buffer: string
-): { units: Record<ActiveUnit, UnitState>; activeUnit: ActiveUnit } => {
-  let h = '00';
-  let m = '00';
-  let s = '00';
-  let activeUnit: ActiveUnit = 'm';
+/** Two-space sentinel used to mark a unit as cleared (empty) by the user. */
+const CLEARED_VALUE = '  ';
+const isCleared = (value: string) => value === CLEARED_VALUE;
 
-  if (buffer.length === 0) {
-    return {
-      units: emptyUnits(),
-      activeUnit: 'm',
-    };
+/**
+ * In edit mode, when a unit has only 1 digit left and the user backspaces,
+ * pull the value from the unit to the left (h→m or m→s) and clear that left unit.
+ */
+const clearAndCascadeUp = (
+  units: Record<ActiveUnit, string>,
+  activeUnit: ActiveUnit
+): Record<ActiveUnit, string> => {
+  const prevUnit = getPrevUnit(activeUnit);
+  const prevValue = units[prevUnit];
+  if (prevUnit === activeUnit || isCleared(prevValue)) {
+    return { ...units, [activeUnit]: CLEARED_VALUE };
+  }
+  return {
+    ...units,
+    [activeUnit]: prevValue,
+    [prevUnit]: CLEARED_VALUE,
+  };
+};
+
+/**
+ * Backspace when all digits are selected (initial state): shifts all values one slot to the right
+ * up to activeUnit, clearing the leftmost slot. E.g. activeUnit='s': h→CLEARED, m←h, s←m.
+ */
+const cascadeAll = (
+  units: Record<ActiveUnit, string>,
+  activeUnit: ActiveUnit
+): Record<ActiveUnit, string> => {
+  const newUnits = { ...units };
+  const upTo = UNITS.indexOf(activeUnit);
+  for (let i = upTo; i > 0; i--) {
+    newUnits[UNITS[i]] = units[UNITS[i - 1]];
+  }
+  newUnits[UNITS[0]] = CLEARED_VALUE;
+  return newUnits;
+};
+
+type ApplyResult = { units: Record<ActiveUnit, string>; activeUnit: ActiveUnit };
+
+/**
+ * Applies one backspace in digit-edit mode (allDigitsSelected=false) starting at the given unit.
+ * If the unit is already CLEARED, navigates right and applies there (navigate+delete in one press).
+ * If the result is CLEARED and a unit to the right exists, auto-advances activeUnit.
+ */
+const applyDigitBackspace = (
+  units: Record<ActiveUnit, string>,
+  activeUnit: ActiveUnit
+): ApplyResult => {
+  const value = units[activeUnit];
+
+  if (isCleared(value)) {
+    const next = getNextUnit(activeUnit);
+    if (next === activeUnit) return { units, activeUnit }; // rightmost, nothing to do
+    return applyDigitBackspace(units, next);
   }
 
+  if (value[0] !== CLEARED_VALUE[0]) {
+    // 2 digits (XY): remove last → ' X'
+    return { units: { ...units, [activeUnit]: CLEARED_VALUE[0] + value[0] }, activeUnit };
+  }
+
+  // 1 digit (' X'): cascade from previous unit
+  const newUnits = clearAndCascadeUp(units, activeUnit);
+  if (isCleared(newUnits[activeUnit])) {
+    // Unit got cleared (no left neighbour to pull from): auto-advance right
+    const next = getNextUnit(activeUnit);
+    if (next !== activeUnit) return { units: newUnits, activeUnit: next };
+  }
+  return { units: newUnits, activeUnit };
+};
+
+/**
+ * In creation mode, digits fill m then s (≤4 digits), then redistribute h/m/s (5–6 digits),
+ * so that typing "013700" produces 01h37m00s. Derives display units from the digit string.
+ */
+const parseBuffer = (
+  digits: string
+): { units: Record<ActiveUnit, string>; activeUnit: ActiveUnit } => {
   const processChunk = (chunk: string, unit: ActiveUnit) => {
-    if (!chunk) return '00';
-
-    const num = Number(chunk);
-    let newVal = num;
-    if ((unit === 'm' || unit === 's') && num > 59) newVal = 59;
-    // For hours, we typically don't clamp to 59, but we can respect 2-digit max implicitly by slicing
-    // or just let it be. Currently slicing limits to 2 chars max (<= 99).
-
-    if (newVal !== num) {
-      return newVal.toString().padStart(2, '0');
-    }
-
-    if (chunk.length === 1) return ' ' + chunk;
-    return chunk.padStart(2, '0');
+    if (!chunk) return CLEARED_VALUE;
+    const n = Number(chunk);
+    const clamped = unit !== 'h' ? Math.min(n, 59) : n;
+    return clamped !== n
+      ? clamped.toString().padStart(2, '0')
+      : chunk.length === 1
+        ? CLEARED_VALUE[0] + chunk
+        : chunk.padStart(2, '0');
   };
 
-  if (buffer.length <= 4) {
-    m = processChunk(buffer.slice(0, 2), 'm');
-    s = processChunk(buffer.slice(2, 4), 's');
-    activeUnit = buffer.length <= 2 ? 'm' : 's';
-  } else {
-    h = processChunk(buffer.slice(0, 2), 'h');
-    m = processChunk(buffer.slice(2, 4), 'm');
-    s = processChunk(buffer.slice(4, 6), 's');
-    activeUnit = 's';
+  if (digits.length === 0)
+    return {
+      units: { h: CLEARED_VALUE, m: CLEARED_VALUE, s: CLEARED_VALUE },
+      activeUnit: 'm',
+    };
+  if (digits.length <= 4) {
+    return {
+      units: {
+        h: CLEARED_VALUE,
+        m: processChunk(digits.slice(0, 2), 'm'),
+        s: processChunk(digits.slice(2, 4), 's'),
+      },
+      activeUnit: digits.length <= 2 ? 'm' : 's',
+    };
   }
-
   return {
     units: {
-      h: { value: h, cursor: 0 },
-      m: { value: m, cursor: 0 },
-      s: { value: s, cursor: 0 },
+      h: processChunk(digits.slice(0, 2), 'h'),
+      m: processChunk(digits.slice(2, 4), 'm'),
+      s: processChunk(digits.slice(4, 6), 's'),
     },
-    activeUnit,
+    activeUnit: 's',
   };
 };
 
 type DurationState = {
   isEditing: boolean;
-  hasTyped: boolean;
+  allDigitsSelected: boolean;
   isCreationMode: boolean;
-  finishedEntry: boolean;
   activeUnit: ActiveUnit;
-  units: Record<ActiveUnit, UnitState>;
-  buffer: string;
-  initialSeconds: number;
+  units: Record<ActiveUnit, string>;
+  creationDigits: string; // buffer for creation mode : digits shift h←m←s as you type
 };
 
 type DurationAction =
-  | { type: 'START_EDITING'; payload: { seconds: number; unit: ActiveUnit } }
+  | {
+      type: 'START_EDITING';
+      payload: { seconds: number; unit: ActiveUnit; isCreationMode: boolean };
+    }
   | { type: 'STOP_EDITING' }
   | { type: 'WRITE_DIGIT'; payload: string }
   | { type: 'BACKSPACE' }
   | { type: 'NAVIGATE'; payload: 'left' | 'right' }
   | { type: 'SET_ACTIVE_UNIT'; payload: ActiveUnit }
-  | { type: 'DISABLE_CREATION_MODE' };
+  | { type: 'EXTERNAL_VALUE_CHANGED'; payload: number };
 
 const initialState: DurationState = {
   isEditing: false,
-  hasTyped: false,
+  allDigitsSelected: true,
   isCreationMode: false,
-  finishedEntry: false,
   activeUnit: 'm',
-  units: emptyUnits(),
-  buffer: '',
-  initialSeconds: 0,
+  units: secondsToUnits(0),
+  creationDigits: '',
 };
+
+const initialDurationState = (controlledValue: Duration | null): DurationState => ({
+  ...initialState,
+  units: controlledValue
+    ? secondsToUnits(Math.round(controlledValue.total('second')))
+    : secondsToUnits(0),
+});
 
 const durationReducer = (state: DurationState, action: DurationAction): DurationState => {
   switch (action.type) {
     case 'START_EDITING': {
-      const { seconds, unit } = action.payload;
+      const { seconds, unit, isCreationMode } = action.payload;
+      const clearedUnits: Record<ActiveUnit, string> = {
+        h: CLEARED_VALUE,
+        m: CLEARED_VALUE,
+        s: CLEARED_VALUE,
+      };
       return {
         ...state,
-        units: seconds ? secondsToUnits(seconds) : emptyUnits(),
+        units: isCreationMode ? clearedUnits : secondsToUnits(seconds),
         activeUnit: unit,
         isEditing: true,
-        hasTyped: false,
-        isCreationMode: seconds === 0,
-        finishedEntry: false,
-        buffer: '',
-        initialSeconds: seconds,
+        allDigitsSelected: true,
+        isCreationMode,
+        creationDigits: '',
       };
     }
     case 'STOP_EDITING': {
@@ -165,87 +230,77 @@ const durationReducer = (state: DurationState, action: DurationAction): Duration
 
     case 'WRITE_DIGIT': {
       const digit = action.payload;
-      if (state.finishedEntry) return state;
 
-      const newState = { ...state, hasTyped: true };
-
-      if (newState.isCreationMode) {
-        const nextBuffer = newState.buffer + digit;
-        if (nextBuffer.length > 6) return newState;
-
-        newState.buffer = nextBuffer;
-
-        const { units, activeUnit } = parseBuffer(nextBuffer);
-        newState.units = units;
-        newState.activeUnit = activeUnit;
-        return newState;
+      if (state.isCreationMode) {
+        const nextDigits = state.creationDigits + digit;
+        if (nextDigits.length > 6) return state;
+        const { units, activeUnit } = parseBuffer(nextDigits);
+        return {
+          ...state,
+          allDigitsSelected: false,
+          creationDigits: nextDigits,
+          units,
+          activeUnit,
+        };
       }
 
-      // Shift edit mode
-      const unit = newState.units[newState.activeUnit];
-      const nextValue = clamp(newState.activeUnit, unit.value[1] + digit);
+      const value = state.units[state.activeUnit];
+      // Replacement mode: initial state, cleared unit, or untouched '00' unit
+      const nextValue =
+        state.allDigitsSelected || value === '00' || isCleared(value)
+          ? CLEARED_VALUE[0] + digit
+          : clamp(state.activeUnit, value[1] + digit);
 
       return {
-        ...newState,
-        units: {
-          ...newState.units,
-          [newState.activeUnit]: { value: nextValue, cursor: 1 },
-        },
+        ...state,
+        allDigitsSelected: false,
+        units: { ...state.units, [state.activeUnit]: nextValue },
       };
     }
 
     case 'BACKSPACE': {
-      const newState = { ...state };
-      // Reset hasTyped logic akin to original
-      newState.hasTyped = true;
-
-      if (newState.finishedEntry) newState.finishedEntry = false;
-
-      if (newState.isCreationMode) {
-        if (newState.buffer.length === 0) return newState;
-        const nextBuffer = newState.buffer.slice(0, -1);
-        newState.buffer = nextBuffer;
-
-        const { units, activeUnit } = parseBuffer(nextBuffer);
-        newState.units = units;
-        newState.activeUnit = activeUnit;
-        return newState;
-      }
-
-      // Shift edit mode backspace
-      const unit = newState.units[newState.activeUnit];
-      if (unit.value !== '00') {
-        const nextValue = '0' + unit.value[0];
-        newState.units = {
-          ...newState.units,
-          [newState.activeUnit]: { value: nextValue, cursor: 1 },
+      if (state.isCreationMode && state.creationDigits.length > 0) {
+        const nextDigits = state.creationDigits.slice(0, -1);
+        const { units, activeUnit } = parseBuffer(nextDigits);
+        return {
+          ...state,
+          allDigitsSelected: false,
+          creationDigits: nextDigits,
+          units,
+          activeUnit,
         };
-        return newState;
       }
 
-      const prevUnit = getPrevUnit(newState.activeUnit);
-      newState.activeUnit = prevUnit;
-      // When moving back to prev unit, do we clear it? Or just focus it?
-      // Standard behavior: just focus it.
-      // But if we backtrack, maybe we want to delete last digit of prev unit?
-      // Let's stick to navigation for now, or just focus.
-      return newState;
+      if (state.allDigitsSelected) {
+        return {
+          ...state,
+          isCreationMode: false,
+          allDigitsSelected: false,
+          units: cascadeAll(state.units, state.activeUnit),
+        };
+      }
+
+      const { units, activeUnit } = applyDigitBackspace(state.units, state.activeUnit);
+      return { ...state, isCreationMode: false, allDigitsSelected: false, units, activeUnit };
     }
 
     case 'NAVIGATE': {
       const direction = action.payload;
       return {
         ...state,
+        isCreationMode: false,
         activeUnit:
           direction === 'left' ? getPrevUnit(state.activeUnit) : getNextUnit(state.activeUnit),
       };
     }
 
     case 'SET_ACTIVE_UNIT':
-      return { ...state, activeUnit: action.payload };
+      return { ...state, isCreationMode: false, activeUnit: action.payload };
 
-    case 'DISABLE_CREATION_MODE':
-      return { ...state, isCreationMode: false };
+    case 'EXTERNAL_VALUE_CHANGED':
+      // Only sync if not currently editing to avoid overwriting user input
+      if (state.isEditing) return state;
+      return { ...state, units: secondsToUnits(action.payload) };
 
     default:
       return state;
@@ -266,7 +321,7 @@ const UnitDisplay = ({ unit, state, dispatch, startEditing, isEdited }: UnitDisp
   const baseClass = 'duration-cell-digit';
   const savedClass = !state.isEditing && isEdited ? `${baseClass}-saved` : '';
   const focusClass = focused
-    ? state.hasTyped
+    ? !state.allDigitsSelected
       ? 'duration-cell-digit-focused-editing'
       : 'duration-cell-digit-focused-initial'
     : '';
@@ -282,18 +337,23 @@ const UnitDisplay = ({ unit, state, dispatch, startEditing, isEdited }: UnitDisp
         e.stopPropagation();
         if (state.isEditing) {
           dispatch({ type: 'SET_ACTIVE_UNIT', payload: unit });
-          dispatch({ type: 'DISABLE_CREATION_MODE' });
         } else {
           startEditing(unit);
         }
       }}
     >
       <span className="duration-cell-digits-value">
-        {focused && state.hasTyped && (
+        {focused && !state.allDigitsSelected && !isCleared(u) && (
           <span className="duration-cell-caret" style={{ left: '100%' }} />
         )}
-        <span>{u.value[0]}</span>
-        <span>{u.value[1]}</span>
+        {isCleared(u) ? (
+          <span className="duration-cell-cleared">--</span>
+        ) : (
+          <>
+            <span>{u[0] === CLEARED_VALUE[0] ? '-' : u[0]}</span>
+            <span>{u[1]}</span>
+          </>
+        )}
       </span>
       {unit && <span className={letterClass}>{unit}</span>}
     </span>
@@ -301,30 +361,71 @@ const UnitDisplay = ({ unit, state, dispatch, startEditing, isEdited }: UnitDisp
 };
 
 const DurationCell = ({
+  disabled,
   ...props
 }: CellContext<TimesStopsRowNew, Duration | null> &
   Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange'> & {
-    onChange?: (e: { target: { value: number } }) => void;
+    onChange?: (e: { target: { value: number | null } }) => void;
+    disabled?: boolean;
   }) => {
-  const { onChange } = props || {};
-  const [state, dispatch] = useReducer(durationReducer, initialState);
+  const { onChange, getValue } = props || {};
+  const controlledValue = getValue();
+  const [state, dispatch] = useReducer(durationReducer, controlledValue, initialDurationState);
   const containerRef = useRef<HTMLDivElement>(null);
   const mouseDownRef = useRef(false);
+  const [btnPos, setBtnPos] = useState<{ top: number; left: number } | null>(null);
 
+  // Sync internal state with external value when it changes (and not editing)
   useEffect(() => {
-    if (state.isEditing && containerRef.current) {
-      containerRef.current.focus();
+    const seconds = controlledValue?.total('second') ?? 0;
+    dispatch({ type: 'EXTERNAL_VALUE_CHANGED', payload: Math.round(seconds) });
+  }, [controlledValue]);
+
+  useLayoutEffect(() => {
+    if (!state.isEditing) {
+      setBtnPos(null);
+      return undefined;
     }
+    containerRef.current?.focus();
+    const updatePos = () => {
+      if (!containerRef.current) return;
+      const rect = containerRef.current.closest('td')!.getBoundingClientRect();
+      setBtnPos({ top: rect.top + rect.height / 2, left: rect.left });
+    };
+    updatePos();
+    window.addEventListener('scroll', updatePos, true);
+    window.addEventListener('resize', updatePos);
+    return () => {
+      window.removeEventListener('scroll', updatePos, true);
+      window.removeEventListener('resize', updatePos);
+    };
   }, [state.isEditing]);
 
   const startEditing = (unit: ActiveUnit) => {
-    const seconds = unitsToSeconds(state.units);
-    const targetUnit = seconds === 0 ? 'm' : unit;
-    dispatch({ type: 'START_EDITING', payload: { seconds, unit: targetUnit } });
+    if (disabled) return;
+    const isCreationMode = controlledValue === null;
+    const seconds = isCreationMode ? 0 : Math.round(controlledValue.total('second'));
+    dispatch({
+      type: 'START_EDITING',
+      payload: { seconds, unit: isCreationMode ? 'm' : unit, isCreationMode },
+    });
+  };
+
+  const handleClear = () => {
+    if (controlledValue !== null) onChange?.({ target: { value: null } });
+    dispatch({ type: 'STOP_EDITING' });
   };
 
   const commit = () => {
-    onChange?.({ target: { value: unitsToSeconds(state.units) } });
+    const allCleared = Object.values(state.units).every((u) => isCleared(u));
+    if (allCleared) {
+      if (controlledValue !== null) onChange?.({ target: { value: null } });
+    } else {
+      const newSeconds = unitsToSeconds(state.units);
+      const initialSeconds =
+        controlledValue !== null ? Math.round(controlledValue.total('second')) : null;
+      if (newSeconds !== initialSeconds) onChange?.({ target: { value: newSeconds } });
+    }
     dispatch({ type: 'STOP_EDITING' });
   };
 
@@ -356,8 +457,8 @@ const DurationCell = ({
     }
   };
 
-  const isEdited = Object.values(state.units).some((u) => u.value !== '00');
-  const showPlaceholder = !state.isEditing && !isEdited;
+  const isEdited = controlledValue !== null || Object.values(state.units).some((u) => u !== '00');
+  const showPlaceholder = !state.isEditing && controlledValue === null;
 
   const handleMouseDown = () => {
     mouseDownRef.current = true;
@@ -367,38 +468,66 @@ const DurationCell = ({
     mouseDownRef.current = false;
   };
 
+  const clearButton =
+    state.isEditing && btnPos
+      ? createPortal(
+          <button
+            type="button"
+            className="duration-cell-clear-btn"
+            tabIndex={-1}
+            style={{ top: btnPos.top, left: btnPos.left }}
+            onMouseDown={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+            }}
+            onClick={(e) => {
+              e.stopPropagation();
+              handleClear();
+            }}
+          >
+            <Clear size="sm" />
+          </button>,
+          document.body
+        )
+      : null;
+
   return (
-    <div
-      ref={containerRef}
-      tabIndex={0}
-      className="duration-cell"
-      onKeyDown={handleKeyDown}
-      onFocus={() => {
-        if (!mouseDownRef.current && !state.isEditing) startEditing('m');
-      }}
-      onMouseDown={handleMouseDown}
-      onMouseUp={handleMouseUp}
-      onBlur={() => {
-        mouseDownRef.current = false;
-        if (state.isEditing) commit();
-      }}
-      onClick={() => !state.isEditing && startEditing('m')}
-    >
-      {showPlaceholder ? (
-        <CellPlaceholder onClick={() => {}} />
-      ) : (
-        UNITS.map((unit) => (
-          <UnitDisplay
-            key={unit}
-            unit={unit}
-            state={state}
-            dispatch={dispatch}
-            startEditing={startEditing}
-            isEdited={isEdited}
-          />
-        ))
-      )}
-    </div>
+    <>
+      <div
+        ref={containerRef}
+        tabIndex={0}
+        className="duration-cell"
+        onKeyDown={handleKeyDown}
+        onFocus={() => {
+          if (!mouseDownRef.current && !state.isEditing) startEditing('m');
+        }}
+        onMouseDown={handleMouseDown}
+        onMouseUp={handleMouseUp}
+        onBlur={() => {
+          mouseDownRef.current = false;
+          if (state.isEditing) commit();
+        }}
+        onClick={() => !state.isEditing && startEditing('m')}
+      >
+        {showPlaceholder ? (
+          <CellPlaceholder onClick={() => {}} />
+        ) : (
+          <>
+            {UNITS.map((unit) => (
+              <UnitDisplay
+                key={unit}
+                unit={unit}
+                state={state}
+                dispatch={dispatch}
+                startEditing={startEditing}
+                isEdited={isEdited}
+              />
+            ))}
+          </>
+        )}
+      </div>
+      {clearButton}
+    </>
   );
 };
 

--- a/front/src/modules/timesStops/TimeCell.tsx
+++ b/front/src/modules/timesStops/TimeCell.tsx
@@ -2,6 +2,8 @@ import { useEffect, useReducer, useRef, type ChangeEvent } from 'react';
 
 import type { CellContext } from '@tanstack/react-table';
 
+import { SECONDS_IN_A_DAY } from 'utils/timeManipulation';
+
 import CellPlaceholder from './CellPlaceholder';
 import type { TimesStopsRowNew } from './types';
 
@@ -34,7 +36,8 @@ type TimeAction =
   | { type: 'FOCUSED'; section: Section }
   | { type: 'LEFT_ARROW_PRESSED' }
   | { type: 'RIGHT_ARROW_PRESSED' }
-  | { type: 'BLURRED' };
+  | { type: 'BLURRED' }
+  | { type: 'EXTERNAL_VALUE_CHANGED'; value: Date | null };
 
 // Helpers
 
@@ -365,6 +368,13 @@ const handleHorizontalArrow = (state: TimeState, direction: 'left' | 'right'): T
   };
 };
 
+const initialTimeState = (controlledValue: Date | null): TimeState => ({
+  ...parseTimeState(controlledValue),
+  focusedSection: null,
+  empty: controlledValue === null,
+  hasTyped: controlledValue === null,
+});
+
 // Reducer
 
 const timeReducer = (state: TimeState, action: TimeAction): TimeState => {
@@ -385,17 +395,40 @@ const timeReducer = (state: TimeState, action: TimeAction): TimeState => {
       return handleHorizontalArrow(state, 'left');
     case 'RIGHT_ARROW_PRESSED':
       return handleHorizontalArrow(state, 'right');
+    case 'EXTERNAL_VALUE_CHANGED':
+      // Don't override user's in-progress edits
+      if (state.focusedSection) return state;
+      return initialTimeState(action.value);
     default:
       return state;
   }
 };
 
-const initialTimeState = (controlledValue: Date | null): TimeState => ({
-  ...parseTimeState(controlledValue),
-  focusedSection: null,
-  empty: controlledValue === null,
-  hasTyped: controlledValue === null,
-});
+// Helpers for commit
+
+/**
+ * Build a Date from the time state using referenceDate as the calendar day base.
+ * If the resulting time is before referenceDate, assume it's the next day.
+ */
+const buildDateFromState = (state: TimeState, referenceDate: Date): Date | null => {
+  if (state.empty) return null;
+
+  const hours = parseInt(state.hours, 10);
+  const minutes = parseInt(state.minutes, 10);
+  const seconds = parseInt(state.seconds, 10);
+
+  if (isNaN(hours) || isNaN(minutes) || isNaN(seconds)) return null;
+
+  const result = new Date(referenceDate);
+  result.setHours(hours, minutes, seconds, 0);
+
+  // If the result is before the reference, assume the user meant the next day
+  if (result < referenceDate) {
+    result.setTime(result.getTime() + SECONDS_IN_A_DAY * 1000);
+  }
+
+  return result;
+};
 
 // Component
 
@@ -417,10 +450,14 @@ const renderTimeSection = (value: string, focused: boolean, hasTyped: boolean) =
   </span>
 );
 
-const TimeCell = ({
-  getValue,
-  ...props
-}: CellContext<TimesStopsRowNew, Date | null> & React.InputHTMLAttributes<HTMLInputElement>) => {
+type TimeCellProps = CellContext<TimesStopsRowNew, Date | null> &
+  React.InputHTMLAttributes<HTMLInputElement> & {
+    /** Reference date used as the calendar day base. If the entered time is before this date, the next day is assumed. */
+    referenceDate?: Date;
+    onCommit?: (date: Date | null) => void;
+  };
+
+const TimeCell = ({ getValue, referenceDate, onCommit, ...props }: TimeCellProps) => {
   const { onKeyDown, onBlur, onFocus, onChange, ...userProps } = props || {};
 
   const controlledValue = getValue();
@@ -499,8 +536,23 @@ const TimeCell = ({
 
   const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
     dispatch({ type: 'BLURRED' });
+
+    if (onCommit && referenceDate) {
+      const newDate = buildDateFromState(state, referenceDate);
+      const hasChanged = newDate?.getTime() !== controlledValue?.getTime();
+      if (hasChanged) {
+        onCommit(newDate);
+      }
+    }
+
     onBlur?.(e);
   };
+
+  // Sync internal state when the external controlled value changes (e.g., after simulation re-run).
+  // Skip sync while the user is editing (focusedSection !== null) — handled by the reducer guard.
+  useEffect(() => {
+    dispatch({ type: 'EXTERNAL_VALUE_CHANGED', value: controlledValue });
+  }, [controlledValue?.getTime()]);
 
   useEffect(() => {
     if (state.focusedSection) {

--- a/front/src/modules/timesStops/TimesStopsOutput.tsx
+++ b/front/src/modules/timesStops/TimesStopsOutput.tsx
@@ -37,6 +37,7 @@ type TimesStopsOutputProps = {
   simulatedPathItemTimes?: Extract<SimulationSummary, { isValid: true }>['pathItemTimes'];
   simulatedPathItemRespect?: Extract<SimulationSummary, { isValid: true }>['pathItemRespect'];
   operationalPointsOnPath?: PathPropertiesFormatted['operationalPoints'];
+  isSimulationDataLoading?: boolean;
 };
 
 const TimesStopsOutput = ({
@@ -49,11 +50,15 @@ const TimesStopsOutput = ({
   simulatedPathItemTimes,
   simulatedPathItemRespect,
   operationalPointsOnPath,
+  isSimulationDataLoading = false,
 }: TimesStopsOutputProps) => {
   const useNewTimesStopsTable = useSelector(getUseNewTimesStopsTable);
 
-  // Store the simulatedPathItemTimes reference before an edit to detect when new simulation arrives
+  // Refs used to track simulation refresh after a user edit (see isAwaitingSimulation):
+  //   - preEditPathItemTimesRef: batch summary (simulatedPathItemTimes reference)
+  //   - isTrainSimulationPendingRef: all simulation queries (isSimulationDataLoading)
   const preEditPathItemTimesRef = useRef<typeof simulatedPathItemTimes>(undefined);
+  const isTrainSimulationPendingRef = useRef(false);
 
   // Store pending edit for optimistic UI update (state to trigger re-render)
   const [pendingEdit, setPendingEdit] = useState<PendingEdit | null>(null);
@@ -68,9 +73,10 @@ const TimesStopsOutput = ({
     useNewTimesStopsTable ? undefined : operationalPointsOnPath
   );
 
-  const newRows = useTimesStopsTableData(
+  const { rows: newRows, stableIsValid } = useTimesStopsTableData(
     infraId,
     isValid,
+    isSimulationDataLoading,
     selectedTrain,
     useNewTimesStopsTable ? simulatedTrain : undefined,
     useNewTimesStopsTable ? simulatedPathItemTimes : undefined,
@@ -87,40 +93,58 @@ const TimesStopsOutput = ({
     upsertTimetableItems
   );
 
-  // Are we waiting for simulation to refresh after a user edit?
+  // True if we are still waiting for fresh simulation data after a user edit.
+  // Both pipelines must finish before we clear the loading state:
+  //   - Condition 1 (batch summary): wait until simulatedPathItemTimes gets a new reference.
+  //   - Condition 2 (all simulation queries): wait until isSimulationDataLoading is false.
   const isAwaitingSimulation =
-    preEditPathItemTimesRef.current !== undefined &&
-    simulatedPathItemTimes === preEditPathItemTimesRef.current;
+    (preEditPathItemTimesRef.current !== undefined &&
+      simulatedPathItemTimes === preEditPathItemTimesRef.current) ||
+    (isTrainSimulationPendingRef.current && isSimulationDataLoading);
 
-  // Clear refs/state when fresh simulation data arrives
+  // Reset refs and pending edit once both pipelines are done
   useEffect(() => {
-    if (!isAwaitingSimulation && preEditPathItemTimesRef.current !== undefined) {
+    if (
+      !isAwaitingSimulation &&
+      (preEditPathItemTimesRef.current !== undefined || isTrainSimulationPendingRef.current)
+    ) {
       preEditPathItemTimesRef.current = undefined;
+      isTrainSimulationPendingRef.current = false;
       setPendingEdit(null);
     }
   }, [isAwaitingSimulation]);
 
+  // Call this before any edit to start tracking simulation refresh.
+  const startSimulationTracking = (pendingEditValue: PendingEdit) => {
+    preEditPathItemTimesRef.current = simulatedPathItemTimes;
+    isTrainSimulationPendingRef.current = true;
+    setPendingEdit(pendingEditValue);
+  };
+
+  // Call this on error to cancel the tracking started by startSimulationTracking.
+  const cancelSimulationTracking = () => {
+    preEditPathItemTimesRef.current = undefined;
+    isTrainSimulationPendingRef.current = false;
+    setPendingEdit(null);
+  };
+
   const handleArrivalChange = async (row: TimesStopsRowNew, arrival: Date | null) => {
     if (isAwaitingSimulation) return;
-    preEditPathItemTimesRef.current = simulatedPathItemTimes;
-    setPendingEdit({ rowId: row.id, field: 'requestedArrival', value: arrival });
+    startSimulationTracking({ rowId: row.id, field: 'requestedArrival', value: arrival });
     try {
       await updateArrival(row, arrival);
     } catch {
-      preEditPathItemTimesRef.current = undefined;
-      setPendingEdit(null);
+      cancelSimulationTracking();
     }
   };
 
   const handleDepartureChange = async (row: TimesStopsRowNew, departure: Date | null) => {
     if (isAwaitingSimulation) return;
-    preEditPathItemTimesRef.current = simulatedPathItemTimes;
-    setPendingEdit({ rowId: row.id, field: 'requestedDeparture', value: departure });
+    startSimulationTracking({ rowId: row.id, field: 'requestedDeparture', value: departure });
     try {
       await updateDeparture(row, departure);
     } catch {
-      preEditPathItemTimesRef.current = undefined;
-      setPendingEdit(null);
+      cancelSimulationTracking();
     }
   };
 
@@ -129,8 +153,7 @@ const TimesStopsOutput = ({
     durationSeconds: number | null
   ) => {
     if (isAwaitingSimulation) return;
-    preEditPathItemTimesRef.current = simulatedPathItemTimes;
-    setPendingEdit({
+    startSimulationTracking({
       rowId: row.id,
       field: 'stopDuration',
       value: durationSeconds !== null ? new Duration({ seconds: durationSeconds }) : null,
@@ -138,8 +161,7 @@ const TimesStopsOutput = ({
     try {
       await updateStopDuration(row, durationSeconds);
     } catch {
-      preEditPathItemTimesRef.current = undefined;
-      setPendingEdit(null);
+      cancelSimulationTracking();
     }
   };
 
@@ -158,8 +180,7 @@ const TimesStopsOutput = ({
       <TimesStopsTable
         rows={displayRows}
         startTime={startTime}
-        dataIsLoading={newRows.length === 0}
-        isValid={isValid}
+        isValid={stableIsValid}
         isComputedDataPending={isAwaitingSimulation}
         onArrivalChange={handleArrivalChange}
         onStopDurationChange={handleStopDurationChange}

--- a/front/src/modules/timesStops/TimesStopsOutput.tsx
+++ b/front/src/modules/timesStops/TimesStopsOutput.tsx
@@ -12,6 +12,7 @@ import type { SimulationSummary, TimetableItemWithDetails } from 'modules/timeta
 import type { TimetableItem, Train } from 'reducers/osrdconf/types';
 import { getUseNewTimesStopsTable } from 'reducers/user/userSelectors';
 import { formatLocalTime } from 'utils/date';
+import { Duration } from 'utils/duration';
 
 import useOutputTableData from './hooks/useOutputTableData';
 import useTimesStopsTableData from './hooks/useTimesStopsTableData';
@@ -19,6 +20,11 @@ import useUpdateTimesStopsTable from './hooks/useUpdateTimesStopsTable';
 import TimesStops from './TimesStops';
 import TimesStopsTable from './TimesStopsTable';
 import { TableType, type TimesStopsRow, type TimesStopsRowNew } from './types';
+
+type PendingEdit =
+  | { rowId: string; field: 'requestedArrival'; value: Date | null }
+  | { rowId: string; field: 'requestedDeparture'; value: Date | null }
+  | { rowId: string; field: 'stopDuration'; value: Duration | null };
 
 type TimesStopsOutputProps = {
   infraId: number;
@@ -50,11 +56,7 @@ const TimesStopsOutput = ({
   const preEditPathItemTimesRef = useRef<typeof simulatedPathItemTimes>(undefined);
 
   // Store pending edit for optimistic UI update (state to trigger re-render)
-  const [pendingEdit, setPendingEdit] = useState<{
-    rowId: string;
-    field: 'requestedArrival' | 'requestedDeparture';
-    value: Date | null;
-  } | null>(null);
+  const [pendingEdit, setPendingEdit] = useState<PendingEdit | null>(null);
 
   // Only call the hook that corresponds to the active table to avoid unnecessary computation
   const legacyRows = useOutputTableData(
@@ -78,7 +80,7 @@ const TimesStopsOutput = ({
 
   const startTime = useMemo(() => new Date(selectedTrain.start_time), [selectedTrain.start_time]);
 
-  const { updateArrival, updateDeparture } = useUpdateTimesStopsTable(
+  const { updateArrival, updateStopDuration, updateDeparture } = useUpdateTimesStopsTable(
     selectedTrain,
     newRows,
     timetableItemsWithDetails,
@@ -122,6 +124,25 @@ const TimesStopsOutput = ({
     }
   };
 
+  const handleStopDurationChange = async (
+    row: TimesStopsRowNew,
+    durationSeconds: number | null
+  ) => {
+    if (isAwaitingSimulation) return;
+    preEditPathItemTimesRef.current = simulatedPathItemTimes;
+    setPendingEdit({
+      rowId: row.id,
+      field: 'stopDuration',
+      value: durationSeconds !== null ? new Duration({ seconds: durationSeconds }) : null,
+    });
+    try {
+      await updateStopDuration(row, durationSeconds);
+    } catch {
+      preEditPathItemTimesRef.current = undefined;
+      setPendingEdit(null);
+    }
+  };
+
   // Apply optimistic update to display rows
   const displayRows = pendingEdit
     ? newRows.map((row) => {
@@ -141,6 +162,7 @@ const TimesStopsOutput = ({
         isValid={isValid}
         isComputedDataPending={isAwaitingSimulation}
         onArrivalChange={handleArrivalChange}
+        onStopDurationChange={handleStopDurationChange}
         onDepartureChange={handleDepartureChange}
       />
     );

--- a/front/src/modules/timesStops/TimesStopsOutput.tsx
+++ b/front/src/modules/timesStops/TimesStopsOutput.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+
 import cx from 'classnames';
 import { useSelector } from 'react-redux';
 
@@ -6,21 +8,24 @@ import type {
   CorePathfindingResultSuccess,
   SimulationResponseSuccess,
 } from 'common/api/osrdEditoastApi';
-import type { SimulationSummary } from 'modules/timetableItem/types';
-import type { Train } from 'reducers/osrdconf/types';
+import type { SimulationSummary, TimetableItemWithDetails } from 'modules/timetableItem/types';
+import type { TimetableItem, Train } from 'reducers/osrdconf/types';
 import { getUseNewTimesStopsTable } from 'reducers/user/userSelectors';
 import { formatLocalTime } from 'utils/date';
 
 import useOutputTableData from './hooks/useOutputTableData';
 import useTimesStopsTableData from './hooks/useTimesStopsTableData';
+import useUpdateTimesStopsTable from './hooks/useUpdateTimesStopsTable';
 import TimesStops from './TimesStops';
 import TimesStopsTable from './TimesStopsTable';
-import { TableType, type TimesStopsRow } from './types';
+import { TableType, type TimesStopsRow, type TimesStopsRowNew } from './types';
 
 type TimesStopsOutputProps = {
   infraId: number;
-  isValid: boolean;
+  isValid?: boolean;
   selectedTrain: Train;
+  timetableItemsWithDetails: TimetableItemWithDetails[];
+  upsertTimetableItems: (timetableItems: TimetableItem[]) => void;
   simulatedTrain?: SimulationResponseSuccess['final_output'];
   simulatedPath?: CorePathfindingResultSuccess;
   simulatedPathItemTimes?: Extract<SimulationSummary, { isValid: true }>['pathItemTimes'];
@@ -30,14 +35,26 @@ type TimesStopsOutputProps = {
 
 const TimesStopsOutput = ({
   infraId,
-  isValid,
+  isValid = false,
   selectedTrain,
+  timetableItemsWithDetails,
+  upsertTimetableItems,
   simulatedTrain,
   simulatedPathItemTimes,
   simulatedPathItemRespect,
   operationalPointsOnPath,
 }: TimesStopsOutputProps) => {
   const useNewTimesStopsTable = useSelector(getUseNewTimesStopsTable);
+
+  // Store the simulatedPathItemTimes reference before an edit to detect when new simulation arrives
+  const preEditPathItemTimesRef = useRef<typeof simulatedPathItemTimes>(undefined);
+
+  // Store pending edit for optimistic UI update (state to trigger re-render)
+  const [pendingEdit, setPendingEdit] = useState<{
+    rowId: string;
+    field: 'requestedArrival' | 'requestedDeparture';
+    value: Date | null;
+  } | null>(null);
 
   // Only call the hook that corresponds to the active table to avoid unnecessary computation
   const legacyRows = useOutputTableData(
@@ -59,9 +76,73 @@ const TimesStopsOutput = ({
     useNewTimesStopsTable ? operationalPointsOnPath : undefined
   );
 
+  const startTime = useMemo(() => new Date(selectedTrain.start_time), [selectedTrain.start_time]);
+
+  const { updateArrival, updateDeparture } = useUpdateTimesStopsTable(
+    selectedTrain,
+    newRows,
+    timetableItemsWithDetails,
+    upsertTimetableItems
+  );
+
+  // Are we waiting for simulation to refresh after a user edit?
+  const isAwaitingSimulation =
+    preEditPathItemTimesRef.current !== undefined &&
+    simulatedPathItemTimes === preEditPathItemTimesRef.current;
+
+  // Clear refs/state when fresh simulation data arrives
+  useEffect(() => {
+    if (!isAwaitingSimulation && preEditPathItemTimesRef.current !== undefined) {
+      preEditPathItemTimesRef.current = undefined;
+      setPendingEdit(null);
+    }
+  }, [isAwaitingSimulation]);
+
+  const handleArrivalChange = async (row: TimesStopsRowNew, arrival: Date | null) => {
+    if (isAwaitingSimulation) return;
+    preEditPathItemTimesRef.current = simulatedPathItemTimes;
+    setPendingEdit({ rowId: row.id, field: 'requestedArrival', value: arrival });
+    try {
+      await updateArrival(row, arrival);
+    } catch {
+      preEditPathItemTimesRef.current = undefined;
+      setPendingEdit(null);
+    }
+  };
+
+  const handleDepartureChange = async (row: TimesStopsRowNew, departure: Date | null) => {
+    if (isAwaitingSimulation) return;
+    preEditPathItemTimesRef.current = simulatedPathItemTimes;
+    setPendingEdit({ rowId: row.id, field: 'requestedDeparture', value: departure });
+    try {
+      await updateDeparture(row, departure);
+    } catch {
+      preEditPathItemTimesRef.current = undefined;
+      setPendingEdit(null);
+    }
+  };
+
+  // Apply optimistic update to display rows
+  const displayRows = pendingEdit
+    ? newRows.map((row) => {
+        if (row.id === pendingEdit.rowId) {
+          return { ...row, [pendingEdit.field]: pendingEdit.value };
+        }
+        return row;
+      })
+    : newRows;
+
   if (useNewTimesStopsTable) {
     return (
-      <TimesStopsTable rows={newRows} dataIsLoading={newRows.length === 0} isValid={isValid} />
+      <TimesStopsTable
+        rows={displayRows}
+        startTime={startTime}
+        dataIsLoading={newRows.length === 0}
+        isValid={isValid}
+        isComputedDataPending={isAwaitingSimulation}
+        onArrivalChange={handleArrivalChange}
+        onDepartureChange={handleDepartureChange}
+      />
     );
   }
 

--- a/front/src/modules/timesStops/TimesStopsOutput.tsx
+++ b/front/src/modules/timesStops/TimesStopsOutput.tsx
@@ -14,17 +14,13 @@ import { getUseNewTimesStopsTable } from 'reducers/user/userSelectors';
 import { formatLocalTime } from 'utils/date';
 import { Duration } from 'utils/duration';
 
+import { computeOptimisticSchedule } from './helpers/cellUpdate';
 import useOutputTableData from './hooks/useOutputTableData';
 import useTimesStopsTableData from './hooks/useTimesStopsTableData';
 import useUpdateTimesStopsTable from './hooks/useUpdateTimesStopsTable';
 import TimesStops from './TimesStops';
 import TimesStopsTable from './TimesStopsTable';
-import { TableType, type TimesStopsRow, type TimesStopsRowNew } from './types';
-
-type PendingEdit =
-  | { rowId: string; field: 'requestedArrival'; value: Date | null }
-  | { rowId: string; field: 'requestedDeparture'; value: Date | null }
-  | { rowId: string; field: 'stopDuration'; value: Duration | null };
+import { TableType, type PendingEdit, type TimesStopsRow, type TimesStopsRowNew } from './types';
 
 type TimesStopsOutputProps = {
   infraId: number;
@@ -60,9 +56,6 @@ const TimesStopsOutput = ({
   const preEditPathItemTimesRef = useRef<typeof simulatedPathItemTimes>(undefined);
   const isTrainSimulationPendingRef = useRef(false);
 
-  // Store pending edit for optimistic UI update (state to trigger re-render)
-  const [pendingEdit, setPendingEdit] = useState<PendingEdit | null>(null);
-
   // Only call the hook that corresponds to the active table to avoid unnecessary computation
   const legacyRows = useOutputTableData(
     infraId,
@@ -84,6 +77,33 @@ const TimesStopsOutput = ({
     useNewTimesStopsTable ? operationalPointsOnPath : undefined
   );
 
+  // Keeps the last edit visible until selectedTrain.schedule gets a new reference.
+  // Bridges the gap between the save request completing and the Redux update propagating through the tree.
+  // Note: useOptimistic was considered but doesn't work here. It reverts to the source state as soon
+  // as the async action resolves, but at that point selectedTrain.schedule hasn't been updated yet by
+  // Redux — causing the same flash. pinnedState stays active until the data itself changes.
+  const [pinnedState, setPinnedState] = useState<{
+    edit: PendingEdit;
+    forSchedule: Train['schedule'];
+  } | null>(null);
+
+  const optimisticEdit =
+    pinnedState !== null && pinnedState.forSchedule === selectedTrain.schedule
+      ? pinnedState.edit
+      : null;
+
+  const optimisticRows = useMemo(
+    () =>
+      optimisticEdit
+        ? newRows.map((row) =>
+            row.id === optimisticEdit.rowId
+              ? { ...row, ...computeOptimisticSchedule(row, optimisticEdit) }
+              : row
+          )
+        : newRows,
+    [newRows, optimisticEdit]
+  );
+
   const startTime = useMemo(() => new Date(selectedTrain.start_time), [selectedTrain.start_time]);
 
   const { updateArrival, updateStopDuration, updateDeparture } = useUpdateTimesStopsTable(
@@ -94,15 +114,15 @@ const TimesStopsOutput = ({
   );
 
   // True if we are still waiting for fresh simulation data after a user edit.
-  // Both pipelines must finish before we clear the loading state:
-  //   - Condition 1 (batch summary): wait until simulatedPathItemTimes gets a new reference.
-  //   - Condition 2 (all simulation queries): wait until isSimulationDataLoading is false.
+  // Both conditions must be false before we clear the loading state:
+  //   - Condition 1 (batch summary): simulatedPathItemTimes must get a new reference.
+  //   - Condition 2 (all simulation queries): isSimulationDataLoading must be false.
   const isAwaitingSimulation =
     (preEditPathItemTimesRef.current !== undefined &&
       simulatedPathItemTimes === preEditPathItemTimesRef.current) ||
     (isTrainSimulationPendingRef.current && isSimulationDataLoading);
 
-  // Reset refs and pending edit once both pipelines are done
+  // Reset refs once both simulation pipelines are done
   useEffect(() => {
     if (
       !isAwaitingSimulation &&
@@ -110,75 +130,45 @@ const TimesStopsOutput = ({
     ) {
       preEditPathItemTimesRef.current = undefined;
       isTrainSimulationPendingRef.current = false;
-      setPendingEdit(null);
     }
   }, [isAwaitingSimulation]);
 
-  // Call this before any edit to start tracking simulation refresh.
-  const startSimulationTracking = (pendingEditValue: PendingEdit) => {
+  const commitEdit = (edit: PendingEdit, updateFn: () => Promise<void>) => {
+    if (isAwaitingSimulation) return;
+    setPinnedState({ edit, forSchedule: selectedTrain.schedule });
     preEditPathItemTimesRef.current = simulatedPathItemTimes;
     isTrainSimulationPendingRef.current = true;
-    setPendingEdit(pendingEditValue);
-  };
-
-  // Call this on error to cancel the tracking started by startSimulationTracking.
-  const cancelSimulationTracking = () => {
-    preEditPathItemTimesRef.current = undefined;
-    isTrainSimulationPendingRef.current = false;
-    setPendingEdit(null);
-  };
-
-  const handleArrivalChange = async (row: TimesStopsRowNew, arrival: Date | null) => {
-    if (isAwaitingSimulation) return;
-    startSimulationTracking({ rowId: row.id, field: 'requestedArrival', value: arrival });
-    try {
-      await updateArrival(row, arrival);
-    } catch {
-      cancelSimulationTracking();
-    }
-  };
-
-  const handleDepartureChange = async (row: TimesStopsRowNew, departure: Date | null) => {
-    if (isAwaitingSimulation) return;
-    startSimulationTracking({ rowId: row.id, field: 'requestedDeparture', value: departure });
-    try {
-      await updateDeparture(row, departure);
-    } catch {
-      cancelSimulationTracking();
-    }
-  };
-
-  const handleStopDurationChange = async (
-    row: TimesStopsRowNew,
-    durationSeconds: number | null
-  ) => {
-    if (isAwaitingSimulation) return;
-    startSimulationTracking({
-      rowId: row.id,
-      field: 'stopDuration',
-      value: durationSeconds !== null ? new Duration({ seconds: durationSeconds }) : null,
+    updateFn().catch(() => {
+      setPinnedState(null);
+      preEditPathItemTimesRef.current = undefined;
+      isTrainSimulationPendingRef.current = false;
     });
-    try {
-      await updateStopDuration(row, durationSeconds);
-    } catch {
-      cancelSimulationTracking();
-    }
   };
 
-  // Apply optimistic update to display rows
-  const displayRows = pendingEdit
-    ? newRows.map((row) => {
-        if (row.id === pendingEdit.rowId) {
-          return { ...row, [pendingEdit.field]: pendingEdit.value };
-        }
-        return row;
-      })
-    : newRows;
+  const handleArrivalChange = (row: TimesStopsRowNew, arrival: Date | null) =>
+    commitEdit({ rowId: row.id, field: 'requestedArrival', value: arrival }, () =>
+      updateArrival(row, arrival)
+    );
+
+  const handleDepartureChange = (row: TimesStopsRowNew, departure: Date | null) =>
+    commitEdit({ rowId: row.id, field: 'requestedDeparture', value: departure }, () =>
+      updateDeparture(row, departure)
+    );
+
+  const handleStopDurationChange = (row: TimesStopsRowNew, durationSeconds: number | null) =>
+    commitEdit(
+      {
+        rowId: row.id,
+        field: 'stopDuration',
+        value: durationSeconds !== null ? new Duration({ seconds: durationSeconds }) : null,
+      },
+      () => updateStopDuration(row, durationSeconds)
+    );
 
   if (useNewTimesStopsTable) {
     return (
       <TimesStopsTable
-        rows={displayRows}
+        rows={optimisticRows}
         startTime={startTime}
         isValid={stableIsValid}
         isComputedDataPending={isAwaitingSimulation}

--- a/front/src/modules/timesStops/TimesStopsTable.tsx
+++ b/front/src/modules/timesStops/TimesStopsTable.tsx
@@ -24,15 +24,62 @@ declare module '@tanstack/react-table' {
   }
 }
 
+/**
+ * Get the reference date for arrival editing.
+ * Uses the previous row's latest time (departure > arrival) to determine the correct day.
+ */
+const getArrivalReferenceDate = (
+  row: TimesStopsRowNew,
+  allRows: TimesStopsRowNew[],
+  startTime: Date
+): Date => {
+  // Find the previous row with any time information
+  const previousRow = allRows.findLast(
+    (r) =>
+      r.opOnPathIndex < row.opOnPathIndex &&
+      (r.computedDeparture || r.computedArrival || r.requestedDeparture || r.requestedArrival)
+  );
+
+  if (!previousRow) return startTime;
+
+  // Use the latest available time from the previous row
+  return (
+    previousRow.computedDeparture ??
+    previousRow.computedArrival ??
+    previousRow.requestedDeparture ??
+    previousRow.requestedArrival ??
+    startTime
+  );
+};
+
+/**
+ * Get the reference date for departure editing.
+ * Uses the current row's arrival time since departure must be after arrival.
+ */
+const getDepartureReferenceDate = (row: TimesStopsRowNew, startTime: Date): Date =>
+  row.computedArrival ?? row.requestedArrival ?? startTime;
+
 type TimesStopsTableProps = {
   rows: TimesStopsRowNew[];
-  dataIsLoading: boolean;
+  startTime: Date;
+  dataIsLoading?: boolean;
   isValid: boolean;
+  isComputedDataPending?: boolean;
+  onArrivalChange: (row: TimesStopsRowNew, arrival: Date | null) => void;
+  onDepartureChange: (row: TimesStopsRowNew, departure: Date | null) => void;
 };
 
 const columnHelper = createColumnHelper<TimesStopsRowNew>();
 
-const TimesStopsTable = ({ rows, dataIsLoading, isValid }: TimesStopsTableProps) => {
+const TimesStopsTable = ({
+  rows,
+  startTime,
+  dataIsLoading,
+  isValid,
+  isComputedDataPending,
+  onArrivalChange,
+  onDepartureChange,
+}: TimesStopsTableProps) => {
   const { t } = useTranslation('translation', { keyPrefix: 'timeStopTable' });
 
   const isScheduleNotHonored = rows.some((row) => row.scheduleNotHonored);
@@ -98,14 +145,26 @@ const TimesStopsTable = ({ rows, dataIsLoading, isValid }: TimesStopsTableProps)
       }),
       columnHelper.accessor('requestedArrival', {
         header: () => t('arrivalTime'),
-        cell: (info) => <TimeCell {...info} />,
+        cell: (info) => (
+          <TimeCell
+            {...info}
+            referenceDate={getArrivalReferenceDate(info.row.original, rows, startTime)}
+            onCommit={(date) => onArrivalChange(info.row.original, date)}
+          />
+        ),
         meta: {
           className: 'col-requested-arrival',
         },
       }),
       columnHelper.accessor('computedArrival', {
         header: () => t('calculatedArrivalTime'),
-        cell: (info) => <span>{info.getValue() ? formatLocalTime(info.getValue()!) : ''}</span>,
+        cell: (info) => {
+          if (isComputedDataPending) {
+            return <span className="cell-loading-placeholder" />;
+          }
+          const value = info.getValue();
+          return <span>{value ? formatLocalTime(value) : ''}</span>;
+        },
         meta: {
           className: 'col-computed-arrival computed',
         },
@@ -119,20 +178,40 @@ const TimesStopsTable = ({ rows, dataIsLoading, isValid }: TimesStopsTableProps)
       }),
       columnHelper.accessor('requestedDeparture', {
         header: () => t('departureTime'),
-        cell: (info) => <span>{info.getValue() ? formatLocalTime(info.getValue()!) : ''}</span>,
+        cell: (info) => {
+          const row = info.row.original;
+          // Disable departure editing on the first row (origin)
+          if (row.opOnPathIndex === 0) {
+            const value = info.getValue();
+            return <span>{value ? formatLocalTime(value) : ''}</span>;
+          }
+          return (
+            <TimeCell
+              {...info}
+              referenceDate={getDepartureReferenceDate(row, startTime)}
+              onCommit={(date) => onDepartureChange(row, date)}
+            />
+          );
+        },
         meta: {
           className: 'col-requested-departure',
         },
       }),
       columnHelper.accessor('computedDeparture', {
         header: () => t('calculatedDepartureTime'),
-        cell: (info) => <span>{info.getValue() ? formatLocalTime(info.getValue()!) : ''}</span>,
+        cell: (info) => {
+          if (isComputedDataPending) {
+            return <span className="cell-loading-placeholder" />;
+          }
+          const value = info.getValue();
+          return <span>{value ? formatLocalTime(value) : ''}</span>;
+        },
         meta: {
           className: 'col-computed-departure computed',
         },
       }),
     ],
-    [t]
+    [startTime, isComputedDataPending]
   );
 
   // eslint-disable-next-line react-hooks/incompatible-library
@@ -159,7 +238,9 @@ const TimesStopsTable = ({ rows, dataIsLoading, isValid }: TimesStopsTableProps)
   }
 
   return (
-    <div className="times-stops-table-new">
+    <div
+      className={cx('times-stops-table-new', { 'computed-data-pending': isComputedDataPending })}
+    >
       <table className="table-container">
         <thead>
           {table.getHeaderGroups().map((headerGroup) => (

--- a/front/src/modules/timesStops/TimesStopsTable.tsx
+++ b/front/src/modules/timesStops/TimesStopsTable.tsx
@@ -104,6 +104,10 @@ const TimesStopsTable = ({
         id: 'stepStatus',
         header: '',
         cell: (info) => {
+          if (isComputedDataPending) {
+            return <span>&nbsp;</span>;
+          }
+
           const {
             marginNotHonored,
             scheduleNotHonored,

--- a/front/src/modules/timesStops/TimesStopsTable.tsx
+++ b/front/src/modules/timesStops/TimesStopsTable.tsx
@@ -10,7 +10,6 @@ import {
 import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
 
-import { Loader } from 'common/Loaders/Loader';
 import { formatLocalTime } from 'utils/date';
 
 import DurationCell from './DurationCell';
@@ -69,7 +68,6 @@ const getDepartureReferenceDate = (row: TimesStopsRowNew, startTime: Date): Date
 type TimesStopsTableProps = {
   rows: TimesStopsRowNew[];
   startTime: Date;
-  dataIsLoading?: boolean;
   isValid: boolean;
   isComputedDataPending?: boolean;
   onArrivalChange: (row: TimesStopsRowNew, arrival: Date | null) => void;
@@ -82,7 +80,6 @@ const columnHelper = createColumnHelper<TimesStopsRowNew>();
 const TimesStopsTable = ({
   rows,
   startTime,
-  dataIsLoading,
   isValid,
   isComputedDataPending,
   onArrivalChange,
@@ -245,14 +242,6 @@ const TimesStopsTable = ({
       onDepartureChange,
     },
   });
-
-  if (dataIsLoading) {
-    return (
-      <div className="times-stops-table-new-loader">
-        <Loader />
-      </div>
-    );
-  }
 
   if (rows.length === 0) {
     return (

--- a/front/src/modules/timesStops/TimesStopsTable.tsx
+++ b/front/src/modules/timesStops/TimesStopsTable.tsx
@@ -22,6 +22,13 @@ declare module '@tanstack/react-table' {
   interface ColumnMeta<TData extends RowData, TValue> {
     className: string;
   }
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions, @typescript-eslint/no-unused-vars
+  interface TableMeta<TData extends RowData> {
+    allRows: TimesStopsRowNew[];
+    onArrivalChange: (row: TimesStopsRowNew, arrival: Date | null) => void;
+    onStopDurationChange: (row: TimesStopsRowNew, durationSeconds: number | null) => void;
+    onDepartureChange: (row: TimesStopsRowNew, departure: Date | null) => void;
+  }
 }
 
 /**
@@ -66,6 +73,7 @@ type TimesStopsTableProps = {
   isValid: boolean;
   isComputedDataPending?: boolean;
   onArrivalChange: (row: TimesStopsRowNew, arrival: Date | null) => void;
+  onStopDurationChange: (row: TimesStopsRowNew, durationSeconds: number | null) => void;
   onDepartureChange: (row: TimesStopsRowNew, departure: Date | null) => void;
 };
 
@@ -78,6 +86,7 @@ const TimesStopsTable = ({
   isValid,
   isComputedDataPending,
   onArrivalChange,
+  onStopDurationChange,
   onDepartureChange,
 }: TimesStopsTableProps) => {
   const { t } = useTranslation('translation', { keyPrefix: 'timeStopTable' });
@@ -145,13 +154,16 @@ const TimesStopsTable = ({
       }),
       columnHelper.accessor('requestedArrival', {
         header: () => t('arrivalTime'),
-        cell: (info) => (
-          <TimeCell
-            {...info}
-            referenceDate={getArrivalReferenceDate(info.row.original, rows, startTime)}
-            onCommit={(date) => onArrivalChange(info.row.original, date)}
-          />
-        ),
+        cell: (info) => {
+          const { allRows, onArrivalChange: onArrival } = info.table.options.meta!;
+          return (
+            <TimeCell
+              {...info}
+              referenceDate={getArrivalReferenceDate(info.row.original, allRows, startTime)}
+              onCommit={(date) => onArrival(info.row.original, date)}
+            />
+          );
+        },
         meta: {
           className: 'col-requested-arrival',
         },
@@ -171,7 +183,14 @@ const TimesStopsTable = ({
       }),
       columnHelper.accessor('stopDuration', {
         header: () => t('stopTime'),
-        cell: (info) => <DurationCell {...info} />,
+        cell: (info) => (
+          <DurationCell
+            {...info}
+            onChange={(e) =>
+              info.table.options.meta!.onStopDurationChange(info.row.original, e.target.value)
+            }
+          />
+        ),
         meta: {
           className: 'col-stop-duration',
         },
@@ -189,7 +208,7 @@ const TimesStopsTable = ({
             <TimeCell
               {...info}
               referenceDate={getDepartureReferenceDate(row, startTime)}
-              onCommit={(date) => onDepartureChange(row, date)}
+              onCommit={(date) => info.table.options.meta!.onDepartureChange(row, date)}
             />
           );
         },
@@ -219,6 +238,12 @@ const TimesStopsTable = ({
     data: rows,
     columns,
     getCoreRowModel: getCoreRowModel(),
+    meta: {
+      allRows: rows,
+      onArrivalChange,
+      onStopDurationChange,
+      onDepartureChange,
+    },
   });
 
   if (dataIsLoading) {

--- a/front/src/modules/timesStops/helpers/__tests__/cellUpdate.spec.ts
+++ b/front/src/modules/timesStops/helpers/__tests__/cellUpdate.spec.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+
+import { Duration } from 'utils/duration';
+
+import { applyScheduleEdit, type ScheduleState } from '../cellUpdate';
+
+// Fixed reference times for tests
+const _10H00 = new Date('2025-01-01T10:00:00Z');
+const _10H30 = new Date('2025-01-01T10:30:00Z');
+const _11H00 = new Date('2025-01-01T11:00:00Z');
+
+const _30MIN = new Duration({ minutes: 30 });
+const _60MIN = new Duration({ minutes: 60 });
+
+/** Helper to compare dates by their timestamp */
+const t = (d: Date | null) => d?.getTime() ?? null;
+/** Helper to compare durations by their ms */
+const ms = (d: Duration | null) => d?.ms ?? null;
+
+describe('applyScheduleEdit', () => {
+  describe('requestedArrival', () => {
+    it('sets arrival and recomputes departure when stop exists', () => {
+      const state: ScheduleState = { arrival: _10H00, stop: _30MIN };
+      const result = applyScheduleEdit(state, { field: 'requestedArrival', value: _10H30 });
+
+      expect(t(result.arrival)).toBe(t(_10H30));
+      expect(ms(result.stop)).toBe(ms(_30MIN));
+      // departure = 10h30 + 30min = 11h00
+      expect(t(result.departure)).toBe(t(_11H00));
+    });
+
+    it('sets arrival and leaves departure null when no stop', () => {
+      const state: ScheduleState = { arrival: _10H00, stop: null };
+      const result = applyScheduleEdit(state, { field: 'requestedArrival', value: _10H30 });
+
+      expect(t(result.arrival)).toBe(t(_10H30));
+      expect(ms(result.stop)).toBeNull();
+      expect(t(result.departure)).toBeNull();
+    });
+
+    it('clears arrival and departure, keeps stop', () => {
+      const state: ScheduleState = { arrival: _10H00, stop: _30MIN };
+      const result = applyScheduleEdit(state, { field: 'requestedArrival', value: null });
+
+      expect(t(result.arrival)).toBeNull();
+      expect(ms(result.stop)).toBe(ms(_30MIN));
+      expect(t(result.departure)).toBeNull();
+    });
+  });
+
+  describe('stopDuration', () => {
+    it('sets stop and recomputes departure when arrival exists', () => {
+      const state: ScheduleState = { arrival: _10H00, stop: null };
+      const result = applyScheduleEdit(state, { field: 'stopDuration', value: _60MIN });
+
+      expect(t(result.arrival)).toBe(t(_10H00));
+      expect(ms(result.stop)).toBe(ms(_60MIN));
+      // departure = 10h00 + 60min = 11h00
+      expect(t(result.departure)).toBe(t(_11H00));
+    });
+
+    it('sets stop and leaves departure null when no arrival', () => {
+      const state: ScheduleState = { arrival: null, stop: null };
+      const result = applyScheduleEdit(state, { field: 'stopDuration', value: _30MIN });
+
+      expect(t(result.arrival)).toBeNull();
+      expect(ms(result.stop)).toBe(ms(_30MIN));
+      expect(t(result.departure)).toBeNull();
+    });
+
+    it('clears stop and departure, keeps arrival', () => {
+      const state: ScheduleState = { arrival: _10H00, stop: _30MIN };
+      const result = applyScheduleEdit(state, { field: 'stopDuration', value: null });
+
+      expect(t(result.arrival)).toBe(t(_10H00));
+      expect(ms(result.stop)).toBeNull();
+      expect(t(result.departure)).toBeNull();
+    });
+  });
+
+  describe('requestedDeparture', () => {
+    it('sets departure and computes stop from arrival when arrival exists', () => {
+      const state: ScheduleState = { arrival: _10H00, stop: null };
+      // departure = 11h00 = 10h00 + 60min
+      const result = applyScheduleEdit(state, { field: 'requestedDeparture', value: _11H00 });
+
+      expect(t(result.arrival)).toBe(t(_10H00));
+      expect(ms(result.stop)).toBe(ms(_60MIN));
+      expect(t(result.departure)).toBe(t(_11H00));
+    });
+
+    it('sets departure and computes arrival from stop when no arrival', () => {
+      const state: ScheduleState = { arrival: null, stop: _30MIN };
+      // departure = 10h30, arrival = 10h30 - 30min = 10h00
+      const result = applyScheduleEdit(state, { field: 'requestedDeparture', value: _10H30 });
+
+      expect(t(result.arrival)).toBe(t(_10H00));
+      expect(ms(result.stop)).toBe(ms(_30MIN));
+      expect(t(result.departure)).toBe(t(_10H30));
+    });
+
+    it('sets departure as arrival when no arrival and no stop', () => {
+      const state: ScheduleState = { arrival: null, stop: null };
+      const result = applyScheduleEdit(state, { field: 'requestedDeparture', value: _10H30 });
+
+      expect(t(result.arrival)).toBe(t(_10H30));
+      expect(ms(result.stop)).toBeNull();
+      expect(t(result.departure)).toBe(t(_10H30));
+    });
+
+    it('clears departure and arrival, keeps stop', () => {
+      const state: ScheduleState = { arrival: _10H00, stop: _30MIN };
+      const result = applyScheduleEdit(state, { field: 'requestedDeparture', value: null });
+
+      expect(t(result.arrival)).toBeNull();
+      expect(ms(result.stop)).toBe(ms(_30MIN));
+      expect(t(result.departure)).toBeNull();
+    });
+
+    it('clears departure and arrival when no arrival, keeps stop', () => {
+      const state: ScheduleState = { arrival: null, stop: _30MIN };
+      const result = applyScheduleEdit(state, { field: 'requestedDeparture', value: null });
+
+      expect(t(result.arrival)).toBeNull();
+      expect(ms(result.stop)).toBe(ms(_30MIN));
+      expect(t(result.departure)).toBeNull();
+    });
+  });
+});

--- a/front/src/modules/timesStops/helpers/cellUpdate.ts
+++ b/front/src/modules/timesStops/helpers/cellUpdate.ts
@@ -49,6 +49,10 @@ type BuildScheduleItemParams = {
   startTime: Date;
 };
 
+/** Difference between two dates, truncated to whole seconds. */
+const diffSeconds = (a: Date, b: Date) =>
+  Math.floor(a.getTime() / 1000) - Math.floor(b.getTime() / 1000);
+
 /**
  * Build a new ScheduleItem based on the field being updated.
  * Note: Day adjustment for overnight journeys is handled by TimeCell using referenceDate.
@@ -63,7 +67,9 @@ export const buildScheduleItemForField = ({
   switch (update.field) {
     case 'requestedArrival': {
       // TimeCell already adjusted the date using the previous row's time as reference
-      return { arrival: Duration.subtractDate(update.value, startTime).toISOString() };
+      return {
+        arrival: new Duration({ seconds: diffSeconds(update.value, startTime) }).toISOString(),
+      };
     }
 
     case 'stopDuration': {
@@ -77,18 +83,19 @@ export const buildScheduleItemForField = ({
       if (arrivalTime) {
         // Arrival exists => stop_for = departure - arrival
         // TimeCell already ensured departure >= arrival by using arrival as referenceDate
-        // Truncate to seconds to match input table behavior (works with HH:MM:SS strings)
-        const arrivalSec = Math.floor(arrivalTime.getTime() / 1000);
-        const departureSec = Math.floor(departureTime.getTime() / 1000);
-        const stopForSec = departureSec - arrivalSec;
-        return { stop_for: new Duration({ seconds: stopForSec }).toISOString() };
+        return {
+          stop_for: new Duration({
+            seconds: diffSeconds(departureTime, arrivalTime),
+          }).toISOString(),
+        };
       }
 
       // No arrival => arrival = departure - stopDuration
       const existingStopForSeconds = update.row.stopDuration?.total('second') ?? 0;
-      const arrivalDate = new Date(departureTime.getTime() - existingStopForSeconds * 1000);
       const newSchedule: Partial<ScheduleItem> = {
-        arrival: Duration.subtractDate(arrivalDate, startTime).toISOString(),
+        arrival: new Duration({
+          seconds: diffSeconds(departureTime, startTime) - existingStopForSeconds,
+        }).toISOString(),
       };
       // Keep stop_for if there was an existing stopDuration (including PT0S)
       if (update.row.stopDuration) {

--- a/front/src/modules/timesStops/helpers/cellUpdate.ts
+++ b/front/src/modules/timesStops/helpers/cellUpdate.ts
@@ -5,7 +5,7 @@ import type { Train } from 'reducers/osrdconf/types';
 import { addElementAtIndex } from 'utils/array';
 import { Duration } from 'utils/duration';
 
-import type { CellUpdate, TimesStopsRowNew } from '../types';
+import type { OptimisticEdit, TimesStopsRowNew } from '../types';
 
 /** Compute the insertion index for a new PathStep using row opOnPathIndex values. */
 const computeInsertIndex = (
@@ -44,70 +44,88 @@ export const upsertPathStep = (
   return { pathStepId: newPathStep.id, updatedPath };
 };
 
-type BuildScheduleItemParams = {
-  update: CellUpdate;
-  startTime: Date;
-};
-
 /** Difference between two dates, truncated to whole seconds. */
 const diffSeconds = (a: Date, b: Date) =>
   Math.floor(a.getTime() / 1000) - Math.floor(b.getTime() / 1000);
 
+/** State of a stop's schedule in display format (Date / Duration). */
+export type ScheduleState = {
+  arrival: Date | null;
+  stop: Duration | null;
+};
+
 /**
- * Build a new ScheduleItem based on the field being updated.
+ * Apply a schedule field edit to the current state.
+ * Single source of truth for schedule editing business rules.
+ * Both optimistic display updates and API payload computation derive from this function.
+ *
  * Note: Day adjustment for overnight journeys is handled by TimeCell using referenceDate.
  * The dates received here are already on the correct calendar day.
  */
-export const buildScheduleItemForField = ({
-  update,
-  startTime,
-}: BuildScheduleItemParams): Partial<ScheduleItem> => {
-  if (update.value === null) return {};
+export const applyScheduleEdit = (
+  current: ScheduleState,
+  edit: OptimisticEdit
+): ScheduleState & { departure: Date | null } => {
+  const { arrival, stop } = current;
 
-  switch (update.field) {
+  switch (edit.field) {
     case 'requestedArrival': {
-      // TimeCell already adjusted the date using the previous row's time as reference
+      const newArrival = edit.value;
       return {
-        arrival: new Duration({ seconds: diffSeconds(update.value, startTime) }).toISOString(),
+        arrival: newArrival,
+        stop,
+        departure:
+          newArrival !== null && stop !== null ? new Date(newArrival.getTime() + stop.ms) : null,
       };
     }
 
     case 'stopDuration': {
-      return { stop_for: new Duration({ seconds: update.value }).toISOString() };
+      const newStop = edit.value;
+      return {
+        arrival,
+        stop: newStop,
+        departure:
+          arrival !== null && newStop !== null ? new Date(arrival.getTime() + newStop.ms) : null,
+      };
     }
 
     case 'requestedDeparture': {
-      const departureTime = update.value;
-      const arrivalTime = update.row.requestedArrival;
-
-      if (arrivalTime) {
-        // Arrival exists => stop_for = departure - arrival
+      const newDeparture = edit.value;
+      if (newDeparture === null) {
+        return { arrival: null, stop, departure: null };
+      }
+      if (arrival !== null) {
+        // Arrival exists → stop = departure - arrival
         // TimeCell already ensured departure >= arrival by using arrival as referenceDate
         return {
-          stop_for: new Duration({
-            seconds: diffSeconds(departureTime, arrivalTime),
-          }).toISOString(),
+          arrival,
+          stop: new Duration({ milliseconds: newDeparture.getTime() - arrival.getTime() }),
+          departure: newDeparture,
         };
       }
-
-      // No arrival => arrival = departure - stopDuration
-      const existingStopForSeconds = update.row.stopDuration?.total('second') ?? 0;
-      const newSchedule: Partial<ScheduleItem> = {
-        arrival: new Duration({
-          seconds: diffSeconds(departureTime, startTime) - existingStopForSeconds,
-        }).toISOString(),
+      // No arrival → arrival = departure - existingStop
+      return {
+        arrival: new Date(newDeparture.getTime() - (stop?.ms ?? 0)),
+        stop,
+        departure: newDeparture,
       };
-      // Keep stop_for if there was an existing stopDuration (including PT0S)
-      if (update.row.stopDuration) {
-        newSchedule.stop_for = update.row.stopDuration.toISOString();
-      }
-      return newSchedule;
     }
-
-    default:
-      return {};
   }
 };
+
+/**
+ * Convert a ScheduleState to API ScheduleItem fields (ISO duration strings relative to startTime).
+ */
+export const scheduleStateToApiFields = (
+  state: ScheduleState,
+  startTime: Date
+): { arrival: string | null; stop_for: string | null } => ({
+  arrival:
+    state.arrival !== null
+      ? new Duration({ seconds: diffSeconds(state.arrival, startTime) }).toISOString()
+      : null,
+  stop_for: state.stop !== null ? state.stop.toISOString() : null,
+});
 
 const getPathIndex = (pathStepId: string, path: PathItem[]) =>
   path.findIndex((step) => step.id === pathStepId);
@@ -127,6 +145,20 @@ export const insertScheduleItemInOrder = (
   const insertIndex = foundIndex === -1 ? schedule.length : foundIndex;
 
   return addElementAtIndex(schedule, insertIndex, newItem);
+};
+
+/**
+ * Compute the optimistic display values for all schedule fields when a cell is edited.
+ */
+export const computeOptimisticSchedule = (
+  row: TimesStopsRowNew,
+  edit: OptimisticEdit
+): Pick<TimesStopsRowNew, 'requestedArrival' | 'stopDuration' | 'requestedDeparture'> => {
+  const { arrival, stop, departure } = applyScheduleEdit(
+    { arrival: row.requestedArrival, stop: row.stopDuration },
+    edit
+  );
+  return { requestedArrival: arrival, stopDuration: stop, requestedDeparture: departure };
 };
 
 /** Build a TrainSchedule object from a Train with updated path and schedule. */

--- a/front/src/modules/timesStops/helpers/cellUpdate.ts
+++ b/front/src/modules/timesStops/helpers/cellUpdate.ts
@@ -1,0 +1,146 @@
+import { v4 as uuidV4 } from 'uuid';
+
+import type { TrainSchedule, PathItem, ScheduleItem } from 'common/api/osrdEditoastApi';
+import type { Train } from 'reducers/osrdconf/types';
+import { addElementAtIndex } from 'utils/array';
+import { Duration } from 'utils/duration';
+
+import type { CellUpdate, TimesStopsRowNew } from '../types';
+
+/** Compute the insertion index for a new PathStep using row opOnPathIndex values. */
+const computeInsertIndex = (
+  editedOpIndex: number,
+  allRows: TimesStopsRowNew[],
+  currentPath: PathItem[]
+): number => {
+  // Build a map of pathStepId -> opOnPathIndex from rows that are path steps
+  const pathStepOpIndices = new Map(
+    allRows.filter((r) => r.isPathStep).map((r) => [r.id, r.opOnPathIndex])
+  );
+
+  // Find the first PathStep whose opOnPathIndex is greater than the edited OP's
+  const foundIndex = currentPath.findIndex((step) => {
+    const opIndex = pathStepOpIndices.get(step.id);
+    return opIndex !== undefined && opIndex > editedOpIndex;
+  });
+
+  return foundIndex === -1 ? currentPath.length : foundIndex;
+};
+
+/** Find existing PathStep or create a new one at the correct position. */
+export const upsertPathStep = (
+  editedRow: TimesStopsRowNew,
+  currentPath: PathItem[],
+  allRows: TimesStopsRowNew[]
+): { pathStepId: string; updatedPath: PathItem[] } => {
+  if (editedRow.isPathStep) {
+    return { pathStepId: editedRow.id, updatedPath: currentPath };
+  }
+
+  const newPathStep: PathItem = { id: uuidV4(), location: editedRow.location };
+  const insertIndex = computeInsertIndex(editedRow.opOnPathIndex, allRows, currentPath);
+  const updatedPath = addElementAtIndex(currentPath, insertIndex, newPathStep);
+
+  return { pathStepId: newPathStep.id, updatedPath };
+};
+
+type BuildScheduleItemParams = {
+  update: CellUpdate;
+  startTime: Date;
+};
+
+/**
+ * Build a new ScheduleItem based on the field being updated.
+ * Note: Day adjustment for overnight journeys is handled by TimeCell using referenceDate.
+ * The dates received here are already on the correct calendar day.
+ */
+export const buildScheduleItemForField = ({
+  update,
+  startTime,
+}: BuildScheduleItemParams): Partial<ScheduleItem> => {
+  if (update.value === null) return {};
+
+  switch (update.field) {
+    case 'requestedArrival': {
+      // TimeCell already adjusted the date using the previous row's time as reference
+      return { arrival: Duration.subtractDate(update.value, startTime).toISOString() };
+    }
+
+    case 'stopDuration': {
+      return { stop_for: new Duration({ seconds: update.value }).toISOString() };
+    }
+
+    case 'requestedDeparture': {
+      const departureTime = update.value;
+      const arrivalTime = update.row.requestedArrival;
+
+      if (arrivalTime) {
+        // Arrival exists => stop_for = departure - arrival
+        // TimeCell already ensured departure >= arrival by using arrival as referenceDate
+        // Truncate to seconds to match input table behavior (works with HH:MM:SS strings)
+        const arrivalSec = Math.floor(arrivalTime.getTime() / 1000);
+        const departureSec = Math.floor(departureTime.getTime() / 1000);
+        const stopForSec = departureSec - arrivalSec;
+        return { stop_for: new Duration({ seconds: stopForSec }).toISOString() };
+      }
+
+      // No arrival => arrival = departure - stopDuration
+      const existingStopForSeconds = update.row.stopDuration?.total('second') ?? 0;
+      const arrivalDate = new Date(departureTime.getTime() - existingStopForSeconds * 1000);
+      const newSchedule: Partial<ScheduleItem> = {
+        arrival: Duration.subtractDate(arrivalDate, startTime).toISOString(),
+      };
+      // Keep stop_for if there was an existing stopDuration (including PT0S)
+      if (update.row.stopDuration) {
+        newSchedule.stop_for = update.row.stopDuration.toISOString();
+      }
+      return newSchedule;
+    }
+
+    default:
+      return {};
+  }
+};
+
+const getPathIndex = (pathStepId: string, path: PathItem[]) =>
+  path.findIndex((step) => step.id === pathStepId);
+
+/**
+ * Insert a schedule item at the correct position to maintain path order.
+ * Schedule items should be ordered according to their path step position.
+ */
+export const insertScheduleItemInOrder = (
+  schedule: ScheduleItem[],
+  newItem: ScheduleItem,
+  path: PathItem[]
+): ScheduleItem[] => {
+  const newItemPathIndex = getPathIndex(newItem.at, path);
+
+  const foundIndex = schedule.findIndex((item) => getPathIndex(item.at, path) > newItemPathIndex);
+  const insertIndex = foundIndex === -1 ? schedule.length : foundIndex;
+
+  return addElementAtIndex(schedule, insertIndex, newItem);
+};
+
+/** Build a TrainSchedule object from a Train with updated path and schedule. */
+export const buildUpdatedOccurrence = (
+  selectedTrain: Train,
+  updatedPath: PathItem[],
+  updatedSchedule: ScheduleItem[],
+  trainName: string
+): TrainSchedule => ({
+  category: selectedTrain.category,
+  comfort: selectedTrain.comfort,
+  constraint_distribution: selectedTrain.constraint_distribution,
+  initial_speed: selectedTrain.initial_speed,
+  labels: selectedTrain.labels,
+  margins: selectedTrain.margins,
+  options: selectedTrain.options,
+  path: updatedPath,
+  power_restrictions: selectedTrain.power_restrictions,
+  rolling_stock_name: selectedTrain.rolling_stock_name,
+  schedule: updatedSchedule,
+  speed_limit_tag: selectedTrain.speed_limit_tag,
+  start_time: selectedTrain.start_time,
+  train_name: trainName,
+});

--- a/front/src/modules/timesStops/helpers/utils.ts
+++ b/front/src/modules/timesStops/helpers/utils.ts
@@ -4,6 +4,7 @@ import dayjs from 'dayjs';
 import type { TFunction } from 'i18next';
 import { round, isEqual, isNil } from 'lodash';
 
+import type { PathPropertiesFormatted } from 'applications/operationalStudies/types';
 import { getInvalidStepLabel } from 'applications/operationalStudies/utils';
 import type {
   OperationalPoint,
@@ -22,6 +23,7 @@ import {
   secToHoursString,
   time2sec,
 } from 'utils/timeManipulation';
+import type { ArrayElement } from 'utils/types';
 
 import { marginRegExValidation, MarginUnit } from '../consts';
 import { TableType, type TimeExtraDays, type TimesStopsInputRow } from '../types';
@@ -356,3 +358,15 @@ export const getOperationalPointName = (
   // Invalid step
   return getInvalidStepLabel(step.operational_point);
 };
+
+/** Build matching parameters from an operational point for PathStep matching. */
+export const buildOpMatchParams = (
+  op: ArrayElement<PathPropertiesFormatted['operationalPoints']>
+) => ({
+  opId: op.id,
+  uic: op.extensions?.identifier?.uic,
+  ch: op.extensions?.sncf?.ch,
+  trigram: op.extensions?.sncf?.trigram,
+  track: op.part.track,
+  offsetOnTrack: op.part.position,
+});

--- a/front/src/modules/timesStops/hooks/useTimesStopsTableData.ts
+++ b/front/src/modules/timesStops/hooks/useTimesStopsTableData.ts
@@ -9,6 +9,7 @@ import { useScenarioContext } from 'applications/operationalStudies/hooks/useSce
 import type { PathPropertiesFormatted } from 'applications/operationalStudies/types';
 import { matchOpRefAndOp } from 'applications/operationalStudies/utils';
 import type {
+  PathItemLocation,
   SimulationResponseSuccess,
   TrackSection,
   ScheduleItem,
@@ -20,7 +21,7 @@ import type { Train } from 'reducers/osrdconf/types';
 import { getDisplayOnlyPathSteps } from 'reducers/simulationResults/selectors';
 import { Duration } from 'utils/duration';
 
-import { getOperationalPointName } from '../helpers/utils';
+import { buildOpMatchParams, getOperationalPointName } from '../helpers/utils';
 import type { TimesStopsRowNew } from '../types';
 
 type BuildTableRowParams = {
@@ -35,7 +36,7 @@ type BuildTableRowParams = {
   invalidPathStep?: boolean;
   scheduleNotHonored?: boolean;
   marginNotHonored?: boolean;
-  isPathStep?: boolean;
+  location: PathItemLocation;
 };
 
 const buildTableRow = ({
@@ -50,7 +51,7 @@ const buildTableRow = ({
   invalidPathStep,
   scheduleNotHonored,
   marginNotHonored,
-  isPathStep,
+  location,
 }: BuildTableRowParams): TimesStopsRowNew => {
   const requestedArrival = schedule?.arrival
     ? new Date(startDate.getTime() + Duration.parse(schedule.arrival).ms)
@@ -89,7 +90,8 @@ const buildTableRow = ({
     invalidPathStep,
     scheduleNotHonored,
     marginNotHonored,
-    isPathStep,
+    isPathStep: true,
+    location,
   };
 };
 
@@ -180,7 +182,7 @@ const useTimesStopsTableData = (
           invalidPathStep: !matchingOp,
           scheduleNotHonored,
           marginNotHonored,
-          isPathStep: true,
+          location: pathStep.location,
         });
 
         return [pathStep.id, row];
@@ -195,14 +197,7 @@ const useTimesStopsTableData = (
         const trackName = op.part.local_track_name;
 
         const matchingPathStep = selectedTrain.path.find((pathStep) =>
-          matchPathStepAndOp(pathStep.location, {
-            opId: op.id,
-            uic: op.extensions?.identifier?.uic,
-            ch: op.extensions?.sncf?.ch,
-            trigram: op.extensions?.sncf?.trigram,
-            track: op.part.track,
-            offsetOnTrack: op.part.position,
-          })
+          matchPathStepAndOp(pathStep.location, buildOpMatchParams(op))
         );
 
         const matchingPathStepRow = matchingPathStep
@@ -228,8 +223,8 @@ const useTimesStopsTableData = (
               ? new Duration({ milliseconds: computedArrivalMs })
               : undefined;
 
-          formattedRows.push(
-            buildTableRow({
+          formattedRows.push({
+            ...buildTableRow({
               id: op.id,
               opOnPathIndex: opIndex,
               name: op.extensions?.identifier?.name,
@@ -237,9 +232,19 @@ const useTimesStopsTableData = (
               trackName,
               startDate,
               computedArrival,
-              isPathStep: false,
-            })
-          );
+              // Build location from OP data for creating a new PathItem if user edits this row
+              // OPs on path always have a UIC identifier
+              location: {
+                operational_point: {
+                  type: 'uic',
+                  uic: op.extensions!.identifier!.uic,
+                  secondary_code: op.extensions?.sncf?.ch ?? null,
+                },
+                local_track_name: op.part.local_track_name,
+              },
+            }),
+            isPathStep: false,
+          });
         }
       });
     } else {

--- a/front/src/modules/timesStops/hooks/useTimesStopsTableData.ts
+++ b/front/src/modules/timesStops/hooks/useTimesStopsTableData.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo } from 'react';
+import { useEffect, useState, useMemo, useRef } from 'react';
 
 import { keyBy } from 'lodash';
 import { useTranslation } from 'react-i18next';
@@ -103,15 +103,59 @@ const buildTableRow = ({
 const useTimesStopsTableData = (
   infraId: number,
   isValid: boolean,
+  isSimulationDataLoading: boolean,
   selectedTrain: Train,
   simulatedTrain?: SimulationResponseSuccess['final_output'],
   simulatedPathItemTimes?: Extract<SimulationSummary, { isValid: true }>['pathItemTimes'],
   simulatedPathItemRespect?: Extract<SimulationSummary, { isValid: true }>['pathItemRespect'],
   operationalPointsOnPath?: PathPropertiesFormatted['operationalPoints']
-): TimesStopsRowNew[] => {
+): { rows: TimesStopsRowNew[]; stableIsValid: boolean } => {
   const { t } = useTranslation('operational-studies');
   const { getTrackSectionsByIds } = useScenarioContext();
   const displayOnlyPathSteps = useSelector(getDisplayOnlyPathSteps);
+
+  // Stale-while-revalidate: keep the last known-good simulation props in a ref so the table
+  // doesn't flash back to path-step-only view during the brief window where RTK Query sets
+  // currentData = undefined while refetching (e.g. operationalPointsOnPath goes undefined
+  // between a path change and the new response arriving).
+  // Three cases:
+  //   isValid=true              → snapshot the props (they are consistent)
+  //   isValid=false, fetching   → use the snapshot (transitional, data is reloading)
+  //   isValid=false, not fetching → clear the snapshot (genuinely invalid simulation)
+  const lastSimRef = useRef<{
+    simulatedTrain: typeof simulatedTrain;
+    simulatedPathItemTimes: typeof simulatedPathItemTimes;
+    simulatedPathItemRespect: typeof simulatedPathItemRespect;
+    operationalPointsOnPath: typeof operationalPointsOnPath;
+  } | null>(null);
+
+  // Invalidate the snapshot on train switch to avoid briefly showing the previous train's data.
+  const prevTrainIdRef = useRef(selectedTrain.id);
+  if (prevTrainIdRef.current !== selectedTrain.id) {
+    prevTrainIdRef.current = selectedTrain.id;
+    lastSimRef.current = null;
+  }
+
+  if (isValid) {
+    lastSimRef.current = {
+      simulatedTrain,
+      simulatedPathItemTimes,
+      simulatedPathItemRespect,
+      operationalPointsOnPath,
+    };
+  } else if (!isSimulationDataLoading) {
+    // Not fetching and not valid — the simulation is genuinely invalid, discard stale data.
+    lastSimRef.current = null;
+  }
+
+  // Only use the snapshot while a fetch is in progress (transitional invalid state).
+  const snapshot = isSimulationDataLoading ? lastSimRef.current : undefined;
+  const stableIsValid = isValid || !!snapshot;
+
+  const stableTrain = simulatedTrain ?? snapshot?.simulatedTrain;
+  const stablePathItemTimes = simulatedPathItemTimes ?? snapshot?.simulatedPathItemTimes;
+  const stablePathItemRespect = simulatedPathItemRespect ?? snapshot?.simulatedPathItemRespect;
+  const stableOPs = operationalPointsOnPath ?? snapshot?.operationalPointsOnPath;
 
   const pathStepOps = usePathOps(infraId, selectedTrain.path);
 
@@ -159,15 +203,15 @@ const useTimesStopsTableData = (
 
         const schedule = scheduleByAt[pathStep.id];
         const computedArrival =
-          simulatedPathItemTimes?.final[stepIndex] !== undefined
-            ? new Duration({ milliseconds: simulatedPathItemTimes.final[stepIndex] })
+          stablePathItemTimes?.final[stepIndex] !== undefined
+            ? new Duration({ milliseconds: stablePathItemTimes.final[stepIndex] })
             : undefined;
-        const scheduleNotHonored = isValid && !simulatedPathItemRespect?.times[stepIndex];
+        const scheduleNotHonored = stableIsValid && !stablePathItemRespect?.times[stepIndex];
         // The back end returns the status at the end of the interval but we want to display the information at the beginning of the interval so we check the next path items status
         const marginNotHonored =
-          isValid &&
+          stableIsValid &&
           stepIndex < selectedTrain.path.length - 1 &&
-          !simulatedPathItemRespect?.margins[stepIndex + 1];
+          !stablePathItemRespect?.margins[stepIndex + 1];
 
         const row = buildTableRow({
           id: pathStep.id,
@@ -192,8 +236,8 @@ const useTimesStopsTableData = (
     let formattedRows: TimesStopsRowNew[] = [];
 
     // Case 1: Valid train with simulation results
-    if (isValid && simulatedTrain && operationalPointsOnPath) {
-      operationalPointsOnPath.forEach((op, opIndex) => {
+    if (stableIsValid && stableTrain && stableOPs) {
+      stableOPs.forEach((op, opIndex) => {
         const trackName = op.part.local_track_name;
 
         const matchingPathStep = selectedTrain.path.find((pathStep) =>
@@ -211,13 +255,13 @@ const useTimesStopsTableData = (
             opOnPathIndex: opIndex,
           });
         } else if (!displayOnlyPathSteps) {
-          const matchingReportTrainIndex = simulatedTrain.positions.findIndex(
+          const matchingReportTrainIndex = stableTrain.positions.findIndex(
             (position) => position === op.position
           );
           const computedArrivalMs =
             matchingReportTrainIndex === -1
-              ? interpolateValue(simulatedTrain, op.position, 'times')
-              : simulatedTrain.times[matchingReportTrainIndex];
+              ? interpolateValue(stableTrain, op.position, 'times')
+              : stableTrain.times[matchingReportTrainIndex];
           const computedArrival =
             computedArrivalMs !== undefined
               ? new Duration({ milliseconds: computedArrivalMs })
@@ -262,17 +306,18 @@ const useTimesStopsTableData = (
     return formattedRows;
   }, [
     selectedTrain,
-    isValid,
-    simulatedTrain,
-    operationalPointsOnPath,
-    simulatedPathItemTimes,
+    stableIsValid,
+    stableTrain,
+    stableOPs,
+    stablePathItemTimes,
+    stablePathItemRespect,
     trackSections,
     pathStepOps,
     displayOnlyPathSteps,
     t,
   ]);
 
-  return rows;
+  return { rows, stableIsValid };
 };
 
 export default useTimesStopsTableData;

--- a/front/src/modules/timesStops/hooks/useUpdateTimesStopsTable.ts
+++ b/front/src/modules/timesStops/hooks/useUpdateTimesStopsTable.ts
@@ -1,0 +1,268 @@
+import { useCallback } from 'react';
+
+import { isNil } from 'lodash';
+
+import { buildPacedTrainWithUpdatedException } from 'applications/operationalStudies/views/Scenario/components/ManageTimetableItem/helpers/buildPacedTrainException';
+import { formatPacedTrainWithDetailsToPacedTrainPayload } from 'applications/operationalStudies/views/Scenario/components/ManageTimetableItem/helpers/formatTimetableItemPayload';
+import {
+  osrdEditoastApi,
+  type TrainSchedule,
+  type PathItem,
+  type ScheduleItem,
+} from 'common/api/osrdEditoastApi';
+import {
+  getOccurrenceTrainName,
+  isPacedTrainBase,
+  isPacedTrainWithDetails,
+} from 'modules/timetableItem/helpers/pacedTrain';
+import type { TimetableItemWithDetails } from 'modules/timetableItem/types';
+import type { OccurrenceId, PacedTrainId, TimetableItem, Train } from 'reducers/osrdconf/types';
+import { removeElementAtIndex, replaceElementAtIndex } from 'utils/array';
+import {
+  extractEditoastIdFromPacedTrainId,
+  extractPacedTrainIdFromOccurrenceId,
+  isOccurrenceId,
+  isPacedTrainId,
+} from 'utils/trainId';
+
+import {
+  upsertPathStep,
+  buildScheduleItemForField,
+  buildUpdatedOccurrence,
+  insertScheduleItemInOrder,
+} from '../helpers/cellUpdate';
+import type { CellUpdate, TimesStopsRowNew } from '../types';
+
+/**
+ * Hook that provides a callback to update times/stops cell values.
+ * When a cell is edited (TimeCell or DurationCell), this callback:
+ * 1. Updates the train's schedule array
+ * 2. Calls the API to persist the change
+ * 3. Triggers simulation re-run via upsertTimetableItems
+ *
+ * When editing an occurrence:
+ * - Finds the parent PacedTrain from timetableItemsWithDetails
+ * - Generates or updates the exception for this occurrence
+ * - Updates the PacedTrain with the new exception
+ * - Calls upsertTimetableItems to trigger re-simulation
+ */
+const useUpdateTimesStopsTable = (
+  selectedTrain: Train,
+  allRows: TimesStopsRowNew[],
+  timetableItemsWithDetails: TimetableItemWithDetails[],
+  upsertTimetableItems: (timetableItems: TimetableItem[]) => void
+) => {
+  const [updatePacedTrain] = osrdEditoastApi.endpoints.putPacedTrainById.useMutation();
+
+  /**
+   * Compute the updated path and schedule based on the cell update.
+   */
+  const computeUpdatedPathAndSchedule = useCallback(
+    (
+      update: CellUpdate
+    ): { updatedPath: PathItem[]; updatedSchedule: ScheduleItem[] } | undefined => {
+      const { pathStepId, updatedPath } = upsertPathStep(update.row, selectedTrain.path, allRows);
+      const currentSchedule = selectedTrain.schedule ?? [];
+      const existingScheduleItemIndex = currentSchedule.findIndex((item) => item.at === pathStepId);
+      let updatedSchedule: ScheduleItem[];
+
+      // Handle clearing the value (setting to null)
+      if (update.value === null) {
+        if (existingScheduleItemIndex < 0) return undefined;
+
+        const fieldToNull: Extract<keyof ScheduleItem, 'arrival' | 'stop_for'> =
+          update.field === 'requestedArrival' ? 'arrival' : 'stop_for';
+        const updatedScheduleItem: ScheduleItem = {
+          ...currentSchedule[existingScheduleItemIndex],
+          [fieldToNull]: null,
+        };
+
+        const shouldRemoveScheduleItem =
+          isNil(updatedScheduleItem.arrival) && isNil(updatedScheduleItem.stop_for);
+
+        updatedSchedule = shouldRemoveScheduleItem
+          ? removeElementAtIndex(currentSchedule, existingScheduleItemIndex)
+          : replaceElementAtIndex(currentSchedule, existingScheduleItemIndex, updatedScheduleItem);
+
+        return { updatedPath, updatedSchedule };
+      }
+
+      // Handle setting a new value
+      const startTime = new Date(selectedTrain.start_time);
+      const newScheduleItem: ScheduleItem = {
+        at: pathStepId,
+        ...buildScheduleItemForField({ update, startTime }),
+      };
+
+      updatedSchedule =
+        existingScheduleItemIndex >= 0
+          ? replaceElementAtIndex(currentSchedule, existingScheduleItemIndex, {
+              ...currentSchedule[existingScheduleItemIndex],
+              ...newScheduleItem,
+            })
+          : insertScheduleItemInOrder(currentSchedule, newScheduleItem, updatedPath);
+
+      return { updatedPath, updatedSchedule };
+    },
+    [selectedTrain, allRows]
+  );
+
+  /**
+   * Handle update when the selected train is an occurrence of a PacedTrain.
+   */
+  const updateOccurrence = useCallback(
+    async (occurrenceId: OccurrenceId, update: CellUpdate) => {
+      const pacedTrainId = extractPacedTrainIdFromOccurrenceId(occurrenceId);
+      const originalPacedTrainWithDetails = timetableItemsWithDetails.find(
+        (item) => item.id === pacedTrainId
+      );
+
+      if (
+        !originalPacedTrainWithDetails ||
+        !isPacedTrainWithDetails(originalPacedTrainWithDetails)
+      ) {
+        throw new Error(`Parent PacedTrain not found for occurrence: ${occurrenceId}`);
+      }
+
+      const originalPacedTrain = formatPacedTrainWithDetailsToPacedTrainPayload(
+        originalPacedTrainWithDetails
+      );
+      if (!isPacedTrainBase(originalPacedTrain)) {
+        throw new Error('Formatted PacedTrain is missing paced field');
+      }
+
+      // selectedTrain.train_name is the paced train's BASE name, but the
+      // exception diff expects the occurrence's computed name.
+      const occurrenceTrainName = getOccurrenceTrainName(originalPacedTrain, occurrenceId);
+
+      // Build updated occurrence based on update type
+      let updatedOccurrence: TrainSchedule;
+      if (update.field === 'requestedArrival' && update.row.opOnPathIndex === 0) {
+        if (!update.value) {
+          console.error('Cannot clear start time on the origin');
+          return;
+        }
+        updatedOccurrence = {
+          ...buildUpdatedOccurrence(
+            selectedTrain,
+            selectedTrain.path,
+            selectedTrain.schedule ?? [],
+            occurrenceTrainName
+          ),
+          start_time: update.value.toISOString(),
+        };
+      } else {
+        const result = computeUpdatedPathAndSchedule(update);
+        if (!result) return;
+        updatedOccurrence = buildUpdatedOccurrence(
+          selectedTrain,
+          result.updatedPath,
+          result.updatedSchedule,
+          occurrenceTrainName
+        );
+      }
+
+      const updatedPacedTrain = buildPacedTrainWithUpdatedException(
+        originalPacedTrain,
+        updatedOccurrence,
+        occurrenceId
+      );
+
+      await updatePacedTrain({
+        id: extractEditoastIdFromPacedTrainId(pacedTrainId),
+        trainSchedule: updatedPacedTrain,
+      }).unwrap();
+      upsertTimetableItems([{ ...updatedPacedTrain, id: pacedTrainId }]);
+    },
+    [selectedTrain, timetableItemsWithDetails, computeUpdatedPathAndSchedule]
+  );
+
+  /**
+   * Handle update when the selected train is a TimetableItem (not an occurrence).
+   */
+  const updateTimetableItem = useCallback(
+    async (trainId: PacedTrainId, update: CellUpdate) => {
+      // Handle first row
+      if (update.field === 'requestedArrival' && update.row.opOnPathIndex === 0) {
+        if (!update.value) return;
+
+        const train: TimetableItem = {
+          ...selectedTrain,
+          id: trainId,
+          start_time: update.value.toISOString(),
+        };
+
+        await updatePacedTrain({
+          id: extractEditoastIdFromPacedTrainId(trainId),
+          trainSchedule: train,
+        }).unwrap();
+        upsertTimetableItems([train]);
+        return;
+      }
+
+      const result = computeUpdatedPathAndSchedule(update);
+      if (!result) return;
+
+      const { updatedPath, updatedSchedule } = result;
+      const train: TimetableItem = {
+        ...selectedTrain,
+        id: trainId,
+        path: updatedPath,
+        schedule: updatedSchedule,
+      };
+
+      await updatePacedTrain({
+        id: extractEditoastIdFromPacedTrainId(trainId),
+        trainSchedule: train,
+      }).unwrap();
+      upsertTimetableItems([train]);
+    },
+    [selectedTrain, computeUpdatedPathAndSchedule]
+  );
+
+  /**
+   * Main update function that routes to the appropriate handler.
+   */
+  const updateCell = useCallback(
+    async (update: CellUpdate) => {
+      const { id: trainId } = selectedTrain;
+
+      if (isOccurrenceId(trainId)) {
+        await updateOccurrence(trainId, update);
+      } else if (isPacedTrainId(trainId)) {
+        await updateTimetableItem(trainId, update);
+      } else {
+        throw new Error('TrainSchedules are not handled anymore.');
+      }
+    },
+    [selectedTrain, updateOccurrence, updateTimetableItem]
+  );
+
+  // Functions are included in deps (exception to the project convention) to propagate
+  // allRows updates through the entire callback chain.
+  const updateArrival = useCallback(
+    (row: TimesStopsRowNew, arrival: Date | null) =>
+      updateCell({ row, field: 'requestedArrival', value: arrival }),
+    [updateCell]
+  );
+
+  const updateStopDuration = useCallback(
+    (row: TimesStopsRowNew, durationSeconds: number | null) =>
+      updateCell({ row, field: 'stopDuration', value: durationSeconds }),
+    [updateCell]
+  );
+
+  const updateDeparture = useCallback(
+    (row: TimesStopsRowNew, departure: Date | null) =>
+      updateCell({ row, field: 'requestedDeparture', value: departure }),
+    [updateCell]
+  );
+
+  return {
+    updateArrival,
+    updateStopDuration,
+    updateDeparture,
+  };
+};
+
+export default useUpdateTimesStopsTable;

--- a/front/src/modules/timesStops/hooks/useUpdateTimesStopsTable.ts
+++ b/front/src/modules/timesStops/hooks/useUpdateTimesStopsTable.ts
@@ -1,7 +1,5 @@
 import { useCallback } from 'react';
 
-import { isNil } from 'lodash';
-
 import { buildPacedTrainWithUpdatedException } from 'applications/operationalStudies/views/Scenario/components/ManageTimetableItem/helpers/buildPacedTrainException';
 import { formatPacedTrainWithDetailsToPacedTrainPayload } from 'applications/operationalStudies/views/Scenario/components/ManageTimetableItem/helpers/formatTimetableItemPayload';
 import {
@@ -18,6 +16,7 @@ import {
 import type { TimetableItemWithDetails } from 'modules/timetableItem/types';
 import type { OccurrenceId, PacedTrainId, TimetableItem, Train } from 'reducers/osrdconf/types';
 import { removeElementAtIndex, replaceElementAtIndex } from 'utils/array';
+import { Duration } from 'utils/duration';
 import {
   extractEditoastIdFromPacedTrainId,
   extractPacedTrainIdFromOccurrenceId,
@@ -27,11 +26,12 @@ import {
 
 import {
   upsertPathStep,
-  buildScheduleItemForField,
+  applyScheduleEdit,
+  scheduleStateToApiFields,
   buildUpdatedOccurrence,
   insertScheduleItemInOrder,
 } from '../helpers/cellUpdate';
-import type { CellUpdate, TimesStopsRowNew } from '../types';
+import type { CellUpdate, OptimisticEdit, TimesStopsRowNew } from '../types';
 
 /**
  * Hook that provides a callback to update times/stops cell values.
@@ -63,50 +63,51 @@ const useUpdateTimesStopsTable = (
     ): { updatedPath: PathItem[]; updatedSchedule: ScheduleItem[] } | undefined => {
       const { pathStepId, updatedPath } = upsertPathStep(update.row, selectedTrain.path, allRows);
       const currentSchedule = selectedTrain.schedule ?? [];
-      const existingScheduleItemIndex = currentSchedule.findIndex((item) => item.at === pathStepId);
-      let updatedSchedule: ScheduleItem[];
+      const existingItemIndex = currentSchedule.findIndex((item) => item.at === pathStepId);
 
-      // Handle clearing the value (setting to null)
-      if (update.value === null) {
-        if (existingScheduleItemIndex < 0) return undefined;
-
-        const fieldToNull: Extract<keyof ScheduleItem, 'arrival' | 'stop_for'> =
-          update.field === 'requestedArrival' ? 'arrival' : 'stop_for';
-        const updatedScheduleItem: ScheduleItem = {
-          ...currentSchedule[existingScheduleItemIndex],
-          [fieldToNull]: null,
+      // Convert CellUpdate to OptimisticEdit (stopDuration: number → Duration)
+      let edit: OptimisticEdit;
+      if (update.field === 'stopDuration') {
+        edit = {
+          field: 'stopDuration',
+          value: update.value !== null ? new Duration({ seconds: update.value }) : null,
         };
-
-        const shouldRemoveScheduleItem =
-          isNil(updatedScheduleItem.arrival) && isNil(updatedScheduleItem.stop_for);
-
-        updatedSchedule = shouldRemoveScheduleItem
-          ? removeElementAtIndex(currentSchedule, existingScheduleItemIndex)
-          : replaceElementAtIndex(currentSchedule, existingScheduleItemIndex, updatedScheduleItem);
-
-        const pathStepIndex = updatedPath.findIndex((step) => step.id === pathStepId);
-        const finalPath =
-          shouldRemoveScheduleItem && pathStepIndex > 0 && pathStepIndex < updatedPath.length - 1
-            ? removeElementAtIndex(updatedPath, pathStepIndex)
-            : updatedPath;
-
-        return { updatedPath: finalPath, updatedSchedule };
+      } else {
+        edit = update;
       }
 
-      // Handle setting a new value
-      const startTime = new Date(selectedTrain.start_time);
-      const newScheduleItem: ScheduleItem = {
-        at: pathStepId,
-        ...buildScheduleItemForField({ update, startTime }),
-      };
+      const newState = applyScheduleEdit(
+        { arrival: update.row.requestedArrival, stop: update.row.stopDuration },
+        edit
+      );
 
-      updatedSchedule =
-        existingScheduleItemIndex >= 0
-          ? replaceElementAtIndex(currentSchedule, existingScheduleItemIndex, {
-              ...currentSchedule[existingScheduleItemIndex],
-              ...newScheduleItem,
-            })
-          : insertScheduleItemInOrder(currentSchedule, newScheduleItem, updatedPath);
+      const startTime = new Date(selectedTrain.start_time);
+      const { arrival: newArrival, stop_for: newStopFor } = scheduleStateToApiFields(
+        newState,
+        startTime
+      );
+
+      const shouldRemove = newArrival === null && newStopFor === null;
+      let updatedSchedule: ScheduleItem[];
+
+      if (shouldRemove) {
+        // Both fields cleared: remove the schedule item entirely
+        if (existingItemIndex < 0) return undefined;
+        updatedSchedule = removeElementAtIndex(currentSchedule, existingItemIndex);
+      } else if (existingItemIndex >= 0) {
+        // Update existing schedule item
+        updatedSchedule = replaceElementAtIndex(currentSchedule, existingItemIndex, {
+          ...currentSchedule[existingItemIndex],
+          arrival: newArrival,
+          stop_for: newStopFor,
+        });
+      } else {
+        // Insert new schedule item in path order
+        const newItem: ScheduleItem = { at: pathStepId };
+        if (newArrival !== null) newItem.arrival = newArrival;
+        if (newStopFor !== null) newItem.stop_for = newStopFor;
+        updatedSchedule = insertScheduleItemInOrder(currentSchedule, newItem, updatedPath);
+      }
 
       return { updatedPath, updatedSchedule };
     },

--- a/front/src/modules/timesStops/hooks/useUpdateTimesStopsTable.ts
+++ b/front/src/modules/timesStops/hooks/useUpdateTimesStopsTable.ts
@@ -84,7 +84,13 @@ const useUpdateTimesStopsTable = (
           ? removeElementAtIndex(currentSchedule, existingScheduleItemIndex)
           : replaceElementAtIndex(currentSchedule, existingScheduleItemIndex, updatedScheduleItem);
 
-        return { updatedPath, updatedSchedule };
+        const pathStepIndex = updatedPath.findIndex((step) => step.id === pathStepId);
+        const finalPath =
+          shouldRemoveScheduleItem && pathStepIndex > 0 && pathStepIndex < updatedPath.length - 1
+            ? removeElementAtIndex(updatedPath, pathStepIndex)
+            : updatedPath;
+
+        return { updatedPath: finalPath, updatedSchedule };
       }
 
       // Handle setting a new value

--- a/front/src/modules/timesStops/styles/_durationCell.scss
+++ b/front/src/modules/timesStops/styles/_durationCell.scss
@@ -48,6 +48,10 @@
   }
 }
 
+.duration-cell-cleared {
+  color: var(--black100);
+}
+
 .duration-cell-caret {
   position: absolute;
   top: 50%;
@@ -58,7 +62,48 @@
 }
 
 .duration-cell {
+  position: relative;
+
   &:focus {
     outline: none;
+  }
+}
+
+.duration-cell-clear-btn {
+  position: fixed;
+  transform: translate(calc(-100% + 4px), -50%);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  width: 24px;
+  height: 24px;
+  border: none;
+  border-radius: 4px;
+  background-color: var(--ambientB5);
+  color: var(--primary60);
+  box-shadow:
+    0 0.5px 1px 0 rgba(0, 0, 0, 0.25),
+    0 5px 9px -3px rgba(0, 0, 0, 0.16),
+    0 13px 12px -5px rgba(255, 171, 88, 0.13);
+  cursor: pointer;
+  z-index: 100;
+
+  &:hover {
+    background-color: var(--white100);
+    color: var(--primary80);
+    box-shadow:
+      0 0.5px 1px 0 rgba(0, 0, 0, 0.25),
+      0 5px 9px -3px rgba(0, 0, 0, 0.16),
+      0 13px 12px -5px rgba(255, 171, 88, 0.13);
+  }
+
+  &:active {
+    background-color: var(--ambientB10);
+    color: var(--primary40);
+    box-shadow:
+      0 2px 4px 0 rgba(0, 0, 0, 0.22),
+      0 4px 7px -3px rgba(255, 171, 88, 0.17),
+      inset 0 1px 0 0 rgba(255, 255, 255, 1);
   }
 }

--- a/front/src/modules/timesStops/styles/_timesStopsTable.scss
+++ b/front/src/modules/timesStops/styles/_timesStopsTable.scss
@@ -4,6 +4,10 @@
 }
 
 .times-stops-table-new {
+  &.computed-data-pending {
+    pointer-events: none;
+  }
+
   .table-container {
     position: relative;
     thead {
@@ -236,5 +240,26 @@
     td:last-child {
       border-right: none;
     }
+  }
+}
+
+.cell-loading-placeholder {
+  display: inline-block;
+  width: 38px;
+  height: 16px;
+  border-radius: 8px;
+  background-color: var(--black10);
+  animation: cell-loading-pulse 1s ease-in-out infinite;
+}
+
+@keyframes cell-loading-pulse {
+  0% {
+    opacity: 0.2;
+  }
+  50% {
+    opacity: 0.3;
+  }
+  100% {
+    opacity: 1;
   }
 }

--- a/front/src/modules/timesStops/styles/_timesStopsTable.scss
+++ b/front/src/modules/timesStops/styles/_timesStopsTable.scss
@@ -248,18 +248,18 @@
   width: 38px;
   height: 16px;
   border-radius: 8px;
-  background-color: var(--black10);
+  background-color: var(--black100);
   animation: cell-loading-pulse 1s ease-in-out infinite;
 }
 
 @keyframes cell-loading-pulse {
   0% {
-    opacity: 0.2;
+    opacity: 0.25;
   }
   50% {
-    opacity: 0.3;
+    opacity: 0.05;
   }
   100% {
-    opacity: 1;
+    opacity: 0.25;
   }
 }

--- a/front/src/modules/timesStops/types.ts
+++ b/front/src/modules/timesStops/types.ts
@@ -88,3 +88,10 @@ export type DepartureUpdate = {
 };
 
 export type CellUpdate = ArrivalUpdate | StopDurationUpdate | DepartureUpdate;
+
+export type OptimisticEdit =
+  | { field: 'requestedArrival'; value: Date | null }
+  | { field: 'requestedDeparture'; value: Date | null }
+  | { field: 'stopDuration'; value: Duration | null };
+
+export type PendingEdit = OptimisticEdit & { rowId: string };

--- a/front/src/modules/timesStops/types.ts
+++ b/front/src/modules/timesStops/types.ts
@@ -1,3 +1,4 @@
+import type { PathItemLocation } from 'common/api/osrdEditoastApi';
 import type { TimeString } from 'common/types';
 import type { SuggestedOP } from 'modules/timetableItem/types';
 import type { Duration } from 'utils/duration';
@@ -22,7 +23,10 @@ export type TimesStopsRowNew = {
   invalidPathStep: boolean | undefined;
   scheduleNotHonored: boolean | undefined;
   marginNotHonored: boolean | undefined;
-  isPathStep?: boolean;
+  /** True if this row corresponds to a pathStep input, false if it's just a waypoint */
+  isPathStep: boolean;
+  /** Location info to create a new PathItem when editing a waypoint that's not yet a pathStep */
+  location: PathItemLocation;
 };
 
 export type TimesStopsRow = {
@@ -64,3 +68,23 @@ export type TheoreticalMarginsRecord = Record<
   string,
   { theoreticalMargin: string; isBoundary: boolean }
 >;
+
+export type ArrivalUpdate = {
+  row: TimesStopsRowNew;
+  field: 'requestedArrival';
+  value: Date | null;
+};
+
+export type StopDurationUpdate = {
+  row: TimesStopsRowNew;
+  field: 'stopDuration';
+  value: number | null;
+};
+
+export type DepartureUpdate = {
+  row: TimesStopsRowNew;
+  field: 'requestedDeparture';
+  value: Date | null;
+};
+
+export type CellUpdate = ArrivalUpdate | StopDurationUpdate | DepartureUpdate;

--- a/front/src/modules/timetableItem/helpers/pacedTrain.ts
+++ b/front/src/modules/timetableItem/helpers/pacedTrain.ts
@@ -19,6 +19,7 @@ import {
   isIndexedOccurrenceId,
 } from 'utils/trainId';
 
+import computeOccurrenceName from './computeOccurrenceName';
 import type {
   ExceptionChangeGroups,
   PacedTrainWithDetails,
@@ -172,6 +173,35 @@ export const getExceptionFromOccurrenceId = (
     exception = pacedTrain.paced.exceptions.find((e) => e.key === key);
   }
   return exception;
+};
+
+/**
+ * Compute the train_name for an occurrence, taking into account any existing exception override.
+ * - If an exception already overrides train_name, use that value.
+ * - For indexed occurrences, compute the name from the base name + index.
+ * - For added exceptions, use `baseName/+`.
+ */
+export const getOccurrenceTrainName = (
+  pacedTrain: Pick<PacedTrainWithPaced, 'train_name' | 'paced'>,
+  occurrenceId: OccurrenceId
+): string => {
+  const existingException = findExceptionWithOccurrenceId(
+    pacedTrain.paced.exceptions,
+    occurrenceId
+  );
+
+  if (existingException?.train_name?.value) {
+    return existingException.train_name.value;
+  }
+
+  if (isIndexedOccurrenceId(occurrenceId)) {
+    return computeOccurrenceName(
+      pacedTrain.train_name,
+      extractOccurrenceIndexFromOccurrenceId(occurrenceId)
+    );
+  }
+
+  return `${pacedTrain.train_name}/+`;
 };
 
 export const getOcurrencesIds = (pacedTrain: PacedTrainWithPaced, pacedTrainId: PacedTrainId) => {


### PR DESCRIPTION
Closes #14282
## Summary
- Wire TimeCell to "Arrival Time" / "Heure d'arrivée",  "Departure Time" / "Heure de départ" and "Stop Duration" / "Temps d'arrêt"  columns
- Cell updates are saved on onBlur event

_See commits_

## Editable columns
 - [x] Arrival Time / Heure d'arrivée (requestedArrival)
 - [x] Departure Time / Heure de départ (requestedDeparture)
 - [x] Stop Duration / Temps d'arrêt (stopDuration) :  component ready, not yet wired


## Test plan
- [ ] Edit arrival time on a row ==> resimulation triggers, computed times update
- [ ] Edit departure time on a row (not first row) ==> resimulation triggers
- [ ] Edit departure time on first row ==> updates train start_time, all other times shift accordingly
- [ ] Edit on a PacedTrain (simple train)
- [ ] Edit on an occurrence (exception is created/updated)
- [ ] Clear a time field ==> value is removed from schedule
