### PR TITLE
editoast: Check arrival time on origin is zero

### DIFF
--- a/editoast/schemas/src/paced_train.rs
+++ b/editoast/schemas/src/paced_train.rs
@@ -53,16 +53,17 @@ impl<'de> Deserialize<'de> for TrainSchedule {
     where
         D: Deserializer<'de>,
     {
-        let raw = TrainSchedule::deserialize(deserializer)?;
+        let train_schedule = TrainSchedule::deserialize(deserializer)?;
 
         // Schedule item, if on the first path item, shouldn’t have an arrival
         // time different of zero (the start time of the train occurrence)
-        let arrival_time_on_first_path_item = raw
+        let arrival_time_on_first_path_item = train_schedule
             .train_occurrence
             .schedule
             .iter()
             .find(|schedule_item| {
-                raw.train_occurrence
+                train_schedule
+                    .train_occurrence
                     .path
                     .first()
                     .is_some_and(|path_item| schedule_item.at == path_item.id)
@@ -77,7 +78,7 @@ impl<'de> Deserialize<'de> for TrainSchedule {
             )));
         }
         // Check integrity of the pace in the train schedule
-        if let Some(ref paced) = raw.paced {
+        if let Some(ref paced) = train_schedule.paced {
             let mut seen_keys = HashSet::with_capacity(paced.exceptions.len());
             for e in &paced.exceptions {
                 if !seen_keys.insert(&e.key) {
@@ -103,7 +104,7 @@ impl<'de> Deserialize<'de> for TrainSchedule {
                 }
             }
         }
-        Ok(raw)
+        Ok(train_schedule)
     }
 }
 

--- a/editoast/schemas/src/paced_train.rs
+++ b/editoast/schemas/src/paced_train.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 
 use chrono::DateTime;
+use chrono::Duration;
 use chrono::Utc;
 use serde::Deserialize;
 use serde::Deserializer;
@@ -59,6 +60,28 @@ impl<'de> Deserialize<'de> for TrainSchedule {
         }
         let raw = PacedTrainJson::deserialize(deserializer)?;
 
+        // Schedule item, if on the first path item, shouldn’t have an arrival
+        // time different of zero (the start time of the train occurrence)
+        let arrival_time_on_first_path_item = raw
+            .train_occurrence
+            .schedule
+            .iter()
+            .find(|schedule_item| {
+                raw.train_occurrence
+                    .path
+                    .first()
+                    .is_some_and(|path_item| schedule_item.at == path_item.id)
+            })
+            .and_then(|ScheduleItem { arrival, .. }| arrival.as_deref().copied());
+        if let Some(arrival) = arrival_time_on_first_path_item
+            && arrival != Duration::seconds(0)
+        {
+            return Err(serde::de::Error::custom(format!(
+                "Scheduled arrival time on the origin of the path is necessary 0 seconds, but is: '{}'",
+                arrival.num_seconds()
+            )));
+        }
+        // Check integrity of the pace in the train schedule
         if let Some(ref paced) = raw.paced {
             let mut seen_keys = HashSet::with_capacity(paced.exceptions.len());
             for e in &paced.exceptions {

--- a/editoast/schemas/src/paced_train.rs
+++ b/editoast/schemas/src/paced_train.rs
@@ -38,7 +38,8 @@ pub struct Paced {
     pub exceptions: Vec<PacedTrainException>,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, ToSchema)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
+#[serde(remote = "Self")]
 pub struct TrainSchedule {
     #[serde(flatten)]
     #[schema(inline)]
@@ -52,13 +53,7 @@ impl<'de> Deserialize<'de> for TrainSchedule {
     where
         D: Deserializer<'de>,
     {
-        #[derive(Deserialize)]
-        struct PacedTrainJson {
-            #[serde(flatten)]
-            pub train_occurrence: TrainOccurrence,
-            pub paced: Option<Paced>,
-        }
-        let raw = PacedTrainJson::deserialize(deserializer)?;
+        let raw = TrainSchedule::deserialize(deserializer)?;
 
         // Schedule item, if on the first path item, shouldn’t have an arrival
         // time different of zero (the start time of the train occurrence)
@@ -108,10 +103,16 @@ impl<'de> Deserialize<'de> for TrainSchedule {
                 }
             }
         }
-        Ok(TrainSchedule {
-            train_occurrence: raw.train_occurrence,
-            paced: raw.paced,
-        })
+        Ok(raw)
+    }
+}
+
+impl Serialize for TrainSchedule {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        TrainSchedule::serialize(self, serializer)
     }
 }
 


### PR DESCRIPTION
When a schedule item is on the first path item, and there is an arrival time, the value must be zero: the train necessary starts at “start time” which is zero seconds from the beginning.