### PR TITLE
github: add backport label to PRs targeting "staging"

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -47,3 +47,5 @@
       - changed-files:
           - any-glob-to-any-file: "editoast/openapi.yaml"
           - any-glob-to-any-file: "front/src/reducers/osrdconf/infra_schema.json"
+"kind:backport":
+  - base-branch: "^staging$"


### PR DESCRIPTION
Makes it easier to spot these.

Note, the new `kind:backport` label needs to be created before this PR is merged.