### PR TITLE
core: scripts: remove unnecessary del after format change

### DIFF
--- a/core/scripts/download-timetable.py
+++ b/core/scripts/download-timetable.py
@@ -33,7 +33,6 @@ async def download_timetable(
     paced_trains = []
     for paced_train in raw_paced_trains:
         del paced_train["id"]
-        del paced_train["timetable_id"]
         paced_trains.append(paced_train)
     return {
         "train_schedules": [],


### PR DESCRIPTION
This line isn't necessary anymore, the field has been removed from the returned data. It causes an error when trying to delete it. 