### PR TITLE
editoast: attempt to fix rust-analyzer type inference false negative

### DIFF
--- a/editoast/editoast_derive/src/model/codegen/create_batch_impl.rs
+++ b/editoast/editoast_derive/src/model/codegen/create_batch_impl.rs
@@ -39,13 +39,13 @@ impl ToTokens for CreateBatchImpl {
             },
             chunk_iteration_ident: syn::parse_quote! { chunk },
             chunk_iteration_body: quote! {
-                diesel::insert_into(dsl::#table_name)
+                let stream = diesel::insert_into(dsl::#table_name)
                     .values(chunk)
                     .returning((#(dsl::#columns,)*))
                     .load_stream::<#row>(conn.write().await.deref_mut())
                     .await
-                    .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))?
-                    .map_ok(<#model as Model>::from_row)
+                    .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))?;
+                futures_util::TryStreamExt::map_ok(stream, <#model as Model>::from_row)
                     .try_collect::<Vec<_>>()
                     .await
                     .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))?
@@ -70,7 +70,7 @@ impl ToTokens for CreateBatchImpl {
                     use std::ops::DerefMut;
                     use diesel::prelude::*;
                     use diesel_async::RunQueryDsl;
-                    use futures_util::stream::TryStreamExt;
+                    use futures_util::TryStreamExt;
                     let values = values.into_iter().collect::<Vec<_>>();
                     Ok({ #create_loop })
                 }

--- a/editoast/editoast_derive/src/model/codegen/create_batch_with_key_impl.rs
+++ b/editoast/editoast_derive/src/model/codegen/create_batch_with_key_impl.rs
@@ -44,13 +44,13 @@ impl ToTokens for CreateBatchWithKeyImpl {
                 collection_init: syn::parse_quote! { C::default() },
             },
             chunk_iteration_body: quote! {
-                diesel::insert_into(dsl::#table_name)
+                let stream = diesel::insert_into(dsl::#table_name)
                     .values(chunk)
                     .returning((#(dsl::#columns,)*))
                     .load_stream::<#row>(conn.write().await.deref_mut())
                     .await
-                    .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))?
-                    .map_ok(|row| {
+                    .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))?;
+                futures_util::TryStreamExt::map_ok(stream, |row| {
                         let model = <#model as Model>::from_row(row);
                         (model.get_id(), model)
                     })
@@ -79,7 +79,7 @@ impl ToTokens for CreateBatchWithKeyImpl {
                     use #table_mod::dsl;
                     use diesel::prelude::*;
                     use diesel_async::RunQueryDsl;
-                    use futures_util::stream::TryStreamExt;
+                    use futures_util::TryStreamExt;
                     let values = values.into_iter().collect::<Vec<_>>();
                     Ok({ #create_loop })
                 }

--- a/editoast/editoast_derive/src/model/codegen/list_impl.rs
+++ b/editoast/editoast_derive/src/model/codegen/list_impl.rs
@@ -38,7 +38,7 @@ impl ToTokens for ListImpl {
                 ) -> std::result::Result<Vec<Self>, Self::Error> {
                     use diesel::QueryDsl;
                     use diesel_async::RunQueryDsl;
-                    use futures_util::stream::TryStreamExt;
+                    use futures_util::TryStreamExt;
                     use #table_mod::dsl;
                     use std::ops::DerefMut;
 
@@ -64,12 +64,12 @@ impl ToTokens for ListImpl {
                         query = query.offset(offset);
                     }
 
-                    query
+                    let stream = query
                         .select((#(dsl::#columns,)*))
                         .load_stream::<#row>(conn.write().await.deref_mut())
                         .await
-                        .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))?
-                        .map_ok(<#model as crate::prelude::Model>::from_row)
+                        .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))?;
+                    futures_util::TryStreamExt::map_ok(stream, <#model as crate::prelude::Model>::from_row)
                         .try_collect::<Vec<_>>()
                         .await
                         .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))

--- a/editoast/editoast_derive/src/model/codegen/retrieve_batch_impl.rs
+++ b/editoast/editoast_derive/src/model/codegen/retrieve_batch_impl.rs
@@ -51,12 +51,12 @@ impl ToTokens for RetrieveBatchImpl {
                 for #id_ident in chunk.into_iter() {
                     query = query.or_filter(#filters);
                 }
-                query
+                let stream = query
                     .select((#(dsl::#columns,)*))
                     .load_stream::<#row>(conn.write().await.deref_mut())
                     .await
-                    .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))?
-                    .map_ok(<#model as Model>::from_row)
+                    .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))?;
+                futures_util::TryStreamExt::map_ok(stream, <#model as Model>::from_row)
                     .try_collect::<Vec<_>>()
                     .await
                     .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))?
@@ -68,12 +68,12 @@ impl ToTokens for RetrieveBatchImpl {
             for #id_ident in chunk.into_iter() {
                 query = query.or_filter(#filters);
             }
-            query
+            let stream = query
                 .select((#(dsl::#columns,)*))
                 .load_stream::<#row>(conn.write().await.deref_mut())
                 .await
-                .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))?
-                .map_ok(|row| {
+                .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))?;
+            futures_util::TryStreamExt::map_ok(stream, |row| {
                     let model = <#model as Model>::from_row(row);
                     (model.get_id(), model)
                 })
@@ -99,7 +99,7 @@ impl ToTokens for RetrieveBatchImpl {
                     use #table_mod::dsl;
                     use diesel::prelude::*;
                     use diesel_async::RunQueryDsl;
-                    use futures_util::stream::TryStreamExt;
+                    use futures_util::TryStreamExt;
                     use std::ops::DerefMut;
                     let ids = ids.into_iter().collect::<Vec<_>>();
                     tracing::Span::current().record("query_ids", tracing::field::debug(&ids));
@@ -119,7 +119,7 @@ impl ToTokens for RetrieveBatchImpl {
                     use #table_mod::dsl;
                     use diesel::prelude::*;
                     use diesel_async::RunQueryDsl;
-                    use futures_util::stream::TryStreamExt;
+                    use futures_util::TryStreamExt;
                     use std::ops::DerefMut;
                     let ids = ids.into_iter().collect::<Vec<_>>();
                     tracing::Span::current().record("query_ids", tracing::field::debug(&ids));

--- a/editoast/editoast_derive/src/model/codegen/update_batch_impl.rs
+++ b/editoast/editoast_derive/src/model/codegen/update_batch_impl.rs
@@ -56,14 +56,14 @@ impl ToTokens for UpdateBatchImpl {
                 for #id_ident in chunk.into_iter() {
                     query = query.or_filter(#filters);
                 }
-                diesel::update(dsl::#table_name)
+                let stream = diesel::update(dsl::#table_name)
                     .filter(dsl::#primary_key_column.eq_any(query))
                     .set(&self)
                     .returning((#(dsl::#columns,)*))
                     .load_stream::<#row>(conn.write().await.deref_mut())
                     .await
-                    .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))?
-                    .map_ok(<#model as Model>::from_row)
+                    .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))?;
+                futures_util::TryStreamExt::map_ok(stream, <#model as Model>::from_row)
                     .try_collect::<Vec<_>>()
                     .await
                     .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))?
@@ -75,14 +75,14 @@ impl ToTokens for UpdateBatchImpl {
             for #id_ident in chunk.into_iter() {
                 query = query.or_filter(#filters);
             }
-            diesel::update(dsl::#table_name)
+            let stream = diesel::update(dsl::#table_name)
                 .filter(dsl::#primary_key_column.eq_any(query))
                 .set(&self)
                 .returning((#(dsl::#columns,)*))
                 .load_stream::<#row>(conn.write().await.deref_mut())
                 .await
-                .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))?
-                .map_ok(|row| {
+                .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))?;
+            futures_util::TryStreamExt::map_ok(stream, |row| {
                     let model = <#model as Model>::from_row(row);
                     (model.get_id(), model)
                 })
@@ -109,7 +109,7 @@ impl ToTokens for UpdateBatchImpl {
                     use #table_mod::dsl;
                     use diesel::prelude::*;
                     use diesel_async::RunQueryDsl;
-                    use futures_util::stream::TryStreamExt as _;
+                    use futures_util::TryStreamExt as _;
                     use futures_util::TryFutureExt as _;
                     use std::ops::DerefMut;
                     let ids = ids.into_iter().collect::<Vec<_>>();
@@ -132,7 +132,7 @@ impl ToTokens for UpdateBatchImpl {
                     use std::ops::DerefMut;
                     use diesel::prelude::*;
                     use diesel_async::RunQueryDsl;
-                    use futures_util::stream::TryStreamExt as _;
+                    use futures_util::TryStreamExt as _;
                     use futures_util::TryFutureExt as _;
                     let ids = ids.into_iter().collect::<Vec<_>>();
                     tracing::Span::current().record("query_ids", tracing::field::debug(&ids));

--- a/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__construction.snap
+++ b/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__construction.snap
@@ -510,7 +510,7 @@ impl crate::prelude::List for Document {
     ) -> std::result::Result<Vec<Self>, Self::Error> {
         use diesel::QueryDsl;
         use diesel_async::RunQueryDsl;
-        use futures_util::stream::TryStreamExt;
+        use futures_util::TryStreamExt;
         use database::tables::osrd_infra_document::dsl;
         use std::ops::DerefMut;
         let mut query = database::tables::osrd_infra_document::table.into_boxed();
@@ -530,12 +530,15 @@ impl crate::prelude::List for Document {
             tracing::Span::current().record("offset", offset);
             query = query.offset(offset);
         }
-        query
+        let stream = query
             .select((dsl::id, dsl::content_type, dsl::data))
             .load_stream::<DocumentRow>(conn.write().await.deref_mut())
             .await
-            .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))?
-            .map_ok(<Document as crate::prelude::Model>::from_row)
+            .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))?;
+        futures_util::TryStreamExt::map_ok(
+                stream,
+                <Document as crate::prelude::Model>::from_row,
+            )
             .try_collect::<Vec<_>>()
             .await
             .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))
@@ -604,7 +607,7 @@ impl crate::prelude::CreateBatch for Document {
         use std::ops::DerefMut;
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
-        use futures_util::stream::TryStreamExt;
+        use futures_util::TryStreamExt;
         let values = values.into_iter().collect::<Vec<_>>();
         Ok({
             const LIBPQ_MAX_PARAMETERS: usize = 2_usize.pow(16) - 1;
@@ -614,13 +617,18 @@ impl crate::prelude::CreateBatch for Document {
             let chunks = values.chunks(CHUNK_SIZE.min(2048usize));
             for chunk in chunks {
                 let chunk_result = {
-                    diesel::insert_into(dsl::osrd_infra_document)
+                    let stream = diesel::insert_into(dsl::osrd_infra_document)
                         .values(chunk)
                         .returning((dsl::id, dsl::content_type, dsl::data))
                         .load_stream::<DocumentRow>(conn.write().await.deref_mut())
                         .await
-                        .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))?
-                        .map_ok(<Document as Model>::from_row)
+                        .map_err(|e| Self::Error::from(
+                            editoast_models::Error::from(e),
+                        ))?;
+                    futures_util::TryStreamExt::map_ok(
+                            stream,
+                            <Document as Model>::from_row,
+                        )
                         .try_collect::<Vec<_>>()
                         .await
                         .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))?
@@ -648,7 +656,7 @@ impl crate::prelude::CreateBatchWithKey<(String)> for Document {
         use database::tables::osrd_infra_document::dsl;
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
-        use futures_util::stream::TryStreamExt;
+        use futures_util::TryStreamExt;
         let values = values.into_iter().collect::<Vec<_>>();
         Ok({
             const LIBPQ_MAX_PARAMETERS: usize = 2_usize.pow(16) - 1;
@@ -658,16 +666,21 @@ impl crate::prelude::CreateBatchWithKey<(String)> for Document {
             let chunks = values.chunks(CHUNK_SIZE.min(2048usize));
             for chunk in chunks {
                 let chunk_result = {
-                    diesel::insert_into(dsl::osrd_infra_document)
+                    let stream = diesel::insert_into(dsl::osrd_infra_document)
                         .values(chunk)
                         .returning((dsl::id, dsl::content_type, dsl::data))
                         .load_stream::<DocumentRow>(conn.write().await.deref_mut())
                         .await
-                        .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))?
-                        .map_ok(|row| {
-                            let model = <Document as Model>::from_row(row);
-                            (model.get_id(), model)
-                        })
+                        .map_err(|e| Self::Error::from(
+                            editoast_models::Error::from(e),
+                        ))?;
+                    futures_util::TryStreamExt::map_ok(
+                            stream,
+                            |row| {
+                                let model = <Document as Model>::from_row(row);
+                                (model.get_id(), model)
+                            },
+                        )
                         .try_collect::<Vec<_>>()
                         .await
                         .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))?
@@ -695,7 +708,7 @@ impl crate::prelude::CreateBatchWithKey<(i64)> for Document {
         use database::tables::osrd_infra_document::dsl;
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
-        use futures_util::stream::TryStreamExt;
+        use futures_util::TryStreamExt;
         let values = values.into_iter().collect::<Vec<_>>();
         Ok({
             const LIBPQ_MAX_PARAMETERS: usize = 2_usize.pow(16) - 1;
@@ -705,16 +718,21 @@ impl crate::prelude::CreateBatchWithKey<(i64)> for Document {
             let chunks = values.chunks(CHUNK_SIZE.min(2048usize));
             for chunk in chunks {
                 let chunk_result = {
-                    diesel::insert_into(dsl::osrd_infra_document)
+                    let stream = diesel::insert_into(dsl::osrd_infra_document)
                         .values(chunk)
                         .returning((dsl::id, dsl::content_type, dsl::data))
                         .load_stream::<DocumentRow>(conn.write().await.deref_mut())
                         .await
-                        .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))?
-                        .map_ok(|row| {
-                            let model = <Document as Model>::from_row(row);
-                            (model.get_id(), model)
-                        })
+                        .map_err(|e| Self::Error::from(
+                            editoast_models::Error::from(e),
+                        ))?;
+                    futures_util::TryStreamExt::map_ok(
+                            stream,
+                            |row| {
+                                let model = <Document as Model>::from_row(row);
+                                (model.get_id(), model)
+                            },
+                        )
                         .try_collect::<Vec<_>>()
                         .await
                         .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))?
@@ -742,7 +760,7 @@ impl crate::prelude::RetrieveBatchUnchecked<(String)> for Document {
         use database::tables::osrd_infra_document::dsl;
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
-        use futures_util::stream::TryStreamExt;
+        use futures_util::TryStreamExt;
         use std::ops::DerefMut;
         let ids = ids.into_iter().collect::<Vec<_>>();
         tracing::Span::current().record("query_ids", tracing::field::debug(&ids));
@@ -758,12 +776,17 @@ impl crate::prelude::RetrieveBatchUnchecked<(String)> for Document {
                     for content_type in chunk.into_iter() {
                         query = query.or_filter(dsl::content_type.eq(content_type));
                     }
-                    query
+                    let stream = query
                         .select((dsl::id, dsl::content_type, dsl::data))
                         .load_stream::<DocumentRow>(conn.write().await.deref_mut())
                         .await
-                        .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))?
-                        .map_ok(<Document as Model>::from_row)
+                        .map_err(|e| Self::Error::from(
+                            editoast_models::Error::from(e),
+                        ))?;
+                    futures_util::TryStreamExt::map_ok(
+                            stream,
+                            <Document as Model>::from_row,
+                        )
                         .try_collect::<Vec<_>>()
                         .await
                         .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))?
@@ -788,7 +811,7 @@ impl crate::prelude::RetrieveBatchUnchecked<(String)> for Document {
         use database::tables::osrd_infra_document::dsl;
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
-        use futures_util::stream::TryStreamExt;
+        use futures_util::TryStreamExt;
         use std::ops::DerefMut;
         let ids = ids.into_iter().collect::<Vec<_>>();
         tracing::Span::current().record("query_ids", tracing::field::debug(&ids));
@@ -804,15 +827,20 @@ impl crate::prelude::RetrieveBatchUnchecked<(String)> for Document {
                     for content_type in chunk.into_iter() {
                         query = query.or_filter(dsl::content_type.eq(content_type));
                     }
-                    query
+                    let stream = query
                         .select((dsl::id, dsl::content_type, dsl::data))
                         .load_stream::<DocumentRow>(conn.write().await.deref_mut())
                         .await
-                        .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))?
-                        .map_ok(|row| {
-                            let model = <Document as Model>::from_row(row);
-                            (model.get_id(), model)
-                        })
+                        .map_err(|e| Self::Error::from(
+                            editoast_models::Error::from(e),
+                        ))?;
+                    futures_util::TryStreamExt::map_ok(
+                            stream,
+                            |row| {
+                                let model = <Document as Model>::from_row(row);
+                                (model.get_id(), model)
+                            },
+                        )
                         .try_collect::<Vec<_>>()
                         .await
                         .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))?
@@ -840,7 +868,7 @@ impl crate::prelude::RetrieveBatchUnchecked<(i64)> for Document {
         use database::tables::osrd_infra_document::dsl;
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
-        use futures_util::stream::TryStreamExt;
+        use futures_util::TryStreamExt;
         use std::ops::DerefMut;
         let ids = ids.into_iter().collect::<Vec<_>>();
         tracing::Span::current().record("query_ids", tracing::field::debug(&ids));
@@ -856,12 +884,17 @@ impl crate::prelude::RetrieveBatchUnchecked<(i64)> for Document {
                     for id_ in chunk.into_iter() {
                         query = query.or_filter(dsl::id.eq(id_));
                     }
-                    query
+                    let stream = query
                         .select((dsl::id, dsl::content_type, dsl::data))
                         .load_stream::<DocumentRow>(conn.write().await.deref_mut())
                         .await
-                        .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))?
-                        .map_ok(<Document as Model>::from_row)
+                        .map_err(|e| Self::Error::from(
+                            editoast_models::Error::from(e),
+                        ))?;
+                    futures_util::TryStreamExt::map_ok(
+                            stream,
+                            <Document as Model>::from_row,
+                        )
                         .try_collect::<Vec<_>>()
                         .await
                         .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))?
@@ -886,7 +919,7 @@ impl crate::prelude::RetrieveBatchUnchecked<(i64)> for Document {
         use database::tables::osrd_infra_document::dsl;
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
-        use futures_util::stream::TryStreamExt;
+        use futures_util::TryStreamExt;
         use std::ops::DerefMut;
         let ids = ids.into_iter().collect::<Vec<_>>();
         tracing::Span::current().record("query_ids", tracing::field::debug(&ids));
@@ -902,15 +935,20 @@ impl crate::prelude::RetrieveBatchUnchecked<(i64)> for Document {
                     for id_ in chunk.into_iter() {
                         query = query.or_filter(dsl::id.eq(id_));
                     }
-                    query
+                    let stream = query
                         .select((dsl::id, dsl::content_type, dsl::data))
                         .load_stream::<DocumentRow>(conn.write().await.deref_mut())
                         .await
-                        .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))?
-                        .map_ok(|row| {
-                            let model = <Document as Model>::from_row(row);
-                            (model.get_id(), model)
-                        })
+                        .map_err(|e| Self::Error::from(
+                            editoast_models::Error::from(e),
+                        ))?;
+                    futures_util::TryStreamExt::map_ok(
+                            stream,
+                            |row| {
+                                let model = <Document as Model>::from_row(row);
+                                (model.get_id(), model)
+                            },
+                        )
                         .try_collect::<Vec<_>>()
                         .await
                         .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))?
@@ -942,7 +980,7 @@ impl crate::prelude::UpdateBatchUnchecked<Document, (String)> for DocumentChange
         use database::tables::osrd_infra_document::dsl;
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
-        use futures_util::stream::TryStreamExt as _;
+        use futures_util::TryStreamExt as _;
         use futures_util::TryFutureExt as _;
         use std::ops::DerefMut;
         let ids = ids.into_iter().collect::<Vec<_>>();
@@ -961,14 +999,19 @@ impl crate::prelude::UpdateBatchUnchecked<Document, (String)> for DocumentChange
                     for content_type in chunk.into_iter() {
                         query = query.or_filter(dsl::content_type.eq(content_type));
                     }
-                    diesel::update(dsl::osrd_infra_document)
+                    let stream = diesel::update(dsl::osrd_infra_document)
                         .filter(dsl::id.eq_any(query))
                         .set(&self)
                         .returning((dsl::id, dsl::content_type, dsl::data))
                         .load_stream::<DocumentRow>(conn.write().await.deref_mut())
                         .await
-                        .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))?
-                        .map_ok(<Document as Model>::from_row)
+                        .map_err(|e| Self::Error::from(
+                            editoast_models::Error::from(e),
+                        ))?;
+                    futures_util::TryStreamExt::map_ok(
+                            stream,
+                            <Document as Model>::from_row,
+                        )
                         .try_collect::<Vec<_>>()
                         .await
                         .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))?
@@ -998,7 +1041,7 @@ impl crate::prelude::UpdateBatchUnchecked<Document, (String)> for DocumentChange
         use std::ops::DerefMut;
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
-        use futures_util::stream::TryStreamExt as _;
+        use futures_util::TryStreamExt as _;
         use futures_util::TryFutureExt as _;
         let ids = ids.into_iter().collect::<Vec<_>>();
         tracing::Span::current().record("query_ids", tracing::field::debug(&ids));
@@ -1016,17 +1059,22 @@ impl crate::prelude::UpdateBatchUnchecked<Document, (String)> for DocumentChange
                     for content_type in chunk.into_iter() {
                         query = query.or_filter(dsl::content_type.eq(content_type));
                     }
-                    diesel::update(dsl::osrd_infra_document)
+                    let stream = diesel::update(dsl::osrd_infra_document)
                         .filter(dsl::id.eq_any(query))
                         .set(&self)
                         .returning((dsl::id, dsl::content_type, dsl::data))
                         .load_stream::<DocumentRow>(conn.write().await.deref_mut())
                         .await
-                        .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))?
-                        .map_ok(|row| {
-                            let model = <Document as Model>::from_row(row);
-                            (model.get_id(), model)
-                        })
+                        .map_err(|e| Self::Error::from(
+                            editoast_models::Error::from(e),
+                        ))?;
+                    futures_util::TryStreamExt::map_ok(
+                            stream,
+                            |row| {
+                                let model = <Document as Model>::from_row(row);
+                                (model.get_id(), model)
+                            },
+                        )
                         .try_collect::<Vec<_>>()
                         .await
                         .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))?
@@ -1058,7 +1106,7 @@ impl crate::prelude::UpdateBatchUnchecked<Document, (i64)> for DocumentChangeset
         use database::tables::osrd_infra_document::dsl;
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
-        use futures_util::stream::TryStreamExt as _;
+        use futures_util::TryStreamExt as _;
         use futures_util::TryFutureExt as _;
         use std::ops::DerefMut;
         let ids = ids.into_iter().collect::<Vec<_>>();
@@ -1077,14 +1125,19 @@ impl crate::prelude::UpdateBatchUnchecked<Document, (i64)> for DocumentChangeset
                     for id_ in chunk.into_iter() {
                         query = query.or_filter(dsl::id.eq(id_));
                     }
-                    diesel::update(dsl::osrd_infra_document)
+                    let stream = diesel::update(dsl::osrd_infra_document)
                         .filter(dsl::id.eq_any(query))
                         .set(&self)
                         .returning((dsl::id, dsl::content_type, dsl::data))
                         .load_stream::<DocumentRow>(conn.write().await.deref_mut())
                         .await
-                        .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))?
-                        .map_ok(<Document as Model>::from_row)
+                        .map_err(|e| Self::Error::from(
+                            editoast_models::Error::from(e),
+                        ))?;
+                    futures_util::TryStreamExt::map_ok(
+                            stream,
+                            <Document as Model>::from_row,
+                        )
                         .try_collect::<Vec<_>>()
                         .await
                         .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))?
@@ -1114,7 +1167,7 @@ impl crate::prelude::UpdateBatchUnchecked<Document, (i64)> for DocumentChangeset
         use std::ops::DerefMut;
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
-        use futures_util::stream::TryStreamExt as _;
+        use futures_util::TryStreamExt as _;
         use futures_util::TryFutureExt as _;
         let ids = ids.into_iter().collect::<Vec<_>>();
         tracing::Span::current().record("query_ids", tracing::field::debug(&ids));
@@ -1132,17 +1185,22 @@ impl crate::prelude::UpdateBatchUnchecked<Document, (i64)> for DocumentChangeset
                     for id_ in chunk.into_iter() {
                         query = query.or_filter(dsl::id.eq(id_));
                     }
-                    diesel::update(dsl::osrd_infra_document)
+                    let stream = diesel::update(dsl::osrd_infra_document)
                         .filter(dsl::id.eq_any(query))
                         .set(&self)
                         .returning((dsl::id, dsl::content_type, dsl::data))
                         .load_stream::<DocumentRow>(conn.write().await.deref_mut())
                         .await
-                        .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))?
-                        .map_ok(|row| {
-                            let model = <Document as Model>::from_row(row);
-                            (model.get_id(), model)
-                        })
+                        .map_err(|e| Self::Error::from(
+                            editoast_models::Error::from(e),
+                        ))?;
+                    futures_util::TryStreamExt::map_ok(
+                            stream,
+                            |row| {
+                                let model = <Document as Model>::from_row(row);
+                                (model.get_id(), model)
+                            },
+                        )
                         .try_collect::<Vec<_>>()
                         .await
                         .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))?

--- a/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__single_pk_model.snap
+++ b/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__single_pk_model.snap
@@ -222,7 +222,7 @@ impl crate::prelude::List for Timetable {
     ) -> std::result::Result<Vec<Self>, Self::Error> {
         use diesel::QueryDsl;
         use diesel_async::RunQueryDsl;
-        use futures_util::stream::TryStreamExt;
+        use futures_util::TryStreamExt;
         use database::tables::timetable::dsl;
         use std::ops::DerefMut;
         let mut query = database::tables::timetable::table.into_boxed();
@@ -242,12 +242,15 @@ impl crate::prelude::List for Timetable {
             tracing::Span::current().record("offset", offset);
             query = query.offset(offset);
         }
-        query
+        let stream = query
             .select((dsl::id,))
             .load_stream::<TimetableRow>(conn.write().await.deref_mut())
             .await
-            .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))?
-            .map_ok(<Timetable as crate::prelude::Model>::from_row)
+            .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))?;
+        futures_util::TryStreamExt::map_ok(
+                stream,
+                <Timetable as crate::prelude::Model>::from_row,
+            )
             .try_collect::<Vec<_>>()
             .await
             .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))
@@ -317,7 +320,7 @@ impl crate::prelude::RetrieveBatchUnchecked<(i64)> for Timetable {
         use database::tables::timetable::dsl;
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
-        use futures_util::stream::TryStreamExt;
+        use futures_util::TryStreamExt;
         use std::ops::DerefMut;
         let ids = ids.into_iter().collect::<Vec<_>>();
         tracing::Span::current().record("query_ids", tracing::field::debug(&ids));
@@ -333,12 +336,17 @@ impl crate::prelude::RetrieveBatchUnchecked<(i64)> for Timetable {
                     for id in chunk.into_iter() {
                         query = query.or_filter(dsl::id.eq(id));
                     }
-                    query
+                    let stream = query
                         .select((dsl::id,))
                         .load_stream::<TimetableRow>(conn.write().await.deref_mut())
                         .await
-                        .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))?
-                        .map_ok(<Timetable as Model>::from_row)
+                        .map_err(|e| Self::Error::from(
+                            editoast_models::Error::from(e),
+                        ))?;
+                    futures_util::TryStreamExt::map_ok(
+                            stream,
+                            <Timetable as Model>::from_row,
+                        )
                         .try_collect::<Vec<_>>()
                         .await
                         .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))?
@@ -363,7 +371,7 @@ impl crate::prelude::RetrieveBatchUnchecked<(i64)> for Timetable {
         use database::tables::timetable::dsl;
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
-        use futures_util::stream::TryStreamExt;
+        use futures_util::TryStreamExt;
         use std::ops::DerefMut;
         let ids = ids.into_iter().collect::<Vec<_>>();
         tracing::Span::current().record("query_ids", tracing::field::debug(&ids));
@@ -379,15 +387,20 @@ impl crate::prelude::RetrieveBatchUnchecked<(i64)> for Timetable {
                     for id in chunk.into_iter() {
                         query = query.or_filter(dsl::id.eq(id));
                     }
-                    query
+                    let stream = query
                         .select((dsl::id,))
                         .load_stream::<TimetableRow>(conn.write().await.deref_mut())
                         .await
-                        .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))?
-                        .map_ok(|row| {
-                            let model = <Timetable as Model>::from_row(row);
-                            (model.get_id(), model)
-                        })
+                        .map_err(|e| Self::Error::from(
+                            editoast_models::Error::from(e),
+                        ))?;
+                    futures_util::TryStreamExt::map_ok(
+                            stream,
+                            |row| {
+                                let model = <Timetable as Model>::from_row(row);
+                                (model.get_id(), model)
+                            },
+                        )
                         .try_collect::<Vec<_>>()
                         .await
                         .map_err(|e| Self::Error::from(editoast_models::Error::from(e)))?

--- a/editoast/src/models/infra_objects.rs
+++ b/editoast/src/models/infra_objects.rs
@@ -74,13 +74,13 @@ macro_rules! infra_model {
             ) -> Result<C, database::DatabaseError> {
                 use diesel::prelude::*;
                 use diesel_async::RunQueryDsl;
-                use futures::stream::TryStreamExt;
+                use futures::TryStreamExt;
                 use $table::dsl;
-                Ok($table::table
+                let stream = $table::table
                     .filter(dsl::infra_id.eq(infra_id))
                     .load_stream(conn.write().await.deref_mut())
-                    .await?
-                    .map_ok(Self::from_row)
+                    .await?;
+                Ok(futures::TryStreamExt::map_ok(stream, Self::from_row)
                     .try_collect::<C>()
                     .await?)
             }


### PR DESCRIPTION
Not sure if it happens just for me or if the issue is widespread. For the
longest time I had false diagnostics like

> no method `map_ok` on type `!`

on structs deriving the `Model` macro.

It looks like diesel DSL + stream interface from trait + codegen combo is
too much for rust-analyzer.

This commit attempts to fix the issue by providing more type information.
It looks like it works locally, but since the code is and was ultimately
correct, not sure how robust this patch is.

<img width="882" height="200" alt="Capture d’écran 2026-03-17 à 12 10 51" src="https://github.com/user-attachments/assets/5b2f3ae8-fcf1-4aa7-9ae0-7275fde6e18c" />