### PR TITLE
core: adapt routing requirements to backtracking

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/api/CommonSchemas.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/CommonSchemas.kt
@@ -69,13 +69,13 @@ data class SignalCriticalPosition(
     val state: String,
 )
 
-class RJSRoutingRequirement(
+data class RJSRoutingRequirement(
     val route: String,
     @Json(name = "begin_time") val beginTime: TimeDelta,
     val zones: List<RJSRoutingZoneRequirement>,
 )
 
-class RJSRoutingZoneRequirement(
+data class RJSRoutingZoneRequirement(
     val zone: String,
     @Json(name = "entry_detector") val entryDetector: String,
     @Json(name = "exit_detector") val exitDetector: String,

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
@@ -33,6 +33,7 @@ import fr.sncf.osrd.train.RollingStock
 import fr.sncf.osrd.train.TrainStop
 import fr.sncf.osrd.utils.simplifyEnvelopePoints
 import fr.sncf.osrd.utils.units.Distance
+import fr.sncf.osrd.utils.units.Duration
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.Speed
 import fr.sncf.osrd.utils.units.TimeDelta
@@ -239,6 +240,17 @@ fun makeSimpleReportTrain(
     )
 }
 
+private fun getArrivalAt(envelope: EnvelopeTimeInterpolate, offset: Offset<PhysicsPath>): Duration {
+    return envelope.interpolateArrivalAtClamp(offset.meters).seconds
+}
+
+private fun getDepartureFrom(
+    envelope: EnvelopeTimeInterpolate,
+    offset: Offset<PhysicsPath>,
+): Duration {
+    return envelope.interpolateDepartureFromClamp(offset.meters).seconds
+}
+
 fun routingRequirements(
     fullInfra: FullInfra,
     trainPath: TrainPath,
@@ -294,7 +306,7 @@ fun routingRequirements(
             //  Actually, there should be no routing requirement at all on the first route (when
             //  the train doesn't see any route entry signal). But the implications are weird and
             //  counterintuitive.
-            return envelope.interpolateDepartureFromClamp(straightSubPathRange.start.meters).seconds
+            return getDepartureFrom(envelope, straightSubPathRange.start)
         }
 
         val firstBlockRange =
@@ -307,7 +319,7 @@ fun routingRequirements(
         // find the entry signal for this route. if there is no entry signal,
         // the set deadline is the start after the last backtrack
         if (blockInfra.blockStartAtBufferStop(firstBlockRange.value))
-            return envelope.interpolateDepartureFromClamp(straightSubPathRange.start.meters).seconds
+            return getDepartureFrom(envelope, straightSubPathRange.start)
         val etcsSimulator = context?.let { ETCSBrakingSimulatorImpl(it) }
 
         val singleEnvelope = envelope.rawEnvelopeIfSingle
@@ -327,7 +339,7 @@ fun routingRequirements(
 
         if (routeCriticalPos == null) return null
 
-        var routeCriticalTime = envelope.interpolateArrivalAtClamp(routeCriticalPos.meters).seconds
+        var routeCriticalTime = getArrivalAt(envelope, routeCriticalPos)
 
         // check if an arrival on stop signal is scheduled between the route critical position and
         // the entry signal of the route (both position and time, as there is a time margin) in this
@@ -342,9 +354,8 @@ fun routingRequirements(
         for (stop in sortedClosedSignalStops.reversed()) {
             val stopTravelledOffset = stop.pathOffset
             if (stopTravelledOffset <= entrySignalOffset) {
-                // stop duration is included in interpolateDepartureFromClamp()
-                val stopDepartureTime =
-                    envelope.interpolateDepartureFromClamp(stopTravelledOffset.meters).seconds
+                // stop duration is included
+                val stopDepartureTime = getDepartureFrom(envelope, stopTravelledOffset)
                 if (
                     routeCriticalTime < stopDepartureTime - CLOSED_SIGNAL_RESERVATION_MARGIN.seconds
                 ) {
@@ -354,10 +365,7 @@ fun routingRequirements(
             }
         }
 
-        return maxOf(
-            routeCriticalTime,
-            envelope.interpolateArrivalAtClamp(straightSubPathRange.start.meters).seconds,
-        )
+        return maxOf(routeCriticalTime, getArrivalAt(envelope, straightSubPathRange.start))
     }
 
     val res = mutableListOf<RoutingRequirement>()
@@ -397,8 +405,7 @@ fun routingRequirements(
                 trainPath.getNonBacktrackingSubPathBoundariesContainingOffset(zoneRange.pathBegin)
             val exitCriticalPos = Offset.min(zoneOccupationExit, straightSubPathRange.end)
 
-            val exitCriticalTime =
-                envelope.interpolateDepartureFromClamp(exitCriticalPos.meters).seconds
+            val exitCriticalTime = getDepartureFrom(envelope, exitCriticalPos)
             zoneRequirements.add(routingZoneRequirement(rawInfra, zonePath, exitCriticalTime))
         }
         res.add(RoutingRequirement(route, routeSetDeadline.seconds, zoneRequirements))
@@ -706,11 +713,11 @@ fun zoneOccupationChangeEvents(
         // entry is always at the start of the zone (might lead to some adjacent identical zone
         // occupation for the same zone at backtrack)
         val entryOffset = zoneRange.pathBegin
-        val entryTime = envelope.interpolateArrivalAtClamp(entryOffset.meters).seconds
+        val entryTime = getArrivalAt(envelope, entryOffset)
 
         val exitOffset =
             zoneRangeExitOffset(trainPath.getBacktrackLocations(), trainLength, zoneRange)
-        val exitTime = envelope.interpolateDepartureFromClamp(exitOffset.meters).seconds
+        val exitTime = getDepartureFrom(envelope, exitOffset)
 
         // Avoid generating entry + exit at the same time
         if (exitTime <= entryTime) continue

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
@@ -101,7 +101,7 @@ fun runScheduleMetadataExtractor(
             closedSignalStops,
             envelopeWithStops,
             context,
-            rollingStock,
+            zoneOccupationChangeEvents,
         )
     val reportTrain =
         makeSimpleReportTrain(envelope, trainPath, rollingStock, schedule, pathItemPositions)
@@ -142,6 +142,8 @@ fun getSignalCriticalPositions(
         }
 
         val physicalSignal = loadedSignalInfra.getPhysicalSignal(pathSignal.signal)
+        // This is OK to use signal offset as the signals strictly outside the path are removed at
+        // that point
         val straightSubPathRange =
             trainPath.getNonBacktrackingSubPathBoundariesContainingOffset(pathSignal.pathOffset)
         var signalCriticalOffset =
@@ -244,7 +246,7 @@ fun routingRequirements(
     envelope: EnvelopeInterpolate,
     // TODO: Required for ETCS (STDCM doesn't provide it currently, will have to eventually)
     context: EnvelopeSimContext?,
-    rollingStock: RollingStock,
+    zoneOccupationChangeEvents: List<ZoneOccupationChangeEvent>,
 ): List<RoutingRequirement> {
     val rawInfra = fullInfra.rawInfra
     val blockInfra = fullInfra.blockInfra
@@ -257,6 +259,8 @@ fun routingRequirements(
     val signalingTrainStates = mutableMapOf<LogicalSignalId, SignalingTrainState>()
     for (blockRange in blockRanges) {
         val block = blockRange.value
+        val straightSubPathRange =
+            trainPath.getNonBacktrackingSubPathBoundariesContainingOffset(blockRange.pathBegin)
         val signals = blockInfra.getBlockSignals(block)
         val signalPositions = blockInfra.getSignalsPositions(block)
         val consideredSignals =
@@ -266,7 +270,8 @@ fun routingRequirements(
             val signalOffset = signalPositions[signalIndex]
             val signalPathOffset = blockRange.offsetToTrainPath(signalOffset)
             val sightDistance = rawInfra.getSignalSightDistance(rawInfra.getPhysicalSignal(signal))
-            val sightOffset = Offset.max(Offset.zero(), signalPathOffset - sightDistance)
+            val sightOffset =
+                Offset.max(straightSubPathRange.start, signalPathOffset - sightDistance)
             if (sightOffset >= blockRange.pathEnd) {
                 val state = SignalingTrainStateImpl(speed = 0.0.metersPerSecond)
                 signalingTrainStates[signal] = state
@@ -282,12 +287,14 @@ fun routingRequirements(
     }
 
     fun findRouteSetDeadline(routeRange: RouteRange): TimeDelta? {
-        if (routeRange.pathBegin == Offset.zero<TrainPath>()) {
+        val straightSubPathRange =
+            trainPath.getNonBacktrackingSubPathBoundariesContainingOffset(routeRange.pathBegin)
+        if (routeRange.pathBegin == straightSubPathRange.start) {
             // TODO: this isn't quite true when the path starts with a stop
             //  Actually, there should be no routing requirement at all on the first route (when
             //  the train doesn't see any route entry signal). But the implications are weird and
             //  counterintuitive.
-            return TimeDelta.ZERO
+            return envelope.interpolateDepartureFromClamp(straightSubPathRange.start.meters).seconds
         }
 
         val firstBlockRange =
@@ -298,8 +305,9 @@ fun routingRequirements(
                 .value
 
         // find the entry signal for this route. if there is no entry signal,
-        // the set deadline is the start of the simulation
-        if (blockInfra.blockStartAtBufferStop(firstBlockRange.value)) return TimeDelta.ZERO
+        // the set deadline is the start after the last backtrack
+        if (blockInfra.blockStartAtBufferStop(firstBlockRange.value))
+            return envelope.interpolateDepartureFromClamp(straightSubPathRange.start.meters).seconds
         val etcsSimulator = context?.let { ETCSBrakingSimulatorImpl(it) }
 
         val singleEnvelope = envelope.rawEnvelopeIfSingle
@@ -325,8 +333,11 @@ fun routingRequirements(
         // the entry signal of the route (both position and time, as there is a time margin) in this
         // case, just move the route critical position to the stop
         val entrySignalOffset =
-            firstBlockRange.offsetToTrainPath(
-                blockInfra.getSignalsPositions(firstBlockRange.value).first()
+            Offset.max(
+                straightSubPathRange.start,
+                firstBlockRange.offsetToTrainPath(
+                    blockInfra.getSignalsPositions(firstBlockRange.value).first()
+                ),
             )
         for (stop in sortedClosedSignalStops.reversed()) {
             val stopTravelledOffset = stop.pathOffset
@@ -343,7 +354,10 @@ fun routingRequirements(
             }
         }
 
-        return maxOf(routeCriticalTime, TimeDelta.ZERO)
+        return maxOf(
+            routeCriticalTime,
+            envelope.interpolateArrivalAtClamp(straightSubPathRange.start.meters).seconds,
+        )
     }
 
     val res = mutableListOf<RoutingRequirement>()
@@ -360,17 +374,29 @@ fun routingRequirements(
         val zoneRequirements = mutableListOf<RoutingZoneRequirement>()
         for (zoneRange in zoneRanges) {
             val zonePath = zoneRange.value
-            // the distance to the end of the zone from the start of the train path
-            val zoneEndOffset = zoneRange.objectAbsolutePathEnd
-            // the point in the train path at which the zone is released
-            val exitCriticalPos = zoneEndOffset + rollingStock.length.meters
+
             // if the zones are never occupied by the train, no requirement is emitted
             // Note: the train is considered starting from a "portal", so "growing" from its start
             // offset
-            if (zoneEndOffset < Offset.zero()) {
+            if (zoneRange.objectAbsolutePathEnd < Offset.zero()) {
                 assert(routeRange.pathBegin == Offset.zero<TrainPath>())
                 continue
             }
+
+            // the point in the train path at which the zone is released
+            val zoneOccupationExit =
+                zoneOccupationChangeEvents
+                    .first {
+                        it.zone == rawInfra.getZonePathZone(zonePath) &&
+                            !it.isEntry &&
+                            it.offset > zoneRange.pathBegin
+                    }
+                    .offset
+            // release the "route zone" at the latest before the train restart after backtracking
+            val straightSubPathRange =
+                trainPath.getNonBacktrackingSubPathBoundariesContainingOffset(zoneRange.pathBegin)
+            val exitCriticalPos = Offset.min(zoneOccupationExit, straightSubPathRange.end)
+
             val exitCriticalTime =
                 envelope.interpolateDepartureFromClamp(exitCriticalPos.meters).seconds
             zoneRequirements.add(routingZoneRequirement(rawInfra, zonePath, exitCriticalTime))
@@ -402,6 +428,9 @@ private fun getRouteCriticalPos(
                 "Routing requirements for curve-based signals are only available for " +
                     "ETCS_LEVEL2 and through StandaloneSimulation"
             )
+        }
+        if (trainPath.getBacktrackLocations().isNotEmpty()) {
+            TODO("ETCS_LEVEL2 does not handle backtracking yet")
         }
         getEtcsRouteCriticalPos(blockInfra, firstBlockRange, envelope, etcsSimulator)
     } else {
@@ -459,7 +488,15 @@ private fun getSightRouteCriticalPos(
     // until the start of the route, which is INCOMPATIBLE
 
     // We only want the path up to the route offset of the given route
-    val subTrainPath = trainPath.subPath(Offset.zero(), firstBlockRange.objectAbsolutePathStart)
+    val straightSubPathRange =
+        trainPath.getNonBacktrackingSubPathBoundariesContainingOffset(firstBlockRange.pathBegin)
+    val subTrainPath =
+        trainPath.subPath(
+            straightSubPathRange.start,
+            firstBlockRange.objectAbsolutePathStart,
+            includeExactStart = straightSubPathRange.start == Offset.zero<TrainPath>(),
+            includeExactEnd = firstBlockRange.objectAbsolutePathStart == straightSubPathRange.end,
+        )
 
     // TODO: the complexity of finding route set deadlines is currently n^2 of the
     //   number of blocks in the path. it can be improved upon by only simulating blocks
@@ -494,7 +531,9 @@ private fun getSightRouteCriticalPos(
     val signalSightDistance = rawInfra.getSignalSightDistance(rawInfra.getPhysicalSignal(signal))
 
     // find the location at which establishing the route becomes necessary
-    return limitingBlockRange.offsetToTrainPath(limitingSignalOffsetInBlock - signalSightDistance)
+    val subTrainPathCriticalPos =
+        limitingBlockRange.offsetToTrainPath(limitingSignalOffsetInBlock - signalSightDistance)
+    return straightSubPathRange.start + Distance.max(subTrainPathCriticalPos.distance, 0.meters)
 }
 
 /** Create a zone requirement, which embeds all needed properties for conflict detection */

--- a/core/src/test/kotlin/fr/sncf/osrd/backtracks/BacktrackTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/backtracks/BacktrackTests.kt
@@ -1,6 +1,8 @@
 package fr.sncf.osrd.backtracks
 
 import fr.sncf.osrd.api.FullInfra
+import fr.sncf.osrd.api.RJSRoutingRequirement
+import fr.sncf.osrd.api.RJSRoutingZoneRequirement
 import fr.sncf.osrd.api.RangeValues
 import fr.sncf.osrd.api.SignalCriticalPosition
 import fr.sncf.osrd.api.path_properties.makePathPropResponse
@@ -40,7 +42,6 @@ import fr.sncf.osrd.utils.units.seconds
 import fr.sncf.osrd.utils.units.sumDistances
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import org.junit.jupiter.api.Disabled
 
 /**
  * This class takes one fixed path that contains backtracks, and tests most parts of the codebase to
@@ -584,84 +585,361 @@ class BacktrackTests {
     }
 
     @Test
-    @Disabled("Not working yet")
     fun testSimulationBacktrackingOverNothing() {
         val path = buildPathBacktrackingOverNothing(infra, rollingStock.length.meters)
-        // Smoke test, we only test for uncaught exceptions and failed asserts
-        runStandaloneSimulation(
-            infra = infra,
-            trainPath = path,
-            rollingStock = REALISTIC_FAST_TRAIN,
-            comfort = Comfort.STANDARD,
-            constraintDistribution = RJSAllowanceDistribution.LINEAR,
-            speedLimitTag = null,
-            powerRestrictions = distanceRangeMapOf(),
-            useElectricalProfiles = false,
-            useSpeedLimits = true,
-            timeStep = 2.0,
-            schedule =
-                listOf(
-                    SimulationScheduleItem(Offset(9700.meters), null, 60.seconds, SHORT_SLIP_STOP),
-                    SimulationScheduleItem(Offset(18700.meters), null, 0.seconds, OPEN),
+        val resp =
+            runStandaloneSimulation(
+                infra = infra,
+                trainPath = path,
+                rollingStock = REALISTIC_FAST_TRAIN,
+                comfort = Comfort.STANDARD,
+                constraintDistribution = RJSAllowanceDistribution.LINEAR,
+                speedLimitTag = null,
+                powerRestrictions = distanceRangeMapOf(),
+                useElectricalProfiles = false,
+                useSpeedLimits = true,
+                timeStep = 2.0,
+                schedule =
+                    listOf(
+                        SimulationScheduleItem(
+                            Offset(9700.meters),
+                            null,
+                            60.seconds,
+                            SHORT_SLIP_STOP,
+                        ),
+                        SimulationScheduleItem(Offset(18700.meters), null, 0.seconds, OPEN),
+                    ),
+                initialSpeed = 0.0,
+                margins = RangeValues(),
+                pathItemPositions = listOf(Offset(9700.meters), Offset(18700.meters)),
+            )
+        assertEquals(Offset(18700.meters), resp.finalOutput.positions.last())
+
+        val backtrackingArrivalTime = 301.914.seconds
+        val backtrackingDepartureTime = backtrackingArrivalTime + 60.seconds
+        assertEquals(backtrackingArrivalTime, resp.finalOutput.pathItemTimes.first())
+        val finalTime = 731.665.seconds
+        assertEquals(finalTime, resp.finalOutput.pathItemTimes.last())
+        assertEquals(finalTime, resp.finalOutput.times.last())
+        assertEquals(
+            listOf(
+                RJSRoutingRequirement( // regular route at the start of the path
+                    "rt.bf.a->det.a3",
+                    0.seconds,
+                    listOf(
+                        RJSRoutingZoneRequirement(
+                            "zone.[det.a1:INCREASING, det.a2:DECREASING]",
+                            "INCREASING:det.a1",
+                            "INCREASING:det.a2",
+                            mapOf(),
+                            126.463.seconds, // end of zone occupation
+                        ),
+                        RJSRoutingZoneRequirement(
+                            "zone.[det.a2:INCREASING, det.a3:DECREASING]",
+                            "INCREASING:det.a2",
+                            "INCREASING:det.a3",
+                            mapOf(),
+                            182.153.seconds, // end of zone occupation
+                        ),
+                    ),
                 ),
-            initialSpeed = 0.0,
-            margins = RangeValues(),
-            pathItemPositions = listOf(Offset(9700.meters), Offset(18700.meters)),
+                RJSRoutingRequirement( // route occupied before backtracking
+                    "rt.det.a3->bf.c",
+                    108.618.seconds, // 1 signal upstream before entering route
+                    listOf(
+                        RJSRoutingZoneRequirement(
+                            "zone.[det.a3:INCREASING, det.b3:INCREASING, det.c1:DECREASING]",
+                            "INCREASING:det.a3",
+                            "INCREASING:det.c1",
+                            mapOf("switch" to "A_B1"),
+                            224.235.seconds, // end of zone occupation
+                        ),
+                        RJSRoutingZoneRequirement(
+                            "zone.[det.c1:INCREASING, det.c2:DECREASING]",
+                            "INCREASING:det.c1",
+                            "INCREASING:det.c2",
+                            mapOf(),
+                            backtrackingDepartureTime,
+                        ),
+                    ),
+                ),
+                RJSRoutingRequirement( // route occupied after backtracking
+                    "rt.bf.c->det.c1",
+                    backtrackingDepartureTime,
+                    listOf(
+                        RJSRoutingZoneRequirement(
+                            "zone.[det.c1:INCREASING, det.c2:DECREASING]",
+                            "DECREASING:det.c2",
+                            "DECREASING:det.c1",
+                            mapOf(),
+                            533.269.seconds, // end of zone occupation
+                        )
+                    ),
+                ),
+                RJSRoutingRequirement( // regular last route of a path
+                    "rt.det.c1->bf.b",
+                    // first seen signal is the entry (should have been 1 signal upstream if it had
+                    // been seen)
+                    506.655.seconds,
+                    listOf(
+                        RJSRoutingZoneRequirement(
+                            "zone.[det.a3:INCREASING, det.b3:INCREASING, det.c1:DECREASING]",
+                            "DECREASING:det.c1",
+                            "DECREASING:det.b3",
+                            mapOf("switch" to "A_B2"),
+                            580.905.seconds,
+                        ),
+                        RJSRoutingZoneRequirement(
+                            "zone.[det.b2:INCREASING, det.b3:DECREASING]",
+                            "DECREASING:det.b3",
+                            "DECREASING:det.b2",
+                            mapOf(),
+                            637.857.seconds,
+                        ),
+                        RJSRoutingZoneRequirement(
+                            "zone.[det.b1:INCREASING, det.b2:DECREASING]",
+                            "DECREASING:det.b2",
+                            "DECREASING:det.b1",
+                            mapOf(),
+                            finalTime,
+                        ),
+                    ),
+                ),
+            ),
+            resp.finalOutput.routingRequirements,
         )
     }
 
     @Test
-    @Disabled("Not working yet")
     fun testSimulationBacktrackingOverRouteDelimiter() {
         val path = buildPathBacktrackingOverRouteDelimiter(infra, rollingStock.length.meters)
-        // Smoke test, we only test for uncaught exceptions and failed asserts
-        runStandaloneSimulation(
-            infra = infra,
-            trainPath = path,
-            rollingStock = REALISTIC_FAST_TRAIN,
-            comfort = Comfort.STANDARD,
-            constraintDistribution = RJSAllowanceDistribution.LINEAR,
-            speedLimitTag = null,
-            powerRestrictions = distanceRangeMapOf(),
-            useElectricalProfiles = false,
-            useSpeedLimits = true,
-            timeStep = 2.0,
-            schedule =
-                listOf(
-                    SimulationScheduleItem(Offset(8000.meters), null, 60.seconds, SHORT_SLIP_STOP),
-                    SimulationScheduleItem(Offset(15300.meters), null, 0.seconds, OPEN),
+        val resp =
+            runStandaloneSimulation(
+                infra = infra,
+                trainPath = path,
+                rollingStock = REALISTIC_FAST_TRAIN,
+                comfort = Comfort.STANDARD,
+                constraintDistribution = RJSAllowanceDistribution.LINEAR,
+                speedLimitTag = null,
+                powerRestrictions = distanceRangeMapOf(),
+                useElectricalProfiles = false,
+                useSpeedLimits = true,
+                timeStep = 2.0,
+                schedule =
+                    listOf(
+                        SimulationScheduleItem(
+                            Offset(8000.meters),
+                            null,
+                            60.seconds,
+                            SHORT_SLIP_STOP,
+                        ),
+                        SimulationScheduleItem(Offset(15300.meters), null, 0.seconds, OPEN),
+                    ),
+                initialSpeed = 0.0,
+                margins = RangeValues(),
+                pathItemPositions = listOf(Offset(8000.meters), Offset(15300.meters)),
+            )
+        assertEquals(Offset(15300.meters), resp.finalOutput.positions.last())
+
+        val backtrackingArrivalTime = 269.094.seconds
+        val backtrackingDepartureTime = backtrackingArrivalTime + 60.seconds
+        assertEquals(backtrackingArrivalTime, resp.finalOutput.pathItemTimes.first())
+        val finalTime = 748.193.seconds
+        assertEquals(finalTime, resp.finalOutput.pathItemTimes.last())
+        assertEquals(finalTime, resp.finalOutput.times.last())
+        assertEquals(
+            listOf(
+                RJSRoutingRequirement( // regular route at the start of the path
+                    "rt.bf.a->det.a3",
+                    0.seconds,
+                    listOf(
+                        RJSRoutingZoneRequirement(
+                            "zone.[det.a1:INCREASING, det.a2:DECREASING]",
+                            "INCREASING:det.a1",
+                            "INCREASING:det.a2",
+                            mapOf(),
+                            126.463.seconds, // end of zone occupation
+                        ),
+                        RJSRoutingZoneRequirement(
+                            "zone.[det.a2:INCREASING, det.a3:DECREASING]",
+                            "INCREASING:det.a2",
+                            "INCREASING:det.a3",
+                            mapOf(),
+                            186.632.seconds, // end of zone occupation
+                        ),
+                    ),
                 ),
-            initialSpeed = 0.0,
-            margins = RangeValues(),
-            pathItemPositions = listOf(Offset(8000.meters), Offset(15300.meters)),
+                RJSRoutingRequirement( // route occupied before backtracking
+                    "rt.det.a3->bf.c",
+                    108.618.seconds, // 1 signal upstream before entering route
+                    listOf(
+                        RJSRoutingZoneRequirement(
+                            "zone.[det.a3:INCREASING, det.b3:INCREASING, det.c1:DECREASING]",
+                            "INCREASING:det.a3",
+                            "INCREASING:det.c1",
+                            mapOf("switch" to "A_B1"),
+                            backtrackingDepartureTime,
+                        ),
+                        RJSRoutingZoneRequirement(
+                            "zone.[det.c1:INCREASING, det.c2:DECREASING]",
+                            "INCREASING:det.c1",
+                            "INCREASING:det.c2",
+                            mapOf(),
+                            backtrackingDepartureTime,
+                        ),
+                    ),
+                ),
+                RJSRoutingRequirement( // route occupied after backtracking and last route of path
+                    "rt.det.c1->bf.b",
+                    backtrackingDepartureTime,
+                    listOf(
+                        RJSRoutingZoneRequirement(
+                            "zone.[det.a3:INCREASING, det.b3:INCREASING, det.c1:DECREASING]",
+                            "DECREASING:det.c1",
+                            "DECREASING:det.b3",
+                            mapOf("switch" to "A_B2"),
+                            556.635.seconds,
+                        ),
+                        RJSRoutingZoneRequirement(
+                            "zone.[det.b2:INCREASING, det.b3:DECREASING]",
+                            "DECREASING:det.b3",
+                            "DECREASING:det.b2",
+                            mapOf(),
+                            654.382.seconds, // impacted by short-slip stop slowdown
+                        ),
+                        RJSRoutingZoneRequirement(
+                            "zone.[det.b1:INCREASING, det.b2:DECREASING]",
+                            "DECREASING:det.b2",
+                            "DECREASING:det.b1",
+                            mapOf(),
+                            finalTime,
+                        ),
+                    ),
+                ),
+            ),
+            resp.finalOutput.routingRequirements,
         )
     }
 
     @Test
-    @Disabled("Not working yet")
     fun testSimulationBacktrackingShortlyAfterRouteDelimiter() {
         val path =
             buildPathBacktrackingShortlyAfterRouteDelimiter(infra, rollingStock.length.meters)
-        // Smoke test, we only test for uncaught exceptions and failed asserts
-        runStandaloneSimulation(
-            infra = infra,
-            trainPath = path,
-            rollingStock = REALISTIC_FAST_TRAIN,
-            comfort = Comfort.STANDARD,
-            constraintDistribution = RJSAllowanceDistribution.LINEAR,
-            speedLimitTag = null,
-            powerRestrictions = distanceRangeMapOf(),
-            useElectricalProfiles = false,
-            useSpeedLimits = true,
-            timeStep = 2.0,
-            schedule =
-                listOf(
-                    SimulationScheduleItem(Offset(8400.meters), null, 60.seconds, STOP),
-                    SimulationScheduleItem(Offset(16400.meters), null, 0.seconds, OPEN),
+        val resp =
+            runStandaloneSimulation(
+                infra = infra,
+                trainPath = path,
+                rollingStock = REALISTIC_FAST_TRAIN,
+                comfort = Comfort.STANDARD,
+                constraintDistribution = RJSAllowanceDistribution.LINEAR,
+                speedLimitTag = null,
+                powerRestrictions = distanceRangeMapOf(),
+                useElectricalProfiles = false,
+                useSpeedLimits = true,
+                timeStep = 2.0,
+                schedule =
+                    listOf(
+                        SimulationScheduleItem(Offset(8400.meters), null, 60.seconds, STOP),
+                        SimulationScheduleItem(Offset(16400.meters), null, 0.seconds, OPEN),
+                    ),
+                initialSpeed = 0.0,
+                margins = RangeValues(),
+                pathItemPositions = listOf(Offset(8400.meters), Offset(16400.meters)),
+            )
+        assertEquals(Offset(16400.meters), resp.finalOutput.positions.last())
+
+        val backtrackingArrivalTime = 276.282.seconds
+        val backtrackingDepartureTime = backtrackingArrivalTime + 60.seconds
+        assertEquals(backtrackingArrivalTime, resp.finalOutput.pathItemTimes.first())
+        val finalTime = 688.374.seconds
+        assertEquals(finalTime, resp.finalOutput.pathItemTimes.last())
+        assertEquals(finalTime, resp.finalOutput.times.last())
+        assertEquals(
+            listOf(
+                RJSRoutingRequirement( // regular route at the start of the path
+                    "rt.bf.a->det.a3",
+                    0.seconds,
+                    listOf(
+                        RJSRoutingZoneRequirement(
+                            "zone.[det.a1:INCREASING, det.a2:DECREASING]",
+                            "INCREASING:det.a1",
+                            "INCREASING:det.a2",
+                            mapOf(),
+                            126.463.seconds, // end of zone occupation
+                        ),
+                        RJSRoutingZoneRequirement(
+                            "zone.[det.a2:INCREASING, det.a3:DECREASING]",
+                            "INCREASING:det.a2",
+                            "INCREASING:det.a3",
+                            mapOf(),
+                            184.631.seconds, // end of zone occupation
+                        ),
+                    ),
                 ),
-            initialSpeed = 0.0,
-            margins = RangeValues(),
-            pathItemPositions = listOf(Offset(8400.meters), Offset(16400.meters)),
+                RJSRoutingRequirement( // route occupied before backtracking
+                    "rt.det.a3->bf.c",
+                    108.618.seconds, // 1 signal upstream before entering route
+                    listOf(
+                        RJSRoutingZoneRequirement(
+                            "zone.[det.a3:INCREASING, det.b3:INCREASING, det.c1:DECREASING]",
+                            "INCREASING:det.a3",
+                            "INCREASING:det.c1",
+                            mapOf("switch" to "A_B1"),
+                            256.282.seconds, // end of zone occupation
+                        ),
+                        RJSRoutingZoneRequirement(
+                            "zone.[det.c1:INCREASING, det.c2:DECREASING]",
+                            "INCREASING:det.c1",
+                            "INCREASING:det.c2",
+                            mapOf(),
+                            backtrackingDepartureTime,
+                        ),
+                    ),
+                ),
+                RJSRoutingRequirement( // route occupied after backtracking
+                    "rt.bf.c->det.c1",
+                    backtrackingDepartureTime,
+                    listOf(
+                        RJSRoutingZoneRequirement(
+                            "zone.[det.c1:INCREASING, det.c2:DECREASING]",
+                            "DECREASING:det.c2",
+                            "DECREASING:det.c1",
+                            mapOf(),
+                            382.677.seconds, // end of zone occupation
+                        )
+                    ),
+                ),
+                RJSRoutingRequirement( // regular last route of a path
+                    "rt.det.c1->bf.b",
+                    // first seen signal is the entry, in sight when restarting after backtracking
+                    // and required 20 s before restart on closed signal
+                    backtrackingDepartureTime - 20.seconds,
+                    listOf(
+                        RJSRoutingZoneRequirement(
+                            "zone.[det.a3:INCREASING, det.b3:INCREASING, det.c1:DECREASING]",
+                            "DECREASING:det.c1",
+                            "DECREASING:det.b3",
+                            mapOf("switch" to "A_B2"),
+                            514.590.seconds,
+                        ),
+                        RJSRoutingZoneRequirement(
+                            "zone.[det.b2:INCREASING, det.b3:DECREASING]",
+                            "DECREASING:det.b3",
+                            "DECREASING:det.b2",
+                            mapOf(),
+                            588.374.seconds,
+                        ),
+                        RJSRoutingZoneRequirement(
+                            "zone.[det.b1:INCREASING, det.b2:DECREASING]",
+                            "DECREASING:det.b2",
+                            "DECREASING:det.b1",
+                            mapOf(),
+                            finalTime,
+                        ),
+                    ),
+                ),
+            ),
+            resp.finalOutput.routingRequirements,
         )
     }
 }


### PR DESCRIPTION
Also activate and enrich smoke tests

Part of #14824
Fixes #15159 (spacing not handled but tests work without adapting it)