### PR TITLE
Remove grcov from test docker images

### DIFF
--- a/editoast/Dockerfile
+++ b/editoast/Dockerfile
@@ -50,8 +50,7 @@ RUN /assets/fonts/generate-glyphs.sh
 FROM base_builder AS test_builder
 RUN rustup component add llvm-tools && \
     rustup component add rustfmt && \
-    rustup component add clippy && \
-    cargo install grcov
+    rustup component add clippy
 
 COPY --from=planner /editoast/recipe.json recipe.json
 COPY --from=planner /editoast/editoast_derive/ editoast_derive

--- a/editoast/README.md
+++ b/editoast/README.md
@@ -54,7 +54,6 @@ Here a list of components to help you in your development (see CI jobs if necess
 - [rustfmt](https://github.com/rust-lang/rustfmt): Format the whole code `cargo fmt --all`
 - [taplo](https://taplo.tamasfe.dev/): Format the TOML files with `taplo fmt`
 - [clippy](https://github.com/rust-lang/rust-clippy): Run a powerful linter `cargo clippy --workspace --all-features --all-targets -- -D warnings`
-- [grcov](https://github.com/mozilla/grcov): Check code coverage (see documentation on GitHub)
 
 To install `rustfmt` and `clippy`, simply run:
 
@@ -67,8 +66,6 @@ To install `taplo`, run:
 ```sh
 cargo install --locked taplo-cli
 ```
-
-To setup `grcov`, please see [its documentation](https://github.com/mozilla/grcov#how-to-get-grcov)
 
 ## Debugging
 

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -37,8 +37,7 @@ RUN --mount=type=cache,target=/cargo_gateway/registry \
 FROM chef AS testing_env
 RUN rustup component add llvm-tools && \
     rustup component add rustfmt && \
-    rustup component add clippy && \
-    cargo install grcov
+    rustup component add clippy
 COPY --from=planner /gateway/recipe.json recipe.json
 
 ENV LLVM_PROFILE_FILE="gateway-%p-%m.profraw"

--- a/osrdyne/Dockerfile
+++ b/osrdyne/Dockerfile
@@ -37,8 +37,7 @@ RUN --mount=type=cache,target=/cargo_osrdyne/registry \
 FROM chef AS testing_env
 RUN rustup component add llvm-tools && \
     rustup component add rustfmt && \
-    rustup component add clippy && \
-    cargo install grcov
+    rustup component add clippy
 COPY --from=planner /osrdyne/recipe.json recipe.json
 
 ENV LLVM_PROFILE_FILE="osrdyne-%p-%m.profraw"


### PR DESCRIPTION
We don't use code coverage anymore.
grcov installation is legacy.