### PR TITLE
editoast: add occurrences utilities functions

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -1858,9 +1858,13 @@ paths:
                         required:
                         - train_schedule_id
                         - index
+                        - exception_id
                         - exception_key
                         - type
                         properties:
+                          exception_id:
+                            type: integer
+                            format: int64
                           exception_key:
                             type: string
                           index:
@@ -1876,9 +1880,13 @@ paths:
                       - type: object
                         required:
                         - train_schedule_id
+                        - exception_id
                         - exception_key
                         - type
                         properties:
+                          exception_id:
+                            type: integer
+                            format: int64
                           exception_key:
                             type: string
                           train_schedule_id:
@@ -4478,9 +4486,13 @@ paths:
                             required:
                             - train_schedule_id
                             - index
+                            - exception_id
                             - exception_key
                             - type
                             properties:
+                              exception_id:
+                                type: integer
+                                format: int64
                               exception_key:
                                 type: string
                               index:
@@ -4496,9 +4508,13 @@ paths:
                           - type: object
                             required:
                             - train_schedule_id
+                            - exception_id
                             - exception_key
                             - type
                             properties:
+                              exception_id:
+                                type: integer
+                                format: int64
                               exception_key:
                                 type: string
                               train_schedule_id:
@@ -5136,9 +5152,13 @@ components:
               required:
               - train_schedule_id
               - index
+              - exception_id
               - exception_key
               - type
               properties:
+                exception_id:
+                  type: integer
+                  format: int64
                 exception_key:
                   type: string
                 index:
@@ -5154,9 +5174,13 @@ components:
             - type: object
               required:
               - train_schedule_id
+              - exception_id
               - exception_key
               - type
               properties:
+                exception_id:
+                  type: integer
+                  format: int64
                 exception_key:
                   type: string
                 train_schedule_id:

--- a/editoast/schemas/src/train_schedule_exception.rs
+++ b/editoast/schemas/src/train_schedule_exception.rs
@@ -55,3 +55,122 @@ pub struct TrainScheduleExceptionChangeGroups {
     #[schema(nullable = false)]
     pub path_and_schedule: Option<PathAndScheduleChangeGroup>,
 }
+
+#[cfg(any(test, feature = "testing"))]
+impl TrainScheduleExceptionChangeGroups {
+    pub fn fake_created() -> Self {
+        use std::str::FromStr;
+
+        use chrono::DateTime;
+        use chrono::Utc;
+
+        use crate::infra::TrackOffset;
+        use crate::primitives::Identifier;
+        use crate::primitives::NonBlankString;
+        use crate::train_schedule::Comfort;
+        use crate::train_schedule::Distribution;
+        use crate::train_schedule::MarginValue;
+        use crate::train_schedule::Margins;
+        use crate::train_schedule::OperationalPointPartReference;
+        use crate::train_schedule::OperationalPointReference;
+        use crate::train_schedule::PathItem;
+        use crate::train_schedule::PathItemLocation;
+        use crate::train_schedule::ScheduleItem;
+        use crate::train_schedule::TrainScheduleOptions;
+
+        Self {
+            train_name: Some(TrainNameChangeGroup {
+                value: "created_exception_train_name".into(),
+            }),
+            constraint_distribution: Some(ConstraintDistributionChangeGroup {
+                value: Distribution::Mareco,
+            }),
+            initial_speed: Some(InitialSpeedChangeGroup { value: 10.0 }),
+            labels: Some(LabelsChangeGroup {
+                value: vec!["Label 1".to_string(), "Label 3".to_string()],
+            }),
+            options: Some(OptionsChangeGroup {
+                value: TrainScheduleOptions::default(),
+            }),
+            path_and_schedule: Some(PathAndScheduleChangeGroup {
+                power_restrictions: vec![],
+                schedule: vec![
+                    ScheduleItem {
+                        at: NonBlankString("aa".to_string()),
+                        ..Default::default()
+                    },
+                    ScheduleItem {
+                        at: NonBlankString("bb".to_string()),
+                        ..Default::default()
+                    },
+                    ScheduleItem {
+                        at: NonBlankString("cc".to_string()),
+                        ..Default::default()
+                    },
+                    ScheduleItem {
+                        at: NonBlankString("dd".to_string()),
+                        ..Default::default()
+                    },
+                ],
+                path: vec![
+                    PathItem {
+                        id: "aa".into(),
+                        location: PathItemLocation::TrackOffset(TrackOffset {
+                            offset: 300,
+                            track: Identifier("TC0".to_string()),
+                        }),
+                    },
+                    PathItem {
+                        id: "bb".into(),
+                        location: PathItemLocation::OperationalPointPartReference(
+                            OperationalPointPartReference {
+                                operational_point: OperationalPointReference::Id {
+                                    operational_point: Identifier("Mid_East_station".to_string()),
+                                },
+                                local_track_name: None,
+                            },
+                        ),
+                    },
+                    PathItem {
+                        id: "cc".into(),
+                        location: PathItemLocation::TrackOffset(TrackOffset {
+                            offset: 300,
+                            track: Identifier("TC1".to_string()),
+                        }),
+                    },
+                    PathItem {
+                        id: "dd".into(),
+                        location: PathItemLocation::TrackOffset(TrackOffset {
+                            offset: 300,
+                            track: Identifier("TC2".to_string()),
+                        }),
+                    },
+                ],
+                margins: Margins {
+                    boundaries: vec![],
+                    values: vec![MarginValue::Percentage(5.0)],
+                },
+            }),
+            rolling_stock: Some(RollingStockChangeGroup {
+                rolling_stock_name: "simulation_rolling_stock".into(),
+                comfort: Comfort::AirConditioning,
+            }),
+            rolling_stock_category: Some(RollingStockCategoryChangeGroup { value: None }),
+            speed_limit_tag: Some(SpeedLimitTagChangeGroup {
+                value: Some(NonBlankString("GB".into())),
+            }),
+            start_time: Some(StartTimeChangeGroup {
+                value: DateTime::<Utc>::from_str("2025-05-15T15:10:00+02:00").unwrap(),
+            }),
+        }
+    }
+
+    pub fn fake_modified() -> Self {
+        let mut created = Self::fake_created();
+        created.start_time = None;
+        created.train_name = Some(TrainNameChangeGroup {
+            value: "modified_exception_train_name".to_string(),
+        });
+        created
+    }
+}

--- a/editoast/src/models/fixtures.rs
+++ b/editoast/src/models/fixtures.rs
@@ -1,6 +1,3 @@
-use std::str::FromStr;
-
-use chrono::DateTime;
 use chrono::Duration as ChronoDuration;
 use chrono::Utc;
 use database::DbConnection;
@@ -25,35 +22,13 @@ use schemas::fixtures::simple_created_exception_with_change_groups;
 use schemas::fixtures::simple_modified_exception_with_change_groups;
 use schemas::infra::InfraObject;
 use schemas::infra::RailJson;
-use schemas::infra::TrackOffset;
-use schemas::paced_train::ConstraintDistributionChangeGroup;
 use schemas::paced_train::ExceptionType;
-use schemas::paced_train::InitialSpeedChangeGroup;
-use schemas::paced_train::LabelsChangeGroup;
-use schemas::paced_train::OptionsChangeGroup;
 use schemas::paced_train::Paced;
 use schemas::paced_train::PacedTrainException;
-use schemas::paced_train::PathAndScheduleChangeGroup;
-use schemas::paced_train::RollingStockCategoryChangeGroup;
-use schemas::paced_train::RollingStockChangeGroup;
-use schemas::paced_train::SpeedLimitTagChangeGroup;
-use schemas::paced_train::StartTimeChangeGroup;
 use schemas::paced_train::TrainNameChangeGroup;
 use schemas::paced_train::TrainSchedule;
-use schemas::primitives::Identifier;
-use schemas::primitives::NonBlankString;
 use schemas::primitives::OSRDObject;
 use schemas::rolling_stock::SubCategoryColor;
-use schemas::train_schedule::Comfort;
-use schemas::train_schedule::Distribution;
-use schemas::train_schedule::MarginValue;
-use schemas::train_schedule::Margins;
-use schemas::train_schedule::OperationalPointPartReference;
-use schemas::train_schedule::OperationalPointReference;
-use schemas::train_schedule::PathItem;
-use schemas::train_schedule::PathItemLocation;
-use schemas::train_schedule::ScheduleItem;
-use schemas::train_schedule::TrainScheduleOptions;
 
 use crate::infra_cache::operation::create::apply_create_operation;
 use crate::models;
@@ -139,91 +114,7 @@ pub fn create_created_exception_with_change_groups(key: &str) -> PacedTrainExcep
         key: key.into(),
         exception_type: ExceptionType::Created {},
         disabled: false,
-        change_groups: TrainScheduleExceptionChangeGroups {
-            train_name: Some(TrainNameChangeGroup {
-                value: "created_exception_train_name".into(),
-            }),
-            constraint_distribution: Some(ConstraintDistributionChangeGroup {
-                value: Distribution::Mareco,
-            }),
-            initial_speed: Some(InitialSpeedChangeGroup { value: 10.0 }),
-            labels: Some(LabelsChangeGroup {
-                value: vec!["Label 1".to_string(), "Label 3".to_string()],
-            }),
-            options: Some(OptionsChangeGroup {
-                value: TrainScheduleOptions::default(),
-            }),
-            path_and_schedule: Some(PathAndScheduleChangeGroup {
-                power_restrictions: vec![],
-                schedule: vec![
-                    ScheduleItem {
-                        at: NonBlankString("aa".to_string()),
-                        ..Default::default()
-                    },
-                    ScheduleItem {
-                        at: NonBlankString("bb".to_string()),
-                        ..Default::default()
-                    },
-                    ScheduleItem {
-                        at: NonBlankString("cc".to_string()),
-                        ..Default::default()
-                    },
-                    ScheduleItem {
-                        at: NonBlankString("dd".to_string()),
-                        ..Default::default()
-                    },
-                ],
-                path: vec![
-                    PathItem {
-                        id: "aa".into(),
-                        location: PathItemLocation::TrackOffset(TrackOffset {
-                            offset: 300,
-                            track: Identifier("TC0".to_string()),
-                        }),
-                    },
-                    PathItem {
-                        id: "bb".into(),
-                        location: PathItemLocation::OperationalPointPartReference(
-                            OperationalPointPartReference {
-                                operational_point: OperationalPointReference::Id {
-                                    operational_point: Identifier("Mid_East_station".to_string()),
-                                },
-                                local_track_name: None,
-                            },
-                        ),
-                    },
-                    PathItem {
-                        id: "cc".into(),
-                        location: PathItemLocation::TrackOffset(TrackOffset {
-                            offset: 300,
-                            track: Identifier("TC1".to_string()),
-                        }),
-                    },
-                    PathItem {
-                        id: "dd".into(),
-                        location: PathItemLocation::TrackOffset(TrackOffset {
-                            offset: 300,
-                            track: Identifier("TC2".to_string()),
-                        }),
-                    },
-                ],
-                margins: Margins {
-                    boundaries: vec![],
-                    values: vec![MarginValue::Percentage(5.0)],
-                },
-            }),
-            rolling_stock: Some(RollingStockChangeGroup {
-                rolling_stock_name: "simulation_rolling_stock".into(),
-                comfort: Comfort::AirConditioning,
-            }),
-            rolling_stock_category: Some(RollingStockCategoryChangeGroup { value: None }),
-            speed_limit_tag: Some(SpeedLimitTagChangeGroup {
-                value: Some(NonBlankString("GB".into())),
-            }),
-            start_time: Some(StartTimeChangeGroup {
-                value: DateTime::<Utc>::from_str("2025-05-15T15:10:00+02:00").unwrap(),
-            }),
-        },
+        change_groups: TrainScheduleExceptionChangeGroups::fake_created(),
     }
 }
 

--- a/editoast/src/models/train_schedule.rs
+++ b/editoast/src/models/train_schedule.rs
@@ -186,6 +186,7 @@ impl TrainSchedule {
         }
     }
 
+    // TODO remove it
     /// Returns an iterator over "created" train exceptions with their IDs and schedules.
     fn get_created_occurrences_exceptions(
         &self,
@@ -195,7 +196,11 @@ impl TrainSchedule {
             .filter(|exception| matches!(exception.exception_type, ExceptionType::Created { .. }))
             .map(|exception| {
                 (
-                    OccurrenceId::new_created(self.id, exception.key.clone()),
+                    OccurrenceId::new_created(
+                        self.id,
+                        exception.id.unwrap_or_default(), // TODO use only id
+                        exception.key.clone(),
+                    ),
                     self.apply_exception(exception),
                 )
             })
@@ -226,6 +231,7 @@ impl TrainSchedule {
             .collect()
     }
 
+    // TODO remove it
     /// Returns an iterator over all train occurrences, including:
     /// - base occurrences, minus the ones disabled by a modified exception
     /// - occurrences modified by exceptions (which replace a base one)
@@ -258,6 +264,7 @@ impl TrainSchedule {
                     let occurrence_id = OccurrenceId::new_modified(
                         self.id,
                         occurrence_index,
+                        exception.id.unwrap_or_default(), // TODO use only id
                         exception.key.clone(),
                     );
                     *occurrence = (occurrence_id, self.apply_exception(exception));
@@ -295,6 +302,91 @@ impl TrainSchedule {
             .interval
             .expect("interval should be set for paced trains");
         (time_window.num_seconds() / interval.num_seconds()) as usize
+    }
+
+    /// Returns an iterator over "created" train exceptions with their IDs and schedules.
+    fn get_created_occurrences_exceptions_v2(
+        &self,
+        exceptions: &[TrainScheduleException],
+    ) -> impl Iterator<Item = (OccurrenceId, TrainOccurrence)> {
+        exceptions
+            .iter()
+            .filter(|exception| exception.occurrence_index.is_none())
+            .map(|exception| {
+                (
+                    OccurrenceId::new_created(
+                        self.id,
+                        exception.id,
+                        exception
+                            .key
+                            .clone()
+                            .unwrap_or_else(|| exception.id.to_string()),
+                    ),
+                    self.apply_train_schedule_exception(exception),
+                )
+            })
+    }
+
+    /// Returns an iterator over all train occurrences, including:
+    /// - base occurrences, minus the ones disabled by a modified exception
+    /// - occurrences modified by exceptions (which replace a base one)
+    /// - occurrences created by exceptions (additional trains)
+    ///
+    /// If it's not a paced train (i.e., no time window), this will return the single train schedule.
+    ///
+    /// This function replaces any base occurrence that has a `Modified` exception,
+    /// and appends any `Created` exceptions as new trains.
+    ///
+    /// The result is sorted by `start_time` to reflect the chronological order of the trains.
+    pub fn iter_occurrences_v2(
+        &self,
+        exceptions: &[TrainScheduleException],
+    ) -> impl Iterator<Item = (OccurrenceId, TrainOccurrence)> {
+        let mut base_occurrences = self.get_base_occurrences();
+
+        let modified_exceptions = exceptions.iter().filter_map(|e| {
+            e.occurrence_index
+                .map(|occurrence_index| (occurrence_index, e))
+        });
+
+        let mut to_remove = vec![false; base_occurrences.len()];
+        // Modify corresponding occurrences.
+        for (occurrence_index, exception) in modified_exceptions {
+            if let Some(occurrence) = base_occurrences.get_mut(occurrence_index as usize) {
+                if exception.disabled {
+                    to_remove[occurrence_index as usize] = true;
+                } else {
+                    let occurrence_id = OccurrenceId::new_modified(
+                        self.id,
+                        occurrence_index as usize,
+                        exception.id,
+                        exception
+                            .key
+                            .clone()
+                            .unwrap_or_else(|| exception.id.to_string()),
+                    );
+                    *occurrence = (
+                        occurrence_id,
+                        self.apply_train_schedule_exception(exception),
+                    );
+                }
+            }
+        }
+        // Remove disabled occurrences.
+        let occurrences = base_occurrences
+            .into_iter()
+            .zip(to_remove)
+            .filter_map(|(occ, disabled)| if disabled { None } else { Some(occ) });
+
+        let created_occurrences = self
+            .get_created_occurrences_exceptions_v2(exceptions)
+            .collect::<Vec<_>>();
+        dbg!(created_occurrences);
+
+        occurrences
+            .into_iter()
+            .chain(self.get_created_occurrences_exceptions_v2(exceptions))
+            .sorted_by_key(|(_, ts)| ts.start_time)
     }
 }
 
@@ -384,11 +476,13 @@ pub enum OccurrenceId {
     Modified {
         train_schedule_id: i64,
         index: usize,
-        exception_key: String,
+        exception_id: i64,
+        exception_key: String, // TODO remove it
     },
     Created {
         train_schedule_id: i64,
-        exception_key: String,
+        exception_id: i64,
+        exception_key: String, // TODO remove it
     },
 }
 
@@ -402,18 +496,20 @@ impl OccurrenceId {
     }
 
     /// Create a new `Occurrence::Modified` without an exception key.
-    pub fn new_modified(id: i64, index: usize, exception_key: String) -> Self {
+    pub fn new_modified(id: i64, index: usize, exception_id: i64, exception_key: String) -> Self {
         OccurrenceId::Modified {
             train_schedule_id: id,
             index,
+            exception_id,
             exception_key,
         }
     }
 
     /// Creates a new `Occurrence::Created`.
-    pub fn new_created(id: i64, exception_key: String) -> Self {
+    pub fn new_created(id: i64, exception_id: i64, exception_key: String) -> Self {
         OccurrenceId::Created {
             train_schedule_id: id,
+            exception_id,
             exception_key,
         }
     }
@@ -429,13 +525,15 @@ impl Display for OccurrenceId {
             OccurrenceId::Modified {
                 train_schedule_id: id,
                 index,
-                exception_key,
-            } => write!(f, "{}@{}#{}", id, exception_key, index),
+                exception_id,
+                ..
+            } => write!(f, "{}@{}#{}", id, exception_id, index),
             OccurrenceId::Created {
                 train_schedule_id: id,
-                exception_key,
+                exception_id,
+                ..
             } => {
-                write!(f, "{}@{}", id, exception_key)
+                write!(f, "{}@{}", id, exception_id)
             }
         }
     }
@@ -455,11 +553,13 @@ mod tests {
     use chrono::DateTime;
     use chrono::Utc;
     use database::DbConnectionPoolV2;
+    use editoast_models::TrainScheduleException;
     use editoast_models::prelude::*;
     use editoast_models::rolling_stock::TrainMainCategory;
     use editoast_models::tags::Tags;
     use pretty_assertions::assert_eq;
     use rstest::rstest;
+    use schemas::TrainScheduleExceptionChangeGroups;
     use schemas::paced_train::PacedTrainException;
     use schemas::paced_train::RollingStockCategoryChangeGroup;
     use schemas::paced_train::StartTimeChangeGroup;
@@ -628,14 +728,46 @@ mod tests {
 
     #[tokio::test]
     async fn iter_occurrences_with_exceptions() {
-        let exception_1 = create_modified_exception_with_change_groups("key_1", 1);
-        let exception_2 = create_created_exception_with_change_groups("key_2");
-        let mut exception_3 = create_modified_exception_with_change_groups("key_3", 0);
-        exception_3.disabled = true;
+        let exception_1: schemas::TrainScheduleException = TrainScheduleException {
+            id: 1,
+            timetable_id: 1,
+            train_schedule_id: 1,
+            key: Some("key_1".into()),
+            occurrence_index: Some(1),
+            disabled: false,
+            change_groups: TrainScheduleExceptionChangeGroups::fake_modified(),
+        }
+        .into();
 
-        let paced_train =
-            create_paced_train(vec![exception_1.clone(), exception_2.clone(), exception_3]);
-        let occurrences: Vec<_> = paced_train.iter_occurrences().collect();
+        let exception_2: schemas::TrainScheduleException = TrainScheduleException {
+            id: 2,
+            timetable_id: 1,
+            train_schedule_id: 1,
+            key: Some("key_2".into()),
+            occurrence_index: None,
+            disabled: false,
+            change_groups: TrainScheduleExceptionChangeGroups::fake_created(),
+        }
+        .into();
+        let exception_3: schemas::TrainScheduleException = TrainScheduleException {
+            id: 3,
+            timetable_id: 1,
+            train_schedule_id: 1,
+            key: Some("key_3".into()),
+            occurrence_index: Some(0),
+            disabled: true,
+            change_groups: TrainScheduleExceptionChangeGroups::fake_modified(),
+        }
+        .into();
+
+        let paced_train = create_paced_train(vec![]);
+        let exceptions: Vec<schemas::TrainScheduleException> = vec![
+            exception_1.clone(),
+            exception_2.clone(),
+            exception_3.clone(),
+        ];
+
+        let occurrences: Vec<_> = paced_train.iter_occurrences_v2(&exceptions).collect();
 
         assert_eq!(occurrences.len(), 4);
 
@@ -670,9 +802,9 @@ mod tests {
         assert_eq!(
             types,
             vec![
-                OccurrenceId::new_modified(paced_train.id, 1, "key_1".to_string()),
+                OccurrenceId::new_modified(paced_train.id, 1, 1, "key_1".into()),
                 OccurrenceId::new_base(paced_train.id, 2),
-                OccurrenceId::new_created(paced_train.id, "key_2".to_string()),
+                OccurrenceId::new_created(paced_train.id, 2, "key_2".into()),
                 OccurrenceId::new_base(paced_train.id, 3),
             ]
         );
@@ -684,9 +816,21 @@ mod tests {
         exception_1.change_groups.start_time = Some(StartTimeChangeGroup {
             value: DateTime::<Utc>::from_str("2025-05-15T14:31:00+02:00").unwrap(),
         });
+        let exception_1: schemas::TrainScheduleException = TrainScheduleException {
+            id: 1,
+            timetable_id: 1,
+            train_schedule_id: 1,
+            key: Some("key_1".into()),
+            occurrence_index: Some(1),
+            disabled: false,
+            change_groups: exception_1.change_groups,
+        }
+        .into();
 
-        let paced_train = create_paced_train(vec![exception_1.clone()]);
-        let occurrences: Vec<_> = paced_train.iter_occurrences().collect();
+        let paced_train = create_paced_train(vec![]);
+        let occurrences: Vec<_> = paced_train
+            .iter_occurrences_v2(&vec![exception_1.clone()])
+            .collect();
 
         assert_eq!(occurrences.len(), 4);
 
@@ -722,7 +866,14 @@ mod tests {
             types,
             vec![
                 OccurrenceId::new_base(paced_train.id, 0),
-                OccurrenceId::new_modified(paced_train.id, 1, "key_1".to_string()),
+                OccurrenceId::new_modified(
+                    paced_train.id,
+                    1,
+                    exception_1.id,
+                    exception_1
+                        .key
+                        .unwrap_or_else(|| exception_1.id.to_string())
+                ),
                 OccurrenceId::new_base(paced_train.id, 2),
                 OccurrenceId::new_base(paced_train.id, 3),
             ]

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -1908,12 +1908,14 @@ export type PostLevelCrossingOccupancyApiResponse =
           type: 'base';
         }
       | {
+          exception_id: number;
           exception_key: string;
           index: number;
           train_schedule_id: number;
           type: 'modified';
         }
       | {
+          exception_id: number;
           exception_key: string;
           train_schedule_id: number;
           type: 'created';
@@ -2574,12 +2576,14 @@ export type PostTrainSchedulesTrackOccupancyApiResponse =
           type: 'base';
         }
       | {
+          exception_id: number;
           exception_key: string;
           index: number;
           train_schedule_id: number;
           type: 'modified';
         }
       | {
+          exception_id: number;
           exception_key: string;
           train_schedule_id: number;
           type: 'created';
@@ -4363,12 +4367,14 @@ export type Conflict = {
         type: 'base';
       }
     | {
+        exception_id: number;
         exception_key: string;
         index: number;
         train_schedule_id: number;
         type: 'modified';
       }
     | {
+        exception_id: number;
         exception_key: string;
         train_schedule_id: number;
         type: 'created';

--- a/front/src/modules/conflict/__tests__/utils.spec.ts
+++ b/front/src/modules/conflict/__tests__/utils.spec.ts
@@ -26,7 +26,7 @@ describe('addTrainNamesToConflicts', () => {
       train_ids: [
         { train_schedule_id: 10, type: 'base', index: 0 },
         { train_schedule_id: 20, type: 'base', index: 8 },
-        { train_schedule_id: 20, type: 'created', exception_key: 'abc' },
+        { train_schedule_id: 20, type: 'created', exception_key: 'abc', exception_id: 1 },
       ],
     });
 


### PR DESCRIPTION
Add `iter_occurrences_v2` and `get_created_occurrences_exceptions_v2` functions that use the new exceptions

It used in endpoints, like conflicts, requirements and others