### PR TITLE
editoast: fix operational point projection

### DIFF
--- a/editoast/src/views/projection.rs
+++ b/editoast/src/views/projection.rs
@@ -459,7 +459,8 @@ pub struct TrainToProjectOnOperationalPoint {
 }
 
 impl TrainToProjectOnOperationalPoint {
-    fn new<T: TrainScheduleLike>(ts: &T) -> Self {
+    /// Only use the train schedule to build the projection input
+    fn new_from_input<T: TrainScheduleLike>(ts: &T) -> Self {
         let stops_input: HashMap<_, _> = ts
             .schedule()
             .iter()
@@ -519,11 +520,85 @@ impl TrainToProjectOnOperationalPoint {
         }
     }
 
-    fn new_from_simulation<T: TrainScheduleLike>(ts: &T, sim: simulation::Response) -> Self {
-        let simulation::Response::Success(SimulationResponseSuccess { final_output, .. }) = sim
+    /// Use the train schedule to build the projection and complete the last point with simulation information
+    fn new_from_input_and_completed<T: TrainScheduleLike>(
+        ts: &T,
+        sim: SimulationResponseSuccess,
+    ) -> Self {
+        let mut input_only = Self::new_from_input(ts);
+
+        let Some((last_path_item_index, last_path_item_id, last_path_item_op_ref)) = ts
+            .path()
+            .iter()
+            .enumerate()
+            .rev()
+            .find_map(|(path_item_index, path_item)| match &path_item.location {
+                PathItemLocation::OperationalPointPartReference(op_ref) => Some((
+                    path_item_index,
+                    path_item.id.clone(),
+                    op_ref.operational_point.clone(),
+                )),
+                PathItemLocation::TrackOffset(_) => None,
+            })
         else {
-            return TrainToProjectOnOperationalPoint::new(ts);
+            return input_only;
         };
+
+        let last_scheduled_op_ref = &input_only.refs.last().unwrap().op_ref;
+        if last_scheduled_op_ref == &last_path_item_op_ref {
+            // The last operational point is already present
+            return input_only;
+        }
+
+        let stop_for = ts
+            .schedule()
+            .iter()
+            .rfind(|schedule_item| schedule_item.at == last_path_item_id)
+            .and_then(|schedule_item| schedule_item.stop_for)
+            .map(|stop_for| stop_for.num_milliseconds() as u64)
+            .unwrap_or_default();
+
+        let last_scheduled_op_index = ts
+            .path()
+            .iter()
+            .rposition(|path_item| match &path_item.location {
+                PathItemLocation::OperationalPointPartReference(op_ref) => {
+                    &op_ref.operational_point == last_scheduled_op_ref
+                }
+                _ => false,
+            })
+            .unwrap();
+
+        // `last_schedule_op_sim_time - last_schedule_op_time` is how off the simulation is
+        // compared to the time from the input. We use this value to offset the simulated time at
+        // the last operational point `last_op_sim_time`, to align the simulation with the input
+        // curve.
+        let last_op_sim_time = sim.final_output.report_train.path_item_times[last_path_item_index];
+        let last_schedule_op_time = input_only.refs.last().unwrap().arrival_time;
+        let last_schedule_op_sim_time =
+            sim.final_output.report_train.path_item_times[last_scheduled_op_index];
+
+        input_only.refs.push(OperationalPointRefAndTime {
+            arrival_time: last_op_sim_time + last_schedule_op_time - last_schedule_op_sim_time,
+            stop_for,
+            op_ref: last_path_item_op_ref,
+        });
+        input_only
+    }
+
+    /// Use the train simulation to build the projection input
+    fn new_from_simulation<T: TrainScheduleLike>(ts: &T, sim: simulation::Response) -> Self {
+        let simulation::Response::Success(sim) = sim else {
+            return Self::new_from_input(ts);
+        };
+        let respect_times = sim
+            .path_item_respect_times(ts)
+            .into_iter()
+            .all(|path_item| path_item);
+        if !respect_times {
+            return Self::new_from_input_and_completed(ts, sim);
+        }
+
         let stops_input: HashMap<_, _> = ts
             .schedule()
             .iter()
@@ -534,7 +609,7 @@ impl TrainToProjectOnOperationalPoint {
                     .map(|stop_for| (&schedule.at, stop_for.num_milliseconds() as u64))
             })
             .collect();
-        let CompleteReportTrain { report_train, .. } = final_output;
+        let CompleteReportTrain { report_train, .. } = sim.final_output;
         let space_time_curve = Some(SpaceTimeCurve {
             positions: report_train.positions,
             times: report_train.times,
@@ -771,7 +846,7 @@ pub fn compute_projected_train_path_op_without_simulation<T: TrainScheduleLike>(
     train_schedules
         .iter()
         .map(|train_schedule| {
-            let train_to_project = TrainToProjectOnOperationalPoint::new(train_schedule);
+            let train_to_project = TrainToProjectOnOperationalPoint::new_from_input(train_schedule);
             Arc::new(project_train_path_op(
                 &train_to_project,
                 path_item_cache,

--- a/editoast/src/views/projection.rs
+++ b/editoast/src/views/projection.rs
@@ -658,29 +658,42 @@ pub async fn compute_projected_train_path_op<T: TrainScheduleLike>(
     )
     .await?;
 
+    struct ComputeContext<'a, T> {
+        indexes: Vec<usize>,
+        train_schedule: &'a T,
+        simulation: simulation::Response,
+    }
+
     let mut to_compute = HashMap::new();
-    for ((idx, ts), (sim, _)) in train_schedules
+    for ((idx, train_schedule), (simulation, _)) in train_schedules
         .iter()
         .enumerate()
         .zip(simulations.into_iter())
     {
         to_compute
-            .entry(Arc::as_ptr(&sim))
-            .or_insert((vec![], ts, Arc::unwrap_or_clone(sim)))
-            .0
+            .entry(Arc::as_ptr(&simulation))
+            .or_insert(ComputeContext {
+                indexes: vec![],
+                train_schedule,
+                simulation: Arc::unwrap_or_clone(simulation),
+            })
+            .indexes
             .push(idx);
     }
 
     let mut results = vec![Arc::default(); train_schedules.len()];
-    for (indexes, ts, sim) in to_compute.into_values() {
-        let train_to_project = TrainToProjectOnOperationalPoint::new_from_simulation(ts, sim);
+    for context in to_compute.into_values() {
+        let train_to_project = TrainToProjectOnOperationalPoint::new_from_simulation(
+            context.train_schedule,
+            context.simulation,
+        );
         let curves = Arc::new(project_train_path_op(
             &train_to_project,
             path_item_cache,
             &operational_points_projection,
         ));
 
-        for index in indexes {
+        for index in context.indexes {
             results[index] = curves.clone();
         }
     }


### PR DESCRIPTION
Closes #14857

See #14863 for the track projection fix

~trains that do not respect times are thus projected as not-simulated. Contrary to #14863 this does not display the segment to the last path item if it doesn't have an arrival time. This could be fixed in another pull request.~

~I tried using `extract_curve_for_invalid_train_with_sim` but ended up with weird visual glitches on the curve when the train schedule has a long stop in the middle of its path... probably because `TrainToProjectOnOperationalPoint.refs` relies on the path item times.~

---

example where "a" is valid:

<img width="1355" height="572" alt="screen-20260128153940" src="https://github.com/user-attachments/assets/d05ea7f7-b013-4a41-9374-58d4cd1b1e24" />

---

example where "a" is invalid:

<img width="1355" height="572" alt="screen-20260128152324" src="https://github.com/user-attachments/assets/9fa5c7b1-46e9-4f1d-9599-bf77509e42f8" />