### PR TITLE
editoast: add titles to openapi variants

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -5076,8 +5076,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "utoipa"
 version = "5.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
+source = "git+https://github.com/leovalais/utoipa.git?branch=enum-variant-titles#207c68f807031056798120be3a2ff2ddd9e3fd69"
 dependencies = [
  "indexmap",
  "serde",
@@ -5088,8 +5087,7 @@ dependencies = [
 [[package]]
 name = "utoipa-gen"
 version = "5.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d79d08d92ab8af4c5e8a6da20c47ae3f61a0f1dabc1997cdf2d082b757ca08b"
+source = "git+https://github.com/leovalais/utoipa.git?branch=enum-variant-titles#207c68f807031056798120be3a2ff2ddd9e3fd69"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -144,7 +144,10 @@ tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 uom = { version = "0.38.0", default-features = false, features = ["f64", "si"] }
 url = { version = "2.5.8", features = ["serde"] }
 urlencoding = "2.1.3"
-utoipa = { version = "5.4.0", features = ["chrono", "uuid"] }
+utoipa = { git = "https://github.com/leovalais/utoipa.git", branch = "enum-variant-titles", features = [
+  "chrono",
+  "uuid",
+] }
 uuid = { version = "1.23.0", features = ["serde", "v4"] }
 
 [dependencies]
@@ -255,6 +258,9 @@ rstest.workspace = true
 schemas = { workspace = true, features = ["testing"] }
 stdext.workspace = true
 tempfile.workspace = true
+
+[patch.crates-io]
+utoipa = { git = "https://github.com/leovalais/utoipa.git", branch = "enum-variant-titles" }
 
 [lints]
 workspace = true

--- a/editoast/core_client/src/path_properties.rs
+++ b/editoast/core_client/src/path_properties.rs
@@ -78,7 +78,7 @@ impl PropertyElectrificationValues {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
-#[schema(as = core::PropertyElectrificationValue)]
+#[schema(as = core::PropertyElectrificationValue, title_variants)]
 #[derive(PartialEq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum PropertyElectrificationValue {

--- a/editoast/core_client/src/pathfinding.rs
+++ b/editoast/core_client/src/pathfinding.rs
@@ -126,7 +126,7 @@ pub struct PathfindingResultSuccess {
 
 // Enum for input-related errors
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, ToSchema)]
-#[schema(as = core::PathfindingInputError)]
+#[schema(as = core::PathfindingInputError, title_variants)]
 #[serde(tag = "error_type", rename_all = "snake_case")]
 pub enum PathfindingInputError {
     InvalidPathItems {
@@ -142,7 +142,7 @@ pub enum PathfindingInputError {
 
 // Enum for not-found results and incompatible constraints
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, ToSchema, Default)]
-#[schema(as = core::PathfindingNotFound)]
+#[schema(as = core::PathfindingNotFound, title_variants)]
 #[serde(tag = "error_type", rename_all = "snake_case")]
 pub enum PathfindingNotFound {
     NotFoundInBlocks {

--- a/editoast/core_client/src/simulation.rs
+++ b/editoast/core_client/src/simulation.rs
@@ -220,7 +220,7 @@ pub struct ElectricalProfiles {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
-#[schema(as = core::ElectricalProfileValue)]
+#[schema(as = core::ElectricalProfileValue, title_variants)]
 #[serde(tag = "electrical_profile_type", rename_all = "snake_case")]
 pub enum ElectricalProfileValue {
     NoProfile,
@@ -231,7 +231,7 @@ pub enum ElectricalProfileValue {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
-#[schema(as = core::SpeedLimitSource)]
+#[schema(as = core::SpeedLimitSource, title_variants)]
 #[serde(tag = "speed_limit_source_type", rename_all = "snake_case")]
 #[allow(clippy::enum_variant_names)]
 pub enum SpeedLimitSource {

--- a/editoast/editoast_derive/src/search.rs
+++ b/editoast/editoast_derive/src/search.rs
@@ -356,6 +356,7 @@ pub fn expand_store(input: &DeriveInput) -> Result<TokenStream> {
 
         #[derive(Serialize, ToSchema)]
         #[serde(untagged)]
+        #[schema(title_variants)]
         #[allow(unused, clippy::enum_variant_names)]
         /// A search result item that depends on the query's `object`
         pub(super) enum SearchResultItem {

--- a/editoast/editoast_derive/src/snapshots/editoast_derive__search__tests__store_construction.snap
+++ b/editoast/editoast_derive/src/snapshots/editoast_derive__search__tests__store_construction.snap
@@ -79,6 +79,7 @@ impl search::SearchConfigStore for SearchStore {
 }
 #[derive(Serialize, ToSchema)]
 #[serde(untagged)]
+#[schema(title_variants)]
 #[allow(unused, clippy::enum_variant_names)]
 /// A search result item that depends on the query's `object`
 pub(super) enum SearchResultItem {

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -1838,6 +1838,7 @@ paths:
                     allOf:
                     - oneOf:
                       - type: object
+                        title: OccurrenceIdBase
                         required:
                         - train_schedule_id
                         - index
@@ -1854,6 +1855,7 @@ paths:
                             enum:
                             - base
                       - type: object
+                        title: OccurrenceIdModified
                         required:
                         - train_schedule_id
                         - index
@@ -1873,6 +1875,7 @@ paths:
                             enum:
                             - modified
                       - type: object
+                        title: OccurrenceIdCreated
                         required:
                         - train_schedule_id
                         - exception_key
@@ -4435,6 +4438,7 @@ paths:
                         allOf:
                         - oneOf:
                           - type: object
+                            title: OccurrenceIdBase
                             required:
                             - train_schedule_id
                             - index
@@ -4451,6 +4455,7 @@ paths:
                                 enum:
                                 - base
                           - type: object
+                            title: OccurrenceIdModified
                             required:
                             - train_schedule_id
                             - index
@@ -4470,6 +4475,7 @@ paths:
                                 enum:
                                 - modified
                           - type: object
+                            title: OccurrenceIdCreated
                             required:
                             - train_schedule_id
                             - exception_key
@@ -5093,6 +5099,7 @@ components:
           items:
             oneOf:
             - type: object
+              title: OccurrenceIdBase
               required:
               - train_schedule_id
               - index
@@ -5109,6 +5116,7 @@ components:
                   enum:
                   - base
             - type: object
+              title: OccurrenceIdModified
               required:
               - train_schedule_id
               - index
@@ -5128,6 +5136,7 @@ components:
                   enum:
                   - modified
             - type: object
+              title: OccurrenceIdCreated
               required:
               - train_schedule_id
               - exception_key
@@ -9051,6 +9060,7 @@ components:
     EnergySource:
       oneOf:
       - type: object
+        title: EnergySourceElectrification
         description: energy source for a rolling stock representing a electrification
         required:
         - max_input_power
@@ -9072,6 +9082,7 @@ components:
           max_output_power:
             $ref: '#/components/schemas/SpeedDependantPower'
       - type: object
+        title: EnergySourcePowerPack
         required:
         - max_input_power
         - max_output_power
@@ -9095,6 +9106,7 @@ components:
           max_output_power:
             $ref: '#/components/schemas/SpeedDependantPower'
       - type: object
+        title: EnergySourceBattery
         description: energy source for a rolling stock representing a battery
         required:
         - max_input_power
@@ -9412,6 +9424,7 @@ components:
     InfraErrorType:
       oneOf:
       - type: object
+        title: InfraErrorTypeDuplicatedGroup
         required:
         - original_group_path
         - error_type
@@ -9423,6 +9436,7 @@ components:
           original_group_path:
             type: string
       - type: object
+        title: InfraErrorTypeEmptyObject
         required:
         - error_type
         properties:
@@ -9431,6 +9445,7 @@ components:
             enum:
             - empty_object
       - type: object
+        title: InfraErrorTypeInvalidGroup
         required:
         - group
         - switch_type
@@ -9445,6 +9460,7 @@ components:
           switch_type:
             type: string
       - type: object
+        title: InfraErrorTypeInvalidReference
         required:
         - reference
         - error_type
@@ -9456,6 +9472,7 @@ components:
           reference:
             $ref: '#/components/schemas/ObjectRef'
       - type: object
+        title: InfraErrorTypeInvalidRoute
         required:
         - error_type
         properties:
@@ -9464,6 +9481,7 @@ components:
             enum:
             - invalid_route
       - type: object
+        title: InfraErrorTypeInvalidSwitchPorts
         required:
         - error_type
         properties:
@@ -9472,6 +9490,7 @@ components:
             enum:
             - invalid_switch_ports
       - type: object
+        title: InfraErrorTypeMissingRoute
         required:
         - error_type
         properties:
@@ -9480,6 +9499,7 @@ components:
             enum:
             - missing_route
       - type: object
+        title: InfraErrorTypeMissingBufferStop
         required:
         - endpoint
         - error_type
@@ -9491,6 +9511,7 @@ components:
             enum:
             - missing_buffer_stop
       - type: object
+        title: InfraErrorTypeNodeEndpointsNotUnique
         required:
         - error_type
         properties:
@@ -9499,6 +9520,7 @@ components:
             enum:
             - node_endpoints_not_unique
       - type: object
+        title: InfraErrorTypeObjectOutOfPath
         required:
         - reference
         - error_type
@@ -9510,6 +9532,7 @@ components:
           reference:
             $ref: '#/components/schemas/ObjectRef'
       - type: object
+        title: InfraErrorTypeOddBufferStopLocation
         required:
         - error_type
         properties:
@@ -9518,6 +9541,7 @@ components:
             enum:
             - odd_buffer_stop_location
       - type: object
+        title: InfraErrorTypeOutOfRange
         required:
         - position
         - expected_range
@@ -9539,6 +9563,7 @@ components:
           reference:
             $ref: '#/components/schemas/ObjectRef'
       - type: object
+        title: InfraErrorTypeOverlappingElectrifications
         required:
         - reference
         - error_type
@@ -9550,6 +9575,7 @@ components:
           reference:
             $ref: '#/components/schemas/ObjectRef'
       - type: object
+        title: InfraErrorTypeOverlappingSpeedSections
         required:
         - reference
         - error_type
@@ -9561,6 +9587,7 @@ components:
           reference:
             $ref: '#/components/schemas/ObjectRef'
       - type: object
+        title: InfraErrorTypeOverlappingSwitches
         required:
         - reference
         - error_type
@@ -9572,6 +9599,7 @@ components:
           reference:
             $ref: '#/components/schemas/ObjectRef'
       - type: object
+        title: InfraErrorTypeUnknownPortName
         required:
         - port_name
         - error_type
@@ -9583,6 +9611,7 @@ components:
           port_name:
             type: string
       - type: object
+        title: InfraErrorTypeUnusedPort
         required:
         - port_name
         - error_type
@@ -9602,6 +9631,7 @@ components:
     InfraObject:
       oneOf:
       - type: object
+        title: InfraObjectTrackSection
         required:
         - railjson
         - obj_type
@@ -9613,6 +9643,7 @@ components:
           railjson:
             $ref: '#/components/schemas/TrackSection'
       - type: object
+        title: InfraObjectSignal
         required:
         - railjson
         - obj_type
@@ -9624,6 +9655,7 @@ components:
           railjson:
             $ref: '#/components/schemas/Signal'
       - type: object
+        title: InfraObjectNeutralSection
         required:
         - railjson
         - obj_type
@@ -9635,6 +9667,7 @@ components:
           railjson:
             $ref: '#/components/schemas/NeutralSection'
       - type: object
+        title: InfraObjectSpeedSection
         required:
         - railjson
         - obj_type
@@ -9646,6 +9679,7 @@ components:
           railjson:
             $ref: '#/components/schemas/SpeedSection'
       - type: object
+        title: InfraObjectSwitch
         required:
         - railjson
         - obj_type
@@ -9657,6 +9691,7 @@ components:
           railjson:
             $ref: '#/components/schemas/Switch'
       - type: object
+        title: InfraObjectSwitchType
         required:
         - railjson
         - obj_type
@@ -9668,6 +9703,7 @@ components:
           railjson:
             $ref: '#/components/schemas/SwitchType'
       - type: object
+        title: InfraObjectDetector
         required:
         - railjson
         - obj_type
@@ -9679,6 +9715,7 @@ components:
           railjson:
             $ref: '#/components/schemas/Detector'
       - type: object
+        title: InfraObjectBufferStop
         required:
         - railjson
         - obj_type
@@ -9690,6 +9727,7 @@ components:
           railjson:
             $ref: '#/components/schemas/BufferStop'
       - type: object
+        title: InfraObjectRoute
         required:
         - railjson
         - obj_type
@@ -9701,6 +9739,7 @@ components:
           railjson:
             $ref: '#/components/schemas/Route'
       - type: object
+        title: InfraObjectOperationalPoint
         required:
         - railjson
         - obj_type
@@ -9712,6 +9751,7 @@ components:
           railjson:
             $ref: '#/components/schemas/OperationalPoint'
       - type: object
+        title: InfraObjectElectrification
         required:
         - railjson
         - obj_type
@@ -9723,6 +9763,7 @@ components:
           railjson:
             $ref: '#/components/schemas/Electrification'
       - type: object
+        title: InfraObjectLevelCrossing
         required:
         - railjson
         - obj_type
@@ -10402,6 +10443,7 @@ components:
               type: string
               enum:
               - CREATE
+        title: OperationCreate
       - allOf:
         - type: object
           required:
@@ -10427,6 +10469,7 @@ components:
               type: string
               enum:
               - UPDATE
+        title: OperationUpdate
       - allOf:
         - type: object
           description: A delete operation. Contains same information as a object ref but has another serialization.
@@ -10447,6 +10490,7 @@ components:
               type: string
               enum:
               - DELETE
+        title: OperationDelete
     OperationalPoint:
       type: object
       required:
@@ -10796,6 +10840,7 @@ components:
               type: string
               enum:
               - add
+        title: PatchOperationAddOperation
         description: '''add'' operation'
       - allOf:
         - $ref: '#/components/schemas/RemoveOperation'
@@ -10808,6 +10853,7 @@ components:
               type: string
               enum:
               - remove
+        title: PatchOperationRemoveOperation
         description: '''remove'' operation'
       - allOf:
         - $ref: '#/components/schemas/ReplaceOperation'
@@ -10820,6 +10866,7 @@ components:
               type: string
               enum:
               - replace
+        title: PatchOperationReplaceOperation
         description: '''replace'' operation'
       - allOf:
         - $ref: '#/components/schemas/MoveOperation'
@@ -10832,6 +10879,7 @@ components:
               type: string
               enum:
               - move
+        title: PatchOperationMoveOperation
         description: '''move'' operation'
       - allOf:
         - $ref: '#/components/schemas/CopyOperation'
@@ -10844,6 +10892,7 @@ components:
               type: string
               enum:
               - copy
+        title: PatchOperationCopyOperation
         description: '''copy'' operation'
       - allOf:
         - $ref: '#/components/schemas/TestOperation'
@@ -10856,6 +10905,7 @@ components:
               type: string
               enum:
               - test
+        title: PatchOperationTestOperation
         description: '''test'' operation'
       description: JSON Patch single patch operation
     PathAndScheduleChangeGroup:
@@ -10978,6 +11028,7 @@ components:
                 items:
                   oneOf:
                   - type: object
+                    title: PropertyElectrificationValueElectrification
                     description: Electrified section with a given voltage
                     required:
                     - voltage
@@ -10990,6 +11041,7 @@ components:
                       voltage:
                         type: string
                   - type: object
+                    title: PropertyElectrificationValueNeutralSection
                     description: Neutral section with a lower pantograph instruction or just a dead section
                     required:
                     - lower_pantograph
@@ -11002,6 +11054,7 @@ components:
                         enum:
                         - neutral_section
                   - type: object
+                    title: PropertyElectrificationValueNonElectrified
                     description: Non electrified section
                     required:
                     - type
@@ -11121,6 +11174,7 @@ components:
               type: string
               enum:
               - pathfinding_input_error
+        title: PathfindingFailurePathfindingInputError
       - allOf:
         - $ref: '#/components/schemas/core.PathfindingNotFound'
         - type: object
@@ -11131,7 +11185,9 @@ components:
               type: string
               enum:
               - pathfinding_not_found
+        title: PathfindingFailurePathfindingNotFound
       - type: object
+        title: PathfindingFailureInternalError
         required:
         - core_error
         - failed_status
@@ -11279,6 +11335,7 @@ components:
               type: string
               enum:
               - success
+        title: PathfindingResultSuccess
       - allOf:
         - $ref: '#/components/schemas/PathfindingFailure'
         - type: object
@@ -11289,6 +11346,7 @@ components:
               type: string
               enum:
               - failure
+        title: PathfindingResultFailure
     PathfindingTrackLocationInput:
       type: object
       required:
@@ -12464,8 +12522,9 @@ components:
         object: operationalpoint
         query:
         - and
-        - - =
-          - - infra_id
+        - - like
+          - - to_string
+            - - infra_id
           - 2
         - - search
           - - name
@@ -12473,31 +12532,53 @@ components:
     SearchQuery:
       oneOf:
       - type: boolean
+        title: SearchQueryBoolean
       - type: number
+        title: SearchQueryNumber
         format: double
       - type: integer
+        title: SearchQueryInt
         format: int64
       - type: string
+        title: SearchQueryString
       - type: object
+        title: SearchQueryArray
       description: A search query
       example:
       - and
-      - - =
-        - - infra_id
+      - - like
+        - - to_string
+          - - infra_id
         - 2
       - - search
         - - name
         - plop
     SearchResultItem:
       oneOf:
-      - $ref: '#/components/schemas/SearchResultItemTrack'
-      - $ref: '#/components/schemas/SearchResultItemOperationalPoint'
-      - $ref: '#/components/schemas/SearchResultItemSignal'
-      - $ref: '#/components/schemas/SearchResultItemProject'
-      - $ref: '#/components/schemas/SearchResultItemStudy'
-      - $ref: '#/components/schemas/SearchResultItemScenario'
-      - $ref: '#/components/schemas/SearchResultItemTrainSchedule'
-      - $ref: '#/components/schemas/SearchResultItemUser'
+      - oneOf:
+        - $ref: '#/components/schemas/SearchResultItemTrack'
+        title: SearchResultItemSearchResultItemTrack
+      - oneOf:
+        - $ref: '#/components/schemas/SearchResultItemOperationalPoint'
+        title: SearchResultItemSearchResultItemOperationalPoint
+      - oneOf:
+        - $ref: '#/components/schemas/SearchResultItemSignal'
+        title: SearchResultItemSearchResultItemSignal
+      - oneOf:
+        - $ref: '#/components/schemas/SearchResultItemProject'
+        title: SearchResultItemSearchResultItemProject
+      - oneOf:
+        - $ref: '#/components/schemas/SearchResultItemStudy'
+        title: SearchResultItemSearchResultItemStudy
+      - oneOf:
+        - $ref: '#/components/schemas/SearchResultItemScenario'
+        title: SearchResultItemSearchResultItemScenario
+      - oneOf:
+        - $ref: '#/components/schemas/SearchResultItemTrainSchedule'
+        title: SearchResultItemSearchResultItemTrainSchedule
+      - oneOf:
+        - $ref: '#/components/schemas/SearchResultItemUser'
+        title: SearchResultItemSearchResultItemUser
       description: A search result item that depends on the query's `object`
     SearchResultItemOperationalPoint:
       type: object
@@ -12991,7 +13072,9 @@ components:
               type: string
               enum:
               - success
+        title: ResponseSuccess
       - type: object
+        title: ResponsePathfindingFailed
         required:
         - pathfinding_failed
         - status
@@ -13003,6 +13086,7 @@ components:
             enum:
             - pathfinding_failed
       - type: object
+        title: ResponseSimulationFailed
         required:
         - core_error
         - status
@@ -13045,6 +13129,7 @@ components:
               items:
                 oneOf:
                 - type: object
+                  title: ElectricalProfileValueNoProfile
                   required:
                   - electrical_profile_type
                   properties:
@@ -13053,6 +13138,7 @@ components:
                       enum:
                       - no_profile
                 - type: object
+                  title: ElectricalProfileValueProfile
                   required:
                   - handled
                   - electrical_profile_type
@@ -13124,6 +13210,7 @@ components:
                     - type: 'null'
                     - oneOf:
                       - type: object
+                        title: SpeedLimitSourceGivenTrainTag
                         required:
                         - tag
                         - speed_limit_source_type
@@ -13135,6 +13222,7 @@ components:
                           tag:
                             type: string
                       - type: object
+                        title: SpeedLimitSourceFallbackTag
                         required:
                         - tag
                         - speed_limit_source_type
@@ -13146,6 +13234,7 @@ components:
                           tag:
                             type: string
                       - type: object
+                        title: SpeedLimitSourceUnknownTag
                         required:
                         - speed_limit_source_type
                         properties:
@@ -13165,6 +13254,7 @@ components:
     SimulationSummaryResult:
       oneOf:
       - type: object
+        title: SummaryResponseSuccess
         description: Minimal information on a simulation's result
         required:
         - length
@@ -13252,8 +13342,10 @@ components:
               type: string
               enum:
               - pathfinding_not_found
+        title: SummaryResponsePathfindingNotFound
         description: Pathfinding not found
       - type: object
+        title: SummaryResponsePathfindingFailure
         description: An error has occurred during pathfinding
         required:
         - core_error
@@ -13266,6 +13358,7 @@ components:
             enum:
             - pathfinding_failure
       - type: object
+        title: SummaryResponseSimulationFailed
         description: An error has occurred during computing
         required:
         - error_type
@@ -13288,6 +13381,7 @@ components:
               type: string
               enum:
               - pathfinding_input_error
+        title: SummaryResponsePathfindingInputError
         description: InputError
     Slope:
       type: object
@@ -13488,6 +13582,7 @@ components:
     StdcmResponse:
       oneOf:
       - type: object
+        title: StdcmResponseSuccess
         required:
         - simulation
         - pathfinding_result
@@ -13510,6 +13605,7 @@ components:
             enum:
             - success
       - type: object
+        title: StdcmResponsePathNotFound
         required:
         - status
         properties:
@@ -13522,6 +13618,7 @@ components:
             enum:
             - path_not_found
       - type: object
+        title: StdcmResponsePreprocessingSimulationError
         required:
         - error
         - status
@@ -13537,6 +13634,7 @@ components:
             enum:
             - preprocessing_simulation_error
       - type: object
+        title: StdcmResponseInternalError
         required:
         - error
         - status
@@ -14026,6 +14124,7 @@ components:
     SupportedSignalingSystem:
       oneOf:
       - type: object
+        title: SupportedSignalingSystemBAL
         required:
         - type
         properties:
@@ -14034,6 +14133,7 @@ components:
             enum:
             - BAL
       - type: object
+        title: SupportedSignalingSystemBAPR
         required:
         - type
         properties:
@@ -14042,6 +14142,7 @@ components:
             enum:
             - BAPR
       - type: object
+        title: SupportedSignalingSystemTVM300
         required:
         - type
         properties:
@@ -14050,6 +14151,7 @@ components:
             enum:
             - TVM300
       - type: object
+        title: SupportedSignalingSystemTVM430
         required:
         - type
         properties:
@@ -14058,6 +14160,7 @@ components:
             enum:
             - TVM430
       - type: object
+        title: SupportedSignalingSystemEtcsLevel2
         required:
         - brake_params
         - type
@@ -14720,6 +14823,7 @@ components:
     Waypoint:
       oneOf:
       - type: object
+        title: WaypointBufferStop
         required:
         - id
         - type
@@ -14733,6 +14837,7 @@ components:
             enum:
             - BufferStop
       - type: object
+        title: WaypointDetector
         required:
         - id
         - type
@@ -15260,6 +15365,7 @@ components:
     core.PathfindingInputError:
       oneOf:
       - type: object
+        title: PathfindingInputErrorInvalidPathItems
         required:
         - items
         - error_type
@@ -15282,6 +15388,7 @@ components:
                 path_item:
                   $ref: '#/components/schemas/PathItemLocation'
       - type: object
+        title: PathfindingInputErrorNotEnoughPathItems
         required:
         - error_type
         properties:
@@ -15290,6 +15397,7 @@ components:
             enum:
             - not_enough_path_items
       - type: object
+        title: PathfindingInputErrorRollingStockNotFound
         required:
         - rolling_stock_name
         - error_type
@@ -15301,6 +15409,7 @@ components:
           rolling_stock_name:
             type: string
       - type: object
+        title: PathfindingInputErrorZeroLengthPath
         required:
         - error_type
         properties:
@@ -15311,6 +15420,7 @@ components:
     core.PathfindingNotFound:
       oneOf:
       - type: object
+        title: PathfindingNotFoundNotFoundInBlocks
         required:
         - track_section_ranges
         - length
@@ -15329,6 +15439,7 @@ components:
             items:
               $ref: '#/components/schemas/core.TrackRange'
       - type: object
+        title: PathfindingNotFoundNotFoundInRoutes
         required:
         - track_section_ranges
         - length
@@ -15347,6 +15458,7 @@ components:
             items:
               $ref: '#/components/schemas/core.TrackRange'
       - type: object
+        title: PathfindingNotFoundNotFoundInTracks
         required:
         - error_type
         properties:
@@ -15355,6 +15467,7 @@ components:
             enum:
             - not_found_in_tracks
       - type: object
+        title: PathfindingNotFoundIncompatibleConstraints
         required:
         - relaxed_constraints_path
         - incompatible_constraints
@@ -15616,6 +15729,7 @@ components:
           - type: 'null'
           - oneOf:
             - type: object
+              title: MarginValuePercentage
               required:
               - Percentage
               properties:
@@ -15623,6 +15737,7 @@ components:
                   type: number
                   format: double
             - type: object
+              title: MarginValueMinPer100Km
               required:
               - MinPer100Km
               properties:

--- a/editoast/schemas/src/infra/infra_object.rs
+++ b/editoast/schemas/src/infra/infra_object.rs
@@ -16,6 +16,7 @@ use crate::primitives::ObjectType;
 
 #[derive(Debug, Clone, PartialEq, serde::Deserialize, serde::Serialize, utoipa::ToSchema)]
 #[serde(tag = "obj_type", deny_unknown_fields)]
+#[schema(title_variants)]
 pub enum InfraObject {
     TrackSection { railjson: TrackSection },
     Signal { railjson: Signal },

--- a/editoast/schemas/src/infra/waypoint.rs
+++ b/editoast/schemas/src/infra/waypoint.rs
@@ -9,6 +9,7 @@ use utoipa::ToSchema;
 
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, Hash, ToSchema)]
 #[serde(tag = "type", deny_unknown_fields)]
+#[schema(title_variants)]
 pub enum Waypoint {
     BufferStop {
         #[schema(inline)]

--- a/editoast/schemas/src/rolling_stock/energy_source.rs
+++ b/editoast/schemas/src/rolling_stock/energy_source.rs
@@ -7,6 +7,7 @@ use utoipa::ToSchema;
 /// energy source of a rolling stock
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize, ToSchema)]
 #[serde(tag = "energy_source_type", deny_unknown_fields)]
+#[schema(title_variants)]
 pub enum EnergySource {
     /// energy source for a rolling stock representing a electrification
     Electrification {

--- a/editoast/schemas/src/rolling_stock/supported_signaling_system.rs
+++ b/editoast/schemas/src/rolling_stock/supported_signaling_system.rs
@@ -9,6 +9,7 @@ use crate::rolling_stock::EtcsBrakeParams;
 #[derive(Clone, Debug, Deserialize, Serialize, Display, Educe, ToSchema, strum::IntoStaticStr)]
 #[educe(Hash, Eq, PartialEq)]
 #[serde(tag = "type")]
+#[schema(title_variants)]
 #[allow(clippy::large_enum_variant)]
 pub enum SupportedSignalingSystem {
     BAL,

--- a/editoast/schemas/src/rolling_stock/train_category.rs
+++ b/editoast/schemas/src/rolling_stock/train_category.rs
@@ -6,6 +6,7 @@ use crate::rolling_stock::TrainMainCategory;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, ToSchema)]
 #[serde(untagged)]
+#[schema(title_variants)]
 pub enum TrainCategory {
     #[schema(title = "TrainCategoryMain")]
     Main { main_category: TrainMainCategory },

--- a/editoast/schemas/src/train_schedule/allowance.rs
+++ b/editoast/schemas/src/train_schedule/allowance.rs
@@ -4,6 +4,7 @@ use utoipa::ToSchema;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
 #[serde(tag = "allowance_type", rename_all = "lowercase")]
+#[schema(title_variants)]
 pub enum Allowance {
     Engineering(EngineeringAllowance),
     Standard(StandardAllowance),
@@ -35,6 +36,7 @@ const fn default_capacity_speed_limit() -> f64 {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
 #[serde(tag = "value_type")]
+#[schema(title_variants)]
 pub enum AllowanceValue {
     #[serde(rename = "time_per_distance")]
     TimePerDistance { minutes: f64 },

--- a/editoast/schemas/src/train_schedule/margins.rs
+++ b/editoast/schemas/src/train_schedule/margins.rs
@@ -46,6 +46,7 @@ impl Serialize for Margins {
 
 #[derive(Debug, Copy, Clone, Educe, ToSchema)]
 #[educe(Hash, Default, PartialEq, Eq)]
+#[schema(title_variants)]
 pub enum MarginValue {
     #[educe(Default)]
     Percentage(

--- a/editoast/schemas/src/train_schedule/path_item.rs
+++ b/editoast/schemas/src/train_schedule/path_item.rs
@@ -54,6 +54,7 @@ pub struct OperationalPointPartReference {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema, Hash)]
 #[serde(deny_unknown_fields)]
 #[serde(tag = "type", rename_all = "lowercase")]
+#[schema(title_variants)]
 pub enum OperationalPointReference {
     #[schema(title = "OperationalPointReferenceId")]
     Id {

--- a/editoast/src/generated_data/error/infra_error.rs
+++ b/editoast/src/generated_data/error/infra_error.rs
@@ -28,6 +28,7 @@ pub struct InfraError {
 #[strum_discriminants(serde(rename_all = "snake_case", deny_unknown_fields))]
 #[strum_discriminants(strum(serialize_all = "snake_case"))]
 #[serde(tag = "error_type", rename_all = "snake_case", deny_unknown_fields)]
+#[schema(title_variants)]
 pub enum InfraErrorType {
     DuplicatedGroup {
         original_group_path: String,

--- a/editoast/src/infra_cache/operation/mod.rs
+++ b/editoast/src/infra_cache/operation/mod.rs
@@ -69,6 +69,7 @@ impl utoipa::PartialSchema for Operation {
         #[derive(ToSchema, Serialize)]
         #[serde(untagged)]
         #[allow(unused)]
+        #[schema(title_variants)]
         enum Operation {
             Create {
                 #[schema(inline)]

--- a/editoast/src/models/train_schedule.rs
+++ b/editoast/src/models/train_schedule.rs
@@ -326,6 +326,7 @@ impl From<TrainSchedule> for paced_train::TrainSchedule {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema, Hash)]
 #[serde(tag = "type", rename_all = "snake_case")]
+#[schema(title_variants)]
 /// This ID is used to identify paced train occurrences and exceptions when sending them to the core API for conflict detection.
 pub enum OccurrenceId {
     Base {

--- a/editoast/src/views/openapi.rs
+++ b/editoast/src/views/openapi.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 
+use itertools::Either;
 use itertools::Itertools as _;
 use tracing::debug;
 use utoipa::OpenApi;
@@ -9,6 +10,12 @@ use utoipa::openapi::RefOr;
 use utoipa::openapi::Schema;
 use utoipa::openapi::path::Operation;
 use utoipa::openapi::path::PathItemBuilder;
+use utoipa::openapi::schema::AdditionalProperties;
+use utoipa::openapi::schema::AllOf;
+use utoipa::openapi::schema::ArrayItems;
+use utoipa::openapi::schema::OneOf;
+use utoipa::openapi::schema::SchemaType;
+use utoipa::openapi::schema::Type;
 
 use crate::error::ErrorDefinition;
 use crate::views::router::FlattenedPath;
@@ -247,16 +254,338 @@ impl OpenApiRoot {
         Self::insert_schemas(&mut openapi, routes_schemas);
         Self::add_errors_in_schema(&mut openapi);
         Self::remove_operation_id(&mut openapi);
+        set_patch_operation_titles(&mut openapi);
+        set_search_query_titles(&mut openapi);
+        check_variant_titles(&openapi);
         openapi
+    }
+}
+
+// Returns the oneOf schema for the given name, or panics.
+fn get_one_of_schema_mut<'a>(
+    openapi: &'a mut utoipa::openapi::OpenApi,
+    name: &str,
+) -> &'a mut OneOf {
+    let schemas = &mut openapi
+        .components
+        .as_mut()
+        .expect("openapi components should always be present")
+        .schemas;
+    let Some(RefOr::T(Schema::OneOf(one_of))) = schemas.get_mut(name) else {
+        panic!("openapi: expected '{name}' schema to be a oneOf");
+    };
+    one_of
+}
+
+// Sets titles on `PatchOperation`'s oneOf variants.
+// `PatchOperation` is from the `json_patch` crate so we can't use `#[schema(title_variants)]`.
+fn set_patch_operation_titles(openapi: &mut utoipa::openapi::OpenApi) {
+    let one_of = get_one_of_schema_mut(openapi, "PatchOperation");
+    for item in &mut one_of.items {
+        if let RefOr::T(Schema::AllOf(all_of)) = item
+            && let Some(RefOr::Ref(r)) = all_of.items.first()
+        {
+            let name = r.ref_location.rsplit('/').next().unwrap_or_else(|| {
+                panic!(
+                    "openapi: malformed $ref in PatchOperation: '{}'",
+                    r.ref_location
+                )
+            });
+            all_of.title = Some(format!("PatchOperation{name}"));
+        }
+    }
+}
+
+// Sets titles on `SearchQuery`'s oneOf variants.
+// The `Array` variant uses `#[schema(value_type = Object)]` which drops the title.
+fn set_search_query_titles(openapi: &mut utoipa::openapi::OpenApi) {
+    let one_of = get_one_of_schema_mut(openapi, "SearchQuery");
+    for item in &mut one_of.items {
+        if let RefOr::T(Schema::Object(obj)) = item
+            && obj.title.is_none()
+        {
+            obj.title = Some("SearchQueryArray".to_string());
+        }
+    }
+}
+
+// Checks that every oneOf/anyOf variant in all schemas has a unique title.
+// Panics if a title is missing, duplicated, or if components is missing.
+fn check_variant_titles(openapi: &utoipa::openapi::OpenApi) {
+    let components = openapi.components.as_ref().unwrap();
+    // Every root schema name becomes a generated class name in codegen,
+    // so reserve all of them up front to catch any variant title that clashes.
+    let mut seen_titles: BTreeMap<&str, &str> = components
+        .schemas
+        .keys()
+        .map(|name| (name.as_str(), name.as_str()))
+        .collect();
+    for (schema_name, schema) in &components.schemas {
+        check_schema_titles(schema, schema_name, &mut seen_titles);
+    }
+}
+
+// Recurses into a schema to check titles on oneOf/anyOf variants.
+fn check_schema_titles<'a>(
+    schema: &'a RefOr<Schema>,
+    component_schema_name: &'a str,
+    seen_titles: &mut BTreeMap<&'a str, &'a str>,
+) {
+    let RefOr::T(schema) = schema else { return };
+    match schema {
+        Schema::OneOf(utoipa::openapi::schema::OneOf { items, .. })
+        | Schema::AnyOf(utoipa::openapi::schema::AnyOf { items, .. }) => {
+            check_item_titles(items, component_schema_name, seen_titles)
+        }
+        Schema::AllOf(all_of) => {
+            // allOf items are composition, not discrimination — no title required on the items
+            // themselves, but recurse to find nested oneOf/anyOf.
+            for item in &all_of.items {
+                check_schema_titles(item, component_schema_name, seen_titles);
+            }
+        }
+        Schema::Object(obj) => {
+            for prop in obj.properties.values() {
+                check_schema_titles(prop, component_schema_name, seen_titles);
+            }
+            if let Some(additional) = &obj.additional_properties
+                && let AdditionalProperties::RefOr(schema) = additional.as_ref()
+            {
+                check_schema_titles(schema, component_schema_name, seen_titles);
+            }
+        }
+        Schema::Array(arr) => {
+            if let ArrayItems::RefOrSchema(schema) = &arr.items {
+                check_schema_titles(schema, component_schema_name, seen_titles);
+            }
+        }
+        // Schema is #[non_exhaustive], so the wildcard is required by the compiler.
+        &_ => {}
+    }
+}
+
+// For each inline (non-$ref) item in a oneOf/anyOf, checks that a title exists
+// and is unique, then recurses into the item.
+fn check_item_titles<'a>(
+    items: &'a [RefOr<Schema>],
+    component_schema_name: &'a str,
+    seen_titles: &mut BTreeMap<&'a str, &'a str>,
+) {
+    let inline_schemas: Vec<&Schema> = items
+        .iter()
+        .filter_map(|item| {
+            if let RefOr::T(s) = item {
+                Some(s)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    let (titled, untitled): (Vec<_>, Vec<_>) = inline_schemas
+        .iter()
+        .copied()
+        .filter(|s| !matches!(s, Schema::Object(obj) if obj.schema_type == SchemaType::Type(Type::Null)))
+        .partition_map(|s| match get_title(s) {
+            Some(title) => Either::Left(title),
+            None => Either::Right(s),
+        });
+
+    // Require titles when there are 2+ non-null items and any of them has no title.
+    if titled.len() + untitled.len() >= 2 && !untitled.is_empty() {
+        panic!(
+            "openapi: a oneOf/anyOf item inside schema '{component_schema_name}' has no title. \
+            Add #[schema(title_variants)] on the enum or \
+            #[schema(title = \"...\")] on the specific variant."
+        );
+    }
+
+    // Register titles only after the pre-condition is satisfied.
+    for title in &titled {
+        if let Some(prev) = seen_titles.insert(title, component_schema_name) {
+            panic!(
+                "openapi: duplicate title '{title}' in schemas '{prev}' and '{component_schema_name}'. \
+                    Override with #[schema(title = \"...\")] on one of the conflicting variants."
+            );
+        }
+    }
+
+    // Recurse into all items (including $refs and null).
+    for item in items {
+        check_schema_titles(item, component_schema_name, seen_titles);
+    }
+}
+
+// Returns the title of an inline schema, or None if it has no title.
+fn get_title(schema: &Schema) -> Option<&str> {
+    match schema {
+        Schema::Object(obj) => obj.title.as_deref(),
+        Schema::AllOf(AllOf { title, .. }) | Schema::OneOf(OneOf { title, .. }) => title.as_deref(),
+        _ => None,
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use utoipa::openapi::ObjectBuilder;
+    use utoipa::openapi::OneOfBuilder;
+    use utoipa::openapi::OpenApi;
+    use utoipa::openapi::schema::AllOfBuilder;
+    use utoipa::openapi::schema::OneOf;
+
     use super::*;
+
+    fn variant(title: &str) -> Schema {
+        Schema::Object(ObjectBuilder::new().title(Some(title)).build())
+    }
+
+    fn make_two_variant_one_of(t1: &str, t2: &str) -> OneOf {
+        OneOfBuilder::new()
+            .item(variant(t1))
+            .item(variant(t2))
+            .build()
+    }
+
+    fn build_openapi_with_schema(name: &str, schema: Schema) -> OpenApi {
+        let mut openapi = OpenApiRoot::build_openapi();
+        openapi
+            .components
+            .as_mut()
+            .unwrap()
+            .schemas
+            .insert(name.to_string(), schema.into());
+        openapi
+    }
 
     #[test]
     fn openapi_building_goes_well() {
         let _ = OpenApiRoot::build_openapi(); // panics if something is wrong
+    }
+
+    #[test]
+    fn valid_titles_pass_validation() {
+        let waypoint_schema = make_two_variant_one_of("WaypointBufferStop", "WaypointDetector");
+        let openapi = build_openapi_with_schema("Waypoint", Schema::OneOf(waypoint_schema));
+        check_variant_titles(&openapi);
+    }
+
+    #[test]
+    #[should_panic(expected = "has no title")]
+    fn missing_title_fails_validation() {
+        let variant_without_title = Schema::Object(ObjectBuilder::new().build());
+        let variant_with_title = Schema::Object(
+            ObjectBuilder::new()
+                .title(Some("WaypointBufferStop"))
+                .build(),
+        );
+        let waypoint_schema = OneOfBuilder::new()
+            .item(variant_without_title)
+            .item(variant_with_title)
+            .build();
+        let openapi = build_openapi_with_schema("Waypoint", Schema::OneOf(waypoint_schema));
+        check_variant_titles(&openapi);
+    }
+
+    #[test]
+    #[should_panic(expected = "duplicate title")]
+    fn duplicate_title_fails_validation() {
+        let waypoint_schema = make_two_variant_one_of("WaypointBufferStop", "WaypointBufferStop");
+        let openapi = build_openapi_with_schema("Waypoint", Schema::OneOf(waypoint_schema));
+        check_variant_titles(&openapi);
+    }
+
+    #[test]
+    #[should_panic(expected = "has no title")]
+    fn nested_one_of_missing_title_fails_validation() {
+        // inner oneOf has one untitled item — this should be caught
+        let inner_variant_without_title = Schema::Object(ObjectBuilder::new().build());
+        let inner_variant_with_title = Schema::Object(
+            ObjectBuilder::new()
+                .title(Some("WaypointKindBufferStop"))
+                .build(),
+        );
+        let inner_waypoint_schema = OneOfBuilder::new()
+            .item(inner_variant_without_title)
+            .item(inner_variant_with_title)
+            .build();
+        // outer oneOf wraps the allOf so the nested oneOf is reachable
+        let outer_variant1 = variant("WaypointKindDetector");
+        let outer_variant2 = variant("WaypointKindWaypoint");
+        let outer_all_of = AllOfBuilder::new()
+            .item(outer_variant1)
+            .item(Schema::OneOf(inner_waypoint_schema))
+            .build();
+        let outer_waypoint_schema = OneOfBuilder::new()
+            .item(Schema::AllOf(outer_all_of))
+            .item(outer_variant2)
+            .build();
+        let openapi =
+            build_openapi_with_schema("WaypointKind", Schema::OneOf(outer_waypoint_schema));
+        check_variant_titles(&openapi);
+    }
+
+    #[test]
+    #[should_panic(expected = "duplicate title")]
+    fn duplicate_title_across_schemas_fails_validation() {
+        let var = OneOfBuilder::new()
+            .item(variant("WaypointBufferStop"))
+            .build();
+        let waypoint_schema = make_two_variant_one_of("WaypointBufferStop", "WaypointDetector");
+        let mut openapi = OpenApiRoot::build_openapi();
+        let schemas = &mut openapi.components.as_mut().unwrap().schemas;
+        schemas.insert(
+            "Waypoint".to_string(),
+            Schema::OneOf(waypoint_schema).into(),
+        );
+        schemas.insert("Waypoint2".to_string(), Schema::OneOf(var).into());
+        check_variant_titles(&openapi);
+    }
+
+    #[test]
+    #[should_panic(expected = "duplicate title")]
+    fn single_item_one_of_name_conflicts_with_variant_title() {
+        // "Waypoint" is a single-item oneOf (wrapper) — codegen names it "Waypoint".
+        // "WaypointKind" has a variant titled "Waypoint" — conflict.
+        let wrapper_schema = OneOfBuilder::new()
+            .item(Schema::Object(ObjectBuilder::new().build()))
+            .build();
+        let kind_schema = make_two_variant_one_of("WaypointKindBufferStop", "Waypoint");
+        let mut openapi = OpenApiRoot::build_openapi();
+        let schemas = &mut openapi.components.as_mut().unwrap().schemas;
+        schemas.insert("Waypoint".to_string(), Schema::OneOf(wrapper_schema).into());
+        schemas.insert(
+            "WaypointKind".to_string(),
+            Schema::OneOf(kind_schema).into(),
+        );
+        check_variant_titles(&openapi);
+    }
+
+    #[test]
+    #[should_panic(expected = "has no title")]
+    fn multi_variant_one_of_without_titles_fails_validation() {
+        let schema = OneOfBuilder::new()
+            .item(Schema::Object(ObjectBuilder::new().build()))
+            .item(Schema::Object(ObjectBuilder::new().build()))
+            .build();
+        let openapi = build_openapi_with_schema("Waypoint", Schema::OneOf(schema));
+        check_variant_titles(&openapi);
+    }
+
+    #[test]
+    #[should_panic(expected = "duplicate title")]
+    fn root_schema_name_used_as_variant_title_fails_validation() {
+        // "TrackSection" is a plain object schema (not a oneOf) — its name still becomes a class in codegen.
+        // "Waypoint" has a variant titled "TrackSection" — that clashes with the "TrackSection" class name.
+        let mut openapi = OpenApiRoot::build_openapi();
+        let schemas = &mut openapi.components.as_mut().unwrap().schemas;
+        schemas.insert(
+            "Detector".to_string(),
+            Schema::Object(ObjectBuilder::new().build()).into(),
+        );
+        schemas.insert(
+            "Waypoint".to_string(),
+            Schema::OneOf(make_two_variant_one_of("BufferStop", "Detector")).into(),
+        );
+        check_variant_titles(&openapi);
     }
 }

--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -123,6 +123,7 @@ impl PathfindingInput {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, ToSchema)]
 #[serde(tag = "status", rename_all = "snake_case")]
+#[schema(title_variants)]
 pub enum PathfindingResult {
     Success(PathfindingResultSuccess),
     Failure(PathfindingFailure),
@@ -194,6 +195,7 @@ impl From<PathfindingCoreResult> for PathfindingResult {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, ToSchema, Educe)]
 #[educe(Default)]
 #[serde(tag = "failed_status", rename_all = "snake_case")]
+#[schema(title_variants)]
 pub enum PathfindingFailure {
     PathfindingInputError(PathfindingInputError),
     #[educe(Default)]

--- a/editoast/src/views/search.rs
+++ b/editoast/src/views/search.rs
@@ -250,7 +250,7 @@ enum SearchApiError {
 
 /// A search query
 #[derive(ToSchema, Serialize)]
-#[schema(example = json!(["and", ["=", ["infra_id"], 2], ["search", ["name"], "plop"]]))]
+#[schema(example = json!(["and", ["like", ["to_string", ["infra_id"]], 2], ["search", ["name"], "plop"]]), title_variants)]
 #[serde(untagged)]
 #[allow(unused)] // only used as an OpenAPI schema
 enum SearchQuery {
@@ -266,7 +266,7 @@ enum SearchQuery {
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 #[schema(example = json!({
     "object": "operationalpoint",
-    "query": ["and", ["=", ["infra_id"], 2], ["search", ["name"], "plop"]]
+    "query": ["and", ["like", ["to_string", ["infra_id"]], 2], ["search", ["name"], "plop"]]
 }))]
 pub struct SearchPayload {
     /// The object kind to query - run `editoast search list` to get all possible values

--- a/editoast/src/views/timetable/simulation.rs
+++ b/editoast/src/views/timetable/simulation.rs
@@ -201,7 +201,7 @@ pub fn path_item_respect_margins<T: TrainScheduleLike>(
 // We accepted the difference of memory size taken by variants
 // Since there is only on success and others are error cases
 #[allow(clippy::large_enum_variant)]
-#[schema(as = SimulationResponse)]
+#[schema(as = SimulationResponse, title_variants)]
 pub enum Response {
     Success(SimulationResponseSuccess),
     PathfindingFailed {
@@ -257,7 +257,7 @@ impl From<core_client::simulation::Response> for Response {
 #[derive(Debug, Serialize, ToSchema)]
 #[cfg_attr(test, derive(PartialEq, serde::Deserialize))]
 #[serde(tag = "status", rename_all = "snake_case")]
-#[schema(as = SimulationSummaryResult)]
+#[schema(as = SimulationSummaryResult, title_variants)]
 pub enum SummaryResponse {
     /// Minimal information on a simulation's result
     Success {

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -68,6 +68,7 @@ use editoast_models::timetable::Timetable;
 // We accepted the difference of memory size taken by variants
 // Since there is only on success and others are error cases
 #[allow(clippy::large_enum_variant)]
+#[schema(title_variants)]
 pub(in crate::views) enum StdcmResponse {
     Success {
         simulation: SimulationResponseSuccess,


### PR DESCRIPTION
closes https://github.com/OpenRailAssociation/osrd/issues/15160

`datamodel-codegen` needs a title on each `oneOf`/`anyOf` item to generate meaningful Python class names. Without it, classes get generic names like `SimulationResponse1`, `SimulationResponse2`, etc.

#### Approach:

- Use an `utoipa` fork (`leovalais/utoipa`, branch `enum-variant-titles`) that adds `#[schema(title_variants)]` support
- Add `#[schema(title_variants)]` on all enums that produce `oneOf`/`anyOf` in the OpenAPI spec
- Manually set titles for schemas that can't use the attribute:
  - `PatchOperation` (external `json_patch` crate): titles are derived from the `$ref` name (e.g. `AddOperation`)
  - `SearchQuery`: the `Array` variant uses `#[schema(value_type = Object)]` which drops the title set by title_variants
- Add a validation step (`check_variant_titles`) that panics at build time if any `oneOf`/`anyOf` variant is missing a title or has a duplicate