### PR TITLE
front: operational-studies: clarify "import" button hover

### DIFF
--- a/front/public/locales/de/operational-studies.json
+++ b/front/public/locales/de/operational-studies.json
@@ -145,7 +145,7 @@
       "duplicate": "Duplizieren",
       "exportSelection": "Ausgewählte Züge exportieren",
       "filterLabel": "Name, Label",
-      "importTimetableItem": "Züge importieren",
+      "importTimetableNetworkGraphItem": "Züge oder Netzgrafik importieren",
       "invalid": {
         "incompatible_constraints": "Beschränkungen nicht kompatibel",
         "invalid_path_items": "Pfaditems ungültig",

--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -211,9 +211,9 @@
       "duplicate": "Clone",
       "exportSelection": "Export selected trains",
       "filterLabel": "Name, label",
-      "importTimetableFromCatalog": "Import from catalog",
-      "importTimetableFromFile": "Import from file",
-      "importTimetableItem": "Import trains",
+      "importTimetableNetworkGraphFromCatalog": "Import from catalog",
+      "importTimetableNetworkGraphFromFile": "Import from file",
+      "importTimetableNetworkGraphItem": "Import trains or network graphs",
       "invalid": {
         "incompatible_constraints": "Incompatible constraints",
         "invalid_path_items": "Invalid path items",

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -211,9 +211,9 @@
       "duplicate": "Dupliquer",
       "exportSelection": "Exporter les trains sélectionnés",
       "filterLabel": "Nom, étiquette",
-      "importTimetableFromCatalog": "Importer depuis le catalogue",
-      "importTimetableFromFile": "Importer depuis un fichier",
-      "importTimetableItem": "Importer des trains",
+      "importTimetableNetworkGraphFromCatalog": "Importer depuis le catalogue",
+      "importTimetableNetworkGraphFromFile": "Importer depuis un fichier",
+      "importTimetableNetworkGraphItem": "Importer des trains ou des réticulaires",
       "invalid": {
         "incompatible_constraints": "Contraintes incompatibles",
         "invalid_path_items": "Point(s) de passage(s) invalide(s)",

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TimetableToolbar.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TimetableToolbar.tsx
@@ -180,20 +180,20 @@ const TimetableToolbar = ({
             buttonProps={{
               icon: <Download />,
               dataTestID: 'scenarios-import-timetable-item-button',
-              title: t('timetable.importTimetableItem'),
+              title: t('timetable.importTimetableNetworkGraphItem'),
               className: 'import-button',
             }}
             menuProps={{
               items: [
                 {
                   icon: <File />,
-                  title: t('timetable.importTimetableFromFile'),
+                  title: t('timetable.importTimetableNetworkGraphFromFile'),
                   dataTestID: 'scenarios-import-timetable-by-file',
                   onClick: () => openTimetableImportModal(),
                 },
                 {
                   icon: <Book />,
-                  title: t('timetable.importTimetableFromCatalog'),
+                  title: t('timetable.importTimetableNetworkGraphFromCatalog'),
                   dataTestID: 'scenarios-import-timetable-by-catalog',
                   onClick: () =>
                     setDisplayTimetableItemManagement(MANAGE_TIMETABLE_ITEM_TYPES.catalog),

--- a/front/src/styles/scss/applications/_operationalStudies.scss
+++ b/front/src/styles/scss/applications/_operationalStudies.scss
@@ -1,7 +1,7 @@
 @use 'operationalStudies/nge';
 @use 'operationalStudies/scenario';
 @use 'operationalStudies/manageTimetableItem';
-@use 'operationalStudies/importTimetableItem';
+@use 'operationalStudies/importTimetableNetworkGraphItem';
 @use 'operationalStudies/importTrainScheduleSets';
 @use 'operationalStudies/simulationresults';
 @use 'operationalStudies/waypointsPanel';

--- a/front/src/styles/scss/applications/operationalStudies/_importTimetableNetworkGraphItem.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_importTimetableNetworkGraphItem.scss
@@ -1,4 +1,4 @@
-.import-timetable-item {
+.import-timetable-network-graph-item {
   .import-button {
     height: 51px;
   }


### PR DESCRIPTION
fixes #14507 

As it's capable of importing either a timetable or a network graph.