### PR TITLE
front : itinerary modal : line management

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModal.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModal.tsx
@@ -1,13 +1,12 @@
 import { useEffect, useEffectEvent, useRef, useState } from 'react';
 
 import { Button } from '@osrd-project/ui-core';
-import { ArrowSwitch, FrameAll } from '@osrd-project/ui-icons';
+import { ArrowSwitch, FrameAll, Plus } from '@osrd-project/ui-icons';
 import bbox from '@turf/bbox';
 import type { Position } from 'geojson';
 import { compact } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
-import { v4 as uuidV4 } from 'uuid';
 
 import useCategoryColors from 'applications/operationalStudies/hooks/useCategoryColors';
 import { useManageTimetableItemContext } from 'applications/operationalStudies/hooks/useManageTimetableItemContext';
@@ -29,6 +28,7 @@ import {
 } from 'reducers/osrdconf/operationalStudiesConf/selectors';
 import type { PathStep, PathStepMetadata, PathStepV2 } from 'reducers/osrdconf/types';
 import { useAppDispatch } from 'store';
+import { addElementAtIndex } from 'utils/array';
 import useModalFocusTrap from 'utils/hooks/useModalFocusTrap';
 
 import { type OperationalPointSuggestion } from './ComboBoxCustomList/ListElementComponent';
@@ -38,6 +38,12 @@ import ItineraryModalMap from './ItineraryModalMap';
 import PathStepItem from './PathStepItem';
 import { computePathStepCoordinates } from './utils';
 import { MANAGE_TIMETABLE_ITEM_TYPES } from '../../../consts';
+import {
+  createEmptyPathStep,
+  ensureTrailingEmptyStep,
+  isEmptyStep,
+  deletePathStep,
+} from '../helpers/pathStepsActions';
 
 type ItineraryModalProps = {
   itineraryModalIsOpen: boolean;
@@ -68,6 +74,9 @@ const ItineraryModal = ({
 
   const [pathSteps, setPathSteps] = useState<PathStepV2[]>([]);
   const [categoryWarning, setCategoryWarning] = useState<string | undefined>(undefined);
+
+  const [hoveredGapIndex, setHoveredGapIndex] = useState<number | null>(null);
+
   const {
     activeStepId,
     setActiveStepId,
@@ -101,17 +110,51 @@ const ItineraryModal = ({
       },
     };
 
-    setPathSteps((prev) =>
-      prev.map((s) => (s.id === stepId ? { ...s, location: newLocation } : s))
-    );
+    setPathSteps((prev) => {
+      const next = prev.map((step) =>
+        step.id === stepId ? { ...step, location: newLocation } : step
+      );
+      return ensureTrailingEmptyStep(next);
+    });
 
     commitSelectionForStep(stepId, formatChosenValue(suggestion, chosenCh));
     resetOpSuggestions();
   };
 
-  const hasInvalidPathStep = Array.from(pathStepsMetadataById.values()).some(
-    (metadata) => metadata.isInvalid
-  );
+  const isOnlyStep = pathSteps.filter((s) => !isEmptyStep(s, getInputForStep(s.id))).length <= 1;
+
+  const hasInvalidPathStep = pathSteps.some((step) => {
+    if (isEmptyStep(step, getInputForStep(step.id))) return false;
+    const meta = pathStepsMetadataById.get(step.id);
+    return !meta || meta.isInvalid;
+  });
+
+  const handleDeletePathStep = (stepId: string) => {
+    resetOpSuggestions();
+
+    if (activeStepId === stepId) setActiveStepId('');
+
+    setPathSteps((prev) => {
+      const step = prev.find((s) => s.id === stepId);
+      if (!step) return prev;
+
+      const next = deletePathStep(prev, stepId);
+      return ensureTrailingEmptyStep(next);
+    });
+  };
+
+  const handleAddIntermediateStep = (insertIndex: number) => {
+    resetOpSuggestions();
+    setHoveredGapIndex(null);
+
+    const newStep = createEmptyPathStep();
+
+    setPathSteps((prev) => ensureTrailingEmptyStep(addElementAtIndex(prev, insertIndex, newStep)));
+
+    setActiveStepId(newStep.id);
+    setInputForStep(newStep.id, '');
+  };
+
   const editingStepIdRef = useRef<string>('');
 
   const isStepInvalidAndIsEditing = (step: PathStepV2, metadata?: PathStepMetadata) => {
@@ -176,17 +219,7 @@ const ItineraryModal = ({
       displayTimetableItemManagement === MANAGE_TIMETABLE_ITEM_TYPES.add
     ) {
       const formattedPathSteps = storePathSteps.map<PathStepV2>((pathStep) => {
-        // TODO : Remove this condition when PathStepV2 will be the default path step type in the store
-        if (!pathStep) {
-          return {
-            id: uuidV4(),
-            location: null,
-            arrival: null,
-            stopFor: null,
-            theoreticalMargin: null,
-            receptionSignal: null,
-          };
-        }
+        if (!pathStep) return createEmptyPathStep();
         return {
           id: pathStep.id,
           location: pathStep.location,
@@ -196,20 +229,27 @@ const ItineraryModal = ({
           receptionSignal: pathStep.receptionSignal ?? null,
         };
       });
-      setPathSteps(formattedPathSteps);
-    }
-  }, [storePathSteps]);
 
+      setPathSteps(ensureTrailingEmptyStep(formattedPathSteps));
+    }
+  }, [storePathSteps, displayTimetableItemManagement]);
+
+  const pathfindingSteps = pathSteps.filter((s) => {
+    if (!s.location) return false;
+    const meta = pathStepsMetadataById.get(s.id);
+    return !!meta && !meta.isInvalid;
+  });
+
+  const pathfindingLocations = pathfindingSteps.map((s) => s.location);
+
+  const metadataByPathStepId = new Map(
+    pathfindingSteps.map((s) => [s.id, pathStepsMetadataById.get(s.id)!])
+  );
   useEffect(() => {
-    if (
-      workerStatus === 'READY' &&
-      pathSteps.length >= 2 &&
-      pathStepsMetadataById.size === pathSteps.length &&
-      rollingStockId
-    ) {
+    if (workerStatus === 'READY' && pathfindingLocations.length >= 2 && rollingStockId) {
       launchPathfindingV2({
-        pathSteps: pathSteps.map((step) => step.location),
-        pathStepsMetadataById,
+        pathSteps: pathfindingLocations,
+        pathStepsMetadataById: metadataByPathStepId,
         rollingStockId,
         speedLimitTag,
       });
@@ -246,10 +286,10 @@ const ItineraryModal = ({
   };
 
   const buildPathSteps = (steps: PathStepV2[], metadataById: Map<string, PathStepMetadata>) =>
-    steps.map<PathStep | null>((s) => {
-      if (!s.location) return null;
+    steps.map<PathStep | null>((step) => {
+      if (!step.location) return null;
 
-      const metadata = metadataById.get(s.id);
+      const metadata = metadataById.get(step.id);
       if (!metadata || metadata.isInvalid) return null;
 
       const coordinates =
@@ -258,12 +298,12 @@ const ItineraryModal = ({
       const secondary_code = metadata.type === 'opRef' ? metadata.secondaryCode : undefined;
 
       return {
-        id: s.id,
-        location: s.location,
-        arrival: s.arrival,
-        stopFor: s.stopFor,
-        theoreticalMargin: s.theoreticalMargin ?? undefined,
-        receptionSignal: s.receptionSignal ?? undefined,
+        id: step.id,
+        location: step.location,
+        arrival: step.arrival,
+        stopFor: step.stopFor,
+        theoreticalMargin: step.theoreticalMargin ?? undefined,
+        receptionSignal: step.receptionSignal ?? undefined,
 
         name: metadata.type === 'opRef' ? metadata.name : undefined,
         uic: metadata.type === 'opRef' ? metadata.uic : undefined,
@@ -276,14 +316,20 @@ const ItineraryModal = ({
     setInputForStep(stepId, '');
     resetOpSuggestions();
 
-    setPathSteps((prev) => prev.map((s) => (s.id === stepId ? { ...s, location: null } : s)));
+    setPathSteps((prev) =>
+      prev.map((step) => (step.id === stepId ? { ...step, location: null } : step))
+    );
   };
 
   const reverseItinerary = () => {
-    const updatedPathSteps = buildPathSteps(pathSteps, pathStepsMetadataById);
+    const filledSteps = pathSteps.filter((step) => !isEmptyStep(step, getInputForStep(step.id)));
+    const updatedPathSteps = buildPathSteps(filledSteps, pathStepsMetadataById);
 
     // No step should be null when reverseItinerary is called (as start and arrival need to be defined), so compact should let the array unchanged but constrain the type
     const cPathSteps = compact(updatedPathSteps);
+
+    if (cPathSteps.length < 2) return;
+
     launchPathfinding(reversePathSteps(cPathSteps));
   };
 
@@ -292,12 +338,17 @@ const ItineraryModal = ({
       if (hasInvalidPathStep || pathfindingError) return;
     }
 
-    const updatedPathSteps = buildPathSteps(pathSteps, pathStepsMetadataById);
+    const filledSteps = pathSteps.filter((step) => !isEmptyStep(step, getInputForStep(step.id)));
+    if (filledSteps.length < 2) return;
 
-    dispatch(updatePathSteps(updatedPathSteps));
-    launchPathfinding(updatedPathSteps, rollingStockId, {
-      isInitialization: true,
-    });
+    const updatedPathSteps = buildPathSteps(filledSteps, pathStepsMetadataById);
+
+    const compacted = compact(updatedPathSteps);
+
+    if (compacted.length < 2) return;
+
+    dispatch(updatePathSteps(compacted));
+    launchPathfinding(compacted, rollingStockId, { isInitialization: true });
     closeModal();
   };
 
@@ -356,56 +407,91 @@ const ItineraryModal = ({
               const pathStepMetadata = pathStepsMetadataById.get(pathStep.id);
               const isInvalid = isStepInvalidAndIsEditing(pathStep, pathStepMetadata);
 
+              const previousPathStepMetadata = pathStepsMetadataById.get(pathSteps[i - 1]?.id);
+              const hideLine =
+                i > 0 && (pathStepMetadata?.isInvalid || previousPathStepMetadata?.isInvalid);
+              const isTrailingPlaceholder =
+                i === pathSteps.length - 1 && isEmptyStep(pathStep, getInputForStep(pathStep.id));
+
               return (
-                <PathStepItem
-                  key={pathStep.id}
-                  setPathSteps={setPathSteps}
-                  pathStep={pathStep}
-                  pathStepMetadata={pathStepMetadata}
-                  index={i + 1}
-                  categoryColors={categoryColors}
-                  hidePathfindingLine={i > 0 && isInvalid}
-                  onOpFocus={() => markEditing(pathStep.id)}
-                  onOpInputChange={(value) => {
-                    markEditing(pathStep.id);
-                    if (value === '') {
-                      clearStep(pathStep.id);
-                      return;
-                    }
-                    setInputForStep(pathStep.id, value);
-                  }}
-                  onTrackNameChange={(trackName) => {
-                    setPathSteps((prev) =>
-                      prev.map((step) => {
-                        if (step.id !== pathStep.id) return step;
-                        if (!step.location || !('operational_point' in step.location)) return step;
-                        return {
-                          ...step,
-                          location: {
-                            ...step.location,
-                            local_track_name: trackName || undefined,
-                          },
-                        };
-                      })
-                    );
-                  }}
-                  onOpBlur={() => unmarkEditing(pathStep.id)}
-                  inputValue={getInputForStep(pathStep.id)}
-                  opSuggestions={activeStepId === pathStep.id ? opSuggestions : []}
-                  onSelectOpSuggestion={(suggestion, chCode) => {
-                    applyOperationalPointToStep(pathStep.id, suggestion, chCode);
-                  }}
-                  onChevronClick={(queryValue) => {
-                    reopenSuggestionsForStep(pathStep.id, queryValue);
-                  }}
-                  isInvalidAndIsEditing={isInvalid}
-                />
+                <>
+                  <div>
+                    {!hideLine && (
+                      <div className="path-step-gap">
+                        <div
+                          className="path-step-gap-hitbox"
+                          onPointerEnter={() => setHoveredGapIndex(i)}
+                          onPointerLeave={() => setHoveredGapIndex(null)}
+                        >
+                          {hoveredGapIndex === i && (
+                            <button
+                              type="button"
+                              className="add-pathitem"
+                              onClick={() => handleAddIntermediateStep(i)}
+                            >
+                              <Plus iconColor="var(--white100)" />
+                            </button>
+                          )}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                  <PathStepItem
+                    key={pathStep.id}
+                    pathStep={pathStep}
+                    setPathSteps={setPathSteps}
+                    pathStepMetadata={pathStepMetadata}
+                    index={i + 1}
+                    categoryColors={categoryColors}
+                    hidePathfindingLine={i > 0 && isInvalid && !isTrailingPlaceholder}
+                    onDelete={() => {
+                      if (isOnlyStep) return;
+                      handleDeletePathStep(pathStep.id);
+                    }}
+                    onOpFocus={() => markEditing(pathStep.id)}
+                    onOpInputChange={(value) => {
+                      markEditing(pathStep.id);
+                      if (value === '') {
+                        clearStep(pathStep.id);
+                        return;
+                      }
+                      setInputForStep(pathStep.id, value);
+                    }}
+                    onTrackNameChange={(trackName) => {
+                      setPathSteps((prev) =>
+                        prev.map((step) => {
+                          if (step.id !== pathStep.id) return step;
+                          if (!step.location || !('operational_point' in step.location))
+                            return step;
+                          return {
+                            ...step,
+                            location: {
+                              ...step.location,
+                              local_track_name: trackName || undefined,
+                            },
+                          };
+                        })
+                      );
+                    }}
+                    onOpBlur={() => unmarkEditing(pathStep.id)}
+                    inputValue={getInputForStep(pathStep.id)}
+                    opSuggestions={activeStepId === pathStep.id ? opSuggestions : []}
+                    onSelectOpSuggestion={(suggestion, chCode) => {
+                      applyOperationalPointToStep(pathStep.id, suggestion, chCode);
+                    }}
+                    onChevronClick={(queryValue) => {
+                      reopenSuggestionsForStep(pathStep.id, queryValue);
+                    }}
+                    resetOpSuggestions={resetOpSuggestions}
+                    connectorLong={hoveredGapIndex === i}
+                    isTrailingPlaceHolder={isTrailingPlaceholder}
+                    isIndexed
+                    isOnlyStep={isOnlyStep}
+                    isInvalidAndIsEditing={isInvalid}
+                  />
+                </>
               );
             })}
-            <PathStepItem
-              hidePathfindingLine={pathSteps.length === 0}
-              categoryColors={categoryColors}
-            />
           </div>
         </div>
         <div className="itinerary-modal-form-footer">

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModal.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useEffectEvent, useRef, useState } from 'react';
+import { useEffect, useEffectEvent, useMemo, useRef, useState } from 'react';
 
 import { Button } from '@osrd-project/ui-core';
 import { ArrowSwitch, FrameAll, Plus } from '@osrd-project/ui-icons';
@@ -234,34 +234,46 @@ const ItineraryModal = ({
     }
   }, [storePathSteps, displayTimetableItemManagement]);
 
-  const pathfindingSteps = pathSteps.filter((s) => {
-    if (!s.location) return false;
-    const meta = pathStepsMetadataById.get(s.id);
-    return !!meta && !meta.isInvalid;
-  });
-
-  const pathfindingLocations = pathfindingSteps.map((s) => s.location);
-
-  const metadataByPathStepId = new Map(
-    pathfindingSteps.map((s) => [s.id, pathStepsMetadataById.get(s.id)!])
+  const pathfindingStepsWithLocations = useMemo(
+    () =>
+      pathSteps.filter((s) => {
+        if (!s.location) return false;
+        const meta = pathStepsMetadataById.get(s.id);
+        return !!meta && !meta.isInvalid;
+      }),
+    [pathSteps, pathStepsMetadataById]
   );
+  const pathfindingStepsRef = useRef<PathStepV2[]>([]);
+
+  const pathfindingSteps = useMemo(() => {
+    const prev = pathfindingStepsRef.current;
+    const next = pathfindingStepsWithLocations;
+
+    const sameSteps =
+      prev.length === next.length &&
+      prev.every((p, i) => p.id === next[i].id && p.location === next[i].location);
+
+    if (sameSteps) return prev;
+
+    pathfindingStepsRef.current = next;
+    return next;
+  }, [pathfindingStepsWithLocations]);
+
   useEffect(() => {
-    if (workerStatus === 'READY' && pathfindingLocations.length >= 2 && rollingStockId) {
-      launchPathfindingV2({
-        pathSteps: pathfindingLocations,
-        pathStepsMetadataById: metadataByPathStepId,
-        rollingStockId,
-        speedLimitTag,
-      });
-    }
-  }, [
-    workerStatus,
-    pathSteps,
-    pathStepsMetadataById,
-    rollingStockId,
-    speedLimitTag,
-    launchPathfindingV2,
-  ]);
+    if (workerStatus !== 'READY' || !rollingStockId || pathfindingSteps.length < 2) return;
+
+    const pathfindingLocations = pathfindingSteps.map((s) => s.location!);
+    const metadataByPathStepId = new Map(
+      pathfindingSteps.map((s) => [s.id, pathStepsMetadataById.get(s.id)!])
+    );
+
+    launchPathfindingV2({
+      pathSteps: pathfindingLocations,
+      pathStepsMetadataById: metadataByPathStepId,
+      rollingStockId,
+      speedLimitTag,
+    });
+  }, [workerStatus, rollingStockId, speedLimitTag, pathfindingSteps]);
 
   const onPathfindingLoad = useEffectEvent((geometry: PathProperties['geometry']) => {
     const newViewport = computeBBoxViewport(bbox(geometry), mapSettings.viewport, {

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModal.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModal.tsx
@@ -485,7 +485,6 @@ const ItineraryModal = ({
                     resetOpSuggestions={resetOpSuggestions}
                     connectorLong={hoveredGapIndex === i}
                     isTrailingPlaceHolder={isTrailingPlaceholder}
-                    isIndexed
                     isOnlyStep={isOnlyStep}
                     isInvalidAndIsEditing={isInvalid}
                   />

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModal.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModal.tsx
@@ -29,6 +29,7 @@ import {
 import type { PathStep, PathStepMetadata, PathStepV2 } from 'reducers/osrdconf/types';
 import { useAppDispatch } from 'store';
 import { addElementAtIndex } from 'utils/array';
+import { Duration } from 'utils/duration';
 import useModalFocusTrap from 'utils/hooks/useModalFocusTrap';
 
 import { type OperationalPointSuggestion } from './ComboBoxCustomList/ListElementComponent';
@@ -353,7 +354,11 @@ const ItineraryModal = ({
     const filledSteps = pathSteps.filter((step) => !isEmptyStep(step, getInputForStep(step.id)));
     if (filledSteps.length < 2) return;
 
-    const updatedPathSteps = buildPathSteps(filledSteps, pathStepsMetadataById);
+    const stepsWithStopAtDestination = filledSteps.map((step, i) =>
+      i === filledSteps.length - 1 ? { ...step, stopFor: new Duration({ minutes: 0 }) } : step
+    );
+
+    const updatedPathSteps = buildPathSteps(stepsWithStopAtDestination, pathStepsMetadataById);
 
     const compacted = compact(updatedPathSteps);
 

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/PathStepItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/PathStepItem.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 
 import { ComboBox, Select, SegmentedControl } from '@osrd-project/ui-core';
 import {
@@ -8,6 +8,7 @@ import {
   ArrowRight,
   Square,
   KebabHorizontal,
+  X,
 } from '@osrd-project/ui-icons';
 import bbox from '@turf/bbox';
 import cx from 'classnames';
@@ -48,6 +49,11 @@ type PathStepProps = {
   onInputClear?: () => void;
   isCleared?: boolean;
   isInvalidAndIsEditing?: boolean;
+  connectorLong?: boolean;
+  onDelete?: () => void;
+  isTrailingPlaceHolder?: boolean;
+  isIndexed?: boolean;
+  isOnlyStep?: boolean;
 };
 
 const PathStepItem = ({
@@ -67,6 +73,10 @@ const PathStepItem = ({
   resetOpSuggestions,
   onChevronClick,
   isInvalidAndIsEditing,
+  connectorLong,
+  onDelete,
+  isTrailingPlaceHolder,
+  isOnlyStep,
 }: PathStepProps) => {
   const { t } = useTranslation('operational-studies', {
     keyPrefix: 'manageTimetableItem.itineraryModal',
@@ -75,11 +85,14 @@ const PathStepItem = ({
   const mapSettings = useMapSettings();
   const { updateViewport } = useMapSettingsActions();
 
+  const [hovered, setHovered] = useState(false);
+
   const blurActiveElement = () => {
     requestAnimationFrame(() => {
       (document.activeElement as HTMLElement | null)?.blur();
     });
   };
+  const isIndexed = !!index && !isTrailingPlaceHolder;
 
   const shouldShowInvalidMessage = !!pathStep && !!isInvalidAndIsEditing;
 
@@ -233,28 +246,45 @@ const PathStepItem = ({
     : visibleSuggestions.length;
 
   return (
-    <div className="path-step-wrapper">
-      <div className="path-step">
-        <div
+    <div className={cx('path-step-wrapper', { 'is-placeholder': isTrailingPlaceHolder })}>
+      <div
+        className={cx('path-step', {
+          'requested-point': pathStep?.location && 'track' in pathStep.location,
+        })}
+      >
+        <button
+          type="button"
           className={cx('path-step-counter', {
+            'delete-hovered': hovered && !isTrailingPlaceHolder && !isOnlyStep,
             invalid: isInvalidAndIsEditing,
-            index,
+            'is-only-step': isOnlyStep,
+            index: isIndexed,
             'pathfinding-line': !hidePathfindingLine,
             origin: index === 1,
             empty: !pathStep,
           })}
           style={{
             borderColor: !isInvalidAndIsEditing
-              ? index
+              ? isIndexed
                 ? categoryColors.background
                 : categoryColors.normal
               : '',
             // @ts-expect-error: variable CSS custom property to be used to style ::before
-            '--pathBackground': categoryColors.normal,
+            '--pathBackground': isTrailingPlaceHolder
+              ? 'rgba(0, 0, 0, 0.2)'
+              : categoryColors.normal,
+            '--counterLink': connectorLong ? '48px' : '28px',
           }}
+          onClick={(e) => {
+            e.stopPropagation();
+            onDelete?.();
+          }}
+          onPointerEnter={() => !isTrailingPlaceHolder && setHovered(true)}
+          onPointerLeave={() => !isTrailingPlaceHolder && setHovered(false)}
         >
-          {index}
-        </div>
+          {isTrailingPlaceHolder ? null : hovered && !isOnlyStep ? <X /> : index}
+        </button>
+
         <div
           role="button"
           tabIndex={0}

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/PathStepItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/PathStepItem.tsx
@@ -31,29 +31,26 @@ import { computePathStepCoordinates, isOpRefMetadata } from './utils';
 const EMPTY_OPTION = { label: '', id: '' };
 
 type PathStepProps = {
+  pathStep: PathStepV2;
   setPathSteps?: React.Dispatch<React.SetStateAction<PathStepV2[]>>;
-  pathStep?: PathStepV2;
-  pathStepMetadata?: PathStepMetadata;
-  index?: number;
-  hidePathfindingLine?: boolean;
+  pathStepMetadata: PathStepMetadata | undefined;
+  index: number;
+  hidePathfindingLine: boolean;
   categoryColors: CategoryColors;
-  onOpInputChange?: (value: string) => void;
-  onTrackNameChange?: (trackName: string) => void;
-  onOpFocus?: () => void;
-  onOpBlur?: () => void;
-  inputValue?: string;
-  opSuggestions?: Array<OperationalPointSuggestion | string>;
-  onSelectOpSuggestion?: (suggestion: OperationalPointSuggestion, secondaryCode?: string) => void;
-  resetOpSuggestions?: () => void;
-  onChevronClick?: (queryValue: string) => void;
-  onInputClear?: () => void;
-  isCleared?: boolean;
-  isInvalidAndIsEditing?: boolean;
-  connectorLong?: boolean;
-  onDelete?: () => void;
-  isTrailingPlaceHolder?: boolean;
-  isIndexed?: boolean;
-  isOnlyStep?: boolean;
+  onOpInputChange: (value: string) => void;
+  onTrackNameChange: (trackName: string) => void;
+  onOpFocus: () => void;
+  onOpBlur: () => void;
+  inputValue: string | undefined;
+  opSuggestions: Array<OperationalPointSuggestion | string>;
+  onSelectOpSuggestion: (suggestion: OperationalPointSuggestion, secondaryCode?: string) => void;
+  resetOpSuggestions: () => void;
+  onChevronClick: (queryValue: string) => void;
+  isInvalidAndIsEditing: boolean;
+  connectorLong: boolean;
+  onDelete: () => void;
+  isTrailingPlaceHolder: boolean;
+  isOnlyStep: boolean;
 };
 
 const PathStepItem = ({
@@ -68,7 +65,7 @@ const PathStepItem = ({
   onOpFocus,
   onOpBlur,
   inputValue,
-  opSuggestions = [],
+  opSuggestions,
   onSelectOpSuggestion,
   resetOpSuggestions,
   onChevronClick,
@@ -92,9 +89,9 @@ const PathStepItem = ({
       (document.activeElement as HTMLElement | null)?.blur();
     });
   };
-  const isIndexed = !!index && !isTrailingPlaceHolder;
+  const isIndexed = !isTrailingPlaceHolder;
 
-  const shouldShowInvalidMessage = !!pathStep && !!isInvalidAndIsEditing;
+  const shouldShowInvalidMessage = !!isInvalidAndIsEditing;
 
   const getInvalidMessage = (comboBoxValue: string) => {
     let message = t('invalidOP');
@@ -104,7 +101,7 @@ const PathStepItem = ({
       `;
     }
 
-    if (!pathStepMetadata?.isInvalid || !pathStep?.location) return message;
+    if (!pathStepMetadata?.isInvalid || !pathStep.location) return message;
 
     const { location } = pathStep;
 
@@ -142,7 +139,7 @@ const PathStepItem = ({
       label: pathStepMetadata?.secondaryCode ?? '',
       id: pathStepMetadata?.secondaryCode ?? '',
     };
-  }, [pathStep, pathStepMetadata]);
+  }, [pathStepMetadata]);
 
   const trackNameSuggestions = useMemo(() => {
     const selectedSecondaryCode = selectedSecondaryCodeOption.id;
@@ -183,7 +180,7 @@ const PathStepItem = ({
       trackNameSuggestions.find((track) => track.label === pathStepMetadata.trackName) ||
       EMPTY_OPTION
     );
-  }, [pathStep, pathStepMetadata]);
+  }, [pathStepMetadata, trackNameSuggestions]);
 
   const handleFocusClick = () => {
     if (!pathStepMetadata) return;
@@ -249,7 +246,7 @@ const PathStepItem = ({
     <div className={cx('path-step-wrapper', { 'is-placeholder': isTrailingPlaceHolder })}>
       <div
         className={cx('path-step', {
-          'requested-point': pathStep?.location && 'track' in pathStep.location,
+          'requested-point': pathStep.location && 'track' in pathStep.location,
         })}
       >
         <button
@@ -261,7 +258,7 @@ const PathStepItem = ({
             index: isIndexed,
             'pathfinding-line': !hidePathfindingLine,
             origin: index === 1,
-            empty: !pathStep,
+            empty: !pathStep.location,
           })}
           style={{
             borderColor: !isInvalidAndIsEditing
@@ -277,7 +274,7 @@ const PathStepItem = ({
           }}
           onClick={(e) => {
             e.stopPropagation();
-            onDelete?.();
+            onDelete();
           }}
           onPointerEnter={() => !isTrailingPlaceHolder && setHovered(true)}
           onPointerLeave={() => !isTrailingPlaceHolder && setHovered(false)}
@@ -294,12 +291,12 @@ const PathStepItem = ({
           onMouseDownCapture={(e) => {
             const target = e.target as HTMLElement | null;
             if (target?.closest('.chevron-icon')) {
-              onChevronClick?.(comboBoxValue ?? '');
+              onChevronClick(comboBoxValue ?? '');
             }
           }}
         >
           <ComboBox
-            id={`pathStep-name-${pathStep?.id ?? 'empty'}`}
+            id={`pathStep-name-${pathStep.id}`}
             value={comboBoxValue}
             numberOfSuggestionsToShow={numberOfSuggestionsToShow}
             suggestions={visibleSuggestions}
@@ -310,21 +307,21 @@ const PathStepItem = ({
             }}
             onSelectSuggestion={(op) => {
               if (!op) {
-                onOpInputChange?.('');
-                resetOpSuggestions?.();
+                onOpInputChange('');
+                resetOpSuggestions();
                 return;
               }
 
               if (typeof op === 'string') {
-                onOpInputChange?.(op);
+                onOpInputChange(op);
                 return;
               }
 
-              onSelectOpSuggestion?.(op);
-              resetOpSuggestions?.();
+              onSelectOpSuggestion(op);
+              resetOpSuggestions();
               blurActiveElement();
             }}
-            resetSuggestions={() => resetOpSuggestions?.()}
+            resetSuggestions={() => resetOpSuggestions()}
             renderListElementComponent={({
               suggestion,
               index: suggestionIndex,
@@ -340,8 +337,8 @@ const PathStepItem = ({
                   isActive={isActive}
                   isSelected={isSelected}
                   onSelect={(op, secondaryCode) => {
-                    onSelectOpSuggestion?.(op, secondaryCode);
-                    resetOpSuggestions?.();
+                    onSelectOpSuggestion(op, secondaryCode);
+                    resetOpSuggestions();
                     blurActiveElement();
                   }}
                 />
@@ -373,10 +370,10 @@ const PathStepItem = ({
             narrow
             onFocus={onOpFocus}
             onBlur={onOpBlur}
-            onChange={(e) => onOpInputChange?.(e.target.value)}
+            onChange={(e) => onOpInputChange(e.target.value)}
           />
         </div>
-        {pathStep?.location && 'track' in pathStep.location ? (
+        {pathStep.location && 'track' in pathStep.location ? (
           <div className="requested-point-block" />
         ) : (
           <div
@@ -385,12 +382,12 @@ const PathStepItem = ({
             })}
           >
             <Select
-              id={`pathStep-status-${pathStep?.id ?? 'empty'}`}
+              id={`pathStep-status-${pathStep.id}`}
               value={selectedTrackNameOption}
               options={trackNameSuggestions}
               getOptionLabel={(option) => option.label}
               getOptionValue={(option) => option.id}
-              onChange={(option) => onTrackNameChange?.(option?.label ?? '')}
+              onChange={(option) => onTrackNameChange(option?.label ?? '')}
               small
               narrow
             />
@@ -408,7 +405,7 @@ const PathStepItem = ({
           small
         />
         <div className="map-interactions">
-          {pathStep?.location && 'track' in pathStep.location ? (
+          {pathStep.location && 'track' in pathStep.location ? (
             <AddedLocation
               size="lg"
               variant="fill"
@@ -424,8 +421,8 @@ const PathStepItem = ({
             />
           )}
           <button
-            className={cx('focus-map-icon', { empty: !pathStep })}
-            disabled={!pathStep}
+            className={cx('focus-map-icon', { empty: !pathStep.location })}
+            disabled={!pathStep.location}
             onClick={handleFocusClick}
           >
             <FocusLocation

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/helpers/pathStepsActions.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/helpers/pathStepsActions.ts
@@ -1,0 +1,28 @@
+import { v4 as uuidV4 } from 'uuid';
+
+import type { PathStepV2 } from 'reducers/osrdconf/types';
+
+export const createEmptyPathStep = (): PathStepV2 => ({
+  id: uuidV4(),
+  location: null,
+  arrival: null,
+  stopFor: null,
+  theoreticalMargin: null,
+  receptionSignal: null,
+});
+
+export const isEmptyStep = (step: PathStepV2, input?: string) => {
+  if (input === undefined) {
+    return true;
+  }
+  return !step.location && input.trim() === '';
+};
+
+export const ensureTrailingEmptyStep = (steps: PathStepV2[]): PathStepV2[] => {
+  const last = steps.at(-1);
+  if (last && !isEmptyStep(last, '')) return [...steps, createEmptyPathStep()];
+  return steps;
+};
+
+export const deletePathStep = (steps: PathStepV2[], stepId: string): PathStepV2[] =>
+  steps.filter((s) => s.id !== stepId);

--- a/front/src/modules/pathfinding/hooks/usePathfindingV2.ts
+++ b/front/src/modules/pathfinding/hooks/usePathfindingV2.ts
@@ -69,6 +69,9 @@ const usePathfindingV2 = () => {
         },
       };
 
+      setPathProperties(undefined);
+      setPathfindingError('');
+
       const pathfindingResult = await postPathfindingBlocks(pathFindingPayload).unwrap();
 
       if (pathfindingResult.status === 'success') {

--- a/front/src/styles/scss/applications/operationalStudies/_itineraryModal.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_itineraryModal.scss
@@ -28,6 +28,11 @@
     background: var(--grey30);
   }
 
+  .ui-combo-box .clear-icon {
+    position: relative;
+    z-index: 10;
+  }
+
   .itinerary-modal-form {
     min-width: 628px;
     width: 50%;
@@ -120,7 +125,59 @@
         margin-top: 12px;
         margin-inline: 8px;
         padding-top: 16px;
+        .path-step-gap {
+          position: relative;
+          height: 28px;
+          margin-top: -28px;
+        }
 
+        .path-step-gap-hitbox {
+          position: absolute;
+          left: 0;
+          top: 12px;
+          width: 56px;
+          height: 100%;
+        }
+
+        .path-step-gap:has(.path-step-gap-hitbox:hover) {
+          height: 48px;
+        }
+
+        .path-step-gap:has(.path-step-gap-hitbox:hover)::after {
+          content: '';
+          position: absolute;
+          left: 30px;
+          right: calc(
+            var(--map-interactions-width) + var(--map-interactions-margin-left) +
+              var(--path-step-row-gap) + var(--path-step-wrapper-padding-right)
+          );
+          top: 34px;
+          height: 4px;
+          opacity: 0.5;
+          background-color: var(--grey30);
+          pointer-events: none;
+        }
+
+        .path-step-gap .add-pathitem {
+          position: absolute;
+          left: 12px;
+          top: 12px;
+          z-index: 2;
+          padding: 0;
+          margin: 0;
+          border: 0;
+          width: 24px;
+          height: 24px;
+          display: grid;
+          place-items: center;
+          cursor: pointer;
+          background: var(--primary60);
+          border-radius: 50%;
+
+          svg {
+            display: block !important;
+          }
+        }
         .reverse-itinerary-button {
           position: absolute;
           padding: 8px;
@@ -167,7 +224,11 @@
             margin-left: 1px;
           }
         }
-
+        .path-step-wrapper.is-placeholder {
+          .invalid-step-message {
+            display: none;
+          }
+        }
         // this wrapper is being used to display the "adding location on map" style
         .path-step-wrapper {
           padding-inline: var(--path-step-wrapper-padding-left)
@@ -188,6 +249,20 @@
             gap: 8px;
             padding-block: 8px;
 
+            &.requested-point {
+              grid-template-columns:
+                24px minmax(184px, 1fr) calc(
+                  var(--path-step-secondary-code-width) + var(--path-step-track-name-width) +
+                    var(--path-step-row-gap)
+                )
+                auto;
+            }
+
+            .path-step-counter.delete-hovered {
+              opacity: 1;
+              background-color: var(--error60) !important;
+              border-color: var(--error30) !important;
+            }
             .path-step-counter {
               position: relative;
               width: 24px;
@@ -198,6 +273,7 @@
               opacity: 0.5;
               background-color: var(--white100);
               margin-right: 4px;
+              z-index: 1;
 
               &.pathfinding-line::before {
                 content: '';
@@ -206,8 +282,9 @@
                 left: 50%;
                 transform: translateX(-50%) translateY(-100%);
                 width: 4px;
-                height: 28px;
+                height: var(--counterLink);
                 background-color: var(--pathBackground);
+                pointer-events: none;
               }
 
               &.origin::before {
@@ -224,7 +301,6 @@
                 font-size: 0.75rem;
                 font-weight: 600;
                 text-align: center;
-                padding-top: 1px;
                 width: 24px;
                 height: 24px;
                 border-width: 2px;
@@ -241,6 +317,9 @@
               &.invalid {
                 background-color: var(--error60);
                 border-color: var(--error30);
+              }
+              &.is-only-step {
+                pointer-events: none;
               }
             }
 


### PR DESCRIPTION
closes #14244 

AC : 

- [ ] If you hover over the circle of a PR line, it displays a red cross.

- [ ] Clicking on this cross deletes the line.

- [ ] If you hover between two lines of 2 PRs (or before the first line or after the last line), a blue plus sign appears and the following lines shift downwards.

- [ ] BONUS: If you hover over a line, a small dot appears on the line connecting the PR numbers, between this line and the previous one, and another between this line and the next one, to indicate that you can click on this dot to add a line (except for the last empty line, where nothing appears after it).

- [ ] If you click on this plus sign, an empty line appears at the indicated location

- [ ] Update the waypoint numbers in the waypoint list and on the map

- [ ] Do not recalculate the pathfinding

