### PR TITLE
docker: use --fail-early for s3 curl check

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,7 +100,7 @@ services:
       test:
         [
           "CMD",
-          "curl", "-f",
+          "curl", "--fail", "--fail-early",
           "http://localhost:9000/health",
           "http://localhost:9001/rustfs/console/health",
         ]


### PR DESCRIPTION
With --fail, curl uses the last request's status code to decide whether to exit with a failure. Use --fail-early instead, which stops at the first HTTP error.

Fixes: 6279da9dea39 ("docker: drop sh for s3 healthcheck")
Suggested-by: Khoyo <khoyobegenn@gmail.com>