### PR TITLE
front: use local state instead of API call in useSelectedTimetableItem

### DIFF
--- a/front/src/applications/operationalStudies/hooks/useEtcsBrakingCurves.ts
+++ b/front/src/applications/operationalStudies/hooks/useEtcsBrakingCurves.ts
@@ -20,6 +20,7 @@ import {
   isPacedTrain,
 } from 'modules/timetableItem/helpers/pacedTrain';
 import useSelectedTimetableItem from 'modules/timetableItem/hooks/useSelectedTimetableItem';
+import type { TimetableItem } from 'reducers/osrdconf/types';
 import { getSelectedTrainId } from 'reducers/simulationResults/selectors';
 import { isOccurrenceId, isPacedTrainId } from 'utils/trainId';
 
@@ -52,7 +53,8 @@ const formatEtcsCurves = (etcsBrakingCurves: CoreEtcsBrakingCurvesResponse): Etc
 
 const useEtcsBrakingCurves = (
   isEtcs: boolean,
-  simulation: SimulationResponseSuccess | undefined
+  simulation: SimulationResponseSuccess | undefined,
+  timetableItems: TimetableItem[] | undefined
 ): {
   etcsBrakingCurves: EtcsBrakingCurves | undefined;
   fetchEtcsBrakingCurves: (() => Promise<void>) | undefined;
@@ -62,7 +64,7 @@ const useEtcsBrakingCurves = (
 
   const { infraId, electricalProfileSetId } = useScenarioContext();
   const selectedTrainId = useSelector(getSelectedTrainId);
-  const timetableItem = useSelectedTimetableItem();
+  const timetableItem = useSelectedTimetableItem(timetableItems);
   const exception = useMemo(() => {
     if (
       !selectedTrainId ||

--- a/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
+++ b/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
@@ -13,7 +13,7 @@ import {
   getOccurrenceTrainName,
 } from 'modules/timetableItem/helpers/pacedTrain';
 import useSelectedTimetableItem from 'modules/timetableItem/hooks/useSelectedTimetableItem';
-import type { Train } from 'reducers/osrdconf/types';
+import type { TimetableItem, Train } from 'reducers/osrdconf/types';
 import { getSelectedTrainId } from 'reducers/simulationResults/selectors';
 import { Duration } from 'utils/duration';
 import {
@@ -29,7 +29,9 @@ import { useScenarioContext } from './useScenarioContext';
 /**
  * Prepare data to be used in simulation results
  */
-const useSimulationResults = (): {
+const useSimulationResults = (
+  timetableItems: TimetableItem[] | undefined
+): {
   results: SimulationResults | undefined;
   isSimulationDataLoading: boolean;
 } => {
@@ -38,7 +40,7 @@ const useSimulationResults = (): {
   const { infraId, electricalProfileSetId } = useScenarioContext();
   const selectedTrainId = useSelector(getSelectedTrainId);
 
-  const timetableItem = useSelectedTimetableItem();
+  const timetableItem = useSelectedTimetableItem(timetableItems);
 
   const train: Train | undefined = useMemo(() => {
     if (!selectedTrainId || !timetableItem) return undefined;

--- a/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
@@ -221,6 +221,7 @@ const ScenarioContent = ({ activeBoards }: ScenarioContentProps) => {
                 projectionData={projectionData}
                 conflicts={conflicts}
                 timetableItemsWithDetails={timetableItemsWithDetails}
+                timetableItems={timetableItems ?? []}
                 activeBoards={activeBoards}
                 updateTrainDepartureTime={updateTrainDepartureTimeWithNge}
                 upsertTimetableItems={upsertTimetableItemsWithNge}

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
@@ -52,6 +52,7 @@ type SimulationResultsProps = {
   scenarioData: { name: string; infraName: string };
   projectionData: ProjectionData | undefined;
   timetableItemsWithDetails: TimetableItemWithDetails[];
+  timetableItems: TimetableItem[];
   conflicts?: Conflict[];
   activeBoards: Set<Board>;
   updateTrainDepartureTime: (trainId: number, newDepartureTime: Date) => Promise<void>;
@@ -62,6 +63,7 @@ const SimulationResults = ({
   scenarioData,
   projectionData,
   timetableItemsWithDetails,
+  timetableItems,
   conflicts = [],
   activeBoards,
   updateTrainDepartureTime,
@@ -72,7 +74,8 @@ const SimulationResults = ({
   const { infraId, timetableId } = useScenarioContext();
   const useNewTimesStopsTable = useSelector(getUseNewTimesStopsTable);
 
-  const { results: simulationResults, isSimulationDataLoading } = useSimulationResults();
+  const { results: simulationResults, isSimulationDataLoading } =
+    useSimulationResults(timetableItems);
   const selectedTrainId = simulationResults?.train.id;
 
   const displayOnlyPathSteps = useSelector(getDisplayOnlyPathSteps);
@@ -171,7 +174,8 @@ const SimulationResults = ({
 
   const { etcsBrakingCurves, fetchEtcsBrakingCurves } = useEtcsBrakingCurves(
     isEtcs,
-    simulationResults?.isValid ? simulationResults.simulation : undefined
+    simulationResults?.isValid ? simulationResults.simulation : undefined,
+    timetableItems
   );
 
   if (!simulationResults && !projectionData) {

--- a/front/src/modules/timetableItem/hooks/useSelectedTimetableItem.tsx
+++ b/front/src/modules/timetableItem/hooks/useSelectedTimetableItem.tsx
@@ -1,7 +1,7 @@
-import { skipToken } from '@reduxjs/toolkit/query';
+import { useMemo } from 'react';
+
 import { useSelector } from 'react-redux';
 
-import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import type { TimetableItem, TrainId } from 'reducers/osrdconf/types';
 import { getSelectedTrainId } from 'reducers/simulationResults/selectors';
 import {
@@ -17,20 +17,17 @@ const extractTimetableItemId = (trainId?: TrainId) => {
   );
 };
 
-const useSelectedTimetableItem = (): TimetableItem | undefined => {
+const useSelectedTimetableItem = (
+  timetableItems: TimetableItem[] | undefined
+): TimetableItem | undefined => {
   const trainId = useSelector(getSelectedTrainId);
 
   const timetableItemId = extractTimetableItemId(trainId);
 
-  const { currentData: timetableItem } = osrdEditoastApi.endpoints.getTimetableItemById.useQuery(
-    timetableItemId
-      ? {
-          id: timetableItemId,
-        }
-      : skipToken
+  return useMemo(
+    () => timetableItems?.find((item) => item.id === timetableItemId),
+    [timetableItems, timetableItemId]
   );
-
-  return timetableItem;
 };
 
 export default useSelectedTimetableItem;


### PR DESCRIPTION
Replace getTimetableItemById API call with a direct lookup from timetableItems (useScenarioData), which includes exceptions data

(fix white screen: 
<img width="752" height="287" alt="image" src="https://github.com/user-attachments/assets/b9fac127-6836-4b28-9f59-1b662107a9f7" />
)