### PR TITLE
editoast: Update the `track_occupancy` endpoint to identify operational points by `id`, `trigram`or `uic`

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -2486,7 +2486,7 @@ paths:
               type: object
               required:
               - paced_train_ids
-              - operational_point_id
+              - operational_point_reference
               - infra_id
               - use_simulation
               properties:
@@ -2498,8 +2498,8 @@ paths:
                 infra_id:
                   type: integer
                   format: int64
-                operational_point_id:
-                  type: string
+                operational_point_reference:
+                  $ref: '#/components/schemas/OperationalPointReference'
                 paced_train_ids:
                   type: array
                   items:
@@ -2514,76 +2514,111 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties:
-                  type: array
-                  items:
-                    allOf:
-                    - oneOf:
-                      - type: object
-                        required:
-                        - id
-                        - index
-                        - type
-                        properties:
-                          id:
-                            type: integer
-                            format: int64
-                          index:
-                            type: integer
-                            minimum: 0
-                          type:
-                            type: string
-                            enum:
-                            - base
-                      - type: object
-                        required:
-                        - id
-                        - index
-                        - exception_key
-                        - type
-                        properties:
-                          exception_key:
-                            type: string
-                          id:
-                            type: integer
-                            format: int64
-                          index:
-                            type: integer
-                            minimum: 0
-                          type:
-                            type: string
-                            enum:
-                            - modified
-                      - type: object
-                        required:
-                        - id
-                        - exception_key
-                        - type
-                        properties:
-                          exception_key:
-                            type: string
-                          id:
-                            type: integer
-                            format: int64
-                          type:
-                            type: string
-                            enum:
-                            - created
-                      description: This ID is used to identify paced train occurrences and exceptions when sending them to the core API for conflict detection.
-                    - type: object
-                      required:
-                      - time_begin
-                      - duration
-                      properties:
-                        duration:
-                          type: string
-                          example: PT5M
-                        time_begin:
-                          type: string
-                          format: date-time
-                propertyNames:
-                  type: string
+                type: array
+                items:
+                  type: object
+                  required:
+                  - trains
+                  properties:
+                    track_reference:
+                      oneOf:
+                      - type: 'null'
+                      - oneOf:
+                        - type: object
+                          required:
+                          - id
+                          - type
+                          properties:
+                            id:
+                              type: string
+                            type:
+                              type: string
+                              enum:
+                              - track_id
+                        - type: object
+                          required:
+                          - name
+                          - type
+                          properties:
+                            name:
+                              type: string
+                            type:
+                              type: string
+                              enum:
+                              - track_name
+                      description: |-
+                        Which track section the train is on at the queried operational point.
+
+                        - `null`: no track could be determined (trains are in no-simulation, no `local_track_name`)
+                        - `track_id`: track resolved via pathfinding or `local_track_name` lookup
+                        - `track_name`: `local_track_name` given but not matched to any track ID
+                    trains:
+                      type: array
+                      items:
+                        allOf:
+                        - oneOf:
+                          - type: object
+                            required:
+                            - id
+                            - index
+                            - type
+                            properties:
+                              id:
+                                type: integer
+                                format: int64
+                              index:
+                                type: integer
+                                minimum: 0
+                              type:
+                                type: string
+                                enum:
+                                - base
+                          - type: object
+                            required:
+                            - id
+                            - index
+                            - exception_key
+                            - type
+                            properties:
+                              exception_key:
+                                type: string
+                              id:
+                                type: integer
+                                format: int64
+                              index:
+                                type: integer
+                                minimum: 0
+                              type:
+                                type: string
+                                enum:
+                                - modified
+                          - type: object
+                            required:
+                            - id
+                            - exception_key
+                            - type
+                            properties:
+                              exception_key:
+                                type: string
+                              id:
+                                type: integer
+                                format: int64
+                              type:
+                                type: string
+                                enum:
+                                - created
+                          description: This ID is used to identify paced train occurrences and exceptions when sending them to the core API for conflict detection.
+                        - type: object
+                          required:
+                          - time_begin
+                          - duration
+                          properties:
+                            duration:
+                              type: string
+                              example: PT5M
+                            time_begin:
+                              type: string
+                              format: date-time
   /paced_train/{id}:
     get:
       tags:
@@ -6980,10 +7015,10 @@ components:
         context:
           type: object
           required:
-          - operational_point_id
+          - reference
           properties:
-            operational_point_id:
-              type: string
+            reference:
+              type: object
         message:
           type: string
         status:

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -1842,48 +1842,48 @@ paths:
                     - oneOf:
                       - type: object
                         required:
-                        - id
+                        - train_schedule_id
                         - index
                         - type
                         properties:
-                          id:
-                            type: integer
-                            format: int64
                           index:
                             type: integer
                             minimum: 0
+                          train_schedule_id:
+                            type: integer
+                            format: int64
                           type:
                             type: string
                             enum:
                             - base
                       - type: object
                         required:
-                        - id
+                        - train_schedule_id
                         - index
                         - exception_key
                         - type
                         properties:
                           exception_key:
                             type: string
-                          id:
-                            type: integer
-                            format: int64
                           index:
                             type: integer
                             minimum: 0
+                          train_schedule_id:
+                            type: integer
+                            format: int64
                           type:
                             type: string
                             enum:
                             - modified
                       - type: object
                         required:
-                        - id
+                        - train_schedule_id
                         - exception_key
                         - type
                         properties:
                           exception_key:
                             type: string
-                          id:
+                          train_schedule_id:
                             type: integer
                             format: int64
                           type:
@@ -2559,48 +2559,48 @@ paths:
                         - oneOf:
                           - type: object
                             required:
-                            - id
+                            - train_schedule_id
                             - index
                             - type
                             properties:
-                              id:
-                                type: integer
-                                format: int64
                               index:
                                 type: integer
                                 minimum: 0
+                              train_schedule_id:
+                                type: integer
+                                format: int64
                               type:
                                 type: string
                                 enum:
                                 - base
                           - type: object
                             required:
-                            - id
+                            - train_schedule_id
                             - index
                             - exception_key
                             - type
                             properties:
                               exception_key:
                                 type: string
-                              id:
-                                type: integer
-                                format: int64
                               index:
                                 type: integer
                                 minimum: 0
+                              train_schedule_id:
+                                type: integer
+                                format: int64
                               type:
                                 type: string
                                 enum:
                                 - modified
                           - type: object
                             required:
-                            - id
+                            - train_schedule_id
                             - exception_key
                             - type
                             properties:
                               exception_key:
                                 type: string
-                              id:
+                              train_schedule_id:
                                 type: integer
                                 format: int64
                               type:
@@ -5085,48 +5085,48 @@ components:
             oneOf:
             - type: object
               required:
-              - id
+              - train_schedule_id
               - index
               - type
               properties:
-                id:
-                  type: integer
-                  format: int64
                 index:
                   type: integer
                   minimum: 0
+                train_schedule_id:
+                  type: integer
+                  format: int64
                 type:
                   type: string
                   enum:
                   - base
             - type: object
               required:
-              - id
+              - train_schedule_id
               - index
               - exception_key
               - type
               properties:
                 exception_key:
                   type: string
-                id:
-                  type: integer
-                  format: int64
                 index:
                   type: integer
                   minimum: 0
+                train_schedule_id:
+                  type: integer
+                  format: int64
                 type:
                   type: string
                   enum:
                   - modified
             - type: object
               required:
-              - id
+              - train_schedule_id
               - exception_key
               - type
               properties:
                 exception_key:
                   type: string
-                id:
+                train_schedule_id:
                   type: integer
                   format: int64
                 type:

--- a/editoast/schemas/src/train_schedule/path_item.rs
+++ b/editoast/schemas/src/train_schedule/path_item.rs
@@ -75,3 +75,27 @@ pub enum OperationalPointReference {
         secondary_code: Option<String>,
     },
 }
+
+impl std::fmt::Display for OperationalPointReference {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Id { operational_point } => write!(f, "id:{operational_point}"),
+            Self::Trigram {
+                trigram,
+                secondary_code: None,
+            } => write!(f, "trigram:{trigram}"),
+            Self::Trigram {
+                trigram,
+                secondary_code: Some(secondary_code),
+            } => write!(f, "trigram:{trigram}:{secondary_code}"),
+            Self::Uic {
+                uic,
+                secondary_code: None,
+            } => write!(f, "uic:{uic}"),
+            Self::Uic {
+                uic,
+                secondary_code: Some(secondary_code),
+            } => write!(f, "uic:{uic}:{secondary_code}"),
+        }
+    }
+}

--- a/editoast/src/models/train_schedule.rs
+++ b/editoast/src/models/train_schedule.rs
@@ -325,16 +325,16 @@ impl From<TrainSchedule> for paced_train::TrainSchedule {
 /// This ID is used to identify paced train occurrences and exceptions when sending them to the core API for conflict detection.
 pub enum OccurrenceId {
     Base {
-        id: i64,
+        train_schedule_id: i64,
         index: usize,
     },
     Modified {
-        id: i64,
+        train_schedule_id: i64,
         index: usize,
         exception_key: String,
     },
     Created {
-        id: i64,
+        train_schedule_id: i64,
         exception_key: String,
     },
 }
@@ -342,13 +342,16 @@ pub enum OccurrenceId {
 impl OccurrenceId {
     /// Creates a new `Occurrence::Base`.
     pub fn new_base(id: i64, index: usize) -> Self {
-        OccurrenceId::Base { id, index }
+        OccurrenceId::Base {
+            train_schedule_id: id,
+            index,
+        }
     }
 
     /// Create a new `Occurrence::Modified` without an exception key.
     pub fn new_modified(id: i64, index: usize, exception_key: String) -> Self {
         OccurrenceId::Modified {
-            id,
+            train_schedule_id: id,
             index,
             exception_key,
         }
@@ -356,20 +359,29 @@ impl OccurrenceId {
 
     /// Creates a new `Occurrence::Created`.
     pub fn new_created(id: i64, exception_key: String) -> Self {
-        OccurrenceId::Created { id, exception_key }
+        OccurrenceId::Created {
+            train_schedule_id: id,
+            exception_key,
+        }
     }
 }
 
 impl Display for OccurrenceId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            OccurrenceId::Base { id, index } => write!(f, "{}#{}", id, index),
+            OccurrenceId::Base {
+                train_schedule_id: id,
+                index,
+            } => write!(f, "{}#{}", id, index),
             OccurrenceId::Modified {
-                id,
+                train_schedule_id: id,
                 index,
                 exception_key,
             } => write!(f, "{}@{}#{}", id, exception_key, index),
-            OccurrenceId::Created { id, exception_key } => {
+            OccurrenceId::Created {
+                train_schedule_id: id,
+                exception_key,
+            } => {
                 write!(f, "{}@{}", id, exception_key)
             }
         }

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -1143,7 +1143,9 @@ mod tests {
         let simple_ts_train_core_id = trains_ids_map
             .iter()
             .find_map(|(core_id, train_id)| match train_id {
-                OccurrenceId::Base { id, .. } if *id == ts_id => Some(core_id),
+                OccurrenceId::Base {
+                    train_schedule_id, ..
+                } if *train_schedule_id == ts_id => Some(core_id),
                 _ => None,
             })
             .unwrap();
@@ -1166,9 +1168,11 @@ mod tests {
         let paced_0_train_core_id = trains_ids_map
             .iter()
             .find_map(|(core_id, train_id)| match train_id {
-                OccurrenceId::Base { id, index, .. } if *id == paced_train_id && *index == 0 => {
-                    Some(core_id)
-                }
+                OccurrenceId::Base {
+                    train_schedule_id,
+                    index,
+                    ..
+                } if *train_schedule_id == paced_train_id && *index == 0 => Some(core_id),
                 _ => None,
             })
             .unwrap();
@@ -1190,9 +1194,11 @@ mod tests {
         let paced_1_train_core_id = trains_ids_map
             .iter()
             .find_map(|(core_id, train_id)| match train_id {
-                OccurrenceId::Base { id, index, .. } if *id == paced_train_id && *index == 1 => {
-                    Some(core_id)
-                }
+                OccurrenceId::Base {
+                    train_schedule_id,
+                    index,
+                    ..
+                } if *train_schedule_id == paced_train_id && *index == 1 => Some(core_id),
                 _ => None,
             })
             .unwrap();

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -23,6 +23,7 @@ use reqwest::StatusCode;
 use schemas::paced_train::TrainSchedule;
 use schemas::primitives::TimeWindow;
 use schemas::train_schedule::OperationalPointPartReference;
+use schemas::train_schedule::OperationalPointReference;
 use schemas::train_schedule::PathItemLocation;
 use serde::Deserialize;
 use serde::Serialize;
@@ -79,9 +80,11 @@ enum PacedTrainError {
     #[error("Exception '{exception_key}', could not be found")]
     #[editoast_error(status = 404)]
     ExceptionNotFound { exception_key: String },
-    #[error("Operational point '{operational_point_id}', could not be found")]
+    #[error("Operational point '{reference}' could not be found")]
     #[editoast_error(status = 404)]
-    OperationalPointNotFound { operational_point_id: String },
+    OperationalPointNotFound {
+        reference: OperationalPointReference,
+    },
     #[error("Rolling stock '{rolling_stock_name}', could not be found")]
     #[editoast_error(status = 404)]
     RollingStockNotFound { rolling_stock_name: String },
@@ -1171,7 +1174,7 @@ pub(in crate::views) async fn occupancy_blocks(
 #[schema(as = PacedTrainTrackOccupancyForm)]
 pub(in crate::views) struct TrackOccupancyForm {
     paced_train_ids: Vec<i64>,
-    operational_point_id: String,
+    operational_point_reference: OperationalPointReference,
     infra_id: i64,
     electrical_profile_set_id: Option<i64>,
     use_simulation: bool,
@@ -1188,6 +1191,33 @@ pub(in crate::views) struct TrackOccupancy {
     time_window: TimeWindow,
 }
 
+#[derive(Debug, Serialize, ToSchema)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[cfg_attr(test, derive(Deserialize, PartialEq))]
+pub(in crate::views) enum TrackReference {
+    TrackId {
+        id: String,
+    },
+    #[cfg_attr(not(test), expect(dead_code))]
+    TrackName {
+        name: String,
+    },
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+#[cfg_attr(test, derive(Deserialize))]
+pub(in crate::views) struct TrackSectionOccupancy {
+    /// Which track section the train is on at the queried operational point.
+    ///
+    /// - `null`: no track could be determined (trains are in no-simulation, no `local_track_name`)
+    /// - `track_id`: track resolved via pathfinding or `local_track_name` lookup
+    /// - `track_name`: `local_track_name` given but not matched to any track ID
+    #[schema(inline)]
+    track_reference: Option<TrackReference>,
+    #[schema(inline)]
+    trains: Vec<TrackOccupancy>,
+}
+
 #[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
@@ -1195,7 +1225,7 @@ pub(in crate::views) struct TrackOccupancy {
     request_body = inline(TrackOccupancyForm),
     responses(
         (status = 200, description = "Track section occupancy periods for paced trains",
-         body = inline(HashMap<String, Vec<TrackOccupancy>>)),
+         body = inline(Vec<TrackSectionOccupancy>)),
     ),
 )]
 pub(in crate::views) async fn track_occupancy(
@@ -1209,12 +1239,12 @@ pub(in crate::views) async fn track_occupancy(
     Extension(auth): AuthenticationExt,
     Json(TrackOccupancyForm {
         paced_train_ids,
-        operational_point_id,
+        operational_point_reference,
         infra_id,
         electrical_profile_set_id,
         use_simulation,
     }): Json<TrackOccupancyForm>,
-) -> Result<Json<HashMap<String, Vec<TrackOccupancy>>>> {
+) -> Result<Json<Vec<TrackSectionOccupancy>>> {
     let authorized = auth
         .check_roles([authz::Role::OperationalStudies].into())
         .await
@@ -1247,14 +1277,8 @@ pub(in crate::views) async fn track_occupancy(
         .await?;
 
     // Get the operational point
-    let operational_point = models::OperationalPointModel::retrieve_or_fail(
-        db_pool.get().await?,
-        (infra_id, operational_point_id.clone()),
-        || PacedTrainError::OperationalPointNotFound {
-            operational_point_id: operational_point_id.clone(),
-        },
-    )
-    .await?;
+    let operational_point =
+        get_operational_point(db_pool.clone(), infra_id, operational_point_reference).await?;
 
     // Collect all occurrences from all paced trains using iter_occurrences()
     let (train_ids, trains): (Vec<_>, Vec<_>) = paced_trains
@@ -1290,7 +1314,7 @@ pub(in crate::views) async fn track_occupancy(
         izip!(train_ids, trains, simulations_result)
             .flat_map(|(train_id, train, (simulation, pathfinding))| {
                 track_occupancy::find_track_occupancy_for_operational_point(
-                    &operational_point_id,
+                    &operational_point.obj_id,
                     &operational_point_track_offsets,
                     &op_cache,
                     &simulation,
@@ -1319,7 +1343,7 @@ pub(in crate::views) async fn track_occupancy(
         izip!(train_ids, trains)
             .flat_map(|(train_id, train_schedule)| {
                 track_occupancy::find_track_occupancy_for_operational_point_without_simulation(
-                    &operational_point_id,
+                    &operational_point.obj_id,
                     &operational_point_track_offsets,
                     &op_cache,
                     &train_schedule,
@@ -1345,15 +1369,81 @@ pub(in crate::views) async fn track_occupancy(
     };
 
     // Group occupancies by track section
-    let results: HashMap<String, Vec<TrackOccupancy>> =
-        all_occupancies
-            .into_iter()
-            .fold(HashMap::new(), |mut map, (track_section, occupancy)| {
-                map.entry(track_section).or_default().push(occupancy);
-                map
-            });
+    let results: Vec<TrackSectionOccupancy> = all_occupancies
+        .into_iter()
+        .into_group_map()
+        .into_iter()
+        .map(|(track_reference, trains)| TrackSectionOccupancy {
+            track_reference: Some(TrackReference::TrackId {
+                id: track_reference,
+            }),
+            trains,
+        })
+        .collect();
 
     Ok(Json(results))
+}
+
+async fn get_operational_point(
+    db_pool: Arc<DbConnectionPoolV2>,
+    infra_id: i64,
+    operational_point_reference: OperationalPointReference,
+) -> Result<models::OperationalPointModel> {
+    match &operational_point_reference {
+        OperationalPointReference::Id { operational_point } => {
+            models::OperationalPointModel::retrieve_or_fail(
+                db_pool.get().await?,
+                (infra_id, operational_point.to_string()),
+                || {
+                    PacedTrainError::OperationalPointNotFound {
+                        reference: operational_point_reference.clone(),
+                    }
+                    .into()
+                },
+            )
+            .await
+        }
+        OperationalPointReference::Trigram {
+            trigram,
+            secondary_code,
+        } => models::OperationalPointModel::retrieve_from_trigrams(
+            &mut db_pool.get().await?,
+            infra_id,
+            &[trigram.to_string()],
+        )
+        .await
+        .map_err(|e| PacedTrainError::Database(e.into()))?
+        .into_iter()
+        .find(|op| {
+            op.schema.extensions.sncf.as_ref().map(|s| s.ch.as_str()) == secondary_code.as_deref()
+        })
+        .ok_or_else(|| {
+            PacedTrainError::OperationalPointNotFound {
+                reference: operational_point_reference.clone(),
+            }
+            .into()
+        }),
+        OperationalPointReference::Uic {
+            uic,
+            secondary_code,
+        } => models::OperationalPointModel::retrieve_from_uic(
+            &mut db_pool.get().await?,
+            infra_id,
+            &[*uic],
+        )
+        .await
+        .map_err(|e| PacedTrainError::Database(e.into()))?
+        .into_iter()
+        .find(|op| {
+            op.schema.extensions.sncf.as_ref().map(|s| s.ch.as_str()) == secondary_code.as_deref()
+        })
+        .ok_or_else(|| {
+            PacedTrainError::OperationalPointNotFound {
+                reference: operational_point_reference.clone(),
+            }
+            .into()
+        }),
+    }
 }
 
 #[cfg_attr(test, derive(serde::Serialize))]
@@ -1481,6 +1571,7 @@ mod tests {
     use schemas::paced_train::TrainSchedule;
     use schemas::rolling_stock::TrainCategory;
     use schemas::train_schedule::Comfort;
+    use schemas::train_schedule::OperationalPointReference;
     use schemas::train_schedule::PathItem;
     use schemas::train_schedule::ScheduleItem;
     use schemas::train_schedule::TrainOccurrence;
@@ -1508,8 +1599,9 @@ mod tests {
     use crate::views::timetable::paced_train::OccupancyBlocksPacedTrainResult;
     use crate::views::timetable::paced_train::PacedTrainSummaryResponse;
     use crate::views::timetable::paced_train::ProjectPathPacedTrainResult;
-    use crate::views::timetable::paced_train::TrackOccupancy;
     use crate::views::timetable::paced_train::TrackOccupancyForm;
+    use crate::views::timetable::paced_train::TrackReference;
+    use crate::views::timetable::paced_train::TrackSectionOccupancy;
     use crate::views::timetable::paced_train::TrainScheduleResponse;
     use crate::views::timetable::simulation;
     use crate::views::timetable::simulation::SimulationResponseSuccess;
@@ -2474,7 +2566,7 @@ mod tests {
 
     async fn init_paced_train_test(
         exceptions: Vec<PacedTrainException>,
-        operational_point_id: String,
+        operational_point_reference: OperationalPointReference,
     ) -> TestResponse {
         let mut core = MockingClient::new();
         core.stub("/pathfinding/blocks")
@@ -2514,7 +2606,7 @@ mod tests {
             .post("/paced_train/track_occupancy")
             .json(&TrackOccupancyForm {
                 paced_train_ids: vec![paced_train.id],
-                operational_point_id,
+                operational_point_reference,
                 infra_id: small_infra.id,
                 electrical_profile_set_id: None,
                 use_simulation: true,
@@ -2534,24 +2626,37 @@ mod tests {
         #[case] exceptions: Vec<PacedTrainException>,
         #[case] paced_trains: usize,
     ) {
-        let response = init_paced_train_test(exceptions, "Mid_West_station".to_string());
-        let track_occupancies: HashMap<String, Vec<TrackOccupancy>> =
+        let response = init_paced_train_test(
+            exceptions,
+            OperationalPointReference::Id {
+                operational_point: "Mid_West_station".into(),
+            },
+        );
+        let track_occupancies: Vec<TrackSectionOccupancy> =
             response.await.assert_status(StatusCode::OK).json_into();
 
         assert_eq!(track_occupancies.len(), 1);
-        assert_eq!(
-            track_occupancies
-                .get("TC1")
-                .expect("Expected track occupancies for TC1 but none were found")
-                .len(),
-            paced_trains
-        );
+        let tc1_item = track_occupancies
+            .iter()
+            .find(|x| {
+                x.track_reference
+                    == Some(TrackReference::TrackId {
+                        id: "TC1".to_string(),
+                    })
+            })
+            .expect("TC1 track reference not found");
+        assert_eq!(tc1_item.trains.len(), paced_trains);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn paced_train_returns_empty_track_occupancies() {
-        let response = init_paced_train_test(Vec::new(), "West_station".to_string());
-        let track_occupancies: HashMap<String, Vec<TrackOccupancy>> =
+        let response = init_paced_train_test(
+            Vec::new(),
+            OperationalPointReference::Id {
+                operational_point: "West_station".into(),
+            },
+        );
+        let track_occupancies: Vec<TrackSectionOccupancy> =
             response.await.assert_status(StatusCode::OK).json_into();
 
         assert!(track_occupancies.is_empty());

--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -154,7 +154,7 @@
       "ExceptionNotFound": "Exception '{{exception_key}}' could not be found",
       "InfraNotFound": "Infrastructure '{{infra_id}}' could not be found",
       "NotFound": "Paced train '{{paced_train_id}}' could not be found",
-      "OperationalPointNotFound": "Operational point '{{operational_point_id}}' could not be found",
+      "OperationalPointNotFound": "Operational point '{{reference}}' could not be found",
       "PathfindingFailed": "Pathfinding failed for paced train '{{paced_train_id}}'",
       "RollingStockNotFound": "Rolling Stock '{{rolling_stock_name}}' could not be found",
       "SimulationFailed": "Simulation failed for paced train '{{paced_train_id}}'",

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -154,7 +154,7 @@
       "ExceptionNotFound": "Exception '{{exception_key}}' non trouvée",
       "InfraNotFound": "Infrastructure '{{infra_id}}' non trouvée",
       "NotFound": "Mission '{{paced_train_id}}' non trouvée",
-      "OperationalPointNotFound": "Point remarquable '{{operational_point_id}}' non trouvé",
+      "OperationalPointNotFound": "Point remarquable '{{reference}}' non trouvé",
       "PathfindingFailed": "La recherche de chemin n'a pas abouti pour la mission '{{paced_train_id}}'",
       "RollingStockNotFound": "Matériel roulant '{{rolling_stock_name}}' non trouvé",
       "SimulationFailed": "La simulation n'a pas abouti pour la mission '{{paced_train_id}}'",

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -2044,7 +2044,24 @@ export type PostPacedTrainSimulationSummaryApiArg = {
 };
 export type PostPacedTrainTrackOccupancyApiResponse =
   /** status 200 Track section occupancy periods for paced trains */ {
-    [key: string]: ((
+    /** Which track section the train is on at the queried operational point.
+    
+    - `null`: no track could be determined (trains are in no-simulation, no `local_track_name`)
+    - `track_id`: track resolved via pathfinding or `local_track_name` lookup
+    - `track_name`: `local_track_name` given but not matched to any track ID */
+    track_reference?:
+      | null
+      | (
+          | {
+              id: string;
+              type: 'track_id';
+            }
+          | {
+              name: string;
+              type: 'track_name';
+            }
+        );
+    trains: ((
       | {
           id: number;
           index: number;
@@ -2065,12 +2082,12 @@ export type PostPacedTrainTrackOccupancyApiResponse =
       duration: string;
       time_begin: string;
     })[];
-  };
+  }[];
 export type PostPacedTrainTrackOccupancyApiArg = {
   body: {
     electrical_profile_set_id?: number | null;
     infra_id: number;
-    operational_point_id: string;
+    operational_point_reference: OperationalPointReference;
     paced_train_ids: number[];
     use_simulation: boolean;
   };

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -1870,19 +1870,19 @@ export type PostLevelCrossingOccupancyApiResponse =
   /** status 200 Occupancy periods of the given level crossings */ {
     [key: string]: ((
       | {
-          id: number;
           index: number;
+          train_schedule_id: number;
           type: 'base';
         }
       | {
           exception_key: string;
-          id: number;
           index: number;
+          train_schedule_id: number;
           type: 'modified';
         }
       | {
           exception_key: string;
-          id: number;
+          train_schedule_id: number;
           type: 'created';
         }
     ) & {
@@ -2063,19 +2063,19 @@ export type PostPacedTrainTrackOccupancyApiResponse =
         );
     trains: ((
       | {
-          id: number;
           index: number;
+          train_schedule_id: number;
           type: 'base';
         }
       | {
           exception_key: string;
-          id: number;
           index: number;
+          train_schedule_id: number;
           type: 'modified';
         }
       | {
           exception_key: string;
-          id: number;
+          train_schedule_id: number;
           type: 'created';
         }
     ) & {
@@ -4714,19 +4714,19 @@ export type Conflict = {
   /** List of trains involved in the conflict. */
   train_ids: (
     | {
-        id: number;
         index: number;
+        train_schedule_id: number;
         type: 'base';
       }
     | {
         exception_key: string;
-        id: number;
         index: number;
+        train_schedule_id: number;
         type: 'modified';
       }
     | {
         exception_key: string;
-        id: number;
+        train_schedule_id: number;
         type: 'created';
       }
   )[];

--- a/front/src/modules/conflict/__tests__/utils.spec.ts
+++ b/front/src/modules/conflict/__tests__/utils.spec.ts
@@ -24,9 +24,9 @@ describe('addTrainNamesToConflicts', () => {
 
     const conflict = conflictBase({
       train_ids: [
-        { id: 10, type: 'base', index: 0 },
-        { id: 20, type: 'base', index: 8 },
-        { id: 20, type: 'created', exception_key: 'abc' },
+        { train_schedule_id: 10, type: 'base', index: 0 },
+        { train_schedule_id: 20, type: 'base', index: 8 },
+        { train_schedule_id: 20, type: 'created', exception_key: 'abc' },
       ],
     });
 
@@ -43,7 +43,7 @@ describe('filterAndReorderConflict - filtering', () => {
   it('keeps conflict when name matches', () => {
     const conflict: ConflictWithTrainNames = {
       ...conflictBase({
-        train_ids: [{ id: 2, type: 'base', index: 0 }],
+        train_ids: [{ train_schedule_id: 2, type: 'base', index: 0 }],
       }),
       trainsData: [
         { name: '1234', category: null },
@@ -58,7 +58,7 @@ describe('filterAndReorderConflict - filtering', () => {
 
   it('drops conflict when name does not match', () => {
     const conflict: ConflictWithTrainNames = {
-      ...conflictBase({ train_ids: [{ id: 1, type: 'base', index: 0 }] }),
+      ...conflictBase({ train_ids: [{ train_schedule_id: 1, type: 'base', index: 0 }] }),
       trainsData: [
         { name: '1234', category: null },
         { name: '1236', category: null },

--- a/front/src/modules/conflict/utils.ts
+++ b/front/src/modules/conflict/utils.ts
@@ -12,7 +12,7 @@ function getConflictTrainNames(
 ): string[] {
   const trainNames: string[] = [];
   conflict.train_ids.forEach((train) => {
-    const pacedTrain = trainMap.get(formatEditoastIdToPacedTrainId(train.id));
+    const pacedTrain = trainMap.get(formatEditoastIdToPacedTrainId(train.train_schedule_id));
     if (!pacedTrain) return;
 
     if (train.type === 'base') {
@@ -25,7 +25,7 @@ function getConflictTrainNames(
     }
 
     if (!isPacedTrainBase(pacedTrain))
-      throw new Error(`Train with id ${train.id} should be a paced train`);
+      throw new Error(`Train with id ${train.train_schedule_id} should be a paced train`);
 
     if (train.type === 'modified') {
       // Updated exception
@@ -61,7 +61,7 @@ function getConflictTrainCategories(
 ): (TrainCategory | null)[] {
   // /!\ TODO: we don't use the exceptions here to get the correct categories
   return conflict.train_ids.map((train) => {
-    const pacedTrain = trainMap.get(formatEditoastIdToPacedTrainId(train.id));
+    const pacedTrain = trainMap.get(formatEditoastIdToPacedTrainId(train.train_schedule_id));
     return pacedTrain?.category ?? null;
   });
 }

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/zones.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/zones.ts
@@ -54,7 +54,7 @@ function getTimeToPosition(
 export function getMovableOccupancyZone(
   trackId: string,
   trainId: TrainId,
-  occupation: PostPacedTrainTrackOccupancyApiResponse[string][number],
+  occupation: PostPacedTrainTrackOccupancyApiResponse[number]['trains'][number],
   spaceTimeCurves: BaseTrainProjection['spaceTimeCurves'],
   trainName: string,
   departureTime: Date,

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useTrackOccupancy.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useTrackOccupancy.ts
@@ -202,7 +202,7 @@ const useTrackOccupancy = ({
           const trackId =
             track_reference.type === 'track_id' ? track_reference.id : track_reference.name;
           for (const occupation of trains) {
-            const pacedId = formatEditoastIdToPacedTrainId(occupation.id);
+            const pacedId = formatEditoastIdToPacedTrainId(occupation.train_schedule_id);
             const train = trainsCollection[pacedId];
 
             if (!train) throw new Error(`No train found for id ${pacedId}`);

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useTrackOccupancy.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useTrackOccupancy.ts
@@ -54,6 +54,18 @@ function extractStationLabel(
   return stationLabel.label;
 }
 
+function getOperationalPointReference(
+  op: PathOperationalPoint | undefined
+): OperationalPointReference | undefined {
+  if (!op) return undefined;
+  if (op.opId) return { type: 'id', operational_point: op.opId };
+  const trigram = op.extensions?.sncf?.trigram;
+  if (trigram) return { type: 'trigram', trigram, secondary_code: op.extensions?.sncf?.ch };
+  const uic = op.extensions?.identifier?.uic;
+  if (uic != null) return { type: 'uic', uic, secondary_code: op.extensions?.sncf?.ch };
+  return undefined;
+}
+
 /**
  * This hook handles track occupancy zones lifecycle.
  *
@@ -157,10 +169,10 @@ const useTrackOccupancy = ({
 
   const fetchTrackOccupancy = useCallback(
     async (
-      opId: string | undefined | null,
+      opRef: OperationalPointReference | undefined | null,
       trainsCollection: Record<TimetableItemId, TrainSpaceTimeData>
     ): Promise<MovableOccupancyZone[]> => {
-      if (!opId) return [];
+      if (!opRef) return [];
 
       const pacedTrainIds: PacedTrainId[] = [];
       for (const id of Object.keys(trainsCollection)) {
@@ -170,7 +182,7 @@ const useTrackOccupancy = ({
       const bodyForPaced =
         pacedTrainIds.length > 0
           ? {
-              operational_point_id: opId,
+              operational_point_reference: opRef,
               infra_id: infraId,
               paced_train_ids: pacedTrainIds.map(extractEditoastIdFromPacedTrainId),
               use_simulation: isSimulationEnabled,
@@ -184,8 +196,12 @@ const useTrackOccupancy = ({
       const zones: MovableOccupancyZone[] = [];
 
       if (pacedResp?.data) {
-        for (const [trackId, occupations] of Object.entries(pacedResp.data)) {
-          for (const occupation of occupations) {
+        for (const trackItem of pacedResp.data) {
+          const { track_reference, trains } = trackItem;
+          if (!track_reference) continue;
+          const trackId =
+            track_reference.type === 'track_id' ? track_reference.id : track_reference.name;
+          for (const occupation of trains) {
             const pacedId = formatEditoastIdToPacedTrainId(occupation.id);
             const train = trainsCollection[pacedId];
 
@@ -312,7 +328,7 @@ const useTrackOccupancy = ({
           Array.from(timetableItemProjectionsById.keys()),
           (ids) =>
             fetchTrackOccupancy(
-              waypoint.opId,
+              getOperationalPointReference(waypoint),
               Object.fromEntries(ids.map((id) => [id, timetableItemProjectionsById.get(id)!]))
             ),
           {
@@ -359,12 +375,12 @@ const useTrackOccupancy = ({
 
         // refresh zones when reopening waypoint, if TOD was closed.
         if (!currentSelected && newSelected) {
-          const opId = pathOpsByWaypointId.get(waypointId)?.opId;
-          if (!opId) return;
+          const opRef = getOperationalPointReference(pathOpsByWaypointId.get(waypointId));
+          if (!opRef) return;
 
           const trains = Object.fromEntries(Array.from(timetableItemProjectionsById.entries()));
 
-          fetchTrackOccupancy(opId, trains).then((newZones) => {
+          fetchTrackOccupancy(opRef, trains).then((newZones) => {
             if (!newZones.length) return;
 
             updatePathOperationalPointState(waypointId, (state) =>
@@ -432,9 +448,12 @@ const useTrackOccupancy = ({
         const draggedTrainEditoastId = draggedTrainId;
         await Promise.all(
           [...impactedPathOperationalPointIDs].map(async (waypointId) => {
-            const newZones = await fetchTrackOccupancy(pathOpsByWaypointId.get(waypointId)?.opId, {
-              [draggedTrainEditoastId]: newTrainData,
-            });
+            const newZones = await fetchTrackOccupancy(
+              getOperationalPointReference(pathOpsByWaypointId.get(waypointId)),
+              {
+                [draggedTrainEditoastId]: newTrainData,
+              }
+            );
 
             if (newZones.length)
               setPathOperationalPointsState((state) => {
@@ -583,7 +602,7 @@ const useTrackOccupancy = ({
     if (addedTrainIDs.size || modifiedTrainIDs.size) {
       forEach(pathOperationalPointsState, async (_, waypointId) => {
         const newZones = await fetchTrackOccupancy(
-          pathOpsByWaypointId.get(waypointId)?.opId,
+          getOperationalPointReference(pathOpsByWaypointId.get(waypointId)),
           Object.fromEntries(
             [...addedTrainIDs, ...modifiedTrainIDs].map((id) => [
               id,


### PR DESCRIPTION
Part of https://github.com/OpenRailAssociation/osrd/issues/15153

The `operational_point_reference` field in the track occupancy endpoint previously only accepted `operational_point_id`. It now supports three variants: `id`, `trigram` and `uic`.

The `track_reference` field in the response is now a typed enum instead of a plain string.

The `OccurrenceId.id` field is also renamed to `train_schedule_id` for clarity.

The frontend and error messages are updated to match.

> [!IMPORTANT]
`TrackReference::TrackName` variant is added to the schema but not yet used (marked with `#[allow(dead_code)]`). It is intentionally included now to prepare the OpenAPI schema for the next PR, which will update the track occupancy logic to make use of it.