### PR TITLE
editoast: train schedule exceptions make occurrence_index non null

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -14516,9 +14516,7 @@ components:
           - string
           - 'null'
         occurrence_index:
-          type:
-          - integer
-          - 'null'
+          type: integer
           format: int64
           description: If None the exception is created, otherwise it is a modified exception
         timetable_id:

--- a/editoast/schemas/src/train_schedule_exception.rs
+++ b/editoast/schemas/src/train_schedule_exception.rs
@@ -15,6 +15,7 @@ use crate::paced_train::SpeedLimitTagChangeGroup;
 use crate::paced_train::StartTimeChangeGroup;
 use crate::paced_train::TrainNameChangeGroup;
 
+#[skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
 pub struct TrainScheduleException {
     pub id: i64,
@@ -22,6 +23,7 @@ pub struct TrainScheduleException {
     pub timetable_id: i64,
     pub train_schedule_id: i64,
     /// If None the exception is created, otherwise it is a modified exception
+    #[schema(nullable = false)]
     pub occurrence_index: Option<i64>,
     pub disabled: bool,
     pub change_groups: TrainScheduleExceptionChangeGroups,

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -4928,7 +4928,7 @@ export type TrainScheduleException = {
   id: number;
   key?: string | null;
   /** If None the exception is created, otherwise it is a modified exception */
-  occurrence_index?: number | null;
+  occurrence_index?: number;
   timetable_id: number;
   train_schedule_id: number;
 };


### PR DESCRIPTION
This PR make occurrence_index non null like the old exception type