### PR TITLE
front: fix combobox overlapping

### DIFF
--- a/front/src/styles/scss/applications/operationalStudies/_itineraryModal.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_itineraryModal.scss
@@ -79,6 +79,7 @@
 
         .rolling-stock-combobox {
           min-width: 217px;
+          max-width: 217px;
 
           // Fix osrd-ui styles
           label {

--- a/front/ui/ui-core/src/styles/inputs/input.css
+++ b/front/ui/ui-core/src/styles/inputs/input.css
@@ -235,6 +235,18 @@
       padding: 0.188rem 0.5rem 0.188rem 0.438rem;
       border-radius: 0.188rem;
 
+      /* The small variant overrides padding and loses the with-icons-* padding-right, 
+      causing text to overlap the clear/chevron buttons*/
+      &.with-icons-1 {
+        /* one icon (chevron or clear)*/
+        padding-right: 35px;
+      }
+
+      &.with-icons-2 {
+        /* 2 icons */
+        padding-right: 54px;
+      }
+
       &.with-leading-only {
         border-radius: 0 0.25rem 0.25rem 0;
       }


### PR DESCRIPTION
closes #15952 

> [!NOTE]
In the first commit i fix the max-width of the rolling stock combox input, to match the mock-up:
<img width="755" height="153" alt="Capture d’écran 2026-03-27 à 11 19 19" src="https://github.com/user-attachments/assets/bcac9709-0561-4064-bbac-3791a126c408" />

In the second commit, I fixed the behaviour of the ComboBox in ui-core so that we won't have the same problem in other parts of the application.
before:
<img width="1030" height="279" alt="Capture d’écran 2026-03-27 à 11 06 41" src="https://github.com/user-attachments/assets/ee465862-7b17-467c-9032-d792f534be73" />

after:
<img width="1030" height="278" alt="Capture d’écran 2026-03-27 à 11 07 30" src="https://github.com/user-attachments/assets/d7fe28da-d09f-48a6-b91d-8acb8db83979" />
