### PR TITLE
front: drop esbuild dependency

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -118,7 +118,6 @@
         "@vitejs/plugin-react": "^6.0.1",
         "@vitest/eslint-plugin": "^1.4.3",
         "ansi-to-html": "^0.7.2",
-        "esbuild": "0.27.4",
         "eslint": "^9.39.2",
         "eslint-import-resolver-typescript": "^4.4.4",
         "eslint-plugin-import": "^2.31.0",

--- a/front/package.json
+++ b/front/package.json
@@ -118,7 +118,6 @@
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/eslint-plugin": "^1.4.3",
     "ansi-to-html": "^0.7.2",
-    "esbuild": "0.27.4",
     "eslint": "^9.39.2",
     "eslint-import-resolver-typescript": "^4.4.4",
     "eslint-plugin-import": "^2.31.0",


### PR DESCRIPTION
It seems like this was added by mistake in https://github.com/OpenRailAssociation/osrd/pull/15289