### PR TITLE
front: fix crash when reloading conflicts

### DIFF
--- a/front/src/applications/operationalStudies/hooks/useScenarioData.ts
+++ b/front/src/applications/operationalStudies/hooks/useScenarioData.ts
@@ -90,13 +90,13 @@ const useScenarioData = (scenario: ScenarioWithDetails, infraId: number) => {
   // TODO Paced trains : adapt this to handle paced trains in the conflicts issue
   const {
     data: conflicts,
-    isLoading,
+    isUninitialized,
     isFetching,
   } = osrdEditoastApi.endpoints.getTimetableByIdConflicts.useQuery(
     allTrainsSimulated ? { id: scenario.timetable_id, infraId: scenario.infra_id } : skipToken
   );
 
-  const isConflictsLoading = isLoading || isFetching;
+  const isConflictsLoading = isUninitialized || isFetching;
 
   const timetableItemsWithDetails = useMemo(() => {
     const items = (timetableItems || []).map((timetableItem) => {

--- a/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
@@ -256,21 +256,20 @@ const ScenarioContent = ({ activeBoards }: ScenarioContentProps) => {
             withFooter
           >
             <div className="conflicts-wrapper">
-              {isConflictsLoading ? (
+              {isConflictsLoading && (
                 <Loader
                   msg={t('main.loadingConflicts')}
                   className="scenario-loader"
                   childClass="scenario-loader-msg"
                 />
-              ) : (
-                <Conflicts
-                  showOnlySelectedTrain={showOnlySelectedTrain}
-                  onToggleFilter={handleToggleConflictsFilter}
-                  selectedTrainName={selectedTrainName}
-                  conflictsCount={selectedTrainConflictsCount}
-                  displayedConflicts={displayedConflicts}
-                />
               )}
+              <Conflicts
+                showOnlySelectedTrain={showOnlySelectedTrain}
+                onToggleFilter={handleToggleConflictsFilter}
+                selectedTrainName={selectedTrainName}
+                conflictsCount={selectedTrainConflictsCount}
+                displayedConflicts={displayedConflicts}
+              />
             </div>
           </BoardWrapper>
         </div>

--- a/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
@@ -72,7 +72,8 @@ const ScenarioContent = ({ activeBoards }: ScenarioContentProps) => {
     displayedConflicts,
   } = useConflictsFilter(
     useMemo(() => timetableItems || [], [timetableItems]),
-    conflicts
+    conflicts,
+    isConflictsLoading
   );
 
   const macroEditorState = useRef<MacroEditorState>(null);

--- a/front/src/modules/conflict/hooks/useConflictsFilter.ts
+++ b/front/src/modules/conflict/hooks/useConflictsFilter.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo, useEffect } from 'react';
 
 import { useSelector } from 'react-redux';
 
@@ -18,14 +18,20 @@ import {
   extractEditoastIdFromPacedTrainId,
 } from 'utils/trainId';
 
+import type { ConflictWithTrainNames } from '../types';
 import addTrainNamesToConflicts, {
   filterAndReorderConflict,
   reorderConflictTrains,
 } from '../utils';
 
-const useConflictsFilter = (timetableItems: TimetableItem[], conflicts: Conflict[] | undefined) => {
+const useConflictsFilter = (
+  timetableItems: TimetableItem[],
+  conflicts: Conflict[] | undefined,
+  isConflictsLoading: boolean
+) => {
   const selectedTrainId = useSelector(getSelectedTrainId);
   const [showOnlySelectedTrain, setShowOnlySelectedTrain] = useState(false);
+  const [enrichedConflicts, setEnrichedConflicts] = useState<ConflictWithTrainNames[]>([]);
 
   const handleToggleConflictsFilter = useCallback(() => {
     setShowOnlySelectedTrain(!showOnlySelectedTrain);
@@ -68,13 +74,13 @@ const useConflictsFilter = (timetableItems: TimetableItem[], conflicts: Conflict
 
   const totalConflictsCount = useMemo(() => conflicts?.length ?? 0, [conflicts]);
 
-  const enrichedConflicts = useMemo(() => {
-    if (!conflicts) return [];
-    const sortedByStartTime = [...conflicts].sort(
+  useEffect(() => {
+    if (isConflictsLoading) return;
+    const sortedByStartTime = [...(conflicts ?? [])].sort(
       (a, b) => new Date(a.start_time).getTime() - new Date(b.start_time).getTime()
     );
-    return addTrainNamesToConflicts(sortedByStartTime, timetableItems);
-  }, [conflicts, timetableItems]);
+    setEnrichedConflicts(addTrainNamesToConflicts(sortedByStartTime, timetableItems));
+  }, [conflicts, isConflictsLoading, timetableItems]);
 
   const selectedEnrichedConflicts = useMemo(() => {
     if (!selectedTrainName || !selectedTrainId) return [];

--- a/front/src/modules/conflict/hooks/useConflictsFilter.ts
+++ b/front/src/modules/conflict/hooks/useConflictsFilter.ts
@@ -76,7 +76,7 @@ const useConflictsFilter = (
 
   useEffect(() => {
     if (isConflictsLoading) return;
-    const sortedByStartTime = [...(conflicts ?? [])].sort(
+    const sortedByStartTime = [...conflicts!].sort(
       (a, b) => new Date(a.start_time).getTime() - new Date(b.start_time).getTime()
     );
     setEnrichedConflicts(addTrainNamesToConflicts(sortedByStartTime, timetableItems));

--- a/front/src/styles/scss/applications/operationalStudies/_scenarioContentV2.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_scenarioContentV2.scss
@@ -66,14 +66,10 @@
       .conflicts-wrapper {
         display: block;
         position: relative;
+        height: 100%;
         width: 100%;
         transition: 0.2s;
-        max-height: 90vh;
         overflow-y: auto;
-
-        .scenario-loader {
-          top: 10vw;
-        }
       }
     }
   }


### PR DESCRIPTION
Close https://github.com/OpenRailAssociation/osrd/issues/14668

Caused by stale conflicts being incompatible with fresh timetable items (for example when a paced train with exceptions is turned into a train schedule).

In this version we stop displaying conflicts while we are loading new ones. If we want to continue displaying the old conflicts while loading new ones, we can simply replace the useMemo by useState + useEffect (in order to display the old conflicts using the old timetable items). Tell me if you would prefer that.

~~We could also add a loading indication in the conflicts display.~~ -> there already was a loader but its display was broken. Fixed in the second commit.

(This pr has no bearing on https://github.com/OpenRailAssociation/osrd/issues/14504 afaik.)