### PR TITLE
e2e: add start new query steps for stdcm tests

### DIFF
--- a/front/tests/03-stdcm/001-stdcm.spec.ts
+++ b/front/tests/03-stdcm/001-stdcm.spec.ts
@@ -5,7 +5,7 @@ import {
   fastRollingStockName,
 } from './../assets/constants/project-const';
 import { CONFLICT_ARRIVAL_TIME } from './../assets/constants/stdcm-const';
-import test from './../page-object-fixture';
+import test, { createStdcmTab } from './../page-object-fixture';
 import { waitForInfraStateToBeCached } from './../utils';
 import { getInfra, setTowedRollingStock } from './../utils/api-utils';
 import type { ConsistFields } from './../utils/types';
@@ -61,6 +61,7 @@ test.describe('@stdcm', () => {
 
   /** *************** Test 2 **************** */
   test('@smoke Launch STDCM simulation with all stops', async ({
+    page,
     consistSection,
     originSection,
     destinationSection,
@@ -97,6 +98,26 @@ test.describe('@stdcm', () => {
         validSimulationNumber: 1,
       });
       await stdcmSimulationResultPage.verifyTableData('./tests/assets/stdcm/stdcm-all-stops.json');
+    });
+
+    await test.step('Retain simulation and start new query without data', async () => {
+      await stdcmSimulationResultPage.retainSimulation();
+
+      const [newPage] = await Promise.all([
+        page.context().waitForEvent('page'),
+        stdcmSimulationResultPage.startNewQueryWithoutData(),
+      ]);
+      await newPage.bringToFront();
+      await newPage.waitForLoadState('domcontentloaded');
+      const {
+        consistSection: newConsistSection,
+        originSection: newOriginSection,
+        destinationSection: newDestinationSection,
+      } = createStdcmTab(newPage);
+
+      await newConsistSection.verifyDefaultConsistFields();
+      await newOriginSection.verifyDefaultOriginFields();
+      await newDestinationSection.verifyDefaultDestinationFields();
     });
   });
 

--- a/front/tests/03-stdcm/003-stdcm-linked-train.spec.ts
+++ b/front/tests/03-stdcm/003-stdcm-linked-train.spec.ts
@@ -1,10 +1,11 @@
 import type { Infra, TowedRollingStock } from 'common/api/osrdEditoastApi';
 
 import { fastRollingStockName } from './../assets/constants/project-const';
-import test from './../page-object-fixture';
+import test, { createStdcmTab } from './../page-object-fixture';
 import { waitForInfraStateToBeCached } from './../utils';
 import { getInfra, setTowedRollingStock } from './../utils/api-utils';
 import type { ConsistFields } from './../utils/types';
+import { DEFAULT_DETAILS } from '../assets/constants/stdcm-const';
 
 const fastRollingStockPrefilledValues = {
   tonnage: '190',
@@ -38,6 +39,7 @@ test.describe('@stdcm @stdcm-linked-train', () => {
 
   /** *************** Test 1 **************** */
   test('Verify STDCM anterior linked train', async ({
+    page,
     consistSection,
     linkedTrainSection,
     destinationSection,
@@ -72,6 +74,34 @@ test.describe('@stdcm @stdcm-linked-train', () => {
     await test.step('Retain + download simulation PDF', async () => {
       await stdcmSimulationResultPage.retainSimulation();
       await stdcmSimulationResultPage.downloadSimulation(testInfo.outputDir);
+    });
+
+    await test.step('Start new query with data', async () => {
+      const [newPage] = await Promise.all([
+        page.context().waitForEvent('page'),
+        stdcmSimulationResultPage.startNewQueryWithData(),
+      ]);
+
+      await newPage.bringToFront();
+      await newPage.waitForLoadState('domcontentloaded');
+
+      const {
+        consistSection: newConsistSection,
+        originSection: newOriginSection,
+        viaSection: newViaSection,
+        destinationSection: newDestinationSection,
+      } = createStdcmTab(newPage);
+      await newConsistSection.verifyConsistDetails({
+        tractionEngine: fastRollingStockName,
+        towedRollingStock: createdTowedRollingStock.name,
+        tonnage: `${Number(fastRollingStockPrefilledValues.tonnage) + Number(towedRollingStockPrefilledValues.tonnage)}`,
+        length: `${Number(towedRollingStockPrefilledValues.length) + Number(fastRollingStockPrefilledValues.length)}`,
+        maxSpeed: DEFAULT_DETAILS.maxSpeed,
+        speedLimitTag: DEFAULT_DETAILS.speedLimitTag,
+      });
+      await newOriginSection.verifyOriginDetails();
+      await newDestinationSection.verifyDestinationDetails();
+      await newViaSection.verifyViaDetails();
     });
   });
 

--- a/front/tests/page-object-fixture.ts
+++ b/front/tests/page-object-fixture.ts
@@ -69,6 +69,19 @@ type Fixtures = {
   secondScenarioTimetableSection: ScenarioTimetableSection;
 };
 
+/**
+ * Factory used when you obtain a stdcm Page dynamically (new tab via waitForEvent('page')).
+ */
+export function createStdcmTab(page: Page) {
+  return {
+    page,
+    consistSection: new ConsistSection(page),
+    originSection: new OriginSection(page),
+    viaSection: new ViaSection(page),
+    destinationSection: new DestinationSection(page),
+  };
+}
+
 const test = testWithLogging.extend<Fixtures>({
   // Operational studies
   operationalStudiesPage: async ({ page }, use) => {

--- a/front/tests/pages/stdcm/consist-section.ts
+++ b/front/tests/pages/stdcm/consist-section.ts
@@ -31,7 +31,7 @@ class ConsistSection {
       this.lengthField,
       this.maxSpeedField,
     ];
-    for (const field of emptyFields) await expect(field).toHaveValue('');
+    await Promise.all(emptyFields.map((field) => expect(field).toHaveValue('')));
     await expect(this.speedLimitTagField).toHaveValue(DEFAULT_DETAILS.speedLimitTag);
   }
 
@@ -110,6 +110,21 @@ class ConsistSection {
       await this.speedLimitTagField.selectOption(speedLimitTag);
       await expect(this.speedLimitTagField).toHaveValue(speedLimitTag);
     }
+  }
+
+  async verifyConsistDetails(consistFields: ConsistFields) {
+    const fieldMap: Array<[keyof ConsistFields, Locator]> = [
+      ['tractionEngine', this.tractionEngineField],
+      ['towedRollingStock', this.towedRollingStockField],
+      ['tonnage', this.tonnageField],
+      ['length', this.lengthField],
+      ['maxSpeed', this.maxSpeedField],
+      ['speedLimitTag', this.speedLimitTagField],
+    ];
+
+    await Promise.all(
+      fieldMap.map(([key, locator]) => expect(locator).toHaveValue(consistFields[key] ?? ''))
+    );
   }
 
   // Set consist values

--- a/front/tests/pages/stdcm/destination-section.ts
+++ b/front/tests/pages/stdcm/destination-section.ts
@@ -132,6 +132,14 @@ class DestinationSection extends STDCMPage {
     await expect(this.destinationArrival).toHaveValue(arrivalType);
   }
 
+  async verifyDestinationDetails() {
+    const { chValue, arrivalType } = DESTINATION_DETAILS;
+
+    await expect(this.destinationCiField).toHaveValue(CI_SUGGESTIONS.south[1]);
+    await expect(this.dynamicDestinationCh).toHaveValue(chValue);
+    await expect(this.destinationArrival).toHaveValue(arrivalType.default);
+  }
+
   async clearDestination(): Promise<void> {
     await this.clearButton.click();
 

--- a/front/tests/pages/stdcm/origin-section.ts
+++ b/front/tests/pages/stdcm/origin-section.ts
@@ -1,6 +1,7 @@
 import { expect, type Locator, type Page } from '@playwright/test';
 
 import STDCMPage from './stdcm-page';
+import LINKED_TRAIN_DETAILS from '../../assets/constants/linked-train-const';
 import {
   CI_SUGGESTIONS,
   DEFAULT_DETAILS,
@@ -45,6 +46,21 @@ class OriginSection extends STDCMPage {
     await expect(this.toleranceOriginArrival).toHaveValue(tolerance);
   }
 
+  async verifyOriginDetails() {
+    const {
+      dynamicOriginCi,
+      dynamicOriginCh,
+      originArrival,
+      dateOriginArrival,
+      timeOriginArrival,
+    } = LINKED_TRAIN_DETAILS.anterior;
+    await expect(this.originCiField).toHaveValue(dynamicOriginCi);
+    await expect(this.originChField).toHaveValue(dynamicOriginCh);
+    await expect(this.originArrival).toHaveValue(originArrival);
+    await expect(this.dateOriginArrival).toHaveValue(dateOriginArrival);
+    await expect(this.timeOriginArrival).toHaveValue(timeOriginArrival);
+    await expect(this.toleranceOriginArrival).toHaveValue('-15/+15');
+  }
   // Verify the origin suggestions when searching for north
   private async verifyOriginNorthSuggestions() {
     await this.verifySuggestions(CI_SUGGESTIONS.north);

--- a/front/tests/pages/stdcm/simulation-results-page.ts
+++ b/front/tests/pages/stdcm/simulation-results-page.ts
@@ -112,6 +112,14 @@ class SimulationResultPage {
     await expect(this.startNewQueryWithDataButton).toBeVisible();
   }
 
+  async startNewQueryWithData() {
+    await this.startNewQueryWithDataButton.click();
+  }
+
+  async startNewQueryWithoutData() {
+    await this.startNewQueryButton.click();
+  }
+
   async downloadSimulation(downloadDir: string): Promise<void> {
     await expect(this.downloadLink).toBeVisible();
 

--- a/front/tests/pages/stdcm/via-section.ts
+++ b/front/tests/pages/stdcm/via-section.ts
@@ -2,6 +2,7 @@ import { expect, type Locator, type Page } from '@playwright/test';
 
 import STDCMPage from './stdcm-page';
 import {
+  CI_SUGGESTIONS,
   DEFAULT_DETAILS,
   VIA_STOP_TIMES,
   VIA_STOP_TYPES,
@@ -131,6 +132,14 @@ class ViaSection extends STDCMPage {
       default:
         throw new Error(`Unsupported viaSearch value: ${ciSearchText}`);
     }
+  }
+
+  async verifyViaDetails(viaNumber: number = 1) {
+    await expect(this.getViaCI(viaNumber)).toHaveValue(CI_SUGGESTIONS.north[1]);
+    await expect(this.getViaType(viaNumber)).toHaveValue(VIA_STOP_TYPES.DRIVER_SWITCH);
+    await expect(this.getViaStopTime(viaNumber)).toHaveValue(
+      VIA_STOP_TIMES.driverSwitch.validInput
+    );
   }
 }
 


### PR DESCRIPTION
In stdcm tests don't test the buttons  `Start a new query` and `Start a new query from the current one` so I added the missing steps in different tests 