### PR TITLE
editoast: check train schedule exception occurrence index

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -6347,6 +6347,7 @@ components:
       - $ref: '#/components/schemas/EditoastTrainScheduleErrorTrainScheduleSetNotFound'
       - $ref: '#/components/schemas/EditoastTrainScheduleExceptionErrorBatchNotFound'
       - $ref: '#/components/schemas/EditoastTrainScheduleExceptionErrorDatabase'
+      - $ref: '#/components/schemas/EditoastTrainScheduleExceptionErrorInvalidOccurrenceIndex'
       - $ref: '#/components/schemas/EditoastTrainScheduleExceptionErrorNotFound'
       - $ref: '#/components/schemas/EditoastTrainScheduleExceptionErrorNotPacedTrain'
       - $ref: '#/components/schemas/EditoastTrainScheduleExceptionErrorTimetableNotFound'
@@ -8664,6 +8665,39 @@ components:
           type: string
           enum:
           - editoast:train_schedule_exception:Database
+    EditoastTrainScheduleExceptionErrorInvalidOccurrenceIndex:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+          required:
+          - interval
+          - occurrence_index
+          - time_window
+          - train_schedule_id
+          properties:
+            interval:
+              type: string
+            occurrence_index:
+              type: integer
+            time_window:
+              type: string
+            train_schedule_id:
+              type: integer
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 400
+        type:
+          type: string
+          enum:
+          - editoast:train_schedule_exception:InvalidOccurrenceIndex
     EditoastTrainScheduleExceptionErrorNotFound:
       type: object
       required:

--- a/editoast/src/models/train_schedule.rs
+++ b/editoast/src/models/train_schedule.rs
@@ -65,6 +65,11 @@ pub struct TrainSchedule {
 }
 
 impl TrainSchedule {
+    pub fn is_exception_occurrence_index_valid(&self, occurrence_index: i64) -> bool {
+        usize::try_from(occurrence_index)
+            .is_ok_and(|i| (0..self.num_base_occurrences()).contains(&i))
+    }
+
     pub fn apply_train_schedule_exception(
         &self,
         exception: &TrainScheduleException,
@@ -471,6 +476,71 @@ mod tests {
             sub_category: None,
             exceptions: vec![],
         }
+    }
+
+    #[rstest]
+    #[case(
+        chrono::Duration::try_hours(2),
+        chrono::Duration::try_minutes(30),
+        0,
+        true
+    )]
+    #[case(
+        chrono::Duration::try_hours(2),
+        chrono::Duration::try_minutes(30),
+        1,
+        true
+    )]
+    #[case(
+        chrono::Duration::try_hours(2),
+        chrono::Duration::try_minutes(30),
+        3,
+        true
+    )]
+    #[case(
+        chrono::Duration::try_hours(2),
+        chrono::Duration::try_minutes(30),
+        4,
+        false
+    )]
+    #[case(
+        chrono::Duration::try_hours(2),
+        chrono::Duration::try_minutes(30),
+        100,
+        false
+    )]
+    #[case(chrono::Duration::try_hours(2), chrono::Duration::try_minutes(30), -1, false)]
+    #[case(
+        chrono::Duration::try_seconds(120),
+        chrono::Duration::try_seconds(50),
+        3,
+        false
+    )]
+    #[case(
+        chrono::Duration::try_minutes(60),
+        chrono::Duration::try_minutes(25),
+        2,
+        true
+    )]
+    #[case(
+        chrono::Duration::try_minutes(60),
+        chrono::Duration::try_minutes(25),
+        3,
+        false
+    )]
+    fn train_schedule_is_exception_occurrence_index_invalid(
+        #[case] time_window: Option<chrono::Duration>,
+        #[case] interval: Option<chrono::Duration>,
+        #[case] occurrence_index: i64,
+        #[case] expected_valid: bool,
+    ) {
+        let mut train_schedule = create_paced_train();
+        train_schedule.time_window = time_window;
+        train_schedule.interval = interval;
+        assert_eq!(
+            train_schedule.is_exception_occurrence_index_valid(occurrence_index),
+            expected_valid
+        );
     }
 
     #[tokio::test]

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -317,11 +317,13 @@ pub(in crate::views) async fn simulation_summary(
     .await?;
 
     let train_schedules: Vec<models::TrainSchedule> =
-        models::TrainSchedule::retrieve_batch_or_fail(conn, train_schedule_ids.clone(), |missing| {
-            TrainScheduleError::BatchNotFound {
+        models::TrainSchedule::retrieve_batch_or_fail(
+            conn,
+            train_schedule_ids.clone(),
+            |missing| TrainScheduleError::BatchNotFound {
                 count: missing.len(),
-            }
-        })
+            },
+        )
         .await?;
 
     let mut exceptions = TrainScheduleException::retrieve_exceptions_by_train_schedules(

--- a/editoast/src/views/timetable/train_schedule_exceptions.rs
+++ b/editoast/src/views/timetable/train_schedule_exceptions.rs
@@ -44,6 +44,16 @@ pub enum TrainScheduleExceptionError {
     #[error("Train schedule '{train_schedule_id}' is not a paced train")]
     #[editoast_error(status = 400)]
     NotPacedTrain { train_schedule_id: i64 },
+    #[error(
+        "Occurrence index '{occurrence_index}' is invalid for train schedule '{train_schedule_id}' with time window '{time_window}' and interval '{interval}'"
+    )]
+    #[editoast_error(status = 400)]
+    InvalidOccurrenceIndex {
+        train_schedule_id: i64,
+        occurrence_index: i64,
+        time_window: String,
+        interval: String,
+    },
     #[error(transparent)]
     Database(#[from] editoast_models::Error),
 }
@@ -127,6 +137,24 @@ pub(in crate::views) async fn create_train_schedule_exception(
     if train_schedule.pace().is_none() {
         return Err(TrainScheduleExceptionError::NotPacedTrain {
             train_schedule_id: train_schedule_exception_form.train_schedule_id,
+        }
+        .into());
+    }
+
+    if let Some(occurrence_index) = train_schedule_exception_form.occurrence_index
+        && !train_schedule.is_exception_occurrence_index_valid(occurrence_index)
+    {
+        return Err(TrainScheduleExceptionError::InvalidOccurrenceIndex {
+            train_schedule_id: train_schedule_exception_form.train_schedule_id,
+            occurrence_index,
+            time_window: train_schedule
+                .time_window
+                .map(|t| t.to_string())
+                .unwrap_or_else(|| "None".to_string()),
+            interval: train_schedule
+                .interval
+                .map(|i| i.to_string())
+                .unwrap_or_else(|| "None".to_string()),
         }
         .into());
     }
@@ -219,6 +247,24 @@ pub(in crate::views) async fn update(
         return Err(TrainScheduleExceptionError::NotPacedTrain { train_schedule_id }.into());
     }
 
+    if let Some(occurrence_index) = train_schedule_exception_form.occurrence_index
+        && !train_schedule.is_exception_occurrence_index_valid(occurrence_index)
+    {
+        return Err(TrainScheduleExceptionError::InvalidOccurrenceIndex {
+            train_schedule_id: train_schedule_exception_form.train_schedule_id,
+            occurrence_index,
+            time_window: train_schedule
+                .time_window
+                .map(|t| t.to_string())
+                .unwrap_or_else(|| "None".to_string()),
+            interval: train_schedule
+                .interval
+                .map(|i| i.to_string())
+                .unwrap_or_else(|| "None".to_string()),
+        }
+        .into());
+    }
+
     let changeset: TrainScheduleExceptionChangeset = train_schedule_exception_form.into();
 
     changeset
@@ -244,6 +290,7 @@ mod tests {
     use schemas::paced_train::TrainNameChangeGroup;
     use serde_json::json;
 
+    use crate::error::InternalError;
     use crate::models::fixtures::create_timetable_with_simple_paced_train;
     use crate::models::fixtures::create_train_schedule_exception;
     use crate::views::test_app::TestAppBuilder;
@@ -294,6 +341,40 @@ mod tests {
         );
         assert_eq!(response.train_schedule_id, train_schedule.id);
         assert_eq!(response.timetable_id, timetable.id);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn train_schedule_exception_invalid_occurrence_index_post() {
+        let app = TestAppBuilder::default_app();
+        let pool = app.db_pool();
+
+        let mut conn = pool.get_ok();
+
+        let (timetable, train_schedule) = create_timetable_with_simple_paced_train(&mut conn).await;
+
+        let train_schedule_exception_form: TrainScheduleExceptionForm =
+            TrainScheduleExceptionForm {
+                train_schedule_id: train_schedule.id,
+                occurrence_index: Some(100),
+                disabled: false,
+                change_groups: TrainScheduleExceptionChangeGroups::fixture_modified(),
+            };
+
+        // Insert train schedule exception
+        let request = app
+            .post(format!("/timetable/{}/train_schedule_exception", timetable.id).as_str())
+            .json(&json!(&train_schedule_exception_form));
+
+        let response: InternalError = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::BAD_REQUEST)
+            .json_into();
+
+        assert_eq!(
+            &response.error_type,
+            "editoast:train_schedule_exception:InvalidOccurrenceIndex"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -399,5 +480,54 @@ mod tests {
         );
         assert_eq!(updated_exception.train_schedule_id, train_schedule.id);
         assert_eq!(updated_exception.timetable_id, timetable.id);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn train_schedule_exception_invalid_occurrence_index_update() {
+        let app = TestAppBuilder::default_app();
+        let pool = app.db_pool();
+
+        let (timetable, train_schedule) =
+            create_timetable_with_simple_paced_train(&mut pool.get_ok()).await;
+
+        let train_schedule_exception = create_train_schedule_exception(
+            &mut pool.get_ok(),
+            timetable.id,
+            train_schedule.id,
+            Some(1),
+            None,
+            None,
+        )
+        .await;
+
+        let train_schedule_exeption_form_change_groups = TrainScheduleExceptionChangeGroups {
+            train_name: Some(TrainNameChangeGroup {
+                value: "Modified".to_string(),
+            }),
+            ..Default::default()
+        };
+
+        let train_schedule_exeption_form: TrainScheduleExceptionForm = TrainScheduleExceptionForm {
+            train_schedule_id: train_schedule.id,
+            occurrence_index: Some(-100),
+            disabled: false,
+            change_groups: train_schedule_exeption_form_change_groups.clone(),
+        };
+
+        // Update train schedule exception
+        let request = app
+            .put(format!("/train_schedule_exception/{}", train_schedule_exception.id).as_str())
+            .json(&json!(&train_schedule_exeption_form));
+
+        let response: InternalError = app
+            .fetch(request)
+            .await
+            .assert_status(StatusCode::BAD_REQUEST)
+            .json_into();
+
+        assert_eq!(
+            &response.error_type,
+            "editoast:train_schedule_exception:InvalidOccurrenceIndex"
+        )
     }
 }

--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -290,6 +290,7 @@
     "train_schedule_exception": {
       "BatchNotFound": "'{{count}}' train schedule exception(s) could not be found",
       "Database": "Internal error (database)",
+      "InvalidOccurrenceIndex": "Occurrence index '{{occurrence_index}}' is invalid for train schedule '{{train_schedule_id}}' with time window '{{time_window}}' and interval '{{interval}}'",
       "NotFound": "Train schedule exception '{{exception_id}}' could not be found",
       "NotPacedTrain": "Train schedule '{{train_schedule_id}}' is not a paced train",
       "TimetableNotFound": "Timetable '{{timetable_id}}' could not be found",

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -290,6 +290,7 @@
     "train_schedule_exception": {
       "BatchNotFound": "'{{count}}' exception(s) non trouvée(s)",
       "Database": "Erreur interne (base de données)",
+      "InvalidOccurrenceIndex": "L'index d'occurrence '{{occurrence_index}}' est invalide pour la circulation '{{train_schedule_id}}' avec une fenêtre temporelle de '{{time_window}}' et un intervalle de '{{interval}}'",
       "NotFound": "Exception '{{exception_id}}' non trouvée",
       "NotPacedTrain": "La circulation '{{train_schedule_id}}' n'est pas une mission",
       "TimetableNotFound": "Grille horaire '{{timetable_id}}' non trouvée",


### PR DESCRIPTION
Part of https://github.com/OpenRailAssociation/osrd/issues/15202

- [x] When exception is created or updated, check the occurrence index
- [x] Tests

> [!NOTE]
> This PR targets a feature branch and may contain all its commits, as it has not been rebased yet. Only the last commit need to be reviewed.