### PR TITLE
front: add grey border to timesStopsTable on invalid or late train

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
@@ -331,6 +331,7 @@ const SimulationResults = ({
                       isValid: true,
                       simulatedTrain: simulationResults.simulation.final_output,
                       simulatedPathItemTimes: simulationSummary.pathItemTimes,
+                      simulatedPathItemRespect: simulationSummary.pathItemRespect,
                       operationalPointsOnPath: simulationResults.pathProperties.operationalPoints,
                     }
                   : { isValid: false })}

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
@@ -320,6 +320,7 @@ const SimulationResults = ({
                 </div>
               )
             }
+            withFooter
           >
             <div data-testid="time-stop-outputs" className="time-stop-outputs">
               <TimesStopsOutput

--- a/front/src/modules/timesStops/TimesStopsOutput.tsx
+++ b/front/src/modules/timesStops/TimesStopsOutput.tsx
@@ -24,6 +24,7 @@ type TimesStopsOutputProps = {
   simulatedTrain?: SimulationResponseSuccess['final_output'];
   simulatedPath?: CorePathfindingResultSuccess;
   simulatedPathItemTimes?: Extract<SimulationSummary, { isValid: true }>['pathItemTimes'];
+  simulatedPathItemRespect?: Extract<SimulationSummary, { isValid: true }>['pathItemRespect'];
   operationalPointsOnPath?: PathPropertiesFormatted['operationalPoints'];
 };
 
@@ -33,6 +34,7 @@ const TimesStopsOutput = ({
   selectedTrain,
   simulatedTrain,
   simulatedPathItemTimes,
+  simulatedPathItemRespect,
   operationalPointsOnPath,
 }: TimesStopsOutputProps) => {
   const useNewTimesStopsTable = useSelector(getUseNewTimesStopsTable);
@@ -53,6 +55,7 @@ const TimesStopsOutput = ({
     selectedTrain,
     useNewTimesStopsTable ? simulatedTrain : undefined,
     useNewTimesStopsTable ? simulatedPathItemTimes : undefined,
+    useNewTimesStopsTable ? simulatedPathItemRespect : undefined,
     useNewTimesStopsTable ? operationalPointsOnPath : undefined
   );
 

--- a/front/src/modules/timesStops/TimesStopsOutput.tsx
+++ b/front/src/modules/timesStops/TimesStopsOutput.tsx
@@ -60,7 +60,9 @@ const TimesStopsOutput = ({
   );
 
   if (useNewTimesStopsTable) {
-    return <TimesStopsTable rows={newRows} dataIsLoading={newRows.length === 0} />;
+    return (
+      <TimesStopsTable rows={newRows} dataIsLoading={newRows.length === 0} isValid={isValid} />
+    );
   }
 
   return (

--- a/front/src/modules/timesStops/TimesStopsTable.tsx
+++ b/front/src/modules/timesStops/TimesStopsTable.tsx
@@ -7,6 +7,7 @@ import {
   useReactTable,
   type RowData,
 } from '@tanstack/react-table';
+import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
 
 import { Loader } from 'common/Loaders/Loader';
@@ -26,12 +27,15 @@ declare module '@tanstack/react-table' {
 type TimesStopsTableProps = {
   rows: TimesStopsRowNew[];
   dataIsLoading: boolean;
+  isValid: boolean;
 };
 
 const columnHelper = createColumnHelper<TimesStopsRowNew>();
 
-const TimesStopsTable = ({ rows, dataIsLoading }: TimesStopsTableProps) => {
+const TimesStopsTable = ({ rows, dataIsLoading, isValid }: TimesStopsTableProps) => {
   const { t } = useTranslation('translation', { keyPrefix: 'timeStopTable' });
+
+  const scheduleNotHonored = rows.some((row) => row.scheduleNotHonored);
 
   const columns = useMemo(
     () => [
@@ -141,7 +145,11 @@ const TimesStopsTable = ({ rows, dataIsLoading }: TimesStopsTableProps) => {
             </tr>
           ))}
         </thead>
-        <tbody>
+        <tbody
+          className={cx({
+            invalid: !isValid || scheduleNotHonored,
+          })}
+        >
           {table.getRowModel().rows.map((row) => (
             <tr key={row.id}>
               {row.getVisibleCells().map((cell) => (

--- a/front/src/modules/timesStops/hooks/useTimesStopsTableData.ts
+++ b/front/src/modules/timesStops/hooks/useTimesStopsTableData.ts
@@ -32,6 +32,8 @@ type BuildTableRowParams = {
   startDate: Date;
   schedule?: ScheduleItem;
   computedArrival?: Duration;
+  scheduleNotHonored?: boolean;
+  marginNotHonored?: boolean;
 };
 
 const buildTableRow = ({
@@ -43,6 +45,8 @@ const buildTableRow = ({
   startDate,
   schedule,
   computedArrival,
+  scheduleNotHonored,
+  marginNotHonored,
 }: BuildTableRowParams): TimesStopsRowNew => {
   const requestedArrival = schedule?.arrival
     ? new Date(startDate.getTime() + Duration.parse(schedule.arrival).ms)
@@ -78,6 +82,8 @@ const buildTableRow = ({
     stopDuration,
     requestedDeparture,
     computedDeparture,
+    scheduleNotHonored,
+    marginNotHonored,
   };
 };
 
@@ -92,6 +98,7 @@ const useTimesStopsTableData = (
   selectedTrain: Train,
   simulatedTrain?: SimulationResponseSuccess['final_output'],
   simulatedPathItemTimes?: Extract<SimulationSummary, { isValid: true }>['pathItemTimes'],
+  simulatedPathItemRespect?: Extract<SimulationSummary, { isValid: true }>['pathItemRespect'],
   operationalPointsOnPath?: PathPropertiesFormatted['operationalPoints']
 ): TimesStopsRowNew[] => {
   const { t } = useTranslation('operational-studies');
@@ -147,6 +154,8 @@ const useTimesStopsTableData = (
           simulatedPathItemTimes?.final[stepIndex] !== undefined
             ? new Duration({ milliseconds: simulatedPathItemTimes.final[stepIndex] })
             : undefined;
+        const scheduleNotHonored = !simulatedPathItemRespect?.times[stepIndex];
+        const marginNotHonored = !simulatedPathItemRespect?.margins[stepIndex];
 
         const row = buildTableRow({
           id: pathStep.id,
@@ -158,6 +167,8 @@ const useTimesStopsTableData = (
           startDate,
           schedule,
           computedArrival,
+          scheduleNotHonored,
+          marginNotHonored,
         });
 
         return [pathStep.id, row];

--- a/front/src/modules/timesStops/styles/_timesStopsTable.scss
+++ b/front/src/modules/timesStops/styles/_timesStopsTable.scss
@@ -1,5 +1,6 @@
 .times-stops-table-new {
   .table-container {
+    position: relative;
     thead {
       th {
         background: color-mix(in srgb, var(--black100) 5%, var(--ambientB5) 100%);
@@ -14,6 +15,16 @@
         &:nth-child(even) {
           background: var(--ambientB15);
         }
+      }
+      &.invalid::after {
+        position: absolute;
+        top: 40px; // Hardcoding this is awful, but setting position: relative in tbody instead of table-container bugs borders in firefox
+        left: 0;
+        box-shadow: 0 0 0 8px var(--black10) inset;
+        content: '';
+        height: calc(100% - 40px);
+        width: 100%;
+        z-index: 20;
       }
     }
     td.col-index {

--- a/front/src/modules/timesStops/types.ts
+++ b/front/src/modules/timesStops/types.ts
@@ -19,6 +19,8 @@ export type TimesStopsRowNew = {
   stopDuration: Duration | null;
   requestedDeparture: Date | null;
   computedDeparture: Date | null;
+  scheduleNotHonored: boolean | undefined;
+  marginNotHonored: boolean | undefined;
 };
 
 export type TimesStopsRow = {


### PR DESCRIPTION
Close #15190

Second commit is not fully required for that issue, but these attributes will also be used in the index column mentioned in https://github.com/osrd-project/osrd-confidential/issues/1351

(Also 8px of border instead of 4px as discussed with thibaut)