### PR TITLE
show path operational points even when simulation fails

### DIFF
--- a/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
+++ b/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
@@ -126,12 +126,7 @@ const useSimulationResults = (): {
     return { results: undefined, isSimulationDataLoading };
   }
 
-  if (
-    pathfinding?.status !== 'success' ||
-    simulation?.status !== 'success' ||
-    !rawPathProperties ||
-    !rollingStock
-  ) {
+  if (pathfinding?.status !== 'success' || !rawPathProperties || !rollingStock) {
     return {
       results: { isValid: false, train, rollingStock },
       isSimulationDataLoading,
@@ -139,12 +134,24 @@ const useSimulationResults = (): {
   }
 
   const pathProperties = preparePathPropertiesData(
-    simulation.electrical_profiles,
+    simulation?.status === 'success' ? simulation.electrical_profiles : undefined,
     rawPathProperties,
     pathfinding,
     train.path,
     t
   );
+
+  if (simulation?.status !== 'success') {
+    return {
+      results: {
+        isValid: false,
+        train,
+        rollingStock,
+        pathProperties,
+      },
+      isSimulationDataLoading,
+    };
+  }
 
   const powerRestrictions =
     formatPowerRestrictionRangesWithHandled({

--- a/front/src/applications/operationalStudies/types.ts
+++ b/front/src/applications/operationalStudies/types.ts
@@ -122,7 +122,12 @@ export type ElectrificationVoltage = {
 };
 
 export type SimulationResults =
-  | { isValid: false; train: Train; rollingStock?: RollingStockWithLiveries }
+  | {
+      isValid: false;
+      train: Train;
+      rollingStock?: RollingStockWithLiveries;
+      pathProperties?: PathPropertiesFormatted;
+    }
   | {
       isValid: true;
       train: Train;

--- a/front/src/applications/operationalStudies/utils.ts
+++ b/front/src/applications/operationalStudies/utils.ts
@@ -181,7 +181,7 @@ export const transformElectricalBoundariesToRanges = (
  * Format path properties data to be used in simulation results charts
  */
 export const preparePathPropertiesData = (
-  electricalProfiles: SimulationResponseSuccess['electrical_profiles'],
+  electricalProfiles: SimulationResponseSuccess['electrical_profiles'] | undefined,
   { slopes, curves, electrifications, operational_points, geometry }: PathProperties,
   { path_item_positions, length }: CorePathfindingResultSuccess,
   trainSchedulePath: TrainSchedule['path'],
@@ -190,17 +190,16 @@ export const preparePathPropertiesData = (
   const formattedSlopes = transformBoundariesDataToPositionDataArray(slopes, length, 'gradient');
   const formattedCurves = transformBoundariesDataToPositionDataArray(curves, length, 'radius');
 
-  const mergedElectrificationAndProfiles = mergeElectrificationAndProfiles(
-    electrifications,
-    electricalProfiles
-  );
+  const mergedElectrificationAndProfiles = electricalProfiles
+    ? mergeElectrificationAndProfiles(electrifications, electricalProfiles)
+    : undefined;
 
   const electrificationAndProfilesRanges = transformElectricalBoundariesToRanges(
     mergedElectrificationAndProfiles,
     length
   );
 
-  const voltageRanges = getPathVoltages(electrifications, length);
+  const voltageRanges = electricalProfiles ? getPathVoltages(electrifications, length) : [];
 
   const operationalPointsWithAllWaypoints = upsertMapWaypointsInOperationalPoints(
     'EditoastPathOperationalPoint',

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
@@ -338,13 +338,13 @@ const SimulationResults = ({
                 timetableItemsWithDetails={timetableItemsWithDetails}
                 upsertTimetableItems={upsertTimetableItems}
                 isSimulationDataLoading={isSimulationDataLoading}
+                operationalPointsOnPath={simulationResults.pathProperties?.operationalPoints}
                 {...(simulationResults?.isValid &&
                   simulationSummary?.isValid && {
                     isValid: true,
                     simulatedTrain: simulationResults.simulation.final_output,
                     simulatedPathItemTimes: simulationSummary.pathItemTimes,
                     simulatedPathItemRespect: simulationSummary.pathItemRespect,
-                    operationalPointsOnPath: simulationResults.pathProperties.operationalPoints,
                   })}
               />
             </div>

--- a/front/src/modules/timesStops/hooks/useTimesStopsTableData.ts
+++ b/front/src/modules/timesStops/hooks/useTimesStopsTableData.ts
@@ -268,8 +268,9 @@ const useTimesStopsTableData = (
 
     let formattedRows: TimesStopsRowNew[] = [];
 
-    // Case 1: Valid train with simulation results
-    if (stableIsValid && stableTrain && stableOPs) {
+    // Case 1: Path is known show all OPs on path (intermediate OPs included).
+    // Computed arrival times are only filled in when simulation results are available.
+    if (stableOPs) {
       stableOPs.forEach((op, opIndex) => {
         const trackName = op.part.local_track_name;
 
@@ -288,17 +289,20 @@ const useTimesStopsTableData = (
             opOnPathIndex: opIndex,
           });
         } else if (!displayOnlyPathSteps) {
-          const matchingReportTrainIndex = stableTrain.positions.findIndex(
-            (position) => position === op.position
-          );
-          const computedArrivalMs =
-            matchingReportTrainIndex === -1
-              ? interpolateValue(stableTrain, op.position, 'times')
-              : stableTrain.times[matchingReportTrainIndex];
-          const computedArrival =
-            computedArrivalMs !== undefined
-              ? new Duration({ milliseconds: computedArrivalMs })
-              : undefined;
+          let computedArrival: Duration | undefined;
+          if (stableTrain) {
+            const matchingReportTrainIndex = stableTrain.positions.findIndex(
+              (position) => position === op.position
+            );
+            const computedArrivalMs =
+              matchingReportTrainIndex === -1
+                ? interpolateValue(stableTrain, op.position, 'times')
+                : stableTrain.times[matchingReportTrainIndex];
+            computedArrival =
+              computedArrivalMs !== undefined
+                ? new Duration({ milliseconds: computedArrivalMs })
+                : undefined;
+          }
 
           formattedRows.push({
             ...buildTableRow({


### PR DESCRIPTION
Closes #15411 

- Split the early return in `useSimulationResults` to distinguish pathfinding failure (no path data) from simulation failure (path available, no timing data)
- When pathfinding succeeds but simulation fails, `preparePathPropertiesData` is now called with `undefined` electrical profiles, returning valid path geometry and operational points with empty electrification data
- `SimulationResults` type exposes `pathProperties?` on the `isValid: false` variant
- The times & stops table now shows all operational points on path as soon as pathfinding results are available, even without a valid simulation

You can import this timetable where the simulation failed and check that in `TimeStopsTable` we keep all waypoint
[timetable (1).json](https://github.com/user-attachments/files/25897727/timetable.1.json)
