### PR TITLE
editoast: front: change handling of null secondary_code in operational point matching

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -1178,6 +1178,9 @@ paths:
               required:
               - operational_point_references
               properties:
+                ignore_secondary_code:
+                  type: boolean
+                  description: When true, ignores secondary_code matching and returns all OPs with the given trigram/UIC.
                 operational_point_references:
                   type: array
                   items:

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -770,6 +770,9 @@ pub(in crate::views) async fn unlock(
 #[cfg_attr(test, derive(Serialize))]
 pub(in crate::views) struct MatchOperationalPointsForm {
     operational_point_references: Vec<OperationalPointReference>,
+    /// When true, ignores secondary_code matching and returns all OPs with the given trigram/UIC.
+    #[serde(default)]
+    ignore_secondary_code: bool,
 }
 
 #[derive(Serialize, ToSchema)]
@@ -819,6 +822,7 @@ pub(in crate::views) async fn match_operational_points(
     Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
     Json(MatchOperationalPointsForm {
         operational_point_references,
+        ignore_secondary_code,
     }): Json<MatchOperationalPointsForm>,
 ) -> Result<Json<MatchOperationalPointsResponse>> {
     let authorized = auth
@@ -843,7 +847,7 @@ pub(in crate::views) async fn match_operational_points(
     for operational_point_reference in operational_point_references {
         // Retrieve related OPs based on the input operational point identifier:
         let related_operational_points = op_cache
-            .get_reference(operational_point_reference)
+            .get_reference(operational_point_reference, ignore_secondary_code)
             .expect("should get the provided reference");
 
         // Add the operational point reference related operational points to the response:
@@ -1401,13 +1405,16 @@ pub mod tests {
                 secondary_code: Some("BV".into()),
             },
             OperationalPointReference::Uic {
-                uic: 8,
+                uic: 8755,
                 secondary_code: None,
             },
         ];
         let request = app
             .post(format!("/infra/{}/match_operational_points", infra.id).as_str())
-            .json(&json!({"operational_point_references": operational_point_references}));
+            .json(&json!({
+                "operational_point_references": operational_point_references,
+                "ignore_secondary_code": false
+            }));
         let response: MatchOperationalPointsResponse = app
             .fetch(request)
             .await
@@ -1453,7 +1460,10 @@ pub mod tests {
         ];
         let request = app
             .post(format!("/infra/{}/match_operational_points", infra.id).as_str())
-            .json(&json!({"operational_point_references": operational_point_references}));
+            .json(&json!({
+                "operational_point_references": operational_point_references,
+                "ignore_secondary_code": false
+            }));
         let response: MatchOperationalPointsResponse = app
             .fetch(request)
             .await
@@ -1465,6 +1475,57 @@ pub mod tests {
             .map(|op_ref| op_ref.iter().map(|op| op.id.as_str()).collect::<Vec<_>>())
             .collect::<Vec<_>>();
         let expected_identifiers: [Vec<&str>; 2] = [vec![], vec![]];
+        assert_eq!(response_op_identifiers, expected_identifiers);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn match_operational_points_with_ignore_secondary_code() {
+        let app = TestAppBuilder::default_app();
+        let db_pool = app.db_pool();
+        let mut infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let infra_cache = InfraCache::load(&mut db_pool.get_ok(), &infra)
+            .await
+            .unwrap();
+        infra
+            .refresh(db_pool.clone(), false, &infra_cache)
+            .await
+            .unwrap();
+
+        // Test with ignore_secondary_code set to true to retrieve all OPs with this trigram or UIC
+        let operational_point_references = vec![
+            OperationalPointReference::Id {
+                operational_point: ("West_station").into(),
+            },
+            OperationalPointReference::Trigram {
+                trigram: "MES".into(),
+                secondary_code: Some("BV".into()),
+            },
+            OperationalPointReference::Uic {
+                uic: 8755,
+                secondary_code: None,
+            },
+        ];
+        let request = app
+            .post(format!("/infra/{}/match_operational_points", infra.id).as_str())
+            .json(&json!({
+                "operational_point_references": operational_point_references,
+                "ignore_secondary_code": true
+            }));
+        let response: MatchOperationalPointsResponse = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
+        let response_op_identifiers = response
+            .related_operational_points
+            .iter()
+            .map(|op_ref| op_ref.iter().map(|op| op.id.as_str()).collect::<Vec<_>>())
+            .collect_vec();
+        let expected_identifiers = [
+            vec!["West_station"],
+            vec!["Mid_East_station"],
+            vec!["North_station"],
+        ];
         assert_eq!(response_op_identifiers, expected_identifiers);
     }
 

--- a/editoast/src/views/path/operational_point_cache.rs
+++ b/editoast/src/views/path/operational_point_cache.rs
@@ -366,6 +366,7 @@ impl OperationalPointCache {
     pub fn get_reference(
         &self,
         op_ref: OperationalPointReference,
+        ignore_secondary_code: bool,
     ) -> Result<Vec<&OperationalPoint>> {
         let related_operational_points = match op_ref {
             OperationalPointReference::Id {
@@ -380,7 +381,13 @@ impl OperationalPointCache {
                 secondary_code,
             } => {
                 if let Some(op_models) = self.get_from_trigram(&trigram.0) {
-                    filter_by_secondary_code_and_retrieve_op(secondary_code, op_models)
+                    if ignore_secondary_code {
+                        op_models.map(|op_model| &op_model.schema).collect()
+                    } else {
+                        find_op_by_secondary_code(secondary_code.as_ref(), op_models.collect())
+                            .map(|op| vec![&op.schema])
+                            .unwrap_or_default()
+                    }
                 } else {
                     vec![]
                 }
@@ -390,7 +397,13 @@ impl OperationalPointCache {
                 secondary_code,
             } => {
                 if let Some(op_models) = self.get_from_uic(uic) {
-                    filter_by_secondary_code_and_retrieve_op(secondary_code, op_models)
+                    if ignore_secondary_code {
+                        op_models.map(|op_model| &op_model.schema).collect()
+                    } else {
+                        find_op_by_secondary_code(secondary_code.as_ref(), op_models.collect())
+                            .map(|op| vec![&op.schema])
+                            .unwrap_or_default()
+                    }
                 } else {
                     vec![]
                 }
@@ -471,23 +484,6 @@ fn find_op_by_secondary_code<'a>(
 ) -> Option<&'a OperationalPointModel> {
     ops.into_iter()
         .find(|op| secondary_code == op.extensions.sncf.as_ref().map(|sncf| &sncf.ch))
-}
-
-fn filter_by_secondary_code_and_retrieve_op<'a>(
-    secondary_code: Option<String>,
-    op_models: impl Iterator<Item = &'a OperationalPointModel>,
-) -> Vec<&'a OperationalPoint> {
-    op_models
-        .map(|op_model| &op_model.schema)
-        .filter(|op| match secondary_code.as_ref() {
-            Some(secondary_code) => op
-                .extensions
-                .sncf
-                .as_ref()
-                .is_some_and(|ext| &ext.ch == secondary_code),
-            None => true,
-        })
-        .collect::<Vec<_>>()
 }
 
 #[cfg(test)]

--- a/front/src/applications/operationalStudies/hooks/usePathOps.ts
+++ b/front/src/applications/operationalStudies/hooks/usePathOps.ts
@@ -9,8 +9,6 @@ import {
 } from 'common/api/osrdEditoastApi';
 import type { Train } from 'reducers/osrdconf/types';
 
-import { getStationFromOps } from '../utils';
-
 /**
  * Given a train's path, return the operational points corresponding to the pathSteps of this train
  */
@@ -18,7 +16,7 @@ const usePathOps = (
   infraId: number,
   path?: Train['path'],
   options?: {
-    returnAllOps: boolean;
+    ignoreSecondaryCode: boolean;
   }
 ): RelatedOperationalPoint[] => {
   const operationalPointReferences: OperationalPointReference[] = useMemo(
@@ -39,6 +37,7 @@ const usePathOps = (
             infraId,
             body: {
               operational_point_references: operationalPointReferences,
+              ignore_secondary_code: options?.ignoreSecondaryCode ?? false,
             },
           }
         : skipToken
@@ -51,16 +50,8 @@ const usePathOps = (
     )
       return [];
 
-    // To remove empty arrays related to invalid step
-    const allValidOps = operationalPoints.related_operational_points.filter(
-      (ops) => ops.length !== 0
-    );
-
-    if (options?.returnAllOps) {
-      return allValidOps.flat();
-    }
-
-    return allValidOps.map((matchingOps) => getStationFromOps(matchingOps)!);
+    // To remove empty arrays related to invalid step and flatten
+    return operationalPoints.related_operational_points.filter((ops) => ops.length !== 0).flat();
   }, [operationalPoints]);
 };
 

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/hooks/usePathStepsMetadata.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/hooks/usePathStepsMetadata.ts
@@ -1,15 +1,11 @@
 import { useEffect, useMemo, useState } from 'react';
 
-import { skipToken } from '@reduxjs/toolkit/query';
 import type { Position } from 'geojson';
+import { v4 as uuid } from 'uuid';
 
 import usePathOps from 'applications/operationalStudies/hooks/usePathOps';
 import { useScenarioContext } from 'applications/operationalStudies/hooks/useScenarioContext';
-import {
-  osrdEditoastApi,
-  type OperationalPointReference,
-  type TrainSchedule,
-} from 'common/api/osrdEditoastApi';
+import type { TrainSchedule } from 'common/api/osrdEditoastApi';
 import type { PathStepMetadata, PathStepV2 } from 'reducers/osrdconf/types';
 import { getPointOnTrackCoordinates } from 'utils/geometry';
 
@@ -25,45 +21,29 @@ export const usePathStepsMetadata = (pathSteps: PathStepV2[]) => {
   );
 
   // 1. Extract the train path to extract its steps related operational points
-  const strippedTrainPath: TrainSchedule['path'] = useMemo(
+  const trainPath: TrainSchedule['path'] = useMemo(
     () =>
       pathSteps.reduce<TrainSchedule['path']>((acc, step) => {
-        if (!step.location) return acc;
-        if ('operational_point' in step.location) {
-          if (
-            step.location.operational_point.type === 'uic' ||
-            step.location.operational_point.type === 'trigram'
-          ) {
-            // strip location from its secondary_code so we can have all matchs for an uic or trigram
-            const { secondary_code: _secCode, ...operational_point } =
-              step.location.operational_point;
-            acc.push({
-              id: step.id,
-              location: {
-                operational_point,
-              },
-            });
-            return acc;
-          }
+        if (step.location) {
+          acc.push({
+            id: step.id,
+            location: step.location,
+          });
         }
-        acc.push({
-          id: step.id,
-          location: step.location,
-        });
         return acc;
       }, []),
     [pathSteps]
   );
 
-  const pathStepsOperationalPoints = usePathOps(infraId, strippedTrainPath, {
-    returnAllOps: true,
+  const pathStepsOperationalPoints = usePathOps(infraId, trainPath, {
+    ignoreSecondaryCode: true,
   });
 
   // 2. Since a path step containing 'operational_point' as location will have only one match
   // with postInfraByInfraIdMatchOperationalPoints, we need to call the endpoint again with
   // the opId corresponding uic in order to get all the possible matches and have
   // all the secondary codes and track names
-  const uicPayload: OperationalPointReference[] = useMemo(() => {
+  const uicTrainPath: TrainSchedule['path'] = useMemo(() => {
     const opIds = pathSteps.reduce<string[]>((acc, step) => {
       if (
         step.location &&
@@ -77,33 +57,27 @@ export const usePathStepsMetadata = (pathSteps: PathStepV2[]) => {
 
     if (opIds.length === 0) return [];
 
-    return pathStepsOperationalPoints.reduce<OperationalPointReference[]>((acc, op) => {
-      const uic = op.extensions?.identifier?.uic;
-      if (uic && opIds.includes(op.id)) {
-        acc.push({ uic, type: 'uic' });
-      }
-      return acc;
-    }, []);
+    return pathStepsOperationalPoints
+      .filter((op) => op.extensions?.identifier?.uic)
+      .map((op) => ({
+        // The step id is required by the type but ignored by usePathOps
+        id: uuid(),
+        location: {
+          operational_point: {
+            type: 'uic' as const,
+            uic: op.extensions!.identifier!.uic,
+          },
+        },
+      }));
   }, [pathSteps, pathStepsOperationalPoints]);
 
-  const { currentData: allOpIdsOperationalPoints } =
-    osrdEditoastApi.endpoints.postInfraByInfraIdMatchOperationalPoints.useQuery(
-      uicPayload.length > 0
-        ? {
-            infraId,
-            body: {
-              operational_point_references: uicPayload,
-            },
-          }
-        : skipToken
-    );
+  const allOpIdsOperationalPoints = usePathOps(infraId, uicTrainPath, {
+    ignoreSecondaryCode: true,
+  });
 
   // 3. Merge both operational points lists to have all possible matches
   const allOps = useMemo(
-    () => [
-      ...pathStepsOperationalPoints,
-      ...(allOpIdsOperationalPoints?.related_operational_points || []).flat(),
-    ],
+    () => [...pathStepsOperationalPoints, ...allOpIdsOperationalPoints],
     [pathStepsOperationalPoints, allOpIdsOperationalPoints]
   );
 

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -1699,6 +1699,8 @@ export type PostInfraByInfraIdMatchOperationalPointsApiArg = {
   /** An existing infra ID */
   infraId: number;
   body: {
+    /** When true, ignores secondary_code matching and returns all OPs with the given trigram/UIC. */
+    ignore_secondary_code?: boolean;
     operational_point_references: OperationalPointReference[];
   };
 };

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -149,9 +149,9 @@ const osrdEditoastApi = generatedEditoastApi
       }),
       matchAllOperationalPoints: builder.query<
         RelatedOperationalPoint[][],
-        { infraId: number; opRefs: OperationalPointReference[] }
+        { infraId: number; opRefs: OperationalPointReference[]; ignoreSecondaryCode?: boolean }
       >({
-        queryFn: async ({ infraId, opRefs }, { dispatch }) => {
+        queryFn: async ({ infraId, opRefs, ignoreSecondaryCode }, { dispatch }) => {
           const batchSize = 200;
           const result: RelatedOperationalPoint[][] = [];
 
@@ -165,6 +165,7 @@ const osrdEditoastApi = generatedEditoastApi
                   infraId,
                   body: {
                     operational_point_references: batch,
+                    ignore_secondary_code: ignoreSecondaryCode ?? false,
                   },
                 },
                 { subscribe: false }


### PR DESCRIPTION
Refactors how operational points are filtered by their secondary codes in the /match_operational_points endpoint.

- When `secondary_code` is null, it now matches only operational points with `extensions.sncf` being null
- When `secondary_code` has a value, it matches operational points where extensions.sncf.ch equals that value

To keep the possibility of filtering only by uic/trigram, it introduces a new boolean parameter `ignore_secondary_code` to ignore secondary code matching when retrieving operational points (OPs) by trigram or UIC.
The frontend is adapted accordingly.