### PR TITLE
core: DistanceRangeMap: add foreach

### DIFF
--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/EnvelopeTrainPath.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/EnvelopeTrainPath.kt
@@ -23,9 +23,9 @@ object EnvelopeTrainPath {
         val gradePositions = DoubleArrayList()
         gradePositions.add(0.0)
         val gradeValues = DoubleArrayList()
-        for (range in path.getGradients()) {
-            gradePositions.add(toMeters(range.upper))
-            gradeValues.add(range.value)
+        path.getGradients().forEach { _, upper, value ->
+            gradePositions.add(toMeters(upper))
+            gradeValues.add(value)
         }
 
         val distanceElectrificationMap = buildElectrificationMap(path)
@@ -72,8 +72,8 @@ object EnvelopeTrainPath {
         map: DistanceRangeMap<Electrification>
     ): ImmutableRangeMap<Double, Electrification> {
         val res = TreeRangeMap.create<Double, Electrification>()
-        for (entry in map) {
-            res.put(Range.closed(toMeters(entry.lower), toMeters(entry.upper)), entry.value)
+        map.forEach { lower, upper, value ->
+            res.put(Range.closed(toMeters(lower), toMeters(upper)), value)
         }
         return ImmutableRangeMap.copyOf(res)
     }

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathImpl.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathImpl.kt
@@ -360,10 +360,10 @@ data class TrainPathImpl(
             if (dirChunk.direction == Direction.INCREASING) return data
             val chunkLength = rawInfra.getTrackChunkLength(dirChunk.value).distance
             val res = distanceRangeMapOf<T>()
-            for (entry in data) {
-                assert(0.meters <= entry.lower && entry.lower <= chunkLength)
-                assert(0.meters <= entry.upper && entry.upper <= chunkLength)
-                res.put(chunkLength - entry.upper, chunkLength - entry.lower, entry.value)
+            data.forEach { lower, upper, value ->
+                assert(0.meters <= lower && lower <= chunkLength)
+                assert(0.meters <= upper && upper <= chunkLength)
+                res.put(chunkLength - upper, chunkLength - lower, value)
             }
             return res
         }

--- a/core/kt-osrd-rjs-parser/src/main/kotlin/fr/sncf/osrd/RawInfraRJSParser.kt
+++ b/core/kt-osrd-rjs-parser/src/main/kotlin/fr/sncf/osrd/RawInfraRJSParser.kt
@@ -444,15 +444,16 @@ fun parseNeutralRanges(
 
                 val previousDirNeutralSections =
                     chunkDirNeutralSections.subMap(dirChunkLower, dirChunkUpper)
-                for (previousNeutralSection in previousDirNeutralSections) {
-                    if (previousNeutralSection.value != incomingNeutralSection) {
+                previousDirNeutralSections.forEachWhile { _, _, value ->
+                    if (value != incomingNeutralSection) {
                         logger.warn(
                             "Neutral-section conflict on track-range $track.$dir" +
                                 "[$chunkLower, $chunkUpper]: " +
-                                "${previousNeutralSection.value} != $incomingNeutralSection"
+                                "$value != $incomingNeutralSection"
                         )
-                        break
+                        return@forEachWhile false
                     }
+                    true
                 }
 
                 chunkDirNeutralSections.put(dirChunkLower, dirChunkUpper, incomingNeutralSection)

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraImpl.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraImpl.kt
@@ -532,8 +532,10 @@ class RawInfraImpl(
 
         val trainSpeedLimitTagDescriptor = speedLimitTagPool[trainTag]
 
-        for (entry in trackChunkPool[trackChunk.value].speedSections.get(trackChunk.direction)) {
-            val speedSection = entry.value
+        trackChunkPool[trackChunk.value].speedSections.get(trackChunk.direction).forEach {
+            lower,
+            upper,
+            speedSection ->
             val infraTagSpeedAndSource =
                 getInfraTagSpeedAndSource(speedSection, trainTag, trainSpeedLimitTagDescriptor)
 
@@ -563,7 +565,7 @@ class RawInfraImpl(
                         if (trainTag != null) SpeedLimitSource.UnknownTag() else null,
                     )
                 }
-            res.put(entry.lower, entry.upper, allowedSpeedAndTag)
+            res.put(lower, upper, allowedSpeedAndTag)
         }
         return res
     }

--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/DistanceRangeMapExt.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/DistanceRangeMapExt.kt
@@ -14,9 +14,7 @@ import fr.sncf.osrd.utils.units.Distance
  */
 fun <T : Any> DistanceRangeMap<T>.toRangeMap(): RangeMap<Double, T> {
     val res = ImmutableRangeMap.builder<Double, T>()
-    for (entry in this) {
-        res.put(Range.closedOpen(entry.lower.meters, entry.upper.meters), entry.value)
-    }
+    forEach { lower, upper, value -> res.put(Range.closedOpen(lower.meters, upper.meters), value) }
     return res.build()
 }
 
@@ -34,8 +32,8 @@ fun <T : Any> DistanceRangeMapImpl.Companion.toRangeMap(
     distanceRangeMap: DistanceRangeMap<T>
 ): RangeMap<Distance, T> {
     val rangeMap = TreeRangeMap.create<Distance, T>()
-    for (entry in distanceRangeMap) {
-        rangeMap.put(Range.closed(entry.lower, entry.upper), entry.value)
+    distanceRangeMap.forEach { lower, upper, value ->
+        rangeMap.put(Range.closed(lower, upper), value)
     }
     return rangeMap
 }

--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeMap.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeMap.kt
@@ -81,6 +81,15 @@ interface DistanceRangeMap<T> : Iterable<DistanceRangeMap.RangeMapEntry<T>> {
 
     /** Clear the map */
     fun clear()
+
+    /**
+     * Run the callback for each entry in the map, on (lower, upper, value). Similar to iterating
+     * over entries, but without allocating a `RangeMapEntry` for each entry.
+     */
+    fun forEach(callback: (lower: Distance, upper: Distance, value: T) -> Unit)
+
+    /** Same as [forEach], with early exit if the callback returns false. */
+    fun forEachWhile(callback: (lower: Distance, upper: Distance, value: T) -> Boolean)
 }
 
 fun <T> distanceRangeMapOf(vararg entries: DistanceRangeMap.RangeMapEntry<T>): DistanceRangeMap<T> {
@@ -108,8 +117,8 @@ fun <T, R> filterIntersection(
     filter: DistanceRangeMap<R>,
 ): DistanceRangeMap<T> {
     val res = distanceRangeMapOf<T>()
-    for (range in filter) {
-        val filteredRange = mapToFilter.subMap(range.lower, range.upper)
+    filter.forEach { lower, upper, _ ->
+        val filteredRange = mapToFilter.subMap(lower, upper)
         res.putMany(filteredRange)
     }
     return res

--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeMapImpl.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeMapImpl.kt
@@ -196,7 +196,7 @@ data class DistanceRangeMapImpl<T>(
         updateFunction: (T, U) -> T,
     ) {
         for ((updateLower, updateUpper, updateValue) in update) {
-            for ((subMapLower, subMapUpper, subMapValue) in this.subMap(updateLower, updateUpper)) {
+            subMap(updateLower, updateUpper).forEach { subMapLower, subMapUpper, subMapValue ->
                 this.put(subMapLower, subMapUpper, updateFunction(subMapValue, updateValue))
             }
         }
@@ -256,7 +256,7 @@ data class DistanceRangeMapImpl<T>(
         // Add non-overlapping segments from `this`
         // It's the same thing except we never add the overlapping segments
         // Iterate over each range in the update map
-        for ((thisLower, thisUpper, thisValue) in this) {
+        forEach { thisLower, thisUpper, thisValue ->
             val subMap = update.subMap(thisLower, thisUpper)
 
             // Track segments that are part of the updated map but not intersecting with `this`
@@ -298,6 +298,20 @@ data class DistanceRangeMapImpl<T>(
     override fun clear() {
         bounds.clear()
         values.clear()
+    }
+
+    override fun forEach(callback: (lower: Distance, upper: Distance, value: T) -> Unit) {
+        for ((i, value) in values.withIndex()) {
+            if (value == null) continue
+            callback(bounds[i], bounds[i + 1], value)
+        }
+    }
+
+    override fun forEachWhile(callback: (lower: Distance, upper: Distance, value: T) -> Boolean) {
+        for ((i, value) in values.withIndex()) {
+            if (value == null) continue
+            if (!callback(bounds[i], bounds[i + 1], value)) break
+        }
     }
 
     /** Merges adjacent values, removes 0-length ranges */

--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeSet.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/DistanceRangeSet.kt
@@ -44,9 +44,9 @@ fun distanceRangeSetOf(): DistanceRangeSet {
  */
 fun <T> DistanceRangeMap<T>.mapToRangeSet(f: (T) -> Boolean): DistanceRangeSet {
     val res = distanceRangeSetOf()
-    for (entry in this) {
-        if (f(entry.value)) {
-            res.put(entry.lower, entry.upper)
+    forEach { lower, upper, value ->
+        if (f(value)) {
+            res.put(lower, upper)
         }
     }
     return res

--- a/core/src/main/kotlin/fr/sncf/osrd/api/etcs/ETCSBrakingCurvesEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/etcs/ETCSBrakingCurvesEndpoint.kt
@@ -181,8 +181,7 @@ class ETCSBrakingCurvesEndpoint(
     ): Envelope {
         val speedLimitDistanceRangeMap = rawMrsp.toDistanceRangeMap(beginPos, endPos)
         val mrspParts = mutableListOf<EnvelopePart>()
-        for (entry in speedLimitDistanceRangeMap) {
-            val speedLimitProperty = entry.value
+        speedLimitDistanceRangeMap.forEach { lower, upper, speedLimitProperty ->
             val speed = speedLimitProperty.speed.metersPerSecond
             val speedLimitSource = speedLimitProperty.source
             val attrs: MutableList<SelfTypeHolder> = mutableListOf(EnvelopeProfile.CONSTANT_SPEED)
@@ -190,7 +189,7 @@ class ETCSBrakingCurvesEndpoint(
             mrspParts.add(
                 EnvelopePart.generateTimes(
                     attrs,
-                    doubleArrayOf(entry.lower.meters, entry.upper.meters),
+                    doubleArrayOf(lower.meters, upper.meters),
                     doubleArrayOf(speed, speed),
                 )
             )

--- a/core/src/main/kotlin/fr/sncf/osrd/api/path_properties/PathPropResponseConverter.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/path_properties/PathPropResponseConverter.kt
@@ -122,9 +122,9 @@ private fun makeZones(path: TrainPath, rawInfra: RawSignalingInfra): RangeValues
 private fun <T> makeRangeValues(distanceRangeMap: DistanceRangeMap<T>): RangeValues<T> {
     val boundaries = mutableListOf<Offset<PhysicsPath>>()
     val values = mutableListOf<T>()
-    for (entry in distanceRangeMap) {
-        boundaries.add(Offset(entry.upper))
-        values.add(entry.value)
+    distanceRangeMap.forEach { _, upper, value ->
+        boundaries.add(Offset(upper))
+        values.add(value)
     }
     boundaries.removeLast()
     return RangeValues(boundaries, values)
@@ -134,25 +134,19 @@ private fun makeElectrificationMap(
     distanceRangeMap: DistanceRangeMap<out Any>
 ): DistanceRangeMap<Electrification> {
     val res = DistanceRangeMapImpl<Electrification>()
-    for (entry in distanceRangeMap) {
-        when (entry.value) {
+    distanceRangeMap.forEach { lower, upper, value ->
+        when (value) {
             // Is electrified
             is Set<*> -> {
-                val values = (entry.value as Set<*>)
                 res.put(
-                    entry.lower,
-                    entry.upper,
-                    if (values.isEmpty()) NonElectrified()
-                    else Electrified(values.first() as String),
+                    lower,
+                    upper,
+                    if (value.isEmpty()) NonElectrified() else Electrified(value.first() as String),
                 )
             }
             // Is neutral
             is NeutralSection -> {
-                res.put(
-                    entry.lower,
-                    entry.upper,
-                    Neutral((entry.value as NeutralSection).lowerPantograph),
-                )
+                res.put(lower, upper, Neutral(value.lowerPantograph))
             }
             else -> {
                 throw IllegalArgumentException(

--- a/core/src/main/kotlin/fr/sncf/osrd/envelope_sim_infra/MRSP.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/envelope_sim_infra/MRSP.kt
@@ -86,11 +86,10 @@ fun computeMRSP(
     val speedLimitProperties =
         if (useSpeedLimits) path.getSpeedLimitProperties(trainTag, temporarySpeedLimitManager)
         else distanceRangeMapOf()
-    for (speedLimitPropertyRange in speedLimitProperties) {
+    speedLimitProperties.forEach { lowerSpeedLimitRange, upperSpeedLimitRange, speedLimitProp ->
         // Compute where this limit is active from and to
-        val start = toMeters(speedLimitPropertyRange.lower)
-        val end = min(pathLength, offset + toMeters(speedLimitPropertyRange.upper))
-        val speedLimitProp = speedLimitPropertyRange.value
+        val start = toMeters(lowerSpeedLimitRange)
+        val end = min(pathLength, offset + toMeters(upperSpeedLimitRange))
         val speed = toMetersPerSecond(speedLimitProp.speed)
         val attrs =
             mutableListOf<SelfTypeHolder>(
@@ -126,8 +125,7 @@ fun computeMRSP(
 
     // Add safety speeds
     if (useSpeedLimits && safetySpeedRanges != null) {
-        for (range in safetySpeedRanges) {
-            val speed = range.value
+        safetySpeedRanges.forEach { lower, upper, speed ->
             val newAttrs =
                 listOf<SelfTypeHolder>(
                     EnvelopeProfile.CONSTANT_SPEED,
@@ -135,8 +133,8 @@ fun computeMRSP(
                 )
             addSpeedSection(
                 builder,
-                range.lower,
-                Distance.min(range.upper, pathLength.meters),
+                lower,
+                Distance.min(upper, pathLength.meters),
                 speed,
                 newAttrs,
                 speedLimitProperties,
@@ -155,11 +153,11 @@ fun addSpeedSection(
     propertyRangeMap: DistanceRangeMap<SpeedLimitProperty>,
 ) {
     val propsRanges = makeSpeedLimitAttributes(lower, upper, propertyRangeMap, attrs)
-    for (propsRange in propsRanges) {
+    propsRanges.forEach { lower, upper, value ->
         builder.addPart(
             EnvelopePart.generateTimes(
-                propsRange.value,
-                doubleArrayOf(propsRange.lower.meters, propsRange.upper.meters),
+                value,
+                doubleArrayOf(lower.meters, upper.meters),
                 doubleArrayOf(speed.metersPerSecond, speed.metersPerSecond),
             )
         )
@@ -183,12 +181,12 @@ fun makeSpeedLimitAttributes(
     // Add important attributes from the old speed ranges
     val attrsWithMissingRange = baseAttrs.toMutableList()
     attrsWithMissingRange.add(HasMissingSpeedTag)
-    for (oldRange in propertyRangeMap.subMap(lower, upper)) {
-        if (oldRange.value.source is UnknownTag) {
+    propertyRangeMap.subMap(lower, upper).forEach { lower, upper, value ->
+        if (value.source is UnknownTag) {
             // TODO: ideally, it shouldn't be this method's job to figure out which attributes
             // should be kept. Eventually we may look into reworking this, either with warnings or
             // by making the builder handle this
-            result.put(oldRange.lower, oldRange.upper, attrsWithMissingRange)
+            result.put(lower, upper, attrsWithMissingRange)
         }
     }
 

--- a/core/src/main/kotlin/fr/sncf/osrd/pathfinding/constraints/ElectrificationConstraints.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/pathfinding/constraints/ElectrificationConstraints.kt
@@ -41,8 +41,8 @@ data class ElectrificationConstraints(
             val res = HashSet<OffsetRange<Block>>()
             val voltages = path.getElectrification()
             val neutralSections = rangeSetFromMap(path.getNeutralSections())
-            for ((lower, upper, value) in voltages) {
-                if (lower == upper) continue
+            voltages.forEach { lower, upper, value ->
+                if (lower == upper) return@forEach
                 if (compatibleElectrification.intersect(value).isEmpty()) {
                     val voltageInterval = Range.open(lower, upper)
                     val blockingRanges =


### PR DESCRIPTION
Fix https://github.com/OpenRailAssociation/osrd/issues/15828, because @hhirtz shouldn't be the only one working to improve `DistanceRangeMap` :smile: 

I'll finish this once the other PRs are merged to avoid massive conflicts.

Iterating that way goes roughly 30% faster as we don't need to create all entry objects (just the iterating, not the actual processing inside the loops). It also reduces the number of allocations. 