### PR TITLE
editoast: group everything that define what is Train

### DIFF
--- a/editoast/core_task/src/envs/pathfinding.rs
+++ b/editoast/core_task/src/envs/pathfinding.rs
@@ -18,6 +18,7 @@ use tokio::sync::Mutex;
 use crate::CoreEnv;
 use crate::Correlated;
 use crate::Task;
+use crate::TrainKey;
 use crate::TrainSet;
 
 // ========== Environment public API ==========
@@ -32,7 +33,7 @@ use crate::TrainSet;
 /// It will be cloned several times over internally, so this operation should be cheap.
 pub struct PathfindingEnv<Train>
 where
-    Train: Clone + Hash + Eq + Send + Sync + 'static,
+    Train: TrainKey + 'static,
 {
     pub(in crate::envs) core_env: CoreEnv,
     pub(in crate::envs) inputs: PathfindingEnvInputs<Train>,
@@ -40,7 +41,7 @@ where
 
 impl<Train> PathfindingEnv<Train>
 where
-    Train: Clone + Hash + Eq + Send + Sync + 'static,
+    Train: TrainKey + 'static,
 {
     pub fn new(core_env: CoreEnv) -> Self {
         Self {
@@ -131,7 +132,7 @@ pub struct PathfindingTrain {
 #[cfg_attr(test, derive(Clone))]
 pub(crate) struct PathfindingEnvInputs<Train>
 where
-    Train: Clone + Hash + Eq + Send + Sync + 'static,
+    Train: TrainKey + 'static,
 {
     // TODO: deduplicate values
     consists: HashMap<Train, Arc<PathfindingConsist>>,
@@ -140,7 +141,7 @@ where
 
 impl<Train> Default for PathfindingEnvInputs<Train>
 where
-    Train: Clone + Hash + Eq + Send + Sync + 'static,
+    Train: TrainKey + 'static,
 {
     fn default() -> Self {
         Self {
@@ -198,7 +199,7 @@ impl IntoIterator for PathWaypointAlternatives {
 
 impl<Train> Extend<(Train, PathfindingTrain)> for PathfindingEnv<Train>
 where
-    Train: Clone + Hash + Eq + Send + Sync + 'static,
+    Train: TrainKey + 'static,
 {
     fn extend<T: IntoIterator<Item = (Train, PathfindingTrain)>>(&mut self, iter: T) {
         let iter = iter.into_iter().map(
@@ -223,7 +224,7 @@ where
 
 impl<Train> PathfindingEnvInputs<Train>
 where
-    Train: Clone + Hash + Eq + Send + Sync + 'static,
+    Train: TrainKey + 'static,
 {
     fn iter(&self) -> impl Iterator<Item = Correlated<Train, Input>> {
         self.consists.keys().map(|train| {
@@ -249,7 +250,7 @@ where
 /// its internal state. Do not create this struct directly.
 pub(in crate::envs) struct Runner<Train>
 where
-    Train: Clone + Hash + Eq + Send + Sync + 'static,
+    Train: TrainKey + 'static,
 {
     core_env: CoreEnv,
     pub(in crate::envs) pathfinding_inputs: Arc<PathfindingEnvInputs<Train>>,
@@ -264,7 +265,7 @@ pub(in crate::envs) struct Input(
 
 impl<Train> Runner<Train>
 where
-    Train: Clone + Hash + Eq + Send + Sync + 'static,
+    Train: TrainKey + 'static,
 {
     pub(in crate::envs) fn new(PathfindingEnv { core_env, inputs }: PathfindingEnv<Train>) -> Self {
         let input_index = DashMap::<Input, TrainSet<Train>>::new();
@@ -331,7 +332,7 @@ where
 #[derive(Debug, Clone)]
 pub struct PathfindingRun<Train>
 where
-    Train: Clone + Hash + Eq + Send + Sync + 'static,
+    Train: TrainKey + 'static,
 {
     inputs: Arc<PathfindingEnvInputs<Train>>,
     // optionally deduplicate similar outputs of different inputs
@@ -344,7 +345,7 @@ type PendingPathfindingResult =
 
 impl<Train> PathfindingRun<Train>
 where
-    Train: Clone + Hash + Eq + Send + Sync + 'static,
+    Train: TrainKey + 'static,
 {
     fn new(runner: &Runner<Train>) -> Self {
         let paths = DashMap::from_iter(

--- a/editoast/core_task/src/envs/simulation.rs
+++ b/editoast/core_task/src/envs/simulation.rs
@@ -15,6 +15,7 @@ use tokio::sync::Mutex;
 use crate::CoreEnv;
 use crate::Correlated;
 use crate::PathfindingEnv;
+use crate::TrainKey;
 use crate::TrainSet;
 use crate::envs::pathfinding;
 use crate::envs::pathfinding::PathfindingEnvInputs;
@@ -35,7 +36,7 @@ use crate::envs::pathfinding::PathfindingEnvInputs;
 /// It will be cloned several times over internally, so this operation should be cheap.
 pub struct SimulationEnv<Train>
 where
-    Train: Clone + Hash + Eq + Send + Sync + 'static,
+    Train: TrainKey + 'static,
 {
     pathfinding_env: PathfindingEnv<Train>,
     inputs: SimulationInputs<Train>,
@@ -60,7 +61,7 @@ pub enum SimulationOutput {
 
 impl<Train> SimulationEnv<Train>
 where
-    Train: Clone + Hash + Eq + Send + Sync + 'static,
+    Train: TrainKey + 'static,
 {
     pub fn new(core_env: CoreEnv) -> Self {
         Self {
@@ -120,7 +121,7 @@ where
 /// its internal state. Do not create this struct directly.
 pub(in crate::envs) struct Runner<Train>
 where
-    Train: Clone + Hash + Eq + Send + Sync + 'static,
+    Train: TrainKey + 'static,
 {
     core_env: CoreEnv,
     simulation_inputs: Arc<SimulationInputs<Train>>,
@@ -139,7 +140,7 @@ pub(in crate::envs) struct SimulationKey(
 
 impl<Train> Runner<Train>
 where
-    Train: Clone + Hash + Eq + Send + Sync + 'static,
+    Train: TrainKey + 'static,
 {
     pub(in crate::envs) fn new(
         SimulationEnv {

--- a/editoast/core_task/src/envs/simulation/inputs.rs
+++ b/editoast/core_task/src/envs/simulation/inputs.rs
@@ -16,12 +16,13 @@ use crate::Correlated;
 use crate::PathfindingConsist;
 use crate::PathfindingConstraints;
 use crate::PathfindingTrain;
+use crate::TrainKey;
 use crate::envs::pathfinding::PathWaypointAlternatives;
 
 #[derive(Debug)]
 pub(crate) struct SimulationInputs<Train>
 where
-    Train: Clone + std::hash::Hash + Eq + Send + Sync + 'static,
+    Train: TrainKey + 'static,
 {
     pub(super) electrical_profile_set_id: Option<u64>,
 
@@ -125,7 +126,7 @@ impl SimulationTrainParameters {
 
 impl<Train> SimulationInputs<Train>
 where
-    Train: Clone + std::hash::Hash + Eq + Send + Sync + 'static,
+    Train: TrainKey + 'static,
 {
     pub(super) fn iter(
         &self,
@@ -290,7 +291,7 @@ impl SimulationTrain {
 
 impl<Train> Extend<(Train, SimulationTrain)> for super::SimulationEnv<Train>
 where
-    Train: Clone + std::hash::Hash + Eq + Send + Sync + 'static,
+    Train: TrainKey + 'static,
 {
     fn extend<T: IntoIterator<Item = (Train, SimulationTrain)>>(&mut self, iter: T) {
         let (simulation_consists, simulation_params, pathfinding_trains): (Vec<_>, Vec<_>, Vec<_>) =

--- a/editoast/core_task/src/lib.rs
+++ b/editoast/core_task/src/lib.rs
@@ -1,6 +1,7 @@
 mod envs;
 mod path_properties;
 
+use std::hash::Hash;
 use std::sync::Arc;
 
 // Crate-level exports
@@ -24,6 +25,12 @@ use serde::de::DeserializeOwned;
 use serde::ser::Serialize;
 use tokio::sync::Mutex;
 use tracing::Instrument;
+
+/// Interface required by [SimulationEnv] and friends for [Correlated] keys
+///
+/// A unique identifier to represent a train in environments.
+pub trait TrainKey: Clone + Hash + Eq + Send + Sync {}
+impl<T> TrainKey for T where T: Clone + Hash + Eq + Send + Sync {}
 
 /// Indicates that a Core task can be performed and cached
 ///


### PR DESCRIPTION
We often need a way to define what constraints should be valid for a generic `Train` in `core_task`. Regrouping them should help reduce the writing of the bounds.