### PR TITLE
editoast: return 201 status on timetable creation

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -3745,14 +3745,12 @@ paths:
       - timetable
       summary: Create a timetable
       responses:
-        '200':
+        '201':
           description: Timetable with train schedule ids
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/TimetableResult'
-        '404':
-          description: Timetable not found
   /timetable/{id}:
     delete:
       tags:

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -118,14 +118,13 @@ pub struct TimetableIdParam {
     post, path = "",
     tag = "timetable",
     responses(
-        (status = 200, description = "Timetable with train schedule ids", body = TimetableResult),
-        (status = 404, description = "Timetable not found"),
+        (status = 201, description = "Timetable with train schedule ids", body = TimetableResult),
     ),
 )]
 pub(in crate::views) async fn post(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
     Extension(auth): AuthenticationExt,
-) -> Result<Json<TimetableResult>> {
+) -> Result<impl IntoResponse> {
     let authorized = auth
         .check_roles([authz::Role::OperationalStudies].into())
         .await
@@ -137,8 +136,9 @@ pub(in crate::views) async fn post(
     let conn = &mut db_pool.get().await?;
 
     let timetable = Timetable::changeset().create(conn).await?;
+    let response: TimetableResult = timetable.into();
 
-    Ok(Json(timetable.into()))
+    Ok((StatusCode::CREATED, Json(response)))
 }
 
 /// Delete a timetable
@@ -949,7 +949,7 @@ mod tests {
         let created_timetable: TimetableResult = app
             .fetch(request)
             .await
-            .assert_status(StatusCode::OK)
+            .assert_status(StatusCode::CREATED)
             .json_into();
 
         let retrieved_timetable =

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -2357,7 +2357,7 @@ export type PostTemporarySpeedLimitGroupApiArg = {
   };
 };
 export type PostTimetableApiResponse =
-  /** status 200 Timetable with train schedule ids */ TimetableResult;
+  /** status 201 Timetable with train schedule ids */ TimetableResult;
 export type PostTimetableApiArg = void;
 export type DeleteTimetableByIdApiResponse = unknown;
 export type DeleteTimetableByIdApiArg = {


### PR DESCRIPTION
Updates the timetable creation endpoint to return the correct HTTP status code for resource creation (201 Created) :

* Changed the HTTP response code for successful timetable creation from 200 to 201
* Modified the corresponding test