### PR TITLE
pr-tests: force pull on "up"

### DIFF
--- a/scripts/pr-tests-compose.sh
+++ b/scripts/pr-tests-compose.sh
@@ -79,6 +79,11 @@ elif [ "$2" = "up" ] || [ "$2" = "up-and-load-backup" ]; then
 
     export PR_NB="pr-$1"
 
+    docker compose \
+        -p "osrd-pr-tests" \
+        -f "docker/docker-compose.pr-tests.yml" \
+        pull
+
     if [ "$2" = "up-and-load-backup" ]; then
 
         docker compose \


### PR DESCRIPTION
Previously, the script wouldn't pull the pr-test images when testing a PR for a second time. This causes issues to test after someone made changes.