### PR TITLE
editoast: minor `TestApp` changes for `authz` V2

### DIFF
--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -1311,7 +1311,10 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn whoami_authorization_disabled() {
-        let app = test_app!().enable_authorization(false).build();
+        let app = test_app!()
+            .enable_authorization(false)
+            .with_openfga_store()
+            .build();
         let user = app.user("test", "test").create().await;
 
         let request = app.get("/authz/me").by_user(&user);
@@ -1376,7 +1379,10 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn user_groups_authorization_disabled() {
-        let app = test_app!().enable_authorization(false).build();
+        let app = test_app!()
+            .enable_authorization(false)
+            .with_openfga_store()
+            .build();
         let user = app.user("test", "test").create().await;
 
         let request = app.get("/authz/me/groups").by_user(&user);

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -90,6 +90,7 @@ pub(crate) struct TestAppBuilder {
     db_pool: Option<DbConnectionPoolV2>,
     core_client: Option<CoreClient>,
     enable_authorization: bool,
+    openfga_store: bool,
     enable_telemetry: bool,
     root_url: Option<Url>,
     trains_traffic: TrainsTrafficPool,
@@ -102,6 +103,7 @@ impl TestAppBuilder {
             db_pool: None,
             core_client: None,
             enable_authorization: false,
+            openfga_store: false,
             enable_telemetry: true,
             root_url: None,
             trains_traffic: TrainsTrafficPool::new(),
@@ -126,8 +128,17 @@ impl TestAppBuilder {
         self
     }
 
+    /// Setting this to true implies [with_openfga_store]
     pub fn enable_authorization(mut self, enable_authorization: bool) -> Self {
         self.enable_authorization = enable_authorization;
+        if enable_authorization {
+            self.openfga_store = true;
+        }
+        self
+    }
+
+    pub fn with_openfga_store(mut self) -> Self {
+        self.openfga_store = true;
         self
     }
 
@@ -241,7 +252,7 @@ impl TestAppBuilder {
             fga_connection_settings.clone(),
         ))
         .expect("Failed creating OpenFGA authorization store");
-        if self.enable_authorization {
+        if self.openfga_store {
             let migrations_store_name = fga::test_utilities::sanitize_store_name_length(&format!(
                 "migrations@{}",
                 self.test_name

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -40,6 +40,8 @@ use url::Url;
 use crate::AppState;
 use crate::generated_data::speed_limit_tags_config::SpeedLimitTagIds;
 use crate::infra_cache::InfraCache;
+use crate::views::authentication_extraction_middleware;
+use crate::views::authentication_validation_middleware;
 use crate::views::service_router;
 use crate::views::timetable::similar_trains::trains_traffic::TrainTraffic;
 use crate::views::timetable::similar_trains::trains_traffic::TrainsTrafficPool;
@@ -278,6 +280,13 @@ impl TestAppBuilder {
             .route_layer(axum::middleware::from_fn_with_state(
                 app_state.clone(),
                 authentication_middleware,
+            ))
+            .route_layer(axum::middleware::from_fn_with_state(
+                app_state.clone(),
+                authentication_validation_middleware,
+            ))
+            .route_layer(axum::middleware::from_fn(
+                authentication_extraction_middleware,
             ))
             .layer(OtelAxumLayer::default())
             .layer(TraceLayer::new_for_http())


### PR DESCRIPTION
- **editoast: add missing middlewares in TestApp**
- **editoast: allow starting OpenFGA with disabled authz in TestApp**

part of https://github.com/OpenRailAssociation/osrd/pull/15857
