### PR TITLE
front: stdcm: adding initializing computation message

### DIFF
--- a/front/public/locales/en/stdcm.json
+++ b/front/public/locales/en/stdcm.json
@@ -128,6 +128,7 @@
   },
   "simulation": {
     "additionalResults": "No results were found for your request; alternative options are being computed.",
+    "calculatingInitialization": "Setting up calculation…",
     "calculatingSimulation": "Calculation in progress…",
     "getSimulation": "Get the simulation",
     "infoMessage": "This simulation doesn't ensure the availability of the path.",

--- a/front/public/locales/fr/stdcm.json
+++ b/front/public/locales/fr/stdcm.json
@@ -128,6 +128,7 @@
   },
   "simulation": {
     "additionalResults": "Pas de résultat pour votre demande, d’autres possibilités sont en cours de calcul.",
+    "calculatingInitialization": "Préparation du calcul…",
     "calculatingSimulation": "Calcul en cours…",
     "getSimulation": "Obtenir la simulation",
     "infoMessage": "Cette simulation n'offre pas la garantie de disponibilité du sillon.",

--- a/front/src/applications/stdcm/StdcmView.tsx
+++ b/front/src/applications/stdcm/StdcmView.tsx
@@ -65,6 +65,7 @@ const StdcmViewContent = ({
     cancelStdcmRequest,
     resetStdcmState,
     isPending,
+    isInProgress,
     isPendingAdditional,
     isRejected,
     isCanceled,
@@ -185,6 +186,7 @@ const StdcmViewContent = ({
       <StdcmConfig
         isPending={isPending}
         isPendingAdditional={isPendingAdditional}
+        isInProgress={isInProgress}
         isDebugMode={isDebugMode}
         showBtnToLaunchSimulation={showBtnToLaunchSimulation}
         retainedSimulationIndex={retainedSimulationIndex}

--- a/front/src/applications/stdcm/StdcmView.tsx
+++ b/front/src/applications/stdcm/StdcmView.tsx
@@ -30,6 +30,7 @@ import StdcmHeader from './components/StdcmHeader';
 import StdcmHelpModule from './components/StdcmHelpModule';
 import StdcmResults from './components/StdcmResults';
 import StdcmStatusBanner from './components/StdcmStatusBanner';
+import { STDCM_REQUEST_STATUS } from './consts';
 import useStdcm from './hooks/useStdcm';
 import useStdcmEnvironment, { NO_CONFIG_FOUND_MSG } from './hooks/useStdcmEnv';
 import useStdcmForm from './hooks/useStdcmForm';
@@ -60,18 +61,8 @@ const StdcmViewContent = ({
   const resultSectionRef = useRef<HTMLDivElement | null>(null);
   const previousResultSectionOffsetRef = useRef<number | null>(null);
 
-  const {
-    launchStdcmRequest,
-    cancelStdcmRequest,
-    resetStdcmState,
-    isPending,
-    isInProgress,
-    isPendingAdditional,
-    isRejected,
-    isCanceled,
-    isCalculationCompleted,
-    progressPoints,
-  } = useStdcm({ showFailureNotification: false });
+  const { launchStdcmRequest, cancelStdcmRequest, resetStdcmState, requestStatus, progressPoints } =
+    useStdcm({ showFailureNotification: false });
 
   const dispatch = useAppDispatch();
 
@@ -124,30 +115,29 @@ const StdcmViewContent = ({
   }, [currentSimulationInputs, selectedSimulationIndex]);
 
   useEffect(() => {
-    if (isPending || isPendingAdditional) {
-      setShowBtnToLaunchSimulation(false);
+    switch (requestStatus) {
+      case STDCM_REQUEST_STATUS.in_progress:
+      case STDCM_REQUEST_STATUS.pending:
+      case STDCM_REQUEST_STATUS.pending_additional: {
+        setShowBtnToLaunchSimulation(false);
+        break;
+      }
+      case STDCM_REQUEST_STATUS.success: {
+        setShowStatusBanner(true);
+        setDisplayInfoMessage(false);
+        break;
+      }
+      case STDCM_REQUEST_STATUS.canceled: {
+        setShowBtnToLaunchSimulation(true);
+        setDisplayInfoMessage(true);
+        break;
+      }
+      case STDCM_REQUEST_STATUS.rejected: {
+        if (!isReloading) setShowStatusBanner(true);
+        break;
+      }
     }
-  }, [isPending, isPendingAdditional]);
-
-  useEffect(() => {
-    if (isCanceled) {
-      setShowBtnToLaunchSimulation(true);
-      setDisplayInfoMessage(true);
-    }
-  }, [isCanceled]);
-
-  useEffect(() => {
-    if (isCalculationCompleted) {
-      setShowStatusBanner(true);
-      setDisplayInfoMessage(false);
-    }
-  }, [isCalculationCompleted]);
-
-  useEffect(() => {
-    if (isRejected && !isReloading) {
-      setShowStatusBanner(true);
-    }
-  }, [isRejected, isReloading]);
+  }, [requestStatus, isReloading]);
 
   useEffect(() => {
     const handleBeforeUnload = () => {
@@ -184,9 +174,7 @@ const StdcmViewContent = ({
   return (
     <div>
       <StdcmConfig
-        isPending={isPending}
-        isPendingAdditional={isPendingAdditional}
-        isInProgress={isInProgress}
+        requestStatus={requestStatus}
         isDebugMode={isDebugMode}
         showBtnToLaunchSimulation={showBtnToLaunchSimulation}
         retainedSimulationIndex={retainedSimulationIndex}
@@ -197,12 +185,14 @@ const StdcmViewContent = ({
         progressPoints={progressPoints}
       />
 
-      {showStatusBanner && <StdcmStatusBanner isFailed={isRejected} />}
+      {showStatusBanner && (
+        <StdcmStatusBanner isFailed={requestStatus === STDCM_REQUEST_STATUS.rejected} />
+      )}
 
       {completedSimulations.length > 0 && (
         <div ref={resultSectionRef} className="stdcm-results">
           <StdcmResults
-            isCalculationFailed={isRejected}
+            isCalculationFailed={requestStatus === STDCM_REQUEST_STATUS.rejected}
             isDebugMode={isDebugMode}
             onSelectSimulation={handleSelectSimulation}
             displayInfoMessage={displayInfoMessage}

--- a/front/src/applications/stdcm/components/StdcmForm/StdcmConfig.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmConfig.tsx
@@ -84,6 +84,7 @@ type StdcmConfigProps = {
   isDebugMode: boolean;
   isPending: boolean;
   isPendingAdditional: boolean;
+  isInProgress: boolean;
   retainedSimulationIndex?: number;
   showBtnToLaunchSimulation: boolean;
   skipPathfindingStatusMessage: boolean;
@@ -97,6 +98,7 @@ const StdcmConfig = ({
   isDebugMode,
   isPending,
   isPendingAdditional,
+  isInProgress,
   retainedSimulationIndex,
   showBtnToLaunchSimulation,
   skipPathfindingStatusMessage,
@@ -427,6 +429,7 @@ const StdcmConfig = ({
           {(isPending || isPendingAdditional) && (
             <StdcmLoader
               isPendingAdditional={isPendingAdditional}
+              isInProgress={isInProgress}
               cancelStdcmRequest={cancelStdcmRequest}
               launchButtonRef={launchButtonRef}
               formRef={formRef}

--- a/front/src/applications/stdcm/components/StdcmForm/StdcmConfig.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmConfig.tsx
@@ -14,6 +14,7 @@ import { isEqual } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
+import { STDCM_REQUEST_STATUS } from 'applications/stdcm/consts';
 import { extractMarkersInfo } from 'applications/stdcm/utils';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import DefaultBaseMap from 'common/Map/DefaultBaseMap';
@@ -60,6 +61,7 @@ import type {
   StdcmConfigErrors,
   ConsistErrors,
   StdcmProgressPoints,
+  StdcmRequestStatus,
 } from '../../types';
 import StdcmMapProgressLayer from '../StdcmMapProgressLayer';
 import StdcmSimulationParams from '../StdcmSimulationParams';
@@ -82,9 +84,7 @@ declare global {
  */
 type StdcmConfigProps = {
   isDebugMode: boolean;
-  isPending: boolean;
-  isPendingAdditional: boolean;
-  isInProgress: boolean;
+  requestStatus: StdcmRequestStatus;
   retainedSimulationIndex?: number;
   showBtnToLaunchSimulation: boolean;
   skipPathfindingStatusMessage: boolean;
@@ -96,9 +96,7 @@ type StdcmConfigProps = {
 
 const StdcmConfig = ({
   isDebugMode,
-  isPending,
-  isPendingAdditional,
-  isInProgress,
+  requestStatus,
   retainedSimulationIndex,
   showBtnToLaunchSimulation,
   skipPathfindingStatusMessage,
@@ -202,7 +200,10 @@ const StdcmConfig = ({
     [initialConsistErrors, viaConsistErrors]
   );
 
-  const disabled = isPending || retainedSimulationIndex !== undefined;
+  const disabled =
+    requestStatus === STDCM_REQUEST_STATUS.in_progress ||
+    requestStatus === STDCM_REQUEST_STATUS.pending ||
+    retainedSimulationIndex !== undefined;
 
   const markersInfo = useMemo(() => extractMarkersInfo(pathSteps), [pathSteps]);
 
@@ -335,6 +336,14 @@ const StdcmConfig = ({
     }
   }, [t, formErrors, consistErrors, rollingStockID, stdcmConf]);
 
+  const isLoading = useMemo(
+    () =>
+      requestStatus === STDCM_REQUEST_STATUS.in_progress ||
+      requestStatus === STDCM_REQUEST_STATUS.pending ||
+      requestStatus === STDCM_REQUEST_STATUS.pending_additional,
+    [requestStatus]
+  );
+
   return (
     <div className="stdcm__body">
       {isDebugMode && (
@@ -426,10 +435,9 @@ const StdcmConfig = ({
               </div>
             </div>
           )}
-          {(isPending || isPendingAdditional) && (
+          {isLoading && (
             <StdcmLoader
-              isPendingAdditional={isPendingAdditional}
-              isInProgress={isInProgress}
+              requestStatus={requestStatus}
               cancelStdcmRequest={cancelStdcmRequest}
               launchButtonRef={launchButtonRef}
               formRef={formRef}
@@ -452,9 +460,7 @@ const StdcmConfig = ({
             updateMapSettings={updateMapSettings}
             updateViewport={updateViewport}
           >
-            {(isPending || isPendingAdditional) && (
-              <StdcmMapProgressLayer progressPoints={progressPoints} />
-            )}
+            {isLoading && <StdcmMapProgressLayer progressPoints={progressPoints} />}
           </DefaultBaseMap>
         </div>
       </div>

--- a/front/src/applications/stdcm/components/StdcmLoader.tsx
+++ b/front/src/applications/stdcm/components/StdcmLoader.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type RefObject } from 'react';
+import { useEffect, useMemo, useRef, useState, type RefObject } from 'react';
 
 import { Button } from '@osrd-project/ui-core';
 import cx from 'classnames';
@@ -11,6 +11,7 @@ const LOADER_OFFSET = 32;
 
 type StdcmLoaderProps = {
   isPendingAdditional: boolean;
+  isInProgress: boolean;
   cancelStdcmRequest: () => void;
   launchButtonRef: RefObject<HTMLDivElement | null>;
   formRef: RefObject<HTMLDivElement | null>;
@@ -20,6 +21,7 @@ const StdcmLoader = ({
   cancelStdcmRequest,
   launchButtonRef,
   formRef,
+  isInProgress,
   isPendingAdditional,
 }: StdcmLoaderProps) => {
   const { t } = useTranslation('stdcm');
@@ -81,6 +83,12 @@ const StdcmLoader = ({
     };
   }, []);
 
+  const loadingStatusLabelKey = useMemo(() => {
+    if (isPendingAdditional) return 'simulation.additionalResults';
+    if (isInProgress) return 'simulation.calculatingSimulation';
+    return 'simulation.calculatingInitialization';
+  }, [isInProgress, isPendingAdditional]);
+
   return (
     <div
       ref={loaderRef}
@@ -92,13 +100,7 @@ const StdcmLoader = ({
       })}
     >
       <div className="stdcm-loader__wrapper">
-        <h2>
-          {t(
-            isPendingAdditional
-              ? 'simulation.additionalResults'
-              : 'simulation.calculatingSimulation'
-          )}
-        </h2>
+        <h2>{t(loadingStatusLabelKey)}</h2>
         <div className="stdcm-loader__cancel-btn">
           <Button
             data-testid="cancel-simulation-button"

--- a/front/src/applications/stdcm/components/StdcmLoader.tsx
+++ b/front/src/applications/stdcm/components/StdcmLoader.tsx
@@ -4,14 +4,14 @@ import { Button } from '@osrd-project/ui-core';
 import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
 
-import type { LoaderStatus } from '../types';
+import { STDCM_REQUEST_STATUS } from '../consts';
+import type { LoaderStatus, StdcmRequestStatus } from '../types';
 
 const LOADER_HEIGHT = 176;
 const LOADER_OFFSET = 32;
 
 type StdcmLoaderProps = {
-  isPendingAdditional: boolean;
-  isInProgress: boolean;
+  requestStatus: StdcmRequestStatus;
   cancelStdcmRequest: () => void;
   launchButtonRef: RefObject<HTMLDivElement | null>;
   formRef: RefObject<HTMLDivElement | null>;
@@ -21,8 +21,7 @@ const StdcmLoader = ({
   cancelStdcmRequest,
   launchButtonRef,
   formRef,
-  isInProgress,
-  isPendingAdditional,
+  requestStatus,
 }: StdcmLoaderProps) => {
   const { t } = useTranslation('stdcm');
   const loaderRef = useRef<HTMLDivElement>(null);
@@ -84,10 +83,12 @@ const StdcmLoader = ({
   }, []);
 
   const loadingStatusLabelKey = useMemo(() => {
-    if (isPendingAdditional) return 'simulation.additionalResults';
-    if (isInProgress) return 'simulation.calculatingSimulation';
+    if (requestStatus === STDCM_REQUEST_STATUS.in_progress)
+      return 'simulation.calculatingSimulation';
+    if (requestStatus === STDCM_REQUEST_STATUS.pending_additional)
+      return 'simulation.additionalResults';
     return 'simulation.calculatingInitialization';
-  }, [isInProgress, isPendingAdditional]);
+  }, [requestStatus]);
 
   return (
     <div

--- a/front/src/applications/stdcm/consts.ts
+++ b/front/src/applications/stdcm/consts.ts
@@ -5,6 +5,7 @@ import type { ConsistErrors } from './types';
 export const STDCM_REQUEST_STATUS = Object.freeze({
   idle: 'IDLE',
   pending: 'PENDING',
+  in_progress: 'IN_PROGRESS',
   success: 'SUCCESS',
   rejected: 'REJECTED',
   canceled: 'CANCELED',

--- a/front/src/applications/stdcm/hooks/useStdcm.ts
+++ b/front/src/applications/stdcm/hooks/useStdcm.ts
@@ -103,7 +103,10 @@ const useStdcm = ({
         id: STDCM_TRAIN_ID,
         comfort: payload.body.comfort,
         constraint_distribution: 'MARECO',
-        path: payload.body.steps.map((step) => ({ location: step.location, id: uuidV4() })),
+        path: payload.body.steps.map((step) => ({
+          location: step.location,
+          id: uuidV4(),
+        })),
         rolling_stock_name: stdcmRollingStock!.name,
         start_time: formattedResponse.departure_time,
         train_name: 'stdcm',
@@ -297,26 +300,12 @@ const useStdcm = ({
     setCurrentStdcmRequestStatus(STDCM_REQUEST_STATUS.canceled);
   };
 
-  const isPending =
-    currentStdcmRequestStatus === STDCM_REQUEST_STATUS.pending ||
-    currentStdcmRequestStatus === STDCM_REQUEST_STATUS.in_progress;
-  const isInProgress = currentStdcmRequestStatus === STDCM_REQUEST_STATUS.in_progress;
-  const isPendingAdditional = currentStdcmRequestStatus === STDCM_REQUEST_STATUS.pending_additional;
-  const isRejected = currentStdcmRequestStatus === STDCM_REQUEST_STATUS.rejected;
-  const isCanceled = currentStdcmRequestStatus === STDCM_REQUEST_STATUS.canceled;
-  const isCalculationCompleted = currentStdcmRequestStatus === STDCM_REQUEST_STATUS.success;
-
   return {
     launchStdcmRequest,
     cancelStdcmRequest,
     resetStdcmState,
-    isPending,
-    isInProgress,
-    isRejected,
-    isCanceled,
-    isPendingAdditional,
-    isCalculationCompleted,
     progressPoints,
+    requestStatus: currentStdcmRequestStatus,
   };
 };
 

--- a/front/src/applications/stdcm/hooks/useStdcm.ts
+++ b/front/src/applications/stdcm/hooks/useStdcm.ts
@@ -240,6 +240,7 @@ const useStdcm = ({
             break;
           }
           case 'ongoing': {
+            setCurrentStdcmRequestStatus(STDCM_REQUEST_STATUS.in_progress);
             const now = Date.now();
             if (now > lastPointReceivedAt.timestamp) {
               lastPointReceivedAt = { timestamp: Date.now(), nb: 0 };
@@ -296,7 +297,10 @@ const useStdcm = ({
     setCurrentStdcmRequestStatus(STDCM_REQUEST_STATUS.canceled);
   };
 
-  const isPending = currentStdcmRequestStatus === STDCM_REQUEST_STATUS.pending;
+  const isPending =
+    currentStdcmRequestStatus === STDCM_REQUEST_STATUS.pending ||
+    currentStdcmRequestStatus === STDCM_REQUEST_STATUS.in_progress;
+  const isInProgress = currentStdcmRequestStatus === STDCM_REQUEST_STATUS.in_progress;
   const isPendingAdditional = currentStdcmRequestStatus === STDCM_REQUEST_STATUS.pending_additional;
   const isRejected = currentStdcmRequestStatus === STDCM_REQUEST_STATUS.rejected;
   const isCanceled = currentStdcmRequestStatus === STDCM_REQUEST_STATUS.canceled;
@@ -307,6 +311,7 @@ const useStdcm = ({
     cancelStdcmRequest,
     resetStdcmState,
     isPending,
+    isInProgress,
     isRejected,
     isCanceled,
     isPendingAdditional,


### PR DESCRIPTION
Before this change, users could see points appear on the map only after a delay, which could feel confusing or inconsistent from their perspective.

This was due to the algorithm initialization phase (process startup, data loading, etc.). To make the experience clearer, this commit updates the label of the pending state during algorithm initialization and while the frontend begins receiving points.

This PR follows a discussion with @eckter @MartinBourbier