### PR TITLE
front: remove s from translation in times stops table header

### DIFF
--- a/front/public/locales/en/translation.json
+++ b/front/public/locales/en/translation.json
@@ -835,7 +835,7 @@
     "receptionOnClosedSignalFull": "reception on closed signal",
     "requestedTheoreticalMargin": "requested theoretical margin",
     "shortSlipDistance": "short slip distance",
-    "stopTime": "stopping time (s)",
+    "stopTime": "stopping time",
     "theoreticalMargin": "theoretical margin",
     "theoreticalMarginPlaceholder": "% or min/100km",
     "theoreticalMarginSeconds": "theoretical margin (s)",

--- a/front/public/locales/fr/translation.json
+++ b/front/public/locales/fr/translation.json
@@ -835,7 +835,7 @@
     "receptionOnClosedSignalFull": "réception sur signal fermé",
     "requestedTheoreticalMargin": "marge théorique demandée",
     "shortSlipDistance": "faible glissement",
-    "stopTime": "temps d'arrêt (s)",
+    "stopTime": "temps d'arrêt",
     "theoreticalMargin": "marge théorique",
     "theoreticalMarginPlaceholder": "% ou min/100km",
     "theoreticalMarginSeconds": "marge théorique (s)",


### PR DESCRIPTION
closes #15929 