### PR TITLE
front: fix e2e tests on exceptions feature branch

### DIFF
--- a/front/src/applications/operationalStudies/helpers/TrainSimulationLazyLoader.ts
+++ b/front/src/applications/operationalStudies/helpers/TrainSimulationLazyLoader.ts
@@ -94,7 +94,7 @@ export default class TrainSimulationLazyLoader {
     }
 
     const pacedTrainSummaries = new Map();
-    for (const [id, rawSummary] of Object.entries(rawPacedTrainSummaries)) {
+    for (const [id, rawSummary] of Object.entries(rawPacedTrainSummaries ?? {})) {
       pacedTrainSummaries.set(Number(id), rawSummary);
     }
 

--- a/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/postPayloads.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/postPayloads.ts
@@ -103,8 +103,33 @@ export const postFullImportPayload = async (
     const exceptionsWithTrainIds = exceptions
       .map((trainExceptions, i) => ({ trainExceptions, pacedTrainId: timetableItems[i].id }))
       .filter(({ trainExceptions }) => trainExceptions.length > 0);
+
     for (const { trainExceptions, pacedTrainId } of exceptionsWithTrainIds) {
-      await createExceptions(dispatch, trainExceptions, pacedTrainId, timetableId);
+      const created = await createExceptions(dispatch, trainExceptions, pacedTrainId, timetableId);
+
+      // TODO: remove this part when the back will be done inserting the new exception format in TrainSchedule
+      const createdExceptions = created.map(
+        ({ change_groups, train_schedule_id: _, timetable_id: __, ...rest }) => ({
+          ...change_groups,
+          ...rest,
+          // TODO_EXCEPTION: remove this when drop key in the model
+          key: rest.id.toString(),
+        })
+      );
+
+      // Update the timetableItem with its exceptions
+      const trainIndex = timetableItems.findIndex((item) => item.id === pacedTrainId);
+      if (trainIndex === -1) continue;
+      const currentTrain = timetableItems[trainIndex];
+      if (currentTrain.paced) {
+        timetableItems[trainIndex] = {
+          ...currentTrain,
+          paced: {
+            ...currentTrain.paced,
+            exceptions: createdExceptions,
+          },
+        };
+      }
     }
 
     if (round_trips) {

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/ngeToOsrd/trainrun.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/ngeToOsrd/trainrun.ts
@@ -509,7 +509,8 @@ export const handleUpdateTimetableItem = async ({
   addUpsertedTimetableItems: (timetableItems: TimetableItem[]) => void;
   addDeletedTimetableItemIds: (timetableItemIds: number[]) => void;
 }) => {
-  const timetableItemIds = state.timetableItemIdByNgeId.get(trainrun.id)!;
+  const timetableItemIds = state.timetableItemIdByNgeId.get(trainrun.id);
+  if (!timetableItemIds) return;
   const oldForwardTimetableItem = await fetchTimetableItem(timetableItemIds[0], dispatch);
   const trainrunSections = getContinuousTrainrunSectionsByTrainrunId(netzgrafikDto, trainrun.id);
   const labels = getTrainrunLabels(netzgrafikDto, trainrun);

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/helpers/__tests__/generatePacedTrainException.spec.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/helpers/__tests__/generatePacedTrainException.spec.ts
@@ -215,10 +215,11 @@ describe('generatePacedTrainException', () => {
         expect(exception.path_and_schedule).toMatchObject({
           path: expect.arrayContaining([
             expect.objectContaining({
-              location: {
+              location: expect.objectContaining({
+                type: 'operational_point_part_reference',
                 operational_point: { trigram: 'NS', secondary_code: 'BV', type: 'trigram' },
                 local_track_name: null,
-              },
+              }),
             }),
           ]),
           schedule: [{ at: '1-1', stop_for: 'PT30S' }],

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/hooks/useOccurrenceActions.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/hooks/useOccurrenceActions.ts
@@ -25,7 +25,7 @@ import type { OccurrenceId, TimetableItem } from 'reducers/osrdconf/types';
 import { updateSelectedTrainId, updateTrainIdUsedForProjection } from 'reducers/simulationResults';
 import { getSelectedTrainId } from 'reducers/simulationResults/selectors';
 import { useAppDispatch } from 'store';
-import { isIndexedOccurrenceId, extractExceptionIdFromOccurrenceId } from 'utils/trainId';
+import { extractExceptionIdFromOccurrenceId, isIndexedOccurrenceId } from 'utils/trainId';
 
 type OccurrenceActionsParams = {
   pacedTrain: PacedTrainWithPacedWithDetails;

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/hooks/useOccurrences.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/hooks/useOccurrences.ts
@@ -90,7 +90,7 @@ const useOccurrences = (
 
     // Handle added exceptions
     exceptions.forEach((exception) => {
-      if (exception.occurrence_index !== undefined) return;
+      if (exception.occurrence_index !== undefined || !exception.start_time) return;
 
       let occurrenceRollingStock = rollingStock;
       if (exception.rolling_stock && rollingStockList) {
@@ -98,8 +98,7 @@ const useOccurrences = (
         occurrenceRollingStock = rollingStockList.find((rs) => rs.name === rollingStockName);
       }
 
-      // An added exception will always have a least a start time in its exceptions
-      const startTime = new Date(exception.start_time!.value);
+      const startTime = new Date(exception.start_time.value);
 
       computedOccurrences.push({
         // TODO_EXCEPTION: remove `!` when use TrainScheduleException type

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -304,6 +304,9 @@ const osrdEditoastApi = generatedEditoastApi
       postTimetableByIdTrainScheduleException: {
         invalidatesTags: ['train_schedule_exceptions', 'train_schedule'],
       },
+      putTrainScheduleExceptionById: {
+        invalidatesTags: ['train_schedule_exceptions', 'train_schedule'],
+      },
 
       postLevelCrossingOccupancy: {
         providesTags: ['level_crossing', 'train_schedule'],

--- a/front/tests/02-operational-studies/paced-trains/002-paced-train-exceptions.spec.ts
+++ b/front/tests/02-operational-studies/paced-trains/002-paced-train-exceptions.spec.ts
@@ -59,7 +59,8 @@ test.describe('@op @paced-trains @exceptions', () => {
       infra.id
     );
     scenarioItems = scenario;
-    await sendTrains(trainScheduleSet.id, trains.slice(0, 6));
+    const trainsSubset = trains.slice(0, 6);
+    await sendTrains(trainScheduleSet.id, trainsSubset, scenarioItems.timetable_id);
   });
 
   test.beforeEach(
@@ -200,6 +201,7 @@ test.describe('@op @paced-trains @exceptions', () => {
   });
 
   /** *************** Test 2 **************** */
+
   test('Modify a paced train and create added exception', async ({
     pacedTrainSection,
     scenarioTimetableSection,

--- a/front/tests/02-operational-studies/paced-trains/003-paced-train-occurrence-edition.spec.ts
+++ b/front/tests/02-operational-studies/paced-trains/003-paced-train-occurrence-edition.spec.ts
@@ -64,7 +64,8 @@ test.describe('@op @paced-trains @exceptions', () => {
       infra.id
     );
     scenarioItems = scenario;
-    await sendTrains(trainScheduleSet.id, trains.slice(0, 6));
+    const trainsSubset = trains.slice(0, 6);
+    await sendTrains(trainScheduleSet.id, trainsSubset, scenarioItems.timetable_id);
   });
 
   test.beforeEach(

--- a/front/tests/assets/trains/trains.json
+++ b/front/tests/assets/trains/trains.json
@@ -111,13 +111,14 @@
       "exceptions": [
         {
           "disabled": false,
-          "key": "e0573b19-d957-47ac-9a96-834d44ab842a",
           "occurrence_index": 1,
-          "train_name": {
-            "value": "abc"
-          },
-          "labels": {
-            "value": ["exception-label"]
+          "change_groups": {
+            "train_name": {
+              "value": "abc"
+            },
+            "labels": {
+              "value": ["exception-label"]
+            }
           }
         }
       ]
@@ -195,11 +196,12 @@
       "exceptions": [
         {
           "disabled": false,
-          "key": "e05qs3b19-d957-47ac-9a96-834d44ab842a",
           "occurrence_index": 2,
-          "rolling_stock": {
-            "rolling_stock_name": "SLOW_RS_E2E",
-            "comfort": "STANDARD"
+          "change_groups": {
+            "rolling_stock": {
+              "rolling_stock_name": "SLOW_RS_E2E",
+              "comfort": "STANDARD"
+            }
           }
         }
       ]
@@ -276,63 +278,64 @@
       "interval": "PT3900S",
       "exceptions": [
         {
-          "key": "0d03f1d8-6791-4380-87f1-3bf14e2f12d8",
           "occurrence_index": 1,
           "disabled": false,
-          "train_name": {
-            "value": "Paced Train - All exceptions 31"
-          },
-          "speed_limit_tag": {
-            "value": "MA100"
-          },
-          "path_and_schedule": {
-            "path": [
-              {
-                "id": "id2458",
-                "location": {
-                  "type": "track_offset",
-                  "track": "TG4",
-                  "offset": 1549000
-                }
-              },
-              {
-                "id": "id2570",
-                "location": {
-                  "type": "operational_point_part_reference",
-                  "operational_point": {
-                    "uic": 8733,
-                    "secondary_code": "BV",
-                    "type": "uic"
-                  },
-                  "track_reference": null
-                }
-              },
-              {
-                "id": "8369cfc6-e667-4b6b-965a-79795c94dd18",
-                "location": {
-                  "type": "operational_point_part_reference",
-                  "operational_point": {
-                    "uic": 8799,
-                    "secondary_code": "BV",
-                    "type": "uic"
-                  },
-                  "track_reference": null
-                }
-              }
-            ],
-            "schedule": [
-              {
-                "at": "8369cfc6-e667-4b6b-965a-79795c94dd18",
-                "arrival": null,
-                "stop_for": "P0D",
-                "reception_signal": "OPEN"
-              }
-            ],
-            "margins": {
-              "boundaries": ["8369cfc6-e667-4b6b-965a-79795c94dd18"],
-              "values": ["5%", "0%"]
+          "change_groups": {
+            "train_name": {
+              "value": "Paced Train - All exceptions 31"
             },
-            "power_restrictions": []
+            "speed_limit_tag": {
+              "value": "MA100"
+            },
+            "path_and_schedule": {
+              "path": [
+                {
+                  "id": "id2458",
+                  "location": {
+                    "type": "track_offset",
+                    "track": "TG4",
+                    "offset": 1549000
+                  }
+                },
+                {
+                  "id": "id2570",
+                  "location": {
+                    "type": "operational_point_part_reference",
+                    "operational_point": {
+                      "uic": 8733,
+                      "secondary_code": "BV",
+                      "type": "uic"
+                    },
+                    "track_reference": null
+                  }
+                },
+                {
+                  "id": "8369cfc6-e667-4b6b-965a-79795c94dd18",
+                  "location": {
+                    "type": "operational_point_part_reference",
+                    "operational_point": {
+                      "uic": 8799,
+                      "secondary_code": "BV",
+                      "type": "uic"
+                    },
+                    "track_reference": null
+                  }
+                }
+              ],
+              "schedule": [
+                {
+                  "at": "8369cfc6-e667-4b6b-965a-79795c94dd18",
+                  "arrival": null,
+                  "stop_for": "P0D",
+                  "reception_signal": "OPEN"
+                }
+              ],
+              "margins": {
+                "boundaries": ["8369cfc6-e667-4b6b-965a-79795c94dd18"],
+                "values": ["5%", "0%"]
+              },
+              "power_restrictions": []
+            }
           }
         },
         {
@@ -518,10 +521,11 @@
       "interval": "PT3600S",
       "exceptions": [
         {
-          "key": "e0f2d454-ccaa-4df6-8a57-39c28c904976",
           "disabled": false,
-          "start_time": {
-            "value": "2024-10-16T00:30:00Z"
+          "change_groups": {
+            "start_time": {
+              "value": "2024-10-16T00:30:00Z"
+            }
           }
         },
         {
@@ -628,11 +632,12 @@
       "exceptions": [
         {
           "disabled": false,
-          "key": "e0573b19-d957-47ac-9a96-224d44ab842b",
           "occurrence_index": 0,
-          "rolling_stock": {
-            "rolling_stock_name": "SLOW_RS_E2E",
-            "comfort": "STANDARD"
+          "change_groups": {
+            "rolling_stock": {
+              "rolling_stock_name": "SLOW_RS_E2E",
+              "comfort": "STANDARD"
+            }
           }
         },
         {
@@ -715,63 +720,64 @@
       "interval": "PT3900S",
       "exceptions": [
         {
-          "key": "0d03f1d8-6791-4380-87f1-3bf14e2f12d8",
           "occurrence_index": 1,
           "disabled": false,
-          "train_name": {
-            "value": "Paced Train - All exceptions 31"
-          },
-          "speed_limit_tag": {
-            "value": "MA100"
-          },
-          "path_and_schedule": {
-            "path": [
-              {
-                "id": "id2458",
-                "location": {
-                  "type": "track_offset",
-                  "track": "TG4",
-                  "offset": 1549000
-                }
-              },
-              {
-                "id": "id2570",
-                "location": {
-                  "type": "operational_point_part_reference",
-                  "operational_point": {
-                    "uic": 8733,
-                    "secondary_code": "BV",
-                    "type": "uic"
-                  },
-                  "track_reference": null
-                }
-              },
-              {
-                "id": "8369cfc6-e667-4b6b-965a-79795c94dd18",
-                "location": {
-                  "type": "operational_point_part_reference",
-                  "operational_point": {
-                    "uic": 8799,
-                    "secondary_code": "BV",
-                    "type": "uic"
-                  },
-                  "track_reference": null
-                }
-              }
-            ],
-            "schedule": [
-              {
-                "at": "8369cfc6-e667-4b6b-965a-79795c94dd18",
-                "arrival": null,
-                "stop_for": "P0D",
-                "reception_signal": "OPEN"
-              }
-            ],
-            "margins": {
-              "boundaries": ["8369cfc6-e667-4b6b-965a-79795c94dd18"],
-              "values": ["5%", "0%"]
+          "change_groups": {
+            "train_name": {
+              "value": "Paced Train - All exceptions 31"
             },
-            "power_restrictions": []
+            "speed_limit_tag": {
+              "value": "MA100"
+            },
+            "path_and_schedule": {
+              "path": [
+                {
+                  "id": "id2458",
+                  "location": {
+                    "type": "track_offset",
+                    "track": "TG4",
+                    "offset": 1549000
+                  }
+                },
+                {
+                  "id": "id2570",
+                  "location": {
+                    "type": "operational_point_part_reference",
+                    "operational_point": {
+                      "uic": 8733,
+                      "secondary_code": "BV",
+                      "type": "uic"
+                    },
+                    "track_reference": null
+                  }
+                },
+                {
+                  "id": "8369cfc6-e667-4b6b-965a-79795c94dd18",
+                  "location": {
+                    "type": "operational_point_part_reference",
+                    "operational_point": {
+                      "uic": 8799,
+                      "secondary_code": "BV",
+                      "type": "uic"
+                    },
+                    "track_reference": null
+                  }
+                }
+              ],
+              "schedule": [
+                {
+                  "at": "8369cfc6-e667-4b6b-965a-79795c94dd18",
+                  "arrival": null,
+                  "stop_for": "P0D",
+                  "reception_signal": "OPEN"
+                }
+              ],
+              "margins": {
+                "boundaries": ["8369cfc6-e667-4b6b-965a-79795c94dd18"],
+                "values": ["5%", "0%"]
+              },
+              "power_restrictions": []
+            }
           }
         },
         {

--- a/front/tests/utils/send-trains.ts
+++ b/front/tests/utils/send-trains.ts
@@ -1,32 +1,171 @@
 import type { APIRequestContext, APIResponse } from '@playwright/test';
 
-import type { TrainScheduleResponse } from 'common/api/osrdEditoastApi';
+import type {
+  PacedTrainException,
+  TrainSchedule,
+  TrainScheduleException,
+  TrainScheduleExceptionChangeGroups,
+  TrainScheduleResponse,
+} from 'common/api/osrdEditoastApi';
 
-import { getApiContext, handleErrorResponse } from './api-utils';
+import { getApiContext, handleErrorResponse, postApiRequest } from './api-utils';
+import type { ExceptionFormat } from './types';
+
+const CHANGE_GROUP_KEYS: ReadonlyArray<keyof TrainScheduleExceptionChangeGroups> = [
+  'constraint_distribution',
+  'initial_speed',
+  'labels',
+  'options',
+  'path_and_schedule',
+  'rolling_stock',
+  'rolling_stock_category',
+  'speed_limit_tag',
+  'start_time',
+  'train_name',
+];
 
 /**
- * Send paced trains to the API for a specific train_schedule_set and returns the result.
+ * Convert TrainScheduleException (API format with nested change_groups)
+ * to PacedTrainException (frontend format with flat change groups)
+ */
+const convertToPacedTrainException = (
+  apiException: TrainScheduleException
+): PacedTrainException => {
+  const { change_groups, disabled, id, key, occurrence_index } = apiException;
+
+  return {
+    ...change_groups,
+    disabled,
+    id,
+    key: key ?? '',
+    occurrence_index,
+  };
+};
+
+/**
+ * Extract change groups from an exception.
+ * Handles both formats:
+ * - Direct properties (matching PacedTrainException type)
+ * - Nested in 'change_groups' object (legacy format from JSON files)
+ */
+const extractChangeGroups = (exception: ExceptionFormat): TrainScheduleExceptionChangeGroups => {
+  // Check if exception has change_groups property (legacy JSON format)
+  if ('change_groups' in exception && exception.change_groups) {
+    return exception.change_groups;
+  }
+
+  // Otherwise, extract from direct properties (standard format)
+  const pacedException = exception as PacedTrainException;
+  return Object.fromEntries(
+    CHANGE_GROUP_KEYS.filter((key) => pacedException[key] !== undefined).map((key) => [
+      key,
+      pacedException[key],
+    ])
+  ) as TrainScheduleExceptionChangeGroups;
+};
+
+/**
+ * Send trains to the API for a specific train_schedule_set and returns the result.
  *
- * @param trainScheduleSetId - The ID of the train_schedule_set for which the paced trains are being sent.
- * @param body - The request payload containing paced train data.
+ * 1. Strips paced.exceptions from the payload and sends trains first.
+ * 2. If timetableId is provided, uses the returned train_schedule_ids to create
+ *    each exception separately. If timetableId is absent, exceptions are ignored.
+ *
+ * @param trainScheduleSetId - The ID of the train_schedule_set.
+ * @param body               - The request payload containing train data.
+ * @param timetableId        - Optional. The ID of the timetable (used for the exception endpoint).
+ *                             If not provided, exceptions are not created.
  * @returns {Promise<TrainScheduleResponse[]>} - The API response containing the train schedule response.
  */
-async function sendTrains<T>(
+async function sendTrains(
   trainScheduleSetId: number,
-  body: T
+  trains: TrainSchedule[],
+  timetableId?: number
 ): Promise<TrainScheduleResponse[]> {
+  // Collect exceptions per train index before stripping them
+  // Only if timetableId is provided, otherwise treat as no exceptions
+
+  const exceptionsToCreate: {
+    trainIndex: number;
+    exceptions: ExceptionFormat[];
+  }[] = [];
+
+  if (timetableId !== undefined) {
+    trains.forEach((train, index) => {
+      if (train.paced?.exceptions) {
+        exceptionsToCreate.push({
+          trainIndex: index,
+          exceptions: train.paced.exceptions as ExceptionFormat[],
+        });
+      }
+    });
+  }
+
+  if (trains.some((train) => train.paced?.exceptions)) {
+    // Strip exceptions from the payload before sending trains
+    trains.forEach((train) => {
+      if (train.paced?.exceptions) {
+        train.paced.exceptions = [];
+      }
+    });
+  }
+
+  // 1. Send trains first to get their IDs
   const apiContext: APIRequestContext = await getApiContext();
   const pacedTrainsResponse: APIResponse = await apiContext.post(
     `/api/train_schedule_sets/${trainScheduleSetId}/train_schedules/`,
     {
-      data: JSON.stringify(body),
-      headers: {
-        'Content-Type': 'application/json',
-      },
+      data: JSON.stringify(trains),
+      headers: { 'Content-Type': 'application/json' },
     }
   );
   handleErrorResponse(pacedTrainsResponse, 'Failed to send paced train');
   const responseData = (await pacedTrainsResponse.json()) as TrainScheduleResponse[];
+
+  // 2. Create exceptions using the train_schedule_id returned for each train
+  if (exceptionsToCreate.length > 0) {
+    const createdExceptions = await Promise.all(
+      exceptionsToCreate.flatMap(({ trainIndex, exceptions }) => {
+        const trainScheduleId = responseData[trainIndex]?.id;
+        if (trainScheduleId === undefined) {
+          throw new Error(
+            `No train_schedule_id found in response for train at index ${trainIndex}`
+          );
+        }
+
+        return exceptions.map(async (exception) => {
+          const changeGroups = extractChangeGroups(exception);
+
+          const createdExceptionResponse: TrainScheduleException = await postApiRequest(
+            `/api/timetable/${timetableId}/train_schedule_exception`,
+            {
+              train_schedule_id: trainScheduleId,
+              disabled: exception.disabled ?? false,
+              occurrence_index: exception.occurrence_index ?? null,
+              change_groups: changeGroups,
+            },
+            undefined,
+            `Failed to create exception for train_schedule_id ${trainScheduleId}`
+          );
+
+          // Convert API format (TrainScheduleException with nested change_groups)
+          // to frontend format (PacedTrainException with flat change groups)
+          const createdException = convertToPacedTrainException(createdExceptionResponse);
+
+          return { trainIndex, exception: createdException };
+        });
+      })
+    );
+
+    // Integrate created exceptions back into responseData
+    createdExceptions.forEach(({ trainIndex, exception }) => {
+      const paced = responseData[trainIndex].paced;
+      if (paced) {
+        paced.exceptions ??= [];
+        paced.exceptions.push(exception);
+      }
+    });
+  }
 
   return responseData;
 }

--- a/front/tests/utils/setup-utils.ts
+++ b/front/tests/utils/setup-utils.ts
@@ -187,7 +187,7 @@ export async function createDataForTests(): Promise<void> {
       studyWithTimetableItems.id,
       mediumInfra.id
     );
-    await sendTrains(trainScheduleSet.id, trains);
+    await sendTrains(trainScheduleSet.id, trains, scenario.timetable_id);
 
     // Step 7: Configure STDCM search environment for the tests
     const stdcmEnvironment = {

--- a/front/tests/utils/types.ts
+++ b/front/tests/utils/types.ts
@@ -1,4 +1,8 @@
-import type { Tags } from 'common/api/osrdEditoastApi';
+import type {
+  PacedTrainException,
+  Tags,
+  TrainScheduleExceptionChangeGroups,
+} from 'common/api/osrdEditoastApi';
 
 type StationRequest = {
   name: string;
@@ -304,3 +308,11 @@ export type PacedTrainOptions = {
   pacedTrainCardAlreadyOpen?: boolean;
   occurrenceColor?: string;
 };
+
+export type ExceptionFormat =
+  | PacedTrainException
+  | {
+      change_groups: TrainScheduleExceptionChangeGroups;
+      disabled?: boolean;
+      occurrence_index?: number;
+    };


### PR DESCRIPTION
part of https://github.com/OpenRailAssociation/osrd/pull/15653

Since our feature branch on exceptions, we have changed the behavior of exception creation.
This PR therefore makes it possible to create exceptions in the E2E tests from an adapted JSON file, while also handling the import/export use case.

There is also a tag invalidation when calling putTrainScheduleExceptionById, which allows the arrival time to be recalculated when deleting a path and schedule type exception.

The final goal of this PR is to make the E2E tests work properly on the feature branch.
