### PR TITLE
front: set waypointRef and isActive to TOD manchette items

### DIFF
--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
@@ -246,6 +246,7 @@ const SpaceTimeChartWrapper = ({
         selectedTrainId,
         onCloseOccupancyLayer,
         handleWaypointClick,
+        activeWaypointId,
         hoveredTrainIdForChart,
         hoveredTrainId
       ),

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/buildSplitPoints.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/buildSplitPoints.tsx
@@ -45,6 +45,7 @@ export function buildSplitPoints(
   selectedTrainId?: TrainId,
   onCloseOccupancyLayer?: (waypointId: string) => void,
   handleWaypointClick?: (waypointId: string) => void,
+  activeWaypointId?: string,
   hoveredTrainIdForChart?: TrainId,
   hoveredTrainId?: TrainId
 ): SplitPoint[] {
@@ -138,8 +139,8 @@ export function buildSplitPoints(
               position: operationalPointPosition,
               onClick: handleWaypointClick,
             }}
-            waypointRef={activeWaypointRef}
-            isActive={false}
+            waypointRef={waypointId == activeWaypointId ? activeWaypointRef : undefined}
+            isActive={waypointId == activeWaypointId}
             isMenuActive={false}
           />
         </TrackOccupancyManchette>


### PR DESCRIPTION
Previously `isActive` would always be set to `false`, meaning the waypoint wouldn't ever sow as active even when the popup menu was shown. Meanwhile `waypointRef` was always set to `activeWaypointRef`, meaning the popup menu would have a non-deterministic position when a TOD is open.

This commit duplicates the behavior found in osrd-ui:

https://github.com/OpenRailAssociation/osrd/blob/d446ec1f1bc300bc476cc88bd6f1ab8bab4af272/front/ui/ui-charts/src/manchette/components/Manchette.tsx#L56-L57

Closes https://github.com/OpenRailAssociation/osrd/issues/12521

# How to test

1. in a scenario with at least one train schedule, open a TOD
2. make sure clicking the waypoint where the TOD is opened makes the waypoint name background darker (same as the hover style) and the popup menu is at the right place under the waypoint name
3. make sure clicking on all other waypoints yields the same results
4. open another TOD without closing the previous one and repeat steps 2 and 3