### PR TITLE
front: fix focus style and interaction in new table

### DIFF
--- a/front/src/modules/timesStops/DurationCell.tsx
+++ b/front/src/modules/timesStops/DurationCell.tsx
@@ -147,7 +147,7 @@ const durationReducer = (state: DurationState, action: DurationAction): Duration
         units: seconds ? secondsToUnits(seconds) : emptyUnits(),
         activeUnit: unit,
         isEditing: true,
-        hasTyped: seconds > 0,
+        hasTyped: false,
         isCreationMode: seconds === 0,
         finishedEntry: false,
         buffer: '',
@@ -197,7 +197,7 @@ const durationReducer = (state: DurationState, action: DurationAction): Duration
     case 'BACKSPACE': {
       const newState = { ...state };
       // Reset hasTyped logic akin to original
-      newState.hasTyped = newState.initialSeconds > 0;
+      newState.hasTyped = true;
 
       if (newState.finishedEntry) newState.finishedEntry = false;
 
@@ -265,7 +265,11 @@ const UnitDisplay = ({ unit, state, dispatch, startEditing, isEdited }: UnitDisp
   const focused = state.isEditing && state.activeUnit === unit;
   const baseClass = 'duration-cell-digit';
   const savedClass = !state.isEditing && isEdited ? `${baseClass}-saved` : '';
-  const focusClass = focused ? 'duration-cell-digit-focused-editing' : '';
+  const focusClass = focused
+    ? state.hasTyped
+      ? 'duration-cell-digit-focused-editing'
+      : 'duration-cell-digit-focused-initial'
+    : '';
   const letterClass =
     !state.isEditing && isEdited ? 'duration-cell-letter-saved' : 'duration-cell-letter';
 
@@ -285,7 +289,9 @@ const UnitDisplay = ({ unit, state, dispatch, startEditing, isEdited }: UnitDisp
       }}
     >
       <span className="duration-cell-digits-value">
-        {focused && <span className="duration-cell-caret" style={{ left: '100%' }} />}
+        {focused && state.hasTyped && (
+          <span className="duration-cell-caret" style={{ left: '100%' }} />
+        )}
         <span>{u.value[0]}</span>
         <span>{u.value[1]}</span>
       </span>

--- a/front/src/modules/timesStops/TimeCell.tsx
+++ b/front/src/modules/timesStops/TimeCell.tsx
@@ -23,6 +23,7 @@ type TimeState = {
   seconds: SectionState;
   focusedSection: Section | null;
   empty?: boolean;
+  hasTyped: boolean;
 };
 
 type TimeAction =
@@ -46,7 +47,9 @@ const formatSectionDigits = (str: string, section: Section): SectionState => {
   return sectionPlaceholder + sectionPlaceholder;
 };
 
-const parseTimeState = (date: Date | null): Omit<TimeState, 'focusedSection' | 'empty'> => {
+const parseTimeState = (
+  date: Date | null
+): Omit<TimeState, 'focusedSection' | 'empty' | 'hasTyped'> => {
   if (!date)
     return {
       hours: formatSectionDigits('', 'hours'),
@@ -133,6 +136,7 @@ const clampTimeState = (state: TimeState): TimeState => {
     minutes: clampSection('minutes'),
     seconds: clampSection('seconds'),
     focusedSection: state.focusedSection,
+    hasTyped: state.hasTyped,
   };
 };
 
@@ -306,6 +310,7 @@ const handleBlurred = (state: TimeState): TimeState => {
       seconds: 'ss',
       focusedSection: null,
       empty: true,
+      hasTyped: false,
     };
   }
   return clampTimeState({
@@ -318,11 +323,13 @@ const handleFocused = (state: TimeState, section: Section): TimeState => ({
   ...state,
   focusedSection: section,
   empty: false,
+  hasTyped: state.empty || false,
 });
 
 const handleSectionClicked = (state: TimeState, section: Section): TimeState => ({
   ...state,
   focusedSection: section,
+  hasTyped: state.empty || false,
 });
 
 const handleHorizontalArrow = (state: TimeState, direction: 'left' | 'right'): TimeState => {
@@ -354,6 +361,7 @@ const handleHorizontalArrow = (state: TimeState, direction: 'left' | 'right'): T
   return {
     ...state,
     focusedSection: newFocusedSection(),
+    hasTyped: false,
   };
 };
 
@@ -362,9 +370,9 @@ const handleHorizontalArrow = (state: TimeState, direction: 'left' | 'right'): T
 const timeReducer = (state: TimeState, action: TimeAction): TimeState => {
   switch (action.type) {
     case 'DIGIT_PRESSED':
-      return handleDigitPressed(state, action.digit);
+      return { ...handleDigitPressed(state, action.digit), hasTyped: true };
     case 'BACKSPACE_PRESSED':
-      return handleBackspacePressed(state);
+      return { ...handleBackspacePressed(state), hasTyped: true };
     case 'BLURRED':
       return handleBlurred(state);
     case 'FOCUSED':
@@ -386,13 +394,16 @@ const initialTimeState = (controlledValue: Date | null): TimeState => ({
   ...parseTimeState(controlledValue),
   focusedSection: null,
   empty: controlledValue === null,
+  hasTyped: controlledValue === null,
 });
 
 // Component
 
-const renderTimeSection = (value: string, focused: boolean) => (
-  <span className={`value ${focused ? 'value-focused' : ''}`}>
-    {focused && <span className="custom-caret" />}
+const renderTimeSection = (value: string, focused: boolean, hasTyped: boolean) => (
+  <span
+    className={`value ${focused ? (hasTyped ? 'value-focused' : 'value-focused-initial') : ''}`}
+  >
+    {focused && hasTyped && <span className="custom-caret" />}
     <span
       className={/\d/.test(value[0]) ? '' : `placeholder-letter placeholder-letter-${value[0]}`}
     >
@@ -526,11 +537,11 @@ const TimeCell = ({
           }`}
           aria-hidden="true"
         >
-          {renderTimeSection(state.hours, state.focusedSection === 'hours')}
+          {renderTimeSection(state.hours, state.focusedSection === 'hours', state.hasTyped)}
           <span className="separator">:</span>
-          {renderTimeSection(state.minutes, state.focusedSection === 'minutes')}
+          {renderTimeSection(state.minutes, state.focusedSection === 'minutes', state.hasTyped)}
           <span className="separator">:</span>
-          {renderTimeSection(state.seconds, state.focusedSection === 'seconds')}
+          {renderTimeSection(state.seconds, state.focusedSection === 'seconds', state.hasTyped)}
         </div>
       ) : (
         <CellPlaceholder onClick={handlePlaceholderClick} />

--- a/front/src/modules/timesStops/styles/_durationCell.scss
+++ b/front/src/modules/timesStops/styles/_durationCell.scss
@@ -24,6 +24,20 @@
   color: var(--primary30);
 }
 
+.duration-cell-digit-focused-initial {
+  .duration-cell-digits-value {
+    position: relative;
+    width: 17px;
+    height: 20px;
+    background-color: rgba(0, 109, 255, 1);
+    border-radius: 0;
+
+    span {
+      color: var(--white100);
+    }
+  }
+}
+
 .duration-cell-digit-focused-editing {
   .duration-cell-digits-value {
     position: relative;

--- a/front/src/modules/timesStops/styles/_timeCell.scss
+++ b/front/src/modules/timesStops/styles/_timeCell.scss
@@ -68,6 +68,19 @@
       width: 17px;
     }
 
+    .value-focused-initial {
+      position: relative;
+      background-color: rgba(0, 109, 255, 1);
+      border-radius: 0;
+      height: 20px;
+      width: 17px;
+      color: var(--white100);
+
+      .placeholder-letter {
+        color: var(--white100);
+      }
+    }
+
     .value-focused {
       position: relative;
       background-color: var(--primary10);

--- a/front/src/modules/timesStops/styles/_timesStopsTable.scss
+++ b/front/src/modules/timesStops/styles/_timesStopsTable.scss
@@ -108,11 +108,11 @@
     }
 
     /* Input focus inside cell */
-    td[class^='col-']:has(input:focus, div:focus)::before {
+    td[class^='col-']:has(input:focus:not(:active), div:focus:not(:active))::before {
       box-shadow:
         0 1px 3px 0 inset rgba(0, 0, 0, 0.34),
         inset 0 0 0 1px var(--primary60);
-      background-color: var(--white100);
+      background-color: var(--white50);
     }
 
     /* Ensure content is above layer */


### PR DESCRIPTION
closes #14957 
fix focus on minutes on timeCell on first click
fix color, caret and hover when we focus on timeCell/durationCell, that do not behave exactly the same way : 

mockup : https://www.sketch.com/s/44a4dfe4-6ef5-4f9f-92d3-72b79136e5da/p/75E5A212-E842-4F76-A64E-09C05C02D7E1/canvas#Inspect

TimeCell : `light blue` on first focus, then `dark blue` when we have an already set input
<img width="78" height="191" alt="Capture d’écran 2026-01-30 à 13 24 26" src="https://github.com/user-attachments/assets/7c89f6fe-330b-478e-9710-dd73ce9e741c" />
<img width="455" height="161" alt="Capture d’écran 2026-01-30 à 13 24 36" src="https://github.com/user-attachments/assets/ed26fdf6-5f8b-4675-be9c-cf80f05104c2" />

durationCell : `dark blue` on focus, then `soft blue`
<img width="610" height="481" alt="Capture d’écran 2026-01-30 à 13 25 00" src="https://github.com/user-attachments/assets/7a185259-9cc0-4590-9a0a-535043ee2ff9" />
