### PR TITLE
front: bump nge (asymmetry fixes)

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -17,7 +17,7 @@
         "@ag-media/react-pdf-table": "^2.0.3",
         "@nivo/core": "^0.99.0",
         "@nivo/line": "^0.99.0",
-        "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.cb1b08f6a8889b698a6c4fda65d0d8a9eb516114",
+        "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.366e9191f3aeb90bffdb77f62a160f4f835c246c",
         "@osrd-project/ui-charts": "0.0.1-dev",
         "@osrd-project/ui-core": "0.0.1-dev",
         "@osrd-project/ui-icons": "0.0.1-dev",
@@ -3463,9 +3463,9 @@
       "link": true
     },
     "node_modules/@osrd-project/netzgrafik-frontend": {
-      "version": "0.0.0-snapshot.cb1b08f6a8889b698a6c4fda65d0d8a9eb516114",
-      "resolved": "https://registry.npmjs.org/@osrd-project/netzgrafik-frontend/-/netzgrafik-frontend-0.0.0-snapshot.cb1b08f6a8889b698a6c4fda65d0d8a9eb516114.tgz",
-      "integrity": "sha512-yZsSzEZo1FD4RD+TY+bHIW8t7p72H84pN5lx+KDP5ON5dmJgTR0jCjCVt4n1hOjllDxhiUNx/f/AAihT+SJbdA=="
+      "version": "0.0.0-snapshot.366e9191f3aeb90bffdb77f62a160f4f835c246c",
+      "resolved": "https://registry.npmjs.org/@osrd-project/netzgrafik-frontend/-/netzgrafik-frontend-0.0.0-snapshot.366e9191f3aeb90bffdb77f62a160f4f835c246c.tgz",
+      "integrity": "sha512-DxclrHyXxuhuk2y9Q5nvO7IcRg10UGoJXi1PO27UN5Bv0JRe62s46HJtqeOhJJSXhJJdxl6zTJ1guyDMXj1KTA=="
     },
     "node_modules/@osrd-project/storybook": {
       "resolved": "ui/storybook",

--- a/front/package.json
+++ b/front/package.json
@@ -14,7 +14,7 @@
     "@ag-media/react-pdf-table": "^2.0.3",
     "@nivo/core": "^0.99.0",
     "@nivo/line": "^0.99.0",
-    "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.cb1b08f6a8889b698a6c4fda65d0d8a9eb516114",
+    "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.366e9191f3aeb90bffdb77f62a160f4f835c246c",
     "@osrd-project/ui-charts": "0.0.1-dev",
     "@osrd-project/ui-core": "0.0.1-dev",
     "@osrd-project/ui-icons": "0.0.1-dev",


### PR DESCRIPTION
Casual bump of NGE, based on this branch: https://github.com/osrd-project/netzgrafik-editor-frontend/tree/standalone-asymmetry (only the last 3 commits are not already part of our current bump)

Embed these commits:
- https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/commit/22cee26f0588e176fbdc924221884749e70d5877 (allows to propagate and persist the time propagation from the reticular)
- https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/commit/c7ad92354f43c7b528b19686b1bdd5687236037f (brings the fix of https://github.com/OpenRailAssociation/osrd/issues/15959)
- https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/commit/366e9191f3aeb90bffdb77f62a160f4f835c246c (missing translation)

https://github.com/user-attachments/assets/e4f606b9-e8fc-4ff1-a9eb-c582a530836f


