### PR TITLE
editoast: truncate macro_node.trigram before migration

### DIFF
--- a/editoast/migrations/2026-03-03-100000_increase_macro_node_trigram_length/down.sql
+++ b/editoast/migrations/2026-03-03-100000_increase_macro_node_trigram_length/down.sql
@@ -1,1 +1,2 @@
+UPDATE macro_node SET trigram = LEFT(trigram, 25) WHERE LENGTH(trigram) > 25;
 ALTER TABLE macro_node ALTER COLUMN trigram TYPE varchar(25);


### PR DESCRIPTION
Fixes https://github.com/OpenRailAssociation/osrd/pull/15519#issuecomment-3996430447