### PR TITLE
front: refactor train schedule set inside a proper manager object

### DIFF
--- a/front/src/applications/operationalStudies/hooks/useScenarioTrainScheduleSet.ts
+++ b/front/src/applications/operationalStudies/hooks/useScenarioTrainScheduleSet.ts
@@ -9,7 +9,7 @@ import {
   type TrainScheduleSet,
 } from 'common/api/osrdEditoastApi';
 import { createPacedTrains } from 'modules/timetableItem/helpers/updateTimetableItemHelpers';
-import type { TimetableItemWithDetails } from 'modules/timetableItem/types';
+import type { PacedTrainWithDetails, TimetableItemWithDetails } from 'modules/timetableItem/types';
 import type { TimetableItem } from 'reducers/osrdconf/types';
 import { useAppDispatch } from 'store';
 import { formatEditoastIdToPacedTrainId } from 'utils/trainId';
@@ -26,6 +26,21 @@ export type ImportTrainScheduleSetsPayload = Array<{
   type: TrainScheduleSetImportType;
   trainScheduleSet: TrainScheduleSet;
 }>;
+
+export type TimetableItemsByTrainScheduleSet = {
+  trainScheduleSet: TrainScheduleSet;
+  trains: PacedTrainWithDetails[];
+  catalog?: CatalogEntry;
+};
+
+export type TrainScheduleSetManager = {
+  createSet: (data: TrainScheduleSetFormData) => Promise<void>;
+  publishSet: (trainScheduleSet: TrainScheduleSet, data: TrainScheduleSetFormData) => Promise<void>;
+  getSetByCatalogAndName: (name: string, catalogId: number) => TrainScheduleSet | null;
+  localCopySet: (trainScheduleSet: TrainScheduleSet) => Promise<void>;
+  updateSet: (trainScheduleSet: TrainScheduleSet, data: TrainScheduleSetFormData) => Promise<void>;
+  removeSet: (id: number) => Promise<void>;
+};
 
 export default function useScenarioTrainScheduleSet(
   timetableItemsWithDetails: TimetableItemWithDetails[],
@@ -350,24 +365,45 @@ export default function useScenarioTrainScheduleSet(
 
     return Array.from(trainScheduleSetsById.values())
       .sort((a, b) => sortTrainScheduleSets(a, b, catalogEntriesIndex))
-      .map((trainScheduleSet) => ({
-        trainScheduleSet,
-        trains: trainsByTrainScheduleSetId.get(trainScheduleSet.id) || [],
-        catalog: trainScheduleSet.catalog_entry_id
-          ? catalogEntriesIndex.get(trainScheduleSet.catalog_entry_id)
-          : undefined, // can happen if it's the sandbox
-      }));
+      .map(
+        (trainScheduleSet): TimetableItemsByTrainScheduleSet => ({
+          trainScheduleSet,
+          trains: trainsByTrainScheduleSetId.get(trainScheduleSet.id) || [],
+          catalog: trainScheduleSet.catalog_entry_id
+            ? catalogEntriesIndex.get(trainScheduleSet.catalog_entry_id)
+            : undefined, // can happen if it's the sandbox
+        })
+      );
   }, [trainScheduleSets, catalogEntries, timetableItemsWithDetails]);
+
+  const manageTrainScheduleSet = useMemo(
+    (): TrainScheduleSetManager => ({
+      createSet: createTrainScheduleSet,
+      publishSet: publishTrainScheduleSet,
+      getSetByCatalogAndName: getTrainScheduleSetByCatalogAndName,
+      localCopySet: localCopyTrainScheduleSet,
+      updateSet: updateTrainScheduleSet,
+      removeSet: removeTrainScheduleSet,
+    }),
+    [
+      createTrainScheduleSet,
+      publishTrainScheduleSet,
+      getTrainScheduleSetByCatalogAndName,
+      localCopyTrainScheduleSet,
+      updateTrainScheduleSet,
+      removeTrainScheduleSet,
+    ]
+  );
 
   return {
     catalogEntries: catalogEntries ?? [],
     timetableItemsByTrainScheduleSets,
-    createTrainScheduleSet,
-    updateTrainScheduleSet,
-    removeTrainScheduleSet,
-    publishTrainScheduleSet,
-    localCopyTrainScheduleSet,
-    getTrainScheduleSetByCatalogAndName,
+    manageTrainScheduleSet,
     importTrainScheduleSets,
+  } satisfies {
+    catalogEntries?: CatalogEntry[];
+    timetableItemsByTrainScheduleSets: TimetableItemsByTrainScheduleSet[] | null;
+    manageTrainScheduleSet: TrainScheduleSetManager;
+    importTrainScheduleSets: (data: ImportTrainScheduleSetsPayload) => Promise<void>;
   };
 }

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/Timetable.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/Timetable.tsx
@@ -73,16 +73,8 @@ const Timetable = ({
   const [pacedTrainIdsToMove, setPacedTrainIdsToMove] = useState<PacedTrainId[]>([]);
   const [trainScheduleSetIdSelected, setTrainScheduleSetIdSelected] = useState<number>();
 
-  const {
-    timetableItemsByTrainScheduleSets,
-    catalogEntries,
-    createTrainScheduleSet,
-    publishTrainScheduleSet,
-    getTrainScheduleSetByCatalogAndName,
-    localCopyTrainScheduleSet,
-    updateTrainScheduleSet,
-    removeTrainScheduleSet,
-  } = useScenarioTrainScheduleSet(timetableItemsWithDetails, timetableItems, upsertTimetableItems);
+  const { timetableItemsByTrainScheduleSets, catalogEntries, manageTrainScheduleSet } =
+    useScenarioTrainScheduleSet(timetableItemsWithDetails, timetableItems, upsertTimetableItems);
 
   const { filteredTimetableItems, ...timetableFilters } =
     useFilterTimetableItems(timetableItemsWithDetails);
@@ -196,11 +188,7 @@ const Timetable = ({
           handleSelectTrainScheduleSet={handleSelectTrainScheduleSet}
           catalogEntries={catalogEntries}
           moveTimetableItem={(pacedTrainIds) => openMoveDialog(pacedTrainIds)}
-          publishTrainScheduleSet={publishTrainScheduleSet}
-          getTrainScheduleSetByCatalogAndName={getTrainScheduleSetByCatalogAndName}
-          localCopyTrainScheduleSet={localCopyTrainScheduleSet}
-          updateTrainScheduleSet={updateTrainScheduleSet}
-          removeTrainScheduleSet={removeTrainScheduleSet}
+          manageTrainScheduleSet={manageTrainScheduleSet}
           expandedTrainScheduleSetIds={expandedTrainScheduleSetIds}
           setShowTrainScheduleSetDialog={setShowTrainScheduleSetDialog}
         />
@@ -209,7 +197,7 @@ const Timetable = ({
         <TrainScheduleSetDialog
           catalogEntries={catalogEntries}
           onCancel={() => setShowTrainScheduleSetDialog(false)}
-          onSubmit={createTrainScheduleSet}
+          onSubmit={manageTrainScheduleSet.createSet}
           labels={{
             title: t('trainScheduleSets.newLocalTrainScheduleSet'),
             submit: t('trainScheduleSets.addTrainScheduleSet'),

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TrainList.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TrainList.tsx
@@ -4,8 +4,11 @@ import { useSelector } from 'react-redux';
 import { Virtualizer } from 'virtua';
 
 import { useScenarioContext } from 'applications/operationalStudies/hooks/useScenarioContext';
-import type useScenarioTrainScheduleSet from 'applications/operationalStudies/hooks/useScenarioTrainScheduleSet';
-import type { CatalogEntry, TrainScheduleSet } from 'common/api/osrdEditoastApi';
+import type {
+  TimetableItemsByTrainScheduleSet,
+  TrainScheduleSetManager,
+} from 'applications/operationalStudies/hooks/useScenarioTrainScheduleSet';
+import type { CatalogEntry } from 'common/api/osrdEditoastApi';
 import { Loader } from 'common/Loaders';
 import { useSubCategoryContext } from 'common/SubCategoryContext';
 import { isPacedTrainWithDetails } from 'modules/timetableItem/helpers/pacedTrain';
@@ -32,14 +35,6 @@ import TrainScheduleSetTab from './TrainScheduleSet/TrainScheduleSetTab';
 import type { TimetableMode } from './types';
 import UniqueTrainItem from './UniqueTrainItem';
 
-type TimetableItemByTrainScheduleSets =
-  | {
-      trainScheduleSet: TrainScheduleSet;
-      trains: PacedTrainWithDetails[];
-      catalog: CatalogEntry | undefined;
-    }[]
-  | null;
-
 type TrainListProps = {
   setDisplayTimetableItemManagement: (mode: string) => void;
   upsertTimetableItems: (timetableItems: TimetableItem[]) => void;
@@ -53,21 +48,11 @@ type TrainListProps = {
   isSelectMode: boolean;
   timetableMode: TimetableMode;
   moveTimetableItem?: (pacedTrainIds: PacedTrainId[]) => void;
-  timetableItemsByTrainScheduleSets: TimetableItemByTrainScheduleSets;
+  timetableItemsByTrainScheduleSets: TimetableItemsByTrainScheduleSet[] | null;
   handleClickTrainScheduleSet: (id: number) => void;
   handleSelectTrainScheduleSet: (trainIds: TimetableItemId[]) => void;
   catalogEntries: CatalogEntry[];
-  publishTrainScheduleSet: ReturnType<
-    typeof useScenarioTrainScheduleSet
-  >['publishTrainScheduleSet'];
-  getTrainScheduleSetByCatalogAndName: ReturnType<
-    typeof useScenarioTrainScheduleSet
-  >['getTrainScheduleSetByCatalogAndName'];
-  localCopyTrainScheduleSet: ReturnType<
-    typeof useScenarioTrainScheduleSet
-  >['localCopyTrainScheduleSet'];
-  updateTrainScheduleSet: ReturnType<typeof useScenarioTrainScheduleSet>['updateTrainScheduleSet'];
-  removeTrainScheduleSet: ReturnType<typeof useScenarioTrainScheduleSet>['removeTrainScheduleSet'];
+  manageTrainScheduleSet: TrainScheduleSetManager;
   expandedTrainScheduleSetIds: Set<number>;
   setShowTrainScheduleSetDialog: (value: boolean) => void;
 };
@@ -92,11 +77,7 @@ const TrainList = ({
   handleClickTrainScheduleSet,
   handleSelectTrainScheduleSet,
   catalogEntries,
-  publishTrainScheduleSet,
-  getTrainScheduleSetByCatalogAndName,
-  localCopyTrainScheduleSet,
-  updateTrainScheduleSet,
-  removeTrainScheduleSet,
+  manageTrainScheduleSet,
   expandedTrainScheduleSetIds,
   setShowTrainScheduleSetDialog,
 }: TrainListProps) => {
@@ -282,11 +263,7 @@ const TrainList = ({
                   isCheckboxDisabled={isCheckboxDisabled}
                   isTrainListOpen={isTrainListOpen}
                   catalogEntries={catalogEntries}
-                  publishTrainScheduleSet={publishTrainScheduleSet}
-                  getTrainScheduleSetByCatalogAndName={getTrainScheduleSetByCatalogAndName}
-                  localCopyTrainScheduleSet={localCopyTrainScheduleSet}
-                  updateTrainScheduleSet={updateTrainScheduleSet}
-                  removeTrainScheduleSet={removeTrainScheduleSet}
+                  manageTrainScheduleSet={manageTrainScheduleSet}
                 />
               );
 

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TrainScheduleSet/TrainScheduleSetTab.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TrainScheduleSet/TrainScheduleSetTab.tsx
@@ -18,7 +18,7 @@ import { noop } from 'lodash';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 
-import type useScenarioTrainScheduleSet from 'applications/operationalStudies/hooks/useScenarioTrainScheduleSet';
+import type { TrainScheduleSetManager } from 'applications/operationalStudies/hooks/useScenarioTrainScheduleSet';
 import type { CatalogEntry, TrainScheduleSet } from 'common/api/osrdEditoastApi';
 import MenuTriggerButton, { type MenuProps } from 'common/MenuTriggerButton';
 
@@ -47,17 +47,7 @@ type TrainScheduleSetTabProps = PropsWithChildren<{
   isCheckboxDisabled: boolean;
   isTrainListOpen: boolean;
   catalogEntries: CatalogEntry[];
-  publishTrainScheduleSet: ReturnType<
-    typeof useScenarioTrainScheduleSet
-  >['publishTrainScheduleSet'];
-  getTrainScheduleSetByCatalogAndName: ReturnType<
-    typeof useScenarioTrainScheduleSet
-  >['getTrainScheduleSetByCatalogAndName'];
-  localCopyTrainScheduleSet: ReturnType<
-    typeof useScenarioTrainScheduleSet
-  >['localCopyTrainScheduleSet'];
-  updateTrainScheduleSet: ReturnType<typeof useScenarioTrainScheduleSet>['updateTrainScheduleSet'];
-  removeTrainScheduleSet: ReturnType<typeof useScenarioTrainScheduleSet>['removeTrainScheduleSet'];
+  manageTrainScheduleSet: TrainScheduleSetManager;
 }>;
 
 const TrainScheduleSetTab = ({
@@ -71,11 +61,7 @@ const TrainScheduleSetTab = ({
   isCheckboxDisabled,
   isTrainListOpen,
   catalogEntries,
-  publishTrainScheduleSet,
-  getTrainScheduleSetByCatalogAndName,
-  localCopyTrainScheduleSet,
-  updateTrainScheduleSet,
-  removeTrainScheduleSet,
+  manageTrainScheduleSet,
 }: TrainScheduleSetTabProps) => {
   const { t } = useTranslation('operational-studies', {
     keyPrefix: 'main.timetable.trainScheduleSets',
@@ -193,10 +179,10 @@ const TrainScheduleSetTab = ({
             }}
             onCancel={() => setOpenedDialog(null)}
             onSubmit={async (data) => {
-              await publishTrainScheduleSet(trainScheduleSet, data);
+              await manageTrainScheduleSet.publishSet(trainScheduleSet, data);
             }}
             checkNameInCatalogIsUniq={async (name, catalogId) => {
-              const result = getTrainScheduleSetByCatalogAndName(name, catalogId);
+              const result = manageTrainScheduleSet.getSetByCatalogAndName(name, catalogId);
               if (!result) return true;
               return result.id === trainScheduleSet.id;
             }}
@@ -210,7 +196,7 @@ const TrainScheduleSetTab = ({
             trainScheduleSet={trainScheduleSet}
             onCancel={() => setOpenedDialog(null)}
             onSubmit={async () => {
-              await localCopyTrainScheduleSet(trainScheduleSet);
+              await manageTrainScheduleSet.localCopySet(trainScheduleSet);
             }}
           />,
           document.body
@@ -227,7 +213,7 @@ const TrainScheduleSetTab = ({
             }}
             onCancel={() => setOpenedDialog(null)}
             onSubmit={async (data) => {
-              await updateTrainScheduleSet(trainScheduleSet, data);
+              await manageTrainScheduleSet.updateSet(trainScheduleSet, data);
             }}
           />,
           document.body
@@ -252,7 +238,7 @@ const TrainScheduleSetTab = ({
             }}
             onCancel={() => setOpenedDialog(null)}
             onDelete={async () => {
-              await removeTrainScheduleSet(trainScheduleSet.id);
+              await manageTrainScheduleSet.removeSet(trainScheduleSet.id);
             }}
           />,
           document.body


### PR DESCRIPTION
Fixes #15776.

Passing around a group of props is both annoying and hurtful in the long run, as it can signal to other contributers that it's okay to have 20+ props on a component (it's not).

As it's not relevant in my opinion to create a context for a component that is not deep inside a hierarchy, this commit simply regroup those multiple functions inside a properly typed object that we can send to `TrainList`.

Irony: the final result is a -85/+85 (so, an even diff) because of all the types I took the time to define in the process!