### PR TITLE
front: fix train schedule set forms labels and behaviour

### DIFF
--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -309,7 +309,7 @@
         "newCatalogEntry": "New set",
         "newLocalTrainScheduleSet": "New local package",
         "newTrainScheduleSet": "Create new package",
-        "package": "Series",
+        "package": "Series name",
         "parentCatalogEntry": "Parent train set",
         "publishDialogTitle": "Publish local package",
         "publishSubmit": "Publish package",

--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -312,7 +312,7 @@
         "package": "Series",
         "parentCatalogEntry": "Parent train set",
         "publishDialogTitle": "Publish local package",
-        "publishSubmit": "Edit package",
+        "publishSubmit": "Publish package",
         "publishToCatalog": "Publish to catalog",
         "removeDialogText": "You’re about to remove '{{name}}' from this scenario.",
         "removeDialogTitle": "Remove package",

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -312,7 +312,7 @@
         "package": "Série",
         "parentCatalogEntry": "Ensemble parent",
         "publishDialogTitle": "Publier le paquet local",
-        "publishSubmit": "Editer le paquet",
+        "publishSubmit": "Publier le paquet",
         "publishToCatalog": "Publier au catalogue",
         "removeDialogText": "Vous êtes sur le point de retirer {{name}} du scénario.",
         "removeDialogTitle": "Retirer le paquet",

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -309,7 +309,7 @@
         "newCatalogEntry": "Nouvel ensemble",
         "newLocalTrainScheduleSet": "Nouveau paquet local",
         "newTrainScheduleSet": "Créer un nouveau paquet",
-        "package": "Série",
+        "package": "Nom de série",
         "parentCatalogEntry": "Ensemble parent",
         "publishDialogTitle": "Publier le paquet local",
         "publishSubmit": "Publier le paquet",

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TrainScheduleSet/TrainScheduleSetDialog.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TrainScheduleSet/TrainScheduleSetDialog.tsx
@@ -20,6 +20,7 @@ type TrainScheduleSetDialogProps = {
   labels: {
     title: string;
     submit: string;
+    submitWithChanges?: string;
     cancel: string;
   };
 };
@@ -35,6 +36,7 @@ const TrainScheduleSetDialog = ({
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
   const [formHasError, setFormHasError] = useState<boolean>(false);
+  const [isEditing, setIsEditing] = useState<boolean>(false);
 
   const submit = useCallback(
     async (data: TrainScheduleSetFormData) => {
@@ -74,7 +76,9 @@ const TrainScheduleSetDialog = ({
               isDisabled={loading}
             />
             <Button
-              label={labels.submit}
+              label={
+                labels.submitWithChanges && isEditing ? labels.submitWithChanges : labels.submit
+              }
               form="train-schedule-set"
               type="submit"
               className={cx('submit-button', formHasError && 'wizz-effect')}
@@ -93,6 +97,7 @@ const TrainScheduleSetDialog = ({
         onSubmit={submit}
         onValidation={(hasError) => setFormHasError(hasError)}
         checkNameInCatalogIsUniq={checkNameInCatalogIsUniq}
+        setIsEditing={setIsEditing}
       />
     </Dialog>
   );

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TrainScheduleSet/TrainScheduleSetForm.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TrainScheduleSet/TrainScheduleSetForm.tsx
@@ -22,6 +22,7 @@ type TrainScheduleSetFormProps = {
   ) => Partial<Record<FieldName, StatusWithMessage>>;
   onValidation: (hasError: boolean) => void;
   checkNameInCatalogIsUniq?: (name: string, catalogId: number) => Promise<boolean>;
+  setIsEditing: (hasChanged: boolean) => void;
 };
 
 /**
@@ -40,6 +41,7 @@ const TrainScheduleSetForm = ({
   onSubmit,
   onValidation,
   checkNameInCatalogIsUniq,
+  setIsEditing,
 }: TrainScheduleSetFormProps) => {
   const { t } = useTranslation('operational-studies', {
     keyPrefix: 'main.timetable.trainScheduleSets',
@@ -175,6 +177,21 @@ const TrainScheduleSetForm = ({
     () => t('namePlaceholder', { series: trainSetNameExample() }),
     []
   );
+
+  const isEditing = useMemo(() => {
+    const catalogEntryChanged =
+      catalogEntry?.type === 'create' || trainScheduleSet?.catalog_entry_id !== catalogEntry?.id;
+
+    return (
+      trainScheduleSet?.name !== name ||
+      trainScheduleSet?.description !== description ||
+      catalogEntryChanged
+    );
+  }, [trainScheduleSet, name, description, catalogEntry]);
+
+  useEffect(() => {
+    setIsEditing(isEditing);
+  }, [isEditing]);
 
   return (
     <form

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TrainScheduleSet/TrainScheduleSetTab.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TrainScheduleSet/TrainScheduleSetTab.tsx
@@ -116,7 +116,7 @@ const TrainScheduleSetTab = ({
             },
       ],
     }),
-    [trainScheduleSet]
+    [trainScheduleSet, t]
   );
 
   const tabName = isSandbox(trainScheduleSet)

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TrainScheduleSet/TrainScheduleSetTab.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TrainScheduleSet/TrainScheduleSetTab.tsx
@@ -175,6 +175,7 @@ const TrainScheduleSetTab = ({
             labels={{
               title: t('publishDialogTitle'),
               submit: t('publishSubmit'),
+              submitWithChanges: t('editAndPublish'),
               cancel: t('cancel'),
             }}
             onCancel={() => setOpenedDialog(null)}


### PR DESCRIPTION
Fixes osrd-project/osrd-confidential#1432.

This pull request covers two leftovers items from the specification (see [this comment](https://github.com/osrd-project/osrd-confidential/issues/1432#issuecomment-4090166350)):

- We should always use "series name" as a label for all fields in edition forms, even when selecting items.
- We should change the label of the submit button to "Edit and publish package" (instead of "Publish package") if the package is changed during the publication process.