### PR TITLE
core: remove @JvmRecord annotations in osrd-mp

### DIFF
--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/envelope_sim/PhysicsRollingStock.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/envelope_sim/PhysicsRollingStock.kt
@@ -5,7 +5,6 @@ import fr.sncf.osrd.envelope_sim.etcs.M_ROTATING_MAX
 import fr.sncf.osrd.envelope_sim.etcs.M_ROTATING_MIN
 import fr.sncf.osrd.path.interfaces.Electrification
 import fr.sncf.osrd.utils.DistanceRangeMap
-import kotlin.jvm.JvmRecord
 import kotlin.math.abs
 
 enum class Comfort {
@@ -55,7 +54,6 @@ interface PhysicsRollingStock {
         val conditions: DistanceRangeMap<InfraConditions>,
     )
 
-    @JvmRecord
     data class InfraConditions(
         val mode: String?,
         val electricalProfile: String?,


### PR DESCRIPTION
Closes #16054 

It seems osrd-mp builds common code with Java 1.8 target if that makes any sense? At least using `@JvmRecord` makes the build fails on native targets with this error:

    Using @JvmRecord is only allowed with -jvm-target 16 or later

But adding the `-jvm-target` argument isn't possible or fails. At least i couldn't do it. I tried doing this below, as well as other stuff:

    diff --git a/core/osrd-mp/build.gradle b/core/osrd-mp/build.gradle
    index 275ee7e13c..d19c0d7916 100644
    --- a/core/osrd-mp/build.gradle
    +++ b/core/osrd-mp/build.gradle
    @@ -1,3 +1,6 @@
    +import org.jetbrains.kotlin.gradle.dsl.JvmTarget
    +import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
    +
     plugins {
         alias(libs.plugins.kotlin.multiplatform)
         alias(libs.plugins.ksp)
    @@ -7,9 +10,14 @@
     version = '1.0.0'

     kotlin {
    +    jvmToolchain(21)
    +    compilerOptions {
    +        languageVersion = KotlinVersion.KOTLIN_2_3
    +        apiVersion = KotlinVersion.KOTLIN_2_3
    +    }
         jvm {
             compilerOptions {
    -            jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21
    +            jvmTarget = JvmTarget.JVM_21
             }
         }
         linuxX64()

in the meantime, we can avoid the annotations i think? A CI change will be planned to enforce that osrd-mp builds to linuxX64 successfully.