### PR TITLE
core: s3: only use timetable ID when saving it to s3

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/api/TimetableCacheManager.kt
+++ b/core/src/main/java/fr/sncf/osrd/api/TimetableCacheManager.kt
@@ -169,7 +169,7 @@ class TimetableCacheManager(
             }
 
         // Once the requirements are loaded, we save them to s3 as well for reproducibility
-        saveToS3(cacheKey, requirements)
+        saveToS3(timetableId, requirements)
 
         return requirements
     }
@@ -289,11 +289,11 @@ class TimetableCacheManager(
 
     /** If there's no file yet with the given cache key, save the timetable in the s3 storage. */
     @WithSpan(kind = SpanKind.SERVER)
-    private fun saveToS3(cacheKey: String, requirements: STDCMTimetableData) {
+    private fun saveToS3(timetableId: TimetableId, requirements: STDCMTimetableData) {
         if (s3Context == null) return
 
         s3Context.runAsync {
-            val objectPath = "stdcm/saved_timetables/$cacheKey.cbor"
+            val objectPath = "stdcm/saved_timetables/$timetableId.cbor"
             if (s3Context.fileExists(objectPath)) return@runAsync
 
             try {


### PR DESCRIPTION
Using cacheKey as before gives more data and reduces the risk of collision, but it also makes it a lot harder to find the correct file from just the payload (which is the goal here). Using a "stale" version of the same timetable shouldn't be an issue.

Note: this file is only used to save context and reproduce requests, it's not used as cache. 

First requirement for https://github.com/OpenRailAssociation/osrd/issues/15402, it will be easier to fully test the rest once this one is merged.