### PR TITLE
front, ui: style checkbox inputs directly

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/UniqueTrainItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/UniqueTrainItem.tsx
@@ -198,7 +198,10 @@ const UniqueTrainItem = ({
                   />
                 )}
               </div>
-              <div title={train.name} className="checkbox-label">
+              <div
+                title={train.name}
+                className={cx('checkbox-label', { 'with-checkbox': isSelectMode })}
+              >
                 <div
                   className={cx('train-info', getTrainCategoryClassName(category, 'text'))}
                   style={{ color: currentSubCategory?.color }}

--- a/front/src/modules/conflict/components/ConflictsToolbar.tsx
+++ b/front/src/modules/conflict/components/ConflictsToolbar.tsx
@@ -43,8 +43,9 @@ const ConflictsToolbar = ({
           onChange={onToggleFilter}
           disabled={disabled || !selectedTrainName}
           small
-        />
-        <div className="filter-label">{getDisplayText()}</div>
+        >
+          <div className="filter-label">{getDisplayText()}</div>
+        </Checkbox>
       </div>
     </div>
   );

--- a/front/src/modules/conflict/styles/_conflictsToolbar.scss
+++ b/front/src/modules/conflict/styles/_conflictsToolbar.scss
@@ -3,27 +3,14 @@
   align-items: center;
   background-color: var(--ambientB5);
   border-bottom: 1px solid white;
-  position: relative;
-
-  &::after {
-    content: '';
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    height: 1px;
-    background-color: var(--black10);
-  }
+  box-shadow: inset 0 -1px 0 0 var(--black10);
 
   .filter-label {
     display: flex;
     align-items: center;
     white-space: nowrap;
-    margin-left: 6px;
     gap: 4px;
-    font-size: 0.875rem;
     color: var(--grey80);
-    line-height: 16px;
   }
 
   .filter-label .train-name {
@@ -38,6 +25,11 @@
     display: flex;
     align-items: center;
     width: 100%;
-    padding: 0 6px;
+    padding: 0 6px 3px 8px;
+
+    // Even if we use its label property, we still want to center the whole checkbox and label combo ourselves
+    .ui-checkbox {
+      margin-bottom: 0;
+    }
   }
 }

--- a/front/src/modules/simulationResult/styles/_manchetteWithSpaceTimeChart.scss
+++ b/front/src/modules/simulationResult/styles/_manchetteWithSpaceTimeChart.scss
@@ -116,7 +116,7 @@
     section {
       // Correctly align the checkbox with the radio buttons
       .ui-checkbox {
-        margin-left: 2px;
+        margin-left: 8px;
       }
 
       // Override the default padding of the radio button wrapper

--- a/front/src/styles/scss/applications/operationalStudies/_pacedTrain.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_pacedTrain.scss
@@ -126,7 +126,6 @@
 
   .ui-checkbox.small {
     margin-bottom: 0;
-    padding-left: 21px;
   }
 
   .base-info {

--- a/front/src/styles/scss/applications/operationalStudies/_scenario.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_scenario.scss
@@ -467,8 +467,7 @@
           line-height: 24px;
 
           .ui-checkbox.small {
-            padding-left: 21px;
-            margin-left: 2px;
+            margin-left: 6px;
           }
         }
 
@@ -481,6 +480,10 @@
           font-size: 1rem;
           font-weight: 600;
           max-width: 160px;
+
+          &.with-checkbox {
+            margin-left: 2px;
+          }
 
           .train-info {
             display: flex;
@@ -680,7 +683,8 @@
           border-bottom: solid 1px var(--black25);
 
           .select-button {
-            margin-left: 6px;
+            margin-left: 10px;
+            margin-right: 5px;
           }
 
           .export-selection-button {
@@ -856,6 +860,10 @@
             flex: 1;
             min-width: 0;
             cursor: pointer;
+
+            .ui-checkbox {
+              margin-inline: 4px;
+            }
 
             &.add-tab {
               gap: 12px;

--- a/front/src/styles/scss/applications/operationalStudies/_scenario.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_scenario.scss
@@ -681,7 +681,6 @@
 
           .select-button {
             margin-left: 6px;
-            margin-top: 2px;
           }
 
           .export-selection-button {

--- a/front/tests/pages/operational-studies/get-manchette-component.ts
+++ b/front/tests/pages/operational-studies/get-manchette-component.ts
@@ -40,8 +40,9 @@ class GetManchetteComponent extends OpSimulationResultPage {
     this.spaceTimeChartMenuButton = this.spaceTimeChart.getByTestId('menu-button');
     this.spaceTimeChartCloseSettingsButton = page.getByTestId('settings-panel-close-button');
     this.spaceTimeChartSettingsPanel = page.getByTestId('settings-panel');
-    this.spaceTimeChartCheckboxItems =
-      this.spaceTimeChartSettingsPanel.locator('.ui-checkbox .checkmark');
+    this.spaceTimeChartCheckboxItems = this.spaceTimeChartSettingsPanel.locator(
+      '.ui-checkbox input[type=checkbox]'
+    );
     this.manchetteMenuButton = this.simulationResults.getByTestId('board-header-button').first();
     this.manchetteVisibilityButton = page.getByTestId('manchette-waypoints-visibility-button');
     this.waypointsList = page.getByTestId('waypoint-base-info');

--- a/front/tests/pages/operational-studies/simulation-results-page.ts
+++ b/front/tests/pages/operational-studies/simulation-results-page.ts
@@ -28,7 +28,7 @@ class OpSimulationResultPage extends ScenarioPage {
     this.simulationMap = page.getByTestId('simulation-map');
     this.speedSpaceChartSettingsButton = page.getByTestId('interaction-settings');
     this.speedSpaceChartCloseSettingsButton = page.getByTestId('settings-panel-close');
-    this.speedSpaceChartCheckboxItems = page.locator('#settings-panel .checkmark');
+    this.speedSpaceChartCheckboxItems = page.locator('#settings-panel input[type=checkbox]');
     this.conflictsList = page.getByTestId('conflicts-list');
     this.trainList = page.getByTestId('scenario-left-column');
     this.simulationMap = page.getByTestId('simulation-map');

--- a/front/ui/ui-core/src/components/Checkbox/Checkbox.tsx
+++ b/front/ui/ui-core/src/components/Checkbox/Checkbox.tsx
@@ -2,12 +2,14 @@ import React, { type InputHTMLAttributes, type MouseEvent } from 'react';
 
 import cx from 'classnames';
 
-export type CheckboxProps = InputHTMLAttributes<HTMLInputElement> & {
-  label?: string;
-  small?: boolean;
-  hint?: string;
-  isIndeterminate?: boolean;
-};
+export type CheckboxProps = React.PropsWithChildren<
+  Omit<InputHTMLAttributes<HTMLInputElement>, 'children'> & {
+    label?: string;
+    small?: boolean;
+    hint?: string;
+    isIndeterminate?: boolean;
+  }
+>;
 
 const Checkbox = ({
   label,
@@ -18,6 +20,7 @@ const Checkbox = ({
   readOnly,
   isIndeterminate = false,
   onClick,
+  children,
   ...rest
 }: CheckboxProps) => {
   const handleClick = (e: MouseEvent<HTMLInputElement>) => {
@@ -29,7 +32,9 @@ const Checkbox = ({
     }
   };
   return (
-    <label className={cx('ui-checkbox', { small, 'with-label': label, 'with-hint': hint })}>
+    <label
+      className={cx('ui-checkbox', { small, 'with-label': label || children, 'with-hint': hint })}
+    >
       <input
         // Browsers' read-only attribute is not working on checkboxes. See: https://stackoverflow.com/a/70375659
         className={cx({ 'read-only': readOnly })}
@@ -45,6 +50,7 @@ const Checkbox = ({
         {...rest}
       />
       {label && <div className="label">{label}</div>}
+      {children && <div className="label">{children}</div>}
       {hint && <span className="hint">{hint}</span>}
     </label>
   );

--- a/front/ui/ui-core/src/components/Checkbox/Checkbox.tsx
+++ b/front/ui/ui-core/src/components/Checkbox/Checkbox.tsx
@@ -2,8 +2,6 @@ import React, { type InputHTMLAttributes, type MouseEvent } from 'react';
 
 import cx from 'classnames';
 
-import useFocusByTab from '../../hooks/useFocusByTab';
-
 export type CheckboxProps = InputHTMLAttributes<HTMLInputElement> & {
   label?: string;
   small?: boolean;
@@ -20,12 +18,8 @@ const Checkbox = ({
   readOnly,
   isIndeterminate = false,
   onClick,
-  onKeyUp,
-  onBlur,
   ...rest
 }: CheckboxProps) => {
-  const { handleKeyUp, handleBlur, isFocusByTab } = useFocusByTab({ onBlur, onKeyUp });
-
   const handleClick = (e: MouseEvent<HTMLInputElement>) => {
     if (readOnly) {
       e.preventDefault();
@@ -35,9 +29,9 @@ const Checkbox = ({
     }
   };
   return (
-    <label className={cx('ui-checkbox', { small })}>
+    <label className={cx('ui-checkbox', { small, 'with-label': label, 'with-hint': hint })}>
       <input
-        //read-only state is not working on checkbox as well explain here : https://stackoverflow.com/a/70375659
+        // Browsers' read-only attribute is not working on checkboxes. See: https://stackoverflow.com/a/70375659
         className={cx({ 'read-only': readOnly })}
         type="checkbox"
         checked={checked}
@@ -48,11 +42,8 @@ const Checkbox = ({
           }
         }}
         onClick={handleClick}
-        onBlur={handleBlur}
-        onKeyUp={handleKeyUp}
         {...rest}
       />
-      <span className={cx('checkmark', { 'focused-by-tab': isFocusByTab })}></span>
       {label && <div className="label">{label}</div>}
       {hint && <span className="hint">{hint}</span>}
     </label>

--- a/front/ui/ui-core/src/styles/inputs/checkbox.css
+++ b/front/ui/ui-core/src/styles/inputs/checkbox.css
@@ -185,11 +185,12 @@
   grid: auto / minmax(calc(var(--ui-checkbox-size) + 6px), auto);
   align-items: center;
   width: fit-content;
-  margin-bottom: 0.3rem;
+  margin-bottom: unset;
 
   &.with-label,
   &.with-hint {
     grid-template-columns: auto auto;
+    margin-bottom: 0.3rem;
   }
   &.with-hint {
     grid-template-rows: minmax(calc(var(--ui-checkbox-size) + 6px), auto) auto;

--- a/front/ui/ui-core/src/styles/inputs/checkbox.css
+++ b/front/ui/ui-core/src/styles/inputs/checkbox.css
@@ -1,299 +1,245 @@
+/* Checkbox styles
+ * Note that we style the input directly, using &:before to draw the outer hover or focus ring,
+ * and &:after for the symbols visible inside of it (i.e. the checkmark or the indeterminate dash). */
 .ui-checkbox {
-  display: block;
-  position: relative;
-  padding-left: 31px;
-  margin-bottom: 4.8px;
-  cursor: pointer;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  opacity: 1;
-  font-size: 1rem;
-  font-weight: 400;
-  letter-spacing: 0;
-  text-align: left;
-  width: fit-content;
-  height: 24px;
-
-  .label {
-    line-height: 24px;
-    padding: 0 0 0 3px;
-    @apply text-grey-80;
-  }
-
-  &:has(> input:disabled),
-  &:has(> input.read-only) {
-    cursor: default;
-  }
-
-  .checkmark {
-    position: absolute;
-    top: 2.4px;
-    left: 6.4px;
-    border-radius: 3px;
-    box-sizing: content-box;
-    width: 18px;
-    height: 18px;
-    border: 2px solid rgba(235, 235, 234, 1);
-    border: 2.5px solid rgba(211, 209, 207, 1);
-    border: 2px solid rgba(255, 255, 255, 1);
-    border: 1px solid rgba(148, 145, 142, 1);
-    opacity: 1;
-    background-image: linear-gradient(
-      180deg,
-      rgba(255, 255, 255, 1) 0%,
-      rgba(245, 245, 245, 1) 100%
-    );
-    outline: solid 0.125rem #ebebea;
-
-    &:after {
-      content: '';
-      position: absolute;
-      top: 0.063rem;
-      left: 0.063rem;
-      bottom: 0.063rem;
-      right: 0.063rem;
-      border: 0.031rem #d3d1cf solid;
-      border-radius: 0.063rem;
-    }
-
-    &.focused-by-tab {
-      outline: none;
-
-      &:before {
-        content: '';
-        position: absolute;
-        top: -0.188rem;
-        left: -0.188rem;
-        bottom: -0.188rem;
-        right: -0.188rem;
-        border: 0.063rem solid rgba(37, 106, 250, 1);
-      }
-    }
-  }
-
-  .hint {
-    font-size: 0.875rem;
-    line-height: 1.25rem;
-    text-align: left;
-    font-size: 0.875rem;
-    font-weight: 400;
-    letter-spacing: 0;
-    @apply text-grey-50;
-  }
-
-  &:hover {
-    &.small {
-      .checkmark {
-        outline: solid 0.094rem #98c0f5;
-      }
-    }
-    .checkmark {
-      outline: solid 0.125rem #98c0f5;
-    }
-  }
-
-  &.small {
-    font-size: 0.875rem;
-    padding-left: 1.5rem;
-    margin-bottom: 0.125rem;
-
-    .checkmark {
-      width: 0.875rem;
-      height: 0.875rem;
-      top: 0.25rem;
-      left: 0.25rem;
-      outline: solid 0.094rem #ebebea;
-    }
-    .label {
-      line-height: 1.25rem;
-      padding-top: 0.125rem;
-    }
-    input {
-      &:indeterminate ~ .checkmark,
-      &:checked ~ .checkmark {
-        &:after {
-          position: absolute;
-          border: none;
-          opacity: 1;
-          top: -0.094rem;
-          left: 0;
-        }
-      }
-
-      &.read-only {
-        &:checked ~ .checkmark {
-          &:after {
-            content: inline('../assets/check_small_readonly.svg');
-          }
-        }
-        &:indeterminate ~ .checkmark {
-          &:after {
-            content: inline('../assets/indeterminateCheckbox_small_readonly.svg');
-          }
-        }
-      }
-
-      &:disabled {
-        &:checked ~ .checkmark {
-          &:after {
-            content: inline('../assets/check_small_disabled.svg');
-          }
-        }
-        &:indeterminate ~ .checkmark {
-          &:after {
-            content: inline('../assets/indeterminateCheckbox_small_disabled.svg');
-          }
-        }
-      }
-
-      &:indeterminate ~ .checkmark {
-        &:after {
-          content: inline('../assets/indeterminateCheckbox_small_shadow.svg');
-        }
-      }
-
-      &:checked ~ .checkmark {
-        &:after {
-          content: inline('../assets/check_small_shadow.svg');
-        }
-      }
-    }
-  }
+  --ui-checkbox-size: 18px;
 
   input {
-    position: absolute;
-    opacity: 0;
-    cursor: pointer;
-    height: 0;
-    width: 0;
+    appearance: none;
+    width: var(--ui-checkbox-size);
+    height: var(--ui-checkbox-size);
+    border-radius: 3px;
+    border: 1px solid #94918e;
 
-    &:checked ~ .checkmark {
-      border-radius: 0.188rem;
-      border: 0.063rem solid #1f1b17;
-      opacity: 1;
-      background-image: linear-gradient(
-        180deg,
-        rgba(148, 145, 142, 1) 0%,
-        rgba(121, 118, 113, 1) 100%
-      );
-      &:after {
-        border: none;
-        content: inline('../assets/check_regular_shadow.svg');
-        opacity: 1;
-        top: 0;
-        left: 0;
-      }
+    --ui-checkbox-outer-ring-color: #ebebea;
+    box-shadow:
+      inset 0 0 0 1px white,
+      inset 0 0 0 1.5px #d3d1cf;
+    background-image: linear-gradient(180deg, white 0%, #f5f5f5 100%);
+    outline: 0 none;
+
+    cursor: pointer;
+
+    display: grid;
+    grid: 1fr / 1fr;
+    place-items: center;
+
+    &:before {
+      content: '';
+      display: block;
+      width: 100%;
+      height: 100%;
+      grid-area: 1 / 1;
+      border-radius: 2px;
+      outline: 2px solid var(--ui-checkbox-outer-ring-color);
+      outline-offset: 1px;
+      pointer-events: none;
     }
 
-    &:indeterminate ~ .checkmark {
-      border-radius: 0.188rem;
-      border: 0.063rem solid #1f1b17;
-      opacity: 1;
-      background-image: linear-gradient(
-        180deg,
-        rgba(148, 145, 142, 1) 0%,
-        rgba(121, 118, 113, 1) 100%
-      );
-      &:after {
-        border: none;
-        content: inline('../assets/indeterminateCheckbox_regular_shadow.svg');
-        opacity: 1;
-        top: 0;
-        left: 0;
+    &:hover:not(:disabled) {
+      --ui-checkbox-outer-ring-color: #98c0f5;
+    }
+
+    &:focus-visible:before {
+      border-radius: 0;
+      outline: 1px solid #256afa;
+      outline-offset: 2px;
+      box-shadow: none;
+    }
+
+    &:after {
+      grid-area: 1 / 1;
+      content: '';
+      display: block;
+      width: calc(var(--ui-checkbox-size) - 2px);
+      height: calc(var(--ui-checkbox-size) - 2px);
+      pointer-events: none;
+      background-position: center center;
+    }
+
+    &:checked,
+    &:indeterminate {
+      background-image: linear-gradient(180deg, #94918e 0%, #797671 100%);
+      border-color: #1f1b17;
+      box-shadow: none;
+    }
+
+    &:checked:after {
+      background-image: inline('../assets/check_regular_shadow.svg');
+    }
+
+    &:indeterminate:after {
+      background-image: inline('../assets/indeterminateCheckbox_regular_shadow.svg');
+    }
+
+    &:disabled {
+      box-shadow: none;
+      background-image: none;
+      background-color: white;
+      @apply border-grey-20;
+      cursor: default;
+
+      &:checked,
+      &:indeterminate {
+        background-color: #d3d1cf;
+        border-color: #b6b3af;
+      }
+
+      &:before {
+        display: none;
+      }
+
+      &:checked:after {
+        background-image: inline('../assets/check_regular_without_shadow.svg');
+
+        .small & {
+          background-image: inline('../assets/check_small_readonly.svg');
+        }
+      }
+
+      &:indeterminate:after {
+        background-image: inline('../assets/indeterminateCheckbox_regular_without_shadow.svg');
+
+        .small & {
+          background-image: inline('../assets/indeterminateCheckbox_small_readonly.svg');
+        }
       }
     }
 
     &.read-only {
-      pointer-events: none;
-      & ~ .checkmark {
-        border: 1px solid rgba(92, 89, 85, 1);
-        outline: none;
+      box-shadow: none;
+      cursor: default;
 
-        &:after {
-          border: 0;
+      &,
+      &:checked,
+      &:indeterminate {
+        background-image: none;
+        background-color: white;
+        @apply border-grey-60;
+      }
+
+      &:not(:focus-visible):before {
+        display: none;
+      }
+
+      &:checked:after {
+        background-image: inline('../assets/check_readonly.svg');
+
+        .small & {
+          background-image: inline('../assets/check_small_readonly.svg');
         }
       }
-      & ~ .label {
-        @apply text-grey-50;
-      }
-      &:checked ~ .checkmark {
-        border: 0.063rem solid rgba(92, 89, 85, 1);
-        background-color: rgba(255, 255, 255, 1);
-        outline: none;
-        background-image: linear-gradient(
-          180deg,
-          rgba(255, 255, 255, 1) 0%,
-          rgba(245, 245, 245, 1) 100%
-        );
 
-        &:after {
-          border: none;
-          content: inline('../assets/check_readonly.svg');
-        }
-      }
-      &:indeterminate ~ .checkmark {
-        border: 0.063rem solid rgba(92, 89, 85, 1);
-        background-color: rgba(255, 255, 255, 1);
-        outline: none;
-        background-image: linear-gradient(
-          180deg,
-          rgba(255, 255, 255, 1) 0%,
-          rgba(245, 245, 245, 1) 100%
-        );
+      &:indeterminate:after {
+        background-image: inline('../assets/indeterminateCheckbox_readonly.svg');
 
-        &:after {
-          border: none;
-          content: inline('../assets/indeterminateCheckbox_readonly.svg');
+        .small & {
+          background-image: inline('../assets/indeterminateCheckbox_small_readonly.svg');
         }
       }
     }
+  }
 
-    &:disabled {
-      & ~ .label {
-        @apply text-grey-30;
+  &.small {
+    --ui-checkbox-size: 16px;
+
+    input {
+      &:before {
+        outline-width: 1px;
       }
 
-      & ~ .checkmark {
-        outline: none;
-        @apply border-grey-20;
+      &:checked:after {
+        background-image: inline('../assets/check_small_shadow.svg');
+      }
 
-        &:after {
-          border: none;
+      &:indeterminate:after {
+        background-image: inline('../assets/indeterminateCheckbox_small_shadow.svg');
+      }
+
+      &:disabled {
+        &:checked:after {
+          background-image: inline('../assets/check_small_disabled.svg');
+        }
+
+        &:indeterminate:after {
+          background-image: inline('../assets/indeterminateCheckbox_small_disabled.svg');
         }
       }
 
-      &:checked ~ .checkmark,
-      &:indeterminate ~ .checkmark {
-        outline: none;
-        @apply border-grey-30;
-        background-image: linear-gradient(
-          180deg,
-          rgba(211, 209, 207, 1) 0%,
-          rgba(211, 209, 207, 1) 100%
-        );
-      }
-
-      &:checked ~ .checkmark {
-        &:after {
-          border: none;
-          content: inline('../assets/check_regular_without_shadow.svg');
+      &.read-only {
+        &:checked:after {
+          background-image: inline('../assets/check_small_readonly.svg');
         }
-      }
 
-      &:indeterminate ~ .checkmark {
-        &:after {
-          border: none;
-          content: inline('../assets/indeterminateCheckbox_regular_without_shadow.svg');
+        &:indeterminate:after {
+          background-image: inline('../assets/indeterminateCheckbox_small_readonly.svg');
         }
       }
     }
   }
 }
 
+/* Labels and hints */
+.ui-checkbox {
+  display: grid;
+  grid: auto / minmax(calc(var(--ui-checkbox-size) + 6px), auto);
+  align-items: center;
+  width: fit-content;
+  margin-bottom: 0.3rem;
+
+  &.with-label,
+  &.with-hint {
+    grid-template-columns: auto auto;
+  }
+  &.with-hint {
+    grid-template-rows: minmax(calc(var(--ui-checkbox-size) + 6px), auto) auto;
+  }
+
+  .label,
+  .hint {
+    grid-column: 2;
+    cursor: pointer;
+  }
+
+  .label {
+    line-height: var(--ui-checkbox-size);
+  }
+
+  &.small .label {
+    font-size: 0.875rem;
+  }
+
+  .hint {
+    font-size: 0.875rem;
+    @apply text-grey-50;
+  }
+
+  input:disabled {
+    & ~ .label,
+    & ~ .hint {
+      cursor: default;
+      @apply text-grey-30;
+    }
+  }
+
+  .read-only {
+    & ~ .label,
+    & ~ .hint {
+      cursor: default;
+      @apply text-grey-50;
+    }
+  }
+
+  column-gap: 8px;
+
+  &.small {
+    column-gap: 6px;
+  }
+}
+
 .checkbox-list ul {
   margin-left: 1.25rem;
+
   &.small {
     margin-left: 1rem;
   }


### PR DESCRIPTION
Fixes #15787.

Okay, it's not _only_ about fixing this little bug… it's a matter of two things:
- There is no need to use the "label next to the input" trick anymore to style checkboxes.
- `:focus-visible` is now widely available and we should use it to cover all the cases where we want to display focus rings properly.

I also spot that checkboxes were _slightly_ bigger than Thibaut's mockups on Sketch and that we draw a full pixel line for the inner square (instead of a .5px line), so I also fixed that. I also opted for grids to layout the label and the hint, removing all usage of the `relative` + `absolute` combo that relied on paddings — I am sure that it will get rid of a lot of weird, frustrating bugs in the long run.

I also changed the Checkbox "signature" (well, its proprs) component a little bit to add support for children. Indeed, I noticed that in ConflictsToolbar, we reimplemented the whole checkbox + label layout just so we could use a fancy label; it's easier and more "Reacty" to use a children for that matter.

After a discussion with @Math-R, I also added some fixes for all the usage of those checkboxes everywhere.

An obvious follow-up will be to apply the same work to radiobuttons, but let's do it step-by-step.