### PR TITLE
tests: add missing power_restrictions to the test rolling stocks jsons

### DIFF
--- a/tests/data/rolling_stocks/fast_rolling_stock_high_gamma.json
+++ b/tests/data/rolling_stocks/fast_rolling_stock_high_gamma.json
@@ -9,6 +9,7 @@
   "name": "fast_rolling_stock_high_gamma",
   "mass": 900000,
   "loading_gauge": "G1",
+  "power_restrictions": {},
   "const_gamma": 0.95,
   "rolling_resistance": {
     "type": "davis",

--- a/tests/data/rolling_stocks/short_fast_rolling_stock.json
+++ b/tests/data/rolling_stocks/short_fast_rolling_stock.json
@@ -9,6 +9,7 @@
   "name": "short_fast_rolling_stock",
   "mass": 900000,
   "loading_gauge": "G1",
+  "power_restrictions": {},
   "const_gamma": 0.5,
   "rolling_resistance": {
     "type": "davis",

--- a/tests/data/rolling_stocks/short_slow_rolling_stock.json
+++ b/tests/data/rolling_stocks/short_slow_rolling_stock.json
@@ -9,6 +9,7 @@
   "name": "short_slow_rolling_stock",
   "mass": 900000,
   "loading_gauge": "G1",
+  "power_restrictions": {},
   "const_gamma": 0.5,
   "rolling_resistance": {
     "type": "davis",

--- a/tests/data/rolling_stocks/slow_rolling_stock.json
+++ b/tests/data/rolling_stocks/slow_rolling_stock.json
@@ -9,6 +9,7 @@
   "name": "slow_rolling_stock",
   "mass": 900000,
   "loading_gauge": "G1",
+  "power_restrictions": {},
   "const_gamma": 0.5,
   "rolling_resistance": {
     "type": "davis",


### PR DESCRIPTION
The power restrictions are optional for Editoast but they are mandatory in core to be parsed into PhysicsConsistModel.