### PR TITLE
chart: use timestamped versions for non prod versions

### DIFF
--- a/.github/workflows/chart-build.yml
+++ b/.github/workflows/chart-build.yml
@@ -27,13 +27,13 @@ jobs:
           CHART_NAME="osrd-dev"
           CHART_IMAGES_REPOSITORY="edge"
           CHART_IMAGES_VERSION="dev"
-
+          TIMESTAMP=$(date +%s)
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            CHART_VERSION="0.0.1-${{ github.event.pull_request.number }}-${GITHUB_SHA}"
+            CHART_VERSION="0.0.${TIMESTAMP}-${{ github.event.pull_request.number }}-${GITHUB_SHA}"
           elif [[ "${{ github.ref }}" == "refs/heads/dev" ]]; then
-            CHART_VERSION="0.0.1-dev-${GITHUB_SHA}"
+            CHART_VERSION="0.0.${TIMESTAMP}-dev-${GITHUB_SHA}"
           elif [[ "${{ github.ref }}" == "refs/heads/staging" ]]; then
-            CHART_VERSION="0.0.1-staging-${GITHUB_SHA}"
+            CHART_VERSION="0.0.${TIMESTAMP}-staging-${GITHUB_SHA}"
           fi
 
           echo "CHART_NAME=$CHART_NAME" >> $GITHUB_ENV


### PR DESCRIPTION
This PR changes version for non prod chart from 0.0.1 to 0.0.{{ epoch }} in order to be able to find latest version easily