### PR TITLE
editost: adapt track_occupancy endpoint with new exceptions

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -4423,6 +4423,7 @@ paths:
               - train_schedule_ids
               - operational_point_reference
               - infra_id
+              - timetable_id
               - use_simulation
               properties:
                 electrical_profile_set_id:
@@ -4435,6 +4436,9 @@ paths:
                   format: int64
                 operational_point_reference:
                   $ref: '#/components/schemas/OperationalPointReference'
+                timetable_id:
+                  type: integer
+                  format: int64
                 train_schedule_ids:
                   type: array
                   items:

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -1203,6 +1203,7 @@ pub(in crate::views) struct TrackOccupancyForm {
     train_schedule_ids: Vec<i64>,
     operational_point_reference: OperationalPointReference,
     infra_id: i64,
+    timetable_id: i64,
     electrical_profile_set_id: Option<i64>,
     use_simulation: bool,
 }
@@ -1251,6 +1252,7 @@ pub(in crate::views) async fn track_occupancy(
         train_schedule_ids,
         operational_point_reference,
         infra_id,
+        timetable_id,
         electrical_profile_set_id,
         use_simulation,
     }): Json<TrackOccupancyForm>,
@@ -1279,17 +1281,32 @@ pub(in crate::views) async fn track_occupancy(
     let conn = &mut db_pool.get().await?;
 
     let train_schedules: Vec<models::TrainSchedule> =
-        models::TrainSchedule::retrieve_batch_or_fail(conn, train_schedule_ids, |missing| {
-            TrainScheduleError::BatchNotFound {
+        models::TrainSchedule::retrieve_batch_or_fail(
+            conn,
+            train_schedule_ids.clone(),
+            |missing| TrainScheduleError::BatchNotFound {
                 count: missing.len(),
-            }
-        })
+            },
+        )
         .await?;
 
-    // Collect all occurrences from all paced trains using iter_occurrences()
+    let mut exceptions = TrainScheduleException::retrieve_exceptions_by_train_schedules(
+        conn,
+        timetable_id,
+        train_schedule_ids,
+    )
+    .await?
+    .into_iter()
+    .map_into::<schemas::TrainScheduleException>()
+    .into_group_map_by(|e| e.timetable_id);
+
     let (train_ids, trains): (Vec<_>, Vec<_>) = train_schedules
         .iter()
-        .flat_map(|train_schedule| train_schedule.iter_occurrences())
+        .flat_map(|train_schedule| {
+            train_schedule
+                .iter_occurrences_v2(&exceptions.remove(&train_schedule.id).unwrap_or_default())
+                .collect::<Vec<_>>()
+        })
         .unzip();
 
     let op_location =
@@ -1628,7 +1645,6 @@ mod tests {
     use schemas::fixtures::simple_created_exception_with_change_groups;
     use schemas::fixtures::simple_modified_exception_with_change_groups;
     use schemas::infra::Direction;
-    use schemas::paced_train::ExceptionType;
     use schemas::paced_train::InitialSpeedChangeGroup;
     use schemas::paced_train::Paced;
     use schemas::paced_train::PacedTrainException;
@@ -2724,7 +2740,7 @@ mod tests {
     }
 
     async fn init_paced_train_test(
-        exceptions: Vec<PacedTrainException>,
+        with_exception: bool,
         path: Vec<PathItem>,
         schedule: Vec<ScheduleItem>,
         operational_point_reference: OperationalPointReference,
@@ -2744,8 +2760,9 @@ mod tests {
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let rolling_stock =
             create_fast_rolling_stock(&mut db_pool.get_ok(), "simulation_rolling_stock").await;
-        let train_schedule_set = create_train_schedule_set(&mut db_pool.get_ok()).await;
-        let paced_train = models::TrainSchedule::default()
+        let (timetable, train_schedule_set) =
+            create_timetable_with_train_schedule_set(&mut db_pool.get_ok()).await;
+        let train_schedule = models::TrainSchedule::default()
             .into_changeset()
             .train_schedule_set_id(train_schedule_set.id)
             .rolling_stock_name(rolling_stock.name)
@@ -2753,17 +2770,27 @@ mod tests {
             .schedule(schedule)
             .interval(TimeDelta::try_minutes(15))
             .time_window(TimeDelta::try_hours(1))
-            .exceptions(exceptions)
             .create(&mut db_pool.get_ok())
             .await
             .expect("Failed to create paced train");
 
+        if with_exception {
+            TrainScheduleException::changeset()
+                .timetable_id(timetable.id)
+                .train_schedule_id(train_schedule.id)
+                .change_groups(TrainScheduleExceptionChangeGroups::default())
+                .create(&mut db_pool.get_ok())
+                .await
+                .expect("Failed to create exception");
+        }
+
         let request = app
             .post("/train_schedules/track_occupancy")
             .json(&TrackOccupancyForm {
-                train_schedule_ids: vec![paced_train.id],
+                train_schedule_ids: vec![train_schedule.id],
                 operational_point_reference,
                 infra_id: small_infra.id,
+                timetable_id: timetable.id,
                 electrical_profile_set_id: None,
                 use_simulation,
             });
@@ -2771,19 +2798,10 @@ mod tests {
         app.fetch(request).await
     }
 
-    #[rstest]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    #[case(vec![], 4)]
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    #[case(vec![
-        PacedTrainException { exception_type: ExceptionType::Created {}, ..Default::default()}], 5)
-    ]
-    async fn paced_train_track_occupancy(
-        #[case] exceptions: Vec<PacedTrainException>,
-        #[case] paced_trains: usize,
-    ) {
+    async fn paced_train_track_occupancy_without_exceptions() {
         let response = init_paced_train_test(
-            exceptions,
+            false,
             vec![
                 PathItem::new_operational_point("Mid_West_station"),
                 PathItem::new_operational_point("Mid_East_station"),
@@ -2806,13 +2824,42 @@ mod tests {
             item.local_track_name,
             Some(NonBlankString("V2".to_string()))
         );
-        assert_eq!(item.trains.len(), paced_trains);
+        assert_eq!(item.trains.len(), 4);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn paced_train_track_occupancy_with_exceptions() {
+        let response = init_paced_train_test(
+            true,
+            vec![
+                PathItem::new_operational_point("Mid_West_station"),
+                PathItem::new_operational_point("Mid_East_station"),
+            ],
+            vec![ScheduleItem::new_with_stop(
+                "Mid_East_station",
+                Duration::new(0, 0).expect("Failed to parse duration"),
+            )],
+            OperationalPointReference::Id {
+                operational_point: "Mid_West_station".into(),
+            },
+            true,
+        );
+        let track_occupancies: Vec<TrackSectionOccupancy> =
+            response.await.assert_status(StatusCode::OK).json_into();
+
+        assert_eq!(track_occupancies.len(), 1);
+        let item = &track_occupancies[0];
+        assert_eq!(
+            item.local_track_name,
+            Some(NonBlankString("V2".to_string()))
+        );
+        assert_eq!(item.trains.len(), 5);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn paced_train_returns_empty_track_occupancies() {
         let response = init_paced_train_test(
-            Vec::new(),
+            false,
             vec![
                 PathItem::new_operational_point("Mid_West_station"),
                 PathItem::new_operational_point("Mid_East_station"),
@@ -2870,7 +2917,7 @@ mod tests {
         #[case] use_simulation: bool,
     ) {
         let response = init_paced_train_test(
-            Vec::new(),
+            false,
             vec![
                 new_op_with_trigram_and_local_track_name("Mid_West_station", "MWS", None, None),
                 new_op_with_trigram_and_local_track_name(
@@ -2932,7 +2979,7 @@ mod tests {
             ),
         };
         let response = init_paced_train_test(
-            Vec::new(),
+            false,
             vec![
                 first_path_item,
                 PathItem::new_operational_point("Mid_East_station"),
@@ -2957,7 +3004,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn track_occupancy_no_sim_no_arrival_returns_empty() {
         let response = init_paced_train_test(
-            Vec::new(),
+            false,
             vec![
                 PathItem::new_operational_point("Mid_West_station"),
                 PathItem::new_operational_point("Mid_East_station"),
@@ -3061,7 +3108,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn track_occupancy_op_in_db_but_not_in_path_items() {
         let response = init_paced_train_test(
-            Vec::new(),
+            false,
             vec![
                 PathItem::new_operational_point("South_West_station"),
                 PathItem::new_operational_point("Mid_East_station"),

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
@@ -114,6 +114,7 @@ const SimulationResults = ({
     updateTrackOccupanciesOnDrag: handleTrainDragInTrackOccupancy,
   } = useTrackOccupancy({
     infraId,
+    timetableId,
     pathfindingHasFailed: projectionData?.pathfindingStatus === 'failed',
     pathOperationalPoints: filteredOperationalPoints,
     timetableItemProjections,

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -2598,6 +2598,7 @@ export type PostTrainSchedulesTrackOccupancyApiArg = {
     electrical_profile_set_id?: number | null;
     infra_id: number;
     operational_point_reference: OperationalPointReference;
+    timetable_id: number;
     train_schedule_ids: number[];
     use_simulation: boolean;
   };

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useTrackOccupancy.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useTrackOccupancy.ts
@@ -87,11 +87,13 @@ function getOperationalPointReference(
  */
 const useTrackOccupancy = ({
   infraId,
+  timetableId,
   timetableItemProjections,
   pathOperationalPoints,
   pathfindingHasFailed = false,
 }: {
   infraId: number;
+  timetableId: number;
   timetableItemProjections: TrainSpaceTimeData[];
   pathOperationalPoints: PathOperationalPoint[];
   pathfindingHasFailed?: boolean;
@@ -186,6 +188,7 @@ const useTrackOccupancy = ({
           ? {
               operational_point_reference: opRef,
               infra_id: infraId,
+              timetable_id: timetableId,
               train_schedule_ids: pacedTrainIds.map(extractEditoastIdFromPacedTrainId),
               use_simulation: isSimulationEnabled,
             }


### PR DESCRIPTION
Part of https://github.com/OpenRailAssociation/osrd/issues/15202

This PR adapt the `/train_schedules/track_occupancy`endpoint to use the new exceptions table
It also requires the timetable_id as a parameter, as exceptions are now related to a timetable and not just to a train schedule
Fix tests and frontend

> [!NOTE]
> This PR targets a feature branch and may contain all its commits, as it has not been rebased yet. Only the last commit need to be reviewed.