### PR TITLE
front: bugfix for #15234

### DIFF
--- a/front/src/modules/simulationResult/components/SpeedDistanceDiagram/SpeedDistanceDiagramWrapper.tsx
+++ b/front/src/modules/simulationResult/components/SpeedDistanceDiagram/SpeedDistanceDiagramWrapper.tsx
@@ -113,6 +113,7 @@ const SpeedDistanceDiagramWrapper = ({
     <div
       ref={root}
       id="container-SpeedSpaceChart"
+      className="speed-space-chart-wrapper"
       data-testid="speed-space-chart"
       style={{ height: `${height}px` }}
     >

--- a/front/src/styles/scss/applications/operationalStudies/_simulationresults.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_simulationresults.scss
@@ -88,6 +88,10 @@
     .osrd-simulation-container {
       position: relative;
       border-radius: 4px;
+
+      .speed-space-chart-wrapper {
+        overflow: hidden;
+      }
     }
 
     .simulation-map {
@@ -126,6 +130,7 @@
         font-weight: 500;
         font-size: 1rem;
       }
+
       svg {
         color: var(--primary60);
       }
@@ -148,11 +153,13 @@
       padding: 2.4px 4px;
       font-size: 0.7rem;
       white-space: nowrap;
+
       &.via-number {
         padding: 0;
         font-weight: bold;
         color: white;
       }
+
       &.stdcm-via {
         align-self: flex-start;
         padding-top: 8px;


### PR DESCRIPTION
Following the instructions of a previous pull request:

https://github.com/OpenRailAssociation/osrd/pull/15496#issuecomment-3992863106

This pull request adds a `overflow: hidden` attribute to the SpeedSpaceChart `div` container, in order to prevent the flickering described in the issue https://github.com/OpenRailAssociation/osrd/issues/15234