### PR TITLE
core: add DistanceRangeSubMap

### DIFF
--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/EnvelopeTrainPath.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/EnvelopeTrainPath.kt
@@ -56,7 +56,7 @@ object EnvelopeTrainPath {
     ): Map<String, DistanceRangeMap<Electrification>> {
         val res = mutableMapOf<String, DistanceRangeMap<Electrification>>()
         for (entry in profileMap.entries) {
-            val electrificationMapWithProfiles = electrificationMap.clone()
+            val electrificationMapWithProfiles = electrificationMap.toMutableDistanceRangeMap()
             electrificationMapWithProfiles.updateMapIntersection(entry.value) {
                 obj: Electrification,
                 profile: String ->

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathImpl.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathImpl.kt
@@ -309,8 +309,11 @@ data class TrainPathImpl(
                 .filter { !it.isSinglePoint() }
                 .flatMap {
                     getData(it.value)
-                        .subMap(it.objectBegin.distance, it.objectEnd.distance)
-                        .shiftPositions(it.pathBegin.distance - it.objectBegin.distance)
+                        .subMap(
+                            lower = it.objectBegin.distance,
+                            upper = it.objectEnd.distance,
+                            shift = it.pathBegin.distance - it.objectBegin.distance,
+                        )
                 }
         return distanceRangeMapOf(entries)
     }

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/legacy_objects/ElectricalProfileMapping.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/legacy_objects/ElectricalProfileMapping.kt
@@ -19,13 +19,13 @@ class ElectricalProfileMapping {
      * Internal representation: {"power class": {"track section": {"range": "electrical profile
      * value"}}}
      */
-    var mapping = HashMap<String, HashMap<String, DistanceRangeMap<String>>>()
+    var mapping = HashMap<String, HashMap<String, MutableDistanceRangeMap<String>>>()
 
     /** Parse the rjs profiles and store them in the internal mapping. */
     fun parseRJS(rjsProfileSet: RJSElectricalProfileSet) {
         assert(mapping.isEmpty())
         for (rjsProfile in rjsProfileSet.levels) {
-            val trackMapping: HashMap<String, DistanceRangeMap<String>> =
+            val trackMapping: HashMap<String, MutableDistanceRangeMap<String>> =
                 mapping.computeIfAbsent(rjsProfile.powerClass) { _: String? -> HashMap() }
             for (trackRange in rjsProfile.trackRanges) {
                 val rangeMapping =
@@ -62,21 +62,20 @@ class ElectricalProfileMapping {
     fun getProfilesOnChunk(
         infra: RawInfra,
         chunk: TrackChunkId,
-        mapping: HashMap<String, DistanceRangeMap<String>>,
+        mapping: HashMap<String, MutableDistanceRangeMap<String>>,
     ): DistanceRangeMap<String> {
         val chunkOffset = infra.getTrackChunkOffset(chunk)
         val trackId = infra.getTrackFromChunk(chunk)
         val trackName = infra.getTrackSectionName(trackId)
-        var profilesOnChunk = distanceRangeMapOf<String>()
-        if (mapping.containsKey(trackName)) {
+        return if (mapping.containsKey(trackName)) {
             val trackProfiles = mapping[trackName]!!
-            profilesOnChunk =
-                trackProfiles.subMap(
-                    lower = chunkOffset.distance,
-                    upper = chunkOffset.distance + infra.getTrackChunkLength(chunk).distance,
-                    shift = -chunkOffset.distance,
-                )
+            trackProfiles.subMap(
+                lower = chunkOffset.distance,
+                upper = chunkOffset.distance + infra.getTrackChunkLength(chunk).distance,
+                shift = -chunkOffset.distance,
+            )
+        } else {
+            distanceRangeMapOf()
         }
-        return profilesOnChunk
     }
 }

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/legacy_objects/ElectricalProfileMapping.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/legacy_objects/ElectricalProfileMapping.kt
@@ -5,7 +5,7 @@ import fr.sncf.osrd.railjson.schema.external_generated_inputs.RJSElectricalProfi
 import fr.sncf.osrd.sim_infra.api.RawInfra
 import fr.sncf.osrd.sim_infra.api.TrackChunkId
 import fr.sncf.osrd.utils.DistanceRangeMap
-import fr.sncf.osrd.utils.DistanceRangeMapImpl
+import fr.sncf.osrd.utils.MutableDistanceRangeMap
 import fr.sncf.osrd.utils.distanceRangeMapOf
 import fr.sncf.osrd.utils.units.Distance.Companion.fromMeters
 
@@ -30,7 +30,7 @@ class ElectricalProfileMapping {
             for (trackRange in rjsProfile.trackRanges) {
                 val rangeMapping =
                     trackMapping.computeIfAbsent(trackRange.trackSectionID) { _: String? ->
-                        DistanceRangeMapImpl()
+                        MutableDistanceRangeMap()
                     }
                 rangeMapping.put(
                     fromMeters(trackRange.begin),

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/legacy_objects/ElectricalProfileMapping.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/legacy_objects/ElectricalProfileMapping.kt
@@ -72,10 +72,10 @@ class ElectricalProfileMapping {
             val trackProfiles = mapping[trackName]!!
             profilesOnChunk =
                 trackProfiles.subMap(
-                    chunkOffset.distance,
-                    chunkOffset.distance + infra.getTrackChunkLength(chunk).distance,
+                    lower = chunkOffset.distance,
+                    upper = chunkOffset.distance + infra.getTrackChunkLength(chunk).distance,
+                    shift = -chunkOffset.distance,
                 )
-            profilesOnChunk.shiftPositions(-chunkOffset.distance)
         }
         return profilesOnChunk
     }

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/legacy_objects/EnvelopeTrainPathUtils.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/legacy_objects/EnvelopeTrainPathUtils.kt
@@ -12,7 +12,7 @@ import fr.sncf.osrd.utils.units.Distance
 
 /** Builds the ElectrificationMap */
 fun buildElectrificationMap(path: TrainPath): DistanceRangeMap<Electrification> {
-    val res: DistanceRangeMap<Electrification> = MutableDistanceRangeMap()
+    val res = MutableDistanceRangeMap<Electrification>()
     res.put(Distance.ZERO, path.getLength().distance, NonElectrified())
     res.updateMapIntersection(path.getElectrification()) {
         _: Electrification?,

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/legacy_objects/EnvelopeTrainPathUtils.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/legacy_objects/EnvelopeTrainPathUtils.kt
@@ -7,12 +7,12 @@ import fr.sncf.osrd.path.legacy_objects.electrification.Neutral
 import fr.sncf.osrd.path.legacy_objects.electrification.NonElectrified
 import fr.sncf.osrd.sim_infra.api.NeutralSection
 import fr.sncf.osrd.utils.DistanceRangeMap
-import fr.sncf.osrd.utils.DistanceRangeMapImpl
+import fr.sncf.osrd.utils.MutableDistanceRangeMap
 import fr.sncf.osrd.utils.units.Distance
 
 /** Builds the ElectrificationMap */
 fun buildElectrificationMap(path: TrainPath): DistanceRangeMap<Electrification> {
-    val res: DistanceRangeMap<Electrification> = DistanceRangeMapImpl()
+    val res: DistanceRangeMap<Electrification> = MutableDistanceRangeMap()
     res.put(Distance.ZERO, path.getLength().distance, NonElectrified())
     res.updateMapIntersection(path.getElectrification()) {
         _: Electrification?,

--- a/core/kt-osrd-rjs-parser/src/main/kotlin/fr/sncf/osrd/RawInfraRJSParser.kt
+++ b/core/kt-osrd-rjs-parser/src/main/kotlin/fr/sncf/osrd/RawInfraRJSParser.kt
@@ -108,7 +108,7 @@ private fun getChunkDirectionalDistanceRange(
     val chunkLength = chunkEndOffset - chunkStartOffset
     return DirectionalMap(
         increasingChunkRange,
-        DistanceRangeMapImpl(
+        MutableDistanceRangeMap(
             increasingChunkRange.reversed().map {
                 DistanceRangeMap.RangeMapEntry(
                     chunkLength - it.upper,

--- a/core/kt-osrd-rjs-parser/src/main/kotlin/fr/sncf/osrd/RawInfraRJSParser.kt
+++ b/core/kt-osrd-rjs-parser/src/main/kotlin/fr/sncf/osrd/RawInfraRJSParser.kt
@@ -103,8 +103,11 @@ private fun getChunkDirectionalDistanceRange(
     chunkEndOffset: Offset<TrackSection>,
 ): DirectionalMap<DistanceRangeMap<Double>> {
     val increasingChunkRange =
-        distanceRangeMap.subMap(chunkStartOffset.distance, chunkEndOffset.distance)
-    increasingChunkRange.shiftPositions(-chunkStartOffset.distance)
+        distanceRangeMap.subMap(
+            lower = chunkStartOffset.distance,
+            upper = chunkEndOffset.distance,
+            shift = -chunkStartOffset.distance,
+        )
     val chunkLength = chunkEndOffset - chunkStartOffset
     return DirectionalMap(
         increasingChunkRange,
@@ -366,8 +369,11 @@ private fun parseRjsTrackSection(
             getChunkDirectionalDistanceRange(trackSectionCurves, chunkStartOffset, chunkEndOffset)
 
         val chunkBlockedGauges =
-            trackSectionBlockedGauges.subMap(chunkStartOffset.distance, chunkEndOffset.distance)
-        chunkBlockedGauges.shiftPositions(-chunkStartOffset.distance)
+            trackSectionBlockedGauges.subMap(
+                lower = chunkStartOffset.distance,
+                upper = chunkEndOffset.distance,
+                shift = -chunkStartOffset.distance,
+            )
 
         val chunkLength = chunkEndOffset - chunkStartOffset
 

--- a/core/kt-osrd-rjs-parser/src/main/kotlin/fr/sncf/osrd/RawInfraRJSParser.kt
+++ b/core/kt-osrd-rjs-parser/src/main/kotlin/fr/sncf/osrd/RawInfraRJSParser.kt
@@ -474,7 +474,7 @@ fun parseNeutralRanges(
 
 // Parse speed-sections
 fun mergeIntoSpeedSections(
-    initialSpeedSections: DirectionalMap<DistanceRangeMap<SpeedSection>>,
+    initialSpeedSections: DirectionalMap<MutableDistanceRangeMap<SpeedSection>>,
     direction: Direction,
     lower: Distance,
     upper: Distance,

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/TrackProperties.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/TrackProperties.kt
@@ -2,6 +2,7 @@ package fr.sncf.osrd.sim_infra.api
 
 import fr.sncf.osrd.geom.LineString
 import fr.sncf.osrd.utils.DistanceRangeMap
+import fr.sncf.osrd.utils.MutableDistanceRangeMap
 import fr.sncf.osrd.utils.SelfTypeHolder
 import fr.sncf.osrd.utils.indexing.StaticIdx
 import fr.sncf.osrd.utils.units.Length
@@ -83,7 +84,7 @@ interface TrackProperties {
         trackChunk: DirTrackChunkId,
         trainTag: String?,
         route: String?,
-    ): DistanceRangeMap<SpeedLimitProperty>
+    ): MutableDistanceRangeMap<SpeedLimitProperty>
 
     fun getTrackChunkGeom(trackChunk: TrackChunkId): LineString
 

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraImpl.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraImpl.kt
@@ -7,6 +7,7 @@ import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.utils.Direction
 import fr.sncf.osrd.utils.DirectionalMap
 import fr.sncf.osrd.utils.DistanceRangeMap
+import fr.sncf.osrd.utils.MutableDistanceRangeMap
 import fr.sncf.osrd.utils.distanceRangeMapOf
 import fr.sncf.osrd.utils.indexing.*
 import fr.sncf.osrd.utils.units.*
@@ -101,9 +102,9 @@ class TrackChunkDescriptor(
     val routes: DirectionalMap<List<RouteId>>,
     var operationalPointParts: List<OperationalPointPartId>,
     val loadingGaugeConstraints: DistanceRangeMap<LoadingGaugeConstraint>,
-    val electrificationVoltage: DistanceRangeMap<Set<String>>,
-    val neutralSections: DirectionalMap<DistanceRangeMap<NeutralSection>>,
-    val speedSections: DirectionalMap<DistanceRangeMap<SpeedSection>>,
+    val electrificationVoltage: MutableDistanceRangeMap<Set<String>>,
+    val neutralSections: DirectionalMap<MutableDistanceRangeMap<NeutralSection>>,
+    val speedSections: DirectionalMap<MutableDistanceRangeMap<SpeedSection>>,
 )
 
 class ZoneDescriptor(val movableElements: StaticIdxSortedSet<TrackNode>, var name: String = "")
@@ -527,7 +528,7 @@ class RawInfraImpl(
         trackChunk: DirTrackChunkId,
         trainTag: String?,
         route: String?,
-    ): DistanceRangeMap<SpeedLimitProperty> {
+    ): MutableDistanceRangeMap<SpeedLimitProperty> {
         val res = distanceRangeMapOf<SpeedLimitProperty>()
 
         val trainSpeedLimitTagDescriptor = speedLimitTagPool[trainTag]

--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/DistanceRangeMapExt.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/DistanceRangeMapExt.kt
@@ -20,7 +20,9 @@ fun <T : Any> DistanceRangeMap<T>.toRangeMap(): RangeMap<Double, T> {
     return res.build()
 }
 
-fun <T : Any> DistanceRangeMapImpl.Companion.from(map: RangeMap<Distance, T>): DistanceRangeMap<T> {
+fun <T : Any> MutableDistanceRangeMap.Companion.from(
+    map: RangeMap<Distance, T>
+): DistanceRangeMap<T> {
     val res = distanceRangeMapOf<T>()
     for (entry in map.asMapOfRanges().entries) res.put(
         entry.key.lowerEndpoint(),
@@ -30,7 +32,7 @@ fun <T : Any> DistanceRangeMapImpl.Companion.from(map: RangeMap<Distance, T>): D
     return res
 }
 
-fun <T : Any> DistanceRangeMapImpl.Companion.toRangeMap(
+fun <T : Any> MutableDistanceRangeMap.Companion.toRangeMap(
     distanceRangeMap: DistanceRangeMap<T>
 ): RangeMap<Distance, T> {
     val rangeMap = TreeRangeMap.create<Distance, T>()

--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeMap.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeMap.kt
@@ -14,6 +14,20 @@ import fr.sncf.osrd.utils.units.Distance
  *
  * `DistanceRangeMap` should be used when memory footprint is a concern (in particular to store
  * infra data), and only when precise interval semantics aren't necessary.
+ *
+ * # Note to implementors
+ *
+ * [DistanceRangeMap.iterator] must return entries in ascending order.
+ *
+ * Like [List] implementations, [DistanceRangeMap] implementations must override [Any.toString],
+ * [Any.equals] and [Any.hashCode] functions and provide implementations such that:
+ * - [DistanceRangeMap.toString] should return a string containing string representation of the
+ *   range entries in ascending order.
+ * - [DistanceRangeMap.equals] should consider two maps equal if and only if they contain the same
+ *   entries.
+ * - [DistanceRangeMap.hashCode] should be computed as a combination of the entries' hash codes
+ *   using the following algorithm: ```kotlin var hashCode: Int = 1 for (entry in
+ *   this.sortedAscending()) hashCode = hashCode * 31 + entry.hashCode() ```
  */
 interface DistanceRangeMap<T> : Iterable<DistanceRangeMap.RangeMapEntry<T>> {
 

--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeMap.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeMap.kt
@@ -84,19 +84,19 @@ interface DistanceRangeMap<T> : Iterable<DistanceRangeMap.RangeMapEntry<T>> {
 }
 
 fun <T> distanceRangeMapOf(vararg entries: DistanceRangeMap.RangeMapEntry<T>): DistanceRangeMap<T> {
-    return DistanceRangeMapImpl(entries.asList())
+    return MutableDistanceRangeMap(entries.asList())
 }
 
 fun <T> distanceRangeMapOf(
     entries: Sequence<DistanceRangeMap.RangeMapEntry<T>>
 ): DistanceRangeMap<T> {
-    return DistanceRangeMapImpl(entries.asIterable())
+    return MutableDistanceRangeMap(entries.asIterable())
 }
 
 fun <T> distanceRangeMapOf(
     entries: Iterable<DistanceRangeMap.RangeMapEntry<T>>
 ): DistanceRangeMap<T> {
-    return DistanceRangeMapImpl(entries)
+    return MutableDistanceRangeMap(entries)
 }
 
 /**

--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeMap.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeMap.kt
@@ -43,12 +43,6 @@ interface DistanceRangeMap<T> : Iterable<DistanceRangeMap.RangeMapEntry<T>> {
     fun truncate(beginOffset: Distance, endOffset: Distance)
 
     /**
-     * Shifts the positions by adding the given value. Map is changed inplace, but still returned
-     * for call chains.
-     */
-    fun shiftPositions(offset: Distance): DistanceRangeMap<T>
-
-    /**
      * Get the value at the given offset, if there is any. On exact transition offsets, the value
      * for the higher offset is used.
      */
@@ -57,8 +51,16 @@ interface DistanceRangeMap<T> : Iterable<DistanceRangeMap.RangeMapEntry<T>> {
     /** Returns a deep copy of the map as a [MutableDistanceRangeMap] */
     fun toMutableDistanceRangeMap(): MutableDistanceRangeMap<T>
 
-    /** Returns a new DistanceRangeMap of the ranges between lower and upper */
-    fun subMap(lower: Distance, upper: Distance): DistanceRangeMap<T>
+    /**
+     * Returns a new [DistanceRangeMap] of the ranges between [lower] and [upper].
+     *
+     * Optionally, it shifts the ranges of the resulting map by [shift].
+     */
+    fun subMap(
+        lower: Distance,
+        upper: Distance,
+        shift: Distance = Distance.ZERO,
+    ): DistanceRangeMap<T>
 
     /**
      * Updates the map with another one, using a merge function to fuse the values of intersecting

--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeMap.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeMap.kt
@@ -20,12 +20,6 @@ interface DistanceRangeMap<T> : Iterable<DistanceRangeMap.RangeMapEntry<T>> {
     /** When iterating over the values of the map, this represents one range of constant value */
     data class RangeMapEntry<T>(val lower: Distance, val upper: Distance, val value: T)
 
-    /** Sets the value between the lower and upper distances */
-    fun put(lower: Distance, upper: Distance, value: T)
-
-    /** Sets many values more efficiently than many calls to `put` */
-    fun putMany(entries: Iterable<RangeMapEntry<T>>)
-
     /** Returns a list of the entries in the map */
     @Deprecated(
         message =
@@ -38,9 +32,6 @@ interface DistanceRangeMap<T> : Iterable<DistanceRangeMap.RangeMapEntry<T>> {
 
     /** Upper bound of the entry with the highest distance */
     fun upperBound(): Distance
-
-    /** Removes all values outside the given range */
-    fun truncate(beginOffset: Distance, endOffset: Distance)
 
     /**
      * Get the value at the given offset, if there is any. On exact transition offsets, the value
@@ -62,42 +53,25 @@ interface DistanceRangeMap<T> : Iterable<DistanceRangeMap.RangeMapEntry<T>> {
         shift: Distance = Distance.ZERO,
     ): DistanceRangeMap<T>
 
-    /**
-     * Updates the map with another one, using a merge function to fuse the values of intersecting
-     * ranges. Doesn't keep any range from update where there is no intersection.
-     */
-    fun <U> updateMapIntersection(update: DistanceRangeMap<U>, updateFunction: (T, U) -> T)
-
-    /**
-     * Updates the map with another one, using a merge function to fuse the values of intersecting
-     * ranges. Calls default on the values of the ranges from update where there is no intersection.
-     */
-    fun updateMap(
-        update: DistanceRangeMap<T>,
-        updateFunction: (T, T) -> T,
-        default: (T) -> T = { it },
-    )
-
     /** Returns true if there is no entry at all */
     fun isEmpty(): Boolean
-
-    /** Clear the map */
-    fun clear()
 }
 
-fun <T> distanceRangeMapOf(vararg entries: DistanceRangeMap.RangeMapEntry<T>): DistanceRangeMap<T> {
+fun <T> distanceRangeMapOf(
+    vararg entries: DistanceRangeMap.RangeMapEntry<T>
+): MutableDistanceRangeMap<T> {
     return MutableDistanceRangeMap(entries.asList())
 }
 
 fun <T> distanceRangeMapOf(
     entries: Sequence<DistanceRangeMap.RangeMapEntry<T>>
-): DistanceRangeMap<T> {
+): MutableDistanceRangeMap<T> {
     return MutableDistanceRangeMap(entries.asIterable())
 }
 
 fun <T> distanceRangeMapOf(
     entries: Iterable<DistanceRangeMap.RangeMapEntry<T>>
-): DistanceRangeMap<T> {
+): MutableDistanceRangeMap<T> {
     return MutableDistanceRangeMap(entries)
 }
 

--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeMap.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeMap.kt
@@ -54,8 +54,8 @@ interface DistanceRangeMap<T> : Iterable<DistanceRangeMap.RangeMapEntry<T>> {
      */
     fun get(offset: Distance): T?
 
-    /** Returns a deep copy of the map */
-    fun clone(): DistanceRangeMap<T>
+    /** Returns a deep copy of the map as a [MutableDistanceRangeMap] */
+    fun toMutableDistanceRangeMap(): MutableDistanceRangeMap<T>
 
     /** Returns a new DistanceRangeMap of the ranges between lower and upper */
     fun subMap(lower: Distance, upper: Distance): DistanceRangeMap<T>

--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeSet.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeSet.kt
@@ -25,9 +25,6 @@ interface DistanceRangeSet : Iterable<DistanceRangeSet.RangeSetEntry> {
     /** Removes all values outside the given range */
     fun truncate(beginOffset: Distance, endOffset: Distance)
 
-    /** Shifts the positions by adding the given value */
-    fun shiftPositions(offset: Distance)
-
     /**
      * Returns true if the value is contained in the set. On range transition, returns the value to
      * the right.

--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeSetImpl.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeSetImpl.kt
@@ -31,10 +31,6 @@ class DistanceRangeSetImpl : DistanceRangeSet {
         map.truncate(beginOffset, endOffset)
     }
 
-    override fun shiftPositions(offset: Distance) {
-        map.shiftPositions(offset)
-    }
-
     override fun contains(offset: Distance): Boolean {
         return map.get(offset) ?: false
     }

--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeSubMap.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeSubMap.kt
@@ -1,0 +1,59 @@
+package fr.sncf.osrd.utils
+
+import fr.sncf.osrd.utils.units.Distance
+
+internal class DistanceRangeSubMap<T>(
+    private val fullMap: DistanceRangeMap<T>,
+    private val lower: Distance,
+    private val upper: Distance,
+    private val shift: Distance,
+) : DistanceRangeMap<T> {
+    override fun lowerBound(): Distance = lower
+
+    override fun upperBound(): Distance = upper
+
+    override fun get(offset: Distance): T? =
+        if (offset !in lower..<upper) {
+            null
+        } else {
+            fullMap.get(offset - shift)
+        }
+
+    override fun toMutableDistanceRangeMap(): MutableDistanceRangeMap<T> = distanceRangeMapOf(this)
+
+    override fun subMap(lower: Distance, upper: Distance, shift: Distance): DistanceRangeMap<T> =
+        DistanceRangeSubMap(
+            fullMap = fullMap,
+            lower = Distance.max(lower, this.lower) + shift,
+            upper = Distance.min(upper, this.upper) + shift,
+            shift = this.shift + shift,
+        )
+
+    override fun isEmpty(): Boolean = lower >= upper
+
+    override fun iterator(): Iterator<DistanceRangeMap.RangeMapEntry<T>> =
+        fullMap
+            .asSequence()
+            .dropWhile { it.upper <= this.lower - shift }
+            .takeWhile { it.lower < this.upper - shift }
+            .map {
+                if (it.lower < this.lower - shift || it.upper > this.upper - shift) {
+                    it.copy(
+                        lower = Distance.max(it.lower + shift, this.lower),
+                        upper = Distance.min(it.upper + shift, this.upper),
+                    )
+                } else {
+                    it.copy(lower = it.lower + shift, upper = it.upper + shift)
+                }
+            }
+            .iterator()
+
+    override fun equals(other: Any?): Boolean =
+        other is DistanceRangeMap<*> &&
+            this.asSequence().zip(other.asSequence()).all { (t, o) -> t == o }
+
+    override fun hashCode(): Int = fold(1) { hashCode, entry -> hashCode * 31 + entry.hashCode() }
+
+    override fun toString(): String =
+        joinToString(prefix = "{", postfix = "}") { "[${it.lower},${it.upper}]=${it.value}" }
+}

--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/MutableDistanceRangeMap.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/MutableDistanceRangeMap.kt
@@ -176,13 +176,13 @@ data class MutableDistanceRangeMap<T>(
         return null
     }
 
-    override fun clone(): DistanceRangeMap<T> {
+    override fun toMutableDistanceRangeMap(): MutableDistanceRangeMap<T> {
         return MutableDistanceRangeMap(bounds.clone(), values.toMutableList())
     }
 
     override fun subMap(lower: Distance, upper: Distance): DistanceRangeMap<T> {
         require(lower < upper)
-        val res = this.clone()
+        val res = this.toMutableDistanceRangeMap()
         res.truncate(lower, upper)
         return res
     }

--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/MutableDistanceRangeMap.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/MutableDistanceRangeMap.kt
@@ -163,11 +163,6 @@ data class MutableDistanceRangeMap<T>(
         }
     }
 
-    override fun shiftPositions(offset: Distance): DistanceRangeMap<T> {
-        for (i in 0 until bounds.size) bounds[i] = bounds[i] + offset
-        return this
-    }
-
     override fun get(offset: Distance): T? {
         // TODO: use a binary search
         for (entry in this.reversed()) {
@@ -180,10 +175,13 @@ data class MutableDistanceRangeMap<T>(
         return MutableDistanceRangeMap(bounds.clone(), values.toMutableList())
     }
 
-    override fun subMap(lower: Distance, upper: Distance): DistanceRangeMap<T> {
+    override fun subMap(lower: Distance, upper: Distance, shift: Distance): DistanceRangeMap<T> {
         require(lower < upper)
         val res = this.toMutableDistanceRangeMap()
         res.truncate(lower, upper)
+        if (shift != Distance.ZERO) {
+            for (i in 0 until res.bounds.size) res.bounds[i] = res.bounds[i] + shift
+        }
         return res
     }
 

--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/MutableDistanceRangeMap.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/MutableDistanceRangeMap.kt
@@ -4,7 +4,7 @@ import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.MutableDistanceArrayList
 import kotlin.math.min
 
-data class DistanceRangeMapImpl<T>(
+data class MutableDistanceRangeMap<T>(
     private val bounds: MutableDistanceArrayList,
     private val values: MutableList<T?>,
 ) : DistanceRangeMap<T> {
@@ -177,7 +177,7 @@ data class DistanceRangeMapImpl<T>(
     }
 
     override fun clone(): DistanceRangeMap<T> {
-        return DistanceRangeMapImpl(bounds.clone(), values.toMutableList())
+        return MutableDistanceRangeMap(bounds.clone(), values.toMutableList())
     }
 
     override fun subMap(lower: Distance, upper: Distance): DistanceRangeMap<T> {
@@ -396,7 +396,7 @@ data class DistanceRangeMapImpl<T>(
         }
     }
 
-    private class IteratorImpl<T>(val rangeMap: DistanceRangeMapImpl<T>) :
+    private class IteratorImpl<T>(val rangeMap: MutableDistanceRangeMap<T>) :
         Iterator<DistanceRangeMap.RangeMapEntry<T>> {
         private var cursor = -1
 

--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/MutableDistanceRangeMap.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/MutableDistanceRangeMap.kt
@@ -16,7 +16,7 @@ data class MutableDistanceRangeMap<T>(
     }
 
     /** Sets the value between the lower and upper distances */
-    override fun put(lower: Distance, upper: Distance, value: T) {
+    fun put(lower: Distance, upper: Distance, value: T) {
         putOptional(lower, upper, value)
     }
 
@@ -29,7 +29,7 @@ data class MutableDistanceRangeMap<T>(
      * Another idea would be to use a temporary (so we can free the memory later) tree-like
      * structure (RangeMaps lib).
      */
-    override fun putMany(entries: Iterable<DistanceRangeMap.RangeMapEntry<T>>) {
+    fun putMany(entries: Iterable<DistanceRangeMap.RangeMapEntry<T>>) {
         // Unfortunately, built-in groupBy doesn't consider the original order, here we want
         // consecutive values.
         fun <U, V> groupByConsecutiveFirst(pairs: List<Pair<U, V>>): List<Pair<U, List<V>>> {
@@ -154,7 +154,8 @@ data class MutableDistanceRangeMap<T>(
         return bounds[bounds.size - 1]
     }
 
-    override fun truncate(beginOffset: Distance, endOffset: Distance) {
+    /** Removes all values outside the given range */
+    fun truncate(beginOffset: Distance, endOffset: Distance) {
         if (bounds.isNotEmpty()) {
             putOptional(lowerBound(), beginOffset, null)
             if (bounds.isNotEmpty()) {
@@ -189,10 +190,11 @@ data class MutableDistanceRangeMap<T>(
         return bounds.isEmpty()
     }
 
-    override fun <U> updateMapIntersection(
-        update: DistanceRangeMap<U>,
-        updateFunction: (T, U) -> T,
-    ) {
+    /**
+     * Updates the map with another one, using a merge function to fuse the values of intersecting
+     * ranges. Doesn't keep any range from update where there is no intersection.
+     */
+    fun <U> updateMapIntersection(update: DistanceRangeMap<U>, updateFunction: (T, U) -> T) {
         for ((updateLower, updateUpper, updateValue) in update) {
             for ((subMapLower, subMapUpper, subMapValue) in this.subMap(updateLower, updateUpper)) {
                 this.put(subMapLower, subMapUpper, updateFunction(subMapValue, updateValue))
@@ -200,10 +202,14 @@ data class MutableDistanceRangeMap<T>(
         }
     }
 
-    override fun updateMap(
+    /**
+     * Updates the map with another one, using a merge function to fuse the values of intersecting
+     * ranges. Calls default on the values of the ranges from update where there is no intersection.
+     */
+    fun updateMap(
         update: DistanceRangeMap<T>,
         updateFunction: (T, T) -> T,
-        default: (T) -> T,
+        default: (T) -> T = { it },
     ) {
         val resultEntries = mutableListOf<DistanceRangeMap.RangeMapEntry<T>>()
 
@@ -293,7 +299,8 @@ data class MutableDistanceRangeMap<T>(
         this.putMany(resultEntries)
     }
 
-    override fun clear() {
+    /** Clear the map */
+    fun clear() {
         bounds.clear()
         values.clear()
     }

--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/MutableDistanceRangeMap.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/MutableDistanceRangeMap.kt
@@ -4,7 +4,7 @@ import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.MutableDistanceArrayList
 import kotlin.math.min
 
-data class MutableDistanceRangeMap<T>(
+class MutableDistanceRangeMap<T>(
     private val bounds: MutableDistanceArrayList,
     private val values: MutableList<T?>,
 ) : DistanceRangeMap<T> {
@@ -177,13 +177,12 @@ data class MutableDistanceRangeMap<T>(
     }
 
     override fun subMap(lower: Distance, upper: Distance, shift: Distance): DistanceRangeMap<T> {
-        require(lower < upper)
-        val res = this.toMutableDistanceRangeMap()
-        res.truncate(lower, upper)
-        if (shift != Distance.ZERO) {
-            for (i in 0 until res.bounds.size) res.bounds[i] = res.bounds[i] + shift
-        }
-        return res
+        return DistanceRangeSubMap(
+            fullMap = this,
+            lower = lower + shift,
+            upper = upper + shift,
+            shift = shift,
+        )
     }
 
     override fun isEmpty(): Boolean {
@@ -196,7 +195,8 @@ data class MutableDistanceRangeMap<T>(
      */
     fun <U> updateMapIntersection(update: DistanceRangeMap<U>, updateFunction: (T, U) -> T) {
         for ((updateLower, updateUpper, updateValue) in update) {
-            for ((subMapLower, subMapUpper, subMapValue) in this.subMap(updateLower, updateUpper)) {
+            val subMap = this.subMap(updateLower, updateUpper).toMutableDistanceRangeMap()
+            for ((subMapLower, subMapUpper, subMapValue) in subMap) {
                 this.put(subMapLower, subMapUpper, updateFunction(subMapValue, updateValue))
             }
         }
@@ -426,6 +426,15 @@ data class MutableDistanceRangeMap<T>(
 
         override fun hasNext(): Boolean = cursor + 1 < rangeMap.values.size
     }
+
+    override fun equals(other: Any?): Boolean =
+        other is DistanceRangeMap<*> &&
+            this.asSequence().zip(other.asSequence()).all { (t, o) -> t == o }
+
+    override fun hashCode(): Int = fold(1) { hashCode, entry -> hashCode * 31 + entry.hashCode() }
+
+    override fun toString(): String =
+        joinToString(prefix = "{", postfix = "}") { "[${it.lower},${it.upper}]=${it.value}" }
 
     // This declaration is needed for the extension methods in kt-osrd-utils
     companion object

--- a/core/osrd-mp/src/commonTest/kotlin/fr/sncf/osrd/utils/TestDistanceRangeMap.kt
+++ b/core/osrd-mp/src/commonTest/kotlin/fr/sncf/osrd/utils/TestDistanceRangeMap.kt
@@ -23,7 +23,7 @@ class TestDistanceRangeMap {
         rangeMapMany.putMany(entries)
         assertEquals(expected, rangeMapMany.toList())
 
-        val rangeMapCtor = DistanceRangeMapImpl(entries)
+        val rangeMapCtor = MutableDistanceRangeMap(entries)
         assertEquals(expected, rangeMapCtor.toList())
     }
 
@@ -247,16 +247,16 @@ class TestDistanceRangeMap {
 
         val mark3 = timeSource.markNow()
         val mark4 = mark3 + oneSecond
-        val rangeMapCtor = DistanceRangeMapImpl(entries)
+        val rangeMapCtor = MutableDistanceRangeMap(entries)
         assertFalse(mark4.hasPassedNow())
         assertEquals(entries, rangeMapCtor.toList())
     }
 
     @Test
     fun updateMapIntersection() {
-        val map = DistanceRangeMapImpl<String>()
+        val map = MutableDistanceRangeMap<String>()
         map.put(0.0.meters, 10.0.meters, "A")
-        val updateMap = DistanceRangeMapImpl<String>()
+        val updateMap = MutableDistanceRangeMap<String>()
         updateMap.put(5.0.meters, 15.0.meters, "B")
         map.updateMapIntersection(updateMap) { old, new -> old + new }
         assertEquals("AB", map.get(7.5.meters))
@@ -266,9 +266,9 @@ class TestDistanceRangeMap {
 
     @Test
     fun updateMap_noOverlap() {
-        val map = DistanceRangeMapImpl<String>()
+        val map = MutableDistanceRangeMap<String>()
         map.put(0.0.meters, 5.0.meters, "A")
-        val update = DistanceRangeMapImpl<String>()
+        val update = MutableDistanceRangeMap<String>()
         update.put(10.0.meters, 15.0.meters, "B")
         map.updateMap(update, { old, new -> old + new })
         assertEquals("A", map.get(2.5.meters))
@@ -278,9 +278,9 @@ class TestDistanceRangeMap {
 
     @Test
     fun updateMap_partialOverlap() {
-        val map = DistanceRangeMapImpl<String>()
+        val map = MutableDistanceRangeMap<String>()
         map.put(0.0.meters, 10.0.meters, "A")
-        val update = DistanceRangeMapImpl<String>()
+        val update = MutableDistanceRangeMap<String>()
         update.put(5.0.meters, 15.0.meters, "B")
         map.updateMap(update, { old, new -> old + new })
         assertEquals("A", map.get(2.5.meters))
@@ -290,9 +290,9 @@ class TestDistanceRangeMap {
 
     @Test
     fun updateMap_fullOverlap() {
-        val map = DistanceRangeMapImpl<String>()
+        val map = MutableDistanceRangeMap<String>()
         map.put(0.0.meters, 10.0.meters, "A")
-        val update = DistanceRangeMapImpl<String>()
+        val update = MutableDistanceRangeMap<String>()
         update.put(0.0.meters, 10.0.meters, "B")
         map.updateMap(update, { old, new -> old + new })
         assertEquals("AB", map.get(5.0.meters))
@@ -300,10 +300,10 @@ class TestDistanceRangeMap {
 
     @Test
     fun updateMap_multipleRanges() {
-        val map = DistanceRangeMapImpl<String>()
+        val map = MutableDistanceRangeMap<String>()
         map.put(0.0.meters, 5.0.meters, "A")
         map.put(10.0.meters, 15.0.meters, "C")
-        val update = DistanceRangeMapImpl<String>()
+        val update = MutableDistanceRangeMap<String>()
         update.put(3.0.meters, 12.0.meters, "B")
         map.updateMap(update, { old, new -> old + new })
         assertEquals("A", map.get(1.0.meters))
@@ -315,17 +315,17 @@ class TestDistanceRangeMap {
 
     @Test
     fun updateMapKeepingNonIntersecting_emptyUpdate() {
-        val map = DistanceRangeMapImpl<String>()
+        val map = MutableDistanceRangeMap<String>()
         map.put(0.0.meters, 10.0.meters, "A")
-        val update = DistanceRangeMapImpl<String>()
+        val update = MutableDistanceRangeMap<String>()
         map.updateMap(update, { old, new -> old + new })
         assertEquals("A", map.get(5.0.meters))
     }
 
     @Test
     fun updateMap_emptyOriginal() {
-        val map = DistanceRangeMapImpl<String>()
-        val update = DistanceRangeMapImpl<String>()
+        val map = MutableDistanceRangeMap<String>()
+        val update = MutableDistanceRangeMap<String>()
         update.put(0.0.meters, 10.0.meters, "B")
         map.updateMap(update, { old, new -> old + new })
         assertEquals("B", map.get(5.0.meters))
@@ -333,7 +333,7 @@ class TestDistanceRangeMap {
 
     @Test
     fun clear() {
-        val map = DistanceRangeMapImpl<String>()
+        val map = MutableDistanceRangeMap<String>()
         map.put(0.0.meters, 10.0.meters, "A")
         map.clear()
         assertNull(map.get(5.0.meters))

--- a/core/osrd-mp/src/commonTest/kotlin/fr/sncf/osrd/utils/TestDistanceRangeMap.kt
+++ b/core/osrd-mp/src/commonTest/kotlin/fr/sncf/osrd/utils/TestDistanceRangeMap.kt
@@ -194,21 +194,6 @@ class TestDistanceRangeMap {
     }
 
     @Test
-    fun testShift() {
-        val rangeMap = distanceRangeMapOf<Int>()
-        rangeMap.put(Distance(0), Distance(100), 41)
-        rangeMap.put(Distance(200), Distance(300), 42)
-        rangeMap.shiftPositions(Distance(-100))
-        assertEquals(
-            listOf(
-                DistanceRangeMap.RangeMapEntry(Distance(-100), Distance(0), 41),
-                DistanceRangeMap.RangeMapEntry(Distance(100), Distance(200), 42),
-            ),
-            rangeMap.toList(),
-        )
-    }
-
-    @Test
     fun testPutManyOnNonEmpty() {
         val rangeMap = distanceRangeMapOf<Int>()
         rangeMap.put(Distance(100), Distance(1000), 42)

--- a/core/osrd-mp/src/commonTest/kotlin/fr/sncf/osrd/utils/TestDistanceRangeMap.kt
+++ b/core/osrd-mp/src/commonTest/kotlin/fr/sncf/osrd/utils/TestDistanceRangeMap.kt
@@ -323,4 +323,119 @@ class TestDistanceRangeMap {
         map.clear()
         assertNull(map.get(5.0.meters))
     }
+
+    @Test
+    fun subMapShiftSingleEntry() {
+        val map = MutableDistanceRangeMap<String>()
+        map.put(0.meters, 10.meters, "A")
+        map.put(10.meters, 20.meters, "B")
+        map.put(20.meters, 30.meters, "C")
+
+        val subMap = map.subMap(lower = 10.meters, upper = 20.meters, shift = (-10).meters)
+
+        assertNull(subMap.get((-1).meters))
+        assertEquals("B", subMap.get(0.meters))
+        assertEquals("B", subMap.get(5.meters))
+        assertNull(subMap.get(10.meters))
+
+        assertEquals(0.meters, subMap.lowerBound())
+        assertEquals(10.meters, subMap.upperBound())
+
+        assertFalse(subMap.isEmpty())
+
+        assertEquals(
+            listOf(
+                DistanceRangeMap.RangeMapEntry(lower = 0.meters, upper = 10.meters, value = "B")
+            ),
+            subMap.toList(),
+        )
+    }
+
+    @Test
+    fun subMapShiftDoubleEntries() {
+        val map = MutableDistanceRangeMap<String>()
+        map.put(0.meters, 10.meters, "A")
+        map.put(10.meters, 20.meters, "B")
+        map.put(20.meters, 30.meters, "C")
+
+        val subMap = map.subMap(lower = 5.meters, upper = 15.meters, shift = (-5).meters)
+
+        assertNull(subMap.get((-1).meters))
+        assertEquals("A", subMap.get(0.meters))
+        assertEquals("A", subMap.get(2.meters))
+        assertEquals("B", subMap.get(5.meters))
+        assertEquals("B", subMap.get(7.meters))
+        assertNull(subMap.get(10.meters))
+
+        assertEquals(0.meters, subMap.lowerBound())
+        assertEquals(10.meters, subMap.upperBound())
+
+        assertFalse(subMap.isEmpty())
+
+        assertEquals(
+            listOf(
+                DistanceRangeMap.RangeMapEntry(lower = 0.meters, upper = 5.meters, value = "A"),
+                DistanceRangeMap.RangeMapEntry(lower = 5.meters, upper = 10.meters, value = "B"),
+            ),
+            subMap.toList(),
+        )
+    }
+
+    @Test
+    fun subMapOfSubMap() {
+        val map = MutableDistanceRangeMap<String>()
+        map.put(0.meters, 10.meters, "A")
+        map.put(10.meters, 20.meters, "B")
+        map.put(20.meters, 30.meters, "C")
+
+        val subMap = map.subMap(lower = 5.meters, upper = 25.meters, shift = (-5).meters)
+
+        assertNull(subMap.get((-1).meters))
+        assertEquals("A", subMap.get(0.meters))
+        assertEquals("A", subMap.get(2.meters))
+        assertEquals("B", subMap.get(5.meters))
+        assertEquals("B", subMap.get(7.meters))
+        assertEquals("B", subMap.get(10.meters))
+        assertEquals("B", subMap.get(12.meters))
+        assertEquals("C", subMap.get(15.meters))
+        assertEquals("C", subMap.get(17.meters))
+        assertNull(subMap.get(20.meters))
+
+        assertEquals(0.meters, subMap.lowerBound())
+        assertEquals(20.meters, subMap.upperBound())
+
+        assertFalse(subMap.isEmpty())
+
+        assertEquals(
+            listOf(
+                DistanceRangeMap.RangeMapEntry(lower = 0.meters, upper = 5.meters, value = "A"),
+                DistanceRangeMap.RangeMapEntry(lower = 5.meters, upper = 15.meters, value = "B"),
+                DistanceRangeMap.RangeMapEntry(lower = 15.meters, upper = 20.meters, value = "C"),
+            ),
+            subMap.toList(),
+        )
+
+        val subSubMap = subMap.subMap(lower = 12.meters, upper = 22.meters, shift = 100.meters)
+
+        assertNull(subSubMap.get(100.meters))
+        assertNull(subSubMap.get(110.meters))
+        assertNull(subSubMap.get(111.meters))
+        assertEquals("B", subSubMap.get(112.meters))
+        assertEquals("C", subSubMap.get(115.meters))
+        assertEquals("C", subSubMap.get(117.meters))
+        assertNull(subSubMap.get(120.meters))
+
+        assertEquals(112.meters, subSubMap.lowerBound())
+        assertEquals(120.meters, subSubMap.upperBound())
+
+        assertFalse(subSubMap.isEmpty())
+
+        assertEquals(
+            listOf(
+                DistanceRangeMap.RangeMapEntry(lower = 112.meters, upper = 115.meters, value = "B"),
+                DistanceRangeMap.RangeMapEntry(lower = 115.meters, upper = 120.meters, value = "C"),
+            ),
+            subSubMap.toList(),
+        )
+    }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/api/path_properties/PathPropResponseConverter.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/path_properties/PathPropResponseConverter.kt
@@ -8,7 +8,7 @@ import fr.sncf.osrd.railjson.schema.geom.RJSLineString
 import fr.sncf.osrd.sim_infra.api.NeutralSection
 import fr.sncf.osrd.sim_infra.api.RawSignalingInfra
 import fr.sncf.osrd.utils.DistanceRangeMap
-import fr.sncf.osrd.utils.DistanceRangeMapImpl
+import fr.sncf.osrd.utils.MutableDistanceRangeMap
 import fr.sncf.osrd.utils.from
 import fr.sncf.osrd.utils.toRangeMap
 import fr.sncf.osrd.utils.units.Offset
@@ -35,7 +35,7 @@ private fun makeCurves(pathProperties: TrainPath): RangeValues<Double> {
 private fun makeElectrifications(pathProperties: TrainPath): RangeValues<Electrification> {
     val electrifications = makeElectrificationMap(pathProperties.getElectrification())
     val neutralSections = makeElectrificationMap(pathProperties.getNeutralSections())
-    val mergedMap = DistanceRangeMapImpl.toRangeMap(electrifications)
+    val mergedMap = MutableDistanceRangeMap.toRangeMap(electrifications)
     for (neutralSection in neutralSections) {
         // Neutral section has priority over any electrification on an overlapping range
         mergedMap.merge(
@@ -45,7 +45,7 @@ private fun makeElectrifications(pathProperties: TrainPath): RangeValues<Electri
             neutralSectionValue
         }
     }
-    return makeRangeValues(DistanceRangeMapImpl.from(mergedMap))
+    return makeRangeValues(MutableDistanceRangeMap.from(mergedMap))
 }
 
 private fun makeGeographic(path: TrainPath): RJSLineString {
@@ -133,7 +133,7 @@ private fun <T> makeRangeValues(distanceRangeMap: DistanceRangeMap<T>): RangeVal
 private fun makeElectrificationMap(
     distanceRangeMap: DistanceRangeMap<out Any>
 ): DistanceRangeMap<Electrification> {
-    val res = DistanceRangeMapImpl<Electrification>()
+    val res = MutableDistanceRangeMap<Electrification>()
     for (entry in distanceRangeMap) {
         when (entry.value) {
             // Is electrified

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
@@ -52,8 +52,8 @@ import fr.sncf.osrd.stdcm.tracing.FailureExplainer
 import fr.sncf.osrd.train.RollingStock
 import fr.sncf.osrd.train.TrainStop
 import fr.sncf.osrd.utils.Direction
-import fr.sncf.osrd.utils.DistanceRangeMap
 import fr.sncf.osrd.utils.DistanceRangeMap.RangeMapEntry
+import fr.sncf.osrd.utils.MutableDistanceRangeMap
 import fr.sncf.osrd.utils.distanceRangeMapOf
 import fr.sncf.osrd.utils.units.*
 import io.opentelemetry.api.trace.Span
@@ -297,7 +297,8 @@ fun buildTemporarySpeedLimitManager(
     infra: FullInfra,
     speedLimits: Collection<STDCMTemporarySpeedLimit>,
 ): TemporarySpeedLimitManager {
-    val outputSpeedLimits: MutableMap<DirTrackChunkId, DistanceRangeMap<SpeedLimitProperty>> =
+    val outputSpeedLimits:
+        MutableMap<DirTrackChunkId, MutableDistanceRangeMap<SpeedLimitProperty>> =
         mutableMapOf()
     for (speedLimit in speedLimits) {
         for (trackRange in speedLimit.trackRanges) {

--- a/core/src/main/kotlin/fr/sncf/osrd/envelope_sim_infra/MRSP.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/envelope_sim_infra/MRSP.kt
@@ -177,8 +177,7 @@ fun makeSpeedLimitAttributes(
     propertyRangeMap: DistanceRangeMap<SpeedLimitProperty>,
     baseAttrs: List<SelfTypeHolder>,
 ): DistanceRangeMap<List<SelfTypeHolder>> {
-    val result: DistanceRangeMap<List<SelfTypeHolder>> =
-        distanceRangeMapOf(DistanceRangeMap.RangeMapEntry(lower, upper, baseAttrs))
+    val result = distanceRangeMapOf(DistanceRangeMap.RangeMapEntry(lower, upper, baseAttrs))
 
     // Add important attributes from the old speed ranges
     val attrsWithMissingRange = baseAttrs.toMutableList()

--- a/core/src/test/kotlin/fr/sncf/osrd/external_generated_inputs/ElectricalProfileMappingTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/external_generated_inputs/ElectricalProfileMappingTest.kt
@@ -9,11 +9,11 @@ import org.junit.jupiter.api.Test
 class ElectricalProfileMappingTest {
     @Test
     fun testRJSParsing() {
-        val powerClass1TrackTA0 = DistanceRangeMapImpl<String>()
+        val powerClass1TrackTA0 = MutableDistanceRangeMap<String>()
         powerClass1TrackTA0.put(0.meters, 1_600.meters, "A")
         powerClass1TrackTA0.put(1_600.meters, 1_800.meters, "B")
         powerClass1TrackTA0.put(1_800.meters, 2_000.meters, "A")
-        val powerClass1TrackTA1 = DistanceRangeMapImpl<String>()
+        val powerClass1TrackTA1 = MutableDistanceRangeMap<String>()
         powerClass1TrackTA1.put(0.meters, 1_950.meters, "B")
         val powerClass1Map =
             hashMapOf<String, DistanceRangeMap<String>>(
@@ -21,9 +21,9 @@ class ElectricalProfileMappingTest {
                 Pair("TA1", powerClass1TrackTA1),
             )
 
-        val powerClass2TrackTA0 = DistanceRangeMapImpl<String>()
+        val powerClass2TrackTA0 = MutableDistanceRangeMap<String>()
         powerClass2TrackTA0.put(0.meters, 2_000.meters, "C")
-        val powerClass2TrackTA1 = DistanceRangeMapImpl<String>()
+        val powerClass2TrackTA1 = MutableDistanceRangeMap<String>()
         powerClass2TrackTA1.put(0.meters, 1_950.meters, "D")
         val powerClass2Map =
             hashMapOf<String, DistanceRangeMap<String>>(
@@ -56,13 +56,13 @@ class ElectricalProfileMappingTest {
                 3_500.meters,
             )
 
-        val powerClass1Map = DistanceRangeMapImpl<String>()
+        val powerClass1Map = MutableDistanceRangeMap<String>()
         powerClass1Map.put(0.meters, 600.meters, "A")
         powerClass1Map.put(600.meters, 800.meters, "B")
         powerClass1Map.put(800.meters, 1_000.meters, "A")
         powerClass1Map.put(1_000.meters, 2_500.meters, "B")
 
-        val powerClass2Map = DistanceRangeMapImpl<String>()
+        val powerClass2Map = MutableDistanceRangeMap<String>()
         powerClass2Map.put(0.meters, 1_000.meters, "C")
         powerClass2Map.put(1_000.meters, 2_500.meters, "D")
         val expectedProfileMapping = hashMapOf(Pair("1", powerClass1Map), Pair("2", powerClass2Map))

--- a/core/src/test/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulationTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulationTest.kt
@@ -343,7 +343,7 @@ class StandaloneSimulationTest {
         val signalingRangesBAL = buildSignalingRanges(infra, trainPath)
 
         // ETCS_LEVEL2 range covers the first stop only: getting safetySpeed for the other stops
-        val signalingRangesEtcsHappyPath = signalingRangesBAL.clone()
+        val signalingRangesEtcsHappyPath = signalingRangesBAL.toMutableDistanceRangeMap()
         signalingRangesEtcsHappyPath.put(10.meters, 1_000.meters, ETCS_LEVEL2.id)
         val safetySpeedRangesEtcsHappyPath =
             makeSafetySpeedRanges(infra, trainPath, schedule, signalingRangesEtcsHappyPath)
@@ -358,7 +358,7 @@ class StandaloneSimulationTest {
 
         // ETCS_LEVEL2 range covers the last 2 stops only and their associated EoA: no safetySpeed
         // for those stops (only the first)
-        val signalingRangesEndFullEtcs = signalingRangesBAL.clone()
+        val signalingRangesEndFullEtcs = signalingRangesBAL.toMutableDistanceRangeMap()
         signalingRangesEndFullEtcs.put(9_500.meters, 10_400.meters, ETCS_LEVEL2.id)
         val safetySpeedRangesEndFullEtcs =
             makeSafetySpeedRanges(infra, trainPath, schedule, signalingRangesEndFullEtcs)
@@ -370,7 +370,7 @@ class StandaloneSimulationTest {
 
         // ETCS_LEVEL2 range covers the last 2 stops but not the final buffer-stop: no safetySpeed
         // for those stops (only the first)
-        val signalingRangesEndEtcsExceptFinalBuffer = signalingRangesBAL.clone()
+        val signalingRangesEndEtcsExceptFinalBuffer = signalingRangesBAL.toMutableDistanceRangeMap()
         signalingRangesEndEtcsExceptFinalBuffer.put(9_500.meters, 10_350.meters, ETCS_LEVEL2.id)
         val safetySpeedRangesEndFullEtcsExceptFinalBuffer =
             makeSafetySpeedRanges(
@@ -391,7 +391,7 @@ class StandaloneSimulationTest {
         // ETCS_LEVEL2 range covers all the end, starting between penultimate stop and its signal:
         // safetySpeed for first and penultimate stops
         val signalingRangesEtcsStartingBetweenPenultimateStopAndItsSignal =
-            signalingRangesBAL.clone()
+            signalingRangesBAL.toMutableDistanceRangeMap()
         signalingRangesEtcsStartingBetweenPenultimateStopAndItsSignal.put(
             10_100.meters,
             10_400.meters,
@@ -417,7 +417,8 @@ class StandaloneSimulationTest {
 
         // ETCS_LEVEL2 covers only the end, starting between the last stop and the buffer-stop:
         // safetySpeed expected for all (stops are in BAL range)
-        val signalingRangesEtcsStartingBetweenLastStopAndBuffer = signalingRangesBAL.clone()
+        val signalingRangesEtcsStartingBetweenLastStopAndBuffer =
+            signalingRangesBAL.toMutableDistanceRangeMap()
         signalingRangesEtcsStartingBetweenLastStopAndBuffer.put(
             10_350.meters,
             10_400.meters,

--- a/core/src/test/kotlin/fr/sncf/osrd/utils/DummyInfra.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/utils/DummyInfra.kt
@@ -448,9 +448,9 @@ class DummyInfra : RawInfra, BlockInfra {
         trackChunk: DirTrackChunkId,
         trainTag: String?,
         route: String?,
-    ): DistanceRangeMap<SpeedLimitProperty> {
+    ): MutableDistanceRangeMap<SpeedLimitProperty> {
         val desc = blockPool[trackChunk.value.index]
-        return desc.allowedSpeed
+        return desc.allowedSpeed.toMutableDistanceRangeMap()
     }
 
     override fun getTrackChunkGeom(trackChunk: TrackChunkId): LineString {

--- a/core/src/test/kotlin/fr/sncf/osrd/utils/DummyInfra.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/utils/DummyInfra.kt
@@ -421,7 +421,7 @@ class DummyInfra : RawInfra, BlockInfra {
     override fun getTrackChunkLoadingGaugeConstraints(
         trackChunk: TrackChunkId
     ): DistanceRangeMap<LoadingGaugeConstraint> {
-        return DistanceRangeMapImpl()
+        return MutableDistanceRangeMap()
     }
 
     override fun getTrackChunkElectrificationVoltage(
@@ -440,7 +440,7 @@ class DummyInfra : RawInfra, BlockInfra {
         val neutralSection =
             if (trackChunk.direction == Direction.INCREASING) desc.neutralSectionForward
             else desc.neutralSectionBackward
-        return if (neutralSection == null) DistanceRangeMapImpl()
+        return if (neutralSection == null) MutableDistanceRangeMap()
         else makeRangeMap(desc.length, neutralSection)
     }
 
@@ -566,8 +566,8 @@ class DummyInfra : RawInfra, BlockInfra {
     // endregion
 
     // region utils
-    private fun <T> makeRangeMap(length: Distance, default: T): DistanceRangeMapImpl<T> {
-        val res = DistanceRangeMapImpl<T>()
+    private fun <T> makeRangeMap(length: Distance, default: T): MutableDistanceRangeMap<T> {
+        val res = MutableDistanceRangeMap<T>()
         res.put(0.meters, length, default)
         return res
     }


### PR DESCRIPTION
Closes https://github.com/OpenRailAssociation/osrd/issues/15582

Two issues with this:

`DistanceRangeMapImpl.updateMapIntersection` does rely on `subMap` making a clone of the map. with the plan above, modifying the backing range map also modifies the submap, so this breaks a bunch of tests. I added a clone, but it's a foot gun i don't think we want to have...

`DistanceRangeSubMap` has to go over the whole `DistanceRangeMap` during iteration. if we go with `subMapIterator` we won't have this problem