### PR TITLE
editoast: adapt simulation endpoint with new exceptions

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -4673,11 +4673,12 @@ paths:
         schema:
           type: integer
           format: int64
-      - name: exception_key
+      - name: exception_id
         in: query
         required: false
         schema:
-          type: string
+          type: integer
+          format: int64
       responses:
         '200':
           description: Simulation Output

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -503,7 +503,7 @@ pub struct ElectricalProfileSetIdQueryParam {
 #[utoipa::path(
     get, path = "",
     tag = "paced_train",
-    params(TrainScheduleIdParam, InfraIdQueryParam, ElectricalProfileSetIdQueryParam, ExceptionQueryParam),
+    params(TrainScheduleIdParam, InfraIdQueryParam, ElectricalProfileSetIdQueryParam, TrainScheduleExceptionQueryParam),
     responses(
         (status = 200, description = "Simulation Output", body = simulation::Response),
     ),
@@ -524,7 +524,9 @@ pub(in crate::views) async fn simulation(
     Query(ElectricalProfileSetIdQueryParam {
         electrical_profile_set_id,
     }): Query<ElectricalProfileSetIdQueryParam>,
-    Query(ExceptionQueryParam { exception_key }): Query<ExceptionQueryParam>,
+    Query(TrainScheduleExceptionQueryParam { exception_id }): Query<
+        TrainScheduleExceptionQueryParam,
+    >,
 ) -> Result<Json<simulation::Response>> {
     let authorized = auth
         .check_roles([authz::Role::OperationalStudies].into())
@@ -555,17 +557,20 @@ pub(in crate::views) async fn simulation(
         })
         .await?;
 
-    let train_schedule = match exception_key {
-        Some(exception_key) => {
-            let exception = train_schedule
-                .exceptions
-                .iter()
-                .find(|e| e.key == exception_key)
-                .ok_or_else(|| TrainScheduleError::ExceptionNotFound {
-                    exception_key: exception_key.clone(),
-                })?;
-
-            train_schedule.apply_exception(exception)
+    let train_schedule = match exception_id {
+        Some(exception_id) => {
+            let exception = TrainScheduleException::retrieve_or_fail(
+                db_pool.get().await?,
+                exception_id,
+                || {
+                    TrainScheduleError::ExceptionNotFound {
+                        // TODO rename to exception_id
+                        exception_key: exception_id.to_string(),
+                    }
+                },
+            )
+            .await?;
+            train_schedule.apply_train_schedule_exception(&exception.into())
         }
         None => train_schedule.into_train_occurrence(),
     };
@@ -1614,6 +1619,7 @@ mod tests {
     use core_client::simulation::ReportTrain;
     use core_client::simulation::SpeedLimitProperties;
     use database::DbConnectionPoolV2;
+    use editoast_models::TrainScheduleException;
     use editoast_models::prelude::*;
     use editoast_models::rolling_stock::TrainMainCategory;
     use pretty_assertions::assert_eq;
@@ -1978,12 +1984,16 @@ mod tests {
         assert_eq!(response.train_schedule, paced_train.into());
     }
 
-    async fn app_infra_id_paced_train_id_for_simulation_tests() -> (TestApp, i64, i64) {
+    async fn app_infra_id_paced_train_id_for_simulation_tests()
+    -> (TestApp, i64, i64, TrainScheduleException) {
         let db_pool = DbConnectionPoolV2::for_tests();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
-        let train_schedule_set = create_train_schedule_set(&mut db_pool.get_ok()).await;
         let rolling_stock =
             create_fast_rolling_stock(&mut db_pool.get_ok(), "simulation_rolling_stock").await;
+        let (timetable, train_schedule_set) =
+            create_timetable_with_train_schedule_set(&mut db_pool.get_ok()).await;
+        let exception = create_created_exception_with_change_groups("created_exception_key");
+
         let paced_train_base = TrainSchedule {
             train_occurrence: TrainOccurrence {
                 rolling_stock_name: rolling_stock.name.clone(),
@@ -1992,9 +2002,7 @@ mod tests {
             paced: Some(Paced {
                 time_window: Duration::hours(1).try_into().unwrap(),
                 interval: Duration::minutes(15).try_into().unwrap(),
-                exceptions: vec![create_created_exception_with_change_groups(
-                    "created_exception_key",
-                )],
+                exceptions: vec![],
             }),
         };
         let paced_train: TrainScheduleChangeset = paced_train_base.into();
@@ -2003,17 +2011,28 @@ mod tests {
             .create(&mut db_pool.get_ok())
             .await
             .expect("Failed to create paced train");
+
+        let exception = create_train_schedule_exception(
+            &mut db_pool.get_ok(),
+            timetable.id,
+            paced_train.id,
+            None,
+            Some("created_exception_key".to_string()),
+            Some(exception.change_groups),
+        )
+        .await;
+
         let core = mocked_core_pathfinding_sim_and_proj();
         let app = TestAppBuilder::new()
             .db_pool(db_pool)
             .core_client(core.into())
             .build();
-        (app, small_infra.id, paced_train.id)
+        (app, small_infra.id, paced_train.id, exception)
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn paced_train_simulation() {
-        let (app, infra_id, train_schedule_id) =
+        let (app, infra_id, train_schedule_id, _exception) =
             app_infra_id_paced_train_id_for_simulation_tests().await;
         let request = app.get(
             format!("/train_schedules/{train_schedule_id}/simulation/?infra_id={infra_id}")
@@ -2030,11 +2049,11 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn paced_train_exception_simulation_with_invalid_exception_key() {
-        let (app, infra_id, train_schedule_id) =
+        let (app, infra_id, train_schedule_id, _exception) =
             app_infra_id_paced_train_id_for_simulation_tests().await;
         let request = app.get(
             format!(
-                "/train_schedules/{train_schedule_id}/simulation/?infra_id={infra_id}&exception_key=toto"
+                "/train_schedules/{train_schedule_id}/simulation/?infra_id={infra_id}&exception_id=9999"
             )
             .as_str(),
         );
@@ -2052,10 +2071,14 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn paced_train_exception_simulation() {
-        let (app, infra_id, train_schedule_id) =
+        let (app, infra_id, train_schedule_id, exception) =
             app_infra_id_paced_train_id_for_simulation_tests().await;
         let request = app.get(
-            format!("/train_schedules/{train_schedule_id}/simulation/?infra_id={infra_id}&exception_key=created_exception_key").as_str(),
+            format!(
+                "/train_schedules/{train_schedule_id}/simulation/?infra_id={infra_id}&exception_id={}",
+                exception.id
+            )
+            .as_str(),
         );
         let response: simulation::Response = app
             .fetch(request)
@@ -2108,34 +2131,28 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn paced_train_exception_simulation_with_rolling_stock_not_found() {
         // GIVEN
-        let (app, infra_id, train_schedule_id) =
+        let (app, infra_id, train_schedule_id, exception) =
             app_infra_id_paced_train_id_for_simulation_tests().await;
-        let request = app.get(format!("/train_schedules/{train_schedule_id}").as_str());
-        let mut paced_train_response: TrainScheduleResponse = app
-            .fetch(request)
-            .await
-            .assert_status(StatusCode::OK)
-            .json_into();
-        paced_train_response
-            .train_schedule
-            .paced
-            .as_mut()
-            .unwrap()
-            .exceptions[0]
-            .change_groups
-            .rolling_stock = Some(RollingStockChangeGroup {
+
+        let mut change_groupe = exception.change_groups;
+        change_groupe.rolling_stock = Some(RollingStockChangeGroup {
             rolling_stock_name: "R2D2".into(),
             comfort: Comfort::AirConditioning,
         });
-        let request = app
-            .put(format!("/train_schedules/{train_schedule_id}").as_str())
-            .json(&json!(paced_train_response.train_schedule));
-        app.fetch(request)
+        let exception = editoast_models::TrainScheduleException::changeset()
+            .change_groups(change_groupe)
+            .update(&mut app.db_pool().get_ok(), train_schedule_id)
             .await
-            .assert_status(StatusCode::NO_CONTENT);
+            .expect("Fail to update exception")
+            .expect("Fail to update exception");
+
         // WHEN
         let request = app.get(
-            format!("/train_schedules/{train_schedule_id}/simulation/?infra_id={infra_id}&exception_key=created_exception_key").as_str(),
+            format!(
+                "/train_schedules/{train_schedule_id}/simulation/?infra_id={infra_id}&exception_id={}",
+                exception.id
+            )
+            .as_str(),
         );
         let response: simulation::Response = app
             .fetch(request)
@@ -2158,7 +2175,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn paced_train_simulation_not_found() {
-        let (app, infra_id, _paced_train_id) =
+        let (app, infra_id, _paced_train_id, _exception) =
             app_infra_id_paced_train_id_for_simulation_tests().await;
         let request =
             app.get(format!("/train_schedules/{}/simulation/?infra_id={}", 0, infra_id).as_str());
@@ -2174,7 +2191,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn paced_train_simulation_summary() {
-        let (app, infra_id, paced_train_id) =
+        let (app, infra_id, paced_train_id, _exception) =
             app_infra_id_paced_train_id_for_simulation_tests().await;
         let request = app.get(format!("/train_schedules/{paced_train_id}").as_str());
         let mut paced_train_response: TrainScheduleResponse = app
@@ -2278,7 +2295,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn paced_train_simulation_summary_not_found() {
-        let (app, infra_id, _paced_train_id) =
+        let (app, infra_id, _paced_train_id, _exception) =
             app_infra_id_paced_train_id_for_simulation_tests().await;
         let request = app
             .post("/train_schedules/simulation_summary")
@@ -2605,8 +2622,8 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn train_schedule_occupancy_blocks() {
-        let (app, infra_id, paced_train_id) =
+    async fn paced_train_occupancy_blocks() {
+        let (app, infra_id, paced_train_id, _exception) =
             app_infra_id_paced_train_id_for_simulation_tests().await;
 
         let request = app.get(format!("/train_schedules/{paced_train_id}").as_str());

--- a/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
+++ b/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
@@ -91,7 +91,7 @@ const useSimulationResults = (): {
             id: selectedTrainId,
             infraId,
             electricalProfileSetId,
-            exceptionKey: exception?.key,
+            exceptionId: exception?.id ?? undefined,
           }
         : skipToken
     );

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -1354,7 +1354,7 @@ const injectedRtkApi = api
           params: {
             infra_id: queryArg.infraId,
             electrical_profile_set_id: queryArg.electricalProfileSetId,
-            exception_key: queryArg.exceptionKey,
+            exception_id: queryArg.exceptionId,
           },
         }),
         providesTags: ['paced_train'],
@@ -2632,7 +2632,7 @@ export type GetTrainSchedulesByIdSimulationApiArg = {
   id: number;
   infraId: number;
   electricalProfileSetId?: number;
-  exceptionKey?: string;
+  exceptionId?: number;
 };
 export type GetVersionApiResponse = /** status 200 Return the service version */ Version;
 export type GetVersionApiArg = void;

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -97,10 +97,10 @@ const osrdEditoastApi = generatedEditoastApi
       }),
       getTrainSimulation: builder.query<
         SimulationResponse,
-        { id: TrainId; infraId: number; electricalProfileSetId?: number; exceptionKey?: string }
+        { id: TrainId; infraId: number; electricalProfileSetId?: number; exceptionId?: number }
       >({
         queryFn: async (
-          { id: trainId, infraId, electricalProfileSetId, exceptionKey },
+          { id: trainId, infraId, electricalProfileSetId, exceptionId },
           { dispatch }
         ) => {
           const pacedTrainId = isOccurrenceId(trainId)
@@ -112,7 +112,7 @@ const osrdEditoastApi = generatedEditoastApi
                 id: extractEditoastIdFromPacedTrainId(pacedTrainId),
                 infraId,
                 electricalProfileSetId,
-                exceptionKey,
+                exceptionId,
               },
               { subscribe: false }
             )

--- a/tests/tests/test_paced_train.py
+++ b/tests/tests/test_paced_train.py
@@ -159,7 +159,10 @@ def test_get_paced_train_with_exception_path(
 
 
 def test_get_paced_train_with_exception_simulation(
-    west_to_south_east_paced_train: Sequence[Any], small_infra: Infra, session: Session
+    west_to_south_east_paced_train: Sequence[Any],
+    small_infra: Infra,
+    timetable_id: int,
+    session: Session,
 ):
     paced_train = west_to_south_east_paced_train[0]
     paced_train_id = paced_train["id"]
@@ -170,36 +173,42 @@ def test_get_paced_train_with_exception_simulation(
     ).json()
 
     # Add exception to the paced train
-    exception = {
+    exception_payload = {
         "key": "exception_key",
+        "train_schedule_id": paced_train_id,
         "disabled": False,
-        "path_and_schedule": {
-            "path": [
-                {
-                    "id": "id1",
-                    "deleted": False,
-                    "location": {"track": "TA0", "offset": 470000},
+        "change_groups": {
+            "path_and_schedule": {
+                "power_restrictions": [],
+                "schedule": [],
+                "path": [
+                    {
+                        "id": "id1",
+                        "deleted": False,
+                        "location": {"track": "TA0", "offset": 470000},
+                    },
+                    {
+                        "id": "id2",
+                        "deleted": False,
+                        "location": {"track": "TG4", "offset": 1993000},
+                    },
+                ],
+                "margins": {
+                    "boundaries": [],
+                    "values": ["5%"],
                 },
-                {
-                    "id": "id2",
-                    "deleted": False,
-                    "location": {"track": "TG4", "offset": 1993000},
-                },
-            ],
-            "schedule": [],
-            "margins": {"boundaries": [], "values": ["0%"]},
-            "power_restrictions": [],
+            },
+            "initial_speed": {"value": 20.0},
         },
-        "initial_speed": {"value": 20.0},
     }
-    paced_train["paced"]["exceptions"] = [exception]
-    update_response = session.put(
-        f"{EDITOAST_URL}train_schedules/{paced_train_id}", json=paced_train
-    )
-    assert update_response.status_code == 204
+    exception = session.post(
+        f"{EDITOAST_URL}timetable/{timetable_id}/train_schedule_exception",
+        json=exception_payload,
+    ).json()
+
     # Get exception path
     exception_simulation_result = session.get(
-        f"{EDITOAST_URL}train_schedules/{paced_train_id}/simulation?infra_id={small_infra.id}&exception_key=exception_key"
+        f"{EDITOAST_URL}train_schedules/{paced_train_id}/simulation?infra_id={small_infra.id}&exception_id={exception['id']}"
     ).json()
 
     # Check if the response is different from paced train


### PR DESCRIPTION
Part of #15653

This PR adapt the `GET /train_schedules/{id}/simulation` with new exceptions
Rename query string to exception_id
Fix tests and frontend

> [!NOTE]
> This PR targets a feature branch and may contain all its commits, as it has not been rebased yet. Only the last commit need to be reviewed.
