### PR TITLE
core: use max speed envelope cache to simulate blocks during stdcm exploration

### DIFF
--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/Envelope.kt
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/Envelope.kt
@@ -342,6 +342,11 @@ class Envelope(parts: Array<EnvelopePart>) :
         return res.toTypedArray()
     }
 
+    /** Shifts an envelope's positions. */
+    fun copyAndShift(positionDelta: Double): Envelope {
+        return make(*parts.map { it.copyAndShift(positionDelta) }.toTypedArray())
+    }
+
     // endregion
     override fun iterator(): MutableIterator<EnvelopePart> {
         return object : MutableIterator<EnvelopePart> {

--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/part/EnvelopePart.kt
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/part/EnvelopePart.kt
@@ -528,8 +528,8 @@ class EnvelopePart(
      */
     fun copyAndShift(
         positionDelta: Double,
-        minPosition: Double,
-        maxPosition: Double,
+        minPosition: Double? = null,
+        maxPosition: Double? = null,
     ): EnvelopePart {
         val newPositions = DoubleArrayList()
         val newSpeeds = DoubleArrayList()
@@ -537,7 +537,9 @@ class EnvelopePart(
         newPositions.add(positions[0] + positionDelta)
         newSpeeds.add(speeds[0])
         for (i in 1 until positions.size) {
-            val p = max(minPosition, min(maxPosition, positions[i] + positionDelta))
+            var p = positions[i] + positionDelta
+            if (minPosition != null) p = max(minPosition, p)
+            if (maxPosition != null) p = min(maxPosition, p)
             if (newPositions.last().value != p) {
                 // Positions that are an epsilon away may be overlapping after the shift, we only
                 // add the distinct ones

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/CachedBlockMaxSpeedEnvBuilder.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/CachedBlockMaxSpeedEnvBuilder.kt
@@ -41,8 +41,9 @@ import kotlin.math.min
  */
 data class CachedBlockMaxSpeedEnvBuilder(
     private val rawInfra: RawInfra,
-    private val blockInfra: BlockInfra,
+    val blockInfra: BlockInfra,
     private val rollingStock: PhysicsRollingStock,
+    // Explorer steps must have unique block locations per block.
     private val steps: List<ExplorerStep>,
     private val timeStep: Double,
     private val comfort: Comfort? = null,
@@ -52,52 +53,50 @@ data class CachedBlockMaxSpeedEnvBuilder(
     private val addRollingStockLength: Boolean = true,
 ) {
     private val maxSpeedEnvCache = mutableMapOf<CachedBlock, Envelope>()
-    private val mrspEnvCache = mutableMapOf<BlockId, CachedMrsp>()
+    private val mrspEnvCache = mutableMapOf<BlockId, MrspAndContext>()
     private val blockToStopMap = mutableMapOf<BlockId, MutableList<Offset<Block>>>()
     private val blockToMaxSpeedMap = mutableMapOf<BlockId, Double>()
 
     private data class CachedBlock(val block: BlockId, val endSpeed: Double?)
 
-    private data class CachedMrsp(val mrsp: Envelope, val context: EnvelopeSimContext)
+    data class MrspAndContext(val mrsp: Envelope, val context: EnvelopeSimContext)
 
     init {
-        for (stop in steps.filter { it.stop }) {
-            val blockToLocationMap = mutableMapOf<BlockId, Offset<Block>>()
+        for (stop in steps.filterIndexed { index, it -> it.stop || index == 0 }) {
             for (location in stop.locations) {
-                val currentOffset = blockToLocationMap.getOrPut(location.edge) { location.offset }
-                if (location.offset < currentOffset)
-                    blockToLocationMap[location.edge] = location.offset
-            }
-            blockToLocationMap.forEach { (block, stopOffset) ->
-                blockToStopMap.getOrPut(block) { mutableListOf() }.add(stopOffset)
+                blockToStopMap.getOrPut(location.edge) { mutableListOf() }.add(location.offset)
             }
         }
     }
 
-    /** Returns the max speed envelope/mrsp for the given block (cached). */
+    /** Returns the mrsp and context for the given block (cached). */
+    fun getMrspAndContext(block: BlockId): MrspAndContext {
+        return mrspEnvCache.computeIfAbsent(block) {
+            // TODO: change input to infra explorers, and fetch last route there
+            val pathProps = buildTrainPathFromBlock(rawInfra, blockInfra, block, routes = listOf())
+            val context = build(rollingStock, pathProps, timeStep, comfort)
+            val mrsp =
+                computeMRSP(
+                    pathProps,
+                    rollingStock.maxSpeed,
+                    rollingStock.length,
+                    addRollingStockLength = addRollingStockLength,
+                    speedLimitTag,
+                    temporarySpeedLimitManager,
+                )
+            MrspAndContext(mrsp, context)
+        }
+    }
+
+    /** Returns the max speed envelope for the given block/end speed (cached). */
     fun getMaxSpeedEnvelope(block: BlockId, endSpeed: Double?): Envelope {
         if (endSpeed == null && blockToMaxSpeedMap.containsKey(block)) {
             // Return fastest block envelope by maximising its end speed.
             return maxSpeedEnvCache[CachedBlock(block, blockToMaxSpeedMap[block])]!!
         }
-        val cachedMrsp =
-            mrspEnvCache.computeIfAbsent(block) {
-                // TODO: change input to infra explorers, and fetch last route there
-                val pathProps =
-                    buildTrainPathFromBlock(rawInfra, blockInfra, block, routes = listOf())
-                val context = build(rollingStock, pathProps, timeStep, comfort)
-                val mrsp =
-                    computeMRSP(
-                        pathProps,
-                        rollingStock.maxSpeed,
-                        rollingStock.length,
-                        addRollingStockLength = addRollingStockLength,
-                        speedLimitTag,
-                        temporarySpeedLimitManager,
-                    )
-                CachedMrsp(mrsp, context)
-            }
-        val actualEndSpeed = min(cachedMrsp.mrsp.endSpeed, endSpeed ?: Double.POSITIVE_INFINITY)
+        val (cachedMrsp, cachedContext) = getMrspAndContext(block)
+        if (cachedMrsp.beginPos == cachedMrsp.endPos) return cachedMrsp
+        val actualEndSpeed = min(cachedMrsp.endSpeed, endSpeed ?: Double.POSITIVE_INFINITY)
         blockToMaxSpeedMap.compute(block) { _, oldSpeed ->
             max(actualEndSpeed, oldSpeed ?: Double.NEGATIVE_INFINITY)
         }
@@ -107,12 +106,12 @@ data class CachedBlockMaxSpeedEnvBuilder(
                     SimStop(Offset(it.distance), RJSTrainStop.RJSReceptionSignal.SHORT_SLIP_STOP)
                 } ?: listOf()
             val newMrsp =
-                if (actualEndSpeed < cachedMrsp.mrsp.endSpeed)
-                    addEndBrakingPart(cachedMrsp.context, actualEndSpeed, cachedMrsp.mrsp)
-                else cachedMrsp.mrsp
+                if (actualEndSpeed < cachedMrsp.endSpeed)
+                    addEndBrakingPart(cachedContext, actualEndSpeed, cachedMrsp)
+                else cachedMrsp
             // TODO: Look into adding accelerations to the max speed envelope and benchmark it to
             // see if it improves the computing time.
-            maxSpeedEnvelopeFrom(cachedMrsp.context, stops, newMrsp)
+            maxSpeedEnvelopeFrom(cachedContext, stops, newMrsp)
         }
     }
 

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/BacktrackingManager.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/BacktrackingManager.kt
@@ -70,18 +70,12 @@ class BacktrackingManager(private val graph: STDCMGraph) {
     private fun rebuildEdgeBackward(old: STDCMEdge, endSpeed: Double): STDCMEdge? {
         val oldEnvelope =
             graph.stdcmSimulations.simulateBlock(
-                graph.rollingStock,
-                graph.comfort,
-                graph.timeStep,
-                graph.tag,
-                graph.temporarySpeedLimitManager,
-                old.infraExplorer,
                 BlockSimulationParameters(
                     old.infraExplorer.getCurrentBlock(),
                     old.beginSpeed,
                     old.envelopeStartOffset,
                     getNextStopOnCurrentBlock(old.infraExplorer),
-                ),
+                )
             )
         val path = old.infraExplorer.getCurrentEdgePathProperties(old.envelopeStartOffset, null)
         val context = build(graph.rollingStock, path, graph.timeStep, graph.comfort)

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/BlockSimulationParameters.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/BlockSimulationParameters.kt
@@ -2,6 +2,7 @@ package fr.sncf.osrd.stdcm.graph
 
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockId
+import fr.sncf.osrd.utils.round
 import fr.sncf.osrd.utils.units.Offset
 
 /**
@@ -13,4 +14,8 @@ data class BlockSimulationParameters(
     val initialSpeed: Double,
     val start: Offset<Block>,
     val stop: Offset<Block>?,
-)
+) {
+    fun round(): BlockSimulationParameters {
+        return BlockSimulationParameters(block, initialSpeed.round(), start, stop)
+    }
+}

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdgeBuilder.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdgeBuilder.kt
@@ -86,18 +86,12 @@ internal constructor(
         if (envelope == null)
             envelope =
                 graph.stdcmSimulations.simulateBlock(
-                    graph.rollingStock,
-                    graph.comfort,
-                    graph.timeStep,
-                    graph.tag,
-                    graph.temporarySpeedLimitManager,
-                    infraExplorer,
                     BlockSimulationParameters(
                         infraExplorer.getCurrentBlock(),
                         prevNode.speed,
                         startOffset,
                         getNextStopOnCurrentBlock(infraExplorer),
-                    ),
+                    )
                 )
         return envelope
     }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
@@ -53,7 +53,6 @@ class STDCMGraph(
 ) : Graph<STDCMNode, STDCMEdge> {
     val rawInfra = fullInfra.rawInfra
     val blockInfra = fullInfra.blockInfra
-    var stdcmSimulations: STDCMSimulations = STDCMSimulations()
     val delayManager: DelayManager =
         DelayManager(
             minScheduleTimeStart,
@@ -77,6 +76,7 @@ class STDCMGraph(
             temporarySpeedLimitManager = temporarySpeedLimitManager,
             addRollingStockLength = false,
         )
+    var stdcmSimulations = STDCMSimulations(maxSpeedEnvBuilder)
 
     // min 30s between two edges, determined empirically
     // TODO: this value *should* reflect twice the min delay between two trains,

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
@@ -14,6 +14,7 @@ import fr.sncf.osrd.sim_infra.impl.TemporarySpeedLimitManager
 import fr.sncf.osrd.stdcm.STDCMResult
 import fr.sncf.osrd.stdcm.infra_exploration.ExplorerStep
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
+import fr.sncf.osrd.stdcm.infra_exploration.deduplicateLocations
 import fr.sncf.osrd.stdcm.infra_exploration.initInfraExplorerWithEnvelope
 import fr.sncf.osrd.stdcm.preprocessing.interfaces.BlockAvailabilityInterface
 import fr.sncf.osrd.stdcm.tracing.FailureExplainer
@@ -64,12 +65,14 @@ fun findPath(
     searchMetadata: STDCMGraph.SearchMetadata? = null,
     failureExplainer: FailureExplainer? = null,
 ): STDCMResult? {
+    // Remove duplicate locations (i.e. have the same block).
+    val uniqueSteps = steps.deduplicateLocations()
     return STDCMPathfinding(
             fullInfra,
             rollingStock,
             comfort,
             startTime,
-            steps,
+            uniqueSteps,
             blockAvailability,
             timeStep,
             maxDepartureDelay,

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMSimulations.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMSimulations.kt
@@ -8,29 +8,18 @@ import fr.sncf.osrd.envelope.part.EnvelopePartBuilder
 import fr.sncf.osrd.envelope.part.constraints.EnvelopeConstraint
 import fr.sncf.osrd.envelope.part.constraints.EnvelopePartConstraintType
 import fr.sncf.osrd.envelope.part.constraints.SpeedConstraint
-import fr.sncf.osrd.envelope_sim.Comfort
 import fr.sncf.osrd.envelope_sim.EnvelopeProfile
 import fr.sncf.osrd.envelope_sim.EnvelopeSimContext
 import fr.sncf.osrd.envelope_sim.overlays.EnvelopeDeceleration
-import fr.sncf.osrd.envelope_sim.pipelines.SimStop
 import fr.sncf.osrd.envelope_sim.pipelines.maxEffortEnvelopeFrom
-import fr.sncf.osrd.envelope_sim.pipelines.maxSpeedEnvelopeFrom
-import fr.sncf.osrd.envelope_sim_infra.computeMRSP
-import fr.sncf.osrd.path.interfaces.PhysicsPath
-import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal
 import fr.sncf.osrd.reporting.exceptions.OSRDError
-import fr.sncf.osrd.sim_infra.api.Block
-import fr.sncf.osrd.sim_infra.impl.TemporarySpeedLimitManager
 import fr.sncf.osrd.stdcm.BacktrackingSelfTypeHolder
-import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorer
-import fr.sncf.osrd.train.RollingStock
+import fr.sncf.osrd.stdcm.CachedBlockMaxSpeedEnvBuilder
 import fr.sncf.osrd.utils.SelfTypeHolder
-import fr.sncf.osrd.utils.units.Distance
-import fr.sncf.osrd.utils.units.Offset
 import java.lang.ref.SoftReference
 
 /** This class contains all the methods used to simulate the train behavior. */
-class STDCMSimulations {
+class STDCMSimulations(private val cachedBlockMaxSpeedEnvBuilder: CachedBlockMaxSpeedEnvBuilder) {
     private var simulatedEnvelopes: HashMap<BlockSimulationParameters, SoftReference<Envelope>?> =
         HashMap()
 
@@ -41,72 +30,35 @@ class STDCMSimulations {
      * Returns the corresponding envelope if the block's envelope has already been computed in
      * simulatedEnvelopes, otherwise computes the matching envelope and adds it to the STDCMGraph.
      */
-    fun simulateBlock(
-        rollingStock: RollingStock,
-        comfort: Comfort?,
-        timeStep: Double,
-        trainTag: String?,
-        temporarySpeedLimitManager: TemporarySpeedLimitManager?,
-        infraExplorer: InfraExplorer,
-        blockParams: BlockSimulationParameters,
-    ): Envelope? {
-        val cached = simulatedEnvelopes.getOrDefault(blockParams, null)?.get()
+    fun simulateBlock(blockParams: BlockSimulationParameters): Envelope? {
+        val roundedBlockParams = blockParams.round()
+        val cached = simulatedEnvelopes.getOrDefault(roundedBlockParams, null)?.get()
         if (cached != null) return cached
-        val simulatedEnvelope =
-            simulateBlock(
-                infraExplorer,
-                blockParams.initialSpeed,
-                blockParams.start,
-                rollingStock,
-                comfort,
-                timeStep,
-                blockParams.stop,
-                trainTag,
-                temporarySpeedLimitManager,
-            )
-        simulatedEnvelopes[blockParams] = SoftReference(simulatedEnvelope)
+        val simulatedEnvelope = simulateBlockNoCache(roundedBlockParams)
+        simulatedEnvelopes[roundedBlockParams] = SoftReference(simulatedEnvelope)
         return simulatedEnvelope
     }
 
     /**
-     * Returns an envelope matching the given block. The envelope time starts when the train enters
-     * the block. stopPosition specifies the position at which the train should stop, may be null
-     * (no stop).
+     * Computes the corresponding envelope.
      *
      * Note: there are some approximations made here as we only "see" the tracks on the given
      * blocks. We are missing slopes and speed limits from earlier in the path.
      */
-    fun simulateBlock(
-        infraExplorer: InfraExplorer,
-        initialSpeed: Double,
-        start: Offset<Block>,
-        rollingStock: RollingStock,
-        comfort: Comfort?,
-        timeStep: Double,
-        stopPosition: Offset<Block>?,
-        trainTag: String?,
-        temporarySpeedLimitManager: TemporarySpeedLimitManager?,
-    ): Envelope? {
+    private fun simulateBlockNoCache(blockParams: BlockSimulationParameters): Envelope? {
+        val (block, initialSpeed, start, stopPosition) = blockParams
         assert(stopPosition == null || stopPosition >= start)
         if (stopPosition != null && stopPosition == start) return makeSinglePointEnvelope(0.0)
-        val blockLength = infraExplorer.getCurrentBlockLength()
+        val blockLength = cachedBlockMaxSpeedEnvBuilder.blockInfra.getBlockLength(block)
         if (start >= blockLength) return makeSinglePointEnvelope(initialSpeed)
-        var stops = emptyList<SimStop>()
-        var simLength = blockLength.distance - start.distance
-        if (stopPosition != null) {
-            val stopOffset = Offset<PhysicsPath>(stopPosition - start)
-            // We presently consider all stdcm stops to be performed on closed signal by default
-            // This presently only affects ETCS computations, which are not yet supported in stdcm
-            // either
-            stops = listOf(SimStop(stopOffset, RJSReceptionSignal.SHORT_SLIP_STOP))
-            simLength = Distance.min(simLength, stopOffset.distance)
-        }
-        val path = infraExplorer.getCurrentEdgePathProperties(start, simLength)
-        val context = build(rollingStock, path, timeStep, comfort)
-        val mrsp = computeMRSP(path, rollingStock, false, trainTag, temporarySpeedLimitManager)
         return try {
-            val maxSpeedEnvelope = maxSpeedEnvelopeFrom(context, stops, mrsp)
-            maxEffortEnvelopeFrom(context, initialSpeed, maxSpeedEnvelope)
+            val context = cachedBlockMaxSpeedEnvBuilder.getMrspAndContext(block).context
+            val maxSpeedEnvelope = cachedBlockMaxSpeedEnvBuilder.getMaxSpeedEnvelope(block, null)
+            Envelope.make(
+                    *maxEffortEnvelopeFrom(context, initialSpeed, maxSpeedEnvelope)
+                        .slice(start.meters, (stopPosition ?: blockLength).meters)
+                )
+                .copyAndShift(-start.meters)
         } catch (e: OSRDError) {
             // The train can't reach its destination, for example because of high slopes
             if (nFailedSimulation == 0) {
@@ -134,7 +86,7 @@ class STDCMSimulations {
 }
 
 /** Make an envelope with a single point of the given speed */
-private fun makeSinglePointEnvelope(speed: Double): Envelope {
+fun makeSinglePointEnvelope(speed: Double): Envelope {
     return Envelope.make(
         EnvelopePart(
             mapOf<Class<out SelfTypeHolder>, SelfTypeHolder>(

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
@@ -164,6 +164,24 @@ data class ExplorerStep(
     val plannedTimingData: PlannedTimingData? = null,
 )
 
+private fun ExplorerStep.deduplicateLocations(isFirstStep: Boolean = false): ExplorerStep {
+    val deduplicatedLocations =
+        locations
+            .groupBy { it.edge }
+            .values
+            .map { locationsForEdge ->
+                // If first step, we want to minimize the path and keep the highest offset.
+                if (isFirstStep) locationsForEdge.maxBy { it.offset }
+                // Else, especially for the last step, keep the lowest offset.
+                else locationsForEdge.minBy { it.offset }
+            }
+    return copy(locations = deduplicatedLocations)
+}
+
+fun List<ExplorerStep>.deduplicateLocations(): List<ExplorerStep> = mapIndexed { index, step ->
+    step.deduplicateLocations(isFirstStep = index == 0)
+}
+
 /**
  * Init all InfraExplorers starting at the given location. The last of `stops` are used to identify
  * when the incremental path is complete. `constraints` are used to determine if a block can be

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/BacktrackingTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/BacktrackingTests.kt
@@ -2,7 +2,7 @@ package fr.sncf.osrd.stdcm
 
 import com.google.common.collect.ImmutableMultimap
 import fr.sncf.osrd.envelope_sim.Comfort
-import fr.sncf.osrd.sim_infra.api.Block
+import fr.sncf.osrd.stdcm.graph.BlockSimulationParameters
 import fr.sncf.osrd.stdcm.infra_exploration.BlockLocation
 import fr.sncf.osrd.stdcm.preprocessing.OccupancySegment
 import fr.sncf.osrd.train.TestTrains
@@ -27,15 +27,13 @@ class BacktrackingTests {
         val block = infra.addBlock("a", "b", 1000.meters)
         val firstBlockEnvelope =
             simulateBlock(
-                infraExplorerFromBlock(infra, infra, block),
-                0.0,
-                Offset(0.meters),
+                BlockSimulationParameters(block, 0.0, Offset(0.meters), null),
+                infra,
+                infra,
                 TestTrains.REALISTIC_FAST_TRAIN,
-                Comfort.STANDARD,
+                listOf(),
                 2.0,
-                null,
-                null,
-                null,
+                Comfort.STANDARD,
             )!!
         val runTime = firstBlockEnvelope.totalTime
         val occupancyGraph =
@@ -46,8 +44,8 @@ class BacktrackingTests {
         val res =
             STDCMPathfindingBuilder()
                 .setInfra(infra.fullInfra())
-                .setStartLocations(setOf(BlockLocation(block, Offset<Block>(0.meters))))
-                .setEndLocations(setOf(BlockLocation(block, Offset<Block>(1000.meters))))
+                .setStartLocations(setOf(BlockLocation(block, Offset(0.meters))))
+                .setEndLocations(setOf(BlockLocation(block, Offset(1000.meters))))
                 .setUnavailableTimes(occupancyGraph)
                 .run() ?: return
         occupancyTest(res, occupancyGraph)
@@ -69,15 +67,13 @@ class BacktrackingTests {
         val lastBlock = infra.addBlock("d", "e", 10.meters)
         val firstBlockEnvelope =
             simulateBlock(
-                infraExplorerFromBlock(infra, infra, firstBlock),
-                0.0,
-                Offset(0.meters),
+                BlockSimulationParameters(firstBlock, 0.0, Offset(0.meters), null),
+                infra,
+                infra,
                 TestTrains.REALISTIC_FAST_TRAIN,
-                Comfort.STANDARD,
+                listOf(),
                 2.0,
-                null,
-                null,
-                null,
+                Comfort.STANDARD,
             )!!
         val runTime = firstBlockEnvelope.totalTime
         val occupancyGraph =
@@ -88,8 +84,8 @@ class BacktrackingTests {
         val res =
             STDCMPathfindingBuilder()
                 .setInfra(infra.fullInfra())
-                .setStartLocations(setOf(BlockLocation(firstBlock, Offset<Block>(0.meters))))
-                .setEndLocations(setOf(BlockLocation(lastBlock, Offset<Block>(5.meters))))
+                .setStartLocations(setOf(BlockLocation(firstBlock, Offset(0.meters))))
+                .setEndLocations(setOf(BlockLocation(lastBlock, Offset(5.meters))))
                 .setUnavailableTimes(occupancyGraph)
                 .run() ?: return
         occupancyTest(res, occupancyGraph)
@@ -109,15 +105,13 @@ class BacktrackingTests {
         val secondBlock = infra.addBlock("b", "c", 100.meters, 5.0)
         val firstBlockEnvelope =
             simulateBlock(
-                infraExplorerFromBlock(infra, infra, firstBlock),
-                0.0,
-                Offset(0.meters),
+                BlockSimulationParameters(firstBlock, 0.0, Offset(0.meters), null),
+                infra,
+                infra,
                 TestTrains.REALISTIC_FAST_TRAIN,
-                Comfort.STANDARD,
+                listOf(),
                 2.0,
-                null,
-                null,
-                null,
+                Comfort.STANDARD,
             )!!
         val runTime = firstBlockEnvelope.totalTime
         val occupancyGraph =
@@ -128,8 +122,8 @@ class BacktrackingTests {
         val res =
             STDCMPathfindingBuilder()
                 .setInfra(infra.fullInfra())
-                .setStartLocations(setOf(BlockLocation(firstBlock, Offset<Block>(0.meters))))
-                .setEndLocations(setOf(BlockLocation(secondBlock, Offset<Block>(5.meters))))
+                .setStartLocations(setOf(BlockLocation(firstBlock, Offset(0.meters))))
+                .setEndLocations(setOf(BlockLocation(secondBlock, Offset(5.meters))))
                 .setUnavailableTimes(occupancyGraph)
                 .run() ?: return
         occupancyTest(res, occupancyGraph)
@@ -152,8 +146,8 @@ class BacktrackingTests {
         val res =
             STDCMPathfindingBuilder()
                 .setInfra(infra.fullInfra())
-                .setStartLocations(setOf(BlockLocation(firstBlock, Offset<Block>(0.meters))))
-                .setEndLocations(setOf(BlockLocation(lastBlock, Offset<Block>(1000.meters))))
+                .setStartLocations(setOf(BlockLocation(firstBlock, Offset(0.meters))))
+                .setEndLocations(setOf(BlockLocation(lastBlock, Offset(1000.meters))))
                 .run()!!
         Assertions.assertTrue(res.envelope.continuous)
     }

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/DepartureTimeShiftTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/DepartureTimeShiftTests.kt
@@ -2,6 +2,7 @@ package fr.sncf.osrd.stdcm
 
 import com.google.common.collect.ImmutableMultimap
 import fr.sncf.osrd.envelope_sim.Comfort
+import fr.sncf.osrd.stdcm.graph.BlockSimulationParameters
 import fr.sncf.osrd.stdcm.infra_exploration.BlockLocation
 import fr.sncf.osrd.stdcm.preprocessing.OccupancySegment
 import fr.sncf.osrd.train.TestTrains
@@ -166,15 +167,13 @@ class DepartureTimeShiftTests {
         val secondBlock = infra.addBlock("b", "c")
         val firstBlockEnvelope =
             simulateBlock(
-                infraExplorerFromBlock(infra, infra, firstBlock),
-                0.0,
-                Offset(0.meters),
+                BlockSimulationParameters(firstBlock, 0.0, Offset(0.meters), null),
+                infra,
+                infra,
                 TestTrains.REALISTIC_FAST_TRAIN,
-                Comfort.STANDARD,
+                listOf(),
                 2.0,
-                null,
-                null,
-                null,
+                Comfort.STANDARD,
             )!!
         val occupancyGraph =
             ImmutableMultimap.of(

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/EngineeringAllowanceTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/EngineeringAllowanceTests.kt
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMultimap
 import fr.sncf.osrd.envelope_sim.Comfort
 import fr.sncf.osrd.envelope_sim.allowances.AllowanceValue
 import fr.sncf.osrd.sim_infra.api.BlockId
+import fr.sncf.osrd.stdcm.graph.BlockSimulationParameters
 import fr.sncf.osrd.stdcm.infra_exploration.BlockLocation
 import fr.sncf.osrd.stdcm.preprocessing.OccupancySegment
 import fr.sncf.osrd.train.TestTrains
@@ -39,27 +40,28 @@ class EngineeringAllowanceTests {
         val thirdBlock = infra.addBlock("c", "d", 100.meters, 30.0)
         val firstBlockEnvelope =
             simulateBlock(
-                infraExplorerFromBlock(infra, infra, firstBlock),
-                0.0,
-                Offset(0.meters),
+                BlockSimulationParameters(firstBlock, 0.0, Offset(0.meters), null),
+                infra,
+                infra,
                 TestTrains.REALISTIC_FAST_TRAIN,
-                Comfort.STANDARD,
+                listOf(),
                 2.0,
-                null,
-                null,
-                null,
+                Comfort.STANDARD,
             )!!
         val secondBlockEnvelope =
             simulateBlock(
-                infraExplorerFromBlock(infra, infra, secondBlock),
-                firstBlockEnvelope.endSpeed,
-                Offset(0.meters),
+                BlockSimulationParameters(
+                    secondBlock,
+                    firstBlockEnvelope.endSpeed,
+                    Offset(0.meters),
+                    null,
+                ),
+                infra,
+                infra,
                 TestTrains.REALISTIC_FAST_TRAIN,
-                Comfort.STANDARD,
+                listOf(),
                 2.0,
-                null,
-                null,
-                null,
+                Comfort.STANDARD,
             )!!
         val timeThirdBlockFree = firstBlockEnvelope.totalTime + secondBlockEnvelope.totalTime
         val occupancyGraph =
@@ -119,27 +121,28 @@ class EngineeringAllowanceTests {
         val lastBlock = infra.addBlock("e", "f", 1000.meters, 20.0)
         val firstBlockEnvelope =
             simulateBlock(
-                infraExplorerFromBlock(infra, infra, firstBlock),
-                0.0,
-                Offset(0.meters),
+                BlockSimulationParameters(firstBlock, 0.0, Offset(0.meters), null),
+                infra,
+                infra,
                 TestTrains.REALISTIC_FAST_TRAIN,
-                Comfort.STANDARD,
+                listOf(),
                 2.0,
-                null,
-                null,
-                null,
+                Comfort.STANDARD,
             )!!
         val secondBlockEnvelope =
             simulateBlock(
-                infraExplorerFromBlock(infra, infra, secondBlock),
-                firstBlockEnvelope.endSpeed,
-                Offset(0.meters),
+                BlockSimulationParameters(
+                    secondBlock,
+                    firstBlockEnvelope.endSpeed,
+                    Offset(0.meters),
+                    null,
+                ),
+                infra,
+                infra,
                 TestTrains.REALISTIC_FAST_TRAIN,
-                Comfort.STANDARD,
+                listOf(),
                 2.0,
-                null,
-                null,
-                null,
+                Comfort.STANDARD,
             )!!
         val timeLastBlockFree =
             firstBlockEnvelope.totalTime + 120 + secondBlockEnvelope.totalTime * 3
@@ -202,27 +205,28 @@ class EngineeringAllowanceTests {
         val lastBlock = infra.addBlock("e", "f", 1000.meters, 20.0)
         val firstBlockEnvelope =
             simulateBlock(
-                infraExplorerFromBlock(infra, infra, firstBlock),
-                0.0,
-                Offset(0.meters),
+                BlockSimulationParameters(firstBlock, 0.0, Offset(0.meters), null),
+                infra,
+                infra,
                 TestTrains.REALISTIC_FAST_TRAIN,
-                Comfort.STANDARD,
+                listOf(),
                 2.0,
-                null,
-                null,
-                null,
+                Comfort.STANDARD,
             )!!
         val secondBlockEnvelope =
             simulateBlock(
-                infraExplorerFromBlock(infra, infra, secondBlock),
-                firstBlockEnvelope.endSpeed,
-                Offset(0.meters),
+                BlockSimulationParameters(
+                    secondBlock,
+                    firstBlockEnvelope.endSpeed,
+                    Offset(0.meters),
+                    null,
+                ),
+                infra,
+                infra,
                 TestTrains.REALISTIC_FAST_TRAIN,
-                Comfort.STANDARD,
+                listOf(),
                 2.0,
-                null,
-                null,
-                null,
+                Comfort.STANDARD,
             )!!
         val timeLastBlockFree =
             firstBlockEnvelope.totalTime + 120 + secondBlockEnvelope.totalTime * 3
@@ -630,27 +634,28 @@ class EngineeringAllowanceTests {
         val thirdBlock = infra.addBlock("c", "d", 100.meters, 0.5)
         val firstBlockEnvelope =
             simulateBlock(
-                infraExplorerFromBlock(infra, infra, firstBlock),
-                0.0,
-                Offset(0.meters),
+                BlockSimulationParameters(firstBlock, 0.0, Offset(0.meters), null),
+                infra,
+                infra,
                 TestTrains.REALISTIC_FAST_TRAIN,
-                Comfort.STANDARD,
+                listOf(),
                 2.0,
-                null,
-                null,
-                null,
+                Comfort.STANDARD,
             )!!
         val secondBlockEnvelope =
             simulateBlock(
-                infraExplorerFromBlock(infra, infra, secondBlock),
-                firstBlockEnvelope.endSpeed,
-                Offset(0.meters),
+                BlockSimulationParameters(
+                    secondBlock,
+                    firstBlockEnvelope.endSpeed,
+                    Offset(0.meters),
+                    null,
+                ),
+                infra,
+                infra,
                 TestTrains.REALISTIC_FAST_TRAIN,
-                Comfort.STANDARD,
+                listOf(),
                 2.0,
-                null,
-                null,
-                null,
+                Comfort.STANDARD,
             )!!
         val timeThirdBlockFree = firstBlockEnvelope.totalTime + secondBlockEnvelope.totalTime
         val occupancyGraph =

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMHelpers.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMHelpers.kt
@@ -5,16 +5,17 @@ import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.conflicts.SpacingRequirement
 import fr.sncf.osrd.envelope.Envelope
 import fr.sncf.osrd.envelope_sim.Comfort
+import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.sim_infra.impl.TemporarySpeedLimitManager
 import fr.sncf.osrd.standalone_sim.EnvelopeStopWrapper
+import fr.sncf.osrd.stdcm.graph.BlockSimulationParameters
 import fr.sncf.osrd.stdcm.graph.STDCMSimulations
 import fr.sncf.osrd.stdcm.infra_exploration.BlockLocation
 import fr.sncf.osrd.stdcm.infra_exploration.ExplorerStep
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorer
 import fr.sncf.osrd.stdcm.infra_exploration.initInfraExplorers
 import fr.sncf.osrd.stdcm.preprocessing.OccupancySegment
-import fr.sncf.osrd.train.RollingStock
 import fr.sncf.osrd.train.TestTrains
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
@@ -30,15 +31,13 @@ fun getBlocksRunTime(infra: FullInfra, blocks: List<BlockId>): Double {
     for (block in blocks) {
         val envelope =
             simulateBlock(
-                infraExplorerFromBlock(infra.rawInfra, infra.blockInfra, block),
-                speed,
-                Offset(0.meters),
+                BlockSimulationParameters(block, speed, Offset(0.meters), null),
+                infra.rawInfra,
+                infra.blockInfra,
                 TestTrains.REALISTIC_FAST_TRAIN,
-                Comfort.STANDARD,
+                listOf(),
                 2.0,
-                null,
-                null,
-                null,
+                Comfort.STANDARD,
             )!!
         time += envelope.totalTime
         speed = envelope.endSpeed
@@ -48,29 +47,32 @@ fun getBlocksRunTime(infra: FullInfra, blocks: List<BlockId>): Double {
 
 /** Helper function to call `simulateBlock` without instantiating an `STDCMSimulations` */
 fun simulateBlock(
-    infraExplorer: InfraExplorer,
-    initialSpeed: Double,
-    start: Offset<Block>,
-    rollingStock: RollingStock,
-    comfort: Comfort?,
+    block: BlockSimulationParameters,
+    rawInfra: RawInfra,
+    blockInfra: BlockInfra,
+    rollingStock: PhysicsRollingStock,
+    steps: List<ExplorerStep>,
     timeStep: Double,
-    stopPosition: Offset<Block>?,
-    trainTag: String?,
-    temporarySpeedLimitManager: TemporarySpeedLimitManager?,
+    comfort: Comfort? = null,
+    speedLimitTag: String? = null,
+    temporarySpeedLimitManager: TemporarySpeedLimitManager = TemporarySpeedLimitManager(),
+    addRollingStockLength: Boolean = true,
 ): Envelope? {
-    val sim = STDCMSimulations()
-    val res =
-        sim.simulateBlock(
-            infraExplorer,
-            initialSpeed,
-            start,
-            rollingStock,
-            comfort,
-            timeStep,
-            stopPosition,
-            trainTag,
-            temporarySpeedLimitManager,
+    val sim =
+        STDCMSimulations(
+            CachedBlockMaxSpeedEnvBuilder(
+                rawInfra,
+                blockInfra,
+                rollingStock,
+                steps,
+                timeStep,
+                comfort,
+                speedLimitTag,
+                temporarySpeedLimitManager,
+                addRollingStockLength,
+            )
         )
+    val res = sim.simulateBlock(block)
     sim.logWarnings()
     return res
 }

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMPathfindingTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMPathfindingTests.kt
@@ -518,8 +518,8 @@ class STDCMPathfindingTests {
     }
 
     /**
-     * This is mostly a malformed input, but it can happen on misplaced operational points. It's
-     * actually really hard to handle it *perfectly* but we should at least not crash.
+     * This is mostly a malformed input, but it can happen on misplaced operational points. Right
+     * now, we're merging duplicate locations of a same ExplorerStep to handle the case.
      */
     @Test
     fun repeatedLocationsOnEdge() {


### PR DESCRIPTION
Fixes #14492.
CachedBlockMaxSpeedEnvBuilder was added previously to improve heuristic. Plug it into STDCMSimulations to use it to simulate explored stdcm blocks as well.

~There's also a bug found by @eckter on the fuzzer which I have to reproduce.~ -> due to a malformed input with multiple block locations on the same block for the same step -> prefilter block locations.

Benchmark:
| | time_old | time_new | time_diff |
|---|---|---|---|
| count | 750.000000 | 750.000000 | 750.000000 |
| mean | 19.798747 | 19.535747 | -0.263000 |
| std | 28.124987 | 26.888255 | 2.660127 |
| min | 1.246000 | 1.250000 | -18.984000 |
| 25% | 4.904000 | 4.369000 | -1.124750 |
| 50% | 11.977500 | 12.076000 | -0.038000 |
| 75% | 22.787000 | 23.411000 | 0.684000 |
| max | 160.337000 | 151.131000 | 7.639000 |

| | mb_old | mb_new | mb_diff |
|---|---|---|---|
| count | 750.000000 | 750.000000 | 750.000000 |
| mean | 4198.573333 | 4066.193333 | -132.380000 |
| std | 2909.711650 | 2418.327462 | 1811.710552 |
| min | 1654.000000 | 1541.000000 | -7960.000000 |
| 25% | 2617.000000 | 2510.000000 | -738.500000 |
| 50% | 3499.500000 | 3589.000000 | -61.000000 |
| 75% | 4764.000000 | 5002.000000 | 709.250000 |
| max | 20174.000000 | 17729.000000 | 5225.000000 |