### PR TITLE
front: fix spaces and hyphens in locales

### DIFF
--- a/front/public/locales/de/operational-studies.json
+++ b/front/public/locales/de/operational-studies.json
@@ -52,7 +52,9 @@
       "unableToDeleteScenarioMessage": "Szenario löschen nicht möglich"
     },
     "filterPlaceholder": "Filter, Tags",
-    "infrastructure": "Netz",
+    "infrastructure": {
+      "label": "Netz:"
+    },
     "lessDetails": "Weniger Details anzeigen",
     "linearMode": "Linear",
     "macroEditor": {

--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -75,8 +75,8 @@
       "title": "Timetables deletion"
     },
     "description": {
-      "electricalProfileWithId": "Electrical profiles : ID{{id}}",
-      "electricalProfileWithName": "Electrical profiles : {{name}} | ID{{id}}"
+      "electricalProfileWithId": "Electrical profiles: ID{{id}}",
+      "electricalProfileWithName": "Electrical profiles: {{name}} | ID{{id}}"
     },
     "editScenario": "Edit scenario",
     "electricalProfileSet": "Electrical profiles set",
@@ -85,7 +85,9 @@
       "unableToDeleteScenarioMessage": "Unable to delete a scenario"
     },
     "filterPlaceholder": "Filter, tags",
-    "infrastructure": "Infrastructure",
+    "infrastructure": {
+      "label": "Infrastructure:"
+    },
     "lessDetails": "Display less details",
     "linearMode": "Linear",
     "loadingConflicts": "Loading conflicts…",
@@ -306,7 +308,7 @@
         "moveToSelectPackage": "Move to selected package",
         "movingToAnotherPackage": "Moving to another package",
         "name": "Series",
-        "namePlaceholder": "Ex: {{series}}",
+        "namePlaceholder": "E.g., {{series}}",
         "newCatalogEntry": "New set",
         "newLocalTrainScheduleSet": "New local package",
         "newTrainScheduleSet": "Create new package",
@@ -404,7 +406,7 @@
     },
     "infraLoading": "Infrastructure is loading…",
     "inputOPTrigrams": "Enter the trigrams of operational points you want to the path to go through, separated by a space.",
-    "inputOPTrigramsExample": "Ex: LSN CIG CCS",
+    "inputOPTrigramsExample": "E.g., LSN CIG CCS",
     "invalidTimetableItemStep": "At least one of the waypoints could not be recognized",
     "inverseOD": "Reverse itinerary",
     "itineraryModal": {
@@ -415,7 +417,7 @@
       "cancelMapSelection": "Cancel",
       "focusLocationOnMap": "Focus the map on this operational point",
       "frameAll": "Center on all path steps on map",
-      "invalidOP": "Non recognized point : ",
+      "invalidOP": "Non recognized point: ",
       "moveLocationOnMap": "Move location on the map",
       "movePointOnMap": "Move this waypoint using the map",
       "next": "Next",

--- a/front/public/locales/en/translation.json
+++ b/front/public/locales/en/translation.json
@@ -672,7 +672,7 @@
       "version": "Version"
     },
     "languages": "Languages",
-    "safeWord": "Safety keyword",
+    "safeWord": "Security keyword",
     "safeWordHelp": "The \"security keyword\" allows you to transparently filter the list of projects with the word you enter, used as a label. Choose a complicated word so that no-one uses it inadvertently. Add it as a label to a project; it will be automatically added when the project is created if the word is entered here.",
     "useNewTimesStopsTable": "Use the new timetable",
     "userSettings": "User settings",

--- a/front/public/locales/es/operational-studies.json
+++ b/front/public/locales/es/operational-studies.json
@@ -24,7 +24,9 @@
     "failure": "Operación fallida"
   },
   "main": {
-    "infrastructure": "Infraestructura",
+    "infrastructure": {
+      "label": "Infraestructura:"
+    },
     "macroEditor": {
       "trainCategory": {
         "NO_CATEGORY": {

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -85,7 +85,9 @@
       "unableToDeleteScenarioMessage": "Impossible de supprimer le scénario"
     },
     "filterPlaceholder": "Filtre, étiquettes",
-    "infrastructure": "Infrastructure",
+    "infrastructure": {
+      "label": "Infrastructure :"
+    },
     "lessDetails": "Afficher moins de détails",
     "linearMode": "Linéaire",
     "loadingConflicts": "Chargement des conflits…",
@@ -306,7 +308,7 @@
         "moveToSelectPackage": "Déplacer vers le paquet sélectionné",
         "movingToAnotherPackage": "Déplacement vers un autre paquet",
         "name": "Série",
-        "namePlaceholder": "Ex. {{series}}",
+        "namePlaceholder": "Ex : {{series}}",
         "newCatalogEntry": "Nouvel ensemble",
         "newLocalTrainScheduleSet": "Nouveau paquet local",
         "newTrainScheduleSet": "Créer un nouveau paquet",
@@ -404,7 +406,7 @@
     },
     "infraLoading": "Infra en cours de chargement…",
     "inputOPTrigrams": "Entrez la liste des trigrammes des points remarquables composant l'itinéraire souhaité.",
-    "inputOPTrigramsExample": "Ex : LSN CIG CCS",
+    "inputOPTrigramsExample": "Ex : LSN CIG CCS",
     "invalidTimetableItemStep": "Au moins un des points de passage n'a pas été reconnu",
     "inverseOD": "Inverser l'itinéraire",
     "itineraryModal": {

--- a/front/public/locales/fr/translation.json
+++ b/front/public/locales/fr/translation.json
@@ -672,8 +672,8 @@
       "version": "Version"
     },
     "languages": "Langues",
-    "safeWord": "Mot clé de sécurité",
-    "safeWordHelp": "Le « mot-clé de sécurité » permet de filtrer de manière transparente la liste des projets avec le mot renseigné, utilisé comme une étiquette. Préférez un mot compliqué dans l'idée que personne ne l'utilise par inadvertance. Ajoutez-le comme une étiquette à un projet ; il sera automatiquement ajouté à la création de projet si le mot est renseigné ici.",
+    "safeWord": "Mot-clé de sécurité",
+    "safeWordHelp": "Le « mot-clé de sécurité » permet de filtrer de manière transparente la liste des projets avec le mot renseigné, utilisé comme une étiquette. Préférez un mot compliqué dans l'idée que personne ne l'utilise par inadvertance. Ajoutez-le comme une étiquette à un projet ; il sera automatiquement ajouté à la création de projet si le mot est renseigné ici.",
     "useNewTimesStopsTable": "Utiliser le nouveau tableau horaire",
     "userSettings": "Paramètres utilisateur",
     "yourSafeWord": "Tapez votre mot"

--- a/front/src/applications/operationalStudies/views/Scenario/components/ScenarioHeader.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ScenarioHeader.tsx
@@ -178,7 +178,7 @@ const ScenarioHeader = ({ activeBoards, toggleBoard }: ScenarioHeaderProps) => {
           </span>
 
           <div className="scenario-details-infra-name">
-            {t('main.infrastructure')} :&nbsp;
+            {t('main.infrastructure.label')}&nbsp;
             <InfraLoadingState />
             &nbsp;
             <span className="scenario-infra-name" data-testid="scenario-infra-name">


### PR DESCRIPTION
Fixes #16063.

Some non-breaking spaces where missing in French where they should belong, and some were there when they shouldn't.

To make sure we properly add or not a space before the column, it was added inside the relevant translation string and removed from the component source itself.