### PR TITLE
ci: ensure **/uv.lock are up to date

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,7 +205,7 @@ jobs:
           enable-cache: true
       - name: Install dependencies
         run: |
-          uv --directory railway_manager_interface/ sync
+          uv --directory railway_manager_interface/ sync --locked
       - name: Generate models.py
         run: |
           cd railway_manager_interface

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -362,7 +362,7 @@ jobs:
           enable-cache: true
       - name: Install dependencies
         run: |
-          uv --directory python/osrd_schemas/ sync --extra check
+          uv --directory python/osrd_schemas/ sync --extra check --locked
       - name: Ruff
         run: |
           uv --directory python/osrd_schemas/ run ruff check --output-format github

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -237,7 +237,7 @@ jobs:
 
       - name: Install railjson_generator dependencies
         run: |
-          uv --directory python/railjson_generator/ sync
+          uv --directory python/railjson_generator/ sync --locked
 
       - name: Generate railjson
         run: |
@@ -260,7 +260,7 @@ jobs:
 
       - name: Install railjson_generator dependencies
         run: |
-          uv --directory python/railjson_generator/ sync --extra check
+          uv --directory python/railjson_generator/ sync --extra check --locked
 
       - name: Ruff
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -341,7 +341,7 @@ jobs:
           enable-cache: true
       - name: Install dependencies
         run: |
-          uv --directory tests/ sync --extra check
+          uv --directory tests/ sync --extra check --locked
       - name: Ruff
         run: |
           uv --directory tests/ run ruff check
@@ -827,7 +827,7 @@ jobs:
           enable-cache: true
       - name: Install dependencies
         run: |
-          uv --directory tests/ sync
+          uv --directory tests/ sync --locked
 
       - name: Startup the test infrastructure
         id: start_integration_worker

--- a/railway_manager_interface/uv.lock
+++ b/railway_manager_interface/uv.lock
@@ -249,7 +249,7 @@ wheels = [
 
 [[package]]
 name = "osrd-railway-manager-interface"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "datamodel-code-generator" },


### PR DESCRIPTION
From `uv sync --help`:

    --locked
        Assert that the `uv.lock` will remain unchanged [env: UV_LOCKED=]

This makes the check fail if `uv.lock` needs updating.