### PR TITLE
ci: unpin buildx version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,8 +50,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          version: v0.12.0
-          driver-opts: image=moby/buildkit:v0.12.3
           buildkitd-flags: --debug
 
       - name: Login to ghcr.io

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,8 +41,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          version: v0.12.0
-          driver-opts: image=moby/buildkit:v0.12.3
           buildkitd-flags: --debug
 
       - name: Login to ghcr.io


### PR DESCRIPTION
v0.12 version seems no longer compatible with github. To avoid the need for future upgrades, we will try unpinning and using the default version.