### PR TITLE
front: fix whitescreen invalid path steps

### DIFF
--- a/front/src/modules/pathfinding/utils.ts
+++ b/front/src/modules/pathfinding/utils.ts
@@ -140,7 +140,7 @@ export const upsertPathStepsInOPs = (
       );
 
       // if index === -1, it means that the position on path of the last step is bigger
-      // than the last operationnal point position.
+      // than the last operational point position.
       // So we know this pathStep is the destination and we want to add it at the end of the array.
       if (index !== -1) {
         updatedOPs = addElementAtIndex(updatedOPs, index, formattedStep);

--- a/front/src/modules/pathfinding/utils.ts
+++ b/front/src/modules/pathfinding/utils.ts
@@ -103,6 +103,8 @@ export const getPathfindingQuery = ({
   return null;
 };
 
+export const isPathStepInvalid = (step: PathStep | null): boolean => step?.isInvalid || false;
+
 export const upsertPathStepsInOPs = (
   ops: SuggestedOP[],
   pathSteps: PathStep[],
@@ -110,6 +112,7 @@ export const upsertPathStepsInOPs = (
 ): SuggestedOP[] => {
   let updatedOPs = [...ops];
   pathSteps.forEach((step, stepIndex) => {
+    if (isPathStepInvalid(step)) return;
     const { arrival, stopFor, receptionSignal, theoreticalMargin } = step;
     // We check only for pathSteps added by map click
     if ('track' in step.location) {
@@ -209,5 +212,3 @@ export const isVia = (
 
 export const isStation = (chCode: string): boolean =>
   chCode === 'BV' || chCode === '00' || chCode === '';
-
-export const isPathStepInvalid = (step: PathStep | null): boolean => step?.isInvalid || false;


### PR DESCRIPTION
Close #14967

Invalid path steps typically can not be matched with an op (I'm not sure if there are other cases that cause isInvalid to be set to true beyond the back not finding an op?). Here I skipped the matching entirely, we could also just skip the throw.