### PR TITLE
front: fix invalid occurrence train marker color

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/OccurrenceItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/OccurrenceItem.tsx
@@ -220,6 +220,7 @@ const OccurrenceItem = ({
     >
       <div
         className={cx('main', {
+          invalid: !disabled && summary && !summary.isValid,
           warning: !disabled && summary && (!summary.isValid || !!summary.notHonoredReason),
           'not-honored': !disabled && summary?.isValid && !!summary.notHonoredReason,
         })}


### PR DESCRIPTION
make occurrences for invalid paced trains the same color as invalid paced trains (red).

keep the color of valid paced train occurrences that do not respect their times as orange.

Close #15328 

# How to test

Using the instructions in #15328 or using this timetable on small infra:
[timetable(15).json](https://github.com/user-attachments/files/25419154/timetable.15.json)

notice that trains and occurrences that have unrecognized rolling stocks are both red instead of what the screenshot shows in the bug report.