### PR TITLE
docker: change rustfs port to 9900

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,20 +89,22 @@ services:
     image: rustfs/rustfs
     container_name: s3
     ports:
-      - 9000:9000
-      - 9001:9001
+      - 9900:9900
+      - 9901:9901
     volumes:
       - s3_data:/data
     environment:
       RUSTFS_ACCESS_KEY: access_key
       RUSTFS_SECRET_KEY: secret_key
+      RUSTFS_ADDRESS: ":9900"
+      RUSTFS_CONSOLE_ADDRESS: ":9901"
     healthcheck:
       test:
         [
           "CMD",
           "curl", "--fail", "--fail-early",
-          "http://localhost:9000/health",
-          "http://localhost:9001/rustfs/console/health",
+          "http://localhost:9900/health",
+          "http://localhost:9901/rustfs/console/health",
         ]
       interval: 30s
       timeout: 10s
@@ -119,7 +121,7 @@ services:
     environment:
       AWS_ACCESS_KEY_ID: access_key
       AWS_SECRET_ACCESS_KEY: secret_key
-      AWS_ENDPOINT_URL_S3: http://s3:9000
+      AWS_ENDPOINT_URL_S3: http://s3:9900
     entrypoint: ["/create_bucket.sh", "osrd"]
 
   core:
@@ -151,7 +153,7 @@ services:
       VALKEY_URL: "redis://valkey"
       AWS_ACCESS_KEY_ID: access_key
       AWS_SECRET_ACCESS_KEY: secret_key
-      AWS_ENDPOINT_URL_S3: http://s3:9000
+      AWS_ENDPOINT_URL_S3: http://s3:9900
       BUCKET_NAME: osrd
     restart: "no"
     command: "true"

--- a/docker/docker-compose.host.yml
+++ b/docker/docker-compose.host.yml
@@ -29,7 +29,7 @@ services:
     environment:
       AWS_ACCESS_KEY_ID: access_key
       AWS_SECRET_ACCESS_KEY: secret_key
-      AWS_ENDPOINT_URL_S3: http://127.0.0.1:9000
+      AWS_ENDPOINT_URL_S3: http://127.0.0.1:9900
 
   editoast:
     ports: !reset []
@@ -71,7 +71,7 @@ services:
       OSRDYNE__WORKER_DRIVER__HOST_NETWORKING: "true"
       OSRDYNE__WORKER_DRIVER__NETWORK: ""
       OSRDYNE__WORKER_DRIVER__DEFAULT_ENV: >
-        [ "CORE_EDITOAST_URL=http://127.0.0.1:8090", "JAVA_TOOL_OPTIONS=-javaagent:/app/opentelemetry-javaagent.jar", "CORE_MONITOR_TYPE=opentelemetry", "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=grpc", "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://127.0.0.1:4317", "OTEL_METRICS_EXPORTER=none", "OTEL_LOGS_EXPORTER=none", "AWS_ACCESS_KEY_ID=access_key", "AWS_SECRET_ACCESS_KEY=secret_key", "AWS_ENDPOINT_URL_S3=http://127.0.0.1:9000" ]
+        [ "CORE_EDITOAST_URL=http://127.0.0.1:8090", "JAVA_TOOL_OPTIONS=-javaagent:/app/opentelemetry-javaagent.jar", "CORE_MONITOR_TYPE=opentelemetry", "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=grpc", "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://127.0.0.1:4317", "OTEL_METRICS_EXPORTER=none", "OTEL_LOGS_EXPORTER=none", "AWS_ACCESS_KEY_ID=access_key", "AWS_SECRET_ACCESS_KEY=secret_key", "AWS_ENDPOINT_URL_S3=http://127.0.0.1:9900" ]
       OSRDYNE__AMQP_URI: "amqp://osrd:password@127.0.0.1:5672/%2f"
       OSRDYNE__MAX_MSG_SIZE: 671088640 # 1024 * 1024 * 128 * 5
       OSRDYNE__MANAGEMENT_URI: "http://osrd:password@127.0.0.1:15672/"

--- a/docker/osrdyne.yml
+++ b/docker/osrdyne.yml
@@ -7,7 +7,7 @@ worker_driver:
   default_env:
     - "AWS_ACCESS_KEY_ID=access_key"
     - "AWS_SECRET_ACCESS_KEY=secret_key"
-    - "AWS_ENDPOINT_URL_S3=http://s3:9000"
+    - "AWS_ENDPOINT_URL_S3=http://s3:9900"
     - "BUCKET_NAME=osrd"
     - "CORE_EDITOAST_URL=http://editoast"
     - "JAVA_TOOL_OPTIONS=-javaagent:/app/opentelemetry-javaagent.jar"


### PR DESCRIPTION
The default ports conflicts with Microsoft's Jupyter VSCode extension used by some of our devs.

Suggested-by: @Synar 