### PR TITLE
editoast: adapt mocking core client and tests to support streaming JSONL

### DIFF
--- a/editoast/core_client/src/lib.rs
+++ b/editoast/core_client/src/lib.rs
@@ -159,11 +159,14 @@ impl CoreClient {
                     todo!("TODO: handle protocol errors")
                 })))
             }
-            CoreClient::Mocked(client) => match client.fetch_mocked::<_, B, R>(path, body) {
-                Ok(Some(response)) => Ok(Either::Right(stream::once(async { Ok(response) }))),
-                Ok(None) => Err(Error::NoResponseContent),
-                Err(mocking::MockingError { bytes, url }) => Err(Error::parse(&bytes, url)),
-            },
+            CoreClient::Mocked(client) => {
+                match client.fetch_streaming_mocked::<_, B, R>(path, body) {
+                    Ok(responses) => Ok(Either::Right(
+                        stream::iter(responses).map(|response| Ok(response)),
+                    )),
+                    Err(mocking::MockingError { bytes, url }) => Err(Error::parse(&bytes, url)),
+                }
+            }
         }
     }
 }

--- a/editoast/core_client/src/mocking.rs
+++ b/editoast/core_client/src/mocking.rs
@@ -41,21 +41,33 @@ impl MockingClient {
         StubRequestBuilder::new(path.as_ref().into(), self)
     }
 
-    pub(super) fn fetch_mocked<P: AsRef<str>, B: Serialize, R: CoreResponse>(
+    pub(super) fn fetch_streaming_mocked<P: AsRef<str>, B: Serialize, R: CoreResponse>(
         &self,
         req_path: P,
         req_body: Option<&B>,
-    ) -> Result<Option<R::Response>, MockingError> {
-        let req_path = req_path.as_ref().to_string();
+    ) -> Result<Vec<R::Response>, MockingError> {
+        let req_path = req_path.as_ref();
 
-        let Some(stub) = self
+        let Some(stubs) = self
             .stubs
-            .get(&req_path)
-            .and_then(|stubs| stubs.deref().lock().unwrap().pop_front())
+            .get(req_path)
+            .map(|stubs| stubs.deref().lock().unwrap().drain(..).collect::<Vec<_>>())
         else {
             panic!("could not find stub for request at PATH '{req_path}'");
         };
 
+        stubs
+            .iter()
+            .map(|stub| Self::process_stub_request::<B, R>(stub, req_path, req_body))
+            .flat_map(Result::transpose)
+            .collect()
+    }
+
+    fn process_stub_request<B: Serialize, R: CoreResponse>(
+        stub: &StubRequest,
+        req_path: &str,
+        req_body: Option<&B>,
+    ) -> Result<Option<R::Response>, MockingError> {
         match (
             req_body.map(|b| serde_json::to_string(b).expect("could not serialize request body")),
             stub.body.as_ref().map(|b| b.as_str().to_string()),
@@ -83,7 +95,7 @@ impl MockingClient {
                     .to_vec();
                 Err(MockingError {
                     bytes: err,
-                    url: req_path,
+                    url: req_path.to_string(),
                 })
             }
         }

--- a/editoast/core_client/src/stdcm.rs
+++ b/editoast/core_client/src/stdcm.rs
@@ -141,7 +141,6 @@ pub struct ConsistSchedule {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(tag = "status", rename_all = "SCREAMING_SNAKE_CASE")]
-#[allow(clippy::large_enum_variant)]
 pub enum ProgressStatus {
     InProgress {
         point: ProgressCoordinates,

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -746,4 +746,49 @@ impl TestResponse {
             panic!("could not deserialize test request");
         })
     }
+
+    #[tracing::instrument(
+        name = "Deserialization",
+        level = "debug",
+        skip(self),
+        fields(response_status = ?self.inner.status_code())
+    )]
+    #[track_caller]
+    pub fn last_jsonl_into<T: DeserializeOwned>(self) -> T {
+        self.jsonl_into()
+            .into_iter()
+            .last()
+            .expect("Response should not be empty")
+    }
+
+    #[tracing::instrument(
+        name = "Deserialization",
+        level = "debug",
+        skip(self),
+        fields(response_status = ?self.inner.status_code())
+    )]
+    #[track_caller]
+    pub fn jsonl_into<T: DeserializeOwned>(self) -> Vec<T> {
+        let body = self.string();
+
+        body.lines()
+            .map(|line| {
+                serde_json::from_str(line).unwrap_or_else(|err| {
+                    tracing::error!(error = ?err, "Error deserializing test response into the desired type");
+                    let actual: serde_json::Value =
+                        serde_json::from_str(line).unwrap_or_else(|err| {
+                            tracing::error!(
+                                error = ?err,
+                                ?body,
+                                "Failed to deserialize test response body into JSON"
+                            );
+                            panic!("could not deserialize test response into JSON");
+                        });
+                    let pretty = serde_json::to_string_pretty(&actual).unwrap();
+                    tracing::error!(body = %pretty, "Actual JSON value");
+                    panic!("could not deserialize test request");
+                })
+            })
+            .collect::<Vec<_>>()
+    }
 }

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -558,7 +558,6 @@ mod tests {
     use schemas::train_schedule::OperationalPointPartReference;
     use schemas::train_schedule::OperationalPointReference;
     use schemas::train_schedule::PathItemLocation;
-    use serde_json::json;
     use std::str::FromStr;
     use uom::si::length::Length;
     use uom::si::length::meter;
@@ -841,11 +840,13 @@ mod tests {
         let mut core = core_mocking_client();
         core.stub("/stdcm")
             .response(StatusCode::OK)
-            .json(core_client::stdcm::Response::Success {
-                simulation: simulation_empty_response().success().unwrap(),
-                path: pathfinding_result_success(),
-                departure_time: DateTime::from_str("2024-01-02T00:00:00Z")
-                    .expect("Failed to parse datetime"),
+            .json(core_client::stdcm::ProgressStatus::Done {
+                result: core_client::stdcm::Response::Success {
+                    simulation: simulation_empty_response().success().unwrap(),
+                    path: pathfinding_result_success(),
+                    departure_time: DateTime::from_str("2024-01-02T00:00:00Z")
+                        .expect("Failed to parse datetime"),
+                },
             })
             .finish();
 
@@ -860,24 +861,24 @@ mod tests {
             .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
             .json(&get_stdcm_payload(rolling_stock.id, None, None, None));
 
-        let stdcm_response: StdcmResponse = app
+        let stdcm_response: Result<StdcmProgression, InternalError> = app
             .fetch(request)
             .await
             .assert_status(StatusCode::OK)
-            .json_into();
+            .last_jsonl_into();
 
         if let PathfindingResult::Success(path) =
             PathfindingResult::Success(pathfinding_result_success())
         {
             assert_eq!(
-                stdcm_response,
-                StdcmResponse::Success {
+                stdcm_response.unwrap(),
+                StdcmProgression::Completed(StdcmResponse::Success {
                     simulation: simulation_empty_response().success().unwrap().into(),
                     pathfinding_result: path,
                     departure_time: DateTime::from_str("2024-01-02T00:00:00Z")
                         .expect("Failed to parse datetime"),
                     core_payload: None,
-                }
+                })
             );
         }
     }
@@ -971,11 +972,13 @@ mod tests {
         let mut core = core_mocking_client();
         core.stub("/stdcm")
             .response(StatusCode::OK)
-            .json(core_client::stdcm::Response::Success {
-                simulation: simulation_empty_response().success().unwrap(),
-                path: pathfinding_result_success(),
-                departure_time: DateTime::from_str("2024-01-02T00:00:00Z")
-                    .expect("Failed to parse datetime"),
+            .json(core_client::stdcm::ProgressStatus::Done {
+                result: core_client::stdcm::Response::Success {
+                    simulation: simulation_empty_response().success().unwrap(),
+                    path: pathfinding_result_success(),
+                    departure_time: DateTime::from_str("2024-01-02T00:00:00Z")
+                        .expect("Failed to parse datetime"),
+                },
             })
             .finish();
 
@@ -997,24 +1000,24 @@ mod tests {
                 total_length,
             ));
 
-        let stdcm_response: StdcmResponse = app
+        let stdcm_response: Result<StdcmProgression, InternalError> = app
             .fetch(request)
             .await
             .assert_status(StatusCode::OK)
-            .json_into();
+            .last_jsonl_into();
 
         if let PathfindingResult::Success(path) =
             PathfindingResult::Success(pathfinding_result_success())
         {
             assert_eq!(
-                stdcm_response,
-                StdcmResponse::Success {
+                stdcm_response.unwrap(),
+                StdcmProgression::Completed(StdcmResponse::Success {
                     simulation: simulation_empty_response().success().unwrap().into(),
                     pathfinding_result: path,
                     departure_time: DateTime::from_str("2024-01-02T00:00:00Z")
                         .expect("Failed to parse datetime"),
                     core_payload: None,
-                }
+                })
             );
         }
     }
@@ -1024,7 +1027,9 @@ mod tests {
         let mut core = core_mocking_client();
         core.stub("/stdcm")
             .response(StatusCode::OK)
-            .json(json!({"status": "path_not_found"}))
+            .json(core_client::stdcm::ProgressStatus::Done {
+                result: core_client::stdcm::Response::PathNotFound,
+            })
             .finish();
 
         let app = TestAppBuilder::new().core_client(core.into()).build();
@@ -1038,15 +1043,142 @@ mod tests {
             .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
             .json(&get_stdcm_payload(rolling_stock.id, None, None, None));
 
-        let stdcm_response: StdcmResponse = app
+        let stdcm_response: Result<StdcmProgression, InternalError> = app
             .fetch(request)
             .await
             .assert_status(StatusCode::OK)
-            .json_into();
+            .last_jsonl_into();
 
         assert_eq!(
-            stdcm_response,
-            StdcmResponse::PathNotFound { core_payload: None }
+            stdcm_response.unwrap(),
+            StdcmProgression::Completed(StdcmResponse::PathNotFound { core_payload: None })
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn stdcm_multiple_response_return_success() {
+        let mut core = core_mocking_client();
+        core.stub("/stdcm")
+            .response(StatusCode::OK)
+            .json(core_client::stdcm::ProgressStatus::InProgress {
+                point: core_client::stdcm::ProgressCoordinates { lat: 0.0, lon: 0.0 },
+                best_travel_time: 1,
+            })
+            .json(core_client::stdcm::ProgressStatus::InProgress {
+                point: core_client::stdcm::ProgressCoordinates { lat: 1.0, lon: 1.0 },
+                best_travel_time: 5,
+            })
+            .json(core_client::stdcm::ProgressStatus::Done {
+                result: core_client::stdcm::Response::Success {
+                    simulation: simulation_empty_response().success().unwrap(),
+                    path: pathfinding_result_success(),
+                    departure_time: DateTime::from_str("2024-01-02T00:00:00Z")
+                        .expect("Failed to parse datetime"),
+                },
+            })
+            .finish();
+
+        let app = TestAppBuilder::new().core_client(core.into()).build();
+        let db_pool = app.db_pool();
+        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let timetable = create_timetable(&mut db_pool.get_ok()).await;
+        let rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+
+        let request = app
+            .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
+            .json(&get_stdcm_payload(rolling_stock.id, None, None, None));
+
+        let stdcm_response: Vec<Result<StdcmProgression, InternalError>> = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .jsonl_into();
+
+        if let PathfindingResult::Success(path) =
+            PathfindingResult::Success(pathfinding_result_success())
+        {
+            assert_eq!(stdcm_response.len(), 3);
+            assert_eq!(
+                stdcm_response[0].clone().unwrap(),
+                StdcmProgression::Ongoing(StdcmProgressionEvent {
+                    point: Geometry::new(Value::Point(vec![0.0, 0.0])),
+                    best_travel_time: 1,
+                })
+            );
+            assert_eq!(
+                stdcm_response[1].clone().unwrap(),
+                StdcmProgression::Ongoing(StdcmProgressionEvent {
+                    point: Geometry::new(Value::Point(vec![1.0, 1.0])),
+                    best_travel_time: 5,
+                })
+            );
+            assert_eq!(
+                stdcm_response[2].clone().unwrap(),
+                StdcmProgression::Completed(StdcmResponse::Success {
+                    simulation: simulation_empty_response().success().unwrap().into(),
+                    pathfinding_result: path,
+                    departure_time: DateTime::from_str("2024-01-02T00:00:00Z")
+                        .expect("Failed to parse datetime"),
+                    core_payload: None,
+                })
+            );
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn stdcm_multiple_response_path_not_found() {
+        let mut core = core_mocking_client();
+        core.stub("/stdcm")
+            .response(StatusCode::OK)
+            .json(core_client::stdcm::ProgressStatus::InProgress {
+                point: core_client::stdcm::ProgressCoordinates { lat: 0.0, lon: 0.0 },
+                best_travel_time: 1,
+            })
+            .json(core_client::stdcm::ProgressStatus::InProgress {
+                point: core_client::stdcm::ProgressCoordinates { lat: 1.0, lon: 1.0 },
+                best_travel_time: 5,
+            })
+            .json(core_client::stdcm::ProgressStatus::Done {
+                result: core_client::stdcm::Response::PathNotFound,
+            })
+            .finish();
+
+        let app = TestAppBuilder::new().core_client(core.into()).build();
+        let db_pool = app.db_pool();
+        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let timetable = create_timetable(&mut db_pool.get_ok()).await;
+        let rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+
+        let request = app
+            .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
+            .json(&get_stdcm_payload(rolling_stock.id, None, None, None));
+
+        let stdcm_response: Vec<Result<StdcmProgression, InternalError>> = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .jsonl_into();
+
+        assert_eq!(stdcm_response.len(), 3);
+        assert_eq!(
+            stdcm_response[0].clone().unwrap(),
+            StdcmProgression::Ongoing(StdcmProgressionEvent {
+                point: Geometry::new(Value::Point(vec![0.0, 0.0])),
+                best_travel_time: 1,
+            })
+        );
+        assert_eq!(
+            stdcm_response[1].clone().unwrap(),
+            StdcmProgression::Ongoing(StdcmProgressionEvent {
+                point: Geometry::new(Value::Point(vec![1.0, 1.0])),
+                best_travel_time: 5,
+            })
+        );
+        assert_eq!(
+            stdcm_response[2].clone().unwrap(),
+            StdcmProgression::Completed(StdcmResponse::PathNotFound { core_payload: None })
         );
     }
 


### PR DESCRIPTION
Closes #15492

> [!WARNING]
> Commits 
> `editoast: change terminating_response header in mq_client` 
>and 
> `editoast: adapt the stdcm endpoint to stream as JSONL` 
> are from this PR #15662 
> This PR will be merged on `bam/lmr-search-progress` before `dev`