### PR TITLE
front: display ch and uic of origin and destination in old itinerary modal

### DIFF
--- a/front/src/modules/pathfinding/components/Itinerary/DisplayItinerary/Destination.tsx
+++ b/front/src/modules/pathfinding/components/Itinerary/DisplayItinerary/Destination.tsx
@@ -8,6 +8,7 @@ import { useSelector } from 'react-redux';
 import { useManageTimetableItemContext } from 'applications/operationalStudies/hooks/useManageTimetableItemContext';
 import { isPathStepInvalid } from 'modules/pathfinding/utils';
 import { getDestination, getPathSteps } from 'reducers/osrdconf/operationalStudiesConf/selectors';
+import { formatUicToCi } from 'utils/strings';
 
 type DestinationProps = {
   zoomToFeaturePoint: (lngLat?: Position, id?: string) => void;
@@ -18,6 +19,7 @@ const Destination = ({ zoomToFeaturePoint }: DestinationProps) => {
 
   const destination = useSelector(getDestination);
   const pathSteps = useSelector(getPathSteps);
+  const location = destination?.location;
 
   const { t } = useTranslation('operational-studies', { keyPrefix: 'manageTimetableItem' });
   if (!destination || pathSteps.length === 1)
@@ -47,11 +49,24 @@ const Destination = ({ zoomToFeaturePoint }: DestinationProps) => {
         >
           <strong data-testid="destination-op-info" className="mr-1 text-nowrap">
             {/* If destination doesn't have name, we know that it has been added by click on map and has a track property */}
-            {destination?.name ||
-              (destination &&
-                'track' in destination.location &&
-                destination.location.track.split('-')[0])}
+            {destination?.name || (location && 'track' in location && location.track.split('-')[0])}
           </strong>
+          {location &&
+            'operational_point' in location &&
+            location.operational_point.type !== 'id' && (
+              <>
+                {location.operational_point.secondary_code && (
+                  <small data-testid="destination-ch" className="ml-1">
+                    {location.operational_point.secondary_code}
+                  </small>
+                )}
+                {location.operational_point.type === 'uic' && (
+                  <small data-testid="destination-uic" className="text-muted ml-3">
+                    {formatUicToCi(location.operational_point.uic)}
+                  </small>
+                )}
+              </>
+            )}
         </div>
         <button
           data-testid="delete-destination-button"

--- a/front/src/modules/pathfinding/components/Itinerary/DisplayItinerary/Origin.tsx
+++ b/front/src/modules/pathfinding/components/Itinerary/DisplayItinerary/Origin.tsx
@@ -8,6 +8,7 @@ import { useSelector } from 'react-redux';
 import { useManageTimetableItemContext } from 'applications/operationalStudies/hooks/useManageTimetableItemContext';
 import { isPathStepInvalid } from 'modules/pathfinding/utils';
 import { getOrigin, getPathSteps } from 'reducers/osrdconf/operationalStudiesConf/selectors';
+import { formatUicToCi } from 'utils/strings';
 
 type OriginProps = {
   zoomToFeaturePoint: (lngLat?: Position, id?: string) => void;
@@ -19,6 +20,7 @@ const Origin = ({ zoomToFeaturePoint }: OriginProps) => {
 
   const origin = useSelector(getOrigin);
   const pathSteps = useSelector(getPathSteps);
+  const location = origin?.location;
 
   const originPointName = (
     <div
@@ -30,9 +32,22 @@ const Origin = ({ zoomToFeaturePoint }: OriginProps) => {
     >
       <strong data-testid="origin-op-info" className="mr-1 text-nowrap">
         {/* If origin doesn't have name, we know that it has been added by click on map and has a track property */}
-        {origin?.name ||
-          (origin && 'track' in origin.location && origin.location.track.split('-')[0])}
+        {origin?.name || (location && 'track' in location && location.track.split('-')[0])}
       </strong>
+      {location && 'operational_point' in location && location.operational_point.type !== 'id' && (
+        <>
+          {location.operational_point.secondary_code && (
+            <small data-testid="origin-ch" className="ml-1">
+              {location.operational_point.secondary_code}
+            </small>
+          )}
+          {location.operational_point.type === 'uic' && (
+            <small data-testid="origin-uic" className="text-muted ml-3">
+              {formatUicToCi(location.operational_point.uic)}
+            </small>
+          )}
+        </>
+      )}
     </div>
   );
 


### PR DESCRIPTION
Implementation taken from Vias.tsx

This change is motivated by our current inability to determine what op corresponds to the origin or destination from the modal when the pathfinding fails and the map position is fuzzy.

This change is also in line with the new itinerary modal which displays the same information for vias and origin and destination.