### PR TITLE
editoast: authz: migrate get_infra_readers, get_infra_writers and get_infra_owners to v2

### DIFF
--- a/editoast/authz/src/model.rs
+++ b/editoast/authz/src/model.rs
@@ -6,7 +6,7 @@ use strum::EnumIter;
 use strum::EnumString;
 use utoipa::ToSchema;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, derive_more::From)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, derive_more::From)]
 pub enum Subject {
     User(User),
     Group(Group),
@@ -76,6 +76,8 @@ impl AsRef<Group> for Subject {
     Copy,
     PartialEq,
     Eq,
+    PartialOrd,
+    Ord,
     Hash,
 )]
 pub struct User(pub i64);
@@ -91,6 +93,8 @@ pub struct User(pub i64);
     Clone,
     Copy,
     PartialEq,
+    PartialOrd,
+    Ord,
     Eq,
     Hash,
 )]

--- a/editoast/authz/src/regulator.rs
+++ b/editoast/authz/src/regulator.rs
@@ -436,7 +436,9 @@ impl<S: StorageDriver> Regulator<S> {
             && subject_grant == InfraGrant::Owner
             && new_grant < subject_grant
         {
-            let current_owners = self.get_infra_owners(infra).await?;
+            let current_owners = authorize
+                .access_value(crate::v2::infra_granted_subjects(*infra, InfraGrant::Owner))
+                .await?;
             if current_owners.len() == 1 && current_owners.contains(subject) {
                 return Ok(Authorization::Denied {
                     reason: "cannot demote the last owner",
@@ -493,7 +495,10 @@ impl<S: StorageDriver> Regulator<S> {
         };
 
         if is_subject_owner {
-            let current_owners = self.get_infra_owners(infra).await?;
+            let authorize = crate::v2::special_authorizers::Authorize(&self.openfga);
+            let current_owners = authorize
+                .access_value(crate::v2::infra_granted_subjects(*infra, InfraGrant::Owner))
+                .await?;
             if current_owners.len() == 1 && current_owners.contains(subject) {
                 return Ok(Authorization::Denied {
                     reason: "cannot remove the last owner from infrastructure",

--- a/editoast/authz/src/regulator.rs
+++ b/editoast/authz/src/regulator.rs
@@ -2,7 +2,6 @@ use std::collections::HashSet;
 use std::future::Future;
 
 use fga::client::QueryError;
-use fga::client::UserList;
 use fga::model::Relation;
 use tracing::Level;
 
@@ -232,84 +231,6 @@ impl<S: StorageDriver> Regulator<S> {
             }
         };
         Ok(Authorization::from_privilege_check(check))
-    }
-
-    #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
-    pub async fn get_infra_readers(&self, infra: &Infra) -> Result<Vec<Subject>, Error<S::Error>> {
-        // Check if the infra exists
-        if !self
-            .driver
-            .infra_exists(infra.0)
-            .await
-            .map_err(Error::Storage)?
-        {
-            return Err(Error::UnknownResource(infra.0));
-        }
-
-        let (UserList { users, .. }, groups) = tokio::try_join!(
-            self.openfga.list_users(Infra::reader().query_users(infra)),
-            self.openfga
-                .list_usersets(Infra::reader().query_usersets(Group::member(), infra))
-        )
-        .map_err(QueryError::parsing_ok)?;
-
-        Ok(users
-            .into_iter()
-            .map(Subject::User)
-            .chain(groups.into_iter().map(Subject::Group))
-            .collect())
-    }
-
-    #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
-    pub async fn get_infra_writers(&self, infra: &Infra) -> Result<Vec<Subject>, Error<S::Error>> {
-        // Check if the infra exists
-        if !self
-            .driver
-            .infra_exists(infra.0)
-            .await
-            .map_err(Error::Storage)?
-        {
-            return Err(Error::UnknownResource(infra.0));
-        }
-
-        let (UserList { users, .. }, groups) = tokio::try_join!(
-            self.openfga.list_users(Infra::writer().query_users(infra)),
-            self.openfga
-                .list_usersets(Infra::writer().query_usersets(Group::member(), infra))
-        )
-        .map_err(QueryError::parsing_ok)?;
-
-        Ok(users
-            .into_iter()
-            .map(Subject::User)
-            .chain(groups.into_iter().map(Subject::Group))
-            .collect())
-    }
-
-    #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
-    pub async fn get_infra_owners(&self, infra: &Infra) -> Result<Vec<Subject>, Error<S::Error>> {
-        // Check if the infra exists
-        if !self
-            .driver
-            .infra_exists(infra.0)
-            .await
-            .map_err(Error::Storage)?
-        {
-            return Err(Error::UnknownResource(infra.0));
-        }
-
-        let (UserList { users, .. }, groups) = tokio::try_join!(
-            self.openfga.list_users(Infra::owner().query_users(infra)),
-            self.openfga
-                .list_usersets(Infra::owner().query_usersets(Group::member(), infra))
-        )
-        .map_err(QueryError::parsing_ok)?;
-
-        Ok(users
-            .into_iter()
-            .map(Subject::User)
-            .chain(groups.into_iter().map(Subject::Group))
-            .collect())
     }
 
     /// Get IDS of infras a subject can read

--- a/editoast/authz/src/v2/infra.rs
+++ b/editoast/authz/src/v2/infra.rs
@@ -1,7 +1,10 @@
 use std::collections::HashSet;
 
+use fga::client::QueryError;
+use fga::client::UserList;
 use fga::model::Relation as _;
 use futures::FutureExt as _;
+use itertools::Itertools as _;
 
 use crate::Group;
 use crate::Infra;
@@ -175,6 +178,76 @@ pub fn infra_privileges(user: User, infra: Infra) -> Protected<HashSet<InfraPriv
         InfraPrivilege::CanRead,
         infra,
     ))
+}
+
+/// Return an operation that checks the list of subjects which have the given grant on an infra.
+pub fn infra_granted_subjects(infra: Infra, grant: InfraGrant) -> Protected<Vec<Subject>> {
+    fn get_granted_users(infra: Infra, grant: InfraGrant) -> Protected<Vec<User>> {
+        Protected::new(move |openfga| {
+            async move {
+                match grant {
+                    InfraGrant::Reader => {
+                        openfga
+                            .list_users(Infra::reader().query_users(&infra))
+                            .await
+                    }
+                    InfraGrant::Writer => {
+                        openfga
+                            .list_users(Infra::writer().query_users(&infra))
+                            .await
+                    }
+                    InfraGrant::Owner => {
+                        openfga.list_users(Infra::owner().query_users(&infra)).await
+                    }
+                }
+                .map(|UserList { users, .. }| users)
+                .map_err(QueryError::parsing_ok)
+            }
+            .boxed()
+        })
+    }
+    fn get_granted_groups(infra: Infra, grant: InfraGrant) -> Protected<Vec<Group>> {
+        Protected::new(move |openfga| {
+            async move {
+                match grant {
+                    InfraGrant::Reader => {
+                        openfga
+                            .list_usersets(Infra::reader().query_usersets(Group::member(), &infra))
+                            .await
+                    }
+                    InfraGrant::Writer => {
+                        openfga
+                            .list_usersets(Infra::writer().query_usersets(Group::member(), &infra))
+                            .await
+                    }
+                    InfraGrant::Owner => {
+                        openfga
+                            .list_usersets(Infra::owner().query_usersets(Group::member(), &infra))
+                            .await
+                    }
+                }
+                .map_err(QueryError::parsing_ok)
+            }
+            .boxed()
+        })
+    }
+    get_granted_users(infra, grant)
+        .zip(get_granted_groups(infra, grant))
+        .map(move |_, (users, groups)| {
+            async move {
+                Ok(users
+                    .into_iter()
+                    .map(Subject::User)
+                    .chain(groups.into_iter().map(Subject::Group))
+                    .collect_vec())
+            }
+            .boxed()
+        })
+        .with_guardrail(Guardrail::IssuerHasInfraPrivilege(
+            InfraPrivilege::CanRead,
+            infra,
+        ))
+        .with_check(SanityCheck::InfraExists(infra))
 }
 
 #[cfg(test)]
@@ -405,5 +478,36 @@ mod tests {
             openfga.infra_privileges(User(1), Infra(1)).await,
             HashSet::new(),
         );
+    }
+
+    #[tokio::test]
+    async fn infra_granted_subjects() {
+        let openfga = crate::authz_client!();
+        openfga
+            .prepare_writes()
+            .write(&Infra::reader().tuple(&User(1), &Infra(1)))
+            .write(&Infra::writer().tuple(&User(2), &Infra(1)))
+            .write(&Group::member().tuple(&User(3), &Group(1)))
+            .write(&Infra::writer().tuple(Group::member().userset(&Group(1)), &Infra(1)))
+            .execute()
+            .await
+            .unwrap();
+        assert_eq!(
+            openfga
+                .infra_granted_subjects(Infra(1), InfraGrant::Reader)
+                .await,
+            vec![Subject::User(User(1))]
+        );
+        let mut response = openfga
+            .infra_granted_subjects(Infra(1), InfraGrant::Writer)
+            .await;
+        let mut expected = vec![
+            Subject::user(2),  // Direct relationship
+            Subject::user(3),  // Indirect relationship
+            Subject::group(1), // Direct relationship
+        ];
+        expected.sort();
+        response.sort();
+        assert_eq!(response, expected);
     }
 }

--- a/editoast/authz/src/v2/test_client_ext.rs
+++ b/editoast/authz/src/v2/test_client_ext.rs
@@ -11,6 +11,7 @@ use crate::Subject;
 use crate::User;
 use crate::v2::infra_direct_grant;
 use crate::v2::infra_effective_grant;
+use crate::v2::infra_granted_subjects;
 use crate::v2::infra_privileges;
 use crate::v2::special_authorizers;
 
@@ -24,6 +25,7 @@ pub trait TestClientExt {
         infra: Infra,
     ) -> Option<InfraGrant>;
     async fn infra_privileges(&self, user: User, infra: Infra) -> HashSet<InfraPrivilege>;
+    async fn infra_granted_subjects(&self, infra: Infra, grant: InfraGrant) -> Vec<Subject>;
 }
 
 impl TestClientExt for fga::Client {
@@ -70,6 +72,14 @@ impl TestClientExt for fga::Client {
         let authorize = special_authorizers::Authorize(self);
         authorize
             .access_value(infra_privileges(user, infra))
+            .await
+            .unwrap()
+    }
+
+    async fn infra_granted_subjects(&self, infra: Infra, grant: InfraGrant) -> Vec<Subject> {
+        let authorize = special_authorizers::Authorize(self);
+        authorize
+            .access_value(infra_granted_subjects(infra, grant))
             .await
             .unwrap()
     }

--- a/editoast/src/views.rs
+++ b/editoast/src/views.rs
@@ -94,7 +94,7 @@ fn service_router() -> server::router::DocumentedRouter {
                 path.route("/grants", post!(authz::update_grants))
                     .route(
                         "/{resource_type}/{resource_id}",
-                        get!(authz::subjects_with_grant_on_resource),
+                        get!(authz::my_grants_on_ressource),
                     )
                     .nests("/me", |path| {
                         path.route("/", get!(authz::whoami))

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -487,32 +487,47 @@ pub(in crate::views) struct SubjectGrant {
     ),
 )]
 pub(in crate::views) async fn subjects_with_grant_on_resource(
-    Extension(authn): AuthenticationExt,
+    Extension(user): Extension<Option<authz::User>>,
+    Extension(roles): Extension<Vec<authz::Role>>,
     State(AppState {
         db_pool, regulator, ..
     }): State<AppState>,
     Path(ResourceTypeParam { resource_type }): Path<ResourceTypeParam>,
     Path(ResourceIdParam { resource_id }): Path<ResourceIdParam>,
 ) -> Result<Json<Vec<SubjectGrant>>> {
+    let Some(user) = user else {
+        return Err(AuthorizationError::Unauthorized.into());
+    };
     // Ask OpenFGA about grants on the resource
-    let (readers, writers, owners) = match resource_type {
+    let ((readers, writers), owners) = match resource_type {
         ResourceType::Infra => {
             let infra = authz::Infra(resource_id);
-            // One must be able to interact with the resource in order to
-            // consult who has access to it.
-            authn
-                .check_authorization(async |authorizer| {
-                    authorizer
-                        .authorize_infra(&infra, authz::InfraPrivilege::CanRead)
-                        .await
-                })
-                .await?;
-            tokio::try_join!(
-                regulator.get_infra_readers(&infra),
-                regulator.get_infra_writers(&infra),
-                regulator.get_infra_owners(&infra)
-            )
-            .map_err(AuthzError::from)?
+            let conn = db_pool.get().await?;
+            let openfga = regulator.openfga();
+            let authorizer = UserAuthorizer {
+                user,
+                roles,
+                openfga,
+                conn,
+            };
+            authorizer
+                .authorize(
+                    authz::v2::infra_granted_subjects(infra, InfraGrant::Reader)
+                        .zip(authz::v2::infra_granted_subjects(infra, InfraGrant::Writer))
+                        .zip(authz::v2::infra_granted_subjects(infra, InfraGrant::Owner)),
+                )
+                .await?
+                .access()
+                .await?
+                .map_err(|err| match err {
+                    Rejection::LackingInfraPrivilege(InfraPrivilege::CanRead, ..) => {
+                        AuthzError::Authz(AuthorizationError::Forbidden)
+                    }
+                    Rejection::NoSuchInfra(_) => AuthzError::UnknownResource {
+                        resource_id: infra.0,
+                    },
+                    rejection => impossible!(rejection),
+                })?
         }
     };
 

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -486,7 +486,7 @@ pub(in crate::views) struct SubjectGrant {
         (status = 200, description = "Get list of user that have a grant on the resource", body = inline(Vec<SubjectGrant>)),
     ),
 )]
-pub(in crate::views) async fn subjects_with_grant_on_resource(
+pub(in crate::views) async fn my_grants_on_ressource(
     Extension(user): Extension<Option<authz::User>>,
     Extension(roles): Extension<Vec<authz::Role>>,
     State(AppState {


### PR DESCRIPTION
Part of https://github.com/osrd-project/osrd-confidential/issues/1168: this PR takes care of the `authz::regulator::Regulator` methods `get_infra_readers`, `get_infra_writers` and `get_infra_owners` methods that it merges into a new `authz::v2` method.
- Implement a function in `authz::v2` that returns the list of users with a specific grant on an infra. 
- Replace the uses of the `authz::regulator::Regulator` methods `get_infra_readers`, `get_infra_writers` and `get_infra_owners` by the new `authz::v2` function.
-  Delete the old `Regulator` methods.