### PR TITLE
e2e: add e2e test for timetable export

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TimetableSelectionToolbar.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TimetableSelectionToolbar.tsx
@@ -50,6 +50,7 @@ const TimetableSelectionToolbar = ({
       {selectedTimetableItemIds.length > 0 && (
         <>
           <button
+            data-testid="export-selection-button"
             className="export-selection-button"
             title={t('timetable.exportSelection')}
             onClick={handleExportTimetableItems}

--- a/front/tests/01-home/001-home-page.spec.ts
+++ b/front/tests/01-home/001-home-page.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 
 import test from './../page-object-fixture';
-import readJsonFile from '../utils/file-utils';
+import { readJsonFile } from '../utils/file-utils';
 import type { FlatTranslations } from '../utils/types';
 
 const frTranslations: { applications: FlatTranslations } = readJsonFile(

--- a/front/tests/02-operational-studies/management/001-project-management.spec.ts
+++ b/front/tests/02-operational-studies/management/001-project-management.spec.ts
@@ -2,7 +2,7 @@ import type { Project } from 'common/api/osrdEditoastApi';
 
 import test from '../../page-object-fixture';
 import { generateUniqueName } from '../../utils';
-import readJsonFile from '../../utils/file-utils';
+import { readJsonFile } from '../../utils/file-utils';
 import { createProject } from '../../utils/setup-utils';
 import { deleteProject } from '../../utils/teardown-utils';
 import type { ProjectData } from '../../utils/types';

--- a/front/tests/02-operational-studies/management/002-study-management.spec.ts
+++ b/front/tests/02-operational-studies/management/002-study-management.spec.ts
@@ -6,7 +6,7 @@ import test from '../../page-object-fixture';
 import { generateUniqueName } from '../../utils';
 import { getProject } from '../../utils/api-utils';
 import { formatDateToDayMonthYear } from '../../utils/date-utils';
-import readJsonFile from '../../utils/file-utils';
+import { readJsonFile } from '../../utils/file-utils';
 import { createStudy } from '../../utils/setup-utils';
 import { deleteStudy } from '../../utils/teardown-utils';
 import type { StudyData, StudyFrTranslations } from '../../utils/types';

--- a/front/tests/02-operational-studies/management/003-scenario-management.spec.ts
+++ b/front/tests/02-operational-studies/management/003-scenario-management.spec.ts
@@ -18,7 +18,7 @@ import {
   getStudy,
   setElectricalProfile,
 } from '../../utils/api-utils';
-import readJsonFile from '../../utils/file-utils';
+import { readJsonFile } from '../../utils/file-utils';
 import createScenario from '../../utils/scenario';
 import { deleteScenario } from '../../utils/teardown-utils';
 import type { ScenarioData } from '../../utils/types';

--- a/front/tests/02-operational-studies/nge/001-osrd-nge.spec.ts
+++ b/front/tests/02-operational-studies/nge/001-osrd-nge.spec.ts
@@ -7,7 +7,7 @@ import {
 import test from '../../page-object-fixture';
 import { generateUniqueName, waitForInfraStateToBeCached } from '../../utils';
 import { getInfra, getProject, getStudy } from '../../utils/api-utils';
-import readJsonFile from '../../utils/file-utils';
+import { readJsonFile } from '../../utils/file-utils';
 import createScenario from '../../utils/scenario';
 import sendTrains from '../../utils/send-trains';
 import { deleteScenario } from '../../utils/teardown-utils';

--- a/front/tests/02-operational-studies/nge/002-nge-osrd.spec.ts
+++ b/front/tests/02-operational-studies/nge/002-nge-osrd.spec.ts
@@ -9,7 +9,7 @@ import {
 import test from '../../page-object-fixture';
 import { generateUniqueName, waitForInfraStateToBeCached } from '../../utils';
 import { getInfra, getProject, getStudy } from '../../utils/api-utils';
-import readJsonFile from '../../utils/file-utils';
+import { readJsonFile } from '../../utils/file-utils';
 import createScenario from '../../utils/scenario';
 import { deleteScenario } from '../../utils/teardown-utils';
 import type { CommonTranslations, TimetableFilterTranslations } from '../../utils/types';

--- a/front/tests/02-operational-studies/paced-trains/001-paced-train-management.spec.ts
+++ b/front/tests/02-operational-studies/paced-trains/001-paced-train-management.spec.ts
@@ -26,7 +26,7 @@ import test from '../../page-object-fixture';
 import { waitForInfraStateToBeCached } from '../../utils';
 import { getInfra } from '../../utils/api-utils';
 import { cleanWhitespace } from '../../utils/data-normalizer';
-import readJsonFile from '../../utils/file-utils';
+import { readJsonFile } from '../../utils/file-utils';
 import createScenario from '../../utils/scenario';
 import sendTrains from '../../utils/send-trains';
 import { deleteScenario } from '../../utils/teardown-utils';

--- a/front/tests/02-operational-studies/paced-trains/002-paced-train-exceptions.spec.ts
+++ b/front/tests/02-operational-studies/paced-trains/002-paced-train-exceptions.spec.ts
@@ -12,7 +12,7 @@ import { ADDED_EXCEPTION_MENU_BUTTONS } from '../../assets/paced-train/const';
 import test from '../../page-object-fixture';
 import { generateUniqueName, waitForInfraStateToBeCached } from '../../utils';
 import { getInfra, getProject, getStudy } from '../../utils/api-utils';
-import readJsonFile from '../../utils/file-utils';
+import { readJsonFile } from '../../utils/file-utils';
 import createScenario from '../../utils/scenario';
 import sendTrains from '../../utils/send-trains';
 import { deleteScenario } from '../../utils/teardown-utils';

--- a/front/tests/02-operational-studies/paced-trains/003-paced-train-occurrence-edition.spec.ts
+++ b/front/tests/02-operational-studies/paced-trains/003-paced-train-occurrence-edition.spec.ts
@@ -17,7 +17,7 @@ import {
 import test from '../../page-object-fixture';
 import { generateUniqueName, waitForInfraStateToBeCached } from '../../utils';
 import { getInfra, getProject, getStudy } from '../../utils/api-utils';
-import readJsonFile from '../../utils/file-utils';
+import { readJsonFile } from '../../utils/file-utils';
 import createScenario from '../../utils/scenario';
 import sendTrains from '../../utils/send-trains';
 import { deleteScenario } from '../../utils/teardown-utils';

--- a/front/tests/02-operational-studies/simulation-result/001-get-manchette.spec.ts
+++ b/front/tests/02-operational-studies/simulation-result/001-get-manchette.spec.ts
@@ -22,7 +22,7 @@ import {
 } from '../../pages/operational-studies/std-manchette';
 import { generateUniqueName, waitForInfraStateToBeCached } from '../../utils';
 import { getInfra, getProject, getStudy } from '../../utils/api-utils';
-import readJsonFile from '../../utils/file-utils';
+import { readJsonFile } from '../../utils/file-utils';
 import { verifyWaypointsData } from '../../utils/manchette';
 import createScenario from '../../utils/scenario';
 import sendTrains from '../../utils/send-trains';

--- a/front/tests/02-operational-studies/timetable/001-train-timetable.spec.ts
+++ b/front/tests/02-operational-studies/timetable/001-train-timetable.spec.ts
@@ -19,7 +19,7 @@ import {
 import test from '../../page-object-fixture';
 import { waitForInfraStateToBeCached } from '../../utils';
 import { getInfra, getProject, getScenario, getStudy } from '../../utils/api-utils';
-import readJsonFile from '../../utils/file-utils';
+import { readJsonFile } from '../../utils/file-utils';
 import type { CommonTranslations, TimetableFilterTranslations } from '../../utils/types';
 
 const frScenarioTranslations: TimetableFilterTranslations = readJsonFile<{

--- a/front/tests/02-operational-studies/timetable/002-train-timetable-filter.spec.ts
+++ b/front/tests/02-operational-studies/timetable/002-train-timetable-filter.spec.ts
@@ -27,7 +27,7 @@ import {
 import test from '../../page-object-fixture';
 import { waitForInfraStateToBeCached } from '../../utils';
 import { getInfra, getProject, getScenario, getStudy } from '../../utils/api-utils';
-import readJsonFile from '../../utils/file-utils';
+import { readJsonFile } from '../../utils/file-utils';
 import type { CommonTranslations, TimetableFilterTranslations } from '../../utils/types';
 
 const frScenarioTranslations: TimetableFilterTranslations = readJsonFile<{

--- a/front/tests/02-operational-studies/timetable/003-train-timetable-multiselection.spec.ts
+++ b/front/tests/02-operational-studies/timetable/003-train-timetable-multiselection.spec.ts
@@ -12,7 +12,7 @@ import {
 import test from '../../page-object-fixture';
 import { generateUniqueName, waitForInfraStateToBeCached } from '../../utils';
 import { getInfra, getProject, getStudy } from '../../utils/api-utils';
-import readJsonFile from '../../utils/file-utils';
+import { readJsonFile } from '../../utils/file-utils';
 import createScenario from '../../utils/scenario';
 import sendTrains from '../../utils/send-trains';
 import { deleteScenario } from '../../utils/teardown-utils';
@@ -75,7 +75,7 @@ test.describe('@op @timetable-items @timetable-multiselection', () => {
     });
 
     await test.step('Select all timetable items', async () => {
-      await scenarioTimetableSection.selectAllTimetableItems(frTranslations, {
+      await scenarioTimetableSection.selectAllTimetableItemsAndVerifySelection(frTranslations, {
         totalPacedTrainCount: TOTAL_PACED_TRAINS,
         totalUniqueTrainCount: TOTAL_UNIQUE_TRAINS,
       });

--- a/front/tests/02-operational-studies/timetable/004-train-edition.spec.ts
+++ b/front/tests/02-operational-studies/timetable/004-train-edition.spec.ts
@@ -14,7 +14,7 @@ import {
 import test from '../../page-object-fixture';
 import { generateUniqueName, waitForInfraStateToBeCached } from '../../utils';
 import { getInfra, getProject, getStudy } from '../../utils/api-utils';
-import readJsonFile from '../../utils/file-utils';
+import { readJsonFile } from '../../utils/file-utils';
 import createScenario from '../../utils/scenario';
 import sendTrains from '../../utils/send-trains';
 import { deleteScenario } from '../../utils/teardown-utils';

--- a/front/tests/02-operational-studies/timetable/005-timetable-import-export.spec.ts
+++ b/front/tests/02-operational-studies/timetable/005-timetable-import-export.spec.ts
@@ -2,8 +2,13 @@ import type { Scenario, Project, Study, Infra } from 'common/api/osrdEditoastApi
 
 import {
   timetableItemProjectName,
+  timetableItemScenarioName,
   timetableItemStudyName,
 } from '../../assets/constants/project-const';
+import {
+  TOTAL_PACED_TRAINS,
+  TOTAL_UNIQUE_TRAINS,
+} from '../../assets/constants/timetable-items-count';
 import {
   EXPECTED_COUNTS,
   PACED_DETAILS,
@@ -11,8 +16,8 @@ import {
 } from '../../assets/constants/timetable-items-details';
 import test from '../../page-object-fixture';
 import { generateUniqueName, waitForInfraStateToBeCached } from '../../utils';
-import { getInfra, getProject, getStudy } from '../../utils/api-utils';
-import readJsonFile from '../../utils/file-utils';
+import { getInfra, getProject, getScenario, getStudy } from '../../utils/api-utils';
+import { readJsonFile } from '../../utils/file-utils';
 import createScenario from '../../utils/scenario';
 import { deleteScenario } from '../../utils/teardown-utils';
 import type { CommonTranslations, TimetableFilterTranslations } from '../../utils/types';
@@ -27,27 +32,40 @@ const frTranslations = {
   ...frCommonTranslations,
 };
 
-test.describe('@op @timetable-items @import', () => {
+test.describe('@op @timetable-items @import @export', () => {
   let project: Project;
   let study: Study;
   let scenario: Scenario;
+  let scenarioToExport: Scenario;
   let infra: Infra;
+
+  let downloadDir: string;
+  let downloadedFilePath: string;
 
   test.beforeAll('Fetch project, study and infrastructure', async () => {
     project = await getProject(timetableItemProjectName);
     study = await getStudy(project.id, timetableItemStudyName);
+    scenarioToExport = await getScenario(study.id, timetableItemScenarioName);
     infra = await getInfra();
   });
 
-  test.beforeEach('Open scenario ', async ({ page }) => {
+  test.beforeEach('Open scenario ', async ({ page, importExportPage }) => {
     await test.step('Create, open scenario and wait for infra to be loaded', async () => {
       scenario = (
-        await createScenario(generateUniqueName('import-scenario'), project.id, study.id, infra.id)
+        await createScenario(
+          generateUniqueName('import-export-scenario'),
+          project.id,
+          study.id,
+          infra.id
+        )
       ).scenario;
       await page.goto(
         `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenario.id}`
       );
       await waitForInfraStateToBeCached(infra.id);
+    });
+    await test.step('Verify timetable is empty', async () => {
+      await importExportPage.verifyTimetableIsEmpty(frTranslations.timetable.noItem);
     });
   });
 
@@ -55,24 +73,64 @@ test.describe('@op @timetable-items @import', () => {
     await deleteScenario(study.id, scenario.name);
   });
 
-  test('Verify timetable items are imported correctly', async ({
-    importPage,
+  test('@smoke Verify timetable is exported and imported correctly', async ({
+    page,
+    importExportPage,
+    timetableItemDetailSection,
+  }, testInfo) => {
+    await test.step('Open scenario to export and verify initial timetable items count', async () => {
+      await page.goto(
+        `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenarioToExport.id}`
+      );
+      await timetableItemDetailSection.verifyTotalItemsLabel(frTranslations, {
+        totalPacedTrainCount: TOTAL_PACED_TRAINS,
+        totalUniqueTrainCount: TOTAL_UNIQUE_TRAINS,
+      });
+    });
+
+    await test.step('Select all timetable items and verify selection', async () => {
+      await timetableItemDetailSection.selectAllTimetableItemsAndVerifySelection(frTranslations, {
+        totalPacedTrainCount: TOTAL_PACED_TRAINS,
+        totalUniqueTrainCount: TOTAL_UNIQUE_TRAINS,
+      });
+    });
+
+    await test.step('Export timetable items and verify download', async () => {
+      downloadDir = testInfo.outputDir;
+      downloadedFilePath = await importExportPage.exportTimetableItems(downloadDir);
+    });
+
+    await test.step('Import timetable items JSON and close dialog in the target scenario', async () => {
+      await page.goto(
+        `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenario.id}`
+      );
+      await importExportPage.openImportTimetableItemUploadDialog();
+      await importExportPage.uploadTimetableItemFile(downloadedFilePath, frTranslations.success);
+    });
+
+    await test.step('Verify timetable items count after import', async () => {
+      await timetableItemDetailSection.verifyTotalItemsLabel(frTranslations, {
+        totalPacedTrainCount: TOTAL_PACED_TRAINS,
+        totalUniqueTrainCount: TOTAL_UNIQUE_TRAINS,
+      });
+    });
+  });
+
+  test('@smoke Verify timetable items are imported correctly', async ({
+    importExportPage,
     timetableItemDetailSection,
     pacedTrainSection,
   }) => {
-    await test.step('Verify timetable is empty', async () => {
-      await importPage.verifyTimetableIsEmpty(frTranslations.timetable.noItem);
-    });
     await test.step('Import timetable items JSON and return to scenario', async () => {
-      await importPage.openImportTimetableItemUploadDialog();
-      await importPage.uploadTimetableItemFile(
+      await importExportPage.openImportTimetableItemUploadDialog();
+      await importExportPage.uploadTimetableItemFile(
         './tests/assets/operation-studies/timetable-items.json',
         frTranslations.success
       );
     });
 
     await test.step('Verify timetable items count after import', async () => {
-      await importPage.verifyTotalItemsLabel(frTranslations, EXPECTED_COUNTS);
+      await importExportPage.verifyTotalItemsLabel(frTranslations, EXPECTED_COUNTS);
     });
 
     await test.step('Verify details for valid imported paced trains', async () => {

--- a/front/tests/02-operational-studies/timetable/006-round-trips.spec.ts
+++ b/front/tests/02-operational-studies/timetable/006-round-trips.spec.ts
@@ -15,7 +15,7 @@ import {
 import test from '../../page-object-fixture';
 import { generateUniqueName, waitForInfraStateToBeCached } from '../../utils';
 import { getInfra, getProject, getStudy } from '../../utils/api-utils';
-import readJsonFile from '../../utils/file-utils';
+import { readJsonFile } from '../../utils/file-utils';
 import createScenario from '../../utils/scenario';
 import sendTrains from '../../utils/send-trains';
 import { deleteScenario } from '../../utils/teardown-utils';

--- a/front/tests/02-operational-studies/timetable/007-scenario-page-synchronization.spec.ts
+++ b/front/tests/02-operational-studies/timetable/007-scenario-page-synchronization.spec.ts
@@ -7,7 +7,7 @@ import {
 import test from '../../page-object-fixture';
 import { generateUniqueName, waitForInfraStateToBeCached } from '../../utils';
 import { getInfra, getProject, getStudy } from '../../utils/api-utils';
-import readJsonFile from '../../utils/file-utils';
+import { readJsonFile } from '../../utils/file-utils';
 import createScenario from '../../utils/scenario';
 import sendTrains from '../../utils/send-trains';
 import { deleteScenario } from '../../utils/teardown-utils';

--- a/front/tests/02-operational-studies/timetable/008-invalid-train.spec.ts
+++ b/front/tests/02-operational-studies/timetable/008-invalid-train.spec.ts
@@ -12,7 +12,7 @@ import ScenarioTimetableSection from '../../pages/operational-studies/scenario-t
 import TimeAndStopSimulationOutputs from '../../pages/operational-studies/time-stop-simulation-outputs';
 import { generateUniqueName, waitForInfraStateToBeCached } from '../../utils';
 import { getInfra, getProject, getStudy } from '../../utils/api-utils';
-import readJsonFile from '../../utils/file-utils';
+import { readJsonFile } from '../../utils/file-utils';
 import createScenario from '../../utils/scenario';
 import sendTrains from '../../utils/send-trains';
 import { deleteScenario } from '../../utils/teardown-utils';

--- a/front/tests/02-operational-studies/train-creation-tabs/003-op-times-and-stops-tab.spec.ts
+++ b/front/tests/02-operational-studies/train-creation-tabs/003-op-times-and-stops-tab.spec.ts
@@ -8,7 +8,7 @@ import test from '../../page-object-fixture';
 import { waitForInfraStateToBeCached } from '../../utils';
 import { getInfra } from '../../utils/api-utils';
 import { cleanWhitespace, cleanWhitespaceInArray } from '../../utils/data-normalizer';
-import readJsonFile from '../../utils/file-utils';
+import { readJsonFile } from '../../utils/file-utils';
 import createScenario from '../../utils/scenario';
 import { deleteScenario } from '../../utils/teardown-utils';
 import type { CellData, FlatTranslations, StationData } from '../../utils/types';

--- a/front/tests/02-operational-studies/train-creation-tabs/004-op-simulation-settings-tab.spec.ts
+++ b/front/tests/02-operational-studies/train-creation-tabs/004-op-simulation-settings-tab.spec.ts
@@ -18,7 +18,7 @@ import test from '../../page-object-fixture';
 import { waitForInfraStateToBeCached } from '../../utils';
 import { deleteApiRequest, getInfra, setElectricalProfile } from '../../utils/api-utils';
 import { cleanWhitespace } from '../../utils/data-normalizer';
-import readJsonFile from '../../utils/file-utils';
+import { readJsonFile } from '../../utils/file-utils';
 import createScenario from '../../utils/scenario';
 import { deleteScenario } from '../../utils/teardown-utils';
 import type { FlatTranslations, StationData } from '../../utils/types';

--- a/front/tests/03-stdcm/004-stdcm-missing-fields.spec.ts
+++ b/front/tests/03-stdcm/004-stdcm-missing-fields.spec.ts
@@ -10,7 +10,7 @@ import { electricRollingStockName } from './../assets/constants/project-const';
 import test from './../page-object-fixture';
 import { waitForInfraStateToBeCached } from './../utils';
 import { getInfra } from './../utils/api-utils';
-import readJsonFile from './../utils/file-utils';
+import { readJsonFile } from './../utils/file-utils';
 import type { StdcmTranslations } from './../utils/types';
 
 const frTranslations: StdcmTranslations = readJsonFile('public/locales/fr/stdcm.json');

--- a/front/tests/04-rolling-stock-editor/001-rolling-stock-editor.spec.ts
+++ b/front/tests/04-rolling-stock-editor/001-rolling-stock-editor.spec.ts
@@ -2,7 +2,7 @@ import { expect } from '@playwright/test';
 
 import { electricRollingStockName } from './../assets/constants/project-const';
 import test from './../page-object-fixture';
-import readJsonFile from './../utils/file-utils';
+import { readJsonFile } from './../utils/file-utils';
 import {
   generateUniqueName,
   verifyAndCheckInputById,

--- a/front/tests/assets/constants/mail-feedback-const.ts
+++ b/front/tests/assets/constants/mail-feedback-const.ts
@@ -1,4 +1,4 @@
-import readJsonFile from '../../utils/file-utils';
+import { readJsonFile } from '../../utils/file-utils';
 import type { StdcmTranslations } from '../../utils/types';
 
 const frTranslations: StdcmTranslations = readJsonFile('public/locales/fr/stdcm.json');

--- a/front/tests/assets/constants/simulation-sheet-const.ts
+++ b/front/tests/assets/constants/simulation-sheet-const.ts
@@ -1,5 +1,5 @@
 import { getLocalizedDateString } from '../../utils/date-utils';
-import readJsonFile from '../../utils/file-utils';
+import { readJsonFile } from '../../utils/file-utils';
 import type { FlatTranslations, PdfSimulationContent } from '../../utils/types';
 
 const frTranslations: FlatTranslations = readJsonFile<Record<string, FlatTranslations>>(

--- a/front/tests/assets/constants/timetable-items-details.ts
+++ b/front/tests/assets/constants/timetable-items-details.ts
@@ -1,4 +1,4 @@
-import readJsonFile from '../../utils/file-utils';
+import { readJsonFile } from '../../utils/file-utils';
 import type { TimetableFilterTranslations } from '../../utils/types';
 const frScenarioTranslations: TimetableFilterTranslations = readJsonFile<{
   main: TimetableFilterTranslations;

--- a/front/tests/assets/operation-studies/round-trips/round-trip-card.ts
+++ b/front/tests/assets/operation-studies/round-trips/round-trip-card.ts
@@ -1,4 +1,4 @@
-import readJsonFile from '../../../utils/file-utils';
+import { readJsonFile } from '../../../utils/file-utils';
 import type { FlatTranslations, RoundTripCardExpected } from '../../../utils/types';
 
 const frTranslations: FlatTranslations = readJsonFile<{

--- a/front/tests/assets/operation-studies/timetable-items.json
+++ b/front/tests/assets/operation-studies/timetable-items.json
@@ -10,14 +10,14 @@
           "id": "id227",
           "location": {
             "operational_point": { "uic": 8766, "secondary_code": "BV", "type": "uic" },
-            "local_track_name": null
+            "track_reference": null
           }
         },
         {
           "id": "id228",
           "location": {
             "operational_point": { "uic": 8755, "secondary_code": "BV", "type": "uic" },
-            "local_track_name": null
+            "track_reference": null
           }
         }
       ],
@@ -47,27 +47,16 @@
       }
     },
     {
-      "category": {
-        "main_category": "REGIONAL_TRAIN"
-      },
-      "comfort": "STANDARD",
-      "constraint_distribution": "MARECO",
-      "initial_speed": 33.333333333333336,
+      "train_name": "Train2",
       "labels": ["Tag-2", "WS-SES"],
-      "margins": {
-        "boundaries": ["id478"],
-        "values": ["5%", "0%"]
-      },
-      "options": {
-        "use_electrical_profiles": true,
-        "use_speed_limits_for_simulation": true
-      },
+      "rolling_stock_name": "ELECTRIC_RS_E2E",
+      "start_time": "2024-10-17T03:15:00.000Z",
       "path": [
         {
           "id": "id477",
           "location": {
             "operational_point": { "uic": 8722, "secondary_code": "BV", "type": "uic" },
-            "local_track_name": null
+            "track_reference": null
           }
         },
         {
@@ -78,19 +67,17 @@
           "id": "id498",
           "location": {
             "operational_point": { "uic": 8744, "secondary_code": "BV", "type": "uic" },
-            "local_track_name": null
+            "track_reference": null
           }
         },
         {
           "id": "id478",
           "location": {
             "operational_point": { "uic": 8788, "secondary_code": "BV", "type": "uic" },
-            "local_track_name": null
+            "track_reference": null
           }
         }
       ],
-      "power_restrictions": [],
-      "rolling_stock_name": "ELECTRIC_RS_E2E",
       "schedule": [
         {
           "at": "id498",
@@ -103,10 +90,22 @@
           "stop_for": "P0D"
         }
       ],
+      "margins": {
+        "boundaries": ["id478"],
+        "values": ["5%", "0%"]
+      },
+      "initial_speed": 33.333333333333336,
+      "comfort": "STANDARD",
+      "constraint_distribution": "MARECO",
       "speed_limit_tag": "MA90",
-      "start_time": "2024-10-17T03:15:00.000Z",
-      "train_name": "Train2",
-      "timetable_id": 597
+      "power_restrictions": [],
+      "options": {
+        "use_electrical_profiles": true,
+        "use_speed_limits_for_simulation": true
+      },
+      "category": {
+        "main_category": "REGIONAL_TRAIN"
+      }
     },
     {
       "train_name": "Train3",
@@ -122,14 +121,14 @@
           "id": "id765",
           "location": {
             "operational_point": { "uic": 8744, "secondary_code": "BV", "type": "uic" },
-            "local_track_name": null
+            "track_reference": null
           }
         },
         {
           "id": "id745",
           "location": {
             "operational_point": { "uic": 8777, "secondary_code": "BV", "type": "uic" },
-            "local_track_name": null
+            "track_reference": null
           }
         }
       ],
@@ -165,39 +164,26 @@
       }
     },
     {
-      "category": {
-        "main_category": "WORK_TRAIN"
-      },
-      "comfort": "STANDARD",
-      "constraint_distribution": "MARECO",
-      "initial_speed": 16.666666666666668,
+      "train_name": "Train4",
       "labels": ["MWS-NES", "Tag-4"],
-      "margins": {
-        "boundaries": [],
-        "values": ["0%"]
-      },
-      "options": {
-        "use_electrical_profiles": true,
-        "use_speed_limits_for_simulation": true
-      },
+      "rolling_stock_name": "ELECTRIC_RS_E2E",
+      "start_time": "2024-10-17T09:35:59.000Z",
       "path": [
         {
           "id": "id2854",
           "location": {
             "operational_point": { "uic": 8733, "secondary_code": "BV", "type": "uic" },
-            "local_track_name": null
+            "track_reference": null
           }
         },
         {
           "id": "id2855",
           "location": {
             "operational_point": { "uic": 8777, "secondary_code": "BV", "type": "uic" },
-            "local_track_name": null
+            "track_reference": null
           }
         }
       ],
-      "power_restrictions": [],
-      "rolling_stock_name": "ELECTRIC_RS_E2E",
       "schedule": [
         {
           "at": "id2855",
@@ -206,10 +192,23 @@
           "stop_for": "P0D"
         }
       ],
+      "margins": {
+        "boundaries": [],
+        "values": ["0%"]
+      },
+      "initial_speed": 16.666666666666668,
+      "comfort": "STANDARD",
+      "constraint_distribution": "MARECO",
       "speed_limit_tag": "MA100",
-      "start_time": "2024-10-17T09:35:59.000Z",
-      "train_name": "Train4",
-      "timetable_id": 597
+      "power_restrictions": [],
+      "options": {
+        "use_electrical_profiles": true,
+        "use_speed_limits_for_simulation": true
+      },
+
+      "category": {
+        "main_category": "WORK_TRAIN"
+      }
     },
     {
       "train_name": "Train5",
@@ -258,19 +257,10 @@
       "category": null
     },
     {
-      "category": null,
-      "comfort": "STANDARD",
-      "constraint_distribution": "STANDARD",
-      "initial_speed": 0,
+      "train_name": "Train6",
       "labels": ["Tag-6"],
-      "margins": {
-        "boundaries": [],
-        "values": ["0%"]
-      },
-      "options": {
-        "use_electrical_profiles": true,
-        "use_speed_limits_for_simulation": true
-      },
+      "rolling_stock_name": "IMPROBABLE_RS_E2E",
+      "start_time": "2024-10-17T12:30:00.000Z",
       "path": [
         {
           "id": "id1073",
@@ -285,8 +275,6 @@
           "location": { "track": "TH1", "offset": 3761000 }
         }
       ],
-      "power_restrictions": [],
-      "rolling_stock_name": "IMPROBABLE_RS_E2E",
       "schedule": [
         {
           "at": "id1109",
@@ -294,39 +282,38 @@
           "stop_for": "P0D"
         }
       ],
-      "start_time": "2024-10-17T12:30:00.000Z",
-      "train_name": "Train6",
-      "timetable_id": 597
-    },
-    {
-      "category": {
-        "main_category": "FREIGHT_TRAIN"
-      },
-      "comfort": "STANDARD",
-      "constraint_distribution": "MARECO",
-      "initial_speed": 27.777777777777779,
-      "labels": ["NWS-NES", "Tag-7"],
       "margins": {
         "boundaries": [],
         "values": ["0%"]
       },
+      "initial_speed": 0,
+      "comfort": "STANDARD",
+      "constraint_distribution": "STANDARD",
+      "power_restrictions": [],
       "options": {
-        "use_electrical_profiles": false,
+        "use_electrical_profiles": true,
         "use_speed_limits_for_simulation": true
       },
+      "category": null
+    },
+    {
+      "train_name": "Train7",
+      "labels": ["NWS-NES", "Tag-7"],
+      "rolling_stock_name": "ELECTRIC_RS_E2E",
+      "start_time": "2024-10-17T19:05:00.000Z",
       "path": [
         {
           "id": "b4df37d0-ffe2-4166-b7b6-8c0c5a47e9b0",
           "location": {
             "operational_point": { "uic": 8777, "secondary_code": "BV", "type": "uic" },
-            "local_track_name": null
+            "track_reference": null
           }
         },
         {
           "id": "id2659",
           "location": {
             "operational_point": { "uic": 8744, "secondary_code": "BV", "type": "uic" },
-            "local_track_name": null
+            "track_reference": null
           }
         },
         {
@@ -337,19 +324,17 @@
           "id": "id2570",
           "location": {
             "operational_point": { "uic": 8733, "secondary_code": "BV", "type": "uic" },
-            "local_track_name": null
+            "track_reference": null
           }
         },
         {
           "id": "dbc7c80b-aee0-4835-8857-63863dae2ff1",
           "location": {
             "operational_point": { "uic": 8799, "secondary_code": "BC", "type": "uic" },
-            "local_track_name": null
+            "track_reference": null
           }
         }
       ],
-      "power_restrictions": [],
-      "rolling_stock_name": "ELECTRIC_RS_E2E",
       "schedule": [
         {
           "at": "id2659",
@@ -368,10 +353,22 @@
           "stop_for": "P0D"
         }
       ],
+      "margins": {
+        "boundaries": [],
+        "values": ["0%"]
+      },
+      "initial_speed": 27.777777777777779,
+      "comfort": "STANDARD",
+      "constraint_distribution": "MARECO",
       "speed_limit_tag": "MA100",
-      "start_time": "2024-10-17T19:05:00.000Z",
-      "train_name": "Train7",
-      "timetable_id": 597
+      "power_restrictions": [],
+      "options": {
+        "use_electrical_profiles": false,
+        "use_speed_limits_for_simulation": true
+      },
+      "category": {
+        "main_category": "FREIGHT_TRAIN"
+      }
     },
     {
       "train_name": "Paced Train - Updated exception (RS)",
@@ -383,21 +380,21 @@
           "id": "id744",
           "location": {
             "operational_point": { "uic": 8733, "secondary_code": "BV", "type": "uic" },
-            "local_track_name": null
+            "track_reference": null
           }
         },
         {
           "id": "id765",
           "location": {
             "operational_point": { "uic": 8744, "secondary_code": "BV", "type": "uic" },
-            "local_track_name": null
+            "track_reference": null
           }
         },
         {
           "id": "id745",
           "location": {
             "operational_point": { "uic": 8777, "secondary_code": "BV", "type": "uic" },
-            "local_track_name": null
+            "track_reference": null
           }
         }
       ],
@@ -513,14 +510,14 @@
           "id": "a414e7d1-32a5-4f41-94b1-feb7f8876d2d",
           "location": {
             "operational_point": { "uic": 8711, "secondary_code": "BV", "type": "uic" },
-            "local_track_name": null
+            "track_reference": null
           }
         },
         {
           "id": "4131eb71-da70-4f86-a713-78d812699558",
           "location": {
             "operational_point": { "uic": 8777, "secondary_code": "BV", "type": "uic" },
-            "local_track_name": null
+            "track_reference": null
           }
         }
       ],
@@ -581,7 +578,7 @@
           "id": "8bf52569-50a5-46a5-8e62-b5626460cfba",
           "location": {
             "operational_point": { "uic": 8777, "secondary_code": "BV", "type": "uic" },
-            "local_track_name": null
+            "track_reference": null
           }
         },
         {
@@ -647,14 +644,14 @@
                   "id": "id2570",
                   "location": {
                     "operational_point": { "uic": 8733, "secondary_code": "BV", "type": "uic" },
-                    "local_track_name": null
+                    "track_reference": null
                   }
                 },
                 {
                   "id": "8369cfc6-e667-4b6b-965a-79795c94dd18",
                   "location": {
                     "operational_point": { "uic": 8799, "secondary_code": "BV", "type": "uic" },
-                    "local_track_name": null
+                    "track_reference": null
                   }
                 }
               ],
@@ -697,7 +694,7 @@
                   "id": "id2659",
                   "location": {
                     "operational_point": { "uic": 8744, "secondary_code": "BV", "type": "uic" },
-                    "local_track_name": null
+                    "track_reference": null
                   }
                 },
                 {
@@ -708,14 +705,14 @@
                   "id": "id2570",
                   "location": {
                     "operational_point": { "uic": 8733, "secondary_code": "BV", "type": "uic" },
-                    "local_track_name": null
+                    "track_reference": null
                   }
                 },
                 {
                   "id": "b174dfa7-f6e7-45d9-9545-469a64e675b9",
                   "location": {
                     "operational_point": { "uic": 8799, "secondary_code": "BC", "type": "uic" },
-                    "local_track_name": null
+                    "track_reference": null
                   }
                 }
               ],

--- a/front/tests/page-object-fixture.ts
+++ b/front/tests/page-object-fixture.ts
@@ -3,7 +3,7 @@ import type { Page } from '@playwright/test';
 import testWithLogging from './logging-fixture';
 import HomePage from './pages/home-page';
 import GetManchetteComponent from './pages/operational-studies/get-manchette-component';
-import ImportPage from './pages/operational-studies/import-page';
+import ImportExportPage from './pages/operational-studies/import-export-page';
 import NGEPage from './pages/operational-studies/nge-page';
 import OperationalStudiesPage from './pages/operational-studies/operational-studies-page';
 import PacedTrainSection from './pages/operational-studies/paced-train-section';
@@ -45,7 +45,7 @@ type Fixtures = {
   getManchetteComponent: GetManchetteComponent;
   ngePage: NGEPage;
   roundTripPage: RoundTripPage;
-  importPage: ImportPage;
+  importExportPage: ImportExportPage;
 
   // Rolling stock
   rollingStockSelector: RollingStockSelector;
@@ -163,8 +163,8 @@ const test = testWithLogging.extend<Fixtures>({
   homePage: async ({ page }, use) => {
     await use(new HomePage(page));
   },
-  importPage: async ({ page }, use) => {
-    await use(new ImportPage(page));
+  importExportPage: async ({ page }, use) => {
+    await use(new ImportExportPage(page));
   },
 
   // Second TAB fixtures for multi-tab tests

--- a/front/tests/pages/operational-studies/import-export-page.ts
+++ b/front/tests/pages/operational-studies/import-export-page.ts
@@ -1,8 +1,14 @@
 import { expect, type Locator, type Page } from '@playwright/test';
 
-import OperationalStudiesPage from './operational-studies-page';
+import ScenarioTimetableSection from './scenario-timetable-section';
+import { logger } from '../../logging-fixture';
+import {
+  assertSuggestedFilename,
+  saveDownloadToDir,
+  triggerFileDownload,
+} from '../../utils/file-utils';
 
-class ImportPage extends OperationalStudiesPage {
+class ImportExportPage extends ScenarioTimetableSection {
   private readonly importTimetableMenuButton: Locator;
   private readonly importTimetableItemButton: Locator;
   private readonly uploadFileDropzone: Locator;
@@ -35,5 +41,16 @@ class ImportPage extends OperationalStudiesPage {
     await this.uploadFileDownloadButton.click();
     await this.checkToastHasBeenLaunched(toastMessage);
   }
+
+  async exportTimetableItems(downloadDir: string): Promise<string> {
+    const download = await triggerFileDownload(this.page, this.exportTimetableItemButton);
+
+    assertSuggestedFilename(download, /^timetable.*\.json$/);
+
+    const downloadPath = await saveDownloadToDir(download, downloadDir);
+
+    logger.info(`The JSON file was successfully downloaded to: ${downloadPath}`);
+    return downloadPath;
+  }
 }
-export default ImportPage;
+export default ImportExportPage;

--- a/front/tests/pages/operational-studies/route-tab.ts
+++ b/front/tests/pages/operational-studies/route-tab.ts
@@ -1,6 +1,6 @@
 import { expect, type Locator, type Page } from '@playwright/test';
 
-import readJsonFile from '../../utils/file-utils';
+import { readJsonFile } from '../../utils/file-utils';
 import type { FlatTranslations } from '../../utils/types';
 
 const frTranslations: FlatTranslations = readJsonFile<{ manageTimetableItem: FlatTranslations }>(

--- a/front/tests/pages/operational-studies/scenario-timetable-section.ts
+++ b/front/tests/pages/operational-studies/scenario-timetable-section.ts
@@ -46,6 +46,8 @@ class ScenarioTimetableSection extends OpSimulationResultPage {
   private readonly timetableItemArrivalTime: Locator;
   private readonly timetableItemArrivalTimeLoader: Locator;
   private readonly invalidTimetableItemsReasons: Locator;
+  private readonly unselectTTimetableItemsButton: Locator;
+  readonly exportTimetableItemButton: Locator;
   private readonly trainName: Locator;
 
   constructor(page: Page) {
@@ -88,6 +90,8 @@ class ScenarioTimetableSection extends OpSimulationResultPage {
     this.timetableItemArrivalTime = page.getByTestId('timetable-item-arrival-time');
     this.timetableItemArrivalTimeLoader = page.getByTestId('arrival-time-loader');
     this.invalidTimetableItemsReasons = this.timetableItems.getByTestId('invalid-reason');
+    this.exportTimetableItemButton = page.getByTestId('export-selection-button');
+    this.unselectTTimetableItemsButton = page.getByTestId('scenarios-unselect-all-button');
     this.trainName = page.getByTestId('train-name');
   }
 
@@ -355,7 +359,14 @@ class ScenarioTimetableSection extends OpSimulationResultPage {
       .toBe(expectedArrivalTime);
   }
 
-  async selectAllTimetableItems(
+  async selectAllTimetableItems() {
+    await this.timetableSelectAllButton.click();
+    await expect(this.exportTimetableItemButton).toBeVisible();
+    await expect(this.unselectTTimetableItemsButton).toBeVisible();
+    await expect(this.deleteAllTimetableItemsButton).toBeVisible();
+  }
+
+  async selectAllTimetableItemsAndVerifySelection(
     translations: TimetableFilterTranslations & CommonTranslations,
     itemCounts: {
       totalPacedTrainCount: number;
@@ -364,7 +375,7 @@ class ScenarioTimetableSection extends OpSimulationResultPage {
   ) {
     await this.timetableSelectOptionsButton.click();
     await expect(this.timetableSelectAllButton).toBeVisible();
-    await this.timetableSelectAllButton.click();
+    await this.selectAllTimetableItems();
 
     const { totalPacedTrainCount, totalUniqueTrainCount } = itemCounts;
     await expect(this.timetableTotalItemLabel).toBeVisible();

--- a/front/tests/pages/operational-studies/scenario-timetable-section.ts
+++ b/front/tests/pages/operational-studies/scenario-timetable-section.ts
@@ -2,7 +2,7 @@ import { type Locator, type Page, expect } from '@playwright/test';
 
 import PacedTrainSection from './paced-train-section';
 import OpSimulationResultPage from './simulation-results-page';
-import readJsonFile from '../../utils/file-utils';
+import { readJsonFile } from '../../utils/file-utils';
 import type {
   CommonTranslations,
   FlatTranslations,

--- a/front/tests/pages/operational-studies/std-manchette.ts
+++ b/front/tests/pages/operational-studies/std-manchette.ts
@@ -1,4 +1,4 @@
-import readJsonFile from '../../utils/file-utils';
+import { readJsonFile } from '../../utils/file-utils';
 import { requestedPoint, type Waypoint } from '../../utils/manchette';
 import type { TimetableFilterTranslations } from '../../utils/types';
 const frScenarioTranslations: TimetableFilterTranslations = readJsonFile<{

--- a/front/tests/pages/operational-studies/time-stop-simulation-outputs.ts
+++ b/front/tests/pages/operational-studies/time-stop-simulation-outputs.ts
@@ -1,7 +1,7 @@
 import { type Locator, type Page, expect } from '@playwright/test';
 
 import { normalizeStationData } from '../../utils/data-normalizer';
-import readJsonFile from '../../utils/file-utils';
+import { readJsonFile } from '../../utils/file-utils';
 import type { FlatTranslations, StationData } from '../../utils/types';
 
 const frTranslations = readJsonFile<Record<string, FlatTranslations>>(

--- a/front/tests/pages/operational-studies/times-and-stops-tab.ts
+++ b/front/tests/pages/operational-studies/times-and-stops-tab.ts
@@ -1,7 +1,7 @@
 import { type Locator, type Page, expect } from '@playwright/test';
 
 import { cleanWhitespace } from '../../utils/data-normalizer';
-import readJsonFile from '../../utils/file-utils';
+import { readJsonFile } from '../../utils/file-utils';
 import type { FlatTranslations } from '../../utils/types';
 
 const frTranslations = readJsonFile<Record<string, FlatTranslations>>(

--- a/front/tests/pages/rolling-stock/rolling-stock-editor-page.ts
+++ b/front/tests/pages/rolling-stock/rolling-stock-editor-page.ts
@@ -2,7 +2,7 @@ import { expect, type Locator, type Page } from '@playwright/test';
 
 import RollingStockSelector from './rolling-stock-selector';
 import { fillAndCheckInputById } from '../../utils';
-import readJsonFile from '../../utils/file-utils';
+import { readJsonFile } from '../../utils/file-utils';
 import type { FlatTranslations } from '../../utils/types';
 
 type RollingStockTranslations = FlatTranslations & { categoriesOptions: FlatTranslations };

--- a/front/tests/pages/stdcm/destination-section.ts
+++ b/front/tests/pages/stdcm/destination-section.ts
@@ -6,7 +6,7 @@ import {
   DESTINATION_DETAILS,
   LIGHT_DESTINATION_DETAILS,
 } from '../../assets/constants/stdcm-const';
-import readJsonFile from '../../utils/file-utils';
+import { readJsonFile } from '../../utils/file-utils';
 import type { StdcmTranslations } from '../../utils/types';
 
 const frTranslations: StdcmTranslations = readJsonFile('public/locales/fr/stdcm.json');

--- a/front/tests/pages/stdcm/simulation-results-page.ts
+++ b/front/tests/pages/stdcm/simulation-results-page.ts
@@ -1,10 +1,12 @@
-import fs from 'fs';
-import path from 'path';
-
 import { expect, type Locator, type Page } from '@playwright/test';
 
 import { logger } from '../../logging-fixture';
-import readJsonFile from '../../utils/file-utils';
+import {
+  assertSuggestedFilename,
+  readJsonFile,
+  saveDownloadToDir,
+  triggerFileDownload,
+} from '../../utils/file-utils';
 import type { STDCMResultTableRow, StdcmTranslations } from '../../utils/types';
 
 const frTranslations: StdcmTranslations = readJsonFile('public/locales/fr/stdcm.json');
@@ -122,18 +124,11 @@ class SimulationResultPage {
   async downloadSimulation(downloadDir: string): Promise<void> {
     await expect(this.downloadLink).toBeVisible();
 
-    const [download] = await Promise.all([
-      this.page.waitForEvent('download'),
-      this.downloadLink.click(),
-    ]);
+    const download = await triggerFileDownload(this.page, this.downloadLink);
 
-    const suggestedFilename = download.suggestedFilename();
-    expect(suggestedFilename).toMatch(/^Stdcm.*\.pdf$/);
+    assertSuggestedFilename(download, /^Stdcm.*\.pdf$/);
 
-    await fs.promises.mkdir(downloadDir, { recursive: true });
-
-    const downloadPath = path.join(downloadDir, suggestedFilename);
-    await download.saveAs(downloadPath);
+    const downloadPath = await saveDownloadToDir(download, downloadDir);
 
     logger.info(`The PDF was successfully downloaded to: ${downloadPath}`);
   }

--- a/front/tests/pages/stdcm/stdcm-page.ts
+++ b/front/tests/pages/stdcm/stdcm-page.ts
@@ -1,6 +1,6 @@
 import { expect, type Locator, type Page } from '@playwright/test';
 
-import readJsonFile from '../../utils/file-utils';
+import { readJsonFile } from '../../utils/file-utils';
 import type { StdcmTranslations } from '../../utils/types';
 
 const frTranslations: StdcmTranslations = readJsonFile('public/locales/fr/stdcm.json');

--- a/front/tests/pages/stdcm/via-section.ts
+++ b/front/tests/pages/stdcm/via-section.ts
@@ -7,7 +7,7 @@ import {
   VIA_STOP_TIMES,
   VIA_STOP_TYPES,
 } from '../../assets/constants/stdcm-const';
-import readJsonFile from '../../utils/file-utils';
+import { readJsonFile } from '../../utils/file-utils';
 import type { StdcmTranslations } from '../../utils/types';
 
 const frTranslations: StdcmTranslations = readJsonFile('public/locales/fr/stdcm.json');

--- a/front/tests/utils/api-utils.ts
+++ b/front/tests/utils/api-utils.ts
@@ -31,7 +31,7 @@ import {
   infrastructureName,
 } from '../assets/constants/project-const';
 import { logger } from '../logging-fixture';
-import readJsonFile from './file-utils';
+import { readJsonFile } from './file-utils';
 
 /**
  * Initialize a new API request context with the base URL.

--- a/front/tests/utils/file-utils.ts
+++ b/front/tests/utils/file-utils.ts
@@ -1,12 +1,54 @@
 import fs from 'fs';
+import path from 'path';
+
+import { expect, type Download, type Locator, type Page } from '@playwright/test';
 
 /**
  * Read a JSON file from the specified path and returns its parsed content.
  *
  * @template T - Type of the object parsed.
- * @param path - The file path of the JSON file.
+ * @param filePath - The file path of the JSON file.
  * @returns {T} - The parsed JSON content.
  */
-export default function readJsonFile<T extends object>(path: string): T {
-  return JSON.parse(fs.readFileSync(path, 'utf8')) as T;
+export function readJsonFile<T extends object>(filePath: string): T {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8')) as T;
+}
+
+/**
+ * Save a Playwright download into a directory and return the saved file path.
+ *
+ * @param download - Playwright Download object
+ * @param downloadDir - Target directory
+ * @returns Absolute path to the saved file
+ */
+export async function saveDownloadToDir(download: Download, downloadDir: string): Promise<string> {
+  await fs.promises.mkdir(downloadDir, { recursive: true });
+
+  const downloadPath = path.join(downloadDir, download.suggestedFilename());
+  await download.saveAs(downloadPath);
+
+  return downloadPath;
+}
+
+/**
+ * Trigger a file download by clicking a locator and wait for the `download` event.
+ *
+ * @param page - The Playwright `Page` where the download is expected to happen
+ * @param locator - Locator that triggers the download when clicked
+ * @returns The Playwright `Download` object
+ */
+export async function triggerFileDownload(page: Page, locator: Locator): Promise<Download> {
+  const [download] = await Promise.all([page.waitForEvent('download'), locator.click()]);
+
+  return download;
+}
+
+/**
+ * Assert the browser-provided suggested filename matches a pattern.
+ *
+ * @param download - The Playwright `Download` object
+ * @param expected - Expected filename regex pattern
+ */
+export function assertSuggestedFilename(download: Download, expected: RegExp): void {
+  expect(download.suggestedFilename()).toMatch(expected);
 }

--- a/front/tests/utils/manchette.ts
+++ b/front/tests/utils/manchette.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
 
-import readJsonFile from './file-utils';
+import { readJsonFile } from './file-utils';
 import type { TimetableFilterTranslations } from './types';
 const frScenarioTranslations: TimetableFilterTranslations = readJsonFile<{
   main: TimetableFilterTranslations;

--- a/front/tests/utils/scenario.ts
+++ b/front/tests/utils/scenario.ts
@@ -10,7 +10,7 @@ import type {
 } from 'common/api/osrdEditoastApi';
 
 import { postApiRequest, getInfra, getProject, getStudy } from './api-utils';
-import readJsonFile from './file-utils';
+import { readJsonFile } from './file-utils';
 import type { ScenarioData } from './types';
 
 const scenarioData: ScenarioData = readJsonFile('tests/assets/operation-studies/scenario.json');

--- a/front/tests/utils/setup-utils.ts
+++ b/front/tests/utils/setup-utils.ts
@@ -20,7 +20,7 @@ import {
   createStdcmEnvironment,
 } from './api-utils';
 import { createDateInSpecialTimeZone } from './date-utils';
-import readJsonFile from './file-utils';
+import { readJsonFile } from './file-utils';
 import createScenario from './scenario';
 import sendTrains from './send-trains';
 import type { ProjectData, StudyData } from './types';


### PR DESCRIPTION
Adds an e2e test covering the timetable export flow.
The test selects all timetable items, triggers the export, verifies that a valid JSON file is downloaded successfully, and reuses the exported file in the import test