### PR TITLE
editoast: adapt conflicts endpoint

### DIFF
--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -391,11 +391,37 @@ pub(in crate::views) async fn conflicts(
     })
     .await?;
 
-    let trains = retrieve_trains(conn, timetable_id).await?;
+    let trains = retrieve_trains(conn.clone(), timetable_id).await?;
+    let train_schedules_ids = trains.iter().map(|t| t.id).collect::<Vec<_>>();
+
+    let mut exceptions =
+        editoast_models::TrainScheduleException::retrieve_exceptions_by_train_schedules(
+            &mut conn.clone(),
+            timetable_id,
+            train_schedules_ids,
+        )
+        .await?
+        .into_iter()
+        .map_into::<schemas::TrainScheduleException>()
+        .into_group_map_by(|e| e.train_schedule_id);
+
+    let train_schedules_with_exceptions: Vec<(
+        models::TrainSchedule,
+        Vec<schemas::TrainScheduleException>,
+    )> = trains
+        .into_iter()
+        .map(|ts| {
+            let ts_exceptions = exceptions.remove(&ts.id).unwrap_or_default();
+            (ts, ts_exceptions)
+        })
+        .collect();
 
     // Flatten paced trains occurrences
-    let (occurrence_ids, occurrence_trains): (Vec<_>, Vec<_>) =
-        trains.iter().flat_map(|pt| pt.iter_occurrences()).unzip();
+    let (occurrence_ids, occurrence_trains): (Vec<_>, Vec<_>) = train_schedules_with_exceptions
+        .iter()
+        .flat_map(|(ts, exceptions)| ts.iter_occurrences_v2(exceptions))
+        .unzip();
+
     let occurrence_simulations: Vec<_> = train_simulation_batch(
         &mut db_pool.get().await?,
         valkey_client.clone(),

--- a/tests/tests/test_timetable.py
+++ b/tests/tests/test_timetable.py
@@ -350,38 +350,64 @@ def test_paced_train_with_exceptions_conflicts(
         "paced": {
             "time_window": "PT1H",
             "interval": "PT15M",
-            "exceptions": [
-                {
-                    "key": "created_ex_key",
-                    "disabled": False,
-                    "start_time": {
-                        "value": "2024-05-22T08:01:00.000Z",
-                    },
-                    "train_name": {"value": "created_exception_train_name"},
-                },
-                {
-                    "key": "modified_ex_key",
-                    "occurrence_index": 2,
-                    "disabled": False,
-                    "train_name": {"value": "modified_exception_train_name"},
-                },
-                {
-                    "key": "created_ex_conflict_modified_key",
-                    "disabled": False,
-                    "start_time": {
-                        "value": "2024-05-22T08:30:00.000Z",
-                    },
-                    "train_name": {"value": "exception_train_name"},
-                },
-            ],
+            "exceptions": [],
         },
     }
 
     paced_train_response = session.post(
         f"{EDITOAST_URL}train_schedule_sets/{train_schedule_set_id}/train_schedules",
         json=[paced_train_payload],
-    )
-    paced_train_response.raise_for_status()
+    ).json()
+
+    paced_train_id = paced_train_response[0]["id"]
+
+    created_ex_payload = {
+        "key": "created_ex_key",
+        "train_schedule_id": paced_train_id,
+        "disabled": False,
+        "change_groups": {
+            "start_time": {
+                "value": "2024-05-22T08:01:00.000Z",
+            },
+            "train_name": {"value": "created_exception_train_name"},
+        },
+    }
+    created_ex = session.post(
+        f"{EDITOAST_URL}timetable/{timetable_id}/train_schedule_exception",
+        json=created_ex_payload,
+    ).json()
+
+    modified_ex_payload = {
+        "key": "modified_ex_key",
+        "train_schedule_id": paced_train_id,
+        "occurrence_index": 2,
+        "disabled": False,
+        "change_groups": {
+            "train_name": {"value": "modified_exception_train_name"},
+        },
+    }
+    modified_ex = session.post(
+        f"{EDITOAST_URL}timetable/{timetable_id}/train_schedule_exception",
+        json=modified_ex_payload,
+    ).json()
+
+    created_ex_conflict_modified_payload = {
+        "key": "created_ex_conflict_modified_key",
+        "train_schedule_id": paced_train_id,
+        "disabled": False,
+        "change_groups": {
+            "start_time": {
+                "value": "2024-05-22T08:30:00.000Z",
+            },
+            "train_name": {"value": "exception_train_name"},
+        },
+    }
+    created_ex_conflict_modified = session.post(
+        f"{EDITOAST_URL}timetable/{timetable_id}/train_schedule_exception",
+        json=created_ex_conflict_modified_payload,
+    ).json()
+
+    print(created_ex_conflict_modified)
 
     conflicts_response = session.get(
         f"{EDITOAST_URL}timetable/{timetable_id}/conflicts/?infra_id={small_infra.id}"
@@ -393,7 +419,7 @@ def test_paced_train_with_exceptions_conflicts(
         [
             {
                 "index": c.get("index", None),
-                "exception_key": c.get("exception_key", None),
+                "exception_id": c.get("exception_id", None),
             }
             for c in conflict["train_ids"]
         ]
@@ -401,13 +427,13 @@ def test_paced_train_with_exceptions_conflicts(
     ]
 
     expected_conflict_with_created_exception = [
-        {"exception_key": None, "index": 0},
-        {"exception_key": "created_ex_key", "index": None},
+        {"exception_id": None, "index": 0},
+        {"exception_id": created_ex["id"], "index": None},
     ]
 
     expected_conflict_with_modified_exception = [
-        {"exception_key": "modified_ex_key", "index": 2},
-        {"exception_key": "created_ex_conflict_modified_key", "index": None},
+        {"exception_id": modified_ex["id"], "index": 2},
+        {"exception_id": created_ex_conflict_modified["id"], "index": None},
     ]
 
     assert any(


### PR DESCRIPTION
part of https://github.com/OpenRailAssociation/osrd/issues/15202

This PR adapt `GET /timetable/{id}/conflicts` with new exceptions

Fix tests: exceptions must now be created through the timetable/{id}/train_schedule_exceptions endpoint

> [!NOTE]
> This PR targets a feature branch and may contain all its commits, as it has not been rebased yet. Only the last commit need to be reviewed.