### PR TITLE
editoast: adapt occupancy blocks endpoint

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -10415,6 +10415,7 @@ components:
       type: object
       required:
       - infra_id
+      - timetable_id
       - ids
       - path
       properties:
@@ -10434,6 +10435,9 @@ components:
           format: int64
         path:
           $ref: '#/components/schemas/core.TrainPath'
+        timetable_id:
+          type: integer
+          format: int64
     OccupancyBlocksTrainScheduleResult:
       type: object
       description: Occupancy blocks output is described by blocks (signal updates)

--- a/editoast/src/views/timetable/occupancy_blocks.rs
+++ b/editoast/src/views/timetable/occupancy_blocks.rs
@@ -88,6 +88,7 @@ impl TrainBlockOccupancyDetails {
 #[derive(Debug, Deserialize, ToSchema)]
 pub(in crate::views) struct OccupancyBlockForm {
     pub(super) infra_id: i64,
+    pub(super) timetable_id: i64,
     pub(super) electrical_profile_set_id: Option<i64>,
     pub(super) ids: HashSet<i64>,
     pub(super) path: TrainPath,

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -1119,6 +1119,7 @@ pub(in crate::views) async fn occupancy_blocks(
     Extension(auth): AuthenticationExt,
     Json(OccupancyBlockForm {
         infra_id,
+        timetable_id,
         ids: train_schedule_ids,
         path,
         electrical_profile_set_id,
@@ -1154,21 +1155,39 @@ pub(in crate::views) async fn occupancy_blocks(
         })
         .await?;
 
+    let mut exceptions =
+        editoast_models::TrainScheduleException::retrieve_exceptions_by_train_schedules(
+            conn,
+            timetable_id,
+            train_schedules.iter().map(|t| t.id).collect::<Vec<_>>(),
+        )
+        .await?
+        .into_iter()
+        .map_into::<schemas::TrainScheduleException>()
+        .into_group_map_by(|e| e.train_schedule_id);
+
     let simulation_contexts: Vec<SimulationContext> = train_schedules
         .iter()
         .flat_map(|train_schedule| {
+            let ts_exceptions = exceptions.remove(&train_schedule.id).unwrap_or_default();
             std::iter::once(SimulationContext {
                 paced_train_id: train_schedule.id,
                 exception_key: None,
                 train_schedule: train_schedule.clone().into_train_occurrence(),
             })
-            .chain(train_schedule.exceptions.iter().map(|exception| {
-                SimulationContext {
-                    paced_train_id: train_schedule.id,
-                    exception_key: Some(exception.key.clone()),
-                    train_schedule: train_schedule.apply_exception(exception),
-                }
-            }))
+            .chain(
+                ts_exceptions
+                    .iter()
+                    .map(|exception| {
+                        SimulationContext {
+                            paced_train_id: train_schedule.id,
+                            exception_key: exception.key.clone(), // TODO use exception.id
+                            train_schedule: train_schedule
+                                .apply_train_schedule_exception(exception),
+                        }
+                    })
+                    .collect::<Vec<_>>(),
+            )
         })
         .collect();
 
@@ -1679,6 +1698,7 @@ mod tests {
     use editoast_models::TrainScheduleException;
     use editoast_models::prelude::*;
     use editoast_models::rolling_stock::TrainMainCategory;
+    use editoast_models::timetable::Timetable;
     use pretty_assertions::assert_eq;
     use rstest::rstest;
     use schemas::TrainScheduleExceptionChangeGroups;
@@ -1687,7 +1707,6 @@ mod tests {
     use schemas::infra::Direction;
     use schemas::paced_train::InitialSpeedChangeGroup;
     use schemas::paced_train::Paced;
-    use schemas::paced_train::PacedTrainException;
     use schemas::paced_train::RollingStockChangeGroup;
     use schemas::paced_train::TrainNameChangeGroup;
     use schemas::paced_train::TrainSchedule;
@@ -2041,8 +2060,13 @@ mod tests {
         assert_eq!(response.train_schedule, paced_train.into());
     }
 
-    async fn app_infra_id_paced_train_id_for_simulation_tests()
-    -> (TestApp, i64, i64, TrainScheduleException) {
+    async fn app_infra_id_paced_train_id_for_simulation_tests() -> (
+        TestApp,
+        i64,
+        Timetable,
+        models::TrainSchedule,
+        TrainScheduleException,
+    ) {
         let db_pool = DbConnectionPoolV2::for_tests();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let rolling_stock =
@@ -2051,7 +2075,7 @@ mod tests {
             create_timetable_with_train_schedule_set(&mut db_pool.get_ok()).await;
         let exception = create_created_exception_with_change_groups("created_exception_key");
 
-        let paced_train_base = TrainSchedule {
+        let train_schedule_base = TrainSchedule {
             train_occurrence: TrainOccurrence {
                 rolling_stock_name: rolling_stock.name.clone(),
                 ..TrainOccurrence::fake()
@@ -2062,8 +2086,8 @@ mod tests {
                 exceptions: vec![],
             }),
         };
-        let paced_train: TrainScheduleChangeset = paced_train_base.into();
-        let paced_train = paced_train
+        let train_schedule: TrainScheduleChangeset = train_schedule_base.into();
+        let train_schedule = train_schedule
             .train_schedule_set_id(train_schedule_set.id)
             .create(&mut db_pool.get_ok())
             .await
@@ -2072,7 +2096,7 @@ mod tests {
         let exception = create_train_schedule_exception(
             &mut db_pool.get_ok(),
             timetable.id,
-            paced_train.id,
+            train_schedule.id,
             None,
             Some("created_exception_key".to_string()),
             Some(exception.change_groups),
@@ -2084,16 +2108,19 @@ mod tests {
             .db_pool(db_pool)
             .core_client(core.into())
             .build();
-        (app, small_infra.id, paced_train.id, exception)
+        (app, small_infra.id, timetable, train_schedule, exception)
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn paced_train_simulation() {
-        let (app, infra_id, train_schedule_id, _exception) =
+        let (app, infra_id, _timetable, train_schedule, _exception) =
             app_infra_id_paced_train_id_for_simulation_tests().await;
         let request = app.get(
-            format!("/train_schedules/{train_schedule_id}/simulation/?infra_id={infra_id}")
-                .as_str(),
+            format!(
+                "/train_schedules/{}/simulation/?infra_id={infra_id}",
+                train_schedule.id
+            )
+            .as_str(),
         );
         let response: core_client::simulation::Response = app
             .fetch(request)
@@ -2106,11 +2133,12 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn paced_train_exception_simulation_with_invalid_exception_key() {
-        let (app, infra_id, train_schedule_id, _exception) =
+        let (app, infra_id, _timetable, train_schedule, _exception) =
             app_infra_id_paced_train_id_for_simulation_tests().await;
         let request = app.get(
             format!(
-                "/train_schedules/{train_schedule_id}/simulation/?infra_id={infra_id}&exception_id=9999"
+                "/train_schedules/{}/simulation/?infra_id={infra_id}&exception_id=9999",
+                train_schedule.id
             )
             .as_str(),
         );
@@ -2128,12 +2156,12 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn paced_train_exception_simulation() {
-        let (app, infra_id, train_schedule_id, exception) =
+        let (app, infra_id, _timetable, train_schedule, exception) =
             app_infra_id_paced_train_id_for_simulation_tests().await;
         let request = app.get(
             format!(
-                "/train_schedules/{train_schedule_id}/simulation/?infra_id={infra_id}&exception_id={}",
-                exception.id
+                "/train_schedules/{}/simulation/?infra_id={infra_id}&exception_id={}",
+                train_schedule.id, exception.id
             )
             .as_str(),
         );
@@ -2188,7 +2216,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn paced_train_exception_simulation_with_rolling_stock_not_found() {
         // GIVEN
-        let (app, infra_id, train_schedule_id, exception) =
+        let (app, infra_id, _timetable, train_schedule, exception) =
             app_infra_id_paced_train_id_for_simulation_tests().await;
 
         let mut change_groupe = exception.change_groups;
@@ -2198,7 +2226,7 @@ mod tests {
         });
         let exception = editoast_models::TrainScheduleException::changeset()
             .change_groups(change_groupe)
-            .update(&mut app.db_pool().get_ok(), train_schedule_id)
+            .update(&mut app.db_pool().get_ok(), train_schedule.id)
             .await
             .expect("Fail to update exception")
             .expect("Fail to update exception");
@@ -2206,8 +2234,8 @@ mod tests {
         // WHEN
         let request = app.get(
             format!(
-                "/train_schedules/{train_schedule_id}/simulation/?infra_id={infra_id}&exception_id={}",
-                exception.id
+                "/train_schedules/{}/simulation/?infra_id={infra_id}&exception_id={}",
+                train_schedule.id, exception.id
             )
             .as_str(),
         );
@@ -2232,7 +2260,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn paced_train_simulation_not_found() {
-        let (app, infra_id, _paced_train_id, _exception) =
+        let (app, infra_id, _timetable, _train_schedule, _exception) =
             app_infra_id_paced_train_id_for_simulation_tests().await;
         let request =
             app.get(format!("/train_schedules/{}/simulation/?infra_id={}", 0, infra_id).as_str());
@@ -2358,7 +2386,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn paced_train_simulation_summary_not_found() {
-        let (app, infra_id, _paced_train_id, _exception) =
+        let (app, infra_id, _timetable, _paced_train_id, _exception) =
             app_infra_id_paced_train_id_for_simulation_tests().await;
         let timetable = create_timetable(&mut app.db_pool().get_ok()).await;
         let request = app
@@ -2696,67 +2724,50 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn paced_train_occupancy_blocks() {
-        let (app, infra_id, paced_train_id, _exception) =
+        let (app, infra_id, timetable, train_schedule, exception) =
             app_infra_id_paced_train_id_for_simulation_tests().await;
+        let db_pool = app.db_pool();
 
-        let request = app.get(format!("/train_schedules/{paced_train_id}").as_str());
-        let mut paced_train_response: TrainScheduleResponse = app
-            .fetch(request)
-            .await
-            .assert_status(StatusCode::OK)
-            .json_into();
         // First remove all already generated exceptions
-        paced_train_response
-            .train_schedule
-            .paced
-            .as_mut()
-            .unwrap()
-            .exceptions
-            .clear();
+        exception
+            .delete(&mut db_pool.get_ok())
+            .await
+            .expect("Failled to remove exception");
 
         // Add one exception which will not change the simulation from base
-        paced_train_response
-            .train_schedule
-            .paced
-            .as_mut()
-            .unwrap()
-            .exceptions
-            .push(PacedTrainException {
-                key: "change_train_name".to_string(),
-                change_groups: TrainScheduleExceptionChangeGroups {
-                    train_name: Some(TrainNameChangeGroup {
-                        value: "exception_name_but_same_simulation".into(),
-                    }),
-                    ..Default::default()
-                },
+        let _exception1 = create_train_schedule_exception(
+            &mut db_pool.get_ok(),
+            timetable.id,
+            train_schedule.id,
+            None,
+            Some("change_train_name".to_string()),
+            Some(TrainScheduleExceptionChangeGroups {
+                train_name: Some(TrainNameChangeGroup {
+                    value: "exception_name_but_same_simulation".into(),
+                }),
                 ..Default::default()
-            });
+            }),
+        )
+        .await;
+
         // Add one exception which will change the simulation from base
-        // and therefore add another entry in the response (field `exceptions`)
-        paced_train_response
-            .train_schedule
-            .paced
-            .as_mut()
-            .unwrap()
-            .exceptions
-            .push(PacedTrainException {
-                key: "change_initial_speed".to_string(),
-                change_groups: TrainScheduleExceptionChangeGroups {
-                    initial_speed: Some(InitialSpeedChangeGroup { value: 1.23 }),
-                    ..Default::default()
-                },
+        let _exception1 = create_train_schedule_exception(
+            &mut db_pool.get_ok(),
+            timetable.id,
+            train_schedule.id,
+            None,
+            Some("change_initial_speed".to_string()),
+            Some(TrainScheduleExceptionChangeGroups {
+                initial_speed: Some(InitialSpeedChangeGroup { value: 1.23 }),
                 ..Default::default()
-            });
-        let request = app
-            .put(format!("/train_schedules/{paced_train_id}").as_str())
-            .json(&json!(paced_train_response.train_schedule));
-        app.fetch(request)
-            .await
-            .assert_status(StatusCode::NO_CONTENT);
+            }),
+        )
+        .await;
 
         let request = app.post("/train_schedules/occupancy_blocks").json(
-            &json!({"ids": vec![paced_train_id],
+            &json!({"ids": vec![train_schedule.id],
                 "infra_id": infra_id,
+                "timetable_id": timetable.id,
                 "path": {
                     "track_section_ranges": [{
                         "track_section": "T1",
@@ -2775,10 +2786,17 @@ mod tests {
         assert_eq!(response.len(), 1);
         // TODO fix mocked simulation to return path item times that respect times
         assert_eq!(
-            response.get(&paced_train_id).unwrap().train_schedule.len(),
+            response
+                .get(&train_schedule.id)
+                .unwrap()
+                .train_schedule
+                .len(),
             0
         );
-        assert_eq!(response.get(&paced_train_id).unwrap().exceptions.len(), 0);
+        assert_eq!(
+            response.get(&train_schedule.id).unwrap().exceptions.len(),
+            0
+        );
     }
 
     fn pathfinding_result_success() -> PathfindingResultSuccess {

--- a/front/src/applications/operationalStudies/helpers/TrainOpProjectionLazyLoader.ts
+++ b/front/src/applications/operationalStudies/helpers/TrainOpProjectionLazyLoader.ts
@@ -34,7 +34,7 @@ export default class TrainOpProjectionLazyLoader extends TrainProjectionLazyLoad
   }
 
   async processBatch(ids: number[]) {
-    const { infraId, path, electricalProfileSetId } = this.options;
+    const { infraId, timetableId, path, electricalProfileSetId } = this.options;
 
     if (this.opRefs.length < 2) {
       this.options.onProgress(new Map());
@@ -72,6 +72,7 @@ export default class TrainOpProjectionLazyLoader extends TrainProjectionLazyLoad
               {
                 occupancyBlockForm: {
                   infra_id: infraId,
+                  timetable_id: timetableId,
                   path,
                   ids,
                   electrical_profile_set_id: electricalProfileSetId,

--- a/front/src/applications/operationalStudies/helpers/TrainTrackProjectionLazyLoader.ts
+++ b/front/src/applications/operationalStudies/helpers/TrainTrackProjectionLazyLoader.ts
@@ -61,6 +61,7 @@ export default class TrainTrackProjectionLazyLoader extends TrainProjectionLazyL
             {
               occupancyBlockForm: {
                 infra_id: infraId,
+                timetable_id: timetableId,
                 path,
                 ids,
                 electrical_profile_set_id: electricalProfileSetId,

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -4848,6 +4848,7 @@ export type OccupancyBlockForm = {
   ids: number[];
   infra_id: number;
   path: CoreTrainPath;
+  timetable_id: number;
 };
 export type SpaceTimeCurve = {
   /** List of positions of a train in mm


### PR DESCRIPTION
Part of https://github.com/OpenRailAssociation/osrd/issues/15202

This PR adapt the `/train_schedules/occupancy_blocks`endpoint to use the new exceptions table
It also requires the timetable_id as a parameter, as exceptions are now related to a timetable and not just to a train schedule
Rename exception_key into exception_id
Fix tests and frontend

> [!NOTE]
> This PR targets a feature branch and may contain all its commits, as it has not been rebased yet. Only the last commit need to be reviewed.