### PR TITLE
editoast: log errored authentication headers

### DIFF
--- a/editoast/src/authentication.rs
+++ b/editoast/src/authentication.rs
@@ -24,70 +24,44 @@ pub enum Authentication {
     },
 }
 
-impl Authentication {
-    pub fn builder() -> AuthenticationBuilder {
-        AuthenticationBuilder::default()
-    }
-}
-
 #[derive(Default)]
-pub struct AuthenticationBuilder {
+pub struct AuthenticationParameters {
     pub identity: Option<String>,
     pub name: Option<String>,
     pub impersonate: Option<String>,
     pub skip: bool,
 }
 
-impl AuthenticationBuilder {
-    pub fn identity(mut self, identity: Option<String>) -> Self {
-        self.identity = identity;
-        self
-    }
-
-    pub fn name(mut self, name: Option<String>) -> Self {
-        self.name = name;
-        self
-    }
-
-    pub fn impersonate(mut self, identity: Option<String>) -> Self {
-        self.impersonate = identity;
-        self
-    }
-
-    pub fn skip(mut self, skip: bool) -> Self {
-        self.skip = skip;
-        self
-    }
-
-    pub fn build(self) -> Result<Authentication, Self> {
-        let authn = match self {
-            Self {
+impl Authentication {
+    pub fn try_new(params: AuthenticationParameters) -> Result<Self, AuthenticationParameters> {
+        let authn = match params {
+            AuthenticationParameters {
                 skip: true,
                 identity,
                 name,
                 ..
-            } => Authentication::Skip { identity, name },
-            Self {
+            } => Self::Skip { identity, name },
+            AuthenticationParameters {
                 impersonate: Some(impersonated_identity),
                 identity: Some(impersonator_identity),
                 name: Some(impersonator_name),
                 ..
-            } => Authentication::Impersonating {
+            } => Self::Impersonating {
                 impersonator_identity,
                 impersonator_name,
                 impersonated_identity,
             },
-            Self {
+            AuthenticationParameters {
                 identity: Some(identity),
                 name: Some(name),
                 ..
-            } => Authentication::Authenticated { identity, name },
-            Self {
+            } => Self::Authenticated { identity, name },
+            AuthenticationParameters {
                 identity: None,
                 name: None,
                 impersonate: None,
                 ..
-            } => Authentication::Unauthenticated,
+            } => Self::Unauthenticated,
             params => return Err(params),
         };
         Ok(authn)

--- a/editoast/src/authentication.rs
+++ b/editoast/src/authentication.rs
@@ -32,10 +32,10 @@ impl Authentication {
 
 #[derive(Default)]
 pub struct AuthenticationBuilder {
-    identity: Option<String>,
-    name: Option<String>,
-    impersonate: Option<String>,
-    skip: bool,
+    pub identity: Option<String>,
+    pub name: Option<String>,
+    pub impersonate: Option<String>,
+    pub skip: bool,
 }
 
 impl AuthenticationBuilder {
@@ -59,7 +59,7 @@ impl AuthenticationBuilder {
         self
     }
 
-    pub fn build(self) -> Result<Authentication, ()> {
+    pub fn build(self) -> Result<Authentication, Self> {
         let authn = match self {
             Self {
                 skip: true,
@@ -88,7 +88,7 @@ impl AuthenticationBuilder {
                 impersonate: None,
                 ..
             } => Authentication::Unauthenticated,
-            _ => return Err(()),
+            params => return Err(params),
         };
         Ok(authn)
     }

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -84,6 +84,7 @@ use tracing::info;
 use tracing::warn;
 use url::Url;
 
+use crate::authentication::AuthenticationBuilder;
 use crate::error::Result;
 use crate::generated_data::speed_limit_tags_config::SpeedLimitTagIds;
 use crate::infra_cache::InfraCache;
@@ -516,10 +517,23 @@ async fn authentication_extraction_middleware(mut req: Request, next: Next) -> R
             .impersonate(impersonate)
             .skip(skip_authz)
             .build()
-            .map_err(|()| {
-                tracing::error!("invalid authentication parameters");
-                AuthorizationError::Unauthorized
-            })
+            .map_err(
+                |AuthenticationBuilder {
+                     identity,
+                     name,
+                     impersonate,
+                     skip,
+                 }| {
+                    tracing::error!(
+                        identity,
+                        name,
+                        impersonate,
+                        skip,
+                        "invalid authentication parameters"
+                    );
+                    AuthorizationError::Unauthorized
+                },
+            )
     })?;
 
     tracing::info!(?authn, "authentication complete");

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -84,7 +84,7 @@ use tracing::info;
 use tracing::warn;
 use url::Url;
 
-use crate::authentication::AuthenticationBuilder;
+use crate::authentication::AuthenticationParameters;
 use crate::error::Result;
 use crate::generated_data::speed_limit_tags_config::SpeedLimitTagIds;
 use crate::infra_cache::InfraCache;
@@ -511,29 +511,29 @@ async fn authentication_extraction_middleware(mut req: Request, next: Next) -> R
         skip_authz,
     )
     .in_scope(move || {
-        crate::authentication::Authentication::builder()
-            .identity(identity)
-            .name(name)
-            .impersonate(impersonate)
-            .skip(skip_authz)
-            .build()
-            .map_err(
-                |AuthenticationBuilder {
-                     identity,
-                     name,
-                     impersonate,
-                     skip,
-                 }| {
-                    tracing::error!(
-                        identity,
-                        name,
-                        impersonate,
-                        skip,
-                        "invalid authentication parameters"
-                    );
-                    AuthorizationError::Unauthorized
-                },
-            )
+        crate::authentication::Authentication::try_new(AuthenticationParameters {
+            identity,
+            name,
+            impersonate,
+            skip: skip_authz,
+        })
+        .map_err(
+            |AuthenticationParameters {
+                 identity,
+                 name,
+                 impersonate,
+                 skip,
+             }| {
+                tracing::error!(
+                    identity,
+                    name,
+                    impersonate,
+                    skip,
+                    "invalid authentication parameters"
+                );
+                AuthorizationError::Unauthorized
+            },
+        )
     })?;
 
     tracing::info!(?authn, "authentication complete");


### PR DESCRIPTION
@flomonster follows yesterday's inability to use traces.

<details open id="prdesc">

- 33f74c6540 *editoast: forward and log errored authentication parameters*
- 30bbbd646c *editoast: remove `AutheticationBuilder`*
    ```md
    Made little sense from the start, even more so since its fields became
    `pub`. There's still another structure to provide the parameters in
    order to name the data. Avoids having a function taking three unordered
    `Option<String>`: mismatches can happen more easily.
    ```

</details>