### PR TITLE
front: fix itinerary modal line not showing around an invalid path step

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModal.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModal.tsx
@@ -443,33 +443,29 @@ const ItineraryModal = ({
               const isInvalid = isStepInvalidAndIsEditing(pathStep, pathStepMetadata);
 
               const previousPathStepMetadata = pathStepsMetadataById.get(pathSteps[i - 1]?.id);
-              const hideLine =
-                i > 0 && (pathStepMetadata?.isInvalid || previousPathStepMetadata?.isInvalid);
               const isTrailingPlaceholder =
                 i === pathSteps.length - 1 && isEmptyStep(pathStep, getInputForStep(pathStep.id));
 
               return (
                 <>
                   <div>
-                    {!hideLine && (
-                      <div className="path-step-gap">
-                        <div
-                          className="path-step-gap-hitbox"
-                          onPointerEnter={() => setHoveredGapIndex(i)}
-                          onPointerLeave={() => setHoveredGapIndex(null)}
-                        >
-                          {hoveredGapIndex === i && (
-                            <button
-                              type="button"
-                              className="add-pathitem"
-                              onClick={() => handleAddIntermediateStep(i)}
-                            >
-                              <Plus iconColor="var(--white100)" />
-                            </button>
-                          )}
-                        </div>
+                    <div className="path-step-gap">
+                      <div
+                        className="path-step-gap-hitbox"
+                        onPointerEnter={() => setHoveredGapIndex(i)}
+                        onPointerLeave={() => setHoveredGapIndex(null)}
+                      >
+                        {hoveredGapIndex === i && (
+                          <button
+                            type="button"
+                            className="add-pathitem"
+                            onClick={() => handleAddIntermediateStep(i)}
+                          >
+                            <Plus iconColor="var(--white100)" />
+                          </button>
+                        )}
                       </div>
-                    )}
+                    </div>
                   </div>
                   <PathStepItem
                     key={pathStep.id}


### PR DESCRIPTION
Removes the `hideLine` condition which did not allow adding path steps around invalid path steps.

After discussing it with @thibautsailly, the correct behaviour is to not display the vertical line before and after an invalid path step while still being able to add new path steps. You can find a recording of the fixed behaviour just below.

Closes https://github.com/OpenRailAssociation/osrd/issues/15612


https://github.com/user-attachments/assets/d8e99ba4-6550-4b42-827c-8d352c415da5

