### PR TITLE
front: display only one empty line when we create a train

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModal.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModal.tsx
@@ -232,17 +232,16 @@ const ItineraryModal = ({
       displayTimetableItemManagement === MANAGE_TIMETABLE_ITEM_TYPES.edit ||
       displayTimetableItemManagement === MANAGE_TIMETABLE_ITEM_TYPES.add
     ) {
-      const formattedPathSteps = storePathSteps.map<PathStepV2>((pathStep) => {
-        if (!pathStep) return createEmptyPathStep();
-        return {
+      const formattedPathSteps = storePathSteps
+        .filter((pathStep): pathStep is PathStep => pathStep !== null)
+        .map<PathStepV2>((pathStep) => ({
           id: pathStep.id,
           location: pathStep.location,
           arrival: pathStep.arrival ?? null,
           stopFor: pathStep.stopFor ?? null,
           theoreticalMargin: pathStep.theoreticalMargin ?? null,
           receptionSignal: pathStep.receptionSignal ?? null,
-        };
-      });
+        }));
 
       setPathSteps(ensureTrailingEmptyStep(formattedPathSteps));
     }

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/helpers/pathStepsActions.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/helpers/pathStepsActions.ts
@@ -18,7 +18,7 @@ export const isEmptyStep = (step: PathStepV2, input?: string) => {
 
 export const ensureTrailingEmptyStep = (steps: PathStepV2[]): PathStepV2[] => {
   const last = steps.at(-1);
-  if (last && !isEmptyStep(last, '')) return [...steps, createEmptyPathStep()];
+  if (!last || !isEmptyStep(last, '')) return [...steps, createEmptyPathStep()];
   return steps;
 };
 


### PR DESCRIPTION
closes #15948 

Two changes made:

`pathStepsActions.ts`: ensureTrailingEmptyStep now also adds a trailing empty step when the array is empty (!last condition added).

`ItineraryModal.tsx`: null path steps are filtered out before mapping, so the initial store state [null, null] produces an empty array, which then gets exactly one trailing empty step from ensureTrailingEmptyStep.

Before: [null, null] → [emptyStep, emptyStep] → 2 empty rows displayed

After: [null, null] → filter → [] → ensureTrailingEmptyStep → [emptyStep] → 1 empty row displayed