### PR TITLE
 front: fix map kinetic panning

### DIFF
--- a/front/src/applications/editor/Map.tsx
+++ b/front/src/applications/editor/Map.tsx
@@ -1,7 +1,7 @@
 import { useContext, useMemo, useState, type PropsWithChildren } from 'react';
 
 import type { TFunction } from 'i18next';
-import { isEmpty, isEqual, isNil } from 'lodash';
+import { isEmpty, isNil } from 'lodash';
 import maplibregl from 'maplibre-gl';
 import { Protocol } from 'pmtiles';
 import { withTranslation } from 'react-i18next';
@@ -49,12 +49,6 @@ type MapProps<S extends CommonToolState = CommonToolState> = {
   infraID: number | undefined;
 };
 
-type MapState = {
-  isLoaded: boolean;
-  isDragging: boolean;
-  isHovering: boolean;
-};
-
 const protocol = new Protocol();
 maplibregl.addProtocol('pmtiles', protocol.tile);
 
@@ -72,11 +66,7 @@ const MapUnplugged = ({
   const dispatch = useAppDispatch();
   const { removeMapSearchMarker } = useMapSettingsActions();
   const mapBlankStyle = useMapBlankStyle();
-  const [mapState, setMapState] = useState<MapState>({
-    isLoaded: true,
-    isDragging: false,
-    isHovering: false,
-  });
+  const [isDraggingState, setIsDraggingState] = useState<boolean>(false);
   const context = useContext(EditorContext) as EditorContextType<CommonToolState>;
   const { data: switchTypes } = useSwitchTypes(infraID);
   const editorState = useSelector(getEditorState);
@@ -116,8 +106,9 @@ const MapUnplugged = ({
   );
 
   const cursor = useMemo(
-    () => (activeTool.getCursor ? activeTool.getCursor(extendedContext, mapState) : 'default'),
-    [activeTool, extendedContext, mapState]
+    () =>
+      activeTool.getCursor ? activeTool.getCursor(extendedContext, isDraggingState) : 'default',
+    [activeTool, extendedContext, isDraggingState]
   );
 
   return (
@@ -137,8 +128,8 @@ const MapUnplugged = ({
           style={{ width: '100%', height: '100%' }}
           mapStyle={mapBlankStyle}
           onMove={(e) => setViewport(e.viewState)}
-          onDragStart={() => setMapState((prev) => ({ ...prev, isDragging: true }))}
-          onDragEnd={() => setMapState((prev) => ({ ...prev, isDragging: false }))}
+          onDragStart={() => setIsDraggingState(true)}
+          onDragEnd={() => setIsDraggingState(false)}
           onMouseOut={() => {
             setToolState({ hovered: null });
           }}
@@ -155,12 +146,10 @@ const MapUnplugged = ({
             const partialToolState: Partial<CommonToolState> = {
               mousePosition: [e.lngLat.lng, e.lngLat.lat],
             };
-            const partialMapState: Partial<MapState> = { isHovering: false };
 
             // if we hover something
             if (nearestResult) {
               const { feature } = nearestResult;
-              partialMapState.isHovering = true;
               if (activeTool.onHover) {
                 activeTool.onHover(
                   {
@@ -214,14 +203,10 @@ const MapUnplugged = ({
             }
 
             if (!isEmpty(partialToolState)) setToolState(partialToolState);
-
-            const newMapState = { ...mapState, ...partialMapState };
-            if (!isEqual(mapState, newMapState)) setMapState(newMapState);
           }}
           onLoad={(e) => {
             // need to call resize, otherwise sometimes the canvas doesn't take 100%
             e.target.resize();
-            setMapState((prev) => ({ ...prev, isLoaded: false }));
           }}
           onResize={(e) => {
             setViewport({

--- a/front/src/applications/editor/Map.tsx
+++ b/front/src/applications/editor/Map.tsx
@@ -8,8 +8,8 @@ import { withTranslation } from 'react-i18next';
 import ReactMapGL, { AttributionControl, ScaleControl, type MapRef } from 'react-map-gl/maplibre';
 import { useSelector } from 'react-redux';
 
-import { LAYER_TO_EDITOAST_DICT, LAYERS_SET } from 'applications/editor/consts';
 import type { Layer } from 'applications/editor/consts';
+import { LAYER_TO_EDITOAST_DICT, LAYERS_SET } from 'applications/editor/consts';
 import EditorContext from 'applications/editor/context';
 import { getEntity } from 'applications/editor/data/api';
 import useSwitchTypes from 'applications/editor/tools/switchEdition/useSwitchTypes';
@@ -25,8 +25,8 @@ import {
   OSMLayers,
   Platforms,
   SearchMarker,
-  VirtualLayers,
   useMapBlankStyle,
+  VirtualLayers,
 } from 'common/Map/Layers';
 import LevelCrossingsLayer from 'common/Map/Layers/InfraObjectLayers/LevelCrossing';
 import { colors } from 'common/Map/theme';
@@ -137,10 +137,8 @@ const MapUnplugged = ({
           style={{ width: '100%', height: '100%' }}
           mapStyle={mapBlankStyle}
           onMove={(e) => setViewport(e.viewState)}
-          onMoveStart={() => setMapState((prev) => ({ ...prev, isDragging: true }))}
-          onMoveEnd={() => {
-            setMapState((prev) => ({ ...prev, isDragging: false }));
-          }}
+          onDragStart={() => setMapState((prev) => ({ ...prev, isDragging: true }))}
+          onDragEnd={() => setMapState((prev) => ({ ...prev, isDragging: false }))}
           onMouseOut={() => {
             setToolState({ hovered: null });
           }}

--- a/front/src/applications/editor/tools/pointEdition/tool-factory.tsx
+++ b/front/src/applications/editor/tools/pointEdition/tool-factory.tsx
@@ -22,7 +22,7 @@ import { NULL_GEOMETRY } from 'types';
 import { nearestPointOnLine } from 'utils/geometry';
 import { getNearestPoint } from 'utils/mapHelper';
 
-import { PointEditionMessages, PointEditionLeftPanel } from './components';
+import { PointEditionLeftPanel, PointEditionMessages } from './components';
 import { POINT_LAYER_ID } from './consts';
 import type { BufferStopEntity, DetectorEntity, PointEditionState, SignalEntity } from './types';
 
@@ -167,7 +167,7 @@ function getPointEditionTool<T extends EditorPoint>({
     ],
 
     // Interactions:
-    getCursor({ state }, { isDragging }) {
+    getCursor({ state }, isDragging) {
       if (isDragging || !state.entity.geometry || isEqual(state.entity.geometry, NULL_GEOMETRY))
         return 'grabbing';
       if (state.isHoveringTarget) return 'pointer';

--- a/front/src/applications/editor/tools/selection/tool.tsx
+++ b/front/src/applications/editor/tools/selection/tool.tsx
@@ -20,9 +20,9 @@ import { ConfirmModal } from 'common/BootstrapSNCF/ModalSNCF/ConfirmModal';
 import { save } from 'reducers/editor/thunkActions';
 import { selectInZone } from 'utils/mapHelper';
 
-import { SelectionLayers, SelectionMessages, SelectionLeftPanel } from './components';
-import type { SelectionState } from './types';
 import TOOL_NAMES from '../constsToolNames';
+import { SelectionLayers, SelectionLeftPanel, SelectionMessages } from './components';
+import type { SelectionState } from './types';
 import type { TrackSectionEntity } from '../trackEdition/types';
 
 const SelectionTool: Tool<SelectionState> = {
@@ -326,7 +326,7 @@ const SelectionTool: Tool<SelectionState> = {
   },
 
   // Layers:
-  getCursor({ state }, { isDragging }) {
+  getCursor({ state }, isDragging) {
     if (isDragging) return 'grabbing';
     if (state.selectionState.type === 'single' && state.hovered) return 'pointer';
     if (state.selectionState.type === 'rectangle' || state.selectionState.type === 'polygon')

--- a/front/src/applications/editor/tools/trackEdition/tool.tsx
+++ b/front/src/applications/editor/tools/trackEdition/tool.tsx
@@ -16,11 +16,11 @@ import { save } from 'reducers/editor/thunkActions';
 import { nearestPointOnLine, type NearestPointOnLine } from 'utils/geometry';
 import { getMapMouseEventNearestFeature } from 'utils/mapHelper';
 
+import TOOL_NAMES from '../constsToolNames';
 import { TrackEditionLayers, TrackEditionLeftPanel, TrackEditionMessages } from './components';
 import { POINTS_LAYER_ID, TRACK_LAYER_ID } from './consts';
 import type { TrackEditionState } from './types';
 import { getInitialState } from './utils';
-import TOOL_NAMES from '../constsToolNames';
 
 const TrackEditionTool: Tool<TrackEditionState> = {
   id: 'track-edition',
@@ -408,7 +408,7 @@ const TrackEditionTool: Tool<TrackEditionState> = {
     return ['editor/geo/track-main', POINTS_LAYER_ID, TRACK_LAYER_ID];
   },
 
-  getCursor({ state }, { isDragging }) {
+  getCursor({ state }, isDragging) {
     if (isDragging) return 'grabbing';
     if (state.editionState.type === 'addPoint') return 'copy';
     if (state.editionState.type === 'movePoint') {

--- a/front/src/applications/editor/tools/trackSplit/tool.tsx
+++ b/front/src/applications/editor/tools/trackSplit/tool.tsx
@@ -7,11 +7,11 @@ import type { Tool } from 'applications/editor/types';
 import { nearestPointOnLine } from 'utils/geometry';
 import { getMapMouseEventNearestFeature } from 'utils/mapHelper';
 
+import TOOL_NAMES from '../constsToolNames';
+import { approximateDistanceForEditoast, getNewLine } from '../utils';
 import { TrackSplitLayers, TrackSplitLeftPanel, TrackSplitMessages } from './components';
 import type { TrackSplitState } from './types';
 import { isOffsetValid } from './utils';
-import TOOL_NAMES from '../constsToolNames';
-import { approximateDistanceForEditoast, getNewLine } from '../utils';
 
 const TrackSplitTool: Tool<TrackSplitState> = {
   id: 'track-split',
@@ -147,7 +147,7 @@ const TrackSplitTool: Tool<TrackSplitState> = {
       }
     }
   },
-  getCursor({ state }, { isDragging }) {
+  getCursor({ state }, isDragging) {
     if (isDragging) return 'grabbing';
     if (state.splitState.type === 'movePoint') return 'grabbing';
     if (state.splitState.type === 'hoverPoint') return 'pointer';

--- a/front/src/applications/editor/types.ts
+++ b/front/src/applications/editor/types.ts
@@ -114,10 +114,7 @@ export type Tool<S> = {
   onHover?: (e: MapLayerMouseEvent, context: ExtendedEditorContextType<S>) => void;
   onMove?: (e: MapLayerMouseEvent, context: ExtendedEditorContextType<S>) => void;
   onKeyDown?: (e: KeyboardEvent, context: ExtendedEditorContextType<S>) => void;
-  getCursor?: (
-    context: ExtendedEditorContextType<S>,
-    mapState: { isLoaded: boolean; isDragging: boolean; isHovering: boolean }
-  ) => string;
+  getCursor?: (context: ExtendedEditorContextType<S>, isDragging: boolean) => string;
 
   // Display:
   getInteractiveLayers?: (context: ReadOnlyEditorContextType<S>) => string[];

--- a/front/src/applications/referenceMap/Map.tsx
+++ b/front/src/applications/referenceMap/Map.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useRef } from 'react';
 
+import type { MapLibreEvent } from 'maplibre-gl';
 import type { MapRef } from 'react-map-gl/maplibre';
 
 import BaseMap from 'common/Map/BaseMap';
@@ -8,7 +9,7 @@ import { MapContextProvider } from 'common/Map/useMapContext';
 import { useInfraID } from 'common/osrdContext';
 import { useMapSettings, useMapSettingsActions } from 'reducers/commonMap';
 import type { MapSettings, Viewport } from 'reducers/commonMap/types';
-import { updateReferenceMapViewport } from 'reducers/referenceMap';
+import { syncReferenceMapRouterViewport, updateReferenceMapViewport } from 'reducers/referenceMap';
 import { useAppDispatch } from 'store';
 
 const REFERENCE_MAP_ID = 'reference-map';
@@ -32,10 +33,17 @@ const Map = () => {
   );
 
   const updateViewportChange = useCallback(
-    (value: Partial<Viewport>, { updateRouter } = { updateRouter: false }) => {
-      dispatch(updateReferenceMapViewport(value, updateRouter));
+    (value: Partial<Viewport>) => {
+      dispatch(updateReferenceMapViewport(value));
     },
-    []
+    [dispatch]
+  );
+
+  const updateMapRouterViewportChange = useCallback(
+    (value: MapLibreEvent) => {
+      dispatch(syncReferenceMapRouterViewport(value));
+    },
+    [dispatch]
   );
 
   const resetPitchBearing = () => {
@@ -75,6 +83,7 @@ const Map = () => {
           onClick={() => {
             dispatch(removeMapSearchMarker());
           }}
+          onIdleRouterSync={updateMapRouterViewportChange}
           updatePartialViewPort={updateViewportChange}
         />
       </MapContextProvider>

--- a/front/src/common/Map/BaseMap.tsx
+++ b/front/src/common/Map/BaseMap.tsx
@@ -2,8 +2,8 @@ import { type MutableRefObject, type PropsWithChildren, useEffect, useState } fr
 
 import type { Geometry } from 'geojson';
 import type { MapLayerMouseEvent, MapLibreEvent } from 'maplibre-gl';
-import ReactMapGL, { AttributionControl, ScaleControl } from 'react-map-gl/maplibre';
 import type { MapRef } from 'react-map-gl/maplibre';
+import ReactMapGL, { AttributionControl, ScaleControl } from 'react-map-gl/maplibre';
 import { useParams } from 'react-router-dom';
 
 import {
@@ -12,8 +12,8 @@ import {
   LineSearchLayer,
   OSMLayers,
   SearchMarker,
-  VirtualLayers,
   useMapBlankStyle,
+  VirtualLayers,
 } from 'common/Map/Layers';
 import { colors } from 'common/Map/theme';
 import { LAYER_GROUPS_ORDER, LAYERS } from 'config/layerOrder';
@@ -27,10 +27,7 @@ type MapProps = {
   mapRef: MutableRefObject<MapRef | null>;
   interactiveLayerIds: string[];
   infraId?: number;
-  updatePartialViewPort: (
-    newPartialViewPort: Partial<Viewport>,
-    options?: { updateRouter: boolean }
-  ) => void;
+  updatePartialViewPort: (newPartialViewPort: Partial<Viewport>) => void;
   cursor?: 'default' | 'pointer' | 'normal';
   hideAttribution?: boolean;
   hoveredOperationalPointId?: string;
@@ -38,6 +35,7 @@ type MapProps = {
   onMouseEnter?: (e: MapLayerMouseEvent) => void;
   onMouseMove?: (e: MapLayerMouseEvent) => void;
   onIdle?: (e: MapLibreEvent) => void;
+  onIdleRouterSync?: (e: MapLibreEvent) => void;
   /**
    * If an area is provided, then the map style is focus on it :
    * - filtering all data layouts on this area
@@ -61,6 +59,7 @@ const BaseMap = ({
   onMouseEnter,
   onMouseMove,
   onIdle,
+  onIdleRouterSync,
   highlightedArea,
 }: PropsWithChildren<MapProps>) => {
   const mapBlankStyle = useMapBlankStyle();
@@ -110,12 +109,14 @@ const BaseMap = ({
       onMouseEnter={onMouseEnter}
       onMouseMove={onMouseMove}
       onClick={onClick}
-      onIdle={onIdle}
+      onIdle={(e) => {
+        onIdle?.(e);
+        onIdleRouterSync?.(e);
+      }}
       // default behavior
       onMove={(e) => {
         updatePartialViewPort(e.viewState);
       }}
-      onMoveEnd={(e) => updatePartialViewPort(e.viewState, { updateRouter: true })}
       onResize={(e) => {
         updatePartialViewPort({
           width: e.target.getContainer().offsetWidth,

--- a/front/src/reducers/referenceMap/index.ts
+++ b/front/src/reducers/referenceMap/index.ts
@@ -1,4 +1,5 @@
 import { createSlice, type Dispatch } from '@reduxjs/toolkit';
+import type { MapLibreEvent } from 'maplibre-gl';
 
 import history from 'main/history';
 import { defaultMapSettings, buildMapStateReducer } from 'reducers/commonMap';
@@ -25,20 +26,20 @@ export const referenceMapSlice = createSlice({
   },
 });
 
-export function updateReferenceMapViewport(viewport: Partial<Viewport>, updateRouter = false) {
-  return (dispatch: Dispatch, getState: () => { referenceMap: ReferenceMapState }) => {
+export function updateReferenceMapViewport(viewport: Partial<Viewport>) {
+  return (dispatch: Dispatch) => {
     dispatch(referenceMapSlice.actions.updateViewport(viewport));
+  };
+}
 
-    if (!updateRouter) return;
-
-    const {
-      referenceMap: { mapSettings },
-    } = getState();
-    const latitude = gpsRound(viewport.latitude || mapSettings.viewport.latitude);
-    const longitude = gpsRound(viewport.longitude || mapSettings.viewport.longitude);
-    const zoom = gpsRound(viewport.zoom || mapSettings.viewport.zoom);
-    const bearing = gpsRound(viewport.bearing || mapSettings.viewport.bearing);
-    const pitch = gpsRound(viewport.pitch || mapSettings.viewport.pitch);
+export function syncReferenceMapRouterViewport(event: MapLibreEvent) {
+  return (_dispatch: Dispatch) => {
+    const center = event.target.getCenter();
+    const latitude = gpsRound(center.lat);
+    const longitude = gpsRound(center.lng);
+    const zoom = gpsRound(event.target.getZoom());
+    const bearing = gpsRound(event.target.getBearing());
+    const pitch = gpsRound(event.target.getPitch());
 
     history.push(`/map/${latitude}/${longitude}/${zoom}/${bearing}/${pitch}`);
   };


### PR DESCRIPTION
fix #13313

Review commits individually

> [!NOTE]
> This is an alternative of https://github.com/OpenRailAssociation/osrd/pull/13775 

When grabbing the map while kinetic panning, the map freezes. This was due to an updateViewportChange onMoveEnd.

Here I'm splitting the viewport change and router update. I'm updating the router only onIdle which makes sense from a user point of view.

> [!WARNING]
> I still have the issue with the editor map. Otherwise, all maps are fixed. 
> Fixing it on the editor map is quite difficult and is done in a follow-up PR: https://github.com/OpenRailAssociation/osrd/pull/15594

![2026-03-0419-06-38-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/f244bec5-dd02-4bf7-9091-ab01badd85f2)
