### PR TITLE
front: grey out timesStopsTable row with invalid path step

### DIFF
--- a/front/src/modules/timesStops/TimesStopsTable.tsx
+++ b/front/src/modules/timesStops/TimesStopsTable.tsx
@@ -151,7 +151,12 @@ const TimesStopsTable = ({ rows, dataIsLoading, isValid }: TimesStopsTableProps)
           })}
         >
           {table.getRowModel().rows.map((row) => (
-            <tr key={row.id}>
+            <tr
+              key={row.id}
+              className={cx({
+                'invalid-path-step': row.original.invalidPathStep,
+              })}
+            >
               {row.getVisibleCells().map((cell) => (
                 <td key={cell.id} className={cell.column.columnDef.meta?.className}>
                   {flexRender(cell.column.columnDef.cell, cell.getContext())}

--- a/front/src/modules/timesStops/hooks/useTimesStopsTableData.ts
+++ b/front/src/modules/timesStops/hooks/useTimesStopsTableData.ts
@@ -32,6 +32,7 @@ type BuildTableRowParams = {
   startDate: Date;
   schedule?: ScheduleItem;
   computedArrival?: Duration;
+  invalidPathStep?: boolean;
   scheduleNotHonored?: boolean;
   marginNotHonored?: boolean;
 };
@@ -45,6 +46,7 @@ const buildTableRow = ({
   startDate,
   schedule,
   computedArrival,
+  invalidPathStep,
   scheduleNotHonored,
   marginNotHonored,
 }: BuildTableRowParams): TimesStopsRowNew => {
@@ -82,6 +84,7 @@ const buildTableRow = ({
     stopDuration,
     requestedDeparture,
     computedDeparture,
+    invalidPathStep,
     scheduleNotHonored,
     marginNotHonored,
   };
@@ -167,6 +170,7 @@ const useTimesStopsTableData = (
           startDate,
           schedule,
           computedArrival,
+          invalidPathStep: !matchingOp,
           scheduleNotHonored,
           marginNotHonored,
         });

--- a/front/src/modules/timesStops/styles/_timesStopsTable.scss
+++ b/front/src/modules/timesStops/styles/_timesStopsTable.scss
@@ -15,6 +15,10 @@
         &:nth-child(even) {
           background: var(--ambientB15);
         }
+
+        &:hover {
+          background: var(--white50);
+        }
       }
       &.invalid::after {
         position: absolute;
@@ -111,11 +115,6 @@
 
     td.uncomputed::before {
       background: var(--white100);
-    }
-
-    /* Hover per cell only */
-    td[class^='col-']:hover::before {
-      background: var(--white50);
     }
 
     /* Input focus inside cell */

--- a/front/src/modules/timesStops/styles/_timesStopsTable.scss
+++ b/front/src/modules/timesStops/styles/_timesStopsTable.scss
@@ -24,6 +24,7 @@
         content: '';
         height: calc(100% - 40px);
         width: 100%;
+        pointer-events: none;
       }
     }
     td.col-index {

--- a/front/src/modules/timesStops/styles/_timesStopsTable.scss
+++ b/front/src/modules/timesStops/styles/_timesStopsTable.scss
@@ -16,6 +16,10 @@
           background: var(--ambientB15);
         }
 
+        &.invalid-path-step {
+          background: var(--grey10);
+        }
+
         &:hover {
           background: var(--white50);
         }
@@ -114,7 +118,12 @@
     }
 
     td.uncomputed::before {
+      // TODO: The color used here is suspicious, check with mock ups before usage
       background: var(--white100);
+    }
+
+    tr.invalid-path-step td::before {
+      background: transparent;
     }
 
     /* Input focus inside cell */

--- a/front/src/modules/timesStops/types.ts
+++ b/front/src/modules/timesStops/types.ts
@@ -19,6 +19,7 @@ export type TimesStopsRowNew = {
   stopDuration: Duration | null;
   requestedDeparture: Date | null;
   computedDeparture: Date | null;
+  invalidPathStep: boolean | undefined;
   scheduleNotHonored: boolean | undefined;
   marginNotHonored: boolean | undefined;
 };


### PR DESCRIPTION
Close #15172 

Also fix clicks blocked for invalid trains (the overlay adding the grey border did not let clicks pass through), and highlight the entire row instead of just the individual cells when hovered