### PR TITLE
front: show error message on train name if empty

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModalFormHeader.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModalFormHeader.tsx
@@ -96,7 +96,7 @@ const ItineraryModalFormHeader = ({
   const [isNameBlurred, setIsNameBlurred] = useState(false);
 
   const nameError: StatusWithMessage | undefined = useMemo(() => {
-    const shouldShowError = (isNameBlurred || (submitAttempted && isNameBlurred)) && isNameEmpty;
+    const shouldShowError = (isNameBlurred || submitAttempted) && isNameEmpty;
     if (!shouldShowError) return undefined;
 
     return {


### PR DESCRIPTION
closes #16155 

Before, if the input was never focused and that we tried submitting the itinerary, no error message was displayed. 
We now display it if the input is empty and that we click on "Submit itinerary", as well as if the user focuses on it once and unfocuses without typing anything. 