### PR TITLE
Modify empty time cell in new schedule sheet

### DIFF
--- a/front/src/modules/timesStops/DurationCell.tsx
+++ b/front/src/modules/timesStops/DurationCell.tsx
@@ -1,6 +1,14 @@
 /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
 /* eslint-disable jsx-a11y/no-static-element-interactions */
-import { useReducer, useRef, useLayoutEffect, useEffect, useState, type Dispatch } from 'react';
+import {
+  useReducer,
+  useRef,
+  useLayoutEffect,
+  useEffect,
+  useState,
+  useImperativeHandle,
+  type Dispatch,
+} from 'react';
 
 import { Clear } from '@osrd-project/ui-icons';
 import type { CellContext } from '@tanstack/react-table';
@@ -360,13 +368,19 @@ const UnitDisplay = ({ unit, state, dispatch, startEditing, isEdited }: UnitDisp
   );
 };
 
+export type DurationCellHandle = {
+  focus: () => void;
+};
+
 const DurationCell = ({
   disabled,
+  ref,
   ...props
 }: CellContext<TimesStopsRowNew, Duration | null> &
   Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange'> & {
     onChange?: (e: { target: { value: number | null } }) => void;
     disabled?: boolean;
+    ref?: React.Ref<DurationCellHandle>;
   }) => {
   const { onChange, getValue } = props || {};
   const controlledValue = getValue();
@@ -374,6 +388,14 @@ const DurationCell = ({
   const containerRef = useRef<HTMLDivElement>(null);
   const mouseDownRef = useRef(false);
   const [btnPos, setBtnPos] = useState<{ top: number; left: number } | null>(null);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      focus: () => containerRef.current?.focus(),
+    }),
+    []
+  );
 
   // Sync internal state with external value when it changes (and not editing)
   useEffect(() => {

--- a/front/src/modules/timesStops/TimeCell.tsx
+++ b/front/src/modules/timesStops/TimeCell.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useReducer, useRef, type ChangeEvent } from 'react';
+import { useEffect, useImperativeHandle, useReducer, useRef, type ChangeEvent } from 'react';
 
 import type { CellContext } from '@tanstack/react-table';
 
@@ -28,10 +28,17 @@ type TimeState = {
   hasTyped: boolean;
 };
 
+type BlurIntent = 'none' | 'commit' | 'cancel';
+
+export type TimeCellHandle = {
+  focus: () => void;
+};
+
 type TimeAction =
   | { type: 'DIGIT_PRESSED'; digit: string }
   | { type: 'BACKSPACE_PRESSED' }
   | { type: 'ENTER_PRESSED' }
+  | { type: 'ESCAPE_PRESSED'; value: Date | null }
   | { type: 'SECTION_CLICKED'; section: Section }
   | { type: 'FOCUSED'; section: Section }
   | { type: 'FOCUSED_WITH_PREFILL'; section: Section; prefillValue: Date }
@@ -405,6 +412,8 @@ const timeReducer = (state: TimeState, action: TimeAction): TimeState => {
       return computeSectionClickState(state, action.section);
     case 'ENTER_PRESSED':
       return computeBlurState(state);
+    case 'ESCAPE_PRESSED':
+      return initialTimeState(action.value);
     case 'LEFT_ARROW_PRESSED':
       return computeArrowState(state, 'left');
     case 'RIGHT_ARROW_PRESSED':
@@ -469,21 +478,38 @@ type TimeCellProps = CellContext<TimesStopsRowNew, Date | null> &
     /** Reference date used as the calendar day base. If the entered time is before this date, the next day is assumed. */
     referenceDate?: Date;
     /** When the cell is empty, pre-fill the input with this value when the user focuses to edit. */
-    computedValue?: Date | null;
+    prefillValue?: Date | null;
+    /** Called after Enter validates the input. Use to move focus (e.g. to the cell below). */
+    onEnterKeyDown?: () => void;
     onCommit?: (date: Date | null) => void;
+    ref?: React.Ref<TimeCellHandle>;
   };
 
 const TimeCell = ({
   getValue,
   referenceDate,
-  computedValue,
+  prefillValue,
+  onEnterKeyDown,
   onCommit,
+  ref,
   ...props
 }: TimeCellProps) => {
   const { onKeyDown, onBlur, onFocus, onChange, ...userProps } = props || {};
 
   const controlledValue = getValue();
   const inputRef = useRef<HTMLInputElement>(null);
+  const shouldPrefillRef = useRef(false);
+  const blurIntentRef = useRef<BlurIntent>('none');
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      focus: () => {
+        inputRef.current?.focus();
+      },
+    }),
+    []
+  );
 
   const [state, dispatch] = useReducer(timeReducer, controlledValue, initialTimeState);
 
@@ -507,6 +533,14 @@ const TimeCell = ({
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     switch (e.key) {
       case 'Enter':
+        e.preventDefault();
+        blurIntentRef.current = 'commit';
+        onEnterKeyDown?.();
+        e.currentTarget.blur();
+        break;
+      case 'Escape':
+        e.preventDefault();
+        blurIntentRef.current = 'cancel';
         e.currentTarget.blur();
         break;
       case 'Backspace':
@@ -541,18 +575,19 @@ const TimeCell = ({
   };
 
   const handlePlaceholderClick = () => {
-    if (state.empty && computedValue) {
-      dispatch({ type: 'FOCUSED_WITH_PREFILL', section: 'minutes', prefillValue: computedValue });
-    }
+    shouldPrefillRef.current = true;
     inputRef.current?.focus();
   };
 
   const handleFocus = (e: React.FocusEvent<HTMLInputElement>) => {
+    const shouldPrefill = shouldPrefillRef.current;
+    shouldPrefillRef.current = false;
+
     let section: Section;
     if (state.empty) {
       section = 'minutes';
-      if (computedValue) {
-        dispatch({ type: 'FOCUSED_WITH_PREFILL', section, prefillValue: computedValue });
+      if (prefillValue && shouldPrefill) {
+        dispatch({ type: 'FOCUSED_WITH_PREFILL', section, prefillValue });
         onFocus?.(e);
         return;
       }
@@ -565,18 +600,33 @@ const TimeCell = ({
   };
 
   const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+    const blurIntent = blurIntentRef.current;
+
+    if (blurIntent === 'cancel') {
+      blurIntentRef.current = 'none';
+      dispatch({ type: 'ESCAPE_PRESSED', value: controlledValue });
+      onBlur?.(e);
+      return;
+    }
+
     // Commit first: useReducer updates are async, so we compute the clamped state
     // ourselves rather than waiting for the BLURRED dispatch to take effect.
     // This ensures "14:45" (no seconds) commits as "14:45:00" instead of null.
+
     if (onCommit && referenceDate) {
       const newDate = buildDateFromState(computeBlurState(state), referenceDate);
       const hasChanged = newDate?.getTime() !== controlledValue?.getTime();
       if (hasChanged) {
-        onCommit(newDate);
+        if (blurIntent === 'commit') {
+          setTimeout(() => onCommit(newDate), 0);
+        } else {
+          onCommit(newDate);
+        }
       }
     }
 
     dispatch({ type: 'BLURRED' });
+    blurIntentRef.current = 'none';
     onBlur?.(e);
   };
 

--- a/front/src/modules/timesStops/TimeCell.tsx
+++ b/front/src/modules/timesStops/TimeCell.tsx
@@ -481,6 +481,8 @@ type TimeCellProps = CellContext<TimesStopsRowNew, Date | null> &
     prefillValue?: Date | null;
     /** Called after Enter validates the input. Use to move focus (e.g. to the cell below). */
     onEnterKeyDown?: () => void;
+    /** Called on Tab key to move focus to the next/previous editable time cell. */
+    onTabKeyDown?: (direction: 'forward' | 'backward') => boolean;
     onCommit?: (date: Date | null) => void;
     ref?: React.Ref<TimeCellHandle>;
   };
@@ -490,6 +492,7 @@ const TimeCell = ({
   referenceDate,
   prefillValue,
   onEnterKeyDown,
+  onTabKeyDown,
   onCommit,
   ref,
   ...props
@@ -542,6 +545,13 @@ const TimeCell = ({
         e.preventDefault();
         blurIntentRef.current = 'cancel';
         e.currentTarget.blur();
+        break;
+      case 'Tab':
+        blurIntentRef.current = 'commit';
+        if (onTabKeyDown?.(e.shiftKey ? 'backward' : 'forward')) {
+          e.preventDefault();
+          e.currentTarget.blur();
+        }
         break;
       case 'Backspace':
         e.preventDefault();

--- a/front/src/modules/timesStops/TimeCell.tsx
+++ b/front/src/modules/timesStops/TimeCell.tsx
@@ -34,6 +34,7 @@ type TimeAction =
   | { type: 'ENTER_PRESSED' }
   | { type: 'SECTION_CLICKED'; section: Section }
   | { type: 'FOCUSED'; section: Section }
+  | { type: 'FOCUSED_WITH_PREFILL'; section: Section; prefillValue: Date }
   | { type: 'LEFT_ARROW_PRESSED' }
   | { type: 'RIGHT_ARROW_PRESSED' }
   | { type: 'BLURRED' }
@@ -335,6 +336,17 @@ const computeSectionClickState = (state: TimeState, section: Section): TimeState
   hasTyped: state.empty || false,
 });
 
+const computeFocusedWithPrefillState = (
+  state: TimeState,
+  section: Section,
+  prefillValue: Date
+): TimeState => ({
+  ...parseTimeState(prefillValue),
+  focusedSection: section,
+  empty: false,
+  hasTyped: state.empty || false,
+});
+
 const computeArrowState = (state: TimeState, direction: 'left' | 'right'): TimeState => {
   const { focusedSection } = state;
   if (!focusedSection) return state;
@@ -387,6 +399,8 @@ const timeReducer = (state: TimeState, action: TimeAction): TimeState => {
       return computeBlurState(state);
     case 'FOCUSED':
       return computeFocusState(state, action.section);
+    case 'FOCUSED_WITH_PREFILL':
+      return computeFocusedWithPrefillState(state, action.section, action.prefillValue);
     case 'SECTION_CLICKED':
       return computeSectionClickState(state, action.section);
     case 'ENTER_PRESSED':
@@ -454,10 +468,18 @@ type TimeCellProps = CellContext<TimesStopsRowNew, Date | null> &
   React.InputHTMLAttributes<HTMLInputElement> & {
     /** Reference date used as the calendar day base. If the entered time is before this date, the next day is assumed. */
     referenceDate?: Date;
+    /** When the cell is empty, pre-fill the input with this value when the user focuses to edit. */
+    computedValue?: Date | null;
     onCommit?: (date: Date | null) => void;
   };
 
-const TimeCell = ({ getValue, referenceDate, onCommit, ...props }: TimeCellProps) => {
+const TimeCell = ({
+  getValue,
+  referenceDate,
+  computedValue,
+  onCommit,
+  ...props
+}: TimeCellProps) => {
   const { onKeyDown, onBlur, onFocus, onChange, ...userProps } = props || {};
 
   const controlledValue = getValue();
@@ -519,6 +541,9 @@ const TimeCell = ({ getValue, referenceDate, onCommit, ...props }: TimeCellProps
   };
 
   const handlePlaceholderClick = () => {
+    if (state.empty && computedValue) {
+      dispatch({ type: 'FOCUSED_WITH_PREFILL', section: 'minutes', prefillValue: computedValue });
+    }
     inputRef.current?.focus();
   };
 
@@ -526,6 +551,11 @@ const TimeCell = ({ getValue, referenceDate, onCommit, ...props }: TimeCellProps
     let section: Section;
     if (state.empty) {
       section = 'minutes';
+      if (computedValue) {
+        dispatch({ type: 'FOCUSED_WITH_PREFILL', section, prefillValue: computedValue });
+        onFocus?.(e);
+        return;
+      }
     } else {
       const position = e.currentTarget.selectionStart || 0;
       section = getSectionFromPosition(position);

--- a/front/src/modules/timesStops/TimesStopsTable.tsx
+++ b/front/src/modules/timesStops/TimesStopsTable.tsx
@@ -165,12 +165,14 @@ const TimesStopsTable = ({
       columnHelper.accessor('requestedArrival', {
         header: () => t('arrivalTime'),
         cell: (info) => {
+          const row = info.row.original;
           const { allRows, onArrivalChange: onArrival } = info.table.options.meta!;
           return (
             <TimeCell
               {...info}
-              referenceDate={getArrivalReferenceDate(info.row.original, allRows, startTime)}
-              onCommit={(date) => onArrival(info.row.original, date)}
+              referenceDate={getArrivalReferenceDate(row, allRows, startTime)}
+              computedValue={row.computedArrival}
+              onCommit={(date) => onArrival(row, date)}
             />
           );
         },
@@ -218,6 +220,7 @@ const TimesStopsTable = ({
             <TimeCell
               {...info}
               referenceDate={getDepartureReferenceDate(row, startTime)}
+              computedValue={row.computedDeparture}
               onCommit={(date) => info.table.options.meta!.onDepartureChange(row, date)}
             />
           );

--- a/front/src/modules/timesStops/TimesStopsTable.tsx
+++ b/front/src/modules/timesStops/TimesStopsTable.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 
 import {
   createColumnHelper,
@@ -13,7 +13,7 @@ import { useTranslation } from 'react-i18next';
 import { formatLocalTime } from 'utils/date';
 
 import DurationCell from './DurationCell';
-import TimeCell from './TimeCell';
+import TimeCell, { type TimeCellHandle } from './TimeCell';
 import { type TimesStopsRowNew } from './types';
 
 declare module '@tanstack/react-table' {
@@ -24,6 +24,7 @@ declare module '@tanstack/react-table' {
   // eslint-disable-next-line @typescript-eslint/consistent-type-definitions, @typescript-eslint/no-unused-vars
   interface TableMeta<TData extends RowData> {
     allRows: TimesStopsRowNew[];
+    isComputedDataPending?: boolean;
     onArrivalChange: (row: TimesStopsRowNew, arrival: Date | null) => void;
     onStopDurationChange: (row: TimesStopsRowNew, durationSeconds: number | null) => void;
     onDepartureChange: (row: TimesStopsRowNew, departure: Date | null) => void;
@@ -76,6 +77,7 @@ type TimesStopsTableProps = {
 };
 
 const columnHelper = createColumnHelper<TimesStopsRowNew>();
+const getTimeCellKey = (rowIndex: number, columnId: string) => `${rowIndex}-${columnId}`;
 
 const TimesStopsTable = ({
   rows,
@@ -87,8 +89,30 @@ const TimesStopsTable = ({
   onDepartureChange,
 }: TimesStopsTableProps) => {
   const { t } = useTranslation('translation', { keyPrefix: 'timeStopTable' });
-
   const scheduleNotHonored = rows.some((row) => row.stepStatus === 'scheduleNotHonored');
+  const cellHandlesRef = useRef<Map<string, TimeCellHandle>>(new Map());
+
+  const registerTimeCellRef = useCallback(
+    (rowIndex: number, columnId: string) => (handle: TimeCellHandle | null) => {
+      const key = getTimeCellKey(rowIndex, columnId);
+      if (handle) {
+        cellHandlesRef.current.set(key, handle);
+      } else {
+        cellHandlesRef.current.delete(key);
+      }
+    },
+    []
+  );
+
+  const focusCellBelow = useCallback(
+    (rowIndex: number, columnId: string) => {
+      const targetRowIndex = rowIndex + 1;
+      if (targetRowIndex >= rows.length) return;
+      const key = getTimeCellKey(targetRowIndex, columnId);
+      cellHandlesRef.current.get(key)?.focus();
+    },
+    [rows.length]
+  );
 
   const columns = useMemo(
     () => [
@@ -104,7 +128,7 @@ const TimesStopsTable = ({
         id: 'stepStatus',
         header: '',
         cell: (info) => {
-          if (isComputedDataPending) {
+          if (info.table.options.meta!.isComputedDataPending) {
             return <span>&nbsp;</span>;
           }
 
@@ -169,9 +193,11 @@ const TimesStopsTable = ({
           const { allRows, onArrivalChange: onArrival } = info.table.options.meta!;
           return (
             <TimeCell
+              ref={registerTimeCellRef(info.row.index, 'requestedArrival')}
               {...info}
               referenceDate={getArrivalReferenceDate(row, allRows, startTime)}
-              computedValue={row.computedArrival}
+              prefillValue={row.computedArrival}
+              onEnterKeyDown={() => focusCellBelow(info.row.index, 'requestedArrival')}
               onCommit={(date) => onArrival(row, date)}
             />
           );
@@ -183,7 +209,7 @@ const TimesStopsTable = ({
       columnHelper.accessor('computedArrival', {
         header: () => t('calculatedArrivalTime'),
         cell: (info) => {
-          if (isComputedDataPending) {
+          if (info.table.options.meta!.isComputedDataPending) {
             return <span className="cell-loading-placeholder" />;
           }
           const value = info.getValue();
@@ -218,9 +244,11 @@ const TimesStopsTable = ({
           }
           return (
             <TimeCell
+              ref={registerTimeCellRef(info.row.index, 'requestedDeparture')}
               {...info}
               referenceDate={getDepartureReferenceDate(row, startTime)}
-              computedValue={row.computedDeparture}
+              prefillValue={row.computedDeparture}
+              onEnterKeyDown={() => focusCellBelow(info.row.index, 'requestedDeparture')}
               onCommit={(date) => info.table.options.meta!.onDepartureChange(row, date)}
             />
           );
@@ -232,7 +260,7 @@ const TimesStopsTable = ({
       columnHelper.accessor('computedDeparture', {
         header: () => t('calculatedDepartureTime'),
         cell: (info) => {
-          if (isComputedDataPending) {
+          if (info.table.options.meta!.isComputedDataPending) {
             return <span className="cell-loading-placeholder" />;
           }
           const value = info.getValue();
@@ -304,7 +332,7 @@ const TimesStopsTable = ({
         },
       }),
     ],
-    [startTime, isComputedDataPending]
+    [startTime, focusCellBelow]
   );
 
   // eslint-disable-next-line react-hooks/incompatible-library
@@ -314,6 +342,7 @@ const TimesStopsTable = ({
     getCoreRowModel: getCoreRowModel(),
     meta: {
       allRows: rows,
+      isComputedDataPending,
       onArrivalChange,
       onStopDurationChange,
       onDepartureChange,

--- a/front/src/modules/timesStops/TimesStopsTable.tsx
+++ b/front/src/modules/timesStops/TimesStopsTable.tsx
@@ -12,7 +12,7 @@ import { useTranslation } from 'react-i18next';
 
 import { formatLocalTime } from 'utils/date';
 
-import DurationCell from './DurationCell';
+import DurationCell, { type DurationCellHandle } from './DurationCell';
 import TimeCell, { type TimeCellHandle } from './TimeCell';
 import { type TimesStopsRowNew } from './types';
 
@@ -20,6 +20,7 @@ declare module '@tanstack/react-table' {
   // eslint-disable-next-line @typescript-eslint/consistent-type-definitions, @typescript-eslint/no-unused-vars
   interface ColumnMeta<TData extends RowData, TValue> {
     className: string;
+    tabbable?: boolean;
   }
   // eslint-disable-next-line @typescript-eslint/consistent-type-definitions, @typescript-eslint/no-unused-vars
   interface TableMeta<TData extends RowData> {
@@ -78,6 +79,12 @@ type TimesStopsTableProps = {
 
 const columnHelper = createColumnHelper<TimesStopsRowNew>();
 const getTimeCellKey = (rowIndex: number, columnId: string) => `${rowIndex}-${columnId}`;
+type TabbableCellColumnId = 'requestedArrival' | 'stopDuration' | 'requestedDeparture';
+type TabbableCellHandle = TimeCellHandle | DurationCellHandle;
+type TimeCellTabEntry = {
+  next: string | null;
+  prev: string | null;
+};
 
 const TimesStopsTable = ({
   rows,
@@ -90,10 +97,11 @@ const TimesStopsTable = ({
 }: TimesStopsTableProps) => {
   const { t } = useTranslation('translation', { keyPrefix: 'timeStopTable' });
   const scheduleNotHonored = rows.some((row) => row.stepStatus === 'scheduleNotHonored');
-  const cellHandlesRef = useRef<Map<string, TimeCellHandle>>(new Map());
+  const cellHandlesRef = useRef<Map<string, TabbableCellHandle>>(new Map());
+  const cellTabOrderRef = useRef<Map<string, TimeCellTabEntry>>(new Map());
 
   const registerTimeCellRef = useCallback(
-    (rowIndex: number, columnId: string) => (handle: TimeCellHandle | null) => {
+    (rowIndex: number, columnId: string) => (handle: TabbableCellHandle | null) => {
       const key = getTimeCellKey(rowIndex, columnId);
       if (handle) {
         cellHandlesRef.current.set(key, handle);
@@ -112,6 +120,20 @@ const TimesStopsTable = ({
       cellHandlesRef.current.get(key)?.focus();
     },
     [rows.length]
+  );
+
+  const focusRequestedCellOnTab = useCallback(
+    (rowIndex: number, columnId: TabbableCellColumnId, direction: 'forward' | 'backward') => {
+      const currentKey = getTimeCellKey(rowIndex, columnId);
+      const entry = cellTabOrderRef.current.get(currentKey);
+      if (!entry) return false;
+      const key = direction === 'forward' ? entry.next : entry.prev;
+      if (!key) return false;
+
+      cellHandlesRef.current.get(key)?.focus();
+      return true;
+    },
+    []
   );
 
   const columns = useMemo(
@@ -198,12 +220,16 @@ const TimesStopsTable = ({
               referenceDate={getArrivalReferenceDate(row, allRows, startTime)}
               prefillValue={row.computedArrival}
               onEnterKeyDown={() => focusCellBelow(info.row.index, 'requestedArrival')}
+              onTabKeyDown={(direction) =>
+                focusRequestedCellOnTab(info.row.index, 'requestedArrival', direction)
+              }
               onCommit={(date) => onArrival(row, date)}
             />
           );
         },
         meta: {
           className: 'col-requested-arrival',
+          tabbable: true,
         },
       }),
       columnHelper.accessor('computedArrival', {
@@ -223,6 +249,7 @@ const TimesStopsTable = ({
         header: () => t('stopTime'),
         cell: (info) => (
           <DurationCell
+            ref={registerTimeCellRef(info.row.index, 'stopDuration')}
             {...info}
             onChange={(e) =>
               info.table.options.meta!.onStopDurationChange(info.row.original, e.target.value)
@@ -231,6 +258,7 @@ const TimesStopsTable = ({
         ),
         meta: {
           className: 'col-stop-duration',
+          tabbable: true,
         },
       }),
       columnHelper.accessor('requestedDeparture', {
@@ -249,12 +277,16 @@ const TimesStopsTable = ({
               referenceDate={getDepartureReferenceDate(row, startTime)}
               prefillValue={row.computedDeparture}
               onEnterKeyDown={() => focusCellBelow(info.row.index, 'requestedDeparture')}
+              onTabKeyDown={(direction) =>
+                focusRequestedCellOnTab(info.row.index, 'requestedDeparture', direction)
+              }
               onCommit={(date) => info.table.options.meta!.onDepartureChange(row, date)}
             />
           );
         },
         meta: {
           className: 'col-requested-departure',
+          tabbable: true,
         },
       }),
       columnHelper.accessor('computedDeparture', {
@@ -332,7 +364,7 @@ const TimesStopsTable = ({
         },
       }),
     ],
-    [startTime, focusCellBelow]
+    [startTime, focusCellBelow, focusRequestedCellOnTab]
   );
 
   // eslint-disable-next-line react-hooks/incompatible-library
@@ -348,6 +380,24 @@ const TimesStopsTable = ({
       onDepartureChange,
     },
   });
+
+  const tabbableColumns = table
+    .getAllColumns()
+    .filter((column) => column.columnDef.meta?.tabbable)
+    .map((column) => column.id as TabbableCellColumnId);
+
+  const tabOrder = rows.flatMap((row, index) =>
+    tabbableColumns
+      .filter((columnId) => !(columnId === 'requestedDeparture' && row.opOnPathIndex === 0))
+      .map((columnId) => getTimeCellKey(index, columnId))
+  );
+
+  cellTabOrderRef.current = new Map(
+    tabOrder.map((key, i) => [
+      key,
+      { next: tabOrder[i + 1] ?? null, prev: tabOrder[i - 1] ?? null },
+    ])
+  );
 
   if (rows.length === 0) {
     return (


### PR DESCRIPTION
> [!NOTE]
This PR introduces the first part of the propagation menu feature.
It only covers the prerequisites for handling time cells (selection, navigation, and validation).
The propagation menu itself will be implemented in a follow-up PR.

close #15157 