### PR TITLE
editoast: replace `track_reference` with `local_track_name`

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -2398,38 +2398,12 @@ paths:
                   required:
                   - trains
                   properties:
-                    track_reference:
+                    local_track_name:
                       oneOf:
                       - type: 'null'
-                      - oneOf:
-                        - type: object
-                          required:
-                          - id
-                          - type
-                          properties:
-                            id:
-                              type: string
-                            type:
-                              type: string
-                              enum:
-                              - track_id
-                        - type: object
-                          required:
-                          - name
-                          - type
-                          properties:
-                            name:
-                              type: string
-                            type:
-                              type: string
-                              enum:
-                              - track_name
-                      description: |-
-                        Which track section the train is on at the queried operational point.
-
-                        - `null`: no track could be determined (trains are in no-simulation, no `local_track_name`)
-                        - `track_id`: track resolved via pathfinding or `local_track_name` lookup
-                        - `track_name`: `local_track_name` given but not matched to any track ID
+                      - type: string
+                        minLength: 1
+                      description: Local track name. Unset if trains occupy the operational point but the specific track is unknown.
                     trains:
                       type: array
                       items:

--- a/editoast/src/views/path/operational_point_cache.rs
+++ b/editoast/src/views/path/operational_point_cache.rs
@@ -31,7 +31,7 @@ pub struct OperationalPointCache {
     /// Maps obj_id to index in the ops Vec
     obj_id_to_index: HashMap<String, usize>,
     track_ids: HashSet<String>,
-    track_ids_to_name: HashMap<String, NonBlankString>,
+    track_ids_to_local_track_name: HashMap<String, NonBlankString>,
 }
 
 impl OperationalPointCache {
@@ -90,18 +90,14 @@ impl OperationalPointCache {
             .map(|track| track.obj_id.clone())
             .collect();
 
-        let track_ids_to_name = track_sections
-            .into_iter()
-            .filter_map(|track| {
-                track
-                    .extensions
-                    .sncf
-                    .as_ref()
-                    .map(|extension| (track.obj_id.clone(), extension.track_name.clone()))
-            })
+        let track_ids_to_local_track_name = op_cache
+            .ops
+            .iter()
+            .flat_map(|op| &op.parts)
+            .map(|part| (part.track.0.clone(), part.local_track_name.clone()))
             .collect();
 
-        op_cache.track_ids_to_name = track_ids_to_name;
+        op_cache.track_ids_to_local_track_name = track_ids_to_local_track_name;
         op_cache.track_ids = track_ids;
         Ok(op_cache)
     }
@@ -141,7 +137,7 @@ impl OperationalPointCache {
         let mut obj_id_to_index: HashMap<String, usize> = HashMap::new();
         let mut uic_to_indices: HashMap<u32, Vec<usize>> = HashMap::new();
         let mut trigram_to_indices: HashMap<String, Vec<usize>> = HashMap::new();
-        let track_ids_to_name: HashMap<String, NonBlankString> = HashMap::new();
+        let track_ids_to_local_track_name: HashMap<String, NonBlankString> = HashMap::new();
         let track_ids: HashSet<String> = HashSet::new();
 
         for (index, op) in ops.iter().enumerate() {
@@ -171,7 +167,7 @@ impl OperationalPointCache {
             trigram_to_indices,
             obj_id_to_index,
             track_ids,
-            track_ids_to_name,
+            track_ids_to_local_track_name,
         })
     }
 
@@ -199,7 +195,7 @@ impl OperationalPointCache {
 
     /// Get the track name by track id
     pub fn get_name_by_track(&self, track_id: &str) -> Option<&NonBlankString> {
-        self.track_ids_to_name.get(track_id)
+        self.track_ids_to_local_track_name.get(track_id)
     }
 
     /// Check if a track exists
@@ -351,7 +347,7 @@ impl OperationalPointCache {
         trigram_to_indices: HashMap<String, Vec<usize>>,
         obj_id_to_index: HashMap<String, usize>,
         track_ids: HashSet<String>,
-        track_ids_to_name: HashMap<String, NonBlankString>,
+        track_ids_to_local_track_name: HashMap<String, NonBlankString>,
     ) -> Self {
         Self {
             ops,
@@ -359,7 +355,7 @@ impl OperationalPointCache {
             trigram_to_indices,
             obj_id_to_index,
             track_ids,
-            track_ids_to_name,
+            track_ids_to_local_track_name,
         }
     }
 

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -21,6 +21,7 @@ use itertools::Itertools;
 use itertools::izip;
 use reqwest::StatusCode;
 use schemas::paced_train::TrainSchedule;
+use schemas::primitives::NonBlankString;
 use schemas::primitives::TimeWindow;
 use schemas::train_schedule::OperationalPointPartReference;
 use schemas::train_schedule::OperationalPointReference;
@@ -1202,28 +1203,11 @@ pub(in crate::views) struct TrackOccupancy {
 }
 
 #[derive(Debug, Serialize, ToSchema)]
-#[serde(tag = "type", rename_all = "snake_case")]
-#[cfg_attr(test, derive(Deserialize, PartialEq))]
-pub(in crate::views) enum TrackReference {
-    TrackId {
-        id: String,
-    },
-    #[cfg_attr(not(test), expect(dead_code))]
-    TrackName {
-        name: String,
-    },
-}
-
-#[derive(Debug, Serialize, ToSchema)]
 #[cfg_attr(test, derive(Deserialize))]
 pub(in crate::views) struct TrackSectionOccupancy {
-    /// Which track section the train is on at the queried operational point.
-    ///
-    /// - `null`: no track could be determined (trains are in no-simulation, no `local_track_name`)
-    /// - `track_id`: track resolved via pathfinding or `local_track_name` lookup
-    /// - `track_name`: `local_track_name` given but not matched to any track ID
+    /// Local track name. Unset if trains occupy the operational point but the specific track is unknown.
     #[schema(inline)]
-    track_reference: Option<TrackReference>,
+    local_track_name: Option<NonBlankString>,
     #[schema(inline)]
     trains: Vec<TrackOccupancy>,
 }
@@ -1334,11 +1318,11 @@ pub(in crate::views) async fn track_occupancy(
                 .into_iter()
                 .map(
                     |track_occupancy::TrackOccupancy {
-                         track_section,
+                         local_track_name,
                          time_window,
                      }| {
                         (
-                            track_section,
+                            local_track_name,
                             TrackOccupancy {
                                 train_id: train_id.clone(),
                                 time_window,
@@ -1361,11 +1345,11 @@ pub(in crate::views) async fn track_occupancy(
                 .into_iter()
                 .map(
                     |track_occupancy::TrackOccupancy {
-                         track_section,
+                         local_track_name,
                          time_window,
                      }| {
                         (
-                            track_section,
+                            local_track_name,
                             TrackOccupancy {
                                 train_id: train_id.clone(),
                                 time_window,
@@ -1378,15 +1362,13 @@ pub(in crate::views) async fn track_occupancy(
             .collect_vec()
     };
 
-    // Group occupancies by track section
+    // Group occupancies by local_track_name
     let results: Vec<TrackSectionOccupancy> = all_occupancies
         .into_iter()
         .into_group_map()
         .into_iter()
-        .map(|(track_reference, trains)| TrackSectionOccupancy {
-            track_reference: Some(TrackReference::TrackId {
-                id: track_reference,
-            }),
+        .map(|(local_track_name, trains)| TrackSectionOccupancy {
+            local_track_name,
             trains,
         })
         .collect();
@@ -1582,6 +1564,7 @@ mod tests {
     use schemas::paced_train::RollingStockChangeGroup;
     use schemas::paced_train::TrainNameChangeGroup;
     use schemas::paced_train::TrainSchedule;
+    use schemas::primitives::NonBlankString;
     use schemas::rolling_stock::TrainCategory;
     use schemas::train_schedule::Comfort;
     use schemas::train_schedule::OperationalPointReference;
@@ -1612,7 +1595,6 @@ mod tests {
     use crate::views::timetable::paced_train::OccupancyBlocksTrainScheduleResult;
     use crate::views::timetable::paced_train::ProjectPathPacedTrainResult;
     use crate::views::timetable::paced_train::TrackOccupancyForm;
-    use crate::views::timetable::paced_train::TrackReference;
     use crate::views::timetable::paced_train::TrackSectionOccupancy;
     use crate::views::timetable::paced_train::TrainScheduleResponse;
     use crate::views::timetable::paced_train::TrainScheduleSummaryResponse;
@@ -2669,16 +2651,12 @@ mod tests {
             response.await.assert_status(StatusCode::OK).json_into();
 
         assert_eq!(track_occupancies.len(), 1);
-        let tc1_item = track_occupancies
-            .iter()
-            .find(|x| {
-                x.track_reference
-                    == Some(TrackReference::TrackId {
-                        id: "TC1".to_string(),
-                    })
-            })
-            .expect("TC1 track reference not found");
-        assert_eq!(tc1_item.trains.len(), paced_trains);
+        let item = &track_occupancies[0];
+        assert_eq!(
+            item.local_track_name,
+            Some(NonBlankString("V2".to_string()))
+        );
+        assert_eq!(item.trains.len(), paced_trains);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/editoast/src/views/timetable/track_occupancy.rs
+++ b/editoast/src/views/timetable/track_occupancy.rs
@@ -2,6 +2,7 @@ use chrono::Duration;
 use core_client::pathfinding::PathfindingResultSuccess;
 use core_client::simulation::ReportTrain;
 use schemas::infra::TrackOffset;
+use schemas::primitives::NonBlankString;
 use schemas::primitives::TimeWindow;
 use schemas::train_schedule::PathItem;
 use schemas::train_schedule::PathItemLocation;
@@ -15,7 +16,7 @@ use crate::views::timetable::simulation;
 
 #[derive(Debug, Clone)]
 pub(super) struct TrackOccupancy {
-    pub(super) track_section: String,
+    pub(super) local_track_name: Option<NonBlankString>,
     pub(super) time_window: TimeWindow,
 }
 
@@ -137,37 +138,33 @@ fn get_arrival_time(
     None
 }
 
-// Returns the track section for an operational point, using pathfinding or input.
-fn get_track_section(
+// Returns the local_track_name for an operational point, using pathfinding or input.
+fn get_local_track_name(
     context: &OccupancyContext,
     operational_point_track_offsets: &[TrackOffset],
     op_cache: &OperationalPointCache,
     train_schedule: &schemas::TrainOccurrence,
-) -> Option<String> {
+) -> Option<NonBlankString> {
+    if let Some(idx) = context.matching_index {
+        let PathItemLocation::OperationalPointPartReference(op_ref) =
+            &train_schedule.path[idx].location
+        else {
+            panic!("matching_index must reference an OperationalPointPartReference")
+        };
+        if op_ref.local_track_name.is_some() {
+            return op_ref.local_track_name.clone();
+        }
+    }
+
     if let Some(pathfinding_success) = context.pathfinding_success {
         let path_projection = PathProjection::new(&pathfinding_success.path.track_section_ranges);
         return operational_point_track_offsets
             .iter()
             .find(|to| path_projection.get_position(to).is_some())
-            .map(|to| to.track.to_string());
+            .and_then(|to| op_cache.get_name_by_track(to.track.as_str()))
+            .cloned();
     }
 
-    if let Some(idx) = context.matching_index {
-        let local_track_name = match &train_schedule.path[idx].location {
-            PathItemLocation::OperationalPointPartReference(op_ref) => &op_ref.local_track_name,
-            PathItemLocation::TrackOffset(_) => {
-                panic!("matching_index must reference an OperationalPointPartReference")
-            }
-        };
-        if local_track_name.is_some() {
-            return operational_point_track_offsets
-                .iter()
-                .find(|track_offset| {
-                    op_cache.get_name_by_track(&track_offset.track) == local_track_name.as_ref()
-                })
-                .map(|track_offset| track_offset.track.to_string());
-        }
-    }
     None
 }
 
@@ -221,9 +218,8 @@ fn find_track_occupancy_for_operational_point_with_context<'a>(
     op_cache: &OperationalPointCache,
     train_schedule: &schemas::TrainOccurrence,
 ) -> Vec<TrackOccupancy> {
-    let arrival_time = match get_arrival_time(&context, operational_point_track_offsets) {
-        Some(time) => time,
-        None => return vec![],
+    let Some(arrival_time) = get_arrival_time(&context, operational_point_track_offsets) else {
+        return vec![];
     };
 
     let stop_duration = context
@@ -231,20 +227,21 @@ fn find_track_occupancy_for_operational_point_with_context<'a>(
         .and_then(|item| item.stop_for)
         .unwrap_or_default();
 
-    if let Some(track_section) = get_track_section(
+    if let Some(local_track_name) = get_local_track_name(
         &context,
         operational_point_track_offsets,
         op_cache,
         train_schedule,
     ) {
         return vec![TrackOccupancy {
-            track_section,
+            local_track_name: Some(local_track_name),
             time_window: TimeWindow {
                 time_begin: train_schedule.start_time + Duration::milliseconds(arrival_time),
                 duration: stop_duration,
             },
         }];
     }
+
     vec![]
 }
 
@@ -302,7 +299,11 @@ pub mod tests {
             HashMap::new(),
             HashMap::new(),
             HashSet::new(),
-            HashMap::from([("T3".into(), "TS3".into())]),
+            HashMap::from([
+                ("T1".into(), "V1".into()),
+                ("T2".into(), "V2".into()),
+                ("T3".into(), "V3".into()),
+            ]),
         );
 
         let track_range = TrackRange {
@@ -360,7 +361,7 @@ pub mod tests {
                             operational_point: OperationalPointReference::Id {
                                 operational_point: "op_3".into(),
                             },
-                            local_track_name: Some("TS3".into()),
+                            local_track_name: Some("V3".into()),
                         },
                     ),
                 },

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -2044,23 +2044,8 @@ export type PostPacedTrainProjectPathOpApiArg = {
 };
 export type PostPacedTrainTrackOccupancyApiResponse =
   /** status 200 Track section occupancy periods for paced trains */ {
-    /** Which track section the train is on at the queried operational point.
-    
-    - `null`: no track could be determined (trains are in no-simulation, no `local_track_name`)
-    - `track_id`: track resolved via pathfinding or `local_track_name` lookup
-    - `track_name`: `local_track_name` given but not matched to any track ID */
-    track_reference?:
-      | null
-      | (
-          | {
-              id: string;
-              type: 'track_id';
-            }
-          | {
-              name: string;
-              type: 'track_name';
-            }
-        );
+    /** Local track name. Unset if trains occupy the operational point but the specific track is unknown. */
+    local_track_name?: null | string;
     trains: ((
       | {
           index: number;

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useTrackOccupancy.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useTrackOccupancy.ts
@@ -138,6 +138,7 @@ const useTrackOccupancy = ({
   const trainsStationLabelsRef = useRef<
     Record<string, { origin?: StationLabel; destination?: StationLabel } | undefined>
   >({});
+  const localTrackNameToTrackIdRef = useRef<Map<string, Map<string, string>>>(new Map());
   const updatePathOperationalPointState = useCallback(
     (
       waypointId: string,
@@ -170,6 +171,7 @@ const useTrackOccupancy = ({
   const fetchTrackOccupancy = useCallback(
     async (
       opRef: OperationalPointReference | undefined | null,
+      opId: string | undefined | null,
       trainsCollection: Record<TimetableItemId, TrainSpaceTimeData>
     ): Promise<MovableOccupancyZone[]> => {
       if (!opRef) return [];
@@ -197,10 +199,12 @@ const useTrackOccupancy = ({
 
       if (pacedResp?.data) {
         for (const trackItem of pacedResp.data) {
-          const { track_reference, trains } = trackItem;
-          if (!track_reference) continue;
-          const trackId =
-            track_reference.type === 'track_id' ? track_reference.id : track_reference.name;
+          const { local_track_name: localTrackName, trains } = trackItem;
+          if (!localTrackName) continue;
+          const trackId = opId
+            ? localTrackNameToTrackIdRef.current.get(opId)?.get(localTrackName)
+            : undefined;
+          if (!trackId) continue;
           for (const occupation of trains) {
             const pacedId = formatEditoastIdToPacedTrainId(occupation.train_schedule_id);
             const train = trainsCollection[pacedId];
@@ -329,6 +333,7 @@ const useTrackOccupancy = ({
           (ids) =>
             fetchTrackOccupancy(
               getOperationalPointReference(waypoint),
+              waypoint.opId,
               Object.fromEntries(ids.map((id) => [id, timetableItemProjectionsById.get(id)!]))
             ),
           {
@@ -380,7 +385,7 @@ const useTrackOccupancy = ({
 
           const trains = Object.fromEntries(Array.from(timetableItemProjectionsById.entries()));
 
-          fetchTrackOccupancy(opRef, trains).then((newZones) => {
+          fetchTrackOccupancy(opRef, waypoint.opId, trains).then((newZones) => {
             if (!newZones.length) return;
 
             updatePathOperationalPointState(waypointId, (state) =>
@@ -450,6 +455,7 @@ const useTrackOccupancy = ({
           [...impactedPathOperationalPointIDs].map(async (waypointId) => {
             const newZones = await fetchTrackOccupancy(
               getOperationalPointReference(pathOpsByWaypointId.get(waypointId)),
+              pathOpsByWaypointId.get(waypointId)?.opId,
               {
                 [draggedTrainEditoastId]: newTrainData,
               }
@@ -514,6 +520,17 @@ const useTrackOccupancy = ({
         for (const trackSections of Object.values(fetchedTrackSections)) {
           if (trackSections.id) trackSectionByTrackId.set(trackSections.id, trackSections);
         }
+
+        localTrackNameToTrackIdRef.current = new Map();
+
+        data.related_operational_points.forEach(([operationalPoint]) => {
+          if (!operationalPoint) return;
+          const mapping = new Map<string, string>();
+          for (const part of operationalPoint.parts) {
+            mapping.set(part.local_track_name, part.track);
+          }
+          localTrackNameToTrackIdRef.current.set(operationalPoint.id, mapping);
+        });
 
         const loadedTracks = fromPairs(
           operationalPointReferences.map(({ operational_point }, i) => [
@@ -603,6 +620,7 @@ const useTrackOccupancy = ({
       forEach(pathOperationalPointsState, async (_, waypointId) => {
         const newZones = await fetchTrackOccupancy(
           getOperationalPointReference(pathOpsByWaypointId.get(waypointId)),
+          pathOpsByWaypointId.get(waypointId)?.opId,
           Object.fromEntries(
             [...addedTrainIDs, ...modifiedTrainIDs].map((id) => [
               id,


### PR DESCRIPTION
Part of https://github.com/OpenRailAssociation/osrd/issues/15153

### Editoast:
- Remove `TrackReference` enum. Use a simple `local_track_name` string instead.
- The field is null when no track name can be found.
- Two ways to find `local_track_name`: from the timetable path item directly, or from the OP parts when pathfinding is available.
- The OP cache now stores names from `OperationalPointPart.local_track_name` instead of the SNCF track extension.

### Front:
- Update the frontend to use `local_track_name` instead of `track_reference`.