### PR TITLE
front: stdcm: disable consist when algo is running

### DIFF
--- a/front/src/applications/stdcm/components/StdcmForm/StdcmConsist.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmConsist.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 
 import { Input, ComboBox, useDefaultComboBox, Select } from '@osrd-project/ui-core';
 import { skipToken } from '@reduxjs/toolkit/query';
+import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
@@ -30,13 +31,15 @@ import useStdcmConsist from '../../hooks/useStdcmConsist';
 
 const ConsistCardTitle = ({
   rollingStock,
+  disabled,
 }: {
   rollingStock?: LightRollingStockWithLiveries | null;
+  disabled: boolean;
 }) => {
   if (!rollingStock) return null;
 
   return (
-    <div className="stdcm-consist-img">
+    <div className={cx('stdcm-consist-img', { disabled })}>
       <RollingStock2Img rollingStock={rollingStock} />
     </div>
   );
@@ -185,7 +188,7 @@ const StdcmConsist = ({
 
   return (
     <>
-      <ConsistCardTitle rollingStock={rollingStock} />
+      <ConsistCardTitle rollingStock={rollingStock} disabled={disabled} />
       <StdcmCard
         name={t('consist.consist')}
         title={

--- a/front/src/applications/stdcm/components/StdcmForm/StdcmVias.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmVias.tsx
@@ -245,7 +245,7 @@ const StdcmVias = ({
                 <StdcmDefaultCard
                   testId="edit-consist"
                   className="edit-consist"
-                  disabled={hasConsistsErrors()}
+                  disabled={hasConsistsErrors() || disabled}
                   tip="right"
                   text={t('trainPath.consistChange.add')}
                   tooltip={
@@ -257,6 +257,7 @@ const StdcmVias = ({
               ) : (
                 <>
                   <StdcmConsist
+                    disabled={disabled}
                     isDebugMode={isDebugMode}
                     onConsistErrorsChange={(errors) => handleConsistErrors(pathStep.id, errors)}
                     consist={pathStep.consistChange ?? {}}

--- a/front/src/applications/stdcm/styles/_home.scss
+++ b/front/src/applications/stdcm/styles/_home.scss
@@ -75,6 +75,11 @@
         max-width: 100%;
         height: 20px;
       }
+
+      &.disabled {
+        opacity: 0.5;
+        pointer-events: none;
+      }
     }
 
     .stdcm__separator {


### PR DESCRIPTION
Fix #16040

Disabled consists forms when stdcm algo is running, like for others sections.
Same for the button "Edit a consist".
