### PR TITLE
editoast: adapt train schedule get path endpoint to use exceptions table

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -4634,11 +4634,12 @@ paths:
         schema:
           type: integer
           format: int64
-      - name: exception_key
+      - name: exception_id
         in: query
         required: false
         schema:
-          type: string
+          type: integer
+          format: int64
       responses:
         '200':
           description: The path

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -412,7 +412,7 @@ pub(in crate::views) struct TrainScheduleExceptionQueryParam {
 #[utoipa::path(
     get, path = "",
     tags = ["paced_train", "pathfinding"],
-    params(TrainScheduleIdParam, InfraIdQueryParam, ExceptionQueryParam),
+    params(TrainScheduleIdParam, InfraIdQueryParam, TrainScheduleExceptionQueryParam),
     responses(
         (status = 200, description = "The path", body = PathfindingResult),
         (status = 404, description = "Infrastructure or Train schedule not found")
@@ -431,7 +431,9 @@ pub(in crate::views) async fn get_path(
         id: train_schedule_id,
     }): Path<TrainScheduleIdParam>,
     Query(InfraIdQueryParam { infra_id }): Query<InfraIdQueryParam>,
-    Query(ExceptionQueryParam { exception_key }): Query<ExceptionQueryParam>,
+    Query(TrainScheduleExceptionQueryParam { exception_id }): Query<
+        TrainScheduleExceptionQueryParam,
+    >,
 ) -> Result<Json<PathfindingResult>> {
     let authorized = auth
         .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
@@ -462,17 +464,17 @@ pub(in crate::views) async fn get_path(
         })
         .await?;
 
-    let train_schedule = match exception_key {
-        Some(exception_key) => {
-            let exception = paced_train
-                .exceptions
-                .iter()
-                .find(|e| e.key == exception_key)
-                .ok_or_else(|| TrainScheduleError::ExceptionNotFound {
-                    exception_key: exception_key.clone(),
-                })?;
-
-            paced_train.apply_exception(exception)
+    let train_schedule = match exception_id {
+        Some(exception_id) => {
+            let exception =
+                TrainScheduleException::retrieve_or_fail(conn.clone(), exception_id, || {
+                    TrainScheduleError::ExceptionNotFound {
+                        // TODO rename to exception_id
+                        exception_key: exception_id.to_string(),
+                    }
+                })
+                .await?;
+            paced_train.apply_train_schedule_exception(&exception.into())
         }
         None => paced_train.into_train_occurrence(),
     };
@@ -1647,6 +1649,8 @@ mod tests {
     use crate::models::fixtures::create_paced_train_with_exceptions;
     use crate::models::fixtures::create_simple_paced_train;
     use crate::models::fixtures::create_small_infra;
+    use crate::models::fixtures::create_timetable_with_train_schedule_set;
+    use crate::models::fixtures::create_train_schedule_exception;
     use crate::models::fixtures::create_train_schedule_set;
     use crate::models::fixtures::simple_paced_train_base;
     use crate::models::fixtures::simple_paced_train_changeset;
@@ -2343,7 +2347,7 @@ mod tests {
             create_simple_paced_train(&mut pool.get_ok(), train_schedule_set.id).await;
         let request = app.get(
             format!(
-                "/train_schedules/{}/path/?infra_id={}&exception_key=toto",
+                "/train_schedules/{}/path/?infra_id={}&exception_id=1234",
                 paced_train.id, small_infra.id
             )
             .as_str(),
@@ -2428,24 +2432,40 @@ mod tests {
         let db_pool = app.db_pool();
 
         create_fast_rolling_stock(&mut db_pool.get_ok(), "R2D2").await;
-        let train_schedule_set = create_train_schedule_set(&mut db_pool.get_ok()).await;
-        let mut exception = create_created_exception_with_change_groups("exception_created_key");
-        exception.change_groups.rolling_stock = Some(RollingStockChangeGroup {
-            rolling_stock_name: "exception_rolling_stock".into(),
-            comfort: Comfort::Standard,
-        });
-        let paced_train = create_paced_train_with_exceptions(
+        let (timetable, train_schedule_set) =
+            create_timetable_with_train_schedule_set(&mut db_pool.get_ok()).await;
+
+        let train_schedule = create_paced_train_with_exceptions(
             &mut db_pool.get_ok(),
             train_schedule_set.id,
-            vec![exception.clone()],
+            vec![],
+        )
+        .await;
+
+        let change_rolling_stock_exception = create_train_schedule_exception(
+            &mut db_pool.get_ok(),
+            timetable.id,
+            train_schedule.id,
+            None,
+            Some("exception_for_get_path".to_string()),
+            Some(TrainScheduleExceptionChangeGroups {
+                train_name: Some(TrainNameChangeGroup {
+                    value: "exception_name_for_get_path".into(),
+                }),
+                rolling_stock: Some(RollingStockChangeGroup {
+                    rolling_stock_name: "exception_rolling_stock".into(),
+                    comfort: Comfort::Standard,
+                }),
+                ..Default::default()
+            }),
         )
         .await;
 
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
 
         let request = app.get(&format!(
-            "/train_schedules/{}/path?infra_id={}&exception_key={}",
-            paced_train.id, small_infra.id, exception.key
+            "/train_schedules/{}/path?infra_id={}&exception_id={}",
+            train_schedule.id, small_infra.id, change_rolling_stock_exception.id
         ));
 
         let response = app
@@ -2483,21 +2503,38 @@ mod tests {
         let app = TestAppBuilder::new().core_client(core.into()).build();
         let db_pool = app.db_pool();
 
-        create_fast_rolling_stock(&mut db_pool.get_ok(), "simulation_rolling_stock").await;
-        let train_schedule_set = create_train_schedule_set(&mut db_pool.get_ok()).await;
-        let exception = create_created_exception_with_change_groups("exception_created_key");
-        let paced_train = create_paced_train_with_exceptions(
+        let (timetable, train_schedule_set) =
+            create_timetable_with_train_schedule_set(&mut db_pool.get_ok()).await;
+
+        create_fast_rolling_stock(&mut db_pool.get_ok(), "R2D2").await;
+
+        let train_schedule = create_paced_train_with_exceptions(
             &mut db_pool.get_ok(),
             train_schedule_set.id,
-            vec![exception.clone()],
+            vec![],
+        )
+        .await;
+
+        let change_train_name_exception = create_train_schedule_exception(
+            &mut db_pool.get_ok(),
+            timetable.id,
+            train_schedule.id,
+            None,
+            Some("exception_for_get_path".to_string()),
+            Some(TrainScheduleExceptionChangeGroups {
+                train_name: Some(TrainNameChangeGroup {
+                    value: "exception_name_for_get_path".into(),
+                }),
+                ..Default::default()
+            }),
         )
         .await;
 
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
 
         let request = app.get(&format!(
-            "/train_schedules/{}/path?infra_id={}&exception_key={}",
-            paced_train.id, small_infra.id, exception.key
+            "/train_schedules/{}/path?infra_id={}&exception_id={}",
+            train_schedule.id, small_infra.id, change_train_name_exception.id
         ));
 
         let response = app

--- a/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
+++ b/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
@@ -79,7 +79,7 @@ const useSimulationResults = (): {
         ? {
             id: selectedTrainId,
             infraId,
-            exceptionKey: exception?.key,
+            exceptionId: exception?.id ?? undefined,
           }
         : skipToken
     );

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -1340,7 +1340,7 @@ const injectedRtkApi = api
           url: `/train_schedules/${queryArg.id}/path`,
           params: {
             infra_id: queryArg.infraId,
-            exception_key: queryArg.exceptionKey,
+            exception_id: queryArg.exceptionId,
           },
         }),
         providesTags: ['paced_train', 'pathfinding'],
@@ -2624,7 +2624,7 @@ export type GetTrainSchedulesByIdPathApiResponse = /** status 200 The path */ Pa
 export type GetTrainSchedulesByIdPathApiArg = {
   id: number;
   infraId: number;
-  exceptionKey?: string;
+  exceptionId?: number;
 };
 export type GetTrainSchedulesByIdSimulationApiResponse =
   /** status 200 Simulation Output */ SimulationResponse;

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -75,9 +75,9 @@ const osrdEditoastApi = generatedEditoastApi
       }),
       getTrainPath: builder.query<
         PathfindingResult,
-        { id: TrainId; infraId: number; exceptionKey?: string }
+        { id: TrainId; infraId: number; exceptionId?: number }
       >({
-        queryFn: async ({ id: trainId, infraId, exceptionKey }, { dispatch }) => {
+        queryFn: async ({ id: trainId, infraId, exceptionId }, { dispatch }) => {
           const pacedTrainId = isOccurrenceId(trainId)
             ? extractPacedTrainIdFromOccurrenceId(trainId)
             : trainId;
@@ -86,7 +86,7 @@ const osrdEditoastApi = generatedEditoastApi
               {
                 id: extractEditoastIdFromPacedTrainId(pacedTrainId),
                 infraId,
-                exceptionKey,
+                exceptionId,
               },
               { subscribe: false }
             )

--- a/tests/tests/test_paced_train.py
+++ b/tests/tests/test_paced_train.py
@@ -72,7 +72,10 @@ def test_put_paced_train(
 
 
 def test_get_paced_train_with_exception_path(
-    west_to_south_east_paced_train: Sequence[Any], small_infra: Infra, session: Session
+    west_to_south_east_paced_train: Sequence[Any],
+    small_infra: Infra,
+    timetable_id: int,
+    session: Session,
 ):
     paced_train = west_to_south_east_paced_train[0]
     paced_train_id = paced_train["id"]
@@ -83,40 +86,44 @@ def test_get_paced_train_with_exception_path(
     ).json()
 
     # Add exception to the paced train
-    exception = {
+    exception_payload = {
         "key": "exception_key",
+        "train_schedule_id": paced_train_id,
         "disabled": False,
-        "path_and_schedule": {
-            "power_restrictions": [],
-            "schedule": [],
-            "path": [
-                {
-                    "id": "id1",
-                    "deleted": False,
-                    "location": {"track": "TA0", "offset": 470000},
+        "change_groups": {
+            "path_and_schedule": {
+                "power_restrictions": [],
+                "schedule": [],
+                "path": [
+                    {
+                        "id": "id1",
+                        "deleted": False,
+                        "location": {"track": "TA0", "offset": 470000},
+                    },
+                    {
+                        "id": "id2",
+                        "deleted": False,
+                        "location": {"track": "TG4", "offset": 1993000},
+                    },
+                ],
+                "margins": {
+                    "boundaries": [],
+                    "values": ["5%"],
                 },
-                {
-                    "id": "id2",
-                    "deleted": False,
-                    "location": {"track": "TG4", "offset": 1993000},
-                },
-            ],
-            "margins": {
-                "boundaries": [],
-                "values": ["5%"],
             },
+            "initial_speed": {"value": 20.0},
         },
-        "initial_speed": {"value": 20.0},
     }
-    paced_train["paced"]["exceptions"] = [exception]
-    update_response = session.put(
-        f"{EDITOAST_URL}train_schedules/{paced_train_id}", json=paced_train
-    )
-    assert update_response.status_code == 204
+    exception = session.post(
+        f"{EDITOAST_URL}timetable/{timetable_id}/train_schedule_exception",
+        json=exception_payload,
+    ).json()
+
     # Get exception path
     exception_path_result = session.get(
-        f"{EDITOAST_URL}train_schedules/{paced_train_id}/path?infra_id={small_infra.id}&exception_key=exception_key"
+        f"{EDITOAST_URL}train_schedules/{paced_train_id}/path?infra_id={small_infra.id}&exception_id={exception['id']}"
     ).json()
+
     base_track_sections = [
         tsr["track_section"]
         for tsr in paced_train_path_result["path"]["track_section_ranges"]


### PR DESCRIPTION
fix https://github.com/OpenRailAssociation/osrd/issues/15593
part of https://github.com/OpenRailAssociation/osrd/issues/15202

adapt `GET /train_schedule/{id}/path` endpoint with new exceptions with incremental refactoring to be able to have small PR and adapt endpoints one by one

- [x] Use exception id in query string
- [x] Adapts tests to use new exceptions


> [!NOTE]
> This PR targets a feature branch and may contain all its commits, as it has not been rebased yet. Only the last commit need to be reviewed.