### PR TITLE
editoast: fix scenario search

### DIFF
--- a/editoast/src/views/search.rs
+++ b/editoast/src/views/search.rs
@@ -721,11 +721,11 @@ pub(super) struct SearchResultItemScenario {
     #[search(sql = "infra.name")]
     infra_name: String,
     #[search(
-        sql = "(SELECT COUNT(trains.id) FROM train_schedule AS trains WHERE scenario.timetable_id = trains.timetable_id)"
+        sql = "(SELECT COUNT(trains.id) FROM train_schedule AS trains INNER JOIN timetable_train_schedule_set AS ttss ON trains.train_schedule_set_id = ttss.train_schedule_set_id WHERE ttss.timetable_id = scenario.timetable_id)"
     )]
     paced_trains_count: u64,
     #[search(
-        sql = "(SELECT COUNT(trains.id) FROM train_schedule AS trains WHERE scenario.timetable_id = trains.timetable_id)"
+        sql = "(SELECT COUNT(trains.id) FROM train_schedule AS trains INNER JOIN timetable_train_schedule_set AS ttss ON trains.train_schedule_set_id = ttss.train_schedule_set_id WHERE ttss.timetable_id = scenario.timetable_id)"
     )]
     trains_count: u64,
     #[search(sql = "scenario.description")]


### PR DESCRIPTION
The trains count were still referencing `train_schedule.timetable_id` which was removed in favor of `train_schedule_set`causing a 500.
This PR updates the `paced_trains_count` and the `trains_count` fields in `SearchResultItemScenario` to use an `INNER JOIN` with `timetable_train_schedule_set` instead.