### PR TITLE
front: remove useless header in itinerary modal

### DIFF
--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -415,7 +415,6 @@
       "opName": "Operational point name",
       "openItineraryModal": "New interface for itinerary edition",
       "requestedPoint": "Point on map",
-      "secondaryCode": "Code",
       "track": "Track",
       "trainName": "Train name",
       "trigram": "Trigram",

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -415,7 +415,6 @@
       "opName": "Nom du point remarquable",
       "openItineraryModal": "Nouvelle interface d'édition d'itinéraire",
       "requestedPoint": "Point sur la carte",
-      "secondaryCode": "CH",
       "track": "Voie",
       "trainName": "Nom du train",
       "trigram": "Trigramme",

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModal.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModal.tsx
@@ -349,7 +349,6 @@ const ItineraryModal = ({
             </div>
             <div className="path-step-list-header">
               <span>{t('opName')}</span>
-              <span>{t('secondaryCode')}</span>
               <span>{t('track')}</span>
             </div>
             {pathSteps.map((pathStep, i) => {

--- a/front/src/styles/scss/applications/operationalStudies/_itineraryModal.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_itineraryModal.scss
@@ -140,7 +140,7 @@
 
         .path-step-list-header {
           display: grid;
-          grid-template-columns: minmax(184px, 1fr) 60px 76px;
+          grid-template-columns: minmax(184px, 1fr) 76px;
           gap: 8px;
 
           font-size: 0.875rem;


### PR DESCRIPTION
Fixes #15379.

The "code" header is not shown in [the original mockups](https://www.sketch.com/s/008d6980-d719-4bdc-bb2a-b4c2dda0dc1e/p/0031FF32-FD8B-49F7-AA94-7024D7887E54/canvas#About), so this pull request get rid of it.

<img width="719" height="226" alt="image" src="https://github.com/user-attachments/assets/425b388e-0e47-470d-b018-e5b1ee8b84d9" />
