### PR TITLE
core: scripts: add script that downloads and render s3 data

### DIFF
--- a/core/scripts/.dockerignore
+++ b/core/scripts/.dockerignore
@@ -1,3 +1,2 @@
-.env
 debug-space-time-chart.html
 .s3_cache

--- a/core/scripts/common.py
+++ b/core/scripts/common.py
@@ -1,9 +1,13 @@
 import asyncio
 import ssl
-from typing import List, Dict
+from pathlib import Path
+from typing import List, Dict, Any
 
 import aiohttp
+import boto3
 from aiohttp import ClientSession
+import subprocess
+import webbrowser
 
 
 def make_connector(gateway_cookie):
@@ -62,3 +66,66 @@ async def get_with_retries(
                 await asyncio.sleep(10.0)
             else:
                 raise e
+
+
+def download_s3_file(s3_client, bucket: str, path: str, s3_cache: Path) -> Path:
+    """
+    Download a file from s3, only if not already cached. Returns a `Path` to the downloaded file.
+    """
+    local_path = s3_cache / bucket / path
+    if local_path.exists():
+        print(f"local cache hit for {bucket}/{path}, at {local_path}")
+        return local_path
+    print(f"downloading {bucket}/{path} from s3...")
+
+    local_path.parent.mkdir(parents=True, exist_ok=True)
+    s3_client.download_file(bucket, path, str(local_path))
+    return local_path
+
+
+def open_html(html: Path):
+    """
+    Opens an HTML file in the default web browser. In WSL environments, opens the default host browser.
+    """
+
+    def is_wsl():
+        try:
+            with open("/proc/version", "r") as f:
+                return "microsoft" in f.read().lower()
+        except FileNotFoundError:
+            return False
+
+    if is_wsl():
+        win_path = (
+            subprocess.check_output(["wslpath", "-w", str(html)]).decode().strip()
+        )
+        subprocess.run(["cmd.exe", "/C", "start", "", win_path])
+    else:
+        webbrowser.open(str(html))
+
+
+def create_aws_session(profile: str) -> Any:
+    """
+    Create a working aws session. Refresh SSO login if necessary.
+    On error, include relevant documentation in exception message.
+    """
+    try:
+        session = boto3.Session(profile_name=profile)
+        # Basic call just to make sure the sso is setup
+        session.client("s3").list_buckets()
+    except:
+        print("Can't access s3 bucket, refreshing SSO login...")
+        try:
+            subprocess.check_call(f"aws sso login --profile {profile}".split())
+            session = boto3.Session(profile_name=profile)
+        except Exception as e:
+            err = (
+                "\n\n"
+                + "Couldn't create a working s3 sessions.\n"
+                + "If the SSO login doesn't work, refer to the setup documented here:\n"
+                + "https://gitlab-repo-res.apps.eul.sncf.fr/dsir/groupedxs-dsir/04735/osrd\n"
+                + "Original error: "
+                + str(e)
+            )
+            raise RuntimeError(err)
+    return session

--- a/core/scripts/generate-debug-space-chart.py
+++ b/core/scripts/generate-debug-space-chart.py
@@ -12,6 +12,8 @@ from dateutil import tz
 from bokeh.models import DatetimeTickFormatter
 import click
 
+from common import open_html
+
 
 @click.command(
     help="""
@@ -67,6 +69,7 @@ def main(input_location, output_location):
     output_file(output_location)
     save(fig)
     print(f"file://{os.path.abspath(output_location)}")
+    open_html(output_location)
 
 
 def convert_times(departure_time: datetime, times: List[int]) -> List[datetime]:

--- a/core/scripts/pyproject.toml
+++ b/core/scripts/pyproject.toml
@@ -8,6 +8,7 @@ requires-python = ">=3.11"
 dependencies = [
   "aiohttp>=3.13.3",
   "bokeh>=3.8.2",
+  "boto3>=1.42.59",
   "click>=8.3.1",
   "python-dotenv>=1.2.1",
 ]

--- a/core/scripts/render-s3-stdcm-sim.py
+++ b/core/scripts/render-s3-stdcm-sim.py
@@ -1,0 +1,55 @@
+import os
+from pathlib import Path
+
+import click
+import subprocess
+
+from common import download_s3_file, create_aws_session
+
+
+@click.command(
+    help="""
+Downloads simulation data from the s3 for a past STDCM request,
+then renders the space-time chart.
+The trace ID refers to datadog traces,
+it's also included at the bottom of the simulation sheet.
+
+Requires setting up a prod AWS access, see README here:
+https://gitlab-repo-res.apps.eul.sncf.fr/dsir/groupedxs-dsir/04735/osrd
+"""
+)
+@click.option(
+    "--profile",
+    "-p",
+    type=str,
+    help="""
+AWS profile name. Defaults to the content of AWS_PROFILE, then to 'default-ops-912306251540'
+if not set. This profile comes from the internal AWS setup.""",
+)
+@click.option(
+    "--s3-cache",
+    "-s",
+    type=click.Path(file_okay=False, path_type=Path, resolve_path=True),
+    default=None,
+)
+@click.option("--bucket", "-b", default="osrd-dev", type=str)
+@click.argument("trace-id")
+def main(profile: str | None, s3_cache: Path | None, bucket: str, trace_id: str):
+    if s3_cache is None:
+        s3_cache = Path(__file__).resolve().parent / ".s3_cache"
+    if profile is None:
+        profile = os.environ.get("AWS_PROFILE", default="default-ops-912306251540")
+
+    session = create_aws_session(profile)
+    s3 = session.client("s3")
+    file = download_s3_file(
+        s3,
+        bucket,
+        f"stdcm/requests/{trace_id}/output_simulation_data.json",
+        s3_cache,
+    )
+    subprocess.check_call(f"uv run generate-debug-space-chart.py -i {file}".split())
+
+
+if __name__ == "__main__":
+    main()

--- a/core/scripts/uv.lock
+++ b/core/scripts/uv.lock
@@ -165,6 +165,34 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.42.59"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b0/4e/499cb52aaee9468c346bcc1158965e24e72b4e2a20052725b680e0ac949b/boto3-1.42.59.tar.gz", hash = "sha256:6c4a14a4eb37b58a9048901bdeefbe1c529638b73e8f55413319a25f010ca211", size = 112725, upload-time = "2026-02-27T20:25:33.228Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/c0/22d868b9408dc5a33935a72896ec8d638b2766c459668d1b37c3e5ac2066/boto3-1.42.59-py3-none-any.whl", hash = "sha256:7a66e3e8e2087ea4403e135e9de592e6d63fc9a91080d8dac415bb74df873a72", size = 140557, upload-time = "2026-02-27T20:25:31.774Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.42.59"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/45/ae/50fb33bdf1911c216d50f98d989dd032a506f054cf829ebd737c6fa7e3e6/botocore-1.42.59.tar.gz", hash = "sha256:5314f19e1da8fc0ebc41bdb8bbe17c9a7397d87f4d887076ac8bdef972a34138", size = 14950271, upload-time = "2026-02-27T20:25:20.614Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/df/9d52819e0d804ead073d53ab1823bc0f0cb172a250fba31107b0b43fbb04/botocore-1.42.59-py3-none-any.whl", hash = "sha256:d2f2ff7ecc31e86ef46b5daee112cfbca052c13801285fb23af909f7bff5b657", size = 14619293, upload-time = "2026-02-27T20:25:17.455Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -391,6 +419,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
 ]
 
 [[package]]
@@ -679,6 +716,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "bokeh" },
+    { name = "boto3" },
     { name = "click" },
     { name = "python-dotenv" },
 ]
@@ -692,6 +730,7 @@ dev = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.13.3" },
     { name = "bokeh", specifier = ">=3.8.2" },
+    { name = "boto3", specifier = ">=1.42.59" },
     { name = "click", specifier = ">=8.3.1" },
     { name = "python-dotenv", specifier = ">=1.2.1" },
 ]
@@ -1056,6 +1095,18 @@ wheels = [
 ]
 
 [[package]]
+name = "s3transfer"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830, upload-time = "2025-12-01T02:30:57.729Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1099,6 +1150,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Usage, expected to be run with WSL:

```bash
aws --profile default-ops-912306251540 sso login
uv run render-s3-stdcm-sim.py trace_id
```

Requires AWS CLI: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html

The first command should be given in the error message if it needs to be run again. 

And now I might consider setting up a proper python environment for these scripts instead of standalone uv scripts with their own dependencies (even if that uv feature is extremely nice).