### PR TITLE
front: simulation results map - fix marker positions

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResultsMap.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResultsMap.tsx
@@ -144,7 +144,7 @@ const SimulationResultMap = ({
           const coordinates = correspondingTrack
             ? getPointOnTrackCoordinates(
                 correspondingTrack.geo,
-                mToMm(correspondingTrack.length),
+                correspondingTrack.length,
                 matchedOp.part.position
               )
             : null;


### PR DESCRIPTION
The position field of each part of each operational point return by the path_properties endpoint is actually in meters (and not millimeters unlike the rest of the app) so the track length doesn't need to be converted in mm to compute the marker coordinates.

An issue has been opened (https://github.com/OpenRailAssociation/osrd/issues/15442) to correct this misleading value.

fix #15435 