### PR TITLE
chart: use short sha for dev chart version

### DIFF
--- a/.github/workflows/chart-build.yml
+++ b/.github/workflows/chart-build.yml
@@ -39,12 +39,13 @@ jobs:
           CHART_IMAGES_REPOSITORY="edge"
           CHART_IMAGES_VERSION="dev"
           TIMESTAMP=$(date +%s)
+          SHORT_SHA=$(git rev-parse --short HEAD)
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            CHART_VERSION="0.0.${TIMESTAMP}-${{ github.event.pull_request.number }}-${GITHUB_SHA}"
+            CHART_VERSION="0.0.${TIMESTAMP}-${{ github.event.pull_request.number }}-${SHORT_SHA}"
           elif [[ "${{ github.ref }}" == "refs/heads/dev" ]]; then
-            CHART_VERSION="0.0.${TIMESTAMP}-dev-${GITHUB_SHA}"
+            CHART_VERSION="0.0.${TIMESTAMP}-dev-${SHORT_SHA}"
           elif [[ "${{ github.ref }}" == "refs/heads/staging" ]]; then
-            CHART_VERSION="0.0.${TIMESTAMP}-staging-${GITHUB_SHA}"
+            CHART_VERSION="0.0.${TIMESTAMP}-staging-${SHORT_SHA}"
           fi
 
           echo "CHART_NAME=$CHART_NAME" >> $GITHUB_ENV


### PR DESCRIPTION
I did not realise that adding timestamp in version will create a too long chart version for kubernetes annotations and labels.
This PR fixes this by switching to short sha instead of full sha