### PR TITLE
front: LMR search progress

### DIFF
--- a/front/src/applications/stdcm/StdcmView.tsx
+++ b/front/src/applications/stdcm/StdcmView.tsx
@@ -69,6 +69,7 @@ const StdcmViewContent = ({
     isRejected,
     isCanceled,
     isCalculationCompleted,
+    progressPoints,
   } = useStdcm({ showFailureNotification: false });
 
   const dispatch = useAppDispatch();
@@ -191,6 +192,7 @@ const StdcmViewContent = ({
         setSkipPathfindingStatusMessage={setSkipPathfindingStatusMessage}
         launchStdcmRequest={launchStdcmRequest}
         cancelStdcmRequest={cancelStdcmRequest}
+        progressPoints={progressPoints}
       />
 
       {showStatusBanner && <StdcmStatusBanner isFailed={isRejected} />}

--- a/front/src/applications/stdcm/components/StdcmForm/StdcmConfig.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmConfig.tsx
@@ -1,4 +1,12 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type RefObject,
+} from 'react';
 
 import { Button } from '@osrd-project/ui-core';
 import cx from 'classnames';
@@ -47,7 +55,13 @@ import StdcmDestination from './StdcmDestination';
 import StdcmLinkedTrainSearch from './StdcmLinkedTrainSearch';
 import StdcmOrigin from './StdcmOrigin';
 import useStaticPathfinding from '../../hooks/useStaticPathfinding';
-import type { ConsistData, StdcmConfigErrors, ConsistErrors } from '../../types';
+import type {
+  ConsistData,
+  StdcmConfigErrors,
+  ConsistErrors,
+  StdcmProgressPoints,
+} from '../../types';
+import StdcmMapProgressLayer from '../StdcmMapProgressLayer';
 import StdcmSimulationParams from '../StdcmSimulationParams';
 import StdcmVias from './StdcmVias';
 import { ArrivalTimeTypes, StdcmConfigErrorTypes } from '../../types';
@@ -76,6 +90,7 @@ type StdcmConfigProps = {
   launchStdcmRequest: () => Promise<void>;
   cancelStdcmRequest: () => void;
   setSkipPathfindingStatusMessage: (value: boolean) => void;
+  progressPoints: RefObject<StdcmProgressPoints>;
 };
 
 const StdcmConfig = ({
@@ -88,6 +103,7 @@ const StdcmConfig = ({
   setSkipPathfindingStatusMessage,
   cancelStdcmRequest,
   launchStdcmRequest,
+  progressPoints,
 }: StdcmConfigProps) => {
   const { t } = useTranslation('stdcm');
   const dateTimeLocale = useDateTimeLocale();
@@ -432,7 +448,11 @@ const StdcmConfig = ({
             pathStepMarkers={markersInfo}
             updateMapSettings={updateMapSettings}
             updateViewport={updateViewport}
-          />
+          >
+            {(isPending || isPendingAdditional) && (
+              <StdcmMapProgressLayer progressPoints={progressPoints} />
+            )}
+          </DefaultBaseMap>
         </div>
       </div>
     </div>

--- a/front/src/applications/stdcm/components/StdcmMapProgressLayer.tsx
+++ b/front/src/applications/stdcm/components/StdcmMapProgressLayer.tsx
@@ -1,0 +1,224 @@
+import { useEffect, type RefObject } from 'react';
+
+import type { Feature, FeatureCollection, Point } from 'geojson';
+import type { GeoJSONSource } from 'maplibre-gl';
+import { Source, useMap } from 'react-map-gl/maplibre';
+
+import { OrderedLayer } from 'common/Map/Layers';
+import { LAYER_GROUPS, LAYER_GROUPS_ORDER } from 'config/layerOrder';
+import { linearColorScaleInterpolation } from 'utils/color';
+import { linearScaleInterpolation } from 'utils/numbers';
+
+import type { StdcmProgressPoints } from '../types';
+
+/**
+ * Definition of the animation steps.
+ */
+const ANIMATION_STEPS = [
+  {
+    time: 0,
+    innerCircleColor: 'rgb(79, 63, 225)',
+    innerCircleSize: 0,
+    innerCircleBorder: 0,
+    outerCircleColor: 'rgb(0, 0, 0)',
+    outerCircleSize: 0,
+    outerCircleBorder: 0,
+  },
+  {
+    time: 33,
+    innerCircleColor: 'rgb(79, 63, 225)',
+    innerCircleSize: 3,
+    innerCircleBorder: 2,
+    outerCircleColor: 'rgb(0, 0, 0)',
+    outerCircleSize: 0,
+    outerCircleBorder: 0,
+  },
+  {
+    time: 100,
+    innerCircleColor: 'rgba(0, 73, 255, 0.9)',
+    innerCircleSize: 7,
+    innerCircleBorder: 5,
+    outerCircleColor: 'rgba(72, 69, 227, 1)',
+    outerCircleSize: 13,
+    outerCircleBorder: 2,
+  },
+  {
+    time: 825,
+    innerCircleColor: 'rgba(0, 129, 255, 0.7)',
+    innerCircleSize: 6,
+    innerCircleBorder: 4,
+    outerCircleColor: 'rgba(0, 129, 255, 0.5)',
+    outerCircleSize: 17,
+    outerCircleBorder: 2,
+  },
+  {
+    time: 1750,
+    innerCircleColor: 'rgba(90, 180, 234, 0.78)',
+    innerCircleSize: 4.5,
+    innerCircleBorder: 2,
+    outerCircleColor: 'rgb(0, 0, 0)',
+    outerCircleSize: 0,
+    outerCircleBorder: 0,
+  },
+  {
+    time: 2000,
+    innerCircleColor: 'rgba(112, 193, 229, 0.8)',
+    innerCircleSize: 4,
+    innerCircleBorder: 1,
+    outerCircleColor: 'rgb(0, 0, 0)',
+    outerCircleSize: 0,
+    outerCircleBorder: 0,
+  },
+];
+
+/**
+ * Between each animation step we need to do a linear interpolation.
+ * For each range, we create a function that transform a point to a the geojson with the good style variables.
+ * The last range is from the last step time to infinity and should return a static value (animation is finished).
+ */
+const ANIMATIONS = ANIMATION_STEPS.reduce(
+  (acc, curr, index) => {
+    // Special case for the latest step,
+    if (index === ANIMATION_STEPS.length - 1) {
+      return [
+        ...acc,
+        {
+          timeRange: { min: curr.time, max: Infinity },
+          pointToGeojson: (point) => ({
+            type: 'Feature',
+            properties: ANIMATION_STEPS[ANIMATION_STEPS.length - 1],
+            geometry: point.geoPoint,
+          }),
+        },
+      ];
+    }
+
+    const next = ANIMATION_STEPS[index + 1];
+    const timeRange = {
+      min: curr.time,
+      max: next.time,
+    };
+    return [
+      ...acc,
+      {
+        timeRange,
+        pointToGeojson: (point, elapsedTime) => ({
+          type: 'Feature',
+          properties: {
+            innerCircleColor: linearColorScaleInterpolation(
+              { min: curr.innerCircleColor, max: next.innerCircleColor },
+              timeRange,
+              elapsedTime
+            ),
+            innerCircleSize: linearScaleInterpolation(
+              { min: curr.innerCircleSize, max: next.innerCircleSize },
+              timeRange,
+              elapsedTime
+            ),
+            innerCircleBorder: linearScaleInterpolation(
+              { min: curr.innerCircleBorder, max: next.innerCircleBorder },
+              timeRange,
+              elapsedTime
+            ),
+            outerCircleColor: linearColorScaleInterpolation(
+              { min: curr.outerCircleColor, max: next.outerCircleColor },
+              timeRange,
+              elapsedTime
+            ),
+            outerCircleSize: linearScaleInterpolation(
+              { min: curr.outerCircleSize, max: next.outerCircleSize },
+              timeRange,
+              elapsedTime
+            ),
+            outerCircleBorder: linearScaleInterpolation(
+              { min: curr.outerCircleBorder, max: next.outerCircleBorder },
+              timeRange,
+              elapsedTime
+            ),
+          },
+          geometry: point.geoPoint,
+        }),
+      },
+    ];
+  },
+  [] as Array<{
+    timeRange: { min: number; max: number };
+    pointToGeojson: (point: StdcmProgressPoints[0], elapsedTime: number) => Feature<Point>;
+  }>
+);
+
+/**
+ * React Map layer component that display the progress of the stdcm path finding algo.
+ */
+const StdcmMapProgressLayer = ({
+  progressPoints,
+}: {
+  progressPoints: RefObject<StdcmProgressPoints>;
+}) => {
+  const mapRef = useMap();
+
+  useEffect(() => {
+    const map = mapRef.current?.getMap();
+
+    let timeoutId: null | number = null;
+    const animate = () => {
+      if (!map) return;
+      const source = map.getSource<GeoJSONSource>('stdcm-algo-progress');
+      if (!source) return;
+
+      const data: FeatureCollection = {
+        type: 'FeatureCollection',
+        features: progressPoints.current.map((point) => {
+          const elapsedTime = Date.now() - point.timestamp;
+          const animation = ANIMATIONS.find(
+            (a) => a.timeRange.min <= elapsedTime && elapsedTime < a.timeRange.max
+          )!;
+          return animation.pointToGeojson(point, elapsedTime);
+        }),
+      };
+      source.setData(data);
+      timeoutId = window.setTimeout(animate, 0);
+    };
+    timeoutId = window.setTimeout(animate, 0);
+
+    return () => {
+      if (timeoutId) window.clearTimeout(timeoutId);
+    };
+  }, [progressPoints, mapRef]);
+
+  return (
+    <Source
+      id="stdcm-algo-progress"
+      type="geojson"
+      data={{
+        type: 'FeatureCollection',
+        features: [],
+      }}
+    >
+      <OrderedLayer
+        id="stdcm-algo-progress-outer"
+        type="circle"
+        layerOrder={LAYER_GROUPS_ORDER[LAYER_GROUPS.OVER_PUNCTUAL]}
+        paint={{
+          'circle-radius': ['get', 'outerCircleSize'],
+          'circle-color': 'rgba(255, 255, 255, 0)',
+          'circle-stroke-width': ['get', 'outerCircleBorder'],
+          'circle-stroke-color': ['get', 'outerCircleColor'],
+        }}
+      />
+      <OrderedLayer
+        id="stdcm-algo-progress-inner"
+        type="circle"
+        layerOrder={LAYER_GROUPS_ORDER[LAYER_GROUPS.OVER_PUNCTUAL]}
+        paint={{
+          'circle-radius': ['get', 'innerCircleSize'],
+          'circle-color': ['get', 'innerCircleColor'],
+          'circle-stroke-width': ['get', 'innerCircleBorder'],
+          'circle-stroke-color': '#FFF',
+        }}
+      />
+    </Source>
+  );
+};
+
+export default StdcmMapProgressLayer;

--- a/front/src/applications/stdcm/components/StdcmMapProgressLayer.tsx
+++ b/front/src/applications/stdcm/components/StdcmMapProgressLayer.tsx
@@ -9,7 +9,7 @@ import { LAYER_GROUPS, LAYER_GROUPS_ORDER } from 'config/layerOrder';
 import { linearColorScaleInterpolation } from 'utils/color';
 import { linearScaleInterpolation } from 'utils/numbers';
 
-import type { StdcmProgressPoints } from '../types';
+import type { StdcmProgressPoint, StdcmProgressPoints } from '../types';
 
 /**
  * Definition of the animation steps.
@@ -76,76 +76,67 @@ const ANIMATION_STEPS = [
  * For each range, we create a function that transform a point to a the geojson with the good style variables.
  * The last range is from the last step time to infinity and should return a static value (animation is finished).
  */
-const ANIMATIONS = ANIMATION_STEPS.reduce(
-  (acc, curr, index) => {
-    // Special case for the latest step,
-    if (index === ANIMATION_STEPS.length - 1) {
-      return [
-        ...acc,
-        {
-          timeRange: { min: curr.time, max: Infinity },
-          pointToGeojson: (point) => ({
-            type: 'Feature',
-            properties: ANIMATION_STEPS[ANIMATION_STEPS.length - 1],
-            geometry: point.geoPoint,
-          }),
-        },
-      ];
-    }
-
-    const next = ANIMATION_STEPS[index + 1];
-    const timeRange = {
-      min: curr.time,
-      max: next.time,
+const ANIMATIONS: Array<{
+  timeRange: { min: number; max: number };
+  pointToGeojson: (point: StdcmProgressPoint, elapsedTime: number) => Feature<Point>;
+}> = ANIMATION_STEPS.map((curr, index) => {
+  // Special case for the latest step,
+  if (index === ANIMATION_STEPS.length - 1) {
+    return {
+      timeRange: { min: curr.time, max: Infinity },
+      pointToGeojson: (point) => ({
+        type: 'Feature',
+        properties: ANIMATION_STEPS[ANIMATION_STEPS.length - 1],
+        geometry: point.geoPoint,
+      }),
     };
-    return [
-      ...acc,
-      {
-        timeRange,
-        pointToGeojson: (point, elapsedTime) => ({
-          type: 'Feature',
-          properties: {
-            innerCircleColor: linearColorScaleInterpolation(
-              { min: curr.innerCircleColor, max: next.innerCircleColor },
-              timeRange,
-              elapsedTime
-            ),
-            innerCircleSize: linearScaleInterpolation(
-              { min: curr.innerCircleSize, max: next.innerCircleSize },
-              timeRange,
-              elapsedTime
-            ),
-            innerCircleBorder: linearScaleInterpolation(
-              { min: curr.innerCircleBorder, max: next.innerCircleBorder },
-              timeRange,
-              elapsedTime
-            ),
-            outerCircleColor: linearColorScaleInterpolation(
-              { min: curr.outerCircleColor, max: next.outerCircleColor },
-              timeRange,
-              elapsedTime
-            ),
-            outerCircleSize: linearScaleInterpolation(
-              { min: curr.outerCircleSize, max: next.outerCircleSize },
-              timeRange,
-              elapsedTime
-            ),
-            outerCircleBorder: linearScaleInterpolation(
-              { min: curr.outerCircleBorder, max: next.outerCircleBorder },
-              timeRange,
-              elapsedTime
-            ),
-          },
-          geometry: point.geoPoint,
-        }),
+  }
+
+  const next = ANIMATION_STEPS[index + 1];
+  const timeRange = {
+    min: curr.time,
+    max: next.time,
+  };
+  return {
+    timeRange,
+    pointToGeojson: (point, elapsedTime) => ({
+      type: 'Feature',
+      properties: {
+        innerCircleColor: linearColorScaleInterpolation(
+          { from: curr.innerCircleColor, to: next.innerCircleColor },
+          timeRange,
+          elapsedTime
+        ),
+        innerCircleSize: linearScaleInterpolation(
+          { from: curr.innerCircleSize, to: next.innerCircleSize },
+          timeRange,
+          elapsedTime
+        ),
+        innerCircleBorder: linearScaleInterpolation(
+          { from: curr.innerCircleBorder, to: next.innerCircleBorder },
+          timeRange,
+          elapsedTime
+        ),
+        outerCircleColor: linearColorScaleInterpolation(
+          { from: curr.outerCircleColor, to: next.outerCircleColor },
+          timeRange,
+          elapsedTime
+        ),
+        outerCircleSize: linearScaleInterpolation(
+          { from: curr.outerCircleSize, to: next.outerCircleSize },
+          timeRange,
+          elapsedTime
+        ),
+        outerCircleBorder: linearScaleInterpolation(
+          { from: curr.outerCircleBorder, to: next.outerCircleBorder },
+          timeRange,
+          elapsedTime
+        ),
       },
-    ];
-  },
-  [] as Array<{
-    timeRange: { min: number; max: number };
-    pointToGeojson: (point: StdcmProgressPoints[0], elapsedTime: number) => Feature<Point>;
-  }>
-);
+      geometry: point.geoPoint,
+    }),
+  };
+});
 
 /**
  * React Map layer component that display the progress of the stdcm path finding algo.
@@ -169,7 +160,13 @@ const StdcmMapProgressLayer = ({
       const data: FeatureCollection = {
         type: 'FeatureCollection',
         features: progressPoints.current.map((point) => {
-          const elapsedTime = Date.now() - point.timestamp;
+          // Point timestamp can be in the futur. If so its delta time is O except if it override a previous point
+          // In this case it takes the max animation value
+          const deltaTime = Date.now() - point.animationStartTime;
+          let elapsedTime = deltaTime;
+          if (deltaTime < 0) {
+            elapsedTime = point.skipFadeIn ? ANIMATION_STEPS.at(-1)!.time : 0;
+          }
           const animation = ANIMATIONS.find(
             (a) => a.timeRange.min <= elapsedTime && elapsedTime < a.timeRange.max
           )!;

--- a/front/src/applications/stdcm/hooks/useStdcm.ts
+++ b/front/src/applications/stdcm/hooks/useStdcm.ts
@@ -11,6 +11,7 @@ import {
   STDCM_TRAIN_TIMETABLE_ID,
 } from 'applications/stdcm/consts';
 import type {
+  StdcmProgressPoint,
   StdcmProgressPoints,
   StdcmRequestStatus,
   StdcmSimulation,
@@ -170,8 +171,8 @@ const useStdcm = ({
       const downstream = postTimetableByIdStdcm(payloadDownstream);
       abortRequests.current = [upstream.unsubscribe, downstream.unsubscribe];
 
-      const promiseUpstream = upstream.awaitResult();
-      const promiseDownstream = downstream.awaitResult();
+      const promiseUpstream = upstream.runAndAwaitResult();
+      const promiseDownstream = downstream.runAndAwaitResult();
 
       // Run two additional requests for alternative simulations
       const [resUp, resDown] = await Promise.all([promiseUpstream, promiseDownstream]);
@@ -226,8 +227,11 @@ const useStdcm = ({
       // The key is built from rounded coordinates (toFixed(1)),
       // allowing nearby points to be grouped into the same grid cell
       // and avoiding storing too many very close points
-      const pointsOnGrid = new Map<string, StdcmProgressPoints[0]>();
+      const pointsOnGrid = new Map<string, StdcmProgressPoint>();
 
+      // We can receive many points at the same timestamp. To avoid displaying them at once,
+      // we track the number of nodes received at the same timestamp to be able to add a delay
+      let lastPointReceivedAt = { timestamp: Date.now(), nb: 0 };
       // Listen to events
       await subscribe(async (event) => {
         switch (event.event) {
@@ -236,14 +240,27 @@ const useStdcm = ({
             break;
           }
           case 'ongoing': {
-            const newPoint = { geoPoint: event.data.point, timestamp: Date.now() };
+            const now = Date.now();
+            if (now > lastPointReceivedAt.timestamp) {
+              lastPointReceivedAt = { timestamp: Date.now(), nb: 0 };
+            } else {
+              lastPointReceivedAt.nb++;
+            }
+            const newPoint = {
+              geoPoint: event.data.point,
+              animationStartTime: lastPointReceivedAt.timestamp + 10 * lastPointReceivedAt.nb,
+            };
             const newPointKey = newPoint.geoPoint.coordinates.map((n) => n.toFixed(1)).join('/');
             const pointOnGrid = pointsOnGrid.get(newPointKey);
-            // If a point is already present, we check that its animation is ended before to replace it to avoid blink effect
-            if (!pointOnGrid || newPoint.timestamp - pointOnGrid.timestamp > 2000) {
+
+            if (!pointOnGrid) {
               pointsOnGrid.set(newPointKey, newPoint);
-              progressPoints.current = [...pointsOnGrid.values()];
+              // If a point is already present, we check that its animation is ended before to replace it to avoid blink effect
+              // and we set that if this new point override a previous one
+            } else if (now - pointOnGrid.animationStartTime > 2000) {
+              pointsOnGrid.set(newPointKey, { ...newPoint, skipFadeIn: true });
             }
+            progressPoints.current = [...pointsOnGrid.values()];
             break;
           }
           case 'completed': {

--- a/front/src/applications/stdcm/hooks/useStdcm.ts
+++ b/front/src/applications/stdcm/hooks/useStdcm.ts
@@ -11,6 +11,7 @@ import {
   STDCM_TRAIN_TIMETABLE_ID,
 } from 'applications/stdcm/consts';
 import type {
+  StdcmProgressPoints,
   StdcmRequestStatus,
   StdcmSimulation,
   StdcmSimulationInputs,
@@ -19,8 +20,8 @@ import type {
 import {
   osrdEditoastApi,
   type PostTimetableByIdStdcmApiArg,
-  type PostTimetableByIdStdcmApiResponseWithTraceId,
   type RollingStockWithLiveries,
+  type StdcmResponseWithTraceId,
 } from 'common/api/osrdEditoastApi';
 import { setFailure } from 'reducers/main';
 import { addStdcmSimulations } from 'reducers/osrdconf/stdcmConf';
@@ -52,12 +53,13 @@ const useStdcm = ({
   const dateTimeLocale = useDateTimeLocale();
   const osrdconf = useSelector(getStdcmConf);
   const infraId = useSelector(getStdcmInfraID);
-  const requestPromise = useRef<ReturnType<typeof postTimetableByIdStdcm>[]>(null);
+  const abortRequests = useRef<Array<() => void>>(null);
   const isCancelledRef = useRef(false);
+  const progressPoints = useRef<StdcmProgressPoints>([]);
 
   const currentSimulationInputs = useStdcmForm();
 
-  const [postTimetableByIdStdcm] = osrdEditoastApi.endpoints.postTimetableByIdStdcm.useMutation();
+  const postTimetableByIdStdcm = osrdEditoastApi.endpoints.postTimetableByIdStdcm;
 
   const { data: stdcmRollingStock } =
     osrdEditoastApi.endpoints.getLightRollingStockByRollingStockId.useQuery(
@@ -77,10 +79,7 @@ const useStdcm = ({
   const createSimulation = async (
     inputs: StdcmSimulationInputs,
     payload: PostTimetableByIdStdcmApiArg,
-    response: Extract<
-      PostTimetableByIdStdcmApiResponseWithTraceId,
-      { status: 'success' | 'path_not_found' }
-    >,
+    response: Extract<StdcmResponseWithTraceId, { status: 'success' | 'path_not_found' }>,
     alternativePath?: 'upstream' | 'downstream'
   ): Promise<Omit<StdcmSimulation, 'index'>> => {
     const creationDate = new Date();
@@ -143,19 +142,18 @@ const useStdcm = ({
   };
 
   const handleSuccess = async (
-    response: Extract<PostTimetableByIdStdcmApiResponseWithTraceId, { status: 'success' }>,
+    response: Extract<StdcmResponseWithTraceId, { status: 'success' }>,
     payload: PostTimetableByIdStdcmApiArg
   ) => {
     setCurrentStdcmRequestStatus(STDCM_REQUEST_STATUS.success);
     dispatch(updateSelectedTrainId(STDCM_TRAIN_TIMETABLE_ID));
 
     const simulation = await createSimulation(currentSimulationInputs, payload, response);
-    if (isCancelledRef.current) return;
     dispatch(addStdcmSimulations([simulation]));
   };
 
   const handlePathNotFound = async (
-    response: Extract<PostTimetableByIdStdcmApiResponseWithTraceId, { status: 'path_not_found' }>,
+    response: Extract<StdcmResponseWithTraceId, { status: 'path_not_found' }>,
     payload: PostTimetableByIdStdcmApiArg
   ) => {
     const simulationsToAdd: Omit<StdcmSimulation, 'index'>[] = [];
@@ -168,22 +166,24 @@ const useStdcm = ({
       const payloadUpstream = adjustPayloadByDirection(payload, 'upstream');
       const payloadDownstream = adjustPayloadByDirection(payload, 'downstream');
 
-      const promiseUpstream = postTimetableByIdStdcm(payloadUpstream);
-      const promiseDownstream = postTimetableByIdStdcm(payloadDownstream);
-      requestPromise.current = [promiseUpstream, promiseDownstream];
+      const upstream = postTimetableByIdStdcm(payloadUpstream);
+      const downstream = postTimetableByIdStdcm(payloadDownstream);
+      abortRequests.current = [upstream.unsubscribe, downstream.unsubscribe];
+
+      const promiseUpstream = upstream.awaitResult();
+      const promiseDownstream = downstream.awaitResult();
 
       // Run two additional requests for alternative simulations
-      const [resUp, resDown] = await Promise.all([
-        promiseUpstream.unwrap(),
-        promiseDownstream.unwrap(),
-      ]);
+      const [resUp, resDown] = await Promise.all([promiseUpstream, promiseDownstream]);
 
+      // Handle error cases
+      if (resUp.status === 'internal_error') throw new Error(resUp.error.message);
+      if (resDown.status === 'internal_error') throw new Error(resDown.error.message);
       if (
         resUp.status === 'preprocessing_simulation_error' ||
         resDown.status === 'preprocessing_simulation_error'
-      ) {
+      )
         throw new Error('Error in response');
-      }
 
       dispatch(updateSelectedTrainId(STDCM_TRAIN_TIMETABLE_ID));
 
@@ -211,6 +211,7 @@ const useStdcm = ({
   const launchStdcmRequest = async () => {
     resetStdcmState();
     isCancelledRef.current = false;
+    progressPoints.current = [];
 
     const validConfig = checkStdcmConf(dispatch, t, dateTimeLocale, osrdconf);
     if (!validConfig) return;
@@ -219,33 +220,62 @@ const useStdcm = ({
     const payload = formatStdcmPayload(validConfig);
 
     try {
-      const promise = postTimetableByIdStdcm(payload);
-      requestPromise.current = [promise];
+      const { subscribe, unsubscribe } = postTimetableByIdStdcm(payload);
+      abortRequests.current = [unsubscribe];
+      // This Map acts as a spatial grid.
+      // The key is built from rounded coordinates (toFixed(1)),
+      // allowing nearby points to be grouped into the same grid cell
+      // and avoiding storing too many very close points
+      const pointsOnGrid = new Map<string, StdcmProgressPoints[0]>();
 
-      const response = await promise.unwrap();
-
-      if (response.status === 'success') {
-        await handleSuccess(response, payload);
-      } else if (response.status === 'path_not_found') {
-        await handlePathNotFound(response, payload);
-      } else {
-        handleRejection(new Error('Unexpected response status.'));
-      }
+      // Listen to events
+      await subscribe(async (event) => {
+        switch (event.event) {
+          case 'error': {
+            if (event.error.name !== 'AbortError') handleRejection(event.error);
+            break;
+          }
+          case 'ongoing': {
+            const newPoint = { geoPoint: event.data.point, timestamp: Date.now() };
+            const newPointKey = newPoint.geoPoint.coordinates.map((n) => n.toFixed(1)).join('/');
+            const pointOnGrid = pointsOnGrid.get(newPointKey);
+            // If a point is already present, we check that its animation is ended before to replace it to avoid blink effect
+            if (!pointOnGrid || newPoint.timestamp - pointOnGrid.timestamp > 2000) {
+              pointsOnGrid.set(newPointKey, newPoint);
+              progressPoints.current = [...pointsOnGrid.values()];
+            }
+            break;
+          }
+          case 'completed': {
+            const result = event.data;
+            switch (result.status) {
+              case 'path_not_found':
+                await handlePathNotFound(result, payload);
+                break;
+              case 'success':
+                await handleSuccess(result, payload);
+                break;
+              case 'preprocessing_simulation_error':
+                await handleRejection(result.error);
+                break;
+              case 'internal_error':
+                await handleRejection(result.error);
+            }
+            break;
+          }
+        }
+      });
     } catch (err) {
-      if ((err as Error).name !== 'AbortError') {
-        handleRejection(err);
-      }
+      handleRejection(err);
     }
   };
 
   const cancelStdcmRequest = () => {
     isCancelledRef.current = true;
-    requestPromise.current?.forEach((promise) => {
-      if (typeof promise.abort === 'function') {
-        promise.abort();
-      }
+    abortRequests.current?.forEach((abortFn) => {
+      abortFn();
     });
-    requestPromise.current = null;
+    abortRequests.current = null;
     setCurrentStdcmRequestStatus(STDCM_REQUEST_STATUS.canceled);
   };
 
@@ -264,6 +294,7 @@ const useStdcm = ({
     isCanceled,
     isPendingAdditional,
     isCalculationCompleted,
+    progressPoints,
   };
 };
 

--- a/front/src/applications/stdcm/types.ts
+++ b/front/src/applications/stdcm/types.ts
@@ -257,4 +257,17 @@ export type StdcmSearchDatetimeWindow = {
   end: Date;
 };
 
-export type StdcmProgressPoints = Array<{ geoPoint: GeoJsonPoint; timestamp: number }>;
+export type StdcmProgressPoint = {
+  geoPoint: GeoJsonPoint;
+  /** When the animation for this point should start. When many points
+   *  arrive at the same time, each one is delayed by a few ms so they
+   *  don't all appear together (can be in the future).
+   */
+  animationStartTime: number;
+  /** If true, show the point directly in its final state and skip the
+   *  fade-in. Used when a new point replaces an old one whose animation
+   *  was already done.
+   */
+  skipFadeIn?: boolean;
+};
+export type StdcmProgressPoints = StdcmProgressPoint[];

--- a/front/src/applications/stdcm/types.ts
+++ b/front/src/applications/stdcm/types.ts
@@ -3,11 +3,11 @@ import type {
   GeoJsonPoint,
   Conflict,
   LightRollingStock,
-  PostTimetableByIdStdcmApiResponseWithTraceId,
   LightRollingStockWithLiveries,
   TowedRollingStock,
   PathProperties,
   LoadingGaugeType,
+  StdcmResponseWithTraceId,
 } from 'common/api/osrdEditoastApi';
 import type {
   PathOperationalPoint,
@@ -21,10 +21,7 @@ import type { ValueOf } from 'utils/types';
 
 export type StdcmRequestStatus = ValueOf<typeof STDCM_REQUEST_STATUS>;
 
-export type StdcmSuccessResponse = Extract<
-  PostTimetableByIdStdcmApiResponseWithTraceId,
-  { status: 'success' }
-> & {
+export type StdcmSuccessResponse = Extract<StdcmResponseWithTraceId, { status: 'success' }> & {
   rollingStock: LightRollingStock;
   creationDate: Date;
   speedLimitByTag?: string;
@@ -32,10 +29,7 @@ export type StdcmSuccessResponse = Extract<
   alternativePath?: 'upstream' | 'downstream';
 };
 
-export type StdcmPathNotFound = Extract<
-  PostTimetableByIdStdcmApiResponseWithTraceId,
-  { status: 'path_not_found' }
->;
+export type StdcmPathNotFound = Extract<StdcmResponseWithTraceId, { status: 'path_not_found' }>;
 
 export type StdcmResponse = StdcmPathNotFound | StdcmSuccessResponse;
 
@@ -262,3 +256,5 @@ export type StdcmSearchDatetimeWindow = {
   begin: Date;
   end: Date;
 };
+
+export type StdcmProgressPoints = Array<{ geoPoint: GeoJsonPoint; timestamp: number }>;

--- a/front/src/common/api/editoastStream/postTimetableByIdStdcm.ts
+++ b/front/src/common/api/editoastStream/postTimetableByIdStdcm.ts
@@ -24,7 +24,9 @@ export default function postTimetableByIdStdcm(args: PostTimetableByIdStdcmApiAr
         }
       );
       if (!response.ok) {
-        throw new Error('Bad response from stdcm stream endpoint');
+        throw new Error(
+          `Bad response from stdcm stream endpoint: ${response.status} ${response.statusText}`
+        );
       }
       const traceparent = response.headers.get('traceparent');
       const traceId = traceparent?.split('-')[1];
@@ -60,7 +62,7 @@ export default function postTimetableByIdStdcm(args: PostTimetableByIdStdcmApiAr
     controller.abort();
   };
 
-  const awaitResult = () =>
+  const runAndAwaitResult = () =>
     new Promise<StdcmResponse>((resolve, reject) => {
       subscribe((event) => {
         if (event.event === 'error') reject(event.error);
@@ -73,6 +75,6 @@ export default function postTimetableByIdStdcm(args: PostTimetableByIdStdcmApiAr
   return {
     subscribe,
     unsubscribe,
-    awaitResult,
+    runAndAwaitResult,
   };
 }

--- a/front/src/common/api/editoastStream/postTimetableByIdStdcm.ts
+++ b/front/src/common/api/editoastStream/postTimetableByIdStdcm.ts
@@ -1,0 +1,78 @@
+import type {
+  PostTimetableByIdStdcmApiArg,
+  PostTimetableByIdStdcmApiResponseWithTraceId,
+  StdcmResponse,
+} from 'common/api/osrdEditoastApi';
+
+export default function postTimetableByIdStdcm(args: PostTimetableByIdStdcmApiArg) {
+  const controller = new AbortController();
+  const { signal } = controller;
+
+  const subscribe = async (
+    callback: (
+      arg: PostTimetableByIdStdcmApiResponseWithTraceId | { event: 'error'; error: Error }
+    ) => void
+  ) => {
+    try {
+      const response = await fetch(
+        `/api/timetable/${args.id}/stdcm?infra=${args.infra}${args.returnDebugPayloads === true ? '&return_debug_payloads' : ''}`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(args.body),
+          signal: signal,
+        }
+      );
+      if (!response.ok) {
+        throw new Error('Bad response from stdcm stream endpoint');
+      }
+      const traceparent = response.headers.get('traceparent');
+      const traceId = traceparent?.split('-')[1];
+
+      const reader = response.body!.getReader();
+      const decoder = new TextDecoder();
+      let buffer: string = '';
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() || '';
+
+        for (const line of lines) {
+          try {
+            const data = JSON.parse(line);
+            callback({ ...data, traceId });
+          } catch (e) {
+            console.error(e);
+            throw new Error(`Error while JSON parse ${line}`);
+          }
+        }
+      }
+    } catch (e) {
+      callback({ event: 'error', error: e as Error });
+      controller.abort();
+    }
+  };
+
+  const unsubscribe = () => {
+    controller.abort();
+  };
+
+  const awaitResult = () =>
+    new Promise<StdcmResponse>((resolve, reject) => {
+      subscribe((event) => {
+        if (event.event === 'error') reject(event.error);
+        else {
+          if (event.event === 'completed') resolve(event.data);
+        }
+      });
+    });
+
+  return {
+    subscribe,
+    unsubscribe,
+    awaitResult,
+  };
+}

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -2291,20 +2291,12 @@ export type GetTimetableByIdRoundTripsTrainSchedulesApiArg = {
 };
 export type PostTimetableByIdStdcmApiResponse = /** status 200 The simulation result */
   | {
-      core_payload?: null | CoreStdcmRequest;
-      departure_time: string;
-      pathfinding_result: CorePathfindingResultSuccess;
-      simulation: SimulationResponseSuccess;
-      status: 'success';
+      data: StdcmProgressionEvent;
+      event: 'ongoing';
     }
   | {
-      core_payload?: null | CoreStdcmRequest;
-      status: 'path_not_found';
-    }
-  | {
-      core_payload?: null | CoreStdcmRequest;
-      error: SimulationResponse;
-      status: 'preprocessing_simulation_error';
+      data: StdcmResponse;
+      event: 'completed';
     };
 export type PostTimetableByIdStdcmApiArg = {
   /** timetable_id */
@@ -4407,6 +4399,10 @@ export type CoreTrainRequirementsById = {
   /** ID that can be used to find the train in tools other than OSRD. Used in debug traces. */
   train_name: string;
 };
+export type StdcmProgressionEvent = {
+  best_travel_time: number;
+  point: GeoJsonPoint;
+};
 export type ConsistConfiguration = {
   loading_gauge_type?: null | LoadingGaugeType;
   /** Velocity in m·s⁻¹ */
@@ -4598,6 +4594,28 @@ export type SimulationResponse =
   | {
       core_error: InternalError;
       status: 'simulation_failed';
+    };
+export type StdcmResponse =
+  | {
+      core_payload?: null | CoreStdcmRequest;
+      departure_time: string;
+      pathfinding_result: CorePathfindingResultSuccess;
+      simulation: SimulationResponseSuccess;
+      status: 'success';
+    }
+  | {
+      core_payload?: null | CoreStdcmRequest;
+      status: 'path_not_found';
+    }
+  | {
+      core_payload?: null | CoreStdcmRequest;
+      error: SimulationResponse;
+      status: 'preprocessing_simulation_error';
+    }
+  | {
+      core_payload?: null | CoreStdcmRequest;
+      error: InternalError;
+      status: 'internal_error';
     };
 export type PathfindingItem = {
   /** The stop duration in milliseconds, None if the train does not stop. */

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -9,6 +9,7 @@ import {
 } from 'utils/trainId';
 
 import type { ApiError } from './baseGeneratedApis';
+import postTimetableByIdStdcm from './editoastStream/postTimetableByIdStdcm';
 import {
   generatedEditoastApi,
   type CatalogEntry,
@@ -24,10 +25,14 @@ import {
   type PostTimetableByIdStdcmApiResponse,
   type RelatedOperationalPoint,
   type SimulationResponse,
+  type StdcmResponse,
 } from './generatedEditoastApi';
 
 // Type extension for PostTimetableByIdStdcm to include traceId
 export type PostTimetableByIdStdcmApiResponseWithTraceId = PostTimetableByIdStdcmApiResponse & {
+  traceId?: string;
+};
+export type StdcmResponseWithTraceId = StdcmResponse & {
   traceId?: string;
 };
 
@@ -278,18 +283,6 @@ const osrdEditoastApi = generatedEditoastApi
   })
   .enhanceEndpoints({
     endpoints: {
-      postTimetableByIdStdcm: {
-        transformResponse: (
-          response: PostTimetableByIdStdcmApiResponse,
-          metadata: { response: Response }
-        ): PostTimetableByIdStdcmApiResponseWithTraceId => {
-          const headers = metadata.response.headers;
-          const traceparent = headers.get('traceparent');
-          const traceId = traceparent?.split('-')[1];
-
-          return { ...response, traceId };
-        },
-      },
       getLightRollingStock: {
         transformResponse: (response: GetLightRollingStockApiResponse) => ({
           ...response,
@@ -455,4 +448,13 @@ const osrdEditoastApi = generatedEditoastApi
   });
 
 export * from './generatedEditoastApi';
-export { osrdEditoastApi };
+
+const enhancedOsrdEditoastApi = {
+  ...osrdEditoastApi,
+  endpoints: {
+    ...osrdEditoastApi.endpoints,
+    postTimetableByIdStdcm,
+  },
+};
+
+export { enhancedOsrdEditoastApi as osrdEditoastApi };

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -449,6 +449,14 @@ const osrdEditoastApi = generatedEditoastApi
 
 export * from './generatedEditoastApi';
 
+/**
+ * RTK Query's mutation hook can't expose intermediate streaming events to
+ * the component (it only returns a final result). So we replace the
+ * generated `postTimetableByIdStdcm` endpoint with a custom streaming
+ * function.
+ *
+ * The generated RTK types are still used to keep type safety on the payload
+ */
 const enhancedOsrdEditoastApi = {
   ...osrdEditoastApi,
   endpoints: {

--- a/front/src/utils/__tests__/color.spec.ts
+++ b/front/src/utils/__tests__/color.spec.ts
@@ -5,26 +5,48 @@ import { linearColorScaleInterpolation } from 'utils/color';
 describe('linearColorScaleInterpolation', () => {
   it('should work with value in domain range', () => {
     const value = linearColorScaleInterpolation(
-      { min: '#000000', max: '#0000FF' },
+      { from: '#000000', to: '#0000FF' },
       { min: 0, max: 255 },
       15
     );
     expect(value.toUpperCase()).toBe('#00000F');
   });
-  it('should return min scale with value inferior to domain range', () => {
+  it('should return "from"" scale with value inferior to domain range', () => {
     const value = linearColorScaleInterpolation(
-      { min: '#000000', max: '#0000FF' },
+      { from: '#000000', to: '#0000FF' },
       { min: 0, max: 255 },
       -10
     );
     expect(value.toUpperCase()).toBe('#000000');
   });
-  it('should return max scale with value superior to domain range', () => {
+  it('should return "to" scale with value superior to domain range', () => {
     const value = linearColorScaleInterpolation(
-      { min: '#000000', max: '#0000FF' },
+      { from: '#000000', to: '#0000FF' },
       { min: 0, max: 255 },
       300
     );
     expect(value.toUpperCase()).toBe('#0000FF');
+  });
+
+  it('should return "from" scale with value equal to min domain range', () => {
+    const value = linearColorScaleInterpolation(
+      { from: '#000000', to: '#0000FF' },
+      { min: 0, max: 255 },
+      0
+    );
+    expect(value.toUpperCase()).toBe('#000000');
+  });
+  it('should return "to" scale with value equal to max domain range', () => {
+    const value = linearColorScaleInterpolation(
+      { from: '#000000', to: '#0000FF' },
+      { min: 0, max: 255 },
+      255
+    );
+    expect(value.toUpperCase()).toBe('#0000FF');
+  });
+  it('should throw when domain min is greater than max', () => {
+    expect(() =>
+      linearColorScaleInterpolation({ from: '#000000', to: '#0000FF' }, { min: 100, max: 0 }, 50)
+    ).toThrow();
   });
 });

--- a/front/src/utils/__tests__/color.spec.ts
+++ b/front/src/utils/__tests__/color.spec.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+
+import { linearColorScaleInterpolation } from 'utils/color';
+
+describe('linearColorScaleInterpolation', () => {
+  it('should work with value in domain range', () => {
+    const value = linearColorScaleInterpolation(
+      { min: '#000000', max: '#0000FF' },
+      { min: 0, max: 255 },
+      15
+    );
+    expect(value.toUpperCase()).toBe('#00000F');
+  });
+  it('should return min scale with value inferior to domain range', () => {
+    const value = linearColorScaleInterpolation(
+      { min: '#000000', max: '#0000FF' },
+      { min: 0, max: 255 },
+      -10
+    );
+    expect(value.toUpperCase()).toBe('#000000');
+  });
+  it('should return max scale with value superior to domain range', () => {
+    const value = linearColorScaleInterpolation(
+      { min: '#000000', max: '#0000FF' },
+      { min: 0, max: 255 },
+      300
+    );
+    expect(value.toUpperCase()).toBe('#0000FF');
+  });
+});

--- a/front/src/utils/__tests__/numbers.spec.ts
+++ b/front/src/utils/__tests__/numbers.spec.ts
@@ -68,15 +68,41 @@ describe('isInvalidFloatNumber', () => {
 
 describe('linearScaleInterpolation', () => {
   it('should work with value in domain range', () => {
-    const value = linearScaleInterpolation({ min: 0, max: 100 }, { min: 2000, max: 2025 }, 2005);
+    const value = linearScaleInterpolation({ from: 0, to: 100 }, { min: 2000, max: 2025 }, 2005);
     expect(value).toBe(20);
+
+    const value2 = linearScaleInterpolation({ from: 100, to: 0 }, { min: 2000, max: 2025 }, 2005);
+    expect(value2).toBe(80);
   });
-  it('should return min scale with value inferior to domain range', () => {
-    const value = linearScaleInterpolation({ min: 0, max: 100 }, { min: 2000, max: 2025 }, 1998);
+  it('should return "from" scale with value inferior to domain range', () => {
+    const value = linearScaleInterpolation({ from: 0, to: 100 }, { min: 2000, max: 2025 }, 1998);
     expect(value).toBe(0);
+
+    const value2 = linearScaleInterpolation({ from: 100, to: 0 }, { min: 2000, max: 2025 }, 1998);
+    expect(value2).toBe(100);
   });
-  it('should return max scale with value superior to domain range', () => {
-    const value = linearScaleInterpolation({ min: 0, max: 100 }, { min: 2000, max: 2025 }, 2026);
+  it('should return "to" scale with value superior to domain range', () => {
+    const value = linearScaleInterpolation({ from: 0, to: 100 }, { min: 2000, max: 2025 }, 2026);
     expect(value).toBe(100);
+
+    const value2 = linearScaleInterpolation({ from: 100, to: 0 }, { min: 2000, max: 2025 }, 2026);
+    expect(value2).toBe(0);
+  });
+  it('should return "from" scale with value equal to min domain range', () => {
+    const value = linearScaleInterpolation({ from: 0, to: 100 }, { min: 2000, max: 2025 }, 2000);
+    expect(value).toBe(0);
+
+    const value2 = linearScaleInterpolation({ from: 100, to: 0 }, { min: 2000, max: 2025 }, 2000);
+    expect(value2).toBe(100);
+  });
+  it('should return "to" scale with value equal to max domain range', () => {
+    const value = linearScaleInterpolation({ from: 0, to: 100 }, { min: 2000, max: 2025 }, 2025);
+    expect(value).toBe(100);
+
+    const value2 = linearScaleInterpolation({ from: 100, to: 0 }, { min: 2000, max: 2025 }, 2025);
+    expect(value2).toBe(0);
+  });
+  it('should throw when domain min is greater than max', () => {
+    expect(() => linearScaleInterpolation({ from: 0, to: 10 }, { min: 100, max: 0 }, 50)).toThrow();
   });
 });

--- a/front/src/utils/__tests__/numbers.spec.ts
+++ b/front/src/utils/__tests__/numbers.spec.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from 'vitest';
 
-import { budgetFormat, isFloat, isInvalidFloatNumber } from 'utils/numbers';
+import {
+  budgetFormat,
+  isFloat,
+  isInvalidFloatNumber,
+  linearScaleInterpolation,
+} from 'utils/numbers';
 import { NARROW_NO_BREAK_SPACE, NO_BREAK_SPACE } from 'utils/strings';
 
 describe('budgetFormat', () => {
@@ -58,5 +63,20 @@ describe('isInvalidFloatNumber', () => {
 
   it('should return false if the number is NaN and decimal number is NaN', () => {
     expect(isInvalidFloatNumber(NaN, NaN)).toBe(false);
+  });
+});
+
+describe('linearScaleInterpolation', () => {
+  it('should work with value in domain range', () => {
+    const value = linearScaleInterpolation({ min: 0, max: 100 }, { min: 2000, max: 2025 }, 2005);
+    expect(value).toBe(20);
+  });
+  it('should return min scale with value inferior to domain range', () => {
+    const value = linearScaleInterpolation({ min: 0, max: 100 }, { min: 2000, max: 2025 }, 1998);
+    expect(value).toBe(0);
+  });
+  it('should return max scale with value superior to domain range', () => {
+    const value = linearScaleInterpolation({ min: 0, max: 100 }, { min: 2000, max: 2025 }, 2026);
+    expect(value).toBe(100);
   });
 });

--- a/front/src/utils/color.ts
+++ b/front/src/utils/color.ts
@@ -3,13 +3,13 @@ import chroma from 'chroma-js';
 /**
  * Linear color interpolation for a value from the domain range into the scale range.
  *
- * @param scale The min & max color (of the range you want (the target range)
- * @param domain The min & max of the domain range of the data (the data range)
+ * @param scale The color of the range you want (target range)
+ * @param domain The min & max of the domain range of the data (data range)
  * @param value The value in domain range to interpolate into scale range
  * @returns A color as string like rgb(0,0,0)
  */
 export function linearColorScaleInterpolation(
-  scale: { min: string; max: string },
+  scale: { from: string; to: string },
   domain: { min: number; max: number },
   value: number
 ): string {
@@ -18,10 +18,10 @@ export function linearColorScaleInterpolation(
     throw new Error("Domain: 'min' is superior to 'max' which is not allowed");
 
   // Side effects
-  if (value >= domain.max) return scale.max;
-  if (value <= domain.min) return scale.min;
+  if (value >= domain.max) return scale.to;
+  if (value <= domain.min) return scale.from;
 
   // Linear interpolation
-  const f = chroma.scale([scale.min, scale.max]).domain([domain.min, domain.max]);
+  const f = chroma.scale([scale.from, scale.to]).domain([domain.min, domain.max]);
   return f(value).hex();
 }

--- a/front/src/utils/color.ts
+++ b/front/src/utils/color.ts
@@ -1,0 +1,27 @@
+import chroma from 'chroma-js';
+
+/**
+ * Linear color interpolation for a value from the domain range into the scale range.
+ *
+ * @param scale The min & max color (of the range you want (the target range)
+ * @param domain The min & max of the domain range of the data (the data range)
+ * @param value The value in domain range to interpolate into scale range
+ * @returns A color as string like rgb(0,0,0)
+ */
+export function linearColorScaleInterpolation(
+  scale: { min: string; max: string },
+  domain: { min: number; max: number },
+  value: number
+): string {
+  // Checks
+  if (domain.min > domain.max)
+    throw new Error("Domain: 'min' is superior to 'max' which is not allowed");
+
+  // Side effects
+  if (value >= domain.max) return scale.max;
+  if (value <= domain.min) return scale.min;
+
+  // Linear interpolation
+  const f = chroma.scale([scale.min, scale.max]).domain([domain.min, domain.max]);
+  return f(value).hex();
+}

--- a/front/src/utils/numbers.ts
+++ b/front/src/utils/numbers.ts
@@ -43,21 +43,25 @@ export const isInvalidFloatNumber = (value: number, numberOfDecimal: number): bo
 /**
  * Linear interpolation for a value from the domain range into the scale range.
  *
- * @param scale The min & max value of the range you want (the target range)
- * @param domain The min & max of the domain range of the data (the data range)
+ * @param scale The range you want (target range)
+ * @param domain The min & max of the domain range of the data (data range)
  * @param value The value in domain range to interpolate into scale range
  */
 export function linearScaleInterpolation(
-  scale: { min: number; max: number },
+  scale: { from: number; to: number },
   domain: { min: number; max: number },
   value: number
 ): number {
+  // Checks
+  if (domain.min > domain.max)
+    throw new Error("Domain: 'min' is superior to 'max' which is not allowed");
+
   // Side effects
-  if (value >= domain.max) return scale.max;
-  if (value <= domain.min) return scale.min;
+  if (value >= domain.max) return scale.to;
+  if (value <= domain.min) return scale.from;
 
   // Linear interpolation
-  const ratio = (scale.max - scale.min) / (domain.max - domain.min);
-  const result = scale.min + ratio * (value - domain.min);
-  return isNaN(result) ? scale.min : result;
+  const ratio = (scale.to - scale.from) / (domain.max - domain.min);
+  const result = scale.from + ratio * (value - domain.min);
+  return isNaN(result) ? scale.from : result;
 }

--- a/front/src/utils/numbers.ts
+++ b/front/src/utils/numbers.ts
@@ -39,3 +39,25 @@ export const isInvalidFloatNumber = (value: number, numberOfDecimal: number): bo
   const stringifyValue = value.toString();
   return stringifyValue.split('.')[1].length > numberOfDecimal;
 };
+
+/**
+ * Linear interpolation for a value from the domain range into the scale range.
+ *
+ * @param scale The min & max value of the range you want (the target range)
+ * @param domain The min & max of the domain range of the data (the data range)
+ * @param value The value in domain range to interpolate into scale range
+ */
+export function linearScaleInterpolation(
+  scale: { min: number; max: number },
+  domain: { min: number; max: number },
+  value: number
+): number {
+  // Side effects
+  if (value >= domain.max) return scale.max;
+  if (value <= domain.min) return scale.min;
+
+  // Linear interpolation
+  const ratio = (scale.max - scale.min) / (domain.max - domain.min);
+  const result = scale.min + ratio * (value - domain.min);
+  return isNaN(result) ? scale.min : result;
+}


### PR DESCRIPTION
Fix #15171

Adding a new layer on top of the LMR map, to display the progress of the algo. 

- The STDCM endpoint has been changed to stream data as JSONL, which is not supported by RTK query (check the second commit)
- Continuously repaint the map to generate the animation (check the third commit)

> [!WARNING]
> This PR is based on  #15315 &  #15662
> We merged our work into the same branch `bam/lmr-search-progress` before to do it on `dev`

Here is the render on the map :

https://github.com/user-attachments/assets/16f8eb4f-d191-48e7-b904-5feff269c4f1