### PR TITLE
front: fix callbacks to let trains be moved across sets

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/Timetable.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/Timetable.tsx
@@ -195,6 +195,7 @@ const Timetable = ({
           handleClickTrainScheduleSet={handleClickTrainScheduleSet}
           handleSelectTrainScheduleSet={handleSelectTrainScheduleSet}
           catalogEntries={catalogEntries}
+          moveTimetableItem={(pacedTrainIds) => openMoveDialog(pacedTrainIds)}
           publishTrainScheduleSet={publishTrainScheduleSet}
           getTrainScheduleSetByCatalogAndName={getTrainScheduleSetByCatalogAndName}
           localCopyTrainScheduleSet={localCopyTrainScheduleSet}


### PR DESCRIPTION
In #15632 (about virtualization), I had to move props around between components, this one 'fall off' during the move, making the move button unusable.

I did *not* add a regression test on that one, as I am already committed to refactor all those props in #15776, so it would be redundant in my humble opinion.