### PR TITLE
tests: stabilize `test_with_fuzzer.py`

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -4,9 +4,6 @@
 
 To run tests `uv run pytest` after starting docker containers (`docker compose up` or `./osrd-compose up` at the root of the project) and installing dependencies (`uv sync --all-extras`, see [uv doc](https://docs.astral.sh/uv/)).
 
-> [!TIP]
-> Running tests on a blank stack (empty db) is recommended, especially for `test_with_fuzzer.py` to succeed.
-
 To run a list of specific tests, run `uv run pytest -k test_name_1 test_name_2 ...`.
 
 To setup end-to-end (e2e) tests, please see [the dedicated readme](../front/tests/README.md).

--- a/tests/README.md
+++ b/tests/README.md
@@ -9,7 +9,7 @@ To run tests `uv run pytest` after starting docker containers (`docker compose u
 
 To run a list of specific tests, run `uv run pytest -k test_name_1 test_name_2 ...`.
 
-To setup end-to-end (e2e) tests, please see [front readme](../front/README.md#npm-run-e2e-tests).
+To setup end-to-end (e2e) tests, please see [the dedicated readme](../front/tests/README.md).
 
 ### Create new integration tests
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -233,14 +233,14 @@ def create_rolling_stock(
     return ids
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def fast_rolling_stock(session: Session) -> Iterator[int]:
     rs_id = create_rolling_stock(session, FAST_ROLLING_STOCK_JSON_PATH)[0]
     yield rs_id
     session.delete(f"{EDITOAST_URL}rolling_stock/{rs_id}?force=true")
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def etcs_rolling_stock(session: Session) -> Iterator[int]:
     rs_id = create_rolling_stock(session, ETCS_ROLLING_STOCK_JSON_PATH)[0]
     yield rs_id

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 import json
-from collections.abc import Iterable, Iterator, Mapping
+from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -154,14 +154,11 @@ def etcs_scenario(
     )
 
 
-def get_rolling_stock(
+def get_rolling_stock_id(
     session: Session, editoast_url: str, rolling_stock_name: str
 ) -> int:
     """
     Returns the ID corresponding to the rolling stock name, if available.
-    :param editoast_url: Api url
-    :param rolling_stock_name: name of the rolling stock
-    :return: ID the rolling stock
     """
     page = 1
     while page is not None:
@@ -220,7 +217,9 @@ def create_rolling_stock(
         response = session.post(f"{EDITOAST_URL}rolling_stock/", json=payload)
         rjson = response.json()
         if response.status_code // 100 == 4 and "NameAlreadyUsed" in rjson["type"]:
-            return [get_rolling_stock(session, EDITOAST_URL, rjson["context"]["name"])]
+            return [
+                get_rolling_stock_id(session, EDITOAST_URL, rjson["context"]["name"])
+            ]
         assert "id" in rjson, f"Failed to create rolling stock: {rjson}"
         return [rjson["id"]]
     ids = []
@@ -235,33 +234,17 @@ def create_rolling_stock(
 
 
 @pytest.fixture
-def fast_rolling_stocks(
-    request: pytest.FixtureRequest, session: Session
-) -> Iterator[Iterable[int]]:
-    closest_marker = request.node.get_closest_marker("names_and_metadata")
-    assert closest_marker is not None
-    ids = create_rolling_stock(
-        session,
-        FAST_ROLLING_STOCK_JSON_PATH,
-        closest_marker.args[0],
-    )
-    yield ids
-    for id in ids:
-        session.delete(f"{EDITOAST_URL}rolling_stock/{id}?force=true")
-
-
-@pytest.fixture
 def fast_rolling_stock(session: Session) -> Iterator[int]:
-    id = create_rolling_stock(session, FAST_ROLLING_STOCK_JSON_PATH)[0]
-    yield id
-    session.delete(f"{EDITOAST_URL}rolling_stock/{id}?force=true")
+    rs_id = create_rolling_stock(session, FAST_ROLLING_STOCK_JSON_PATH)[0]
+    yield rs_id
+    session.delete(f"{EDITOAST_URL}rolling_stock/{rs_id}?force=true")
 
 
 @pytest.fixture
 def etcs_rolling_stock(session: Session) -> Iterator[int]:
-    id = create_rolling_stock(session, ETCS_ROLLING_STOCK_JSON_PATH)[0]
-    yield id
-    session.delete(f"{EDITOAST_URL}rolling_stock/{id}?force=true")
+    rs_id = create_rolling_stock(session, ETCS_ROLLING_STOCK_JSON_PATH)[0]
+    yield rs_id
+    session.delete(f"{EDITOAST_URL}rolling_stock/{rs_id}?force=true")
 
 
 @pytest.fixture

--- a/tests/fuzzer/fuzzer.py
+++ b/tests/fuzzer/fuzzer.py
@@ -41,11 +41,11 @@ def run(
     editoast_url: str,
     scenario: Scenario,
     session: Session,
+    rolling_stock_name: str | None,
     scenario_ttl: int = 20,
     n_test: int = 1000,
     log_folder: Path | None = None,
     seed: int | None = None,
-    rolling_stock_name: str | None = None,
 ):
     """
     Runs every test
@@ -71,13 +71,18 @@ def run(
         time.sleep(0.1)
 
         try:
+            rs_name = (
+                _get_random_rolling_stock(editoast_url, session).name
+                if rolling_stock_name is None
+                else rolling_stock_name
+            )
             _run_test(
                 infra_graph,
                 editoast_url,
                 scenario,
                 session,
                 prelude,
-                rolling_stock_name,
+                rs_name,
             )
         except Exception as e:
             if log_folder is None:
@@ -221,7 +226,7 @@ def _run_test(
     scenario: Scenario,
     session: Session,
     prelude: list,
-    rolling_stock_name: str | None,
+    rolling_stock_name: str,
 ):
     """
     Runs a single random test
@@ -229,13 +234,9 @@ def _run_test(
     :param editoast_url: Api url
     :param scenario: Scenario to use for the test
     :param prelude: path/schedule requests sent so far
-    :param rolling_stock_name: rolling stock to use, random if None
+    :param rolling_stock_name: rolling stock to use (use _get_random_rolling_stock() if necessary)
     """
-    rolling_stock = (
-        _get_random_rolling_stock(editoast_url, session)
-        if rolling_stock_name is None
-        else _get_rolling_stock(editoast_url, rolling_stock_name, session)
-    )
+    rolling_stock = _get_rolling_stock(editoast_url, rolling_stock_name, session)
     path = _make_valid_path(infra)
 
     if random.randint(0, 1) == 1:
@@ -364,7 +365,6 @@ def _get_rolling_stock(
 def _get_random_rolling_stock(editoast_url: str, session: Session) -> _RollingStock:
     """
     Returns a random rolling stock ID
-    :param editoast_url: Api url
     :return: ID of a valid rolling stock
     """
     # TODO: we may want to check more pages, for more randomness

--- a/tests/fuzzer/fuzzer.py
+++ b/tests/fuzzer/fuzzer.py
@@ -44,7 +44,6 @@ def run(
     scenario_ttl: int = 20,
     n_test: int = 1000,
     log_folder: Path | None = None,
-    infra_name: str = _INFRA_NAME,
     seed: int | None = None,
     rolling_stock_name: str | None = None,
 ):
@@ -56,7 +55,6 @@ def run(
     :param scenario_ttl: number of tests to run before a scenario reset
     :param n_test: number of tests to run
     :param log_folder: (optional) path to a folder to log errors in
-    :param infra_name: name of the infra, for better reporting
     :param seed: first seed, incremented by 1 for each individual test
     :param rolling_stock_name: rolling stock to use, random if None
     """
@@ -78,7 +76,6 @@ def run(
                 editoast_url,
                 scenario,
                 session,
-                infra_name,
                 prelude,
                 rolling_stock_name,
             )
@@ -200,7 +197,7 @@ U = TypeVar("U")
 def _make_error(
     error_type: _ErrorType,
     response: Response,
-    infra_name: str,
+    infra_id: int,
     **kwargs,
 ):
     """
@@ -212,7 +209,7 @@ def _make_error(
             "error_type": error_type.value,
             "code": response.status_code,
             "error": error,
-            "infra_name": infra_name,
+            "infra_id": infra_id,
             **kwargs,
         }
     )
@@ -223,7 +220,6 @@ def _run_test(
     editoast_url: str,
     scenario: Scenario,
     session: Session,
-    infra_name: str,
     prelude: list,
     rolling_stock_name: str | None,
 ):
@@ -232,7 +228,6 @@ def _run_test(
     :param infra: infra graph
     :param editoast_url: Api url
     :param scenario: Scenario to use for the test
-    :param infra_name: name of the infra, for better reporting
     :param prelude: path/schedule requests sent so far
     :param rolling_stock_name: rolling stock to use, random if None
     """
@@ -249,22 +244,18 @@ def _run_test(
             session,
             scenario,
             rolling_stock.name,
-            infra_name,
             path,
             prelude,
         )
     else:
-        _test_stdcm(
-            editoast_url, session, scenario, rolling_stock.id, infra_name, path, prelude
-        )
+        _test_stdcm(editoast_url, session, scenario, rolling_stock.id, path, prelude)
 
 
 def _test_new_train(
     editoast_url: str,
     session: Session,
     scenario: Scenario,
-    rolling_stock: str,
-    infra_name: str,
+    rolling_stock_name: str,
     path: list[tuple[str, float]],
     prelude: list,
 ):
@@ -272,7 +263,7 @@ def _test_new_train(
     Try to create a new train on the given path.
     """
     print("testing new train")
-    schedule_payload = _make_payload_schedule(path, rolling_stock)
+    schedule_payload = _make_payload_schedule(path, rolling_stock_name)
     r = _post_with_timeout(
         session,
         editoast_url
@@ -283,7 +274,7 @@ def _test_new_train(
         _make_error(
             _ErrorType.SCHEDULE,
             r,
-            infra_name,
+            scenario.infra,
             schedule_payload=schedule_payload,
         )
 
@@ -297,7 +288,7 @@ def _test_new_train(
         _make_error(
             _ErrorType.RESULT,
             r,
-            infra_name,
+            scenario.infra,
             schedule_payload=schedule_payload,
         )
     prelude.append({"schedule_payload": schedule_payload})
@@ -309,7 +300,6 @@ def _test_stdcm(
     session: Session,
     scenario: Scenario,
     rolling_stock: int,
-    infra_name: str,
     path: list[tuple[str, float]],
     prelude: list,
 ):
@@ -332,7 +322,7 @@ def _test_stdcm(
         _make_error(
             _ErrorType.STDCM,
             r,
-            infra_name,
+            scenario.infra,
             stdcm_payload=stdcm_payload,
             prelude=prelude,
         )
@@ -694,6 +684,5 @@ if __name__ == "__main__":
         scenario_ttl=20,
         n_test=100,
         log_folder=Path(__file__).parent / "errors",
-        infra_name=_INFRA_NAME,
         rolling_stock_name=_ROLLING_STOCK_NAME,
     )

--- a/tests/fuzzer/fuzzer.py
+++ b/tests/fuzzer/fuzzer.py
@@ -99,15 +99,13 @@ def run(
         # Let's reset the scenario (empty timetable) so we can keep a
         # manageable/reproducible state.
         if seed % scenario_ttl == 0:
-            scenario = _reset_timetable(editoast_url, scenario)
+            scenario = _reset_timetable(editoast_url, scenario, session)
             prelude = []
 
 
 def get_infra(editoast_url: str, infra_name: str, session: Session) -> int:
     """
     Returns the ID corresponding to the infra name, if available.
-    :param editoast_url: Api url
-    :param infra_name: name of the infra
     :return: ID the infra
     """
     # TODO: we may want a generic pages handler, if we keep adding queries
@@ -124,7 +122,7 @@ def get_infra(editoast_url: str, infra_name: str, session: Session) -> int:
     raise ValueError(f"Unable to find infra {infra_name}")
 
 
-def create_scenario(editoast_url: str, infra_id: int) -> Scenario:
+def create_scenario(editoast_url: str, infra_id: int, session: Session) -> Scenario:
     # Create the timetable
     r = _post_with_timeout(session, editoast_url + "/timetable/", json={})
     timetable_id = r.json()["timetable_id"]
@@ -139,7 +137,7 @@ def create_scenario(editoast_url: str, infra_id: int) -> Scenario:
         },
     )
     train_schedule_set_id = r.json()["id"]
-    r = _post_with_timeout(
+    _resp = _post_with_timeout(
         session,
         editoast_url + "/timetable/{timetable_id}/train_schedule_sets/",
         json=[train_schedule_set_id],
@@ -367,16 +365,9 @@ def _make_stdcm_payload(path: list[tuple[str, float]], rolling_stock: int) -> di
 def _get_rolling_stock(
     editoast_url: str, rolling_stock_name: str, session: Session
 ) -> _RollingStock:
-    """
-    Returns the ID corresponding to the rolling stock name, if available.
-    :param editoast_url: Api url
-    :param rolling_stock_name: name of the rolling stock
-    :return: ID the rolling stock
-    """
-    session = conftest.session_no_fixture()
     return _RollingStock(
         rolling_stock_name,
-        conftest.get_rolling_stock(session, editoast_url, rolling_stock_name),
+        conftest.get_rolling_stock_id(session, editoast_url, rolling_stock_name),
     )
 
 
@@ -398,8 +389,6 @@ def _get_random_rolling_stock(editoast_url: str, session: Session) -> _RollingSt
 def _make_graph(editoast_url: str, infra_id: int, session: Session) -> _InfraGraph:
     """
     Makes a graph from the infra
-    :param editoast_url: editoast url
-    :param infra: infra id
     """
     url = editoast_url + f"infra/{infra_id}/railjson/"
     r = _get_with_timeout(session, url)
@@ -536,7 +525,9 @@ def _convert_stop(stop: tuple[str, float], i: int) -> dict:
     }
 
 
-def _reset_timetable(editoast_url: str, scenario: Scenario) -> Scenario:
+def _reset_timetable(
+    editoast_url: str, scenario: Scenario, session: Session
+) -> Scenario:
     """Deletes the current timetable and creates a new one."""
     # Delete the current timetable
     _raise_if_error(
@@ -559,7 +550,7 @@ def _reset_timetable(editoast_url: str, scenario: Scenario) -> Scenario:
         },
     )
     train_schedule_set_id = r.json()["id"]
-    r = _post_with_timeout(
+    _resp = _post_with_timeout(
         session,
         editoast_url + f"/timetable/{timetable_id}/train_schedule_sets",
         json=[train_schedule_set_id],
@@ -684,20 +675,22 @@ _to_ms = _to_mm
 
 
 if __name__ == "__main__":
-    session = conftest.session_no_fixture()
-    infra_id = get_infra(_EDITOAST_URL, _INFRA_NAME, session)
-    new_scenario = create_scenario(_EDITOAST_URL, infra_id)
+    main_session = conftest.session_no_fixture()
+    main_infra_id = get_infra(_EDITOAST_URL, _INFRA_NAME, main_session)
+    new_scenario = create_scenario(_EDITOAST_URL, main_infra_id, main_session)
     if _ROLLING_STOCK_NAME == "fast_rolling_stock":
         try:
-            _get_rolling_stock(_EDITOAST_URL, _ROLLING_STOCK_NAME, session)
+            _get_rolling_stock(_EDITOAST_URL, _ROLLING_STOCK_NAME, main_session)
         except ValueError:
             conftest.create_rolling_stock(
-                session, conftest.FAST_ROLLING_STOCK_JSON_PATH, test_rolling_stocks=None
+                main_session,
+                conftest.FAST_ROLLING_STOCK_JSON_PATH,
+                test_rolling_stocks=None,
             )
     run(
         _EDITOAST_URL,
         new_scenario,
-        session,
+        main_session,
         scenario_ttl=20,
         n_test=100,
         log_folder=Path(__file__).parent / "errors",

--- a/tests/tests/test_regressions.py
+++ b/tests/tests/test_regressions.py
@@ -70,7 +70,7 @@ def _check_result(editoast_url: str, schedule_id: int, infra_id: int, session: S
     Get the /result/ of the given train id. The function doesn't return anything, it just raises any error
     """
     r = session.get(
-        f"{EDITOAST_URL}train_schedules/{schedule_id}/simulation/?infra_id={infra_id}"
+        f"{editoast_url}train_schedules/{schedule_id}/simulation/?infra_id={infra_id}"
     )
     if r.status_code // 100 != 2 or r.json().get("status", "") != "success":
         raise RuntimeError(
@@ -113,7 +113,7 @@ def _reproduce_test(
     is_private_infra = fuzzer_output["infra_name"] not in ["small_infra", "Small Infra"]
     if is_private_infra:
         infra_id = get_infra(EDITOAST_URL, fuzzer_output["infra_name"], session)
-        scenario = create_scenario(EDITOAST_URL, infra_id)
+        scenario = create_scenario(EDITOAST_URL, infra_id, session)
 
     if fuzzer_output["error_type"] == "STDCM":
         _apply_prelude(

--- a/tests/tests/test_with_fuzzer.py
+++ b/tests/tests/test_with_fuzzer.py
@@ -11,7 +11,14 @@ from .services import EDITOAST_URL
 @pytest.mark.usefixtures("fast_rolling_stock")
 @pytest.mark.parametrize("seed", range(5))
 def test_with_fuzzer(tiny_scenario: Scenario, seed: int, session: Session):
-    fuzzer.run(EDITOAST_URL, tiny_scenario, session, n_test=1, seed=seed + 1)
+    fuzzer.run(
+        EDITOAST_URL,
+        tiny_scenario,
+        session,
+        "fast_rolling_stock",
+        n_test=1,
+        seed=seed + 1,
+    )
 
 
 @pytest.mark.usefixtures("fast_rolling_stock")


### PR DESCRIPTION
Fix impossibility to have stability on tests running on a stack with rolling-stock already provided (or test_with_fuzzer launched single).

NB: The RS for those was random before, picked on what was available in the running stack (possible leftovers from previous tests also).
This is not the case anymore.

* rolling-stock fixtures have to be test-session-scoped: the web session is  cached (partially) and test-session-scoped (previously,  fast_rolling_stock fixture was recreated at each instance, changing its id)
* force rolling-stock name to be explicit for fuzzer tests (and pin it to  "fast_rolling_stock"), but keep the capacity to ramdomize RS

🔍 Please review by commit