### PR TITLE
editoast: remove flag used to return core payload

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -3470,14 +3470,6 @@ paths:
         schema:
           type: integer
           format: int64
-      - name: return_debug_payloads
-        in: query
-        description: If true, extra payloads are returned to help with debugging
-        required: false
-        schema:
-          type:
-          - boolean
-          - 'null'
       requestBody:
         content:
           application/json:
@@ -5299,112 +5291,6 @@ components:
       enum:
       - Spacing
       - Routing
-    CoreConsistConfiguration:
-      type: object
-      description: Represents a physics consist.
-      required:
-      - supported_signaling_systems
-      - loading_gauge_type
-      - physics_consist
-      properties:
-        loading_gauge_type:
-          $ref: '#/components/schemas/LoadingGaugeType'
-          description: The loading gauge of the rolling stock
-        physics_consist:
-          type: object
-          required:
-          - effort_curves
-          - length
-          - max_speed
-          - startup_time
-          - startup_acceleration
-          - comfort_acceleration
-          - const_gamma
-          - inertia_coefficient
-          - mass
-          - rolling_resistance
-          properties:
-            base_power_class:
-              type:
-              - string
-              - 'null'
-            comfort_acceleration:
-              type: number
-              format: double
-              description: Acceleration in m·s⁻²
-            const_gamma:
-              type: number
-              format: double
-              description: |2-
-                 The constant gamma braking coefficient used when NOT circulating
-                 under ETCS/ERTMS signaling system
-                Acceleration in m·s⁻²
-            effort_curves:
-              $ref: '#/components/schemas/EffortCurves'
-            electrical_power_startup_time:
-              type:
-              - integer
-              - 'null'
-              format: int64
-              description: |-
-                The time the train takes before actually using electrical power.
-                Is null if the train is not electric or the value not specified.
-              minimum: 0
-            etcs_brake_params:
-              oneOf:
-              - type: 'null'
-              - $ref: '#/components/schemas/EtcsBrakeParams'
-            inertia_coefficient:
-              type: number
-              format: double
-            length:
-              type: integer
-              format: int64
-              minimum: 0
-            mass:
-              type: integer
-              format: int64
-              minimum: 0
-            max_speed:
-              type: number
-              format: double
-              description: Velocity in m·s⁻¹
-            power_restrictions:
-              type: object
-              description: Mapping of power restriction code to power class
-              additionalProperties:
-                type: string
-              propertyNames:
-                type: string
-            raise_pantograph_time:
-              type:
-              - integer
-              - 'null'
-              format: int64
-              description: |-
-                The time it takes to raise this train's pantograph.
-                Is null if the train is not electric or the value not specified.
-              minimum: 0
-            rolling_resistance:
-              $ref: '#/components/schemas/RollingResistance'
-            startup_acceleration:
-              type: number
-              format: double
-              description: Acceleration in m·s⁻²
-            startup_time:
-              type: integer
-              format: int64
-              minimum: 0
-        speed_limit_tag:
-          type:
-          - string
-          - 'null'
-        supported_signaling_systems:
-          type: array
-          items:
-            type: string
-          description: List of supported signaling systems
-          uniqueItems: true
     CoreETCSBrakingCurvesResponse:
       type: object
       required:
@@ -5535,21 +5421,6 @@ components:
           type: integer
           format: int64
           minimum: 0
-    CorePathItem:
-      type: object
-      required:
-      - locations
-      properties:
-        can_backtrack:
-          type:
-          - boolean
-          - 'null'
-          description: If true, the train can backtrack at these track offsets.
-        locations:
-          type: array
-          items:
-            $ref: '#/components/schemas/TrackOffset'
-          description: The track offsets of the path item.
     CorePathfindingInputError:
       oneOf:
       - type: object
@@ -5790,26 +5661,6 @@ components:
             type: string
         zone:
           type: string
-    CoreSTDCMPathItem:
-      type: object
-      required:
-      - path_item
-      properties:
-        path_item:
-          $ref: '#/components/schemas/CorePathItem'
-          description: The path item containing its locations and backtrack information.
-        step_timing_data:
-          oneOf:
-          - type: 'null'
-          - $ref: '#/components/schemas/CoreStepTimingData'
-            description: If specified, describes when the train may arrive at the location
-        stop_duration:
-          type:
-          - integer
-          - 'null'
-          format: int64
-          description: Stop duration in milliseconds. None if the train does not stop at this path item.
-          minimum: 0
     CoreSignalCriticalPosition:
       type: object
       description: |-
@@ -5932,150 +5783,6 @@ components:
           minimum: 0
         zone:
           type: string
-    CoreStdcmRequest:
-      type: object
-      required:
-      - infra
-      - expected_version
-      - timetable_id
-      - path_items
-      - comfort
-      - consist_schedule
-      - start_time
-      - maximum_departure_delay
-      - maximum_run_time
-      - time_gap_before
-      - time_gap_after
-      - work_schedules
-      - temporary_speed_limits
-      properties:
-        allowed_track_sections:
-          type:
-          - array
-          - 'null'
-          items:
-            type: string
-          description: Set of authorized track section ids for the current request
-          uniqueItems: true
-        comfort:
-          $ref: '#/components/schemas/Comfort'
-          description: The comfort of the train
-        consist_schedule:
-          $ref: '#/components/schemas/ConsistSchedule'
-        expected_version:
-          type: integer
-          format: int64
-          description: Infrastructure expected version
-        infra:
-          type: integer
-          format: int64
-          description: Infrastructure id
-        margin:
-          oneOf:
-          - type: 'null'
-          - oneOf:
-            - type: object
-              title: MarginValuePercentage
-              required:
-              - Percentage
-              properties:
-                Percentage:
-                  type: number
-                  format: double
-            - type: object
-              title: MarginValueMinPer100Km
-              required:
-              - MinPer100Km
-              properties:
-                MinPer100Km:
-                  type: number
-                  format: double
-          description: Margin to apply to the whole train
-        maximum_departure_delay:
-          type: integer
-          format: int64
-          description: Maximum departure delay in milliseconds.
-          minimum: 0
-        maximum_run_time:
-          type: integer
-          format: int64
-          description: Maximum run time of the simulation in milliseconds
-          minimum: 0
-        path_items:
-          type: array
-          items:
-            $ref: '#/components/schemas/CoreSTDCMPathItem'
-          description: List of waypoints. Each waypoint is a list of track offset.
-        start_time:
-          type: string
-          format: date-time
-        temporary_speed_limits:
-          type: array
-          items:
-            type: object
-            description: Lighter description of a work schedule with only the relevant information for core
-            required:
-            - speed_limit
-            - track_ranges
-            properties:
-              speed_limit:
-                type: number
-                format: double
-                description: Speed limitation in m/s
-              track_ranges:
-                type: array
-                items:
-                  $ref: '#/components/schemas/CoreTrackRange'
-                description: Track ranges on which the speed limitation applies
-          description: List of applicable temporary speed limits between the train departure and arrival
-        time_gap_after:
-          type: integer
-          format: int64
-          description: Gap between the created train and following trains in milliseconds
-          minimum: 0
-        time_gap_before:
-          type: integer
-          format: int64
-          description: Gap between the created train and previous trains in milliseconds
-          minimum: 0
-        time_step:
-          type:
-          - integer
-          - 'null'
-          format: int64
-          description: Numerical integration time step in milliseconds. Use default value if not specified.
-          minimum: 0
-        timetable_id:
-          type: integer
-          format: int64
-          description: Timetable id
-        work_schedules:
-          type: array
-          items:
-            $ref: '#/components/schemas/CoreWorkSchedule'
-          description: List of planned work schedules
-    CoreStepTimingData:
-      type: object
-      description: Contains the data of a step timing, when it is specified
-      required:
-      - arrival_time
-      - arrival_time_tolerance_before
-      - arrival_time_tolerance_after
-      properties:
-        arrival_time:
-          type: string
-          format: date-time
-          description: Time the train should arrive at this point
-        arrival_time_tolerance_after:
-          type: integer
-          format: int64
-          description: Tolerance for the arrival time, when it arrives after the expected time, in ms
-          minimum: 0
-        arrival_time_tolerance_before:
-          type: integer
-          format: int64
-          description: Tolerance for the arrival time, when it arrives before the expected time, in ms
-          minimum: 0
     CoreTrackRange:
       type: object
       description: |-
@@ -6156,52 +5863,6 @@ components:
         train_name:
           type: string
           description: ID that can be used to find the train in tools other than OSRD. Used in debug traces.
-    CoreUndirectedTrackRange:
-      type: object
-      description: |-
-        A range on a track section.
-        `begin` is always less than `end`.
-      required:
-      - track_section
-      - begin
-      - end
-      properties:
-        begin:
-          type: integer
-          format: int64
-          description: The beginning of the range in mm.
-          minimum: 0
-        end:
-          type: integer
-          format: int64
-          description: The end of the range in mm.
-          minimum: 0
-        track_section:
-          type: string
-          description: The track section identifier.
-    CoreWorkSchedule:
-      type: object
-      description: Lighter description of a work schedule, with only the relevant information for core
-      required:
-      - start_time
-      - end_time
-      - track_ranges
-      properties:
-        end_time:
-          type: integer
-          format: int64
-          description: End time as a time delta from the stdcm start time in ms
-          minimum: 0
-        start_time:
-          type: integer
-          format: int64
-          description: Start time as a time delta from the stdcm start time in ms
-          minimum: 0
-        track_ranges:
-          type: array
-          items:
-            $ref: '#/components/schemas/CoreUndirectedTrackRange'
-          description: List of unavailable track ranges
     CoreZoneUpdate:
       type: object
       required:
@@ -14953,10 +14614,6 @@ components:
         - departure_time
         - status
         properties:
-          core_payload:
-            oneOf:
-            - type: 'null'
-            - $ref: '#/components/schemas/CoreStdcmRequest'
           departure_time:
             type: string
             format: date-time
@@ -14973,10 +14630,6 @@ components:
         required:
         - status
         properties:
-          core_payload:
-            oneOf:
-            - type: 'null'
-            - $ref: '#/components/schemas/CoreStdcmRequest'
           status:
             type: string
             enum:
@@ -14987,10 +14640,6 @@ components:
         - error
         - status
         properties:
-          core_payload:
-            oneOf:
-            - type: 'null'
-            - $ref: '#/components/schemas/CoreStdcmRequest'
           error:
             $ref: '#/components/schemas/SimulationResponse'
           status:
@@ -15003,10 +14652,6 @@ components:
         - error
         - status
         properties:
-          core_payload:
-            oneOf:
-            - type: 'null'
-            - $ref: '#/components/schemas/CoreStdcmRequest'
           error:
             $ref: '#/components/schemas/InternalError'
           status:

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -3990,10 +3990,6 @@ paths:
                   - departure_time
                   - status
                   properties:
-                    core_payload:
-                      oneOf:
-                      - type: 'null'
-                      - $ref: '#/components/schemas/core.StdcmRequest'
                     departure_time:
                       type: string
                       format: date-time
@@ -4009,10 +4005,6 @@ paths:
                   required:
                   - status
                   properties:
-                    core_payload:
-                      oneOf:
-                      - type: 'null'
-                      - $ref: '#/components/schemas/core.StdcmRequest'
                     status:
                       type: string
                       enum:
@@ -4022,10 +4014,6 @@ paths:
                   - error
                   - status
                   properties:
-                    core_payload:
-                      oneOf:
-                      - type: 'null'
-                      - $ref: '#/components/schemas/core.StdcmRequest'
                     error:
                       $ref: '#/components/schemas/SimulationResponse'
                     status:
@@ -5202,126 +5190,6 @@ components:
             type: integer
             format: int64
           description: List of work schedule ids involved in the conflict
-    ConsistConfiguration:
-      type: object
-      description: Represents a physics consist.
-      required:
-      - supported_signaling_systems
-      - loading_gauge_type
-      - physics_consist
-      properties:
-        loading_gauge_type:
-          $ref: '#/components/schemas/LoadingGaugeType'
-          description: The loading gauge of the rolling stock
-        physics_consist:
-          type: object
-          required:
-          - effort_curves
-          - length
-          - max_speed
-          - startup_time
-          - startup_acceleration
-          - comfort_acceleration
-          - const_gamma
-          - inertia_coefficient
-          - mass
-          - rolling_resistance
-          properties:
-            base_power_class:
-              type:
-              - string
-              - 'null'
-            comfort_acceleration:
-              type: number
-              format: double
-              description: Acceleration in m·s⁻²
-            const_gamma:
-              type: number
-              format: double
-              description: |2-
-                 The constant gamma braking coefficient used when NOT circulating
-                 under ETCS/ERTMS signaling system
-                Acceleration in m·s⁻²
-            effort_curves:
-              $ref: '#/components/schemas/EffortCurves'
-            electrical_power_startup_time:
-              type:
-              - integer
-              - 'null'
-              format: int64
-              description: |-
-                The time the train takes before actually using electrical power.
-                Is null if the train is not electric or the value not specified.
-              minimum: 0
-            etcs_brake_params:
-              oneOf:
-              - type: 'null'
-              - $ref: '#/components/schemas/EtcsBrakeParams'
-            inertia_coefficient:
-              type: number
-              format: double
-            length:
-              type: integer
-              format: int64
-              minimum: 0
-            mass:
-              type: integer
-              format: int64
-              minimum: 0
-            max_speed:
-              type: number
-              format: double
-              description: Velocity in m·s⁻¹
-            power_restrictions:
-              type: object
-              description: Mapping of power restriction code to power class
-              additionalProperties:
-                type: string
-              propertyNames:
-                type: string
-            raise_pantograph_time:
-              type:
-              - integer
-              - 'null'
-              format: int64
-              description: |-
-                The time it takes to raise this train's pantograph.
-                Is null if the train is not electric or the value not specified.
-              minimum: 0
-            rolling_resistance:
-              $ref: '#/components/schemas/RollingResistance'
-            startup_acceleration:
-              type: number
-              format: double
-              description: Acceleration in m·s⁻²
-            startup_time:
-              type: integer
-              format: int64
-              minimum: 0
-        speed_limit_tag:
-          type:
-          - string
-          - 'null'
-        supported_signaling_systems:
-          type: array
-          items:
-            type: string
-          description: List of supported signaling systems
-    ConsistSchedule:
-      type: object
-      required:
-      - boundaries
-      - values
-      properties:
-        boundaries:
-          type: array
-          items:
-            type: integer
-            minimum: 0
-        values:
-          type: array
-          items:
-            $ref: '#/components/schemas/ConsistConfiguration'
     ConstraintDistributionChangeGroup:
       type: object
       required:
@@ -15166,28 +15034,6 @@ components:
           type: integer
           format: int64
           minimum: 0
-    core.PathItem:
-      type: object
-      required:
-      - locations
-      properties:
-        locations:
-          type: array
-          items:
-            $ref: '#/components/schemas/TrackOffset'
-          description: The track offsets of the path item
-        step_timing_data:
-          oneOf:
-          - type: 'null'
-          - $ref: '#/components/schemas/core.StepTimingData'
-            description: If specified, describes when the train may arrive at the location
-        stop_duration:
-          type:
-          - integer
-          - 'null'
-          format: int64
-          description: Stop duration in milliseconds. None if the train does not stop at this path item.
-          minimum: 0
     core.PathfindingInputError:
       oneOf:
       - type: object
@@ -15504,148 +15350,6 @@ components:
           minimum: 0
         zone:
           type: string
-    core.StdcmRequest:
-      type: object
-      required:
-      - infra
-      - expected_version
-      - timetable_id
-      - path_items
-      - comfort
-      - consist_schedule
-      - start_time
-      - maximum_departure_delay
-      - maximum_run_time
-      - time_gap_before
-      - time_gap_after
-      - work_schedules
-      - temporary_speed_limits
-      properties:
-        allowed_track_sections:
-          type:
-          - array
-          - 'null'
-          items:
-            type: string
-          description: Set of authorized track section ids for the current request
-          uniqueItems: true
-        comfort:
-          $ref: '#/components/schemas/Comfort'
-          description: The comfort of the train
-        consist_schedule:
-          $ref: '#/components/schemas/ConsistSchedule'
-        expected_version:
-          type: integer
-          format: int64
-          description: Infrastructure expected version
-        infra:
-          type: integer
-          format: int64
-          description: Infrastructure id
-        margin:
-          oneOf:
-          - type: 'null'
-          - oneOf:
-            - type: object
-              required:
-              - Percentage
-              properties:
-                Percentage:
-                  type: number
-                  format: double
-            - type: object
-              required:
-              - MinPer100Km
-              properties:
-                MinPer100Km:
-                  type: number
-                  format: double
-          description: Margin to apply to the whole train
-        maximum_departure_delay:
-          type: integer
-          format: int64
-          description: Maximum departure delay in milliseconds.
-          minimum: 0
-        maximum_run_time:
-          type: integer
-          format: int64
-          description: Maximum run time of the simulation in milliseconds
-          minimum: 0
-        path_items:
-          type: array
-          items:
-            $ref: '#/components/schemas/core.PathItem'
-          description: List of waypoints. Each waypoint is a list of track offset.
-        start_time:
-          type: string
-          format: date-time
-        temporary_speed_limits:
-          type: array
-          items:
-            type: object
-            description: Lighter description of a work schedule with only the relevant information for core
-            required:
-            - speed_limit
-            - track_ranges
-            properties:
-              speed_limit:
-                type: number
-                format: double
-                description: Speed limitation in m/s
-              track_ranges:
-                type: array
-                items:
-                  $ref: '#/components/schemas/core.TrackRange'
-                description: Track ranges on which the speed limitation applies
-          description: List of applicable temporary speed limits between the train departure and arrival
-        time_gap_after:
-          type: integer
-          format: int64
-          description: Gap between the created train and following trains in milliseconds
-          minimum: 0
-        time_gap_before:
-          type: integer
-          format: int64
-          description: Gap between the created train and previous trains in milliseconds
-          minimum: 0
-        time_step:
-          type:
-          - integer
-          - 'null'
-          format: int64
-          description: Numerical integration time step in milliseconds. Use default value if not specified.
-          minimum: 0
-        timetable_id:
-          type: integer
-          format: int64
-          description: Timetable id
-        work_schedules:
-          type: array
-          items:
-            $ref: '#/components/schemas/core.WorkSchedule'
-          description: List of planned work schedules
-    core.StepTimingData:
-      type: object
-      description: Contains the data of a step timing, when it is specified
-      required:
-      - arrival_time
-      - arrival_time_tolerance_before
-      - arrival_time_tolerance_after
-      properties:
-        arrival_time:
-          type: string
-          format: date-time
-          description: Time the train should arrive at this point
-        arrival_time_tolerance_after:
-          type: integer
-          format: int64
-          description: Tolerance for the arrival time, when it arrives after the expected time, in ms
-          minimum: 0
-        arrival_time_tolerance_before:
-          type: integer
-          format: int64
-          description: Tolerance for the arrival time, when it arrives before the expected time, in ms
-          minimum: 0
     core.TrackRange:
       type: object
       description: |-
@@ -15726,52 +15430,6 @@ components:
         train_name:
           type: string
           description: ID that can be used to find the train in tools other than OSRD. Used in debug traces.
-    core.UndirectedTrackRange:
-      type: object
-      description: |-
-        A range on a track section.
-        `begin` is always less than `end`.
-      required:
-      - track_section
-      - begin
-      - end
-      properties:
-        begin:
-          type: integer
-          format: int64
-          description: The beginning of the range in mm.
-          minimum: 0
-        end:
-          type: integer
-          format: int64
-          description: The end of the range in mm.
-          minimum: 0
-        track_section:
-          type: string
-          description: The track section identifier.
-    core.WorkSchedule:
-      type: object
-      description: Lighter description of a work schedule, with only the relevant information for core
-      required:
-      - start_time
-      - end_time
-      - track_ranges
-      properties:
-        end_time:
-          type: integer
-          format: int64
-          description: End time as a time delta from the stdcm start time in ms
-          minimum: 0
-        start_time:
-          type: integer
-          format: int64
-          description: Start time as a time delta from the stdcm start time in ms
-          minimum: 0
-        track_ranges:
-          type: array
-          items:
-            $ref: '#/components/schemas/core.UndirectedTrackRange'
-          description: List of unavailable track ranges
     core.ZoneUpdate:
       type: object
       required:

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -76,22 +76,13 @@ pub(in crate::views) enum StdcmResponse {
         simulation: SimulationResponseSuccess,
         pathfinding_result: PathfindingResultSuccess,
         departure_time: DateTime<Utc>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        core_payload: Option<StdcmRequest>,
     },
-    PathNotFound {
-        #[serde(skip_serializing_if = "Option::is_none")]
-        core_payload: Option<StdcmRequest>,
-    },
+    PathNotFound,
     PreprocessingSimulationError {
         error: simulation::Response,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        core_payload: Option<StdcmRequest>,
     },
     InternalError {
         error: InternalError,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        core_payload: Option<StdcmRequest>,
     },
 }
 
@@ -160,11 +151,6 @@ pub(in crate::views) struct StdcmQueryParams {
     /// The infra id
     #[param(required = true)]
     infra: i64,
-    /// If true, extra payloads are returned to help with debugging
-    #[schema(required = false)]
-    #[serde(default)]
-    #[param(nullable)]
-    return_debug_payloads: bool,
 }
 
 /// This function computes a STDCM and returns the result.
@@ -182,7 +168,6 @@ pub(in crate::views) struct StdcmQueryParams {
     skip_all,
     err,
     fields(
-        request,
         timetable_id = id,
         infra_id = query.infra,
         path_found,
@@ -202,39 +187,6 @@ pub(in crate::views) struct StdcmQueryParams {
     )
 )]
 pub(in crate::views) async fn stdcm(
-    state: State<AppState>,
-    extension: AuthenticationExt,
-    Path(id): Path<i64>,
-    Query(query): Query<StdcmQueryParams>,
-    Json(request): Json<Request>,
-) -> Result<impl IntoResponse> {
-    // Add serialized request to trace attributes, skipping allowed track sections
-    // (as it would make the payload too large to be saved). TODO: include search env ID
-    let mut request_copy = request.clone();
-    request_copy.allowed_track_sections = None;
-    Span::current().record("request", serde_json::to_string(&request_copy)?);
-    let mut returned_request: Option<core_client::stdcm::Request> = None;
-    stdcm_handler(
-        state,
-        extension,
-        Path(id),
-        Query(query),
-        Json(request),
-        &mut returned_request,
-    )
-    .await
-    .map_err(|mut err| {
-        if let Some(request) = returned_request {
-            err.context.insert(
-                String::from("core_payload"),
-                serde_json::to_value(request).unwrap_or(serde_json::Value::Null),
-            );
-        }
-        err
-    })
-}
-
-pub(in crate::views) async fn stdcm_handler(
     State(AppState {
         config,
         db_pool,
@@ -246,7 +198,6 @@ pub(in crate::views) async fn stdcm_handler(
     Path(id): Path<i64>,
     Query(query): Query<StdcmQueryParams>,
     Json(request): Json<Request>,
-    returned_request: &mut Option<core_client::stdcm::Request>,
 ) -> Result<Response> {
     let mut conn = db_pool.get().await?;
 
@@ -349,7 +300,6 @@ pub(in crate::views) async fn stdcm_handler(
     if let Some(failure) = pathfinding_failures.pop() {
         let payload = StdcmResponse::PreprocessingSimulationError {
             error: failure.simulation,
-            core_payload: None,
         };
         return Ok(StreamBodyAs::json_nl(stream::once(async { payload })).into_response());
     }
@@ -406,10 +356,8 @@ pub(in crate::views) async fn stdcm_handler(
             })
             .collect(),
     };
-    *returned_request = query.return_debug_payloads.then_some(stdcm_request.clone());
 
     let (tx, rx) = mpsc::unbounded_channel();
-    let core_payload = returned_request.clone();
 
     let stream_result_lambda = async move {
         let stream_stdcm_response = stdcm_request
@@ -423,7 +371,6 @@ pub(in crate::views) async fn stdcm_handler(
             Err(e) => {
                 let _ = tx.send(StdcmProgression::Completed(StdcmResponse::InternalError {
                     error: e,
-                    core_payload: core_payload.clone(),
                 }));
                 return;
             }
@@ -455,21 +402,15 @@ pub(in crate::views) async fn stdcm_handler(
                                 simulation: simulation.into(),
                                 pathfinding_result: path,
                                 departure_time,
-                                core_payload: core_payload.clone(),
                             })
                         }
                         core_client::stdcm::Response::PathNotFound => {
                             span.record("path_found", false);
-                            StdcmProgression::Completed(StdcmResponse::PathNotFound {
-                                core_payload: core_payload.clone(),
-                            })
+                            StdcmProgression::Completed(StdcmResponse::PathNotFound {})
                         }
                     },
                 },
-                Err(e) => StdcmProgression::Completed(StdcmResponse::InternalError {
-                    error: e,
-                    core_payload: core_payload.clone(),
-                }),
+                Err(e) => StdcmProgression::Completed(StdcmResponse::InternalError { error: e }),
             }
         });
 
@@ -1078,7 +1019,6 @@ mod tests {
                     pathfinding_result: path,
                     departure_time: DateTime::from_str("2024-01-02T00:00:00Z")
                         .expect("Failed to parse datetime"),
-                    core_payload: None,
                 })
             );
         }
@@ -1212,7 +1152,7 @@ mod tests {
 
         assert_eq!(
             stdcm_response,
-            StdcmProgression::Completed(StdcmResponse::PathNotFound { core_payload: None })
+            StdcmProgression::Completed(StdcmResponse::PathNotFound {})
         );
     }
 
@@ -1288,7 +1228,6 @@ mod tests {
                     pathfinding_result: path,
                     departure_time: DateTime::from_str("2024-01-02T00:00:00Z")
                         .expect("Failed to parse datetime"),
-                    core_payload: None,
                 })
             );
         }
@@ -1353,7 +1292,7 @@ mod tests {
         );
         assert_eq!(
             stdcm_response[2].clone(),
-            StdcmProgression::Completed(StdcmResponse::PathNotFound { core_payload: None })
+            StdcmProgression::Completed(StdcmResponse::PathNotFound {})
         );
     }
 
@@ -1562,7 +1501,6 @@ mod tests {
                 pathfinding_result: pathfinding_result_success(),
                 departure_time: DateTime::from_str("2024-01-02T00:00:00Z")
                     .expect("Failed to parse datetime"),
-                core_payload: None,
             })
         );
     }
@@ -1649,7 +1587,6 @@ mod tests {
                 pathfinding_result: pathfinding_result_success(),
                 departure_time: DateTime::from_str("2024-01-02T00:00:00Z")
                     .expect("Failed to parse datetime"),
-                core_payload: None,
             })
         );
     }

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -62,17 +62,10 @@ pub(in crate::views) enum StdcmResponse {
         simulation: SimulationResponseSuccess,
         pathfinding_result: PathfindingResultSuccess,
         departure_time: DateTime<Utc>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        core_payload: Option<StdcmRequest>,
     },
-    PathNotFound {
-        #[serde(skip_serializing_if = "Option::is_none")]
-        core_payload: Option<StdcmRequest>,
-    },
+    PathNotFound,
     PreprocessingSimulationError {
         error: simulation::Response,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        core_payload: Option<StdcmRequest>,
     },
 }
 
@@ -140,7 +133,6 @@ pub(in crate::views) struct StdcmQueryParams {
     skip_all,
     err,
     fields(
-        request,
         timetable_id = id,
         infra_id = query.infra,
         path_found,
@@ -160,39 +152,6 @@ pub(in crate::views) struct StdcmQueryParams {
     )
 )]
 pub(in crate::views) async fn stdcm(
-    state: State<AppState>,
-    extension: AuthenticationExt,
-    Path(id): Path<i64>,
-    Query(query): Query<StdcmQueryParams>,
-    Json(request): Json<Request>,
-) -> Result<Json<StdcmResponse>> {
-    // Add serialized request to trace attributes, skipping allowed track sections
-    // (as it would make the payload too large to be saved). TODO: include search env ID
-    let mut request_copy = request.clone();
-    request_copy.allowed_track_sections = None;
-    Span::current().record("request", serde_json::to_string(&request_copy)?);
-    let mut returned_request: Option<core_client::stdcm::Request> = None;
-    stdcm_handler(
-        state,
-        extension,
-        Path(id),
-        Query(query),
-        Json(request),
-        &mut returned_request,
-    )
-    .await
-    .map_err(|mut err| {
-        if let Some(request) = returned_request {
-            err.context.insert(
-                String::from("core_payload"),
-                serde_json::to_value(request).unwrap_or(serde_json::Value::Null),
-            );
-        }
-        err
-    })
-}
-
-pub(in crate::views) async fn stdcm_handler(
     State(AppState {
         config,
         db_pool,
@@ -204,7 +163,6 @@ pub(in crate::views) async fn stdcm_handler(
     Path(id): Path<i64>,
     Query(query): Query<StdcmQueryParams>,
     Json(request): Json<Request>,
-    returned_request: &mut Option<core_client::stdcm::Request>,
 ) -> Result<Json<StdcmResponse>> {
     let authorized = auth
         .check_roles([authz::Role::Stdcm].into())
@@ -284,7 +242,6 @@ pub(in crate::views) async fn stdcm_handler(
     else {
         return Ok(Json(StdcmResponse::PreprocessingSimulationError {
             error: virtual_train_run.simulation,
-            core_payload: None,
         }))
     };
 
@@ -329,7 +286,6 @@ pub(in crate::views) async fn stdcm_handler(
             })
             .collect(),
     };
-    *returned_request = query.return_debug_payloads.then_some(stdcm_request.clone());
 
     let stdcm_response: Result<core_client::stdcm::Response, InternalError> = stdcm_request
         .fetch(core_client.as_ref())
@@ -349,14 +305,11 @@ pub(in crate::views) async fn stdcm_handler(
                 simulation: simulation.into(),
                 pathfinding_result: path,
                 departure_time,
-                core_payload: returned_request.clone(),
             }))
         }
         core_client::stdcm::Response::PathNotFound => {
             span.record("path_found", false);
-            Ok(Json(StdcmResponse::PathNotFound {
-                core_payload: returned_request.clone(),
-            }))
+            Ok(Json(StdcmResponse::PathNotFound))
         }
     }
 }
@@ -815,7 +768,6 @@ mod tests {
                     pathfinding_result: path,
                     departure_time: DateTime::from_str("2024-01-02T00:00:00Z")
                         .expect("Failed to parse datetime"),
-                    core_payload: None,
                 }
             );
         }
@@ -952,7 +904,6 @@ mod tests {
                     pathfinding_result: path,
                     departure_time: DateTime::from_str("2024-01-02T00:00:00Z")
                         .expect("Failed to parse datetime"),
-                    core_payload: None,
                 }
             );
         }
@@ -983,10 +934,7 @@ mod tests {
             .assert_status(StatusCode::OK)
             .json_into();
 
-        assert_eq!(
-            stdcm_response,
-            StdcmResponse::PathNotFound { core_payload: None }
-        );
+        assert_eq!(stdcm_response, StdcmResponse::PathNotFound);
     }
 
     #[rstest]

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -1141,7 +1141,6 @@ const injectedRtkApi = api
           body: queryArg.body,
           params: {
             infra: queryArg.infra,
-            return_debug_payloads: queryArg.returnDebugPayloads,
           },
         }),
         invalidatesTags: ['stdcm'],
@@ -2463,8 +2462,6 @@ export type PostTimetableByIdStdcmApiArg = {
   id: number;
   /** The infra id */
   infra: number;
-  /** If true, extra payloads are returned to help with debugging */
-  returnDebugPayloads?: boolean | null;
   body: {
     /** Set of authorized track section ids for the current loading gauge,
         None value means no zone restriction. */
@@ -4680,6 +4677,36 @@ export type StdcmProgressionEvent = {
   best_travel_time: number;
   point: GeoJsonPoint;
 };
+export type SimulationResponse =
+  | (SimulationResponseSuccess & {
+      status: 'success';
+    })
+  | {
+      pathfinding_failed: PathfindingFailure;
+      status: 'pathfinding_failed';
+    }
+  | {
+      core_error: InternalError;
+      status: 'simulation_failed';
+    };
+export type StdcmResponse =
+  | {
+      departure_time: string;
+      pathfinding_result: CorePathfindingResultSuccess;
+      simulation: SimulationResponseSuccess;
+      status: 'success';
+    }
+  | {
+      status: 'path_not_found';
+    }
+  | {
+      error: SimulationResponse;
+      status: 'preprocessing_simulation_error';
+    }
+  | {
+      error: InternalError;
+      status: 'internal_error';
+    };
 export type ConsistConfiguration = {
   loading_gauge_type?: null | LoadingGaugeType;
   /** Velocity in m·s⁻¹ */
@@ -4701,123 +4728,6 @@ export type ConsistSchedule = {
     It should contain one more element than boundaries */
   values: ConsistConfiguration[];
 };
-export type CorePathItem = {
-  /** If true, the train can backtrack at these track offsets. */
-  can_backtrack?: boolean | null;
-  /** The track offsets of the path item. */
-  locations: TrackOffset[];
-};
-export type CoreStepTimingData = {
-  /** Time the train should arrive at this point */
-  arrival_time: string;
-  /** Tolerance for the arrival time, when it arrives after the expected time, in ms */
-  arrival_time_tolerance_after: number;
-  /** Tolerance for the arrival time, when it arrives before the expected time, in ms */
-  arrival_time_tolerance_before: number;
-};
-export type CoreStdcmPathItem = {
-  /** The path item containing its locations and backtrack information. */
-  path_item: CorePathItem;
-  step_timing_data?: null | CoreStepTimingData;
-  /** Stop duration in milliseconds. None if the train does not stop at this path item. */
-  stop_duration?: number | null;
-};
-export type CoreUndirectedTrackRange = {
-  /** The beginning of the range in mm. */
-  begin: number;
-  /** The end of the range in mm. */
-  end: number;
-  /** The track section identifier. */
-  track_section: string;
-};
-export type CoreWorkSchedule = {
-  /** End time as a time delta from the stdcm start time in ms */
-  end_time: number;
-  /** Start time as a time delta from the stdcm start time in ms */
-  start_time: number;
-  /** List of unavailable track ranges */
-  track_ranges: CoreUndirectedTrackRange[];
-};
-export type CoreStdcmRequest = {
-  /** Set of authorized track section ids for the current request */
-  allowed_track_sections?: string[] | null;
-  /** The comfort of the train */
-  comfort: Comfort;
-  consist_schedule: ConsistSchedule;
-  /** Infrastructure expected version */
-  expected_version: number;
-  /** Infrastructure id */
-  infra: number;
-  /** Margin to apply to the whole train */
-  margin?:
-    | null
-    | (
-        | {
-            Percentage: number;
-          }
-        | {
-            MinPer100Km: number;
-          }
-      );
-  /** Maximum departure delay in milliseconds. */
-  maximum_departure_delay: number;
-  /** Maximum run time of the simulation in milliseconds */
-  maximum_run_time: number;
-  /** List of waypoints. Each waypoint is a list of track offset. */
-  path_items: CoreStdcmPathItem[];
-  start_time: string;
-  /** List of applicable temporary speed limits between the train departure and arrival */
-  temporary_speed_limits: {
-    /** Speed limitation in m/s */
-    speed_limit: number;
-    /** Track ranges on which the speed limitation applies */
-    track_ranges: CoreTrackRange[];
-  }[];
-  /** Gap between the created train and following trains in milliseconds */
-  time_gap_after: number;
-  /** Gap between the created train and previous trains in milliseconds */
-  time_gap_before: number;
-  /** Numerical integration time step in milliseconds. Use default value if not specified. */
-  time_step?: number | null;
-  /** Timetable id */
-  timetable_id: number;
-  /** List of planned work schedules */
-  work_schedules: CoreWorkSchedule[];
-};
-export type SimulationResponse =
-  | (SimulationResponseSuccess & {
-      status: 'success';
-    })
-  | {
-      pathfinding_failed: PathfindingFailure;
-      status: 'pathfinding_failed';
-    }
-  | {
-      core_error: InternalError;
-      status: 'simulation_failed';
-    };
-export type StdcmResponse =
-  | {
-      core_payload?: null | CoreStdcmRequest;
-      departure_time: string;
-      pathfinding_result: CorePathfindingResultSuccess;
-      simulation: SimulationResponseSuccess;
-      status: 'success';
-    }
-  | {
-      core_payload?: null | CoreStdcmRequest;
-      status: 'path_not_found';
-    }
-  | {
-      core_payload?: null | CoreStdcmRequest;
-      error: SimulationResponse;
-      status: 'preprocessing_simulation_error';
-    }
-  | {
-      core_payload?: null | CoreStdcmRequest;
-      error: InternalError;
-      status: 'internal_error';
-    };
 export type PathfindingItem = {
   /** The stop duration in milliseconds, None if the train does not stop. */
   duration?: number | null;

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -2407,18 +2407,15 @@ export type GetTimetableByIdRoundTripsPacedTrainsApiArg = {
 };
 export type PostTimetableByIdStdcmApiResponse = /** status 200 The simulation result */
   | {
-      core_payload?: null | CoreStdcmRequest;
       departure_time: string;
       pathfinding_result: CorePathfindingResultSuccess;
       simulation: SimulationResponseSuccess;
       status: 'success';
     }
   | {
-      core_payload?: null | CoreStdcmRequest;
       status: 'path_not_found';
     }
   | {
-      core_payload?: null | CoreStdcmRequest;
       error: SimulationResponse;
       status: 'preprocessing_simulation_error';
     };
@@ -4700,124 +4697,6 @@ export type CoreTrainRequirementsById = {
   train_id: string;
   /** ID that can be used to find the train in tools other than OSRD. Used in debug traces. */
   train_name: string;
-};
-export type ConsistConfiguration = {
-  /** The loading gauge of the rolling stock */
-  loading_gauge_type: LoadingGaugeType;
-  physics_consist: {
-    base_power_class?: string | null;
-    /** Acceleration in m·s⁻² */
-    comfort_acceleration: number;
-    /**  The constant gamma braking coefficient used when NOT circulating
-         under ETCS/ERTMS signaling system
-        Acceleration in m·s⁻² */
-    const_gamma: number;
-    effort_curves: EffortCurves;
-    /** The time the train takes before actually using electrical power.
-        Is null if the train is not electric or the value not specified. */
-    electrical_power_startup_time?: number | null;
-    etcs_brake_params?: null | EtcsBrakeParams;
-    inertia_coefficient: number;
-    length: number;
-    mass: number;
-    /** Velocity in m·s⁻¹ */
-    max_speed: number;
-    /** Mapping of power restriction code to power class */
-    power_restrictions?: {
-      [key: string]: string;
-    };
-    /** The time it takes to raise this train's pantograph.
-        Is null if the train is not electric or the value not specified. */
-    raise_pantograph_time?: number | null;
-    rolling_resistance: RollingResistance;
-    /** Acceleration in m·s⁻² */
-    startup_acceleration: number;
-    startup_time: number;
-  };
-  speed_limit_tag?: string | null;
-  /** List of supported signaling systems */
-  supported_signaling_systems: string[];
-};
-export type ConsistSchedule = {
-  boundaries: number[];
-  values: ConsistConfiguration[];
-};
-export type CoreStepTimingData = {
-  /** Time the train should arrive at this point */
-  arrival_time: string;
-  /** Tolerance for the arrival time, when it arrives after the expected time, in ms */
-  arrival_time_tolerance_after: number;
-  /** Tolerance for the arrival time, when it arrives before the expected time, in ms */
-  arrival_time_tolerance_before: number;
-};
-export type CorePathItem = {
-  /** The track offsets of the path item */
-  locations: TrackOffset[];
-  step_timing_data?: null | CoreStepTimingData;
-  /** Stop duration in milliseconds. None if the train does not stop at this path item. */
-  stop_duration?: number | null;
-};
-export type CoreUndirectedTrackRange = {
-  /** The beginning of the range in mm. */
-  begin: number;
-  /** The end of the range in mm. */
-  end: number;
-  /** The track section identifier. */
-  track_section: string;
-};
-export type CoreWorkSchedule = {
-  /** End time as a time delta from the stdcm start time in ms */
-  end_time: number;
-  /** Start time as a time delta from the stdcm start time in ms */
-  start_time: number;
-  /** List of unavailable track ranges */
-  track_ranges: CoreUndirectedTrackRange[];
-};
-export type CoreStdcmRequest = {
-  /** Set of authorized track section ids for the current request */
-  allowed_track_sections?: string[] | null;
-  /** The comfort of the train */
-  comfort: Comfort;
-  consist_schedule: ConsistSchedule;
-  /** Infrastructure expected version */
-  expected_version: number;
-  /** Infrastructure id */
-  infra: number;
-  /** Margin to apply to the whole train */
-  margin?:
-    | null
-    | (
-        | {
-            Percentage: number;
-          }
-        | {
-            MinPer100Km: number;
-          }
-      );
-  /** Maximum departure delay in milliseconds. */
-  maximum_departure_delay: number;
-  /** Maximum run time of the simulation in milliseconds */
-  maximum_run_time: number;
-  /** List of waypoints. Each waypoint is a list of track offset. */
-  path_items: CorePathItem[];
-  start_time: string;
-  /** List of applicable temporary speed limits between the train departure and arrival */
-  temporary_speed_limits: {
-    /** Speed limitation in m/s */
-    speed_limit: number;
-    /** Track ranges on which the speed limitation applies */
-    track_ranges: CoreTrackRange[];
-  }[];
-  /** Gap between the created train and following trains in milliseconds */
-  time_gap_after: number;
-  /** Gap between the created train and previous trains in milliseconds */
-  time_gap_before: number;
-  /** Numerical integration time step in milliseconds. Use default value if not specified. */
-  time_step?: number | null;
-  /** Timetable id */
-  timetable_id: number;
-  /** List of planned work schedules */
-  work_schedules: CoreWorkSchedule[];
 };
 export type PathfindingItem = {
   /** The stop duration in milliseconds, None if the train does not stop. */

--- a/osrd_schemas_auto/osrd_schemas_auto/models.py
+++ b/osrd_schemas_auto/osrd_schemas_auto/models.py
@@ -332,80 +332,6 @@ class CoreSpacingRequirement(BaseModel):
     zone: str
 
 
-class MarginValuePercentage(BaseModel):
-    """
-    Margin to apply to the whole train
-    """
-
-    Percentage: float
-
-
-class MarginValueMinPer100Km(BaseModel):
-    """
-    Margin to apply to the whole train
-    """
-
-    MinPer100Km: float
-
-
-class CoreStepTimingData(BaseModel):
-    """
-    Contains the data of a step timing, when it is specified
-    """
-
-    arrival_time: AwareDatetime
-    """
-    Time the train should arrive at this point
-    """
-    arrival_time_tolerance_after: Annotated[int, Field(ge=0)]
-    """
-    Tolerance for the arrival time, when it arrives after the expected time, in ms
-    """
-    arrival_time_tolerance_before: Annotated[int, Field(ge=0)]
-    """
-    Tolerance for the arrival time, when it arrives before the expected time, in ms
-    """
-
-
-class CoreUndirectedTrackRange(BaseModel):
-    """
-    A range on a track section.
-    `begin` is always less than `end`.
-    """
-
-    begin: Annotated[int, Field(ge=0)]
-    """
-    The beginning of the range in mm.
-    """
-    end: Annotated[int, Field(ge=0)]
-    """
-    The end of the range in mm.
-    """
-    track_section: str
-    """
-    The track section identifier.
-    """
-
-
-class CoreWorkSchedule(BaseModel):
-    """
-    Lighter description of a work schedule, with only the relevant information for core
-    """
-
-    end_time: Annotated[int, Field(ge=0)]
-    """
-    End time as a time delta from the stdcm start time in ms
-    """
-    start_time: Annotated[int, Field(ge=0)]
-    """
-    Start time as a time delta from the stdcm start time in ms
-    """
-    track_ranges: list[CoreUndirectedTrackRange]
-    """
-    List of unavailable track ranges
-    """
-
-
 class CoreZoneUpdate(BaseModel):
     is_entry: bool
     position: Annotated[int, Field(ge=0)]
@@ -3634,6 +3560,15 @@ class StartTimeChangeGroup(BaseModel):
     value: AwareDatetime
 
 
+class StdcmResponsePathNotFound(BaseModel):
+    status: Literal["path_not_found"]
+
+
+class StdcmResponseInternalError(BaseModel):
+    error: InternalError
+    status: Literal["internal_error"]
+
+
 class StdcmSearchEnvironment(BaseModel):
     allowed_tracks: dict[str, Any] | None = None
     """
@@ -4243,17 +4178,6 @@ class CoreIncompatibleOffsetRangeWithValue(BaseModel):
     value: str
 
 
-class CorePathItem(BaseModel):
-    can_backtrack: bool | None = None
-    """
-    If true, the train can backtrack at these track offsets.
-    """
-    locations: list[TrackOffset]
-    """
-    The track offsets of the path item.
-    """
-
-
 class CoreRoutingRequirement(BaseModel):
     begin_time: Annotated[int, Field(ge=0)]
     """
@@ -4261,18 +4185,6 @@ class CoreRoutingRequirement(BaseModel):
     """
     route: str
     zones: list[CoreRoutingZoneRequirement]
-
-
-class CoreSTDCMPathItem(BaseModel):
-    path_item: CorePathItem
-    """
-    The path item containing its locations and backtrack information.
-    """
-    step_timing_data: CoreStepTimingData | None = None
-    stop_duration: Annotated[int | None, Field(ge=0)] = None
-    """
-    Stop duration in milliseconds. None if the train does not stop at this path item.
-    """
 
 
 class CoreTrackRange(BaseModel):
@@ -5497,82 +5409,6 @@ class CorePathfindingResultSuccess(BaseModel):
     """
 
 
-class TemporarySpeedLimit(BaseModel):
-    """
-    Lighter description of a work schedule with only the relevant information for core
-    """
-
-    speed_limit: float
-    """
-    Speed limitation in m/s
-    """
-    track_ranges: list[CoreTrackRange]
-    """
-    Track ranges on which the speed limitation applies
-    """
-
-
-class CoreStdcmRequest(BaseModel):
-    allowed_track_sections: list[str] | None = None
-    """
-    Set of authorized track section ids for the current request
-    """
-    comfort: Comfort
-    """
-    The comfort of the train
-    """
-    consist_schedule: ConsistSchedule
-    expected_version: int
-    """
-    Infrastructure expected version
-    """
-    infra: int
-    """
-    Infrastructure id
-    """
-    margin: MarginValuePercentage | MarginValueMinPer100Km | None = None
-    """
-    Margin to apply to the whole train
-    """
-    maximum_departure_delay: Annotated[int, Field(ge=0)]
-    """
-    Maximum departure delay in milliseconds.
-    """
-    maximum_run_time: Annotated[int, Field(ge=0)]
-    """
-    Maximum run time of the simulation in milliseconds
-    """
-    path_items: list[CoreSTDCMPathItem]
-    """
-    List of waypoints. Each waypoint is a list of track offset.
-    """
-    start_time: AwareDatetime
-    temporary_speed_limits: list[TemporarySpeedLimit]
-    """
-    List of applicable temporary speed limits between the train departure and arrival
-    """
-    time_gap_after: Annotated[int, Field(ge=0)]
-    """
-    Gap between the created train and following trains in milliseconds
-    """
-    time_gap_before: Annotated[int, Field(ge=0)]
-    """
-    Gap between the created train and previous trains in milliseconds
-    """
-    time_step: Annotated[int | None, Field(ge=0)] = None
-    """
-    Numerical integration time step in milliseconds. Use default value if not specified.
-    """
-    timetable_id: int
-    """
-    Timetable id
-    """
-    work_schedules: list[CoreWorkSchedule]
-    """
-    List of planned work schedules
-    """
-
-
 class Detector(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -6187,22 +6023,10 @@ class SpeedSection(BaseModel):
 
 
 class StdcmResponseSuccess(BaseModel):
-    core_payload: CoreStdcmRequest | None = None
     departure_time: AwareDatetime
     pathfinding_result: CorePathfindingResultSuccess
     simulation: SimulationResponseSuccess
     status: Literal["success"]
-
-
-class StdcmResponsePathNotFound(BaseModel):
-    core_payload: CoreStdcmRequest | None = None
-    status: Literal["path_not_found"]
-
-
-class StdcmResponseInternalError(BaseModel):
-    core_payload: CoreStdcmRequest | None = None
-    error: InternalError
-    status: Literal["internal_error"]
 
 
 class Switch(BaseModel):
@@ -6227,66 +6051,6 @@ class TrackSectionModel(BaseModel):
     length: float
     loading_gauge_limits: list[LoadingGaugeLimit] | None = None
     slopes: list[Slope]
-
-
-class PhysicsConsist(BaseModel):
-    base_power_class: str | None = None
-    comfort_acceleration: float
-    """
-    Acceleration in m·s⁻²
-    """
-    const_gamma: float
-    """
-     The constant gamma braking coefficient used when NOT circulating
-     under ETCS/ERTMS signaling system
-    Acceleration in m·s⁻²
-    """
-    effort_curves: EffortCurves
-    electrical_power_startup_time: Annotated[int | None, Field(ge=0)] = None
-    """
-    The time the train takes before actually using electrical power.
-    Is null if the train is not electric or the value not specified.
-    """
-    etcs_brake_params: EtcsBrakeParams | None = None
-    inertia_coefficient: float
-    length: Annotated[int, Field(ge=0)]
-    mass: Annotated[int, Field(ge=0)]
-    max_speed: float
-    """
-    Velocity in m·s⁻¹
-    """
-    power_restrictions: dict[str, str] | None = None
-    """
-    Mapping of power restriction code to power class
-    """
-    raise_pantograph_time: Annotated[int | None, Field(ge=0)] = None
-    """
-    The time it takes to raise this train's pantograph.
-    Is null if the train is not electric or the value not specified.
-    """
-    rolling_resistance: RollingResistance
-    startup_acceleration: float
-    """
-    Acceleration in m·s⁻²
-    """
-    startup_time: Annotated[int, Field(ge=0)]
-
-
-class CoreConsistConfiguration(BaseModel):
-    """
-    Represents a physics consist.
-    """
-
-    loading_gauge_type: LoadingGaugeType
-    """
-    The loading gauge of the rolling stock
-    """
-    physics_consist: PhysicsConsist
-    speed_limit_tag: str | None = None
-    supported_signaling_systems: list[str]
-    """
-    List of supported signaling systems
-    """
 
 
 class PathfindingNotFoundIncompatibleConstraints(BaseModel):
@@ -6511,7 +6275,6 @@ class SummaryResponsePathfindingNotFound(BaseModel):
 
 
 class StdcmResponsePreprocessingSimulationError(BaseModel):
-    core_payload: CoreStdcmRequest | None = None
     error: ResponseSuccess | ResponsePathfindingFailed | ResponseSimulationFailed
     status: Literal["preprocessing_simulation_error"]
 


### PR DESCRIPTION
That was used to reproduce past requests before they were saved through the s3.

~~Though the s3 isn't deployed everywhere yet, so this is still a draft.~~