### PR TITLE
front, ui: drop eslint-plugin-only-warn dependency

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -124,7 +124,6 @@
         "eslint-import-resolver-typescript": "^4.4.4",
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-jsx-a11y": "^6.10.2",
-        "eslint-plugin-only-warn": "^1.1.0",
         "eslint-plugin-prettier": "^5.5.5",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^7.0.0",
@@ -9971,14 +9970,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/eslint-plugin-only-warn": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/eslint-plugin-prettier": {
       "version": "5.5.5",
       "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.5.tgz",
@@ -19138,7 +19129,6 @@
         "eslint-config-prettier": "^10.1.5",
         "eslint-import-resolver-typescript": "^4.4.4",
         "eslint-plugin-import": "^2.29.1",
-        "eslint-plugin-only-warn": "^1.1.0",
         "eslint-plugin-prettier": "^5.5.5",
         "eslint-plugin-react": "^7.35.0",
         "eslint-plugin-react-hooks": "^7.0.0",

--- a/front/package.json
+++ b/front/package.json
@@ -121,7 +121,6 @@
     "eslint-import-resolver-typescript": "^4.4.4",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",
-    "eslint-plugin-only-warn": "^1.1.0",
     "eslint-plugin-prettier": "^5.5.5",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.0",

--- a/front/ui/base/package.json
+++ b/front/ui/base/package.json
@@ -19,7 +19,6 @@
     "eslint-config-prettier": "^10.1.5",
     "eslint-import-resolver-typescript": "^4.4.4",
     "eslint-plugin-import": "^2.29.1",
-    "eslint-plugin-only-warn": "^1.1.0",
     "eslint-plugin-prettier": "^5.5.5",
     "eslint-plugin-react": "^7.35.0",
     "eslint-plugin-react-hooks": "^7.0.0",


### PR DESCRIPTION
This isn't used anywhere.