### PR TITLE
core: avoid simulation step with zero distance and non zero speed diff

### DIFF
--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/overlays/EnvelopeAcceleration.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/overlays/EnvelopeAcceleration.java
@@ -1,5 +1,6 @@
 package fr.sncf.osrd.envelope_sim.overlays;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import fr.sncf.osrd.envelope.part.InteractiveEnvelopePartConsumer;
 import fr.sncf.osrd.envelope_sim.Action;
 import fr.sncf.osrd.envelope_sim.EnvelopeSimContext;
@@ -9,6 +10,7 @@ import fr.sncf.osrd.reporting.exceptions.OSRDError;
 
 public class EnvelopeAcceleration {
     /** Accelerate, storing the resulting steps into consumer */
+    @SuppressFBWarnings({"FE_FLOATING_POINT_EQUALITY"})
     public static void accelerate(
             EnvelopeSimContext context,
             double startPosition,
@@ -23,6 +25,11 @@ public class EnvelopeAcceleration {
             var step = TrainPhysicsIntegrator.step(context, position, speed, Action.ACCELERATE, direction);
             position += step.positionDelta;
             speed = step.endSpeed;
+            if (step.positionDelta == 0.0 && step.startSpeed != step.endSpeed) {
+                // This case causes failed assertions in `consumer.addStep`, we need to throw earlier than in the
+                // generic positionDelta == 0 case. When the speed delta is 0, we may break normally before throwing.
+                throw new OSRDError(ErrorType.ImpossibleSimulationError);
+            }
             if (!consumer.addStep(position, speed, step.timeDelta)) break;
             if (step.positionDelta == 0.0) throw new OSRDError(ErrorType.ImpossibleSimulationError);
         }


### PR DESCRIPTION
Fix https://github.com/OpenRailAssociation/osrd/issues/16001 (I think)

Another bug identified through fuzzer. I do not like floating point.

I tried to add a unit case but couldn't reproduce the exact same behavior without copying a lot of data. The comment describes what happened and how it's avoided. 