### PR TITLE
editoast: remove useless `.into_iter()`

### DIFF
--- a/editoast/editoast_models/src/prelude/retrieve.rs
+++ b/editoast/editoast_models/src/prelude/retrieve.rs
@@ -157,13 +157,10 @@ where
     {
         let ids = ids.into_iter().collect::<std::collections::HashSet<_>>();
         let (retrieved_ids, results): (std::collections::HashSet<_>, C) =
-            Self::retrieve_batch_with_key_unchecked::<_, Vec<(_, _)>>(
-                conn,
-                ids.clone().into_iter(),
-            )
-            .await?
-            .into_iter()
-            .unzip();
+            Self::retrieve_batch_with_key_unchecked::<_, Vec<(_, _)>>(conn, ids.clone())
+                .await?
+                .into_iter()
+                .unzip();
         let missing = ids
             .difference(&retrieved_ids)
             .collect::<std::collections::HashSet<_>>();
@@ -206,14 +203,11 @@ where
     {
         let ids = ids.into_iter().collect::<std::collections::HashSet<_>>();
         let (retrieved_ids, results): (std::collections::HashSet<_>, C) =
-            Self::retrieve_batch_with_key_unchecked::<_, Vec<(_, _)>>(
-                conn,
-                ids.clone().into_iter(),
-            )
-            .await?
-            .into_iter()
-            .map(|(k, v)| (k.clone(), (k, v)))
-            .unzip();
+            Self::retrieve_batch_with_key_unchecked::<_, Vec<(_, _)>>(conn, ids.clone())
+                .await?
+                .into_iter()
+                .map(|(k, v)| (k.clone(), (k, v)))
+                .unzip();
         let missing = ids
             .difference(&retrieved_ids)
             .collect::<std::collections::HashSet<_>>();

--- a/editoast/editoast_models/src/prelude/update.rs
+++ b/editoast/editoast_models/src/prelude/update.rs
@@ -195,7 +195,7 @@ where
     {
         let ids = ids.into_iter().collect::<std::collections::HashSet<_>>();
         let (updated_ids, results): (std::collections::HashSet<_>, C) = self
-            .update_batch_with_key_unchecked::<_, Vec<(_, _)>>(conn, ids.clone().into_iter())
+            .update_batch_with_key_unchecked::<_, Vec<(_, _)>>(conn, ids.clone())
             .await?
             .into_iter()
             .unzip();
@@ -247,7 +247,7 @@ where
     {
         let ids = ids.into_iter().collect::<std::collections::HashSet<_>>();
         let (updated_ids, results): (std::collections::HashSet<_>, C) = self
-            .update_batch_with_key_unchecked::<_, Vec<(_, _)>>(conn, ids.clone().into_iter())
+            .update_batch_with_key_unchecked::<_, Vec<(_, _)>>(conn, ids.clone())
             .await?
             .into_iter()
             .map(|(k, v)| (k.clone(), (k, v)))

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -309,7 +309,7 @@ pub(in crate::views) async fn user_privileges(
 ) -> Result<Json<HashMap<ResourceType, Vec<ResourcePrivileges>>>> {
     let resources = body
         .into_iter()
-        .flat_map(|(rtype, ids)| std::iter::repeat(rtype).zip(ids.into_iter()));
+        .flat_map(|(rtype, ids)| std::iter::repeat(rtype).zip(ids));
 
     let mut result = HashMap::<_, Vec<_>>::new();
 

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -203,9 +203,9 @@ pub(in crate::views) async fn users_info(
 
     // Retrieve users by IDs
     let users_1: Vec<_> =
-        User::retrieve_batch_or_fail(&mut db_pool.get().await?, user_ids, |missings| {
+        User::retrieve_batch_or_fail(&mut db_pool.get().await?, user_ids, |missing| {
             AuthzError::UnknownUser {
-                id: *missings.iter().next().unwrap(),
+                id: *missing.iter().next().unwrap(),
             }
         })
         .await?;

--- a/editoast/src/views/infra/delimited_area.rs
+++ b/editoast/src/views/infra/delimited_area.rs
@@ -188,7 +188,7 @@ pub(in crate::views) async fn delimited_area(
     if !(invalid_exits.is_empty() && invalid_entries.is_empty()) {
         let invalid_locations = invalid_entries
             .into_iter()
-            .chain(invalid_exits.into_iter())
+            .chain(invalid_exits)
             .collect::<Vec<_>>();
         return Err(DelimitedAreaError::InvalidLocations { invalid_locations }.into());
     }

--- a/editoast/src/views/projection.rs
+++ b/editoast/src/views/projection.rs
@@ -737,10 +737,8 @@ pub async fn compute_projected_train_path_op<T: TrainScheduleLike>(
     }
 
     let mut to_compute = HashMap::new();
-    for ((idx, train_schedule), (simulation, pathfinding)) in train_schedules
-        .iter()
-        .enumerate()
-        .zip(simulations.into_iter())
+    for ((idx, train_schedule), (simulation, pathfinding)) in
+        train_schedules.iter().enumerate().zip(simulations)
     {
         to_compute
             .entry(Arc::as_ptr(&simulation))


### PR DESCRIPTION
Solves nightly lint:

```
explicit call to `.into_iter()` in function argument accepting
`IntoIterator`
for further information visit
https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion
`#[warn(clippy::useless_conversion)]` on by default
```
