### PR TITLE
front: display operational point names during itinerary creation

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/ManageTimetableItemMap/AddPathStepPopup.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/ManageTimetableItemMap/AddPathStepPopup.tsx
@@ -143,6 +143,7 @@ const AddPathStepPopup = ({
 
       setClickedOp({
         id: uuidV4(),
+        name: operationalPoint.extensions?.identifier?.name,
         location: {
           operational_point: {
             secondary_code: operationalPoint.extensions!.sncf!.ch,


### PR DESCRIPTION
In the `ManageTimetableItemMap`, when the user adds an OP to the itinerary, don't wait for pathfinding to display the OP name if it has one.

Closes https://github.com/OpenRailAssociation/osrd/issues/11344