### PR TITLE
front: fix rocket crashing when a result has a `null` name

### DIFF
--- a/front/src/modules/pathfinding/components/Pathfinding/TypeAndPath.tsx
+++ b/front/src/modules/pathfinding/components/Pathfinding/TypeAndPath.tsx
@@ -117,9 +117,11 @@ const TypeAndPath = ({
     })
       .unwrap()
       .then((results) => {
-        const filteredResults = results.filter((result) =>
-          MAIN_OP_CH_CODES.includes((result as SearchResultItemOperationalPoint).ch)
-        );
+        const filteredResults = results.filter((result) => {
+          const searchResult = result as SearchResultItemOperationalPoint;
+          // We need to ensure the name is not null since we sort the results depending on it.
+          return searchResult.name != null && MAIN_OP_CH_CODES.includes(searchResult.ch);
+        });
         setSearchResults(filteredResults as SearchResultItemOperationalPoint[]);
       })
       .catch(() => {


### PR DESCRIPTION
This PR fixes the linked bug.

Since the crash comes from a search result not having a name, we simply filter out the ones that do not have a name

Closes https://github.com/OpenRailAssociation/osrd/issues/15595