### PR TITLE
Use "chenille" pathfinding positions when possible

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
@@ -419,6 +419,7 @@ const SimulationResults = ({
             pathProperties={
               simulationResults?.isValid ? simulationResults.pathProperties : undefined
             }
+            pathfindingResults={simulationResults?.isValid ? simulationResults.path : undefined}
             setMapCanvas={setMapCanvas}
           />
         </div>

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
@@ -292,6 +292,7 @@ const SimulationResults = ({
                 pathProperties={
                   simulationResults.isValid ? simulationResults.pathProperties : undefined
                 }
+                pathfindingResults={simulationResults.isValid ? simulationResults.path : undefined}
                 setMapCanvas={setMapCanvas}
               />
             </div>

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResultsMap.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResultsMap.tsx
@@ -11,13 +11,19 @@ import usePathOps from 'applications/operationalStudies/hooks/usePathOps';
 import { useScenarioContext } from 'applications/operationalStudies/hooks/useScenarioContext';
 import type { PathPropertiesFormatted } from 'applications/operationalStudies/types';
 import { matchOpRefAndOp } from 'applications/operationalStudies/utils';
-import type { RelatedOperationalPoint, TrainSchedule } from 'common/api/osrdEditoastApi';
+import type {
+  CorePathfindingResultSuccess,
+  RelatedOperationalPoint,
+  TrainSchedule,
+} from 'common/api/osrdEditoastApi';
 import BaseMap from 'common/Map/BaseMap';
 import MapButtons from 'common/Map/Buttons/MapButtons';
 import PathStepMarker, { type PathStepsMarkerProps } from 'common/Map/components/PathStepMarker';
 import { MapContextProvider } from 'common/Map/useMapContext';
 import { computeBBoxViewport } from 'common/Map/WarpedMap/core/helpers';
 import { LAYER_GROUPS_ORDER, LAYERS } from 'config/layerOrder';
+import getPointOnPathCoordinates from 'modules/pathfinding/helpers/getPointOnPathCoordinates';
+import getTrackLengthCumulativeSums from 'modules/pathfinding/helpers/getTrackLengthCumulativeSums';
 import Itinerary from 'modules/simulationResult/components/SimulationResultsMap/RenderItinerary';
 import { useMapSettings, useMapSettingsActions } from 'reducers/commonMap';
 import type { MapSettings, Viewport } from 'reducers/commonMap/types';
@@ -30,12 +36,14 @@ const MAP_ID = 'simulation-result-map';
 type SimulationResultMapProps = {
   pathSteps?: TrainSchedule['path'];
   pathProperties?: PathPropertiesFormatted;
+  pathfindingResults?: CorePathfindingResultSuccess;
   setMapCanvas?: (mapCanvas: string) => void;
 };
 
 const SimulationResultMap = ({
   pathSteps,
   pathProperties,
+  pathfindingResults,
   setMapCanvas,
 }: SimulationResultMapProps) => {
   const { t } = useTranslation('operational-studies', {
@@ -78,7 +86,8 @@ const SimulationResultMap = ({
     const getPathItemsCoordinates = async (
       steps: TrainSchedule['path'],
       matchedOps: Map<string, RelatedOperationalPoint | null>,
-      pathPropertiesOps?: PathPropertiesFormatted['operationalPoints']
+      pathPropertiesOps?: PathPropertiesFormatted['operationalPoints'],
+      simulatedPath?: CorePathfindingResultSuccess
     ) => {
       // 1. Get path steps track ids to fetch their track metadata
       const allTrackIds = steps.reduce<string[]>((acc, step) => {
@@ -99,6 +108,15 @@ const SimulationResultMap = ({
       // 2. Build markers data
       const markers = steps.map((step, index) => {
         const { location } = step;
+
+        const simulatedCoordinates = simulatedPath
+          ? getPointOnPathCoordinates(
+              trackSectionsById,
+              simulatedPath.path.track_section_ranges,
+              getTrackLengthCumulativeSums(simulatedPath.path.track_section_ranges),
+              simulatedPath.path_item_positions[index]
+            )
+          : null;
 
         const markerIndicator = (index + 1).toString();
 
@@ -140,22 +158,16 @@ const SimulationResultMap = ({
 
           if (!matchedOp) return null;
 
-          const correspondingTrack = trackSectionsById[matchedOp.part.track];
-          const coordinates = correspondingTrack
-            ? getPointOnTrackCoordinates(
-                correspondingTrack.geo,
-                correspondingTrack.length,
-                matchedOp.part.position
-              )
-            : null;
-
-          if (!coordinates) return null;
+          if (!simulatedCoordinates)
+            throw new Error(
+              'Simulated coordinates should not be undefined when there is a simulated path'
+            );
 
           return {
             id: step.id,
             markerIndicator,
             name: matchedOp.name,
-            coordinates,
+            coordinates: simulatedCoordinates,
           };
         } else {
           const matchedOp = matchedOps.get(step.id);
@@ -175,7 +187,7 @@ const SimulationResultMap = ({
             id: step.id,
             markerIndicator,
             name: matchedOp.name,
-            coordinates,
+            coordinates: simulatedCoordinates ?? coordinates,
           };
         }
       });
@@ -187,10 +199,16 @@ const SimulationResultMap = ({
       getPathItemsCoordinates(
         pathSteps,
         pathStepsOperationalPoints,
-        pathProperties?.operationalPoints
+        pathProperties?.operationalPoints,
+        pathfindingResults
       );
     }
-  }, [pathSteps, pathStepsOperationalPoints, pathProperties?.operationalPoints]);
+  }, [
+    pathSteps,
+    pathStepsOperationalPoints,
+    pathProperties?.operationalPoints,
+    pathfindingResults,
+  ]);
 
   const interactiveLayerIds = useMemo(
     () => (geojsonPath ? ['geojsonPath', 'main-train-path'] : []),

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResultsMap.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResultsMap.tsx
@@ -11,13 +11,19 @@ import usePathOps from 'applications/operationalStudies/hooks/usePathOps';
 import { useScenarioContext } from 'applications/operationalStudies/hooks/useScenarioContext';
 import type { PathPropertiesFormatted } from 'applications/operationalStudies/types';
 import { matchOpRefAndOp } from 'applications/operationalStudies/utils';
-import type { RelatedOperationalPoint, TrainSchedule } from 'common/api/osrdEditoastApi';
+import type {
+  CorePathfindingResultSuccess,
+  RelatedOperationalPoint,
+  TrainSchedule,
+} from 'common/api/osrdEditoastApi';
 import BaseMap from 'common/Map/BaseMap';
 import MapButtons from 'common/Map/Buttons/MapButtons';
 import PathStepMarker, { type PathStepsMarkerProps } from 'common/Map/components/PathStepMarker';
 import { MapContextProvider } from 'common/Map/useMapContext';
 import { computeBBoxViewport } from 'common/Map/WarpedMap/core/helpers';
 import { LAYER_GROUPS_ORDER, LAYERS } from 'config/layerOrder';
+import getPointOnPathCoordinates from 'modules/pathfinding/helpers/getPointOnPathCoordinates';
+import getTrackLengthCumulativeSums from 'modules/pathfinding/helpers/getTrackLengthCumulativeSums';
 import Itinerary from 'modules/simulationResult/components/SimulationResultsMap/RenderItinerary';
 import { useMapSettings, useMapSettingsActions } from 'reducers/commonMap';
 import type { MapSettings, Viewport } from 'reducers/commonMap/types';
@@ -30,12 +36,14 @@ const MAP_ID = 'simulation-result-map';
 type SimulationResultMapProps = {
   pathSteps: TrainSchedule['path'];
   pathProperties?: PathPropertiesFormatted;
+  pathfindingResults?: CorePathfindingResultSuccess;
   setMapCanvas?: (mapCanvas: string) => void;
 };
 
 const SimulationResultMap = ({
   pathSteps,
   pathProperties,
+  pathfindingResults,
   setMapCanvas,
 }: SimulationResultMapProps) => {
   const { t } = useTranslation('operational-studies', {
@@ -78,7 +86,8 @@ const SimulationResultMap = ({
     const getPathItemsCoordinates = async (
       steps: TrainSchedule['path'],
       matchedOps: Map<string, RelatedOperationalPoint[]>,
-      pathPropertiesOps?: PathPropertiesFormatted['operationalPoints']
+      pathPropertiesOps?: PathPropertiesFormatted['operationalPoints'],
+      simulatedPath?: CorePathfindingResultSuccess
     ) => {
       // 1. Get path steps track ids to fetch their track metadata
       const allTrackIds = steps.reduce<string[]>((acc, step) => {
@@ -99,6 +108,15 @@ const SimulationResultMap = ({
       // 2. Build markers data
       const markers = steps.map((step, index) => {
         const { location } = step;
+
+        const simulatedCoordinates = simulatedPath
+          ? getPointOnPathCoordinates(
+              trackSectionsById,
+              simulatedPath.path.track_section_ranges,
+              getTrackLengthCumulativeSums(simulatedPath.path.track_section_ranges),
+              simulatedPath.path_item_positions[index]
+            )
+          : null;
 
         const markerIndicator = (index + 1).toString();
 
@@ -131,7 +149,7 @@ const SimulationResultMap = ({
             id: step.id,
             markerIndicator,
             name,
-            coordinates,
+            coordinates: simulatedCoordinates ?? coordinates,
           };
         }
 
@@ -155,7 +173,7 @@ const SimulationResultMap = ({
             id: step.id,
             markerIndicator,
             name: matchedOp.extensions?.identifier?.name || '',
-            coordinates,
+            coordinates: simulatedCoordinates ?? coordinates,
           };
         } else {
           const matchedOp = matchedOps.get(step.id)?.at(0);
@@ -175,7 +193,7 @@ const SimulationResultMap = ({
             id: step.id,
             markerIndicator,
             name: matchedOp.extensions?.identifier?.name || '',
-            coordinates,
+            coordinates: simulatedCoordinates ?? coordinates,
           };
         }
       });
@@ -187,10 +205,16 @@ const SimulationResultMap = ({
       getPathItemsCoordinates(
         pathSteps,
         pathStepsOperationalPoints,
-        pathProperties?.operationalPoints
+        pathProperties?.operationalPoints,
+        pathfindingResults
       );
     }
-  }, [pathSteps, pathStepsOperationalPoints, pathProperties?.operationalPoints]);
+  }, [
+    pathSteps,
+    pathStepsOperationalPoints,
+    pathProperties?.operationalPoints,
+    pathfindingResults,
+  ]);
 
   const interactiveLayerIds = useMemo(
     () => (geojsonPath ? ['geojsonPath', 'main-train-path'] : []),


### PR DESCRIPTION
New map markers were not using simulated path data, when it's needed to place stops at the actual end of block when `stops_at_the_end_of_block` flag is set for the train.

closes #15447 