### PR TITLE
docker: drop sh for s3 healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,8 +100,9 @@ services:
       test:
         [
           "CMD",
-          "sh", "-c",
-          "curl -f http://localhost:9000/health && curl -f http://localhost:9001/rustfs/console/health"
+          "curl", "-f",
+          "http://localhost:9000/health",
+          "http://localhost:9001/rustfs/console/health",
         ]
       interval: 30s
       timeout: 10s


### PR DESCRIPTION
For some reason, this check always fail for me. I'm not sure exactly why: running the command via `docker compose exec` works fine. Weirdly, removing the sh(1) invocation seems to fix it. Maybe some kind of argument escaping issue?

Anyways, curl(1) can check a sequence of URLs, so let's just do that since it's simpler regardless.