### PR TITLE
editoast: fix mm rounding inconsistencies with core

### DIFF
--- a/editoast/core_client/src/pathfinding.rs
+++ b/editoast/core_client/src/pathfinding.rs
@@ -214,8 +214,8 @@ impl From<schemas::infra::DirectionalTrackRange> for TrackRange {
     fn from(value: schemas::infra::DirectionalTrackRange) -> Self {
         TrackRange {
             track_section: value.track,
-            begin: (value.begin * 1000.).round() as u64,
-            end: (value.end * 1000.).round() as u64,
+            begin: (value.begin * 1000.0).round() as u64,
+            end: (value.end * 1000.0).round() as u64,
             direction: value.direction,
         }
     }

--- a/editoast/schemas/src/infra/level_crossing.rs
+++ b/editoast/schemas/src/infra/level_crossing.rs
@@ -53,7 +53,7 @@ impl LevelCrossing {
             .into_iter()
             .map(|lcp| TrackOffset {
                 track: lcp.track,
-                offset: (lcp.position * 1000.0) as u64,
+                offset: (lcp.position * 1000.0).round() as u64,
             })
             .collect()
     }

--- a/editoast/schemas/src/infra/operational_point.rs
+++ b/editoast/schemas/src/infra/operational_point.rs
@@ -121,7 +121,7 @@ impl OperationalPoint {
             })
             .map(|part| TrackOffset {
                 track: part.track.clone(),
-                offset: (part.position * 1000.0) as u64,
+                offset: (part.position * 1000.0).round() as u64,
             })
             .collect()
     }

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -1430,7 +1430,7 @@ pub mod tests {
         assert_eq!(
             response.related_operational_points[0][0].geo,
             Some(GeoJsonPoint::Point(GeoJsonPointValue(vec!(
-                -0.3907884613333333,
+                -0.3907884636666667,
                 49.4999,
             ))))
         );

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -461,8 +461,8 @@ pub fn as_core_work_schedule(
             .iter()
             .map(|track| UndirectedTrackRange {
                 track_section: track.track.to_string(),
-                begin: (track.begin * 1000.0) as u64,
-                end: (track.end * 1000.0) as u64,
+                begin: (track.begin * 1000.0).round() as u64,
+                end: (track.end * 1000.0).round() as u64,
             })
             .collect(),
     })

--- a/editoast/src/views/work_schedules.rs
+++ b/editoast/src/views/work_schedules.rs
@@ -243,8 +243,8 @@ pub(in crate::views) async fn project_path(
                 .into_iter()
                 .map(|tr| core_client::pathfinding::TrackRange {
                     track_section: tr.track,
-                    begin: (tr.begin * 1000.0) as u64,
-                    end: (tr.end * 1000.0) as u64,
+                    begin: (tr.begin * 1000.0).round() as u64,
+                    end: (tr.end * 1000.0).round() as u64,
                     direction: Direction::StartToStop,
                 })
                 .collect();

--- a/tests/data/infras/etcs_infra/infra.json
+++ b/tests/data/infras/etcs_infra/infra.json
@@ -6,7 +6,7 @@
             "parts": [
                 {
                     "track": "TA0",
-                    "position": 700.0,
+                    "position": 699.99959,
                     "local_track_name": "V1"
                 },
                 {

--- a/tests/data/infras/medium_infra/infra.json
+++ b/tests/data/infras/medium_infra/infra.json
@@ -54,7 +54,7 @@
             "parts": [
                 {
                     "track": "TA0",
-                    "position": 700.0,
+                    "position": 699.99959,
                     "local_track_name": "V1"
                 },
                 {

--- a/tests/data/infras/small_infra/infra.json
+++ b/tests/data/infras/small_infra/infra.json
@@ -6,7 +6,7 @@
             "parts": [
                 {
                     "track": "TA0",
-                    "position": 700.0,
+                    "position": 699.99959,
                     "local_track_name": "V1"
                 },
                 {

--- a/tests/infra-scripts/medium_infra.py
+++ b/tests/infra-scripts/medium_infra.py
@@ -193,7 +193,7 @@ def create_medium_infra(signaling_system: str) -> ScenarioData:
     )
     # Station
     west = builder.add_operational_point(label="West_station", trigram="WS", uic=8722)
-    west.add_part(ta0, 700, "V1")
+    west.add_part(ta0, 699.99959, "V1")  # To be rounded to 700
     west.add_part(ta1, 500, "V2")
     west.add_part(ta2, 500, "A")
     # Slopes

--- a/tests/infra-scripts/small_infra_creator/__init__.py
+++ b/tests/infra-scripts/small_infra_creator/__init__.py
@@ -198,7 +198,7 @@ def create_small_infra(signaling_system: str) -> ScenarioData:
     )
     # Station
     west = builder.add_operational_point(label="West_station", trigram="WS", uic=8722)
-    west.add_part(ta0, 700, "V1")
+    west.add_part(ta0, 699.99959, "V1")  # To be rounded to 700
     west.add_part(ta1, 500, "V2")
     west.add_part(ta2, 500, "V3")
     # Slopes

--- a/tests/tests/test_pathfinding.py
+++ b/tests/tests/test_pathfinding.py
@@ -1,9 +1,10 @@
-from collections.abc import Sequence
-from typing import Any
-
 import pytest
+from requests import Session
+from tests.infra import Infra
+from tests.path import Path as TrainPath
 
 from .path import Path
+from .services import EDITOAST_URL
 
 _EXPECTED_WEST_TO_SOUTH_EAST_PATH = Path(
     **{
@@ -157,21 +158,6 @@ _EXPECTED_WEST_TO_SOUTH_EAST_PATH = Path(
 )
 
 
-def assert_track_ranges_are_equals(
-    track_ranges: Sequence[Any], expected_track_ranges: Sequence[Any]
-):
-    assert len(track_ranges) == len(expected_track_ranges)
-
-    for i in range(len(track_ranges)):
-        assert (
-            track_ranges[i]["track_section"]
-            == expected_track_ranges[i]["track_section"]
-        )
-        assert track_ranges[i]["begin"] == expected_track_ranges[i]["begin"]
-        assert track_ranges[i]["end"] == expected_track_ranges[i]["end"]
-        assert track_ranges[i]["direction"] == expected_track_ranges[i]["direction"]
-
-
 def test_west_to_south_east_path(west_to_south_east_path: Path):
     assert west_to_south_east_path.status == _EXPECTED_WEST_TO_SOUTH_EAST_PATH.status
     assert west_to_south_east_path.length == pytest.approx(
@@ -182,3 +168,115 @@ def test_west_to_south_east_path(west_to_south_east_path: Path):
         west_to_south_east_path.path_item_positions
         == _EXPECTED_WEST_TO_SOUTH_EAST_PATH.path_item_positions
     )
+
+
+def test_start_ws_v1_path(session: Session, small_infra: Infra):
+    path_resp = session.post(
+        f"{EDITOAST_URL}infra/{small_infra.id}/pathfinding/blocks",
+        json={
+            "path_items": [
+                {
+                    "operational_point": {
+                        "uic": 8722,
+                        "secondary_code": "BV",
+                        "type": "uic",
+                    },
+                    "local_track_name": "V1",
+                },
+                {"offset": 1000000, "track": "TA0"},
+            ],
+            "rolling_stock_is_thermal": True,
+            "rolling_stock_loading_gauge": "G1",
+            "rolling_stock_supported_electrifications": [],
+            "rolling_stock_supported_signaling_systems": [
+                "BAL",
+                "BAPR",
+                "TVM300",
+                "TVM430",
+                "ETCS_LEVEL2",
+            ],
+            "rolling_stock_maximum_speed": 200,
+            "rolling_stock_length": 100000,
+            "stops_at_end_of_block": False,
+        },
+    )
+    start_ws_v1_path = TrainPath(**path_resp.json())
+
+    assert start_ws_v1_path.status == "success"
+    assert start_ws_v1_path.length == pytest.approx(300000, rel=1e-3)
+    # especially check that the start is rounded to 700 m (closest value from 699.99959 m in data)
+    assert start_ws_v1_path.path == {
+        "blocks": [
+            {
+                "id": "block.1053dfcc22f763572986fca41a69581e",
+                "begin": 700000,
+                "end": 1000000,
+            }
+        ],
+        "routes": [{"id": "rt.buffer_stop.0->DA2", "begin": 700000, "end": 1000000}],
+        "track_section_ranges": [
+            {
+                "track_section": "TA0",
+                "begin": 700000,
+                "end": 1000000,
+                "direction": "START_TO_STOP",
+            }
+        ],
+    }
+    assert start_ws_v1_path.path_item_positions == [0, 300000]
+
+    # especially check that OP part is at the very beginning of the path (match pathfinding blocks)
+    path_properties = session.post(
+        f"{EDITOAST_URL}infra/{small_infra.id}/path_properties",
+        json={
+            "track_section_ranges": [
+                {
+                    "track_section": "TA0",
+                    "begin": 700000,
+                    "end": 1000000,
+                    "direction": "START_TO_STOP",
+                }
+            ]
+        },
+    ).json()
+    assert path_properties == {
+        "slopes": {"boundaries": [], "values": [0.0]},
+        "curves": {"boundaries": [], "values": [0.0]},
+        "electrifications": {
+            "boundaries": [],
+            "values": [{"type": "electrification", "voltage": "1500V"}],
+        },
+        "geometry": {
+            "type": "LineString",
+            "coordinates": [[-0.38775, 49.5], [-0.3825, 49.5]],
+        },
+        "operational_points": [
+            {
+                "id": "West_station",
+                "part": {
+                    "track": "TA0",
+                    "position": 700.000,
+                    "local_track_name": "V1",
+                    "extensions": {
+                        "sncf": None,
+                    },
+                },
+                "extensions": {
+                    "sncf": {
+                        "ci": 22,
+                        "ch": "BV",
+                        "ch_short_label": "BV",
+                        "ch_long_label": "0",
+                        "trigram": "WS",
+                    },
+                    "identifier": {"name": "West_station", "uic": 8722},
+                },
+                "position": 0,
+                "weight": None,
+            }
+        ],
+        "zones": {
+            "boundaries": [],
+            "values": ["zone.[DA2:DECREASING, buffer_stop.0:INCREASING]"],
+        },
+    }


### PR DESCRIPTION
Round to the nearest mm

Fixes https://github.com/OpenRailAssociation/osrd/issues/15345

Also:
* Add integration test highlighting the issue (inconsistency of pathfinding blocks vs. path_properties) when the mm value should be rounded to top integer
* cleanup unused integration test assert function

✅ hand-tested on bug's data

> [!NOTE]
> This triggers a larger topic around the management of roundings between editoast and core, to be tracked and discussed in a separate issue: #15461