### PR TITLE
core: move EtcsBrakeParams to osrd-mp

### DIFF
--- a/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/EtcsBrakeParamsExt.kt
+++ b/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/EtcsBrakeParamsExt.kt
@@ -1,0 +1,22 @@
+package fr.sncf.osrd.envelope_sim.etcs
+
+import fr.sncf.osrd.railjson.schema.rollingstock.RJSEtcsBrakeParams
+
+fun RJSEtcsBrakeParams.toEtcsBrakeParams(): EtcsBrakeParams =
+    EtcsBrakeParams(
+        gammaEmergency = gammaEmergency.toSpeedIntervalValueCurve(),
+        gammaService = gammaService.toSpeedIntervalValueCurve(),
+        gammaNormalService = gammaNormalService.toSpeedIntervalValueCurve(),
+        kDry = kDry.toSpeedIntervalValueCurve(),
+        kWet = kWet.toSpeedIntervalValueCurve(),
+        kNPos = kNPos.toSpeedIntervalValueCurve(),
+        kNNeg = kNNeg.toSpeedIntervalValueCurve(),
+        tTractionCutOff = tTractionCutOff,
+        tBs1 = tBs1,
+        tBs2 = tBs2,
+        tBe = tBe,
+    )
+
+fun RJSEtcsBrakeParams.RJSSpeedIntervalValueCurve.toSpeedIntervalValueCurve():
+    EtcsBrakeParams.SpeedIntervalValueCurve =
+    EtcsBrakeParams.SpeedIntervalValueCurve(boundaries = boundaries, values = values)

--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/envelope_sim/etcs/EtcsBrakeParams.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/envelope_sim/etcs/EtcsBrakeParams.kt
@@ -1,6 +1,5 @@
 package fr.sncf.osrd.envelope_sim.etcs
 
-import fr.sncf.osrd.railjson.schema.rollingstock.RJSEtcsBrakeParams
 import kotlin.math.abs
 
 /**
@@ -106,7 +105,7 @@ class EtcsBrakeParams(
         var values: DoubleArray,
     ) {
         fun getValue(speed: Double): Double {
-            assert(values.size == boundaries.size + 1)
+            require(values.size == boundaries.size + 1)
             var index = 0
             val absSpeed = abs(speed)
             for (boundary in boundaries) {
@@ -122,22 +121,3 @@ class EtcsBrakeParams(
 
 /** National Default Value: Available Adhesion. Found in Subset Appendix A.3.2 table. */
 private const val mNvavadh = 0.0
-
-fun RJSEtcsBrakeParams.toEtcsBrakeParams(): EtcsBrakeParams =
-    EtcsBrakeParams(
-        gammaEmergency = gammaEmergency.toSpeedIntervalValueCurve(),
-        gammaService = gammaService.toSpeedIntervalValueCurve(),
-        gammaNormalService = gammaNormalService.toSpeedIntervalValueCurve(),
-        kDry = kDry.toSpeedIntervalValueCurve(),
-        kWet = kWet.toSpeedIntervalValueCurve(),
-        kNPos = kNPos.toSpeedIntervalValueCurve(),
-        kNNeg = kNNeg.toSpeedIntervalValueCurve(),
-        tTractionCutOff = tTractionCutOff,
-        tBs1 = tBs1,
-        tBs2 = tBs2,
-        tBe = tBe,
-    )
-
-fun RJSEtcsBrakeParams.RJSSpeedIntervalValueCurve.toSpeedIntervalValueCurve():
-    EtcsBrakeParams.SpeedIntervalValueCurve =
-    EtcsBrakeParams.SpeedIntervalValueCurve(boundaries = boundaries, values = values)


### PR DESCRIPTION
as a dependency of `TrainPhysicsIntegrator`, which is depended on by the new simulation module

this changes asserts to requires, since kotlin multiplatform doesn't have asserts for common code for some reason:
https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/assert.html

The original `EtcsBrakeParams.kt` file is renamed to `EtcsBrakeParamsExt.kt` to fix jacoco duplicate class errors

KMP move todolist: https://github.com/OpenRailAssociation/osrd/issues/13273#issuecomment-3744411531