### PR TITLE
editoast: stdcm: make simulation run time a 12h default value when simulation fails

### DIFF
--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -276,12 +276,14 @@ pub(in crate::views) async fn stdcm_handler(
     )
     .await?;
 
-    // Only the success variant of the simulation response contains the simulation run time.
-    let Some(simulation_run_time) = virtual_train_run.simulation.simulation_run_time() else {
+    let Some(simulation_run_time) = virtual_train_run.simulation.simulation_run_time().or_else(||
+        // Default 12h value when the simulation fails
+        matches!(virtual_train_run.simulation, simulation::Response::SimulationFailed { .. }).then_some(12 * 3_600_000))
+    else {
         return Ok(Json(StdcmResponse::PreprocessingSimulationError {
             error: virtual_train_run.simulation,
             core_payload: None,
-        }));
+        }))
     };
 
     let earliest_departure_time = request.get_earliest_departure_time(simulation_run_time);


### PR DESCRIPTION
Everything's in the title.
Fixes https://github.com/OpenRailAssociation/osrd/issues/14164.

Tested by returning SimulationFailed in core endpoint (fail test result does not fail anymore because the corresponding data problem was probably fixed).
Elected to just make `simulation_run_time` = 12h rather than `maximum_run_time` 'cause it's simpler and makes `maximum_run_time` value even higher (~18h), which is good to make sure we don't fail on the longer paths.