### PR TITLE
front: improve macOS onboarding experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ docker compose up -d --build
 xdg-open http://localhost:4000/
 ```
 
-(Linux or WSL users can use `./osrd-compose host` instead of `docker compose` to enable host networking - useful to launch services in a debugger)
+Linux or WSL users can use `./osrd-compose host` instead of `docker compose` to enable host networking: it can be useful to launch services in a debugger.
+
+macOS users on Apple Silicon should make sure to set an arm64 image name for Postgres/PostGIS (to prevent slow amd64 emulation). This image name can be set by running `export OSRD_POSTGIS_IMAGE='nickblah/postgis:16-postgis-3'` before the first `docker compose` command.
 
 The last-minute train (STDCM) module needs additional setup: start by creating a scenario, copy its ID from its URL, then run:
 

--- a/docker/docker-compose.ext-front.yml
+++ b/docker/docker-compose.ext-front.yml
@@ -1,0 +1,10 @@
+services:
+  gateway:
+    image: ghcr.io/openrailassociation/osrd-${RELEASE_CHANNEL-edge}/osrd-gateway:${TAG-dev}-${GATEWAY_FLAVOR-standalone}
+    volumes:
+      - "./docker/gateway.dev.ext-front.toml:/srv/gateway.toml"
+    build:
+      args:
+        SKIP_FRONT: "1"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"

--- a/docker/gateway.dev.ext-front.toml
+++ b/docker/gateway.dev.ext-front.toml
@@ -1,0 +1,32 @@
+# This config file is copied into the default dev container
+
+# generate a production key with this command:
+# python3 -c "import secrets, base64; print(base64.standard_b64encode(secrets.token_bytes(64)).decode())"
+secret_key = "NOT+A+SECRET++NOT+A+SECRET++NOT+A+SECRET++NOT+A+SECRET++NOT+A+SECRET++NOT+A+SECRET++NOT+A+SECRET"
+
+listen_addr = "0.0.0.0"
+allowed_origins = ["http://127.0.0.1:3000", "http://localhost:3000"]
+
+[telemetry.tracing]
+type = "Otlp"
+endpoint = "http://osrd-jaeger:4317"
+
+[[targets]]
+tracing_name = "editoast"
+prefix = "/api"
+upstream = "http://osrd-editoast:80"
+require_auth = true
+
+[[targets]]
+tracing_name = "front"
+upstream = "http://host.docker.internal:3000"
+require_auth = false
+
+[auth]
+default_provider = "mock"
+secure_cookies = false
+
+[[auth.providers]]
+type = "Mocked"
+provider_id = "mock"
+username = "Example User"

--- a/editoast/README.md
+++ b/editoast/README.md
@@ -228,16 +228,6 @@ configuration for own URL and editoast's prefix).
 > editoast authz rejecting some requests), providing the correct `ROOT_URL` to
 > editoast might be the solution.
 
-## For M1 MacOS users
-
-Our `docker-compose.yml` at the root of the project uses the `postgis` image by default.
-For M1 macs, it requires emulation since it's not compiled for arm platforms, which results
-in a significant slowdown. Define this variable in your environment or in a `.env` file somewhere:
-
-```sh
-export OSRD_POSTGIS_IMAGE='nickblah/postgis:16-postgis-3'
-```
-
 ## Editoast diesel tables model update
 
 After creating a new migration, one should update `database/src/tables.rs` with

--- a/front/README.md
+++ b/front/README.md
@@ -38,6 +38,9 @@ npm run build-ui
 npm start -- --host 127.0.0.1
 ```
 
+Don’t be fooled by Vite’s start message: you should then navigate to http://localhost:4000/ (not `:3000`!)
+to open OSRD, as requests must pass through the `gateway`.
+
 > [!NOTE]
 > We use `--host 127.0.0.1` to let Vite know it should also bind to Docker's `bridge`
 > network interface, so the `gateway` can proxy the requests accordingly.

--- a/front/README.md
+++ b/front/README.md
@@ -8,8 +8,10 @@ A Docker Compose override is provided in `docker/docker-compose.front.yml` to ru
 watch mode together with the rest of the OSRD stack. The osrd-compose script can be used to start
 OSRD in this mode:
 
-    ./osrd-compose dev-front build
-    ./osrd-compose up -d
+```sh
+./osrd-compose dev-front build
+./osrd-compose up -d
+```
 
 The first time the container starts up, the osrd-ui library will be missing. This will trigger some
 build errors, which should go away as soon as osrd-ui gets built. Restarting the front container
@@ -17,13 +19,28 @@ helps getting rid of lingering ESLint errors.
 
 ### Outside of Docker
 
-- go inside `/front/` from OSRD main project
-- you'll need [`npm`](https://nodejs.org/en/download/package-manager)
-- exec `npm install` (hope you have a good connection and a good cup of tea)
-- exec `npm run build-ui`
-- exec `npm start` (perhaps you'll need `NODE_OPTIONS="--openssl-legacy-provider"` if your node
-  version is too new)
-- enjoy
+If for some reason you can't or don't want to use the docker image during development, you can run
+the server directly from your development host.
+
+Everything else is still needed, so let's use `osrd-compose` with the `ext-front` flag:
+
+```sh
+./osrd-compose ext-front build
+./osrd-compose up -d
+```
+
+Make sure `npm` is [installed](https://nodejs.org/en/download), then run:
+
+```sh
+cd ./front/
+npm install
+npm run build-ui
+npm start -- --host 127.0.0.1
+```
+
+> [!NOTE]
+> We use `--host 127.0.0.1` to let Vite know it should also bind to Docker's `bridge`
+> network interface, so the `gateway` can proxy the requests accordingly.
 
 ## Commands
 

--- a/osrd-compose
+++ b/osrd-compose
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -eo pipefail
 
@@ -87,7 +87,9 @@ if [ ${#flags[@]} -gt 0 ]; then
     printf "%s\n" "${flags[@]}" > "$STATE_FILE"
 # If no flags but state exists, load it
 elif [ -f "$STATE_FILE" ]; then
-    mapfile -t flags < "$STATE_FILE"
+    while IFS= read -r flag || [[ -n "$flag" ]]; do
+        flags+=("$flag")
+    done < "$STATE_FILE"
 fi
 
 has_flag() {

--- a/osrd-compose
+++ b/osrd-compose
@@ -17,6 +17,7 @@ This script simplifies docker compose operations by managing override files.
 
 Flags (optional, can be combined):
   dev-front    Add front-end development container (docker/docker-compose.front.yml)
+  ext-front    Use a separately started front-end server (docker/docker-compose.ext-front.yml)
   sw           Enable single worker mode (docker/docker-compose.single-worker.yml)
   host         Use host networking mode (docker/docker-compose.host.yml)
   playwright   Start playwright container with the stack (docker/docker-compose.playwright.yml)
@@ -29,7 +30,7 @@ Examples:
 
 State System:
 The script maintains a state system to remember your last configuration.
-When you run the script with flags (dev-front, sw, host), these choices are saved
+When you run the script with flags (dev-front, sw, host…), these choices are saved
 in a hidden file (.osrd-compose-state). Next time you run the script without
 flags, it will automatically use this saved configuration. This lets you run
 quick commands like 'ps' or 'logs' without re-specifying your setup each time.
@@ -60,7 +61,7 @@ while [[ $# -gt 0 ]]; do
             DEFAULT_FLAG=true
             shift
             ;;
-        dev-front|sw|host|playwright)
+        dev-front|ext-front|sw|host|playwright)
             flags+=("$1")
             shift
             ;;
@@ -106,11 +107,19 @@ if has_flag "sw" && ! has_flag "host"; then
     exit 1
 fi
 
+if has_flag "ext-front" && has_flag "dev-front"; then
+    echo "Error: 'ext-front' and 'dev-front' flags are mutually exclusive."
+    echo "Hint: 'ext-front' should only be used if you are running \`npm start\` on the host."
+    exit 1
+fi
+
 if has_flag "host"; then
     compose_files+=("$OVERRIDE_DIR/docker-compose.host.yml")
 fi
 
-if has_flag "dev-front"; then
+if has_flag "ext-front"; then
+    compose_files+=("$OVERRIDE_DIR/docker-compose.ext-front.yml")
+elif has_flag "dev-front"; then
     if has_flag "host"; then
         compose_files+=("$OVERRIDE_DIR/docker-compose.host-front.yml")
     else


### PR DESCRIPTION
_A very common theme for a first contribution is to make sure to fix the little issues we find during the onboarding process, so here I am_ 😅

On macOS, there is a known issue with the current Docker image for the front that break the file watch system, and provoke annoying refreshes every few seconds.

The first commit add a proper way to run everything but the front development server using docker; the gateway is setup to proxify requests to the host, using the `host.docker.internal` address automatically defined by Docker Compose.

(For the anecdote, host networking on Docker is not required for this to work! this setup run successfully on macOS (tested on Sequoia 15.7.4.)

The second commit simply move around a tip around using an environment variable to switch the Postgres/PostGIS image to an Apple Silicon one. That great advice is not specific to `editoast`, yet it's where it's hosted right now; that second commit lift up this comment to the root README and makes it shorter.