### PR TITLE
editoast: fix the number of generated occurrences

### DIFF
--- a/editoast/schemas/src/paced_train.rs
+++ b/editoast/schemas/src/paced_train.rs
@@ -91,11 +91,18 @@ impl<'de> Deserialize<'de> for TrainSchedule {
 
             let time_window_secs = paced.time_window.num_seconds();
             let interval_secs = paced.interval.num_seconds();
-            let num_occurrences = (time_window_secs / interval_secs) as usize;
+            // Ideally, we’d use `div_ceil` which is nightly-only at the time of writing
+            // https://doc.rust-lang.org/std/primitive.i64.html#method.div_ceil
+            let num_occurrences = (time_window_secs / interval_secs) as usize
+                + if time_window_secs.rem_euclid(interval_secs) != 0 {
+                    1
+                } else {
+                    0
+                };
 
             for ex in &paced.exceptions {
                 if let ExceptionType::Modified { occurrence_index } = ex.exception_type
-                    && occurrence_index > num_occurrences
+                    && occurrence_index >= num_occurrences
                 {
                     return Err(serde::de::Error::custom(format!(
                         "Modified exception '{}' references invalid occurrence index {}",

--- a/editoast/src/models/train_schedule.rs
+++ b/editoast/src/models/train_schedule.rs
@@ -233,7 +233,16 @@ impl TrainSchedule {
     /// Returns 1 if it's not a paced train.
     fn num_base_occurrences(&self) -> usize {
         if let Some((time_window, interval)) = self.pace() {
-            (time_window.num_seconds() / interval.num_seconds()) as usize
+            // Ideally, we’d use `div_ceil` which is nightly-only at the time of writing
+            // https://doc.rust-lang.org/std/primitive.i64.html#method.div_ceil
+            let time_window = time_window.num_seconds();
+            let interval = interval.num_seconds();
+            (time_window / interval) as usize
+                + if time_window.rem_euclid(interval) != 0 {
+                    1
+                } else {
+                    0
+                }
         } else {
             1
         }

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -1901,7 +1901,7 @@ mod tests {
 
         let mut paced_train_base = simple_paced_train_base();
         paced_train_base.paced.as_mut().unwrap().time_window =
-            Duration::minutes(60).try_into().unwrap();
+            Duration::minutes(65).try_into().unwrap();
         paced_train_base.paced.as_mut().unwrap().interval =
             Duration::minutes(15).try_into().unwrap();
         paced_train_base.paced.as_mut().unwrap().exceptions =

--- a/editoast/src/views/train_schedule_set.rs
+++ b/editoast/src/views/train_schedule_set.rs
@@ -408,6 +408,7 @@ mod tests {
     use schemas::paced_train::ExceptionType;
     use schemas::paced_train::PacedTrainException;
     use schemas::paced_train::PathAndScheduleChangeGroup;
+    use schemas::primitives::PositiveDuration;
     use schemas::train_schedule::MarginValue;
     use schemas::train_schedule::Margins;
 
@@ -537,6 +538,41 @@ mod tests {
 
         assert_eq!(&list_result[0].exceptions[0], &exception_1);
         assert_eq!(&list_result[0].exceptions[1], &exception_2);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn create_paced_train_with_out_of_bound_exceptions() {
+        let app = TestAppBuilder::default_app();
+        let pool = app.db_pool();
+
+        let train_schedule_set = create_train_schedule_set(&mut pool.get_ok()).await;
+        let mut paced_train = simple_paced_train_base();
+        paced_train.paced.as_mut().unwrap().interval =
+            PositiveDuration::new(chrono::Duration::seconds(50));
+        paced_train.paced.as_mut().unwrap().time_window =
+            PositiveDuration::new(chrono::Duration::seconds(120));
+
+        let exception = simple_modified_exception_with_change_groups("modified_exception", 3);
+        paced_train.paced.as_mut().unwrap().exceptions = vec![exception];
+
+        let request = app
+            .post(
+                format!(
+                    "/train_schedule_sets/{}/train_schedules",
+                    train_schedule_set.id
+                )
+                .as_str(),
+            )
+            .json(&vec![paced_train.clone()]);
+
+        let response = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::UNPROCESSABLE_ENTITY)
+            .string();
+        assert!(response.contains(
+            "Modified exception 'modified_exception' references invalid occurrence index 3"
+        ))
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]


### PR DESCRIPTION
The number of occurrences is the result of the divisions of integers, rounded to the top. A basic integer division round to the bottom. The bug rarely manifest because:
- most of our tests use numbers where the result of the division is exact
- the front receives the train schedule most of the time and does the correct operation of rounding to the top when creating the occurrences (see 788cb17 in front/src/modules/trainschedule/helpers/pacedTrain.ts).

> [!NOTE]
> Note: In one test, I only change a value from `60` to `65`. The impact needs a bit of explanation. The exception in that test is on occurrence 5. When `interval` at `15` and `time_window` at `60`, it means we have 4 occurrences, meaning valid indexes are from `0` to `3`. The bug manifest particularly when the index is only one away, not 2 (especially because of the `>` which has been modified into a `>=`). Changing to `65` means there will be 5 occurrences (not 4), meaning the index 5 is just one away out of bound, and it triggers the problem for the strict comparison.