### PR TITLE
front: add consist_schedule to stdcm payload

### DIFF
--- a/front/public/locales/en/stdcm.json
+++ b/front/public/locales/en/stdcm.json
@@ -46,7 +46,8 @@
       "invalidInput": "The date must be formatted as dd/mm/yy"
     },
     "incompleteForm": "Incomplete form",
-    "viaNotDefined": "Au moins une localisation n'est pas renseignée"
+    "viaNotDefined": "At least one missing operational point",
+    "viaRollingStockMissing": "At least one traction engine missing for consist change"
   },
   "infrastructure": "Infra",
   "leaveAt": "Leave at {{ time }}",

--- a/front/public/locales/fr/stdcm.json
+++ b/front/public/locales/fr/stdcm.json
@@ -46,7 +46,8 @@
       "invalidInput": "Saisissez une date au format dd/mm/yy"
     },
     "incompleteForm": "Formulaire incomplet",
-    "viaNotDefined": "Au moins une localisation n'est pas renseignée"
+    "viaNotDefined": "Au moins une localisation n'est pas renseignée",
+    "viaRollingStockMissing": "Au moins un engin de traction pour un changement de convoi n'est pas renseigné"
   },
   "infrastructure": "Infra",
   "leaveAt": "Partir à {{ time }}",

--- a/front/src/applications/stdcm/components/StdcmForm/StdcmConsist.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmConsist.tsx
@@ -154,7 +154,7 @@ const StdcmConsist = ({
   );
 
   const handleRollingStockSelect = (option?: LightRollingStockWithLiveries) => {
-    prefillConsist(option, towedRollingStock, consist.speedLimitByTag, {
+    prefillConsist(isConsistChange, option, towedRollingStock, consist.speedLimitByTag, {
       rollingStockID: option?.id,
     });
     setStatusMessagesVisible({
@@ -230,7 +230,7 @@ const StdcmConsist = ({
             value={towedRollingStock}
             getSuggestionLabel={(suggestion: TowedRollingStock) => suggestion.name}
             onSelectSuggestion={(towed) => {
-              prefillConsist(rollingStock, towed, consist.speedLimitByTag, {
+              prefillConsist(isConsistChange, rollingStock, towed, consist.speedLimitByTag, {
                 towedRollingStockID: towed?.id,
               });
             }}

--- a/front/src/applications/stdcm/hooks/useStdcmConsist.ts
+++ b/front/src/applications/stdcm/hooks/useStdcmConsist.ts
@@ -120,6 +120,7 @@ const useStdcmConsist = (
   };
 
   const prefillConsist = (
+    isConsistChange: boolean,
     rollingStock?: LightRollingStockWithLiveries,
     towed?: TowedRollingStock,
     maxSpeedTag?: string | null,
@@ -149,11 +150,14 @@ const useStdcmConsist = (
     }
     setTotalLengthChanged(false);
 
-    const newMaxSpeed = calculateConsistMaxSpeed(
-      rollingStock,
-      towed,
-      maxSpeedTag ? (speedLimitTags || {})[maxSpeedTag] : undefined
-    );
+    const newMaxSpeed = isConsistChange
+      ? undefined
+      : calculateConsistMaxSpeed(
+          rollingStock,
+          towed,
+          maxSpeedTag ? (speedLimitTags || {})[maxSpeedTag] : undefined
+        );
+
     if (maxSpeedChanged && consist.maxSpeed !== undefined) {
       newStatus.maxSpeed = {
         status: 'info',

--- a/front/src/applications/stdcm/utils/formatStdcmConf.ts
+++ b/front/src/applications/stdcm/utils/formatStdcmConf.ts
@@ -3,6 +3,7 @@ import { compact } from 'lodash';
 import type { Dispatch } from 'redux';
 
 import type {
+  ConsistSchedule,
   LoadingGaugeType,
   PathfindingItem,
   PostTimetableByIdStdcmApiArg,
@@ -34,6 +35,7 @@ type ValidStdcmConfig = {
   temporarySpeedLimitGroupId?: number;
   electricalProfileSetId?: number;
   allowedTrackSections?: string[];
+  consistSchedule: ConsistSchedule;
 };
 
 export const checkStdcmConf = (
@@ -160,8 +162,6 @@ export const checkStdcmConf = (
     );
   }
 
-  if (error) return null;
-
   const path = compact(osrdconf.stdcmPathSteps).map((step) => {
     const formattedLocation = stdcmPathStepToPathItemLocation(step.operationalPoint);
 
@@ -194,15 +194,58 @@ export const checkStdcmConf = (
     };
   });
 
+  const initialConsist = {
+    rolling_stock_id: rollingStockID!,
+    towed_rolling_stock_id: towedRollingStockID,
+    total_mass: totalMass ? tToKg(totalMass) : undefined,
+    total_length: totalLength,
+    max_speed: maxSpeed ? kmhToMs(maxSpeed) : undefined,
+    loading_gauge_type: loadingGauge,
+    speed_limit_tag: speedLimitByTag,
+  };
+
+  const boundaries: number[] = [];
+  const consistValues = [initialConsist];
+
+  for (const [index, step] of pathSteps.entries()) {
+    if (!step.isVia || !step.consistChange) continue;
+    if (!step.consistChange.rollingStockID) {
+      error = true;
+      dispatch(
+        setFailure({
+          name: t('stdcm:form.incompleteForm'),
+          message: t('stdcm:form.viaRollingStockMissing'),
+        })
+      );
+
+      break;
+    }
+
+    boundaries.push(index);
+    consistValues.push({
+      rolling_stock_id: step.consistChange.rollingStockID,
+      towed_rolling_stock_id: step.consistChange.towedRollingStockID,
+      total_mass: step.consistChange.totalMass ? tToKg(step.consistChange.totalMass) : undefined,
+      total_length: step.consistChange.totalLength,
+      max_speed: step.consistChange.maxSpeed ? kmhToMs(step.consistChange.maxSpeed) : undefined,
+      speed_limit_tag: step.consistChange.speedLimitByTag,
+      loading_gauge_type: step.consistChange.loadingGauge,
+    });
+  }
+
+  if (error) return null;
+
+  const consistSchedule = { boundaries, values: consistValues };
+
   return {
     infraId: infraID!,
     rollingStockId: rollingStockID!,
     timetableId: timetableID!,
     path,
     speedLimitByTag,
-    totalMass,
+    totalMass: initialConsist.total_mass,
     totalLength,
-    maxSpeed,
+    maxSpeed: initialConsist.max_speed,
     loadingGauge,
     towedRollingStockID,
     margin: standardAllowance,
@@ -212,6 +255,7 @@ export const checkStdcmConf = (
     temporarySpeedLimitGroupId,
     electricalProfileSetId,
     allowedTrackSections,
+    consistSchedule,
   };
 };
 
@@ -227,8 +271,8 @@ export const formatStdcmPayload = (
     rolling_stock_id: validConfig.rollingStockId,
     towed_rolling_stock_id: validConfig.towedRollingStockID,
     speed_limit_tags: validConfig.speedLimitByTag,
-    total_mass: validConfig.totalMass ? tToKg(validConfig.totalMass) : undefined,
-    max_speed: validConfig.maxSpeed ? kmhToMs(validConfig.maxSpeed) : undefined,
+    total_mass: validConfig.totalMass,
+    max_speed: validConfig.maxSpeed,
     total_length: validConfig.totalLength,
     steps: validConfig.path,
     time_gap_after: validConfig.gridMarginBefore?.ms,
@@ -238,6 +282,6 @@ export const formatStdcmPayload = (
     electrical_profile_set_id: validConfig.electricalProfileSetId,
     loading_gauge_type: validConfig.loadingGauge,
     allowed_track_sections: validConfig.allowedTrackSections,
-    consist_schedule: { boundaries: [], values: [] },
+    consist_schedule: validConfig.consistSchedule,
   },
 });


### PR DESCRIPTION
fix #15246

---

With this form:

<img width="863" height="889" alt="image" src="https://github.com/user-attachments/assets/3bed3932-8166-4348-8915-90082433698f" />

We are sending this payload:

<img width="449" height="692" alt="image" src="https://github.com/user-attachments/assets/52e1023c-32ed-4d1c-893a-e03ec3f9b063" />