### PR TITLE
editoast: ensure margin and power restriction are strictly increasing

### DIFF
--- a/editoast/core_task/src/envs/simulation.rs
+++ b/editoast/core_task/src/envs/simulation.rs
@@ -438,7 +438,7 @@ pub(crate) mod test_data {
             NonBlankString::from("a"),
             SimulationWaypoint::ScheduleItem {
                 arrival_at: Some(1200),
-                stop_for: 60,
+                stop_for: Some(60),
                 reception_signal: Default::default(),
             },
         );
@@ -450,7 +450,7 @@ pub(crate) mod test_data {
             NonBlankString::from("b"),
             SimulationWaypoint::ScheduleItem {
                 arrival_at: None,
-                stop_for: 120,
+                stop_for: Some(120),
                 reception_signal: Default::default(),
             },
         );
@@ -459,7 +459,7 @@ pub(crate) mod test_data {
             NonBlankString::from("finish"),
             SimulationWaypoint::ScheduleItem {
                 arrival_at: Some(2400),
-                stop_for: 0,
+                stop_for: Some(0),
                 reception_signal: Default::default(),
             },
         );

--- a/editoast/core_task/src/envs/simulation/inputs.rs
+++ b/editoast/core_task/src/envs/simulation/inputs.rs
@@ -62,7 +62,7 @@ pub enum SimulationWaypoint {
     PathItem,
     /// The train must stop at this waypoint
     ScheduleItem {
-        stop_for: u64,
+        stop_for: Option<u64>,
         arrival_at: Option<u64>,
         reception_signal: ReceptionSignal,
     },

--- a/editoast/core_task/src/envs/simulation/inputs.rs
+++ b/editoast/core_task/src/envs/simulation/inputs.rs
@@ -8,6 +8,7 @@ use schemas::train_schedule::ReceptionSignal;
 use schemas::train_schedule::TrainScheduleOptions;
 
 use std::borrow::Borrow;
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::hash::Hash;
 use std::sync::Arc;
@@ -250,10 +251,16 @@ impl SimulationTrain {
         if begin_index >= n || end_index >= n {
             panic!("path waypoint index out of bounds");
         }
-        debug_assert!(begin_index < end_index);
-        self.parameters
-            .power_restrictions
-            .insert(begin_index..end_index, restriction);
+        match begin_index.cmp(&end_index) {
+            Ordering::Less => self
+                .parameters
+                .power_restrictions
+                .insert(begin_index..end_index, restriction),
+            Ordering::Equal => tracing::warn!("ignoring a zero-length power restriction"),
+            Ordering::Greater => panic!(
+                "power restriction must be defined on strictly increasing offset along the path"
+            ),
+        }
     }
 
     /// Sets a margin for a range of waypoints.
@@ -282,10 +289,16 @@ impl SimulationTrain {
         if begin_index >= n || end_index >= n {
             panic!("path waypoint index out of bounds");
         }
-        debug_assert!(begin_index < end_index);
-        self.parameters
-            .margins
-            .insert(begin_index..end_index, margin);
+        match begin_index.cmp(&end_index) {
+            Ordering::Less => self
+                .parameters
+                .margins
+                .insert(begin_index..end_index, margin),
+            Ordering::Equal => tracing::warn!("ignoring a zero-length margin"),
+            Ordering::Greater => {
+                panic!("margin must be defined on strictly increasing offset along the path")
+            }
+        }
     }
 }
 

--- a/editoast/core_task/src/envs/simulation/request.rs
+++ b/editoast/core_task/src/envs/simulation/request.rs
@@ -80,7 +80,7 @@ pub(super) fn build_request(
             schedule.push(core_client::simulation::SimulationScheduleItem {
                 path_offset: position,
                 arrival: *arrival_at,
-                stop_for: Some(*stop_for).filter(|t| *t > 0),
+                stop_for: *stop_for,
                 reception_signal: *reception_signal,
             });
         }
@@ -204,7 +204,7 @@ mod tests {
             NonBlankString::from("b"),
             SimulationWaypoint::ScheduleItem {
                 arrival_at: Some(300),
-                stop_for: 0,
+                stop_for: Some(0),
                 reception_signal: Default::default(),
             },
         );
@@ -224,7 +224,7 @@ mod tests {
             schedule: vec![core_client::simulation::SimulationScheduleItem {
                 path_offset: 10,
                 arrival: Some(300),
-                stop_for: None,
+                stop_for: Some(0),
                 reception_signal: Default::default(),
             }],
             margins: core_client::simulation::SimulationMargins {
@@ -296,7 +296,7 @@ mod tests {
                 NonBlankString::from(i.to_string()),
                 SimulationWaypoint::ScheduleItem {
                     arrival_at: *arrival,
-                    stop_for: 0,
+                    stop_for: Some(0),
                     reception_signal: Default::default(),
                 },
             );
@@ -324,31 +324,31 @@ mod tests {
                 core_client::simulation::SimulationScheduleItem {
                     path_offset: 0,
                     arrival: None,
-                    stop_for: None,
+                    stop_for: Some(0),
                     reception_signal: Default::default(),
                 },
                 core_client::simulation::SimulationScheduleItem {
                     path_offset: 10,
                     arrival: Some(100),
-                    stop_for: None,
+                    stop_for: Some(0),
                     reception_signal: Default::default(),
                 },
                 core_client::simulation::SimulationScheduleItem {
                     path_offset: 20,
                     arrival: Some(200),
-                    stop_for: None,
+                    stop_for: Some(0),
                     reception_signal: Default::default(),
                 },
                 core_client::simulation::SimulationScheduleItem {
                     path_offset: 30,
                     arrival: Some(300),
-                    stop_for: None,
+                    stop_for: Some(0),
                     reception_signal: Default::default(),
                 },
                 core_client::simulation::SimulationScheduleItem {
                     path_offset: 40,
                     arrival: Some(400),
-                    stop_for: None,
+                    stop_for: Some(0),
                     reception_signal: Default::default(),
                 },
             ],
@@ -433,7 +433,7 @@ mod tests {
             NonBlankString::from("b"),
             SimulationWaypoint::ScheduleItem {
                 arrival_at: Some(300),
-                stop_for: 0,
+                stop_for: Some(0),
                 reception_signal: Default::default(),
             },
         );

--- a/editoast/core_task/src/lib.rs
+++ b/editoast/core_task/src/lib.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 // Crate-level exports
 pub use envs::TrainSet;
 pub use envs::core::CoreEnv;
+pub use envs::pathfinding::PathWaypointAlternatives;
 pub use envs::pathfinding::PathfindingConsist;
 pub use envs::pathfinding::PathfindingConstraints;
 pub use envs::pathfinding::PathfindingEnv;


### PR DESCRIPTION
Before, we were not making any distinction between equality and decreasing. But decreasing should panic, but equality is a case we do see in the wild and is not really an error semantically (just a no-information). Let’s only filter them out with a log.