### PR TITLE
fix TimesStopsTable edition bugs

### DIFF
--- a/front/src/modules/timesStops/TimeCell.tsx
+++ b/front/src/modules/timesStops/TimeCell.tsx
@@ -143,11 +143,11 @@ const clampTimeState = (state: TimeState): TimeState => {
   };
 };
 
-// Handlers
+// State transformers (pure functions used by the reducer)
 
 // The minutes section needs special handling when overflowing
 // It allows the user to quickly enter times like 01:45 by typing 0145 even when focused on minutes
-const handleMinutesOverflow = (state: TimeState, digit: string): TimeState => {
+const computeMinutesOverflowState = (state: TimeState, digit: string): TimeState => {
   if (!hasAllDigits(state.hours)) {
     return {
       ...state,
@@ -171,7 +171,7 @@ const handleMinutesOverflow = (state: TimeState, digit: string): TimeState => {
   };
 };
 
-const handleNormalOverflow = (state: TimeState, digit: string): TimeState => {
+const computeNormalOverflowState = (state: TimeState, digit: string): TimeState => {
   const { focusedSection } = state;
   if (!focusedSection) return state;
 
@@ -208,7 +208,7 @@ const handleNormalOverflow = (state: TimeState, digit: string): TimeState => {
   return state;
 };
 
-const handleDigitPressed = (state: TimeState, digit: string): TimeState => {
+const computeDigitState = (state: TimeState, digit: string): TimeState => {
   const { focusedSection } = state;
   if (!focusedSection) return state;
 
@@ -255,14 +255,14 @@ const handleDigitPressed = (state: TimeState, digit: string): TimeState => {
     case 2:
     default:
       return focusedSection === 'minutes'
-        ? handleMinutesOverflow(state, digit)
-        : handleNormalOverflow(state, digit);
+        ? computeMinutesOverflowState(state, digit)
+        : computeNormalOverflowState(state, digit);
   }
 };
 
 // When a section is emptied, we need to shift the other sections to the left
 // This way the user can quickly delete time by holding backspace
-const handleBackspaceShift = (state: TimeState, section: Section): TimeState => {
+const computeBackspaceShiftState = (state: TimeState, section: Section): TimeState => {
   if (section === 'seconds') {
     return {
       ...state,
@@ -285,7 +285,7 @@ const handleBackspaceShift = (state: TimeState, section: Section): TimeState => 
   };
 };
 
-const handleBackspacePressed = (state: TimeState): TimeState => {
+const computeBackspaceState = (state: TimeState): TimeState => {
   const { focusedSection } = state;
   if (!focusedSection) return state;
 
@@ -296,7 +296,7 @@ const handleBackspacePressed = (state: TimeState): TimeState => {
   const newSectionState = removeDigitFromSectionState(currentSectionState, focusedSection);
 
   if (hasNoDigits(newSectionState)) {
-    return handleBackspaceShift(state, focusedSection);
+    return computeBackspaceShiftState(state, focusedSection);
   }
 
   return {
@@ -305,7 +305,7 @@ const handleBackspacePressed = (state: TimeState): TimeState => {
   };
 };
 
-const handleBlurred = (state: TimeState): TimeState => {
+const computeBlurState = (state: TimeState): TimeState => {
   if (hasNoDigits(state.hours) && hasNoDigits(state.minutes) && hasNoDigits(state.seconds)) {
     return {
       hours: 'hh',
@@ -322,20 +322,20 @@ const handleBlurred = (state: TimeState): TimeState => {
   });
 };
 
-const handleFocused = (state: TimeState, section: Section): TimeState => ({
+const computeFocusState = (state: TimeState, section: Section): TimeState => ({
   ...state,
   focusedSection: section,
   empty: false,
   hasTyped: state.empty || false,
 });
 
-const handleSectionClicked = (state: TimeState, section: Section): TimeState => ({
+const computeSectionClickState = (state: TimeState, section: Section): TimeState => ({
   ...state,
   focusedSection: section,
   hasTyped: state.empty || false,
 });
 
-const handleHorizontalArrow = (state: TimeState, direction: 'left' | 'right'): TimeState => {
+const computeArrowState = (state: TimeState, direction: 'left' | 'right'): TimeState => {
   const { focusedSection } = state;
   if (!focusedSection) return state;
 
@@ -380,21 +380,21 @@ const initialTimeState = (controlledValue: Date | null): TimeState => ({
 const timeReducer = (state: TimeState, action: TimeAction): TimeState => {
   switch (action.type) {
     case 'DIGIT_PRESSED':
-      return { ...handleDigitPressed(state, action.digit), hasTyped: true };
+      return { ...computeDigitState(state, action.digit), hasTyped: true };
     case 'BACKSPACE_PRESSED':
-      return { ...handleBackspacePressed(state), hasTyped: true };
+      return { ...computeBackspaceState(state), hasTyped: true };
     case 'BLURRED':
-      return handleBlurred(state);
+      return computeBlurState(state);
     case 'FOCUSED':
-      return handleFocused(state, action.section);
+      return computeFocusState(state, action.section);
     case 'SECTION_CLICKED':
-      return handleSectionClicked(state, action.section);
+      return computeSectionClickState(state, action.section);
     case 'ENTER_PRESSED':
-      return handleBlurred(state);
+      return computeBlurState(state);
     case 'LEFT_ARROW_PRESSED':
-      return handleHorizontalArrow(state, 'left');
+      return computeArrowState(state, 'left');
     case 'RIGHT_ARROW_PRESSED':
-      return handleHorizontalArrow(state, 'right');
+      return computeArrowState(state, 'right');
     case 'EXTERNAL_VALUE_CHANGED':
       // Don't override user's in-progress edits
       if (state.focusedSection) return state;

--- a/front/src/modules/timesStops/TimeCell.tsx
+++ b/front/src/modules/timesStops/TimeCell.tsx
@@ -535,16 +535,18 @@ const TimeCell = ({ getValue, referenceDate, onCommit, ...props }: TimeCellProps
   };
 
   const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
-    dispatch({ type: 'BLURRED' });
-
+    // Commit first: useReducer updates are async, so we compute the clamped state
+    // ourselves rather than waiting for the BLURRED dispatch to take effect.
+    // This ensures "14:45" (no seconds) commits as "14:45:00" instead of null.
     if (onCommit && referenceDate) {
-      const newDate = buildDateFromState(state, referenceDate);
+      const newDate = buildDateFromState(computeBlurState(state), referenceDate);
       const hasChanged = newDate?.getTime() !== controlledValue?.getTime();
       if (hasChanged) {
         onCommit(newDate);
       }
     }
 
+    dispatch({ type: 'BLURRED' });
     onBlur?.(e);
   };
 

--- a/front/src/modules/timesStops/TimesStopsTable.tsx
+++ b/front/src/modules/timesStops/TimesStopsTable.tsx
@@ -108,9 +108,10 @@ const TimesStopsTable = ({
             return <span>&nbsp;</span>;
           }
 
-          const { stepStatus, computedArrival, isPathStep } = info.row.original;
+          const { stepStatus, computedArrival, requestedArrival, isPathStep } = info.row.original;
 
           const isSuccessSchedule =
+            requestedArrival &&
             computedArrival &&
             !(stepStatus === 'marginNotHonored') &&
             !(stepStatus === 'scheduleNotHonored');

--- a/front/src/modules/timesStops/hooks/useTimesStopsTableData.ts
+++ b/front/src/modules/timesStops/hooks/useTimesStopsTableData.ts
@@ -20,6 +20,7 @@ import type { Train } from 'reducers/osrdconf/types';
 import { getDisplayOnlyPathSteps } from 'reducers/simulationResults/selectors';
 import { Duration } from 'utils/duration';
 
+import { ARRIVAL_TIME_ACCEPTABLE_ERROR } from '../consts';
 import { buildOpMatchParams, getOperationalPointName } from '../helpers/utils';
 import { type StepStatus, type TimesStopsRowNew } from '../types';
 
@@ -59,8 +60,16 @@ const buildTableRow = ({
     : null;
 
   // computedArrival is offset from startDate
-  const computedArrivalDate =
+  const rawComputedArrivalDate =
     computedArrival !== undefined ? new Date(startDate.getTime() + computedArrival.ms) : null;
+
+  // Snap to requested arrival when within tolerance, consistent with the legacy table behavior.
+  const isOnTime =
+    requestedArrival && rawComputedArrivalDate
+      ? Duration.subtractDate(requestedArrival, rawComputedArrivalDate).abs() <=
+        ARRIVAL_TIME_ACCEPTABLE_ERROR
+      : false;
+  const computedArrivalDate = isOnTime ? requestedArrival : rawComputedArrivalDate;
 
   // schedule.stop_for is ISO 8601 duration
   const stopDuration = schedule?.stop_for ? Duration.parse(schedule.stop_for) : null;


### PR DESCRIPTION
- Rename `TimeCell` reducer helper functions from `handle*` to `compute*State` for clarity (pure state transformers, not event handlers)
- Fix #15575
- Fix #15577
- Fix #15578