### PR TITLE
front: upgrade vite-plugin-static-copy to v4

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -139,7 +139,7 @@
         "typescript-eslint": "^8.58.0",
         "vite": "^8.0.5",
         "vite-plugin-checker": "^0.12.0",
-        "vite-plugin-static-copy": "^3.3.0",
+        "vite-plugin-static-copy": "^4.0.0",
         "vite-tsconfig-paths": "^6.1.1",
         "vitest": "^4.1.2"
       },
@@ -19061,9 +19061,9 @@
       }
     },
     "node_modules/vite-plugin-static-copy": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-3.3.0.tgz",
-      "integrity": "sha512-XiAtZcev7nppxNFgKoD55rfL+ukVp/RtrnTJONRwRuzv/B2FK2h2ZRCYjvxhwBV/Oarse83SiyXBSxMTfeEM0Q==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-4.0.1.tgz",
+      "integrity": "sha512-r3kQUrrimduikhyRm58ayemoxsgB8lZdn/JULLL4wpXHAZlYejtyZx7E/id7dwRtIOSYWu/tWvFjdEOTzso2MA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -19073,14 +19073,14 @@
         "tinyglobby": "^0.2.15"
       },
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": "^22.0.0 || >=24.0.0"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/sapphi-red"
       },
       "peerDependencies": {
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/vite-tsconfig-paths": {

--- a/front/package.json
+++ b/front/package.json
@@ -139,7 +139,7 @@
     "typescript-eslint": "^8.58.0",
     "vite": "^8.0.5",
     "vite-plugin-checker": "^0.12.0",
-    "vite-plugin-static-copy": "^3.3.0",
+    "vite-plugin-static-copy": "^4.0.0",
     "vite-tsconfig-paths": "^6.1.1",
     "vitest": "^4.1.2"
   },

--- a/front/vite.config.ts
+++ b/front/vite.config.ts
@@ -55,6 +55,7 @@ export default defineConfig(({ mode }) => {
               path.join(ngeBase, 'src_assets_i18n_*_json.js'),
             ],
             dest: 'netzgrafik-frontend/',
+            rename: { stripBase: true },
           },
         ],
       }),


### PR DESCRIPTION
By default, this new major version preserves directory structure, so copied files end up in this directory:

    build/netzgrafik-frontend/node_modules/@osrd-project/netzgrafik-frontend/dist/netzgrafik-frontend/

Add `rename: { stripBase: true }` to flatten everything.