### PR TITLE
front: add D+N day change banner in TimesStopsTable

### DIFF
--- a/front/src/modules/timesStops/TimesStopsTable.tsx
+++ b/front/src/modules/timesStops/TimesStopsTable.tsx
@@ -1,18 +1,21 @@
-import { useCallback, useMemo, useRef } from 'react';
+import { useCallback, Fragment, useMemo, useRef } from 'react';
 
 import { Checkbox } from '@osrd-project/ui-core';
+import { Moon } from '@osrd-project/ui-icons';
 import {
   createColumnHelper,
   flexRender,
   getCoreRowModel,
   useReactTable,
+  type Row,
   type RowData,
 } from '@tanstack/react-table';
 import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
 
 import type { ReceptionSignal } from 'common/api/osrdEditoastApi';
-import { formatLocalTime } from 'utils/date';
+import { formatLocalTime, useDateTimeLocale } from 'utils/date';
+import { calculateTimeDifferenceInDays } from 'utils/timeManipulation';
 
 import DurationCell, { type DurationCellHandle } from './DurationCell';
 import { onStopSignalToReceptionSignal } from './helpers/utils';
@@ -103,6 +106,7 @@ const TimesStopsTable = ({
   onReceptionSignalChange,
 }: TimesStopsTableProps) => {
   const { t } = useTranslation('translation', { keyPrefix: 'timeStopTable' });
+  const dateTimeLocale = useDateTimeLocale();
   const scheduleNotHonored = rows.some((row) => row.stepStatus === 'scheduleNotHonored');
   const cellHandlesRef = useRef<Map<string, TabbableCellHandle>>(new Map());
   const cellTabOrderRef = useRef<Map<string, TimeCellTabEntry>>(new Map());
@@ -447,6 +451,12 @@ const TimesStopsTable = ({
     ])
   );
 
+  const getRowDayOffset = (row: Row<TimesStopsRowNew>) =>
+    calculateTimeDifferenceInDays(
+      startTime,
+      row.original.computedArrival ?? row.original.requestedArrival ?? undefined
+    ) ?? 0;
+
   if (rows.length === 0) {
     return (
       <div className="d-flex justify-content-center align-items-center h-100">
@@ -482,20 +492,44 @@ const TimesStopsTable = ({
             invalid: !isValid || scheduleNotHonored,
           })}
         >
-          {table.getRowModel().rows.map((row) => (
-            <tr
-              key={row.id}
-              className={cx({
-                'invalid-path-step': row.original.stepStatus === 'invalidPathStep',
-              })}
-            >
-              {row.getVisibleCells().map((cell) => (
-                <td key={cell.id} className={cell.column.columnDef.meta?.className}>
-                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                </td>
-              ))}
-            </tr>
-          ))}
+          {table.getRowModel().rows.map((row, rowIndex) => {
+            const prevRow = rowIndex > 0 ? table.getRowModel().rows[rowIndex - 1] : null;
+            const rowArrivalDate = row.original.computedArrival ?? row.original.requestedArrival;
+            const dayOffset = getRowDayOffset(row);
+            const prevDayOffset = prevRow ? getRowDayOffset(prevRow) : 0;
+
+            return (
+              <Fragment key={row.id}>
+                {dayOffset > prevDayOffset && (
+                  <tr className="day-change-banner">
+                    <td colSpan={row.getVisibleCells().length}>
+                      <div className="day-change-banner-content">
+                        <Moon />
+                        <span>
+                          {rowArrivalDate?.toLocaleDateString(dateTimeLocale, {
+                            day: 'numeric',
+                            month: 'long',
+                            year: 'numeric',
+                          })}
+                        </span>
+                      </div>
+                    </td>
+                  </tr>
+                )}
+                <tr
+                  className={cx({
+                    'invalid-path-step': row.original.stepStatus === 'invalidPathStep',
+                  })}
+                >
+                  {row.getVisibleCells().map((cell) => (
+                    <td key={cell.id} className={cell.column.columnDef.meta?.className}>
+                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </td>
+                  ))}
+                </tr>
+              </Fragment>
+            );
+          })}
         </tbody>
       </table>
     </div>

--- a/front/src/modules/timesStops/styles/_timesStopsTable.scss
+++ b/front/src/modules/timesStops/styles/_timesStopsTable.scss
@@ -46,6 +46,38 @@
           background: var(--grey10);
         }
 
+        &.day-change-banner {
+          height: 41px;
+
+          td {
+            padding-inline-start: 50px;
+            vertical-align: middle;
+            background: color-mix(in srgb, var(--info60) 20%, transparent);
+            box-shadow: inset 0 1px 0 var(--white75);
+
+            .day-change-banner-content {
+              display: flex;
+              align-items: center;
+              color: var(--info60);
+
+              > span:first-child {
+                display: flex;
+                align-items: center;
+              }
+
+              span:last-child {
+                font-size: 0.875rem;
+                font-weight: 400;
+                line-height: 20px;
+              }
+
+              svg {
+                margin-right: 12px;
+              }
+            }
+          }
+        }
+
         &:hover {
           background: var(--white50);
         }


### PR DESCRIPTION
Closes #15147 

Display a banner row between consecutive stops when the train crosses midnight. The banner shows J+N where N is the calendar day offset from departure.