### PR TITLE
front: add isPathStep to table rows type

### DIFF
--- a/front/src/modules/timesStops/TimesStopsTable.tsx
+++ b/front/src/modules/timesStops/TimesStopsTable.tsx
@@ -55,11 +55,10 @@ const TimesStopsTable = ({ rows, dataIsLoading, isValid }: TimesStopsTableProps)
             marginNotHonored,
             scheduleNotHonored,
             invalidPathStep,
-            requestedArrival,
             computedArrival,
+            isPathStep,
           } = info.row.original;
 
-          const isPathStep = requestedArrival;
           const isSuccessSchedule = computedArrival && !marginNotHonored && !scheduleNotHonored;
 
           const className = cx({

--- a/front/src/modules/timesStops/hooks/useTimesStopsTableData.ts
+++ b/front/src/modules/timesStops/hooks/useTimesStopsTableData.ts
@@ -35,6 +35,7 @@ type BuildTableRowParams = {
   invalidPathStep?: boolean;
   scheduleNotHonored?: boolean;
   marginNotHonored?: boolean;
+  isPathStep?: boolean;
 };
 
 const buildTableRow = ({
@@ -49,6 +50,7 @@ const buildTableRow = ({
   invalidPathStep,
   scheduleNotHonored,
   marginNotHonored,
+  isPathStep,
 }: BuildTableRowParams): TimesStopsRowNew => {
   const requestedArrival = schedule?.arrival
     ? new Date(startDate.getTime() + Duration.parse(schedule.arrival).ms)
@@ -87,6 +89,7 @@ const buildTableRow = ({
     invalidPathStep,
     scheduleNotHonored,
     marginNotHonored,
+    isPathStep,
   };
 };
 
@@ -177,6 +180,7 @@ const useTimesStopsTableData = (
           invalidPathStep: !matchingOp,
           scheduleNotHonored,
           marginNotHonored,
+          isPathStep: true,
         });
 
         return [pathStep.id, row];
@@ -233,6 +237,7 @@ const useTimesStopsTableData = (
               trackName,
               startDate,
               computedArrival,
+              isPathStep: false,
             })
           );
         }

--- a/front/src/modules/timesStops/types.ts
+++ b/front/src/modules/timesStops/types.ts
@@ -22,6 +22,7 @@ export type TimesStopsRowNew = {
   invalidPathStep: boolean | undefined;
   scheduleNotHonored: boolean | undefined;
   marginNotHonored: boolean | undefined;
+  isPathStep?: boolean;
 };
 
 export type TimesStopsRow = {


### PR DESCRIPTION
closes #15263 

Previously, isPathStep did not accurately reflect whether the OP was a pathStep or not, as it only took into account the calculated arrival times (which do not exist for the first OP, for example), which could create inconsistencies in the display of step statuses and unmet margins.