### PR TITLE
front: empty combobox value when pathstep is invalid

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/PathStepItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/PathStepItem.tsx
@@ -222,7 +222,9 @@ const PathStepItem = ({
 
   const comboBoxValue = useMemo(() => {
     // Don't show invalid points in the combobox - they'll be shown in the error message instead
-    if (inputValue !== undefined && pathStepMetadata?.isInvalid) return undefined;
+    if (shouldShowInvalidMessage) {
+      return '';
+    }
 
     if (inputValue !== undefined) return inputValue;
 
@@ -231,7 +233,7 @@ const PathStepItem = ({
     }
 
     return undefined;
-  }, [inputValue, pathStepMetadata]);
+  }, [shouldShowInvalidMessage, inputValue, pathStepMetadata]);
 
   const maxVisibleSuggestions = 8;
   const visibleSuggestions = opSuggestions.slice(0, maxVisibleSuggestions);


### PR DESCRIPTION
close #15833

now using `shouldShowInvalidMessage` for more consistency : error in the step -> we empty the value 
Also chose to set the input value to `""` instead of `undefined`, but both are working the same. 