### PR TITLE
core: penalize track number changes in pathfinding

### DIFF
--- a/core/kt-osrd-rjs-parser/src/main/kotlin/fr/sncf/osrd/RawInfraRJSParser.kt
+++ b/core/kt-osrd-rjs-parser/src/main/kotlin/fr/sncf/osrd/RawInfraRJSParser.kt
@@ -328,6 +328,7 @@ private fun parseRjsTrackSection(
     val trackSectionSlopes = getSlopes(rjsTrack)
     val trackSectionCurves = getCurves(rjsTrack)
     val trackSectionBlockedGauges = getBlockedGauge(rjsTrack)
+    val trackSectionNumber = rjsTrack.extensions?.sncf?.trackNumber
 
     val chunkBoundariesOffsets = mutableOffsetArrayListOf<TrackSection>(Offset.zero())
     val chunkBoundariesDetectors = mutableListOf<List<String>?>(null)
@@ -388,6 +389,7 @@ private fun parseRjsTrackSection(
                 Offset(chunkLength),
                 chunkStartOffset,
                 chunkBlockedGauges,
+                trackSectionNumber,
             )
         trackSectionChunks.add(chunkIdx)
     }

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/TrackProperties.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/TrackProperties.kt
@@ -87,6 +87,8 @@ interface TrackProperties {
 
     fun getTrackChunkGeom(trackChunk: TrackChunkId): LineString
 
+    fun getTrackChunkTrackNumber(trackChunk: TrackChunkId): Int?
+
     // Operational points
     fun getTrackChunkOperationalPointParts(trackChunk: TrackChunkId): List<OperationalPointPartId>
 

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraBuilder.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraBuilder.kt
@@ -463,6 +463,7 @@ class RawInfraBuilder {
         length: Length<TrackChunk>,
         offset: Offset<TrackSection>,
         loadingGaugeConstraints: DistanceRangeMap<LoadingGaugeConstraint>,
+        trackNumber: Int?,
     ): TrackChunkId {
         val initSpeedSections = {
             distanceRangeMapOf(
@@ -498,6 +499,7 @@ class RawInfraBuilder {
                 DirectionalMap(distanceRangeMapOf(), distanceRangeMapOf()),
                 // SpeedSections will be filled later on,
                 DirectionalMap(initSpeedSections(), initSpeedSections()),
+                trackNumber,
             )
         )
     }

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraImpl.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraImpl.kt
@@ -104,6 +104,7 @@ class TrackChunkDescriptor(
     val electrificationVoltage: DistanceRangeMap<Set<String>>,
     val neutralSections: DirectionalMap<DistanceRangeMap<NeutralSection>>,
     val speedSections: DirectionalMap<DistanceRangeMap<SpeedSection>>,
+    val trackNumber: Int?,
 )
 
 class ZoneDescriptor(val movableElements: StaticIdxSortedSet<TrackNode>, var name: String = "")
@@ -491,6 +492,10 @@ class RawInfraImpl(
 
     override fun getTrackChunkGeom(trackChunk: TrackChunkId): LineString {
         return trackChunkPool[trackChunk].geo
+    }
+
+    override fun getTrackChunkTrackNumber(trackChunk: TrackChunkId): Int? {
+        return trackChunkPool[trackChunk].trackNumber
     }
 
     override fun getTrackChunkSlope(trackChunk: DirTrackChunkId): DistanceRangeMap<Double> {

--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/Extensions.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/Extensions.kt
@@ -2,12 +2,11 @@ package fr.sncf.osrd.utils
 
 /** Removes consecutive duplicated values from a list. Keeps duplicates that aren't consecutive. */
 fun <T> List<T>.withoutConsecutiveDuplicates(): List<T> {
-    val res = mutableListOf<T>()
-    var last: T? = null
-    for (x in this) {
-        if (last != x) {
+    if (isEmpty()) return emptyList()
+    val res = mutableListOf(first())
+    for (x in dropSeq(1)) {
+        if (res.last() != x) {
             res.add(x)
-            last = x
         }
     }
     return res

--- a/core/osrd-railjson/src/main/java/fr/sncf/osrd/railjson/schema/infra/RJSTrackSection.java
+++ b/core/osrd-railjson/src/main/java/fr/sncf/osrd/railjson/schema/infra/RJSTrackSection.java
@@ -8,6 +8,7 @@ import fr.sncf.osrd.railjson.schema.infra.trackranges.RJSCurve;
 import fr.sncf.osrd.railjson.schema.infra.trackranges.RJSLoadingGaugeLimit;
 import fr.sncf.osrd.railjson.schema.infra.trackranges.RJSSlope;
 import java.util.List;
+import org.jetbrains.annotations.Nullable;
 
 @SuppressFBWarnings({"UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR", "UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD"})
 public class RJSTrackSection implements Identified {
@@ -22,6 +23,9 @@ public class RJSTrackSection implements Identified {
 
     public RJSLineString geo;
 
+    @Nullable
+    public TrackExtensions extensions;
+
     public RJSTrackSection(String id, double length) {
         this.id = id;
         this.length = length;
@@ -30,5 +34,29 @@ public class RJSTrackSection implements Identified {
     @Override
     public String getID() {
         return id;
+    }
+
+    /** Track extensions are extra metadata that shouldn't normally be used for simulation, but may help with some heuristic. */
+    public static class TrackExtensions {
+        @Nullable
+        public SNCFExtension sncf;
+    }
+
+    public static class SNCFExtension {
+        @Nullable
+        @Json(name = "line_code")
+        public Integer lineCode;
+
+        @Nullable
+        @Json(name = "line_name")
+        public String lineName;
+
+        @Nullable
+        @Json(name = "track_name")
+        public String trackName;
+
+        @Nullable
+        @Json(name = "track_number")
+        public Integer trackNumber;
     }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.kt
@@ -222,12 +222,20 @@ fun hasDuplicateTracks(infra: FullInfra, path: TrainPath): Boolean {
 }
 
 const val SIGNALING_SYSTEM_COST_WEIGHTING = 1e-2
+const val COST_PER_TRACK_CHANGE = 10.0
 
 private fun getRangeCost(
     range: EdgeRange<PathfindingEdge>,
     mrspBuilder: CachedBlockMRSPBuilder,
     infra: FullInfra,
 ): Double {
+    val trackNumbers =
+        infra.blockInfra
+            .getBlockZonePaths(range.edge.block)
+            .flatMap { infra.rawInfra.getZonePathChunks(it) }
+            .map { infra.rawInfra.getTrackChunkTrackNumber(it.value) }
+            .withoutConsecutiveDuplicates()
+    val trackChanges = trackNumbers.size - 1
     val edgeDuration =
         mrspBuilder.getBlockTime(range.edge.block, range.end) -
             mrspBuilder.getBlockTime(range.edge.block, range.start)
@@ -236,7 +244,8 @@ private fun getRangeCost(
             infra.signalingSimulator.sigModuleManager.getCost(
                 infra.blockInfra.getBlockSignalingSystem(range.edge.block)
             )
-    return (edgeDuration) * (1 + signalingSystemPenaltyFactor)
+    return (edgeDuration) * (1 + signalingSystemPenaltyFactor) +
+        COST_PER_TRACK_CHANGE * trackChanges
 }
 
 @WithSpan(value = "Identifying why no path was found")

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMNode.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMNode.kt
@@ -11,6 +11,8 @@ import fr.sncf.osrd.utils.cacheable
 import fr.sncf.osrd.utils.units.Offset
 import kotlin.math.min
 
+const val STDCM_COST_PER_TRACK_CHANGE = 10.0
+
 data class STDCMNode(
     val timeData: TimeData,
     // Speed at the end of the previous edge
@@ -49,17 +51,25 @@ data class STDCMNode(
      * path. We then explore them in that order.
      */
     override fun compareTo(other: STDCMNode): Int {
-        val runTimeEstimation = timeData.totalRunningTime + remainingTimeEstimation
-        val otherRunTimeEstimation = other.timeData.totalRunningTime + other.remainingTimeEstimation
+
         // First, minimize the total run time:
         // highest priority node takes the least time to complete the path
-        if (!areTimesEqual(runTimeEstimation, otherRunTimeEstimation))
-            return runTimeEstimation.compareTo(otherRunTimeEstimation)
+        val runTimeEstimation = timeData.totalRunningTime + remainingTimeEstimation
+        val otherRunTimeEstimation = other.timeData.totalRunningTime + other.remainingTimeEstimation
+
+        // Main cost, this is where "penalties" should be added.
+        // The rest only apply in case of equalities.
+        val cost =
+            runTimeEstimation + STDCM_COST_PER_TRACK_CHANGE * infraExplorer.getTrackChangeCount()
+        val otherCost =
+            otherRunTimeEstimation +
+                STDCM_COST_PER_TRACK_CHANGE * other.infraExplorer.getTrackChangeCount()
+        if (!areTimesEqual(cost, otherCost)) return cost.compareTo(otherCost)
 
         val plannedRelativeTimeDiff = getRelativeTimeDiff(timeData)
         val otherPlannedRelativeTimeDiff = other.getRelativeTimeDiff(other.timeData)
 
-        // If equal, minimise the difference with the planned arrival times
+        // If equal, minimize the difference with the planned arrival times
         return if (
             plannedRelativeTimeDiff != null &&
                 otherPlannedRelativeTimeDiff != null &&

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
@@ -150,8 +150,6 @@ class STDCMPathfinding(
                     comfort,
                     maxRunTime,
                     blockAvailability,
-                    graph.tag,
-                    temporarySpeedLimitManager,
                 ) ?: return null
         val travelTime = res.envelope.totalTime
         val stopTime = res.stopResults.sumOf { it.duration }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
@@ -7,7 +7,6 @@ import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
 import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal.OPEN
 import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal.SHORT_SLIP_STOP
-import fr.sncf.osrd.sim_infra.impl.TemporarySpeedLimitManager
 import fr.sncf.osrd.stdcm.STDCMResult
 import fr.sncf.osrd.stdcm.preprocessing.interfaces.BlockAvailabilityInterface
 import fr.sncf.osrd.train.RollingStock
@@ -39,8 +38,6 @@ class STDCMPostProcessing(private val graph: STDCMGraph) {
         comfort: Comfort?,
         maxRunTime: Double,
         blockAvailability: BlockAvailabilityInterface,
-        trainTag: String?,
-        temporarySpeedLimitManager: TemporarySpeedLimitManager,
     ): STDCMResult? {
         val edges = path.edges
         val lastExplorer = edges.last().infraExplorer

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
@@ -138,6 +138,8 @@ interface InfraExplorer {
      * of the currently known path.
      */
     fun getLookaheadEndOffset(): Offset<PhysicsPath>
+
+    fun getTrackChangeCount(): Int
 }
 
 /** Returns the current block and the lookahead blocks */
@@ -187,7 +189,6 @@ fun initInfraExplorers(
                 appendOnlyLinkedListOf(),
                 appendOnlyLinkedListOf(),
                 appendOnlyMapOf(),
-                null,
                 blockToPathProperties,
                 stepTracker = StepTracker(steps),
                 constraints = constraints,
@@ -204,12 +205,13 @@ private class InfraExplorerImpl(
     private var blockRanges: AppendOnlyLinkedList<BlockRange>,
     private var routes: AppendOnlyLinkedList<RouteRange>,
     private var blockRoutes: AppendOnlyMap<BlockId, RouteId>,
-    private var lastTrack: TrackSectionId?,
     private var trainPathCache: MutableMap<BlockId, TrainPath>,
     private var currentIndex: Int = 0,
     private var stepTracker: StepTracker,
     private var constraints: List<PathfindingConstraint<Block>>,
     override var isPathComplete: Boolean = false,
+    private var trackChangeCount: Int = 0,
+    private var lastTrackNumber: Int? = null,
 ) : InfraExplorer {
     override fun getCurrentEdgePathProperties(offset: Offset<Block>, length: Distance?): TrainPath {
         // We re-compute the routes of the current path since the cache may be incorrect
@@ -302,12 +304,13 @@ private class InfraExplorerImpl(
             this.blockRanges.shallowCopy(),
             this.routes.shallowCopy(),
             this.blockRoutes.shallowCopy(),
-            this.lastTrack,
             this.trainPathCache,
             this.currentIndex,
             this.stepTracker.clone(),
             this.constraints,
             this.isPathComplete,
+            trackChangeCount = this.trackChangeCount,
+            lastTrackNumber = this.lastTrackNumber,
         )
     }
 
@@ -378,6 +381,10 @@ private class InfraExplorerImpl(
 
     override fun getLookaheadEndOffset(): Offset<PhysicsPath> =
         blockRanges.lastOrNull()?.pathEnd ?: Offset.zero()
+
+    override fun getTrackChangeCount(): Int {
+        return trackChangeCount
+    }
 
     /**
      * Updates `incrementalPath`, `routes`, `blocks` and returns true if route can be explored.
@@ -453,6 +460,17 @@ private class InfraExplorerImpl(
                 if (isPathComplete) break // Can't extend any further
             }
         }
+
+        for (zonePath in rawInfra.getRoutePath(route)) {
+            for (chunk in rawInfra.getZonePathChunks(zonePath)) {
+                val trackNumber = rawInfra.getTrackChunkTrackNumber(chunk.value)
+                if (trackNumber != lastTrackNumber) {
+                    lastTrackNumber = trackNumber
+                    trackChangeCount++
+                }
+            }
+        }
+
         assert(seenFirstBlock)
         return true
     }

--- a/core/src/test/kotlin/fr/sncf/osrd/utils/DummyInfra.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/utils/DummyInfra.kt
@@ -461,6 +461,10 @@ class DummyInfra : RawInfra, BlockInfra {
         return LineString.make(entry, exit)
     }
 
+    override fun getTrackChunkTrackNumber(trackChunk: TrackChunkId): Int? {
+        return null
+    }
+
     override fun getTrackChunkOperationalPointParts(
         trackChunk: TrackChunkId
     ): List<OperationalPointPartId> {


### PR DESCRIPTION
On the requests I tested, It seems to significantly reduce the number of track changes in both pathfinding and stdcm, for very little extra path length. I'm using the `track_number` field of sncf track extension, if set. 

* pathfinding: number of track changes is divided by 3, path length is increased by 1m out of 800km
* stdcm: number of track changes divided by 2, path duration increased by 50s out of 10h

TODO: evaluate how that works out on an actual import, and ideally see if we pick the "correct" track.