### PR TITLE
front: fix nodes import in MacroEditor

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/utils.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/utils.ts
@@ -113,7 +113,7 @@ export const storeRoundTrip = async (
 
 /**
  * Check if every new nodes (from import) are already in the DB (by path_item_key).
- * If not we persist them.
+ * If not we persist them and update the state with their dbIds.
  */
 export const storeTrainPathNodes = async (state: MacroEditorState, dispatch: AppDispatch) => {
   const allNodes = state.nodes.filter((n) => n && !n.dbId);
@@ -122,11 +122,17 @@ export const storeTrainPathNodes = async (state: MacroEditorState, dispatch: App
 
   const payload = allNodes.map((n) => omit(n, ['ngeId', 'geocoord']));
 
-  await dispatch(
+  const result = await dispatch(
     osrdEditoastApi.endpoints.postMacroNodes.initiate({
       macroNodeBatchForm: { macro_nodes: payload, scenario_id: state.scenarioId },
     })
   ).unwrap();
+
+  result.macro_nodes.forEach((createdNode) => {
+    state.updateNodeDataByKey(createdNode.path_item_key, {
+      dbId: createdNode.id,
+    });
+  });
 };
 
 /**

--- a/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
@@ -121,11 +121,6 @@ const ScenarioContent = ({ activeBoards }: ScenarioContentProps) => {
     activeBoards.has(board)
   );
 
-  // To update dynamic translations in NGE when language changes
-  useEffect(() => {
-    refreshNge();
-  }, [i18n.language]);
-
   const prevMacroActive = usePrevious(activeBoards.has('macro'));
 
   useEffect(() => {
@@ -133,7 +128,7 @@ const ScenarioContent = ({ activeBoards }: ScenarioContentProps) => {
       if (!prevMacroActive) setNGEIsLoading(true);
       refreshNge();
     }
-  }, [activeBoards.has('macro')]);
+  }, [activeBoards.has('macro'), i18n.language, refreshNge]);
 
   const handleNGEOperation = (event: NGEEvent, netzgrafikDto: NetzgrafikDto) => {
     // Wait for the previous handler to complete before starting the next one

--- a/front/tests/02-operational-studies/nge/001-osrd-nge.spec.ts
+++ b/front/tests/02-operational-studies/nge/001-osrd-nge.spec.ts
@@ -134,11 +134,11 @@ test.describe('@op @nge', () => {
       await ngePage.deleteNodeByIndexViaDialog(0, { nodes: 2, lines: 1 });
     });
 
-    await test.step('Delete next node via dialog (expect 1 node, 0 line)', async () => {
+    await test.step('Delete next node via dialog (expect 1 node, 0 lines)', async () => {
       await ngePage.deleteNodeByIndexViaDialog(0, { nodes: 1, lines: 0 });
     });
 
-    await test.step('Delete last node using keyboard (expect 0 nodes, 0 line)', async () => {
+    await test.step('Delete last node using keyboard (expect 0 nodes, 0 lines)', async () => {
       await ngePage.deleteFocusedNodeWithKeyboard({ nodes: 0, lines: 0 });
     });
 
@@ -151,9 +151,9 @@ test.describe('@op @nge', () => {
       await scenarioTimetableSection.verifyTimetableIsEmpty(frTranslations.timetable.noItem);
     });
 
-    await test.step('Re-toggle macro layout and re-assert graph is empty (no lines, nodes are persisted)', async () => {
+    await test.step('Re-toggle macro layout and re-assert graph is empty (expect 0 nodes, 0 lines)', async () => {
       await ngePage.enableMacroViewWithDefaultTrainList();
-      await ngePage.verifyNodeAndLinesCount({ nodes: 3, lines: 0 });
+      await ngePage.verifyNodeAndLinesCount({ nodes: 0, lines: 0 });
     });
   });
 });


### PR DESCRIPTION
Ensures newly imported nodes are handled correctly:

- Updated `storeTrainPathNodes` to persist new nodes and immediately update their state with the corresponding database IDs (fixes 500 errors when moving newly imported macro nodes).
- Fixed e2e test `Delete a train from train list`
- Merged the language change and macro board activation `useEffects` into a single one to prevent duplicate calls to `refreshNge` (fixes 500 errors when refreshing after an import).