### PR TITLE
front: fix itineary modal white page

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModal.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useEffectEvent, useRef, useState } from 'react';
+import { useCallback, useEffect, useEffectEvent, useRef, useState } from 'react';
 
 import { Button } from '@osrd-project/ui-core';
 import { ArrowSwitch, FrameAll } from '@osrd-project/ui-icons';
@@ -154,13 +154,15 @@ const ItineraryModal = ({
     if (activeStepId === stepId) setActiveStepId('');
   };
 
-  const frameAllPathSteps = () => {
+  const frameAllPathSteps = useCallback(() => {
     if (pathProperties && pathProperties.geometry) {
       const newViewport = computeBBoxViewport(bbox(pathProperties.geometry), mapSettings.viewport, {
         padding: 64,
       });
       dispatch(updateViewport(newViewport));
     } else {
+      if (pathStepsMetadataById.values().every((metadata) => metadata.isInvalid)) return;
+
       // Zoom on all path steps markers
       const allMarkersCoordinates = pathStepsMetadataById
         .values()
@@ -175,7 +177,7 @@ const ItineraryModal = ({
       const newViewport = computeBBoxViewport(box, mapSettings.viewport, { padding: 64 });
       dispatch(updateViewport(newViewport));
     }
-  };
+  }, [pathProperties, pathStepsMetadataById, mapSettings.viewport]);
 
   useEffect(() => {
     if (


### PR DESCRIPTION
The white page was happening because we tried to compute the bbox of all path steps before having their metadata yet.
Before being computed, the pathsteps metadata are set to invalid which should probably not happen. A refacto might be need in usePathStepsMetadata.

fix #15086 