### PR TITLE
e2e: replace symbol tags with tag objects

### DIFF
--- a/front/tests/01-home/001-home-page.spec.ts
+++ b/front/tests/01-home/001-home-page.spec.ts
@@ -3,20 +3,28 @@ import { expect } from '@playwright/test';
 import { EXPECTED_HOME_LINKS } from '../assets/constants/homepage-const';
 import test from './../page-object-fixture';
 
-test.describe('@home @navigation', () => {
+test.describe('Home page navigation', { tag: ['@home', '@navigation'] }, () => {
   test.beforeEach('Navigate to the home page', async ({ homePage }) => {
     await homePage.goToHomePage();
   });
 
   /** *************** Test 1 **************** */
-  test('@smoke Verify the links for different pages in Home Page', async ({ homePage }) => {
-    await expect(homePage.linksTitle).toHaveText(EXPECTED_HOME_LINKS);
-  });
+  test(
+    'Verify the links for different pages in Home Page',
+    { tag: '@smoke' },
+    async ({ homePage }) => {
+      await expect(homePage.linksTitle).toHaveText(EXPECTED_HOME_LINKS);
+    }
+  );
 
   /** *************** Test 2 **************** */
-  test('@smoke Verify redirection to the Operational Studies page', async ({ homePage }) => {
-    await homePage.goToOperationalStudiesPage();
-  });
+  test(
+    'Verify redirection to the Operational Studies page',
+    { tag: '@smoke' },
+    async ({ homePage }) => {
+      await homePage.goToOperationalStudiesPage();
+    }
+  );
 
   /** *************** Test 3 **************** */
   test('Verify redirection to the Map page', async ({ homePage }) => {
@@ -29,7 +37,7 @@ test.describe('@home @navigation', () => {
   });
 
   /** *************** Test 5 **************** */
-  test('@smoke Verify redirection to the STDCM page', async ({ context, homePage }) => {
+  test('Verify redirection to the STDCM page', { tag: '@smoke' }, async ({ context, homePage }) => {
     await homePage.goToSTDCMPage(context);
   });
 });

--- a/front/tests/02-operational-studies/management/001-project-management.spec.ts
+++ b/front/tests/02-operational-studies/management/001-project-management.spec.ts
@@ -10,7 +10,7 @@ import { generateUniqueName } from '../../utils';
 import { createProject } from '../../utils/setup-utils';
 import { deleteProject } from '../../utils/teardown-utils';
 
-test.describe('@op @project @management', () => {
+test.describe('Project management', { tag: ['@op', '@project', '@management'] }, () => {
   let project: Project;
   const createdProjects: string[] = [];
 
@@ -20,7 +20,7 @@ test.describe('@op @project @management', () => {
   });
 
   /** *************** Test 1 **************** */
-  test('@smoke Create a new project', async ({ page, projectPage }) => {
+  test('Create a new project', { tag: '@smoke' }, async ({ page, projectPage }) => {
     const projectName = generateUniqueName(PROJECT_DATA.name);
     createdProjects.push(projectName);
 

--- a/front/tests/02-operational-studies/management/002-study-management.spec.ts
+++ b/front/tests/02-operational-studies/management/002-study-management.spec.ts
@@ -13,7 +13,7 @@ import { DATE_OFFSET, formatDateToDayMonthYear, getISODate } from '../../utils/d
 import { createStudy } from '../../utils/setup-utils';
 import { deleteStudy } from '../../utils/teardown-utils';
 
-test.describe('@op @study @management', () => {
+test.describe('Study management', { tag: ['@op', '@study', '@management'] }, () => {
   let project: Project;
   let study: Study;
 
@@ -29,7 +29,7 @@ test.describe('@op @study @management', () => {
   });
 
   /** *************** Test 1 **************** */
-  test('@smoke Create a new study', async ({ studyPage, page }) => {
+  test('Create a new study', { tag: '@smoke' }, async ({ studyPage, page }) => {
     const studyName = generateUniqueName(STUDY_DATA.name);
     const todayISO = getISODate(DATE_OFFSET.TODAY);
     const expectedDate = formatDateToDayMonthYear(todayISO);

--- a/front/tests/02-operational-studies/management/003-scenario-management.spec.ts
+++ b/front/tests/02-operational-studies/management/003-scenario-management.spec.ts
@@ -24,7 +24,7 @@ import {
 import createScenario from '../../utils/scenario';
 import { deleteScenario } from '../../utils/teardown-utils';
 
-test.describe('@op @scenario @management', () => {
+test.describe('Scenario management', { tag: ['@op', '@scenario', '@management'] }, () => {
   let project: Project;
   let study: Study;
   let scenario: Scenario;
@@ -47,7 +47,7 @@ test.describe('@op @scenario @management', () => {
   });
 
   /** *************** Test 1 **************** */
-  test('@smoke Create a new scenario', async ({ page, scenarioPage }) => {
+  test('Create a new scenario', { tag: '@smoke' }, async ({ page, scenarioPage }) => {
     const scenarioName = generateUniqueName(SCENARIO_DATA.name);
     createdScenarios.push({ projectId: project.id, studyId: study.id, name: scenarioName });
 
@@ -78,7 +78,7 @@ test.describe('@op @scenario @management', () => {
   });
 
   /** *************** Test 2 **************** */
-  test('@smoke Update an existing scenario', async ({ page, scenarioPage }) => {
+  test('Update an existing scenario', { tag: '@smoke' }, async ({ page, scenarioPage }) => {
     await test.step('Create a base scenario', async () => {
       ({ project, study, scenario } = await createScenario());
     });
@@ -89,7 +89,11 @@ test.describe('@op @scenario @management', () => {
       name: updatedScenarioName,
     };
 
-    createdScenarios.push({ projectId: project.id, studyId: study.id, name: updatedScenarioName });
+    createdScenarios.push({
+      projectId: project.id,
+      studyId: study.id,
+      name: updatedScenarioName,
+    });
 
     await test.step('Open scenario from study page and wait for infra cache', async () => {
       await page.goto(SCENARIO_URLS.study(project.id, study.id));

--- a/front/tests/02-operational-studies/nge/001-osrd-nge.spec.ts
+++ b/front/tests/02-operational-studies/nge/001-osrd-nge.spec.ts
@@ -19,7 +19,7 @@ const frTranslations: TimetableFilterTranslations = readJsonFile<{
   main: TimetableFilterTranslations;
 }>('public/locales/fr/operational-studies.json').main;
 
-test.describe('@op @nge', () => {
+test.describe('Netzgrafik Editor', { tag: ['@op', '@nge'] }, () => {
   let project: Project;
   let study: Study;
   let scenarioItems: Scenario;

--- a/front/tests/02-operational-studies/nge/002-nge-osrd.spec.ts
+++ b/front/tests/02-operational-studies/nge/002-nge-osrd.spec.ts
@@ -24,7 +24,7 @@ const frTranslations = {
   ...frCommonTranslations,
 };
 
-test.describe('@op @nge @round-trips', () => {
+test.describe('Netzgrafik Editor', { tag: ['@op', '@nge', '@round-trips'] }, () => {
   test.use({ ignorePageErrors: true });
 
   let project: Project;
@@ -59,53 +59,53 @@ test.describe('@op @nge @round-trips', () => {
   });
 
   /** *************** Test 1 **************** */
-  test('@smoke Add a train from NGE', async ({
-    ngePage,
-    scenarioTimetableSection,
-    roundTripPage,
-  }) => {
-    await test.step('Create three nodes', async () => {
-      await ngePage.createNode({ x: 50, y: 400 }, 'NWS', 'Origin');
-      await expect(ngePage.nodeCards).toHaveCount(1);
+  test(
+    'Add a train from NGE',
+    { tag: '@smoke' },
+    async ({ ngePage, scenarioTimetableSection, roundTripPage }) => {
+      await test.step('Create three nodes', async () => {
+        await ngePage.createNode({ x: 50, y: 400 }, 'NWS', 'Origin');
+        await expect(ngePage.nodeCards).toHaveCount(1);
 
-      await ngePage.createNode({ x: 250, y: 400 }, 'MWS', 'OP');
-      await expect(ngePage.nodeCards).toHaveCount(2);
+        await ngePage.createNode({ x: 250, y: 400 }, 'MWS', 'OP');
+        await expect(ngePage.nodeCards).toHaveCount(2);
 
-      await ngePage.createNode({ x: 450, y: 400 }, 'SS', 'Destination');
-      await expect(ngePage.nodeCards).toHaveCount(3);
-    });
-
-    await test.step('Connect Origin → OP and create Train1', async () => {
-      await ngePage.connectNodesByIndex(0, 1);
-      await expect(ngePage.trainDetailsGroup).toBeVisible();
-      await ngePage.setTrainBasics({ name: 'Train1', isFrequency30: true });
-      await ngePage.closeDetailsDialogIfVisible();
-      await expect(ngePage.trainDetailsGroup).toBeHidden();
-      await expect(ngePage.trainLines).toHaveCount(1);
-    });
-
-    await test.step('Connect OP → Destination', async () => {
-      await ngePage.connectNodesByIndex(1, 2);
-      await expect(ngePage.trainDetailsGroup).toBeHidden();
-      await expect(ngePage.trainLines).toHaveCount(2);
-    });
-
-    await test.step('Validate timetable list and round-trip modal', async () => {
-      await scenarioTimetableSection.verifyTotalItemsLabel(frTranslations, {
-        totalPacedTrainCount: 2,
-        totalUniqueTrainCount: 0,
+        await ngePage.createNode({ x: 450, y: 400 }, 'SS', 'Destination');
+        await expect(ngePage.nodeCards).toHaveCount(3);
       });
-      await scenarioTimetableSection.verifyInvalidReasons([
-        frTranslations.timetable.invalid.rolling_stock_not_found,
-        frTranslations.timetable.invalid.rolling_stock_not_found,
-      ]);
 
-      await roundTripPage.openRoundTripModal();
-      await roundTripPage.assertRoundTripColumnCounts({
-        expectedToDoCount: 0,
-        expectedOneWayCount: 0,
-        expectedRoundTripCount: 1,
+      await test.step('Connect Origin → OP and create Train1', async () => {
+        await ngePage.connectNodesByIndex(0, 1);
+        await expect(ngePage.trainDetailsGroup).toBeVisible();
+        await ngePage.setTrainBasics({ name: 'Train1', isFrequency30: true });
+        await ngePage.closeDetailsDialogIfVisible();
+        await expect(ngePage.trainDetailsGroup).toBeHidden();
+        await expect(ngePage.trainLines).toHaveCount(1);
       });
-    });
-  });
+
+      await test.step('Connect OP → Destination', async () => {
+        await ngePage.connectNodesByIndex(1, 2);
+        await expect(ngePage.trainDetailsGroup).toBeHidden();
+        await expect(ngePage.trainLines).toHaveCount(2);
+      });
+
+      await test.step('Validate timetable list and round-trip modal', async () => {
+        await scenarioTimetableSection.verifyTotalItemsLabel(frTranslations, {
+          totalPacedTrainCount: 2,
+          totalUniqueTrainCount: 0,
+        });
+        await scenarioTimetableSection.verifyInvalidReasons([
+          frTranslations.timetable.invalid.rolling_stock_not_found,
+          frTranslations.timetable.invalid.rolling_stock_not_found,
+        ]);
+
+        await roundTripPage.openRoundTripModal();
+        await roundTripPage.assertRoundTripColumnCounts({
+          expectedToDoCount: 0,
+          expectedOneWayCount: 0,
+          expectedRoundTripCount: 1,
+        });
+      });
+    }
+  );
 });

--- a/front/tests/02-operational-studies/paced-trains/001-paced-train-management.spec.ts
+++ b/front/tests/02-operational-studies/paced-trains/001-paced-train-management.spec.ts
@@ -69,7 +69,7 @@ const expectedOutputData: { pacedTrain: StationData[]; secondOccurrence: Station
 
 const trains: [TrainSchedule] = readJsonFile('./tests/assets/trains/trains.json');
 
-test.describe('@op @paced-trains', () => {
+test.describe('Paced train management', { tag: ['@op', '@paced-trains'] }, () => {
   let project: Project;
   let study: Study;
   let scenario: Scenario;
@@ -119,89 +119,93 @@ test.describe('@op @paced-trains', () => {
   });
 
   /** *************** Test 2 **************** */
-  test('@smoke Add a paced train and verify its timetable details', async ({
-    browserName,
-    operationalStudiesPage,
-    rollingStockSelector,
-    routeTab,
-    timesAndStopsTab,
-    scenarioTimetableSection,
-    pacedTrainSection,
-    opSimulationResultPage,
-    timeAndStopSimulationOutputs,
-  }) => {
-    await test.step('Open timetable item form', async () => {
-      await operationalStudiesPage.openTimetableItemForm();
-    });
-
-    await test.step('Fill paced train inputs', async () => {
-      await operationalStudiesPage.fillPacedTrainSettings(NEW_PACED_TRAIN_SETTINGS);
-    });
-
-    await test.step('Select rolling stock', async () => {
-      await rollingStockSelector.selectRollingStock(dualModeRollingStockName);
-    });
-
-    await test.step('Select itinerary and verify distance', async () => {
-      await operationalStudiesPage.openRouteTab();
-      await routeTab.performPathfindingByTrigram({
-        originTrigram: 'WS',
-        destinationTrigram: 'NES',
+  test(
+    'Add a paced train and verify its timetable details',
+    { tag: '@smoke' },
+    async ({
+      browserName,
+      operationalStudiesPage,
+      rollingStockSelector,
+      routeTab,
+      timesAndStopsTab,
+      scenarioTimetableSection,
+      pacedTrainSection,
+      opSimulationResultPage,
+      timeAndStopSimulationOutputs,
+    }) => {
+      await test.step('Open timetable item form', async () => {
+        await operationalStudiesPage.openTimetableItemForm();
       });
-      await operationalStudiesPage.checkPathfindingDistance('46.050 km');
-    });
 
-    await test.step('Fill Times & Stops table with initial inputs', async () => {
-      await operationalStudiesPage.openTimesAndStopsTab();
-      await timesAndStopsTab.verifyActiveRowsCount(2);
-
-      for (const cell of initialInputsData) {
-        const translatedHeader = cleanWhitespace(frTranslations[cell.header]);
-        await timesAndStopsTab.fillTableCellByStationAndHeader(
-          cell.stationName,
-          translatedHeader,
-          cell.value,
-          cell.marginForm
-        );
-      }
-    });
-
-    await test.step('Create paced train and return to results', async () => {
-      await operationalStudiesPage.createTimetableItem();
-      await operationalStudiesPage.checkToastHasBeenLaunched(frTranslations.pacedTrains.added);
-      await operationalStudiesPage.returnSimulationResult();
-    });
-
-    await test.step('Verify list contains exactly one paced train', async () => {
-      await scenarioTimetableSection.verifyTimetableItemsCount(1);
-    });
-
-    await test.step('Verify paced train is selected when clicked', async () => {
-      await pacedTrainSection.verifyPacedTrainSelected(0);
-    });
-
-    await test.step('Verify result in output table is paced train result', async () => {
-      await timeAndStopSimulationOutputs.getOutputTableData(expectedOutputData.pacedTrain);
-    });
-
-    await test.step('Verify paced train card and first occurrence details', async () => {
-      await pacedTrainSection.verifyPacedTrainItemDetails(NEW_PACED_TRAIN_SETTINGS, 0, {
-        occurrenceData: ADD_PACED_TRAIN_OCCURRENCES_DETAILS[0],
-        occurrenceColor: FREIGHT_TRAIN.color,
+      await test.step('Fill paced train inputs', async () => {
+        await operationalStudiesPage.fillPacedTrainSettings(NEW_PACED_TRAIN_SETTINGS);
       });
-    });
 
-    await test.step('Open first occurrence and verify its simulation results (screenshot comparison for the GEV)', async () => {
-      await pacedTrainSection.selectOccurrence({ pacedTrainIndex: 0, occurrenceIndex: 1 });
-      await opSimulationResultPage.setTrainListVisible();
-      if (browserName === 'chromium') {
-        await expect(opSimulationResultPage.speedSpaceChart).toHaveScreenshot(
-          'SpeedSpaceChart-InitialInputs.png'
-        );
-      }
-      await timeAndStopSimulationOutputs.getOutputTableData(expectedOutputData.secondOccurrence);
-    });
-  });
+      await test.step('Select rolling stock', async () => {
+        await rollingStockSelector.selectRollingStock(dualModeRollingStockName);
+      });
+
+      await test.step('Select itinerary and verify distance', async () => {
+        await operationalStudiesPage.openRouteTab();
+        await routeTab.performPathfindingByTrigram({
+          originTrigram: 'WS',
+          destinationTrigram: 'NES',
+        });
+        await operationalStudiesPage.checkPathfindingDistance('46.050 km');
+      });
+
+      await test.step('Fill Times & Stops table with initial inputs', async () => {
+        await operationalStudiesPage.openTimesAndStopsTab();
+        await timesAndStopsTab.verifyActiveRowsCount(2);
+
+        for (const cell of initialInputsData) {
+          const translatedHeader = cleanWhitespace(frTranslations[cell.header]);
+          await timesAndStopsTab.fillTableCellByStationAndHeader(
+            cell.stationName,
+            translatedHeader,
+            cell.value,
+            cell.marginForm
+          );
+        }
+      });
+
+      await test.step('Create paced train and return to results', async () => {
+        await operationalStudiesPage.createTimetableItem();
+        await operationalStudiesPage.checkToastHasBeenLaunched(frTranslations.pacedTrains.added);
+        await operationalStudiesPage.returnSimulationResult();
+      });
+
+      await test.step('Verify list contains exactly one paced train', async () => {
+        await scenarioTimetableSection.verifyTimetableItemsCount(1);
+      });
+
+      await test.step('Verify paced train is selected when clicked', async () => {
+        await pacedTrainSection.verifyPacedTrainSelected(0);
+      });
+
+      await test.step('Verify result in output table is paced train result', async () => {
+        await timeAndStopSimulationOutputs.getOutputTableData(expectedOutputData.pacedTrain);
+      });
+
+      await test.step('Verify paced train card and first occurrence details', async () => {
+        await pacedTrainSection.verifyPacedTrainItemDetails(NEW_PACED_TRAIN_SETTINGS, 0, {
+          occurrenceData: ADD_PACED_TRAIN_OCCURRENCES_DETAILS[0],
+          occurrenceColor: FREIGHT_TRAIN.color,
+        });
+      });
+
+      await test.step('Open first occurrence and verify its simulation results (screenshot comparison for the GEV)', async () => {
+        await pacedTrainSection.selectOccurrence({ pacedTrainIndex: 0, occurrenceIndex: 1 });
+        await opSimulationResultPage.setTrainListVisible();
+        if (browserName === 'chromium') {
+          await expect(opSimulationResultPage.speedSpaceChart).toHaveScreenshot(
+            'SpeedSpaceChart-InitialInputs.png'
+          );
+        }
+        await timeAndStopSimulationOutputs.getOutputTableData(expectedOutputData.secondOccurrence);
+      });
+    }
+  );
 
   /** *************** Test 3 **************** */
   test('Duplicate and delete a paced train', async ({

--- a/front/tests/02-operational-studies/paced-trains/002-paced-train-exceptions.spec.ts
+++ b/front/tests/02-operational-studies/paced-trains/002-paced-train-exceptions.spec.ts
@@ -41,7 +41,7 @@ const frTranslations = {
 
 const trains: TrainSchedule[] = readJsonFile('./tests/assets/trains/trains.json');
 
-test.describe('@op @paced-trains @exceptions', () => {
+test.describe('Paced train exceptions', { tag: ['@op', '@paced-trains', '@exceptions'] }, () => {
   let project: Project;
   let study: Study;
   let infra: Infra;
@@ -77,127 +77,133 @@ test.describe('@op @paced-trains @exceptions', () => {
   });
 
   /** *************** Test 1 **************** */
-  test('@smoke Edit a paced train and handle exceptions', async ({
-    pacedTrainSection,
-    scenarioTimetableSection,
-    rollingStockSelector,
-    operationalStudiesPage,
-  }) => {
-    const editedPacedTrainData = trains[5];
+  test(
+    'Edit a paced train and handle exceptions',
+    { tag: '@smoke' },
+    async ({
+      pacedTrainSection,
+      scenarioTimetableSection,
+      rollingStockSelector,
+      operationalStudiesPage,
+    }) => {
+      const editedPacedTrainData = trains[5];
 
-    await test.step('Open action buttons for paced train at index 5', async () => {
-      await pacedTrainSection.getActionButtonsLocators({
-        itemIndex: 5,
-        itemType: 'paced-train',
-        withExceptions: true,
-        checkVisibility: true,
+      await test.step('Open action buttons for paced train at index 5', async () => {
+        await pacedTrainSection.getActionButtonsLocators({
+          itemIndex: 5,
+          itemType: 'paced-train',
+          withExceptions: true,
+          checkVisibility: true,
+        });
       });
-    });
 
-    await test.step('Edit the paced train', async () => {
-      await pacedTrainSection.openPacedTrainEditor(5);
-      await scenarioTimetableSection.verifyEditTimetableItemButtonVisibility();
-    });
-
-    await test.step('Update rolling stock', async () => {
-      await rollingStockSelector.openRollingstockModal();
-      await rollingStockSelector.searchRollingstock(fastRollingStockName);
-      await rollingStockSelector.selectRollingStockCard({
-        name: fastRollingStockName,
-        confirmSelection: true,
+      await test.step('Edit the paced train', async () => {
+        await pacedTrainSection.openPacedTrainEditor(5);
+        await scenarioTimetableSection.verifyEditTimetableItemButtonVisibility();
       });
-      await expect(rollingStockSelector.selectedRollingStockName).toHaveText(fastRollingStockName);
-    });
 
-    await test.step('Update departure time and submit edit', async () => {
-      await operationalStudiesPage.setTimetableItemStartTime('12:00');
-      await operationalStudiesPage.submitTimetableItemEdit();
-      await operationalStudiesPage.checkToastHasBeenLaunched(
-        frTranslations.timetable.pacedTrainUpdated
-      );
-    });
-
-    await test.step('Verify all occurrences (4 occurrences including 1 added exception)', async () => {
-      await pacedTrainSection.verifyOccurrenceDetails(
-        {
-          name: `${editedPacedTrainData.train_name}/+`,
-          startTime: '21:00',
-          arrivalTime: '21:03',
-          rollingStock: fastRollingStockName,
-        },
-        0
-      );
-      await pacedTrainSection.verifyOccurrenceDetails(
-        {
-          name: `${editedPacedTrainData.train_name} 1`,
-          startTime: '12:00',
-          arrivalTime: '12:07',
-          rollingStock: slowRollingStockName,
-        },
-        1
-      );
-      await pacedTrainSection.verifyOccurrenceDetails(
-        {
-          name: `${editedPacedTrainData.train_name} 3`,
-          startTime: '13:00',
-          arrivalTime: '13:03',
-          rollingStock: fastRollingStockName,
-        },
-        2
-      );
-      await pacedTrainSection.verifyOccurrenceDetails(
-        {
-          name: `${editedPacedTrainData.train_name} 5`,
-          startTime: '14:00',
-          arrivalTime: '14:03',
-          rollingStock: fastRollingStockName,
-        },
-        3
-      );
-    });
-
-    await test.step('Reset all exceptions', async () => {
-      await pacedTrainSection.resetAllPacedTrainExceptions(5);
-    });
-
-    await test.step('Verify occurrences after reset', async () => {
-      await pacedTrainSection.verifyOccurrenceDetails(
-        {
-          name: `${editedPacedTrainData.train_name} 1`,
-          startTime: '12:00',
-          arrivalTime: '12:03',
-          rollingStock: editedPacedTrainData.rolling_stock_name,
-        },
-        0
-      );
-      await pacedTrainSection.verifyOccurrenceDetails(
-        {
-          name: `${editedPacedTrainData.train_name} 3`,
-          startTime: '13:00',
-          arrivalTime: '13:03',
-          rollingStock: editedPacedTrainData.rolling_stock_name,
-        },
-        1
-      );
-      await pacedTrainSection.verifyOccurrenceDetails(
-        {
-          name: `${editedPacedTrainData.train_name} 5`,
-          startTime: '14:00',
-          arrivalTime: '14:03',
-          rollingStock: editedPacedTrainData.rolling_stock_name,
-        },
-        2
-      );
-    });
-
-    await test.step('Check action buttons count after reset (4 buttons instead of 5)', async () => {
-      await pacedTrainSection.getActionButtonsLocators({
-        itemIndex: 5,
-        itemType: 'paced-train',
-        checkVisibility: true,
+      await test.step('Update rolling stock', async () => {
+        await rollingStockSelector.openRollingstockModal();
+        await rollingStockSelector.searchRollingstock(fastRollingStockName);
+        await rollingStockSelector.selectRollingStockCard({
+          name: fastRollingStockName,
+          confirmSelection: true,
+        });
+        await expect(rollingStockSelector.selectedRollingStockName).toHaveText(
+          fastRollingStockName
+        );
       });
-    });
-  });
+
+      await test.step('Update departure time and submit edit', async () => {
+        await operationalStudiesPage.setTimetableItemStartTime('12:00');
+        await operationalStudiesPage.submitTimetableItemEdit();
+        await operationalStudiesPage.checkToastHasBeenLaunched(
+          frTranslations.timetable.pacedTrainUpdated
+        );
+      });
+
+      await test.step('Verify all occurrences (4 occurrences including 1 added exception)', async () => {
+        await pacedTrainSection.verifyOccurrenceDetails(
+          {
+            name: `${editedPacedTrainData.train_name}/+`,
+            startTime: '21:00',
+            arrivalTime: '21:03',
+            rollingStock: fastRollingStockName,
+          },
+          0
+        );
+        await pacedTrainSection.verifyOccurrenceDetails(
+          {
+            name: `${editedPacedTrainData.train_name} 1`,
+            startTime: '12:00',
+            arrivalTime: '12:07',
+            rollingStock: slowRollingStockName,
+          },
+          1
+        );
+        await pacedTrainSection.verifyOccurrenceDetails(
+          {
+            name: `${editedPacedTrainData.train_name} 3`,
+            startTime: '13:00',
+            arrivalTime: '13:03',
+            rollingStock: fastRollingStockName,
+          },
+          2
+        );
+        await pacedTrainSection.verifyOccurrenceDetails(
+          {
+            name: `${editedPacedTrainData.train_name} 5`,
+            startTime: '14:00',
+            arrivalTime: '14:03',
+            rollingStock: fastRollingStockName,
+          },
+          3
+        );
+      });
+
+      await test.step('Reset all exceptions', async () => {
+        await pacedTrainSection.resetAllPacedTrainExceptions(5);
+      });
+
+      await test.step('Verify occurrences after reset', async () => {
+        await pacedTrainSection.verifyOccurrenceDetails(
+          {
+            name: `${editedPacedTrainData.train_name} 1`,
+            startTime: '12:00',
+            arrivalTime: '12:03',
+            rollingStock: editedPacedTrainData.rolling_stock_name,
+          },
+          0
+        );
+        await pacedTrainSection.verifyOccurrenceDetails(
+          {
+            name: `${editedPacedTrainData.train_name} 3`,
+            startTime: '13:00',
+            arrivalTime: '13:03',
+            rollingStock: editedPacedTrainData.rolling_stock_name,
+          },
+          1
+        );
+        await pacedTrainSection.verifyOccurrenceDetails(
+          {
+            name: `${editedPacedTrainData.train_name} 5`,
+            startTime: '14:00',
+            arrivalTime: '14:03',
+            rollingStock: editedPacedTrainData.rolling_stock_name,
+          },
+          2
+        );
+      });
+
+      await test.step('Check action buttons count after reset (4 buttons instead of 5)', async () => {
+        await pacedTrainSection.getActionButtonsLocators({
+          itemIndex: 5,
+          itemType: 'paced-train',
+          checkVisibility: true,
+        });
+      });
+    }
+  );
 
   /** *************** Test 2 **************** */
   test('Modify a paced train and create added exception', async ({

--- a/front/tests/02-operational-studies/paced-trains/003-paced-train-occurrence-edition.spec.ts
+++ b/front/tests/02-operational-studies/paced-trains/003-paced-train-occurrence-edition.spec.ts
@@ -46,221 +46,230 @@ const frTranslations = {
 
 const trains: TrainSchedule[] = readJsonFile('./tests/assets/trains/trains.json');
 
-test.describe('@op @paced-trains @exceptions', () => {
-  let project: Project;
-  let study: Study;
-  let infra: Infra;
+test.describe(
+  'Paced train occurrence edition',
+  { tag: ['@op', '@paced-trains', '@exceptions'] },
+  () => {
+    let project: Project;
+    let study: Study;
+    let infra: Infra;
 
-  let scenarioItems: Scenario;
+    let scenarioItems: Scenario;
 
-  test.beforeAll('Setup project, study, infra and create scenario with paced trains', async () => {
-    project = await getProject(timetableItemProjectName);
-    study = await getStudy(project.id, timetableItemStudyName);
-    infra = await getInfra();
-    const { scenario, trainScheduleSet } = await createScenario(
-      generateUniqueName('paced-trains-scenario'),
-      project.id,
-      study.id,
-      infra.id
+    test.beforeAll(
+      'Setup project, study, infra and create scenario with paced trains',
+      async () => {
+        project = await getProject(timetableItemProjectName);
+        study = await getStudy(project.id, timetableItemStudyName);
+        infra = await getInfra();
+        const { scenario, trainScheduleSet } = await createScenario(
+          generateUniqueName('paced-trains-scenario'),
+          project.id,
+          study.id,
+          infra.id
+        );
+        scenarioItems = scenario;
+        await sendTrains(trainScheduleSet.id, trains.slice(0, 6));
+      }
     );
-    scenarioItems = scenario;
-    await sendTrains(trainScheduleSet.id, trains.slice(0, 6));
-  });
 
-  test.beforeEach(
-    'Navigate to scenario page and wait for infrastructure to be loaded',
-    async ({ page }) => {
-      await page.goto(
-        `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenarioItems.id}`
-      );
-      await waitForInfraStateToBeCached(infra.id);
-    }
-  );
+    test.beforeEach(
+      'Navigate to scenario page and wait for infrastructure to be loaded',
+      async ({ page }) => {
+        await page.goto(
+          `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenarioItems.id}`
+        );
+        await waitForInfraStateToBeCached(infra.id);
+      }
+    );
 
-  test.afterAll('Delete the created scenario', async () => {
-    await deleteScenario(study.id, scenarioItems.name);
-  });
+    test.afterAll('Delete the created scenario', async () => {
+      await deleteScenario(study.id, scenarioItems.name);
+    });
 
-  /** *************** Test 1 **************** */
-  test('Edit an indexed occurrence', async ({ pacedTrainSection, operationalStudiesPage }) => {
-    await test.step('Open paced train and check initial menu (first occurrence)', async () => {
-      await pacedTrainSection.expandPacedTrainOccurrenceList(0);
-      await pacedTrainSection.checkOccurrenceMenuIcon(0);
-      await pacedTrainSection.checkOccurrenceActionMenu({
-        occurrenceIndex: 0,
-        expectedButtons: CONFORM_ACTIVE_OCCURRENCE_MENU_BUTTONS,
-        translations: frTranslations,
+    /** *************** Test 1 **************** */
+    test('Edit an indexed occurrence', async ({ pacedTrainSection, operationalStudiesPage }) => {
+      await test.step('Open paced train and check initial menu (first occurrence)', async () => {
+        await pacedTrainSection.expandPacedTrainOccurrenceList(0);
+        await pacedTrainSection.checkOccurrenceMenuIcon(0);
+        await pacedTrainSection.checkOccurrenceActionMenu({
+          occurrenceIndex: 0,
+          expectedButtons: CONFORM_ACTIVE_OCCURRENCE_MENU_BUTTONS,
+          translations: frTranslations,
+        });
+      });
+
+      await test.step('Edit occurrence name and save', async () => {
+        await pacedTrainSection.clickOccurrenceMenuButton('edit');
+        await operationalStudiesPage.setTimetableItemName(EDITED_OCCURRENCE_NAME);
+        await operationalStudiesPage.updateTimetableItem(
+          frTranslations.pacedTrains.updatePacedTrain
+        );
+        await operationalStudiesPage.checkToastHasBeenLaunched(
+          frTranslations.timetable.pacedTrainUpdated
+        );
+      });
+
+      await test.step('Verify edited occurrence tooltip and menu', async () => {
+        await pacedTrainSection.checkExceptionTooltip(
+          0,
+          frTranslations.timetable.occurrenceType.editedOccurrence +
+            frTranslations.timetable.occurrenceChangeGroup.train_name
+        );
+        await pacedTrainSection.checkOccurrenceMenuIcon(0);
+        await pacedTrainSection.checkOccurrenceActionMenu({
+          occurrenceIndex: 0,
+          expectedButtons: EXCEPTION_ACTIVE_OCCURRENCE_MENU_BUTTONS,
+          translations: frTranslations,
+        });
+      });
+
+      await test.step('Disable edited occurrence', async () => {
+        await pacedTrainSection.clickOccurrenceMenuButton('disable');
+        await pacedTrainSection.verifyOccurrenceName(0, EDITED_OCCURRENCE_NAME);
+        await pacedTrainSection.checkOccurrenceMenuIcon(0);
+        await pacedTrainSection.checkOccurrenceActionMenu({
+          occurrenceIndex: 0,
+          expectedButtons: DISABLED_OCCURRENCE_MENU_BUTTONS,
+          translations: frTranslations,
+        });
+      });
+
+      await test.step('Re-enable edited occurrence', async () => {
+        await pacedTrainSection.clickOccurrenceMenuButton('enable');
+        await pacedTrainSection.verifyOccurrenceName(0, EDITED_OCCURRENCE_NAME);
+        await pacedTrainSection.checkOccurrenceMenuIcon(0);
+        await pacedTrainSection.checkOccurrenceActionMenu({
+          occurrenceIndex: 0,
+          expectedButtons: EXCEPTION_ACTIVE_OCCURRENCE_MENU_BUTTONS,
+          translations: frTranslations,
+        });
+      });
+
+      await test.step('Restore occurrence to initial model', async () => {
+        await pacedTrainSection.clickOccurrenceMenuButton('restore');
+        await pacedTrainSection.verifyOccurrenceName(0, INITIAL_OCCURRENCE_NAME);
       });
     });
 
-    await test.step('Edit occurrence name and save', async () => {
-      await pacedTrainSection.clickOccurrenceMenuButton('edit');
-      await operationalStudiesPage.setTimetableItemName(EDITED_OCCURRENCE_NAME);
-      await operationalStudiesPage.updateTimetableItem(frTranslations.pacedTrains.updatePacedTrain);
-      await operationalStudiesPage.checkToastHasBeenLaunched(
-        frTranslations.timetable.pacedTrainUpdated
-      );
-    });
+    /** *************** Test 2 **************** */
+    test('Edit added exception', async ({
+      pacedTrainSection,
+      operationalStudiesPage,
+      rollingStockSelector,
+      timesAndStopsTab,
+      routeTab,
+      simulationSettingsTab,
+    }) => {
+      const PACED_TRAIN_NUMBER = 4;
+      const addedOccurrenceIndex = 1;
+      const editedPacedTrainData = trains[PACED_TRAIN_NUMBER];
 
-    await test.step('Verify edited occurrence tooltip and menu', async () => {
-      await pacedTrainSection.checkExceptionTooltip(
-        0,
-        frTranslations.timetable.occurrenceType.editedOccurrence +
-          frTranslations.timetable.occurrenceChangeGroup.train_name
-      );
-      await pacedTrainSection.checkOccurrenceMenuIcon(0);
-      await pacedTrainSection.checkOccurrenceActionMenu({
-        occurrenceIndex: 0,
-        expectedButtons: EXCEPTION_ACTIVE_OCCURRENCE_MENU_BUTTONS,
-        translations: frTranslations,
-      });
-    });
-
-    await test.step('Disable edited occurrence', async () => {
-      await pacedTrainSection.clickOccurrenceMenuButton('disable');
-      await pacedTrainSection.verifyOccurrenceName(0, EDITED_OCCURRENCE_NAME);
-      await pacedTrainSection.checkOccurrenceMenuIcon(0);
-      await pacedTrainSection.checkOccurrenceActionMenu({
-        occurrenceIndex: 0,
-        expectedButtons: DISABLED_OCCURRENCE_MENU_BUTTONS,
-        translations: frTranslations,
-      });
-    });
-
-    await test.step('Re-enable edited occurrence', async () => {
-      await pacedTrainSection.clickOccurrenceMenuButton('enable');
-      await pacedTrainSection.verifyOccurrenceName(0, EDITED_OCCURRENCE_NAME);
-      await pacedTrainSection.checkOccurrenceMenuIcon(0);
-      await pacedTrainSection.checkOccurrenceActionMenu({
-        occurrenceIndex: 0,
-        expectedButtons: EXCEPTION_ACTIVE_OCCURRENCE_MENU_BUTTONS,
-        translations: frTranslations,
-      });
-    });
-
-    await test.step('Restore occurrence to initial model', async () => {
-      await pacedTrainSection.clickOccurrenceMenuButton('restore');
-      await pacedTrainSection.verifyOccurrenceName(0, INITIAL_OCCURRENCE_NAME);
-    });
-  });
-
-  /** *************** Test 2 **************** */
-  test('Edit added exception', async ({
-    pacedTrainSection,
-    operationalStudiesPage,
-    rollingStockSelector,
-    timesAndStopsTab,
-    routeTab,
-    simulationSettingsTab,
-  }) => {
-    const PACED_TRAIN_NUMBER = 4;
-    const addedOccurrenceIndex = 1;
-    const editedPacedTrainData = trains[PACED_TRAIN_NUMBER];
-
-    await test.step('Open paced train and check initial menu state', async () => {
-      await pacedTrainSection.expandPacedTrainOccurrenceList(PACED_TRAIN_NUMBER);
-      await pacedTrainSection.checkOccurrenceMenuIcon(addedOccurrenceIndex);
-      await pacedTrainSection.checkOccurrenceActionMenu({
-        occurrenceIndex: addedOccurrenceIndex,
-        expectedButtons: ADDED_EXCEPTION_MENU_BUTTONS,
-        translations: frTranslations,
-      });
-    });
-
-    await test.step('Open exception edit menu', async () => {
-      await pacedTrainSection.clickOccurrenceMenuButton('edit');
-      await operationalStudiesPage.checkEditOccurrenceButtonsVisibility();
-    });
-
-    await test.step('Modify RS, route, start time and simulation params', async () => {
-      await rollingStockSelector.openRollingstockModal();
-      await rollingStockSelector.selectRollingStockCard({
-        name: electricRollingStockName,
-        confirmSelection: true,
+      await test.step('Open paced train and check initial menu state', async () => {
+        await pacedTrainSection.expandPacedTrainOccurrenceList(PACED_TRAIN_NUMBER);
+        await pacedTrainSection.checkOccurrenceMenuIcon(addedOccurrenceIndex);
+        await pacedTrainSection.checkOccurrenceActionMenu({
+          occurrenceIndex: addedOccurrenceIndex,
+          expectedButtons: ADDED_EXCEPTION_MENU_BUTTONS,
+          translations: frTranslations,
+        });
       });
 
-      await operationalStudiesPage.openRouteTab();
-      await routeTab.performPathfindingByTrigram({
-        originTrigram: 'WS',
-        destinationTrigram: 'NES',
+      await test.step('Open exception edit menu', async () => {
+        await pacedTrainSection.clickOccurrenceMenuButton('edit');
+        await operationalStudiesPage.checkEditOccurrenceButtonsVisibility();
       });
 
-      await operationalStudiesPage.setTimetableItemStartTime('02:40', '2024-10-16');
+      await test.step('Modify RS, route, start time and simulation params', async () => {
+        await rollingStockSelector.openRollingstockModal();
+        await rollingStockSelector.selectRollingStockCard({
+          name: electricRollingStockName,
+          confirmSelection: true,
+        });
 
-      await operationalStudiesPage.openTimesAndStopsTab();
-      await timesAndStopsTab.fillTableCellByStationAndHeader(
-        'Mid_East_station',
-        frTranslations.timeStopTable.stopTime,
-        '18000'
-      );
+        await operationalStudiesPage.openRouteTab();
+        await routeTab.performPathfindingByTrigram({
+          originTrigram: 'WS',
+          destinationTrigram: 'NES',
+        });
 
-      await operationalStudiesPage.openSimulationSettingsTab();
-      await simulationSettingsTab.selectSpeedLimitTagOption('MA100');
+        await operationalStudiesPage.setTimetableItemStartTime('02:40', '2024-10-16');
 
-      await operationalStudiesPage.submitTimetableItemEdit();
-      await operationalStudiesPage.checkToastHasBeenLaunched(
-        frTranslations.timetable.pacedTrainUpdated
-      );
-    });
+        await operationalStudiesPage.openTimesAndStopsTab();
+        await timesAndStopsTab.fillTableCellByStationAndHeader(
+          'Mid_East_station',
+          frTranslations.timeStopTable.stopTime,
+          '18000'
+        );
 
-    await test.step('Check exception tooltip after modifications', async () => {
-      await pacedTrainSection.checkExceptionTooltip(
-        addedOccurrenceIndex,
-        frTranslations.timetable.occurrenceType.addedOccurrence,
-        frTranslations.timetable.occurrenceChangeGroup.path_and_schedule as ChangeGroup,
-        frTranslations.timetable.occurrenceChangeGroup.rolling_stock as ChangeGroup,
-        frTranslations.timetable.occurrenceChangeGroup.speed_limit_tag as ChangeGroup,
-        frTranslations.timetable.occurrenceChangeGroup.start_time as ChangeGroup
-      );
-    });
+        await operationalStudiesPage.openSimulationSettingsTab();
+        await simulationSettingsTab.selectSpeedLimitTagOption('MA100');
 
-    await test.step('Check occurrence menu after modifications', async () => {
-      await pacedTrainSection.checkOccurrenceMenuIcon(addedOccurrenceIndex);
-      await pacedTrainSection.checkOccurrenceActionMenu({
-        occurrenceIndex: addedOccurrenceIndex,
-        expectedButtons: ADDED_AND_MODIFIED_EXCEPTION_MENU_BUTTONS,
-        translations: frTranslations,
+        await operationalStudiesPage.submitTimetableItemEdit();
+        await operationalStudiesPage.checkToastHasBeenLaunched(
+          frTranslations.timetable.pacedTrainUpdated
+        );
+      });
+
+      await test.step('Check exception tooltip after modifications', async () => {
+        await pacedTrainSection.checkExceptionTooltip(
+          addedOccurrenceIndex,
+          frTranslations.timetable.occurrenceType.addedOccurrence,
+          frTranslations.timetable.occurrenceChangeGroup.path_and_schedule as ChangeGroup,
+          frTranslations.timetable.occurrenceChangeGroup.rolling_stock as ChangeGroup,
+          frTranslations.timetable.occurrenceChangeGroup.speed_limit_tag as ChangeGroup,
+          frTranslations.timetable.occurrenceChangeGroup.start_time as ChangeGroup
+        );
+      });
+
+      await test.step('Check occurrence menu after modifications', async () => {
+        await pacedTrainSection.checkOccurrenceMenuIcon(addedOccurrenceIndex);
+        await pacedTrainSection.checkOccurrenceActionMenu({
+          occurrenceIndex: addedOccurrenceIndex,
+          expectedButtons: ADDED_AND_MODIFIED_EXCEPTION_MENU_BUTTONS,
+          translations: frTranslations,
+        });
+      });
+
+      await test.step('Restore occurrence to model', async () => {
+        await pacedTrainSection.clickOccurrenceMenuButton('restore');
+        await pacedTrainSection.verifyOccurrenceDetails(
+          {
+            name: `${editedPacedTrainData.train_name}/+`,
+            startTime: '02:40',
+            arrivalTime: '02:47',
+          },
+          addedOccurrenceIndex
+        );
+
+        await pacedTrainSection.checkOccurrenceActionMenu({
+          occurrenceIndex: addedOccurrenceIndex,
+          expectedButtons: ADDED_EXCEPTION_MENU_BUTTONS,
+          translations: frTranslations,
+        });
+      });
+
+      await test.step('Delete occurrence and check remaining ones', async () => {
+        await pacedTrainSection.clickOccurrenceMenuButton('delete');
+
+        await pacedTrainSection.expectOccurrencesListLength(2);
+        await pacedTrainSection.verifyOccurrenceDetails(
+          {
+            name: `${editedPacedTrainData.train_name} 1`,
+            startTime: '02:00',
+            arrivalTime: '02:07',
+          },
+          0
+        );
+        await pacedTrainSection.verifyOccurrenceDetails(
+          {
+            name: `${editedPacedTrainData.train_name} 3`,
+            startTime: '03:00',
+            arrivalTime: '03:07',
+          },
+          1
+        );
       });
     });
-
-    await test.step('Restore occurrence to model', async () => {
-      await pacedTrainSection.clickOccurrenceMenuButton('restore');
-      await pacedTrainSection.verifyOccurrenceDetails(
-        {
-          name: `${editedPacedTrainData.train_name}/+`,
-          startTime: '02:40',
-          arrivalTime: '02:47',
-        },
-        addedOccurrenceIndex
-      );
-
-      await pacedTrainSection.checkOccurrenceActionMenu({
-        occurrenceIndex: addedOccurrenceIndex,
-        expectedButtons: ADDED_EXCEPTION_MENU_BUTTONS,
-        translations: frTranslations,
-      });
-    });
-
-    await test.step('Delete occurrence and check remaining ones', async () => {
-      await pacedTrainSection.clickOccurrenceMenuButton('delete');
-
-      await pacedTrainSection.expectOccurrencesListLength(2);
-      await pacedTrainSection.verifyOccurrenceDetails(
-        {
-          name: `${editedPacedTrainData.train_name} 1`,
-          startTime: '02:00',
-          arrivalTime: '02:07',
-        },
-        0
-      );
-      await pacedTrainSection.verifyOccurrenceDetails(
-        {
-          name: `${editedPacedTrainData.train_name} 3`,
-          startTime: '03:00',
-          arrivalTime: '03:07',
-        },
-        1
-      );
-    });
-  });
-});
+  }
+);

--- a/front/tests/02-operational-studies/simulation-result/001-get-manchette.spec.ts
+++ b/front/tests/02-operational-studies/simulation-result/001-get-manchette.spec.ts
@@ -61,7 +61,7 @@ test.skip(
   'Limit to Chromium for GitHub snapshots storage optimization'
 );
 
-test.describe('@op @manchette @std', () => {
+test.describe('Space Time Diagram / Manchette', { tag: ['@op', '@manchette', '@std'] }, () => {
   let project: Project;
   let study: Study;
   let scenarioItems: Scenario;
@@ -95,68 +95,68 @@ test.describe('@op @manchette @std', () => {
   });
 
   /** *************** Test 1 **************** */
-  test('@smoke Basic checks for STD/Manchette', async ({
-    scenarioTimetableSection,
-    opSimulationResultPage,
-    getManchetteComponent,
-  }) => {
-    await test.step('Verify first unique train is selected', async () => {
-      await scenarioTimetableSection.verifyFirstTimetableItemIsSelected();
-      await opSimulationResultPage.setTrainListVisible();
-    });
-    await test.step('Assert GET slider', async () => {
-      await getManchetteComponent.assertDefaultSliderValue();
-    });
+  test(
+    'Basic checks for Space Time Diagram / Manchette',
+    { tag: '@smoke' },
+    async ({ scenarioTimetableSection, opSimulationResultPage, getManchetteComponent }) => {
+      await test.step('Verify first unique train is selected', async () => {
+        await scenarioTimetableSection.verifyFirstTimetableItemIsSelected();
+        await opSimulationResultPage.setTrainListVisible();
+      });
+      await test.step('Assert GET slider', async () => {
+        await getManchetteComponent.assertDefaultSliderValue();
+      });
 
-    await test.step('Toggle linear km mode', async () => {
-      await getManchetteComponent.toggleLinearKmMode();
-    });
+      await test.step('Toggle linear km mode', async () => {
+        await getManchetteComponent.toggleLinearKmMode();
+      });
 
-    await test.step('Expand and collapse warped map', async () => {
-      await getManchetteComponent.expandWarpedMap();
-      await getManchetteComponent.collapseWarpedMap();
-    });
+      await test.step('Expand and collapse warped map', async () => {
+        await getManchetteComponent.expandWarpedMap();
+        await getManchetteComponent.collapseWarpedMap();
+      });
 
-    await test.step('Zoom controls on GET', async () => {
-      await getManchetteComponent.adjustAndResetGetZoom();
-    });
+      await test.step('Zoom controls on GET', async () => {
+        await getManchetteComponent.adjustAndResetGetZoom();
+      });
 
-    await test.step('Zoom controls on Manchette', async () => {
-      await getManchetteComponent.zoomInAndResetManchette();
-    });
+      await test.step('Zoom controls on Manchette', async () => {
+        await getManchetteComponent.zoomInAndResetManchette();
+      });
 
-    await test.step('Tracks occupancy panel can open/close', async () => {
-      await getManchetteComponent.openTrackOccupancyPanel(
-        STD_MANCHETTE.occupancyWaypointIndex,
-        frTranslations
-      );
-      await getManchetteComponent.closeTrackOccupancyPanel(
-        STD_MANCHETTE.occupancyWaypointIndex,
-        frTranslations
-      );
-    });
+      await test.step('Tracks occupancy panel can open/close', async () => {
+        await getManchetteComponent.openTrackOccupancyPanel(
+          STD_MANCHETTE.occupancyWaypointIndex,
+          frTranslations
+        );
+        await getManchetteComponent.closeTrackOccupancyPanel(
+          STD_MANCHETTE.occupancyWaypointIndex,
+          frTranslations
+        );
+      });
 
-    await test.step('Show and hide waypoints', async () => {
-      await getManchetteComponent.verifyVisibleWaypointsCount(
-        STD_MANCHETTE.initialVisibleWaypoints
-      );
-      await getManchetteComponent.hideWaypoint(STD_MANCHETTE.normalWaypointIndex);
-      // After hiding the normal waypoint the requested point is displayed instead
-      await getManchetteComponent.verifyVisibleWaypointsCount(
-        STD_MANCHETTE.initialVisibleWaypoints
-      );
-      await getManchetteComponent.hideWaypoint(STD_MANCHETTE.requestedWaypointIndex, true);
-      await getManchetteComponent.verifyVisibleWaypointsCount(
-        STD_MANCHETTE.visibleAfterHidingRequested
-      );
-      await getManchetteComponent.openManchettePanel();
-      await getManchetteComponent.verifyWaypointsCheckedState(
-        WAYPOINT_CHECKBOX_STATE.checked,
-        WAYPOINT_CHECKBOX_STATE.total
-      );
-      await getManchetteComponent.closeWaypointPanel();
-    });
-  });
+      await test.step('Show and hide waypoints', async () => {
+        await getManchetteComponent.verifyVisibleWaypointsCount(
+          STD_MANCHETTE.initialVisibleWaypoints
+        );
+        await getManchetteComponent.hideWaypoint(STD_MANCHETTE.normalWaypointIndex);
+        // After hiding the normal waypoint the requested point is displayed instead
+        await getManchetteComponent.verifyVisibleWaypointsCount(
+          STD_MANCHETTE.initialVisibleWaypoints
+        );
+        await getManchetteComponent.hideWaypoint(STD_MANCHETTE.requestedWaypointIndex, true);
+        await getManchetteComponent.verifyVisibleWaypointsCount(
+          STD_MANCHETTE.visibleAfterHidingRequested
+        );
+        await getManchetteComponent.openManchettePanel();
+        await getManchetteComponent.verifyWaypointsCheckedState(
+          WAYPOINT_CHECKBOX_STATE.checked,
+          WAYPOINT_CHECKBOX_STATE.total
+        );
+        await getManchetteComponent.closeWaypointPanel();
+      });
+    }
+  );
 
   /** *************** Test 2 **************** */
   test.skip('Space time diagram (temporarily skipped until STD snapshots are stable)', async ({

--- a/front/tests/02-operational-studies/timetable/001-train-timetable.spec.ts
+++ b/front/tests/02-operational-studies/timetable/001-train-timetable.spec.ts
@@ -36,7 +36,7 @@ const frTranslations = {
 //       this workaround simply makes the viewport bigger so the whole list is rendered.
 test.use({ viewport: { width: 1920, height: 1920 } });
 
-test.describe('@op @timetable-items', () => {
+test.describe('Timetable items management', { tag: ['@op', '@timetable-items'] }, () => {
   let project: Project;
   let study: Study;
   let scenario: Scenario;
@@ -60,26 +60,28 @@ test.describe('@op @timetable-items', () => {
   );
 
   /** *************** Test 1 **************** */
-  test('@smoke Loading timetable items and verifying simulation result for unique trains', async ({
-    scenarioTimetableSection,
-  }) => {
-    await test.step('Verify counts then filter valid unique trains', async () => {
-      await scenarioTimetableSection.verifyTimetableItemsCount(TOTAL_TIMETABLE_ITEMS);
-      await scenarioTimetableSection.filterTrainTypeAndVerifyTrainCount(
-        'Unique train',
-        TOTAL_UNIQUE_TRAINS
-      );
-      await scenarioTimetableSection.filterValidityAndVerifyTrainCount(
-        'Valid',
-        VALID_UNIQUE_TRAIN,
-        frTranslations
-      );
-    });
+  test(
+    'Loading timetable items and verifying simulation result for unique trains',
+    { tag: '@smoke' },
+    async ({ scenarioTimetableSection }) => {
+      await test.step('Verify counts then filter valid unique trains', async () => {
+        await scenarioTimetableSection.verifyTimetableItemsCount(TOTAL_TIMETABLE_ITEMS);
+        await scenarioTimetableSection.filterTrainTypeAndVerifyTrainCount(
+          'Unique train',
+          TOTAL_UNIQUE_TRAINS
+        );
+        await scenarioTimetableSection.filterValidityAndVerifyTrainCount(
+          'Valid',
+          VALID_UNIQUE_TRAIN,
+          frTranslations
+        );
+      });
 
-    await test.step('Verify simulation results for valid unique trains', async () => {
-      await scenarioTimetableSection.verifyEachUniqueTrainSimulation(VALID_UNIQUE_TRAIN);
-    });
-  });
+      await test.step('Verify simulation results for valid unique trains', async () => {
+        await scenarioTimetableSection.verifyEachUniqueTrainSimulation(VALID_UNIQUE_TRAIN);
+      });
+    }
+  );
 
   /** *************** Test 2 **************** */
   test('Loading timetable items and verifying simulation result for paced trains', async ({

--- a/front/tests/02-operational-studies/timetable/002-train-timetable-filter.spec.ts
+++ b/front/tests/02-operational-studies/timetable/002-train-timetable-filter.spec.ts
@@ -44,7 +44,7 @@ const frTranslations = {
 //       this workaround simply makes the viewport bigger so the whole list is rendered.
 test.use({ viewport: { width: 1920, height: 1920 } });
 
-test.describe('@op @timetable-items @filter', () => {
+test.describe('Timetable items filtering', { tag: ['@op', '@timetable-items', '@filter'] }, () => {
   let project: Project;
   let study: Study;
   let scenario: Scenario;

--- a/front/tests/02-operational-studies/timetable/003-train-timetable-multiselection.spec.ts
+++ b/front/tests/02-operational-studies/timetable/003-train-timetable-multiselection.spec.ts
@@ -30,7 +30,7 @@ const frTranslations = {
 
 const trains: TrainSchedule[] = readJsonFile('./tests/assets/trains/trains.json');
 
-test.describe('@op @timetable-items @timetable-multiselection', () => {
+test.describe('Timetable items multiselection', { tag: ['@op', '@timetable-items'] }, () => {
   let project: Project;
   let study: Study;
   let scenarioItems: Scenario;

--- a/front/tests/02-operational-studies/timetable/004-train-edition.spec.ts
+++ b/front/tests/02-operational-studies/timetable/004-train-edition.spec.ts
@@ -41,7 +41,7 @@ const frTranslations = {
 
 const trains: TrainSchedule[] = readJsonFile('./tests/assets/trains/trains.json');
 
-test.describe('@op @paced-train @unique-train', () => {
+test.describe('Train edition', { tag: ['@op', '@paced-trains', '@unique-trains'] }, () => {
   let project: Project;
   let study: Study;
   let scenarioItems: Scenario;

--- a/front/tests/02-operational-studies/timetable/005-timetable-import-export.spec.ts
+++ b/front/tests/02-operational-studies/timetable/005-timetable-import-export.spec.ts
@@ -32,125 +32,135 @@ const frTranslations = {
   ...frCommonTranslations,
 };
 
-test.describe('@op @timetable-items @import @export', () => {
-  let project: Project;
-  let study: Study;
-  let scenario: Scenario;
-  let scenarioToExport: Scenario;
-  let infra: Infra;
+test.describe(
+  'Timetable import and export',
+  { tag: ['@op', '@timetable-items', '@import', '@export'] },
+  () => {
+    let project: Project;
+    let study: Study;
+    let scenario: Scenario;
+    let scenarioToExport: Scenario;
+    let infra: Infra;
 
-  let downloadDir: string;
-  let downloadedFilePath: string;
+    let downloadDir: string;
+    let downloadedFilePath: string;
 
-  test.beforeAll('Fetch project, study and infrastructure', async () => {
-    project = await getProject(timetableItemProjectName);
-    study = await getStudy(project.id, timetableItemStudyName);
-    scenarioToExport = await getScenario(study.id, timetableItemScenarioName);
-    infra = await getInfra();
-  });
-
-  test.beforeEach('Open scenario ', async ({ page, importExportPage }) => {
-    await test.step('Create, open scenario and wait for infra to be loaded', async () => {
-      scenario = (
-        await createScenario(
-          generateUniqueName('import-export-scenario'),
-          project.id,
-          study.id,
-          infra.id
-        )
-      ).scenario;
-      await page.goto(
-        `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenario.id}`
-      );
-      await waitForInfraStateToBeCached(infra.id);
+    test.beforeAll('Fetch project, study and infrastructure', async () => {
+      project = await getProject(timetableItemProjectName);
+      study = await getStudy(project.id, timetableItemStudyName);
+      scenarioToExport = await getScenario(study.id, timetableItemScenarioName);
+      infra = await getInfra();
     });
-    await test.step('Verify timetable is empty', async () => {
-      await importExportPage.verifyTimetableIsEmpty(frTranslations.timetable.noItem);
-    });
-  });
 
-  test.afterEach('Delete the created scenario', async () => {
-    await deleteScenario(study.id, scenario.name);
-  });
-
-  test('@smoke Verify timetable is exported and imported correctly', async ({
-    page,
-    importExportPage,
-    timetableItemDetailSection,
-  }, testInfo) => {
-    await test.step('Open scenario to export and verify initial timetable items count', async () => {
-      await page.goto(
-        `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenarioToExport.id}`
-      );
-      await timetableItemDetailSection.verifyTotalItemsLabel(frTranslations, {
-        totalPacedTrainCount: TOTAL_PACED_TRAINS,
-        totalUniqueTrainCount: TOTAL_UNIQUE_TRAINS,
+    test.beforeEach('Open scenario ', async ({ page, importExportPage }) => {
+      await test.step('Create, open scenario and wait for infra to be loaded', async () => {
+        scenario = (
+          await createScenario(
+            generateUniqueName('import-export-scenario'),
+            project.id,
+            study.id,
+            infra.id
+          )
+        ).scenario;
+        await page.goto(
+          `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenario.id}`
+        );
+        await waitForInfraStateToBeCached(infra.id);
+      });
+      await test.step('Verify timetable is empty', async () => {
+        await importExportPage.verifyTimetableIsEmpty(frTranslations.timetable.noItem);
       });
     });
 
-    await test.step('Select all timetable items and verify selection', async () => {
-      await timetableItemDetailSection.selectAllTimetableItemsAndVerifySelection(frTranslations, {
-        totalPacedTrainCount: TOTAL_PACED_TRAINS,
-        totalUniqueTrainCount: TOTAL_UNIQUE_TRAINS,
-      });
+    test.afterEach('Delete the created scenario', async () => {
+      await deleteScenario(study.id, scenario.name);
     });
 
-    await test.step('Export timetable items and verify download', async () => {
-      downloadDir = testInfo.outputDir;
-      downloadedFilePath = await importExportPage.exportTimetableItems(downloadDir);
-    });
+    test(
+      'Verify timetable is exported and imported correctly',
+      { tag: '@smoke' },
+      async ({ page, importExportPage, timetableItemDetailSection }, testInfo) => {
+        await test.step('Open scenario to export and verify initial timetable items count', async () => {
+          await page.goto(
+            `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenarioToExport.id}`
+          );
+          await timetableItemDetailSection.verifyTotalItemsLabel(frTranslations, {
+            totalPacedTrainCount: TOTAL_PACED_TRAINS,
+            totalUniqueTrainCount: TOTAL_UNIQUE_TRAINS,
+          });
+        });
 
-    await test.step('Import timetable items JSON and close dialog in the target scenario', async () => {
-      await page.goto(
-        `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenario.id}`
-      );
-      await importExportPage.openImportTimetableItemUploadDialog();
-      await importExportPage.uploadTimetableItemFile(downloadedFilePath, frTranslations.success);
-    });
+        await test.step('Select all timetable items and verify selection', async () => {
+          await timetableItemDetailSection.selectAllTimetableItemsAndVerifySelection(
+            frTranslations,
+            {
+              totalPacedTrainCount: TOTAL_PACED_TRAINS,
+              totalUniqueTrainCount: TOTAL_UNIQUE_TRAINS,
+            }
+          );
+        });
 
-    await test.step('Verify timetable items count after import', async () => {
-      await timetableItemDetailSection.verifyTotalItemsLabel(frTranslations, {
-        totalPacedTrainCount: TOTAL_PACED_TRAINS,
-        totalUniqueTrainCount: TOTAL_UNIQUE_TRAINS,
-      });
-    });
-  });
+        await test.step('Export timetable items and verify download', async () => {
+          downloadDir = testInfo.outputDir;
+          downloadedFilePath = await importExportPage.exportTimetableItems(downloadDir);
+        });
 
-  test('@smoke Verify timetable items are imported correctly', async ({
-    importExportPage,
-    timetableItemDetailSection,
-    pacedTrainSection,
-  }) => {
-    await test.step('Import timetable items JSON and return to scenario', async () => {
-      await importExportPage.openImportTimetableItemUploadDialog();
-      await importExportPage.uploadTimetableItemFile(
-        './tests/assets/operation-studies/timetable-items.json',
-        frTranslations.success
-      );
-    });
+        await test.step('Import timetable items JSON and close dialog in the target scenario', async () => {
+          await page.goto(
+            `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenario.id}`
+          );
+          await importExportPage.openImportTimetableItemUploadDialog();
+          await importExportPage.uploadTimetableItemFile(
+            downloadedFilePath,
+            frTranslations.success
+          );
+        });
 
-    await test.step('Verify timetable items count after import', async () => {
-      await importExportPage.verifyTotalItemsLabel(frTranslations, EXPECTED_COUNTS);
-    });
+        await test.step('Verify timetable items count after import', async () => {
+          await timetableItemDetailSection.verifyTotalItemsLabel(frTranslations, {
+            totalPacedTrainCount: TOTAL_PACED_TRAINS,
+            totalUniqueTrainCount: TOTAL_UNIQUE_TRAINS,
+          });
+        });
+      }
+    );
 
-    await test.step('Verify details for valid imported paced trains', async () => {
-      await timetableItemDetailSection.showTimetableItemsDetails();
-      await timetableItemDetailSection.verifyPacedTrainDetails(0, PACED_DETAILS[0]);
-      await pacedTrainSection.verifyOccurrencesCount(3, 0);
-      await timetableItemDetailSection.verifyPacedTrainDetails(1, PACED_DETAILS[1]);
-      await pacedTrainSection.verifyOccurrencesCount(5, 3);
-    });
-    await test.step('Verify details for valid imported unique trains', async () => {
-      await timetableItemDetailSection.verifyUniqueTrainsDetails(UNIQUE_TRAIN_DETAILS);
-    });
-    await test.step('Verify invalid items reasons', async () => {
-      await timetableItemDetailSection.verifyInvalidReasons([
-        frTranslations.timetable.invalid.rolling_stock_not_found,
-        frTranslations.timetable.invalid.incompatible_constraints,
-        frTranslations.timetable.invalid.rolling_stock_not_found,
-        frTranslations.timetable.invalid.incompatible_constraints,
-        frTranslations.timetable.invalid.not_found_in_blocks,
-      ]);
-    });
-  });
-});
+    test(
+      'Verify timetable items are imported correctly',
+      { tag: '@smoke' },
+      async ({ importExportPage, timetableItemDetailSection, pacedTrainSection }) => {
+        await test.step('Import timetable items JSON and return to scenario', async () => {
+          await importExportPage.openImportTimetableItemUploadDialog();
+          await importExportPage.uploadTimetableItemFile(
+            './tests/assets/operation-studies/timetable-items.json',
+            frTranslations.success
+          );
+        });
+
+        await test.step('Verify timetable items count after import', async () => {
+          await importExportPage.verifyTotalItemsLabel(frTranslations, EXPECTED_COUNTS);
+        });
+
+        await test.step('Verify details for valid imported paced trains', async () => {
+          await timetableItemDetailSection.showTimetableItemsDetails();
+          await timetableItemDetailSection.verifyPacedTrainDetails(0, PACED_DETAILS[0]);
+          await pacedTrainSection.verifyOccurrencesCount(3, 0);
+          await timetableItemDetailSection.verifyPacedTrainDetails(1, PACED_DETAILS[1]);
+          await pacedTrainSection.verifyOccurrencesCount(5, 3);
+        });
+        await test.step('Verify details for valid imported unique trains', async () => {
+          await timetableItemDetailSection.verifyUniqueTrainsDetails(UNIQUE_TRAIN_DETAILS);
+        });
+        await test.step('Verify invalid items reasons', async () => {
+          await timetableItemDetailSection.verifyInvalidReasons([
+            frTranslations.timetable.invalid.rolling_stock_not_found,
+            frTranslations.timetable.invalid.incompatible_constraints,
+            frTranslations.timetable.invalid.rolling_stock_not_found,
+            frTranslations.timetable.invalid.incompatible_constraints,
+            frTranslations.timetable.invalid.not_found_in_blocks,
+          ]);
+        });
+      }
+    );
+  }
+);

--- a/front/tests/02-operational-studies/timetable/006-round-trips.spec.ts
+++ b/front/tests/02-operational-studies/timetable/006-round-trips.spec.ts
@@ -27,242 +27,248 @@ const frTranslations: RoundTripsModalTranslations = readJsonFile<{
 
 const trains: TrainSchedule[] = readJsonFile('./tests/assets/trains/trains.json');
 
-test.describe('@op @timetable-items @round-trips', () => {
-  let project: Project;
-  let study: Study;
-  let scenarioItems: Scenario;
-  let infra: Infra;
+test.describe(
+  'Round trips management',
+  { tag: ['@op', '@timetable-items', '@round-trips'] },
+  () => {
+    let project: Project;
+    let study: Study;
+    let scenarioItems: Scenario;
+    let infra: Infra;
 
-  test.beforeAll('Fetch project, study and infrastructure', async () => {
-    project = await getProject(timetableItemProjectName);
-    study = await getStudy(project.id, timetableItemStudyName);
-    infra = await getInfra();
-  });
-
-  test.beforeEach('Open scenario & round-trip modal', async ({ page, roundTripPage }) => {
-    await test.step('Create, open scenario and wait for infra to be loaded', async () => {
-      const { scenario, trainScheduleSet } = await createScenario(
-        generateUniqueName('round-trips-scenario'),
-        project.id,
-        study.id,
-        infra.id
-      );
-      scenarioItems = scenario;
-
-      const selectedTrains = [...trains.slice(4, 7), ...trains.slice(25, 28)];
-      await sendTrains(trainScheduleSet.id, selectedTrains);
-
-      await page.goto(
-        `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenarioItems.id}`
-      );
-      await waitForInfraStateToBeCached(infra.id);
-    });
-    await test.step('Open round trip page modal', async () => {
-      await roundTripPage.openRoundTripModal();
-    });
-  });
-
-  test.afterEach('Delete the created scenario', async () => {
-    await deleteScenario(study.id, scenarioItems.name);
-  });
-
-  /** *************** Test 1 **************** */
-  test('Basic checks round trips', async ({ roundTripPage }) => {
-    await test.step('Verify round trips elements are visible', async () => {
-      await roundTripPage.verifyRoundTripsModalElements(
-        frTranslations.roundTripsModal.todo,
-        frTranslations.roundTripsModal.oneWays,
-        frTranslations.roundTripsModal.roundTrips
-      );
+    test.beforeAll('Fetch project, study and infrastructure', async () => {
+      project = await getProject(timetableItemProjectName);
+      study = await getStudy(project.id, timetableItemStudyName);
+      infra = await getInfra();
     });
 
-    await test.step('Assert default column cards count', async () => {
-      await roundTripPage.assertRoundTripColumnCounts({
-        expectedToDoCount: 6,
-        expectedOneWayCount: 0,
-        expectedRoundTripCount: 0,
+    test.beforeEach('Open scenario & round-trip modal', async ({ page, roundTripPage }) => {
+      await test.step('Create, open scenario and wait for infra to be loaded', async () => {
+        const { scenario, trainScheduleSet } = await createScenario(
+          generateUniqueName('round-trips-scenario'),
+          project.id,
+          study.id,
+          infra.id
+        );
+        scenarioItems = scenario;
+
+        const selectedTrains = [...trains.slice(4, 7), ...trains.slice(25, 28)];
+        await sendTrains(trainScheduleSet.id, selectedTrains);
+
+        await page.goto(
+          `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenarioItems.id}`
+        );
+        await waitForInfraStateToBeCached(infra.id);
       });
-    });
-  });
-
-  /** *************** Test 2 **************** */
-  test('@smoke Verify round trip cards: paced trains and unique trains', async ({
-    roundTripPage,
-  }) => {
-    await test.step('First paced train - data & no tooltip', async () => {
-      await roundTripPage.verifyRoundTripCardData({
-        roundTripCardIndex: 0,
-        expectedCard: FirstPacedTrain,
-      });
-      await roundTripPage.verifyNoTooltipDisplayed({ roundTripCardIndex: 0 });
-    });
-
-    await test.step('Second paced train - data & tooltip check', async () => {
-      await roundTripPage.verifyRoundTripCardData({
-        roundTripCardIndex: 1,
-        expectedCard: SecondPacedTrain,
-      });
-      await roundTripPage.checkIntermediateStopsTooltip({ roundTripCardIndex: 1 });
-    });
-
-    await test.step('Third paced train - data & no tooltip', async () => {
-      await roundTripPage.verifyRoundTripCardData({
-        roundTripCardIndex: 2,
-        expectedCard: ThirdPacedTrain,
-      });
-      await roundTripPage.verifyNoTooltipDisplayed({ roundTripCardIndex: 2 });
-    });
-
-    await test.step('First unique train - data & no tooltip', async () => {
-      await roundTripPage.verifyRoundTripCardData({
-        roundTripCardIndex: 3,
-        expectedCard: FirstUniqueTrain,
-      });
-      await roundTripPage.verifyNoTooltipDisplayed({ roundTripCardIndex: 3 });
-    });
-
-    await test.step('Second unique train - data & tooltip check', async () => {
-      await roundTripPage.verifyRoundTripCardData({
-        roundTripCardIndex: 4,
-        expectedCard: SecondUniqueTrain,
-      });
-      await roundTripPage.checkIntermediateStopsTooltip({ roundTripCardIndex: 4 });
-    });
-
-    await test.step('Third unique train - data, tooltip check & final no-tooltip', async () => {
-      await roundTripPage.verifyRoundTripCardData({
-        roundTripCardIndex: 5,
-        expectedCard: ThirdUniqueTrain,
-      });
-      await roundTripPage.checkIntermediateStopsTooltip({ roundTripCardIndex: 5 });
-    });
-  });
-
-  /** *************** Test 3 **************** */
-  test('Cancel round trip items', async ({ roundTripPage }) => {
-    await test.step('Move 1 item from To-do → One-way (not yet saved)', async () => {
-      await roundTripPage.setTodoCardToOneWay({
-        index: 3,
-        toDoCount: 5,
-        oneWayCount: 1,
-        roundTripCount: 0,
+      await test.step('Open round trip page modal', async () => {
+        await roundTripPage.openRoundTripModal();
       });
     });
 
-    await test.step('Cancel changes and close the modal', async () => {
-      await roundTripPage.cancelRoundTripModal();
+    test.afterEach('Delete the created scenario', async () => {
+      await deleteScenario(study.id, scenarioItems.name);
     });
 
-    await test.step('Reopen modal → no changes persisted', async () => {
-      await roundTripPage.openRoundTripModal();
-      await roundTripPage.assertRoundTripColumnCounts({
-        expectedToDoCount: 6,
-        expectedOneWayCount: 0,
-        expectedRoundTripCount: 0,
+    /** *************** Test 1 **************** */
+    test('Basic checks round trips', async ({ roundTripPage }) => {
+      await test.step('Verify round trips elements are visible', async () => {
+        await roundTripPage.verifyRoundTripsModalElements(
+          frTranslations.roundTripsModal.todo,
+          frTranslations.roundTripsModal.oneWays,
+          frTranslations.roundTripsModal.roundTrips
+        );
       });
-    });
-  });
 
-  /** *************** Test 4 **************** */
-  test('@smoke Save round trip items', async ({ roundTripPage }) => {
-    await test.step('Move 1 item from To-do → One-way', async () => {
-      await roundTripPage.setTodoCardToOneWay({
-        index: 0,
-        toDoCount: 5,
-        oneWayCount: 1,
-        roundTripCount: 0,
-      });
-    });
-
-    await test.step('Save changes and close the modal', async () => {
-      await roundTripPage.saveRoundTripModal();
-    });
-
-    await test.step('Reopen modal → reflect the saved state', async () => {
-      await roundTripPage.openRoundTripModal();
-      await roundTripPage.assertRoundTripColumnCounts({
-        expectedToDoCount: 5,
-        expectedOneWayCount: 1,
-        expectedRoundTripCount: 0,
-      });
-    });
-  });
-
-  /** *************** Test 5 **************** */
-  test('Set One-way trip', async ({ roundTripPage }) => {
-    await test.step('Filter item by name → verify filtered counts', async () => {
-      await roundTripPage.searchForRoundTripsCard({
-        searchText: 'train19',
-        expectedToDoCount: 1,
-        expectedOneWayCount: 0,
-        expectedRoundTripCount: 0,
+      await test.step('Assert default column cards count', async () => {
+        await roundTripPage.assertRoundTripColumnCounts({
+          expectedToDoCount: 6,
+          expectedOneWayCount: 0,
+          expectedRoundTripCount: 0,
+        });
       });
     });
 
-    await test.step('Convert the filtered item To-do → One-way', async () => {
-      await roundTripPage.setTodoCardToOneWay({
-        index: 0,
-        toDoCount: 0,
-        oneWayCount: 1,
-        roundTripCount: 0,
+    /** *************** Test 2 **************** */
+    test(
+      'Verify round trip cards: paced trains and unique trains',
+      { tag: '@smoke' },
+      async ({ roundTripPage }) => {
+        await test.step('First paced train - data & no tooltip', async () => {
+          await roundTripPage.verifyRoundTripCardData({
+            roundTripCardIndex: 0,
+            expectedCard: FirstPacedTrain,
+          });
+          await roundTripPage.verifyNoTooltipDisplayed({ roundTripCardIndex: 0 });
+        });
+
+        await test.step('Second paced train - data & tooltip check', async () => {
+          await roundTripPage.verifyRoundTripCardData({
+            roundTripCardIndex: 1,
+            expectedCard: SecondPacedTrain,
+          });
+          await roundTripPage.checkIntermediateStopsTooltip({ roundTripCardIndex: 1 });
+        });
+
+        await test.step('Third paced train - data & no tooltip', async () => {
+          await roundTripPage.verifyRoundTripCardData({
+            roundTripCardIndex: 2,
+            expectedCard: ThirdPacedTrain,
+          });
+          await roundTripPage.verifyNoTooltipDisplayed({ roundTripCardIndex: 2 });
+        });
+
+        await test.step('First unique train - data & no tooltip', async () => {
+          await roundTripPage.verifyRoundTripCardData({
+            roundTripCardIndex: 3,
+            expectedCard: FirstUniqueTrain,
+          });
+          await roundTripPage.verifyNoTooltipDisplayed({ roundTripCardIndex: 3 });
+        });
+
+        await test.step('Second unique train - data & tooltip check', async () => {
+          await roundTripPage.verifyRoundTripCardData({
+            roundTripCardIndex: 4,
+            expectedCard: SecondUniqueTrain,
+          });
+          await roundTripPage.checkIntermediateStopsTooltip({ roundTripCardIndex: 4 });
+        });
+
+        await test.step('Third unique train - data, tooltip check & final no-tooltip', async () => {
+          await roundTripPage.verifyRoundTripCardData({
+            roundTripCardIndex: 5,
+            expectedCard: ThirdUniqueTrain,
+          });
+          await roundTripPage.checkIntermediateStopsTooltip({ roundTripCardIndex: 5 });
+        });
+      }
+    );
+
+    /** *************** Test 3 **************** */
+    test('Cancel round trip items', async ({ roundTripPage }) => {
+      await test.step('Move 1 item from To-do → One-way (not yet saved)', async () => {
+        await roundTripPage.setTodoCardToOneWay({
+          index: 3,
+          toDoCount: 5,
+          oneWayCount: 1,
+          roundTripCount: 0,
+        });
+      });
+
+      await test.step('Cancel changes and close the modal', async () => {
+        await roundTripPage.cancelRoundTripModal();
+      });
+
+      await test.step('Reopen modal → no changes persisted', async () => {
+        await roundTripPage.openRoundTripModal();
+        await roundTripPage.assertRoundTripColumnCounts({
+          expectedToDoCount: 6,
+          expectedOneWayCount: 0,
+          expectedRoundTripCount: 0,
+        });
       });
     });
 
-    await test.step('Clear filter → restore the One-way item back to To-do', async () => {
-      await roundTripPage.clearRoundTripSearchField({
-        expectedToDoCount: 5,
-        expectedOneWayCount: 1,
-        expectedRoundTripCount: 0,
+    /** *************** Test 4 **************** */
+    test('Save round trip items', { tag: '@smoke' }, async ({ roundTripPage }) => {
+      await test.step('Move 1 item from To-do → One-way', async () => {
+        await roundTripPage.setTodoCardToOneWay({
+          index: 0,
+          toDoCount: 5,
+          oneWayCount: 1,
+          roundTripCount: 0,
+        });
       });
-      await roundTripPage.restoreOneWayCardToTodo({
-        index: 0,
-        toDoCount: 6,
-        oneWayCount: 0,
-        roundTripCount: 0,
-      });
-    });
-  });
 
-  /** *************** Test 6 **************** */
-  test('Create and undo Round trips', async ({ roundTripPage }) => {
-    await test.step('Pair first One-way with its return', async () => {
-      await roundTripPage.pickReturnForOneWayCard({
-        index: 2,
-        pairingCardCount: 2,
-        pairingCardIndex: 1,
-        expectedToDoCount: 4,
-        expectedOneWayCount: 0,
-        expectedRoundTripCount: 1,
+      await test.step('Save changes and close the modal', async () => {
+        await roundTripPage.saveRoundTripModal();
+      });
+
+      await test.step('Reopen modal → reflect the saved state', async () => {
+        await roundTripPage.openRoundTripModal();
+        await roundTripPage.assertRoundTripColumnCounts({
+          expectedToDoCount: 5,
+          expectedOneWayCount: 1,
+          expectedRoundTripCount: 0,
+        });
       });
     });
 
-    await test.step('Pair second One-way with its return', async () => {
-      await roundTripPage.pickReturnForOneWayCard({
-        index: 1,
-        pairingCardCount: 2,
-        pairingCardIndex: 0,
-        expectedToDoCount: 2,
-        expectedOneWayCount: 0,
-        expectedRoundTripCount: 2,
+    /** *************** Test 5 **************** */
+    test('Set One-way trip', async ({ roundTripPage }) => {
+      await test.step('Filter item by name → verify filtered counts', async () => {
+        await roundTripPage.searchForRoundTripsCard({
+          searchText: 'train19',
+          expectedToDoCount: 1,
+          expectedOneWayCount: 0,
+          expectedRoundTripCount: 0,
+        });
+      });
+
+      await test.step('Convert the filtered item To-do → One-way', async () => {
+        await roundTripPage.setTodoCardToOneWay({
+          index: 0,
+          toDoCount: 0,
+          oneWayCount: 1,
+          roundTripCount: 0,
+        });
+      });
+
+      await test.step('Clear filter → restore the One-way item back to To-do', async () => {
+        await roundTripPage.clearRoundTripSearchField({
+          expectedToDoCount: 5,
+          expectedOneWayCount: 1,
+          expectedRoundTripCount: 0,
+        });
+        await roundTripPage.restoreOneWayCardToTodo({
+          index: 0,
+          toDoCount: 6,
+          oneWayCount: 0,
+          roundTripCount: 0,
+        });
       });
     });
 
-    await test.step('Restore the most recent Round trip back to To-do', async () => {
-      await roundTripPage.restoreRoundTripCardsToTodo({
-        index: 1,
-        toDoCount: 4,
-        oneWayCount: 0,
-        roundTripCount: 1,
+    /** *************** Test 6 **************** */
+    test('Create and undo Round trips', async ({ roundTripPage }) => {
+      await test.step('Pair first One-way with its return', async () => {
+        await roundTripPage.pickReturnForOneWayCard({
+          index: 2,
+          pairingCardCount: 2,
+          pairingCardIndex: 1,
+          expectedToDoCount: 4,
+          expectedOneWayCount: 0,
+          expectedRoundTripCount: 1,
+        });
       });
-    });
 
-    await test.step('Restore the remaining Round trip all back to To-do', async () => {
-      await roundTripPage.restoreRoundTripCardsToTodo({
-        index: 0,
-        toDoCount: 6,
-        oneWayCount: 0,
-        roundTripCount: 0,
+      await test.step('Pair second One-way with its return', async () => {
+        await roundTripPage.pickReturnForOneWayCard({
+          index: 1,
+          pairingCardCount: 2,
+          pairingCardIndex: 0,
+          expectedToDoCount: 2,
+          expectedOneWayCount: 0,
+          expectedRoundTripCount: 2,
+        });
+      });
+
+      await test.step('Restore the most recent Round trip back to To-do', async () => {
+        await roundTripPage.restoreRoundTripCardsToTodo({
+          index: 1,
+          toDoCount: 4,
+          oneWayCount: 0,
+          roundTripCount: 1,
+        });
+      });
+
+      await test.step('Restore the remaining Round trip all back to To-do', async () => {
+        await roundTripPage.restoreRoundTripCardsToTodo({
+          index: 0,
+          toDoCount: 6,
+          oneWayCount: 0,
+          roundTripCount: 0,
+        });
       });
     });
-  });
-});
+  }
+);

--- a/front/tests/02-operational-studies/timetable/007-scenario-page-synchronization.spec.ts
+++ b/front/tests/02-operational-studies/timetable/007-scenario-page-synchronization.spec.ts
@@ -40,7 +40,7 @@ test.skip(
   'This test is only stable on Chromium due to tab sync flakiness in Firefox'
 );
 
-test.describe('@op @multi-tab-sync', () => {
+test.describe('Scenario page synchronization', { tag: ['@op, @multi-tab-sync'] }, () => {
   let project: Project;
   let study: Study;
   let scenarioItems: Scenario;

--- a/front/tests/02-operational-studies/timetable/008-invalid-train.spec.ts
+++ b/front/tests/02-operational-studies/timetable/008-invalid-train.spec.ts
@@ -19,58 +19,62 @@ import { deleteScenario } from '../../utils/teardown-utils';
 
 const trains: TrainSchedule[] = readJsonFile('./tests/assets/trains/trains.json');
 
-test.describe('@op @paced-train @unique-train', () => {
-  let project: Project;
-  let study: Study;
-  let scenarioItems: Scenario;
-  let infra: Infra;
-  let scenarioTimetableSection: ScenarioTimetableSection;
-  let pacedTrainSection: PacedTrainSection;
-  let timeAndStopSimulationOutputs: TimeAndStopSimulationOutputs;
+test.describe(
+  'Invalid train simulation',
+  { tag: ['@op', '@paced-trains', '@unique-trains', '@invalid-trains'] },
+  () => {
+    let project: Project;
+    let study: Study;
+    let scenarioItems: Scenario;
+    let infra: Infra;
+    let scenarioTimetableSection: ScenarioTimetableSection;
+    let pacedTrainSection: PacedTrainSection;
+    let timeAndStopSimulationOutputs: TimeAndStopSimulationOutputs;
 
-  test.beforeAll('Fetch project, study and infrastructure', async () => {
-    project = await getProject(timetableItemProjectName);
-    study = await getStudy(project.id, timetableItemStudyName);
-    infra = await getInfra();
-  });
-
-  test.beforeEach('Setup scenario with invalid trains', async ({ page }) => {
-    scenarioTimetableSection = new ScenarioTimetableSection(page);
-    pacedTrainSection = new PacedTrainSection(page);
-    timeAndStopSimulationOutputs = new TimeAndStopSimulationOutputs(page);
-    scenarioItems = (
-      await createScenario(
-        generateUniqueName('invalid-train-scenario'),
-        project.id,
-        study.id,
-        infra.id
-      )
-    ).scenario;
-
-    const selectedTrains = [...trains.slice(3, 4), ...trains.slice(17, 18)];
-    await sendTrains(scenarioItems.timetable_id, selectedTrains);
-
-    await page.goto(
-      `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenarioItems.id}`
-    );
-    await waitForInfraStateToBeCached(infra.id);
-  });
-
-  test.afterAll('Delete the created scenario', async () => {
-    await deleteScenario(study.id, scenarioItems.name);
-  });
-
-  /** *************** Test 1 **************** */
-  test('@smoke Verify invalid train simulation result', async () => {
-    await test.step('Project paced train and verify invalid simulation outputs', async () => {
-      await pacedTrainSection.projectPacedTrain();
-      await scenarioTimetableSection.verifyInvalidTrainSimulationResultsVisibility();
+    test.beforeAll('Fetch project, study and infrastructure', async () => {
+      project = await getProject(timetableItemProjectName);
+      study = await getStudy(project.id, timetableItemStudyName);
+      infra = await getInfra();
     });
-    await timeAndStopSimulationOutputs.getOutputTableData(invalidPacedTrainTimetableOutput);
-    await test.step('Project invalid train and verify invalid simulation outputs', async () => {
-      await scenarioTimetableSection.projectTrain(1);
-      await scenarioTimetableSection.verifyInvalidTrainSimulationResultsVisibility();
-      await timeAndStopSimulationOutputs.getOutputTableData(invalidUniqueTrainTimetableOutput);
+
+    test.beforeEach('Setup scenario with invalid trains', async ({ page }) => {
+      scenarioTimetableSection = new ScenarioTimetableSection(page);
+      pacedTrainSection = new PacedTrainSection(page);
+      timeAndStopSimulationOutputs = new TimeAndStopSimulationOutputs(page);
+      scenarioItems = (
+        await createScenario(
+          generateUniqueName('invalid-train-scenario'),
+          project.id,
+          study.id,
+          infra.id
+        )
+      ).scenario;
+
+      const selectedTrains = [...trains.slice(3, 4), ...trains.slice(17, 18)];
+      await sendTrains(scenarioItems.timetable_id, selectedTrains);
+
+      await page.goto(
+        `/operational-studies/projects/${project.id}/studies/${study.id}/scenarios/${scenarioItems.id}`
+      );
+      await waitForInfraStateToBeCached(infra.id);
     });
-  });
-});
+
+    test.afterAll('Delete the created scenario', async () => {
+      await deleteScenario(study.id, scenarioItems.name);
+    });
+
+    /** *************** Test 1 **************** */
+    test('Verify invalid train simulation result', { tag: '@smoke' }, async () => {
+      await test.step('Project paced train and verify invalid simulation outputs', async () => {
+        await pacedTrainSection.projectPacedTrain();
+        await scenarioTimetableSection.verifyInvalidTrainSimulationResultsVisibility();
+      });
+      await timeAndStopSimulationOutputs.getOutputTableData(invalidPacedTrainTimetableOutput);
+      await test.step('Project invalid train and verify invalid simulation outputs', async () => {
+        await scenarioTimetableSection.projectTrain(1);
+        await scenarioTimetableSection.verifyInvalidTrainSimulationResultsVisibility();
+        await timeAndStopSimulationOutputs.getOutputTableData(invalidUniqueTrainTimetableOutput);
+      });
+    });
+  }
+);

--- a/front/tests/02-operational-studies/train-creation-tabs/001-op-rolling-stock-tab.spec.ts
+++ b/front/tests/02-operational-studies/train-creation-tabs/001-op-rolling-stock-tab.spec.ts
@@ -18,7 +18,7 @@ import { getInfra, getRollingStock } from '../../utils/api-utils';
 import createScenario from '../../utils/scenario';
 import { deleteScenario } from '../../utils/teardown-utils';
 
-test.describe('@op @rs-tab', () => {
+test.describe('Rolling stock tab', { tag: ['@op', '@rs-tab'] }, () => {
   let project: Project;
   let study: Study;
   let scenario: Scenario;
@@ -47,37 +47,38 @@ test.describe('@op @rs-tab', () => {
   );
 
   /** *************** Test 1 **************** */
-  test('@smoke Select a rolling stock for operational study', async ({
-    operationalStudiesPage,
-    rollingStockSelector,
-  }) => {
-    await test.step('Verify tab warnings are present', async () => {
-      await operationalStudiesPage.verifyTabWarningPresence();
-    });
-
-    await test.step('Open selector and search dual-mode rolling stock', async () => {
-      await rollingStockSelector.openEmptyRollingStockSelector();
-      await rollingStockSelector.searchRollingstock(dualModeRollingStockName);
-    });
-
-    await test.step('Verify RS card is inactive before selection', async () => {
-      await rollingStockSelector.verifyRollingStockIsInactive(dualModeRollingStockName);
-    });
-
-    await test.step('Activate RS card', async () => {
-      await rollingStockSelector.selectRollingStockCard({ name: dualModeRollingStockName });
-    });
-
-    await test.step('Select AIR_CONDITIONING comfort and confirm the new RS is displayed', async () => {
-      const comfortACRadioText = await rollingStockSelector.comfortACButton.innerText();
-      await rollingStockSelector.selectRollingStockCard({
-        name: dualModeRollingStockName,
-        selectComfort: true,
-        confirmSelection: true,
+  test(
+    'Select a rolling stock for operational study',
+    { tag: '@smoke' },
+    async ({ operationalStudiesPage, rollingStockSelector }) => {
+      await test.step('Verify tab warnings are present', async () => {
+        await operationalStudiesPage.verifyTabWarningPresence();
       });
-      await rollingStockSelector.verifySelectedComfortMatches(comfortACRadioText);
-    });
-  });
+
+      await test.step('Open selector and search dual-mode rolling stock', async () => {
+        await rollingStockSelector.openEmptyRollingStockSelector();
+        await rollingStockSelector.searchRollingstock(dualModeRollingStockName);
+      });
+
+      await test.step('Verify RS card is inactive before selection', async () => {
+        await rollingStockSelector.verifyRollingStockIsInactive(dualModeRollingStockName);
+      });
+
+      await test.step('Activate RS card', async () => {
+        await rollingStockSelector.selectRollingStockCard({ name: dualModeRollingStockName });
+      });
+
+      await test.step('Select AIR_CONDITIONING comfort and confirm the new RS is displayed', async () => {
+        const comfortACRadioText = await rollingStockSelector.comfortACButton.innerText();
+        await rollingStockSelector.selectRollingStockCard({
+          name: dualModeRollingStockName,
+          selectComfort: true,
+          confirmSelection: true,
+        });
+        await rollingStockSelector.verifySelectedComfortMatches(comfortACRadioText);
+      });
+    }
+  );
 
   /** *************** Test 2 **************** */
   test('Modify a rolling stock for operational study', async ({ rollingStockSelector }) => {

--- a/front/tests/02-operational-studies/train-creation-tabs/002-op-route-tab.spec.ts
+++ b/front/tests/02-operational-studies/train-creation-tabs/002-op-route-tab.spec.ts
@@ -7,7 +7,7 @@ import { getInfra } from '../../utils/api-utils';
 import createScenario from '../../utils/scenario';
 import { deleteScenario } from '../../utils/teardown-utils';
 
-test.describe('@op @route-tab', () => {
+test.describe('Route tab', { tag: ['@op', '@route-tab'] }, () => {
   let project: Project;
   let study: Study;
   let scenario: Scenario;
@@ -39,34 +39,38 @@ test.describe('@op @route-tab', () => {
   });
 
   /** *************** Test 1 **************** */
-  test('@smoke Select a route for operational study', async ({
-    browserName,
-    routeTab,
-    operationalStudiesPage,
-  }) => {
-    await test.step('Verify no route selected initially', async () => {
-      await routeTab.verifyNoSelectedRoute();
-    });
-
-    await test.step('Perform pathfinding by trigrams (WS → NES via MES)', async () => {
-      await routeTab.performPathfindingByTrigram({
-        originTrigram: 'WS',
-        destinationTrigram: 'NES',
-        viaTrigram: 'MES',
+  test(
+    'Select a route for operational study',
+    { tag: '@smoke' },
+    async ({ browserName, routeTab, operationalStudiesPage }) => {
+      await test.step('Verify no route selected initially', async () => {
+        await routeTab.verifyNoSelectedRoute();
       });
-    });
 
-    await test.step('Verify map markers (Chromium only)', async () => {
-      if (browserName === 'chromium') {
-        const expectedMapMarkersValues = ['West_station', 'North_East_station', 'Mid_East_station'];
-        await routeTab.verifyMapMarkers(...expectedMapMarkersValues);
-      }
-    });
+      await test.step('Perform pathfinding by trigrams (WS → NES via MES)', async () => {
+        await routeTab.performPathfindingByTrigram({
+          originTrigram: 'WS',
+          destinationTrigram: 'NES',
+          viaTrigram: 'MES',
+        });
+      });
 
-    await test.step('Verify tab warnings are absent', async () => {
-      await operationalStudiesPage.verifyTabWarningAbsence();
-    });
-  });
+      await test.step('Verify map markers (Chromium only)', async () => {
+        if (browserName === 'chromium') {
+          const expectedMapMarkersValues = [
+            'West_station',
+            'North_East_station',
+            'Mid_East_station',
+          ];
+          await routeTab.verifyMapMarkers(...expectedMapMarkersValues);
+        }
+      });
+
+      await test.step('Verify tab warnings are absent', async () => {
+        await operationalStudiesPage.verifyTabWarningAbsence();
+      });
+    }
+  );
 
   /** *************** Test 2 **************** */
   test('Adding waypoints to a route for operational study', async ({

--- a/front/tests/02-operational-studies/train-creation-tabs/003-op-times-and-stops-tab.spec.ts
+++ b/front/tests/02-operational-studies/train-creation-tabs/003-op-times-and-stops-tab.spec.ts
@@ -38,7 +38,7 @@ const expectedViaValues = [
   { name: 'Mid_East_station', ch: 'BV', uic: '44', km: 'KM 26.500' },
 ];
 
-test.describe('@op @times-stops-tab', () => {
+test.describe('Times and Stops tab', { tag: ['@op', '@times-stops-tab'] }, () => {
   let project: Project;
   let study: Study;
   let scenario: Scenario;
@@ -78,122 +78,126 @@ test.describe('@op @times-stops-tab', () => {
   });
 
   /** *************** Test 1 **************** */
-  test('@smoke Set and display times and stops tables', async ({
-    timesAndStopsTab,
-    operationalStudiesPage,
-    routeTab,
-    timeAndStopSimulationOutputs,
-  }) => {
-    await test.step('Verify table headers', async () => {
-      const expectedColumnNames = cleanWhitespaceInArray([
-        frTranslations.name,
-        frTranslations.ch,
-        frTranslations.trackName,
-        frTranslations.arrivalTime,
-        frTranslations.stopTime,
-        frTranslations.departureTime,
-        frTranslations.receptionOnClosedSignal,
-        frTranslations.shortSlipDistance,
-        frTranslations.theoreticalMargin,
-      ]);
-      const actualColumnHeaders = cleanWhitespaceInArray(
-        await timesAndStopsTab.columnHeaders.allInnerTexts()
-      );
-      expect(actualColumnHeaders).toEqual(expectedColumnNames);
-    });
-
-    await test.step('Fill initial inputs (2 active rows → 4 active rows)', async () => {
-      await timesAndStopsTab.verifyActiveRowsCount(2);
-      for (const cell of initialInputsData) {
-        const translatedHeader = cleanWhitespace(frTranslations[cell.header]);
-        await timesAndStopsTab.fillTableCellByStationAndHeader(
-          cell.stationName,
-          translatedHeader,
-          cell.value,
-          cell.marginForm
+  test(
+    'Set and display times and stops tables',
+    { tag: '@smoke' },
+    async ({
+      timesAndStopsTab,
+      operationalStudiesPage,
+      routeTab,
+      timeAndStopSimulationOutputs,
+    }) => {
+      await test.step('Verify table headers', async () => {
+        const expectedColumnNames = cleanWhitespaceInArray([
+          frTranslations.name,
+          frTranslations.ch,
+          frTranslations.trackName,
+          frTranslations.arrivalTime,
+          frTranslations.stopTime,
+          frTranslations.departureTime,
+          frTranslations.receptionOnClosedSignal,
+          frTranslations.shortSlipDistance,
+          frTranslations.theoreticalMargin,
+        ]);
+        const actualColumnHeaders = cleanWhitespaceInArray(
+          await timesAndStopsTab.columnHeaders.allInnerTexts()
         );
-      }
-    });
+        expect(actualColumnHeaders).toEqual(expectedColumnNames);
+      });
 
-    await test.step('Verify input table state after fill', async () => {
-      await timesAndStopsTab.verifyActiveRowsCount(4);
-      await timesAndStopsTab.verifyClearButtons(2);
-      await timesAndStopsTab.verifyInputTableData(inputExpectedData);
-    });
+      await test.step('Fill initial inputs (2 active rows → 4 active rows)', async () => {
+        await timesAndStopsTab.verifyActiveRowsCount(2);
+        for (const cell of initialInputsData) {
+          const translatedHeader = cleanWhitespace(frTranslations[cell.header]);
+          await timesAndStopsTab.fillTableCellByStationAndHeader(
+            cell.stationName,
+            translatedHeader,
+            cell.value,
+            cell.marginForm
+          );
+        }
+      });
 
-    await test.step('Validate waypoints in Route tab', async () => {
-      await operationalStudiesPage.openRouteTab();
-      for (const [viaIndex, expectedValue] of expectedViaValues.entries()) {
-        const droppedWaypoint = routeTab.droppedWaypoints.nth(viaIndex);
-        await routeTab.validateAddedWaypoint(
-          droppedWaypoint,
-          expectedValue.name,
-          expectedValue.ch,
-          expectedValue.uic
-        );
-      }
-    });
+      await test.step('Verify input table state after fill', async () => {
+        await timesAndStopsTab.verifyActiveRowsCount(4);
+        await timesAndStopsTab.verifyClearButtons(2);
+        await timesAndStopsTab.verifyInputTableData(inputExpectedData);
+      });
 
-    await test.step('Create timetable item, open results and verify outputs', async () => {
-      await operationalStudiesPage.createTimetableItem();
-      await operationalStudiesPage.closeToastNotification();
-      await operationalStudiesPage.returnSimulationResult();
-      await operationalStudiesPage.verifyTimesStopsDataSheetVisibility();
-      await timeAndStopSimulationOutputs.getOutputTableData(outputExpectedCellData);
-    });
-  });
+      await test.step('Validate waypoints in Route tab', async () => {
+        await operationalStudiesPage.openRouteTab();
+        for (const [viaIndex, expectedValue] of expectedViaValues.entries()) {
+          const droppedWaypoint = routeTab.droppedWaypoints.nth(viaIndex);
+          await routeTab.validateAddedWaypoint(
+            droppedWaypoint,
+            expectedValue.name,
+            expectedValue.ch,
+            expectedValue.uic
+          );
+        }
+      });
+
+      await test.step('Create timetable item, open results and verify outputs', async () => {
+        await operationalStudiesPage.createTimetableItem();
+        await operationalStudiesPage.closeToastNotification();
+        await operationalStudiesPage.returnSimulationResult();
+        await operationalStudiesPage.verifyTimesStopsDataSheetVisibility();
+        await timeAndStopSimulationOutputs.getOutputTableData(outputExpectedCellData);
+      });
+    }
+  );
 
   /** *************** Test 2 **************** */
-  test('@smoke Update and clear input table row', async ({
-    timesAndStopsTab,
-    operationalStudiesPage,
-    routeTab,
-  }) => {
-    await test.step('Fill initial inputs and verify table', async () => {
-      for (const cell of initialInputsData) {
-        const translatedHeader = cleanWhitespace(frTranslations[cell.header]);
-        await timesAndStopsTab.fillTableCellByStationAndHeader(
-          cell.stationName,
-          translatedHeader,
-          cell.value,
-          cell.marginForm
-        );
-      }
-      await timesAndStopsTab.verifyInputTableData(inputExpectedData);
-    });
+  test(
+    'Update and clear input table row',
+    { tag: '@smoke' },
+    async ({ timesAndStopsTab, operationalStudiesPage, routeTab }) => {
+      await test.step('Fill initial inputs and verify table', async () => {
+        for (const cell of initialInputsData) {
+          const translatedHeader = cleanWhitespace(frTranslations[cell.header]);
+          await timesAndStopsTab.fillTableCellByStationAndHeader(
+            cell.stationName,
+            translatedHeader,
+            cell.value,
+            cell.marginForm
+          );
+        }
+        await timesAndStopsTab.verifyInputTableData(inputExpectedData);
+      });
 
-    await test.step('Update inputs (keep 4 active rows)', async () => {
-      await timesAndStopsTab.verifyActiveRowsCount(4);
-      for (const cell of updatedInputsData) {
-        const translatedHeader = cleanWhitespace(frTranslations[cell.header]);
-        await timesAndStopsTab.fillTableCellByStationAndHeader(
-          cell.stationName,
-          translatedHeader,
-          cell.value,
-          cell.marginForm
-        );
-      }
-    });
+      await test.step('Update inputs (keep 4 active rows)', async () => {
+        await timesAndStopsTab.verifyActiveRowsCount(4);
+        for (const cell of updatedInputsData) {
+          const translatedHeader = cleanWhitespace(frTranslations[cell.header]);
+          await timesAndStopsTab.fillTableCellByStationAndHeader(
+            cell.stationName,
+            translatedHeader,
+            cell.value,
+            cell.marginForm
+          );
+        }
+      });
 
-    await test.step('Clear a row and verify new state (row count remains unchanged)', async () => {
-      await timesAndStopsTab.verifyClearButtons(2);
-      await timesAndStopsTab.clearRow(0);
-      await timesAndStopsTab.verifyActiveRowsCount(4);
-      await timesAndStopsTab.verifyClearButtons(1);
-      await timesAndStopsTab.verifyInputTableData(updatedCellData);
-    });
+      await test.step('Clear a row and verify new state (row count remains unchanged)', async () => {
+        await timesAndStopsTab.verifyClearButtons(2);
+        await timesAndStopsTab.clearRow(0);
+        await timesAndStopsTab.verifyActiveRowsCount(4);
+        await timesAndStopsTab.verifyClearButtons(1);
+        await timesAndStopsTab.verifyInputTableData(updatedCellData);
+      });
 
-    await test.step('Validate waypoints after updates (Route tab)', async () => {
-      await operationalStudiesPage.openRouteTab();
-      for (const [viaIndex, expectedValue] of expectedViaValues.entries()) {
-        const droppedWaypoint = routeTab.droppedWaypoints.nth(viaIndex);
-        await routeTab.validateAddedWaypoint(
-          droppedWaypoint,
-          expectedValue.name,
-          expectedValue.ch,
-          expectedValue.uic
-        );
-      }
-    });
-  });
+      await test.step('Validate waypoints after updates (Route tab)', async () => {
+        await operationalStudiesPage.openRouteTab();
+        for (const [viaIndex, expectedValue] of expectedViaValues.entries()) {
+          const droppedWaypoint = routeTab.droppedWaypoints.nth(viaIndex);
+          await routeTab.validateAddedWaypoint(
+            droppedWaypoint,
+            expectedValue.name,
+            expectedValue.ch,
+            expectedValue.uic
+          );
+        }
+      });
+    }
+  );
 });

--- a/front/tests/02-operational-studies/train-creation-tabs/004-op-simulation-settings-tab.spec.ts
+++ b/front/tests/02-operational-studies/train-creation-tabs/004-op-simulation-settings-tab.spec.ts
@@ -51,7 +51,7 @@ const expectedCellDataForAllSettings: StationData[] = readJsonFile(
   './tests/assets/operation-studies/simulation-settings/all-settings.json'
 );
 
-test.describe('@op @simulation-settings-tab', () => {
+test.describe('Simulation settings tab', { tag: ['@op', '@simulation-settings-tab'] }, () => {
   let electricalProfileSet: ElectricalProfileSet;
   let project: Project;
   let study: Study;
@@ -320,60 +320,64 @@ test.describe('@op @simulation-settings-tab', () => {
   });
 
   /** *************** Test 4 **************** */
-  test('@smoke Add all the simulation settings', async ({
-    browserName,
-    timesAndStopsTab,
-    operationalStudiesPage,
-    simulationSettingsTab,
-    scenarioTimetableSection,
-    opSimulationResultPage,
-    timeAndStopSimulationOutputs,
-  }) => {
-    const inputTableData: CellData[] = [
-      { stationName: 'Mid_East_station', header: 'stopTime', value: '124' },
-      {
-        stationName: 'West_station',
-        header: 'theoreticalMargin',
-        value: '5%',
-        marginForm: '% ou min/100km',
-      },
-    ];
+  test(
+    'Add all the simulation settings',
+    { tag: '@smoke' },
+    async ({
+      browserName,
+      timesAndStopsTab,
+      operationalStudiesPage,
+      simulationSettingsTab,
+      scenarioTimetableSection,
+      opSimulationResultPage,
+      timeAndStopSimulationOutputs,
+    }) => {
+      const inputTableData: CellData[] = [
+        { stationName: 'Mid_East_station', header: 'stopTime', value: '124' },
+        {
+          stationName: 'West_station',
+          header: 'theoreticalMargin',
+          value: '5%',
+          marginForm: '% ou min/100km',
+        },
+      ];
 
-    await test.step('Fill Times & Stops inputs', async () => {
-      for (const cell of inputTableData) {
-        const translatedHeader = cleanWhitespace(frTranslations[cell.header]);
-        await timesAndStopsTab.fillTableCellByStationAndHeader(
-          cell.stationName,
-          translatedHeader,
-          cell.value,
-          cell.marginForm
-        );
-      }
-    });
+      await test.step('Fill Times & Stops inputs', async () => {
+        for (const cell of inputTableData) {
+          const translatedHeader = cleanWhitespace(frTranslations[cell.header]);
+          await timesAndStopsTab.fillTableCellByStationAndHeader(
+            cell.stationName,
+            translatedHeader,
+            cell.value,
+            cell.marginForm
+          );
+        }
+      });
 
-    await test.step('Enable Linear margin + electrical profile + speed limit tag', async () => {
-      await operationalStudiesPage.openSimulationSettingsTab();
-      await simulationSettingsTab.checkElectricalProfile();
-      await simulationSettingsTab.activateLinearMargin();
-      await simulationSettingsTab.selectSpeedLimitTagOption('E32C');
-    });
+      await test.step('Enable Linear margin + electrical profile + speed limit tag', async () => {
+        await operationalStudiesPage.openSimulationSettingsTab();
+        await simulationSettingsTab.checkElectricalProfile();
+        await simulationSettingsTab.activateLinearMargin();
+        await simulationSettingsTab.selectSpeedLimitTagOption('E32C');
+      });
 
-    await test.step('Create unique train and verify outputs (all settings ON)', async () => {
-      await operationalStudiesPage.createTimetableItem();
-      await operationalStudiesPage.closeToastNotification();
-      await operationalStudiesPage.returnSimulationResult();
-      await opSimulationResultPage.setTrainListVisible();
+      await test.step('Create unique train and verify outputs (all settings ON)', async () => {
+        await operationalStudiesPage.createTimetableItem();
+        await operationalStudiesPage.closeToastNotification();
+        await operationalStudiesPage.returnSimulationResult();
+        await opSimulationResultPage.setTrainListVisible();
 
-      await operationalStudiesPage.verifyTimesStopsDataSheetVisibility();
-      await opSimulationResultPage.selectAllSpeedSpaceChartCheckboxes();
-      if (browserName === 'chromium') {
-        await expect(opSimulationResultPage.speedSpaceChart).toHaveScreenshot(
-          'SpeedSpaceChart-AllSettingsEnabled.png'
-        );
-      }
-      await timeAndStopSimulationOutputs.getOutputTableData(expectedCellDataForAllSettings);
-      await opSimulationResultPage.setTrainListVisible(false);
-      await scenarioTimetableSection.getTimetableItemArrivalTime('11:50');
-    });
-  });
+        await operationalStudiesPage.verifyTimesStopsDataSheetVisibility();
+        await opSimulationResultPage.selectAllSpeedSpaceChartCheckboxes();
+        if (browserName === 'chromium') {
+          await expect(opSimulationResultPage.speedSpaceChart).toHaveScreenshot(
+            'SpeedSpaceChart-AllSettingsEnabled.png'
+          );
+        }
+        await timeAndStopSimulationOutputs.getOutputTableData(expectedCellDataForAllSettings);
+        await opSimulationResultPage.setTrainListVisible(false);
+        await scenarioTimetableSection.getTimetableItemArrivalTime('11:50');
+      });
+    }
+  );
 });

--- a/front/tests/03-stdcm/001-stdcm.spec.ts
+++ b/front/tests/03-stdcm/001-stdcm.spec.ts
@@ -29,7 +29,7 @@ import test, { createStdcmTab } from './../page-object-fixture';
 import { waitForInfraStateToBeCached } from './../utils';
 import { getInfra, setTowedRollingStock } from './../utils/api-utils';
 
-test.describe('@stdcm', () => {
+test.describe('STDCM simulation with all stops and towed rolling stock', { tag: '@stdcm' }, () => {
   let infra: Infra;
   let createdTowedRollingStock: TowedRollingStock;
 
@@ -43,148 +43,157 @@ test.describe('@stdcm', () => {
   });
 
   /** *************** Test 1 **************** */
-  test('@smoke Verify default STDCM page', async ({
-    stdcmPage,
-    consistSection,
-    originSection,
-    viaSection,
-    destinationSection,
-    linkedTrainSection,
-  }) => {
-    await test.step('Verify base UI sections are visible', async () => {
-      await stdcmPage.verifyStdcmElementsVisibility();
-    });
-
-    await test.step('Verify default input values', async () => {
-      await consistSection.verifyDefaultConsistFields({
-        defaultSpeedLimitTag: DEFAULT_DETAILS.speedLimitTag,
+  test(
+    ' Verify default STDCM page',
+    { tag: '@smoke' },
+    async ({
+      stdcmPage,
+      consistSection,
+      originSection,
+      viaSection,
+      destinationSection,
+      linkedTrainSection,
+    }) => {
+      await test.step('Verify base UI sections are visible', async () => {
+        await stdcmPage.verifyStdcmElementsVisibility();
       });
 
-      await originSection.verifyDefaultOriginFields({
-        arrivalType: ORIGIN_DETAILS.arrivalType.default,
-        arrivalDate: DEFAULT_DETAILS.arrivalDate,
-        arrivalTime: DEFAULT_DETAILS.arrivalTime,
-        tolerance: DEFAULT_DETAILS.tolerance,
+      await test.step('Verify default input values', async () => {
+        await consistSection.verifyDefaultConsistFields({
+          defaultSpeedLimitTag: DEFAULT_DETAILS.speedLimitTag,
+        });
+
+        await originSection.verifyDefaultOriginFields({
+          arrivalType: ORIGIN_DETAILS.arrivalType.default,
+          arrivalDate: DEFAULT_DETAILS.arrivalDate,
+          arrivalTime: DEFAULT_DETAILS.arrivalTime,
+          tolerance: DEFAULT_DETAILS.tolerance,
+        });
+
+        await destinationSection.verifyDefaultDestinationFields(
+          DESTINATION_DETAILS.arrivalType.default
+        );
       });
 
-      await destinationSection.verifyDefaultDestinationFields(
-        DESTINATION_DETAILS.arrivalType.default
-      );
-    });
-
-    await test.step('Add/delete default via and linked path', async () => {
-      await viaSection.addAndDeletedDefaultVia(VIA_STOP_TYPES.PASSAGE_TIME);
-      await linkedTrainSection.addAndDeleteDefaultLinkedPath({
-        defaultDate: DEFAULT_DETAILS.arrivalDate,
+      await test.step('Add/delete default via and linked path', async () => {
+        await viaSection.addAndDeletedDefaultVia(VIA_STOP_TYPES.PASSAGE_TIME);
+        await linkedTrainSection.addAndDeleteDefaultLinkedPath({
+          defaultDate: DEFAULT_DETAILS.arrivalDate,
+        });
       });
-    });
-  });
+    }
+  );
 
   /** *************** Test 2 **************** */
-  test('@smoke Launch STDCM simulation with all stops', async ({
-    page,
-    consistSection,
-    originSection,
-    destinationSection,
-    viaSection,
-    stdcmPage,
-    stdcmSimulationResultPage,
-  }) => {
-    await test.step('Fill consist, origin and destination', async () => {
-      await consistSection.fillAndVerifyConsistDetails({
-        consistFields: CONSIST_DETAILS,
-        defaultMaxSpeed: DEFAULT_DETAILS.maxSpeed,
-        tractionEnginePrefilledValues: {
-          expectedTonnage: TRACTION_ENGINE_PREFILLED_VALUES.tonnage,
-          expectedLength: TRACTION_ENGINE_PREFILLED_VALUES.length,
-        },
-      });
-
-      await originSection.fillAndVerifyOriginDetails({
-        input: ORIGIN_DETAILS.input,
-        expectedCiValue: ORIGIN_DETAILS.suggestion,
-        suggestionText: CI_SUGGESTIONS.north[2],
-        expectedSuggestions: CI_SUGGESTIONS.north,
-        chValue: ORIGIN_DETAILS.chValue,
-        arrivalDate: ORIGIN_DETAILS.arrivalDate,
-        arrivalTime: ORIGIN_DETAILS.arrivalTime,
-        tolerance: ORIGIN_DETAILS.tolerance,
-        updatedChValue: ORIGIN_DETAILS.updatedChValue,
-        arrivalType: ORIGIN_DETAILS.arrivalType,
-      });
-
-      await destinationSection.fillAndVerifyDestinationDetails({
-        destinationDetails: {
-          ...DESTINATION_DETAILS,
-          expectedCiValue: CI_SUGGESTIONS.south[1],
-        },
-        southSuggestions: CI_SUGGESTIONS.south,
-        noScheduledPointMessage: STDCM_TRANSLATIONS.stdcmErrors.routeErrors.noScheduledPoint,
-      });
-    });
-
-    await test.step('Fill three vias and verify each', async () => {
-      for (const viaDetail of VIA_DETAILS) {
-        await viaSection.fillAndVerifyViaDetails({
-          ...viaDetail,
-          expectedChValue: DEFAULT_DETAILS.chValue,
-          stopTypes: VIA_STOP_TYPES,
-          stopTimes: VIA_STOP_TIMES,
-          suggestionTextBySearch: {
-            mid_west: VIA_SUGGESTIONS[0],
-            mid_east: VIA_SUGGESTIONS[1],
-            nS: VIA_SUGGESTIONS[2],
+  test(
+    'Launch STDCM simulation with all stops',
+    { tag: '@smoke' },
+    async ({
+      page,
+      consistSection,
+      originSection,
+      destinationSection,
+      viaSection,
+      stdcmPage,
+      stdcmSimulationResultPage,
+    }) => {
+      await test.step('Fill consist, origin and destination', async () => {
+        await consistSection.fillAndVerifyConsistDetails({
+          consistFields: CONSIST_DETAILS,
+          defaultMaxSpeed: DEFAULT_DETAILS.maxSpeed,
+          tractionEnginePrefilledValues: {
+            expectedTonnage: TRACTION_ENGINE_PREFILLED_VALUES.tonnage,
+            expectedLength: TRACTION_ENGINE_PREFILLED_VALUES.length,
           },
-          driverSwitchTooShortWarning:
-            STDCM_TRANSLATIONS.stdcmErrors.routeErrors.viaStopDurationDriverSwitchTooShort,
         });
-      }
-    });
 
-    await test.step('Launch simulation and verify results table', async () => {
-      await stdcmPage.verifyValidSimulationLaunch(
-        STDCM_TRANSLATIONS.simulation.results.status.completed
-      );
-      await stdcmSimulationResultPage.verifySimulationDetails({
-        ...SIMULATION_RESULTS_WITH_STOPS_DETAILS,
-        noOutputSimulationName: STDCM_TRANSLATIONS.simulation.results.simulationName.withoutOutputs,
-      });
-      await stdcmSimulationResultPage.verifyTableData(ALL_STOPS_TABLE_DATA_PATH);
-    });
+        await originSection.fillAndVerifyOriginDetails({
+          input: ORIGIN_DETAILS.input,
+          expectedCiValue: ORIGIN_DETAILS.suggestion,
+          suggestionText: CI_SUGGESTIONS.north[2],
+          expectedSuggestions: CI_SUGGESTIONS.north,
+          chValue: ORIGIN_DETAILS.chValue,
+          arrivalDate: ORIGIN_DETAILS.arrivalDate,
+          arrivalTime: ORIGIN_DETAILS.arrivalTime,
+          tolerance: ORIGIN_DETAILS.tolerance,
+          updatedChValue: ORIGIN_DETAILS.updatedChValue,
+          arrivalType: ORIGIN_DETAILS.arrivalType,
+        });
 
-    await test.step('Retain simulation and start new query without data', async () => {
-      await stdcmSimulationResultPage.retainSimulation();
-
-      const [newPage] = await Promise.all([
-        page.context().waitForEvent('page'),
-        stdcmSimulationResultPage.startNewQueryWithoutData(),
-      ]);
-
-      await newPage.bringToFront();
-      await newPage.waitForLoadState('domcontentloaded');
-
-      const {
-        consistSection: newConsistSection,
-        originSection: newOriginSection,
-        destinationSection: newDestinationSection,
-      } = createStdcmTab(newPage);
-
-      await newConsistSection.verifyDefaultConsistFields({
-        defaultSpeedLimitTag: DEFAULT_DETAILS.speedLimitTag,
+        await destinationSection.fillAndVerifyDestinationDetails({
+          destinationDetails: {
+            ...DESTINATION_DETAILS,
+            expectedCiValue: CI_SUGGESTIONS.south[1],
+          },
+          southSuggestions: CI_SUGGESTIONS.south,
+          noScheduledPointMessage: STDCM_TRANSLATIONS.stdcmErrors.routeErrors.noScheduledPoint,
+        });
       });
 
-      await newOriginSection.verifyDefaultOriginFields({
-        arrivalType: ORIGIN_DETAILS.arrivalType.default,
-        arrivalDate: DEFAULT_DETAILS.arrivalDate,
-        arrivalTime: DEFAULT_DETAILS.arrivalTime,
-        tolerance: DEFAULT_DETAILS.tolerance,
+      await test.step('Fill three vias and verify each', async () => {
+        for (const viaDetail of VIA_DETAILS) {
+          await viaSection.fillAndVerifyViaDetails({
+            ...viaDetail,
+            expectedChValue: DEFAULT_DETAILS.chValue,
+            stopTypes: VIA_STOP_TYPES,
+            stopTimes: VIA_STOP_TIMES,
+            suggestionTextBySearch: {
+              mid_west: VIA_SUGGESTIONS[0],
+              mid_east: VIA_SUGGESTIONS[1],
+              nS: VIA_SUGGESTIONS[2],
+            },
+            driverSwitchTooShortWarning:
+              STDCM_TRANSLATIONS.stdcmErrors.routeErrors.viaStopDurationDriverSwitchTooShort,
+          });
+        }
       });
 
-      await newDestinationSection.verifyDefaultDestinationFields(
-        DESTINATION_DETAILS.arrivalType.default
-      );
-    });
-  });
+      await test.step('Launch simulation and verify results table', async () => {
+        await stdcmPage.verifyValidSimulationLaunch(
+          STDCM_TRANSLATIONS.simulation.results.status.completed
+        );
+        await stdcmSimulationResultPage.verifySimulationDetails({
+          ...SIMULATION_RESULTS_WITH_STOPS_DETAILS,
+          noOutputSimulationName:
+            STDCM_TRANSLATIONS.simulation.results.simulationName.withoutOutputs,
+        });
+        await stdcmSimulationResultPage.verifyTableData(ALL_STOPS_TABLE_DATA_PATH);
+      });
+
+      await test.step('Retain simulation and start new query without data', async () => {
+        await stdcmSimulationResultPage.retainSimulation();
+
+        const [newPage] = await Promise.all([
+          page.context().waitForEvent('page'),
+          stdcmSimulationResultPage.startNewQueryWithoutData(),
+        ]);
+
+        await newPage.bringToFront();
+        await newPage.waitForLoadState('domcontentloaded');
+
+        const {
+          consistSection: newConsistSection,
+          originSection: newOriginSection,
+          destinationSection: newDestinationSection,
+        } = createStdcmTab(newPage);
+
+        await newConsistSection.verifyDefaultConsistFields({
+          defaultSpeedLimitTag: DEFAULT_DETAILS.speedLimitTag,
+        });
+
+        await newOriginSection.verifyDefaultOriginFields({
+          arrivalType: ORIGIN_DETAILS.arrivalType.default,
+          arrivalDate: DEFAULT_DETAILS.arrivalDate,
+          arrivalTime: DEFAULT_DETAILS.arrivalTime,
+          tolerance: DEFAULT_DETAILS.tolerance,
+        });
+
+        await newDestinationSection.verifyDefaultDestinationFields(
+          DESTINATION_DETAILS.arrivalType.default
+        );
+      });
+    }
+  );
 
   /** *************** Test 3 **************** */
   test('Launch simulation with and without capacity for towed rolling stock', async ({

--- a/front/tests/03-stdcm/002-stdcm-simulation-sheet.spec.ts
+++ b/front/tests/03-stdcm/002-stdcm-simulation-sheet.spec.ts
@@ -29,7 +29,7 @@ import { getInfra } from './../utils/api-utils';
 import { findFirstPdf, parsePdfText, verifySimulationContent } from './../utils/pdf-parser';
 import type { PdfSimulationContent } from './../utils/types';
 
-test.describe('@stdcm @stdcm-sheet', () => {
+test.describe('STDCM simulation sheet', { tag: ['@stdcm, @stdcm-sheet'] }, () => {
   test.describe.configure({ mode: 'serial' });
 
   let infra: Infra;
@@ -45,119 +45,126 @@ test.describe('@stdcm @stdcm-sheet', () => {
   });
 
   /** *************** Test 1 **************** */
-  test('@smoke Verify STDCM stops and simulation sheet', async ({
-    browserName,
-    context,
-    consistSection,
-    originSection,
-    destinationSection,
-    viaSection,
-    stdcmPage,
-    stdcmSimulationResultPage,
-  }, testInfo) => {
-    await test.step('Fill consist, origin, destination and via', async () => {
-      await consistSection.fillAndVerifyConsistDetails({
-        consistFields: CONSIST_DETAILS,
-        defaultMaxSpeed: DEFAULT_DETAILS.maxSpeed,
-        tractionEnginePrefilledValues: {
-          expectedTonnage: TRACTION_ENGINE_PREFILLED_VALUES.tonnage,
-          expectedLength: TRACTION_ENGINE_PREFILLED_VALUES.length,
-        },
+  test(
+    'Verify STDCM stops and simulation sheet',
+    { tag: '@smoke' },
+    async (
+      {
+        browserName,
+        context,
+        consistSection,
+        originSection,
+        destinationSection,
+        viaSection,
+        stdcmPage,
+        stdcmSimulationResultPage,
+      },
+      testInfo
+    ) => {
+      await test.step('Fill consist, origin, destination and via', async () => {
+        await consistSection.fillAndVerifyConsistDetails({
+          consistFields: CONSIST_DETAILS,
+          defaultMaxSpeed: DEFAULT_DETAILS.maxSpeed,
+          tractionEnginePrefilledValues: {
+            expectedTonnage: TRACTION_ENGINE_PREFILLED_VALUES.tonnage,
+            expectedLength: TRACTION_ENGINE_PREFILLED_VALUES.length,
+          },
+        });
+
+        await originSection.fillOriginDetailsLight({
+          originDetails: {
+            ...LIGHT_ORIGIN_DETAILS,
+            suggestionText: CI_SUGGESTIONS.north[2],
+          },
+          expectedSuggestions: CI_SUGGESTIONS.north,
+          expectedCiValue: CI_SUGGESTIONS.north[2],
+        });
+
+        await destinationSection.fillDestinationDetailsLight({
+          destinationDetails: {
+            ...LIGHT_DESTINATION_DETAILS,
+            expectedCiValue: CI_SUGGESTIONS.south[1],
+          },
+          southSuggestions: CI_SUGGESTIONS.south,
+          suggestionText: CI_SUGGESTIONS.south[1],
+        });
+
+        await viaSection.fillAndVerifyViaDetails({
+          viaNumber: 1,
+          ciSearchText: 'mid_west',
+          expectedChValue: DEFAULT_DETAILS.chValue,
+          stopTypes: VIA_STOP_TYPES,
+          stopTimes: VIA_STOP_TIMES,
+          suggestionTextBySearch: {
+            mid_west: VIA_SUGGESTIONS[0],
+            mid_east: VIA_SUGGESTIONS[1],
+            nS: VIA_SUGGESTIONS[2],
+          },
+          driverSwitchTooShortWarning:
+            STDCM_TRANSLATIONS.stdcmErrors.routeErrors.viaStopDurationDriverSwitchTooShort,
+        });
       });
 
-      await originSection.fillOriginDetailsLight({
-        originDetails: {
-          ...LIGHT_ORIGIN_DETAILS,
-          suggestionText: CI_SUGGESTIONS.north[2],
-        },
-        expectedSuggestions: CI_SUGGESTIONS.north,
-        expectedCiValue: CI_SUGGESTIONS.north[2],
+      await test.step('Verify input map markers (Chromium only)', async () => {
+        if (browserName === 'chromium') {
+          await stdcmPage.mapMarkerVisibility();
+        }
       });
 
-      await destinationSection.fillDestinationDetailsLight({
-        destinationDetails: {
-          ...LIGHT_DESTINATION_DETAILS,
-          expectedCiValue: CI_SUGGESTIONS.south[1],
-        },
-        southSuggestions: CI_SUGGESTIONS.south,
-        suggestionText: CI_SUGGESTIONS.south[1],
+      await test.step('Launch simulation', async () => {
+        await stdcmPage.verifyValidSimulationLaunch(
+          STDCM_TRANSLATIONS.simulation.results.status.completed
+        );
       });
 
-      await viaSection.fillAndVerifyViaDetails({
-        viaNumber: 1,
-        ciSearchText: 'mid_west',
-        expectedChValue: DEFAULT_DETAILS.chValue,
-        stopTypes: VIA_STOP_TYPES,
-        stopTimes: VIA_STOP_TIMES,
-        suggestionTextBySearch: {
-          mid_west: VIA_SUGGESTIONS[0],
-          mid_east: VIA_SUGGESTIONS[1],
-          nS: VIA_SUGGESTIONS[2],
-        },
-        driverSwitchTooShortWarning:
-          STDCM_TRANSLATIONS.stdcmErrors.routeErrors.viaStopDurationDriverSwitchTooShort,
-      });
-    });
-
-    await test.step('Verify input map markers (Chromium only)', async () => {
-      if (browserName === 'chromium') {
-        await stdcmPage.mapMarkerVisibility();
-      }
-    });
-
-    await test.step('Launch simulation', async () => {
-      await stdcmPage.verifyValidSimulationLaunch(
-        STDCM_TRANSLATIONS.simulation.results.status.completed
-      );
-    });
-
-    await test.step('Verify result map markers and tables', async () => {
-      if (browserName === 'chromium') {
-        await stdcmSimulationResultPage.mapMarkerResultVisibility();
-      }
-      await stdcmSimulationResultPage.verifyTableData(STDCM_WITHOUT_ALL_VIA_DATA_PATH);
-      await stdcmSimulationResultPage.displayAllOperationalPoints();
-      await stdcmSimulationResultPage.verifyTableData(STDCM_WITH_ALL_VIA_DATA_PATH);
-    });
-
-    await test.step('Retain & download simulation PDF', async () => {
-      await stdcmSimulationResultPage.retainSimulation();
-      downloadDir = testInfo.outputDir;
-      await stdcmSimulationResultPage.downloadSimulation(downloadDir);
-    });
-
-    await test.step('Start a new query and verify fields are reset', async () => {
-      const [newPage] = await Promise.all([
-        context.waitForEvent('page'),
-        stdcmSimulationResultPage.startNewQuery(),
-      ]);
-      await newPage.waitForLoadState();
-
-      const [newConsistSection, newOriginSection, newDestinationSection] = [
-        new ConsistSection(newPage),
-        new OriginSection(newPage),
-        new DestinationSection(newPage),
-      ];
-
-      await newConsistSection.verifyDefaultConsistFields({
-        defaultSpeedLimitTag: DEFAULT_DETAILS.speedLimitTag,
+      await test.step('Verify result map markers and tables', async () => {
+        if (browserName === 'chromium') {
+          await stdcmSimulationResultPage.mapMarkerResultVisibility();
+        }
+        await stdcmSimulationResultPage.verifyTableData(STDCM_WITHOUT_ALL_VIA_DATA_PATH);
+        await stdcmSimulationResultPage.displayAllOperationalPoints();
+        await stdcmSimulationResultPage.verifyTableData(STDCM_WITH_ALL_VIA_DATA_PATH);
       });
 
-      await newOriginSection.verifyDefaultOriginFields({
-        arrivalType: ORIGIN_DETAILS.arrivalType.default,
-        arrivalDate: DEFAULT_DETAILS.arrivalDate,
-        arrivalTime: DEFAULT_DETAILS.arrivalTime,
-        tolerance: DEFAULT_DETAILS.tolerance,
+      await test.step('Retain & download simulation PDF', async () => {
+        await stdcmSimulationResultPage.retainSimulation();
+        downloadDir = testInfo.outputDir;
+        await stdcmSimulationResultPage.downloadSimulation(downloadDir);
       });
 
-      await newDestinationSection.verifyDefaultDestinationFields(
-        DESTINATION_DETAILS.arrivalType.default
-      );
-    });
-  });
+      await test.step('Start a new query and verify fields are reset', async () => {
+        const [newPage] = await Promise.all([
+          context.waitForEvent('page'),
+          stdcmSimulationResultPage.startNewQuery(),
+        ]);
+        await newPage.waitForLoadState();
+
+        const [newConsistSection, newOriginSection, newDestinationSection] = [
+          new ConsistSection(newPage),
+          new OriginSection(newPage),
+          new DestinationSection(newPage),
+        ];
+
+        await newConsistSection.verifyDefaultConsistFields({
+          defaultSpeedLimitTag: DEFAULT_DETAILS.speedLimitTag,
+        });
+
+        await newOriginSection.verifyDefaultOriginFields({
+          arrivalType: ORIGIN_DETAILS.arrivalType.default,
+          arrivalDate: DEFAULT_DETAILS.arrivalDate,
+          arrivalTime: DEFAULT_DETAILS.arrivalTime,
+          tolerance: DEFAULT_DETAILS.tolerance,
+        });
+
+        await newDestinationSection.verifyDefaultDestinationFields(
+          DESTINATION_DETAILS.arrivalType.default
+        );
+      });
+    }
+  );
 
   /** *************** Test 2 *************** */
-  test('@smoke Verify simulation sheet content', async () => {
+  test('Verify simulation sheet content', { tag: '@smoke' }, async () => {
     const pdfFilePath = await test.step('Find the downloaded PDF', async () => {
       const filePath = findFirstPdf(downloadDir!);
       if (!filePath) {

--- a/front/tests/03-stdcm/003-stdcm-linked-train.spec.ts
+++ b/front/tests/03-stdcm/003-stdcm-linked-train.spec.ts
@@ -24,7 +24,7 @@ import test, { createStdcmTab } from './../page-object-fixture';
 import { waitForInfraStateToBeCached } from './../utils';
 import { getInfra, setTowedRollingStock } from './../utils/api-utils';
 
-test.describe('@stdcm @stdcm-linked-train', () => {
+test.describe('STDCM linked train simulation', { tag: ['@stdcm', '@stdcm-linked-train'] }, () => {
   let infra: Infra;
   let createdTowedRollingStock: TowedRollingStock;
   let towedConsistDetails: ConsistFields;

--- a/front/tests/03-stdcm/004-stdcm-missing-fields.spec.ts
+++ b/front/tests/03-stdcm/004-stdcm-missing-fields.spec.ts
@@ -24,127 +24,136 @@ import test from './../page-object-fixture';
 import { waitForInfraStateToBeCached } from './../utils';
 import { getInfra } from './../utils/api-utils';
 
-test.describe('@stdcm @stdcm-missing-fields', () => {
-  let infra: Infra;
+test.describe(
+  'STDCM missing fields and warning handling',
+  { tag: ['@stdcm', '@stdcm-missing-fields'] },
+  () => {
+    let infra: Infra;
 
-  test.beforeAll('Fetch infrastructure', async () => {
-    infra = await getInfra();
-  });
-
-  test.beforeEach('Navigate to the STDCM page', async ({ page }) => {
-    await page.goto(STDCM_URL);
-    await waitForInfraStateToBeCached(infra.id);
-  });
-
-  /** *************** Test 1 **************** */
-  test('Verify missing fields warnings when launching simulation', async ({
-    stdcmPage,
-    consistSection,
-    originSection,
-    destinationSection,
-    stdcmSimulationResultPage,
-  }) => {
-    await test.step('Launch simulation with all fields empty → expect all missing field warnings', async () => {
-      const allMissingLabels = getFieldsLabel(ALL_MISSING_FIELDS_KEY, STDCM_TRANSLATIONS);
-      await stdcmPage.verifyInvalidSimulationLaunch();
-      await stdcmPage.expectWarningBoxVisible();
-      await stdcmPage.expectWarningBoxContains(allMissingLabels);
+    test.beforeAll('Fetch infrastructure', async () => {
+      infra = await getInfra();
     });
 
-    await test.step('Fill origin and destination → expect partial missing field warnings', async () => {
-      await originSection.fillOriginDetailsLight({
-        originDetails: {
-          ...LIGHT_ORIGIN_DETAILS,
-          suggestionText: CI_SUGGESTIONS.north[2],
-        },
-        expectedSuggestions: CI_SUGGESTIONS.north,
-        expectedCiValue: CI_SUGGESTIONS.north[2],
-      });
-
-      await destinationSection.fillDestinationDetailsLight({
-        destinationDetails: {
-          ...LIGHT_DESTINATION_DETAILS,
-          expectedCiValue: CI_SUGGESTIONS.south[1],
-        },
-        southSuggestions: CI_SUGGESTIONS.south,
-        suggestionText: CI_SUGGESTIONS.south[1],
-      });
-
-      await stdcmPage.verifyInvalidSimulationLaunch();
-      await stdcmPage.expectWarningBoxVisible();
-
-      const partialMissingLabels = getFieldsLabel(PARTIAL_MISSING_FIELDS_KEYS, STDCM_TRANSLATIONS);
-      const nonMissingLabels = getFieldsLabel(REMOVED_MISSING_FIELDS_KEYS, STDCM_TRANSLATIONS);
-      await stdcmPage.expectWarningBoxContains(partialMissingLabels, nonMissingLabels);
+    test.beforeEach('Navigate to the STDCM page', async ({ page }) => {
+      await page.goto(STDCM_URL);
+      await waitForInfraStateToBeCached(infra.id);
     });
 
-    await test.step('Fill all mandatory fields → expect valid simulation', async () => {
-      await consistSection.fillAndVerifyConsistDetails({
-        consistFields: { tractionEngine: electricRollingStockName },
-        defaultMaxSpeed: DEFAULT_DETAILS.maxSpeed,
-        tractionEnginePrefilledValues: {
-          expectedTonnage: TRACTION_ENGINE_PREFILLED_VALUES.tonnage,
-          expectedLength: TRACTION_ENGINE_PREFILLED_VALUES.length,
-        },
+    /** *************** Test 1 **************** */
+    test('Verify missing fields warnings when launching simulation', async ({
+      stdcmPage,
+      consistSection,
+      originSection,
+      destinationSection,
+      stdcmSimulationResultPage,
+    }) => {
+      await test.step('Launch simulation with all fields empty → expect all missing field warnings', async () => {
+        const allMissingLabels = getFieldsLabel(ALL_MISSING_FIELDS_KEY, STDCM_TRANSLATIONS);
+        await stdcmPage.verifyInvalidSimulationLaunch();
+        await stdcmPage.expectWarningBoxVisible();
+        await stdcmPage.expectWarningBoxContains(allMissingLabels);
       });
 
-      await stdcmPage.verifyValidSimulationLaunch(
-        STDCM_TRANSLATIONS.simulation.results.status.completed
-      );
-      await stdcmPage.expectWarningBoxHidden();
-      await stdcmSimulationResultPage.verifySimulationDetails({
-        ...SIMULATION_RESULTS_DETAILS,
-        noOutputSimulationName: STDCM_TRANSLATIONS.simulation.results.simulationName.withoutOutputs,
-      });
-    });
+      await test.step('Fill origin and destination → expect partial missing field warnings', async () => {
+        await originSection.fillOriginDetailsLight({
+          originDetails: {
+            ...LIGHT_ORIGIN_DETAILS,
+            suggestionText: CI_SUGGESTIONS.north[2],
+          },
+          expectedSuggestions: CI_SUGGESTIONS.north,
+          expectedCiValue: CI_SUGGESTIONS.north[2],
+        });
 
-    await test.step('Enter invalid tonnage, length and max speed → expect invalid field warnings', async () => {
-      await consistSection.setTonnage(INVALID_CONSIST_DATA.invalidTonnage);
-      await consistSection.setLength(INVALID_CONSIST_DATA.invalidLength);
-      await consistSection.setMaxSpeed(INVALID_CONSIST_DATA.invalidMaxSpeed);
-      await stdcmPage.verifyInvalidSimulationLaunch();
-      await stdcmPage.expectWarningBoxVisible();
-      await stdcmPage.expectWarningBoxContains([
-        STDCM_TRANSLATIONS.stdcmErrors.invalidFields.totalMass,
-        STDCM_TRANSLATIONS.stdcmErrors.invalidFields.totalLength,
-        STDCM_TRANSLATIONS.stdcmErrors.invalidFields.maxSpeed,
-      ]);
-    });
+        await destinationSection.fillDestinationDetailsLight({
+          destinationDetails: {
+            ...LIGHT_DESTINATION_DETAILS,
+            expectedCiValue: CI_SUGGESTIONS.south[1],
+          },
+          southSuggestions: CI_SUGGESTIONS.south,
+          suggestionText: CI_SUGGESTIONS.south[1],
+        });
 
-    await test.step('Fix tonnage, clear length and destination → expect missing + invalid warnings', async () => {
-      await consistSection.setTonnage(VALID_CONSIST_DATA.validTonnage);
-      await consistSection.clearLength();
-      await destinationSection.clearDestination();
-      await stdcmPage.verifyInvalidSimulationLaunch();
-      await stdcmPage.expectWarningBoxVisible();
-      await stdcmPage.expectWarningBoxContains([
-        STDCM_TRANSLATIONS.stdcmErrors.missingFields.destination,
-        STDCM_TRANSLATIONS.stdcmErrors.missingFields.totalLength,
-        STDCM_TRANSLATIONS.stdcmErrors.invalidFields.maxSpeed,
-      ]);
-    });
+        await stdcmPage.verifyInvalidSimulationLaunch();
+        await stdcmPage.expectWarningBoxVisible();
 
-    await test.step('Fill all fields with valid values → expect valid simulation', async () => {
-      await consistSection.setLength(VALID_CONSIST_DATA.validLength);
-      await consistSection.setMaxSpeed(VALID_CONSIST_DATA.validMaxSpeed);
-
-      await destinationSection.fillDestinationDetailsLight({
-        destinationDetails: {
-          ...LIGHT_DESTINATION_DETAILS,
-          expectedCiValue: CI_SUGGESTIONS.south[1],
-        },
-        southSuggestions: CI_SUGGESTIONS.south,
-        suggestionText: CI_SUGGESTIONS.south[1],
+        const partialMissingLabels = getFieldsLabel(
+          PARTIAL_MISSING_FIELDS_KEYS,
+          STDCM_TRANSLATIONS
+        );
+        const nonMissingLabels = getFieldsLabel(REMOVED_MISSING_FIELDS_KEYS, STDCM_TRANSLATIONS);
+        await stdcmPage.expectWarningBoxContains(partialMissingLabels, nonMissingLabels);
       });
 
-      await stdcmPage.verifyValidSimulationLaunch(
-        STDCM_TRANSLATIONS.simulation.results.status.completed
-      );
-      await stdcmPage.expectWarningBoxHidden();
-      await stdcmSimulationResultPage.verifySimulationDetails({
-        ...MISSING_FIELDS_SIMULATION_RESULTS_DETAILS,
-        noOutputSimulationName: STDCM_TRANSLATIONS.simulation.results.simulationName.withoutOutputs,
+      await test.step('Fill all mandatory fields → expect valid simulation', async () => {
+        await consistSection.fillAndVerifyConsistDetails({
+          consistFields: { tractionEngine: electricRollingStockName },
+          defaultMaxSpeed: DEFAULT_DETAILS.maxSpeed,
+          tractionEnginePrefilledValues: {
+            expectedTonnage: TRACTION_ENGINE_PREFILLED_VALUES.tonnage,
+            expectedLength: TRACTION_ENGINE_PREFILLED_VALUES.length,
+          },
+        });
+
+        await stdcmPage.verifyValidSimulationLaunch(
+          STDCM_TRANSLATIONS.simulation.results.status.completed
+        );
+        await stdcmPage.expectWarningBoxHidden();
+        await stdcmSimulationResultPage.verifySimulationDetails({
+          ...SIMULATION_RESULTS_DETAILS,
+          noOutputSimulationName:
+            STDCM_TRANSLATIONS.simulation.results.simulationName.withoutOutputs,
+        });
+      });
+
+      await test.step('Enter invalid tonnage, length and max speed → expect invalid field warnings', async () => {
+        await consistSection.setTonnage(INVALID_CONSIST_DATA.invalidTonnage);
+        await consistSection.setLength(INVALID_CONSIST_DATA.invalidLength);
+        await consistSection.setMaxSpeed(INVALID_CONSIST_DATA.invalidMaxSpeed);
+        await stdcmPage.verifyInvalidSimulationLaunch();
+        await stdcmPage.expectWarningBoxVisible();
+        await stdcmPage.expectWarningBoxContains([
+          STDCM_TRANSLATIONS.stdcmErrors.invalidFields.totalMass,
+          STDCM_TRANSLATIONS.stdcmErrors.invalidFields.totalLength,
+          STDCM_TRANSLATIONS.stdcmErrors.invalidFields.maxSpeed,
+        ]);
+      });
+
+      await test.step('Fix tonnage, clear length and destination → expect missing + invalid warnings', async () => {
+        await consistSection.setTonnage(VALID_CONSIST_DATA.validTonnage);
+        await consistSection.clearLength();
+        await destinationSection.clearDestination();
+        await stdcmPage.verifyInvalidSimulationLaunch();
+        await stdcmPage.expectWarningBoxVisible();
+        await stdcmPage.expectWarningBoxContains([
+          STDCM_TRANSLATIONS.stdcmErrors.missingFields.destination,
+          STDCM_TRANSLATIONS.stdcmErrors.missingFields.totalLength,
+          STDCM_TRANSLATIONS.stdcmErrors.invalidFields.maxSpeed,
+        ]);
+      });
+
+      await test.step('Fill all fields with valid values → expect valid simulation', async () => {
+        await consistSection.setLength(VALID_CONSIST_DATA.validLength);
+        await consistSection.setMaxSpeed(VALID_CONSIST_DATA.validMaxSpeed);
+
+        await destinationSection.fillDestinationDetailsLight({
+          destinationDetails: {
+            ...LIGHT_DESTINATION_DETAILS,
+            expectedCiValue: CI_SUGGESTIONS.south[1],
+          },
+          southSuggestions: CI_SUGGESTIONS.south,
+          suggestionText: CI_SUGGESTIONS.south[1],
+        });
+
+        await stdcmPage.verifyValidSimulationLaunch(
+          STDCM_TRANSLATIONS.simulation.results.status.completed
+        );
+        await stdcmPage.expectWarningBoxHidden();
+        await stdcmSimulationResultPage.verifySimulationDetails({
+          ...MISSING_FIELDS_SIMULATION_RESULTS_DETAILS,
+          noOutputSimulationName:
+            STDCM_TRANSLATIONS.simulation.results.simulationName.withoutOutputs,
+        });
       });
     });
-  });
-});
+  }
+);

--- a/front/tests/03-stdcm/005-stdcm-feedback-mail.spec.ts
+++ b/front/tests/03-stdcm/005-stdcm-feedback-mail.spec.ts
@@ -16,7 +16,7 @@ import test from './../page-object-fixture';
 import { waitForInfraStateToBeCached } from './../utils';
 import { getInfra } from './../utils/api-utils';
 
-test.describe('@stdcm @stdcm-feedback', () => {
+test.describe('STDCM mail feedback ', { tag: ['@stdcm', '@stdcm-feedback'] }, () => {
   let infra: Infra;
 
   test.beforeAll('Fetch infrastructure', async () => {

--- a/front/tests/04-rolling-stock-editor/001-rolling-stock-editor.spec.ts
+++ b/front/tests/04-rolling-stock-editor/001-rolling-stock-editor.spec.ts
@@ -15,7 +15,7 @@ const rollingstockDetails: RollingStockDetails = readJsonFile(
   './tests/assets/rolling-stock/rolling-stock-details.json'
 );
 
-test.describe('@rs-editor', () => {
+test.describe('Rolling stock editor management', { tag: '@rs-editor' }, () => {
   const createdRollingStocks: string[] = [];
 
   let uniqueRollingStockName: string;
@@ -48,89 +48,93 @@ test.describe('@rs-editor', () => {
   });
 
   /** *************** Test 1 **************** */
-  test('@smoke Create a new rolling stock', async ({ page, rollingStockEditorPage }) => {
-    createdRollingStocks.push(uniqueRollingStockName);
+  test(
+    'Create a new rolling stock',
+    { tag: '@smoke' },
+    async ({ page, rollingStockEditorPage }) => {
+      createdRollingStocks.push(uniqueRollingStockName);
 
-    await test.step('Open creation form', async () => {
-      await rollingStockEditorPage.openNewRollingStockForm();
-    });
+      await test.step('Open creation form', async () => {
+        await rollingStockEditorPage.openNewRollingStockForm();
+      });
 
-    await test.step('Fill base details and loading gauge', async () => {
-      for (const input of rollingstockDetails.inputs) {
-        const value = input.id === 'name' ? uniqueRollingStockName : input.value;
-        await fillAndCheckInputById(page, input.id, value, input.isNumeric);
-      }
-      await rollingStockEditorPage.selectLoadingGauge('GA');
-    });
+      await test.step('Fill base details and loading gauge', async () => {
+        for (const input of rollingstockDetails.inputs) {
+          const value = input.id === 'name' ? uniqueRollingStockName : input.value;
+          await fillAndCheckInputById(page, input.id, value, input.isNumeric);
+        }
+        await rollingStockEditorPage.selectLoadingGauge('GA');
+      });
 
-    await test.step('Select categories (primary + other)', async () => {
-      await rollingStockEditorPage.selectPrimaryCategory('WORK_TRAIN');
-      await rollingStockEditorPage.selectPrimaryCategory('NIGHT_TRAIN');
-      await rollingStockEditorPage.uncheckCategoryCheckbox('WORK_TRAIN');
-      await rollingStockEditorPage.selectPrimaryCategory('WORK_TRAIN');
-      await rollingStockEditorPage.selectPrimaryCategory('NIGHT_TRAIN');
-      await rollingStockEditorPage.checkCategoryCheckbox('FREIGHT_TRAIN');
-      await rollingStockEditorPage.checkCategoryCheckbox('FAST_FREIGHT_TRAIN');
-      await rollingStockEditorPage.uncheckCategoryCheckbox('FAST_FREIGHT_TRAIN');
-    });
+      await test.step('Select categories (primary + other)', async () => {
+        await rollingStockEditorPage.selectPrimaryCategory('WORK_TRAIN');
+        await rollingStockEditorPage.selectPrimaryCategory('NIGHT_TRAIN');
+        await rollingStockEditorPage.uncheckCategoryCheckbox('WORK_TRAIN');
+        await rollingStockEditorPage.selectPrimaryCategory('WORK_TRAIN');
+        await rollingStockEditorPage.selectPrimaryCategory('NIGHT_TRAIN');
+        await rollingStockEditorPage.checkCategoryCheckbox('FREIGHT_TRAIN');
+        await rollingStockEditorPage.checkCategoryCheckbox('FAST_FREIGHT_TRAIN');
+        await rollingStockEditorPage.uncheckCategoryCheckbox('FAST_FREIGHT_TRAIN');
+      });
 
-    await test.step('Submit initial form and handle warnings', async () => {
-      await rollingStockEditorPage.submitRollingstock();
-      await expect(rollingStockEditorPage.toastContainer).toBeVisible();
-    });
+      await test.step('Submit initial form and handle warnings', async () => {
+        await rollingStockEditorPage.submitRollingstock();
+        await expect(rollingStockEditorPage.toastContainer).toBeVisible();
+      });
 
-    await test.step('Fill speed effort curves (Not specified + C1)', async () => {
-      await rollingStockEditorPage.fillSpeedEffortCurves(
-        rollingstockDetails.speedEffortData,
-        false,
-        '',
-        '1500V'
-      );
-      await rollingStockEditorPage.fillSpeedEffortCurves(
-        rollingstockDetails.speedEffortDataC1,
-        true,
-        'C1 ',
-        '1500V'
-      );
-    });
+      await test.step('Fill speed effort curves (Not specified + C1)', async () => {
+        await rollingStockEditorPage.fillSpeedEffortCurves(
+          rollingstockDetails.speedEffortData,
+          false,
+          '',
+          '1500V'
+        );
+        await rollingStockEditorPage.fillSpeedEffortCurves(
+          rollingstockDetails.speedEffortDataC1,
+          true,
+          'C1 ',
+          '1500V'
+        );
+      });
 
-    await test.step('Fill additional details', async () => {
-      await rollingStockEditorPage.fillAdditionalDetails(rollingstockDetails.additionalDetails);
-    });
+      await test.step('Fill additional details', async () => {
+        await rollingStockEditorPage.fillAdditionalDetails(rollingstockDetails.additionalDetails);
+      });
 
-    await test.step('Submit and confirm rolling stock creation', async () => {
-      await rollingStockEditorPage.confirmRollingStockCreation();
-      expect(
-        rollingStockEditorPage.page.getByTestId(`rollingstock-${uniqueRollingStockName}`)
-      ).toBeDefined();
-    });
+      await test.step('Submit and confirm rolling stock creation', async () => {
+        await rollingStockEditorPage.confirmRollingStockCreation();
+        expect(
+          rollingStockEditorPage.page.getByTestId(`rollingstock-${uniqueRollingStockName}`)
+        ).toBeDefined();
+      });
 
-    await test.step('Search and verify rolling stock details', async () => {
-      await rollingStockEditorPage.searchRollingStock(uniqueRollingStockName);
-      await rollingStockEditorPage.verifyRollingStockDetailsTable(
-        rollingstockDetails.expectedValues
-      );
-      await rollingStockEditorPage.editRollingStock(uniqueRollingStockName);
-      for (const input of rollingstockDetails.inputs) {
-        const value = input.id === 'name' ? uniqueRollingStockName : input.value;
-        await verifyAndCheckInputById(page, input.id, value, input.isNumeric);
-      }
-    });
+      await test.step('Search and verify rolling stock details', async () => {
+        await rollingStockEditorPage.searchRollingStock(uniqueRollingStockName);
+        await rollingStockEditorPage.verifyRollingStockDetailsTable(
+          rollingstockDetails.expectedValues
+        );
+        await rollingStockEditorPage.editRollingStock(uniqueRollingStockName);
+        for (const input of rollingstockDetails.inputs) {
+          const value = input.id === 'name' ? uniqueRollingStockName : input.value;
+          await verifyAndCheckInputById(page, input.id, value, input.isNumeric);
+        }
+      });
 
-    await test.step('Verify speed effort curves values', async () => {
-      await rollingStockEditorPage.openSpeedEffortCurves();
-      await rollingStockEditorPage.verifySpeedEffortCurves(
-        rollingstockDetails.speedEffortData,
-        false,
-        'C1'
-      );
-      await rollingStockEditorPage.verifySpeedEffortCurves(
-        rollingstockDetails.speedEffortDataC1,
-        true,
-        'C1'
-      );
-    });
-  });
+      await test.step('Verify speed effort curves values', async () => {
+        await rollingStockEditorPage.openSpeedEffortCurves();
+        await rollingStockEditorPage.verifySpeedEffortCurves(
+          rollingstockDetails.speedEffortData,
+          false,
+          'C1'
+        );
+        await rollingStockEditorPage.verifySpeedEffortCurves(
+          rollingstockDetails.speedEffortDataC1,
+          true,
+          'C1'
+        );
+      });
+    }
+  );
 
   /** *************** Test 2 **************** */
   test('Duplicate and modify a rolling stock', async ({ page, rollingStockEditorPage }) => {

--- a/front/tests/04-rolling-stock-editor/002-rolling-stock-filter.spec.ts
+++ b/front/tests/04-rolling-stock-editor/002-rolling-stock-filter.spec.ts
@@ -3,7 +3,7 @@ import { expect } from '@playwright/test';
 import { dualModeRollingStockName } from './../assets/constants/project-const';
 import test from './../page-object-fixture';
 
-test.describe('@rs-editor @filter', () => {
+test.describe('Rolling stock editor filter', { tag: ['@rs-editor', '@filter'] }, () => {
   test.beforeEach('Navigate to editor page', async ({ rollingStockEditorPage }) => {
     await rollingStockEditorPage.navigateToRollingStockPage();
   });

--- a/front/tests/README.md
+++ b/front/tests/README.md
@@ -182,7 +182,7 @@ The `@smoke` tag should be used for:
 ### Example
 
 ```ts
-test('@smoke create a new study', async ({ page }) => {
+test('Create a new study', { tag: '@smoke' }, async ({ page }) => {
   ...
 });
 ```
@@ -190,7 +190,7 @@ test('@smoke create a new study', async ({ page }) => {
 ### Run only smoke tests
 
 ```bash
-npx playwright test -g "@smoke"
+npx playwright test -g @smoke
 ```
 
 ---


### PR DESCRIPTION
The `@` symbol was tagging GitHub users in the summary report (thankfully without triggering notifications). Using the [tag annotation object](https://playwright.dev/docs/test-annotations#tag-tests) instead will fix this while still allowing us to filter tests by tag

Current : <img width="1039" height="399" alt="image" src="https://github.com/user-attachments/assets/8d04910e-f5c8-45dc-9dde-e9c87108c114" />

With this PR : 

<img width="967" height="451" alt="image" src="https://github.com/user-attachments/assets/70957d3c-5437-46ec-971b-2e040d27e51d" />
