### PR TITLE
front: enable rocket path filling without rolling stock

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModal.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModal.tsx
@@ -550,7 +550,7 @@ const ItineraryModal = ({
                 />
               </div>
             )}
-          <TypeAndPath rollingStockId={modalFormState.rollingStockId} isInNewModal />
+          <TypeAndPath isInNewModal />
           <div className="path-step-list">
             <button
               data-testid="reverse-itinerary-button"

--- a/front/src/modules/pathfinding/components/Itinerary/Itinerary.tsx
+++ b/front/src/modules/pathfinding/components/Itinerary/Itinerary.tsx
@@ -109,10 +109,7 @@ const Itinerary = ({ rollingStockId }: { rollingStockId: number | undefined }) =
       </div>
       {displayTypeAndPath && (
         <div className="mb-2">
-          <TypeAndPath
-            setDisplayTypeAndPath={setDisplayTypeAndPath}
-            rollingStockId={rollingStockId}
-          />
+          <TypeAndPath setDisplayTypeAndPath={setDisplayTypeAndPath} />
         </div>
       )}
       {origin && destination && (

--- a/front/src/modules/pathfinding/components/Pathfinding/TypeAndPath.tsx
+++ b/front/src/modules/pathfinding/components/Pathfinding/TypeAndPath.tsx
@@ -57,16 +57,11 @@ function OpTooltips({ opList }: { opList: SearchResultItemOperationalPoint[] }) 
   );
 }
 type TypeAndPathProps = {
-  rollingStockId: number | undefined;
   setDisplayTypeAndPath?: React.Dispatch<React.SetStateAction<boolean>>;
   isInNewModal?: boolean;
 };
 
-const TypeAndPath = ({
-  setDisplayTypeAndPath,
-  rollingStockId,
-  isInNewModal = false,
-}: TypeAndPathProps) => {
+const TypeAndPath = ({ setDisplayTypeAndPath, isInNewModal = false }: TypeAndPathProps) => {
   const { launchPathfinding } = useManageTimetableItemContext();
 
   const [inputText, setInputText] = useState('');
@@ -167,7 +162,7 @@ const TypeAndPath = ({
   const isInvalid = useMemo(() => opList.some((op) => !op.name && op.trigram !== ''), [opList]);
 
   const handleSubmit = async () => {
-    if (infraId && rollingStockId && opList.length > 0) {
+    if (infraId && opList.length > 0) {
       const pathSteps: PathItem[] = opList
         .filter((op) => op.trigram !== '')
         .map(({ trigram, ch }) => ({


### PR DESCRIPTION
Close #16153

The issue only asked for the new modal, but this also works in the old modal - both because I think it's a positive change in the old modal too and because it's not worth creating special cases for something we will soon drop. 

launchPathfinding (in usePathfinding) still guards for rollingStockId != undefined before sending a request to the back, so only the part that fills the path steps and add the warnings (such as the fact the rolling stock is missing) gets executed - as we wish. 