### PR TITLE
front: virtualize the new times stops table

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -29,6 +29,7 @@
         "@rjsf/validator-ajv8": "^6.4.2",
         "@sdziadkowiec/react-datasheet-grid": "^4.12.3",
         "@tanstack/react-table": "^8.21.3",
+        "@tanstack/react-virtual": "^3.13.23",
         "@turf/along": "^7.3.4",
         "@turf/bbox": "^7.3.4",
         "@turf/bbox-clip": "^7.3.4",
@@ -5921,10 +5922,12 @@
       }
     },
     "node_modules/@tanstack/react-virtual": {
-      "version": "3.13.12",
+      "version": "3.13.23",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.23.tgz",
+      "integrity": "sha512-XnMRnHQ23piOVj2bzJqHrRrLg4r+F86fuBcwteKfbIjJrtGxb4z7tIvPVAe4B+4UVwo9G4Giuz5fmapcrnZ0OQ==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/virtual-core": "3.13.12"
+        "@tanstack/virtual-core": "3.13.23"
       },
       "funding": {
         "type": "github",
@@ -5947,7 +5950,9 @@
       }
     },
     "node_modules/@tanstack/virtual-core": {
-      "version": "3.13.12",
+      "version": "3.13.23",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.23.tgz",
+      "integrity": "sha512-zSz2Z2HNyLjCplANTDyl3BcdQJc2k1+yyFoKhNRmCr7V7dY8o8q5m8uFTI1/Pg1kL+Hgrz6u3Xo6eFUB7l66cg==",
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/front/package.json
+++ b/front/package.json
@@ -29,6 +29,7 @@
     "@rjsf/validator-ajv8": "^6.4.2",
     "@sdziadkowiec/react-datasheet-grid": "^4.12.3",
     "@tanstack/react-table": "^8.21.3",
+    "@tanstack/react-virtual": "^3.13.23",
     "@turf/along": "^7.3.4",
     "@turf/bbox": "^7.3.4",
     "@turf/bbox-clip": "^7.3.4",

--- a/front/src/modules/timesStops/TimesStopsTable.tsx
+++ b/front/src/modules/timesStops/TimesStopsTable.tsx
@@ -1,4 +1,4 @@
-import { useCallback, Fragment, useMemo, useRef } from 'react';
+import React, { useCallback, Fragment, useMemo, useRef } from 'react';
 
 import { Checkbox } from '@osrd-project/ui-core';
 import { Moon } from '@osrd-project/ui-icons';
@@ -10,6 +10,7 @@ import {
   type Row,
   type RowData,
 } from '@tanstack/react-table';
+import { useVirtualizer } from '@tanstack/react-virtual';
 import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
 
@@ -115,6 +116,10 @@ type TimeCellTabEntry = {
   prev: string | null;
 };
 
+const HEADER_HEIGHT = 40;
+const ROW_HEIGHT = 40;
+const DAY_CHANGE_BANNER_HEIGHT = 40;
+
 const TimesStopsTable = ({
   rows,
   startTime,
@@ -214,10 +219,13 @@ const TimesStopsTable = ({
           return (
             <>
               {isPathStep && <span className="requested-point-dot" />}
-              <div title={`${name}${secondaryCode ? ` ${secondaryCode}` : ''}`}>
-                <span>{name}</span>
-                {secondaryCode && <span className="secondary-code"> {secondaryCode}</span>}
-              </div>
+              <span
+                className="op-full-name"
+                title={`${name}${secondaryCode ? ` ${secondaryCode}` : ''}`}
+              >
+                {name}
+              </span>
+              {secondaryCode && <span className="secondary-code">{secondaryCode}</span>}
             </>
           );
         },
@@ -233,7 +241,7 @@ const TimesStopsTable = ({
           return (
             <>
               {isPathStep && hasRequestedTrack && <span className="requested-point-dot" />}
-              <span>{info.getValue() ?? ''}</span>
+              <span title={info.getValue()}>{info.getValue() ?? ''}</span>
             </>
           );
         },
@@ -263,7 +271,7 @@ const TimesStopsTable = ({
           );
         },
         meta: {
-          className: 'col-requested-arrival',
+          className: 'col-requested-arrival col-with-clock-time',
           tabbable: true,
           title: t('arrivalTime'),
         },
@@ -278,7 +286,7 @@ const TimesStopsTable = ({
           return <span>{value ? formatLocalTime(value) : ''}</span>;
         },
         meta: {
-          className: 'col-computed-arrival computed',
+          className: 'col-computed-arrival col-with-clock-time computed',
           title: t('calculatedArrivalTime'),
         },
       }),
@@ -294,7 +302,7 @@ const TimesStopsTable = ({
           />
         ),
         meta: {
-          className: 'col-stop-duration',
+          className: 'col-stop-duration col-with-duration',
           tabbable: true,
           title: t('stopTime'),
         },
@@ -320,7 +328,7 @@ const TimesStopsTable = ({
           );
         },
         meta: {
-          className: 'col-requested-departure',
+          className: 'col-requested-departure col-with-clock-time',
           tabbable: true,
           title: t('departureTime'),
         },
@@ -340,7 +348,7 @@ const TimesStopsTable = ({
           );
         },
         meta: {
-          className: 'col-computed-departure computed',
+          className: 'col-computed-departure col-with-clock-time computed',
           title: t('calculatedDepartureTime'),
         },
       }),
@@ -371,7 +379,7 @@ const TimesStopsTable = ({
           );
         },
         meta: {
-          className: 'col-closed-signal',
+          className: 'col-closed-signal col-with-checkbox',
           title: t('receptionOnClosedSignalFull'),
         },
       }),
@@ -397,7 +405,7 @@ const TimesStopsTable = ({
           );
         },
         meta: {
-          className: 'col-short-slip-distance',
+          className: 'col-short-slip-distance col-with-checkbox',
           title: t('shortSlipDistance'),
         },
       }),
@@ -484,13 +492,13 @@ const TimesStopsTable = ({
       columnHelper.accessor('timeFromPreviousOp', {
         header: () => t('timeFromPreviousOp'),
         meta: {
-          className: 'col-time-from-previous-op computed',
+          className: 'col-time-from-previous-op col-with-duration computed',
         },
       }),
       columnHelper.accessor('totalTravelTime', {
         header: () => t('totalTravelTime'),
         meta: {
-          className: 'col-total-travel-time computed',
+          className: 'col-total-travel-time col-with-duration computed',
         },
       }),
     ],
@@ -556,6 +564,25 @@ const TimesStopsTable = ({
     return acc;
   }, []);
 
+  const virtualizedWrapperRef = React.useRef<HTMLDivElement>(null);
+
+  const headerHeight = 40;
+  const rowHeight = 40;
+
+  // TODO: Replace this (punching-hole) query selector by a proper refactoring
+  //       of our outer layout so we only rely on the scroll offset of the viewport,
+  //       which would also allow us to use `useWindowVirtualizer`!
+  const centerColumn = document.querySelector('.center-column');
+
+  const virtualizer = useVirtualizer({
+    count: rows.length,
+    overscan: 10,
+    estimateSize: () => ROW_HEIGHT,
+    getScrollElement: () => centerColumn,
+    scrollMargin: virtualizedWrapperRef.current?.offsetTop,
+    useFlushSync: false,
+  });
+
   if (rows.length === 0) {
     return (
       <div className="d-flex justify-content-center align-items-center h-100">
@@ -567,6 +594,8 @@ const TimesStopsTable = ({
   return (
     <div
       className={cx('times-stops-table-new', { 'computed-data-pending': isComputedDataPending })}
+      ref={virtualizedWrapperRef}
+      style={{ height: `${virtualizer.getTotalSize() + HEADER_HEIGHT}px` }}
     >
       <table className="table-container">
         <thead>
@@ -591,15 +620,26 @@ const TimesStopsTable = ({
             invalid: !isValid || scheduleNotHonored,
           })}
         >
-          {tableRows.map((row, rowIndex) => {
+          {virtualizer.getVirtualItems().map((virtualRow, index) => {
+            const rowIndex = virtualRow.index;
+            const row = tableRows[rowIndex];
+
             const rowArrivalDate = row.original.computedArrival ?? row.original.requestedArrival;
             const dayOffset = effectiveDayOffsets[rowIndex];
             const prevDayOffset = rowIndex > 0 ? effectiveDayOffsets[rowIndex - 1] : 0;
 
+            const translateY =
+              virtualRow.start - index * virtualRow.size - virtualizer.options.scrollMargin;
+
             return (
               <Fragment key={row.id}>
                 {dayOffset > prevDayOffset && (
-                  <tr className="day-change-banner">
+                  <tr
+                    className="day-change-banner"
+                    style={{
+                      transform: `translateY(${translateY}px)`,
+                    }}
+                  >
                     <td colSpan={row.getVisibleCells().length}>
                       <div className="day-change-banner-content">
                         <Moon />
@@ -617,7 +657,14 @@ const TimesStopsTable = ({
                 <tr
                   className={cx({
                     'invalid-path-step': row.original.stepStatus === 'invalidPathStep',
+                    'odd-row': rowIndex % 2 === 0,
+                    'even-row': rowIndex % 2,
+                    'first-row': rowIndex === 0,
+                    'last-row': rowIndex === tableRows.length - 1,
                   })}
+                  style={{
+                    transform: `translateY(${translateY}px)`,
+                  }}
                 >
                   {row.getVisibleCells().map((cell) => (
                     <td key={cell.id} className={cell.column.columnDef.meta?.className}>

--- a/front/src/modules/timesStops/TimesStopsTable.tsx
+++ b/front/src/modules/timesStops/TimesStopsTable.tsx
@@ -566,9 +566,6 @@ const TimesStopsTable = ({
 
   const virtualizedWrapperRef = React.useRef<HTMLDivElement>(null);
 
-  const headerHeight = 40;
-  const rowHeight = 40;
-
   // TODO: Replace this (punching-hole) query selector by a proper refactoring
   //       of our outer layout so we only rely on the scroll offset of the viewport,
   //       which would also allow us to use `useWindowVirtualizer`!
@@ -581,6 +578,8 @@ const TimesStopsTable = ({
     getScrollElement: () => centerColumn,
     scrollMargin: virtualizedWrapperRef.current?.offsetTop,
     useFlushSync: false,
+    measureElement: (element) =>
+      (element.classList.contains('day-change-banner') ? DAY_CHANGE_BANNER_HEIGHT : 0) + ROW_HEIGHT,
   });
 
   if (rows.length === 0) {
@@ -590,6 +589,8 @@ const TimesStopsTable = ({
       </div>
     );
   }
+
+  const virtualItems = virtualizer.getVirtualItems();
 
   return (
     <div
@@ -620,25 +621,27 @@ const TimesStopsTable = ({
             invalid: !isValid || scheduleNotHonored,
           })}
         >
-          {virtualizer.getVirtualItems().map((virtualRow, index) => {
+          {virtualItems.map((virtualRow) => {
             const rowIndex = virtualRow.index;
             const row = tableRows[rowIndex];
 
             const rowArrivalDate = row.original.computedArrival ?? row.original.requestedArrival;
             const dayOffset = effectiveDayOffsets[rowIndex];
             const prevDayOffset = rowIndex > 0 ? effectiveDayOffsets[rowIndex - 1] : 0;
+            const hasDayChanged = dayOffset > prevDayOffset;
 
-            const translateY =
-              virtualRow.start - index * virtualRow.size - virtualizer.options.scrollMargin;
+            const translateY = (virtualItems.at(0)?.start ?? 0) - virtualizer.options.scrollMargin;
 
             return (
               <Fragment key={row.id}>
-                {dayOffset > prevDayOffset && (
+                {hasDayChanged && (
                   <tr
                     className="day-change-banner"
                     style={{
                       transform: `translateY(${translateY}px)`,
                     }}
+                    data-index={rowIndex}
+                    ref={virtualizer.measureElement}
                   >
                     <td colSpan={row.getVisibleCells().length}>
                       <div className="day-change-banner-content">
@@ -665,6 +668,8 @@ const TimesStopsTable = ({
                   style={{
                     transform: `translateY(${translateY}px)`,
                   }}
+                  data-index={rowIndex}
+                  ref={!hasDayChanged ? virtualizer.measureElement : undefined}
                 >
                   {row.getVisibleCells().map((cell) => (
                     <td key={cell.id} className={cell.column.columnDef.meta?.className}>

--- a/front/src/modules/timesStops/styles/_timesStopsTable.scss
+++ b/front/src/modules/timesStops/styles/_timesStopsTable.scss
@@ -4,12 +4,25 @@
 }
 
 .times-stops-table-new {
+  container-name: times-stops-table;
+  container-type: inline-size;
+
   &.computed-data-pending {
     pointer-events: none;
   }
 
   .table-container {
-    position: relative;
+    // Because of the virtualization, we have to "opt-out" of the border collapsing:
+    // setting spacing to zero and only showing the right and bottom border on every cell
+    border-collapse: separate;
+    border-spacing: 0;
+
+    th,
+    td {
+      border: 1px solid var(--color-grey-30);
+      border-width: 0 1px 1px 0;
+    }
+
     thead {
       th {
         background: color-mix(in srgb, var(--black100) 5%, var(--ambientB5) 100%);
@@ -28,17 +41,19 @@
     tbody {
       tr {
         height: 40px;
+
         td {
           max-height: 40px;
           white-space: nowrap;
           overflow: hidden;
         }
 
-        &:nth-child(odd) {
+        // We can’t use :nth-child(odd) and :nth-child(even) as rows are virtualized
+        &.odd-row td {
           background: var(--ambientB10);
         }
 
-        &:nth-child(even) {
+        &.even-row td {
           background: var(--ambientB15);
         }
 
@@ -87,28 +102,108 @@
         overflow: hidden;
         text-overflow: ellipsis;
       }
-      &.invalid::after {
-        position: absolute;
-        top: 40px; // Hardcoding this is awful, but setting position: relative in tbody instead of table-container bugs borders in firefox
-        left: 0;
-        box-shadow: 0 0 0 8px var(--black10) inset;
-        content: '';
-        height: calc(100% - 40px);
-        width: 100%;
-        pointer-events: none;
-        z-index: 1;
+    }
+
+    th,
+    td {
+      --col-width: 70px;
+      --col-confortable-width: 90px;
+      --col-padding-inline: 4px;
+      --col-confortable-padding-inline: 12px;
+
+      --col-used-width: var(--col-width);
+      --col-used-padding-inline: var(--col-padding-inline);
+    }
+
+    thead th,
+    tbody td {
+      min-width: calc(var(--col-used-width));
+      width: calc(var(--col-used-width));
+      max-width: calc(var(--col-used-width));
+    }
+
+    tbody td {
+      padding-inline: var(--col-used-padding-inline);
+    }
+
+    // Confortable mode (responsive: large viewport)
+    @container (width > 1280px) {
+      th,
+      td {
+        --col-used-width: var(--col-confortable-width, var(--col-width));
+        --col-used-padding-inline: var(--col-confortable-padding-inline, var(--col-padding-inline));
       }
     }
+
+    .col-index {
+      --col-width: 28px;
+      --col-confortable-width: 36px;
+      --col-padding-inline: 4px;
+      --col-confortable-padding-inline: 8px;
+    }
+
+    .col-step-status {
+      --col-width: 8px;
+      --col-confortable-width: 16px;
+      --col-padding-inline: 0;
+      --col-confortable-padding-inline: 0;
+    }
+
+    .col-name {
+      --col-width: unset;
+      --col-confortable-width: unset;
+    }
+
+    .col-track {
+      --col-width: 55px;
+      --col-confortable-width: 80px;
+      --col-confortable-padding-inline: 4px;
+    }
+
+    .col-with-clock-time {
+      --col-width: 68px;
+      --col-confortable-width: 85px;
+    }
+
+    .col-with-duration {
+      --col-width: 88px;
+      --col-confortable-width: 103px;
+    }
+
+    .col-with-checkbox {
+      --col-width: 35px;
+      --col-confortable-width: 41px;
+      --col-padding-inline: 9px;
+    }
+
+    .col-power-restriction {
+      --col-width: 89px;
+      --col-confortable-width: 93px;
+    }
+
+    .col-requested-theoretical-margin {
+      --col-width: 73px;
+      --col-confortable-width: 88px;
+    }
+
+    .col-computed-theoretical-margin,
+    .col-real-margin {
+      --col-width: 63px;
+      --col-confortable-width: 79px;
+    }
+
+    .col-margins-difference {
+      --col-width: 72px;
+      --col-confortable-width: 88px;
+    }
+
     td.col-index {
-      width: 28px;
       font-size: 0.625rem;
       line-height: 16px;
       color: var(--grey50);
     }
 
     td.col-step-status {
-      padding-inline: 0px;
-      width: 8px;
       span {
         display: block;
         width: 100%;
@@ -133,7 +228,6 @@
       }
     }
 
-    td.col-name,
     td.col-track {
       position: relative;
 
@@ -141,137 +235,81 @@
         position: absolute;
         left: 3px;
         top: 4px;
-        width: 3px;
-        height: 3px;
-        border-radius: 1px;
-        background-color: var(--info60);
+      }
+    }
+
+    .requested-point-dot {
+      width: 3px;
+      height: 3px;
+      border-radius: 1px;
+      background-color: var(--info60);
+    }
+
+    th.col-name,
+    td.col-name {
+      width: 100%;
+      min-width: 225px;
+      max-width: 100%;
+
+      @container times-stops-table (width > 1280px) {
+        min-width: 260px;
       }
     }
 
     td.col-name {
-      text-align: left;
+      container-name: col-name;
+      container-type: inline-size;
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      grid-template-areas: 'full-name secondary-code';
+      align-items: center;
+      column-gap: 8px;
+      padding-inline: 8px;
 
-      div {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
+      .op-full-name {
+        grid-area: full-name;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        text-align: left;
+      }
+
+      .requested-point-dot {
+        grid-area: full-name;
+        place-self: start start;
+        margin: 4px 0 0 -4px;
       }
 
       .secondary-code {
+        grid-area: secondary-code;
         font-size: 0.875rem;
         color: var(--grey50);
-        padding-left: 8px;
+        width: 28px;
+        text-align: center;
       }
 
-      @media (min-width: 1240px) {
-        div {
-          justify-content: flex-end;
+      @container times-stops-table (width > 1280px) {
+        column-gap: 16px;
+        padding-left: 16px;
+
+        .requested-point-dot {
+          margin-left: -12px;
         }
-        .secondary-code {
-          padding-left: 16px;
+      }
+
+      @container col-name (width > 344px) {
+        .op-full-name {
+          text-align: right;
         }
       }
     }
 
     td.col-track {
-      width: 54px;
       font-size: 0.75rem;
     }
 
-    td.col-requested-arrival,
-    td.col-computed-arrival,
-    td.col-requested-departure,
-    td.col-computed-departure {
-      min-width: 68px;
-      max-width: 68px;
+    td.col-with-clock-time {
       font-size: 0.875rem;
-    }
-
-    td.col-stop-duration {
-      width: 87px;
-    }
-
-    th.col-closed-signal,
-    th.col-short-slip-distance {
-      max-width: 36px;
-    }
-
-    th.col-real-margin,
-    th.col-computed-theoretical-margin {
-      min-width: 62px;
-      max-width: 62px;
-      padding-inline: 4px;
-    }
-
-    th.col-margins-difference,
-    th.col-requested-theoretical-margin {
-      min-width: 72px;
-      max-width: 72px;
-      padding-inline: 4px;
-    }
-
-    /* comfortable padding */
-    @media (min-width: 784px) {
-      th[class^='col-'] {
-        padding-inline: 8px;
-      }
-
-      td.col-index {
-        padding-inline: 8px;
-        width: 36px;
-      }
-
-      td.col-step-status {
-        padding-inline: 0px;
-        width: 16px;
-      }
-
-      td.col-track {
-        width: 79px;
-        font-size: 0.875rem;
-      }
-
-      td.col-requested-arrival,
-      td.col-computed-arrival,
-      td.col-requested-departure,
-      td.col-computed-departure {
-        min-width: 84px;
-        max-width: 84px;
-      }
-
-      td.col-stop-duration {
-        width: 103px;
-      }
-
-      td.col-closed-signal,
-      td.col-short-slip-distance {
-        max-width: 44px;
-        padding-inline: 10px;
-      }
-
-      th.col-real-margin,
-      th.col-computed-theoretical-margin {
-        min-width: 78px;
-        max-width: 78px;
-        padding-inline: 12px;
-      }
-
-      td.col-margins-difference,
-      td.col-requested-theoretical-margin {
-        min-width: 88px;
-        max-width: 88px;
-        padding-inline: 12px;
-      }
-
-      td[class^='col-']:not(
-          .col-index,
-          .col-step-status,
-          .col-closed-signal,
-          .col-short-slip-distance,
-          .col-requested-theoretical-margin
-        ) {
-        padding-inline: 12px;
-      }
     }
 
     /* Computed / uncomputed cells */
@@ -314,15 +352,12 @@
     /* =========================
      * Removal of external borders
      * ========================= */
-    tr:first-child th {
+    tr.first-row td {
       border-top: none;
     }
 
-    tr:last-child {
-      th,
-      td {
-        border-bottom: none;
-      }
+    tr.last-row td {
+      border-bottom: none;
     }
 
     th:first-child,
@@ -333,6 +368,50 @@
     th:last-child,
     td:last-child {
       border-right: none;
+    }
+
+    /* Invalid rows */
+    tbody.invalid {
+      td {
+        --invalid-shadow-x: 0px;
+        --invalid-shadow-y: 0px;
+      }
+
+      tr.first-row td,
+      tr.last-row td,
+      tr td:first-child,
+      tr td:last-child {
+        &::after {
+          content: '';
+          position: absolute;
+          inset: 0;
+          pointer-events: none;
+          z-index: 3;
+          box-shadow: inset var(--invalid-shadow-x) var(--invalid-shadow-y) 0 0 var(--black10);
+        }
+      }
+
+      tr.first-row td {
+        --invalid-shadow-y: 8px;
+      }
+
+      tr.last-row td {
+        --invalid-shadow-y: -8px;
+      }
+
+      tr td:first-child {
+        --invalid-shadow-x: 8px;
+      }
+
+      tr td:last-child {
+        --invalid-shadow-x: -8px;
+      }
+
+      tr.day-change-banner td::after {
+        box-shadow:
+          inset 8px 0 0 0 var(--black10),
+          inset -8px 0 0 0 var(--black10);
+      }
     }
   }
 }

--- a/front/src/modules/timesStops/styles/_timesStopsTable.scss
+++ b/front/src/modules/timesStops/styles/_timesStopsTable.scss
@@ -63,7 +63,7 @@
         }
 
         &.day-change-banner {
-          height: 41px;
+          height: 40px;
 
           td {
             padding-inline-start: 50px;

--- a/front/src/modules/timesStops/styles/_timesStopsTable.scss
+++ b/front/src/modules/timesStops/styles/_timesStopsTable.scss
@@ -41,6 +41,7 @@
     tbody {
       tr {
         height: 40px;
+        opacity: 1;
 
         td {
           max-height: 40px;
@@ -414,6 +415,20 @@
       }
     }
   }
+
+  // Best-effort placeholder background while we wait for the virtualized rows to render
+  background-image: linear-gradient(
+    to bottom,
+    var(--ambientB10) 0,
+    var(--ambientB10) 39px,
+    var(--color-grey-30) 39px,
+    var(--ambientB15) 40px,
+    var(--ambientB15) 79px,
+    var(--color-grey-30) 80px
+  );
+  background-position: 0 40px;
+  background-size: 1px 80px;
+  background-repeat: repeat;
 }
 
 .cell-empty-dot {


### PR DESCRIPTION
Fixes #16127.

This uses `@tanstack/react-virtual` to virtualize the new TimesStopsTable, i.e. make sure we only render rows (and so, mount components) that are shown to the user.

Because this rely on using `transform` to position each rows, we have to opt-out from border collapsing; it also means that we can't use some tricks we used before, like having a pseudo-element to cover the whole table for the ".invalid" state.

The whole column sizing has to be redone: we can't rely anymore on the sizing of any row, as they are not rendered all the time… This commit uses CSS variables to make sure everything stays somewhat readable and maintenable.

I also took the time to follow Thibaut's instructions around responsiveness: using container query, we can actually react to the panel width, notwithstanding if the train list panel or the conflict panel is open.

A specific case is handled around the operational point name column, which is the only one that should resize when there is space left (it wasn't done properly before); I use some grids and some container queries to make sure we follow Thibaut's intentions described in mockups.