### PR TITLE
editoast: authz: `Protected::<T>::map`

### DIFF
--- a/editoast/authz/src/model.rs
+++ b/editoast/authz/src/model.rs
@@ -6,7 +6,7 @@ use strum::EnumIter;
 use strum::EnumString;
 use utoipa::ToSchema;
 
-#[derive(Debug, Clone, Copy, PartialEq, derive_more::From)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, derive_more::From)]
 pub enum Subject {
     User(User),
     Group(Group),

--- a/editoast/authz/src/model.rs
+++ b/editoast/authz/src/model.rs
@@ -195,6 +195,6 @@ impl Role {
             roles.public_access.is_none(),
             "we don't write public accesses for roles"
         );
-        Ok(roles.users.into_iter().collect())
+        Ok(roles.users)
     }
 }

--- a/editoast/authz/src/v2.rs
+++ b/editoast/authz/src/v2.rs
@@ -1,9 +1,10 @@
 use std::collections::HashSet;
 
 use fga::client::QueryError;
+use fga::client::UserList;
 use fga::model::Relation as _;
 use futures::FutureExt;
-use futures::future::BoxFuture;
+use futures::future::LocalBoxFuture;
 use itertools::Itertools;
 
 use crate::Group;
@@ -12,7 +13,7 @@ use crate::Subject;
 use crate::User;
 
 pub type OpenFgaError = fga::client::RequestFailure;
-type ValueFut<'a, T> = BoxFuture<'a, Result<T, OpenFgaError>>;
+type ValueFut<'a, T> = LocalBoxFuture<'a, Result<T, OpenFgaError>>;
 /// An alias for the type of a protected operation
 ///
 /// The operation cannot capture any references in the closure context on purpose.
@@ -125,6 +126,30 @@ impl<T> Protected<T> {
     }
 }
 
+impl<T: 'static> Protected<T> {
+    pub fn map<U: 'static>(
+        self,
+        f: impl for<'c> AsyncFnOnce(&'c fga::Client, T) -> Result<U, OpenFgaError> + 'static,
+    ) -> Protected<U> {
+        let Self {
+            op,
+            guardrails,
+            sanity_checks,
+        } = self;
+        Protected {
+            op: Box::new(move |openfga| {
+                async move {
+                    let t = op(openfga).await?;
+                    f(openfga, t).await
+                }
+                .boxed_local()
+            }),
+            guardrails,
+            sanity_checks,
+        }
+    }
+}
+
 impl<'a, T, R> Access<'a, T, R> {
     /// Awaits the authorized operation future if authorized or yields the rejection if not
     ///
@@ -153,6 +178,27 @@ impl<'a, T, R: std::fmt::Debug> Access<'a, T, R> {
     }
 }
 
+pub fn group_members(group: Group) -> Protected<Vec<User>> {
+    Protected::new(move |openfga| {
+        async move {
+            let UserList {
+                users,
+                public_access,
+            } = openfga
+                .list_users(Group::member().query_users(&group))
+                .await
+                .map_err(QueryError::parsing_ok)?;
+            debug_assert!(
+                public_access.is_none(),
+                "we don't write public accesses for groups"
+            );
+            Ok(users)
+        }
+        .boxed()
+    })
+    .with_check(SanityCheck::GroupExists(group))
+}
+
 // TODO: move somewhere more appropriate
 /// Adds some members to a group
 ///
@@ -163,19 +209,9 @@ pub fn add_members(group: Group, members: HashSet<User>) -> Protected<()> {
         .map(|user| SanityCheck::UserExists(*user))
         .collect_vec(); // members is moved in Protected
 
-    Protected::new(move |openfga| {
-        async move {
-            let existing_members = openfga
-                .list_users(Group::member().query_users(&group))
-                .await
-                .map_err(QueryError::parsing_ok)?;
-
-            debug_assert!(
-                existing_members.public_access.is_none(),
-                "we don't write public accesses for groups"
-            );
-
-            let existing_members = HashSet::from_iter(existing_members.users);
+    group_members(group)
+        .map(async move |openfga, existing_members| {
+            let existing_members = HashSet::from_iter(existing_members);
             let new_members = members.difference(&existing_members);
             let mut writes = openfga.prepare_writes();
             for user in new_members {
@@ -183,14 +219,10 @@ pub fn add_members(group: Group, members: HashSet<User>) -> Protected<()> {
                 writes.push(&User::group().tuple(&group, user));
             }
             writes.execute().await?;
-
             Ok(())
-        }
-        .boxed()
-    })
-    .with_check(SanityCheck::GroupExists(group))
-    .with_check_iter(user_exists_checks)
-    .with_guardrail(Guardrail::IssuerHasRole(Role::Admin))
+        })
+        .with_check_iter(user_exists_checks)
+        .with_guardrail(Guardrail::IssuerHasRole(Role::Admin))
 }
 
 // TODO: move somewhere more appropriate
@@ -241,19 +273,9 @@ pub fn remove_members(group: Group, members: HashSet<User>) -> Protected<()> {
         .map(|user| SanityCheck::UserExists(*user))
         .collect_vec(); // members is moved in Protected
 
-    Protected::new(move |openfga| {
-        async move {
-            let existing_members = openfga
-                .list_users(Group::member().query_users(&group))
-                .await
-                .map_err(QueryError::parsing_ok)?;
-
-            debug_assert!(
-                existing_members.public_access.is_none(),
-                "we don't write public accesses for groups"
-            );
-
-            let existing_members = HashSet::from_iter(existing_members.users);
+    group_members(group)
+        .map(async move |openfga, existing_members| {
+            let existing_members = HashSet::from_iter(existing_members);
             let expelled = members.intersection(&existing_members);
             let mut writes = openfga.prepare_deletes();
             for user in expelled {
@@ -262,12 +284,9 @@ pub fn remove_members(group: Group, members: HashSet<User>) -> Protected<()> {
             }
             writes.execute().await?;
             Ok(())
-        }
-        .boxed()
-    })
-    .with_check(SanityCheck::GroupExists(group))
-    .with_check_iter(user_exists_checks)
-    .with_guardrail(Guardrail::IssuerHasRole(Role::Admin))
+        })
+        .with_check_iter(user_exists_checks)
+        .with_guardrail(Guardrail::IssuerHasRole(Role::Admin))
 }
 
 // TODO: move somewhere more appropriate

--- a/editoast/authz/src/v2.rs
+++ b/editoast/authz/src/v2.rs
@@ -51,8 +51,17 @@ pub enum Guardrail {
 /// Not to be confused with [Guardrail]s, which are checks to ensure the permission workflow of editoast is respected.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub enum SanityCheck {
-    UserExists(User),
-    GroupExists(Group),
+    SubjectExists(Subject),
+}
+
+impl SanityCheck {
+    pub fn user(user: User) -> Self {
+        SanityCheck::SubjectExists(Subject::User(user))
+    }
+
+    pub fn group(group: Group) -> Self {
+        SanityCheck::SubjectExists(Subject::Group(group))
+    }
 }
 
 /// The result of authorizing a [Protected] operation via [Authorizer::authorize]
@@ -196,7 +205,7 @@ pub fn group_members(group: Group) -> Protected<Vec<User>> {
         }
         .boxed()
     })
-    .with_check(SanityCheck::GroupExists(group))
+    .with_check(SanityCheck::group(group))
 }
 
 // TODO: move somewhere more appropriate
@@ -206,7 +215,7 @@ pub fn group_members(group: Group) -> Protected<Vec<User>> {
 pub fn add_members(group: Group, members: HashSet<User>) -> Protected<()> {
     let user_exists_checks = members
         .iter()
-        .map(|user| SanityCheck::UserExists(*user))
+        .map(|user| SanityCheck::user(*user))
         .collect_vec(); // members is moved in Protected
 
     group_members(group)
@@ -235,10 +244,7 @@ pub fn subject_roles(subject: Subject) -> Protected<Vec<Role>> {
         }
         .boxed()
     })
-    .with_check(match subject {
-        Subject::User(user) => SanityCheck::UserExists(user),
-        Subject::Group(group) => SanityCheck::GroupExists(group),
-    })
+    .with_check(SanityCheck::SubjectExists(subject))
 }
 
 // TODO: move somewhere more appropriate
@@ -275,7 +281,7 @@ pub fn add_roles(subject: Subject, roles: HashSet<Role>) -> Protected<()> {
 pub fn remove_members(group: Group, members: HashSet<User>) -> Protected<()> {
     let user_exists_checks = members
         .iter()
-        .map(|user| SanityCheck::UserExists(*user))
+        .map(|user| SanityCheck::user(*user))
         .collect_vec(); // members is moved in Protected
 
     group_members(group)

--- a/editoast/authz/src/v2.rs
+++ b/editoast/authz/src/v2.rs
@@ -13,7 +13,12 @@ use crate::User;
 
 pub type OpenFgaError = fga::client::RequestFailure;
 type ValueFut<'a, T> = BoxFuture<'a, Result<T, OpenFgaError>>;
-type Operation<'a, T> = dyn for<'c> FnOnce(&'c fga::Client) -> ValueFut<'c, T> + 'a;
+/// An alias for the type of a protected operation
+///
+/// The operation cannot capture any references in the closure context on purpose.
+/// This is to allow eventually combining [Protected] objects together. It would
+/// "merge" the lifetime of the context and the client together.
+type Operation<T> = dyn for<'c> FnOnce(&'c fga::Client) -> ValueFut<'c, T> + 'static;
 
 /// Represents a protected operation yielding a value `T` and the necessary checks required to run it
 ///
@@ -21,9 +26,9 @@ type Operation<'a, T> = dyn for<'c> FnOnce(&'c fga::Client) -> ValueFut<'c, T> +
 /// but rather by an [Authorizer] implementation, which can choose which checks to enforce or not.
 /// Running a [Protected] through an [Authorizer] will yield an [Access], which represents either an authorization, a bypass or a denial.
 #[derive(derive_more::Debug)]
-pub struct Protected<'a, T> {
+pub struct Protected<T> {
     #[debug(skip)]
-    op: Box<Operation<'a, T>>,
+    op: Box<Operation<T>>,
     pub guardrails: HashSet<Guardrail>,
     pub sanity_checks: HashSet<SanityCheck>,
 }
@@ -66,19 +71,19 @@ pub enum Access<'a, T, R> {
 /// The authorization logic is up to the implementation, but it should take into account the guardrails and sanity checks of the [Protected] operation.
 /// Not every check needs to be enforced depending on the purpose of the implementor, but make sure to authorize each protected operation with
 /// an appropriate [Authorizer], otherwise that *will result in security issues*.
-pub trait Authorizer<'a> {
+pub trait Authorizer {
     type Rejection;
     type Error;
 
     /// Turns a [Protected] operation into an [Access] by enforcing the necessary checks
-    async fn authorize<T>(
-        &self,
-        data: Protected<'a, T>,
+    async fn authorize<'a, T>(
+        &'a self,
+        data: Protected<T>,
     ) -> Result<Access<'a, T, Self::Rejection>, Self::Error>;
 }
 
-impl<'a, T> Protected<'a, T> {
-    pub fn new(f: impl for<'c> FnOnce(&'c fga::Client) -> ValueFut<'c, T> + 'a) -> Self {
+impl<T> Protected<T> {
+    pub fn new(f: impl for<'c> FnOnce(&'c fga::Client) -> ValueFut<'c, T> + 'static) -> Self {
         Self {
             op: Box::new(f),
             guardrails: HashSet::new(),
@@ -87,9 +92,9 @@ impl<'a, T> Protected<'a, T> {
     }
 
     /// For convenient chaining
-    pub async fn authorize<A: Authorizer<'a>>(
+    pub async fn authorize<'a, A: Authorizer>(
         self,
-        authorizer: &A,
+        authorizer: &'a A,
     ) -> Result<Access<'a, T, A::Rejection>, A::Error> {
         authorizer.authorize(self).await
     }
@@ -97,7 +102,7 @@ impl<'a, T> Protected<'a, T> {
     /// Consumes the protection and produces an [Access::Authorized] without performing any check
     ///
     /// Only use this in trusted context or in an [Authorizer] implementation after performing the necessary checks.
-    pub fn blindly_authorize<R>(self, openfga: &'a fga::Client) -> Access<'a, T, R> {
+    pub fn blindly_authorize<'a, R>(self, openfga: &'a fga::Client) -> Access<'a, T, R> {
         Access::Authorized((self.op)(openfga))
     }
 
@@ -152,7 +157,7 @@ impl<'a, T, R: std::fmt::Debug> Access<'a, T, R> {
 /// Adds some members to a group
 ///
 /// Idempotent but not atomic due to the lack of transactions in OpenFGA.
-pub fn add_members(group: Group, members: HashSet<User>) -> Protected<'static, ()> {
+pub fn add_members(group: Group, members: HashSet<User>) -> Protected<()> {
     let user_exists_checks = members
         .iter()
         .map(|user| SanityCheck::UserExists(*user))
@@ -192,7 +197,7 @@ pub fn add_members(group: Group, members: HashSet<User>) -> Protected<'static, (
 /// Gives the subject the specified roles
 ///
 /// Idempotent but not atomic due to the lack of transactions in OpenFGA.
-pub fn add_roles(subject: Subject, roles: HashSet<Role>) -> Protected<'static, ()> {
+pub fn add_roles(subject: Subject, roles: HashSet<Role>) -> Protected<()> {
     Protected::new(move |openfga| {
         async move {
             let existing_roles = match &subject {
@@ -230,7 +235,7 @@ pub fn add_roles(subject: Subject, roles: HashSet<Role>) -> Protected<'static, (
 /// Removes some members from a group
 ///
 /// Idempotent but not atomic due to the lack of transactions in OpenFGA.
-pub fn remove_members(group: Group, members: HashSet<User>) -> Protected<'static, ()> {
+pub fn remove_members(group: Group, members: HashSet<User>) -> Protected<()> {
     let user_exists_checks = members
         .iter()
         .map(|user| SanityCheck::UserExists(*user))
@@ -269,7 +274,7 @@ pub fn remove_members(group: Group, members: HashSet<User>) -> Protected<'static
 /// Removes the specified roles from the subject
 ///
 /// Idempotent but not atomic due to the lack of transactions in OpenFGA.
-pub fn remove_roles(subject: Subject, roles: HashSet<Role>) -> Protected<'static, ()> {
+pub fn remove_roles(subject: Subject, roles: HashSet<Role>) -> Protected<()> {
     Protected::new(move |openfga| {
         async move {
             let existing_roles = match &subject {
@@ -317,25 +322,25 @@ pub mod test_authorizers {
     /// Always rejects with the given rejection reason
     pub struct Reject<Rejection>(Rejection);
 
-    impl<'a> Authorizer<'a> for Authorize<'a> {
+    impl Authorizer for Authorize<'_> {
         type Rejection = ();
         type Error = Infallible;
 
-        async fn authorize<T>(
-            &self,
-            data: Protected<'a, T>,
+        async fn authorize<'a, T>(
+            &'a self,
+            data: Protected<T>,
         ) -> Result<Access<'a, T, Self::Rejection>, Self::Error> {
             Ok(data.blindly_authorize(self.0))
         }
     }
 
-    impl<'a, Rejection: Clone> Authorizer<'a> for Reject<Rejection> {
+    impl<Rejection: Clone> Authorizer for Reject<Rejection> {
         type Rejection = Rejection;
         type Error = Infallible;
 
-        async fn authorize<T>(
-            &self,
-            _data: Protected<'a, T>,
+        async fn authorize<'a, T>(
+            &'a self,
+            _data: Protected<T>,
         ) -> Result<Access<'a, T, Self::Rejection>, Self::Error> {
             Ok(Access::Denied {
                 rejection: self.0.clone(),

--- a/editoast/authz/src/v2.rs
+++ b/editoast/authz/src/v2.rs
@@ -225,18 +225,29 @@ pub fn add_members(group: Group, members: HashSet<User>) -> Protected<()> {
         .with_guardrail(Guardrail::IssuerHasRole(Role::Admin))
 }
 
+pub fn subject_roles(subject: Subject) -> Protected<Vec<Role>> {
+    Protected::new(move |openfga| {
+        async move {
+            match &subject {
+                Subject::User(user) => Role::list_roles(openfga, User::role(), user).await,
+                Subject::Group(group) => Role::list_roles(openfga, Group::role(), group).await,
+            }
+        }
+        .boxed()
+    })
+    .with_check(match subject {
+        Subject::User(user) => SanityCheck::UserExists(user),
+        Subject::Group(group) => SanityCheck::GroupExists(group),
+    })
+}
+
 // TODO: move somewhere more appropriate
 /// Gives the subject the specified roles
 ///
 /// Idempotent but not atomic due to the lack of transactions in OpenFGA.
 pub fn add_roles(subject: Subject, roles: HashSet<Role>) -> Protected<()> {
-    Protected::new(move |openfga| {
-        async move {
-            let existing_roles = match &subject {
-                Subject::User(user) => Role::list_roles(openfga, User::role(), user).await?,
-                Subject::Group(group) => Role::list_roles(openfga, Group::role(), group).await?,
-            };
-
+    subject_roles(subject)
+        .map(async move |openfga, existing_roles| {
             let existing_roles = HashSet::from_iter(existing_roles);
             let new_roles = roles.difference(&existing_roles);
             let mut writes = openfga.prepare_writes();
@@ -254,14 +265,8 @@ pub fn add_roles(subject: Subject, roles: HashSet<Role>) -> Protected<()> {
             }
             writes.execute().await?;
             Ok(())
-        }
-        .boxed()
-    })
-    .with_guardrail(Guardrail::IssuerHasRole(Role::Admin))
-    .with_check(match &subject {
-        Subject::User(user) => SanityCheck::UserExists(*user),
-        Subject::Group(group) => SanityCheck::GroupExists(*group),
-    })
+        })
+        .with_guardrail(Guardrail::IssuerHasRole(Role::Admin))
 }
 
 /// Removes some members from a group
@@ -294,13 +299,8 @@ pub fn remove_members(group: Group, members: HashSet<User>) -> Protected<()> {
 ///
 /// Idempotent but not atomic due to the lack of transactions in OpenFGA.
 pub fn remove_roles(subject: Subject, roles: HashSet<Role>) -> Protected<()> {
-    Protected::new(move |openfga| {
-        async move {
-            let existing_roles = match &subject {
-                Subject::User(user) => Role::list_roles(openfga, User::role(), user).await?,
-                Subject::Group(group) => Role::list_roles(openfga, Group::role(), group).await?,
-            };
-
+    subject_roles(subject)
+        .map(async move |openfga, existing_roles| {
             let existing_roles = HashSet::from_iter(existing_roles);
             let removed_roles = roles.intersection(&existing_roles);
             let mut writes = openfga.prepare_deletes();
@@ -318,14 +318,8 @@ pub fn remove_roles(subject: Subject, roles: HashSet<Role>) -> Protected<()> {
             }
             writes.execute().await?;
             Ok(())
-        }
-        .boxed()
-    })
-    .with_guardrail(Guardrail::IssuerHasRole(Role::Admin))
-    .with_check(match &subject {
-        Subject::User(user) => SanityCheck::UserExists(*user),
-        Subject::Group(group) => SanityCheck::GroupExists(*group),
-    })
+        })
+        .with_guardrail(Guardrail::IssuerHasRole(Role::Admin))
 }
 
 pub mod test_authorizers {

--- a/editoast/src/authorizers.rs
+++ b/editoast/src/authorizers.rs
@@ -46,11 +46,11 @@ async fn sanity_check(
     conn: &mut database::DbConnection,
 ) -> Result<Option<Rejection>, editoast_models::Error> {
     match sanity_check {
-        SanityCheck::UserExists(authz::User(user_id)) => {
+        SanityCheck::SubjectExists(authz::Subject::User(authz::User(user_id))) => {
             Ok((!editoast_models::User::exists(conn, *user_id).await?)
                 .then_some(Rejection::NoSuchUser(*user_id)))
         }
-        SanityCheck::GroupExists(authz::Group(group_id)) => {
+        SanityCheck::SubjectExists(authz::Subject::Group(authz::Group(group_id))) => {
             Ok((!editoast_models::Group::exists(conn, *group_id).await?)
                 .then_some(Rejection::NoSuchGroup(*group_id)))
         }

--- a/editoast/src/authorizers.rs
+++ b/editoast/src/authorizers.rs
@@ -15,14 +15,14 @@ pub struct SystemAuthorizer<'a> {
     pub conn: database::DbConnection,
 }
 
-impl<'a> Authorizer<'a> for SystemAuthorizer<'a> {
+impl Authorizer for SystemAuthorizer<'_> {
     type Error = editoast_models::Error;
     type Rejection = Rejection;
 
     #[tracing::instrument(skip_all)]
-    async fn authorize<T>(
-        &self,
-        data: Protected<'a, T>,
+    async fn authorize<'a, T>(
+        &'a self,
+        data: Protected<T>,
     ) -> Result<Access<'a, T, Self::Rejection>, Self::Error> {
         let conn = &mut self.conn.clone();
         for check in &data.sanity_checks {


### PR DESCRIPTION
refs https://github.com/osrd-project/osrd-confidential/issues/1168

I had to remove the closure lifetime of `Operation` because it makes composition nearly impossible. It's fine since we'll never capture by reference: all our `authz::model` objects are Copy value types.

> [!TIP]
> review commit by commit 


- **editoast: authz: remove lifetime from `Protected` type**
- **editoast: authz: add `Protected::map`**
- **editoast: authz: factorize `v2::subject_roles`**
- **editoast: authz: remove useless iteration/collection**
