### PR TITLE
editoast: refactor train schedule exceptions fixtures

### DIFF
--- a/editoast/editoast_models/src/train_schedule_exception.rs
+++ b/editoast/editoast_models/src/train_schedule_exception.rs
@@ -25,6 +25,33 @@ pub struct TrainScheduleException {
     pub change_groups: TrainScheduleExceptionChangeGroups,
 }
 
+#[cfg(any(test, feature = "testing"))]
+impl TrainScheduleException {
+    pub fn fixture_created(key: &str, occurrence_index: Option<i64>) -> Self {
+        Self {
+            id: 1,
+            disabled: false,
+            key: Some(key.into()),
+            occurrence_index,
+            timetable_id: 1,
+            train_schedule_id: 1,
+            change_groups: TrainScheduleExceptionChangeGroups::fixture_created(),
+        }
+    }
+
+    pub fn fixture_modified(key: &str, occurrence_index: i64) -> Self {
+        Self {
+            id: 1,
+            disabled: false,
+            key: Some(key.into()),
+            occurrence_index: Some(occurrence_index),
+            timetable_id: 1,
+            train_schedule_id: 1,
+            change_groups: TrainScheduleExceptionChangeGroups::fixture_modified(),
+        }
+    }
+}
+
 impl From<TrainScheduleException> for schemas::TrainScheduleException {
     fn from(train_schedule_exception: TrainScheduleException) -> Self {
         Self {

--- a/editoast/schemas/src/train_schedule_exception.rs
+++ b/editoast/schemas/src/train_schedule_exception.rs
@@ -58,7 +58,7 @@ pub struct TrainScheduleExceptionChangeGroups {
 
 #[cfg(any(test, feature = "testing"))]
 impl TrainScheduleExceptionChangeGroups {
-    pub fn fake_created() -> Self {
+    pub fn fixture_created() -> Self {
         use std::str::FromStr;
 
         use chrono::DateTime;
@@ -165,8 +165,8 @@ impl TrainScheduleExceptionChangeGroups {
         }
     }
 
-    pub fn fake_modified() -> Self {
-        let mut created = Self::fake_created();
+    pub fn fixture_modified() -> Self {
+        let mut created = Self::fixture_created();
         created.start_time = None;
         created.train_name = Some(TrainNameChangeGroup {
             value: "modified_exception_train_name".to_string(),

--- a/editoast/src/models/fixtures.rs
+++ b/editoast/src/models/fixtures.rs
@@ -22,7 +22,6 @@ use schemas::fixtures::simple_created_exception_with_change_groups;
 use schemas::fixtures::simple_modified_exception_with_change_groups;
 use schemas::infra::InfraObject;
 use schemas::infra::RailJson;
-use schemas::paced_train::ExceptionType;
 use schemas::paced_train::Paced;
 use schemas::paced_train::PacedTrainException;
 use schemas::paced_train::TrainNameChangeGroup;
@@ -106,29 +105,6 @@ async fn link_train_schedule_set_to_timetable(
         .create(conn)
         .await
         .expect("Failed to link train schedule set to timetable")
-}
-
-pub fn create_created_exception_with_change_groups(key: &str) -> PacedTrainException {
-    PacedTrainException {
-        id: None,
-        key: key.into(),
-        exception_type: ExceptionType::Created {},
-        disabled: false,
-        change_groups: TrainScheduleExceptionChangeGroups::fake_created(),
-    }
-}
-
-pub fn create_modified_exception_with_change_groups(
-    key: &str,
-    occurrence_index: usize,
-) -> PacedTrainException {
-    let mut exception = create_created_exception_with_change_groups(key);
-    exception.exception_type = ExceptionType::Modified { occurrence_index };
-    exception.change_groups.start_time = None;
-    exception.change_groups.train_name = Some(TrainNameChangeGroup {
-        value: "modified_exception_train_name".to_string(),
-    });
-    exception
 }
 
 pub fn simple_paced_train_base() -> TrainSchedule {

--- a/editoast/src/models/train_schedule.rs
+++ b/editoast/src/models/train_schedule.rs
@@ -538,8 +538,6 @@ mod tests {
     use std::str::FromStr;
 
     use crate::models::TrainSchedule;
-    use crate::models::fixtures::create_created_exception_with_change_groups;
-    use crate::models::fixtures::create_modified_exception_with_change_groups;
     use crate::models::fixtures::create_timetable;
     use crate::models::fixtures::simple_paced_train_changeset;
     use crate::models::fixtures::simple_sub_category;
@@ -554,7 +552,6 @@ mod tests {
     use pretty_assertions::assert_eq;
     use rstest::rstest;
     use schemas::TrainScheduleExceptionChangeGroups;
-    use schemas::paced_train::PacedTrainException;
     use schemas::paced_train::RollingStockCategoryChangeGroup;
     use schemas::paced_train::StartTimeChangeGroup;
     use schemas::train_schedule::Comfort;
@@ -562,7 +559,7 @@ mod tests {
     use schemas::train_schedule::Margins;
     use schemas::train_schedule::TrainScheduleOptions;
 
-    pub fn create_paced_train(exceptions: Vec<PacedTrainException>) -> TrainSchedule {
+    pub fn create_paced_train() -> TrainSchedule {
         TrainSchedule {
             id: 1,
             train_schedule_set_id: 1,
@@ -588,23 +585,26 @@ mod tests {
             time_window: chrono::Duration::try_hours(2),
             interval: chrono::Duration::try_minutes(30),
             sub_category: None,
-            exceptions,
+            exceptions: vec![],
         }
     }
 
     #[tokio::test]
     async fn paced_train_main_category_apply_exception() {
-        let mut exception = create_created_exception_with_change_groups("key_1");
-
-        exception.change_groups.rolling_stock_category = Some(RollingStockCategoryChangeGroup {
-            value: Some(schemas::rolling_stock::TrainCategory::Main {
-                main_category: schemas::rolling_stock::TrainMainCategory::FastFreightTrain,
+        let mut exception = TrainScheduleException::fixture_created("key_1", None);
+        exception.change_groups = TrainScheduleExceptionChangeGroups {
+            rolling_stock_category: Some(RollingStockCategoryChangeGroup {
+                value: Some(schemas::rolling_stock::TrainCategory::Main {
+                    main_category: schemas::rolling_stock::TrainMainCategory::FastFreightTrain,
+                }),
             }),
-        });
+            ..Default::default()
+        };
 
         // The paced train has HighSpeedTrain
-        let paced_train = create_paced_train(vec![exception.clone()]);
-        let paced_train_exception = paced_train.apply_exception(&exception);
+        let paced_train = create_paced_train();
+
+        let paced_train_exception = paced_train.apply_train_schedule_exception(&exception.into());
 
         // Check if it get replaced by exception category
         assert_eq!(
@@ -617,12 +617,13 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    #[case::created(create_created_exception_with_change_groups("key_1"))]
+    #[case::created(TrainScheduleException::fixture_created("key_1", None))]
     #[tokio::test]
-    #[case::modified(create_modified_exception_with_change_groups("key_2", 0))]
-    async fn paced_train_apply_exception(#[case] exception: PacedTrainException) {
-        let paced_train = create_paced_train(vec![exception.clone()]);
-        let paced_train_exception = paced_train.apply_exception(&exception);
+    #[case::modified(TrainScheduleException::fixture_created("key_2", Some(0)))]
+    async fn paced_train_apply_exception(#[case] exception: TrainScheduleException) {
+        let exception: schemas::TrainScheduleException = exception.into();
+        let paced_train = create_paced_train();
+        let paced_train_exception = paced_train.apply_train_schedule_exception(&exception);
 
         assert_eq!(
             paced_train_exception.train_name,
@@ -707,16 +708,13 @@ mod tests {
 
     #[tokio::test]
     async fn num_base_occurrences_without_exceptions() {
-        let paced_train = create_paced_train(vec![]);
+        let paced_train = create_paced_train();
         assert_eq!(paced_train.num_base_occurrences(), 4);
     }
 
     #[tokio::test]
     async fn num_base_occurrences_with_exceptions() {
-        let paced_train = create_paced_train(vec![
-            create_created_exception_with_change_groups("key_2"),
-            create_modified_exception_with_change_groups("key_1", 0),
-        ]);
+        let paced_train = create_paced_train();
         assert_eq!(paced_train.num_base_occurrences(), 4);
     }
 
@@ -729,7 +727,7 @@ mod tests {
             key: Some("key_1".into()),
             occurrence_index: Some(1),
             disabled: false,
-            change_groups: TrainScheduleExceptionChangeGroups::fake_modified(),
+            change_groups: TrainScheduleExceptionChangeGroups::fixture_modified(),
         }
         .into();
 
@@ -740,7 +738,7 @@ mod tests {
             key: Some("key_2".into()),
             occurrence_index: None,
             disabled: false,
-            change_groups: TrainScheduleExceptionChangeGroups::fake_created(),
+            change_groups: TrainScheduleExceptionChangeGroups::fixture_created(),
         }
         .into();
         let exception_3: schemas::TrainScheduleException = TrainScheduleException {
@@ -750,11 +748,11 @@ mod tests {
             key: Some("key_3".into()),
             occurrence_index: Some(0),
             disabled: true,
-            change_groups: TrainScheduleExceptionChangeGroups::fake_modified(),
+            change_groups: TrainScheduleExceptionChangeGroups::fixture_modified(),
         }
         .into();
 
-        let paced_train = create_paced_train(vec![]);
+        let paced_train = create_paced_train();
         let exceptions: Vec<schemas::TrainScheduleException> = vec![
             exception_1.clone(),
             exception_2.clone(),
@@ -806,7 +804,7 @@ mod tests {
 
     #[tokio::test]
     async fn iter_occurrences_with_modified_start_time_exception() {
-        let mut exception_1 = create_modified_exception_with_change_groups("key_1", 1);
+        let mut exception_1 = TrainScheduleException::fixture_modified("key_1", 1);
         exception_1.change_groups.start_time = Some(StartTimeChangeGroup {
             value: DateTime::<Utc>::from_str("2025-05-15T14:31:00+02:00").unwrap(),
         });
@@ -821,7 +819,7 @@ mod tests {
         }
         .into();
 
-        let paced_train = create_paced_train(vec![]);
+        let paced_train = create_paced_train();
         let occurrences: Vec<_> = paced_train
             .iter_occurrences_v2(std::slice::from_ref(&exception_1))
             .collect();

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -1718,7 +1718,6 @@ mod tests {
 
     use crate::error::InternalError;
     use crate::models;
-    use crate::models::fixtures::create_created_exception_with_change_groups;
     use crate::models::fixtures::create_fast_rolling_stock;
     use crate::models::fixtures::create_paced_train_with_exceptions;
     use crate::models::fixtures::create_simple_paced_train;
@@ -2066,7 +2065,7 @@ mod tests {
             create_fast_rolling_stock(&mut db_pool.get_ok(), "simulation_rolling_stock").await;
         let (timetable, train_schedule_set) =
             create_timetable_with_train_schedule_set(&mut db_pool.get_ok()).await;
-        let exception = create_created_exception_with_change_groups("created_exception_key");
+        let exception = TrainScheduleException::fixture_created("created_exception_key", None);
 
         let train_schedule_base = TrainSchedule {
             train_occurrence: TrainOccurrence {


### PR DESCRIPTION
Part of https://github.com/OpenRailAssociation/osrd/issues/15202

Refactor train schedule exceptions fixtures and test that still use old exceptions types

> [!NOTE]
> This PR targets a feature branch and may contain all its commits, as it has not been rebased yet. Only the last commit need to be reviewed.
