### PR TITLE
front: fix itinerary modal instantly writing the train header to the store

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModal.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModal.tsx
@@ -13,16 +13,15 @@ import { useManageTimetableItemContext } from 'applications/operationalStudies/h
 import { useOperationalPointSearch } from 'applications/operationalStudies/hooks/useOperationalPointSearch';
 import { useScenarioContext } from 'applications/operationalStudies/hooks/useScenarioContext';
 import AlertBox from 'common/AlertBox';
-import { type PathProperties, type PathItemLocation } from 'common/api/osrdEditoastApi';
+import type { PathProperties, PathItemLocation, TrainCategory } from 'common/api/osrdEditoastApi';
 import { computeBBoxViewport } from 'common/Map/WarpedMap/core/helpers';
 import { useInfraID } from 'common/osrdContext';
 import IncompatibleConstraints from 'modules/pathfinding/components/IncompatibleConstraints';
 import TypeAndPath from 'modules/pathfinding/components/Pathfinding/TypeAndPath';
 import reversePathSteps from 'modules/pathfinding/helpers/reversePathSteps';
 import usePathfindingV2 from 'modules/pathfinding/hooks/usePathfindingV2';
-import type { RootState } from 'reducers';
 import { useMapSettings, useMapSettingsActions } from 'reducers/commonMap';
-import { updatePathSteps } from 'reducers/osrdconf/operationalStudiesConf';
+import { updateItineraryForm } from 'reducers/osrdconf/operationalStudiesConf';
 import {
   getCategory,
   getName,
@@ -58,6 +57,13 @@ type ItineraryModalProps = {
   displayTimetableItemManagement: string;
 };
 
+export type ItineraryModalFormState = {
+  name?: string;
+  rollingStockId?: number;
+  speedLimitTag?: string;
+  category?: TrainCategory;
+};
+
 const ItineraryModal = ({
   itineraryModalIsOpen,
   setItineraryModalIsOpen,
@@ -70,13 +76,21 @@ const ItineraryModal = ({
   const category = useSelector(getCategory);
   const { workerStatus } = useScenarioContext();
   const rollingStockId = useSelector(getOperationalStudiesRollingStockID);
+  const name = useSelector(getName);
   const speedLimitTag = useSelector(getOperationalStudiesSpeedLimitByTag);
   const mapSettings = useMapSettings();
   const dispatch = useAppDispatch();
   const { updateViewport } = useMapSettingsActions();
   const infraId = useInfraID();
 
-  const { categoryColors, currentSubCategory } = useCategoryColors(category);
+  const [modalFormState, setModalFormState] = useState<ItineraryModalFormState>({
+    name,
+    rollingStockId,
+    speedLimitTag,
+    category: category ?? undefined,
+  });
+
+  const { categoryColors, currentSubCategory } = useCategoryColors(modalFormState.category);
 
   const modalRef = useRef<HTMLDialogElement>(null);
   const editingStepIdRef = useRef<string>('');
@@ -299,12 +313,7 @@ const ItineraryModal = ({
     }
   };
 
-  // Use a boolean selector so typing doesn't re-render the whole modal on every keystroke.
-  // Re-renders only when the name transitions between empty and non-empty.
-  const isNameEmpty = useSelector((state: RootState) => {
-    const n = getName(state);
-    return !n || n.trim() === '';
-  });
+  const isNameEmpty = !modalFormState.name || modalFormState.name.trim() === '';
   const [submitAttempted, setSubmitAttempted] = useState(false);
 
   useEffect(() => {
@@ -353,7 +362,8 @@ const ItineraryModal = ({
   }, [pathfindingStepsWithLocations]);
 
   useEffect(() => {
-    if (workerStatus !== 'READY' || !rollingStockId || pathfindingSteps.length < 2) return;
+    if (workerStatus !== 'READY' || !modalFormState.rollingStockId || pathfindingSteps.length < 2)
+      return;
 
     const pathfindingLocations = pathfindingSteps.map((s) => s.location!);
     const metadataByPathStepId = new Map(
@@ -363,10 +373,10 @@ const ItineraryModal = ({
     launchPathfindingV2({
       pathSteps: pathfindingLocations,
       pathStepsMetadataById: metadataByPathStepId,
-      rollingStockId,
-      speedLimitTag,
+      rollingStockId: modalFormState.rollingStockId,
+      speedLimitTag: modalFormState.speedLimitTag ?? null,
     });
-  }, [workerStatus, rollingStockId, speedLimitTag, pathfindingSteps]);
+  }, [workerStatus, modalFormState.rollingStockId, modalFormState.speedLimitTag, pathfindingSteps]);
 
   const onPathfindingLoad = useEffectEvent((geometry: PathProperties['geometry']) => {
     const newViewport = computeBBoxViewport(bbox(geometry), mapSettings.viewport, {
@@ -429,7 +439,7 @@ const ItineraryModal = ({
 
     if (updatedPathSteps.length < 2) return;
 
-    launchPathfinding(reversePathSteps(updatedPathSteps));
+    launchPathfinding(reversePathSteps(updatedPathSteps), modalFormState.rollingStockId);
   };
   const submitItinerary = () => {
     setSubmitAttempted(true);
@@ -450,8 +460,17 @@ const ItineraryModal = ({
 
     if (pathStepsFromV2.length < 2) return;
 
-    dispatch(updatePathSteps(pathStepsFromV2));
-    launchPathfinding(pathStepsFromV2, rollingStockId, { isInitialization: true });
+    dispatch(
+      updateItineraryForm({
+        name: modalFormState.name ?? '',
+        category: modalFormState.category ?? null,
+        rollingStockId: modalFormState.rollingStockId,
+        speedLimitTag: modalFormState.speedLimitTag,
+        pathSteps: pathStepsFromV2,
+      })
+    );
+
+    launchPathfinding(pathStepsFromV2, modalFormState.rollingStockId, { isInitialization: true });
     closeModal();
   };
 
@@ -484,8 +503,9 @@ const ItineraryModal = ({
         {mapSelectionStepId && <div className="map-selection-form-overlay" />}
         <div className="itinerary-modal-form-header">
           <ItineraryModalFormHeader
+            modalFormState={modalFormState}
+            onModalFormStateChange={setModalFormState}
             onCategoryWarningChange={setCategoryWarning}
-            category={category}
             currentSubCategory={currentSubCategory}
             categoryColors={categoryColors}
             submitAttempted={submitAttempted}
@@ -498,7 +518,7 @@ const ItineraryModal = ({
           {!hasInvalidPathStepDisplay && pathfindingError && (
             <AlertBox type="error" message={pathfindingError} />
           )}
-          <TypeAndPath rollingStockId={rollingStockId} isInNewModal />
+          <TypeAndPath rollingStockId={modalFormState.rollingStockId} isInNewModal />
           <div className="path-step-list">
             <button
               data-testid="reverse-itinerary-button"

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModalFormHeader.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModalFormHeader.tsx
@@ -9,32 +9,22 @@ import {
 } from '@osrd-project/ui-core';
 import { isEqual } from 'lodash';
 import { useTranslation } from 'react-i18next';
-import { useSelector } from 'react-redux';
 
 import type { CategoryColors } from 'applications/operationalStudies/types';
-import type {
-  LightRollingStockWithLiveries,
-  SubCategory,
-  TrainCategory,
-} from 'common/api/osrdEditoastApi';
-import { useOsrdConfActions } from 'common/osrdContext';
+import type { LightRollingStockWithLiveries, SubCategory } from 'common/api/osrdEditoastApi';
 import useSpeedLimitTags from 'common/SpeedLimitTagSelector/useSpeedLimitTags';
 import useStoreDataForRollingStockSelector from 'modules/rollingStock/components/RollingStockSelector/useStoreDataForRollingStockSelector';
 import isMainCategory from 'modules/rollingStock/helpers/category';
 import useCategoryOptions from 'modules/rollingStock/hooks/useCategoryOptions';
 import useFilterRollingStock from 'modules/rollingStock/hooks/useFilterRollingStock';
-import { updateCategory, updateName } from 'reducers/osrdconf/operationalStudiesConf';
-import {
-  getName,
-  getOperationalStudiesRollingStockID,
-  getOperationalStudiesSpeedLimitByTag,
-} from 'reducers/osrdconf/operationalStudiesConf/selectors';
-import { useAppDispatch } from 'store';
 import { createStandardSelectOptions } from 'utils/uiCoreHelpers';
 
+import type { ItineraryModalFormState } from './ItineraryModal';
+
 type ItineraryModalFormHeaderProps = {
+  modalFormState: ItineraryModalFormState;
+  onModalFormStateChange: (context: ItineraryModalFormState) => void;
   onCategoryWarningChange: (categoryWarning?: string) => void;
-  category: TrainCategory | null;
   currentSubCategory?: SubCategory;
   categoryColors: CategoryColors;
   submitAttempted?: boolean;
@@ -42,17 +32,14 @@ type ItineraryModalFormHeaderProps = {
 };
 
 const ItineraryModalFormHeader = ({
+  modalFormState,
+  onModalFormStateChange,
   onCategoryWarningChange,
-  category,
   currentSubCategory,
   categoryColors,
   submitAttempted,
   isNameEmpty,
 }: ItineraryModalFormHeaderProps) => {
-  const name = useSelector(getName);
-  const dispatch = useAppDispatch();
-  const { updateSpeedLimitByTag, updateRollingStockID } = useOsrdConfActions();
-
   const { t } = useTranslation('operational-studies', {
     keyPrefix: 'manageTimetableItem',
   });
@@ -62,14 +49,16 @@ const ItineraryModalFormHeader = ({
 
   const handleCategoryChange = (option?: (typeof categoryOptions)[number]) => {
     if (option !== undefined) {
-      dispatch(updateCategory(option.category));
+      onModalFormStateChange({
+        ...modalFormState,
+        category: option.category ?? undefined,
+      });
     }
   };
 
   // RollingStock
-  const rollingStockId = useSelector(getOperationalStudiesRollingStockID);
   const { rollingStock } = useStoreDataForRollingStockSelector({
-    rollingStockId,
+    rollingStockId: modalFormState.rollingStockId,
   });
   const getRollingStockLabel = (rs: LightRollingStockWithLiveries) => {
     const secondPart = rs.metadata?.series || rs.metadata?.reference || '';
@@ -85,23 +74,24 @@ const ItineraryModalFormHeader = ({
 
   const handleRollingStockSelect = (rs?: LightRollingStockWithLiveries) => {
     if (!rs) {
-      dispatch(updateRollingStockID(undefined));
-      dispatch(updateCategory(null));
+      onModalFormStateChange({
+        ...modalFormState,
+        category: undefined,
+        rollingStockId: undefined,
+      });
       return;
     }
 
-    dispatch(updateRollingStockID(rs.id));
-    dispatch(updateCategory(rs.primary_category ? { main_category: rs.primary_category } : null));
+    onModalFormStateChange({
+      ...modalFormState,
+      category: rs.primary_category ? { main_category: rs.primary_category } : undefined,
+      rollingStockId: rs.id,
+    });
   };
 
   // Composition code/speed limit by tag
-  const speedLimitByTag = useSelector(getOperationalStudiesSpeedLimitByTag);
   const speedLimitTags = useSpeedLimitTags();
 
-  // Timetable item name
-  const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    dispatch(updateName(e.target.value));
-  };
   // Timetable item name error
   const [isNameBlurred, setIsNameBlurred] = useState(false);
 
@@ -117,15 +107,15 @@ const ItineraryModalFormHeader = ({
 
   // Category warning
   const categoryWarningMessage = useMemo(() => {
-    if (!rollingStock || !category) return undefined;
+    if (!rollingStock || !modalFormState.category) return undefined;
 
-    const isMismatch = isMainCategory(category)
-      ? category.main_category !== rollingStock.primary_category &&
-        !rollingStock.other_categories.includes(category.main_category)
+    const isMismatch = isMainCategory(modalFormState.category)
+      ? modalFormState.category.main_category !== rollingStock.primary_category &&
+        !rollingStock.other_categories.includes(modalFormState.category.main_category)
       : currentSubCategory?.main_category !== rollingStock.primary_category;
 
     return isMismatch ? t('categoryMismatch') : undefined;
-  }, [rollingStock, category, currentSubCategory, t]);
+  }, [rollingStock, modalFormState.category, currentSubCategory, t]);
 
   useEffect(() => {
     onCategoryWarningChange(categoryWarningMessage);
@@ -146,7 +136,9 @@ const ItineraryModalFormHeader = ({
             narrow
             small
             options={categoryOptions}
-            value={categoryOptions.find((option) => isEqual(option.category, category))}
+            value={categoryOptions.find((option) =>
+              isEqual(option.category, modalFormState.category)
+            )}
             getOptionLabel={(option) => option.label}
             getOptionValue={(option) => option.id}
             onChange={handleCategoryChange}
@@ -174,10 +166,13 @@ const ItineraryModalFormHeader = ({
             narrow
             small
             placeholder={t('noSpeedLimitByTag')}
-            value={speedLimitByTag || ''}
+            value={modalFormState.speedLimitTag ?? ''}
             {...createStandardSelectOptions(speedLimitTags)}
             onChange={(e) => {
-              dispatch(updateSpeedLimitByTag(e ?? null));
+              onModalFormStateChange({
+                ...modalFormState,
+                speedLimitTag: e,
+              });
             }}
           ></Select>
         </div>
@@ -187,15 +182,16 @@ const ItineraryModalFormHeader = ({
             small
             id="itinerary-modal-timetable-item-name"
             label={t('itineraryModal.trainName')}
-            value={name}
-            title={name}
-            onChange={handleNameChange}
-            onBlur={() => {
-              setIsNameBlurred(true);
-            }}
-            onFocus={() => {
-              setIsNameBlurred(false);
-            }}
+            value={modalFormState.name}
+            title={modalFormState.name}
+            onChange={(e) =>
+              onModalFormStateChange({
+                ...modalFormState,
+                name: e.target.value,
+              })
+            }
+            onBlur={() => setIsNameBlurred(true)}
+            onFocus={() => setIsNameBlurred(false)}
             statusWithMessage={nameError}
           />
         </div>

--- a/front/src/reducers/osrdconf/operationalStudiesConf/__tests__/operationalStudiesConfReducer.spec.ts
+++ b/front/src/reducers/osrdconf/operationalStudiesConf/__tests__/operationalStudiesConfReducer.spec.ts
@@ -60,6 +60,28 @@ describe('simulationConfReducer', () => {
     expect(state).toEqual(operationalStudiesInitialConf);
   });
 
+  it('should update itinerary form data at once', () => {
+    const store = createStore();
+    store.dispatch(
+      operationalStudiesConfSlice.actions.updateItineraryForm({
+        name: 'train1',
+        category: {
+          main_category: 'INTERCITY_TRAIN',
+        },
+        rollingStockId: 1,
+        speedLimitTag: 'MA100',
+        pathSteps: [],
+      })
+    );
+
+    const state = store.getState()[operationalStudiesConfSlice.name];
+    expect(state.name).toBe('train1');
+    expect(state.category).toEqual({ main_category: 'INTERCITY_TRAIN' });
+    expect(state.rollingStockID).toBe(1);
+    expect(state.speedLimitByTag).toBe('MA100');
+    expect(state.pathSteps).toEqual([]);
+  });
+
   describe('selectTrainToEdit', () => {
     it('paced train case', () => {
       const pacedTrain: PacedTrainWithDetails = {

--- a/front/src/reducers/osrdconf/operationalStudiesConf/index.ts
+++ b/front/src/reducers/osrdconf/operationalStudiesConf/index.ts
@@ -154,6 +154,7 @@ export const {
   clearAddedExceptionsList,
   toggleEditingItemType,
   updateCategory,
+  updateItineraryForm,
 
   // itinerary reducer
   updatePathSteps,

--- a/front/src/reducers/osrdconf/operationalStudiesConf/trainSettingsReducer.ts
+++ b/front/src/reducers/osrdconf/operationalStudiesConf/trainSettingsReducer.ts
@@ -1,7 +1,7 @@
 import type { PayloadAction } from '@reduxjs/toolkit';
 import type { Draft } from 'immer';
 
-import type { OperationalStudiesConfState } from '../types';
+import type { ItineraryForm, OperationalStudiesConfState } from '../types';
 
 const trainSettingsReducer = {
   updateConstraintDistribution(
@@ -63,6 +63,16 @@ const trainSettingsReducer = {
   },
   toggleEditingItemType(state: Draft<OperationalStudiesConfState>) {
     state.editingItemType = state.editingItemType === 'pacedTrain' ? 'uniqueTrain' : 'pacedTrain';
+  },
+  updateItineraryForm(
+    state: Draft<OperationalStudiesConfState>,
+    action: PayloadAction<ItineraryForm>
+  ) {
+    state.name = action.payload.name;
+    state.category = action.payload.category;
+    state.rollingStockID = action.payload.rollingStockId;
+    state.speedLimitByTag = action.payload.speedLimitTag;
+    state.pathSteps = action.payload.pathSteps;
   },
 };
 

--- a/front/src/reducers/osrdconf/types.ts
+++ b/front/src/reducers/osrdconf/types.ts
@@ -41,6 +41,14 @@ export type StandardAllowance = {
   value?: number;
 };
 
+export type ItineraryForm = {
+  name: string;
+  category: TrainCategory | null;
+  rollingStockId?: number;
+  speedLimitTag?: string;
+  pathSteps: (PathStep | null)[];
+};
+
 export type OperationalStudiesConfState = OsrdConfState & {
   name: string;
   category: TrainCategory | null;


### PR DESCRIPTION
Introduces a `localName` in the modal that gets updated and is written to the store ONLY when submitting the form.

Closes https://github.com/OpenRailAssociation/osrd/issues/15719

Here is an example of the behaviour after the fix (focus on the updates of the `name`. For comparison, a non-functional example can be found in the original issue:

https://github.com/user-attachments/assets/24752581-f7e8-4f12-b521-2816a231b803

