### PR TITLE
editoast: adapt simulation summary endpoint

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -2405,49 +2405,6 @@ paths:
                 propertyNames:
                   type: integer
                   format: int64
-  /paced_train/simulation_summary:
-    post:
-      tags:
-      - paced_train
-      summary: |-
-        Associate each paced train id with its simulation summaries response
-        If the simulation fails, it associates the reason: pathfinding failed or running time failed
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-              - infra_id
-              - ids
-              properties:
-                electrical_profile_set_id:
-                  type:
-                  - integer
-                  - 'null'
-                  format: int64
-                ids:
-                  type: array
-                  items:
-                    type: integer
-                    format: int64
-                  uniqueItems: true
-                infra_id:
-                  type: integer
-                  format: int64
-        required: true
-      responses:
-        '200':
-          description: Associate each paced train id with its simulation summaries
-          content:
-            application/json:
-              schema:
-                type: object
-                additionalProperties:
-                  $ref: '#/components/schemas/PacedTrainSimulationSummaryResult'
-                propertyNames:
-                  type: integer
-                  format: int64
   /paced_train/track_occupancy:
     post:
       tags:
@@ -4675,6 +4632,49 @@ paths:
       responses:
         '204':
           description: The train schedule set is updated with the train schedules
+  /train_schedules/simulation_summary:
+    post:
+      tags:
+      - paced_train
+      summary: |-
+        Associate each train schedule id with its simulation summaries response
+        If the simulation fails, it associates the reason: pathfinding failed or running time failed
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - infra_id
+              - ids
+              properties:
+                electrical_profile_set_id:
+                  type:
+                  - integer
+                  - 'null'
+                  format: int64
+                ids:
+                  type: array
+                  items:
+                    type: integer
+                    format: int64
+                  uniqueItems: true
+                infra_id:
+                  type: integer
+                  format: int64
+        required: true
+      responses:
+        '200':
+          description: Associate each train schedule id with its simulation summaries
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  $ref: '#/components/schemas/TrainScheduleSimulationSummaryResult'
+                propertyNames:
+                  type: integer
+                  format: int64
   /train_schedules/{id}:
     get:
       tags:
@@ -10724,21 +10724,6 @@ components:
         that may deviate from the paced train.
         - Created: A new occurrence manually added by the user, not originally present in the automatically generated occurrences based on the paced train.
         - Modified: An existing occurrence that has been changed
-    PacedTrainSimulationSummaryResult:
-      type: object
-      required:
-      - paced_train
-      - exceptions
-      properties:
-        exceptions:
-          type: object
-          description: The key is the `exception_key`
-          additionalProperties:
-            $ref: '#/components/schemas/SimulationSummaryResult'
-          propertyNames:
-            type: string
-        paced_train:
-          $ref: '#/components/schemas/SimulationSummaryResult'
     PaginationStats:
       type: object
       description: |-
@@ -14627,6 +14612,21 @@ components:
             type: integer
             format: int64
             minimum: 0
+    TrainScheduleSimulationSummaryResult:
+      type: object
+      required:
+      - train_schedule
+      - exceptions
+      properties:
+        exceptions:
+          type: object
+          description: The key is the `exception_key`
+          additionalProperties:
+            $ref: '#/components/schemas/SimulationSummaryResult'
+          propertyNames:
+            type: string
+        train_schedule:
+          $ref: '#/components/schemas/SimulationSummaryResult'
     Version:
       type: object
       required:

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -268,7 +268,9 @@ fn service_router() -> router::DocumentedRouter {
                         "/move",
                         patch!(
                             timetable::paced_train::move_train_schedules_to_another_train_schedule_set
-                        ),
+                        )).route(
+                        "/simulation_summary",
+                        post!(timetable::paced_train::simulation_summary),
                     )
                 .nests("/{id}", |path| {
                     path.route("/", get!(timetable::paced_train::get_by_id))
@@ -285,10 +287,6 @@ fn service_router() -> router::DocumentedRouter {
                     .route(
                         "/project_path_op",
                         post!(timetable::paced_train::project_path_op),
-                    )
-                    .route(
-                        "/simulation_summary",
-                        post!(timetable::paced_train::simulation_summary),
                     )
                     .route(
                         "/track_occupancy",

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -250,9 +250,9 @@ pub(in crate::views) struct SimulationBatchForm {
 
 #[derive(Debug, Serialize, ToSchema)]
 #[cfg_attr(test, derive(PartialEq, serde::Deserialize))]
-#[schema(as = PacedTrainSimulationSummaryResult)]
-pub(in crate::views) struct PacedTrainSummaryResponse {
-    pub paced_train: SummaryResponse,
+#[schema(as = TrainScheduleSimulationSummaryResult)]
+pub(in crate::views) struct TrainScheduleSummaryResponse {
+    pub train_schedule: SummaryResponse,
     /// The key is the `exception_key`
     pub exceptions: HashMap<String, SummaryResponse>,
 }
@@ -264,7 +264,7 @@ struct SimulationContext {
     train_schedule: schemas::TrainOccurrence,
 }
 
-/// Associate each paced train id with its simulation summaries response
+/// Associate each train schedule id with its simulation summaries response
 /// If the simulation fails, it associates the reason: pathfinding failed or running time failed
 #[editoast_derive::route]
 #[utoipa::path(
@@ -272,7 +272,7 @@ struct SimulationContext {
     tag = "paced_train",
     request_body = inline(SimulationBatchForm),
     responses(
-        (status = 200, description = "Associate each paced train id with its simulation summaries", body = HashMap<i64, PacedTrainSummaryResponse>),
+        (status = 200, description = "Associate each train schedule id with its simulation summaries", body = HashMap<i64, TrainScheduleSummaryResponse>),
     ),
 )]
 pub(in crate::views) async fn simulation_summary(
@@ -289,7 +289,7 @@ pub(in crate::views) async fn simulation_summary(
         electrical_profile_set_id,
         ids: paced_train_ids,
     }): Json<SimulationBatchForm>,
-) -> Result<Json<HashMap<i64, PacedTrainSummaryResponse>>> {
+) -> Result<Json<HashMap<i64, TrainScheduleSummaryResponse>>> {
     let authorized = auth
         .check_roles([authz::Role::OperationalStudies].into())
         .await
@@ -359,7 +359,7 @@ pub(in crate::views) async fn simulation_summary(
     // Will remember all simulation that already have been inserted in the response
     let mut base_simulation = Arc::clone(&simulations[0].0);
     let results = simulation_contexts.into_iter().zip(simulations).fold(
-        HashMap::<i64, PacedTrainSummaryResponse>::new(),
+        HashMap::<i64, TrainScheduleSummaryResponse>::new(),
         |mut map, (simulation_context, (simulation, _path))| {
             if let Some(exception_key) = &simulation_context.exception_key {
                 if !Arc::ptr_eq(&base_simulation, &simulation) {
@@ -378,8 +378,8 @@ pub(in crate::views) async fn simulation_summary(
                 base_simulation = Arc::clone(&simulation);
                 map.insert(
                     simulation_context.paced_train_id,
-                    PacedTrainSummaryResponse {
-                        paced_train: SummaryResponse::summarize_simulation(
+                    TrainScheduleSummaryResponse {
+                        train_schedule: SummaryResponse::summarize_simulation(
                             Arc::unwrap_or_clone(simulation),
                             &simulation_context.train_schedule,
                         ),
@@ -1611,12 +1611,12 @@ mod tests {
     use crate::views::tests::mocked_core_pathfinding_sim_and_proj;
     use crate::views::timetable::paced_train::MoveTrainSchedulesForm;
     use crate::views::timetable::paced_train::OccupancyBlocksPacedTrainResult;
-    use crate::views::timetable::paced_train::PacedTrainSummaryResponse;
     use crate::views::timetable::paced_train::ProjectPathPacedTrainResult;
     use crate::views::timetable::paced_train::TrackOccupancyForm;
     use crate::views::timetable::paced_train::TrackReference;
     use crate::views::timetable::paced_train::TrackSectionOccupancy;
     use crate::views::timetable::paced_train::TrainScheduleResponse;
+    use crate::views::timetable::paced_train::TrainScheduleSummaryResponse;
     use crate::views::timetable::simulation;
     use crate::views::timetable::simulation::SimulationResponseSuccess;
     use crate::views::timetable::simulation::SummaryResponse;
@@ -2154,12 +2154,14 @@ mod tests {
         app.fetch(request)
             .await
             .assert_status(StatusCode::NO_CONTENT);
-        let request = app.post("/paced_train/simulation_summary").json(&json!({
-            "infra_id": infra_id,
-            "ids": vec![paced_train_id],
-        }));
+        let request = app
+            .post("/train_schedules/simulation_summary")
+            .json(&json!({
+                "infra_id": infra_id,
+                "ids": vec![paced_train_id],
+            }));
 
-        let response: HashMap<i64, PacedTrainSummaryResponse> = app
+        let response: HashMap<i64, TrainScheduleSummaryResponse> = app
             .fetch(request)
             .await
             .assert_status(StatusCode::OK)
@@ -2167,8 +2169,8 @@ mod tests {
         assert_eq!(response.len(), 1);
         assert_eq!(
             *response.get(&paced_train_id).unwrap(),
-            PacedTrainSummaryResponse {
-                paced_train: SummaryResponse::Success {
+            TrainScheduleSummaryResponse {
+                train_schedule: SummaryResponse::Success {
                     length: 3,
                     time: 3,
                     energy_consumption: 0.0,
@@ -2203,10 +2205,12 @@ mod tests {
     async fn paced_train_simulation_summary_not_found() {
         let (app, infra_id, _paced_train_id) =
             app_infra_id_paced_train_id_for_simulation_tests().await;
-        let request = app.post("/paced_train/simulation_summary").json(&json!({
-            "infra_id": infra_id,
-            "ids": vec![0],
-        }));
+        let request = app
+            .post("/train_schedules/simulation_summary")
+            .json(&json!({
+                "infra_id": infra_id,
+                "ids": vec![0],
+            }));
         let response: InternalError = app
             .fetch(request)
             .await

--- a/front/src/applications/operationalStudies/helpers/TrainSimulationLazyLoader.ts
+++ b/front/src/applications/operationalStudies/helpers/TrainSimulationLazyLoader.ts
@@ -1,7 +1,7 @@
 import {
   osrdEditoastApi,
-  type PacedTrainSimulationSummaryResult,
-  type PostPacedTrainSimulationSummaryApiResponse,
+  type TrainScheduleSimulationSummaryResult,
+  type PostTrainSchedulesSimulationSummaryApiResponse,
 } from 'common/api/osrdEditoastApi';
 import type { PacedTrainId, TimetableItemId } from 'reducers/osrdconf/types';
 import type { AppDispatch } from 'store';
@@ -13,7 +13,9 @@ type TrainSimulationLazyLoaderOptions = {
   dispatch: AppDispatch;
   infraId: number;
   electricalProfileSetId?: number;
-  onProgress: (pacedTrainSummaries: Map<PacedTrainId, PacedTrainSimulationSummaryResult>) => void;
+  onProgress: (
+    pacedTrainSummaries: Map<PacedTrainId, TrainScheduleSimulationSummaryResult>
+  ) => void;
 };
 
 /**
@@ -70,13 +72,12 @@ export default class TrainSimulationLazyLoader {
   async processBatch(batch: TimetableItemId[]) {
     const editoastIds = batch.map((id) => extractEditoastIdFromPacedTrainId(id));
 
-    let pacedTrainPromise: Promise<PostPacedTrainSimulationSummaryApiResponse> = Promise.resolve(
-      {}
-    );
+    let pacedTrainPromise: Promise<PostTrainSchedulesSimulationSummaryApiResponse> =
+      Promise.resolve({});
     if (editoastIds.length > 0) {
       pacedTrainPromise = this.options
         .dispatch(
-          osrdEditoastApi.endpoints.postPacedTrainSimulationSummary.initiate(
+          osrdEditoastApi.endpoints.postTrainSchedulesSimulationSummary.initiate(
             {
               body: {
                 infra_id: this.options.infraId,

--- a/front/src/applications/operationalStudies/hooks/useLazySimulateTrains.ts
+++ b/front/src/applications/operationalStudies/hooks/useLazySimulateTrains.ts
@@ -2,7 +2,7 @@ import { useRef, useEffect, useCallback, useState } from 'react';
 
 import type {
   LightRollingStockWithLiveries,
-  PacedTrainSimulationSummaryResult,
+  TrainScheduleSimulationSummaryResult,
 } from 'common/api/osrdEditoastApi';
 import formatTimetableItemSummaries from 'modules/simulationResult/helpers/formatTimetableItemSummaries';
 import type { TimetableItemWithDetails } from 'modules/timetableItem/types';
@@ -56,7 +56,9 @@ export default function useLazySimulateTrains({
       dispatch,
       infraId,
       electricalProfileSetId,
-      onProgress: (pacedTrainSummaries: Map<PacedTrainId, PacedTrainSimulationSummaryResult>) => {
+      onProgress: (
+        pacedTrainSummaries: Map<PacedTrainId, TrainScheduleSimulationSummaryResult>
+      ) => {
         const summaries = formatTimetableItemSummaries(
           pacedTrainSummaries,
           timetableItemsByIdRef.current,

--- a/front/src/applications/stdcm/hooks/useLinkedTrainSearch.ts
+++ b/front/src/applications/stdcm/hooks/useLinkedTrainSearch.ts
@@ -30,8 +30,8 @@ const useLinkedTrainSearch = () => {
   const dispatch = useAppDispatch();
 
   const [postSearch] = osrdEditoastApi.endpoints.postSearch.useLazyQuery();
-  const [postPacedTrainSimulationSummary] =
-    osrdEditoastApi.endpoints.postPacedTrainSimulationSummary.useLazyQuery();
+  const [postTrainSchedulesSimulationSummary] =
+    osrdEditoastApi.endpoints.postTrainSchedulesSimulationSummary.useLazyQuery();
   const [getTrainScheduleSets] =
     osrdEditoastApi.endpoints.getTimetableByIdTrainScheduleSets.useLazyQuery();
 
@@ -90,7 +90,7 @@ const useLinkedTrainSearch = () => {
 
   const getTrainsSummaries = useCallback(
     async (trainsIds: number[]) => {
-      const trainsSummaries = await postPacedTrainSimulationSummary({
+      const trainsSummaries = await postTrainSchedulesSimulationSummary({
         body: {
           infra_id: infraId,
           ids: trainsIds,
@@ -98,7 +98,7 @@ const useLinkedTrainSearch = () => {
       }).unwrap();
       return trainsSummaries;
     },
-    [postPacedTrainSimulationSummary, infraId]
+    [postTrainSchedulesSimulationSummary, infraId]
   );
 
   const launchTrainScheduleSearch = useCallback(async () => {
@@ -139,7 +139,7 @@ const useLinkedTrainSearch = () => {
       const newLinkedPathResults = await Promise.all(
         filteredResults.map(async (result) => {
           if (!filteredResultsSummaries) return undefined;
-          const resultSummary = filteredResultsSummaries[result.id].paced_train;
+          const resultSummary = filteredResultsSummaries[result.id].train_schedule;
           if (resultSummary.status !== 'success') return undefined;
           const durationFromStartTime = new Duration({
             milliseconds: resultSummary.path_item_times_final.at(-1)!,

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -673,17 +673,6 @@ const injectedRtkApi = api
         }),
         providesTags: ['train_schedule'],
       }),
-      postPacedTrainSimulationSummary: build.query<
-        PostPacedTrainSimulationSummaryApiResponse,
-        PostPacedTrainSimulationSummaryApiArg
-      >({
-        query: (queryArg) => ({
-          url: `/paced_train/simulation_summary`,
-          method: 'POST',
-          body: queryArg.body,
-        }),
-        providesTags: ['paced_train'],
-      }),
       postPacedTrainTrackOccupancy: build.mutation<
         PostPacedTrainTrackOccupancyApiResponse,
         PostPacedTrainTrackOccupancyApiArg
@@ -1345,6 +1334,17 @@ const injectedRtkApi = api
           body: queryArg.body,
         }),
         invalidatesTags: ['paced_train'],
+      }),
+      postTrainSchedulesSimulationSummary: build.query<
+        PostTrainSchedulesSimulationSummaryApiResponse,
+        PostTrainSchedulesSimulationSummaryApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/train_schedules/simulation_summary`,
+          method: 'POST',
+          body: queryArg.body,
+        }),
+        providesTags: ['paced_train'],
       }),
       getTrainSchedulesById: build.query<
         GetTrainSchedulesByIdApiResponse,
@@ -2051,17 +2051,6 @@ export type PostPacedTrainProjectPathOpApiArg = {
     use_simulation: boolean;
   };
 };
-export type PostPacedTrainSimulationSummaryApiResponse =
-  /** status 200 Associate each paced train id with its simulation summaries */ {
-    [key: string]: PacedTrainSimulationSummaryResult;
-  };
-export type PostPacedTrainSimulationSummaryApiArg = {
-  body: {
-    electrical_profile_set_id?: number | null;
-    ids: number[];
-    infra_id: number;
-  };
-};
 export type PostPacedTrainTrackOccupancyApiResponse =
   /** status 200 Track section occupancy periods for paced trains */ {
     /** Which track section the train is on at the queried operational point.
@@ -2632,6 +2621,17 @@ export type PatchTrainSchedulesMoveApiArg = {
   body: {
     train_schedule_ids: number[];
     train_schedule_set_id: number;
+  };
+};
+export type PostTrainSchedulesSimulationSummaryApiResponse =
+  /** status 200 Associate each train schedule id with its simulation summaries */ {
+    [key: string]: TrainScheduleSimulationSummaryResult;
+  };
+export type PostTrainSchedulesSimulationSummaryApiArg = {
+  body: {
+    electrical_profile_set_id?: number | null;
+    ids: number[];
+    infra_id: number;
   };
 };
 export type GetTrainSchedulesByIdApiResponse =
@@ -3870,57 +3870,6 @@ export type ProjectPathForm = {
     track_section: string;
   }[];
 };
-export type SimulationSummaryResult =
-  | {
-      /** Total energy consumption of a train in kWh */
-      energy_consumption: number;
-      /** Length of a path in mm */
-      length: number;
-      /** Whether the final path times respect the input margins for each train schedule path item.
-    The length of this array is the number of path items in the train schedule used as input for the simulation.
-    Important: `true` means the provisional time is acceptable margin-wise, not *precisely* respecting the margin. */
-      path_item_respect_margins: boolean[];
-      /** Whether each path item in the train schedule is reached on time.
-    The length of this array is the number of path items in the train schedule used as input for the simulation.
-    Important: `true` doesn't mean the path item has been reached *precisely* at the requested time. Instead, it means it reached the path item at an acceptable time. */
-      path_item_respect_times: boolean[];
-      /** Base simulation time for each train schedule path item.
-    The length of this array is the number of path items in the train schedule used as input for the simulation.
-    The first value is always `0` (beginning of the path) and the last one, the total time of the simulation (end of the path) */
-      path_item_times_base: number[];
-      /** Final simulation time for each train schedule path item.
-    The length of this array is the number of path items in the train schedule used as input for the simulation.
-    The first value is always `0` (beginning of the path) and the last one, the total time of the simulation (end of the path) */
-      path_item_times_final: number[];
-      /** Provisional simulation time for each train schedule path item.
-    The length of this array is the number of path items in the train schedule used as input for the simulation.
-    The first value is always `0` (beginning of the path) and the last one, the total time of the simulation (end of the path) */
-      path_item_times_provisional: number[];
-      status: 'success';
-      /** Travel time in ms */
-      time: number;
-    }
-  | (CorePathfindingNotFound & {
-      status: 'pathfinding_not_found';
-    })
-  | {
-      core_error: InternalError;
-      status: 'pathfinding_failure';
-    }
-  | {
-      error_type: string;
-      status: 'simulation_failed';
-    }
-  | (CorePathfindingInputError & {
-      status: 'pathfinding_input_error';
-    });
-export type PacedTrainSimulationSummaryResult = {
-  /** The key is the `exception_key` */
-  exceptions: {
-    [key: string]: SimulationSummaryResult;
-  };
-  paced_train: SimulationSummaryResult;
-};
 export type TrainCategory =
   | {
       main_category: TrainMainCategory;
@@ -5010,6 +4959,57 @@ export type TrainScheduleSetForm = {
   description: string;
   name?: string | null;
   published: boolean;
+};
+export type SimulationSummaryResult =
+  | {
+      /** Total energy consumption of a train in kWh */
+      energy_consumption: number;
+      /** Length of a path in mm */
+      length: number;
+      /** Whether the final path times respect the input margins for each train schedule path item.
+    The length of this array is the number of path items in the train schedule used as input for the simulation.
+    Important: `true` means the provisional time is acceptable margin-wise, not *precisely* respecting the margin. */
+      path_item_respect_margins: boolean[];
+      /** Whether each path item in the train schedule is reached on time.
+    The length of this array is the number of path items in the train schedule used as input for the simulation.
+    Important: `true` doesn't mean the path item has been reached *precisely* at the requested time. Instead, it means it reached the path item at an acceptable time. */
+      path_item_respect_times: boolean[];
+      /** Base simulation time for each train schedule path item.
+    The length of this array is the number of path items in the train schedule used as input for the simulation.
+    The first value is always `0` (beginning of the path) and the last one, the total time of the simulation (end of the path) */
+      path_item_times_base: number[];
+      /** Final simulation time for each train schedule path item.
+    The length of this array is the number of path items in the train schedule used as input for the simulation.
+    The first value is always `0` (beginning of the path) and the last one, the total time of the simulation (end of the path) */
+      path_item_times_final: number[];
+      /** Provisional simulation time for each train schedule path item.
+    The length of this array is the number of path items in the train schedule used as input for the simulation.
+    The first value is always `0` (beginning of the path) and the last one, the total time of the simulation (end of the path) */
+      path_item_times_provisional: number[];
+      status: 'success';
+      /** Travel time in ms */
+      time: number;
+    }
+  | (CorePathfindingNotFound & {
+      status: 'pathfinding_not_found';
+    })
+  | {
+      core_error: InternalError;
+      status: 'pathfinding_failure';
+    }
+  | {
+      error_type: string;
+      status: 'simulation_failed';
+    }
+  | (CorePathfindingInputError & {
+      status: 'pathfinding_input_error';
+    });
+export type TrainScheduleSimulationSummaryResult = {
+  /** The key is the `exception_key` */
+  exceptions: {
+    [key: string]: SimulationSummaryResult;
+  };
+  train_schedule: SimulationSummaryResult;
 };
 export type Version = {
   git_describe: string | null;

--- a/front/src/config/openapi-editoast-config.cts
+++ b/front/src/config/openapi-editoast-config.cts
@@ -19,7 +19,7 @@ const config: ConfigFile = {
         'postInfraByInfraIdPathfinding',
         'postInfraByInfraIdPathfindingBlocks',
         'postInfraByInfraIdPathProperties',
-        'postPacedTrainSimulationSummary',
+        'postTrainSchedulesSimulationSummary',
         'postPacedTrainProjectPath',
         'postPacedTrainProjectPathOp',
         'postPacedTrainOccupancyBlocks',

--- a/front/src/modules/simulationResult/helpers/formatTimetableItemSummaries.ts
+++ b/front/src/modules/simulationResult/helpers/formatTimetableItemSummaries.ts
@@ -1,6 +1,6 @@
 import type {
   LightRollingStockWithLiveries,
-  PacedTrainSimulationSummaryResult,
+  TrainScheduleSimulationSummaryResult,
 } from 'common/api/osrdEditoastApi';
 import { formatPacedTrainWithDetails } from 'modules/timetableItem/helpers/formatTimetableItemWithDetails';
 import type { TimetableItemWithDetails } from 'modules/timetableItem/types';
@@ -9,7 +9,7 @@ import { mapBy } from 'utils/types';
 
 type SummaryWithCorrespondingTimetableItemId = {
   timetableItemId: PacedTrainId;
-  summary: PacedTrainSimulationSummaryResult;
+  summary: TrainScheduleSimulationSummaryResult;
 };
 
 const formatTimetableItemWithDetails = (
@@ -27,7 +27,7 @@ const formatTimetableItemWithDetails = (
 
 /** Format the timetable items with their simulation summaries */
 const formatTimetableItemSummaries = (
-  rawPacedTrainSummaries: Map<PacedTrainId, PacedTrainSimulationSummaryResult>,
+  rawPacedTrainSummaries: Map<PacedTrainId, TrainScheduleSimulationSummaryResult>,
   rawTimetableItems: Map<TimetableItemId, TimetableItem>,
   rollingStocks: LightRollingStockWithLiveries[]
 ): Map<TimetableItemId, TimetableItemWithDetails> => {

--- a/front/src/modules/timetableItem/helpers/formatTimetableItemWithDetails.ts
+++ b/front/src/modules/timetableItem/helpers/formatTimetableItemWithDetails.ts
@@ -6,7 +6,7 @@ import {
 import type {
   LightRollingStockWithLiveries,
   SimulationSummaryResult,
-  PacedTrainSimulationSummaryResult,
+  TrainScheduleSimulationSummaryResult,
 } from 'common/api/osrdEditoastApi';
 import type {
   SimulatedException,
@@ -71,7 +71,7 @@ const extractBaseTimetableItemProps = (timetableItem: TimetableItem) => ({
 export const formatPacedTrainWithDetails = (
   pacedTrain: TimetableItem,
   rollingStock?: LightRollingStockWithLiveries,
-  pacedTrainSummary?: PacedTrainSimulationSummaryResult
+  pacedTrainSummary?: TrainScheduleSimulationSummaryResult
 ): TimetableItemWithDetails => {
   // we omit the following props since they're not expected in TimetableItemWithDetails
   const {
@@ -87,7 +87,7 @@ export const formatPacedTrainWithDetails = (
       ...pacedTrainProps,
       ...extractBaseTimetableItemProps(pacedTrain),
       rollingStock,
-      summary: formatSummary(pacedTrainSummary?.paced_train),
+      summary: formatSummary(pacedTrainSummary?.train_schedule),
     };
   }
 
@@ -122,6 +122,6 @@ export const formatPacedTrainWithDetails = (
       interval: Duration.parse(paced.interval),
       exceptions: simulatedExceptions,
     },
-    summary: formatSummary(pacedTrainSummary?.paced_train),
+    summary: formatSummary(pacedTrainSummary?.train_schedule),
   };
 };


### PR DESCRIPTION
rename variables and structs from `simulation_summary` endpoint (paced train to train schedule)

part of #15058 