### PR TITLE
front: fix error msg blinking on pending op search in itinerary modal

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModal.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModal.tsx
@@ -74,6 +74,8 @@ const ItineraryModal = ({
   const { categoryColors, currentSubCategory } = useCategoryColors(category);
 
   const modalRef = useRef<HTMLDialogElement>(null);
+  const editingStepIdRef = useRef<string>('');
+  const pendingStepIdRef = useRef<string>('');
 
   const [pathSteps, setPathSteps] = useState<PathStepV2[]>([]);
   const [categoryWarning, setCategoryWarning] = useState<string | undefined>(undefined);
@@ -95,7 +97,7 @@ const ItineraryModal = ({
 
   const { launchPathfinding } = useManageTimetableItemContext();
 
-  const { pathStepsMetadataById } = usePathStepsMetadata(pathSteps);
+  const { pathStepsMetadataById } = usePathStepsMetadata(pathSteps, pendingStepIdRef);
   const { launchPathfindingV2, pathProperties, pathfindingError } = usePathfindingV2();
   const applyOperationalPointToStep = (
     stepId: string,
@@ -104,7 +106,7 @@ const ItineraryModal = ({
   ) => {
     const chosenCh = chooseChForSuggestion(stepId, suggestion, forcedCh);
     if (!chosenCh) return;
-
+    pendingStepIdRef.current = stepId;
     const newLocation: PathItemLocation = {
       operational_point: {
         type: 'trigram',
@@ -158,22 +160,20 @@ const ItineraryModal = ({
     setInputForStep(newStep.id, '');
   };
 
-  const editingStepIdRef = useRef<string>('');
-
   const isStepInvalidAndIsEditing = (step: PathStepV2, metadata?: PathStepMetadata) => {
     if (!metadata?.isInvalid) return false;
 
+    const query = (getInputForStep(step.id) ?? '').trim();
     const isEditing = editingStepIdRef.current === step.id;
-
+    const isPending = pendingStepIdRef.current === step.id;
     // A step with no location is invalid only if the user typed something and isn't currently editing
     if (!step.location) {
-      const query = (getInputForStep(step.id) ?? '').trim();
       return query.length > 0 && !isEditing;
     }
 
     // A step with a location can still be invalid (OP not found in current infra).
     // Show the error as long as the user is not actively editing it.
-    return !isEditing;
+    return !isEditing && !isPending;
   };
 
   const hasInvalidPathStepDisplay = pathSteps.some((step) =>

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/PathStepItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/PathStepItem.tsx
@@ -303,7 +303,9 @@ const PathStepItem = ({
             getSuggestionLabel={(op) => {
               if (!op) return '';
               if (typeof op === 'string') return op;
-              return `${op.trigram} ${op.name}`;
+
+              const secondaryCode = op.secondaryCodeList[0]?.code;
+              return `${op.name} ${secondaryCode}`;
             }}
             onSelectSuggestion={(op) => {
               if (!op) {

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/hooks/usePathStepsMetadata.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/hooks/usePathStepsMetadata.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, type RefObject } from 'react';
 
 import type { Position } from 'geojson';
 
@@ -13,7 +13,10 @@ import { mToMm } from 'utils/physics';
  * For each path step, get all its secondary codes and track names to display in the form
  * and update the pathStepsMetadataById state.
  */
-export const usePathStepsMetadata = (pathSteps: PathStepV2[]) => {
+export const usePathStepsMetadata = (
+  pathSteps: PathStepV2[],
+  pendingStepIdRef: RefObject<string>
+) => {
   const { infraId, getTrackSectionsByIds } = useScenarioContext();
 
   const [pathStepsMetadataById, setPathStepsMetadataById] = useState<Map<string, PathStepMetadata>>(
@@ -130,7 +133,14 @@ export const usePathStepsMetadata = (pathSteps: PathStepV2[]) => {
           parts,
         });
       });
+      const pendingStepId = pendingStepIdRef?.current;
 
+      if (pendingStepId) {
+        const metadata = newPathStepsMetadataById.get(pendingStepId);
+        if (metadata && !metadata.isInvalid) {
+          pendingStepIdRef.current = '';
+        }
+      }
       setPathStepsMetadataById(newPathStepsMetadataById);
     };
     fetchAndSetMetadata();


### PR DESCRIPTION
closes #15715 

now checking if the op is coming from the ```PathStepItem``` and if its resolution is pending.