### PR TITLE
editoast: rename TrainSchedule struct

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -2617,29 +2617,7 @@ paths:
         content:
           application/json:
             schema:
-              allOf:
-              - $ref: '#/components/schemas/TrainSchedule'
-              - type: object
-                properties:
-                  paced:
-                    oneOf:
-                    - type: 'null'
-                    - type: object
-                      required:
-                      - time_window
-                      - interval
-                      - exceptions
-                      properties:
-                        exceptions:
-                          type: array
-                          items:
-                            $ref: '#/components/schemas/PacedTrainException'
-                        interval:
-                          $ref: '#/components/schemas/PositiveDuration'
-                          description: Time between two occurrences, an ISO 8601 format is expected
-                        time_window:
-                          $ref: '#/components/schemas/PositiveDuration'
-                          description: Duration of the paced train, an ISO 8601 format is expected
+              $ref: '#/components/schemas/PacedTrain'
         required: true
       responses:
         '204':
@@ -10415,7 +10393,71 @@ components:
           $ref: '#/components/schemas/TrainScheduleOptions'
     PacedTrain:
       allOf:
-      - $ref: '#/components/schemas/TrainSchedule'
+      - type: object
+        required:
+        - train_name
+        - rolling_stock_name
+        - start_time
+        - path
+        - constraint_distribution
+        properties:
+          category:
+            oneOf:
+            - type: 'null'
+            - $ref: '#/components/schemas/TrainCategory'
+          comfort:
+            $ref: '#/components/schemas/Comfort'
+          constraint_distribution:
+            $ref: '#/components/schemas/Distribution'
+          initial_speed:
+            type: number
+            format: double
+          labels:
+            type: array
+            items:
+              type: string
+          margins:
+            $ref: '#/components/schemas/Margins'
+          options:
+            $ref: '#/components/schemas/TrainScheduleOptions'
+          path:
+            type: array
+            items:
+              $ref: '#/components/schemas/PathItem'
+          power_restrictions:
+            type: array
+            items:
+              type: object
+              required:
+              - from
+              - to
+              - value
+              properties:
+                from:
+                  type: string
+                  minLength: 1
+                to:
+                  type: string
+                  minLength: 1
+                value:
+                  type: string
+              additionalProperties: false
+          rolling_stock_name:
+            type: string
+          schedule:
+            type: array
+            items:
+              $ref: '#/components/schemas/ScheduleItem'
+          speed_limit_tag:
+            oneOf:
+            - type: 'null'
+            - type: string
+              minLength: 1
+          start_time:
+            type: string
+            format: date-time
+          train_name:
+            type: string
       - type: object
         properties:
           paced:
@@ -14187,72 +14229,6 @@ components:
       - value
       properties:
         value:
-          type: string
-    TrainSchedule:
-      type: object
-      required:
-      - train_name
-      - rolling_stock_name
-      - start_time
-      - path
-      - constraint_distribution
-      properties:
-        category:
-          oneOf:
-          - type: 'null'
-          - $ref: '#/components/schemas/TrainCategory'
-        comfort:
-          $ref: '#/components/schemas/Comfort'
-        constraint_distribution:
-          $ref: '#/components/schemas/Distribution'
-        initial_speed:
-          type: number
-          format: double
-        labels:
-          type: array
-          items:
-            type: string
-        margins:
-          $ref: '#/components/schemas/Margins'
-        options:
-          $ref: '#/components/schemas/TrainScheduleOptions'
-        path:
-          type: array
-          items:
-            $ref: '#/components/schemas/PathItem'
-        power_restrictions:
-          type: array
-          items:
-            type: object
-            required:
-            - from
-            - to
-            - value
-            properties:
-              from:
-                type: string
-                minLength: 1
-              to:
-                type: string
-                minLength: 1
-              value:
-                type: string
-            additionalProperties: false
-        rolling_stock_name:
-          type: string
-        schedule:
-          type: array
-          items:
-            $ref: '#/components/schemas/ScheduleItem'
-        speed_limit_tag:
-          oneOf:
-          - type: 'null'
-          - type: string
-            minLength: 1
-        start_time:
-          type: string
-          format: date-time
-        train_name:
           type: string
     TrainScheduleOptions:
       type: object

--- a/editoast/schemas/src/lib.rs
+++ b/editoast/schemas/src/lib.rs
@@ -10,4 +10,4 @@ pub mod fixtures;
 
 pub use rolling_stock::RollingStock;
 pub use rolling_stock::TowedRollingStock;
-pub use train_schedule::TrainSchedule;
+pub use train_schedule::TrainOccurrence;

--- a/editoast/schemas/src/paced_train.rs
+++ b/editoast/schemas/src/paced_train.rs
@@ -22,7 +22,7 @@ use crate::train_schedule::Margins;
 use crate::train_schedule::PathItem;
 use crate::train_schedule::PowerRestrictionItem;
 use crate::train_schedule::ScheduleItem;
-use crate::train_schedule::TrainSchedule;
+use crate::train_schedule::TrainOccurrence;
 use crate::train_schedule::TrainScheduleOptions;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
@@ -39,7 +39,8 @@ pub struct Paced {
 #[derive(Debug, Clone, Serialize, PartialEq, ToSchema)]
 pub struct PacedTrain {
     #[serde(flatten)]
-    pub train_schedule_base: TrainSchedule,
+    #[schema(inline)]
+    pub train_occurrence: TrainOccurrence,
     #[schema(inline)]
     pub paced: Option<Paced>,
 }
@@ -52,7 +53,7 @@ impl<'de> Deserialize<'de> for PacedTrain {
         #[derive(Deserialize)]
         struct PacedTrainJson {
             #[serde(flatten)]
-            pub train_schedule_base: TrainSchedule,
+            pub train_occurrence: TrainOccurrence,
             pub paced: Option<Paced>,
         }
         let raw = PacedTrainJson::deserialize(deserializer)?;
@@ -84,7 +85,7 @@ impl<'de> Deserialize<'de> for PacedTrain {
             }
         }
         Ok(PacedTrain {
-            train_schedule_base: raw.train_schedule_base,
+            train_occurrence: raw.train_occurrence,
             paced: raw.paced,
         })
     }

--- a/editoast/schemas/src/train_schedule.rs
+++ b/editoast/schemas/src/train_schedule.rs
@@ -53,7 +53,7 @@ use crate::rolling_stock::TrainCategory;
 #[serde_as]
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
 #[serde(remote = "Self")]
-pub struct TrainSchedule {
+pub struct TrainOccurrence {
     pub train_name: String,
     #[serde(default)]
     #[serde_as(as = "DefaultOnNull")]
@@ -101,7 +101,7 @@ pub trait TrainScheduleLike: Clone + Send + Sync + 'static {
     fn options(&self) -> &TrainScheduleOptions;
 }
 
-impl TrainScheduleLike for TrainSchedule {
+impl TrainScheduleLike for TrainOccurrence {
     fn rolling_stock_name(&self) -> &str {
         &self.rolling_stock_name
     }
@@ -147,12 +147,12 @@ impl TrainScheduleLike for TrainSchedule {
     }
 }
 
-impl<'de> Deserialize<'de> for TrainSchedule {
-    fn deserialize<D>(deserializer: D) -> Result<TrainSchedule, D::Error>
+impl<'de> Deserialize<'de> for TrainOccurrence {
+    fn deserialize<D>(deserializer: D) -> Result<TrainOccurrence, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
-        let train_schedule = TrainSchedule::deserialize(deserializer)?;
+        let train_schedule = TrainOccurrence::deserialize(deserializer)?;
 
         // Look for invalid path waypoint reference
         let path_ids: HashSet<_> = train_schedule.path.iter().map(|p| &p.id).collect();
@@ -211,17 +211,17 @@ impl<'de> Deserialize<'de> for TrainSchedule {
     }
 }
 
-impl Serialize for TrainSchedule {
+impl Serialize for TrainOccurrence {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
-        TrainSchedule::serialize(self, serializer)
+        TrainOccurrence::serialize(self, serializer)
     }
 }
 
 #[cfg(any(test, feature = "testing"))]
-impl TrainSchedule {
+impl TrainOccurrence {
     pub fn fake() -> Self {
         use crate::infra::TrackOffset;
         use crate::primitives::Identifier;
@@ -339,7 +339,7 @@ mod tests {
     use crate::train_schedule::Margins;
     use crate::train_schedule::PathItemLocation;
     use crate::train_schedule::ScheduleItem;
-    use crate::train_schedule::TrainSchedule;
+    use crate::train_schedule::TrainOccurrence;
     use crate::train_schedule::path_item::OperationalPointPartReference;
     use crate::train_schedule::path_item::OperationalPointReference::Id;
     use crate::train_schedule::schedule_item::ReceptionSignal;
@@ -360,29 +360,29 @@ mod tests {
             id: "a".into(),
             location,
         };
-        let train_schedule = TrainSchedule {
+        let train_schedule = TrainOccurrence {
             path: vec![path_item.clone(), path_item.clone()],
             ..Default::default()
         };
         let invalid_str = to_string(&train_schedule).unwrap();
-        assert!(from_str::<TrainSchedule>(&invalid_str).is_err());
+        assert!(from_str::<TrainOccurrence>(&invalid_str).is_err());
     }
 
     /// Test deserialize an invalid train schedule
     #[test]
     fn deserialize_schedule_point_not_found_train_schedule() {
-        let train_schedule = TrainSchedule {
+        let train_schedule = TrainOccurrence {
             schedule: vec![Default::default()],
             ..Default::default()
         };
         let invalid_str = to_string(&train_schedule).unwrap();
-        assert!(from_str::<TrainSchedule>(&invalid_str).is_err());
+        assert!(from_str::<TrainOccurrence>(&invalid_str).is_err());
     }
 
     /// Test deserialize an invalid train schedule
     #[test]
     fn deserialize_boundary_not_found_train_schedule() {
-        let train_schedule = TrainSchedule {
+        let train_schedule = TrainOccurrence {
             margins: Margins {
                 boundaries: vec![Default::default()],
                 ..Default::default()
@@ -390,18 +390,18 @@ mod tests {
             ..Default::default()
         };
         let invalid_str = to_string(&train_schedule).unwrap();
-        assert!(from_str::<TrainSchedule>(&invalid_str).is_err());
+        assert!(from_str::<TrainOccurrence>(&invalid_str).is_err());
     }
 
     /// Test deserialize an invalid train schedule
     #[test]
     fn deserialize_power_restriction_train_schedule() {
-        let train_schedule = TrainSchedule {
+        let train_schedule = TrainOccurrence {
             power_restrictions: vec![Default::default()],
             ..Default::default()
         };
         let invalid_str = to_string(&train_schedule).unwrap();
-        assert!(from_str::<TrainSchedule>(&invalid_str).is_err());
+        assert!(from_str::<TrainOccurrence>(&invalid_str).is_err());
     }
 
     /// Test deserialize an invalid train schedule
@@ -418,7 +418,7 @@ mod tests {
             id: "a".into(),
             location,
         };
-        let train_schedule = TrainSchedule {
+        let train_schedule = TrainOccurrence {
             path: vec![path_item.clone(), path_item.clone()],
             schedule: vec![
                 ScheduleItem {
@@ -437,7 +437,7 @@ mod tests {
             ..Default::default()
         };
         let invalid_str = to_string(&train_schedule).unwrap();
-        assert!(from_str::<TrainSchedule>(&invalid_str).is_err());
+        assert!(from_str::<TrainOccurrence>(&invalid_str).is_err());
     }
 
     /// Test deserialize an invalid train schedule
@@ -454,7 +454,7 @@ mod tests {
             id: "a".into(),
             location,
         };
-        let train_schedule = TrainSchedule {
+        let train_schedule = TrainOccurrence {
             path: vec![path_item.clone(), path_item.clone()],
             schedule: vec![ScheduleItem {
                 at: "a".into(),
@@ -465,6 +465,6 @@ mod tests {
             ..Default::default()
         };
         let invalid_str = to_string(&train_schedule).unwrap();
-        assert!(from_str::<TrainSchedule>(&invalid_str).is_err());
+        assert!(from_str::<TrainOccurrence>(&invalid_str).is_err());
     }
 }

--- a/editoast/src/models/fixtures.rs
+++ b/editoast/src/models/fixtures.rs
@@ -228,7 +228,7 @@ pub fn create_modified_exception_with_change_groups(
 
 pub fn simple_paced_train_base() -> PacedTrain {
     PacedTrain {
-        train_schedule_base: schemas::TrainSchedule::fake(),
+        train_occurrence: schemas::TrainOccurrence::fake(),
         paced: Some(Paced {
             time_window: ChronoDuration::hours(2).try_into().unwrap(),
             interval: ChronoDuration::minutes(15).try_into().unwrap(),

--- a/editoast/src/models/paced_train.rs
+++ b/editoast/src/models/paced_train.rs
@@ -18,7 +18,7 @@ use schemas::train_schedule::Margins;
 use schemas::train_schedule::PathItem;
 use schemas::train_schedule::PowerRestrictionItem;
 use schemas::train_schedule::ScheduleItem;
-use schemas::train_schedule::TrainSchedule;
+use schemas::train_schedule::TrainOccurrence;
 use schemas::train_schedule::TrainScheduleOptions;
 use serde::Deserialize;
 use serde::Serialize;
@@ -65,7 +65,7 @@ pub struct PacedTrain {
 }
 
 impl PacedTrain {
-    pub fn apply_exception(&self, exception: &PacedTrainException) -> TrainSchedule {
+    pub fn apply_exception(&self, exception: &PacedTrainException) -> TrainOccurrence {
         let mut train_schedule = self.clone().into_train_schedule();
 
         if let Some(change_group) = &exception.train_name {
@@ -111,8 +111,8 @@ impl PacedTrain {
         train_schedule
     }
 
-    pub fn into_train_schedule(self) -> TrainSchedule {
-        TrainSchedule {
+    pub fn into_train_schedule(self) -> TrainOccurrence {
+        TrainOccurrence {
             train_name: self.train_name,
             labels: self.labels.to_vec(),
             rolling_stock_name: self.rolling_stock_name,
@@ -136,7 +136,7 @@ impl PacedTrain {
     /// Returns an iterator over "created" train exceptions with their IDs and schedules.
     fn get_created_occurrences_exceptions(
         &self,
-    ) -> impl Iterator<Item = (OccurrenceId, TrainSchedule)> {
+    ) -> impl Iterator<Item = (OccurrenceId, TrainOccurrence)> {
         self.exceptions
             .iter()
             .filter(|exception| matches!(exception.exception_type, ExceptionType::Created { .. }))
@@ -159,12 +159,12 @@ impl PacedTrain {
 
     /// Returns all base train occurrences without any exceptions applied.
     /// If it's not a paced train, this will return a vector with a single train schedule.
-    fn get_base_occurrences(&self) -> Vec<(OccurrenceId, TrainSchedule)> {
+    fn get_base_occurrences(&self) -> Vec<(OccurrenceId, TrainOccurrence)> {
         (0..self.num_base_occurrences())
             .map(move |occurrence_idx| {
                 let base_start_time = self.get_occurrence_start_time(occurrence_idx);
                 let occurrence = OccurrenceId::new_base(self.id, occurrence_idx);
-                let train_schedule = TrainSchedule {
+                let train_schedule = TrainOccurrence {
                     start_time: base_start_time,
                     ..self.clone().into_train_schedule()
                 };
@@ -184,7 +184,7 @@ impl PacedTrain {
     /// and appends any `Created` exceptions as new trains.
     ///
     /// The result is sorted by `start_time` to reflect the chronological order of the trains.
-    pub fn iter_occurrences(&self) -> impl Iterator<Item = (OccurrenceId, TrainSchedule)> {
+    pub fn iter_occurrences(&self) -> impl Iterator<Item = (OccurrenceId, TrainOccurrence)> {
         let mut base_occurrences = self.get_base_occurrences();
 
         let modified_exceptions = self
@@ -248,24 +248,24 @@ impl PacedTrain {
 impl From<paced_train::PacedTrain> for PacedTrainChangeset {
     fn from(
         paced_train::PacedTrain {
-            train_schedule_base,
+            train_occurrence,
             paced,
         }: paced_train::PacedTrain,
     ) -> Self {
         let changeset = PacedTrain::changeset()
-            .comfort(train_schedule_base.comfort)
-            .constraint_distribution(train_schedule_base.constraint_distribution)
-            .initial_speed(train_schedule_base.initial_speed)
-            .labels(Tags::new(train_schedule_base.labels))
-            .margins(train_schedule_base.margins)
-            .path(train_schedule_base.path)
-            .power_restrictions(train_schedule_base.power_restrictions)
-            .rolling_stock_name(train_schedule_base.rolling_stock_name)
-            .schedule(train_schedule_base.schedule)
-            .speed_limit_tag(train_schedule_base.speed_limit_tag.map(|s| s.0))
-            .start_time(train_schedule_base.start_time)
-            .train_name(train_schedule_base.train_name)
-            .options(train_schedule_base.options)
+            .comfort(train_occurrence.comfort)
+            .constraint_distribution(train_occurrence.constraint_distribution)
+            .initial_speed(train_occurrence.initial_speed)
+            .labels(Tags::new(train_occurrence.labels))
+            .margins(train_occurrence.margins)
+            .path(train_occurrence.path)
+            .power_restrictions(train_occurrence.power_restrictions)
+            .rolling_stock_name(train_occurrence.rolling_stock_name)
+            .schedule(train_occurrence.schedule)
+            .speed_limit_tag(train_occurrence.speed_limit_tag.map(|s| s.0))
+            .start_time(train_occurrence.start_time)
+            .train_name(train_occurrence.train_name)
+            .options(train_occurrence.options)
             .time_window(
                 paced
                     .as_ref()
@@ -275,7 +275,7 @@ impl From<paced_train::PacedTrain> for PacedTrainChangeset {
             .interval(paced.as_ref().map(|p| p.interval).map(ChronoDuration::from))
             .exceptions(paced.map(|p| p.exceptions).unwrap_or_default());
 
-        match train_schedule_base.category {
+        match train_occurrence.category {
             Some(TrainCategory::Main { main_category }) => changeset
                 .main_category(Some(TrainMainCategory(main_category)))
                 .sub_category(None),
@@ -290,7 +290,7 @@ impl From<paced_train::PacedTrain> for PacedTrainChangeset {
 impl From<PacedTrain> for paced_train::PacedTrain {
     fn from(paced_train: PacedTrain) -> Self {
         Self {
-            train_schedule_base: schemas::TrainSchedule {
+            train_occurrence: schemas::TrainOccurrence {
                 train_name: paced_train.train_name,
                 labels: paced_train.labels.to_vec(),
                 rolling_stock_name: paced_train.rolling_stock_name,

--- a/editoast/src/views/level_crossing_occupancy.rs
+++ b/editoast/src/views/level_crossing_occupancy.rs
@@ -27,7 +27,7 @@ use editoast_derive::EditoastError;
 use editoast_models::prelude::*;
 use editoast_models::rolling_stock::RollingStock;
 use itertools::Itertools;
-use schemas::TrainSchedule;
+use schemas::TrainOccurrence;
 use schemas::infra::Direction;
 use schemas::infra::LevelCrossing;
 use schemas::infra::TrackOffset;
@@ -196,7 +196,7 @@ pub(in crate::views) async fn occupancy(
 }
 
 async fn load_rolling_stock_lengths(
-    train_schedules: &[TrainSchedule],
+    train_schedules: &[TrainOccurrence],
     conn: &mut DbConnection,
 ) -> Result<HashMap<String, u64>> {
     let rolling_stocks_names = train_schedules.iter().map(|t| t.rolling_stock_name.clone());

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -1021,7 +1021,7 @@ mod tests {
 
         let paced_train_1 = simple_paced_train_base();
         let mut paced_train_2 = simple_paced_train_base();
-        paced_train_2.train_schedule_base.start_time += Duration::minutes(200);
+        paced_train_2.train_occurrence.start_time += Duration::minutes(200);
         paced_train_2.paced.as_mut().unwrap().time_window =
             Duration::minutes(120).try_into().unwrap();
         paced_train_2.paced.as_mut().unwrap().interval = Duration::seconds(30).try_into().unwrap();

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -164,7 +164,7 @@ pub(in crate::views) async fn get_by_id(
     put, path = "",
     tags = ["timetable", "paced_train"],
     params(PacedTrainIdParam),
-    request_body = inline(PacedTrain),
+    request_body = PacedTrain,
     responses(
         (status = 204, description = "The paced train has been updated")
     )
@@ -253,7 +253,7 @@ pub(in crate::views) struct PacedTrainSummaryResponse {
 struct SimulationContext {
     paced_train_id: i64,
     exception_key: Option<String>,
-    train_schedule: schemas::TrainSchedule,
+    train_schedule: schemas::TrainOccurrence,
 }
 
 /// Associate each paced train id with its simulation summaries response
@@ -332,7 +332,7 @@ pub(in crate::views) async fn simulation_summary(
             })
             .collect();
 
-    let schedules: Vec<schemas::TrainSchedule> = simulation_contexts
+    let schedules: Vec<schemas::TrainOccurrence> = simulation_contexts
         .iter()
         .map(|ctx| ctx.train_schedule.clone())
         .collect();
@@ -1484,7 +1484,7 @@ mod tests {
     use schemas::train_schedule::Comfort;
     use schemas::train_schedule::PathItem;
     use schemas::train_schedule::ScheduleItem;
-    use schemas::train_schedule::TrainSchedule;
+    use schemas::train_schedule::TrainOccurrence;
     use serde_json::json;
 
     use crate::error::InternalError;
@@ -1558,7 +1558,7 @@ mod tests {
 
         let train_schedule_set = create_train_schedule_set(&mut pool.get_ok()).await;
         let mut paced_train_base = simple_paced_train_base();
-        paced_train_base.train_schedule_base.category = Some(TrainCategory::Sub {
+        paced_train_base.train_occurrence.category = Some(TrainCategory::Sub {
             sub_category_code: created_sub_category.code.clone(),
         });
 
@@ -1594,7 +1594,7 @@ mod tests {
         let created_paced_train: schemas::paced_train::PacedTrain = created_paced_train.into();
 
         assert_eq!(
-            created_paced_train.train_schedule_base.category,
+            created_paced_train.train_occurrence.category,
             Some(TrainCategory::Sub {
                 sub_category_code: created_sub_category.code.clone()
             })
@@ -1806,9 +1806,9 @@ mod tests {
         let rolling_stock =
             create_fast_rolling_stock(&mut db_pool.get_ok(), "simulation_rolling_stock").await;
         let paced_train_base = PacedTrain {
-            train_schedule_base: TrainSchedule {
+            train_occurrence: TrainOccurrence {
                 rolling_stock_name: rolling_stock.name.clone(),
-                ..TrainSchedule::fake()
+                ..TrainOccurrence::fake()
             },
             paced: Some(Paced {
                 time_window: Duration::hours(1).try_into().unwrap(),

--- a/editoast/src/views/timetable/simulation.rs
+++ b/editoast/src/views/timetable/simulation.rs
@@ -687,33 +687,33 @@ fn compute_train_simulation_hash_with_versioning(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use schemas::TrainSchedule;
+    use schemas::TrainOccurrence;
 
     // Test data
     // The simulation responses contain just enough data to compute
     // `path_items_respect_{times,margins}`.
 
-    fn train_schedule_too_fast() -> TrainSchedule {
+    fn train_schedule_too_fast() -> TrainOccurrence {
         const JSON: &str = include_str!("tests/train_schedule_too_fast.json");
         serde_json::from_str(JSON).unwrap()
     }
 
-    fn train_schedule_too_fast_on_interval() -> TrainSchedule {
+    fn train_schedule_too_fast_on_interval() -> TrainOccurrence {
         const JSON: &str = include_str!("tests/train_schedule_too_fast_on_interval.json");
         serde_json::from_str(JSON).unwrap()
     }
 
-    fn train_schedule_not_honored() -> TrainSchedule {
+    fn train_schedule_not_honored() -> TrainOccurrence {
         const JSON: &str = include_str!("tests/train_schedule_not_honored.json");
         serde_json::from_str(JSON).unwrap()
     }
 
-    fn train_schedule_honored() -> TrainSchedule {
+    fn train_schedule_honored() -> TrainOccurrence {
         const JSON: &str = include_str!("tests/train_schedule_honored.json");
         serde_json::from_str(JSON).unwrap()
     }
 
-    fn train_schedule_no_schedule() -> TrainSchedule {
+    fn train_schedule_no_schedule() -> TrainOccurrence {
         const JSON: &str = include_str!("tests/train_schedule_no_schedule.json");
         serde_json::from_str(JSON).unwrap()
     }

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -24,7 +24,7 @@ use schemas::train_schedule::MarginValue;
 use schemas::train_schedule::Margins;
 use schemas::train_schedule::ReceptionSignal;
 use schemas::train_schedule::ScheduleItem;
-use schemas::train_schedule::TrainSchedule;
+use schemas::train_schedule::TrainOccurrence;
 use serde::Deserialize;
 use serde::Serialize;
 use std::cmp::max;
@@ -375,7 +375,7 @@ impl VirtualTrainRun {
         let path = convert_steps(&stdcm_request.steps);
         let last_step = path.last().expect("empty step list");
 
-        let train_schedule = TrainSchedule {
+        let train_schedule = TrainOccurrence {
             train_name: "".to_string(),
             labels: vec![],
             rolling_stock_name: consist_parameters.traction_engine.name.clone(),

--- a/editoast/src/views/timetable/track_occupancy.rs
+++ b/editoast/src/views/timetable/track_occupancy.rs
@@ -50,7 +50,7 @@ fn extract_occupancy_context<'a>(
     op_cache: &OperationalPointCache,
     simulation: &'a simulation::Response,
     pathfinding: &'a PathfindingResult,
-    train_schedule: &'a schemas::TrainSchedule,
+    train_schedule: &'a schemas::TrainOccurrence,
 ) -> OccupancyContext<'a> {
     let report_train = match simulation {
         simulation::Response::Success(simulation) => simulation
@@ -80,7 +80,7 @@ fn extract_occupancy_context<'a>(
 fn extract_occupancy_context_without_simulation<'a>(
     operational_point_id: &str,
     op_cache: &OperationalPointCache,
-    train_schedule: &'a schemas::TrainSchedule,
+    train_schedule: &'a schemas::TrainOccurrence,
 ) -> OccupancyContext<'a> {
     let matching_index =
         find_matching_path_item_index(&train_schedule.path, operational_point_id, op_cache);
@@ -140,7 +140,7 @@ fn get_track_section(
     context: &OccupancyContext,
     operational_point_track_offsets: &[TrackOffset],
     op_cache: &OperationalPointCache,
-    train_schedule: &schemas::TrainSchedule,
+    train_schedule: &schemas::TrainOccurrence,
 ) -> Option<String> {
     if let Some(pathfinding_success) = context.pathfinding_success {
         let path_projection = PathProjection::new(&pathfinding_success.path.track_section_ranges);
@@ -177,7 +177,7 @@ pub fn find_track_occupancy_for_operational_point(
     op_cache: &OperationalPointCache,
     simulation: &simulation::Response,
     pathfinding: &PathfindingResult,
-    train_schedule: &schemas::TrainSchedule,
+    train_schedule: &schemas::TrainOccurrence,
 ) -> Vec<TrackOccupancy> {
     let context = extract_occupancy_context(
         operational_point_id,
@@ -198,7 +198,7 @@ pub fn find_track_occupancy_for_operational_point_without_simulation(
     operational_point_id: &str,
     operational_point_track_offsets: &[TrackOffset],
     op_cache: &OperationalPointCache,
-    train_schedule: &schemas::TrainSchedule,
+    train_schedule: &schemas::TrainOccurrence,
 ) -> Vec<TrackOccupancy> {
     let context = extract_occupancy_context_without_simulation(
         operational_point_id,
@@ -217,7 +217,7 @@ fn find_track_occupancy_for_operational_point_with_context<'a>(
     context: OccupancyContext<'a>,
     operational_point_track_offsets: &[TrackOffset],
     op_cache: &OperationalPointCache,
-    train_schedule: &schemas::TrainSchedule,
+    train_schedule: &schemas::TrainOccurrence,
 ) -> Vec<TrackOccupancy> {
     let arrival_time = match get_arrival_time(&context, operational_point_track_offsets) {
         Some(time) => time,
@@ -326,7 +326,7 @@ pub mod tests {
 
         // Create a train schedule with path items and schedule items
         let start_time = DateTime::from_timestamp(1000000000, 0).unwrap();
-        let train_schedule = schemas::TrainSchedule {
+        let train_schedule = schemas::TrainOccurrence {
             start_time,
             path: vec![
                 PathItem {

--- a/front/src/applications/operationalStudies/helpers/upsertMapWaypointsInOperationalPoints.ts
+++ b/front/src/applications/operationalStudies/helpers/upsertMapWaypointsInOperationalPoints.ts
@@ -1,6 +1,6 @@
 import type { TFunction } from 'i18next';
 
-import type { CorePathfindingResultSuccess, TrainSchedule } from 'common/api/osrdEditoastApi';
+import type { CorePathfindingResultSuccess, PacedTrain } from 'common/api/osrdEditoastApi';
 import type {
   PathOperationalPoint,
   EditoastPathOperationalPoint,
@@ -13,21 +13,21 @@ const HIGHEST_PRIORITY_WEIGHT = 100;
  */
 export function upsertMapWaypointsInOperationalPoints(
   type: 'PathOperationalPoint',
-  path: TrainSchedule['path'],
+  path: PacedTrain['path'],
   pathItemsPositions: CorePathfindingResultSuccess['path_item_positions'],
   operationalPoints: PathOperationalPoint[],
   t: TFunction<'operational-studies'>
 ): PathOperationalPoint[];
 export function upsertMapWaypointsInOperationalPoints(
   type: 'EditoastPathOperationalPoint',
-  path: TrainSchedule['path'],
+  path: PacedTrain['path'],
   pathItemsPositions: CorePathfindingResultSuccess['path_item_positions'],
   operationalPoints: EditoastPathOperationalPoint[],
   t: TFunction<'operational-studies'>
 ): EditoastPathOperationalPoint[];
 export function upsertMapWaypointsInOperationalPoints(
   type: 'PathOperationalPoint' | 'EditoastPathOperationalPoint',
-  path: TrainSchedule['path'],
+  path: PacedTrain['path'],
   pathItemsPositions: CorePathfindingResultSuccess['path_item_positions'],
   operationalPoints: (PathOperationalPoint | EditoastPathOperationalPoint)[],
   t: TFunction<'operational-studies'>

--- a/front/src/applications/operationalStudies/hooks/useScenarioData.ts
+++ b/front/src/applications/operationalStudies/hooks/useScenarioData.ts
@@ -206,7 +206,7 @@ const useScenarioData = (scenario: ScenarioWithDetails, infraId: number) => {
 
       await putPacedTrainById({
         id: editoastPacedTrainId,
-        body: {
+        pacedTrain: {
           ...timetableItem,
           start_time: newDeparture.toISOString(),
         },

--- a/front/src/applications/operationalStudies/types.ts
+++ b/front/src/applications/operationalStudies/types.ts
@@ -7,7 +7,6 @@ import type {
   CorePathfindingResultSuccess,
   SimulationResponse,
   SimulationResponseSuccess,
-  TrainSchedule,
   MacroNodeForm,
   RollingStockWithLiveries,
   TrainCategory,
@@ -115,7 +114,7 @@ export type PathPropertiesFormatted = {
   voltages: RangedValue[];
 };
 
-export type PowerRestriction = ArrayElement<TrainSchedule['power_restrictions']>;
+export type PowerRestriction = ArrayElement<PacedTrain['power_restrictions']>;
 
 export type ElectrificationVoltage = {
   type: string;

--- a/front/src/applications/operationalStudies/utils.ts
+++ b/front/src/applications/operationalStudies/utils.ts
@@ -11,7 +11,7 @@ import type {
   RoundTrips,
   SimulationResponseSuccess,
   SimulationSummaryResult,
-  TrainSchedule,
+  PacedTrain,
 } from 'common/api/osrdEditoastApi';
 import getPathVoltages from 'modules/pathfinding/helpers/getPathVoltages';
 import { isPacedTrain } from 'modules/timetableItem/helpers/pacedTrain';
@@ -156,7 +156,7 @@ export const preparePathPropertiesData = (
   electricalProfiles: SimulationResponseSuccess['electrical_profiles'],
   { slopes, curves, electrifications, operational_points, geometry }: PathProperties,
   { path_item_positions, length }: CorePathfindingResultSuccess,
-  trainSchedulePath: TrainSchedule['path'],
+  trainSchedulePath: PacedTrain['path'],
   t: TFunction<'operational-studies'>
 ): PathPropertiesFormatted => {
   const formattedSlopes = transformBoundariesDataToPositionDataArray(slopes, length, 'gradient');

--- a/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/__tests__/importTimetableItem.spec.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/__tests__/importTimetableItem.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 
 import type { CichDictValue } from 'applications/operationalStudies/types';
-import type { TrainSchedule } from 'common/api/osrdEditoastApi';
+import type { PacedTrain } from 'common/api/osrdEditoastApi';
 
 import { buildSteps } from '../buildStepsFromOcp';
 import findMostFrequentScheduleInPacedTrain from '../findMostFrequentXmlSchedule';
@@ -72,7 +72,7 @@ describe('buildSteps', () => {
   });
 });
 
-function buildSchedule(id: string, timeOffsetSeconds: number = 0): TrainSchedule {
+function buildSchedule(id: string, timeOffsetSeconds: number = 0): PacedTrain {
   const baseDate = new Date('2025-01-01T08:00:00');
   const departureDate = new Date(baseDate.getTime() + timeOffsetSeconds * 1000);
 
@@ -156,7 +156,7 @@ describe('findMostFrequentScheduleInPacedTrain', () => {
 
 describe('getMostFrequentInterval', () => {
   it('returns 60 min when 60 and 120 are equally frequent', () => {
-    const schedules: TrainSchedule[] = [
+    const schedules: PacedTrain[] = [
       buildSchedule('s1', 0),
       buildSchedule('s2', 3600),
       buildSchedule('s3', 10800),

--- a/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/buildStepsFromOcp.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/buildStepsFromOcp.ts
@@ -1,7 +1,7 @@
 import { v4 as uuidV4 } from 'uuid';
 
 import type { CichDictValue } from 'applications/operationalStudies/types';
-import type { TrainSchedule } from 'common/api/osrdEditoastApi';
+import type { PacedTrain } from 'common/api/osrdEditoastApi';
 import { Duration } from 'utils/duration';
 import { time2sec } from 'utils/timeManipulation';
 
@@ -11,7 +11,7 @@ export const buildSteps = (
   ocpTTs: Element[],
   cichDict: Record<string, CichDictValue>,
   startDate: Date
-): Required<Pick<TrainSchedule, 'path' | 'schedule'>> => {
+): Required<Pick<PacedTrain, 'path' | 'schedule'>> => {
   let dayOffset = 0;
 
   let previousDepartureSeconds: number | null = null;
@@ -83,8 +83,8 @@ export const buildSteps = (
     })
     .filter((step) => step !== null);
 
-  const path: TrainSchedule['path'] = [];
-  const schedule: TrainSchedule['schedule'] = [];
+  const path: PacedTrain['path'] = [];
+  const schedule: PacedTrain['schedule'] = [];
   const departureTime = steps[0].departureDate;
   for (const step of steps) {
     const id = uuidV4();

--- a/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/findMostFrequentXmlSchedule.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/findMostFrequentXmlSchedule.ts
@@ -1,6 +1,6 @@
-import type { TrainSchedule } from 'common/api/osrdEditoastApi';
+import type { PacedTrain } from 'common/api/osrdEditoastApi';
 
-function getRelativeStepsTimeAndNames(trainSchedule: TrainSchedule): string {
+function getRelativeStepsTimeAndNames(trainSchedule: PacedTrain): string {
   const stepsWithRelativeTimesAndNames = trainSchedule.schedule!.map((step) => ({
     ...trainSchedule.path.find((pathStep) => pathStep.id === step.at),
     arrival: step.arrival,
@@ -10,8 +10,8 @@ function getRelativeStepsTimeAndNames(trainSchedule: TrainSchedule): string {
   return JSON.stringify(stepsWithRelativeTimesAndNames);
 }
 
-export default function findMostFrequentScheduleInPacedTrain(schedules: TrainSchedule[]) {
-  const scheduleOccurrences = new Map<string, { count: number; schedule: TrainSchedule }>();
+export default function findMostFrequentScheduleInPacedTrain(schedules: PacedTrain[]) {
+  const scheduleOccurrences = new Map<string, { count: number; schedule: PacedTrain }>();
 
   schedules.forEach((schedule) => {
     const relativeSteps = getRelativeStepsTimeAndNames(schedule);
@@ -23,7 +23,7 @@ export default function findMostFrequentScheduleInPacedTrain(schedules: TrainSch
     }
   });
 
-  let mostFrequent: TrainSchedule | null = null;
+  let mostFrequent: PacedTrain | null = null;
   let highestCount = 0;
 
   for (const { count, schedule } of scheduleOccurrences.values()) {

--- a/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/parseJson.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/parseJson.ts
@@ -8,9 +8,9 @@ import type {
 } from 'applications/operationalStudies/types';
 import { convertNgeDtoToOsrd } from 'applications/operationalStudies/views/Scenario/components/MacroEditor/ngeToOsrd';
 import type { NetzgrafikDto } from 'applications/operationalStudies/views/Scenario/components/NGE/types';
-import { type TrainSchedule } from 'common/api/osrdEditoastApi';
+import { type PacedTrain } from 'common/api/osrdEditoastApi';
 
-const TRAIN_SCHEDULE_COMPULSORY_KEYS: (keyof TrainSchedule)[] = [
+const TRAIN_SCHEDULE_COMPULSORY_KEYS: (keyof PacedTrain)[] = [
   'constraint_distribution',
   'path',
   'rolling_stock_name',

--- a/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/parseXML.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/parseXML.ts
@@ -6,7 +6,7 @@ import type {
   PacedTrainWithPaced,
   TimetableJsonPayload,
 } from 'applications/operationalStudies/types';
-import type { PacedTrain, TrainSchedule, PacedTrainException } from 'common/api/osrdEditoastApi';
+import type { PacedTrain, PacedTrainException } from 'common/api/osrdEditoastApi';
 import { addDurationToDate, Duration } from 'utils/duration';
 
 import { buildSteps, cleanTimeFormat } from './buildStepsFromOcp';
@@ -19,7 +19,7 @@ const extractCiChCode = (code: string) => {
 };
 
 const trainScheduleToPacedTrain = (
-  trainSchedule: TrainSchedule,
+  trainSchedule: PacedTrain,
   pacedTrainId: string,
   intervalDuration: Duration,
   timeWindowDuration: Duration
@@ -33,7 +33,7 @@ const trainScheduleToPacedTrain = (
   },
 });
 
-const mapTrainNames = (trainSchedules: TrainSchedule[], trains: Element[]): TrainSchedule[] => {
+const mapTrainNames = (trainSchedules: PacedTrain[], trains: Element[]): PacedTrain[] => {
   const trainPartToTrainMap: Record<string, string> = {};
 
   trains.forEach((train) => {
@@ -56,7 +56,7 @@ const mapTrainNames = (trainSchedules: TrainSchedule[], trains: Element[]): Trai
   return updatedTrainSchedules;
 };
 
-export const getMostFrequentInterval = (schedules: TrainSchedule[]): Duration => {
+export const getMostFrequentInterval = (schedules: PacedTrain[]): Duration => {
   const departureTimes = schedules
     .map((s) => new Date(s.start_time))
     .sort((a, b) => a.getTime() - b.getTime());
@@ -97,8 +97,8 @@ export const getMostFrequentInterval = (schedules: TrainSchedule[]): Duration =>
 
 const reconcilePacedTrainOccurrences = (
   pacedTrainId: string,
-  importedTrainSchedules: TrainSchedule[],
-  modelTrainSchedule: TrainSchedule,
+  importedTrainSchedules: PacedTrain[],
+  modelTrainSchedule: PacedTrain,
   intervalDuration: Duration
 ): PacedTrain | null => {
   if (importedTrainSchedules.length < 2) {
@@ -141,7 +141,7 @@ const reconcilePacedTrainOccurrences = (
 
   const osrdDefaultOccurrences: {
     startTime: Date;
-    matchedImportedSchedule: TrainSchedule | null;
+    matchedImportedSchedule: PacedTrain | null;
   }[] = [];
   for (let i = 0; i < numberOfExpectedOccurrences; i += 1) {
     const expectedDepartureTime = addDurationToDate(
@@ -155,12 +155,12 @@ const reconcilePacedTrainOccurrences = (
   }
 
   const matchedImportedScheduleKeys = new Set<string>();
-  const getScheduleKey = (s: TrainSchedule) => `${s.start_time}`;
+  const getScheduleKey = (s: PacedTrain) => `${s.start_time}`;
   const exceptions: PacedTrainException[] = [];
 
   // Match OSRD Default Occurrences to imported Trains
   osrdDefaultOccurrences.forEach((osrdOccurrence, index) => {
-    let bestCandidate: TrainSchedule | null = null;
+    let bestCandidate: PacedTrain | null = null;
     let minTimeDifference = Infinity;
 
     const availableImportedSchedules = sortedImportedSchedules.filter(
@@ -230,7 +230,7 @@ const reconcilePacedTrainOccurrences = (
 };
 
 const parseXML = async (xmlDoc: Document): Promise<TimetableJsonPayload> => {
-  const trainSchedules: TrainSchedule[] = [];
+  const trainSchedules: PacedTrain[] = [];
 
   // Initialize localCichDict
   const localCichDict: Record<string, CichDictValue> = {};
@@ -251,10 +251,10 @@ const parseXML = async (xmlDoc: Document): Promise<TimetableJsonPayload> => {
     });
   });
 
-  const pacedTrains: Record<string, TrainSchedule[]> = {};
+  const pacedTrains: Record<string, PacedTrain[]> = {};
   const trainGroups = Array.from(xmlDoc.getElementsByTagName('trainGroup'));
 
-  const trainSchedulesByTrainPartId: Record<string, TrainSchedule> = {};
+  const trainSchedulesByTrainPartId: Record<string, PacedTrain> = {};
   const trainParts = Array.from(xmlDoc.getElementsByTagName('trainPart'));
   const period = xmlDoc.getElementsByTagName('timetablePeriod')[0];
   const startDate = period ? period.getAttribute('startDate') : null;
@@ -290,7 +290,7 @@ const parseXML = async (xmlDoc: Document): Promise<TimetableJsonPayload> => {
     // Build steps using the fully populated localCichDict
     const { path, schedule } = buildSteps(ocpSteps, localCichDict, new Date(startDate));
 
-    const trainSchedule: TrainSchedule = {
+    const trainSchedule: PacedTrain = {
       train_name: trainNumber,
       rolling_stock_name: rollingStockName || formationRef || '', // RollingStocks in xml files rarely have the correct format
       start_time: new Date(`${startDate} ${firstDepartureTimeformatted}`).toISOString(),
@@ -328,7 +328,7 @@ const parseXML = async (xmlDoc: Document): Promise<TimetableJsonPayload> => {
 
   const pacedTrainMostFrequentSchedules: Record<
     string,
-    { schedule: TrainSchedule | null; count: number }
+    { schedule: PacedTrain | null; count: number }
   > = {};
 
   Object.entries(pacedTrains).forEach(([pacedTrainId, schedules]) => {

--- a/front/src/applications/operationalStudies/views/Scenario/components/ImportTrainScheduleSets/TrainScheduleSetsCart.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ImportTrainScheduleSets/TrainScheduleSetsCart.tsx
@@ -20,7 +20,7 @@ const TrainScheduleSetsCart = ({
   const { t } = useTranslation('operational-studies', { keyPrefix: 'importTrainScheduleSet' });
 
   /**
-   * List of TrainSchedule sets in the cart
+   * List of train schedule sets in the cart
    */
   const trainScheduleSetsInCart = useMemo(
     () =>

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/consts.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/consts.ts
@@ -1,4 +1,4 @@
-import type { TrainMainCategory, TrainSchedule } from 'common/api/osrdEditoastApi';
+import type { TrainMainCategory, PacedTrain } from 'common/api/osrdEditoastApi';
 import { Duration } from 'utils/duration';
 
 import type {
@@ -154,7 +154,7 @@ export const DEFAULT_TIME_LOCK: TimeLockDto = {
 };
 
 export const DEFAULT_TRAIN_SCHEDULE_PAYLOAD: Pick<
-  TrainSchedule,
+  PacedTrain,
   'constraint_distribution' | 'rolling_stock_name'
 > = {
   constraint_distribution: 'STANDARD',

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/ngeToOsrd/trainrun.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/ngeToOsrd/trainrun.ts
@@ -2,7 +2,6 @@ import { compact, uniq } from 'lodash';
 
 import {
   type PacedTrain,
-  type TrainSchedule,
   type PathItemLocation,
   type PacedTrainResponse,
 } from 'common/api/osrdEditoastApi';
@@ -143,7 +142,7 @@ const createPathItemFromNode = (
   node: NodeDto,
   index: number,
   state?: MacroEditorState
-): TrainSchedule['path'][number] => {
+): PacedTrain['path'][number] => {
   let pathItemLocation: PathItemLocation;
   if (state) {
     const indexedNode = state.getNodeByNgeId(node.id)!;
@@ -183,7 +182,7 @@ export const generatePath = (
   nodes: NodeDto[],
   trainrunDirection: TRAINRUN_DIRECTIONS,
   state?: MacroEditorState
-): TrainSchedule['path'] => {
+): PacedTrain['path'] => {
   const isForward = trainrunDirection === TRAINRUN_DIRECTIONS.FORWARD;
   const path = trainrunSections.map((section, index) => {
     const fromNode = getNodeById(nodes, isForward ? section.sourceNodeId : section.targetNodeId);
@@ -227,7 +226,7 @@ const generateSchedule = (
   nodes: NodeDto[],
   startDate: Date,
   trainrunDirection: TRAINRUN_DIRECTIONS
-): TrainSchedule['schedule'] => {
+): PacedTrain['schedule'] => {
   const isForward = trainrunDirection === TRAINRUN_DIRECTIONS.FORWARD;
   return trainrunSections.flatMap((section, index) => {
     const nextSection = trainrunSections[index + 1];
@@ -342,7 +341,7 @@ export const generatePathAndSchedule = (
 // TODO: drop this function once this PR is merged:
 // https://github.com/OpenRailAssociation/osrd/pull/10325
 const populateSecondaryCodesInPath = async (
-  path: TrainSchedule['path'],
+  path: PacedTrain['path'],
   infraId: number,
   dispatch: AppDispatch
 ) => {

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/hooks/usePathStepsMetadata.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/hooks/usePathStepsMetadata.ts
@@ -8,7 +8,7 @@ import { useScenarioContext } from 'applications/operationalStudies/hooks/useSce
 import {
   osrdEditoastApi,
   type OperationalPointReference,
-  type TrainSchedule,
+  type PacedTrain,
 } from 'common/api/osrdEditoastApi';
 import type { PathStepMetadata, PathStepV2 } from 'reducers/osrdconf/types';
 import { getPointOnTrackCoordinates } from 'utils/geometry';
@@ -25,9 +25,9 @@ export const usePathStepsMetadata = (pathSteps: PathStepV2[]) => {
   );
 
   // 1. Extract the train path to extract its steps related operational points
-  const strippedTrainPath: TrainSchedule['path'] = useMemo(
+  const strippedTrainPath: PacedTrain['path'] = useMemo(
     () =>
-      pathSteps.reduce<TrainSchedule['path']>((acc, step) => {
+      pathSteps.reduce<PacedTrain['path']>((acc, step) => {
         if (!step.location) return acc;
         if ('operational_point' in step.location) {
           if (

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/helpers/buildPacedTrainException.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/helpers/buildPacedTrainException.ts
@@ -1,7 +1,7 @@
 import { isEmpty, isEqual, omit } from 'lodash';
 
 import type { PacedTrainWithPaced } from 'applications/operationalStudies/types';
-import type { PacedTrain, PacedTrainException, TrainSchedule } from 'common/api/osrdEditoastApi';
+import type { PacedTrain, PacedTrainException } from 'common/api/osrdEditoastApi';
 import computeBasePathStep from 'modules/timetableItem/helpers/computeBasePathStep';
 import computeOccurrenceName from 'modules/timetableItem/helpers/computeOccurrenceName';
 import {
@@ -23,7 +23,7 @@ import {
  * the caller is responsible for generating the exception key and occurrence index.
  */
 export function generatePacedTrainException(
-  updatedOccurrence: TrainSchedule,
+  updatedOccurrence: PacedTrain,
   originalPacedTrain: Omit<PacedTrainWithPaced, 'train_schedule_set_id'>,
   occurrenceIndex: number | null = null
 ): Omit<PacedTrainException, 'key' | 'occurrence_index'> {
@@ -179,7 +179,7 @@ export function updatePacedTrainExceptionsList<T extends PacedTrainException>(
  * If the exceptions as no change group after those checks, the exception is removed.
  */
 export function checkChangeGroups(
-  updatedTrain: TrainSchedule,
+  updatedTrain: PacedTrain,
   paced: NonNullable<PacedTrain['paced']>,
   originalExceptions: PacedTrainException[]
 ): PacedTrainException[] {

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/helpers/formatSchedule.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/helpers/formatSchedule.ts
@@ -1,9 +1,9 @@
 import { compact } from 'lodash';
 
-import type { TrainSchedule } from 'common/api/osrdEditoastApi';
+import type { PacedTrain } from 'common/api/osrdEditoastApi';
 import type { PathStep } from 'reducers/osrdconf/types';
 
-const formatSchedule = (pathSteps: PathStep[]): TrainSchedule['schedule'] => {
+const formatSchedule = (pathSteps: PathStep[]): PacedTrain['schedule'] => {
   const schedules = pathSteps.map((step) => {
     if (step?.arrival || step.stopFor) {
       return {

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/helpers/formatTimetableItemPayload.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/helpers/formatTimetableItemPayload.ts
@@ -2,7 +2,7 @@ import { compact } from 'lodash';
 import { v4 as uuidV4 } from 'uuid';
 
 import type { PacedTrainWithPaced } from 'applications/operationalStudies/types';
-import type { PacedTrain, TrainSchedule } from 'common/api/osrdEditoastApi';
+import type { PacedTrain } from 'common/api/osrdEditoastApi';
 import getStepLocation from 'modules/pathfinding/helpers/getStepLocation';
 import {
   findExceptionWithOccurrenceId,
@@ -33,7 +33,7 @@ export function formatTimetableItemPayload(
   osrdconf: OperationalStudiesConfState,
   // TODO TS2 : remove this when rollingStockName will replace rollingStockId in the store
   rollingStockName: string
-): TrainSchedule {
+): PacedTrain {
   return {
     category: osrdconf.category,
     comfort: osrdconf.rollingStockComfort,

--- a/front/src/applications/operationalStudies/views/Scenario/components/RoundTrips/utils.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/RoundTrips/utils.ts
@@ -6,7 +6,7 @@ import {
   checkRoundTripCompatible,
   getStationFromOps,
 } from 'applications/operationalStudies/utils';
-import type { OperationalPoint, TrainSchedule, RoundTrips } from 'common/api/osrdEditoastApi';
+import type { OperationalPoint, PacedTrain, RoundTrips } from 'common/api/osrdEditoastApi';
 import { isPacedTrain } from 'modules/timetableItem/helpers/pacedTrain';
 import type { TimetableItemWithPathOps } from 'reducers/osrdconf/types';
 import { addDurationToDate, Duration } from 'utils/duration';
@@ -16,8 +16,8 @@ import type { PairingItem } from './types';
 
 const getStepLabels = (
   ops: (OperationalPoint[] | null)[],
-  steps: TrainSchedule['path'],
-  schedule: TrainSchedule['schedule'],
+  steps: PacedTrain['path'],
+  schedule: PacedTrain['schedule'],
   t: TFunction<'operational-studies', 'main'>
 ) =>
   steps.reduce<string[]>((acc, step, index) => {

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TrainScheduleItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TrainScheduleItem.tsx
@@ -8,7 +8,7 @@ import { omit } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
-import type { SubCategory, TrainSchedule } from 'common/api/osrdEditoastApi';
+import type { SubCategory, PacedTrain } from 'common/api/osrdEditoastApi';
 import RollingStock2Img from 'modules/rollingStock/components/RollingStock2Img';
 import isMainCategory from 'modules/rollingStock/helpers/category';
 import { deletePacedTrains } from 'modules/timetableItem/helpers/updateTimetableItemHelpers';
@@ -113,7 +113,7 @@ const TrainScheduleItem = ({
         new Duration({ minutes: TIMETABLE_ITEM_DELTA })
       );
 
-      const newTrain: TrainSchedule = {
+      const newTrain: PacedTrain = {
         ...omit(trainDetail, ['id', 'train_schedule_set_id']),
         start_time: startTime.toISOString(),
         train_name: trainName,

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -709,7 +709,7 @@ const injectedRtkApi = api
         query: (queryArg) => ({
           url: `/paced_train/${queryArg.id}`,
           method: 'PUT',
-          body: queryArg.body,
+          body: queryArg.pacedTrain,
         }),
         invalidatesTags: ['timetable', 'paced_train'],
       }),
@@ -2069,15 +2069,7 @@ export type GetPacedTrainByIdApiArg = {
 export type PutPacedTrainByIdApiResponse = unknown;
 export type PutPacedTrainByIdApiArg = {
   id: number;
-  body: TrainSchedule & {
-    paced?: null | {
-      exceptions: PacedTrainException[];
-      /** Time between two occurrences, an ISO 8601 format is expected */
-      interval: PositiveDuration;
-      /** Duration of the paced train, an ISO 8601 format is expected */
-      time_window: PositiveDuration;
-    };
-  };
+  pacedTrain: PacedTrain;
 };
 export type GetPacedTrainByIdEtcsBrakingCurvesApiResponse =
   /** status 200 ETCS Braking Curves Output */ CoreEtcsBrakingCurvesResponse;
@@ -3879,26 +3871,6 @@ export type ScheduleItem = {
   reception_signal?: ReceptionSignal;
   stop_for?: null | PositiveDuration;
 };
-export type TrainSchedule = {
-  category?: null | TrainCategory;
-  comfort?: Comfort;
-  constraint_distribution: Distribution;
-  initial_speed?: number;
-  labels?: string[];
-  margins?: Margins;
-  options?: TrainScheduleOptions;
-  path: PathItem[];
-  power_restrictions?: {
-    from: string;
-    to: string;
-    value: string;
-  }[];
-  rolling_stock_name: string;
-  schedule?: ScheduleItem[];
-  speed_limit_tag?: null | string;
-  start_time: string;
-  train_name: string;
-};
 export type ConstraintDistributionChangeGroup = {
   value: Distribution;
 };
@@ -3955,7 +3927,26 @@ export type PacedTrainException = {
   start_time?: StartTimeChangeGroup;
   train_name?: TrainNameChangeGroup;
 };
-export type PacedTrain = TrainSchedule & {
+export type PacedTrain = {
+  category?: null | TrainCategory;
+  comfort?: Comfort;
+  constraint_distribution: Distribution;
+  initial_speed?: number;
+  labels?: string[];
+  margins?: Margins;
+  options?: TrainScheduleOptions;
+  path: PathItem[];
+  power_restrictions?: {
+    from: string;
+    to: string;
+    value: string;
+  }[];
+  rolling_stock_name: string;
+  schedule?: ScheduleItem[];
+  speed_limit_tag?: null | string;
+  start_time: string;
+  train_name: string;
+} & {
   paced?: null | {
     exceptions: PacedTrainException[];
     /** Time between two occurrences, an ISO 8601 format is expected */

--- a/front/src/modules/powerRestriction/helpers/__tests__/formatPowerRestrionRangesWithHandle.spec.ts
+++ b/front/src/modules/powerRestriction/helpers/__tests__/formatPowerRestrionRangesWithHandle.spec.ts
@@ -1,7 +1,7 @@
 import type { LayerData, PowerRestrictionValues } from '@osrd-project/ui-charts';
 import { describe, it, expect } from 'vitest';
 
-import type { TrainSchedule } from 'common/api/osrdEditoastApi';
+import type { PacedTrain } from 'common/api/osrdEditoastApi';
 import type { RangedValue } from 'common/types';
 
 import {
@@ -12,7 +12,7 @@ import generateEffortCurvesForTests from './generateEffortCurvesForTests';
 
 describe('formatPowerRestrictionRanges', () => {
   it('should properly format power restrictions ranges', () => {
-    const powerRestrictions: NonNullable<TrainSchedule['power_restrictions']> = [
+    const powerRestrictions: NonNullable<PacedTrain['power_restrictions']> = [
       {
         from: 'step1',
         to: 'step2',
@@ -24,7 +24,7 @@ describe('formatPowerRestrictionRanges', () => {
         value: 'code2',
       },
     ];
-    const pathSteps: TrainSchedule['path'] = [
+    const pathSteps: PacedTrain['path'] = [
       {
         location: { operational_point: { uic: 12345, type: 'uic', secondary_code: null } },
         id: 'step1',

--- a/front/src/modules/powerRestriction/helpers/formatPowerRestrictionRangesWithHandled.ts
+++ b/front/src/modules/powerRestriction/helpers/formatPowerRestrictionRangesWithHandled.ts
@@ -5,7 +5,7 @@ import type { PathPropertiesFormatted } from 'applications/operationalStudies/ty
 import type {
   CorePathfindingResultSuccess,
   RollingStock,
-  TrainSchedule,
+  PacedTrain,
 } from 'common/api/osrdEditoastApi';
 import type { RangedValue } from 'common/types';
 import { getRollingStockPowerRestrictionsByMode } from 'modules/rollingStock/helpers/powerRestrictions';
@@ -16,8 +16,8 @@ import { mmToKm, mToMm } from 'utils/physics';
  * Format power restrictions data to ranges data base on path steps position
  */
 export const formatPowerRestrictionRanges = (
-  powerRestrictions: NonNullable<TrainSchedule['power_restrictions']>,
-  path: TrainSchedule['path'],
+  powerRestrictions: NonNullable<PacedTrain['power_restrictions']>,
+  path: PacedTrain['path'],
   stepsPathPositions: CorePathfindingResultSuccess['path_item_positions']
 ): LayerData<Omit<PowerRestrictionValues, 'handled'>>[] =>
   compact(

--- a/front/src/modules/simulationResult/types.ts
+++ b/front/src/modules/simulationResult/types.ts
@@ -12,7 +12,7 @@ import type {
   PathProperties,
   RollingStockWithLiveries,
   SimulationResponseSuccess,
-  TrainSchedule,
+  PacedTrain,
   PathItem,
 } from 'common/api/osrdEditoastApi';
 import type { PacedTrainWithDetails } from 'modules/timetableItem/types';
@@ -96,7 +96,7 @@ export type WaypointsPanelData = {
   setFilteredWaypoints: Dispatch<SetStateAction<PathOperationalPoint[]>>;
   deployedWaypoints: Set<string>;
   toggleDeployedWaypoint: (waypointId: string, deployed?: boolean) => void;
-  projectionPath: TrainSchedule['path'];
+  projectionPath: PacedTrain['path'];
 };
 
 export type LayerRangeData = {

--- a/front/src/modules/timetableItem/helpers/computeBasePathStep.ts
+++ b/front/src/modules/timetableItem/helpers/computeBasePathStep.ts
@@ -1,4 +1,4 @@
-import type { TrainSchedule } from 'common/api/osrdEditoastApi';
+import type { PacedTrain } from 'common/api/osrdEditoastApi';
 import type { PathStep } from 'reducers/osrdconf/types';
 import { Duration } from 'utils/duration';
 
@@ -19,7 +19,7 @@ const findCorrespondingMargin = (
  * Given a timetable item and a path item index, aggregate schedule, margins and the corresponding path item to return a PathStep
  */
 const computeBasePathStep = (
-  timetableItem: Pick<TrainSchedule, 'path' | 'schedule' | 'margins'>,
+  timetableItem: Pick<PacedTrain, 'path' | 'schedule' | 'margins'>,
   pathItemIndex: number
 ): PathStep => {
   const { id, location } = timetableItem.path[pathItemIndex];

--- a/front/src/modules/timetableItem/helpers/updateTimetableItemHelpers.ts
+++ b/front/src/modules/timetableItem/helpers/updateTimetableItemHelpers.ts
@@ -56,7 +56,7 @@ async function updatePacedTrain(dispatch: AppDispatch, id: PacedTrainId, pacedTr
   await dispatch(
     osrdEditoastApi.endpoints.putPacedTrainById.initiate({
       id: extractEditoastIdFromPacedTrainId(id),
-      body: pacedTrain,
+      pacedTrain,
     })
   ).unwrap();
 }

--- a/front/src/reducers/osrdconf/operationalStudiesConf/__tests__/trainSettingsReducer.ts
+++ b/front/src/reducers/osrdconf/operationalStudiesConf/__tests__/trainSettingsReducer.ts
@@ -1,6 +1,6 @@
 import { beforeEach, it, expect } from 'vitest';
 
-import type { Distribution, TrainCategory, TrainSchedule } from 'common/api/osrdEditoastApi';
+import type { Distribution, TrainCategory, PacedTrain } from 'common/api/osrdEditoastApi';
 import {
   operationalStudiesConfSlice,
   operationalStudiesInitialConf,
@@ -89,7 +89,7 @@ const testTrainSettingsReducer = () => {
   });
 
   it('should handle updateRollingStockComfort', () => {
-    const newRollingStockComfort: TrainSchedule['comfort'] = 'AIR_CONDITIONING';
+    const newRollingStockComfort: PacedTrain['comfort'] = 'AIR_CONDITIONING';
     defaultStore.dispatch(updateRollingStockComfort(newRollingStockComfort));
     const state = getState();
     expect(state.rollingStockComfort).toBe(newRollingStockComfort);

--- a/front/tests/02-operational-studies/nge/001-osrd-nge.spec.ts
+++ b/front/tests/02-operational-studies/nge/001-osrd-nge.spec.ts
@@ -1,4 +1,4 @@
-import type { Scenario, Project, Study, Infra, TrainSchedule } from 'common/api/osrdEditoastApi';
+import type { Scenario, Project, Study, Infra, PacedTrain } from 'common/api/osrdEditoastApi';
 
 import {
   timetableItemProjectName,
@@ -13,7 +13,7 @@ import sendTrains from '../../utils/send-trains';
 import { deleteScenario } from '../../utils/teardown-utils';
 import type { TimetableFilterTranslations } from '../../utils/types';
 
-const trains: TrainSchedule[] = readJsonFile('./tests/assets/trains/trains.json');
+const trains: PacedTrain[] = readJsonFile('./tests/assets/trains/trains.json');
 
 const frTranslations: TimetableFilterTranslations = readJsonFile<{
   main: TimetableFilterTranslations;

--- a/front/tests/02-operational-studies/timetable/007-scenario-page-synchronization.spec.ts
+++ b/front/tests/02-operational-studies/timetable/007-scenario-page-synchronization.spec.ts
@@ -1,4 +1,4 @@
-import type { Scenario, Project, Study, Infra, TrainSchedule } from 'common/api/osrdEditoastApi';
+import type { Scenario, Project, Study, Infra, PacedTrain } from 'common/api/osrdEditoastApi';
 
 import {
   timetableItemProjectName,
@@ -33,7 +33,7 @@ const frTranslations = {
   ...frCommonTranslations,
 };
 
-const trains: TrainSchedule[] = readJsonFile('./tests/assets/trains/trains.json');
+const trains: PacedTrain[] = readJsonFile('./tests/assets/trains/trains.json');
 
 test.skip(
   ({ browserName }) => browserName !== 'chromium',

--- a/railway_manager_interface/osrd_railway_manager_interface/models.py
+++ b/railway_manager_interface/osrd_railway_manager_interface/models.py
@@ -131,6 +131,24 @@ class Paced(BaseModel):
     """
 
 
+class PacedTrain(BaseModel):
+    category: TrainCategoryMain | TrainCategorySub | None = None
+    comfort: Comfort | None = None
+    constraint_distribution: Distribution
+    initial_speed: float | None = None
+    labels: list[str] | None = None
+    margins: Margins | None = None
+    options: TrainScheduleOptions | None = None
+    path: list[PathItem]
+    power_restrictions: list[PowerRestriction] | None = None
+    rolling_stock_name: str
+    schedule: list[ScheduleItem] | None = None
+    speed_limit_tag: SpeedLimitTag | None = None
+    start_time: AwareDatetime
+    train_name: str
+    paced: Paced | None = None
+
+
 class PacedTrainException(BaseModel):
     """
     Represents an exception for a paced train occurrence.
@@ -396,23 +414,6 @@ class TrainNameChangeGroup(BaseModel):
     value: str
 
 
-class TrainSchedule(BaseModel):
-    category: TrainCategoryMain | TrainCategorySub | None = None
-    comfort: Comfort | None = None
-    constraint_distribution: Distribution
-    initial_speed: float | None = None
-    labels: list[str] | None = None
-    margins: Margins | None = None
-    options: TrainScheduleOptions | None = None
-    path: list[PathItem]
-    power_restrictions: list[PowerRestriction] | None = None
-    rolling_stock_name: str
-    schedule: list[ScheduleItem] | None = None
-    speed_limit_tag: SpeedLimitTag | None = None
-    start_time: AwareDatetime
-    train_name: str
-
-
 class TrainScheduleOptions(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -435,7 +436,3 @@ class TransformTimetableResponse(BaseModel):
 
 class Value(RootModel[str]):
     root: Annotated[str, Field(min_length=1)]
-
-
-class PacedTrain(TrainSchedule):
-    paced: Paced | None = None

--- a/railway_manager_interface/pyproject.toml
+++ b/railway_manager_interface/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "osrd-railway-manager-interface"
-version = "0.2.2"
+version = "0.2.3"
 description = "Railway manager interface"
 authors = [{ name = "OSRD Contributors", email = "contact@osrd.fr" }]
 requires-python = ">=3.11"

--- a/railway_manager_interface/uv.lock
+++ b/railway_manager_interface/uv.lock
@@ -249,7 +249,7 @@ wheels = [
 
 [[package]]
 name = "osrd-railway-manager-interface"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "datamodel-code-generator" },


### PR DESCRIPTION
After a discussion with @flomonster @leovalais @Khoyo, we've decided to rename TrainSchedule struct into TrainOccurrence. 