### PR TITLE
front: fix timetable cache invalidation on train creation

### DIFF
--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -378,7 +378,7 @@ const osrdEditoastApi = generatedEditoastApi
         ],
       },
       postTimetableByIdTrainScheduleSets: {
-        invalidatesTags: () => [{ type: 'train_schedule_set', id: 'LIST' }],
+        invalidatesTags: () => [{ type: 'train_schedule_set', id: 'LIST' }, 'timetable'],
       },
       getTrainScheduleSets: {
         providesTags: (result) => [
@@ -399,7 +399,7 @@ const osrdEditoastApi = generatedEditoastApi
         invalidatesTags: (_result, _error, args) => [{ type: 'train_schedule_set', id: args.id }],
       },
       deleteTrainScheduleSetsById: {
-        invalidatesTags: () => [{ type: 'train_schedule_set', id: 'LIST' }],
+        invalidatesTags: () => [{ type: 'train_schedule_set', id: 'LIST' }, 'timetable'],
       },
     },
   });

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -260,7 +260,7 @@ const osrdEditoastApi = generatedEditoastApi
         invalidatesTags: ['timetable', 'scenarios'],
       },
       postTrainScheduleSetsByIdTrainSchedules: {
-        invalidatesTags: ['train_schedule_set', 'scenarios'],
+        invalidatesTags: ['train_schedule_set', 'scenarios', 'timetable'],
       },
 
       // Project handling


### PR DESCRIPTION
Close https://github.com/OpenRailAssociation/osrd/issues/15330

Note that the predecessor of postTrainScheduleSetsByIdPacedTrains, postTimetableByIdPacedTrains, used to invalidate the timetable. With the move to sets and deletion of postTimetableByIdPacedTrains, this invalidation was lost.

This cache invalidation is not as precise as it should be, but it fixes the app (in particular nge) not reacting to changes at all. A more careful reexamination of our cache invalidation strategies would be appreciated, but is not the goal of this pr.