### PR TITLE
front: remove the minimum stop time warning for a consist change

### DIFF
--- a/front/public/locales/en/stdcm.json
+++ b/front/public/locales/en/stdcm.json
@@ -259,7 +259,6 @@
       "bothPointAreScheduled": "The calculation cannot take into account both an origin and a destination schedule. You have to choose one or the other:",
       "global": "Please check the errors related to the following route:",
       "noScheduledPoint": "The calculation requires either the origin or destination schedule.",
-      "viaStopDurationConsistChangeTooShort": "Consist changes should take at least 30 minutes.",
       "viaStopDurationDriverSwitchTooShort": "The driver switch stop time is usually at least 3 minutes.",
       "viaStopDurationMissing": "Please specify the stop duration for the intermediate OP.",
       "zeroLengthPath": "Origin and destination cannot be the same."

--- a/front/public/locales/fr/stdcm.json
+++ b/front/public/locales/fr/stdcm.json
@@ -259,7 +259,6 @@
       "bothPointAreScheduled": "Le calcul ne peut pas prendre en compte à la fois un horaire d'origine et un horaire de destination. Il faut choisir l'un ou l'autre :",
       "global": "Veuillez vérifier les erreurs suivantes liées au trajet :",
       "noScheduledPoint": "Le calcul a besoin de l'horaire d'origine ou de celui de la destination.",
-      "viaStopDurationConsistChangeTooShort": "Un changement de convoi devrait nécessiter au moins 30 minutes.",
       "viaStopDurationDriverSwitchTooShort": "Le temps d'arrêt d'une relève conducteur est d'au moins 3 minutes.",
       "viaStopDurationMissing": "Le temps d'arrêt pour le PR intermédiaire.",
       "zeroLengthPath": "Origine et destination ne peuvent pas être identiques."

--- a/front/src/applications/stdcm/components/StdcmForm/StdcmVias.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmVias.tsx
@@ -154,26 +154,14 @@ const StdcmVias = ({
 
   const addConsistChange = (viaPathStep: StdcmViaPathStep, index: number) => {
     const previousConsistChange = getPreviousConsistChange(index);
-    if (viaPathStep.stopFor && viaPathStep.stopFor < new Duration({ minutes: 30 })) {
-      dispatch(
-        updateStdcmPathStep({
-          id: viaPathStep.id,
-          updates: {
-            stopFor: new Duration({ minutes: 30 }),
-            consistChange: previousConsistChange,
-          },
-        })
-      );
-    } else {
-      dispatch(
-        updateStdcmPathStep({
-          id: viaPathStep.id,
-          updates: {
-            consistChange: previousConsistChange,
-          },
-        })
-      );
-    }
+    dispatch(
+      updateStdcmPathStep({
+        id: viaPathStep.id,
+        updates: {
+          consistChange: previousConsistChange,
+        },
+      })
+    );
   };
 
   const removeConsistChange = (viaPathStep: StdcmViaPathStep) => {

--- a/front/src/applications/stdcm/components/StdcmForm/StopDurationInput.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StopDurationInput.tsx
@@ -31,22 +31,10 @@ const StopDurationInput = ({ pathStep }: StopDurationInputProps) => {
       pathStep.stopFor !== undefined &&
       pathStep.stopFor < new Duration({ minutes: 3 });
 
-    const isInvalidConsistChange =
-      pathStep.stopFor !== undefined &&
-      pathStep.consistChange &&
-      pathStep.stopFor < new Duration({ minutes: 30 });
-
     if (isInvalidDriverStop) {
       return {
         status: 'warning',
         message: t('stdcmErrors.routeErrors.viaStopDurationDriverSwitchTooShort'),
-      };
-    }
-
-    if (isInvalidConsistChange) {
-      return {
-        status: 'warning',
-        message: t('stdcmErrors.routeErrors.viaStopDurationConsistChangeTooShort'),
       };
     }
 


### PR DESCRIPTION
fix #15589

---

The BO changed their mind and don't want the stop time warning, neither default value anymore.