### PR TITLE
github: add a label for osrd-ui

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -14,6 +14,10 @@
   - any:
       - changed-files:
           - any-glob-to-any-file: "front/**"
+"area:ui":
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: "front/ui/**"
 "area:gateway":
   - any:
       - changed-files:


### PR DESCRIPTION
This makes it easier to spot changes which can impact external osrd-ui users and to write changelogs.

Note, the label doesn't exist it and needs to be created before this is merged.