### PR TITLE
editoast: model: remove offset-based listing query

### DIFF
--- a/editoast/editoast_derive/src/model/codegen.rs
+++ b/editoast/editoast_derive/src/model/codegen.rs
@@ -354,6 +354,7 @@ impl ModelConfig {
         ListImpl {
             model: self.model.clone(),
             table_mod: self.table.clone(),
+            primary_key: self.get_primary_field_column(),
             row: self.row.name.clone(),
             columns: self.columns().cloned().collect(),
             error: self.errors.list.clone(),

--- a/editoast/editoast_derive/src/model/codegen/list_impl.rs
+++ b/editoast/editoast_derive/src/model/codegen/list_impl.rs
@@ -4,6 +4,7 @@ use quote::quote;
 pub(crate) struct ListImpl {
     pub(super) model: syn::Ident,
     pub(super) table_mod: syn::Path,
+    pub(super) primary_key: syn::Ident,
     pub(super) row: syn::Ident,
     pub(super) columns: Vec<syn::Ident>,
     pub(super) error: syn::Path,
@@ -14,6 +15,7 @@ impl ToTokens for ListImpl {
         let Self {
             model,
             table_mod,
+            primary_key,
             row,
             columns,
             error,
@@ -36,32 +38,78 @@ impl ToTokens for ListImpl {
                     conn: &mut database::DbConnection,
                     settings: crate::prelude::SelectionSettings<Self>,
                 ) -> std::result::Result<Vec<Self>, Self::Error> {
-                    use diesel::QueryDsl;
-                    use diesel_async::RunQueryDsl;
-                    use futures_util::TryStreamExt;
+                    use diesel::ExpressionMethods as _;
+                    use diesel::NullableExpressionMethods as _;
+                    use diesel::QueryDsl as _;
+                    use diesel_async::RunQueryDsl as _;
+                    use futures_util::TryStreamExt as _;
                     use #table_mod::dsl;
                     use std::ops::DerefMut;
 
                     let mut query = #table_mod::table.into_boxed();
 
-                    for filter_fun in settings.filters {
+                    for filter_fun in &settings.filters {
                         let crate::prelude::FilterSetting(filter) = (*filter_fun)();
                         query = query.filter(filter);
                     }
 
-                    for sort_fun in settings.sorts {
+                    for sort_fun in &settings.sorts {
                         let crate::prelude::SortSetting(sort) = (*sort_fun)();
                         query = query.order_by(sort);
+                    }
+
+                    if settings.sorts.is_empty() {
+                        query = query.order_by(dsl::#primary_key.asc());
+                    }
+
+                    // Avoids OFFSET: instead of scanning past offset
+                    // rows, use a subquery to skip directly to the
+                    // right pk and let the index find the first row faster.
+                    //
+                    // Makes PostgreSQL waste less time on IO skipping rows. More
+                    // info: https://github.com/OpenRailAssociation/osrd/issues/15852
+                    //
+                    // We should eventually change the API to expect cursor pagination
+                    // or streaming when applicable.
+                    //
+                    // Generated SQL:
+                    //   SELECT cols FROM table
+                    //   WHERE <filters>
+                    //     AND pk >= (SELECT pk FROM table WHERE <filters>
+                    //                ORDER BY pk ASC LIMIT 1 OFFSET <offset>)
+                    //   ORDER BY pk ASC
+                    //   LIMIT <limit>
+                    if let Some(offset) = settings.offset
+                        && offset > 0
+                    {
+                        tracing::Span::current().record("offset", offset);
+
+                        let mut first_pk_query = #table_mod::table.into_boxed();
+                        for filter_fun in &settings.filters {
+                            let crate::prelude::FilterSetting(filter) = (*filter_fun)();
+                            first_pk_query = first_pk_query.filter(filter);
+                        }
+
+                        for sort_fun in &settings.sorts {
+                            let crate::prelude::SortSetting(sort) = (*sort_fun)();
+                            first_pk_query = first_pk_query.order_by(sort);
+                        }
+
+                        if settings.sorts.is_empty() {
+                            first_pk_query = first_pk_query.order_by(dsl::#primary_key.asc());
+                        }
+
+                        let first_pk = first_pk_query
+                            .select(dsl::#primary_key)
+                            .offset(offset)
+                            .single_value();
+
+                        query = query.filter(dsl::#primary_key.nullable().ge(first_pk));
                     }
 
                     if let Some(limit) = settings.limit {
                         tracing::Span::current().record("limit", limit);
                         query = query.limit(limit);
-                    }
-
-                    if let Some(offset) = settings.offset {
-                        tracing::Span::current().record("offset", offset);
-                        query = query.offset(offset);
                     }
 
                     let stream = query

--- a/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__construction.snap
+++ b/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__construction.snap
@@ -508,27 +508,46 @@ impl crate::prelude::List for Document {
         conn: &mut database::DbConnection,
         settings: crate::prelude::SelectionSettings<Self>,
     ) -> std::result::Result<Vec<Self>, Self::Error> {
-        use diesel::QueryDsl;
-        use diesel_async::RunQueryDsl;
-        use futures_util::TryStreamExt;
+        use diesel::ExpressionMethods as _;
+        use diesel::NullableExpressionMethods as _;
+        use diesel::QueryDsl as _;
+        use diesel_async::RunQueryDsl as _;
+        use futures_util::TryStreamExt as _;
         use database::tables::osrd_infra_document::dsl;
         use std::ops::DerefMut;
         let mut query = database::tables::osrd_infra_document::table.into_boxed();
-        for filter_fun in settings.filters {
+        for filter_fun in &settings.filters {
             let crate::prelude::FilterSetting(filter) = (*filter_fun)();
             query = query.filter(filter);
         }
-        for sort_fun in settings.sorts {
+        for sort_fun in &settings.sorts {
             let crate::prelude::SortSetting(sort) = (*sort_fun)();
             query = query.order_by(sort);
+        }
+        if settings.sorts.is_empty() {
+            query = query.order_by(dsl::id.asc());
+        }
+        if let Some(offset) = settings.offset && offset > 0 {
+            tracing::Span::current().record("offset", offset);
+            let mut first_pk_query = database::tables::osrd_infra_document::table
+                .into_boxed();
+            for filter_fun in &settings.filters {
+                let crate::prelude::FilterSetting(filter) = (*filter_fun)();
+                first_pk_query = first_pk_query.filter(filter);
+            }
+            for sort_fun in &settings.sorts {
+                let crate::prelude::SortSetting(sort) = (*sort_fun)();
+                first_pk_query = first_pk_query.order_by(sort);
+            }
+            if settings.sorts.is_empty() {
+                first_pk_query = first_pk_query.order_by(dsl::id.asc());
+            }
+            let first_pk = first_pk_query.select(dsl::id).offset(offset).single_value();
+            query = query.filter(dsl::id.nullable().ge(first_pk));
         }
         if let Some(limit) = settings.limit {
             tracing::Span::current().record("limit", limit);
             query = query.limit(limit);
-        }
-        if let Some(offset) = settings.offset {
-            tracing::Span::current().record("offset", offset);
-            query = query.offset(offset);
         }
         let stream = query
             .select((dsl::id, dsl::content_type, dsl::data))

--- a/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__single_pk_model.snap
+++ b/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__single_pk_model.snap
@@ -220,27 +220,45 @@ impl crate::prelude::List for Timetable {
         conn: &mut database::DbConnection,
         settings: crate::prelude::SelectionSettings<Self>,
     ) -> std::result::Result<Vec<Self>, Self::Error> {
-        use diesel::QueryDsl;
-        use diesel_async::RunQueryDsl;
-        use futures_util::TryStreamExt;
+        use diesel::ExpressionMethods as _;
+        use diesel::NullableExpressionMethods as _;
+        use diesel::QueryDsl as _;
+        use diesel_async::RunQueryDsl as _;
+        use futures_util::TryStreamExt as _;
         use database::tables::timetable::dsl;
         use std::ops::DerefMut;
         let mut query = database::tables::timetable::table.into_boxed();
-        for filter_fun in settings.filters {
+        for filter_fun in &settings.filters {
             let crate::prelude::FilterSetting(filter) = (*filter_fun)();
             query = query.filter(filter);
         }
-        for sort_fun in settings.sorts {
+        for sort_fun in &settings.sorts {
             let crate::prelude::SortSetting(sort) = (*sort_fun)();
             query = query.order_by(sort);
+        }
+        if settings.sorts.is_empty() {
+            query = query.order_by(dsl::id.asc());
+        }
+        if let Some(offset) = settings.offset && offset > 0 {
+            tracing::Span::current().record("offset", offset);
+            let mut first_pk_query = database::tables::timetable::table.into_boxed();
+            for filter_fun in &settings.filters {
+                let crate::prelude::FilterSetting(filter) = (*filter_fun)();
+                first_pk_query = first_pk_query.filter(filter);
+            }
+            for sort_fun in &settings.sorts {
+                let crate::prelude::SortSetting(sort) = (*sort_fun)();
+                first_pk_query = first_pk_query.order_by(sort);
+            }
+            if settings.sorts.is_empty() {
+                first_pk_query = first_pk_query.order_by(dsl::id.asc());
+            }
+            let first_pk = first_pk_query.select(dsl::id).offset(offset).single_value();
+            query = query.filter(dsl::id.nullable().ge(first_pk));
         }
         if let Some(limit) = settings.limit {
             tracing::Span::current().record("limit", limit);
             query = query.limit(limit);
-        }
-        if let Some(offset) = settings.offset {
-            tracing::Span::current().record("offset", offset);
-            query = query.offset(offset);
         }
         let stream = query
             .select((dsl::id,))


### PR DESCRIPTION
fixes https://github.com/OpenRailAssociation/osrd/issues/15852

Scrolling though OFFSET rows wastes a lot of IO and time when there's a
lot of rows. We should instead use cursors. In order to avoid changing
the API right now (though we eventually should) we compute the cursor
using a subquery. IO is wasted, but significantly less.

