### PR TITLE
core: Use a binary search for DistanceRangeMap.get

### DIFF
--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeMap.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeMap.kt
@@ -13,7 +13,23 @@ import fr.sncf.osrd.utils.units.Distance
  * intervals.
  *
  * `DistanceRangeMap` should be used when memory footprint is a concern (in particular to store
- * infra data), and only when precise interval semantics aren't necessary.
+ * infra data).
+ *
+ * # Interval semantics
+ *
+ * Ranges in a [DistanceRangeMap] are closed-open with the following exception: ranges whose upper
+ * bound aren't any range's lower bound (i.e. ranges that are followed by empty intervals, or the
+ * last range) are closed.
+ *
+ * For example, if a [DistanceRangeMap] has these ranges:
+ *
+ *        A          B            C            D
+ *     [1;100[   [100;128]   [256;1000[   [1000;1234]
+ *
+ * Then ranges A and C are closed-open, and ranges B and D are closed.
+ *
+ * TODO simplify bound management to have [closed;open[ intervals only (and dig on the impact for
+ * the ETCS simulator, which _should_ be acceptable)
  *
  * # Note to implementors
  *
@@ -53,8 +69,9 @@ interface DistanceRangeMap<T> : Iterable<DistanceRangeMap.RangeMapEntry<T>> {
     fun shiftPositions(offset: Distance): DistanceRangeMap<T>
 
     /**
-     * Get the value at the given offset, if there is any. On exact transition offsets, the value
-     * for the higher offset is used.
+     * Get the value at the given offset, if there is any.
+     *
+     * See "Interval semantics" in the [DistanceRangeMap] doc-comment.
      */
     fun get(offset: Distance): T?
 

--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeMapImpl.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeMapImpl.kt
@@ -169,11 +169,33 @@ data class DistanceRangeMapImpl<T>(
     }
 
     override fun get(offset: Distance): T? {
-        // TODO: use a binary search
-        for (entry in this.reversed()) {
-            if (entry.lower <= offset && offset <= entry.upper) return entry.value
+        val i = bounds.binarySearch { it.compareTo(offset) }
+        return if (i == bounds.size - 1) {
+            // Here, either `offset` is the upper bound of the map, or the map is empty. In the
+            // first case, we return the last value to replicate the old behavior of `get` (and not
+            // break the ETCS simulator...). In the second case, `values` is empty so we return
+            // `null`.
+            values.lastOrNull()
+        } else if (i >= 0) {
+            // Here, we have `0 < i <= bounds.size-2 == values.size-1` so the value is `values[i]`.
+            // In case `values[i]` is null, `i` is guaranteed to be one or greater, and then we
+            // return the previous value to replicate the old behavior of `get` (and not break the
+            // ETCS simulator)
+            values[i] ?: values[i - 1]
+        } else if (i == -1 || i == -bounds.size - 1) {
+            // When [i] is negative, [binarySearch] specifies that inserting [offset] at index
+            // `-i - 1` keeps [bounds] sorted. This means that:
+            // - when [i] is -1, [offset] points to the left of the lowest bound, and therefore out
+            //   of bounds (inserting [offset] at `-(-1) - 1 == 0` would keep bounds sorted.
+            // - when [i] is `-bounds.size - 1`, [offset] points to the right of the highest bound
+            //   (would insert [offset] at `-(-bounds.size - 1) - 1 == bounds.size`)
+            null
+        } else {
+            // - otherwise, `-i - 1` is the index of the upper bound of the range containing
+            //   [offset], so we have to get the value below it. Here, we have
+            //   `-bounds.size <= i <= -2`, so `0 <= -i - 2 <= values.size - 1`.
+            values[-i - 2]
         }
-        return null
     }
 
     override fun clone(): DistanceRangeMap<T> {

--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeMapImpl.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeMapImpl.kt
@@ -90,7 +90,7 @@ data class DistanceRangeMapImpl<T>(
 
         // Order matters and existing entries should come first.
         // E.g. allEntries = [(lower=0, upper=5, value=1), (lower=5, upper=10, value=1)]
-        val allEntries = this + entries
+        val allEntries = this + entries.asSequence().filter { it.lower < it.upper }
 
         // Start from scratch.
         values.clear()

--- a/core/osrd-mp/src/commonTest/kotlin/fr/sncf/osrd/utils/TestDistanceRangeMap.kt
+++ b/core/osrd-mp/src/commonTest/kotlin/fr/sncf/osrd/utils/TestDistanceRangeMap.kt
@@ -460,4 +460,47 @@ class TestDistanceRangeMap {
             distanceRangeMapOf<Unit>().commonRanges(map).toList()
         }
     }
+
+    @Test
+    fun get() {
+        val map =
+            distanceRangeMapOf(
+                DistanceRangeMap.RangeMapEntry(lower = 0.meters, upper = 1.meters, value = 1),
+                DistanceRangeMap.RangeMapEntry(lower = 1.meters, upper = 2.meters, value = 12),
+                DistanceRangeMap.RangeMapEntry(lower = 2.meters, upper = 3.meters, value = 23),
+                DistanceRangeMap.RangeMapEntry(lower = 3.meters, upper = 4.meters, value = 34),
+                DistanceRangeMap.RangeMapEntry(lower = 6.meters, upper = 7.meters, value = 67),
+            )
+
+        val tests =
+            listOf(
+                -0.5 to null,
+                0.0 to 1,
+                0.5 to 1,
+                1.0 to 12,
+                1.5 to 12,
+                2.0 to 23,
+                2.5 to 23,
+                3.0 to 34,
+                3.5 to 34,
+                4.0 to 34,
+                4.5 to null,
+                5.0 to null,
+                5.5 to null,
+                6.0 to 67,
+                6.5 to 67,
+                7.0 to 67,
+                7.5 to null,
+            )
+
+        val expectedValues = tests.map { it.second }
+        val actualValues = tests.map { map.get(it.first.meters) }
+
+        assertEquals(expectedValues, actualValues)
+    }
+
+    @Test
+    fun getEmpty() {
+        assertNull(distanceRangeMapOf<Unit>().get(42.meters))
+    }
 }


### PR DESCRIPTION
also filter empty ranges in `DistanceRangeMap.putMany`, otherwise during `TestDistanceRangeMap.testEmptyEntry` the map would end up having `bounds.size==1` and `values.size==0` instead of having both cleared.