### PR TITLE
codeowners: replace OSRD-Tests by editoast and core maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -34,7 +34,7 @@
 /front/playwright.config.ts
 
 # --- INTEGRATION TESTS  ---
-/tests                                                   @openrailassociation/OSRD-Tests
+/tests                                                   @openrailassociation/OSRD-Editoast @openrailassociation/OSRD-Core
 
 # --- CORE ---
 /core                                                    @openrailassociation/OSRD-Core


### PR DESCRIPTION
Here is the documentation explaining how Codeowners works when multiple groups are assigned: https://docs.github.com/fr/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-and-branch-protection

This works as intended (an “editoast” or “core” maintainer will be able to approve PRs related to tests).