### PR TITLE
editoast: retrieve exceptions by ids and timetable utility function

### DIFF
--- a/editoast/editoast_models/src/train_schedule_exception.rs
+++ b/editoast/editoast_models/src/train_schedule_exception.rs
@@ -1,8 +1,14 @@
+use std::collections::HashMap;
+
+use database::DbConnection;
 use editoast_derive::Model;
+use itertools::Itertools;
 use schemas::paced_train::PacedTrainException;
 use schemas::train_schedule_exception::TrainScheduleExceptionChangeGroups;
 
 use crate as editoast_models;
+use crate::prelude::List;
+use crate::prelude::SelectionSettings;
 
 #[derive(Debug, Clone, Model)]
 #[cfg_attr(test, derive(serde::Deserialize))]
@@ -30,6 +36,35 @@ impl From<TrainScheduleException> for schemas::TrainScheduleException {
             disabled: train_schedule_exception.disabled,
             change_groups: train_schedule_exception.change_groups,
         }
+    }
+}
+
+impl TrainScheduleException {
+    pub async fn retrieve_exceptions_by_train_schedules(
+        conn: &mut DbConnection,
+        timetable_id: i64,
+        train_schedules_ids: Vec<i64>,
+    ) -> Result<Vec<TrainScheduleException>, editoast_models::Error> {
+        let train_schedules_ids_for_settings = train_schedules_ids.clone();
+        let exceptions_settings = SelectionSettings::new()
+            .filter(move || editoast_models::TrainScheduleException::TIMETABLE_ID.eq(timetable_id))
+            .filter(move || {
+                editoast_models::TrainScheduleException::TRAIN_SCHEDULE_ID
+                    .eq_any(train_schedules_ids_for_settings.clone())
+            });
+
+        let mut exceptions_map: HashMap<i64, Vec<TrainScheduleException>> =
+            Self::list(conn, exceptions_settings)
+                .await?
+                .into_iter()
+                .into_group_map_by(|e| e.train_schedule_id);
+
+        let exceptions = train_schedules_ids
+            .into_iter()
+            .flat_map(|id| exceptions_map.remove(&id).unwrap_or_default())
+            .collect();
+
+        Ok(exceptions)
     }
 }
 


### PR DESCRIPTION
This PR add a small utility function to retrieve exceptions by ids and timetable useful for multiple endpoints