### PR TITLE
front: in simulation sheets show last time as passage if no stop

### DIFF
--- a/front/src/modules/SimulationReportSheet/utils/formatSimulationTable.ts
+++ b/front/src/modules/SimulationReportSheet/utils/formatSimulationTable.ts
@@ -121,14 +121,14 @@ export const formatOperationalStudiesDataForSimulationTable = (
     const isLast = index === operationalPointsList.length - 1;
     const previousStep = operationalPointsList[index - 1];
 
-    const isStop = !isFirst && !isLast && !!step.duration;
     const isVia = pathItemPositions.slice(1, -1).some((p) => p / 1000 === step.position);
     const isPathStep = isFirst || isVia || isLast;
 
-    const endTime = isLast || isStop ? timeToLocaleStringRounded(step.time, dateTimeLocale) : '';
+    const endTime =
+      !isFirst && !!step.duration ? timeToLocaleStringRounded(step.time, dateTimeLocale) : '';
 
     let passageStop = '';
-    if (!isFirst && !isLast) {
+    if (!isFirst && (!isLast || !step.duration)) {
       // display the stop duration if is a stop, the passage time if not
       passageStop = step.duration
         ? getStopDurationTime(step.duration)
@@ -136,7 +136,7 @@ export const formatOperationalStudiesDataForSimulationTable = (
     }
 
     const startTime =
-      isFirst || isStop
+      isFirst || (!isLast && !!step.duration)
         ? timeToLocaleStringRounded(
             addDurationToDate(step.time, step.duration ?? Duration.zero),
             dateTimeLocale


### PR DESCRIPTION
Follow up of https://github.com/OpenRailAssociation/osrd/pull/15287
Closes https://github.com/OpenRailAssociation/osrd/issues/12372

if the last path item doesn't have a stop duration, show its time in the "passage" column instead of the "end"/"arrival" column.

- `endTime` (arrival time): set iff it's not the first path item and the path item has a stop duration (and not unconditionally if the path item is the last)
- `passageStop` (passage time or stop duration): we relax the condition to set it also when the last path item has no stop duration
- `startTime` (departure time): we just inline `isStop` here because it's not used elsewhere (the `!isFirst` condition in `isStop` is always true here, because otherwise it is catched by the `isFirst ||`, so we drop it)

For anyone curious, the condition to set `passageStop`

    !isFirst && (!isLast || !step.duration)

is actually not the opposite of to the condition to set `startTime`:

    isFirst || (!isLast && !!step.duration)

because

    . isFirst || (!isLast && !!step.duration)
    = isFirst || !(isLast || !step.duration)
    = !(!isFirst && (isLast || !step.duration))
    ≠ !(!isFirst && (!isLast || !step.duration))

# How to test

Using this timetable on small infra:
https://github.com/user-attachments/files/25362255/timetable.14.json

Click on the simulation sheet button at the bottom of the table. All train schedules should have the same output as in `dev` except the one with no stop at the end. This one should have the last path item time in the "passage" column instead of the "arrival" column.