### PR TITLE
editoast: disable incremental compilation in the docker image

### DIFF
--- a/editoast/Dockerfile
+++ b/editoast/Dockerfile
@@ -20,6 +20,7 @@ RUN cargo chef prepare --recipe-path recipe.json
 FROM chef AS base_builder
 RUN apk add --no-cache build-base curl openssl openssl-dev openssl-libs-static mold libpq-dev geos-dev
 ENV RUSTFLAGS="-C target-feature=-crt-static -C link-arg=-fuse-ld=mold"
+ENV CARGO_INCREMENTAL=0
 RUN set -eux; \
     arch="$(uname -m)"; \
     mkdir -p /cargo_editoast/bin; \


### PR DESCRIPTION
I don't know if it'll change much, this is a test.

See:
https://matklad.github.io/2021/09/04/fast-rust-builds.html#CI-Workflow https://doc.rust-lang.org/cargo/reference/profiles.html#incremental

basically this decreases the amount of I/O during builds

rust-analyzer also disabled it:
https://github.com/rust-lang/rust-analyzer/blob/64ddb549bc9a70d011328746fa46a8883f937b6b/.github/workflows/ci.yaml#L14