### PR TITLE
front: fix list rolling stock in debug mode

### DIFF
--- a/front/src/applications/stdcm/components/StdcmForm/StdcmConsist.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmConsist.tsx
@@ -136,7 +136,10 @@ const StdcmConsist = ({
   const lengthFieldStatus = useFieldStatus('totalLength');
   const speedFieldStatus = useFieldStatus('maxSpeed');
 
-  const { filteredRollingStockList: rollingStocks } = useFilterRollingStock({ isStdcm: true });
+  const { filteredRollingStockList: rollingStocks } = useFilterRollingStock({
+    isStdcm: true,
+    isDebugMode,
+  });
 
   const { filteredTowedRollingStockList: towedRollingStocks } = useFilterTowedRollingStock({
     isDebugMode,

--- a/front/src/modules/rollingStock/hooks/useFilterRollingStock.ts
+++ b/front/src/modules/rollingStock/hooks/useFilterRollingStock.ts
@@ -156,7 +156,13 @@ function computeCategoryFilter(filters: RollingStockFilters, category?: Category
   return { ...filters, category: category?.id };
 }
 
-const useFilterRollingStock = ({ isStdcm } = { isStdcm: false }) => {
+const useFilterRollingStock = ({
+  isStdcm = false,
+  isDebugMode = false,
+}: {
+  isStdcm?: boolean;
+  isDebugMode?: boolean;
+} = {}) => {
   const dispatch = useAppDispatch();
 
   const [filters, setFilters] = useState<RollingStockFilters>(initialFilters);
@@ -172,10 +178,10 @@ const useFilterRollingStock = ({ isStdcm } = { isStdcm: false }) => {
 
   const usefulRollingStocks = useMemo(
     () =>
-      isStdcm
+      isStdcm && !isDebugMode
         ? allRollingStocks.filter((rs) => STDCM_ROLLING_STOCKS.includes(rs.name))
         : allRollingStocks,
-    [isStdcm, allRollingStocks]
+    [isStdcm, isDebugMode, allRollingStocks]
   );
 
   const [searchIsLoading, setSearchIsLoading] = useState(true);


### PR DESCRIPTION
The list is not filtered anymore when the debug mode is enabled.

> [!NOTE]
> Thanks to Zejily for reporting this bug.

![2026-04-1418-42-19-ezgif com-video-to-gif-converter(1)](https://github.com/user-attachments/assets/626a6780-9557-473f-9eeb-925178b0e442)

