### PR TITLE
editoast: make paced information a whole object in the model

### DIFF
--- a/editoast/src/models/train_schedule.rs
+++ b/editoast/src/models/train_schedule.rs
@@ -224,25 +224,19 @@ impl TrainSchedule {
             .sorted_by_key(|(_, ts)| ts.start_time)
     }
 
-    /// Returns whether this train has paced occurrences.
-    pub fn is_paced(&self) -> bool {
-        self.time_window.is_some() && self.interval.is_some()
+    /// Returns time window and interval when this train has paced occurrences.
+    pub fn pace(&self) -> Option<(ChronoDuration, ChronoDuration)> {
+        self.time_window.zip(self.interval)
     }
 
     /// Returns the number of base train occurrences within the pacing window.
     /// Returns 1 if it's not a paced train.
     fn num_base_occurrences(&self) -> usize {
-        if !self.is_paced() {
-            return 1;
+        if let Some((time_window, interval)) = self.pace() {
+            (time_window.num_seconds() / interval.num_seconds()) as usize
+        } else {
+            1
         }
-
-        let time_window = self
-            .time_window
-            .expect("time_window should be set for paced trains");
-        let interval = self
-            .interval
-            .expect("interval should be set for paced trains");
-        (time_window.num_seconds() / interval.num_seconds()) as usize
     }
 }
 

--- a/editoast/src/views/timetable/train_schedule_exceptions.rs
+++ b/editoast/src/views/timetable/train_schedule_exceptions.rs
@@ -124,7 +124,7 @@ pub(in crate::views) async fn create_train_schedule_exception(
     )
     .await?;
 
-    if !train_schedule.is_paced() {
+    if train_schedule.pace().is_none() {
         return Err(TrainScheduleExceptionError::NotPacedTrain {
             train_schedule_id: train_schedule_exception_form.train_schedule_id,
         }
@@ -215,7 +215,7 @@ pub(in crate::views) async fn update(
     )
     .await?;
 
-    if !train_schedule.is_paced() {
+    if train_schedule.pace().is_none() {
         return Err(TrainScheduleExceptionError::NotPacedTrain { train_schedule_id }.into());
     }
 


### PR DESCRIPTION
Both the time window and the interval are part of the same semantic object. Let’s present them together, which makes the rest of the code flows more logically.