### PR TITLE
docker: fix editoast user add command invocation in pr-test script

### DIFF
--- a/docker/docker-compose.pr-tests.yml
+++ b/docker/docker-compose.pr-tests.yml
@@ -202,7 +202,7 @@ services:
       /bin/sh -c "
         fga_migrations apply &&
         diesel migration run --locked-schema &&
-        editoast user add 'mock/mocked' 'Example User' &&
+        editoast user add 'Example User' 'mock/mocked' &&
         editoast roles add 'mock/mocked' Admin &&
         exec editoast runserver"
     healthcheck:


### PR DESCRIPTION
The arguments have been swapped in this commit:
12761b1ad00b38868c5d537f19ddb63c4783a6cc

closes https://github.com/OpenRailAssociation/osrd/issues/15466

# how to test

use the script, with this change it should work