### PR TITLE
editoast: adapt etcs braking curves endpoint

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -4602,11 +4602,12 @@ paths:
         schema:
           type: integer
           format: int64
-      - name: exception_key
+      - name: exception_id
         in: query
         required: false
         schema:
-          type: string
+          type: integer
+          format: int64
       responses:
         '200':
           description: ETCS Braking Curves Output

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -18,6 +18,7 @@ use core_client::simulation::PhysicsConsist;
 use database::DbConnection;
 use database::DbConnectionPoolV2;
 use editoast_derive::EditoastError;
+use editoast_models::TrainScheduleException;
 use editoast_models::prelude::*;
 use editoast_models::round_trips::TrainScheduleRoundTrips;
 use itertools::Itertools;
@@ -400,6 +401,12 @@ pub(in crate::views) struct ExceptionQueryParam {
     exception_key: Option<String>,
 }
 
+#[derive(Debug, Default, Clone, Serialize, Deserialize, IntoParams, ToSchema)]
+#[into_params(parameter_in = Query)]
+pub(in crate::views) struct TrainScheduleExceptionQueryParam {
+    exception_id: Option<i64>,
+}
+
 /// Get a path from a paced train given an infrastructure id and a paced train id
 #[editoast_derive::route]
 #[utoipa::path(
@@ -583,7 +590,7 @@ pub(in crate::views) async fn simulation(
 #[utoipa::path(
     get, path = "",
     tags = ["paced_train", "etcs_braking_curves"],
-    params(TrainScheduleIdParam, InfraIdQueryParam, ElectricalProfileSetIdQueryParam, ExceptionQueryParam),
+    params(TrainScheduleIdParam, InfraIdQueryParam, ElectricalProfileSetIdQueryParam, TrainScheduleExceptionQueryParam),
     responses(
         (status = 200, description = "ETCS Braking Curves Output", body = core_client::etcs_braking_curves::Response),
     ),
@@ -604,7 +611,9 @@ pub(in crate::views) async fn etcs_braking_curves(
     Query(ElectricalProfileSetIdQueryParam {
         electrical_profile_set_id,
     }): Query<ElectricalProfileSetIdQueryParam>,
-    Query(ExceptionQueryParam { exception_key }): Query<ExceptionQueryParam>,
+    Query(TrainScheduleExceptionQueryParam { exception_id }): Query<
+        TrainScheduleExceptionQueryParam,
+    >,
 ) -> Result<Json<core_client::etcs_braking_curves::Response>> {
     let authorized = auth
         .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
@@ -635,17 +644,19 @@ pub(in crate::views) async fn etcs_braking_curves(
         })
         .await?;
 
-    let train_schedule = match exception_key {
-        Some(exception_key) => {
-            let exception = train_schedule
-                .exceptions
-                .iter()
-                .find(|e| e.key == exception_key)
-                .ok_or_else(|| TrainScheduleError::ExceptionNotFound {
-                    exception_key: exception_key.clone(),
-                })?;
-
-            train_schedule.apply_exception(exception)
+    let train_occurrence = match exception_id {
+        Some(exception_id) => {
+            let exception: schemas::TrainScheduleException =
+                TrainScheduleException::retrieve_or_fail(
+                    db_pool.get().await?,
+                    exception_id,
+                    || TrainScheduleError::ExceptionNotFound {
+                        exception_key: exception_id.to_string(),
+                    },
+                )
+                .await?
+                .into();
+            train_schedule.apply_train_schedule_exception(&exception)
         }
         None => train_schedule.into_train_occurrence(),
     };
@@ -655,7 +666,7 @@ pub(in crate::views) async fn etcs_braking_curves(
         &mut db_pool.get().await?,
         valkey_client,
         core_client.clone(),
-        std::slice::from_ref(&train_schedule),
+        std::slice::from_ref(&train_occurrence),
         &infra,
         electrical_profile_set_id,
         config.app_version.as_deref(),
@@ -683,9 +694,9 @@ pub(in crate::views) async fn etcs_braking_curves(
     // Build physics consist
     let rs = RollingStock::retrieve_or_fail(
         db_pool.get().await?,
-        train_schedule.rolling_stock_name.clone(),
+        train_occurrence.rolling_stock_name.clone(),
         || TrainScheduleError::RollingStockNotFound {
-            rolling_stock_name: train_schedule.rolling_stock_name.clone(),
+            rolling_stock_name: train_occurrence.rolling_stock_name.clone(),
         },
     )
     .await?;
@@ -694,12 +705,12 @@ pub(in crate::views) async fn etcs_braking_curves(
 
     // Build schedule items and power restrictions
     let path_items_to_position = build_path_items_to_position(
-        &train_schedule.path,
+        &train_occurrence.path,
         &pathfinding_response.path_item_positions,
     );
-    let schedule = build_sim_schedule_items(&train_schedule.schedule, &path_items_to_position);
+    let schedule = build_sim_schedule_items(&train_occurrence.schedule, &path_items_to_position);
     let power_restrictions = build_sim_power_restriction_items(
-        &train_schedule.power_restrictions,
+        &train_occurrence.power_restrictions,
         &path_items_to_position,
     );
 
@@ -707,12 +718,12 @@ pub(in crate::views) async fn etcs_braking_curves(
         infra: infra.id,
         expected_version: infra.version,
         physics_consist,
-        comfort: train_schedule.comfort,
+        comfort: train_occurrence.comfort,
         path: pathfinding_response.path,
         schedule,
         power_restrictions,
         electrical_profile_set_id,
-        use_electrical_profiles: train_schedule.options.use_electrical_profiles,
+        use_electrical_profiles: train_occurrence.options.use_electrical_profiles,
         mrsp,
     };
 

--- a/front/src/applications/operationalStudies/hooks/useEtcsBrakingCurves.ts
+++ b/front/src/applications/operationalStudies/hooks/useEtcsBrakingCurves.ts
@@ -82,7 +82,7 @@ const useEtcsBrakingCurves = (
         id: selectedTrainId,
         infraId,
         electricalProfileSetId,
-        exceptionKey: exception?.key,
+        exceptionId: exception?.id ?? undefined,
       }).unwrap();
       setEtcsBrakingCurves(formatEtcsCurves(data));
     } else {

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -1327,7 +1327,7 @@ const injectedRtkApi = api
           params: {
             infra_id: queryArg.infraId,
             electrical_profile_set_id: queryArg.electricalProfileSetId,
-            exception_key: queryArg.exceptionKey,
+            exception_id: queryArg.exceptionId,
           },
         }),
         providesTags: ['paced_train', 'etcs_braking_curves'],
@@ -2618,7 +2618,7 @@ export type GetTrainSchedulesByIdEtcsBrakingCurvesApiArg = {
   id: number;
   infraId: number;
   electricalProfileSetId?: number;
-  exceptionKey?: string;
+  exceptionId?: number;
 };
 export type GetTrainSchedulesByIdPathApiResponse = /** status 200 The path */ PathfindingResult;
 export type GetTrainSchedulesByIdPathApiArg = {

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -123,10 +123,10 @@ const osrdEditoastApi = generatedEditoastApi
       }),
       getEtcsBrakingCurves: builder.query<
         CoreEtcsBrakingCurvesResponse,
-        { id: TrainId; infraId: number; electricalProfileSetId?: number; exceptionKey?: string }
+        { id: TrainId; infraId: number; electricalProfileSetId?: number; exceptionId?: number }
       >({
         queryFn: async (
-          { id: trainId, infraId, electricalProfileSetId, exceptionKey },
+          { id: trainId, infraId, electricalProfileSetId, exceptionId },
           { dispatch }
         ) => {
           const pacedTrainId = isOccurrenceId(trainId)
@@ -138,7 +138,7 @@ const osrdEditoastApi = generatedEditoastApi
                 id: extractEditoastIdFromPacedTrainId(pacedTrainId),
                 infraId,
                 electricalProfileSetId,
-                exceptionKey,
+                exceptionId,
               },
               { subscribe: false }
             )


### PR DESCRIPTION
Part of https://github.com/OpenRailAssociation/osrd/issues/15202

This PR adapt the `/train_schedules/{id}/etcs_braking_curves` to use the new exception table
Rename the query string to `exception_id`
Fix frontend

> [!NOTE]
> This PR targets a feature branch and may contain all its commits, as it has not been rebased yet. Only the last commit need to be reviewed.