### PR TITLE
front: add missing source-layer in the infra editor

### DIFF
--- a/front/src/common/Map/Layers/InfraObjectLayers/OperationalPoints.tsx
+++ b/front/src/common/Map/Layers/InfraObjectLayers/OperationalPoints.tsx
@@ -8,7 +8,7 @@ import type {
 } from 'maplibre-gl';
 import { Source, type LayerProps } from 'react-map-gl/maplibre';
 
-import { MAP_URL } from 'common/Map/const';
+import { MAP_TRACK_SOURCES, MAP_URL } from 'common/Map/const';
 import type { Theme } from 'common/Map/theme';
 import { useMapContext } from 'common/Map/useMapContext';
 
@@ -286,6 +286,7 @@ const OperationalPointsLayer = ({
         }}
         id="chartis/tracks-geo/track-name"
         layerOrder={layerOrder}
+        source-layer={MAP_TRACK_SOURCES.geographic}
       />
       <OrderedLayer
         {...name}


### PR DESCRIPTION
Otherwise the `chartis/tracks-geo/track-name` layer would complain about it and spam the console with error traces
