### PR TITLE
ui-charts: fix infinite loop when all occupancy zones overlap

### DIFF
--- a/front/ui/ui-charts/src/trackOccupancyDiagram/components/layers/OccupancyZonesLayer.tsx
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/components/layers/OccupancyZonesLayer.tsx
@@ -148,7 +148,9 @@ const OccupancyZonesLayer = ({
             (filteredZone, i) => i > zoneIndex && filteredZone.startTime >= lastEndTime
           );
 
-          const remainingTrainsNb = nextIndex - zoneIndex;
+          // nextIndex === -1 means all remaining zones overlap — skip to the end
+          const endIndex = nextIndex === -1 ? filteredOccupancyZones.length : nextIndex;
+          const remainingTrainsNb = endIndex - zoneIndex;
 
           instructions.push({
             type: 'remainingTrains',
@@ -157,7 +159,7 @@ const OccupancyZonesLayer = ({
             offsetY: trackY,
           });
 
-          zoneIndex += remainingTrainsNb;
+          zoneIndex = endIndex;
         }
       }
     });


### PR DESCRIPTION
closes #16051 

You'll need to rebuild the ui-charts package: `npm run build --workspace ui/ui-charts`