### PR TITLE
core: pathfinding: process path with backtracking

### DIFF
--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/JsonTrainPath.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/JsonTrainPath.kt
@@ -85,7 +85,11 @@ fun TrainPath.toJsonTrainPath(rawInfra: RawInfra, blockInfra: BlockInfra): JsonT
                     EdgeDirection.STOP_TO_START,
                 )
         val lastAddedRange = tracks.lastOrNull()
-        if (lastAddedRange == null || lastAddedRange.trackSection != trackRange.trackSection) {
+        if (
+            lastAddedRange == null ||
+                lastAddedRange.trackSection != trackRange.trackSection ||
+                lastAddedRange.direction != trackRange.direction
+        ) {
             tracks.add(trackRange)
         } else {
             val newLastRange =
@@ -93,6 +97,7 @@ fun TrainPath.toJsonTrainPath(rawInfra: RawInfra, blockInfra: BlockInfra): JsonT
                     begin = min(lastAddedRange.begin, trackRange.begin),
                     end = max(lastAddedRange.end, trackRange.end),
                 )
+            require(lastAddedRange.direction == trackRange.direction)
             // Check that we only extend the range, and only on one end
             require(
                 lastAddedRange.begin == newLastRange.begin || lastAddedRange.end == newLastRange.end

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/LoadedSignalingInfra.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/LoadedSignalingInfra.kt
@@ -33,6 +33,8 @@ typealias SigState = SigData<SignalStateMarker>
 
 typealias SigStateSchema = SigSchema<SignalStateMarker>
 
+data class BlockLocation(val edge: BlockId, val offset: Offset<Block>)
+
 /** The signaling system manager is a repository for drivers and signaling systems */
 interface InfraSigSystemManager {
     val signalingSystems: StaticIdxSpace<SignalingSystem>

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/LoadedSignalingInfra.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/LoadedSignalingInfra.kt
@@ -126,3 +126,25 @@ interface BlockInfra {
 fun InfraSigSystemManager.findSignalingSystemOrThrow(sigSystem: String): SignalingSystemId {
     return findSignalingSystem(sigSystem) ?: throw OSRDError.newSignalingError(sigSystem)
 }
+
+fun BlockInfra.getBlockOffset(
+    blockId: BlockId,
+    waypointDirChunkLocation: DirChunkLocation,
+    rawInfra: RawInfra,
+): Offset<Block> {
+    var startBlockToStartChunk: Offset<Block> = Offset(0.meters)
+    val blockTrackChunks = this.getTrackChunksFromBlock(blockId)
+    for (blockTrackChunkDirId in blockTrackChunks) {
+        if (blockTrackChunkDirId == waypointDirChunkLocation.dirChunk) {
+            return startBlockToStartChunk + waypointDirChunkLocation.offset.distance
+        }
+        startBlockToStartChunk += rawInfra.getTrackChunkLength(blockTrackChunkDirId.value).distance
+    }
+    throw AssertionError(
+        String.format(
+            "getBlockOffset: Directed track chunk %s not in block %s",
+            waypointDirChunkLocation.dirChunk,
+            blockId,
+        )
+    )
+}

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/LoadedSignalingInfra.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/LoadedSignalingInfra.kt
@@ -150,3 +150,24 @@ fun BlockInfra.getBlockOffset(
         )
     )
 }
+
+fun BlockInfra.getDirChunkLocation(
+    blockLocation: BlockLocation,
+    rawInfra: RawInfra,
+): DirChunkLocation {
+    val chunks = this.getTrackChunksFromBlock(blockLocation.edge)
+    var offsetToStep = blockLocation.offset.distance
+    chunks.forEach { chunk ->
+        val chunkLength = rawInfra.getTrackChunkLength(chunk.value).distance
+        if (offsetToStep > chunkLength) {
+            offsetToStep -= chunkLength
+            return@forEach
+        }
+        return DirChunkLocation(chunk, Offset(offsetToStep))
+    }
+    throw AssertionError(
+        String.format(
+            "getDirChunkLocation: Did not find chunk location for BlockLocation $blockLocation: wrong offset?"
+        )
+    )
+}

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/RawSignalingInfra.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/RawSignalingInfra.kt
@@ -71,4 +71,83 @@ fun RawSignalingInfra.getLogicalSignalName(signal: LogicalSignalId): String? {
     return getPhysicalSignalName(getPhysicalSignal(signal))
 }
 
+/**
+ * From a given sorted list of consecutive directed chunks
+ *
+ * Return all route-paths (consecutive routes) that cover all the chunks (without interruption and
+ * in order)
+ */
+fun RawSignalingInfra.chunksToRoutePaths(
+    consecutiveChunksToCover: List<DirTrackChunkId>
+): Set<List<RouteId>> {
+    val firstRoutes = getRoutesOnTrackChunk(consecutiveChunksToCover.first())
+    return firstRoutes
+        .flatMap { firstRoute ->
+            getRoutePathsCoveringAllChunks(consecutiveChunksToCover, firstRoute, false)
+        }
+        .toSet()
+}
+
+/**
+ * Recursive function
+ *
+ * From:
+ * - a given sorted list of consecutive directed chunks to be covered by a path (multiple routes)
+ * - a starting route for those paths (route covers at least the start of the chunk list)
+ * - a boolean allowing to skip first chunks of the route (the first route can start with extra
+ *   chunks, but not the next ones)
+ *
+ * Return each route-path that covers all the chunks (without interruption and in order):
+ * - a route-path is a sorted list of routes
+ * - wrap route-paths into a set
+ */
+private fun RawSignalingInfra.getRoutePathsCoveringAllChunks(
+    consecutiveChunksToCover: List<DirTrackChunkId>,
+    currentRoute: RouteId,
+    alreadyStartedToCover: Boolean,
+): Set<List<RouteId>> {
+    val chunksOnCurrentRoute = getChunksOnRoute(currentRoute)
+    var idxNextChunkToCover = 0
+    var startedToCover = alreadyStartedToCover
+    for (chunk in chunksOnCurrentRoute) {
+        // Different chunk on route than expected: no valid route-path will be found using current
+        // route
+        if (startedToCover && consecutiveChunksToCover[idxNextChunkToCover] != chunk) return setOf()
+
+        if (consecutiveChunksToCover[idxNextChunkToCover] == chunk) {
+            startedToCover = true
+            idxNextChunkToCover++
+
+            // Coverage finished: the current route covers all
+            if (idxNextChunkToCover == consecutiveChunksToCover.size)
+                return setOf(listOf(currentRoute))
+        }
+    }
+    require(startedToCover)
+    require(idxNextChunkToCover > 0)
+
+    // Ongoing coverage:
+    // - retrieve sub-route-paths that cover the end of the chunk list (if any)
+    // - for each sub-route-path:
+    //   - add [current-route + sub-route-path] to the result set
+    val currentRouteExit = getRouteExit(currentRoute)
+    val nextPossibleRoutes = getRoutesStartingAtDet(currentRouteExit)
+
+    val result = mutableSetOf<List<RouteId>>()
+    for (nextRoute in nextPossibleRoutes) {
+        val nextRoutePaths =
+            getRoutePathsCoveringAllChunks(
+                consecutiveChunksToCover.subList(
+                    idxNextChunkToCover,
+                    consecutiveChunksToCover.size,
+                ),
+                nextRoute,
+                true,
+            )
+        val completedRoutePaths = nextRoutePaths.map { listOf(currentRoute) + it }
+        result.addAll(completedRoutePaths)
+    }
+    return result
+}
+
 typealias RawInfra = RawSignalingInfra

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/TrackInfra.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/TrackInfra.kt
@@ -3,7 +3,9 @@ package fr.sncf.osrd.sim_infra.api
 import fr.sncf.osrd.reporting.exceptions.OSRDError.newUnknownTrackSectionError
 import fr.sncf.osrd.utils.Direction
 import fr.sncf.osrd.utils.indexing.*
+import fr.sncf.osrd.utils.units.DirOffset
 import fr.sncf.osrd.utils.units.Length
+import fr.sncf.osrd.utils.units.Offset
 
 /** Detectors detect when trains arrive and leave a given point location */
 sealed interface Detector
@@ -35,6 +37,10 @@ typealias DirDetectorId = DirStaticIdx<Detector>
 typealias DirTrackChunkId = DirStaticIdx<TrackChunk>
 
 typealias OptDirTrackChunkId = OptDirStaticIdx<TrackChunk>
+
+data class DirChunkLocation(val dirChunk: DirTrackChunkId, val offset: DirOffset<TrackChunk>)
+
+data class ChunkLocation(val chunk: TrackChunkId, val offset: Offset<TrackChunk>)
 
 fun <T> StaticIdx<T>.withDirection(dir: Direction): DirStaticIdx<T> {
     return DirStaticIdx(this, dir)

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/utils/InfraUtils.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/utils/InfraUtils.kt
@@ -20,13 +20,6 @@ fun TrackNetworkInfra.getNextTrackSections(
     return nextTrackSections
 }
 
-/** Returns the list of dir chunk id on the given block list */
-fun BlockInfra.chunksOnBlocks(blockIds: List<BlockId>): List<DirTrackChunkId> {
-    val res = mutableDirStaticIdxArrayListOf<TrackChunk>()
-    for (block in blockIds) for (chunk in getTrackChunksFromBlock(block)) res.add(chunk)
-    return res
-}
-
 /** Returns all routes that cover the given block */
 fun BlockInfra.routesOnBlock(rawInfra: RawInfra, block: BlockId): List<RouteId> {
     val chunks = getTrackChunksFromBlock(block)

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/utils/InfraUtils.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/utils/InfraUtils.kt
@@ -1,6 +1,7 @@
 package fr.sncf.osrd.sim_infra.utils
 
 import fr.sncf.osrd.sim_infra.api.*
+import fr.sncf.osrd.sim_infra.impl.logger
 import fr.sncf.osrd.utils.indexing.mutableDirStaticIdxArrayListOf
 import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
 
@@ -61,7 +62,11 @@ fun BlockInfra.getRouteBlocks(
 ): List<BlockId> {
     val blockPaths =
         recoverBlocks(rawInfra, this, mutableStaticIdxArrayListOf(route), allowedSigSystems)
-    if (blockPaths.isEmpty()) return mutableStaticIdxArrayListOf()
+    if (blockPaths.isEmpty()) {
+        // quite "common" situation
+        logger.debug("Route ${rawInfra.getRouteName(route)} has no block")
+        return mutableStaticIdxArrayListOf()
+    }
     // No signaling system for now, take the first block path possibility.
     // Correct when signalisation is taken into account.
     val blocks = blockPaths[0].toBlockList()

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/utils/InfraUtils.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/utils/InfraUtils.kt
@@ -1,7 +1,5 @@
 package fr.sncf.osrd.sim_infra.utils
 
-import fr.sncf.osrd.reporting.exceptions.ErrorType
-import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.utils.indexing.mutableDirStaticIdxArrayListOf
 import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
@@ -19,26 +17,6 @@ fun TrackNetworkInfra.getNextTrackSections(
         }
     }
     return nextTrackSections
-}
-
-/** Converts a list of dir chunks into a list of routes */
-fun BlockInfra.chunksToRoutes(
-    infra: RawSignalingInfra,
-    pathChunks: List<DirTrackChunkId>,
-): List<RouteId> {
-    var chunkStartIndex = 0
-    val res = mutableStaticIdxArrayListOf<Route>()
-    while (chunkStartIndex < pathChunks.size) {
-        val route = findRoute(infra, this, pathChunks, chunkStartIndex, chunkStartIndex != 0)
-        res.add(route)
-        val chunkSetOnRoute = infra.getChunksOnRoute(route).toSet()
-        while (
-            chunkStartIndex < pathChunks.size &&
-                chunkSetOnRoute.contains(pathChunks[chunkStartIndex])
-        ) chunkStartIndex++ // Increase the index in the chunk path, for as long as it is covered by
-        // the route
-    }
-    return res
 }
 
 /** Returns the list of dir chunk id on the given block list */
@@ -88,70 +66,4 @@ fun BlockInfra.getRouteBlocks(
     // Correct when signalisation is taken into account.
     val blocks = blockPaths[0].toBlockList()
     return blocks
-}
-
-/** Finds a valid route that follows the given path */
-private fun findRoute(
-    infra: RawSignalingInfra,
-    blockInfra: BlockInfra,
-    chunks: List<DirTrackChunkId>,
-    startIndex: Int,
-    routeMustIncludeStart: Boolean,
-): RouteId {
-    val routes = infra.getRoutesOnTrackChunk(chunks[startIndex])
-
-    // We need to evaluate the longest route first, in case one route covers a subset of another
-    val sortedRoutes = routes.sortedBy { r -> -infra.getChunksOnRoute(r).size }
-    for (routeId in sortedRoutes) {
-        if (routeMatchPath(infra, blockInfra, chunks, startIndex, routeMustIncludeStart, routeId)) {
-            return routeId
-        }
-    }
-    throw OSRDError(ErrorType.MissingRouteFromChunkPath)
-}
-
-/** Returns false if the route differs from the path */
-private fun routeMatchPath(
-    infra: RawSignalingInfra,
-    blockInfra: BlockInfra,
-    chunks: List<DirTrackChunkId>,
-    chunkIndex: Int,
-    routeMustIncludeStart: Boolean,
-    routeId: RouteId,
-): Boolean {
-    var mutChunkIndex = chunkIndex
-    if (!routeHasBlockPath(infra, blockInfra, routeId))
-        return false // Filter out routes that don't have block, they would cause issues later on
-    val firstChunk = chunks[mutChunkIndex]
-    val routeChunks = infra.getChunksOnRoute(routeId)
-    var routeChunkIndex = 0
-    if (routeMustIncludeStart) {
-        if (routeChunks[0] != firstChunk) return false
-    } else {
-        while (routeChunks[routeChunkIndex] != firstChunk) routeChunkIndex++
-    }
-    while (true) {
-        if (routeChunkIndex == routeChunks.size) return true // end of route
-        if (mutChunkIndex == chunks.size) return true // end of path
-        if (routeChunks[routeChunkIndex] != chunks[mutChunkIndex])
-            return false // route and path differ
-        routeChunkIndex++
-        mutChunkIndex++
-    }
-}
-
-/**
- * Returns true if the route contains a valid block path.
- *
- * This should always be true, but it can be false on infrastructures with errors in its signaling
- * data (such as the ones imported from poor data sources). At this step we know that there is at
- * least one route with a valid block path, we just need to filter out the ones that don't.
- */
-private fun routeHasBlockPath(
-    infra: RawSignalingInfra,
-    blockInfra: BlockInfra,
-    routeId: RouteId,
-): Boolean {
-    val blockPaths = recoverBlocks(infra, blockInfra, mutableStaticIdxArrayListOf(routeId), null)
-    return blockPaths.isNotEmpty()
 }

--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/units/Distance.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/utils/units/Distance.kt
@@ -235,6 +235,11 @@ fun <T> Offset<T>.toDirected(objectLength: Length<T>, direction: Direction): Dir
     }
 }
 
+/** Converts an undirected offset into the opposite undirected offset, using the object length. */
+fun <T> DirOffset<T>.toOpposite(objectLength: Length<T>): DirOffset<T> {
+    return Offset(objectLength.distance - this.distance)
+}
+
 /**
  * Forces the conversion from <T> to <Directed<T>>. A little more type-safe than just .cast().
  * Should generally only be used for Lengths, though as a type alias this isn't type-checked.

--- a/core/src/main/kotlin/fr/sncf/osrd/api/CommonSchemas.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/CommonSchemas.kt
@@ -70,6 +70,11 @@ data class RangeValues<valueT>(
     }
 }
 
+data class PathItem(
+    val locations: Collection<TrackLocation>,
+    @Json(name = "can_backtrack") val canBacktrack: Boolean,
+)
+
 class TrackLocation(val track: String, val offset: Offset<TrackSection>)
 
 class ZoneUpdate(

--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlockRequest.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlockRequest.kt
@@ -4,7 +4,7 @@ import com.squareup.moshi.Json
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
-import fr.sncf.osrd.api.TrackLocation
+import fr.sncf.osrd.api.PathItem
 import fr.sncf.osrd.railjson.schema.rollingstock.RJSLoadingGaugeType
 import fr.sncf.osrd.utils.json.UnitAdapterFactory
 
@@ -24,7 +24,7 @@ class PathfindingBlockRequest(
     @Json(name = "expected_version") val expectedVersion: Int?,
 
     // One set of location by step, each step must be reached in order
-    @Json(name = "path_items") val pathItems: List<Collection<TrackLocation>>,
+    @Json(name = "path_items") val pathItems: List<PathItem>,
 )
 
 val pathfindingRequestAdapter: JsonAdapter<PathfindingBlockRequest> =

--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlockResponse.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlockResponse.kt
@@ -25,6 +25,7 @@ class PathfindingBlockSuccess(
 
     /** Offsets of the waypoints given as input */
     @Json(name = "path_item_positions") val pathItemPositions: List<Offset<PhysicsPath>>,
+    @Json(name = "backtrack_positions") val backtrackPositions: List<Offset<PhysicsPath>>,
 ) : PathfindingBlockResponse {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -33,12 +34,13 @@ class PathfindingBlockSuccess(
         if (path != other.path) return false
         if (length != other.length) return false
         if (pathItemPositions != other.pathItemPositions) return false
+        if (backtrackPositions != other.backtrackPositions) return false
 
         return true
     }
 
     override fun hashCode(): Int {
-        return Objects.hash(path, length, pathItemPositions)
+        return Objects.hash(path, length, pathItemPositions, backtrackPositions)
     }
 }
 

--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.kt
@@ -95,11 +95,11 @@ fun runPathfinding(infra: FullInfra, request: PathfindingBlockRequest): Pathfind
     // Parse the waypoints
     val waypoints = ArrayList<Collection<BlockLocation>>()
     val destinationTrack = request.pathItems.last()
-    val destinationBlock = findWaypointBlocks(infra, destinationTrack)
+    val destinationBlock = findWaypointBlocks(infra, destinationTrack.locations)
     request.pathItems.forEachIndexed { stepIndex, step ->
         val allStarts = HashSet<BlockLocation>()
         for (direction in Direction.entries) {
-            for (waypoint in step) {
+            for (waypoint in step.locations) {
                 val waypointBlocks = findDirectedWaypointBlocks(infra, waypoint, direction)
                 if (
                     request.stopsAtEndOfBlock == true &&

--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.kt
@@ -26,6 +26,7 @@ import fr.sncf.osrd.utils.*
 import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
+import fr.sncf.osrd.utils.units.toDirected
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.annotations.WithSpan
@@ -268,13 +269,8 @@ fun findDirectedWaypointBlocks(
 
     val chunkLocationOnWaypoint =
         getChunkLocationOnWaypoint(trackSectionId, waypoint.offset, infra.rawInfra)
-    val directedChunkOffset =
-        Offset<DirTrackChunkId>(
-            if (direction == Direction.INCREASING) chunkLocationOnWaypoint.offset.distance
-            else
-                infra.rawInfra.getTrackChunkLength(chunkLocationOnWaypoint.chunk).distance -
-                    chunkLocationOnWaypoint.offset.distance
-        )
+    val chunkLength = infra.rawInfra.getTrackChunkLength(chunkLocationOnWaypoint.chunk)
+    val directedChunkOffset = chunkLocationOnWaypoint.offset.toDirected(chunkLength, direction)
     val waypointDirChunkLocation =
         DirChunkLocation(
             DirTrackChunkId(chunkLocationOnWaypoint.chunk, direction),
@@ -285,7 +281,7 @@ fun findDirectedWaypointBlocks(
         infra.blockInfra.getBlocksFromTrackChunk(chunkLocationOnWaypoint.chunk, direction).toSet()
     for (block in blocksOnWaypoint) {
         val offset =
-            getBlockOffset(block, waypointDirChunkLocation, infra.rawInfra, infra.blockInfra)
+            infra.blockInfra.getBlockOffset(block, waypointDirChunkLocation, infra.rawInfra)
         assert(offset <= infra.blockInfra.getBlockLength(block))
         res.add(BlockLocation(block, offset))
     }
@@ -302,13 +298,6 @@ fun findWaypointBlocks(infra: FullInfra, waypoints: Collection<TrackLocation>): 
     return waypointBlocks
 }
 
-private data class DirChunkLocation(
-    val dirChunk: DirTrackChunkId,
-    val offset: Offset<DirTrackChunkId>,
-)
-
-private data class ChunkLocation(val chunk: TrackChunkId, val offset: Offset<TrackChunk>)
-
 private fun getChunkLocationOnWaypoint(
     trackSectionId: TrackSectionId,
     waypointOffset: Offset<TrackSection>,
@@ -324,29 +313,6 @@ private fun getChunkLocationOnWaypoint(
     throw OSRDError(ErrorType.InvalidWaypointLocation)
         .withContext("track", rawInfra.getTrackSectionName(trackSectionId))
         .withContext("offset", waypointOffset)
-}
-
-private fun getBlockOffset(
-    blockId: BlockId,
-    waypointDirChunkLocation: DirChunkLocation,
-    rawInfra: RawInfra,
-    blockInfra: BlockInfra,
-): Offset<Block> {
-    var startBlockToStartChunk: Offset<Block> = Offset(0.meters)
-    val blockTrackChunks = blockInfra.getTrackChunksFromBlock(blockId)
-    for (blockTrackChunkDirId in blockTrackChunks) {
-        if (blockTrackChunkDirId == waypointDirChunkLocation.dirChunk) {
-            return startBlockToStartChunk + waypointDirChunkLocation.offset.distance
-        }
-        startBlockToStartChunk += rawInfra.getTrackChunkLength(blockTrackChunkDirId.value).distance
-    }
-    throw AssertionError(
-        String.format(
-            "getBlockOffset: Directed track chunk %s not in block %s",
-            waypointDirChunkLocation.dirChunk,
-            blockId,
-        )
-    )
 }
 
 /**

--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.kt
@@ -189,7 +189,7 @@ fun hasDuplicateTracks(infra: FullInfra, path: TrainPath): Boolean {
         path
             .getChunks()
             .map { it.value }
-            .map { infra.rawInfra.getTrackFromChunk(it.value) }
+            .map { DirTrackSectionId(infra.rawInfra.getTrackFromChunk(it.value), it.direction) }
             .withoutConsecutiveDuplicates()
     return tracks.toSet().size < tracks.size
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.kt
@@ -156,7 +156,7 @@ private fun computePaths(
                 constraints,
                 initialRequest.speedLimitTag,
                 initialRequest.rollingStockMaximumSpeed,
-                initialRequest.rollingStockLength,
+                initialRequest.rollingStockLength.meters,
             )
             .runPathfinding()
 
@@ -210,7 +210,7 @@ private fun throwNoPathFoundException(
                     listOf(),
                     initialRequest.speedLimitTag,
                     initialRequest.rollingStockMaximumSpeed,
-                    initialRequest.rollingStockLength,
+                    initialRequest.rollingStockLength.meters,
                 )
                 .runPathfinding(timeout)
         if (possiblePathWithoutErrorNoConstraints != null) {

--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.kt
@@ -265,20 +265,27 @@ fun findDirectedWaypointBlocks(
     val trackSectionId =
         infra.rawInfra.getTrackSectionFromName(waypoint.track)
             ?: throw OSRDError.newUnknownTrackSectionError(waypoint.track)
-    val trackChunkOnWaypoint =
-        getTrackSectionChunkOnWaypoint(trackSectionId, waypoint.offset, infra.rawInfra)
+
+    val chunkLocationOnWaypoint =
+        getChunkLocationOnWaypoint(trackSectionId, waypoint.offset, infra.rawInfra)
+    val directedChunkOffset =
+        Offset<DirTrackChunkId>(
+            if (direction == Direction.INCREASING) chunkLocationOnWaypoint.offset.distance
+            else
+                infra.rawInfra.getTrackChunkLength(chunkLocationOnWaypoint.chunk).distance -
+                    chunkLocationOnWaypoint.offset.distance
+        )
+    val waypointDirChunkLocation =
+        DirChunkLocation(
+            DirTrackChunkId(chunkLocationOnWaypoint.chunk, direction),
+            directedChunkOffset,
+        )
+
     val blocksOnWaypoint =
-        infra.blockInfra.getBlocksFromTrackChunk(trackChunkOnWaypoint, direction).toSet()
+        infra.blockInfra.getBlocksFromTrackChunk(chunkLocationOnWaypoint.chunk, direction).toSet()
     for (block in blocksOnWaypoint) {
         val offset =
-            getBlockOffset(
-                block,
-                trackChunkOnWaypoint,
-                trackSectionId,
-                waypoint.offset,
-                direction,
-                infra,
-            )
+            getBlockOffset(block, waypointDirChunkLocation, infra.rawInfra, infra.blockInfra)
         assert(offset <= infra.blockInfra.getBlockLength(block))
         res.add(BlockLocation(block, offset))
     }
@@ -295,53 +302,50 @@ fun findWaypointBlocks(infra: FullInfra, waypoints: Collection<TrackLocation>): 
     return waypointBlocks
 }
 
-private fun getTrackSectionChunkOnWaypoint(
+private data class DirChunkLocation(
+    val dirChunk: DirTrackChunkId,
+    val offset: Offset<DirTrackChunkId>,
+)
+
+private data class ChunkLocation(val chunk: TrackChunkId, val offset: Offset<TrackChunk>)
+
+private fun getChunkLocationOnWaypoint(
     trackSectionId: TrackSectionId,
     waypointOffset: Offset<TrackSection>,
     rawInfra: RawSignalingInfra,
-): TrackChunkId {
+): ChunkLocation {
     val trackSectionChunks = rawInfra.getTrackSectionChunks(trackSectionId)
-    return trackSectionChunks.firstOrNull { chunk: TrackChunkId ->
+    for (chunk in trackSectionChunks) {
         val startChunk = rawInfra.getTrackChunkOffset(chunk)
         val endChunk = startChunk + rawInfra.getTrackChunkLength(chunk).distance
-        waypointOffset in startChunk..endChunk
+        if (waypointOffset in startChunk..endChunk)
+            return ChunkLocation(chunk, Offset(waypointOffset - startChunk))
     }
-        ?: throw OSRDError(ErrorType.InvalidWaypointLocation)
-            .withContext("track", rawInfra.getTrackSectionName(trackSectionId))
-            .withContext("offset", waypointOffset)
+    throw OSRDError(ErrorType.InvalidWaypointLocation)
+        .withContext("track", rawInfra.getTrackSectionName(trackSectionId))
+        .withContext("offset", waypointOffset)
 }
 
 private fun getBlockOffset(
     blockId: BlockId,
-    trackChunkId: TrackChunkId,
-    trackSectionId: TrackSectionId,
-    waypointOffset: Offset<TrackSection>,
-    direction: Direction,
-    infra: FullInfra,
+    waypointDirChunkLocation: DirChunkLocation,
+    rawInfra: RawInfra,
+    blockInfra: BlockInfra,
 ): Offset<Block> {
-    val trackSectionLength = infra.rawInfra.getTrackSectionLength(trackSectionId)
-    val trackChunkOffset = infra.rawInfra.getTrackChunkOffset(trackChunkId)
-    val trackChunkLength = infra.rawInfra.getTrackChunkLength(trackChunkId)
-    val dirTrackChunkOffset =
-        if (direction == Direction.INCREASING) trackChunkOffset.distance
-        else trackSectionLength.distance - trackChunkOffset.distance - trackChunkLength.distance
-    val dirWaypointOffset =
-        if (direction == Direction.INCREASING) waypointOffset
-        else Offset(trackSectionLength - waypointOffset)
-    var startBlockToStartChunk = 0.meters
-    val blockTrackChunks = infra.blockInfra.getTrackChunksFromBlock(blockId)
+    var startBlockToStartChunk: Offset<Block> = Offset(0.meters)
+    val blockTrackChunks = blockInfra.getTrackChunksFromBlock(blockId)
     for (blockTrackChunkDirId in blockTrackChunks) {
-        val blockTrackChunkId = blockTrackChunkDirId.value
-        if (blockTrackChunkId == trackChunkId) {
-            return Offset(
-                (startBlockToStartChunk + dirWaypointOffset.distance - dirTrackChunkOffset)
-                    .absoluteValue
-            )
+        if (blockTrackChunkDirId == waypointDirChunkLocation.dirChunk) {
+            return startBlockToStartChunk + waypointDirChunkLocation.offset.distance
         }
-        startBlockToStartChunk += infra.rawInfra.getTrackChunkLength(blockTrackChunkId).distance
+        startBlockToStartChunk += rawInfra.getTrackChunkLength(blockTrackChunkDirId.value).distance
     }
     throw AssertionError(
-        String.format("getBlockOffset: Track chunk %s not in block %s", trackChunkId, blockId)
+        String.format(
+            "getBlockOffset: Directed track chunk %s not in block %s",
+            waypointDirChunkLocation.dirChunk,
+            blockId,
+        )
     )
 }
 

--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.kt
@@ -19,7 +19,6 @@ import fr.sncf.osrd.pathfinding.constraints.initConstraintsFromRSProps
 import fr.sncf.osrd.reporting.exceptions.ErrorType
 import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.sim_infra.api.*
-import fr.sncf.osrd.stdcm.infra_exploration.BlockLocation
 import fr.sncf.osrd.stdcm.infra_exploration.ExplorerStep
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorer
 import fr.sncf.osrd.utils.*

--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.kt
@@ -20,6 +20,7 @@ import fr.sncf.osrd.reporting.exceptions.ErrorType
 import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.stdcm.infra_exploration.BlockLocation
+import fr.sncf.osrd.stdcm.infra_exploration.ExplorerStep
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorer
 import fr.sncf.osrd.utils.*
 import fr.sncf.osrd.utils.units.Length
@@ -93,7 +94,7 @@ class PathfindingBlocksEndpoint(private val infraManager: InfraProvider) : Take 
 @Throws(OSRDError::class)
 fun runPathfinding(infra: FullInfra, request: PathfindingBlockRequest): PathfindingBlockResponse {
     // Parse the waypoints
-    val waypoints = ArrayList<Collection<BlockLocation>>()
+    val targets = ArrayList<ExplorerStep>()
     val destinationTrack = request.pathItems.last()
     val destinationBlock = findWaypointBlocks(infra, destinationTrack.locations)
     request.pathItems.forEachIndexed { stepIndex, step ->
@@ -121,9 +122,9 @@ fun runPathfinding(infra: FullInfra, request: PathfindingBlockRequest): Pathfind
                 }
             }
         }
-        waypoints.add(allStarts)
+        targets.add(ExplorerStep(allStarts, canBacktrack = step.canBacktrack))
     }
-    if (waypoints.size < 2) throw NoPathFoundException(NotEnoughPathItems())
+    if (targets.size < 2) throw NoPathFoundException(NotEnoughPathItems())
     val constraints =
         initConstraintsFromRSProps(
             infra,
@@ -135,14 +136,14 @@ fun runPathfinding(infra: FullInfra, request: PathfindingBlockRequest): Pathfind
 
     // Compute the paths from the entry waypoint to the exit waypoint
     val timeout = request.timeout ?: Pathfinding.TIMEOUT
-    val path = computePaths(infra, waypoints, constraints, request, timeout)
+    val path = computePaths(infra, targets, constraints, request, timeout)
     return runPathfindingPostProcessing(infra, request, path)
 }
 
 @Throws(OSRDError::class)
 private fun computePaths(
     infra: FullInfra,
-    waypoints: ArrayList<Collection<BlockLocation>>,
+    targets: ArrayList<ExplorerStep>,
     constraints: List<PathfindingConstraint>,
     initialRequest: PathfindingBlockRequest,
     timeout: Double,
@@ -151,7 +152,7 @@ private fun computePaths(
     val pathFound =
         Pathfinding(
                 infra,
-                waypoints,
+                targets,
                 constraints,
                 initialRequest.speedLimitTag,
                 initialRequest.rollingStockMaximumSpeed,
@@ -172,7 +173,7 @@ private fun computePaths(
     val elapsedSeconds = Duration.between(start, Instant.now()).toSeconds()
     throwNoPathFoundException(
         infra,
-        waypoints,
+        targets,
         constraints,
         initialRequest,
         timeout.minus(elapsedSeconds),
@@ -196,7 +197,7 @@ fun hasDuplicateTracks(infra: FullInfra, path: TrainPath): Boolean {
 @WithSpan(value = "Identifying why no path was found")
 private fun throwNoPathFoundException(
     infra: FullInfra,
-    waypoints: ArrayList<Collection<BlockLocation>>,
+    targets: ArrayList<ExplorerStep>,
     constraints: Collection<PathfindingConstraint>,
     initialRequest: PathfindingBlockRequest,
     timeout: Double,
@@ -205,7 +206,7 @@ private fun throwNoPathFoundException(
         val possiblePathWithoutErrorNoConstraints =
             Pathfinding(
                     infra,
-                    waypoints,
+                    targets,
                     listOf(),
                     initialRequest.speedLimitTag,
                     initialRequest.rollingStockMaximumSpeed,
@@ -231,16 +232,21 @@ private fun throwNoPathFoundException(
     throw NoPathFoundException(NotFoundInBlocks(listOf(), Length(0.meters)))
 }
 
-data class ProcessedPathfindingResponse(val path: TrainPath, val offsets: List<Offset<PhysicsPath>>)
+data class ProcessedPathfindingResponse(
+    val path: TrainPath,
+    val targetOffsets: List<Offset<PhysicsPath>>,
+    val backtrackingOffsets: List<Offset<PhysicsPath>>,
+)
 
 private fun processPathfindingResponse(
     infra: FullInfra,
     explorer: InfraExplorer,
 ): ProcessedPathfindingResponse {
     val trainPath = explorer.buildFullPath(infra.rawInfra, infra.blockInfra)
-    val stepOffsets =
-        explorer.getStepTracker().getSeenSteps().toList().map { it.travelledPathOffset }
-    return ProcessedPathfindingResponse(trainPath, stepOffsets)
+    val seenSteps = explorer.getStepTracker().getSeenSteps().toList()
+    val stepOffsets = seenSteps.map { it.travelledPathOffset }
+    val backtrackingOffsets = seenSteps.filter { it.isBacktracking }.map { it.travelledPathOffset }
+    return ProcessedPathfindingResponse(trainPath, stepOffsets, backtrackingOffsets)
 }
 
 /**

--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingPostProcessing.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingPostProcessing.kt
@@ -13,7 +13,13 @@ fun runPathfindingPostProcessing(
     initialRequest: PathfindingBlockRequest,
     rawPath: ProcessedPathfindingResponse,
 ): PathfindingBlockSuccess {
-    val res = runPathfindingBlockPostProcessing(infra, rawPath.path, rawPath.offsets)
+    val res =
+        runPathfindingBlockPostProcessing(
+            infra,
+            rawPath.path,
+            rawPath.targetOffsets,
+            rawPath.backtrackingOffsets,
+        )
     validatePathfindingResponse(infra, initialRequest, res)
     return res
 }
@@ -22,12 +28,13 @@ fun runPathfindingBlockPostProcessing(
     infra: FullInfra,
     trainPath: TrainPath,
     waypointOffsets: List<Offset<PhysicsPath>>,
+    backtrackingOffsets: List<Offset<PhysicsPath>>,
 ): PathfindingBlockSuccess {
     return PathfindingBlockSuccess(
         trainPath.toJsonTrainPath(infra.rawInfra, infra.blockInfra),
         trainPath.getLength(),
         waypointOffsets,
-        listOf(),
+        backtrackingOffsets,
     )
 }
 

--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingPostProcessing.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingPostProcessing.kt
@@ -27,6 +27,7 @@ fun runPathfindingBlockPostProcessing(
         trainPath.toJsonTrainPath(infra.rawInfra, infra.blockInfra),
         trainPath.getLength(),
         waypointOffsets,
+        listOf(),
     )
 }
 

--- a/core/src/main/kotlin/fr/sncf/osrd/api/standalone_sim/SimulationRequest.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/standalone_sim/SimulationRequest.kt
@@ -35,6 +35,13 @@ class SimulationRequest(
     @Json(name = "path_item_positions") val pathItemPositions: List<Offset<PhysicsPath>>,
     @Json(name = "backtrack_positions") val backtrackPositions: List<Offset<PhysicsPath>>,
 ) {
+    init {
+        backtrackPositions.forEach { position ->
+            require(pathItemPositions.contains(position))
+            require(schedule.first { it.pathOffset == position }.stopFor != null)
+        }
+    }
+
     companion object {
         val adapter: JsonAdapter<SimulationRequest> =
             Moshi.Builder()

--- a/core/src/main/kotlin/fr/sncf/osrd/api/standalone_sim/SimulationRequest.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/standalone_sim/SimulationRequest.kt
@@ -33,6 +33,7 @@ class SimulationRequest(
     @Json(name = "physics_consist") val physicsConsist: PhysicsConsistModel,
     @Json(name = "electrical_profile_set_id") val electricalProfileSetId: String?,
     @Json(name = "path_item_positions") val pathItemPositions: List<Offset<PhysicsPath>>,
+    @Json(name = "backtrack_positions") val backtrackPositions: List<Offset<PhysicsPath>>,
 ) {
     companion object {
         val adapter: JsonAdapter<SimulationRequest> =

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
@@ -318,8 +318,7 @@ class STDCMEndpoint(
                 provisional = simpleReportTrain,
                 finalOutput = reportTrain,
                 mrsp = makeMRSPResponse(speedLimits),
-                electricalProfiles =
-                    STDCMEndpoint.buildSTDCMElectricalProfiles(path, path.rollingStocks, comfort),
+                electricalProfiles = buildSTDCMElectricalProfiles(path, path.rollingStocks, comfort),
             )
         }
 
@@ -470,8 +469,9 @@ fun parseSteps(
                 max(rollingStockLengths[index], rollingStockLengths.getOrElse(index - 1) { 0.0 })
             ExplorerStep(
                 if (index != 0 && index != pathItems.size - 1) {
-                    val destinationBlock = findWaypointBlocks(infra, pathItems.last().locations)
-                    findWaypointBlocks(infra, it.locations).map { waypointBlock ->
+                    val destinationBlock =
+                        findWaypointBlocks(infra, pathItems.last().pathItem.locations)
+                    findWaypointBlocks(infra, it.pathItem.locations).map { waypointBlock ->
                         findStopPositionAtEndOfBlockConsideringRollingStock(
                             waypointBlock,
                             destinationBlock,
@@ -480,7 +480,7 @@ fun parseSteps(
                         )
                     }
                 } else {
-                    findWaypointBlocks(infra, it.locations)
+                    findWaypointBlocks(infra, it.pathItem.locations)
                 },
                 it.stopDuration?.seconds,
                 it.stopDuration != null,

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
@@ -203,7 +203,12 @@ class STDCMEndpoint(
                 return RsJson(RsWithBody(STDCMFinalResult.adapter.toJson(response)))
             }
             val pathfindingResponse =
-                runPathfindingBlockPostProcessing(infra, path.trainPath, path.waypointOffsets)
+                runPathfindingBlockPostProcessing(
+                    infra,
+                    path.trainPath,
+                    path.waypointOffsets,
+                    path.backtrackingOffsets,
+                )
 
             val simulationResponse =
                 buildSimResponse(
@@ -484,6 +489,7 @@ fun parseSteps(
                 },
                 it.stopDuration?.seconds,
                 it.stopDuration != null,
+                it.pathItem.canBacktrack,
                 if (it.stepTimingData != null)
                     PlannedTimingData(
                         TimeDelta(between(startTime, it.stepTimingData.arrivalTime).toMillis()),

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMRequest.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMRequest.kt
@@ -5,8 +5,8 @@ import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import fr.sncf.osrd.api.DirectionalTrackRange
+import fr.sncf.osrd.api.PathItem
 import fr.sncf.osrd.api.TimetableId
-import fr.sncf.osrd.api.TrackLocation
 import fr.sncf.osrd.api.WorkSchedule
 import fr.sncf.osrd.api.standalone_sim.MarginValue
 import fr.sncf.osrd.api.standalone_sim.MarginValueAdapter
@@ -66,7 +66,7 @@ data class STDCMTemporarySpeedLimit(
 )
 
 class STDCMPathItem(
-    val locations: List<TrackLocation>,
+    @Json(name = "path_item") val pathItem: PathItem,
     @Json(name = "stop_duration") var stopDuration: Duration?,
     @Json(name = "step_timing_data") val stepTimingData: StepTimingData?,
 )

--- a/core/src/main/kotlin/fr/sncf/osrd/graph/Interfaces.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/graph/Interfaces.kt
@@ -2,7 +2,7 @@ package fr.sncf.osrd.graph
 
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockId
-import fr.sncf.osrd.stdcm.infra_exploration.BlockLocation
+import fr.sncf.osrd.sim_infra.api.BlockLocation
 import fr.sncf.osrd.utils.units.OffsetRange
 
 /**

--- a/core/src/main/kotlin/fr/sncf/osrd/pathfinding/Pathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/pathfinding/Pathfinding.kt
@@ -5,6 +5,7 @@ import fr.sncf.osrd.api.pathfinding.pathfindingLogger
 import fr.sncf.osrd.graph.AStarHeuristic
 import fr.sncf.osrd.graph.PathfindingConstraint
 import fr.sncf.osrd.path.interfaces.BlockRange
+import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.pathfinding.constraints.CachedBlockConstraintCombiner
 import fr.sncf.osrd.reporting.exceptions.ErrorType
 import fr.sncf.osrd.reporting.exceptions.OSRDError
@@ -19,6 +20,7 @@ import fr.sncf.osrd.utils.CachedBlockMRSPBuilder
 import fr.sncf.osrd.utils.arePositionsEqual
 import fr.sncf.osrd.utils.areTimesEqual
 import fr.sncf.osrd.utils.units.Distance
+import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import io.opentelemetry.instrumentation.annotations.WithSpan
 import java.time.Duration
@@ -168,7 +170,13 @@ class Pathfinding(
                 CachedBlockConstraintCombiner.getCachedConstraintCombiner(fullInfra, it)
             }
         val startTime = Instant.now()
-        val seenBlocks = HashMap<BlockId, Int>()
+
+        // When exploring a block (last block range of the route here), the decision to try to
+        // backtrack (and where) later on the considered route is already made.
+        // So we have to discriminate blocks used to go to backtracking (and the different
+        // backtracking) and blocks used fully to go straight to the end of the route.
+        data class VisitedKey(val block: BlockId, val nextBacktracking: Offset<PhysicsPath>?)
+        val seenBlocks = HashMap<VisitedKey, Int>()
 
         val startInfraExplorers =
             getStartInfraExplorers(
@@ -217,13 +225,23 @@ class Pathfinding(
             maxSeenTarget = max(nbSeenTargets, maxSeenTarget)
 
             val currentBlock = step.infraExplorer.getCurrentBlock()
-            if (seenBlocks.getOrDefault(currentBlock, -1) >= nbSeenTargets) {
+            val backtrackingOffsetOnBlock =
+                step.infraExplorer
+                    .getStepTracker()
+                    .iterateSeenStepsBackwards()
+                    .takeWhile { it.location.edge == currentBlock }
+                    .firstOrNull { it.isBacktracking }
+                    ?.travelledPathOffset
+            if (
+                seenBlocks.getOrDefault(VisitedKey(currentBlock, backtrackingOffsetOnBlock), -1) >=
+                    nbSeenTargets
+            ) {
                 pathfindingLogger.trace(
-                    "Dropping current search as a more promising search on the same block is already done"
+                    "Dropping current search as a more promising search on the same block and targeting the same backtracking is already done"
                 )
                 continue
             }
-            seenBlocks[currentBlock] = nbSeenTargets
+            seenBlocks[VisitedKey(currentBlock, backtrackingOffsetOnBlock)] = nbSeenTargets
 
             step.infraExplorer.cloneAndExtendLookahead().forEach {
                 registerStep(it, step.establishedCost, step.establishedLength)

--- a/core/src/main/kotlin/fr/sncf/osrd/pathfinding/Pathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/pathfinding/Pathfinding.kt
@@ -36,17 +36,17 @@ const val SIGNALING_SYSTEM_COST_WEIGHTING = 1e-1
 @WithSpan(value = "Building heuristic")
 private fun makeRemainingDistanceHeuristics(
     infra: FullInfra,
-    waypoints: List<Collection<BlockLocation>>,
+    targets: List<ExplorerStep>,
 ): ArrayList<AStarHeuristic> {
     // Compute the minimum distance between steps
-    val stepMinDistance = Array(waypoints.size - 1) { 0.meters }
-    for (i in 0 until waypoints.size - 2) {
+    val stepMinDistance = Array(targets.size - 1) { 0.meters }
+    for (i in 0 until targets.size - 2) {
         stepMinDistance[i] =
             minDistanceBetweenSteps(
                 infra.blockInfra,
                 infra.rawInfra,
-                waypoints[i + 1],
-                waypoints[i + 2],
+                targets[i + 1].locations,
+                targets[i + 2].locations,
             )
     }
 
@@ -57,12 +57,12 @@ private fun makeRemainingDistanceHeuristics(
 
     // Setup estimators foreach intermediate steps
     val remainingCostEstimators = ArrayList<AStarHeuristic>()
-    for (i in 0 until waypoints.size - 1) {
+    for (i in 0 until targets.size - 1) {
         val remainingDistanceEstimator =
             RemainingDistanceEstimator(
                 infra.blockInfra,
                 infra.rawInfra,
-                waypoints[i + 1],
+                targets[i + 1].locations,
                 stepMinDistance[i],
             )
 
@@ -75,14 +75,25 @@ private fun makeRemainingDistanceHeuristics(
 
 class Pathfinding(
     val fullInfra: FullInfra,
-    val waypoints: List<Collection<BlockLocation>>,
+    val inputTargets: List<ExplorerStep>,
     val constraints: List<PathfindingConstraint>?,
     val speedLimitTag: String?,
     val rollingStockMaxSpeed: Double,
     rollingStockLength: Double,
 ) {
+    private val targets =
+        inputTargets.mapIndexed { index, it ->
+            ExplorerStep(
+                it.locations,
+                it.duration,
+                it.stop,
+                if (index > 0 && index < inputTargets.size - 1) it.canBacktrack else false,
+                it.plannedTimingData,
+            )
+        }
+
     init {
-        checkParameters(waypoints)
+        checkParameters(inputTargets)
     }
 
     val mrspBuilder: CachedBlockMRSPBuilder =
@@ -93,7 +104,7 @@ class Pathfinding(
             speedLimitTag,
         )
 
-    val remainingCostEstimators = makeRemainingDistanceHeuristics(fullInfra, waypoints)
+    val remainingCostEstimators = makeRemainingDistanceHeuristics(fullInfra, targets)
 
     private data class Step( // Instance used to explore the infra
         val infraExplorer: InfraExplorer,
@@ -163,7 +174,7 @@ class Pathfinding(
             getStartInfraExplorers(
                 fullInfra.rawInfra,
                 fullInfra.blockInfra,
-                waypoints,
+                targets,
                 constraintCombiner,
             )
         for (infraExplorer in startInfraExplorers) {
@@ -182,7 +193,7 @@ class Pathfinding(
             if (step == null) {
                 // Fail :(
                 pathfindingLogger.info(
-                    "pathfinding failed, # reached waypoints = $maxSeenTarget/${waypoints.size}"
+                    "pathfinding failed, # reached waypoints = $maxSeenTarget/${targets.size}"
                 )
                 return null
             }
@@ -223,20 +234,19 @@ class Pathfinding(
     private fun getStartInfraExplorers(
         rawInfra: RawSignalingInfra,
         blockInfra: BlockInfra,
-        waypoints: List<Collection<BlockLocation>>,
+        targets: List<ExplorerStep>,
         constraints: PathfindingConstraint?,
     ): Collection<InfraExplorer> {
         val res = mutableListOf<InfraExplorer>()
-        val firstStep = waypoints[0]
-        val steps = waypoints.map { ExplorerStep(it) }
-        for (location in firstStep) {
+        val firstLocations = targets[0].locations
+        for (location in firstLocations) {
             val infraExplorers =
                 initInfraExplorers(
                     rawInfra,
                     blockInfra,
                     location,
-                    steps = steps,
-                    constraints = constraints?.let { MutableList(waypoints.size) { _ -> it } },
+                    targets,
+                    constraints?.let { MutableList(targets.size) { _ -> it } },
                 )
             res.addAll(infraExplorers)
         }
@@ -244,7 +254,7 @@ class Pathfinding(
     }
 
     /** Checks that required parameters are set, sets the optional ones to their default values */
-    private fun checkParameters(targets: List<Collection<BlockLocation>>) {
+    private fun checkParameters(targets: List<ExplorerStep>) {
         if (targets.size < 2)
             throw OSRDError(ErrorType.InvalidSTDCMInputs)
                 .withContext("cause", "Not enough steps have been set to find a path")

--- a/core/src/main/kotlin/fr/sncf/osrd/pathfinding/Pathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/pathfinding/Pathfinding.kt
@@ -79,7 +79,7 @@ class Pathfinding(
     val constraints: List<PathfindingConstraint>?,
     val speedLimitTag: String?,
     val rollingStockMaxSpeed: Double,
-    rollingStockLength: Double,
+    val rollingStockLength: Distance,
 ) {
     private val targets =
         inputTargets.mapIndexed { index, it ->
@@ -100,7 +100,7 @@ class Pathfinding(
         CachedBlockMRSPBuilder.getCachedBlockMRSPBuilder(
             fullInfra,
             rollingStockMaxSpeed,
-            rollingStockLength,
+            rollingStockLength.meters,
             speedLimitTag,
         )
 
@@ -244,6 +244,7 @@ class Pathfinding(
                 initInfraExplorers(
                     rawInfra,
                     blockInfra,
+                    rollingStockLength,
                     location,
                     targets,
                     constraints?.let { MutableList(targets.size) { _ -> it } },

--- a/core/src/main/kotlin/fr/sncf/osrd/pathfinding/Pathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/pathfinding/Pathfinding.kt
@@ -10,8 +10,8 @@ import fr.sncf.osrd.reporting.exceptions.ErrorType
 import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.sim_infra.api.BlockInfra
+import fr.sncf.osrd.sim_infra.api.BlockLocation
 import fr.sncf.osrd.sim_infra.api.RawSignalingInfra
-import fr.sncf.osrd.stdcm.infra_exploration.BlockLocation
 import fr.sncf.osrd.stdcm.infra_exploration.ExplorerStep
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorer
 import fr.sncf.osrd.stdcm.infra_exploration.initInfraExplorers

--- a/core/src/main/kotlin/fr/sncf/osrd/pathfinding/RemainingDistanceEstimator.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/pathfinding/RemainingDistanceEstimator.kt
@@ -5,9 +5,9 @@ import fr.sncf.osrd.graph.AStarHeuristic
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.sim_infra.api.BlockInfra
+import fr.sncf.osrd.sim_infra.api.BlockLocation
 import fr.sncf.osrd.sim_infra.api.RawSignalingInfra
 import fr.sncf.osrd.sim_infra.api.TrackChunk
-import fr.sncf.osrd.stdcm.infra_exploration.BlockLocation
 import fr.sncf.osrd.utils.Direction
 import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Length

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
@@ -604,7 +604,7 @@ private fun findLimitingSignal(
         for (curSignalIndex in (signalIndexStart until blockSignals.size).reversed()) {
             val signal = blockSignals[curSignalIndex]
 
-            // ignore unseen signals before the start of the travelled path
+            // ignore unseen signals before the start of the traveled path
             val signalTravelledOffset =
                 blockRange.offsetToTrainPath(blockSignalOffsets[curSignalIndex])
             if (signalTravelledOffset < Offset.zero()) break

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMResult.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMResult.kt
@@ -22,5 +22,6 @@ data class STDCMResult(
     val departureTime: Double,
     val stopResults: List<TrainStop>,
     val waypointOffsets: List<Offset<PhysicsPath>>,
+    val backtrackingOffsets: List<Offset<PhysicsPath>>,
     val engineeringAllowanceRanges: List<EngineeringAllowanceRange>,
 )

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
@@ -76,6 +76,7 @@ class STDCMPostProcessing(private val graph: STDCMGraph) {
                 stops,
                 updatedTimeData,
             )
+        val seenSteps = lastExplorer.getStepTracker().getSeenSteps().toList()
         val res =
             STDCMResult(
                 withAllowance.envelope,
@@ -88,9 +89,8 @@ class STDCMPostProcessing(private val graph: STDCMGraph) {
                 // Allow us to display OP, a hack that will be fixed
                 // after the redesign of simulation data models
                 makePathStops(stops, trainPath),
-                lastExplorer.getStepTracker().getSeenSteps().toList().map {
-                    it.travelledPathOffset
-                },
+                seenSteps.map { it.travelledPathOffset },
+                seenSteps.filter { it.isBacktracking }.map { it.travelledPathOffset },
                 withAllowance.engineeringAllowanceRanges,
             )
         return if (res.envelope.totalTime > maxRunTime) {

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
@@ -419,52 +419,51 @@ private class InfraExplorerImpl(
 
         for (block in routeBlocks) {
             seenFirstBlock = seenFirstBlock || block == firstLocation?.edge
-            if (seenFirstBlock) {
-                val startsPath = !pathAlreadyStarted
-                blockRoutes[block] = route
 
-                // Simulation range start on the current block, 0m on any block that isn't the first
-                val blockStartOffset: Offset<Block> =
-                    if (startsPath) firstLocation!!.offset else Offset.zero()
+            if (!seenFirstBlock) continue
 
-                val blockLength = blockInfra.getBlockLength(block)
+            val startsPath = !pathAlreadyStarted
+            blockRoutes[block] = route
 
-                stepTracker.exploreBlockRange(block, blockStartOffset, blockLength)
+            // Simulation range start on the current block, 0m on any block that isn't the first
+            val blockStartOffset: Offset<Block> =
+                if (startsPath) firstLocation!!.offset else Offset.zero()
 
-                val lastSeenStepLocation = stepTracker.getSeenSteps().lastOrNull()?.location
-                isPathComplete =
-                    stepTracker.hasSeenDestination() && lastSeenStepLocation?.edge == block
-                val blockEndOffset =
-                    if (isPathComplete) lastSeenStepLocation!!.offset else blockLength
+            val blockLength = blockInfra.getBlockLength(block)
 
-                val stepIndex =
-                    max(0, stepTracker.iterateSeenStepsBackwards().count { it.isPlanned } - 1)
+            stepTracker.exploreBlockRange(block, blockStartOffset, blockLength)
 
-                // If a block cannot be explored, give up
-                val isRouteBlocked =
-                    constraints?.get(stepIndex)?.apply(block)?.any {
-                        blockStartOffset < it.end && blockEndOffset > it.start
-                    } ?: false
-                if (isRouteBlocked) return false
+            val lastSeenStepLocation = stepTracker.getSeenSteps().lastOrNull()?.location
+            isPathComplete = stepTracker.hasSeenDestination() && lastSeenStepLocation?.edge == block
+            val blockEndOffset = if (isPathComplete) lastSeenStepLocation!!.offset else blockLength
 
-                val rangePathBegin = getLookaheadEndOffset()
-                val rangePathEnd = rangePathBegin + (blockEndOffset - blockStartOffset)
+            val stepIndex =
+                max(0, stepTracker.iterateSeenStepsBackwards().count { it.isPlanned } - 1)
 
-                if (rangePathBegin > rangePathEnd) continue
+            // If a block cannot be explored, give up
+            val isRouteBlocked =
+                constraints?.get(stepIndex)?.apply(block)?.any {
+                    blockStartOffset < it.end && blockEndOffset > it.start
+                } ?: false
+            if (isRouteBlocked) return false
 
-                val blockRange =
-                    BlockRange(
-                        value = block,
-                        objectBegin = blockStartOffset,
-                        objectEnd = blockEndOffset,
-                        pathBegin = rangePathBegin,
-                        pathEnd = rangePathEnd,
-                        objectLength = blockLength,
-                    )
-                blockRanges.add(blockRange)
-                pathAlreadyStarted = true
-                if (isPathComplete) break // Can't extend any further
-            }
+            val rangePathBegin = getLookaheadEndOffset()
+            val rangePathEnd = rangePathBegin + (blockEndOffset - blockStartOffset)
+
+            if (rangePathBegin > rangePathEnd) continue
+
+            val blockRange =
+                BlockRange(
+                    value = block,
+                    objectBegin = blockStartOffset,
+                    objectEnd = blockEndOffset,
+                    pathBegin = rangePathBegin,
+                    pathEnd = rangePathEnd,
+                    objectLength = blockLength,
+                )
+            blockRanges.add(blockRange)
+            pathAlreadyStarted = true
+            if (isPathComplete) break // Can't extend any further
         }
         assert(seenFirstBlock)
         return true

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
@@ -403,7 +403,6 @@ private class InfraExplorerImpl(
     fun extend(route: RouteId, firstLocation: BlockLocation? = null): Boolean {
         val routeBlocks = blockInfra.getRouteBlocks(rawInfra, route)
         var seenFirstBlock = firstLocation == null
-        var pathAlreadyStarted = blockRanges.isNotEmpty()
 
         var routeBeginOffset = Offset<Route>(firstLocation?.offset?.distance ?: 0.meters)
         for (block in routeBlocks) {
@@ -416,12 +415,11 @@ private class InfraExplorerImpl(
                 continue
             }
 
-            val startsPath = !pathAlreadyStarted
             blockRoutes[block] = route
 
             // Simulation range start on the current block, 0m on any block that isn't the first
             val blockStartOffset: Offset<Block> =
-                if (startsPath) firstLocation!!.offset else Offset.zero()
+                if (block == firstLocation?.edge) firstLocation.offset else Offset(0.meters)
 
             stepTracker.exploreBlockRange(block, blockStartOffset, blockLength)
 
@@ -454,7 +452,6 @@ private class InfraExplorerImpl(
                     objectLength = blockLength,
                 )
             blockRanges.add(blockRange)
-            pathAlreadyStarted = true
             if (isPathComplete) break // Can't extend any further
         }
         assert(seenFirstBlock)

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
@@ -156,8 +156,6 @@ interface EdgeIdentifier {
     override fun hashCode(): Int
 }
 
-data class BlockLocation(val edge: BlockId, val offset: Offset<Block>)
-
 data class ExplorerStep(
     val locations: Collection<BlockLocation>,
     val duration: Double? = null,

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
@@ -401,26 +401,20 @@ private class InfraExplorerImpl(
      * updated to keep track of the route used for each block.
      */
     fun extend(route: RouteId, firstLocation: BlockLocation? = null): Boolean {
-        val lastRouteEndOffset = getLookaheadEndOffset()
-        val routeLength = rawInfra.getRouteLength(route)
-        routes.add(
-            RouteRange(
-                route,
-                Offset.zero(),
-                routeLength,
-                lastRouteEndOffset,
-                lastRouteEndOffset + routeLength.distance,
-                routeLength,
-            )
-        )
         val routeBlocks = blockInfra.getRouteBlocks(rawInfra, route)
         var seenFirstBlock = firstLocation == null
         var pathAlreadyStarted = blockRanges.isNotEmpty()
 
+        var routeBeginOffset = Offset<Route>(firstLocation?.offset?.distance ?: 0.meters)
         for (block in routeBlocks) {
+            val blockLength = blockInfra.getBlockLength(block)
+
             seenFirstBlock = seenFirstBlock || block == firstLocation?.edge
 
-            if (!seenFirstBlock) continue
+            if (!seenFirstBlock) {
+                routeBeginOffset += blockLength.distance
+                continue
+            }
 
             val startsPath = !pathAlreadyStarted
             blockRoutes[block] = route
@@ -428,8 +422,6 @@ private class InfraExplorerImpl(
             // Simulation range start on the current block, 0m on any block that isn't the first
             val blockStartOffset: Offset<Block> =
                 if (startsPath) firstLocation!!.offset else Offset.zero()
-
-            val blockLength = blockInfra.getBlockLength(block)
 
             stepTracker.exploreBlockRange(block, blockStartOffset, blockLength)
 
@@ -466,6 +458,23 @@ private class InfraExplorerImpl(
             if (isPathComplete) break // Can't extend any further
         }
         assert(seenFirstBlock)
+
+        val lastRouteEndOffset = routes.lastOrNull()?.pathEnd ?: Offset(0.meters)
+        val newRouteEndOffset = blockRanges.lastOrNull()?.pathEnd ?: Offset(0.meters)
+        val routeLengthAdded = newRouteEndOffset - lastRouteEndOffset
+        val routeLength = rawInfra.getRouteLength(route)
+
+        routes.add(
+            RouteRange(
+                route,
+                routeBeginOffset,
+                routeBeginOffset + routeLengthAdded,
+                lastRouteEndOffset,
+                newRouteEndOffset,
+                routeLength,
+            )
+        )
+
         return true
     }
 

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
@@ -172,6 +172,7 @@ data class ExplorerStep(
 fun initInfraExplorers(
     rawInfra: RawInfra,
     blockInfra: BlockInfra,
+    rollingStockLength: Distance,
     location: BlockLocation,
     targets: List<ExplorerStep> = listOf(),
     constraints: List<PathfindingConstraint>? = null,
@@ -188,6 +189,7 @@ fun initInfraExplorers(
             InfraExplorerImpl(
                 rawInfra,
                 blockInfra,
+                rollingStockLength,
                 appendOnlyLinkedListOf(),
                 appendOnlyLinkedListOf(),
                 appendOnlyMapOf(),
@@ -205,6 +207,7 @@ fun initInfraExplorers(
 private class InfraExplorerImpl(
     private val rawInfra: RawInfra,
     private val blockInfra: BlockInfra,
+    private val rollingStockLength: Distance,
     private var blockRanges: AppendOnlyLinkedList<BlockRange>,
     private var routes: AppendOnlyLinkedList<RouteRange>,
     private var blockRoutes: AppendOnlyMap<BlockId, RouteId>,
@@ -312,6 +315,7 @@ private class InfraExplorerImpl(
         return InfraExplorerImpl(
             this.rawInfra,
             this.blockInfra,
+            this.rollingStockLength,
             this.blockRanges.shallowCopy(),
             this.routes.shallowCopy(),
             this.blockRoutes.shallowCopy(),

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
@@ -400,15 +400,15 @@ private class InfraExplorerImpl(
      * Otherwise, it returns false and the instance is supposed to be dropped. `blockRoutes` is
      * updated to keep track of the route used for each block.
      */
-    fun extend(route: RouteId, firstLocation: BlockLocation? = null): Boolean {
+    fun extend(route: RouteId, fromLocation: BlockLocation? = null): Boolean {
         val routeBlocks = blockInfra.getRouteBlocks(rawInfra, route)
-        var seenFirstBlock = firstLocation == null
+        var seenFirstBlock = fromLocation == null
 
-        var routeBeginOffset = Offset<Route>(firstLocation?.offset?.distance ?: 0.meters)
+        var routeBeginOffset = Offset<Route>(fromLocation?.offset?.distance ?: 0.meters)
         for (block in routeBlocks) {
             val blockLength = blockInfra.getBlockLength(block)
 
-            seenFirstBlock = seenFirstBlock || block == firstLocation?.edge
+            seenFirstBlock = seenFirstBlock || block == fromLocation?.edge
 
             if (!seenFirstBlock) {
                 routeBeginOffset += blockLength.distance
@@ -419,7 +419,7 @@ private class InfraExplorerImpl(
 
             // Simulation range start on the current block, 0m on any block that isn't the first
             val blockStartOffset: Offset<Block> =
-                if (block == firstLocation?.edge) firstLocation.offset else Offset(0.meters)
+                if (block == fromLocation?.edge) fromLocation.offset else Offset(0.meters)
 
             stepTracker.exploreBlockRange(block, blockStartOffset, blockLength)
 

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
@@ -162,6 +162,7 @@ data class ExplorerStep(
     val locations: Collection<BlockLocation>,
     val duration: Double? = null,
     val stop: Boolean = false,
+    val canBacktrack: Boolean = false,
     val plannedTimingData: PlannedTimingData? = null,
 )
 
@@ -174,10 +175,10 @@ fun initInfraExplorers(
     rawInfra: RawInfra,
     blockInfra: BlockInfra,
     location: BlockLocation,
-    steps: List<ExplorerStep> = listOf(),
+    targets: List<ExplorerStep> = listOf(),
     constraints: List<PathfindingConstraint>? = null,
 ): Collection<InfraExplorer> {
-    require(constraints == null || steps.isEmpty() || constraints.size == steps.size)
+    require(constraints == null || targets.isEmpty() || constraints.size == targets.size)
     val infraExplorers = mutableListOf<InfraExplorer>()
     val block = location.edge
     val pathProps = buildTrainPathFromBlock(rawInfra, blockInfra, block)
@@ -194,7 +195,7 @@ fun initInfraExplorers(
                 appendOnlyMapOf(),
                 null,
                 blockToPathProperties,
-                stepTracker = StepTracker(steps),
+                stepTracker = StepTracker(targets),
                 constraints = constraints,
             )
         val infraExtended = infraExplorer.extend(route, location)

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
@@ -5,16 +5,19 @@ import fr.sncf.osrd.graph.PathfindingConstraint
 import fr.sncf.osrd.path.implementations.buildTrainPathFromBlock
 import fr.sncf.osrd.path.implementations.buildTrainPathFromBlockRanges
 import fr.sncf.osrd.path.interfaces.BlockRange
+import fr.sncf.osrd.path.interfaces.DirChunkRange
 import fr.sncf.osrd.path.interfaces.GenericLinearRange
 import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.path.interfaces.RouteRange
 import fr.sncf.osrd.path.interfaces.TrainPath
+import fr.sncf.osrd.path.interfaces.mapSubObjects
 import fr.sncf.osrd.path.interfaces.subRange
 import fr.sncf.osrd.path.legacy_objects.ElectricalProfileMapping
 import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.sim_infra.utils.getRouteBlocks
 import fr.sncf.osrd.sim_infra.utils.routesOnBlock
+import fr.sncf.osrd.stdcm.graph.logger
 import fr.sncf.osrd.utils.AppendOnlyLinkedList
 import fr.sncf.osrd.utils.AppendOnlyMap
 import fr.sncf.osrd.utils.appendOnlyLinkedListOf
@@ -22,7 +25,9 @@ import fr.sncf.osrd.utils.appendOnlyMapOf
 import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
+import fr.sncf.osrd.utils.units.forceDirected
 import fr.sncf.osrd.utils.units.meters
+import fr.sncf.osrd.utils.units.toOpposite
 import java.util.*
 import kotlin.math.max
 import kotlin.to
@@ -208,7 +213,11 @@ private class InfraExplorerImpl(
     private val rawInfra: RawInfra,
     private val blockInfra: BlockInfra,
     private val rollingStockLength: Distance,
+    // the "teleporting" part during backtracking (tail location becomes head location) is skipped
+    // so there is a spatial discontinuity in this range list
     private var blockRanges: AppendOnlyLinkedList<BlockRange>,
+    // the "teleporting" part during backtracking (tail location becomes head location) is skipped
+    // so there is a spatial discontinuity in this range list
     private var routes: AppendOnlyLinkedList<RouteRange>,
     private var blockRoutes: AppendOnlyMap<BlockId, RouteId>,
     private var lastTrack: TrackSectionId?,
@@ -251,16 +260,56 @@ private class InfraExplorerImpl(
     override fun cloneAndExtendLookahead(): Collection<InfraExplorer> {
         if (isPathComplete) return listOf() // Can't extend beyond the destination
         val infraExplorers = mutableListOf<InfraExplorer>()
-        val lastRoute = routes.last().value
-        val lastRouteExit = rawInfra.getRouteExit(lastRoute)
-        val nextRoutes = rawInfra.getRoutesStartingAtDet(lastRouteExit)
-        nextRoutes.forEach {
+
+        val lastSeenStep = stepTracker.getSeenSteps().lastOrNull()
+        val nextRouteToBlockLocations = getNextRouteToBlockLocations(lastSeenStep)
+        nextRouteToBlockLocations.forEach { (route, blockLocation) ->
             val infraExplorer = this.clone() as InfraExplorerImpl
-            val infraExtended = infraExplorer.extend(it)
+            val infraExtended = infraExplorer.extend(route, blockLocation)
             // Blocked explorers are dropped
             if (infraExtended) infraExplorers.add(infraExplorer)
+
+            // generate lookaheads until all possible backtracking locations (and let future extend
+            // handle the rest)
+            val nbAddedSteps =
+                infraExplorer.stepTracker.getSeenSteps().size - this.stepTracker.getSeenSteps().size
+            val isLastStepArrival = infraExplorer.isPathComplete
+            val possibleBacktrackingSteps =
+                infraExplorer.stepTracker
+                    .iterateSeenStepsBackwards()
+                    .take(nbAddedSteps)
+                    .drop(if (isLastStepArrival) 1 else 0) // ignore arrival even if canBacktrack
+                    .filter { step -> step.originalStep.canBacktrack }
+            for (possibleBacktracking in possibleBacktrackingSteps) {
+                val explorerToBacktracking = this.clone() as InfraExplorerImpl
+                val extendedToBacktracking =
+                    explorerToBacktracking.extend(
+                        route,
+                        blockLocation,
+                        possibleBacktracking.location,
+                    )
+                if (extendedToBacktracking) infraExplorers.add(explorerToBacktracking)
+            }
         }
         return infraExplorers
+    }
+
+    private fun getNextRouteToBlockLocations(
+        lastSeenStep: LocatedStep?
+    ): Map<RouteId, BlockLocation?> {
+        if (
+            lastSeenStep != null &&
+                lastSeenStep.isBacktracking &&
+                lastSeenStep.travelledPathOffset == blockRanges.lastOrNull()?.pathEnd
+        ) {
+            // backtracking step at the end of the current path: generate backtracking routes
+            return getRouteToBlockLocationsAfterBacktracking(lastSeenStep)
+        }
+
+        // generate routes starting after the last one
+        val lastRoute = routes.last().value
+        val lastRouteExit = rawInfra.getRouteExit(lastRoute)
+        return rawInfra.getRoutesStartingAtDet(lastRouteExit).associateWith { null }
     }
 
     override fun moveForward(): InfraExplorer {
@@ -364,6 +413,7 @@ private class InfraExplorerImpl(
             .takeWhile { from <= it.pathEnd }
             .toList()
             .asReversed()
+            // TODO: implement subRange for AppendOnlyLinkedList<GenericLinearRange>.
             .subRange(from, to)
     }
 
@@ -402,9 +452,16 @@ private class InfraExplorerImpl(
      * Otherwise, it returns false and the instance is supposed to be dropped. `blockRoutes` is
      * updated to keep track of the route used for each block.
      */
-    fun extend(route: RouteId, fromLocation: BlockLocation? = null): Boolean {
+    fun extend(
+        route: RouteId,
+        fromLocation: BlockLocation? = null,
+        untilBacktrackingLocation: BlockLocation? = null,
+    ): Boolean {
         val routeBlocks = blockInfra.getRouteBlocks(rawInfra, route)
+        if (routeBlocks.isEmpty()) return false
+
         var seenFirstBlock = fromLocation == null
+        var isBacktrackingBlockReached = false
 
         var routeBeginOffset = Offset<Route>(fromLocation?.offset?.distance ?: 0.meters)
         for (block in routeBlocks) {
@@ -419,15 +476,25 @@ private class InfraExplorerImpl(
 
             blockRoutes[block] = route
 
-            // Simulation range start on the current block, 0m on any block that isn't the first
+            // Simulation range start on the current block, 0m on any block that isn't the first or
+            // just after backtracking
             val blockStartOffset: Offset<Block> =
                 if (block == fromLocation?.edge) fromLocation.offset else Offset(0.meters)
 
-            stepTracker.exploreBlockRange(block, blockStartOffset, blockLength)
+            isBacktrackingBlockReached = block == untilBacktrackingLocation?.edge
+            val untilOffset =
+                if (isBacktrackingBlockReached) untilBacktrackingLocation!!.offset else blockLength
+
+            stepTracker.exploreBlockRange(
+                block,
+                blockStartOffset,
+                untilOffset,
+                isBacktrackingBlockReached,
+            )
 
             val lastSeenStepLocation = stepTracker.getSeenSteps().lastOrNull()?.location
             isPathComplete = stepTracker.hasSeenDestination() && lastSeenStepLocation?.edge == block
-            val blockEndOffset = if (isPathComplete) lastSeenStepLocation!!.offset else blockLength
+            val blockEndOffset = if (isPathComplete) lastSeenStepLocation!!.offset else untilOffset
 
             val stepIndex =
                 max(0, stepTracker.iterateSeenStepsBackwards().count { it.isPlanned } - 1)
@@ -454,9 +521,10 @@ private class InfraExplorerImpl(
                     objectLength = blockLength,
                 )
             blockRanges.add(blockRange)
-            if (isPathComplete) break // Can't extend any further
+            if (isPathComplete || isBacktrackingBlockReached) break // Can't extend any further
         }
         assert(seenFirstBlock)
+        assert(untilBacktrackingLocation == null || isBacktrackingBlockReached)
 
         val lastRouteEndOffset = routes.lastOrNull()?.pathEnd ?: Offset(0.meters)
         val newRouteEndOffset = blockRanges.lastOrNull()?.pathEnd ?: Offset(0.meters)
@@ -481,6 +549,125 @@ private class InfraExplorerImpl(
         // Not everything is printed, this is what feels the most comfortable in a debugging window
         return String.format("currentBlock=%s, lookahead=%s", getCurrentBlock(), getLookahead())
     }
+
+    private fun getRouteToBlockLocationsAfterBacktracking(
+        headStepBeforeBacktracking: LocatedStep
+    ): Map<RouteId, BlockLocation> {
+        val chunksUnderTrainAfterBacktracking =
+            getDirChunksUnderTrainAfterBacktracking(headStepBeforeBacktracking)
+
+        val headRestartBlockLocations =
+            getHeadRestartBlockLocationsAfterBacktracking(headStepBeforeBacktracking)
+
+        val routePathsUnderTrainAfterBacktracking =
+            rawInfra.chunksToRoutePaths(chunksUnderTrainAfterBacktracking)
+        val routesOnHeadRestart =
+            routePathsUnderTrainAfterBacktracking
+                .map { it.last() } // only the last route is useful
+                .toSet()
+
+        val result = mutableMapOf<RouteId, BlockLocation>()
+
+        routesOnHeadRestart.forEach { headRestartRoute ->
+            val lastRouteBlocks = blockInfra.getRouteBlocks(rawInfra, headRestartRoute)
+            if (lastRouteBlocks.isEmpty()) return@forEach
+
+            val headRestartBlockLocation =
+                headRestartBlockLocations.firstOrNull { it.edge in lastRouteBlocks }
+            if (headRestartBlockLocation == null) {
+                logger.warn(
+                    "Route ${rawInfra.getRouteName(headRestartRoute)} has no block listed in restart locations"
+                )
+                return@forEach
+            }
+
+            result[headRestartRoute] = headRestartBlockLocation
+        }
+
+        return result
+    }
+
+    /**
+     * During backtracking, head of the train is "teleported" to the former tail location.
+     *
+     * From the head location before backtracking, compute the tail location, then obtain all the
+     * possible block-location at that location corresponding to the opposite direction
+     */
+    private fun getHeadRestartBlockLocationsAfterBacktracking(
+        headStepBeforeBacktracking: LocatedStep
+    ): List<BlockLocation> {
+        val tailOffsetBeforeBacktracking =
+            Offset.max(
+                headStepBeforeBacktracking.travelledPathOffset - rollingStockLength,
+                Offset(0.meters),
+            )
+        val tailBlockRangeBeforeBacktracking =
+            blockRanges.iterateBackwards().first { it.pathBegin <= tailOffsetBeforeBacktracking }
+        val possibleRestartBlockLocations =
+            getOppositeBlockLocations(
+                BlockLocation(
+                    tailBlockRangeBeforeBacktracking.value,
+                    Offset(
+                        tailOffsetBeforeBacktracking -
+                            tailBlockRangeBeforeBacktracking.objectAbsolutePathStart
+                    ),
+                ),
+                blockInfra,
+                rawInfra,
+            )
+        return possibleRestartBlockLocations
+    }
+
+    private fun getDirChunksUnderTrainAfterBacktracking(
+        headStepBeforeBacktracking: LocatedStep
+    ): List<DirTrackChunkId> {
+        val blockRangesUnderTrainBeforeBacktracking =
+            getSubRanges(
+                blockRanges,
+                headStepBeforeBacktracking.travelledPathOffset - rollingStockLength,
+                headStepBeforeBacktracking.travelledPathOffset,
+            )
+        val chunkRangesUnderTrainBeforeBacktracking: List<DirChunkRange> =
+            blockRangesUnderTrainBeforeBacktracking.mapSubObjects(
+                blockInfra::getTrackChunksFromBlock
+            ) {
+                rawInfra.getTrackChunkLength(it.value).forceDirected()
+            }
+        return chunkRangesUnderTrainBeforeBacktracking.map { it.value.opposite }.asReversed()
+    }
+}
+
+/**
+ * From a given block location, return all the block locations corresponding to the opposite
+ * direction
+ */
+private fun getOppositeBlockLocations(
+    blockLocation: BlockLocation,
+    blockInfra: BlockInfra,
+    rawInfra: RawInfra,
+): List<BlockLocation> {
+    val dirChunkLocation = blockInfra.getDirChunkLocation(blockLocation, rawInfra)
+    val oppositeDirChunkLocation =
+        DirChunkLocation(
+            dirChunkLocation.dirChunk.opposite,
+            dirChunkLocation.offset.toOpposite(
+                rawInfra.getTrackChunkLength(dirChunkLocation.dirChunk.value)
+            ),
+        )
+    val oppositeBlocks =
+        blockInfra
+            .getBlocksFromTrackChunk(
+                oppositeDirChunkLocation.dirChunk.value,
+                oppositeDirChunkLocation.dirChunk.direction,
+            )
+            .toSet()
+    val oppositeBlockLocations = mutableListOf<BlockLocation>()
+    for (block in oppositeBlocks) {
+        val offset = blockInfra.getBlockOffset(block, oppositeDirChunkLocation, rawInfra)
+        assert(offset <= blockInfra.getBlockLength(block))
+        oppositeBlockLocations.add(BlockLocation(block, offset))
+    }
+    return oppositeBlockLocations
 }
 
 private class EdgeIdentifierImpl(private val blocks: List<BlockId>) : EdgeIdentifier {

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelope.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelope.kt
@@ -17,6 +17,7 @@ import fr.sncf.osrd.utils.units.Duration
 import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.TimeDelta
+import fr.sncf.osrd.utils.units.meters
 import kotlin.math.abs
 
 /**
@@ -125,6 +126,7 @@ fun initInfraExplorerWithEnvelope(
     return initInfraExplorers(
             fullInfra.rawInfra,
             fullInfra.blockInfra,
+            consistSchedule.rollingStocks.first().length.meters,
             location,
             targets = targets,
             consistSchedule.constraints,

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelope.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelope.kt
@@ -119,13 +119,13 @@ fun initInfraExplorerWithEnvelope(
     fullInfra: FullInfra,
     location: BlockLocation,
     consistSchedule: ConsistSchedule,
-    steps: List<ExplorerStep> = listOf(),
+    targets: List<ExplorerStep> = listOf(),
 ): Collection<InfraExplorerWithEnvelope> {
     return initInfraExplorers(
             fullInfra.rawInfra,
             fullInfra.blockInfra,
             location,
-            steps = steps,
+            targets = targets,
             consistSchedule.constraints,
         )
         .map { explorer ->

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelope.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelope.kt
@@ -8,6 +8,7 @@ import fr.sncf.osrd.envelope.Envelope
 import fr.sncf.osrd.envelope.EnvelopeTimeInterpolate
 import fr.sncf.osrd.envelope_sim.PhysicsRollingStock
 import fr.sncf.osrd.path.interfaces.PhysicsPath
+import fr.sncf.osrd.sim_infra.api.BlockLocation
 import fr.sncf.osrd.stdcm.graph.TimeData
 import fr.sncf.osrd.train.TrainStop
 import fr.sncf.osrd.utils.DistanceRangeMap

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/StepTracker.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/StepTracker.kt
@@ -76,8 +76,19 @@ class StepTracker(
 
             val isBacktrackingStep =
                 isBacktrackingAtEnd && location.offset == rangeEnd && step.canBacktrack
+            val explorerStep =
+                ExplorerStep(
+                    step.locations,
+                    // If the step is a backtracking location, it has to mark a stop.
+                    duration =
+                        if (isBacktrackingStep && step.duration == null) 0.0 else step.duration,
+                    stop = step.stop || isBacktrackingStep,
+                    step.canBacktrack,
+                    step.plannedTimingData,
+                )
 
-            val newStep = LocatedStep(currentPathOffset, location, step, true, isBacktrackingStep)
+            val newStep =
+                LocatedStep(currentPathOffset, location, explorerStep, true, isBacktrackingStep)
             res.add(newStep)
             seenSteps.add(newStep)
             if (isBacktrackingStep) break
@@ -141,5 +152,7 @@ data class LocatedStep(
 ) {
     init {
         assert(originalStep.locations.contains(location))
+        // If the step is a backtracking location, it has to mark a stop.
+        assert(!isBacktracking || (originalStep.stop && originalStep.duration != null))
     }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/StepTracker.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/StepTracker.kt
@@ -128,6 +128,8 @@ data class LocatedStep(
     val location: BlockLocation,
     val originalStep: ExplorerStep,
     val isPlanned: Boolean = true, // Set to false for overtakes (when implemented)
+    // /!\ A step can allow backtracking but actually not backtrack /!\
+    val isBacktracking: Boolean = false,
 ) {
     init {
         assert(originalStep.locations.contains(location))

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/StepTracker.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/StepTracker.kt
@@ -60,6 +60,7 @@ class StepTracker(
         block: BlockId,
         rangeStart: Offset<Block>,
         rangeEnd: Offset<Block>, // No default value as we need the infra to know the block len
+        isBacktrackingAtEnd: Boolean,
     ): List<LocatedStep> {
         val res = mutableListOf<LocatedStep>()
 
@@ -72,10 +73,16 @@ class StepTracker(
                     .filter { it.offset in currentPathBlockOffset..rangeEnd }
                     .minByOrNull { it.offset } ?: break
             currentPathOffset = currentBlockStart + location.offset.distance
-            val newStep = LocatedStep(currentPathOffset, location, step)
+
+            val isBacktrackingStep =
+                isBacktrackingAtEnd && location.offset == rangeEnd && step.canBacktrack
+
+            val newStep = LocatedStep(currentPathOffset, location, step, true, isBacktrackingStep)
             res.add(newStep)
             seenSteps.add(newStep)
+            if (isBacktrackingStep) break
         }
+        assert(!isBacktrackingAtEnd || res.last().isBacktracking)
         currentPathOffset = currentBlockStart + rangeEnd.distance
         return res
     }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/StepTracker.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/StepTracker.kt
@@ -3,6 +3,7 @@ package fr.sncf.osrd.stdcm.infra_exploration
 import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockId
+import fr.sncf.osrd.sim_infra.api.BlockLocation
 import fr.sncf.osrd.utils.AppendOnlyLinkedList
 import fr.sncf.osrd.utils.appendOnlyLinkedListOf
 import fr.sncf.osrd.utils.dropSeq

--- a/core/src/test/java/fr/sncf/osrd/utils/graph/PathfindingTests.kt
+++ b/core/src/test/java/fr/sncf/osrd/utils/graph/PathfindingTests.kt
@@ -9,6 +9,7 @@ import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.stdcm.infra_exploration.BlockLocation
+import fr.sncf.osrd.stdcm.infra_exploration.ExplorerStep
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorer
 import fr.sncf.osrd.train.RollingStock
 import fr.sncf.osrd.train.TestTrains
@@ -51,9 +52,9 @@ class PathfindingTests {
         infra.addBlock("1", "3", 21.meters)
         val block34 = infra.addBlock("3", "4", 0.meters)
         val waypoints =
-            arrayListOf<Collection<BlockLocation>>(
-                listOf(BlockLocation(block01, Offset(0.meters))),
-                listOf(BlockLocation(block34, Offset(0.meters))),
+            arrayListOf(
+                ExplorerStep(listOf(BlockLocation(block01, Offset(0.meters))), canBacktrack = true),
+                ExplorerStep(listOf(BlockLocation(block34, Offset(0.meters))), canBacktrack = true),
             )
         val res = runPathFinding(waypoints, infra)
         Assertions.assertEquals(
@@ -94,9 +95,9 @@ class PathfindingTests {
         val block13 = infra.addBlock("1", "3", 19.meters)
         val block34 = infra.addBlock("3", "4", 0.meters)
         val waypoints =
-            arrayListOf<Collection<BlockLocation>>(
-                listOf(BlockLocation(block01, Offset(0.meters))),
-                listOf(BlockLocation(block34, Offset(0.meters))),
+            arrayListOf(
+                ExplorerStep(listOf(BlockLocation(block01, Offset(0.meters)))),
+                ExplorerStep(listOf(BlockLocation(block34, Offset(0.meters)))),
             )
         val res = runPathFinding(waypoints, infra)
         Assertions.assertEquals(
@@ -136,13 +137,15 @@ class PathfindingTests {
         val block34 = infra.addBlock("3", "4", 1000.meters, 50.0)
         val block45 = infra.addBlock("4", "5", 2000.meters, 50.0)
         val waypoints =
-            arrayListOf<Collection<BlockLocation>>(
-                listOf(BlockLocation(block01, Offset.zero())),
-                listOf(
-                    BlockLocation(block12, Offset(1000.meters)),
-                    BlockLocation(block13, Offset(1250.meters)),
+            arrayListOf(
+                ExplorerStep(listOf(BlockLocation(block01, Offset.zero()))),
+                ExplorerStep(
+                    listOf(
+                        BlockLocation(block12, Offset(1000.meters)),
+                        BlockLocation(block13, Offset(1250.meters)),
+                    )
                 ),
-                listOf(BlockLocation(block45, Offset(2000.meters))),
+                ExplorerStep(listOf(BlockLocation(block45, Offset(2000.meters)))),
             )
 
         val res = runPathFinding(waypoints, infra)
@@ -188,11 +191,11 @@ class PathfindingTests {
         val block12 = infra.addBlock("1", "2", 10.meters)
         val block23 = infra.addBlock("2", "3", 10.meters)
         val waypoints =
-            arrayListOf<Collection<BlockLocation>>(
-                listOf(BlockLocation(block01, Offset(10.meters))),
-                listOf(BlockLocation(block12, Offset(10.meters))),
-                listOf(BlockLocation(block12, Offset(10.meters))),
-                listOf(BlockLocation(block23, Offset(1.meters))),
+            arrayListOf(
+                ExplorerStep(listOf(BlockLocation(block01, Offset(10.meters)))),
+                ExplorerStep(listOf(BlockLocation(block12, Offset(10.meters)))),
+                ExplorerStep(listOf(BlockLocation(block12, Offset(10.meters)))),
+                ExplorerStep(listOf(BlockLocation(block23, Offset(1.meters)))),
             )
         val res = runPathFinding(waypoints, infra)
         Assertions.assertEquals(
@@ -241,12 +244,14 @@ class PathfindingTests {
         val block45 = infra.addBlock("4", "5", 4.meters)
         val block56 = infra.addBlock("5", "6", 0.meters)
         val waypoints =
-            arrayListOf<Collection<BlockLocation>>(
-                listOf(
-                    BlockLocation(block01, Offset(0.meters)),
-                    BlockLocation(block23, Offset(0.meters)),
+            arrayListOf(
+                ExplorerStep(
+                    listOf(
+                        BlockLocation(block01, Offset(0.meters)),
+                        BlockLocation(block23, Offset(0.meters)),
+                    )
                 ),
-                listOf(BlockLocation(block56, Offset(0.meters))),
+                ExplorerStep(listOf(BlockLocation(block56, Offset(0.meters)))),
             )
         val res = runPathFinding(waypoints, infra)
         Assertions.assertEquals(
@@ -277,11 +282,13 @@ class PathfindingTests {
         val block45 = infra.addBlock("4", "5", 5.meters)
         val block56 = infra.addBlock("5", "6", 0.meters)
         val waypoints =
-            arrayListOf<Collection<BlockLocation>>(
-                listOf(BlockLocation(block01, Offset(0.meters))),
-                listOf(
-                    BlockLocation(block23, Offset(0.meters)),
-                    BlockLocation(block56, Offset(0.meters)),
+            arrayListOf(
+                ExplorerStep(listOf(BlockLocation(block01, Offset(0.meters)))),
+                ExplorerStep(
+                    listOf(
+                        BlockLocation(block23, Offset(0.meters)),
+                        BlockLocation(block56, Offset(0.meters)),
+                    )
                 ),
             )
         val res = runPathFinding(waypoints, infra)
@@ -311,9 +318,9 @@ class PathfindingTests {
         val block31 = infra.addBlock("3", "1", 0.meters)
         val block12 = infra.addBlock("1", "2", 100.meters)
         val waypoints =
-            arrayListOf<Collection<BlockLocation>>(
-                listOf(BlockLocation(block01, Offset(0.meters))),
-                listOf(BlockLocation(block12, Offset(50.meters))),
+            arrayListOf(
+                ExplorerStep(listOf(BlockLocation(block01, Offset(0.meters)))),
+                ExplorerStep(listOf(BlockLocation(block12, Offset(50.meters)))),
             )
         val res = runPathFinding(waypoints, infra)
         Assertions.assertEquals(
@@ -346,9 +353,9 @@ class PathfindingTests {
         infra.addBlock("1", "2", 100.meters)
         val block23 = infra.addBlock("2", "3", 100.meters)
         val waypoints =
-            arrayListOf<Collection<BlockLocation>>(
-                listOf(BlockLocation(block23, Offset(0.meters))),
-                listOf(BlockLocation(block01, Offset(0.meters))),
+            arrayListOf(
+                ExplorerStep(listOf(BlockLocation(block23, Offset(0.meters)))),
+                ExplorerStep(listOf(BlockLocation(block01, Offset(0.meters)))),
             )
         val res = runPathFinding(waypoints, infra)
         Assertions.assertNull(res)
@@ -365,10 +372,10 @@ class PathfindingTests {
         infra.addBlock("1", "2", 100.meters)
         val block23 = infra.addBlock("2", "3", 100.meters)
         val waypoints =
-            arrayListOf<Collection<BlockLocation>>(
-                listOf(BlockLocation(block01, Offset(0.meters))),
-                listOf(BlockLocation(block23, Offset(20.meters))),
-                listOf(BlockLocation(block23, Offset(10.meters))),
+            arrayListOf(
+                ExplorerStep(listOf(BlockLocation(block01, Offset(0.meters)))),
+                ExplorerStep(listOf(BlockLocation(block23, Offset(20.meters)))),
+                ExplorerStep(listOf(BlockLocation(block23, Offset(10.meters)))),
             )
         val res = runPathFinding(waypoints, infra)
         Assertions.assertNull(res)
@@ -383,9 +390,9 @@ class PathfindingTests {
         val infra = DummyInfra()
         val block01 = infra.addBlock("0", "1", 100.meters)
         val waypoints =
-            arrayListOf<Collection<BlockLocation>>(
-                listOf(BlockLocation(block01, Offset(60.meters))),
-                listOf(BlockLocation(block01, Offset(30.meters))),
+            arrayListOf(
+                ExplorerStep(listOf(BlockLocation(block01, Offset(60.meters)))),
+                ExplorerStep(listOf(BlockLocation(block01, Offset(30.meters)))),
             )
         val res = runPathFinding(waypoints, infra)
         Assertions.assertNull(res)
@@ -401,10 +408,10 @@ class PathfindingTests {
         val block01 = infra.addBlock("0", "1", 100.meters)
         infra.addBlock("1", "2", 100.meters)
         val waypoints =
-            arrayListOf<Collection<BlockLocation>>(
-                listOf(BlockLocation(block01, Offset(10.meters))),
-                listOf(BlockLocation(block01, Offset(40.meters))),
-                listOf(BlockLocation(block01, Offset(20.meters))),
+            arrayListOf(
+                ExplorerStep(listOf(BlockLocation(block01, Offset(10.meters)))),
+                ExplorerStep(listOf(BlockLocation(block01, Offset(40.meters)))),
+                ExplorerStep(listOf(BlockLocation(block01, Offset(20.meters)))),
             )
         val res = runPathFinding(waypoints, infra)
         Assertions.assertNull(res)
@@ -424,9 +431,9 @@ class PathfindingTests {
         val block12 = infra.addBlock("1", "2", 100.meters)
         val block20 = infra.addBlock("2", "0", 100.meters)
         val waypoints =
-            arrayListOf<Collection<BlockLocation>>(
-                listOf(BlockLocation(block01, Offset(60.meters))),
-                listOf(BlockLocation(block01, Offset(30.meters))),
+            arrayListOf(
+                ExplorerStep(listOf(BlockLocation(block01, Offset(60.meters)))),
+                ExplorerStep(listOf(BlockLocation(block01, Offset(30.meters)))),
             )
         val res = runPathFinding(waypoints, infra)
         Assertions.assertEquals(
@@ -480,11 +487,13 @@ class PathfindingTests {
         val block14 = infra.addBlock("1", "4", 100.meters)
         val block45 = infra.addBlock("4", "5", 1000.meters)
         val waypoints =
-            arrayListOf<Collection<BlockLocation>>(
-                listOf(BlockLocation(block01, Offset(0.meters))),
-                listOf(
-                    BlockLocation(block23, Offset(500.meters)),
-                    BlockLocation(block45, Offset(10.meters)),
+            arrayListOf(
+                ExplorerStep(listOf(BlockLocation(block01, Offset(0.meters)))),
+                ExplorerStep(
+                    listOf(
+                        BlockLocation(block23, Offset(500.meters)),
+                        BlockLocation(block45, Offset(10.meters)),
+                    )
                 ),
             )
         val res = runPathFinding(waypoints, infra)
@@ -527,10 +536,10 @@ class PathfindingTests {
         val block45 = infra.addBlock("4", "5", 10.meters)
         val block52 = infra.addBlock("5", "2", 1000.meters)
         val waypoints =
-            arrayListOf<Collection<BlockLocation>>(
-                listOf(BlockLocation(block01, Offset(5.meters))),
-                listOf(BlockLocation(block45, Offset(5.meters))),
-                listOf(BlockLocation(block23, Offset(5.meters))),
+            arrayListOf(
+                ExplorerStep(listOf(BlockLocation(block01, Offset(5.meters)))),
+                ExplorerStep(listOf(BlockLocation(block45, Offset(5.meters)))),
+                ExplorerStep(listOf(BlockLocation(block23, Offset(5.meters)))),
             )
         val res = runPathFinding(waypoints, infra)
         Assertions.assertEquals(
@@ -593,12 +602,14 @@ class PathfindingTests {
         val block34 = infra.addBlock("3", "4", 100000.meters)
         val block45 = infra.addBlock("4", "5", 0.meters)
         val waypoints =
-            arrayListOf<Collection<BlockLocation>>(
-                listOf(
-                    BlockLocation(block01, Offset(0.meters)),
-                    BlockLocation(block23, Offset(0.meters)),
+            arrayListOf(
+                ExplorerStep(
+                    listOf(
+                        BlockLocation(block01, Offset(0.meters)),
+                        BlockLocation(block23, Offset(0.meters)),
+                    )
                 ),
-                listOf(BlockLocation(block45, Offset(0.meters))),
+                ExplorerStep(listOf(BlockLocation(block45, Offset(0.meters)))),
             )
         val res =
             runPathFinding(
@@ -650,9 +661,9 @@ class PathfindingTests {
         val infra = DummyInfra()
         val block01 = infra.addBlock("0", "1", 100.meters)
         val waypoints =
-            arrayListOf<Collection<BlockLocation>>(
-                listOf(BlockLocation(block01, Offset(5.meters))),
-                listOf(BlockLocation(block01, Offset(7.meters))),
+            arrayListOf(
+                ExplorerStep(listOf(BlockLocation(block01, Offset(5.meters)))),
+                ExplorerStep(listOf(BlockLocation(block01, Offset(7.meters)))),
             )
         val res =
             runPathFinding(
@@ -679,9 +690,9 @@ class PathfindingTests {
         val infra = DummyInfra()
         val block01 = infra.addBlock("0", "1", 100.meters)
         val waypoints =
-            arrayListOf<Collection<BlockLocation>>(
-                listOf(BlockLocation(block01, Offset(40.meters))),
-                listOf(BlockLocation(block01, Offset(50.meters))),
+            arrayListOf(
+                ExplorerStep(listOf(BlockLocation(block01, Offset(40.meters)))),
+                ExplorerStep(listOf(BlockLocation(block01, Offset(50.meters)))),
             )
         val res =
             runPathFinding(
@@ -723,9 +734,9 @@ class PathfindingTests {
         val block01 = infra.addBlock("0", "1", 100.meters)
         val block12 = infra.addBlock("1", "2", 100.meters)
         val waypoints =
-            arrayListOf<Collection<BlockLocation>>(
-                listOf(BlockLocation(block01, Offset(0.meters))),
-                listOf(BlockLocation(block12, Offset(50.meters))),
+            arrayListOf(
+                ExplorerStep(listOf(BlockLocation(block01, Offset(0.meters)))),
+                ExplorerStep(listOf(BlockLocation(block12, Offset(50.meters)))),
             )
         val res =
             runPathFinding(
@@ -771,9 +782,9 @@ class PathfindingTests {
         val block01 = infra.addBlock("0", "1", 100.meters)
         val block12 = infra.addBlock("1", "2", 100.meters)
         val waypoints =
-            arrayListOf<Collection<BlockLocation>>(
-                listOf(BlockLocation(block01, Offset(0.meters))),
-                listOf(BlockLocation(block12, Offset(50.meters))),
+            arrayListOf(
+                ExplorerStep(listOf(BlockLocation(block01, Offset(0.meters)))),
+                ExplorerStep(listOf(BlockLocation(block12, Offset(50.meters)))),
             )
         val res =
             runPathFinding(
@@ -800,12 +811,14 @@ class PathfindingTests {
         val infra = DummyInfra()
         val block01 = infra.addBlock("0", "1", 100.meters)
         val waypoints =
-            arrayListOf<Collection<BlockLocation>>(
-                listOf(
-                    BlockLocation(block01, Offset(10.meters)),
-                    BlockLocation(block01, Offset(40.meters)),
+            arrayListOf(
+                ExplorerStep(
+                    listOf(
+                        BlockLocation(block01, Offset(10.meters)),
+                        BlockLocation(block01, Offset(40.meters)),
+                    )
                 ),
-                listOf(BlockLocation(block01, Offset(50.meters))),
+                ExplorerStep(listOf(BlockLocation(block01, Offset(50.meters)))),
             )
         val res =
             runPathFinding(
@@ -845,9 +858,9 @@ class PathfindingTests {
         val infra = DummyInfra()
         val block01 = infra.addBlock("0", "1", 100.meters)
         val waypoints =
-            arrayListOf<Collection<BlockLocation>>(
-                listOf(BlockLocation(block01, Offset(55.meters))),
-                listOf(BlockLocation(block01, Offset(60.meters))),
+            arrayListOf(
+                ExplorerStep(listOf(BlockLocation(block01, Offset(55.meters)))),
+                ExplorerStep(listOf(BlockLocation(block01, Offset(60.meters)))),
             )
         val res =
             runPathFinding(
@@ -881,14 +894,18 @@ class PathfindingTests {
         infra.addBlock("3", "4", 1000.meters)
         val block45 = infra.addBlock("4", "5", 1000.meters)
         val waypoints =
-            arrayListOf<Collection<BlockLocation>>(
-                listOf(
-                    BlockLocation(block01, Offset(5000.meters)),
-                    BlockLocation(block23, Offset(0.meters)),
+            arrayListOf(
+                ExplorerStep(
+                    listOf(
+                        BlockLocation(block01, Offset(5000.meters)),
+                        BlockLocation(block23, Offset(0.meters)),
+                    )
                 ),
-                listOf(
-                    BlockLocation(block01, Offset(6999.meters)),
-                    BlockLocation(block45, Offset(1000.meters)),
+                ExplorerStep(
+                    listOf(
+                        BlockLocation(block01, Offset(6999.meters)),
+                        BlockLocation(block45, Offset(1000.meters)),
+                    )
                 ),
             )
         val res = runPathFinding(waypoints, infra)
@@ -912,9 +929,9 @@ class PathfindingTests {
         val infra = DummyInfra()
         val block01 = infra.addBlock("0", "1", 100.meters)
         val waypoints =
-            arrayListOf<Collection<BlockLocation>>(
-                listOf(BlockLocation(block01, Offset(0.meters))),
-                listOf(BlockLocation(block01, Offset(10.meters))),
+            arrayListOf(
+                ExplorerStep(listOf(BlockLocation(block01, Offset(0.meters)))),
+                ExplorerStep(listOf(BlockLocation(block01, Offset(10.meters)))),
             )
 
         if (!timesOut) {
@@ -963,12 +980,14 @@ class PathfindingTests {
         val slow = infra.addBlock("x", "b", 100.meters, 1.0)
         val secondBlock = infra.addBlock("b", "c", 100.meters)
         val waypoints =
-            arrayListOf<Collection<BlockLocation>>(
-                listOf(
-                    BlockLocation(slow, Offset(0.meters)),
-                    BlockLocation(fast, Offset(0.meters)),
+            arrayListOf(
+                ExplorerStep(
+                    listOf(
+                        BlockLocation(slow, Offset(0.meters)),
+                        BlockLocation(fast, Offset(0.meters)),
+                    )
                 ),
-                listOf(BlockLocation(secondBlock, Offset(0.meters))),
+                ExplorerStep(listOf(BlockLocation(secondBlock, Offset(0.meters)))),
             )
         val res = runPathFinding(waypoints, infra)
         Assertions.assertEquals(
@@ -1062,10 +1081,9 @@ class PathfindingTests {
 
         // ---------- ----------- ----------
 
-        val aPlus20 = listOf(BlockLocation(aK0Blocks[0], Offset(20.meters)))
-        val d2Plus70 = listOf(BlockLocation(bF2Blocks[2], Offset(70.meters)))
-        val res2Routes =
-            runPathFinding(listOf<Collection<BlockLocation>>(aPlus20, d2Plus70), dummyInfra)
+        val aPlus20 = ExplorerStep(listOf(BlockLocation(aK0Blocks[0], Offset(20.meters))))
+        val d2Plus70 = ExplorerStep(listOf(BlockLocation(bF2Blocks[2], Offset(70.meters))))
+        val res2Routes = runPathFinding(listOf(aPlus20, d2Plus70), dummyInfra)
 
         fun getBlockLength(blockId: BlockId): Length<Block> {
             return dummyInfra.fullInfra().blockInfra.getBlockLength(blockId)
@@ -1114,9 +1132,8 @@ class PathfindingTests {
 
         // ---------- ----------- ----------
 
-        val h1Plus500 = listOf(BlockLocation(f2K1Blocks[2], Offset(500.meters)))
-        val res3routes =
-            runPathFinding(listOf<Collection<BlockLocation>>(aPlus20, h1Plus500), dummyInfra)
+        val h1Plus500 = ExplorerStep(listOf(BlockLocation(f2K1Blocks[2], Offset(500.meters))))
+        val res3routes = runPathFinding(listOf(aPlus20, h1Plus500), dummyInfra)
 
         Assertions.assertEquals(
             arrayListOf(
@@ -1215,20 +1232,16 @@ class PathfindingTests {
 
         // ---------- ----------- ----------
 
-        val c3Plus0 = listOf(BlockLocation(aF3Blocks[1], Offset(500.meters)))
-        val resNoPath =
-            runPathFinding(listOf<Collection<BlockLocation>>(c3Plus0, d2Plus70), dummyInfra)
+        val c3Plus0 = ExplorerStep(listOf(BlockLocation(aF3Blocks[1], Offset(500.meters))))
+        val resNoPath = runPathFinding(listOf(c3Plus0, d2Plus70), dummyInfra)
         Assertions.assertNull(resNoPath)
 
         // ---------- ----------- ----------
 
-        val c2Plus10 = listOf(BlockLocation(bF2Blocks[1], Offset(10.meters)))
-        val j1Plus400 = listOf(BlockLocation(f2K1Blocks[4], Offset(400.meters)))
+        val c2Plus10 = ExplorerStep(listOf(BlockLocation(bF2Blocks[1], Offset(10.meters))))
+        val j1Plus400 = ExplorerStep(listOf(BlockLocation(f2K1Blocks[4], Offset(400.meters))))
         val multipleStepInBlockGroups =
-            runPathFinding(
-                listOf<Collection<BlockLocation>>(c2Plus10, d2Plus70, h1Plus500, j1Plus400),
-                dummyInfra,
-            )
+            runPathFinding(listOf(c2Plus10, d2Plus70, h1Plus500, j1Plus400), dummyInfra)
 
         Assertions.assertEquals(
             arrayListOf(
@@ -1327,7 +1340,7 @@ class PathfindingTests {
     }
 
     private fun runPathFinding(
-        targets: List<Collection<BlockLocation>>,
+        targets: List<ExplorerStep>,
         infra: DummyInfra,
         rollingStock: RollingStock = TestTrains.REALISTIC_FAST_TRAIN,
         speedLimitTag: String? = null,

--- a/core/src/test/java/fr/sncf/osrd/utils/graph/PathfindingTests.kt
+++ b/core/src/test/java/fr/sncf/osrd/utils/graph/PathfindingTests.kt
@@ -8,7 +8,7 @@ import fr.sncf.osrd.reporting.exceptions.ErrorType
 import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockId
-import fr.sncf.osrd.stdcm.infra_exploration.BlockLocation
+import fr.sncf.osrd.sim_infra.api.BlockLocation
 import fr.sncf.osrd.stdcm.infra_exploration.ExplorerStep
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorer
 import fr.sncf.osrd.train.RollingStock

--- a/core/src/test/java/fr/sncf/osrd/utils/graph/PathfindingTests.kt
+++ b/core/src/test/java/fr/sncf/osrd/utils/graph/PathfindingTests.kt
@@ -1354,7 +1354,7 @@ class PathfindingTests {
                     constraints,
                     speedLimitTag,
                     rollingStock.maxSpeed,
-                    rollingStock.length,
+                    rollingStock.length.meters,
                 )
                 .runPathfinding()
         else
@@ -1364,7 +1364,7 @@ class PathfindingTests {
                     constraints,
                     speedLimitTag,
                     rollingStock.maxSpeed,
-                    rollingStock.length,
+                    rollingStock.length.meters,
                 )
                 .runPathfinding(timeout)
     }

--- a/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingBlocksEndpointTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingBlocksEndpointTest.kt
@@ -6,7 +6,7 @@ import fr.sncf.osrd.api.pathfinding.findDirectedWaypointBlocks
 import fr.sncf.osrd.reporting.exceptions.ErrorType
 import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.sim_infra.api.BlockId
-import fr.sncf.osrd.stdcm.infra_exploration.BlockLocation
+import fr.sncf.osrd.sim_infra.api.BlockLocation
 import fr.sncf.osrd.utils.Direction
 import fr.sncf.osrd.utils.Helpers
 import fr.sncf.osrd.utils.units.Offset

--- a/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingElectrificationTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingElectrificationTest.kt
@@ -2,6 +2,7 @@ package fr.sncf.osrd.pathfinding
 
 import fr.sncf.osrd.api.ApiTest
 import fr.sncf.osrd.api.InfraMetadata
+import fr.sncf.osrd.api.PathItem
 import fr.sncf.osrd.api.TrackLocation
 import fr.sncf.osrd.api.pathfinding.IncompatibleConstraintsPathResponse
 import fr.sncf.osrd.api.pathfinding.NoPathFoundException
@@ -59,7 +60,7 @@ class PathfindingElectrificationTest : ApiTest() {
                 infra.fullInfra(),
                 getPathfindingBlockRequest(
                     TestTrains.FAST_ELECTRIC_TRAIN,
-                    listOf(waypointsStart, waypointsEnd),
+                    listOf(PathItem(waypointsStart, false), PathItem(waypointsEnd, false)),
                 ),
             )
         val normalPathSuccess = checkPathfindingSuccess(normalPathResp, 400.meters)
@@ -78,7 +79,7 @@ class PathfindingElectrificationTest : ApiTest() {
                 infra.fullInfra(),
                 getPathfindingBlockRequest(
                     TestTrains.FAST_ELECTRIC_TRAIN,
-                    listOf(waypointsStart, waypointsEnd),
+                    listOf(PathItem(waypointsStart, false), PathItem(waypointsEnd, false)),
                 ),
             )
         val electricPathSuccess = checkPathfindingSuccess(electricPathResp, 400.meters)
@@ -94,7 +95,7 @@ class PathfindingElectrificationTest : ApiTest() {
                     infra.fullInfra(),
                     getPathfindingBlockRequest(
                         TestTrains.FAST_ELECTRIC_TRAIN,
-                        listOf(waypointsStart, waypointsEnd),
+                        listOf(PathItem(waypointsStart, false), PathItem(waypointsEnd, false)),
                     ),
                 )
             }
@@ -149,7 +150,7 @@ class PathfindingElectrificationTest : ApiTest() {
                     infra.fullInfra(),
                     getPathfindingBlockRequest(
                         TestTrains.FAST_ELECTRIC_TRAIN,
-                        listOf(waypointsStart, waypointsEnd),
+                        listOf(PathItem(waypointsStart, false), PathItem(waypointsEnd, false)),
                     ),
                 )
             checkPathfindingSuccess(electricPathResp, 300.meters)
@@ -159,7 +160,7 @@ class PathfindingElectrificationTest : ApiTest() {
                         infra.fullInfra(),
                         getPathfindingBlockRequest(
                             TestTrains.FAST_ELECTRIC_TRAIN,
-                            listOf(waypointsStart, waypointsEnd),
+                            listOf(PathItem(waypointsStart, false), PathItem(waypointsEnd, false)),
                         ),
                     )
                 }
@@ -221,7 +222,7 @@ class PathfindingElectrificationTest : ApiTest() {
                 infraWithAllElectrifiedTrack,
                 getPathfindingBlockRequest(
                     TestTrains.FAST_ELECTRIC_TRAIN,
-                    listOf(waypointsStart, waypointsEnd),
+                    listOf(PathItem(waypointsStart, false), PathItem(waypointsEnd, false)),
                 ),
             )
         val normalPathSuccess = checkPathfindingSuccess(normalPathResp, 39_553.meters)
@@ -244,7 +245,7 @@ class PathfindingElectrificationTest : ApiTest() {
                 infraPartialElectrifiedTrack,
                 getPathfindingBlockRequest(
                     TestTrains.FAST_ELECTRIC_TRAIN,
-                    listOf(waypointsStart, waypointsEnd),
+                    listOf(PathItem(waypointsStart, false), PathItem(waypointsEnd, false)),
                 ),
             )
         val partialElectricPathSuccess =
@@ -269,7 +270,7 @@ class PathfindingElectrificationTest : ApiTest() {
                     Helpers.fullInfraFromRJS(rjsInfra, InfraMetadata("modified_small_infra")),
                     getPathfindingBlockRequest(
                         TestTrains.FAST_ELECTRIC_TRAIN,
-                        listOf(waypointsStart, waypointsEnd),
+                        listOf(PathItem(waypointsStart, false), PathItem(waypointsEnd, false)),
                     ),
                 )
             }

--- a/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingSignalingTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingSignalingTest.kt
@@ -1,5 +1,6 @@
 package fr.sncf.osrd.pathfinding
 
+import fr.sncf.osrd.api.PathItem
 import fr.sncf.osrd.api.TrackLocation
 import fr.sncf.osrd.api.pathfinding.IncompatibleConstraintsPathResponse
 import fr.sncf.osrd.api.pathfinding.NoPathFoundException
@@ -60,7 +61,7 @@ class PathfindingSignalingTest {
                     infra.fullInfra(),
                     getPathfindingBlockRequest(
                         TestTrains.TRAIN_WITHOUT_TVM,
-                        listOf(waypointsStart, waypointsEnd),
+                        listOf(PathItem(waypointsStart, false), PathItem(waypointsEnd, false)),
                     ),
                 )
             }
@@ -88,7 +89,7 @@ class PathfindingSignalingTest {
                 infra.fullInfra(),
                 getPathfindingBlockRequest(
                     TestTrains.TRAIN_WITHOUT_TVM,
-                    listOf(waypointsStart, waypointsEnd),
+                    listOf(PathItem(waypointsStart, false), PathItem(waypointsEnd, false)),
                 ),
             )
         checkPathfindingSuccess(
@@ -115,7 +116,7 @@ class PathfindingSignalingTest {
                 infra.fullInfra(),
                 getPathfindingBlockRequest(
                     TestTrains.TRAIN_WITHOUT_TVM,
-                    listOf(waypointsStart, waypointsEnd),
+                    listOf(PathItem(waypointsStart, false), PathItem(waypointsEnd, false)),
                 ),
             )
         checkPathfindingSuccess(
@@ -161,7 +162,11 @@ class PathfindingSignalingTest {
                 infra.fullInfra(),
                 getPathfindingBlockRequest(
                     TestTrains.REALISTIC_ETCS_FAST_TRAIN,
-                    listOf(waypointsStart, waypointsInter, waypointsEnd),
+                    listOf(
+                        PathItem(waypointsStart, false),
+                        PathItem(waypointsInter, false),
+                        PathItem(waypointsEnd, false),
+                    ),
                 ),
             )
         checkPathfindingSuccess(

--- a/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingTest.kt
@@ -2,6 +2,7 @@ package fr.sncf.osrd.pathfinding
 
 import fr.sncf.osrd.api.ApiTest
 import fr.sncf.osrd.api.InfraMetadata
+import fr.sncf.osrd.api.PathItem
 import fr.sncf.osrd.api.TrackLocation
 import fr.sncf.osrd.api.pathfinding.*
 import fr.sncf.osrd.cli.RqFake
@@ -28,7 +29,7 @@ import org.junit.jupiter.api.TestInstance
 
 fun getPathfindingBlockRequest(
     rs: RollingStock,
-    pathItems: List<Collection<TrackLocation>>,
+    trackLocations: List<Collection<TrackLocation>>,
     infra: String = "unused_name",
     stopsAtEndOfBlock: Boolean? = false,
 ): PathfindingBlockRequest {
@@ -44,7 +45,7 @@ fun getPathfindingBlockRequest(
         null,
         infra,
         1,
-        pathItems,
+        trackLocations.map { PathItem(it, false) },
     )
 }
 
@@ -141,6 +142,7 @@ class PathfindingTest : ApiTest() {
         val waypointsStart = listOf(waypointStart)
         val waypointsEnd = listOf(waypointEnd)
         val waypoints = listOf(waypointsStart, waypointsEnd)
+        val pathItems = waypoints.map { PathItem(it, false) }
 
         val unconstrainedRequestBody =
             pathfindingRequestAdapter.toJson(
@@ -155,7 +157,7 @@ class PathfindingTest : ApiTest() {
                     timeout = null,
                     infra = "tiny_infra/infra.json",
                     expectedVersion = 1,
-                    pathItems = waypoints,
+                    pathItems = pathItems,
                 )
             )
         val unconstrainedResponse =
@@ -176,7 +178,7 @@ class PathfindingTest : ApiTest() {
                     rollingStockLength = 0.0,
                     infra = "tiny_infra/infra.json",
                     expectedVersion = 1,
-                    pathItems = waypoints,
+                    pathItems = pathItems,
                 )
             )
         val response = PathfindingBlocksEndpoint(infraManager).act(RqFake(requestBody))
@@ -207,6 +209,7 @@ class PathfindingTest : ApiTest() {
         val waypointsStart = listOf(waypointStart)
         val waypointsEnd = listOf(waypointEnd)
         val waypoints = listOf(waypointsStart, waypointsEnd)
+        val pathItems = waypoints.map { PathItem(it, false) }
 
         val unconstrainedRequestBody =
             pathfindingRequestAdapter.toJson(
@@ -221,7 +224,7 @@ class PathfindingTest : ApiTest() {
                     rollingStockLength = 0.0,
                     infra = "small_infra/infra.json",
                     expectedVersion = 1,
-                    pathItems = waypoints,
+                    pathItems = pathItems,
                 )
             )
         val unconstrainedResponse =
@@ -242,7 +245,7 @@ class PathfindingTest : ApiTest() {
                     timeout = null,
                     infra = "small_infra/infra.json",
                     expectedVersion = 1,
-                    pathItems = waypoints,
+                    pathItems = pathItems,
                 )
             )
         val response = PathfindingBlocksEndpoint(infraManager).act(RqFake(requestBody))

--- a/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingTest.kt
@@ -923,4 +923,185 @@ class PathfindingStopsAtEndOfBlock : ApiTest() {
                 listOf(Offset(intermediateStopDistance), Offset(secondIntermediateStopDistance)),
         )
     }
+
+    @Test
+    fun simpleBacktrackingYInfraTest() {
+        val waypointsStart = listOf(TrackLocation("t_a", Offset(3100.meters)))
+        val waypointsBacktracking = listOf(TrackLocation("t_center", Offset(2800.meters)))
+        val waypointsEnd = listOf(TrackLocation("t_b", Offset(3400.meters)))
+        val parsed =
+            callPathfindingEndpoint(
+                TestTrains.REALISTIC_FAST_TRAIN,
+                listOf(
+                    PathItem(waypointsStart, false),
+                    PathItem(waypointsBacktracking, true),
+                    PathItem(waypointsEnd, false),
+                ),
+                "y_infra/infra.json",
+                false,
+            )
+        checkPathfindingSuccess(
+            parsed,
+            18_700.meters,
+            expectedBlocks =
+                listOf(
+                    "[s.right.a1-BAL, s.right.a2-BAL];[det.a1, det.a2];[]",
+                    "[s.right.a2-BAL, s.right.a3-BAL];[det.a2, det.a3];[]",
+                    "[s.right.a3-BAL, s.right.c2-BAL];[det.a3, det.c2];[switch-A_B1]",
+                    "[s.left.c3-BAL, s.left.c1-BAL];[det.c3, det.c1];[]",
+                    "[s.left.c1-BAL, s.left.b2-BAL];[det.c1, det.b2];[switch-A_B2]",
+                    "[s.left.b2-BAL, s.left.b1-BAL];[det.b2, det.b1];[]",
+                ),
+            expectedRoutes =
+                listOf("rt.bf.a->det.a3", "rt.det.a3->bf.c", "rt.bf.c->det.c1", "rt.det.c1->bf.b"),
+            expectedTrackSectionRanges =
+                listOf(
+                    TrackSectionRange(
+                        "t_a",
+                        Offset(3_100.meters),
+                        Offset(10_000.meters),
+                        EdgeDirection.START_TO_STOP,
+                    ),
+                    TrackSectionRange(
+                        "t_center",
+                        Offset(0.meters),
+                        Offset(2_800.meters),
+                        EdgeDirection.START_TO_STOP,
+                    ),
+                    TrackSectionRange(
+                        "t_center",
+                        Offset(0.meters),
+                        Offset(2_400.meters),
+                        EdgeDirection.STOP_TO_START,
+                    ),
+                    TrackSectionRange(
+                        "t_b",
+                        Offset(3_400.meters),
+                        Offset(10_000.meters),
+                        EdgeDirection.STOP_TO_START,
+                    ),
+                ),
+            expectedIntermediatePathItemPosition = listOf(Offset(9_700.meters)),
+        )
+    }
+
+    @Test
+    fun backtrackingOverRouteDelimiterYInfraTest() {
+        val waypointsStart = listOf(TrackLocation("t_a", Offset(3100.meters)))
+        val waypointsBacktracking = listOf(TrackLocation("t_center", Offset(1100.meters)))
+        val waypointsEnd = listOf(TrackLocation("t_b", Offset(3400.meters)))
+        val parsed =
+            callPathfindingEndpoint(
+                TestTrains.REALISTIC_FAST_TRAIN,
+                listOf(
+                    PathItem(waypointsStart, false),
+                    PathItem(waypointsBacktracking, true),
+                    PathItem(waypointsEnd, false),
+                ),
+                "y_infra/infra.json",
+                false,
+            )
+        checkPathfindingSuccess(
+            parsed,
+            15_300.meters,
+            expectedBlocks =
+                listOf(
+                    "[s.right.a1-BAL, s.right.a2-BAL];[det.a1, det.a2];[]",
+                    "[s.right.a2-BAL, s.right.a3-BAL];[det.a2, det.a3];[]",
+                    "[s.right.a3-BAL, s.right.c2-BAL];[det.a3, det.c2];[switch-A_B1]",
+                    "[s.left.c1-BAL, s.left.b2-BAL];[det.c1, det.b2];[switch-A_B2]",
+                    "[s.left.b2-BAL, s.left.b1-BAL];[det.b2, det.b1];[]",
+                ),
+            expectedRoutes = listOf("rt.bf.a->det.a3", "rt.det.a3->bf.c", "rt.det.c1->bf.b"),
+            expectedTrackSectionRanges =
+                listOf(
+                    TrackSectionRange(
+                        "t_a",
+                        Offset(3_100.meters),
+                        Offset(10_000.meters),
+                        EdgeDirection.START_TO_STOP,
+                    ),
+                    TrackSectionRange(
+                        "t_center",
+                        Offset(0.meters),
+                        Offset(1_100.meters),
+                        EdgeDirection.START_TO_STOP,
+                    ),
+                    TrackSectionRange(
+                        "t_center",
+                        Offset(0.meters),
+                        Offset(700.meters),
+                        EdgeDirection.STOP_TO_START,
+                    ),
+                    TrackSectionRange(
+                        "t_b",
+                        Offset(3_400.meters),
+                        Offset(10_000.meters),
+                        EdgeDirection.STOP_TO_START,
+                    ),
+                ),
+            expectedIntermediatePathItemPosition = listOf(Offset(8_000.meters)),
+        )
+    }
+
+    @Test
+    fun backtrackingShortlyAfterRouteDelimiterYInfraTest() {
+        val waypointsStart = listOf(TrackLocation("t_a", Offset(3100.meters)))
+        val waypointsBacktracking = listOf(TrackLocation("t_center", Offset(1500.meters)))
+        val waypointsEnd = listOf(TrackLocation("t_b", Offset(3100.meters)))
+        val parsed =
+            callPathfindingEndpoint(
+                TestTrains.REALISTIC_FAST_TRAIN,
+                listOf(
+                    PathItem(waypointsStart, false),
+                    PathItem(waypointsBacktracking, true),
+                    PathItem(waypointsEnd, false),
+                ),
+                "y_infra/infra.json",
+                false,
+            )
+        checkPathfindingSuccess(
+            parsed,
+            16_400.meters,
+            expectedBlocks =
+                listOf(
+                    "[s.right.a1-BAL, s.right.a2-BAL];[det.a1, det.a2];[]",
+                    "[s.right.a2-BAL, s.right.a3-BAL];[det.a2, det.a3];[]",
+                    "[s.right.a3-BAL, s.right.c2-BAL];[det.a3, det.c2];[switch-A_B1]",
+                    "[s.left.c3-BAL, s.left.c1-BAL];[det.c3, det.c1];[]",
+                    "[s.left.c1-BAL, s.left.b2-BAL];[det.c1, det.b2];[switch-A_B2]",
+                    "[s.left.b2-BAL, s.left.b1-BAL];[det.b2, det.b1];[]",
+                ),
+            expectedRoutes =
+                listOf("rt.bf.a->det.a3", "rt.det.a3->bf.c", "rt.bf.c->det.c1", "rt.det.c1->bf.b"),
+            expectedTrackSectionRanges =
+                listOf(
+                    TrackSectionRange(
+                        "t_a",
+                        Offset(3_100.meters),
+                        Offset(10_000.meters),
+                        EdgeDirection.START_TO_STOP,
+                    ),
+                    TrackSectionRange(
+                        "t_center",
+                        Offset(0.meters),
+                        Offset(1_500.meters),
+                        EdgeDirection.START_TO_STOP,
+                    ),
+                    TrackSectionRange(
+                        "t_center",
+                        Offset(0.meters),
+                        Offset(1_100.meters),
+                        EdgeDirection.STOP_TO_START,
+                    ),
+                    TrackSectionRange(
+                        "t_b",
+                        Offset(3_100.meters),
+                        Offset(10_000.meters),
+                        EdgeDirection.STOP_TO_START,
+                    ),
+                ),
+            expectedIntermediatePathItemPosition = listOf(Offset(8_400.meters)),
+        )
+    }
 }

--- a/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingTest.kt
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.TestInstance
 
 fun getPathfindingBlockRequest(
     rs: RollingStock,
-    trackLocations: List<Collection<TrackLocation>>,
+    trackLocations: List<PathItem>,
     infra: String = "unused_name",
     stopsAtEndOfBlock: Boolean? = false,
 ): PathfindingBlockRequest {
@@ -45,7 +45,7 @@ fun getPathfindingBlockRequest(
         null,
         infra,
         1,
-        trackLocations.map { PathItem(it, false) },
+        trackLocations,
     )
 }
 
@@ -94,7 +94,7 @@ class PathfindingTest : ApiTest() {
         val parsed =
             callPathfindingEndpoint(
                 TestTrains.REALISTIC_FAST_TRAIN,
-                listOf(waypointsStart, waypointsEnd),
+                listOf(PathItem(waypointsStart, true), PathItem(waypointsEnd, true)),
                 "tiny_infra/infra.json",
             )
         checkPathfindingSuccess(
@@ -139,10 +139,9 @@ class PathfindingTest : ApiTest() {
     fun incompatibleElectrification() {
         val waypointStart = TrackLocation("ne.micro.foo_b", Offset(50.meters))
         val waypointEnd = TrackLocation("ne.micro.bar_a", Offset(100.meters))
-        val waypointsStart = listOf(waypointStart)
-        val waypointsEnd = listOf(waypointEnd)
+        val waypointsStart = PathItem(listOf(waypointStart), false)
+        val waypointsEnd = PathItem(listOf(waypointEnd), false)
         val waypoints = listOf(waypointsStart, waypointsEnd)
-        val pathItems = waypoints.map { PathItem(it, false) }
 
         val unconstrainedRequestBody =
             pathfindingRequestAdapter.toJson(
@@ -157,7 +156,7 @@ class PathfindingTest : ApiTest() {
                     timeout = null,
                     infra = "tiny_infra/infra.json",
                     expectedVersion = 1,
-                    pathItems = pathItems,
+                    pathItems = waypoints,
                 )
             )
         val unconstrainedResponse =
@@ -178,7 +177,7 @@ class PathfindingTest : ApiTest() {
                     rollingStockLength = 0.0,
                     infra = "tiny_infra/infra.json",
                     expectedVersion = 1,
-                    pathItems = pathItems,
+                    pathItems = waypoints,
                 )
             )
         val response = PathfindingBlocksEndpoint(infraManager).act(RqFake(requestBody))
@@ -206,10 +205,9 @@ class PathfindingTest : ApiTest() {
     fun incompatibleConstraints() {
         val waypointStart = TrackLocation("TA0", Offset(0.meters))
         val waypointEnd = TrackLocation("TA6", Offset(2000.meters))
-        val waypointsStart = listOf(waypointStart)
-        val waypointsEnd = listOf(waypointEnd)
+        val waypointsStart = PathItem(listOf(waypointStart), false)
+        val waypointsEnd = PathItem(listOf(waypointEnd), false)
         val waypoints = listOf(waypointsStart, waypointsEnd)
-        val pathItems = waypoints.map { PathItem(it, false) }
 
         val unconstrainedRequestBody =
             pathfindingRequestAdapter.toJson(
@@ -224,7 +222,7 @@ class PathfindingTest : ApiTest() {
                     rollingStockLength = 0.0,
                     infra = "small_infra/infra.json",
                     expectedVersion = 1,
-                    pathItems = pathItems,
+                    pathItems = waypoints,
                 )
             )
         val unconstrainedResponse =
@@ -245,7 +243,7 @@ class PathfindingTest : ApiTest() {
                     timeout = null,
                     infra = "small_infra/infra.json",
                     expectedVersion = 1,
-                    pathItems = pathItems,
+                    pathItems = waypoints,
                 )
             )
         val response = PathfindingBlocksEndpoint(infraManager).act(RqFake(requestBody))
@@ -288,7 +286,11 @@ class PathfindingTest : ApiTest() {
         val parsed =
             callPathfindingEndpoint(
                 TestTrains.REALISTIC_FAST_TRAIN,
-                listOf(waypointsStart, waypointsMid, waypointsEnd),
+                listOf(
+                    PathItem(waypointsStart, false),
+                    PathItem(waypointsMid, false),
+                    PathItem(waypointsEnd, false),
+                ),
                 "tiny_infra/infra.json",
             )
         checkPathfindingSuccess(
@@ -338,7 +340,7 @@ class PathfindingTest : ApiTest() {
             pathfindingRequestAdapter.toJson(
                 getPathfindingBlockRequest(
                     TestTrains.REALISTIC_FAST_TRAIN,
-                    listOf(waypointsStart, waypointsEnd),
+                    listOf(PathItem(waypointsStart, false), PathItem(waypointsEnd, false)),
                     "tiny_infra/infra.json",
                 )
             )
@@ -355,7 +357,7 @@ class PathfindingTest : ApiTest() {
             pathfindingRequestAdapter.toJson(
                 getPathfindingBlockRequest(
                     TestTrains.REALISTIC_FAST_TRAIN,
-                    listOf(waypointsStart),
+                    listOf(PathItem(waypointsStart, false)),
                     "tiny_infra/infra.json",
                 )
             )
@@ -383,7 +385,7 @@ class PathfindingTest : ApiTest() {
                 infra,
                 getPathfindingBlockRequest(
                     TestTrains.REALISTIC_FAST_TRAIN,
-                    listOf(waypointsStart, waypointsEnd),
+                    listOf(PathItem(waypointsStart, false), PathItem(waypointsEnd, false)),
                 ),
             )
         checkPathfindingSuccess(normalPathResp, 10200.meters)
@@ -394,7 +396,7 @@ class PathfindingTest : ApiTest() {
                     infra,
                     getPathfindingBlockRequest(
                         TestTrains.FAST_TRAIN_LARGE_GAUGE,
-                        listOf(waypointsStart, waypointsEnd),
+                        listOf(PathItem(waypointsStart, false), PathItem(waypointsEnd, false)),
                     ),
                 )
             }
@@ -420,7 +422,7 @@ class PathfindingTest : ApiTest() {
                 infra,
                 getPathfindingBlockRequest(
                     TestTrains.REALISTIC_FAST_TRAIN,
-                    listOf(waypointsStart, closerWaypointsEnd),
+                    listOf(PathItem(waypointsStart, false), PathItem(closerWaypointsEnd, false)),
                 ),
             )
         checkPathfindingSuccess(shorterPathResp, 1100.meters)
@@ -433,7 +435,7 @@ class PathfindingTest : ApiTest() {
         val parsed =
             callPathfindingEndpoint(
                 TestTrains.REALISTIC_FAST_TRAIN,
-                listOf(waypointsStart, waypointsEnd),
+                listOf(PathItem(waypointsStart, false), PathItem(waypointsEnd, false)),
                 "tiny_infra/infra.json",
             )
         checkPathfindingSuccess(
@@ -483,7 +485,7 @@ class PathfindingTest : ApiTest() {
         val parsed =
             callPathfindingEndpoint(
                 TestTrains.REALISTIC_FAST_TRAIN,
-                listOf(waypointsStart, waypointsEnd),
+                listOf(PathItem(waypointsStart, false), PathItem(waypointsEnd, false)),
                 "tiny_infra/infra.json",
             )
         checkPathfindingSuccess(
@@ -510,7 +512,7 @@ class PathfindingTest : ApiTest() {
         val parsed =
             callPathfindingEndpoint(
                 TestTrains.REALISTIC_FAST_TRAIN,
-                listOf(waypointsStart, waypointsEnd),
+                listOf(PathItem(waypointsStart, false), PathItem(waypointsEnd, false)),
                 "tiny_infra/infra.json",
             )
         checkPathfindingSuccess(
@@ -549,7 +551,7 @@ class PathfindingTest : ApiTest() {
                 infra,
                 getPathfindingBlockRequest(
                     TestTrains.REALISTIC_FAST_TRAIN,
-                    listOf(waypointsStart, waypointsEnd),
+                    listOf(PathItem(waypointsStart, false), PathItem(waypointsEnd, false)),
                 ),
             )
         checkPathfindingSuccess(
@@ -586,7 +588,7 @@ class PathfindingTest : ApiTest() {
 
     fun callPathfindingEndpoint(
         rs: RollingStock,
-        pathItems: List<Collection<TrackLocation>>,
+        pathItems: List<PathItem>,
         infra: String,
     ): PathfindingBlockResponse {
         val requestBody =
@@ -600,7 +602,7 @@ class PathfindingTest : ApiTest() {
 class PathfindingStopsAtEndOfBlock : ApiTest() {
     fun callPathfindingEndpoint(
         rs: RollingStock,
-        pathItems: List<Collection<TrackLocation>>,
+        pathItems: List<PathItem>,
         infra: String,
         stopsAtEndOfBlock: Boolean,
     ): PathfindingBlockResponse {
@@ -613,7 +615,7 @@ class PathfindingStopsAtEndOfBlock : ApiTest() {
         return parsed
     }
 
-    private lateinit var waypoints: List<List<TrackLocation>>
+    private lateinit var waypoints: List<PathItem>
     private val firstIntermediateStopDistance = 12050.meters
     private val secondIntermediateStopDistance = 26500.meters
     private val reversedFirstIntermediateStopDistance = 19400.meters
@@ -632,10 +634,10 @@ class PathfindingStopsAtEndOfBlock : ApiTest() {
         val endWaypoint = TrackLocation("TH1", Offset(4400.meters))
         waypoints =
             listOf(
-                listOf(startWaypoint),
-                listOf(firstIntermediateWaypoint),
-                listOf(secondIntermediateWaypoint),
-                listOf(endWaypoint),
+                PathItem(listOf(startWaypoint), false),
+                PathItem(listOf(firstIntermediateWaypoint), false),
+                PathItem(listOf(secondIntermediateWaypoint), false),
+                PathItem(listOf(endWaypoint), false),
             )
     }
 
@@ -796,11 +798,15 @@ class PathfindingStopsAtEndOfBlock : ApiTest() {
 
     @Test
     fun penultimateCorrectlyMovedJustBeforeDestination() {
-        var waypoints: List<List<TrackLocation>>
         val startWaypoint = TrackLocation("TC1", Offset(500.meters))
         val intermediateWaypoint = TrackLocation("TD0", Offset(12550.meters))
         val endWaypoint = TrackLocation("TD0", Offset(13000.meters))
-        waypoints = listOf(listOf(startWaypoint), listOf(intermediateWaypoint), listOf(endWaypoint))
+        val waypoints =
+            listOf(
+                PathItem(listOf(startWaypoint), false),
+                PathItem(listOf(intermediateWaypoint), false),
+                PathItem(listOf(endWaypoint), false),
+            )
 
         val intermediateStopDistance = 13450.meters
 
@@ -820,11 +826,15 @@ class PathfindingStopsAtEndOfBlock : ApiTest() {
 
     @Test
     fun penultimateStopNotMovedExactlyToDestination() {
-        var waypoints: List<List<TrackLocation>>
         val startWaypoint = TrackLocation("TC1", Offset(500.meters))
         val intermediateWaypoint = TrackLocation("TD0", Offset(12600.meters))
         val endWaypoint = TrackLocation("TD0", Offset(13000.meters))
-        waypoints = listOf(listOf(startWaypoint), listOf(intermediateWaypoint), listOf(endWaypoint))
+        val waypoints =
+            listOf(
+                PathItem(listOf(startWaypoint), false),
+                PathItem(listOf(intermediateWaypoint), false),
+                PathItem(listOf(endWaypoint), false),
+            )
 
         // The intermediate stop is moved to the next block-delimiting signal, but the
         // distance available is more than the length of the train, so it would be moved by the
@@ -848,11 +858,15 @@ class PathfindingStopsAtEndOfBlock : ApiTest() {
 
     @Test
     fun penultimateStopTooCloseToDestination() {
-        var waypoints: List<List<TrackLocation>>
         val startWaypoint = TrackLocation("TC1", Offset(500.meters))
         val intermediateWaypoint = TrackLocation("TD0", Offset(12990.meters))
         val endWaypoint = TrackLocation("TD0", Offset(13000.meters))
-        waypoints = listOf(listOf(startWaypoint), listOf(intermediateWaypoint), listOf(endWaypoint))
+        val waypoints =
+            listOf(
+                PathItem(listOf(startWaypoint), false),
+                PathItem(listOf(intermediateWaypoint), false),
+                PathItem(listOf(endWaypoint), false),
+            )
 
         // The intermediate stop is moved to the next block-delimiting signal, but the
         // distance available is more than the length of the train, so it would be moved by the
@@ -876,17 +890,16 @@ class PathfindingStopsAtEndOfBlock : ApiTest() {
 
     @Test
     fun twoPenultimatesStopTooCloseToDestination() {
-        var waypoints: List<List<TrackLocation>>
         val startWaypoint = TrackLocation("TC1", Offset(500.meters))
         val intermediateWaypoint = TrackLocation("TD0", Offset(12950.meters))
         val secondIntermediateWaypoint = TrackLocation("TD0", Offset(12990.meters))
         val endWaypoint = TrackLocation("TD0", Offset(13000.meters))
-        waypoints =
+        val waypoints =
             listOf(
-                listOf(startWaypoint),
-                listOf(intermediateWaypoint),
-                listOf(secondIntermediateWaypoint),
-                listOf(endWaypoint),
+                PathItem(listOf(startWaypoint), false),
+                PathItem(listOf(intermediateWaypoint), false),
+                PathItem(listOf(secondIntermediateWaypoint), false),
+                PathItem(listOf(endWaypoint), false),
             )
 
         // The intermediate stops are moved to the next block-delimiting signal, but the

--- a/core/src/test/kotlin/fr/sncf/osrd/pathfinding/RemainingDistanceEstimatorTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/pathfinding/RemainingDistanceEstimatorTest.kt
@@ -7,7 +7,7 @@ import fr.sncf.osrd.path.implementations.buildTrainPathFromBlock
 import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockId
-import fr.sncf.osrd.stdcm.infra_exploration.BlockLocation
+import fr.sncf.osrd.sim_infra.api.BlockLocation
 import fr.sncf.osrd.utils.Helpers
 import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Distance.Companion.fromMeters

--- a/core/src/test/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulationTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulationTest.kt
@@ -247,7 +247,7 @@ class StandaloneSimulationTest {
                     true,
                 )
             if (scheduledPoint.arrival != null) {
-                assertEquals(scheduledPoint.arrival!!.seconds, arrival, 2.0)
+                assertEquals(scheduledPoint.arrival.seconds, arrival, 2.0)
             }
             assertEquals(scheduledPoint.stopFor?.seconds ?: 0.0, departure - arrival, 2.0)
         }

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/BacktrackingTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/BacktrackingTests.kt
@@ -26,7 +26,12 @@ class BacktrackingTests {
         val block = infra.addBlock("a", "b", 1000.meters)
         val firstBlockEnvelope =
             simulateBlock(
-                infraExplorerFromBlock(infra, infra, block),
+                infraExplorerFromBlock(
+                    infra,
+                    infra,
+                    TestTrains.REALISTIC_FAST_TRAIN.length.meters,
+                    block,
+                ),
                 0.0,
                 Offset(0.meters),
                 TestTrains.REALISTIC_FAST_TRAIN,
@@ -68,7 +73,12 @@ class BacktrackingTests {
         val lastBlock = infra.addBlock("d", "e", 10.meters)
         val firstBlockEnvelope =
             simulateBlock(
-                infraExplorerFromBlock(infra, infra, firstBlock),
+                infraExplorerFromBlock(
+                    infra,
+                    infra,
+                    TestTrains.REALISTIC_FAST_TRAIN.length.meters,
+                    firstBlock,
+                ),
                 0.0,
                 Offset(0.meters),
                 TestTrains.REALISTIC_FAST_TRAIN,
@@ -108,7 +118,12 @@ class BacktrackingTests {
         val secondBlock = infra.addBlock("b", "c", 100.meters, 5.0)
         val firstBlockEnvelope =
             simulateBlock(
-                infraExplorerFromBlock(infra, infra, firstBlock),
+                infraExplorerFromBlock(
+                    infra,
+                    infra,
+                    TestTrains.REALISTIC_FAST_TRAIN.length.meters,
+                    firstBlock,
+                ),
                 0.0,
                 Offset(0.meters),
                 TestTrains.REALISTIC_FAST_TRAIN,

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/BacktrackingTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/BacktrackingTests.kt
@@ -2,7 +2,6 @@ package fr.sncf.osrd.stdcm
 
 import com.google.common.collect.ImmutableMultimap
 import fr.sncf.osrd.envelope_sim.Comfort
-import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.stdcm.infra_exploration.BlockLocation
 import fr.sncf.osrd.stdcm.preprocessing.OccupancySegment
 import fr.sncf.osrd.train.TestTrains
@@ -46,8 +45,8 @@ class BacktrackingTests {
         val res =
             STDCMPathfindingBuilder()
                 .setInfra(infra.fullInfra())
-                .setStartLocations(setOf(BlockLocation(block, Offset<Block>(0.meters))))
-                .setEndLocations(setOf(BlockLocation(block, Offset<Block>(1000.meters))))
+                .setStartLocations(setOf(BlockLocation(block, Offset(0.meters))))
+                .setEndLocations(setOf(BlockLocation(block, Offset(1000.meters))))
                 .setUnavailableTimes(occupancyGraph)
                 .run() ?: return
         occupancyTest(res, occupancyGraph)
@@ -88,8 +87,8 @@ class BacktrackingTests {
         val res =
             STDCMPathfindingBuilder()
                 .setInfra(infra.fullInfra())
-                .setStartLocations(setOf(BlockLocation(firstBlock, Offset<Block>(0.meters))))
-                .setEndLocations(setOf(BlockLocation(lastBlock, Offset<Block>(5.meters))))
+                .setStartLocations(setOf(BlockLocation(firstBlock, Offset(0.meters))))
+                .setEndLocations(setOf(BlockLocation(lastBlock, Offset(5.meters))))
                 .setUnavailableTimes(occupancyGraph)
                 .run() ?: return
         occupancyTest(res, occupancyGraph)
@@ -128,8 +127,8 @@ class BacktrackingTests {
         val res =
             STDCMPathfindingBuilder()
                 .setInfra(infra.fullInfra())
-                .setStartLocations(setOf(BlockLocation(firstBlock, Offset<Block>(0.meters))))
-                .setEndLocations(setOf(BlockLocation(secondBlock, Offset<Block>(5.meters))))
+                .setStartLocations(setOf(BlockLocation(firstBlock, Offset(0.meters))))
+                .setEndLocations(setOf(BlockLocation(secondBlock, Offset(5.meters))))
                 .setUnavailableTimes(occupancyGraph)
                 .run() ?: return
         occupancyTest(res, occupancyGraph)
@@ -152,8 +151,8 @@ class BacktrackingTests {
         val res =
             STDCMPathfindingBuilder()
                 .setInfra(infra.fullInfra())
-                .setStartLocations(setOf(BlockLocation(firstBlock, Offset<Block>(0.meters))))
-                .setEndLocations(setOf(BlockLocation(lastBlock, Offset<Block>(1000.meters))))
+                .setStartLocations(setOf(BlockLocation(firstBlock, Offset(0.meters))))
+                .setEndLocations(setOf(BlockLocation(lastBlock, Offset(1000.meters))))
                 .run()!!
         Assertions.assertTrue(res.envelope.continuous)
     }

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/BacktrackingTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/BacktrackingTests.kt
@@ -2,7 +2,7 @@ package fr.sncf.osrd.stdcm
 
 import com.google.common.collect.ImmutableMultimap
 import fr.sncf.osrd.envelope_sim.Comfort
-import fr.sncf.osrd.stdcm.infra_exploration.BlockLocation
+import fr.sncf.osrd.sim_infra.api.BlockLocation
 import fr.sncf.osrd.stdcm.preprocessing.OccupancySegment
 import fr.sncf.osrd.train.TestTrains
 import fr.sncf.osrd.utils.DummyInfra

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/ConditionalOccupancyTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/ConditionalOccupancyTests.kt
@@ -3,7 +3,7 @@ package fr.sncf.osrd.stdcm
 import com.google.common.collect.ImmutableMultimap
 import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.sim_infra.api.BlockId
-import fr.sncf.osrd.stdcm.infra_exploration.BlockLocation
+import fr.sncf.osrd.sim_infra.api.BlockLocation
 import fr.sncf.osrd.stdcm.preprocessing.OccupancySegment
 import fr.sncf.osrd.utils.DummyInfra
 import fr.sncf.osrd.utils.units.Offset

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/DepartureTimeShiftTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/DepartureTimeShiftTests.kt
@@ -2,7 +2,7 @@ package fr.sncf.osrd.stdcm
 
 import com.google.common.collect.ImmutableMultimap
 import fr.sncf.osrd.envelope_sim.Comfort
-import fr.sncf.osrd.stdcm.infra_exploration.BlockLocation
+import fr.sncf.osrd.sim_infra.api.BlockLocation
 import fr.sncf.osrd.stdcm.preprocessing.OccupancySegment
 import fr.sncf.osrd.train.TestTrains
 import fr.sncf.osrd.utils.DummyInfra

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/DepartureTimeShiftTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/DepartureTimeShiftTests.kt
@@ -166,7 +166,12 @@ class DepartureTimeShiftTests {
         val secondBlock = infra.addBlock("b", "c")
         val firstBlockEnvelope =
             simulateBlock(
-                infraExplorerFromBlock(infra, infra, firstBlock),
+                infraExplorerFromBlock(
+                    infra,
+                    infra,
+                    TestTrains.REALISTIC_FAST_TRAIN.length.meters,
+                    firstBlock,
+                ),
                 0.0,
                 Offset(0.meters),
                 TestTrains.REALISTIC_FAST_TRAIN,

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/EngineeringAllowanceTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/EngineeringAllowanceTests.kt
@@ -4,7 +4,7 @@ import com.google.common.collect.ImmutableMultimap
 import fr.sncf.osrd.envelope_sim.Comfort
 import fr.sncf.osrd.envelope_sim.allowances.AllowanceValue
 import fr.sncf.osrd.sim_infra.api.BlockId
-import fr.sncf.osrd.stdcm.infra_exploration.BlockLocation
+import fr.sncf.osrd.sim_infra.api.BlockLocation
 import fr.sncf.osrd.stdcm.preprocessing.OccupancySegment
 import fr.sncf.osrd.train.TestTrains
 import fr.sncf.osrd.train.TestTrains.VERY_LONG_FAST_TRAIN

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/EngineeringAllowanceTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/EngineeringAllowanceTests.kt
@@ -39,7 +39,12 @@ class EngineeringAllowanceTests {
         val thirdBlock = infra.addBlock("c", "d", 100.meters, 30.0)
         val firstBlockEnvelope =
             simulateBlock(
-                infraExplorerFromBlock(infra, infra, firstBlock),
+                infraExplorerFromBlock(
+                    infra,
+                    infra,
+                    TestTrains.REALISTIC_FAST_TRAIN.length.meters,
+                    firstBlock,
+                ),
                 0.0,
                 Offset(0.meters),
                 TestTrains.REALISTIC_FAST_TRAIN,
@@ -51,7 +56,12 @@ class EngineeringAllowanceTests {
             )!!
         val secondBlockEnvelope =
             simulateBlock(
-                infraExplorerFromBlock(infra, infra, secondBlock),
+                infraExplorerFromBlock(
+                    infra,
+                    infra,
+                    TestTrains.REALISTIC_FAST_TRAIN.length.meters,
+                    secondBlock,
+                ),
                 firstBlockEnvelope.endSpeed,
                 Offset(0.meters),
                 TestTrains.REALISTIC_FAST_TRAIN,
@@ -119,7 +129,12 @@ class EngineeringAllowanceTests {
         val lastBlock = infra.addBlock("e", "f", 1000.meters, 20.0)
         val firstBlockEnvelope =
             simulateBlock(
-                infraExplorerFromBlock(infra, infra, firstBlock),
+                infraExplorerFromBlock(
+                    infra,
+                    infra,
+                    TestTrains.REALISTIC_FAST_TRAIN.length.meters,
+                    firstBlock,
+                ),
                 0.0,
                 Offset(0.meters),
                 TestTrains.REALISTIC_FAST_TRAIN,
@@ -131,7 +146,12 @@ class EngineeringAllowanceTests {
             )!!
         val secondBlockEnvelope =
             simulateBlock(
-                infraExplorerFromBlock(infra, infra, secondBlock),
+                infraExplorerFromBlock(
+                    infra,
+                    infra,
+                    TestTrains.REALISTIC_FAST_TRAIN.length.meters,
+                    secondBlock,
+                ),
                 firstBlockEnvelope.endSpeed,
                 Offset(0.meters),
                 TestTrains.REALISTIC_FAST_TRAIN,
@@ -202,7 +222,12 @@ class EngineeringAllowanceTests {
         val lastBlock = infra.addBlock("e", "f", 1000.meters, 20.0)
         val firstBlockEnvelope =
             simulateBlock(
-                infraExplorerFromBlock(infra, infra, firstBlock),
+                infraExplorerFromBlock(
+                    infra,
+                    infra,
+                    TestTrains.REALISTIC_FAST_TRAIN.length.meters,
+                    firstBlock,
+                ),
                 0.0,
                 Offset(0.meters),
                 TestTrains.REALISTIC_FAST_TRAIN,
@@ -214,7 +239,12 @@ class EngineeringAllowanceTests {
             )!!
         val secondBlockEnvelope =
             simulateBlock(
-                infraExplorerFromBlock(infra, infra, secondBlock),
+                infraExplorerFromBlock(
+                    infra,
+                    infra,
+                    TestTrains.REALISTIC_FAST_TRAIN.length.meters,
+                    secondBlock,
+                ),
                 firstBlockEnvelope.endSpeed,
                 Offset(0.meters),
                 TestTrains.REALISTIC_FAST_TRAIN,
@@ -630,7 +660,12 @@ class EngineeringAllowanceTests {
         val thirdBlock = infra.addBlock("c", "d", 100.meters, 0.5)
         val firstBlockEnvelope =
             simulateBlock(
-                infraExplorerFromBlock(infra, infra, firstBlock),
+                infraExplorerFromBlock(
+                    infra,
+                    infra,
+                    TestTrains.REALISTIC_FAST_TRAIN.length.meters,
+                    firstBlock,
+                ),
                 0.0,
                 Offset(0.meters),
                 TestTrains.REALISTIC_FAST_TRAIN,
@@ -642,7 +677,12 @@ class EngineeringAllowanceTests {
             )!!
         val secondBlockEnvelope =
             simulateBlock(
-                infraExplorerFromBlock(infra, infra, secondBlock),
+                infraExplorerFromBlock(
+                    infra,
+                    infra,
+                    TestTrains.REALISTIC_FAST_TRAIN.length.meters,
+                    secondBlock,
+                ),
                 firstBlockEnvelope.endSpeed,
                 Offset(0.meters),
                 TestTrains.REALISTIC_FAST_TRAIN,

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/FullSTDCMTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/FullSTDCMTests.kt
@@ -451,7 +451,7 @@ fun makeRequirementsFromPath(
                 null,
                 "",
                 null,
-                listOf(startLocations, endLocations),
+                listOf(startLocations, endLocations).map { PathItem(it, false) },
             ),
         )
             as PathfindingBlockSuccess

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/FullSTDCMTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/FullSTDCMTests.kt
@@ -451,7 +451,7 @@ fun makeRequirementsFromPath(
                 null,
                 "",
                 null,
-                listOf(startLocations, endLocations).map { PathItem(it, false) },
+                listOf(PathItem(startLocations, false), PathItem(endLocations, false)),
             ),
         )
             as PathfindingBlockSuccess

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/PerformanceTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/PerformanceTests.kt
@@ -4,7 +4,7 @@ import com.google.common.collect.ImmutableMultimap
 import com.google.common.collect.Iterables
 import fr.sncf.osrd.geom.Point
 import fr.sncf.osrd.sim_infra.api.BlockId
-import fr.sncf.osrd.stdcm.infra_exploration.BlockLocation
+import fr.sncf.osrd.sim_infra.api.BlockLocation
 import fr.sncf.osrd.stdcm.preprocessing.OccupancySegment
 import fr.sncf.osrd.utils.DummyInfra
 import fr.sncf.osrd.utils.units.Distance

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMHelpers.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMHelpers.kt
@@ -6,10 +6,10 @@ import fr.sncf.osrd.conflicts.SpacingRequirement
 import fr.sncf.osrd.envelope.Envelope
 import fr.sncf.osrd.envelope_sim.Comfort
 import fr.sncf.osrd.sim_infra.api.*
+import fr.sncf.osrd.sim_infra.api.BlockLocation
 import fr.sncf.osrd.sim_infra.impl.TemporarySpeedLimitManager
 import fr.sncf.osrd.standalone_sim.EnvelopeStopWrapper
 import fr.sncf.osrd.stdcm.graph.STDCMSimulations
-import fr.sncf.osrd.stdcm.infra_exploration.BlockLocation
 import fr.sncf.osrd.stdcm.infra_exploration.ExplorerStep
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorer
 import fr.sncf.osrd.stdcm.infra_exploration.initInfraExplorers

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMHelpers.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMHelpers.kt
@@ -16,6 +16,7 @@ import fr.sncf.osrd.stdcm.infra_exploration.initInfraExplorers
 import fr.sncf.osrd.stdcm.preprocessing.OccupancySegment
 import fr.sncf.osrd.train.RollingStock
 import fr.sncf.osrd.train.TestTrains
+import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import org.junit.jupiter.api.Assertions
@@ -30,7 +31,12 @@ fun getBlocksRunTime(infra: FullInfra, blocks: List<BlockId>): Double {
     for (block in blocks) {
         val envelope =
             simulateBlock(
-                infraExplorerFromBlock(infra.rawInfra, infra.blockInfra, block),
+                infraExplorerFromBlock(
+                    infra.rawInfra,
+                    infra.blockInfra,
+                    TestTrains.REALISTIC_FAST_TRAIN.length.meters,
+                    block,
+                ),
                 speed,
                 Offset(0.meters),
                 TestTrains.REALISTIC_FAST_TRAIN,
@@ -111,9 +117,15 @@ fun occupancyTest(
 fun infraExplorerFromBlock(
     rawInfra: RawInfra,
     blockInfra: BlockInfra,
+    rollingStockLength: Distance,
     block: BlockId,
 ): InfraExplorer {
-    return initInfraExplorers(rawInfra, blockInfra, BlockLocation(block, Offset(0.meters)))
+    return initInfraExplorers(
+            rawInfra,
+            blockInfra,
+            rollingStockLength,
+            BlockLocation(block, Offset(0.meters)),
+        )
         .elementAt(0)
 }
 

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMPathfindingBuilder.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMPathfindingBuilder.kt
@@ -82,7 +82,16 @@ data class STDCMPathfindingBuilder(
         startLocations: Set<BlockLocation>,
         plannedTimingData: PlannedTimingData? = null,
     ): STDCMPathfindingBuilder {
-        steps.add(0, ExplorerStep(startLocations, null, false, plannedTimingData))
+        steps.add(
+            0,
+            ExplorerStep(
+                startLocations,
+                duration = null,
+                stop = false,
+                canBacktrack = false,
+                plannedTimingData = plannedTimingData,
+            ),
+        )
         return this
     }
 
@@ -94,7 +103,15 @@ data class STDCMPathfindingBuilder(
         endLocations: Set<BlockLocation>,
         plannedTimingData: PlannedTimingData? = null,
     ): STDCMPathfindingBuilder {
-        steps.add(ExplorerStep(endLocations, 0.0, true, plannedTimingData))
+        steps.add(
+            ExplorerStep(
+                endLocations,
+                duration = 0.0,
+                stop = true,
+                canBacktrack = false,
+                plannedTimingData = plannedTimingData,
+            )
+        )
         return this
     }
 

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMPathfindingBuilder.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMPathfindingBuilder.kt
@@ -8,9 +8,9 @@ import fr.sncf.osrd.envelope_sim.Comfort
 import fr.sncf.osrd.envelope_sim.allowances.AllowanceValue
 import fr.sncf.osrd.pathfinding.Pathfinding
 import fr.sncf.osrd.sim_infra.api.BlockId
+import fr.sncf.osrd.sim_infra.api.BlockLocation
 import fr.sncf.osrd.sim_infra.impl.TemporarySpeedLimitManager
 import fr.sncf.osrd.stdcm.graph.findPath
-import fr.sncf.osrd.stdcm.infra_exploration.BlockLocation
 import fr.sncf.osrd.stdcm.infra_exploration.ExplorerStep
 import fr.sncf.osrd.stdcm.infra_exploration.PlannedTimingData
 import fr.sncf.osrd.stdcm.preprocessing.DummyBlockAvailability

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMPathfindingTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMPathfindingTests.kt
@@ -3,8 +3,8 @@ package fr.sncf.osrd.stdcm
 import com.google.common.collect.ImmutableMultimap
 import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.sim_infra.api.BlockId
+import fr.sncf.osrd.sim_infra.api.BlockLocation
 import fr.sncf.osrd.sim_infra.api.SpeedLimitProperty
-import fr.sncf.osrd.stdcm.infra_exploration.BlockLocation
 import fr.sncf.osrd.stdcm.infra_exploration.PlannedTimingData
 import fr.sncf.osrd.stdcm.preprocessing.OccupancySegment
 import fr.sncf.osrd.train.TestTrains

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/StandardAllowanceTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/StandardAllowanceTests.kt
@@ -3,7 +3,7 @@ package fr.sncf.osrd.stdcm
 import com.google.common.collect.ImmutableMultimap
 import fr.sncf.osrd.envelope_sim.allowances.AllowanceValue
 import fr.sncf.osrd.sim_infra.api.BlockId
-import fr.sncf.osrd.stdcm.infra_exploration.BlockLocation
+import fr.sncf.osrd.sim_infra.api.BlockLocation
 import fr.sncf.osrd.stdcm.preprocessing.OccupancySegment
 import fr.sncf.osrd.utils.DummyInfra
 import fr.sncf.osrd.utils.units.Offset

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/StopTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/StopTests.kt
@@ -5,9 +5,9 @@ import fr.sncf.osrd.envelope_sim.allowances.AllowanceValue
 import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal.SHORT_SLIP_STOP
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockId
+import fr.sncf.osrd.sim_infra.api.BlockLocation
 import fr.sncf.osrd.stdcm.StandardAllowanceTests.Companion.checkAllowanceResult
 import fr.sncf.osrd.stdcm.StandardAllowanceTests.Companion.runWithAndWithoutAllowance
-import fr.sncf.osrd.stdcm.infra_exploration.BlockLocation
 import fr.sncf.osrd.stdcm.infra_exploration.ExplorerStep
 import fr.sncf.osrd.stdcm.infra_exploration.PlannedTimingData
 import fr.sncf.osrd.stdcm.preprocessing.OccupancySegment

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/TemporarySpeedLimitTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/TemporarySpeedLimitTests.kt
@@ -5,8 +5,10 @@ import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.api.stdcm.STDCMTemporarySpeedLimit
 import fr.sncf.osrd.api.stdcm.buildTemporarySpeedLimitManager
 import fr.sncf.osrd.railjson.schema.common.graph.EdgeDirection
-import fr.sncf.osrd.sim_infra.api.*
-import fr.sncf.osrd.stdcm.infra_exploration.BlockLocation
+import fr.sncf.osrd.sim_infra.api.BlockLocation
+import fr.sncf.osrd.sim_infra.api.DirDetectorId
+import fr.sncf.osrd.sim_infra.api.SpeedLimitProperty
+import fr.sncf.osrd.sim_infra.api.SpeedLimitSource
 import fr.sncf.osrd.utils.Direction
 import fr.sncf.osrd.utils.DistanceRangeMap.RangeMapEntry
 import fr.sncf.osrd.utils.Helpers.smallInfra

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/VisitedNodesTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/VisitedNodesTests.kt
@@ -303,10 +303,12 @@ class VisitedNodesTests {
             )
 
         // d -> e
-        val lastExplorer = infraExplorerFromBlock(infra, infra, blocks.last())
+        val lastExplorer =
+            infraExplorerFromBlock(infra, infra, STANDARD_TRAIN.length.meters, blocks.last())
 
         // a -> b, lookahead: b -> c -> d
-        var explorerWithLookahead = infraExplorerFromBlock(infra, infra, blocks.first())
+        var explorerWithLookahead =
+            infraExplorerFromBlock(infra, infra, STANDARD_TRAIN.length.meters, blocks.first())
         for (i in 0..<2) explorerWithLookahead =
             explorerWithLookahead.cloneAndExtendLookahead().first()
 

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerTests.kt
@@ -33,6 +33,7 @@ class InfraExplorerTests {
             initInfraExplorers(
                 infra,
                 infra,
+                TestTrains.REALISTIC_FAST_TRAIN.length.meters,
                 BlockLocation(block, Offset(0.meters)),
                 stepsFromLocations(BlockLocation(block, infra.getBlockLength(block))),
             )
@@ -60,6 +61,7 @@ class InfraExplorerTests {
             initInfraExplorers(
                 infra,
                 infra,
+                TestTrains.REALISTIC_FAST_TRAIN.length.meters,
                 BlockLocation(blocks[0], Offset(0.meters)),
                 stepsFromLocations(
                     BlockLocation(blocks.last(), infra.getBlockLength(blocks.last()))
@@ -120,7 +122,12 @@ class InfraExplorerTests {
 
         // a --> b
         val firstExplorers =
-            initInfraExplorers(infra, infra, BlockLocation(blocks[0], Offset(0.meters)))
+            initInfraExplorers(
+                infra,
+                infra,
+                TestTrains.REALISTIC_FAST_TRAIN.length.meters,
+                BlockLocation(blocks[0], Offset(0.meters)),
+            )
         assertEquals(1, firstExplorers.size)
         val firstExplorer = firstExplorers.first()
 
@@ -212,6 +219,7 @@ class InfraExplorerTests {
             initInfraExplorers(
                 infra,
                 infra,
+                TestTrains.FAST_ELECTRIC_TRAIN.length.meters,
                 BlockLocation(blocks[0], Offset(0.meters)),
                 constraints = listOf(electrificationConstraints),
             )
@@ -262,6 +270,7 @@ class InfraExplorerTests {
             initInfraExplorers(
                 infra.rawInfra,
                 infra.blockInfra,
+                TestTrains.REALISTIC_FAST_TRAIN.length.meters,
                 BlockLocation(firstBlock, Offset(0.meters)),
             )
         assertEquals(2, firstExplorers.size) // There should be one instance per route
@@ -301,6 +310,7 @@ class InfraExplorerTests {
             initInfraExplorers(
                 infra.rawInfra,
                 infra.blockInfra,
+                TestTrains.REALISTIC_FAST_TRAIN.length.meters,
                 BlockLocation(block, Offset(0.meters)),
             )
         assertEquals(4, explorers.size) // There should be one instance per route
@@ -339,6 +349,7 @@ class InfraExplorerTests {
             initInfraExplorers(
                     infra.rawInfra,
                     infra.blockInfra,
+                    TestTrains.REALISTIC_FAST_TRAIN.length.meters,
                     BlockLocation(block, Offset(0.meters)),
                 )
                 .toList()
@@ -367,6 +378,7 @@ class InfraExplorerTests {
             initInfraExplorers(
                     infra,
                     infra,
+                    TestTrains.REALISTIC_FAST_TRAIN.length.meters,
                     BlockLocation(blocks[0], Offset(50.meters)),
                     stepsFromLocations(
                         BlockLocation(blocks[0], Offset(50.meters)),
@@ -405,6 +417,7 @@ class InfraExplorerTests {
             initInfraExplorers(
                     infra.rawInfra,
                     infra.blockInfra,
+                    TestTrains.REALISTIC_FAST_TRAIN.length.meters,
                     BlockLocation(block, Offset(32.meters)),
                     stepsFromLocations(BlockLocation(block, Offset(42.meters)), stops = true),
                 )

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerTests.kt
@@ -2,6 +2,7 @@ package fr.sncf.osrd.stdcm.infra_exploration
 
 import fr.sncf.osrd.pathfinding.constraints.ElectrificationConstraints
 import fr.sncf.osrd.sim_infra.api.BlockId
+import fr.sncf.osrd.sim_infra.api.BlockLocation
 import fr.sncf.osrd.sim_infra.api.DirDetectorId
 import fr.sncf.osrd.sim_infra.utils.routesOnBlock
 import fr.sncf.osrd.stdcm.stepsFromLocations

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelopeTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelopeTests.kt
@@ -5,6 +5,7 @@ import fr.sncf.osrd.envelope.Envelope
 import fr.sncf.osrd.envelope.EnvelopeTimeInterpolate
 import fr.sncf.osrd.envelope.part.EnvelopePart
 import fr.sncf.osrd.envelope_sim.EnvelopeProfile
+import fr.sncf.osrd.sim_infra.api.BlockLocation
 import fr.sncf.osrd.train.TestTrains.REALISTIC_FAST_TRAIN
 import fr.sncf.osrd.utils.DummyInfra
 import fr.sncf.osrd.utils.arePositionsEqual

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/infra_exploration/StepTrackerTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/infra_exploration/StepTrackerTests.kt
@@ -36,7 +36,8 @@ class StepTrackerTests {
             )
         val tracker = StepTracker(steps)
 
-        val firstSteps = tracker.exploreBlockRange(blocks[0], Offset(25.meters), Offset(100.meters))
+        val firstSteps =
+            tracker.exploreBlockRange(blocks[0], Offset(25.meters), Offset(100.meters), false)
         val expectedFirstSteps =
             listOf(
                 LocatedStep(Offset(25.meters), steps[0].locations.single(), steps[0]),
@@ -47,7 +48,8 @@ class StepTrackerTests {
                 ),
             )
         assertEquals(expectedFirstSteps, firstSteps)
-        val second = tracker.exploreBlockRange(blocks[1], Offset(0.meters), Offset(100.meters))
+        val second =
+            tracker.exploreBlockRange(blocks[1], Offset(0.meters), Offset(100.meters), false)
         val expectedSecond =
             listOf(
                 LocatedStep(Offset(75.meters), steps[2].locations.single(), steps[2]),
@@ -55,7 +57,8 @@ class StepTrackerTests {
             )
         assertEquals(expectedSecond, second)
         assertFalse { tracker.hasSeenDestination() }
-        val third = tracker.exploreBlockRange(blocks[2], Offset(0.meters), Offset(100.meters))
+        val third =
+            tracker.exploreBlockRange(blocks[2], Offset(0.meters), Offset(100.meters), false)
         val expectedThird =
             listOf(LocatedStep(Offset(275.meters), steps[4].locations.single(), steps[4]))
         assertEquals(expectedThird, third)

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/infra_exploration/StepTrackerTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/infra_exploration/StepTrackerTests.kt
@@ -1,5 +1,6 @@
 package fr.sncf.osrd.stdcm.infra_exploration
 
+import fr.sncf.osrd.sim_infra.api.BlockLocation
 import fr.sncf.osrd.utils.DummyInfra
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/BlockAvailabilityTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/BlockAvailabilityTests.kt
@@ -7,8 +7,8 @@ import fr.sncf.osrd.envelope.part.EnvelopePart
 import fr.sncf.osrd.envelope_sim.EnvelopeProfile
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockId
+import fr.sncf.osrd.sim_infra.api.BlockLocation
 import fr.sncf.osrd.sim_infra.api.DirDetectorId
-import fr.sncf.osrd.stdcm.infra_exploration.BlockLocation
 import fr.sncf.osrd.stdcm.infra_exploration.ExplorerStep
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
 import fr.sncf.osrd.stdcm.infra_exploration.PlannedTimingData

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/BlockAvailabilityTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/BlockAvailabilityTests.kt
@@ -623,6 +623,7 @@ class BlockAvailabilityTests {
                     listOf(BlockLocation(blocks[0], plannedStepOffset)),
                     null,
                     false,
+                    false,
                     PlannedTimingData(0.seconds, 0.seconds, timeAtZoneEnd.seconds),
                 )
             )
@@ -650,11 +651,13 @@ class BlockAvailabilityTests {
                     listOf(BlockLocation(blocks[0], outOfBoundsStepOffset)),
                     null,
                     false,
+                    false,
                     PlannedTimingData(0.seconds, 0.seconds, 0.seconds),
                 ),
                 ExplorerStep(
                     listOf(BlockLocation(blocks[1], Offset(0.meters))),
                     null,
+                    false,
                     false,
                     PlannedTimingData(0.seconds, 0.seconds, 0.seconds),
                 ),
@@ -686,6 +689,7 @@ class BlockAvailabilityTests {
                 ExplorerStep(
                     listOf(BlockLocation(blocks[0], plannedStepOffset)),
                     null,
+                    false,
                     false,
                     PlannedTimingData(
                         30.seconds,
@@ -736,6 +740,7 @@ class BlockAvailabilityTests {
                     listOf(BlockLocation(blocks[0], plannedStepOffset)),
                     null,
                     false,
+                    false,
                     PlannedTimingData(0.seconds, 0.seconds, 0.seconds),
                 )
             )
@@ -771,6 +776,7 @@ class BlockAvailabilityTests {
                 ExplorerStep(
                     listOf(BlockLocation(blocks[0], plannedStepOffset)),
                     null,
+                    false,
                     false,
                     PlannedTimingData(0.seconds, 0.seconds, 0.seconds),
                 )
@@ -810,6 +816,7 @@ class BlockAvailabilityTests {
                     listOf(BlockLocation(blocks[0], plannedStepOffset)),
                     null,
                     false,
+                    false,
                     PlannedTimingData(minDelay.seconds, 0.seconds, 10.seconds),
                 )
             )
@@ -844,6 +851,7 @@ class BlockAvailabilityTests {
                     listOf(BlockLocation(blocks[0], plannedStepOffset)),
                     null,
                     false,
+                    false,
                     PlannedTimingData(
                         (timeAtZoneEnd + internalMarginForSteps).seconds,
                         0.seconds,
@@ -854,6 +862,7 @@ class BlockAvailabilityTests {
                 ExplorerStep(
                     listOf(BlockLocation(blocks[0], secondPlannedStepOffset)),
                     null,
+                    false,
                     false,
                     PlannedTimingData(0.seconds, 0.seconds, timeAtZoneEnd.seconds),
                 ),
@@ -892,6 +901,7 @@ class BlockAvailabilityTests {
                 ExplorerStep(
                     listOf(BlockLocation(blocks[0], Offset(100.meters))),
                     null,
+                    false,
                     false,
                     PlannedTimingData(
                         timeAtZoneEnd.seconds,

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/ConsistChangeTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/ConsistChangeTests.kt
@@ -1,6 +1,7 @@
 package fr.sncf.osrd.stdcm.preprocessing
 
 import fr.sncf.osrd.api.ConsistSchedule
+import fr.sncf.osrd.api.PathItem
 import fr.sncf.osrd.api.TrackLocation
 import fr.sncf.osrd.api.stdcm.ConsistConfiguration
 import fr.sncf.osrd.api.stdcm.RequestConsistSchedule
@@ -35,8 +36,8 @@ class ConsistChangeTests {
     fun explorationWithConsistChangeProducesExpectedOutput() {
         val infra = Helpers.fullInfraFromFile("small_infra/infra.json")
         val start = convertRouteLocation(infra, "rt.buffer_stop.1->DA0", Offset(100.meters))
-        val middle_1 = convertRouteLocation(infra, "rt.DC4->DD2", Offset(400.meters))
-        val middle_2 = convertRouteLocation(infra, "rt.DD2->DD6", Offset(200.meters))
+        val middle1 = convertRouteLocation(infra, "rt.DC4->DD2", Offset(400.meters))
+        val middle2 = convertRouteLocation(infra, "rt.DD2->DD6", Offset(200.meters))
         val end = convertRouteLocation(infra, "rt.DG4->buffer_stop.6", Offset(2000.meters))
         val requirements = emptyList<SpacingRequirement>()
         val slowTrain =
@@ -55,8 +56,8 @@ class ConsistChangeTests {
             STDCMPathfindingBuilder()
                 .setInfra(infra)
                 .setStartLocations(start.blockLocations)
-                .addStep(ExplorerStep(middle_1.blockLocations, duration = 2000.0, stop = true))
-                .addStep(ExplorerStep(middle_2.blockLocations, duration = 2000.0, stop = true))
+                .addStep(ExplorerStep(middle1.blockLocations, duration = 2000.0, stop = true))
+                .addStep(ExplorerStep(middle2.blockLocations, duration = 2000.0, stop = true))
                 .setEndLocations(end.blockLocations)
                 .setBlockAvailability(makeBlockAvailability(requirements))
                 .setStandardAllowance(AllowanceValue.Percentage(0.0))
@@ -90,8 +91,8 @@ class ConsistChangeTests {
     fun displayGraphicalResult() {
         val infra = Helpers.fullInfraFromFile("small_infra/infra.json")
         val start = convertRouteLocation(infra, "rt.buffer_stop.1->DA0", Offset(100.meters))
-        val middle_1 = convertRouteLocation(infra, "rt.DC4->DD2", Offset(400.meters))
-        val middle_2 = convertRouteLocation(infra, "rt.DD2->DD6", Offset(200.meters))
+        val middle1 = convertRouteLocation(infra, "rt.DC4->DD2", Offset(400.meters))
+        val middle2 = convertRouteLocation(infra, "rt.DD2->DD6", Offset(200.meters))
         val end = convertRouteLocation(infra, "rt.DG4->buffer_stop.6", Offset(2000.meters))
         val requirements = emptyList<SpacingRequirement>()
         val slowTrain =
@@ -110,8 +111,8 @@ class ConsistChangeTests {
             STDCMPathfindingBuilder()
                 .setInfra(infra)
                 .setStartLocations(start.blockLocations)
-                .addStep(ExplorerStep(middle_1.blockLocations, duration = 2000.0, stop = true))
-                .addStep(ExplorerStep(middle_2.blockLocations, duration = 2000.0, stop = true))
+                .addStep(ExplorerStep(middle1.blockLocations, duration = 2000.0, stop = true))
+                .addStep(ExplorerStep(middle2.blockLocations, duration = 2000.0, stop = true))
                 .setEndLocations(end.blockLocations)
                 .setBlockAvailability(makeBlockAvailability(requirements))
                 .setStandardAllowance(AllowanceValue.Percentage(0.0))
@@ -238,8 +239,8 @@ class ConsistChangeTests {
         // Mixing up stop steps with and without consist changes
         val infra = Helpers.fullInfraFromFile("small_infra/infra.json")
         val start = convertRouteLocation(infra, "rt.buffer_stop.1->DA0", Offset(100.meters))
-        val step_1 = convertRouteLocation(infra, "rt.DC4->DD2", Offset(400.meters))
-        val step_2 = convertRouteLocation(infra, "rt.DD2->DD6", Offset(200.meters))
+        val step1 = convertRouteLocation(infra, "rt.DC4->DD2", Offset(400.meters))
+        val step2 = convertRouteLocation(infra, "rt.DD2->DD6", Offset(200.meters))
         val end = convertRouteLocation(infra, "rt.DG4->buffer_stop.6", Offset(2000.meters))
         val requirements = emptyList<SpacingRequirement>()
         val slowTrain =
@@ -254,8 +255,8 @@ class ConsistChangeTests {
             STDCMPathfindingBuilder()
                 .setInfra(infra)
                 .setStartLocations(start.blockLocations)
-                .addStep(ExplorerStep(step_1.blockLocations, duration = 2000.0, stop = true))
-                .addStep(ExplorerStep(step_2.blockLocations, duration = 2000.0, stop = true))
+                .addStep(ExplorerStep(step1.blockLocations, duration = 2000.0, stop = true))
+                .addStep(ExplorerStep(step2.blockLocations, duration = 2000.0, stop = true))
                 .setEndLocations(end.blockLocations)
                 .setBlockAvailability(makeBlockAvailability(requirements))
                 .setStandardAllowance(AllowanceValue.Percentage(0.0))
@@ -361,19 +362,23 @@ class ConsistChangeTests {
         val consistShortLongShort = ConsistSchedule(requestShortLongShort, infra, null, nbSteps)
         val pathItems =
             listOf(
-                STDCMPathItem(listOf(TrackLocation("TB0", Offset(0.0.meters))), null, null),
                 STDCMPathItem(
-                    listOf(TrackLocation("TB0", Offset(500.0.meters))),
+                    PathItem(listOf(TrackLocation("TB0", Offset(0.0.meters))), false),
+                    null,
+                    null,
+                ),
+                STDCMPathItem(
+                    PathItem(listOf(TrackLocation("TB0", Offset(500.0.meters))), false),
                     Duration(100_000),
                     null,
                 ),
                 STDCMPathItem(
-                    listOf(TrackLocation("TB0", Offset(1000.0.meters))),
+                    PathItem(listOf(TrackLocation("TB0", Offset(1000.0.meters))), false),
                     Duration(100_000),
                     null,
                 ),
                 STDCMPathItem(
-                    listOf(TrackLocation("TB0", Offset(1500.meters))),
+                    PathItem(listOf(TrackLocation("TB0", Offset(1500.meters))), false),
                     Duration(100_000),
                     null,
                 ),

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
@@ -68,7 +68,14 @@ class STDCMHeuristicTests {
 
         // Current block = 0
         var explorer =
-            initInfraExplorers(infra, infra, steps.first().locations.first(), steps).single()
+            initInfraExplorers(
+                    infra,
+                    infra,
+                    STANDARD_TRAIN.length.meters,
+                    steps.first().locations.first(),
+                    steps,
+                )
+                .single()
 
         // Heuristic takes into account decelerations: decelerations add 1s to remaining time,
         // because the train decelerates on 1m and takes 2s instead of 1s at constant speed.
@@ -152,7 +159,14 @@ class STDCMHeuristicTests {
                 .build()
 
         val explorer =
-            initInfraExplorers(infra, infra, steps.first().locations.first(), steps).single()
+            initInfraExplorers(
+                    infra,
+                    infra,
+                    STANDARD_TRAIN.length.meters,
+                    steps.first().locations.first(),
+                    steps,
+                )
+                .single()
 
         val resWithAllowance =
             getLocationRemainingTime(infra, explorer, 50.meters, heuristicWithAllowance)
@@ -205,7 +219,14 @@ class STDCMHeuristicTests {
                 .build()
 
         var explorer =
-            initInfraExplorers(infra, infra, steps.first().locations.first(), steps).single()
+            initInfraExplorers(
+                    infra,
+                    infra,
+                    STANDARD_TRAIN.length.meters,
+                    steps.first().locations.first(),
+                    steps,
+                )
+                .single()
 
         // Heuristic takes into account decelerations: decelerations add 1s to remaining time,
         // because the train decelerates on 1m and takes 2s instead of 1s at constant speed.
@@ -224,7 +245,14 @@ class STDCMHeuristicTests {
         }
 
         var wrongPathExplorer =
-            initInfraExplorers(infra, infra, steps.first().locations.first(), steps).single()
+            initInfraExplorers(
+                    infra,
+                    infra,
+                    STANDARD_TRAIN.length.meters,
+                    steps.first().locations.first(),
+                    steps,
+                )
+                .single()
         repeat(2) {
             wrongPathExplorer =
                 wrongPathExplorer.cloneAndExtendLookahead().single {

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
@@ -6,13 +6,13 @@ import fr.sncf.osrd.envelope.Envelope.Companion.make
 import fr.sncf.osrd.envelope.EnvelopeTestUtils
 import fr.sncf.osrd.envelope_sim.SimpleRollingStock.Companion.STANDARD_TRAIN
 import fr.sncf.osrd.envelope_sim.allowances.AllowanceValue
+import fr.sncf.osrd.sim_infra.api.BlockLocation
 import fr.sncf.osrd.stdcm.CachedBlockMaxSpeedEnvBuilder
 import fr.sncf.osrd.stdcm.STDCMAStarHeuristic
 import fr.sncf.osrd.stdcm.STDCMHeuristicBuilder
 import fr.sncf.osrd.stdcm.graph.STDCMEdge
 import fr.sncf.osrd.stdcm.graph.STDCMNode
 import fr.sncf.osrd.stdcm.graph.TimeData
-import fr.sncf.osrd.stdcm.infra_exploration.BlockLocation
 import fr.sncf.osrd.stdcm.infra_exploration.ExplorerStep
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorer
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelopeImpl

--- a/core/src/test/kotlin/fr/sncf/osrd/utils/Helpers.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/utils/Helpers.kt
@@ -13,12 +13,12 @@ import fr.sncf.osrd.railjson.schema.infra.RJSInfra
 import fr.sncf.osrd.railjson.schema.rollingstock.RJSRollingResistance
 import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.sim_infra.api.BlockId
+import fr.sncf.osrd.sim_infra.api.BlockLocation
 import fr.sncf.osrd.sim_infra.api.Route
 import fr.sncf.osrd.sim_infra.api.SignalingSystem
 import fr.sncf.osrd.sim_infra.api.SignalingSystemId
 import fr.sncf.osrd.sim_infra.utils.recoverBlocks
 import fr.sncf.osrd.sim_infra.utils.toBlockList
-import fr.sncf.osrd.stdcm.infra_exploration.BlockLocation
 import fr.sncf.osrd.utils.indexing.MutableStaticIdxArrayList
 import fr.sncf.osrd.utils.indexing.StaticIdx
 import fr.sncf.osrd.utils.json.UnitAdapterFactory

--- a/editoast/core_client/src/pathfinding.rs
+++ b/editoast/core_client/src/pathfinding.rs
@@ -22,8 +22,8 @@ pub struct PathfindingRequest {
     pub infra: i64,
     /// Infrastructure expected version
     pub expected_version: i64,
-    /// List of waypoints. Each waypoint is a list of track offset.
-    pub path_items: Vec<Vec<TrackOffset>>,
+    /// List of waypoints. Each waypoint is a list of track offsets.
+    pub path_items: Vec<PathItem>,
     /// The loading gauge of the rolling stock
     pub rolling_stock_loading_gauge: LoadingGaugeType,
     /// Can the rolling stock run on non-electrified tracks
@@ -44,6 +44,15 @@ pub struct PathfindingRequest {
     /// Stops the train at a new stop position: near next block-delimiting signal,
     /// staying in the same block and keeping the tail on the initial position
     pub stops_at_end_of_block: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Deserialize, ToSchema, Hash)]
+#[schema(as = CorePathItem)]
+pub struct PathItem {
+    /// The track offsets of the path item.
+    pub locations: Vec<TrackOffset>,
+    /// If true, the train can backtrack at these track offsets.
+    pub can_backtrack: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
@@ -122,6 +131,8 @@ pub struct PathfindingResultSuccess {
     /// The path offset in mm of each path item given as input of the pathfinding
     /// The first value is always `0` (beginning of the path) and the last one is always equal to the `length` of the path in mm
     pub path_item_positions: Vec<u64>,
+    /// The path offset in mm of each position where the train backtracks
+    pub backtrack_positions: Option<Vec<u64>>,
 }
 
 // Enum for input-related errors

--- a/editoast/core_client/src/simulation.rs
+++ b/editoast/core_client/src/simulation.rs
@@ -282,6 +282,8 @@ pub struct Request {
     pub electrical_profile_set_id: Option<i64>,
     /// The path offset in mm of each path item given as input of the pathfinding
     pub path_item_positions: Vec<u64>,
+    /// The path offset in mm of each position where the train backtracks
+    pub backtrack_positions: Option<Vec<u64>>,
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]

--- a/editoast/core_client/src/stdcm.rs
+++ b/editoast/core_client/src/stdcm.rs
@@ -2,7 +2,6 @@ use std::collections::HashSet;
 
 use chrono::DateTime;
 use chrono::Utc;
-use schemas::infra::TrackOffset;
 use schemas::rolling_stock::LoadingGaugeType;
 use schemas::train_schedule::Comfort;
 use schemas::train_schedule::MarginValue;
@@ -10,6 +9,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
 
+use super::pathfinding::PathItem;
 use super::pathfinding::PathfindingResultSuccess;
 use super::pathfinding::TrackRange;
 use super::simulation::PhysicsConsist;
@@ -30,7 +30,7 @@ pub struct Request {
 
     // Pathfinding inputs
     /// List of waypoints. Each waypoint is a list of track offset.
-    pub path_items: Vec<PathItem>,
+    pub path_items: Vec<STDCMPathItem>,
     /// Set of authorized track section ids for the current request
     pub allowed_track_sections: Option<HashSet<String>>,
 
@@ -62,10 +62,10 @@ pub struct Request {
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Deserialize, ToSchema)]
-#[schema(as = CorePathItem)]
-pub struct PathItem {
-    /// The track offsets of the path item
-    pub locations: Vec<TrackOffset>,
+#[schema(as = CoreSTDCMPathItem)]
+pub struct STDCMPathItem {
+    /// The path item containing its locations and backtrack information.
+    pub path_item: PathItem,
     /// Stop duration in milliseconds. None if the train does not stop at this path item.
     pub stop_duration: Option<u64>,
     /// If specified, describes when the train may arrive at the location

--- a/editoast/core_task/src/envs/pathfinding.rs
+++ b/editoast/core_task/src/envs/pathfinding.rs
@@ -384,7 +384,10 @@ fn build_request(
             .path_items
             .iter()
             .map(|PathWaypointAlternatives(track_alternatives)| {
-                track_alternatives.clone().into_iter().collect()
+                core_client::pathfinding::PathItem {
+                    locations: track_alternatives.clone(),
+                    can_backtrack: Some(false),
+                }
             })
             .collect(),
         rolling_stock_loading_gauge: consist.loading_gauge,

--- a/editoast/core_task/src/envs/simulation.rs
+++ b/editoast/core_task/src/envs/simulation.rs
@@ -342,6 +342,7 @@ pub(crate) mod test_data {
                 },
                 length: id as u64,
                 path_item_positions: (1..=positions_count).collect(),
+                backtrack_positions: Some(vec![]),
             },
         );
         let mut path = serde_json::to_value(response).unwrap();

--- a/editoast/core_task/src/envs/simulation/request.rs
+++ b/editoast/core_task/src/envs/simulation/request.rs
@@ -19,6 +19,7 @@ pub(super) fn build_request(
     core_client::pathfinding::PathfindingResultSuccess {
         path,
         path_item_positions,
+        backtrack_positions,
         ..
     }: core_client::pathfinding::PathfindingResultSuccess,
 ) -> Result<core_client::simulation::Request, ()> {
@@ -115,6 +116,7 @@ pub(super) fn build_request(
         physics_consist: sim_consist.0.clone(),
         path,
         path_item_positions,
+        backtrack_positions,
     })
 }
 
@@ -169,6 +171,7 @@ mod tests {
             path: path.clone(),
             length: 100,
             path_item_positions: path_item_positions.clone(),
+            backtrack_positions: Some(vec![]),
         };
 
         let core_env = CoreEnv::new_mock(MockingClient::new());
@@ -241,6 +244,7 @@ mod tests {
             physics_consist: sim_consist.0,
             path,
             path_item_positions,
+            backtrack_positions: Some(vec![]),
         };
 
         assert_eq!(request, expected);
@@ -259,6 +263,7 @@ mod tests {
             path: path.clone(),
             length: 100,
             path_item_positions: path_item_positions.clone(),
+            backtrack_positions: Some(vec![]),
         };
 
         let core_env = CoreEnv::new_mock(MockingClient::new());
@@ -385,6 +390,7 @@ mod tests {
             physics_consist: sim_consist.0,
             path,
             path_item_positions,
+            backtrack_positions: Some(vec![]),
         };
 
         assert_eq!(request, expected);
@@ -404,6 +410,7 @@ mod tests {
             path,
             length: 100,
             path_item_positions: path_positions,
+            backtrack_positions: Some(vec![]),
         };
 
         let core_env = CoreEnv::new_mock(MockingClient::new());

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -5653,23 +5653,16 @@ components:
       required:
       - locations
       properties:
+        can_backtrack:
+          type:
+          - boolean
+          - 'null'
+          description: If true, the train can backtrack at these track offsets.
         locations:
           type: array
           items:
             $ref: '#/components/schemas/TrackOffset'
-          description: The track offsets of the path item
-        step_timing_data:
-          oneOf:
-          - type: 'null'
-          - $ref: '#/components/schemas/CoreStepTimingData'
-            description: If specified, describes when the train may arrive at the location
-        stop_duration:
-          type:
-          - integer
-          - 'null'
-          format: int64
-          description: Stop duration in milliseconds. None if the train does not stop at this path item.
-          minimum: 0
+          description: The track offsets of the path item.
     CorePathfindingInputError:
       oneOf:
       - type: object
@@ -5797,6 +5790,15 @@ components:
       - length
       - path_item_positions
       properties:
+        backtrack_positions:
+          type:
+          - array
+          - 'null'
+          items:
+            type: integer
+            format: int64
+            minimum: 0
+          description: The path offset in mm of each position where the train backtracks
         length:
           type: integer
           format: int64
@@ -5901,6 +5903,26 @@ components:
             type: string
         zone:
           type: string
+    CoreSTDCMPathItem:
+      type: object
+      required:
+      - path_item
+      properties:
+        path_item:
+          $ref: '#/components/schemas/CorePathItem'
+          description: The path item containing its locations and backtrack information.
+        step_timing_data:
+          oneOf:
+          - type: 'null'
+          - $ref: '#/components/schemas/CoreStepTimingData'
+            description: If specified, describes when the train may arrive at the location
+        stop_duration:
+          type:
+          - integer
+          - 'null'
+          format: int64
+          description: Stop duration in milliseconds. None if the train does not stop at this path item.
+          minimum: 0
     CoreSignalCriticalPosition:
       type: object
       description: |-
@@ -6066,7 +6088,7 @@ components:
         path_items:
           type: array
           items:
-            $ref: '#/components/schemas/CorePathItem'
+            $ref: '#/components/schemas/CoreSTDCMPathItem'
           description: List of waypoints. Each waypoint is a list of track offset.
         start_time:
           type: string

--- a/editoast/src/views/level_crossing_occupancy.rs
+++ b/editoast/src/views/level_crossing_occupancy.rs
@@ -439,6 +439,7 @@ mod tests {
             },
             length: 14450000,
             path_item_positions: vec![0, 14450000],
+            backtrack_positions: Some(vec![]),
         }
     }
 

--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -247,7 +247,7 @@ pub(in crate::views) async fn post(
     let op_cache = OperationalPointCache::load_path_items(conn, infra.id, &path_items).await?;
     let request = match build_pathfinding_request(&path_input, &infra, &op_cache) {
         Ok(request) => request,
-        Err(result) => return Ok(Json(result)),
+        Err(result) => return Ok(Json(*result)),
     };
     Ok(Json(
         match request
@@ -339,7 +339,7 @@ async fn pathfinding_blocks_batch(
                 to_compute_hashes.push(hash);
             }
             Err(result) => {
-                let arc_result = Arc::new(result.clone());
+                let arc_result = Arc::new(*result.clone());
                 hash_to_path_indexes[hash]
                     .iter()
                     .for_each(|index| pathfinding_results[*index] = arc_result.clone());
@@ -364,7 +364,7 @@ async fn pathfinding_blocks_batch(
     for (path_result, hash) in computed_paths.into_iter().zip(to_compute_hashes) {
         let result = match path_result {
             Ok(path) => {
-                to_cache.push((hash, path.clone().into()));
+                to_cache.push((hash, Box::new(path.clone().into())));
                 Arc::new(path.into())
             }
             // TODO: only make HTTP status code errors non-fatal
@@ -389,12 +389,12 @@ fn build_pathfinding_request(
     pathfinding_input: &PathfindingInput,
     infra: &Infra,
     op_cache: &OperationalPointCache,
-) -> std::result::Result<PathfindingRequest, PathfindingResult> {
+) -> std::result::Result<PathfindingRequest, Box<PathfindingResult>> {
     let path_items: Vec<_> = pathfinding_input.path_items.iter().collect();
     if path_items.len() <= 1 {
-        return Err(PathfindingResult::Failure(
+        return Err(Box::from(PathfindingResult::Failure(
             PathfindingFailure::PathfindingInputError(PathfindingInputError::NotEnoughPathItems),
-        ));
+        )));
     }
     let track_offsets = op_cache
         .extract_location_from_path_items(&path_items)
@@ -404,7 +404,13 @@ fn build_pathfinding_request(
     Ok(PathfindingRequest {
         infra: infra.id,
         expected_version: infra.version,
-        path_items: track_offsets,
+        path_items: track_offsets
+            .into_iter()
+            .map(|offsets| core_client::pathfinding::PathItem {
+                locations: offsets,
+                can_backtrack: Some(false),
+            })
+            .collect(),
         rolling_stock_loading_gauge: pathfinding_input.rolling_stock_loading_gauge,
         rolling_stock_is_thermal: pathfinding_input.rolling_stock_is_thermal,
         rolling_stock_supported_electrifications: pathfinding_input
@@ -549,6 +555,7 @@ pub mod tests {
             },
             length,
             path_item_positions: vec![],
+            backtrack_positions: Some(vec![]),
         })
     }
 

--- a/editoast/src/views/timetable/simulation.rs
+++ b/editoast/src/views/timetable/simulation.rs
@@ -736,6 +736,7 @@ fn build_simulation_request<T: TrainScheduleLike>(
         physics_consist,
         electrical_profile_set_id,
         path_item_positions: path_item_positions.to_vec(),
+        backtrack_positions: Some(vec![]),
     }
 }
 

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -768,6 +768,7 @@ mod tests {
             },
             length: 1,
             path_item_positions: vec![0, 10],
+            backtrack_positions: Some(vec![]),
         }
     }
 

--- a/editoast/src/views/timetable/stdcm/request.rs
+++ b/editoast/src/views/timetable/stdcm/request.rs
@@ -251,7 +251,7 @@ impl Request {
         &self,
         conn: DbConnection,
         infra_id: i64,
-    ) -> Result<Vec<core_client::stdcm::PathItem>> {
+    ) -> Result<Vec<core_client::stdcm::STDCMPathItem>> {
         let locations: Vec<_> = self.steps.iter().map(|item| &item.location).collect();
 
         let op_cache = OperationalPointCache::load_path_items(conn, infra_id, &locations).await?;
@@ -267,17 +267,23 @@ impl Request {
         Ok(track_offsets
             .iter()
             .zip(&self.steps)
-            .map(|(track_offset, path_item)| core_client::stdcm::PathItem {
-                stop_duration: path_item.duration,
-                locations: track_offset.to_vec(),
-                step_timing_data: path_item.timing_data.as_ref().map(|timing_data| {
-                    core_client::stdcm::StepTimingData {
-                        arrival_time: timing_data.arrival_time,
-                        arrival_time_tolerance_before: timing_data.arrival_time_tolerance_before,
-                        arrival_time_tolerance_after: timing_data.arrival_time_tolerance_after,
-                    }
-                }),
-            })
+            .map(
+                |(track_offset, path_item)| core_client::stdcm::STDCMPathItem {
+                    stop_duration: path_item.duration,
+                    path_item: core_client::pathfinding::PathItem {
+                        locations: track_offset.clone(),
+                        can_backtrack: Some(false),
+                    },
+                    step_timing_data: path_item.timing_data.as_ref().map(|timing_data| {
+                        core_client::stdcm::StepTimingData {
+                            arrival_time: timing_data.arrival_time,
+                            arrival_time_tolerance_before: timing_data
+                                .arrival_time_tolerance_before,
+                            arrival_time_tolerance_after: timing_data.arrival_time_tolerance_after,
+                        }
+                    }),
+                },
+            )
             .collect())
     }
 

--- a/editoast/src/views/timetable/track_occupancy.rs
+++ b/editoast/src/views/timetable/track_occupancy.rs
@@ -305,6 +305,7 @@ pub mod tests {
             },
             length: 100,
             path_item_positions,
+            backtrack_positions: Some(vec![]),
         })
     }
 

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -2660,6 +2660,7 @@ mod tests {
                     "track_section_ranges": [],
                 },
                 "path_item_positions": [],
+                "backtrack_positions": [],
                 "length": 1,
                 "status": "success"
             }))
@@ -2693,6 +2694,7 @@ mod tests {
                     track_section_ranges: vec![],
                 },
                 path_item_positions: vec![],
+                backtrack_positions: Some(vec![]),
                 length: 1
             })
         )
@@ -2776,6 +2778,7 @@ mod tests {
                     "track_section_ranges": [],
                 },
                 "path_item_positions": [],
+                "backtrack_positions": [],
                 "length": 1,
                 "status": "success"
             }))
@@ -2828,6 +2831,7 @@ mod tests {
                     track_section_ranges: vec![],
                 },
                 path_item_positions: vec![],
+                backtrack_positions: Some(vec![]),
                 length: 1
             })
         )
@@ -2971,6 +2975,7 @@ mod tests {
             },
             length: 14450000,
             path_item_positions: vec![0, 14450000],
+            backtrack_positions: Some(vec![]),
         }
     }
 

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -3606,6 +3606,8 @@ export type CoreTrainPath = {
   track_section_ranges: CoreTrackRange[];
 };
 export type CorePathfindingResultSuccess = {
+  /** The path offset in mm of each position where the train backtracks */
+  backtrack_positions?: number[] | null;
   /** Length of the path in mm */
   length: number;
   /** Full description of the path data */
@@ -4548,6 +4550,12 @@ export type ConsistSchedule = {
     It should contain one more element than boundaries */
   values: ConsistConfiguration[];
 };
+export type CorePathItem = {
+  /** If true, the train can backtrack at these track offsets. */
+  can_backtrack?: boolean | null;
+  /** The track offsets of the path item. */
+  locations: TrackOffset[];
+};
 export type CoreStepTimingData = {
   /** Time the train should arrive at this point */
   arrival_time: string;
@@ -4556,9 +4564,9 @@ export type CoreStepTimingData = {
   /** Tolerance for the arrival time, when it arrives before the expected time, in ms */
   arrival_time_tolerance_before: number;
 };
-export type CorePathItem = {
-  /** The track offsets of the path item */
-  locations: TrackOffset[];
+export type CoreStdcmPathItem = {
+  /** The path item containing its locations and backtrack information. */
+  path_item: CorePathItem;
   step_timing_data?: null | CoreStepTimingData;
   /** Stop duration in milliseconds. None if the train does not stop at this path item. */
   stop_duration?: number | null;
@@ -4605,7 +4613,7 @@ export type CoreStdcmRequest = {
   /** Maximum run time of the simulation in milliseconds */
   maximum_run_time: number;
   /** List of waypoints. Each waypoint is a list of track offset. */
-  path_items: CorePathItem[];
+  path_items: CoreStdcmPathItem[];
   start_time: string;
   /** List of applicable temporary speed limits between the train departure and arrival */
   temporary_speed_limits: {

--- a/tests/tests/path.py
+++ b/tests/tests/path.py
@@ -11,3 +11,4 @@ class Path:
     path: Dict[str, List]
     length: int
     path_item_positions: Iterable[Any]
+    backtrack_positions: Iterable[Any]

--- a/tests/tests/test_pathfinding.py
+++ b/tests/tests/test_pathfinding.py
@@ -154,6 +154,7 @@ _EXPECTED_WEST_TO_SOUTH_EAST_PATH = Path(
         },
         "length": 45548966,
         "path_item_positions": [0, 45548966],
+        "backtrack_positions": [],
     }
 )
 


### PR DESCRIPTION
> [!IMPORTANT]
> To activate this, the [filtering on duplicate track-sections](https://github.com/OpenRailAssociation/osrd/blob/d1495451e59cd8beff525296ece1be5338553542/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.kt#L165) will have to be removed/adapted (currently protecting editoast/front against bad crashes on loops).

The main idea to handle backtracking:
* when extending (whole route) also extend targetting 'canBacktrack' steps encountered on the route (and stop there).
* then when (re-) extending from backtracking steps, consider the succession of routes covering all the chunks under the tail of the train during bachtracking and explore restart from all of them (teleporting where the tail was located before backtracking)

Note: teleport should be "OK" for trainLength influence as the trainLength is taken into account in CachedBlockMRSPBuilder anyway.

Also a lot of preparatory refactors.

---

⚠️ ~Cannot be merged, to be done:~ All good for me:
- [x] plug and use `canBacktrack` (instead of `stop` currently)
- [x] Fix tests broken (I suspect from the original plumbing PR)
- [ ] add tests (☑️more on Y_infra, on small infra, "chenille" + backtracking : to fix #15180) -> to be handled later if that's fine for everyone
- [x] Hand test (fuzzer, large france infra)
- [x] Fix/investigate tests (☑️dequeue order, ☑️stdcm NPE, ☑️e2e test)

🔍 To be reviewed by commit with message.

Note: a specific [peb/core/backtracking_pf_demo](https://github.com/OpenRailAssociation/osrd/compare/peb/core/backtracking_pf...peb/core/backtraking_pf_demo?expand=1) branch was added to save what was useful to display result in OSRD.