### PR TITLE
editoast: add index (train_schedule_set_id, train_schedule_id)

### DIFF
--- a/editoast/migrations/2026-04-01-144616_train_schedule_ts_set_index/down.sql
+++ b/editoast/migrations/2026-04-01-144616_train_schedule_ts_set_index/down.sql
@@ -1,0 +1,1 @@
+drop index train_schedule_train_schedule_set_id_id_idx;

--- a/editoast/migrations/2026-04-01-144616_train_schedule_ts_set_index/up.sql
+++ b/editoast/migrations/2026-04-01-144616_train_schedule_ts_set_index/up.sql
@@ -1,0 +1,1 @@
+create index train_schedule_train_schedule_set_id_id_idx on train_schedule (train_schedule_set_id, id);


### PR DESCRIPTION
Guides PostgreSQL query planner otherwise producing an unexpected plan which takes too long for a listing request.

Makes listing train schedules with pagination faster. We should change the API to stop relying on OFFSET at some point though.

thanks @Signez @bougue-pe, refs #15852
