### PR TITLE
front: test useSearchUser hook

### DIFF
--- a/front/src/common/__tests__/useSearchUser.spec.ts
+++ b/front/src/common/__tests__/useSearchUser.spec.ts
@@ -1,0 +1,119 @@
+import { skipToken } from '@reduxjs/toolkit/query';
+import { act, renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+
+import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
+import { SUBJECT_TYPES } from 'common/authorization/consts';
+
+import useSearchUsers, { DEBOUNCE_DURATION, type User } from '../useSearchUsers';
+
+const searchTermA = 'lphons';
+const searchTermB = 'Bea';
+const searchTermC = 'harl';
+
+const searchedUsersA = [{ id: 1, name: 'Alphonse', type: SUBJECT_TYPES.USER }];
+const searchedUsersB = [
+  { id: 2, name: 'Bea', type: SUBJECT_TYPES.USER },
+  { id: 3, name: 'Beatrice', type: SUBJECT_TYPES.USER },
+];
+const searchedUsersC: User[] = [];
+
+const apiResultsBySearchTerm: Record<string, User[]> = {
+  [searchTermA]: searchedUsersA,
+  [searchTermB]: searchedUsersB,
+  [searchTermC]: searchedUsersC,
+};
+
+describe('useSearchUsers', () => {
+  let useQuerySpy: ReturnType<typeof vi.spyOn>;
+
+  beforeAll(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    vi.clearAllTimers();
+    useQuerySpy = vi.spyOn(osrdEditoastApi.endpoints.postSearch, 'useQuery').mockImplementation(((
+      arg
+    ) => {
+      if (arg === skipToken) return { data: undefined };
+      // Queries form is ['search', ['name'], searchTerm]
+      const searchTerm = (arg.searchPayload.query as [string, string[], string])[2];
+      return { data: apiResultsBySearchTerm[searchTerm] };
+    }) as typeof osrdEditoastApi.endpoints.postSearch.useQuery);
+  });
+
+  afterAll(() => {
+    vi.clearAllMocks();
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('should send a search request when a search term is sent and eventually return its result', () => {
+    const { result } = renderHook(() => useSearchUsers());
+    expect(result.current.searchedUsers).toEqual([]);
+
+    act(() => result.current.setSearchTerm(searchTermA));
+    act(() => vi.advanceTimersByTime(DEBOUNCE_DURATION));
+
+    expect(useQuerySpy).toHaveBeenLastCalledWith({
+      searchPayload: {
+        object: 'user',
+        query: ['search', ['name'], searchTermA],
+      },
+      pageSize: 101,
+    });
+    expect(result.current.searchedUsers).toEqual(searchedUsersA);
+  });
+
+  it('should debounce requests on search term changes', () => {
+    const { result } = renderHook(() => useSearchUsers());
+    expect(result.current.searchedUsers).toEqual([]);
+
+    act(() => result.current.setSearchTerm(searchTermB));
+    expect(result.current.searchedUsers).toEqual([]);
+
+    act(() => vi.advanceTimersByTime(DEBOUNCE_DURATION - 1));
+    expect(result.current.searchedUsers).toEqual([]);
+
+    act(() => vi.advanceTimersByTime(1));
+    expect(result.current.searchedUsers).toEqual(searchedUsersB);
+
+    act(() => result.current.setSearchTerm(searchTermC));
+    expect(result.current.searchedUsers).toEqual(searchedUsersB);
+
+    act(() => vi.advanceTimersByTime(DEBOUNCE_DURATION - 1));
+    expect(result.current.searchedUsers).toEqual(searchedUsersB);
+
+    act(() => vi.advanceTimersByTime(1));
+    expect(result.current.searchedUsers).toEqual(searchedUsersC);
+  });
+
+  it('should skip the request and return an empty list after the debounce timer when the term is removed', () => {
+    const { result } = renderHook(() => useSearchUsers());
+    expect(useQuerySpy).toHaveBeenLastCalledWith(skipToken);
+    expect(result.current.searchedUsers).toEqual([]);
+
+    act(() => result.current.setSearchTerm(searchTermA));
+    act(() => vi.advanceTimersByTime(DEBOUNCE_DURATION));
+    expect(result.current.searchedUsers).toEqual(searchedUsersA);
+
+    act(() => result.current.setSearchTerm(''));
+    act(() => vi.advanceTimersByTime(DEBOUNCE_DURATION - 1));
+    expect(useQuerySpy).not.toHaveBeenLastCalledWith(skipToken);
+    expect(result.current.searchedUsers).toEqual(searchedUsersA);
+
+    act(() => vi.advanceTimersByTime(1));
+    expect(useQuerySpy).toHaveBeenLastCalledWith(skipToken);
+    expect(result.current.searchedUsers).toEqual([]);
+  });
+
+  it('should eventually return an empty list when resetSuggestions is called', () => {
+    const { result } = renderHook(() => useSearchUsers());
+    act(() => result.current.setSearchTerm(searchTermA));
+    act(() => vi.advanceTimersByTime(DEBOUNCE_DURATION));
+    expect(result.current.searchedUsers).toEqual(searchedUsersA);
+
+    act(() => result.current.resetSuggestions());
+    act(() => vi.advanceTimersByTime(DEBOUNCE_DURATION));
+    expect(result.current.searchedUsers).toEqual([]);
+  });
+});

--- a/front/src/common/useSearchUsers.ts
+++ b/front/src/common/useSearchUsers.ts
@@ -15,9 +15,11 @@ export type User = {
   name: string;
 };
 
+export const DEBOUNCE_DURATION = 150;
+
 export default function useSearchUsers() {
   const [searchTerm, setSearchTerm] = useState('');
-  const debouncedSearchTerm = useDebounce(searchTerm, 150);
+  const debouncedSearchTerm = useDebounce(searchTerm, DEBOUNCE_DURATION);
 
   const { data: searchedUsersData } = osrdEditoastApi.endpoints.postSearch.useQuery(
     debouncedSearchTerm


### PR DESCRIPTION
Part of https://github.com/issues/mentioned?issue=osrd-project%7Cosrd-confidential%7C1422

I realized by writing the test that resetSuggestions no longer immeditaly reset suggestions, only after the debounceTimer. This behavior was lost during one of my refactor. We should probably either:
- drop resetSuggestions in favor of just setSearchTerm('')
- or reinstate the immediate reset behavior, moving searchedUsers back to a state with a useEffect to set it rather than the simpler useMemo it currently uses

Also realized that calling useFakeTimers outside of the describe seems to also affect the timeout timer, so I wrapped the set up in before and afterAll ^^