### PR TITLE
editoast: remove `path_item_positions` from `SimulationSummary`

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -12997,7 +12997,6 @@ components:
         - path_item_times_base
         - path_item_respect_times
         - path_item_respect_margins
-        - path_item_positions
         - status
         properties:
           energy_consumption:
@@ -13009,16 +13008,6 @@ components:
             format: int64
             description: Length of a path in mm
             minimum: 0
-          path_item_positions:
-            type: array
-            items:
-              type: integer
-              format: int64
-              minimum: 0
-            description: |-
-              The path offset in mm of each path item given as input of the pathfinding
-              The length of this array is the number of path items in the train schedule used as input for the simulation.
-              The first value is always `0` (beginning of the path) and the last one is always equal to the `length` of the path in mm
           path_item_respect_margins:
             type: array
             items:

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -352,7 +352,7 @@ pub(in crate::views) async fn simulation_summary(
     let mut base_simulation = Arc::clone(&simulations[0].0);
     let results = simulation_contexts.into_iter().zip(simulations).fold(
         HashMap::<i64, PacedTrainSummaryResponse>::new(),
-        |mut map, (simulation_context, (simulation, path))| {
+        |mut map, (simulation_context, (simulation, _path))| {
             if let Some(exception_key) = &simulation_context.exception_key {
                 if !Arc::ptr_eq(&base_simulation, &simulation) {
                     map.entry(simulation_context.paced_train_id)
@@ -361,7 +361,6 @@ pub(in crate::views) async fn simulation_summary(
                                 exception_key.to_string(),
                                 SummaryResponse::summarize_simulation(
                                     Arc::unwrap_or_clone(simulation),
-                                    Arc::unwrap_or_clone(path),
                                     &simulation_context.train_schedule,
                                 ),
                             );
@@ -374,7 +373,6 @@ pub(in crate::views) async fn simulation_summary(
                     PacedTrainSummaryResponse {
                         paced_train: SummaryResponse::summarize_simulation(
                             Arc::unwrap_or_clone(simulation),
-                            Arc::unwrap_or_clone(path),
                             &simulation_context.train_schedule,
                         ),
                         exceptions: HashMap::new(),
@@ -2065,7 +2063,6 @@ mod tests {
                     path_item_times_base: vec![0, 1, 2, 3],
                     path_item_respect_times: vec![true, false, true, false],
                     path_item_respect_margins: vec![true, true, true, true],
-                    path_item_positions: vec![0, 1, 2, 3]
                 },
                 exceptions: [(
                     "change_initial_speed".to_string(),
@@ -2080,7 +2077,6 @@ mod tests {
                         path_item_times_base: vec![0, 1, 2, 3],
                         path_item_respect_times: vec![true, false, true, false],
                         path_item_respect_margins: vec![true, true, true, true],
-                        path_item_positions: vec![0, 1, 2, 3]
                     }
                 )]
                 .into_iter()

--- a/editoast/src/views/timetable/simulation.rs
+++ b/editoast/src/views/timetable/simulation.rs
@@ -284,10 +284,6 @@ pub enum SummaryResponse {
         /// The length of this array is the number of path items in the train schedule used as input for the simulation.
         /// Important: `true` means the provisional time is acceptable margin-wise, not *precisely* respecting the margin.
         path_item_respect_margins: Vec<bool>,
-        /// The path offset in mm of each path item given as input of the pathfinding
-        /// The length of this array is the number of path items in the train schedule used as input for the simulation.
-        /// The first value is always `0` (beginning of the path) and the last one is always equal to the `length` of the path in mm
-        path_item_positions: Vec<u64>,
     },
     /// Pathfinding not found
     PathfindingNotFound(PathfindingNotFound),
@@ -302,19 +298,10 @@ pub enum SummaryResponse {
 impl SummaryResponse {
     pub fn summarize_simulation<T: TrainScheduleLike>(
         response: simulation::Response,
-        path: PathfindingResult,
         train_schedule: &T,
     ) -> Self {
         match response {
             simulation::Response::Success(sim) => {
-                let PathfindingResult::Success(PathfindingResultSuccess {
-                    path_item_positions,
-                    ..
-                }) = path
-                else {
-                    panic!("Pathfinding cannnot fail if the simulation has succeeded")
-                };
-
                 let path_item_respect_times = sim.path_item_respect_times(train_schedule);
                 let path_item_respect_margins = sim.path_item_respect_margins(train_schedule);
 
@@ -334,7 +321,6 @@ impl SummaryResponse {
                     path_item_times_base: base.path_item_times.clone(),
                     path_item_respect_times,
                     path_item_respect_margins,
-                    path_item_positions: path_item_positions.clone(),
                 }
             }
             simulation::Response::PathfindingFailed { pathfinding_failed } => {

--- a/front/src/applications/operationalStudies/__tests__/sampleData.ts
+++ b/front/src/applications/operationalStudies/__tests__/sampleData.ts
@@ -321,7 +321,6 @@ export const trainSummaryTooFast: Extract<SimulationSummaryResult, { status: 'su
   path_item_times_base: [0, 1444453, 2491479],
   path_item_respect_times: [true, true, true],
   path_item_respect_margins: [true, false, true],
-  path_item_positions: [0, 1000, 2000],
 };
 
 export const trainSummaryTooFastOnInterval: Extract<
@@ -337,7 +336,6 @@ export const trainSummaryTooFastOnInterval: Extract<
   path_item_times_base: [0, 4730243, 13828795],
   path_item_respect_times: [true, true, true],
   path_item_respect_margins: [true, true, false],
-  path_item_positions: [0, 1000, 2000],
 };
 
 export const trainSummaryNotHonored: Extract<SimulationSummaryResult, { status: 'success' }> = {
@@ -350,7 +348,6 @@ export const trainSummaryNotHonored: Extract<SimulationSummaryResult, { status: 
   path_item_times_base: [0, 1425534, 2186885],
   path_item_respect_times: [true, false, true],
   path_item_respect_margins: [true, true, true],
-  path_item_positions: [0, 1000, 2000],
 };
 
 export const trainScheduleHonored: TimetableItem = {
@@ -420,5 +417,4 @@ export const trainSummaryHonored: Extract<SimulationSummaryResult, { status: 'su
   path_item_times_base: [0, 2186885],
   path_item_respect_times: [true, true],
   path_item_respect_margins: [true, true],
-  path_item_positions: [0, 1000],
 };

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -3787,10 +3787,6 @@ export type SimulationSummaryResult =
       energy_consumption: number;
       /** Length of a path in mm */
       length: number;
-      /** The path offset in mm of each path item given as input of the pathfinding
-    The length of this array is the number of path items in the train schedule used as input for the simulation.
-    The first value is always `0` (beginning of the path) and the last one is always equal to the `length` of the path in mm */
-      path_item_positions: number[];
       /** Whether the final path times respect the input margins for each train schedule path item.
     The length of this array is the number of path items in the train schedule used as input for the simulation.
     Important: `true` means the provisional time is acceptable margin-wise, not *precisely* respecting the margin. */


### PR DESCRIPTION
The `path_item_positions` is relative to a pathfinding, and not the simulation. It is already present inside the pathfinding response, so it is still available if needed.

ℹ️ The field `path_item_positions` was not used in the `front` (the pathfinding one is used instead).