### PR TITLE
front: e2e-tests: improve default cmd and doc

### DIFF
--- a/front/README.md
+++ b/front/README.md
@@ -54,10 +54,12 @@ Launches end to end tests.
 
 It requires:
 
-- Install Playwright dependencies `cd ./front/ && npx playwright install --with-deps`
-- Ensure backend containers are running
-Then run the tests with: `cd front/ && npm run e2e-tests`.
-For more details, or if you're using a Linux distribution other than Ubuntu or Debian, refer to the README located in `front/tests`.
+- Ensure the [stack is running](./tests/README.md#requirements)
+- Install [Playwright dependencies](./tests/README.md#install-specific-e2e-tests-dependencies)
+- Then [run the tests](./tests/README.md#run-e2e-tests)
+
+For more details/tips/troubleshoot/alternatives, or if you're using a Linux distribution other than Ubuntu or
+Debian, refer to the dedicated [README](./tests/README.md).
 
 ## Design rules
 

--- a/front/playwright.config.ts
+++ b/front/playwright.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
   fullyParallel: true,
   workers: isCI ? undefined : '30%',
   forbidOnly: isCI,
-  retries: isCI ? 1 : 0,
+  retries: 1,
   use: {
     navigationTimeout: isCI ? 30_000 : 60_000,
     actionTimeout: 10_000,

--- a/front/tests/README.md
+++ b/front/tests/README.md
@@ -33,7 +33,10 @@ In this mode, Playwright runs on your host machine while OSRD services run in Do
 ./osrd-compose default up -d --build
 ```
 
-## Install dependencies
+> [!NOTE]
+> The front is significantly slower using `dev-front` mode, and it can lead to timeout during e2e-tests.
+
+## Install specific e2e-tests dependencies
 
 ```bash
 cd front/
@@ -45,7 +48,7 @@ npx playwright install --with-deps
 
 ```bash
 npm run e2e-tests
-# or
+# equivalent to
 npx playwright test
 ```
 
@@ -62,7 +65,7 @@ Start the Playwright container only:
 ```
 
 **Or**, start the full stack including the front-end (recommended when working on both the front-end
-and E2E tests):
+and E2E tests, but beware of timeouts):
 
 ```bash
 ./osrd-compose playwright dev-front up playwright
@@ -331,14 +334,20 @@ In the CI those files are available as artifacts. You can view them in the Githu
 
 # ⚙️ 7. Playwright Configuration Summary
 
-- **Retries**: enabled in CI
+One can list all the options available using:
+
+```bash
+npx playwright test --help
+```
+
+- **Retries on test failure**: `1` in CI and locally
 - **Trace**: on first retry
 - **Video**: only when retried
-- **Projects**: Chromium, Firefox
+- **Projects**: only `chromium` & `firefox` are available
 - **Locale**: `fr`
 - **Timezone**: `Europe/Paris`
 - **Reporter**: custom + HTML
-- **Parallel workers**: dynamic
+- **Parallel workers**: no limit in CI, but technically `2` (and `30%` of logical CPU locally, after empirical tries)
 - **Screenshots**: on failure
 
 ---


### PR DESCRIPTION
The goal is to have something working for the majority of devs.
Also warn about `dev-front` mode that can timeout tests.