### PR TITLE
ui-core: fix combobox outside click

### DIFF
--- a/front/ui/ui-core/src/components/ComboBox/ComboBox.tsx
+++ b/front/ui/ui-core/src/components/ComboBox/ComboBox.tsx
@@ -167,7 +167,10 @@ const ComboBox = <T,>({
     focusInput();
   };
 
-  useOutsideClick(wrapperRef, closeSuggestions);
+  useOutsideClick(
+    showSuggestions ? wrapperRef : null, // Only trigger when the suggestions are displayed
+    closeSuggestions
+  );
 
   const inputIcons = useMemo(() => {
     if (inputProps.readOnly || inputProps.disabled) return undefined;

--- a/front/ui/ui-core/src/hooks/useOutsideClick.tsx
+++ b/front/ui/ui-core/src/hooks/useOutsideClick.tsx
@@ -1,16 +1,16 @@
-import { useEffect } from 'react';
+import { useEffect, useEffectEvent } from 'react';
 
 const useOutsideClick = (
-  ref: React.RefObject<HTMLElement | null>,
+  ref: React.RefObject<HTMLElement | null> | null,
   handler: (event: MouseEvent) => void
 ) => {
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (ref.current && !ref.current.contains(event.target as Node)) {
-        handler(event);
-      }
-    };
+  const handleClickOutside = useEffectEvent((event: MouseEvent) => {
+    if (ref?.current && !ref.current.contains(event.target as Node)) {
+      handler(event);
+    }
+  });
 
+  useEffect(() => {
     document.addEventListener('mousedown', handleClickOutside);
     return () => {
       document.removeEventListener('mousedown', handleClickOutside);


### PR DESCRIPTION
The outside click event of the combobox had no condition when to be fired resulting to call `closeSuggestions` on every click outside of the combobox even if the suggestions were not opened.

This PR :
- ensures that the listener starts only if the condition is met
- removes the listener as soon as the condition isn't met anymore to avoid keeping it listening for a lot of time for no reason.

> [!NOTE]
> Another way to avoid having to do part 2 would have been to move the suggestion list in its own component and call usOutsideClick inside. This way when the list is unmounted the listener would be removed without any other condition. 

fix #15547 