### PR TITLE
core: fix a few backtracking bugs

### DIFF
--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathImpl.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathImpl.kt
@@ -79,15 +79,41 @@ data class TrainPathImpl(
         checkRangeList(chunks) { rawInfra.getTrackChunkLength(it.value).forceDirected() }
     }
 
-    override fun subPath(from: Offset<PhysicsPath>?, to: Offset<PhysicsPath>?): TrainPath {
-        val fromDist = from?.cast<PhysicsPath>() ?: Offset(0.meters)
-        val toDist = (to ?: getLength()).cast<PhysicsPath>()
+    override fun subPath(
+        from: Offset<PhysicsPath>?,
+        to: Offset<PhysicsPath>?,
+        includeExactStart: Boolean,
+        includeExactEnd: Boolean,
+    ): TrainPath {
+        val fromDist = from ?: Offset(0.meters)
+        val toDist = to ?: getLength()
         return TrainPathImpl(
             rawInfra = rawInfra,
             blockInfra = blockInfra,
-            routes = routes?.subRange(fromDist, toDist, resetOffsets = true),
-            blocks = blocks.subRange(fromDist, toDist, resetOffsets = true),
-            chunks = chunks.subRange(fromDist, toDist, resetOffsets = true),
+            routes =
+                routes?.subRange(
+                    fromDist,
+                    toDist,
+                    resetOffsets = true,
+                    includeExactStart = includeExactStart,
+                    includeExactEnd = includeExactEnd,
+                ),
+            blocks =
+                blocks.subRange(
+                    fromDist,
+                    toDist,
+                    resetOffsets = true,
+                    includeExactStart = includeExactStart,
+                    includeExactEnd = includeExactEnd,
+                ),
+            chunks =
+                chunks.subRange(
+                    fromDist,
+                    toDist,
+                    resetOffsets = true,
+                    includeExactStart = includeExactStart,
+                    includeExactEnd = includeExactEnd,
+                ),
             electricalProfileMapping = electricalProfileMapping,
             haveApproximateBlocks = haveApproximateBlocks,
             backtrackLocations = backtrackLocations.filter { it.cast() in fromDist..toDist },

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/GenericLinearRange.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/GenericLinearRange.kt
@@ -312,17 +312,27 @@ fun <ValueType, OffsetType, ObjectType> List<GenericLinearRange<ValueType, Offse
         .withoutConsecutiveDuplicates() // For objects exactly on range boundaries
 }
 
-/** Truncate the list of linear objects, updating the underlying object ranges */
+/**
+ * Truncate the list of linear objects, updating the underlying object ranges. If
+ * [includeExactStart] (resp. [includeExactEnd]) is set to false, zero-length ranges are removed at
+ * the start (resp. end).
+ */
 fun <ValueType, OffsetType> List<GenericLinearRange<ValueType, OffsetType>>.subRange(
     from: Offset<PhysicsPath>,
     to: Offset<PhysicsPath>,
     resetOffsets: Boolean = false,
+    includeExactStart: Boolean = true,
+    includeExactEnd: Boolean = true,
 ): List<GenericLinearRange<ValueType, OffsetType>> {
     return mapNotNull { range ->
         val truncatedStart = max(from, range.pathBegin)
         val truncatedEnd = min(to, range.pathEnd)
 
         if (truncatedStart > truncatedEnd) return@mapNotNull null
+        if (truncatedStart == truncatedEnd) {
+            if (truncatedEnd == from && !includeExactStart) return@mapNotNull null
+            if (truncatedStart == to && !includeExactEnd) return@mapNotNull null
+        }
 
         val newPathBegin = if (resetOffsets) truncatedStart - from.distance else truncatedStart
         val newPathEnd = if (resetOffsets) truncatedEnd - from.distance else truncatedEnd

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/TrainPath.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/TrainPath.kt
@@ -33,7 +33,12 @@ import fr.sncf.osrd.utils.units.Offset
  * may include partial blocks, especially at the edges of the path or around backtracks.
  */
 interface TrainPath : PhysicsPath, PathProperties {
-    fun subPath(from: Offset<PhysicsPath>?, to: Offset<PhysicsPath>?): TrainPath
+    fun subPath(
+        from: Offset<PhysicsPath>?,
+        to: Offset<PhysicsPath>?,
+        includeExactStart: Boolean = true,
+        includeExactEnd: Boolean = true,
+    ): TrainPath
 
     /** Returns a copy with the specified routes instead */
     override fun withRoutes(routes: List<RouteId>): TrainPath
@@ -70,4 +75,40 @@ fun TrainPath.getLegacyBlockPath(): List<BlockId> {
 fun TrainPath.getLegacyRoutePath(): List<RouteId> {
     // Legacy route list excluded routes that were only used in 0-length segments
     return getRoutes().filter { !it.isSinglePoint() }.map { it.value }
+}
+
+/**
+ * Split the path at each backtrack location, converting a path that may have backtracks into a list
+ * of paths that don't have any. Zero-length ranges are removed at backtrack locations, to avoid
+ * leaving traces of the path across the backtrack location.
+ *
+ * Note: for typing consistency, all subpath become their own references for their
+ * `Offset<PhysicsPath>`. Projecting onto the original path requires some extra effort. If this
+ * becomes an issue, some tooling can be added.
+ */
+fun TrainPath.splitAtBacktracks(): List<TrainPath> {
+    val res = mutableListOf<TrainPath>()
+    var currentBeginOffset = Offset.zero<PhysicsPath>()
+    for (backtrackLocation in getBacktrackLocations()) {
+        if (backtrackLocation == currentBeginOffset || backtrackLocation == this.getLength())
+            continue
+        res.add(
+            subPath(
+                from = currentBeginOffset,
+                to = backtrackLocation,
+                includeExactStart = currentBeginOffset == Offset.zero<TrainPath>(),
+                includeExactEnd = false,
+            )
+        )
+        currentBeginOffset = backtrackLocation
+    }
+    res.add(
+        subPath(
+            from = currentBeginOffset,
+            to = getLength(),
+            includeExactStart = currentBeginOffset == Offset.zero<TrainPath>(),
+            includeExactEnd = true,
+        )
+    )
+    return res
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/conflicts/SpacingResourceGenerator.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/conflicts/SpacingResourceGenerator.kt
@@ -8,7 +8,7 @@ import fr.sncf.osrd.envelope_sim.etcs.EoaType
 import fr.sncf.osrd.path.interfaces.BlockRange
 import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.path.interfaces.RouteRange
-import fr.sncf.osrd.path.interfaces.ZoneRange
+import fr.sncf.osrd.path.interfaces.ZonePathRange
 import fr.sncf.osrd.path.interfaces.addLinearObjects
 import fr.sncf.osrd.path.interfaces.mapPointObjects
 import fr.sncf.osrd.path.interfaces.mapSubObjects
@@ -24,8 +24,8 @@ import fr.sncf.osrd.sim_infra.api.LoadedSignalInfra
 import fr.sncf.osrd.sim_infra.api.LogicalSignalId
 import fr.sncf.osrd.sim_infra.api.RawInfra
 import fr.sncf.osrd.sim_infra.api.RouteId
-import fr.sncf.osrd.sim_infra.api.Zone
 import fr.sncf.osrd.sim_infra.api.ZoneId
+import fr.sncf.osrd.sim_infra.api.ZonePathId
 import fr.sncf.osrd.sim_infra.api.getLogicalSignalName
 import fr.sncf.osrd.sim_infra.api.getZonePathZone
 import fr.sncf.osrd.standalone_sim.CLOSED_SIGNAL_RESERVATION_MARGIN
@@ -103,10 +103,12 @@ data class SpacingResourceGenerator(
     // train moves past the given objects.
     private val blockRanges = ArrayDeque<BlockRange>()
     private val routeRanges = ArrayDeque<RouteRange>()
-    private val zoneRanges = ArrayDeque<ZoneRange>()
+    private val zoneRanges = ArrayDeque<ZonePathRange>()
     private val stops = ArrayDeque<PathStop>()
     private val pendingSignals = ArrayDeque<PendingSignalData>()
-    private val ongoingZoneRequirements = mutableMapOf<ZoneId, OngoingZoneRequirement>()
+    // It's tempting to use zone id instead of zone path ids here,
+    // but data for the same zone in different directions can't be merged
+    private val ongoingZoneRequirements = mutableMapOf<ZonePathId, OngoingZoneRequirement>()
 
     private var isPathComplete: Boolean = false
     private var reachedFirstSignal: Boolean = false
@@ -135,9 +137,7 @@ data class SpacingResourceGenerator(
         if (emptyPathExtension) return
 
         val newZoneRanges =
-            newBlockRanges
-                .mapSubObjects(blockInfra::getBlockZonePaths, rawInfra::getZonePathLength)
-                .map { it.mapValue<ZoneId, Zone>(rawInfra.getZonePathZone(it.value)) }
+            newBlockRanges.mapSubObjects(blockInfra::getBlockZonePaths, rawInfra::getZonePathLength)
         require(newPathEnd == newZoneRanges.last().pathEnd)
         val signals =
             newBlockRanges.mapPointObjects(
@@ -321,12 +321,17 @@ data class SpacingResourceGenerator(
     private fun yieldCurrentRequirements(): List<SpacingRequirement> {
         val callbacks = callbacks!!
         val res = mutableListOf<SpacingRequirement>()
-        for ((zone, ongoingRequirementData) in ongoingZoneRequirements) {
-            val requirement = ongoingRequirementData.generateRequirement(zone, callbacks, stops)
-            if (requirement != null) res.add(requirement)
+        val zonePathsToRemove = mutableListOf<ZonePathId>()
+        for ((zonePath, ongoingRequirementData) in ongoingZoneRequirements) {
+            val zoneId = rawInfra.getZonePathZone(zonePath)
+            val requirement = ongoingRequirementData.generateRequirement(zoneId, callbacks, stops)
+            if (requirement != null) {
+                res.add(requirement)
+                if (requirement.isComplete) zonePathsToRemove.add(zonePath)
+            }
         }
-        for (requirement in res) { // Avoid modifying while iterating
-            if (requirement.isComplete) ongoingZoneRequirements.remove(requirement.zone)
+        for (zonePath in zonePathsToRemove) { // Avoid modifying while iterating
+            ongoingZoneRequirements.remove(zonePath)
         }
         stops.removeWhile { it.pathOffset < callbacks.currentPathOffset }
         return res
@@ -458,6 +463,8 @@ data class SpacingResourceGenerator(
                 // Otherwise we rely on the `followingZoneState` of `simulator.evaluate`
                 mapOf()
             }
+        val firstZonePath = zoneRanges.first().value
+        val firstZone = rawInfra.getZonePathZone(firstZonePath)
         val simulatedSignalStates =
             simulator.evaluate(
                 rawInfra,
@@ -468,7 +475,7 @@ data class SpacingResourceGenerator(
                 simulationData.blockIds.size,
                 zoneStates,
                 ZoneStatus.OCCUPIED,
-                firstZone = zoneRanges.first().value,
+                firstZone = firstZone,
             )
         val signalState = simulatedSignalStates[signal]!!
 

--- a/core/src/test/kotlin/fr/sncf/osrd/backtracks/BacktrackTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/backtracks/BacktrackTests.kt
@@ -8,6 +8,7 @@ import fr.sncf.osrd.path.implementations.buildRangeList
 import fr.sncf.osrd.path.implementations.buildTrainPathFromBlockRanges
 import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.path.interfaces.TrainPath
+import fr.sncf.osrd.path.interfaces.splitAtBacktracks
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
 import fr.sncf.osrd.railjson.schema.schedule.RJSAllowanceDistribution
 import fr.sncf.osrd.sim_infra.api.Block
@@ -24,6 +25,7 @@ import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import fr.sncf.osrd.utils.units.sumDistances
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import org.junit.jupiter.api.Disabled
 
 /**
@@ -149,6 +151,29 @@ class BacktrackTests {
     fun testPathProperties() {
         // Smoke test, we only test for uncaught exceptions and failed asserts
         makePathPropResponse(path, infra.rawInfra)
+    }
+
+    @Test
+    fun testPathSplit() {
+        val paths = path.splitAtBacktracks()
+        assertEquals(2, paths.size)
+        val first = paths[0]
+        val second = paths[1]
+
+        assertEquals(first.getLength(), path.getBacktrackLocations().single())
+        assertEquals(path.getLength(), first.getLength() + second.getLength().distance)
+        assertEquals(path.getRoutes().size, first.getRoutes().size + second.getRoutes().size)
+
+        val firstBlockRanges = first.getBlocks()
+        val secondBlockRanges = second.getBlocks()
+        val allBlockRanges = path.getBlocks()
+        assertEquals(allBlockRanges.size, firstBlockRanges.size + secondBlockRanges.size)
+
+        val firstBlocks = firstBlockRanges.map { it.value }.toSet()
+        val secondBlocks = secondBlockRanges.map { it.value }.toSet()
+        val allBlocks = allBlockRanges.map { it.value }.toSet()
+        assert(firstBlocks.intersect(secondBlocks).isEmpty())
+        assertEquals(allBlocks, firstBlocks.union(secondBlocks))
     }
 
     @Test


### PR DESCRIPTION
Subset of https://github.com/OpenRailAssociation/osrd/pull/14676 with just the parts that aren't still a work in progress. Done by enabling the disabled backtrack unit tests and identifying what breaks.

1. Fix an issue with zone ranges being merged even in different directions
2. Add a method to iterate on backtrack-free sub-paths