### PR TITLE
front: fix stopsCount for train schedules

### DIFF
--- a/front/README.md
+++ b/front/README.md
@@ -191,7 +191,7 @@ All common code (and shared components) supposed to be in `common/`.
 
 Any translation key used in the code must at least be present in `/public/locales/en` and
 `/public/locales/fr`, other languages are work in progress. You can use
-`npm run-script i18n-checker.ts` to see a complete list of unused and missing French and English
+`npm run i18n-checker` to see a complete list of unused and missing French and English
 keys. You can use `./scripts/i18n-order-checker.sh --fix` to automatically sort translation keys.
 
 # Other

--- a/front/public/locales/de/operational-studies.json
+++ b/front/public/locales/de/operational-studies.json
@@ -171,6 +171,7 @@
       "showValidTrains": "Gültig",
       "stopsCount_one": "1 Stop",
       "stopsCount_other": "{{ count }} Stops",
+      "stopsCount_zero": "0 Stops",
       "toggleFilters": "Filteranzeige umschalten",
       "trainAdded": "Zug hinzugefügt",
       "trainDeleted": "Zug „{{ name }}“ ist gelöscht worden.",

--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -269,6 +269,7 @@
       "speedLimitTags": "Composition codes",
       "stopsCount_one": "1 stop",
       "stopsCount_other": "{{ count }} stops",
+      "stopsCount_zero": "0 stops",
       "toggleFilters": "Toggle filters display",
       "trainAdded": "Train added",
       "trainCategories": "Train categories",

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -269,6 +269,7 @@
       "speedLimitTags": "Codes de composition",
       "stopsCount_one": "1 arrêt",
       "stopsCount_other": "{{count}} arrêts",
+      "stopsCount_zero": "0 arrêt",
       "toggleFilters": "Afficher ou masquer les filtres",
       "trainAdded": "Train ajouté",
       "trainCategories": "Catégorie de train",

--- a/front/src/applications/operationalStudies/utils.ts
+++ b/front/src/applications/operationalStudies/utils.ts
@@ -12,6 +12,8 @@ import type {
   SimulationResponseSuccess,
   SimulationSummaryResult,
   PacedTrain,
+  ScheduleItem,
+  PathItem,
 } from 'common/api/osrdEditoastApi';
 import getPathVoltages from 'modules/pathfinding/helpers/getPathVoltages';
 import { isPacedTrain } from 'modules/timetableItem/helpers/pacedTrain';
@@ -38,6 +40,32 @@ import type {
   PositionData,
   TimetableItemRoundTripGroups,
 } from './types';
+
+/**
+ * The number of stops in the schedule, not counting the one at the destination.
+ */
+export const intermediateStopsCount = ({
+  schedule,
+  path,
+}: {
+  schedule?: ScheduleItem[];
+  path: PathItem[];
+}) => {
+  if (!schedule) {
+    return 0;
+  }
+  const lastPathItem = path.at(-1);
+  if (!lastPathItem) {
+    return 0;
+  }
+  const lastScheduleItem = schedule.find((step) => step.at === lastPathItem.id);
+  const stopsCount = schedule.filter((step) => step.stop_for).length;
+  if (lastScheduleItem?.stop_for) {
+    return stopsCount - 1;
+  } else {
+    return stopsCount;
+  }
+};
 
 /**
  * Transform data received with boundaries / values format :

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/hooks/useOccurrences.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/hooks/useOccurrences.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 
 import { omit, sortBy } from 'lodash';
 
+import { intermediateStopsCount } from 'applications/operationalStudies/utils';
 import { type LightRollingStockWithLiveries } from 'common/api/osrdEditoastApi';
 import computeOccurrenceName from 'modules/timetableItem/helpers/computeOccurrenceName';
 import {
@@ -57,7 +58,7 @@ const useOccurrences = (
         rollingStock: occurrenceRollingStock,
         startTime,
         stopsCount: correspondingException?.path_and_schedule
-          ? correspondingException.path_and_schedule.schedule.filter((step) => step.stop_for).length
+          ? intermediateStopsCount(correspondingException.path_and_schedule)
           : stopsCount,
         disabled: correspondingException?.disabled,
         // In the model, we can currently have a null category value so we need to handle this case
@@ -91,7 +92,7 @@ const useOccurrences = (
         rollingStock: occurrenceRollingStock,
         startTime,
         stopsCount: exception.path_and_schedule
-          ? exception.path_and_schedule.schedule.filter((step) => step.stop_for).length
+          ? intermediateStopsCount(exception.path_and_schedule)
           : stopsCount,
         // In the model, we can currently have a null category value so we need to handle this case
         category: exception.rolling_stock_category

--- a/front/src/modules/timetableItem/helpers/formatTimetableItemWithDetails.ts
+++ b/front/src/modules/timetableItem/helpers/formatTimetableItemWithDetails.ts
@@ -58,9 +58,7 @@ const formatSummary = (summary?: SimulationSummaryResult): SimulationSummary | u
 const extractBaseTimetableItemProps = (timetableItem: TimetableItem) => ({
   name: timetableItem.train_name,
   startTime: new Date(timetableItem.start_time),
-  stopsCount:
-    (timetableItem.schedule?.filter((step) => step.stop_for && Duration.parse(step.stop_for).ms > 0)
-      .length ?? 0) + 1, // +1 to take the final stop (destination) into account
+  stopsCount: timetableItem.schedule?.filter((step) => step.stop_for).length ?? 0,
   rollingStockName: timetableItem.rolling_stock_name,
   speedLimitTag: timetableItem.speed_limit_tag ?? null,
   labels: timetableItem.labels ?? [],

--- a/front/src/modules/timetableItem/helpers/formatTimetableItemWithDetails.ts
+++ b/front/src/modules/timetableItem/helpers/formatTimetableItemWithDetails.ts
@@ -1,4 +1,8 @@
-import { isTooFast, isScheduledPointsNotHonored } from 'applications/operationalStudies/utils';
+import {
+  isTooFast,
+  isScheduledPointsNotHonored,
+  intermediateStopsCount,
+} from 'applications/operationalStudies/utils';
 import type {
   LightRollingStockWithLiveries,
   SimulationSummaryResult,
@@ -58,7 +62,7 @@ const formatSummary = (summary?: SimulationSummaryResult): SimulationSummary | u
 const extractBaseTimetableItemProps = (timetableItem: TimetableItem) => ({
   name: timetableItem.train_name,
   startTime: new Date(timetableItem.start_time),
-  stopsCount: timetableItem.schedule?.filter((step) => step.stop_for).length ?? 0,
+  stopsCount: intermediateStopsCount(timetableItem),
   rollingStockName: timetableItem.rolling_stock_name,
   speedLimitTag: timetableItem.speed_limit_tag ?? null,
   labels: timetableItem.labels ?? [],

--- a/front/tests/assets/constants/timetable-items-details.ts
+++ b/front/tests/assets/constants/timetable-items-details.ts
@@ -21,16 +21,17 @@ function itemStops(number: string): string {
 }
 
 const itemStopSingular = frScenarioTranslations.timetable.stopsCount_one;
+const itemStopZero = frScenarioTranslations.timetable.stopsCount_zero;
 
 export const PACED_DETAILS: DetailRow[] = [
   {
-    stopsCount: itemStops('2'),
+    stopsCount: itemStopSingular,
     pathLength: '34.0 km',
     energyConsumed: '808 kWh',
     durationTime: '00h19',
   },
   {
-    stopsCount: itemStops('2'),
+    stopsCount: itemStopSingular,
     pathLength: '47.7 km',
     energyConsumed: '558 kWh',
     durationTime: '00h21',
@@ -39,25 +40,25 @@ export const PACED_DETAILS: DetailRow[] = [
 
 export const TRAIN_SCHEDULE_DETAILS: DetailRow[] = [
   {
-    stopsCount: itemStopSingular,
+    stopsCount: itemStopZero,
     pathLength: '6.8 km',
     energyConsumed: '11 kWh',
     durationTime: '00h06',
   },
   {
-    stopsCount: itemStops('2'),
+    stopsCount: itemStopSingular,
     pathLength: '45.9 km',
     energyConsumed: '1390 kWh',
     durationTime: '00h18',
   },
   {
-    stopsCount: itemStopSingular,
+    stopsCount: itemStopZero,
     pathLength: '34.0 km',
     energyConsumed: '1459 kWh',
     durationTime: '00h09',
   },
   {
-    stopsCount: itemStops('3'),
+    stopsCount: itemStops('2'),
     pathLength: '47.5 km',
     energyConsumed: '912 kWh',
     durationTime: '03h11',


### PR DESCRIPTION
The previous computation wasn't working in the following cases:
- the train has no stops (because of the `+1` at the end)
- the train has several 0s stops (because it filters stops that last zero seconds)

This commit copies the `stopsCount` computation for paced trains here:
https://github.com/OpenRailAssociation/osrd/blob/c33666ef215468065858cf70036a01434cd52d9c/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/hooks/useOccurrences.ts#L59-L61

This commit also adds `stopsCount_zero` translation entries, otherwise train schedules with zero stops shows up as having one stop.

Solves a part of this issue: https://github.com/OpenRailAssociation/osrd/issues/12372
The other part is solved by: https://github.com/OpenRailAssociation/osrd/pull/15290

# How to test

Example timetable on small infra: 
[timetable(14).json](https://github.com/user-attachments/files/25362255/timetable.14.json)

Without this change, train schedules that have no stops, train schedules that have several zero-second stops and train schedules that have one zero-second stop at the end all show up as having one stop if you click on the "show more details" button at the top of the TS list.

With this change, the correct stop count should be shown for all train schedules.