### PR TITLE
front: railway manager modal - add requested departure date

### DIFF
--- a/front/public/locales/en/stdcm.json
+++ b/front/public/locales/en/stdcm.json
@@ -150,6 +150,7 @@
         "convoy": "CONVOY",
         "createRailManagerRequest": "Create the GESICO request",
         "csCode": "CS code",
+        "date": "Date",
         "departurePoint": "Departure {{departureAt}}",
         "departureTime": "Departure of the retained simulation",
         "departureTiming": "Departure time constraint",

--- a/front/public/locales/fr/stdcm.json
+++ b/front/public/locales/fr/stdcm.json
@@ -150,6 +150,7 @@
         "convoy": "CONVOI",
         "createRailManagerRequest": "Créer la demande GESICO",
         "csCode": "Code CS",
+        "date": "Date",
         "departurePoint": "Départ {{departureAt}}",
         "departureTime": "Départ de la simulation retenue",
         "departureTiming": "CONTRAINTE HORAIRE DE DÉPART",

--- a/front/src/applications/stdcm/components/StdcmResults/SendToRailwayManagerModal.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/SendToRailwayManagerModal.tsx
@@ -338,6 +338,13 @@ const SendToRailwayManagerModal = ({
           <section className="requested-route">
             <h3>{t('modal.requestedRoute')}</h3>
             <ul>
+              <li>
+                {`${t('modal.date')} : ${realDepartureTime.toLocaleDateString(dateTimeLocale, {
+                  day: '2-digit',
+                  month: '2-digit',
+                  year: 'numeric',
+                })}`}
+              </li>
               {linkedTrains.anteriorTrain && (
                 <span className="linked-train-infos">
                   <li>{`${t('modal.from')} : ${linkedTrains.anteriorTrain.trainName}`}</li>


### PR DESCRIPTION
close https://github.com/OpenRailAssociation/osrd/issues/15283

Modal after the changes (don't mind the old date, it corresponds to the one I used for the simulation) : 

<img width="1239" height="729" alt="Capture d’écran 2026-02-17 à 14 36 31" src="https://github.com/user-attachments/assets/6089ebb5-0b06-46ad-b437-f2550683bd01" />
