### PR TITLE
front: select edited train on update

### DIFF
--- a/front/src/applications/operationalStudies/hooks/useAutoSelectTrainIds.ts
+++ b/front/src/applications/operationalStudies/hooks/useAutoSelectTrainIds.ts
@@ -5,6 +5,7 @@ import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
 import { isValidPathfinding } from 'applications/operationalStudies/views/Scenario/components/Timetable/utils';
 import type { TimetableItemWithDetails } from 'modules/timetableItem/types';
+import type { TrainId } from 'reducers/osrdconf/types';
 import { updateSelectedTrainId, updateTrainIdUsedForProjection } from 'reducers/simulationResults';
 import {
   getSelectedTrainId,
@@ -25,6 +26,21 @@ type SimulationParams = {
   scenarioId: string;
 };
 
+const isTrainIdInTimetable = (
+  trainId: TrainId | undefined,
+  timetableItemsWithDetails: TimetableItemWithDetails[]
+): boolean => {
+  if (!trainId) return false;
+
+  const pacedTrainId = isOccurrenceId(trainId)
+    ? extractPacedTrainIdFromOccurrenceId(trainId)
+    : trainId;
+  const timetableItemId = extractEditoastIdFromPacedTrainId(pacedTrainId);
+
+  const timetableItem = timetableItemsWithDetails.find((item) => item.id === timetableItemId);
+  return !!timetableItem;
+};
+
 /**
  * Automatically select the train to be used for the simulation results display and for the projection.
  *
@@ -35,8 +51,7 @@ type SimulationParams = {
  * currentTrainIdForProjection will still be undefined and must be updated)
  */
 const useAutoSelectTrainIds = (
-  timetableItemIds: number[] | undefined,
-  timetableItemsWithDetails: TimetableItemWithDetails[]
+  timetableItemsWithDetails: TimetableItemWithDetails[] | undefined
 ) => {
   const dispatch = useAppDispatch();
   const currentTrainIdForProjection = useSelector(getTrainIdUsedForProjection);
@@ -111,11 +126,11 @@ const useAutoSelectTrainIds = (
   }, [parametersLoaded, selectedTrainId, currentTrainIdForProjection, setParamsInUrlAndStorage]);
 
   useEffect(() => {
-    if (timetableItemIds === undefined) {
+    if (timetableItemsWithDetails === undefined) {
       return;
     }
 
-    if (timetableItemIds.length === 0) {
+    if (timetableItemsWithDetails.length === 0) {
       if (selectedTrainId) dispatch(updateSelectedTrainId(undefined));
       if (currentTrainIdForProjection) dispatch(updateTrainIdUsedForProjection(undefined));
       setParametersLoaded(true);
@@ -128,23 +143,13 @@ const useAutoSelectTrainIds = (
       return;
     }
 
-    let timetableItemId: number | undefined;
-    if (selectedTrainId) {
-      timetableItemId = extractEditoastIdFromPacedTrainId(
-        !isOccurrenceId(selectedTrainId)
-          ? selectedTrainId
-          : extractPacedTrainIdFromOccurrenceId(selectedTrainId)
-      );
-    }
-
-    const isSelectedTimetableItemIncluded =
-      !!timetableItemId && timetableItemIds.some((id) => id === timetableItemId);
+    const isSelectedTrainIdValid = isTrainIdInTimetable(selectedTrainId, timetableItemsWithDetails);
 
     // if a selected timetable item is given and is still in the timetable, don't change the selected train
-    if (timetableItemId && isSelectedTimetableItemIncluded) {
+    if (isSelectedTrainIdValid) {
       // if no train is used for the projection, use the selected train
       if (!currentTrainIdForProjection) {
-        dispatch(updateTrainIdUsedForProjection(formatEditoastIdToPacedTrainId(timetableItemId)));
+        dispatch(updateTrainIdUsedForProjection(selectedTrainId));
       }
       return;
     }
@@ -161,7 +166,7 @@ const useAutoSelectTrainIds = (
       dispatch(updateTrainIdUsedForProjection(pacedTrainId));
       dispatch(updateSelectedTrainId(pacedTrainId));
     }
-  }, [timetableItemIds, timetableItemsWithDetails, setIdsFromUrlOrStorage, parametersLoaded]);
+  }, [timetableItemsWithDetails, setIdsFromUrlOrStorage, parametersLoaded]);
 };
 
 export default useAutoSelectTrainIds;

--- a/front/src/applications/operationalStudies/hooks/useAutoSelectTrainIds.ts
+++ b/front/src/applications/operationalStudies/hooks/useAutoSelectTrainIds.ts
@@ -127,11 +127,15 @@ const useAutoSelectTrainIds = (
     }
 
     const isSelectedTrainIdValid = isTrainIdInTimetable(selectedTrainId, timetableItemsWithDetails);
+    const isProjectedTrainIdValid = isTrainIdInTimetable(
+      currentTrainIdForProjection,
+      timetableItemsWithDetails
+    );
 
     // if a selected timetable item is given and is still in the timetable, don't change the selected train
     if (isSelectedTrainIdValid) {
-      // if no train is used for the projection, use the selected train
-      if (!currentTrainIdForProjection) {
+      // if no train is used for the projection or the id is invalid, use the selected train
+      if (!isProjectedTrainIdValid) {
         dispatch(updateTrainIdUsedForProjection(selectedTrainId));
       }
       return;
@@ -146,8 +150,8 @@ const useAutoSelectTrainIds = (
 
     if (firstTrainCanBeUsedForProjection) {
       const pacedTrainId = formatEditoastIdToPacedTrainId(firstTrainCanBeUsedForProjection.id);
-      dispatch(updateTrainIdUsedForProjection(pacedTrainId));
       dispatch(updateSelectedTrainId(pacedTrainId));
+      if (!isProjectedTrainIdValid) dispatch(updateTrainIdUsedForProjection(pacedTrainId));
     }
   }, [timetableItemsWithDetails, setIdsFromUrlOrStorage, parametersLoaded]);
 };

--- a/front/src/applications/operationalStudies/hooks/useAutoSelectTrainIds.ts
+++ b/front/src/applications/operationalStudies/hooks/useAutoSelectTrainIds.ts
@@ -5,7 +5,6 @@ import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
 import { isValidPathfinding } from 'applications/operationalStudies/views/Scenario/components/Timetable/utils';
 import type { TimetableItemWithDetails } from 'modules/timetableItem/types';
-import type { TrainId } from 'reducers/osrdconf/types';
 import { updateSelectedTrainId, updateTrainIdUsedForProjection } from 'reducers/simulationResults';
 import {
   getSelectedTrainId,
@@ -13,32 +12,16 @@ import {
 } from 'reducers/simulationResults/selectors';
 import { useAppDispatch } from 'store';
 import {
-  extractEditoastIdFromPacedTrainId,
-  extractPacedTrainIdFromOccurrenceId,
   formatEditoastIdToPacedTrainId,
   isOccurrenceId,
   isPacedTrainId,
+  isTrainIdInTimetable,
 } from 'utils/trainId';
 
 type SimulationParams = {
   projectId: string;
   studyId: string;
   scenarioId: string;
-};
-
-const isTrainIdInTimetable = (
-  trainId: TrainId | undefined,
-  timetableItemsWithDetails: TimetableItemWithDetails[]
-): boolean => {
-  if (!trainId) return false;
-
-  const pacedTrainId = isOccurrenceId(trainId)
-    ? extractPacedTrainIdFromOccurrenceId(trainId)
-    : trainId;
-  const timetableItemId = extractEditoastIdFromPacedTrainId(pacedTrainId);
-
-  const timetableItem = timetableItemsWithDetails.find((item) => item.id === timetableItemId);
-  return !!timetableItem;
 };
 
 /**

--- a/front/src/applications/operationalStudies/hooks/useAutoSelectTrainIds.ts
+++ b/front/src/applications/operationalStudies/hooks/useAutoSelectTrainIds.ts
@@ -5,7 +5,6 @@ import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
 import { isValidPathfinding } from 'applications/operationalStudies/views/Scenario/components/Timetable/utils';
 import type { TimetableItemWithDetails } from 'modules/timetableItem/types';
-import type { TrainId } from 'reducers/osrdconf/types';
 import { updateSelectedTrainId, updateTrainIdUsedForProjection } from 'reducers/simulationResults';
 import {
   getSelectedTrainId,
@@ -16,7 +15,6 @@ import {
   extractEditoastIdFromPacedTrainId,
   extractPacedTrainIdFromOccurrenceId,
   formatEditoastIdToPacedTrainId,
-  formatPacedTrainIdToIndexedOccurrenceId,
   isOccurrenceId,
   isPacedTrainId,
 } from 'utils/trainId';
@@ -161,13 +159,7 @@ const useAutoSelectTrainIds = (
     if (firstTrainCanBeUsedForProjection) {
       const pacedTrainId = formatEditoastIdToPacedTrainId(firstTrainCanBeUsedForProjection.id);
       dispatch(updateTrainIdUsedForProjection(pacedTrainId));
-      let newTrainIdToSelect: TrainId;
-      if (!firstTrainCanBeUsedForProjection.paced) {
-        newTrainIdToSelect = pacedTrainId;
-      } else {
-        newTrainIdToSelect = formatPacedTrainIdToIndexedOccurrenceId(pacedTrainId, 0);
-      }
-      dispatch(updateSelectedTrainId(newTrainIdToSelect));
+      dispatch(updateSelectedTrainId(pacedTrainId));
     }
   }, [timetableItemIds, timetableItemsWithDetails, setIdsFromUrlOrStorage, parametersLoaded]);
 };

--- a/front/src/applications/operationalStudies/hooks/useScenarioData.ts
+++ b/front/src/applications/operationalStudies/hooks/useScenarioData.ts
@@ -113,9 +113,7 @@ const useScenarioData = (scenario: ScenarioWithDetails, infraId: number) => {
     [projectedTrainsById]
   );
 
-  const timetableItemIds = useMemo(() => timetableItems?.map((item) => item.id), [timetableItems]);
-
-  useAutoSelectTrainIds(timetableItemIds, timetableItemsWithDetails);
+  useAutoSelectTrainIds(timetableItems ? timetableItemsWithDetails : undefined);
 
   // first load of the summaries
   useEffect(() => {

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/ngeToOsrd/trainrun.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/ngeToOsrd/trainrun.ts
@@ -12,8 +12,10 @@ import {
   storePacedTrain,
 } from 'modules/timetableItem/helpers/updateTimetableItemHelpers';
 import type { TimetableItem } from 'reducers/osrdconf/types';
+import { updateSelectedTrainId } from 'reducers/simulationResults';
 import type { AppDispatch } from 'store';
 import { Duration } from 'utils/duration';
+import { formatEditoastIdToPacedTrainId } from 'utils/trainId';
 
 import { checkChangeGroups } from '../../ManageTimetableItem/helpers/buildPacedTrainException';
 import type {
@@ -448,6 +450,7 @@ const handleCreateTimetableItem = async (
     throw new Error('Failed to create timetable item(s)');
   }
   addUpsertedTimetableItems(newTimetableItems);
+  dispatch(updateSelectedTrainId(formatEditoastIdToPacedTrainId(newTimetableItems[0].id)));
 
   const newTrainIds: [number, number | null] = [
     newTimetableItems[0].id,

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/CreateTimetableItemButton.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/CreateTimetableItemButton.tsx
@@ -9,8 +9,10 @@ import { setFailure, setSuccess } from 'reducers/main';
 import { clearAddedExceptionsList } from 'reducers/osrdconf/operationalStudiesConf';
 import { getOperationalStudiesConf } from 'reducers/osrdconf/operationalStudiesConf/selectors';
 import type { TimetableItem } from 'reducers/osrdconf/types';
+import { updateSelectedTrainId } from 'reducers/simulationResults';
 import { useAppDispatch } from 'store';
 import { castErrorToFailure } from 'utils/error';
+import { formatEditoastIdToPacedTrainId } from 'utils/trainId';
 
 import checkCurrentConfig from './helpers/checkCurrentConfig';
 import {
@@ -57,6 +59,7 @@ const CreateTimetableItemButton = ({
       const formattedNewPacedTrain: TimetableItem = (
         await createPacedTrains(dispatch, sandboxId, [payload])
       )[0];
+      dispatch(updateSelectedTrainId(formatEditoastIdToPacedTrainId(formattedNewPacedTrain.id)));
 
       dispatch(
         setSuccess({

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/ManageTimetableItemLeftPanel.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/ManageTimetableItemLeftPanel.tsx
@@ -15,7 +15,6 @@ import {
   getOperationalStudiesConf,
 } from 'reducers/osrdconf/operationalStudiesConf/selectors';
 import type { TimetableItem, TimetableItemToEditData } from 'reducers/osrdconf/types';
-import { getSelectedTrainId } from 'reducers/simulationResults/selectors';
 import { useAppDispatch } from 'store';
 
 import CreateTimetableItemButton from './CreateTimetableItemButton';
@@ -45,7 +44,6 @@ const ManageTimetableItemLeftPanel = ({
   const dispatch = useAppDispatch();
   const { t } = useTranslation('operational-studies', { keyPrefix: 'manageTimetableItem' });
   const editingItemType = useSelector(getEditingItemType);
-  const selectedTrainId = useSelector(getSelectedTrainId);
   const osrdConf = useSelector(getOperationalStudiesConf);
 
   const { openModal, closeModal } = useModal();
@@ -63,8 +61,7 @@ const ManageTimetableItemLeftPanel = ({
     setDisplayTimetableItemManagement,
     upsertTimetableItems,
     setTimetableItemToEditData,
-    timetableItemToEditData,
-    selectedTrainId
+    timetableItemToEditData
   );
 
   const getEditLabel = (_itemToEdit: TimetableItemToEditData) => {

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/hooks/useUpdateTimetableItem.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/hooks/useUpdateTimetableItem.ts
@@ -11,17 +11,11 @@ import {
   getStartTime,
   getOperationalStudiesConf,
 } from 'reducers/osrdconf/operationalStudiesConf/selectors';
-import type { TimetableItem, TrainId, TimetableItemToEditData } from 'reducers/osrdconf/types';
+import type { TimetableItem, TimetableItemToEditData } from 'reducers/osrdconf/types';
 import { updateSelectedTrainId, updateTrainIdUsedForProjection } from 'reducers/simulationResults';
 import { getTrainIdUsedForProjection } from 'reducers/simulationResults/selectors';
 import { useAppDispatch } from 'store';
-import {
-  extractEditoastIdFromPacedTrainId,
-  extractPacedTrainIdFromOccurrenceId,
-  formatEditoastIdToIndexedOccurrenceId,
-  formatEditoastIdToPacedTrainId,
-  isOccurrenceId,
-} from 'utils/trainId';
+import { formatEditoastIdToPacedTrainId, isOccurrenceId } from 'utils/trainId';
 
 import checkCurrentConfig from '../helpers/checkCurrentConfig';
 import { formatPacedTrainPayload } from '../helpers/formatTimetableItemPayload';
@@ -31,8 +25,7 @@ const useUpdateTimetableItem = (
   setDisplayTimetableItemManagement: (type: string) => void,
   upsertTimetableItems: (timetableItems: TimetableItem[]) => void,
   setTimetableItemIdToEdit: (timetableItemToEditData?: TimetableItemToEditData) => void,
-  timetableItemToEditData?: TimetableItemToEditData,
-  selectedTrainId?: TrainId
+  timetableItemToEditData?: TimetableItemToEditData
 ) => {
   const { t } = useTranslation('operational-studies', { keyPrefix: 'manageTimetableItem' });
   const dispatch = useAppDispatch();
@@ -71,19 +64,9 @@ const useUpdateTimetableItem = (
       upsertTimetableItems
     );
 
-    // if the selected TimetableItem is an Occurrence of the edited PacedTrain, keep it selected
-    // else select the first Occurrence by default
-    const trainIdToSelect =
-      (selectedTrainId &&
-        isOccurrenceId(selectedTrainId) &&
-        extractEditoastIdFromPacedTrainId(extractPacedTrainIdFromOccurrenceId(selectedTrainId)) ===
-          timetableItemId) ||
-      !updatedItem.paced
-        ? selectedTrainId
-        : formatEditoastIdToIndexedOccurrenceId({
-            pacedTrainId: updatedItem.id,
-            occurrenceIndex: 0,
-          });
+    const editedTrainId =
+      timetableItemToEditData.occurrenceId ??
+      formatEditoastIdToPacedTrainId(timetableItemToEditData.timetableItemId);
 
     // dispatch success and update the selected train id
     dispatch(
@@ -95,7 +78,7 @@ const useUpdateTimetableItem = (
         text: `${confName}: ${startTime.toLocaleString()}`,
       })
     );
-    dispatch(updateSelectedTrainId(trainIdToSelect));
+    dispatch(updateSelectedTrainId(editedTrainId));
 
     // if the updated train was just transformed from pacedTrain to uniqueTrain
     // and one of the occurrences was used for the projection, update the projectedTrainId

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/PacedTrainItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/PacedTrainItem.tsx
@@ -223,6 +223,7 @@ const PacedTrainItem = ({
     const formattedPacedTrainResponse: TimetableItem = (
       await createPacedTrains(dispatch, pacedTrainDetail.train_schedule_set_id, [newPacedTrain])
     )[0];
+    dispatch(updateSelectedTrainId(formatEditoastIdToPacedTrainId(formattedPacedTrainResponse.id)));
     upsertTimetableItems([formattedPacedTrainResponse]);
     dispatch(
       setSuccess({

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/UniqueTrainItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/UniqueTrainItem.tsx
@@ -121,12 +121,13 @@ const UniqueTrainItem = ({
         train_name: trainName,
       };
 
-      const newUniqueTrain: TimetableItem[] = await createPacedTrains(
-        dispatch,
-        trainDetail.train_schedule_set_id,
-        [newUniqueTrainPayload]
-      );
-      upsertUniqueTrains(newUniqueTrain);
+      const newUniqueTrain: TimetableItem = (
+        await createPacedTrains(dispatch, trainDetail.train_schedule_set_id, [
+          newUniqueTrainPayload,
+        ])
+      )[0];
+      dispatch(updateSelectedTrainId(formatEditoastIdToPacedTrainId(newUniqueTrain.id)));
+      upsertUniqueTrains([newUniqueTrain]);
       dispatch(
         setSuccess({
           title: t('timetable.trainAdded'),

--- a/front/src/modules/timetableItem/helpers/__tests__/pacedTrain.spec.ts
+++ b/front/src/modules/timetableItem/helpers/__tests__/pacedTrain.spec.ts
@@ -3,11 +3,17 @@ import { describe, it, expect } from 'vitest';
 import type { TrainSchedule, PacedTrainException } from 'common/api/osrdEditoastApi';
 import type { SimulatedException, SimulationSummary } from 'modules/timetableItem/types';
 import { Duration } from 'utils/duration';
+import {
+  formatEditoastIdToPacedTrainId,
+  formatPacedTrainIdToExceptionId,
+  formatPacedTrainIdToIndexedOccurrenceId,
+} from 'utils/trainId';
 
 import {
   extractOccurrenceDetailsFromPacedTrain,
   getOccurrencesNb,
   getOccurrencesWorstStatus,
+  isOccurrencePresentInPacedTrain,
 } from '../pacedTrain';
 
 describe('getOccurrencesNb', () => {
@@ -317,5 +323,96 @@ describe('getOccurrencesWorstStatus', () => {
         ])
       ).toEqual('');
     });
+  });
+});
+
+describe('isOccurrencePresentInPacedTrain', () => {
+  const timetableItemId = 123;
+  const pacedTrainId = formatEditoastIdToPacedTrainId(timetableItemId);
+
+  const paced = {
+    timeWindow: Duration.parse('PT2H'),
+    interval: Duration.parse('PT30M'),
+    exceptions: [
+      { key: 'added-exception' },
+      { key: 'disabled-exception', occurrence_index: 1, disabled: true },
+      { key: 'modified-exception', occurrence_index: 2, disabled: false },
+    ],
+  };
+  const timetableItem = { paced, id: timetableItemId };
+
+  it('should return false if the timetable item is not paced', () => {
+    expect(
+      isOccurrencePresentInPacedTrain(formatPacedTrainIdToIndexedOccurrenceId(pacedTrainId, 0), {
+        paced: undefined,
+        id: timetableItemId,
+      })
+    ).toEqual(false);
+  });
+
+  it('should return false if the occurrence does not belong to the paced train id', () => {
+    expect(
+      isOccurrencePresentInPacedTrain(
+        formatPacedTrainIdToIndexedOccurrenceId(formatEditoastIdToPacedTrainId(999), 0),
+        timetableItem
+      )
+    ).toEqual(false);
+  });
+
+  it('should return true if the indexed occurrence is in range and not disabled', () => {
+    expect(
+      isOccurrencePresentInPacedTrain(
+        formatPacedTrainIdToIndexedOccurrenceId(pacedTrainId, 0), // regular occurrence
+        timetableItem
+      )
+    ).toEqual(true);
+    expect(
+      isOccurrencePresentInPacedTrain(
+        formatPacedTrainIdToIndexedOccurrenceId(pacedTrainId, 2), // modified exception
+        timetableItem
+      )
+    ).toEqual(true);
+  });
+
+  it('should return false if the indexed occurrence is out of range', () => {
+    expect(
+      isOccurrencePresentInPacedTrain(
+        formatPacedTrainIdToIndexedOccurrenceId(pacedTrainId, -1),
+        timetableItem
+      )
+    ).toEqual(false);
+    expect(
+      isOccurrencePresentInPacedTrain(
+        formatPacedTrainIdToIndexedOccurrenceId(pacedTrainId, 4),
+        timetableItem
+      )
+    ).toEqual(false);
+  });
+
+  it('should return false if the indexed occurrence is a disabled exception', () => {
+    expect(
+      isOccurrencePresentInPacedTrain(
+        formatPacedTrainIdToIndexedOccurrenceId(pacedTrainId, 1),
+        timetableItem
+      )
+    ).toEqual(false);
+  });
+
+  it('should return true if the occurrence is an added exception present in the paced train', () => {
+    expect(
+      isOccurrencePresentInPacedTrain(
+        formatPacedTrainIdToExceptionId(pacedTrainId, 'added-exception'),
+        timetableItem
+      )
+    ).toEqual(true);
+  });
+
+  it('should return false if the occurrence is an added exception not present in the paced train', () => {
+    expect(
+      isOccurrencePresentInPacedTrain(
+        formatPacedTrainIdToExceptionId(pacedTrainId, 'unknown-exception'),
+        timetableItem
+      )
+    ).toEqual(false);
   });
 });

--- a/front/src/modules/timetableItem/helpers/pacedTrain.ts
+++ b/front/src/modules/timetableItem/helpers/pacedTrain.ts
@@ -12,6 +12,7 @@ import {
   extractPacedTrainIdFromOccurrenceId,
   formatPacedTrainIdToExceptionId,
   formatPacedTrainIdToIndexedOccurrenceId,
+  isAddedExceptionId,
   isIndexedOccurrenceId,
 } from 'utils/trainId';
 
@@ -214,4 +215,28 @@ export const getOcurrencesIds = (pacedTrain: PacedTrainWithPaced, pacedTrainId: 
     occurrencesIds.push(formatPacedTrainIdToIndexedOccurrenceId(pacedTrainId, i));
   }
   return occurrencesIds;
+};
+
+export const isOccurrencePresentInPacedTrain = (
+  occurrenceId: OccurrenceId,
+  timetableItem: Pick<TimetableItemWithDetails, 'paced' | 'id'>
+): boolean => {
+  const paced = timetableItem.paced;
+  if (!paced) return false;
+
+  const pacedTrainId = extractPacedTrainIdFromOccurrenceId(occurrenceId);
+  if (extractEditoastIdFromPacedTrainId(pacedTrainId) !== timetableItem.id) return false;
+
+  if (isAddedExceptionId(occurrenceId)) {
+    const exceptionId = extractExceptionIdFromOccurrenceId(occurrenceId);
+    return paced.exceptions.some((exception) => exception.key === exceptionId);
+  }
+
+  const occurrenceIndex = extractOccurrenceIndexFromOccurrenceId(occurrenceId);
+  const isDisabledException = paced.exceptions.find(
+    (exception) => exception.occurrence_index === occurrenceIndex
+  )?.disabled;
+  if (isDisabledException) return false;
+
+  return occurrenceIndex >= 0 && occurrenceIndex < getOccurrencesNb(paced);
 };

--- a/front/src/utils/__tests__/trainId.spec.ts
+++ b/front/src/utils/__tests__/trainId.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 
 import type { OccurrenceId, PacedTrainId } from 'reducers/osrdconf/types';
+import { Duration } from 'utils/duration';
 
 import {
   formatEditoastIdToIndexedOccurrenceId,
@@ -12,6 +13,7 @@ import {
   formatEditoastIdToExceptionId,
   extractExceptionIdFromOccurrenceId,
   formatPacedTrainIdToExceptionId,
+  isTrainIdInTimetable,
 } from '../trainId';
 
 describe('formatEditoastIdToPacedTrainId', () => {
@@ -160,5 +162,109 @@ describe('extractExceptionIdFromOccurrenceId', () => {
     expect(() => extractExceptionIdFromOccurrenceId(occurrenceId)).toThrow(
       'The occurrence id should match the format "exception_{pacedTrainId}_{exceptionId}"'
     );
+  });
+});
+
+describe('isTrainIdInTimetable', () => {
+  const pacedTimetableItemId = 123;
+  const notPacedTimetableItemId = 456;
+  const missingTimetableItemId = 999;
+  const pacedTrainId = formatEditoastIdToPacedTrainId(pacedTimetableItemId);
+  const notPacedTrainId = formatEditoastIdToPacedTrainId(notPacedTimetableItemId);
+  const missingPacedTrainId = formatEditoastIdToPacedTrainId(missingTimetableItemId);
+
+  const timetableItems = [
+    {
+      id: pacedTimetableItemId,
+      paced: {
+        timeWindow: Duration.parse('PT2H'),
+        interval: Duration.parse('PT30M'),
+        exceptions: [
+          { key: 'added-exception' },
+          { key: 'disabled-exception', occurrence_index: 1, disabled: true },
+          { key: 'modified-exception', occurrence_index: 2, disabled: false },
+        ],
+      },
+    },
+    {
+      id: notPacedTimetableItemId,
+      paced: undefined,
+    },
+  ];
+
+  it('should return false if trainId is undefined', () => {
+    expect(isTrainIdInTimetable(undefined, timetableItems)).toEqual(false);
+  });
+
+  it('should return true if paced train id is present in timetable', () => {
+    expect(isTrainIdInTimetable(pacedTrainId, timetableItems)).toEqual(true); // paced
+    expect(isTrainIdInTimetable(notPacedTrainId, timetableItems)).toEqual(true); // not paced
+  });
+
+  it('should return false if paced train id is not present in timetable', () => {
+    expect(isTrainIdInTimetable(missingPacedTrainId, timetableItems)).toEqual(false);
+  });
+
+  it('should return true if indexed occurrence id is present in timetable', () => {
+    expect(
+      isTrainIdInTimetable(formatPacedTrainIdToIndexedOccurrenceId(pacedTrainId, 0), timetableItems) // regular occurrence
+    ).toEqual(true);
+    expect(
+      isTrainIdInTimetable(formatPacedTrainIdToIndexedOccurrenceId(pacedTrainId, 2), timetableItems) // modified exception
+    ).toEqual(true);
+  });
+
+  it('should return false if occurrence id is not present in timetable as its paced train is not present', () => {
+    expect(
+      isTrainIdInTimetable(
+        formatPacedTrainIdToIndexedOccurrenceId(missingPacedTrainId, 0),
+        timetableItems
+      )
+    ).toEqual(false);
+  });
+
+  it('should return false if occurrence id is not present in timetable as its base train is not paced', () => {
+    expect(
+      isTrainIdInTimetable(
+        formatPacedTrainIdToIndexedOccurrenceId(notPacedTrainId, 0),
+        timetableItems
+      )
+    ).toEqual(false);
+  });
+
+  it('should return false if indexed occurrence id is not present in timetable as its index is out of bounds', () => {
+    expect(
+      isTrainIdInTimetable(
+        formatPacedTrainIdToIndexedOccurrenceId(pacedTrainId, -1),
+        timetableItems
+      )
+    ).toEqual(false);
+    expect(
+      isTrainIdInTimetable(formatPacedTrainIdToIndexedOccurrenceId(pacedTrainId, 4), timetableItems)
+    ).toEqual(false);
+  });
+
+  it('should return false if indexed occurrence id is not present in timetable as it is disabled', () => {
+    expect(
+      isTrainIdInTimetable(formatPacedTrainIdToIndexedOccurrenceId(pacedTrainId, 1), timetableItems)
+    ).toEqual(false);
+  });
+
+  it('should return true if added exception id is present in timetable', () => {
+    expect(
+      isTrainIdInTimetable(
+        formatPacedTrainIdToExceptionId(pacedTrainId, 'added-exception'),
+        timetableItems
+      )
+    ).toEqual(true);
+  });
+
+  it('should return false if added exception id is not present in timetable', () => {
+    expect(
+      isTrainIdInTimetable(
+        formatPacedTrainIdToExceptionId(pacedTrainId, 'unknown-exception'),
+        timetableItems
+      )
+    ).toEqual(false);
   });
 });

--- a/front/src/utils/trainId.ts
+++ b/front/src/utils/trainId.ts
@@ -1,7 +1,8 @@
 import { isEmpty } from 'lodash';
 
 import type { PacedTrainException } from 'common/api/osrdEditoastApi';
-import type { Occurrence } from 'modules/timetableItem/types';
+import { isOccurrencePresentInPacedTrain } from 'modules/timetableItem/helpers/pacedTrain';
+import type { Occurrence, TimetableItemWithDetails } from 'modules/timetableItem/types';
 import type {
   AddedExceptionId,
   IndexedOccurrenceId,
@@ -199,4 +200,22 @@ export const extractExceptionIdFromOccurrenceId = (occurrenceId: OccurrenceId): 
 
   // Handle the case where exceptionId contains "_" itself
   return exceptionId.join('_');
+};
+
+export const isTrainIdInTimetable = (
+  trainId: TrainId | undefined,
+  timetableItems: Pick<TimetableItemWithDetails, 'id' | 'paced'>[]
+): boolean => {
+  if (!trainId) return false;
+
+  const pacedTrainId = isOccurrenceId(trainId)
+    ? extractPacedTrainIdFromOccurrenceId(trainId)
+    : trainId;
+  const timetableItemId = extractEditoastIdFromPacedTrainId(pacedTrainId);
+
+  const timetableItem = timetableItems.find((item) => item.id === timetableItemId);
+  if (!timetableItem) return false;
+
+  if (!isOccurrenceId(trainId)) return true;
+  return isOccurrencePresentInPacedTrain(trainId, timetableItem);
 };


### PR DESCRIPTION
Close #16165

Select edited train upon saving

Edit:  
- also select created train upon creation
- stop selecting first occurrence instead of base train when selecting a train by default
- stop resetting the projected train id when selecting a train by default