### PR TITLE
editoast: identity verification middleware

### DIFF
--- a/editoast/authz/src/authorizer.rs
+++ b/editoast/authz/src/authorizer.rs
@@ -139,7 +139,7 @@ mod tests {
     use crate::model;
     use crate::model::Group;
     use crate::v2;
-    use crate::v2::test_authorizers;
+    use crate::v2::special_authorizers;
     use pretty_assertions::assert_eq;
 
     #[tokio::test]
@@ -183,7 +183,7 @@ mod tests {
                 Subject::user(user_id),
                 HashSet::from([Role::OperationalStudies, Role::Stdcm]),
             )
-            .authorize(&v2::test_authorizers::Authorize(regulator().openfga()))
+            .authorize(&v2::special_authorizers::Authorize(regulator().openfga()))
             .await
             .expect("roles should be granted")
             .unwrap_authorized()
@@ -221,7 +221,7 @@ mod tests {
                 Subject::user(user_id),
                 HashSet::from([Role::OperationalStudies]),
             )
-            .authorize(&v2::test_authorizers::Authorize(regulator().openfga()))
+            .authorize(&v2::special_authorizers::Authorize(regulator().openfga()))
             .await
             .expect("roles should be stripped")
             .unwrap_authorized()
@@ -315,7 +315,7 @@ mod tests {
 
         // add members
         v2::add_members(friends, HashSet::from([User(alice_id), User(bob_id)]))
-            .authorize(&test_authorizers::Authorize(regulator().openfga()))
+            .authorize(&special_authorizers::Authorize(regulator().openfga()))
             .await
             .expect("members should be added")
             .unwrap_authorized()
@@ -323,14 +323,14 @@ mod tests {
 
         // setup roles
         v2::add_roles(friends.into(), HashSet::from([Role::OperationalStudies]))
-            .authorize(&v2::test_authorizers::Authorize(regulator().openfga()))
+            .authorize(&v2::special_authorizers::Authorize(regulator().openfga()))
             .await
             .expect("group's roles should be granted")
             .unwrap_authorized()
             .await;
 
         v2::add_roles(Subject::user(bob_id), HashSet::from([Role::Stdcm]))
-            .authorize(&v2::test_authorizers::Authorize(regulator().openfga()))
+            .authorize(&v2::special_authorizers::Authorize(regulator().openfga()))
             .await
             .expect("bob's roles should be granted")
             .unwrap_authorized()
@@ -375,7 +375,7 @@ mod tests {
 
         // remove user
         v2::remove_members(friends, HashSet::from([User(bob_id)]))
-            .authorize(&test_authorizers::Authorize(regulator().openfga()))
+            .authorize(&special_authorizers::Authorize(regulator().openfga()))
             .await
             .expect("bob should be removed from the group")
             .unwrap_authorized()

--- a/editoast/authz/src/lib.rs
+++ b/editoast/authz/src/lib.rs
@@ -170,7 +170,7 @@ mod mock_driver {
 
         pub async fn set_role(&self, user: model::User, role: Role) {
             v2::add_roles(user.into(), HashSet::from([role]))
-                .authorize(&v2::test_authorizers::Authorize(self.openfga()))
+                .authorize(&v2::special_authorizers::Authorize(self.openfga()))
                 .await
                 .expect("role set should succeed")
                 .unwrap_authorized()

--- a/editoast/authz/src/v2.rs
+++ b/editoast/authz/src/v2.rs
@@ -163,6 +163,12 @@ impl<T: Send + 'static> Protected<T> {
     }
 }
 
+impl<T: Default> Default for Protected<T> {
+    fn default() -> Self {
+        Self::new(|_| async { Ok(T::default()) }.boxed())
+    }
+}
+
 impl<'a, T, R> Access<'a, T, R> {
     /// Awaits the authorized operation future if authorized or yields the rejection if not
     ///

--- a/editoast/authz/src/v2.rs
+++ b/editoast/authz/src/v2.rs
@@ -358,7 +358,7 @@ pub mod special_authorizers {
     pub struct Reject<Rejection>(Rejection);
 
     impl Authorizer for Authorize<'_> {
-        type Rejection = ();
+        type Rejection = Infallible;
         type Error = Infallible;
 
         async fn authorize<'a, T>(

--- a/editoast/authz/src/v2.rs
+++ b/editoast/authz/src/v2.rs
@@ -344,7 +344,7 @@ pub fn remove_roles(subject: Subject, roles: HashSet<Role>) -> Protected<()> {
         .with_guardrail(Guardrail::IssuerHasRole(Role::Admin))
 }
 
-pub mod test_authorizers {
+pub mod special_authorizers {
     use std::convert::Infallible;
 
     use crate::v2::Access;
@@ -412,7 +412,7 @@ impl TestClientExt for fga::Client {
 
 #[cfg(test)]
 mod tests {
-    use crate::v2::test_authorizers::Authorize;
+    use crate::v2::special_authorizers::Authorize;
 
     use super::*;
 

--- a/editoast/editoast_models/Cargo.toml
+++ b/editoast/editoast_models/Cargo.toml
@@ -45,6 +45,7 @@ utoipa.workspace = true
 database = { path = "../database", features = ["testing"] }
 editoast_models = { path = "./", features = ["testing"] }
 pretty_assertions.workspace = true
+schemas = { path = "../schemas", features = ["testing"] }
 
 [lints]
 workspace = true

--- a/editoast/editoast_models/src/authn/user.rs
+++ b/editoast/editoast_models/src/authn/user.rs
@@ -11,10 +11,11 @@ use diesel::QueryDsl;
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 use editoast_derive::Model;
+use itertools::Itertools as _;
 
 use crate as editoast_models; // HACK: remove after all models are in this crate
 
-#[derive(Debug, Clone, Model)]
+#[derive(Debug, Clone, PartialEq, Eq, Model)]
 #[model(table = database::tables::authn_user)]
 #[model(gen(ops = r, batch_ops = r, list))]
 pub struct User {
@@ -23,6 +24,53 @@ pub struct User {
 }
 
 impl User {
+    /// Inserts a new [User], fails if the identity is already associated with another user
+    #[tracing::instrument(skip(conn), ret(level = "debug"), err)]
+    pub async fn register(
+        conn: DbConnection,
+        identities: Vec<String>,
+        name: String,
+    ) -> Result<User, database::DatabaseError> {
+        conn.transaction(async move |conn| {
+            let id = diesel::dsl::insert_into(authn_user::table)
+                .values(authn_user::name.eq(&name))
+                .returning(authn_user::id)
+                .get_result::<i64>(&mut conn.write().await)
+                .await?;
+            diesel::dsl::insert_into(authn_user_identity::table)
+                .values(
+                    identities
+                        .iter()
+                        .map(|identity| {
+                            (
+                                authn_user_identity::identity.eq(identity),
+                                authn_user_identity::user_id.eq(id),
+                            )
+                        })
+                        .collect_vec(),
+                )
+                .execute(&mut conn.write().await)
+                .await?;
+            Ok(Self { id, name })
+        })
+        .await
+    }
+
+    /// Return the [User] with the provided identity, if any
+    pub async fn retrieve_by_identity(
+        identity: &UserIdentity,
+        conn: DbConnection,
+    ) -> Result<Option<User>, database::DatabaseError> {
+        Ok(authn_user::table
+            .inner_join(authn_user_identity::table)
+            .select(authn_user::all_columns)
+            .filter(authn_user_identity::identity.eq(identity))
+            .first::<(i64, String)>(conn.write().await.deref_mut())
+            .await
+            .optional()?
+            .map(|(id, name)| User { id, name }))
+    }
+
     /// Return the list of [User] associated with the input list of identities.
     pub async fn get_batch_users_by_identity(
         identities: &[&UserIdentity],
@@ -82,5 +130,45 @@ impl User {
             })
             .collect();
         Ok(user_to_identities)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn register_twice_fails() {
+        let pool = database::DbConnectionPoolV2::for_tests();
+        let conn = pool.get_ok();
+
+        let identity = "toto".to_string();
+        let name = "Toto".to_string();
+
+        // First registration should succeed
+        let user1 = User::register(conn.clone(), vec![identity.clone()], name.clone())
+            .await
+            .expect("First registration should succeed");
+
+        // Verify the user can be retrieved
+        let retrieved = User::retrieve_by_identity(&identity, conn.clone())
+            .await
+            .expect("Query should succeed")
+            .expect("User should exist");
+
+        assert_eq!(user1, retrieved);
+
+        // Second registration with the same identity should fail
+        let result = User::register(
+            conn.clone(),
+            vec![identity.clone()],
+            "Toto Imposter".to_string(),
+        )
+        .await;
+
+        assert!(
+            result.is_err(),
+            "Second registration with same identity should fail"
+        );
     }
 }

--- a/editoast/src/authentication.rs
+++ b/editoast/src/authentication.rs
@@ -66,4 +66,16 @@ impl Authentication {
         };
         Ok(authn)
     }
+
+    pub fn origin(&self) -> Option<(&str, &str)> {
+        match self {
+            Authentication::Authenticated { identity, name }
+            | Authentication::Impersonating {
+                impersonator_identity: identity,
+                impersonator_name: name,
+                impersonated_identity: _,
+            } => Some((identity.as_str(), name.as_str())),
+            Authentication::Unauthenticated | Authentication::Skip { .. } => None,
+        }
+    }
 }

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -33,6 +33,8 @@ mod test_app;
 use ::authz::Authorization;
 use ::authz::Infra;
 use ::authz::StorageDriver;
+use ::authz::v2::special_authorizers;
+use axum::Extension;
 use common::Version;
 use fga::client::Limits;
 #[cfg(test)]
@@ -41,6 +43,7 @@ use tracing::Instrument;
 
 use ::core::str;
 use std::collections::HashSet;
+use std::convert::Infallible;
 use std::env;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -545,6 +548,137 @@ async fn authentication_extraction_middleware(mut req: Request, next: Next) -> R
         .await)
 }
 
+/// Takes an authenticated request and performs a few verifications
+///
+/// - the origin user exists in the database, if not we create it
+/// - the impersonator must be an admin
+/// - the impersonated user must already exist in the database, we do not create it if it does not
+/// - push the roles of the origin user in the request extensions
+async fn authentication_validation_middleware(
+    Extension(authn): Extension<crate::authentication::Authentication>,
+    State(AppState {
+        db_pool, regulator, ..
+    }): State<AppState>,
+    mut req: Request,
+    next: Next,
+) -> Result<Response> {
+    use ::authz::v2::Authorizer as _;
+
+    let openfga = regulator.openfga(); // to remove once OpenFGA is in the AppState directly
+    let conn = db_pool.get().await?;
+
+    let is_impersonation = matches!(
+        authn,
+        crate::authentication::Authentication::Impersonating { .. }
+    );
+
+    fn origin_user_roles(
+        user: Option<editoast_models::User>,
+        identity: &str,
+        header_name: &str,
+    ) -> Option<::authz::v2::Protected<Vec<Role>>> {
+        user.inspect(|user| {
+            if user.name != header_name {
+                tracing::warn!(
+                    identity,
+                    header = header_name,
+                    stored = user.name,
+                    "provided name for identity differ from stored",
+                );
+            }
+        })
+        .map(|user| ::authz::v2::subject_roles(::authz::Subject::user(user.id)))
+    }
+
+    async fn register_origin_user(
+        conn: database::DbConnection,
+        (identity, name): (&str, &str),
+    ) -> Result<::authz::v2::Protected<Vec<Role>>> {
+        tracing::info!(identity, name, "registering new user");
+        let user =
+            editoast_models::User::register(conn, vec![identity.to_owned()], name.to_owned())
+                .await?;
+        Ok(::authz::v2::subject_roles(::authz::Subject::user(user.id)))
+    }
+
+    let roles_prot = conn
+        .transaction(async move |conn| {
+            let roles_prot = match &authn {
+                crate::authentication::Authentication::Authenticated { identity, name } => {
+                    let user =
+                        editoast_models::User::retrieve_by_identity(identity, conn.clone()).await?;
+                    origin_user_roles(user, identity, name)
+                }
+                crate::authentication::Authentication::Impersonating {
+                    impersonator_identity,
+                    impersonator_name,
+                    impersonated_identity,
+                } => {
+                    let (impersonator, impersonated) = tokio::try_join!(
+                        // The batching API is annoying, that's the best I can do concisely for now. We should
+                        // work on the DB user management that got worse since we added multiple identities support.
+                        editoast_models::User::retrieve_by_identity(
+                            impersonator_identity,
+                            conn.clone()
+                        ),
+                        editoast_models::User::retrieve_by_identity(
+                            impersonated_identity,
+                            conn.clone()
+                        )
+                    )?;
+                    if impersonated.is_none() {
+                        return Err::<_, crate::error::InternalError>(
+                            AuthorizationError::ImpersonatedUserNotFound {
+                                identity: impersonated_identity.to_owned(),
+                            }
+                            .into(),
+                        );
+                    }
+                    origin_user_roles(impersonator, impersonator_identity, impersonator_name)
+                }
+                crate::authentication::Authentication::Unauthenticated
+                | crate::authentication::Authentication::Skip { .. } => None,
+            };
+
+            let roles_prot = match roles_prot {
+                // origin user does exist, we use the Protected afterwards
+                Some(roles_prot) => roles_prot,
+                // origin user does not exist
+                None => {
+                    // if there is an origin user (no skip or unauthenticated)
+                    if let Some(origin) = authn.origin() {
+                        register_origin_user(conn, origin).await?
+                    } else {
+                        ::authz::v2::Protected::default()
+                    }
+                }
+            };
+
+            Ok(roles_prot)
+        })
+        .await?;
+
+    // A failed OpenFGA request does not invalidate the creation of a new user
+    let bypass = special_authorizers::Authorize(openfga);
+    let Ok::<_, Infallible>(access) = bypass.authorize(roles_prot).await;
+    let Ok::<_, Infallible>(roles) = access.access().await.map_err(AuthorizationError::from)?;
+
+    if is_impersonation {
+        if !roles.contains(&Role::Admin) {
+            return Err(AuthorizationError::ForbiddenImpersonation.into());
+        } else {
+            tracing::info!("impersonation enabled");
+        }
+    }
+
+    Ok(tracing::info_span!("authentication validation", ?roles)
+        .in_scope(move || {
+            req.extensions_mut().insert(roles);
+            next.run(req).in_current_span()
+        })
+        .await)
+}
+
 /// Represents the bundle of information about the issuer of a request
 /// that can be extracted form recognized headers.
 #[derive(Debug, Clone)]
@@ -755,7 +889,7 @@ async fn authentication_middleware(
 
 pub type AuthorizerError = ::authz::Error<<PgAuthDriver as ::authz::StorageDriver>::Error>;
 
-#[derive(Debug, Error, EditoastError)]
+#[derive(Debug, Error, derive_more::From, EditoastError)]
 #[editoast_error(base_id = "authz")]
 pub enum AuthorizationError {
     #[error("Unauthorized — user must be authenticated")]
@@ -772,7 +906,8 @@ pub enum AuthorizationError {
     ImpersonatedUserNotFound { identity: String },
     #[error(transparent)]
     #[editoast_error(status = 500)]
-    AuthError(#[from] AuthorizerError),
+    #[from(AuthorizerError, fga::client::RequestFailure)]
+    AuthError(AuthorizerError),
     #[error(transparent)]
     #[editoast_error(status = 500)]
     DbError(#[from] database::db_connection_pool::DatabasePoolError),
@@ -1101,6 +1236,10 @@ impl Server {
             .route_layer(axum::middleware::from_fn_with_state(
                 app_state.clone(),
                 authentication_middleware,
+            ))
+            .route_layer(axum::middleware::from_fn_with_state(
+                app_state.clone(),
+                authentication_validation_middleware,
             ))
             .route_layer(axum::middleware::from_fn(
                 authentication_extraction_middleware,

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -3,7 +3,7 @@
 //! components.
 
 use authz::v2;
-use authz::v2::test_authorizers;
+use authz::v2::special_authorizers;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::path::PathBuf;
@@ -515,7 +515,7 @@ impl<'a> UserBuilder<'a> {
             .expect("User should be created successfully");
         if app.app_state.config.enable_authorization {
             v2::add_roles(authz::Subject::user(user.id), roles)
-                .authorize(&test_authorizers::Authorize(regulator.openfga()))
+                .authorize(&special_authorizers::Authorize(regulator.openfga()))
                 .await
                 .expect("roles should be granted successfully")
                 .unwrap_authorized()
@@ -591,7 +591,7 @@ impl<'a> GroupBuilder<'a> {
         if !authz_disabled {
             let group_auth = authz::Group(group.id);
             v2::add_roles(group_auth.into(), roles)
-                .authorize(&test_authorizers::Authorize(regulator.openfga()))
+                .authorize(&special_authorizers::Authorize(regulator.openfga()))
                 .await
                 .expect("roles should be granted successfully")
                 .unwrap_authorized()
@@ -604,7 +604,7 @@ impl<'a> GroupBuilder<'a> {
                     .map(|authz::identity::User { id, .. }| authz::User(*id))
                     .collect(),
             )
-            .authorize(&test_authorizers::Authorize(regulator.openfga()))
+            .authorize(&special_authorizers::Authorize(regulator.openfga()))
             .await
             .expect("members should be added successfully")
             .unwrap_authorized()


### PR DESCRIPTION
to merge after #15768 and #15762 

refs https://github.com/osrd-project/osrd-confidential/issues/1168

This PR finalizes the replacement of the old Authorizer-producing middleware. (Will be removed on refactoring completion.)


<details open id="prdesc">

- 5c72266878 *editoast: authz: rename `test_authorizers` to `special_authorizers`*
    ```md
    May be used outside of tests.
    ```
- 1436cd1ed5 *editoast: authz: make `Authorize::Rejection` `Infallible`*
    ```md
    Semantically debatable, but its behaviour as the never type is useful to
    avoid unwraps when using `Access::access`.
    ```
- 0eedbc902e *editoast: authz: add `impl Default for Protected`*
- 5882dc9119 *editoast: models: fix broken Cargo.toml for dev*
- 5bc515d2fa *editoast: models: create and retrieve single users*
    ```md
    * `User::register` is an improved port of `AuthzDriver::save_new_user`
      that's bound to disappear.
    * `User::retrieve_by_identity` is a simpler version of
      `User::get_batch_users_by_identity` which is awkward to use.
    ```
- b184b14e16 *editoast: add an identity verification middleware*
    ```md
    Runs after the authentication middleware that just collects and
    organizes the headers. This new middleware actually verfies user
    existence, whether impersonation is allowed and pushes roles on the
    request extensions.
    
    Next step: the `UserAuthorizer`, finally.
    ```

</details>