### PR TITLE
front: fix train schedule set rtk-query cache invalidation

### DIFF
--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -393,11 +393,8 @@ const osrdEditoastApi = generatedEditoastApi
       getTrainScheduleSetsById: {
         providesTags: (_result, _error, args) => [{ type: 'train_schedule_set', id: args.id }],
       },
-      // Don't invalidate the train schedule sets (tss) when creating one as each post is followed
-      // by a postTimetableByIdTrainScheduleSets call, which links a tss to a timetable, who
-      // is responsible to invalidate the tss list
       postTrainScheduleSets: {
-        invalidatesTags: () => [],
+        invalidatesTags: () => [{ type: 'train_schedule_set', id: 'LIST' }],
       },
       putTrainScheduleSetsById: {
         invalidatesTags: (_result, _error, args) => [{ type: 'train_schedule_set', id: args.id }],

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -400,7 +400,7 @@ const osrdEditoastApi = generatedEditoastApi
         invalidatesTags: (_result, _error, args) => [{ type: 'train_schedule_set', id: args.id }],
       },
       deleteTrainScheduleSetsById: {
-        invalidatesTags: () => [],
+        invalidatesTags: () => [{ type: 'train_schedule_set', id: 'LIST' }],
       },
     },
   });


### PR DESCRIPTION
Creating or deleting a train schedule set needs to erase the rtk-query cache entry. Not doing that leaves stale cache entries behind.

See discussion in https://github.com/OpenRailAssociation/osrd/pull/15015#discussion_r2758200825