### PR TITLE
railway-manager-interface: make SimulationReport.max_speed a number

### DIFF
--- a/railway_manager_interface/openapi.yaml
+++ b/railway_manager_interface/openapi.yaml
@@ -216,7 +216,7 @@ components:
           title: Total Mass
           description: Total mass of the train in kg
         max_speed:
-          type: integer
+          type: number
           title: Max Speed
           description: Maximum speed in m/s
         total_length:

--- a/railway_manager_interface/osrd_railway_manager_interface/models.py
+++ b/railway_manager_interface/osrd_railway_manager_interface/models.py
@@ -281,7 +281,7 @@ class SimulationReport(BaseModel):
     """
     Total mass of the train in kg
     """
-    max_speed: Annotated[int, Field(title="Max Speed")]
+    max_speed: Annotated[float, Field(title="Max Speed")]
     """
     Maximum speed in m/s
     """

--- a/railway_manager_interface/pyproject.toml
+++ b/railway_manager_interface/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "osrd-railway-manager-interface"
-version = "0.2.1"
+version = "0.2.2"
 description = "Railway manager interface"
 authors = [{ name = "OSRD Contributors", email = "contact@osrd.fr" }]
 requires-python = ">=3.11"

--- a/railway_manager_interface/uv.lock
+++ b/railway_manager_interface/uv.lock
@@ -249,7 +249,7 @@ wheels = [
 
 [[package]]
 name = "osrd-railway-manager-interface"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "datamodel-code-generator" },


### PR DESCRIPTION
That's what the front actually sends, not an int

(The typescript models weren't changed after the generation with the new openAPI)