### PR TITLE
nix: fix some outdated package names

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -70,7 +70,7 @@
             fixedNode
 
             # Nix formatter
-            nixfmt-rfc-style
+            nixfmt
             nixd
 
             # OSRD dev scripts
@@ -80,7 +80,7 @@
           # Section added only on Linux systems
           ++ lib.optionals (!stdenv.isDarwin) [
             # Linker
-            mold-wrapped
+            mold
           ]
           # Section added only on Darwin (macOS) systems
           ++ lib.optionals stdenv.isDarwin [


### PR DESCRIPTION
Here are the previous warnings when using the `flake.nix`.

```
evaluation warning: nixfmt-rfc-style is now the same as pkgs.nixfmt which should be used instead.
evaluation warning: 'mold-wrapped' has been renamed to 'mold'
```