### PR TITLE
front: fix invalid step message when query is pending

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModal.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModal.tsx
@@ -116,6 +116,7 @@ const ItineraryModal = ({
   const editingStepIdRef = useRef<string>('');
 
   const isStepInvalidAndIsEditing = (step: PathStepV2, metadata?: PathStepMetadata) => {
+    if (step.location) return false;
     if (!metadata?.isInvalid) return false;
 
     const query = (getInputForStep(step.id) ?? '').trim();


### PR DESCRIPTION
closes #15029 

a quick message was shown, displaying the step was invalid, as the step.location hasn't been resolved immediately. 
Added a isFetching to not display the message while fetching locations 