### PR TITLE
front: correct translation json typos

### DIFF
--- a/front/public/locales/de/translation.json
+++ b/front/public/locales/de/translation.json
@@ -128,11 +128,11 @@
     "about": "Über OSRD",
     "disconnect": "Abmelden",
     "help": "Hilfe",
-    "informations": {
+    "information": {
       "application": "Anwendung",
       "collaborations": "Kooperationen",
       "dataSources": "Datenquellen",
-      "librairies": "Versionsinformationen",
+      "libraries": "Versionsinformationen",
       "version": "Version"
     },
     "languages": "Spraches",

--- a/front/public/locales/en/translation.json
+++ b/front/public/locales/en/translation.json
@@ -83,7 +83,7 @@
           "name": "Overlapping of speed limits"
         },
         "overlapping_switches": {
-          "description": "Switches « {{obj_id}} » and « {{reference.obj_id}} » have the same extremeties",
+          "description": "Switches « {{obj_id}} » and « {{reference.obj_id}} » have the same extremities",
           "name": "Overlapping of switches"
         },
         "unknown_port_name": {
@@ -91,7 +91,7 @@
           "name": "Unknown branch name"
         },
         "unused_port": {
-          "description": "Branch « {{port_name}} » of switch type « {{obj_id}} » is nerver used",
+          "description": "Branch « {{port_name}} » of switch type « {{obj_id}} » is never used",
           "name": "Unused branch"
         }
       },
@@ -270,7 +270,7 @@
         "label": "Route tool",
         "locked-release-detectors": "This property can not be disabled after saving",
         "no-route-found": "No compatible route found",
-        "no-waypoint-picked-yet": "Click the button to select a detector or a bufferstop on the map",
+        "no-waypoint-picked-yet": "Click the button to select a detector or a buffer stop on the map",
         "preview-candidate": "Select",
         "search-routes": "Search for compatible routes",
         "search-routes-alt": "Search for alternative routes",
@@ -349,7 +349,7 @@
         "move-range-extremity": "Click to move the end:",
         "new-tag": "Composition code",
         "ralen-30-60": "Speed restriction",
-        "remove-track-range": "Click to detatch from:",
+        "remove-track-range": "Click to detach from:",
         "search-routes": "Search for compatible routes",
         "select-route": "Select a route",
         "select-switches-to-get-route": "Select switches and their position to search for routes",
@@ -512,7 +512,7 @@
         "title": "Modifications saved"
       }
     },
-    "toggleInfraErrors": "Toggler infra errors layer",
+    "toggleInfraErrors": "Toggle infra errors layer",
     "units": {
       "day": "d",
       "hour": "h",
@@ -575,7 +575,7 @@
   "jsonUpload": {
     "badJSON": "Invalid content. Only RailJSON files are supported (usually .json or .railjson extensions)",
     "emptyFile": "The file is empty",
-    "uploadError": "Error occurred while upload the file"
+    "uploadError": "Error occurred while uploading the file"
   },
   "map": {
     "layers-modal": {
@@ -665,11 +665,11 @@
     "disconnect": "Sign out",
     "help": "Help",
     "impersonation": "Impersonate user",
-    "informations": {
+    "information": {
       "application": "Application",
       "collaborations": "Collaborations",
       "dataSources": "Data sources",
-      "librairies": "Libraries & licenses",
+      "libraries": "Libraries & licenses",
       "version": "Version"
     },
     "languages": "Languages",
@@ -699,7 +699,7 @@
       "choose": "Choose a category",
       "noCategory": "No category"
     },
-    "chooseRollingStock": "Select a rolling stock to display informations",
+    "chooseRollingStock": "Select a rolling stock to display information",
     "comfort": "Comfort",
     "comfortAcceleration": "Comfort acceleration",
     "comfortLevels": "Comfort levels",
@@ -731,8 +731,8 @@
       "minMaxRangeError": "The value must be between {{min}} and {{max}}",
       "minRangeError": "The value must be greater than {{min}}",
       "missingConversion": "This conversion doesn't exist in the schema. Value hasn't been changed.",
-      "missingInformation": "Missing informations",
-      "ressourcesNotFound": "Resources not found",
+      "missingInformation": "Missing information",
+      "resourcesNotFound": "Resources not found",
       "rollingStockUsed": "This rolling stock is used in the following scenarios:",
       "unableToRetrieveRollingStock": "Cannot fetch rolling stock",
       "unableToRetrieveRollingStockMessage": "An error has occurred"

--- a/front/public/locales/fr/translation.json
+++ b/front/public/locales/fr/translation.json
@@ -665,11 +665,11 @@
     "disconnect": "Déconnexion",
     "help": "Aide",
     "impersonation": "Se faire passer pour un utilisateur",
-    "informations": {
+    "information": {
       "application": "Application",
       "collaborations": "Collaborations",
       "dataSources": "Sources de données",
-      "librairies": "Librairies & licences",
+      "libraries": "Librairies & licences",
       "version": "Version"
     },
     "languages": "Langues",
@@ -732,7 +732,7 @@
       "minRangeError": "La valeur doit être supérieure ou égale à {{min}}",
       "missingConversion": "Cette conversion n'existe pas dans le schéma. La valeur n'a pas été modifiée.",
       "missingInformation": "Informations manquantes",
-      "ressourcesNotFound": "Ressources introuvables",
+      "resourcesNotFound": "Ressources introuvables",
       "rollingStockUsed": "Le Matériel roulant est utilisé dans les scénarios suivants :",
       "unableToRetrieveRollingStock": "Récupération matériel impossible",
       "unableToRetrieveRollingStockMessage": "Une erreur est survenue"

--- a/front/src/common/NavBar/LicenseAttributions.tsx
+++ b/front/src/common/NavBar/LicenseAttributions.tsx
@@ -84,19 +84,19 @@ const LicenseAttributions = () => {
 
   return (
     <div className="col-md-6 h-100 d-flex flex-column">
-      <h2 className="text-center mb-4">{t('nav-bar.informations.collaborations')}</h2>
+      <h2 className="text-center mb-4">{t('nav-bar.information.collaborations')}</h2>
       <div className="license-attributions">
         {COLLABORATIONS.map((dataSource) => (
           <LicenseCard attribution={dataSource} key={dataSource.name} />
         ))}
       </div>
-      <h2 className="text-center my-4">{t('nav-bar.informations.dataSources')}</h2>
+      <h2 className="text-center my-4">{t('nav-bar.information.dataSources')}</h2>
       <div className="license-attributions">
         {DATA_SOURCES.map((dataSource) => (
           <LicenseCard attribution={dataSource} key={dataSource.name} />
         ))}
       </div>
-      <h2 className="text-center my-4">{t('nav-bar.informations.librairies')}</h2>
+      <h2 className="text-center my-4">{t('nav-bar.information.libraries')}</h2>
       <div className="license-attributions licenses">
         {licences.map((attribution) => (
           <LicenseCard attribution={attribution} key={attribution.name + attribution.version} />

--- a/front/src/common/NavBar/ReleaseInformation.tsx
+++ b/front/src/common/NavBar/ReleaseInformation.tsx
@@ -59,10 +59,10 @@ const ReleaseInformation = () => {
                 <thead>
                   <tr>
                     <th scope="col">
-                      <div className="cell-inner">{t('nav-bar.informations.application')}</div>
+                      <div className="cell-inner">{t('nav-bar.information.application')}</div>
                     </th>
                     <th scope="col" id="cellfirst-t5">
-                      <div className="cell-inner">{t('nav-bar.informations.version')}</div>
+                      <div className="cell-inner">{t('nav-bar.information.version')}</div>
                     </th>
                   </tr>
                 </thead>


### PR DESCRIPTION
There are other errors linked to keys not being used at all in the project (such as `resourcesNotFound`). We'll have to check and delete them all eventually.