### PR TITLE
Edit consist form to allow consist change

### DIFF
--- a/front/public/locales/en/stdcm.json
+++ b/front/public/locales/en/stdcm.json
@@ -246,6 +246,8 @@
       "totalLength": "the total length of the consist",
       "totalMass": "the total mass of the consist",
       "tractionEngine": "the traction engine",
+      "viaConsistTotalLength": "the total length of a consist change",
+      "viaConsistTotalMass": "the total mass of a consist change",
       "vias": "At least one intermediate OP"
     },
     "missingInformations": "Missing informations for calculation:",
@@ -269,7 +271,8 @@
     "ch": "CH",
     "ci": "CI",
     "consistChange": {
-      "add": "Edit consist"
+      "add": "Edit consist",
+      "fixErrorsFirst": "Fix errors before editing consist"
     },
     "date": "Date",
     "destination": "Destination",

--- a/front/public/locales/fr/stdcm.json
+++ b/front/public/locales/fr/stdcm.json
@@ -246,6 +246,8 @@
       "totalLength": "la longueur totale du convoi",
       "totalMass": "le poids total du convoi",
       "tractionEngine": "l'engin de traction",
+      "viaConsistTotalLength": "la longueur totale d'un changement convoi",
+      "viaConsistTotalMass": "le poids total d'un changement de convoi",
       "vias": "au moins un PR intermédiaire"
     },
     "missingInformations": "Informations manquantes pour le calcul :",
@@ -269,7 +271,8 @@
     "ch": "CH",
     "ci": "CI",
     "consistChange": {
-      "add": "Modifier le convoi"
+      "add": "Modifier le convoi",
+      "fixErrorsFirst": "Corrigez les erreurs avant de modifier le convoi"
     },
     "date": "Date",
     "destination": "Destination",

--- a/front/src/applications/stdcm/components/StdcmForm/StdcmConfig.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmConfig.tsx
@@ -137,6 +137,7 @@ const StdcmConfig = ({
     towedRollingStockID,
     totalMass,
     totalLength,
+    maxSpeed,
   };
 
   const { updateRollingStockID, updateSpeedLimitByTag } = useOsrdConfActions();
@@ -366,6 +367,7 @@ const StdcmConfig = ({
             skipAnimation={skipPathfindingStatusMessage}
             onItineraryChange={onItineraryChange}
             initialConsist={initialConsist}
+            initialConsistErrors={initialConsistErrors}
             onHasViaConsistErrorsChange={setViaConsistErrors}
           />
           <StdcmDestination disabled={disabled} onItineraryChange={onItineraryChange} />

--- a/front/src/applications/stdcm/components/StdcmForm/StdcmConfig.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmConfig.tsx
@@ -9,19 +9,14 @@ import { useSelector } from 'react-redux';
 import { extractMarkersInfo } from 'applications/stdcm/utils';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import DefaultBaseMap from 'common/Map/DefaultBaseMap';
-import { useOsrdConfActions } from 'common/osrdContext';
 import useWorkerStatus from 'modules/pathfinding/hooks/useWorkerStatus';
 import { useMapSettings, useMapSettingsActions } from 'reducers/commonMap';
 import type { MapSettings, Viewport } from 'reducers/commonMap/types';
 import {
   resetMargins,
   restoreStdcmConfig,
+  updateInitialConsist,
   updateStdcmPathStep,
-  updateTotalMass,
-  updateTotalLength,
-  updateMaxSpeed,
-  updateLoadingGauge,
-  updateTowedRollingStockID,
 } from 'reducers/osrdconf/stdcmConf';
 import {
   getOperationalPoints,
@@ -140,17 +135,9 @@ const StdcmConfig = ({
     maxSpeed,
   };
 
-  const { updateRollingStockID, updateSpeedLimitByTag } = useOsrdConfActions();
-
-  const onConsistChange = useCallback(
+  const onInitialConsistChange = useCallback(
     (newConsist: ConsistData) => {
-      dispatch(updateRollingStockID(newConsist.rollingStockID));
-      dispatch(updateTowedRollingStockID(newConsist.towedRollingStockID));
-      dispatch(updateTotalMass(newConsist.totalMass));
-      dispatch(updateTotalLength(newConsist.totalLength));
-      dispatch(updateMaxSpeed(newConsist.maxSpeed));
-      dispatch(updateLoadingGauge(newConsist.loadingGauge));
-      dispatch(updateSpeedLimitByTag(newConsist.speedLimitByTag));
+      dispatch(updateInitialConsist(newConsist));
     },
     [dispatch]
   );
@@ -357,7 +344,7 @@ const StdcmConfig = ({
               loadingGauge: loadingGaugeType,
               speedLimitByTag,
             }}
-            onConsistChange={onConsistChange}
+            onConsistChange={onInitialConsistChange}
           />
           <div className="stdcm__separator" />
           <StdcmOrigin disabled={disabled} onItineraryChange={onItineraryChange} />

--- a/front/src/applications/stdcm/components/StdcmForm/StdcmConfig.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmConfig.tsx
@@ -9,10 +9,20 @@ import { useSelector } from 'react-redux';
 import { extractMarkersInfo } from 'applications/stdcm/utils';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import DefaultBaseMap from 'common/Map/DefaultBaseMap';
+import { useOsrdConfActions } from 'common/osrdContext';
 import useWorkerStatus from 'modules/pathfinding/hooks/useWorkerStatus';
 import { useMapSettings, useMapSettingsActions } from 'reducers/commonMap';
 import type { MapSettings, Viewport } from 'reducers/commonMap/types';
-import { resetMargins, restoreStdcmConfig, updateStdcmPathStep } from 'reducers/osrdconf/stdcmConf';
+import {
+  resetMargins,
+  restoreStdcmConfig,
+  updateStdcmPathStep,
+  updateTotalMass,
+  updateTotalLength,
+  updateMaxSpeed,
+  updateLoadingGauge,
+  updateTowedRollingStockID,
+} from 'reducers/osrdconf/stdcmConf';
 import {
   getOperationalPoints,
   getTrackSectionIdsByLoadingGauge,
@@ -27,6 +37,11 @@ import {
   getStdcmTimetableID,
   getLoadingGauge,
   getStdcmRollingStockID,
+  getTotalMass,
+  getTotalLength,
+  getMaxSpeed,
+  getTowedRollingStockID,
+  getStdcmSpeedLimitByTag,
 } from 'reducers/osrdconf/stdcmConf/selectors';
 import type { OsrdStdcmConfState } from 'reducers/osrdconf/types';
 import { useAppDispatch } from 'store';
@@ -37,7 +52,7 @@ import StdcmDestination from './StdcmDestination';
 import StdcmLinkedTrainSearch from './StdcmLinkedTrainSearch';
 import StdcmOrigin from './StdcmOrigin';
 import useStaticPathfinding from '../../hooks/useStaticPathfinding';
-import type { StdcmConfigErrors, ConsistErrors } from '../../types';
+import type { ConsistData, StdcmConfigErrors, ConsistErrors } from '../../types';
 import StdcmSimulationParams from '../StdcmSimulationParams';
 import StdcmVias from './StdcmVias';
 import { ArrivalTimeTypes, StdcmConfigErrorTypes } from '../../types';
@@ -105,12 +120,39 @@ const StdcmConfig = ({
   const pathSteps = useSelector(getStdcmPathSteps);
   const destination = useSelector(getStdcmDestination);
   const rollingStockID = useSelector(getStdcmRollingStockID);
+  const towedRollingStockID = useSelector(getTowedRollingStockID);
+  const totalMass = useSelector(getTotalMass);
+  const totalLength = useSelector(getTotalLength);
+  const maxSpeed = useSelector(getMaxSpeed);
+  const speedLimitByTag = useSelector(getStdcmSpeedLimitByTag);
   const projectID = useSelector(getStdcmProjectID);
   const studyID = useSelector(getStdcmStudyID);
   const scenarioID = useSelector(getStdcmScenarioID);
   const operationalPoints = useSelector(getOperationalPoints);
   const trackSectionIdsByLoadingGauge = useSelector(getTrackSectionIdsByLoadingGauge);
   const loadingGaugeType = useSelector(getLoadingGauge);
+
+  const initialConsist: ConsistData = {
+    rollingStockID,
+    towedRollingStockID,
+    totalMass,
+    totalLength,
+  };
+
+  const { updateRollingStockID, updateSpeedLimitByTag } = useOsrdConfActions();
+
+  const onConsistChange = useCallback(
+    (newConsist: ConsistData) => {
+      dispatch(updateRollingStockID(newConsist.rollingStockID));
+      dispatch(updateTowedRollingStockID(newConsist.towedRollingStockID));
+      dispatch(updateTotalMass(newConsist.totalMass));
+      dispatch(updateTotalLength(newConsist.totalLength));
+      dispatch(updateMaxSpeed(newConsist.maxSpeed));
+      dispatch(updateLoadingGauge(newConsist.loadingGauge));
+      dispatch(updateSpeedLimitByTag(newConsist.speedLimitByTag));
+    },
+    [dispatch]
+  );
 
   const mapSettings = useMapSettings();
 
@@ -141,11 +183,18 @@ const StdcmConfig = ({
 
   const [formErrors, setFormErrors] = useState<StdcmConfigErrors>();
 
-  const [consistErrors, setConsistErrors] = useState<ConsistErrors>({
+  const [initialConsistErrors, setInitialConsistErrors] = useState<ConsistErrors>({
     totalMass: { message: undefined, display: false, type: 'missing' },
     totalLength: { message: undefined, display: false, type: 'missing' },
     maxSpeed: { message: undefined, display: false, type: 'missing' },
   });
+
+  const [viaConsistErrors, setViaConsistErrors] = useState<ConsistErrors[]>([]);
+
+  const consistErrors = useMemo(
+    () => [initialConsistErrors, ...viaConsistErrors],
+    [initialConsistErrors, viaConsistErrors]
+  );
 
   const disabled = isPending || retainedSimulationIndex !== undefined;
 
@@ -294,14 +343,21 @@ const StdcmConfig = ({
             linkedTrainType="anterior"
             linkedOpId={origin.id}
           />
-          <div className="stdcm-consist-container">
-            <StdcmConsist
-              disabled={disabled}
-              isDebugMode={isDebugMode}
-              consistErrors={consistErrors}
-              setConsistErrors={setConsistErrors}
-            />
-          </div>
+          <StdcmConsist
+            disabled={disabled}
+            isDebugMode={isDebugMode}
+            onConsistErrorsChange={setInitialConsistErrors}
+            consist={{
+              rollingStockID,
+              towedRollingStockID,
+              totalMass,
+              totalLength,
+              maxSpeed,
+              loadingGauge: loadingGaugeType,
+              speedLimitByTag,
+            }}
+            onConsistChange={onConsistChange}
+          />
           <div className="stdcm__separator" />
           <StdcmOrigin disabled={disabled} onItineraryChange={onItineraryChange} />
           <StdcmVias
@@ -309,6 +365,8 @@ const StdcmConfig = ({
             isDebugMode={isDebugMode}
             skipAnimation={skipPathfindingStatusMessage}
             onItineraryChange={onItineraryChange}
+            initialConsist={initialConsist}
+            onHasViaConsistErrorsChange={setViaConsistErrors}
           />
           <StdcmDestination disabled={disabled} onItineraryChange={onItineraryChange} />
           <StdcmLinkedTrainSearch

--- a/front/src/applications/stdcm/components/StdcmForm/StdcmConsist.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmConsist.tsx
@@ -190,10 +190,7 @@ const StdcmConsist = ({
         name={t('consist.consist')}
         title={
           isConsistChange ? (
-            <div
-              data-testid="stdcm-via-delete-consist-change"
-              className="stdcm-via-delete-consist-change"
-            >
+            <div data-testid="stdcm-via-delete-consist-change" className="stdcm-via-icons">
               <button
                 data-testid="delete-consist-change-button"
                 type="button"

--- a/front/src/applications/stdcm/components/StdcmForm/StdcmConsist.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmConsist.tsx
@@ -1,37 +1,28 @@
 import { useEffect, useMemo, useState } from 'react';
 
 import { Input, ComboBox, useDefaultComboBox, Select } from '@osrd-project/ui-core';
+import { skipToken } from '@reduxjs/toolkit/query';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
 import { consistErrorFields } from 'applications/stdcm/consts';
 import useConsistFieldStatus from 'applications/stdcm/hooks/useConsistFieldStatus';
 import useFilterTowedRollingStock from 'applications/stdcm/hooks/useFilterTowedRollingStock';
-import useStdcmLightRollingStock from 'applications/stdcm/hooks/useStdcmLightRollingStock';
-import useStdcmTowedRollingStock from 'applications/stdcm/hooks/useStdcmTowedRollingStock';
-import type { ConsistErrors } from 'applications/stdcm/types';
+import type { ConsistData, ConsistErrors } from 'applications/stdcm/types';
 import calculateConsistMaxSpeed from 'applications/stdcm/utils/calculateConsistMaxSpeed';
-import {
-  validateMaxSpeed,
-  validateTotalLength,
-  validateTotalMass,
-} from 'applications/stdcm/utils/consistValidation';
+import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import type {
   LightRollingStockWithLiveries,
   TowedRollingStock,
   LoadingGaugeType,
 } from 'common/api/osrdEditoastApi';
-import { useOsrdConfActions } from 'common/osrdContext';
 import SpeedLimitTagSelector from 'common/SpeedLimitTagSelector';
 import RollingStock2Img from 'modules/rollingStock/components/RollingStock2Img';
 import useFilterRollingStock from 'modules/rollingStock/hooks/useFilterRollingStock';
-import { updateMaxSpeed, updateTowedRollingStockID } from 'reducers/osrdconf/stdcmConf';
 import {
   getTrackSectionIdsByLoadingGauge,
-  getStdcmSpeedLimitByTag,
   getStdcmSpeedLimitsByTag,
 } from 'reducers/osrdconf/stdcmConf/selectors';
-import { useAppDispatch } from 'store';
 import { removeDuplicates } from 'utils/array';
 import { createStandardSelectOptions } from 'utils/uiCoreHelpers';
 
@@ -55,8 +46,11 @@ const ConsistCardTitle = ({
 export type StdcmConsistProps = {
   isDebugMode: boolean;
   disabled?: boolean;
-  consistErrors: ConsistErrors;
-  setConsistErrors: React.Dispatch<React.SetStateAction<ConsistErrors>>;
+  consist: ConsistData;
+  onConsistChange: (consist: ConsistData) => void;
+  onConsistErrorsChange: (errors: ConsistErrors) => void;
+  isConsistChange?: boolean;
+  onDeleteConsistChange?: () => void;
 };
 
 const GAUGES_LIST: LoadingGaugeType[] = [
@@ -77,12 +71,20 @@ const isLoadingGaugeType = (gauge: string | undefined): gauge is LoadingGaugeTyp
 const StdcmConsist = ({
   isDebugMode,
   disabled = false,
-  consistErrors,
-  setConsistErrors,
+  consist,
+  onConsistChange,
+  onConsistErrorsChange,
+  isConsistChange = false,
+  onDeleteConsistChange,
 }: StdcmConsistProps) => {
   const { t } = useTranslation('stdcm');
 
-  const selectedSpeedLimitTag = useSelector(getStdcmSpeedLimitByTag);
+  const [consistErrors, setConsistErrors] = useState<ConsistErrors>({
+    totalMass: { message: undefined, display: false, type: 'missing' },
+    totalLength: { message: undefined, display: false, type: 'missing' },
+    maxSpeed: { message: undefined, display: false, type: 'missing' },
+  });
+
   const speedLimitsByTag = useSelector(getStdcmSpeedLimitsByTag);
   const speedLimitTags = useMemo(
     () => removeDuplicates(Object.keys(speedLimitsByTag)).sort(),
@@ -93,11 +95,15 @@ const StdcmConsist = ({
     ? Object.keys(trackSectionIdsByLoadingGauge)
     : [];
 
-  const { updateRollingStockID, updateSpeedLimitByTag } = useOsrdConfActions();
-  const dispatch = useAppDispatch();
+  const { data: rollingStock } =
+    osrdEditoastApi.endpoints.getLightRollingStockByRollingStockId.useQuery(
+      consist.rollingStockID ? { rollingStockId: consist.rollingStockID } : skipToken
+    );
 
-  const rollingStock = useStdcmLightRollingStock();
-  const towedRollingStock = useStdcmTowedRollingStock();
+  const { currentData: towedRollingStock } =
+    osrdEditoastApi.endpoints.getTowedRollingStockByTowedRollingStockId.useQuery(
+      consist.towedRollingStockID ? { towedRollingStockId: consist.towedRollingStockID } : skipToken
+    );
 
   const [statusMessagesVisible, setStatusMessagesVisible] = useState({
     mass: true,
@@ -106,18 +112,14 @@ const StdcmConsist = ({
   });
 
   const {
-    totalMass,
     onTotalMassChange,
-    totalLength,
     onTotalLengthChange,
-    maxSpeed,
     onMaxSpeedChange,
-    loadingGauge,
     onLoadingGaugeChange,
     prefillConsist,
     statusWithMessage,
     setMaxSpeedChanged,
-  } = useStdcmConsist();
+  } = useStdcmConsist(consist, onConsistChange, rollingStock, towedRollingStock);
 
   const useFieldStatus = (field: 'totalMass' | 'totalLength' | 'maxSpeed') =>
     useConsistFieldStatus(
@@ -132,13 +134,6 @@ const StdcmConsist = ({
   const massFieldStatus = useFieldStatus('totalMass');
   const lengthFieldStatus = useFieldStatus('totalLength');
   const speedFieldStatus = useFieldStatus('maxSpeed');
-
-  const getMissingFieldMessage = (value?: number): string | null => {
-    if (!value) {
-      return t('consist.errors.missingValue');
-    }
-    return null;
-  };
 
   const { filteredRollingStockList: rollingStocks } = useFilterRollingStock({ isStdcm: true });
 
@@ -158,8 +153,9 @@ const StdcmConsist = ({
   );
 
   const handleRollingStockSelect = (option?: LightRollingStockWithLiveries) => {
-    prefillConsist(option, towedRollingStock, selectedSpeedLimitTag);
-    dispatch(updateRollingStockID(option?.id));
+    prefillConsist(option, towedRollingStock, consist.speedLimitByTag, {
+      rollingStockID: option?.id,
+    });
     setStatusMessagesVisible({
       mass: true,
       length: true,
@@ -168,16 +164,15 @@ const StdcmConsist = ({
   };
 
   const onSpeedLimitTagChange = (newTag: string | null) => {
-    dispatch(
-      updateMaxSpeed(
-        calculateConsistMaxSpeed(
-          rollingStock,
-          towedRollingStock,
-          newTag ? speedLimitsByTag[newTag] : undefined
-        )
-      )
-    );
-    dispatch(updateSpeedLimitByTag(newTag));
+    onConsistChange({
+      ...consist,
+      speedLimitByTag: newTag ?? undefined,
+      maxSpeed: calculateConsistMaxSpeed(
+        rollingStock,
+        towedRollingStock,
+        newTag ? speedLimitsByTag[newTag] : undefined
+      ),
+    });
     setMaxSpeedChanged(false);
   };
 
@@ -185,189 +180,158 @@ const StdcmConsist = ({
     setStatusMessagesVisible((prevState) => ({ ...prevState, [key]: false }));
   };
 
-  const handleBlurError = (field: keyof ConsistErrors, error?: string) => {
-    setConsistErrors((prev) => ({
-      ...prev,
-      [field]: {
-        message: error,
-        display: !!error,
-        type: error === t('consist.errors.missingValue') ? 'missing' : 'invalid',
-      },
-    }));
-  };
-
-  const totalMassError = useMemo(
-    () =>
-      getMissingFieldMessage(totalMass) ??
-      validateTotalMass({
-        tractionEngineMass: rollingStock?.mass,
-        towedMass: towedRollingStock?.mass,
-        totalMass,
-      }),
-    [totalMass]
-  );
-
-  const totalLengthError = useMemo(
-    () =>
-      getMissingFieldMessage(totalLength) ??
-      validateTotalLength({
-        tractionEngineLength: rollingStock?.length,
-        towedLength: towedRollingStock?.length,
-        totalLength,
-      }),
-    [totalLength]
-  );
-
-  const maxSpeedError = useMemo(
-    () => getMissingFieldMessage(maxSpeed) ?? validateMaxSpeed(maxSpeed, rollingStock?.max_speed),
-    [maxSpeed]
-  );
-
+  // Propagate consist errors to parent component
   useEffect(() => {
-    const errors = {
-      totalMass: totalMassError,
-      totalLength: totalLengthError,
-      maxSpeed: maxSpeedError,
-    };
-
-    consistErrorFields.forEach((field) => {
-      setConsistErrors((prev) => ({
-        ...prev,
-        [field]: {
-          ...prev[field],
-          display:
-            prev[field].display &&
-            (prev[field].type === 'missing'
-              ? // Hide tooltip if the error was a missing one and is fixed regardless if the fied is still invalid
-                !!(errors[field] === t('consist.errors.missingValue'))
-              : !!errors[field]),
-        },
-      }));
-    });
-  }, [totalMassError, totalLengthError, maxSpeedError]);
+    onConsistErrorsChange(consistErrors);
+  }, [consistErrors]);
 
   return (
-    <StdcmCard
-      name={t('consist.consist')}
-      title={<ConsistCardTitle rollingStock={rollingStock} />}
-      disabled={disabled}
-      className="consist"
-      testId="consist"
-    >
-      <div className="traction-engine">
-        <ComboBox
-          testIdPrefix="traction-engine"
-          id="tractionEngine"
-          label={t('consist.tractionEngine')}
-          value={rollingStock}
-          getSuggestionLabel={getLabel}
-          onSelectSuggestion={handleRollingStockSelect}
-          {...rollingStockComboBoxDefaultProps}
-          autoComplete="off"
-          disabled={disabled}
-          narrow
-        />
-      </div>
-      <div className="towed-rolling-stock">
-        <ComboBox
-          testIdPrefix="towed-rolling-stock"
-          id="towedRollingStock"
-          label={t('consist.towedRollingStock')}
-          value={towedRollingStock}
-          getSuggestionLabel={(suggestion: TowedRollingStock) => suggestion.name}
-          onSelectSuggestion={(towed) => {
-            prefillConsist(rollingStock, towed, selectedSpeedLimitTag);
-            dispatch(updateTowedRollingStockID(towed?.id));
-          }}
-          {...towedRollingStockComboBoxDefaultProps}
-          autoComplete="off"
-          disabled={disabled}
-          narrow
-        />
-      </div>
-      <div className="loading-gauge">
-        {loadingGauges && loadingGauges.length > 0 && (
-          <Select
-            id="loading-gauge-selector"
-            value={loadingGauge}
-            label={t('consist.loadingGauge')}
-            onChange={(e) => {
-              if (isLoadingGaugeType(e)) {
-                onLoadingGaugeChange(e);
-              } else {
-                onLoadingGaugeChange(undefined);
-              }
-            }}
-            {...createStandardSelectOptions(loadingGauges)}
+    <>
+      <ConsistCardTitle rollingStock={rollingStock} />
+      <StdcmCard
+        name={t('consist.consist')}
+        title={
+          isConsistChange ? (
+            <div
+              data-testid="stdcm-via-delete-consist-change"
+              className="stdcm-via-delete-consist-change"
+            >
+              <button
+                data-testid="delete-consist-change-button"
+                type="button"
+                onClick={onDeleteConsistChange}
+              >
+                {t('translation:common.delete')}
+              </button>
+            </div>
+          ) : undefined
+        }
+        disabled={disabled}
+        className="consist"
+        testId="consist"
+      >
+        <div className="traction-engine">
+          <ComboBox
+            testIdPrefix="traction-engine"
+            id="tractionEngine"
+            label={t('consist.tractionEngine')}
+            value={rollingStock}
+            getSuggestionLabel={getLabel}
+            onSelectSuggestion={handleRollingStockSelect}
+            {...rollingStockComboBoxDefaultProps}
+            autoComplete="off"
             disabled={disabled}
             narrow
           />
+        </div>
+        <div className="towed-rolling-stock">
+          <ComboBox
+            testIdPrefix="towed-rolling-stock"
+            id="towedRollingStock"
+            label={t('consist.towedRollingStock')}
+            value={towedRollingStock}
+            getSuggestionLabel={(suggestion: TowedRollingStock) => suggestion.name}
+            onSelectSuggestion={(towed) => {
+              prefillConsist(rollingStock, towed, consist.speedLimitByTag, {
+                towedRollingStockID: towed?.id,
+              });
+            }}
+            {...towedRollingStockComboBoxDefaultProps}
+            autoComplete="off"
+            disabled={disabled}
+            narrow
+          />
+        </div>
+        {!isConsistChange && (
+          <div className="loading-gauge">
+            {loadingGauges && loadingGauges.length > 0 && (
+              <Select
+                id="loading-gauge-selector"
+                value={consist.loadingGauge}
+                label={t('consist.loadingGauge')}
+                onChange={(e) => {
+                  if (isLoadingGaugeType(e)) {
+                    onLoadingGaugeChange(e);
+                  } else {
+                    onLoadingGaugeChange(undefined);
+                  }
+                }}
+                {...createStandardSelectOptions(loadingGauges)}
+                disabled={disabled}
+                narrow
+              />
+            )}
+          </div>
         )}
-      </div>
-      <div className="stdcm-consist__properties">
-        <Input
-          testIdPrefix="tonnage"
-          id="tonnage"
-          label={t('consist.tonnage')}
-          trailingContent="t"
-          type="number"
-          min={0}
-          value={totalMass ?? ''}
-          onChange={(e) => {
-            onTotalMassChange(e);
-          }}
-          onBlur={() => handleBlurError('totalMass', totalMassError)}
-          disabled={disabled}
-          statusWithMessage={massFieldStatus}
-          onCloseStatusMessage={() => handleCloseStatusMessage('mass')}
-          narrow
-        />
-        <Input
-          testIdPrefix="length"
-          id="length"
-          label={t('consist.length')}
-          trailingContent="m"
-          type="number"
-          min={0}
-          value={totalLength ?? ''}
-          onChange={(e) => {
-            onTotalLengthChange(e);
-          }}
-          onBlur={() => handleBlurError('totalLength', totalLengthError)}
-          disabled={disabled}
-          statusWithMessage={lengthFieldStatus}
-          onCloseStatusMessage={() => handleCloseStatusMessage('length')}
-          narrow
-        />
-      </div>
-      <div className="stdcm-consist__properties">
-        <SpeedLimitTagSelector
-          disabled={disabled}
-          selectedSpeedLimitTag={selectedSpeedLimitTag}
-          speedLimitTags={speedLimitTags}
-          updateSpeedLimitTag={onSpeedLimitTagChange}
-          showPlaceHolder={isDebugMode}
-          narrow
-        />
-        <Input
-          testIdPrefix="maxSpeed"
-          id="maxSpeed"
-          label={t('consist.maxSpeed')}
-          trailingContent="km/h"
-          type="number"
-          min={0}
-          value={maxSpeed ?? ''}
-          onChange={(e) => {
-            onMaxSpeedChange(e);
-          }}
-          onBlur={() => handleBlurError('maxSpeed', maxSpeedError)}
-          disabled={disabled}
-          statusWithMessage={speedFieldStatus}
-          onCloseStatusMessage={() => handleCloseStatusMessage('speed')}
-          narrow
-        />
-      </div>
-    </StdcmCard>
+        <div className="stdcm-consist__properties">
+          <Input
+            testIdPrefix="tonnage"
+            id="tonnage"
+            label={t('consist.tonnage')}
+            trailingContent="t"
+            type="number"
+            min={0}
+            value={consist.totalMass ?? ''}
+            onChange={(e) => {
+              onTotalMassChange(e);
+            }}
+            onBlur={() => handleBlurError('totalMass', totalMassError)}
+            disabled={disabled}
+            statusWithMessage={massFieldStatus}
+            onCloseStatusMessage={() => handleCloseStatusMessage('mass')}
+            narrow
+          />
+          <Input
+            testIdPrefix="length"
+            id="length"
+            label={t('consist.length')}
+            trailingContent="m"
+            type="number"
+            min={0}
+            value={consist.totalLength ?? ''}
+            onChange={(e) => {
+              onTotalLengthChange(e);
+            }}
+            onBlur={() => handleBlurError('totalLength', totalLengthError)}
+            disabled={disabled}
+            statusWithMessage={lengthFieldStatus}
+            onCloseStatusMessage={() => handleCloseStatusMessage('length')}
+            narrow
+          />
+        </div>
+        <div className="stdcm-consist__properties">
+          {!isConsistChange && (
+            <>
+              <SpeedLimitTagSelector
+                disabled={disabled}
+                selectedSpeedLimitTag={consist.speedLimitByTag}
+                speedLimitTags={speedLimitTags}
+                updateSpeedLimitTag={onSpeedLimitTagChange}
+                showPlaceHolder={isDebugMode}
+                narrow
+              />
+              <Input
+                testIdPrefix="maxSpeed"
+                id="maxSpeed"
+                label={t('consist.maxSpeed')}
+                trailingContent="km/h"
+                type="number"
+                min={0}
+                value={consist.maxSpeed ?? ''}
+                onChange={(e) => {
+                  onMaxSpeedChange(e);
+                }}
+                onBlur={() => handleBlurError('maxSpeed', maxSpeedError)}
+                disabled={disabled}
+                statusWithMessage={speedFieldStatus}
+                onCloseStatusMessage={() => handleCloseStatusMessage('speed')}
+                narrow
+              />
+            </>
+          )}
+        </div>
+      </StdcmCard>
+    </>
   );
 };
 

--- a/front/src/applications/stdcm/components/StdcmForm/StdcmConsist.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmConsist.tsx
@@ -5,7 +5,6 @@ import { skipToken } from '@reduxjs/toolkit/query';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
-import { consistErrorFields } from 'applications/stdcm/consts';
 import useConsistFieldStatus from 'applications/stdcm/hooks/useConsistFieldStatus';
 import useFilterTowedRollingStock from 'applications/stdcm/hooks/useFilterTowedRollingStock';
 import type { ConsistData, ConsistErrors } from 'applications/stdcm/types';
@@ -79,12 +78,6 @@ const StdcmConsist = ({
 }: StdcmConsistProps) => {
   const { t } = useTranslation('stdcm');
 
-  const [consistErrors, setConsistErrors] = useState<ConsistErrors>({
-    totalMass: { message: undefined, display: false, type: 'missing' },
-    totalLength: { message: undefined, display: false, type: 'missing' },
-    maxSpeed: { message: undefined, display: false, type: 'missing' },
-  });
-
   const speedLimitsByTag = useSelector(getStdcmSpeedLimitsByTag);
   const speedLimitTags = useMemo(
     () => removeDuplicates(Object.keys(speedLimitsByTag)).sort(),
@@ -119,6 +112,11 @@ const StdcmConsist = ({
     prefillConsist,
     statusWithMessage,
     setMaxSpeedChanged,
+    consistErrors,
+    updateConsistErrors,
+    totalMassError,
+    totalLengthError,
+    maxSpeedError,
   } = useStdcmConsist(consist, onConsistChange, rollingStock, towedRollingStock);
 
   const useFieldStatus = (field: 'totalMass' | 'totalLength' | 'maxSpeed') =>
@@ -275,7 +273,7 @@ const StdcmConsist = ({
             onChange={(e) => {
               onTotalMassChange(e);
             }}
-            onBlur={() => handleBlurError('totalMass', totalMassError)}
+            onBlur={() => updateConsistErrors({ totalMass: totalMassError })}
             disabled={disabled}
             statusWithMessage={massFieldStatus}
             onCloseStatusMessage={() => handleCloseStatusMessage('mass')}
@@ -292,7 +290,7 @@ const StdcmConsist = ({
             onChange={(e) => {
               onTotalLengthChange(e);
             }}
-            onBlur={() => handleBlurError('totalLength', totalLengthError)}
+            onBlur={() => updateConsistErrors({ totalLength: totalLengthError })}
             disabled={disabled}
             statusWithMessage={lengthFieldStatus}
             onCloseStatusMessage={() => handleCloseStatusMessage('length')}
@@ -321,7 +319,7 @@ const StdcmConsist = ({
                 onChange={(e) => {
                   onMaxSpeedChange(e);
                 }}
-                onBlur={() => handleBlurError('maxSpeed', maxSpeedError)}
+                onBlur={() => updateConsistErrors({ maxSpeed: maxSpeedError })}
                 disabled={disabled}
                 statusWithMessage={speedFieldStatus}
                 onCloseStatusMessage={() => handleCloseStatusMessage('speed')}

--- a/front/src/applications/stdcm/components/StdcmForm/StdcmDefaultCard.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmDefaultCard.tsx
@@ -8,6 +8,7 @@ type StdcmCardProps = {
   onClick?: () => void;
   className?: string;
   testId?: string;
+  tooltip?: string;
 };
 const StdcmDefaultCard = ({
   text,
@@ -17,18 +18,21 @@ const StdcmDefaultCard = ({
   disabled = false,
   className = '',
   testId = '',
+  tooltip,
 }: StdcmCardProps) => (
-  <button
-    className={`${className}-card-wrapper`}
-    type="button"
-    disabled={disabled}
-    onClick={onClick}
-  >
-    <StdcmCard tip={tip} disabled={disabled} className={className} testId={testId}>
-      <span className="stdcm-default-card-icon">{Icon}</span>
-      <span className="stdcm-default-card-text">{text}</span>
-    </StdcmCard>
-  </button>
+  <div title={tooltip} style={{ display: 'contents' }}>
+    <button
+      className={`${className}-card-wrapper`}
+      type="button"
+      disabled={disabled}
+      onClick={onClick}
+    >
+      <StdcmCard tip={tip} disabled={disabled} className={className} testId={testId}>
+        <span className="stdcm-default-card-icon">{Icon}</span>
+        <span className="stdcm-default-card-text">{text}</span>
+      </StdcmCard>
+    </button>
+  </div>
 );
 
 export default StdcmDefaultCard;

--- a/front/src/applications/stdcm/components/StdcmForm/StdcmVias.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmVias.tsx
@@ -5,6 +5,8 @@ import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
+import filterMissingFields from 'applications/stdcm/utils/filterMissingFields';
+import getInvalidFields from 'applications/stdcm/utils/getInvalidFields';
 import { updateStdcmPathStep, deleteStdcmVia, addStdcmVia } from 'reducers/osrdconf/stdcmConf';
 import { getStdcmPathSteps } from 'reducers/osrdconf/stdcmConf/selectors';
 import type { StdcmViaPathStep } from 'reducers/osrdconf/types';
@@ -24,6 +26,7 @@ import StdcmCardMarkerIcon from '../StdcmCardMarkerIcon';
 type StdcmViasProps = StdcmItineraryProps & {
   skipAnimation: boolean;
   initialConsist: ConsistData;
+  initialConsistErrors: ConsistErrors;
   onHasViaConsistErrorsChange: (errors: ConsistErrors[]) => void;
 };
 
@@ -33,6 +36,7 @@ const StdcmVias = ({
   skipAnimation,
   onItineraryChange,
   initialConsist,
+  initialConsistErrors,
   onHasViaConsistErrorsChange,
 }: StdcmViasProps) => {
   const { t } = useTranslation('stdcm');
@@ -48,6 +52,11 @@ const StdcmVias = ({
     [pathSteps]
   ) as StdcmViaPathStep[];
 
+  const cleanupConsistErrors = (pathStepId: string) => {
+    delete consistErrorsByStep.current[pathStepId];
+    onHasViaConsistErrorsChange(Object.values(consistErrorsByStep.current));
+  };
+
   const updateStopType = (newStopType: StdcmStopTypes, pathStep: StdcmViaPathStep) => {
     let defaultStopTime: Duration | undefined;
     if (newStopType === StdcmStopTypes.DRIVER_SWITCH) {
@@ -60,6 +69,8 @@ const StdcmVias = ({
     if (newStopType !== StdcmStopTypes.SERVICE_STOP && pathStep.consistChange) {
       // Disable consist change
       newConsistChange = undefined;
+
+      cleanupConsistErrors(pathStep.id);
     }
 
     dispatch(
@@ -120,6 +131,7 @@ const StdcmVias = ({
   }, [newIntermediateOpIndex]);
 
   const deleteViaOnClick = (pathStepId: string) => {
+    cleanupConsistErrors(pathStepId);
     dispatch(deleteStdcmVia(pathStepId));
     onItineraryChange();
   };
@@ -141,13 +153,14 @@ const StdcmVias = ({
   };
 
   const addConsistChange = (viaPathStep: StdcmViaPathStep, index: number) => {
+    const previousConsistChange = getPreviousConsistChange(index);
     if (viaPathStep.stopFor && viaPathStep.stopFor < new Duration({ minutes: 30 })) {
       dispatch(
         updateStdcmPathStep({
           id: viaPathStep.id,
           updates: {
             stopFor: new Duration({ minutes: 30 }),
-            consistChange: getPreviousConsistChange(index),
+            consistChange: previousConsistChange,
           },
         })
       );
@@ -156,7 +169,7 @@ const StdcmVias = ({
         updateStdcmPathStep({
           id: viaPathStep.id,
           updates: {
-            consistChange: getPreviousConsistChange(index),
+            consistChange: previousConsistChange,
           },
         })
       );
@@ -164,8 +177,7 @@ const StdcmVias = ({
   };
 
   const removeConsistChange = (viaPathStep: StdcmViaPathStep) => {
-    delete consistErrorsByStep.current[viaPathStep.id];
-    onHasViaConsistErrorsChange(Object.values(consistErrorsByStep.current));
+    cleanupConsistErrors(viaPathStep.id);
 
     dispatch(
       updateStdcmPathStep({
@@ -180,6 +192,28 @@ const StdcmVias = ({
   const handleConsistErrors = (id: string, errors: ConsistErrors) => {
     consistErrorsByStep.current[id] = errors;
     onHasViaConsistErrorsChange(Object.values(consistErrorsByStep.current));
+  };
+
+  const hasConsistsErrors = (): boolean | undefined => {
+    const invalidConsistsFields = getInvalidFields([
+      initialConsistErrors,
+      ...Object.values(consistErrorsByStep.current),
+    ]);
+    const missingConsistsFields = filterMissingFields({
+      totalMass: initialConsist.totalMass,
+      totalLength: initialConsist.totalLength,
+      maxSpeed: initialConsist.maxSpeed,
+      vias: pathSteps,
+      missingFields: [
+        'totalMass',
+        'totalLength',
+        'maxSpeed',
+        'viaConsistTotalMass',
+        'viaConsistTotalLength',
+      ],
+    });
+
+    return invalidConsistsFields.length !== 0 || missingConsistsFields.length !== 0;
   };
 
   return (
@@ -211,8 +245,12 @@ const StdcmVias = ({
                 <StdcmDefaultCard
                   testId="edit-consist"
                   className="edit-consist"
+                  disabled={hasConsistsErrors()}
                   tip="right"
                   text={t('trainPath.consistChange.add')}
+                  tooltip={
+                    hasConsistsErrors() ? t('trainPath.consistChange.fixErrorsFirst') : undefined
+                  }
                   Icon={<Location size="lg" variant="base" />}
                   onClick={() => addConsistChange(pathStep, index)}
                 />

--- a/front/src/applications/stdcm/components/StdcmForm/StdcmVias.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmVias.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useMemo, useState } from 'react';
+import { useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 import { Location } from '@osrd-project/ui-icons';
 import cx from 'classnames';
@@ -7,21 +7,24 @@ import { useSelector } from 'react-redux';
 
 import { updateStdcmPathStep, deleteStdcmVia, addStdcmVia } from 'reducers/osrdconf/stdcmConf';
 import { getStdcmPathSteps } from 'reducers/osrdconf/stdcmConf/selectors';
-import type { StdcmPathStep, StdcmViaPathStep } from 'reducers/osrdconf/types';
+import type { StdcmViaPathStep } from 'reducers/osrdconf/types';
 import { useAppDispatch } from 'store';
 import { Duration } from 'utils/duration';
 
 import StdcmCard from './StdcmCard';
+import StdcmConsist from './StdcmConsist';
 import StdcmDefaultCard from './StdcmDefaultCard';
 import StdcmOperationalPoint from './StdcmOperationalPoint';
 import StdcmStopType from './StdcmStopType';
 import StopDurationInput from './StopDurationInput';
 import { StdcmStopTypes } from '../../types';
-import type { StdcmItineraryProps } from '../../types';
+import type { ConsistData, ConsistErrors, StdcmItineraryProps } from '../../types';
 import StdcmCardMarkerIcon from '../StdcmCardMarkerIcon';
 
 type StdcmViasProps = StdcmItineraryProps & {
   skipAnimation: boolean;
+  initialConsist: ConsistData;
+  onHasViaConsistErrorsChange: (errors: ConsistErrors[]) => void;
 };
 
 const StdcmVias = ({
@@ -29,6 +32,8 @@ const StdcmVias = ({
   isDebugMode,
   skipAnimation,
   onItineraryChange,
+  initialConsist,
+  onHasViaConsistErrorsChange,
 }: StdcmViasProps) => {
   const { t } = useTranslation('stdcm');
   const dispatch = useAppDispatch();
@@ -36,9 +41,14 @@ const StdcmVias = ({
 
   const [newIntermediateOpIndex, setNewIntermediateOpIndex] = useState<number>();
 
-  const intermediatePoints = useMemo(() => pathSteps.slice(1, -1), [pathSteps]);
+  const consistErrorsByStep = useRef<Record<string, ConsistErrors>>({});
 
-  const updateStopType = (newStopType: StdcmStopTypes, pathStep: StdcmPathStep) => {
+  const intermediatePoints = useMemo(
+    () => pathSteps.slice(1, -1),
+    [pathSteps]
+  ) as StdcmViaPathStep[];
+
+  const updateStopType = (newStopType: StdcmStopTypes, pathStep: StdcmViaPathStep) => {
     let defaultStopTime: Duration | undefined;
     if (newStopType === StdcmStopTypes.DRIVER_SWITCH) {
       defaultStopTime = new Duration({ minutes: 3 });
@@ -46,15 +56,20 @@ const StdcmVias = ({
       defaultStopTime = Duration.zero;
     }
 
-    let hasConsistChange = pathStep.isVia && pathStep.hasConsistChange;
-    if (newStopType !== StdcmStopTypes.SERVICE_STOP && hasConsistChange) {
-      hasConsistChange = false;
+    let newConsistChange = pathStep.consistChange;
+    if (newStopType !== StdcmStopTypes.SERVICE_STOP && pathStep.consistChange) {
+      // Disable consist change
+      newConsistChange = undefined;
     }
 
     dispatch(
       updateStdcmPathStep({
         id: pathStep.id,
-        updates: { stopType: newStopType, stopFor: defaultStopTime, hasConsistChange },
+        updates: {
+          stopType: newStopType,
+          stopFor: defaultStopTime,
+          consistChange: newConsistChange,
+        },
       })
     );
   };
@@ -115,14 +130,24 @@ const StdcmVias = ({
     onItineraryChange();
   };
 
-  const addConsistChange = (viaPathStep: StdcmViaPathStep) => {
+  const getPreviousConsistChange = (index: number): ConsistData => {
+    for (let i = index - 1; i >= 0; i--) {
+      if (intermediatePoints[i].consistChange) {
+        return { ...intermediatePoints[i].consistChange };
+      }
+    }
+
+    return initialConsist;
+  };
+
+  const addConsistChange = (viaPathStep: StdcmViaPathStep, index: number) => {
     if (viaPathStep.stopFor && viaPathStep.stopFor < new Duration({ minutes: 30 })) {
       dispatch(
         updateStdcmPathStep({
           id: viaPathStep.id,
           updates: {
-            hasConsistChange: true,
             stopFor: new Duration({ minutes: 30 }),
+            consistChange: getPreviousConsistChange(index),
           },
         })
       );
@@ -131,7 +156,7 @@ const StdcmVias = ({
         updateStdcmPathStep({
           id: viaPathStep.id,
           updates: {
-            hasConsistChange: true,
+            consistChange: getPreviousConsistChange(index),
           },
         })
       );
@@ -139,14 +164,22 @@ const StdcmVias = ({
   };
 
   const removeConsistChange = (viaPathStep: StdcmViaPathStep) => {
+    delete consistErrorsByStep.current[viaPathStep.id];
+    onHasViaConsistErrorsChange(Object.values(consistErrorsByStep.current));
+
     dispatch(
       updateStdcmPathStep({
         id: viaPathStep.id,
         updates: {
-          hasConsistChange: false,
+          consistChange: undefined,
         },
       })
     );
+  };
+
+  const handleConsistErrors = (id: string, errors: ConsistErrors) => {
+    consistErrorsByStep.current[id] = errors;
+    onHasViaConsistErrorsChange(Object.values(consistErrorsByStep.current));
   };
 
   return (
@@ -174,21 +207,32 @@ const StdcmVias = ({
             {/* TODO #15344: remove isDebugMode */}
             {isDebugMode &&
               pathStep.stopType === StdcmStopTypes.SERVICE_STOP &&
-              (!pathStep.hasConsistChange ? (
+              (!pathStep.consistChange ? (
                 <StdcmDefaultCard
                   testId="edit-consist"
                   className="edit-consist"
                   tip="right"
                   text={t('trainPath.consistChange.add')}
                   Icon={<Location size="lg" variant="base" />}
-                  onClick={() => addConsistChange(pathStep)}
+                  onClick={() => addConsistChange(pathStep, index)}
                 />
               ) : (
                 <>
-                  {/* // TODO #15242: add consist change form */}
-                  <button onClick={() => removeConsistChange(pathStep)}>
-                    **Consist change form placeholder (click to remove consist change)**
-                  </button>
+                  <StdcmConsist
+                    isDebugMode={isDebugMode}
+                    onConsistErrorsChange={(errors) => handleConsistErrors(pathStep.id, errors)}
+                    consist={pathStep.consistChange ?? {}}
+                    onConsistChange={(newConsist) =>
+                      dispatch(
+                        updateStdcmPathStep({
+                          id: pathStep.id,
+                          updates: { consistChange: newConsist },
+                        })
+                      )
+                    }
+                    isConsistChange
+                    onDeleteConsistChange={() => removeConsistChange(pathStep)}
+                  />
                   <div className="stdcm__separator" />
                 </>
               ))}

--- a/front/src/applications/stdcm/components/StdcmForm/StopDurationInput.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StopDurationInput.tsx
@@ -33,7 +33,7 @@ const StopDurationInput = ({ pathStep }: StopDurationInputProps) => {
 
     const isInvalidConsistChange =
       pathStep.stopFor !== undefined &&
-      pathStep.hasConsistChange &&
+      pathStep.consistChange &&
       pathStep.stopFor < new Duration({ minutes: 30 });
 
     if (isInvalidDriverStop) {
@@ -51,7 +51,7 @@ const StopDurationInput = ({ pathStep }: StopDurationInputProps) => {
     }
 
     return undefined;
-  }, [pathStep.stopType, pathStep.stopFor, pathStep.hasConsistChange]);
+  }, [pathStep.stopType, pathStep.stopFor, pathStep.consistChange]);
 
   useEffect(() => {
     setStopDuration(pathStep.stopFor !== undefined ? `${pathStep.stopFor.total('minute')}` : '');

--- a/front/src/applications/stdcm/hooks/useStdcmConsist.ts
+++ b/front/src/applications/stdcm/hooks/useStdcmConsist.ts
@@ -12,10 +12,20 @@ import type {
 import { getStdcmSpeedLimitsByTag } from 'reducers/osrdconf/stdcmConf/selectors';
 import { kgToT } from 'utils/physics';
 
-import type { ConsistData } from '../types';
+import type { ConsistData, ConsistErrors } from '../types';
 import calculateConsistMaxSpeed from '../utils/calculateConsistMaxSpeed';
+import {
+  validateMaxSpeed,
+  validateTotalLength,
+  validateTotalMass,
+} from '../utils/consistValidation';
 
-const useStdcmConsist = (consist: ConsistData, onConsistChange: (consist: ConsistData) => void) => {
+const useStdcmConsist = (
+  consist: ConsistData,
+  onConsistChange: (consist: ConsistData) => void,
+  selectedRollingStock: LightRollingStockWithLiveries | undefined,
+  selectedTowedRollingStock: TowedRollingStock | undefined
+) => {
   const { t } = useTranslation('stdcm');
   const speedLimitTags = useSelector(getStdcmSpeedLimitsByTag);
 
@@ -29,25 +39,80 @@ const useStdcmConsist = (consist: ConsistData, onConsistChange: (consist: Consis
     maxSpeed?: InputProps['statusWithMessage'];
   }>({});
 
+  const [consistErrors, setConsistErrors] = useState<ConsistErrors>({
+    totalMass: { message: undefined, display: false, type: 'missing' },
+    totalLength: { message: undefined, display: false, type: 'missing' },
+    maxSpeed: { message: undefined, display: false, type: 'missing' },
+  });
+
+  const missingValueMessage = t('consist.errors.missingValue');
+
+  const getMissingFieldMessage = (value?: number): string | null =>
+    !value ? missingValueMessage : null;
+
+  const updateConsistErrors = (
+    errors: Partial<Record<keyof ConsistErrors, string | undefined>>
+  ) => {
+    setConsistErrors((prev) =>
+      (Object.entries(errors) as [keyof ConsistErrors, string | undefined][]).reduce(
+        (acc, [field, error]) => ({
+          ...acc,
+          [field]: {
+            message: error,
+            display: !!error,
+            type: error === missingValueMessage ? 'missing' : 'invalid',
+          },
+        }),
+        prev
+      )
+    );
+  };
+
   const onTotalMassChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const totalMassValue = Number(e.target.value);
     setTotalMassChanged(true);
-    onConsistChange({ ...consist, totalMass: totalMassValue === 0 ? undefined : totalMassValue });
+    const newMass = totalMassValue === 0 ? undefined : totalMassValue;
+    const newError =
+      getMissingFieldMessage(newMass) ??
+      validateTotalMass({
+        tractionEngineMass: selectedRollingStock?.mass,
+        towedMass: selectedTowedRollingStock?.mass,
+        totalMass: newMass,
+      });
+    if (consistErrors.totalMass.display) {
+      updateConsistErrors({ totalMass: newError });
+    }
+    onConsistChange({ ...consist, totalMass: newMass });
   };
 
   const onTotalLengthChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const totalLengthValue = Number(e.target.value);
     setTotalLengthChanged(true);
-    onConsistChange({
-      ...consist,
-      totalLength: totalLengthValue === 0 ? undefined : totalLengthValue,
-    });
+    const newLength = totalLengthValue === 0 ? undefined : totalLengthValue;
+    const newError =
+      getMissingFieldMessage(newLength) ??
+      validateTotalLength({
+        tractionEngineLength: selectedRollingStock?.length,
+        towedLength: selectedTowedRollingStock?.length,
+        totalLength: newLength,
+      });
+    if (consistErrors.totalLength.display) {
+      updateConsistErrors({ totalLength: newError });
+    }
+    onConsistChange({ ...consist, totalLength: newLength });
   };
 
   const onMaxSpeedChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const totalMaxSpeed = Number(e.target.value);
     setMaxSpeedChanged(true);
-    onConsistChange({ ...consist, maxSpeed: totalMaxSpeed === 0 ? undefined : totalMaxSpeed });
+    const newSpeed = totalMaxSpeed === 0 ? undefined : totalMaxSpeed;
+    const newError =
+      getMissingFieldMessage(newSpeed) ??
+      validateMaxSpeed(newSpeed, selectedRollingStock?.max_speed);
+    if (consistErrors.maxSpeed.display) {
+      updateConsistErrors({ maxSpeed: newError });
+    }
+    onConsistChange({ ...consist, maxSpeed: newSpeed });
   };
 
   const onLoadingGaugeChange = (option: LoadingGaugeType | undefined) => {
@@ -99,6 +164,7 @@ const useStdcmConsist = (consist: ConsistData, onConsistChange: (consist: Consis
     setMaxSpeedChanged(false);
 
     setStatusWithMessage(newStatus);
+
     onConsistChange({
       ...consist,
       totalMass: newTotalMass,
@@ -106,6 +172,8 @@ const useStdcmConsist = (consist: ConsistData, onConsistChange: (consist: Consis
       maxSpeed: newMaxSpeed,
       ...extraFields,
     });
+
+    updateConsistErrors({ totalMass: undefined, totalLength: undefined, maxSpeed: undefined });
   };
 
   const totalMassError = useMemo(
@@ -146,7 +214,7 @@ const useStdcmConsist = (consist: ConsistData, onConsistChange: (consist: Consis
     statusWithMessage,
     setMaxSpeedChanged,
     consistErrors,
-    handleBlurError,
+    updateConsistErrors,
     totalMassError,
     totalLengthError,
     maxSpeedError,

--- a/front/src/applications/stdcm/hooks/useStdcmConsist.ts
+++ b/front/src/applications/stdcm/hooks/useStdcmConsist.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import type { InputProps } from '@osrd-project/ui-core';
 import { useTranslation } from 'react-i18next';
@@ -9,27 +9,14 @@ import type {
   LoadingGaugeType,
   TowedRollingStock,
 } from 'common/api/osrdEditoastApi';
-import {
-  updateTotalMass,
-  updateTotalLength,
-  updateMaxSpeed,
-  updateLoadingGauge,
-} from 'reducers/osrdconf/stdcmConf';
-import {
-  getTotalMass,
-  getTotalLength,
-  getMaxSpeed,
-  getLoadingGauge,
-  getStdcmSpeedLimitsByTag,
-} from 'reducers/osrdconf/stdcmConf/selectors';
-import { useAppDispatch } from 'store';
+import { getStdcmSpeedLimitsByTag } from 'reducers/osrdconf/stdcmConf/selectors';
 import { kgToT } from 'utils/physics';
 
+import type { ConsistData } from '../types';
 import calculateConsistMaxSpeed from '../utils/calculateConsistMaxSpeed';
 
-const useStdcmConsist = () => {
+const useStdcmConsist = (consist: ConsistData, onConsistChange: (consist: ConsistData) => void) => {
   const { t } = useTranslation('stdcm');
-  const dispatch = useAppDispatch();
   const speedLimitTags = useSelector(getStdcmSpeedLimitsByTag);
 
   const [totalMassChanged, setTotalMassChanged] = useState(false);
@@ -42,42 +29,42 @@ const useStdcmConsist = () => {
     maxSpeed?: InputProps['statusWithMessage'];
   }>({});
 
-  const totalMass = useSelector(getTotalMass);
   const onTotalMassChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const totalMassValue = Number(e.target.value);
     setTotalMassChanged(true);
-    dispatch(updateTotalMass(totalMassValue === 0 ? undefined : totalMassValue));
+    onConsistChange({ ...consist, totalMass: totalMassValue === 0 ? undefined : totalMassValue });
   };
 
-  const totalLength = useSelector(getTotalLength);
   const onTotalLengthChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const totalLengthValue = Number(e.target.value);
     setTotalLengthChanged(true);
-    dispatch(updateTotalLength(totalLengthValue === 0 ? undefined : totalLengthValue));
+    onConsistChange({
+      ...consist,
+      totalLength: totalLengthValue === 0 ? undefined : totalLengthValue,
+    });
   };
 
-  const maxSpeed = useSelector(getMaxSpeed);
   const onMaxSpeedChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const totalMaxSpeed = Number(e.target.value);
     setMaxSpeedChanged(true);
-    dispatch(updateMaxSpeed(totalMaxSpeed === 0 ? undefined : totalMaxSpeed));
+    onConsistChange({ ...consist, maxSpeed: totalMaxSpeed === 0 ? undefined : totalMaxSpeed });
   };
 
-  const loadingGauge = useSelector(getLoadingGauge);
   const onLoadingGaugeChange = (option: LoadingGaugeType | undefined) => {
-    dispatch(updateLoadingGauge(option));
+    onConsistChange({ ...consist, loadingGauge: option });
   };
 
   const prefillConsist = (
     rollingStock?: LightRollingStockWithLiveries,
     towed?: TowedRollingStock,
-    maxSpeedTag?: string | null
+    maxSpeedTag?: string | null,
+    extraFields?: Partial<ConsistData>
   ) => {
     const newStatus: typeof statusWithMessage = {};
 
     const consistMass = Math.ceil(kgToT((rollingStock?.mass ?? 0) + (towed?.mass ?? 0)));
-    dispatch(updateTotalMass(consistMass > 0 ? consistMass : undefined));
-    if (totalMassChanged && totalMass !== undefined) {
+    const newTotalMass = consistMass > 0 ? consistMass : undefined;
+    if (totalMassChanged && consist.totalMass !== undefined) {
       newStatus.totalMass = {
         status: 'info',
         message: t('consist.info.totalMass'),
@@ -87,8 +74,8 @@ const useStdcmConsist = () => {
     setTotalMassChanged(false);
 
     const consistLength = Math.ceil((rollingStock?.length ?? 0) + (towed?.length ?? 0));
-    dispatch(updateTotalLength(consistLength > 0 ? consistLength : undefined));
-    if (totalLengthChanged && totalLength !== undefined) {
+    const newTotalLength = consistLength > 0 ? consistLength : undefined;
+    if (totalLengthChanged && consist.totalLength !== undefined) {
       newStatus.totalLength = {
         status: 'info',
         message: t('consist.info.totalLength'),
@@ -97,16 +84,12 @@ const useStdcmConsist = () => {
     }
     setTotalLengthChanged(false);
 
-    dispatch(
-      updateMaxSpeed(
-        calculateConsistMaxSpeed(
-          rollingStock,
-          towed,
-          maxSpeedTag ? (speedLimitTags || {})[maxSpeedTag] : undefined
-        )
-      )
+    const newMaxSpeed = calculateConsistMaxSpeed(
+      rollingStock,
+      towed,
+      maxSpeedTag ? (speedLimitTags || {})[maxSpeedTag] : undefined
     );
-    if (maxSpeedChanged && maxSpeed !== undefined) {
+    if (maxSpeedChanged && consist.maxSpeed !== undefined) {
       newStatus.maxSpeed = {
         status: 'info',
         message: t('consist.info.maxSpeed'),
@@ -116,20 +99,57 @@ const useStdcmConsist = () => {
     setMaxSpeedChanged(false);
 
     setStatusWithMessage(newStatus);
+    onConsistChange({
+      ...consist,
+      totalMass: newTotalMass,
+      totalLength: newTotalLength,
+      maxSpeed: newMaxSpeed,
+      ...extraFields,
+    });
   };
 
+  const totalMassError = useMemo(
+    () =>
+      getMissingFieldMessage(consist.totalMass) ??
+      validateTotalMass({
+        tractionEngineMass: selectedRollingStock?.mass,
+        towedMass: selectedTowedRollingStock?.mass,
+        totalMass: consist.totalMass,
+      }),
+    [consist.totalMass, selectedRollingStock?.mass, selectedTowedRollingStock?.mass]
+  );
+
+  const totalLengthError = useMemo(
+    () =>
+      getMissingFieldMessage(consist.totalLength) ??
+      validateTotalLength({
+        tractionEngineLength: selectedRollingStock?.length,
+        towedLength: selectedTowedRollingStock?.length,
+        totalLength: consist.totalLength,
+      }),
+    [consist.totalLength, selectedRollingStock?.length, selectedTowedRollingStock?.length]
+  );
+
+  const maxSpeedError = useMemo(
+    () =>
+      getMissingFieldMessage(consist.maxSpeed) ??
+      validateMaxSpeed(consist.maxSpeed, selectedRollingStock?.max_speed),
+    [consist.maxSpeed, selectedRollingStock?.max_speed]
+  );
+
   return {
-    totalMass,
     onTotalMassChange,
-    totalLength,
     onTotalLengthChange,
-    maxSpeed,
     onMaxSpeedChange,
-    loadingGauge,
     onLoadingGaugeChange,
     prefillConsist,
     statusWithMessage,
     setMaxSpeedChanged,
+    consistErrors,
+    handleBlurError,
+    totalMassError,
+    totalLengthError,
+    maxSpeedError,
   };
 };
 

--- a/front/src/applications/stdcm/styles/_card.scss
+++ b/front/src/applications/stdcm/styles/_card.scss
@@ -214,28 +214,3 @@
     padding: 8px;
   }
 }
-
-.stdcm-card:hover {
-  .stdcm-via-icons {
-    .icon-bundle {
-      display: none;
-    }
-    button {
-      display: contents;
-      font-size: 1rem;
-      font-weight: 600;
-      cursor: pointer;
-      color: var(--primary60);
-    }
-  }
-}
-
-.stdcm-via-delete-consist-change {
-  button {
-    display: contents;
-    font-size: 1rem;
-    font-weight: 600;
-    cursor: pointer;
-    color: var(--primary60);
-  }
-}

--- a/front/src/applications/stdcm/styles/_card.scss
+++ b/front/src/applications/stdcm/styles/_card.scss
@@ -214,3 +214,28 @@
     padding: 8px;
   }
 }
+
+.stdcm-card:hover {
+  .stdcm-via-icons {
+    .icon-bundle {
+      display: none;
+    }
+    button {
+      display: contents;
+      font-size: 1rem;
+      font-weight: 600;
+      cursor: pointer;
+      color: var(--primary60);
+    }
+  }
+}
+
+.stdcm-via-delete-consist-change {
+  button {
+    display: contents;
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    color: var(--primary60);
+  }
+}

--- a/front/src/applications/stdcm/styles/_home.scss
+++ b/front/src/applications/stdcm/styles/_home.scss
@@ -43,32 +43,37 @@
       }
     }
 
-    .stdcm-consist-container {
-      .stdcm-consist-title {
-        padding-right: 12px;
-        position: relative;
-      }
+    .consist-wrapper {
+      grid-column: consist-col;
+    }
 
-      .stdcm-consist-title::after {
-        content: '';
-        background: linear-gradient(270deg, transparent 0px, rgba(235, 235, 234) 40px);
-        position: absolute;
-        left: 100%;
-        width: 40px;
-        height: 22px;
-        z-index: 1;
-      }
+    .stdcm-consist-title {
+      padding-right: 12px;
+      position: relative;
+    }
 
-      .stdcm-consist-img {
-        overflow: hidden;
-        padding-bottom: 12px;
-        img {
-          object-fit: cover;
-          object-position: left;
-          transform: scaleX(-1);
-          max-width: 100%;
-          height: 20px;
-        }
+    .stdcm-consist-title::after {
+      content: '';
+      background: linear-gradient(270deg, transparent 0px, rgba(235, 235, 234) 40px);
+      position: absolute;
+      left: 100%;
+      width: 40px;
+      height: 22px;
+      z-index: 1;
+    }
+
+    .stdcm-consist-img {
+      grid-column: consist-col;
+      grid-row: 1;
+      align-self: end;
+      overflow: hidden;
+      padding-bottom: 12px;
+      img {
+        object-fit: cover;
+        object-position: left;
+        transform: scaleX(-1);
+        max-width: 100%;
+        height: 20px;
       }
     }
 

--- a/front/src/applications/stdcm/types.ts
+++ b/front/src/applications/stdcm/types.ts
@@ -125,6 +125,20 @@ export type StdcmSimulationInputs = {
   linkedTrains: LinkedTrains;
 };
 
+export type ConsistData = {
+  rollingStockID?: number;
+  towedRollingStockID?: number;
+  /** In ton */
+  totalMass?: number;
+  /** In meters */
+  totalLength?: number;
+  /** Loading gauge, max speed and speed limit can only be set on initial consist and cannot be changed */
+  /** In km/h */
+  maxSpeed?: number;
+  loadingGauge?: LoadingGaugeType;
+  speedLimitByTag?: string;
+};
+
 export type StdcmResultsOutput = {
   pathProperties: StdcmPathProperties;
   results: StdcmSuccessResponse;

--- a/front/src/applications/stdcm/types.ts
+++ b/front/src/applications/stdcm/types.ts
@@ -198,7 +198,9 @@ export type MissingFields =
   | 'maxSpeed'
   | 'origin'
   | 'vias'
-  | 'destination';
+  | 'destination'
+  | 'viaConsistTotalMass'
+  | 'viaConsistTotalLength';
 
 export type InvalidFields = {
   fieldName: 'totalMass' | 'totalLength' | 'maxSpeed';

--- a/front/src/applications/stdcm/utils/__tests__/filterMissingFields.spec.ts
+++ b/front/src/applications/stdcm/utils/__tests__/filterMissingFields.spec.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect } from 'vitest';
+
+import { ArrivalTimeTypes, StdcmStopTypes } from 'applications/stdcm/types';
+import type { StdcmPathStep } from 'reducers/osrdconf/types';
+import { Duration } from 'utils/duration';
+
+import filterMissingFields from '../filterMissingFields';
+
+describe('filterMissingFields', () => {
+  const makePathStep = (hasOP = true): StdcmPathStep => ({
+    id: 'step',
+    isVia: false,
+    arrivalType: ArrivalTimeTypes.ASAP,
+    tolerances: { before: new Duration({ seconds: 0 }), after: new Duration({ seconds: 0 }) },
+    ...(hasOP && {
+      operationalPoint: {
+        id: 'op1',
+        trigram: 'ABC',
+        uic: 12345,
+        secondaryCode: '00',
+        name: 'Station A',
+        coordinates: [0, 0],
+      },
+    }),
+  });
+
+  const makeViaStep = (totalMass?: number, totalLength?: number, hasOP = true): StdcmPathStep => ({
+    id: 'via',
+    isVia: true,
+    stopType: StdcmStopTypes.SERVICE_STOP,
+    consistChange: { totalMass, totalLength },
+    ...(hasOP && {
+      operationalPoint: {
+        id: 'op2',
+        trigram: 'DEF',
+        uic: 67890,
+        secondaryCode: '00',
+        name: 'Station B',
+        coordinates: [1, 1],
+      },
+    }),
+  });
+
+  describe('checkAllFields mode', () => {
+    it('returns [] when checkAllFields is false and missingFields is undefined', () => {
+      const result = filterMissingFields({});
+      expect(result).toEqual([]);
+    });
+
+    it('returns only the missingFields entries that are actually missing', () => {
+      const result = filterMissingFields({
+        missingFields: ['tractionEngine', 'totalMass'],
+        rollingStockID: 1,
+      });
+      expect(result).toEqual(['totalMass']);
+    });
+
+    it('returns all fields when checkAllFields is true and nothing is provided', () => {
+      const result = filterMissingFields({ checkAllFields: true });
+      expect(result).toEqual([
+        'tractionEngine',
+        'totalMass',
+        'totalLength',
+        'maxSpeed',
+        'origin',
+        'destination',
+      ]);
+    });
+
+    it('returns [] when checkAllFields is true and all fields are valid', () => {
+      const result = filterMissingFields({
+        checkAllFields: true,
+        rollingStockID: 1,
+        totalMass: 100,
+        totalLength: 200,
+        maxSpeed: 80,
+        origin: makePathStep(),
+        vias: [],
+        destination: makePathStep(),
+      });
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('tractionEngine', () => {
+    it('is missing when rollingStockID is undefined', () => {
+      const result = filterMissingFields({ missingFields: ['tractionEngine'] });
+      expect(result).toEqual(['tractionEngine']);
+    });
+
+    it('is missing when rollingStockID is 0 (falsy)', () => {
+      const result = filterMissingFields({
+        missingFields: ['tractionEngine'],
+        rollingStockID: 0,
+      });
+      expect(result).toEqual(['tractionEngine']);
+    });
+
+    it('is not missing when rollingStockID is a positive number', () => {
+      const result = filterMissingFields({
+        missingFields: ['tractionEngine'],
+        rollingStockID: 42,
+      });
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('totalMass / totalLength / maxSpeed (strict undefined check)', () => {
+    it('are missing when values are undefined', () => {
+      const result = filterMissingFields({
+        missingFields: ['totalMass', 'totalLength', 'maxSpeed'],
+      });
+      expect(result).toEqual(['totalMass', 'totalLength', 'maxSpeed']);
+    });
+
+    it('are not missing when values are 0', () => {
+      const result = filterMissingFields({
+        missingFields: ['totalMass', 'totalLength', 'maxSpeed'],
+        totalMass: 0,
+        totalLength: 0,
+        maxSpeed: 0,
+      });
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('origin', () => {
+    it('is missing when origin is undefined', () => {
+      const result = filterMissingFields({ missingFields: ['origin'] });
+      expect(result).toEqual(['origin']);
+    });
+
+    it('is missing when origin has no operationalPoint', () => {
+      const result = filterMissingFields({
+        missingFields: ['origin'],
+        origin: makePathStep(false),
+      });
+      expect(result).toEqual(['origin']);
+    });
+
+    it('is not missing when origin has an operationalPoint', () => {
+      const result = filterMissingFields({
+        missingFields: ['origin'],
+        origin: makePathStep(),
+      });
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('destination', () => {
+    it('is missing when destination is undefined', () => {
+      const result = filterMissingFields({ missingFields: ['destination'] });
+      expect(result).toEqual(['destination']);
+    });
+
+    it('is missing when destination has no operationalPoint', () => {
+      const result = filterMissingFields({
+        missingFields: ['destination'],
+        destination: makePathStep(false),
+      });
+      expect(result).toEqual(['destination']);
+    });
+
+    it('is not missing when destination has an operationalPoint', () => {
+      const result = filterMissingFields({
+        missingFields: ['destination'],
+        destination: makePathStep(),
+      });
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('vias', () => {
+    it('is not flagged when vias is undefined', () => {
+      const result = filterMissingFields({ missingFields: ['vias'] });
+      expect(result).toEqual([]);
+    });
+
+    it('is not missing when all vias have an operationalPoint', () => {
+      const result = filterMissingFields({
+        missingFields: ['vias'],
+        vias: [makeViaStep(100, 200)],
+      });
+      expect(result).toEqual([]);
+    });
+
+    it('is missing when any via lacks an operationalPoint', () => {
+      const result = filterMissingFields({
+        missingFields: ['vias'],
+        vias: [makeViaStep(100, 200), makeViaStep(100, 200, false)],
+      });
+      expect(result).toEqual(['vias']);
+    });
+  });
+
+  describe('viaConsistTotalMass', () => {
+    it('is not flagged when vias is undefined', () => {
+      const result = filterMissingFields({ missingFields: ['viaConsistTotalMass'] });
+      expect(result).toEqual([]);
+    });
+
+    it('is not missing when all isVia steps have totalMass set (including 0)', () => {
+      const result = filterMissingFields({
+        missingFields: ['viaConsistTotalMass'],
+        vias: [makeViaStep(0, 200)],
+      });
+      expect(result).toEqual([]);
+    });
+
+    it('is missing when any isVia step has totalMass undefined', () => {
+      const result = filterMissingFields({
+        missingFields: ['viaConsistTotalMass'],
+        vias: [makeViaStep(undefined, 200)],
+      });
+      expect(result).toEqual(['viaConsistTotalMass']);
+    });
+
+    it('is not triggered by non-isVia path steps', () => {
+      const result = filterMissingFields({
+        missingFields: ['viaConsistTotalMass'],
+        vias: [makePathStep()],
+      });
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('viaConsistTotalLength', () => {
+    it('is not flagged when vias is undefined', () => {
+      const result = filterMissingFields({ missingFields: ['viaConsistTotalLength'] });
+      expect(result).toEqual([]);
+    });
+
+    it('is not missing when all isVia steps have totalLength set (including 0)', () => {
+      const result = filterMissingFields({
+        missingFields: ['viaConsistTotalLength'],
+        vias: [makeViaStep(100, 0)],
+      });
+      expect(result).toEqual([]);
+    });
+
+    it('is missing when any isVia step has totalLength undefined', () => {
+      const result = filterMissingFields({
+        missingFields: ['viaConsistTotalLength'],
+        vias: [makeViaStep(100, undefined)],
+      });
+      expect(result).toEqual(['viaConsistTotalLength']);
+    });
+
+    it('is not triggered by non-isVia path steps', () => {
+      const result = filterMissingFields({
+        missingFields: ['viaConsistTotalLength'],
+        vias: [makePathStep()],
+      });
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/front/src/applications/stdcm/utils/checkStdcmConfigErrors.ts
+++ b/front/src/applications/stdcm/utils/checkStdcmConfigErrors.ts
@@ -51,7 +51,7 @@ const checkStdcmConfigErrors = ({
     })
   );
 
-  let invalidFields = consistErrors ? getInvalidFields(consistErrors) : [];
+  let invalidFields = getInvalidFields(consistErrors);
 
   if (!shouldCheckMandatoryFields) {
     const prevInvalid = prevFormErrors?.errorDetails?.invalidFields || [];

--- a/front/src/applications/stdcm/utils/checkStdcmConfigErrors.ts
+++ b/front/src/applications/stdcm/utils/checkStdcmConfigErrors.ts
@@ -27,7 +27,7 @@ const checkStdcmConfigErrors = ({
   pathfindingStatus?: 'success' | 'failure';
   stdcmConf?: OsrdStdcmConfState;
   prevFormErrors?: StdcmConfigErrors;
-  consistErrors?: ConsistErrors;
+  consistErrors?: ConsistErrors[];
   shouldCheckMandatoryFields?: boolean;
 }): StdcmConfigErrors | undefined => {
   const { stdcmPathSteps, rollingStockID, totalMass, totalLength, maxSpeed } = stdcmConf!;

--- a/front/src/applications/stdcm/utils/filterMissingFields.ts
+++ b/front/src/applications/stdcm/utils/filterMissingFields.ts
@@ -1,5 +1,3 @@
-import { isNil } from 'lodash';
-
 import type { StdcmPathStep } from 'reducers/osrdconf/types';
 
 import type { MissingFields } from '../types';
@@ -24,6 +22,8 @@ const ALL_MISSING_FIELDS: MissingFields[] = [
   'origin',
   'vias',
   'destination',
+  'viaConsistTotalMass',
+  'viaConsistTotalLength',
 ];
 
 const filterMissingFields = ({
@@ -44,17 +44,25 @@ const filterMissingFields = ({
       case 'tractionEngine':
         return !rollingStockID;
       case 'totalMass':
-        return isNil(totalMass);
+        return totalMass === undefined;
       case 'totalLength':
-        return isNil(totalLength);
+        return totalLength === undefined;
       case 'maxSpeed':
-        return isNil(maxSpeed);
+        return maxSpeed === undefined;
       case 'origin':
         return !origin?.operationalPoint;
       case 'vias':
-        return vias?.some((via) => !via.operationalPoint) ?? false;
+        return vias?.some((via) => !via.operationalPoint);
       case 'destination':
         return !destination?.operationalPoint;
+      case 'viaConsistTotalMass':
+        return vias?.some(
+          (via) => via.isVia && via.consistChange && via.consistChange?.totalMass === undefined
+        );
+      case 'viaConsistTotalLength':
+        return vias?.some(
+          (via) => via.isVia && via.consistChange && via.consistChange?.totalLength === undefined
+        );
       default:
         return false;
     }

--- a/front/src/applications/stdcm/utils/getInvalidFields.ts
+++ b/front/src/applications/stdcm/utils/getInvalidFields.ts
@@ -1,15 +1,25 @@
 import { consistErrorFields } from '../consts';
 import type { ConsistErrors, InvalidFields } from '../types';
 
-const getInvalidFields = (consistErrors: ConsistErrors): InvalidFields[] =>
-  consistErrorFields.reduce<InvalidFields[]>((acc, key) => {
-    const fieldError = consistErrors[key];
+const getInvalidFields = (consistErrors: ConsistErrors[]): InvalidFields[] => {
+  const seen = new Set<string>();
+  return consistErrors.flatMap((errors) =>
+    consistErrorFields.reduce<InvalidFields[]>((acc, key) => {
+      const fieldError = errors[key];
 
-    if (fieldError?.type === 'invalid' && fieldError.display && fieldError.message) {
-      acc.push({ fieldName: key });
-    }
+      if (
+        fieldError?.type === 'invalid' &&
+        fieldError.display &&
+        fieldError.message &&
+        !seen.has(key)
+      ) {
+        seen.add(key);
+        acc.push({ fieldName: key });
+      }
 
-    return acc;
-  }, []);
+      return acc;
+    }, [])
+  );
+};
 
 export default getInvalidFields;

--- a/front/src/applications/stdcm/utils/getInvalidFields.ts
+++ b/front/src/applications/stdcm/utils/getInvalidFields.ts
@@ -1,7 +1,9 @@
 import { consistErrorFields } from '../consts';
 import type { ConsistErrors, InvalidFields } from '../types';
 
-const getInvalidFields = (consistErrors: ConsistErrors[]): InvalidFields[] => {
+const getInvalidFields = (consistErrors: ConsistErrors[] | undefined): InvalidFields[] => {
+  if (!consistErrors) return [];
+
   const seen = new Set<string>();
   return consistErrors.flatMap((errors) =>
     consistErrorFields.reduce<InvalidFields[]>((acc, key) => {

--- a/front/src/reducers/osrdconf/stdcmConf/index.ts
+++ b/front/src/reducers/osrdconf/stdcmConf/index.ts
@@ -245,7 +245,7 @@ export const stdcmConfSlice = createSlice({
         id: uuidV4(),
         stopType: StdcmStopTypes.PASSAGE_TIME,
         isVia: true,
-        hasConsistChange: false,
+        consistChange: undefined,
       });
     },
     deleteStdcmVia(state: Draft<OsrdStdcmConfState>, action: PayloadAction<string>) {

--- a/front/src/reducers/osrdconf/stdcmConf/index.ts
+++ b/front/src/reducers/osrdconf/stdcmConf/index.ts
@@ -6,6 +6,7 @@ import {
   ArrivalTimeTypes,
   MarginType,
   StdcmStopTypes,
+  type ConsistData,
   type ExtremityPathStepType,
   type StdcmLinkedTrainExtremity,
   type StdcmSimulation,
@@ -123,6 +124,15 @@ export const stdcmConfSlice = createSlice({
       action: PayloadAction<OsrdStdcmConfState['towedRollingStockID']>
     ) {
       state.towedRollingStockID = action.payload;
+    },
+    updateInitialConsist(state: Draft<OsrdStdcmConfState>, action: PayloadAction<ConsistData>) {
+      state.rollingStockID = action.payload.rollingStockID;
+      state.towedRollingStockID = action.payload.towedRollingStockID;
+      state.totalMass = action.payload.totalMass;
+      state.totalLength = action.payload.totalLength;
+      state.maxSpeed = action.payload.maxSpeed;
+      state.loadingGauge = action.payload.loadingGauge;
+      state.speedLimitByTag = action.payload.speedLimitByTag;
     },
     resetMargins(state: Draft<OsrdStdcmConfState>) {
       state.margins = {
@@ -336,6 +346,7 @@ export const {
   updateMaxSpeed,
   updateLoadingGauge,
   updateTowedRollingStockID,
+  updateInitialConsist,
   resetMargins,
   updateGridMarginAfter,
   updateGridMarginBefore,

--- a/front/src/reducers/osrdconf/stdcmConf/stdcmConfReducers.spec.ts
+++ b/front/src/reducers/osrdconf/stdcmConf/stdcmConfReducers.spec.ts
@@ -242,26 +242,69 @@ describe('stdcmConfReducers', () => {
     });
   });
 
-  it('should handle updateInitialConsist', () => {
-    const consist: ConsistData = {
-      rollingStockID: 1,
-      towedRollingStockID: 2,
-      totalMass: 500,
-      totalLength: 400,
-      maxSpeed: 160,
-      loadingGauge: 'GB',
-      speedLimitByTag: 'some-tag',
-    };
-    const store = createStore();
-    store.dispatch(updateInitialConsist(consist));
-    const state = store.getState()[stdcmConfSlice.name];
-    expect(state.rollingStockID).toBe(1);
-    expect(state.towedRollingStockID).toBe(2);
-    expect(state.totalMass).toBe(500);
-    expect(state.totalLength).toBe(400);
-    expect(state.maxSpeed).toBe(160);
-    expect(state.loadingGauge).toBe('GB');
-    expect(state.speedLimitByTag).toBe('some-tag');
+  describe('should handle updateInitialConsist', () => {
+    it('should update all consist fields', () => {
+      const consist: ConsistData = {
+        rollingStockID: 1,
+        towedRollingStockID: 2,
+        totalMass: 500,
+        totalLength: 400,
+        maxSpeed: 160,
+        loadingGauge: 'GB',
+        speedLimitByTag: 'some-tag',
+      };
+      const store = createStore();
+      store.dispatch(updateInitialConsist(consist));
+      const state = store.getState()[stdcmConfSlice.name];
+      expect(state.rollingStockID).toBe(1);
+      expect(state.towedRollingStockID).toBe(2);
+      expect(state.totalMass).toBe(500);
+      expect(state.totalLength).toBe(400);
+      expect(state.maxSpeed).toBe(160);
+      expect(state.loadingGauge).toBe('GB');
+      expect(state.speedLimitByTag).toBe('some-tag');
+    });
+
+    it('should reset consist fields to undefined when payload fields are undefined', () => {
+      const store = createStore({
+        rollingStockID: 10,
+        towedRollingStockID: 20,
+        totalMass: 500,
+        totalLength: 400,
+        maxSpeed: 160,
+        speedLimitByTag: 'old-tag',
+      });
+      store.dispatch(
+        updateInitialConsist({
+          rollingStockID: undefined,
+          towedRollingStockID: undefined,
+          totalMass: undefined,
+          totalLength: undefined,
+          maxSpeed: undefined,
+          loadingGauge: undefined,
+          speedLimitByTag: undefined,
+        })
+      );
+      const state = store.getState()[stdcmConfSlice.name];
+      expect(state.rollingStockID).toBeUndefined();
+      expect(state.towedRollingStockID).toBeUndefined();
+      expect(state.totalMass).toBeUndefined();
+      expect(state.totalLength).toBeUndefined();
+      expect(state.maxSpeed).toBeUndefined();
+      expect(state.loadingGauge).toBeUndefined();
+      expect(state.speedLimitByTag).toBeUndefined();
+    });
+
+    it('should not affect pathSteps or margins', () => {
+      const store = createStore(initialStateSTDCMConfig);
+      const stateBefore = store.getState()[stdcmConfSlice.name];
+      store.dispatch(
+        updateInitialConsist({ rollingStockID: 99, totalMass: 200, totalLength: 150 })
+      );
+      const stateAfter = store.getState()[stdcmConfSlice.name];
+      expect(stateAfter.stdcmPathSteps).toEqual(stateBefore.stdcmPathSteps);
+      expect(stateAfter.margins).toEqual(stateBefore.margins);
+    });
   });
 
   describe('StdcmPathStep updates', () => {

--- a/front/src/reducers/osrdconf/stdcmConf/stdcmConfReducers.spec.ts
+++ b/front/src/reducers/osrdconf/stdcmConf/stdcmConfReducers.spec.ts
@@ -4,6 +4,7 @@ import {
   ArrivalTimeTypes,
   StdcmStopTypes,
   MarginType,
+  type ConsistData,
   type LinkedTrains,
   type StdcmSimulation,
 } from 'applications/stdcm/types';
@@ -14,6 +15,7 @@ import {
   resetStdcmConfig,
   updateGridMarginAfter,
   updateGridMarginBefore,
+  updateInitialConsist,
   updateMaxSpeed,
   updateStandardAllowance,
   updateStdcmPathStep,
@@ -238,6 +240,28 @@ describe('stdcmConfReducers', () => {
       const state = store.getState()[stdcmConfSlice.name];
       expect(state.loadingGauge).toEqual('GB');
     });
+  });
+
+  it('should handle updateInitialConsist', () => {
+    const consist: ConsistData = {
+      rollingStockID: 1,
+      towedRollingStockID: 2,
+      totalMass: 500,
+      totalLength: 400,
+      maxSpeed: 160,
+      loadingGauge: 'GB',
+      speedLimitByTag: 'some-tag',
+    };
+    const store = createStore();
+    store.dispatch(updateInitialConsist(consist));
+    const state = store.getState()[stdcmConfSlice.name];
+    expect(state.rollingStockID).toBe(1);
+    expect(state.towedRollingStockID).toBe(2);
+    expect(state.totalMass).toBe(500);
+    expect(state.totalLength).toBe(400);
+    expect(state.maxSpeed).toBe(160);
+    expect(state.loadingGauge).toBe('GB');
+    expect(state.speedLimitByTag).toBe('some-tag');
   });
 
   describe('StdcmPathStep updates', () => {

--- a/front/src/reducers/osrdconf/stdcmConf/stdcmConfReducers.spec.ts
+++ b/front/src/reducers/osrdconf/stdcmConf/stdcmConfReducers.spec.ts
@@ -104,7 +104,7 @@ const stdcmPathSteps: StdcmPathStep[] = [
     id: '1',
     isVia: true,
     stopType: StdcmStopTypes.PASSAGE_TIME,
-    hasConsistChange: false,
+    consistChange: undefined,
   },
   {
     operationalPoint: {
@@ -118,7 +118,7 @@ const stdcmPathSteps: StdcmPathStep[] = [
     id: '2',
     isVia: true,
     stopType: StdcmStopTypes.PASSAGE_TIME,
-    hasConsistChange: false,
+    consistChange: undefined,
   },
   {
     operationalPoint: {
@@ -132,7 +132,7 @@ const stdcmPathSteps: StdcmPathStep[] = [
     id: '3',
     isVia: true,
     stopType: StdcmStopTypes.PASSAGE_TIME,
-    hasConsistChange: false,
+    consistChange: undefined,
   },
   {
     operationalPoint: {

--- a/front/src/reducers/osrdconf/types.ts
+++ b/front/src/reducers/osrdconf/types.ts
@@ -2,6 +2,7 @@ import type { Position } from 'geojson';
 
 import type { PowerRestriction } from 'applications/operationalStudies/types';
 import type {
+  ConsistData,
   MarginType,
   ArrivalTimeTypes,
   LinkedTrains,
@@ -168,7 +169,12 @@ export type StdcmPathStep = {
     coordinates: [number, number];
   };
 } & (
-  | { isVia: true; stopType: StdcmStopTypes; stopFor?: Duration; hasConsistChange: boolean }
+  | {
+      isVia: true;
+      stopType: StdcmStopTypes;
+      stopFor?: Duration;
+      consistChange?: ConsistData;
+    }
   | {
       isVia: false;
       arrivalType: ArrivalTimeTypes;

--- a/front/tests/utils/index.ts
+++ b/front/tests/utils/index.ts
@@ -80,6 +80,7 @@ export async function handleAndVerifyInput(inputField: Locator, value?: string):
   await expect(inputField).toBeVisible();
   await inputField.fill(value);
   await expect(inputField).toHaveValue(value);
+  await inputField.blur();
 }
 
 /**


### PR DESCRIPTION
Issue: https://github.com/OpenRailAssociation/osrd/issues/15242
Meta issue: https://github.com/OpenRailAssociation/osrd/issues/15324

----

<img width="843" height="1076" alt="Screenshot From 2026-03-05 15-54-17" src="https://github.com/user-attachments/assets/3371679c-d509-484d-84ab-e16da0821873" />

# Non trivial changes in this PR

1. StdcmConsist was edited to be a fully controlled component via props instead of via Redux (allow multiple instances of the component to have it's own consist data)
2. Consist img had to be moved above consist form to leave space for the delete button, this change has been validated by Thibault

More details inside each commits

# How to test

1. Go to stdcm
2. Enable debug
3. Add a via
4. Set via to service stop
5. A "edit consist" button should appear

# Identified regression

https://github.com/OpenRailAssociation/osrd/issues/15660