### PR TITLE
editoast: update track occupancy endpoint part 2

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -6382,7 +6382,6 @@ components:
       - $ref: '#/components/schemas/EditoastTrainScheduleErrorExceptionNotFound'
       - $ref: '#/components/schemas/EditoastTrainScheduleErrorInfraNotFound'
       - $ref: '#/components/schemas/EditoastTrainScheduleErrorNotFound'
-      - $ref: '#/components/schemas/EditoastTrainScheduleErrorOperationalPointNotFound'
       - $ref: '#/components/schemas/EditoastTrainScheduleErrorPathfindingFailed'
       - $ref: '#/components/schemas/EditoastTrainScheduleErrorRollingStockNotFound'
       - $ref: '#/components/schemas/EditoastTrainScheduleErrorSimulationFailed'
@@ -8567,30 +8566,6 @@ components:
           type: string
           enum:
           - editoast:paced_train:NotFound
-    EditoastTrainScheduleErrorOperationalPointNotFound:
-      type: object
-      required:
-      - type
-      - status
-      - message
-      properties:
-        context:
-          type: object
-          required:
-          - reference
-          properties:
-            reference:
-              type: object
-        message:
-          type: string
-        status:
-          type: integer
-          enum:
-          - 404
-        type:
-          type: string
-          enum:
-          - editoast:paced_train:OperationalPointNotFound
     EditoastTrainScheduleErrorPathfindingFailed:
       type: object
       required:

--- a/editoast/src/views/path/operational_point_cache.rs
+++ b/editoast/src/views/path/operational_point_cache.rs
@@ -398,34 +398,6 @@ impl OperationalPointCache {
         };
         Ok(related_operational_points)
     }
-
-    /// Merge another cache into this one.
-    ///
-    /// Useful to add OPs that were not part of the original path items
-    /// (e.g. passage points loaded on demand from the database).
-    pub fn extend(&mut self, other: OperationalPointCache) {
-        let offset = self.ops.len();
-        self.ops.extend(other.ops);
-
-        for (id, idx) in other.obj_id_to_index {
-            self.obj_id_to_index.insert(id, idx + offset);
-        }
-        for (uic, indices) in other.uic_to_indices {
-            self.uic_to_indices
-                .entry(uic)
-                .or_default()
-                .extend(indices.into_iter().map(|i| i + offset));
-        }
-        for (trigram, indices) in other.trigram_to_indices {
-            self.trigram_to_indices
-                .entry(trigram)
-                .or_default()
-                .extend(indices.into_iter().map(|i| i + offset));
-        }
-        self.track_ids.extend(other.track_ids);
-        self.track_ids_to_local_track_name
-            .extend(other.track_ids_to_local_track_name);
-    }
 }
 
 /// Collect the ids of the operational points from the path items

--- a/editoast/src/views/path/operational_point_cache.rs
+++ b/editoast/src/views/path/operational_point_cache.rs
@@ -398,6 +398,34 @@ impl OperationalPointCache {
         };
         Ok(related_operational_points)
     }
+
+    /// Merge another cache into this one.
+    ///
+    /// Useful to add OPs that were not part of the original path items
+    /// (e.g. passage points loaded on demand from the database).
+    pub fn extend(&mut self, other: OperationalPointCache) {
+        let offset = self.ops.len();
+        self.ops.extend(other.ops);
+
+        for (id, idx) in other.obj_id_to_index {
+            self.obj_id_to_index.insert(id, idx + offset);
+        }
+        for (uic, indices) in other.uic_to_indices {
+            self.uic_to_indices
+                .entry(uic)
+                .or_default()
+                .extend(indices.into_iter().map(|i| i + offset));
+        }
+        for (trigram, indices) in other.trigram_to_indices {
+            self.trigram_to_indices
+                .entry(trigram)
+                .or_default()
+                .extend(indices.into_iter().map(|i| i + offset));
+        }
+        self.track_ids.extend(other.track_ids);
+        self.track_ids_to_local_track_name
+            .extend(other.track_ids_to_local_track_name);
+    }
 }
 
 /// Collect the ids of the operational points from the path items

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -865,23 +865,23 @@ pub(in crate::views) fn simulation_empty_response() -> core_client::simulation::
 
     core_client::simulation::Response::Success(SimulationSuccess {
         base: ReportTrain {
-            positions: vec![0, 1, 2, 3],
-            times: vec![0, 1, 2, 3],
+            positions: vec![0, 500_000, 15_050_000],
+            times: vec![0, 30_000, 100_000],
             speeds: vec![],
             energy_consumption: 0.0,
             path_item_times: vec![0, 1, 2, 3],
         },
         provisional: ReportTrain {
-            positions: vec![0, 1, 2, 3],
-            times: vec![0, 1, 2, 3],
+            positions: vec![0, 500_000, 15_050_000],
+            times: vec![0, 30_000, 100_000],
             speeds: vec![],
             energy_consumption: 0.0,
             path_item_times: vec![0, 1, 2, 3],
         },
         final_output: CompleteReportTrain {
             report_train: ReportTrain {
-                positions: vec![0, 1, 2, 3],
-                times: vec![0, 1, 2, 3],
+                positions: vec![0, 500_000, 15_050_000],
+                times: vec![0, 30_000, 100_000],
                 speeds: vec![],
                 energy_consumption: 0.0,
                 path_item_times: vec![0, 1, 2, 3],

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -2603,6 +2603,7 @@ mod tests {
         path: Vec<PathItem>,
         schedule: Vec<ScheduleItem>,
         operational_point_reference: OperationalPointReference,
+        use_simulation: bool,
     ) -> TestResponse {
         let mut core = MockingClient::new();
         core.stub("/pathfinding/blocks")
@@ -2639,7 +2640,7 @@ mod tests {
                 operational_point_reference,
                 infra_id: small_infra.id,
                 electrical_profile_set_id: None,
-                use_simulation: true,
+                use_simulation,
             });
 
         app.fetch(request).await
@@ -2669,6 +2670,7 @@ mod tests {
             OperationalPointReference::Id {
                 operational_point: "Mid_West_station".into(),
             },
+            true,
         );
         let track_occupancies: Vec<TrackSectionOccupancy> =
             response.await.assert_status(StatusCode::OK).json_into();
@@ -2697,6 +2699,7 @@ mod tests {
             OperationalPointReference::Id {
                 operational_point: "West_station".into(),
             },
+            true,
         );
         let track_occupancies: Vec<TrackSectionOccupancy> =
             response.await.assert_status(StatusCode::OK).json_into();
@@ -2767,9 +2770,151 @@ mod tests {
                 trigram: "UNKNOWN_TRIGRAM".into(),
                 secondary_code: None,
             },
+            true,
         );
         let track_occupancies: Vec<TrackSectionOccupancy> =
             response.await.assert_status(StatusCode::OK).json_into();
+        assert_eq!(track_occupancies.len(), 4);
+        assert!(
+            track_occupancies
+                .iter()
+                .all(|to| to.local_track_name == Some(NonBlankString("UNKNOWN_V".to_string())))
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn track_occupancy_no_sim_no_local_track_name_has_null_reference() {
+        let response = init_paced_train_test(
+            Vec::new(),
+            vec![
+                PathItem::new_operational_point("Mid_West_station"),
+                PathItem::new_operational_point("Mid_East_station"),
+            ],
+            vec![ScheduleItem::new_with_stop(
+                "Mid_East_station",
+                Duration::new(0, 0).expect("Failed to parse duration"),
+            )],
+            OperationalPointReference::Id {
+                operational_point: "Mid_West_station".into(),
+            },
+            false,
+        );
+        let track_occupancies: Vec<TrackSectionOccupancy> =
+            response.await.assert_status(StatusCode::OK).json_into();
+
+        assert_eq!(track_occupancies.len(), 1);
+        assert_eq!(track_occupancies[0].local_track_name, None);
+        assert_eq!(track_occupancies[0].trains.len(), 4);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn track_occupancy_no_sim_local_track_name_not_in_infra_returns_local_track_name() {
+        let path_item_with_unknown_track = PathItem {
+            id: "Mid_West_station".into(),
+            location: PathItemLocation::OperationalPointPartReference(
+                OperationalPointPartReference {
+                    operational_point: OperationalPointReference::Id {
+                        operational_point: "Mid_West_station".into(),
+                    },
+                    local_track_name: Some(NonBlankString("UNKNOWN_V".to_string())),
+                },
+            ),
+        };
+        let response = init_paced_train_test(
+            Vec::new(),
+            vec![
+                path_item_with_unknown_track,
+                PathItem::new_operational_point("Mid_East_station"),
+            ],
+            vec![ScheduleItem::new_with_stop(
+                "Mid_East_station",
+                Duration::new(0, 0).expect("Failed to parse duration"),
+            )],
+            OperationalPointReference::Id {
+                operational_point: "Mid_West_station".into(),
+            },
+            false,
+        );
+        let track_occupancies: Vec<TrackSectionOccupancy> =
+            response.await.assert_status(StatusCode::OK).json_into();
+
+        assert_eq!(track_occupancies.len(), 1);
+        assert_eq!(
+            track_occupancies[0].local_track_name,
+            Some(NonBlankString("UNKNOWN_V".to_string()))
+        );
+        assert_eq!(track_occupancies[0].trains.len(), 4);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn track_occupancy_no_sim_no_arrival_returns_empty() {
+        let response = init_paced_train_test(
+            Vec::new(),
+            vec![
+                PathItem::new_operational_point("Mid_West_station"),
+                PathItem::new_operational_point("Mid_East_station"),
+                PathItem::new_operational_point("North_station"),
+            ],
+            vec![
+                ScheduleItem::new_with_stop(
+                    "Mid_East_station",
+                    Duration::new(60, 0).expect("Failed to parse duration"),
+                ),
+                ScheduleItem::new_with_stop(
+                    "North_station",
+                    Duration::new(0, 0).expect("Failed to parse duration"),
+                ),
+            ],
+            OperationalPointReference::Id {
+                operational_point: "Mid_East_station".into(),
+            },
+            false,
+        );
+        let track_occupancies: Vec<TrackSectionOccupancy> =
+            response.await.assert_status(StatusCode::OK).json_into();
+
+        assert!(track_occupancies.is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn track_occupancy_no_sim_unknown_op_with_local_track_name_has_track_name() {
+        let response = init_paced_train_test(
+            Vec::new(),
+            vec![
+                new_op_with_trigram_and_local_track_name("Mid_West_station", "MWS", None, None),
+                new_op_with_trigram_and_local_track_name(
+                    "UNKNOWN_ID",
+                    "UNKNOWN_TRIGRAM",
+                    None,
+                    Some(NonBlankString("UNKNOWN_V".to_string())),
+                ),
+                new_op_with_trigram_and_local_track_name("Mid_East_station", "MES", None, None),
+            ],
+            vec![
+                ScheduleItem {
+                    at: "UNKNOWN_ID".into(),
+                    arrival: Some(PositiveDuration::new(
+                        Duration::new(300, 0).expect("Failed to parse duration"),
+                    )),
+                    stop_for: Some(PositiveDuration::new(
+                        Duration::new(120, 0).expect("Failed to parse duration"),
+                    )),
+                    reception_signal: ReceptionSignal::Open,
+                },
+                ScheduleItem::new_with_stop(
+                    "Mid_East_station",
+                    Duration::new(0, 0).expect("Failed to parse duration"),
+                ),
+            ],
+            OperationalPointReference::Trigram {
+                trigram: "UNKNOWN_TRIGRAM".into(),
+                secondary_code: None,
+            },
+            false,
+        );
+        let track_occupancies: Vec<TrackSectionOccupancy> =
+            response.await.assert_status(StatusCode::OK).json_into();
+
         assert_eq!(track_occupancies.len(), 4);
         assert!(
             track_occupancies

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -11,9 +11,11 @@ use axum::extract::State;
 use axum::response::IntoResponse;
 use chrono::Duration;
 use core_client::AsCoreRequest;
+use core_client::CoreClient;
 use core_client::pathfinding::PathfindingResultSuccess;
 use core_client::signal_projection::SignalUpdate;
 use core_client::simulation::PhysicsConsist;
+use database::DbConnection;
 use database::DbConnectionPoolV2;
 use editoast_derive::EditoastError;
 use editoast_models::prelude::*;
@@ -21,6 +23,7 @@ use editoast_models::round_trips::TrainScheduleRoundTrips;
 use itertools::Itertools;
 use itertools::izip;
 use reqwest::StatusCode;
+use schemas::infra::OperationalPoint;
 use schemas::paced_train::TrainSchedule;
 use schemas::primitives::NonBlankString;
 use schemas::primitives::TimeWindow;
@@ -1271,164 +1274,220 @@ pub(in crate::views) async fn track_occupancy(
         .flat_map(|train_schedule| train_schedule.iter_occurrences())
         .unzip();
 
+    let op_location =
+        PathItemLocation::OperationalPointPartReference(OperationalPointPartReference {
+            operational_point: operational_point_reference.clone(),
+            local_track_name: None,
+        });
+
     let path_items = trains
         .iter()
         .flat_map(|ts| &ts.path)
         .map(|p| &p.location)
+        .chain(std::iter::once(&op_location))
         .collect_vec();
 
-    let mut op_cache =
+    let op_cache =
         OperationalPointCache::load_path_items(db_pool.get().await?, infra_id, &path_items).await?;
 
-    // If the OP is not in the op_cache (e.g. a passage point not declared as a path item),
-    // load it from the DB and merge it into op_cache.
-    if op_cache
-        .get_reference(operational_point_reference.clone())?
-        .is_empty()
-    {
-        let op_location =
-            PathItemLocation::OperationalPointPartReference(OperationalPointPartReference {
-                operational_point: operational_point_reference.clone(),
-                local_track_name: None,
-            });
-        let current_op =
-            OperationalPointCache::load_path_items(db_pool.get().await?, infra_id, &[&op_location])
-                .await?;
-        op_cache.extend(current_op);
-    }
-
-    // Get the operational point (found either in path items or loaded from DB above)
     let operational_point = op_cache
         .get_reference(operational_point_reference.clone())?
-        .into_iter()
-        .next();
+        .pop();
 
-    let results = match operational_point {
+    let occupancies = match operational_point {
         Some(operational_point) => {
-            // Get track positions at the operational point
-            let operational_point_track_offsets = operational_point.track_offsets();
-
-            // For each occurrence + simulation result, compute track occupancies
-            let all_occupancies: Vec<_> = if use_simulation {
-                let simulations_result = train_simulation_batch(
+            if use_simulation {
+                let simulation_params = TrackOccupancySimulationParams {
                     conn,
                     valkey_client,
                     core_client,
-                    &trains,
-                    &infra,
+                    infra: &infra,
                     electrical_profile_set_id,
-                    config.app_version.as_deref(),
-                )
-                .await?;
-
-                izip!(train_ids, trains, simulations_result)
-                    .flat_map(|(train_id, train, (simulation, pathfinding))| {
-                        track_occupancy::find_track_occupancy_for_operational_point(
-                            &operational_point.id,
-                            &operational_point_track_offsets,
-                            &op_cache,
-                            &simulation,
-                            &pathfinding,
-                            &train,
-                        )
-                        .into_iter()
-                        .map(
-                            move |track_occupancy::TrackOccupancy {
-                                      local_track_name,
-                                      time_window,
-                                  }| {
-                                (
-                                    local_track_name,
-                                    TrackOccupancy {
-                                        train_id: train_id.clone(),
-                                        time_window,
-                                    },
-                                )
-                            },
-                        )
-                    })
-                    .collect()
-            } else {
-                izip!(train_ids, trains)
-                    .flat_map(|(train_id, train_schedule)| {
-                        track_occupancy::find_track_occupancy_for_operational_point_without_simulation(
-                            &operational_point.id,
-                            &operational_point_track_offsets,
-                            &op_cache,
-                            &train_schedule,
-                        )
-                        .into_iter()
-                        .map(move |track_occupancy::TrackOccupancy { local_track_name, time_window }| {
-                            (local_track_name, TrackOccupancy { train_id: train_id.clone(), time_window })
-                        })
-                    })
-                    .collect()
-            };
-
-            // Group occupancies by local_track_name
-            all_occupancies
-                .into_iter()
-                .into_group_map()
-                .into_iter()
-                .map(|(local_track_name, trains)| TrackSectionOccupancy {
-                    local_track_name,
+                    app_version: config.app_version.as_deref(),
+                };
+                find_track_occupancy_for_known_operational_point_with_simulation(
+                    train_ids,
                     trains,
-                })
-                .collect()
+                    &op_cache,
+                    operational_point,
+                    simulation_params,
+                )
+                .await?
+            } else {
+                find_track_occupancy_for_known_operational_point_without_simulation(
+                    train_ids,
+                    trains,
+                    &op_cache,
+                    operational_point,
+                )
+            }
         }
-        None => izip!(train_ids, trains)
-            .flat_map(|(train_id, train_schedule)| {
-                train_schedule
-                    .path
-                    .iter()
-                    .filter_map(|path_item| {
-                        find_track_occupancy_without_known_operational_point(
-                            path_item,
-                            &train_schedule,
-                            &train_id,
-                            &operational_point_reference,
-                        )
-                    })
-                    .collect_vec()
-            })
-            .collect(),
+        None => find_track_occupancy_unknown_operational_point(
+            train_ids,
+            trains,
+            &operational_point_reference,
+        ),
     };
+
+    let results = occupancies
+        .into_iter()
+        .into_group_map()
+        .into_iter()
+        .map(|(local_track_name, trains)| TrackSectionOccupancy {
+            local_track_name,
+            trains,
+        })
+        .collect();
 
     Ok(Json(results))
 }
 
-fn find_track_occupancy_without_known_operational_point(
-    path_item: &schemas::train_schedule::PathItem,
-    train_schedule: &schemas::TrainOccurrence,
-    train_id: &OccurrenceId,
+struct TrackOccupancySimulationParams<'a> {
+    conn: &'a mut DbConnection,
+    valkey_client: Arc<cache::Client>,
+    core_client: Arc<CoreClient>,
+    infra: &'a Infra,
+    electrical_profile_set_id: Option<i64>,
+    app_version: Option<&'a str>,
+}
+
+async fn find_track_occupancy_for_known_operational_point_with_simulation(
+    train_ids: Vec<OccurrenceId>,
+    train_occurrences: Vec<schemas::TrainOccurrence>,
+    op_cache: &OperationalPointCache,
+    operational_point: &OperationalPoint,
+    simulation_params: TrackOccupancySimulationParams<'_>,
+) -> Result<Vec<(Option<NonBlankString>, TrackOccupancy)>> {
+    let operational_point_track_offsets = operational_point.track_offsets();
+
+    let TrackOccupancySimulationParams {
+        conn,
+        valkey_client,
+        core_client,
+        infra,
+        electrical_profile_set_id,
+        app_version,
+    } = simulation_params;
+
+    let simulations_result = train_simulation_batch(
+        conn,
+        valkey_client,
+        core_client,
+        &train_occurrences,
+        infra,
+        electrical_profile_set_id,
+        app_version,
+    )
+    .await?;
+
+    Ok(izip!(train_ids, train_occurrences, simulations_result)
+        .flat_map(|(train_id, train, (simulation, pathfinding))| {
+            track_occupancy::find_track_occupancy_for_operational_point(
+                &operational_point.id,
+                &operational_point_track_offsets,
+                op_cache,
+                &simulation,
+                &pathfinding,
+                &train,
+            )
+            .into_iter()
+            .map(
+                move |track_occupancy::TrackOccupancy {
+                          local_track_name,
+                          time_window,
+                      }| {
+                    (
+                        local_track_name,
+                        TrackOccupancy {
+                            train_id: train_id.clone(),
+                            time_window,
+                        },
+                    )
+                },
+            )
+        })
+        .collect())
+}
+
+fn find_track_occupancy_for_known_operational_point_without_simulation(
+    train_ids: Vec<OccurrenceId>,
+    train_occurrences: Vec<schemas::TrainOccurrence>,
+    op_cache: &OperationalPointCache,
+    operational_point: &OperationalPoint,
+) -> Vec<(Option<NonBlankString>, TrackOccupancy)> {
+    let operational_point_track_offsets = operational_point.track_offsets();
+
+    izip!(train_ids, train_occurrences)
+        .flat_map(|(train_id, train_schedule)| {
+            track_occupancy::find_track_occupancy_for_operational_point_without_simulation(
+                &operational_point.id,
+                &operational_point_track_offsets,
+                op_cache,
+                &train_schedule,
+            )
+            .into_iter()
+            .map(
+                move |track_occupancy::TrackOccupancy {
+                          local_track_name,
+                          time_window,
+                      }| {
+                    (
+                        local_track_name,
+                        TrackOccupancy {
+                            train_id: train_id.clone(),
+                            time_window,
+                        },
+                    )
+                },
+            )
+        })
+        .collect()
+}
+
+fn find_track_occupancy_unknown_operational_point(
+    train_ids: Vec<OccurrenceId>,
+    trains: Vec<schemas::TrainOccurrence>,
     operational_point_reference: &OperationalPointReference,
-) -> Option<TrackSectionOccupancy> {
-    let PathItemLocation::OperationalPointPartReference(ref op_ref) = path_item.location else {
-        return None;
-    };
-    if op_ref.operational_point != *operational_point_reference {
-        return None;
-    }
-    let time_window = train_schedule
-        .schedule
-        .iter()
-        .find(|ts| ts.at == path_item.id)
-        .and_then(|ts| {
-            let duration = ts.stop_for.unwrap_or_default();
-            let arrival_time = ts.arrival?.num_milliseconds();
-            let time_begin = train_schedule.start_time + Duration::milliseconds(arrival_time);
-            Some(TimeWindow {
-                time_begin,
-                duration,
-            })
-        })?;
-    Some(TrackSectionOccupancy {
-        local_track_name: op_ref.local_track_name.clone(),
-        trains: vec![TrackOccupancy {
-            train_id: train_id.clone(),
-            time_window,
-        }],
-    })
+) -> Vec<(Option<NonBlankString>, TrackOccupancy)> {
+    izip!(train_ids, trains)
+        .flat_map(|(train_id, train_schedule)| {
+            train_schedule
+                .path
+                .iter()
+                .filter_map(|path_item| {
+                    let PathItemLocation::OperationalPointPartReference(ref op_ref) =
+                        path_item.location
+                    else {
+                        return None;
+                    };
+                    if op_ref.operational_point != *operational_point_reference {
+                        return None;
+                    }
+                    let time_window = train_schedule
+                        .schedule
+                        .iter()
+                        .find(|schedule_item| schedule_item.at == path_item.id)
+                        .and_then(|schedule_item| {
+                            let duration = schedule_item.stop_for.unwrap_or_default();
+                            let arrival_time = schedule_item.arrival?.num_milliseconds();
+                            let time_begin =
+                                train_schedule.start_time + Duration::milliseconds(arrival_time);
+                            Some(TimeWindow {
+                                time_begin,
+                                duration,
+                            })
+                        })?;
+                    Some((
+                        op_ref.local_track_name.clone(),
+                        TrackOccupancy {
+                            train_id: train_id.clone(),
+                            time_window,
+                        },
+                    ))
+                })
+                .collect_vec()
+        })
+        .collect()
 }
 
 #[cfg_attr(test, derive(serde::Serialize))]
@@ -1596,7 +1655,7 @@ mod tests {
     use crate::views::timetable::paced_train::TrackSectionOccupancy;
     use crate::views::timetable::paced_train::TrainScheduleResponse;
     use crate::views::timetable::paced_train::TrainScheduleSummaryResponse;
-    use crate::views::timetable::paced_train::find_track_occupancy_without_known_operational_point;
+    use crate::views::timetable::paced_train::find_track_occupancy_unknown_operational_point;
     use crate::views::timetable::simulation;
     use crate::views::timetable::simulation::SimulationResponseSuccess;
     use crate::views::timetable::simulation::SummaryResponse;
@@ -1992,23 +2051,23 @@ mod tests {
             response,
             simulation::Response::Success(SimulationResponseSuccess {
                 base: ReportTrain {
-                    positions: vec![0, 1, 2, 3],
-                    times: vec![0, 1, 2, 3],
+                    positions: vec![0, 500_000, 15_050_000],
+                    times: vec![0, 30_000, 100_000],
                     speeds: vec![],
                     energy_consumption: 0.0,
                     path_item_times: vec![0, 1, 2, 3]
                 },
                 provisional: ReportTrain {
-                    positions: vec![0, 1, 2, 3],
-                    times: vec![0, 1, 2, 3],
+                    positions: vec![0, 500_000, 15_050_000],
+                    times: vec![0, 30_000, 100_000],
                     speeds: vec![],
                     energy_consumption: 0.0,
                     path_item_times: vec![0, 1, 2, 3]
                 },
                 final_output: CompleteReportTrain {
                     report_train: ReportTrain {
-                        positions: vec![0, 1, 2, 3],
-                        times: vec![0, 1, 2, 3],
+                        positions: vec![0, 500_000, 15_050_000],
+                        times: vec![0, 30_000, 100_000],
                         speeds: vec![],
                         energy_consumption: 0.0,
                         path_item_times: vec![0, 1, 2, 3]
@@ -2171,7 +2230,7 @@ mod tests {
             *response.get(&paced_train_id).unwrap(),
             TrainScheduleSummaryResponse {
                 train_schedule: SummaryResponse::Success {
-                    length: 3,
+                    length: 15_050_000,
                     time: 3,
                     energy_consumption: 0.0,
                     path_item_times_final: vec![0, 1, 2, 3],
@@ -2185,7 +2244,7 @@ mod tests {
                     // Simulation of the exception is the same than base
                     // because all simulation results from core are identical stubs
                     SummaryResponse::Success {
-                        length: 3,
+                        length: 15_050_000,
                         time: 3,
                         energy_consumption: 0.0,
                         path_item_times_final: vec![0, 1, 2, 3],
@@ -2736,8 +2795,14 @@ mod tests {
         );
     }
 
+    #[rstest]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn track_occupancy_returns_unkown_op() {
+    #[case(true)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[case(false)]
+    async fn track_occupancy_unknown_op_returns_path_item_local_track_name(
+        #[case] use_simulation: bool,
+    ) {
         let response = init_paced_train_test(
             Vec::new(),
             vec![
@@ -2770,60 +2835,40 @@ mod tests {
                 trigram: "UNKNOWN_TRIGRAM".into(),
                 secondary_code: None,
             },
-            true,
+            use_simulation,
         );
         let track_occupancies: Vec<TrackSectionOccupancy> =
             response.await.assert_status(StatusCode::OK).json_into();
-        assert_eq!(track_occupancies.len(), 4);
-        assert!(
-            track_occupancies
-                .iter()
-                .all(|to| to.local_track_name == Some(NonBlankString("UNKNOWN_V".to_string())))
-        );
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn track_occupancy_no_sim_no_local_track_name_has_null_reference() {
-        let response = init_paced_train_test(
-            Vec::new(),
-            vec![
-                PathItem::new_operational_point("Mid_West_station"),
-                PathItem::new_operational_point("Mid_East_station"),
-            ],
-            vec![ScheduleItem::new_with_stop(
-                "Mid_East_station",
-                Duration::new(0, 0).expect("Failed to parse duration"),
-            )],
-            OperationalPointReference::Id {
-                operational_point: "Mid_West_station".into(),
-            },
-            false,
-        );
-        let track_occupancies: Vec<TrackSectionOccupancy> =
-            response.await.assert_status(StatusCode::OK).json_into();
-
         assert_eq!(track_occupancies.len(), 1);
-        assert_eq!(track_occupancies[0].local_track_name, None);
-        assert_eq!(track_occupancies[0].trains.len(), 4);
+        assert_eq!(
+            track_occupancies[0].local_track_name,
+            Some(NonBlankString("UNKNOWN_V".to_string()))
+        );
     }
 
+    #[rstest]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn track_occupancy_no_sim_local_track_name_not_in_infra_returns_local_track_name() {
-        let path_item_with_unknown_track = PathItem {
+    #[case(None)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[case(Some(NonBlankString("UNKNOWN_V".to_string())))]
+    async fn track_occupancy_no_sim_known_op_returns_local_track_name(
+        #[case] local_track_name: Option<NonBlankString>,
+    ) {
+        let first_path_item = PathItem {
             id: "Mid_West_station".into(),
             location: PathItemLocation::OperationalPointPartReference(
                 OperationalPointPartReference {
                     operational_point: OperationalPointReference::Id {
                         operational_point: "Mid_West_station".into(),
                     },
-                    local_track_name: Some(NonBlankString("UNKNOWN_V".to_string())),
+                    local_track_name: local_track_name.clone(),
                 },
             ),
         };
         let response = init_paced_train_test(
             Vec::new(),
             vec![
-                path_item_with_unknown_track,
+                first_path_item,
                 PathItem::new_operational_point("Mid_East_station"),
             ],
             vec![ScheduleItem::new_with_stop(
@@ -2839,10 +2884,7 @@ mod tests {
             response.await.assert_status(StatusCode::OK).json_into();
 
         assert_eq!(track_occupancies.len(), 1);
-        assert_eq!(
-            track_occupancies[0].local_track_name,
-            Some(NonBlankString("UNKNOWN_V".to_string()))
-        );
+        assert_eq!(track_occupancies[0].local_track_name, local_track_name);
         assert_eq!(track_occupancies[0].trains.len(), 4);
     }
 
@@ -2876,53 +2918,6 @@ mod tests {
         assert!(track_occupancies.is_empty());
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn track_occupancy_no_sim_unknown_op_with_local_track_name_has_track_name() {
-        let response = init_paced_train_test(
-            Vec::new(),
-            vec![
-                new_op_with_trigram_and_local_track_name("Mid_West_station", "MWS", None, None),
-                new_op_with_trigram_and_local_track_name(
-                    "UNKNOWN_ID",
-                    "UNKNOWN_TRIGRAM",
-                    None,
-                    Some(NonBlankString("UNKNOWN_V".to_string())),
-                ),
-                new_op_with_trigram_and_local_track_name("Mid_East_station", "MES", None, None),
-            ],
-            vec![
-                ScheduleItem {
-                    at: "UNKNOWN_ID".into(),
-                    arrival: Some(PositiveDuration::new(
-                        Duration::new(300, 0).expect("Failed to parse duration"),
-                    )),
-                    stop_for: Some(PositiveDuration::new(
-                        Duration::new(120, 0).expect("Failed to parse duration"),
-                    )),
-                    reception_signal: ReceptionSignal::Open,
-                },
-                ScheduleItem::new_with_stop(
-                    "Mid_East_station",
-                    Duration::new(0, 0).expect("Failed to parse duration"),
-                ),
-            ],
-            OperationalPointReference::Trigram {
-                trigram: "UNKNOWN_TRIGRAM".into(),
-                secondary_code: None,
-            },
-            false,
-        );
-        let track_occupancies: Vec<TrackSectionOccupancy> =
-            response.await.assert_status(StatusCode::OK).json_into();
-
-        assert_eq!(track_occupancies.len(), 4);
-        assert!(
-            track_occupancies
-                .iter()
-                .all(|to| to.local_track_name == Some(NonBlankString("UNKNOWN_V".to_string())))
-        );
-    }
-
     #[test]
     fn unknown_op_without_local_track_name_has_null_reference() {
         let op_ref = OperationalPointReference::Trigram {
@@ -2950,16 +2945,15 @@ mod tests {
         };
         let train_id = OccurrenceId::new_base(42, 0);
 
-        let result = find_track_occupancy_without_known_operational_point(
-            &path_item,
-            &train_schedule,
-            &train_id,
+        let mut result = find_track_occupancy_unknown_operational_point(
+            vec![train_id],
+            vec![train_schedule],
             &op_ref,
         );
 
-        let occupancy = result.expect("Failed to find track occupancy");
-        assert_eq!(occupancy.local_track_name, None);
-        assert_eq!(occupancy.trains.len(), 1);
+        assert_eq!(result.len(), 1);
+        let (local_track_name, _train_occupancy) = result.remove(0);
+        assert_eq!(local_track_name, None);
     }
 
     #[test]
@@ -2989,13 +2983,34 @@ mod tests {
         };
         let train_id = OccurrenceId::new_base(1, 0);
 
-        let result = find_track_occupancy_without_known_operational_point(
-            &path_item,
-            &train_schedule,
-            &train_id,
+        let result = find_track_occupancy_unknown_operational_point(
+            vec![train_id],
+            vec![train_schedule],
             &op_ref,
         );
 
-        assert!(result.is_none());
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn track_occupancy_op_in_db_but_not_in_path_items() {
+        let response = init_paced_train_test(
+            Vec::new(),
+            vec![
+                PathItem::new_operational_point("South_West_station"),
+                PathItem::new_operational_point("Mid_East_station"),
+            ],
+            vec![ScheduleItem::new_with_stop(
+                "Mid_East_station",
+                Duration::new(0, 0).expect("Failed to parse duration"),
+            )],
+            OperationalPointReference::Id {
+                operational_point: "Mid_West_station".into(),
+            },
+            true,
+        );
+        let track_occupancies: Vec<TrackSectionOccupancy> =
+            response.await.assert_status(StatusCode::OK).json_into();
+        assert!(!track_occupancies.is_empty());
     }
 }

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -1558,10 +1558,14 @@ mod tests {
     use schemas::paced_train::TrainNameChangeGroup;
     use schemas::paced_train::TrainSchedule;
     use schemas::primitives::NonBlankString;
+    use schemas::primitives::PositiveDuration;
     use schemas::rolling_stock::TrainCategory;
     use schemas::train_schedule::Comfort;
+    use schemas::train_schedule::OperationalPointPartReference;
     use schemas::train_schedule::OperationalPointReference;
     use schemas::train_schedule::PathItem;
+    use schemas::train_schedule::PathItemLocation;
+    use schemas::train_schedule::ReceptionSignal;
     use schemas::train_schedule::ScheduleItem;
     use schemas::train_schedule::TrainOccurrence;
     use serde_json::json;
@@ -1577,6 +1581,7 @@ mod tests {
     use crate::models::fixtures::simple_paced_train_base;
     use crate::models::fixtures::simple_paced_train_changeset;
     use crate::models::fixtures::simple_sub_category;
+    use crate::models::train_schedule::OccurrenceId;
     use crate::models::train_schedule::TrainScheduleChangeset;
     use crate::views::path::pathfinding::PathfindingFailure;
     use crate::views::path::pathfinding::PathfindingResult;
@@ -1591,10 +1596,31 @@ mod tests {
     use crate::views::timetable::paced_train::TrackSectionOccupancy;
     use crate::views::timetable::paced_train::TrainScheduleResponse;
     use crate::views::timetable::paced_train::TrainScheduleSummaryResponse;
+    use crate::views::timetable::paced_train::find_track_occupancy_without_known_operational_point;
     use crate::views::timetable::simulation;
     use crate::views::timetable::simulation::SimulationResponseSuccess;
     use crate::views::timetable::simulation::SummaryResponse;
     use crate::views::timetable::simulation_empty_response;
+
+    pub fn new_op_with_trigram_and_local_track_name(
+        id: &str,
+        trigram: &str,
+        secondary_code: Option<String>,
+        local_track_name: Option<NonBlankString>,
+    ) -> PathItem {
+        PathItem {
+            id: id.into(),
+            location: PathItemLocation::OperationalPointPartReference(
+                OperationalPointPartReference {
+                    operational_point: OperationalPointReference::Trigram {
+                        trigram: trigram.into(),
+                        secondary_code,
+                    },
+                    local_track_name,
+                },
+            ),
+        }
+    }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn train_schedule_post() {
@@ -2574,6 +2600,8 @@ mod tests {
 
     async fn init_paced_train_test(
         exceptions: Vec<PacedTrainException>,
+        path: Vec<PathItem>,
+        schedule: Vec<ScheduleItem>,
         operational_point_reference: OperationalPointReference,
     ) -> TestResponse {
         let mut core = MockingClient::new();
@@ -2595,14 +2623,8 @@ mod tests {
             .into_changeset()
             .train_schedule_set_id(train_schedule_set.id)
             .rolling_stock_name(rolling_stock.name)
-            .path(vec![
-                PathItem::new_operational_point("Mid_West_station"),
-                PathItem::new_operational_point("Mid_East_station"),
-            ])
-            .schedule(vec![ScheduleItem::new_with_stop(
-                "Mid_East_station",
-                Duration::new(0, 0).expect("Failed to parse duration"),
-            )])
+            .path(path)
+            .schedule(schedule)
             .interval(TimeDelta::try_minutes(15))
             .time_window(TimeDelta::try_hours(1))
             .exceptions(exceptions)
@@ -2636,6 +2658,14 @@ mod tests {
     ) {
         let response = init_paced_train_test(
             exceptions,
+            vec![
+                PathItem::new_operational_point("Mid_West_station"),
+                PathItem::new_operational_point("Mid_East_station"),
+            ],
+            vec![ScheduleItem::new_with_stop(
+                "Mid_East_station",
+                Duration::new(0, 0).expect("Failed to parse duration"),
+            )],
             OperationalPointReference::Id {
                 operational_point: "Mid_West_station".into(),
             },
@@ -2656,6 +2686,14 @@ mod tests {
     async fn paced_train_returns_empty_track_occupancies() {
         let response = init_paced_train_test(
             Vec::new(),
+            vec![
+                PathItem::new_operational_point("Mid_West_station"),
+                PathItem::new_operational_point("Mid_East_station"),
+            ],
+            vec![ScheduleItem::new_with_stop(
+                "Mid_East_station",
+                Duration::new(0, 0).expect("Failed to parse duration"),
+            )],
             OperationalPointReference::Id {
                 operational_point: "West_station".into(),
             },
@@ -2693,5 +2731,126 @@ mod tests {
             train_schedule.unwrap().train_schedule_set_id,
             train_schedule_set_to_move.id
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn track_occupancy_returns_unkown_op() {
+        let response = init_paced_train_test(
+            Vec::new(),
+            vec![
+                new_op_with_trigram_and_local_track_name("Mid_West_station", "MWS", None, None),
+                new_op_with_trigram_and_local_track_name(
+                    "UNKNOWN_ID",
+                    "UNKNOWN_TRIGRAM",
+                    None,
+                    Some(NonBlankString("UNKNOWN_V".to_string())),
+                ),
+                new_op_with_trigram_and_local_track_name("Mid_East_station", "MES", None, None),
+            ],
+            vec![
+                ScheduleItem {
+                    at: "UNKNOWN_ID".into(),
+                    arrival: Some(PositiveDuration::new(
+                        Duration::new(300, 0).expect("Failed to parse duration"),
+                    )),
+                    stop_for: Some(PositiveDuration::new(
+                        Duration::new(120, 0).expect("Failed to parse duration"),
+                    )),
+                    reception_signal: ReceptionSignal::Open,
+                },
+                ScheduleItem::new_with_stop(
+                    "Mid_East_station",
+                    Duration::new(0, 0).expect("Failed to parse duration"),
+                ),
+            ],
+            OperationalPointReference::Trigram {
+                trigram: "UNKNOWN_TRIGRAM".into(),
+                secondary_code: None,
+            },
+        );
+        let track_occupancies: Vec<TrackSectionOccupancy> =
+            response.await.assert_status(StatusCode::OK).json_into();
+        assert_eq!(track_occupancies.len(), 4);
+        assert!(
+            track_occupancies
+                .iter()
+                .all(|to| to.local_track_name == Some(NonBlankString("UNKNOWN_V".to_string())))
+        );
+    }
+
+    #[test]
+    fn unknown_op_without_local_track_name_has_null_reference() {
+        let op_ref = OperationalPointReference::Trigram {
+            trigram: "UNKNOWN".into(),
+            secondary_code: None,
+        };
+        let path_item = PathItem {
+            id: "item_1".into(),
+            location: PathItemLocation::OperationalPointPartReference(
+                OperationalPointPartReference {
+                    operational_point: op_ref.clone(),
+                    local_track_name: None,
+                },
+            ),
+        };
+        let train_schedule = schemas::TrainOccurrence {
+            path: vec![path_item.clone()],
+            schedule: vec![ScheduleItem {
+                at: "item_1".into(),
+                arrival: Some(PositiveDuration::try_from(Duration::seconds(100)).unwrap()),
+                stop_for: Some(PositiveDuration::try_from(Duration::seconds(60)).unwrap()),
+                reception_signal: ReceptionSignal::Open,
+            }],
+            ..Default::default()
+        };
+        let train_id = OccurrenceId::new_base(42, 0);
+
+        let result = find_track_occupancy_without_known_operational_point(
+            &path_item,
+            &train_schedule,
+            &train_id,
+            &op_ref,
+        );
+
+        let occupancy = result.expect("Failed to find track occupancy");
+        assert_eq!(occupancy.local_track_name, None);
+        assert_eq!(occupancy.trains.len(), 1);
+    }
+
+    #[test]
+    fn unknown_op_without_arrival_time_returns_none() {
+        let op_ref = OperationalPointReference::Trigram {
+            trigram: "UNKNOWN".into(),
+            secondary_code: None,
+        };
+        let path_item = PathItem {
+            id: "item_1".into(),
+            location: PathItemLocation::OperationalPointPartReference(
+                OperationalPointPartReference {
+                    operational_point: op_ref.clone(),
+                    local_track_name: None,
+                },
+            ),
+        };
+        let train_schedule = schemas::TrainOccurrence {
+            path: vec![path_item.clone()],
+            schedule: vec![ScheduleItem {
+                at: "item_1".into(),
+                arrival: None,
+                stop_for: None,
+                reception_signal: ReceptionSignal::Open,
+            }],
+            ..Default::default()
+        };
+        let train_id = OccurrenceId::new_base(1, 0);
+
+        let result = find_track_occupancy_without_known_operational_point(
+            &path_item,
+            &train_schedule,
+            &train_id,
+            &op_ref,
+        );
+
+        assert!(result.is_none());
     }
 }

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -9,6 +9,7 @@ use axum::extract::Path;
 use axum::extract::Query;
 use axum::extract::State;
 use axum::response::IntoResponse;
+use chrono::Duration;
 use core_client::AsCoreRequest;
 use core_client::pathfinding::PathfindingResultSuccess;
 use core_client::signal_projection::SignalUpdate;
@@ -81,11 +82,6 @@ enum TrainScheduleError {
     #[error("Exception '{exception_key}', could not be found")]
     #[editoast_error(status = 404)]
     ExceptionNotFound { exception_key: String },
-    #[error("Operational point '{reference}' could not be found")]
-    #[editoast_error(status = 404)]
-    OperationalPointNotFound {
-        reference: OperationalPointReference,
-    },
     #[error("Rolling stock '{rolling_stock_name}', could not be found")]
     #[editoast_error(status = 404)]
     RollingStockNotFound { rolling_stock_name: String },
@@ -1269,18 +1265,11 @@ pub(in crate::views) async fn track_occupancy(
         })
         .await?;
 
-    // Get the operational point
-    let operational_point =
-        get_operational_point(db_pool.clone(), infra_id, operational_point_reference).await?;
-
     // Collect all occurrences from all paced trains using iter_occurrences()
     let (train_ids, trains): (Vec<_>, Vec<_>) = train_schedules
         .iter()
         .flat_map(|train_schedule| train_schedule.iter_occurrences())
         .unzip();
-
-    // Get track positions at the operational point
-    let operational_point_track_offsets = operational_point.schema.track_offsets();
 
     let path_items = trains
         .iter()
@@ -1288,153 +1277,158 @@ pub(in crate::views) async fn track_occupancy(
         .map(|p| &p.location)
         .collect_vec();
 
-    let op_cache =
+    let mut op_cache =
         OperationalPointCache::load_path_items(db_pool.get().await?, infra_id, &path_items).await?;
 
-    // For each occurrence + simulation result, compute track occupancies
-    let all_occupancies = if use_simulation {
-        let simulations_result = train_simulation_batch(
-            conn,
-            valkey_client,
-            core_client,
-            &trains,
-            &infra,
-            electrical_profile_set_id,
-            config.app_version.as_deref(),
-        )
-        .await?;
+    // If the OP is not in the op_cache (e.g. a passage point not declared as a path item),
+    // load it from the DB and merge it into op_cache.
+    if op_cache
+        .get_reference(operational_point_reference.clone())?
+        .is_empty()
+    {
+        let op_location =
+            PathItemLocation::OperationalPointPartReference(OperationalPointPartReference {
+                operational_point: operational_point_reference.clone(),
+                local_track_name: None,
+            });
+        let current_op =
+            OperationalPointCache::load_path_items(db_pool.get().await?, infra_id, &[&op_location])
+                .await?;
+        op_cache.extend(current_op);
+    }
 
-        izip!(train_ids, trains, simulations_result)
-            .flat_map(|(train_id, train, (simulation, pathfinding))| {
-                track_occupancy::find_track_occupancy_for_operational_point(
-                    &operational_point.obj_id,
-                    &operational_point_track_offsets,
-                    &op_cache,
-                    &simulation,
-                    &pathfinding,
-                    &train,
+    // Get the operational point (found either in path items or loaded from DB above)
+    let operational_point = op_cache
+        .get_reference(operational_point_reference.clone())?
+        .into_iter()
+        .next();
+
+    let results = match operational_point {
+        Some(operational_point) => {
+            // Get track positions at the operational point
+            let operational_point_track_offsets = operational_point.track_offsets();
+
+            // For each occurrence + simulation result, compute track occupancies
+            let all_occupancies: Vec<_> = if use_simulation {
+                let simulations_result = train_simulation_batch(
+                    conn,
+                    valkey_client,
+                    core_client,
+                    &trains,
+                    &infra,
+                    electrical_profile_set_id,
+                    config.app_version.as_deref(),
                 )
-                .into_iter()
-                .map(
-                    |track_occupancy::TrackOccupancy {
-                         local_track_name,
-                         time_window,
-                     }| {
-                        (
-                            local_track_name,
-                            TrackOccupancy {
-                                train_id: train_id.clone(),
-                                time_window,
+                .await?;
+
+                izip!(train_ids, trains, simulations_result)
+                    .flat_map(|(train_id, train, (simulation, pathfinding))| {
+                        track_occupancy::find_track_occupancy_for_operational_point(
+                            &operational_point.id,
+                            &operational_point_track_offsets,
+                            &op_cache,
+                            &simulation,
+                            &pathfinding,
+                            &train,
+                        )
+                        .into_iter()
+                        .map(
+                            move |track_occupancy::TrackOccupancy {
+                                      local_track_name,
+                                      time_window,
+                                  }| {
+                                (
+                                    local_track_name,
+                                    TrackOccupancy {
+                                        train_id: train_id.clone(),
+                                        time_window,
+                                    },
+                                )
                             },
                         )
-                    },
-                )
-                .collect_vec()
-            })
-            .collect_vec()
-    } else {
-        izip!(train_ids, trains)
+                    })
+                    .collect()
+            } else {
+                izip!(train_ids, trains)
+                    .flat_map(|(train_id, train_schedule)| {
+                        track_occupancy::find_track_occupancy_for_operational_point_without_simulation(
+                            &operational_point.id,
+                            &operational_point_track_offsets,
+                            &op_cache,
+                            &train_schedule,
+                        )
+                        .into_iter()
+                        .map(move |track_occupancy::TrackOccupancy { local_track_name, time_window }| {
+                            (local_track_name, TrackOccupancy { train_id: train_id.clone(), time_window })
+                        })
+                    })
+                    .collect()
+            };
+
+            // Group occupancies by local_track_name
+            all_occupancies
+                .into_iter()
+                .into_group_map()
+                .into_iter()
+                .map(|(local_track_name, trains)| TrackSectionOccupancy {
+                    local_track_name,
+                    trains,
+                })
+                .collect()
+        }
+        None => izip!(train_ids, trains)
             .flat_map(|(train_id, train_schedule)| {
-                track_occupancy::find_track_occupancy_for_operational_point_without_simulation(
-                    &operational_point.obj_id,
-                    &operational_point_track_offsets,
-                    &op_cache,
-                    &train_schedule,
-                )
-                .into_iter()
-                .map(
-                    |track_occupancy::TrackOccupancy {
-                         local_track_name,
-                         time_window,
-                     }| {
-                        (
-                            local_track_name,
-                            TrackOccupancy {
-                                train_id: train_id.clone(),
-                                time_window,
-                            },
+                train_schedule
+                    .path
+                    .iter()
+                    .filter_map(|path_item| {
+                        find_track_occupancy_without_known_operational_point(
+                            path_item,
+                            &train_schedule,
+                            &train_id,
+                            &operational_point_reference,
                         )
-                    },
-                )
-                .collect_vec()
+                    })
+                    .collect_vec()
             })
-            .collect_vec()
+            .collect(),
     };
-
-    // Group occupancies by local_track_name
-    let results: Vec<TrackSectionOccupancy> = all_occupancies
-        .into_iter()
-        .into_group_map()
-        .into_iter()
-        .map(|(local_track_name, trains)| TrackSectionOccupancy {
-            local_track_name,
-            trains,
-        })
-        .collect();
 
     Ok(Json(results))
 }
 
-async fn get_operational_point(
-    db_pool: Arc<DbConnectionPoolV2>,
-    infra_id: i64,
-    operational_point_reference: OperationalPointReference,
-) -> Result<models::OperationalPointModel> {
-    match &operational_point_reference {
-        OperationalPointReference::Id { operational_point } => {
-            models::OperationalPointModel::retrieve_or_fail(
-                db_pool.get().await?,
-                (infra_id, operational_point.to_string()),
-                || {
-                    TrainScheduleError::OperationalPointNotFound {
-                        reference: operational_point_reference.clone(),
-                    }
-                    .into()
-                },
-            )
-            .await
-        }
-        OperationalPointReference::Trigram {
-            trigram,
-            secondary_code,
-        } => models::OperationalPointModel::retrieve_from_trigrams(
-            &mut db_pool.get().await?,
-            infra_id,
-            &[trigram.to_string()],
-        )
-        .await
-        .map_err(|e| TrainScheduleError::Database(e.into()))?
-        .into_iter()
-        .find(|op| {
-            op.schema.extensions.sncf.as_ref().map(|s| s.ch.as_str()) == secondary_code.as_deref()
-        })
-        .ok_or_else(|| {
-            TrainScheduleError::OperationalPointNotFound {
-                reference: operational_point_reference.clone(),
-            }
-            .into()
-        }),
-        OperationalPointReference::Uic {
-            uic,
-            secondary_code,
-        } => models::OperationalPointModel::retrieve_from_uic(
-            &mut db_pool.get().await?,
-            infra_id,
-            &[*uic],
-        )
-        .await
-        .map_err(|e| TrainScheduleError::Database(e.into()))?
-        .into_iter()
-        .find(|op| {
-            op.schema.extensions.sncf.as_ref().map(|s| s.ch.as_str()) == secondary_code.as_deref()
-        })
-        .ok_or_else(|| {
-            TrainScheduleError::OperationalPointNotFound {
-                reference: operational_point_reference.clone(),
-            }
-            .into()
-        }),
+fn find_track_occupancy_without_known_operational_point(
+    path_item: &schemas::train_schedule::PathItem,
+    train_schedule: &schemas::TrainOccurrence,
+    train_id: &OccurrenceId,
+    operational_point_reference: &OperationalPointReference,
+) -> Option<TrackSectionOccupancy> {
+    let PathItemLocation::OperationalPointPartReference(ref op_ref) = path_item.location else {
+        return None;
+    };
+    if op_ref.operational_point != *operational_point_reference {
+        return None;
     }
+    let time_window = train_schedule
+        .schedule
+        .iter()
+        .find(|ts| ts.at == path_item.id)
+        .and_then(|ts| {
+            let duration = ts.stop_for.unwrap_or_default();
+            let arrival_time = ts.arrival?.num_milliseconds();
+            let time_begin = train_schedule.start_time + Duration::milliseconds(arrival_time);
+            Some(TimeWindow {
+                time_begin,
+                duration,
+            })
+        })?;
+    Some(TrackSectionOccupancy {
+        local_track_name: op_ref.local_track_name.clone(),
+        trains: vec![TrackOccupancy {
+            train_id: train_id.clone(),
+            time_window,
+        }],
+    })
 }
 
 #[cfg_attr(test, derive(serde::Serialize))]

--- a/editoast/src/views/timetable/track_occupancy.rs
+++ b/editoast/src/views/timetable/track_occupancy.rs
@@ -227,22 +227,18 @@ fn find_track_occupancy_for_operational_point_with_context<'a>(
         .and_then(|item| item.stop_for)
         .unwrap_or_default();
 
-    if let Some(local_track_name) = get_local_track_name(
-        &context,
-        operational_point_track_offsets,
-        op_cache,
-        train_schedule,
-    ) {
-        return vec![TrackOccupancy {
-            local_track_name: Some(local_track_name),
-            time_window: TimeWindow {
-                time_begin: train_schedule.start_time + Duration::milliseconds(arrival_time),
-                duration: stop_duration,
-            },
-        }];
-    }
-
-    vec![]
+    vec![TrackOccupancy {
+        local_track_name: get_local_track_name(
+            &context,
+            operational_point_track_offsets,
+            op_cache,
+            train_schedule,
+        ),
+        time_window: TimeWindow {
+            time_begin: train_schedule.start_time + Duration::milliseconds(arrival_time),
+            duration: stop_duration,
+        },
+    }]
 }
 
 #[cfg(test)]
@@ -275,7 +271,7 @@ pub mod tests {
     #[case("op_2", 1000, 300000, true, true, true)]
     // Edge cases: missing simulation or pathfinding
     #[case("op_1", 0, 0, false, true, true)] // op_1 at index 0 works without simulation
-    #[case("op_1", 0, 0, false, false, false)] // No pathfinding fails (no local_track_name)
+    #[case("op_1", 0, 0, false, false, true)] // op_1 at index 0 works without pathfinding
     #[case("op_2", 1000, 300000, false, true, false)] // No simulation fails (no arrival_time)
     #[case("op_3", 5000, 200000, false, false, true)] // op_3 works without simulation/pathfinding (explicit arrival + local_track_name)
     fn test_find_track_occupancy_with_matching_path_item(

--- a/editoast/src/views/timetable/track_occupancy.rs
+++ b/editoast/src/views/timetable/track_occupancy.rs
@@ -247,6 +247,7 @@ pub mod tests {
     use crate::views::path::pathfinding::PathfindingFailure;
     use crate::views::timetable::simulation::SimulationResponseSuccess;
     use chrono::DateTime;
+    use chrono::Utc;
     use core_client::pathfinding::PathfindingNotFound;
     use core_client::pathfinding::TrackRange;
     use core_client::simulation::CompleteReportTrain;
@@ -263,8 +264,49 @@ pub mod tests {
     use schemas::train_schedule::ReceptionSignal;
     use std::collections::HashMap;
     use std::collections::HashSet;
+    use std::str::FromStr;
 
     use super::*;
+
+    fn make_simulation_success(path_item_times: Vec<u64>) -> simulation::Response {
+        let report_train = ReportTrain {
+            positions: vec![],
+            times: vec![],
+            speeds: vec![],
+            energy_consumption: 0.0,
+            path_item_times,
+        };
+        simulation::Response::Success(SimulationResponseSuccess {
+            base: report_train.clone(),
+            provisional: report_train.clone(),
+            final_output: CompleteReportTrain {
+                report_train,
+                ..Default::default()
+            },
+            mrsp: Default::default(),
+            electrical_profiles: Default::default(),
+        })
+    }
+
+    fn make_pathfinding_success(
+        track_section: Identifier,
+        path_item_positions: Vec<u64>,
+    ) -> PathfindingResult {
+        PathfindingResult::Success(PathfindingResultSuccess {
+            path: core_client::pathfinding::TrainPath {
+                blocks: vec![],
+                routes: vec![],
+                track_section_ranges: vec![TrackRange {
+                    track_section,
+                    begin: 0,
+                    end: 100,
+                    direction: Direction::StartToStop,
+                }],
+            },
+            length: 100,
+            path_item_positions,
+        })
+    }
 
     #[rstest]
     // Normal cases with both simulation and pathfinding
@@ -302,26 +344,10 @@ pub mod tests {
             ]),
         );
 
-        let track_range = TrackRange {
-            track_section: track_section.clone(),
-            begin: 0,
-            end: 150,
-            direction: Direction::StartToStop,
-        };
-        let track_ranges = vec![track_range];
-
         let operational_point_track_offsets = vec![TrackOffset {
             track: track_section.clone(),
             offset: track_offset,
         }];
-
-        let report_train = ReportTrain {
-            positions: vec![0, 50, 100, 150],
-            times: vec![0, expected_time, 2000, 5000],
-            speeds: vec![10.0; 4],
-            energy_consumption: 0.0,
-            path_item_times: vec![0, expected_time, 5000],
-        };
 
         // Create a train schedule with path items and schedule items
         let start_time = DateTime::from_timestamp(1000000000, 0).unwrap();
@@ -387,16 +413,7 @@ pub mod tests {
 
         // Call the function
         let simulation = if has_simulation {
-            simulation::Response::Success(SimulationResponseSuccess {
-                base: report_train.clone(),
-                provisional: report_train.clone(),
-                final_output: CompleteReportTrain {
-                    report_train,
-                    ..Default::default()
-                },
-                mrsp: Default::default(),
-                electrical_profiles: Default::default(),
-            })
+            make_simulation_success(vec![0, expected_time, 5000])
         } else {
             simulation::Response::SimulationFailed {
                 core_error: InternalError {
@@ -409,15 +426,7 @@ pub mod tests {
         };
 
         let pathfinding = if has_pathfinding {
-            PathfindingResult::Success(PathfindingResultSuccess {
-                path: core_client::pathfinding::TrainPath {
-                    blocks: vec![],
-                    routes: vec![],
-                    track_section_ranges: track_ranges,
-                },
-                length: 150,
-                path_item_positions,
-            })
+            make_pathfinding_success(track_section.clone(), path_item_positions)
         } else {
             PathfindingResult::Failure(PathfindingFailure::PathfindingNotFound(
                 PathfindingNotFound::NotFoundInBlocks {
@@ -501,6 +510,67 @@ pub mod tests {
         assert_eq!(
             find_matching_path_item_index(&path, op_id, &cache),
             expected_index
+        );
+    }
+
+    #[test]
+    fn test_schedule_arrival_used_when_simulation_does_not_honor_times() {
+        let start_time =
+            DateTime::<Utc>::from_str("2026-02-01T00:00:00Z").expect("Date should be valid");
+
+        let train_schedule = schemas::TrainOccurrence {
+            start_time,
+            path: vec![
+                PathItem::new_operational_point("op_1"),
+                PathItem::new_operational_point("op_2"),
+            ],
+            schedule: vec![ScheduleItem {
+                at: "op_2".into(),
+                arrival: Some(PositiveDuration::try_from(Duration::minutes(5)).unwrap()),
+                stop_for: Some(
+                    PositiveDuration::try_from(Duration::seconds(0))
+                        .expect("Failed to parse duration"),
+                ),
+                reception_signal: ReceptionSignal::Open,
+            }],
+            ..Default::default()
+        };
+
+        // simulation arrival_time: 10min, input arrival_time: 5min
+        let simulation = make_simulation_success(vec![0, 600_000]);
+        let pathfinding = make_pathfinding_success(Identifier::from("T2"), vec![0, 100]);
+
+        let op_cache = OperationalPointCache::new(
+            Vec::new(),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            HashSet::new(),
+            HashMap::from([("T2".into(), "V2".into())]),
+        );
+
+        let operational_point_track_offsets = vec![TrackOffset {
+            track: Identifier::from("T2"),
+            offset: 100,
+        }];
+
+        let results = find_track_occupancy_for_operational_point(
+            "op_2",
+            &operational_point_track_offsets,
+            &op_cache,
+            &simulation,
+            &pathfinding,
+            &train_schedule,
+        );
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(
+            results[0].local_track_name,
+            Some(NonBlankString("V2".to_string()))
+        );
+        assert_eq!(
+            results[0].time_window.time_begin,
+            start_time + Duration::minutes(5)
         );
     }
 }

--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -153,9 +153,8 @@
       "Database": "Internal error (database)",
       "ExceptionNotFound": "Exception '{{exception_key}}' could not be found",
       "InfraNotFound": "Infrastructure '{{infra_id}}' could not be found",
-      "NotFound": "Train schedule '{{train_schedule_id}}' could not be found",
-      "OperationalPointNotFound": "Operational point '{{reference}}' could not be found",
-      "PathfindingFailed": "Pathfinding failed for train schedule '{{train_schedule_id}}'",
+      "NotFound": "Paced train '{{train_schedule_id}}' could not be found",
+      "PathfindingFailed": "Pathfinding failed for paced train '{{train_schedule_id}}'",
       "RollingStockNotFound": "Rolling Stock '{{rolling_stock_name}}' could not be found",
       "SimulationFailed": "Simulation failed for train schedule '{{train_schedule_id}}'",
       "TrainScheduleSetNotFound": "Train schedule set '{{train_schedule_set_id}}' could not be found"

--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -153,7 +153,7 @@
       "Database": "Internal error (database)",
       "ExceptionNotFound": "Exception '{{exception_key}}' could not be found",
       "InfraNotFound": "Infrastructure '{{infra_id}}' could not be found",
-      "NotFound": "Paced train '{{train_schedule_id}}' could not be found",
+      "NotFound": "Train schedule '{{train_schedule_id}}' could not be found",
       "PathfindingFailed": "Pathfinding failed for paced train '{{train_schedule_id}}'",
       "RollingStockNotFound": "Rolling Stock '{{rolling_stock_name}}' could not be found",
       "SimulationFailed": "Simulation failed for train schedule '{{train_schedule_id}}'",

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -153,9 +153,8 @@
       "Database": "Erreur interne (base de données)",
       "ExceptionNotFound": "Exception '{{exception_key}}' non trouvée",
       "InfraNotFound": "Infrastructure '{{infra_id}}' non trouvée",
-      "NotFound": "Circulation '{{train_schedule_id}}' non trouvée",
-      "OperationalPointNotFound": "Point remarquable '{{reference}}' non trouvé",
-      "PathfindingFailed": "La recherche de chemin n'a pas abouti pour la circulation '{{train_schedule_id}}'",
+      "NotFound": "Mission '{{train_schedule_id}}' non trouvée",
+      "PathfindingFailed": "La recherche de chemin n'a pas abouti pour la mission '{{train_schedule_id}}'",
       "RollingStockNotFound": "Matériel roulant '{{rolling_stock_name}}' non trouvé",
       "SimulationFailed": "La simulation n'a pas abouti pour la circulation '{{train_schedule_id}}'",
       "TrainScheduleSetNotFound": "Paquet de train '{{train_schedule_set_id}}' non trouvé"

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -153,7 +153,7 @@
       "Database": "Erreur interne (base de données)",
       "ExceptionNotFound": "Exception '{{exception_key}}' non trouvée",
       "InfraNotFound": "Infrastructure '{{infra_id}}' non trouvée",
-      "NotFound": "Mission '{{train_schedule_id}}' non trouvée",
+      "NotFound": "La circulation '{{train_schedule_id}}' n’a pas été trouvée",
       "PathfindingFailed": "La recherche de chemin n'a pas abouti pour la mission '{{train_schedule_id}}'",
       "RollingStockNotFound": "Matériel roulant '{{rolling_stock_name}}' non trouvé",
       "SimulationFailed": "La simulation n'a pas abouti pour la circulation '{{train_schedule_id}}'",


### PR DESCRIPTION
Part of https://github.com/OpenRailAssociation/osrd/issues/15153

## What changed

### New behavior
- The `track_occupancy` endpoint no longer returns a 404 when the operational point is not found in the
infra
- When the OP is not found: falls back to `local_track_name` and schedule arrival from the train path,
returns one entry per occurrence
- When the OP is found: works as before, groups results by `local_track_name`


### Tests added
- Unit tests for the unknown OP path (no local track name, no arrival time)
- Unit tests for `use_simulation: false`
- Unit test for the fallback to schedule arrival when simulation time does not match