### PR TITLE
editoast: authz: `v2::add_roles`

### DIFF
--- a/editoast/authz/src/authorizer.rs
+++ b/editoast/authz/src/authorizer.rs
@@ -179,13 +179,15 @@ mod tests {
 
         // setup roles
         {
-            regulator()
-                .grant_user_roles(
-                    &User(user_id),
-                    HashSet::from([Role::OperationalStudies, Role::Stdcm]),
-                )
-                .await
-                .expect("roles should be granted");
+            v2::add_roles(
+                Subject::user(user_id),
+                HashSet::from([Role::OperationalStudies, Role::Stdcm]),
+            )
+            .authorize(&v2::test_authorizers::Authorize(regulator().openfga()))
+            .await
+            .expect("roles should be granted")
+            .unwrap_authorized()
+            .await;
         }
 
         assert!(
@@ -315,15 +317,19 @@ mod tests {
             .await;
 
         // setup roles
-        regulator()
-            .grant_group_roles(&friends, HashSet::from([Role::OperationalStudies]))
+        v2::add_roles(friends.into(), HashSet::from([Role::OperationalStudies]))
+            .authorize(&v2::test_authorizers::Authorize(regulator().openfga()))
             .await
-            .expect("group's roles should be granted");
+            .expect("group's roles should be granted")
+            .unwrap_authorized()
+            .await;
 
-        regulator()
-            .grant_user_roles(&User(bob_id), HashSet::from([Role::Stdcm]))
+        v2::add_roles(Subject::user(bob_id), HashSet::from([Role::Stdcm]))
+            .authorize(&v2::test_authorizers::Authorize(regulator().openfga()))
             .await
-            .expect("bob's roles should be granted");
+            .expect("bob's roles should be granted")
+            .unwrap_authorized()
+            .await;
 
         // check roles
         assert!(

--- a/editoast/authz/src/lib.rs
+++ b/editoast/authz/src/lib.rs
@@ -147,6 +147,7 @@ mod mock_driver {
     use crate::identity::UserInfo;
     use crate::identity::UserName;
     use crate::model;
+    use crate::v2;
 
     #[derive(Debug, Clone, Default)]
     pub struct MockAuthDriver {
@@ -168,9 +169,12 @@ mod mock_driver {
         }
 
         pub async fn set_role(&self, user: model::User, role: Role) {
-            self.grant_user_roles(&user, HashSet::from([role]))
+            v2::add_roles(user.into(), HashSet::from([role]))
+                .authorize(&v2::test_authorizers::Authorize(self.openfga()))
                 .await
                 .expect("role set should succeed")
+                .unwrap_authorized()
+                .await;
         }
 
         pub async fn get_infra_grant(

--- a/editoast/authz/src/model.rs
+++ b/editoast/authz/src/model.rs
@@ -13,12 +13,10 @@ pub enum Subject {
 }
 
 impl Subject {
-    #[cfg(test)]
     pub fn user(id: i64) -> Self {
         Subject::User(User(id))
     }
 
-    #[cfg(test)]
     pub fn group(id: i64) -> Self {
         Subject::Group(Group(id))
     }

--- a/editoast/authz/src/model.rs
+++ b/editoast/authz/src/model.rs
@@ -6,13 +6,23 @@ use strum::EnumIter;
 use strum::EnumString;
 use utoipa::ToSchema;
 
-#[derive(Debug, PartialEq, derive_more::From)]
+#[derive(Debug, Clone, Copy, PartialEq, derive_more::From)]
 pub enum Subject {
     User(User),
     Group(Group),
 }
 
 impl Subject {
+    #[cfg(test)]
+    pub fn user(id: i64) -> Self {
+        Subject::User(User(id))
+    }
+
+    #[cfg(test)]
+    pub fn group(id: i64) -> Self {
+        Subject::Group(Group(id))
+    }
+
     pub fn id(&self) -> i64 {
         match self {
             Subject::User(user) => user.0,

--- a/editoast/authz/src/regulator.rs
+++ b/editoast/authz/src/regulator.rs
@@ -218,24 +218,6 @@ impl<S: StorageDriver> Regulator<S> {
     }
 
     #[tracing::instrument(skip_all, fields(user, ?roles), ret(level = Level::DEBUG), err)]
-    pub async fn grant_user_roles(
-        &self,
-        user: &User,
-        roles: HashSet<Role>,
-    ) -> Result<(), Error<S::Error>> {
-        if !self.user_exists(user.0).await? {
-            return Err(Error::UnknownSubject(user.0));
-        }
-        let mut writes = self.openfga.prepare_writes();
-        let existing_roles = self.user_roles(user).await?;
-        for role in roles.difference(&existing_roles) {
-            writes.push(&User::role().tuple(role, user));
-        }
-        writes.execute().await?;
-        Ok(())
-    }
-
-    #[tracing::instrument(skip_all, fields(user, ?roles), ret(level = Level::DEBUG), err)]
     pub async fn revoke_user_roles(
         &self,
         user: &User,
@@ -250,24 +232,6 @@ impl<S: StorageDriver> Regulator<S> {
             deletes.push(&User::role().tuple(role, user));
         }
         deletes.execute().await?;
-        Ok(())
-    }
-
-    #[tracing::instrument(skip_all, fields(group, ?roles), ret(level = Level::DEBUG), err)]
-    pub async fn grant_group_roles(
-        &self,
-        group: &Group,
-        roles: HashSet<Role>,
-    ) -> Result<(), Error<S::Error>> {
-        if !self.group_exists(group.0).await? {
-            return Err(Error::UnknownSubject(group.0));
-        }
-        let mut writes = self.openfga.prepare_writes();
-        let existing_roles = self.group_roles(group).await?;
-        for role in roles.difference(&existing_roles) {
-            writes.push(&Group::role().tuple(role, group));
-        }
-        writes.execute().await?;
         Ok(())
     }
 

--- a/editoast/authz/src/v2.rs
+++ b/editoast/authz/src/v2.rs
@@ -8,6 +8,7 @@ use itertools::Itertools;
 
 use crate::Group;
 use crate::Role;
+use crate::Subject;
 use crate::User;
 
 pub type OpenFgaError = fga::client::RequestFailure;
@@ -187,6 +188,45 @@ pub fn add_members<'a>(group: Group, members: HashSet<User>) -> Protected<'a, ()
     .with_guardrail(Guardrail::IssuerHasRole(Role::Admin))
 }
 
+// TODO: move somewhere more appropriate
+/// Gives the subject the specified roles
+///
+/// Idempotent but not atomic due to the lack of transactions in OpenFGA.
+pub fn add_roles(subject: Subject, roles: HashSet<Role>) -> Protected<'static, ()> {
+    Protected::new(move |openfga| {
+        async move {
+            let existing_roles = match &subject {
+                Subject::User(user) => Role::list_roles(openfga, User::role(), user).await?,
+                Subject::Group(group) => Role::list_roles(openfga, Group::role(), group).await?,
+            };
+
+            let existing_roles = HashSet::from_iter(existing_roles);
+            let new_roles = roles.difference(&existing_roles);
+            let mut writes = openfga.prepare_writes();
+            match subject {
+                Subject::User(user) => {
+                    for role in new_roles {
+                        writes.push(&User::role().tuple(role, &user));
+                    }
+                }
+                Subject::Group(group) => {
+                    for role in new_roles {
+                        writes.push(&Group::role().tuple(role, &group));
+                    }
+                }
+            }
+            writes.execute().await?;
+            Ok(())
+        }
+        .boxed()
+    })
+    .with_guardrail(Guardrail::IssuerHasRole(Role::Admin))
+    .with_check(match &subject {
+        Subject::User(user) => SanityCheck::UserExists(*user),
+        Subject::Group(group) => SanityCheck::GroupExists(*group),
+    })
+}
+
 pub mod test_authorizers {
     use std::convert::Infallible;
 
@@ -228,10 +268,21 @@ pub mod test_authorizers {
 }
 
 pub trait TestClientExt {
+    async fn subject_roles(&self, subject: &Subject) -> HashSet<Role>;
     async fn group_members(&self, group: &Group) -> HashSet<User>;
 }
 
 impl TestClientExt for fga::Client {
+    async fn subject_roles(&self, subject: &Subject) -> HashSet<Role> {
+        match subject {
+            Subject::User(user) => Role::list_roles(self, User::role(), user).await,
+            Subject::Group(group) => Role::list_roles(self, Group::role(), group).await,
+        }
+        .unwrap()
+        .into_iter()
+        .collect()
+    }
+
     async fn group_members(&self, group: &Group) -> HashSet<User> {
         self.list_users(Group::member().query_users(group))
             .await
@@ -301,6 +352,74 @@ mod tests {
         assert_eq!(
             openfga.group_members(&Group(1)).await,
             HashSet::from_iter([User(1), User(2), User(3)])
+        );
+    }
+
+    #[tokio::test]
+    async fn add_roles_idempotent() {
+        let openfga = crate::authz_client!();
+        let authorize = Authorize(&openfga);
+
+        add_roles(
+            Subject::user(1),
+            HashSet::from_iter([Role::Admin, Role::Stdcm]),
+        )
+        .authorize(&authorize)
+        .await
+        .unwrap()
+        .unwrap_authorized()
+        .await;
+        assert_eq!(
+            openfga.subject_roles(&Subject::user(1)).await,
+            HashSet::from_iter([Role::Admin, Role::Stdcm])
+        );
+
+        add_roles(
+            Subject::user(1),
+            HashSet::from_iter([Role::Admin, Role::Stdcm]),
+        )
+        .authorize(&authorize)
+        .await
+        .unwrap()
+        .unwrap_authorized()
+        .await;
+        assert_eq!(
+            openfga.subject_roles(&Subject::user(1)).await,
+            HashSet::from_iter([Role::Admin, Role::Stdcm])
+        );
+    }
+
+    #[tokio::test]
+    async fn add_roles_intersecting_calls() {
+        let openfga = crate::authz_client!();
+        let authorize = Authorize(&openfga);
+
+        add_roles(
+            Subject::user(1),
+            HashSet::from_iter([Role::Admin, Role::Stdcm]),
+        )
+        .authorize(&authorize)
+        .await
+        .unwrap()
+        .unwrap_authorized()
+        .await;
+        assert_eq!(
+            openfga.subject_roles(&Subject::user(1)).await,
+            HashSet::from_iter([Role::Admin, Role::Stdcm])
+        );
+
+        add_roles(
+            Subject::user(1),
+            HashSet::from_iter([Role::Admin, Role::OperationalStudies]),
+        )
+        .authorize(&authorize)
+        .await
+        .unwrap()
+        .unwrap_authorized()
+        .await;
+        assert_eq!(
+            openfga.subject_roles(&Subject::user(1)).await,
+            HashSet::from_iter([Role::Admin, Role::Stdcm, Role::OperationalStudies])
         );
     }
 }

--- a/editoast/src/client/openfga_config.rs
+++ b/editoast/src/client/openfga_config.rs
@@ -39,21 +39,23 @@ impl From<OpenfgaConfig> for views::OpenfgaConfig {
 }
 
 impl OpenfgaConfig {
+    pub async fn into_client(self) -> anyhow::Result<fga::Client> {
+        let config: views::OpenfgaConfig = self.into();
+        tracing::info!(url = %config.url, "connecting to OpenFGA");
+        match fga::Client::try_with_store(&config.store, config.as_settings()).await {
+            Err(fga::client::InitializationError::NotFound(store)) => {
+                tracing::info!(store, "store not found, creating it");
+                Ok(fga::Client::try_new_store(&store, config.as_settings()).await?)
+            }
+            result => Ok(result?),
+        }
+    }
+
     pub async fn into_regulator(
         self,
         pool: Arc<DbConnectionPoolV2>,
     ) -> anyhow::Result<views::Regulator> {
-        let config: views::OpenfgaConfig = self.into();
-        let openfga = {
-            tracing::info!(url = %config.url, "connecting to OpenFGA");
-            match fga::Client::try_with_store(&config.store, config.as_settings()).await {
-                Err(fga::client::InitializationError::NotFound(store)) => {
-                    tracing::info!(store, "store not found, creating it");
-                    fga::Client::try_new_store(&store, config.as_settings()).await?
-                }
-                result => result?,
-            }
-        };
+        let openfga = self.into_client().await?;
         let driver = PgAuthDriver::new(pool);
         Ok(views::Regulator::new(openfga, driver))
     }

--- a/editoast/src/client/roles.rs
+++ b/editoast/src/client/roles.rs
@@ -9,6 +9,7 @@ use authz::Role;
 use authz::StorageDriver;
 use authz::identity::GroupInfo;
 use authz::identity::UserInfo;
+use authz::v2::Authorizer;
 use clap::Args;
 use clap::Subcommand;
 use database::DbConnectionPoolV2;
@@ -17,6 +18,9 @@ use strum::IntoEnumIterator;
 use tracing::info;
 
 use editoast_models::PgAuthDriver;
+
+use crate::authorizers::Rejection;
+use crate::authorizers::SystemAuthorizer;
 
 use super::openfga_config::OpenfgaConfig;
 
@@ -77,6 +81,13 @@ impl Subject {
         Self {
             id,
             info: SubjectInfo::Group(info),
+        }
+    }
+
+    fn into_authz(self) -> authz::Subject {
+        match self.info {
+            SubjectInfo::User(_) => authz::Subject::User(authz::User(self.id)),
+            SubjectInfo::Group(_) => authz::Subject::Group(authz::Group(self.id)),
         }
     }
 }
@@ -161,7 +172,12 @@ pub async fn add_roles(
     pool: Arc<DbConnectionPoolV2>,
     openfga_config: OpenfgaConfig,
 ) -> anyhow::Result<()> {
-    let regulator = openfga_config.into_regulator(pool).await?;
+    let openfga = &openfga_config.into_client().await?;
+    let system = SystemAuthorizer {
+        openfga,
+        conn: pool.get().await?,
+    };
+
     let roles = roles
         .iter()
         .map(String::as_str)
@@ -175,21 +191,14 @@ pub async fn add_roles(
             .collect_vec()
             .join(", "),
     );
-    match parse_and_fetch_subject(&subject, regulator.driver()).await? {
-        Subject {
-            id,
-            info: SubjectInfo::User(_),
-        } => regulator.grant_user_roles(&authz::User(id), roles).await?,
-        Subject {
-            id,
-            info: SubjectInfo::Group(_),
-        } => {
-            regulator
-                .grant_group_roles(&authz::Group(id), roles)
-                .await?
+    let subject = parse_and_fetch_subject(&subject, &PgAuthDriver::new(pool)).await?;
+    let add_roles = authz::v2::add_roles(subject.into_authz(), roles);
+    match system.authorize(add_roles).await?.access().await? {
+        Ok(()) => Ok(()),
+        Err(Rejection::NoSuchUser(_)) | Err(Rejection::NoSuchGroup(_)) => {
+            unreachable!("checked by parse_and_fetch_subject")
         }
     }
-    Ok(())
 }
 
 pub async fn remove_roles(

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -514,10 +514,12 @@ impl<'a> UserBuilder<'a> {
             .await
             .expect("User should be created successfully");
         if app.app_state.config.enable_authorization {
-            regulator
-                .grant_user_roles(&authz::User(user.id), roles)
+            v2::add_roles(authz::Subject::user(user.id), roles)
+                .authorize(&test_authorizers::Authorize(regulator.openfga()))
                 .await
-                .expect("roles should be granted successfully");
+                .expect("roles should be granted successfully")
+                .unwrap_authorized()
+                .await;
 
             for (infra_id, grant) in infras_grant.into_iter() {
                 regulator
@@ -588,10 +590,12 @@ impl<'a> GroupBuilder<'a> {
         let group = authz::identity::Group { id, info };
         if !authz_disabled {
             let group_auth = authz::Group(group.id);
-            regulator
-                .grant_group_roles(&group_auth, roles)
+            v2::add_roles(group_auth.into(), roles)
+                .authorize(&test_authorizers::Authorize(regulator.openfga()))
                 .await
-                .expect("roles should be granted successfully");
+                .expect("roles should be granted successfully")
+                .unwrap_authorized()
+                .await;
 
             v2::add_members(
                 group_auth,


### PR DESCRIPTION
Peer-programmed with @SaumonDesMers.

- **editoast: client: extract OpenFGA client creation from config**
- **editoast: authz: migrate `add_roles` to next `authz` paradigm**
- **editoast: replace old `grant_user_roles` and `grant_group_roles`**
---

`Regulator` functions `grant_user_roles` and `grant_group_roles` have
been merged into a single function `add_roles` taking a `Subject`.
These fucntions are still in use in some tests.
Role retrieval has been inlined. That might change when `Protected::map`
will be available.
