### PR TITLE
editoast: do not send origin/destination in boundaries

### DIFF
--- a/editoast/core_task/src/envs/simulation.rs
+++ b/editoast/core_task/src/envs/simulation.rs
@@ -45,7 +45,7 @@ where
 ///
 /// It is necessary to obtain a path to run a simulation, but pathfinding request may fail.
 /// The error is forwarded by [SimulationOutput::PathfindingFailure].
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg_attr(test, derive(PartialEq))]
 #[expect(clippy::large_enum_variant)] // success is large, we can Box it if it becomes problematic but it's less convenient
 pub enum SimulationOutput {

--- a/editoast/core_task/src/envs/simulation.rs
+++ b/editoast/core_task/src/envs/simulation.rs
@@ -545,24 +545,31 @@ mod tests {
         use futures::StreamExt as _;
         let simulations = simenv
             .into_stream(Arc::new(Mutex::new(vk.get_connection().await.unwrap())))
-            .collect::<Vec<_>>()
+            .flat_map(
+                |Correlated {
+                     correlation_key,
+                     data,
+                 }| {
+                    futures::stream::iter(
+                        correlation_key
+                            .into_iter()
+                            .map(move |train| (train, data.clone())),
+                    )
+                },
+            )
+            .collect::<HashMap<_, _>>()
             .await;
         assert_eq!(
-            simulations,
-            vec![
-                Correlated::new(
-                    TrainSet::from([1usize]),
-                    Ok(SimulationOutput::Success(
-                        serde_json::from_value(simulation_success(1)).unwrap()
-                    ))
-                ),
-                Correlated::new(
-                    TrainSet::from([2usize]),
-                    Ok(SimulationOutput::Success(
-                        serde_json::from_value(simulation_success(2)).unwrap()
-                    ))
-                )
-            ]
+            *simulations.get(&1).unwrap(),
+            Ok(SimulationOutput::Success(
+                serde_json::from_value(simulation_success(1)).unwrap()
+            )),
+        );
+        assert_eq!(
+            *simulations.get(&2).unwrap(),
+            Ok(SimulationOutput::Success(
+                serde_json::from_value(simulation_success(2)).unwrap()
+            ))
         );
     }
 }

--- a/editoast/core_task/src/envs/simulation/request.rs
+++ b/editoast/core_task/src/envs/simulation/request.rs
@@ -86,13 +86,22 @@ pub(super) fn build_request(
         }
     }
 
+    let margin_boundaries_len = margin_boundaries.len();
     Ok(core_client::simulation::Request {
         infra: core_env.infra_id as i64,
         expected_version: core_env.infra_version,
         electrical_profile_set_id: electrical_profile_set_id.map(|id| id as i64),
         schedule,
         margins: core_client::simulation::SimulationMargins {
-            boundaries: margin_boundaries,
+            // Margins are defined on the entire path, from origin to
+            // destination. Therefore, the only interesting boundaries are the
+            // one in-between. Origin and Destination are not part of the API
+            // contract.
+            boundaries: margin_boundaries
+                .into_iter()
+                .skip(1)
+                .take(margin_boundaries_len.saturating_sub(2))
+                .collect(),
             values: margin_values,
         },
         power_restrictions,
@@ -344,7 +353,7 @@ mod tests {
                 },
             ],
             margins: core_client::simulation::SimulationMargins {
-                boundaries: vec![0u64, 10u64, 30u64, 40u64],
+                boundaries: vec![10u64, 30u64],
                 values: vec![
                     MarginValue::Percentage(10.0),
                     MarginValue::Percentage(5.0),

--- a/editoast/core_task/src/lib.rs
+++ b/editoast/core_task/src/lib.rs
@@ -1,7 +1,6 @@
 mod envs;
 mod path_properties;
 
-use std::iter;
 use std::sync::Arc;
 
 // Crate-level exports
@@ -238,8 +237,8 @@ where
             // and sends a bunch of data to the 'aggregation' task
             tokio::spawn(
                 self.chunks(T::CACHE_READS_BATCH_SIZE)
-                    .zip(stream::iter(iter::repeat(vkconn.clone())))
-                    .zip(stream::iter(iter::repeat(cache_read_tx)))
+                    .zip(stream::repeat(vkconn.clone()))
+                    .zip(stream::repeat(cache_read_tx))
                     .for_each_concurrent(None, async move |((inputs, vkconn), cache_read_tx)| {
                         let mut vk = vkconn.lock().await;
 


### PR DESCRIPTION
The number of margin boundaries are one less than the values, because they are necessarily defined on the entire path, and therefore, the origin and destination would be redundant to add.

The way `RangeMap` iterates makes the construction of the boundaries contains the origin and destination so we need to remove them.