### PR TITLE
editoast: authz: `v2::remove_members`

### DIFF
--- a/editoast/authz/src/authorizer.rs
+++ b/editoast/authz/src/authorizer.rs
@@ -369,10 +369,12 @@ mod tests {
         );
 
         // remove user
-        regulator()
-            .remove_members(&friends, &HashSet::from([User(bob_id)]))
+        v2::remove_members(friends, HashSet::from([User(bob_id)]))
+            .authorize(&test_authorizers::Authorize(regulator().openfga()))
             .await
-            .expect("bob should be removed from the group");
+            .expect("bob should be removed from the group")
+            .unwrap_authorized()
+            .await;
 
         assert!(
             !Authorizer::try_initialize(bob_identity(), regulator())

--- a/editoast/authz/src/regulator.rs
+++ b/editoast/authz/src/regulator.rs
@@ -185,24 +185,6 @@ impl<S: StorageDriver> Regulator<S> {
         Ok(members.users.into_iter().collect())
     }
 
-    /// Removes some users from a group
-    #[tracing::instrument(skip_all, fields(group, ?members), ret(level = Level::DEBUG), err)]
-    pub async fn remove_members(
-        &self,
-        group: &Group,
-        members: &HashSet<User>,
-    ) -> Result<(), Error<S::Error>> {
-        let existing_members = self.group_members(group).await?;
-        let members = members.intersection(&existing_members);
-        let mut deletes = self.openfga.prepare_deletes();
-        for user in members {
-            deletes.push(&Group::member().tuple(user, group));
-            deletes.push(&User::group().tuple(group, user));
-        }
-        deletes.execute().await?;
-        Ok(())
-    }
-
     #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
     pub async fn user_roles(&self, user: &User) -> Result<HashSet<Role>, Error<S::Error>> {
         // no need to check for user inexistence, an empty set will be returned in this case

--- a/editoast/authz/src/v2.rs
+++ b/editoast/authz/src/v2.rs
@@ -227,6 +227,45 @@ pub fn add_roles(subject: Subject, roles: HashSet<Role>) -> Protected<'static, (
     })
 }
 
+/// Removes some members from a group
+///
+/// Idempotent but not atomic due to the lack of transactions in OpenFGA.
+pub fn remove_members(group: Group, members: HashSet<User>) -> Protected<'static, ()> {
+    let user_exists_checks = members
+        .iter()
+        .map(|user| SanityCheck::UserExists(*user))
+        .collect_vec(); // members is moved in Protected
+
+    Protected::new(move |openfga| {
+        async move {
+            let existing_members = openfga
+                .list_users(Group::member().query_users(&group))
+                .await
+                .map_err(QueryError::parsing_ok)?;
+
+            debug_assert!(
+                existing_members.public_access.is_none(),
+                "we don't write public accesses for groups"
+            );
+
+            let existing_members = HashSet::from_iter(existing_members.users);
+            let expelled = members.intersection(&existing_members);
+            let mut writes = openfga.prepare_deletes();
+            for user in expelled {
+                writes.push(&Group::member().tuple(user, &group));
+                writes.push(&User::group().tuple(&group, user));
+            }
+            writes.execute().await?;
+
+            Ok(())
+        }
+        .boxed()
+    })
+    .with_check(SanityCheck::GroupExists(group))
+    .with_check_iter(user_exists_checks)
+    .with_guardrail(Guardrail::IssuerHasRole(Role::Admin))
+}
+
 pub mod test_authorizers {
     use std::convert::Infallible;
 
@@ -352,6 +391,84 @@ mod tests {
         assert_eq!(
             openfga.group_members(&Group(1)).await,
             HashSet::from_iter([User(1), User(2), User(3)])
+        );
+    }
+
+    #[tokio::test]
+    async fn remove_members_idempotent() {
+        let openfga = crate::authz_client!();
+        let authorize = Authorize(&openfga);
+
+        add_members(Group(1), HashSet::from_iter([User(1), User(2)]))
+            .authorize(&authorize)
+            .await
+            .unwrap()
+            .unwrap_authorized()
+            .await;
+        assert_eq!(
+            openfga.group_members(&Group(1)).await,
+            HashSet::from_iter([User(1), User(2)])
+        );
+
+        remove_members(Group(1), HashSet::from_iter([User(1), User(2)]))
+            .authorize(&authorize)
+            .await
+            .unwrap()
+            .unwrap_authorized()
+            .await;
+        assert_eq!(
+            openfga.group_members(&Group(1)).await,
+            HashSet::from_iter([])
+        );
+
+        remove_members(Group(1), HashSet::from_iter([User(1), User(2)]))
+            .authorize(&authorize)
+            .await
+            .unwrap()
+            .unwrap_authorized()
+            .await;
+        assert_eq!(
+            openfga.group_members(&Group(1)).await,
+            HashSet::from_iter([])
+        );
+    }
+
+    #[tokio::test]
+    async fn remove_members_intersecting_calls() {
+        let openfga = crate::authz_client!();
+        let authorize = Authorize(&openfga);
+
+        add_members(Group(1), HashSet::from_iter([User(1), User(2), User(3)]))
+            .authorize(&authorize)
+            .await
+            .unwrap()
+            .unwrap_authorized()
+            .await;
+        assert_eq!(
+            openfga.group_members(&Group(1)).await,
+            HashSet::from_iter([User(1), User(2), User(3)])
+        );
+
+        remove_members(Group(1), HashSet::from_iter([User(1), User(2)]))
+            .authorize(&authorize)
+            .await
+            .unwrap()
+            .unwrap_authorized()
+            .await;
+        assert_eq!(
+            openfga.group_members(&Group(1)).await,
+            HashSet::from_iter([User(3)])
+        );
+
+        remove_members(Group(1), HashSet::from_iter([User(1), User(3)]))
+            .authorize(&authorize)
+            .await
+            .unwrap()
+            .unwrap_authorized()
+            .await;
+        assert_eq!(
+            openfga.group_members(&Group(1)).await,
+            HashSet::from_iter([])
         );
     }
 

--- a/editoast/authz/src/v2.rs
+++ b/editoast/authz/src/v2.rs
@@ -152,7 +152,7 @@ impl<'a, T, R: std::fmt::Debug> Access<'a, T, R> {
 /// Adds some members to a group
 ///
 /// Idempotent but not atomic due to the lack of transactions in OpenFGA.
-pub fn add_members<'a>(group: Group, members: HashSet<User>) -> Protected<'a, ()> {
+pub fn add_members(group: Group, members: HashSet<User>) -> Protected<'static, ()> {
     let user_exists_checks = members
         .iter()
         .map(|user| SanityCheck::UserExists(*user))

--- a/editoast/src/client/group.rs
+++ b/editoast/src/client/group.rs
@@ -136,6 +136,10 @@ pub async fn exclude_group(
 
     let regulator = openfga_config.into_regulator(pool.clone()).await?;
     let driver = regulator.driver();
+    let system = SystemAuthorizer {
+        openfga: regulator.openfga(),
+        conn: pool.get().await?,
+    };
 
     let Some(group_id) = driver.get_group_id(&group_name).await? else {
         bail!("No such group: '{group_name}'");
@@ -152,10 +156,12 @@ pub async fn exclude_group(
         authz_users.insert(authz::User(uid));
     }
 
-    regulator
-        .remove_members(&authz::Group(group_id), &authz_users)
-        .await?;
-    Ok(())
+    let remove_member = authz::v2::remove_members(authz::Group(group_id), authz_users);
+    match system.authorize(remove_member).await?.access().await? {
+        Ok(()) => Ok(()),
+        Err(Rejection::NoSuchGroup(_)) => unreachable!("tested above"),
+        Err(Rejection::NoSuchUser(user_id)) => bail!("No such user {user_id}"),
+    }
 }
 
 /// Include users in a group
@@ -205,6 +211,10 @@ pub async fn delete_group(
 ) -> anyhow::Result<()> {
     let regulator = openfga_config.into_regulator(pool.clone()).await?;
     let driver = regulator.driver();
+    let system = SystemAuthorizer {
+        openfga: regulator.openfga(),
+        conn: pool.get().await?,
+    };
     let group_id = if let Some(id) = driver.get_group_id(&name).await? {
         id
     } else {
@@ -214,7 +224,12 @@ pub async fn delete_group(
 
     // Delete the relationships between the group to be deleted and its members
     let users_in_group = regulator.group_members(&group).await?;
-    regulator.remove_members(&group, &users_in_group).await?;
+    let remove_member = authz::v2::remove_members(group, users_in_group);
+    match system.authorize(remove_member).await?.access().await? {
+        Ok(()) => {}
+        Err(Rejection::NoSuchGroup(_)) => unreachable!("tested above"),
+        Err(Rejection::NoSuchUser(_)) => unreachable!("tested above"),
+    }
 
     let deleted = driver.delete_group(group_id).await?;
     if deleted {


### PR DESCRIPTION
Add remove_members function in v2 and replace the old one with it.

I'm not entirely sure what to test to make sure everything work (I just did `cargo test authz`).
If someone can help me with that.