### PR TITLE
editoast: port infra privileges retrieval to `authz::v2`

### DIFF
--- a/editoast/authz/src/authorizer.rs
+++ b/editoast/authz/src/authorizer.rs
@@ -64,15 +64,6 @@ impl<S: StorageDriver> Authorizer<S> {
         self.regulator.check_roles(&User(self.user_id), roles).await
     }
 
-    pub async fn infra_privileges(
-        &self,
-        infra: &Infra,
-    ) -> Result<HashSet<InfraPrivilege>, Error<S::Error>> {
-        self.regulator
-            .infra_privileges(&User(self.user_id), infra)
-            .await
-    }
-
     pub async fn authorize_infra(
         &self,
         infra: &Infra,

--- a/editoast/authz/src/model.rs
+++ b/editoast/authz/src/model.rs
@@ -95,7 +95,17 @@ pub struct User(pub i64);
 pub struct Group(pub i64);
 
 #[derive(
-    fga::Type, fga::User, fga::Object, derive_more::FromStr, Debug, Clone, Copy, PartialEq, Eq, Hash,
+    fga::Type,
+    fga::User,
+    fga::Object,
+    derive_more::FromStr,
+    derive_more::Deref,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
 )]
 pub struct Infra(pub i64);
 

--- a/editoast/authz/src/regulator.rs
+++ b/editoast/authz/src/regulator.rs
@@ -227,44 +227,6 @@ impl<S: StorageDriver> Regulator<S> {
     }
 
     #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
-    pub async fn infra_privileges(
-        &self,
-        user: &User,
-        infra: &Infra,
-    ) -> Result<HashSet<InfraPrivilege>, Error<S::Error>> {
-        if self.is_admin(user).await? {
-            return Ok(HashSet::from([
-                InfraPrivilege::CanRead,
-                InfraPrivilege::CanShareRead,
-                InfraPrivilege::CanWrite,
-                InfraPrivilege::CanShareWrite,
-                InfraPrivilege::CanDelete,
-                InfraPrivilege::CanShareOwnership,
-            ]));
-        }
-
-        let (can_read, can_share_read, can_write, can_share_write, can_delete, can_share_ownership) =
-            self.openfga
-                .checks((
-                    Infra::can_read().check(user, infra),
-                    Infra::can_share_read().check(user, infra),
-                    Infra::can_write().check(user, infra),
-                    Infra::can_share_write().check(user, infra),
-                    Infra::can_delete().check(user, infra),
-                    Infra::can_share_ownership().check(user, infra),
-                ))
-                .await?;
-        let mut privileges = HashSet::new();
-        privileges.extend(can_read.then_some(InfraPrivilege::CanRead));
-        privileges.extend(can_share_read.then_some(InfraPrivilege::CanShareRead));
-        privileges.extend(can_write.then_some(InfraPrivilege::CanWrite));
-        privileges.extend(can_share_write.then_some(InfraPrivilege::CanShareWrite));
-        privileges.extend(can_delete.then_some(InfraPrivilege::CanDelete));
-        privileges.extend(can_share_ownership.then_some(InfraPrivilege::CanShareOwnership));
-        Ok(privileges)
-    }
-
-    #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
     pub async fn infra_direct_grant(
         &self,
         subject: &Subject,

--- a/editoast/authz/src/v2.rs
+++ b/editoast/authz/src/v2.rs
@@ -143,6 +143,11 @@ impl<T> Protected<T> {
 }
 
 impl<T: Send + 'static> Protected<T> {
+    /// A [Protected] value that always succeeds with the provided value
+    pub fn value(t: T) -> Self {
+        Self::new(move |_| async move { Ok(t) }.boxed())
+    }
+
     pub fn map<U: Send + 'static>(
         self,
         f: impl for<'c> FnOnce(&'c fga::Client, T) -> BoxFuture<'c, Result<U, OpenFgaError>>
@@ -161,6 +166,30 @@ impl<T: Send + 'static> Protected<T> {
                     f(openfga, t).await
                 }
                 .boxed()
+            }),
+            guardrails,
+            sanity_checks,
+        }
+    }
+
+    pub fn zip<U: Send + 'static>(
+        self,
+        Protected {
+            op: other_op,
+            guardrails: other_guardrails,
+            sanity_checks: other_sanity_checks,
+        }: Protected<U>,
+    ) -> Protected<(T, U)> {
+        let Self {
+            op,
+            mut guardrails,
+            mut sanity_checks,
+        } = self;
+        guardrails.extend(other_guardrails);
+        sanity_checks.extend(other_sanity_checks);
+        Protected {
+            op: Box::new(move |openfga| {
+                async move { tokio::try_join!(op(openfga), other_op(openfga)) }.boxed()
             }),
             guardrails,
             sanity_checks,

--- a/editoast/authz/src/v2.rs
+++ b/editoast/authz/src/v2.rs
@@ -418,6 +418,49 @@ pub fn infra_effective_grant(subject: Subject, infra: Infra) -> Protected<Option
     .with_guardrail(Guardrail::IssuerHasInfraPrivilege(InfraPrivilege::CanRead, infra))
 }
 
+pub fn infra_privileges(user: User, infra: Infra) -> Protected<HashSet<InfraPrivilege>> {
+    Protected::new(move |openfga| {
+        async move {
+            let (
+                admin,
+                can_read,
+                can_share_read,
+                can_write,
+                can_share_write,
+                can_delete,
+                can_share_ownership,
+            ) = openfga
+                .checks((
+                    User::role().check(&Role::Admin, &user),
+                    Infra::can_read().check(&user, &infra),
+                    Infra::can_share_read().check(&user, &infra),
+                    Infra::can_write().check(&user, &infra),
+                    Infra::can_share_write().check(&user, &infra),
+                    Infra::can_delete().check(&user, &infra),
+                    Infra::can_share_ownership().check(&user, &infra),
+                ))
+                .await?;
+            let mut privileges = HashSet::new();
+            privileges.extend((admin || can_read).then_some(InfraPrivilege::CanRead));
+            privileges.extend((admin || can_share_read).then_some(InfraPrivilege::CanShareRead));
+            privileges.extend((admin || can_write).then_some(InfraPrivilege::CanWrite));
+            privileges.extend((admin || can_share_write).then_some(InfraPrivilege::CanShareWrite));
+            privileges.extend((admin || can_delete).then_some(InfraPrivilege::CanDelete));
+            privileges.extend(
+                (admin || can_share_ownership).then_some(InfraPrivilege::CanShareOwnership),
+            );
+            Ok(privileges)
+        }
+        .boxed()
+    })
+    .with_check(SanityCheck::InfraExists(infra))
+    .with_check(SanityCheck::SubjectExists(Subject::user(user)))
+    .with_guardrail(Guardrail::IssuerHasInfraPrivilege(
+        InfraPrivilege::CanRead,
+        infra,
+    ))
+}
+
 pub mod special_authorizers {
     use std::convert::Infallible;
 
@@ -471,6 +514,7 @@ pub trait TestClientExt {
     async fn subject_roles(&self, subject: &Subject) -> HashSet<Role>;
     async fn group_members(&self, group: &Group) -> HashSet<User>;
     async fn infra_effective_grant(&self, subject: Subject, infra: Infra) -> Option<InfraGrant>;
+    async fn infra_privileges(&self, user: User, infra: Infra) -> HashSet<InfraPrivilege>;
 }
 
 impl TestClientExt for fga::Client {
@@ -497,6 +541,14 @@ impl TestClientExt for fga::Client {
         let authorize = special_authorizers::Authorize(self);
         authorize
             .access_value(infra_effective_grant(subject, infra))
+            .await
+            .unwrap()
+    }
+
+    async fn infra_privileges(&self, user: User, infra: Infra) -> HashSet<InfraPrivilege> {
+        let authorize = special_authorizers::Authorize(self);
+        authorize
+            .access_value(infra_privileges(user, infra))
             .await
             .unwrap()
     }
@@ -839,5 +891,50 @@ mod tests {
             .unwrap_authorized()
             .await;
         assert_eq!(grant, Some(InfraGrant::Owner));
+    }
+
+    #[tokio::test]
+    async fn infra_privileges_non_admin() {
+        let openfga = crate::authz_client!();
+
+        openfga
+            .write_tuples(&[Infra::writer().tuple(&User(1), &Infra(1))])
+            .await
+            .unwrap();
+
+        assert_eq!(
+            openfga.infra_privileges(User(1), Infra(1)).await,
+            HashSet::from_iter([
+                InfraPrivilege::CanRead,
+                InfraPrivilege::CanShareRead,
+                InfraPrivilege::CanWrite,
+                InfraPrivilege::CanShareWrite,
+            ])
+        );
+    }
+
+    #[tokio::test]
+    async fn infra_privileges_admin() {
+        let openfga = crate::authz_client!();
+
+        openfga
+            .prepare_writes()
+            .write(&User::role().tuple(&Role::Admin, &User(1)))
+            .write(&Infra::reader().tuple(&User(2), &Infra(1)))
+            .execute()
+            .await
+            .unwrap();
+
+        assert_eq!(
+            openfga.infra_privileges(User(1), Infra(1)).await,
+            HashSet::from_iter([
+                InfraPrivilege::CanRead,
+                InfraPrivilege::CanShareRead,
+                InfraPrivilege::CanWrite,
+                InfraPrivilege::CanShareWrite,
+                InfraPrivilege::CanDelete,
+                InfraPrivilege::CanShareOwnership,
+            ])
+        );
     }
 }

--- a/editoast/authz/src/v2.rs
+++ b/editoast/authz/src/v2.rs
@@ -937,4 +937,19 @@ mod tests {
             ])
         );
     }
+
+    #[tokio::test]
+    async fn no_infra_privileges() {
+        let openfga = crate::authz_client!();
+
+        openfga
+            .write_tuples(&[Infra::reader().tuple(&User(2), &Infra(1))])
+            .await
+            .unwrap();
+
+        assert_eq!(
+            openfga.infra_privileges(User(1), Infra(1)).await,
+            HashSet::new(),
+        );
+    }
 }

--- a/editoast/authz/src/v2.rs
+++ b/editoast/authz/src/v2.rs
@@ -95,6 +95,27 @@ pub trait Authorizer {
         &'a self,
         data: Protected<T>,
     ) -> Result<Access<'a, T, Self::Rejection>, Self::Error>;
+
+    /// Authorizes multiple [Protected] operations concurrently
+    ///
+    /// Errors are coalesced into a single top-level `Err`. If they are
+    /// needed individually, call [Self::authorize] multiple times directly.
+    ///
+    /// Note that you'll need to `.await` each [Access] as well. Make sure to
+    /// do so concurrently as well. You can use [Access::access_all] for this.
+    ///
+    /// Also note that you'll have to then deal with each potential rejection
+    /// individually. If they're all the same, the upcoming transformation from
+    /// `Vec<Protected<T>>` to `Protected<Vec<T>>` will serve this purpose. Stay tuned!
+    async fn authorize_all<'a, T>(
+        &'a self,
+        data: impl IntoIterator<Item = Protected<T>>,
+    ) -> Result<Vec<Access<'a, T, Self::Rejection>>, Self::Error> {
+        futures::future::join_all(data.into_iter().map(|d| self.authorize(d)))
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
+    }
 }
 
 impl<T> Protected<T> {
@@ -218,6 +239,16 @@ impl<'a, T, R> Access<'a, T, R> {
                 Ok(Ok(value))
             }
         }
+    }
+
+    /// Concurrently awaits all accesses and factorizes OpenFGA errors
+    ///
+    /// If you don't need to handle individual rejections, stay tuned for the
+    /// upcoming `Protected<Vec<T>>` transformation.
+    pub async fn access_all(
+        accesses: impl IntoIterator<Item = Access<'_, T, R>>,
+    ) -> Result<Vec<Result<T, R>>, OpenFgaError> {
+        futures::future::try_join_all(accesses.into_iter().map(|access| access.access())).await
     }
 }
 

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -158,7 +158,7 @@ paths:
       tags:
       - authz
       requestBody:
-        description: The resources of which to get the request sender's privileges. If a resource doesn't exist, it will be omitted.
+        description: The resources of which to get the request sender's privileges.
         content:
           application/json:
             schema:
@@ -175,7 +175,7 @@ paths:
         required: true
       responses:
         '200':
-          description: The privileges of the user sending the request over each requested resource.
+          description: The privileges of the user sending the request over each requested resource. The resource is omitted if it does not exist. An empty privileges list is returned if the user has no privileges over it.
           content:
             application/json:
               schema:

--- a/editoast/src/authentication.rs
+++ b/editoast/src/authentication.rs
@@ -6,7 +6,6 @@
 ///
 /// The values are **not validated by the builder**.
 #[derive(Debug, Clone)]
-#[expect(unused)]
 pub enum Authentication {
     Unauthenticated,
     Authenticated {
@@ -19,7 +18,9 @@ pub enum Authentication {
         impersonated_identity: String,
     },
     Skip {
+        #[expect(unused)]
         identity: Option<String>,
+        #[expect(unused)]
         name: Option<String>,
     },
 }
@@ -30,6 +31,7 @@ pub struct AuthenticationParameters {
     pub name: Option<String>,
     pub impersonate: Option<String>,
     pub skip: bool,
+    pub authorization_enabled: bool,
 }
 
 impl Authentication {
@@ -37,6 +39,12 @@ impl Authentication {
         let authn = match params {
             AuthenticationParameters {
                 skip: true,
+                identity,
+                name,
+                ..
+            }
+            | AuthenticationParameters {
+                authorization_enabled: false,
                 identity,
                 name,
                 ..

--- a/editoast/src/authorizers.rs
+++ b/editoast/src/authorizers.rs
@@ -112,7 +112,7 @@ pub enum Rejection {
     LackingInfraPrivilege(
         InfraPrivilege,
         #[expect(dead_code)] authz::Subject,
-        #[expect(dead_code)] authz::Infra,
+        authz::Infra,
     ),
 }
 

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -338,12 +338,13 @@ pub(in crate::views) async fn user_privileges(
             crate::authorizers::UserAuthorizer::new(user, roles, regulator.openfga(), conn);
         for infra in infras {
             match v2::infra_privileges(user, infra)
+                .zip(v2::Protected::value(infra))
                 .authorize(&authorizer)
                 .await?
                 .access()
                 .await?
             {
-                Ok(privileges) => {
+                Ok((privileges, infra)) => {
                     result_infras.push(ResourcePrivileges {
                         resource_id: *infra,
                         privileges,

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -339,10 +339,9 @@ pub(in crate::views) async fn user_privileges(
             infras.map(|infra| v2::infra_privileges(user, infra).zip(v2::Protected::value(infra)));
         let authorizer =
             crate::authorizers::UserAuthorizer::new(user, roles, regulator.openfga(), conn);
-        let futs = protected_privileges.map(|p| authorizer.authorize(p));
-        let privileges_accesses = futures::future::join_all(futs).await;
-        for access_res in privileges_accesses {
-            match access_res?.access().await? {
+        let accesses = authorizer.authorize_all(protected_privileges).await?;
+        for access in v2::Access::access_all(accesses).await? {
+            match access {
                 Ok((privileges, infra)) => {
                     result_infras.push(ResourcePrivileges {
                         resource_id: *infra,

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -14,6 +14,7 @@ use ::authz::InfraPrivilege;
 use ::authz::Role;
 use authz::Authorization;
 use authz::v2;
+use authz::v2::Authorizer;
 use axum::Extension;
 use axum::extract::Path;
 use axum::extract::State;
@@ -334,16 +335,14 @@ pub(in crate::views) async fn user_privileges(
         .flatten();
     if let Some(user) = user {
         let infras = infra_ids.map(authz::Infra);
+        let protected_privileges =
+            infras.map(|infra| v2::infra_privileges(user, infra).zip(v2::Protected::value(infra)));
         let authorizer =
             crate::authorizers::UserAuthorizer::new(user, roles, regulator.openfga(), conn);
-        for infra in infras {
-            match v2::infra_privileges(user, infra)
-                .zip(v2::Protected::value(infra))
-                .authorize(&authorizer)
-                .await?
-                .access()
-                .await?
-            {
+        let futs = protected_privileges.map(|p| authorizer.authorize(p));
+        let privileges_accesses = futures::future::join_all(futs).await;
+        for access_res in privileges_accesses {
+            match access_res?.access().await? {
                 Ok((privileges, infra)) => {
                     result_infras.push(ResourcePrivileges {
                         resource_id: *infra,

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -13,6 +13,7 @@ use ::authz::InfraGrant;
 use ::authz::InfraPrivilege;
 use ::authz::Role;
 use authz::Authorization;
+use authz::v2;
 use axum::Extension;
 use axum::extract::Path;
 use axum::extract::State;
@@ -297,72 +298,93 @@ pub(in crate::views) struct ResourcePrivileges {
     tag = "authz",
     request_body(
         content = inline(HashMap<ResourceType, Vec<i64>>),
-        description = "The resources of which to get the request sender's privileges. If a resource doesn't exist, it will be omitted.",
+        description = "The resources of which to get the request sender's privileges.",
     ),
     responses((
         status = 200,
-        description = "The privileges of the user sending the request over each requested resource.",
+        description = "The privileges of the user sending the request over each requested resource. \
+        The resource is omitted if it does not exist. \
+        An empty privileges list is returned if the user has no privileges over it.",
         body = inline(HashMap<ResourceType, Vec<ResourcePrivileges>>)
     )),
 )]
 pub(in crate::views) async fn user_privileges(
-    State(AppState { db_pool, .. }): State<AppState>,
-    Extension(auth): AuthenticationExt,
-    Json(body): Json<HashMap<ResourceType, Vec<i64>>>,
+    State(AppState {
+        db_pool, regulator, ..
+    }): State<AppState>,
+    Extension(user): Extension<Option<authz::User>>,
+    Extension(roles): Extension<Vec<Role>>,
+    Extension(authn): Extension<crate::authentication::Authentication>,
+    Json(mut resources_ids): Json<HashMap<ResourceType, Vec<i64>>>,
 ) -> Result<Json<HashMap<ResourceType, Vec<ResourcePrivileges>>>> {
-    let resources = body
-        .into_iter()
-        .flat_map(|(rtype, ids)| std::iter::repeat(rtype).zip(ids));
-
-    let mut result = HashMap::<_, Vec<_>>::new();
-
-    // Disabled authorization bypass — needs to be implemented more properly
-    if matches!(auth, Authentication::SkipAuthorization { .. }) {
-        for (resource_type, resource_id) in resources {
-            match resource_type {
-                ResourceType::Infra => {
-                    // If the infra exists, we return all privileges
-                    if Infra::exists(&mut db_pool.get().await?, resource_id).await? {
-                        result
-                            .entry(ResourceType::Infra)
-                            .or_default()
-                            .push(ResourcePrivileges {
-                                resource_id,
-                                privileges: HashSet::from([
-                                    InfraPrivilege::CanRead,
-                                    InfraPrivilege::CanShareRead,
-                                    InfraPrivilege::CanWrite,
-                                    InfraPrivilege::CanShareWrite,
-                                    InfraPrivilege::CanDelete,
-                                    InfraPrivilege::CanShareOwnership,
-                                ]),
-                            });
-                    }
-                }
-            }
-        }
-        return Ok(Json(result));
+    if matches!(
+        authn,
+        crate::authentication::Authentication::Unauthenticated
+    ) {
+        return Err(AuthorizationError::Unauthorized.into());
     }
 
-    let authorizer = auth.authorizer()?;
-    for (resource_type, resource_id) in resources {
-        match resource_type {
-            ResourceType::Infra => {
-                // check that the infra exists before to check the grants
-                if Infra::exists(&mut db_pool.get().await?, resource_id).await? {
-                    result
-                        .entry(ResourceType::Infra)
-                        .or_default()
-                        .push(ResourcePrivileges {
-                            resource_id,
-                            privileges: authorizer
-                                .infra_privileges(&authz::Infra(resource_id))
-                                .await
-                                .map_err(AuthzError::from)?,
-                        });
+    let mut result = HashMap::<_, Vec<_>>::new();
+    let result_infras = result.entry(ResourceType::Infra).or_default();
+
+    let mut conn = db_pool.get().await?;
+    let infra_ids = resources_ids
+        .remove(&ResourceType::Infra) // change when more resources are supported
+        .into_iter()
+        .flatten();
+    if let Some(user) = user {
+        let infras = infra_ids.map(authz::Infra);
+        let authorizer =
+            crate::authorizers::UserAuthorizer::new(user, roles, regulator.openfga(), conn);
+        for infra in infras {
+            match v2::infra_privileges(user, infra)
+                .authorize(&authorizer)
+                .await?
+                .access()
+                .await?
+            {
+                Ok(privileges) => {
+                    result_infras.push(ResourcePrivileges {
+                        resource_id: *infra,
+                        privileges,
+                    });
+                }
+                Err(Rejection::NoSuchInfra(_)) => {
+                    // not an error under the target API
+                    // (though maybe we should revisit it?)
+                }
+                Err(Rejection::LackingInfraPrivilege(InfraPrivilege::CanRead, _, infra)) => {
+                    result_infras.push(ResourcePrivileges {
+                        resource_id: *infra,
+                        privileges: HashSet::new(),
+                    });
+                }
+                Err(Rejection::NoSuchUser(_)) => {
+                    panic!("race condition: user deleted");
+                }
+                Err(rejection @ Rejection::LackingInfraPrivilege(_, _, _)) | Err(rejection) => {
+                    impossible!(rejection)
                 }
             }
         }
+    } else {
+        // Authorization is skipped (--enable-authorization or header), everyone has full access
+        debug_assert!(matches!(
+            authn,
+            crate::authentication::Authentication::Skip { .. }
+        ));
+        let infras: Vec<_> = Infra::retrieve_batch_unchecked(&mut conn, infra_ids).await?;
+        result_infras.extend(infras.into_iter().map(|infra| ResourcePrivileges {
+            resource_id: infra.id,
+            privileges: HashSet::from([
+                InfraPrivilege::CanRead,
+                InfraPrivilege::CanShareRead,
+                InfraPrivilege::CanWrite,
+                InfraPrivilege::CanShareWrite,
+                InfraPrivilege::CanDelete,
+                InfraPrivilege::CanShareOwnership,
+            ]),
+        }));
     }
 
     Ok(Json(result))

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -483,7 +483,11 @@ fn service_router() -> router::DocumentedRouter {
     })
 }
 
-async fn authentication_extraction_middleware(mut req: Request, next: Next) -> Result<Response> {
+async fn authentication_extraction_middleware(
+    State(AppState { config, .. }): State<AppState>,
+    mut req: Request,
+    next: Next,
+) -> Result<Response> {
     const IDENTITY: &str = "x-remote-user-identity";
     const NAME: &str = "x-remote-user-name";
     const SKIP_AUTHZ: &str = "x-osrd-skip-authz";
@@ -520,6 +524,7 @@ async fn authentication_extraction_middleware(mut req: Request, next: Next) -> R
             name,
             impersonate,
             skip: skip_authz,
+            authorization_enabled: config.enable_authorization,
         })
         .map_err(
             |AuthenticationParameters {
@@ -527,12 +532,14 @@ async fn authentication_extraction_middleware(mut req: Request, next: Next) -> R
                  name,
                  impersonate,
                  skip,
+                 authorization_enabled,
              }| {
                 tracing::error!(
                     identity,
                     name,
                     impersonate,
                     skip,
+                    authorization_enabled,
                     "invalid authentication parameters"
                 );
                 AuthorizationError::Unauthorized
@@ -1262,7 +1269,8 @@ impl Server {
                 app_state.clone(),
                 authentication_validation_middleware,
             ))
-            .route_layer(axum::middleware::from_fn(
+            .route_layer(axum::middleware::from_fn_with_state(
+                app_state.clone(),
                 authentication_extraction_middleware,
             ))
             .layer(OtelInResponseLayer)

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -297,7 +297,8 @@ impl TestAppBuilder {
                 app_state.clone(),
                 authentication_validation_middleware,
             ))
-            .route_layer(axum::middleware::from_fn(
+            .route_layer(axum::middleware::from_fn_with_state(
+                app_state.clone(),
                 authentication_extraction_middleware,
             ))
             .layer(OtelAxumLayer::default())

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -1593,14 +1593,14 @@ export type GetAuthzMeGroupsApiResponse =
   }[];
 export type GetAuthzMeGroupsApiArg = void;
 export type PostAuthzMePrivilegesApiResponse =
-  /** status 200 The privileges of the user sending the request over each requested resource. */ {
+  /** status 200 The privileges of the user sending the request over each requested resource. The resource is omitted if it does not exist. An empty privileges list is returned if the user has no privileges over it. */ {
     [key: string]: {
       privileges: InfraPrivilege[];
       resource_id: number;
     }[];
   };
 export type PostAuthzMePrivilegesApiArg = {
-  /** The resources of which to get the request sender's privileges. If a resource doesn't exist, it will be omitted. */
+  /** The resources of which to get the request sender's privileges. */
   body: {
     [key: string]: number[];
   };


### PR DESCRIPTION
refs https://github.com/osrd-project/osrd-confidential/issues/1168

> [!TIP]
> review each commit one by one

# About admin bypass

I decided to go against the plan for this. We were supposed to have an `.if_admin_then` closure in `Protected`. But there is a few issues:

* first, it's kind of a hack to be honest
* we introduce two paths for resolving `Protected`, which can lead us to the same issues we currently have with `if is_admin` branches down the line
* composes very poorly: what do we do for `map`, `zip`, etc. ?

`Access::Bypass` is now probably not necessary anymore, I'll get rid of it in another PR if it happens to be the case.