### PR TITLE
front: fix frameAllPathSteps functions in itinerary modal

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModal.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModal.tsx
@@ -317,9 +317,10 @@ const ItineraryModal = ({
 
   useEffect(() => {
     if (locatedStepsCount < 2 || pathStepsMetadataById.size < 2) return;
+    if (hasInvalidPathStep) return;
 
     frameAllPathSteps();
-  }, [pathStepsMetadataById]);
+  }, [pathStepsMetadataById, hasInvalidPathStep]);
 
   return (
     <dialog ref={modalRef} className="itinerary-modal">

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/hooks/usePathStepsMetadata.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/hooks/usePathStepsMetadata.ts
@@ -130,7 +130,7 @@ export const usePathStepsMetadata = (pathSteps: PathStepV2[]) => {
 
       pathSteps.forEach((pathStep) => {
         const { location } = pathStep;
-
+        // TODO : we need to evaluate if we still need to invalidate a pathstep when it has no location
         if (!location) {
           newPathStepsMetadataById.set(pathStep.id, { isInvalid: true });
           return;


### PR DESCRIPTION
the frameAllPathSteps function, used to frame the pathsteps into viewport, was giving an error when coming from the legacy itinerary modal. 
pathsteps metadatas were not ready at the opening of the new modal, resulting in an assert error. 

closes #15064