### PR TITLE
core: specify DistanceRangeMap range-openness

### DIFF
--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/DistanceRangeMapExt.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/DistanceRangeMapExt.kt
@@ -35,7 +35,7 @@ fun <T : Any> DistanceRangeMapImpl.Companion.toRangeMap(
 ): RangeMap<Distance, T> {
     val rangeMap = TreeRangeMap.create<Distance, T>()
     for (entry in distanceRangeMap.asList()) {
-        rangeMap.put(Range.closed(entry.lower, entry.upper), entry.value)
+        rangeMap.put(Range.closedOpen(entry.lower, entry.upper), entry.value)
     }
     return rangeMap
 }

--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeMap.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeMap.kt
@@ -17,10 +17,25 @@ import fr.sncf.osrd.utils.units.Distance
  */
 interface DistanceRangeMap<T> : Iterable<DistanceRangeMap.RangeMapEntry<T>> {
 
-    /** When iterating over the values of the map, this represents one range of constant value */
-    data class RangeMapEntry<T>(val lower: Distance, val upper: Distance, val value: T)
+    /** One range of constant value */
+    data class RangeMapEntry<T>(
+        /** The lower bound of the range. Always included. */
+        val lower: Distance,
+        /** The lower bound of the range. Always excluded. */
+        val upper: Distance,
+        val value: T,
+    ) {
+        fun isEmpty(): Boolean = lower >= upper
+    }
 
-    /** Sets the value between the lower and upper distances */
+    /**
+     * Sets the value between the [lower] and [upper] distances.
+     *
+     * [lower] is always included and [upper] is always excluded. If you want to exclude [lower] or
+     * include [upper], use [Distance.nextUp] or [Distance.nextDown].
+     *
+     * If the range between [lower] and [upper] is empty, this method has no effect.
+     */
     fun put(lower: Distance, upper: Distance, value: T)
 
     /** Sets many values more efficiently than many calls to `put` */
@@ -29,10 +44,20 @@ interface DistanceRangeMap<T> : Iterable<DistanceRangeMap.RangeMapEntry<T>> {
     /** Returns a list of the entries in the map */
     fun asList(): List<RangeMapEntry<T>>
 
-    /** Lower bound of the entry with the smallest distance */
+    /**
+     * Lower bound of the entry with the smallest distance.
+     *
+     * This method throws an exception when called on an empty map. Otherwise, because lower bounds
+     * are always excluded, `get(lowerBound())` will always be non-null.
+     */
     fun lowerBound(): Distance
 
-    /** Upper bound of the entry with the highest distance */
+    /**
+     * Upper bound of the entry with the highest distance
+     *
+     * This method throws an exception when called on an empty map. Otherwise, because upper bounds
+     * are always excluded, `get(upperBound())` will always be null.
+     */
     fun upperBound(): Distance
 
     /** Removes all values outside the given range */
@@ -53,7 +78,10 @@ interface DistanceRangeMap<T> : Iterable<DistanceRangeMap.RangeMapEntry<T>> {
     /** Returns a deep copy of the map */
     fun clone(): DistanceRangeMap<T>
 
-    /** Returns a new DistanceRangeMap of the ranges between lower and upper */
+    /**
+     * Returns a new [DistanceRangeMap] where only the ranges between [lower] (included) and [upper]
+     * (excluded) are kept.
+     */
     fun subMap(lower: Distance, upper: Distance): DistanceRangeMap<T>
 
     /**

--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeMapImpl.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeMapImpl.kt
@@ -192,7 +192,7 @@ data class DistanceRangeMapImpl<T>(
     override fun get(offset: Distance): T? {
         // TODO: use a binary search
         for (entry in this.reversed()) {
-            if (entry.lower <= offset && offset <= entry.upper) return entry.value
+            if (entry.lower <= offset && offset < entry.upper) return entry.value
         }
         return null
     }

--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeMapImpl.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeMapImpl.kt
@@ -90,7 +90,7 @@ data class DistanceRangeMapImpl<T>(
 
         // Order matters and existing entries should come first.
         // E.g. allEntries = [(lower=0, upper=5, value=1), (lower=5, upper=10, value=1)]
-        val allEntries = asList() + entries
+        val allEntries = asList() + entries.filter { !it.isEmpty() }
 
         // Start from scratch.
         values.clear()
@@ -367,6 +367,9 @@ data class DistanceRangeMapImpl<T>(
      * values, used to delete ranges
      */
     private fun putOptional(lower: Distance, upper: Distance, value: T?) {
+        if (lower >= upper) {
+            return
+        }
         if (bounds.size == 0) {
             bounds.add(lower)
             bounds.add(upper)

--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/units/Distance.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/units/Distance.kt
@@ -83,6 +83,14 @@ value class Distance(val millimeters: Long) : Comparable<Distance> {
         millimeters.toDouble() / distance.millimeters.toDouble()
 
     operator fun times(d: Double): Distance = Distance(round(millimeters * d).toLong())
+
+    /** The closest [Distance] larger than `this` */
+    val nextUp: Distance
+        get() = Distance(millimeters = millimeters + 1)
+
+    /** The closest [Distance] smaller than `this` */
+    val nextDown: Distance
+        get() = Distance(millimeters = millimeters - 1)
 }
 
 val Double.meters: Distance

--- a/core/osrd-mp/src/commonTest/kotlin/fr/sncf/osrd/utils/TestDistanceRangeMap.kt
+++ b/core/osrd-mp/src/commonTest/kotlin/fr/sncf/osrd/utils/TestDistanceRangeMap.kt
@@ -63,8 +63,12 @@ class TestDistanceRangeMap {
     }
 
     @Test
-    fun testEmptyEntry() {
-        val entries = listOf(DistanceRangeMap.RangeMapEntry(Distance(100), Distance(100), 42))
+    fun testEmptyEntries() {
+        val entries =
+            listOf(
+                DistanceRangeMap.RangeMapEntry(Distance(100), Distance(100), 42),
+                DistanceRangeMap.RangeMapEntry(Distance(256), Distance(128), 42),
+            )
 
         testPut(entries, emptyList())
     }

--- a/core/osrd-mp/src/commonTest/kotlin/fr/sncf/osrd/utils/TestDistanceRangeMap.kt
+++ b/core/osrd-mp/src/commonTest/kotlin/fr/sncf/osrd/utils/TestDistanceRangeMap.kt
@@ -5,6 +5,7 @@ import fr.sncf.osrd.utils.units.meters
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -16,15 +17,36 @@ class TestDistanceRangeMap {
         expected: List<DistanceRangeMap.RangeMapEntry<T>> = entries,
     ) {
         val rangeMap = distanceRangeMapOf<T>()
-        for (entry in entries) rangeMap.put(entry.lower, entry.upper, entry.value)
+        for (entry in entries) {
+            val upperValue = rangeMap.get(entry.upper)
+            rangeMap.put(entry.lower, entry.upper, entry.value)
+            if (!entry.isEmpty()) {
+                assertEquals(rangeMap.get(entry.lower), entry.value)
+                assertEquals(rangeMap.get(entry.upper.nextDown), entry.value)
+                // upper bound is excluded, check that [put] didn't update its value
+                assertEquals(rangeMap.get(entry.upper), upperValue)
+            }
+        }
         assertEquals(expected, rangeMap.asList())
+        if (!rangeMap.isEmpty()) {
+            assertNotNull(rangeMap.get(rangeMap.lowerBound()))
+            assertNull(rangeMap.get(rangeMap.upperBound()))
+        }
 
         val rangeMapMany = distanceRangeMapOf<T>()
         rangeMapMany.putMany(entries)
         assertEquals(expected, rangeMapMany.asList())
+        if (!rangeMap.isEmpty()) {
+            assertNotNull(rangeMapMany.get(rangeMap.lowerBound()))
+            assertNull(rangeMapMany.get(rangeMapMany.upperBound()))
+        }
 
         val rangeMapCtor = DistanceRangeMapImpl(entries)
         assertEquals(expected, rangeMapCtor.asList())
+        if (!rangeMap.isEmpty()) {
+            assertNotNull(rangeMapCtor.get(rangeMap.lowerBound()))
+            assertNull(rangeMapCtor.get(rangeMapCtor.upperBound()))
+        }
     }
 
     @Test


### PR DESCRIPTION
Related to: https://github.com/OpenRailAssociation/osrd/issues/12828
and https://github.com/OpenRailAssociation/osrd/issues/13273#issuecomment-3744411531

Right now `DistanceRangeMap` doesn't expose any way to express range
openness during updates and queries, nor documents whether lower and
upper bounds are included. As a result, it is blurry whether
`DistanceRangeMap.put(lower,upper,value)` updates the binding of `upper`
to `value`:

- `DistanceRangeMap.get` assumes ranges are closed:
  https://github.com/OpenRailAssociation/osrd/blob/2d584a28f6a32e01918bbfdd54ccdbcff53300e7/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeMapImpl.kt#L195
- `DistanceRangeMap.toRangeMap` assumes ranges are closed-open:
  https://github.com/OpenRailAssociation/osrd/blob/2d584a28f6a32e01918bbfdd54ccdbcff53300e7/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/DistanceRangeMapExt.kt#L18
- `DistanceRangeMapImpl.toRangeMap` assumes ranges are closed:
  https://github.com/OpenRailAssociation/osrd/blob/2d584a28f6a32e01918bbfdd54ccdbcff53300e7/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/DistanceRangeMapExt.kt#L38
- `TestDistanceRangeMap.testEmptyEntry` assumes ranges are either
  closed-open or open:
  https://github.com/OpenRailAssociation/osrd/blob/97a744834191a53fdf9808b16dddb9b56c5b99f5/core/osrd-mp/src/commonTest/kotlin/fr/sncf/osrd/utils/TestDistanceRangeMap.kt#L45-L47
- `TestDistanceRangeMap.testOverlappingRanges` assumes ranges are either
  closed-open or open-closed:
  https://github.com/OpenRailAssociation/osrd/blob/97a744834191a53fdf9808b16dddb9b56c5b99f5/core/osrd-mp/src/commonTest/kotlin/fr/sncf/osrd/utils/TestDistanceRangeMap.kt#L51-L64

This change is further needed by the migration from `RangeMap` to
`DistanceRangeMap` for electrification maps, which require precise
specification of range openness.

To solve this, this commit specifies that all ranges are closed-open. I
feel this is a better solution than:

- adding an non-guava equivalent of `Range` and `Cut` classes for
  `Distance`s, because this option adds too much boilerplate. Assuming
  ranges' openness doesn't change neither the data structures nor the
  interface. It also changes the implementation very little.
- assuming all ranges are closed, because most code assumes ranges are
  closed-open. Also, assuming ranges are closed is a bigger change since
  `DistanceRangeMapImpl` would need to coalesce "touching" ranges
  (ranges where `upper1.millimeters+1 == lower2.millimeters`). While
  assuming ranges are closed-open is a bit awkward e.g. to set values at
  the end of a path, this awkwardness can be alleviated by the use of
  `Distance.nextAfter` and good documentation.

---

Additionally, there's a second commit [core: have DistanceRangeMap.put filter invalid ranges](https://github.com/OpenRailAssociation/osrd/commit/a7ba1a50dc41bbcfe366b0a7752c7cd232a2fc5b)

If the lower bound of an entry is higher or equal to its upper bound,
`DistanceRangeMap.put` should not insert the entry.