### PR TITLE
core: implement OffsetRangeMap to replace DistanceRangeMap when solely using offsets to index

### DIFF
--- a/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/DriverBehaviour.kt
+++ b/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/DriverBehaviour.kt
@@ -4,8 +4,9 @@ import fr.sncf.osrd.envelope.Envelope
 import fr.sncf.osrd.envelope.MRSPEnvelopeBuilder
 import fr.sncf.osrd.envelope.part.EnvelopePart
 import fr.sncf.osrd.envelope_sim.EnvelopeProfile
-import fr.sncf.osrd.utils.DistanceRangeMap
-import fr.sncf.osrd.utils.distanceRangeMapOf
+import fr.sncf.osrd.path.interfaces.PhysicsPath
+import fr.sncf.osrd.utils.OffsetRangeMap
+import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import kotlin.math.max
 import kotlin.math.min
@@ -18,18 +19,26 @@ data class DriverBehaviour(
     /** Applies the driver behavior to the MRSP, adding reaction time for MRSP changes */
     fun applyToMRSP(
         mrsp: Envelope,
-        optSignalingSystemRanges: DistanceRangeMap<String>? = null,
+        optSignalingSystemRanges: OffsetRangeMap<PhysicsPath, String>? = null,
     ): Envelope {
-        val signalingSystemRanges = optSignalingSystemRanges ?: distanceRangeMapOf()
+        val signalingSystemRanges = optSignalingSystemRanges ?: OffsetRangeMap()
         val builder = MRSPEnvelopeBuilder()
         val totalLength = mrsp.totalDistance
         for (part in mrsp) {
             var begin = part.beginPos
             var end = part.endPos
             // compute driver behaviour offsets
-            if (signalingSystems.contains(signalingSystemRanges.get(begin.meters) ?: ""))
+            if (
+                signalingSystems.contains(
+                    signalingSystemRanges.get(Offset<PhysicsPath>(begin.meters)) ?: ""
+                )
+            )
                 begin -= this.brakingAnticipationOffset
-            if (signalingSystems.contains(signalingSystemRanges.get(end.meters) ?: ""))
+            if (
+                signalingSystems.contains(
+                    signalingSystemRanges.get(Offset<PhysicsPath>(end.meters)) ?: ""
+                )
+            )
                 end += this.acceleratingPostponementOffset
             begin = max(0.0, begin)
             end = min(totalLength, end)

--- a/core/envelope-sim/src/test/kotlin/fr/sncf/osrd/envelope_sim/EnvelopeSimPathTest.kt
+++ b/core/envelope-sim/src/test/kotlin/fr/sncf/osrd/envelope_sim/EnvelopeSimPathTest.kt
@@ -1,10 +1,14 @@
 package fr.sncf.osrd.envelope_sim
 
 import fr.sncf.osrd.path.implementations.EnvelopeSimPath
+import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.path.legacy_objects.electrification.Electrified
 import fr.sncf.osrd.path.legacy_objects.electrification.NonElectrified
 import fr.sncf.osrd.utils.DistanceRangeMap
+import fr.sncf.osrd.utils.OffsetRangeMap
 import fr.sncf.osrd.utils.distanceRangeMapOf
+import fr.sncf.osrd.utils.offsetRangeMapOf
+import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
@@ -69,7 +73,11 @@ class EnvelopeSimPathTest {
         val path = EnvelopeSimPathBuilder.withElectricalProfiles1500()
         val modeAndProfileMap =
             if (withEmptyPowerRestrictionMap)
-                path.getElectrificationMap("2", distanceRangeMapOf(), mapOf("Restrict1" to "1"))
+                path.getElectrificationMap(
+                    "2",
+                    offsetRangeMapOf<PhysicsPath, String>(),
+                    mapOf("Restrict1" to "1"),
+                )
             else path.getElectrificationMap("2", null, mapOf("Restrict1" to "1"))
 
         Assertions.assertTrue(modeAndProfileMap.fullyCovers(path.length.meters))
@@ -87,7 +95,13 @@ class EnvelopeSimPathTest {
         val path = EnvelopeSimPathBuilder.withElectricalProfiles1500()
 
         val powerRestrictionMap =
-            distanceRangeMapOf(DistanceRangeMap.RangeMapEntry(2.5.meters, 6.5.meters, "Restrict2"))
+            offsetRangeMapOf(
+                OffsetRangeMap.RangeMapEntry(
+                    Offset<PhysicsPath>(2.5.meters),
+                    Offset(6.5.meters),
+                    "Restrict2",
+                )
+            )
 
         val modeAndProfileMap =
             path.getElectrificationMap("1", powerRestrictionMap, mapOf("Restrict2" to "2"))
@@ -125,7 +139,13 @@ class EnvelopeSimPathTest {
         val path = EnvelopeSimPathBuilder.withElectricalProfiles1500()
 
         val powerRestrictionMap =
-            distanceRangeMapOf(DistanceRangeMap.RangeMapEntry(2.5.meters, 6.5.meters, "Restrict2"))
+            offsetRangeMapOf(
+                OffsetRangeMap.RangeMapEntry(
+                    Offset<PhysicsPath>(2.5.meters),
+                    Offset(6.5.meters),
+                    "Restrict2",
+                )
+            )
 
         val modeAndProfileMap =
             path.getElectrificationMap("1", powerRestrictionMap, mapOf("Restrict2" to "2"), true)

--- a/core/envelope-sim/src/testFixtures/java/fr/sncf/osrd/envelope_sim/FlatPath.kt
+++ b/core/envelope-sim/src/testFixtures/java/fr/sncf/osrd/envelope_sim/FlatPath.kt
@@ -3,6 +3,7 @@ package fr.sncf.osrd.envelope_sim
 import fr.sncf.osrd.path.interfaces.Electrification
 import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.utils.DistanceRangeMap
+import fr.sncf.osrd.utils.OffsetRangeMap
 
 class FlatPath(override val length: Double, private val slope: Double) : PhysicsPath {
     override fun getAverageGrade(begin: Double, end: Double): Double {
@@ -15,7 +16,7 @@ class FlatPath(override val length: Double, private val slope: Double) : Physics
 
     override fun getElectrificationMap(
         basePowerClass: String?,
-        powerRestrictionMap: DistanceRangeMap<String>?,
+        powerRestrictionMap: OffsetRangeMap<PhysicsPath, String>?,
         powerRestrictionToPowerClass: Map<String, String>?,
         ignoreElectricalProfiles: Boolean,
     ): DistanceRangeMap<Electrification> {

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/EnvelopeSimPath.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/EnvelopeSimPath.kt
@@ -3,6 +3,7 @@ package fr.sncf.osrd.path.implementations
 import fr.sncf.osrd.path.interfaces.Electrification
 import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.utils.DistanceRangeMap
+import fr.sncf.osrd.utils.OffsetRangeMap
 import fr.sncf.osrd.utils.arePositionsEqual
 import fr.sncf.osrd.utils.entries
 import fr.sncf.osrd.utils.units.Distance
@@ -149,7 +150,7 @@ class EnvelopeSimPath(
     /** Get the electrification related data for a given power class and power restriction map. */
     override fun getElectrificationMap(
         basePowerClass: String?,
-        powerRestrictionMap: DistanceRangeMap<String>?,
+        powerRestrictionMap: OffsetRangeMap<PhysicsPath, String>?,
         powerRestrictionToPowerClass: Map<String, String>?,
         ignoreElectricalProfiles: Boolean,
     ): DistanceRangeMap<Electrification> {
@@ -159,7 +160,12 @@ class EnvelopeSimPath(
         powerRestrictionMap?.forEach { lower, upper, restriction ->
             val powerClass = powerRestrictionToPowerClass?.getOrDefault(restriction, basePowerClass)
             val modeAndProfileMap =
-                getModeAndProfileMap(powerClass, lower, upper, ignoreElectricalProfiles)
+                getModeAndProfileMap(
+                    powerClass,
+                    lower.distance,
+                    upper.distance,
+                    ignoreElectricalProfiles,
+                )
             for (modeAndProfileEntry in modeAndProfileMap) {
                 val electrification = modeAndProfileEntry.value
                 res.put(

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/SubPhysicsPath.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/SubPhysicsPath.kt
@@ -1,10 +1,11 @@
 package fr.sncf.osrd.path.implementations
 
-import com.google.common.collect.ImmutableRangeMap
 import fr.sncf.osrd.path.interfaces.Electrification
 import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.utils.DistanceRangeMap
+import fr.sncf.osrd.utils.OffsetRangeMap
 import fr.sncf.osrd.utils.distanceRangeMapOf
+import fr.sncf.osrd.utils.offsetRangeMapOf
 import fr.sncf.osrd.utils.units.meters
 
 class SubPhysicsPath(val begin: Double, val end: Double, val path: PhysicsPath) : PhysicsPath {
@@ -33,21 +34,20 @@ class SubPhysicsPath(val begin: Double, val end: Double, val path: PhysicsPath) 
 
     override fun getElectrificationMap(
         basePowerClass: String?,
-        powerRestrictionMap: DistanceRangeMap<String>?,
+        powerRestrictionMap: OffsetRangeMap<PhysicsPath, String>?,
         powerRestrictionToPowerClass: Map<String, String>?,
         ignoreElectricalProfiles: Boolean,
     ): DistanceRangeMap<Electrification> {
-        val powerRestrictionMapBuilder = ImmutableRangeMap.Builder<Double, String>()
         val newPowerRestrictionMap =
             powerRestrictionMap
                 ?.map {
-                    DistanceRangeMap.RangeMapEntry(
+                    OffsetRangeMap.RangeMapEntry(
                         it.lower + begin.meters,
                         it.upper + begin.meters,
                         it.value,
                     )
                 }
-                ?.let { distanceRangeMapOf(it) }
+                ?.let { offsetRangeMapOf(it) }
         val electrificationMap =
             path.getElectrificationMap(
                 basePowerClass,

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathImpl.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathImpl.kt
@@ -8,6 +8,7 @@ import fr.sncf.osrd.sim_infra.impl.TemporarySpeedLimitManager
 import fr.sncf.osrd.sim_infra.impl.makeDirChunk
 import fr.sncf.osrd.utils.Direction
 import fr.sncf.osrd.utils.DistanceRangeMap
+import fr.sncf.osrd.utils.OffsetRangeMap
 import fr.sncf.osrd.utils.distanceRangeMapOf
 import fr.sncf.osrd.utils.indexing.DirStaticIdx
 import fr.sncf.osrd.utils.units.Distance
@@ -149,7 +150,7 @@ data class TrainPathImpl(
 
     override fun getElectrificationMap(
         basePowerClass: String?,
-        powerRestrictionMap: DistanceRangeMap<String>?,
+        powerRestrictionMap: OffsetRangeMap<PhysicsPath, String>?,
         powerRestrictionToPowerClass: Map<String, String>?,
         ignoreElectricalProfiles: Boolean,
     ): DistanceRangeMap<Electrification> {

--- a/core/kt-osrd-path/src/test/kotlin/fr/sncf/osrd/path/SubPhysicsPathTest.kt
+++ b/core/kt-osrd-path/src/test/kotlin/fr/sncf/osrd/path/SubPhysicsPathTest.kt
@@ -4,7 +4,10 @@ import fr.sncf.osrd.path.implementations.SubPhysicsPath
 import fr.sncf.osrd.path.interfaces.Electrification
 import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.utils.DistanceRangeMap
+import fr.sncf.osrd.utils.OffsetRangeMap
 import fr.sncf.osrd.utils.distanceRangeMapOf
+import fr.sncf.osrd.utils.offsetRangeMapOf
+import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -27,7 +30,7 @@ class SubPhysicsPathTest {
         var lastAverageGradeCall: Pair<Double, Double>? = null
         var lastMinGradeCall: Pair<Double, Double>? = null
         var lastBasePowerClass: String? = null
-        var lastPowerRestrictionMap: DistanceRangeMap<String>? = null
+        var lastPowerRestrictionMap: OffsetRangeMap<PhysicsPath, String>? = null
         var lastPowerRestrictionToPowerClass: Map<String, String>? = null
         var lastIgnoreElectricalProfiles: Boolean? = null
 
@@ -43,7 +46,7 @@ class SubPhysicsPathTest {
 
         override fun getElectrificationMap(
             basePowerClass: String?,
-            powerRestrictionMap: DistanceRangeMap<String>?,
+            powerRestrictionMap: OffsetRangeMap<PhysicsPath, String>?,
             powerRestrictionToPowerClass: Map<String, String>?,
             ignoreElectricalProfiles: Boolean,
         ): DistanceRangeMap<Electrification> {
@@ -141,11 +144,15 @@ class SubPhysicsPathTest {
         val subPath = SubPhysicsPath(begin = 100.0, end = 300.0, path = path)
 
         val inputRestrictionMap =
-            distanceRangeMapOf(
-                DistanceRangeMap.RangeMapEntry(0.0.meters, 10.0.meters, "r1"),
-                DistanceRangeMap.RangeMapEntry(11.0.meters, 20.0.meters, "r2"),
-                DistanceRangeMap.RangeMapEntry(21.0.meters, 30.0.meters, "r3"),
-                DistanceRangeMap.RangeMapEntry(31.0.meters, 40.0.meters, "r4"),
+            offsetRangeMapOf(
+                OffsetRangeMap.RangeMapEntry(
+                    Offset<PhysicsPath>(0.0.meters),
+                    Offset(10.0.meters),
+                    "r1",
+                ),
+                OffsetRangeMap.RangeMapEntry(Offset(11.0.meters), Offset(20.0.meters), "r2"),
+                OffsetRangeMap.RangeMapEntry(Offset(21.0.meters), Offset(30.0.meters), "r3"),
+                OffsetRangeMap.RangeMapEntry(Offset(31.0.meters), Offset(40.0.meters), "r4"),
             )
         val powerClassMap = mapOf("r1" to "A", "r2" to "B")
 
@@ -165,10 +172,14 @@ class SubPhysicsPathTest {
         assertNotNull(forwardedRestrictions)
         assertEquals(
             listOf(
-                DistanceRangeMap.RangeMapEntry(100.0.meters, 110.0.meters, "r1"),
-                DistanceRangeMap.RangeMapEntry(111.0.meters, 120.0.meters, "r2"),
-                DistanceRangeMap.RangeMapEntry(121.0.meters, 130.0.meters, "r3"),
-                DistanceRangeMap.RangeMapEntry(131.0.meters, 140.0.meters, "r4"),
+                OffsetRangeMap.RangeMapEntry(
+                    Offset<PhysicsPath>(100.0.meters),
+                    Offset(110.0.meters),
+                    "r1",
+                ),
+                OffsetRangeMap.RangeMapEntry(Offset(111.0.meters), Offset(120.0.meters), "r2"),
+                OffsetRangeMap.RangeMapEntry(Offset(121.0.meters), Offset(130.0.meters), "r3"),
+                OffsetRangeMap.RangeMapEntry(Offset(131.0.meters), Offset(140.0.meters), "r4"),
             ),
             forwardedRestrictions.toList(),
         )

--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/path/interfaces/PhysicsPath.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/path/interfaces/PhysicsPath.kt
@@ -1,6 +1,7 @@
 package fr.sncf.osrd.path.interfaces
 
 import fr.sncf.osrd.utils.DistanceRangeMap
+import fr.sncf.osrd.utils.OffsetRangeMap
 
 /**
  * A [PhysicsPath] describes the physics of a path taken by a train.
@@ -21,7 +22,7 @@ interface PhysicsPath {
     /** Get the electrification related data for a given power class and power restriction map. */
     fun getElectrificationMap(
         basePowerClass: String?,
-        powerRestrictionMap: DistanceRangeMap<String>?,
+        powerRestrictionMap: OffsetRangeMap<PhysicsPath, String>?,
         powerRestrictionToPowerClass: Map<String, String>?,
         ignoreElectricalProfiles: Boolean = false,
     ): DistanceRangeMap<Electrification>

--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/OffsetRangeMap.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/OffsetRangeMap.kt
@@ -1,0 +1,115 @@
+package fr.sncf.osrd.utils
+
+import fr.sncf.osrd.utils.units.Distance
+import fr.sncf.osrd.utils.units.Offset
+import kotlin.jvm.JvmInline
+
+@JvmInline
+value class OffsetRangeMap<OffsetType, ValueType>(
+    private val distanceRangeMap: DistanceRangeMap<ValueType> = distanceRangeMapOf()
+) : Iterable<OffsetRangeMap.RangeMapEntry<OffsetType, ValueType>> {
+
+    data class RangeMapEntry<OffsetType, ValueType>(
+        val lower: Offset<OffsetType>,
+        val upper: Offset<OffsetType>,
+        val value: ValueType,
+    )
+
+    fun put(lower: Offset<OffsetType>, upper: Offset<OffsetType>, value: ValueType) =
+        distanceRangeMap.put(lower.distance, upper.distance, value)
+
+    fun putMany(entries: Iterable<RangeMapEntry<OffsetType, ValueType>>) {
+        distanceRangeMap.putMany(
+            entries
+                .asSequence()
+                .map {
+                    DistanceRangeMap.RangeMapEntry(it.lower.distance, it.upper.distance, it.value)
+                }
+                .asIterable()
+        )
+    }
+
+    fun lowerBound(): Offset<OffsetType> = Offset(distanceRangeMap.lowerBound())
+
+    fun upperBound(): Offset<OffsetType> = Offset(distanceRangeMap.upperBound())
+
+    fun truncate(begin: Offset<OffsetType>, end: Offset<OffsetType>) =
+        distanceRangeMap.truncate(begin.distance, end.distance)
+
+    fun shiftPositions(delta: Distance): OffsetRangeMap<OffsetType, ValueType> {
+        distanceRangeMap.shiftPositions(delta)
+        return this
+    }
+
+    fun get(offset: Offset<OffsetType>): ValueType? = distanceRangeMap.get(offset.distance)
+
+    fun clone(): OffsetRangeMap<OffsetType, ValueType> = OffsetRangeMap(distanceRangeMap.clone())
+
+    fun subMap(
+        lower: Offset<OffsetType>,
+        upper: Offset<OffsetType>,
+    ): OffsetRangeMap<OffsetType, ValueType> =
+        OffsetRangeMap(distanceRangeMap.subMap(lower.distance, upper.distance))
+
+    fun <U> updateMapIntersection(
+        update: OffsetRangeMap<OffsetType, U>,
+        updateFunction: (ValueType, U) -> ValueType,
+    ) = distanceRangeMap.updateMapIntersection(update.distanceRangeMap, updateFunction)
+
+    fun updateMap(
+        update: OffsetRangeMap<OffsetType, ValueType>,
+        updateFunction: (ValueType, ValueType) -> ValueType,
+        default: (ValueType) -> ValueType = { it },
+    ) = distanceRangeMap.updateMap(update.distanceRangeMap, updateFunction, default)
+
+    fun mapToRangeSet(f: (ValueType) -> Boolean): DistanceRangeSet =
+        distanceRangeMap.mapToRangeSet(f)
+
+    fun isEmpty(): Boolean = distanceRangeMap.isEmpty()
+
+    fun clear() = distanceRangeMap.clear()
+
+    fun forEach(
+        callback: (lower: Offset<OffsetType>, upper: Offset<OffsetType>, value: ValueType) -> Unit
+    ) {
+        distanceRangeMap.forEach { lower, upper, value ->
+            callback(Offset(lower), Offset(upper), value)
+        }
+    }
+
+    fun forEachWhile(
+        callback:
+            (lower: Offset<OffsetType>, upper: Offset<OffsetType>, value: ValueType) -> Boolean
+    ) {
+        distanceRangeMap.forEachWhile { lower, upper, value ->
+            callback(Offset(lower), Offset(upper), value)
+        }
+    }
+
+    fun fullyCovers(length: Offset<OffsetType>): Boolean =
+        distanceRangeMap.fullyCovers(length.distance)
+
+    override fun iterator(): Iterator<RangeMapEntry<OffsetType, ValueType>> {
+        return distanceRangeMap
+            .asSequence()
+            .map {
+                RangeMapEntry<OffsetType, ValueType>(Offset(it.lower), Offset(it.upper), it.value)
+            }
+            .iterator()
+    }
+}
+
+fun <OffsetType, ValueType> offsetRangeMapOf(
+    vararg entries: OffsetRangeMap.RangeMapEntry<OffsetType, ValueType>
+): OffsetRangeMap<OffsetType, ValueType> =
+    OffsetRangeMap<OffsetType, ValueType>().also { it.putMany(entries.asIterable()) }
+
+fun <OffsetType, ValueType> offsetRangeMapOf(
+    entries: Sequence<OffsetRangeMap.RangeMapEntry<OffsetType, ValueType>>
+): OffsetRangeMap<OffsetType, ValueType> =
+    OffsetRangeMap<OffsetType, ValueType>().also { it.putMany(entries.asIterable()) }
+
+fun <OffsetType, ValueType> offsetRangeMapOf(
+    entries: Iterable<OffsetRangeMap.RangeMapEntry<OffsetType, ValueType>>
+): OffsetRangeMap<OffsetType, ValueType> =
+    OffsetRangeMap<OffsetType, ValueType>().also { it.putMany(entries) }

--- a/core/osrd-mp/src/commonTest/kotlin/fr/sncf/osrd/utils/TestOffsetRangeMap.kt
+++ b/core/osrd-mp/src/commonTest/kotlin/fr/sncf/osrd/utils/TestOffsetRangeMap.kt
@@ -1,0 +1,333 @@
+package fr.sncf.osrd.utils
+
+import fr.sncf.osrd.utils.units.Distance
+import fr.sncf.osrd.utils.units.Offset
+import fr.sncf.osrd.utils.units.meters
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
+
+private class TestPath
+
+private fun offset(mm: Long) = Offset<TestPath>(Distance(mm))
+
+private fun offset(m: Double) = Offset<TestPath>(m.meters)
+
+private fun <T> entry(lower: Long, upper: Long, value: T) =
+    OffsetRangeMap.RangeMapEntry(offset(lower), offset(upper), value)
+
+class TestOffsetRangeMap {
+    private fun <T> testPut(
+        entries: List<OffsetRangeMap.RangeMapEntry<TestPath, T>>,
+        expected: List<OffsetRangeMap.RangeMapEntry<TestPath, T>> = entries,
+    ) {
+        val rangeMap = offsetRangeMapOf<TestPath, T>()
+        for (entry in entries) rangeMap.put(entry.lower, entry.upper, entry.value)
+        assertEquals(expected, rangeMap.toList())
+
+        val rangeMapMany = offsetRangeMapOf<TestPath, T>()
+        rangeMapMany.putMany(entries)
+        assertEquals(expected, rangeMapMany.toList())
+
+        val rangeMapIterable = offsetRangeMapOf(entries)
+        assertEquals(expected, rangeMapIterable.toList())
+
+        val rangeMapSequence = offsetRangeMapOf(entries.asSequence())
+        assertEquals(expected, rangeMapSequence.toList())
+    }
+
+    @Test
+    fun testEmpty() {
+        val rangeMap = offsetRangeMapOf<TestPath, Int>()
+        assertEquals(emptyList(), rangeMap.toList())
+    }
+
+    @Test
+    fun testSingleEntry() {
+        testPut(listOf(entry(100, 1000, 42)))
+    }
+
+    @Test
+    fun testEmptyEntry() {
+        testPut(listOf(entry(100, 100, 42)), emptyList())
+    }
+
+    @Test
+    fun testOverlappingRanges() {
+        testPut(
+            listOf(entry(100, 200, 42), entry(150, 300, 43)),
+            listOf(entry(100, 150, 42), entry(150, 300, 43)),
+        )
+    }
+
+    @Test
+    fun testNonOverlappingRanges() {
+        testPut(listOf(entry(100, 200, 42), entry(300, 400, 43)))
+    }
+
+    @Test
+    fun testSplitRange() {
+        testPut(
+            listOf(entry(100, 200, 42), entry(120, 130, 43)),
+            listOf(entry(100, 120, 42), entry(120, 130, 43), entry(130, 200, 42)),
+        )
+    }
+
+    @Test
+    fun testOverwritingSeveralRanges() {
+        testPut(
+            listOf(
+                entry(0, 100, 1),
+                entry(100, 200, 2),
+                entry(200, 300, 3),
+                entry(300, 400, 4),
+                entry(400, 500, 5),
+                entry(50, 450, 42),
+            ),
+            listOf(entry(0, 50, 1), entry(50, 450, 42), entry(450, 500, 5)),
+        )
+    }
+
+    @Test
+    fun testAddingFromEnd() {
+        testPut(
+            listOf(entry(100, 200, 1), entry(0, 100, 2)),
+            listOf(entry(0, 100, 2), entry(100, 200, 1)),
+        )
+    }
+
+    @Test
+    fun testMergeRanges() {
+        testPut(
+            listOf(
+                entry(0, 100, 42),
+                entry(100, 200, 2),
+                entry(200, 300, 3),
+                entry(300, 400, 4),
+                entry(400, 500, 42),
+                entry(50, 450, 42),
+            ),
+            listOf(entry(0, 500, 42)),
+        )
+    }
+
+    @Test
+    fun testAdjacentRanges() {
+        testPut(listOf(entry(0, 5, 1), entry(5, 10, 1)), listOf(entry(0, 10, 1)))
+    }
+
+    @Test
+    fun testTruncate() {
+        val rangeMap = offsetRangeMapOf<TestPath, Int>()
+        rangeMap.put(offset(0), offset(100), 41)
+        rangeMap.put(offset(200), offset(300), 42)
+        rangeMap.truncate(offset(250), offset(260))
+        assertEquals(listOf(entry(250, 260, 42)), rangeMap.toList())
+    }
+
+    @Test
+    fun testTruncateAll() {
+        val rangeMap = offsetRangeMapOf<TestPath, Int>()
+        rangeMap.put(offset(0), offset(100), 41)
+        rangeMap.put(offset(200), offset(300), 42)
+        rangeMap.truncate(offset(0), offset(0))
+        assertEquals(listOf(), rangeMap.toList())
+    }
+
+    @Test
+    fun testTruncateToEmptyRange() {
+        val rangeMap = offsetRangeMapOf<TestPath, Int>()
+        rangeMap.put(offset(0), offset(100), 41)
+        rangeMap.put(offset(200), offset(300), 42)
+        rangeMap.truncate(offset(150), offset(160))
+        assertEquals(listOf(), rangeMap.toList())
+    }
+
+    @Test
+    fun testTruncateEmptyRange() {
+        val rangeMap = offsetRangeMapOf<TestPath, Int>()
+        rangeMap.truncate(offset(150), offset(160))
+        assertEquals(rangeMap, rangeMap)
+    }
+
+    @Test
+    fun testShift() {
+        val rangeMap = offsetRangeMapOf<TestPath, Int>()
+        rangeMap.put(offset(0), offset(100), 41)
+        rangeMap.put(offset(200), offset(300), 42)
+        rangeMap.shiftPositions(Distance(-100))
+        assertEquals(listOf(entry(-100, 0, 41), entry(100, 200, 42)), rangeMap.toList())
+    }
+
+    @Test
+    fun testPutManyOnNonEmpty() {
+        val rangeMap = offsetRangeMapOf<TestPath, Int>()
+        rangeMap.put(offset(100), offset(1000), 42)
+        rangeMap.putMany(listOf(entry(100, 500, 41), entry(600, 1000, 43)))
+        assertEquals(
+            listOf(entry(100, 500, 41), entry(500, 600, 42), entry(600, 1000, 43)),
+            rangeMap.toList(),
+        )
+    }
+
+    @Test
+    fun testLarge() {
+        val n = 10000
+        val oneSecond = 1.seconds
+        val timeSource = TimeSource.Monotonic
+        val entries = List(n) { entry(it.toLong(), it.toLong() + 1, it) }
+
+        val mark1 = timeSource.markNow()
+        val mark2 = mark1 + oneSecond
+        val rangeMap = offsetRangeMapOf<TestPath, Int>()
+        rangeMap.putMany(entries)
+        assertFalse(mark2.hasPassedNow())
+        assertEquals(entries, rangeMap.toList())
+
+        val mark3 = timeSource.markNow()
+        val mark4 = mark3 + oneSecond
+        val rangeMapIterable = offsetRangeMapOf(entries)
+        assertFalse(mark4.hasPassedNow())
+        assertEquals(entries, rangeMapIterable.toList())
+    }
+
+    @Test
+    fun updateMapIntersection() {
+        val map = offsetRangeMapOf<TestPath, String>()
+        map.put(offset(0.0), offset(10.0), "A")
+        val updateMap = offsetRangeMapOf<TestPath, String>()
+        updateMap.put(offset(5.0), offset(15.0), "B")
+        map.updateMapIntersection(updateMap) { old, new -> old + new }
+        assertEquals("AB", map.get(offset(7.5)))
+        assertEquals("A", map.get(offset(2.5)))
+        assertNull(map.get(offset(12.5)))
+    }
+
+    @Test
+    fun updateMap_noOverlap() {
+        val map = offsetRangeMapOf<TestPath, String>()
+        map.put(offset(0.0), offset(5.0), "A")
+        val update = offsetRangeMapOf<TestPath, String>()
+        update.put(offset(10.0), offset(15.0), "B")
+        map.updateMap(update, { old, new -> old + new })
+        assertEquals("A", map.get(offset(2.5)))
+        assertEquals("B", map.get(offset(12.5)))
+        assertNull(map.get(offset(7.5)))
+    }
+
+    @Test
+    fun updateMap_partialOverlap() {
+        val map = offsetRangeMapOf<TestPath, String>()
+        map.put(offset(0.0), offset(10.0), "A")
+        val update = offsetRangeMapOf<TestPath, String>()
+        update.put(offset(5.0), offset(15.0), "B")
+        map.updateMap(update, { old, new -> old + new })
+        assertEquals("A", map.get(offset(2.5)))
+        assertEquals("AB", map.get(offset(7.5)))
+        assertEquals("B", map.get(offset(12.5)))
+    }
+
+    @Test
+    fun updateMap_fullOverlap() {
+        val map = offsetRangeMapOf<TestPath, String>()
+        map.put(offset(0.0), offset(10.0), "A")
+        val update = offsetRangeMapOf<TestPath, String>()
+        update.put(offset(0.0), offset(10.0), "B")
+        map.updateMap(update, { old, new -> old + new })
+        assertEquals("AB", map.get(offset(5.0)))
+    }
+
+    @Test
+    fun updateMap_multipleRanges() {
+        val map = offsetRangeMapOf<TestPath, String>()
+        map.put(offset(0.0), offset(5.0), "A")
+        map.put(offset(10.0), offset(15.0), "C")
+        val update = offsetRangeMapOf<TestPath, String>()
+        update.put(offset(3.0), offset(12.0), "B")
+        map.updateMap(update, { old, new -> old + new })
+        assertEquals("A", map.get(offset(1.0)))
+        assertEquals("AB", map.get(offset(4.0)))
+        assertEquals("B", map.get(offset(8.0)))
+        assertEquals("CB", map.get(offset(11.0)))
+        assertEquals("C", map.get(offset(14.0)))
+    }
+
+    @Test
+    fun updateMapKeepingNonIntersecting_emptyUpdate() {
+        val map = offsetRangeMapOf<TestPath, String>()
+        map.put(offset(0.0), offset(10.0), "A")
+        val update = offsetRangeMapOf<TestPath, String>()
+        map.updateMap(update, { old, new -> old + new })
+        assertEquals("A", map.get(offset(5.0)))
+    }
+
+    @Test
+    fun updateMap_emptyOriginal() {
+        val map = offsetRangeMapOf<TestPath, String>()
+        val update = offsetRangeMapOf<TestPath, String>()
+        update.put(offset(0.0), offset(10.0), "B")
+        map.updateMap(update, { old, new -> old + new })
+        assertEquals("B", map.get(offset(5.0)))
+    }
+
+    @Test
+    fun clear() {
+        val map = offsetRangeMapOf<TestPath, String>()
+        map.put(offset(0.0), offset(10.0), "A")
+        map.clear()
+        assertNull(map.get(offset(5.0)))
+    }
+
+    @Test
+    fun fullyCovers() {
+        val map =
+            offsetRangeMapOf(
+                OffsetRangeMap.RangeMapEntry(offset(0.0), offset(1.0), true),
+                OffsetRangeMap.RangeMapEntry(offset(1.0), offset(4.0), true),
+                OffsetRangeMap.RangeMapEntry(offset(7.0), offset(9.0), true),
+            )
+        assertTrue(map.fullyCovers(offset(-1.0)))
+        assertTrue(map.fullyCovers(offset(0.0)))
+        assertTrue(map.fullyCovers(offset(1.0)))
+        assertTrue(map.fullyCovers(offset(2.0)))
+        assertTrue(map.fullyCovers(offset(3.0)))
+        assertTrue(map.fullyCovers(offset(4.0)))
+        assertFalse(map.fullyCovers(offset(5.0)))
+        assertFalse(map.fullyCovers(offset(6.0)))
+        assertFalse(map.fullyCovers(offset(7.0)))
+        assertFalse(map.fullyCovers(offset(8.0)))
+        assertFalse(map.fullyCovers(offset(9.0)))
+        assertFalse(map.fullyCovers(offset(10.0)))
+    }
+
+    @Test
+    fun mapToRangeSet() {
+        val map = offsetRangeMapOf<TestPath, String>()
+        map.put(offset(0.0), offset(10.0), "A")
+        map.put(offset(10.0), offset(20.0), "B")
+        map.put(offset(20.0), offset(30.0), "A")
+        val distanceMap =
+            distanceRangeMapOf(
+                DistanceRangeMap.RangeMapEntry(offset(0.0).distance, offset(10.0).distance, "A"),
+                DistanceRangeMap.RangeMapEntry(offset(10.0).distance, offset(20.0).distance, "B"),
+                DistanceRangeMap.RangeMapEntry(offset(20.0).distance, offset(30.0).distance, "A"),
+            )
+        val predicate: (String) -> Boolean = { it == "A" }
+        assertEquals(
+            distanceMap.mapToRangeSet(predicate).asList(),
+            map.mapToRangeSet(predicate).asList(),
+        )
+    }
+
+    @Test
+    fun fullyCoversEmptyMap() {
+        val map = offsetRangeMapOf<TestPath, Boolean>()
+        assertTrue(map.fullyCovers(offset(-1.0)))
+        assertTrue(map.fullyCovers(offset(0.0)))
+        assertFalse(map.fullyCovers(offset(1.0)))
+    }
+}

--- a/core/src/main/kotlin/fr/sncf/osrd/api/SimulationParser.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/SimulationParser.kt
@@ -2,11 +2,12 @@ package fr.sncf.osrd.api
 
 import fr.sncf.osrd.api.standalone_sim.SimulationPowerRestrictionItem
 import fr.sncf.osrd.api.standalone_sim.SimulationScheduleItem
+import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal.OPEN
 import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal.SHORT_SLIP_STOP
 import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal.STOP
-import fr.sncf.osrd.utils.DistanceRangeMap
-import fr.sncf.osrd.utils.distanceRangeMapOf
+import fr.sncf.osrd.utils.OffsetRangeMap
+import fr.sncf.osrd.utils.offsetRangeMapOf
 import fr.sncf.osrd.utils.units.TimeDelta
 import java.lang.Long.min
 import mu.KotlinLogging
@@ -70,10 +71,10 @@ fun parseRawSimulationScheduleItems(
 
 fun parsePowerRestrictions(
     powerRestrictions: List<SimulationPowerRestrictionItem>
-): DistanceRangeMap<String> {
-    val res = distanceRangeMapOf<String>()
+): OffsetRangeMap<PhysicsPath, String> {
+    val res = offsetRangeMapOf<PhysicsPath, String>()
     for (entry in powerRestrictions) {
-        res.put(entry.from.distance, entry.to.distance, entry.value)
+        res.put(entry.from, entry.to, entry.value)
     }
     return res
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
@@ -54,6 +54,7 @@ import fr.sncf.osrd.utils.Direction
 import fr.sncf.osrd.utils.DistanceRangeMap
 import fr.sncf.osrd.utils.DistanceRangeMap.RangeMapEntry
 import fr.sncf.osrd.utils.distanceRangeMapOf
+import fr.sncf.osrd.utils.offsetRangeMapOf
 import fr.sncf.osrd.utils.units.*
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.SpanKind
@@ -280,7 +281,7 @@ class STDCMEndpoint(
         val electrificationMap =
             path.trainPath.getElectrificationMap(
                 rollingStock.basePowerClass,
-                distanceRangeMapOf(),
+                offsetRangeMapOf(),
                 rollingStock.powerRestrictions,
                 false,
             )

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/SafetySpeed.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/SafetySpeed.kt
@@ -8,6 +8,7 @@ import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop
 import fr.sncf.osrd.signaling.etcs_level2.ETCS_LEVEL2
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.utils.DistanceRangeMap
+import fr.sncf.osrd.utils.OffsetRangeMap
 import fr.sncf.osrd.utils.distanceRangeMapOf
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.Speed
@@ -29,7 +30,7 @@ fun makeSafetySpeedRanges(
     infra: FullInfra,
     trainPath: TrainPath,
     schedule: List<SimulationScheduleItem>,
-    signalingRanges: DistanceRangeMap<String>,
+    signalingRanges: OffsetRangeMap<PhysicsPath, String>,
 ): DistanceRangeMap<Speed> {
     val rawInfra = infra.rawInfra
     val signalOffsets = getSignalOffsets(infra, trainPath)
@@ -88,10 +89,10 @@ fun makeSafetySpeedRanges(
 /** Check if a given stop is in a range of a given signaling system. */
 private fun isStopInSignalingSystemRange(
     stopOffset: Offset<PhysicsPath>,
-    signalingRanges: DistanceRangeMap<String>,
+    signalingRanges: OffsetRangeMap<PhysicsPath, String>,
     signalingSystem: String,
 ): Boolean {
-    return (signalingRanges.get(stopOffset.distance) == signalingSystem)
+    return (signalingRanges.get(stopOffset) == signalingSystem)
 }
 
 /**

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulation.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulation.kt
@@ -34,9 +34,9 @@ import fr.sncf.osrd.standalone_sim.result.ElectrificationRange
 import fr.sncf.osrd.standalone_sim.result.ElectrificationRange.ElectrificationUsage
 import fr.sncf.osrd.standalone_sim.result.ElectrificationRange.ElectrificationUsage.ElectrifiedUsage
 import fr.sncf.osrd.train.RollingStock
-import fr.sncf.osrd.utils.DistanceRangeMap
-import fr.sncf.osrd.utils.distanceRangeMapOf
+import fr.sncf.osrd.utils.OffsetRangeMap
 import fr.sncf.osrd.utils.entries
+import fr.sncf.osrd.utils.offsetRangeMapOf
 import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
@@ -55,7 +55,7 @@ fun runStandaloneSimulation(
     comfort: Comfort,
     constraintDistribution: RJSAllowanceDistribution,
     speedLimitTag: String?,
-    powerRestrictions: DistanceRangeMap<String>,
+    powerRestrictions: OffsetRangeMap<PhysicsPath, String>,
     useElectricalProfiles: Boolean,
     useSpeedLimits: Boolean,
     timeStep: Double,
@@ -176,13 +176,16 @@ fun runStandaloneSimulation(
 }
 
 /** Returns the ranges where each signaling system is encountered. */
-fun buildSignalingRanges(infra: FullInfra, trainPath: TrainPath): DistanceRangeMap<String> {
+fun buildSignalingRanges(
+    infra: FullInfra,
+    trainPath: TrainPath,
+): OffsetRangeMap<PhysicsPath, String> {
     val blockInfra = infra.blockInfra
-    val res = distanceRangeMapOf<String>()
+    val res = offsetRangeMapOf<PhysicsPath, String>()
     for (blockRange in trainPath.getBlocks()) {
         val sigSystem = blockInfra.getBlockSignalingSystem(blockRange.value)
         val sigSystemName = infra.signalingSimulator.sigModuleManager.getName(sigSystem)
-        res.put(blockRange.pathBegin.distance, blockRange.pathEnd.distance, sigSystemName)
+        res.put(blockRange.pathBegin, blockRange.pathEnd, sigSystemName)
     }
     return res
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/etcsContextBuilder.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/etcsContextBuilder.kt
@@ -10,6 +10,7 @@ import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.sim_infra.utils.getNextTrackSections
 import fr.sncf.osrd.train.RollingStock
 import fr.sncf.osrd.utils.*
+import fr.sncf.osrd.utils.OffsetRangeMap
 import fr.sncf.osrd.utils.indexing.DirStaticIdx
 import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Offset
@@ -19,7 +20,7 @@ fun makeETCSContext(
     rollingStock: RollingStock,
     infra: FullInfra,
     trainPath: TrainPath,
-    signalingRanges: DistanceRangeMap<String>,
+    signalingRanges: OffsetRangeMap<PhysicsPath, String>,
 ): EnvelopeSimContext.ETCSContext? {
     val etcsRanges = signalingRanges.mapToRangeSet { it == ETCS_LEVEL2.id }
 

--- a/core/src/test/java/fr/sncf/osrd/DriverBehaviourTest.kt
+++ b/core/src/test/java/fr/sncf/osrd/DriverBehaviourTest.kt
@@ -2,10 +2,12 @@ package fr.sncf.osrd
 
 import fr.sncf.osrd.envelope_sim_infra.computeMRSP
 import fr.sncf.osrd.path.implementations.buildTrainPathFromBlocks
+import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.train.TestTrains
-import fr.sncf.osrd.utils.DistanceRangeMap
 import fr.sncf.osrd.utils.DummyInfra
-import fr.sncf.osrd.utils.distanceRangeMapOf
+import fr.sncf.osrd.utils.OffsetRangeMap
+import fr.sncf.osrd.utils.offsetRangeMapOf
+import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
@@ -27,8 +29,12 @@ class DriverBehaviourTest {
         mrsp =
             driverBehaviour.applyToMRSP(
                 mrsp,
-                distanceRangeMapOf(
-                    DistanceRangeMap.RangeMapEntry(0.meters, path.getLength().distance, "BAL")
+                offsetRangeMapOf(
+                    OffsetRangeMap.RangeMapEntry(
+                        Offset<PhysicsPath>(0.meters),
+                        Offset(path.getLength().distance),
+                        "BAL",
+                    )
                 ),
             )
         Assertions.assertEquals(20.0, mrsp.interpolateSpeedRightDir(0.0, 1.0))

--- a/core/src/test/java/fr/sncf/osrd/train/TestRollingStock.kt
+++ b/core/src/test/java/fr/sncf/osrd/train/TestRollingStock.kt
@@ -6,9 +6,11 @@ import fr.sncf.osrd.envelope_sim.EnvelopeSimPathBuilder
 import fr.sncf.osrd.envelope_sim.PhysicsRollingStock.InfraConditions
 import fr.sncf.osrd.envelope_sim.PhysicsRollingStock.TractiveEffortPoint
 import fr.sncf.osrd.path.interfaces.PhysicsPath
-import fr.sncf.osrd.utils.DistanceRangeMap
-import fr.sncf.osrd.utils.distanceRangeMapOf
+import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
+import fr.sncf.osrd.utils.OffsetRangeMap
+import fr.sncf.osrd.utils.offsetRangeMapOf
 import fr.sncf.osrd.utils.units.Distance
+import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
@@ -22,11 +24,15 @@ private fun maxSpeed(curve: Array<TractiveEffortPoint>): Double {
 
 private fun mapTractiveEffortCurveArgs(): Iterable<Arguments> {
     val powerRestrictionMap =
-        distanceRangeMapOf(
-            DistanceRangeMap.RangeMapEntry(0.0.meters, 10.0.meters, "Restrict1"),
-            DistanceRangeMap.RangeMapEntry(10.0.meters, 20.0.meters, "Restrict2"),
+        offsetRangeMapOf(
+            OffsetRangeMap.RangeMapEntry(
+                Offset<PhysicsPath>(0.0.meters),
+                Offset(10.0.meters),
+                "Restrict1",
+            ),
+            OffsetRangeMap.RangeMapEntry(Offset(10.0.meters), Offset(20.0.meters), "Restrict2"),
         )
-    val emptyPowerRestrictionMap = distanceRangeMapOf<String>()
+    val emptyPowerRestrictionMap = offsetRangeMapOf<PhysicsPath, String>()
     return Lists.cartesianProduct(
             listOf(
                 EnvelopeSimPathBuilder.withElectricalProfiles25000(40.0),
@@ -45,7 +51,7 @@ class TestRollingStock {
     fun testMapTractiveEffortCurveCoherent(
         path: PhysicsPath,
         comfort: Comfort,
-        powerRestrictionMap: DistanceRangeMap<String>,
+        powerRestrictionMap: OffsetRangeMap<PhysicsPath, String>,
     ) {
         val rollingStock = TestTrains.REALISTIC_FAST_TRAIN
 
@@ -64,10 +70,18 @@ class TestRollingStock {
     @Test
     fun testMapTractiveEffortCurveWithProfiles() {
         val powerRestrictionMap =
-            distanceRangeMapOf(
-                DistanceRangeMap.RangeMapEntry(5.0.meters, 11.0.meters, "Restrict2"),
-                DistanceRangeMap.RangeMapEntry(15.0.meters, 18.0.meters, "Restrict1"),
-                DistanceRangeMap.RangeMapEntry(18.0.meters, 20.0.meters, "UnknownRestrict"),
+            offsetRangeMapOf(
+                OffsetRangeMap.RangeMapEntry(
+                    Offset<PhysicsPath>(5.0.meters),
+                    Offset(11.0.meters),
+                    "Restrict2",
+                ),
+                OffsetRangeMap.RangeMapEntry(Offset(15.0.meters), Offset(18.0.meters), "Restrict1"),
+                OffsetRangeMap.RangeMapEntry(
+                    Offset(18.0.meters),
+                    Offset(20.0.meters),
+                    "UnknownRestrict",
+                ),
             )
         val path = EnvelopeSimPathBuilder.withElectricalProfiles25000(50.0)
 

--- a/core/src/test/java/fr/sncf/osrd/train/TestRollingStock.kt
+++ b/core/src/test/java/fr/sncf/osrd/train/TestRollingStock.kt
@@ -6,8 +6,9 @@ import fr.sncf.osrd.envelope_sim.EnvelopeSimPathBuilder
 import fr.sncf.osrd.envelope_sim.PhysicsRollingStock.InfraConditions
 import fr.sncf.osrd.envelope_sim.PhysicsRollingStock.TractiveEffortPoint
 import fr.sncf.osrd.path.interfaces.PhysicsPath
-import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
+import fr.sncf.osrd.utils.DistanceRangeMap
 import fr.sncf.osrd.utils.OffsetRangeMap
+import fr.sncf.osrd.utils.distanceRangeMapOf
 import fr.sncf.osrd.utils.offsetRangeMapOf
 import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Offset
@@ -24,15 +25,11 @@ private fun maxSpeed(curve: Array<TractiveEffortPoint>): Double {
 
 private fun mapTractiveEffortCurveArgs(): Iterable<Arguments> {
     val powerRestrictionMap =
-        offsetRangeMapOf(
-            OffsetRangeMap.RangeMapEntry(
-                Offset<PhysicsPath>(0.0.meters),
-                Offset(10.0.meters),
-                "Restrict1",
-            ),
-            OffsetRangeMap.RangeMapEntry(Offset(10.0.meters), Offset(20.0.meters), "Restrict2"),
+        distanceRangeMapOf(
+            DistanceRangeMap.RangeMapEntry(0.0.meters, 10.0.meters, "Restrict1"),
+            DistanceRangeMap.RangeMapEntry(10.0.meters, 20.0.meters, "Restrict2"),
         )
-    val emptyPowerRestrictionMap = offsetRangeMapOf<PhysicsPath, String>()
+    val emptyPowerRestrictionMap = distanceRangeMapOf<String>()
     return Lists.cartesianProduct(
             listOf(
                 EnvelopeSimPathBuilder.withElectricalProfiles25000(40.0),
@@ -51,14 +48,14 @@ class TestRollingStock {
     fun testMapTractiveEffortCurveCoherent(
         path: PhysicsPath,
         comfort: Comfort,
-        powerRestrictionMap: OffsetRangeMap<PhysicsPath, String>,
+        powerRestrictionMap: DistanceRangeMap<String>,
     ) {
         val rollingStock = TestTrains.REALISTIC_FAST_TRAIN
 
         val elecCondMap =
             path.getElectrificationMap(
                 rollingStock.basePowerClass,
-                powerRestrictionMap,
+                OffsetRangeMap<PhysicsPath, String>(powerRestrictionMap),
                 rollingStock.powerRestrictions,
                 false,
             )

--- a/core/src/test/kotlin/fr/sncf/osrd/backtracks/BacktrackTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/backtracks/BacktrackTests.kt
@@ -34,6 +34,7 @@ import fr.sncf.osrd.train.TestTrains.REALISTIC_FAST_TRAIN
 import fr.sncf.osrd.train.TrainStop
 import fr.sncf.osrd.utils.Helpers.fullInfraFromFile
 import fr.sncf.osrd.utils.distanceRangeMapOf
+import fr.sncf.osrd.utils.offsetRangeMapOf
 import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
@@ -595,7 +596,7 @@ class BacktrackTests {
                 comfort = Comfort.STANDARD,
                 constraintDistribution = RJSAllowanceDistribution.LINEAR,
                 speedLimitTag = null,
-                powerRestrictions = distanceRangeMapOf(),
+                powerRestrictions = offsetRangeMapOf(),
                 useElectricalProfiles = false,
                 useSpeedLimits = true,
                 timeStep = 2.0,
@@ -721,7 +722,7 @@ class BacktrackTests {
                 comfort = Comfort.STANDARD,
                 constraintDistribution = RJSAllowanceDistribution.LINEAR,
                 speedLimitTag = null,
-                powerRestrictions = distanceRangeMapOf(),
+                powerRestrictions = offsetRangeMapOf(),
                 useElectricalProfiles = false,
                 useSpeedLimits = true,
                 timeStep = 2.0,
@@ -833,7 +834,7 @@ class BacktrackTests {
                 comfort = Comfort.STANDARD,
                 constraintDistribution = RJSAllowanceDistribution.LINEAR,
                 speedLimitTag = null,
-                powerRestrictions = distanceRangeMapOf(),
+                powerRestrictions = offsetRangeMapOf(),
                 useElectricalProfiles = false,
                 useSpeedLimits = true,
                 timeStep = 2.0,

--- a/core/src/test/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulationTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulationTest.kt
@@ -59,7 +59,7 @@ class StandaloneSimulationTest {
     private val electrificationMap =
         trainPath.getElectrificationMap(
             rollingStock.basePowerClass,
-            distanceRangeMapOf(),
+            offsetRangeMapOf(),
             rollingStock.powerRestrictions,
             true,
         )

--- a/core/src/test/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulationTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulationTest.kt
@@ -81,7 +81,7 @@ class StandaloneSimulationTest {
                 Comfort.STANDARD,
                 RJSAllowanceDistribution.LINEAR,
                 null,
-                distanceRangeMapOf(),
+                offsetRangeMapOf(),
                 false,
                 true,
                 2.0,
@@ -99,7 +99,7 @@ class StandaloneSimulationTest {
         val startSpeed: Double = 0.0,
         val margins: RangeValues<MarginValue> = RangeValues(),
         val pathLength: Distance,
-        val powerRestrictions: DistanceRangeMap<String> = distanceRangeMapOf(),
+        val powerRestrictions: OffsetRangeMap<PhysicsPath, String> = offsetRangeMapOf(),
     )
 
     /**
@@ -160,23 +160,23 @@ class StandaloneSimulationTest {
             )
 
         // Power restriction values
-        val powerRestrictionRangeMaps: List<DistanceRangeMap<String>> =
+        val powerRestrictionRangeMaps: List<OffsetRangeMap<PhysicsPath, String>> =
             listOf(
-                distanceRangeMapOf(),
-                distanceRangeMapOf(
-                    DistanceRangeMap.RangeMapEntry(
-                        0.meters,
-                        pathLength.distance / 3.0,
+                offsetRangeMapOf(),
+                offsetRangeMapOf(
+                    OffsetRangeMap.RangeMapEntry(
+                        Offset(0.meters),
+                        Offset(pathLength.distance / 3.0),
                         "Restrict1",
                     ),
-                    DistanceRangeMap.RangeMapEntry(
-                        pathLength.distance / 3.0,
-                        pathLength.distance * 2.0 / 3.0,
+                    OffsetRangeMap.RangeMapEntry(
+                        Offset(pathLength.distance / 3.0),
+                        Offset(pathLength.distance * 2.0 / 3.0),
                         "Restrict2",
                     ),
-                    DistanceRangeMap.RangeMapEntry(
-                        pathLength.distance * 2.0 / 3.0,
-                        pathLength.distance,
+                    OffsetRangeMap.RangeMapEntry(
+                        Offset(pathLength.distance * 2.0 / 3.0),
+                        Offset(pathLength.distance),
                         "Restrict1",
                     ),
                 ),
@@ -343,7 +343,7 @@ class StandaloneSimulationTest {
 
         // ETCS_LEVEL2 range covers the first stop only: getting safetySpeed for the other stops
         val signalingRangesEtcsHappyPath = signalingRangesBAL.clone()
-        signalingRangesEtcsHappyPath.put(10.meters, 1_000.meters, ETCS_LEVEL2.id)
+        signalingRangesEtcsHappyPath.put(Offset(10.meters), Offset(1_000.meters), ETCS_LEVEL2.id)
         val safetySpeedRangesEtcsHappyPath =
             makeSafetySpeedRanges(infra, trainPath, schedule, signalingRangesEtcsHappyPath)
         val expectedEtcsHappyPath =
@@ -358,7 +358,7 @@ class StandaloneSimulationTest {
         // ETCS_LEVEL2 range covers the last 2 stops only and their associated EoA: no safetySpeed
         // for those stops (only the first)
         val signalingRangesEndFullEtcs = signalingRangesBAL.clone()
-        signalingRangesEndFullEtcs.put(9_500.meters, 10_400.meters, ETCS_LEVEL2.id)
+        signalingRangesEndFullEtcs.put(Offset(9_500.meters), Offset(10_400.meters), ETCS_LEVEL2.id)
         val safetySpeedRangesEndFullEtcs =
             makeSafetySpeedRanges(infra, trainPath, schedule, signalingRangesEndFullEtcs)
         val expectedEndFullEtcs =
@@ -370,7 +370,11 @@ class StandaloneSimulationTest {
         // ETCS_LEVEL2 range covers the last 2 stops but not the final buffer-stop: no safetySpeed
         // for those stops (only the first)
         val signalingRangesEndEtcsExceptFinalBuffer = signalingRangesBAL.clone()
-        signalingRangesEndEtcsExceptFinalBuffer.put(9_500.meters, 10_350.meters, ETCS_LEVEL2.id)
+        signalingRangesEndEtcsExceptFinalBuffer.put(
+            Offset(9_500.meters),
+            Offset(10_350.meters),
+            ETCS_LEVEL2.id,
+        )
         val safetySpeedRangesEndFullEtcsExceptFinalBuffer =
             makeSafetySpeedRanges(
                 infra,
@@ -392,8 +396,8 @@ class StandaloneSimulationTest {
         val signalingRangesEtcsStartingBetweenPenultimateStopAndItsSignal =
             signalingRangesBAL.clone()
         signalingRangesEtcsStartingBetweenPenultimateStopAndItsSignal.put(
-            10_100.meters,
-            10_400.meters,
+            Offset(10_100.meters),
+            Offset(10_400.meters),
             ETCS_LEVEL2.id,
         )
         val safetySpeedRangesEtcsStartingBetweenPenultimateStopAndItsSignal =
@@ -418,8 +422,8 @@ class StandaloneSimulationTest {
         // safetySpeed expected for all (stops are in BAL range)
         val signalingRangesEtcsStartingBetweenLastStopAndBuffer = signalingRangesBAL.clone()
         signalingRangesEtcsStartingBetweenLastStopAndBuffer.put(
-            10_350.meters,
-            10_400.meters,
+            Offset(10_350.meters),
+            Offset(10_400.meters),
             ETCS_LEVEL2.id,
         )
         val safetySpeedRangesEtcsStartingBetweenLastStopAndBuffer =

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/FullSTDCMTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/FullSTDCMTests.kt
@@ -464,7 +464,7 @@ fun makeRequirementsFromPath(
             Comfort.STANDARD,
             RJSAllowanceDistribution.LINEAR,
             null,
-            distanceRangeMapOf(),
+            offsetRangeMapOf(),
             useElectricalProfiles = false,
             useSpeedLimits = true,
             2.0,


### PR DESCRIPTION
This PR introduces `OffsetRangeMap` which is a thin layer over `DistanceRangeMap` that is used when indexing the range map using offsets, which often is the case.

I might have missed spots where we can replace DistanceRangeMap so if anybody knows of some of these spots, I will gladly modify them in this PR.

Closes https://github.com/OpenRailAssociation/osrd/issues/15832