### PR TITLE
editoast, gateway, osrdyne: bump cargo chef and rust version

### DIFF
--- a/editoast/Dockerfile
+++ b/editoast/Dockerfile
@@ -2,7 +2,7 @@
 ##############
 # Cargo chef #
 ##############
-FROM lukemathwalker/cargo-chef:0.1.72-rust-1.89-alpine3.22 AS chef
+FROM lukemathwalker/cargo-chef:0.1.77-rust-1.94-alpine3.23 AS chef
 WORKDIR /editoast
 ENV CARGO_HOME=/cargo_editoast
 ENV PATH="/cargo_editoast/bin:$PATH"
@@ -94,7 +94,7 @@ RUN --mount=type=cache,target=/cargo_editoast/registry \
 ###############
 # Running env #
 ###############
-FROM alpine:3.22 AS running_env
+FROM alpine:3.23 AS running_env
 RUN apk add --no-cache jemalloc curl ca-certificates geos libpq openssl postgresql16-client
 
 COPY --from=run_builder /cargo_editoast/bin/editoast /usr/local/bin/editoast

--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1772521798,
-        "narHash": "sha256-N69u6BZTfCyCsqyc1Qv/qvqkGkTCO6peGInKae51r/E=",
+        "lastModified": 1774336807,
+        "narHash": "sha256-9Wu6fqKbjHBh//Rlx0p/jFVobZwgvBlBov2W2H1kfAI=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "9ba6d89cd7cb4d2b94953d56bea1d46e08aa53bd",
+        "rev": "2b5c85b86be24ff24e9586a56101e22f90ead9d4",
         "type": "github"
       },
       "original": {
@@ -55,11 +55,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772433332,
-        "narHash": "sha256-izhTDFKsg6KeVBxJS9EblGeQ8y+O8eCa6RcW874vxEc=",
+        "lastModified": 1774106199,
+        "narHash": "sha256-US5Tda2sKmjrg2lNHQL3jRQ6p96cgfWh3J1QBliQ8Ws=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cf59864ef8aa2e178cccedbe2c178185b0365705",
+        "rev": "6c9a78c09ff4d6c21d0319114873508a6ec01655",
         "type": "github"
       },
       "original": {
@@ -80,11 +80,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1772438613,
-        "narHash": "sha256-D+yZsIKkfRABreaY0Q+jsCtLB5WlnBKpZ1+Sk5qjuRQ=",
+        "lastModified": 1774276450,
+        "narHash": "sha256-B+2C4/9l+ggImtYBwbzEDY3v9DFcDS7hNGDUI+E460o=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "3c4ae110c7682cfc723f9f0adb49c19e2e7a0893",
+        "rev": "da2fe7fed8960a4e351818d52bf444d7c9569da7",
         "type": "github"
       },
       "original": {

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -3,7 +3,7 @@
 ##############
 # Cargo chef #
 ##############
-FROM lukemathwalker/cargo-chef:0.1.72-rust-1.89-alpine3.22 AS chef
+FROM lukemathwalker/cargo-chef:0.1.77-rust-1.94-alpine3.23 AS chef
 WORKDIR /gateway
 ENV CARGO_HOME=/cargo_gateway
 ENV PATH="/cargo_editoast/bin:$PATH"
@@ -47,7 +47,7 @@ COPY . .
 #######################
 # Running env : build #
 #######################
-FROM alpine:3.22 AS running_env
+FROM alpine:3.23 AS running_env
 RUN apk add --no-cache curl ca-certificates bind-tools jq
 WORKDIR /srv
 COPY --from=run_builder /cargo_gateway/bin/osrd_gateway /usr/local/bin/osrd_gateway

--- a/osrdyne/Dockerfile
+++ b/osrdyne/Dockerfile
@@ -3,7 +3,7 @@
 ##############
 # Cargo chef #
 ##############
-FROM lukemathwalker/cargo-chef:0.1.72-rust-1.89-alpine3.22 AS chef
+FROM lukemathwalker/cargo-chef:0.1.77-rust-1.94-alpine3.23 AS chef
 WORKDIR /osrdyne
 ENV CARGO_HOME=/cargo_osrdyne
 ENV PATH="/cargo_editoast/bin:$PATH"
@@ -47,7 +47,7 @@ COPY . .
 #######################
 # Running env : build #
 #######################
-FROM alpine:3.22 AS running_env
+FROM alpine:3.23 AS running_env
 RUN apk add --no-cache curl ca-certificates bind-tools
 COPY --from=run_builder /cargo_osrdyne/bin/osrdyne /usr/local/bin/osrdyne
 


### PR DESCRIPTION
This also bumps the alpine image used in the build and running envs. Also bump the flake to ensure its users won't have a lower rust version.