### PR TITLE
front: allow submit with invalid pathsteps in itinerary modal

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModal.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModal.tsx
@@ -5,7 +5,6 @@ import { ArrowSwitch, FrameAll, Plus } from '@osrd-project/ui-icons';
 import bbox from '@turf/bbox';
 import cx from 'classnames';
 import type { Position } from 'geojson';
-import { compact } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
@@ -387,31 +386,33 @@ const ItineraryModal = ({
   };
 
   const buildPathSteps = (steps: PathStepV2[], metadataById: Map<string, PathStepMetadata>) =>
-    steps.map<PathStep | null>((step) => {
-      if (!step.location) return null;
+    steps
+      .filter((step) => step.location !== null)
+      .map<PathStep>((step) => {
+        const metadata = metadataById.get(step.id);
 
-      const metadata = metadataById.get(step.id);
-      if (!metadata || metadata.isInvalid) return null;
+        const baseStep = {
+          id: step.id,
+          location: step.location!,
+          arrival: step.arrival,
+          stopFor: step.stopFor,
+          theoreticalMargin: step.theoreticalMargin ?? undefined,
+          receptionSignal: step.receptionSignal ?? undefined,
+        };
 
-      const coordinates =
-        metadata.type === 'trackOffset' ? metadata.coordinates : metadata.parts[0]?.coordinates;
+        if (!metadata || metadata.isInvalid) {
+          return { ...baseStep, isInvalid: true };
+        }
 
-      const secondary_code = metadata.type === 'opRef' ? metadata.secondaryCode : undefined;
-
-      return {
-        id: step.id,
-        location: step.location,
-        arrival: step.arrival,
-        stopFor: step.stopFor,
-        theoreticalMargin: step.theoreticalMargin ?? undefined,
-        receptionSignal: step.receptionSignal ?? undefined,
-
-        name: metadata.type === 'opRef' ? metadata.name : undefined,
-        uic: metadata.type === 'opRef' ? metadata.uic : undefined,
-        secondary_code,
-        coordinates,
-      };
-    });
+        return {
+          ...baseStep,
+          name: metadata.type === 'opRef' ? metadata.name : undefined,
+          uic: metadata.type === 'opRef' ? metadata.uic : undefined,
+          secondary_code: metadata.type === 'opRef' ? metadata.secondaryCode : undefined,
+          coordinates:
+            metadata.type === 'trackOffset' ? metadata.coordinates : metadata.parts[0]?.coordinates,
+        };
+      });
 
   const clearStep = (stepId: string) => {
     setInputForStep(stepId, '');
@@ -426,36 +427,31 @@ const ItineraryModal = ({
     const filledSteps = pathSteps.filter((step) => !isEmptyStep(step, getInputForStep(step.id)));
     const updatedPathSteps = buildPathSteps(filledSteps, pathStepsMetadataById);
 
-    // No step should be null when reverseItinerary is called (as start and arrival need to be defined), so compact should let the array unchanged but constrain the type
-    const cPathSteps = compact(updatedPathSteps);
+    if (updatedPathSteps.length < 2) return;
 
-    if (cPathSteps.length < 2) return;
-
-    launchPathfinding(reversePathSteps(cPathSteps));
+    launchPathfinding(reversePathSteps(updatedPathSteps));
   };
-
   const submitItinerary = () => {
     setSubmitAttempted(true);
     if (isNameEmpty) return;
-    if (locatedStepsCount < 2) {
-      return;
-    }
 
-    const filledSteps = pathSteps.filter((step) => !isEmptyStep(step, getInputForStep(step.id)));
-    if (filledSteps.length < 2) return;
-
-    const stepsWithStopAtDestination = filledSteps.map((step, i) =>
-      i === filledSteps.length - 1 ? { ...step, stopFor: new Duration({ minutes: 0 }) } : step
+    const stepsWithLocationOrInput = pathSteps.filter(
+      (step) => !isEmptyStep(step, getInputForStep(step.id))
     );
+    if (stepsWithLocationOrInput.length < 2) return;
 
-    const updatedPathSteps = buildPathSteps(stepsWithStopAtDestination, pathStepsMetadataById);
+    const stepsWithStopAtDestination = stepsWithLocationOrInput.map((step, i) =>
+      i === stepsWithLocationOrInput.length - 1
+        ? { ...step, stopFor: new Duration({ minutes: 0 }) }
+        : step
+    );
+    //TODO this variable name should be changed when we no longer have to convert from v2 to v1 for path steps
+    const pathStepsFromV2 = buildPathSteps(stepsWithStopAtDestination, pathStepsMetadataById);
 
-    const compacted = compact(updatedPathSteps);
+    if (pathStepsFromV2.length < 2) return;
 
-    if (compacted.length < 2) return;
-
-    dispatch(updatePathSteps(compacted));
-    launchPathfinding(compacted, rollingStockId, { isInitialization: true });
+    dispatch(updatePathSteps(pathStepsFromV2));
+    launchPathfinding(pathStepsFromV2, rollingStockId, { isInitialization: true });
     closeModal();
   };
 

--- a/front/src/modules/pathfinding/components/Itinerary/DisplayItinerary/Destination.tsx
+++ b/front/src/modules/pathfinding/components/Itinerary/DisplayItinerary/Destination.tsx
@@ -49,7 +49,14 @@ const Destination = ({ zoomToFeaturePoint }: DestinationProps) => {
         >
           <strong data-testid="destination-op-info" className="mr-1 text-nowrap">
             {/* If destination doesn't have name, we know that it has been added by click on map and has a track property */}
-            {destination?.name || (location && 'track' in location && location.track.split('-')[0])}
+            {destination?.name ||
+              (destination &&
+                'track' in destination.location &&
+                destination.location.track.split('-')[0]) ||
+              (destination &&
+                'operational_point' in destination.location &&
+                destination.location.operational_point.type === 'trigram' &&
+                destination.location.operational_point.trigram)}
           </strong>
           {location &&
             'operational_point' in location &&

--- a/front/src/modules/pathfinding/components/Itinerary/DisplayItinerary/Origin.tsx
+++ b/front/src/modules/pathfinding/components/Itinerary/DisplayItinerary/Origin.tsx
@@ -32,7 +32,12 @@ const Origin = ({ zoomToFeaturePoint }: OriginProps) => {
     >
       <strong data-testid="origin-op-info" className="mr-1 text-nowrap">
         {/* If origin doesn't have name, we know that it has been added by click on map and has a track property */}
-        {origin?.name || (location && 'track' in location && location.track.split('-')[0])}
+        {origin?.name ||
+          (origin && 'track' in origin.location && origin.location.track.split('-')[0]) ||
+          (origin &&
+            'operational_point' in origin.location &&
+            origin.location.operational_point.type === 'trigram' &&
+            origin.location.operational_point.trigram)}
       </strong>
       {location && 'operational_point' in location && location.operational_point.type !== 'id' && (
         <>

--- a/front/src/modules/pathfinding/components/Itinerary/DisplayItinerary/Vias.tsx
+++ b/front/src/modules/pathfinding/components/Itinerary/DisplayItinerary/Vias.tsx
@@ -41,7 +41,15 @@ const Vias = ({ zoomToFeaturePoint }: ViasProps) => {
             >
               <small className="font-weight-bold text-muted mr-1">{index + 1}</small>
               <small data-testid="via-dropped-name" className="mr-1 text-nowrap">
-                {`${via.name || (via.positionOnPath && `KM ${(Math.round(via.positionOnPath) / 1000000).toFixed(3)}`) || t('unavailableDistance')}`}
+                {`${
+                  via.name ||
+                  ('operational_point' in via.location &&
+                    via.location.operational_point.type === 'trigram' &&
+                    via.location.operational_point.trigram) ||
+                  (via.positionOnPath &&
+                    `KM ${(Math.round(via.positionOnPath) / 1000000).toFixed(3)}`) ||
+                  t('unavailableDistance')
+                }`}
               </small>
               {'operational_point' in via.location &&
                 via.location.operational_point.type !== 'id' &&


### PR DESCRIPTION
close #15716
close #15115 

Removed conditions in `submitItinerary` to allow submitting with invalid path steps. 

It was decided it was ok to build the invalid path step on this following format when the user has typed something not recognized in our infra : ` operational_point: {
            type: 'trigram',
            trigram: inputValue,
            secondary_code: null,
          },`

We will later have a specific field for the unrecognized waypoint, but for now it is ok to have it as a trigram. 
