### PR TITLE
front, ui: upgrade TypeScript to v6

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -135,7 +135,7 @@
         "ts-node": "^10.9.2",
         "tslib": "^2.8.1",
         "tsx": "^4.21.0",
-        "typescript": "~5.9",
+        "typescript": "^6.0.0",
         "typescript-eslint": "^8.58.0",
         "vite": "^8.0.5",
         "vite-plugin-checker": "^0.12.0",
@@ -5289,6 +5289,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/@rtk-query/codegen-openapi/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -14034,6 +14048,20 @@
         "@oazapfts/runtime": "*"
       }
     },
+    "node_modules/oazapfts/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "license": "MIT",
@@ -18262,25 +18290,6 @@
         }
       }
     },
-    "node_modules/tsconfck": {
-      "version": "3.0.3",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "tsconfck": "bin/tsconfck.js"
-      },
-      "engines": {
-        "node": "^18 || >=20"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "dev": true,
@@ -18396,7 +18405,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
@@ -19098,6 +19109,27 @@
         "vite": "*"
       }
     },
+    "node_modules/vite-tsconfig-paths/node_modules/tsconfck": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
+      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tsconfck": "bin/tsconfck.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vite/node_modules/picomatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
@@ -19675,6 +19707,20 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "ui/base/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "ui/storybook": {

--- a/front/package.json
+++ b/front/package.json
@@ -135,7 +135,7 @@
     "ts-node": "^10.9.2",
     "tslib": "^2.8.1",
     "tsx": "^4.21.0",
-    "typescript": "~5.9",
+    "typescript": "^6.0.0",
     "typescript-eslint": "^8.58.0",
     "vite": "^8.0.5",
     "vite-plugin-checker": "^0.12.0",

--- a/front/ui/tsconfig.base.json
+++ b/front/ui/tsconfig.base.json
@@ -6,7 +6,6 @@
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,
     "alwaysStrict": true,
-    "baseUrl": ".",
     "declaration": true,
     "declarationDir": "./dist",
     "diagnostics": false,
@@ -37,9 +36,6 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "outDir": "./dist",
-    "paths": {
-      "*": ["@types/*"]
-    },
     "preserveConstEnums": true,
     "pretty": true,
     "removeComments": false,
@@ -56,6 +52,7 @@
     "stripInternal": true,
     "suppressExcessPropertyErrors": false,
     "suppressImplicitAnyIndexErrors": false,
+    "noUncheckedSideEffectImports": false,
     "target": "esnext"
   }
 }


### PR DESCRIPTION
osrd-ui needs a few changes for TypeScript v6 compatibility:

- `baseUrl` needs to be dropped because it's now deprecated and causes warnings (and thus CI failures).
- `paths` had a bogus unused entry, TypeScript now complains that it's not a relative path.
- `noUncheckedSideEffectImports` now defaults to true. This causes failures because we import .css files. A better way to solve this would be to `declare module '*.css'`, but that's cumbersome to apply to all osrd-ui packages. For now, let's just explicitly set this config option to the v5 default.