### PR TITLE
editoast: fix PathfindingEnv deduplication

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -444,9 +444,9 @@ dependencies = [
 
 [[package]]
 name = "axum-test"
-version = "20.0.0"
+version = "19.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a86bfe2ef15bee102ac34912f7f4542b0bb37dc464fa55461763999c4d625e7"
+checksum = "6a28640adad0e99978d38bc455b323c62a5cddc4e22f83eacde93f8c395ae7e3"
 dependencies = [
  "anyhow",
  "axum",

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -160,7 +160,7 @@ axum-extra = { version = "0.12.2", default-features = false, features = [
   "typed-header",
 ] }
 axum-streams = { version = "0.25.0", features = ["json"] }
-axum-test = { version = "19.0", default-features = false }
+axum-test = { version = "20.0", default-features = false }
 axum-tracing-opentelemetry = { version = "0.33.0", default-features = false, features = [
   "tracing_level_info",
 ] }

--- a/editoast/core_task/src/envs/pathfinding.rs
+++ b/editoast/core_task/src/envs/pathfinding.rs
@@ -303,17 +303,11 @@ where
         use crate::TaskStreamExt as _;
 
         let requests = self
-            .pathfinding_inputs
-            .iter()
-            .map(
-                |Correlated {
-                     correlation_key: _,
-                     data: input,
-                 }| {
-                    let request = build_request(&self.core_env, &input);
-                    Correlated::new(input, request)
-                },
-            )
+            .iter_inputs()
+            .map(|input| {
+                let request = build_request(&self.core_env, &input);
+                Correlated::new(input, request)
+            })
             .collect_vec();
 
         stream::iter(requests).run(vkconn, self.core_env.client.clone())
@@ -546,5 +540,49 @@ mod tests {
             Some(Poll::Ready(Ok(serde_json::from_value(path(2)).unwrap())))
         );
         assert_eq!(pfrun.get_path(&3), None);
+    }
+
+    // PathfindingEnv::run applies another deduplication to the results, this test
+    // ensures into_stream deduplicates correctly as well.
+    #[tokio::test]
+    async fn pathfinding_env_into_stream() {
+        common::setup_tracing_for_test();
+
+        // A unique train seed to generate twice the same inputs
+        const TRAIN: usize = 123456789;
+
+        let mut mock = MockingClient::new();
+        mock.stub("/pathfinding/blocks")
+            .response(StatusCode::OK)
+            .json(path(TRAIN))
+            .finish();
+        mock.stub("/pathfinding/blocks")
+            .response(StatusCode::OK)
+            .json(path(TRAIN))
+            .finish();
+
+        let mut pfenv = PathfindingEnv::<usize>::new(CoreEnv::new_mock(mock));
+        pfenv.extend([(1, train(TRAIN)), (2, train(TRAIN))]);
+
+        let vk = cache::Client::new(cache::Config::NoCache, "");
+
+        use futures::StreamExt as _;
+        let results = tokio::time::timeout(Duration::from_secs(1), async move {
+            pfenv
+                .into_stream(Arc::new(Mutex::new(vk.get_connection().await.unwrap())))
+                .collect::<Vec<_>>()
+                .await
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(
+            results,
+            vec![Correlated::new(
+                TrainSet::from([1, 2]),
+                Ok(serde_json::from_value(path(TRAIN)).unwrap()),
+            )]
+        );
     }
 }


### PR DESCRIPTION
- **editoast: core_task: fix request deduplication in `PathfindingEnv::into_stream`**
- **editoast: bump `axum-test` properly**

refs #15468 