### PR TITLE
editoast: paced train exceptions data migration

### DIFF
--- a/editoast/migrations/2026-04-15-141109-0000_paced_train_exceptions_data_migration/down.sql
+++ b/editoast/migrations/2026-04-15-141109-0000_paced_train_exceptions_data_migration/down.sql
@@ -1,0 +1,34 @@
+UPDATE train_schedule
+SET exceptions = sub.reconstructed_exceptions
+FROM (
+    SELECT
+        train_schedule_id,
+        jsonb_agg(
+            change_groups
+            || jsonb_build_object('disabled', disabled)
+            || CASE
+                WHEN occurrence_index IS NOT NULL
+                THEN jsonb_build_object('occurrence_index', occurrence_index)
+                ELSE '{}'::jsonb
+            END
+            || CASE
+                WHEN key IS NOT NULL
+                THEN jsonb_build_object('key', key)
+                ELSE '{}'::jsonb
+            END
+            ORDER BY occurrence_index ASC NULLS LAST
+        ) AS reconstructed_exceptions
+    FROM (
+        SELECT DISTINCT
+            train_schedule_id,
+            key,
+            occurrence_index,
+            disabled,
+            change_groups
+        FROM train_schedule_exception
+    ) distinct_exceptions
+    GROUP BY train_schedule_id
+) sub
+WHERE train_schedule.id = sub.train_schedule_id;
+
+DELETE FROM train_schedule_exception;

--- a/editoast/migrations/2026-04-15-141109-0000_paced_train_exceptions_data_migration/up.sql
+++ b/editoast/migrations/2026-04-15-141109-0000_paced_train_exceptions_data_migration/up.sql
@@ -1,0 +1,28 @@
+INSERT INTO train_schedule_exception (
+    timetable_id,
+    train_schedule_id,
+    key,
+    occurrence_index,
+    disabled,
+    change_groups
+)
+SELECT
+	timetable_train_schedule_set.timetable_id AS timetable_id,
+	train_schedule.id AS train_schedule_id,
+    elem->>'key' AS key,
+    (elem->>'occurrence_index')::INTEGER AS occurrence_index,
+    COALESCE((elem->>'disabled')::BOOLEAN, FALSE) AS disabled,
+    (elem - 'occurrence_index' - 'disabled' - 'key') AS change_groups
+FROM
+    train_schedule
+JOIN train_schedule_set ON train_schedule_set.id = train_schedule.train_schedule_set_id
+JOIN timetable_train_schedule_set ON timetable_train_schedule_set.train_schedule_set_id  = train_schedule_set.id
+CROSS JOIN
+    jsonb_array_elements(train_schedule.exceptions) AS elem
+WHERE
+	train_schedule.exceptions IS NOT NULL
+	AND jsonb_array_length(train_schedule.exceptions) > 0;
+
+UPDATE train_schedule
+SET exceptions = '[]'::jsonb
+WHERE jsonb_array_length(train_schedule.exceptions) > 0;


### PR DESCRIPTION
Part of https://github.com/OpenRailAssociation/osrd/issues/15202

This PR move existing paced train exceptions in `train_schedule.exceptions` json to the new table `train_schedule_exceptions`
The removal of `train_schedule.exceptions` will be done in another PR

> [!NOTE]
> This PR targets a feature branch and may contain all its commits, as it has not been rebased yet. Only the last commit need to be reviewed.