### PR TITLE
editoast: suppress unused trains_count field

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -12593,7 +12593,6 @@ components:
       - infra_id
       - infra_name
       - paced_trains_count
-      - trains_count
       - description
       - last_modification
       - tags
@@ -12633,10 +12632,6 @@ components:
           type: array
           items:
             type: string
-        trains_count:
-          type: integer
-          format: int64
-          minimum: 0
     SearchResultItemSignal:
       type: object
       description: |

--- a/editoast/src/views/search.rs
+++ b/editoast/src/views/search.rs
@@ -724,10 +724,6 @@ pub(super) struct SearchResultItemScenario {
         sql = "(SELECT COUNT(trains.id) FROM train_schedule AS trains INNER JOIN timetable_train_schedule_set AS ttss ON trains.train_schedule_set_id = ttss.train_schedule_set_id WHERE ttss.timetable_id = scenario.timetable_id)"
     )]
     paced_trains_count: u64,
-    #[search(
-        sql = "(SELECT COUNT(trains.id) FROM train_schedule AS trains INNER JOIN timetable_train_schedule_set AS ttss ON trains.train_schedule_set_id = ttss.train_schedule_set_id WHERE ttss.timetable_id = scenario.timetable_id)"
-    )]
-    trains_count: u64,
     #[search(sql = "scenario.description")]
     description: String,
     #[search(sql = "scenario.last_modification")]

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -4258,7 +4258,6 @@ export type SearchResultItemScenario = {
   paced_trains_count: number;
   study_id: number;
   tags: string[];
-  trains_count: number;
 };
 export type Margins = {
   boundaries: string[];


### PR DESCRIPTION
This field is a duplicate of `paced_trains_count` (that will be rename in another PR).