### PR TITLE
front, git: replace commited overrides.json with readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ __pycache__
 
 # Helper script
 .osrd-compose-state
+
+# Deployment overrides
+/front/public/overrides/overrides.json

--- a/front/public/overrides/README.md
+++ b/front/public/overrides/README.md
@@ -1,0 +1,9 @@
+# Overrides
+
+In order to configure the app, you can provide a json `overrides.json` file located in [`front/public/locales/overrides/`](.).
+
+This contains both settings aimed at deployment in production, such as custom module names and logos, as well as generally useful settings even when developing locally, such as the railway manager interface url.
+
+Please consult the `Overrides` typescript type in [useDeploymentSettings.tsx](../../src/utils/hooks/useDeploymentSettings.tsx) for a full list of available settings, as well as their expected structure.
+
+Each top level field of `overrides.json`, as well as the file itself, are entirely optional. Some features, such as the railway manager interface, may however be disabled by default.

--- a/front/public/overrides/overrides.json
+++ b/front/public/overrides/overrides.json
@@ -1,1 +1,0 @@
-{ "railway_manager_interface_url": null }

--- a/front/src/utils/hooks/useDeploymentSettings.tsx
+++ b/front/src/utils/hooks/useDeploymentSettings.tsx
@@ -40,6 +40,31 @@ export type DeploymentSettings = {
   railwayManagerInterfaceUrl?: string;
 };
 
+type Overrides = {
+  /** Url of your railway manager interface if any. Also useful in dev. Can also be a relative url inside the gateway container, such as "/tartine". */
+  railway_manager_interface_url?: string;
+  /** Email that stdcm users should use in order to submit feedback. */
+  stdcm_feedback_mail?: string;
+  /** Whether the options to edit the rail infrastructure should be visible to users. */
+  no_infra_edit?: boolean;
+  /** Custom names to display to users for the osrd modules. */
+  names?: {
+    operational_studies?: string;
+    stdcm?: string;
+  };
+  /** Paths to custom icons to display to users for the osrd modules. */
+  icons?: {
+    operational_studies?: {
+      logo: string;
+      logo_with_name: string;
+    };
+    stdcm?: {
+      logo: string;
+      simulation_sheet_logo: string;
+    };
+  };
+};
+
 export type DeploymentSettingsContext = {
   isLoading: boolean;
   deploymentSettings?: DeploymentSettings;
@@ -82,7 +107,7 @@ export const DeploymentContextProvider = ({ children }: DeploymentContextProvide
             },
           });
         } else {
-          const overridesData = await response.json();
+          const overridesData = (await response.json()) as Overrides;
           const {
             icons,
             names,


### PR DESCRIPTION
Stop commiting front/public/overrides/overrides.json in order to work on raimi with a clean git tree.

In its place, add a readme that roughly explains the expected structure and goal of the file.

(I added a completely random name for the railway_manager_interface_url example, I can remove it if it's not serious enough ;p)