### PR TITLE
osm_to_railjson: fix missing local_track_name

### DIFF
--- a/editoast/osm_to_railjson/src/osm_to_railjson.rs
+++ b/editoast/osm_to_railjson/src/osm_to_railjson.rs
@@ -15,6 +15,9 @@ use crate::generate_routes;
 use crate::generate_signals;
 use schemas::infra::RailJson;
 use schemas::infra::TrackSection;
+
+use itertools::Itertools as _;
+
 /// Run the osm-to-railjson subcommand
 /// Converts OpenStreetMap pbf file to railjson
 pub fn osm_to_railjson(
@@ -62,7 +65,8 @@ pub fn parse_osm(
     let rail_edges = edges
         .iter()
         .filter(|e| e.properties.train == osm4routing::TrainAccessibility::Allowed)
-        .filter(|e| e.source != e.target);
+        .filter(|e| e.source != e.target)
+        .collect_vec();
 
     let mut adjacencies = HashMap::<osm4routing::NodeId, NodeAdjacencies>::new();
     for edge in rail_edges.clone() {
@@ -70,23 +74,8 @@ pub fn parse_osm(
         adjacencies.entry(edge.target).or_default().edges.push(edge);
     }
 
-    let nodes_tracks = NodeToTrack::from_edges(&edges);
-    let signals = if generate_signals {
-        vec![]
-    } else {
-        signals(&osm_pbf_in, &nodes_tracks, &adjacencies)
-    };
-    let mut railjson = RailJson {
-        extended_switch_types: vec![],
-        detectors: signals.iter().map(detector).collect(),
-        signals,
-        speed_sections: rail_edges.clone().flat_map(speed_sections).collect(),
-        electrifications: rail_edges.clone().flat_map(electrifications).collect(),
-        operational_points: operational_points(&osm_pbf_in, &nodes_tracks),
-        ..Default::default()
-    };
-
-    railjson.track_sections = rail_edges
+    let track_sections: Vec<TrackSection> = rail_edges
+        .iter()
         .map(|e| {
             let geo = geos::geojson::Geometry::new(geos::geojson::Value::LineString(
                 e.geometry.iter().map(|c| vec![c.x, c.y]).collect(),
@@ -119,6 +108,31 @@ pub fn parse_osm(
             }
         })
         .collect();
+
+    let nodes_tracks = NodeToTrack::from_edges(&edges);
+    let signals = if generate_signals {
+        vec![]
+    } else {
+        signals(&osm_pbf_in, &nodes_tracks, &adjacencies)
+    };
+    let mut railjson = RailJson {
+        extended_switch_types: vec![],
+        detectors: signals.iter().map(detector).collect(),
+        signals,
+        speed_sections: rail_edges
+            .iter()
+            .copied()
+            .flat_map(speed_sections)
+            .collect(),
+        electrifications: rail_edges
+            .iter()
+            .copied()
+            .flat_map(electrifications)
+            .collect(),
+        operational_points: operational_points(&osm_pbf_in, &nodes_tracks, &track_sections),
+        track_sections,
+        ..Default::default()
+    };
 
     for (node, mut adj) in adjacencies {
         for e1 in &adj.edges {

--- a/editoast/osm_to_railjson/src/utils.rs
+++ b/editoast/osm_to_railjson/src/utils.rs
@@ -25,6 +25,7 @@ use schemas::infra::Speed;
 use schemas::infra::SpeedSection;
 use schemas::infra::Switch;
 use schemas::infra::TrackEndpoint;
+use schemas::infra::TrackSection;
 use schemas::primitives::Identifier;
 use schemas::primitives::NonBlankString;
 use std::collections::HashMap;
@@ -33,6 +34,7 @@ use std::sync::atomic::AtomicU32;
 use std::sync::atomic::Ordering;
 use tracing::error;
 use tracing::warn;
+use uuid::Uuid;
 
 // Given an edge and a coordinate, returns the coordinates used to compute the angle
 // It uses the nearest OpenStreetMap node, and the other as the rails might do a loop
@@ -228,7 +230,10 @@ impl<'a> NodeToTrack<'a> {
     /// Given an OSM node, returns the track, the position it is on and the local ref if its available
     /// If there is an ambiguity (the node is at intersection), we just pick one
     /// We log weird situations (the are 3 edges for that node)
-    pub fn track_and_position(&self, id: NodeId) -> Option<(Identifier, f64, NonBlankString)> {
+    pub fn track_and_position(
+        &self,
+        id: NodeId,
+    ) -> Option<(Identifier, f64, Option<NonBlankString>)> {
         self.nodes_edges.get(&id).and_then(|edges| {
             if edges.is_empty() {
                 error!("Missing edge for node {}", id.0);
@@ -236,11 +241,7 @@ impl<'a> NodeToTrack<'a> {
             } else if edges.len() >= 3 {
                 warn!("Too many edges for node {}", id.0);
             }
-            let local_ref = edges[0]
-                .tags
-                .get("local_ref")
-                .map(NonBlankString::from)
-                .unwrap_or(NonBlankString::from("unknown"));
+            let local_ref = edges[0].tags.get("local_ref").map(NonBlankString::from);
             Some((
                 edges[0].id.clone().into(),
                 edges[0].length_until(&id),
@@ -464,9 +465,31 @@ fn map_node_id_to_trigram(
         .collect()
 }
 
+/// If the local_track_name is None, we try to find if the track_section associated to this operational_point_part has a track_name.
+/// If no track_name is found, we generate a random one.
+fn local_track_name_fallback(
+    track: &Identifier,
+    track_sections: &[TrackSection],
+) -> NonBlankString {
+    track_sections
+        .iter()
+        .find(|track_section| track_section.id == *track)
+        .and_then(|track_section| {
+            if let Some(sncf) = &track_section.extensions.sncf
+                && sncf.track_name != "??".into()
+            {
+                Some(sncf.track_name.clone())
+            } else {
+                None
+            }
+        })
+        .unwrap_or(NonBlankString::from(Uuid::new_v4().to_string()))
+}
+
 pub fn operational_points(
     osm_pbf_in: &std::path::PathBuf,
     nodes_to_tracks: &NodeToTrack,
+    track_sections: &[TrackSection],
 ) -> Vec<OperationalPoint> {
     let file = std::fs::File::open(osm_pbf_in).unwrap();
     let mut pbf: OsmPbfReader<std::fs::File> = osm4routing::osmpbfreader::OsmPbfReader::new(file);
@@ -494,7 +517,12 @@ pub fn operational_points(
                 .flat_map(|node| {
                     nodes_to_tracks
                         .track_and_position(node)
-                        .map(|(track, position, local_track_name)| OperationalPointPart { track, position, local_track_name, extensions: Default::default() })
+                        .map(|(track, position, local_track_name)| OperationalPointPart {
+                            track: track.clone(),
+                            position,
+                            local_track_name: local_track_name.unwrap_or_else(|| local_track_name_fallback(&track, track_sections)),
+                            extensions: Default::default()
+                        })
                 })
                 .collect();
             // Get operational point trigram


### PR DESCRIPTION
Try to find `operational_point_part.local_track_name` in associated track sections.
Generate the `local_track_name` if none is found.

close https://github.com/OpenRailAssociation/osrd/issues/16049