### PR TITLE
editoast: introduce `UserAuthorizer` for `Protected` authenticated operations

### DIFF
--- a/editoast/authz/src/authorizer.rs
+++ b/editoast/authz/src/authorizer.rs
@@ -73,12 +73,6 @@ impl<S: StorageDriver> Authorizer<S> {
             .await
     }
 
-    pub async fn infra_grant(&self, infra: &Infra) -> Result<Option<InfraGrant>, Error<S::Error>> {
-        self.regulator
-            .infra_grant(&Subject::User(User(self.user_id)), infra)
-            .await
-    }
-
     pub async fn authorize_infra(
         &self,
         infra: &Infra,

--- a/editoast/authz/src/lib.rs
+++ b/editoast/authz/src/lib.rs
@@ -148,6 +148,7 @@ mod mock_driver {
     use crate::identity::UserName;
     use crate::model;
     use crate::v2;
+    use crate::v2::TestClientExt as _;
 
     #[derive(Debug, Clone, Default)]
     pub struct MockAuthDriver {
@@ -182,9 +183,9 @@ mod mock_driver {
             user: model::User,
             infra: model::Infra,
         ) -> Option<InfraGrant> {
-            self.infra_direct_grant(&user.into(), &infra)
+            self.openfga()
+                .infra_effective_grant(user.into(), infra)
                 .await
-                .expect("infra grant get should succeed")
         }
 
         pub async fn set_infra_grant(

--- a/editoast/authz/src/regulator.rs
+++ b/editoast/authz/src/regulator.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use std::convert::Infallible;
 use std::future::Future;
 
 use fga::client::QueryError;
@@ -19,6 +20,7 @@ use crate::identity::UserInfo;
 use crate::identity::UserName;
 use crate::model;
 use crate::model::*;
+use crate::v2;
 
 /// Entry point for managing authorizations (roles and grants)
 ///
@@ -261,86 +263,6 @@ impl<S: StorageDriver> Regulator<S> {
         privileges.extend(can_delete.then_some(InfraPrivilege::CanDelete));
         privileges.extend(can_share_ownership.then_some(InfraPrivilege::CanShareOwnership));
         Ok(privileges)
-    }
-
-    /// Returns the maximum grant a subject has on an infra
-    ///
-    /// A given user may have multiple grants on the same resource. This can happen
-    /// if a user inherits a grant from one of its groups and also has a direct grant.
-    /// Inherited grants are not the same thing as privileges: they do not have the same semantic,
-    /// are not represented by the same enum, do no work on the same scale nor in the same way.
-    ///
-    /// Groups only have direct grants. If multiple direct grants are found, this function will panic.
-    #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
-    pub async fn infra_grant(
-        &self,
-        subject: &Subject,
-        infra: &Infra,
-    ) -> Result<Option<InfraGrant>, Error<S::Error>> {
-        // Check if the infra exists
-        if !self
-            .driver
-            .infra_exists(infra.0)
-            .await
-            .map_err(Error::Storage)?
-        {
-            return Err(Error::UnknownResource(infra.0));
-        }
-
-        // Check if subject exists
-        if !self.subject_exists(subject).await? {
-            return Err(Error::UnknownSubject(subject.id()));
-        }
-
-        // Calling openfga
-        let (is_reader, is_writer, is_owner) = match subject {
-            Subject::User(user) => {
-                self.openfga
-                    .checks((
-                        model::Infra::reader().check(user, infra),
-                        model::Infra::writer().check(user, infra),
-                        model::Infra::owner().check(user, infra),
-                    ))
-                    .await?
-            }
-            Subject::Group(group) => {
-                let (is_reader, is_writer, is_owner) = self
-                    .openfga
-                    .checks((
-                        model::Infra::reader().check(Group::member().userset(group), infra),
-                        model::Infra::writer().check(Group::member().userset(group), infra),
-                        model::Infra::owner().check(Group::member().userset(group), infra),
-                    ))
-                    .await?;
-                if !matches!(
-                    (is_reader, is_writer, is_owner),
-                    (true, false, false)
-                        | (false, true, false)
-                        | (false, false, true)
-                        | (false, false, false)
-                ) {
-                    tracing::error!(
-                        is_reader,
-                        is_writer,
-                        is_owner,
-                        ?subject,
-                        resource = ?infra,
-                        "Group has multiple direct grants on the same resource"
-                    );
-                    panic!(
-                        "Group {subject:?} has multiple direct grants on the same resource {infra:?}, which is not supposed to happen by design. \n\
-                        While a user may have inherited grants from one of their groups, groups do not have inherited grants. \n\
-                        Detected direct grants: reader: {is_reader}, writer: {is_writer}, owner: {is_owner}"
-                    );
-                }
-                (is_reader, is_writer, is_owner)
-            }
-        };
-
-        Ok(is_owner
-            .then_some(InfraGrant::Owner)
-            .or_else(|| is_writer.then_some(InfraGrant::Writer))
-            .or_else(|| is_reader.then_some(InfraGrant::Reader)))
     }
 
     #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
@@ -657,8 +579,15 @@ impl<S: StorageDriver> Regulator<S> {
 
         let is_admin = self.is_admin(issuer).await?;
         let issuer = Subject::User(User(issuer.0));
-        let issuer_grant = self.infra_grant(&issuer, infra).await?;
-        let subject_grant = self.infra_grant(subject, infra).await?;
+        let authorize = v2::special_authorizers::Authorize(&self.openfga);
+        let Ok::<_, Infallible>(access) = v2::infra_effective_grant(issuer, *infra)
+            .authorize(&authorize)
+            .await;
+        let Ok::<_, Infallible>(issuer_grant) = access.access().await?;
+        let Ok::<_, Infallible>(access) = v2::infra_effective_grant(*subject, *infra)
+            .authorize(&authorize)
+            .await;
+        let Ok::<_, Infallible>(subject_grant) = access.access().await?;
 
         // Rule 2.1 and 3.1
         if let Some(subject_grant) = subject_grant

--- a/editoast/authz/src/regulator.rs
+++ b/editoast/authz/src/regulator.rs
@@ -1,5 +1,4 @@
 use std::collections::HashSet;
-use std::convert::Infallible;
 use std::future::Future;
 
 use fga::client::QueryError;
@@ -580,14 +579,12 @@ impl<S: StorageDriver> Regulator<S> {
         let is_admin = self.is_admin(issuer).await?;
         let issuer = Subject::User(User(issuer.0));
         let authorize = v2::special_authorizers::Authorize(&self.openfga);
-        let Ok::<_, Infallible>(access) = v2::infra_effective_grant(issuer, *infra)
-            .authorize(&authorize)
-            .await;
-        let Ok::<_, Infallible>(issuer_grant) = access.access().await?;
-        let Ok::<_, Infallible>(access) = v2::infra_effective_grant(*subject, *infra)
-            .authorize(&authorize)
-            .await;
-        let Ok::<_, Infallible>(subject_grant) = access.access().await?;
+        let issuer_grant = authorize
+            .access_value(v2::infra_effective_grant(issuer, *infra))
+            .await?;
+        let subject_grant = authorize
+            .access_value(v2::infra_effective_grant(*subject, *infra))
+            .await?;
 
         // Rule 2.1 and 3.1
         if let Some(subject_grant) = subject_grant

--- a/editoast/authz/src/v2.rs
+++ b/editoast/authz/src/v2.rs
@@ -787,4 +787,39 @@ mod tests {
             HashSet::from_iter([])
         );
     }
+
+    #[tokio::test]
+    async fn infra_effective_grant_direct_and_inherited() {
+        let openfga = crate::authz_client!();
+        let authorize = Authorize(&openfga);
+
+        openfga
+            .write_tuples(&[Infra::reader().tuple(&User(1), &Infra(1))])
+            .await
+            .unwrap();
+
+        let grant = infra_effective_grant(Subject::user(1), Infra(1))
+            .authorize(&authorize)
+            .await
+            .unwrap()
+            .unwrap_authorized()
+            .await;
+        assert_eq!(grant, Some(InfraGrant::Reader));
+
+        openfga
+            .prepare_writes()
+            .write(&Group::member().tuple(&User(1), &Group(1)))
+            .write(&Infra::owner().tuple(Group::member().userset(&Group(1)), &Infra(1)))
+            .execute()
+            .await
+            .unwrap();
+
+        let grant = infra_effective_grant(Subject::user(1), Infra(1))
+            .authorize(&authorize)
+            .await
+            .unwrap()
+            .unwrap_authorized()
+            .await;
+        assert_eq!(grant, Some(InfraGrant::Owner));
+    }
 }

--- a/editoast/authz/src/v2.rs
+++ b/editoast/authz/src/v2.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use std::convert::Infallible;
 
 use fga::client::QueryError;
 use fga::client::UserList;
@@ -461,6 +462,7 @@ pub mod special_authorizers {
 pub trait TestClientExt {
     async fn subject_roles(&self, subject: &Subject) -> HashSet<Role>;
     async fn group_members(&self, group: &Group) -> HashSet<User>;
+    async fn infra_effective_grant(&self, subject: Subject, infra: Infra) -> Option<InfraGrant>;
 }
 
 impl TestClientExt for fga::Client {
@@ -481,6 +483,15 @@ impl TestClientExt for fga::Client {
             .users
             .into_iter()
             .collect()
+    }
+
+    async fn infra_effective_grant(&self, subject: Subject, infra: Infra) -> Option<InfraGrant> {
+        let authorize = special_authorizers::Authorize(self);
+        let Ok::<_, Infallible>(access) = infra_effective_grant(subject, infra)
+            .authorize(&authorize)
+            .await;
+        let Ok::<_, Infallible>(grant) = access.access().await.unwrap();
+        grant
     }
 }
 

--- a/editoast/authz/src/v2.rs
+++ b/editoast/authz/src/v2.rs
@@ -1,5 +1,4 @@
 use std::collections::HashSet;
-use std::convert::Infallible;
 
 use fga::client::QueryError;
 use fga::client::UserList;
@@ -423,6 +422,7 @@ pub mod special_authorizers {
     use std::convert::Infallible;
 
     use crate::v2::Access;
+    use crate::v2::OpenFgaError;
     use crate::v2::Protected;
 
     use super::Authorizer;
@@ -457,6 +457,14 @@ pub mod special_authorizers {
             })
         }
     }
+
+    impl Authorize<'_> {
+        pub async fn access_value<T>(&self, p: Protected<T>) -> Result<T, OpenFgaError> {
+            let Ok::<_, Infallible>(access) = self.authorize(p).await;
+            let Ok::<_, Infallible>(value) = access.access().await?;
+            Ok(value)
+        }
+    }
 }
 
 pub trait TestClientExt {
@@ -487,11 +495,10 @@ impl TestClientExt for fga::Client {
 
     async fn infra_effective_grant(&self, subject: Subject, infra: Infra) -> Option<InfraGrant> {
         let authorize = special_authorizers::Authorize(self);
-        let Ok::<_, Infallible>(access) = infra_effective_grant(subject, infra)
-            .authorize(&authorize)
-            .await;
-        let Ok::<_, Infallible>(grant) = access.access().await.unwrap();
-        grant
+        authorize
+            .access_value(infra_effective_grant(subject, infra))
+            .await
+            .unwrap()
     }
 }
 

--- a/editoast/authz/src/v2.rs
+++ b/editoast/authz/src/v2.rs
@@ -8,6 +8,9 @@ use futures::future::BoxFuture;
 use itertools::Itertools;
 
 use crate::Group;
+use crate::Infra;
+use crate::InfraGrant;
+use crate::InfraPrivilege;
 use crate::Role;
 use crate::Subject;
 use crate::User;
@@ -42,6 +45,7 @@ pub struct Protected<T> {
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub enum Guardrail {
     IssuerHasRole(Role),
+    IssuerHasInfraPrivilege(InfraPrivilege, Infra),
 }
 
 /// A check to ensure the consistency of the data in OpenFGA and PostgreSQL
@@ -52,6 +56,7 @@ pub enum Guardrail {
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub enum SanityCheck {
     SubjectExists(Subject),
+    InfraExists(Infra),
 }
 
 impl SanityCheck {
@@ -348,6 +353,69 @@ pub fn remove_roles(subject: Subject, roles: HashSet<Role>) -> Protected<()> {
             .boxed()
         })
         .with_guardrail(Guardrail::IssuerHasRole(Role::Admin))
+}
+
+/// Returns the effective (maximum) grant a subject has on an [Infra], if any
+///
+/// A given user may have multiple grants on the same resource. This can happen
+/// if a user inherits a grant from one of its groups and also has a direct grant.
+/// Inherited grants are not the same thing as privileges: they do not have the same semantic,
+/// are not represented by the same enum, do no work on the same scale nor in the same way.
+///
+/// Groups only have direct grants. If multiple direct grants are found, this protected operation will panic.
+pub fn infra_effective_grant(subject: Subject, infra: Infra) -> Protected<Option<InfraGrant>> {
+    Protected::new(move |openfga| {
+        async move {
+            let (is_reader, is_writer, is_owner) = match &subject {
+                Subject::User(user) => {
+                    openfga
+                        .checks((
+                            Infra::reader().check(user, &infra),
+                            Infra::writer().check(user, &infra),
+                            Infra::owner().check(user, &infra),
+                        ))
+                        .await?
+                }
+                Subject::Group(group) => {
+                    let (is_reader, is_writer, is_owner) = openfga
+                        .checks((
+                            Infra::reader().check(Group::member().userset(group), &infra),
+                            Infra::writer().check(Group::member().userset(group), &infra),
+                            Infra::owner().check(Group::member().userset(group), &infra),
+                        ))
+                        .await?;
+                    if matches!(
+                        (is_reader, is_writer, is_owner),
+                        (true, true, _) | (true, _, true) | (_, true, true)
+                    ) {
+                        tracing::error!(
+                            is_reader,
+                            is_writer,
+                            is_owner,
+                            ?subject,
+                            resource = ?infra,
+                            "Group has multiple direct grants on the same resource"
+                        );
+                        panic!(
+                            "Group {subject:?} has multiple direct grants on the same resource {infra:?}, which is not supposed to happen by design. \n\
+                            While a user may have inherited grants from one of their groups, groups do not have inherited grants. \n\
+                            Detected direct grants: reader: {is_reader}, writer: {is_writer}, owner: {is_owner}"
+                        );
+                    }
+                    (is_reader, is_writer, is_owner)
+                }
+            };
+
+            Ok(is_owner
+                .then_some(InfraGrant::Owner)
+                .or_else(|| is_writer.then_some(InfraGrant::Writer))
+                .or_else(|| is_reader.then_some(InfraGrant::Reader)))
+        }
+        .boxed()
+    })
+    .with_check(SanityCheck::SubjectExists(subject))
+    .with_check(SanityCheck::InfraExists(infra))
+    .with_guardrail(Guardrail::IssuerHasInfraPrivilege(InfraPrivilege::CanRead, infra))
 }
 
 pub mod special_authorizers {

--- a/editoast/src/authorizers.rs
+++ b/editoast/src/authorizers.rs
@@ -1,8 +1,11 @@
+use authz::InfraPrivilege;
 use authz::v2::Access;
 use authz::v2::Authorizer;
+use authz::v2::Guardrail;
 use authz::v2::Protected;
 use authz::v2::SanityCheck;
 use editoast_models::prelude::*;
+use fga::model::Relation as _;
 
 /// An authorizer that represents editoast's authorization decisions
 ///
@@ -34,11 +37,94 @@ impl Authorizer for SystemAuthorizer<'_> {
     }
 }
 
+pub struct UserAuthorizer<'c> {
+    pub user: authz::User,
+    pub roles: Vec<authz::Role>, // TODO: use a SmallVec
+    pub openfga: &'c fga::Client,
+    pub conn: database::DbConnection,
+}
+
+impl<'c> UserAuthorizer<'c> {
+    pub fn new(
+        user: authz::User,
+        roles: Vec<authz::Role>,
+        openfga: &'c fga::Client,
+        conn: database::DbConnection,
+    ) -> Self {
+        Self {
+            user,
+            roles,
+            openfga,
+            conn,
+        }
+    }
+}
+
+impl Authorizer for UserAuthorizer<'_> {
+    type Error = Error;
+    type Rejection = Rejection;
+
+    #[tracing::instrument(skip_all)]
+    async fn authorize<'a, T>(
+        &'a self,
+        data: Protected<T>,
+    ) -> Result<Access<'a, T, Self::Rejection>, Self::Error> {
+        let conn = &mut self.conn.clone();
+        for check in &data.sanity_checks {
+            if let Some(rejection) = sanity_check(check, conn).await? {
+                return Ok(Access::Denied { rejection });
+            }
+        }
+        if !self.roles.contains(&authz::Role::Admin) {
+            for gr in &data.guardrails {
+                if let Some(rejection) =
+                    guardrail(gr, &self.user, &self.roles, self.openfga).await?
+                {
+                    return Ok(Access::Denied { rejection });
+                }
+            }
+        }
+        Ok(data.blindly_authorize(self.openfga))
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error(transparent)]
+    Database(#[from] editoast_models::Error),
+    #[error(transparent)]
+    OpenFga(#[from] authz::v2::OpenFgaError),
+}
+
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Rejection {
+    // Sanity check rejections
     NoSuchUser(i64),
     NoSuchGroup(#[expect(dead_code)] i64),
+    NoSuchInfra(i64),
+
+    // Guardrail rejections
+    LackingRole(
+        #[expect(dead_code)] authz::Subject,
+        #[expect(dead_code)] authz::Role,
+    ),
+    LackingInfraPrivilege(
+        InfraPrivilege,
+        #[expect(dead_code)] authz::Subject,
+        #[expect(dead_code)] authz::Infra,
+    ),
 }
+
+/// Wraps [`unreachable!`] with a message specific to impossible rejections
+macro_rules! impossible {
+    ($rejection:expr) => {
+        unreachable!(
+            "impossible rejection {:?} — if this occurs, some authz::Protected check rejection has been overlooked", $rejection
+        )
+    };
+}
+pub(crate) use impossible;
 
 #[tracing::instrument(skip_all, fields(?sanity_check), ret(level = "trace"), err)]
 async fn sanity_check(
@@ -54,5 +140,64 @@ async fn sanity_check(
             Ok((!editoast_models::Group::exists(conn, *group_id).await?)
                 .then_some(Rejection::NoSuchGroup(*group_id)))
         }
+        SanityCheck::InfraExists(authz::Infra(infra_id)) => {
+            Ok((!crate::models::Infra::exists(conn, *infra_id).await?)
+                .then_some(Rejection::NoSuchInfra(*infra_id)))
+        }
     }
+}
+
+#[tracing::instrument(skip_all, fields(?guardrail, ?issuer, ?roles), ret(level = "trace"), err)]
+async fn guardrail(
+    guardrail: &Guardrail,
+    issuer: &authz::User,
+    roles: &[authz::Role],
+    openfga: &fga::Client,
+) -> Result<Option<Rejection>, authz::v2::OpenFgaError> {
+    Ok(match guardrail {
+        Guardrail::IssuerHasRole(role) if !roles.contains(role) => {
+            Some(Rejection::LackingRole(authz::Subject::user(*issuer), *role))
+        }
+        Guardrail::IssuerHasRole(_) => None,
+
+        Guardrail::IssuerHasInfraPrivilege(privilege, infra) => {
+            let has_privilege = match privilege {
+                InfraPrivilege::CanRead => {
+                    openfga
+                        .check(authz::Infra::can_read().check(issuer, infra))
+                        .await?
+                }
+                InfraPrivilege::CanWrite => {
+                    openfga
+                        .check(authz::Infra::can_write().check(issuer, infra))
+                        .await?
+                }
+                InfraPrivilege::CanDelete => {
+                    openfga
+                        .check(authz::Infra::can_delete().check(issuer, infra))
+                        .await?
+                }
+                InfraPrivilege::CanShareRead => {
+                    openfga
+                        .check(authz::Infra::can_share_read().check(issuer, infra))
+                        .await?
+                }
+                InfraPrivilege::CanShareWrite => {
+                    openfga
+                        .check(authz::Infra::can_share_write().check(issuer, infra))
+                        .await?
+                }
+                InfraPrivilege::CanShareOwnership => {
+                    openfga
+                        .check(authz::Infra::can_share_ownership().check(issuer, infra))
+                        .await?
+                }
+            };
+            (!has_privilege).then_some(Rejection::LackingInfraPrivilege(
+                *privilege,
+                authz::Subject::user(*issuer),
+                *infra,
+            ))
+        }
+    })
 }

--- a/editoast/src/client/group.rs
+++ b/editoast/src/client/group.rs
@@ -19,6 +19,7 @@ use editoast_models::PgAuthDriver;
 
 use crate::authorizers::Rejection;
 use crate::authorizers::SystemAuthorizer;
+use crate::authorizers::impossible;
 
 use super::openfga_config::OpenfgaConfig;
 
@@ -161,6 +162,7 @@ pub async fn exclude_group(
         Ok(()) => Ok(()),
         Err(Rejection::NoSuchGroup(_)) => unreachable!("tested above"),
         Err(Rejection::NoSuchUser(user_id)) => bail!("No such user {user_id}"),
+        Err(rejection) => impossible!(rejection),
     }
 }
 
@@ -201,6 +203,7 @@ pub async fn include_group(
         Ok(()) => Ok(()),
         Err(Rejection::NoSuchGroup(_)) => unreachable!("tested above"),
         Err(Rejection::NoSuchUser(user_id)) => bail!("No such user {user_id}"),
+        Err(rejection) => impossible!(rejection),
     }
 }
 
@@ -229,6 +232,7 @@ pub async fn delete_group(
         Ok(()) => {}
         Err(Rejection::NoSuchGroup(_)) => unreachable!("tested above"),
         Err(Rejection::NoSuchUser(_)) => unreachable!("tested above"),
+        Err(rejection) => impossible!(rejection),
     }
 
     let deleted = driver.delete_group(group_id).await?;

--- a/editoast/src/client/roles.rs
+++ b/editoast/src/client/roles.rs
@@ -21,6 +21,7 @@ use editoast_models::PgAuthDriver;
 
 use crate::authorizers::Rejection;
 use crate::authorizers::SystemAuthorizer;
+use crate::authorizers::impossible;
 
 use super::openfga_config::OpenfgaConfig;
 
@@ -198,6 +199,7 @@ pub async fn add_roles(
         Err(Rejection::NoSuchUser(_)) | Err(Rejection::NoSuchGroup(_)) => {
             unreachable!("checked by parse_and_fetch_subject")
         }
+        Err(rejection) => impossible!(rejection),
     }
 }
 
@@ -232,5 +234,6 @@ pub async fn remove_roles(
         Err(Rejection::NoSuchUser(_)) | Err(Rejection::NoSuchGroup(_)) => {
             unreachable!("checked by parse_and_fetch_subject")
         }
+        Err(rejection) => impossible!(rejection),
     }
 }

--- a/editoast/src/error.rs
+++ b/editoast/src/error.rs
@@ -321,6 +321,21 @@ impl From<crate::views::AuthorizerError> for InternalError {
     }
 }
 
+impl From<fga::client::RequestFailure> for InternalError {
+    fn from(value: fga::client::RequestFailure) -> Self {
+        crate::views::AuthorizationError::from(value).into()
+    }
+}
+
+impl From<crate::authorizers::Error> for InternalError {
+    fn from(value: crate::authorizers::Error) -> Self {
+        match value {
+            crate::authorizers::Error::Database(error) => error.into(),
+            crate::authorizers::Error::OpenFga(error) => error.into(),
+        }
+    }
+}
+
 // error definition : uses by the macro EditoastError to generate
 // the list of error and share it with the openAPI generator
 #[derive(Debug)]

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -2,6 +2,9 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
 
+use crate::authorizers::Rejection;
+use crate::authorizers::UserAuthorizer;
+use crate::authorizers::impossible;
 use crate::error::Result;
 use crate::models::Infra;
 use crate::views::Authentication;
@@ -388,33 +391,51 @@ pub(in crate::views) struct UserResourceGrant {
     )),
 )]
 pub(in crate::views) async fn user_grants(
-    State(AppState { db_pool, .. }): State<AppState>,
-    Extension(auth): AuthenticationExt,
+    State(AppState {
+        db_pool, regulator, ..
+    }): State<AppState>,
+    Extension(roles): Extension<Vec<authz::Role>>,
+    Extension(user): Extension<Option<authz::User>>,
     Json(body): Json<HashMap<ResourceType, Vec<i64>>>,
 ) -> Result<Json<HashMap<ResourceType, Vec<UserResourceGrant>>>> {
-    let authorizer = auth.authorizer()?;
-    let mut response = HashMap::<_, Vec<UserResourceGrant>>::new();
-    let conn = &mut db_pool.get().await?;
+    let Some(user) = user else {
+        return Err(AuthorizationError::Unauthorized.into());
+    };
+    let authorizer = UserAuthorizer::new(user, roles, regulator.openfga(), db_pool.get().await?);
 
+    let mut response = HashMap::<_, Vec<UserResourceGrant>>::new();
     if let Some(infra_ids) = body.get(&ResourceType::Infra) {
         for infra_id in infra_ids {
-            // check that the infra exists before to check the grants
-            if Infra::exists(conn, *infra_id).await? {
-                let Some(grant) = authorizer
-                    .infra_grant(&authz::Infra(*infra_id))
-                    .await
-                    .map_err(AuthzError::from)?
-                else {
-                    continue; // skip if the user has no grant on this infra
-                };
-                response
-                    .entry(ResourceType::Infra)
-                    .or_default()
-                    .push(UserResourceGrant {
-                        id: *infra_id,
-                        grant,
-                    });
-            }
+            let grant_access = authz::v2::infra_effective_grant(
+                authz::Subject::user(user),
+                authz::Infra(*infra_id),
+            )
+            .authorize(&authorizer)
+            .await?;
+            let grant = match grant_access.access().await? {
+                Ok(Some(grant)) => grant,
+                Ok(None) => continue,
+                Err(Rejection::NoSuchInfra(infra_id)) => {
+                    tracing::warn!(infra_id, "non-existent infra — skipping");
+                    continue;
+                }
+                Err(Rejection::LackingInfraPrivilege(privilege, ..)) => {
+                    debug_assert_eq!(privilege, InfraPrivilege::CanRead);
+                    tracing::warn!(infra_id, "user cannot read infra — skipping");
+                    continue;
+                }
+                Err(Rejection::NoSuchUser(user_id)) => {
+                    unreachable!("user {user_id} exists or race condition")
+                }
+                Err(rejection) => impossible!(rejection),
+            };
+            response
+                .entry(ResourceType::Infra)
+                .or_default()
+                .push(UserResourceGrant {
+                    id: *infra_id,
+                    grant,
+                });
         }
     }
 
@@ -927,6 +948,7 @@ mod tests {
         let app = test_app!().enable_authorization(true).build();
         let db_pool = app.db_pool();
         let infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let infra_no_grant = create_small_infra(&mut db_pool.get_ok()).await;
         let user = app
             .user("test", "Test")
             .with_roles([Role::OperationalStudies])
@@ -962,7 +984,7 @@ mod tests {
 
         // Ask the grant of the user for the infra again
         let request = app.post("/authz/me/grants").by_user(&user).json(&json!({
-            "infra": [infra.id],
+            "infra": [infra.id, infra_no_grant.id, infra_no_grant.id + 1000],
         }));
         let response: HashMap<ResourceType, Vec<UserResourceGrant>> = app
             .fetch(request)
@@ -971,6 +993,7 @@ mod tests {
             .json_into();
 
         // Check the inherited grant from the group has overridden by the user's direct grant
+        // Unreadable and non-existent infras are filtered out
         assert_eq!(
             response.get(&ResourceType::Infra).unwrap(),
             &[UserResourceGrant {

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -573,11 +573,11 @@ async fn authentication_validation_middleware(
         crate::authentication::Authentication::Impersonating { .. }
     );
 
-    fn origin_user_roles(
+    fn origin_user(
         user: Option<editoast_models::User>,
         identity: &str,
         header_name: &str,
-    ) -> Option<::authz::v2::Protected<Vec<Role>>> {
+    ) -> Option<(editoast_models::User, ::authz::v2::Protected<Vec<Role>>)> {
         user.inspect(|user| {
             if user.name != header_name {
                 tracing::warn!(
@@ -588,27 +588,34 @@ async fn authentication_validation_middleware(
                 );
             }
         })
-        .map(|user| ::authz::v2::subject_roles(::authz::Subject::user(user.id)))
+        .map(|user| {
+            let authz_user = ::authz::Subject::user(user.id);
+            (user, ::authz::v2::subject_roles(authz_user))
+        })
     }
 
     async fn register_origin_user(
         conn: database::DbConnection,
         (identity, name): (&str, &str),
-    ) -> Result<::authz::v2::Protected<Vec<Role>>> {
+    ) -> Result<(
+        Option<editoast_models::User>,
+        ::authz::v2::Protected<Vec<Role>>,
+    )> {
         tracing::info!(identity, name, "registering new user");
         let user =
             editoast_models::User::register(conn, vec![identity.to_owned()], name.to_owned())
                 .await?;
-        Ok(::authz::v2::subject_roles(::authz::Subject::user(user.id)))
+        let authz_user = ::authz::Subject::user(user.id);
+        Ok((Some(user), ::authz::v2::subject_roles(authz_user)))
     }
 
-    let roles_prot = conn
+    let (user, roles_prot) = conn
         .transaction(async move |conn| {
-            let roles_prot = match &authn {
+            let origin = match &authn {
                 crate::authentication::Authentication::Authenticated { identity, name } => {
                     let user =
                         editoast_models::User::retrieve_by_identity(identity, conn.clone()).await?;
-                    origin_user_roles(user, identity, name)
+                    origin_user(user, identity, name)
                 }
                 crate::authentication::Authentication::Impersonating {
                     impersonator_identity,
@@ -635,27 +642,25 @@ async fn authentication_validation_middleware(
                             .into(),
                         );
                     }
-                    origin_user_roles(impersonator, impersonator_identity, impersonator_name)
+                    origin_user(impersonator, impersonator_identity, impersonator_name)
                 }
                 crate::authentication::Authentication::Unauthenticated
                 | crate::authentication::Authentication::Skip { .. } => None,
             };
 
-            let roles_prot = match roles_prot {
+            Ok(match origin {
                 // origin user does exist, we use the Protected afterwards
-                Some(roles_prot) => roles_prot,
+                Some((user, roles_prot)) => (Some(user), roles_prot),
                 // origin user does not exist
                 None => {
                     // if there is an origin user (no skip or unauthenticated)
                     if let Some(origin) = authn.origin() {
                         register_origin_user(conn, origin).await?
                     } else {
-                        ::authz::v2::Protected::default()
+                        (None, ::authz::v2::Protected::default())
                     }
                 }
-            };
-
-            Ok(roles_prot)
+            })
         })
         .await?;
 
@@ -678,12 +683,19 @@ async fn authentication_validation_middleware(
         }
     }
 
-    Ok(tracing::info_span!("authentication validation", ?roles)
-        .in_scope(move || {
-            req.extensions_mut().insert(roles);
-            next.run(req).in_current_span()
-        })
-        .await)
+    let user_id = user.as_ref().map(|editoast_models::User { id, .. }| *id);
+    Ok(
+        tracing::info_span!("authentication validation", user_id, ?roles)
+            .in_scope(move || {
+                req.extensions_mut().insert(roles);
+                // for `fga` queries and `authz` interface
+                req.extensions_mut().insert(user_id.map(::authz::User));
+                // database model, also carries the user name
+                req.extensions_mut().insert(user);
+                next.run(req).in_current_span()
+            })
+            .await,
+    )
 }
 
 /// Represents the bundle of information about the issuer of a request

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -684,18 +684,21 @@ async fn authentication_validation_middleware(
     }
 
     let user_id = user.as_ref().map(|editoast_models::User { id, .. }| *id);
-    Ok(
-        tracing::info_span!("authentication validation", user_id, ?roles)
-            .in_scope(move || {
-                req.extensions_mut().insert(roles);
-                // for `fga` queries and `authz` interface
-                req.extensions_mut().insert(user_id.map(::authz::User));
-                // database model, also carries the user name
-                req.extensions_mut().insert(user);
-                next.run(req).in_current_span()
-            })
-            .await,
+    Ok(tracing::info_span!(
+        "authentication validation",
+        user_id,
+        ?roles,
+        is_admin = roles.contains(&Role::Admin) // easy way to filter real user requests in logs
     )
+    .in_scope(move || {
+        req.extensions_mut().insert(roles);
+        // for `fga` queries and `authz` interface
+        req.extensions_mut().insert(user_id.map(::authz::User));
+        // database model, also carries the user name
+        req.extensions_mut().insert(user);
+        next.run(req).in_current_span()
+    })
+    .await)
 }
 
 /// Represents the bundle of information about the issuer of a request

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -43,7 +43,7 @@ use tracing::Instrument;
 
 use ::core::str;
 use std::collections::HashSet;
-use std::convert::Infallible;
+
 use std::env;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -563,8 +563,6 @@ async fn authentication_validation_middleware(
     mut req: Request,
     next: Next,
 ) -> Result<Response> {
-    use ::authz::v2::Authorizer as _;
-
     let openfga = regulator.openfga(); // to remove once OpenFGA is in the AppState directly
     let conn = db_pool.get().await?;
 
@@ -671,9 +669,10 @@ async fn authentication_validation_middleware(
     std::mem::drop(conn);
 
     // A failed OpenFGA request does not invalidate the creation of a new user
-    let bypass = special_authorizers::Authorize(openfga);
-    let Ok::<_, Infallible>(access) = bypass.authorize(roles_prot).await;
-    let Ok::<_, Infallible>(roles) = access.access().await.map_err(AuthorizationError::from)?;
+    let roles = special_authorizers::Authorize(openfga)
+        .access_value(roles_prot)
+        .await
+        .map_err(AuthorizationError::from)?;
 
     if is_impersonation {
         if !roles.contains(&Role::Admin) {

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -3,6 +3,7 @@
 //! components.
 
 use authz::v2;
+use authz::v2::TestClientExt;
 use authz::v2::special_authorizers;
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -436,8 +437,11 @@ impl TestApp {
     pub fn infra_grant(&self, infra_id: i64, subject_id: i64) -> Option<InfraGrant> {
         let regulator = &self.app_state.regulator;
         let subject = self.authz_subject(subject_id);
-        block_on(regulator.infra_grant(&subject, &authz::Infra(infra_id)))
-            .expect("Infra grant should be fetched successfully")
+        block_on(
+            regulator
+                .openfga()
+                .infra_effective_grant(subject, authz::Infra(infra_id)),
+        )
     }
 
     pub fn infra_direct_grant(&self, infra_id: i64, subject_id: i64) -> Option<InfraGrant> {


### PR DESCRIPTION
refs https://github.com/osrd-project/osrd-confidential/issues/1168

> [!TIP]
> review each commit one by one

Adds the `UserAuthorizer` middleware representing the checks that must be performed when authorizing an operation initiated by an authenticated user. `infra_effective_grant` has been migrated to avoid unused defitions and provide an example.

As discussed with @woshilapin, there may be a way to exhaustively match on possible rejections and avoid `unreachable!` or `impossible!`. We should experiment on that later.

<details open id="prdesc">

- fdc4bea5a0 *editoast: add user to request extensions*
    ```md
    Adds both the model and the `authz` newtype.
    ```
- 70fd6b0183 *editoast: add `UserAuthorizer` and `infra_effective_grant`*
    ```md
    - `UserAuthorizer` is tied to a user provided by the request headers and
      checks `Guardrails`
    - port `Regulator::infra_grant` as `v2::infra_effective_grant` and use
      it in `/authz/me/{resource}/{id}`
    - improve its integration test to trigger the guardrail rejection
    ```
- 6b37779d3b *editoast: add `is_admin` field to authentication validation span*
    ```md
    Redundant with `roles` but easier to filter in datadog. Useful to tell
    apart our requests from users' (especially for STDCM).
    ```
- 183004eaf9 *editoast: authz: add unit test for `infra_effective_grant`*
- c7196a2c80 *editoast: authz: remove old effective infra grant fetching*
    ```md
    Replaced by its `Protected`-based counterpart. No `views` usage (outside
    of tests) so no `SystemAuthorizer` required.
    ```
- 4dea7b7bb6 *editoast: authz: add `special_authorizers::Authorize::access_value`*

</details>