### PR TITLE
front: chronogram integration

### DIFF
--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -4,6 +4,7 @@
     "std": "Space Time Diagram"
   },
   "boards": {
+    "chronogram": "Chronogram",
     "conflicts": "Conflicts",
     "macro": "Macro",
     "map": "Map",

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -4,6 +4,7 @@
     "std": "Graphique Espace Temps"
   },
   "boards": {
+    "chronogram": "Chronogramme",
     "conflicts": "Conflits",
     "macro": "Macro",
     "map": "Carte",

--- a/front/src/applications/operationalStudies/types.ts
+++ b/front/src/applications/operationalStudies/types.ts
@@ -26,7 +26,15 @@ import type { Train, TimetableItemWithPathOps, PacedTrainId } from 'reducers/osr
 import type { Duration } from 'utils/duration';
 import type { ArrayElement } from 'utils/types';
 
-export type Board = 'trains' | 'map' | 'macro' | 'std' | 'sdd' | 'tables' | 'conflicts';
+export type Board =
+  | 'trains'
+  | 'map'
+  | 'macro'
+  | 'std'
+  | 'sdd'
+  | 'tables'
+  | 'conflicts'
+  | 'chronogram';
 
 export type PacedTrainWithPaced = Omit<TrainScheduleResponse, 'id' | 'paced'> & {
   paced: NonNullable<TrainScheduleResponse['paced']>;

--- a/front/src/applications/operationalStudies/views/Scenario/ScenarioView.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/ScenarioView.tsx
@@ -16,6 +16,7 @@ const Scenario = () => {
     'std',
     'sdd',
     'tables',
+    'chronogram',
   ]);
 
   if (!scenario || !sandboxId) return null;

--- a/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
@@ -126,7 +126,7 @@ const ScenarioContent = ({ activeBoards }: ScenarioContentProps) => {
     [updateTrainDepartureTime, refreshNge]
   );
 
-  const simulationResultBoards = ['map', 'tables', 'std', 'sdd'] as Board[];
+  const simulationResultBoards = ['map', 'tables', 'std', 'sdd', 'chronogram'] as Board[];
   const isBoardSimulationResultsActive = simulationResultBoards.some((board) =>
     activeBoards.has(board)
   );

--- a/front/src/applications/operationalStudies/views/Scenario/components/ScenarioHeader.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ScenarioHeader.tsx
@@ -15,7 +15,16 @@ import useAuth from 'utils/hooks/useAuth';
 
 import InfraLoadingState from './InfraLoadingState';
 
-const BOARDS: Board[] = ['trains', 'map', 'macro', 'std', 'sdd', 'tables', 'conflicts'];
+const BOARDS: Board[] = [
+  'trains',
+  'map',
+  'macro',
+  'std',
+  'sdd',
+  'chronogram',
+  'tables',
+  'conflicts',
+];
 
 type ScenarioHeaderProps = {
   activeBoards: Set<Board>;

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
@@ -10,6 +10,7 @@ import useSimulationResults from 'applications/operationalStudies/hooks/useSimul
 import type { Board } from 'applications/operationalStudies/types';
 import { type Conflict } from 'common/api/osrdEditoastApi';
 import SimulationWarpedMap from 'common/Map/WarpedMap/SimulationWarpedMap';
+import ChronogramWrapper from 'modules/simulationResult/components/Chronogram/ChronogramWrapper';
 import createHandleTrainDrag from 'modules/simulationResult/components/SpaceTimeChartWrapper/helpers/createHandleTrainDrag';
 import SpaceTimeChartWrapper, {
   MANCHETTE_WITH_SPACE_TIME_CHART_DEFAULT_HEIGHT,
@@ -40,6 +41,8 @@ import SimulationResultsMap from './SimulationResultsMap';
 export const HIDDEN_CHART_TOP_HEIGHT = 23;
 const SDD_INITIAL_HEIGHT = 460;
 const SDD_MIN_HEIGHT = 400;
+const CHRONOGRAM_INITIAL_HEIGHT = 492;
+const CHRONOGRAM_MIN_HEIGHT = 398;
 
 type SimulationResultsProps = {
   scenarioData: { name: string; infraName: string };
@@ -80,6 +83,8 @@ const SimulationResults = ({
   );
 
   const [SDDHeight, setSDDHeight] = useState(SDD_INITIAL_HEIGHT);
+
+  const [chronogramHeight, setChronogramHeight] = useState(CHRONOGRAM_INITIAL_HEIGHT);
 
   const [mapCanvas, setMapCanvas] = useState<string>();
 
@@ -296,6 +301,27 @@ const SimulationResults = ({
               />
             </div>
           </BoardWrapper>
+
+          {/* CHRONOGRAMME */}
+          {timetableItemsWithDetails.length > 0 && (
+            <BoardWrapper
+              hidden={!activeBoards.has('chronogram')}
+              name={t('boards.chronogram')}
+              resizable={{
+                height: chronogramHeight,
+                setHeight: setChronogramHeight,
+                minHeight: CHRONOGRAM_MIN_HEIGHT,
+              }}
+              withFooter
+            >
+              <div data-testid="chronogram" className="simulation-chronogram">
+                <ChronogramWrapper
+                  timetableItemsWithDetails={timetableItemsWithDetails}
+                  chronogramHeight={chronogramHeight}
+                />
+              </div>
+            </BoardWrapper>
+          )}
 
           {/* TIME STOPS TABLE */}
           <BoardWrapper

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -509,7 +509,7 @@ const injectedRtkApi = api
         }),
         providesTags: ['layers'],
       }),
-      postLevelCrossingOccupancy: build.mutation<
+      postLevelCrossingOccupancy: build.query<
         PostLevelCrossingOccupancyApiResponse,
         PostLevelCrossingOccupancyApiArg
       >({
@@ -518,7 +518,7 @@ const injectedRtkApi = api
           method: 'POST',
           body: queryArg.body,
         }),
-        invalidatesTags: ['level_crossing'],
+        providesTags: ['level_crossing'],
       }),
       getLightRollingStock: build.query<
         GetLightRollingStockApiResponse,

--- a/front/src/config/openapi-editoast-config.cts
+++ b/front/src/config/openapi-editoast-config.cts
@@ -19,6 +19,7 @@ const config: ConfigFile = {
         'postInfraByInfraIdPathfinding',
         'postInfraByInfraIdPathfindingBlocks',
         'postInfraByInfraIdPathProperties',
+        'postLevelCrossingOccupancy',
         'postTrainSchedulesProjectPath',
         'postTrainSchedulesSimulationSummary',
         'postTrainSchedulesProjectPathOp',

--- a/front/src/modules/simulationResult/components/Chronogram/ChronogramWrapper.tsx
+++ b/front/src/modules/simulationResult/components/Chronogram/ChronogramWrapper.tsx
@@ -1,0 +1,33 @@
+import { Chronogram } from '@osrd-project/ui-charts';
+
+import type { TimetableItemWithDetails } from 'modules/timetableItem/types';
+
+import useLevelCrossingsWithChronogram from './useLevelCrossingsWithChronogram';
+
+const CHRONOGRAM_FOOTER_HEIGHT = 39;
+
+type ChronogramWrapperProps = {
+  timetableItemsWithDetails: TimetableItemWithDetails[];
+  chronogramHeight: number;
+};
+
+const ChronogramWrapper = ({
+  timetableItemsWithDetails,
+  chronogramHeight,
+}: ChronogramWrapperProps) => {
+  const { levelCrossingData, timeOrigin } = useLevelCrossingsWithChronogram({
+    trains: timetableItemsWithDetails,
+  });
+
+  return (
+    levelCrossingData && (
+      <Chronogram
+        timeOrigin={timeOrigin}
+        levelCrossingData={levelCrossingData}
+        height={chronogramHeight - CHRONOGRAM_FOOTER_HEIGHT}
+      />
+    )
+  );
+};
+
+export default ChronogramWrapper;

--- a/front/src/modules/simulationResult/components/Chronogram/buildOccupancyBlocks.ts
+++ b/front/src/modules/simulationResult/components/Chronogram/buildOccupancyBlocks.ts
@@ -1,0 +1,67 @@
+import type { LevelCrossingData, LevelCrossingOccupancies } from '@osrd-project/ui-charts';
+
+import type {
+  InfraObjectWithGeometry,
+  LevelCrossing,
+  PostLevelCrossingOccupancyApiResponse,
+} from 'common/api/osrdEditoastApi';
+import { addDurationToDate, Duration } from 'utils/duration';
+
+const MIN_GAP_BETWEEN_OCCUPANCIES_MS = 15_000; // 15 seconds
+
+/**
+ * This function takes all the occupancy periods for a level crossing and organizes them into groups.
+ * If two occupancies overlap, we merge them, or if the gap between them is very short (less than 15 seconds),
+ * we consider them as part of the same group.
+ */
+function computeOccupanciesBlocks(
+  occupancies: PostLevelCrossingOccupancyApiResponse[number]
+): LevelCrossingOccupancies {
+  const sortedOccupancies = occupancies
+    .map((occupancy) => ({
+      startTime: new Date(occupancy.time_begin).getTime(),
+      endTime: addDurationToDate(
+        new Date(occupancy.time_begin),
+        Duration.parse(occupancy.duration)
+      ).getTime(),
+    }))
+    .sort((a, b) => a.startTime - b.startTime);
+
+  const result = sortedOccupancies.reduce<LevelCrossingOccupancies>(
+    (occupanciesGroups, occupancy) => {
+      const currentGroup = occupanciesGroups.at(-1);
+      const lastOccupancy = currentGroup?.at(-1);
+      if (!currentGroup || !lastOccupancy) {
+        occupanciesGroups.push([occupancy]);
+      } else if (occupancy.startTime <= lastOccupancy.endTime) {
+        lastOccupancy.endTime = Math.max(lastOccupancy.endTime, occupancy.endTime);
+      } else if (occupancy.startTime - lastOccupancy.endTime < MIN_GAP_BETWEEN_OCCUPANCIES_MS) {
+        currentGroup.push(occupancy);
+      } else {
+        occupanciesGroups.push([occupancy]);
+      }
+      return occupanciesGroups;
+    },
+    []
+  );
+  return result;
+}
+
+export function formatLevelCrossingOccupanciesForChronogram(
+  levelCrossingOccupancies: PostLevelCrossingOccupancyApiResponse,
+  levelCrossingsMetadata: InfraObjectWithGeometry[]
+): LevelCrossingData[] {
+  const levelCrossingsRailJsonById = levelCrossingsMetadata.reduce<Record<string, LevelCrossing>>(
+    (acc, metadata) => {
+      acc[metadata.obj_id] = metadata.railjson as LevelCrossing;
+      return acc;
+    },
+    {}
+  );
+  return Object.entries(levelCrossingOccupancies)
+    .map(([levelCrossingId, occupancies]) => ({
+      name: levelCrossingsRailJsonById[levelCrossingId].name,
+      occupancies: computeOccupanciesBlocks(occupancies),
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/front/src/modules/simulationResult/components/Chronogram/useLevelCrossingsWithChronogram.ts
+++ b/front/src/modules/simulationResult/components/Chronogram/useLevelCrossingsWithChronogram.ts
@@ -1,0 +1,78 @@
+import { useEffect, useMemo } from 'react';
+
+import { skipToken } from '@reduxjs/toolkit/query';
+
+import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
+import { useInfraID } from 'common/osrdContext';
+import type { TimetableItemWithDetails } from 'modules/timetableItem/types';
+import { setFailure } from 'reducers/main';
+import { useAppDispatch } from 'store';
+import { castErrorToFailure } from 'utils/error';
+import { extractEditoastIdFromPacedTrainId } from 'utils/trainId';
+
+import { formatLevelCrossingOccupanciesForChronogram } from './buildOccupancyBlocks';
+
+type UseLevelCrossingsWithChronogramProps = {
+  trains: TimetableItemWithDetails[];
+};
+
+const useLevelCrossingsWithChronogram = ({ trains }: UseLevelCrossingsWithChronogramProps) => {
+  const infraId = useInfraID();
+  const dispatch = useAppDispatch();
+
+  const timeOrigin = useMemo(() => new Date(trains[0].startTime).getTime(), [trains]);
+
+  const trainIds = useMemo(
+    () => trains.map((train) => extractEditoastIdFromPacedTrainId(train.id)),
+    [trains]
+  );
+
+  const { currentData: levelCrossingsIds } =
+    osrdEditoastApi.endpoints.getInfraByInfraIdObjectsAndObjectTypeIds.useQuery(
+      infraId
+        ? {
+            infraId,
+            objectType: 'LevelCrossing',
+          }
+        : skipToken
+    );
+
+  const { currentData: levelCrossings } =
+    osrdEditoastApi.endpoints.postInfraByInfraIdObjectsAndObjectType.useQuery(
+      infraId && levelCrossingsIds && levelCrossingsIds.ids.length
+        ? {
+            infraId,
+            objectType: 'LevelCrossing',
+            body: levelCrossingsIds.ids,
+          }
+        : skipToken
+    );
+
+  const { data: levelCrossingOccupancies, error } =
+    osrdEditoastApi.endpoints.postLevelCrossingOccupancy.useQuery(
+      infraId && trainIds.length && levelCrossingsIds && levelCrossingsIds.ids.length
+        ? {
+            body: {
+              infra_id: infraId,
+              train_ids: trainIds,
+              level_crossing_ids: levelCrossingsIds.ids,
+            },
+          }
+        : skipToken
+    );
+
+  const levelCrossingData = useMemo(() => {
+    if (!levelCrossingOccupancies || !levelCrossings) return [];
+    return formatLevelCrossingOccupanciesForChronogram(levelCrossingOccupancies, levelCrossings);
+  }, [levelCrossingOccupancies, levelCrossings]);
+
+  useEffect(() => {
+    if (error) {
+      dispatch(setFailure(castErrorToFailure(error)));
+    }
+  }, [error, dispatch]);
+
+  return { levelCrossingData, timeOrigin };
+};
+
+export default useLevelCrossingsWithChronogram;


### PR DESCRIPTION
Closes #14317 

**How to test :** 

- Load an [infra with level crossings](https://sncf.sharepoint.com/:u:/r/sites/OSRD644GrpO365/Documents%20partages/Donn%C3%A9es/0-OSRD%20Dumps/France%202026-02-06%20(SA26)%20avec%2012%20passages%20%C3%A0%20niveau.railjson?csf=1&web=1&e=qJwfHc)
- Create a scenario with trains running between Brumath and Saverne, in both directions, to ensure you get overlapping level crossing closures.