### PR TITLE
core: fast path for new DistanceRangeMap from sorted entries

### DIFF
--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeMap.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeMap.kt
@@ -18,7 +18,9 @@ import fr.sncf.osrd.utils.units.Distance
 interface DistanceRangeMap<T> : Iterable<DistanceRangeMap.RangeMapEntry<T>> {
 
     /** When iterating over the values of the map, this represents one range of constant value */
-    data class RangeMapEntry<T>(val lower: Distance, val upper: Distance, val value: T)
+    data class RangeMapEntry<T>(val lower: Distance, val upper: Distance, val value: T) {
+        fun isEmpty(): Boolean = lower >= upper
+    }
 
     /** Sets the value between the lower and upper distances */
     fun put(lower: Distance, upper: Distance, value: T)

--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeMapImpl.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeMapImpl.kt
@@ -12,7 +12,22 @@ data class DistanceRangeMapImpl<T>(
     constructor(
         entries: Iterable<DistanceRangeMap.RangeMapEntry<T>> = emptyList()
     ) : this(MutableDistanceArrayList(), ArrayList()) {
-        putMany(entries)
+        if (!isSortedContiguous(entries.asSequence())) {
+            putMany(entries)
+            return
+        }
+        val firstEntry = entries.firstOrNull() ?: return
+        bounds.add(firstEntry.lower)
+        for (entry in entries) {
+            values.lastOrNull().let { prevValue ->
+                if (prevValue == entry.value) {
+                    bounds[bounds.size - 1] = entry.upper
+                    continue
+                }
+            }
+            bounds.add(entry.upper)
+            values.add(entry.value)
+        }
     }
 
     /** Sets the value between the lower and upper distances */
@@ -425,3 +440,7 @@ data class DistanceRangeMapImpl<T>(
     // This declaration is needed for the extension methods in kt-osrd-utils
     companion object
 }
+
+private fun <T> isSortedContiguous(entries: Sequence<DistanceRangeMap.RangeMapEntry<T>>): Boolean =
+    entries.all { a -> !a.isEmpty() } &&
+        entries.zipWithNext { a, b -> a.upper == b.lower }.all { it }


### PR DESCRIPTION
when building a `DistanceRangeMapImpl` from a list of entries that are sorted and cover a contiguous range we can build the range map more easily.

TODO still have to bench

Closes #15610