### PR TITLE
core: remove calls to DistanceRangeMap.asList

### DIFF
--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/EnvelopeTrainPath.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/EnvelopeTrainPath.kt
@@ -72,7 +72,7 @@ object EnvelopeTrainPath {
         map: DistanceRangeMap<Electrification>
     ): ImmutableRangeMap<Double, Electrification> {
         val res = TreeRangeMap.create<Double, Electrification>()
-        for (entry in map.asList()) {
+        for (entry in map) {
             res.put(Range.closed(toMeters(entry.lower), toMeters(entry.upper)), entry.value)
         }
         return ImmutableRangeMap.copyOf(res)

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathImpl.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathImpl.kt
@@ -18,7 +18,6 @@ import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.forceDirected
 import fr.sncf.osrd.utils.units.meters
 import fr.sncf.osrd.utils.units.toDirected
-import kotlin.collections.flatMap
 
 /**
  * Default train path implementation. Other implementation may be views or similar.
@@ -303,8 +302,7 @@ data class TrainPathImpl(
     private fun <T> getRangeMap(
         getData: (dirChunkId: DirTrackChunkId) -> DistanceRangeMap<T>
     ): DistanceRangeMap<T> {
-        // TODO: reduce allocations (subMap allocates -too much- before truncate, then asList
-        //       allocates again)
+        // TODO: reduce allocations (subMap allocates -too much- before truncate)
         val entries =
             chunks
                 .asSequence()
@@ -313,7 +311,6 @@ data class TrainPathImpl(
                     getData(it.value)
                         .subMap(it.objectBegin.distance, it.objectEnd.distance)
                         .shiftPositions(it.pathBegin.distance - it.objectBegin.distance)
-                        .asList()
                 }
         return distanceRangeMapOf(entries.toList())
     }

--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/DistanceRangeMapExt.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/DistanceRangeMapExt.kt
@@ -34,7 +34,7 @@ fun <T : Any> DistanceRangeMapImpl.Companion.toRangeMap(
     distanceRangeMap: DistanceRangeMap<T>
 ): RangeMap<Distance, T> {
     val rangeMap = TreeRangeMap.create<Distance, T>()
-    for (entry in distanceRangeMap.asList()) {
+    for (entry in distanceRangeMap) {
         rangeMap.put(Range.closed(entry.lower, entry.upper), entry.value)
     }
     return rangeMap

--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeMap.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeMap.kt
@@ -24,7 +24,7 @@ interface DistanceRangeMap<T> : Iterable<DistanceRangeMap.RangeMapEntry<T>> {
     fun put(lower: Distance, upper: Distance, value: T)
 
     /** Sets many values more efficiently than many calls to `put` */
-    fun putMany(entries: List<RangeMapEntry<T>>)
+    fun putMany(entries: Iterable<RangeMapEntry<T>>)
 
     /** Returns a list of the entries in the map */
     fun asList(): List<RangeMapEntry<T>> = toList()
@@ -99,7 +99,7 @@ fun <T, R> filterIntersection(
     for (range in filter) {
         val filteredRange = mapToFilter.clone()
         filteredRange.truncate(range.lower, range.upper)
-        res.putMany(filteredRange.asList())
+        res.putMany(filteredRange)
     }
     return res
 }

--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeMap.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeMap.kt
@@ -27,7 +27,7 @@ interface DistanceRangeMap<T> : Iterable<DistanceRangeMap.RangeMapEntry<T>> {
     fun putMany(entries: List<RangeMapEntry<T>>)
 
     /** Returns a list of the entries in the map */
-    fun asList(): List<RangeMapEntry<T>>
+    fun asList(): List<RangeMapEntry<T>> = toList()
 
     /** Lower bound of the entry with the smallest distance */
     fun lowerBound(): Distance

--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeMap.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeMap.kt
@@ -27,6 +27,10 @@ interface DistanceRangeMap<T> : Iterable<DistanceRangeMap.RangeMapEntry<T>> {
     fun putMany(entries: Iterable<RangeMapEntry<T>>)
 
     /** Returns a list of the entries in the map */
+    @Deprecated(
+        message =
+            "If you want to iterate on entries, DistanceRangeMap is already an Iterable. If you really want a list, use Iterable.toList"
+    )
     fun asList(): List<RangeMapEntry<T>> = toList()
 
     /** Lower bound of the entry with the smallest distance */

--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeMapImpl.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeMapImpl.kt
@@ -29,7 +29,7 @@ data class DistanceRangeMapImpl<T>(
      * Another idea would be to use a temporary (so we can free the memory later) tree-like
      * structure (RangeMaps lib).
      */
-    override fun putMany(entries: List<DistanceRangeMap.RangeMapEntry<T>>) {
+    override fun putMany(entries: Iterable<DistanceRangeMap.RangeMapEntry<T>>) {
         // Unfortunately, built-in groupBy doesn't consider the original order, here we want
         // consecutive values.
         fun <U, V> groupByConsecutiveFirst(pairs: List<Pair<U, V>>): List<Pair<U, List<V>>> {
@@ -90,7 +90,7 @@ data class DistanceRangeMapImpl<T>(
 
         // Order matters and existing entries should come first.
         // E.g. allEntries = [(lower=0, upper=5, value=1), (lower=5, upper=10, value=1)]
-        val allEntries = asList() + entries
+        val allEntries = this + entries
 
         // Start from scratch.
         values.clear()

--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeMapImpl.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeMapImpl.kt
@@ -168,19 +168,11 @@ data class DistanceRangeMapImpl<T>(
     }
 
     override fun truncate(beginOffset: Distance, endOffset: Distance) {
-        if (bounds.size != 0) {
-            validate()
+        if (bounds.isNotEmpty()) {
             putOptional(lowerBound(), beginOffset, null)
-            putOptional(endOffset, upperBound(), null)
-            if (values.isNotEmpty() && values[0] == null) {
-                bounds.remove(0)
-                values.removeAt(0)
+            if (bounds.isNotEmpty()) {
+                putOptional(endOffset, upperBound(), null)
             }
-            if (values.isNotEmpty() && values[values.size - 1] == null) {
-                bounds.remove(bounds.size - 1)
-                values.removeAt(values.size - 1)
-            }
-            if (values.isEmpty()) bounds.clear()
         }
     }
 
@@ -391,13 +383,30 @@ data class DistanceRangeMapImpl<T>(
                 } else i++
             }
         }
-        mergeAdjacent()
-        validate()
+        ensureInvariants()
     }
 
-    /** Asserts that the internal state is consistent */
-    private fun validate() {
-        require(bounds.size == values.size + 1 || (bounds.size == 0 && values.isEmpty()))
+    /**
+     * Ensures that the internal state is consistent.
+     * 1. [bounds] must have one more element than [values]
+     * 2. ranges are coalesced
+     * 3. [values] must not start nor end with `null`s
+     */
+    private fun ensureInvariants() {
+        require(bounds.size == values.size + 1 || (bounds.isEmpty() && values.isEmpty()))
+        mergeAdjacent()
+        if (values.isNotEmpty() && values.first() == null) {
+            bounds.remove(0)
+            values.removeAt(0)
+        }
+        // Re-check for emptiness in case we took the branch above
+        if (values.isNotEmpty() && values.last() == null) {
+            bounds.remove(bounds.size - 1)
+            values.removeAt(values.size - 1)
+        }
+        if (values.isEmpty()) {
+            bounds.clear()
+        }
     }
 
     // This declaration is needed for the extension methods in kt-osrd-utils

--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeMapImpl.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeMapImpl.kt
@@ -144,20 +144,7 @@ data class DistanceRangeMapImpl<T>(
     }
 
     /** Iterates over the entries in the map */
-    override fun iterator(): Iterator<DistanceRangeMap.RangeMapEntry<T>> {
-        return asList().iterator()
-    }
-
-    /** Returns a list of the entries in the map */
-    override fun asList(): List<DistanceRangeMap.RangeMapEntry<T>> {
-        validate()
-        val res = ArrayList<DistanceRangeMap.RangeMapEntry<T>>()
-        for (i in 0 until values.size) {
-            if (values[i] != null)
-                res.add(DistanceRangeMap.RangeMapEntry(bounds[i], bounds[i + 1], values[i]!!))
-        }
-        return res
-    }
+    override fun iterator(): Iterator<DistanceRangeMap.RangeMapEntry<T>> = IteratorImpl(this)
 
     override fun lowerBound(): Distance {
         return bounds[0]
@@ -407,6 +394,32 @@ data class DistanceRangeMapImpl<T>(
         if (values.isEmpty()) {
             bounds.clear()
         }
+    }
+
+    private class IteratorImpl<T>(val rangeMap: DistanceRangeMapImpl<T>) :
+        Iterator<DistanceRangeMap.RangeMapEntry<T>> {
+        private var cursor = -1
+
+        override fun next(): DistanceRangeMap.RangeMapEntry<T> {
+            if (cursor + 1 >= rangeMap.values.size) {
+                throw NoSuchElementException()
+            }
+            cursor++
+            if (rangeMap.values[cursor] == null) {
+                // skip over the gap...
+                // because of [DistanceRangeMapImpl.ensureInvariants], we know there is at least one
+                // range entry after the null one, so no need to throw an exception
+                cursor++
+            }
+            return DistanceRangeMap.RangeMapEntry(
+                lower = rangeMap.bounds[cursor],
+                upper = rangeMap.bounds[cursor + 1],
+                // [values] shouldn't contain consecutive nulls thanks to [mergeAdjacent]
+                value = rangeMap.values[cursor]!!,
+            )
+        }
+
+        override fun hasNext(): Boolean = cursor + 1 < rangeMap.values.size
     }
 
     // This declaration is needed for the extension methods in kt-osrd-utils

--- a/core/osrd-mp/src/commonTest/kotlin/fr/sncf/osrd/utils/TestDistanceRangeMap.kt
+++ b/core/osrd-mp/src/commonTest/kotlin/fr/sncf/osrd/utils/TestDistanceRangeMap.kt
@@ -17,20 +17,20 @@ class TestDistanceRangeMap {
     ) {
         val rangeMap = distanceRangeMapOf<T>()
         for (entry in entries) rangeMap.put(entry.lower, entry.upper, entry.value)
-        assertEquals(expected, rangeMap.asList())
+        assertEquals(expected, rangeMap.toList())
 
         val rangeMapMany = distanceRangeMapOf<T>()
         rangeMapMany.putMany(entries)
-        assertEquals(expected, rangeMapMany.asList())
+        assertEquals(expected, rangeMapMany.toList())
 
         val rangeMapCtor = DistanceRangeMapImpl(entries)
-        assertEquals(expected, rangeMapCtor.asList())
+        assertEquals(expected, rangeMapCtor.toList())
     }
 
     @Test
     fun testEmpty() {
         val rangeMap = distanceRangeMapOf<Int>()
-        assertEquals(emptyList(), rangeMap.asList())
+        assertEquals(emptyList(), rangeMap.toList())
     }
 
     @Test
@@ -164,7 +164,7 @@ class TestDistanceRangeMap {
         rangeMap.truncate(Distance(250), Distance(260))
         assertEquals(
             listOf(DistanceRangeMap.RangeMapEntry(Distance(250), Distance(260), 42)),
-            rangeMap.asList(),
+            rangeMap.toList(),
         )
     }
 
@@ -174,7 +174,7 @@ class TestDistanceRangeMap {
         rangeMap.put(Distance(0), Distance(100), 41)
         rangeMap.put(Distance(200), Distance(300), 42)
         rangeMap.truncate(Distance(0), Distance(0))
-        assertEquals(listOf(), rangeMap.asList())
+        assertEquals(listOf(), rangeMap.toList())
     }
 
     @Test
@@ -183,7 +183,7 @@ class TestDistanceRangeMap {
         rangeMap.put(Distance(0), Distance(100), 41)
         rangeMap.put(Distance(200), Distance(300), 42)
         rangeMap.truncate(Distance(150), Distance(160))
-        assertEquals(listOf(), rangeMap.asList())
+        assertEquals(listOf(), rangeMap.toList())
     }
 
     @Test
@@ -204,7 +204,7 @@ class TestDistanceRangeMap {
                 DistanceRangeMap.RangeMapEntry(Distance(-100), Distance(0), 41),
                 DistanceRangeMap.RangeMapEntry(Distance(100), Distance(200), 42),
             ),
-            rangeMap.asList(),
+            rangeMap.toList(),
         )
     }
 
@@ -224,7 +224,7 @@ class TestDistanceRangeMap {
                 DistanceRangeMap.RangeMapEntry(Distance(500), Distance(600), 42),
                 DistanceRangeMap.RangeMapEntry(Distance(600), Distance(1000), 43),
             ),
-            rangeMap.asList(),
+            rangeMap.toList(),
         )
     }
 
@@ -243,13 +243,13 @@ class TestDistanceRangeMap {
         val rangeMap = distanceRangeMapOf<Int>()
         rangeMap.putMany(entries)
         assertFalse(mark2.hasPassedNow())
-        assertEquals(entries, rangeMap.asList())
+        assertEquals(entries, rangeMap.toList())
 
         val mark3 = timeSource.markNow()
         val mark4 = mark3 + oneSecond
         val rangeMapCtor = DistanceRangeMapImpl(entries)
         assertFalse(mark4.hasPassedNow())
-        assertEquals(entries, rangeMapCtor.asList())
+        assertEquals(entries, rangeMapCtor.toList())
     }
 
     @Test

--- a/core/src/main/kotlin/fr/sncf/osrd/api/path_properties/PathPropResponseConverter.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/path_properties/PathPropResponseConverter.kt
@@ -120,13 +120,9 @@ private fun makeZones(path: TrainPath, rawInfra: RawSignalingInfra): RangeValues
 }
 
 private fun <T> makeRangeValues(distanceRangeMap: DistanceRangeMap<T>): RangeValues<T> {
-    return makeRangeValues(distanceRangeMap.asList())
-}
-
-private fun <T> makeRangeValues(entries: List<DistanceRangeMap.RangeMapEntry<T>>): RangeValues<T> {
     val boundaries = mutableListOf<Offset<PhysicsPath>>()
     val values = mutableListOf<T>()
-    for (entry in entries) {
+    for (entry in distanceRangeMap) {
         boundaries.add(Offset(entry.upper))
         values.add(entry.value)
     }

--- a/core/src/main/kotlin/fr/sncf/osrd/pathfinding/constraints/ElectrificationConstraints.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/pathfinding/constraints/ElectrificationConstraints.kt
@@ -12,6 +12,7 @@ import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.OffsetRange
 import java.util.stream.Collectors
+import kotlin.streams.asStream
 
 data class ElectrificationConstraints(
     val blockInfra: BlockInfra,
@@ -59,8 +60,8 @@ data class ElectrificationConstraints(
         private fun <T> rangeSetFromMap(rangeMap: DistanceRangeMap<T>): RangeSet<Distance> {
             return TreeRangeSet.create(
                 rangeMap
-                    .asList()
-                    .stream()
+                    .asSequence()
+                    .asStream()
                     .map { (lower, upper): DistanceRangeMap.RangeMapEntry<T> ->
                         Range.closed(lower, upper)
                     }

--- a/core/src/test/java/fr/sncf/osrd/api/ElectricalProfileSetManagerTest.java
+++ b/core/src/test/java/fr/sncf/osrd/api/ElectricalProfileSetManagerTest.java
@@ -1,5 +1,6 @@
 package fr.sncf.osrd.api;
 
+import static kotlin.collections.CollectionsKt.count;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -62,7 +63,7 @@ public class ElectricalProfileSetManagerTest extends ApiTest {
         for (var byTrack : profileMap.getMapping().entrySet()) {
             assertNotEquals(0, byTrack.getValue().size());
             for (var byRange : byTrack.getValue().entrySet()) {
-                assertNotEquals(0, byRange.getValue().asList().size());
+                assertNotEquals(0, count(byRange.getValue()));
             }
         }
     }

--- a/core/src/test/kotlin/fr/sncf/osrd/sim_infra_adapter/PathPropertiesTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/sim_infra_adapter/PathPropertiesTests.kt
@@ -70,7 +70,7 @@ class PathPropertiesTests {
                 RangeMapEntry(1_500.meters, 2_500.meters, .0),
                 RangeMapEntry(2_500.meters, 3_000.meters, -5.0),
             ),
-            slopes.asList(),
+            slopes.toList(),
         )
 
         val pathBackward =
@@ -87,7 +87,7 @@ class PathPropertiesTests {
                 RangeMapEntry(0.meters, 1_000.meters, .0),
                 RangeMapEntry(1_000.meters, 2_000.meters, -15.0),
             ),
-            slopesBackward.asList(),
+            slopesBackward.toList(),
         )
     }
 
@@ -265,7 +265,7 @@ class PathPropertiesTests {
                 RangeMapEntry(0.meters, 500.meters, -10_000.0),
                 RangeMapEntry(500.meters, 1_000.meters, -5_000.0),
             ),
-            slopesBackward.asList(),
+            slopesBackward.toList(),
         )
     }
 
@@ -298,7 +298,7 @@ class PathPropertiesTests {
                 RangeMapEntry(0.meters, 500.meters, -15.0),
                 RangeMapEntry(500.meters, 1_000.meters, -5.0 + 800.0 / 5_000.0),
             ),
-            slopesBackward.asList(),
+            slopesBackward.toList(),
         )
     }
 
@@ -417,7 +417,7 @@ class PathPropertiesTests {
                 RangeMapEntry(0.meters, 2_500.meters, setOf("1500V")),
                 RangeMapEntry(2_500.meters, 3_000.meters, setOf("25000V")),
             ),
-            electrificationForward.asList(),
+            electrificationForward.toList(),
         )
 
         val pathBackward =
@@ -434,7 +434,7 @@ class PathPropertiesTests {
                 RangeMapEntry(0.meters, 500.meters, setOf("25000V")),
                 RangeMapEntry(500.meters, 2_500.meters, setOf("1500V")),
             ),
-            electrificationBackward.asList(),
+            electrificationBackward.toList(),
         )
     }
 
@@ -507,7 +507,7 @@ class PathPropertiesTests {
                 routes = listOf(),
             )
         val speedLimits = path.getSpeedLimitProperties("trainTag", null)
-        assertThat(speedLimits.asList())
+        assertThat(speedLimits.toList())
             .containsExactlyElementsOf(
                 listOf(
                     RangeMapEntry(
@@ -568,7 +568,7 @@ class PathPropertiesTests {
         */
 
         val speedLimitsMA100 = path.getSpeedLimitProperties("MA100", null)
-        assertThat(speedLimitsMA100.asList())
+        assertThat(speedLimitsMA100.toList())
             .containsExactlyElementsOf(
                 listOf(
                     RangeMapEntry(
@@ -595,7 +595,7 @@ class PathPropertiesTests {
             )
 
         val speedLimitsME100 = path.getSpeedLimitProperties("ME100", null)
-        assertThat(speedLimitsME100.asList())
+        assertThat(speedLimitsME100.toList())
             .containsExactlyElementsOf(
                 listOf(
                     RangeMapEntry(
@@ -622,7 +622,7 @@ class PathPropertiesTests {
             )
 
         val speedLimitsE32C = path.getSpeedLimitProperties("E32C", null)
-        assertThat(speedLimitsE32C.asList())
+        assertThat(speedLimitsE32C.toList())
             .containsExactlyElementsOf(
                 listOf(
                     RangeMapEntry(
@@ -649,7 +649,7 @@ class PathPropertiesTests {
             )
 
         val speedLimitsHLP = path.getSpeedLimitProperties("HLP", null)
-        assertThat(speedLimitsHLP.asList())
+        assertThat(speedLimitsHLP.toList())
             .containsExactlyElementsOf(
                 listOf(
                     RangeMapEntry(
@@ -676,7 +676,7 @@ class PathPropertiesTests {
             )
 
         val speedLimitsNull = path.getSpeedLimitProperties(null, null)
-        assertThat(speedLimitsNull.asList())
+        assertThat(speedLimitsNull.toList())
             .containsExactlyElementsOf(
                 listOf(
                     RangeMapEntry(
@@ -726,10 +726,10 @@ class PathPropertiesTests {
                 ),
             )
         val speedLimitsMA90 = path.getSpeedLimitProperties("MA90", null)
-        assertThat(speedLimitsMA90.asList()).containsExactlyElementsOf(expectedSpeedLimitsMA90)
+        assertThat(speedLimitsMA90.toList()).containsExactlyElementsOf(expectedSpeedLimitsMA90)
 
         val speedLimitsMA80 = path.getSpeedLimitProperties("MA80", null)
-        assertThat(speedLimitsMA80.asList()).containsExactlyElementsOf(expectedSpeedLimitsMA90)
+        assertThat(speedLimitsMA80.toList()).containsExactlyElementsOf(expectedSpeedLimitsMA90)
     }
 
     /** Assert that line strings are equal, with a certain tolerance for double values */


### PR DESCRIPTION
With the migration of electrification maps to `DistanceRangeMap`[^1] i figured some perf work will be necessary

[^1]:https://github.com/OpenRailAssociation/osrd/pull/15538

Previously iterating over the entries of `DistanceRangeMap` would call `asList` and allocate an `ArrayList` (so a list was also be allocated by `get` :skull:) so the first two commits implement `DistanceRangeMapImpl.iterator` with a hand-made allocator.

Then `asList` can be implemented using `Iterable.toList` from the standard library.

Then the later commit removes `asList` calls from `main` because none of them are necessary.

The final commit ~removes the method from the interface (i can drop the commit if you'd rather keep `asList`)~

The final commit marks the method as deprecated to keep a reminder having a list isn't needed in most cases