### PR TITLE
editoast: remove exception key from OccurrenceId enum

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -1862,14 +1862,11 @@ paths:
                         - train_schedule_id
                         - index
                         - exception_id
-                        - exception_key
                         - type
                         properties:
                           exception_id:
                             type: integer
                             format: int64
-                          exception_key:
-                            type: string
                           index:
                             type: integer
                             minimum: 0
@@ -1884,14 +1881,11 @@ paths:
                         required:
                         - train_schedule_id
                         - exception_id
-                        - exception_key
                         - type
                         properties:
                           exception_id:
                             type: integer
                             format: int64
-                          exception_key:
-                            type: string
                           train_schedule_id:
                             type: integer
                             format: int64
@@ -4479,14 +4473,11 @@ paths:
                             - train_schedule_id
                             - index
                             - exception_id
-                            - exception_key
                             - type
                             properties:
                               exception_id:
                                 type: integer
                                 format: int64
-                              exception_key:
-                                type: string
                               index:
                                 type: integer
                                 minimum: 0
@@ -4501,14 +4492,11 @@ paths:
                             required:
                             - train_schedule_id
                             - exception_id
-                            - exception_key
                             - type
                             properties:
                               exception_id:
                                 type: integer
                                 format: int64
-                              exception_key:
-                                type: string
                               train_schedule_id:
                                 type: integer
                                 format: int64
@@ -5148,14 +5136,11 @@ components:
               - train_schedule_id
               - index
               - exception_id
-              - exception_key
               - type
               properties:
                 exception_id:
                   type: integer
                   format: int64
-                exception_key:
-                  type: string
                 index:
                   type: integer
                   minimum: 0
@@ -5170,14 +5155,11 @@ components:
               required:
               - train_schedule_id
               - exception_id
-              - exception_key
               - type
               properties:
                 exception_id:
                   type: integer
                   format: int64
-                exception_key:
-                  type: string
                 train_schedule_id:
                   type: integer
                   format: int64
@@ -8465,10 +8447,10 @@ components:
         context:
           type: object
           required:
-          - exception_key
+          - exception_id
           properties:
-            exception_key:
-              type: string
+            exception_id:
+              type: integer
         message:
           type: string
         status:
@@ -10490,7 +10472,8 @@ components:
             items:
               $ref: '#/components/schemas/core.SignalUpdate'
           propertyNames:
-            type: string
+            type: integer
+            format: int64
         train_schedule:
           type: array
           items:
@@ -11629,7 +11612,8 @@ components:
             items:
               $ref: '#/components/schemas/SpaceTimeCurve'
           propertyNames:
-            type: string
+            type: integer
+            format: int64
         train_schedule:
           type: array
           items:
@@ -14817,11 +14801,12 @@ components:
       properties:
         exceptions:
           type: object
-          description: The key is the `exception_key`
+          description: The key is the `exception_id`
           additionalProperties:
             $ref: '#/components/schemas/SimulationSummaryResult'
           propertyNames:
-            type: string
+            type: integer
+            format: int64
         train_schedule:
           $ref: '#/components/schemas/SimulationSummaryResult'
     Version:

--- a/editoast/src/models/train_schedule.rs
+++ b/editoast/src/models/train_schedule.rs
@@ -202,14 +202,7 @@ impl TrainSchedule {
             .filter(|exception| exception.occurrence_index.is_none())
             .map(|exception| {
                 (
-                    OccurrenceId::new_created(
-                        self.id,
-                        exception.id,
-                        exception
-                            .key
-                            .clone()
-                            .unwrap_or_else(|| exception.id.to_string()),
-                    ),
+                    OccurrenceId::new_created(self.id, exception.id),
                     self.apply_train_schedule_exception(exception),
                 )
             })
@@ -248,10 +241,6 @@ impl TrainSchedule {
                         self.id,
                         occurrence_index as usize,
                         exception.id,
-                        exception
-                            .key
-                            .clone()
-                            .unwrap_or_else(|| exception.id.to_string()),
                     );
                     *occurrence = (
                         occurrence_id,
@@ -366,12 +355,10 @@ pub enum OccurrenceId {
         train_schedule_id: i64,
         index: usize,
         exception_id: i64,
-        exception_key: String, // TODO remove it
     },
     Created {
         train_schedule_id: i64,
         exception_id: i64,
-        exception_key: String, // TODO remove it
     },
 }
 
@@ -385,21 +372,19 @@ impl OccurrenceId {
     }
 
     /// Create a new `Occurrence::Modified` without an exception key.
-    pub fn new_modified(id: i64, index: usize, exception_id: i64, exception_key: String) -> Self {
+    pub fn new_modified(id: i64, index: usize, exception_id: i64) -> Self {
         OccurrenceId::Modified {
             train_schedule_id: id,
             index,
             exception_id,
-            exception_key,
         }
     }
 
     /// Creates a new `Occurrence::Created`.
-    pub fn new_created(id: i64, exception_id: i64, exception_key: String) -> Self {
+    pub fn new_created(id: i64, exception_id: i64) -> Self {
         OccurrenceId::Created {
             train_schedule_id: id,
             exception_id,
-            exception_key,
         }
     }
 }
@@ -415,15 +400,11 @@ impl Display for OccurrenceId {
                 train_schedule_id: id,
                 index,
                 exception_id,
-                ..
             } => write!(f, "{}@{}#{}", id, exception_id, index),
             OccurrenceId::Created {
                 train_schedule_id: id,
                 exception_id,
-                ..
-            } => {
-                write!(f, "{}@{}", id, exception_id)
-            }
+            } => write!(f, "{}@{}", id, exception_id),
         }
     }
 }
@@ -782,9 +763,9 @@ mod tests {
         assert_eq!(
             types,
             vec![
-                OccurrenceId::new_modified(paced_train.id, 1, 1, "key_1".into()),
+                OccurrenceId::new_modified(paced_train.id, 1, 1),
                 OccurrenceId::new_base(paced_train.id, 2),
-                OccurrenceId::new_created(paced_train.id, 2, "key_2".into()),
+                OccurrenceId::new_created(paced_train.id, 2),
                 OccurrenceId::new_base(paced_train.id, 3),
             ]
         );
@@ -846,14 +827,7 @@ mod tests {
             types,
             vec![
                 OccurrenceId::new_base(paced_train.id, 0),
-                OccurrenceId::new_modified(
-                    paced_train.id,
-                    1,
-                    exception_1.id,
-                    exception_1
-                        .key
-                        .unwrap_or_else(|| exception_1.id.to_string())
-                ),
+                OccurrenceId::new_modified(paced_train.id, 1, exception_1.id),
                 OccurrenceId::new_base(paced_train.id, 2),
                 OccurrenceId::new_base(paced_train.id, 3),
             ]

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -91,9 +91,9 @@ enum TrainScheduleError {
     #[error("Infra '{infra_id}', could not be found")]
     #[editoast_error(status = 404)]
     InfraNotFound { infra_id: i64 },
-    #[error("Exception '{exception_key}', could not be found")]
+    #[error("Exception '{exception_id}', could not be found")]
     #[editoast_error(status = 404)]
-    ExceptionNotFound { exception_key: String },
+    ExceptionNotFound { exception_id: i64 },
     #[error("Rolling stock '{rolling_stock_name}', could not be found")]
     #[editoast_error(status = 404)]
     RollingStockNotFound { rolling_stock_name: String },
@@ -284,14 +284,14 @@ pub(in crate::views) struct SimulationBatchForm {
 #[schema(as = TrainScheduleSimulationSummaryResult)]
 pub(in crate::views) struct TrainScheduleSummaryResponse {
     pub train_schedule: SummaryResponse,
-    /// The key is the `exception_key`
-    pub exceptions: HashMap<String, SummaryResponse>,
+    /// The key is the `exception_id`
+    pub exceptions: HashMap<i64, SummaryResponse>,
 }
 
 #[derive(Default)]
 struct TrainScheduleSummaryResponseBuilder {
     train_schedule: Option<SummaryResponse>,
-    exceptions: HashMap<String, SummaryResponse>,
+    exceptions: HashMap<i64, SummaryResponse>,
 }
 
 impl TrainScheduleSummaryResponseBuilder {
@@ -300,12 +300,8 @@ impl TrainScheduleSummaryResponseBuilder {
         self
     }
     // Can be called multiple times for each exception to add
-    fn add_exception(
-        &mut self,
-        exception_key: String,
-        summary_response: SummaryResponse,
-    ) -> &mut Self {
-        self.exceptions.insert(exception_key, summary_response);
+    fn add_exception(&mut self, exception_id: i64, summary_response: SummaryResponse) -> &mut Self {
+        self.exceptions.insert(exception_id, summary_response);
         self
     }
     /// Only returns None if no summary response is available for the base occurrence
@@ -509,11 +505,9 @@ pub(in crate::views) async fn simulation_summary(
                         train_schedule_id,
                         index: _,
                         exception_id: _,
-                        exception_key: _,
                     }
                     | OccurrenceId::Created {
                         train_schedule_id,
-                        exception_key: _,
                         exception_id: _,
                     } => *train_schedule_id,
                 })
@@ -600,16 +594,14 @@ pub(in crate::views) async fn simulation_summary(
                     OccurrenceId::Modified {
                         train_schedule_id,
                         index: _,
-                        exception_id: _,
-                        exception_key,
+                        exception_id,
                     }
                     | OccurrenceId::Created {
                         train_schedule_id,
-                        exception_id: _,
-                        exception_key,
+                        exception_id,
                     } => {
                         let builder = simulation_summaries.entry(train_schedule_id).or_default();
-                        builder.add_exception(exception_key, summary_response);
+                        builder.add_exception(exception_id, summary_response);
                     }
                 }
                 simulation_summaries
@@ -696,10 +688,7 @@ pub(in crate::views) async fn get_path(
         Some(exception_id) => {
             let exception =
                 TrainScheduleException::retrieve_or_fail(conn.clone(), exception_id, || {
-                    TrainScheduleError::ExceptionNotFound {
-                        // TODO rename to exception_id
-                        exception_key: exception_id.to_string(),
-                    }
+                    TrainScheduleError::ExceptionNotFound { exception_id }
                 })
                 .await?;
             train_schedule.apply_train_schedule_exception(&exception.into())
@@ -788,12 +777,7 @@ pub(in crate::views) async fn simulation(
             let exception = TrainScheduleException::retrieve_or_fail(
                 db_pool.get().await?,
                 exception_id,
-                || {
-                    TrainScheduleError::ExceptionNotFound {
-                        // TODO rename to exception_id
-                        exception_key: exception_id.to_string(),
-                    }
-                },
+                || TrainScheduleError::ExceptionNotFound { exception_id },
             )
             .await?;
             train_schedule.apply_train_schedule_exception(&exception.into())
@@ -883,9 +867,7 @@ pub(in crate::views) async fn etcs_braking_curves(
                 TrainScheduleException::retrieve_or_fail(
                     db_pool.get().await?,
                     exception_id,
-                    || TrainScheduleError::ExceptionNotFound {
-                        exception_key: exception_id.to_string(),
-                    },
+                    || TrainScheduleError::ExceptionNotFound { exception_id },
                 )
                 .await?
                 .into();
@@ -973,7 +955,7 @@ pub struct ProjectPathTrainScheduleResult {
     /// Train schedule
     pub train_schedule: Vec<SpaceTimeCurve>,
     /// Exceptions whose projection is different from the train schedule when it has a paced
-    pub exceptions: HashMap<String, Vec<SpaceTimeCurve>>,
+    pub exceptions: HashMap<i64, Vec<SpaceTimeCurve>>,
 }
 
 /// Projects the space-time curves and paths of a number of train schedules onto a given path.
@@ -1096,16 +1078,13 @@ pub(in crate::views) async fn project_path(
     let results = simulation_contexts.into_iter().enumerate().fold(
         HashMap::<i64, ProjectPathTrainScheduleResult>::new(),
         |mut results, (index, simulation_context)| {
-            if let Some(exception_key) = simulation_context.exception_id {
+            if let Some(exception_id) = simulation_context.exception_id {
                 if !Arc::ptr_eq(&base_project_path, &project_path_result[index]) {
                     results
                         .get_mut(&simulation_context.train_schedule_id)
                         .expect("train_schedule_id should exist")
                         .exceptions
-                        .insert(
-                            exception_key.to_string(),
-                            (*project_path_result[index]).clone(),
-                        );
+                        .insert(exception_id, (*project_path_result[index]).clone());
                 }
             } else {
                 results.insert(
@@ -1260,12 +1239,12 @@ pub(in crate::views) async fn project_path_op(
             match id {
                 OccurrenceId::Modified {
                     train_schedule_id,
-                    exception_key,
+                    exception_id,
                     ..
                 }
                 | OccurrenceId::Created {
                     train_schedule_id,
-                    exception_key,
+                    exception_id,
                     ..
                 } => {
                     if !Arc::ptr_eq(&base_project_path, &projected_train) {
@@ -1276,7 +1255,7 @@ pub(in crate::views) async fn project_path_op(
                                 exceptions: HashMap::new(),
                             })
                             .exceptions
-                            .insert(exception_key, (*projected_train).clone());
+                            .insert(exception_id, (*projected_train).clone());
                     }
                 }
                 OccurrenceId::Base {
@@ -1306,8 +1285,8 @@ pub struct OccupancyBlocksTrainScheduleResult {
     #[schema(value_type = Vec<SignalUpdate>)]
     pub train_schedule: OccupancyBlocks,
     /// Exceptions whose blocks are different from the paced train
-    #[schema(value_type = HashMap<String, Vec<SignalUpdate>>)]
-    pub exceptions: HashMap<String, OccupancyBlocks>,
+    #[schema(value_type = HashMap<i64, Vec<SignalUpdate>>)]
+    pub exceptions: HashMap<i64, OccupancyBlocks>,
 }
 
 /// ## Important:
@@ -1425,14 +1404,14 @@ pub(in crate::views) async fn occupancy_blocks(
     let mut results = HashMap::<i64, OccupancyBlocksTrainScheduleResult>::new();
 
     for (index, simulation_context) in simulation_contexts.into_iter().enumerate() {
-        if let Some(exception_key) = simulation_context.exception_id {
+        if let Some(exception_id) = simulation_context.exception_id {
             if !Arc::ptr_eq(&base_occupancy_blocks, &occupancy_blocks_result[index]) {
                 results
                     .get_mut(&simulation_context.train_schedule_id)
                     .expect("train_schedule_id should exist")
                     .exceptions
                     .insert(
-                        exception_key.to_string(),
+                        exception_id,
                         Arc::unwrap_or_clone(occupancy_blocks_result[index].clone()),
                     );
             }
@@ -2508,7 +2487,7 @@ mod tests {
         .await;
 
         // Add one exception which will change the simulation from base
-        let _exception_2 = create_train_schedule_exception(
+        let exception_2 = create_train_schedule_exception(
             &mut db_pool.get_ok(),
             timetable.id,
             train_schedule.id,
@@ -2522,7 +2501,7 @@ mod tests {
         .await;
 
         // Add one exception which will change the simulation from base with another rolling stock
-        let _exception_3 = create_train_schedule_exception(
+        let exception_3 = create_train_schedule_exception(
             &mut db_pool.get_ok(),
             timetable.id,
             train_schedule.id,
@@ -2541,7 +2520,7 @@ mod tests {
         .await;
 
         // Add one exception with a different path whose path item don’t exists
-        let _exception_3 = create_train_schedule_exception(
+        let exception_4 = create_train_schedule_exception(
             &mut db_pool.get_ok(),
             timetable.id,
             train_schedule.id,
@@ -2599,7 +2578,7 @@ mod tests {
         );
 
         assert_eq!(
-            exceptions.get("change_rolling_stock").unwrap(),
+            exceptions.get(&exception_3.id).unwrap(),
             // Simulation of the exception is the same than base
             // because all simulation results from core are identical stubs
             &SummaryResponse::Success {
@@ -2614,7 +2593,7 @@ mod tests {
             }
         );
         assert_eq!(
-            exceptions.get("change_initial_speed").unwrap(),
+            exceptions.get(&exception_2.id).unwrap(),
             // Simulation of the exception is the same than base
             // because all simulation results from core are identical stubs
             &SummaryResponse::Success {
@@ -2629,7 +2608,7 @@ mod tests {
             }
         );
         assert_eq!(
-            exceptions.get("unknown_path_item").unwrap(),
+            exceptions.get(&exception_4.id).unwrap(),
             &SummaryResponse::PathfindingInputError(PathfindingInputError::InvalidPathItems {
                 items: vec![
                     InvalidPathItem {

--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -279,7 +279,7 @@
     "train_schedule": {
       "BatchNotFound": "'{{count}}' train schedule(s) could not be found",
       "Database": "Internal error (database)",
-      "ExceptionNotFound": "Exception '{{exception_key}}' could not be found",
+      "ExceptionNotFound": "Exception '{{exception_id}}' could not be found",
       "InfraNotFound": "Infrastructure '{{infra_id}}' could not be found",
       "NotFound": "Train schedule '{{train_schedule_id}}' could not be found",
       "PathfindingFailed": "Pathfinding failed for train schedule '{{train_schedule_id}}'",

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -279,7 +279,7 @@
     "train_schedule": {
       "BatchNotFound": "'{{count}}' circulation(s) sont introuvable(s)",
       "Database": "Erreur interne (base de données)",
-      "ExceptionNotFound": "Exception '{{exception_key}}' non trouvée",
+      "ExceptionNotFound": "Exception '{{exception_id}}' non trouvée",
       "InfraNotFound": "Infrastructure '{{infra_id}}' non trouvée",
       "NotFound": "Circulation '{{train_schedule_id}}' non trouvée",
       "PathfindingFailed": "La recherche de chemin n'a pas abouti pour la circulation '{{train_schedule_id}}'",

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -2030,14 +2030,12 @@ export type PostLevelCrossingOccupancyApiResponse =
         }
       | {
           exception_id: number;
-          exception_key: string;
           index: number;
           train_schedule_id: number;
           type: 'modified';
         }
       | {
           exception_id: number;
-          exception_key: string;
           train_schedule_id: number;
           type: 'created';
         }
@@ -2701,14 +2699,12 @@ export type PostTrainSchedulesTrackOccupancyApiResponse =
         }
       | {
           exception_id: number;
-          exception_key: string;
           index: number;
           train_schedule_id: number;
           type: 'modified';
         }
       | {
           exception_id: number;
-          exception_key: string;
           train_schedule_id: number;
           type: 'created';
         }
@@ -4499,14 +4495,12 @@ export type Conflict = {
       }
     | {
         exception_id: number;
-        exception_key: string;
         index: number;
         train_schedule_id: number;
         type: 'modified';
       }
     | {
         exception_id: number;
-        exception_key: string;
         train_schedule_id: number;
         type: 'created';
       }
@@ -5079,7 +5073,7 @@ export type SimulationSummaryResult =
       status: 'pathfinding_input_error';
     });
 export type TrainScheduleSimulationSummaryResult = {
-  /** The key is the `exception_key` */
+  /** The key is the `exception_id` */
   exceptions: {
     [key: string]: SimulationSummaryResult;
   };

--- a/front/src/modules/conflict/__tests__/utils.spec.ts
+++ b/front/src/modules/conflict/__tests__/utils.spec.ts
@@ -26,7 +26,7 @@ describe('addTrainNamesToConflicts', () => {
       train_ids: [
         { train_schedule_id: 10, type: 'base', index: 0 },
         { train_schedule_id: 20, type: 'base', index: 8 },
-        { train_schedule_id: 20, type: 'created', exception_key: '1', exception_id: 1 },
+        { train_schedule_id: 20, type: 'created', exception_id: 1 },
       ],
     });
 


### PR DESCRIPTION
When the feature branch will be merge, `exception_key` won't be used anymore !


> [!NOTE]
> This PR targets a feature branch. 