### PR TITLE
editoast: integration of SimulationEnv

### DIFF
--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -1335,24 +1335,26 @@ mod tests {
     #[cfg(test)]
     pub fn mocked_core_pathfinding_sim_and_proj() -> MockingClient {
         let mut core = MockingClient::new();
-        core.stub("/pathfinding/blocks")
-            .response(StatusCode::OK)
-            .json(json!({
-                "path": {
-                    "blocks":[],
-                    "routes": [],
-                    "track_section_ranges": [{"track_section": "TA1", "begin":0, "end": 3, "direction": "START_TO_STOP"}],
-                },
-                "path_item_positions": [0,1,2,3],
-                "length": 3,
-                "status": "success"
-            }))
-            .finish();
-        core.stub("/standalone_simulation")
-            .response(StatusCode::OK)
-            .json(simulation_empty_response())
-            .json(simulation_empty_response())
-            .finish();
+        let mut pathfinding_stub = core.stub("/pathfinding/blocks").response(StatusCode::OK);
+        for _ in 0..10 {
+            pathfinding_stub = pathfinding_stub.json(
+                 json!({
+                    "path": {
+                        "blocks":[],
+                        "routes": [],
+                        "track_section_ranges": [{"track_section": "TA1", "begin":0, "end": 3, "direction": "START_TO_STOP"}],
+                    },
+                    "path_item_positions": [0,1,2,3],
+                    "length": 3,
+                    "status": "success"
+            }));
+        }
+        pathfinding_stub.finish();
+        let mut simulation_stub = core.stub("/standalone_simulation").response(StatusCode::OK);
+        for _ in 0..10 {
+            simulation_stub = simulation_stub.json(simulation_empty_response());
+        }
+        simulation_stub.finish();
         core.stub("/signal_projection")
             .response(StatusCode::OK)
             .json(json!({

--- a/editoast/src/views/timetable/simulation.rs
+++ b/editoast/src/views/timetable/simulation.rs
@@ -12,8 +12,14 @@ use core_client::simulation::SimulationMargins;
 use core_client::simulation::SimulationPowerRestrictionItem;
 use core_client::simulation::SimulationScheduleItem;
 use core_client::simulation::SpeedLimitProperties;
+use core_task::PathfindingConsist;
+use core_task::SimulationConsist;
+use core_task::SimulationTrain;
+use core_task::SimulationTrainParameters;
+use core_task::SimulationWaypoint;
 use database::DbConnection;
 use itertools::Itertools;
+use ordered_float::OrderedFloat;
 use schemas::train_schedule::Margins;
 use schemas::train_schedule::PathItem;
 use schemas::train_schedule::PowerRestrictionItem;
@@ -29,11 +35,13 @@ use std::iter;
 use std::sync::Arc;
 use tracing::Instrument;
 use tracing::info;
+use uom::si::f64::Velocity;
 use utoipa::ToSchema;
 
 use crate::error::InternalError;
 use crate::error::Result;
 use crate::views::CoreClient;
+use crate::views::path::operational_point_cache::OperationalPointCache;
 use crate::views::path::pathfinding::PathfindingFailure;
 use crate::views::path::pathfinding_from_train_batch;
 use crate::views::rolling_stock::RollingStockError;
@@ -558,6 +566,142 @@ pub async fn consist_train_simulation_batch<T: TrainScheduleLike>(
         .flatten()
         .zip(pathfinding_results)
         .collect())
+}
+
+fn build_pathfinding_consist(
+    physics_consist_parameters: &PhysicsConsistParameters,
+    speed_limit_tag: Option<String>,
+) -> PathfindingConsist {
+    PathfindingConsist {
+        loading_gauge: physics_consist_parameters.traction_engine.loading_gauge,
+        thermal: physics_consist_parameters
+            .traction_engine
+            .effort_curves
+            .has_thermal_curves(),
+        supported_electrifications: physics_consist_parameters
+            .traction_engine
+            .effort_curves
+            .supported_electrification(),
+        supported_signaling_systems: physics_consist_parameters
+            .traction_engine
+            .supported_signaling_systems(),
+        maximum_speed: OrderedFloat(
+            physics_consist_parameters
+                .compute_max_speed()
+                .get::<uom::si::velocity::meter_per_second>(),
+        ),
+        length: OrderedFloat(
+            physics_consist_parameters
+                .compute_length()
+                .get::<uom::si::length::meter>(),
+        ),
+        speed_limit_tag,
+    }
+}
+
+// Panics if the operational point cache doesn’t contain one of the path items of the train occurrence
+pub fn build_simulation_train(
+    train_occurrence: &schemas::TrainOccurrence,
+    physics_consist_parameters: &PhysicsConsistParameters,
+    operational_point_cache: &OperationalPointCache,
+) -> SimulationTrain {
+    let schemas::TrainOccurrence {
+        train_name: _,
+        labels: _,
+        rolling_stock_name: _,
+        start_time: _,
+        path,
+        schedule,
+        margins,
+        initial_speed,
+        comfort,
+        constraint_distribution,
+        speed_limit_tag,
+        power_restrictions,
+        options,
+        category: _,
+    } = train_occurrence;
+    let pathfinding_consist = build_pathfinding_consist(
+        physics_consist_parameters,
+        speed_limit_tag
+            .clone()
+            .map(|non_blank_string| non_blank_string.0),
+    );
+    let simulation_consist =
+        SimulationConsist(PhysicsConsist::from(physics_consist_parameters.clone()));
+    let simulation_train_parameters = SimulationTrainParameters::new(
+        Velocity::new::<uom::si::velocity::meter_per_second>(*initial_speed),
+        *constraint_distribution,
+        *comfort,
+        speed_limit_tag
+            .clone()
+            .map(|non_blank_string| non_blank_string.0),
+        options.clone(),
+    );
+    let mut simulation_train = SimulationTrain::new(
+        simulation_consist,
+        pathfinding_consist,
+        simulation_train_parameters,
+    );
+    let path_item_locations = path
+        .iter()
+        .map(|path_item| &path_item.location)
+        .collect_vec();
+    let track_offsets = operational_point_cache
+        .extract_location_from_path_items(&path_item_locations)
+        .expect("the path item cache should be built out from all the input path items of the train occurrence");
+    let schedule_map = schedule
+        .iter()
+        .map(|schedule_item @ ScheduleItem { at, .. }| (at, schedule_item))
+        .collect::<HashMap<_, _>>();
+    for (track_offsets, PathItem { id, .. }) in track_offsets.iter().zip(path) {
+        let (at, simulation_waypoint) = match schedule_map.get(id) {
+            None => (id, SimulationWaypoint::PathItem),
+            Some(ScheduleItem {
+                at,
+                arrival,
+                stop_for,
+                reception_signal,
+            }) => (
+                at,
+                SimulationWaypoint::ScheduleItem {
+                    arrival_at: arrival.as_ref().map(|a| a.num_milliseconds() as u64),
+                    stop_for: stop_for.as_ref().map(|s| s.num_milliseconds() as u64),
+                    reception_signal: *reception_signal,
+                },
+            ),
+        };
+        simulation_train.push_waypoint(
+            track_offsets.iter().cloned().collect(),
+            at.clone(),
+            simulation_waypoint,
+        )
+    }
+    debug_assert!(
+        path.len() >= 2,
+        "there should be at least 2 path items for a train schedule"
+    );
+    let at_origin = path.first().map(|path_item| &path_item.id);
+    let at_destination = path.last().map(|path_item| &path_item.id);
+    debug_assert_eq!(
+        margins.boundaries.len() + 1,
+        margins.values.len(),
+        "there should be one more margin values than margin boundaries which indicate the intervals (origin and destination omitted)"
+    );
+    itertools::chain!(at_origin, &margins.boundaries, at_destination)
+        .tuple_windows()
+        .zip(&margins.values)
+        .for_each(|((at_from, at_to), margin_value)| {
+            simulation_train.set_margin(at_from, at_to, *margin_value);
+        });
+    power_restrictions.iter().for_each(|power_restriction| {
+        simulation_train.set_power_restriction(
+            &power_restriction.from,
+            &power_restriction.to,
+            power_restriction.value.clone(),
+        );
+    });
+    simulation_train
 }
 
 fn build_simulation_request<T: TrainScheduleLike>(

--- a/editoast/src/views/timetable/simulation.rs
+++ b/editoast/src/views/timetable/simulation.rs
@@ -11,6 +11,7 @@ use core_client::simulation::ReportTrain;
 use core_client::simulation::SimulationMargins;
 use core_client::simulation::SimulationPowerRestrictionItem;
 use core_client::simulation::SimulationScheduleItem;
+use core_client::simulation::SimulationSuccess;
 use core_client::simulation::SpeedLimitProperties;
 use core_task::PathfindingConsist;
 use core_task::SimulationConsist;
@@ -20,6 +21,7 @@ use core_task::SimulationWaypoint;
 use database::DbConnection;
 use itertools::Itertools;
 use ordered_float::OrderedFloat;
+use schemas::TrainOccurrence;
 use schemas::train_schedule::Margins;
 use schemas::train_schedule::PathItem;
 use schemas::train_schedule::PowerRestrictionItem;
@@ -349,6 +351,51 @@ impl SummaryResponse {
             simulation::Response::SimulationFailed { core_error } => Self::SimulationFailed {
                 error_type: core_error.error_type,
             },
+        }
+    }
+    pub fn from_simulation_output(
+        simulation_output: &core_task::SimulationOutput,
+        train_occurrence: &TrainOccurrence,
+    ) -> Self {
+        match simulation_output {
+            core_task::SimulationOutput::Success(SimulationSuccess {
+                base,
+                provisional,
+                final_output,
+                ..
+            }) => SummaryResponse::Success {
+                length: *final_output.report_train.positions.last().unwrap(),
+                time: *final_output.report_train.path_item_times.last().unwrap(),
+                energy_consumption: final_output.report_train.energy_consumption,
+                path_item_times_final: final_output.report_train.path_item_times.clone(),
+                path_item_times_provisional: provisional.path_item_times.clone(),
+                path_item_times_base: base.path_item_times.clone(),
+                path_item_respect_times: super::simulation::path_item_respect_times(
+                    &final_output.report_train.path_item_times,
+                    train_occurrence,
+                ),
+                path_item_respect_margins: super::simulation::path_item_respect_margins(
+                    &final_output.report_train.path_item_times,
+                    &provisional.path_item_times,
+                    train_occurrence,
+                ),
+            },
+            core_task::SimulationOutput::PathfindingFailure(pathfinding_failure) => {
+                match PathfindingResult::from(pathfinding_failure.clone()) {
+                    PathfindingResult::Success(_pathfinding_result_success) => {
+                        unreachable!("simulation only returns errors of pathfinding in this field")
+                    }
+                    PathfindingResult::Failure(PathfindingFailure::PathfindingInputError(
+                        pathfinding_input_error,
+                    )) => SummaryResponse::PathfindingInputError(pathfinding_input_error),
+                    PathfindingResult::Failure(PathfindingFailure::PathfindingNotFound(
+                        pathfinding_not_found,
+                    )) => SummaryResponse::PathfindingNotFound(pathfinding_not_found),
+                    PathfindingResult::Failure(PathfindingFailure::InternalError {
+                        core_error,
+                    }) => SummaryResponse::PathfindingFailure { core_error },
+                }
+            }
         }
     }
 }

--- a/editoast/src/views/timetable/simulation.rs
+++ b/editoast/src/views/timetable/simulation.rs
@@ -299,60 +299,6 @@ pub enum SummaryResponse {
 }
 
 impl SummaryResponse {
-    pub fn summarize_simulation<T: TrainScheduleLike>(
-        response: simulation::Response,
-        train_schedule: &T,
-    ) -> Self {
-        match response {
-            simulation::Response::Success(sim) => {
-                let path_item_respect_times = path_item_respect_times(
-                    &sim.final_output.report_train.path_item_times,
-                    train_schedule,
-                );
-                let path_item_respect_margins = path_item_respect_margins(
-                    &sim.final_output.report_train.path_item_times,
-                    &sim.provisional.path_item_times,
-                    train_schedule,
-                );
-
-                let SimulationResponseSuccess {
-                    final_output: CompleteReportTrain { report_train, .. },
-                    provisional,
-                    base,
-                    ..
-                } = sim;
-
-                Self::Success {
-                    length: *report_train.positions.last().unwrap(),
-                    time: *report_train.path_item_times.last().unwrap(),
-                    energy_consumption: report_train.energy_consumption,
-                    path_item_times_final: report_train.path_item_times,
-                    path_item_times_provisional: provisional.path_item_times,
-                    path_item_times_base: base.path_item_times.clone(),
-                    path_item_respect_times,
-                    path_item_respect_margins,
-                }
-            }
-            simulation::Response::PathfindingFailed { pathfinding_failed } => {
-                match pathfinding_failed {
-                    PathfindingFailure::InternalError { core_error } => {
-                        Self::PathfindingFailure { core_error }
-                    }
-
-                    PathfindingFailure::PathfindingInputError(input_error) => {
-                        Self::PathfindingInputError(input_error)
-                    }
-
-                    PathfindingFailure::PathfindingNotFound(not_found) => {
-                        Self::PathfindingNotFound(not_found)
-                    }
-                }
-            }
-            simulation::Response::SimulationFailed { core_error } => Self::SimulationFailed {
-                error_type: core_error.error_type,
-            },
-        }
-    }
     pub fn from_simulation_output(
         simulation_output: &core_task::SimulationOutput,
         train_occurrence: &TrainOccurrence,

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -1837,6 +1837,7 @@ mod tests {
     use crate::models::fixtures::create_created_exception_with_change_groups;
     use crate::models::fixtures::create_fast_rolling_stock;
     use crate::models::fixtures::create_paced_train_with_exceptions;
+    use crate::models::fixtures::create_rolling_stock_with_energy_sources;
     use crate::models::fixtures::create_simple_paced_train;
     use crate::models::fixtures::create_small_infra;
     use crate::models::fixtures::create_train_schedule_set;
@@ -2403,6 +2404,35 @@ mod tests {
                 },
                 ..Default::default()
             });
+        // Add one exception which will change the simulation from base with another rolling stock
+        // and therefore add another entry in the response (field `exceptions`)
+        create_rolling_stock_with_energy_sources(
+            &mut app.db_pool().get_ok(),
+            "exception_rolling_stock",
+        )
+        .await;
+        paced_train_response
+            .train_schedule
+            .paced
+            .as_mut()
+            .unwrap()
+            .exceptions
+            .push(PacedTrainException {
+                key: "change_rolling_stock".to_string(),
+                exception_type: ExceptionType::Modified {
+                    occurrence_index: 2,
+                },
+                change_groups: TrainScheduleExceptionChangeGroups {
+                    rolling_stock: Some(RollingStockChangeGroup {
+                        rolling_stock_name: "exception_rolling_stock".to_string(),
+                        // This property is what make the simulation request different
+                        // hence producing a different simulation
+                        comfort: Comfort::AirConditioning,
+                    }),
+                    ..Default::default()
+                },
+                ..Default::default()
+            });
         let request = app
             .put(format!("/train_schedules/{paced_train_id}").as_str())
             .json(&json!(paced_train_response.train_schedule));
@@ -2416,42 +2446,59 @@ mod tests {
                 "ids": vec![paced_train_id],
             }));
 
-        let response: HashMap<i64, TrainScheduleSummaryResponse> = app
+        let mut response: HashMap<i64, TrainScheduleSummaryResponse> = app
             .fetch(request)
             .await
             .assert_status(StatusCode::OK)
             .json_into();
         assert_eq!(response.len(), 1);
+
+        let TrainScheduleSummaryResponse {
+            train_schedule,
+            exceptions,
+        } = response.remove(&paced_train_id).unwrap();
         assert_eq!(
-            *response.get(&paced_train_id).unwrap(),
-            TrainScheduleSummaryResponse {
-                train_schedule: SummaryResponse::Success {
-                    length: 15_050_000,
-                    time: 3,
-                    energy_consumption: 0.0,
-                    path_item_times_final: vec![0, 1, 2, 3],
-                    path_item_times_provisional: vec![0, 1, 2, 3],
-                    path_item_times_base: vec![0, 1, 2, 3],
-                    path_item_respect_times: vec![true, false, true, false],
-                    path_item_respect_margins: vec![true, true, true, true],
-                },
-                exceptions: [(
-                    "change_initial_speed".to_string(),
-                    // Simulation of the exception is the same than base
-                    // because all simulation results from core are identical stubs
-                    SummaryResponse::Success {
-                        length: 15_050_000,
-                        time: 3,
-                        energy_consumption: 0.0,
-                        path_item_times_final: vec![0, 1, 2, 3],
-                        path_item_times_provisional: vec![0, 1, 2, 3],
-                        path_item_times_base: vec![0, 1, 2, 3],
-                        path_item_respect_times: vec![true, false, true, false],
-                        path_item_respect_margins: vec![true, true, true, true],
-                    }
-                )]
-                .into_iter()
-                .collect()
+            train_schedule,
+            SummaryResponse::Success {
+                length: 15_050_000,
+                time: 3,
+                energy_consumption: 0.0,
+                path_item_times_final: vec![0, 1, 2, 3],
+                path_item_times_provisional: vec![0, 1, 2, 3],
+                path_item_times_base: vec![0, 1, 2, 3],
+                path_item_respect_times: vec![true, false, true, false],
+                path_item_respect_margins: vec![true, true, true, true],
+            }
+        );
+
+        assert_eq!(
+            exceptions.get("change_rolling_stock").unwrap(),
+            // Simulation of the exception is the same than base
+            // because all simulation results from core are identical stubs
+            &SummaryResponse::Success {
+                length: 15_050_000,
+                time: 3,
+                energy_consumption: 0.0,
+                path_item_times_final: vec![0, 1, 2, 3],
+                path_item_times_provisional: vec![0, 1, 2, 3],
+                path_item_times_base: vec![0, 1, 2, 3],
+                path_item_respect_times: vec![true, false, true, false],
+                path_item_respect_margins: vec![true, true, true, true],
+            }
+        );
+        assert_eq!(
+            exceptions.get("change_initial_speed").unwrap(),
+            // Simulation of the exception is the same than base
+            // because all simulation results from core are identical stubs
+            &SummaryResponse::Success {
+                length: 15_050_000,
+                time: 3,
+                energy_consumption: 0.0,
+                path_item_times_final: vec![0, 1, 2, 3],
+                path_item_times_provisional: vec![0, 1, 2, 3],
+                path_item_times_base: vec![0, 1, 2, 3],
+                path_item_respect_times: vec![true, false, true, false],
+                path_item_respect_margins: vec![true, true, true, true],
             }
         );
     }

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::iter::Extend as _;
 use std::sync::Arc;
 
 use authz;
@@ -12,15 +13,18 @@ use axum::response::IntoResponse;
 use chrono::Duration;
 use core_client::AsCoreRequest;
 use core_client::CoreClient;
+use core_client::pathfinding::PathfindingInputError;
 use core_client::pathfinding::PathfindingResultSuccess;
 use core_client::signal_projection::SignalUpdate;
 use core_client::simulation::PhysicsConsist;
+use core_task::Correlated;
 use database::DbConnection;
 use database::DbConnectionPoolV2;
 use editoast_derive::EditoastError;
 use editoast_models::prelude::*;
 use editoast_models::round_trips::TrainScheduleRoundTrips;
-use itertools::Itertools;
+use futures::StreamExt as _;
+use itertools::Itertools as _;
 use itertools::izip;
 use reqwest::StatusCode;
 use schemas::infra::OperationalPoint;
@@ -33,11 +37,13 @@ use schemas::train_schedule::PathItemLocation;
 use serde::Deserialize;
 use serde::Serialize;
 use thiserror::Error;
+use tokio::sync::Mutex;
 use utoipa::IntoParams;
 use utoipa::ToSchema;
 
 use super::AppState;
 use super::AuthenticationExt;
+use crate::error::EditoastError as _;
 use crate::error::Result;
 use crate::models;
 use crate::models::Infra;
@@ -56,6 +62,7 @@ use crate::views::projection::SpaceTimeCurve;
 use crate::views::projection::compute_projected_train_path_op;
 use crate::views::projection::compute_projected_train_path_op_without_simulation;
 use crate::views::projection::compute_projected_train_paths;
+use crate::views::rolling_stock::RollingStockError;
 use crate::views::timetable::PhysicsConsistParameters;
 use crate::views::timetable::occupancy_blocks::OccupancyBlockForm;
 use crate::views::timetable::occupancy_blocks::OccupancyBlocks;
@@ -257,6 +264,35 @@ pub(in crate::views) struct TrainScheduleSummaryResponse {
     pub exceptions: HashMap<String, SummaryResponse>,
 }
 
+#[derive(Default)]
+struct TrainScheduleSummaryResponseBuilder {
+    train_schedule: Option<SummaryResponse>,
+    exceptions: HashMap<String, SummaryResponse>,
+}
+
+impl TrainScheduleSummaryResponseBuilder {
+    fn train_schedule(&mut self, summary_response: SummaryResponse) -> &mut Self {
+        self.train_schedule = Some(summary_response);
+        self
+    }
+    // Can be called multiple times for each exception to add
+    fn add_exception(
+        &mut self,
+        exception_key: String,
+        summary_response: SummaryResponse,
+    ) -> &mut Self {
+        self.exceptions.insert(exception_key, summary_response);
+        self
+    }
+    /// Only returns None if no summary response is available for the base occurrence
+    fn build(self) -> Option<TrainScheduleSummaryResponse> {
+        Some(TrainScheduleSummaryResponse {
+            train_schedule: self.train_schedule?,
+            exceptions: self.exceptions,
+        })
+    }
+}
+
 #[derive(Debug, Clone)]
 struct SimulationContext {
     train_schedule_id: i64,
@@ -277,7 +313,6 @@ struct SimulationContext {
 )]
 pub(in crate::views) async fn simulation_summary(
     State(AppState {
-        config,
         db_pool,
         valkey_client,
         core_client,
@@ -313,6 +348,25 @@ pub(in crate::views) async fn simulation_summary(
     })
     .await?;
 
+    /////
+    // Init the simulation environment
+    let core_env = core_task::CoreEnv {
+        infra_id: infra.id as u64,
+        infra_version: infra.version,
+        client: core_client.clone(),
+    };
+    let mut simulation_env =
+        if let Some(electrical_profile_set_id) = electrical_profile_set_id.map(|i| i as u64) {
+            core_task::SimulationEnv::new_with_electrical_profile_set(
+                core_env,
+                electrical_profile_set_id,
+            )
+        } else {
+            core_task::SimulationEnv::new(core_env)
+        };
+
+    /////
+    // Generate the train simulation inputs
     let train_schedules: Vec<models::TrainSchedule> =
         models::TrainSchedule::retrieve_batch_or_fail(conn, train_schedule_ids, |missing| {
             TrainScheduleError::BatchNotFound {
@@ -321,76 +375,206 @@ pub(in crate::views) async fn simulation_summary(
         })
         .await?;
 
-    let simulation_contexts: Vec<SimulationContext> = train_schedules
+    let train_occurrences = train_schedules
         .iter()
-        .flat_map(|train_schedule| {
-            std::iter::once(SimulationContext {
-                train_schedule_id: train_schedule.id,
-                exception_key: None,
-                train_schedule: train_schedule.clone().into_train_occurrence(),
+        .flat_map(models::TrainSchedule::iter_occurrences)
+        .collect::<HashMap<_, _>>();
+
+    // Get the physic consist parameters for the train schedules
+    let rolling_stocks_ids = train_occurrences
+        .values()
+        .map::<String, _>(|train_occurrence| train_occurrence.rolling_stock_name.to_string())
+        .collect::<HashSet<_>>();
+
+    let consists =
+        RollingStock::retrieve_batch_unchecked::<_, Vec<_>>(&mut conn.clone(), rolling_stocks_ids)
+            .await
+            .map_err(RollingStockError::from)?
+            .into_iter()
+            .map(|rolling_stock| {
+                (
+                    rolling_stock.name.clone(),
+                    PhysicsConsistParameters::from_traction_engine(rolling_stock.into()),
+                )
             })
-            .chain(train_schedule.exceptions.iter().map(|exception| {
-                SimulationContext {
-                    train_schedule_id: train_schedule.id,
-                    exception_key: Some(exception.key.clone()),
-                    train_schedule: train_schedule.apply_exception(exception),
-                }
-            }))
+            .collect::<HashMap<_, _>>();
+
+    // Associate train schedules with their consist, when possible
+    let (train_occurrences_with_physics_consist, not_found_rolling_stock_names) = train_occurrences
+        .into_iter()
+        .map(|(occurrence_id, train_occurrence)| {
+            let rolling_stock_name = train_occurrence.rolling_stock_name.clone();
+            consists
+                .get(&rolling_stock_name)
+                .map(|consist| (occurrence_id.clone(), (train_occurrence, consist)))
+                .ok_or((occurrence_id, rolling_stock_name))
         })
-        .collect();
+        .partition_result::<HashMap<_, _>, Vec<_>, _, _>();
 
-    let schedules: Vec<schemas::TrainOccurrence> = simulation_contexts
-        .iter()
-        .map(|ctx| ctx.train_schedule.clone())
-        .collect();
+    // Build the operational point cache
+    let path_items = train_occurrences_with_physics_consist
+        .values()
+        .flat_map(|(train_occurrence, _physics_consist)| &train_occurrence.path)
+        .map(|path_item| &path_item.location)
+        .collect_vec();
+    let path_item_cache =
+        OperationalPointCache::load_path_items(conn.clone(), infra.id, &path_items).await?;
 
-    let simulations = train_simulation_batch(
-        conn,
-        valkey_client,
-        core_client,
-        &schedules,
-        &infra,
-        electrical_profile_set_id,
-        config.app_version.as_deref(),
-    )
-    .await?;
-
-    // Will remember all simulation that already have been inserted in the response
-    let mut base_simulation = Arc::clone(&simulations[0].0);
-    let results = simulation_contexts.into_iter().zip(simulations).fold(
-        HashMap::<i64, TrainScheduleSummaryResponse>::new(),
-        |mut map, (simulation_context, (simulation, _path))| {
-            if let Some(exception_key) = &simulation_context.exception_key {
-                if !Arc::ptr_eq(&base_simulation, &simulation) {
-                    map.entry(simulation_context.train_schedule_id)
-                        .and_modify(|summary| {
-                            summary.exceptions.insert(
-                                exception_key.to_string(),
-                                SummaryResponse::summarize_simulation(
-                                    Arc::unwrap_or_clone(simulation),
-                                    &simulation_context.train_schedule,
-                                ),
-                            );
-                        });
-                }
-            } else {
-                base_simulation = Arc::clone(&simulation);
-                map.insert(
-                    simulation_context.train_schedule_id,
-                    TrainScheduleSummaryResponse {
-                        train_schedule: SummaryResponse::summarize_simulation(
-                            Arc::unwrap_or_clone(simulation),
-                            &simulation_context.train_schedule,
-                        ),
-                        exceptions: HashMap::new(),
-                    },
-                );
-            }
-            map
+    // Build the simulation trains for the simulation environment
+    let simulation_trains = train_occurrences_with_physics_consist.iter().map(
+        |(occurrence_id, (train_occurrence, physics_consist_parameters))| {
+            (
+                occurrence_id.clone(),
+                simulation::build_simulation_train(
+                    train_occurrence,
+                    physics_consist_parameters,
+                    &path_item_cache,
+                ),
+            )
         },
     );
 
-    Ok(Json(results))
+    /////
+    // Populate the simulation environment and simulate
+    simulation_env.extend(simulation_trains);
+    let simulations = simulation_env
+        .into_stream(Arc::new(Mutex::new(valkey_client.get_connection().await?)))
+        .collect::<Vec<_>>()
+        .await;
+
+    /////
+    // Prepare the API responses from the core simulation
+
+    // Duplicate simulations for each trai schedule
+    let simulations = simulations.into_iter().flat_map(
+        |Correlated {
+             correlation_key,
+             data,
+         }| {
+            // Simulation from different train schedules might be grouped into
+            // the same correlation object (each having its own correlation key
+            // still), but the final response need one simulation for each train
+            // schedule (not each occurrence of the same train schedule though)
+            let grouped_correlation_keys = correlation_key
+                .into_iter()
+                .into_grouping_map_by(|occurrence_id| match occurrence_id {
+                    OccurrenceId::Base {
+                        train_schedule_id,
+                        index: _,
+                    }
+                    | OccurrenceId::Modified {
+                        train_schedule_id,
+                        index: _,
+                        exception_key: _,
+                    }
+                    | OccurrenceId::Created {
+                        train_schedule_id,
+                        exception_key: _,
+                    } => *train_schedule_id,
+                })
+                .collect::<HashSet<_>>();
+            grouped_correlation_keys
+                .into_values()
+                .map(move |correlation_key| Correlated {
+                    correlation_key,
+                    data: data.clone(),
+                })
+        },
+    );
+
+    // Collect all the simulations per train schedule
+    let simulation_summaries = simulations
+        .into_iter()
+        .flat_map(
+            |Correlated {
+                 correlation_key,
+                 data,
+             }| {
+                let correlation_key = if let Some(base) = correlation_key
+                    .iter()
+                    .find(|occurrence_id| matches!(occurrence_id, OccurrenceId::Base { .. }))
+                {
+                    // We need to produce only one simulation response for all
+                    // occurrences that are identical to the base occurrence
+                    HashSet::from([base.clone()])
+                } else {
+                    correlation_key
+                };
+                correlation_key
+                    .into_iter()
+                    .map(move |occurrence_id| (occurrence_id, data.clone()))
+            },
+        )
+        .map(|(occurrence_id, data)| {
+            let summary_response = match &data {
+                Ok(simulation_output) => {
+                    let train_occurrence = train_occurrences_with_physics_consist
+                        .get(&occurrence_id)
+                        .map(|(train_occurrence, _physic_consist)| train_occurrence)
+                        .unwrap_or_else(|| {
+                            panic!(
+                                "no train schedule occurrence “{occurrence_id}” has been simulated"
+                            )
+                        });
+                    SummaryResponse::from_simulation_output(simulation_output, train_occurrence)
+                }
+                Err(error) => SummaryResponse::SimulationFailed {
+                    error_type: error.get_type().to_owned(),
+                },
+            };
+            (occurrence_id, summary_response)
+        })
+        .chain(not_found_rolling_stock_names.into_iter().map(
+            |(occurrence_id, rolling_stock_name)| {
+                (
+                    occurrence_id,
+                    SummaryResponse::PathfindingInputError(
+                        PathfindingInputError::RollingStockNotFound { rolling_stock_name },
+                    ),
+                )
+            },
+        ))
+        .fold(
+            HashMap::<i64, TrainScheduleSummaryResponseBuilder>::default(),
+            |mut simulation_summaries, (occurrence_id, summary_response)| {
+                match occurrence_id {
+                    OccurrenceId::Base {
+                        train_schedule_id,
+                        index: _,
+                    } => {
+                        let builder = simulation_summaries.entry(train_schedule_id).or_default();
+                        builder.train_schedule(summary_response);
+                    }
+                    OccurrenceId::Modified {
+                        train_schedule_id,
+                        index: _,
+                        exception_key,
+                    }
+                    | OccurrenceId::Created {
+                        train_schedule_id,
+                        exception_key,
+                    } => {
+                        let builder = simulation_summaries.entry(train_schedule_id).or_default();
+                        builder.add_exception(exception_key, summary_response);
+                    }
+                }
+                simulation_summaries
+            },
+        )
+        .into_iter()
+        .map(
+            |(train_schedule_id, train_schedule_summary_response_builder)| {
+                (
+                train_schedule_id,
+                train_schedule_summary_response_builder.build().unwrap_or_else(|| panic!(
+                    "no simulation was received for the paced train’s base ‘{train_schedule_id}’"
+                )),
+            )
+            },
+        )
+        .collect();
+
+    Ok(Json(simulation_summaries))
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, IntoParams, ToSchema)]


### PR DESCRIPTION
🔍 Review each commit and its description that explains some implementation choices.

Two things make the code more clutter that it could be.

# respect_path_item_(times|margins)

To calculate those, we need to keep around a `HashMap` of all the train schedules per ID because those values are calculated from the simulation results (output) and the path items (inputs).

Perhaps it's possible that `SimulationEnv` takes care of it directly which would avoid this bookkeeping?

# Deduplication (the biggest clutter)

The deduplication of simulations by `SimulationEnv` works well… too well actually. Because the response will produce at least one result for each train schedule (and all the exceptions if those are different). But multiple trains may have the same simulation inputs (and therefore same output). Maybe the API is not ideal and should be changed to something similar to what `SimulationEnv` returns: a simulation result associated with the list of concerned trains. But for another PR if we decide something like that.