### PR TITLE
front: fix project and study scroll

### DIFF
--- a/front/src/applications/stdcm/styles/_home.scss
+++ b/front/src/applications/stdcm/styles/_home.scss
@@ -1,7 +1,6 @@
 .stdcm {
   font-family: 'IBM Plex Sans';
   position: relative;
-  overflow: auto;
 
   /*
   We set the cursor to default to avoid the pointer cursor that appears due to role="button" on the div.

--- a/front/src/styles/scss/applications/operationalStudies/_scenarioContentV2.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_scenarioContentV2.scss
@@ -2,7 +2,6 @@
   display: flex;
   flex-direction: column;
   height: 100vh;
-  overflow-y: hidden;
 }
 
 .scenario-content-v2 {


### PR DESCRIPTION
Issue introduced by commit c7212f982.
overflow: hidden is not useful with the flex: 1.

backport of https://github.com/OpenRailAssociation/osrd/pull/15100