### PR TITLE
front: fix crash when reopening scenario with a projected occurence

### DIFF
--- a/front/src/applications/operationalStudies/hooks/usePathProjection.ts
+++ b/front/src/applications/operationalStudies/hooks/usePathProjection.ts
@@ -118,6 +118,7 @@ const usePathProjection = (
     } else {
       const pacedTrainId = extractPacedTrainIdFromOccurrenceId(trainIdUsedForProjection);
       rawPacedTrainId = extractEditoastIdFromPacedTrainId(pacedTrainId);
+
       exceptionKey = getExceptionFromOccurrenceId(
         timetableItemsById,
         trainIdUsedForProjection
@@ -157,7 +158,7 @@ const usePathProjection = (
       )
     );
     const exception = getExceptionFromOccurrenceId(timetableItemsById, trainIdUsedForProjection);
-    return exception?.path_and_schedule?.path ?? pacedTrain!.path;
+    return exception?.path_and_schedule?.path ?? pacedTrain?.path;
   }, [trainIdUsedForProjection, timetableItemsById]);
 
   const opRefs = useMemo(() => {

--- a/front/src/modules/timetableItem/helpers/pacedTrain.ts
+++ b/front/src/modules/timetableItem/helpers/pacedTrain.ts
@@ -159,8 +159,8 @@ export const getExceptionFromOccurrenceId = (
     extractPacedTrainIdFromOccurrenceId(occurrenceId)
   );
   const pacedTrain = timetableItemsById.get(pacedTrainId);
-  if (!pacedTrain || !isPacedTrain(pacedTrain))
-    throw new Error(`No paced train found for id ${pacedTrainId}`);
+  if (!pacedTrain) return undefined;
+  if (!isPacedTrain(pacedTrain)) throw new Error(`No paced train found for id ${pacedTrainId}`);
 
   let exception: PacedTrainException | undefined;
   if (isIndexedOccurrenceId(occurrenceId)) {


### PR DESCRIPTION
closes #15945 

the `trainIdUsedForProjection` is coming from redux -> it was already there when opening the scenario
but the Map `timetableItemsById` wasn't ready yet, which caused the crash. 

now waiting to get the `pacedTrain` before trying to get the `ExceptionKey`. 
Also had to return `undefined` instead of throwing an error -> this I'm not sure if it could be handled in another way, or if it's ok to not throw an error. 