### PR TITLE
editoast: setup next `authz` model

### DIFF
--- a/editoast/authz/src/authorizer.rs
+++ b/editoast/authz/src/authorizer.rs
@@ -138,6 +138,8 @@ mod tests {
     use crate::mock_driver::MockAuthDriver;
     use crate::model;
     use crate::model::Group;
+    use crate::v2;
+    use crate::v2::test_authorizers;
     use pretty_assertions::assert_eq;
 
     #[tokio::test]
@@ -305,10 +307,12 @@ mod tests {
         );
 
         // add members
-        regulator()
-            .add_members(&friends, HashSet::from([User(alice_id), User(bob_id)]))
+        v2::add_members(friends, HashSet::from([User(alice_id), User(bob_id)]))
+            .authorize(&test_authorizers::Authorize(regulator().openfga()))
             .await
-            .expect("members should be added");
+            .expect("members should be added")
+            .unwrap_authorized()
+            .await;
 
         // setup roles
         regulator()

--- a/editoast/authz/src/lib.rs
+++ b/editoast/authz/src/lib.rs
@@ -2,6 +2,7 @@ mod authorizer;
 pub mod identity;
 mod model;
 mod regulator;
+pub mod v2;
 
 pub use authorizer::Authorizer;
 pub use regulator::Regulator;

--- a/editoast/authz/src/regulator.rs
+++ b/editoast/authz/src/regulator.rs
@@ -185,27 +185,6 @@ impl<S: StorageDriver> Regulator<S> {
         Ok(members.users.into_iter().collect())
     }
 
-    /// Adds some users to a group
-    #[tracing::instrument(skip_all, fields(group, ?members), ret(level = Level::DEBUG), err)]
-    pub async fn add_members(
-        &self,
-        group: &Group,
-        members: HashSet<User>,
-    ) -> Result<(), Error<S::Error>> {
-        let existing_members = self.group_members(group).await?;
-        let new_members = members.difference(&existing_members);
-        let mut writes = self.openfga.prepare_writes();
-        for user in new_members {
-            if !self.user_exists(user.0).await? {
-                return Err(Error::UnknownSubject(user.0));
-            }
-            writes.push(&Group::member().tuple(user, group));
-            writes.push(&User::group().tuple(group, user));
-        }
-        writes.execute().await?;
-        Ok(())
-    }
-
     /// Removes some users from a group
     #[tracing::instrument(skip_all, fields(group, ?members), ret(level = Level::DEBUG), err)]
     pub async fn remove_members(

--- a/editoast/authz/src/v2.rs
+++ b/editoast/authz/src/v2.rs
@@ -1,0 +1,157 @@
+use std::collections::HashSet;
+
+use fga::client::QueryError;
+use fga::model::Relation as _;
+use futures::FutureExt;
+use futures::future::BoxFuture;
+use itertools::Itertools;
+
+use crate::Group;
+use crate::Role;
+use crate::User;
+
+pub type OpenFgaError = fga::client::RequestFailure;
+type ValueFut<'a, T> = BoxFuture<'a, Result<T, OpenFgaError>>;
+type Operation<'a, T> = dyn for<'c> FnOnce(&'c fga::Client) -> ValueFut<'c, T> + 'a;
+
+/// Represents a protected operation yielding a value `T` and the necessary checks required to run it
+///
+/// Checks are divided into [Guardrail]s and [SanityCheck]s. They are not enforced by the [Protected] itself
+/// but rather by an [Authorizer] implementation, which can choose which checks to enforce or not.
+/// Running a [Protected] through an [Authorizer] will yield an [Access], which represents either an authorization, a bypass or a denial.
+#[derive(derive_more::Debug)]
+pub struct Protected<'a, T> {
+    #[debug(skip)]
+    op: Box<Operation<'a, T>>,
+    pub guardrails: HashSet<Guardrail>,
+    pub sanity_checks: HashSet<SanityCheck>,
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub enum Guardrail {
+    IssuerHasRole(Role),
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub enum SanityCheck {
+    UserExists(User),
+    GroupExists(Group),
+}
+
+/// The result of authorizing a [Protected] operation via [Authorizer::authorize]
+pub enum Access<'a, T, R> {
+    /// The operation is authorized, poll the future to get the result of the operation
+    ///
+    /// See [Access::access].
+    Authorized(ValueFut<'a, T>),
+    /// The operation is bypassed, the operation is not run and a substitute value is provided instead
+    Bypassed { value: T, reason: &'static str },
+    /// The operation is rejected, the protected operation cannot be run and a rejection reason is provided by the [Authorizer]
+    Denied { rejection: R },
+}
+
+/// An entity capable of authorizing a [Protected] operation, yielding an [Access]
+///
+/// The authorization logic is up to the implementation, but it should take into account the guardrails and sanity checks of the [Protected] operation.
+/// Not every check needs to be enforced depending on the purpose of the implementor, but make sure to authorize each protected operation with
+/// an appropriate [Authorizer], otherwise that *will result in security issues*.
+pub trait Authorizer<'a> {
+    type Rejection;
+    type Error;
+
+    /// Turns a [Protected] operation into an [Access] by enforcing the necessary checks
+    async fn authorize<T>(
+        &self,
+        data: Protected<'a, T>,
+    ) -> Result<Access<'a, T, Self::Rejection>, Self::Error>;
+}
+
+impl<'a, T> Protected<'a, T> {
+    pub fn new(f: impl for<'c> FnOnce(&'c fga::Client) -> ValueFut<'c, T> + 'a) -> Self {
+        Self {
+            op: Box::new(f),
+            guardrails: HashSet::new(),
+            sanity_checks: HashSet::new(),
+        }
+    }
+
+    pub fn blindly_authorize<R>(self, openfga: &'a fga::Client) -> Access<'a, T, R> {
+        Access::Authorized((self.op)(openfga))
+    }
+
+    fn with_guardrail(self, guardrail: Guardrail) -> Self {
+        self.with_guardrail_iter([guardrail])
+    }
+
+    fn with_guardrail_iter(mut self, guardrails: impl IntoIterator<Item = Guardrail>) -> Self {
+        self.guardrails.extend(guardrails);
+        self
+    }
+
+    fn with_check(self, sanity_check: SanityCheck) -> Self {
+        self.with_check_iter([sanity_check])
+    }
+
+    fn with_check_iter(mut self, sanity_checks: impl IntoIterator<Item = SanityCheck>) -> Self {
+        self.sanity_checks.extend(sanity_checks);
+        self
+    }
+}
+
+impl<'a, T, R> Access<'a, T, R> {
+    /// Awaits the authorized operation future if authorized or yields the rejection if not
+    ///
+    /// Returns the value if bypassed, logging a warning.
+    ///
+    /// Never match on the double Result, match on the Access itself if needed.
+    pub async fn access(self) -> Result<Result<T, R>, OpenFgaError> {
+        match self {
+            Access::Authorized(fut) => fut.await.map(Ok),
+            Access::Denied { rejection } => Ok(Err(rejection)),
+            Access::Bypassed { value, reason } => {
+                tracing::warn!(reason, "using admin bypass");
+                Ok(Ok(value))
+            }
+        }
+    }
+}
+
+// TODO: move somewhere more appropriate
+/// Adds some members to a group
+///
+/// Idempotent but not atomic due to the lack of transactions in OpenFGA.
+pub fn add_members<'a>(group: Group, members: HashSet<User>) -> Protected<'a, ()> {
+    let user_exists_checks = members
+        .iter()
+        .map(|user| SanityCheck::UserExists(*user))
+        .collect_vec(); // members is moved in Protected
+
+    Protected::new(move |openfga| {
+        async move {
+            let existing_members = openfga
+                .list_users(Group::member().query_users(&group))
+                .await
+                .map_err(QueryError::parsing_ok)?;
+
+            debug_assert!(
+                existing_members.public_access.is_none(),
+                "we don't write public accesses for groups"
+            );
+
+            let existing_members = HashSet::from_iter(existing_members.users);
+            let new_members = members.difference(&existing_members);
+            let mut writes = openfga.prepare_writes();
+            for user in new_members {
+                writes.push(&Group::member().tuple(user, &group));
+                writes.push(&User::group().tuple(&group, user));
+            }
+            writes.execute().await?;
+
+            Ok(())
+        }
+        .boxed()
+    })
+    .with_check(SanityCheck::GroupExists(group))
+    .with_check_iter(user_exists_checks)
+    .with_guardrail(Guardrail::IssuerHasRole(Role::Admin))
+}

--- a/editoast/authz/src/v2.rs
+++ b/editoast/authz/src/v2.rs
@@ -226,3 +226,81 @@ pub mod test_authorizers {
         }
     }
 }
+
+pub trait TestClientExt {
+    async fn group_members(&self, group: &Group) -> HashSet<User>;
+}
+
+impl TestClientExt for fga::Client {
+    async fn group_members(&self, group: &Group) -> HashSet<User> {
+        self.list_users(Group::member().query_users(group))
+            .await
+            .unwrap()
+            .users
+            .into_iter()
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::v2::test_authorizers::Authorize;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn add_members_idempotent() {
+        let openfga = crate::authz_client!();
+        let authorize = Authorize(&openfga);
+
+        add_members(Group(1), HashSet::from_iter([User(1), User(2)]))
+            .authorize(&authorize)
+            .await
+            .unwrap()
+            .unwrap_authorized()
+            .await;
+        assert_eq!(
+            openfga.group_members(&Group(1)).await,
+            HashSet::from_iter([User(1), User(2)])
+        );
+
+        add_members(Group(1), HashSet::from_iter([User(1), User(2)]))
+            .authorize(&authorize)
+            .await
+            .unwrap()
+            .unwrap_authorized()
+            .await;
+        assert_eq!(
+            openfga.group_members(&Group(1)).await,
+            HashSet::from_iter([User(1), User(2)])
+        );
+    }
+
+    #[tokio::test]
+    async fn add_members_intersecting_calls() {
+        let openfga = crate::authz_client!();
+        let authorize = Authorize(&openfga);
+
+        add_members(Group(1), HashSet::from_iter([User(1), User(2)]))
+            .authorize(&authorize)
+            .await
+            .unwrap()
+            .unwrap_authorized()
+            .await;
+        assert_eq!(
+            openfga.group_members(&Group(1)).await,
+            HashSet::from_iter([User(1), User(2)])
+        );
+
+        add_members(Group(1), HashSet::from_iter([User(1), User(3)]))
+            .authorize(&authorize)
+            .await
+            .unwrap()
+            .unwrap_authorized()
+            .await;
+        assert_eq!(
+            openfga.group_members(&Group(1)).await,
+            HashSet::from_iter([User(1), User(2), User(3)])
+        );
+    }
+}

--- a/editoast/authz/src/v2.rs
+++ b/editoast/authz/src/v2.rs
@@ -27,12 +27,22 @@ pub struct Protected<'a, T> {
     pub sanity_checks: HashSet<SanityCheck>,
 }
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+/// A check to ensure the permission workflow of editoast is respected
+///
+/// For example, one cannot share a resource to a level higher that their own.
+///
+/// Not to be confused with [SanityCheck]s, which are checks that ensure the consistency of the data in OpenFGA and PostgreSQL.
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub enum Guardrail {
     IssuerHasRole(Role),
 }
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+/// A check to ensure the consistency of the data in OpenFGA and PostgreSQL
+///
+/// For example, one cannot add a user to a group if the user doesn't exist in PostgreSQL, even if it doesn't cause any issue in OpenFGA.
+///
+/// Not to be confused with [Guardrail]s, which are checks to ensure the permission workflow of editoast is respected.
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub enum SanityCheck {
     UserExists(User),
     GroupExists(Group),
@@ -75,6 +85,17 @@ impl<'a, T> Protected<'a, T> {
         }
     }
 
+    /// For convenient chaining
+    pub async fn authorize<A: Authorizer<'a>>(
+        self,
+        authorizer: &A,
+    ) -> Result<Access<'a, T, A::Rejection>, A::Error> {
+        authorizer.authorize(self).await
+    }
+
+    /// Consumes the protection and produces an [Access::Authorized] without performing any check
+    ///
+    /// Only use this in trusted context or in an [Authorizer] implementation after performing the necessary checks.
     pub fn blindly_authorize<R>(self, openfga: &'a fga::Client) -> Access<'a, T, R> {
         Access::Authorized((self.op)(openfga))
     }
@@ -112,6 +133,16 @@ impl<'a, T, R> Access<'a, T, R> {
                 tracing::warn!(reason, "using admin bypass");
                 Ok(Ok(value))
             }
+        }
+    }
+}
+
+impl<'a, T, R: std::fmt::Debug> Access<'a, T, R> {
+    pub async fn unwrap_authorized(self) -> T {
+        match self.access().await {
+            Ok(Ok(value)) => value,
+            Ok(Err(rejection)) => panic!("authorization failed: {:?}", rejection),
+            Err(error) => panic!("authorization error: {:?}", error),
         }
     }
 }
@@ -154,4 +185,44 @@ pub fn add_members<'a>(group: Group, members: HashSet<User>) -> Protected<'a, ()
     .with_check(SanityCheck::GroupExists(group))
     .with_check_iter(user_exists_checks)
     .with_guardrail(Guardrail::IssuerHasRole(Role::Admin))
+}
+
+pub mod test_authorizers {
+    use std::convert::Infallible;
+
+    use crate::v2::Access;
+    use crate::v2::Protected;
+
+    use super::Authorizer;
+
+    /// Always authorizes without performing any check
+    pub struct Authorize<'a>(pub &'a fga::Client);
+    /// Always rejects with the given rejection reason
+    pub struct Reject<Rejection>(Rejection);
+
+    impl<'a> Authorizer<'a> for Authorize<'a> {
+        type Rejection = ();
+        type Error = Infallible;
+
+        async fn authorize<T>(
+            &self,
+            data: Protected<'a, T>,
+        ) -> Result<Access<'a, T, Self::Rejection>, Self::Error> {
+            Ok(data.blindly_authorize(self.0))
+        }
+    }
+
+    impl<'a, Rejection: Clone> Authorizer<'a> for Reject<Rejection> {
+        type Rejection = Rejection;
+        type Error = Infallible;
+
+        async fn authorize<T>(
+            &self,
+            _data: Protected<'a, T>,
+        ) -> Result<Access<'a, T, Self::Rejection>, Self::Error> {
+            Ok(Access::Denied {
+                rejection: self.0.clone(),
+            })
+        }
+    }
 }

--- a/editoast/src/authorizers.rs
+++ b/editoast/src/authorizers.rs
@@ -1,0 +1,58 @@
+use authz::v2::Access;
+use authz::v2::Authorizer;
+use authz::v2::Protected;
+use authz::v2::SanityCheck;
+use editoast_models::prelude::*;
+
+/// An authorizer that represents editoast's authorization decisions
+///
+/// Decorrelated from any user, this authorizer is used for actions that the
+/// system knows are correct. For example, attributing the first owner of a new resource.
+///
+/// No user can be associated with this authorizer.
+pub struct SystemAuthorizer<'a> {
+    pub openfga: &'a fga::Client,
+    pub conn: database::DbConnection,
+}
+
+impl<'a> Authorizer<'a> for SystemAuthorizer<'a> {
+    type Error = editoast_models::Error;
+    type Rejection = Rejection;
+
+    #[tracing::instrument(skip_all)]
+    async fn authorize<T>(
+        &self,
+        data: Protected<'a, T>,
+    ) -> Result<Access<'a, T, Self::Rejection>, Self::Error> {
+        let conn = &mut self.conn.clone();
+        for check in &data.sanity_checks {
+            if let Some(rejection) = sanity_check(check, conn).await? {
+                return Ok(Access::Denied { rejection });
+            }
+        }
+        Ok(data.blindly_authorize(self.openfga))
+    }
+}
+
+#[derive(Debug)]
+pub enum Rejection {
+    NoSuchUser(i64),
+    NoSuchGroup(#[expect(dead_code)] i64),
+}
+
+#[tracing::instrument(skip_all, fields(?sanity_check), ret(level = "trace"), err)]
+async fn sanity_check(
+    sanity_check: &SanityCheck,
+    conn: &mut database::DbConnection,
+) -> Result<Option<Rejection>, editoast_models::Error> {
+    match sanity_check {
+        SanityCheck::UserExists(authz::User(user_id)) => {
+            Ok((!editoast_models::User::exists(conn, *user_id).await?)
+                .then_some(Rejection::NoSuchUser(*user_id)))
+        }
+        SanityCheck::GroupExists(authz::Group(group_id)) => {
+            Ok((!editoast_models::Group::exists(conn, *group_id).await?)
+                .then_some(Rejection::NoSuchGroup(*group_id)))
+        }
+    }
+}

--- a/editoast/src/client/group.rs
+++ b/editoast/src/client/group.rs
@@ -1,6 +1,7 @@
 use anyhow::anyhow;
 use anyhow::bail;
 use authz::Group;
+use authz::v2::Authorizer;
 use clap::Args;
 use clap::Subcommand;
 
@@ -16,6 +17,9 @@ use std::sync::Arc;
 
 use editoast_models::PgAuthDriver;
 
+use crate::authorizers::Rejection;
+use crate::authorizers::SystemAuthorizer;
+
 use super::openfga_config::OpenfgaConfig;
 
 #[derive(Debug, Subcommand)]
@@ -24,7 +28,7 @@ pub enum GroupCommand {
     Create(CreateArgs),
     /// List groups
     List,
-    /// Get a group's informations
+    /// Get group information
     Info(InfoArgs),
     /// Add members to a group
     Include(IncludeArgs),
@@ -166,6 +170,10 @@ pub async fn include_group(
 
     let regulator = openfga_config.into_regulator(pool.clone()).await?;
     let driver = regulator.driver();
+    let system = SystemAuthorizer {
+        openfga: regulator.openfga(),
+        conn: pool.get().await?,
+    };
 
     let Some(group_id) = driver.get_group_id(&group_name).await? else {
         bail!("No such group: '{group_name}'");
@@ -182,10 +190,12 @@ pub async fn include_group(
         authz_users.insert(authz::User(uid));
     }
 
-    regulator
-        .add_members(&authz::Group(group_id), authz_users)
-        .await?;
-    Ok(())
+    let add_member = authz::v2::add_members(authz::Group(group_id), authz_users);
+    match system.authorize(add_member).await?.access().await? {
+        Ok(()) => Ok(()),
+        Err(Rejection::NoSuchGroup(_)) => unreachable!("tested above"),
+        Err(Rejection::NoSuchUser(user_id)) => bail!("No such user {user_id}"),
+    }
 }
 
 pub async fn delete_group(

--- a/editoast/src/main.rs
+++ b/editoast/src/main.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 extern crate diesel;
 
+mod authorizers;
 mod client;
 mod error;
 mod generated_data;

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -2,6 +2,8 @@
 //! test axum server, database connection pool, and different mocking
 //! components.
 
+use authz::v2;
+use authz::v2::test_authorizers;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::path::PathBuf;
@@ -591,16 +593,18 @@ impl<'a> GroupBuilder<'a> {
                 .await
                 .expect("roles should be granted successfully");
 
-            regulator
-                .add_members(
-                    &group_auth,
-                    members
-                        .into_iter()
-                        .map(|authz::identity::User { id, .. }| authz::User(*id))
-                        .collect(),
-                )
-                .await
-                .expect("members should be added successfully");
+            v2::add_members(
+                group_auth,
+                members
+                    .into_iter()
+                    .map(|authz::identity::User { id, .. }| authz::User(*id))
+                    .collect(),
+            )
+            .authorize(&test_authorizers::Authorize(regulator.openfga()))
+            .await
+            .expect("members should be added successfully")
+            .unwrap_authorized()
+            .await;
 
             let subject = authz::Subject::Group(group_auth);
             for (infra_id, grant) in infras_grant.into_iter() {


### PR DESCRIPTION
initial step of https://github.com/osrd-project/osrd-confidential/issues/1168

- **editoast: authz: add v2 setup**
- **editoast: authz: v2 testing utils and remove old `add_members`**
- **editoast: authz: add `authz` tests for `add_members`**

Also ports `add_members` (for groups) in order to use code and demonstrate the new paradigm.

The views middleware and `v2::Authorizer` creation has currently been left out on purpose (for another PR that is).

I've put everything in v2.rs for now, I'd vote to reorganize and move things as we go.

> [!NOTE]
> The `Guardrail` name is too good not to be used sorry... 🛤️ 
