### PR TITLE
Fix board header disappearing when hovering username

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/ScenarioHeader.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ScenarioHeader.tsx
@@ -44,6 +44,7 @@ const ScenarioHeader = ({ activeBoards, toggleBoard }: ScenarioHeaderProps) => {
   });
   const [areScenarioDetailsVisible, setAreScenarioDetailsVisible] = useState(false);
 
+  const headerRef = useRef<HTMLElement>(null);
   const scenarioNameRef = useRef<HTMLSpanElement>(null);
   const usernameRef = useRef<HTMLSpanElement>(null);
 
@@ -68,31 +69,33 @@ const ScenarioHeader = ({ activeBoards, toggleBoard }: ScenarioHeaderProps) => {
   };
 
   useEffect(() => {
-    const checkTruncation = () => {
-      setIsTruncated((prev) => ({
-        scenarioName: scenarioNameRef.current
-          ? scenarioNameRef.current.scrollWidth > scenarioNameRef.current.clientWidth
-          : prev.scenarioName,
-        username: usernameRef.current
-          ? usernameRef.current.scrollWidth > usernameRef.current.clientWidth
-          : prev.username,
-      }));
-    };
-    checkTruncation();
-    window.addEventListener('resize', checkTruncation);
-    return () => {
-      window.removeEventListener('resize', checkTruncation);
-    };
+    if (!headerRef.current) return undefined;
+
+    const checkTruncation = (element: HTMLElement) => element.scrollWidth > element.clientWidth;
+
+    const observer = new ResizeObserver(() => {
+      setIsTruncated({
+        scenarioName: scenarioNameRef.current ? checkTruncation(scenarioNameRef.current) : false,
+        username: usernameRef.current ? checkTruncation(usernameRef.current) : false,
+      });
+    });
+
+    observer.observe(headerRef.current);
+    return () => observer.disconnect();
   }, []);
 
   const userDropdownTitle = (
-    <span ref={usernameRef} className={cx('user-name', { 'is-truncated': isTruncated.username })}>
+    <span
+      ref={usernameRef}
+      className={cx('user-name', { 'is-truncated': isTruncated.username })}
+      title={isTruncated.username ? username : undefined}
+    >
       {username}
     </span>
   );
 
   return (
-    <header className="scenario-header-container">
+    <header ref={headerRef} className="scenario-header-container">
       <div className={cx('scenario-header', { impersonated: impersonatedUser })}>
         {/* scenario info */}
         <div className="scenario-info">

--- a/front/src/styles/scss/applications/operationalStudies/_scenarioV2.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_scenarioV2.scss
@@ -188,7 +188,19 @@
       margin-right: 8px;
       justify-content: end;
 
+      .btn-group {
+        min-width: 0;
+        width: 100%;
+      }
+
+      .dropdwon-position {
+        min-width: 0;
+        width: 100%;
+        overflow: hidden;
+      }
+
       .user-name {
+        display: block;
         color: var(--black100);
         font-size: 0.875rem;
         text-align: right;
@@ -196,7 +208,6 @@
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
-        min-width: 0;
       }
     }
 
@@ -228,6 +239,7 @@
         flex: 2;
       }
     }
+
     // END HANDLE SCENARIO NAME AND USER NAME HOVER WHEN TRUNCATED
   }
 }


### PR DESCRIPTION
close #15938 

> [!NOTE]
> For text truncation we need to override Bootstrap's intermediate `.btn-group` and `.dropdwon-position` elements to pass the width constraint down to `.user-name`

> [!TIP]
To test it modify the `username`in the return of `useAuth.ts` with a long string.