### PR TITLE
front: correct French translation for Import button 

### DIFF
--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -16,7 +16,7 @@
   "importTrainScheduleSet": {
     "cancel": "Annuler",
     "cartEmpty": "Aucune sélection",
-    "import": "Import",
+    "import": "Importer",
     "importType": {
       "copy": "Import par copie",
       "reference": "Import par référence"


### PR DESCRIPTION
## Summary

Fixed the French translation for the Import button in the train schedule import dialog. The label was left as the English "Import" instead of the French "Importer".

## Changes

One-word change in `front/public/locales/fr/operational-studies.json` (line 19): `"Import"` -> `"Importer"`.

Fixes #16059

This contribution was developed with AI assistance (Claude Code).