### PR TITLE
editoast: fix projection with empty secondary_code

### DIFF
--- a/editoast/schemas/src/train_schedule.rs
+++ b/editoast/schemas/src/train_schedule.rs
@@ -240,7 +240,7 @@ impl TrainSchedule {
                         OperationalPointPartReference {
                             operational_point: OperationalPointReference::Uic {
                                 uic: 8711,
-                                secondary_code: None,
+                                secondary_code: Some("BV".to_string()),
                             },
                             local_track_name: None,
                         },
@@ -259,7 +259,7 @@ impl TrainSchedule {
                         OperationalPointPartReference {
                             operational_point: OperationalPointReference::Trigram {
                                 trigram: NonBlankString::from("MWS"),
-                                secondary_code: None,
+                                secondary_code: Some("BV".to_string()),
                             },
                             local_track_name: None,
                         },

--- a/editoast/src/views/path/operational_point_cache.rs
+++ b/editoast/src/views/path/operational_point_cache.rs
@@ -1,7 +1,6 @@
 use core_client::pathfinding::InvalidPathItem;
 use core_client::pathfinding::PathfindingInputError;
 use database::DbConnection;
-use itertools::Itertools;
 use schemas::infra::OperationalPoint;
 use schemas::infra::TrackOffset;
 use schemas::primitives::NonBlankString;
@@ -229,10 +228,7 @@ impl OperationalPointCache {
                 secondary_code,
             ),
         };
-        secondary_code_filter(secondary_code.as_ref(), ops)
-            .into_iter()
-            .next()
-            .map(|op| op.obj_id.clone())
+        find_op_by_secondary_code(secondary_code.as_ref(), ops).map(|op| op.obj_id.clone())
     }
 
     /// Extract locations from path items
@@ -281,13 +277,10 @@ impl OperationalPointCache {
                         .get_from_trigram(&trigram.0)
                         .map(|op| op.collect())
                         .unwrap_or_default();
-                    let ops = secondary_code_filter(secondary_code.as_ref(), ops);
-                    let track_offsets = ops
-                        .into_iter()
-                        .flat_map(|op| {
-                            op.track_offsets_by_local_track_name(local_track_name.as_ref())
-                        })
-                        .collect_vec();
+                    let op = find_op_by_secondary_code(secondary_code.as_ref(), ops);
+                    let track_offsets = op
+                        .map(|op| op.track_offsets_by_local_track_name(local_track_name.as_ref()))
+                        .unwrap_or_default();
                     if track_offsets.is_empty() {
                         invalid_path_items.push(InvalidPathItem {
                             index,
@@ -311,13 +304,10 @@ impl OperationalPointCache {
                         .get_from_uic(*uic)
                         .map(|op| op.collect())
                         .unwrap_or_default();
-                    let ops = secondary_code_filter(secondary_code.as_ref(), ops);
-                    let track_offsets = ops
-                        .into_iter()
-                        .flat_map(|op| {
-                            op.track_offsets_by_local_track_name(local_track_name.as_ref())
-                        })
-                        .collect_vec();
+                    let op = find_op_by_secondary_code(secondary_code.as_ref(), ops);
+                    let track_offsets = op
+                        .map(|op| op.track_offsets_by_local_track_name(local_track_name.as_ref()))
+                        .unwrap_or_default();
                     if track_offsets.is_empty() {
                         invalid_path_items.push(InvalidPathItem {
                             index,
@@ -471,19 +461,16 @@ async fn retrieve_op_from_ids(
         .map_err(Into::into)
 }
 
-/// Filter operational points by secondary code
-/// If the secondary code is not provided, the original list is returned
-fn secondary_code_filter<'a>(
+/// Filter operational points by secondary code to return one unique OP
+/// since the tuple (operational_point, ch) is supposed to be unique in a given infra.
+/// If secondary_code is None, searches for an OP without sncf extension.
+/// If secondary_code is Some, searches for an OP whose sncf extension matches the given code.
+fn find_op_by_secondary_code<'a>(
     secondary_code: Option<&String>,
     ops: Vec<&'a OperationalPointModel>,
-) -> Vec<&'a OperationalPointModel> {
-    if let Some(secondary_code) = secondary_code {
-        ops.into_iter()
-            .filter(|op| &op.extensions.sncf.as_ref().unwrap().ch == secondary_code)
-            .collect()
-    } else {
-        ops
-    }
+) -> Option<&'a OperationalPointModel> {
+    ops.into_iter()
+        .find(|op| secondary_code == op.extensions.sncf.as_ref().map(|sncf| &sncf.ch))
 }
 
 fn filter_by_secondary_code_and_retrieve_op<'a>(

--- a/editoast/src/views/projection.rs
+++ b/editoast/src/views/projection.rs
@@ -1145,7 +1145,7 @@ mod tests {
     fn create_path_item_from_trigram(trigram: &str) -> OperationalPointReference {
         OperationalPointReference::Trigram {
             trigram: trigram.into(),
-            secondary_code: None,
+            secondary_code: Some("BV".to_string()),
         }
     }
 


### PR DESCRIPTION
Refactors how operational points are filtered by their secondary codes in the /project_path_op endpoint.

This change ensures deterministic behavior when filtering operational points:

- When `secondary_code` is null, it now matches only operational points with `extensions.sncf` being null
- When `secondary_code` has a value, it matches operational points where `extensions.sncf.ch` equals that value

This corrects the previous non-deterministic behavior where a null secondary_code could match any operational point with SNCF extensions, leading to random selection among multiple candidates.

Note: To fully ensure deterministic behavior across the infrastructure, we should enforce that the tuple `(operational_point, ch)` is unique within an infra (including the case where ch is null).