### PR TITLE
front: stdcm: hide gesico button in case of consist change

### DIFF
--- a/front/public/locales/en/stdcm.json
+++ b/front/public/locales/en/stdcm.json
@@ -204,7 +204,8 @@
         "errorMessage": "We are sorry that we could not process your request. The LMR team has been notified and will be aware of the situation as soon as possible.",
         "failed": "A technical issue has occurred"
       },
-      "transferSheetToRailManager": "Send to GESICO"
+      "transferSheetToRailManager": "Send to GESICO",
+      "transferSheetToRailManagerDisabledForConsistChange": "Send to GESICO with consist changes will be available in a next version"
     },
     "stopCalculation": "Stop"
   },

--- a/front/public/locales/fr/stdcm.json
+++ b/front/public/locales/fr/stdcm.json
@@ -204,7 +204,8 @@
         "errorMessage": "Nous sommes désolés de ne pas avoir pu traiter votre demande. L’équipe LMR a été notifiée et prendra connaissance de la situation dès que possible.",
         "failed": "Un problème technique est survenu"
       },
-      "transferSheetToRailManager": "Transmettre à GESICO"
+      "transferSheetToRailManager": "Transmettre à GESICO",
+      "transferSheetToRailManagerDisabledForConsistChange": "L'envoi à GESICO avec des changements de convoi sera disponible dans une prochaine version !"
     },
     "stopCalculation": "Arrêter"
   },

--- a/front/public/overrides/README.md
+++ b/front/public/overrides/README.md
@@ -1,6 +1,6 @@
 # Overrides
 
-In order to configure the app, you can provide a json `overrides.json` file located in [`front/public/locales/overrides/`](.).
+In order to configure the app, you can provide a json `overrides.json` file located in [`front/public/overrides/`](.).
 
 This contains both settings aimed at deployment in production, such as custom module names and logos, as well as generally useful settings even when developing locally, such as the railway manager interface url.
 

--- a/front/src/applications/stdcm/components/StdcmResults/StdcmResults.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/StdcmResults.tsx
@@ -126,6 +126,11 @@ const StdcmResults = ({
     return extractMarkersInfo(outputs.results.simulationPathSteps);
   }, [hasSimulationResults, outputs]);
 
+  const hasConsistChange = useMemo(() => {
+    if (!hasSimulationResults) return false;
+    return outputs.results.simulationPathSteps.some((p) => p.isVia && p.consistChange);
+  }, [hasSimulationResults, outputs]);
+
   const [similarTrains, setSimilarTrains] = useState<SimilarTrainWithSecondaryCode[]>([]);
   const [areSegmentsLoading, setAreSegmentsLoading] = useState(true);
 
@@ -348,6 +353,12 @@ const StdcmResults = ({
                         (!isRailwayRequestSuccessful ? (
                           <Button
                             label={t('transferSheetToRailManager')}
+                            title={
+                              hasConsistChange
+                                ? t('transferSheetToRailManagerDisabledForConsistChange')
+                                : undefined
+                            }
+                            isDisabled={hasConsistChange}
                             onClick={() =>
                               openModal(
                                 <SendToRailwayManagerModal


### PR DESCRIPTION
Fix #15260

Testing this feature is not so easy. You need to enable Gesico by adding the json file `public/overrides/overrides.json`, with a content similar to this :
```
{   "railway_manager_interface_url": "http://XXX/"  }
```
I don't know the url to use here.

Moreover, on STDCM in debug mode, I have some performances issues with the component `StdcmDebugResults`

> [!NOTE] 
> I did a commit to fix the `front/public/overrides/README.md` content (the folder where to place the file).