### PR TITLE
editoast: get rid of non-utoipa usage of `common::geometry`

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -802,6 +802,7 @@ dependencies = [
  "educe",
  "futures 0.3.32",
  "futures-util",
+ "geos",
  "hostname",
  "http",
  "itertools",

--- a/editoast/common/src/geometry.rs
+++ b/editoast/common/src/geometry.rs
@@ -1,70 +1,113 @@
-use serde::Deserialize;
-use serde::Serialize;
+#![expect(unused)] // None of these types are supposed to be used directly: use geos::geojson instead.
+
 use utoipa::ToSchema;
 
-// Schema of a GeoJson value meant to be used **exclusively** in the OpenApi
 /// A GeoJSON geometry item
-#[derive(Serialize, ToSchema)]
-#[serde(untagged)]
-pub enum GeoJson {
-    Point(GeoJsonPoint),
-    MultiPoint(GeoJsonMultiPoint),
-    LineString(GeoJsonLineString),
-    MultiLineString(GeoJsonMultiLineString),
-    Polygon(GeoJsonPolygon),
-    MultiPolygon(GeoJsonMultiPolygon),
+#[derive(ToSchema)]
+pub struct GeoJson(#[schema(inline)] serde_remotes::GeoJson);
+#[derive(ToSchema)]
+pub struct GeoJsonPoint(#[schema(inline)] serde_remotes::GeoJsonPoint);
+#[derive(ToSchema)]
+pub struct GeoJsonMultiPoint(#[schema(inline)] serde_remotes::GeoJsonMultiPoint);
+#[derive(ToSchema)]
+pub struct GeoJsonLineString(#[schema(inline)] serde_remotes::GeoJsonLineString);
+#[derive(ToSchema)]
+pub struct GeoJsonMultiLineString(#[schema(inline)] serde_remotes::GeoJsonMultiLineString);
+#[derive(ToSchema)]
+pub struct GeoJsonPolygon(#[schema(inline)] serde_remotes::GeoJsonPolygon);
+#[derive(ToSchema)]
+pub struct GeoJsonMultiPolygon(#[schema(inline)] serde_remotes::GeoJsonMultiPolygon);
+#[derive(ToSchema)]
+pub struct GeoJsonPointValue(#[schema(inline)] serde_remotes::GeoJsonPointValue);
+#[derive(ToSchema)]
+pub struct GeoJsonMultiPointValue(#[schema(inline)] serde_remotes::GeoJsonMultiPointValue);
+#[derive(ToSchema)]
+pub struct GeoJsonLineStringValue(#[schema(inline)] serde_remotes::GeoJsonLineStringValue);
+#[derive(ToSchema)]
+pub struct GeoJsonMultiLineStringValue(
+    #[schema(inline)] serde_remotes::GeoJsonMultiLineStringValue,
+);
+#[derive(ToSchema)]
+pub struct GeoJsonPolygonValue(#[schema(inline)] serde_remotes::GeoJsonPolygonValue);
+#[derive(ToSchema)]
+pub struct GeoJsonMultiPolygonValue(#[schema(inline)] serde_remotes::GeoJsonMultiPolygonValue);
+
+/// Defines serializable versions of GeoJson types only meant to be used as remote
+/// definitions for the public schemas defined above.
+///
+/// NONE OF THESE TYPES ARE SUPPOSED TO BE USED AT ALL!
+///
+/// The reason we do things this way is because ToSchema reads serde annotations to
+/// configure the schema. Here 'untagged' and 'type/content'. So we derive Serialize
+/// on these private types, so that we can have the right schema, and then use those
+/// in public types to provide the schema. It prevents the public types from being
+/// Serialize or Deserialize, so that they can only be used within ToSchema.
+mod serde_remotes {
+    use serde::Serialize;
+    use utoipa::ToSchema;
+
+    #[derive(Serialize, ToSchema)]
+    #[serde(untagged)]
+    pub(super) enum GeoJson {
+        Point(GeoJsonPoint),
+        MultiPoint(GeoJsonMultiPoint),
+        LineString(GeoJsonLineString),
+        MultiLineString(GeoJsonMultiLineString),
+        Polygon(GeoJsonPolygon),
+        MultiPolygon(GeoJsonMultiPolygon),
+    }
+
+    #[derive(Serialize, ToSchema)]
+    #[serde(tag = "type", content = "coordinates")]
+    pub(super) enum GeoJsonPoint {
+        Point(GeoJsonPointValue),
+    }
+
+    #[derive(Serialize, ToSchema)]
+    #[serde(tag = "type", content = "coordinates")]
+    pub(super) enum GeoJsonMultiPoint {
+        MultiPoint(GeoJsonMultiPointValue),
+    }
+
+    #[derive(Serialize, ToSchema)]
+    #[serde(tag = "type", content = "coordinates")]
+    pub(super) enum GeoJsonLineString {
+        LineString(GeoJsonLineStringValue),
+    }
+
+    #[derive(Serialize, ToSchema)]
+    #[serde(tag = "type", content = "coordinates")]
+    pub(super) enum GeoJsonMultiLineString {
+        MultiLineString(GeoJsonMultiLineStringValue),
+    }
+
+    #[derive(Serialize, ToSchema)]
+    #[serde(tag = "type", content = "coordinates")]
+    pub(super) enum GeoJsonPolygon {
+        Polygon(GeoJsonPolygonValue),
+    }
+
+    #[derive(Serialize, ToSchema)]
+    #[serde(tag = "type", content = "coordinates")]
+    pub(super) enum GeoJsonMultiPolygon {
+        MultiPolygon(GeoJsonMultiPolygonValue),
+    }
+
+    #[derive(Serialize, ToSchema)]
+    pub(super) struct GeoJsonPointValue(Vec<f64>);
+
+    #[derive(Serialize, ToSchema)]
+    pub(super) struct GeoJsonMultiPointValue(Vec<GeoJsonPointValue>);
+
+    #[derive(Serialize, ToSchema)]
+    pub(super) struct GeoJsonLineStringValue(Vec<GeoJsonPointValue>);
+
+    #[derive(Serialize, ToSchema)]
+    pub(super) struct GeoJsonMultiLineStringValue(Vec<GeoJsonLineStringValue>);
+
+    #[derive(Serialize, ToSchema)]
+    pub(super) struct GeoJsonPolygonValue(Vec<GeoJsonLineStringValue>);
+
+    #[derive(Serialize, ToSchema)]
+    pub(super) struct GeoJsonMultiPolygonValue(Vec<GeoJsonPolygonValue>);
 }
-
-#[derive(Serialize, Deserialize, ToSchema, Debug, Clone, PartialEq)]
-#[serde(tag = "type", content = "coordinates")]
-pub enum GeoJsonPoint {
-    Point(GeoJsonPointValue),
-}
-
-#[derive(Serialize, ToSchema)]
-#[serde(tag = "type", content = "coordinates")]
-pub enum GeoJsonMultiPoint {
-    MultiPoint(GeoJsonMultiPointValue),
-}
-
-#[derive(Serialize, Deserialize, PartialEq, ToSchema, Debug, Clone)]
-#[serde(tag = "type", content = "coordinates")]
-pub enum GeoJsonLineString {
-    LineString(GeoJsonLineStringValue),
-}
-
-#[derive(Serialize, ToSchema)]
-#[serde(tag = "type", content = "coordinates")]
-pub enum GeoJsonMultiLineString {
-    MultiLineString(GeoJsonMultiLineStringValue),
-}
-
-#[derive(Serialize, ToSchema)]
-#[serde(tag = "type", content = "coordinates")]
-pub enum GeoJsonPolygon {
-    Polygon(GeoJsonPolygonValue),
-}
-
-#[derive(Serialize, ToSchema)]
-#[serde(tag = "type", content = "coordinates")]
-pub enum GeoJsonMultiPolygon {
-    MultiPolygon(GeoJsonMultiPolygonValue),
-}
-
-#[derive(Serialize, Deserialize, ToSchema, Debug, Clone, PartialEq)]
-pub struct GeoJsonPointValue(Vec<f64>);
-
-#[derive(Serialize, ToSchema)]
-pub struct GeoJsonMultiPointValue(Vec<GeoJsonPointValue>);
-
-#[derive(Serialize, Deserialize, ToSchema, Debug, Clone, PartialEq)]
-pub struct GeoJsonLineStringValue(Vec<GeoJsonPointValue>);
-
-#[derive(Serialize, ToSchema)]
-pub struct GeoJsonMultiLineStringValue(Vec<GeoJsonLineStringValue>);
-
-#[derive(Serialize, ToSchema)]
-pub struct GeoJsonPolygonValue(Vec<GeoJsonLineStringValue>);
-
-#[derive(Serialize, ToSchema)]
-pub struct GeoJsonMultiPolygonValue(Vec<GeoJsonPolygonValue>);

--- a/editoast/common/src/geometry.rs
+++ b/editoast/common/src/geometry.rs
@@ -52,13 +52,13 @@ pub enum GeoJsonMultiPolygon {
 }
 
 #[derive(Serialize, Deserialize, ToSchema, Debug, Clone, PartialEq)]
-pub struct GeoJsonPointValue(pub Vec<f64>);
+pub struct GeoJsonPointValue(Vec<f64>);
 
 #[derive(Serialize, ToSchema)]
 pub struct GeoJsonMultiPointValue(Vec<GeoJsonPointValue>);
 
 #[derive(Serialize, Deserialize, ToSchema, Debug, Clone, PartialEq)]
-pub struct GeoJsonLineStringValue(pub Vec<GeoJsonPointValue>);
+pub struct GeoJsonLineStringValue(Vec<GeoJsonPointValue>);
 
 #[derive(Serialize, ToSchema)]
 pub struct GeoJsonMultiLineStringValue(Vec<GeoJsonLineStringValue>);

--- a/editoast/core_client/Cargo.toml
+++ b/editoast/core_client/Cargo.toml
@@ -13,6 +13,7 @@ editoast_derive.workspace = true
 educe.workspace = true
 futures.workspace = true
 futures-util.workspace = true
+geos.workspace = true
 hostname.workspace = true
 http = { workspace = true }
 itertools.workspace = true

--- a/editoast/core_client/src/path_properties.rs
+++ b/editoast/core_client/src/path_properties.rs
@@ -1,4 +1,4 @@
-use common::geometry::GeoJsonLineString;
+use geos::geojson::Geometry;
 use schemas::infra::OperationalPointExtensions;
 use schemas::infra::OperationalPointPart;
 use schemas::primitives::Identifier;
@@ -31,7 +31,7 @@ pub struct PathPropertiesResponse {
     /// Electrification modes and neutral section along the path
     pub electrifications: PropertyElectrificationValues,
     /// Geometry of the path
-    pub geometry: GeoJsonLineString,
+    pub geometry: Geometry,
     /// Operational points along the path
     pub operational_points: Vec<OperationalPointOnPath>,
     /// Zones along the path

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -9248,12 +9248,13 @@ components:
       additionalProperties: false
     GeoJson:
       oneOf:
-      - $ref: '#/components/schemas/GeoJsonPoint'
-      - $ref: '#/components/schemas/GeoJsonMultiPoint'
-      - $ref: '#/components/schemas/GeoJsonLineString'
-      - $ref: '#/components/schemas/GeoJsonMultiLineString'
-      - $ref: '#/components/schemas/GeoJsonPolygon'
-      - $ref: '#/components/schemas/GeoJsonMultiPolygon'
+      - oneOf:
+        - $ref: '#/components/schemas/GeoJsonPoint'
+        - $ref: '#/components/schemas/GeoJsonMultiPoint'
+        - $ref: '#/components/schemas/GeoJsonLineString'
+        - $ref: '#/components/schemas/GeoJsonMultiLineString'
+        - $ref: '#/components/schemas/GeoJsonPolygon'
+        - $ref: '#/components/schemas/GeoJsonMultiPolygon'
       description: A GeoJSON geometry item
     GeoJsonLineString:
       oneOf:

--- a/editoast/src/generated_data/operational_point.rs
+++ b/editoast/src/generated_data/operational_point.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::ops::DerefMut;
 
-use common::geometry::GeoJsonPoint;
 use database::DbConnection;
 use database::tables::infra_layer_operational_point::dsl;
 use diesel::delete;
@@ -80,7 +79,7 @@ struct OperationalPoint {
     #[diesel(sql_type = Text)]
     obj_id: String,
     #[diesel(sql_type = Jsonb)]
-    geo: diesel_json::Json<GeoJsonPoint>,
+    geo: diesel_json::Json<geos::geojson::Geometry>,
 }
 
 impl OperationalPointLayer {
@@ -88,7 +87,7 @@ impl OperationalPointLayer {
         conn: &mut DbConnection,
         infra_id: i64,
         ids: &[&str],
-    ) -> Result<HashMap<String, Vec<GeoJsonPoint>>> {
+    ) -> Result<HashMap<String, Vec<geos::geojson::Geometry>>> {
         Ok(sql_query(
             "SELECT obj_id, ST_AsGeoJSON(ST_Transform(geographic, 4326))::jsonb AS geo
                 FROM infra_layer_operational_point

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -19,14 +19,11 @@ use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use common::geometry::GeoJsonPoint;
-use common::geometry::GeoJsonPointValue;
 use database::DbConnection;
 use database::DbConnectionPoolV2;
 use editoast_derive::EditoastError;
 use editoast_models::prelude::*;
-use geos::CoordSeq;
 use geos::Geom;
-use geos::Geometry;
 use itertools::Itertools;
 use schemas::infra::SwitchType;
 use schemas::primitives::Identifier;
@@ -777,7 +774,8 @@ pub(in crate::views) struct MatchOperationalPointsForm {
 struct RelatedOperationalPointPart {
     #[serde(flatten)]
     part: OperationalPointPart,
-    geo: Option<GeoJsonPoint>,
+    #[schema(value_type = Option<GeoJsonPoint>)]
+    geo: Option<geos::geojson::Geometry>,
 }
 
 #[derive(Serialize, ToSchema)]
@@ -791,7 +789,8 @@ struct RelatedOperationalPoint {
     extensions: OperationalPointExtensions,
     #[serde(default)]
     weight: Option<u8>,
-    geo: Option<GeoJsonPoint>,
+    #[schema(value_type = Option<GeoJsonPoint>)]
+    geo: Option<geos::geojson::Geometry>,
 }
 
 #[derive(Serialize, ToSchema)]
@@ -857,7 +856,9 @@ pub(in crate::views) async fn match_operational_points(
     }))
 }
 
-fn compute_operational_point_geo(points: &[GeoJsonPoint]) -> Option<GeoJsonPoint> {
+fn compute_operational_point_geo(
+    points: &[geos::geojson::Geometry],
+) -> Option<geos::geojson::Geometry> {
     if points.is_empty() {
         return None;
     } else if points.len() == 1 {
@@ -866,30 +867,23 @@ fn compute_operational_point_geo(points: &[GeoJsonPoint]) -> Option<GeoJsonPoint
     let geo_points = points
         .iter()
         .map(|geojson_point| {
-            let GeoJsonPoint::Point(GeoJsonPointValue(xy)) = geojson_point;
-            let coords = CoordSeq::new_from_vec(&[xy]).expect("invalid point coords");
-            Geometry::create_point(coords).expect("invalid point geometry")
+            geos::Geometry::try_from(geojson_point).expect("invalid point geometry")
         })
         .collect();
-    let center = Geometry::create_multipoint(geo_points)
+    let center = geos::Geometry::create_multipoint(geo_points)
         .expect("invalid multi-point geometry")
         .get_centroid()
-        .expect("failed to get centroid")
-        .get_coord_seq()
-        .expect("invalid centroid coords");
-    Some(GeoJsonPoint::Point(GeoJsonPointValue(vec![
+        .expect("failed to get centroid");
+    Some(
         center
-            .get_x(0)
-            .expect("failed to get centroid X coordinate"),
-        center
-            .get_y(0)
-            .expect("failed to get centroid Y coordinate"),
-    ])))
+            .try_into()
+            .expect("failed to convert centroid to geojson"),
+    )
 }
 
 fn build_related_operational_point(
     op: &OperationalPoint,
-    geo_points: Option<&Vec<GeoJsonPoint>>,
+    geo_points: Option<&Vec<geos::geojson::Geometry>>,
 ) -> RelatedOperationalPoint {
     RelatedOperationalPoint {
         id: op.id.clone(),
@@ -933,7 +927,6 @@ async fn populate_op_geo(
 #[cfg(test)]
 pub mod tests {
     use axum::http::StatusCode;
-    use common::geometry::GeoJsonPointValue;
     use core_client::CoreClient;
     use core_client::mocking::MockingClient;
     use diesel::sql_query;
@@ -1424,17 +1417,15 @@ pub mod tests {
         assert_eq!(response_op_identifiers, expected_identifiers);
         assert_eq!(
             response.related_operational_points[0][0].geo,
-            Some(GeoJsonPoint::Point(GeoJsonPointValue(vec!(
-                -0.3907884636666667,
-                49.4999,
-            ))))
+            Some(geos::geojson::Geometry::new(geos::geojson::Value::Point(
+                vec![-0.3907884636666667, 49.4999],
+            )))
         );
         assert_eq!(
             response.related_operational_points[0][0].parts[1].geo,
-            Some(GeoJsonPoint::Point(GeoJsonPointValue(vec!(
-                -0.392307692,
-                49.4999,
-            ))))
+            Some(geos::geojson::Geometry::new(geos::geojson::Value::Point(
+                vec![-0.392307692, 49.4999],
+            )))
         );
     }
 

--- a/editoast/src/views/path/properties.rs
+++ b/editoast/src/views/path/properties.rs
@@ -17,6 +17,7 @@ use core_client::path_properties::PropertyElectrificationValues;
 use core_client::path_properties::PropertyValuesF64;
 use core_client::path_properties::PropertyZoneValues;
 use core_client::pathfinding::TrackRange;
+use geos::geojson::Geometry;
 use serde::Deserialize;
 use serde::Serialize;
 use std::hash::Hash;
@@ -47,7 +48,8 @@ pub(in crate::views) struct PathProperties {
     #[schema(inline)]
     electrifications: PropertyElectrificationValues,
     /// Geometry of the path
-    geometry: GeoJsonLineString,
+    #[schema(value_type = GeoJsonLineString)]
+    geometry: Geometry,
     /// Operational points along the path
     #[schema(inline)]
     operational_points: Vec<OperationalPointOnPath>,
@@ -121,9 +123,6 @@ pub(in crate::views) async fn post(
 #[cfg(test)]
 mod tests {
     use axum::http::StatusCode;
-    use common::geometry::GeoJsonLineString;
-    use common::geometry::GeoJsonLineStringValue;
-    use common::geometry::GeoJsonPointValue;
     use core_client::mocking::MockingClient;
     use core_client::path_properties::OperationalPointOnPath;
     use core_client::path_properties::PropertyElectrificationValue;
@@ -147,9 +146,9 @@ mod tests {
                 vec![0, 1],
                 vec![PropertyElectrificationValue::NonElectrified],
             ),
-            geometry: GeoJsonLineString::LineString(GeoJsonLineStringValue(vec![
-                GeoJsonPointValue(vec![0.0, 0.0]),
-            ])),
+            geometry: geos::geojson::Geometry::new(geos::geojson::Value::LineString(vec![vec![
+                0.0, 0.0,
+            ]])),
             operational_points: vec![OperationalPointOnPath::new_test("1", 0, "1")],
             zones: PropertyZoneValues::new(vec![0, 1], vec!["Zone 1".into()]),
         }

--- a/editoast/src/views/search.rs
+++ b/editoast/src/views/search.rs
@@ -218,6 +218,7 @@ use diesel_async::RunQueryDsl;
 use editoast_derive::EditoastError;
 use editoast_derive::Search;
 use editoast_derive::SearchConfigStore;
+use geos::geojson::Geometry;
 use schemas::train_schedule::Margins;
 use schemas::train_schedule::PathItem;
 use schemas::train_schedule::PowerRestrictionItem;
@@ -490,7 +491,8 @@ pub(super) struct SearchResultItemOperationalPoint {
     #[search(sql = "OP.data#>>'{extensions,sncf,ci}'")]
     ci: u64,
     #[search(sql = "ST_AsGeoJSON(ST_Transform(lay.geographic, 4326))::json")]
-    geographic: GeoJsonPoint,
+    #[schema(value_type = GeoJsonPoint)]
+    geographic: Geometry,
     #[search(sql = "OP.data->'parts'")]
     #[schema(inline)]
     track_sections: Vec<SearchResultItemOperationalPointTrackSections>,
@@ -572,7 +574,8 @@ pub(super) struct SearchResultItemSignal {
     #[search(sql = "track_section.data->'extensions'->'sncf'->>'line_name'")]
     line_name: String,
     #[search(sql = "ST_AsGeoJSON(ST_Transform(lay.geographic, 4326))::json")]
-    geographic: GeoJsonPoint,
+    #[schema(value_type = GeoJsonPoint)]
+    geographic: Geometry,
     #[search(sql = "lay.signaling_system")]
     sprite_signaling_system: Option<String>,
     #[search(sql = "lay.sprite")]


### PR DESCRIPTION
`common::geometry` was meant to provide utoipa schemas only, but the definitions were used in other contexts as well.

- **editoast: get rid of non-utoipa usage of `common::geometry`**
- **editoast: common: remove all trait implementations in `geometry`**
