### PR TITLE
osm_to_railjson: add a tracing subscriber

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -3339,6 +3339,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/editoast/osm_to_railjson/Cargo.toml
+++ b/editoast/osm_to_railjson/Cargo.toml
@@ -12,6 +12,7 @@ osm4routing = "0.8"
 schemas.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
+tracing-subscriber.workspace = true
 
 [dev-dependencies]
 rstest.workspace = true

--- a/editoast/osm_to_railjson/src/main.rs
+++ b/editoast/osm_to_railjson/src/main.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 use std::path::PathBuf;
+use tracing_subscriber::EnvFilter;
 
 #[derive(Parser)]
 #[command(about, long_about = "Extracts a railjson from OpenStreetMap data")]
@@ -11,6 +12,10 @@ pub struct OsmToRailjsonArgs {
 }
 
 fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .init();
+
     let args = OsmToRailjsonArgs::parse();
     osm_to_railjson::osm_to_railjson(args.osm_pbf_in, args.railjson_out)
         .expect("Could not convert osm to railjson");


### PR DESCRIPTION
osm_to_railjson is a lib and a binary.
It has tracing event, which are probably consumed by the caller when it's used as a lib.
But the binary don't have a subscriber to consume those event.
I added one.