### PR TITLE
e2e: filter timetable items to display only paced trains

### DIFF
--- a/front/tests/02-operational-studies/timetable/001-train-timetable.spec.ts
+++ b/front/tests/02-operational-studies/timetable/001-train-timetable.spec.ts
@@ -102,9 +102,14 @@ test.describe('@op @timetable-items', () => {
 
   /** *************** Test 3 **************** */
   test('Loading timetable items and verifying paced trains display', async ({
+    scenarioTimetableSection,
     pacedTrainSection,
   }) => {
     await test.step('Verify each imported paced train card and its occurrences', async () => {
+      await scenarioTimetableSection.filterTrainTypeAndVerifyTrainCount(
+        'Service',
+        TOTAL_PACED_TRAINS
+      );
       for (let pacedTrainIndex = 0; pacedTrainIndex < 7; pacedTrainIndex += 1) {
         await pacedTrainSection.verifyPacedTrainItemDetails(
           IMPORTED_PACED_TRAIN_DETAILS[pacedTrainIndex],


### PR DESCRIPTION
Due to the full display of the timetable (paced trains + unique trains), the test sometimes fails when clicking on the last element.
To limit this, I applied a filter to display only the paced trains.

Failed builds exemple  : 

- https://github.com/OpenRailAssociation/osrd/actions/runs/22234790917
- https://github.com/OpenRailAssociation/osrd/actions/runs/22233651775