### PR TITLE
core: change Offset/Length<TrainPath> to PhysicsPath

### DIFF
--- a/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/EnvelopeSimContext.kt
+++ b/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/EnvelopeSimContext.kt
@@ -2,7 +2,6 @@ package fr.sncf.osrd.envelope_sim
 
 import com.google.common.collect.RangeMap
 import fr.sncf.osrd.path.interfaces.PhysicsPath
-import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.utils.DistanceRangeSet
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
@@ -29,18 +28,18 @@ constructor(
          * List of switch and buffer stop offsets on the path, up to the first switch/buffer stop
          * *after* the end of the path (or right at the end).
          */
-        val dangerPointOffsets: List<Offset<TrainPath>>,
+        val dangerPointOffsets: List<Offset<PhysicsPath>>,
         /**
          * List of block-delimiting detectors (block entry/exit) offsets for every ETCS-block on the
          * path. Starts at the start of the path, can end after the end of the path.
          */
-        val detectorOffsets: List<Offset<TrainPath>>,
+        val detectorOffsets: List<Offset<PhysicsPath>>,
     ) {
         /**
          * Returns the next danger point location: next buffer stop or switch, whichever is closest.
          * If there is any.
          */
-        private fun getDangerPoint(offset: Offset<TrainPath>): Offset<TrainPath>? {
+        private fun getDangerPoint(offset: Offset<PhysicsPath>): Offset<PhysicsPath>? {
             return dangerPointOffsets.firstOrNull { it >= offset }
         }
 
@@ -51,14 +50,14 @@ constructor(
          * infrastructure, hence we'll be conservative and place the danger point on the EoA (stop
          * location or signal).
          */
-        fun getMandatoryDangerPoint(signalOffset: Offset<TrainPath>): Offset<TrainPath> {
+        fun getMandatoryDangerPoint(signalOffset: Offset<PhysicsPath>): Offset<PhysicsPath> {
             val dangerPoint = getDangerPoint(signalOffset)
             return if (dangerPoint == null || dangerPoint - signalOffset > 200.meters) signalOffset
             else dangerPoint
         }
 
         /** Returns the next ETCS detector location. */
-        fun getNextDetector(offset: Offset<TrainPath>): Offset<TrainPath>? {
+        fun getNextDetector(offset: Offset<PhysicsPath>): Offset<PhysicsPath>? {
             return detectorOffsets.firstOrNull { it >= offset }
         }
     }

--- a/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/ETCSBrakingSimulator.kt
+++ b/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/ETCSBrakingSimulator.kt
@@ -7,7 +7,7 @@ import fr.sncf.osrd.envelope_sim.EnvelopeSimContext
 import fr.sncf.osrd.envelope_sim.etcs.BrakingType.IND
 import fr.sncf.osrd.envelope_sim.etcs.BrakingType.PS
 import fr.sncf.osrd.envelope_sim.pipelines.increase
-import fr.sncf.osrd.path.interfaces.TrainPath
+import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.utils.arePositionsEqual
 import fr.sncf.osrd.utils.units.Offset
@@ -71,7 +71,7 @@ interface ETCSBrakingSimulator {
      */
     fun computeEoaLocations(
         envelope: Envelope,
-        offsets: List<Offset<TrainPath>>,
+        offsets: List<Offset<PhysicsPath>>,
         areSignalsOnOffsetsRestrictive: List<Boolean>,
         eoaType: EoaType,
     ): List<EndOfAuthority>
@@ -85,7 +85,7 @@ typealias EOABrakingCurves = NavigableMap<EndOfAuthority, BrakingCurves>
 
 data class BrakingCurve(val brakingType: BrakingType, val brakingCurve: Envelope)
 
-data class LimitOfAuthority(val offset: Offset<TrainPath>, val speed: Double) :
+data class LimitOfAuthority(val offset: Offset<PhysicsPath>, val speed: Double) :
     Comparable<LimitOfAuthority> {
     init {
         assert(speed > 0)
@@ -98,8 +98,8 @@ data class LimitOfAuthority(val offset: Offset<TrainPath>, val speed: Double) :
 }
 
 data class EndOfAuthority(
-    val offsetEOA: Offset<TrainPath>,
-    val offsetSVL: Offset<TrainPath>?,
+    val offsetEOA: Offset<PhysicsPath>,
+    val offsetSVL: Offset<PhysicsPath>?,
     val usedCurveType: BrakingType,
     val eoaType: EoaType = EoaType.STOP,
 ) : Comparable<EndOfAuthority> {
@@ -211,7 +211,7 @@ class ETCSBrakingSimulatorImpl(override val context: EnvelopeSimContext) : ETCSB
         val cursor = EnvelopeCursor.backward(mrsp)
         val limitsOfAuthority = mutableListOf<LimitOfAuthority>()
         while (cursor.findPartTransition(::increase)) {
-            val offset = Offset<TrainPath>(cursor.position.meters)
+            val offset = Offset<PhysicsPath>(cursor.position.meters)
             if (etcsRanges.contains(offset.distance)) {
                 limitsOfAuthority.add(LimitOfAuthority(offset, cursor.speed))
             }
@@ -222,7 +222,7 @@ class ETCSBrakingSimulatorImpl(override val context: EnvelopeSimContext) : ETCSB
 
     override fun computeEoaLocations(
         envelope: Envelope,
-        offsets: List<Offset<TrainPath>>,
+        offsets: List<Offset<PhysicsPath>>,
         areSignalsOnOffsetsRestrictive: List<Boolean>,
         eoaType: EoaType,
     ): List<EndOfAuthority> {
@@ -267,7 +267,7 @@ class ETCSBrakingSimulatorImpl(override val context: EnvelopeSimContext) : ETCSB
 
     /** Compute the EoA for a simple stop. */
     private fun computeStopEoA(
-        stopOffset: Offset<TrainPath>,
+        stopOffset: Offset<PhysicsPath>,
         isStopOnClosedSignal: Boolean,
     ): EndOfAuthority {
         return if (isStopOnClosedSignal) {
@@ -291,7 +291,7 @@ class ETCSBrakingSimulatorImpl(override val context: EnvelopeSimContext) : ETCSB
 
     /** Compute the EoA for a spacing conflict on a signal. */
     private fun computeSpacingConflictEoa(
-        signalOffset: Offset<TrainPath>,
+        signalOffset: Offset<PhysicsPath>,
         isRouteDelimiter: Boolean,
         endPos: Double,
     ): EndOfAuthority? {
@@ -322,7 +322,7 @@ class ETCSBrakingSimulatorImpl(override val context: EnvelopeSimContext) : ETCSB
 
     /** Compute the EoA for a routing conflict on a signal. */
     private fun computeRoutingConflictEoa(
-        signalOffset: Offset<TrainPath>,
+        signalOffset: Offset<PhysicsPath>,
         isRouteDelimiter: Boolean,
     ): EndOfAuthority? {
         return if (isRouteDelimiter) {

--- a/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/pipelines/MaxSpeedEnvelope.kt
+++ b/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/pipelines/MaxSpeedEnvelope.kt
@@ -15,7 +15,7 @@ import fr.sncf.osrd.envelope_sim.etcs.ETCSBrakingSimulatorImpl
 import fr.sncf.osrd.envelope_sim.etcs.EndOfAuthority
 import fr.sncf.osrd.envelope_sim.etcs.EoaType
 import fr.sncf.osrd.envelope_sim.overlays.EnvelopeDeceleration
-import fr.sncf.osrd.path.interfaces.TrainPath
+import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop
 import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Offset
@@ -30,7 +30,7 @@ import fr.sncf.osrd.utils.units.Offset
  * closed/open signal flag.
  */
 data class SimStop(
-    val offset: Offset<TrainPath>,
+    val offset: Offset<PhysicsPath>,
     val rjsReceptionSignal: RJSTrainStop.RJSReceptionSignal,
 )
 
@@ -130,7 +130,7 @@ private fun addStopBrakingCurves(
 private fun addConstStopBrakingCurves(
     context: EnvelopeSimContext,
     curveWithDecelerations: Envelope,
-    stops: List<Offset<TrainPath>>,
+    stops: List<Offset<PhysicsPath>>,
 ): Envelope {
     var envelope = curveWithDecelerations
     for (stop in stops) {

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathBuilder.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathBuilder.kt
@@ -62,7 +62,7 @@ fun buildTrainPathFromBlocks(
     routeNames: List<String>? = null,
     electricalProfileMapping: ElectricalProfileMapping? = null,
 ): TrainPath {
-    var prevBlockFinalOffset: Offset<TrainPath> = Offset.zero()
+    var prevBlockFinalOffset: Offset<PhysicsPath> = Offset.zero()
     val blockRanges = mutableListOf<BlockRange>()
     for (block in blocks) {
         val blockLength = blockInfra.getBlockLength(block)
@@ -97,7 +97,7 @@ fun buildTrainPathFromBlockRanges(
     routeNames: List<String>? = null,
     electricalProfileMapping: ElectricalProfileMapping? = null,
     haveApproximateBlocks: Boolean = false,
-    backtrackLocations: List<Offset<TrainPath>> = listOf(),
+    backtrackLocations: List<Offset<PhysicsPath>> = listOf(),
 ): TrainPath {
     require(routes == null || routeNames == null)
     val chunks = generateTrackChunks(rawInfra, blockInfra, blockRanges)
@@ -187,7 +187,7 @@ fun <ValueType, OffsetType> buildRangeList(
         else merged[merged.lastIndex] = merged.last().copy(objectEnd = range.objectEnd)
     }
 
-    var prevRangeLength: Offset<TrainPath> = Offset.zero()
+    var prevRangeLength: Offset<PhysicsPath> = Offset.zero()
     val res = mutableListOf<GenericLinearRange<ValueType, OffsetType>>()
     for (range in merged) {
         res.add(

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathImpl.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathImpl.kt
@@ -31,7 +31,7 @@ data class TrainPathNoBacktrack(
     private val blocks: List<BlockRange>,
     private val chunks: List<DirChunkRange>,
     private val electricalProfileMapping: ElectricalProfileMapping?,
-    private val backtrackLocations: List<Offset<TrainPath>>,
+    private val backtrackLocations: List<Offset<PhysicsPath>>,
     // Set to true if the blocks have been generated from the track path. Throws an error if the
     // routes are read. Note: we may eventually want to turn the error into a warning, if we do want
     // approximate blocks along the path (when we lack context and don't have the actual ones).
@@ -78,9 +78,9 @@ data class TrainPathNoBacktrack(
         checkRangeList(chunks) { rawInfra.getTrackChunkLength(it.value).forceDirected() }
     }
 
-    override fun subPath(from: Offset<TrainPath>?, to: Offset<TrainPath>?): TrainPath {
-        val fromDist = from ?: Offset(0.meters)
-        val toDist = to ?: getLength()
+    override fun subPath(from: Offset<PhysicsPath>?, to: Offset<PhysicsPath>?): TrainPath {
+        val fromDist = from?.cast<PhysicsPath>() ?: Offset(0.meters)
+        val toDist = (to ?: getLength()).cast<PhysicsPath>()
         return TrainPathNoBacktrack(
             rawInfra = rawInfra,
             blockInfra = blockInfra,
@@ -89,7 +89,7 @@ data class TrainPathNoBacktrack(
             chunks = chunks.subRange(fromDist, toDist, resetOffsets = true),
             electricalProfileMapping = electricalProfileMapping,
             haveApproximateBlocks = haveApproximateBlocks,
-            backtrackLocations = backtrackLocations.filter { it in fromDist..toDist },
+            backtrackLocations = backtrackLocations.filter { it.cast() in fromDist..toDist },
         )
     }
 
@@ -259,11 +259,11 @@ data class TrainPathNoBacktrack(
         }
     }
 
-    override fun getLength(): Length<TrainPath> {
+    override fun getLength(): Length<PhysicsPath> {
         return blocks.last().pathEnd
     }
 
-    override fun getTrackLocationAtOffset(pathOffset: Offset<TrainPath>): TrackLocation {
+    override fun getTrackLocationAtOffset(pathOffset: Offset<PhysicsPath>): TrackLocation {
         val dirTrackRange = cachedDirTracks.first { it.containsPathOffset(pathOffset) }
         val dirTrackOffset = dirTrackRange.offsetFromTrainPath(pathOffset)
         val trackOffset = dirTrackRange.offsetToUndirected(dirTrackOffset)
@@ -343,7 +343,7 @@ data class TrainPathNoBacktrack(
         return copy(routes = routeRanges)
     }
 
-    override fun getBacktrackLocations(): List<Offset<TrainPath>> {
+    override fun getBacktrackLocations(): List<Offset<PhysicsPath>> {
         return backtrackLocations
     }
 

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/GenericLinearRange.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/GenericLinearRange.kt
@@ -32,7 +32,7 @@ data class GenericLinearRange<ValueType, OffsetType>(
     /** Start of the range, compared to the start of the underlying object. */
     val objectBegin: Offset<OffsetType>,
     /** Start of the range, compared to the start of the train path. */
-    val pathBegin: Offset<TrainPath>,
+    val pathBegin: Offset<PhysicsPath>,
     /** Range length. */
     val length: Distance,
     /** Total length of the underlying object. */
@@ -42,8 +42,8 @@ data class GenericLinearRange<ValueType, OffsetType>(
         value: ValueType,
         objectBegin: Offset<OffsetType>,
         objectEnd: Offset<OffsetType>,
-        pathBegin: Offset<TrainPath>,
-        pathEnd: Offset<TrainPath>,
+        pathBegin: Offset<PhysicsPath>,
+        pathEnd: Offset<PhysicsPath>,
         objectLength: Length<OffsetType>,
     ) : this(value, objectBegin, pathBegin, pathEnd - pathBegin, objectLength) {
         assert(objectEnd - objectBegin == pathEnd - pathBegin)
@@ -59,7 +59,7 @@ data class GenericLinearRange<ValueType, OffsetType>(
     }
 
     /** End of the range, compared to the start of the train path. */
-    val pathEnd: Offset<TrainPath>
+    val pathEnd: Offset<PhysicsPath>
         get() = pathBegin + length
 
     /** End of the range, compared to the start of the underlying object. */
@@ -77,13 +77,13 @@ data class GenericLinearRange<ValueType, OffsetType>(
         get() = objectAbsolutePathStart + objectLength.distance
 
     /** Converts a train path offset into an object offset. */
-    fun offsetFromTrainPath(pathOffset: Offset<TrainPath>): Offset<OffsetType> {
+    fun offsetFromTrainPath(pathOffset: Offset<PhysicsPath>): Offset<OffsetType> {
         val objectStart = objectAbsolutePathStart
         return Offset(pathOffset.distance - objectStart.distance)
     }
 
     /** Converts an object offset into a train path offset. */
-    fun offsetToTrainPath(objectOffset: Offset<OffsetType>): Offset<TrainPath> {
+    fun offsetToTrainPath(objectOffset: Offset<OffsetType>): Offset<PhysicsPath> {
         val objectStart = objectAbsolutePathStart
         return objectStart + objectOffset.distance
     }
@@ -93,8 +93,8 @@ data class GenericLinearRange<ValueType, OffsetType>(
      * train path range.
      */
     fun withTruncatedPathRange(
-        from: Offset<TrainPath>,
-        to: Offset<TrainPath>,
+        from: Offset<PhysicsPath>,
+        to: Offset<PhysicsPath>,
     ): GenericLinearRange<ValueType, OffsetType>? {
         val newPathBegin = max(from, pathBegin)
         val newPathEnd = min(to, pathEnd)
@@ -121,7 +121,7 @@ data class GenericLinearRange<ValueType, OffsetType>(
         subObjectList: List<SubObjectType>,
         getSubObjectLength: (SubObjectType) -> Offset<SubObjectOffset>,
     ): List<GenericLinearRange<SubObjectType, SubObjectOffset>> {
-        var prevObjectEndPathOffset: Offset<TrainPath> = pathBegin - objectBegin.distance
+        var prevObjectEndPathOffset: Offset<PhysicsPath> = pathBegin - objectBegin.distance
         val res = mutableListOf<GenericLinearRange<SubObjectType, SubObjectOffset>>()
         for (subObject in subObjectList) {
             val subObjectLength = getSubObjectLength(subObject)
@@ -175,7 +175,7 @@ data class GenericLinearRange<ValueType, OffsetType>(
         )
     }
 
-    data class LocatedObject<T>(val value: T, val offset: Offset<TrainPath>)
+    data class LocatedObject<T>(val value: T, val offset: Offset<PhysicsPath>)
 
     /**
      * Given two functions to map inner point objects to their IDs and offsets, returns the objects
@@ -208,7 +208,7 @@ data class GenericLinearRange<ValueType, OffsetType>(
         )
     }
 
-    fun containsPathOffset(offset: Offset<TrainPath>): Boolean {
+    fun containsPathOffset(offset: Offset<PhysicsPath>): Boolean {
         return offset in pathBegin..pathEnd
     }
 
@@ -314,8 +314,8 @@ fun <ValueType, OffsetType, ObjectType> List<GenericLinearRange<ValueType, Offse
 
 /** Truncate the list of linear objects, updating the underlying object ranges */
 fun <ValueType, OffsetType> List<GenericLinearRange<ValueType, OffsetType>>.subRange(
-    from: Offset<TrainPath>,
-    to: Offset<TrainPath>,
+    from: Offset<PhysicsPath>,
+    to: Offset<PhysicsPath>,
     resetOffsets: Boolean = false,
 ): List<GenericLinearRange<ValueType, OffsetType>> {
     return mapNotNull { range ->

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/PathProperties.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/PathProperties.kt
@@ -34,9 +34,9 @@ interface PathProperties {
 
     fun getZones(): DistanceRangeMap<ZoneId>
 
-    fun getLength(): Length<TrainPath>
+    fun getLength(): Length<PhysicsPath>
 
-    fun getTrackLocationAtOffset(pathOffset: Offset<TrainPath>): TrackLocation
+    fun getTrackLocationAtOffset(pathOffset: Offset<PhysicsPath>): TrackLocation
 
     fun <T> getRangeMapFromUndirected(
         getData: (chunkId: TrackChunkId) -> DistanceRangeMap<T>

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/PhysicsPath.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/PhysicsPath.kt
@@ -3,7 +3,12 @@ package fr.sncf.osrd.path.interfaces
 import com.google.common.collect.ImmutableRangeMap
 import com.google.common.collect.RangeMap
 
-/** Legacy interface for the envelope module */
+/**
+ * A [PhysicsPath] describes the physics of a path taken by a train.
+ *
+ * Contrary to [TrainPath], a [PhysicsPath] doesn't provide infrastructure-related information and
+ * only provides slopes and electrification.
+ */
 interface PhysicsPath {
     /** The length of the path, in meters */
     val length: Double

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/TrainPath.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/TrainPath.kt
@@ -8,7 +8,7 @@ import fr.sncf.osrd.utils.units.Offset
  * can easily be mapped to train simulations, where we track the distance travelled by the train
  * head.
  *
- * `Offset<TrainPath>` is the correct typing to locate elements on a path.
+ * `Offset<PhysicsPath>` is the correct typing to locate elements on a path.
  *
  * We consider that 1m of train path means 1m of train movement, not necessarily 1m of actual track
  * length. Specifically, when a train turns around at a station, no distance is travelled. See
@@ -33,12 +33,12 @@ import fr.sncf.osrd.utils.units.Offset
  * may include partial blocks, especially at the edges of the path or around backtracks.
  */
 interface TrainPath : PhysicsPath, PathProperties {
-    fun subPath(from: Offset<TrainPath>?, to: Offset<TrainPath>?): TrainPath
+    fun subPath(from: Offset<PhysicsPath>?, to: Offset<PhysicsPath>?): TrainPath
 
     /** Returns a copy with the specified routes instead */
     override fun withRoutes(routes: List<RouteId>): TrainPath
 
-    fun getBacktrackLocations(): List<Offset<TrainPath>>
+    fun getBacktrackLocations(): List<Offset<PhysicsPath>>
 
     fun getBlocks(): List<BlockRange>
 

--- a/core/src/main/kotlin/fr/sncf/osrd/api/CommonSchemas.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/CommonSchemas.kt
@@ -1,7 +1,7 @@
 package fr.sncf.osrd.api
 
 import com.squareup.moshi.Json
-import fr.sncf.osrd.path.interfaces.TrainPath
+import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.railjson.schema.common.graph.EdgeDirection
 import fr.sncf.osrd.sim_infra.api.TrackSection
 import fr.sncf.osrd.utils.DistanceRangeMap
@@ -25,13 +25,13 @@ data class TrackRange(
 data class RangeValues<valueT>(
     // List of `n` internal boundaries of the ranges along the path (excluding start and end
     // bounds).
-    @Json(name = "boundaries") val internalBoundaries: List<Offset<TrainPath>> = listOf(),
+    @Json(name = "boundaries") val internalBoundaries: List<Offset<PhysicsPath>> = listOf(),
     // List of `n+1` values associated to the bounded intervals
     val values: List<valueT> = listOf(),
 ) {
     fun toDistanceRangeMap(
-        beginPos: Offset<TrainPath>,
-        endPos: Offset<TrainPath>,
+        beginPos: Offset<PhysicsPath>,
+        endPos: Offset<PhysicsPath>,
     ): DistanceRangeMap<valueT> {
         val boundaries = internalBoundaries.toMutableList()
         boundaries.add(0, beginPos)
@@ -58,14 +58,14 @@ class TrackLocation(val track: String, val offset: Offset<TrackSection>)
 class ZoneUpdate(
     val zone: String,
     val time: TimeDelta,
-    val position: Offset<TrainPath>,
+    val position: Offset<PhysicsPath>,
     @Json(name = "is_entry") val isEntry: Boolean,
 )
 
 class SignalCriticalPosition(
     val signal: String,
     val time: TimeDelta,
-    val position: Offset<TrainPath>,
+    val position: Offset<PhysicsPath>,
     val state: String,
 )
 

--- a/core/src/main/kotlin/fr/sncf/osrd/api/etcs/ETCSBrakingCurvesEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/etcs/ETCSBrakingCurvesEndpoint.kt
@@ -14,6 +14,7 @@ import fr.sncf.osrd.envelope.part.EnvelopePart
 import fr.sncf.osrd.envelope_sim.EnvelopeProfile
 import fr.sncf.osrd.envelope_sim.EnvelopeSimContext
 import fr.sncf.osrd.envelope_sim.etcs.*
+import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.signaling.etcs_level2.ETCS_LEVEL2
 import fr.sncf.osrd.sim_infra.api.*
@@ -138,7 +139,7 @@ class ETCSBrakingCurvesEndpoint(
     }
 
     private data class TravelledPathSignal(
-        val offset: Offset<TrainPath>,
+        val offset: Offset<PhysicsPath>,
         val isRouteDelimiter: Boolean,
     ) : Comparable<TravelledPathSignal> {
         override fun compareTo(other: TravelledPathSignal): Int {
@@ -175,8 +176,8 @@ class ETCSBrakingCurvesEndpoint(
 
     private fun parseRawMrsp(
         rawMrsp: RangeValues<SpeedLimitProperty>,
-        endPos: Offset<TrainPath>,
-        beginPos: Offset<TrainPath> = Offset(Distance.ZERO),
+        endPos: Offset<PhysicsPath>,
+        beginPos: Offset<PhysicsPath> = Offset(Distance.ZERO),
     ): Envelope {
         val speedLimitDistanceRangeMap = rawMrsp.toDistanceRangeMap(beginPos, endPos)
         val mrspParts = mutableListOf<EnvelopePart>()

--- a/core/src/main/kotlin/fr/sncf/osrd/api/etcs/ETCSBrakingCurvesResponse.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/etcs/ETCSBrakingCurvesResponse.kt
@@ -5,7 +5,7 @@ import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import fr.sncf.osrd.conflicts.ConflictType
-import fr.sncf.osrd.path.interfaces.TrainPath
+import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.utils.json.UnitAdapterFactory
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.TimeDelta
@@ -30,7 +30,7 @@ data class ETCSConflictCurves(
 )
 
 data class SimpleEnvelope(
-    val positions: List<Offset<TrainPath>>,
+    val positions: List<Offset<PhysicsPath>>,
     val times: List<TimeDelta>, // Times are compared to the departure time
     val speeds: List<Double>,
 )

--- a/core/src/main/kotlin/fr/sncf/osrd/api/path_properties/PathPropResponse.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/path_properties/PathPropResponse.kt
@@ -6,7 +6,7 @@ import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import fr.sncf.osrd.api.RangeValues
-import fr.sncf.osrd.path.interfaces.TrainPath
+import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.railjson.schema.geom.RJSLineString
 import fr.sncf.osrd.utils.json.UnitAdapterFactory
 import fr.sncf.osrd.utils.units.Offset
@@ -32,7 +32,7 @@ data class OperationalPointResponse(
     val id: String,
     val part: OperationalPointPartResponse,
     val extensions: OperationalPointExtensions?,
-    val position: Offset<TrainPath>,
+    val position: Offset<PhysicsPath>,
     val weight: Long?,
 )
 

--- a/core/src/main/kotlin/fr/sncf/osrd/api/path_properties/PathPropResponseConverter.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/path_properties/PathPropResponseConverter.kt
@@ -2,6 +2,7 @@ package fr.sncf.osrd.api.path_properties
 
 import com.google.common.collect.Range
 import fr.sncf.osrd.api.RangeValues
+import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.railjson.schema.geom.RJSLineString
 import fr.sncf.osrd.sim_infra.api.NeutralSection
@@ -123,7 +124,7 @@ private fun <T> makeRangeValues(distanceRangeMap: DistanceRangeMap<T>): RangeVal
 }
 
 private fun <T> makeRangeValues(entries: List<DistanceRangeMap.RangeMapEntry<T>>): RangeValues<T> {
-    val boundaries = mutableListOf<Offset<TrainPath>>()
+    val boundaries = mutableListOf<Offset<PhysicsPath>>()
     val values = mutableListOf<T>()
     for (entry in entries) {
         boundaries.add(Offset(entry.upper))

--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlockResponse.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlockResponse.kt
@@ -8,6 +8,7 @@ import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import fr.sncf.osrd.api.DirectionalTrackRange
 import fr.sncf.osrd.path.interfaces.JsonTrainPath
+import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.utils.json.UnitAdapterFactory
@@ -20,10 +21,10 @@ interface PathfindingBlockResponse
 
 class PathfindingBlockSuccess(
     val path: JsonTrainPath,
-    val length: Length<TrainPath>,
+    val length: Length<PhysicsPath>,
 
     /** Offsets of the waypoints given as input */
-    @Json(name = "path_item_positions") val pathItemPositions: List<Offset<TrainPath>>,
+    @Json(name = "path_item_positions") val pathItemPositions: List<Offset<PhysicsPath>>,
 ) : PathfindingBlockResponse {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -43,12 +44,12 @@ class PathfindingBlockSuccess(
 
 class NotFoundInBlocks(
     @Json(name = "track_section_ranges") val trackSectionRanges: List<DirectionalTrackRange>,
-    val length: Length<TrainPath>,
+    val length: Length<PhysicsPath>,
 ) : PathfindingBlockResponse
 
 class NotFoundInRoutes(
     @Json(name = "track_section_ranges") val trackSectionRanges: List<DirectionalTrackRange>,
-    val length: Length<TrainPath>,
+    val length: Length<PhysicsPath>,
 ) : PathfindingBlockResponse
 
 class NotFoundInTracks : PathfindingBlockResponse

--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.kt
@@ -12,6 +12,7 @@ import fr.sncf.osrd.cli.RsWithBody
 import fr.sncf.osrd.cli.RsWithStatus
 import fr.sncf.osrd.cli.Take
 import fr.sncf.osrd.graph.*
+import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.pathfinding.BlockLocation
 import fr.sncf.osrd.pathfinding.Pathfinding
@@ -281,7 +282,7 @@ private fun throwNoPathFoundException(
     throw NoPathFoundException(NotFoundInBlocks(listOf(), Length(0.meters)))
 }
 
-data class ProcessedPathfindingResponse(val path: TrainPath, val offsets: List<Offset<TrainPath>>)
+data class ProcessedPathfindingResponse(val path: TrainPath, val offsets: List<Offset<PhysicsPath>>)
 
 private fun processPathfindingResponse(
     infra: FullInfra,

--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingPostProcessing.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingPostProcessing.kt
@@ -1,6 +1,7 @@
 package fr.sncf.osrd.api.pathfinding
 
 import fr.sncf.osrd.api.FullInfra
+import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.path.interfaces.toJsonTrainPath
 import fr.sncf.osrd.reporting.exceptions.ErrorType
@@ -20,7 +21,7 @@ fun runPathfindingPostProcessing(
 fun runPathfindingBlockPostProcessing(
     infra: FullInfra,
     trainPath: TrainPath,
-    waypointOffsets: List<Offset<TrainPath>>,
+    waypointOffsets: List<Offset<PhysicsPath>>,
 ): PathfindingBlockSuccess {
     return PathfindingBlockSuccess(
         trainPath.toJsonTrainPath(infra.rawInfra, infra.blockInfra),

--- a/core/src/main/kotlin/fr/sncf/osrd/api/project_signals/SignalProjectionResponse.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/project_signals/SignalProjectionResponse.kt
@@ -4,7 +4,7 @@ import com.squareup.moshi.Json
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
-import fr.sncf.osrd.path.interfaces.TrainPath
+import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.utils.json.UnitAdapterFactory
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.TimeDelta
@@ -18,8 +18,8 @@ class SignalUpdate(
     @Json(name = "signaling_system") val signalingSystem: String,
     @Json(name = "time_start") val timeStart: TimeDelta,
     @Json(name = "time_end") val timeEnd: TimeDelta,
-    @Json(name = "position_start") val positionStart: Offset<TrainPath>,
-    @Json(name = "position_end") val positionEnd: Offset<TrainPath>,
+    @Json(name = "position_start") val positionStart: Offset<PhysicsPath>,
+    @Json(name = "position_end") val positionEnd: Offset<PhysicsPath>,
     val color: Int,
     val blinking: Boolean,
     @Json(name = "aspect_label") val aspectLabel: String,

--- a/core/src/main/kotlin/fr/sncf/osrd/api/standalone_sim/SimulationRequest.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/standalone_sim/SimulationRequest.kt
@@ -4,7 +4,7 @@ import com.squareup.moshi.*
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import fr.sncf.osrd.api.RangeValues
 import fr.sncf.osrd.path.interfaces.JsonTrainPath
-import fr.sncf.osrd.path.interfaces.TrainPath
+import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
 import fr.sncf.osrd.railjson.schema.rollingstock.RJSEffortCurves.RJSModeEffortCurve
 import fr.sncf.osrd.railjson.schema.rollingstock.RJSEtcsBrakeParams
@@ -32,7 +32,7 @@ class SimulationRequest(
     val options: TrainScheduleOptions,
     @Json(name = "physics_consist") val physicsConsist: PhysicsConsistModel,
     @Json(name = "electrical_profile_set_id") val electricalProfileSetId: String?,
-    @Json(name = "path_item_positions") val pathItemPositions: List<Offset<TrainPath>>,
+    @Json(name = "path_item_positions") val pathItemPositions: List<Offset<PhysicsPath>>,
 ) {
     companion object {
         val adapter: JsonAdapter<SimulationRequest> =
@@ -82,7 +82,7 @@ class EffortCurve(
 )
 
 class SimulationScheduleItem(
-    @Json(name = "path_offset") val pathOffset: Offset<TrainPath>,
+    @Json(name = "path_offset") val pathOffset: Offset<PhysicsPath>,
     val arrival: TimeDelta?,
     @Json(name = "stop_for") val stopFor: Duration?,
     @Json(name = "reception_signal") val receptionSignal: RJSReceptionSignal,
@@ -130,8 +130,8 @@ class MarginValueAdapter {
 }
 
 class SimulationPowerRestrictionItem(
-    val from: Offset<TrainPath>,
-    val to: Offset<TrainPath>,
+    val from: Offset<PhysicsPath>,
+    val to: Offset<PhysicsPath>,
     val value: String,
 )
 

--- a/core/src/main/kotlin/fr/sncf/osrd/api/standalone_sim/SimulationResponse.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/standalone_sim/SimulationResponse.kt
@@ -6,7 +6,7 @@ import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import fr.sncf.osrd.api.*
-import fr.sncf.osrd.path.interfaces.TrainPath
+import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.sim_infra.api.SpeedLimitProperty
 import fr.sncf.osrd.sim_infra.api.SpeedLimitSource
@@ -46,7 +46,7 @@ sealed class ElectricalProfileValue {
 }
 
 class CompleteReportTrain(
-    positions: List<Offset<TrainPath>>,
+    positions: List<Offset<PhysicsPath>>,
     times: List<TimeDelta>, // Times are compared to the departure time
     speeds: List<Double>,
     @Json(name = "energy_consumption") energyConsumption: Double,
@@ -66,7 +66,7 @@ class CompleteReportTrain(
  * [positions] is sorted.
  */
 open class ReportTrain(
-    val positions: List<Offset<TrainPath>>,
+    val positions: List<Offset<PhysicsPath>>,
     /** Times are compared to departure time */
     val times: List<TimeDelta>,
     val speeds: List<Double>,

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/OutputSimDebugData.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/OutputSimDebugData.kt
@@ -13,6 +13,7 @@ import fr.sncf.osrd.api.standalone_sim.SimulationSuccess
 import fr.sncf.osrd.api.standalone_sim.polymorphicElectricalProfileAdapter
 import fr.sncf.osrd.api.standalone_sim.polymorphicSimulationResponseAdapter
 import fr.sncf.osrd.api.standalone_sim.polymorphicSpeedLimitSourceAdapter
+import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.sim_infra.api.BlockInfra
 import fr.sncf.osrd.sim_infra.api.RawInfra
@@ -49,7 +50,7 @@ data class OutputSimDebugData(
     val engineeringAllowanceRanges: List<EngineeringAllowanceRange>,
     @Json(name = "zone_locations") val zoneLocations: List<ZoneLocation>,
     @Json(name = "train_times") val trainTimes: List<TimeDelta>,
-    @Json(name = "train_positions") val trainPositions: List<Offset<TrainPath>>,
+    @Json(name = "train_positions") val trainPositions: List<Offset<PhysicsPath>>,
 ) {
     companion object {
         val adapter: JsonAdapter<OutputSimDebugData> =
@@ -72,7 +73,11 @@ data class TrainZoneRequirement(
     @Json(name = "train_name") val trainName: String?,
 )
 
-data class ZoneLocation(val name: String, val from: Offset<TrainPath>, val to: Offset<TrainPath>)
+data class ZoneLocation(
+    val name: String,
+    val from: Offset<PhysicsPath>,
+    val to: Offset<PhysicsPath>,
+)
 
 fun generateDebugData(
     rawInfra: RawInfra,

--- a/core/src/main/kotlin/fr/sncf/osrd/conflicts/IncrementalRequirementEnvelopeAdapter.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/conflicts/IncrementalRequirementEnvelopeAdapter.kt
@@ -3,7 +3,7 @@ package fr.sncf.osrd.conflicts
 import fr.sncf.osrd.envelope.Envelope
 import fr.sncf.osrd.envelope.EnvelopeInterpolate
 import fr.sncf.osrd.envelope_sim.PhysicsRollingStock
-import fr.sncf.osrd.path.interfaces.TrainPath
+import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import kotlin.math.max
@@ -22,8 +22,8 @@ class IncrementalRequirementEnvelopeAdapter(
     private val infiniteLastStop: Boolean = false,
 ) : IncrementalRequirementCallbacks {
     override fun maxSpeedInRange(
-        pathBeginOff: Offset<TrainPath>,
-        pathEndOff: Offset<TrainPath>,
+        pathBeginOff: Offset<PhysicsPath>,
+        pathEndOff: Offset<PhysicsPath>,
     ): Double {
         if (envelopeWithStops == null) {
             return Double.POSITIVE_INFINITY
@@ -39,7 +39,7 @@ class IncrementalRequirementEnvelopeAdapter(
         )
     }
 
-    override fun departureFromStop(stopOffset: Offset<TrainPath>): Double {
+    override fun departureFromStop(stopOffset: Offset<PhysicsPath>): Double {
         if (envelopeWithStops == null) {
             return Double.POSITIVE_INFINITY
         }
@@ -66,8 +66,8 @@ class IncrementalRequirementEnvelopeAdapter(
     }
 
     override fun arrivalTimeInRange(
-        pathBeginOff: Offset<TrainPath>,
-        pathEndOff: Offset<TrainPath>,
+        pathBeginOff: Offset<PhysicsPath>,
+        pathEndOff: Offset<PhysicsPath>,
     ): Double {
         if (envelopeWithStops == null) return Double.POSITIVE_INFINITY
         // if the head of the train enters the zone at some point, use that
@@ -86,8 +86,8 @@ class IncrementalRequirementEnvelopeAdapter(
     }
 
     override fun departureTimeFromRange(
-        pathBeginOff: Offset<TrainPath>,
-        pathEndOff: Offset<TrainPath>,
+        pathBeginOff: Offset<PhysicsPath>,
+        pathEndOff: Offset<PhysicsPath>,
     ): Double {
         if (envelopeWithStops == null) return Double.POSITIVE_INFINITY
         val end = pathEndOff.meters
@@ -103,7 +103,7 @@ class IncrementalRequirementEnvelopeAdapter(
         get() = envelopeWithStops?.totalTime ?: 0.0
 
     override val currentPathOffset
-        get() = Offset<TrainPath>(envelopeWithStops?.endPos?.meters ?: 0.meters)
+        get() = Offset<PhysicsPath>(envelopeWithStops?.endPos?.meters ?: 0.meters)
 
     override fun clone(): IncrementalRequirementCallbacks {
         return IncrementalRequirementEnvelopeAdapter(

--- a/core/src/main/kotlin/fr/sncf/osrd/conflicts/Resources.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/conflicts/Resources.kt
@@ -1,33 +1,36 @@
 package fr.sncf.osrd.conflicts
 
 import fr.sncf.osrd.envelope.Envelope
-import fr.sncf.osrd.path.interfaces.TrainPath
+import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.utils.units.Offset
 
 interface IncrementalRequirementCallbacks {
     // if the train never arrives in range, +inf is returned
     // a range is used rather than a point to properly handle the train appearing and disappearing
-    fun arrivalTimeInRange(pathBeginOff: Offset<TrainPath>, pathEndOff: Offset<TrainPath>): Double
+    fun arrivalTimeInRange(
+        pathBeginOff: Offset<PhysicsPath>,
+        pathEndOff: Offset<PhysicsPath>,
+    ): Double
 
     // the departure time from a given location, which has to take into account train length.
     // this is used to compute zone occupancy. if the train never leaves a location, +inf is
     // returned
     fun departureTimeFromRange(
-        pathBeginOff: Offset<TrainPath>,
-        pathEndOff: Offset<TrainPath>,
+        pathBeginOff: Offset<PhysicsPath>,
+        pathEndOff: Offset<PhysicsPath>,
     ): Double
 
     val currentTime: Double
-    val currentPathOffset: Offset<TrainPath>
+    val currentPathOffset: Offset<PhysicsPath>
 
     val simulationComplete: Boolean
 
     fun clone(): IncrementalRequirementCallbacks
 
-    fun maxSpeedInRange(pathBeginOff: Offset<TrainPath>, pathEndOff: Offset<TrainPath>): Double
+    fun maxSpeedInRange(pathBeginOff: Offset<PhysicsPath>, pathEndOff: Offset<PhysicsPath>): Double
 
     // departure time from a given stop. if the train never gets to a stop, +inf is returned
-    fun departureFromStop(stopOffset: Offset<TrainPath>): Double
+    fun departureFromStop(stopOffset: Offset<PhysicsPath>): Double
 
     fun getRawEnvelopeIfSingle(): Envelope?
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/conflicts/SpacingResourceGenerator.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/conflicts/SpacingResourceGenerator.kt
@@ -6,8 +6,8 @@ import fr.sncf.osrd.envelope_sim.etcs.BrakingType.IND
 import fr.sncf.osrd.envelope_sim.etcs.ETCSBrakingSimulatorImpl
 import fr.sncf.osrd.envelope_sim.etcs.EoaType
 import fr.sncf.osrd.path.interfaces.BlockRange
+import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.path.interfaces.RouteRange
-import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.path.interfaces.ZoneRange
 import fr.sncf.osrd.path.interfaces.addLinearObjects
 import fr.sncf.osrd.path.interfaces.mapPointObjects
@@ -44,7 +44,7 @@ import mu.KotlinLogging
 val logger = KotlinLogging.logger {}
 
 data class PathStop(
-    val pathOffset: Offset<TrainPath>,
+    val pathOffset: Offset<PhysicsPath>,
     val receptionSignal: RJSTrainStop.RJSReceptionSignal,
 )
 
@@ -112,7 +112,7 @@ data class SpacingResourceGenerator(
     private var reachedFirstSignal: Boolean = false
 
     /**
-     * Add a new segment of the path. The ranges must cover the same range of `Offset<TrainPath>`,
+     * Add a new segment of the path. The ranges must cover the same range of `Offset<PhysicsPath>`,
      * and any stop in that range needs to be listed.
      */
     fun extendPath(
@@ -199,7 +199,7 @@ data class SpacingResourceGenerator(
     fun processUpdate(): List<SpacingRequirement>? {
         val simulatedLength = callbacks!!.currentPathOffset
         val signalsToProcess = pendingSignals.takeWhile { it.sightOffset <= simulatedLength }
-        val signalEndOffsets = mutableMapOf<LogicalSignalId, Offset<TrainPath>>()
+        val signalEndOffsets = mutableMapOf<LogicalSignalId, Offset<PhysicsPath>>()
 
         val simulationData =
             SimulationCacheData(blockRanges.map { it.value }, routeRanges.map { it.value }, context)
@@ -247,7 +247,7 @@ data class SpacingResourceGenerator(
     }
 
     /** Returns the current end of the processed path. */
-    fun getCurrentPathEndOffset(): Offset<TrainPath> {
+    fun getCurrentPathEndOffset(): Offset<PhysicsPath> {
         return blockRanges.lastOrNull()?.pathEnd ?: Offset.zero()
     }
 
@@ -260,7 +260,7 @@ data class SpacingResourceGenerator(
     private fun signalToOngoingRequirements(
         simulationData: SimulationCacheData,
         signalData: PendingSignalData,
-        endOffset: Offset<TrainPath>,
+        endOffset: Offset<PhysicsPath>,
     ) {
         val zoneRanges =
             zoneRanges.subRange(signalData.offset, endOffset).filter { !it.isSinglePoint() }
@@ -282,7 +282,7 @@ data class SpacingResourceGenerator(
     private fun getETCSFirstRequiredOffset(
         simulationData: SimulationCacheData,
         signalData: PendingSignalData,
-    ): Offset<TrainPath> {
+    ): Offset<PhysicsPath> {
         val signal = signalData.signal
         var isRouteDelimiter = true
         try {
@@ -354,7 +354,7 @@ data class SpacingResourceGenerator(
     private fun getRequirementEndOffset(
         simulationData: SimulationCacheData,
         signalData: PendingSignalData,
-    ): Offset<TrainPath>? {
+    ): Offset<PhysicsPath>? {
         if (signalData.isCurveBased)
             return blockRanges.first { it.pathBegin >= signalData.offset }.pathEnd
         val trainState = buildTrainState(signalData) ?: return null
@@ -484,9 +484,9 @@ data class SpacingResourceGenerator(
         /** ID of the logical signal */
         val signal: LogicalSignalId,
         /** Offset of the signal itself */
-        val offset: Offset<TrainPath>,
+        val offset: Offset<PhysicsPath>,
         /** Offset at which the signal is seen by the train */
-        val sightOffset: Offset<TrainPath>,
+        val sightOffset: Offset<PhysicsPath>,
         /** Whether this signal is curve-based (ETCS or similar) */
         val isCurveBased: Boolean,
     )
@@ -505,17 +505,17 @@ data class SpacingResourceGenerator(
          * TODO: this is incorrect as stops should be considered at the signal level. It's legacy
          *   behavior identical to the previous class, for an easier transition.
          */
-        val zoneEntryOffset: Offset<TrainPath>,
+        val zoneEntryOffset: Offset<PhysicsPath>,
         /** Offset where the train clears the zone. Does not consider the train length. */
-        val zoneExitOffset: Offset<TrainPath>,
+        val zoneExitOffset: Offset<PhysicsPath>,
         /** The train first needs this zone to be free when the head reaches this offset. */
-        var minRequiredOffset: Offset<TrainPath> = zoneEntryOffset,
+        var minRequiredOffset: Offset<PhysicsPath> = zoneEntryOffset,
     ) {
         /**
          * To be called when a signal requires this zone to be free. Updates the minimum sight
          * offset / requirement offset.
          */
-        fun updateMinRequirementOffset(offset: Offset<TrainPath>) {
+        fun updateMinRequirementOffset(offset: Offset<PhysicsPath>) {
             minRequiredOffset = min(minRequiredOffset, offset)
         }
 

--- a/core/src/main/kotlin/fr/sncf/osrd/signal_projection/SignalProjection.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/signal_projection/SignalProjection.kt
@@ -4,6 +4,7 @@ import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.api.SignalCriticalPosition
 import fr.sncf.osrd.api.ZoneUpdate
 import fr.sncf.osrd.api.project_signals.SignalUpdate
+import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.signaling.SigSystemManager
@@ -170,7 +171,7 @@ private fun signalUpdates(
     sigSystemManager: SigSystemManager,
     rawInfra: RawInfra,
     signalCriticalPositions: Collection<SignalCriticalPosition>,
-    travelledPathLength: Length<TrainPath>,
+    travelledPathLength: Length<PhysicsPath>,
     simulationEndTime: TimeDelta,
 ): MutableList<SignalUpdate> {
     val signalUpdates = mutableListOf<SignalUpdate>()

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/SafetySpeed.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/SafetySpeed.kt
@@ -2,6 +2,7 @@ package fr.sncf.osrd.standalone_sim
 
 import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.api.standalone_sim.SimulationScheduleItem
+import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop
 import fr.sncf.osrd.signaling.etcs_level2.ETCS_LEVEL2
@@ -17,7 +18,7 @@ import fr.sncf.osrd.utils.units.meters
  * Simple internal class representing a stop with safety speed. Makes the function logic more
  * straightforward.
  */
-private data class SafetySpeedStop(val offset: Offset<TrainPath>, val isShortSlip: Boolean)
+private data class SafetySpeedStop(val offset: Offset<PhysicsPath>, val isShortSlip: Boolean)
 
 /**
  * Compute safety speed ranges, areas where the train has a lower speed limit because of a scheduled
@@ -86,7 +87,7 @@ fun makeSafetySpeedRanges(
 
 /** Check if a given stop is in a range of a given signaling system. */
 private fun isStopInSignalingSystemRange(
-    stopOffset: Offset<TrainPath>,
+    stopOffset: Offset<PhysicsPath>,
     signalingRanges: DistanceRangeMap<String>,
     signalingSystem: String,
 ): Boolean {
@@ -100,7 +101,7 @@ private fun isStopInSignalingSystemRange(
 private fun makeEndOfPathStop(
     infra: RawSignalingInfra,
     trainPath: TrainPath,
-    signalOffsets: List<Offset<TrainPath>>,
+    signalOffsets: List<Offset<PhysicsPath>>,
 ): SafetySpeedStop? {
     val lastRouteExit = infra.getRouteExit(trainPath.getRoutes().last().value)
     val isBufferStop = infra.isBufferStop(lastRouteExit.value)
@@ -109,8 +110,8 @@ private fun makeEndOfPathStop(
 }
 
 /** Return the offsets of block-delimiting signals on the path. */
-private fun getSignalOffsets(infra: FullInfra, trainPath: TrainPath): List<Offset<TrainPath>> {
-    val res = mutableListOf<Offset<TrainPath>>()
+private fun getSignalOffsets(infra: FullInfra, trainPath: TrainPath): List<Offset<PhysicsPath>> {
+    val res = mutableListOf<Offset<PhysicsPath>>()
     val rawInfra = infra.rawInfra
     val signalingInfra = infra.loadedSignalInfra
     var prevZonePathsLength = 0.meters

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
@@ -17,6 +17,7 @@ import fr.sncf.osrd.envelope_sim.etcs.ETCSBrakingSimulator
 import fr.sncf.osrd.envelope_sim.etcs.ETCSBrakingSimulatorImpl
 import fr.sncf.osrd.envelope_sim.etcs.EoaType
 import fr.sncf.osrd.path.interfaces.BlockRange
+import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.path.interfaces.RouteRange
 import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.signaling.SigSystemManager
@@ -41,7 +42,7 @@ fun runScheduleMetadataExtractor(
     fullInfra: FullInfra,
     rollingStock: RollingStock,
     schedule: List<SimulationScheduleItem>,
-    pathItemPositions: List<Offset<TrainPath>>,
+    pathItemPositions: List<Offset<PhysicsPath>>,
     context: EnvelopeSimContext? = null,
 ): CompleteReportTrain {
     assert(envelope.continuous)
@@ -173,7 +174,7 @@ fun runScheduleMetadataExtractor(
     )
 }
 
-fun getStopTravelledPathOffset(pathStops: List<PathStop>, indexStop: Int): Offset<TrainPath>? {
+fun getStopTravelledPathOffset(pathStops: List<PathStop>, indexStop: Int): Offset<PhysicsPath>? {
     return pathStops.getOrNull(indexStop)?.pathOffset
 }
 
@@ -182,7 +183,7 @@ fun makeSimpleReportTrain(
     trainPath: TrainPath,
     rollingStock: RollingStock,
     schedule: List<SimulationScheduleItem>,
-    pathItemPositions: List<Offset<TrainPath>>,
+    pathItemPositions: List<Offset<PhysicsPath>>,
 ): ReportTrain {
     // Compute energy consumed
     val mechanicalEnergyConsumed =
@@ -196,7 +197,7 @@ fun makeSimpleReportTrain(
     val envelopeStopWrapper = EnvelopeStopWrapper(envelope, stops)
 
     val pathItemTimes =
-        pathItemPositions.map { position: Offset<TrainPath> ->
+        pathItemPositions.map { position: Offset<PhysicsPath> ->
             TimeDelta.fromSeconds(envelopeStopWrapper.interpolateArrivalAt(position.meters))
         }
 
@@ -365,7 +366,7 @@ private fun getRouteCriticalPos(
     signalingTrainStates: Map<LogicalSignalId, SignalingTrainState>,
     envelope: Envelope,
     etcsSimulator: ETCSBrakingSimulator?,
-): Offset<TrainPath>? {
+): Offset<PhysicsPath>? {
     val blockInfra = fullInfra.blockInfra
     val simulator = fullInfra.signalingSimulator
 
@@ -392,7 +393,7 @@ private fun getEtcsRouteCriticalPos(
     firstBlockRange: BlockRange,
     envelope: Envelope,
     etcsSimulator: ETCSBrakingSimulator,
-): Offset<TrainPath> {
+): Offset<PhysicsPath> {
 
     // The braking curve targets the entry signal of the route's first block
     val signalOffset =
@@ -427,7 +428,7 @@ private fun getSightRouteCriticalPos(
     trainPath: TrainPath,
     firstBlockRange: BlockRange,
     signalingTrainStates: Map<LogicalSignalId, SignalingTrainState>,
-): Offset<TrainPath>? {
+): Offset<PhysicsPath>? {
     val simulator = fullInfra.signalingSimulator
     val rawInfra = fullInfra.rawInfra
     val loadedSignalInfra = fullInfra.loadedSignalInfra
@@ -538,7 +539,7 @@ private fun findLimitingSignal(
 
 data class ZoneOccupationChangeEvent(
     val time: TimeDelta,
-    val offset: Offset<TrainPath>,
+    val offset: Offset<PhysicsPath>,
     val isEntry: Boolean,
     val zone: ZoneId,
 )
@@ -572,7 +573,7 @@ fun zoneOccupationChangeEvents(
 
 data class PathSignal(
     val signal: LogicalSignalId,
-    val pathOffset: Offset<TrainPath>,
+    val pathOffset: Offset<PhysicsPath>,
     // when a signal is between blocks, prefer the index of the first block
     val minBlockPathIndex: Int,
 )
@@ -610,8 +611,8 @@ fun pathSignalsInEnvelope(
 fun pathSignalsInRange(
     trainPath: TrainPath,
     blockInfra: BlockInfra,
-    rangeStart: Offset<TrainPath>,
-    rangeEnd: Offset<TrainPath>,
+    rangeStart: Offset<PhysicsPath>,
+    rangeEnd: Offset<PhysicsPath>,
 ): List<PathSignal> {
     return pathSignals(trainPath, blockInfra).filter { signal ->
         signal.pathOffset in rangeStart..rangeEnd

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulation.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulation.kt
@@ -23,6 +23,7 @@ import fr.sncf.osrd.envelope_sim.pipelines.maxEffortEnvelopeFrom
 import fr.sncf.osrd.envelope_sim.pipelines.maxSpeedEnvelopeFrom
 import fr.sncf.osrd.envelope_sim_infra.HasMissingSpeedTag
 import fr.sncf.osrd.envelope_sim_infra.computeMRSP
+import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
 import fr.sncf.osrd.railjson.schema.schedule.RJSAllowanceDistribution
@@ -62,7 +63,7 @@ fun runStandaloneSimulation(
     schedule: List<SimulationScheduleItem>,
     initialSpeed: Double,
     margins: RangeValues<MarginValue>,
-    pathItemPositions: List<Offset<TrainPath>>,
+    pathItemPositions: List<Offset<PhysicsPath>>,
     driverBehaviour: DriverBehaviour = DriverBehaviour(),
 ): SimulationSuccess {
     if (trainPath.getLength() == Offset.zero<TrainPath>()) throw OSRDError(ZeroLengthPath)
@@ -212,14 +213,14 @@ fun makeElectricalProfiles(
     }
 
     val boundaries =
-        profileMap.entries.map { Offset<TrainPath>(it.key.upperEndpoint().meters) }.dropLast(1)
+        profileMap.entries.map { Offset<PhysicsPath>(it.key.upperEndpoint().meters) }.dropLast(1)
     val values = profileMap.values
 
     return RangeValues(internalBoundaries = boundaries, values = values.toList())
 }
 
 fun makeMRSPResponse(speedLimits: Envelope): RangeValues<SpeedLimitProperty> {
-    val internalBoundaries = mutableListOf<Offset<TrainPath>>()
+    val internalBoundaries = mutableListOf<Offset<PhysicsPath>>()
     val sources = mutableListOf<SpeedLimitProperty>()
     for (part in speedLimits.stream()) {
         internalBoundaries.add(Offset(part.endPos.meters))
@@ -259,13 +260,13 @@ fun buildFinalEnvelope(
     allowanceType: RJSAllowanceDistribution,
     scheduledPoints: List<SimulationScheduleItem>,
 ): Envelope {
-    fun getEnvelopeTimeAt(offset: Offset<TrainPath>): Double {
+    fun getEnvelopeTimeAt(offset: Offset<PhysicsPath>): Double {
         return provisionalEnvelope.interpolateDepartureFromClamp(offset.meters)
     }
-    fun getMaxEffortEnvelopeTimeAt(offset: Offset<TrainPath>): Double {
+    fun getMaxEffortEnvelopeTimeAt(offset: Offset<PhysicsPath>): Double {
         return maxEffortEnvelope.interpolateDepartureFromClamp(offset.meters)
     }
-    var prevFixedPointOffset = Offset<TrainPath>(0.meters)
+    var prevFixedPointOffset = Offset<PhysicsPath>(0.meters)
     var prevFixedPointDepartureTime = 0.0
     val marginRanges = mutableListOf<AllowanceRange>()
     for (point in scheduledPoints) {
@@ -324,7 +325,7 @@ fun buildFinalEnvelope(
         }
         prevFixedPointOffset = point.pathOffset
     }
-    val pathEnd = Offset<TrainPath>(maxEffortEnvelope.endPos.meters)
+    val pathEnd = Offset<PhysicsPath>(maxEffortEnvelope.endPos.meters)
     if (prevFixedPointOffset < pathEnd) {
         // Because the last margin call is based on the max effort envelope,
         // we still need to cover all ranges to keep the standard margin,
@@ -361,8 +362,8 @@ fun distributeAllowance(
     provisionalEnvelope: Envelope,
     extraTime: Double,
     margins: RangeValues<MarginValue>,
-    startOffset: Offset<TrainPath>,
-    endOffset: Offset<TrainPath>,
+    startOffset: Offset<PhysicsPath>,
+    endOffset: Offset<PhysicsPath>,
 ): List<AllowanceRange> {
     assert(startOffset <= endOffset)
     if (startOffset == endOffset) {
@@ -371,8 +372,8 @@ fun distributeAllowance(
         return listOf()
     }
     fun rangeTime(
-        from: Offset<TrainPath>,
-        to: Offset<TrainPath>,
+        from: Offset<PhysicsPath>,
+        to: Offset<PhysicsPath>,
         envelope: Envelope = provisionalEnvelope,
     ): Double {
         assert(from < to)
@@ -415,7 +416,7 @@ fun buildProvisionalEnvelope(
 ): Envelope {
     val marginRanges = mutableListOf<AllowanceRange>()
     // Add path extremities to boundaries
-    val boundaries = mutableListOf<Offset<TrainPath>>()
+    val boundaries = mutableListOf<Offset<PhysicsPath>>()
     boundaries.add(Offset(Distance.ZERO))
     boundaries.addAll(rawMargins.internalBoundaries)
     boundaries.add(Offset(Distance.fromMeters(context.path.length)))

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/etcsContextBuilder.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/etcsContextBuilder.kt
@@ -3,6 +3,7 @@ package fr.sncf.osrd.standalone_sim
 import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.envelope_sim.EnvelopeSimContext
 import fr.sncf.osrd.path.interfaces.DirChunkRange
+import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.signaling.etcs_level2.ETCS_LEVEL2
 import fr.sncf.osrd.sim_infra.api.*
@@ -42,8 +43,8 @@ fun makeETCSContext(
  * May return any number of point beyond the end of the path, specifically any point covered by the
  * routes used by the path.
  */
-fun buildETCSDangerPoints(infra: RawInfra, trainPath: TrainPath): List<Offset<TrainPath>> {
-    val res = mutableSetOf<Offset<TrainPath>>()
+fun buildETCSDangerPoints(infra: RawInfra, trainPath: TrainPath): List<Offset<PhysicsPath>> {
+    val res = mutableSetOf<Offset<PhysicsPath>>()
     for (zonePathRange in trainPath.getZonePaths()) {
         val zonePath = zonePathRange.value
         val movableElements = infra.getZonePathMovableElements(zonePath)
@@ -59,8 +60,8 @@ fun buildETCSDangerPoints(infra: RawInfra, trainPath: TrainPath): List<Offset<Tr
 }
 
 /** Builds the offset list of detectors for ETCS blocks on the block path. */
-fun buildETCSBlockDetectors(infra: FullInfra, trainPath: TrainPath): List<Offset<TrainPath>> {
-    val etcsBlockDetectors = mutableListOf<Offset<TrainPath>>()
+fun buildETCSBlockDetectors(infra: FullInfra, trainPath: TrainPath): List<Offset<PhysicsPath>> {
+    val etcsBlockDetectors = mutableListOf<Offset<PhysicsPath>>()
     for (blockRange in trainPath.getBlocks()) {
         val block = blockRange.value
         if (isETCSBlock(block, infra)) {
@@ -82,7 +83,7 @@ private fun isETCSBlock(block: BlockId, infra: FullInfra): Boolean {
  * Find the last danger point, which may extend beyond the end of the path. Null if tracks are
  * circular with no switch nor buffer stop.
  */
-private fun findLastDangerPoint(infra: RawInfra, trainPath: TrainPath): Offset<TrainPath>? {
+private fun findLastDangerPoint(infra: RawInfra, trainPath: TrainPath): Offset<PhysicsPath>? {
     // Find the offset of the last chunk on the path
     val chunkRanges = trainPath.getChunks()
     val lastChunkRange = chunkRanges.last()
@@ -111,7 +112,7 @@ private fun getEndOfLastTrackPathOffset(
     infra: RawInfra,
     lastTrack: TrackSectionId,
     lastChunkRange: DirChunkRange,
-): Offset<TrainPath> {
+): Offset<PhysicsPath> {
     // Note: this function alone doesn't quite justify it,
     // but we could add a List<DirTrackRange> to TrainPath instead
     val dirLastChunk = lastChunkRange.value

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMResult.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMResult.kt
@@ -1,6 +1,7 @@
 package fr.sncf.osrd.stdcm
 
 import fr.sncf.osrd.envelope.Envelope
+import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.sim_infra.api.RouteId
 import fr.sncf.osrd.stdcm.graph.EngineeringAllowanceRange
@@ -17,6 +18,6 @@ data class STDCMResult(
     val routePath: List<RouteId>,
     val departureTime: Double,
     val stopResults: List<TrainStop>,
-    val waypointOffsets: List<Offset<TrainPath>>,
+    val waypointOffsets: List<Offset<PhysicsPath>>,
     val engineeringAllowanceRanges: List<EngineeringAllowanceRange>,
 )

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/PostProcessingSimulation.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/PostProcessingSimulation.kt
@@ -40,7 +40,7 @@ val postProcessingLogger: Logger = LoggerFactory.getLogger("postprocessing-STDCM
 
 private data class FixedTimePoint(
     val time: Double,
-    val offset: Offset<TrainPath>,
+    val offset: Offset<PhysicsPath>,
     val stopTime: Double?,
 ) : Comparable<FixedTimePoint> {
     override fun compareTo(other: FixedTimePoint): Int {
@@ -49,8 +49,8 @@ private data class FixedTimePoint(
 }
 
 data class EngineeringAllowanceRange(
-    val from: Offset<TrainPath>,
-    val to: Offset<TrainPath>,
+    val from: Offset<PhysicsPath>,
+    val to: Offset<PhysicsPath>,
     @Json(name = "added_duration") val addedDuration: Double,
 )
 
@@ -99,7 +99,7 @@ fun buildFinalEnvelope(
         )
 
     val pathLength =
-        Length<TrainPath>(Distance(millimeters = edges.sumOf { it.length.distance.millimeters }))
+        Length<PhysicsPath>(Distance(millimeters = edges.sumOf { it.length.distance.millimeters }))
     val allowanceRanges = getEngineeringAllowanceRanges(edges)
     assert(fullInfraExplorer.isPathComplete)
     val fixedPoints =
@@ -212,7 +212,7 @@ fun buildFinalEnvelope(
 private fun initFixedPoints(
     edges: List<STDCMEdge>,
     stops: List<TrainStop>,
-    length: Length<TrainPath>,
+    length: Length<PhysicsPath>,
     hasStandardAllowance: Boolean,
     updatedTimeData: TimeData,
     allowanceRanges: List<EngineeringAllowanceRange>,
@@ -241,7 +241,7 @@ private fun initFixedPoints(
         res.add(makeFixedPoint(res, edges, length, length, updatedTimeData, allowanceRanges))
 
     // Add points at the end of each engineering allowance
-    val allowanceEndOffsets = mutableListOf<Offset<TrainPath>>()
+    val allowanceEndOffsets = mutableListOf<Offset<PhysicsPath>>()
     for ((from, to, _) in allowanceRanges) {
         // When ranges overlap, we start with just the last point
         allowanceEndOffsets.removeIf { it > from }
@@ -258,7 +258,7 @@ private fun initFixedPoints(
 }
 
 private fun getEngineeringAllowanceRanges(edges: List<STDCMEdge>): List<EngineeringAllowanceRange> {
-    var edgeStartOffset = Offset.zero<TrainPath>()
+    var edgeStartOffset = Offset.zero<PhysicsPath>()
     val res = mutableListOf<EngineeringAllowanceRange>()
     for (edge in edges) {
         val allowance = edge.engineeringAllowance
@@ -302,8 +302,8 @@ private fun getEngineeringAllowanceRanges(edges: List<STDCMEdge>): List<Engineer
 private fun makeFixedPoint(
     fixedPoints: TreeSet<FixedTimePoint>,
     edges: List<STDCMEdge>,
-    conflictOffset: Offset<TrainPath>,
-    pathLength: Length<TrainPath>,
+    conflictOffset: Offset<PhysicsPath>,
+    pathLength: Length<PhysicsPath>,
     updatedTimeData: TimeData,
     allowanceRanges: List<EngineeringAllowanceRange>,
     stopDuration: Double = 0.0,
@@ -350,10 +350,10 @@ private fun makeFixedPoint(
  */
 private fun roundOffset(
     edges: List<STDCMEdge>,
-    offset: Offset<TrainPath>,
+    offset: Offset<PhysicsPath>,
     roundToEnd: Boolean,
-): Offset<TrainPath> {
-    var prevEdgesLength = Offset<TrainPath>(0.meters)
+): Offset<PhysicsPath> {
+    var prevEdgesLength = Offset<PhysicsPath>(0.meters)
     for (edge in edges) {
         if (offset <= prevEdgesLength + edge.length.distance) {
             return if (roundToEnd) prevEdgesLength + edge.length.distance else prevEdgesLength
@@ -371,7 +371,7 @@ private fun roundOffset(
  */
 private fun getTimeOnEdges(
     edges: List<STDCMEdge>,
-    offset: Offset<TrainPath>,
+    offset: Offset<PhysicsPath>,
     updatedTimeData: TimeData,
 ): Double {
     var remainingDistance = offset.distance
@@ -399,7 +399,7 @@ private fun findConflictOffsets(
     blockAvailability: BlockAvailabilityInterface,
     edges: List<STDCMEdge>,
     updatedTimeData: TimeData,
-): Offset<TrainPath>? {
+): Offset<PhysicsPath>? {
     val explorer = getUpdatedExplorer(edges, envelope, updatedTimeData)
     val availability =
         blockAvailability.getAvailability(
@@ -495,7 +495,7 @@ private fun handlePostProcessingConflict(
     stops: List<TrainStop>,
     updatedTimeData: TimeData,
     fixedPoints: TreeSet<FixedTimePoint>,
-    conflictOffset: Offset<TrainPath>,
+    conflictOffset: Offset<PhysicsPath>,
     isMareco: Boolean,
     allowanceRanges: List<EngineeringAllowanceRange>,
     attempt: Int,

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdge.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdge.kt
@@ -1,7 +1,7 @@
 package fr.sncf.osrd.stdcm.graph
 
 import fr.sncf.osrd.envelope.Envelope
-import fr.sncf.osrd.path.interfaces.TrainPath
+import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
 import fr.sncf.osrd.utils.units.Distance
@@ -175,7 +175,7 @@ data class STDCMEdge(
     }
 
     /** Converts a path offset into an edge offset */
-    fun edgeOffsetFromPathOffset(offset: Offset<TrainPath>): Offset<STDCMEdge> {
+    fun edgeOffsetFromPathOffset(offset: Offset<PhysicsPath>): Offset<STDCMEdge> {
         val blockOffset = infraExplorer.getCurrentBlockRange().offsetFromTrainPath(offset)
         return Offset(blockOffset - envelopeStartOffset)
     }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMSimulations.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMSimulations.kt
@@ -14,7 +14,7 @@ import fr.sncf.osrd.envelope_sim.pipelines.SimStop
 import fr.sncf.osrd.envelope_sim.pipelines.maxEffortEnvelopeFrom
 import fr.sncf.osrd.envelope_sim.pipelines.maxSpeedEnvelopeFrom
 import fr.sncf.osrd.envelope_sim_infra.computeMRSP
-import fr.sncf.osrd.path.interfaces.TrainPath
+import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
 import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal
 import fr.sncf.osrd.reporting.exceptions.OSRDError
@@ -97,7 +97,7 @@ class STDCMSimulations {
         var stops = emptyList<SimStop>()
         var simLength = blockLength.distance - start.distance
         if (stopPosition != null) {
-            val stopOffset = Offset<TrainPath>(stopPosition - start)
+            val stopOffset = Offset<PhysicsPath>(stopPosition - start)
             // We presently consider all stdcm stops to be performed on closed signal by default
             // This presently only affects ETCS computations, which are not yet supported in stdcm
             // either

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
@@ -6,6 +6,7 @@ import fr.sncf.osrd.path.implementations.buildTrainPathFromBlock
 import fr.sncf.osrd.path.implementations.buildTrainPathFromBlockRanges
 import fr.sncf.osrd.path.interfaces.BlockRange
 import fr.sncf.osrd.path.interfaces.GenericLinearRange
+import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.path.interfaces.RouteRange
 import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.path.interfaces.subRange
@@ -113,8 +114,8 @@ interface InfraExplorer {
      * unspecified.
      */
     fun getBlocksInRange(
-        from: Offset<TrainPath>? = null,
-        to: Offset<TrainPath>? = null,
+        from: Offset<PhysicsPath>? = null,
+        to: Offset<PhysicsPath>? = null,
     ): List<BlockRange>
 
     /**
@@ -122,21 +123,21 @@ interface InfraExplorer {
      * unspecified.
      */
     fun getRoutesInRange(
-        from: Offset<TrainPath>? = null,
-        to: Offset<TrainPath>? = null,
+        from: Offset<PhysicsPath>? = null,
+        to: Offset<PhysicsPath>? = null,
     ): List<RouteRange>
 
     /** Returns the stops in the given interval, going up to the path start/end if unspecified. */
     fun getStopsInRange(
-        from: Offset<TrainPath>? = null,
-        to: Offset<TrainPath>? = null,
+        from: Offset<PhysicsPath>? = null,
+        to: Offset<PhysicsPath>? = null,
     ): List<PathStop>
 
     /**
      * Returns the end of the lookahead as a train path offset. Can also be seen as the total length
      * of the currently known path.
      */
-    fun getLookaheadEndOffset(): Offset<TrainPath>
+    fun getLookaheadEndOffset(): Offset<PhysicsPath>
 }
 
 /** Returns the current block and the lookahead blocks */
@@ -335,8 +336,8 @@ private class InfraExplorerImpl(
 
     private fun <T, U> getSubRanges(
         list: AppendOnlyLinkedList<GenericLinearRange<T, U>>,
-        from: Offset<TrainPath>?,
-        to: Offset<TrainPath>?,
+        from: Offset<PhysicsPath>?,
+        to: Offset<PhysicsPath>?,
     ): List<GenericLinearRange<T, U>> {
         val from = from ?: Offset.zero()
         val to = to ?: getLookaheadEndOffset()
@@ -349,16 +350,19 @@ private class InfraExplorerImpl(
     }
 
     override fun getBlocksInRange(
-        from: Offset<TrainPath>?,
-        to: Offset<TrainPath>?,
+        from: Offset<PhysicsPath>?,
+        to: Offset<PhysicsPath>?,
     ): List<BlockRange> = getSubRanges(blockRanges, from, to)
 
     override fun getRoutesInRange(
-        from: Offset<TrainPath>?,
-        to: Offset<TrainPath>?,
+        from: Offset<PhysicsPath>?,
+        to: Offset<PhysicsPath>?,
     ): List<RouteRange> = getSubRanges(routes, from, to)
 
-    override fun getStopsInRange(from: Offset<TrainPath>?, to: Offset<TrainPath>?): List<PathStop> {
+    override fun getStopsInRange(
+        from: Offset<PhysicsPath>?,
+        to: Offset<PhysicsPath>?,
+    ): List<PathStop> {
         val from = from ?: Offset.zero()
         val to = to ?: getLookaheadEndOffset()
         return getStepTracker()
@@ -372,7 +376,7 @@ private class InfraExplorerImpl(
             .asReversed()
     }
 
-    override fun getLookaheadEndOffset(): Offset<TrainPath> =
+    override fun getLookaheadEndOffset(): Offset<PhysicsPath> =
         blockRanges.lastOrNull()?.pathEnd ?: Offset.zero()
 
     /**

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelope.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelope.kt
@@ -7,7 +7,7 @@ import fr.sncf.osrd.envelope.Envelope
 import fr.sncf.osrd.envelope.EnvelopeTimeInterpolate
 import fr.sncf.osrd.envelope_sim.PhysicsRollingStock
 import fr.sncf.osrd.graph.PathfindingConstraint
-import fr.sncf.osrd.path.interfaces.TrainPath
+import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.pathfinding.BlockLocation
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.stdcm.graph.TimeData
@@ -54,7 +54,7 @@ interface InfraExplorerWithEnvelope : InfraExplorer {
     fun updateTimeData(updatedTimeData: TimeData): InfraExplorerWithEnvelope
 
     /** Calls `InterpolateDepartureFromClamp` on the underlying envelope. */
-    fun interpolateDepartureFromClamp(pathOffset: Offset<TrainPath>): Double
+    fun interpolateDepartureFromClamp(pathOffset: Offset<PhysicsPath>): Double
 
     /** Returns the spacing requirements since the last update */
     fun getSpacingRequirements(): List<SpacingRequirement>
@@ -63,7 +63,7 @@ interface InfraExplorerWithEnvelope : InfraExplorer {
     fun getFullSpacingRequirements(): List<SpacingRequirement>
 
     /** Returns the length of the simulated section of the path */
-    fun getSimulatedLength(): Length<TrainPath>
+    fun getSimulatedLength(): Length<PhysicsPath>
 
     /**
      * Generate a list of reached train stops, mostly for debugging purposes. Lookahead isn't

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelopeImpl.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelopeImpl.kt
@@ -8,7 +8,7 @@ import fr.sncf.osrd.envelope.EnvelopeConcat
 import fr.sncf.osrd.envelope.EnvelopeConcat.LocatedEnvelopeInterpolate
 import fr.sncf.osrd.envelope.EnvelopeInterpolate
 import fr.sncf.osrd.envelope_sim.PhysicsRollingStock
-import fr.sncf.osrd.path.interfaces.TrainPath
+import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal.SHORT_SLIP_STOP
 import fr.sncf.osrd.standalone_sim.EnvelopeStopWrapper
 import fr.sncf.osrd.stdcm.graph.StopTimeData
@@ -111,7 +111,7 @@ data class InfraExplorerWithEnvelopeImpl(
         return this
     }
 
-    override fun interpolateDepartureFromClamp(pathOffset: Offset<TrainPath>): Double {
+    override fun interpolateDepartureFromClamp(pathOffset: Offset<PhysicsPath>): Double {
         return getFullEnvelope().interpolateDepartureFromClamp(pathOffset.meters)
     }
 
@@ -183,7 +183,7 @@ data class InfraExplorerWithEnvelopeImpl(
         return this
     }
 
-    override fun getSimulatedLength(): Length<TrainPath> {
+    override fun getSimulatedLength(): Length<PhysicsPath> {
         if (envelopes.isEmpty()) return Length(0.meters)
         val lastEnvelope = envelopes[envelopes.size - 1]
         return Length(Distance.fromMeters(lastEnvelope.startOffset + lastEnvelope.envelope.endPos))

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/StepTracker.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/StepTracker.kt
@@ -1,6 +1,6 @@
 package fr.sncf.osrd.stdcm.infra_exploration
 
-import fr.sncf.osrd.path.interfaces.TrainPath
+import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.pathfinding.BlockLocation
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockId
@@ -31,7 +31,7 @@ class StepTracker(
         private set
 
     // Used to compute path offsets
-    private var currentPathOffset: Offset<TrainPath> = Offset.zero()
+    private var currentPathOffset: Offset<PhysicsPath> = Offset.zero()
 
     /** Returns all the steps that have been passed on the path, in order. */
     fun getSeenSteps(): List<LocatedStep> {
@@ -61,7 +61,7 @@ class StepTracker(
     ): List<LocatedStep> {
         val res = mutableListOf<LocatedStep>()
 
-        val currentBlockStart: Offset<TrainPath> = currentPathOffset - rangeStart.distance
+        val currentBlockStart: Offset<PhysicsPath> = currentPathOffset - rangeStart.distance
         for (step in inputSteps.dropSeq(nSeenSteps)) {
             val currentPathBlockOffset = Offset<Block>(currentPathOffset - currentBlockStart)
             val location =
@@ -116,7 +116,7 @@ class StepTracker(
 }
 
 data class LocatedStep(
-    val travelledPathOffset: Offset<TrainPath>,
+    val travelledPathOffset: Offset<PhysicsPath>,
     val location: BlockLocation,
     val originalStep: ExplorerStep,
     val isPlanned: Boolean = true, // Set to false for overtakes (when implemented)

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/implementation/BlockAvailability.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/implementation/BlockAvailability.kt
@@ -5,7 +5,7 @@ import com.google.common.collect.RangeSet
 import com.google.common.collect.TreeRangeSet
 import fr.sncf.osrd.conflicts.*
 import fr.sncf.osrd.envelope_utils.DoubleBinarySearch
-import fr.sncf.osrd.path.interfaces.TrainPath
+import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.sim_infra.api.ZoneId
 import fr.sncf.osrd.standalone_sim.CLOSED_SIGNAL_RESERVATION_MARGIN
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
@@ -28,12 +28,12 @@ data class BlockAvailability(
 
     override fun getAvailability(
         infraExplorer: InfraExplorerWithEnvelope,
-        startOffset: Offset<TrainPath>,
-        endOffset: Offset<TrainPath>,
+        startOffset: Offset<PhysicsPath>,
+        endOffset: Offset<PhysicsPath>,
         startTime: Double,
     ): BlockAvailabilityInterface.Availability {
         var timeShift = 0.0
-        var firstConflictOffset: Offset<TrainPath>? = null
+        var firstConflictOffset: Offset<PhysicsPath>? = null
         while (timeShift.isFinite()) {
             val shiftedStartTime = startTime + timeShift
             val pathStartTime =
@@ -93,12 +93,12 @@ data class BlockAvailability(
      */
     private fun getStepAvailability(
         infraExplorer: InfraExplorerWithEnvelope,
-        startOffset: Offset<TrainPath>,
-        endOffset: Offset<TrainPath>,
+        startOffset: Offset<PhysicsPath>,
+        endOffset: Offset<PhysicsPath>,
         pathStartTime: Double,
     ): BlockAvailabilityInterface.Availability {
         var minimumDelayToBecomeAvailable = 0.0
-        var firstUnavailabilityOffset = Offset<TrainPath>(Double.POSITIVE_INFINITY.meters)
+        var firstUnavailabilityOffset = Offset<PhysicsPath>(Double.POSITIVE_INFINITY.meters)
         var maximumDelayToStayAvailable = Double.POSITIVE_INFINITY
         var timeOfNextUnavailability = Double.POSITIVE_INFINITY
 
@@ -155,8 +155,8 @@ data class BlockAvailability(
     private fun getStepAvailabilityProperties(
         step: LocatedStep,
         infraExplorer: InfraExplorerWithEnvelope,
-        startOffset: Offset<TrainPath>,
-        endOffset: Offset<TrainPath>,
+        startOffset: Offset<PhysicsPath>,
+        endOffset: Offset<PhysicsPath>,
         pathStartTime: Double,
     ): AvailabilityProperties? {
         val plannedTimingData = step.originalStep.plannedTimingData ?: return null
@@ -203,7 +203,7 @@ data class BlockAvailability(
     /** Check the conflicts on the given path and return the corresponding availability. */
     private fun getConflictAvailability(
         infraExplorer: InfraExplorerWithEnvelope,
-        startOffset: Offset<TrainPath>,
+        startOffset: Offset<PhysicsPath>,
         pathStartTime: Double,
         startTime: Double,
         endTime: Double,
@@ -305,7 +305,7 @@ data class BlockAvailability(
     private fun getEnvelopeOffsetFromTime(
         explorer: InfraExplorerWithEnvelope,
         time: Double,
-    ): Offset<TrainPath> {
+    ): Offset<PhysicsPath> {
         if (time < 0.0) return Offset(0.meters)
         val envelope = explorer.getFullEnvelope()
         if (time > envelope.totalTime) return explorer.getSimulatedLength()
@@ -327,7 +327,7 @@ private data class AvailabilityProperties(
     // available
     val minimumDelayToBecomeAvailable: Double,
     // If a resource is unavailable, offset of that resource
-    val firstUnavailabilityOffset: Offset<TrainPath>,
+    val firstUnavailabilityOffset: Offset<PhysicsPath>,
     // If everything is available, maximum delay that can be added to the train without a resource
     // becoming unavailable
     val maximumDelayToStayAvailable: Double,

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/interfaces/BlockAvailabilityInterface.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/interfaces/BlockAvailabilityInterface.kt
@@ -1,6 +1,6 @@
 package fr.sncf.osrd.stdcm.preprocessing.interfaces
 
-import fr.sncf.osrd.path.interfaces.TrainPath
+import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
 import fr.sncf.osrd.utils.units.Offset
 
@@ -37,8 +37,8 @@ interface BlockAvailabilityInterface {
      */
     fun getAvailability(
         infraExplorer: InfraExplorerWithEnvelope,
-        startOffset: Offset<TrainPath>,
-        endOffset: Offset<TrainPath>,
+        startOffset: Offset<PhysicsPath>,
+        endOffset: Offset<PhysicsPath>,
         startTime: Double,
     ): Availability
 
@@ -71,7 +71,7 @@ interface BlockAvailabilityInterface {
          * It's either the offset where we start using a resource before it's available, or the
          * offset where the train would have released a resource it has kept for too long.
          */
-        val firstConflictOffset: Offset<TrainPath>,
+        val firstConflictOffset: Offset<PhysicsPath>,
     ) : Availability()
 
     /**

--- a/core/src/test/java/fr/sncf/osrd/conflicts/SpacingResourceGeneratorTest.kt
+++ b/core/src/test/java/fr/sncf/osrd/conflicts/SpacingResourceGeneratorTest.kt
@@ -9,8 +9,8 @@ import fr.sncf.osrd.path.implementations.PartialBlockRange
 import fr.sncf.osrd.path.implementations.PartialRouteRange
 import fr.sncf.osrd.path.implementations.buildRangeList
 import fr.sncf.osrd.path.interfaces.BlockRange
+import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.path.interfaces.RouteRange
-import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.path.interfaces.ZoneRange
 import fr.sncf.osrd.path.interfaces.mapSubObjects
 import fr.sncf.osrd.path.interfaces.subRange
@@ -291,7 +291,7 @@ class SpacingResourceGeneratorTest {
 
 /** Returns an incremental requirement callback of the given length */
 private fun makeCallbacks(
-    length: Length<TrainPath>,
+    length: Length<PhysicsPath>,
     complete: Boolean,
     rollingStock: PhysicsRollingStock = SimpleRollingStock.STANDARD_TRAIN,
     stops: List<TrainStop> = listOf(),

--- a/core/src/test/kotlin/fr/sncf/osrd/backtracks/BacktrackTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/backtracks/BacktrackTests.kt
@@ -6,6 +6,7 @@ import fr.sncf.osrd.api.path_properties.makePathPropResponse
 import fr.sncf.osrd.path.implementations.PartialBlockRange
 import fr.sncf.osrd.path.implementations.buildRangeList
 import fr.sncf.osrd.path.implementations.buildTrainPathFromBlockRanges
+import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
 import fr.sncf.osrd.railjson.schema.schedule.RJSAllowanceDistribution
@@ -132,7 +133,7 @@ class BacktrackTests {
                 ),
             )
         val backtrackLocation =
-            Offset<TrainPath>(blockRanges.subList(0, 3).map { it.length }.sumDistances())
+            Offset<PhysicsPath>(blockRanges.subList(0, 3).map { it.length }.sumDistances())
 
         return buildTrainPathFromBlockRanges(
             infra.rawInfra,

--- a/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingElectrificationTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingElectrificationTest.kt
@@ -6,7 +6,7 @@ import fr.sncf.osrd.api.TrackLocation
 import fr.sncf.osrd.api.pathfinding.IncompatibleConstraintsPathResponse
 import fr.sncf.osrd.api.pathfinding.NoPathFoundException
 import fr.sncf.osrd.api.pathfinding.runPathfinding
-import fr.sncf.osrd.path.interfaces.TrainPath
+import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.railjson.schema.common.graph.ApplicableDirection
 import fr.sncf.osrd.railjson.schema.infra.RJSTrackSection
 import fr.sncf.osrd.railjson.schema.infra.trackranges.RJSApplicableDirectionsTrackRange
@@ -281,8 +281,8 @@ class PathfindingElectrificationTest : ApiTest() {
                 assert(resp.relaxedConstraintsPath.length.distance == 39_553.meters)
                 val incompElec =
                     resp.incompatibleConstraints.incompatibleElectrificationRanges.single()
-                assert(incompElec.range.start == Offset<TrainPath>(0.meters))
-                assert(incompElec.range.end == Offset<TrainPath>(39_553.meters))
+                assert(incompElec.range.start == Offset<PhysicsPath>(0.meters))
+                assert(incompElec.range.end == Offset<PhysicsPath>(39_553.meters))
                 assert(incompElec.value == "")
             })
     }

--- a/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingTest.kt
@@ -6,7 +6,7 @@ import fr.sncf.osrd.api.TrackLocation
 import fr.sncf.osrd.api.pathfinding.*
 import fr.sncf.osrd.cli.RqFake
 import fr.sncf.osrd.path.interfaces.JsonTrainPath.TrackSectionRange
-import fr.sncf.osrd.path.interfaces.TrainPath
+import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.railjson.schema.common.graph.EdgeDirection
 import fr.sncf.osrd.railjson.schema.infra.trackranges.RJSLoadingGaugeLimit
 import fr.sncf.osrd.railjson.schema.rollingstock.RJSLoadingGaugeType
@@ -54,14 +54,14 @@ fun checkPathfindingSuccess(
     expectedTrackSectionRanges: List<TrackSectionRange>? = null,
     expectedBlocks: List<String>? = null,
     expectedRoutes: List<String>? = null,
-    expectedIntermediatePathItemPosition: List<Offset<TrainPath>> = listOf(),
+    expectedIntermediatePathItemPosition: List<Offset<PhysicsPath>> = listOf(),
 ): PathfindingBlockSuccess {
     assertThat(pathResp).isExactlyInstanceOf(PathfindingBlockSuccess::class.java)
     val pathSuccess = pathResp as PathfindingBlockSuccess
 
     AssertionsForClassTypes.assertThat(pathSuccess.length.distance).isEqualTo(expectedLength)
     val expectedPathItemsPos =
-        listOf(Offset<TrainPath>(0.meters))
+        listOf(Offset<PhysicsPath>(0.meters))
             .plus(expectedIntermediatePathItemPosition)
             .plusElement(Offset(pathSuccess.length.distance))
     assertEquals(expectedPathItemsPos, pathSuccess.pathItemPositions)

--- a/core/src/test/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulationTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulationTest.kt
@@ -13,7 +13,7 @@ import fr.sncf.osrd.envelope_sim.pipelines.maxEffortEnvelopeFrom
 import fr.sncf.osrd.envelope_sim.pipelines.maxSpeedEnvelopeFrom
 import fr.sncf.osrd.envelope_sim_infra.computeMRSP
 import fr.sncf.osrd.path.implementations.buildTrainPathFromBlocks
-import fr.sncf.osrd.path.interfaces.TrainPath
+import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
 import fr.sncf.osrd.railjson.schema.schedule.RJSAllowanceDistribution
 import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal.OPEN
@@ -254,7 +254,7 @@ class StandaloneSimulationTest {
         }
 
         // Test margin values
-        val boundaries = mutableListOf<Offset<TrainPath>>()
+        val boundaries = mutableListOf<Offset<PhysicsPath>>()
         boundaries.add(Offset(Distance.ZERO))
         boundaries.addAll(testCase.margins.internalBoundaries)
         boundaries.add(Offset(testCase.pathLength))
@@ -471,7 +471,7 @@ class StandaloneSimulationTest {
      * Returns the time at which the given offset is reached, interpolating linearly between points.
      */
     private fun getTimeAt(
-        offset: Offset<TrainPath>,
+        offset: Offset<PhysicsPath>,
         train: ReportTrain,
         interpolateRight: Boolean,
     ): Double {
@@ -482,8 +482,8 @@ class StandaloneSimulationTest {
      * Returns the time at which the given offset is reached, interpolating linearly between points.
      */
     private fun getTimeAt(
-        offset: Offset<TrainPath>,
-        positions: List<Offset<TrainPath>>,
+        offset: Offset<PhysicsPath>,
+        positions: List<Offset<PhysicsPath>>,
         times: List<TimeDelta>,
         interpolateRight: Boolean,
     ): Double {

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMPathfindingTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMPathfindingTests.kt
@@ -1,7 +1,7 @@
 package fr.sncf.osrd.stdcm
 
 import com.google.common.collect.ImmutableMultimap
-import fr.sncf.osrd.path.interfaces.TrainPath
+import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.pathfinding.BlockLocation
 import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.sim_infra.api.SpeedLimitProperty
@@ -52,7 +52,7 @@ class STDCMPathfindingTests {
                 .setStartLocations(setOf(BlockLocation(firstBlock, Offset(30.meters))))
                 .setEndLocations(setOf(BlockLocation(secondBlock, Offset(30.meters))))
                 .run()!!
-        assertEquals(Offset<TrainPath>(100.meters), res.trainPath.getLength())
+        assertEquals(Offset<PhysicsPath>(100.meters), res.trainPath.getLength())
     }
 
     /** Look for a path where the blocks are occupied before and after */

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/DummyBlockAvailability.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/DummyBlockAvailability.kt
@@ -2,7 +2,7 @@ package fr.sncf.osrd.stdcm.preprocessing
 
 import com.google.common.collect.Multimap
 import fr.sncf.osrd.path.interfaces.BlockRange
-import fr.sncf.osrd.path.interfaces.TrainPath
+import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.sim_infra.api.BlockInfra
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorer
@@ -26,8 +26,8 @@ class DummyBlockAvailability(
 ) : BlockAvailabilityInterface {
 
     private data class ResourceUse(
-        val startOffset: Offset<TrainPath>,
-        val endOffset: Offset<TrainPath>,
+        val startOffset: Offset<PhysicsPath>,
+        val endOffset: Offset<PhysicsPath>,
         val startTime: Double,
         val endTime: Double,
         val blockId: BlockId,
@@ -36,8 +36,8 @@ class DummyBlockAvailability(
     /** Returns all resource usage for the given path, or null if more lookahead is needed */
     private fun generateResourcesForPath(
         infraExplorer: InfraExplorerWithEnvelope,
-        startOffset: Offset<TrainPath>,
-        endOffset: Offset<TrainPath>,
+        startOffset: Offset<PhysicsPath>,
+        endOffset: Offset<PhysicsPath>,
     ): List<ResourceUse> {
         val blocks = makeBlocksWithOffsets(infraExplorer)
         val res = mutableListOf<ResourceUse>()
@@ -105,8 +105,8 @@ class DummyBlockAvailability(
 
     override fun getAvailability(
         infraExplorer: InfraExplorerWithEnvelope,
-        startOffset: Offset<TrainPath>,
-        endOffset: Offset<TrainPath>,
+        startOffset: Offset<PhysicsPath>,
+        endOffset: Offset<PhysicsPath>,
         startTime: Double,
     ): BlockAvailabilityInterface.Availability {
         val resourceUses = generateResourcesForPath(infraExplorer, startOffset, endOffset)
@@ -125,10 +125,10 @@ class DummyBlockAvailability(
         infraExplorer: InfraExplorerWithEnvelope,
         resourceUses: List<ResourceUse>,
         pathStartTime: Double,
-        startOffset: Offset<TrainPath>,
+        startOffset: Offset<PhysicsPath>,
     ): BlockAvailabilityInterface.Unavailable? {
         var minimumDelay = 0.0
-        var conflictOffset = Offset<TrainPath>(0.meters)
+        var conflictOffset = Offset<PhysicsPath>(0.meters)
         for (resourceUse in resourceUses) {
             val resourceStartTime = resourceUse.startTime + pathStartTime
             val resourceEndTime = resourceUse.endTime + pathStartTime
@@ -224,8 +224,8 @@ class DummyBlockAvailability(
         unavailableSegment: OccupancySegment,
         blockRange: BlockRange,
         explorer: InfraExplorerWithEnvelope,
-        startOffset: Offset<TrainPath>,
-        endOffset: Offset<TrainPath>,
+        startOffset: Offset<PhysicsPath>,
+        endOffset: Offset<PhysicsPath>,
     ): TimeInterval? {
         val blockEnterOffset = blockRange.offsetToTrainPath(unavailableSegment.distanceStart)
         val blockExitOffset = blockRange.offsetToTrainPath(unavailableSegment.distanceEnd)
@@ -239,8 +239,8 @@ class DummyBlockAvailability(
     /** Returns the list of blocks in the given interval on the path */
     private fun getBlocksInRange(
         blocks: List<BlockRange>,
-        start: Offset<TrainPath>,
-        end: Offset<TrainPath>,
+        start: Offset<PhysicsPath>,
+        end: Offset<PhysicsPath>,
     ): List<BlockRange> {
         return blocks
             .mapNotNull { it.withTruncatedPathRange(start, end) }


### PR DESCRIPTION
KMP move todolist: https://github.com/OpenRailAssociation/osrd/issues/13273#issuecomment-3744411531

Since
1. we need to move `EnvelopeSimContext` to osrd-mp,
2. `EnvelopeSimContext` depends on `ETCSContext`, which then depends on `TrainPath`
3. `TrainPath` depends on a *lot* of things, and
4. here `TrainPath` is only used to type `Offset`s

I started changing only what's needed to migrate `EnvelopeSimContext` to osrd-mp by using casts in `ETCSBrakingSimulator` and `etcsContextBuilder`, but we might want to unify the Offset types for full train paths. Since `PhysicsPath` will be usable from everywhere (including osrd-mp), we use `PhysicsPath` everywhere instead of `TrainPath`.