### PR TITLE
editoast: fix auto-fixes test

### DIFF
--- a/editoast/src/views/infra/auto_fixes/mod.rs
+++ b/editoast/src/views/infra/auto_fixes/mod.rs
@@ -982,7 +982,7 @@ mod tests {
 
         assert_eq!(operations.len(), error_count);
 
-        if !operations.len() == 5 {
+        if operations.len() == 5 {
             for obj in [&signal, &detector, &buffer_stop] {
                 assert!(operations.contains(&Operation::Delete(DeleteOperation {
                     obj_id: obj.get_id().to_string(),


### PR DESCRIPTION
The previous test condition used `!operations.len() == 5`, which does not check if the number of operations is different from 5. Instead, it applies a bitwise negation to the length, then compares the result to 5—this is never true for expected values. The test was passing not because the logic was correct, but because the condition was always false, so the assertions inside were never executed.
The new version uses `operations.len() == 5`, which is what we really wanted.