### PR TITLE
raimi, front: add created_request_url to sendLastMinuteRequestResponse

### DIFF
--- a/front/src/applications/stdcm/components/StdcmResults/SendToRailwayManagerModal.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/SendToRailwayManagerModal.tsx
@@ -16,6 +16,7 @@ import {
   type LoadingGaugeType,
   type PostSendLastMinuteRequestApiArg,
   type SimulationReport,
+  type SendLastMinuteRequestResponse,
 } from 'common/api/osrdRailwayManagerApi';
 import {
   createSimilarTrainPayload,
@@ -38,7 +39,7 @@ import { castErrorToFailure } from 'utils/error';
 import { kmhToMs, tToKg } from 'utils/physics';
 
 type SendToRailwayManagerModalProps = {
-  onSuccess: (isSuccessful: boolean, request_identifier?: string) => void;
+  onSuccess: (isSuccessful: boolean, data: SendLastMinuteRequestResponse) => void;
   onClose: () => void;
   consist: StdcmSimulationInputs['consist'];
   stdcmData: StdcmSuccessResponse;
@@ -313,7 +314,7 @@ const SendToRailwayManagerModal = ({
 
   useEffect(() => {
     if (isSuccess) {
-      onSuccess(isSuccess, data.request_identifier);
+      onSuccess(isSuccess, data);
     }
   }, [isSuccess, data]);
 
@@ -554,9 +555,20 @@ const SendToRailwayManagerModal = ({
         <div className="actions">
           {isSuccess && (
             <div>
-              <span className="success-message">
-                {t('modal.successMessage', { demandNumber: data.request_identifier })}
-              </span>
+              {data.created_request_url ? (
+                <a
+                  href={data.created_request_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="success-message"
+                >
+                  {t('modal.successMessage', { demandNumber: data.request_identifier })}
+                </a>
+              ) : (
+                <span className="success-message">
+                  {t('modal.successMessage', { demandNumber: data.request_identifier })}
+                </span>
+              )}
               <span className="success-icon">
                 <CheckCircle variant="fill" />
               </span>

--- a/front/src/applications/stdcm/components/StdcmResults/StdcmResults.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/StdcmResults.tsx
@@ -12,6 +12,7 @@ import { extractMarkersInfo, mergeSimilarTrainSegments } from 'applications/stdc
 import { addSecondaryCodesToSimilarTrains } from 'applications/stdcm/utils/addSecondaryCodesToSimilarTrains';
 import { hasResults } from 'applications/stdcm/utils/simulationOutputUtils';
 import { osrdEditoastApi, type PostSimilarTrainsApiResponse } from 'common/api/osrdEditoastApi';
+import { type SendLastMinuteRequestResponse } from 'common/api/osrdRailwayManagerApi';
 import { useModal } from 'common/BootstrapSNCF/ModalSNCF';
 import DefaultBaseMap from 'common/Map/DefaultBaseMap';
 import {
@@ -64,6 +65,7 @@ const StdcmResults = ({
   const railwayManagerUrl = useSelector(getRailwayManagerInterfaceUrl);
   const [isRailwayRequestSuccessful, setIsRailwayRequestSuccessful] = useState(false);
   const [railwayDemandId, setRailwayDemandId] = useState<string>();
+  const [railwayRequestUrl, setRailwayRequestUrl] = useState<string | null>();
 
   const [pdfBlob, setPdfBlob] = useState<Blob | null>(null);
 
@@ -120,10 +122,14 @@ const StdcmResults = ({
 
   const [postSimilarTrains] = osrdEditoastApi.endpoints.postSimilarTrains.useMutation();
 
-  const handleSubmitSuccess = (isSuccessful: boolean, request_identifier?: string) => {
+  const handleSubmitSuccess = (
+    isSuccessful: boolean,
+    railwayResponse: SendLastMinuteRequestResponse
+  ) => {
     if (isSuccessful) {
       setIsRailwayRequestSuccessful(isSuccessful);
-      setRailwayDemandId(request_identifier);
+      setRailwayDemandId(railwayResponse.request_identifier);
+      setRailwayRequestUrl(railwayResponse.created_request_url);
     }
   };
 
@@ -351,9 +357,28 @@ const StdcmResults = ({
                             }
                           />
                         ) : (
-                          <div className="success-message">
-                            {t('modal.successMessage', { demandNumber: railwayDemandId })}
-                            <CheckCircle className="check-circle" variant="fill" />
+                          <div>
+                            {railwayRequestUrl ? (
+                              <a
+                                href={railwayRequestUrl}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="success-message"
+                              >
+                                {t('modal.successMessage', {
+                                  demandNumber: railwayDemandId,
+                                })}
+                              </a>
+                            ) : (
+                              <span className="success-message">
+                                {t('modal.successMessage', {
+                                  demandNumber: railwayDemandId,
+                                })}
+                              </span>
+                            )}
+                            <span className="success-icon">
+                              <CheckCircle variant="fill" />
+                            </span>
                           </div>
                         ))}
                     </div>

--- a/front/src/common/api/osrdRailwayManagerApi.ts
+++ b/front/src/common/api/osrdRailwayManagerApi.ts
@@ -282,6 +282,7 @@ export type SendLastMinuteRequestResponse = {
   status: string;
   message: string;
   request_identifier: string;
+  created_request_url: string | null;
 };
 export type LoadingGaugeType = 'GA' | 'GB';
 export type Location = {

--- a/railway_manager_interface/openapi.yaml
+++ b/railway_manager_interface/openapi.yaml
@@ -295,11 +295,17 @@ components:
         request_identifier:
           type: string
           title: Request Identifier
+        created_request_url:
+          type:
+          - string
+          - 'null'
+          title: Created Request URL
       type: object
       required:
       - status
       - message
       - request_identifier
+      - created_request_url
       title: SendLastMinuteRequestResponse
       description: Response model to validate and return when a last-minute request
         has been successfully sent.

--- a/railway_manager_interface/osrd_railway_manager_interface/models.py
+++ b/railway_manager_interface/osrd_railway_manager_interface/models.py
@@ -252,6 +252,9 @@ class SendLastMinuteRequestResponse(BaseModel):
     status: Annotated[str, Field(title="Status")]
     message: Annotated[str, Field(title="Message")]
     request_identifier: Annotated[str, Field(title="Request Identifier")]
+    created_request_url: Annotated[str | None, Field(title="Created Request URL")] = (
+        None
+    )
 
 
 class SimilarTrain(BaseModel):

--- a/railway_manager_interface/pyproject.toml
+++ b/railway_manager_interface/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "osrd-railway-manager-interface"
-version = "0.2.3"
+version = "0.2.4"
 description = "Railway manager interface"
 authors = [{ name = "OSRD Contributors", email = "contact@osrd.fr" }]
 requires-python = ">=3.11"

--- a/railway_manager_interface/uv.lock
+++ b/railway_manager_interface/uv.lock
@@ -249,7 +249,7 @@ wheels = [
 
 [[package]]
 name = "osrd-railway-manager-interface"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "datamodel-code-generator" },


### PR DESCRIPTION
Close #15175 
Close #15250 

Depends on [private-gitlab/osrd-data#585](https://gitlab-repo-res.apps.eul.sncf.fr/dsir/groupedxs-dsir/04735/osrd-data/-/merge_requests/585), which also contains private screenshots showing the result

https://github.com/issues/assigned?issue=osrd-project%7Cosrd-confidential%7C1381 still lacks a mock up, so I went for the simplest design for now (the whole translation string constitutes the link, and no specific css is added). This can be changed as soon as a mockup is ready, either in this pr or a follow up.