### PR TITLE
Allow closing GOV in input-only mode

### DIFF
--- a/front/src/modules/simulationResult/styles/_manchetteWithSpaceTimeChart.scss
+++ b/front/src/modules/simulationResult/styles/_manchetteWithSpaceTimeChart.scss
@@ -148,6 +148,7 @@
       left: 0;
       right: 0;
       border: 12px solid rgba(0, 0, 0, 0.05);
+      pointer-events: none;
       z-index: 1;
     }
   }


### PR DESCRIPTION
Enabling the “input-only” mode while the track occupancy diagram is open prevents the TOD from being closed. This PR fixes this bug.