### PR TITLE
front: stdcm: refacto pdf generation

### DIFF
--- a/front/src/applications/stdcm/components/StdcmResults/SendToRailwayManagerModal.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/SendToRailwayManagerModal.tsx
@@ -1,8 +1,7 @@
-import { useEffect, useMemo, useState, useCallback, type ReactElement } from 'react';
+import { useEffect, useMemo, useState, useCallback } from 'react';
 
 import { Button, Checkbox, DatePicker, Input, Select, TextArea } from '@osrd-project/ui-core';
 import { Download, CheckCircle } from '@osrd-project/ui-icons';
-import { pdf, type DocumentProps } from '@react-pdf/renderer';
 import { Trans, useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
@@ -46,8 +45,7 @@ type SendToRailwayManagerModalProps = {
   linkedTrains: StdcmSimulationInputs['linkedTrains'];
   simulationReportSheetNumber: string;
   similarTrains: SimilarTrainWithSecondaryCode[];
-  pdfBlob: Blob | null;
-  pdfDocument: ReactElement<DocumentProps>;
+  pdfBlob: Blob;
 };
 
 type Option = { value: string; label: string };
@@ -72,7 +70,6 @@ const SendToRailwayManagerModal = ({
   simulationReportSheetNumber,
   similarTrains,
   pdfBlob,
-  pdfDocument,
 }: SendToRailwayManagerModalProps) => {
   const { t } = useTranslation('stdcm', { keyPrefix: 'simulation.results' });
   const { t: mainT } = useTranslation('translation');
@@ -218,15 +215,6 @@ const SendToRailwayManagerModal = ({
       return;
     }
 
-    let blobToSend: Blob;
-
-    if (pdfBlob) {
-      blobToSend = pdfBlob;
-    } else {
-      const pdfInstance = pdf(pdfDocument);
-      blobToSend = await pdfInstance.toBlob();
-    }
-
     const filename = `Last Minute Request-${simulationReportSheetNumber}`;
 
     const formData = new FormData();
@@ -289,7 +277,7 @@ const SendToRailwayManagerModal = ({
     formData.append('simulation_report', JSON.stringify(simulationReport));
     formData.append(
       'simulation_report_sheet',
-      new File([blobToSend], filename, { type: 'application/pdf' })
+      new File([pdfBlob], filename, { type: 'application/pdf' })
     );
 
     try {

--- a/front/src/applications/stdcm/components/StdcmResults/StdcmResults.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/StdcmResults.tsx
@@ -2,8 +2,9 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { Button } from '@osrd-project/ui-core';
 import { CheckCircle } from '@osrd-project/ui-icons';
-import { PDFDownloadLink } from '@react-pdf/renderer';
+import { usePDF } from '@react-pdf/renderer';
 import { skipToken } from '@reduxjs/toolkit/query';
+import fileDownload from 'js-file-download';
 import { head, last } from 'lodash';
 import { useTranslation, Trans } from 'react-i18next';
 import { useSelector } from 'react-redux';
@@ -71,7 +72,7 @@ const StdcmResults = ({
   const [railwayDemandId, setRailwayDemandId] = useState<string>();
   const [railwayRequestUrl, setRailwayRequestUrl] = useState<string | null>();
 
-  const [pdfBlob, setPdfBlob] = useState<Blob | null>(null);
+  const [pdfInstance, updatePdfInstance] = usePDF({});
 
   const { t } = useTranslation('stdcm', { keyPrefix: 'simulation.results' });
   const deploymentSettings = useDeploymentSettings();
@@ -270,20 +271,21 @@ const StdcmResults = ({
     }
   }, [isSelectedSimulationRetained]);
 
-  const pdfDocument = useMemo(() => {
-    if (!hasSimulationResults || !isSelectedSimulationRetained || !outputs) return null;
-    return (
-      <StdcmSimulationReportSheet
-        stdcmLinkedTrains={selectedSimulation.inputs.linkedTrains}
-        stdcmData={outputs.results}
-        consist={selectedSimulation.inputs.consist}
-        simulationReportSheetNumber={simulationReportSheetNumber}
-        operationalPointsList={operationalPointsList}
-        simulationSheetLogo={deploymentSettings?.stdcmSimulationSheetLogo}
-        similarTrains={similarTrains}
-      />
-    );
+  useEffect(() => {
+    if (hasSimulationResults && isSelectedSimulationRetained && outputs)
+      updatePdfInstance(
+        <StdcmSimulationReportSheet
+          stdcmLinkedTrains={selectedSimulation.inputs.linkedTrains}
+          stdcmData={outputs.results}
+          consist={selectedSimulation.inputs.consist}
+          simulationReportSheetNumber={simulationReportSheetNumber}
+          operationalPointsList={operationalPointsList}
+          simulationSheetLogo={deploymentSettings?.stdcmSimulationSheetLogo}
+          similarTrains={similarTrains}
+        />
+      );
   }, [
+    updatePdfInstance,
     outputs,
     hasSimulationResults,
     isSelectedSimulationRetained,
@@ -293,6 +295,13 @@ const StdcmResults = ({
     deploymentSettings?.stdcmSimulationSheetLogo,
     similarTrains,
   ]);
+
+  const downloadPdf = useCallback(() => {
+    fileDownload(
+      pdfInstance.blob!,
+      `${deploymentSettings?.stdcmName || 'Stdcm'}-${simulationReportSheetNumber}.pdf`
+    );
+  }, [pdfInstance, deploymentSettings, simulationReportSheetNumber]);
 
   return (
     <>
@@ -327,26 +336,17 @@ const StdcmResults = ({
                     operationalPointsList={operationalPointsList}
                     simulationIndex={selectedSimulation.index}
                   />
-                  {isSelectedSimulationRetained && pdfDocument && (
+                  {isSelectedSimulationRetained && (
                     <div className="get-simulation">
                       <div className="download-simulation" data-testid="download-simulation">
-                        <PDFDownloadLink
-                          document={pdfDocument}
-                          fileName={`${deploymentSettings?.stdcmName || 'Stdcm'}-${simulationReportSheetNumber}.pdf`}
-                        >
-                          {({ blob }) => {
-                            if (blob && blob !== pdfBlob) setPdfBlob(blob);
-                            return (
-                              <Button
-                                data-testid="download-simulation-button"
-                                label={t('downloadSimulationSheet')}
-                                onClick={() => {}}
-                                isDisabled={areSegmentsLoading}
-                                variant="Normal"
-                              />
-                            );
-                          }}
-                        </PDFDownloadLink>
+                        <Button
+                          data-testid="download-simulation-button"
+                          label={t('downloadSimulationSheet')}
+                          onClick={downloadPdf}
+                          isDisabled={areSegmentsLoading || pdfInstance.loading}
+                          variant="Normal"
+                          isLoading={pdfInstance.loading}
+                        />
                       </div>
                       {railwayManagerUrl &&
                         sendLMRAuthorizedResponse?.authorized &&
@@ -358,8 +358,9 @@ const StdcmResults = ({
                                 ? t('transferSheetToRailManagerDisabledForConsistChange')
                                 : undefined
                             }
-                            isDisabled={hasConsistChange}
-                            onClick={() =>
+                            isDisabled={hasConsistChange || pdfInstance.loading}
+                            isLoading={pdfInstance.loading}
+                            onClick={() => {
                               openModal(
                                 <SendToRailwayManagerModal
                                   consist={selectedSimulation.inputs.consist}
@@ -367,15 +368,14 @@ const StdcmResults = ({
                                   linkedTrains={selectedSimulation.inputs.linkedTrains}
                                   simulationReportSheetNumber={simulationReportSheetNumber}
                                   similarTrains={similarTrains}
-                                  pdfBlob={pdfBlob}
-                                  pdfDocument={pdfDocument}
+                                  pdfBlob={pdfInstance.blob!}
                                   onClose={closeModal}
                                   onSuccess={handleSubmitSuccess}
                                 />,
                                 'xl',
                                 'no-close-modal'
-                              )
-                            }
+                              );
+                            }}
                           />
                         ) : (
                           <div className="success-message">

--- a/front/tests/pages/stdcm/simulation-results-page.ts
+++ b/front/tests/pages/stdcm/simulation-results-page.ts
@@ -20,7 +20,6 @@ class SimulationResultPage {
   private readonly allViasButton: Locator;
   private readonly retainSimulationButton: Locator;
   private readonly downloadSimulationButton: Locator;
-  private readonly downloadLink: Locator;
   private readonly startNewQueryButton: Locator;
   private readonly startNewQueryWithDataButton: Locator;
   private readonly feedbackCardContainer: Locator;
@@ -42,8 +41,7 @@ class SimulationResultPage {
     this.simulationTableRows = this.simulationResultTable.locator('tbody tr');
     this.allViasButton = page.getByTestId('all-vias-button');
     this.retainSimulationButton = page.getByTestId('retain-simulation-button');
-    this.downloadSimulationButton = page.getByTestId('download-simulation').locator('a[download]');
-    this.downloadLink = page.getByTestId('download-simulation').locator('a');
+    this.downloadSimulationButton = page.getByTestId('download-simulation');
     this.startNewQueryButton = page.getByTestId('start-new-query-button');
     this.startNewQueryWithDataButton = page.getByTestId('start-new-query-with-data-button');
     this.feedbackCardContainer = page.getByTestId('feedback-card');
@@ -134,9 +132,9 @@ class SimulationResultPage {
   }
 
   async downloadSimulation(downloadDir: string): Promise<void> {
-    await expect(this.downloadLink).toBeVisible();
+    await expect(this.downloadSimulationButton).toBeVisible();
 
-    const download = await triggerFileDownload(this.page, this.downloadLink);
+    const download = await triggerFileDownload(this.page, this.downloadSimulationButton);
 
     assertSuggestedFilename(download, /^Stdcm.*\.pdf$/);
 


### PR DESCRIPTION
Fix #15801

The PDF was being generated during the render phase of the StdcmResults component. This process relied on a setState call, which triggered an additional render cycle and caused the issue.

Additionally:
- The download mechanism used a link wrapping a button with a no-op action, which is not appropriate.
- PDF generation is asynchronous, but the UI did not provide any feedback to inform the user that the PDF was being generated.