### PR TITLE
core: handle backtracking for zone occupation

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
@@ -20,6 +20,7 @@ import fr.sncf.osrd.path.interfaces.BlockRange
 import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.path.interfaces.RouteRange
 import fr.sncf.osrd.path.interfaces.TrainPath
+import fr.sncf.osrd.path.interfaces.ZoneRange
 import fr.sncf.osrd.signaling.SigSystemManager
 import fr.sncf.osrd.signaling.SignalingTrainState
 import fr.sncf.osrd.signaling.ZoneStatus
@@ -30,7 +31,13 @@ import fr.sncf.osrd.standalone_sim.result.ResultSpeed
 import fr.sncf.osrd.train.RollingStock
 import fr.sncf.osrd.train.TrainStop
 import fr.sncf.osrd.utils.simplifyEnvelopePoints
-import fr.sncf.osrd.utils.units.*
+import fr.sncf.osrd.utils.units.Distance
+import fr.sncf.osrd.utils.units.Offset
+import fr.sncf.osrd.utils.units.Speed
+import fr.sncf.osrd.utils.units.TimeDelta
+import fr.sncf.osrd.utils.units.meters
+import fr.sncf.osrd.utils.units.metersPerSecond
+import fr.sncf.osrd.utils.units.seconds
 
 // Reserve clear track with a margin for the reaction time of the driver
 const val CLOSED_SIGNAL_RESERVATION_MARGIN = 20.0
@@ -544,21 +551,116 @@ data class ZoneOccupationChangeEvent(
     val zone: ZoneId,
 )
 
+private fun getBacktrackWithTrainTailOverOffset(
+    ascendingBacktrackLocations: List<Offset<PhysicsPath>>,
+    trainLength: Distance,
+    offset: Offset<PhysicsPath>,
+): Offset<PhysicsPath>? {
+    for (backtracking in ascendingBacktrackLocations) {
+        if (offset < backtracking - trainLength) continue
+        if (offset <= backtracking) return backtracking
+        break
+    }
+    return null
+}
+
+private fun zoneRangeExitOffset(
+    ascendingBacktrackLocations: List<Offset<PhysicsPath>>,
+    trainLength: Distance,
+    zoneRange: ZoneRange,
+): Offset<PhysicsPath> {
+    val backtrackOverZoneBeginOffset =
+        getBacktrackWithTrainTailOverOffset(
+            ascendingBacktrackLocations,
+            trainLength,
+            zoneRange.pathBegin,
+        )
+    if (
+        backtrackOverZoneBeginOffset != null && backtrackOverZoneBeginOffset != zoneRange.pathBegin
+    ) {
+        // Backtracking with tail above zone-start: entry location of the head (zone-start) will
+        // actually be exit location of the tail after backtrack.
+        // No matter the length of the train (> 100m in the example), if the zone started 100m
+        // before backtrack, then it will end 100m after backtrack.
+        return backtrackOverZoneBeginOffset + (backtrackOverZoneBeginOffset - zoneRange.pathBegin)
+    }
+
+    val backtrackOverZoneEndOffset =
+        getBacktrackWithTrainTailOverOffset(
+            ascendingBacktrackLocations,
+            trainLength,
+            zoneRange.pathEnd,
+        )
+    if (backtrackOverZoneEndOffset != null) {
+        // Backtracking with tail above zone-end: will actually lead to occupying zone until the
+        // backtracking (to be merged later with occupation after backtrack).
+        return backtrackOverZoneEndOffset
+    }
+
+    // regular case: wait until tail crosses exit
+    return zoneRange.pathEnd + trainLength
+}
+
+private fun sortAndMergeSameZoneOverlappingOrContiguousOccupations(
+    zoneOccupationChangeEvents: MutableList<ZoneOccupationChangeEvent>
+) {
+    // Sorting entries before exits to "create" overlaps for contiguous occupations, then easily
+    // merge those
+    zoneOccupationChangeEvents.sortWith(compareBy({ it.time }, { !it.isEntry }))
+
+    // Keeping only the events that start-from/end-to no occupation on considered zone
+    val currentOccupationNumberByZone = mutableMapOf<ZoneId, Int>()
+    val eventIterator = zoneOccupationChangeEvents.iterator()
+    while (eventIterator.hasNext()) {
+        val event = eventIterator.next()
+        var updated = currentOccupationNumberByZone.getOrDefault(event.zone, 0)
+        if (event.isEntry) {
+            if (updated > 0) {
+                // keep entry only when not already occupied before the considered entry
+                eventIterator.remove()
+            }
+            updated++
+        } else {
+            updated--
+            if (updated > 0) {
+                // keep exit only when there are no more occupation ongoing after the considered
+                // exit
+                eventIterator.remove()
+            }
+        }
+        require(updated >= 0)
+        currentOccupationNumberByZone[event.zone] = updated
+    }
+}
+
 fun zoneOccupationChangeEvents(
     trainPath: TrainPath,
     envelope: EnvelopeTimeInterpolate,
     trainLength: Distance,
-): MutableList<ZoneOccupationChangeEvent> {
+): List<ZoneOccupationChangeEvent> {
+    // Check that backtracks are sorted ascending and that there is no "backtrack-over-backtrack"
+    // (in which case the following code wouldn't work properly)
+    require(
+        trainPath
+            .getBacktrackLocations()
+            .asSequence()
+            .zipWithNext { current, next -> current < next - trainLength }
+            .all { it }
+    )
+
     val zoneOccupationChangeEvents = mutableListOf<ZoneOccupationChangeEvent>()
     for (zoneRange in trainPath.getZoneRanges()) {
+        // entry is always at the start of the zone (might lead to some adjacent identical zone
+        // occupation for the same zone at backtrack)
         val entryOffset = zoneRange.pathBegin
-        val exitOffset = zoneRange.pathEnd + trainLength
         val entryTime = envelope.interpolateArrivalAtClamp(entryOffset.meters).seconds
+
+        val exitOffset =
+            zoneRangeExitOffset(trainPath.getBacktrackLocations(), trainLength, zoneRange)
         val exitTime = envelope.interpolateDepartureFromClamp(exitOffset.meters).seconds
 
         // Avoid generating entry + exit at the same time
         if (exitTime <= entryTime) continue
-
         zoneOccupationChangeEvents.add(
             ZoneOccupationChangeEvent(entryTime, entryOffset, isEntry = true, zoneRange.value)
         )
@@ -566,7 +668,8 @@ fun zoneOccupationChangeEvents(
             ZoneOccupationChangeEvent(exitTime, exitOffset, isEntry = false, zoneRange.value)
         )
     }
-    zoneOccupationChangeEvents.sortBy { it.time }
+
+    sortAndMergeSameZoneOverlappingOrContiguousOccupations(zoneOccupationChangeEvents)
 
     return zoneOccupationChangeEvents
 }

--- a/core/src/test/kotlin/fr/sncf/osrd/backtracks/BacktrackTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/backtracks/BacktrackTests.kt
@@ -339,7 +339,7 @@ class BacktrackTests {
 
     @Test
     @Disabled("Not working yet")
-    fun testSimulation() {
+    fun testSimulationBacktrackingOverNothing() {
         val path = buildPathBacktrackingOverNothing(infra, rollingStock.length.meters)
         // Smoke test, we only test for uncaught exceptions and failed asserts
         runStandaloneSimulation(
@@ -361,6 +361,33 @@ class BacktrackTests {
             initialSpeed = 0.0,
             margins = RangeValues(),
             pathItemPositions = listOf(Offset(9400.meters), Offset(18100.meters)),
+        )
+    }
+
+    @Test
+    @Disabled("Not working yet")
+    fun testSimulationBacktrackingOverRouteDelimiter() {
+        val path = buildPathBacktrackingOverRouteDelimiter(infra, rollingStock.length.meters)
+        // Smoke test, we only test for uncaught exceptions and failed asserts
+        runStandaloneSimulation(
+            infra = infra,
+            trainPath = path,
+            rollingStock = REALISTIC_FAST_TRAIN,
+            comfort = Comfort.STANDARD,
+            constraintDistribution = RJSAllowanceDistribution.LINEAR,
+            speedLimitTag = null,
+            powerRestrictions = distanceRangeMapOf(),
+            useElectricalProfiles = false,
+            useSpeedLimits = true,
+            timeStep = 2.0,
+            schedule =
+                listOf(
+                    SimulationScheduleItem(Offset(8000.meters), null, 60.seconds, SHORT_SLIP_STOP),
+                    SimulationScheduleItem(Offset(15300.meters), null, 0.seconds, OPEN),
+                ),
+            initialSpeed = 0.0,
+            margins = RangeValues(),
+            pathItemPositions = listOf(Offset(8000.meters), Offset(15300.meters)),
         )
     }
 }

--- a/core/src/test/kotlin/fr/sncf/osrd/backtracks/BacktrackTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/backtracks/BacktrackTests.kt
@@ -3,6 +3,7 @@ package fr.sncf.osrd.backtracks
 import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.api.RangeValues
 import fr.sncf.osrd.api.path_properties.makePathPropResponse
+import fr.sncf.osrd.api.standalone_sim.SimulationScheduleItem
 import fr.sncf.osrd.path.implementations.PartialBlockRange
 import fr.sncf.osrd.path.implementations.buildRangeList
 import fr.sncf.osrd.path.implementations.buildTrainPathFromBlockRanges
@@ -11,6 +12,8 @@ import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.path.interfaces.splitAtBacktracks
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
 import fr.sncf.osrd.railjson.schema.schedule.RJSAllowanceDistribution
+import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal.OPEN
+import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal.SHORT_SLIP_STOP
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.sim_infra.api.getLogicalSignalName
@@ -23,6 +26,7 @@ import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
+import fr.sncf.osrd.utils.units.seconds
 import fr.sncf.osrd.utils.units.sumDistances
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -106,8 +110,9 @@ class BacktrackTests {
                 PartialBlockRange(
                     firstBlocks[2].first,
                     Offset(0.meters),
-                    // Last block before backtrack is used up to 500m before its end
-                    firstBlocks[2].second - 500.meters,
+                    // Last block before backtrack ends at c2 (offset 3000m), and backtrack is at
+                    // offset 2500m
+                    firstBlocks[2].second - (3000.meters - 2500.meters),
                     firstBlocks[2].second,
                 ),
                 // Backtrack there: on track t.center at offset 2500m
@@ -115,7 +120,7 @@ class BacktrackTests {
                 PartialBlockRange(
                     secondBlocks[0].first,
                     // c3 is at offset 5000m, 400m of train length
-                    Offset(5000.meters - 2500.meters - rollingStockLength),
+                    Offset(5000.meters - 2500.meters + rollingStockLength),
                     secondBlocks[0].second,
                     secondBlocks[0].second,
                 ),
@@ -191,10 +196,14 @@ class BacktrackTests {
             useElectricalProfiles = false,
             useSpeedLimits = true,
             timeStep = 2.0,
-            schedule = listOf(),
+            schedule =
+                listOf(
+                    SimulationScheduleItem(Offset(9400.meters), null, 60.seconds, SHORT_SLIP_STOP),
+                    SimulationScheduleItem(Offset(18100.meters), null, 0.seconds, OPEN),
+                ),
             initialSpeed = 0.0,
             margins = RangeValues(),
-            pathItemPositions = listOf(),
+            pathItemPositions = listOf(Offset(9400.meters), Offset(18100.meters)),
         )
     }
 }

--- a/core/src/test/kotlin/fr/sncf/osrd/backtracks/BacktrackTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/backtracks/BacktrackTests.kt
@@ -66,26 +66,29 @@ class BacktrackTests {
 
     val infra = fullInfraFromFile("y_infra/infra.json")
     val rollingStock: RollingStock = REALISTIC_FAST_TRAIN
-    val path = buildPath(infra, rollingStock.length.meters)
 
-    private fun buildPath(infra: FullInfra, rollingStockLength: Distance): TrainPath {
+    private fun signalsToBlocks(signalNameList: List<String>): List<Pair<BlockId, Length<Block>>> {
+        val nameToSignal =
+            infra.rawInfra.logicalSignals.associateBy { signalId ->
+                infra.rawInfra.getLogicalSignalName(signalId)
+            }
+        val signalList = signalNameList.map { nameToSignal[it]!! }
+        val signalPairs = (signalList.dropLast(1) zip signalList.drop(1)).map { it.toList() }
+        val signalPairToBlock =
+            infra.blockInfra.blocks.associateBy { infra.blockInfra.getBlockSignals(it) }
+        return signalPairs.map {
+            val signalId = signalPairToBlock[it]!!
+            Pair(signalId, infra.blockInfra.getBlockLength(signalId))
+        }
+    }
+
+    private fun buildPathBacktrackingOverNothing(
+        infra: FullInfra,
+        rollingStockLength: Distance,
+    ): TrainPath {
         val firstSignalNameList = listOf("s.right.a1", "s.right.a2", "s.right.a3", "s.right.c2")
         val secondSignalNameList = listOf("s.left.c3", "s.left.c1", "s.left.b2", "s.left.b1")
 
-        fun signalsToBlocks(signalNameList: List<String>): List<Pair<BlockId, Length<Block>>> {
-            val nameToSignal =
-                infra.rawInfra.logicalSignals.associateBy { signalId ->
-                    infra.rawInfra.getLogicalSignalName(signalId)
-                }
-            val signalList = signalNameList.map { nameToSignal[it]!! }
-            val signalPairs = (signalList.dropLast(1) zip signalList.drop(1)).map { it.toList() }
-            val signalPairToBlock =
-                infra.blockInfra.blocks.associateBy { infra.blockInfra.getBlockSignals(it) }
-            return signalPairs.map {
-                val signalId = signalPairToBlock[it]!!
-                Pair(signalId, infra.blockInfra.getBlockLength(signalId))
-            }
-        }
         val firstBlocks = signalsToBlocks(firstSignalNameList)
         val secondBlocks = signalsToBlocks(secondSignalNameList)
 
@@ -155,11 +158,15 @@ class BacktrackTests {
     @Test
     fun testPathProperties() {
         // Smoke test, we only test for uncaught exceptions and failed asserts
-        makePathPropResponse(path, infra.rawInfra)
+        makePathPropResponse(
+            buildPathBacktrackingOverNothing(infra, rollingStock.length.meters),
+            infra.rawInfra,
+        )
     }
 
     @Test
     fun testPathSplit() {
+        val path = buildPathBacktrackingOverNothing(infra, rollingStock.length.meters)
         val paths = path.splitAtBacktracks()
         assertEquals(2, paths.size)
         val first = paths[0]
@@ -184,6 +191,7 @@ class BacktrackTests {
     @Test
     @Disabled("Not working yet")
     fun testSimulation() {
+        val path = buildPathBacktrackingOverNothing(infra, rollingStock.length.meters)
         // Smoke test, we only test for uncaught exceptions and failed asserts
         runStandaloneSimulation(
             infra = infra,

--- a/core/src/test/kotlin/fr/sncf/osrd/backtracks/BacktrackTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/backtracks/BacktrackTests.kt
@@ -4,6 +4,7 @@ import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.api.RangeValues
 import fr.sncf.osrd.api.path_properties.makePathPropResponse
 import fr.sncf.osrd.api.standalone_sim.SimulationScheduleItem
+import fr.sncf.osrd.envelope_sim_infra.computeMRSP
 import fr.sncf.osrd.path.implementations.PartialBlockRange
 import fr.sncf.osrd.path.implementations.buildRangeList
 import fr.sncf.osrd.path.implementations.buildTrainPathFromBlockRanges
@@ -16,8 +17,11 @@ import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal.OPE
 import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal.SHORT_SLIP_STOP
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockId
+import fr.sncf.osrd.sim_infra.api.ZoneId
 import fr.sncf.osrd.sim_infra.api.getLogicalSignalName
+import fr.sncf.osrd.standalone_sim.ZoneOccupationChangeEvent
 import fr.sncf.osrd.standalone_sim.runStandaloneSimulation
+import fr.sncf.osrd.standalone_sim.zoneOccupationChangeEvents
 import fr.sncf.osrd.train.RollingStock
 import fr.sncf.osrd.train.TestTrains.REALISTIC_FAST_TRAIN
 import fr.sncf.osrd.utils.Helpers.fullInfraFromFile
@@ -28,6 +32,7 @@ import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import fr.sncf.osrd.utils.units.seconds
 import fr.sncf.osrd.utils.units.sumDistances
+import java.util.Objects
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import org.junit.jupiter.api.Disabled
@@ -155,6 +160,71 @@ class BacktrackTests {
         )
     }
 
+    private fun buildPathBacktrackingOverRouteDelimiter(
+        infra: FullInfra,
+        rollingStockLength: Distance,
+    ): TrainPath {
+        val firstSignalNameList = listOf("s.right.a1", "s.right.a2", "s.right.a3", "s.right.c2")
+        val secondSignalNameList = listOf("s.left.c3", "s.left.c1", "s.left.b2", "s.left.b1")
+
+        val firstBlocks = signalsToBlocks(firstSignalNameList)
+        val secondBlocks = signalsToBlocks(secondSignalNameList)
+
+        // This is verbose, but it makes it easier to follow along
+        val blockRanges =
+            listOf(
+                // a1 -> a2
+                PartialBlockRange(
+                    firstBlocks[0].first,
+                    Offset(100.meters), // Start at offset 100m on first block
+                    firstBlocks[0].second,
+                    firstBlocks[0].second,
+                ),
+                // a2 -> a3
+                PartialBlockRange(
+                    firstBlocks[1].first,
+                    Offset(0.meters),
+                    firstBlocks[1].second,
+                    firstBlocks[1].second,
+                ),
+                // a3 -> c2
+                PartialBlockRange(
+                    firstBlocks[2].first,
+                    Offset(0.meters),
+                    // Last block before backtrack ends at c2 (offset 3000m), and backtrack is at
+                    // offset 1100m
+                    firstBlocks[2].second - (3000.meters - 1100.meters),
+                    firstBlocks[2].second,
+                ),
+                // Backtrack there: on track t.center at offset 1100m
+                // c1 -> b2
+                PartialBlockRange(
+                    secondBlocks[1].first,
+                    // c1 is at offset 1000m, 400m of train length
+                    Offset(1000.meters - 1100.meters + rollingStockLength),
+                    secondBlocks[1].second,
+                    secondBlocks[1].second,
+                ),
+                // b2 -> b1
+                PartialBlockRange(
+                    secondBlocks[2].first,
+                    Offset(0.meters),
+                    secondBlocks[2].second - 400.meters, // stop 400m before the end of the block
+                    secondBlocks[2].second,
+                ),
+            )
+        val backtrackLocation =
+            Offset<PhysicsPath>(blockRanges.subList(0, 3).map { it.length }.sumDistances())
+
+        return buildTrainPathFromBlockRanges(
+            infra.rawInfra,
+            infra.blockInfra,
+            buildRangeList(blockRanges),
+            routeNames = listOf("rt.bf.a->det.a3", "rt.det.a3->bf.c", "rt.det.c1->bf.b"),
+            backtrackLocations = listOf(backtrackLocation),
+        )
+    }
+
     @Test
     fun testPathProperties() {
         // Smoke test, we only test for uncaught exceptions and failed asserts
@@ -186,6 +256,85 @@ class BacktrackTests {
         val allBlocks = allBlockRanges.map { it.value }.toSet()
         assert(firstBlocks.intersect(secondBlocks).isEmpty())
         assertEquals(allBlocks, firstBlocks.union(secondBlocks))
+    }
+
+    class ZoneOccupation(val entry: Offset<PhysicsPath>, var exit: Offset<PhysicsPath>?) {
+        override fun equals(other: Any?): Boolean {
+            if (other !is ZoneOccupation) return false
+            return entry == other.entry && exit == other.exit
+        }
+
+        override fun hashCode(): Int {
+            return Objects.hash(entry, exit)
+        }
+    }
+
+    fun getZoneOccupations(
+        zoneOccupationChangeEvents: List<ZoneOccupationChangeEvent>
+    ): Map<ZoneId, List<ZoneOccupation>> {
+        val mapZoneOccupations = mutableMapOf<ZoneId, MutableList<ZoneOccupation>>()
+        zoneOccupationChangeEvents.forEach { event ->
+            val updated = mapZoneOccupations.getOrDefault(event.zone, mutableListOf())
+            if (event.isEntry) {
+                val lastOccupation = updated.lastOrNull()
+                // A zone is never entered twice in a row
+                assert(lastOccupation == null || lastOccupation.exit != null)
+                updated.addLast(ZoneOccupation(event.offset, null))
+            } else {
+                // A zone is always entered before exited
+                assert(updated.last().exit == null)
+                updated.last().exit = event.offset
+            }
+            mapZoneOccupations[event.zone] = updated
+        }
+        return mapZoneOccupations
+    }
+
+    @Test
+    fun testZoneOccupationBacktrackSingleZone() {
+        val path = buildPathBacktrackingOverNothing(infra, rollingStock.length.meters)
+        val mrsp = computeMRSP(path, rollingStock, true, null, null, distanceRangeMapOf(), true)
+        val zoneOccupationChangeEvents = zoneOccupationChangeEvents(path, mrsp, 400.meters)
+
+        assertEquals(
+            mapOf(
+                Pair(ZoneId(1u), listOf(ZoneOccupation(Offset(0.meters), Offset(3300.meters)))),
+                Pair(ZoneId(2u), listOf(ZoneOccupation(Offset(2900.meters), Offset(6300.meters)))),
+                Pair(
+                    ZoneId(3u),
+                    listOf(
+                        ZoneOccupation(Offset(5900.meters), Offset(8300.meters)),
+                        ZoneOccupation(Offset(10500.meters), Offset(12900.meters)),
+                    ),
+                ),
+                Pair(ZoneId(7u), listOf(ZoneOccupation(Offset(7900.meters), Offset(10900.meters)))),
+                Pair(
+                    ZoneId(6u),
+                    listOf(ZoneOccupation(Offset(12500.meters), Offset(15900.meters))),
+                ),
+                Pair(ZoneId(5u), listOf(ZoneOccupation(Offset(15500.meters), Offset(18500.meters)))),
+            ),
+            getZoneOccupations(zoneOccupationChangeEvents),
+        )
+    }
+
+    @Test
+    fun testZoneOccupationBacktrackingOverRouteDelimiter() {
+        val path = buildPathBacktrackingOverRouteDelimiter(infra, rollingStock.length.meters)
+        val mrsp = computeMRSP(path, rollingStock, true, null, null, distanceRangeMapOf(), true)
+        val zoneOccupationChangeEvents = zoneOccupationChangeEvents(path, mrsp, 400.meters)
+
+        assertEquals(
+            mapOf(
+                Pair(ZoneId(1u), listOf(ZoneOccupation(Offset(0.meters), Offset(3300.meters)))),
+                Pair(ZoneId(2u), listOf(ZoneOccupation(Offset(2900.meters), Offset(6300.meters)))),
+                Pair(ZoneId(3u), listOf(ZoneOccupation(Offset(5900.meters), Offset(10100.meters)))),
+                Pair(ZoneId(7u), listOf(ZoneOccupation(Offset(7900.meters), Offset(8100.meters)))),
+                Pair(ZoneId(6u), listOf(ZoneOccupation(Offset(9700.meters), Offset(13100.meters)))),
+                Pair(ZoneId(5u), listOf(ZoneOccupation(Offset(12700.meters), Offset(15700.meters)))),
+            ),
+            getZoneOccupations(zoneOccupationChangeEvents),
+        )
     }
 
     @Test


### PR DESCRIPTION
Add corresponding tests (with/without overlap on zone border)

Also fix and make some backtracking tests more realistic

🔍 review by commit

Part of https://github.com/OpenRailAssociation/osrd/issues/15159 and https://github.com/OpenRailAssociation/osrd/issues/14824