### PR TITLE
editoast: change the API for SimulationTrain

### DIFF
--- a/editoast/core_task/src/envs/simulation.rs
+++ b/editoast/core_task/src/envs/simulation.rs
@@ -325,6 +325,7 @@ where
 #[cfg(test)]
 pub(crate) mod test_data {
     use schemas::infra::TrackOffset;
+    use schemas::primitives::NonBlankString;
     use schemas::train_schedule::MarginValue;
 
     use super::*;
@@ -426,31 +427,35 @@ pub(crate) mod test_data {
                 Default::default(),
             ),
         );
-        let start = builder.push_waypoint(
+        builder.push_waypoint(
             pathfinding::PathWaypointAlternatives::from_iter([TrackOffset::new("id", id as u64)]),
+            NonBlankString::from("start"),
             SimulationWaypointSchedule::PassBy,
         );
-        let a = builder.push_waypoint(
+        builder.push_waypoint(
             pathfinding::PathWaypointAlternatives::from_iter([TrackOffset::new("a", 42)]),
+            NonBlankString::from("a"),
             SimulationWaypointSchedule::Stop {
                 arrival_at: Some(1200),
                 stop_for: 60,
                 reception_signal: Default::default(),
             },
         );
-        let b = builder.push_waypoint(
+        builder.push_waypoint(
             pathfinding::PathWaypointAlternatives::from_iter([
                 TrackOffset::new("b", 43),
                 TrackOffset::new("bis", 34),
             ]),
+            NonBlankString::from("b"),
             SimulationWaypointSchedule::Stop {
                 arrival_at: None,
                 stop_for: 120,
                 reception_signal: Default::default(),
             },
         );
-        let finish = builder.push_waypoint(
+        builder.push_waypoint(
             pathfinding::PathWaypointAlternatives::from_iter([TrackOffset::new("finish", 44)]),
+            NonBlankString::from("finish"),
             SimulationWaypointSchedule::Stop {
                 arrival_at: Some(2400),
                 stop_for: 0,
@@ -458,9 +463,9 @@ pub(crate) mod test_data {
             },
         );
 
-        builder.set_power_restriction(start, a, "blackout".to_owned());
-        builder.set_margin(start, finish, MarginValue::Percentage(15.0));
-        builder.set_margin(a, b, MarginValue::MinPer100Km(123.4));
+        builder.set_power_restriction("start", "a", "blackout".to_owned());
+        builder.set_margin("start", "finish", MarginValue::Percentage(15.0));
+        builder.set_margin("a", "b", MarginValue::MinPer100Km(123.4));
 
         builder
     }

--- a/editoast/core_task/src/envs/simulation/inputs.rs
+++ b/editoast/core_task/src/envs/simulation/inputs.rs
@@ -1,11 +1,14 @@
 use core_client::simulation::PhysicsConsist;
+use schemas::primitives::NonBlankString;
 use schemas::train_schedule::Comfort;
 use schemas::train_schedule::Distribution;
 use schemas::train_schedule::MarginValue;
 use schemas::train_schedule::ReceptionSignal;
 use schemas::train_schedule::TrainScheduleOptions;
 
+use std::borrow::Borrow;
 use std::collections::HashMap;
+use std::hash::Hash;
 use std::sync::Arc;
 
 use crate::Correlated;
@@ -163,9 +166,10 @@ pub struct SimulationTrain {
     pub(super) pathfinding_consist: PathfindingConsist,
     pub(super) parameters: SimulationTrainParameters,
     pub(super) path_constraints: PathfindingConstraints,
+    schedule_item_to_index: HashMap<NonBlankString, PathWaypointIndex>,
 }
 
-pub type PathWaypointIndex = usize;
+type PathWaypointIndex = usize;
 
 impl SimulationTrain {
     pub fn new(
@@ -184,6 +188,7 @@ impl SimulationTrain {
             path_constraints: PathfindingConstraints {
                 path_items: Vec::new(),
             },
+            schedule_item_to_index: HashMap::default(),
         }
     }
 
@@ -204,32 +209,41 @@ impl SimulationTrain {
 
     /// Adds a waypoint to the train's path with simulation schedule information
     ///
-    /// Returns the index of the newly added waypoint which can be later used to set
-    /// power restrictions or margins.
-    ///
-    /// Checkout [Self::set_power_restriction] and [Self::set_margin].
+    /// The label can be reused for [Self::set_power_restriction] and [Self::set_margin].
     pub fn push_waypoint(
         &mut self,
         path_constraint: PathWaypointAlternatives,
+        label: NonBlankString,
         point: SimulationWaypointSchedule,
-    ) -> PathWaypointIndex {
+    ) {
         let index = self.parameters.schedule.len();
         self.parameters.schedule.push(point);
         self.path_constraints.path_items.push(path_constraint);
-        index
+        self.schedule_item_to_index.insert(label, index);
     }
 
     /// Sets a power restriction for a range of waypoints.
     ///
+    /// Labels are used to define the range: they can be &NonBlankString, &String or &str.
+    ///
     /// # Panics
     ///
-    /// Panics if `begin_index` or `end_index` is out of bounds.
-    pub fn set_power_restriction(
-        &mut self,
-        begin_index: PathWaypointIndex,
-        end_index: PathWaypointIndex,
-        restriction: String,
-    ) {
+    /// Panics if `begin_label` or `end_label` has not been used to push a waypoint.
+    pub fn set_power_restriction<Q>(&mut self, begin_label: &Q, end_label: &Q, restriction: String)
+    where
+        NonBlankString: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        let begin_index = self
+            .schedule_item_to_index
+            .get(begin_label)
+            .copied()
+            .expect("only names already inserted through “push_waypoint” can be used");
+        let end_index = self
+            .schedule_item_to_index
+            .get(end_label)
+            .copied()
+            .expect("only names already inserted through “push_waypoint” can be used");
         let n = self.waypoints();
         if begin_index >= n || end_index >= n {
             panic!("path waypoint index out of bounds");
@@ -242,15 +256,26 @@ impl SimulationTrain {
 
     /// Sets a margin for a range of waypoints.
     ///
+    /// Labels are used to define the range: they can be &NonBlankString, &String or &str.
+    ///
     /// # Panics
     ///
-    /// Panics if `begin_index` or `end_index` is out of bounds.
-    pub fn set_margin(
-        &mut self,
-        begin_index: PathWaypointIndex,
-        end_index: PathWaypointIndex,
-        margin: MarginValue,
-    ) {
+    /// Panics if `begin_label` or `end_label` has not been used to push a waypoint.
+    pub fn set_margin<Q>(&mut self, begin_label: &Q, end_label: &Q, margin: MarginValue)
+    where
+        NonBlankString: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        let begin_index = self
+            .schedule_item_to_index
+            .get(begin_label)
+            .copied()
+            .expect("only names already inserted through “push_waypoint” can be used");
+        let end_index = self
+            .schedule_item_to_index
+            .get(end_label)
+            .copied()
+            .expect("only names already inserted through “push_waypoint” can be used");
         let n = self.waypoints();
         if begin_index >= n || end_index >= n {
             panic!("path waypoint index out of bounds");
@@ -275,6 +300,7 @@ where
                     pathfinding_consist,
                     parameters,
                     path_constraints,
+                    schedule_item_to_index: _,
                 },
             )| {
                 (

--- a/editoast/core_task/src/envs/simulation/request.rs
+++ b/editoast/core_task/src/envs/simulation/request.rs
@@ -136,6 +136,7 @@ mod tests {
 
     use core_client::mocking::MockingClient;
     use pretty_assertions::assert_eq;
+    use schemas::primitives::NonBlankString;
     use schemas::train_schedule::MarginValue;
 
     use super::*;
@@ -184,9 +185,14 @@ mod tests {
                 Default::default(),
             ),
         );
-        builder.push_waypoint(path_items[0].clone(), SimulationWaypointSchedule::PassBy);
+        builder.push_waypoint(
+            path_items[0].clone(),
+            NonBlankString::from("a"),
+            SimulationWaypointSchedule::PassBy,
+        );
         builder.push_waypoint(
             path_items[1].clone(),
+            NonBlankString::from("b"),
             SimulationWaypointSchedule::Stop {
                 arrival_at: Some(300),
                 stop_for: 0,
@@ -278,6 +284,7 @@ mod tests {
         {
             builder.push_waypoint(
                 path_items[i].clone(),
+                NonBlankString::from(i.to_string()),
                 SimulationWaypointSchedule::Stop {
                     arrival_at: *arrival,
                     stop_for: 0,
@@ -285,12 +292,12 @@ mod tests {
                 },
             );
         }
-        builder.set_power_restriction(0, 2, "blackout".to_owned());
-        builder.set_power_restriction(1, 3, "reduced".to_owned());
-        builder.set_power_restriction(3, 4, "normal".to_owned());
-        builder.set_margin(0, 2, MarginValue::Percentage(10.0));
-        builder.set_margin(2, 4, MarginValue::MinPer100Km(50.0));
-        builder.set_margin(1, 3, MarginValue::Percentage(5.0));
+        builder.set_power_restriction("0", "2", "blackout".to_owned());
+        builder.set_power_restriction("1", "3", "reduced".to_owned());
+        builder.set_power_restriction("3", "4", "normal".to_owned());
+        builder.set_margin("0", "2", MarginValue::Percentage(10.0));
+        builder.set_margin("2", "4", MarginValue::MinPer100Km(50.0));
+        builder.set_margin("1", "3", MarginValue::Percentage(5.0));
 
         let sim_consist = builder.simulation_consist.clone();
         let sim_key = SimulationKey(
@@ -409,10 +416,12 @@ mod tests {
         );
         builder.push_waypoint(
             PathWaypointAlternatives::from_iter([]),
+            NonBlankString::from("a"),
             SimulationWaypointSchedule::PassBy,
         );
         builder.push_waypoint(
             PathWaypointAlternatives::from_iter([]),
+            NonBlankString::from("b"),
             SimulationWaypointSchedule::Stop {
                 arrival_at: Some(300),
                 stop_for: 0,

--- a/editoast/core_task/src/lib.rs
+++ b/editoast/core_task/src/lib.rs
@@ -11,7 +11,6 @@ pub use envs::pathfinding::PathfindingConsist;
 pub use envs::pathfinding::PathfindingConstraints;
 pub use envs::pathfinding::PathfindingEnv;
 pub use envs::pathfinding::PathfindingTrain;
-pub use envs::simulation::PathWaypointIndex;
 pub use envs::simulation::SimulationConsist;
 pub use envs::simulation::SimulationEnv;
 pub use envs::simulation::SimulationOutput;

--- a/editoast/schemas/src/primitives/non_blank_string.rs
+++ b/editoast/schemas/src/primitives/non_blank_string.rs
@@ -1,3 +1,4 @@
+use std::borrow::Borrow;
 use std::fmt::Display;
 use std::ops::Deref;
 use std::ops::DerefMut;
@@ -81,6 +82,18 @@ impl Default for NonBlankString {
 impl AsRef<str> for NonBlankString {
     fn as_ref(&self) -> &str {
         self.0.as_str()
+    }
+}
+
+impl Borrow<str> for NonBlankString {
+    fn borrow(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Borrow<String> for NonBlankString {
+    fn borrow(&self) -> &String {
+        &self.0
     }
 }
 

--- a/editoast/src/generated_data/signal.rs
+++ b/editoast/src/generated_data/signal.rs
@@ -30,7 +30,7 @@ fn find_sprite_id(sprite_config: &SpriteConfigs, logical_signal: &LogicalSignal)
     let sprite_config = sprite_config.get(&logical_signal.signaling_system)?;
     'sprite: for conditional_sprite in &sprite_config.sprites {
         for (cond_key, cond_value) in &conditional_sprite.conditions {
-            match logical_signal.settings.get(&cond_key.clone().into()) {
+            match logical_signal.settings.get(cond_key) {
                 Some(value) if &value.0 == cond_value => continue,
                 _ => continue 'sprite,
             }


### PR DESCRIPTION
The API to set up waypoints, power restrictions and margins is cumbersome to deal with because it lets the client deal with indexes. Let’s have an internal map keeping tracks of names for inserted waypoints, names that can be reused when setting power restrictions and margins. These names already exists anyway in the [Timetable API v2](https://osrd.fr/en/docs/reference/design-docs/timetable/#modifiable-fields).

🔍 The PR is split in 4 commits for ease of review, but will be squashed into one commit before merge.
⚠️ This PR targets the PR #14100 which is not yet merged.