### PR TITLE
editoast: accept trigrams with 4 chars or more

### DIFF
--- a/editoast/database/src/tables.rs
+++ b/editoast/database/src/tables.rs
@@ -596,7 +596,7 @@ diesel::table! {
         obj_id -> Nullable<Varchar>,
         infra_id -> Nullable<Int4>,
         uic -> Nullable<Int4>,
-        #[max_length = 3]
+        #[max_length = 255]
         trigram -> Nullable<Varchar>,
         ci -> Nullable<Int4>,
         ch -> Nullable<Text>,

--- a/editoast/migrations/2026-04-13-091021-0000_trigram_arbitrary_length/down.sql
+++ b/editoast/migrations/2026-04-13-091021-0000_trigram_arbitrary_length/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE search_operational_point
+ALTER COLUMN trigram TYPE varchar(3);

--- a/editoast/migrations/2026-04-13-091021-0000_trigram_arbitrary_length/up.sql
+++ b/editoast/migrations/2026-04-13-091021-0000_trigram_arbitrary_length/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE search_operational_point
+ALTER COLUMN trigram TYPE varchar(255);


### PR DESCRIPTION
in other countries trigrams can have more than three characters. For example the Deutsche Bahn has "trigrams" (soon to be "main_code"s in OSRD) of 2 to 5 characters:

https://www.dbinfrago.com/web/schienennetz/betrieb/allgemeine-betriebsinformationen/betriebsstellen-12592996

Here's a small-infra fork with unorthodox values for trigrams: https://github.com/user-attachments/files/26669755/sava.json


I don't think the front is fully ready for this change though. Should we merge this and fix the front later? e.g.

<img width="1060" height="884" alt="screen-20260413112827" src="https://github.com/user-attachments/assets/331986ee-7a2e-40a5-98c9-be4c548e27a5" />

even 5-char trigrams overflow into the name of the OP:

<img width="1060" height="884" alt="screen-20260413113017" src="https://github.com/user-attachments/assets/ea7da962-c49f-4f5b-98c7-afb92a973723" />


Closes https://github.com/OpenRailAssociation/osrd/issues/16212