### PR TITLE
front: map: use the new endpoint of tuiles en liberté

### DIFF
--- a/front/src/common/Map/const.ts
+++ b/front/src/common/Map/const.ts
@@ -5,9 +5,8 @@ import { absoluteUrl } from 'utils/strings';
 export const MAP_URL = `${config.proxy_editoast}/layers`;
 export const SPRITES_URL = absoluteUrl(`${config.proxy_editoast}/sprites`);
 export const FONTS_URL = `${config.proxy_editoast}/fonts`;
-export const OSM_URL = 'pmtiles://https://osm.nbg1.your-objectstorage.com/planet.pmtiles';
-export const TERRAIN_URL =
-  'pmtiles://https://osm.nbg1.your-objectstorage.com/terrain-europe.pmtiles';
+export const OSM_URL = 'pmtiles://https://tuiles.enliberte.fr/planet.pmtiles';
+export const TERRAIN_URL = 'pmtiles://https://tuiles.enliberte.fr/terrain-europe.pmtiles';
 
 export const MAP_MODES = {
   display: 'display',


### PR DESCRIPTION
It is supposed to have a much lower latency

To test: use the map view, add some terrain to be sure that we didn’t miss that. The map should load
Test on sncf’s VPN