### PR TITLE
front: bump virtua from 0.45.3 to 0.48.8

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -97,7 +97,7 @@
         "reselect": "^5.1.0",
         "uuid": "^13.0.0",
         "viewport-mercator-project": "^7.0.4",
-        "virtua": "^0.45.3"
+        "virtua": "^0.48.8"
       },
       "devDependencies": {
         "@apidevtools/swagger-parser": "^12.1.0",
@@ -18230,7 +18230,9 @@
       }
     },
     "node_modules/virtua": {
-      "version": "0.45.3",
+      "version": "0.48.8",
+      "resolved": "https://registry.npmjs.org/virtua/-/virtua-0.48.8.tgz",
+      "integrity": "sha512-jpsxOw5V4B6hg44JePRLo9DL0TV7N1lBEVtPjKpAJebXyhI2s9lfiXJESaLapNtr3vtiSk/pWHiLf7B2a6UcgQ==",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=16.14.0",

--- a/front/package.json
+++ b/front/package.json
@@ -94,7 +94,7 @@
     "reselect": "^5.1.0",
     "uuid": "^13.0.0",
     "viewport-mercator-project": "^7.0.4",
-    "virtua": "^0.45.3"
+    "virtua": "^0.48.8"
   },
   "devDependencies": {
     "@apidevtools/swagger-parser": "^12.1.0",

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TrainList.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TrainList.tsx
@@ -252,7 +252,7 @@ const TrainList = ({
   );
 
   return (
-    <Virtualizer overscan={15}>
+    <Virtualizer>
       {timetableMode === 'calendar' && trainsToItems(timetableItemsWithDetails)}
       {timetableMode === 'trainScheduleSet' &&
         (timetableItemsByTrainScheduleSets ? (

--- a/front/tests/02-operational-studies/timetable/001-train-timetable.spec.ts
+++ b/front/tests/02-operational-studies/timetable/001-train-timetable.spec.ts
@@ -32,6 +32,10 @@ const frTranslations = {
   ...frCommonTranslations,
 };
 
+// TODO: Properly count trains even if the virtualised train list does not render them yet;
+//       this workaround simply makes the viewport bigger so the whole list is rendered.
+test.use({ viewport: { width: 1920, height: 1920 } });
+
 test.describe('@op @timetable-items', () => {
   let project: Project;
   let study: Study;

--- a/front/tests/02-operational-studies/timetable/002-train-timetable-filter.spec.ts
+++ b/front/tests/02-operational-studies/timetable/002-train-timetable-filter.spec.ts
@@ -40,6 +40,10 @@ const frTranslations = {
   ...frCommonTranslations,
 };
 
+// TODO: Properly count trains even if the virtualised train list does not render them yet;
+//       this workaround simply makes the viewport bigger so the whole list is rendered.
+test.use({ viewport: { width: 1920, height: 1920 } });
+
 test.describe('@op @timetable-items @filter', () => {
   let project: Project;
   let study: Study;


### PR DESCRIPTION
`virtua` [decided](https://github.com/inokawa/virtua/releases/tag/0.46.0) in 0.46 to replace the `overscan` prop with a more manual `bufferSize` prop, specified in pixels.

The migration docs suggest to get rid of that parameter altogether if we don't have strong opinions, and I really think we don't: I just tested with the default value (i.e. without defining the prop) and it works just fine.

Superseeds #14214 (that I found / remembered after creating this one…).
Superseeds #15343.