### PR TITLE
core: pathfinding: stabilize path when all is equal

### DIFF
--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/UnitEquality.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/UnitEquality.kt
@@ -10,7 +10,8 @@ const val POSITION_EPSILON: Double = 1E-2
 const val SPEED_EPSILON: Double = 1E-5
 // An acceleration lower than this value will be considered zero
 const val ACCELERATION_EPSILON: Double = 1E-5
-const val TIME_EPSILON: Double = 1E-2
+// Time epsilon matching a 0.01 m epsilon on position at 360 km/h
+const val TIME_EPSILON: Double = 1E-4
 
 /** Returns true if the positions' difference is lower than epsilon */
 fun arePositionsEqual(a: Double, b: Double): Boolean {

--- a/core/src/main/kotlin/fr/sncf/osrd/pathfinding/Pathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/pathfinding/Pathfinding.kt
@@ -17,6 +17,7 @@ import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorer
 import fr.sncf.osrd.stdcm.infra_exploration.initInfraExplorers
 import fr.sncf.osrd.utils.CachedBlockMRSPBuilder
 import fr.sncf.osrd.utils.POSITION_EPSILON
+import fr.sncf.osrd.utils.areTimesEqual
 import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.meters
 import io.opentelemetry.instrumentation.annotations.WithSpan
@@ -104,9 +105,11 @@ class Pathfinding(
         val weight: Double = establishedCost + estimatedRemainingCost
 
         override fun compareTo(other: Step): Int {
-            if (weight != other.weight) return weight.compareTo(other.weight)
+            // Note: epsilon-comparisons are done to prevent float-precision errors (especially with
+            // different speeds and SIGNALING_SYSTEM_COST_WEIGHTING)
+            if (!areTimesEqual(weight, other.weight)) return weight.compareTo(other.weight)
             // favor less uncertain path
-            if (estimatedRemainingCost != other.estimatedRemainingCost)
+            if (!areTimesEqual(estimatedRemainingCost, other.estimatedRemainingCost))
                 return estimatedRemainingCost.compareTo(other.estimatedRemainingCost)
             // favor shorter (in distance) path
             if (establishedLength != other.establishedLength)

--- a/core/src/main/kotlin/fr/sncf/osrd/pathfinding/Pathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/pathfinding/Pathfinding.kt
@@ -16,7 +16,7 @@ import fr.sncf.osrd.stdcm.infra_exploration.ExplorerStep
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorer
 import fr.sncf.osrd.stdcm.infra_exploration.initInfraExplorers
 import fr.sncf.osrd.utils.CachedBlockMRSPBuilder
-import fr.sncf.osrd.utils.POSITION_EPSILON
+import fr.sncf.osrd.utils.arePositionsEqual
 import fr.sncf.osrd.utils.areTimesEqual
 import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.meters
@@ -27,7 +27,6 @@ import java.util.ArrayList
 import java.util.HashMap
 import java.util.PriorityQueue
 import kotlin.collections.set
-import kotlin.math.abs
 import kotlin.math.max
 
 const val SIGNALING_SYSTEM_COST_WEIGHTING = 1e-1
@@ -192,11 +191,12 @@ class Pathfinding(
             if (step.infraExplorer.getStepTracker().hasSeenDestination()) {
                 // Success!
                 require(
-                    abs(
+                    arePositionsEqual(
                         step.infraExplorer.getAllBlocks().iterateBackwards().sumOf {
                             it.length.meters
-                        } - step.establishedLength.meters
-                    ) < POSITION_EPSILON
+                        },
+                        step.establishedLength.meters,
+                    )
                 )
                 return step.infraExplorer
             }
@@ -273,10 +273,10 @@ class Pathfinding(
         TODO: restore this block once asserts are disabled in prod.
         It's a nice sanity check but not worth the computation time.
         assert(
-            abs(
-                newStep.infraExplorer.getAllBlocks().iterateBackwards().sumOf { it.length.meters } -
-                    newStep.establishedLength.meters
-            ) < POSITION_EPSILON
+            arePositionsEqual(
+                newStep.infraExplorer.getAllBlocks().iterateBackwards().sumOf { it.length.meters },
+                newStep.establishedLength.meters,
+            )
         )
         */
         if (newStep.weight.isFinite()) queue.add(newStep)

--- a/core/src/main/kotlin/fr/sncf/osrd/pathfinding/Pathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/pathfinding/Pathfinding.kt
@@ -30,7 +30,7 @@ import kotlin.collections.set
 import kotlin.math.abs
 import kotlin.math.max
 
-const val SIGNALING_SYSTEM_COST_WEIGHTING = 1e-2
+const val SIGNALING_SYSTEM_COST_WEIGHTING = 1e-1
 
 // TODO: Refactor this to remove the list<AStarHeuristic> and better express the intent
 //       Probably also completely remove AStarHeuristic interface

--- a/core/src/main/kotlin/fr/sncf/osrd/pathfinding/Pathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/pathfinding/Pathfinding.kt
@@ -112,10 +112,15 @@ class Pathfinding(
             if (establishedLength != other.establishedLength)
                 return establishedLength.compareTo(other.establishedLength)
             // favor more blocks (hoping that capacity consumed diminishes, could be removed)
-            return -infraExplorer
-                .getAllBlocks()
-                .size
-                .compareTo(other.infraExplorer.getAllBlocks().size)
+            val nbBlocks = infraExplorer.getAllBlocks().size
+            val nbOtherBlocks = other.infraExplorer.getAllBlocks().size
+            if (nbBlocks != nbOtherBlocks) return -nbBlocks.compareTo(nbOtherBlocks)
+            // stable complete discrimination on blocks used (only one optimal way to reach final
+            // block)
+            return infraExplorer
+                .getCurrentBlock()
+                .index
+                .compareTo(other.infraExplorer.getCurrentBlock().index)
         }
     }
 
@@ -159,11 +164,8 @@ class Pathfinding(
                 listOf(constraintCombiner),
             )
         for (infraExplorer in startInfraExplorers) {
-            registerStep(
-                infraExplorer,
-                rangeCost(infraExplorer.getCurrentBlockRange()),
-                infraExplorer.getCurrentBlockRange().length,
-            )
+            val currentRange = infraExplorer.getCurrentBlockRange()
+            registerStep(infraExplorer, rangeCost(currentRange), currentRange.length)
         }
 
         var maxSeenTarget = 0

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelopeTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelopeTests.kt
@@ -185,7 +185,7 @@ class InfraExplorerWithEnvelopeTests {
             Envelope.make(
                 EnvelopePart.generateTimes(
                     listOf(EnvelopeProfile.CONSTANT_SPEED),
-                    doubleArrayOf(0.0, 100.0, 100.1, 200.0),
+                    doubleArrayOf(0.0, 100.0, 100.01, 200.0),
                     doubleArrayOf(30.0, 30.0, 42.00, 42.0),
                 )
             ),

--- a/front/tests/assets/operation-studies/times-and-stops/expected-inputs-cells-data.json
+++ b/front/tests/assets/operation-studies/times-and-stops/expected-inputs-cells-data.json
@@ -13,6 +13,6 @@
   },
   {
     "row": 4,
-    "values": ["North_East_station", "BV", "V2", "", "0", "", ""]
+    "values": ["North_East_station", "BV", "V1", "", "0", "", ""]
   }
 ]

--- a/front/tests/assets/operation-studies/times-and-stops/expected-outputs-cells-data.json
+++ b/front/tests/assets/operation-studies/times-and-stops/expected-outputs-cells-data.json
@@ -54,7 +54,7 @@
   {
     "stationName": "North_East_station",
     "stationCh": "BV",
-    "trackName": "V2",
+    "trackName": "V1",
     "requestedArrival": "",
     "requestedDeparture": "",
     "stopTime": "0",

--- a/front/tests/assets/operation-studies/times-and-stops/updated-inputs-cells-data.json
+++ b/front/tests/assets/operation-studies/times-and-stops/updated-inputs-cells-data.json
@@ -13,6 +13,6 @@
   },
   {
     "row": 4,
-    "values": ["North_East_station", "BV", "V2", "", "0", "", ""]
+    "values": ["North_East_station", "BV", "V1", "", "0", "", ""]
   }
 ]

--- a/front/tests/assets/paced-train/output-table-data.json
+++ b/front/tests/assets/paced-train/output-table-data.json
@@ -55,7 +55,7 @@
     {
       "stationName": "North_East_station",
       "stationCh": "BV",
-      "trackName": "V2",
+      "trackName": "V1",
       "requestedArrival": "",
       "requestedDeparture": "",
       "stopTime": "0",
@@ -126,7 +126,7 @@
     {
       "stationName": "North_East_station",
       "stationCh": "BV",
-      "trackName": "V2",
+      "trackName": "V1",
       "requestedArrival": "",
       "requestedDeparture": "",
       "stopTime": "0",


### PR DESCRIPTION
Add a path-hash to discriminate equal paths and improve stability of results.

As spotted during pathfinding's refactor hand-testing https://github.com/OpenRailAssociation/osrd/pull/14490#pullrequestreview-3857037673 the path was unstable when all is equal but the rolling stock used changed. No constraint/cost change was involved, just the processing order of the search.

✅ hand-tested that it's now stable on the case of e2e's medium infra with thermal/dual/electric rolling stocks.
⚠️ please note that medium-infra used in hand-tests (and probably small-infra too) has defects that sometimes prevent optimal pathfinding solution: topographic length are shorter than geographic length on some track-sections, which prevent A* algorithm to work optimally.

Note: it's just random (block ID's) that tests are going back to old values.

---

Limitations/discussions:
1. At least it highlights that it's not a important cost/constraint bug (but it may not be worth the cost of adding the code)
2. Did not try to investigate/stabilize the order of the search (may be more efficient, may be suspect)
  -> Most probably related to float precision, and reduced with epsilons
4. The pick of block id's has no connotation and guarantees complete order, but it's hard-ish to explain/maintain (if ids) compared to something like "always go south, always go left, etc."
5. No TDD test was added ("confront" 2 different paths that are now identical)