### PR TITLE
Add requested point dot indicator in name and track columns

### DIFF
--- a/front/src/modules/timesStops/TimesStopsTable.tsx
+++ b/front/src/modules/timesStops/TimesStopsTable.tsx
@@ -134,12 +134,15 @@ const TimesStopsTable = ({
       columnHelper.accessor('name', {
         header: () => t('operational_point'),
         cell: (info) => {
-          const { name, secondaryCode } = info.row.original;
+          const { name, secondaryCode, isPathStep } = info.row.original;
           return (
-            <div title={`${name}${secondaryCode ? ` ${secondaryCode}` : ''}`}>
-              <span>{name}</span>
-              {secondaryCode && <span className="secondary-code"> {secondaryCode}</span>}
-            </div>
+            <>
+              {isPathStep && <span className="requested-point-dot" />}
+              <div title={`${name}${secondaryCode ? ` ${secondaryCode}` : ''}`}>
+                <span>{name}</span>
+                {secondaryCode && <span className="secondary-code"> {secondaryCode}</span>}
+              </div>
+            </>
           );
         },
         meta: {
@@ -148,7 +151,15 @@ const TimesStopsTable = ({
       }),
       columnHelper.accessor('track', {
         header: () => t('trackName'),
-        cell: (info) => <span>{info.getValue() ?? ''}</span>,
+        cell: (info) => {
+          const { isPathStep, hasRequestedTrack } = info.row.original;
+          return (
+            <>
+              {isPathStep && hasRequestedTrack && <span className="requested-point-dot" />}
+              <span>{info.getValue() ?? ''}</span>
+            </>
+          );
+        },
         meta: {
           className: 'col-track computed',
         },

--- a/front/src/modules/timesStops/hooks/useTimesStopsTableData.ts
+++ b/front/src/modules/timesStops/hooks/useTimesStopsTableData.ts
@@ -30,6 +30,7 @@ type BuildTableRowParams = {
   name?: string;
   secondaryCode?: string;
   trackName?: string;
+  hasRequestedTrack?: boolean;
   startDate: Date;
   schedule?: ScheduleItem;
   computedArrival?: Duration;
@@ -45,6 +46,7 @@ const buildTableRow = ({
   name,
   secondaryCode,
   trackName,
+  hasRequestedTrack = false,
   startDate,
   schedule,
   computedArrival,
@@ -91,6 +93,7 @@ const buildTableRow = ({
     scheduleNotHonored,
     marginNotHonored,
     isPathStep: true,
+    hasRequestedTrack,
     location,
   };
 };
@@ -201,6 +204,9 @@ const useTimesStopsTableData = (
                 ?.local_track_name
             : (pathStepLocation.local_track_name ?? undefined);
 
+        const hasRequestedTrack =
+          'track' in pathStepLocation || !!pathStepLocation.local_track_name;
+
         const schedule = scheduleByAt[pathStep.id];
         const computedArrival =
           stablePathItemTimes?.final[stepIndex] !== undefined
@@ -220,6 +226,7 @@ const useTimesStopsTableData = (
           name,
           secondaryCode: matchingOp?.extensions?.sncf?.ch,
           trackName,
+          hasRequestedTrack,
           startDate,
           schedule,
           computedArrival,

--- a/front/src/modules/timesStops/styles/_timesStopsTable.scss
+++ b/front/src/modules/timesStops/styles/_timesStopsTable.scss
@@ -101,6 +101,21 @@
       }
     }
 
+    td.col-name,
+    td.col-track {
+      position: relative;
+
+      .requested-point-dot {
+        position: absolute;
+        left: 3px;
+        top: 4px;
+        width: 3px;
+        height: 3px;
+        border-radius: 1px;
+        background-color: var(--info60);
+      }
+    }
+
     td.col-name {
       text-align: left;
 
@@ -212,7 +227,7 @@
     }
 
     /* Ensure content is above layer */
-    td[class^='col-'] > * {
+    td[class^='col-'] > *:not(.requested-point-dot) {
       position: relative;
       z-index: 1;
     }

--- a/front/src/modules/timesStops/types.ts
+++ b/front/src/modules/timesStops/types.ts
@@ -25,6 +25,8 @@ export type TimesStopsRowNew = {
   marginNotHonored: boolean | undefined;
   /** True if this row corresponds to a pathStep input, false if it's just a waypoint */
   isPathStep: boolean;
+  /** True if the pathStep had an explicit track in its location (TrackOffset or local_track_name) */
+  hasRequestedTrack: boolean;
   /** Location info to create a new PathItem when editing a waypoint that's not yet a pathStep */
   location: PathItemLocation;
 };


### PR DESCRIPTION
Close #14281 

- Adds a small dot indicator ([sketch](https://www.sketch.com/s/44a4dfe4-6ef5-4f9f-92d3-72b79136e5da/p/1EB88FE0-2CA8-4729-B47F-ADDBDA831C41/canvas#Inspect)) in the OP name and
  Track columns of the new `TimesStopsTable`
- Dot in OP name column: visible when the row is a requested path step
- Dot in Track: visible when the path step has an explicit track in its location
<img width="742" height="224" alt="image" src="https://github.com/user-attachments/assets/e8b6bc04-108c-473e-8327-2321948af919" />


