### PR TITLE
front: nge: set backwards travel time

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/osrdToNge.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/osrdToNge.ts
@@ -554,6 +554,12 @@ const getNgeTrainrunSectionsWithNodes = (
           travelTime.consecutiveTime = travelTime.time;
         }
 
+        const backwardTravelTime = { ...DEFAULT_TIME_LOCK };
+        if (sourceArrival.consecutiveTime !== null && targetDeparture.consecutiveTime !== null) {
+          backwardTravelTime.time = sourceArrival.consecutiveTime - targetDeparture.consecutiveTime;
+          backwardTravelTime.consecutiveTime = backwardTravelTime.time;
+        }
+
         // Minute symmetry
         const sourceSymmetry = Boolean(
           sourceDeparture.time &&
@@ -573,6 +579,7 @@ const getNgeTrainrunSectionsWithNodes = (
           targetNodeId: targetNode.id,
           targetPortId: targetPort.id,
           travelTime,
+          backwardTravelTime,
           sourceDeparture,
           sourceArrival,
           targetDeparture,

--- a/front/src/applications/operationalStudies/views/Scenario/components/NGE/types.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/NGE/types.ts
@@ -81,6 +81,7 @@ export type TrainrunSectionDto = {
   targetDeparture: TimeLockDto;
   targetArrival: TimeLockDto;
   travelTime: TimeLockDto;
+  backwardTravelTime: TimeLockDto;
 
   numberOfStops: number;
 


### PR DESCRIPTION
Backwards travel time can differ from forwards travel time (it default
if missing) in case of asymmetry so we must set the value explicitly
now.

fixes #15962 