### PR TITLE
Fix track projection for train schedule :timer_clock: 

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -2291,12 +2291,14 @@ paths:
         - Returns 200 with a hashmap of train_id to ProjectPathTrainResult
 
         ## Important:
-        - **Only one train schedule per paced train is projected**.
-        - The train schedule selected is the first occurrence of the paced train.
+        - The main train projected is the model paced train without exceptions.
+        - If there are exceptions defined for the paced train that have a different projection than the main train,
+          they are included in the `exceptions` field of the result.
         - The following paced trains are **excluded** from the result:
             - paced trains for which pathfinding fails
             - paced trains for which the simulation fails
-            - paced trains for which the simulation does not respect schedule times
+        - Trains that have a simulation but that does not honor their schedule, use their schedule with straight lines
+          between the known points.
       requestBody:
         content:
           application/json:

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -1083,10 +1083,10 @@ mod tests {
                 "path": {
                     "blocks":[],
                     "routes": [],
-                    "track_section_ranges": [],
+                    "track_section_ranges": [{"track_section": "TA1", "begin":0, "end": 3, "direction": "START_TO_STOP"}],
                 },
                 "path_item_positions": [0,1,2,3],
-                "length": 1,
+                "length": 3,
                 "status": "success"
             }))
             .finish();

--- a/editoast/src/views/projection.rs
+++ b/editoast/src/views/projection.rs
@@ -95,28 +95,33 @@ impl SpaceTimeCurve {
         self.positions.is_empty()
     }
 
+    /// Generic linear interpolation function
+    /// Panics if the curve is empty or if x and y have different lengths
+    fn linear_interpolate(x: &[u64], y: &[u64], value: u64) -> u64 {
+        assert!(
+            x.len() == y.len(),
+            "Curve x and y must have the same length"
+        );
+        assert!(!x.is_empty(), "Curve can't be empty");
+
+        if value > x[x.len() - 1] {
+            // If the value is greater than the last x, return the last y
+            return y[y.len() - 1];
+        }
+        // Find the index of the first x greater than or equal to the given value
+        let index = find_index_upper(x, value);
+        if index == 0 {
+            // If the index is 0, return the first y
+            return y[0];
+        }
+        // Interpolate between the two points
+        linear_interpolate(x[index - 1], x[index], y[index - 1], y[index], value)
+    }
+
     /// Find the position at a given time
     /// Panics if the curve is empty
-    fn linear_interpolate(&self, time: u64) -> u64 {
-        assert!(!self.is_empty(), "Space time curve is empty");
-        if time > self.times[self.times.len() - 1] {
-            // If the time is greater than the last time, return the last position
-            return self.positions[self.positions.len() - 1];
-        }
-        // Find the index of the first time greater than or equal to the given time
-        let index = find_index_upper(&self.times, time);
-        if index == 0 {
-            // If the index is 0, return the first position
-            return self.positions[0];
-        }
-        // Interpolate between the two positions
-        linear_interpolate(
-            self.times[index - 1],
-            self.times[index],
-            self.positions[index - 1],
-            self.positions[index],
-            time,
-        )
+    fn linear_interpolate_time(&self, time: u64) -> u64 {
+        Self::linear_interpolate(&self.times, &self.positions, time)
     }
 }
 
@@ -703,8 +708,8 @@ fn project_train_path_op(
                     // Add interpolated points between a and b
                     let index_begin = find_index_upper(&space_time_curve.times, a_time);
                     let index_end = find_index_upper(&space_time_curve.times, b_time);
-                    let start = space_time_curve.linear_interpolate(a_time);
-                    let end = space_time_curve.linear_interpolate(b_time);
+                    let start = space_time_curve.linear_interpolate_time(a_time);
+                    let end = space_time_curve.linear_interpolate_time(b_time);
                     let range = index_begin..index_end;
                     for (&time, &position) in space_time_curve.times[range.clone()]
                         .iter()

--- a/editoast/src/views/projection.rs
+++ b/editoast/src/views/projection.rs
@@ -1,11 +1,8 @@
 use crate::error::Result;
 use core_client::CoreClient;
 use core_client::pathfinding::TrackRange;
-use core_client::pathfinding::TrainPath;
 use core_client::simulation::CompleteReportTrain;
 use core_client::simulation::ReportTrain;
-use core_client::simulation::SignalCriticalPosition;
-use core_client::simulation::ZoneUpdate;
 use database::DbConnection;
 use editoast_derive::EditoastError;
 use itertools::Itertools;
@@ -129,8 +126,6 @@ pub struct TrainSimulationDetails {
     pub positions: Vec<u64>,
     pub times: Vec<u64>,
     pub train_path: Vec<TrackRange>,
-    pub signal_critical_positions: Vec<SignalCriticalPosition>,
-    pub zone_updates: Vec<ZoneUpdate>,
 }
 
 impl TrainSimulationDetails {
@@ -150,24 +145,6 @@ impl TrainSimulationDetails {
         path_projection_tracks.hash(&mut hasher);
         let hash_simulation_input = hasher.finish();
         format!("projection_{osrd_version}.{infra_id}.{infra_version}.{hash_simulation_input}")
-    }
-
-    // Compute hash input of the occupancy block of a train schedule on a path
-    pub fn compute_occupancy_block_hash_with_versioning(
-        &self,
-        infra_id: i64,
-        infra_version: i64,
-        path: &TrainPath,
-        app_version: Option<&str>,
-    ) -> String {
-        let osrd_version = app_version.unwrap_or_default();
-        let mut hasher = DefaultHasher::new();
-        self.signal_critical_positions.hash(&mut hasher);
-        self.zone_updates.hash(&mut hasher);
-        self.train_path.hash(&mut hasher);
-        path.hash(&mut hasher);
-        let hash_simulation_input = hasher.finish();
-        format!("occupancy_block_{osrd_version}.{infra_id}.{infra_version}.{hash_simulation_input}")
     }
 }
 
@@ -805,8 +782,6 @@ pub async fn extract_train_details<T: TrainScheduleLike>(
                 positions: sim.final_output.report_train.positions.clone(),
                 times: sim.final_output.report_train.times.clone(),
                 train_path: pathfinding_result.path.track_section_ranges.clone(),
-                signal_critical_positions: sim.final_output.signal_critical_positions.clone(),
-                zone_updates: sim.final_output.zone_updates.clone(),
             })
         })
         .collect()
@@ -902,8 +877,6 @@ mod tests {
             positions,
             times,
             train_path,
-            signal_critical_positions: vec![],
-            zone_updates: vec![],
         };
 
         let space_time_curves = compute_space_time_curves(&project_path_input, &path_projection);
@@ -939,8 +912,6 @@ mod tests {
             positions: positions.clone(),
             times: times.clone(),
             train_path,
-            signal_critical_positions: vec![],
-            zone_updates: vec![],
         };
 
         let space_time_curves = compute_space_time_curves(&project_path_input, &path_projection);
@@ -979,8 +950,6 @@ mod tests {
             positions,
             times,
             train_path,
-            signal_critical_positions: vec![],
-            zone_updates: vec![],
         };
 
         let space_time_curves = compute_space_time_curves(&project_path_input, &path_projection);

--- a/editoast/src/views/projection.rs
+++ b/editoast/src/views/projection.rs
@@ -1,5 +1,6 @@
 use crate::error::Result;
 use core_client::CoreClient;
+use core_client::pathfinding::PathfindingResultSuccess;
 use core_client::pathfinding::TrackRange;
 use core_client::simulation::CompleteReportTrain;
 use core_client::simulation::ReportTrain;
@@ -8,6 +9,7 @@ use editoast_derive::EditoastError;
 use itertools::Itertools;
 use schemas::train_schedule::OperationalPointReference;
 use schemas::train_schedule::PathItemLocation;
+use schemas::train_schedule::ScheduleItem;
 use schemas::train_schedule::TrainScheduleLike;
 use serde::Deserialize;
 use serde::Serialize;
@@ -96,19 +98,20 @@ impl SpaceTimeCurve {
     }
 
     /// Generic linear interpolation function
+    /// For a segmented curve going through the points `(x[i],y[i])` find its Y
+    /// coordinate at the given X coordinate `value`. If `value` is out of bounds
+    /// return the first or the last point of the curve.
+    /// Expects `x` to be sorted.
     /// Panics if the curve is empty or if x and y have different lengths
-    fn linear_interpolate(x: &[u64], y: &[u64], value: u64) -> u64 {
-        assert!(
-            x.len() == y.len(),
-            "Curve x and y must have the same length"
-        );
+    fn linear_interpolate_curve(x: &[u64], y: &[u64], value: u64) -> u64 {
+        assert_eq!(x.len(), y.len(), "Curve x and y must have the same length");
         assert!(!x.is_empty(), "Curve can't be empty");
 
         if value > x[x.len() - 1] {
             // If the value is greater than the last x, return the last y
             return y[y.len() - 1];
         }
-        // Find the index of the first x greater than or equal to the given value
+        // Find the index of the last x equal or greater than value
         let index = find_index_upper(x, value);
         if index == 0 {
             // If the index is 0, return the first y
@@ -121,7 +124,13 @@ impl SpaceTimeCurve {
     /// Find the position at a given time
     /// Panics if the curve is empty
     fn linear_interpolate_time(&self, time: u64) -> u64 {
-        Self::linear_interpolate(&self.times, &self.positions, time)
+        Self::linear_interpolate_curve(&self.times, &self.positions, time)
+    }
+
+    /// Find the time at a given position
+    /// Panics if the curve is empty
+    fn linear_interpolate_position(&self, position: u64) -> u64 {
+        Self::linear_interpolate_curve(&self.positions, &self.times, position)
     }
 }
 
@@ -759,6 +768,71 @@ pub fn compute_projected_train_path_op_without_simulation<T: TrainScheduleLike>(
         .collect_vec()
 }
 
+/// Extract space time curve for train that does not respect their times
+/// These trains have path and simulation information that we can use.
+fn extract_curve_for_invalid_train_with_sim<T: TrainScheduleLike>(
+    train_schedule: &T,
+    sim: &SimulationResponseSuccess,
+    path: &PathfindingResultSuccess,
+) -> SpaceTimeCurve {
+    let mut positions = vec![0];
+    let mut times = vec![0];
+    let mut last_scheduled_time = 0;
+    let schedule_map = train_schedule
+        .schedule()
+        .iter()
+        .map(|s| (&s.at, s))
+        .collect::<HashMap<_, _>>();
+
+    for (path_item, path_item_position) in
+        train_schedule.path().iter().zip(&path.path_item_positions)
+    {
+        let Some(ScheduleItem {
+            arrival: Some(arrival),
+            stop_for,
+            ..
+        }) = schedule_map.get(&path_item.id)
+        else {
+            continue;
+        };
+        last_scheduled_time = arrival.num_milliseconds() as u64;
+        positions.push(*path_item_position);
+        times.push(last_scheduled_time);
+        if let Some(stop_for) = stop_for {
+            positions.push(*path_item_position);
+            times.push((arrival.num_milliseconds() + stop_for.num_milliseconds()) as u64);
+        }
+    }
+
+    // If the schedule has no arrival time for the last path item, so we cannot
+    // draw the final straight segment from schedule data alone. At the last schedule position,
+    // we compute the time offset between the simulation curve and the scheduled time.
+    // Then we draw the last segment (with its optional stop).
+    let last_scheduled_position = *positions.last().unwrap();
+    if last_scheduled_position != path.length {
+        let sim_curve = SpaceTimeCurve {
+            positions: sim.final_output.report_train.positions.clone(),
+            times: sim.final_output.report_train.times.clone(),
+        };
+        let last_sim_time = sim_curve.linear_interpolate_position(last_scheduled_position);
+        // Can't use times.last() because of possible stops at the end
+        let diff_time = last_scheduled_time as i64 - last_sim_time as i64;
+
+        let nb_points_to_ignore =
+            find_index_lower(&sim_curve.positions, *sim_curve.positions.last().unwrap());
+        sim_curve
+            .positions
+            .into_iter()
+            .zip(sim_curve.times)
+            .skip(nb_points_to_ignore)
+            .for_each(|(position, time)| {
+                positions.push(position);
+                times.push((time as i64 + diff_time) as u64);
+            });
+    }
+    SpaceTimeCurve { positions, times }
+}
+
 pub async fn extract_train_details<T: TrainScheduleLike>(
     simulations: Vec<(Arc<simulation::Response>, Arc<PathfindingResult>)>,
     train_schedules: &[T],
@@ -769,23 +843,29 @@ pub async fn extract_train_details<T: TrainScheduleLike>(
         .into_iter()
         .zip(train_schedules)
         .map(|((sim, pathfinding_result), train_schedule)| {
-            let simulation::Response::Success(sim) = sim.as_ref() else {
+            let PathfindingResult::Success(pathfinding_result) = pathfinding_result.as_ref() else {
                 return None;
             };
-            let PathfindingResult::Success(pathfinding_result) = pathfinding_result.as_ref() else {
+            let simulation::Response::Success(sim) = sim.as_ref() else {
                 return None;
             };
             let respect_times = sim
                 .path_item_respect_times(train_schedule)
                 .into_iter()
                 .all(|path_item| path_item);
-            if !respect_times {
-                return None;
-            }
+
+            let curve = if respect_times {
+                SpaceTimeCurve {
+                    positions: sim.final_output.report_train.positions.clone(),
+                    times: sim.final_output.report_train.times.clone(),
+                }
+            } else {
+                extract_curve_for_invalid_train_with_sim(train_schedule, sim, pathfinding_result)
+            };
 
             Some(TrainSimulationDetails {
-                positions: sim.final_output.report_train.positions.clone(),
-                times: sim.final_output.report_train.times.clone(),
+                positions: curve.positions,
+                times: curve.times,
                 train_path: pathfinding_result.path.track_section_ranges.clone(),
             })
         })

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -859,23 +859,23 @@ pub(in crate::views) fn simulation_empty_response() -> core_client::simulation::
 
     core_client::simulation::Response::Success(SimulationSuccess {
         base: ReportTrain {
-            positions: vec![0],
-            times: vec![0],
+            positions: vec![0, 1, 2, 3],
+            times: vec![0, 1, 2, 3],
             speeds: vec![],
             energy_consumption: 0.0,
             path_item_times: vec![0, 1, 2, 3],
         },
         provisional: ReportTrain {
-            positions: vec![0],
-            times: vec![0],
+            positions: vec![0, 1, 2, 3],
+            times: vec![0, 1, 2, 3],
             speeds: vec![],
             energy_consumption: 0.0,
             path_item_times: vec![0, 1, 2, 3],
         },
         final_output: CompleteReportTrain {
             report_train: ReportTrain {
-                positions: vec![0],
-                times: vec![0],
+                positions: vec![0, 1, 2, 3],
+                times: vec![0, 1, 2, 3],
                 speeds: vec![],
                 energy_consumption: 0.0,
                 path_item_times: vec![0, 1, 2, 3],

--- a/editoast/src/views/timetable/occupancy_blocks.rs
+++ b/editoast/src/views/timetable/occupancy_blocks.rs
@@ -4,22 +4,84 @@ use core_client::pathfinding::TrainPath;
 use core_client::signal_projection::SignalUpdate;
 use core_client::signal_projection::SignalUpdatesRequest;
 use core_client::signal_projection::TrainSimulation;
+use core_client::simulation::SignalCriticalPosition;
+use core_client::simulation::ZoneUpdate;
 use database::DbConnection;
 use schemas::train_schedule::TrainScheduleLike;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::Hash;
+use std::hash::Hasher;
 use std::sync::Arc;
 use utoipa::ToSchema;
 
 use crate::error::Result;
 use crate::models::infra::Infra;
-use crate::views::projection::TrainSimulationDetails;
-use crate::views::projection::extract_train_details;
+use crate::views::timetable::simulation;
 use crate::views::timetable::simulation::train_simulation_batch;
 
 /// Occupancy block output is described by time-space points and blocks
 pub type OccupancyBlocks = Vec<SignalUpdate>;
+
+#[derive(Debug, Clone, Hash)]
+pub struct TrainBlockOccupancyDetails {
+    pub signal_critical_positions: Vec<SignalCriticalPosition>,
+    pub zone_updates: Vec<ZoneUpdate>,
+    pub simulation_end_time: u64,
+}
+
+async fn extract_block_occupancy_details<T: TrainScheduleLike>(
+    simulations: Vec<Arc<simulation::Response>>,
+    train_schedules: &[T],
+) -> Vec<Option<TrainBlockOccupancyDetails>> {
+    assert_eq!(train_schedules.len(), simulations.len());
+
+    simulations
+        .into_iter()
+        .zip(train_schedules)
+        .map(|(sim, train_schedule)| {
+            let simulation::Response::Success(sim) = sim.as_ref() else {
+                // TODO: We should project as input mode
+                return None;
+            };
+            let respect_times = sim
+                .path_item_respect_times(train_schedule)
+                .into_iter()
+                .all(|path_item| path_item);
+
+            if !respect_times {
+                return None;
+            }
+            // We have a simulation and we respect times
+            Some(TrainBlockOccupancyDetails {
+                simulation_end_time: *sim.final_output.report_train.times.last().unwrap(),
+                signal_critical_positions: sim.final_output.signal_critical_positions.clone(),
+                zone_updates: sim.final_output.zone_updates.clone(),
+            })
+        })
+        .collect()
+}
+
+impl TrainBlockOccupancyDetails {
+    // Compute hash input of the occupancy block of a train schedule on a path
+    pub fn compute_occupancy_block_hash_with_versioning(
+        &self,
+        infra_id: i64,
+        infra_version: i64,
+        path: &TrainPath,
+        app_version: Option<&str>,
+    ) -> String {
+        let osrd_version = app_version.unwrap_or_default();
+        let mut hasher = DefaultHasher::new();
+        self.signal_critical_positions.hash(&mut hasher);
+        self.zone_updates.hash(&mut hasher);
+        path.hash(&mut hasher);
+        let hash_simulation_input = hasher.finish();
+        format!("occupancy_block_{osrd_version}.{infra_id}.{infra_version}.{hash_simulation_input}")
+    }
+}
 
 #[derive(Debug, Deserialize, ToSchema)]
 pub(in crate::views) struct OccupancyBlockForm {
@@ -34,7 +96,7 @@ pub(super) async fn compute_batch_signal_updates<'a>(
     core: Arc<CoreClient>,
     infra: &Infra,
     path: &'a TrainPath,
-    trains_details: &'a [TrainSimulationDetails],
+    trains_details: &'a [TrainBlockOccupancyDetails],
 ) -> Result<Vec<Vec<SignalUpdate>>> {
     if trains_details.is_empty() {
         return Ok(vec![]);
@@ -48,7 +110,7 @@ pub(super) async fn compute_batch_signal_updates<'a>(
             .map(|train_details| TrainSimulation {
                 signal_critical_positions: &train_details.signal_critical_positions,
                 zone_updates: &train_details.zone_updates,
-                simulation_end_time: train_details.times[train_details.times.len() - 1],
+                simulation_end_time: train_details.simulation_end_time,
             })
             .collect(),
     };
@@ -81,10 +143,13 @@ pub(super) async fn compute_occupancy_blocks<T: TrainScheduleLike>(
         electrical_profile_set_id,
         app_version,
     )
-    .await?;
+    .await?
+    .into_iter()
+    .map(|(sim, _)| sim)
+    .collect();
 
     // 2. Extracts train simulation details and computes unique hashes for projected train paths.
-    let trains_details = extract_train_details(simulations, trains_schedules).await;
+    let trains_details = extract_block_occupancy_details(simulations, trains_schedules).await;
 
     let train_hashes_to_idx: HashMap<String, Vec<usize>> = trains_details
         .iter()

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -1878,23 +1878,23 @@ mod tests {
             response,
             simulation::Response::Success(SimulationResponseSuccess {
                 base: ReportTrain {
-                    positions: vec![0],
-                    times: vec![0],
+                    positions: vec![0, 1, 2, 3],
+                    times: vec![0, 1, 2, 3],
                     speeds: vec![],
                     energy_consumption: 0.0,
                     path_item_times: vec![0, 1, 2, 3]
                 },
                 provisional: ReportTrain {
-                    positions: vec![0],
-                    times: vec![0],
+                    positions: vec![0, 1, 2, 3],
+                    times: vec![0, 1, 2, 3],
                     speeds: vec![],
                     energy_consumption: 0.0,
                     path_item_times: vec![0, 1, 2, 3]
                 },
                 final_output: CompleteReportTrain {
                     report_train: ReportTrain {
-                        positions: vec![0],
-                        times: vec![0],
+                        positions: vec![0, 1, 2, 3],
+                        times: vec![0, 1, 2, 3],
                         speeds: vec![],
                         energy_consumption: 0.0,
                         path_item_times: vec![0, 1, 2, 3]
@@ -2048,7 +2048,7 @@ mod tests {
             *response.get(&paced_train_id).unwrap(),
             PacedTrainSummaryResponse {
                 paced_train: SummaryResponse::Success {
-                    length: 0,
+                    length: 3,
                     time: 3,
                     energy_consumption: 0.0,
                     path_item_times_final: vec![0, 1, 2, 3],
@@ -2063,7 +2063,7 @@ mod tests {
                     // Simulation of the exception is the same than base
                     // because all simulation results from core are identical stubs
                     SummaryResponse::Success {
-                        length: 0,
+                        length: 3,
                         time: 3,
                         energy_consumption: 0.0,
                         path_item_times_final: vec![0, 1, 2, 3],

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -725,12 +725,14 @@ pub struct ProjectPathPacedTrainResult {
 /// - Returns 200 with a hashmap of train_id to ProjectPathTrainResult
 ///
 /// ## Important:
-/// - **Only one train schedule per paced train is projected**.
-/// - The train schedule selected is the first occurrence of the paced train.
+/// - The main train projected is the model paced train without exceptions.
+/// - If there are exceptions defined for the paced train that have a different projection than the main train,
+///   they are included in the `exceptions` field of the result.
 /// - The following paced trains are **excluded** from the result:
 ///     - paced trains for which pathfinding fails
 ///     - paced trains for which the simulation fails
-///     - paced trains for which the simulation does not respect schedule times
+/// - Trains that have a simulation but that does not honor their schedule, use their schedule with straight lines
+///   between the known points.
 #[editoast_derive::route]
 #[utoipa::path(
     post, path = "",


### PR DESCRIPTION
When train schedule does not respect times we can project them as not simulated.

Fix: https://github.com/OpenRailAssociation/osrd/issues/14857


> [!NOTE]
> Commits can be reviewed independently. 

> [!IMPORTANT]
> For trains that did not have a specified time at the end of path it was easier to complete using the real simulation curve instead of cutting it (like we do in non-simulated). I based this decision on the fact that simulax should display as much information as possible.
> ~The resulted curve is a mix of simulated and non simulated.~ -> We have segment also at the end but using the simulation to have the time.
> If validated we could do the exact same thing in inter-op.
> @maelysLeratRosso @Tguisnet What do you think? 

--------------

Examples: 

- First curve does not have schedule points (so it "respects" its schedule).
- Second curve has two schedule points, middle one can not be respected, last one is fine.
- Third curve is like the second one but without the last schedule point.

**Before:**

We had nothing when projecting a train that does not respect times.

**After:**

We project the train as "non simulated".

<img width="1400" height="705" alt="Sans titre" src="https://github.com/user-attachments/assets/9c18c5c8-f7d3-4d89-a182-420a2965ad70" />
<img width="1400" height="703" alt="Sans titre" src="https://github.com/user-attachments/assets/c33a9722-1b90-4b79-ba34-de013c3150ef" />
<img width="1400" height="703" alt="Sans titre" src="https://github.com/user-attachments/assets/beb16072-1f33-4b43-b202-9d8ac0d7914d" />

> [!NOTE]
> As we can see in op projection the result still weird, this is because simulax was not yet implemented for this mode.
> @hhirtz @ppitou I don't know if this is a work in progress or if we need to implement it (in a follow-up PR).
