### PR TITLE
editoast: adapt level crossing occupancy endpoint with new exceptions

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -1806,6 +1806,7 @@ paths:
               - train_ids
               - level_crossing_ids
               - infra_id
+              - timetable_id
               properties:
                 electrical_profile_set_id:
                   type:
@@ -1819,6 +1820,9 @@ paths:
                   type: array
                   items:
                     $ref: '#/components/schemas/Identifier'
+                timetable_id:
+                  type: integer
+                  format: int64
                 train_ids:
                   type: array
                   items:

--- a/editoast/src/models/train_schedule.rs
+++ b/editoast/src/models/train_schedule.rs
@@ -823,7 +823,7 @@ mod tests {
 
         let paced_train = create_paced_train(vec![]);
         let occurrences: Vec<_> = paced_train
-            .iter_occurrences_v2(&[exception_1.clone()])
+            .iter_occurrences_v2(std::slice::from_ref(&exception_1))
             .collect();
 
         assert_eq!(occurrences.len(), 4);

--- a/editoast/src/views/level_crossing_occupancy.rs
+++ b/editoast/src/views/level_crossing_occupancy.rs
@@ -24,6 +24,7 @@ use core_client::pathfinding::TrackRange;
 use core_client::simulation::ReportTrain;
 use database::DbConnection;
 use editoast_derive::EditoastError;
+use editoast_models::TrainScheduleException;
 use editoast_models::prelude::*;
 use editoast_models::rolling_stock::RollingStock;
 use itertools::Itertools;
@@ -61,6 +62,7 @@ pub(in crate::views) struct LevelCrossingOccupancyForm {
     train_ids: Vec<i64>,
     level_crossing_ids: Vec<Identifier>,
     infra_id: i64,
+    timetable_id: i64,
     electrical_profile_set_id: Option<i64>,
 }
 
@@ -98,6 +100,7 @@ pub(in crate::views) async fn occupancy(
         train_ids,
         level_crossing_ids,
         infra_id,
+        timetable_id,
         electrical_profile_set_id,
     }): Json<LevelCrossingOccupancyForm>,
 ) -> Result<Json<HashMap<Identifier, Vec<LevelCrossingOccupancy>>>> {
@@ -137,17 +140,31 @@ pub(in crate::views) async fn occupancy(
         .await?;
 
     let trains: Vec<TrainSchedule> =
-        TrainSchedule::retrieve_batch_or_fail(conn, train_ids, |missing| {
+        TrainSchedule::retrieve_batch_or_fail(conn, train_ids.clone(), |missing| {
             LevelCrossingError::TrainBatchNotFound {
                 count: missing.len(),
             }
         })
         .await?;
 
+    let mut exceptions = TrainScheduleException::retrieve_exceptions_by_train_schedules(
+        conn,
+        timetable_id,
+        train_ids,
+    )
+    .await?
+    .into_iter()
+    .map_into::<schemas::TrainScheduleException>()
+    .into_group_map_by(|e| e.timetable_id);
+
     // Collect all occurrences from all trains
     let train_occurrences = trains
         .iter()
-        .flat_map(|train| train.iter_occurrences())
+        .flat_map(|train| {
+            train
+                .iter_occurrences_v2(&exceptions.remove(&train.id).unwrap_or_default())
+                .collect::<Vec<_>>()
+        })
         .collect_vec();
 
     // Extract train schedules for simulation
@@ -351,7 +368,7 @@ mod tests {
     use super::*;
     use crate::models::fixtures::create_fast_rolling_stock;
     use crate::models::fixtures::create_small_infra;
-    use crate::models::fixtures::create_train_schedule_set;
+    use crate::models::fixtures::create_timetable_with_train_schedule_set;
     use crate::views::test_app::TestAppBuilder;
     use crate::views::test_app::TestResponse;
     use chrono::TimeDelta;
@@ -528,7 +545,8 @@ mod tests {
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let rolling_stock =
             create_fast_rolling_stock(&mut db_pool.get_ok(), "simulation_rolling_stock").await;
-        let train_schedule_set = create_train_schedule_set(&mut db_pool.get_ok()).await;
+        let (timetable, train_schedule_set) =
+            create_timetable_with_train_schedule_set(&mut db_pool.get_ok()).await;
 
         // Create level crossing
         let level_crossing = LevelCrossingModel::default()
@@ -570,6 +588,7 @@ mod tests {
                 train_ids: vec![train.id],
                 level_crossing_ids: vec![level_crossing.obj_id.clone().into()],
                 infra_id: small_infra.id,
+                timetable_id: timetable.id,
                 electrical_profile_set_id: None,
             });
 

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
@@ -325,6 +325,7 @@ const SimulationResults = ({
             >
               <div data-testid="chronogram" className="simulation-chronogram">
                 <ChronogramWrapper
+                  timetableId={timetableId}
                   timetableItemsWithDetails={timetableItemsWithDetails}
                   chronogramHeight={chronogramHeight}
                 />

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -1931,6 +1931,7 @@ export type PostLevelCrossingOccupancyApiArg = {
     electrical_profile_set_id?: number | null;
     infra_id: number;
     level_crossing_ids: Identifier[];
+    timetable_id: number;
     train_ids: number[];
   };
 };

--- a/front/src/modules/simulationResult/components/Chronogram/ChronogramWrapper.tsx
+++ b/front/src/modules/simulationResult/components/Chronogram/ChronogramWrapper.tsx
@@ -7,15 +7,17 @@ import useLevelCrossingsWithChronogram from './useLevelCrossingsWithChronogram';
 const CHRONOGRAM_FOOTER_HEIGHT = 39;
 
 type ChronogramWrapperProps = {
+  timetableId: number;
   timetableItemsWithDetails: TimetableItemWithDetails[];
   chronogramHeight: number;
 };
 
 const ChronogramWrapper = ({
+  timetableId,
   timetableItemsWithDetails,
   chronogramHeight,
 }: ChronogramWrapperProps) => {
-  const { levelCrossingData, timeOrigin } = useLevelCrossingsWithChronogram({
+  const { levelCrossingData, timeOrigin } = useLevelCrossingsWithChronogram(timetableId, {
     trains: timetableItemsWithDetails,
   });
 

--- a/front/src/modules/simulationResult/components/Chronogram/useLevelCrossingsWithChronogram.ts
+++ b/front/src/modules/simulationResult/components/Chronogram/useLevelCrossingsWithChronogram.ts
@@ -15,7 +15,10 @@ type UseLevelCrossingsWithChronogramProps = {
   trains: TimetableItemWithDetails[];
 };
 
-const useLevelCrossingsWithChronogram = ({ trains }: UseLevelCrossingsWithChronogramProps) => {
+const useLevelCrossingsWithChronogram = (
+  timetableId: number,
+  { trains }: UseLevelCrossingsWithChronogramProps
+) => {
   const infraId = useInfraID();
   const dispatch = useAppDispatch();
 
@@ -51,6 +54,7 @@ const useLevelCrossingsWithChronogram = ({ trains }: UseLevelCrossingsWithChrono
             body: {
               infra_id: infraId,
               train_ids: trainIds,
+              timetable_id: timetableId,
               level_crossing_ids: levelCrossingsIds.ids,
             },
           }


### PR DESCRIPTION
Part of https://github.com/OpenRailAssociation/osrd/issues/15202

This PR adapt the `/level_crossing_occupancy`endpoint to use the new exceptions table
It also requires the timetable_id as a parameter, as exceptions are now related to a timetable and not just to a train schedule

> [!NOTE]
> This PR targets a feature branch and may contain all its commits, as it has not been rebased yet. Only the last commit need to be reviewed.

