### PR TITLE
chart: add resources for cronjob

### DIFF
--- a/chart/templates/editoast/cronjob.yaml
+++ b/chart/templates/editoast/cronjob.yaml
@@ -71,6 +71,8 @@ spec:
               {{- with .Values.services.editoast.cronjob.env | default dict }}
               {{- toYaml . | nindent 14 }}
               {{- end }}
+            resources:
+              {{- toYaml .Values.services.editoast.resources | nindent 14 }}
             volumeMounts:
               - name: config
                 mountPath: /crons/cronjob.sh


### PR DESCRIPTION
Cronjob pod had no requests which lead to issue with policies ensuring all pods have requests.
This PR fixes this