### PR TITLE
front: drop collapse timetable as dead code

### DIFF
--- a/front/public/locales/de/operational-studies.json
+++ b/front/public/locales/de/operational-studies.json
@@ -181,7 +181,6 @@
       "update": "Ändern",
       "validityFilter": "Gültigkeit der Züge"
     },
-    "toggleTimetable": "Fahrplan umschalten",
     "trainCount_one": "1/$t(main.main.train, { 'count': {{totalCount}} }) ausgewählt.",
     "trainCount_other": "{{count}}/$t(main.main.train, { 'count': {{totalCount}} }) ausgewählt.",
     "trainCount_zero": "$t(main.main.train, { 'count': {{totalCount}} })",

--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -332,7 +332,6 @@
       "update": "Edit",
       "validityFilter": "Trains validity"
     },
-    "toggleTimetable": "Toggle the timetable",
     "trainCountSelected_one": "1/{{totalCount}} train selected",
     "trainCountSelected_other": "{{count}}/{{totalCount}} trains selected",
     "trainCount_one": "1/{{totalCount}} train",

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -332,7 +332,6 @@
       "update": "Modifier",
       "validityFilter": "Validité des trains"
     },
-    "toggleTimetable": "Basculer l'affichage de la grille horaire",
     "trainCountSelected_one": "1/{{totalCount}} train sélectionné",
     "trainCountSelected_other": "{{count}}/{{totalCount}} trains sélectionnés",
     "trainCount_one": "1/{{totalCount}} train",

--- a/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
@@ -1,6 +1,5 @@
 import { useState, useCallback, useRef, useEffect, useMemo } from 'react';
 
-import { ChevronRight } from '@osrd-project/ui-icons';
 import { useTranslation } from 'react-i18next';
 
 import { useScenarioContext } from 'applications/operationalStudies/hooks/useScenarioContext';
@@ -47,7 +46,6 @@ const ScenarioContent = ({ activeBoards }: ScenarioContentProps) => {
   const [displayTimetableItemManagement, setDisplayTimetableItemManagement] = useState<string>(
     MANAGE_TIMETABLE_ITEM_TYPES.none
   );
-  const [collapsedTimetable, setCollapsedTimetable] = useState(false);
   const [collapsedTimetableEdit, setCollapsedTimetableEdit] = useState(false);
   const [timetableItemToEditData, setTimetableItemToEditData] = useState<TimetableItemToEditData>();
   const [macroBoardHeight, setMacroBoardHeight] = useState<number>(MACRO_EDITOR_HEIGHT);
@@ -198,17 +196,6 @@ const ScenarioContent = ({ activeBoards }: ScenarioContentProps) => {
           </div>
         </div>
         <div className="center-column">
-          {collapsedTimetable && (
-            <button
-              data-testid="timetable-collapse-button"
-              className="timetable-collapse-button"
-              type="button"
-              aria-label={t('main.toggleTimetable')}
-              onClick={() => setCollapsedTimetable(false)}
-            >
-              <ChevronRight />
-            </button>
-          )}
           {!isInfraLoaded &&
             displayTimetableItemManagement !== MANAGE_TIMETABLE_ITEM_TYPES.add &&
             displayTimetableItemManagement !== MANAGE_TIMETABLE_ITEM_TYPES.edit && (


### PR DESCRIPTION
The collapsedTimetable state is always set to false and no longer used anywhere. Additionally, we now "collapse" the timetable by toggling the train list on or off in the boards widget at the top of the page, so this is legacy code corresponding to a former ux.