### PR TITLE
editoast: adapt paced train simulation summary

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -4381,6 +4381,7 @@ paths:
               type: object
               required:
               - infra_id
+              - timetable_id
               - ids
               properties:
                 electrical_profile_set_id:
@@ -4395,6 +4396,9 @@ paths:
                     format: int64
                   uniqueItems: true
                 infra_id:
+                  type: integer
+                  format: int64
+                timetable_id:
                   type: integer
                   format: int64
         required: true

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -245,6 +245,7 @@ pub(in crate::views) async fn delete(
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub(in crate::views) struct SimulationBatchForm {
     infra_id: i64,
+    timetable_id: i64,
     electrical_profile_set_id: Option<i64>,
     ids: HashSet<i64>,
 }
@@ -287,6 +288,7 @@ pub(in crate::views) async fn simulation_summary(
     Extension(auth): AuthenticationExt,
     Json(SimulationBatchForm {
         infra_id,
+        timetable_id,
         electrical_profile_set_id,
         ids: paced_train_ids,
     }): Json<SimulationBatchForm>,
@@ -315,31 +317,46 @@ pub(in crate::views) async fn simulation_summary(
     .await?;
 
     let paced_trains: Vec<models::TrainSchedule> =
-        models::TrainSchedule::retrieve_batch_or_fail(conn, paced_train_ids, |missing| {
+        models::TrainSchedule::retrieve_batch_or_fail(conn, paced_train_ids.clone(), |missing| {
             TrainScheduleError::BatchNotFound {
                 count: missing.len(),
             }
         })
         .await?;
 
-    let simulation_contexts: Vec<SimulationContext> =
-        paced_trains
-            .iter()
-            .flat_map(|paced_train| {
-                std::iter::once(SimulationContext {
-                    paced_train_id: paced_train.id,
-                    exception_key: None,
-                    train_schedule: paced_train.clone().into_train_occurrence(),
-                })
-                .chain(paced_train.exceptions.iter().map(|exception| {
-                    SimulationContext {
-                        paced_train_id: paced_train.id,
-                        exception_key: Some(exception.key.clone()),
-                        train_schedule: paced_train.apply_exception(exception),
-                    }
-                }))
+    let mut exceptions = TrainScheduleException::retrieve_exceptions_by_train_schedules(
+        conn,
+        timetable_id,
+        paced_train_ids.into_iter().collect(),
+    )
+    .await?
+    .into_iter()
+    .map_into::<schemas::TrainScheduleException>()
+    .into_group_map_by(|e| e.train_schedule_id);
+
+    let simulation_contexts: Vec<SimulationContext> = paced_trains
+        .iter()
+        .flat_map(|paced_train| {
+            let ts_exceptions = exceptions.remove(&paced_train.id).unwrap_or_default();
+            std::iter::once(SimulationContext {
+                paced_train_id: paced_train.id,
+                exception_key: None,
+                train_schedule: paced_train.clone().into_train_occurrence(),
             })
-            .collect();
+            .chain(
+                ts_exceptions
+                    .into_iter()
+                    .map(|exception| {
+                        SimulationContext {
+                            paced_train_id: paced_train.id,
+                            exception_key: exception.key.clone(), // TODO use exception.id
+                            train_schedule: paced_train.apply_train_schedule_exception(&exception),
+                        }
+                    })
+                    .collect::<Vec<_>>(),
+            )
+        })
+        .collect();
 
     let schedules: Vec<schemas::TrainOccurrence> = simulation_contexts
         .iter()
@@ -398,12 +415,6 @@ pub(in crate::views) async fn simulation_summary(
 #[derive(Debug, Default, Clone, Serialize, Deserialize, IntoParams, ToSchema)]
 #[into_params(parameter_in = Query)]
 pub(in crate::views) struct ExceptionQueryParam {
-    exception_key: Option<String>,
-}
-
-#[derive(Debug, Default, Clone, Serialize, Deserialize, IntoParams, ToSchema)]
-#[into_params(parameter_in = Query)]
-pub(in crate::views) struct TrainScheduleExceptionQueryParam {
     exception_id: Option<i64>,
 }
 
@@ -412,7 +423,7 @@ pub(in crate::views) struct TrainScheduleExceptionQueryParam {
 #[utoipa::path(
     get, path = "",
     tags = ["paced_train", "pathfinding"],
-    params(TrainScheduleIdParam, InfraIdQueryParam, TrainScheduleExceptionQueryParam),
+    params(TrainScheduleIdParam, InfraIdQueryParam, ExceptionQueryParam),
     responses(
         (status = 200, description = "The path", body = PathfindingResult),
         (status = 404, description = "Infrastructure or Train schedule not found")
@@ -431,9 +442,7 @@ pub(in crate::views) async fn get_path(
         id: train_schedule_id,
     }): Path<TrainScheduleIdParam>,
     Query(InfraIdQueryParam { infra_id }): Query<InfraIdQueryParam>,
-    Query(TrainScheduleExceptionQueryParam { exception_id }): Query<
-        TrainScheduleExceptionQueryParam,
-    >,
+    Query(ExceptionQueryParam { exception_id }): Query<ExceptionQueryParam>,
 ) -> Result<Json<PathfindingResult>> {
     let authorized = auth
         .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
@@ -503,7 +512,7 @@ pub struct ElectricalProfileSetIdQueryParam {
 #[utoipa::path(
     get, path = "",
     tag = "paced_train",
-    params(TrainScheduleIdParam, InfraIdQueryParam, ElectricalProfileSetIdQueryParam, TrainScheduleExceptionQueryParam),
+    params(TrainScheduleIdParam, InfraIdQueryParam, ElectricalProfileSetIdQueryParam, ExceptionQueryParam),
     responses(
         (status = 200, description = "Simulation Output", body = simulation::Response),
     ),
@@ -524,9 +533,7 @@ pub(in crate::views) async fn simulation(
     Query(ElectricalProfileSetIdQueryParam {
         electrical_profile_set_id,
     }): Query<ElectricalProfileSetIdQueryParam>,
-    Query(TrainScheduleExceptionQueryParam { exception_id }): Query<
-        TrainScheduleExceptionQueryParam,
-    >,
+    Query(ExceptionQueryParam { exception_id }): Query<ExceptionQueryParam>,
 ) -> Result<Json<simulation::Response>> {
     let authorized = auth
         .check_roles([authz::Role::OperationalStudies].into())
@@ -597,7 +604,7 @@ pub(in crate::views) async fn simulation(
 #[utoipa::path(
     get, path = "",
     tags = ["paced_train", "etcs_braking_curves"],
-    params(TrainScheduleIdParam, InfraIdQueryParam, ElectricalProfileSetIdQueryParam, TrainScheduleExceptionQueryParam),
+    params(TrainScheduleIdParam, InfraIdQueryParam, ElectricalProfileSetIdQueryParam, ExceptionQueryParam),
     responses(
         (status = 200, description = "ETCS Braking Curves Output", body = core_client::etcs_braking_curves::Response),
     ),
@@ -618,9 +625,7 @@ pub(in crate::views) async fn etcs_braking_curves(
     Query(ElectricalProfileSetIdQueryParam {
         electrical_profile_set_id,
     }): Query<ElectricalProfileSetIdQueryParam>,
-    Query(TrainScheduleExceptionQueryParam { exception_id }): Query<
-        TrainScheduleExceptionQueryParam,
-    >,
+    Query(ExceptionQueryParam { exception_id }): Query<ExceptionQueryParam>,
 ) -> Result<Json<core_client::etcs_braking_curves::Response>> {
     let authorized = auth
         .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
@@ -1655,6 +1660,7 @@ mod tests {
     use crate::models::fixtures::create_paced_train_with_exceptions;
     use crate::models::fixtures::create_simple_paced_train;
     use crate::models::fixtures::create_small_infra;
+    use crate::models::fixtures::create_timetable;
     use crate::models::fixtures::create_timetable_with_train_schedule_set;
     use crate::models::fixtures::create_train_schedule_exception;
     use crate::models::fixtures::create_train_schedule_set;
@@ -2191,66 +2197,72 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn paced_train_simulation_summary() {
-        let (app, infra_id, paced_train_id, _exception) =
-            app_infra_id_paced_train_id_for_simulation_tests().await;
-        let request = app.get(format!("/train_schedules/{paced_train_id}").as_str());
-        let mut paced_train_response: TrainScheduleResponse = app
-            .fetch(request)
+        // Setup tests tools
+        let core = mocked_core_pathfinding_sim_and_proj();
+        let app = TestAppBuilder::new()
+            .db_pool(DbConnectionPoolV2::for_tests())
+            .core_client(core.into())
+            .build();
+        let db_pool = app.db_pool();
+
+        // Setup tests data
+        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
+
+        let (timetable, train_schedule_set) =
+            create_timetable_with_train_schedule_set(&mut db_pool.get_ok()).await;
+        create_fast_rolling_stock(&mut db_pool.get_ok(), "R2D2").await;
+
+        let train_schedule = TrainSchedule {
+            train_occurrence: schemas::TrainOccurrence::fake(),
+            paced: Some(Paced {
+                time_window: Duration::hours(1).try_into().unwrap(),
+                interval: Duration::minutes(15).try_into().unwrap(),
+                exceptions: vec![],
+            }),
+        };
+        let train_schedule: TrainScheduleChangeset = train_schedule.into();
+        let train_schedule = train_schedule
+            .train_schedule_set_id(train_schedule_set.id)
+            .create(&mut db_pool.get_ok())
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
-        // First remove all already generated exceptions
-        paced_train_response
-            .train_schedule
-            .paced
-            .as_mut()
-            .unwrap()
-            .exceptions
-            .clear();
+            .expect("Failed to create train schedule");
+
         // Add one exception which will not change the simulation from base
-        paced_train_response
-            .train_schedule
-            .paced
-            .as_mut()
-            .unwrap()
-            .exceptions
-            .push(PacedTrainException {
-                key: "change_train_name".to_string(),
-                change_groups: TrainScheduleExceptionChangeGroups {
-                    train_name: Some(TrainNameChangeGroup {
-                        value: "exception_name_but_same_simulation".into(),
-                    }),
-                    ..Default::default()
-                },
+        let _change_train_name_exception = create_train_schedule_exception(
+            &mut db_pool.get_ok(),
+            timetable.id,
+            train_schedule.id,
+            None,
+            Some("change_train_name".to_string()),
+            Some(TrainScheduleExceptionChangeGroups {
+                train_name: Some(TrainNameChangeGroup {
+                    value: "exception_name_but_same_simulation".into(),
+                }),
                 ..Default::default()
-            });
+            }),
+        )
+        .await;
+
         // Add one exception which will change the simulation from base
-        // and therefore add another entry in the response (field `exceptions`)
-        paced_train_response
-            .train_schedule
-            .paced
-            .as_mut()
-            .unwrap()
-            .exceptions
-            .push(PacedTrainException {
-                key: "change_initial_speed".to_string(),
-                change_groups: TrainScheduleExceptionChangeGroups {
-                    initial_speed: Some(InitialSpeedChangeGroup { value: 1.23 }),
-                    ..Default::default()
-                },
+        let _change_train_name_exception = create_train_schedule_exception(
+            &mut db_pool.get_ok(),
+            timetable.id,
+            train_schedule.id,
+            None,
+            Some("change_initial_speed".to_string()),
+            Some(TrainScheduleExceptionChangeGroups {
+                initial_speed: Some(InitialSpeedChangeGroup { value: 1.23 }),
                 ..Default::default()
-            });
-        let request = app
-            .put(format!("/train_schedules/{paced_train_id}").as_str())
-            .json(&json!(paced_train_response.train_schedule));
-        app.fetch(request)
-            .await
-            .assert_status(StatusCode::NO_CONTENT);
+            }),
+        )
+        .await;
+
         let request = app
             .post("/train_schedules/simulation_summary")
             .json(&json!({
-                "infra_id": infra_id,
-                "ids": vec![paced_train_id],
+                "infra_id": small_infra.id,
+                "timetable_id": timetable.id,
+                "ids": vec![train_schedule.id],
             }));
 
         let response: HashMap<i64, TrainScheduleSummaryResponse> = app
@@ -2260,7 +2272,7 @@ mod tests {
             .json_into();
         assert_eq!(response.len(), 1);
         assert_eq!(
-            *response.get(&paced_train_id).unwrap(),
+            *response.get(&train_schedule.id).unwrap(),
             TrainScheduleSummaryResponse {
                 train_schedule: SummaryResponse::Success {
                     length: 15_050_000,
@@ -2297,10 +2309,12 @@ mod tests {
     async fn paced_train_simulation_summary_not_found() {
         let (app, infra_id, _paced_train_id, _exception) =
             app_infra_id_paced_train_id_for_simulation_tests().await;
+        let timetable = create_timetable(&mut app.db_pool().get_ok()).await;
         let request = app
             .post("/train_schedules/simulation_summary")
             .json(&json!({
                 "infra_id": infra_id,
+                "timetable_id": timetable.id,
                 "ids": vec![0],
             }));
         let response: InternalError = app

--- a/front/src/applications/operationalStudies/helpers/TrainSimulationLazyLoader.ts
+++ b/front/src/applications/operationalStudies/helpers/TrainSimulationLazyLoader.ts
@@ -12,6 +12,7 @@ const BATCH_SIZE = 20;
 type TrainSimulationLazyLoaderOptions = {
   dispatch: AppDispatch;
   infraId: number;
+  timetableId: number;
   electricalProfileSetId?: number;
   onProgress: (
     pacedTrainSummaries: Map<PacedTrainId, TrainScheduleSimulationSummaryResult>
@@ -81,6 +82,7 @@ export default class TrainSimulationLazyLoader {
             {
               body: {
                 infra_id: this.options.infraId,
+                timetable_id: this.options.timetableId,
                 ids: editoastIds,
                 electrical_profile_set_id: this.options.electricalProfileSetId,
               },

--- a/front/src/applications/operationalStudies/hooks/useLazySimulateTrains.ts
+++ b/front/src/applications/operationalStudies/hooks/useLazySimulateTrains.ts
@@ -13,6 +13,7 @@ import TrainSimulationLazyLoader from '../helpers/TrainSimulationLazyLoader';
 
 type UseLazySimulateTrainsOptions = {
   infraId: number;
+  timetableId: number;
   electricalProfileSetId: number | undefined;
   rollingStocks: LightRollingStockWithLiveries[] | null;
   onProgress?: (results: Map<TimetableItemId, TimetableItemWithDetails>) => void;
@@ -35,6 +36,7 @@ type UseLazySimulateTrainsOptions = {
  */
 export default function useLazySimulateTrains({
   infraId,
+  timetableId,
   electricalProfileSetId,
   rollingStocks,
   onProgress,
@@ -55,6 +57,7 @@ export default function useLazySimulateTrains({
     const loader = new TrainSimulationLazyLoader({
       dispatch,
       infraId,
+      timetableId,
       electricalProfileSetId,
       onProgress: (
         pacedTrainSummaries: Map<PacedTrainId, TrainScheduleSimulationSummaryResult>

--- a/front/src/applications/operationalStudies/hooks/useScenarioData.ts
+++ b/front/src/applications/operationalStudies/hooks/useScenarioData.ts
@@ -22,7 +22,7 @@ type ScenarioBroadcastMessage =
   | { type: 'removeTimetableItems'; timetableItemIds: TimetableItemId[] }
   | { type: 'setTimetableItemDepartureTime'; timetableItemId: TimetableItemId; newDeparture: Date };
 
-const useScenarioData = (scenario: ScenarioWithDetails, infraId: number) => {
+const useScenarioData = (scenario: ScenarioWithDetails, infraId: number, timetableId: number) => {
   const dispatch = useAppDispatch();
 
   const [timetableItems, setTimetableItems] = useState<TimetableItem[]>();
@@ -86,6 +86,7 @@ const useScenarioData = (scenario: ScenarioWithDetails, infraId: number) => {
     updateSimulatedTimetableItemDepartureTime,
   } = useLazySimulateTrains({
     infraId,
+    timetableId,
     electricalProfileSetId: scenario.electrical_profile_set_id,
     rollingStocks,
     onProgress: (summaries) => {

--- a/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
@@ -46,7 +46,7 @@ const ScenarioContent = ({ activeBoards }: ScenarioContentProps) => {
   const dispatch = useAppDispatch();
   const { scenario, sandboxId } = useScenarioContext();
 
-  const { infraId, isInfraLoaded } = useScenarioContext();
+  const { infraId, timetableId, isInfraLoaded } = useScenarioContext();
 
   const [displayTimetableItemManagement, setDisplayTimetableItemManagement] = useState<string>(
     MANAGE_TIMETABLE_ITEM_TYPES.none
@@ -67,7 +67,7 @@ const ScenarioContent = ({ activeBoards }: ScenarioContentProps) => {
     updateTrainDepartureTime,
     selectedTimetableItemIds,
     setSelectedTimetableItemIds,
-  } = useScenarioData(scenario, infraId);
+  } = useScenarioData(scenario, infraId, timetableId);
 
   const {
     showOnlySelectedTrain,

--- a/front/src/applications/stdcm/hooks/useLinkedTrainSearch.ts
+++ b/front/src/applications/stdcm/hooks/useLinkedTrainSearch.ts
@@ -93,6 +93,7 @@ const useLinkedTrainSearch = () => {
       const trainsSummaries = await postTrainSchedulesSimulationSummary({
         body: {
           infra_id: infraId,
+          timetable_id: timetableId,
           ids: trainsIds,
         },
       }).unwrap();

--- a/front/src/applications/stdcm/hooks/useProjectedTrainsForStdcm.ts
+++ b/front/src/applications/stdcm/hooks/useProjectedTrainsForStdcm.ts
@@ -97,6 +97,7 @@ const useProjectedTrainsForStdcm = (stdcmResponse?: StdcmSuccessResponse) => {
   // Progressive loading of the trains
   const { simulatedTrainsById, simulateTimetableItems } = useLazySimulateTrains({
     infraId,
+    timetableId,
     electricalProfileSetId,
     rollingStocks,
     onProgress: (results) => {

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -2563,6 +2563,7 @@ export type PostTrainSchedulesSimulationSummaryApiArg = {
     electrical_profile_set_id?: number | null;
     ids: number[];
     infra_id: number;
+    timetable_id: number;
   };
 };
 export type PostTrainSchedulesTrackOccupancyApiResponse =


### PR DESCRIPTION
fix https://github.com/OpenRailAssociation/osrd/issues/15592
part of #15202

Adapt GET /paced_train/simulation_summary endpoint with new exceptions

Add timetable_id parameter to the simulation summary endpoint, because exceptions are now linked to a timetable
Fix tests and frontend

> [!NOTE]
> This PR targets a feature branch and may contain all its commits, as it has not been rebased yet. Only the last commit need to be reviewed.