### PR TITLE
editoast: fix train_schedule_train_schedule_set_id_id_idx index creation

### DIFF
--- a/editoast/migrations/2026-04-09-154515-0000_fix_train_schedule_ts_set_index/down.sql
+++ b/editoast/migrations/2026-04-09-154515-0000_fix_train_schedule_ts_set_index/down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS train_schedule_train_schedule_set_id_id_idx;
+CREATE INDEX train_schedule_train_schedule_set_id_id_idx on train_schedule (train_schedule_set_id, id);

--- a/editoast/migrations/2026-04-09-154515-0000_fix_train_schedule_ts_set_index/up.sql
+++ b/editoast/migrations/2026-04-09-154515-0000_fix_train_schedule_ts_set_index/up.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS train_schedule_train_schedule_set_id_id_idx;
+CREATE INDEX train_schedule_train_schedule_set_id_id_idx on train_schedule (id, train_schedule_set_id);


### PR DESCRIPTION
Reversing the order seems to help the pg planner.