### PR TITLE
editoast: new authentication model and middleware

### DIFF
--- a/editoast/src/authentication.rs
+++ b/editoast/src/authentication.rs
@@ -1,0 +1,95 @@
+/// Editoast authentication states
+///
+/// Represents all valid user states for editoast interactions. The values are
+/// mostly extracted from request headers, but this module is axum-agnostic in order
+/// to be able to reuse it in other contexts, such as the CLI.
+///
+/// The values are **not validated by the builder**.
+#[derive(Debug, Clone)]
+#[expect(unused)]
+pub enum Authentication {
+    Unauthenticated,
+    Authenticated {
+        identity: String,
+        name: String,
+    },
+    Impersonating {
+        impersonator_identity: String,
+        impersonator_name: String,
+        impersonated_identity: String,
+    },
+    Skip {
+        identity: Option<String>,
+        name: Option<String>,
+    },
+}
+
+impl Authentication {
+    pub fn builder() -> AuthenticationBuilder {
+        AuthenticationBuilder::default()
+    }
+}
+
+#[derive(Default)]
+pub struct AuthenticationBuilder {
+    identity: Option<String>,
+    name: Option<String>,
+    impersonate: Option<String>,
+    skip: bool,
+}
+
+impl AuthenticationBuilder {
+    pub fn identity(mut self, identity: Option<String>) -> Self {
+        self.identity = identity;
+        self
+    }
+
+    pub fn name(mut self, name: Option<String>) -> Self {
+        self.name = name;
+        self
+    }
+
+    pub fn impersonate(mut self, identity: Option<String>) -> Self {
+        self.impersonate = identity;
+        self
+    }
+
+    pub fn skip(mut self, skip: bool) -> Self {
+        self.skip = skip;
+        self
+    }
+
+    pub fn build(self) -> Result<Authentication, ()> {
+        let authn = match self {
+            Self {
+                skip: true,
+                identity,
+                name,
+                ..
+            } => Authentication::Skip { identity, name },
+            Self {
+                impersonate: Some(impersonated_identity),
+                identity: Some(impersonator_identity),
+                name: Some(impersonator_name),
+                ..
+            } => Authentication::Impersonating {
+                impersonator_identity,
+                impersonator_name,
+                impersonated_identity,
+            },
+            Self {
+                identity: Some(identity),
+                name: Some(name),
+                ..
+            } => Authentication::Authenticated { identity, name },
+            Self {
+                identity: None,
+                name: None,
+                impersonate: None,
+                ..
+            } => Authentication::Unauthenticated,
+            _ => return Err(()),
+        };
+        Ok(authn)
+    }
+}

--- a/editoast/src/main.rs
+++ b/editoast/src/main.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 extern crate diesel;
 
+mod authentication;
 mod authorizers;
 mod client;
 mod error;

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -478,6 +478,56 @@ fn service_router() -> router::DocumentedRouter {
     })
 }
 
+async fn authentication_extraction_middleware(mut req: Request, next: Next) -> Result<Response> {
+    const IDENTITY: &str = "x-remote-user-identity";
+    const NAME: &str = "x-remote-user-name";
+    const SKIP_AUTHZ: &str = "x-osrd-skip-authz";
+    const IMPERSONATE: &str = "x-impersonate";
+
+    let headers = req.headers();
+    let identity = headers.get(IDENTITY).map(|hv| {
+        str::from_utf8(hv.as_bytes())
+            .expect("unexpected non-utf8 characters in x-remote-user-identity")
+            .to_owned()
+    });
+    let name = headers.get(NAME).map(|hv| {
+        str::from_utf8(hv.as_bytes())
+            .expect("unexpected non-utf8 characters in x-remote-user-name")
+            .to_owned()
+    });
+    let impersonate = headers.get(IMPERSONATE).map(|hv| {
+        str::from_utf8(hv.as_bytes())
+            .expect("unexpected non-utf8 characters in x-impersonate")
+            .to_owned()
+    });
+    let skip_authz = headers.contains_key(SKIP_AUTHZ);
+
+    let authn = tracing::info_span!(
+        "authenticating request",
+        identity,
+        name,
+        impersonate,
+        skip_authz,
+    )
+    .in_scope(move || {
+        crate::authentication::Authentication::builder()
+            .identity(identity)
+            .name(name)
+            .impersonate(impersonate)
+            .skip(skip_authz)
+            .build()
+            .map_err(|()| {
+                tracing::error!("invalid authentication parameters");
+                AuthorizationError::Unauthorized
+            })
+    })?;
+
+    tracing::info!(?authn, "authentication complete");
+
+    req.extensions_mut().insert(authn);
+    Ok(next.run(req).await)
+}
+
 /// Represents the bundle of information about the issuer of a request
 /// that can be extracted form recognized headers.
 #[derive(Debug, Clone)]
@@ -1034,6 +1084,9 @@ impl Server {
             .route_layer(axum::middleware::from_fn_with_state(
                 app_state.clone(),
                 authentication_middleware,
+            ))
+            .route_layer(axum::middleware::from_fn(
+                authentication_extraction_middleware,
             ))
             .layer(OtelInResponseLayer)
             .layer(OtelAxumLayer::default())

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -523,9 +523,12 @@ async fn authentication_extraction_middleware(mut req: Request, next: Next) -> R
     })?;
 
     tracing::info!(?authn, "authentication complete");
-
-    req.extensions_mut().insert(authn);
-    Ok(next.run(req).await)
+    Ok(tracing::info_span!("authentication", ?authn)
+        .in_scope(move || {
+            req.extensions_mut().insert(authn.clone());
+            next.run(req).in_current_span()
+        })
+        .await)
 }
 
 /// Represents the bundle of information about the issuer of a request


### PR DESCRIPTION
refs https://github.com/osrd-project/osrd-confidential/issues/1168

Prepares the upcoming UserAuthorizer.

The old middleware is still in use. We'll remove it when we'll drop the old Authorizer.

I didn't refactor it using the new Authentication struct. Figured it would be a waste of effort. Lmk.

I suppose it is fine to log the name and identity of the incoming user.