### PR TITLE
front: itinerary modal - fix pathfinding error not update

### DIFF
--- a/front/src/modules/pathfinding/hooks/usePathfindingV2.ts
+++ b/front/src/modules/pathfinding/hooks/usePathfindingV2.ts
@@ -81,6 +81,7 @@ const usePathfindingV2 = () => {
         const pathPropertiesResult = await postPathProperties(pathPropertiesParams).unwrap();
 
         setPathProperties({ ...pathPropertiesResult, length: pathfindingResult.length });
+        setPathfindingError('');
         return;
       }
 


### PR DESCRIPTION
When the pathfinding was in error, we never resett the state to remove the warning leading to the impossibility to submit the form although there wasn't any error left in it.

fix #15440 