### PR TITLE
front, editoast: drop `ignore_secondary_code` param from `/match_operational_points`

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -1178,9 +1178,6 @@ paths:
               required:
               - operational_point_references
               properties:
-                ignore_secondary_code:
-                  type: boolean
-                  description: When true, ignores secondary_code matching and returns all OPs with the given trigram/UIC.
                 operational_point_references:
                   type: array
                   items:

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -770,9 +770,6 @@ pub(in crate::views) async fn unlock(
 #[cfg_attr(test, derive(Serialize))]
 pub(in crate::views) struct MatchOperationalPointsForm {
     operational_point_references: Vec<OperationalPointReference>,
-    /// When true, ignores secondary_code matching and returns all OPs with the given trigram/UIC.
-    #[serde(default)]
-    ignore_secondary_code: bool,
 }
 
 #[derive(Serialize, ToSchema)]
@@ -822,7 +819,6 @@ pub(in crate::views) async fn match_operational_points(
     Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
     Json(MatchOperationalPointsForm {
         operational_point_references,
-        ignore_secondary_code,
     }): Json<MatchOperationalPointsForm>,
 ) -> Result<Json<MatchOperationalPointsResponse>> {
     let authorized = auth
@@ -847,7 +843,7 @@ pub(in crate::views) async fn match_operational_points(
     for operational_point_reference in operational_point_references {
         // Retrieve related OPs based on the input operational point identifier:
         let related_operational_points = op_cache
-            .get_reference(operational_point_reference, ignore_secondary_code)
+            .get_reference(operational_point_reference)
             .expect("should get the provided reference");
 
         // Add the operational point reference related operational points to the response:
@@ -1413,7 +1409,6 @@ pub mod tests {
             .post(format!("/infra/{}/match_operational_points", infra.id).as_str())
             .json(&json!({
                 "operational_point_references": operational_point_references,
-                "ignore_secondary_code": false
             }));
         let response: MatchOperationalPointsResponse = app
             .fetch(request)
@@ -1462,7 +1457,6 @@ pub mod tests {
             .post(format!("/infra/{}/match_operational_points", infra.id).as_str())
             .json(&json!({
                 "operational_point_references": operational_point_references,
-                "ignore_secondary_code": false
             }));
         let response: MatchOperationalPointsResponse = app
             .fetch(request)
@@ -1475,57 +1469,6 @@ pub mod tests {
             .map(|op_ref| op_ref.iter().map(|op| op.id.as_str()).collect::<Vec<_>>())
             .collect::<Vec<_>>();
         let expected_identifiers: [Vec<&str>; 2] = [vec![], vec![]];
-        assert_eq!(response_op_identifiers, expected_identifiers);
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn match_operational_points_with_ignore_secondary_code() {
-        let app = TestAppBuilder::default_app();
-        let db_pool = app.db_pool();
-        let mut infra = create_small_infra(&mut db_pool.get_ok()).await;
-        let infra_cache = InfraCache::load(&mut db_pool.get_ok(), &infra)
-            .await
-            .unwrap();
-        infra
-            .refresh(db_pool.clone(), false, &infra_cache)
-            .await
-            .unwrap();
-
-        // Test with ignore_secondary_code set to true to retrieve all OPs with this trigram or UIC
-        let operational_point_references = vec![
-            OperationalPointReference::Id {
-                operational_point: ("West_station").into(),
-            },
-            OperationalPointReference::Trigram {
-                trigram: "MES".into(),
-                secondary_code: Some("BV".into()),
-            },
-            OperationalPointReference::Uic {
-                uic: 8755,
-                secondary_code: None,
-            },
-        ];
-        let request = app
-            .post(format!("/infra/{}/match_operational_points", infra.id).as_str())
-            .json(&json!({
-                "operational_point_references": operational_point_references,
-                "ignore_secondary_code": true
-            }));
-        let response: MatchOperationalPointsResponse = app
-            .fetch(request)
-            .await
-            .assert_status(StatusCode::OK)
-            .json_into();
-        let response_op_identifiers = response
-            .related_operational_points
-            .iter()
-            .map(|op_ref| op_ref.iter().map(|op| op.id.as_str()).collect::<Vec<_>>())
-            .collect_vec();
-        let expected_identifiers = [
-            vec!["West_station"],
-            vec!["Mid_East_station"],
-            vec!["North_station"],
-        ];
         assert_eq!(response_op_identifiers, expected_identifiers);
     }
 

--- a/editoast/src/views/path/operational_point_cache.rs
+++ b/editoast/src/views/path/operational_point_cache.rs
@@ -366,7 +366,6 @@ impl OperationalPointCache {
     pub fn get_reference(
         &self,
         op_ref: OperationalPointReference,
-        ignore_secondary_code: bool,
     ) -> Result<Vec<&OperationalPoint>> {
         let related_operational_points = match op_ref {
             OperationalPointReference::Id {
@@ -381,13 +380,9 @@ impl OperationalPointCache {
                 secondary_code,
             } => {
                 if let Some(op_models) = self.get_from_trigram(&trigram.0) {
-                    if ignore_secondary_code {
-                        op_models.map(|op_model| &op_model.schema).collect()
-                    } else {
-                        find_op_by_secondary_code(secondary_code.as_ref(), op_models.collect())
-                            .map(|op| vec![&op.schema])
-                            .unwrap_or_default()
-                    }
+                    find_op_by_secondary_code(secondary_code.as_ref(), op_models.collect())
+                        .map(|op| vec![&op.schema])
+                        .unwrap_or_default()
                 } else {
                     vec![]
                 }
@@ -397,13 +392,9 @@ impl OperationalPointCache {
                 secondary_code,
             } => {
                 if let Some(op_models) = self.get_from_uic(uic) {
-                    if ignore_secondary_code {
-                        op_models.map(|op_model| &op_model.schema).collect()
-                    } else {
-                        find_op_by_secondary_code(secondary_code.as_ref(), op_models.collect())
-                            .map(|op| vec![&op.schema])
-                            .unwrap_or_default()
-                    }
+                    find_op_by_secondary_code(secondary_code.as_ref(), op_models.collect())
+                        .map(|op| vec![&op.schema])
+                        .unwrap_or_default()
                 } else {
                     vec![]
                 }

--- a/front/src/applications/operationalStudies/hooks/usePathOps.ts
+++ b/front/src/applications/operationalStudies/hooks/usePathOps.ts
@@ -12,13 +12,7 @@ import type { Train } from 'reducers/osrdconf/types';
 /**
  * Given a train's path, return the operational points corresponding to the pathSteps of this train
  */
-const usePathOps = (
-  infraId: number,
-  path?: Train['path'],
-  options?: {
-    ignoreSecondaryCode: boolean;
-  }
-): RelatedOperationalPoint[] => {
+const usePathOps = (infraId: number, path?: Train['path']): RelatedOperationalPoint[] => {
   const operationalPointReferences: OperationalPointReference[] = useMemo(
     () =>
       (path ?? []).reduce<OperationalPointReference[]>((acc, pathItem) => {
@@ -37,7 +31,6 @@ const usePathOps = (
             infraId,
             body: {
               operational_point_references: operationalPointReferences,
-              ignore_secondary_code: options?.ignoreSecondaryCode ?? false,
             },
           }
         : skipToken

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/hooks/usePathStepsMetadata.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/hooks/usePathStepsMetadata.ts
@@ -1,7 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 
 import type { Position } from 'geojson';
-import { v4 as uuid } from 'uuid';
 
 import usePathOps from 'applications/operationalStudies/hooks/usePathOps';
 import { useScenarioContext } from 'applications/operationalStudies/hooks/useScenarioContext';
@@ -36,57 +35,14 @@ export const usePathStepsMetadata = (pathSteps: PathStepV2[]) => {
     [pathSteps]
   );
 
-  const pathStepsOperationalPoints = usePathOps(infraId, trainPath, {
-    ignoreSecondaryCode: true,
-  });
-
-  // 2. Since a path step containing 'operational_point' as location will have only one match
-  // with postInfraByInfraIdMatchOperationalPoints, we need to call the endpoint again with
-  // the opId corresponding uic in order to get all the possible matches and have
-  // all the secondary codes and track names
-  const uicTrainPath: TrainSchedule['path'] = useMemo(() => {
-    const opIds = pathSteps.reduce<string[]>((acc, step) => {
-      if (
-        step.location &&
-        'operational_point' in step.location &&
-        step.location.operational_point.type === 'id'
-      ) {
-        acc.push(step.location.operational_point.operational_point);
-      }
-      return acc;
-    }, []);
-
-    if (opIds.length === 0) return [];
-
-    return pathStepsOperationalPoints
-      .filter((op) => op.extensions?.identifier?.uic)
-      .map((op) => ({
-        // The step id is required by the type but ignored by usePathOps
-        id: uuid(),
-        location: {
-          operational_point: {
-            type: 'uic' as const,
-            uic: op.extensions!.identifier!.uic,
-          },
-        },
-      }));
-  }, [pathSteps, pathStepsOperationalPoints]);
-
-  const allOpIdsOperationalPoints = usePathOps(infraId, uicTrainPath, {
-    ignoreSecondaryCode: true,
-  });
-
-  // 3. Merge both operational points lists to have all possible matches
-  const allOps = useMemo(
-    () => [...pathStepsOperationalPoints, ...allOpIdsOperationalPoints],
-    [pathStepsOperationalPoints, allOpIdsOperationalPoints]
-  );
+  // 2. Fetch OPs for each path step
+  const pathStepsOperationalPoints = usePathOps(infraId, trainPath);
 
   useEffect(() => {
     const fetchAndSetMetadata = async () => {
-      // 4. Get all track ids of all matched operational points to get all tracks metadata
+      // 3. Get all track ids of all matched operational points to get all tracks metadata
       const matchedTrackIds = new Set<string>();
-      allOps.forEach((op) => {
+      pathStepsOperationalPoints.forEach((op) => {
         op.parts.forEach((part) => {
           matchedTrackIds.add(part.track);
         });
@@ -100,7 +56,7 @@ export const usePathStepsMetadata = (pathSteps: PathStepV2[]) => {
 
       const trackSectionsById = await getTrackSectionsByIds(allTrackIds);
 
-      // 5. Loop of the path steps to build the metadata map
+      // 4. Loop of the path steps to build the metadata map
       const newPathStepsMetadataById = new Map<string, PathStepMetadata>();
 
       pathSteps.forEach((pathStep) => {
@@ -140,7 +96,7 @@ export const usePathStepsMetadata = (pathSteps: PathStepV2[]) => {
         }
         // Find the matching operational point for this pathStep to get
         // its valid status and its name
-        const matchedOp = allOps.find((op) => {
+        const matchedOp = pathStepsOperationalPoints.find((op) => {
           if (location.operational_point.type === 'id') {
             return location.operational_point.operational_point === op.id;
           }
@@ -192,7 +148,7 @@ export const usePathStepsMetadata = (pathSteps: PathStepV2[]) => {
       setPathStepsMetadataById(newPathStepsMetadataById);
     };
     fetchAndSetMetadata();
-  }, [allOps, pathSteps]);
+  }, [pathStepsOperationalPoints, pathSteps]);
 
   return { pathStepsMetadataById, setPathStepsMetadataById };
 };

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -1736,8 +1736,6 @@ export type PostInfraByInfraIdMatchOperationalPointsApiArg = {
   /** An existing infra ID */
   infraId: number;
   body: {
-    /** When true, ignores secondary_code matching and returns all OPs with the given trigram/UIC. */
-    ignore_secondary_code?: boolean;
     operational_point_references: OperationalPointReference[];
   };
 };

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -149,9 +149,9 @@ const osrdEditoastApi = generatedEditoastApi
       }),
       matchAllOperationalPoints: builder.query<
         RelatedOperationalPoint[][],
-        { infraId: number; opRefs: OperationalPointReference[]; ignoreSecondaryCode?: boolean }
+        { infraId: number; opRefs: OperationalPointReference[] }
       >({
-        queryFn: async ({ infraId, opRefs, ignoreSecondaryCode }, { dispatch }) => {
+        queryFn: async ({ infraId, opRefs }, { dispatch }) => {
           const batchSize = 200;
           const result: RelatedOperationalPoint[][] = [];
 
@@ -165,7 +165,6 @@ const osrdEditoastApi = generatedEditoastApi
                   infraId,
                   body: {
                     operational_point_references: batch,
-                    ignore_secondary_code: ignoreSecondaryCode ?? false,
                   },
                 },
                 { subscribe: false }


### PR DESCRIPTION
_See individual commits._