### PR TITLE
editoast: renaming of schedules into path waypoints

### DIFF
--- a/editoast/core_task/src/envs/simulation.rs
+++ b/editoast/core_task/src/envs/simulation.rs
@@ -430,12 +430,12 @@ pub(crate) mod test_data {
         builder.push_waypoint(
             pathfinding::PathWaypointAlternatives::from_iter([TrackOffset::new("id", id as u64)]),
             NonBlankString::from("start"),
-            SimulationWaypointSchedule::PassBy,
+            SimulationWaypoint::PathItem,
         );
         builder.push_waypoint(
             pathfinding::PathWaypointAlternatives::from_iter([TrackOffset::new("a", 42)]),
             NonBlankString::from("a"),
-            SimulationWaypointSchedule::Stop {
+            SimulationWaypoint::ScheduleItem {
                 arrival_at: Some(1200),
                 stop_for: 60,
                 reception_signal: Default::default(),
@@ -447,7 +447,7 @@ pub(crate) mod test_data {
                 TrackOffset::new("bis", 34),
             ]),
             NonBlankString::from("b"),
-            SimulationWaypointSchedule::Stop {
+            SimulationWaypoint::ScheduleItem {
                 arrival_at: None,
                 stop_for: 120,
                 reception_signal: Default::default(),
@@ -456,7 +456,7 @@ pub(crate) mod test_data {
         builder.push_waypoint(
             pathfinding::PathWaypointAlternatives::from_iter([TrackOffset::new("finish", 44)]),
             NonBlankString::from("finish"),
-            SimulationWaypointSchedule::Stop {
+            SimulationWaypoint::ScheduleItem {
                 arrival_at: Some(2400),
                 stop_for: 0,
                 reception_signal: Default::default(),

--- a/editoast/core_task/src/envs/simulation/inputs.rs
+++ b/editoast/core_task/src/envs/simulation/inputs.rs
@@ -40,7 +40,7 @@ pub struct SimulationConsist(pub PhysicsConsist);
 #[derive(Debug, educe::Educe)]
 #[educe(Hash, PartialEq, Eq)]
 pub struct SimulationTrainParameters {
-    schedule: Vec<SimulationWaypointSchedule>,
+    path_items: Vec<SimulationWaypoint>,
     power_restrictions: rangemap::RangeMap<PathWaypointIndex, String>,
     margins: rangemap::RangeMap<PathWaypointIndex, MarginValue>,
 
@@ -55,11 +55,11 @@ pub struct SimulationTrainParameters {
 
 /// Schedule information for a path waypoint
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
-pub enum SimulationWaypointSchedule {
+pub enum SimulationWaypoint {
     /// No specific requirement
-    PassBy,
+    PathItem,
     /// The train must stop at this waypoint
-    Stop {
+    ScheduleItem {
         stop_for: u64,
         arrival_at: Option<u64>,
         reception_signal: ReceptionSignal,
@@ -75,7 +75,7 @@ impl SimulationTrainParameters {
         options: TrainScheduleOptions,
     ) -> Self {
         Self {
-            schedule: Default::default(),
+            path_items: Default::default(),
             power_restrictions: Default::default(),
             margins: Default::default(),
             initial_speed,
@@ -86,8 +86,8 @@ impl SimulationTrainParameters {
         }
     }
 
-    pub fn schedule(&self) -> &[SimulationWaypointSchedule] {
-        &self.schedule
+    pub fn schedule(&self) -> &[SimulationWaypoint] {
+        &self.path_items
     }
 
     pub fn power_restrictions(&self) -> &rangemap::RangeMap<PathWaypointIndex, String> {
@@ -119,7 +119,7 @@ impl SimulationTrainParameters {
     }
 
     fn is_empty(&self) -> bool {
-        self.schedule.is_empty() && self.power_restrictions.is_empty() && self.margins.is_empty()
+        self.path_items.is_empty() && self.power_restrictions.is_empty() && self.margins.is_empty()
     }
 }
 
@@ -167,7 +167,7 @@ pub struct SimulationTrain {
     pub(super) pathfinding_consist: PathfindingConsist,
     pub(super) parameters: SimulationTrainParameters,
     pub(super) path_constraints: PathfindingConstraints,
-    schedule_item_to_index: HashMap<NonBlankString, PathWaypointIndex>,
+    path_item_to_index: HashMap<NonBlankString, PathWaypointIndex>,
 }
 
 type PathWaypointIndex = usize;
@@ -189,13 +189,13 @@ impl SimulationTrain {
             path_constraints: PathfindingConstraints {
                 path_items: Vec::new(),
             },
-            schedule_item_to_index: HashMap::default(),
+            path_item_to_index: HashMap::default(),
         }
     }
 
     fn waypoints(&self) -> usize {
         let n = self.path_constraints.path_items.len();
-        debug_assert_eq!(n, self.parameters.schedule.len());
+        debug_assert_eq!(n, self.parameters.path_items.len());
         debug_assert!(
             self.parameters
                 .power_restrictions
@@ -215,12 +215,12 @@ impl SimulationTrain {
         &mut self,
         path_constraint: PathWaypointAlternatives,
         label: NonBlankString,
-        point: SimulationWaypointSchedule,
+        point: SimulationWaypoint,
     ) {
-        let index = self.parameters.schedule.len();
-        self.parameters.schedule.push(point);
+        let index = self.parameters.path_items.len();
+        self.parameters.path_items.push(point);
         self.path_constraints.path_items.push(path_constraint);
-        self.schedule_item_to_index.insert(label, index);
+        self.path_item_to_index.insert(label, index);
     }
 
     /// Sets a power restriction for a range of waypoints.
@@ -236,12 +236,12 @@ impl SimulationTrain {
         Q: Hash + Eq + ?Sized,
     {
         let begin_index = self
-            .schedule_item_to_index
+            .path_item_to_index
             .get(begin_label)
             .copied()
             .expect("only names already inserted through “push_waypoint” can be used");
         let end_index = self
-            .schedule_item_to_index
+            .path_item_to_index
             .get(end_label)
             .copied()
             .expect("only names already inserted through “push_waypoint” can be used");
@@ -268,12 +268,12 @@ impl SimulationTrain {
         Q: Hash + Eq + ?Sized,
     {
         let begin_index = self
-            .schedule_item_to_index
+            .path_item_to_index
             .get(begin_label)
             .copied()
             .expect("only names already inserted through “push_waypoint” can be used");
         let end_index = self
-            .schedule_item_to_index
+            .path_item_to_index
             .get(end_label)
             .copied()
             .expect("only names already inserted through “push_waypoint” can be used");
@@ -303,7 +303,7 @@ where
                             pathfinding_consist,
                             parameters,
                             path_constraints,
-                            schedule_item_to_index: _,
+                            path_item_to_index: _,
                         },
                     )| {
                         (

--- a/editoast/core_task/src/envs/simulation/request.rs
+++ b/editoast/core_task/src/envs/simulation/request.rs
@@ -10,7 +10,7 @@ use crate::Task;
 use crate::envs::pathfinding;
 
 use super::SimulationKey;
-use super::SimulationWaypointSchedule;
+use super::SimulationWaypoint;
 
 pub(super) fn build_request(
     core_env: &CoreEnv,
@@ -70,7 +70,7 @@ pub(super) fn build_request(
 
     let mut schedule = Vec::new();
     for (i, point) in params.schedule().iter().enumerate() {
-        if let SimulationWaypointSchedule::Stop {
+        if let SimulationWaypoint::ScheduleItem {
             arrival_at,
             stop_for,
             reception_signal,
@@ -145,7 +145,7 @@ mod tests {
     use crate::envs::simulation;
     use crate::envs::simulation::SimulationTrain;
     use crate::envs::simulation::SimulationTrainParameters;
-    use crate::envs::simulation::SimulationWaypointSchedule;
+    use crate::envs::simulation::SimulationWaypoint;
 
     /// Simple request with only schedule items
     #[test]
@@ -188,12 +188,12 @@ mod tests {
         builder.push_waypoint(
             path_items[0].clone(),
             NonBlankString::from("a"),
-            SimulationWaypointSchedule::PassBy,
+            SimulationWaypoint::PathItem,
         );
         builder.push_waypoint(
             path_items[1].clone(),
             NonBlankString::from("b"),
-            SimulationWaypointSchedule::Stop {
+            SimulationWaypoint::ScheduleItem {
                 arrival_at: Some(300),
                 stop_for: 0,
                 reception_signal: Default::default(),
@@ -285,7 +285,7 @@ mod tests {
             builder.push_waypoint(
                 path_items[i].clone(),
                 NonBlankString::from(i.to_string()),
-                SimulationWaypointSchedule::Stop {
+                SimulationWaypoint::ScheduleItem {
                     arrival_at: *arrival,
                     stop_for: 0,
                     reception_signal: Default::default(),
@@ -417,12 +417,12 @@ mod tests {
         builder.push_waypoint(
             PathWaypointAlternatives::from_iter([]),
             NonBlankString::from("a"),
-            SimulationWaypointSchedule::PassBy,
+            SimulationWaypoint::PathItem,
         );
         builder.push_waypoint(
             PathWaypointAlternatives::from_iter([]),
             NonBlankString::from("b"),
-            SimulationWaypointSchedule::Stop {
+            SimulationWaypoint::ScheduleItem {
                 arrival_at: Some(300),
                 stop_for: 0,
                 reception_signal: Default::default(),

--- a/editoast/core_task/src/lib.rs
+++ b/editoast/core_task/src/lib.rs
@@ -16,7 +16,7 @@ pub use envs::simulation::SimulationEnv;
 pub use envs::simulation::SimulationOutput;
 pub use envs::simulation::SimulationTrain;
 pub use envs::simulation::SimulationTrainParameters;
-pub use envs::simulation::SimulationWaypointSchedule;
+pub use envs::simulation::SimulationWaypoint;
 
 use futures::stream;
 use itertools::Itertools as _;


### PR DESCRIPTION
Simulation does not only take schedule item as input, but also any point by which the train schedule goes through, even without a schedule or a stop. These renaming should better reflect those semantics.