### PR TITLE
front: adapt timetable import

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/generatePayloads.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/generatePayloads.ts
@@ -4,6 +4,7 @@ import type {
   SubCategory,
   TrainCategory,
   TrainMainCategory,
+  PacedTrainException,
 } from 'common/api/osrdEditoastApi';
 import { TrainMainCategoryDict } from 'modules/rollingStock/consts';
 import isMainCategory from 'modules/rollingStock/helpers/category';
@@ -94,10 +95,26 @@ const buildLabels = (
 export function generateTrainPayloads(
   parsedPacedTrains: PacedTrainFromJson[],
   allowedSubCategories: SubCategory[]
-): TrainSchedule[] {
-  return parsedPacedTrains.map((pacedTrain) => ({
-    ...pacedTrain,
-    category: checkCategory(pacedTrain.category, allowedSubCategories),
-    labels: buildLabels(pacedTrain.labels, pacedTrain.category, allowedSubCategories),
-  }));
+): { trainSchedules: TrainSchedule[]; exceptions: PacedTrainException[][] } {
+  const trainSchedules: TrainSchedule[] = [];
+  const exceptions: PacedTrainException[][] = [];
+
+  for (const pacedTrain of parsedPacedTrains) {
+    const { paced, ...trainScheduleBase } = pacedTrain;
+
+    const { exceptions: pacedExceptions } = paced ?? { exceptions: [] };
+
+    trainSchedules.push({
+      ...trainScheduleBase,
+      category: checkCategory(pacedTrain.category, allowedSubCategories),
+      labels: buildLabels(pacedTrain.labels, pacedTrain.category, allowedSubCategories),
+      paced: paced
+        ? { interval: paced.interval, time_window: paced.time_window, exceptions: [] }
+        : undefined,
+    });
+
+    exceptions.push(pacedExceptions);
+  }
+
+  return { trainSchedules, exceptions };
 }

--- a/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/postPayloads.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/postPayloads.ts
@@ -5,8 +5,17 @@ import type {
   RoundTripsFromJson,
   TimetableJsonPayload,
 } from 'applications/operationalStudies/types';
-import { osrdEditoastApi, type MacroNodeForm, type SubCategory } from 'common/api/osrdEditoastApi';
-import { createPacedTrains } from 'modules/timetableItem/helpers/updateTimetableItemHelpers';
+import {
+  osrdEditoastApi,
+  type MacroNodeForm,
+  type PacedTrainException,
+  type SubCategory,
+  type TrainSchedule,
+} from 'common/api/osrdEditoastApi';
+import {
+  createPacedTrains,
+  createExceptions,
+} from 'modules/timetableItem/helpers/updateTimetableItemHelpers';
 import { setWarning, setFailure } from 'reducers/main';
 import type { TimetableItem } from 'reducers/osrdconf/types';
 import type { AppDispatch } from 'store';
@@ -67,6 +76,7 @@ const postMacroNodesIfNew = async (
 
 export const postFullImportPayload = async (
   trainScheduleSetId: number,
+  timetableId: number,
   scenarioId: number,
   timetableJsonPayload: TimetableJsonPayload,
   subCategories: SubCategory[],
@@ -76,14 +86,27 @@ export const postFullImportPayload = async (
 ): Promise<TimetableItem[]> => {
   try {
     const { round_trips, macro_nodes, macro_notes } = timetableJsonPayload;
-    const pacedTrains = generateTrainPayloads(timetableJsonPayload.paced_trains, subCategories);
+    const {
+      trainSchedules,
+      exceptions,
+    }: { trainSchedules: TrainSchedule[]; exceptions: PacedTrainException[][] } =
+      generateTrainPayloads(timetableJsonPayload.paced_trains, subCategories);
 
     const timetableItems: TimetableItem[] = [];
 
     const BATCH_SIZE = 1000;
-    const trainChunks = chunk(pacedTrains, BATCH_SIZE);
+    const trainChunks = chunk(trainSchedules, BATCH_SIZE);
     for (const trainChunk of trainChunks) {
-      timetableItems.push(...(await createPacedTrains(dispatch, trainScheduleSetId, trainChunk)));
+      const createdTrains = await createPacedTrains(dispatch, trainScheduleSetId, trainChunk);
+      timetableItems.push(...createdTrains);
+    }
+
+    // TODO: when batch POST is available, replace this loop with a single batch call
+    const exceptionsWithTrainIds = exceptions
+      .map((trainExceptions, i) => ({ trainExceptions, pacedTrainId: timetableItems[i].id }))
+      .filter(({ trainExceptions }) => trainExceptions.length > 0);
+    for (const { trainExceptions, pacedTrainId } of exceptionsWithTrainIds) {
+      await createExceptions(dispatch, trainExceptions, pacedTrainId, timetableId);
     }
 
     if (round_trips) {

--- a/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/useImportTimetableItems.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/useImportTimetableItems.ts
@@ -60,6 +60,7 @@ const useImportTimetableItems = ({ upsertTimetableItems }: ImportTimetableItemsP
 
       const importedTimetableItems = await postFullImportPayload(
         sandboxId,
+        scenario.timetable_id,
         scenario.id,
         timetableJsonPayload,
         subCategories,

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TimetableBoardWrapper.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TimetableBoardWrapper.tsx
@@ -219,6 +219,7 @@ const TimetableBoardWrapper = ({
 
       const newTimetableItems = await postFullImportPayload(
         sandboxId,
+        scenario.timetable_id,
         scenario.id,
         importedPayload,
         subCategories,

--- a/front/src/modules/timetableItem/helpers/updateTimetableItemHelpers.ts
+++ b/front/src/modules/timetableItem/helpers/updateTimetableItemHelpers.ts
@@ -1,9 +1,9 @@
 import {
   osrdEditoastApi,
-  type PacedTrainException,
   type TrainSchedule,
   type TrainScheduleException,
   type TrainScheduleResponse,
+  type PacedTrainException,
 } from 'common/api/osrdEditoastApi';
 import type { PacedTrainId, TimetableItem, TimetableItemId } from 'reducers/osrdconf/types';
 import {


### PR DESCRIPTION
closes https://github.com/OpenRailAssociation/osrd/issues/15209

This PR updates the import logic to move exceptions from paced.exceptions into the new dedicated exceptions table.
Instead of being included in the TrainSchedule payload, exceptions are now created separately via the exceptions endpoint.