### PR TITLE
core: stdcm: cache previous edges in nodes

### DIFF
--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/UnitEquality.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/UnitEquality.kt
@@ -1,6 +1,8 @@
 package fr.sncf.osrd.utils
 
 import kotlin.math.abs
+import kotlin.math.pow
+import kotlin.math.round
 
 // A position delta lower than this value will be considered zero
 // Going back and forth with Distance and double (meters) often causes 1e-3 errors,
@@ -37,6 +39,11 @@ fun isTimeStrictlyPositive(time: Double): Boolean {
     return time > TIME_EPSILON
 }
 
-private fun areDoublesEqual(a: Double, b: Double, delta: Double): Boolean {
+fun Double.round(decimals: Int = 1): Double {
+    val factor = 10.0.pow(decimals)
+    return round(this * factor) / factor
+}
+
+fun areDoublesEqual(a: Double, b: Double, delta: Double): Boolean {
     return abs(a - b) < delta
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/BacktrackingManager.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/BacktrackingManager.kt
@@ -1,6 +1,8 @@
 package fr.sncf.osrd.stdcm.graph
 
 import fr.sncf.osrd.envelope.Envelope
+import fr.sncf.osrd.utils.areDoublesEqual
+import fr.sncf.osrd.utils.round
 
 /**
  * This class contains all the methods used to backtrack in the graph. We need to backtrack to
@@ -20,24 +22,38 @@ class BacktrackingManager(private val graph: STDCMGraph) {
      * the new edge is invalid (for example if it would cause conflicts), returns null.
      */
     fun backtrack(edge: STDCMEdge, envelope: Envelope): STDCMEdge? {
-        if (edge.previousNode.previousEdge == null) {
+        val previousNode = edge.previousNode
+        val previousEdge = previousNode.previousEdge
+        if (previousEdge == null) {
             // First edge of the path
             assert(edge.beginSpeed == 0.0)
             return edge
         }
-        if (edge.previousNode.speed == edge.beginSpeed) {
+        if (areDoublesEqual(previousNode.speed, edge.beginSpeed, 1e-1)) {
             // No need to backtrack any further
             return edge
         }
 
-        // We try to create a new previous edge with the end speed we need
-        val previousEdge = edge.previousNode.previousEdge
+        // To limit caching and improve performance as much as possible, speed should be rounded to
+        // 1e-1. Deltas related to this small approximation can and will be handled by the stdcm
+        // post-processing.
+        val roundedEdgeBeginSpeed = edge.beginSpeed.round()
+        val cachedEdge = previousNode.getCachedPrevEdge(roundedEdgeBeginSpeed)
+        if (cachedEdge != null) {
+            // No need to backtrack any further
+            return edge
+        }
+
+        // We try to create a new previous edge with the rounded end speed we need
         val newPreviousEdge =
-            rebuildEdgeBackward(previousEdge, edge.beginSpeed)
+            rebuildEdgeBackward(previousEdge, roundedEdgeBeginSpeed)
                 ?: return null // No valid result was found
 
+        // Add new previous edge to existing node's cache
+        edge.previousNode.addCachedPrevEdge(newPreviousEdge)
+
         // Create the new edge
-        val newNode = newPreviousEdge.getEdgeEnd(graph)
+        val newNode = newPreviousEdge.getEdgeEnd(graph, edge.previousNode.cachedPrevEdges)
         return STDCMEdgeBuilder.fromNode(graph, newNode, edge.infraExplorer)
             .setEnvelope(envelope)
             .findEdgeSameNextOccupancy(edge.timeData.timeOfNextConflictAtLocation)

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdge.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdge.kt
@@ -9,6 +9,7 @@ import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import java.lang.Double.isNaN
+import java.lang.ref.SoftReference
 
 data class STDCMEdge(
     val timeData: TimeData,
@@ -55,7 +56,10 @@ data class STDCMEdge(
     )
 
     /** Returns the node at the end of this edge */
-    fun getEdgeEnd(graph: STDCMGraph): STDCMNode {
+    fun getEdgeEnd(
+        graph: STDCMGraph,
+        cachedPrevEdges: Map<Double, SoftReference<STDCMEdge>> = mapOf(),
+    ): STDCMNode {
         val previousPlannedNodeRelativeTimeDiff = getPreviousPlannedNodeRelativeTimeDiff()
         val stepTracker = infraExplorer.getStepTracker()
         val newExplorer = infraExplorerWithNewEnvelope.clone()
@@ -66,47 +70,51 @@ data class STDCMEdge(
                 envelopeStartOffset,
                 envelopeStartOffset + length.distance,
             )
-        return if (!endAtStop) {
-            // We move on to the next block
-            STDCMNode(
-                timeData.withAddedTime(totalTime, null, null),
-                endSpeed,
-                newExplorer,
-                this,
-                null,
-                null,
-                null,
-                previousPlannedNodeRelativeTimeDiff,
-                graph.remainingTimeEstimator.invoke(this, null, stepTracker),
-                graph,
-            )
-        } else {
-            // New edge on the same block, after a stop
-            val nextStop =
-                stepTracker.iterateStepsInLookaheadBackwards().last { it.originalStep.stop }
-            val stopDuration = nextStop.originalStep.duration
-            val locationOnEdge = envelopeStartOffset + length.distance
+        val node =
+            if (!endAtStop) {
+                // We move on to the next block
+                STDCMNode(
+                    timeData.withAddedTime(totalTime, null, null),
+                    endSpeed,
+                    newExplorer,
+                    this,
+                    null,
+                    null,
+                    null,
+                    previousPlannedNodeRelativeTimeDiff,
+                    graph.remainingTimeEstimator.invoke(this, null, stepTracker),
+                    graph,
+                )
+            } else {
+                // New edge on the same block, after a stop
+                val nextStop =
+                    stepTracker.iterateStepsInLookaheadBackwards().last { it.originalStep.stop }
+                val stopDuration = nextStop.originalStep.duration
+                val locationOnEdge = envelopeStartOffset + length.distance
 
-            STDCMNode(
-                timeData.withAddedTime(
-                    totalTime,
-                    stopDuration,
-                    graph.delayManager.getMaxAdditionalStopDuration(
-                        infraExplorerWithNewEnvelope,
-                        getEdgeEndTime(),
+                STDCMNode(
+                    timeData.withAddedTime(
+                        totalTime,
+                        stopDuration,
+                        graph.delayManager.getMaxAdditionalStopDuration(
+                            infraExplorerWithNewEnvelope,
+                            getEdgeEndTime(),
+                        ),
                     ),
-                ),
-                endSpeed,
-                newExplorer,
-                this,
-                envelopeStartOffset + length.distance,
-                stopDuration,
-                nextStop.originalStep.plannedTimingData,
-                previousPlannedNodeRelativeTimeDiff,
-                graph.remainingTimeEstimator.invoke(this, locationOnEdge, stepTracker),
-                graph,
-            )
-        }
+                    endSpeed,
+                    newExplorer,
+                    this,
+                    envelopeStartOffset + length.distance,
+                    stopDuration,
+                    nextStop.originalStep.plannedTimingData,
+                    previousPlannedNodeRelativeTimeDiff,
+                    graph.remainingTimeEstimator.invoke(this, locationOnEdge, stepTracker),
+                    graph,
+                )
+            }
+        // Add cached previous edges if any.
+        node.addCachedPrevEdges(cachedPrevEdges)
+        return node
     }
 
     /**

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMNode.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMNode.kt
@@ -9,6 +9,7 @@ import fr.sncf.osrd.utils.SoftLazy
 import fr.sncf.osrd.utils.areTimesEqual
 import fr.sncf.osrd.utils.cacheable
 import fr.sncf.osrd.utils.units.Offset
+import java.lang.ref.SoftReference
 import kotlin.math.min
 
 data class STDCMNode(
@@ -34,6 +35,29 @@ data class STDCMNode(
     // Reference to the main graph. Only null in some unit tests, where we don't have a full graph
     val graph: STDCMGraph?,
 ) : Comparable<STDCMNode> {
+
+    // Map of the possible end edge speeds to their corresponding edges that lead to this node
+    val cachedPrevEdges = HashMap<Double, SoftReference<STDCMEdge>>()
+
+    init {
+        if (previousEdge != null) {
+            cachedPrevEdges[speed] = SoftReference(previousEdge)
+        }
+    }
+
+    fun getCachedPrevEdge(endSpeed: Double): STDCMEdge? {
+        return cachedPrevEdges[endSpeed]?.get()
+    }
+
+    fun addCachedPrevEdges(cachedEdges: Map<Double, SoftReference<STDCMEdge>>) {
+        cachedEdges.forEach { (endSpeed, cachedEdge) ->
+            cachedPrevEdges.putIfAbsent(endSpeed, cachedEdge)
+        }
+    }
+
+    fun addCachedPrevEdge(edge: STDCMEdge) {
+        cachedPrevEdges.putIfAbsent(edge.endSpeed, SoftReference(edge))
+    }
 
     /**
      * Defines the estimated better path between 2 nodes, in the following priority:
@@ -78,7 +102,7 @@ data class STDCMNode(
         // If equal, take the train which has the smallest time since its departure.
         // Unlike the first check, this includes stop time.
         else if (!areTimesEqual(timeData.timeSinceDeparture, other.timeData.timeSinceDeparture))
-            return timeData.timeSinceDeparture.compareTo(other.timeData.timeSinceDeparture)
+            timeData.timeSinceDeparture.compareTo(other.timeData.timeSinceDeparture)
 
         // If equal, take the train which departs first
         else if (timeData.earliestReachableTime != other.timeData.earliestReachableTime)

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/StopTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/StopTests.kt
@@ -510,7 +510,7 @@ class StopTests {
         assertEquals(
             resWithConflict.stopResults.first().duration,
             10_000 - resTravelTime,
-            2 * timeStep,
+            3 * timeStep,
         )
         occupancyTest(resWithConflict, occupancy)
     }
@@ -656,7 +656,7 @@ class StopTests {
         val arrivalTime =
             res.departureTime + res.envelope.totalTime + res.stopResults.first().duration
         assertTrue(res.departureTime >= 3_000.0)
-        assertEquals(15_000.0, arrivalTime, timeStep)
+        assertEquals(15_000.0, arrivalTime, 2 * timeStep)
     }
 
     /** Checks that we can shift the departure time even when there are stops around. */


### PR DESCRIPTION
Cache previous edges for different end speeds in nodes so they can be directly used and not recomputed when backtracking.

Fuzzer: one assertion failing, unrelated to the PR as it happens on dev as well. ~Will be creating a corresponding minor bug with the faulty payload and context as I've already looked into it a little~ -> Done

Perfs look good. Retested on upgraded PC. -14% is pretty nice. These were done with 50/50 payloads with specified begin time/specified arrival time.

| | time_old | time_new | time_diff |
|---|---|---|---|
| count | 750.000000 | 750.000000 | 750.000000 |
| mean | 22.817927 | 19.450893 | -3.367033 |
| std | 34.170898 | 27.669715 | 7.070469 |
| min | 1.316000 | 1.254000 | -41.386000 |
| 25% | 4.348000 | 4.733000 | -3.551000 |
| 50% | 13.546000 | 11.785000 | -0.833500 |
| 75% | 23.263000 | 22.172000 | -0.049500 |
| max | 189.347000 | 157.067000 | 6.778000 |

| | mb_old | mb_new | mb_diff |
|---|---|---|---|
| count | 750.000000 | 750.000000 | 750.000000 |
| mean | 4381.340000 | 4305.626667 | -75.713333 |
| std | 2772.686126 | 3036.603466 | 1909.150186 |
| min | 1706.000000 | 1625.000000 | -6389.000000 |
| 25% | 2782.000000 | 2620.000000 | -1223.250000 |
| 50% | 3681.000000 | 3607.000000 | -144.000000 |
| 75% | 5189.000000 | 4922.000000 | 816.750000 |
| max | 20676.000000 | 20018.000000 | 6588.000000 |