### PR TITLE
editoast: exceptions migration

### DIFF
--- a/editoast/database/src/tables.rs
+++ b/editoast/database/src/tables.rs
@@ -855,7 +855,6 @@ diesel::table! {
         time_window -> Nullable<Interval>,
         interval -> Nullable<Interval>,
         main_category -> Nullable<TrainMainCategory>,
-        exceptions -> Jsonb,
         #[max_length = 255]
         sub_category -> Nullable<Varchar>,
         train_schedule_set_id -> Int8,

--- a/editoast/migrations/2026-04-21-141109-0000_migrate_exceptions/down.sql
+++ b/editoast/migrations/2026-04-21-141109-0000_migrate_exceptions/down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE train_schedule ADD COLUMN exceptions JSONB NOT NULL DEFAULT '[]'::jsonb;
+
+-- We cannot fill in the exceptions column because a train schedule may include multiple exceptions. Since it is not possible to aggregate this data, we have chosen, for the sake of simplicity, not to include it.

--- a/editoast/migrations/2026-04-21-141109-0000_migrate_exceptions/up.sql
+++ b/editoast/migrations/2026-04-21-141109-0000_migrate_exceptions/up.sql
@@ -1,0 +1,26 @@
+INSERT INTO train_schedule_exception (
+    timetable_id,
+    train_schedule_id,
+    key,
+    occurrence_index,
+    disabled,
+    change_groups
+)
+SELECT
+	timetable_train_schedule_set.timetable_id AS timetable_id,
+	train_schedule.id AS train_schedule_id,
+    elem->>'key' AS key,
+    (elem->>'occurrence_index')::INTEGER AS occurrence_index,
+    COALESCE((elem->>'disabled')::BOOLEAN, FALSE) AS disabled,
+    (elem - 'occurrence_index' - 'disabled' - 'key') AS change_groups
+FROM
+    train_schedule
+JOIN train_schedule_set ON train_schedule_set.id = train_schedule.train_schedule_set_id
+JOIN timetable_train_schedule_set ON timetable_train_schedule_set.train_schedule_set_id = train_schedule_set.id
+CROSS JOIN
+    jsonb_array_elements(train_schedule.exceptions) AS elem
+WHERE
+	train_schedule.exceptions IS NOT NULL
+	AND jsonb_array_length(train_schedule.exceptions) > 0;
+
+ALTER TABLE train_schedule DROP COLUMN exceptions;

--- a/editoast/schemas/src/paced_train.rs
+++ b/editoast/schemas/src/paced_train.rs
@@ -1,5 +1,3 @@
-use std::collections::HashSet;
-
 use chrono::DateTime;
 use chrono::Duration;
 use chrono::Utc;
@@ -76,40 +74,6 @@ impl<'de> Deserialize<'de> for TrainSchedule {
                 "Scheduled arrival time on the origin of the path is necessary 0 seconds, but is: '{}'",
                 arrival.num_seconds()
             )));
-        }
-        // Check integrity of the pace in the train schedule
-        if let Some(ref paced) = train_schedule.paced {
-            let mut seen_keys = HashSet::with_capacity(paced.exceptions.len());
-            for e in &paced.exceptions {
-                if !seen_keys.insert(&e.key) {
-                    return Err(serde::de::Error::custom(format!(
-                        "Duplicate exception key: '{}'",
-                        e.key
-                    )));
-                }
-            }
-
-            let time_window_secs = paced.time_window.num_seconds();
-            let interval_secs = paced.interval.num_seconds();
-            // Ideally, we’d use `div_ceil` which is nightly-only at the time of writing
-            // https://doc.rust-lang.org/std/primitive.i64.html#method.div_ceil
-            let num_occurrences = (time_window_secs / interval_secs) as usize
-                + if time_window_secs.rem_euclid(interval_secs) != 0 {
-                    1
-                } else {
-                    0
-                };
-
-            for ex in &paced.exceptions {
-                if let ExceptionType::Modified { occurrence_index } = ex.exception_type
-                    && occurrence_index >= num_occurrences
-                {
-                    return Err(serde::de::Error::custom(format!(
-                        "Modified exception '{}' references invalid occurrence index {}",
-                        ex.key, occurrence_index,
-                    )));
-                }
-            }
         }
         Ok(train_schedule)
     }

--- a/editoast/src/models/fixtures.rs
+++ b/editoast/src/models/fixtures.rs
@@ -21,7 +21,6 @@ use schemas::TrainScheduleExceptionChangeGroups;
 use schemas::infra::InfraObject;
 use schemas::infra::RailJson;
 use schemas::paced_train::Paced;
-use schemas::paced_train::PacedTrainException;
 use schemas::paced_train::TrainNameChangeGroup;
 use schemas::paced_train::TrainSchedule;
 use schemas::primitives::OSRDObject;
@@ -128,18 +127,6 @@ pub async fn create_simple_paced_train(
     train_schedule_set_id: i64,
 ) -> models::TrainSchedule {
     simple_paced_train_changeset(train_schedule_set_id)
-        .create(conn)
-        .await
-        .expect("Failed to create paced train")
-}
-
-pub async fn create_paced_train_with_exceptions(
-    conn: &mut DbConnection,
-    train_schedule_set_id: i64,
-    exceptions: Vec<PacedTrainException>,
-) -> models::TrainSchedule {
-    let paced_train = simple_paced_train_changeset(train_schedule_set_id).exceptions(exceptions);
-    paced_train
         .create(conn)
         .await
         .expect("Failed to create paced train")

--- a/editoast/src/models/train_schedule.rs
+++ b/editoast/src/models/train_schedule.rs
@@ -60,8 +60,41 @@ pub struct TrainSchedule {
     pub main_category: Option<TrainMainCategory>,
     /// Sub category code
     pub sub_category: Option<String>,
-    #[model(json)]
-    pub exceptions: Vec<PacedTrainException>,
+}
+
+/// Transforms the TrainSchedule database type into a paced_train::TrainSchedule schema with exceptions.
+pub fn train_schedule_schema_from_model(
+    train_schedule: TrainSchedule,
+    exceptions: Vec<PacedTrainException>,
+) -> paced_train::TrainSchedule {
+    paced_train::TrainSchedule {
+        train_occurrence: TrainOccurrence {
+            train_name: train_schedule.train_name,
+            labels: train_schedule.labels.to_vec(),
+            rolling_stock_name: train_schedule.rolling_stock_name,
+            start_time: train_schedule.start_time,
+            schedule: train_schedule.schedule,
+            margins: train_schedule.margins,
+            initial_speed: train_schedule.initial_speed,
+            comfort: train_schedule.comfort,
+            path: train_schedule.path,
+            constraint_distribution: train_schedule.constraint_distribution,
+            speed_limit_tag: train_schedule.speed_limit_tag.map(Into::into),
+            power_restrictions: train_schedule.power_restrictions,
+            options: train_schedule.options,
+            category: train_schedule
+                .main_category
+                .map(|main_category| TrainCategory::main(main_category.0))
+                .xor(train_schedule.sub_category.map(TrainCategory::sub)),
+        },
+        paced: train_schedule.time_window.and_then(|time_window| {
+            train_schedule.interval.map(|interval| Paced {
+                time_window: time_window.try_into().unwrap(),
+                interval: interval.try_into().unwrap(),
+                exceptions,
+            })
+        }),
+    }
 }
 
 impl TrainSchedule {
@@ -295,8 +328,7 @@ impl From<paced_train::TrainSchedule> for TrainScheduleChangeset {
                     .map(|p| p.time_window)
                     .map(ChronoDuration::from),
             )
-            .interval(paced.as_ref().map(|p| p.interval).map(ChronoDuration::from))
-            .exceptions(paced.map(|p| p.exceptions).unwrap_or_default());
+            .interval(paced.as_ref().map(|p| p.interval).map(ChronoDuration::from));
 
         match train_occurrence.category {
             Some(TrainCategory::Main { main_category }) => changeset
@@ -306,39 +338,6 @@ impl From<paced_train::TrainSchedule> for TrainScheduleChangeset {
                 .sub_category(Some(sub_category_code))
                 .main_category(None),
             None => changeset.sub_category(None).main_category(None),
-        }
-    }
-}
-
-impl From<TrainSchedule> for paced_train::TrainSchedule {
-    fn from(train_schedule: TrainSchedule) -> Self {
-        Self {
-            train_occurrence: schemas::TrainOccurrence {
-                train_name: train_schedule.train_name,
-                labels: train_schedule.labels.to_vec(),
-                rolling_stock_name: train_schedule.rolling_stock_name,
-                start_time: train_schedule.start_time,
-                schedule: train_schedule.schedule,
-                margins: train_schedule.margins,
-                initial_speed: train_schedule.initial_speed,
-                comfort: train_schedule.comfort,
-                path: train_schedule.path,
-                constraint_distribution: train_schedule.constraint_distribution,
-                speed_limit_tag: train_schedule.speed_limit_tag.map(Into::into),
-                power_restrictions: train_schedule.power_restrictions,
-                options: train_schedule.options,
-                category: train_schedule
-                    .main_category
-                    .map(|main_category| TrainCategory::main(main_category.0))
-                    .xor(train_schedule.sub_category.map(TrainCategory::sub)),
-            },
-            paced: train_schedule.time_window.and_then(|time_window| {
-                train_schedule.interval.map(|interval| Paced {
-                    time_window: time_window.try_into().unwrap(),
-                    interval: interval.try_into().unwrap(),
-                    exceptions: train_schedule.exceptions,
-                })
-            }),
         }
     }
 }
@@ -419,6 +418,7 @@ mod tests {
     use crate::models::fixtures::simple_paced_train_changeset;
     use crate::models::fixtures::simple_sub_category;
     use crate::models::train_schedule::OccurrenceId;
+    use crate::models::train_schedule::train_schedule_schema_from_model;
     use chrono::DateTime;
     use chrono::Utc;
     use database::DbConnectionPoolV2;
@@ -462,7 +462,6 @@ mod tests {
             time_window: chrono::Duration::try_hours(2),
             interval: chrono::Duration::try_minutes(30),
             sub_category: None,
-            exceptions: vec![],
         }
     }
 
@@ -535,7 +534,7 @@ mod tests {
     fn has_same_pace_when_nothing_changed() {
         let train_schedule = create_paced_train();
         let train_schedule_update: schemas::paced_train::TrainSchedule =
-            create_paced_train().into();
+            train_schedule_schema_from_model(create_paced_train(), vec![]);
         assert!(train_schedule.has_same_pace(&train_schedule_update.paced));
     }
 
@@ -543,7 +542,7 @@ mod tests {
     fn has_not_same_pace_when_interval_changed() {
         let train_schedule = create_paced_train();
         let mut train_schedule_update: schemas::paced_train::TrainSchedule =
-            create_paced_train().into();
+            train_schedule_schema_from_model(create_paced_train(), vec![]);
         train_schedule_update.paced.as_mut().unwrap().interval =
             chrono::Duration::minutes(60).try_into().unwrap();
         assert!(!train_schedule.has_same_pace(&train_schedule_update.paced));
@@ -553,7 +552,7 @@ mod tests {
     fn has_not_same_pace_when_time_window_changed() {
         let train_schedule = create_paced_train();
         let mut train_schedule_update: schemas::paced_train::TrainSchedule =
-            create_paced_train().into();
+            train_schedule_schema_from_model(create_paced_train(), vec![]);
         train_schedule_update.paced.as_mut().unwrap().time_window =
             chrono::Duration::hours(4).try_into().unwrap();
         assert!(!train_schedule.has_same_pace(&train_schedule_update.paced));

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -41,8 +41,6 @@ use editoast_models::timetable::Timetable;
 use editoast_models::timetable::TimetableWithTrains;
 use itertools::Itertools;
 use itertools::izip;
-use schemas::paced_train::Paced;
-use schemas::paced_train::TrainSchedule;
 use schemas::rolling_stock::EtcsBrakeParams;
 use schemas::rolling_stock::RollingResistance;
 use schemas::rolling_stock::RollingStock;
@@ -67,6 +65,7 @@ use crate::error::Result;
 use crate::models;
 use crate::models::Infra;
 use crate::models::train_schedule::OccurrenceId;
+use crate::models::train_schedule::train_schedule_schema_from_model;
 use crate::models::train_schedule_set::TrainScheduleSet;
 use crate::views::AuthenticationExt;
 use crate::views::AuthorizationError;
@@ -246,29 +245,17 @@ pub(in crate::views) async fn get_train_schedules(
         .map(|ts| {
             let id = ts.id;
             let train_schedule_set_id = ts.train_schedule_set_id;
-
-            let paced = if let (Some(interval), Some(time_window)) = (ts.interval, ts.time_window) {
-                Some(Paced {
-                    interval: interval.try_into().unwrap(),
-                    time_window: time_window.try_into().unwrap(),
-                    exceptions: exceptions
-                        .remove(&id)
-                        .unwrap_or_default()
-                        .into_iter()
-                        .map_into()
-                        .collect(),
-                })
-            } else {
-                None
-            };
-
+            let exceptions = exceptions
+                .remove(&id)
+                .unwrap_or_default()
+                .into_iter()
+                .map_into()
+                .collect();
+            let train_schedule = train_schedule_schema_from_model(ts, exceptions);
             TrainScheduleResponse {
                 id,
                 train_schedule_set_id,
-                train_schedule: TrainSchedule {
-                    train_occurrence: ts.into_train_occurrence(),
-                    paced,
-                },
+                train_schedule,
             }
         })
         .collect();

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -51,6 +51,7 @@ use crate::models;
 use crate::models::Infra;
 use crate::models::train_schedule::OccurrenceId;
 use crate::models::train_schedule::TrainScheduleChangeset;
+use crate::models::train_schedule::train_schedule_schema_from_model;
 use crate::models::train_schedule_set::TrainScheduleSet;
 use crate::views::AuthorizationError;
 use crate::views::infra::InfraIdQueryParam;
@@ -126,7 +127,7 @@ impl From<models::TrainSchedule> for TrainScheduleResponse {
         Self {
             id: value.id,
             train_schedule_set_id: value.train_schedule_set_id,
-            train_schedule: value.into(),
+            train_schedule: train_schedule_schema_from_model(value, vec![]),
         }
     }
 }
@@ -1918,7 +1919,6 @@ mod tests {
     use crate::error::InternalError;
     use crate::models;
     use crate::models::fixtures::create_fast_rolling_stock;
-    use crate::models::fixtures::create_paced_train_with_exceptions;
     use crate::models::fixtures::create_rolling_stock_with_energy_sources;
     use crate::models::fixtures::create_simple_paced_train;
     use crate::models::fixtures::create_small_infra;
@@ -1931,6 +1931,7 @@ mod tests {
     use crate::models::fixtures::simple_sub_category;
     use crate::models::train_schedule::OccurrenceId;
     use crate::models::train_schedule::TrainScheduleChangeset;
+    use crate::models::train_schedule::train_schedule_schema_from_model;
     use crate::views::path::pathfinding::PathfindingFailure;
     use crate::views::path::pathfinding::PathfindingResult;
     use crate::views::test_app::TestApp;
@@ -2036,7 +2037,8 @@ mod tests {
             created_paced_train.sub_category,
             Some(created_sub_category.code.clone())
         );
-        let created_paced_train: schemas::paced_train::TrainSchedule = created_paced_train.into();
+        let created_paced_train: schemas::paced_train::TrainSchedule =
+            train_schedule_schema_from_model(created_paced_train, vec![]);
 
         assert_eq!(
             created_paced_train.train_occurrence.category,
@@ -2054,8 +2056,7 @@ mod tests {
         let (timetable, train_schedule_set) =
             create_timetable_with_train_schedule_set(&mut pool.get_ok()).await;
 
-        let simple_train_schedule =
-            simple_paced_train_changeset(train_schedule_set.id).exceptions(vec![]);
+        let simple_train_schedule = simple_paced_train_changeset(train_schedule_set.id);
         let train_schedule = simple_train_schedule
             .create(&mut pool.get_ok())
             .await
@@ -2155,7 +2156,10 @@ mod tests {
             .expect("Failed to retrieve updated paced train")
             .expect("Updated paced train not found");
 
-        assert_eq!(paced_train_base, updated_paced_train.into());
+        assert_eq!(
+            paced_train_base,
+            train_schedule_schema_from_model(updated_paced_train, vec![])
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -2214,7 +2218,10 @@ mod tests {
             .assert_status(StatusCode::OK)
             .json_into::<TrainScheduleResponse>();
 
-        assert_eq!(response.train_schedule, paced_train.into());
+        assert_eq!(
+            response.train_schedule,
+            train_schedule_schema_from_model(paced_train, vec![])
+        );
     }
 
     async fn app_infra_id_paced_train_id_for_simulation_tests() -> (
@@ -2803,12 +2810,8 @@ mod tests {
         let (timetable, train_schedule_set) =
             create_timetable_with_train_schedule_set(&mut db_pool.get_ok()).await;
 
-        let train_schedule = create_paced_train_with_exceptions(
-            &mut db_pool.get_ok(),
-            train_schedule_set.id,
-            vec![],
-        )
-        .await;
+        let train_schedule =
+            create_simple_paced_train(&mut db_pool.get_ok(), train_schedule_set.id).await;
 
         let change_rolling_stock_exception = create_train_schedule_exception(
             &mut db_pool.get_ok(),
@@ -2876,12 +2879,8 @@ mod tests {
 
         create_fast_rolling_stock(&mut db_pool.get_ok(), "R2D2").await;
 
-        let train_schedule = create_paced_train_with_exceptions(
-            &mut db_pool.get_ok(),
-            train_schedule_set.id,
-            vec![],
-        )
-        .await;
+        let train_schedule =
+            create_simple_paced_train(&mut db_pool.get_ok(), train_schedule_set.id).await;
 
         let change_train_name_exception = create_train_schedule_exception(
             &mut db_pool.get_ok(),

--- a/editoast/src/views/train_schedule_set.rs
+++ b/editoast/src/views/train_schedule_set.rs
@@ -459,10 +459,6 @@ mod tests {
             .expect("Failed to fetch train schedules");
 
         assert!(list_result.len() == 2);
-        assert_eq!(
-            list_result[0].exceptions,
-            train_schedule_2.paced.unwrap().exceptions
-        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/tests/tests/test_paced_train.py
+++ b/tests/tests/test_paced_train.py
@@ -46,17 +46,7 @@ def test_put_paced_train(
     paced_train = west_to_south_east_paced_train[0]
     paced_train_id = paced_train["id"]
 
-    exception = {
-        "key": "exception_key",
-        "disabled": False,
-        "rolling_stock": {
-            "rolling_stock_name": "etcs_rolling_stock",
-            "comfort": "AIR_CONDITIONING",
-        },
-    }
-
     paced_train["train_name"] = "update_train_name"
-    paced_train["paced"]["exceptions"] = [exception]
 
     update_response = session.put(
         f"{EDITOAST_URL}train_schedules/{paced_train_id}", json=paced_train
@@ -68,7 +58,6 @@ def test_put_paced_train(
     ).json()
 
     assert updated_paced_train["train_name"] == "update_train_name"
-    assert updated_paced_train["paced"]["exceptions"] == [exception]
 
 
 def test_get_paced_train_with_exception_path(


### PR DESCRIPTION
fix https://github.com/OpenRailAssociation/osrd/issues/15503

- [x] Create sql migration script to transform `train_schedule.exceptions` into new table `train_schedule_exceptions`
- [x] Remove train_schedule.exceptions column

Part of https://github.com/OpenRailAssociation/osrd/issues/15202

How to test:
Create a few different exceptions in the dev branch, switch to this branch (reload Docker or apply migrations) and check that the new exceptions are there and everything is working.

> [!NOTE]
> This PR targets a feature branch and may contain all its commits, as it has not been rebased yet. Only the last commit need to be reviewed.