### PR TITLE
front: tweak timetable auto-compute rules on changes

### DIFF
--- a/front/src/modules/timesStops/helpers/__tests__/cellUpdate.spec.ts
+++ b/front/src/modules/timesStops/helpers/__tests__/cellUpdate.spec.ts
@@ -89,6 +89,16 @@ describe('applyScheduleEdit', () => {
       expect(t(result.departure)).toBe(t(_11H00));
     });
 
+    it('sets departure and update stop from arrival when both stop duration and arrival exists', () => {
+      const state: ScheduleState = { arrival: _10H00, stop: _30MIN };
+      // departure = 11h00 = 10h00 + 60min
+      const result = applyScheduleEdit(state, { field: 'requestedDeparture', value: _11H00 });
+
+      expect(t(result.arrival)).toBe(t(_10H00));
+      expect(ms(result.stop)).toBe(ms(_60MIN));
+      expect(t(result.departure)).toBe(t(_11H00));
+    });
+
     it('sets departure and computes arrival from stop when no arrival', () => {
       const state: ScheduleState = { arrival: null, stop: _30MIN };
       // departure = 10h30, arrival = 10h30 - 30min = 10h00

--- a/front/src/modules/timesStops/helpers/__tests__/utils.spec.ts
+++ b/front/src/modules/timesStops/helpers/__tests__/utils.spec.ts
@@ -10,8 +10,228 @@ import {
   calculateStepTimeAndDays,
 } from '../utils';
 
+const inputRow = ({
+  arrival,
+  departure,
+  stopSeconds,
+}: {
+  arrival?: string;
+  departure?: string;
+  stopSeconds?: number;
+}) =>
+  ({
+    opId: 'd94a2af4',
+    name: 'Gr',
+    arrival: arrival ? { time: arrival } : undefined,
+    departure: departure ? { time: departure } : undefined,
+    stopFor: stopSeconds ? new Duration({ seconds: stopSeconds }) : undefined,
+  }) as TimesStopsInputRow;
+
 describe('updateRowTimesAndMargin', () => {
   const whateverOperation = { fromRowIndex: 2 };
+
+  describe('only the arrival was set beforehand', () => {
+    const before = inputRow({ arrival: '10:00:00' });
+
+    describe('on arrival change', () => {
+      const after = inputRow({ arrival: '10:05:00' });
+      const result = updateRowTimesAndMargin(after, before, whateverOperation, 4);
+
+      it('should change arrival time', () => {
+        expect(result.arrival?.time).toEqual('10:05:00');
+      });
+
+      it('should keep departure or stop duration empty', () => {
+        expect(result.departure?.time).toBe(undefined);
+        expect(result.stopFor).toBe(undefined);
+      });
+    });
+
+    describe('on arrival deletion', () => {
+      const after = inputRow({});
+      const result = updateRowTimesAndMargin(after, before, whateverOperation, 4);
+
+      it('should remove arrival time', () => {
+        expect(result.arrival?.time).toBe(undefined);
+      });
+
+      it('should keep departure or stop duration empty', () => {
+        expect(result.departure?.time).toBe(undefined);
+        expect(result.stopFor).toBe(undefined);
+      });
+    });
+
+    describe('on stop duration change', () => {
+      const after = inputRow({ arrival: '10:00:00', stopSeconds: 120 });
+      const result = updateRowTimesAndMargin(after, before, whateverOperation, 4);
+
+      it('should set stop duration', () => {
+        expect(result.stopFor).toEqual(new Duration({ seconds: 120 }));
+      });
+
+      it('should compute new departure time', () => {
+        expect(result.departure?.time).toEqual('10:02:00');
+      });
+
+      it('should keep arrival time as it was beforehand', () => {
+        expect(result.arrival?.time).toEqual('10:00:00');
+      });
+    });
+
+    describe('on departure change', () => {
+      const after = inputRow({ arrival: '10:00:00', departure: '10:02:00' });
+      const result = updateRowTimesAndMargin(after, before, whateverOperation, 4);
+
+      it('should compute new stop duration', () => {
+        expect(result.stopFor).toEqual(new Duration({ seconds: 120 }));
+      });
+
+      it('should set departure time', () => {
+        expect(result.departure?.time).toEqual('10:02:00');
+      });
+
+      it('should keep arrival time as it was beforehand', () => {
+        expect(result.arrival?.time).toEqual('10:00:00');
+      });
+    });
+  });
+
+  describe('only the stop duration was set beforehand', () => {
+    const before = inputRow({ stopSeconds: 60 });
+
+    describe('on stop duration change', () => {
+      const after = inputRow({ stopSeconds: 120 });
+      const result = updateRowTimesAndMargin(after, before, whateverOperation, 4);
+
+      it('should change stop duration', () => {
+        expect(result.stopFor).toEqual(new Duration({ seconds: 120 }));
+      });
+
+      it('should keep departure or stop duration empty', () => {
+        expect(result.departure?.time).toBe(undefined);
+        expect(result.arrival?.time).toBe(undefined);
+      });
+    });
+
+    describe('on stop duration deletion', () => {
+      const after = inputRow({});
+      const result = updateRowTimesAndMargin(after, before, whateverOperation, 4);
+
+      it('should remove stop duration', () => {
+        expect(result.stopFor).toBe(undefined);
+      });
+      it('should keep departure or stop duration empty', () => {
+        expect(result.departure?.time).toBe(undefined);
+        expect(result.arrival?.time).toBe(undefined);
+      });
+    });
+  });
+
+  describe('all arrival, departure and duration stop fields were set beforehand', () => {
+    const before = inputRow({ arrival: '10:00:00', departure: '10:01:00', stopSeconds: 60 });
+
+    describe('on arrival change', () => {
+      const after = inputRow({ arrival: '10:05:00', departure: '10:01:00', stopSeconds: 60 });
+      const result = updateRowTimesAndMargin(after, before, whateverOperation, 4);
+
+      it('should change arrival time', () => {
+        expect(result.arrival?.time).toEqual('10:05:00');
+      });
+
+      it('should compute new departure time', () => {
+        expect(result.departure?.time).toEqual('10:06:00');
+      });
+
+      it('should keep stop duration as it was beforehand', () => {
+        expect(result.stopFor).toEqual(new Duration({ seconds: 60 }));
+      });
+    });
+
+    describe('on arrival deletion', () => {
+      const after = inputRow({ departure: '10:01:00', stopSeconds: 60 });
+      const result = updateRowTimesAndMargin(after, before, whateverOperation, 4);
+
+      it('should remove arrival time', () => {
+        expect(result.arrival?.time).toBe(undefined);
+      });
+
+      it('should also remove departure time', () => {
+        expect(result.departure?.time).toBe(undefined);
+      });
+
+      it('should keep the stop duration as it was beforehand', () => {
+        expect(result.stopFor).toEqual(new Duration({ seconds: 60 }));
+      });
+    });
+
+    describe('on stop duration change', () => {
+      const after = inputRow({ arrival: '10:00:00', departure: '10:01:00', stopSeconds: 120 });
+      const result = updateRowTimesAndMargin(after, before, whateverOperation, 4);
+
+      it('should change stop duration', () => {
+        expect(result.stopFor).toEqual(new Duration({ seconds: 120 }));
+      });
+
+      it('should compute new departure time', () => {
+        expect(result.departure?.time).toEqual('10:02:00');
+      });
+
+      it('should keep arrival time as it was beforehand', () => {
+        expect(result.arrival?.time).toEqual('10:00:00');
+      });
+    });
+
+    describe('on stop duration deletion', () => {
+      const after = inputRow({ arrival: '10:00:00', departure: '10:01:00' });
+      const result = updateRowTimesAndMargin(after, before, whateverOperation, 4);
+
+      it('should remove stop duration', () => {
+        expect(result.stopFor).toBe(undefined);
+      });
+
+      it('should set departure time as arrival time', () => {
+        expect(result.departure?.time).toEqual('10:00:00');
+      });
+
+      it('should keep arrival time as it was beforehand', () => {
+        expect(result.arrival?.time).toEqual('10:00:00');
+      });
+    });
+
+    describe('on departure change', () => {
+      const after = inputRow({ arrival: '10:00:00', departure: '10:02:00', stopSeconds: 60 });
+      const result = updateRowTimesAndMargin(after, before, whateverOperation, 4);
+
+      it('should change departure time', () => {
+        expect(result.departure?.time).toEqual('10:02:00');
+      });
+
+      it('should compute a new stop duration', () => {
+        expect(result.stopFor).toEqual(new Duration({ seconds: 120 }));
+      });
+
+      it('should keep arrival time as it was beforehand', () => {
+        expect(result.arrival?.time).toEqual('10:00:00');
+      });
+    });
+
+    describe('on departure deletion', () => {
+      const after = inputRow({ arrival: '10:00:00', stopSeconds: 60 });
+      const result = updateRowTimesAndMargin(after, before, whateverOperation, 4);
+
+      it('should delete departure time', () => {
+        expect(result.departure?.time).toBe(undefined);
+      });
+
+      it('should also delete arrival time', () => {
+        expect(result.arrival?.time).toBe(undefined);
+      });
+
+      it('should keep stop duration as it was beforehand', () => {
+        expect(result.stopFor).toEqual(new Duration({ seconds: 60 }));
+      });
+    });
+  });
 
   describe('arrival is set, departure just changed', () => {
     it('should update stop duration from the arrival and departure', () => {
@@ -152,38 +372,10 @@ describe('updateRowTimesAndMargin', () => {
       expect(result).toEqual({
         opId: 'd94a2af4',
         name: 'Gr',
-        arrival: { time: '' },
+        arrival: undefined,
         departure: undefined,
         stopFor: new Duration({ seconds: 600 }),
         isMarginValid: true,
-      });
-    });
-  });
-  describe('arrival, departure & stopFor are set, departure gets erased', () => {
-    it('should keep arrival and remove stopFor', () => {
-      const rowData = {
-        opId: 'd94a2af4',
-        name: 'Gr',
-        arrival: { time: '00:10:00' },
-        departure: undefined,
-        stopFor: new Duration({ seconds: 600 }),
-      } as TimesStopsInputRow;
-      const previousRowData = {
-        opId: 'd94a2af4',
-        name: 'Gr',
-        arrival: { time: '00:10:00' },
-        departure: { time: '00:20:00' },
-        stopFor: new Duration({ seconds: 600 }),
-      } as TimesStopsInputRow;
-      const result = updateRowTimesAndMargin(rowData, previousRowData, whateverOperation, 4);
-      expect(result).toEqual({
-        opId: 'd94a2af4',
-        name: 'Gr',
-        arrival: { time: '00:10:00' },
-        departure: undefined,
-        stopFor: undefined,
-        isMarginValid: true,
-        onStopSignal: undefined,
       });
     });
   });

--- a/front/src/modules/timesStops/helpers/__tests__/utils.spec.ts
+++ b/front/src/modules/timesStops/helpers/__tests__/utils.spec.ts
@@ -189,8 +189,8 @@ describe('updateRowTimesAndMargin', () => {
         expect(result.stopFor).toBe(undefined);
       });
 
-      it('should set departure time as arrival time', () => {
-        expect(result.departure?.time).toEqual('10:00:00');
+      it('should remove departure time', () => {
+        expect(result.departure?.time).toBe(undefined);
       });
 
       it('should keep arrival time as it was beforehand', () => {

--- a/front/src/modules/timesStops/helpers/utils.ts
+++ b/front/src/modules/timesStops/helpers/utils.ts
@@ -143,32 +143,68 @@ export function updateRowTimesAndMargin(
   allWaypointsLength: number
 ): TimesStopsInputRow {
   const newRowData = { ...rowData };
-  if (
-    !isEqual(newRowData.arrival, previousRowData.arrival) ||
-    !isEqual(newRowData.departure, previousRowData.departure)
-  ) {
-    if (newRowData.departure?.time && newRowData.arrival?.time) {
-      newRowData.stopFor = new Duration({
-        seconds: durationInSeconds(
-          time2sec(newRowData.arrival.time),
-          time2sec(newRowData.departure.time)
-        ),
-      });
-    } else if (newRowData.departure) {
-      if (!previousRowData.departure) {
-        newRowData.arrival = {
+  const {
+    stopFor: previousStopFor,
+    departure: previousDeparture,
+    arrival: previousArrival,
+  } = previousRowData;
+  const arrivalChanged = !isEqual(newRowData.arrival, previousRowData.arrival);
+  const departureChanged = !isEqual(newRowData.departure, previousRowData.departure);
+  const stopDurationChanged = !isEqual(newRowData.stopFor, previousRowData.stopFor);
+
+  if (previousArrival?.time && previousDeparture?.time) {
+    if (!newRowData.arrival?.time || !newRowData.departure?.time) {
+      newRowData.departure = undefined;
+      newRowData.arrival = undefined;
+    } else {
+      if (arrivalChanged || stopDurationChanged) {
+        newRowData.departure = {
           time: secToHoursString(
-            time2sec(newRowData.departure.time) - (newRowData.stopFor?.total('second') ?? 0)
+            time2sec(newRowData.arrival.time) + (newRowData.stopFor?.total('second') ?? 0)
           ),
         };
-      } else {
-        newRowData.departure = undefined;
       }
-    } else if (newRowData.arrival && previousRowData.departure) {
-      // we just erased departure value
-      newRowData.stopFor = undefined;
+      if (departureChanged) {
+        if (newRowData.departure?.time) {
+          newRowData.stopFor = new Duration({
+            seconds: durationInSeconds(
+              time2sec(newRowData.arrival.time),
+              time2sec(newRowData.departure.time)
+            ),
+          });
+        }
+      }
+    }
+  } else if (previousArrival?.time) {
+    if (newRowData.arrival?.time && (arrivalChanged || stopDurationChanged)) {
+      if (newRowData.stopFor?.total('second') ?? 0 > 0) {
+        newRowData.departure = {
+          time: secToHoursString(
+            time2sec(newRowData.arrival.time) + (newRowData.stopFor?.total('second') ?? 0)
+          ),
+        };
+      }
+    }
+    if (newRowData.departure?.time && newRowData.arrival?.time) {
+      if (newRowData.arrival?.time) {
+        newRowData.stopFor = new Duration({
+          seconds: durationInSeconds(
+            time2sec(newRowData.arrival.time),
+            time2sec(newRowData.departure.time)
+          ),
+        });
+      }
     }
   }
+
+  if (previousStopFor && !previousDeparture?.time && newRowData.departure?.time) {
+    newRowData.arrival = {
+      time: secToHoursString(
+        time2sec(newRowData.departure.time) - (newRowData.stopFor?.total('second') ?? 0)
+      ),
+    };
+  }
+
   if (
     !newRowData.stopFor &&
     newRowData.onStopSignal &&

--- a/front/src/modules/timesStops/helpers/utils.ts
+++ b/front/src/modules/timesStops/helpers/utils.ts
@@ -158,11 +158,15 @@ export function updateRowTimesAndMargin(
       newRowData.arrival = undefined;
     } else {
       if (arrivalChanged || stopDurationChanged) {
-        newRowData.departure = {
-          time: secToHoursString(
-            time2sec(newRowData.arrival.time) + (newRowData.stopFor?.total('second') ?? 0)
-          ),
-        };
+        if (stopDurationChanged && !newRowData.stopFor) {
+          newRowData.departure = undefined;
+        } else {
+          newRowData.departure = {
+            time: secToHoursString(
+              time2sec(newRowData.arrival.time) + (newRowData.stopFor?.total('second') ?? 0)
+            ),
+          };
+        }
       }
       if (departureChanged) {
         if (newRowData.departure?.time) {


### PR DESCRIPTION
Fixes most of https://github.com/osrd-project/osrd-confidential/issues/1439.

The heuristic behind the auto-compute rules is changed, to allow a more "natural" flow of changes (i.e. the arrival time never changes, unless the departure time is deleted altogether.)

--- 

For reference, here are the new acceptance cases that were implemented. ✏️ highlights changes made by the user, ⚙️ highlights changes that should be computed automatically.

**Editions**

| | Arrival time | Stop duration | Departure time |
| :--- | :---: | :---: | :---: |
| Before change | 10h | | |
| After change | ✏️ **10h05** | | |

| | Arrival time | Stop duration | Departure time |
| :--- | :---: | :---: | :---: |
| Before change | 10h | 60s | 10h01 |
| After change | ✏️ **10h05** | 60s |  ⚙️ *10h06* |

| | Arrival time | Stop duration | Departure time |
| :--- | :---: | :---: | :---: |
| Before change | | 60s | |
| After change | | ✏️ **120s** | |

| | Arrival time | Stop duration | Departure time |
| :--- | :---: | :---: | :---: |
| Before change | 10h | 60s | 10h01 |
| After change | 10h | ✏️ **120s** |  ⚙️ *10h02* |

| | Arrival time | Stop duration | Departure time |
| :--- | :---: | :---: | :---: |
| Before change | 10h | 60s | 10h01 |
| After change | 10h |  ⚙️ *120s* | ✏️ **10h02** |

**Deletions**

| | Arrival time | Stop duration | Departure time |
| :--- | :---: | :---: | :---: |
| Before change | 10h | | |
| After change | ✏️ — | | |

| | Arrival time | Stop duration | Departure time |
| :--- | :---: | :---: | :---: |
| Before change | 10h | 60s | 10h01 |
| After change | ✏️ — | 60s |  ⚙️ — |

| | Arrival time | Stop duration | Departure time |
| :--- | :---: | :---: | :---: |
| Before change | | 60s | |
| After change | | ✏️ — | |

| | Arrival time | Stop duration | Departure time |
| :--- | :---: | :---: | :---: |
| Before change | 10h | 60s | 10h01 |
| After change | 10h | ✏️ — |  ⚙️ *10h* |

| | Arrival time | Stop duration | Departure time |
| :--- | :---: | :---: | :---: |
| Before change | 10h | 60s | 10h01 |
| After change | ⚙️ — | 60s | ✏️ — |