### PR TITLE
core: make s3 writes async

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/api/S3Context.kt
+++ b/core/src/main/java/fr/sncf/osrd/api/S3Context.kt
@@ -4,6 +4,10 @@ import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.annotations.WithSpan
 import java.net.URI
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import mu.KotlinLogging
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.regions.Region
@@ -21,23 +25,30 @@ val s3Logger = KotlinLogging.logger {}
  * Note: as this S3 is only used to generate data that helps with viewing and debugging, errors are
  * never critical. All operations are wrapped into try/catch blocks with error logging.
  */
-data class S3Context(val s3Client: S3Client, val bucketName: String) {
+data class S3Context(
+    val s3Client: S3Client,
+    val bucketName: String,
+    // Dispatchers.IO should dispatch tasks to different threads without blocking
+    val asyncDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) {
 
     /** Write a new file for a given stdcm request. */
     @WithSpan(value = "Writing S3 file", kind = SpanKind.SERVER)
     fun writeSTDCMFile(fileName: String, content: String) {
-        try {
-            val traceId = Span.current().spanContext.traceId
-            s3Logger.info { "Request $traceId: writing $fileName" }
-            val putObjectRequest =
-                PutObjectRequest.builder()
-                    .bucket(bucketName)
-                    .key("stdcm/requests/$traceId/$fileName")
-                    .build()
+        runAsync {
+            try {
+                val traceId = Span.current().spanContext.traceId
+                s3Logger.info { "Request $traceId: writing $fileName" }
+                val putObjectRequest =
+                    PutObjectRequest.builder()
+                        .bucket(bucketName)
+                        .key("stdcm/requests/$traceId/$fileName")
+                        .build()
 
-            s3Client.putObject(putObjectRequest, RequestBody.fromString(content))
-        } catch (e: Exception) {
-            s3Logger.error { e }
+                s3Client.putObject(putObjectRequest, RequestBody.fromString(content))
+            } catch (e: Exception) {
+                s3Logger.error { e }
+            }
         }
     }
 
@@ -62,6 +73,14 @@ data class S3Context(val s3Client: S3Client, val bucketName: String) {
             s3Logger.error { e }
             false
         }
+    }
+
+    /**
+     * Run an async task in a "fire and forger" way. Used to write files to the s3 when we don't
+     * need to wait for it to finish nor verify that it worked.
+     */
+    fun runAsync(func: suspend () -> Unit) {
+        CoroutineScope(asyncDispatcher).launch { func() }
     }
 }
 

--- a/core/src/main/java/fr/sncf/osrd/api/TimetableCacheManager.kt
+++ b/core/src/main/java/fr/sncf/osrd/api/TimetableCacheManager.kt
@@ -292,21 +292,23 @@ class TimetableCacheManager(
     private fun saveToS3(cacheKey: String, requirements: STDCMTimetableData) {
         if (s3Context == null) return
 
-        val objectPath = "stdcm/saved_timetables/$cacheKey.cbor"
-        if (s3Context.fileExists(objectPath)) return
+        s3Context.runAsync {
+            val objectPath = "stdcm/saved_timetables/$cacheKey.cbor"
+            if (s3Context.fileExists(objectPath)) return@runAsync
 
-        try {
-            val putObjectRequest =
-                PutObjectRequest.builder().bucket(s3Context.bucketName).key(objectPath).build()
+            try {
+                val putObjectRequest =
+                    PutObjectRequest.builder().bucket(s3Context.bucketName).key(objectPath).build()
 
-            val serializable = requirements.toSerializable()
-            val cbor = Cbor {}
-            val serializer = STDCMTimetableData.SerializableMap.serializer()
-            val bytes = cbor.encodeToByteArray(serializer, serializable)
+                val serializable = requirements.toSerializable()
+                val cbor = Cbor {}
+                val serializer = STDCMTimetableData.SerializableMap.serializer()
+                val bytes = cbor.encodeToByteArray(serializer, serializable)
 
-            s3Context.s3Client.putObject(putObjectRequest, RequestBody.fromBytes(bytes))
-        } catch (e: Exception) {
-            logger.error("failed to save timetable to s3", e)
+                s3Context.s3Client.putObject(putObjectRequest, RequestBody.fromBytes(bytes))
+            } catch (e: Exception) {
+                logger.error("failed to save timetable to s3", e)
+            }
         }
     }
 }


### PR DESCRIPTION
S3 writes can take a while, especially when the service isn't reachable for some reason.

This PR makes it non-blocking, we just "fire and forget" the s3 writes.