### PR TITLE
front: use rollingstock header in itinerary modal

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModal.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModal.tsx
@@ -23,6 +23,7 @@ import { useMapSettings, useMapSettingsActions } from 'reducers/commonMap';
 import { updatePathSteps } from 'reducers/osrdconf/operationalStudiesConf';
 import {
   getCategory,
+  getName,
   getOperationalStudiesRollingStockID,
   getOperationalStudiesSpeedLimitByTag,
   getPathSteps,
@@ -214,6 +215,12 @@ const ItineraryModal = ({
     }
   };
 
+  // RS name
+  const name = useSelector(getName);
+  const [submitAttempted, setSubmitAttempted] = useState(false);
+
+  const isNameEmpty = !name || name.trim() === '';
+
   useEffect(() => {
     if (
       displayTimetableItemManagement === MANAGE_TIMETABLE_ITEM_TYPES.edit ||
@@ -347,6 +354,8 @@ const ItineraryModal = ({
   };
 
   const submitItinerary = () => {
+    setSubmitAttempted(true);
+    if (isNameEmpty) return;
     if (locatedStepsCount < 2) {
       return;
     }
@@ -392,6 +401,9 @@ const ItineraryModal = ({
             category={category}
             currentSubCategory={currentSubCategory}
             categoryColors={categoryColors}
+            submitAttempted={submitAttempted}
+            name={name}
+            isNameEmpty={isNameEmpty}
           />
         </div>
         <div className="itinerary-modal-form-body">

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModalFormHeader.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModalFormHeader.tsx
@@ -1,6 +1,12 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
-import { ComboBox, Input, Select, useDefaultComboBox } from '@osrd-project/ui-core';
+import {
+  ComboBox,
+  Input,
+  Select,
+  useDefaultComboBox,
+  type StatusWithMessage,
+} from '@osrd-project/ui-core';
 import { isEqual } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
@@ -19,7 +25,6 @@ import useCategoryOptions from 'modules/rollingStock/hooks/useCategoryOptions';
 import useFilterRollingStock from 'modules/rollingStock/hooks/useFilterRollingStock';
 import { updateCategory, updateName } from 'reducers/osrdconf/operationalStudiesConf';
 import {
-  getName,
   getOperationalStudiesRollingStockID,
   getOperationalStudiesSpeedLimitByTag,
 } from 'reducers/osrdconf/operationalStudiesConf/selectors';
@@ -31,6 +36,9 @@ type ItineraryModalFormHeaderProps = {
   category: TrainCategory | null;
   currentSubCategory?: SubCategory;
   categoryColors: CategoryColors;
+  submitAttempted?: boolean;
+  name?: string;
+  isNameEmpty?: boolean;
 };
 
 const ItineraryModalFormHeader = ({
@@ -38,6 +46,9 @@ const ItineraryModalFormHeader = ({
   category,
   currentSubCategory,
   categoryColors,
+  submitAttempted,
+  name,
+  isNameEmpty,
 }: ItineraryModalFormHeaderProps) => {
   const dispatch = useAppDispatch();
   const { updateSpeedLimitByTag, updateRollingStockID } = useOsrdConfActions();
@@ -88,10 +99,21 @@ const ItineraryModalFormHeader = ({
   const speedLimitTags = useSpeedLimitTags();
 
   // Timetable item name
-  const name = useSelector(getName);
   const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     dispatch(updateName(e.target.value));
   };
+  // Timetable item name error
+  const [nameFocused, setNameFocused] = useState(false);
+
+  const nameError: StatusWithMessage | undefined = useMemo(() => {
+    const shouldShowError = (nameFocused || submitAttempted) && isNameEmpty;
+    if (!shouldShowError) return undefined;
+
+    return {
+      status: 'error',
+      message: t('errorMessages.requiredField'),
+    };
+  }, [nameFocused, submitAttempted, isNameEmpty, t]);
 
   // Category warning
   const categoryWarningMessage = useMemo(() => {
@@ -168,6 +190,8 @@ const ItineraryModalFormHeader = ({
             value={name}
             title={name}
             onChange={handleNameChange}
+            onBlur={() => setNameFocused(true)}
+            statusWithMessage={nameError}
           />
         </div>
       </div>

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModalFormHeader.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModalFormHeader.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo } from 'react';
 
-import { ComboBox, Input, Select } from '@osrd-project/ui-core';
+import { ComboBox, Input, Select, useDefaultComboBox } from '@osrd-project/ui-core';
 import { isEqual } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
@@ -16,6 +16,7 @@ import useSpeedLimitTags from 'common/SpeedLimitTagSelector/useSpeedLimitTags';
 import useStoreDataForRollingStockSelector from 'modules/rollingStock/components/RollingStockSelector/useStoreDataForRollingStockSelector';
 import isMainCategory from 'modules/rollingStock/helpers/category';
 import useCategoryOptions from 'modules/rollingStock/hooks/useCategoryOptions';
+import useFilterRollingStock from 'modules/rollingStock/hooks/useFilterRollingStock';
 import { updateCategory, updateName } from 'reducers/osrdconf/operationalStudiesConf';
 import {
   getName,
@@ -39,7 +40,7 @@ const ItineraryModalFormHeader = ({
   categoryColors,
 }: ItineraryModalFormHeaderProps) => {
   const dispatch = useAppDispatch();
-  const { updateSpeedLimitByTag } = useOsrdConfActions();
+  const { updateSpeedLimitByTag, updateRollingStockID } = useOsrdConfActions();
 
   const { t } = useTranslation('operational-studies', {
     keyPrefix: 'manageTimetableItem',
@@ -62,6 +63,24 @@ const ItineraryModalFormHeader = ({
   const getRollingStockLabel = (rs: LightRollingStockWithLiveries) => {
     const secondPart = rs.metadata?.series || rs.metadata?.reference || '';
     return secondPart ? `${rs.name} - ${secondPart}` : rs.name;
+  };
+
+  const { filteredRollingStockList } = useFilterRollingStock();
+
+  const rollingStockComboBoxDefaultProps = useDefaultComboBox(
+    filteredRollingStockList,
+    getRollingStockLabel
+  );
+
+  const handleRollingStockSelect = (rs?: LightRollingStockWithLiveries) => {
+    if (!rs) {
+      dispatch(updateRollingStockID(undefined));
+      dispatch(updateCategory(null));
+      return;
+    }
+
+    dispatch(updateRollingStockID(rs.id));
+    dispatch(updateCategory(rs.primary_category ? { main_category: rs.primary_category } : null));
   };
 
   // Composition code/speed limit by tag
@@ -109,7 +128,6 @@ const ItineraryModalFormHeader = ({
             getOptionLabel={(option) => option.label}
             getOptionValue={(option) => option.id}
             onChange={handleCategoryChange}
-            readOnly
           ></Select>
         </div>
       </div>
@@ -123,10 +141,8 @@ const ItineraryModalFormHeader = ({
             autoComplete="off"
             value={rollingStock}
             getSuggestionLabel={getRollingStockLabel}
-            onSelectSuggestion={() => {}}
-            suggestions={[]}
-            resetSuggestions={() => {}}
-            readOnly
+            onSelectSuggestion={handleRollingStockSelect}
+            {...rollingStockComboBoxDefaultProps}
           />
         </div>
         <div className="composition-code-select">
@@ -141,7 +157,6 @@ const ItineraryModalFormHeader = ({
             onChange={(e) => {
               dispatch(updateSpeedLimitByTag(e ?? null));
             }}
-            readOnly
           ></Select>
         </div>
         <div className="train-name-input">
@@ -153,7 +168,6 @@ const ItineraryModalFormHeader = ({
             value={name}
             title={name}
             onChange={handleNameChange}
-            readOnly
           />
         </div>
       </div>

--- a/front/src/styles/scss/applications/operationalStudies/_itineraryModal.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_itineraryModal.scss
@@ -103,6 +103,11 @@
           label {
             margin-bottom: 0;
           }
+          .ui-status-message-wrapper-tooltip {
+            width: 100%;
+            left: 1px;
+            transform: translateY(7px);
+          }
         }
       }
     }


### PR DESCRIPTION
We need to be able to select the rollingstock, its category (that should be updated automatically when selecting a rollingstock), the composition code and the name. 