### PR TITLE
editoast: delete exceptions when update train schedule paced field

### DIFF
--- a/editoast/editoast_models/src/train_schedule_exception.rs
+++ b/editoast/editoast_models/src/train_schedule_exception.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::ops::DerefMut;
 
 use database::DbConnection;
 use editoast_derive::Model;
@@ -92,6 +93,23 @@ impl TrainScheduleException {
             .collect();
 
         Ok(exceptions)
+    }
+
+    pub async fn delete_exceptions_for_train_schedule(
+        conn: &mut DbConnection,
+        train_schedule_id: i64,
+    ) -> Result<usize, editoast_models::Error> {
+        use database::tables::train_schedule_exception::dsl;
+        use diesel::prelude::*;
+        use diesel_async::RunQueryDsl;
+
+        let deleted = diesel::delete(
+            dsl::train_schedule_exception.filter(dsl::train_schedule_id.eq(train_schedule_id)),
+        )
+        .execute(conn.write().await.deref_mut())
+        .await?;
+
+        Ok(deleted)
     }
 }
 

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -6350,6 +6350,7 @@ components:
       - $ref: '#/components/schemas/EditoastTrainScheduleExceptionErrorInvalidOccurrenceIndex'
       - $ref: '#/components/schemas/EditoastTrainScheduleExceptionErrorNotFound'
       - $ref: '#/components/schemas/EditoastTrainScheduleExceptionErrorNotPacedTrain'
+      - $ref: '#/components/schemas/EditoastTrainScheduleExceptionErrorOccurrenceIndexAlreadyUsed'
       - $ref: '#/components/schemas/EditoastTrainScheduleExceptionErrorTimetableNotFound'
       - $ref: '#/components/schemas/EditoastTrainScheduleExceptionErrorTrainScheduleNotFound'
       - $ref: '#/components/schemas/EditoastTrainScheduleSetErrorDatabase'
@@ -8746,6 +8747,30 @@ components:
           type: string
           enum:
           - editoast:train_schedule_exception:NotPacedTrain
+    EditoastTrainScheduleExceptionErrorOccurrenceIndexAlreadyUsed:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+          required:
+          - index
+          properties:
+            index:
+              type: string
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 400
+        type:
+          type: string
+          enum:
+          - editoast:train_schedule_exception:OccurrenceIndexAlreadyUsed
     EditoastTrainScheduleExceptionErrorTimetableNotFound:
       type: object
       required:

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -8757,9 +8757,9 @@ components:
         context:
           type: object
           required:
-          - index
+          - occurrence_index
           properties:
-            index:
+            occurrence_index:
               type: string
         message:
           type: string

--- a/editoast/schemas/src/fixtures.rs
+++ b/editoast/schemas/src/fixtures.rs
@@ -1,26 +1,9 @@
 use std::collections::HashMap;
 use std::collections::HashSet;
-use std::str::FromStr;
 
-use chrono::DateTime;
-use chrono::Utc;
 use common::units;
 
 use crate::RollingStock;
-use crate::TrainScheduleExceptionChangeGroups;
-use crate::paced_train::ConstraintDistributionChangeGroup;
-use crate::paced_train::ExceptionType;
-use crate::paced_train::InitialSpeedChangeGroup;
-use crate::paced_train::LabelsChangeGroup;
-use crate::paced_train::OptionsChangeGroup;
-use crate::paced_train::PacedTrainException;
-use crate::paced_train::PathAndScheduleChangeGroup;
-use crate::paced_train::RollingStockCategoryChangeGroup;
-use crate::paced_train::RollingStockChangeGroup;
-use crate::paced_train::SpeedLimitTagChangeGroup;
-use crate::paced_train::StartTimeChangeGroup;
-use crate::paced_train::TrainNameChangeGroup;
-use crate::primitives::NonBlankString;
 use crate::rolling_stock::EffortCurves;
 use crate::rolling_stock::LoadingGaugeType;
 use crate::rolling_stock::RollingResistance;
@@ -28,11 +11,6 @@ use crate::rolling_stock::RollingResistancePerWeight;
 use crate::rolling_stock::TowedRollingStock;
 use crate::rolling_stock::TrainMainCategory;
 use crate::rolling_stock::default_rolling_stock_railjson_version;
-use crate::train_schedule::Comfort;
-use crate::train_schedule::Distribution;
-use crate::train_schedule::MarginValue;
-use crate::train_schedule::Margins;
-use crate::train_schedule::TrainScheduleOptions;
 
 pub fn simple_rolling_stock() -> RollingStock {
     RollingStock {
@@ -105,57 +83,4 @@ pub fn rolling_stock_with_energy_sources() -> RollingStock {
 
 pub fn rolling_stock_with_invalid_effort_curves_json() -> &'static str {
     include_str!("../examples/rolling_stock_invalid_effort_curves.json")
-}
-
-pub fn simple_created_exception_with_change_groups(key: &str) -> PacedTrainException {
-    PacedTrainException {
-        id: None,
-        key: key.into(),
-        exception_type: ExceptionType::Created {},
-        disabled: false,
-        change_groups: TrainScheduleExceptionChangeGroups {
-            train_name: Some(TrainNameChangeGroup {
-                value: "exception_train_name".into(),
-            }),
-            constraint_distribution: Some(ConstraintDistributionChangeGroup {
-                value: Distribution::Mareco,
-            }),
-            initial_speed: Some(InitialSpeedChangeGroup { value: 10.0 }),
-            labels: Some(LabelsChangeGroup {
-                value: vec!["Label 1".to_string(), "Label 3".to_string()],
-            }),
-            options: Some(OptionsChangeGroup {
-                value: TrainScheduleOptions::default(),
-            }),
-            path_and_schedule: Some(PathAndScheduleChangeGroup {
-                power_restrictions: vec![],
-                schedule: vec![],
-                path: vec![],
-                margins: Margins {
-                    boundaries: vec![],
-                    values: vec![MarginValue::Percentage(5.0)],
-                },
-            }),
-            rolling_stock: Some(RollingStockChangeGroup {
-                rolling_stock_name: "TJV".into(),
-                comfort: Comfort::AirConditioning,
-            }),
-            rolling_stock_category: Some(RollingStockCategoryChangeGroup { value: None }),
-            speed_limit_tag: Some(SpeedLimitTagChangeGroup {
-                value: Some(NonBlankString("GB".into())),
-            }),
-            start_time: Some(StartTimeChangeGroup {
-                value: DateTime::<Utc>::from_str("2025-05-05T20:05:00+02:00").unwrap(),
-            }),
-        },
-    }
-}
-
-pub fn simple_modified_exception_with_change_groups(
-    key: &str,
-    occurrence_index: usize,
-) -> PacedTrainException {
-    let mut exception = simple_created_exception_with_change_groups(key);
-    exception.exception_type = ExceptionType::Modified { occurrence_index };
-    exception
 }

--- a/editoast/src/models/fixtures.rs
+++ b/editoast/src/models/fixtures.rs
@@ -18,8 +18,6 @@ use editoast_models::timetable::Timetable;
 use editoast_models::timetable_train_schedule_set::TimetableTrainScheduleSet;
 use editoast_models::train_schedule_exception::TrainScheduleException;
 use schemas::TrainScheduleExceptionChangeGroups;
-use schemas::fixtures::simple_created_exception_with_change_groups;
-use schemas::fixtures::simple_modified_exception_with_change_groups;
 use schemas::infra::InfraObject;
 use schemas::infra::RailJson;
 use schemas::paced_train::Paced;
@@ -113,10 +111,7 @@ pub fn simple_paced_train_base() -> TrainSchedule {
         paced: Some(Paced {
             time_window: ChronoDuration::hours(2).try_into().unwrap(),
             interval: ChronoDuration::minutes(15).try_into().unwrap(),
-            exceptions: vec![
-                simple_created_exception_with_change_groups("exception_key_1"),
-                simple_modified_exception_with_change_groups("exception_key_2", 0),
-            ],
+            exceptions: vec![],
         }),
     }
 }

--- a/editoast/src/models/train_schedule.rs
+++ b/editoast/src/models/train_schedule.rs
@@ -558,7 +558,7 @@ mod tests {
     }
 
     #[test]
-    fn has_same_pace_when_interval_changed() {
+    fn has_not_same_pace_when_interval_changed() {
         let train_schedule = create_paced_train();
         let mut train_schedule_update: schemas::paced_train::TrainSchedule =
             create_paced_train().into();
@@ -568,7 +568,7 @@ mod tests {
     }
 
     #[test]
-    fn has_same_pace_when_time_window_changed() {
+    fn has_not_same_pace_when_time_window_changed() {
         let train_schedule = create_paced_train();
         let mut train_schedule_update: schemas::paced_train::TrainSchedule =
             create_paced_train().into();

--- a/editoast/src/models/train_schedule.rs
+++ b/editoast/src/models/train_schedule.rs
@@ -271,6 +271,12 @@ impl TrainSchedule {
             .chain(self.get_created_occurrences_exceptions(exceptions))
             .sorted_by_key(|(_, ts)| ts.start_time)
     }
+
+    /// Determines whether the pace (time window and interval) of the train schedule is the same as the given pace.
+    pub fn has_same_pace(&self, paced: &Option<Paced>) -> bool {
+        self.interval == paced.as_ref().map(|p| p.interval.into())
+            && self.time_window == paced.as_ref().map(|p| p.time_window.into())
+    }
 }
 
 impl From<paced_train::TrainSchedule> for TrainScheduleChangeset {
@@ -541,6 +547,34 @@ mod tests {
             train_schedule.is_exception_occurrence_index_valid(occurrence_index),
             expected_valid
         );
+    }
+
+    #[test]
+    fn has_same_pace_when_nothing_changed() {
+        let train_schedule = create_paced_train();
+        let train_schedule_update: schemas::paced_train::TrainSchedule =
+            create_paced_train().into();
+        assert!(train_schedule.has_same_pace(&train_schedule_update.paced));
+    }
+
+    #[test]
+    fn has_same_pace_when_interval_changed() {
+        let train_schedule = create_paced_train();
+        let mut train_schedule_update: schemas::paced_train::TrainSchedule =
+            create_paced_train().into();
+        train_schedule_update.paced.as_mut().unwrap().interval =
+            chrono::Duration::minutes(60).try_into().unwrap();
+        assert!(!train_schedule.has_same_pace(&train_schedule_update.paced));
+    }
+
+    #[test]
+    fn has_same_pace_when_time_window_changed() {
+        let train_schedule = create_paced_train();
+        let mut train_schedule_update: schemas::paced_train::TrainSchedule =
+            create_paced_train().into();
+        train_schedule_update.paced.as_mut().unwrap().time_window =
+            chrono::Duration::hours(4).try_into().unwrap();
+        assert!(!train_schedule.has_same_pace(&train_schedule_update.paced));
     }
 
     #[tokio::test]

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -79,7 +79,7 @@ use crate::views::timetable::simulation::train_simulation_batch;
 use crate::views::timetable::track_occupancy;
 use editoast_models::rolling_stock::RollingStock;
 
-#[derive(Debug, Error, EditoastError)]
+#[derive(Debug, Error, EditoastError, derive_more::From)]
 #[editoast_error(base_id = "train_schedule")]
 enum TrainScheduleError {
     #[error("{count} train schedule(s) could not be found")]
@@ -109,7 +109,8 @@ enum TrainScheduleError {
 
     #[error(transparent)]
     #[editoast_error(status = 500)]
-    Database(#[from] editoast_models::Error),
+    #[from(editoast_models::Error, database::DatabaseError)]
+    Database(editoast_models::Error),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -200,11 +201,31 @@ pub(in crate::views) async fn update_train_schedule(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    let conn = &mut db_pool.get().await?;
+    db_pool
+        .get()
+        .await?
+        .transaction(async move |tx| {
+            let train_schedule =
+                models::TrainSchedule::retrieve_or_fail(tx.clone(), train_schedule_id, || {
+                    TrainScheduleError::NotFound { train_schedule_id }
+                })
+                .await?;
+
+            if !train_schedule.has_same_pace(&train_schedule_base.paced) {
+                TrainScheduleException::delete_exceptions_for_train_schedule(
+                    &mut tx.clone(),
+                    train_schedule.id,
+                )
+                .await?;
+            }
+
     let train_schedule_changeset: TrainScheduleChangeset = train_schedule_base.into();
     train_schedule_changeset
-        .update_or_fail(conn, train_schedule_id, || TrainScheduleError::NotFound {
-            train_schedule_id,
+                .update_or_fail(&mut tx.clone(), train_schedule_id, || {
+                    TrainScheduleError::NotFound { train_schedule_id }
+                })
+                .await?;
+            Ok::<_, TrainScheduleError>(())
         })
         .await?;
 

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -219,8 +219,8 @@ pub(in crate::views) async fn update_train_schedule(
                 .await?;
             }
 
-    let train_schedule_changeset: TrainScheduleChangeset = train_schedule_base.into();
-    train_schedule_changeset
+            let train_schedule_changeset: TrainScheduleChangeset = train_schedule_base.into();
+            train_schedule_changeset
                 .update_or_fail(&mut tx.clone(), train_schedule_id, || {
                     TrainScheduleError::NotFound { train_schedule_id }
                 })
@@ -2148,7 +2148,8 @@ mod tests {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
 
-        let train_schedule_set = create_train_schedule_set(&mut pool.get_ok()).await;
+        let (timetable, train_schedule_set) =
+            create_timetable_with_train_schedule_set(&mut pool.get_ok()).await;
         let paced_train =
             create_simple_paced_train(&mut pool.get_ok(), train_schedule_set.id).await;
 
@@ -2159,7 +2160,13 @@ mod tests {
             Duration::minutes(15).try_into().unwrap();
 
         let request = app
-            .put(format!("/train_schedules/{}", paced_train.id).as_str())
+            .put(
+                format!(
+                    "/train_schedules/{}?timetable_id={}",
+                    paced_train.id, timetable.id
+                )
+                .as_str(),
+            )
             .json(&json!(&paced_train_base));
 
         app.fetch(request)

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -2070,6 +2070,80 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn update_paced_train_resets_exceptions_when_interval_changes() {
+        let app = TestAppBuilder::default_app();
+        let pool = app.db_pool();
+
+        let (timetable, train_schedule_set) =
+            create_timetable_with_train_schedule_set(&mut pool.get_ok()).await;
+
+        let simple_train_schedule =
+            simple_paced_train_changeset(train_schedule_set.id).exceptions(vec![]);
+        let train_schedule = simple_train_schedule
+            .create(&mut pool.get_ok())
+            .await
+            .expect("Failed to create paced train");
+
+        let _exception_1 = create_train_schedule_exception(
+            &mut pool.get_ok(),
+            timetable.id,
+            train_schedule.id,
+            None,
+            Some("exception_1".to_string()),
+            None,
+        )
+        .await;
+
+        let _exception_2 = create_train_schedule_exception(
+            &mut pool.get_ok(),
+            timetable.id,
+            train_schedule.id,
+            Some(0),
+            Some("exception_2".to_string()),
+            None,
+        )
+        .await;
+
+        let exceptions_before = TrainScheduleException::retrieve_exceptions_by_train_schedules(
+            &mut pool.get_ok(),
+            timetable.id,
+            vec![train_schedule.id],
+        )
+        .await
+        .expect("Failed to retrieve exceptions before update");
+        assert_eq!(exceptions_before.len(), 2);
+
+        let mut updated_train_schedule = simple_paced_train_base();
+        updated_train_schedule.paced.as_mut().unwrap().interval =
+            chrono::Duration::minutes(30).try_into().unwrap();
+
+        let request = app
+            .put(&format!(
+                "/train_schedules/{}?timetable_id={}",
+                train_schedule.id, timetable.id
+            ))
+            .json(&json!(&updated_train_schedule));
+
+        app.fetch(request)
+            .await
+            .assert_status(StatusCode::NO_CONTENT);
+
+        let exceptions_after = TrainScheduleException::retrieve_exceptions_by_train_schedules(
+            &mut pool.get_ok(),
+            timetable.id,
+            vec![train_schedule.id],
+        )
+        .await
+        .expect("Failed to retrieve exceptions after update");
+
+        assert!(
+            exceptions_after.is_empty(),
+            "Expected exceptions to be reset after interval change, but found {}",
+            exceptions_after.len()
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn update_paced_train() {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();

--- a/editoast/src/views/timetable/train_schedule_exceptions.rs
+++ b/editoast/src/views/timetable/train_schedule_exceptions.rs
@@ -55,17 +55,16 @@ pub enum TrainScheduleExceptionError {
         interval: String,
     },
     #[error(
-        "The occurrence index '{index}' is already used for another exception of the same train schedule"
+        "The occurrence index '{occurrence_index}' is already used for another exception of the same train schedule"
     )]
     #[editoast_error(status = 400)]
-    OccurrenceIndexAlreadyUsed { index: String },
+    OccurrenceIndexAlreadyUsed { occurrence_index: String },
     #[error(transparent)]
     Database(editoast_models::Error),
 }
 
 impl From<editoast_models::Error> for TrainScheduleExceptionError {
     fn from(e: editoast_models::Error) -> Self {
-        dbg!(&e);
         match e {
             editoast_models::Error::UniqueViolation {
                 constraint,
@@ -75,7 +74,9 @@ impl From<editoast_models::Error> for TrainScheduleExceptionError {
                 == "train_schedule_exception_timetable_id_train_schedule_id_occ_key"
                 && column == "timetable_id, train_schedule_id, occurrence_index" =>
             {
-                Self::OccurrenceIndexAlreadyUsed { index: value }
+                Self::OccurrenceIndexAlreadyUsed {
+                    occurrence_index: value,
+                }
             }
             e => Self::Database(e),
         }

--- a/editoast/src/views/timetable/train_schedule_exceptions.rs
+++ b/editoast/src/views/timetable/train_schedule_exceptions.rs
@@ -54,8 +54,32 @@ pub enum TrainScheduleExceptionError {
         time_window: String,
         interval: String,
     },
+    #[error(
+        "The occurrence index '{index}' is already used for another exception of the same train schedule"
+    )]
+    #[editoast_error(status = 400)]
+    OccurrenceIndexAlreadyUsed { index: String },
     #[error(transparent)]
-    Database(#[from] editoast_models::Error),
+    Database(editoast_models::Error),
+}
+
+impl From<editoast_models::Error> for TrainScheduleExceptionError {
+    fn from(e: editoast_models::Error) -> Self {
+        dbg!(&e);
+        match e {
+            editoast_models::Error::UniqueViolation {
+                constraint,
+                column,
+                value,
+            } if constraint
+                == "train_schedule_exception_timetable_id_train_schedule_id_occ_key"
+                && column == "timetable_id, train_schedule_id, occurrence_index" =>
+            {
+                Self::OccurrenceIndexAlreadyUsed { index: value }
+            }
+            e => Self::Database(e),
+        }
+    }
 }
 
 #[derive(IntoParams, Deserialize)]
@@ -165,7 +189,8 @@ pub(in crate::views) async fn create_train_schedule_exception(
         train_schedule_exception_changeset.timetable_id(timetable_id);
     let train_schedule_exception: TrainScheduleException = train_schedule_exception_changeset
         .create(conn)
-        .await?
+        .await
+        .map_err(TrainScheduleExceptionError::from)?
         .into();
 
     Ok(Json(train_schedule_exception))
@@ -375,6 +400,50 @@ mod tests {
             &response.error_type,
             "editoast:train_schedule_exception:InvalidOccurrenceIndex"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn train_schedule_exception_duplicated_occurrence_index_post() {
+        let app = TestAppBuilder::default_app();
+        let pool = app.db_pool();
+
+        let mut conn = pool.get_ok();
+
+        let (timetable, train_schedule) = create_timetable_with_simple_paced_train(&mut conn).await;
+
+        let _train_schedule_exception_1 = create_train_schedule_exception(
+            &mut pool.get_ok(),
+            timetable.id,
+            train_schedule.id,
+            Some(0),
+            None,
+            None,
+        )
+        .await;
+
+        let train_schedule_exception_form: TrainScheduleExceptionForm =
+            TrainScheduleExceptionForm {
+                train_schedule_id: train_schedule.id,
+                occurrence_index: Some(0),
+                disabled: false,
+                change_groups: TrainScheduleExceptionChangeGroups::fixture_modified(),
+            };
+
+        // Insert train schedule exception
+        let request = app
+            .post(format!("/timetable/{}/train_schedule_exception", timetable.id).as_str())
+            .json(&json!(&train_schedule_exception_form));
+
+        let response: InternalError = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::BAD_REQUEST)
+            .json_into();
+
+        assert_eq!(
+            &response.error_type,
+            "editoast:train_schedule_exception:OccurrenceIndexAlreadyUsed"
+        )
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -291,9 +291,9 @@
       "BatchNotFound": "'{{count}}' train schedule exception(s) could not be found",
       "Database": "Internal error (database)",
       "InvalidOccurrenceIndex": "Occurrence index '{{occurrence_index}}' is invalid for train schedule '{{train_schedule_id}}' with time window '{{time_window}}' and interval '{{interval}}'",
-      "OccurrenceIndexAlreadyUsed": "The occurrence index '{{occurrence_index}}' is already used for another exception of the same train schedule",
       "NotFound": "Train schedule exception '{{exception_id}}' could not be found",
       "NotPacedTrain": "Train schedule '{{train_schedule_id}}' is not a paced train",
+      "OccurrenceIndexAlreadyUsed": "The occurrence index '{{occurrence_index}}' is already used for another exception of the same train schedule",
       "TimetableNotFound": "Timetable '{{timetable_id}}' could not be found",
       "TrainScheduleNotFound": "Train schedule '{{train_schedule_id}}' could not be found"
     },

--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -291,6 +291,7 @@
       "BatchNotFound": "'{{count}}' train schedule exception(s) could not be found",
       "Database": "Internal error (database)",
       "InvalidOccurrenceIndex": "Occurrence index '{{occurrence_index}}' is invalid for train schedule '{{train_schedule_id}}' with time window '{{time_window}}' and interval '{{interval}}'",
+      "OccurrenceIndexAlreadyUsed": "The occurrence index '{{occurrence_index}}' is already used for another exception of the same train schedule",
       "NotFound": "Train schedule exception '{{exception_id}}' could not be found",
       "NotPacedTrain": "Train schedule '{{train_schedule_id}}' is not a paced train",
       "TimetableNotFound": "Timetable '{{timetable_id}}' could not be found",

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -291,9 +291,9 @@
       "BatchNotFound": "'{{count}}' exception(s) non trouvée(s)",
       "Database": "Erreur interne (base de données)",
       "InvalidOccurrenceIndex": "L'index d'occurrence '{{occurrence_index}}' est invalide pour la circulation '{{train_schedule_id}}' avec une fenêtre temporelle de '{{time_window}}' et un intervalle de '{{interval}}'",
-      "OccurrenceIndexAlreadyUsed": "L'index d'occurrence '{{occurrence_index}}' est déjà utilisé pour une autre exception de la même circulation",
       "NotFound": "Exception '{{exception_id}}' non trouvée",
       "NotPacedTrain": "La circulation '{{train_schedule_id}}' n'est pas une mission",
+      "OccurrenceIndexAlreadyUsed": "L'index d'occurrence '{{occurrence_index}}' est déjà utilisé pour une autre exception de la même circulation",
       "TimetableNotFound": "Grille horaire '{{timetable_id}}' non trouvée",
       "TrainScheduleNotFound": "La circulation '{{train_schedule_id}}' n’a pas été trouvée"
     },

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -291,6 +291,7 @@
       "BatchNotFound": "'{{count}}' exception(s) non trouvée(s)",
       "Database": "Erreur interne (base de données)",
       "InvalidOccurrenceIndex": "L'index d'occurrence '{{occurrence_index}}' est invalide pour la circulation '{{train_schedule_id}}' avec une fenêtre temporelle de '{{time_window}}' et un intervalle de '{{interval}}'",
+      "OccurrenceIndexAlreadyUsed": "L'index d'occurrence '{{occurrence_index}}' est déjà utilisé pour une autre exception de la même circulation",
       "NotFound": "Exception '{{exception_id}}' non trouvée",
       "NotPacedTrain": "La circulation '{{train_schedule_id}}' n'est pas une mission",
       "TimetableNotFound": "Grille horaire '{{timetable_id}}' non trouvée",

--- a/front/src/common/api/osrdRailwayManagerApi.ts
+++ b/front/src/common/api/osrdRailwayManagerApi.ts
@@ -128,22 +128,22 @@ export type Items2 = {
 };
 export type Comfort = 'STANDARD' | 'AIR_CONDITIONING' | 'HEATING';
 export type ComponentsSchemasTransformTimetableResponsePropertiesPacedTrainsItemsAllOf0PropertiesCategoryOneOf1 =
-  | {
-      main_category:
-        | 'HIGH_SPEED_TRAIN'
-        | 'INTERCITY_TRAIN'
-        | 'REGIONAL_TRAIN'
-        | 'NIGHT_TRAIN'
-        | 'COMMUTER_TRAIN'
-        | 'FREIGHT_TRAIN'
-        | 'FAST_FREIGHT_TRAIN'
-        | 'TRAM_TRAIN'
-        | 'TOURISTIC_TRAIN'
-        | 'WORK_TRAIN';
-    }
-  | {
-      sub_category_code: string;
-    };
+    | {
+        main_category:
+          | 'HIGH_SPEED_TRAIN'
+          | 'INTERCITY_TRAIN'
+          | 'REGIONAL_TRAIN'
+          | 'NIGHT_TRAIN'
+          | 'COMMUTER_TRAIN'
+          | 'FREIGHT_TRAIN'
+          | 'FAST_FREIGHT_TRAIN'
+          | 'TRAM_TRAIN'
+          | 'TOURISTIC_TRAIN'
+          | 'WORK_TRAIN';
+      }
+    | {
+        sub_category_code: string;
+      };
 export type TransformTimetableResponse = {
   /** List of paced trains */
   paced_trains: ({

--- a/front/tests/02-operational-studies/paced-trains/003-paced-train-occurrence-edition.spec.ts
+++ b/front/tests/02-operational-studies/paced-trains/003-paced-train-occurrence-edition.spec.ts
@@ -69,7 +69,7 @@ test.describe(
           infra.id
         );
         scenarioItems = scenario;
-    const trainsSubset = trains.slice(0, 6);
+        const trainsSubset = trains.slice(0, 6);
         await sendTrains(trainScheduleSet.id, trainsSubset, scenarioItems.timetable_id);
       }
     );


### PR DESCRIPTION
Part of https://github.com/OpenRailAssociation/osrd/issues/15202

- [x] When paced is updated, delete all the exceptions
- [x] Tests


> [!NOTE]
> This PR targets a feature branch and may contain all its commits, as it has not been rebased yet. Only the last commit need to be reviewed.