### PR TITLE
ci: bump rustc version

### DIFF
--- a/editoast/Dockerfile
+++ b/editoast/Dockerfile
@@ -2,7 +2,7 @@
 ##############
 # Cargo chef #
 ##############
-FROM lukemathwalker/cargo-chef:0.1.72-rust-1.89-alpine3.22 AS chef
+FROM lukemathwalker/cargo-chef:0.1.77-rust-1.93-alpine3.23 AS chef
 WORKDIR /editoast
 ENV CARGO_HOME=/cargo_editoast
 ENV PATH="/cargo_editoast/bin:$PATH"

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -3,7 +3,7 @@
 ##############
 # Cargo chef #
 ##############
-FROM lukemathwalker/cargo-chef:0.1.72-rust-1.89-alpine3.22 AS chef
+FROM lukemathwalker/cargo-chef:0.1.77-rust-1.93-alpine3.23 AS chef
 WORKDIR /gateway
 ENV CARGO_HOME=/cargo_gateway
 ENV PATH="/cargo_editoast/bin:$PATH"

--- a/osrdyne/Dockerfile
+++ b/osrdyne/Dockerfile
@@ -3,7 +3,7 @@
 ##############
 # Cargo chef #
 ##############
-FROM lukemathwalker/cargo-chef:0.1.72-rust-1.89-alpine3.22 AS chef
+FROM lukemathwalker/cargo-chef:0.1.77-rust-1.93-alpine3.23 AS chef
 WORKDIR /osrdyne
 ENV CARGO_HOME=/cargo_osrdyne
 ENV PATH="/cargo_editoast/bin:$PATH"


### PR DESCRIPTION
We use a slightly old version of rustc for rust components in CI. This PR bump to previous stable