### PR TITLE
front: fix the scenario page height

### DIFF
--- a/front/src/applications/stdcm/styles/_home.scss
+++ b/front/src/applications/stdcm/styles/_home.scss
@@ -1,6 +1,7 @@
 .stdcm {
   font-family: 'IBM Plex Sans';
   position: relative;
+  overflow: auto;
 
   /*
   We set the cursor to default to avoid the pointer cursor that appears due to role="button" on the div.

--- a/front/src/styles/scss/applications/operationalStudies/_scenarioContentV2.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_scenarioContentV2.scss
@@ -2,10 +2,12 @@
   display: flex;
   flex-direction: column;
   height: 100vh;
+  overflow-y: hidden;
 }
 
 .scenario-content-v2 {
   display: flex;
+  flex: 1;
   min-height: 0;
 
   .right-column,


### PR DESCRIPTION
Closes #15060

This will also fix the double scrollbar that appears on the hole page when the scenario description is opened as it was previously fixed by the breaking change.