### PR TITLE
front: fix puttrainschedulesbyid invalidates tags

### DIFF
--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -263,6 +263,10 @@ const osrdEditoastApi = generatedEditoastApi
         invalidatesTags: ['train_schedule_set', 'scenarios', 'timetable'],
       },
 
+      postLevelCrossingOccupancy: {
+        providesTags: ['level_crossing', 'train_schedule'],
+      },
+
       // Project handling
       getProjects: {
         providesTags: (result) => [
@@ -318,7 +322,7 @@ const osrdEditoastApi = generatedEditoastApi
         ],
       },
 
-      // Scenari handling
+      // Scenario handling
       getScenarios: {
         providesTags: (result) => [
           { type: 'scenarios', id: 'LIST' },


### PR DESCRIPTION
the chronogram updates well when we add or delete a train, but doesn't when we modify a train

we have to add the `level_crossing` tag in `putTrainSchedulesById` `invalidatesTags` key