### PR TITLE
ci: build and push osrd-front again

### DIFF
--- a/.github/scripts/bake-metadata.py
+++ b/.github/scripts/bake-metadata.py
@@ -38,6 +38,7 @@ TARGETS = [
     Target(name="editoast", image="editoast", release=True),
     Target(name="editoast-test", image="editoast", variant="test"),
 
+    Target(name="front-devel", image="front", variant="devel"),
     Target(name="front-tests", image="front", variant="tests"),
 
     Target(name="gateway-standalone", image="gateway", variant="standalone"),

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
           - [core-build, core]
           - [editoast, editoast-test]
           - [gateway-test, gateway-standalone, gateway-front]
-          - [front-tests]
+          - [front-devel, front-tests]
           - [osrdyne, osrdyne-test]
     steps:
       - name: Checkout

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -6,6 +6,7 @@ group "default" {
     "core-build",
     "editoast",
     "editoast-test",
+    "front-devel",
     "front-tests",
     "gateway-standalone",
     "gateway-test",
@@ -132,6 +133,13 @@ target "gateway-front" {
 #########
 # Front #
 #########
+
+target "base-front-devel" {}
+target "front-devel" {
+  inherits = ["base", "base-front-devel"]
+  context = "front"
+  dockerfile = "docker/Dockerfile.devel"
+}
 
 target "base-front-tests" {}
 target "front-tests" {

--- a/docker/docker-compose.front.yml
+++ b/docker/docker-compose.front.yml
@@ -8,7 +8,7 @@ services:
         SKIP_FRONT: "1"
 
   front:
-    image: ghcr.io/openrailassociation/osrd-${RELEASE_CHANNEL-edge}/osrd-front:${TAG-dev}-dev
+    image: ghcr.io/openrailassociation/osrd-${RELEASE_CHANNEL-edge}/osrd-front:${TAG-dev}-devel
     container_name: osrd-front
     build:
       context: front

--- a/docker/docker-compose.host-front.yml
+++ b/docker/docker-compose.host-front.yml
@@ -8,7 +8,7 @@ services:
         SKIP_FRONT: "1"
 
   front:
-    image: ghcr.io/openrailassociation/osrd-${RELEASE_CHANNEL-edge}/osrd-front:${TAG-dev}-dev
+    image: ghcr.io/openrailassociation/osrd-${RELEASE_CHANNEL-edge}/osrd-front:${TAG-dev}-devel
     container_name: osrd-front
     build:
       context: front

--- a/docker/docker-compose.host-front.yml
+++ b/docker/docker-compose.host-front.yml
@@ -27,6 +27,10 @@ services:
     ports: [ "3000:3000" ]
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:3000" ]
-      start_period: 4s
+      start_period: 5m
       interval: 5s
       retries: 6
+
+  wait-healthy:
+    depends_on:
+      front: { condition: service_healthy }


### PR DESCRIPTION
See individual commits

Closes https://github.com/OpenRailAssociation/osrd/issues/15223

This builds and push the front development image to ghcr and makes `./osrd-compose dev-front pull` work. For some reason #10502 removed it from the CI manifest?

This also fixes image sources in `docker/docker-compose.{host-,}front.yml` files.

And this also applies the changes from #13651 to the `host-front.yml` file