### PR TITLE
nix: add playwright browsers

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,9 +26,6 @@
         };
 
         fixedNode = pkgs.nodejs_24;
-        fixedNodePackages = pkgs.nodePackages.override {
-          nodejs = fixedNode;
-        };
 
         rustVer = fenix.packages.${system}.stable;
         rustChan = rustVer.withComponents [

--- a/flake.nix
+++ b/flake.nix
@@ -54,6 +54,8 @@
             openssl
             pkg-config
             postgresql
+            # libs for playwright (see https://wiki.nixos.org/wiki/Playwright)
+            playwright-driver.browsers
 
             # Tools & Libs
             diesel-cli
@@ -88,6 +90,12 @@
           ];
 
           RUSTFLAGS = if stdenv.isDarwin then "" else "-C link-arg=-fuse-ld=mold";
+
+          shellHook = ''
+            export PLAYWRIGHT_BROWSERS_PATH=${pkgs.playwright-driver.browsers}
+            export PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=true
+          '';
+
         };
       }
     );

--- a/front/tests/README.md
+++ b/front/tests/README.md
@@ -43,6 +43,8 @@ npm install
 npx playwright install --with-deps
 ```
 
+ℹ️ If you use nix and the `flake.nix` of the current repository, you won’t need to `npm playwright install`.
+
 ## Run E2E tests
 
 ```bash
@@ -306,7 +308,7 @@ Run tests on a specific browser with custom worker and retry settings:
 npx playwright test --project=chromium --retries=1 --workers=2
 ```
 
-ℹ️ All commands above also work when running tests inside the Playwright container by replacing  
+ℹ️ All commands above also work when running tests inside the Playwright container by replacing
  `npx playwright test` with `./scripts/run-front-playwright-container.sh`.
 
 You may also want to explore [Playwright documentation](https://playwright.dev/docs/intro) for more

--- a/front/tests/README.md
+++ b/front/tests/README.md
@@ -69,7 +69,7 @@ Start the Playwright container only:
 and E2E tests, but beware of timeouts):
 
 ```bash
-./osrd-compose playwright dev-front up playwright
+./osrd-compose playwright up playwright
 ```
 
 Run tests:


### PR DESCRIPTION
Instead of launching everything inside docker, it’s now possible to launch directly on your machine, without the additional docker layer.

Probably @Yohh would be a nice reviewer of this PR as both a maintainer of e2e and a user of nix.