### PR TITLE
New times stop table: Add power restrictions column

### DIFF
--- a/front/public/locales/en/translation.json
+++ b/front/public/locales/en/translation.json
@@ -834,6 +834,8 @@
     "noPathLoaded": "No path loaded",
     "operational_point": "operational point",
     "powerRestriction": "power restriction",
+    "powerRestrictionIncompatibility_one": "{{count}} power restriction code isn't compatible with the electrification.",
+    "powerRestrictionIncompatibility_other": "{{count}} power restriction codes aren't compatible with the electrification.",
     "propagationMenu": {
       "atThisWaypoint": "at this waypoint",
       "fromDeparture": "from departure",

--- a/front/public/locales/fr/translation.json
+++ b/front/public/locales/fr/translation.json
@@ -834,6 +834,8 @@
     "noPathLoaded": "Aucun chemin chargé",
     "operational_point": "point remarquable",
     "powerRestriction": "restriction de puissance",
+    "powerRestrictionIncompatibility_one": "{{count}} code de restriction de puissance n'est pas compatible avec l'électrification.",
+    "powerRestrictionIncompatibility_other": "{{count}} codes de restriction de puissance ne sont pas compatibles avec l'électrification.",
     "propagationMenu": {
       "atThisWaypoint": "appliquer à ce point",
       "fromDeparture": "propager vers le début",

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
@@ -373,6 +373,7 @@ const SimulationResults = ({
                 upsertTimetableItems={upsertTimetableItems}
                 isSimulationDataLoading={isSimulationDataLoading}
                 operationalPointsOnPath={simulationResults.pathProperties?.operationalPoints}
+                voltages={simulationResults.pathProperties?.voltages}
                 rollingStock={simulationResults.rollingStock}
                 {...(simulationResults?.isValid &&
                   simulationSummary?.isValid && {

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
@@ -373,6 +373,7 @@ const SimulationResults = ({
                 upsertTimetableItems={upsertTimetableItems}
                 isSimulationDataLoading={isSimulationDataLoading}
                 operationalPointsOnPath={simulationResults.pathProperties?.operationalPoints}
+                rollingStock={simulationResults.rollingStock}
                 {...(simulationResults?.isValid &&
                   simulationSummary?.isValid && {
                     isValid: true,

--- a/front/src/modules/timesStops/TimesStopsOutput.tsx
+++ b/front/src/modules/timesStops/TimesStopsOutput.tsx
@@ -15,7 +15,7 @@ import { getUseNewTimesStopsTable } from 'reducers/user/userSelectors';
 import { formatLocalTime } from 'utils/date';
 import { Duration } from 'utils/duration';
 
-import { computeOptimisticRowUpdate, propagationToEdits } from './helpers/cellUpdate';
+import { computeOptimisticRow, propagationToEdits } from './helpers/cellUpdate';
 import { propagateTime } from './helpers/timePropagation';
 import useOutputTableData from './hooks/useOutputTableData';
 import useTimesStopsTableData from './hooks/useTimesStopsTableData';
@@ -111,7 +111,7 @@ const TimesStopsOutput = ({
     const editMap = new Map(optimisticEdits.map((e) => [e.rowId, e]));
     return newRows.map((row) => {
       const edit = editMap.get(row.id);
-      return edit ? { ...row, ...computeOptimisticRowUpdate(row, edit) } : row;
+      return edit ? { ...row, ...computeOptimisticRow(row, edit) } : row;
     });
   }, [newRows, optimisticEdits]);
 

--- a/front/src/modules/timesStops/TimesStopsOutput.tsx
+++ b/front/src/modules/timesStops/TimesStopsOutput.tsx
@@ -7,6 +7,7 @@ import type { PathPropertiesFormatted } from 'applications/operationalStudies/ty
 import type {
   CorePathfindingResultSuccess,
   ReceptionSignal,
+  RollingStock,
   SimulationResponseSuccess,
 } from 'common/api/osrdEditoastApi';
 import type { SimulationSummary, TimetableItemWithDetails } from 'modules/timetableItem/types';
@@ -45,6 +46,7 @@ type TimesStopsOutputProps = {
   simulatedPathItemRespect?: Extract<SimulationSummary, { isValid: true }>['pathItemRespect'];
   operationalPointsOnPath?: PathPropertiesFormatted['operationalPoints'];
   isSimulationDataLoading?: boolean;
+  rollingStock?: RollingStock;
 };
 
 const TimesStopsOutput = ({
@@ -58,6 +60,7 @@ const TimesStopsOutput = ({
   simulatedPathItemRespect,
   operationalPointsOnPath,
   isSimulationDataLoading = false,
+  rollingStock,
 }: TimesStopsOutputProps) => {
   const useNewTimesStopsTable = useSelector(getUseNewTimesStopsTable);
 
@@ -117,12 +120,18 @@ const TimesStopsOutput = ({
 
   const startTime = useMemo(() => new Date(selectedTrain.start_time), [selectedTrain.start_time]);
 
+  const availablePowerRestrictions = useMemo(
+    () => Object.keys(rollingStock?.power_restrictions ?? {}),
+    [rollingStock]
+  );
+
   const {
     updateArrival,
     updateStopDuration,
     updateDeparture,
     updateReceptionSignal,
     updateRequestedMargin,
+    updatePowerRestrictions,
   } = useUpdateTimesStopsTable(
     selectedTrain,
     newRows,
@@ -276,6 +285,12 @@ const TimesStopsOutput = ({
     commitEdit(buildEditsForMarginUpdate(row, requestedMargin), () =>
       updateRequestedMargin(row, requestedMargin)
     );
+
+  const handlePowerRestrictionChange = (row: TimesStopsRowNew, value: string | null) =>
+    commitEdit([{ rowId: row.id, field: 'powerRestriction', value }], () =>
+      updatePowerRestrictions(row, value)
+    );
+
   if (useNewTimesStopsTable) {
     return (
       <TimesStopsTable
@@ -283,11 +298,13 @@ const TimesStopsOutput = ({
         startTime={startTime}
         isValid={stableIsValid}
         isComputedDataPending={isAwaitingSimulation}
+        availablePowerRestrictions={availablePowerRestrictions}
         onArrivalChange={handleArrivalChange}
         onStopDurationChange={handleStopDurationChange}
         onDepartureChange={handleDepartureChange}
         onReceptionSignalChange={handleReceptionSignalChange}
         onRequestedMarginChange={handleRequestedMarginChange}
+        onPowerRestrictionChange={handlePowerRestrictionChange}
       />
     );
   }

--- a/front/src/modules/timesStops/TimesStopsOutput.tsx
+++ b/front/src/modules/timesStops/TimesStopsOutput.tsx
@@ -4,20 +4,31 @@ import cx from 'classnames';
 import { useSelector } from 'react-redux';
 
 import type { PathPropertiesFormatted } from 'applications/operationalStudies/types';
+import {
+  getPowerRestrictionsWarnings,
+  countWarnings,
+} from 'applications/operationalStudies/views/Scenario/components/ManageTimetableItem/PowerRestrictionsSelector/helpers/powerRestrictionWarnings';
 import type {
   CorePathfindingResultSuccess,
   ReceptionSignal,
   RollingStock,
   SimulationResponseSuccess,
 } from 'common/api/osrdEditoastApi';
+import { matchPathStepAndOp } from 'modules/pathfinding/utils';
+import { NO_POWER_RESTRICTION } from 'modules/powerRestriction/consts';
 import type { SimulationSummary, TimetableItemWithDetails } from 'modules/timetableItem/types';
 import type { TimetableItem, Train } from 'reducers/osrdconf/types';
 import { getUseNewTimesStopsTable } from 'reducers/user/userSelectors';
 import { formatLocalTime } from 'utils/date';
 import { Duration } from 'utils/duration';
 
-import { computeOptimisticRow, propagationToEdits } from './helpers/cellUpdate';
+import {
+  buildPowerRestrictionsFromRows,
+  computeOptimisticRow,
+  propagationToEdits,
+} from './helpers/cellUpdate';
 import { propagateTime } from './helpers/timePropagation';
+import { buildOpMatchParams } from './helpers/utils';
 import useOutputTableData from './hooks/useOutputTableData';
 import useTimesStopsTableData from './hooks/useTimesStopsTableData';
 import useUpdateTimesStopsTable from './hooks/useUpdateTimesStopsTable';
@@ -45,6 +56,7 @@ type TimesStopsOutputProps = {
   simulatedPathItemTimes?: Extract<SimulationSummary, { isValid: true }>['pathItemTimes'];
   simulatedPathItemRespect?: Extract<SimulationSummary, { isValid: true }>['pathItemRespect'];
   operationalPointsOnPath?: PathPropertiesFormatted['operationalPoints'];
+  voltages?: PathPropertiesFormatted['voltages'];
   isSimulationDataLoading?: boolean;
   rollingStock?: RollingStock;
 };
@@ -59,6 +71,7 @@ const TimesStopsOutput = ({
   simulatedPathItemTimes,
   simulatedPathItemRespect,
   operationalPointsOnPath,
+  voltages,
   isSimulationDataLoading = false,
   rollingStock,
 }: TimesStopsOutputProps) => {
@@ -109,6 +122,9 @@ const TimesStopsOutput = ({
       ? pinnedState.edits
       : null;
 
+  // The single source of truth for what the table displays. Any derived data fed to
+  // TimesStopsTable (warnings, styling, etc.) should be computed from optimisticRows,
+  // not from selectedTrain, to stay in sync with the displayed values during edits.
   const optimisticRows = useMemo(() => {
     if (!optimisticEdits) return newRows;
     const editMap = new Map(optimisticEdits.map((e) => [e.rowId, e]));
@@ -124,6 +140,57 @@ const TimesStopsOutput = ({
     () => Object.keys(rollingStock?.power_restrictions ?? {}),
     [rollingStock]
   );
+
+  const { powerRestrictionWarningCount, incompatiblePowerRestrictionIds } = useMemo(() => {
+    const empty = {
+      powerRestrictionWarningCount: 0,
+      incompatiblePowerRestrictionIds: new Set<string>(),
+    };
+    // Built from optimisticRows (not selectedTrain.power_restrictions) so warnings
+    // update immediately when the user edits a cell, before the API round-trip completes.
+    const powerRestrictions = buildPowerRestrictionsFromRows(optimisticRows);
+    if (!voltages?.length || !rollingStock || !powerRestrictions.length) return empty;
+
+    const pathStepPositions = new Map<string, number>();
+    selectedTrain.path.forEach((pathStep) => {
+      const matchingOp = operationalPointsOnPath?.find((op) =>
+        matchPathStepAndOp(pathStep.location, buildOpMatchParams(op))
+      );
+      if (matchingOp) pathStepPositions.set(pathStep.id, matchingOp.position);
+    });
+
+    const rangesWithId = powerRestrictions.flatMap((pr) => {
+      if (pr.value === NO_POWER_RESTRICTION) return [];
+      const begin = pathStepPositions.get(pr.from);
+      const end = pathStepPositions.get(pr.to);
+      if (begin === undefined || end === undefined) return [];
+      return [{ begin, end, value: pr.value, fromId: pr.from }];
+    });
+
+    if (!rangesWithId.length) return empty;
+
+    const warnings = getPowerRestrictionsWarnings(
+      rangesWithId,
+      voltages,
+      rollingStock.effort_curves.modes
+    );
+
+    const warningRanges = [
+      ...warnings.invalidCombinationWarnings,
+      ...warnings.modeNotSupportedWarnings,
+    ];
+
+    const incompatibleIds = new Set<string>(
+      rangesWithId
+        .filter((pr) => warningRanges.some((w) => w.end > pr.begin && w.begin < pr.end))
+        .map((pr) => pr.fromId)
+    );
+
+    return {
+      powerRestrictionWarningCount: countWarnings(warnings),
+      incompatiblePowerRestrictionIds: incompatibleIds,
+    };
+  }, [optimisticRows, voltages, selectedTrain.path, operationalPointsOnPath, rollingStock]);
 
   const {
     updateArrival,
@@ -299,6 +366,8 @@ const TimesStopsOutput = ({
         isValid={stableIsValid}
         isComputedDataPending={isAwaitingSimulation}
         availablePowerRestrictions={availablePowerRestrictions}
+        powerRestrictionWarningCount={powerRestrictionWarningCount}
+        incompatiblePowerRestrictionIds={incompatiblePowerRestrictionIds}
         onArrivalChange={handleArrivalChange}
         onStopDurationChange={handleStopDurationChange}
         onDepartureChange={handleDepartureChange}

--- a/front/src/modules/timesStops/TimesStopsOutput.tsx
+++ b/front/src/modules/timesStops/TimesStopsOutput.tsx
@@ -4,31 +4,21 @@ import cx from 'classnames';
 import { useSelector } from 'react-redux';
 
 import type { PathPropertiesFormatted } from 'applications/operationalStudies/types';
-import {
-  getPowerRestrictionsWarnings,
-  countWarnings,
-} from 'applications/operationalStudies/views/Scenario/components/ManageTimetableItem/PowerRestrictionsSelector/helpers/powerRestrictionWarnings';
 import type {
   CorePathfindingResultSuccess,
   ReceptionSignal,
   RollingStock,
   SimulationResponseSuccess,
 } from 'common/api/osrdEditoastApi';
-import { matchPathStepAndOp } from 'modules/pathfinding/utils';
-import { NO_POWER_RESTRICTION } from 'modules/powerRestriction/consts';
 import type { SimulationSummary, TimetableItemWithDetails } from 'modules/timetableItem/types';
 import type { TimetableItem, Train } from 'reducers/osrdconf/types';
 import { getUseNewTimesStopsTable } from 'reducers/user/userSelectors';
 import { formatLocalTime } from 'utils/date';
 import { Duration } from 'utils/duration';
 
-import {
-  buildPowerRestrictionsFromRows,
-  computeOptimisticRow,
-  propagationToEdits,
-} from './helpers/cellUpdate';
+import { computeOptimisticRow, propagationToEdits } from './helpers/cellUpdate';
+import { computePowerRestrictionWarnings } from './helpers/powerRestrictionIncompatibility';
 import { propagateTime } from './helpers/timePropagation';
-import { buildOpMatchParams } from './helpers/utils';
 import useOutputTableData from './hooks/useOutputTableData';
 import useTimesStopsTableData from './hooks/useTimesStopsTableData';
 import useUpdateTimesStopsTable from './hooks/useUpdateTimesStopsTable';
@@ -141,56 +131,17 @@ const TimesStopsOutput = ({
     [rollingStock]
   );
 
-  const { powerRestrictionWarningCount, incompatiblePowerRestrictionIds } = useMemo(() => {
-    const empty = {
-      powerRestrictionWarningCount: 0,
-      incompatiblePowerRestrictionIds: new Set<string>(),
-    };
-    // Built from optimisticRows (not selectedTrain.power_restrictions) so warnings
-    // update immediately when the user edits a cell, before the API round-trip completes.
-    const powerRestrictions = buildPowerRestrictionsFromRows(optimisticRows);
-    if (!voltages?.length || !rollingStock || !powerRestrictions.length) return empty;
-
-    const pathStepPositions = new Map<string, number>();
-    selectedTrain.path.forEach((pathStep) => {
-      const matchingOp = operationalPointsOnPath?.find((op) =>
-        matchPathStepAndOp(pathStep.location, buildOpMatchParams(op))
-      );
-      if (matchingOp) pathStepPositions.set(pathStep.id, matchingOp.position);
-    });
-
-    const rangesWithId = powerRestrictions.flatMap((pr) => {
-      if (pr.value === NO_POWER_RESTRICTION) return [];
-      const begin = pathStepPositions.get(pr.from);
-      const end = pathStepPositions.get(pr.to);
-      if (begin === undefined || end === undefined) return [];
-      return [{ begin, end, value: pr.value, fromId: pr.from }];
-    });
-
-    if (!rangesWithId.length) return empty;
-
-    const warnings = getPowerRestrictionsWarnings(
-      rangesWithId,
-      voltages,
-      rollingStock.effort_curves.modes
-    );
-
-    const warningRanges = [
-      ...warnings.invalidCombinationWarnings,
-      ...warnings.modeNotSupportedWarnings,
-    ];
-
-    const incompatibleIds = new Set<string>(
-      rangesWithId
-        .filter((pr) => warningRanges.some((w) => w.end > pr.begin && w.begin < pr.end))
-        .map((pr) => pr.fromId)
-    );
-
-    return {
-      powerRestrictionWarningCount: countWarnings(warnings),
-      incompatiblePowerRestrictionIds: incompatibleIds,
-    };
-  }, [optimisticRows, voltages, selectedTrain.path, operationalPointsOnPath, rollingStock]);
+  const { blocks: powerRestrictionBlocks, warningCount: powerRestrictionWarningCount } = useMemo(
+    () =>
+      computePowerRestrictionWarnings({
+        rows: optimisticRows,
+        path: selectedTrain.path,
+        operationalPointsOnPath,
+        voltages,
+        rollingStock,
+      }),
+    [optimisticRows, voltages, selectedTrain.path, operationalPointsOnPath, rollingStock]
+  );
 
   const {
     updateArrival,
@@ -367,7 +318,7 @@ const TimesStopsOutput = ({
         isComputedDataPending={isAwaitingSimulation}
         availablePowerRestrictions={availablePowerRestrictions}
         powerRestrictionWarningCount={powerRestrictionWarningCount}
-        incompatiblePowerRestrictionIds={incompatiblePowerRestrictionIds}
+        powerRestrictionBlocks={powerRestrictionBlocks}
         onArrivalChange={handleArrivalChange}
         onStopDurationChange={handleStopDurationChange}
         onDepartureChange={handleDepartureChange}

--- a/front/src/modules/timesStops/TimesStopsTable.tsx
+++ b/front/src/modules/timesStops/TimesStopsTable.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, Fragment, useMemo, useRef } from 'react';
 
 import { Checkbox } from '@osrd-project/ui-core';
-import { Moon } from '@osrd-project/ui-icons';
+import { Moon, TriangleDown } from '@osrd-project/ui-icons';
 import {
   createColumnHelper,
   flexRender,
@@ -16,6 +16,7 @@ import { useTranslation } from 'react-i18next';
 
 import type { ReceptionSignal } from 'common/api/osrdEditoastApi';
 import { SkeletonLoader } from 'common/Loaders';
+import { NO_POWER_RESTRICTION } from 'modules/powerRestriction/consts';
 import { formatLocalTime, useDateTimeLocale } from 'utils/date';
 import { calculateTimeDifferenceInDays } from 'utils/timeManipulation';
 
@@ -36,6 +37,7 @@ declare module '@tanstack/react-table' {
   interface TableMeta<TData extends RowData> {
     allRows: TimesStopsRowNew[];
     isComputedDataPending?: boolean;
+    availablePowerRestrictions: string[];
     onArrivalChange: (
       row: TimesStopsRowNew,
       arrival: Date | null,
@@ -49,6 +51,7 @@ declare module '@tanstack/react-table' {
     ) => void;
     onReceptionSignalChange: (row: TimesStopsRowNew, signal: ReceptionSignal | undefined) => void;
     onRequestedMarginChange: (row: TimesStopsRowNew, requestedMargin: MarginValue | null) => void;
+    onPowerRestrictionChange: (row: TimesStopsRowNew, value: string | null) => void;
   }
 }
 
@@ -92,6 +95,7 @@ type TimesStopsTableProps = {
   startTime: Date;
   isValid: boolean;
   isComputedDataPending?: boolean;
+  availablePowerRestrictions: string[];
   onArrivalChange: (
     row: TimesStopsRowNew,
     arrival: Date | null,
@@ -105,6 +109,7 @@ type TimesStopsTableProps = {
   ) => void;
   onReceptionSignalChange: (row: TimesStopsRowNew, signal: ReceptionSignal | undefined) => void;
   onRequestedMarginChange: (row: TimesStopsRowNew, value: MarginValue | null) => void;
+  onPowerRestrictionChange: (row: TimesStopsRowNew, value: string | null) => void;
 };
 
 const columnHelper = createColumnHelper<TimesStopsRowNew>();
@@ -125,11 +130,13 @@ const TimesStopsTable = ({
   startTime,
   isValid,
   isComputedDataPending,
+  availablePowerRestrictions,
   onArrivalChange,
   onStopDurationChange,
   onDepartureChange,
   onReceptionSignalChange,
   onRequestedMarginChange,
+  onPowerRestrictionChange,
 }: TimesStopsTableProps) => {
   const { t } = useTranslation('translation', { keyPrefix: 'timeStopTable' });
   const dateTimeLocale = useDateTimeLocale();
@@ -411,6 +418,34 @@ const TimesStopsTable = ({
       }),
       columnHelper.accessor('powerRestriction', {
         header: () => t('powerRestriction'),
+        cell: (info) => {
+          const {
+            availablePowerRestrictions: codes,
+            onPowerRestrictionChange: onRestrictionChange,
+          } = info.table.options.meta!;
+          const value = info.getValue();
+          const row = info.row.original;
+          return (
+            <div className="power-restriction-select-wrapper">
+              <select
+                value={value ?? ''}
+                onChange={(e) => {
+                  const v = e.target.value;
+                  onRestrictionChange(row, v === '' ? null : v);
+                }}
+              >
+                <option value=""> </option>
+                <option value={NO_POWER_RESTRICTION}>Ø</option>
+                {codes.map((c) => (
+                  <option key={c} value={c}>
+                    {c}
+                  </option>
+                ))}
+              </select>
+              <TriangleDown className="power-restriction-arrow" />
+            </div>
+          );
+        },
         meta: {
           className: 'col-power-restriction',
         },
@@ -513,11 +548,13 @@ const TimesStopsTable = ({
     meta: {
       allRows: rows,
       isComputedDataPending,
+      availablePowerRestrictions,
       onArrivalChange,
       onStopDurationChange,
       onDepartureChange,
       onReceptionSignalChange,
       onRequestedMarginChange,
+      onPowerRestrictionChange,
     },
   });
 

--- a/front/src/modules/timesStops/TimesStopsTable.tsx
+++ b/front/src/modules/timesStops/TimesStopsTable.tsx
@@ -21,6 +21,7 @@ import { formatLocalTime, useDateTimeLocale } from 'utils/date';
 import { calculateTimeDifferenceInDays } from 'utils/timeManipulation';
 
 import DurationCell, { type DurationCellHandle } from './DurationCell';
+import type { PowerRestrictionBlockInfo } from './helpers/powerRestrictionIncompatibility';
 import { onStopSignalToReceptionSignal } from './helpers/utils';
 import MarginCell from './MarginCell';
 import TimeCell, { type TimeCellHandle } from './TimeCell';
@@ -39,7 +40,7 @@ declare module '@tanstack/react-table' {
     isComputedDataPending?: boolean;
     availablePowerRestrictions: string[];
     powerRestrictionWarningCount: number;
-    incompatiblePowerRestrictionIds: Set<string>;
+    powerRestrictionBlocks: Map<string, PowerRestrictionBlockInfo>;
     onArrivalChange: (
       row: TimesStopsRowNew,
       arrival: Date | null,
@@ -99,7 +100,7 @@ type TimesStopsTableProps = {
   isComputedDataPending?: boolean;
   availablePowerRestrictions: string[];
   powerRestrictionWarningCount?: number;
-  incompatiblePowerRestrictionIds?: Set<string>;
+  powerRestrictionBlocks?: Map<string, PowerRestrictionBlockInfo>;
   onArrivalChange: (
     row: TimesStopsRowNew,
     arrival: Date | null,
@@ -136,7 +137,7 @@ const TimesStopsTable = ({
   isComputedDataPending,
   availablePowerRestrictions,
   powerRestrictionWarningCount = 0,
-  incompatiblePowerRestrictionIds,
+  powerRestrictionBlocks,
   onArrivalChange,
   onStopDurationChange,
   onDepartureChange,
@@ -427,14 +428,28 @@ const TimesStopsTable = ({
         cell: (info) => {
           const {
             availablePowerRestrictions: codes,
+            powerRestrictionBlocks: blocks,
             onPowerRestrictionChange: onRestrictionChange,
           } = info.table.options.meta!;
           const value = info.getValue();
           const row = info.row.original;
+
+          // On the first row of an incompatible block, display the propagated restriction
+          // in a lighter style so the user can see which code is causing the warning and
+          // edit it directly at the boundary.
+          const blockInfo = blocks.get(row.id);
+          const showPropagated =
+            value === null && blockInfo?.isBlockStart && blockInfo.propagatedValue !== null;
+          const displayedValue = showPropagated ? blockInfo.propagatedValue : value;
+
           return (
-            <div className="power-restriction-select-wrapper">
+            <div
+              className={cx('power-restriction-select-wrapper', {
+                'power-restriction-propagated': showPropagated,
+              })}
+            >
               <select
-                value={value ?? ''}
+                value={displayedValue ?? ''}
                 onChange={(e) => {
                   const v = e.target.value;
                   onRestrictionChange(row, v === '' ? null : v);
@@ -556,7 +571,7 @@ const TimesStopsTable = ({
       isComputedDataPending,
       availablePowerRestrictions,
       powerRestrictionWarningCount,
-      incompatiblePowerRestrictionIds: incompatiblePowerRestrictionIds ?? new Set(),
+      powerRestrictionBlocks: powerRestrictionBlocks ?? new Map(),
       onArrivalChange,
       onStopDurationChange,
       onDepartureChange,
@@ -643,15 +658,17 @@ const TimesStopsTable = ({
       ref={virtualizedWrapperRef}
       style={{ height: `${virtualizer.getTotalSize() + HEADER_HEIGHT}px` }}
     >
-      {powerRestrictionWarningCount > 0 && (
-        <div className="power-restriction-warning">
-          <Alert variant="fill" />
-          <span>
-            {t('powerRestrictionIncompatibility', { count: powerRestrictionWarningCount })}
-          </span>
-        </div>
-      )}
       <table className="table-container">
+        {powerRestrictionWarningCount > 0 && (
+          <caption className="power-restriction-warning">
+            <div className="power-restriction-warning-content">
+              <Alert variant="fill" />
+              <span>
+                {t('powerRestrictionIncompatibility', { count: powerRestrictionWarningCount })}
+              </span>
+            </div>
+          </caption>
+        )}
         <thead>
           {table.getHeaderGroups().map((headerGroup) => (
             <tr key={headerGroup.id}>
@@ -730,7 +747,8 @@ const TimesStopsTable = ({
                       className={cx(cell.column.columnDef.meta?.className, {
                         'power-restriction-incompatible':
                           cell.column.id === 'powerRestriction' &&
-                          table.options.meta!.incompatiblePowerRestrictionIds.has(row.original.id),
+                          table.options.meta!.powerRestrictionBlocks.get(row.original.id)
+                            ?.hasWarning,
                       })}
                     >
                       {flexRender(cell.column.columnDef.cell, cell.getContext())}

--- a/front/src/modules/timesStops/TimesStopsTable.tsx
+++ b/front/src/modules/timesStops/TimesStopsTable.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, Fragment, useMemo, useRef } from 'react';
 
 import { Checkbox } from '@osrd-project/ui-core';
-import { Moon, TriangleDown } from '@osrd-project/ui-icons';
+import { Alert, Moon, TriangleDown } from '@osrd-project/ui-icons';
 import {
   createColumnHelper,
   flexRender,
@@ -38,6 +38,8 @@ declare module '@tanstack/react-table' {
     allRows: TimesStopsRowNew[];
     isComputedDataPending?: boolean;
     availablePowerRestrictions: string[];
+    powerRestrictionWarningCount: number;
+    incompatiblePowerRestrictionIds: Set<string>;
     onArrivalChange: (
       row: TimesStopsRowNew,
       arrival: Date | null,
@@ -96,6 +98,8 @@ type TimesStopsTableProps = {
   isValid: boolean;
   isComputedDataPending?: boolean;
   availablePowerRestrictions: string[];
+  powerRestrictionWarningCount?: number;
+  incompatiblePowerRestrictionIds?: Set<string>;
   onArrivalChange: (
     row: TimesStopsRowNew,
     arrival: Date | null,
@@ -131,6 +135,8 @@ const TimesStopsTable = ({
   isValid,
   isComputedDataPending,
   availablePowerRestrictions,
+  powerRestrictionWarningCount = 0,
+  incompatiblePowerRestrictionIds,
   onArrivalChange,
   onStopDurationChange,
   onDepartureChange,
@@ -549,6 +555,8 @@ const TimesStopsTable = ({
       allRows: rows,
       isComputedDataPending,
       availablePowerRestrictions,
+      powerRestrictionWarningCount,
+      incompatiblePowerRestrictionIds: incompatiblePowerRestrictionIds ?? new Set(),
       onArrivalChange,
       onStopDurationChange,
       onDepartureChange,
@@ -635,6 +643,14 @@ const TimesStopsTable = ({
       ref={virtualizedWrapperRef}
       style={{ height: `${virtualizer.getTotalSize() + HEADER_HEIGHT}px` }}
     >
+      {powerRestrictionWarningCount > 0 && (
+        <div className="power-restriction-warning">
+          <Alert variant="fill" />
+          <span>
+            {t('powerRestrictionIncompatibility', { count: powerRestrictionWarningCount })}
+          </span>
+        </div>
+      )}
       <table className="table-container">
         <thead>
           {table.getHeaderGroups().map((headerGroup) => (
@@ -709,7 +725,14 @@ const TimesStopsTable = ({
                   ref={!hasDayChanged ? virtualizer.measureElement : undefined}
                 >
                   {row.getVisibleCells().map((cell) => (
-                    <td key={cell.id} className={cell.column.columnDef.meta?.className}>
+                    <td
+                      key={cell.id}
+                      className={cx(cell.column.columnDef.meta?.className, {
+                        'power-restriction-incompatible':
+                          cell.column.id === 'powerRestriction' &&
+                          table.options.meta!.incompatiblePowerRestrictionIds.has(row.original.id),
+                      })}
+                    >
                       {flexRender(cell.column.columnDef.cell, cell.getContext())}
                     </td>
                   ))}

--- a/front/src/modules/timesStops/helpers/__tests__/powerRestrictionIncompatibility.spec.ts
+++ b/front/src/modules/timesStops/helpers/__tests__/powerRestrictionIncompatibility.spec.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect } from 'vitest';
+
+import type { TimesStopsRowNew } from '../../types';
+import { computeRowPowerRestrictionStatus } from '../powerRestrictionIncompatibility';
+
+/** Build a minimal row with only the fields used by computeRowPowerRestrictionStatus. */
+const row = (
+  id: string,
+  opOnPathIndex: number,
+  opts: { isPathStep?: boolean; powerRestriction?: string | null } = {}
+): TimesStopsRowNew =>
+  ({
+    id,
+    opOnPathIndex,
+    isPathStep: opts.isPathStep ?? false,
+    powerRestriction: opts.powerRestriction ?? null,
+  }) as TimesStopsRowNew;
+
+describe('computeRowPowerRestrictionStatus', () => {
+  it('returns empty map for empty rows', () => {
+    const result = computeRowPowerRestrictionStatus([], new Map(), [], []);
+    expect(result.size).toBe(0);
+  });
+
+  it('marks no warnings when there are no warning ranges', () => {
+    const rows = [row('a', 0), row('b', 1), row('c', 2)];
+    const positions = new Map([
+      [0, 100],
+      [1, 200],
+      [2, 300],
+    ]);
+
+    const result = computeRowPowerRestrictionStatus(rows, positions, [], []);
+
+    expect(result.get('a')?.hasWarning).toBe(false);
+    expect(result.get('b')?.hasWarning).toBe(false);
+    expect(result.get('c')?.hasWarning).toBe(false);
+  });
+
+  it('marks a multi-row block as incompatible', () => {
+    const rows = [row('a', 0), row('b', 1), row('c', 2), row('d', 3)];
+    const positions = new Map([
+      [0, 100],
+      [1, 200],
+      [2, 300],
+      [3, 400],
+    ]);
+    const warningRanges = [{ begin: 150, end: 350 }];
+
+    const result = computeRowPowerRestrictionStatus(rows, positions, warningRanges, []);
+
+    expect(result.get('a')?.hasWarning).toBe(false);
+    expect(result.get('b')?.hasWarning).toBe(true);
+    expect(result.get('b')?.isBlockStart).toBe(true);
+    expect(result.get('c')?.hasWarning).toBe(true);
+    expect(result.get('c')?.isBlockStart).toBe(false);
+    expect(result.get('d')?.hasWarning).toBe(false);
+  });
+
+  it('dismisses single-row blocks in electrification transition zones', () => {
+    const rows = [row('a', 0), row('b', 1), row('c', 2)];
+    const positions = new Map([
+      [0, 100],
+      [1, 200],
+      [2, 300],
+    ]);
+    // Warning range covers only row b
+    const warningRanges = [{ begin: 150, end: 250 }];
+    // Row b falls within a transition zone (voltage = "")
+    const voltages = [
+      { begin: 0, end: 180, value: '1500V' },
+      { begin: 180, end: 220, value: '' },
+      { begin: 220, end: 500, value: '25000V' },
+    ];
+
+    const result = computeRowPowerRestrictionStatus(rows, positions, warningRanges, voltages);
+
+    // Row b should be dismissed (single-row block in transition zone)
+    expect(result.get('a')?.hasWarning).toBe(false);
+    expect(result.get('b')?.hasWarning).toBe(false);
+    expect(result.get('b')?.isBlockStart).toBe(false);
+    expect(result.get('c')?.hasWarning).toBe(false);
+  });
+
+  it('keeps single-row blocks outside electrification transition zones', () => {
+    const rows = [row('a', 0), row('b', 1), row('c', 2)];
+    const positions = new Map([
+      [0, 100],
+      [1, 200],
+      [2, 300],
+    ]);
+    // Warning range covers only row b
+    const warningRanges = [{ begin: 150, end: 250 }];
+    // Row b is in a real voltage zone (not a transition)
+    const voltages = [{ begin: 0, end: 500, value: '1500V' }];
+
+    const result = computeRowPowerRestrictionStatus(rows, positions, warningRanges, voltages);
+
+    // Row b should NOT be dismissed (real incompatibility, not a transition)
+    expect(result.get('b')?.hasWarning).toBe(true);
+    expect(result.get('b')?.isBlockStart).toBe(true);
+  });
+
+  it('dismisses single-row block at the end of the table in transition zone', () => {
+    const rows = [row('a', 0), row('b', 1)];
+    const positions = new Map([
+      [0, 100],
+      [1, 200],
+    ]);
+    // Warning range covers only the last row
+    const warningRanges = [{ begin: 150, end: 300 }];
+    // Last row is in a transition zone
+    const voltages = [
+      { begin: 0, end: 180, value: '1500V' },
+      { begin: 180, end: 300, value: '' },
+    ];
+
+    const result = computeRowPowerRestrictionStatus(rows, positions, warningRanges, voltages);
+
+    expect(result.get('a')?.hasWarning).toBe(false);
+    expect(result.get('b')?.hasWarning).toBe(false);
+    expect(result.get('b')?.isBlockStart).toBe(false);
+  });
+
+  it('propagates the active restriction along the rows', () => {
+    const rows = [
+      row('a', 0, { isPathStep: true, powerRestriction: 'C1US' }),
+      row('b', 1),
+      row('c', 2, { isPathStep: true, powerRestriction: 'M1US' }),
+      row('d', 3),
+    ];
+    const positions = new Map([
+      [0, 100],
+      [1, 200],
+      [2, 300],
+      [3, 400],
+    ]);
+
+    const result = computeRowPowerRestrictionStatus(rows, positions, [], []);
+
+    expect(result.get('a')?.propagatedValue).toBe('C1US');
+    expect(result.get('b')?.propagatedValue).toBe('C1US');
+    expect(result.get('c')?.propagatedValue).toBe('M1US');
+    expect(result.get('d')?.propagatedValue).toBe('M1US');
+  });
+
+  it('NO_POWER_RESTRICTION resets the propagated value to null', () => {
+    const rows = [
+      row('a', 0, { isPathStep: true, powerRestriction: 'C1US' }),
+      row('b', 1),
+      row('c', 2, {
+        isPathStep: true,
+        powerRestriction: 'NO_POWER_RESTRICTION',
+      }),
+      row('d', 3),
+    ];
+    const positions = new Map([
+      [0, 100],
+      [1, 200],
+      [2, 300],
+      [3, 400],
+    ]);
+
+    const result = computeRowPowerRestrictionStatus(rows, positions, [], []);
+
+    expect(result.get('a')?.propagatedValue).toBe('C1US');
+    expect(result.get('b')?.propagatedValue).toBe('C1US');
+    expect(result.get('c')?.propagatedValue).toBeNull();
+    expect(result.get('d')?.propagatedValue).toBeNull();
+  });
+
+  it('non-pathStep rows do not reset the propagated value', () => {
+    const rows = [
+      row('a', 0, { isPathStep: true, powerRestriction: 'C1US' }),
+      row('b', 1, { isPathStep: false, powerRestriction: null }),
+      row('c', 2),
+    ];
+    const positions = new Map([
+      [0, 100],
+      [1, 200],
+      [2, 300],
+    ]);
+
+    const result = computeRowPowerRestrictionStatus(rows, positions, [], []);
+
+    expect(result.get('b')?.propagatedValue).toBe('C1US');
+    expect(result.get('c')?.propagatedValue).toBe('C1US');
+  });
+
+  it('detects multiple separate blocks', () => {
+    const rows = [row('a', 0), row('b', 1), row('c', 2), row('d', 3), row('e', 4), row('f', 5)];
+    const positions = new Map([
+      [0, 100],
+      [1, 200],
+      [2, 300],
+      [3, 400],
+      [4, 500],
+      [5, 600],
+    ]);
+    // Two separate warning ranges
+    const warningRanges = [
+      { begin: 150, end: 350 }, // covers b, c
+      { begin: 450, end: 650 }, // covers e, f
+    ];
+
+    const result = computeRowPowerRestrictionStatus(rows, positions, warningRanges, []);
+
+    expect(result.get('a')?.hasWarning).toBe(false);
+    expect(result.get('b')?.hasWarning).toBe(true);
+    expect(result.get('b')?.isBlockStart).toBe(true);
+    expect(result.get('c')?.hasWarning).toBe(true);
+    expect(result.get('c')?.isBlockStart).toBe(false);
+    expect(result.get('d')?.hasWarning).toBe(false);
+    expect(result.get('e')?.hasWarning).toBe(true);
+    expect(result.get('e')?.isBlockStart).toBe(true);
+    expect(result.get('f')?.hasWarning).toBe(true);
+    expect(result.get('f')?.isBlockStart).toBe(false);
+  });
+
+  it('uses semi-open interval: begin is inclusive, end is exclusive', () => {
+    const rows = [row('a', 0), row('b', 1), row('c', 2), row('d', 3)];
+    const positions = new Map([
+      [0, 100],
+      [1, 200],
+      [2, 300],
+      [3, 400],
+    ]);
+    // Row at position 200 should be IN (>= begin), row at 400 should be OUT (< end)
+    const warningRanges = [{ begin: 200, end: 400 }];
+
+    const result = computeRowPowerRestrictionStatus(rows, positions, warningRanges, []);
+
+    expect(result.get('a')?.hasWarning).toBe(false); // 100 < 200
+    expect(result.get('b')?.hasWarning).toBe(true); // 200 >= 200
+    expect(result.get('c')?.hasWarning).toBe(true); // 300 >= 200 && < 400
+    expect(result.get('d')?.hasWarning).toBe(false); // 400 not < 400
+  });
+});

--- a/front/src/modules/timesStops/helpers/cellUpdate.ts
+++ b/front/src/modules/timesStops/helpers/cellUpdate.ts
@@ -159,9 +159,9 @@ export const insertScheduleItemInOrder = (
 };
 
 /**
- * Compute optimistic display values for all editable row fields when a cell is edited.
+ * Compute the optimistic display values for all row fields when a cell is edited.
  */
-export const computeOptimisticRowUpdate = (
+export const computeOptimisticRow = (
   row: TimesStopsRowNew,
   edit: OptimisticEdit
 ): Pick<
@@ -212,12 +212,17 @@ export const propagationToEdits = (
   });
 
 /** Build a TrainSchedule object from a Train with updated path and schedule. */
-export const buildUpdatedOccurrence = (
-  selectedTrain: Train,
-  updatedPath: PathItem[],
-  updatedSchedule: ScheduleItem[],
-  trainName: string
-): TrainSchedule => ({
+export const buildUpdatedOccurrence = ({
+  selectedTrain,
+  updatedPath,
+  updatedSchedule,
+  trainName,
+}: {
+  selectedTrain: Train;
+  updatedPath: PathItem[];
+  updatedSchedule: ScheduleItem[];
+  trainName: string;
+}): TrainSchedule => ({
   category: selectedTrain.category,
   comfort: selectedTrain.comfort,
   constraint_distribution: selectedTrain.constraint_distribution,

--- a/front/src/modules/timesStops/helpers/cellUpdate.ts
+++ b/front/src/modules/timesStops/helpers/cellUpdate.ts
@@ -1,6 +1,11 @@
 import { v4 as uuidV4 } from 'uuid';
 
-import type { TrainSchedule, PathItem, ScheduleItem } from 'common/api/osrdEditoastApi';
+import type {
+  TrainSchedule,
+  PathItem,
+  PowerRestrictionItem,
+  ScheduleItem,
+} from 'common/api/osrdEditoastApi';
 import type { Train } from 'reducers/osrdconf/types';
 import { addElementAtIndex } from 'utils/array';
 import { Duration } from 'utils/duration';
@@ -69,7 +74,7 @@ export type ScheduleState = {
  */
 export const applyScheduleEdit = (
   current: ScheduleState,
-  edit: OptimisticEdit
+  edit: Exclude<OptimisticEdit, { field: 'powerRestriction' }>
 ): ScheduleState & { departure: Date | null } => {
   const { arrival, stop } = current;
 
@@ -172,7 +177,19 @@ export const computeOptimisticRow = (
   | 'closedSignal'
   | 'shortSlipDistance'
   | 'requestedTheoreticalMargin'
+  | 'powerRestriction'
 > => {
+  if (edit.field === 'powerRestriction') {
+    return {
+      requestedArrival: row.requestedArrival,
+      stopDuration: row.stopDuration,
+      requestedDeparture: row.requestedDeparture,
+      closedSignal: row.closedSignal,
+      shortSlipDistance: row.shortSlipDistance,
+      requestedTheoreticalMargin: row.requestedTheoreticalMargin,
+      powerRestriction: edit.value,
+    };
+  }
   const { arrival, stop, departure } = applyScheduleEdit(
     { arrival: row.requestedArrival, stop: row.stopDuration },
     edit
@@ -190,6 +207,7 @@ export const computeOptimisticRow = (
       edit.field === 'requestedTheoreticalMargin'
         ? (edit.value ?? undefined)
         : row.requestedTheoreticalMargin,
+    powerRestriction: row.powerRestriction,
   };
 };
 
@@ -211,17 +229,53 @@ export const propagationToEdits = (
     return [{ rowId: row.id, field: 'requestedArrival' as const, value: newArrival }];
   });
 
+/**
+ * Rebuilds the power_restrictions API array from path step rows.
+ * Each non-null powerRestriction on a path step row marks the start of a range.
+ * The range extends until the next path step with an explicit value (or the last path step).
+ *
+ * @example
+ * // rows: [{ id: 'A', powerRestriction: 'C1' }, { id: 'B', powerRestriction: null }, { id: 'C', powerRestriction: '∅' }, { id: 'D', powerRestriction: null }]
+ * // → [{ from: 'A', to: 'C', value: 'C1' }, { from: 'C', to: 'D', value: '∅' }]
+ *
+ * // rows: [{ id: 'A', powerRestriction: null }, { id: 'B', powerRestriction: 'C2' }, { id: 'C', powerRestriction: null }]
+ * // → [{ from: 'B', to: 'C', value: 'C2' }]
+ */
+export const buildPowerRestrictionsFromRows = (
+  rows: TimesStopsRowNew[]
+): PowerRestrictionItem[] => {
+  const pathStepRows = rows.filter((r) => r.isPathStep);
+  const result: PowerRestrictionItem[] = [];
+
+  for (let i = 0; i < pathStepRows.length - 1; i++) {
+    const code = pathStepRows[i].powerRestriction;
+    if (!code) continue;
+
+    const from = pathStepRows[i].id;
+    let j = i + 1;
+    while (j < pathStepRows.length - 1 && !pathStepRows[j].powerRestriction) {
+      j++;
+    }
+    const to = pathStepRows[j].id;
+    result.push({ from, to, value: code });
+  }
+
+  return result;
+};
+
 /** Build a TrainSchedule object from a Train with updated path and schedule. */
 export const buildUpdatedOccurrence = ({
   selectedTrain,
   updatedPath,
   updatedSchedule,
   trainName,
+  powerRestrictions,
 }: {
   selectedTrain: Train;
   updatedPath: PathItem[];
   updatedSchedule: ScheduleItem[];
   trainName: string;
+  powerRestrictions?: PowerRestrictionItem[];
 }): TrainSchedule => ({
   category: selectedTrain.category,
   comfort: selectedTrain.comfort,
@@ -231,7 +285,7 @@ export const buildUpdatedOccurrence = ({
   margins: selectedTrain.margins,
   options: selectedTrain.options,
   path: updatedPath,
-  power_restrictions: selectedTrain.power_restrictions,
+  power_restrictions: powerRestrictions ?? selectedTrain.power_restrictions,
   rolling_stock_name: selectedTrain.rolling_stock_name,
   schedule: updatedSchedule,
   speed_limit_tag: selectedTrain.speed_limit_tag,

--- a/front/src/modules/timesStops/helpers/cellUpdate.ts
+++ b/front/src/modules/timesStops/helpers/cellUpdate.ts
@@ -164,50 +164,42 @@ export const insertScheduleItemInOrder = (
 };
 
 /**
- * Compute the optimistic display values for all row fields when a cell is edited.
+ * Compute the optimistic display values for the fields affected by a cell edit.
+ * Returns only the fields that need to change — the caller is expected to merge
+ * the result with the row (e.g. `{ ...row, ...computeOptimisticRow(row, edit) }`).
  */
 export const computeOptimisticRow = (
   row: TimesStopsRowNew,
   edit: OptimisticEdit
-): Pick<
-  TimesStopsRowNew,
-  | 'requestedArrival'
-  | 'stopDuration'
-  | 'requestedDeparture'
-  | 'closedSignal'
-  | 'shortSlipDistance'
-  | 'requestedTheoreticalMargin'
-  | 'powerRestriction'
+): Partial<
+  Pick<
+    TimesStopsRowNew,
+    | 'requestedArrival'
+    | 'stopDuration'
+    | 'requestedDeparture'
+    | 'closedSignal'
+    | 'shortSlipDistance'
+    | 'requestedTheoreticalMargin'
+    | 'powerRestriction'
+  >
 > => {
   if (edit.field === 'powerRestriction') {
-    return {
-      requestedArrival: row.requestedArrival,
-      stopDuration: row.stopDuration,
-      requestedDeparture: row.requestedDeparture,
-      closedSignal: row.closedSignal,
-      shortSlipDistance: row.shortSlipDistance,
-      requestedTheoreticalMargin: row.requestedTheoreticalMargin,
-      powerRestriction: edit.value,
-    };
+    return { powerRestriction: edit.value };
+  }
+  if (edit.field === 'receptionSignal') {
+    return receptionSignalToSignalBooleans(edit.value);
+  }
+  if (edit.field === 'requestedTheoreticalMargin') {
+    return { requestedTheoreticalMargin: edit.value ?? undefined };
   }
   const { arrival, stop, departure } = applyScheduleEdit(
     { arrival: row.requestedArrival, stop: row.stopDuration },
     edit
   );
-  const checkboxes =
-    edit.field === 'receptionSignal'
-      ? receptionSignalToSignalBooleans(edit.value)
-      : { closedSignal: row.closedSignal, shortSlipDistance: row.shortSlipDistance };
   return {
     requestedArrival: arrival,
     stopDuration: stop,
     requestedDeparture: departure,
-    ...checkboxes,
-    requestedTheoreticalMargin:
-      edit.field === 'requestedTheoreticalMargin'
-        ? (edit.value ?? undefined)
-        : row.requestedTheoreticalMargin,
-    powerRestriction: row.powerRestriction,
   };
 };
 

--- a/front/src/modules/timesStops/helpers/powerRestrictionIncompatibility.ts
+++ b/front/src/modules/timesStops/helpers/powerRestrictionIncompatibility.ts
@@ -1,0 +1,191 @@
+import type { PathPropertiesFormatted } from 'applications/operationalStudies/types';
+import { getPowerRestrictionsWarnings } from 'applications/operationalStudies/views/Scenario/components/ManageTimetableItem/PowerRestrictionsSelector/helpers/powerRestrictionWarnings';
+import type { PowerRestrictionItem, RollingStock } from 'common/api/osrdEditoastApi';
+import { matchPathStepAndOp } from 'modules/pathfinding/utils';
+import { NO_POWER_RESTRICTION } from 'modules/powerRestriction/consts';
+import type { Train } from 'reducers/osrdconf/types';
+
+import type { TimesStopsRowNew } from '../types';
+import { buildPowerRestrictionsFromRows } from './cellUpdate';
+import { buildOpMatchParams } from './utils';
+
+export type PowerRestrictionBlockInfo = {
+  /** The restriction code active at this row position (null if no restriction is active). */
+  propagatedValue: string | null;
+  /** True if this row falls within a warning range (incompatible restriction + electrification). */
+  hasWarning: boolean;
+  /** True if this row is the first row of a contiguous block of warned rows. */
+  isBlockStart: boolean;
+};
+
+/**
+ * For each row, compute its power restriction status:
+ *
+ * 1. **Propagation**: track which restriction code is active at each position
+ *    (follows the path step chain, reset by NO_POWER_RESTRICTION).
+ *
+ * 2. **Warning detection**: check if the row's position falls within a warning
+ *    range (restriction code incompatible with the electrification).
+ *
+ * 3. **Block detection**: group contiguous warned rows into blocks. The first
+ *    row of each block is flagged so the caller can display the propagated value
+ *    there (in a lighter style) for the user to see what causes the warning and
+ *    edit it directly at the boundary.
+ *
+ * 4. **Single-row block dismissal** — blocks containing only one row in an
+ *    electrification transition zone are cleared. These short gaps between two
+ *    voltage systems are not actionable in the table (the GEV provides more detail).
+ *    Real single-row incompatibilities (outside transition zones) are kept.
+ */
+export const computeRowPowerRestrictionStatus = (
+  rows: TimesStopsRowNew[],
+  operationalPointPositions: Map<number, number>,
+  warningRanges: { begin: number; end: number }[],
+  voltages: { begin: number; end: number; value: string }[]
+): Map<string, PowerRestrictionBlockInfo> => {
+  const result = new Map<string, PowerRestrictionBlockInfo>();
+
+  let activeRestriction: string | null = null;
+  let prevHadWarning = false;
+  // Row that opened a block not yet confirmed (waiting for the next row to
+  // know if the block has 2+ rows or is just a single isolated row).
+  let candidateBlockStart: { id: string; position: number | undefined } | null = null;
+
+  // Ignore a candidate single-row block if it falls within an electrification
+  // transition zone (voltage = ""). Real incompatibilities are kept.
+  const ignoreCandidateIfInTransitionZone = () => {
+    if (!candidateBlockStart) return;
+    const { id, position } = candidateBlockStart;
+    const isInTransitionZone =
+      position !== undefined &&
+      voltages.some((v) => v.value === '' && position >= v.begin && position < v.end);
+    if (isInTransitionZone) {
+      const candidate = result.get(id)!;
+      result.set(id, { ...candidate, hasWarning: false, isBlockStart: false });
+    }
+    candidateBlockStart = null;
+  };
+
+  for (const row of rows) {
+    // 1. Update the active restriction when a path step defines one.
+    if (row.isPathStep && row.powerRestriction !== null) {
+      activeRestriction =
+        row.powerRestriction === NO_POWER_RESTRICTION ? null : row.powerRestriction;
+    }
+
+    // 2. Check if this row's position falls within any warning range.
+    const rowPosition = operationalPointPositions.get(row.opOnPathIndex);
+    const hasWarning =
+      rowPosition !== undefined &&
+      warningRanges.some((w) => rowPosition >= w.begin && rowPosition < w.end);
+
+    // 3. Detect block boundaries.
+    const isBlockStart = hasWarning && !prevHadWarning;
+
+    result.set(row.id, {
+      propagatedValue: activeRestriction,
+      hasWarning,
+      isBlockStart,
+    });
+
+    // 4. Dismiss single-row blocks only if they fall within an electrification
+    //    transition zone (voltage = ""). A single row in a real incompatibility
+    //    zone is a legitimate warning and should be kept.
+    if (isBlockStart) {
+      candidateBlockStart = { id: row.id, position: rowPosition };
+    } else if (hasWarning) {
+      // Block has 2+ rows → confirmed, stop tracking.
+      candidateBlockStart = null;
+    } else {
+      ignoreCandidateIfInTransitionZone();
+    }
+
+    prevHadWarning = hasWarning;
+  }
+
+  // Handle a single-row block at the very end of the table.
+  ignoreCandidateIfInTransitionZone();
+
+  return result;
+};
+
+type ComputePowerRestrictionWarningsResult = {
+  blocks: Map<string, PowerRestrictionBlockInfo>;
+  warningCount: number;
+};
+
+const EMPTY_RESULT: ComputePowerRestrictionWarningsResult = {
+  blocks: new Map(),
+  warningCount: 0,
+};
+
+/**
+ * Compute the power restriction incompatibility warnings for each row of the
+ * TimesStopsTable, based on the current restrictions, the electrification
+ * profile along the path, and the rolling stock effort curves.
+ *
+ * Built from the rows (expected to be the optimistic rows) rather than from
+ * `selectedTrain.power_restrictions` so warnings update immediately when the
+ * user edits a cell, before the API round-trip completes.
+ *
+ * The warning count reflects the number of contiguous blocks of incompatible
+ * rows. Each block represents one distinct issue the user needs to resolve,
+ * matching what is visually highlighted in the table.
+ */
+export const computePowerRestrictionWarnings = ({
+  rows,
+  path,
+  operationalPointsOnPath,
+  voltages,
+  rollingStock,
+}: {
+  rows: TimesStopsRowNew[];
+  path: Train['path'];
+  operationalPointsOnPath: PathPropertiesFormatted['operationalPoints'] | undefined;
+  voltages: PathPropertiesFormatted['voltages'] | undefined;
+  rollingStock: RollingStock | undefined;
+}): ComputePowerRestrictionWarningsResult => {
+  const powerRestrictions: PowerRestrictionItem[] = buildPowerRestrictionsFromRows(rows);
+  if (!voltages?.length || !rollingStock || !powerRestrictions.length) return EMPTY_RESULT;
+
+  const pathStepPositions = new Map<string, number>();
+  path.forEach((pathStep) => {
+    const matchingOp = operationalPointsOnPath?.find((op) =>
+      matchPathStepAndOp(pathStep.location, buildOpMatchParams(op))
+    );
+    if (matchingOp) pathStepPositions.set(pathStep.id, matchingOp.position);
+  });
+
+  const ranges: { begin: number; end: number; value: string }[] = powerRestrictions.flatMap(
+    (pr) => {
+      if (pr.value === NO_POWER_RESTRICTION) return [];
+      const begin = pathStepPositions.get(pr.from);
+      const end = pathStepPositions.get(pr.to);
+      if (begin === undefined || end === undefined) return [];
+      return [{ begin, end, value: pr.value }];
+    }
+  );
+
+  if (!ranges.length) return EMPTY_RESULT;
+
+  const warnings = getPowerRestrictionsWarnings(ranges, voltages, rollingStock.effort_curves.modes);
+
+  const warningRanges = [
+    ...warnings.invalidCombinationWarnings,
+    ...warnings.modeNotSupportedWarnings,
+  ];
+
+  const operationalPointPositions = new Map<number, number>(
+    (operationalPointsOnPath ?? []).map((op, idx) => [idx, op.position])
+  );
+
+  const blocks = computeRowPowerRestrictionStatus(
+    rows,
+    operationalPointPositions,
+    warningRanges,
+    voltages
+  );
+  const warningCount = [...blocks.values()].filter((b) => b.isBlockStart).length;
+
+  return { blocks, warningCount };
+};

--- a/front/src/modules/timesStops/hooks/useTimesStopsTableData.ts
+++ b/front/src/modules/timesStops/hooks/useTimesStopsTableData.ts
@@ -9,6 +9,7 @@ import { useScenarioContext } from 'applications/operationalStudies/hooks/useSce
 import type { PathPropertiesFormatted } from 'applications/operationalStudies/types';
 import type {
   PathItemLocation,
+  PowerRestrictionItem,
   SimulationResponseSuccess,
   TrackSection,
   ScheduleItem,
@@ -29,6 +30,23 @@ import {
 } from '../helpers/utils';
 import { type Margins, type StepStatus, type TimesStopsRowNew } from '../types';
 
+/**
+ * Returns the power restriction code that explicitly STARTS at a given path step index,
+ * or null if no restriction starts here (even if one is active from a previous step).
+ */
+const getPowerRestrictionForPathStep = (
+  stepIndex: number,
+  pathIdToIndex: Map<string, number>,
+  powerRestrictions: PowerRestrictionItem[] | undefined
+): string | null => {
+  if (!powerRestrictions) return null;
+  for (const restriction of powerRestrictions) {
+    const fromIndex = pathIdToIndex.get(restriction.from);
+    if (fromIndex === stepIndex) return restriction.value;
+  }
+  return null;
+};
+
 type BuildTableRowParams = {
   id: string;
   opOnPathIndex: number;
@@ -42,6 +60,7 @@ type BuildTableRowParams = {
   invalidPathStep?: boolean;
   scheduleNotHonored?: boolean;
   marginNotHonored?: boolean;
+  powerRestriction?: string | null;
   location: PathItemLocation;
   isPathStep: boolean;
   shortSlipDistance?: boolean;
@@ -62,6 +81,7 @@ const buildTableRow = ({
   invalidPathStep,
   scheduleNotHonored,
   marginNotHonored,
+  powerRestriction = null,
   location,
   isPathStep,
   shortSlipDistance,
@@ -134,7 +154,7 @@ const buildTableRow = ({
     location,
     closedSignal,
     shortSlipDistance,
-    powerRestriction: null, // TODO : Implementation to be done with the integration of the new columns
+    powerRestriction,
     requestedTheoreticalMargin: theoreticalMargin,
     isTheoreticalMarginBoundary: isTheoreticalMarginBoundary,
     computedTheoreticalMarginSeconds: theoreticalMarginSeconds,
@@ -230,6 +250,7 @@ const useTimesStopsTableData = (
   const allRows = useMemo(() => {
     const startDate = new Date(selectedTrain.start_time);
     const scheduleByAt = keyBy(selectedTrain.schedule, 'at');
+    const pathIdToIndex = new Map(selectedTrain.path.map((step, idx) => [step.id, idx]));
 
     const pathStepRowsById = new Map(
       selectedTrain.path.map((pathStep, stepIndex) => {
@@ -286,6 +307,12 @@ const useTimesStopsTableData = (
           schedule?.reception_signal
         );
 
+        const powerRestriction = getPowerRestrictionForPathStep(
+          stepIndex,
+          pathIdToIndex,
+          selectedTrain.power_restrictions
+        );
+
         const row = buildTableRow({
           id: pathStep.id,
           // opOnPathIndex is a placeholder here (-1), it will be replaced by opIndex when matching with operationalPointsOnPath
@@ -300,6 +327,7 @@ const useTimesStopsTableData = (
           invalidPathStep: !matchingOp,
           scheduleNotHonored,
           marginNotHonored,
+          powerRestriction,
           location: pathStep.location,
           isPathStep: true,
           shortSlipDistance,

--- a/front/src/modules/timesStops/hooks/useUpdateTimesStopsTable.ts
+++ b/front/src/modules/timesStops/hooks/useUpdateTimesStopsTable.ts
@@ -33,12 +33,14 @@ import {
   applyScheduleEdit,
   scheduleStateToApiFields,
   buildUpdatedOccurrence,
+  buildPowerRestrictionsFromRows,
   insertScheduleItemInOrder,
 } from '../helpers/cellUpdate';
 import { propagateTime } from '../helpers/timePropagation';
 import type {
   CellUpdate,
   OptimisticEdit,
+  PowerRestrictionUpdate,
   PropagationMode,
   MarginValue,
   TimesStopsRowNew,
@@ -110,7 +112,7 @@ const useUpdateTimesStopsTable = (
    */
   const computeUpdatedPathAndSchedule = useCallback(
     (
-      update: CellUpdate
+      update: Exclude<CellUpdate, PowerRestrictionUpdate>
     ):
       | {
           updatedPath: PathItem[];
@@ -147,7 +149,7 @@ const useUpdateTimesStopsTable = (
       }
 
       // Convert CellUpdate to OptimisticEdit (stopDuration: number → Duration)
-      let edit: OptimisticEdit;
+      let edit: Exclude<OptimisticEdit, { field: 'powerRestriction' }>;
       if (update.field === 'stopDuration') {
         edit = {
           field: 'stopDuration',
@@ -196,6 +198,24 @@ const useUpdateTimesStopsTable = (
   );
 
   /**
+   * Compute the updated path and rebuilt power_restrictions array when a power restriction
+   * cell is edited. The edited row is upserted as a path step (so a new restriction can
+   * be set on a non-path-step waypoint).
+   */
+  const computePowerRestrictionUpdate = (update: PowerRestrictionUpdate) => {
+    const { pathStepId, updatedPath } = upsertPathStep(update.row, selectedTrain.path, allRows);
+    const modifiedRows = allRows.map((r) =>
+      r.id === update.row.id
+        ? { ...r, id: pathStepId, isPathStep: true, powerRestriction: update.value }
+        : r
+    );
+    return {
+      updatedPath,
+      powerRestrictions: buildPowerRestrictionsFromRows(modifiedRows),
+    };
+  };
+
+  /**
    * Handle update when the selected train is an occurrence of a PacedTrain.
    */
   const updateOccurrence = useCallback(
@@ -225,22 +245,34 @@ const useUpdateTimesStopsTable = (
       // exception diff expects the occurrence's computed name.
       const occurrenceTrainName = getOccurrenceTrainName(originalPacedTrain, occurrenceId);
 
-      const result = computeUpdatedPathAndSchedule(update);
-      if (!result) return 'skipped';
-
-      const trainWithUpdatedMargins = {
-        ...selectedTrain,
-        margins: result.updatedMargins,
-      };
-      const updatedOccurrence: TrainSchedule = {
-        ...buildUpdatedOccurrence({
-          selectedTrain: trainWithUpdatedMargins,
-          updatedPath: result.updatedPath,
-          updatedSchedule: result.updatedSchedule,
+      let updatedOccurrence: TrainSchedule;
+      if (update.field === 'powerRestriction') {
+        const { updatedPath, powerRestrictions } = computePowerRestrictionUpdate(update);
+        updatedOccurrence = buildUpdatedOccurrence({
+          selectedTrain,
+          updatedPath,
+          updatedSchedule: selectedTrain.schedule ?? [],
           trainName: occurrenceTrainName,
-        }),
-        start_time: result.updatedStartTime?.toISOString() ?? selectedTrain.start_time,
-      };
+          powerRestrictions,
+        });
+      } else {
+        const result = computeUpdatedPathAndSchedule(update);
+        if (!result) return 'skipped';
+
+        const trainWithUpdatedMargins = {
+          ...selectedTrain,
+          margins: result.updatedMargins,
+        };
+        updatedOccurrence = {
+          ...buildUpdatedOccurrence({
+            selectedTrain: trainWithUpdatedMargins,
+            updatedPath: result.updatedPath,
+            updatedSchedule: result.updatedSchedule,
+            trainName: occurrenceTrainName,
+          }),
+          start_time: result.updatedStartTime?.toISOString() ?? selectedTrain.start_time,
+        };
+      }
 
       const updatedPacedTrain = buildPacedTrainWithUpdatedException(
         originalPacedTrain,
@@ -259,6 +291,16 @@ const useUpdateTimesStopsTable = (
   const updateTimetableItem = useCallback(
     async (trainId: PacedTrainId, update: CellUpdate): Promise<UpdateCellStatus> => {
       const editoastId = extractEditoastIdFromPacedTrainId(trainId);
+
+      if (update.field === 'powerRestriction') {
+        const { updatedPath, powerRestrictions } = computePowerRestrictionUpdate(update);
+        return persistTrain({
+          ...selectedTrain,
+          id: editoastId,
+          path: updatedPath,
+          power_restrictions: powerRestrictions,
+        });
+      }
 
       const result = computeUpdatedPathAndSchedule(update);
       if (!result) return 'skipped';
@@ -325,12 +367,19 @@ const useUpdateTimesStopsTable = (
     [updateCell]
   );
 
+  const updatePowerRestrictions = useCallback(
+    (row: TimesStopsRowNew, powerRestriction: string | null) =>
+      updateCell({ row, field: 'powerRestriction', value: powerRestriction }),
+    [updateCell]
+  );
+
   return {
     updateArrival,
     updateStopDuration,
     updateDeparture,
     updateReceptionSignal,
     updateRequestedMargin,
+    updatePowerRestrictions,
   };
 };
 

--- a/front/src/modules/timesStops/hooks/useUpdateTimesStopsTable.ts
+++ b/front/src/modules/timesStops/hooks/useUpdateTimesStopsTable.ts
@@ -96,6 +96,15 @@ const useUpdateTimesStopsTable = (
     [selectedTrain]
   );
 
+  const persistTrain = async (train: TimetableItem): Promise<'updated'> => {
+    await updateTrainSchedule({
+      id: train.id,
+      trainSchedule: train,
+    }).unwrap();
+    upsertTimetableItems([train]);
+    return 'updated';
+  };
+
   /**
    * Compute the updated path and schedule based on the cell update.
    */
@@ -216,7 +225,6 @@ const useUpdateTimesStopsTable = (
       // exception diff expects the occurrence's computed name.
       const occurrenceTrainName = getOccurrenceTrainName(originalPacedTrain, occurrenceId);
 
-      // Build updated occurrence based on update type
       const result = computeUpdatedPathAndSchedule(update);
       if (!result) return 'skipped';
 
@@ -225,12 +233,12 @@ const useUpdateTimesStopsTable = (
         margins: result.updatedMargins,
       };
       const updatedOccurrence: TrainSchedule = {
-        ...buildUpdatedOccurrence(
-          trainWithUpdatedMargins,
-          result.updatedPath,
-          result.updatedSchedule,
-          occurrenceTrainName
-        ),
+        ...buildUpdatedOccurrence({
+          selectedTrain: trainWithUpdatedMargins,
+          updatedPath: result.updatedPath,
+          updatedSchedule: result.updatedSchedule,
+          trainName: occurrenceTrainName,
+        }),
         start_time: result.updatedStartTime?.toISOString() ?? selectedTrain.start_time,
       };
 
@@ -240,12 +248,7 @@ const useUpdateTimesStopsTable = (
         occurrenceId
       );
 
-      await updateTrainSchedule({
-        id: pacedTrainId,
-        trainSchedule: updatedPacedTrain,
-      }).unwrap();
-      upsertTimetableItems([{ ...updatedPacedTrain, id: pacedTrainId }]);
-      return 'updated';
+      return persistTrain({ ...updatedPacedTrain, id: pacedTrainId });
     },
     [selectedTrain, timetableItemsWithDetails, computeUpdatedPathAndSchedule]
   );
@@ -260,22 +263,14 @@ const useUpdateTimesStopsTable = (
       const result = computeUpdatedPathAndSchedule(update);
       if (!result) return 'skipped';
 
-      const { updatedPath, updatedSchedule } = result;
-      const train: TimetableItem = {
+      return persistTrain({
         ...selectedTrain,
         id: editoastId,
-        path: updatedPath,
-        schedule: updatedSchedule,
+        path: result.updatedPath,
+        schedule: result.updatedSchedule,
         margins: result.updatedMargins,
         start_time: result.updatedStartTime?.toISOString() ?? selectedTrain.start_time,
-      };
-
-      await updateTrainSchedule({
-        id: editoastId,
-        trainSchedule: train,
-      }).unwrap();
-      upsertTimetableItems([train]);
-      return 'updated';
+      });
     },
     [selectedTrain, computeUpdatedPathAndSchedule]
   );

--- a/front/src/modules/timesStops/styles/_timesStopsTable.scss
+++ b/front/src/modules/timesStops/styles/_timesStopsTable.scss
@@ -11,6 +11,23 @@
     pointer-events: none;
   }
 
+  .power-restriction-warning {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    height: 47px;
+    padding-inline: 16px;
+    background: var(--warning5);
+    color: var(--warning60);
+    font-size: 0.875rem;
+    border-bottom: 1px solid var(--black25);
+
+    svg {
+      flex-shrink: 0;
+      color: var(--warning30);
+    }
+  }
+
   .table-container {
     // Because of the virtualization, we have to "opt-out" of the border collapsing:
     // setting spacing to zero and only showing the right and bottom border on every cell
@@ -314,7 +331,7 @@
     }
 
     td.col-power-restriction {
-      min-width: 93px;
+      min-width: 94px;
       padding-inline: 0;
 
       .power-restriction-select-wrapper {
@@ -337,10 +354,6 @@
 
           option {
             color: initial;
-
-            &:checked {
-              color: var(--primary60);
-            }
           }
         }
 
@@ -351,6 +364,28 @@
           transform: translateY(-50%);
           pointer-events: none;
           color: var(--black25);
+        }
+      }
+
+      &.power-restriction-incompatible {
+        background: var(--warning5);
+        // Override the cell's `overflow: hidden` so the ::after border (which
+        // extends 1px outside the cell via `inset: -1px`) is not clipped.
+        overflow: visible;
+
+        // Pseudo-element to draw the warning border independently of the table's
+        // border-collapse algorithm, which produces inconsistent border widths at
+        // non-integer device pixel ratios.
+        &::after {
+          content: '';
+          position: absolute;
+          inset: -1px;
+          border: 1px solid var(--warning30);
+          pointer-events: none;
+        }
+
+        select {
+          color: var(--warning60);
         }
       }
     }
@@ -482,4 +517,3 @@
   height: 16px;
   border-radius: 8px;
 }
-

--- a/front/src/modules/timesStops/styles/_timesStopsTable.scss
+++ b/front/src/modules/timesStops/styles/_timesStopsTable.scss
@@ -313,6 +313,48 @@
       font-size: 0.875rem;
     }
 
+    td.col-power-restriction {
+      min-width: 93px;
+      padding-inline: 0;
+
+      .power-restriction-select-wrapper {
+        position: relative;
+        display: flex;
+        align-items: center;
+        width: 100%;
+        height: 100%;
+
+        select {
+          appearance: none;
+          background: transparent;
+          border: 0;
+          border-radius: 0;
+          width: 100%;
+          min-height: 0;
+          padding: 0 22px 0 12px;
+          font-size: 0.875rem;
+          color: var(--primary60);
+
+          option {
+            color: initial;
+
+            &:checked {
+              color: var(--primary60);
+            }
+          }
+        }
+
+        .power-restriction-arrow {
+          position: absolute;
+          right: 5px;
+          top: 50%;
+          transform: translateY(-50%);
+          pointer-events: none;
+          color: var(--black25);
+        }
+      }
+    }
+
     /* Computed / uncomputed cells */
     td[class^='col-']::before {
       content: '';
@@ -440,3 +482,4 @@
   height: 16px;
   border-radius: 8px;
 }
+

--- a/front/src/modules/timesStops/styles/_timesStopsTable.scss
+++ b/front/src/modules/timesStops/styles/_timesStopsTable.scss
@@ -11,23 +11,6 @@
     pointer-events: none;
   }
 
-  .power-restriction-warning {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    height: 47px;
-    padding-inline: 16px;
-    background: var(--warning5);
-    color: var(--warning60);
-    font-size: 0.875rem;
-    border-bottom: 1px solid var(--black25);
-
-    svg {
-      flex-shrink: 0;
-      color: var(--warning30);
-    }
-  }
-
   .table-container {
     // Because of the virtualization, we have to "opt-out" of the border collapsing:
     // setting spacing to zero and only showing the right and bottom border on every cell
@@ -38,6 +21,27 @@
     td {
       border: 1px solid var(--color-grey-30);
       border-width: 0 1px 1px 0;
+    }
+
+    .power-restriction-warning {
+      caption-side: top;
+      background: var(--warning5);
+      border-bottom: 1px solid var(--black25);
+
+      .power-restriction-warning-content {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        height: 47px;
+        padding-inline: 16px;
+        color: var(--warning60);
+        font-size: 0.875rem;
+
+        svg {
+          flex-shrink: 0;
+          color: var(--warning30);
+        }
+      }
     }
 
     thead {
@@ -355,6 +359,13 @@
           option {
             color: initial;
           }
+        }
+
+        // On the first row of an incompatible block, display the propagated
+        // restriction in a lighter color so it is clearly distinguished from
+        // a restriction explicitly set on this row by the user.
+        &.power-restriction-propagated select {
+          color: var(--grey60);
         }
 
         .power-restriction-arrow {

--- a/front/src/modules/timesStops/types.ts
+++ b/front/src/modules/timesStops/types.ts
@@ -152,19 +152,27 @@ export type RequestedMarginUpdate = {
   value: MarginValue | null;
 };
 
+export type PowerRestrictionUpdate = {
+  row: TimesStopsRowNew;
+  field: 'powerRestriction';
+  value: string | null;
+};
+
 export type CellUpdate =
   | ArrivalUpdate
   | StopDurationUpdate
   | DepartureUpdate
   | ReceptionSignalUpdate
-  | RequestedMarginUpdate;
+  | RequestedMarginUpdate
+  | PowerRestrictionUpdate;
 
 export type OptimisticEdit =
   | { field: 'requestedArrival'; value: Date | null }
   | { field: 'requestedDeparture'; value: Date | null }
   | { field: 'stopDuration'; value: Duration | null }
   | { field: 'receptionSignal'; value: ReceptionSignal | undefined }
-  | { field: 'requestedTheoreticalMargin'; value: MarginValue | null };
+  | { field: 'requestedTheoreticalMargin'; value: MarginValue | null }
+  | { field: 'powerRestriction'; value: string | null };
 
 export type PendingEdit = OptimisticEdit & { rowId: string };
 


### PR DESCRIPTION
closes #15193

## Summary
- Add an editable power restriction column to the new times & stops table with a custom native select, persistence via the API for both unique trains and paced train occurrences
- Show a warning banner and highlight cells when a power restriction code is incompatible with the electrification on its application range
- Refactor cell update helpers (`computeOptimisticRow`, `buildUpdatedOccurrence`) to support the new field

## Details
- Power restriction codes are sourced from the selected rolling stock (`rollingStock.power_restrictions`)
- Restrictions propagate from the selected row until the next row with an explicit value (or end of path)
- Ø (NO_POWER_RESTRICTION) is always available in the dropdown and marks the end of a restriction
- Incompatibility warnings reuse `getPowerRestrictionsWarnings` from `PowerRestrictionsSelector` and are computed from optimistic rows so they update immediately on edit

## How to test
Use a rolling stock with multiple restriction codes (e.g. 1TGVPBA: C1US/C2US/C3US for 1500V, M1US-M4US for 25000V) on a path that crosses voltage zones. Enable "Electrical Profil" and Power restrictions" layers on the SDD to see the voltage zones and applied restrictions.

- [ ] Select a code compatible with the voltage zone at that point → no warning
- [ ] Select a code incompatible with the voltage zone → cell highlighted in warning + banner appears
- [ ] A restriction that spans across a voltage transition generates a warning even if it's compatible at its start point
- [ ] Select Ø after a restriction → no warning on the Ø cell, restriction range ends (visible on GEV)
- [ ] Clear an incompatible cell → warning disappears immediately (before API response)
- [ ] Restriction ranges on the GEV match what's configured in the table
- [ ] Persistence: reload the page, values are preserved
- [ ] Works for both unique trains and paced train occurrences