### PR TITLE
Fix crash when editing a train with unmatched path steps

### DIFF
--- a/front/src/modules/pathfinding/utils.ts
+++ b/front/src/modules/pathfinding/utils.ts
@@ -155,10 +155,7 @@ export const upsertPathStepsInOPs = (
       }
     } else {
       const index = updatedOPs.findIndex(
-        (op) =>
-          matchPathStepAndOp(step.location, op) &&
-          op.kp === step.kp &&
-          step.positionOnPath === op.positionOnPath
+        (op) => matchPathStepAndOp(step.location, op) && step.positionOnPath === op.positionOnPath
       );
       if (index < 0) {
         throw new Error(`Could not find path step "${step.id}" in OP list`);


### PR DESCRIPTION
Closes #16084
