### PR TITLE
editoast: `is_paced` depends on `time_window` AND `interval`

### DIFF
--- a/editoast/src/models/train_schedule.rs
+++ b/editoast/src/models/train_schedule.rs
@@ -225,7 +225,7 @@ impl TrainSchedule {
 
     /// Returns whether this train has paced occurrences.
     fn is_paced(&self) -> bool {
-        self.time_window.is_some()
+        self.time_window.is_some() && self.interval.is_some()
     }
 
     /// Returns the number of base train occurrences within the pacing window.

--- a/editoast/src/models/train_schedule.rs
+++ b/editoast/src/models/train_schedule.rs
@@ -224,7 +224,7 @@ impl TrainSchedule {
     }
 
     /// Returns whether this train has paced occurrences.
-    fn is_paced(&self) -> bool {
+    pub fn is_paced(&self) -> bool {
         self.time_window.is_some() && self.interval.is_some()
     }
 


### PR DESCRIPTION
A few lines below this function, the function `is_paced` is used and `.unwrap()` both `time_window` AND `interval` so I believe it’s a mistake to not check both fields in the function.