### PR TITLE
editoast: refactoring of `edition.rs` split_track_section tests

### DIFF
--- a/editoast/src/views/infra/edition.rs
+++ b/editoast/src/views/infra/edition.rs
@@ -1380,64 +1380,42 @@ pub mod tests {
         assert_eq!(detector_right.position, 575.0);
     }
 
+    #[rstest::rstest]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn split_track_section_with_buffer_stops() {
+    #[case("TH1", 2_000_000, "buffer_stop.7", 3000.0, 1)] // buffer stop at 5000m on TH1, split at 2000m -> goes to right at 3000m
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[case("TA2", 1_000_000, "buffer_stop.2", 0.0, 0)] // buffer stop at 0m on TA2, split at 1000m -> stays on left at 0m
+    async fn split_track_section_with_buffer_stops(
+        #[case] track: &str,
+        #[case] offset: u64,
+        #[case] buffer_stop_id: &str,
+        #[case] expected_position: f64,
+        #[case] expected_track_index: usize, // 0 for left, 1 for right
+    ) {
         let (app, small_infra) = setup_split_track_test().await;
         let db_pool = app.db_pool();
 
-        // buffer_stop.7 is at 5000m on TH1
-        // Split TH1 at 2000m
-        let request1 = app
+        let request = app
             .post(format!("/infra/{}/split_track_section", small_infra.id).as_str())
             .json(&json!({
-                "track": "TH1",
-                "offset": 2000000,
+                "track": track,
+                "offset": offset,
             }));
-        let res1: Vec<String> = app
-            .fetch(request1)
+        let res: Vec<String> = app
+            .fetch(request)
             .await
             .assert_status(StatusCode::OK)
             .json_into();
 
-        assert_eq!(res1.len(), 2);
-        let th1_right_track_id = &res1[1];
+        assert_eq!(res.len(), 2);
+        let expected_track_id = &res[expected_track_index];
 
-        // buffer_stop.7 should be on the right track after split
         let infra_cache = InfraCache::load(&mut db_pool.get_ok(), &small_infra)
             .await
             .unwrap();
-        let buffer7 = infra_cache.get_buffer_stop("buffer_stop.7").unwrap();
-        assert_eq!(buffer7.track.as_str(), th1_right_track_id);
-        assert_eq!(buffer7.position, 3000.0);
-
-        let req_refresh2 =
-            app.post(format!("/infra/refresh/?infras={}&force=true", small_infra.id).as_str());
-        app.fetch(req_refresh2).await.assert_status(StatusCode::OK);
-
-        // buffer_stop.2 is at 0m on TA2
-        // Split TA2 at 1000m
-        let request2 = app
-            .post(format!("/infra/{}/split_track_section", small_infra.id).as_str())
-            .json(&json!({
-                "track": "TA2",
-                "offset": 1000000,
-            }));
-        let res2: Vec<String> = app
-            .fetch(request2)
-            .await
-            .assert_status(StatusCode::OK)
-            .json_into();
-
-        assert_eq!(res2.len(), 2);
-        let ta2_left_track_id = &res2[0];
-
-        // buffer_stop.2 should be on the left track after split
-        let infra_cache = InfraCache::load(&mut db_pool.get_ok(), &small_infra)
-            .await
-            .unwrap();
-        let buffer2 = infra_cache.get_buffer_stop("buffer_stop.2").unwrap();
-        assert_eq!(buffer2.track.as_str(), ta2_left_track_id);
-        assert_eq!(buffer2.position, 0.0);
+        let buffer_stop = infra_cache.get_buffer_stop(buffer_stop_id).unwrap();
+        assert_eq!(buffer_stop.track.as_str(), expected_track_id);
+        assert_eq!(buffer_stop.position, expected_position);
     }
 
     #[rstest::rstest]

--- a/editoast/src/views/infra/edition.rs
+++ b/editoast/src/views/infra/edition.rs
@@ -1440,42 +1440,40 @@ pub mod tests {
         assert_eq!(buffer2.position, 0.0);
     }
 
+    #[rstest::rstest]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn split_track_section_with_signals() {
+    #[case("SA6_1", 1780.0, 0)] // signal at 1780m on TA6, split at 2000m -> stays on left at 1780m
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[case("SA6_2", 1380.0, 1)] // signal at 3380m on TA6, split at 2000m -> goes to right at 1380m
+    async fn split_track_section_with_signals(
+        #[case] signal_id: &str,
+        #[case] expected_position: f64,
+        #[case] expected_track_index: usize, // 0 for left, 1 for right
+    ) {
         let (app, small_infra) = setup_split_track_test().await;
         let db_pool = app.db_pool();
 
-        // Signal SA6_1 is at 1780m and SA6_2 is at 3380m on TA6
-        // Split TA6 at 2000m
-        let request1 = app
+        let request = app
             .post(format!("/infra/{}/split_track_section", small_infra.id).as_str())
             .json(&json!({
                 "track": "TA6",
-                "offset": 2000000,
+                "offset": 2_000_000,
             }));
-        let res1: Vec<String> = app
-            .fetch(request1)
+        let res: Vec<String> = app
+            .fetch(request)
             .await
             .assert_status(StatusCode::OK)
             .json_into();
 
-        assert_eq!(res1.len(), 2);
-        let left_track_id = &res1[0];
-        let right_track_id = &res1[1];
+        assert_eq!(res.len(), 2);
+        let expected_track_id = &res[expected_track_index];
 
         let infra_cache = InfraCache::load(&mut db_pool.get_ok(), &small_infra)
             .await
             .unwrap();
-
-        // SA6_1 should be on the left track after split
-        let sa6_1 = infra_cache.get_signal("SA6_1").unwrap();
-        assert_eq!(sa6_1.track.as_str(), left_track_id);
-        assert_eq!(sa6_1.position, 1780.0);
-
-        // SA6_2 should be on the right track after split
-        let sa6_2 = infra_cache.get_signal("SA6_2").unwrap();
-        assert_eq!(sa6_2.track.as_str(), right_track_id);
-        assert_eq!(sa6_2.position, 1380.0);
+        let signal = infra_cache.get_signal(signal_id).unwrap();
+        assert_eq!(signal.track.as_str(), expected_track_id);
+        assert_eq!(signal.position, expected_position);
     }
 
     #[rstest::rstest]

--- a/editoast/src/views/infra/edition.rs
+++ b/editoast/src/views/infra/edition.rs
@@ -1423,13 +1423,12 @@ pub mod tests {
 
     #[rstest::rstest]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    #[case("TC0", 500_000, "lc2", 125.0, 0)] // part at 125m on TC0, split at 500m -> stays on left at 125m
+    #[case("TC0", 500_000, 125.0, 0)] // part at 125m on TC0, split at 500m -> stays on left at 125m
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    #[case("TC1", 100_000, "lc2", 20.0, 1)] // part at 120m on TC1, split at 100m -> goes to right at 20m
+    #[case("TC1", 100_000, 20.0, 1)] // part at 120m on TC1, split at 100m -> goes to right at 20m
     async fn split_track_section_with_level_crossings(
         #[case] track: &str,
         #[case] offset: u64,
-        #[case] lc_id: &str,
         #[case] expected_position: f64,
         #[case] expected_track_index: usize, // 0 for left, 1 for right
     ) {
@@ -1454,7 +1453,7 @@ pub mod tests {
         let infra_cache = InfraCache::load(&mut db_pool.get_ok(), &small_infra)
             .await
             .unwrap();
-        let lc = infra_cache.get_level_crossing(lc_id).unwrap();
+        let lc = infra_cache.get_level_crossing("lc2").unwrap();
         let parts_on_track: Vec<_> = lc
             .parts
             .iter()

--- a/editoast/src/views/infra/edition.rs
+++ b/editoast/src/views/infra/edition.rs
@@ -1007,7 +1007,20 @@ pub mod tests {
     use crate::models::fixtures::create_small_infra;
     use crate::models::infra::ObjectQueryable;
     use crate::views::infra::errors::query_errors;
+    use crate::views::test_app::TestApp;
     use crate::views::test_app::TestAppBuilder;
+
+    async fn setup_split_track_test() -> (TestApp, Infra) {
+        let app = TestAppBuilder::default_app();
+        let db_pool = app.db_pool();
+        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
+
+        let req_refresh =
+            app.post(format!("/infra/refresh/?infras={}&force=true", small_infra.id).as_str());
+        app.fetch(req_refresh).await.assert_status(StatusCode::OK);
+
+        (app, small_infra)
+    }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn split_track_section_should_return_404_with_bad_infra() {
@@ -1076,15 +1089,8 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[case("TD1", 15500000)]
     async fn split_track_section_should_work(#[case] track: &str, #[case] offset: u64) {
-        // Init
-        let app = TestAppBuilder::default_app();
+        let (app, small_infra) = setup_split_track_test().await;
         let db_pool = app.db_pool();
-        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
-
-        // Refresh the infra to get the good number of infra errors
-        let req_refresh =
-            app.post(format!("/infra/refresh/?infras={}&force=true", small_infra.id).as_str());
-        app.fetch(req_refresh).await.assert_status(StatusCode::OK);
 
         // Get infra errors
         let (init_errors, _) = query_errors(&mut db_pool.get_ok(), &small_infra).await;
@@ -1263,13 +1269,8 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn split_track_section_with_operational_point() {
-        let app = TestAppBuilder::default_app();
+        let (app, small_infra) = setup_split_track_test().await;
         let db_pool = app.db_pool();
-        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
-
-        let req_refresh =
-            app.post(format!("/infra/refresh/?infras={}&force=true", small_infra.id).as_str());
-        app.fetch(req_refresh).await.assert_status(StatusCode::OK);
 
         // Mid_East_station is at 14000m on TD0
         // First split TD0 at 15000m
@@ -1343,13 +1344,8 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn split_track_section_with_detectors() {
-        let app = TestAppBuilder::default_app();
+        let (app, small_infra) = setup_split_track_test().await;
         let db_pool = app.db_pool();
-        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
-
-        let req_refresh =
-            app.post(format!("/infra/refresh/?infras={}&force=true", small_infra.id).as_str());
-        app.fetch(req_refresh).await.assert_status(StatusCode::OK);
 
         // DD0_5 is at 7887.5mm and DD0_10 is at 15575mm on TD0
         // Split TD0 at 15000m
@@ -1386,13 +1382,8 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn split_track_section_with_buffer_stops() {
-        let app = TestAppBuilder::default_app();
+        let (app, small_infra) = setup_split_track_test().await;
         let db_pool = app.db_pool();
-        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
-
-        let req_refresh =
-            app.post(format!("/infra/refresh/?infras={}&force=true", small_infra.id).as_str());
-        app.fetch(req_refresh).await.assert_status(StatusCode::OK);
 
         // buffer_stop.7 is at 5000m on TH1
         // Split TH1 at 2000m
@@ -1451,13 +1442,8 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn split_track_section_with_signals() {
-        let app = TestAppBuilder::default_app();
+        let (app, small_infra) = setup_split_track_test().await;
         let db_pool = app.db_pool();
-        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
-
-        let req_refresh =
-            app.post(format!("/infra/refresh/?infras={}&force=true", small_infra.id).as_str());
-        app.fetch(req_refresh).await.assert_status(StatusCode::OK);
 
         // Signal SA6_1 is at 1780m and SA6_2 is at 3380m on TA6
         // Split TA6 at 2000m
@@ -1504,13 +1490,8 @@ pub mod tests {
         #[case] expected_position: f64,
         #[case] expected_track_index: usize, // 0 for left, 1 for right
     ) {
-        let app = TestAppBuilder::default_app();
+        let (app, small_infra) = setup_split_track_test().await;
         let db_pool = app.db_pool();
-        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
-
-        let req_refresh =
-            app.post(format!("/infra/refresh/?infras={}&force=true", small_infra.id).as_str());
-        app.fetch(req_refresh).await.assert_status(StatusCode::OK);
 
         let request = app
             .post(format!("/infra/{}/split_track_section", small_infra.id).as_str())

--- a/editoast/src/views/infra/edition.rs
+++ b/editoast/src/views/infra/edition.rs
@@ -1342,18 +1342,24 @@ pub mod tests {
         assert_eq!(right_part.position, 4000.0);
     }
 
+    #[rstest::rstest]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn split_track_section_with_detectors() {
+    #[case("DD0_5", 7887.5, 0)] // detector at 7887.5m on TD0, split at 15000m -> stays on left at 7887.5m
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[case("DD0_10", 575.0, 1)] // detector at 15575m on TD0, split at 15000m -> goes to right at 575m
+    async fn split_track_section_with_detectors(
+        #[case] detector_id: &str,
+        #[case] expected_position: f64,
+        #[case] expected_track_index: usize, // 0 for left, 1 for right
+    ) {
         let (app, small_infra) = setup_split_track_test().await;
         let db_pool = app.db_pool();
 
-        // DD0_5 is at 7887.5mm and DD0_10 is at 15575mm on TD0
-        // Split TD0 at 15000m
         let request = app
             .post(format!("/infra/{}/split_track_section", small_infra.id).as_str())
             .json(&json!({
                 "track": "TD0",
-                "offset": 15000000,
+                "offset": 15_000_000,
             }));
         let res: Vec<String> = app
             .fetch(request)
@@ -1362,22 +1368,14 @@ pub mod tests {
             .json_into();
 
         assert_eq!(res.len(), 2);
-        let left_track_id = &res[0];
-        let right_track_id = &res[1];
+        let expected_track_id = &res[expected_track_index];
 
         let infra_cache = InfraCache::load(&mut db_pool.get_ok(), &small_infra)
             .await
             .unwrap();
-
-        // DD0_5 should be on left track after split
-        let detector_left = infra_cache.get_detector("DD0_5").unwrap();
-        assert_eq!(detector_left.track.as_str(), left_track_id);
-        assert_eq!(detector_left.position, 7887.5);
-
-        // DD0_10 shoud be on right track after split
-        let detector_right = infra_cache.get_detector("DD0_10").unwrap();
-        assert_eq!(detector_right.track.as_str(), right_track_id);
-        assert_eq!(detector_right.position, 575.0);
+        let detector = infra_cache.get_detector(detector_id).unwrap();
+        assert_eq!(detector.track.as_str(), expected_track_id);
+        assert_eq!(detector.position, expected_position);
     }
 
     #[rstest::rstest]

--- a/editoast/src/views/infra/edition.rs
+++ b/editoast/src/views/infra/edition.rs
@@ -1267,79 +1267,48 @@ pub mod tests {
         assert_eq!(2000.0, res[0].railjson.as_object().unwrap()["length"]);
     }
 
+    #[rstest::rstest]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn split_track_section_with_operational_point() {
+    #[case(15_000_000, 14000.0, 0)] // op at 14000m on TD0, split at 15000m -> stays on left at 14000m
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[case(10_000_000, 4000.0, 1)] // op at 14000m on TD0, split at 10000m -> goes to right at 4000m
+    async fn split_track_section_with_operational_point(
+        #[case] offset: u64,
+        #[case] expected_position: f64,
+        #[case] expected_track_index: usize, // 0 for left, 1 for right
+    ) {
         let (app, small_infra) = setup_split_track_test().await;
         let db_pool = app.db_pool();
 
-        // Mid_East_station is at 14000m on TD0
-        // First split TD0 at 15000m
-        let request1 = app
+        let request = app
             .post(format!("/infra/{}/split_track_section", small_infra.id).as_str())
             .json(&json!({
                 "track": "TD0",
-                "offset": 15000000,
+                "offset": offset,
             }));
-        let res1: Vec<String> = app
-            .fetch(request1)
+        let res: Vec<String> = app
+            .fetch(request)
             .await
             .assert_status(StatusCode::OK)
             .json_into();
-        assert_eq!(res1.len(), 2);
-        let left_track_id = &res1[0];
 
-        // Mid_East_station should be on the left track after first split
+        assert_eq!(res.len(), 2);
+        let expected_track_id = &res[expected_track_index];
+
         let infra_cache = InfraCache::load(&mut db_pool.get_ok(), &small_infra)
             .await
             .unwrap();
-        let mid_east_op = infra_cache
+        let op = infra_cache
             .get_operational_point("Mid_East_station")
             .unwrap();
-        let parts_on_left: Vec<_> = mid_east_op
+        let parts_on_track: Vec<_> = op
             .parts
             .iter()
-            .filter(|p| p.track.as_str() == left_track_id)
-            .collect();
-        assert_eq!(parts_on_left.len(), 1);
-        assert_eq!(parts_on_left[0].position, 14000.0);
-
-        // Refresh
-        let req_refresh2 =
-            app.post(format!("/infra/refresh/?infras={}&force=true", small_infra.id).as_str());
-        app.fetch(req_refresh2).await.assert_status(StatusCode::OK);
-
-        // Second split at 10000m on left_track_id - before Mid_East_station
-        let request2 = app
-            .post(format!("/infra/{}/split_track_section", small_infra.id).as_str())
-            .json(&json!({
-                "track": left_track_id,
-                "offset": 10000000,
-            }));
-        let res2: Vec<String> = app
-            .fetch(request2)
-            .await
-            .assert_status(StatusCode::OK)
-            .json_into();
-        assert_eq!(res2.len(), 2);
-        let right_track_id = &res2[1];
-
-        // Mid_East_station should be on the right track after second split
-        let infra_cache = InfraCache::load(&mut db_pool.get_ok(), &small_infra)
-            .await
-            .unwrap();
-        let mid_east_op = infra_cache
-            .get_operational_point("Mid_East_station")
-            .unwrap();
-
-        let parts_on_right: Vec<_> = mid_east_op
-            .parts
-            .iter()
-            .filter(|p| p.track.as_str() == right_track_id)
+            .filter(|p| p.track.as_str() == expected_track_id)
             .collect();
 
-        assert_eq!(parts_on_right.len(), 1);
-        let right_part = &parts_on_right[0];
-        assert_eq!(right_part.position, 4000.0);
+        assert_eq!(parts_on_track.len(), 1);
+        assert_eq!(parts_on_track[0].position, expected_position);
     }
 
     #[rstest::rstest]


### PR DESCRIPTION
Refactors the test setup in `editoast/src/views/infra/edition.rs` to reduce code duplication and improve maintainability : 

- Introduces of a shared `setup_split_track_test` helper function
- Use the #[case] format for the tests