### PR TITLE
core: store a single constraint in InfraExplorer implementations

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/pathfinding/Pathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/pathfinding/Pathfinding.kt
@@ -163,7 +163,7 @@ class Pathfinding(
                 fullInfra.rawInfra,
                 fullInfra.blockInfra,
                 waypoints,
-                listOf(constraintCombiner),
+                constraintCombiner,
             )
         for (infraExplorer in startInfraExplorers) {
             val currentRange = infraExplorer.getCurrentBlockRange()
@@ -223,7 +223,7 @@ class Pathfinding(
         rawInfra: RawSignalingInfra,
         blockInfra: BlockInfra,
         waypoints: List<Collection<BlockLocation>>,
-        constraints: List<PathfindingConstraint>,
+        constraints: PathfindingConstraint,
     ): Collection<InfraExplorer> {
         val res = mutableListOf<InfraExplorer>()
         val firstStep = waypoints[0]

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
@@ -134,7 +134,7 @@ class STDCMPathfinding(
         runInputSanityChecks()
 
         assert(steps.last().stop) { "The last stop is supposed to be an actual stop" }
-        starts = getStartNodes(graph, listOf(constraints))
+        starts = getStartNodes(graph, constraints)
         val path = findPathImpl()
         graph.stdcmSimulations.logWarnings()
         if (path == null) {
@@ -293,7 +293,7 @@ class STDCMPathfinding(
     /** Converts start locations into starting nodes. */
     private fun getStartNodes(
         graph: STDCMGraph,
-        constraints: List<PathfindingConstraint>,
+        constraints: PathfindingConstraint,
     ): Set<STDCMNode> {
         val res = HashSet<STDCMNode>()
         val firstStep = steps[0]

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
@@ -174,7 +174,7 @@ fun initInfraExplorers(
     blockInfra: BlockInfra,
     location: BlockLocation,
     steps: List<ExplorerStep> = listOf(),
-    constraints: List<PathfindingConstraint> = listOf(),
+    constraints: PathfindingConstraint? = null,
 ): Collection<InfraExplorer> {
     val infraExplorers = mutableListOf<InfraExplorer>()
     val block = location.edge
@@ -211,7 +211,7 @@ private class InfraExplorerImpl(
     private var trainPathCache: MutableMap<BlockId, TrainPath>,
     private var currentIndex: Int = 0,
     private var stepTracker: StepTracker,
-    private var constraints: List<PathfindingConstraint>,
+    private var constraints: PathfindingConstraint?,
     override var isPathComplete: Boolean = false,
 ) : InfraExplorer {
     override fun getCurrentEdgePathProperties(offset: Offset<Block>, length: Distance?): TrainPath {
@@ -430,11 +430,9 @@ private class InfraExplorerImpl(
 
                 // If a block cannot be explored, give up
                 val isRouteBlocked =
-                    constraints.any { constraint ->
-                        constraint.apply(block).any {
-                            blockStartOffset < it.end && blockEndOffset > it.start
-                        }
-                    }
+                    constraints?.apply(block)?.any {
+                        blockStartOffset < it.end && blockEndOffset > it.start
+                    } ?: false
                 if (isRouteBlocked) return false
 
                 val rangePathBegin = getLookaheadEndOffset()

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelope.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelope.kt
@@ -114,7 +114,7 @@ fun initInfraExplorerWithEnvelope(
     location: BlockLocation,
     rollingStock: PhysicsRollingStock,
     steps: List<ExplorerStep> = listOf(),
-    constraints: List<PathfindingConstraint> = listOf(),
+    constraints: PathfindingConstraint? = null,
 ): Collection<InfraExplorerWithEnvelope> {
     return initInfraExplorers(
             fullInfra.rawInfra,

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerTests.kt
@@ -205,7 +205,6 @@ class InfraExplorerTests {
 
         val electrificationConstraints =
             ElectrificationConstraints(infra, infra, TestTrains.FAST_ELECTRIC_TRAIN.modeNames)
-        val constraints = listOf(electrificationConstraints)
 
         // a --> b
         val firstExplorers =
@@ -213,7 +212,7 @@ class InfraExplorerTests {
                 infra,
                 infra,
                 BlockLocation(blocks[0], Offset(0.meters)),
-                constraints = constraints,
+                constraints = electrificationConstraints,
             )
         assertEquals(1, firstExplorers.size)
         val firstExplorer = firstExplorers.first()


### PR DESCRIPTION
Update the properties of the classes implementing InfraExplorer to store a single constraint instead of a list of constraints. They were already storing at most one constraint in practice but contained a list of constraints in their properties.