### PR TITLE
core, editoast: change the stdcm api to allow consist changes

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/cli/BenchSTDCM.kt
+++ b/core/src/main/java/fr/sncf/osrd/cli/BenchSTDCM.kt
@@ -177,9 +177,10 @@ class BenchSTDCM : CliCommand {
                         buildTemporarySpeedLimitManager(infra, request.temporarySpeedLimits)
                     val rollingStock =
                         parseRawRollingStock(
-                            request.physicsConsist,
-                            request.rollingStockLoadingGauge,
-                            request.rollingStockSupportedSignalingSystems.filter {
+                            request.consistSchedule.values[0].physicsConsist,
+                            request.consistSchedule.values[0].loadingGaugeType,
+                            request.consistSchedule.values[0].supportedSignalingSystems.filter {
+                                // Ignoring ETCS as it is not (yet) supported for STDCM
                                 it != ETCS_LEVEL2.id
                             },
                         )
@@ -205,7 +206,7 @@ class BenchSTDCM : CliCommand {
                             request.timeStep.seconds,
                             request.maximumDepartureDelay!!.seconds,
                             request.maximumRunTime.seconds,
-                            request.speedLimitTag,
+                            request.consistSchedule.values[0].speedLimitTag,
                             parseMarginValue(request.margin),
                             Pathfinding.TIMEOUT,
                             temporarySpeedLimitManager,

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
@@ -114,9 +114,9 @@ class STDCMEndpoint(
                 buildTemporarySpeedLimitManager(infra, request.temporarySpeedLimits)
             val rollingStock =
                 parseRawRollingStock(
-                    request.physicsConsist,
-                    request.rollingStockLoadingGauge,
-                    request.rollingStockSupportedSignalingSystems.filter {
+                    request.consistSchedule.values[0].physicsConsist,
+                    request.consistSchedule.values[0].loadingGaugeType,
+                    request.consistSchedule.values[0].supportedSignalingSystems.filter {
                         // Ignoring ETCS as it is not (yet) supported for STDCM
                         it != ETCS_LEVEL2.id
                     },
@@ -145,7 +145,7 @@ class STDCMEndpoint(
                     request.timeStep.seconds,
                     request.maximumDepartureDelay!!.seconds,
                     request.maximumRunTime.seconds,
-                    request.speedLimitTag,
+                    request.consistSchedule.values[0].speedLimitTag,
                     parseMarginValue(request.margin),
                     Pathfinding.TIMEOUT,
                     temporarySpeedLimitManager,
@@ -166,7 +166,7 @@ class STDCMEndpoint(
                     infra,
                     path,
                     rollingStock,
-                    request.speedLimitTag,
+                    request.consistSchedule.values[0].speedLimitTag,
                     temporarySpeedLimitManager,
                     request.comfort,
                 )

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMRequest.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMRequest.kt
@@ -25,21 +25,17 @@ class STDCMRequest(
     @Json(name = "expected_version") var expectedVersion: Int,
     @Json(name = "timetable_id") var timetableId: TimetableId,
 
-    // Rolling stock
-    @Json(name = "physics_consist") val physicsConsist: PhysicsConsistModel,
+    // Rolling stocks
+    @Json(name = "consist_schedule") val consistSchedule: ConsistSchedule,
 
     // Pathfinding inputs
     /// List of waypoints. Each waypoint is a list of track offsets
     @Json(name = "path_items") val pathItems: List<STDCMPathItem>,
-    @Json(name = "rolling_stock_loading_gauge") val rollingStockLoadingGauge: RJSLoadingGaugeType,
     // TODO: migrate this to structured SupportedSignalingSystem like editoast for ETCS support of
     // brake params
-    @Json(name = "rolling_stock_supported_signaling_systems")
-    val rollingStockSupportedSignalingSystems: List<String>,
 
     // Simulation inputs
     val comfort: Comfort,
-    @Json(name = "speed_limit_tag") val speedLimitTag: String?,
 
     // STDCM search parameters
     /// Numerical integration time step. Defaults to 2s.
@@ -77,6 +73,18 @@ data class StepTimingData(
     @Json(name = "arrival_time") val arrivalTime: ZonedDateTime,
     @Json(name = "arrival_time_tolerance_before") val arrivalTimeToleranceBefore: Duration,
     @Json(name = "arrival_time_tolerance_after") val arrivalTimeToleranceAfter: Duration,
+)
+
+data class ConsistSchedule(
+    @Json(name = "boundaries") val boundaries: List<Int>,
+    @Json(name = "values") val values: List<ConsistConfiguration>,
+)
+
+data class ConsistConfiguration(
+    @Json(name = "supported_signaling_systems") val supportedSignalingSystems: List<String>,
+    @Json(name = "speed_limit_tag") val speedLimitTag: String?,
+    @Json(name = "loading_gauge_type") val loadingGaugeType: RJSLoadingGaugeType,
+    @Json(name = "physics_consist") val physicsConsist: PhysicsConsistModel,
 )
 
 val stdcmRequestAdapter: JsonAdapter<STDCMRequest> =

--- a/editoast/core_client/src/stdcm.rs
+++ b/editoast/core_client/src/stdcm.rs
@@ -31,19 +31,13 @@ pub struct Request {
     // Pathfinding inputs
     /// List of waypoints. Each waypoint is a list of track offset.
     pub path_items: Vec<PathItem>,
-    /// The loading gauge of the rolling stock
-    pub rolling_stock_loading_gauge: LoadingGaugeType,
     /// Set of authorized track section ids for the current request
     pub allowed_track_sections: Option<HashSet<String>>,
-    /// List of supported signaling systems
-    pub rolling_stock_supported_signaling_systems: Vec<String>,
 
     // Simulation inputs
     /// The comfort of the train
     pub comfort: Comfort,
-    pub speed_limit_tag: Option<String>,
-    #[schema(inline)]
-    pub physics_consist: PhysicsConsist,
+    pub consist_schedule: ConsistSchedule,
 
     // STDCM search parameters
     /// Numerical integration time step in milliseconds. Use default value if not specified.
@@ -123,6 +117,26 @@ pub struct UndirectedTrackRange {
     pub begin: u64,
     /// The end of the range in mm.
     pub end: u64,
+}
+
+/// Represents a physics consist.
+#[derive(Serialize, Deserialize, Clone, Debug, ToSchema, Hash, PartialEq, Eq)]
+pub struct ConsistConfiguration {
+    /// List of supported signaling systems
+    pub supported_signaling_systems: Vec<String>,
+    pub speed_limit_tag: Option<String>,
+    /// The loading gauge of the rolling stock
+    pub loading_gauge_type: LoadingGaugeType,
+    #[schema(inline)]
+    pub physics_consist: PhysicsConsist,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, ToSchema, Hash, PartialEq, Eq)]
+pub struct ConsistSchedule {
+    // Indices of steps where consist changes occur
+    pub boundaries: Vec<usize>,
+    // Consist configuration for each segment
+    pub values: Vec<ConsistConfiguration>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -5202,6 +5202,126 @@ components:
             type: integer
             format: int64
           description: List of work schedule ids involved in the conflict
+    ConsistConfiguration:
+      type: object
+      description: Represents a physics consist.
+      required:
+      - supported_signaling_systems
+      - loading_gauge_type
+      - physics_consist
+      properties:
+        loading_gauge_type:
+          $ref: '#/components/schemas/LoadingGaugeType'
+          description: The loading gauge of the rolling stock
+        physics_consist:
+          type: object
+          required:
+          - effort_curves
+          - length
+          - max_speed
+          - startup_time
+          - startup_acceleration
+          - comfort_acceleration
+          - const_gamma
+          - inertia_coefficient
+          - mass
+          - rolling_resistance
+          properties:
+            base_power_class:
+              type:
+              - string
+              - 'null'
+            comfort_acceleration:
+              type: number
+              format: double
+              description: Acceleration in m·s⁻²
+            const_gamma:
+              type: number
+              format: double
+              description: |2-
+                 The constant gamma braking coefficient used when NOT circulating
+                 under ETCS/ERTMS signaling system
+                Acceleration in m·s⁻²
+            effort_curves:
+              $ref: '#/components/schemas/EffortCurves'
+            electrical_power_startup_time:
+              type:
+              - integer
+              - 'null'
+              format: int64
+              description: |-
+                The time the train takes before actually using electrical power.
+                Is null if the train is not electric or the value not specified.
+              minimum: 0
+            etcs_brake_params:
+              oneOf:
+              - type: 'null'
+              - $ref: '#/components/schemas/EtcsBrakeParams'
+            inertia_coefficient:
+              type: number
+              format: double
+            length:
+              type: integer
+              format: int64
+              minimum: 0
+            mass:
+              type: integer
+              format: int64
+              minimum: 0
+            max_speed:
+              type: number
+              format: double
+              description: Velocity in m·s⁻¹
+            power_restrictions:
+              type: object
+              description: Mapping of power restriction code to power class
+              additionalProperties:
+                type: string
+              propertyNames:
+                type: string
+            raise_pantograph_time:
+              type:
+              - integer
+              - 'null'
+              format: int64
+              description: |-
+                The time it takes to raise this train's pantograph.
+                Is null if the train is not electric or the value not specified.
+              minimum: 0
+            rolling_resistance:
+              $ref: '#/components/schemas/RollingResistance'
+            startup_acceleration:
+              type: number
+              format: double
+              description: Acceleration in m·s⁻²
+            startup_time:
+              type: integer
+              format: int64
+              minimum: 0
+        speed_limit_tag:
+          type:
+          - string
+          - 'null'
+        supported_signaling_systems:
+          type: array
+          items:
+            type: string
+          description: List of supported signaling systems
+    ConsistSchedule:
+      type: object
+      required:
+      - boundaries
+      - values
+      properties:
+        boundaries:
+          type: array
+          items:
+            type: integer
+            minimum: 0
+        values:
+          type: array
+          items:
+            $ref: '#/components/schemas/ConsistConfiguration'
     ConstraintDistributionChangeGroup:
       type: object
       required:
@@ -15391,10 +15511,8 @@ components:
       - expected_version
       - timetable_id
       - path_items
-      - rolling_stock_loading_gauge
-      - rolling_stock_supported_signaling_systems
       - comfort
-      - physics_consist
+      - consist_schedule
       - start_time
       - maximum_departure_delay
       - maximum_run_time
@@ -15414,6 +15532,8 @@ components:
         comfort:
           $ref: '#/components/schemas/Comfort'
           description: The comfort of the train
+        consist_schedule:
+          $ref: '#/components/schemas/ConsistSchedule'
         expected_version:
           type: integer
           format: int64
@@ -15456,103 +15576,6 @@ components:
           items:
             $ref: '#/components/schemas/core.PathItem'
           description: List of waypoints. Each waypoint is a list of track offset.
-        physics_consist:
-          type: object
-          required:
-          - effort_curves
-          - length
-          - max_speed
-          - startup_time
-          - startup_acceleration
-          - comfort_acceleration
-          - const_gamma
-          - inertia_coefficient
-          - mass
-          - rolling_resistance
-          properties:
-            base_power_class:
-              type:
-              - string
-              - 'null'
-            comfort_acceleration:
-              type: number
-              format: double
-              description: Acceleration in m·s⁻²
-            const_gamma:
-              type: number
-              format: double
-              description: |2-
-                 The constant gamma braking coefficient used when NOT circulating
-                 under ETCS/ERTMS signaling system
-                Acceleration in m·s⁻²
-            effort_curves:
-              $ref: '#/components/schemas/EffortCurves'
-            electrical_power_startup_time:
-              type:
-              - integer
-              - 'null'
-              format: int64
-              description: |-
-                The time the train takes before actually using electrical power.
-                Is null if the train is not electric or the value not specified.
-              minimum: 0
-            etcs_brake_params:
-              oneOf:
-              - type: 'null'
-              - $ref: '#/components/schemas/EtcsBrakeParams'
-            inertia_coefficient:
-              type: number
-              format: double
-            length:
-              type: integer
-              format: int64
-              minimum: 0
-            mass:
-              type: integer
-              format: int64
-              minimum: 0
-            max_speed:
-              type: number
-              format: double
-              description: Velocity in m·s⁻¹
-            power_restrictions:
-              type: object
-              description: Mapping of power restriction code to power class
-              additionalProperties:
-                type: string
-              propertyNames:
-                type: string
-            raise_pantograph_time:
-              type:
-              - integer
-              - 'null'
-              format: int64
-              description: |-
-                The time it takes to raise this train's pantograph.
-                Is null if the train is not electric or the value not specified.
-              minimum: 0
-            rolling_resistance:
-              $ref: '#/components/schemas/RollingResistance'
-            startup_acceleration:
-              type: number
-              format: double
-              description: Acceleration in m·s⁻²
-            startup_time:
-              type: integer
-              format: int64
-              minimum: 0
-        rolling_stock_loading_gauge:
-          $ref: '#/components/schemas/LoadingGaugeType'
-          description: The loading gauge of the rolling stock
-        rolling_stock_supported_signaling_systems:
-          type: array
-          items:
-            type: string
-          description: List of supported signaling systems
-        speed_limit_tag:
-          type:
-          - string
-          - 'null'
         start_time:
           type: string
           format: date-time

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -13,6 +13,8 @@ use core_client::AsCoreRequest;
 use core_client::CoreClient;
 use core_client::pathfinding::InvalidPathItem;
 use core_client::pathfinding::PathfindingResultSuccess;
+use core_client::stdcm::ConsistConfiguration;
+use core_client::stdcm::ConsistSchedule;
 use core_client::stdcm::Request as StdcmRequest;
 use core_client::stdcm::UndirectedTrackRange;
 use database::DbConnectionPoolV2;
@@ -294,14 +296,20 @@ pub(in crate::views) async fn stdcm_handler(
         infra: infra.id,
         expected_version: infra.version,
         timetable_id,
-        rolling_stock_loading_gauge: request
-            .loading_gauge_type
-            .unwrap_or(physics_consist_parameters.traction_engine.loading_gauge),
         allowed_track_sections: request.allowed_track_sections.clone(),
-        rolling_stock_supported_signaling_systems: physics_consist_parameters
-            .traction_engine
-            .supported_signaling_systems(),
-        physics_consist: physics_consist_parameters.into(),
+        consist_schedule: ConsistSchedule {
+            boundaries: vec![],
+            values: vec![ConsistConfiguration {
+                loading_gauge_type: request
+                    .loading_gauge_type
+                    .unwrap_or(physics_consist_parameters.traction_engine.loading_gauge),
+                supported_signaling_systems: physics_consist_parameters
+                    .traction_engine
+                    .supported_signaling_systems(),
+                speed_limit_tag: request.speed_limit_tags.clone(),
+                physics_consist: physics_consist_parameters.into(),
+            }],
+        },
         temporary_speed_limits: request
             .get_temporary_speed_limits(&mut conn, simulation_run_time)
             .await?,
@@ -310,7 +318,6 @@ pub(in crate::views) async fn stdcm_handler(
         start_time: earliest_departure_time,
         maximum_departure_delay: request.get_maximum_departure_delay(simulation_run_time),
         maximum_run_time: request.get_maximum_run_time(simulation_run_time),
-        speed_limit_tag: request.speed_limit_tags.clone(),
         time_gap_before: request.time_gap_before,
         time_gap_after: request.time_gap_after,
         margin: request.margin,

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -4733,6 +4733,47 @@ export type CoreTrainRequirementsById = {
   /** ID that can be used to find the train in tools other than OSRD. Used in debug traces. */
   train_name: string;
 };
+export type ConsistConfiguration = {
+  /** The loading gauge of the rolling stock */
+  loading_gauge_type: LoadingGaugeType;
+  physics_consist: {
+    base_power_class?: string | null;
+    /** Acceleration in m·s⁻² */
+    comfort_acceleration: number;
+    /**  The constant gamma braking coefficient used when NOT circulating
+         under ETCS/ERTMS signaling system
+        Acceleration in m·s⁻² */
+    const_gamma: number;
+    effort_curves: EffortCurves;
+    /** The time the train takes before actually using electrical power.
+        Is null if the train is not electric or the value not specified. */
+    electrical_power_startup_time?: number | null;
+    etcs_brake_params?: null | EtcsBrakeParams;
+    inertia_coefficient: number;
+    length: number;
+    mass: number;
+    /** Velocity in m·s⁻¹ */
+    max_speed: number;
+    /** Mapping of power restriction code to power class */
+    power_restrictions?: {
+      [key: string]: string;
+    };
+    /** The time it takes to raise this train's pantograph.
+        Is null if the train is not electric or the value not specified. */
+    raise_pantograph_time?: number | null;
+    rolling_resistance: RollingResistance;
+    /** Acceleration in m·s⁻² */
+    startup_acceleration: number;
+    startup_time: number;
+  };
+  speed_limit_tag?: string | null;
+  /** List of supported signaling systems */
+  supported_signaling_systems: string[];
+};
+export type ConsistSchedule = {
+  boundaries: number[];
+  values: ConsistConfiguration[];
+};
 export type CoreStepTimingData = {
   /** Time the train should arrive at this point */
   arrival_time: string;
@@ -4769,6 +4810,7 @@ export type CoreStdcmRequest = {
   allowed_track_sections?: string[] | null;
   /** The comfort of the train */
   comfort: Comfort;
+  consist_schedule: ConsistSchedule;
   /** Infrastructure expected version */
   expected_version: number;
   /** Infrastructure id */
@@ -4790,41 +4832,6 @@ export type CoreStdcmRequest = {
   maximum_run_time: number;
   /** List of waypoints. Each waypoint is a list of track offset. */
   path_items: CorePathItem[];
-  physics_consist: {
-    base_power_class?: string | null;
-    /** Acceleration in m·s⁻² */
-    comfort_acceleration: number;
-    /**  The constant gamma braking coefficient used when NOT circulating
-         under ETCS/ERTMS signaling system
-        Acceleration in m·s⁻² */
-    const_gamma: number;
-    effort_curves: EffortCurves;
-    /** The time the train takes before actually using electrical power.
-        Is null if the train is not electric or the value not specified. */
-    electrical_power_startup_time?: number | null;
-    etcs_brake_params?: null | EtcsBrakeParams;
-    inertia_coefficient: number;
-    length: number;
-    mass: number;
-    /** Velocity in m·s⁻¹ */
-    max_speed: number;
-    /** Mapping of power restriction code to power class */
-    power_restrictions?: {
-      [key: string]: string;
-    };
-    /** The time it takes to raise this train's pantograph.
-        Is null if the train is not electric or the value not specified. */
-    raise_pantograph_time?: number | null;
-    rolling_resistance: RollingResistance;
-    /** Acceleration in m·s⁻² */
-    startup_acceleration: number;
-    startup_time: number;
-  };
-  /** The loading gauge of the rolling stock */
-  rolling_stock_loading_gauge: LoadingGaugeType;
-  /** List of supported signaling systems */
-  rolling_stock_supported_signaling_systems: string[];
-  speed_limit_tag?: string | null;
   start_time: string;
   /** List of applicable temporary speed limits between the train departure and arrival */
   temporary_speed_limits: {


### PR DESCRIPTION
Part of https://github.com/osrd-project/osrd-confidential/issues/809.

This PR changes the api between core and editoast in anticipation of handling consist changes for a given train schedule in the simulation. For now, core takes the first consist sent by editoast and applies it to the whole simulation as before and editoast sends a single consist and no consist change to core.