### PR TITLE
front: update e2e README

### DIFF
--- a/front/README.md
+++ b/front/README.md
@@ -55,47 +55,9 @@ Launches end to end tests.
 It requires:
 
 - Install Playwright dependencies `cd ./front/ && npx playwright install --with-deps`
-- Backend containers to be up with authorization disabled:
-
-  `docker compose up --no-build --detach valkey postgres gateway core editoast`
-
-- Running front with `docker compose up --build --detach front`
-
-Now you can run the test with `cd front/ && npm run e2e-tests`.
-
-If you are using a Linux distribution not supported by Playwright (Playwright only supports Windows,
-macOS and Ubuntu/Debian), you can start the tests inside a Docker container.
-
-First start the playwright container using `./osrd-compose playwright up playwright`. You can also
-start all back and front containers at the same time as the playwright container, for example using
-`./osrd-compose playwright dev-front up`.
-
-Then you can run the tests using `osrd/scripts/run-front-playwright-container.sh`. This script
-accepts the same options and arguments as `npm run e2e-tests` or `npx playwright test`.
-
-> [!CAUTION]
-> If you try to run `npm run start` instead of running it through docker, you'll notice
-> it doesn't work because the gateway can't access your local port from inside a container. 2
-> solutions:
->
-> - Run all the components locally (you might keep Postgres and Valkey in containers)
-> - If on Linux, you can also launch all the containers on the host network: you can replace the
->   `docker compose <something>` above with `osrd/osrd-compose host <something>`
-
-If the tests fail, a `front/test-results` folder will be created, containing videos and traces of
-the failed test executions. These files can help you understand what went wrong. Additionally, the
-CI system exports these videos and traces as artifacts. You can view the trace files using the
-[Playwright trace viewer](https://trace.playwright.dev/).
-
-If visual comparisons tests fail due to UI changes, new snapshots are required as the baseline. You
-can automatically update snapshots by running tests with the `--update-snapshots` flag:
-`npx playwright test --update-snapshots`.
-
-You may also want to explore [Playwright documentation](https://playwright.dev/docs/intro) for more
-insights. For example: Launch each test independently using: `npx playwright test --ui`. Debug a
-test with: `npx playwright test --debug`. Run a specific test in a specific test file with a
-specific browser and no retries using:
-`npx playwright test 011-op-times-and-stops-tab.spec.ts -g "should correctly set and display times and stops tables" --project=firefox  --retries=0`.
+- Ensure backend containers are running
+Then run the tests with: `cd front/ && npm run e2e-tests`.
+For more details, or if you're using a Linux distribution other than Ubuntu or Debian, refer to the README located in `front/tests`.
 
 ## Design rules
 

--- a/front/tests/README.md
+++ b/front/tests/README.md
@@ -53,6 +53,8 @@ npx playwright test
 
 # 🤖 1.2 Run Tests in OSRD's Playwright Container
 
+It is recommended to use it if you are running a Linux distribution that is not officially supported by Playwright (Playwright supports only Windows, macOS, and Ubuntu/Debian)
+
 Start the Playwright container only:
 
 ```bash
@@ -94,18 +96,21 @@ clean up first:
     tests/
       01-home/
         001-home-page.spec.ts
+        ...
 
-      02-op/
+      02-operational-studies/
         management/
           001-project-management.spec.ts
           002-study-management.spec.ts
           003-scenario-management.spec.ts
+          ...
 
         train-creation-tabs/
           001-op-rolling-stock-tab.spec.ts
           002-op-route-tab.spec.ts
           003-op-times-and-stops-tab.spec.ts
           004-op-simulation-settings-tab.spec.ts
+          ...
 
         timetable/
           001-train-timetable.spec.ts
@@ -113,32 +118,35 @@ clean up first:
           003-train-edition.spec.ts
           004-train-timetable-multiselection.spec.ts
           005-scenario-page-synchronization.spec.ts
+          ...
 
         paced-trains/
           001-paced-train-management.spec.ts
           002-paced-train-exceptions.spec.ts
           003-paced-train-occurrence-edition.spec.ts
+          ...
 
         simulation-result/
           001-get-manchette.spec.ts
-
-        round-trips/
-          001-round-trips.spec.ts
+          ...
 
         nge/
           001-osrd-nge.spec.ts
           002-nge-osrd.spec.ts
+          ...
 
-      03-rolling-stock-editor/
-        001-rolling-stock-editor.spec.ts
-        002-rolling-stock-filter.spec.ts
-
-      04-stdcm/
+      03-stdcm/
         001-stdcm.spec.ts
         002-stdcm-simulation-sheet.spec.ts
         003-stdcm-feedback-mail.spec.ts
         004-stdcm-linked-train.spec.ts
         005-stdcm-missing-fields.spec.ts
+        ...
+
+      04-rolling-stock-editor/
+        001-rolling-stock-editor.spec.ts
+        002-rolling-stock-filter.spec.ts
+        ...
 
       utils/
       reporter/
@@ -152,6 +160,9 @@ clean up first:
 - Assets must never be mixed with test files.
 - Utilities and Page Objects stay in their dedicated folders.
 - Every test file is **incrementally numbered**.
+- Page Object = behavior + locators
+- Test = data + expectations
+
 
 ---
 
@@ -259,11 +270,21 @@ npx playwright test --ui
 
 Update snapshots:
 
+If visual comparison tests fail due to UI changes, new snapshots must be generated as the new baseline.
+
+You can automatically update snapshots by running:
+ 
+
 ```bash
 npx playwright test --update-snapshots
 ```
 
-Debug mode:
+ℹ️ Snapshot files include the operating system name in their filename.
+For example, if you generate snapshots on macOS, the files will end with `-darwin.png`.
+Since CI runs on Linux, you must rename the files to use `-linux.png` before committing them.
+
+Debug in UI mode:
+You can easily walk through each step of the test and visually see what was happening before, during, and after each step
 
 ```bash
 npx playwright test --debug
@@ -286,6 +307,9 @@ npx playwright test --project=chromium --retries=1 --workers=2
 ℹ️ All commands above also work when running tests inside the Playwright container by replacing  
  `npx playwright test` with `./scripts/run-front-playwright-container.sh`.
 
+You may also want to explore [Playwright documentation](https://playwright.dev/docs/intro) for more
+insights. 
+
 ---
 
 # 🎥 6. Debugging Failures (Videos, Traces, Screenshots)
@@ -302,6 +326,7 @@ They are available under:
 
 Open traces via: https://trace.playwright.dev/
 
+In the CI those files are available as artifacts. You can view them in the Github summary.
 ---
 
 # ⚙️ 7. Playwright Configuration Summary


### PR DESCRIPTION
The README under `/front` was outdated, so I removed most of the E2E related sections and updated the README under `/front/tests` with the missing instructions.
