### PR TITLE
front: fix deletion of empty pathStepItem in ItineraryModal

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModal.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModal.tsx
@@ -151,15 +151,13 @@ const ItineraryModal = ({
     commitSelectionForStep(stepId, formatChosenValue(suggestion, chosenCh));
     resetOpSuggestions();
   };
-
-  const isOnlyStep = pathSteps.filter((s) => !isEmptyStep(s, getInputForStep(s.id))).length <= 1;
+  const isOnlyStep = pathSteps.length === 1;
 
   const hasInvalidPathStep = pathSteps.some((step) => {
     if (isEmptyStep(step, getInputForStep(step.id))) return false;
     const meta = pathStepsMetadataById.get(step.id);
     return !meta || meta.isInvalid;
   });
-
   const handleDeletePathStep = (stepId: string) => {
     resetOpSuggestions();
 
@@ -561,7 +559,6 @@ const ItineraryModal = ({
                       (isInvalid || !!previousPathStepMetadata?.isInvalid)
                     }
                     onDelete={() => {
-                      if (isOnlyStep) return;
                       handleDeletePathStep(pathStep.id);
                     }}
                     onOpFocus={() => markEditing(pathStep.id)}

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/PathStepItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/PathStepItem.tsx
@@ -300,10 +300,11 @@ const PathStepItem = ({
           }}
         >
           <span className="counter">{!isTrailingPlaceHolder && index}</span>
-
-          <span className="remove-path-step-icon">
-            <X />
-          </span>
+          {!isOnlyStep && (
+            <span className="remove-path-step-icon">
+              <X />
+            </span>
+          )}
         </button>
 
         {isMapSelectionMode ? (

--- a/front/src/styles/scss/applications/operationalStudies/_itineraryModal.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_itineraryModal.scss
@@ -272,7 +272,7 @@
             }
           }
 
-          .path-step-counter:not(.is-only-step):not(.is-trailing-placeholder):hover {
+          .path-step-counter:not(.is-trailing-placeholder):not(.is-only-step):hover {
             opacity: 1;
             background-color: var(--error60) !important;
 


### PR DESCRIPTION
closes #15949 

reminder for the review: there should always be at least two lines of pathStepItem : the first and the trailing path step. 

edit : we now only want one pathStepItem at the creation of a new itinerary -> we allow the deletion until theres one pathStepItem left