### PR TITLE
editoast: stdcm: filter stream events

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/cli/ReproduceRequest.kt
+++ b/core/src/main/java/fr/sncf/osrd/cli/ReproduceRequest.kt
@@ -131,7 +131,7 @@ class ReproduceRequest : CliCommand {
                 if (stdcmPayloadPath != null) {
                     logger.info("running stdcm request at $stdcmPayloadPath")
                     STDCMEndpoint(infraManager, cacheManager)
-                        .run(loadRequest(stdcmPayloadPath!!, stdcmRequestAdapter))
+                        .run(loadRequest(stdcmPayloadPath!!, stdcmRequestAdapter), null)
                 }
                 if (pathfindingPayloadPath != null) {
                     logger.info("running pathfinding request at $pathfindingPayloadPath")

--- a/core/src/main/java/fr/sncf/osrd/cli/WorkerCommand.kt
+++ b/core/src/main/java/fr/sncf/osrd/cli/WorkerCommand.kt
@@ -291,7 +291,23 @@ class WorkerCommand : CliCommand {
                     var status: ByteArray
                     try {
                         span.makeCurrent().use { scope ->
-                            val response = endpoint.act(MQRequest(body))
+                            val getResponse = {
+                                // Only the STDCMEndpoint requires access to the queue for now.
+                                // This avoids systematically creating a channel that will almost
+                                // always be unused.
+                                if (endpoint.requiresQueueCtx()) {
+                                    it.createChannel().use { chan ->
+                                        endpoint.act(
+                                            MQRequest(body),
+                                            Take.QueueContext(chan, replyTo, correlationId),
+                                        )
+                                    }
+                                } else {
+                                    endpoint.act(MQRequest(body))
+                                }
+                            }
+
+                            val response = getResponse()
                             payload = response.body().toByteArray()
                             val statusCode = response.statusCode()
                             status =
@@ -318,7 +334,12 @@ class WorkerCommand : CliCommand {
                             AMQP.BasicProperties()
                                 .builder()
                                 .correlationId(correlationId)
-                                .headers(mapOf("x-status" to status))
+                                .headers(
+                                    mapOf(
+                                        "x-status" to status,
+                                        "x-non-terminating-response" to false,
+                                    )
+                                )
                                 .build()
                         channel.basicPublish("", replyTo, properties, payload)
                     }
@@ -401,7 +422,24 @@ interface Request {
 }
 
 interface Take {
-    fun act(req: Request): Response
+    data class QueueContext(val chan: Channel, val replyTo: String, val correlationId: String)
+
+    /**
+     * This function processes the `request` and returns a [Response].
+     *
+     * It can optionally take a [QueueContext] to publish messages to a RabbitMQ queue. An example
+     * can be found in the [STDCMEndpoint] class.
+     */
+    fun act(req: Request, ctx: QueueContext? = null): Response
+
+    /**
+     * This function is responsible for telling the caller whether the associated endpoint needs
+     * access to the queue. Since this is only used in STDCMEndpoint right now, it defaults to
+     * false.
+     */
+    fun requiresQueueCtx(): Boolean {
+        return false
+    }
 }
 
 interface Response {

--- a/core/src/main/kotlin/fr/sncf/osrd/api/WorkerLoadEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/WorkerLoadEndpoint.kt
@@ -17,7 +17,7 @@ class WorkerLoadEndpoint(
     private val infraManager: InfraManager,
     private val timetableManager: TimetableCacheManager,
 ) : Take {
-    override fun act(req: Request): Response {
+    override fun act(req: Request, ctx: Take.QueueContext?): Response {
         try {
             // Parse request input
             val body = req.body()

--- a/core/src/main/kotlin/fr/sncf/osrd/api/conflicts/ConflictDetectionEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/conflicts/ConflictDetectionEndpoint.kt
@@ -19,7 +19,7 @@ import java.time.Duration
 import java.time.ZonedDateTime
 
 class ConflictDetectionEndpoint(private val infraManager: InfraProvider) : Take {
-    override fun act(req: Request): Response {
+    override fun act(req: Request, ctx: Take.QueueContext?): Response {
         return try {
             val body = req.body()
             val request =

--- a/core/src/main/kotlin/fr/sncf/osrd/api/etcs/ETCSBrakingCurvesEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/etcs/ETCSBrakingCurvesEndpoint.kt
@@ -33,7 +33,7 @@ class ETCSBrakingCurvesEndpoint(
     private val infraManager: InfraProvider,
     private val electricalProfileSetManager: ElectricalProfileSetManager,
 ) : Take {
-    override fun act(req: Request): Response {
+    override fun act(req: Request, ctx: Take.QueueContext?): Response {
         val request = readRequest(req) ?: return RsWithStatus(RsText("Missing request body"), 400)
         return run(request)
     }

--- a/core/src/main/kotlin/fr/sncf/osrd/api/path_properties/PathPropEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/path_properties/PathPropEndpoint.kt
@@ -24,7 +24,7 @@ import fr.sncf.osrd.utils.units.forceDirected
 import fr.sncf.osrd.utils.units.toDirected
 
 class PathPropEndpoint(private val infraManager: InfraProvider) : Take {
-    override fun act(req: Request): Response {
+    override fun act(req: Request, ctx: Take.QueueContext?): Response {
         return try {
             val body = req.body()
             val request =

--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.kt
@@ -47,7 +47,7 @@ class NoPathFoundException(val response: PathfindingBlockResponse) : Exception()
 val pathfindingLogger: Logger = LoggerFactory.getLogger("Pathfinding")
 
 class PathfindingBlocksEndpoint(private val infraManager: InfraProvider) : Take {
-    override fun act(req: Request): Response {
+    override fun act(req: Request, ctx: Take.QueueContext?): Response {
         val body = req.body()
         val request =
             pathfindingRequestAdapter.fromJson(body)

--- a/core/src/main/kotlin/fr/sncf/osrd/api/project_signals/SignalProjectionEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/project_signals/SignalProjectionEndpoint.kt
@@ -12,7 +12,7 @@ import fr.sncf.osrd.cli.Take
 import fr.sncf.osrd.signal_projection.projectSignals
 
 class SignalProjectionEndpoint(private val infraManager: InfraProvider) : Take {
-    override fun act(req: Request): Response {
+    override fun act(req: Request, ctx: Take.QueueContext?): Response {
         return try {
             val body = req.body()
             val request =

--- a/core/src/main/kotlin/fr/sncf/osrd/api/standalone_sim/SimulationEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/standalone_sim/SimulationEndpoint.kt
@@ -20,7 +20,7 @@ class SimulationEndpoint(
     private val infraManager: InfraProvider,
     private val electricalProfileSetManager: ElectricalProfileSetManager,
 ) : Take {
-    override fun act(req: Request): Response {
+    override fun act(req: Request, ctx: Take.QueueContext?): Response {
         // Parse request input
         val body = req.body()
         val request =

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
@@ -4,19 +4,19 @@ package fr.sncf.osrd.api.stdcm
 
 import com.google.common.collect.Range
 import com.google.common.collect.TreeRangeSet
+import com.rabbitmq.client.AMQP
+import com.rabbitmq.client.Channel
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import fr.sncf.osrd.api.*
 import fr.sncf.osrd.api.pathfinding.findStopPositionAtEndOfBlockConsideringRollingStock
 import fr.sncf.osrd.api.pathfinding.findWaypointBlocks
 import fr.sncf.osrd.api.pathfinding.hasDuplicateTracks
 import fr.sncf.osrd.api.pathfinding.runPathfindingBlockPostProcessing
 import fr.sncf.osrd.api.standalone_sim.*
-import fr.sncf.osrd.cli.Request
-import fr.sncf.osrd.cli.Response
-import fr.sncf.osrd.cli.RsJson
-import fr.sncf.osrd.cli.RsText
-import fr.sncf.osrd.cli.RsWithBody
-import fr.sncf.osrd.cli.RsWithStatus
-import fr.sncf.osrd.cli.Take
+import fr.sncf.osrd.cli.*
 import fr.sncf.osrd.conflicts.ParsedRequirements
 import fr.sncf.osrd.envelope_sim.Comfort
 import fr.sncf.osrd.envelope_sim.allowances.AllowanceValue
@@ -29,11 +29,7 @@ import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop
 import fr.sncf.osrd.reporting.exceptions.ErrorType
 import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.signaling.etcs_level2.ETCS_LEVEL2
-import fr.sncf.osrd.sim_infra.api.DirTrackChunkId
-import fr.sncf.osrd.sim_infra.api.RawInfra
-import fr.sncf.osrd.sim_infra.api.SpeedLimitProperty
-import fr.sncf.osrd.sim_infra.api.TrackSectionId
-import fr.sncf.osrd.sim_infra.api.ZoneId
+import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.sim_infra.impl.TemporarySpeedLimitManager
 import fr.sncf.osrd.standalone_sim.makeElectricalProfiles
 import fr.sncf.osrd.standalone_sim.makeMRSPResponse
@@ -48,6 +44,9 @@ import fr.sncf.osrd.stdcm.infra_exploration.ExplorerStep
 import fr.sncf.osrd.stdcm.infra_exploration.PlannedTimingData
 import fr.sncf.osrd.stdcm.preprocessing.implementation.makeBlockAvailability
 import fr.sncf.osrd.stdcm.tracing.FailureExplainer
+import fr.sncf.osrd.stdcm.tracing.ProgressCallback
+import fr.sncf.osrd.stdcm.tracing.STDCMProgress
+import fr.sncf.osrd.stdcm.tracing.STDCMProgressStatus
 import fr.sncf.osrd.train.RollingStock
 import fr.sncf.osrd.train.TrainStop
 import fr.sncf.osrd.utils.Direction
@@ -65,7 +64,7 @@ import java.time.Duration.ofMillis
 import java.time.LocalDateTime
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
-import java.util.TreeMap
+import java.util.*
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.ExperimentalSerializationApi
 
@@ -74,8 +73,27 @@ class STDCMEndpoint(
     private val timetableCacheManager: TimetableCacheManager,
     private val s3Context: S3Context? = null,
 ) : Take {
+    data class STDCMFinalResult(
+        @Json(name = "status") val status: STDCMProgressStatus,
+        @Json(name = "result") val result: STDCMResponse,
+    ) {
+        companion object {
+            val adapter: JsonAdapter<STDCMFinalResult> =
+                Moshi.Builder()
+                    .addLast(STDCMResponse::class.java, stdcmResponseAdapter)
+                    .addLast(KotlinJsonAdapterFactory())
+                    .build()
+                    .adapter(STDCMFinalResult::class.java)
+        }
+    }
+
+    override fun requiresQueueCtx(): Boolean {
+        // We need access to the queue to send the intermediate STDCM progress payloads
+        return true
+    }
+
     @Throws(OSRDError::class)
-    override fun act(req: Request): Response {
+    override fun act(req: Request, ctx: Take.QueueContext?): Response {
         // Parse request input
         val request = readRequest(req) ?: return RsWithStatus(RsText("missing request body"), 400)
 
@@ -92,7 +110,7 @@ class STDCMEndpoint(
 
         s3Context?.writeSTDCMFile("input_payload.json") { stdcmRequestAdapter.toJson(request) }
 
-        return run(request)
+        return run(request, ctx)
     }
 
     @WithSpan(value = "Reading request content", kind = SpanKind.SERVER)
@@ -103,7 +121,7 @@ class STDCMEndpoint(
 
     /** Process the given parsed request */
     @WithSpan(value = "Processing STDCM request", kind = SpanKind.SERVER)
-    fun run(request: STDCMRequest): Response {
+    fun run(request: STDCMRequest, ctx: Take.QueueContext?): Response {
         logger.info(
             "Request received: start=${request.startTime}, max duration=${request.maximumRunTime}"
         )
@@ -126,6 +144,11 @@ class STDCMEndpoint(
             val allowedTrackSections = parseTrackSectionIds(infra, request.allowedTrackSections)
             val failureExplainer =
                 FailureExplainer(request.startTime, infra.rawInfra, infra.blockInfra)
+
+            var callback: ProgressCallback? = null
+            if (ctx != null) {
+                callback = { progressCallback(ctx.chan, ctx.replyTo, ctx.correlationId, it) }
+            }
 
             // Run the STDCM pathfinding
             val path =
@@ -152,11 +175,13 @@ class STDCMEndpoint(
                     allowedTrackSections,
                     STDCMGraph.SearchMetadata(request.startTime, requirements.metadata, s3Context),
                     failureExplainer = failureExplainer,
+                    callback,
                 )
             if (path == null || hasDuplicateTracks(infra, path.trainPath)) {
                 failureExplainer.saveReport(s3Context)
-                val response = PathNotFound()
-                return RsJson(RsWithBody(stdcmResponseAdapter.toJson(response)))
+                val result = PathNotFound()
+                val response = STDCMFinalResult(status = STDCMProgressStatus.DONE, result = result)
+                return RsJson(RsWithBody(STDCMFinalResult.adapter.toJson(response)))
             }
             val pathfindingResponse =
                 runPathfindingBlockPostProcessing(infra, path.trainPath, path.waypointOffsets)
@@ -182,8 +207,9 @@ class STDCMEndpoint(
                 requirements.metadata,
             )
 
-            val response = STDCMSuccess(simulationResponse, pathfindingResponse, departureTime)
-            RsJson(RsWithBody(stdcmResponseAdapter.toJson(response)))
+            val result = STDCMSuccess(simulationResponse, pathfindingResponse, departureTime)
+            val response = STDCMFinalResult(status = STDCMProgressStatus.DONE, result = result)
+            RsJson(RsWithBody(STDCMFinalResult.adapter.toJson(response)))
         } catch (ex: Throwable) {
             ExceptionHandler.handle(ex)
         }
@@ -496,9 +522,11 @@ fun parseMarginValue(margin: MarginValue): AllowanceValue? {
         is MarginValue.MinPer100Km -> {
             TimePerDistance(margin.value)
         }
+
         is MarginValue.Percentage -> {
             Percentage(margin.percentage)
         }
+
         is MarginValue.None -> {
             null
         }
@@ -518,4 +546,23 @@ private fun parseSimulationScheduleItems(
 
 fun parseTrackSectionIds(infra: FullInfra, trackSectionName: Set<String>?): Set<TrackSectionId>? {
     return trackSectionName?.mapNotNull { infra.rawInfra.getTrackSectionFromName(it) }?.toSet()
+}
+
+private fun progressCallback(
+    channel: Channel,
+    replyTo: String,
+    correlationId: String,
+    data: STDCMProgress,
+) {
+    val properties =
+        AMQP.BasicProperties()
+            .builder()
+            .headers(
+                mapOf("x-non-terminating-response" to true, "x-status" to "ok".encodeToByteArray())
+            )
+            .correlationId(correlationId)
+            .build()
+    val body = STDCMProgress.adapter.toJson(data).encodeToByteArray()
+
+    channel.basicPublish("", replyTo, properties, body)
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
@@ -17,6 +17,7 @@ import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
 import fr.sncf.osrd.stdcm.infra_exploration.initInfraExplorerWithEnvelope
 import fr.sncf.osrd.stdcm.preprocessing.interfaces.BlockAvailabilityInterface
 import fr.sncf.osrd.stdcm.tracing.FailureExplainer
+import fr.sncf.osrd.stdcm.tracing.ProgressCallback
 import fr.sncf.osrd.stdcm.tracing.ProgressLogger
 import fr.sncf.osrd.train.RollingStock
 import fr.sncf.osrd.utils.LogAggregator
@@ -63,6 +64,7 @@ fun findPath(
     allowedTrackSections: Set<TrackSectionId>? = null,
     searchMetadata: STDCMGraph.SearchMetadata? = null,
     failureExplainer: FailureExplainer? = null,
+    progressCallback: ProgressCallback? = null,
 ): STDCMResult? {
     return STDCMPathfinding(
             fullInfra,
@@ -81,6 +83,7 @@ fun findPath(
             allowedTrackSections,
             searchMetadata,
             failureExplainer,
+            progressCallback,
         )
         .findPath()
 }
@@ -102,6 +105,7 @@ class STDCMPathfinding(
     private val allowedTrackSections: Set<TrackSectionId>?,
     private val searchMetadata: STDCMGraph.SearchMetadata?,
     private val failureExplainer: FailureExplainer?,
+    private val progressCallback: ProgressCallback? = null,
 ) {
 
     private var starts: Set<STDCMNode> = HashSet()
@@ -206,7 +210,7 @@ class STDCMPathfinding(
     private fun findPathImpl(): Result? {
         val queue = PriorityQueue<STDCMNode>()
 
-        val progressLogger = ProgressLogger(graph)
+        val progressLogger = ProgressLogger(graph, callback = progressCallback)
         val fValueLogger = LogAggregator({ logger.error(it) })
 
         for (location in starts) {

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/tracing/ProgressLogger.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/tracing/ProgressLogger.kt
@@ -1,5 +1,9 @@
 package fr.sncf.osrd.stdcm.tracing
 
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import fr.sncf.osrd.path.implementations.buildTrainPathFromBlock
 import fr.sncf.osrd.stdcm.graph.STDCMGraph
 import fr.sncf.osrd.stdcm.graph.STDCMNode
@@ -19,6 +23,7 @@ data class ProgressLogger(
     val graph: STDCMGraph,
     val nStepsProgress: Int = 10,
     val memoryReportTimeInterval: Duration = 10.seconds,
+    val callback: ProgressCallback?,
 ) {
     private val thresholdDistance = 1.0 / nStepsProgress.toDouble()
     private var nSamplesReached = 1 // Avoids first node
@@ -65,6 +70,8 @@ data class ProgressLogger(
             while (progress >= thresholdDistance * nSamplesReached) nSamplesReached++
         }
 
+        logNode(node)
+
         if (Instant.now() >= nextMemoryReport) {
             nextMemoryReport += java.time.Duration.ofMillis(memoryReportTimeInterval.milliseconds)
             val rt = Runtime.getRuntime()
@@ -79,4 +86,47 @@ data class ProgressLogger(
             logger.info(str)
         }
     }
+
+    fun logNode(node: STDCMNode): STDCMProgress {
+        val block = node.infraExplorer.getCurrentBlock()
+        val geo =
+            buildTrainPathFromBlock(graph.rawInfra, graph.blockInfra, block).getGeo().getPoints()[0]
+        val bestTravelTime =
+            (node.timeData.earliestReachableTime + node.remainingTimeEstimation).toLong()
+        val data =
+            STDCMProgress(
+                status = STDCMProgressStatus.IN_PROGRESS,
+                point = STDCMProgress.STDCMProgressSampleCoordinates(geo.lat, geo.lon),
+                bestTravelTime = bestTravelTime,
+            )
+
+        callback?.let { it(data) }
+        return data
+    }
 }
+
+data class STDCMProgress(
+    @Json(name = "status") val status: STDCMProgressStatus,
+    @Json(name = "point") val point: STDCMProgressSampleCoordinates,
+    @Json(name = "best_travel_time") val bestTravelTime: Long,
+) {
+    data class STDCMProgressSampleCoordinates(
+        @Json(name = "lat") val lat: Double,
+        @Json(name = "lon") val lon: Double,
+    )
+
+    companion object {
+        val adapter: JsonAdapter<STDCMProgress> =
+            Moshi.Builder()
+                .addLast(KotlinJsonAdapterFactory())
+                .build()
+                .adapter(STDCMProgress::class.java)
+    }
+}
+
+enum class STDCMProgressStatus {
+    IN_PROGRESS,
+    DONE,
+}
+
+typealias ProgressCallback = (STDCMProgress) -> Unit

--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -449,6 +449,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-streams"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e3b97b0eb0c163a3a7ed79c496f9b9e6f121259a8434d893c3245b2d9a42c9"
+dependencies = [
+ "axum",
+ "bytes",
+ "futures 0.3.32",
+ "http",
+ "http-body",
+ "serde",
+ "serde_json",
+ "tokio-stream",
+]
+
+[[package]]
 name = "axum-test"
 version = "19.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1335,6 +1351,7 @@ dependencies = [
  "authz",
  "axum",
  "axum-extra",
+ "axum-streams",
  "axum-test",
  "axum-tracing-opentelemetry",
  "cache",
@@ -1389,6 +1406,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-stream",
  "tower",
  "tower-http",
  "tracing",

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -159,6 +159,7 @@ axum = { version = "0.8.7", default-features = false, features = [
 axum-extra = { version = "0.12.2", default-features = false, features = [
   "typed-header",
 ] }
+axum-streams = { version = "0.25.0", features = ["json"] }
 axum-test = { version = "19.0", default-features = false }
 axum-tracing-opentelemetry = { version = "0.33.0", default-features = false, features = [
   "tracing_level_info",
@@ -220,6 +221,7 @@ sha1.workspace = true
 strum.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
+tokio-stream = "0.1.18"
 tower = "0.5.2"
 tower-http = { version = "0.6.6", features = [
   "compression-full",

--- a/editoast/core_client/src/lib.rs
+++ b/editoast/core_client/src/lib.rs
@@ -95,14 +95,24 @@ impl CoreClient {
         R: CoreResponse,
         <R as CoreResponse>::Response: std::marker::Send,
     {
-        let stream = self
-            .fetch_streaming::<B, R>(path, body, worker_key, override_timeout)
-            .await?;
+        match self {
+            CoreClient::MessageQueue(_) => {
+                let stream = self
+                    .fetch_streaming::<B, R>(path, body, worker_key, override_timeout)
+                    .await?;
 
-        pin!(stream)
-            .next()
-            .await
-            .ok_or(Error::UnparsableErrorOutput)?
+                pin!(stream)
+                    .next()
+                    .await
+                    .ok_or(Error::UnparsableErrorOutput)?
+            }
+
+            CoreClient::Mocked(client) => match client.fetch_mocked::<_, B, R>(path, body) {
+                Ok(Some(response)) => Ok(response),
+                Ok(None) => Err(Error::NoResponseContent),
+                Err(mocking::MockingError { bytes, url }) => Err(Error::parse(&bytes, url)),
+            },
+        }
     }
 
     #[tracing::instrument(
@@ -159,11 +169,12 @@ impl CoreClient {
                     todo!("TODO: handle protocol errors")
                 })))
             }
-            CoreClient::Mocked(client) => match client.fetch_mocked::<_, B, R>(path, body) {
-                Ok(Some(response)) => Ok(Either::Right(stream::once(async { Ok(response) }))),
-                Ok(None) => Err(Error::NoResponseContent),
-                Err(mocking::MockingError { bytes, url }) => Err(Error::parse(&bytes, url)),
-            },
+            CoreClient::Mocked(client) => {
+                match client.fetch_streaming_mocked::<_, B, R>(path, body) {
+                    Ok(responses) => Ok(Either::Right(stream::iter(responses).map(Ok))),
+                    Err(mocking::MockingError { bytes, url }) => Err(Error::parse(&bytes, url)),
+                }
+            }
         }
     }
 }

--- a/editoast/core_client/src/mocking.rs
+++ b/editoast/core_client/src/mocking.rs
@@ -46,16 +46,46 @@ impl MockingClient {
         req_path: P,
         req_body: Option<&B>,
     ) -> Result<Option<R::Response>, MockingError> {
-        let req_path = req_path.as_ref().to_string();
+        let req_path = req_path.as_ref();
 
         let Some(stub) = self
             .stubs
-            .get(&req_path)
+            .get(req_path)
             .and_then(|stubs| stubs.deref().lock().unwrap().pop_front())
         else {
             panic!("could not find stub for request at PATH '{req_path}'");
         };
 
+        Self::process_stub_request::<B, R>(&stub, req_path, req_body)
+    }
+
+    pub(super) fn fetch_streaming_mocked<P: AsRef<str>, B: Serialize, R: CoreResponse>(
+        &self,
+        req_path: P,
+        req_body: Option<&B>,
+    ) -> Result<Vec<R::Response>, MockingError> {
+        let req_path = req_path.as_ref();
+
+        let Some(stubs) = self
+            .stubs
+            .get(req_path)
+            .map(|stubs| stubs.deref().lock().unwrap().drain(..).collect::<Vec<_>>())
+        else {
+            panic!("could not find stub for request at PATH '{req_path}'");
+        };
+
+        stubs
+            .iter()
+            .map(|stub| Self::process_stub_request::<B, R>(stub, req_path, req_body))
+            .flat_map(Result::transpose)
+            .collect()
+    }
+
+    fn process_stub_request<B: Serialize, R: CoreResponse>(
+        stub: &StubRequest,
+        req_path: &str,
+        req_body: Option<&B>,
+    ) -> Result<Option<R::Response>, MockingError> {
         match (
             req_body.map(|b| serde_json::to_string(b).expect("could not serialize request body")),
             stub.body.as_ref().map(|b| b.as_str().to_string()),
@@ -83,7 +113,7 @@ impl MockingClient {
                     .to_vec();
                 Err(MockingError {
                     bytes: err,
-                    url: req_path,
+                    url: req_path.to_string(),
                 })
             }
         }

--- a/editoast/core_client/src/mq_client.rs
+++ b/editoast/core_client/src/mq_client.rs
@@ -30,7 +30,7 @@ use tracing::Instrument;
 use url::Url;
 use uuid::Uuid;
 
-const NON_FINAL_MESSAGE_HEADER: &str = "x-non-final-message";
+const NON_TERMINATING_RESPONSE_HEADER: &str = "x-non-terminating-response";
 
 #[derive(Debug, Clone)]
 pub struct RabbitMQClient {
@@ -172,9 +172,9 @@ impl ChannelWorker {
                     .properties
                     .headers()
                     .as_ref()
-                    .and_then(|f| f.inner().get(NON_FINAL_MESSAGE_HEADER))
+                    .and_then(|f| f.inner().get(NON_TERMINATING_RESPONSE_HEADER))
                     .and_then(|s| s.as_bool())
-                    .unwrap_or(true);
+                    .unwrap_or(false);
 
                 let Some(sender_entry) = response_tracker
                     .get(correlation_id.as_str())
@@ -496,10 +496,10 @@ impl RabbitMQClient {
                         .map(|s| Ok(s.as_slice().to_owned()))
                         .unwrap_or(Err(MqClientError::StatusParsing));
 
-                    let final_message = headers
-                        .and_then(|f| f.inner().get(NON_FINAL_MESSAGE_HEADER))
+                    let final_message = !headers
+                        .and_then(|f| f.inner().get(NON_TERMINATING_RESPONSE_HEADER))
                         .and_then(|s| s.as_bool())
-                        .unwrap_or(true);
+                        .unwrap_or(false);
 
                     (
                         status.map(|status| MQResponse {

--- a/editoast/core_client/src/stdcm.rs
+++ b/editoast/core_client/src/stdcm.rs
@@ -141,6 +141,25 @@ pub struct ConsistSchedule {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(tag = "status", rename_all = "SCREAMING_SNAKE_CASE")]
+#[allow(clippy::large_enum_variant)]
+pub enum ProgressStatus {
+    InProgress {
+        point: ProgressCoordinates,
+        best_travel_time: u64,
+    },
+    Done {
+        result: Response,
+    },
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, ToSchema)]
+pub struct ProgressCoordinates {
+    pub lat: f64,
+    pub lon: f64,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(tag = "status", rename_all = "snake_case")]
 // We accepted the difference of memory size taken by variants
 // Since there is only on success and others are error cases

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -3568,53 +3568,26 @@ paths:
                 oneOf:
                 - type: object
                   required:
-                  - simulation
-                  - pathfinding_result
-                  - departure_time
-                  - status
+                  - data
+                  - event
                   properties:
-                    core_payload:
-                      oneOf:
-                      - type: 'null'
-                      - $ref: '#/components/schemas/core.StdcmRequest'
-                    departure_time:
-                      type: string
-                      format: date-time
-                    pathfinding_result:
-                      $ref: '#/components/schemas/core.PathfindingResultSuccess'
-                    simulation:
-                      $ref: '#/components/schemas/SimulationResponseSuccess'
-                    status:
+                    data:
+                      $ref: '#/components/schemas/StdcmProgressionEvent'
+                    event:
                       type: string
                       enum:
-                      - success
+                      - ongoing
                 - type: object
                   required:
-                  - status
+                  - data
+                  - event
                   properties:
-                    core_payload:
-                      oneOf:
-                      - type: 'null'
-                      - $ref: '#/components/schemas/core.StdcmRequest'
-                    status:
+                    data:
+                      $ref: '#/components/schemas/StdcmResponse'
+                    event:
                       type: string
                       enum:
-                      - path_not_found
-                - type: object
-                  required:
-                  - error
-                  - status
-                  properties:
-                    core_payload:
-                      oneOf:
-                      - type: 'null'
-                      - $ref: '#/components/schemas/core.StdcmRequest'
-                    error:
-                      $ref: '#/components/schemas/SimulationResponse'
-                    status:
-                      type: string
-                      enum:
-                      - preprocessing_simulation_error
+                      - completed
   /timetable/{id}/train_schedule_exception:
     post:
       tags:
@@ -13483,6 +13456,84 @@ components:
         value:
           type: string
           format: date-time
+    StdcmProgressionEvent:
+      type: object
+      required:
+      - point
+      - best_travel_time
+      properties:
+        best_travel_time:
+          type: integer
+          format: int64
+          minimum: 0
+        point:
+          $ref: '#/components/schemas/GeoJsonPoint'
+    StdcmResponse:
+      oneOf:
+      - type: object
+        required:
+        - simulation
+        - pathfinding_result
+        - departure_time
+        - status
+        properties:
+          core_payload:
+            oneOf:
+            - type: 'null'
+            - $ref: '#/components/schemas/core.StdcmRequest'
+          departure_time:
+            type: string
+            format: date-time
+          pathfinding_result:
+            $ref: '#/components/schemas/core.PathfindingResultSuccess'
+          simulation:
+            $ref: '#/components/schemas/SimulationResponseSuccess'
+          status:
+            type: string
+            enum:
+            - success
+      - type: object
+        required:
+        - status
+        properties:
+          core_payload:
+            oneOf:
+            - type: 'null'
+            - $ref: '#/components/schemas/core.StdcmRequest'
+          status:
+            type: string
+            enum:
+            - path_not_found
+      - type: object
+        required:
+        - error
+        - status
+        properties:
+          core_payload:
+            oneOf:
+            - type: 'null'
+            - $ref: '#/components/schemas/core.StdcmRequest'
+          error:
+            $ref: '#/components/schemas/SimulationResponse'
+          status:
+            type: string
+            enum:
+            - preprocessing_simulation_error
+      - type: object
+        required:
+        - error
+        - status
+        properties:
+          core_payload:
+            oneOf:
+            - type: 'null'
+            - $ref: '#/components/schemas/core.StdcmRequest'
+          error:
+            $ref: '#/components/schemas/InternalError'
+          status:
+            type: string
+            enum:
+            - internal_error
     StdcmSearchEnvironment:
       type: object
       required:

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -746,4 +746,49 @@ impl TestResponse {
             panic!("could not deserialize test request");
         })
     }
+
+    #[tracing::instrument(
+        name = "Deserialization",
+        level = "debug",
+        skip(self),
+        fields(response_status = ?self.inner.status_code())
+    )]
+    #[track_caller]
+    pub fn last_jsonl_into<T: DeserializeOwned>(self) -> T {
+        self.jsonl_into()
+            .into_iter()
+            .last()
+            .expect("Response should not be empty")
+    }
+
+    #[tracing::instrument(
+        name = "Deserialization",
+        level = "debug",
+        skip(self),
+        fields(response_status = ?self.inner.status_code())
+    )]
+    #[track_caller]
+    pub fn jsonl_into<T: DeserializeOwned>(self) -> Vec<T> {
+        let body = self.string();
+
+        body.lines()
+            .map(|line| {
+                serde_json::from_str(line).unwrap_or_else(|err| {
+                    tracing::error!(error = ?err, "Error deserializing test response into the desired type");
+                    let actual: serde_json::Value =
+                        serde_json::from_str(line).unwrap_or_else(|err| {
+                            tracing::error!(
+                                error = ?err,
+                                ?body,
+                                "Failed to deserialize test response body into JSON"
+                            );
+                            panic!("could not deserialize test response into JSON");
+                        });
+                    let pretty = serde_json::to_string_pretty(&actual).unwrap();
+                    tracing::error!(body = %pretty, "Actual JSON value");
+                    panic!("could not deserialize test request");
+                })
+            })
+            .collect::<Vec<_>>()
+    }
 }

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -572,7 +572,6 @@ mod tests {
     use schemas::train_schedule::OperationalPointPartReference;
     use schemas::train_schedule::OperationalPointReference;
     use schemas::train_schedule::PathItemLocation;
-    use serde_json::json;
     use std::str::FromStr;
     use uom::si::length::Length;
     use uom::si::length::meter;
@@ -860,11 +859,13 @@ mod tests {
         let mut core = core_mocking_client();
         core.stub("/stdcm")
             .response(StatusCode::OK)
-            .json(core_client::stdcm::Response::Success {
-                simulation: simulation_empty_response().success().unwrap(),
-                path: pathfinding_result_success(),
-                departure_time: DateTime::from_str("2024-01-02T00:00:00Z")
-                    .expect("Failed to parse datetime"),
+            .json(core_client::stdcm::ProgressStatus::Done {
+                result: core_client::stdcm::Response::Success {
+                    simulation: simulation_empty_response().success().unwrap(),
+                    path: pathfinding_result_success(),
+                    departure_time: DateTime::from_str("2024-01-02T00:00:00Z")
+                        .expect("Failed to parse datetime"),
+                },
             })
             .finish();
 
@@ -879,24 +880,24 @@ mod tests {
             .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
             .json(&get_stdcm_payload(rolling_stock.id, None, None, None));
 
-        let stdcm_response: StdcmResponse = app
+        let stdcm_response: StdcmProgression = app
             .fetch(request)
             .await
             .assert_status(StatusCode::OK)
-            .json_into();
+            .last_jsonl_into();
 
         if let PathfindingResult::Success(path) =
             PathfindingResult::Success(pathfinding_result_success())
         {
             assert_eq!(
                 stdcm_response,
-                StdcmResponse::Success {
+                StdcmProgression::Completed(StdcmResponse::Success {
                     simulation: simulation_empty_response().success().unwrap().into(),
                     pathfinding_result: path,
                     departure_time: DateTime::from_str("2024-01-02T00:00:00Z")
                         .expect("Failed to parse datetime"),
                     core_payload: None,
-                }
+                })
             );
         }
     }
@@ -990,11 +991,13 @@ mod tests {
         let mut core = core_mocking_client();
         core.stub("/stdcm")
             .response(StatusCode::OK)
-            .json(core_client::stdcm::Response::Success {
-                simulation: simulation_empty_response().success().unwrap(),
-                path: pathfinding_result_success(),
-                departure_time: DateTime::from_str("2024-01-02T00:00:00Z")
-                    .expect("Failed to parse datetime"),
+            .json(core_client::stdcm::ProgressStatus::Done {
+                result: core_client::stdcm::Response::Success {
+                    simulation: simulation_empty_response().success().unwrap(),
+                    path: pathfinding_result_success(),
+                    departure_time: DateTime::from_str("2024-01-02T00:00:00Z")
+                        .expect("Failed to parse datetime"),
+                },
             })
             .finish();
 
@@ -1016,24 +1019,24 @@ mod tests {
                 total_length,
             ));
 
-        let stdcm_response: StdcmResponse = app
+        let stdcm_response: StdcmProgression = app
             .fetch(request)
             .await
             .assert_status(StatusCode::OK)
-            .json_into();
+            .last_jsonl_into();
 
         if let PathfindingResult::Success(path) =
             PathfindingResult::Success(pathfinding_result_success())
         {
             assert_eq!(
                 stdcm_response,
-                StdcmResponse::Success {
+                StdcmProgression::Completed(StdcmResponse::Success {
                     simulation: simulation_empty_response().success().unwrap().into(),
                     pathfinding_result: path,
                     departure_time: DateTime::from_str("2024-01-02T00:00:00Z")
                         .expect("Failed to parse datetime"),
                     core_payload: None,
-                }
+                })
             );
         }
     }
@@ -1043,7 +1046,9 @@ mod tests {
         let mut core = core_mocking_client();
         core.stub("/stdcm")
             .response(StatusCode::OK)
-            .json(json!({"status": "path_not_found"}))
+            .json(core_client::stdcm::ProgressStatus::Done {
+                result: core_client::stdcm::Response::PathNotFound,
+            })
             .finish();
 
         let app = TestAppBuilder::new().core_client(core.into()).build();
@@ -1057,15 +1062,142 @@ mod tests {
             .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
             .json(&get_stdcm_payload(rolling_stock.id, None, None, None));
 
-        let stdcm_response: StdcmResponse = app
+        let stdcm_response: StdcmProgression = app
             .fetch(request)
             .await
             .assert_status(StatusCode::OK)
-            .json_into();
+            .last_jsonl_into();
 
         assert_eq!(
             stdcm_response,
-            StdcmResponse::PathNotFound { core_payload: None }
+            StdcmProgression::Completed(StdcmResponse::PathNotFound { core_payload: None })
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn stdcm_multiple_response_return_success() {
+        let mut core = core_mocking_client();
+        core.stub("/stdcm")
+            .response(StatusCode::OK)
+            .json(core_client::stdcm::ProgressStatus::InProgress {
+                point: core_client::stdcm::ProgressCoordinates { lat: 0.0, lon: 0.0 },
+                best_travel_time: 1,
+            })
+            .json(core_client::stdcm::ProgressStatus::InProgress {
+                point: core_client::stdcm::ProgressCoordinates { lat: 1.0, lon: 1.0 },
+                best_travel_time: 5,
+            })
+            .json(core_client::stdcm::ProgressStatus::Done {
+                result: core_client::stdcm::Response::Success {
+                    simulation: simulation_empty_response().success().unwrap(),
+                    path: pathfinding_result_success(),
+                    departure_time: DateTime::from_str("2024-01-02T00:00:00Z")
+                        .expect("Failed to parse datetime"),
+                },
+            })
+            .finish();
+
+        let app = TestAppBuilder::new().core_client(core.into()).build();
+        let db_pool = app.db_pool();
+        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let timetable = create_timetable(&mut db_pool.get_ok()).await;
+        let rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+
+        let request = app
+            .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
+            .json(&get_stdcm_payload(rolling_stock.id, None, None, None));
+
+        let stdcm_response: Vec<StdcmProgression> = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .jsonl_into();
+
+        if let PathfindingResult::Success(path) =
+            PathfindingResult::Success(pathfinding_result_success())
+        {
+            assert_eq!(stdcm_response.len(), 3);
+            assert_eq!(
+                stdcm_response[0].clone(),
+                StdcmProgression::Ongoing(StdcmProgressionEvent {
+                    point: Geometry::new(Value::Point(vec![0.0, 0.0])),
+                    best_travel_time: 1,
+                })
+            );
+            assert_eq!(
+                stdcm_response[1].clone(),
+                StdcmProgression::Ongoing(StdcmProgressionEvent {
+                    point: Geometry::new(Value::Point(vec![1.0, 1.0])),
+                    best_travel_time: 5,
+                })
+            );
+            assert_eq!(
+                stdcm_response[2].clone(),
+                StdcmProgression::Completed(StdcmResponse::Success {
+                    simulation: simulation_empty_response().success().unwrap().into(),
+                    pathfinding_result: path,
+                    departure_time: DateTime::from_str("2024-01-02T00:00:00Z")
+                        .expect("Failed to parse datetime"),
+                    core_payload: None,
+                })
+            );
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn stdcm_multiple_response_path_not_found() {
+        let mut core = core_mocking_client();
+        core.stub("/stdcm")
+            .response(StatusCode::OK)
+            .json(core_client::stdcm::ProgressStatus::InProgress {
+                point: core_client::stdcm::ProgressCoordinates { lat: 0.0, lon: 0.0 },
+                best_travel_time: 1,
+            })
+            .json(core_client::stdcm::ProgressStatus::InProgress {
+                point: core_client::stdcm::ProgressCoordinates { lat: 1.0, lon: 1.0 },
+                best_travel_time: 5,
+            })
+            .json(core_client::stdcm::ProgressStatus::Done {
+                result: core_client::stdcm::Response::PathNotFound,
+            })
+            .finish();
+
+        let app = TestAppBuilder::new().core_client(core.into()).build();
+        let db_pool = app.db_pool();
+        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let timetable = create_timetable(&mut db_pool.get_ok()).await;
+        let rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+
+        let request = app
+            .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
+            .json(&get_stdcm_payload(rolling_stock.id, None, None, None));
+
+        let stdcm_response: Vec<StdcmProgression> = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::OK)
+            .jsonl_into();
+
+        assert_eq!(stdcm_response.len(), 3);
+        assert_eq!(
+            stdcm_response[0].clone(),
+            StdcmProgression::Ongoing(StdcmProgressionEvent {
+                point: Geometry::new(Value::Point(vec![0.0, 0.0])),
+                best_travel_time: 1,
+            })
+        );
+        assert_eq!(
+            stdcm_response[1].clone(),
+            StdcmProgression::Ongoing(StdcmProgressionEvent {
+                point: Geometry::new(Value::Point(vec![1.0, 1.0])),
+                best_travel_time: 5,
+            })
+        );
+        assert_eq!(
+            stdcm_response[2].clone(),
+            StdcmProgression::Completed(StdcmResponse::PathNotFound { core_payload: None })
         );
     }
 

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -6,6 +6,8 @@ use axum::extract::Json;
 use axum::extract::Path;
 use axum::extract::Query;
 use axum::extract::State;
+use axum::response::IntoResponse;
+use axum_streams::StreamBodyAs;
 use chrono::DateTime;
 use chrono::Duration;
 use chrono::Utc;
@@ -19,6 +21,10 @@ use core_client::stdcm::Request as StdcmRequest;
 use core_client::stdcm::UndirectedTrackRange;
 use database::DbConnectionPoolV2;
 use editoast_derive::EditoastError;
+use futures::StreamExt as _;
+use futures::stream;
+use geos::geojson::Geometry;
+use geos::geojson::Value;
 use request::Request;
 use request::convert_steps;
 use schemas::primitives::PositiveDuration;
@@ -30,9 +36,12 @@ use schemas::train_schedule::TrainOccurrence;
 use serde::Deserialize;
 use serde::Serialize;
 use std::cmp::max;
+use std::pin::pin;
 use std::slice;
 use std::sync::Arc;
 use thiserror::Error;
+use tokio::spawn;
+use tokio::sync::mpsc;
 use tracing::Span;
 use utoipa::IntoParams;
 use utoipa::ToSchema;
@@ -74,6 +83,26 @@ pub(in crate::views) enum StdcmResponse {
         #[serde(skip_serializing_if = "Option::is_none")]
         core_payload: Option<StdcmRequest>,
     },
+    InternalError {
+        error: InternalError,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        core_payload: Option<StdcmRequest>,
+    },
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, ToSchema)]
+struct StdcmProgressionEvent {
+    #[schema(value_type = common::geometry::GeoJsonPoint)]
+    point: Geometry,
+    best_travel_time: u64,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, ToSchema)]
+#[serde(tag = "event", rename_all = "snake_case", content = "data")]
+#[allow(clippy::large_enum_variant)]
+enum StdcmProgression {
+    Ongoing(StdcmProgressionEvent),
+    Completed(StdcmResponse),
 }
 
 #[derive(Debug, Error, EditoastError, Serialize, derive_more::From)]
@@ -156,7 +185,7 @@ pub(in crate::views) struct StdcmQueryParams {
         StdcmQueryParams,
     ),
     responses(
-        (status = 200, body = inline(StdcmResponse), description = "The simulation result"),
+        (status = 200, body = inline(StdcmProgression), description = "The simulation result"),
     )
 )]
 pub(in crate::views) async fn stdcm(
@@ -165,7 +194,7 @@ pub(in crate::views) async fn stdcm(
     Path(id): Path<i64>,
     Query(query): Query<StdcmQueryParams>,
     Json(request): Json<Request>,
-) -> Result<Json<StdcmResponse>> {
+) -> Result<impl IntoResponse> {
     // Add serialized request to trace attributes, skipping allowed track sections
     // (as it would make the payload too large to be saved). TODO: include search env ID
     let mut request_copy = request.clone();
@@ -205,7 +234,7 @@ pub(in crate::views) async fn stdcm_handler(
     Query(query): Query<StdcmQueryParams>,
     Json(request): Json<Request>,
     returned_request: &mut Option<core_client::stdcm::Request>,
-) -> Result<Json<StdcmResponse>> {
+) -> Result<impl IntoResponse + use<>> {
     let authorized = auth
         .check_roles([authz::Role::Stdcm].into())
         .await
@@ -282,10 +311,10 @@ pub(in crate::views) async fn stdcm_handler(
         // Default 12h value when the simulation fails
         matches!(virtual_train_run.simulation, simulation::Response::SimulationFailed { .. }).then_some(12 * 3_600_000))
     else {
-        return Ok(Json(StdcmResponse::PreprocessingSimulationError {
-            error: virtual_train_run.simulation,
-            core_payload: None,
-        }))
+        let payload = StdcmResponse::PreprocessingSimulationError {
+                error: virtual_train_run.simulation,
+                core_payload: None,};
+        return Ok(StreamBodyAs::json_nl(stream::once(async {payload})))
     };
 
     let earliest_departure_time = request.get_earliest_departure_time(simulation_run_time);
@@ -331,34 +360,80 @@ pub(in crate::views) async fn stdcm_handler(
     };
     *returned_request = query.return_debug_payloads.then_some(stdcm_request.clone());
 
-    let stdcm_response: Result<core_client::stdcm::Response, InternalError> = stdcm_request
-        .fetch(core_client.as_ref())
-        .await
-        .map_err(Into::into);
+    let (tx, rx) = mpsc::unbounded_channel();
+    let core_payload = returned_request.clone();
 
-    // 6. Handle STDCM Core Response
-    let span = Span::current();
-    match stdcm_response? {
-        core_client::stdcm::Response::Success {
-            simulation,
-            path,
-            departure_time,
-        } => {
-            span.record("path_found", true);
-            Ok(Json(StdcmResponse::Success {
-                simulation: simulation.into(),
-                pathfinding_result: path,
-                departure_time,
-                core_payload: returned_request.clone(),
-            }))
+    spawn(async move {
+        let stream_stdcm_response = stdcm_request
+            .fetch_streaming::<core_client::Json<core_client::stdcm::ProgressStatus>>(
+                core_client.as_ref(),
+            )
+            .await
+            .map_err(InternalError::from);
+        let stream_stdcm_response = match stream_stdcm_response {
+            Ok(stream_stdcm_response) => stream_stdcm_response,
+            Err(e) => {
+                let _ = tx.send(StdcmProgression::Completed(StdcmResponse::InternalError {
+                    error: e,
+                    core_payload: core_payload.clone(),
+                }));
+                return;
+            }
+        };
+
+        // 6. Handle STDCM Core Response
+        let result_stream = stream_stdcm_response.map(move |response| {
+            let response = response.map_err(InternalError::from);
+
+            let span = Span::current();
+
+            match response {
+                Ok(result) => match result {
+                    core_client::stdcm::ProgressStatus::InProgress {
+                        point,
+                        best_travel_time,
+                    } => StdcmProgression::Ongoing(StdcmProgressionEvent {
+                        point: Geometry::new(Value::Point(vec![point.lon, point.lat])),
+                        best_travel_time,
+                    }),
+                    core_client::stdcm::ProgressStatus::Done { result } => match result {
+                        core_client::stdcm::Response::Success {
+                            simulation,
+                            path,
+                            departure_time,
+                        } => {
+                            span.record("path_found", true);
+                            StdcmProgression::Completed(StdcmResponse::Success {
+                                simulation: simulation.into(),
+                                pathfinding_result: path,
+                                departure_time,
+                                core_payload: core_payload.clone(),
+                            })
+                        }
+                        core_client::stdcm::Response::PathNotFound => {
+                            span.record("path_found", false);
+                            StdcmProgression::Completed(StdcmResponse::PathNotFound {
+                                core_payload: core_payload.clone(),
+                            })
+                        }
+                    },
+                },
+                Err(e) => StdcmProgression::Completed(StdcmResponse::InternalError {
+                    error: e,
+                    core_payload: core_payload.clone(),
+                }),
+            }
+        });
+
+        let mut result_stream = pin!(result_stream);
+        while let Some(item) = result_stream.next().await {
+            if tx.send(item).is_err() {
+                break;
+            }
         }
-        core_client::stdcm::Response::PathNotFound => {
-            span.record("path_found", false);
-            Ok(Json(StdcmResponse::PathNotFound {
-                core_payload: returned_request.clone(),
-            }))
-        }
-    }
+    });
+    let stream = tokio_stream::wrappers::UnboundedReceiverStream::new(rx);
+    Ok(StreamBodyAs::json_nl(stream))
 }
 
 struct VirtualTrainRun {

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -36,9 +36,11 @@ use schemas::train_schedule::TrainOccurrence;
 use serde::Deserialize;
 use serde::Serialize;
 use std::cmp::max;
+use std::collections::HashMap;
 use std::pin::pin;
 use std::slice;
 use std::sync::Arc;
+use std::time::Instant;
 use thiserror::Error;
 use tokio::spawn;
 use tokio::sync::mpsc;
@@ -362,6 +364,7 @@ pub(in crate::views) async fn stdcm_handler(
 
     let (tx, rx) = mpsc::unbounded_channel();
     let core_payload = returned_request.clone();
+    let mut points_on_grid: HashMap<String, Instant> = HashMap::new();
 
     spawn(async move {
         let stream_stdcm_response = stdcm_request
@@ -427,13 +430,35 @@ pub(in crate::views) async fn stdcm_handler(
 
         let mut result_stream = pin!(result_stream);
         while let Some(item) = result_stream.next().await {
-            if tx.send(item).is_err() {
+            if !should_skip_event(&item, &mut points_on_grid) && tx.send(item).is_err() {
                 break;
             }
         }
     });
     let stream = tokio_stream::wrappers::UnboundedReceiverStream::new(rx);
     Ok(StreamBodyAs::json_nl(stream))
+}
+
+fn should_skip_event(
+    event: &StdcmProgression,
+    points_on_grid: &mut HashMap<String, Instant>,
+) -> bool {
+    match event {
+        StdcmProgression::Ongoing(StdcmProgressionEvent { point, .. }) => {
+            if let Value::Point(coords) = &point.value {
+                let grid_key = format!("{:.2}/{:.2}", coords[0], coords[1]);
+                let now = Instant::now();
+                if let Some(&last_sent) = points_on_grid.get(&grid_key)
+                    && last_sent.elapsed() < std::time::Duration::from_millis(2000)
+                {
+                    return true;
+                }
+                points_on_grid.insert(grid_key, now);
+            }
+            false
+        }
+        _ => false,
+    }
 }
 
 struct VirtualTrainRun {

--- a/tests/tests/test_stdcm.py
+++ b/tests/tests/test_stdcm.py
@@ -197,10 +197,19 @@ def test_work_schedules(
     url = f"{EDITOAST_URL}timetable/{small_scenario.timetable}/stdcm/?infra={small_scenario.infra}"
     r = session.post(url, json=payload)
     assert r.status_code == 200
-    response = r.json()
-    departure_time = datetime.datetime.fromisoformat(
-        response["departure_time"].replace("Z", "+00:00")
-    )
+    departure_time = None
+    for line in r.iter_lines():
+        if not line:
+            continue
+        response_json = json.loads(line)
+        if response_json.get("event") == "completed":
+            data = response_json["data"]
+            if data.get("status") == "success":
+                departure_time = datetime.datetime.fromisoformat(
+                    data["departure_time"].replace("Z", "+00:00")
+                )
+            break
+    assert departure_time is not None
     assert departure_time >= end_time.astimezone(departure_time.tzinfo)
 
 
@@ -337,11 +346,17 @@ def test_max_running_time(
     }
     url = f"{EDITOAST_URL}timetable/{small_scenario.timetable}/stdcm/?infra={small_scenario.infra}"
     r = session.post(url, json=payload)
-    response = r.json()
+    data = None
+    for line in r.iter_lines():
+        if not line:
+            continue
+        response_json = json.loads(line)
+        if response_json.get("event") == "completed":
+            data = response_json["data"]
+            break
     assert r.status_code == 200
-    assert response == {
-        "status": "path_not_found",
-    }
+    assert data is not None
+    assert data.get("status") == "path_not_found"
 
 
 def _get_stdcm_response(
@@ -355,5 +370,15 @@ def _get_stdcm_response(
         json=stdcm_payload,
     )
     stdcm_response.raise_for_status()
-    content = stdcm_response.json()
+    content = None
+
+    for line in stdcm_response.iter_lines():
+        if not line:
+            continue
+        response_json = json.loads(line)
+        if response_json.get("event") == "completed":
+            content = response_json["data"]
+            break
+
+    assert content is not None
     return content


### PR DESCRIPTION
The goal of this PR is to reduce the payload size of the streaming endpoint, by filtering point sent.

On the following example : 
* RS:  ELECTRIC_RS_E2E
* MAL100
* Length: 750
* From: LEW
* To: MSC

Without:
* Received: 11175  
* Displayed: 159

With the code
* Received: 891 
* Displayed: 156
