### PR TITLE
front: style raimi stdcm request url link

### DIFF
--- a/front/public/locales/en/stdcm.json
+++ b/front/public/locales/en/stdcm.json
@@ -173,7 +173,7 @@
         "rollingStock": "towed rolling stock",
         "selectPathType": "Select",
         "stop": "Stop of {{minutes}} at {{stopAt}}",
-        "successMessage": "Request {{demandNumber}} received by GESICO",
+        "successMessage": "Request <requestNumber/> received by GESICO",
         "toleranceAfter": "Future tolerance",
         "toleranceBefore": "Past tolerance",
         "totalLength": "total length",

--- a/front/public/locales/fr/stdcm.json
+++ b/front/public/locales/fr/stdcm.json
@@ -173,7 +173,7 @@
         "rollingStock": "matériel remorqué",
         "selectPathType": "Choisir",
         "stop": "Arrêt de {{minutes}} à {{stopAt}}",
-        "successMessage": "Demande {{demandNumber}} reçue par GESICO",
+        "successMessage": "Demande <requestNumber/> reçue par GESICO",
         "toleranceAfter": "Tolérance aval",
         "toleranceBefore": "Tolérance amont",
         "totalLength": "longueur totale",

--- a/front/src/applications/stdcm/components/StdcmResults/SendToRailwayManagerModal.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/SendToRailwayManagerModal.tsx
@@ -3,7 +3,7 @@ import { useEffect, useMemo, useState, useCallback, type ReactElement } from 're
 import { Button, Checkbox, DatePicker, Input, Select, TextArea } from '@osrd-project/ui-core';
 import { Download, CheckCircle } from '@osrd-project/ui-icons';
 import { pdf, type DocumentProps } from '@react-pdf/renderer';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
 import type {
@@ -554,24 +554,29 @@ const SendToRailwayManagerModal = ({
         <p>{t('modal.followUpMessage')}</p>
         <div className="actions">
           {isSuccess && (
-            <div>
-              {data.created_request_url ? (
-                <a
-                  href={data.created_request_url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="success-message"
+            <div className="success-message">
+              <span>
+                <Trans
+                  components={{
+                    requestNumber: data.created_request_url ? (
+                      <a
+                        href={data.created_request_url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="request-link"
+                      >
+                        {data.request_identifier}
+                      </a>
+                    ) : (
+                      // eslint-disable-next-line react/jsx-no-useless-fragment
+                      <>{data.request_identifier}</>
+                    ),
+                  }}
                 >
-                  {t('modal.successMessage', { demandNumber: data.request_identifier })}
-                </a>
-              ) : (
-                <span className="success-message">
-                  {t('modal.successMessage', { demandNumber: data.request_identifier })}
-                </span>
-              )}
-              <span className="success-icon">
-                <CheckCircle variant="fill" />
+                  {t('modal.successMessage')}
+                </Trans>
               </span>
+              <CheckCircle className="success-icon" variant="fill" />
             </div>
           )}
           <Button

--- a/front/src/applications/stdcm/components/StdcmResults/StdcmResults.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/StdcmResults.tsx
@@ -357,28 +357,29 @@ const StdcmResults = ({
                             }
                           />
                         ) : (
-                          <div>
-                            {railwayRequestUrl ? (
-                              <a
-                                href={railwayRequestUrl}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="success-message"
+                          <div className="success-message">
+                            <span>
+                              <Trans
+                                components={{
+                                  requestNumber: railwayRequestUrl ? (
+                                    <a
+                                      href={railwayRequestUrl}
+                                      target="_blank"
+                                      rel="noopener noreferrer"
+                                      className="request-link"
+                                    >
+                                      {railwayDemandId}
+                                    </a>
+                                  ) : (
+                                    // eslint-disable-next-line react/jsx-no-useless-fragment
+                                    <>{railwayDemandId}</>
+                                  ),
+                                }}
                               >
-                                {t('modal.successMessage', {
-                                  demandNumber: railwayDemandId,
-                                })}
-                              </a>
-                            ) : (
-                              <span className="success-message">
-                                {t('modal.successMessage', {
-                                  demandNumber: railwayDemandId,
-                                })}
-                              </span>
-                            )}
-                            <span className="success-icon">
-                              <CheckCircle variant="fill" />
+                                {t('modal.successMessage')}
+                              </Trans>
                             </span>
+                            <CheckCircle className="check-circle" variant="fill" />
                           </div>
                         ))}
                     </div>

--- a/front/src/applications/stdcm/styles/_railwayManagerModal.scss
+++ b/front/src/applications/stdcm/styles/_railwayManagerModal.scss
@@ -285,19 +285,29 @@
       display: flex;
       gap: 16px;
       white-space: nowrap;
+    }
 
-      div {
-        display: flex;
-        gap: 8px;
-        align-items: center;
-        font-size: 1rem;
-        .success-message {
-          color: var(--success60);
-        }
-        .success-icon {
-          color: var(--success30);
-        }
-      }
+    .request-link {
+      text-decoration: underline;
+      color: var(--primary60);
+    }
+
+    .request-link:hover {
+      color: var(--primary80);
+    }
+
+    .success-message {
+      display: flex;
+      gap: 8px;
+      align-items: center;
+      font-size: 1rem;
+      color: var(--success60);
+    }
+
+    .success-icon {
+      display: flex;
+      align-items: center;
+      color: var(--success30);
     }
   }
 

--- a/front/src/applications/stdcm/styles/_results.scss
+++ b/front/src/applications/stdcm/styles/_results.scss
@@ -153,6 +153,15 @@
     color: var(--success30);
   }
 
+  .request-link {
+    text-decoration: underline;
+    color: var(--primary60);
+  }
+
+  .request-link:hover {
+    color: var(--primary80);
+  }
+
   .success-message {
     display: inline-flex;
     color: var(--success60);


### PR DESCRIPTION
Follow up to https://github.com/OpenRailAssociation/osrd/pull/15266

Add style to the link in accordance with the new mockup in https://github.com/osrd-project/osrd-confidential/issues/1381. 

In order for the link to only apply to part of the translation string, I am using the [Trans component](https://react.i18next.com/latest/trans-component), with the named component syntax that I believe is cleaner and easier to understand and maintain than the default indexed component syntax.

While rewriting the style classes, I've also vertically centered the checkmark icon in the raimi modal message (it was already centered in the stdcm results page message). I've not touched the size of the icon though, even though it seems bigger in the mock up, as this would be too far outside the scope of this pr. 

Here's a video showing both the result, as well as how to test using dummy values without having to actually set up raimi (since the raimi+front behavior has already been tested and this pr is just style):

[gesico_request_monitoring_link_style.webm](https://github.com/user-attachments/assets/492ee027-4cff-483a-915a-b58695364d8f)
