### PR TITLE
editoast: rename paced_train and paced_train_round_trips tables

### DIFF
--- a/editoast/database/src/tables.rs
+++ b/editoast/database/src/tables.rs
@@ -485,50 +485,6 @@ diesel::table! {
 diesel::table! {
     use diesel::sql_types::*;
     use postgis_diesel::sql_types::*;
-    use super::sql_types::TrainMainCategory;
-
-    paced_train (id) {
-        id -> Int8,
-        #[max_length = 128]
-        train_name -> Varchar,
-        labels -> Array<Nullable<Text>>,
-        #[max_length = 128]
-        rolling_stock_name -> Varchar,
-        start_time -> Timestamptz,
-        schedule -> Jsonb,
-        margins -> Jsonb,
-        initial_speed -> Float8,
-        comfort -> Int2,
-        path -> Jsonb,
-        constraint_distribution -> Int2,
-        #[max_length = 128]
-        speed_limit_tag -> Nullable<Varchar>,
-        power_restrictions -> Jsonb,
-        options -> Jsonb,
-        time_window -> Nullable<Interval>,
-        interval -> Nullable<Interval>,
-        main_category -> Nullable<TrainMainCategory>,
-        exceptions -> Jsonb,
-        #[max_length = 255]
-        sub_category -> Nullable<Varchar>,
-        train_schedule_set_id -> Int8,
-    }
-}
-
-diesel::table! {
-    use diesel::sql_types::*;
-    use postgis_diesel::sql_types::*;
-
-    paced_train_round_trips (id) {
-        id -> Int8,
-        left_id -> Int8,
-        right_id -> Nullable<Int8>,
-    }
-}
-
-diesel::table! {
-    use diesel::sql_types::*;
-    use postgis_diesel::sql_types::*;
 
     project (id) {
         id -> Int8,
@@ -876,6 +832,50 @@ diesel::table! {
 diesel::table! {
     use diesel::sql_types::*;
     use postgis_diesel::sql_types::*;
+    use super::sql_types::TrainMainCategory;
+
+    train_schedule (id) {
+        id -> Int8,
+        #[max_length = 128]
+        train_name -> Varchar,
+        labels -> Array<Nullable<Text>>,
+        #[max_length = 128]
+        rolling_stock_name -> Varchar,
+        start_time -> Timestamptz,
+        schedule -> Jsonb,
+        margins -> Jsonb,
+        initial_speed -> Float8,
+        comfort -> Int2,
+        path -> Jsonb,
+        constraint_distribution -> Int2,
+        #[max_length = 128]
+        speed_limit_tag -> Nullable<Varchar>,
+        power_restrictions -> Jsonb,
+        options -> Jsonb,
+        time_window -> Nullable<Interval>,
+        interval -> Nullable<Interval>,
+        main_category -> Nullable<TrainMainCategory>,
+        exceptions -> Jsonb,
+        #[max_length = 255]
+        sub_category -> Nullable<Varchar>,
+        train_schedule_set_id -> Int8,
+    }
+}
+
+diesel::table! {
+    use diesel::sql_types::*;
+    use postgis_diesel::sql_types::*;
+
+    train_schedule_round_trips (id) {
+        id -> Int8,
+        left_id -> Int8,
+        right_id -> Nullable<Int8>,
+    }
+}
+
+diesel::table! {
+    use diesel::sql_types::*;
+    use postgis_diesel::sql_types::*;
 
     train_schedule_set (id) {
         id -> Int8,
@@ -943,7 +943,6 @@ diesel::joinable!(infra_object_switch -> infra (infra_id));
 diesel::joinable!(infra_object_track_section -> infra (infra_id));
 diesel::joinable!(macro_node -> scenario (scenario_id));
 diesel::joinable!(macro_note -> scenario (scenario_id));
-diesel::joinable!(paced_train -> train_schedule_set (train_schedule_set_id));
 diesel::joinable!(project -> document (image_id));
 diesel::joinable!(rolling_stock_livery -> document (compound_image_id));
 diesel::joinable!(rolling_stock_livery -> rolling_stock (rolling_stock_id));
@@ -968,6 +967,7 @@ diesel::joinable!(study -> project (project_id));
 diesel::joinable!(temporary_speed_limit -> temporary_speed_limit_group (temporary_speed_limit_group_id));
 diesel::joinable!(timetable_train_schedule_set -> timetable (timetable_id));
 diesel::joinable!(timetable_train_schedule_set -> train_schedule_set (train_schedule_set_id));
+diesel::joinable!(train_schedule -> train_schedule_set (train_schedule_set_id));
 diesel::joinable!(train_schedule_set -> catalog_entry (catalog_entry_id));
 diesel::joinable!(work_schedule -> work_schedule_group (work_schedule_group_id));
 
@@ -1006,8 +1006,6 @@ diesel::allow_tables_to_appear_in_same_query!(
     infra_object_track_section,
     macro_node,
     macro_note,
-    paced_train,
-    paced_train_round_trips,
     project,
     rolling_stock,
     rolling_stock_livery,
@@ -1028,6 +1026,8 @@ diesel::allow_tables_to_appear_in_same_query!(
     timetable,
     timetable_train_schedule_set,
     towed_rolling_stock,
+    train_schedule,
+    train_schedule_round_trips,
     train_schedule_set,
     work_schedule,
     work_schedule_group,

--- a/editoast/database/src/tables_patch.rs
+++ b/editoast/database/src/tables_patch.rs
@@ -1,4 +1,4 @@
 use crate::tables::*;
 
 // Add missing joinable macros since diesel can not generate them automatically
-diesel::joinable!(paced_train_round_trips -> paced_train (left_id));
+diesel::joinable!(train_schedule_round_trips -> train_schedule (left_id));

--- a/editoast/editoast_models/src/rolling_stock/schedules_from_rolling_stock.rs
+++ b/editoast/editoast_models/src/rolling_stock/schedules_from_rolling_stock.rs
@@ -7,12 +7,12 @@ use serde::Serialize;
 use utoipa::ToSchema;
 
 use database::DbConnection;
-use database::tables::paced_train;
 use database::tables::project;
 use database::tables::rolling_stock;
 use database::tables::scenario;
 use database::tables::study;
 use database::tables::timetable_train_schedule_set;
+use database::tables::train_schedule;
 
 use super::RollingStock;
 
@@ -51,12 +51,12 @@ impl RollingStock {
         &self,
         conn: &mut DbConnection,
     ) -> Result<Vec<ScenarioReference>, database::DatabaseError> {
-        let schedules: Vec<_> = paced_train::table
+        let schedules: Vec<_> = train_schedule::table
             .inner_join(
-                rolling_stock::table.on(paced_train::rolling_stock_name.eq(rolling_stock::name)),
+                rolling_stock::table.on(train_schedule::rolling_stock_name.eq(rolling_stock::name)),
             )
             .inner_join(
-                timetable_train_schedule_set::table.on(paced_train::train_schedule_set_id
+                timetable_train_schedule_set::table.on(train_schedule::train_schedule_set_id
                     .eq(timetable_train_schedule_set::train_schedule_set_id)),
             )
             .inner_join(
@@ -73,7 +73,7 @@ impl RollingStock {
                 scenario::name,
             ))
             .filter(rolling_stock::id.eq(self.id))
-            .filter(paced_train::id.is_not_null())
+            .filter(train_schedule::id.is_not_null())
             .load::<SchedulesFromRollingStock>(conn.write().await.deref_mut())
             .await?;
         let schedules = schedules.into_iter().map_into().collect();

--- a/editoast/editoast_models/src/round_trips.rs
+++ b/editoast/editoast_models/src/round_trips.rs
@@ -11,7 +11,7 @@ use crate as editoast_models;
 
 #[derive(Clone, Debug, Model)]
 #[model(row(derive(QueryableByName)))]
-#[model(table = database::tables::paced_train_round_trips)]
+#[model(table = database::tables::train_schedule_round_trips)]
 #[model(gen(batch_ops = cd))]
 pub struct PacedTrainRoundTrips {
     pub id: i64,
@@ -35,21 +35,21 @@ impl PacedTrainRoundTrips {
         page: u64,
         page_size: u64,
     ) -> Result<(Vec<Self>, u64), database::DatabaseError> {
-        use database::tables::paced_train;
-        use database::tables::paced_train_round_trips;
         use database::tables::timetable_train_schedule_set;
+        use database::tables::train_schedule;
+        use database::tables::train_schedule_round_trips;
 
-        let query = paced_train_round_trips::table
-            .inner_join(paced_train::table)
-            .select(paced_train_round_trips::all_columns)
+        let query = train_schedule_round_trips::table
+            .inner_join(train_schedule::table)
+            .select(train_schedule_round_trips::all_columns)
             .filter(
-                paced_train::dsl::train_schedule_set_id.eq_any(
+                train_schedule::dsl::train_schedule_set_id.eq_any(
                     timetable_train_schedule_set::dsl::timetable_train_schedule_set
                         .select(timetable_train_schedule_set::dsl::train_schedule_set_id)
                         .filter(timetable_train_schedule_set::dsl::timetable_id.eq(timetable_id)),
                 ),
             )
-            .order_by(paced_train_round_trips::id.asc());
+            .order_by(train_schedule_round_trips::id.asc());
 
         let (results, count): (Vec<PacedTrainRoundTripsRow>, _) =
             load_for_pagination(conn, query, page, page_size).await?;
@@ -69,14 +69,14 @@ impl PacedTrainRoundTrips {
         conn: &mut DbConnection,
         paced_train_ids: I,
     ) -> Result<usize, database::DatabaseError> {
-        use database::tables::paced_train_round_trips::dsl;
+        use database::tables::train_schedule_round_trips::dsl;
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
         use std::ops::DerefMut;
 
         let ids = paced_train_ids.into_iter().collect::<Vec<_>>();
         let nb = diesel::delete(
-            database::tables::paced_train_round_trips::table
+            database::tables::train_schedule_round_trips::table
                 .filter(dsl::left_id.eq_any(&ids).or(dsl::right_id.eq_any(&ids))),
         )
         .execute(conn.write().await.deref_mut())
@@ -91,13 +91,13 @@ impl PacedTrainRoundTrips {
         conn: &mut DbConnection,
         paced_train_ids: I,
     ) -> Result<Vec<Self>, database::DatabaseError> {
-        use database::tables::paced_train_round_trips::dsl;
+        use database::tables::train_schedule_round_trips::dsl;
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
         use std::ops::DerefMut;
 
         let ids = paced_train_ids.into_iter().collect::<Vec<_>>();
-        let results = database::tables::paced_train_round_trips::table
+        let results = database::tables::train_schedule_round_trips::table
             .filter(dsl::left_id.eq_any(&ids).or(dsl::right_id.eq_any(&ids)))
             .load::<PacedTrainRoundTripsRow>(conn.write().await.deref_mut())
             .await?;

--- a/editoast/editoast_models/src/timetable.rs
+++ b/editoast/editoast_models/src/timetable.rs
@@ -35,12 +35,12 @@ impl Timetable {
         timetable_id: i64,
         conn: &mut DbConnection,
     ) -> Result<i64, database::DatabaseError> {
-        use database::tables::paced_train;
         use database::tables::timetable_train_schedule_set;
+        use database::tables::train_schedule;
 
-        paced_train::dsl::paced_train
+        train_schedule::dsl::train_schedule
             .filter(
-                paced_train::dsl::train_schedule_set_id.eq_any(
+                train_schedule::dsl::train_schedule_set_id.eq_any(
                     timetable_train_schedule_set::dsl::timetable_train_schedule_set
                         .select(timetable_train_schedule_set::dsl::train_schedule_set_id)
                         .filter(timetable_train_schedule_set::dsl::timetable_id.eq(timetable_id)),
@@ -70,13 +70,13 @@ impl Timetable {
         timetable_id: i64,
         conn: &mut DbConnection,
     ) -> Result<Vec<DateTime<Utc>>, database::DatabaseError> {
-        use database::tables::paced_train;
         use database::tables::timetable_train_schedule_set;
+        use database::tables::train_schedule;
 
-        paced_train::dsl::paced_train
-            .select(paced_train::dsl::start_time)
+        train_schedule::dsl::train_schedule
+            .select(train_schedule::dsl::start_time)
             .filter(
-                paced_train::dsl::train_schedule_set_id.eq_any(
+                train_schedule::dsl::train_schedule_set_id.eq_any(
                     timetable_train_schedule_set::dsl::timetable_train_schedule_set
                         .select(timetable_train_schedule_set::dsl::train_schedule_set_id)
                         .filter(timetable_train_schedule_set::dsl::timetable_id.eq(timetable_id)),
@@ -170,10 +170,10 @@ impl TimetableWithTrains {
     ) -> Result<Option<Self>, DatabaseError> {
         let result = sql_query(
             "SELECT timetable.*,
-        array_remove(array_agg(paced_train.id), NULL) as paced_train_ids
+        array_remove(array_agg(train_schedule.id), NULL) as paced_train_ids
         FROM timetable
         JOIN timetable_train_schedule_set ON timetable.id = timetable_train_schedule_set.timetable_id
-        LEFT JOIN paced_train ON timetable_train_schedule_set.train_schedule_set_id = paced_train.train_schedule_set_id
+        LEFT JOIN train_schedule ON timetable_train_schedule_set.train_schedule_set_id = train_schedule.train_schedule_set_id
         WHERE timetable.id = $1
         GROUP BY timetable.id",
         )

--- a/editoast/migrations/2026-02-04-120554-0000_paced_train_to_train_schedule/down.sql
+++ b/editoast/migrations/2026-02-04-120554-0000_paced_train_to_train_schedule/down.sql
@@ -1,0 +1,5 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE train_schedule
+    RENAME TO paced_train;
+ALTER TABLE train_schedule_round_trips
+    RENAME TO paced_train_round_trips;

--- a/editoast/migrations/2026-02-04-120554-0000_paced_train_to_train_schedule/up.sql
+++ b/editoast/migrations/2026-02-04-120554-0000_paced_train_to_train_schedule/up.sql
@@ -1,0 +1,5 @@
+-- Your SQL goes here
+ALTER TABLE paced_train
+    RENAME TO train_schedule;
+ALTER TABLE paced_train_round_trips
+    RENAME TO train_schedule_round_trips;

--- a/editoast/src/models/paced_train.rs
+++ b/editoast/src/models/paced_train.rs
@@ -27,7 +27,7 @@ use utoipa::ToSchema;
 
 #[derive(Debug, Clone, Model)]
 #[cfg_attr(test, derive(Default, PartialEq))]
-#[model(table = database::tables::paced_train)]
+#[model(table = database::tables::train_schedule)]
 #[model(gen(ops = crud, batch_ops = crud, list))]
 pub struct PacedTrain {
     pub id: i64,

--- a/editoast/src/models/train_schedule_set.rs
+++ b/editoast/src/models/train_schedule_set.rs
@@ -25,9 +25,9 @@ impl TrainScheduleSet {
         train_schedule_set_id: i64,
         conn: &mut DbConnection,
     ) -> Result<i64, database::DatabaseError> {
-        use database::tables::paced_train::dsl;
+        use database::tables::train_schedule::dsl;
 
-        dsl::paced_train
+        dsl::train_schedule
             .filter(dsl::train_schedule_set_id.eq(train_schedule_set_id))
             .count()
             .get_result(conn.write().await.deref_mut())

--- a/editoast/src/views/search.rs
+++ b/editoast/src/views/search.rs
@@ -718,7 +718,7 @@ pub(super) struct SearchResultItemScenario {
     #[search(sql = "infra.name")]
     infra_name: String,
     #[search(
-        sql = "(SELECT COUNT(trains.id) FROM paced_train AS trains WHERE scenario.timetable_id = trains.timetable_id)"
+        sql = "(SELECT COUNT(trains.id) FROM train_schedule AS trains WHERE scenario.timetable_id = trains.timetable_id)"
     )]
     paced_trains_count: u64,
     #[search(
@@ -736,41 +736,41 @@ pub(super) struct SearchResultItemScenario {
 #[derive(Search, Serialize, ToSchema)]
 #[cfg_attr(test, derive(serde::Deserialize))]
 #[search(
-    table = "paced_train",
+    table = "train_schedule",
     column(name = "train_schedule_set_id", data_type = "integer"),
     column(name = "train_name", data_type = "string")
 )]
 /// A search result item for a query with `object = "trainschedule"`
 pub(super) struct SearchResultItemTrainSchedule {
-    #[search(sql = "paced_train.id")]
+    #[search(sql = "train_schedule.id")]
     id: u64,
-    #[search(sql = "paced_train.train_name")]
+    #[search(sql = "train_schedule.train_name")]
     train_name: String,
-    #[search(sql = "paced_train.labels")]
+    #[search(sql = "train_schedule.labels")]
     labels: Vec<Option<String>>,
-    #[search(sql = "paced_train.rolling_stock_name")]
+    #[search(sql = "train_schedule.rolling_stock_name")]
     rolling_stock_name: String,
-    #[search(sql = "paced_train.train_schedule_set_id")]
+    #[search(sql = "train_schedule.train_schedule_set_id")]
     train_schedule_set_id: i64,
-    #[search(sql = "paced_train.start_time")]
+    #[search(sql = "train_schedule.start_time")]
     start_time: DateTime<Utc>,
-    #[search(sql = "paced_train.schedule")]
+    #[search(sql = "train_schedule.schedule")]
     schedule: Vec<ScheduleItem>,
-    #[search(sql = "paced_train.margins")]
+    #[search(sql = "train_schedule.margins")]
     margins: Margins,
-    #[search(sql = "paced_train.initial_speed")]
+    #[search(sql = "train_schedule.initial_speed")]
     initial_speed: f64,
-    #[search(sql = "paced_train.comfort")]
+    #[search(sql = "train_schedule.comfort")]
     comfort: i64,
-    #[search(sql = "paced_train.path")]
+    #[search(sql = "train_schedule.path")]
     path: Vec<PathItem>,
-    #[search(sql = "paced_train.constraint_distribution")]
+    #[search(sql = "train_schedule.constraint_distribution")]
     constraint_distribution: i64,
-    #[search(sql = "paced_train.speed_limit_tag")]
+    #[search(sql = "train_schedule.speed_limit_tag")]
     speed_limit_tag: Option<String>,
-    #[search(sql = "paced_train.power_restrictions")]
+    #[search(sql = "train_schedule.power_restrictions")]
     power_restrictions: Vec<PowerRestrictionItem>,
-    #[search(sql = "paced_train.options")]
+    #[search(sql = "train_schedule.options")]
     options: TrainScheduleOptions,
 }
 


### PR DESCRIPTION
first part of #15058 

The goal of this PR is to rename first only the tables paced_train -> train_schedule and paced_train_round_trips into train_schedule_round_trips

