### PR TITLE
compose: fix script shebang for nixos

### DIFF
--- a/osrd-compose
+++ b/osrd-compose
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eo pipefail
 


### PR DESCRIPTION
The shebang was changed here: https://github.com/OpenRailAssociation/osrd/pull/15404
But not working on NixOS.
This PR reverts this specific change.