### PR TITLE
front: itinerary-modal - fix path step being clearing

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/PathStepItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/PathStepItem.tsx
@@ -235,11 +235,6 @@ const PathStepItem = ({
     return undefined;
   }, [inputValue, pathStepMetadata]);
 
-  const clearInputAndSuggestions = () => {
-    onOpInputChange('');
-    resetOpSuggestions();
-  };
-
   const maxVisibleSuggestions = 8;
   const visibleSuggestions = opSuggestions.slice(0, maxVisibleSuggestions);
   const hasMore = opSuggestions.length > maxVisibleSuggestions;
@@ -326,7 +321,7 @@ const PathStepItem = ({
               resetOpSuggestions();
               blurActiveElement();
             }}
-            resetSuggestions={clearInputAndSuggestions}
+            resetSuggestions={resetOpSuggestions}
             renderListElementComponent={({
               suggestion,
               index: suggestionIndex,


### PR DESCRIPTION
Resetting/closing the combobox suggestions should not clear the input as well.

This removes a part of the changes introduced in this [PR](https://github.com/OpenRailAssociation/osrd/pull/14876) but doesn't seem necessary ?

fix #15555 