### PR TITLE
front: add useDebounce and useDebounceFunc tests

### DIFF
--- a/front/src/applications/operationalStudies/components/FilterTextField.tsx
+++ b/front/src/applications/operationalStudies/components/FilterTextField.tsx
@@ -4,7 +4,7 @@ import { Search } from '@osrd-project/ui-icons';
 import { useTranslation } from 'react-i18next';
 
 import InputSNCF from 'common/BootstrapSNCF/InputSNCF';
-import { useDebounce } from 'utils/helpers';
+import { useDebounce } from 'utils/hooks/useDebounce';
 
 type Props = {
   id: string;

--- a/front/src/applications/operationalStudies/hooks/useOperationalPointSearch.ts
+++ b/front/src/applications/operationalStudies/hooks/useOperationalPointSearch.ts
@@ -4,7 +4,7 @@ import { uniqBy } from 'lodash';
 
 import { osrdEditoastApi, type SearchResultItemOperationalPoint } from 'common/api/osrdEditoastApi';
 import { useInfraID } from 'common/osrdContext';
-import { useDebounce } from 'utils/helpers';
+import { useDebounce } from 'utils/hooks/useDebounce';
 import { toUpper } from 'utils/strings';
 
 import { rankSuggestions, markSuggestions } from '../helpers/rankingSuggestions';

--- a/front/src/applications/operationalStudies/views/Scenario/components/RoundTrips/RoundTripsModal.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/RoundTrips/RoundTripsModal.tsx
@@ -10,7 +10,7 @@ import { checkRoundTripCompatible, groupRoundTrips } from 'applications/operatio
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import { useSubCategoryContext } from 'common/SubCategoryContext';
 import type { TimetableItem, TimetableItemId } from 'reducers/osrdconf/types';
-import { useDebounce } from 'utils/helpers';
+import { useDebounce } from 'utils/hooks/useDebounce';
 import useModalFocusTrap from 'utils/hooks/useModalFocusTrap';
 import { mapBy } from 'utils/types';
 

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/useFilterTimetableItems.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/useFilterTimetableItems.ts
@@ -6,7 +6,7 @@ import { useRollingStockContext } from 'common/RollingStockContext';
 import isMainCategory from 'modules/rollingStock/helpers/category';
 import { isPacedTrainWithDetails } from 'modules/timetableItem/helpers/pacedTrain';
 import type { TimetableItemWithDetails } from 'modules/timetableItem/types';
-import { useDebounce } from 'utils/helpers';
+import { useDebounce } from 'utils/hooks/useDebounce';
 
 import type {
   TimetableFilters,

--- a/front/src/applications/stdcm/components/StdcmForm/StopDurationInput.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StopDurationInput.tsx
@@ -7,7 +7,7 @@ import { updateStdcmPathStep } from 'reducers/osrdconf/stdcmConf';
 import type { StdcmPathStep } from 'reducers/osrdconf/types';
 import { useAppDispatch } from 'store';
 import { Duration } from 'utils/duration';
-import { useDebounce } from 'utils/helpers';
+import { useDebounce } from 'utils/hooks/useDebounce';
 import { parseNumber } from 'utils/strings';
 
 import { StdcmStopTypes } from '../../types';

--- a/front/src/common/BootstrapSNCF/FormSNCF/DebouncedNumberInputSNCF.tsx
+++ b/front/src/common/BootstrapSNCF/FormSNCF/DebouncedNumberInputSNCF.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 
 import InputSNCF from 'common/BootstrapSNCF/InputSNCF';
-import { useDebouncedFunc } from 'utils/helpers';
+import { useDebouncedFunc } from 'utils/hooks/useDebounce';
 
 type DebouncedNumberInputSNCFProps = {
   input: number;

--- a/front/src/common/Map/Search/MapSearchLine.tsx
+++ b/front/src/common/Map/Search/MapSearchLine.tsx
@@ -11,7 +11,7 @@ import { useInfraID } from 'common/osrdContext';
 import { useMapSettingsActions } from 'reducers/commonMap';
 import type { MapSettings, Viewport } from 'reducers/commonMap/types';
 import { useAppDispatch } from 'store';
-import { useDebounce } from 'utils/helpers';
+import { useDebounce } from 'utils/hooks/useDebounce';
 
 type MapSearchLineProps = {
   updateExtViewport: (viewport: Partial<Viewport>) => void;

--- a/front/src/common/Map/Search/MapSearchSignal.tsx
+++ b/front/src/common/Map/Search/MapSearchSignal.tsx
@@ -21,7 +21,7 @@ import { useMapSettingsActions } from 'reducers/commonMap';
 import { setFailure } from 'reducers/main';
 import { useAppDispatch } from 'store';
 import { castErrorToFailure } from 'utils/error';
-import { useDebounce } from 'utils/helpers';
+import { useDebounce } from 'utils/hooks/useDebounce';
 
 type MapSearchSignalProps = {
   closeMapSearchPopUp: () => void;

--- a/front/src/common/Map/Search/useSearchOperationalPoint.tsx
+++ b/front/src/common/Map/Search/useSearchOperationalPoint.tsx
@@ -9,7 +9,7 @@ import { setFailure } from 'reducers/main';
 import { getOperationalPoints } from 'reducers/osrdconf/stdcmConf/selectors';
 import { getIsSuperUser } from 'reducers/user/userSelectors';
 import { castErrorToFailure } from 'utils/error';
-import { useDebounce } from 'utils/helpers';
+import { useDebounce } from 'utils/hooks/useDebounce';
 
 import { MAIN_OP_CH_CODES } from './consts';
 import {

--- a/front/src/common/NavBar/UserSettings.tsx
+++ b/front/src/common/NavBar/UserSettings.tsx
@@ -19,8 +19,8 @@ import SwitchSNCF, { SWITCH_TYPES } from 'common/BootstrapSNCF/SwitchSNCF';
 import { updateUserPreferences } from 'reducers/user';
 import { getUserPreferences } from 'reducers/user/userSelectors';
 import { useAppDispatch } from 'store';
-import { useDebounce } from 'utils/helpers';
 import useAuth from 'utils/hooks/useAuth';
+import { useDebounce } from 'utils/hooks/useDebounce';
 
 const UserSettings = () => {
   const [postSearch] = osrdEditoastApi.endpoints.postSearch.useLazyQuery();

--- a/front/src/common/useSearchUsers.ts
+++ b/front/src/common/useSearchUsers.ts
@@ -2,7 +2,7 @@ import { useState, useMemo } from 'react';
 
 import { skipToken } from '@reduxjs/toolkit/query';
 
-import { useDebounce } from 'utils/helpers';
+import { useDebounce } from 'utils/hooks/useDebounce';
 
 import type { SearchResultItemUser } from './api/generatedEditoastApi';
 import { osrdEditoastApi } from './api/osrdEditoastApi';

--- a/front/src/modules/infra/components/InfraSelector/InfraSelectorModal.tsx
+++ b/front/src/modules/infra/components/InfraSelector/InfraSelectorModal.tsx
@@ -12,7 +12,7 @@ import { Loader } from 'common/Loaders';
 import { setFailure } from 'reducers/main';
 import { useAppDispatch } from 'store';
 import { castErrorToFailure } from 'utils/error';
-import { useDebounce } from 'utils/helpers';
+import { useDebounce } from 'utils/hooks/useDebounce';
 import useDeploymentSettings from 'utils/hooks/useDeploymentSettings';
 
 import InfraSelectorModalBodyEdition from './InfraSelectorModalBodyEdition';

--- a/front/src/modules/pathfinding/components/Pathfinding/TypeAndPath.tsx
+++ b/front/src/modules/pathfinding/components/Pathfinding/TypeAndPath.tsx
@@ -15,7 +15,7 @@ import type {
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import { MAIN_OP_CH_CODES } from 'common/Map/Search/consts';
 import { useInfraID } from 'common/osrdContext';
-import { useDebounce } from 'utils/helpers';
+import { useDebounce } from 'utils/hooks/useDebounce';
 import {
   isCursorSurroundedBySpace,
   findCurrentWord,

--- a/front/src/modules/project/components/AddOrEditProjectModal.tsx
+++ b/front/src/modules/project/components/AddOrEditProjectModal.tsx
@@ -31,7 +31,7 @@ import { setFailure, setSuccess } from 'reducers/main';
 import { getUserSafeWord } from 'reducers/user/userSelectors';
 import { useAppDispatch } from 'store';
 import { castErrorToFailure } from 'utils/error';
-import { useDebounce } from 'utils/helpers';
+import { useDebounce } from 'utils/hooks/useDebounce';
 import useInputChange from 'utils/hooks/useInputChange';
 import useModalFocusTrap from 'utils/hooks/useModalFocusTrap';
 import useOutsideClick from 'utils/hooks/useOutsideClick';

--- a/front/src/utils/helpers.ts
+++ b/front/src/utils/helpers.ts
@@ -1,39 +1,3 @@
-import { useState, useEffect } from 'react';
-
-/**
- * Debounce input fields
- */
-export const useDebounce = <T = string | number>(value: T, delay: number): T => {
-  const [debouncedValue, setDebouncedValue] = useState(value);
-  useEffect(() => {
-    const handler = setTimeout(() => {
-      setDebouncedValue(value);
-    }, delay);
-    return () => {
-      clearTimeout(handler);
-    };
-  }, [value, delay]);
-  return debouncedValue;
-};
-
-/**
- * Debounce function
- */
-export const useDebouncedFunc = <T = (number | null) | (string | null)>(
-  value: T,
-  delay: number,
-  func: (newValue: T) => void
-) => {
-  useEffect(() => {
-    const handler = setTimeout(() => {
-      func(value);
-    }, delay);
-    return () => {
-      clearTimeout(handler);
-    };
-  }, [value, delay]);
-};
-
 /**
  * Given a boolean isHovering, returns the pointer class string
  */

--- a/front/src/utils/hooks/__tests__/useDebounce.spec.ts
+++ b/front/src/utils/hooks/__tests__/useDebounce.spec.ts
@@ -1,0 +1,117 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import { useDebounce, useDebouncedFunc } from '../useDebounce';
+
+vi.useFakeTimers();
+
+describe('useDebounce', () => {
+  it('should debounce value', () => {
+    const { result, rerender } = renderHook((value) => useDebounce<string>(value, 500), {
+      initialProps: 'Hello',
+    });
+
+    expect(result.current).toBe('Hello');
+
+    act(() => {
+      rerender('Hello, World!');
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(result.current).toBe('Hello, World!');
+
+    act(() => {
+      rerender('Hello, World! Again!');
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(result.current).toBe('Hello, World! Again!');
+  });
+
+  it('should clear timeout on unmount', () => {
+    const { result, rerender, unmount } = renderHook((value) => useDebounce<string>(value, 500), {
+      initialProps: 'Hello',
+    });
+
+    expect(result.current).toBe('Hello');
+
+    act(() => {
+      rerender('Hello, World!');
+    });
+
+    act(() => {
+      unmount();
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(result.current).toBe('Hello');
+  });
+});
+
+describe('useDebouncedFunc', () => {
+  it('should debounce function', () => {
+    const mockFunc = vi.fn();
+    const { rerender } = renderHook((value) => useDebouncedFunc<string>(value, 500, mockFunc), {
+      initialProps: 'Hello',
+    });
+
+    expect(mockFunc).not.toHaveBeenCalled();
+
+    act(() => {
+      rerender('Hello, World!');
+    });
+
+    expect(mockFunc).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(mockFunc).toHaveBeenLastCalledWith('Hello, World!');
+
+    act(() => {
+      rerender('Hello, World! Again!');
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(mockFunc).toHaveBeenLastCalledWith('Hello, World! Again!');
+  });
+
+  it('should clear timeout on unmount', () => {
+    const mockFunc = vi.fn();
+    const { rerender, unmount } = renderHook(
+      (value) => useDebouncedFunc<string>(value, 500, mockFunc),
+      {
+        initialProps: 'Hello',
+      }
+    );
+
+    expect(mockFunc).not.toHaveBeenCalled();
+
+    act(() => {
+      rerender('Hello, World!');
+    });
+
+    act(() => {
+      unmount();
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(mockFunc).not.toHaveBeenCalled();
+  });
+});

--- a/front/src/utils/hooks/useDebounce.ts
+++ b/front/src/utils/hooks/useDebounce.ts
@@ -1,0 +1,35 @@
+import { useState, useEffect } from 'react';
+
+/**
+ * Debounce input fields
+ */
+export const useDebounce = <T = string | number>(value: T, delay: number): T => {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+  return debouncedValue;
+};
+
+/**
+ * Debounce function
+ */
+export const useDebouncedFunc = <T = (number | null) | (string | null)>(
+  value: T,
+  delay: number,
+  func: (newValue: T) => void
+) => {
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      func(value);
+    }, delay);
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+};


### PR DESCRIPTION
This is a first test suite to try React Testing Library for custom
hooks

I use vitest for convenience with the others tests in the codebase

For each hook, mainly two things are tested:
- the update of the argument after the timeout
- and the non-update after unmounting the context before the
timeout

I made some cleanup by moving `useDebounce` and `useDebounceFunc` in the `hooks` folder

closes #15521 