### PR TITLE
e2e: add train category selection 

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TrainScheduleItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TrainScheduleItem.tsx
@@ -209,7 +209,9 @@ const TrainScheduleItem = ({
                       <Manchette iconColor="var(--white100)" />
                     </div>
                   )}
-                  <span className="train-name">{train.name}</span>
+                  <span data-testid="train-name" className="train-name">
+                    {train.name}
+                  </span>
                 </div>
               </div>
             </div>

--- a/front/tests/02-operational-studies/paced-trains/001-paced-train-management.spec.ts
+++ b/front/tests/02-operational-studies/paced-trains/001-paced-train-management.spec.ts
@@ -21,6 +21,7 @@ import {
   TOTAL_PACED_TRAINS,
   TOTAL_PACED_TRAINS_WITH_DUPLICATE,
 } from '../../assets/constants/timetable-items-count';
+import { FREIGHT_TRAIN, HIGH_SPEED_TRAIN_COLOR } from '../../assets/operation-studies/train-const';
 import test from '../../page-object-fixture';
 import { waitForInfraStateToBeCached } from '../../utils';
 import { getInfra } from '../../utils/api-utils';
@@ -179,6 +180,7 @@ test.describe('@op @paced-trains', () => {
     await test.step('Verify paced train card and first occurrence details', async () => {
       await pacedTrainSection.verifyPacedTrainItemDetails(NEW_PACED_TRAIN_SETTINGS, 0, {
         occurrenceData: ADD_PACED_TRAIN_OCCURRENCES_DETAILS[0],
+        occurrenceColor: FREIGHT_TRAIN.color,
       });
     });
 
@@ -231,6 +233,7 @@ test.describe('@op @paced-trains', () => {
       await pacedTrainSection.verifyPacedTrainItemDetails(DUPLICATED_PACED_TRAIN_DETAILS, 1, {
         occurrenceData: DUPLICATED_PACED_TRAIN_OCCURRENCES_DETAILS,
         copyTranslation: frTranslations.timetable.copy,
+        occurrenceColor: HIGH_SPEED_TRAIN_COLOR,
       });
     });
 

--- a/front/tests/02-operational-studies/timetable/004-train-edition.spec.ts
+++ b/front/tests/02-operational-studies/timetable/004-train-edition.spec.ts
@@ -4,7 +4,13 @@ import {
   timetableItemProjectName,
   timetableItemStudyName,
 } from '../../assets/constants/project-const';
-import { EDITED_PACED_TRAIN_NAME, INTERVAL, TIME_WINDOW } from '../../assets/paced-train/const';
+import { FREIGHT_TRAIN, HIGH_SPEED_TRAIN_COLOR } from '../../assets/operation-studies/train-const';
+import {
+  PACED_TRAIN_OCCURRENCE_COUNT,
+  EDITED_PACED_TRAIN_NAME,
+  INTERVAL,
+  TIME_WINDOW,
+} from '../../assets/paced-train/const';
 import test from '../../page-object-fixture';
 import { generateUniqueName, waitForInfraStateToBeCached } from '../../utils';
 import { getInfra, getProject, getStudy } from '../../utils/api-utils';
@@ -34,10 +40,6 @@ const frTranslations = {
 };
 
 const trains: PacedTrain[] = readJsonFile('./tests/assets/trains/trains.json');
-
-const TIME_WINDOW = '240';
-const INTERVAL = '20';
-const EDITED_PACED_TRAIN_NAME = 'Paced train edited';
 
 test.describe('@op @paced-train @train-schedule', () => {
   let project: Project;
@@ -83,6 +85,11 @@ test.describe('@op @paced-train @train-schedule', () => {
     pacedTrainSection,
   }) => {
     await test.step('Open paced train edition page', async () => {
+      await pacedTrainSection.verifyOccurrencesCount(
+        PACED_TRAIN_OCCURRENCE_COUNT,
+        0,
+        HIGH_SPEED_TRAIN_COLOR
+      );
       await pacedTrainSection.openPacedTrainEditor();
     });
 
@@ -90,6 +97,7 @@ test.describe('@op @paced-train @train-schedule', () => {
       await operationalStudiesPage.setTimeWindow(TIME_WINDOW);
       await operationalStudiesPage.setInterval(INTERVAL);
       await operationalStudiesPage.setTimetableItemName(EDITED_PACED_TRAIN_NAME);
+      await operationalStudiesPage.selectCategory(FREIGHT_TRAIN.category);
     });
 
     await test.step('Save paced train and verify toast notification', async () => {
@@ -112,7 +120,7 @@ test.describe('@op @paced-train @train-schedule', () => {
           expectedOccurrencesCount: 12,
         },
         0,
-        { pacedTrainCardAlreadyOpen: true }
+        { pacedTrainCardAlreadyOpen: true, occurrenceColor: FREIGHT_TRAIN.color }
       );
     });
   });

--- a/front/tests/02-operational-studies/timetable/004-train-edition.spec.ts
+++ b/front/tests/02-operational-studies/timetable/004-train-edition.spec.ts
@@ -4,6 +4,7 @@ import {
   timetableItemProjectName,
   timetableItemStudyName,
 } from '../../assets/constants/project-const';
+import { EDITED_PACED_TRAIN_NAME, INTERVAL, TIME_WINDOW } from '../../assets/paced-train/const';
 import test from '../../page-object-fixture';
 import { generateUniqueName, waitForInfraStateToBeCached } from '../../utils';
 import { getInfra, getProject, getStudy } from '../../utils/api-utils';

--- a/front/tests/02-operational-studies/train-creation-tabs/003-op-times-and-stops-tab.spec.ts
+++ b/front/tests/02-operational-studies/train-creation-tabs/003-op-times-and-stops-tab.spec.ts
@@ -3,7 +3,7 @@ import { expect } from '@playwright/test';
 import type { Infra, Project, Scenario, Study } from 'common/api/osrdEditoastApi';
 
 import { dualModeRollingStockName } from '../../assets/constants/project-const';
-import { TRAIN_NAME, TRAIN_START_TIME } from '../../assets/operation-studies/train';
+import { TRAIN_NAME, TRAIN_START_TIME } from '../../assets/operation-studies/train-const';
 import test from '../../page-object-fixture';
 import { waitForInfraStateToBeCached } from '../../utils';
 import { getInfra } from '../../utils/api-utils';

--- a/front/tests/02-operational-studies/train-creation-tabs/003-op-times-and-stops-tab.spec.ts
+++ b/front/tests/02-operational-studies/train-creation-tabs/003-op-times-and-stops-tab.spec.ts
@@ -3,6 +3,7 @@ import { expect } from '@playwright/test';
 import type { Infra, Project, Scenario, Study } from 'common/api/osrdEditoastApi';
 
 import { dualModeRollingStockName } from '../../assets/constants/project-const';
+import { TRAIN_NAME, TRAIN_START_TIME } from '../../assets/operation-studies/train';
 import test from '../../page-object-fixture';
 import { waitForInfraStateToBeCached } from '../../utils';
 import { getInfra } from '../../utils/api-utils';
@@ -58,9 +59,9 @@ test.describe('@op @times-stops-tab', () => {
     });
     await test.step('Add a new train schedule and set its properties', async () => {
       await operationalStudiesPage.openTimetableItemForm();
-      await operationalStudiesPage.setTimetableItemStartTime('11:22:40');
+      await operationalStudiesPage.setTimetableItemStartTime(TRAIN_START_TIME);
       await rollingStockSelector.selectRollingStock(dualModeRollingStockName);
-      await operationalStudiesPage.setTimetableItemName('Train-name-e2e-test');
+      await operationalStudiesPage.setTimetableItemName(TRAIN_NAME);
     });
     await test.step('Perform pathfinding then navigate to Times and Stops tab', async () => {
       await operationalStudiesPage.openRouteTab();

--- a/front/tests/02-operational-studies/train-creation-tabs/004-op-simulation-settings-tab.spec.ts
+++ b/front/tests/02-operational-studies/train-creation-tabs/004-op-simulation-settings-tab.spec.ts
@@ -9,7 +9,11 @@ import type {
 } from 'common/api/osrdEditoastApi';
 
 import { improbableRollingStockName } from '../../assets/constants/project-const';
-import { TRAIN_NAME, TRAIN_START_TIME } from '../../assets/operation-studies/train';
+import {
+  FREIGHT_TRAIN,
+  TRAIN_NAME,
+  TRAIN_START_TIME,
+} from '../../assets/operation-studies/train-const';
 import test from '../../page-object-fixture';
 import { waitForInfraStateToBeCached } from '../../utils';
 import { deleteApiRequest, getInfra, setElectricalProfile } from '../../utils/api-utils';
@@ -92,7 +96,7 @@ test.describe('@op @simulation-settings-tab', () => {
       await operationalStudiesPage.setTimetableItemName(TRAIN_NAME);
       await rollingStockSelector.selectRollingStock(improbableRollingStockName);
       await operationalStudiesPage.setTimetableItemStartTime(TRAIN_START_TIME);
-
+      await operationalStudiesPage.selectCategory(FREIGHT_TRAIN.category);
       await operationalStudiesPage.openRouteTab();
       await routeTab.performPathfindingByTrigram({
         originTrigram: 'WS',
@@ -139,6 +143,7 @@ test.describe('@op @simulation-settings-tab', () => {
       await operationalStudiesPage.closeToastNotification();
       await operationalStudiesPage.returnSimulationResult();
       await scenarioTimetableSection.getTimetableItemArrivalTime('11:48');
+      await scenarioTimetableSection.verifyTrainColor(FREIGHT_TRAIN.color);
       await opSimulationResultPage.setTrainListVisible();
 
       await operationalStudiesPage.verifyTimesStopsDataSheetVisibility();

--- a/front/tests/02-operational-studies/train-creation-tabs/004-op-simulation-settings-tab.spec.ts
+++ b/front/tests/02-operational-studies/train-creation-tabs/004-op-simulation-settings-tab.spec.ts
@@ -9,6 +9,7 @@ import type {
 } from 'common/api/osrdEditoastApi';
 
 import { improbableRollingStockName } from '../../assets/constants/project-const';
+import { TRAIN_NAME, TRAIN_START_TIME } from '../../assets/operation-studies/train';
 import test from '../../page-object-fixture';
 import { waitForInfraStateToBeCached } from '../../utils';
 import { deleteApiRequest, getInfra, setElectricalProfile } from '../../utils/api-utils';
@@ -88,9 +89,9 @@ test.describe('@op @simulation-settings-tab', () => {
     });
     await test.step('Add a new train schedule, set its properties and perform pathfinding', async () => {
       await operationalStudiesPage.openTimetableItemForm();
-      await operationalStudiesPage.setTimetableItemName('Train-name-e2e-test');
+      await operationalStudiesPage.setTimetableItemName(TRAIN_NAME);
       await rollingStockSelector.selectRollingStock(improbableRollingStockName);
-      await operationalStudiesPage.setTimetableItemStartTime('11:22:40');
+      await operationalStudiesPage.setTimetableItemStartTime(TRAIN_START_TIME);
 
       await operationalStudiesPage.openRouteTab();
       await routeTab.performPathfindingByTrigram({

--- a/front/tests/assets/operation-studies/train-const.ts
+++ b/front/tests/assets/operation-studies/train-const.ts
@@ -1,0 +1,9 @@
+export const TRAIN_NAME = 'Train-name-e2e-test';
+export const TRAIN_START_TIME = '11:22:40';
+
+export const HIGH_SPEED_TRAIN_COLOR = 'rgb(229, 34, 26)';
+
+export const FREIGHT_TRAIN = {
+  color: 'rgb(84, 130, 59)',
+  category: 'main:FREIGHT_TRAIN',
+};

--- a/front/tests/assets/operation-studies/train.ts
+++ b/front/tests/assets/operation-studies/train.ts
@@ -1,2 +1,0 @@
-export const TRAIN_NAME = 'Train-name-e2e-test';
-export const TRAIN_START_TIME = '11:22:40';

--- a/front/tests/assets/operation-studies/train.ts
+++ b/front/tests/assets/operation-studies/train.ts
@@ -1,0 +1,2 @@
+export const TRAIN_NAME = 'Train-name-e2e-test';
+export const TRAIN_START_TIME = '11:22:40';

--- a/front/tests/assets/paced-train/const.ts
+++ b/front/tests/assets/paced-train/const.ts
@@ -30,3 +30,4 @@ export const DISABLED_OCCURRENCE_MENU_BUTTONS: OccurrenceMenuButton[] = ['enable
 export const TIME_WINDOW = '240';
 export const INTERVAL = '20';
 export const EDITED_PACED_TRAIN_NAME = 'Paced train edited';
+export const PACED_TRAIN_OCCURRENCE_COUNT = 2;

--- a/front/tests/assets/paced-train/const.ts
+++ b/front/tests/assets/paced-train/const.ts
@@ -26,3 +26,7 @@ export const ADDED_AND_MODIFIED_EXCEPTION_MENU_BUTTONS: OccurrenceMenuButton[] =
 ];
 
 export const DISABLED_OCCURRENCE_MENU_BUTTONS: OccurrenceMenuButton[] = ['enable'];
+
+export const TIME_WINDOW = '240';
+export const INTERVAL = '20';
+export const EDITED_PACED_TRAIN_NAME = 'Paced train edited';

--- a/front/tests/assets/trains/trains.json
+++ b/front/tests/assets/trains/trains.json
@@ -49,6 +49,9 @@
     "paced": {
       "time_window": "PT2H",
       "interval": "PT1H"
+    },
+    "category": {
+      "main_category": "HIGH_SPEED_TRAIN"
     }
   },
   {

--- a/front/tests/pages/operational-studies/operational-studies-page.ts
+++ b/front/tests/pages/operational-studies/operational-studies-page.ts
@@ -35,6 +35,7 @@ class OperationalStudiesPage extends ScenarioTimetableSection {
   private readonly createTimetableItemButton: Locator;
   private readonly simulationSettingsTab: Locator;
   private readonly timesAndStopsTab: Locator;
+  private readonly categorySelector: Locator;
 
   constructor(page: Page) {
     super(page);
@@ -62,6 +63,7 @@ class OperationalStudiesPage extends ScenarioTimetableSection {
     this.timetableItemNameInput = page.getByTestId('timetable-item-name-input');
     this.initialSpeedInput = page.getByTestId('initial-speed-input');
     this.timetableItemTagsInput = page.getByTestId('chips-input');
+    this.categorySelector = page.getByTestId('category-selector-select');
   }
 
   // Click on the button to add a scenario timetable item.
@@ -107,6 +109,11 @@ class OperationalStudiesPage extends ScenarioTimetableSection {
   async setFormattedStartTime(startTime: string) {
     await this.startTimeField.fill(startTime);
     await expect(this.startTimeField).toHaveValue(startTime);
+  }
+
+  async selectCategory(categoryName: string): Promise<void> {
+    await this.categorySelector.selectOption(categoryName);
+    await expect(this.categorySelector).toHaveValue(categoryName);
   }
 
   async returnSimulationResult() {

--- a/front/tests/pages/operational-studies/paced-train-section.ts
+++ b/front/tests/pages/operational-studies/paced-train-section.ts
@@ -5,6 +5,7 @@ import type {
   OccurrenceDetails,
   OccurrenceMenuButton,
   PacedTrainDetails,
+  PacedTrainOptions,
   TimetableFilterTranslations,
 } from '../../utils/types';
 import CommonPage from '../common-page';
@@ -94,16 +95,15 @@ class PacedTrainSection extends CommonPage {
   async verifyPacedTrainItemDetails(
     pacedTrainData: PacedTrainDetails,
     index: number,
-    {
+    options: PacedTrainOptions = {}
+  ) {
+    const {
       copyTranslation,
       occurrenceData,
-      pacedTrainCardAlreadyOpen,
-    }: {
-      copyTranslation?: string;
-      occurrenceData?: OccurrenceDetails[];
-      pacedTrainCardAlreadyOpen?: boolean;
-    } = {}
-  ) {
+      pacedTrainCardAlreadyOpen = false,
+      occurrenceColor,
+    } = options;
+
     const { name, labels, interval, expectedOccurrencesCount } = pacedTrainData;
 
     // In paced_trains.json, invalid paced trains are marked with an `Invalid` label
@@ -117,21 +117,15 @@ class PacedTrainSection extends CommonPage {
 
     if (expectedOccurrencesCount !== undefined) {
       await expect(this.testedPacedTrainOccurrences).toHaveCount(expectedOccurrencesCount);
-      await this.verifyOccurrencesCount(expectedOccurrencesCount, index);
+      await this.verifyOccurrencesCount(expectedOccurrencesCount, index, occurrenceColor);
     }
 
-    let expectedName = name;
-    if (copyTranslation) {
-      // duplicated train name should have format : "name (copy)"
-      expectedName = `${name} (${copyTranslation})`;
-    }
+    const expectedName = copyTranslation ? `${name} (${copyTranslation})` : name;
     await expect(this.testedPacedTrainName).toBeVisible();
     await expect(this.testedPacedTrainName).toHaveText(expectedName);
 
     await expect(this.testedPacedTrainInterval).toBeVisible();
-    await expect(this.testedPacedTrainInterval).toHaveText(
-      `${String.fromCodePoint(0x2014)} ${interval}min`
-    ); // UI format: "- Xmin"
+    await expect(this.testedPacedTrainInterval).toHaveText(`— ${interval}min`); // UI: "— Xmin"
 
     // Verify that the pace train item does not display the rolling stock
     await expect(this.testedPacedTrainRollingStock).not.toBeVisible();
@@ -148,10 +142,17 @@ class PacedTrainSection extends CommonPage {
     await this.collapsePacedTrainOccurrenceList(index);
   }
 
-  async verifyOccurrencesCount(expectedOccurrencesCount: number, index: number) {
+  async verifyOccurrencesCount(
+    expectedOccurrencesCount: number,
+    index: number,
+    occurrenceColor?: string
+  ) {
     const pacedTrainOccurrencesCount = this.occurrencesCount.nth(index);
-    await expect(pacedTrainOccurrencesCount).toBeVisible();
     await expect(pacedTrainOccurrencesCount).toHaveText(String(expectedOccurrencesCount));
+
+    if (occurrenceColor) {
+      await expect(pacedTrainOccurrencesCount).toHaveCSS('background-color', occurrenceColor);
+    }
   }
 
   async verifyOccurrenceName(

--- a/front/tests/pages/operational-studies/scenario-timetable-section.ts
+++ b/front/tests/pages/operational-studies/scenario-timetable-section.ts
@@ -46,6 +46,7 @@ class ScenarioTimetableSection extends OpSimulationResultPage {
   private readonly timetableItemArrivalTime: Locator;
   private readonly timetableItemArrivalTimeLoader: Locator;
   private readonly invalidTimetableItemsReasons: Locator;
+  private readonly trainName: Locator;
 
   constructor(page: Page) {
     super(page);
@@ -87,6 +88,7 @@ class ScenarioTimetableSection extends OpSimulationResultPage {
     this.timetableItemArrivalTime = page.getByTestId('timetable-item-arrival-time');
     this.timetableItemArrivalTimeLoader = page.getByTestId('arrival-time-loader');
     this.invalidTimetableItemsReasons = this.timetableItems.getByTestId('invalid-reason');
+    this.trainName = page.getByTestId('train-name');
   }
 
   private static getTrainScheduleButton(trainScheduleSelector: Locator): Locator {
@@ -415,6 +417,11 @@ class ScenarioTimetableSection extends OpSimulationResultPage {
   async verifyInvalidReasons(expectedReason: string[]): Promise<void> {
     await expect(this.invalidTimetableItemsReasons.first()).toBeVisible();
     await expect(this.invalidTimetableItemsReasons).toHaveText(expectedReason);
+  }
+
+  async verifyTrainColor(expectedColor: string, index = 0) {
+    await expect(this.trainName.nth(index)).toBeVisible();
+    await expect(this.trainName.nth(index)).toHaveCSS('color', expectedColor);
   }
 }
 

--- a/front/tests/utils/types.ts
+++ b/front/tests/utils/types.ts
@@ -375,3 +375,10 @@ export type RoundTripCardExpected = {
   startTime: string;
   requestedArrivalTime: string;
 };
+
+export type PacedTrainOptions = {
+  copyTranslation?: string;
+  occurrenceData?: OccurrenceDetails[];
+  pacedTrainCardAlreadyOpen?: boolean;
+  occurrenceColor?: string;
+};


### PR DESCRIPTION
I added a new step to the existing tests to select the train category and verify that it has the correct color.
For paced trains, the verification is limited to the occurrence count, since the color is the same for each occurrence and checking all of them would unnecessarily slow down the test.
I also included a small commit to centralize some test constants.