### PR TITLE
front: fix origin stopfor and departure time in new timestops table

### DIFF
--- a/front/src/modules/timesStops/TimesStopsTable.tsx
+++ b/front/src/modules/timesStops/TimesStopsTable.tsx
@@ -208,11 +208,6 @@ const TimesStopsTable = ({
         header: () => t('departureTime'),
         cell: (info) => {
           const row = info.row.original;
-          // Disable departure editing on the first row (origin)
-          if (row.opOnPathIndex === 0) {
-            const value = info.getValue();
-            return <span>{value ? formatLocalTime(value) : ''}</span>;
-          }
           return (
             <TimeCell
               {...info}

--- a/front/src/modules/timesStops/hooks/useTimesStopsTableData.ts
+++ b/front/src/modules/timesStops/hooks/useTimesStopsTableData.ts
@@ -224,7 +224,8 @@ const useTimesStopsTableData = (
         const hasRequestedTrack =
           'track' in pathStepLocation || !!pathStepLocation.local_track_name;
 
-        const schedule = scheduleByAt[pathStep.id];
+        const schedule = { ...scheduleByAt[pathStep.id] };
+        if (stepIndex === 0) schedule.arrival = 'PT0S'; // The first step has no stored scheduled arrival as redundant with start date
         const computedArrival =
           stablePathItemTimes?.final[stepIndex] !== undefined
             ? new Duration({ milliseconds: stablePathItemTimes.final[stepIndex] })
@@ -320,11 +321,6 @@ const useTimesStopsTableData = (
         ...row,
         opOnPathIndex: rowIndex,
       }));
-    }
-
-    // The first row has no schedule.arrival, so we set requestedArrival to startDate.
-    if (formattedRows.length > 0 && !formattedRows[0].requestedArrival) {
-      formattedRows[0] = { ...formattedRows[0], requestedArrival: startDate };
     }
 
     return formattedRows;

--- a/front/src/modules/timesStops/hooks/useUpdateTimesStopsTable.ts
+++ b/front/src/modules/timesStops/hooks/useUpdateTimesStopsTable.ts
@@ -64,6 +64,7 @@ const useUpdateTimesStopsTable = (
       const { pathStepId, updatedPath } = upsertPathStep(update.row, selectedTrain.path, allRows);
       const currentSchedule = selectedTrain.schedule ?? [];
       const existingItemIndex = currentSchedule.findIndex((item) => item.at === pathStepId);
+      const isOrigin = pathStepId === updatedPath[0].id;
 
       // Convert CellUpdate to OptimisticEdit (stopDuration: number → Duration)
       let edit: OptimisticEdit;
@@ -98,13 +99,13 @@ const useUpdateTimesStopsTable = (
         // Update existing schedule item
         updatedSchedule = replaceElementAtIndex(currentSchedule, existingItemIndex, {
           ...currentSchedule[existingItemIndex],
-          arrival: newArrival,
+          arrival: isOrigin ? null : newArrival,
           stop_for: newStopFor,
         });
       } else {
         // Insert new schedule item in path order
         const newItem: ScheduleItem = { at: pathStepId };
-        if (newArrival !== null) newItem.arrival = newArrival;
+        if (newArrival !== null && !isOrigin) newItem.arrival = newArrival;
         if (newStopFor !== null) newItem.stop_for = newStopFor;
         updatedSchedule = insertScheduleItemInOrder(currentSchedule, newItem, updatedPath);
       }


### PR DESCRIPTION
Close https://github.com/OpenRailAssociation/osrd/issues/15588

The second commit - which enables the departure time for the origin - isn't needed for this issue, but we needed to do it at some point and the first commit makes it possible now.