### PR TITLE
front: remove timetable item id

### DIFF
--- a/front/src/applications/operationalStudies/__tests__/sampleData.ts
+++ b/front/src/applications/operationalStudies/__tests__/sampleData.ts
@@ -8,7 +8,7 @@ import type {
   PositionData,
 } from 'applications/operationalStudies/types';
 import type { SimulationSummaryResult } from 'common/api/osrdEditoastApi';
-import type { PacedTrainId, TimetableItem } from 'reducers/osrdconf/types';
+import type { TimetableItem } from 'reducers/osrdconf/types';
 
 export const pathLength = 4000;
 export const pathLengthLong = 6000;
@@ -351,7 +351,7 @@ export const trainSummaryNotHonored: Extract<SimulationSummaryResult, { status: 
 };
 
 export const uniqueTrainHonored: TimetableItem = {
-  id: 'paced_95' as PacedTrainId,
+  id: 95,
   train_schedule_set_id: 1000,
   train_name: 'normal',
   labels: [],

--- a/front/src/applications/operationalStudies/helpers/TrainOpProjectionLazyLoader.ts
+++ b/front/src/applications/operationalStudies/helpers/TrainOpProjectionLazyLoader.ts
@@ -6,8 +6,6 @@ import {
   type PostTrainSchedulesOccupancyBlocksApiResponse,
   type PostTrainSchedulesProjectPathOpApiResponse,
 } from 'common/api/osrdEditoastApi';
-import type { TimetableItemId } from 'reducers/osrdconf/types';
-import { extractEditoastIdFromPacedTrainId, formatEditoastIdToPacedTrainId } from 'utils/trainId';
 
 import TrainProjectionLazyLoaderAbstract, {
   type ProjectionResult,
@@ -35,7 +33,7 @@ export default class TrainOpProjectionLazyLoader extends TrainProjectionLazyLoad
     this.opDistances = opDistances;
   }
 
-  async processBatch(batch: TimetableItemId[]) {
+  async processBatch(ids: number[]) {
     const { infraId, path, electricalProfileSetId } = this.options;
 
     if (this.opRefs.length < 2) {
@@ -43,21 +41,19 @@ export default class TrainOpProjectionLazyLoader extends TrainProjectionLazyLoad
       return;
     }
 
-    const editoastIds = batch.map((id) => extractEditoastIdFromPacedTrainId(id));
-
     let pacedTrainPromise: Promise<PostTrainSchedulesProjectPathOpApiResponse> = Promise.resolve(
       {}
     );
     let pacedTrainOccupancyBlocksPromise: Promise<PostTrainSchedulesOccupancyBlocksApiResponse> =
       Promise.resolve({});
-    if (editoastIds.length > 0) {
+    if (ids.length > 0) {
       pacedTrainPromise = this.options
         .dispatch(
           osrdEditoastApi.endpoints.postTrainSchedulesProjectPathOp.initiate(
             {
               body: {
                 infra_id: infraId,
-                train_ids: editoastIds,
+                train_ids: ids,
                 operational_points_refs: this.opRefs,
                 operational_points_distances: this.opDistances,
                 use_simulation: this.options.isSimulationEnabled,
@@ -77,7 +73,7 @@ export default class TrainOpProjectionLazyLoader extends TrainProjectionLazyLoad
                 occupancyBlockForm: {
                   infra_id: infraId,
                   path,
-                  ids: editoastIds,
+                  ids,
                   electrical_profile_set_id: electricalProfileSetId,
                 },
               },
@@ -95,10 +91,9 @@ export default class TrainOpProjectionLazyLoader extends TrainProjectionLazyLoad
       return;
     }
 
-    const rawResults = new Map<TimetableItemId, ProjectionResult>();
+    const rawResults = new Map<number, ProjectionResult>();
 
     for (const [id, result] of Object.entries(rawPacedTrainResults)) {
-      const pacedTrainId = formatEditoastIdToPacedTrainId(Number(id));
       const pacedTrainProjectionResult: ProjectionResult = {
         space_time_curves: result.train_schedule,
         signal_updates: rawPacedTrainOccupancyBlocks[id]?.train_schedule,
@@ -114,7 +109,7 @@ export default class TrainOpProjectionLazyLoader extends TrainProjectionLazyLoad
         }
       }
 
-      rawResults.set(pacedTrainId, pacedTrainProjectionResult);
+      rawResults.set(Number(id), pacedTrainProjectionResult);
     }
 
     this.options.onProgress(rawResults);

--- a/front/src/applications/operationalStudies/helpers/TrainProjectionLazyLoaderAbstract.ts
+++ b/front/src/applications/operationalStudies/helpers/TrainProjectionLazyLoaderAbstract.ts
@@ -3,7 +3,6 @@ import {
   type SpaceTimeCurve,
   type CoreTrainPath,
 } from 'common/api/osrdEditoastApi';
-import type { TimetableItemId } from 'reducers/osrdconf/types';
 import type { AppDispatch } from 'store';
 
 const BATCH_SIZE = 20;
@@ -22,13 +21,13 @@ export type TrainProjectionLazyLoaderOptions = {
   infraId: number;
   path?: CoreTrainPath;
   electricalProfileSetId?: number;
-  onProgress: (results: Map<TimetableItemId, ProjectionResult>) => void;
+  onProgress: (results: Map<number, ProjectionResult>) => void;
 };
 
 export default abstract class TrainProjectionLazyLoaderAbstract {
   readonly options: TrainProjectionLazyLoaderOptions;
 
-  pending: TimetableItemId[] = [];
+  pending: number[] = [];
 
   prevPromise: Promise<void> = Promise.resolve();
 
@@ -38,7 +37,7 @@ export default abstract class TrainProjectionLazyLoaderAbstract {
     this.options = options;
   }
 
-  projectTimetableItems(ids: TimetableItemId[]) {
+  projectTimetableItems(ids: number[]) {
     if (this.cancelled) {
       throw new Error('projectTimetableItems() called after cancel()');
     }
@@ -59,5 +58,5 @@ export default abstract class TrainProjectionLazyLoaderAbstract {
     }
   }
 
-  abstract processBatch(batch: TimetableItemId[]): Promise<void>;
+  abstract processBatch(batch: number[]): Promise<void>;
 }

--- a/front/src/applications/operationalStudies/helpers/TrainSimulationLazyLoader.ts
+++ b/front/src/applications/operationalStudies/helpers/TrainSimulationLazyLoader.ts
@@ -3,9 +3,7 @@ import {
   type TrainScheduleSimulationSummaryResult,
   type PostTrainSchedulesSimulationSummaryApiResponse,
 } from 'common/api/osrdEditoastApi';
-import type { PacedTrainId, TimetableItemId } from 'reducers/osrdconf/types';
 import type { AppDispatch } from 'store';
-import { formatEditoastIdToPacedTrainId, extractEditoastIdFromPacedTrainId } from 'utils/trainId';
 
 const BATCH_SIZE = 20;
 
@@ -13,9 +11,7 @@ type TrainSimulationLazyLoaderOptions = {
   dispatch: AppDispatch;
   infraId: number;
   electricalProfileSetId?: number;
-  onProgress: (
-    pacedTrainSummaries: Map<PacedTrainId, TrainScheduleSimulationSummaryResult>
-  ) => void;
+  onProgress: (pacedTrainSummaries: Map<number, TrainScheduleSimulationSummaryResult>) => void;
 };
 
 /**
@@ -28,7 +24,7 @@ type TrainSimulationLazyLoaderOptions = {
 export default class TrainSimulationLazyLoader {
   readonly options: TrainSimulationLazyLoaderOptions;
 
-  pending: TimetableItemId[] = [];
+  pending: number[] = [];
 
   prevPromise: Promise<void> = Promise.resolve();
 
@@ -44,7 +40,7 @@ export default class TrainSimulationLazyLoader {
   /**
    * Queue train IDs for simulation.
    */
-  simulateTimetableItems(ids: TimetableItemId[]) {
+  simulateTimetableItems(ids: number[]) {
     if (this.cancelled) {
       throw new Error('simulateTimetableItems() called after cancel()');
     }
@@ -69,19 +65,17 @@ export default class TrainSimulationLazyLoader {
     }
   }
 
-  async processBatch(batch: TimetableItemId[]) {
-    const editoastIds = batch.map((id) => extractEditoastIdFromPacedTrainId(id));
-
+  async processBatch(ids: number[]) {
     let pacedTrainPromise: Promise<PostTrainSchedulesSimulationSummaryApiResponse> =
       Promise.resolve({});
-    if (editoastIds.length > 0) {
+    if (ids.length > 0) {
       pacedTrainPromise = this.options
         .dispatch(
           osrdEditoastApi.endpoints.postTrainSchedulesSimulationSummary.initiate(
             {
               body: {
                 infra_id: this.options.infraId,
-                ids: editoastIds,
+                ids,
                 electrical_profile_set_id: this.options.electricalProfileSetId,
               },
             },
@@ -98,9 +92,8 @@ export default class TrainSimulationLazyLoader {
     }
 
     const pacedTrainSummaries = new Map();
-    for (const [rawId, rawSummary] of Object.entries(rawPacedTrainSummaries)) {
-      const id = formatEditoastIdToPacedTrainId(Number(rawId));
-      pacedTrainSummaries.set(id, rawSummary);
+    for (const [id, rawSummary] of Object.entries(rawPacedTrainSummaries)) {
+      pacedTrainSummaries.set(Number(id), rawSummary);
     }
 
     this.options.onProgress(pacedTrainSummaries);

--- a/front/src/applications/operationalStudies/helpers/TrainTrackProjectionLazyLoader.ts
+++ b/front/src/applications/operationalStudies/helpers/TrainTrackProjectionLazyLoader.ts
@@ -6,8 +6,6 @@ import {
   type PostTrainSchedulesOccupancyBlocksApiResponse,
   type CoreTrainPath,
 } from 'common/api/osrdEditoastApi';
-import type { TimetableItemId } from 'reducers/osrdconf/types';
-import { extractEditoastIdFromPacedTrainId, formatEditoastIdToPacedTrainId } from 'utils/trainId';
 
 import TrainProjectionLazyLoaderAbstract from './TrainProjectionLazyLoaderAbstract';
 import type {
@@ -33,15 +31,13 @@ export default class TrainTrackProjectionLazyLoader extends TrainProjectionLazyL
     super(options);
   }
 
-  async processBatch(batch: TimetableItemId[]) {
+  async processBatch(ids: number[]) {
     const { infraId, path, electricalProfileSetId } = this.options;
-
-    const editoastIds = batch.map((id) => extractEditoastIdFromPacedTrainId(id));
 
     let pacedTrainPromise: Promise<PostTrainSchedulesProjectPathApiResponse> = Promise.resolve({});
     let trainSchedulesOccupancyBlocksPromise: Promise<PostTrainSchedulesOccupancyBlocksApiResponse> =
       Promise.resolve({});
-    if (editoastIds.length > 0) {
+    if (ids.length > 0) {
       pacedTrainPromise = this.options
         .dispatch(
           osrdEditoastApi.endpoints.postTrainSchedulesProjectPath.initiate(
@@ -49,7 +45,7 @@ export default class TrainTrackProjectionLazyLoader extends TrainProjectionLazyL
               projectPathForm: {
                 infra_id: infraId,
                 track_section_ranges: path.track_section_ranges,
-                ids: editoastIds,
+                ids,
                 electrical_profile_set_id: electricalProfileSetId,
               },
             },
@@ -65,7 +61,7 @@ export default class TrainTrackProjectionLazyLoader extends TrainProjectionLazyL
               occupancyBlockForm: {
                 infra_id: infraId,
                 path,
-                ids: editoastIds,
+                ids,
                 electrical_profile_set_id: electricalProfileSetId,
               },
             },
@@ -82,10 +78,9 @@ export default class TrainTrackProjectionLazyLoader extends TrainProjectionLazyL
       return;
     }
 
-    const rawResults = new Map<TimetableItemId, ProjectionResult>();
+    const rawResults = new Map<number, ProjectionResult>();
 
     for (const [id, result] of Object.entries(rawPacedTrainResults)) {
-      const pacedTrainId = formatEditoastIdToPacedTrainId(Number(id));
       const pacedTrainProjectionResult: ProjectionResult = {
         space_time_curves: result.train_schedule,
         signal_updates: rawTrainSchedulesOccupancyBlocks[id].train_schedule,
@@ -101,7 +96,7 @@ export default class TrainTrackProjectionLazyLoader extends TrainProjectionLazyL
         }
       }
 
-      rawResults.set(pacedTrainId, pacedTrainProjectionResult);
+      rawResults.set(Number(id), pacedTrainProjectionResult);
     }
 
     this.options.onProgress(rawResults);

--- a/front/src/applications/operationalStudies/helpers/upsertNewProjectedTrains.ts
+++ b/front/src/applications/operationalStudies/helpers/upsertNewProjectedTrains.ts
@@ -1,14 +1,14 @@
 import type { BaseTrainProjection, TrainSpaceTimeData } from 'modules/simulationResult/types';
-import type { TimetableItem, TimetableItemId } from 'reducers/osrdconf/types';
+import type { TimetableItem } from 'reducers/osrdconf/types';
 import { Duration } from 'utils/duration';
 
 import type { ProjectionResult } from './TrainProjectionLazyLoaderAbstract';
 
 /** Formats ProjectionResult into TrainSpaceTimeData and upsert into previous projectedTrains */
 const upsertNewProjectedTrains = (
-  projectedTrains: Map<TimetableItemId, TrainSpaceTimeData>,
-  projectedTrainsToUpsert: Map<TimetableItemId, ProjectionResult>,
-  timetableItemsById: Map<TimetableItemId, TimetableItem>
+  projectedTrains: Map<number, TrainSpaceTimeData>,
+  projectedTrainsToUpsert: Map<number, ProjectionResult>,
+  timetableItemsById: Map<number, TimetableItem>
 ) => {
   const newProjectedTrains = new Map(projectedTrains);
 

--- a/front/src/applications/operationalStudies/hooks/useAutoSelectTrainIds.ts
+++ b/front/src/applications/operationalStudies/hooks/useAutoSelectTrainIds.ts
@@ -5,7 +5,7 @@ import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
 import { isValidPathfinding } from 'applications/operationalStudies/views/Scenario/components/Timetable/utils';
 import type { TimetableItemWithDetails } from 'modules/timetableItem/types';
-import type { TimetableItemId, TrainId } from 'reducers/osrdconf/types';
+import type { TrainId } from 'reducers/osrdconf/types';
 import { updateSelectedTrainId, updateTrainIdUsedForProjection } from 'reducers/simulationResults';
 import {
   getSelectedTrainId,
@@ -13,7 +13,9 @@ import {
 } from 'reducers/simulationResults/selectors';
 import { useAppDispatch } from 'store';
 import {
+  extractEditoastIdFromPacedTrainId,
   extractPacedTrainIdFromOccurrenceId,
+  formatEditoastIdToPacedTrainId,
   formatPacedTrainIdToIndexedOccurrenceId,
   isOccurrenceId,
   isPacedTrainId,
@@ -35,7 +37,7 @@ type SimulationParams = {
  * currentTrainIdForProjection will still be undefined and must be updated)
  */
 const useAutoSelectTrainIds = (
-  timetableItemIds: TimetableItemId[] | undefined,
+  timetableItemIds: number[] | undefined,
   timetableItemsWithDetails: TimetableItemWithDetails[]
 ) => {
   const dispatch = useAppDispatch();
@@ -128,11 +130,13 @@ const useAutoSelectTrainIds = (
       return;
     }
 
-    let timetableItemId: TimetableItemId | undefined;
+    let timetableItemId: number | undefined;
     if (selectedTrainId) {
-      timetableItemId = !isOccurrenceId(selectedTrainId)
-        ? selectedTrainId
-        : extractPacedTrainIdFromOccurrenceId(selectedTrainId);
+      timetableItemId = extractEditoastIdFromPacedTrainId(
+        !isOccurrenceId(selectedTrainId)
+          ? selectedTrainId
+          : extractPacedTrainIdFromOccurrenceId(selectedTrainId)
+      );
     }
 
     const isSelectedTimetableItemIncluded =
@@ -142,7 +146,7 @@ const useAutoSelectTrainIds = (
     if (timetableItemId && isSelectedTimetableItemIncluded) {
       // if no train is used for the projection, use the selected train
       if (!currentTrainIdForProjection) {
-        dispatch(updateTrainIdUsedForProjection(timetableItemId));
+        dispatch(updateTrainIdUsedForProjection(formatEditoastIdToPacedTrainId(timetableItemId)));
       }
       return;
     }
@@ -155,15 +159,13 @@ const useAutoSelectTrainIds = (
       timetableItemsWithDetails.find((item) => item.summary && isValidPathfinding(item.summary));
 
     if (firstTrainCanBeUsedForProjection) {
-      dispatch(updateTrainIdUsedForProjection(firstTrainCanBeUsedForProjection.id));
+      const pacedTrainId = formatEditoastIdToPacedTrainId(firstTrainCanBeUsedForProjection.id);
+      dispatch(updateTrainIdUsedForProjection(pacedTrainId));
       let newTrainIdToSelect: TrainId;
       if (!firstTrainCanBeUsedForProjection.paced) {
-        newTrainIdToSelect = firstTrainCanBeUsedForProjection.id;
+        newTrainIdToSelect = pacedTrainId;
       } else {
-        newTrainIdToSelect = formatPacedTrainIdToIndexedOccurrenceId(
-          firstTrainCanBeUsedForProjection.id,
-          0
-        );
+        newTrainIdToSelect = formatPacedTrainIdToIndexedOccurrenceId(pacedTrainId, 0);
       }
       dispatch(updateSelectedTrainId(newTrainIdToSelect));
     }

--- a/front/src/applications/operationalStudies/hooks/useLazySimulateTrains.ts
+++ b/front/src/applications/operationalStudies/hooks/useLazySimulateTrains.ts
@@ -6,7 +6,7 @@ import type {
 } from 'common/api/osrdEditoastApi';
 import formatTimetableItemSummaries from 'modules/simulationResult/helpers/formatTimetableItemSummaries';
 import type { TimetableItemWithDetails } from 'modules/timetableItem/types';
-import type { TimetableItemId, TimetableItem, PacedTrainId } from 'reducers/osrdconf/types';
+import type { TimetableItem } from 'reducers/osrdconf/types';
 import { useAppDispatch } from 'store';
 
 import TrainSimulationLazyLoader from '../helpers/TrainSimulationLazyLoader';
@@ -15,7 +15,7 @@ type UseLazySimulateTrainsOptions = {
   infraId: number;
   electricalProfileSetId: number | undefined;
   rollingStocks: LightRollingStockWithLiveries[] | null;
-  onProgress?: (results: Map<TimetableItemId, TimetableItemWithDetails>) => void;
+  onProgress?: (results: Map<number, TimetableItemWithDetails>) => void;
 };
 
 /**
@@ -41,9 +41,9 @@ export default function useLazySimulateTrains({
 }: UseLazySimulateTrainsOptions) {
   const dispatch = useAppDispatch();
   const loaderRef = useRef<TrainSimulationLazyLoader>(null);
-  const timetableItemsByIdRef = useRef<Map<TimetableItemId, TimetableItem>>(new Map());
+  const timetableItemsByIdRef = useRef<Map<number, TimetableItem>>(new Map());
   const [simulatedTrainsById, setSimulatedTrainsById] = useState<
-    Map<TimetableItemId, TimetableItemWithDetails>
+    Map<number, TimetableItemWithDetails>
   >(new Map());
 
   const onProgressRef = useRef<UseLazySimulateTrainsOptions['onProgress']>(null);
@@ -56,9 +56,7 @@ export default function useLazySimulateTrains({
       dispatch,
       infraId,
       electricalProfileSetId,
-      onProgress: (
-        pacedTrainSummaries: Map<PacedTrainId, TrainScheduleSimulationSummaryResult>
-      ) => {
+      onProgress: (pacedTrainSummaries: Map<number, TrainScheduleSimulationSummaryResult>) => {
         const summaries = formatTimetableItemSummaries(
           pacedTrainSummaries,
           timetableItemsByIdRef.current,
@@ -86,7 +84,7 @@ export default function useLazySimulateTrains({
     loaderRef.current?.simulateTimetableItems(timetableItems.map(({ id }) => id));
   }, []);
 
-  const removeSimulatedTimetableItems = useCallback((ids: TimetableItemId[]) => {
+  const removeSimulatedTimetableItems = useCallback((ids: number[]) => {
     for (const id of ids) {
       timetableItemsByIdRef.current.delete(id);
     }
@@ -101,7 +99,7 @@ export default function useLazySimulateTrains({
   }, []);
 
   const updateSimulatedTimetableItemDepartureTime = useCallback(
-    (id: TimetableItemId, newDeparture: Date) => {
+    (id: number, newDeparture: Date) => {
       setSimulatedTrainsById((prev) => {
         const result = prev.get(id);
         if (!result) {

--- a/front/src/applications/operationalStudies/hooks/usePathProjection.ts
+++ b/front/src/applications/operationalStudies/hooks/usePathProjection.ts
@@ -13,7 +13,7 @@ import {
   type OperationalPointReference,
 } from 'common/api/osrdEditoastApi';
 import { getExceptionFromOccurrenceId } from 'modules/timetableItem/helpers/pacedTrain';
-import type { TimetableItemId, TimetableItem } from 'reducers/osrdconf/types';
+import type { TimetableItem } from 'reducers/osrdconf/types';
 import { updateProjectionType } from 'reducers/simulationResults';
 import {
   getProjectionType,
@@ -103,7 +103,7 @@ const pathfindingResultsDiffer = (
 
 const usePathProjection = (
   infraId: number,
-  timetableItemsById: Map<TimetableItemId, TimetableItem>
+  timetableItemsById: Map<number, TimetableItem>
 ): PathProjectionResult | undefined => {
   const { t } = useTranslation('operational-studies');
   const trainIdUsedForProjection = useSelector(getTrainIdUsedForProjection);
@@ -148,10 +148,13 @@ const usePathProjection = (
   const pathUsedForProjection = useMemo(() => {
     if (!trainIdUsedForProjection) return undefined;
     if (!isOccurrenceId(trainIdUsedForProjection)) {
-      return timetableItemsById.get(trainIdUsedForProjection)?.path;
+      return timetableItemsById.get(extractEditoastIdFromPacedTrainId(trainIdUsedForProjection))
+        ?.path;
     }
     const pacedTrain = timetableItemsById.get(
-      extractPacedTrainIdFromOccurrenceId(trainIdUsedForProjection)
+      extractEditoastIdFromPacedTrainId(
+        extractPacedTrainIdFromOccurrenceId(trainIdUsedForProjection)
+      )
     );
     const exception = getExceptionFromOccurrenceId(timetableItemsById, trainIdUsedForProjection);
     return exception?.path_and_schedule?.path ?? pacedTrain!.path;

--- a/front/src/applications/operationalStudies/hooks/useScenarioData.ts
+++ b/front/src/applications/operationalStudies/hooks/useScenarioData.ts
@@ -7,9 +7,8 @@ import { osrdEditoastApi, type ScenarioWithDetails } from 'common/api/osrdEditoa
 import { useRollingStockContext } from 'common/RollingStockContext';
 import useLazyProjectTrains from 'modules/simulationResult/components/SpaceTimeChartWrapper/useLazyProjectTrains';
 import { formatPacedTrainWithDetails } from 'modules/timetableItem/helpers/formatTimetableItemWithDetails';
-import type { TimetableItemId, TimetableItem } from 'reducers/osrdconf/types';
+import type { TimetableItem } from 'reducers/osrdconf/types';
 import { useAppDispatch } from 'store';
-import { formatEditoastIdToPacedTrainId, extractEditoastIdFromPacedTrainId } from 'utils/trainId';
 import { mapBy } from 'utils/types';
 
 import useAutoSelectTrainIds from './useAutoSelectTrainIds';
@@ -19,15 +18,15 @@ import { useScenarioContext } from './useScenarioContext';
 
 type ScenarioBroadcastMessage =
   | { type: 'upsertTimetableItems'; timetableItems: TimetableItem[] }
-  | { type: 'removeTimetableItems'; timetableItemIds: TimetableItemId[] }
-  | { type: 'setTimetableItemDepartureTime'; timetableItemId: TimetableItemId; newDeparture: Date };
+  | { type: 'removeTimetableItems'; timetableItemIds: number[] }
+  | { type: 'setTimetableItemDepartureTime'; timetableItemId: number; newDeparture: Date };
 
 const useScenarioData = (scenario: ScenarioWithDetails, infraId: number) => {
   const dispatch = useAppDispatch();
 
   const [timetableItems, setTimetableItems] = useState<TimetableItem[]>();
   const timetableItemsById = useMemo(() => mapBy(timetableItems, 'id'), [timetableItems]);
-  const [selectedTimetableItemIds, setSelectedTimetableItemIds] = useState<TimetableItemId[]>([]);
+  const [selectedTimetableItemIds, setSelectedTimetableItemIds] = useState<number[]>([]);
 
   const [updateTrainSchedule] = osrdEditoastApi.endpoints.putTrainSchedulesById.useMutation();
 
@@ -44,12 +43,7 @@ const useScenarioData = (scenario: ScenarioWithDetails, infraId: number) => {
     );
 
     const fetchTimetableItems = async () => {
-      const rawPacedTrains = (await pacedTrainsResult.unwrap()) ?? [];
-
-      const pacedTrains = rawPacedTrains.map((pacedTrain) => ({
-        ...pacedTrain,
-        id: formatEditoastIdToPacedTrainId(pacedTrain.id),
-      }));
+      const pacedTrains = (await pacedTrainsResult.unwrap()) ?? [];
 
       setTimetableItems(sortBy(pacedTrains, 'start_time'));
     };
@@ -153,7 +147,7 @@ const useScenarioData = (scenario: ScenarioWithDetails, infraId: number) => {
     []
   );
 
-  const removeTimetableItems = useCallback((_timetableItemsToRemove: TimetableItemId[]) => {
+  const removeTimetableItems = useCallback((_timetableItemsToRemove: number[]) => {
     setTimetableItems((prev) => {
       const prevTimetableItemsById = mapBy(prev, 'id');
       _timetableItemsToRemove.forEach((timetableItemId) => {
@@ -171,7 +165,7 @@ const useScenarioData = (scenario: ScenarioWithDetails, infraId: number) => {
   }, []);
 
   const setTimetableItemDepartureTime = useCallback(
-    (timetableItemId: TimetableItemId, newDeparture: Date) => {
+    (timetableItemId: number, newDeparture: Date) => {
       setTimetableItems((prev) => {
         const timetableItem = prev?.find((item) => item.id === timetableItemId);
         if (!timetableItem) {
@@ -196,16 +190,14 @@ const useScenarioData = (scenario: ScenarioWithDetails, infraId: number) => {
 
   /** Update only departure time of a timetable item */
   const updateTrainDepartureTime = useCallback(
-    async (timetableItemId: TimetableItemId, newDeparture: Date) => {
+    async (timetableItemId: number, newDeparture: Date) => {
       const timetableItem = timetableItems?.find((item) => item.id === timetableItemId);
       if (!timetableItem) {
         throw new Error(`Timetable item "${timetableItemId}" not found`);
       }
 
-      const editoastPacedTrainId = extractEditoastIdFromPacedTrainId(timetableItem.id);
-
       await updateTrainSchedule({
-        id: editoastPacedTrainId,
+        id: timetableItem.id,
         trainSchedule: {
           ...timetableItem,
           start_time: newDeparture.toISOString(),
@@ -229,7 +221,7 @@ const useScenarioData = (scenario: ScenarioWithDetails, infraId: number) => {
   );
 
   const removeTimetableItemsWithBroadcast = useCallback(
-    (ids: TimetableItemId[]) => {
+    (ids: number[]) => {
       removeTimetableItems(ids);
       broadcastScenarioMessage({
         type: 'removeTimetableItems',
@@ -240,7 +232,7 @@ const useScenarioData = (scenario: ScenarioWithDetails, infraId: number) => {
   );
 
   const updateTrainDepartureTimeWithBroadcast = useCallback(
-    async (timetableItemId: TimetableItemId, newDeparture: Date) => {
+    async (timetableItemId: number, newDeparture: Date) => {
       await updateTrainDepartureTime(timetableItemId, newDeparture);
       broadcastScenarioMessage({
         type: 'setTimetableItemDepartureTime',

--- a/front/src/applications/operationalStudies/hooks/useScenarioTrainScheduleSet.ts
+++ b/front/src/applications/operationalStudies/hooks/useScenarioTrainScheduleSet.ts
@@ -12,7 +12,6 @@ import { createPacedTrains } from 'modules/timetableItem/helpers/updateTimetable
 import type { PacedTrainWithDetails, TimetableItemWithDetails } from 'modules/timetableItem/types';
 import type { TimetableItem } from 'reducers/osrdconf/types';
 import { useAppDispatch } from 'store';
-import { formatEditoastIdToPacedTrainId } from 'utils/trainId';
 
 import { useScenarioContext } from './useScenarioContext';
 import type { TrainScheduleSetImportType } from '../views/Scenario/components/ImportTrainScheduleSets/types';
@@ -280,11 +279,7 @@ export default function useScenarioTrainScheduleSet(
             id: item.trainScheduleSet.id,
           }).unwrap();
 
-          const formattedTrains = referencedPacedTrains.map((train) => ({
-            ...train,
-            id: formatEditoastIdToPacedTrainId(train.id),
-          }));
-          allTrainsToUpsert.push(...formattedTrains);
+          allTrainsToUpsert.push(...referencedPacedTrains);
         } else {
           // For copy imports, create a new train schedule set and copy the trains
           const sourcePacedTrains = await getTrainScheduleSetTrainSchedules({

--- a/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
+++ b/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
@@ -15,7 +15,11 @@ import useSelectedTimetableItem from 'modules/timetableItem/hooks/useSelectedTim
 import type { Train } from 'reducers/osrdconf/types';
 import { getSelectedTrainId } from 'reducers/simulationResults/selectors';
 import { Duration } from 'utils/duration';
-import { extractOccurrenceIndexFromOccurrenceId, isOccurrenceId } from 'utils/trainId';
+import {
+  extractOccurrenceIndexFromOccurrenceId,
+  formatEditoastIdToPacedTrainId,
+  isOccurrenceId,
+} from 'utils/trainId';
 
 import type { SimulationResults } from '../types';
 import { preparePathPropertiesData } from '../utils';
@@ -38,7 +42,7 @@ const useSimulationResults = (): {
   const train: Train | undefined = useMemo(() => {
     if (!selectedTrainId || !timetableItem) return undefined;
     if (!isOccurrenceId(selectedTrainId) || !timetableItem.paced) {
-      return timetableItem;
+      return { ...timetableItem, id: formatEditoastIdToPacedTrainId(timetableItem.id) };
     }
 
     const exception = findExceptionWithOccurrenceId(

--- a/front/src/applications/operationalStudies/types.ts
+++ b/front/src/applications/operationalStudies/types.ts
@@ -22,7 +22,7 @@ import type {
 import type { RangedValue } from 'common/types';
 import type { PathOperationalPoint } from 'modules/simulationResult/types';
 import type { SuggestedOP } from 'modules/timetableItem/types';
-import type { Train, TimetableItemWithPathOps, PacedTrainId } from 'reducers/osrdconf/types';
+import type { Train, TimetableItemWithPathOps } from 'reducers/osrdconf/types';
 import type { Duration } from 'utils/duration';
 import type { ArrayElement } from 'utils/types';
 
@@ -41,7 +41,7 @@ export type PacedTrainWithPaced = Omit<TrainScheduleResponse, 'id' | 'paced'> & 
 };
 
 export type PacedTrainResponseWithPaced = PacedTrainWithPaced & {
-  id: PacedTrainId;
+  id: number;
 };
 
 export type PacedTrainFromJson = Omit<TrainSchedule, 'category'> & {

--- a/front/src/applications/operationalStudies/utils.ts
+++ b/front/src/applications/operationalStudies/utils.ts
@@ -18,15 +18,10 @@ import type {
 import getPathVoltages from 'modules/pathfinding/helpers/getPathVoltages';
 import { isPacedTrain } from 'modules/timetableItem/helpers/pacedTrain';
 import type { SimulationSummary } from 'modules/timetableItem/types';
-import type {
-  TimetableItem,
-  TimetableItemId,
-  TimetableItemWithPathOps,
-} from 'reducers/osrdconf/types';
+import type { TimetableItem, TimetableItemWithPathOps } from 'reducers/osrdconf/types';
 import { Duration } from 'utils/duration';
 import { mmToM } from 'utils/physics';
 import { SMALL_INPUT_MAX_LENGTH } from 'utils/strings';
-import { formatEditoastIdToPacedTrainId } from 'utils/trainId';
 
 import { upsertMapWaypointsInOperationalPoints } from './helpers/upsertMapWaypointsInOperationalPoints';
 import type {
@@ -400,14 +395,11 @@ export const checkRoundTripCompatible = (
  * Group timetable items in three columns: one-ways, round-trips and others.
  */
 export const groupRoundTrips = (
-  timetableItemsById: Map<TimetableItemId, TimetableItemWithPathOps>,
+  timetableItemsById: Map<number, TimetableItemWithPathOps>,
   rawRoundTrips?: RoundTrips
 ): TimetableItemRoundTripGroups => {
-  const oneWayIds = (rawRoundTrips?.one_ways ?? []).map(formatEditoastIdToPacedTrainId);
-  const roundTripIds = (rawRoundTrips?.round_trips ?? []).map(
-    ([leftId, rightId]) =>
-      [formatEditoastIdToPacedTrainId(leftId), formatEditoastIdToPacedTrainId(rightId)] as const
-  );
+  const oneWayIds = rawRoundTrips?.one_ways ?? [];
+  const roundTripIds = rawRoundTrips?.round_trips ?? [];
 
   const oneWays = oneWayIds.map((id) => timetableItemsById.get(id)!);
   const roundTrips = roundTripIds.map(
@@ -415,7 +407,7 @@ export const groupRoundTrips = (
       [timetableItemsById.get(leftId)!, timetableItemsById.get(rightId)!] as const
   );
 
-  const oneWayOrRoundTripIds = new Set<TimetableItemId>([...oneWayIds, ...roundTripIds.flat()]);
+  const oneWayOrRoundTripIds = new Set<number>([...oneWayIds, ...roundTripIds.flat()]);
   const others = [...timetableItemsById.values()].filter(
     (timetableItem) => !oneWayOrRoundTripIds.has(timetableItem.id)
   );

--- a/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/__tests__/generatePayloads.spec.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/__tests__/generatePayloads.spec.ts
@@ -1,28 +1,17 @@
 import { describe, it, expect } from 'vitest';
 
-import type { PacedTrainId } from 'reducers/osrdconf/types';
-import { extractEditoastIdFromPacedTrainId } from 'utils/trainId';
-
 import { generateRoundTripsPayload } from '../generatePayloads';
 
 describe('generateRoundTripsPayload', () => {
   it('correctly generates payload for a mix of one-ways and round-trips paced trains', () => {
-    const pacedTrains = [
-      { id: 'paced_101' as PacedTrainId },
-      { id: 'paced_102' as PacedTrainId },
-      { id: 'paced_103' as PacedTrainId },
-    ];
+    const pacedTrains = [{ id: 101 }, { id: 102 }, { id: 103 }];
 
     const pacedTrainIndexes: ([number, number] | [number, null])[] = [
       [0, 2],
       [1, null],
     ];
 
-    const trainSchedulePayload = generateRoundTripsPayload(
-      pacedTrainIndexes,
-      pacedTrains,
-      extractEditoastIdFromPacedTrainId
-    );
+    const trainSchedulePayload = generateRoundTripsPayload(pacedTrainIndexes, pacedTrains);
 
     expect(trainSchedulePayload).toEqual({
       roundTrips: {
@@ -32,12 +21,7 @@ describe('generateRoundTripsPayload', () => {
     });
   });
 
-  const pacedTrains = [
-    { id: 'paced_7' as PacedTrainId },
-    { id: 'paced_8' as PacedTrainId },
-    { id: 'paced_9' as PacedTrainId },
-    { id: 'paced_15' as PacedTrainId },
-  ];
+  const pacedTrains = [{ id: 7 }, { id: 8 }, { id: 9 }, { id: 15 }];
 
   it('correctly generates payload for only one-ways paced trains', () => {
     const oneWayPacedIndexes: ([number, number] | [number, null])[] = [
@@ -47,11 +31,7 @@ describe('generateRoundTripsPayload', () => {
       [3, null],
     ];
 
-    const oneWayPayload = generateRoundTripsPayload(
-      oneWayPacedIndexes,
-      pacedTrains,
-      extractEditoastIdFromPacedTrainId
-    );
+    const oneWayPayload = generateRoundTripsPayload(oneWayPacedIndexes, pacedTrains);
 
     expect(oneWayPayload).toEqual({
       roundTrips: {
@@ -67,11 +47,7 @@ describe('generateRoundTripsPayload', () => {
       [0, 3],
     ];
 
-    const roundTripsPayload = generateRoundTripsPayload(
-      roundTripsPacedIndexes,
-      pacedTrains,
-      extractEditoastIdFromPacedTrainId
-    );
+    const roundTripsPayload = generateRoundTripsPayload(roundTripsPacedIndexes, pacedTrains);
 
     expect(roundTripsPayload).toEqual({
       roundTrips: {

--- a/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/__tests__/parseJson.spec.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/__tests__/parseJson.spec.ts
@@ -20,8 +20,8 @@ const buildTrainSchedule = (overrides: Record<string, unknown> = {}) => ({
 });
 
 describe('processJsonFile', () => {
-  const train0 = buildTrainSchedule({ train_name: 'train_0', id: 'paced_0' });
-  const train1 = buildTrainSchedule({ train_name: 'train_1', id: 'paced_1' });
+  const train0 = buildTrainSchedule({ train_name: 'train_0', id: 0 });
+  const train1 = buildTrainSchedule({ train_name: 'train_1', id: 1 });
 
   describe('Export/Import of timetable', () => {
     it('Should export and import timetable', () => {

--- a/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/generatePayloads.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/generatePayloads.ts
@@ -8,22 +8,18 @@ import type {
 import { TrainMainCategoryDict } from 'modules/rollingStock/consts';
 import isMainCategory from 'modules/rollingStock/helpers/category';
 
-export const generateRoundTripsPayload = <T>(
+export const generateRoundTripsPayload = (
   roundTripsIndexes: ([number, number] | [number, null])[],
-  trainIds: { id: T }[],
-  extractEditoastIdFromRoundTripId: (trainId: T) => number
+  trainIds: { id: number }[]
 ) => {
   const trainScheduleOneWays: number[] = [];
   const trainScheduleRoundTrips: [number, number][] = [];
 
   for (const [firstIndex, secondIndex] of roundTripsIndexes) {
     if (secondIndex === null) {
-      trainScheduleOneWays.push(extractEditoastIdFromRoundTripId(trainIds[firstIndex].id));
+      trainScheduleOneWays.push(trainIds[firstIndex].id);
     } else {
-      trainScheduleRoundTrips.push([
-        extractEditoastIdFromRoundTripId(trainIds[firstIndex].id),
-        extractEditoastIdFromRoundTripId(trainIds[secondIndex].id),
-      ]);
+      trainScheduleRoundTrips.push([trainIds[firstIndex].id, trainIds[secondIndex].id]);
     }
   }
   return {

--- a/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/postPayloads.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/postPayloads.ts
@@ -10,7 +10,6 @@ import { createPacedTrains } from 'modules/timetableItem/helpers/updateTimetable
 import { setWarning, setFailure } from 'reducers/main';
 import type { TimetableItem } from 'reducers/osrdconf/types';
 import type { AppDispatch } from 'store';
-import { extractEditoastIdFromPacedTrainId } from 'utils/trainId';
 
 import { generateRoundTripsPayload, generateTrainPayloads } from './generatePayloads';
 
@@ -22,8 +21,7 @@ const postRoundTrips = async (
   if (roundTrips.length > 0) {
     const payload = generateRoundTripsPayload(
       roundTrips,
-      formattedPacedTrains,
-      extractEditoastIdFromPacedTrainId
+      formattedPacedTrains.map(({ id }) => ({ id }))
     );
     await dispatch(
       osrdEditoastApi.endpoints.postRoundTripsTrainSchedules.initiate(payload)

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/MacroEditorState.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/MacroEditorState.ts
@@ -5,7 +5,6 @@ import type {
   OperationalPoint,
   PathItemLocation,
 } from 'common/api/osrdEditoastApi';
-import type { TimetableItemId } from 'reducers/osrdconf/types';
 
 import type { TrainrunCategory, TrainrunFrequency } from '../NGE/types';
 
@@ -81,7 +80,7 @@ export default class MacroEditorState {
   /**
    * Given a NGE `Trainrun.id`, returns the OSRD `TimetableItemId`.
    */
-  timetableItemIdByNgeId: Map<number, [TimetableItemId, TimetableItemId | null]>;
+  timetableItemIdByNgeId: Map<number, [number, number | null]>;
 
   /**
    * Default constructor

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/ngeToOsrd/ngeToOsrd.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/ngeToOsrd/ngeToOsrd.ts
@@ -3,7 +3,7 @@ import type {
   TimetableJsonPayload,
 } from 'applications/operationalStudies/types';
 import { type MacroNodeForm } from 'common/api/osrdEditoastApi';
-import type { TimetableItemId, TimetableItem } from 'reducers/osrdconf/types';
+import type { TimetableItem } from 'reducers/osrdconf/types';
 import type { AppDispatch } from 'store';
 
 import type { NetzgrafikDto, NGEEvent, NodeDto, LabelDto } from '../../NGE/types';
@@ -40,7 +40,7 @@ const handleLabelOperation = async ({
   state: MacroEditorState;
   dispatch: AppDispatch;
   addUpsertedTimetableItems: (timetableItems: TimetableItem[]) => void;
-  addDeletedTimetableItemIds: (timetableItemIds: TimetableItemId[]) => void;
+  addDeletedTimetableItemIds: (timetableItemIds: number[]) => void;
 }) => {
   const { trainruns } = netzgrafikDto;
   switch (type) {
@@ -85,7 +85,7 @@ export const handleOperation = async ({
   state: MacroEditorState;
   dispatch: AppDispatch;
   addUpsertedTimetableItems: (timetableItems: TimetableItem[]) => void;
-  addDeletedTimetableItemIds: (timetableItemsIds: TimetableItemId[]) => void;
+  addDeletedTimetableItemIds: (timetableItemsIds: number[]) => void;
 }) => {
   const { type } = event;
   switch (event.objectType) {

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/ngeToOsrd/node.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/ngeToOsrd/node.ts
@@ -1,4 +1,4 @@
-import type { TimetableItem, TimetableItemId } from 'reducers/osrdconf/types';
+import type { TimetableItem } from 'reducers/osrdconf/types';
 import type { AppDispatch } from 'store';
 
 import type { NetzgrafikDto, NGEEvent, NodeDto } from '../../NGE/types';
@@ -55,7 +55,7 @@ export const handleNodeOperation = async ({
   infraId: number;
   trainScheduleSetId: number;
   addUpsertedTimetableItems: (timetableItems: TimetableItem[]) => void;
-  addDeletedTimetableItemIds: (timetableItemIds: TimetableItemId[]) => void;
+  addDeletedTimetableItemIds: (timetableItemIds: number[]) => void;
 }): Promise<void> => {
   const indexNode = state.getNodeByNgeId(node.id);
   switch (type) {

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/ngeToOsrd/trainrun.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/ngeToOsrd/trainrun.ts
@@ -11,10 +11,9 @@ import {
   fetchTimetableItem,
   storePacedTrain,
 } from 'modules/timetableItem/helpers/updateTimetableItemHelpers';
-import type { TimetableItem, TimetableItemId, PacedTrainId } from 'reducers/osrdconf/types';
+import type { TimetableItem } from 'reducers/osrdconf/types';
 import type { AppDispatch } from 'store';
 import { Duration } from 'utils/duration';
-import { isPacedTrainId } from 'utils/trainId';
 
 import { checkChangeGroups } from '../../ManageTimetableItem/helpers/buildPacedTrainException';
 import type {
@@ -449,7 +448,7 @@ const handleCreateTimetableItem = async (
   }
   addUpsertedTimetableItems(newTimetableItems);
 
-  const newTrainIds: [PacedTrainId, PacedTrainId | null] = [
+  const newTrainIds: [number, number | null] = [
     newTimetableItems[0].id,
     newTimetableItems.at(1)?.id ?? null,
   ];
@@ -458,12 +457,11 @@ const handleCreateTimetableItem = async (
 };
 
 const deleteTimetableItemById = async (
-  timetableItemId: TimetableItemId,
+  timetableItemId: number,
   dispatch: AppDispatch,
-  addDeletedTimetableItemIds: (timetableItemIds: TimetableItemId[]) => void
+  addDeletedTimetableItemIds: (timetableItemIds: number[]) => void
 ) => {
-  if (isPacedTrainId(timetableItemId)) await deleteTrainSchedules(dispatch, [timetableItemId]);
-  else throw new Error('TrainSchedules are not handled anymore.');
+  await deleteTrainSchedules(dispatch, [timetableItemId]);
 
   addDeletedTimetableItemIds([timetableItemId]);
 };
@@ -472,7 +470,7 @@ const handleDeleteTimetableItem = async (
   trainrunId: number,
   state: MacroEditorState,
   dispatch: AppDispatch,
-  addDeletedTimetableItemIds: (timetableItemIds: TimetableItemId[]) => void
+  addDeletedTimetableItemIds: (timetableItemIds: number[]) => void
 ) => {
   const timetableItemIds = state.timetableItemIdByNgeId.get(trainrunId);
   for (const timetableItemId of timetableItemIds ?? []) {
@@ -508,7 +506,7 @@ export const handleUpdateTimetableItem = async ({
   state: MacroEditorState;
   dispatch: AppDispatch;
   addUpsertedTimetableItems: (timetableItems: TimetableItem[]) => void;
-  addDeletedTimetableItemIds: (timetableItemIds: TimetableItemId[]) => void;
+  addDeletedTimetableItemIds: (timetableItemIds: number[]) => void;
 }) => {
   const timetableItemIds = state.timetableItemIdByNgeId.get(trainrun.id)!;
   const oldForwardTimetableItem = await fetchTimetableItem(timetableItemIds[0], dispatch);
@@ -664,7 +662,7 @@ export const handleTrainrunOperation = async ({
   state: MacroEditorState;
   dispatch: AppDispatch;
   addUpsertedTimetableItems: (timetableItems: TimetableItem[]) => void;
-  addDeletedTimetableItemIds: (timetableItemIds: TimetableItemId[]) => void;
+  addDeletedTimetableItemIds: (timetableItemIds: number[]) => void;
 }) => {
   const trainrun = netzgrafikDto.trainruns.find((tr) => tr.id === trainrunId);
   switch (type) {
@@ -718,7 +716,7 @@ export const updateTrainrunsByNode = async ({
   infraId: number;
   trainScheduleSetId: number;
   addUpsertedTimetableItems: (timetableItems: TimetableItem[]) => void;
-  addDeletedTimetableItemIds: (timetableItemIds: TimetableItemId[]) => void;
+  addDeletedTimetableItemIds: (timetableItemIds: number[]) => void;
   node: NodeDto;
 }) => {
   const trainrunsById = new Map<number, TrainrunDto>();

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/osrdToNge.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/osrdToNge.ts
@@ -18,7 +18,6 @@ import { isPacedTrain } from 'modules/timetableItem/helpers/pacedTrain';
 import type { TimetableItem, TimetableItemWithPathOps } from 'reducers/osrdconf/types';
 import type { AppDispatch } from 'store';
 import { Duration, addDurationToDate } from 'utils/duration';
-import { formatEditoastIdToPacedTrainId } from 'utils/trainId';
 
 import {
   TRAINRUN_CATEGORY_HALTEZEITEN,
@@ -731,12 +730,9 @@ export const loadNgeDto = async (
       { subscribe: false }
     )
   );
-  const pacedTrains = (await pacedTrainsPromise.unwrap())
-    .filter((pacedTrain) => pacedTrain.path.length >= 2)
-    .map((pacedTrain) => ({
-      ...pacedTrain,
-      id: formatEditoastIdToPacedTrainId(pacedTrain.id),
-    }));
+  const pacedTrains = (await pacedTrainsPromise.unwrap()).filter(
+    (pacedTrain) => pacedTrain.path.length >= 2
+  );
 
   const timetableItems = await fetchTimetableItemPathOps(state.infraId, pacedTrains, dispatch);
 

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/utils.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/utils.ts
@@ -10,10 +10,9 @@ import {
 } from 'common/api/osrdEditoastApi';
 import isMainCategory from 'modules/rollingStock/helpers/category';
 import { isPacedTrain } from 'modules/timetableItem/helpers/pacedTrain';
-import type { TimetableItem, PacedTrainId } from 'reducers/osrdconf/types';
+import type { TimetableItem } from 'reducers/osrdconf/types';
 import type { AppDispatch } from 'store';
 import { Duration } from 'utils/duration';
-import { extractEditoastIdFromPacedTrainId } from 'utils/trainId';
 
 import {
   CUSTOM_TRAINRUN_TIME_CATEGORY,
@@ -89,19 +88,17 @@ export const deleteMacroNodeByNgeId = async (
 
 export const storeRoundTrip = async (
   dispatch: AppDispatch,
-  forwardId: PacedTrainId,
-  returnId?: PacedTrainId
+  forwardId: number,
+  returnId?: number
 ) => {
   let roundTrips;
   if (returnId) {
     roundTrips = {
-      round_trips: [
-        [extractEditoastIdFromPacedTrainId(forwardId), extractEditoastIdFromPacedTrainId(returnId)],
-      ],
+      round_trips: [[forwardId, returnId]],
     };
   } else {
     roundTrips = {
-      one_ways: [extractEditoastIdFromPacedTrainId(forwardId)],
+      one_ways: [forwardId],
     };
   }
   await dispatch(

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/ManageTimetableItemLeftPanel.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/ManageTimetableItemLeftPanel.tsx
@@ -19,7 +19,6 @@ import { getSelectedTrainId } from 'reducers/simulationResults/selectors';
 import { useAppDispatch } from 'store';
 
 import CreateTimetableItemButton from './CreateTimetableItemButton';
-import { isPacedTrainToEditData } from './helpers/formatTimetableItemPayload';
 import useUpdateTimetableItem from './hooks/useUpdateTimetableItem';
 import ItineraryModal from './Itinerary/ItineraryModal';
 import PacedTrainSettings from './PacedTrainSettings';
@@ -69,20 +68,13 @@ const ManageTimetableItemLeftPanel = ({
   );
 
   const getEditLabel = (_itemToEdit: TimetableItemToEditData) => {
-    if (
-      (!isPacedTrainToEditData(_itemToEdit) || !_itemToEdit.originalPacedTrain.paced) &&
-      editingItemType === 'uniqueTrain'
-    ) {
+    if (!_itemToEdit.originalPacedTrain.paced && editingItemType === 'uniqueTrain') {
       return t('updateUniqueTrain');
     }
-    if (
-      isPacedTrainToEditData(_itemToEdit) &&
-      _itemToEdit.originalPacedTrain.paced &&
-      editingItemType !== 'uniqueTrain'
-    ) {
+    if (_itemToEdit.originalPacedTrain.paced && editingItemType !== 'uniqueTrain') {
       return editingItemType === 'pacedTrain' ? t('updatePacedTrain') : t('updateOccurrence');
     }
-    return !isPacedTrainToEditData(_itemToEdit) || !_itemToEdit.originalPacedTrain.paced
+    return !_itemToEdit.originalPacedTrain.paced
       ? t('turnUniqueTrainIntoPacedTrain')
       : t('turnPacedTrainIntoUniqueTrain');
   };
@@ -98,7 +90,6 @@ const ManageTimetableItemLeftPanel = ({
                 type="button"
                 onClick={() => {
                   if (
-                    isPacedTrainToEditData(timetableItemToEditData) &&
                     timetableItemToEditData.originalPacedTrain.paced &&
                     timetableItemToEditData.originalPacedTrain.paced.exceptions.length > 0 &&
                     (osrdConf.timeWindow.toISOString() !==

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/helpers/__tests__/formatTimetableItemPayload.spec.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/helpers/__tests__/formatTimetableItemPayload.spec.ts
@@ -12,7 +12,6 @@ import type {
   IndexedOccurrenceId,
   TimetableItemToEditData,
   OperationalStudiesConfState,
-  PacedTrainId,
 } from 'reducers/osrdconf/types';
 import { Duration } from 'utils/duration';
 
@@ -74,10 +73,10 @@ describe('formatTimetableItemPayload', () => {
   };
   const rollingStockName = 'DUAL-MODE_RS_E2Ee';
   const rawTimetableItemToEditData: {
-    timetableItemId: PacedTrainId;
+    timetableItemId: number;
     originalPacedTrain: PacedTrainWithPacedWithDetails;
   } = {
-    timetableItemId: 'paced_238' as PacedTrainId,
+    timetableItemId: 238,
     originalPacedTrain: {
       category: {
         main_category: 'FREIGHT_TRAIN',
@@ -119,7 +118,7 @@ describe('formatTimetableItemPayload', () => {
       power_restrictions: [],
       schedule: [],
       speed_limit_tag: null,
-      id: 'paced_238' as PacedTrainId,
+      id: 238,
       train_schedule_set_id: 1000,
       name: 'test',
       startTime: new Date('2025-06-02T12:45:00.000Z'),
@@ -279,10 +278,7 @@ describe('formatTimetableItemPayload', () => {
           ...rawOsrdconf,
           ...userChanges,
         };
-        const itemDataWithPREVIOUSLYAddedException: Extract<
-          TimetableItemToEditData,
-          { timetableItemId: PacedTrainId }
-        > = {
+        const itemDataWithPREVIOUSLYAddedException: TimetableItemToEditData = {
           ...rawTimetableItemToEditData,
           originalPacedTrain: {
             ...rawTimetableItemToEditData.originalPacedTrain,

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/helpers/formatTimetableItemPayload.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/helpers/formatTimetableItemPayload.ts
@@ -9,17 +9,9 @@ import {
   isPacedTrainBase,
 } from 'modules/timetableItem/helpers/pacedTrain';
 import type { PacedTrainWithDetails } from 'modules/timetableItem/types';
-import type {
-  TimetableItemToEditData,
-  OperationalStudiesConfState,
-  PacedTrainId,
-} from 'reducers/osrdconf/types';
+import type { TimetableItemToEditData, OperationalStudiesConfState } from 'reducers/osrdconf/types';
 import { kmhToMs } from 'utils/physics';
-import {
-  extractOccurrenceIndexFromOccurrenceId,
-  isIndexedOccurrenceId,
-  isPacedTrainId,
-} from 'utils/trainId';
+import { extractOccurrenceIndexFromOccurrenceId, isIndexedOccurrenceId } from 'utils/trainId';
 
 import {
   generatePacedTrainException,
@@ -90,12 +82,6 @@ export function formatPacedTrainWithDetailsToPacedTrainPayload(
   };
 }
 
-export function isPacedTrainToEditData(
-  timetableItemToEditData: TimetableItemToEditData
-): timetableItemToEditData is Extract<TimetableItemToEditData, { timetableItemId: PacedTrainId }> {
-  return isPacedTrainId(timetableItemToEditData.timetableItemId);
-}
-
 /**
  * Used when creating and editing a paced train
  * @param osrdconf pace train fields that were modified by user
@@ -124,11 +110,7 @@ export function formatPacedTrainPayload(
     },
   };
 
-  if (
-    timetableItemToEditData &&
-    isPacedTrainToEditData(timetableItemToEditData) &&
-    timetableItemToEditData.originalPacedTrain.paced
-  ) {
+  if (timetableItemToEditData && timetableItemToEditData.originalPacedTrain.paced) {
     const originalPacedTrain = formatPacedTrainWithDetailsToPacedTrainPayload(
       timetableItemToEditData.originalPacedTrain
     );

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/hooks/useUpdateTimetableItem.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/hooks/useUpdateTimetableItem.ts
@@ -16,8 +16,10 @@ import { updateSelectedTrainId, updateTrainIdUsedForProjection } from 'reducers/
 import { getTrainIdUsedForProjection } from 'reducers/simulationResults/selectors';
 import { useAppDispatch } from 'store';
 import {
+  extractEditoastIdFromPacedTrainId,
   extractPacedTrainIdFromOccurrenceId,
-  formatPacedTrainIdToIndexedOccurrenceId,
+  formatEditoastIdToIndexedOccurrenceId,
+  formatEditoastIdToPacedTrainId,
   isOccurrenceId,
 } from 'utils/trainId';
 
@@ -74,10 +76,14 @@ const useUpdateTimetableItem = (
     const trainIdToSelect =
       (selectedTrainId &&
         isOccurrenceId(selectedTrainId) &&
-        extractPacedTrainIdFromOccurrenceId(selectedTrainId) === timetableItemId) ||
+        extractEditoastIdFromPacedTrainId(extractPacedTrainIdFromOccurrenceId(selectedTrainId)) ===
+          timetableItemId) ||
       !updatedItem.paced
         ? selectedTrainId
-        : formatPacedTrainIdToIndexedOccurrenceId(updatedItem.id, 0);
+        : formatEditoastIdToIndexedOccurrenceId({
+            pacedTrainId: updatedItem.id,
+            occurrenceIndex: 0,
+          });
 
     // dispatch success and update the selected train id
     dispatch(
@@ -91,13 +97,15 @@ const useUpdateTimetableItem = (
     );
     dispatch(updateSelectedTrainId(trainIdToSelect));
 
-    // if the updated train was used for the projection, update the projectedTrainId
+    // if the updated train was just transformed from pacedTrain to uniqueTrain
+    // and one of the occurrences was used for the projection, update the projectedTrainId
     if (
       trainIdUsedForProjection &&
-      timetableItemId !== updatedItem.id &&
-      trainIdUsedForProjection === timetableItemId
+      isOccurrenceId(trainIdUsedForProjection) &&
+      trainIdUsedForProjection.includes(`_${updatedItem.id}_`) &&
+      !updatedItem.paced
     ) {
-      dispatch(updateTrainIdUsedForProjection(updatedItem.id));
+      dispatch(updateTrainIdUsedForProjection(formatEditoastIdToPacedTrainId(updatedItem.id)));
     }
 
     // close the modal

--- a/front/src/applications/operationalStudies/views/Scenario/components/RoundTrips/RoundTripsModal.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/RoundTrips/RoundTripsModal.tsx
@@ -9,7 +9,7 @@ import useTimetableItemsWithPathOps from 'applications/operationalStudies/hooks/
 import { checkRoundTripCompatible, groupRoundTrips } from 'applications/operationalStudies/utils';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import { useSubCategoryContext } from 'common/SubCategoryContext';
-import type { TimetableItem, TimetableItemId } from 'reducers/osrdconf/types';
+import type { TimetableItem } from 'reducers/osrdconf/types';
 import { useDebounce } from 'utils/hooks/useDebounce';
 import useModalFocusTrap from 'utils/hooks/useModalFocusTrap';
 import { mapBy } from 'utils/types';
@@ -47,7 +47,7 @@ const RoundTripsModal = ({
   const modalRef = useRef<HTMLDialogElement>(null);
 
   const [pairingItems, setPairingItems] = useState<PairingItem[]>([]);
-  const [itemIdToPair, setItemIdToPair] = useState<TimetableItemId>();
+  const [itemIdToPair, setItemIdToPair] = useState<number>();
   const [filter, setFilter] = useState('');
   const debouncedFilter = useDebounce(filter, 300);
 

--- a/front/src/applications/operationalStudies/views/Scenario/components/RoundTrips/RoundTripsModalCard.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/RoundTrips/RoundTripsModalCard.tsx
@@ -11,7 +11,6 @@ import type { OSRDMenuItem } from 'common/OSRDMenu';
 import OSRDMenu from 'common/OSRDMenu';
 import OSRDTooltip from 'common/OSRDTooltip';
 import isMainCategory from 'modules/rollingStock/helpers/category';
-import type { TimetableItemId } from 'reducers/osrdconf/types';
 
 import type { PairDataToolTip, PairingItem } from './types';
 import { getTrainCategoryClassName } from '../Timetable/utils';
@@ -21,7 +20,7 @@ type RoundTripsModalCardProps = {
   isItemToPair?: boolean;
   restoreItems?: () => void;
   moveItemToOneWays?: (item: PairingItem) => void;
-  openPairingMode?: (itemId: TimetableItemId) => void | undefined;
+  openPairingMode?: (itemId: number) => void | undefined;
   isCandidate?: boolean;
   pairData?: PairDataToolTip;
   subCategories: SubCategory[];

--- a/front/src/applications/operationalStudies/views/Scenario/components/RoundTrips/RoundTripsModalPairingColumn.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/RoundTrips/RoundTripsModalPairingColumn.tsx
@@ -5,7 +5,6 @@ import { Filter } from '@osrd-project/ui-icons';
 import { useTranslation } from 'react-i18next';
 
 import type { SubCategory } from 'common/api/osrdEditoastApi';
-import type { TimetableItemId } from 'reducers/osrdconf/types';
 import useOutsideClick from 'utils/hooks/useOutsideClick';
 
 import RoundTripsModalCard from './RoundTripsModalCard';
@@ -16,7 +15,7 @@ type RoundTripsModalPairingColumnProps = {
   suggestions: PairingItem[];
   others: PairingItem[];
   pairItems: (candidate: PairingItem) => void;
-  pairingItemsById: Map<TimetableItemId, PairingItem>;
+  pairingItemsById: Map<number, PairingItem>;
 
   subCategories: SubCategory[];
 };

--- a/front/src/applications/operationalStudies/views/Scenario/components/RoundTrips/TodoColumn.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/RoundTrips/TodoColumn.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { checkRoundTripCompatible } from 'applications/operationalStudies/utils';
 import type { SubCategory } from 'common/api/osrdEditoastApi';
 import { isPacedTrainBase } from 'modules/timetableItem/helpers/pacedTrain';
-import type { TimetableItemId, TimetableItemWithPathOps } from 'reducers/osrdconf/types';
+import type { TimetableItemWithPathOps } from 'reducers/osrdconf/types';
 
 import RoundTripsModalCard from './RoundTripsModalCard';
 import RoundTripsModalPairingColumn from './RoundTripsModalPairingColumn';
@@ -15,10 +15,10 @@ import type { PairingItem } from './types';
 type TodoColumnProps = {
   setPairingItems: React.Dispatch<React.SetStateAction<PairingItem[]>>;
   pairingItems: PairingItem[];
-  itemIdToPair?: TimetableItemId;
-  setItemIdToPair: (itemToPair?: TimetableItemId) => void;
-  timetableItemsWithOpsById: Map<TimetableItemId, TimetableItemWithPathOps>;
-  pairingItemsById: Map<TimetableItemId, PairingItem>;
+  itemIdToPair?: number;
+  setItemIdToPair: (itemToPair?: number) => void;
+  timetableItemsWithOpsById: Map<number, TimetableItemWithPathOps>;
+  pairingItemsById: Map<number, PairingItem>;
   subCategories: SubCategory[];
 };
 
@@ -77,7 +77,7 @@ const TodoColumn = ({
     ]);
   };
 
-  const openPairingMode = (itemId: TimetableItemId) => {
+  const openPairingMode = (itemId: number) => {
     setItemIdToPair(itemId);
   };
 

--- a/front/src/applications/operationalStudies/views/Scenario/components/RoundTrips/__tests__/utils.spec.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/RoundTrips/__tests__/utils.spec.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
 import type { RoundTrips } from 'common/api/osrdEditoastApi';
-import type { PacedTrainId } from 'reducers/osrdconf/types';
 
 import type { PairingItem } from '../types';
 import { buildRoundTripsPayload } from '../utils';
@@ -13,7 +12,7 @@ describe('buildRoundTripsPayload', () => {
   };
 
   const basePairingItems: PairingItem = {
-    id: 'paced_1' as PacedTrainId,
+    id: 1,
     status: 'todo',
     name: 'Train 1',
     category: null,
@@ -30,11 +29,11 @@ describe('buildRoundTripsPayload', () => {
       basePairingItems,
       {
         ...basePairingItems,
-        id: 'paced_2' as PacedTrainId,
+        id: 2,
       },
       {
         ...basePairingItems,
-        id: 'paced_3' as PacedTrainId,
+        id: 3,
       },
     ];
 

--- a/front/src/applications/operationalStudies/views/Scenario/components/RoundTrips/types.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/RoundTrips/types.ts
@@ -1,9 +1,8 @@
 import type { TrainCategory } from 'common/api/osrdEditoastApi';
-import type { TimetableItemId } from 'reducers/osrdconf/types';
 import type { Duration } from 'utils/duration';
 
 export type PairingItem = {
-  id: TimetableItemId;
+  id: number;
   name: string;
   category?: TrainCategory | null;
   interval: Duration | null;
@@ -15,7 +14,7 @@ export type PairingItem = {
 } & (
   | {
       status: 'roundTrips';
-      pairedItemId: TimetableItemId;
+      pairedItemId: number;
       isValidPair: boolean;
     }
   | {

--- a/front/src/applications/operationalStudies/views/Scenario/components/RoundTrips/utils.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/RoundTrips/utils.ts
@@ -10,7 +10,6 @@ import type { OperationalPoint, TrainSchedule, RoundTrips } from 'common/api/osr
 import { isPacedTrain } from 'modules/timetableItem/helpers/pacedTrain';
 import type { TimetableItemWithPathOps } from 'reducers/osrdconf/types';
 import { addDurationToDate, Duration } from 'utils/duration';
-import { extractEditoastIdFromPacedTrainId } from 'utils/trainId';
 
 import type { PairingItem } from './types';
 
@@ -133,22 +132,20 @@ export const buildRoundTripsPayload = (pairingItems: PairingItem[], roundTrips: 
   const roundTripsIds: number[][] = [];
 
   for (const item of pairingItems) {
-    const itemRawId = extractEditoastIdFromPacedTrainId(item.id);
-    const initialStatus = getItemInitialStatus(itemRawId, roundTrips);
+    const initialStatus = getItemInitialStatus(item.id, roundTrips);
 
     if (
       item.status === 'roundTrips' &&
       initialStatus !== item.status &&
-      !roundTripsIds.flat().includes(itemRawId)
+      !roundTripsIds.flat().includes(item.id)
     ) {
-      const pairedItemRawId = extractEditoastIdFromPacedTrainId(item.pairedItemId);
-      roundTripsIds.push([itemRawId, pairedItemRawId]);
+      roundTripsIds.push([item.id, item.pairedItemId]);
     }
     if (item.status === 'oneWays' && initialStatus !== item.status) {
-      oneWaysIds.push(itemRawId);
+      oneWaysIds.push(item.id);
     }
     if (item.status === 'todo' && initialStatus !== item.status) {
-      idsToDelete.push(itemRawId);
+      idsToDelete.push(item.id);
     }
   }
 

--- a/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
@@ -14,11 +14,7 @@ import Conflicts from 'modules/conflict/components/Conflicts';
 import useConflictsFilter from 'modules/conflict/hooks/useConflictsFilter';
 import ScenarioLoaderMessage from 'modules/scenario/components/ScenarioLoaderMessage';
 import { setFailure } from 'reducers/main';
-import type {
-  TimetableItemId,
-  TimetableItem,
-  TimetableItemToEditData,
-} from 'reducers/osrdconf/types';
+import type { TimetableItem, TimetableItemToEditData } from 'reducers/osrdconf/types';
 import { useAppDispatch } from 'store';
 import { castErrorToFailure } from 'utils/error';
 import { usePrevious } from 'utils/hooks/state';
@@ -111,7 +107,7 @@ const ScenarioContent = ({ activeBoards }: ScenarioContentProps) => {
   );
 
   const removeTimetableItemsWithNge = useCallback(
-    (timetableItemIds: TimetableItemId[]) => {
+    (timetableItemIds: number[]) => {
       removeTimetableItems(timetableItemIds);
       refreshNge();
     },
@@ -119,7 +115,7 @@ const ScenarioContent = ({ activeBoards }: ScenarioContentProps) => {
   );
 
   const updateTrainDepartureTimeWithNge = useCallback(
-    async (timetableItemId: TimetableItemId, newDeparture: Date) => {
+    async (timetableItemId: number, newDeparture: Date) => {
       await updateTrainDepartureTime(timetableItemId, newDeparture);
       refreshNge();
     },

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
@@ -24,7 +24,7 @@ import type { ProjectionData, TrainSpaceTimeData } from 'modules/simulationResul
 import TimesStopsOutput from 'modules/timesStops/TimesStopsOutput';
 import { findExceptionWithOccurrenceId } from 'modules/timetableItem/helpers/pacedTrain';
 import type { TimetableItemWithDetails } from 'modules/timetableItem/types';
-import type { TimetableItem, TimetableItemId } from 'reducers/osrdconf/types';
+import type { TimetableItem } from 'reducers/osrdconf/types';
 import { toggleDisplayOnlyPathSteps, updateSelectedTrainId } from 'reducers/simulationResults';
 import {
   getDisplayOnlyPathSteps,
@@ -32,7 +32,11 @@ import {
 } from 'reducers/simulationResults/selectors';
 import { getUseNewTimesStopsTable } from 'reducers/user/userSelectors';
 import { useAppDispatch } from 'store';
-import { extractPacedTrainIdFromOccurrenceId, isOccurrenceId } from 'utils/trainId';
+import {
+  extractEditoastIdFromPacedTrainId,
+  extractPacedTrainIdFromOccurrenceId,
+  isOccurrenceId,
+} from 'utils/trainId';
 
 import BoardWrapper from '../BoardWrapper';
 import SimulationResultsExport from './SimulationResultsExport';
@@ -50,7 +54,7 @@ type SimulationResultsProps = {
   timetableItemsWithDetails: TimetableItemWithDetails[];
   conflicts?: Conflict[];
   activeBoards: Set<Board>;
-  updateTrainDepartureTime: (trainId: TimetableItemId, newDepartureTime: Date) => Promise<void>;
+  updateTrainDepartureTime: (trainId: number, newDepartureTime: Date) => Promise<void>;
   upsertTimetableItems: (timetableItems: TimetableItem[]) => void;
 };
 
@@ -129,12 +133,17 @@ const SimulationResults = ({
     if (!selectedTrainId) return undefined;
 
     if (!isOccurrenceId(selectedTrainId)) {
-      return timetableItemsWithDetails.find((timetableItem) => timetableItem.id === selectedTrainId)
-        ?.summary;
+      const selectedTrainScheduleId = extractEditoastIdFromPacedTrainId(selectedTrainId);
+      return timetableItemsWithDetails.find(
+        (timetableItem) => timetableItem.id === selectedTrainScheduleId
+      )?.summary;
     }
 
+    const selectedTrainScheduleId = extractEditoastIdFromPacedTrainId(
+      extractPacedTrainIdFromOccurrenceId(selectedTrainId)
+    );
     const pacedTrain = timetableItemsWithDetails.find(
-      (timetableItem) => timetableItem.id === extractPacedTrainIdFromOccurrenceId(selectedTrainId)
+      (timetableItem) => timetableItem.id === selectedTrainScheduleId
     );
     // WARNING TODO: race condition here, to fix
     // When turning a train into a service, then pacedTrain and selectedTrainId may be desynchronized.

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/PacedTrainItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/PacedTrainItem.tsx
@@ -29,13 +29,7 @@ import {
 } from 'modules/timetableItem/helpers/updateTimetableItemHelpers';
 import type { PacedTrainWithPacedWithDetails } from 'modules/timetableItem/types';
 import { setFailure, setSuccess } from 'reducers/main';
-import type {
-  PacedTrainId,
-  TimetableItem,
-  TimetableItemId,
-  TrainId,
-  OccurrenceId,
-} from 'reducers/osrdconf/types';
+import type { TimetableItem, TrainId, OccurrenceId } from 'reducers/osrdconf/types';
 import {
   updateHoveredTrainId,
   updateProjectionType,
@@ -51,6 +45,7 @@ import {
   extractPacedTrainIdFromOccurrenceId,
   isPacedTrainId,
   formatPacedTrainIdToOccurrenceId,
+  formatEditoastIdToPacedTrainId,
 } from 'utils/trainId';
 
 import { TIMETABLE_ITEM_DELTA } from '../consts';
@@ -62,9 +57,9 @@ import OccurrenceItem from './OccurrenceItem';
 
 type PacedTrainItemProps = {
   isInSelection: boolean;
-  handleSelectPacedTrain: (pacedTrainId: PacedTrainId) => void;
+  handleSelectPacedTrain: (pacedTrainId: number) => void;
   isOccurrencesListOpen: boolean;
-  handleOpenOccurrencesList: (pacedTrainId: PacedTrainId) => void;
+  handleOpenOccurrencesList: (pacedTrainId: number) => void;
   pacedTrain: PacedTrainWithPacedWithDetails;
   isOnEdit: boolean;
   selectedTrainId?: TrainId;
@@ -74,8 +69,8 @@ type PacedTrainItemProps = {
     occurrenceId?: OccurrenceId
   ) => void;
   upsertTimetableItems: (timetableItems: TimetableItem[]) => void;
-  removePacedTrains: (pacedTrainIdsToRemove: TimetableItemId[]) => void;
-  setSelectedTimetableItemIds: React.Dispatch<React.SetStateAction<TimetableItemId[]>>;
+  removePacedTrains: (pacedTrainIdsToRemove: number[]) => void;
+  setSelectedTimetableItemIds: React.Dispatch<React.SetStateAction<number[]>>;
   subCategories: SubCategory[];
   infraIsCached: boolean;
   projectingOnSimulatedPathException: boolean | undefined;
@@ -113,16 +108,20 @@ const PacedTrainItem = ({
 
   const trainIdUsedForProjection = useSelector(getTrainIdUsedForProjection);
 
+  const formattedPacedTrainId = formatEditoastIdToPacedTrainId(pacedTrain.id);
+
   const { showPacedTrainProjectionIcon, pathUsedForProjectionIsException } = useMemo(() => {
     if (!trainIdUsedForProjection)
       return { showPacedTrainProjectionIcon: false, pathUsedForProjectionIsException: false };
     if (isPacedTrainId(trainIdUsedForProjection))
       return {
-        showPacedTrainProjectionIcon: pacedTrain.id === trainIdUsedForProjection,
+        showPacedTrainProjectionIcon:
+          pacedTrain.id === extractEditoastIdFromPacedTrainId(trainIdUsedForProjection),
         pathUsedForProjectionIsException: false,
       };
     const exception = pacedTrain.paced.exceptions.find(
-      (ex) => formatPacedTrainIdToOccurrenceId(pacedTrain.id, ex) === trainIdUsedForProjection
+      (ex) =>
+        formatPacedTrainIdToOccurrenceId(formattedPacedTrainId, ex) === trainIdUsedForProjection
     );
     const pacedTrainTrackOffsets = pacedTrain.path.filter((step) => 'track' in step);
     const exceptionTrackOffsets = exception?.path_and_schedule?.path?.filter(
@@ -133,7 +132,9 @@ const PacedTrainItem = ({
 
     return {
       showPacedTrainProjectionIcon:
-        extractPacedTrainIdFromOccurrenceId(trainIdUsedForProjection) === pacedTrain.id,
+        extractEditoastIdFromPacedTrainId(
+          extractPacedTrainIdFromOccurrenceId(trainIdUsedForProjection)
+        ) === pacedTrain.id,
       pathUsedForProjectionIsException:
         projectingOnSimulatedPathException || isTrackOffsetsException,
     };
@@ -152,7 +153,7 @@ const PacedTrainItem = ({
   const [getTrainScheduleById] = osrdEditoastApi.endpoints.getTrainSchedulesById.useLazyQuery();
 
   const selectPathProjection = async () => {
-    dispatch(updateTrainIdUsedForProjection(pacedTrain.id));
+    dispatch(updateTrainIdUsedForProjection(formattedPacedTrainId));
     if (!summary?.isValid) dispatch(updateProjectionType('operationalPointProjection'));
   };
 
@@ -172,8 +173,8 @@ const PacedTrainItem = ({
     }
   };
 
-  const selectPacedTrainId = (pacedId: PacedTrainId) => {
-    dispatch(updateSelectedTrainId(pacedId));
+  const selectPacedTrainId = () => {
+    dispatch(updateSelectedTrainId(formattedPacedTrainId));
   };
 
   async function deleteExceptions() {
@@ -196,12 +197,10 @@ const PacedTrainItem = ({
     // Static for now, will be dynamic when UI will be ready
     const pacedTrainName = `${pacedTrain.name} (${t('timetable.copy')})`;
 
-    const editoastTrainId = extractEditoastIdFromPacedTrainId(pacedTrain.id);
-
     let pacedTrainDetail: TrainScheduleResponse;
     try {
       const pacedTrainDetailPromise = getTrainScheduleById({
-        id: editoastTrainId,
+        id: pacedTrain.id,
       });
       pacedTrainDetail = await pacedTrainDetailPromise.unwrap();
       pacedTrainDetailPromise.unsubscribe();
@@ -260,9 +259,9 @@ const PacedTrainItem = ({
           invalid: summary && !summary.isValid,
           warning: !!worstCase,
           [`warning-${worstCase}`]: !!worstCase,
-          selected: selectedTrainId === pacedTrain.id,
+          selected: selectedTrainId === formattedPacedTrainId,
         })}
-        onMouseEnter={() => dispatch(updateHoveredTrainId(pacedTrain.id))}
+        onMouseEnter={() => dispatch(updateHoveredTrainId(formattedPacedTrainId))}
         onMouseLeave={() => dispatch(updateHoveredTrainId(undefined))}
       >
         {isSelectMode && (
@@ -312,7 +311,7 @@ const PacedTrainItem = ({
             className="train-info"
             data-testid="selected-paced-train-area"
             role="button"
-            onClick={() => selectPacedTrainId(pacedTrain.id)}
+            onClick={selectPacedTrainId}
             tabIndex={0}
           >
             <span

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/hooks/useOccurrences.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/hooks/useOccurrences.ts
@@ -12,6 +12,7 @@ import {
 } from 'modules/timetableItem/helpers/pacedTrain';
 import type { Occurrence, PacedTrainWithPacedWithDetails } from 'modules/timetableItem/types';
 import {
+  formatEditoastIdToPacedTrainId,
   formatPacedTrainIdToExceptionId,
   formatPacedTrainIdToIndexedOccurrenceId,
 } from 'utils/trainId';
@@ -35,10 +36,11 @@ const useOccurrences = (
 
   const occurrences = useMemo(() => {
     const computedOccurrences: Occurrence[] = [];
+    const pacedTrainId = formatEditoastIdToPacedTrainId(id);
 
     // Handle indexed occurrences
     for (let i = 0; i < occurrencesCount; i += 1) {
-      const occurrenceId = formatPacedTrainIdToIndexedOccurrenceId(id, i);
+      const occurrenceId = formatPacedTrainIdToIndexedOccurrenceId(pacedTrainId, i);
 
       const correspondingException = findExceptionWithOccurrenceId(exceptions, occurrenceId);
 
@@ -87,7 +89,7 @@ const useOccurrences = (
       const startTime = new Date(exception.start_time!.value);
 
       computedOccurrences.push({
-        id: formatPacedTrainIdToExceptionId(id, exception.key),
+        id: formatPacedTrainIdToExceptionId(pacedTrainId, exception.key),
         trainName: exception.train_name?.value ?? `${name}/+`,
         rollingStock: occurrenceRollingStock,
         startTime,

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/Timetable.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/Timetable.tsx
@@ -7,15 +7,9 @@ import useScenarioTrainScheduleSet from 'applications/operationalStudies/hooks/u
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import type { TimetableItemWithDetails } from 'modules/timetableItem/types';
 import { setFailure } from 'reducers/main';
-import type {
-  TimetableItemId,
-  TimetableItem,
-  TimetableItemToEditData,
-  PacedTrainId,
-} from 'reducers/osrdconf/types';
+import type { TimetableItem, TimetableItemToEditData } from 'reducers/osrdconf/types';
 import { useAppDispatch } from 'store';
 import { castErrorToFailure } from 'utils/error';
-import { extractEditoastIdFromPacedTrainId } from 'utils/trainId';
 
 import TimetableToolbar from './TimetableToolbar';
 import TrainList from './TrainList';
@@ -28,14 +22,14 @@ type TimetableProps = {
   setDisplayTimetableItemManagement: (mode: string) => void;
   upsertTimetableItems: (timetableItems: TimetableItem[]) => void;
   setTimetableItemToEditData: (timetableItemToEditData?: TimetableItemToEditData) => void;
-  setSelectedTimetableItemIds: React.Dispatch<React.SetStateAction<TimetableItemId[]>>;
-  removeAndUnselectTrains: (trainIds: TimetableItemId[]) => void;
+  setSelectedTimetableItemIds: React.Dispatch<React.SetStateAction<number[]>>;
+  removeAndUnselectTrains: (trainIds: number[]) => void;
   handleDeleteTimetableItems: () => void;
   timetableItemToEditData?: TimetableItemToEditData;
   timetableItems?: TimetableItem[];
   timetableItemsWithDetails: TimetableItemWithDetails[];
   refreshNge: () => Promise<void>;
-  selectedTimetableItemIds: TimetableItemId[];
+  selectedTimetableItemIds: number[];
   projectingOnSimulatedPathException: boolean | undefined;
 };
 
@@ -70,7 +64,7 @@ const Timetable = ({
   );
 
   const [showTrainScheduleMoveDialog, setShowTrainScheduleMoveDialog] = useState(false);
-  const [pacedTrainIdsToMove, setPacedTrainIdsToMove] = useState<PacedTrainId[]>([]);
+  const [pacedTrainIdsToMove, setPacedTrainIdsToMove] = useState<number[]>([]);
   const [trainScheduleSetIdSelected, setTrainScheduleSetIdSelected] = useState<number>();
 
   const { timetableItemsByTrainScheduleSets, catalogEntries, manageTrainScheduleSet } =
@@ -93,7 +87,7 @@ const Timetable = ({
   );
 
   const handleSelectTrainScheduleSet = useCallback(
-    (trainIds: TimetableItemId[]) => {
+    (trainIds: number[]) => {
       const allSelected = trainIds.every((id) => selectedTimetableItemIds.includes(id));
       if (allSelected) {
         // Deselect all
@@ -111,7 +105,7 @@ const Timetable = ({
     [selectedTimetableItemIds]
   );
 
-  const openMoveDialog = useCallback((pacedTrainIds: PacedTrainId[]) => {
+  const openMoveDialog = useCallback((pacedTrainIds: number[]) => {
     if (pacedTrainIds.length === 0) return;
 
     setPacedTrainIdsToMove(pacedTrainIds);
@@ -120,11 +114,10 @@ const Timetable = ({
 
   const handleSubmitMove = useCallback(
     async (trainScheduleSetId: number) => {
-      const formattedPacedTrainIds = pacedTrainIdsToMove.map(extractEditoastIdFromPacedTrainId);
       try {
         await updateTrainSchedulesTssId({
           body: {
-            train_schedule_ids: formattedPacedTrainIds,
+            train_schedule_ids: pacedTrainIdsToMove,
             train_schedule_set_id: trainScheduleSetId,
           },
         }).unwrap();

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TimetableBoardWrapper.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TimetableBoardWrapper.tsx
@@ -11,12 +11,7 @@ import { useSubCategoryContext } from 'common/SubCategoryContext';
 import { deleteTrainSchedules } from 'modules/timetableItem/helpers/updateTimetableItemHelpers';
 import type { TimetableItemWithDetails } from 'modules/timetableItem/types';
 import { setFailure, setSuccess } from 'reducers/main';
-import type {
-  TimetableItem,
-  TimetableItemId,
-  TimetableItemToEditData,
-  TrainId,
-} from 'reducers/osrdconf/types';
+import type { TimetableItem, TimetableItemToEditData, TrainId } from 'reducers/osrdconf/types';
 import { updateSelectedTrainId } from 'reducers/simulationResults';
 import { getSelectedTrainId } from 'reducers/simulationResults/selectors';
 import { useAppDispatch } from 'store';
@@ -32,14 +27,14 @@ type TimetableBoardWrapperProps = {
   setDisplayTimetableItemManagement: (mode: string) => void;
   upsertTimetableItems: (timetableItems: TimetableItem[]) => void;
   setTimetableItemToEditData: (timetableItemToEditData?: TimetableItemToEditData) => void;
-  removeTimetableItems: (timetableItemsToRemove: TimetableItemId[]) => void;
+  removeTimetableItems: (timetableItemsToRemove: number[]) => void;
   timetableItemToEditData?: TimetableItemToEditData;
   timetableItems?: TimetableItem[];
   timetableItemsWithDetails: TimetableItemWithDetails[];
   refreshNge: () => Promise<void>;
   projectingOnSimulatedPathException: boolean | undefined;
-  selectedTimetableItemIds: TimetableItemId[];
-  setSelectedTimetableItemIds: React.Dispatch<React.SetStateAction<TimetableItemId[]>>;
+  selectedTimetableItemIds: number[];
+  setSelectedTimetableItemIds: React.Dispatch<React.SetStateAction<number[]>>;
 };
 
 const TimetableBoardWrapper = ({
@@ -94,8 +89,8 @@ const TimetableBoardWrapper = ({
         return acc;
       },
       { selectedUniqueTrainIds: [], selectedPacedTrainIds: [] } as {
-        selectedUniqueTrainIds: TimetableItemId[];
-        selectedPacedTrainIds: TimetableItemId[];
+        selectedUniqueTrainIds: number[];
+        selectedPacedTrainIds: number[];
       }
     );
   }, [selectedTimetableItemIds]);
@@ -143,7 +138,7 @@ const TimetableBoardWrapper = ({
   // --- END BOARD WRAPPER TITLE MANAGEMENT ---------------------
 
   const removeAndUnselectTrains = useCallback(
-    (timetableItemIds: TimetableItemId[]) => {
+    (timetableItemIds: number[]) => {
       removeTimetableItems(timetableItemIds);
     },
     [removeTimetableItems, setSelectedTimetableItemIds]
@@ -158,7 +153,7 @@ const TimetableBoardWrapper = ({
     const isSelectedTimetableItemInSelection =
       currentSelectedTrainId !== undefined &&
       selectedTimetableItemIds.some((timetableItemId) =>
-        currentSelectedTrainId.includes(timetableItemId)
+        currentSelectedTrainId.includes(`${timetableItemId}`)
       );
 
     if (isSelectedTimetableItemInSelection) {

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TimetableSelectionToolbar.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TimetableSelectionToolbar.tsx
@@ -3,10 +3,8 @@ import { FileDirectorySymlink, Trash, Upload } from '@osrd-project/ui-icons';
 import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
 
-import type { TimetableItemId } from 'reducers/osrdconf/types';
-
 type TimetableSelectionToolbarProps = {
-  selectedTimetableItemIds: TimetableItemId[];
+  selectedTimetableItemIds: number[];
   areAllItemsSelected: boolean;
   areInvalidItems: boolean;
   toggleAllTrainsSelection: () => void;

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TimetableToolbar.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TimetableToolbar.tsx
@@ -22,7 +22,7 @@ import { ModalContext } from 'common/BootstrapSNCF/ModalSNCF/ModalProvider';
 import MenuTriggerButton from 'common/MenuTriggerButton';
 import UploadFileModal from 'common/uploadFileModal';
 import type { TimetableItemWithDetails } from 'modules/timetableItem/types';
-import type { TimetableItem, TimetableItemId } from 'reducers/osrdconf/types';
+import type { TimetableItem } from 'reducers/osrdconf/types';
 
 import FilterPanel from './FilterPanel';
 import SelectionToolBar from './TimetableSelectionToolbar';
@@ -36,10 +36,10 @@ type TimetableToolbarProps = {
   timetableFilters: TimetableFilters;
   timetableItems: TimetableItem[];
   filteredTimetableItems: TimetableItemWithDetails[];
-  selectedTimetableItemIds: TimetableItemId[];
+  selectedTimetableItemIds: number[];
   showTrainDetails: boolean;
   isSelectMode: boolean;
-  setSelectedTimetableItemIds: (selectedTimetableItemIds: TimetableItemId[]) => void;
+  setSelectedTimetableItemIds: (selectedTimetableItemIds: number[]) => void;
   setShowTrainDetails: (show: boolean) => void;
   setIsSelectMode: (show: boolean) => void;
   setDisplayTimetableItemManagement: (mode: string) => void;

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TrainList.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TrainList.tsx
@@ -14,19 +14,14 @@ import { useSubCategoryContext } from 'common/SubCategoryContext';
 import { isPacedTrainWithDetails } from 'modules/timetableItem/helpers/pacedTrain';
 import type { PacedTrainWithDetails, TimetableItemWithDetails } from 'modules/timetableItem/types';
 import { selectTrainToEdit } from 'reducers/osrdconf/operationalStudiesConf';
-import type {
-  OccurrenceId,
-  PacedTrainId,
-  TimetableItem,
-  TimetableItemId,
-  TimetableItemToEditData,
-} from 'reducers/osrdconf/types';
+import type { OccurrenceId, TimetableItem, TimetableItemToEditData } from 'reducers/osrdconf/types';
 import {
   getSelectedTrainId,
   getTrainIdUsedForProjection,
 } from 'reducers/simulationResults/selectors';
 import { useAppDispatch } from 'store';
 import { useDateTimeLocale } from 'utils/date';
+import { formatEditoastIdToPacedTrainId } from 'utils/trainId';
 
 import { MANAGE_TIMETABLE_ITEM_TYPES } from '../../consts';
 import PacedTrainItem from './PacedTrain/PacedTrainItem';
@@ -39,18 +34,18 @@ type TrainListProps = {
   setDisplayTimetableItemManagement: (mode: string) => void;
   upsertTimetableItems: (timetableItems: TimetableItem[]) => void;
   setTimetableItemToEditData: (timetableItemToEditData?: TimetableItemToEditData) => void;
-  setSelectedTimetableItemIds: React.Dispatch<React.SetStateAction<TimetableItemId[]>>;
-  removeAndUnselectTrains: (trainIds: TimetableItemId[]) => void;
+  setSelectedTimetableItemIds: React.Dispatch<React.SetStateAction<number[]>>;
+  removeAndUnselectTrains: (trainIds: number[]) => void;
   timetableItemToEditData?: TimetableItemToEditData;
   timetableItemsWithDetails: TimetableItemWithDetails[];
-  selectedTimetableItemIds: TimetableItemId[];
+  selectedTimetableItemIds: number[];
   projectingOnSimulatedPathException: boolean | undefined;
   isSelectMode: boolean;
   timetableMode: TimetableMode;
-  moveTimetableItem?: (pacedTrainIds: PacedTrainId[]) => void;
+  moveTimetableItem?: (pacedTrainIds: number[]) => void;
   timetableItemsByTrainScheduleSets: TimetableItemsByTrainScheduleSet[] | null;
   handleClickTrainScheduleSet: (id: number) => void;
-  handleSelectTrainScheduleSet: (trainIds: TimetableItemId[]) => void;
+  handleSelectTrainScheduleSet: (trainIds: number[]) => void;
   catalogEntries: CatalogEntry[];
   manageTrainScheduleSet: TrainScheduleSetManager;
   expandedTrainScheduleSetIds: Set<number>;
@@ -86,17 +81,15 @@ const TrainList = ({
   const { workerStatus } = useScenarioContext();
   const subCategories = useSubCategoryContext();
 
-  const [expandedTimetableItemIds, setExpandedTimetableItemIds] = useState<Set<TimetableItemId>>(
-    new Set()
-  );
+  const [expandedTimetableItemIds, setExpandedTimetableItemIds] = useState<Set<number>>(new Set());
 
   const selectedTrainId = useSelector(getSelectedTrainId);
   const trainIdUsedForProjection = useSelector(getTrainIdUsedForProjection);
   const dispatch = useAppDispatch();
 
   const handleSelectTimetableItem = useCallback(
-    (id: TimetableItemId) => {
-      const currentSelectedTrainIds: TimetableItemId[] = selectedTimetableItemIds;
+    (id: number) => {
+      const currentSelectedTrainIds: number[] = selectedTimetableItemIds;
       const index = currentSelectedTrainIds.indexOf(id);
 
       if (index === -1) {
@@ -110,7 +103,7 @@ const TrainList = ({
     [selectedTimetableItemIds]
   );
 
-  const handleExpandTimetableItem = useCallback((id: TimetableItemId) => {
+  const handleExpandTimetableItem = useCallback((id: number) => {
     setExpandedTimetableItemIds((prevExpandedIds) => {
       const newExpandedIds = new Set(prevExpandedIds);
       if (newExpandedIds.has(id)) {
@@ -172,14 +165,18 @@ const TrainList = ({
               isInSelection={selectedTimetableItemIds.includes(timetableItem.id)}
               handleSelectTrain={handleSelectTimetableItem}
               train={timetableItem}
-              isSelected={workerStatus === 'READY' && selectedTrainId === timetableItem.id}
+              isSelected={
+                workerStatus === 'READY' &&
+                selectedTrainId === formatEditoastIdToPacedTrainId(timetableItem.id)
+              }
               isModified={timetableItem.id === timetableItemToEditData?.timetableItemId}
               upsertUniqueTrains={upsertTimetableItems}
               removeTrains={removeAndUnselectTrains}
               selectTrainToEdit={selectTimetableItemToEdit}
               setSelectedTimetableItemIds={setSelectedTimetableItemIds}
               projectionPathIsUsed={
-                workerStatus === 'READY' && trainIdUsedForProjection === timetableItem.id
+                workerStatus === 'READY' &&
+                trainIdUsedForProjection === formatEditoastIdToPacedTrainId(timetableItem.id)
               }
               subCategories={subCategories}
               isSelectMode={isSelectMode}

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/UniqueTrainItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/UniqueTrainItem.tsx
@@ -17,7 +17,7 @@ import {
 } from 'modules/timetableItem/helpers/updateTimetableItemHelpers';
 import type { TimetableItemWithDetails } from 'modules/timetableItem/types';
 import { setFailure, setSuccess } from 'reducers/main';
-import type { TimetableItem, TimetableItemId, TrainId } from 'reducers/osrdconf/types';
+import type { TimetableItem, TrainId } from 'reducers/osrdconf/types';
 import {
   updateHoveredTrainId,
   updateTrainIdUsedForProjection,
@@ -28,7 +28,7 @@ import { useAppDispatch } from 'store';
 import { timeToLocaleStringRounded, useDateTimeLocale } from 'utils/date';
 import { addDurationToDate, Duration } from 'utils/duration';
 import { castErrorToFailure } from 'utils/error';
-import { extractEditoastIdFromPacedTrainId } from 'utils/trainId';
+import { formatEditoastIdToPacedTrainId } from 'utils/trainId';
 
 import ArrivalTimeLoader from './ArrivalTimeLoader';
 import { TIMETABLE_ITEM_DELTA } from './consts';
@@ -40,12 +40,12 @@ type UniqueTrainItemProps = {
   train: TimetableItemWithDetails;
   isSelected: boolean;
   isModified?: boolean;
-  handleSelectTrain: (trainId: TimetableItemId) => void;
+  handleSelectTrain: (trainId: number) => void;
   upsertUniqueTrains: (uniqueTrains: TimetableItem[]) => void;
-  removeTrains: (trainIds: TimetableItemId[]) => void;
+  removeTrains: (trainIds: number[]) => void;
   projectionPathIsUsed: boolean;
   selectTrainToEdit: (train: TimetableItemWithDetails) => void;
-  setSelectedTimetableItemIds: React.Dispatch<React.SetStateAction<TimetableItemId[]>>;
+  setSelectedTimetableItemIds: React.Dispatch<React.SetStateAction<number[]>>;
   subCategories: SubCategory[];
   isSelectMode: boolean;
   moveTimetableItem: () => void;
@@ -76,6 +76,8 @@ const UniqueTrainItem = ({
 
   const { summary } = train;
 
+  const formattedTrainId = formatEditoastIdToPacedTrainId(train.id);
+
   const changeSelectedTrainId = (trainId: TrainId) => {
     dispatch(updateSelectedTrainId(trainId));
   };
@@ -95,7 +97,7 @@ const UniqueTrainItem = ({
       .catch((e) => {
         dispatch(setFailure(castErrorToFailure(e)));
         if (isSelected) {
-          dispatch(updateSelectedTrainId(train.id));
+          dispatch(updateSelectedTrainId(formattedTrainId));
         }
       });
   };
@@ -104,9 +106,8 @@ const UniqueTrainItem = ({
     const trainName = `${train.name} (${t('timetable.copy')})`;
 
     try {
-      const editoastTrainId = extractEditoastIdFromPacedTrainId(train.id);
       const trainDetail = await getTrainSchedule({
-        id: editoastTrainId,
+        id: train.id,
       }).unwrap();
 
       const startTime = addDurationToDate(
@@ -138,7 +139,7 @@ const UniqueTrainItem = ({
   };
 
   const selectPathProjection = async () => {
-    dispatch(updateTrainIdUsedForProjection(train.id));
+    dispatch(updateTrainIdUsedForProjection(formattedTrainId));
     if (!summary?.isValid) dispatch(updateProjectionType('operationalPointProjection'));
   };
 
@@ -166,14 +167,14 @@ const UniqueTrainItem = ({
         'in-selection': isInSelection,
         invalid: summary && !summary.isValid,
       })}
-      onMouseEnter={() => dispatch(updateHoveredTrainId(train.id))}
+      onMouseEnter={() => dispatch(updateHoveredTrainId(formattedTrainId))}
       onMouseLeave={() => dispatch(updateHoveredTrainId(undefined))}
     >
       <div
         data-testid="scenario-timetable-unique-train-button"
         role="button"
         tabIndex={0}
-        onClick={() => changeSelectedTrainId(train.id)}
+        onClick={() => changeSelectedTrainId(formattedTrainId)}
         className="w-full clickable-button"
       >
         <div

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/__tests__/utils.spec.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/__tests__/utils.spec.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect } from 'vitest';
 
 import type { RoundTrips } from 'common/api/osrdEditoastApi';
-import type { TimetableItem, PacedTrainId } from 'reducers/osrdconf/types';
+import type { TimetableItem } from 'reducers/osrdconf/types';
 
 import { buildTimetableExportPayload } from '../utils';
 
 const buildPacedTrain = (id: number): TimetableItem =>
   ({
-    id: `paced_${id}` as PacedTrainId,
+    id,
     train_name: `Paced ${id}`,
   }) as TimetableItem;
 
@@ -16,11 +16,7 @@ describe('buildTimetableExportPayload', () => {
     const timetableItems = [buildPacedTrain(12)];
     const roundTrips: RoundTrips = { one_ways: [12], round_trips: [] };
 
-    const payload = buildTimetableExportPayload(
-      timetableItems,
-      ['paced_12' as PacedTrainId],
-      roundTrips
-    );
+    const payload = buildTimetableExportPayload(timetableItems, [12], roundTrips);
 
     expect(payload.round_trips).toEqual([[0, null]]);
   });
@@ -30,24 +26,16 @@ describe('buildTimetableExportPayload', () => {
     const trainB = buildPacedTrain(42);
     const roundTrips: RoundTrips = { round_trips: [[21, 42]] };
 
-    const payloadWithBoth = buildTimetableExportPayload(
-      [trainA, trainB],
-      ['paced_21' as PacedTrainId, 'paced_42' as PacedTrainId],
-      roundTrips
-    );
+    const payloadWithBoth = buildTimetableExportPayload([trainA, trainB], [21, 42], roundTrips);
     expect(payloadWithBoth.round_trips).toEqual([[0, 1]]);
 
-    const payloadWithSingle = buildTimetableExportPayload(
-      [trainA],
-      ['paced_21' as PacedTrainId],
-      roundTrips
-    );
+    const payloadWithSingle = buildTimetableExportPayload([trainA], [21], roundTrips);
     expect(payloadWithSingle.round_trips).toBeUndefined();
   });
 
   it('handles paced train one-ways', () => {
     const paced = buildPacedTrain(7);
-    const payload = buildTimetableExportPayload([paced], ['paced_7' as PacedTrainId], {
+    const payload = buildTimetableExportPayload([paced], [7], {
       one_ways: [7],
     });
 

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/utils.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/utils.ts
@@ -12,9 +12,8 @@ import type {
 } from 'common/api/osrdEditoastApi';
 import isMainCategory from 'modules/rollingStock/helpers/category';
 import type { SimulationSummary, TimetableItemWithDetails } from 'modules/timetableItem/types';
-import type { TimetableItem, TimetableItemId } from 'reducers/osrdconf/types';
+import type { TimetableItem } from 'reducers/osrdconf/types';
 import type { Duration } from 'utils/duration';
-import { extractEditoastIdFromPacedTrainId } from 'utils/trainId';
 
 import { specialCodeDictionary, TRAIN_MAIN_CATEGORY_CLASS } from './consts';
 
@@ -47,15 +46,14 @@ export const formatTrainDuration = (duration: Duration) =>
 
 const formatTimetableItemsForExport = (
   timetableItems: TimetableItem[],
-  selectedTimeTableIdsFromClick: TimetableItemId[]
+  selectedTimeTableIdsFromClick: number[]
 ) => {
   const pacedTrainIndexByEditoastId = new Map<number, number>();
 
   const pacedTrains = timetableItems
     .filter(({ id }) => selectedTimeTableIdsFromClick.includes(id))
     .reduce<TrainSchedule[]>((acc, timetableItem) => {
-      const pacedTrainEditoastId = extractEditoastIdFromPacedTrainId(timetableItem.id);
-      pacedTrainIndexByEditoastId.set(pacedTrainEditoastId, acc.length);
+      pacedTrainIndexByEditoastId.set(timetableItem.id, acc.length);
       acc.push(omit(timetableItem, ['id', 'train_schedule_set_id']));
       return acc;
     }, []);
@@ -67,7 +65,7 @@ const formatTimetableItemsForExport = (
 };
 
 export const copyTimetableItemsToClipboard = async (
-  selectedTimeTableIdsFromClick: TimetableItemId[],
+  selectedTimeTableIdsFromClick: number[],
   timetableItems: TimetableItem[]
 ) => {
   const { formattedTimetableItems } = formatTimetableItemsForExport(
@@ -129,7 +127,7 @@ type TimetableExportPayload = {
 
 export const buildTimetableExportPayload = (
   timetableItems: TimetableItem[],
-  selectedTimeTableIdsFromClick: TimetableItemId[],
+  selectedTimeTableIdsFromClick: number[],
   roundTrips?: RoundTrips
 ): TimetableExportPayload => {
   const { formattedTimetableItems, pacedTrainIndexByEditoastId } = formatTimetableItemsForExport(
@@ -149,7 +147,7 @@ export const buildTimetableExportPayload = (
 };
 
 export const exportTimetableItems = (
-  selectedTimeTableIdsFromClick: TimetableItemId[],
+  selectedTimeTableIdsFromClick: number[],
   timetableItems: TimetableItem[],
   roundTrips?: RoundTrips
 ) => {

--- a/front/src/applications/stdcm/consts.ts
+++ b/front/src/applications/stdcm/consts.ts
@@ -12,7 +12,7 @@ export const STDCM_REQUEST_STATUS = Object.freeze({
   pending_additional: 'PENDING_ADDITIONAL',
 });
 
-const STDCM_TRAIN_ID = -10;
+export const STDCM_TRAIN_ID = -10;
 export const STDCM_TRAIN_TIMETABLE_ID = formatEditoastIdToPacedTrainId(STDCM_TRAIN_ID);
 
 export const consistErrorFields: (keyof ConsistErrors)[] = ['totalMass', 'totalLength', 'maxSpeed'];

--- a/front/src/applications/stdcm/hooks/useProjectedTrainsForStdcm.ts
+++ b/front/src/applications/stdcm/hooks/useProjectedTrainsForStdcm.ts
@@ -13,9 +13,8 @@ import {
   getStdcmInfraID,
   getStdcmTimetableID,
 } from 'reducers/osrdconf/stdcmConf/selectors';
-import type { TimetableItem, TimetableItemId } from 'reducers/osrdconf/types';
+import type { TimetableItem } from 'reducers/osrdconf/types';
 import { Duration, addDurationToDate } from 'utils/duration';
-import { formatEditoastIdToPacedTrainId } from 'utils/trainId';
 import { mapBy } from 'utils/types';
 
 import formatStdcmTrainIntoSpaceTimeData from '../utils/formatStdcmIntoSpaceTimeData';
@@ -26,9 +25,9 @@ import formatStdcmTrainIntoSpaceTimeData from '../utils/formatStdcmIntoSpaceTime
  */
 const keepTrainsRunningDuringStdcm = (
   stdcmResult: StdcmSuccessResponse,
-  trainSchedules: Map<TimetableItemId, TimetableItemWithDetails>
+  trainSchedules: Map<number, TimetableItemWithDetails>
 ) => {
-  const relevantTrainScheduleIds = new Set<TimetableItemId>();
+  const relevantTrainScheduleIds = new Set<number>();
 
   const stdcmDepartureTime = new Date(stdcmResult.departure_time);
   const stdcmArrivalTime = addDurationToDate(
@@ -66,25 +65,17 @@ const useProjectedTrainsForStdcm = (stdcmResponse?: StdcmSuccessResponse) => {
 
   const [spaceTimeData, setSpaceTimeData] = useState<TrainSpaceTimeData[]>([]);
 
-  const { data: timetable } = osrdEditoastApi.endpoints.getAllTimetableByIdTrainSchedules.useQuery({
-    timetableId,
-  });
+  const { data: trainSchedules = [] } =
+    osrdEditoastApi.endpoints.getAllTimetableByIdTrainSchedules.useQuery({
+      timetableId,
+    });
 
   const { data: { results: rollingStocks } = { results: null } } =
     osrdEditoastApi.endpoints.getLightRollingStock.useQuery({ pageSize: 1000 });
 
-  const formattedTrainSchedules: TimetableItem[] = useMemo(
-    () =>
-      timetable?.map((trainSchedule) => ({
-        ...trainSchedule,
-        id: formatEditoastIdToPacedTrainId(trainSchedule.id),
-      })) || [],
-    [timetable]
-  );
-
-  const trainSchedulesById: Map<TimetableItemId, TimetableItem> = useMemo(
-    () => mapBy(formattedTrainSchedules, 'id'),
-    [formattedTrainSchedules]
+  const trainSchedulesById: Map<number, TimetableItem> = useMemo(
+    () => mapBy(trainSchedules, 'id'),
+    [trainSchedules]
   );
 
   // Progressive projection of the trains
@@ -107,8 +98,8 @@ const useProjectedTrainsForStdcm = (stdcmResponse?: StdcmSuccessResponse) => {
   });
 
   useEffect(() => {
-    simulateTimetableItems(formattedTrainSchedules);
-  }, [formattedTrainSchedules]);
+    simulateTimetableItems(trainSchedules);
+  }, [trainSchedules]);
 
   useEffect(() => {
     if (stdcmResponse) {
@@ -135,7 +126,7 @@ const useProjectedTrainsForStdcm = (stdcmResponse?: StdcmSuccessResponse) => {
 
   return {
     spaceTimeData,
-    projectionLoaderData: { allTrainsProjected, totalTrains: timetable?.length ?? 0 },
+    projectionLoaderData: { allTrainsProjected, totalTrains: trainSchedules.length },
   };
 };
 

--- a/front/src/applications/stdcm/hooks/useStdcm.ts
+++ b/front/src/applications/stdcm/hooks/useStdcm.ts
@@ -5,7 +5,11 @@ import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { v4 as uuidV4 } from 'uuid';
 
-import { STDCM_REQUEST_STATUS, STDCM_TRAIN_TIMETABLE_ID } from 'applications/stdcm/consts';
+import {
+  STDCM_REQUEST_STATUS,
+  STDCM_TRAIN_ID,
+  STDCM_TRAIN_TIMETABLE_ID,
+} from 'applications/stdcm/consts';
 import type {
   StdcmRequestStatus,
   StdcmSimulation,
@@ -96,7 +100,7 @@ const useStdcm = ({
         dispatch
       );
       const stdcmTrain: Omit<TimetableItem, 'train_schedule_set_id'> = {
-        id: STDCM_TRAIN_TIMETABLE_ID,
+        id: STDCM_TRAIN_ID,
         comfort: payload.body.comfort,
         constraint_distribution: 'MARECO',
         path: payload.body.steps.map((step) => ({ location: step.location, id: uuidV4() })),

--- a/front/src/applications/stdcm/utils/formatStdcmIntoSpaceTimeData.ts
+++ b/front/src/applications/stdcm/utils/formatStdcmIntoSpaceTimeData.ts
@@ -1,6 +1,6 @@
 import type { TrainSpaceTimeData } from 'modules/simulationResult/types';
 
-import { STDCM_TRAIN_TIMETABLE_ID } from '../consts';
+import { STDCM_TRAIN_ID } from '../consts';
 import type { StdcmSuccessResponse } from '../types';
 
 const formatStdcmTrainIntoSpaceTimeData = (
@@ -14,7 +14,7 @@ const formatStdcmTrainIntoSpaceTimeData = (
   if (!destination?.operationalPoint) throw new Error('Origin point not defined');
 
   return {
-    id: STDCM_TRAIN_TIMETABLE_ID,
+    id: STDCM_TRAIN_ID,
     name: 'stdcm',
     originPathItem: {
       id: origin.id,

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -1,6 +1,6 @@
 import { isNil, sortBy } from 'lodash';
 
-import type { TimetableItem, TimetableItemId, TrainId } from 'reducers/osrdconf/types';
+import type { TimetableItem, TrainId } from 'reducers/osrdconf/types';
 import {
   extractEditoastIdFromPacedTrainId,
   extractPacedTrainIdFromOccurrenceId,
@@ -58,18 +58,17 @@ const osrdEditoastApi = generatedEditoastApi
         },
         providesTags: ['timetable'],
       }),
-      getTimetableItemById: builder.query<TimetableItem, { id: TimetableItemId }>({
-        queryFn: async ({ id: timetableItemId }, { dispatch }) => {
+      getTimetableItemById: builder.query<TimetableItem, { id: number }>({
+        queryFn: async ({ id }, { dispatch }) => {
           const pacedTrain = await dispatch(
             generatedEditoastApi.endpoints.getTrainSchedulesById.initiate(
               {
-                id: extractEditoastIdFromPacedTrainId(timetableItemId),
+                id,
               },
               { subscribe: false }
             )
           ).unwrap();
-          const data: TimetableItem = { ...pacedTrain, id: timetableItemId };
-          return { data };
+          return { data: pacedTrain };
         },
         providesTags: ['timetable', 'train_schedule'],
       }),

--- a/front/src/modules/conflict/__tests__/sampleData.ts
+++ b/front/src/modules/conflict/__tests__/sampleData.ts
@@ -1,10 +1,5 @@
 import type { Conflict, TrainCategory } from 'common/api/osrdEditoastApi';
-import type {
-  TimetableItem,
-  TimetableItemId,
-  PacedTrainId,
-  OccurrenceId,
-} from 'reducers/osrdconf/types';
+import type { TimetableItem, PacedTrainId, OccurrenceId } from 'reducers/osrdconf/types';
 
 export const pacedId = (n: number) => `paced_${n}` as PacedTrainId;
 export const occurrenceId = (paced: number, index = 0) =>
@@ -15,7 +10,7 @@ export const uniqueTrain = ({
   train_name,
   category,
 }: {
-  id: TimetableItemId;
+  id: number;
   train_name: string;
   category?: TrainCategory | null;
 }): TimetableItem =>
@@ -31,7 +26,7 @@ export const pacedTrain = ({
   category,
   exceptions,
 }: {
-  id: PacedTrainId;
+  id: number;
   train_name: string;
   category?: TrainCategory | null;
   exceptions?: Array<{ key?: string; occurrence_index?: number; train_name?: { value: string } }>;

--- a/front/src/modules/conflict/__tests__/utils.spec.ts
+++ b/front/src/modules/conflict/__tests__/utils.spec.ts
@@ -10,12 +10,12 @@ describe('addTrainNamesToConflicts', () => {
   it('combines schedule and occurrence names', () => {
     const trains: TimetableItem[] = [
       {
-        id: pacedId(10),
+        id: 10,
         train_name: 'TS 1234',
         category: null,
       } as TimetableItem,
       {
-        id: pacedId(20),
+        id: 20,
         train_name: 'PT 4567',
         category: null,
         paced: { exceptions: [{ key: 'abc', train_name: { value: 'PT 5678/9' } }] },

--- a/front/src/modules/conflict/hooks/useConflictsFilter.ts
+++ b/front/src/modules/conflict/hooks/useConflictsFilter.ts
@@ -8,13 +8,14 @@ import {
   findExceptionWithOccurrenceId,
   isPacedTrain,
 } from 'modules/timetableItem/helpers/pacedTrain';
-import type { TimetableItem, TimetableItemId } from 'reducers/osrdconf/types';
+import type { TimetableItem } from 'reducers/osrdconf/types';
 import { getSelectedTrainId } from 'reducers/simulationResults/selectors';
 import {
   extractPacedTrainIdFromOccurrenceId,
   isIndexedOccurrenceId,
   extractOccurrenceIndexFromOccurrenceId,
   isOccurrenceId,
+  extractEditoastIdFromPacedTrainId,
 } from 'utils/trainId';
 
 import addTrainNamesToConflicts, {
@@ -30,7 +31,7 @@ const useConflictsFilter = (timetableItems: TimetableItem[], conflicts: Conflict
     setShowOnlySelectedTrain(!showOnlySelectedTrain);
   }, [showOnlySelectedTrain]);
 
-  const timetableItemById = useMemo<Map<TimetableItemId, TimetableItem>>(
+  const timetableItemById = useMemo<Map<number, TimetableItem>>(
     () => new Map(timetableItems.map((item) => [item.id, item])),
     [timetableItems]
   );
@@ -38,10 +39,12 @@ const useConflictsFilter = (timetableItems: TimetableItem[], conflicts: Conflict
   const selectedTrainName = useMemo(() => {
     if (!selectedTrainId) return null;
 
-    const timetableItemId = isOccurrenceId(selectedTrainId)
-      ? extractPacedTrainIdFromOccurrenceId(selectedTrainId)
-      : selectedTrainId;
-    const selectedTrain = timetableItemById.get(timetableItemId);
+    const id = extractEditoastIdFromPacedTrainId(
+      isOccurrenceId(selectedTrainId)
+        ? extractPacedTrainIdFromOccurrenceId(selectedTrainId)
+        : selectedTrainId
+    );
+    const selectedTrain = timetableItemById.get(id);
 
     if (!selectedTrain || !isOccurrenceId(selectedTrainId) || !isPacedTrain(selectedTrain))
       return selectedTrain?.train_name || null;

--- a/front/src/modules/conflict/utils.ts
+++ b/front/src/modules/conflict/utils.ts
@@ -1,18 +1,14 @@
 import type { Conflict, TrainCategory } from 'common/api/osrdEditoastApi';
 import computeOccurrenceName from 'modules/timetableItem/helpers/computeOccurrenceName';
 import { isPacedTrainBase } from 'modules/timetableItem/helpers/pacedTrain';
-import type { TimetableItem, TimetableItemId, TrainId } from 'reducers/osrdconf/types';
-import { formatEditoastIdToPacedTrainId } from 'utils/trainId';
+import type { TimetableItem, TrainId } from 'reducers/osrdconf/types';
 
 import type { ConflictWithTrainNames } from './types';
 
-function getConflictTrainNames(
-  conflict: Conflict,
-  trainMap: Map<TimetableItemId, TimetableItem>
-): string[] {
+function getConflictTrainNames(conflict: Conflict, trainMap: Map<number, TimetableItem>): string[] {
   const trainNames: string[] = [];
   conflict.train_ids.forEach((train) => {
-    const pacedTrain = trainMap.get(formatEditoastIdToPacedTrainId(train.train_schedule_id));
+    const pacedTrain = trainMap.get(train.train_schedule_id);
     if (!pacedTrain) return;
 
     if (train.type === 'base') {
@@ -57,11 +53,11 @@ function getConflictTrainNames(
 
 function getConflictTrainCategories(
   conflict: Conflict,
-  trainMap: Map<TimetableItemId, TimetableItem>
+  trainMap: Map<number, TimetableItem>
 ): (TrainCategory | null)[] {
   // /!\ TODO: we don't use the exceptions here to get the correct categories
   return conflict.train_ids.map((train) => {
-    const pacedTrain = trainMap.get(formatEditoastIdToPacedTrainId(train.train_schedule_id));
+    const pacedTrain = trainMap.get(train.train_schedule_id);
     return pacedTrain?.category ?? null;
   });
 }
@@ -70,7 +66,7 @@ export default function addTrainNamesToConflicts(
   conflicts: Conflict[],
   timetableItems: TimetableItem[]
 ): ConflictWithTrainNames[] {
-  const trainMap: Map<TimetableItemId, TimetableItem> = new Map();
+  const trainMap: Map<number, TimetableItem> = new Map();
 
   for (const timetableItem of timetableItems) {
     trainMap.set(timetableItem.id, timetableItem);

--- a/front/src/modules/simulationResult/components/Chronogram/useLevelCrossingsWithChronogram.ts
+++ b/front/src/modules/simulationResult/components/Chronogram/useLevelCrossingsWithChronogram.ts
@@ -8,7 +8,6 @@ import type { TimetableItemWithDetails } from 'modules/timetableItem/types';
 import { setFailure } from 'reducers/main';
 import { useAppDispatch } from 'store';
 import { castErrorToFailure } from 'utils/error';
-import { extractEditoastIdFromPacedTrainId } from 'utils/trainId';
 
 import { formatLevelCrossingOccupanciesForChronogram } from './buildOccupancyBlocks';
 
@@ -22,10 +21,7 @@ const useLevelCrossingsWithChronogram = ({ trains }: UseLevelCrossingsWithChrono
 
   const timeOrigin = useMemo(() => new Date(trains[0].startTime).getTime(), [trains]);
 
-  const trainIds = useMemo(
-    () => trains.map((train) => extractEditoastIdFromPacedTrainId(train.id)),
-    [trains]
-  );
+  const trainIds = useMemo(() => trains.map((train) => train.id), [trains]);
 
   const { currentData: levelCrossingsIds } =
     osrdEditoastApi.endpoints.getInfraByInfraIdObjectsAndObjectTypeIds.useQuery(

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
@@ -50,6 +50,7 @@ import {
   extractOccurrenceIndexFromOccurrenceId,
   extractExceptionIdFromOccurrenceId,
   isAddedExceptionId,
+  extractEditoastIdFromPacedTrainId,
 } from 'utils/trainId';
 import { mapBy } from 'utils/types';
 
@@ -152,9 +153,11 @@ const SpaceTimeChartWrapper = ({
   const translations = { linearMode: t('main.linearMode') };
 
   const isTimetableItemValid = useMemo(() => {
-    const selectedItemId = isOccurrenceId(selectedProjectionId)
-      ? extractPacedTrainIdFromOccurrenceId(selectedProjectionId)
-      : selectedProjectionId;
+    const selectedItemId = extractEditoastIdFromPacedTrainId(
+      isOccurrenceId(selectedProjectionId)
+        ? extractPacedTrainIdFromOccurrenceId(selectedProjectionId)
+        : selectedProjectionId
+    );
 
     const timetableItemUsedForProjectionWithDetails = timetableItemsWithDetails?.find(
       (item) => item.id === selectedItemId

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/buildSplitPoints.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/buildSplitPoints.tsx
@@ -14,7 +14,7 @@ import { keyBy, sortBy } from 'lodash';
 
 import type { CategoryColors } from 'applications/operationalStudies/types';
 import { Spinner } from 'common/Loaders';
-import type { TimetableItemId, TrainId } from 'reducers/osrdconf/types';
+import type { TrainId } from 'reducers/osrdconf/types';
 import { extractPacedTrainIdFromOccurrenceId, isOccurrenceId } from 'utils/trainId';
 
 import getPathStyle from './helpers/getPathStyle';
@@ -54,7 +54,7 @@ export function buildSplitPoints(
   const pathsById = keyBy(paths, ({ id }) => id);
 
   const countZonesByPacedTrainId = (zones: OccupancyZone[] = []) => {
-    const counts = new Map<TimetableItemId, Map<string, number>>();
+    const counts = new Map<TrainId, Map<string, number>>();
     for (const zone of zones) {
       if (isOccurrenceId(zone.trainId)) {
         const pacedTrainId = extractPacedTrainIdFromOccurrenceId(zone.trainId);

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/__tests__/makeProjectedItems.spec.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/__tests__/makeProjectedItems.spec.ts
@@ -3,7 +3,6 @@ import { describe, expect, test } from 'vitest';
 
 import type { PacedTrainException } from 'common/api/osrdEditoastApi';
 import { type TrainSpaceTimeData } from 'modules/simulationResult/types';
-import type { PacedTrainId } from 'reducers/osrdconf/types';
 import { Duration } from 'utils/duration';
 
 import makeProjectedItems from '../makeProjectedItems';
@@ -73,7 +72,7 @@ describe('makeProjectedItems', () => {
       {
         name: 'GE LYD',
         departureTime: new Date('2025-07-09T05:30:00.000Z'),
-        id: 'paced_2562' as PacedTrainId,
+        id: 2562,
         paced: {
           timeWindow: Duration.parse('PT2H'),
           interval: Duration.parse('PT1H'),
@@ -212,7 +211,7 @@ describe('makeProjectedItems', () => {
           },
         ],
         signalUpdates: [],
-        id: 'paced_2564' as PacedTrainId,
+        id: 2564,
         paced: {
           timeWindow: Duration.parse('PT3H'),
           interval: Duration.parse('PT1H'),

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/__tests__/utils.spec.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/__tests__/utils.spec.ts
@@ -1,7 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-import { formatEditoastIdToPacedTrainId } from 'utils/trainId';
-
 import { batchFetchTrackOccupancy } from '../utils';
 
 describe('batchFetch', () => {
@@ -13,7 +11,7 @@ describe('batchFetch', () => {
     const fetchSpy = vi.fn().mockResolvedValueOnce(['a', 'b']).mockResolvedValueOnce(['c', 'd']);
 
     const onComplete = vi.fn();
-    batchFetchTrackOccupancy([1, 2, 3, 4].map(formatEditoastIdToPacedTrainId), fetchSpy, {
+    batchFetchTrackOccupancy([1, 2, 3, 4], fetchSpy, {
       batchSize: 2,
       onComplete,
     });
@@ -21,8 +19,8 @@ describe('batchFetch', () => {
     await vi.waitFor(() => expect(onComplete).toHaveBeenCalled());
 
     expect(fetchSpy).toHaveBeenCalledTimes(2);
-    expect(fetchSpy).toHaveBeenNthCalledWith(1, [1, 2].map(formatEditoastIdToPacedTrainId));
-    expect(fetchSpy).toHaveBeenNthCalledWith(2, [3, 4].map(formatEditoastIdToPacedTrainId));
+    expect(fetchSpy).toHaveBeenNthCalledWith(1, [1, 2]);
+    expect(fetchSpy).toHaveBeenNthCalledWith(2, [3, 4]);
     expect(onComplete).toHaveBeenCalledExactlyOnceWith(['a', 'b', 'c', 'd']);
   });
 
@@ -37,7 +35,7 @@ describe('batchFetch', () => {
     );
     const onComplete = vi.fn();
 
-    const ids = [1, 2, 3, 4].map(formatEditoastIdToPacedTrainId);
+    const ids = [1, 2, 3, 4];
     const abort = batchFetchTrackOccupancy(ids, fetchSpy, {
       batchSize: 2,
       onComplete,
@@ -61,7 +59,7 @@ describe('batchFetch', () => {
     const onProgress = vi.fn();
     const onComplete = vi.fn();
 
-    batchFetchTrackOccupancy([1, 2, 3, 4].map(formatEditoastIdToPacedTrainId), fetchSpy, {
+    batchFetchTrackOccupancy([1, 2, 3, 4], fetchSpy, {
       batchSize: 2,
       onProgress,
       onComplete,
@@ -82,7 +80,7 @@ describe('batchFetch', () => {
     const onError = vi.fn();
     const onComplete = vi.fn();
 
-    batchFetchTrackOccupancy([1, 2].map(formatEditoastIdToPacedTrainId), fetchSpy, {
+    batchFetchTrackOccupancy([1, 2], fetchSpy, {
       onError,
       onComplete,
     });

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/configureHandlePan.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/configureHandlePan.ts
@@ -10,6 +10,7 @@ import { updateSelectedTrainId } from 'reducers/simulationResults';
 import type { AppDispatch } from 'store';
 import { Duration, subtractDurationFromDate } from 'utils/duration';
 import {
+  extractEditoastIdFromPacedTrainId,
   extractOccurrenceIndexFromOccurrenceId,
   extractPacedTrainIdFromOccurrenceId,
   isTrainId,
@@ -86,7 +87,9 @@ export function configureHandlePan({
         (!draggedTrain.exception || !draggedTrain.exception.start_time)
       ) {
         const occurrencesIndex = extractOccurrenceIndexFromOccurrenceId(draggedTrain.id);
-        const pacedTrainId = extractPacedTrainIdFromOccurrenceId(draggedTrain.id);
+        const pacedTrainId = extractEditoastIdFromPacedTrainId(
+          extractPacedTrainIdFromOccurrenceId(draggedTrain.id)
+        );
         const pacedTrain = timetableItemProjections.find(({ id }) => id === pacedTrainId);
         if (pacedTrain?.paced) {
           newDepartureTime = subtractDurationFromDate(

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/createHandleTrainDrag.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/createHandleTrainDrag.ts
@@ -1,6 +1,10 @@
 import type { TrainSpaceTimeData } from 'modules/simulationResult/types';
-import type { TrainId, TimetableItemId } from 'reducers/osrdconf/types';
-import { extractPacedTrainIdFromOccurrenceId, isOccurrenceId } from 'utils/trainId';
+import type { TrainId } from 'reducers/osrdconf/types';
+import {
+  extractEditoastIdFromPacedTrainId,
+  extractPacedTrainIdFromOccurrenceId,
+  isOccurrenceId,
+} from 'utils/trainId';
 
 export default function createHandleTrainDrag({
   timetableItemProjections,
@@ -16,7 +20,7 @@ export default function createHandleTrainDrag({
     initialDepartureTime: Date;
     stopPanning: boolean;
   }) => Promise<void>;
-  updateTrainDepartureTime: (trainId: TimetableItemId, newDepartureTime: Date) => Promise<void>;
+  updateTrainDepartureTime: (trainId: number, newDepartureTime: Date) => Promise<void>;
 }) {
   return async function handleTrainDrag({
     draggedTrainId,
@@ -29,11 +33,12 @@ export default function createHandleTrainDrag({
     initialDepartureTime: Date;
     stopPanning: boolean;
   }) {
-    const trainToDragId = isOccurrenceId(draggedTrainId)
-      ? extractPacedTrainIdFromOccurrenceId(draggedTrainId)
-      : draggedTrainId;
-
-    const draggedTrain = timetableItemProjections.find((train) => train.id === trainToDragId);
+    const draggedItemId = extractEditoastIdFromPacedTrainId(
+      isOccurrenceId(draggedTrainId)
+        ? extractPacedTrainIdFromOccurrenceId(draggedTrainId)
+        : draggedTrainId
+    );
+    const draggedTrain = timetableItemProjections.find((train) => train.id === draggedItemId);
     if (!draggedTrain) return;
 
     const newTrainData = {
@@ -43,7 +48,7 @@ export default function createHandleTrainDrag({
 
     // Handle updating track occupancy data (with no distant update yet, so with stopPanning: false)
     await handleTrainDragInTrackOccupancy({
-      draggedTrainId: trainToDragId,
+      draggedTrainId,
       stopPanning: false,
       initialDepartureTime,
       newTrainData,
@@ -52,16 +57,16 @@ export default function createHandleTrainDrag({
     if (!stopPanning) {
       // update in the state
       setTimetableItemProjections(
-        timetableItemProjections.map((train) => (train.id === trainToDragId ? newTrainData : train))
+        timetableItemProjections.map((train) => (train.id === draggedItemId ? newTrainData : train))
       );
       return;
     }
 
-    await updateTrainDepartureTime(trainToDragId, newDepartureTime);
+    await updateTrainDepartureTime(draggedItemId, newDepartureTime);
 
     // Handle retrieving track occupancy data from server (so with stopPanning: true):
     await handleTrainDragInTrackOccupancy({
-      draggedTrainId: trainToDragId,
+      draggedTrainId,
       stopPanning: true,
       initialDepartureTime,
       newTrainData,

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/formatSpaceTimeCurves.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/formatSpaceTimeCurves.ts
@@ -13,8 +13,12 @@ import {
   isPacedTrainWithDetails,
 } from 'modules/timetableItem/helpers/pacedTrain';
 import type { TimetableItemWithDetails } from 'modules/timetableItem/types';
-import type { TimetableItemId, TrainId } from 'reducers/osrdconf/types';
-import { isOccurrenceId, extractPacedTrainIdFromOccurrenceId } from 'utils/trainId';
+import type { TrainId } from 'reducers/osrdconf/types';
+import {
+  isOccurrenceId,
+  extractPacedTrainIdFromOccurrenceId,
+  extractEditoastIdFromPacedTrainId,
+} from 'utils/trainId';
 
 export type PathDataWithSimulated = PathData & {
   colors: CategoryColors;
@@ -22,12 +26,12 @@ export type PathDataWithSimulated = PathData & {
 };
 
 const getTrainCategory = (
-  timetableItemsWithDetailsById: Map<TimetableItemId, TimetableItemWithDetails>,
+  timetableItemsWithDetailsById: Map<number, TimetableItemWithDetails>,
   trainId: TrainId
 ) => {
-  const timetableItemId = isOccurrenceId(trainId)
-    ? extractPacedTrainIdFromOccurrenceId(trainId)
-    : trainId;
+  const timetableItemId = extractEditoastIdFromPacedTrainId(
+    isOccurrenceId(trainId) ? extractPacedTrainIdFromOccurrenceId(trainId) : trainId
+  );
 
   const item = timetableItemsWithDetailsById.get(timetableItemId);
 
@@ -40,7 +44,7 @@ const getTrainCategory = (
 const formatSpaceTimeCurves = (
   subCategories: SubCategory[],
   individualTrainProjections: IndividualTrainProjection[],
-  timetableItemsWithDetailsById: Map<TimetableItemId, TimetableItemWithDetails>
+  timetableItemsWithDetailsById: Map<number, TimetableItemWithDetails>
 ): PathDataWithSimulated[] =>
   individualTrainProjections.flatMap((train) => {
     const category = getTrainCategory(timetableItemsWithDetailsById, train.id);

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/getPathStyle.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/getPathStyle.ts
@@ -1,8 +1,13 @@
 import type { PathLevel, HoveredItem } from '@osrd-project/ui-charts';
 
 import type { CategoryColors } from 'applications/operationalStudies/types';
-import type { TrainId } from 'reducers/osrdconf/types';
-import { extractPacedTrainIdFromOccurrenceId, isOccurrenceId } from 'utils/trainId';
+import type { PacedTrainId, TrainId } from 'reducers/osrdconf/types';
+import {
+  extractEditoastIdFromPacedTrainId,
+  extractPacedTrainIdFromOccurrenceId,
+  isOccurrenceId,
+  isPacedTrainId,
+} from 'utils/trainId';
 
 const getPathStyle = (
   hovered: HoveredItem | null,
@@ -20,9 +25,14 @@ const getPathStyle = (
     backgroundColor?: string;
   };
 } => {
-  const timetableItemId = isOccurrenceId(train.id)
-    ? extractPacedTrainIdFromOccurrenceId(train.id)
-    : train.id;
+  let pacedTrainId: PacedTrainId;
+  if (isOccurrenceId(train.id)) {
+    pacedTrainId = extractPacedTrainIdFromOccurrenceId(train.id);
+  } else {
+    if (!isPacedTrainId(train.id)) throw new Error();
+    pacedTrainId = train.id;
+  }
+  const timetableItemId = extractEditoastIdFromPacedTrainId(pacedTrainId);
   const { colors } = train;
 
   const invalidBorder = {
@@ -39,7 +49,10 @@ const getPathStyle = (
       train.id === hoveredTrainIdFromChart ||
       // if the hovered train is an occurrence from the same paced train, apply the hovered style
       (isOccurrenceId(hoveredTrainIdFromChart) &&
-        timetableItemId === extractPacedTrainIdFromOccurrenceId(hoveredTrainIdFromChart))
+        timetableItemId ===
+          extractEditoastIdFromPacedTrainId(
+            extractPacedTrainIdFromOccurrenceId(hoveredTrainIdFromChart)
+          ))
     ) {
       return {
         color: colors.hovered,
@@ -62,7 +75,7 @@ const getPathStyle = (
           ...(train.isSimulated === false && { border: invalidBorder }),
         };
       }
-    } else if (timetableItemId === hoveredTrainIdFromTimetable) {
+    } else if (timetableItemId === extractEditoastIdFromPacedTrainId(hoveredTrainIdFromTimetable)) {
       return {
         color: colors.hovered,
         level: 1,

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/makeProjectedItems.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/makeProjectedItems.ts
@@ -10,7 +10,7 @@ import {
 import {
   formatPacedTrainIdToIndexedOccurrenceId,
   formatEditoastIdToExceptionId,
-  extractEditoastIdFromPacedTrainId,
+  formatEditoastIdToPacedTrainId,
 } from 'utils/trainId';
 
 /**
@@ -19,8 +19,9 @@ import {
  */
 const makeProjectedItems = (timetableItemProjections: TrainSpaceTimeData[]) =>
   timetableItemProjections.flatMap<IndividualTrainProjection>((projectedItem) => {
+    const pacedTrainId = formatEditoastIdToPacedTrainId(projectedItem.id);
     if (!projectedItem.paced) {
-      return projectedItem;
+      return { ...projectedItem, id: pacedTrainId };
     }
 
     const occurrences: IndividualTrainProjection[] = [];
@@ -33,7 +34,7 @@ const makeProjectedItems = (timetableItemProjections: TrainSpaceTimeData[]) =>
     // =========== indexed occurrences ===========
     const occurrencesCount = getOccurrencesNb(projectedItem.paced);
     for (let i = 0; i < occurrencesCount; i += 1) {
-      const occurrenceId = formatPacedTrainIdToIndexedOccurrenceId(projectedItem.id, i);
+      const occurrenceId = formatPacedTrainIdToIndexedOccurrenceId(pacedTrainId, i);
       const correspondingException = findExceptionWithOccurrenceId(
         projectedItem.paced.exceptions,
         occurrenceId
@@ -94,7 +95,7 @@ const makeProjectedItems = (timetableItemProjections: TrainSpaceTimeData[]) =>
       if (!exception.start_time) throw new Error('added exception should have a start time');
 
       const id = formatEditoastIdToExceptionId({
-        pacedTrainId: extractEditoastIdFromPacedTrainId(projectedItem.id),
+        pacedTrainId: projectedItem.id,
         exceptionId: exception.key,
       });
       const name = exception.train_name ? exception.train_name.value : `${projectedItem.name}/+`;

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/utils.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/utils.ts
@@ -2,7 +2,7 @@ import type { OccupancyBlock } from '@osrd-project/ui-charts';
 import { chunk, noop, omit } from 'lodash';
 
 import { ASPECT_LABELS_COLORS } from 'modules/simulationResult/consts';
-import type { OccurrenceId, TimetableItem, TimetableItemId } from 'reducers/osrdconf/types';
+import type { OccurrenceId, TimetableItem } from 'reducers/osrdconf/types';
 import { isOccurrenceId } from 'utils/trainId';
 
 import type { MovableOccupancyZone } from './zones';
@@ -23,8 +23,8 @@ export const getWaypointsLocalStorageKey = (
  * overwhelming the server or API.
  */
 export function batchFetchTrackOccupancy(
-  allIDs: TimetableItemId[],
-  fetchTrackOccupancy: (ids: TimetableItemId[]) => Promise<MovableOccupancyZone[]>,
+  allIDs: number[],
+  fetchTrackOccupancy: (ids: number[]) => Promise<MovableOccupancyZone[]>,
   {
     batchSize = 50,
     onProgress = noop,

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useLazyProjectTrains.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useLazyProjectTrains.ts
@@ -9,7 +9,7 @@ import TrainTrackProjectionLazyLoader from 'applications/operationalStudies/help
 import upsertNewProjectedTrains from 'applications/operationalStudies/helpers/upsertNewProjectedTrains';
 import { type OperationalPointReference, type CoreTrainPath } from 'common/api/osrdEditoastApi';
 import type { TrainSpaceTimeData } from 'modules/simulationResult/types';
-import type { TimetableItemId, TimetableItem } from 'reducers/osrdconf/types';
+import type { TimetableItem } from 'reducers/osrdconf/types';
 import { getProjectionType, getIsSimulationEnabled } from 'reducers/simulationResults/selectors';
 import { useAppDispatch } from 'store';
 
@@ -30,14 +30,14 @@ const useLazyProjectTrains = ({
 }: UseLazyProjectTrainsOptions) => {
   const dispatch = useAppDispatch();
   const loaderRef = useRef<TrainProjectionLazyLoaderAbstract>(null);
-  const timetableItemsByIdRef = useRef<Map<TimetableItemId, TimetableItem>>(new Map());
-  const [projectedTrainsById, setProjectedTrainsById] = useState<
-    Map<TimetableItemId, TrainSpaceTimeData>
-  >(new Map());
+  const timetableItemsByIdRef = useRef<Map<number, TimetableItem>>(new Map());
+  const [projectedTrainsById, setProjectedTrainsById] = useState<Map<number, TrainSpaceTimeData>>(
+    new Map()
+  );
   const projectionType = useSelector(getProjectionType);
   const isSimulationEnabled = useSelector(getIsSimulationEnabled);
 
-  const onProgress = useCallback((results: Map<TimetableItemId, ProjectionResult>) => {
+  const onProgress = useCallback((results: Map<number, ProjectionResult>) => {
     setProjectedTrainsById((prev) =>
       upsertNewProjectedTrains(prev, results, timetableItemsByIdRef.current)
     );
@@ -93,7 +93,7 @@ const useLazyProjectTrains = ({
     loaderRef.current?.projectTimetableItems(timetableItems.map(({ id }) => id));
   }, []);
 
-  const removeProjectedTimetableItems = useCallback((ids: TimetableItemId[]) => {
+  const removeProjectedTimetableItems = useCallback((ids: number[]) => {
     for (const id of ids) {
       timetableItemsByIdRef.current.delete(id);
     }
@@ -108,7 +108,7 @@ const useLazyProjectTrains = ({
   }, []);
 
   const updateProjectedTimetableItemDepartureTime = useCallback(
-    (id: TimetableItemId, newDeparture: Date) => {
+    (id: number, newDeparture: Date) => {
       setProjectedTrainsById((prev) => {
         const result = prev.get(id);
         if (!result) {

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useTrackOccupancy.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useTrackOccupancy.ts
@@ -11,7 +11,7 @@ import { type OperationalPointReference, osrdEditoastApi } from 'common/api/osrd
 import computeOccurrenceName from 'modules/timetableItem/helpers/computeOccurrenceName';
 import { computeIndexedOccurrenceStartTime } from 'modules/timetableItem/helpers/pacedTrain';
 import type { SimulatedException } from 'modules/timetableItem/types';
-import type { PacedTrainId, TimetableItemId, TrainId } from 'reducers/osrdconf/types';
+import type { PacedTrainId, TrainId } from 'reducers/osrdconf/types';
 import { getIsSimulationEnabled } from 'reducers/simulationResults/selectors';
 import {
   extractEditoastIdFromPacedTrainId,
@@ -117,7 +117,7 @@ const useTrackOccupancy = ({
   }) => Promise<void>;
 } => {
   const { t, i18n } = useTranslation('operational-studies');
-  const draggedTimetableItemIds = useRef(new Set<TimetableItemId>());
+  const draggedTimetableItemIds = useRef(new Set<number>());
   const previousTimetableItemProjections = usePrevious(timetableItemProjections);
   const { getTrackSectionsByIds } = useScenarioContext();
 
@@ -131,7 +131,7 @@ const useTrackOccupancy = ({
   const isSimulationEnabled = useSelector(getIsSimulationEnabled);
   const [postInfraByInfraIdMatchOperationalPoints] =
     osrdEditoastApi.endpoints.postInfraByInfraIdMatchOperationalPoints.useLazyQuery();
-  const timetableItemProjectionsById: Map<TimetableItemId, TrainSpaceTimeData> = useMemo(
+  const timetableItemProjectionsById: Map<number, TrainSpaceTimeData> = useMemo(
     () => new Map(timetableItemProjections.map((item) => [item.id, item])),
     [timetableItemProjections]
   );
@@ -171,14 +171,16 @@ const useTrackOccupancy = ({
     []
   );
 
-  const toOwnerTimetableItemId = (id: TrainId): TimetableItemId =>
-    !isOccurrenceId(id) ? id : extractPacedTrainIdFromOccurrenceId(id);
+  const toOwnerTimetableItemId = (id: TrainId): number =>
+    extractEditoastIdFromPacedTrainId(
+      !isOccurrenceId(id) ? id : extractPacedTrainIdFromOccurrenceId(id)
+    );
 
   const fetchTrackOccupancy = useCallback(
     async (
       opRef: OperationalPointReference | undefined | null,
       waypointId: string | undefined | null,
-      trainsCollection: Record<TimetableItemId, TrainSpaceTimeData>
+      trainsCollection: Record<number, TrainSpaceTimeData>
     ): Promise<MovableOccupancyZone[]> => {
       if (!opRef) return [];
 
@@ -217,10 +219,11 @@ const useTrackOccupancy = ({
             trackId = mappedTrackId ?? localTrackName;
           }
           for (const occupation of trains) {
-            const pacedId = formatEditoastIdToPacedTrainId(occupation.train_schedule_id);
-            const train = trainsCollection[pacedId];
+            const itemId = occupation.train_schedule_id;
+            const pacedTrainId = formatEditoastIdToPacedTrainId(itemId);
+            const train = trainsCollection[itemId];
 
-            if (!train) throw new Error(`No train found for id ${pacedId}`);
+            if (!train) throw new Error(`No train found for id ${itemId}`);
 
             if (!train.paced) {
               if (occupation.type !== 'base') {
@@ -231,7 +234,7 @@ const useTrackOccupancy = ({
               zones.push(
                 getMovableOccupancyZone(
                   trackId,
-                  pacedId,
+                  pacedTrainId,
                   occupation,
                   train.spaceTimeCurves,
                   train.name,
@@ -259,11 +262,11 @@ const useTrackOccupancy = ({
               if (!exception?.start_time?.value)
                 throw new Error(`Created exceptions should always be a start time exception`);
 
-              trainId = formatPacedTrainIdToExceptionId(pacedId, occupation.exception_key);
+              trainId = formatPacedTrainIdToExceptionId(pacedTrainId, occupation.exception_key);
               trainName = exception.train_name?.value ?? `${train.name}/+`;
               startTime = new Date(exception.start_time.value);
             } else {
-              trainId = formatPacedTrainIdToIndexedOccurrenceId(pacedId, occupation.index);
+              trainId = formatPacedTrainIdToIndexedOccurrenceId(pacedTrainId, occupation.index);
               trainName =
                 exception?.train_name?.value ?? computeOccurrenceName(train.name, occupation.index);
 
@@ -464,6 +467,7 @@ const useTrackOccupancy = ({
       else draggedTimetableItemIds.current.add(draggedTimetableItemId);
 
       // Update actual state:
+      const draggedPacedTrainId = formatEditoastIdToPacedTrainId(draggedTimetableItemId);
       const impactedPathOperationalPointIDs = new Set<string>();
       const newState = { ...pathOperationalPointsState };
       forEach(newState, (opState, waypointId) => {
@@ -471,7 +475,7 @@ const useTrackOccupancy = ({
           forEach(opState.zones.data, (zone) => {
             if (
               isOccurrenceId(zone.trainId) &&
-              extractPacedTrainIdFromOccurrenceId(zone.trainId) === draggedTimetableItemId &&
+              extractPacedTrainIdFromOccurrenceId(zone.trainId) === draggedPacedTrainId &&
               !zone.isStartTimeException
             ) {
               impactedPathOperationalPointIDs.add(waypointId);
@@ -619,9 +623,9 @@ const useTrackOccupancy = ({
       (timetableItem) => timetableItem.id
     );
 
-    const addedTrainIDs = new Set<TimetableItemId>();
-    const removedTrainIDs = new Set<TimetableItemId>();
-    const modifiedTrainIDs = new Set<TimetableItemId>();
+    const addedTrainIDs = new Set<number>();
+    const removedTrainIDs = new Set<number>();
+    const modifiedTrainIDs = new Set<number>();
     timetableItemProjections.forEach((timetableItem) => {
       const id = timetableItem.id;
       const previousTimetableItem = previousTimetableItemsDict[id];
@@ -717,7 +721,7 @@ const useTrackOccupancy = ({
     const fetchOperationalPoints = async () => {
       try {
         const requests: {
-          timetableItemId: TimetableItemId;
+          timetableItemId: number;
           side: 'origin' | 'destination';
           opReference: OperationalPointReference;
         }[] = [];

--- a/front/src/modules/simulationResult/helpers/formatTimetableItemSummaries.ts
+++ b/front/src/modules/simulationResult/helpers/formatTimetableItemSummaries.ts
@@ -4,17 +4,17 @@ import type {
 } from 'common/api/osrdEditoastApi';
 import { formatPacedTrainWithDetails } from 'modules/timetableItem/helpers/formatTimetableItemWithDetails';
 import type { TimetableItemWithDetails } from 'modules/timetableItem/types';
-import type { TimetableItemId, TimetableItem, PacedTrainId } from 'reducers/osrdconf/types';
+import type { TimetableItem } from 'reducers/osrdconf/types';
 import { mapBy } from 'utils/types';
 
 type SummaryWithCorrespondingTimetableItemId = {
-  timetableItemId: PacedTrainId;
+  timetableItemId: number;
   summary: TrainScheduleSimulationSummaryResult;
 };
 
 const formatTimetableItemWithDetails = (
   inputs: SummaryWithCorrespondingTimetableItemId,
-  rawTimetableItems: Map<TimetableItemId, TimetableItem>,
+  rawTimetableItems: Map<number, TimetableItem>,
   rollingStocks: LightRollingStockWithLiveries[]
 ) => {
   const timetableItem = rawTimetableItems.get(inputs.timetableItemId);
@@ -27,10 +27,10 @@ const formatTimetableItemWithDetails = (
 
 /** Format the timetable items with their simulation summaries */
 const formatTimetableItemSummaries = (
-  rawPacedTrainSummaries: Map<PacedTrainId, TrainScheduleSimulationSummaryResult>,
-  rawTimetableItems: Map<TimetableItemId, TimetableItem>,
+  rawPacedTrainSummaries: Map<number, TrainScheduleSimulationSummaryResult>,
+  rawTimetableItems: Map<number, TimetableItem>,
   rollingStocks: LightRollingStockWithLiveries[]
-): Map<TimetableItemId, TimetableItemWithDetails> => {
+): Map<number, TimetableItemWithDetails> => {
   const items: TimetableItemWithDetails[] = [...rawPacedTrainSummaries].map(
     ([id, pacedTrainSummary]) =>
       formatTimetableItemWithDetails(

--- a/front/src/modules/simulationResult/types.ts
+++ b/front/src/modules/simulationResult/types.ts
@@ -46,7 +46,7 @@ export type BaseTrainProjection = {
 };
 
 export type TrainSpaceTimeData = {
-  id: PacedTrainId;
+  id: number;
   name: string;
   departureTime: Date;
   originPathItem: PathItem;

--- a/front/src/modules/timesStops/hooks/useUpdateTimesStopsTable.ts
+++ b/front/src/modules/timesStops/hooks/useUpdateTimesStopsTable.ts
@@ -132,7 +132,9 @@ const useUpdateTimesStopsTable = (
    */
   const updateOccurrence = useCallback(
     async (occurrenceId: OccurrenceId, update: CellUpdate) => {
-      const pacedTrainId = extractPacedTrainIdFromOccurrenceId(occurrenceId);
+      const pacedTrainId = extractEditoastIdFromPacedTrainId(
+        extractPacedTrainIdFromOccurrenceId(occurrenceId)
+      );
       const originalPacedTrainWithDetails = timetableItemsWithDetails.find(
         (item) => item.id === pacedTrainId
       );
@@ -189,7 +191,7 @@ const useUpdateTimesStopsTable = (
       );
 
       await updateTrainSchedule({
-        id: extractEditoastIdFromPacedTrainId(pacedTrainId),
+        id: pacedTrainId,
         trainSchedule: updatedPacedTrain,
       }).unwrap();
       upsertTimetableItems([{ ...updatedPacedTrain, id: pacedTrainId }]);
@@ -202,18 +204,20 @@ const useUpdateTimesStopsTable = (
    */
   const updateTimetableItem = useCallback(
     async (trainId: PacedTrainId, update: CellUpdate) => {
+      const editoastId = extractEditoastIdFromPacedTrainId(trainId);
+
       // Handle first row
       if (update.field === 'requestedArrival' && update.row.opOnPathIndex === 0) {
         if (!update.value) return;
 
         const train: TimetableItem = {
           ...selectedTrain,
-          id: trainId,
+          id: editoastId,
           start_time: update.value.toISOString(),
         };
 
         await updateTrainSchedule({
-          id: extractEditoastIdFromPacedTrainId(trainId),
+          id: editoastId,
           trainSchedule: train,
         }).unwrap();
         upsertTimetableItems([train]);
@@ -226,13 +230,13 @@ const useUpdateTimesStopsTable = (
       const { updatedPath, updatedSchedule } = result;
       const train: TimetableItem = {
         ...selectedTrain,
-        id: trainId,
+        id: extractEditoastIdFromPacedTrainId(trainId),
         path: updatedPath,
         schedule: updatedSchedule,
       };
 
       await updateTrainSchedule({
-        id: extractEditoastIdFromPacedTrainId(trainId),
+        id: editoastId,
         trainSchedule: train,
       }).unwrap();
       upsertTimetableItems([train]);

--- a/front/src/modules/timetableItem/helpers/pacedTrain.ts
+++ b/front/src/modules/timetableItem/helpers/pacedTrain.ts
@@ -3,14 +3,10 @@ import type {
   PacedTrainWithPaced,
 } from 'applications/operationalStudies/types';
 import type { TrainSchedule, PacedTrainException } from 'common/api/osrdEditoastApi';
-import type {
-  OccurrenceId,
-  PacedTrainId,
-  TimetableItem,
-  TimetableItemId,
-} from 'reducers/osrdconf/types';
+import type { OccurrenceId, PacedTrainId, TimetableItem } from 'reducers/osrdconf/types';
 import { Duration, addDurationToDate } from 'utils/duration';
 import {
+  extractEditoastIdFromPacedTrainId,
   extractExceptionIdFromOccurrenceId,
   extractOccurrenceIndexFromOccurrenceId,
   extractPacedTrainIdFromOccurrenceId,
@@ -156,10 +152,12 @@ export const getOccurrencesWorstStatus = (
 };
 
 export const getExceptionFromOccurrenceId = (
-  timetableItemsById: Map<TimetableItemId, TimetableItem>,
+  timetableItemsById: Map<number, TimetableItem>,
   occurrenceId: OccurrenceId
 ) => {
-  const pacedTrainId = extractPacedTrainIdFromOccurrenceId(occurrenceId);
+  const pacedTrainId = extractEditoastIdFromPacedTrainId(
+    extractPacedTrainIdFromOccurrenceId(occurrenceId)
+  );
   const pacedTrain = timetableItemsById.get(pacedTrainId);
   if (!pacedTrain || !isPacedTrain(pacedTrain))
     throw new Error(`No paced train found for id ${pacedTrainId}`);

--- a/front/src/modules/timetableItem/helpers/updateTimetableItemHelpers.ts
+++ b/front/src/modules/timetableItem/helpers/updateTimetableItemHelpers.ts
@@ -3,36 +3,29 @@ import {
   type TrainSchedule,
   type TrainScheduleResponse,
 } from 'common/api/osrdEditoastApi';
-import type { PacedTrainId, TimetableItem, TimetableItemId } from 'reducers/osrdconf/types';
+import type { TimetableItem } from 'reducers/osrdconf/types';
 import {
   unsetTrainIdsMatching,
   unsetTrainIdsMatchingMissingOccurencesOf,
 } from 'reducers/simulationResults';
 import type { AppDispatch } from 'store';
-import {
-  extractEditoastIdFromPacedTrainId,
-  formatEditoastIdToPacedTrainId,
-  isPacedTrainId,
-} from 'utils/trainId';
+import { formatEditoastIdToPacedTrainId } from 'utils/trainId';
 
 import { getOcurrencesIds, isPacedTrainBase } from './pacedTrain';
 
 export async function fetchTimetableItem(
-  timetableItemId: TimetableItemId,
+  id: number,
   dispatch: AppDispatch
 ): Promise<TimetableItem> {
-  if (isPacedTrainId(timetableItemId)) {
-    const pacedTrain = await dispatch(
-      osrdEditoastApi.endpoints.getTrainSchedulesById.initiate(
-        {
-          id: extractEditoastIdFromPacedTrainId(timetableItemId),
-        },
-        { subscribe: false }
-      )
-    ).unwrap();
-    return { ...pacedTrain, id: timetableItemId };
-  }
-  throw new Error('TrainSchedules are not handled anymore.');
+  const trainSchedule = await dispatch(
+    osrdEditoastApi.endpoints.getTrainSchedulesById.initiate(
+      {
+        id,
+      },
+      { subscribe: false }
+    )
+  ).unwrap();
+  return trainSchedule;
 }
 
 export async function createPacedTrains(
@@ -47,45 +40,39 @@ export async function createPacedTrains(
       body: pacedTrains,
     })
   ).unwrap();
-  return newPacedTrains.map((pacedTrain) => ({
-    ...pacedTrain,
-    id: formatEditoastIdToPacedTrainId(pacedTrain.id),
-  }));
+  return newPacedTrains;
 }
 
-async function updatePacedTrain(
-  dispatch: AppDispatch,
-  id: PacedTrainId,
-  trainSchedule: TrainSchedule
-) {
+async function updatePacedTrain(dispatch: AppDispatch, id: number, trainSchedule: TrainSchedule) {
   await dispatch(
     osrdEditoastApi.endpoints.putTrainSchedulesById.initiate({
-      id: extractEditoastIdFromPacedTrainId(id),
+      id,
       trainSchedule,
     })
   ).unwrap();
 }
 
-export async function deleteTrainSchedules(dispatch: AppDispatch, ids: PacedTrainId[]) {
-  ids.forEach((id) => dispatch(unsetTrainIdsMatching(id)));
+export async function deleteTrainSchedules(dispatch: AppDispatch, ids: number[]) {
+  ids.forEach((id) => dispatch(unsetTrainIdsMatching(formatEditoastIdToPacedTrainId(id))));
   await dispatch(
     osrdEditoastApi.endpoints.deleteTrainSchedules.initiate({
-      body: { ids: ids.map((id) => extractEditoastIdFromPacedTrainId(id)) },
+      body: { ids },
     })
   ).unwrap();
 }
 
 export async function storePacedTrain(
-  timetableItemIdToUpdate: TimetableItemId,
+  timetableItemIdToUpdate: number,
   pacedTrain: Omit<TrainScheduleResponse, 'id'>,
   dispatch: AppDispatch,
   upsertTimetableItems: (timetableItems: TimetableItem[]) => void
 ): Promise<TimetableItem> {
   if (isPacedTrainBase(pacedTrain)) {
+    const pacedTrainId = formatEditoastIdToPacedTrainId(timetableItemIdToUpdate);
     dispatch(
       unsetTrainIdsMatchingMissingOccurencesOf({
-        pacedTrainId: timetableItemIdToUpdate,
-        occurrencesPresent: getOcurrencesIds(pacedTrain, timetableItemIdToUpdate),
+        pacedTrainId,
+        occurrencesPresent: getOcurrencesIds(pacedTrain, pacedTrainId),
       })
     );
   }

--- a/front/src/modules/timetableItem/hooks/useSelectedTimetableItem.tsx
+++ b/front/src/modules/timetableItem/hooks/useSelectedTimetableItem.tsx
@@ -4,11 +4,17 @@ import { useSelector } from 'react-redux';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import type { TimetableItem, TrainId } from 'reducers/osrdconf/types';
 import { getSelectedTrainId } from 'reducers/simulationResults/selectors';
-import { extractPacedTrainIdFromOccurrenceId, isOccurrenceId } from 'utils/trainId';
+import {
+  extractEditoastIdFromPacedTrainId,
+  extractPacedTrainIdFromOccurrenceId,
+  isOccurrenceId,
+} from 'utils/trainId';
 
 const extractTimetableItemId = (trainId?: TrainId) => {
   if (!trainId) return undefined;
-  return isOccurrenceId(trainId) ? extractPacedTrainIdFromOccurrenceId(trainId) : trainId;
+  return extractEditoastIdFromPacedTrainId(
+    isOccurrenceId(trainId) ? extractPacedTrainIdFromOccurrenceId(trainId) : trainId
+  );
 };
 
 const useSelectedTimetableItem = (): TimetableItem | undefined => {

--- a/front/src/modules/timetableItem/types.ts
+++ b/front/src/modules/timetableItem/types.ts
@@ -10,7 +10,7 @@ import type {
   SimulationSummaryResult,
   TrainScheduleResponse,
 } from 'common/api/osrdEditoastApi';
-import type { OccurrenceId, PacedTrainId } from 'reducers/osrdconf/types';
+import type { OccurrenceId } from 'reducers/osrdconf/types';
 import type { Duration } from 'utils/duration';
 
 export type SuggestedOP = {
@@ -67,7 +67,7 @@ export type SimulationSummary =
 
 export type TimetableItemWithSummaries = Omit<
   TrainScheduleResponse,
-  'id' | 'train_name' | 'rolling_stock_name' | 'start_time' | 'paced'
+  'train_name' | 'rolling_stock_name' | 'start_time' | 'paced'
 > & {
   name: string;
   startTime: Date;
@@ -87,7 +87,6 @@ export type InvalidReason =
 export type SimulatedException = PacedTrainException & { summary?: SimulationSummary };
 
 export type PacedTrainWithDetails = TimetableItemWithSummaries & {
-  id: PacedTrainId;
   paced?: {
     timeWindow: Duration;
     interval: Duration;
@@ -97,7 +96,6 @@ export type PacedTrainWithDetails = TimetableItemWithSummaries & {
 
 // tmp type
 export type PacedTrainWithPacedWithDetails = TimetableItemWithSummaries & {
-  id: PacedTrainId;
   paced: {
     timeWindow: Duration;
     interval: Duration;

--- a/front/src/reducers/osrdconf/operationalStudiesConf/__tests__/operationalStudiesConfReducer.spec.ts
+++ b/front/src/reducers/osrdconf/operationalStudiesConf/__tests__/operationalStudiesConfReducer.spec.ts
@@ -12,13 +12,14 @@ import {
 } from 'reducers/osrdconf/operationalStudiesConf';
 import commonConfBuilder from 'reducers/osrdconf/osrdConfCommon/__tests__/commonConfBuilder';
 import testCommonConfReducers from 'reducers/osrdconf/osrdConfCommon/__tests__/utils';
-import type { OperationalStudiesConfState, PacedTrainId, PathStep } from 'reducers/osrdconf/types';
+import type { OperationalStudiesConfState, PathStep } from 'reducers/osrdconf/types';
 import { createStoreWithoutMiddleware } from 'store';
 import { Duration } from 'utils/duration';
 
 import testTrainSettingsReducer from './trainSettingsReducer';
 
 const baseTimetableItemWithSummary: TimetableItemWithSummaries = {
+  id: 1,
   name: 'train1',
   train_schedule_set_id: 1000,
   constraint_distribution: 'MARECO',
@@ -63,7 +64,6 @@ describe('simulationConfReducer', () => {
     it('paced train case', () => {
       const pacedTrain: PacedTrainWithDetails = {
         ...baseTimetableItemWithSummary,
-        id: 'paced_1' as PacedTrainId,
         paced: {
           timeWindow: new Duration({ minutes: 60 }),
           interval: new Duration({ minutes: 30 }),

--- a/front/src/reducers/osrdconf/types.ts
+++ b/front/src/reducers/osrdconf/types.ts
@@ -203,15 +203,14 @@ export type OccurrenceId = IndexedOccurrenceId | AddedExceptionId;
 export type PacedTrainId = string & { readonly __type: unique symbol };
 
 export type TrainId = OccurrenceId | PacedTrainId;
-export type TimetableItemId = PacedTrainId;
 export type TimetableItemToEditData = {
-  timetableItemId: PacedTrainId;
+  timetableItemId: number;
   originalPacedTrain: PacedTrainWithDetails;
   occurrenceId?: OccurrenceId;
 };
 
 export type TimetableItem = Omit<TrainScheduleResponse, 'id'> & {
-  id: PacedTrainId;
+  id: number;
 };
 export type TrainBaseWithPacedTrainId = Omit<TrainScheduleResponse, 'id'> & {
   id: PacedTrainId;


### PR DESCRIPTION
Since unique trains and paced trains leave together inside `TrainSchedule` (depending if `paced` field is defined or not), we don't need to keep `PacedTrainId` for the timetable item ids now.
We still need to keep the distinction for `TrainId` though since we need to be able to differentiate in the STD for example if a train is a paced train, an occurrence or a unique train.

> [!NOTE]
> These changes need, at some places, to chain the "extract" from `OccurrenceId` to `PacedTrainId` to `editoastId` but it was decided that it's better to do that instead of adding a skipping function which doest both.

Since `TrainSchedule` now refers to both a paced train or a unique train, we no longer need to use `TimetableItem` in the codebase and can use `TrainSchedule`, it will be handled in a follow up PR.

> [!CAUTION]
> There a lot of places where "paced train" doesn't make sense anymore. There will be a follow up PR to rename all unnecessary "paced train" into "train schedule".

Most of the app should be tested since a lot of files are concerned.
But they were a few places where we need to be careful to test because code has recently changed : 
- roundtrips : changes in postPayload.ts)
- train list : check that hovering a unique train / paced train / occurrence also hovers them in the STD
- STD curves hover : changes in SpaceTimeChartWrapper, buildSplitPoints, getPathStyle
- STD drag unique train / paced train : changes in  createHandleTrainDrag
- STD curve category colors : changes in formatSpaceTimeCurves
- Projection when transforming in a paced train to a unique train : changes in useUpdateTimetableItem

Thanks to @clarani who did most of the work !