### PR TITLE
front: use create train helper everywhere

### DIFF
--- a/front/src/applications/operationalStudies/hooks/useScenarioTrainScheduleSet.ts
+++ b/front/src/applications/operationalStudies/hooks/useScenarioTrainScheduleSet.ts
@@ -8,8 +8,10 @@ import {
   type TrainSchedule,
   type TrainScheduleSet,
 } from 'common/api/osrdEditoastApi';
+import { createPacedTrains } from 'modules/timetableItem/helpers/updateTimetableItemHelpers';
 import type { TimetableItemWithDetails } from 'modules/timetableItem/types';
 import type { TimetableItem } from 'reducers/osrdconf/types';
+import { useAppDispatch } from 'store';
 import { formatEditoastIdToPacedTrainId } from 'utils/trainId';
 
 import { useScenarioContext } from './useScenarioContext';
@@ -43,8 +45,7 @@ export default function useScenarioTrainScheduleSet(
     {}
   );
 
-  const [createPacedTrains] =
-    osrdEditoastApi.endpoints.postTrainScheduleSetsByIdTrainSchedules.useMutation();
+  const dispatch = useAppDispatch();
 
   const [createCatalogEntryMutation] = osrdEditoastApi.endpoints.postCatalogEntries.useMutation();
 
@@ -190,14 +191,9 @@ export default function useScenarioTrainScheduleSet(
         });
 
       // create the trains and attach them to the new local tss
-      const createdTrains = await createPacedTrains({
-        id: newTss.id,
-        body: trainsToCopy,
-      }).unwrap();
+      const createdTrains = await createPacedTrains(dispatch, newTss.id, trainsToCopy);
 
-      upsertTimetableItems(
-        createdTrains.map((train) => ({ ...train, id: formatEditoastIdToPacedTrainId(train.id) }))
-      );
+      upsertTimetableItems(createdTrains);
     },
     [
       createTrainScheduleSetMutation,
@@ -296,17 +292,9 @@ export default function useScenarioTrainScheduleSet(
             train_schedule_set_id: newTss.id,
           }));
 
-          const createdTrains = await createPacedTrains({
-            id: newTss.id,
-            body: trainsWithoutIds,
-          }).unwrap();
+          const createdTrains = await createPacedTrains(dispatch, newTss.id, trainsWithoutIds);
 
-          const formattedCreatedTrains = createdTrains.map((train) => ({
-            ...train,
-            id: formatEditoastIdToPacedTrainId(train.id),
-          }));
-
-          allTrainsToUpsert.push(...formattedCreatedTrains);
+          allTrainsToUpsert.push(...createdTrains);
         }
       }
 

--- a/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/postPayloads.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/postPayloads.ts
@@ -5,41 +5,14 @@ import type {
   RoundTripsFromJson,
   TimetableJsonPayload,
 } from 'applications/operationalStudies/types';
-import {
-  osrdEditoastApi,
-  type MacroNodeForm,
-  type TrainSchedule,
-  type SubCategory,
-} from 'common/api/osrdEditoastApi';
+import { osrdEditoastApi, type MacroNodeForm, type SubCategory } from 'common/api/osrdEditoastApi';
+import { createPacedTrains } from 'modules/timetableItem/helpers/updateTimetableItemHelpers';
 import { setWarning, setFailure } from 'reducers/main';
 import type { TimetableItem } from 'reducers/osrdconf/types';
 import type { AppDispatch } from 'store';
-import { extractEditoastIdFromPacedTrainId, formatEditoastIdToPacedTrainId } from 'utils/trainId';
+import { extractEditoastIdFromPacedTrainId } from 'utils/trainId';
 
 import { generateRoundTripsPayload, generateTrainPayloads } from './generatePayloads';
-
-// TODO: delete this helper and use createPacedTrains (possibly adding if (payloads.length) to it) when the pr createPacedTrain -> createPacedTrains is merged
-export const postTimetableItems = async (
-  trainScheduleSetId: number,
-  payloads: TrainSchedule[],
-  dispatch: AppDispatch
-) => {
-  let timetableItems: TimetableItem[] = [];
-  if (payloads.length) {
-    const rawTimetableItems = await dispatch(
-      osrdEditoastApi.endpoints.postTrainScheduleSetsByIdTrainSchedules.initiate({
-        id: trainScheduleSetId,
-        body: payloads,
-      })
-    ).unwrap();
-
-    timetableItems = rawTimetableItems.map((timetableItem) => ({
-      ...timetableItem,
-      id: formatEditoastIdToPacedTrainId(timetableItem.id),
-    }));
-  }
-  return timetableItems;
-};
 
 const postRoundTrips = async (
   roundTrips: RoundTripsFromJson,
@@ -106,9 +79,9 @@ export const postFullImportPayload = async (
     const timetableItems: TimetableItem[] = [];
 
     const BATCH_SIZE = 1000;
-    const chunks = chunk(pacedTrains, BATCH_SIZE);
-    for (const c of chunks) {
-      timetableItems.push(...(await postTimetableItems(trainScheduleSetId, c, dispatch)));
+    const trainChunks = chunk(pacedTrains, BATCH_SIZE);
+    for (const trainChunk of trainChunks) {
+      timetableItems.push(...(await createPacedTrains(dispatch, trainScheduleSetId, trainChunk)));
     }
 
     if (round_trips) {

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/CreateTimetableItemButton.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/CreateTimetableItemButton.tsx
@@ -3,15 +3,14 @@ import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
 import { useScenarioContext } from 'applications/operationalStudies/hooks/useScenarioContext';
-import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import { useStoreDataForRollingStockSelector } from 'modules/rollingStock/components/RollingStockSelector/useStoreDataForRollingStockSelector';
+import { createPacedTrains } from 'modules/timetableItem/helpers/updateTimetableItemHelpers';
 import { setFailure, setSuccess } from 'reducers/main';
 import { clearAddedExceptionsList } from 'reducers/osrdconf/operationalStudiesConf';
 import { getOperationalStudiesConf } from 'reducers/osrdconf/operationalStudiesConf/selectors';
 import type { TimetableItem } from 'reducers/osrdconf/types';
 import { useAppDispatch } from 'store';
 import { castErrorToFailure } from 'utils/error';
-import { formatEditoastIdToPacedTrainId } from 'utils/trainId';
 
 import checkCurrentConfig from './helpers/checkCurrentConfig';
 import {
@@ -45,9 +44,6 @@ const CreateTimetableItemButton = ({
     rollingStockId: simulationConf.rollingStockID,
   });
 
-  const [postPacedTrain] =
-    osrdEditoastApi.endpoints.postTrainScheduleSetsByIdTrainSchedules.useMutation();
-
   const createTrainSchedules = async () => {
     if (!checkCurrentConfig(simulationConf, t, dispatch, rollingStock?.name)) return;
 
@@ -57,16 +53,10 @@ const CreateTimetableItemButton = ({
       const payload = isPacedTrainMode
         ? formatPacedTrainPayload(simulationConf, rollingStock!.name)
         : formatTimetableItemPayload(simulationConf, rollingStock!.name);
-      const newTimetableItem = await postPacedTrain({
-        id: sandboxId,
-        body: [payload],
-      }).unwrap();
 
-      // We can only add one paced train at a time
-      const formattedNewPacedTrain: TimetableItem = {
-        ...newTimetableItem.at(0)!,
-        id: formatEditoastIdToPacedTrainId(newTimetableItem.at(0)!.id),
-      };
+      const formattedNewPacedTrain: TimetableItem = (
+        await createPacedTrains(dispatch, sandboxId, [payload])
+      )[0];
 
       dispatch(
         setSuccess({

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/PacedTrainItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/PacedTrainItem.tsx
@@ -23,6 +23,7 @@ import { useRollingStockContext } from 'common/RollingStockContext';
 import isMainCategory from 'modules/rollingStock/helpers/category';
 import { getOccurrencesWorstStatus } from 'modules/timetableItem/helpers/pacedTrain';
 import {
+  createPacedTrains,
   deletePacedTrains,
   storePacedTrain,
 } from 'modules/timetableItem/helpers/updateTimetableItemHelpers';
@@ -46,7 +47,6 @@ import { useAppDispatch } from 'store';
 import { addDurationToDate, Duration } from 'utils/duration';
 import { castErrorToFailure } from 'utils/error';
 import {
-  formatEditoastIdToPacedTrainId,
   extractEditoastIdFromPacedTrainId,
   extractPacedTrainIdFromOccurrenceId,
   isPacedTrainId,
@@ -149,8 +149,6 @@ const PacedTrainItem = ({
     upsertTimetableItems,
   });
 
-  const [postPacedTrain] =
-    osrdEditoastApi.endpoints.postTrainScheduleSetsByIdTrainSchedules.useMutation();
   const [getTrainScheduleById] = osrdEditoastApi.endpoints.getTrainSchedulesById.useLazyQuery();
 
   const selectPathProjection = async () => {
@@ -222,21 +220,9 @@ const PacedTrainItem = ({
       train_name: pacedTrainName,
     };
 
-    let pacedTrainResult;
-    try {
-      [pacedTrainResult] = await postPacedTrain({
-        id: pacedTrainDetail.train_schedule_set_id,
-        body: [newPacedTrain],
-      }).unwrap();
-    } catch (e) {
-      dispatch(setFailure(castErrorToFailure(e)));
-      return;
-    }
-
-    const formattedPacedTrainResponse: TimetableItem = {
-      ...pacedTrainResult,
-      id: formatEditoastIdToPacedTrainId(pacedTrainResult.id),
-    };
+    const formattedPacedTrainResponse: TimetableItem = (
+      await createPacedTrains(dispatch, pacedTrainDetail.train_schedule_set_id, [newPacedTrain])
+    )[0];
     upsertTimetableItems([formattedPacedTrainResponse]);
     dispatch(
       setSuccess({

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/UniqueTrainItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/UniqueTrainItem.tsx
@@ -11,7 +11,10 @@ import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import type { SubCategory, TrainSchedule } from 'common/api/osrdEditoastApi';
 import RollingStock2Img from 'modules/rollingStock/components/RollingStock2Img';
 import isMainCategory from 'modules/rollingStock/helpers/category';
-import { deletePacedTrains } from 'modules/timetableItem/helpers/updateTimetableItemHelpers';
+import {
+  createPacedTrains,
+  deletePacedTrains,
+} from 'modules/timetableItem/helpers/updateTimetableItemHelpers';
 import type { TimetableItemWithDetails } from 'modules/timetableItem/types';
 import { setFailure, setSuccess } from 'reducers/main';
 import type { TimetableItem, TimetableItemId, TrainId } from 'reducers/osrdconf/types';
@@ -25,7 +28,7 @@ import { useAppDispatch } from 'store';
 import { timeToLocaleStringRounded, useDateTimeLocale } from 'utils/date';
 import { addDurationToDate, Duration } from 'utils/duration';
 import { castErrorToFailure } from 'utils/error';
-import { extractEditoastIdFromPacedTrainId, formatEditoastIdToPacedTrainId } from 'utils/trainId';
+import { extractEditoastIdFromPacedTrainId } from 'utils/trainId';
 
 import ArrivalTimeLoader from './ArrivalTimeLoader';
 import { TIMETABLE_ITEM_DELTA } from './consts';
@@ -69,8 +72,6 @@ const UniqueTrainItem = ({
   const dateTimeLocale = useDateTimeLocale();
   const dispatch = useAppDispatch();
 
-  const [postPacedTrain] =
-    osrdEditoastApi.endpoints.postTrainScheduleSetsByIdTrainSchedules.useMutation();
   const [getTrainSchedule] = osrdEditoastApi.endpoints.getTrainSchedulesById.useLazyQuery();
 
   const { summary } = train;
@@ -119,16 +120,12 @@ const UniqueTrainItem = ({
         train_name: trainName,
       };
 
-      const [newUniqueTrain] = await postPacedTrain({
-        id: trainDetail.train_schedule_set_id,
-        body: [newUniqueTrainPayload],
-      }).unwrap();
-
-      const formattedUniqueTrain: TimetableItem = {
-        ...newUniqueTrain,
-        id: formatEditoastIdToPacedTrainId(newUniqueTrain.id),
-      };
-      upsertUniqueTrains([formattedUniqueTrain]);
+      const newUniqueTrain: TimetableItem[] = await createPacedTrains(
+        dispatch,
+        trainDetail.train_schedule_set_id,
+        [newUniqueTrainPayload]
+      );
+      upsertUniqueTrains(newUniqueTrain);
       dispatch(
         setSuccess({
           title: t('timetable.trainAdded'),

--- a/front/src/modules/timetableItem/helpers/updateTimetableItemHelpers.ts
+++ b/front/src/modules/timetableItem/helpers/updateTimetableItemHelpers.ts
@@ -40,6 +40,7 @@ export async function createPacedTrains(
   trainScheduleSetId: number,
   pacedTrains: TrainSchedule[]
 ): Promise<TimetableItem[]> {
+  if (!pacedTrains.length) return [];
   const newPacedTrains = await dispatch(
     osrdEditoastApi.endpoints.postTrainScheduleSetsByIdTrainSchedules.initiate({
       id: trainScheduleSetId,


### PR DESCRIPTION
Generalize the use of the helper to remplace identical code. Many of the places where it is introduced already imported the other helpers from updateTimetableHelpers.ts.