### PR TITLE
core: use iterable even more to reduce alloc around DistanceRangeMap

### DIFF
--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeMap.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeMap.kt
@@ -84,7 +84,7 @@ interface DistanceRangeMap<T> : Iterable<DistanceRangeMap.RangeMapEntry<T>> {
 }
 
 fun <T> distanceRangeMapOf(vararg entries: DistanceRangeMap.RangeMapEntry<T>): DistanceRangeMap<T> {
-    return DistanceRangeMapImpl(entries.asList())
+    return DistanceRangeMapImpl(entries.asIterable())
 }
 
 fun <T> distanceRangeMapOf(


### PR DESCRIPTION
Minor follow-up on [another follow-up](https://github.com/OpenRailAssociation/osrd/pull/15601)