### PR TITLE
front: sort imports through oxfmt

### DIFF
--- a/front/.oxfmtrc.json
+++ b/front/.oxfmtrc.json
@@ -4,7 +4,7 @@
   "arrowParens": "always",
   "proseWrap": "always",
   "trailingComma": "es5",
-  "experimentalSortPackageJson": false,
+  "sortPackageJson": false,
   "ignorePatterns": [
     "*.md",
     "public/locales/en/infraEditor.json",
@@ -15,5 +15,48 @@
     "src/utils/__tests__/assets/*.json",
     "/ui",
     "node_modules"
-  ]
+  ],
+  "sortImports": {
+    "groups": [
+      "react",
+      "builtin",
+      ["external", "nge"],
+      "external_styles",
+      ["internal", "bare_internal"],
+      ["index", "sibling", "parent"],
+      ["style", "side_effect_style"]
+    ],
+    "customGroups": [
+      {
+        "groupName": "react",
+        "elementNamePattern": ["react"]
+      },
+      {
+        "groupName": "bare_internal",
+        "elementNamePattern": ["reducers", "store", "types"]
+      },
+      {
+        "groupName": "nge",
+        "elementNamePattern": ["@osrd-project/netzgrafik-frontend/dist/**/*"]
+      },
+      {
+        "groupName": "external_styles",
+        "elementNamePattern": ["**/dist/**/*.{css,scss}", "**/vendor/**/*.{css,scss}"]
+      }
+    ],
+    "internalPattern": [
+      "applications/",
+      "assets/",
+      "common/",
+      "config/",
+      "main/",
+      "modules/",
+      "reducers/",
+      "styles/",
+      "test-data/",
+      "utils/"
+    ],
+    "newlinesBetween": true,
+    "ignoreCase": true
+  }
 }

--- a/front/eslint.config.js
+++ b/front/eslint.config.js
@@ -56,25 +56,6 @@ export default [
       'react-hooks/set-state-in-effect': 'off',
       'react-hooks/refs': 'off',
       'react-hooks/preserve-manual-memoization': 'off',
-      'import/order': [
-        'error',
-        {
-          groups: ['builtin', 'external', 'internal'],
-          pathGroups: [
-            {
-              pattern: 'react',
-              group: 'builtin',
-              position: 'before',
-            },
-          ],
-          pathGroupsExcludedImportTypes: ['react'],
-          'newlines-between': 'always',
-          alphabetize: {
-            order: 'asc',
-            caseInsensitive: true,
-          },
-        },
-      ],
       'no-shadow': 'off',
       '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
       '@typescript-eslint/consistent-type-imports': ['error', { fixStyle: 'inline-type-imports' }],

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -19178,6 +19178,22 @@
         }
       }
     },
+    "node_modules/vite-tsconfig-paths/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/vite/node_modules/picomatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",

--- a/front/src/applications/editor/components/LinearMetadata/FormComponent.tsx
+++ b/front/src/applications/editor/components/LinearMetadata/FormComponent.tsx
@@ -33,6 +33,7 @@ import { tooltipPosition, notEmpty } from 'common/IntervalsDataViz/utils';
 import { FormBeginEndWidget } from './FormBeginEndWidget';
 import HelpModal from './HelpModal';
 import { LinearMetadataTooltip } from './tooltip';
+
 import 'common/IntervalsDataViz/style.scss';
 
 export type FormContext = {

--- a/front/src/applications/editor/tools/pointEdition/components/PointEditionLeftPanel.tsx
+++ b/front/src/applications/editor/tools/pointEdition/components/PointEditionLeftPanel.tsx
@@ -25,10 +25,10 @@ import { useInfraID } from 'common/osrdContext';
 import { save } from 'reducers/editor/thunkActions';
 import { useAppDispatch } from 'store';
 
+import type { TrackSectionEntity } from '../../trackEdition/types';
 import CustomFlagSignalCheckbox from './CustomFlagSignalCheckbox';
 import CustomPosition from './CustomPosition';
 import RoutesList from './RoutesList';
-import type { TrackSectionEntity } from '../../trackEdition/types';
 
 type EditorPoint = BufferStopEntity | DetectorEntity | SignalEntity;
 

--- a/front/src/applications/editor/tools/rangeEdition/components/GroupedTrackRangeList.tsx
+++ b/front/src/applications/editor/tools/rangeEdition/components/GroupedTrackRangeList.tsx
@@ -12,8 +12,8 @@ import type {
 import type { ExtendedEditorContextType } from 'applications/editor/types';
 import { partialIsEqual } from 'utils/object';
 
-import TrackRange from './TrackRange';
 import { trackRangeKey } from '../utils';
+import TrackRange from './TrackRange';
 
 type GroupedTrackRangeListProps = {
   displayedRanges: ApplicableTrackRange[];

--- a/front/src/applications/editor/tools/rangeEdition/components/TrackRange.tsx
+++ b/front/src/applications/editor/tools/rangeEdition/components/TrackRange.tsx
@@ -11,9 +11,9 @@ import type {
 import type { ExtendedEditorContextType } from 'applications/editor/types';
 import { LoaderFill } from 'common/Loaders';
 
+import { trackRangeKey } from '../utils';
 import TrackRangeApplicableDirections from './TrackRangeApplicableDirections';
 import TrackRangeButtons from './TrackRangeButtons';
-import { trackRangeKey } from '../utils';
 
 type TrackRangeProps = {
   index: number;

--- a/front/src/applications/editor/tools/rangeEdition/components/TrackRangeList.tsx
+++ b/front/src/applications/editor/tools/rangeEdition/components/TrackRangeList.tsx
@@ -11,9 +11,9 @@ import type {
 } from 'applications/editor/tools/rangeEdition/types';
 import type { ExtendedEditorContextType } from 'applications/editor/types';
 
+import { trackRangeKey } from '../utils';
 import GroupedTrackRangeList from './GroupedTrackRangeList';
 import TrackRange from './TrackRange';
-import { trackRangeKey } from '../utils';
 
 const DEFAULT_DISPLAYED_RANGES_COUNT = 5;
 

--- a/front/src/applications/editor/tools/rangeEdition/speedSection/SpeedSectionEditionLeftPanel.tsx
+++ b/front/src/applications/editor/tools/rangeEdition/speedSection/SpeedSectionEditionLeftPanel.tsx
@@ -28,9 +28,9 @@ import { useInfraID } from 'common/osrdContext';
 import useSpeedLimitTags from 'common/SpeedLimitTagSelector/useSpeedLimitTags';
 import { isEmptyArray, toggleElement } from 'utils/array';
 
-import SwitchList from './SwitchList';
 import RouteList from '../components/RouteList';
 import TrackRangesList from '../components/TrackRangeList';
+import SwitchList from './SwitchList';
 
 const SpeedSectionEditionLeftPanel = () => {
   const { t } = useTranslation();

--- a/front/src/applications/editor/tools/rangeEdition/tool-factory.tsx
+++ b/front/src/applications/editor/tools/rangeEdition/tool-factory.tsx
@@ -17,6 +17,7 @@ import { ConfirmModal } from 'common/BootstrapSNCF/ModalSNCF';
 import { save } from 'reducers/editor/thunkActions';
 import { getNearestPoint } from 'utils/mapHelper';
 
+import type { OptionsStateType } from '../routeEdition/types';
 import type {
   HoveredExtremityState,
   HoveredSignState,
@@ -38,7 +39,6 @@ import {
   selectPslSign,
   isNew,
 } from './utils';
-import type { OptionsStateType } from '../routeEdition/types';
 
 export type EditorRange = SpeedSectionEntity | ElectrificationEntity;
 type RangeEditionToolParams<T extends EditorRange> = {

--- a/front/src/applications/editor/tools/rangeEdition/types.ts
+++ b/front/src/applications/editor/tools/rangeEdition/types.ts
@@ -4,9 +4,9 @@ import type { TrackRange, TrackSectionEntity } from 'applications/editor/tools/t
 import type { CommonToolState } from 'applications/editor/tools/types';
 import type { EditorEntity } from 'applications/editor/typesEditorEntity';
 
+import type { OptionsStateType } from '../routeEdition/types';
 import type { APPLICABLE_DIRECTIONS } from './consts';
 import type { EditorRange } from './tool-factory';
-import type { OptionsStateType } from '../routeEdition/types';
 
 export type ApplicableDirection = (typeof APPLICABLE_DIRECTIONS)[number];
 export type PSLSign = {

--- a/front/src/applications/editor/tools/selection/tool.tsx
+++ b/front/src/applications/editor/tools/selection/tool.tsx
@@ -21,9 +21,9 @@ import { save } from 'reducers/editor/thunkActions';
 import { selectInZone } from 'utils/mapHelper';
 
 import TOOL_NAMES from '../constsToolNames';
+import type { TrackSectionEntity } from '../trackEdition/types';
 import { SelectionLayers, SelectionLeftPanel, SelectionMessages } from './components';
 import type { SelectionState } from './types';
-import type { TrackSectionEntity } from '../trackEdition/types';
 
 const SelectionTool: Tool<SelectionState> = {
   id: 'select-items',

--- a/front/src/applications/editor/tools/trackEdition/utils.ts
+++ b/front/src/applications/editor/tools/trackEdition/utils.ts
@@ -9,8 +9,8 @@ import type {
 import type { EditorEntity } from 'applications/editor/typesEditorEntity';
 import type { LinearMetadataItem } from 'common/IntervalsDataViz/types';
 
-import type { TrackEditionState } from './types';
 import { getNewLine } from '../utils';
+import type { TrackEditionState } from './types';
 
 export function getInitialState(): TrackEditionState {
   const track = getNewLine([]);

--- a/front/src/applications/operationalStudies/helpers/rankingSuggestions.ts
+++ b/front/src/applications/operationalStudies/helpers/rankingSuggestions.ts
@@ -2,6 +2,7 @@ import { uniqBy } from 'lodash';
 
 import { normalizeName, splitTokens, toUpper } from 'utils/strings';
 
+import type { OperationalPointSuggestion } from '../views/Scenario/components/ManageTimetableItem/Itinerary/ComboBoxCustomList/ListElementComponent';
 import {
   secondaryCodeStarts,
   secondaryCodeIncludes,
@@ -11,7 +12,6 @@ import {
   tokenMatchesIncludesNoCh,
   lastTokenMatchesStarts,
 } from './suggestionMatchers';
-import type { OperationalPointSuggestion } from '../views/Scenario/components/ManageTimetableItem/Itinerary/ComboBoxCustomList/ListElementComponent';
 
 /**
  * ranks and filters suggestions based on a single search token.

--- a/front/src/applications/operationalStudies/hooks/useScenarioTrainScheduleSet.ts
+++ b/front/src/applications/operationalStudies/hooks/useScenarioTrainScheduleSet.ts
@@ -13,9 +13,9 @@ import type { PacedTrainWithDetails, TimetableItemWithDetails } from 'modules/ti
 import type { TimetableItem } from 'reducers/osrdconf/types';
 import { useAppDispatch } from 'store';
 
-import { useScenarioContext } from './useScenarioContext';
 import type { TrainScheduleSetImportType } from '../views/Scenario/components/ImportTrainScheduleSets/types';
 import { sortTrainScheduleSets } from '../views/Scenario/components/Timetable/utils';
+import { useScenarioContext } from './useScenarioContext';
 
 export type TrainScheduleSetFormData = Omit<TrainScheduleSet, 'catalog_entry_id' | 'id'> & {
   catalog?: { id: number; type: 'selected' } | { name: string; type: 'create' };

--- a/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/parseXML.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/parseXML.ts
@@ -9,9 +9,9 @@ import type {
 import type { TrainSchedule, PacedTrainException } from 'common/api/osrdEditoastApi';
 import { addDurationToDate, Duration } from 'utils/duration';
 
+import { generatePacedTrainException } from '../../ManageTimetableItem/helpers/buildPacedTrainException';
 import { buildSteps, cleanTimeFormat } from './buildStepsFromOcp';
 import findMostFrequentScheduleInPacedTrain from './findMostFrequentXmlSchedule';
-import { generatePacedTrainException } from '../../ManageTimetableItem/helpers/buildPacedTrainException';
 
 const extractCiChCode = (code: string) => {
   const [ciCode, chCode] = code.split('/');

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/osrdToNge.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/osrdToNge.ts
@@ -20,6 +20,18 @@ import type { AppDispatch } from 'store';
 import { Duration, addDurationToDate } from 'utils/duration';
 
 import {
+  type PortDto,
+  type TimeLockDto,
+  type TrainrunDto,
+  type TrainrunSectionDto,
+  type TrainrunFrequency,
+  type NetzgrafikDto,
+  PortAlignment,
+  type LabelDto,
+  type TrainrunCategory,
+  type FreeFloatingTextDto,
+} from '../NGE/types';
+import {
   TRAINRUN_CATEGORY_HALTEZEITEN,
   NODE_LABEL_GROUP,
   TRAINRUN_LABEL_GROUP,
@@ -37,18 +49,6 @@ import {
   getTrainrunTimeCategoryFromFrequency,
   storeTrainPathNodes,
 } from './utils';
-import {
-  type PortDto,
-  type TimeLockDto,
-  type TrainrunDto,
-  type TrainrunSectionDto,
-  type TrainrunFrequency,
-  type NetzgrafikDto,
-  PortAlignment,
-  type LabelDto,
-  type TrainrunCategory,
-  type FreeFloatingTextDto,
-} from '../NGE/types';
 
 /**
  * Get the TrainrunFrequencies from the TimetableItems.

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/utils.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/utils.ts
@@ -14,6 +14,7 @@ import type { TimetableItem } from 'reducers/osrdconf/types';
 import type { AppDispatch } from 'store';
 import { Duration } from 'utils/duration';
 
+import type { TrainrunCategory, TrainrunFrequency, TrainrunTimeCategory } from '../NGE/types';
 import {
   CUSTOM_TRAINRUN_TIME_CATEGORY,
   DEFAULT_PACED_TRAIN_FREQUENCY_IDS,
@@ -28,7 +29,6 @@ import {
 } from './consts';
 import type MacroEditorState from './MacroEditorState';
 import type { NodeIndexed } from './MacroEditorState';
-import type { TrainrunCategory, TrainrunFrequency, TrainrunTimeCategory } from '../NGE/types';
 
 export const createMacroNode = async (
   state: MacroEditorState,

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ComboBoxCustomList/ListElementComponent.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ComboBoxCustomList/ListElementComponent.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
 
-import './ListElementComponent.scss';
 import cx from 'classnames';
+
+import './ListElementComponent.scss';
 
 export type OpSecondaryCode = {
   code: string;

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModal.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/Itinerary/ItineraryModal.tsx
@@ -35,13 +35,6 @@ import { addElementAtIndex } from 'utils/array';
 import { Duration } from 'utils/duration';
 import useModalFocusTrap from 'utils/hooks/useModalFocusTrap';
 
-import { type OperationalPointSuggestion } from './ComboBoxCustomList/ListElementComponent';
-import useMapTrackSelection from '../hooks/useMapTrackSelection';
-import { usePathStepsMetadata } from './hooks/usePathStepsMetadata';
-import ItineraryModalFormHeader from './ItineraryModalFormHeader';
-import ItineraryModalMap from './ItineraryModalMap';
-import PathStepItem from './PathStepItem';
-import { computePathStepCoordinates } from './utils';
 import { MANAGE_TIMETABLE_ITEM_TYPES } from '../../../consts';
 import {
   createEmptyPathStep,
@@ -49,7 +42,14 @@ import {
   isEmptyStep,
   deletePathStep,
 } from '../helpers/pathStepsActions';
+import useMapTrackSelection from '../hooks/useMapTrackSelection';
 import type { FeatureInfoClick } from '../types';
+import { type OperationalPointSuggestion } from './ComboBoxCustomList/ListElementComponent';
+import { usePathStepsMetadata } from './hooks/usePathStepsMetadata';
+import ItineraryModalFormHeader from './ItineraryModalFormHeader';
+import ItineraryModalMap from './ItineraryModalMap';
+import PathStepItem from './PathStepItem';
+import { computePathStepCoordinates } from './utils';
 
 type ItineraryModalProps = {
   itineraryModalIsOpen: boolean;

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/ManageTimetableItemMap/AddPathStepPopup.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/ManageTimetableItemMap/AddPathStepPopup.tsx
@@ -20,10 +20,10 @@ import { getOrigin, getDestination } from 'reducers/osrdconf/operationalStudiesC
 import type { PathStep } from 'reducers/osrdconf/types';
 import { getPointOnTrackCoordinates } from 'utils/geometry';
 
+import useMapTrackSelection from '../hooks/useMapTrackSelection';
 import type { FeatureInfoClick } from '../types';
 import OperationalPointPopupDetails from './OperationalPointPopupDetails';
 import { setPointIti } from './setPointIti';
-import useMapTrackSelection from '../hooks/useMapTrackSelection';
 
 type AddPathStepPopupProps = {
   infraId: number | undefined;

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/ManageTimetableItemMap/ManageTimetableItemMap.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/ManageTimetableItemMap/ManageTimetableItemMap.tsx
@@ -22,8 +22,8 @@ import type { MapSettings, Viewport } from 'reducers/commonMap/types';
 import { useAppDispatch } from 'store';
 import { getMapMouseEventNearestFeature } from 'utils/mapHelper';
 
-import AddPathStepPopup from './AddPathStepPopup';
 import type { FeatureInfoClick } from '../types';
+import AddPathStepPopup from './AddPathStepPopup';
 
 const OPERATIONAL_POINT_LAYERS = [
   'chartis/osrd_operational_point/geo',

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/ManageTimetableItemModal.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/ManageTimetableItemModal.tsx
@@ -7,12 +7,12 @@ import type { ImportTrainScheduleSetsPayload } from 'applications/operationalStu
 import { setFailure } from 'reducers/main';
 import { castErrorToFailure } from 'utils/error';
 
+import { MANAGE_TIMETABLE_ITEM_TYPES } from '../../consts';
+import { TrainScheduleSetCatalogDialog } from '../ImportTrainScheduleSets';
 import ManageTimetableItem from './ManageTimetableItem';
 import ManageTimetableItemLeftPanel, {
   type ManageTimetableItemLeftPanelProps,
 } from './ManageTimetableItemLeftPanel';
-import { MANAGE_TIMETABLE_ITEM_TYPES } from '../../consts';
-import { TrainScheduleSetCatalogDialog } from '../ImportTrainScheduleSets';
 
 type ManageTimetableItemModalProps = ManageTimetableItemLeftPanelProps & {
   setCollapsedTimetableEdit: () => void;

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/PacedTrainSettings/PacedTrainSettings.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/PacedTrainSettings/PacedTrainSettings.tsx
@@ -8,8 +8,8 @@ import { getTimeWindow, getInterval } from 'reducers/osrdconf/operationalStudies
 import { useAppDispatch } from 'store';
 import { Duration } from 'utils/duration';
 
-import AddedOccurrences from './AddedOccurrences';
 import { MAX_TIMEWINDOW_MINUTES } from '../consts';
+import AddedOccurrences from './AddedOccurrences';
 
 const PacedTrainSettings = () => {
   const timeWindow = useSelector(getTimeWindow).total('minute');

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/PowerRestrictionsSelector/helpers/__tests__/powerRestrictionWarnings.spec.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/PowerRestrictionsSelector/helpers/__tests__/powerRestrictionWarnings.spec.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest';
 
 import generateEffortCurvesForTests from 'modules/powerRestriction/helpers/__tests__/generateEffortCurvesForTests';
 
+import type { PowerRestrictionWarnings } from '../../types';
+import { countWarnings, getPowerRestrictionsWarnings } from '../powerRestrictionWarnings';
 import {
   pathElectrificationRanges,
   powerRestrictionRangesMixedIn2Keys,
@@ -9,8 +11,6 @@ import {
   powerRestrictionRangesWithValidRanges,
   validPowerRestrictionRanges,
 } from './sampleData';
-import type { PowerRestrictionWarnings } from '../../types';
-import { countWarnings, getPowerRestrictionsWarnings } from '../powerRestrictionWarnings';
 
 const emptyResult: PowerRestrictionWarnings = {
   invalidCombinationWarnings: [],

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/PowerRestrictionsSelector/hooks/usePowerRestrictionsSelector.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/PowerRestrictionsSelector/hooks/usePowerRestrictionsSelector.ts
@@ -14,9 +14,9 @@ import {
 } from 'reducers/osrdconf/operationalStudiesConf/selectors';
 import { mmToM } from 'utils/physics';
 
-import usePowerRestrictionsSelectorBehaviours from './usePowerRestrictionsSelectorBehaviours';
 import formatPowerRestrictions from '../helpers/formatPowerRestrictions';
 import getPowerRestrictionsWarningsData from '../helpers/powerRestrictionWarnings';
+import usePowerRestrictionsSelectorBehaviours from './usePowerRestrictionsSelectorBehaviours';
 
 const usePowerRestrictionsSelector = (
   voltageRanges: RangedValue[],

--- a/front/src/applications/operationalStudies/views/Scenario/components/RoundTrips/RoundTripsModalCard.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/RoundTrips/RoundTripsModalCard.tsx
@@ -12,8 +12,8 @@ import OSRDMenu from 'common/OSRDMenu';
 import OSRDTooltip from 'common/OSRDTooltip';
 import isMainCategory from 'modules/rollingStock/helpers/category';
 
-import type { PairDataToolTip, PairingItem } from './types';
 import { getTrainCategoryClassName } from '../Timetable/utils';
+import type { PairDataToolTip, PairingItem } from './types';
 
 type RoundTripsModalCardProps = {
   pairingItem: PairingItem;

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/OccurrenceItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/OccurrenceItem.tsx
@@ -37,9 +37,9 @@ import {
   isIndexedOccurrenceId,
 } from 'utils/trainId';
 
-import OccurrenceIndicator from './OccurrenceIndicator';
 import { formatTrainDuration } from '../utils';
 import type useOccurrenceActions from './hooks/useOccurrenceActions';
+import OccurrenceIndicator from './OccurrenceIndicator';
 
 const ConsecutiveDayDateDisplay = ({
   departureTime,

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TimetableBoardWrapper.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TimetableBoardWrapper.tsx
@@ -18,10 +18,10 @@ import { useAppDispatch } from 'store';
 import { castErrorToFailure } from 'utils/error';
 import { mapBy } from 'utils/types';
 
-import Timetable from './Timetable';
-import { copyTimetableItemsToClipboard } from './utils';
 import { validateTimetableJsonPayload } from '../ImportTimetableItem/helpers/parseJson';
 import { postFullImportPayload } from '../ImportTimetableItem/helpers/postPayloads';
+import Timetable from './Timetable';
+import { copyTimetableItemsToClipboard } from './utils';
 
 type TimetableBoardWrapperProps = {
   setDisplayTimetableItemManagement: (mode: string) => void;

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TimetableToolbar.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TimetableToolbar.tsx
@@ -24,13 +24,13 @@ import UploadFileModal from 'common/uploadFileModal';
 import type { TimetableItemWithDetails } from 'modules/timetableItem/types';
 import type { TimetableItem } from 'reducers/osrdconf/types';
 
+import { MANAGE_TIMETABLE_ITEM_TYPES } from '../../consts';
+import useImportTimetableItems from '../ImportTimetableItem';
+import RoundTripsModal from '../RoundTrips/RoundTripsModal';
 import FilterPanel from './FilterPanel';
 import SelectionToolBar from './TimetableSelectionToolbar';
 import type { TimetableFilters, TimetableMode } from './types';
 import { exportTimetableItems, timetableHasInvalidItem } from './utils';
-import { MANAGE_TIMETABLE_ITEM_TYPES } from '../../consts';
-import useImportTimetableItems from '../ImportTimetableItem';
-import RoundTripsModal from '../RoundTrips/RoundTripsModal';
 
 type TimetableToolbarProps = {
   timetableFilters: TimetableFilters;

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TrainScheduleSet/TrainScheduleSetTab.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TrainScheduleSet/TrainScheduleSetTab.tsx
@@ -22,9 +22,9 @@ import type { TrainScheduleSetManager } from 'applications/operationalStudies/ho
 import type { CatalogEntry, TrainScheduleSet } from 'common/api/osrdEditoastApi';
 import MenuTriggerButton, { type MenuProps } from 'common/MenuTriggerButton';
 
-import TrainScheduleDeleteDialog from './TrainScheduleDeleteDialog';
 import { computeTrainScheduleSetName, isSandbox } from '../utils';
 import LocalCopyTrainScheduleSetDialog from './LocalCopyTrainScheduleSetDialog';
+import TrainScheduleDeleteDialog from './TrainScheduleDeleteDialog';
 import TrainScheduleSetDialog from './TrainScheduleSetDialog';
 
 type OpenDialogName =

--- a/front/src/applications/operationalStudies/views/Study/StudyView.tsx
+++ b/front/src/applications/operationalStudies/views/Study/StudyView.tsx
@@ -25,11 +25,11 @@ import AddOrEditScenarioModal from 'modules/scenario/components/AddOrEditScenari
 import { cleanScenarioLocalStorage } from 'modules/scenario/helpers/utils';
 import { budgetFormat } from 'utils/numbers';
 
+import useMultiSelection from '../../hooks/useMultiSelection';
 import DateBox from './components/DateBox';
 import ScenarioCard from './components/ScenarioCard';
 import StateStep from './components/StateStep';
 import { type StudyState, studyStates } from './consts';
-import useMultiSelection from '../../hooks/useMultiSelection';
 
 type SortOptions =
   | 'NameAsc'

--- a/front/src/applications/rollingStockEditor/components/CurveParamSelectors.tsx
+++ b/front/src/applications/rollingStockEditor/components/CurveParamSelectors.tsx
@@ -16,8 +16,6 @@ import {
 } from 'modules/rollingStock/consts';
 
 import { EP_BY_MODE } from '../consts';
-import PowerRestrictionGridModal from './PowerRestrictionGridModal';
-import RollingStockEditorFormModal from './RollingStockEditorFormModal';
 import { sortSelectedModeCurves } from '../helpers/curves';
 import { createEmptyCurve, createEmptyCurves } from '../helpers/defaultValues';
 import { translateItemsList } from '../helpers/utils';
@@ -27,6 +25,8 @@ import type {
   ElectricalProfileByMode,
   RollingStockSelectorParams,
 } from '../types';
+import PowerRestrictionGridModal from './PowerRestrictionGridModal';
+import RollingStockEditorFormModal from './RollingStockEditorFormModal';
 
 const addNewCurveToMode = (
   effortCurves: EffortCurveForms,

--- a/front/src/applications/rollingStockEditor/components/CurveSpreadsheet.tsx
+++ b/front/src/applications/rollingStockEditor/components/CurveSpreadsheet.tsx
@@ -7,14 +7,15 @@ import {
   intColumn,
   floatColumn,
 } from '@sdziadkowiec/react-datasheet-grid';
-import '@sdziadkowiec/react-datasheet-grid/dist/style.css';
 import { useTranslation } from 'react-i18next';
+
+import '@sdziadkowiec/react-datasheet-grid/dist/style.css';
 
 import { replaceElementAtIndex } from 'utils/array';
 import { msToKmh } from 'utils/physics';
 
-import formatCurve from './formatSpreadSheetCurve';
 import type { ConditionalEffortCurveForm, DataSheetCurve, EffortCurveForms } from '../types';
+import formatCurve from './formatSpreadSheetCurve';
 
 type CurveSpreadsheetProps = {
   selectedCurve: ConditionalEffortCurveForm;

--- a/front/src/applications/rollingStockEditor/components/RollingStockEditorCurves.tsx
+++ b/front/src/applications/rollingStockEditor/components/RollingStockEditorCurves.tsx
@@ -9,8 +9,6 @@ import RollingStockCurve from 'modules/rollingStock/components/RollingStockCurve
 import { STANDARD_COMFORT_LEVEL, THERMAL_TRACTION_IDENTIFIER } from 'modules/rollingStock/consts';
 import { removeDuplicates } from 'utils/array';
 
-import CurveParamSelectors from './CurveParamSelectors';
-import CurveSpreadsheet from './CurveSpreadsheet';
 import { filterNullValueInCurve } from '../helpers/curves';
 import { orderElectricalProfils } from '../helpers/electricalValues';
 import {
@@ -22,6 +20,8 @@ import type {
   EffortCurveForms,
   RollingStockParametersValues,
 } from '../types';
+import CurveParamSelectors from './CurveParamSelectors';
+import CurveSpreadsheet from './CurveSpreadsheet';
 
 const EMPTY_PARAMS = {
   comfortLevels: [STANDARD_COMFORT_LEVEL],

--- a/front/src/applications/rollingStockEditor/components/RollingStockEditorForm.tsx
+++ b/front/src/applications/rollingStockEditor/components/RollingStockEditorForm.tsx
@@ -17,11 +17,6 @@ import { useAppDispatch } from 'store';
 import { castErrorToFailure } from 'utils/error';
 import { usePrevious } from 'utils/hooks/state';
 
-import CategoryForm from './CategoryForm';
-import MetadataForm from './MetadataForm';
-import OnboardSystemEquipmentForm from './OnboardSystemEquipmentForm';
-import ParametersForm from './ParametersForm';
-import RollingStockEditorCurves from './RollingStockEditorCurves';
 import {
   getDefaultRollingStockMode,
   getRollingStockEditorDefaultValues,
@@ -30,6 +25,11 @@ import { modifyRollingStockElectricalValues } from '../helpers/electricalValues'
 import isRollingStockFormValid from '../helpers/isRollingStockFormValid';
 import { rollingStockEditorQueryArg } from '../helpers/utils';
 import type { EffortCurveForms, RollingStockParametersValues } from '../types';
+import CategoryForm from './CategoryForm';
+import MetadataForm from './MetadataForm';
+import OnboardSystemEquipmentForm from './OnboardSystemEquipmentForm';
+import ParametersForm from './ParametersForm';
+import RollingStockEditorCurves from './RollingStockEditorCurves';
 import RollingStockEditorFormModal from './RollingStockEditorFormModal';
 
 type RollingStockParametersProps = {

--- a/front/src/applications/rollingStockEditor/helpers/utils.ts
+++ b/front/src/applications/rollingStockEditor/helpers/utils.ts
@@ -6,10 +6,10 @@ import { THERMAL_TRACTION_IDENTIFIER } from 'modules/rollingStock/consts';
 import { isElectric } from 'modules/rollingStock/helpers/electric';
 import { getTranslationKey } from 'utils/strings';
 
-import { handleUnitValue } from './units';
 import { RS_SCHEMA_PROPERTIES } from '../consts';
-import { filterNullValueInCurve } from './curves';
 import type { RollingStockParametersValidValues, EffortCurveForms, SchemaProperty } from '../types';
+import { filterNullValueInCurve } from './curves';
+import { handleUnitValue } from './units';
 
 export const rollingStockEditorQueryArg = (
   data: RollingStockParametersValidValues,

--- a/front/src/applications/stdcm/components/StdcmForm/StdcmConfig.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmConfig.tsx
@@ -51,10 +51,6 @@ import type { OsrdStdcmConfState } from 'reducers/osrdconf/types';
 import { useAppDispatch } from 'store';
 import { useDateTimeLocale } from 'utils/date';
 
-import StdcmConsist from './StdcmConsist';
-import StdcmDestination from './StdcmDestination';
-import StdcmLinkedTrainSearch from './StdcmLinkedTrainSearch';
-import StdcmOrigin from './StdcmOrigin';
 import useStaticPathfinding from '../../hooks/useStaticPathfinding';
 import type {
   ConsistData,
@@ -63,13 +59,17 @@ import type {
   StdcmProgressPoints,
   StdcmRequestStatus,
 } from '../../types';
-import StdcmMapProgressLayer from '../StdcmMapProgressLayer';
-import StdcmSimulationParams from '../StdcmSimulationParams';
-import StdcmVias from './StdcmVias';
 import { ArrivalTimeTypes, StdcmConfigErrorTypes } from '../../types';
 import checkStdcmConfigErrors from '../../utils/checkStdcmConfigErrors';
 import StdcmLoader from '../StdcmLoader';
+import StdcmMapProgressLayer from '../StdcmMapProgressLayer';
+import StdcmSimulationParams from '../StdcmSimulationParams';
 import StdcmWarningBox from '../StdcmWarningBox';
+import StdcmConsist from './StdcmConsist';
+import StdcmDestination from './StdcmDestination';
+import StdcmLinkedTrainSearch from './StdcmLinkedTrainSearch';
+import StdcmOrigin from './StdcmOrigin';
+import StdcmVias from './StdcmVias';
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/consistent-type-definitions

--- a/front/src/applications/stdcm/components/StdcmForm/StdcmConsist.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmConsist.tsx
@@ -26,8 +26,8 @@ import {
 import { removeDuplicates } from 'utils/array';
 import { createStandardSelectOptions } from 'utils/uiCoreHelpers';
 
-import StdcmCard from './StdcmCard';
 import useStdcmConsist from '../../hooks/useStdcmConsist';
+import StdcmCard from './StdcmCard';
 
 const ConsistCardTitle = ({
   rollingStock,

--- a/front/src/applications/stdcm/components/StdcmForm/StdcmDestination.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmDestination.tsx
@@ -3,11 +3,11 @@ import { useSelector } from 'react-redux';
 
 import { getStdcmDestination, getStdcmPathSteps } from 'reducers/osrdconf/stdcmConf/selectors';
 
+import type { StdcmItineraryProps } from '../../types';
+import StdcmCardMarkerIcon from '../StdcmCardMarkerIcon';
 import StdcmCard from './StdcmCard';
 import StdcmOperationalPoint from './StdcmOperationalPoint';
 import StdcmOpSchedule from './StdcmOpSchedule';
-import type { StdcmItineraryProps } from '../../types';
-import StdcmCardMarkerIcon from '../StdcmCardMarkerIcon';
 
 const StdcmDestination = ({ disabled = false, onItineraryChange }: StdcmItineraryProps) => {
   const { t } = useTranslation('stdcm');

--- a/front/src/applications/stdcm/components/StdcmForm/StdcmLinkedTrainSearch.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmLinkedTrainSearch.tsx
@@ -6,10 +6,10 @@ import { useTranslation } from 'react-i18next';
 
 import useLinkedTrainSearch from 'applications/stdcm/hooks/useLinkedTrainSearch';
 
+import type { LinkedTrainType } from '../../types';
 import StdcmCard from './StdcmCard';
 import StdcmDefaultCard from './StdcmDefaultCard';
 import StdcmLinkedTrainResults from './StdcmLinkedTrainResults';
-import type { LinkedTrainType } from '../../types';
 
 type StdcmLinkedTrainSearchProps = {
   disabled: boolean;

--- a/front/src/applications/stdcm/components/StdcmForm/StdcmOrigin.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmOrigin.tsx
@@ -3,11 +3,11 @@ import { useSelector } from 'react-redux';
 
 import { getStdcmOrigin } from 'reducers/osrdconf/stdcmConf/selectors';
 
+import type { StdcmItineraryProps } from '../../types';
+import StdcmCardMarkerIcon from '../StdcmCardMarkerIcon';
 import StdcmCard from './StdcmCard';
 import StdcmOperationalPoint from './StdcmOperationalPoint';
 import StdcmOpSchedule from './StdcmOpSchedule';
-import type { StdcmItineraryProps } from '../../types';
-import StdcmCardMarkerIcon from '../StdcmCardMarkerIcon';
 
 const StdcmOrigin = ({ disabled = false, onItineraryChange }: StdcmItineraryProps) => {
   const { t } = useTranslation('stdcm');

--- a/front/src/applications/stdcm/components/StdcmForm/StdcmVias.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmVias.tsx
@@ -13,15 +13,15 @@ import type { StdcmViaPathStep } from 'reducers/osrdconf/types';
 import { useAppDispatch } from 'store';
 import { Duration } from 'utils/duration';
 
+import { StdcmStopTypes } from '../../types';
+import type { ConsistData, ConsistErrors, StdcmItineraryProps } from '../../types';
+import StdcmCardMarkerIcon from '../StdcmCardMarkerIcon';
 import StdcmCard from './StdcmCard';
 import StdcmConsist from './StdcmConsist';
 import StdcmDefaultCard from './StdcmDefaultCard';
 import StdcmOperationalPoint from './StdcmOperationalPoint';
 import StdcmStopType from './StdcmStopType';
 import StopDurationInput from './StopDurationInput';
-import { StdcmStopTypes } from '../../types';
-import type { ConsistData, ConsistErrors, StdcmItineraryProps } from '../../types';
-import StdcmCardMarkerIcon from '../StdcmCardMarkerIcon';
 
 type StdcmViasProps = StdcmItineraryProps & {
   skipAnimation: boolean;

--- a/front/src/applications/stdcm/hooks/useStdcm.ts
+++ b/front/src/applications/stdcm/hooks/useStdcm.ts
@@ -33,11 +33,11 @@ import { useAppDispatch } from 'store';
 import { useDateTimeLocale } from 'utils/date';
 import { castErrorToFailure } from 'utils/error';
 
-import useStdcmForm from './useStdcmForm';
 import { adjustInputByDirection, adjustPayloadByDirection } from '../utils/adjustSimulationInputs';
 import fetchPathProperties from '../utils/fetchPathProperties';
 import { checkStdcmConf, formatStdcmPayload } from '../utils/formatStdcmConf';
 import computeChartData from '../utils/stdcmComputeChartData';
+import useStdcmForm from './useStdcmForm';
 
 /**
  * Hook to manage the stdcm request with integrated results and chart data handling.

--- a/front/src/applications/stdcm/utils/formatStdcmConf.ts
+++ b/front/src/applications/stdcm/utils/formatStdcmConf.ts
@@ -14,8 +14,8 @@ import type { Duration } from 'utils/duration';
 import { kmhToMs, tToKg } from 'utils/physics';
 
 import { stdcmPathStepToPathItemLocation } from '.';
-import createMargin from './createMargin';
 import { StdcmStopTypes } from '../types';
+import createMargin from './createMargin';
 
 type ValidStdcmConfig = {
   rollingStockId: number;

--- a/front/src/common/Map/Buttons/MapButtons.tsx
+++ b/front/src/common/Map/Buttons/MapButtons.tsx
@@ -34,9 +34,9 @@ import { type EditorState } from 'reducers/editor';
 import { useAppDispatch } from 'store';
 import useOutsideClick from 'utils/hooks/useOutsideClick';
 
+import { MapContextProvider, useMapContext } from '../useMapContext';
 import ButtonMapInfraErrors from './ButtonMapInfraErrors';
 import MapButton from './MapButton';
-import { MapContextProvider, useMapContext } from '../useMapContext';
 
 type MapButtonsProps = {
   map?: MapRef;

--- a/front/src/common/Map/Layers/Hillshade.tsx
+++ b/front/src/common/Map/Layers/Hillshade.tsx
@@ -1,7 +1,7 @@
 import { type LayerProps } from 'react-map-gl/maplibre';
 
-import OrderedLayer from './OrderedLayer';
 import { useMapContext } from '../useMapContext';
+import OrderedLayer from './OrderedLayer';
 
 type HillshadeProps = {
   layerOrder?: number;

--- a/front/src/common/Map/Layers/InfraObjectLayers/GeoJSONs.tsx
+++ b/front/src/common/Map/Layers/InfraObjectLayers/GeoJSONs.tsx
@@ -14,6 +14,16 @@ import { LAYER_ENTITIES_ORDERS, LAYER_GROUPS_ORDER, LAYERS } from 'config/layerO
 import type { MapSettings } from 'reducers/commonMap/types';
 import type { EditorState } from 'reducers/editor';
 
+import { lineNameLayer, lineNumberLayer, trackNameLayer } from '../commonLayers';
+import {
+  getLineErrorsLayerProps,
+  getLineTextErrorsLayerProps,
+  getPointErrorsLayerProps,
+  getPointTextErrorsLayerProps,
+} from '../Errors';
+import OrderedLayer from '../OrderedLayer';
+import { Platforms } from '../OSMLayers/Platforms';
+import type { LayerContext, LayerProps } from '../types';
 import { getBufferStopsLayerProps } from './BufferStops';
 import {
   DETECTOR_CIRCLES_DEF,
@@ -37,17 +47,7 @@ import {
   getSpeedSectionsPointLayerProps,
   getSpeedSectionsTextLayerProps,
 } from './SpeedLimits';
-import {
-  getLineErrorsLayerProps,
-  getLineTextErrorsLayerProps,
-  getPointErrorsLayerProps,
-  getPointTextErrorsLayerProps,
-} from '../Errors';
 import { getSwitchesLayerProps, getSwitchesNameLayerProps } from './Switches';
-import { lineNameLayer, lineNumberLayer, trackNameLayer } from '../commonLayers';
-import OrderedLayer from '../OrderedLayer';
-import { Platforms } from '../OSMLayers/Platforms';
-import type { LayerContext, LayerProps } from '../types';
 
 const POINT_ENTITIES_MIN_ZOOM = 12;
 

--- a/front/src/common/Map/Layers/InfraObjectLayers/Signals.tsx
+++ b/front/src/common/Map/Layers/InfraObjectLayers/Signals.tsx
@@ -6,11 +6,11 @@ import { MAP_URL } from 'common/Map/const';
 import type { Theme } from 'common/Map/theme';
 import { useMapContext } from 'common/Map/useMapContext';
 
+import OrderedLayer from '../OrderedLayer';
+import type { SignalContext } from '../types';
 import { getPointLayerProps, getSignalLayerProps } from './geoSignalsLayers';
 import getKPLabelLayerProps from './getKPLabelLayerProps';
 import getMastLayerProps from './getMastLayerProps';
-import OrderedLayer from '../OrderedLayer';
-import type { SignalContext } from '../types';
 
 type PlatformProps = {
   colors: Theme;

--- a/front/src/common/Map/Layers/InfraObjectLayers/TracksGeographic.tsx
+++ b/front/src/common/Map/Layers/InfraObjectLayers/TracksGeographic.tsx
@@ -7,8 +7,8 @@ import { lineNameLayer, lineNumberLayer, trackNameLayer } from 'common/Map/Layer
 import type { Theme } from 'common/Map/theme';
 import { useMapContext } from 'common/Map/useMapContext';
 
-import geoMainLayer from './getGeographicLayerProps';
 import OrderedLayer from '../OrderedLayer';
+import geoMainLayer from './getGeographicLayerProps';
 
 type TracksGeographicProps = {
   colors: Theme;

--- a/front/src/common/Map/Layers/InfraObjectLayers/extensions/SNCF/NeutralSections.tsx
+++ b/front/src/common/Map/Layers/InfraObjectLayers/extensions/SNCF/NeutralSections.tsx
@@ -6,8 +6,8 @@ import { MAP_URL } from 'common/Map/const';
 import type { Theme } from 'common/Map/theme';
 import { useMapContext } from 'common/Map/useMapContext';
 
-import NeutralSectionSigns from './NeutralSectionSigns';
 import OrderedLayer from '../../../OrderedLayer';
+import NeutralSectionSigns from './NeutralSectionSigns';
 
 type NeutralSectionsProps = {
   colors: Theme;

--- a/front/src/common/Map/Layers/InfraObjectLayers/extensions/SNCF/PSL.tsx
+++ b/front/src/common/Map/Layers/InfraObjectLayers/extensions/SNCF/PSL.tsx
@@ -16,9 +16,9 @@ import { useMapContext } from 'common/Map/useMapContext';
 import type { LayersSettings } from 'reducers/commonMap/types';
 import type { OmitLayer } from 'types';
 
-import SNCF_PSL_Signs from './PSLSigns';
 import OrderedLayer from '../../../OrderedLayer';
 import { getSpeedSectionsName, getFilterBySpeedSectionsTag } from '../../SpeedLimits';
+import SNCF_PSL_Signs from './PSLSigns';
 
 export function getPSLSpeedValueLayerProps({
   colors,

--- a/front/src/common/Map/Layers/OSMLayers/OSMLayers.tsx
+++ b/front/src/common/Map/Layers/OSMLayers/OSMLayers.tsx
@@ -4,8 +4,8 @@ import { colors } from 'common/Map/theme';
 import { LAYER_GROUPS_ORDER, LAYERS } from 'config/layerOrder';
 import type { MapStyle } from 'reducers/commonMap/types';
 
-import Background from './Background';
 import Hillshade from '../Hillshade';
+import Background from './Background';
 import OSM from './OSM';
 import PlatformsLayer from './Platforms';
 import TracksOSM from './TracksOSM';

--- a/front/src/common/NavBar/ChangeLanguageModal.tsx
+++ b/front/src/common/NavBar/ChangeLanguageModal.tsx
@@ -7,7 +7,8 @@ import { useTranslation } from 'react-i18next';
 import { useModal } from 'common/BootstrapSNCF/ModalSNCF';
 import ModalBodySNCF from 'common/BootstrapSNCF/ModalSNCF/ModalBodySNCF';
 import ModalHeaderSNCF from 'common/BootstrapSNCF/ModalSNCF/ModalHeaderSNCF';
-import { supportedLngs } from 'i18n';
+
+import { supportedLngs } from '../../i18n';
 
 // We don't use `t` cause language names are fixed
 export const languageName = (lng: string) => {

--- a/front/src/common/authorization/components/GrantsManagerSubjects.tsx
+++ b/front/src/common/authorization/components/GrantsManagerSubjects.tsx
@@ -5,11 +5,11 @@ import { useTranslation } from 'react-i18next';
 import generateGrantSelectProps from 'common/authorization/utils/generateGrantSelectProps';
 import { LoaderFill } from 'common/Loaders';
 
-import GrantManagerAddSubjectForm from './GrantManagerAddSubjectForm';
-import GrantsManagerSubject from './GrantsManagerSubject';
 import useAuthz from '../hooks/useAuthz';
 import useResourceListSubjects from '../hooks/useResourceListUser';
 import type { Grant, Privilege, ResourceType } from '../types';
+import GrantManagerAddSubjectForm from './GrantManagerAddSubjectForm';
+import GrantsManagerSubject from './GrantsManagerSubject';
 
 type GrantsManagerSubjectsProps = {
   resourceId: number;

--- a/front/src/common/authorization/hooks/useCheckUserPrivileges.ts
+++ b/front/src/common/authorization/hooks/useCheckUserPrivileges.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
-import useAuthz from './useAuthz';
 import type { Privilege, ResourceType } from '../types';
+import useAuthz from './useAuthz';
 
 type UseCheckUserPrivilegesParams = {
   resourceType: ResourceType;

--- a/front/src/i18n.ts
+++ b/front/src/i18n.ts
@@ -32,5 +32,3 @@ i18n
 // Errors namespace must be initialized so t function
 // can be used in plain old function (see utils/error)
 i18n.loadNamespaces('errors');
-
-export default i18n;

--- a/front/src/index.tsx
+++ b/front/src/index.tsx
@@ -3,13 +3,13 @@ import { Provider } from 'react-redux';
 import { PersistGate } from 'redux-persist/integration/react';
 
 import 'maplibre-gl/dist/maplibre-gl.css';
-import 'styles/styles.scss';
-
 import 'styles/scss/vendor/bootstrap-sncf/site-intern.scss';
 
 import { Loader } from 'common/Loaders';
 import App from 'main/app';
 import { persistor, store } from 'store';
+
+import 'styles/styles.scss';
 
 export default function Container() {
   return (

--- a/front/src/main/app.tsx
+++ b/front/src/main/app.tsx
@@ -1,8 +1,8 @@
 import { Suspense, useEffect, useCallback } from 'react';
 
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
-import 'i18n';
 
+import '../i18n';
 import HomeEditor from 'applications/editor/Home';
 import Project from 'applications/operationalStudies/views/Project';
 import ProjectList from 'applications/operationalStudies/views/ProjectList';

--- a/front/src/modules/SimulationReportSheet/utils/formatSimulationTable.ts
+++ b/front/src/modules/SimulationReportSheet/utils/formatSimulationTable.ts
@@ -7,8 +7,8 @@ import { timeToLocaleStringRounded } from 'utils/date';
 import { addDurationToDate, Duration } from 'utils/duration';
 import { kgToT } from 'utils/physics';
 
-import { getStopDurationTime } from './formatSimulationReportSheet';
 import styles from '../styles/SimulationReportStyleSheet';
+import { getStopDurationTime } from './formatSimulationReportSheet';
 
 export const getRowStyle = (
   stepDuration: Duration | null | undefined,

--- a/front/src/modules/conflict/components/Conflicts.tsx
+++ b/front/src/modules/conflict/components/Conflicts.tsx
@@ -1,6 +1,6 @@
+import type { ConflictWithTrainNames } from '../types';
 import ConflictCard from './ConflictCard';
 import ConflictsToolbar from './ConflictsToolbar';
-import type { ConflictWithTrainNames } from '../types';
 
 type ConflictsProps = {
   showOnlySelectedTrain: boolean;

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/configureHandlePan.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/configureHandlePan.ts
@@ -16,8 +16,8 @@ import {
   isTrainId,
 } from 'utils/trainId';
 
-import { isIndividualOccurrenceProjection } from './utils';
 import type { IndividualTrainProjection, TrainSpaceTimeData } from '../../../types';
+import { isIndividualOccurrenceProjection } from './utils';
 
 type DraggingState =
   | {

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/utils.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/utils.ts
@@ -5,8 +5,8 @@ import { ASPECT_LABELS_COLORS } from 'modules/simulationResult/consts';
 import type { OccurrenceId, TimetableItem } from 'reducers/osrdconf/types';
 import { isOccurrenceId } from 'utils/trainId';
 
-import type { MovableOccupancyZone } from './zones';
 import type { AspectLabel, IndividualTrainProjection } from '../../../types';
+import type { MovableOccupancyZone } from './zones';
 
 export const getWaypointsLocalStorageKey = (
   timetableId: number | undefined,

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useTrackOccupancy.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useTrackOccupancy.ts
@@ -23,11 +23,11 @@ import {
 } from 'utils/trainId';
 import { mapBy } from 'utils/types';
 
+import { usePrevious } from '../../../../utils/hooks/state';
 import type { BaseTrainProjection, PathOperationalPoint, TrainSpaceTimeData } from '../../types';
 import { NO_TRACK_SPECIFIED_SYMBOL, sortTracks } from './helpers/sortTracks';
 import { batchFetchTrackOccupancy } from './helpers/utils';
 import { getMovableOccupancyZone, type MovableOccupancyZone } from './helpers/zones';
-import { usePrevious } from '../../../../utils/hooks/state';
 
 type AsyncState<T> = { type: 'loading'; data?: T; abort?: () => void } | { type: 'ok'; data: T };
 type ZonesState = AsyncState<MovableOccupancyZone[]>;

--- a/front/src/modules/timesStops/helpers/computeMargins.ts
+++ b/front/src/modules/timesStops/helpers/computeMargins.ts
@@ -3,7 +3,6 @@ import type { SimulationSummary } from 'modules/timetableItem/types';
 import type { Train } from 'reducers/osrdconf/types';
 import { ms2sec } from 'utils/timeManipulation';
 
-import { formatDigitsAndUnit } from './utils';
 import { marginsUndefined, MarginUnit } from '../consts';
 import type {
   Margins,
@@ -13,6 +12,7 @@ import type {
   MarginValue,
   TheoreticalMarginsRecord,
 } from '../types';
+import { formatDigitsAndUnit } from './utils';
 
 type PathItemTimes = Extract<SimulationSummary, { isValid: true }>['pathItemTimes'];
 

--- a/front/src/modules/timetableItem/helpers/pacedTrain.ts
+++ b/front/src/modules/timetableItem/helpers/pacedTrain.ts
@@ -15,13 +15,13 @@ import {
   isIndexedOccurrenceId,
 } from 'utils/trainId';
 
-import computeOccurrenceName from './computeOccurrenceName';
 import type {
   ExceptionChangeGroups,
   PacedTrainWithDetails,
   PacedTrainWithPacedWithDetails,
   TimetableItemWithDetails,
 } from '../types';
+import computeOccurrenceName from './computeOccurrenceName';
 
 export const isPacedTrainBase = (pacedTrain: TrainSchedule): pacedTrain is PacedTrainWithPaced =>
   !!pacedTrain.paced;

--- a/front/src/reducers/editor/thunkActions.ts
+++ b/front/src/reducers/editor/thunkActions.ts
@@ -1,3 +1,4 @@
+import i18n from 'i18next';
 import type { JSONSchema7, JSONSchema7Definition } from 'json-schema';
 import { omit, clone, isNil, isUndefined } from 'lodash';
 
@@ -13,7 +14,6 @@ import {
 import type { EditorEntity, EditorSchema } from 'applications/editor/typesEditorEntity';
 import type { Operation } from 'common/api/osrdEditoastApi';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
-import i18n from 'i18n';
 import { setLoading, setSuccess, setFailure, setSuccessWithoutMessage } from 'reducers/main';
 import infra_schema from 'reducers/osrdconf/infra_schema.json';
 import type { AppDispatch, GetState } from 'store';

--- a/front/src/reducers/index.ts
+++ b/front/src/reducers/index.ts
@@ -1,7 +1,7 @@
 import type { Action, ReducersMapObject } from 'redux';
 import { createTransform, persistCombineReducers } from 'redux-persist';
-import storage from 'redux-persist/es/storage'; // defaults to localStorage
 import { createFilter, createBlacklistFilter } from 'redux-persist-transform-filter';
+import storage from 'redux-persist/es/storage'; // defaults to localStorage
 
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import { osrdGatewayApi } from 'common/api/osrdGatewayApi';

--- a/front/src/reducers/osrdconf/operationalStudiesConf/index.ts
+++ b/front/src/reducers/osrdconf/operationalStudiesConf/index.ts
@@ -10,10 +10,10 @@ import type { OperationalStudiesConfState } from 'reducers/osrdconf/types';
 import { Duration } from 'utils/duration';
 import { msToKmh } from 'utils/physics';
 
+import { upsertPathStep } from '../helpers';
 import itineraryReducer from './itineraryReducer';
 import powerRestrictionReducer from './powerRestrictionReducer';
 import trainSettingsReducer from './trainSettingsReducer';
-import { upsertPathStep } from '../helpers';
 
 export const operationalStudiesInitialConf: OperationalStudiesConfState = {
   ...defaultCommonConf,

--- a/front/src/utils/error.ts
+++ b/front/src/utils/error.ts
@@ -1,7 +1,7 @@
+import i18n from 'i18next';
 import { isObject } from 'lodash';
 
 import type { ApiError } from 'common/api/baseGeneratedApis';
-import i18n from 'i18n';
 
 /**
  * Given an error, return the associated i18n name.

--- a/front/tests/01-home/001-home-page.spec.ts
+++ b/front/tests/01-home/001-home-page.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 
-import test from './../page-object-fixture';
 import { EXPECTED_HOME_LINKS } from '../assets/constants/homepage-const';
+import test from './../page-object-fixture';
 
 test.describe('@home @navigation', () => {
   test.beforeEach('Navigate to the home page', async ({ homePage }) => {

--- a/front/tests/03-stdcm/001-stdcm.spec.ts
+++ b/front/tests/03-stdcm/001-stdcm.spec.ts
@@ -1,9 +1,5 @@
 import type { Infra, TowedRollingStock } from 'common/api/osrdEditoastApi';
 
-import { fastRollingStockName } from './../assets/constants/project-const';
-import test, { createStdcmTab } from './../page-object-fixture';
-import { waitForInfraStateToBeCached } from './../utils';
-import { getInfra, setTowedRollingStock } from './../utils/api-utils';
 import {
   ALL_STOPS_TABLE_DATA_PATH,
   ALTERNATIVE_SIMULATION_RESULTS_DETAILS,
@@ -28,6 +24,10 @@ import {
   VIA_SUGGESTIONS,
 } from '../assets/constants/stdcm/stdcm-const';
 import type { ConsistFields } from '../utils/stdcm-types';
+import { fastRollingStockName } from './../assets/constants/project-const';
+import test, { createStdcmTab } from './../page-object-fixture';
+import { waitForInfraStateToBeCached } from './../utils';
+import { getInfra, setTowedRollingStock } from './../utils/api-utils';
 
 test.describe('@stdcm', () => {
   let infra: Infra;

--- a/front/tests/03-stdcm/002-stdcm-simulation-sheet.spec.ts
+++ b/front/tests/03-stdcm/002-stdcm-simulation-sheet.spec.ts
@@ -2,15 +2,7 @@ import fs from 'fs';
 
 import type { Infra } from 'common/api/osrdEditoastApi';
 
-import test from './../page-object-fixture';
 import simulationSheetDetails from '../assets/constants/stdcm/simulation-sheet-const';
-import ConsistSection from './../pages/stdcm/consist-section';
-import DestinationSection from './../pages/stdcm/destination-section';
-import OriginSection from './../pages/stdcm/origin-section';
-import { waitForInfraStateToBeCached } from './../utils';
-import { getInfra } from './../utils/api-utils';
-import { findFirstPdf, parsePdfText, verifySimulationContent } from './../utils/pdf-parser';
-import type { PdfSimulationContent } from './../utils/types';
 import {
   CI_SUGGESTIONS,
   CONSIST_DETAILS,
@@ -28,6 +20,14 @@ import {
   VIA_STOP_TYPES,
   VIA_SUGGESTIONS,
 } from '../assets/constants/stdcm/stdcm-const';
+import test from './../page-object-fixture';
+import ConsistSection from './../pages/stdcm/consist-section';
+import DestinationSection from './../pages/stdcm/destination-section';
+import OriginSection from './../pages/stdcm/origin-section';
+import { waitForInfraStateToBeCached } from './../utils';
+import { getInfra } from './../utils/api-utils';
+import { findFirstPdf, parsePdfText, verifySimulationContent } from './../utils/pdf-parser';
+import type { PdfSimulationContent } from './../utils/types';
 
 test.describe('@stdcm @stdcm-sheet', () => {
   test.describe.configure({ mode: 'serial' });

--- a/front/tests/03-stdcm/003-stdcm-linked-train.spec.ts
+++ b/front/tests/03-stdcm/003-stdcm-linked-train.spec.ts
@@ -1,10 +1,5 @@
 import type { Infra, TowedRollingStock } from 'common/api/osrdEditoastApi';
 
-import type { ConsistFields } from '../utils/stdcm-types';
-import { fastRollingStockName } from './../assets/constants/project-const';
-import test, { createStdcmTab } from './../page-object-fixture';
-import { waitForInfraStateToBeCached } from './../utils';
-import { getInfra, setTowedRollingStock } from './../utils/api-utils';
 import LINKED_TRAIN_DETAILS from '../assets/constants/stdcm/linked-train-const';
 import {
   ANTERIOR_LINKED_TRAIN_TABLE_DATA_PATH,
@@ -23,6 +18,11 @@ import {
   VIA_STOP_TYPES,
   VIA_SUGGESTIONS,
 } from '../assets/constants/stdcm/stdcm-const';
+import type { ConsistFields } from '../utils/stdcm-types';
+import { fastRollingStockName } from './../assets/constants/project-const';
+import test, { createStdcmTab } from './../page-object-fixture';
+import { waitForInfraStateToBeCached } from './../utils';
+import { getInfra, setTowedRollingStock } from './../utils/api-utils';
 
 test.describe('@stdcm @stdcm-linked-train', () => {
   let infra: Infra;

--- a/front/tests/03-stdcm/004-stdcm-missing-fields.spec.ts
+++ b/front/tests/03-stdcm/004-stdcm-missing-fields.spec.ts
@@ -6,10 +6,6 @@ import {
   PARTIAL_MISSING_FIELDS_KEYS,
   REMOVED_MISSING_FIELDS_KEYS,
 } from '../assets/constants/stdcm/missing-fields';
-import { electricRollingStockName } from './../assets/constants/project-const';
-import test from './../page-object-fixture';
-import { waitForInfraStateToBeCached } from './../utils';
-import { getInfra } from './../utils/api-utils';
 import {
   CI_SUGGESTIONS,
   DEFAULT_DETAILS,
@@ -23,6 +19,10 @@ import {
   TRACTION_ENGINE_PREFILLED_VALUES,
   VALID_CONSIST_DATA,
 } from '../assets/constants/stdcm/stdcm-const';
+import { electricRollingStockName } from './../assets/constants/project-const';
+import test from './../page-object-fixture';
+import { waitForInfraStateToBeCached } from './../utils';
+import { getInfra } from './../utils/api-utils';
 
 test.describe('@stdcm @stdcm-missing-fields', () => {
   let infra: Infra;

--- a/front/tests/03-stdcm/005-stdcm-feedback-mail.spec.ts
+++ b/front/tests/03-stdcm/005-stdcm-feedback-mail.spec.ts
@@ -1,8 +1,5 @@
 import type { Infra } from 'common/api/osrdEditoastApi';
 
-import test from './../page-object-fixture';
-import { waitForInfraStateToBeCached } from './../utils';
-import { getInfra } from './../utils/api-utils';
 import getMailFeedbackData from '../assets/constants/stdcm/mail-feedback-const';
 import {
   CI_SUGGESTIONS,
@@ -15,6 +12,9 @@ import {
   STDCM_URL,
   TRACTION_ENGINE_PREFILLED_VALUES,
 } from '../assets/constants/stdcm/stdcm-const';
+import test from './../page-object-fixture';
+import { waitForInfraStateToBeCached } from './../utils';
+import { getInfra } from './../utils/api-utils';
 
 test.describe('@stdcm @stdcm-feedback', () => {
   let infra: Infra;

--- a/front/tests/pages/home-page.ts
+++ b/front/tests/pages/home-page.ts
@@ -1,8 +1,8 @@
 import { type BrowserContext, type Locator, type Page } from '@playwright/test';
 import { expect } from '@playwright/test';
 
-import CommonPage from './common-page';
 import { HOME_URLS } from '../assets/constants/homepage-const';
+import CommonPage from './common-page';
 
 class HomePage extends CommonPage {
   private readonly operationalStudiesLink: Locator;

--- a/front/tests/pages/operational-studies/get-manchette-component.ts
+++ b/front/tests/pages/operational-studies/get-manchette-component.ts
@@ -1,9 +1,9 @@
 import { expect, type Locator, type Page } from '@playwright/test';
 
-import OpSimulationResultPage from './simulation-results-page';
 import { getCleanText, isGreyed, isOverflowing } from '../../utils';
 import type { Waypoint } from '../../utils/manchette';
 import type { SimulationResultsTranslations } from '../../utils/types';
+import OpSimulationResultPage from './simulation-results-page';
 
 class GetManchetteComponent extends OpSimulationResultPage {
   private readonly spaceTimeChartMenuButton: Locator;

--- a/front/tests/pages/operational-studies/import-export-page.ts
+++ b/front/tests/pages/operational-studies/import-export-page.ts
@@ -1,12 +1,12 @@
 import { expect, type Locator, type Page } from '@playwright/test';
 
-import ScenarioTimetableSection from './scenario-timetable-section';
 import { logger } from '../../logging-fixture';
 import {
   assertSuggestedFilename,
   saveDownloadToDir,
   triggerFileDownload,
 } from '../../utils/file-utils';
+import ScenarioTimetableSection from './scenario-timetable-section';
 
 class ImportExportPage extends ScenarioTimetableSection {
   private readonly importTimetableMenuButton: Locator;

--- a/front/tests/pages/operational-studies/operational-studies-page.ts
+++ b/front/tests/pages/operational-studies/operational-studies-page.ts
@@ -2,13 +2,13 @@ import { expect, type Locator, type Page } from '@playwright/test';
 
 import { Duration } from 'utils/duration';
 
-import ScenarioTimetableSection from './scenario-timetable-section';
 import {
   DEFAULT_PACED_TRAIN_SETTINGS,
   PACED_TRAIN_SETTINGS_TEST,
 } from '../../assets/constants/operational-studies-const';
 import { createDateInSpecialTimeZone } from '../../utils/date-utils';
 import type { ManageTimetableItemTranslations, PacedTrainDetails } from '../../utils/types';
+import ScenarioTimetableSection from './scenario-timetable-section';
 
 class OperationalStudiesPage extends ScenarioTimetableSection {
   private readonly addTimetableItemButton: Locator;

--- a/front/tests/pages/operational-studies/scenario-timetable-section.ts
+++ b/front/tests/pages/operational-studies/scenario-timetable-section.ts
@@ -1,13 +1,13 @@
 import { type Locator, type Page, expect } from '@playwright/test';
 
-import PacedTrainSection from './paced-train-section';
-import OpSimulationResultPage from './simulation-results-page';
 import { readJsonFile } from '../../utils/file-utils';
 import type {
   CommonTranslations,
   FlatTranslations,
   TimetableFilterTranslations,
 } from '../../utils/types';
+import PacedTrainSection from './paced-train-section';
+import OpSimulationResultPage from './simulation-results-page';
 
 type ScenarioTranslations = {
   timetable: FlatTranslations;

--- a/front/tests/pages/operational-studies/simulation-results-page.ts
+++ b/front/tests/pages/operational-studies/simulation-results-page.ts
@@ -1,7 +1,7 @@
 import { expect, type Locator, type Page } from '@playwright/test';
 
-import ScenarioPage from './scenario-page';
 import { toggleByState } from '../../utils';
+import ScenarioPage from './scenario-page';
 
 class OpSimulationResultPage extends ScenarioPage {
   readonly simulationResults: Locator;

--- a/front/tests/pages/rolling-stock/rolling-stock-editor-page.ts
+++ b/front/tests/pages/rolling-stock/rolling-stock-editor-page.ts
@@ -1,9 +1,9 @@
 import { expect, type Locator, type Page } from '@playwright/test';
 
-import RollingStockSelector from './rolling-stock-selector';
 import { fillAndCheckInputById } from '../../utils';
 import { readJsonFile } from '../../utils/file-utils';
 import type { FlatTranslations } from '../../utils/types';
+import RollingStockSelector from './rolling-stock-selector';
 
 type RollingStockTranslations = FlatTranslations & { categoriesOptions: FlatTranslations };
 

--- a/front/tests/pages/stdcm/destination-section.ts
+++ b/front/tests/pages/stdcm/destination-section.ts
@@ -1,8 +1,8 @@
 import { expect, type Locator, type Page } from '@playwright/test';
 
-import STDCMPage from './stdcm-page';
 import { expectFieldsToHaveValues } from '../../utils';
 import type { DestinationDetailsData, LightDestinationDetailsData } from '../../utils/stdcm-types';
+import STDCMPage from './stdcm-page';
 
 class DestinationSection extends STDCMPage {
   readonly destinationCiField: Locator;

--- a/front/tests/pages/stdcm/linked-train-section.ts
+++ b/front/tests/pages/stdcm/linked-train-section.ts
@@ -1,8 +1,5 @@
 import { expect, type Locator, type Page } from '@playwright/test';
 
-import DestinationSection from './destination-section';
-import OriginSection from './origin-section';
-import STDCMPage from './stdcm-page';
 import { expectFieldsToHaveValues } from '../../utils';
 import type {
   AnteriorLinkedPathDetails,
@@ -10,6 +7,9 @@ import type {
   LinkedTrainInfo,
   PosteriorLinkedPathDetails,
 } from '../../utils/stdcm-types';
+import DestinationSection from './destination-section';
+import OriginSection from './origin-section';
+import STDCMPage from './stdcm-page';
 
 class LinkedTrainSection extends STDCMPage {
   readonly originPage: OriginSection;

--- a/front/tests/pages/stdcm/origin-section.ts
+++ b/front/tests/pages/stdcm/origin-section.ts
@@ -1,12 +1,12 @@
 import { expect, type Locator, type Page } from '@playwright/test';
 
-import STDCMPage from './stdcm-page';
 import type {
   DefaultOriginFields,
   ExpectedOriginDetails,
   LightOriginDetailsData,
   OriginDetailsData,
 } from '../../utils/stdcm-types';
+import STDCMPage from './stdcm-page';
 
 class OriginSection extends STDCMPage {
   readonly originChField: Locator;

--- a/front/tests/pages/stdcm/via-section.ts
+++ b/front/tests/pages/stdcm/via-section.ts
@@ -1,12 +1,12 @@
 import { expect, type Locator, type Page } from '@playwright/test';
 
-import STDCMPage from './stdcm-page';
 import { expectFieldsToHaveValues } from '../../utils';
 import type {
   ViaSearchText,
   FillAndVerifyViaDetailsParams,
   VerifyViaDetailsParams,
 } from '../../utils/stdcm-types';
+import STDCMPage from './stdcm-page';
 
 class ViaSection extends STDCMPage {
   private readonly viaIcon: Locator;

--- a/front/tests/reporter/generate-personalized-report.ts
+++ b/front/tests/reporter/generate-personalized-report.ts
@@ -11,13 +11,13 @@ import {
 } from '@playwright/test/reporter';
 
 import { formatAnsiMessageToHtml } from '.';
+import { logger } from '../logging-fixture';
 import type {
   PersonalizedReport,
   PersonalizedTest,
   PersonalizedTestState,
   ReporterOptions,
 } from './playwright-report-types';
-import { logger } from '../logging-fixture';
 
 // This class generates a personalized JSON report from Playwright test execution.
 class GenerateReport implements Reporter {

--- a/front/tests/utils/index.ts
+++ b/front/tests/utils/index.ts
@@ -1,8 +1,8 @@
 import { type Locator, type Page, expect } from '@playwright/test';
 import { v4 as uuidv4 } from 'uuid';
 
-import { getWorkerStatus } from './api-utils';
 import { logger } from '../logging-fixture';
+import { getWorkerStatus } from './api-utils';
 
 /**
  * Fill the input field identified by ID or TestID with the specified value and verifies it.

--- a/front/tests/utils/pdf-parser.ts
+++ b/front/tests/utils/pdf-parser.ts
@@ -4,8 +4,8 @@ import path from 'path';
 import { expect } from '@playwright/test';
 import { getDocument } from 'pdfjs-dist/legacy/build/pdf.mjs';
 
-import type { PdfSimulationContent } from './types';
 import { logger } from '../logging-fixture';
+import type { PdfSimulationContent } from './types';
 
 /**
  * Find the first PDF file in a directory.

--- a/front/tests/utils/scenario.ts
+++ b/front/tests/utils/scenario.ts
@@ -9,8 +9,8 @@ import type {
   TrainScheduleSet,
 } from 'common/api/osrdEditoastApi';
 
-import { postApiRequest, getInfra, getProject, getStudy } from './api-utils';
 import { SCENARIO_DATA } from '../assets/operation-studies/scenario-const';
+import { postApiRequest, getInfra, getProject, getStudy } from './api-utils';
 
 // Define the SetupResult type to structure the returned setup data.
 type SetupResult = {

--- a/front/tests/utils/setup-utils.ts
+++ b/front/tests/utils/setup-utils.ts
@@ -13,17 +13,6 @@ import type {
 } from 'common/api/osrdEditoastApi';
 
 import {
-  getApiRequest,
-  getInfra,
-  retrieveLatestStdcmEnvironment,
-  postApiRequest,
-  createStdcmEnvironment,
-} from './api-utils';
-import { createDateInSpecialTimeZone } from './date-utils';
-import { readJsonFile } from './file-utils';
-import createScenario from './scenario';
-import sendTrains from './send-trains';
-import {
   dualModeRollingStockName,
   electricRollingStockName,
   fastRollingStockName,
@@ -38,6 +27,17 @@ import {
 } from '../assets/constants/project-const';
 import { PROJECT_DATA } from '../assets/operation-studies/project-const';
 import { STUDY_DATA } from '../assets/operation-studies/study-const';
+import {
+  getApiRequest,
+  getInfra,
+  retrieveLatestStdcmEnvironment,
+  postApiRequest,
+  createStdcmEnvironment,
+} from './api-utils';
+import { createDateInSpecialTimeZone } from './date-utils';
+import { readJsonFile } from './file-utils';
+import createScenario from './scenario';
+import sendTrains from './send-trains';
 
 /**
  * Helper function to create infrastructure using RailJson.

--- a/front/tests/utils/teardown-utils.ts
+++ b/front/tests/utils/teardown-utils.ts
@@ -1,7 +1,7 @@
 import type { LightRollingStock, LightRollingStockWithLiveries } from 'common/api/osrdEditoastApi';
 
-import { deleteApiRequest, getStudy, getScenario, getProject, listApiRequest } from './api-utils';
 import { logger } from '../logging-fixture';
+import { deleteApiRequest, getStudy, getScenario, getProject, listApiRequest } from './api-utils';
 
 /**
  * Delete a project by name if it exists.

--- a/front/ui/.oxfmtrc.json
+++ b/front/ui/.oxfmtrc.json
@@ -4,6 +4,28 @@
   "arrowParens": "always",
   "proseWrap": "always",
   "trailingComma": "es5",
-  "experimentalSortPackageJson": false,
-  "ignorePatterns": ["*.md", "dist", "node_modules", "storybook-static", "ui-icons"]
+  "sortPackageJson": false,
+  "ignorePatterns": ["*.md", "dist", "node_modules", "storybook-static", "ui-icons"],
+  "sortImports": {
+    "groups": [
+      "react",
+      "builtin",
+      "external",
+      "external_styles",
+      ["internal", "index", "sibling", "parent"],
+      ["style", "side_effect_style"]
+    ],
+    "customGroups": [
+      {
+        "groupName": "react",
+        "elementNamePattern": ["react"]
+      },
+      {
+        "groupName": "external_styles",
+        "elementNamePattern": ["**/dist/**/*.{css,scss}", "**/vendor/**/*.{css,scss}"]
+      }
+    ],
+    "newlinesBetween": true,
+    "ignoreCase": true
+  }
 }

--- a/front/ui/eslint.config.js
+++ b/front/ui/eslint.config.js
@@ -1,11 +1,11 @@
 import { join } from 'node:path';
 
 import js from '@eslint/js';
-import { defineConfig, globalIgnores } from 'eslint/config';
 import importPlugin from 'eslint-plugin-import';
 import reactPlugin from 'eslint-plugin-react';
 import reactHooksPlugin from 'eslint-plugin-react-hooks';
 import { configs as storybookPluginConfigs } from 'eslint-plugin-storybook';
+import { defineConfig, globalIgnores } from 'eslint/config';
 import { configs as tsEslintConfigs } from 'typescript-eslint';
 
 export default defineConfig([
@@ -36,29 +36,6 @@ export default defineConfig([
       },
     },
     rules: {
-      'import/order': [
-        'error',
-        {
-          groups: ['builtin', 'external', 'internal'],
-
-          pathGroups: [
-            {
-              pattern: 'react',
-              group: 'builtin',
-              position: 'before',
-            },
-          ],
-
-          pathGroupsExcludedImportTypes: ['react'],
-          'newlines-between': 'always',
-
-          alphabetize: {
-            order: 'asc',
-            caseInsensitive: true,
-          },
-        },
-      ],
-
       'no-shadow': 'off',
 
       '@typescript-eslint/consistent-type-imports': [

--- a/front/ui/storybook/stories/ui-charts/chronogram/base-rendering.stories.tsx
+++ b/front/ui/storybook/stories/ui-charts/chronogram/base-rendering.stories.tsx
@@ -3,9 +3,10 @@ import React from 'react';
 import { Chronogram, type LevelCrossingData } from '@osrd-project/ui-charts';
 import type { Meta } from '@storybook/react-vite';
 
-import { levelCrossingData, START_DATE } from './level-crossing-data';
 import '@osrd-project/ui-charts/dist/theme.css';
 import '@osrd-project/ui-core/dist/theme.css';
+
+import { levelCrossingData, START_DATE } from './level-crossing-data';
 
 type WrapperProps = {
   levelCrossingsData: LevelCrossingData[];

--- a/front/ui/storybook/stories/ui-charts/manchette/Manchette.stories.tsx
+++ b/front/ui/storybook/stories/ui-charts/manchette/Manchette.stories.tsx
@@ -1,7 +1,8 @@
 import { Manchette } from '@osrd-project/ui-charts';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
 import '@osrd-project/ui-core/dist/theme.css';
 import '@osrd-project/ui-charts/dist/theme.css';
-import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { SAMPLE_WAYPOINTS } from './assets/sampleData';
 

--- a/front/ui/storybook/stories/ui-charts/manchette/ManchetteSplit.stories.tsx
+++ b/front/ui/storybook/stories/ui-charts/manchette/ManchetteSplit.stories.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 
-import '@osrd-project/ui-charts/dist/theme.css';
 import { Manchette } from '@osrd-project/ui-charts';
-import '@osrd-project/ui-core/dist/theme.css';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import '@osrd-project/ui-charts/dist/theme.css';
+import '@osrd-project/ui-core/dist/theme.css';
 
 import { SAMPLE_WAYPOINTS } from './assets/sampleData';
 

--- a/front/ui/storybook/stories/ui-charts/manchetteWithSpaceTimeChart/base-with-waypoint-menu.stories.tsx
+++ b/front/ui/storybook/stories/ui-charts/manchetteWithSpaceTimeChart/base-with-waypoint-menu.stories.tsx
@@ -11,6 +11,7 @@ import {
 } from '@osrd-project/ui-charts';
 import { EyeClosed, Telescope } from '@osrd-project/ui-icons';
 import type { Meta } from '@storybook/react-vite';
+
 import '@osrd-project/ui-core/dist/theme.css';
 import '@osrd-project/ui-charts/dist/theme.css';
 

--- a/front/ui/storybook/stories/ui-charts/manchetteWithSpaceTimeChart/base.stories.tsx
+++ b/front/ui/storybook/stories/ui-charts/manchetteWithSpaceTimeChart/base.stories.tsx
@@ -1,7 +1,5 @@
 import React, { useRef } from 'react';
 
-import '@osrd-project/ui-core/dist/theme.css';
-import '@osrd-project/ui-charts/dist/theme.css';
 import {
   SpaceTimeChart,
   Manchette,
@@ -11,6 +9,9 @@ import {
   type ChartPath,
 } from '@osrd-project/ui-charts';
 import type { Meta } from '@storybook/react-vite';
+
+import '@osrd-project/ui-core/dist/theme.css';
+import '@osrd-project/ui-charts/dist/theme.css';
 
 import { SAMPLE_WAYPOINTS, SAMPLE_CHART_PATHS } from './assets/sampleData';
 

--- a/front/ui/storybook/stories/ui-charts/manchetteWithSpaceTimeChart/rectangle-zoom.stories.tsx
+++ b/front/ui/storybook/stories/ui-charts/manchetteWithSpaceTimeChart/rectangle-zoom.stories.tsx
@@ -14,11 +14,12 @@ import { ZoomIn } from '@osrd-project/ui-icons';
 import type { Meta } from '@storybook/react-vite';
 import cx from 'classnames';
 
-import { SAMPLE_WAYPOINTS, SAMPLE_CHART_PATHS } from './assets/sampleData';
-import { MouseTracker } from '../spaceTimeChart/helpers/components';
-
 import '@osrd-project/ui-core/dist/theme.css';
 import '@osrd-project/ui-charts/dist/theme.css';
+
+import { MouseTracker } from '../spaceTimeChart/helpers/components';
+import { SAMPLE_WAYPOINTS, SAMPLE_CHART_PATHS } from './assets/sampleData';
+
 import './styles/rectangle-zoom.css';
 
 type ManchetteWithSpaceTimeWrapperProps = {

--- a/front/ui/storybook/stories/ui-charts/manchetteWithSpaceTimeChart/simple.stories.tsx
+++ b/front/ui/storybook/stories/ui-charts/manchetteWithSpaceTimeChart/simple.stories.tsx
@@ -1,7 +1,8 @@
 import { ManchetteWithSpaceTimeChart } from '@osrd-project/ui-charts';
+import type { Meta } from '@storybook/react-vite';
+
 import '@osrd-project/ui-charts/dist/theme.css';
 import '@osrd-project/ui-core/dist/theme.css';
-import type { Meta } from '@storybook/react-vite';
 
 import { SAMPLE_CHART_PATHS, SAMPLE_WAYPOINTS } from './assets/sampleData';
 

--- a/front/ui/storybook/stories/ui-charts/manchetteWithSpaceTimeChart/split.stories.tsx
+++ b/front/ui/storybook/stories/ui-charts/manchetteWithSpaceTimeChart/split.stories.tsx
@@ -12,10 +12,11 @@ import {
   useDraw,
   useManchetteWithSpaceTimeChart,
 } from '@osrd-project/ui-charts';
-import '@osrd-project/ui-charts/dist/theme.css';
-import '@osrd-project/ui-core/dist/theme.css';
 import type { Meta } from '@storybook/react-vite';
 import { clamp } from 'lodash';
+
+import '@osrd-project/ui-charts/dist/theme.css';
+import '@osrd-project/ui-core/dist/theme.css';
 
 import { SAMPLE_WAYPOINTS, SAMPLE_CHART_PATHS } from './assets/sampleData';
 

--- a/front/ui/storybook/stories/ui-charts/manchetteWithSpaceTimeChart/track-occupancy.stories.tsx
+++ b/front/ui/storybook/stories/ui-charts/manchetteWithSpaceTimeChart/track-occupancy.stories.tsx
@@ -17,9 +17,10 @@ import {
   isSegmentPickingElement,
   BASE_WAYPOINT_HEIGHT,
 } from '@osrd-project/ui-charts';
+import type { Meta } from '@storybook/react-vite';
+
 import '@osrd-project/ui-charts/dist/theme.css';
 import '@osrd-project/ui-core/dist/theme.css';
-import type { Meta } from '@storybook/react-vite';
 
 import {
   getOccupancyZonesFromPathAtGivenWaypoint,

--- a/front/ui/storybook/stories/ui-charts/spaceTimeChart/additional-data.stories.tsx
+++ b/front/ui/storybook/stories/ui-charts/spaceTimeChart/additional-data.stories.tsx
@@ -13,6 +13,10 @@ import type { Meta } from '@storybook/react-vite';
 import cx from 'classnames';
 import { clamp, inRange } from 'lodash';
 
+import '@osrd-project/ui-charts/dist/theme.css';
+import '@osrd-project/ui-core/dist/theme.css';
+
+import { MINUTE, HOUR } from '../common/const';
 import { MouseTracker } from './helpers/components';
 import { AMBIANT_A10, ERROR_30, ERROR_60, KILOMETER } from './helpers/consts';
 import { OPERATIONAL_POINTS, PATHS, START_DATE } from './helpers/paths';
@@ -25,9 +29,6 @@ import {
   Y_ZOOM_LEVEL,
   getDiff,
 } from './helpers/utils';
-import '@osrd-project/ui-charts/dist/theme.css';
-import '@osrd-project/ui-core/dist/theme.css';
-import { MINUTE, HOUR } from '../common/const';
 
 const MONO_TRACK_SPACES = [
   { from: 6 * KILOMETER, to: 24 * KILOMETER },

--- a/front/ui/storybook/stories/ui-charts/spaceTimeChart/base-rendering.stories.tsx
+++ b/front/ui/storybook/stories/ui-charts/spaceTimeChart/base-rendering.stories.tsx
@@ -3,11 +3,11 @@ import React from 'react';
 import { SpaceTimeChart, PathLayer } from '@osrd-project/ui-charts';
 import type { Meta } from '@storybook/react-vite';
 
-import { OPERATIONAL_POINTS, PATHS } from './helpers/paths';
-import { X_ZOOM_LEVEL, Y_ZOOM_LEVEL } from './helpers/utils';
-
 import '@osrd-project/ui-charts/dist/theme.css';
 import '@osrd-project/ui-core/dist/theme.css';
+
+import { OPERATIONAL_POINTS, PATHS } from './helpers/paths';
+import { X_ZOOM_LEVEL, Y_ZOOM_LEVEL } from './helpers/utils';
 
 type WrapperProps = {
   xZoomLevel: number;

--- a/front/ui/storybook/stories/ui-charts/spaceTimeChart/custom-styles.stories.tsx
+++ b/front/ui/storybook/stories/ui-charts/spaceTimeChart/custom-styles.stories.tsx
@@ -4,6 +4,9 @@ import { PathLayer, SpaceTimeChart, type Point } from '@osrd-project/ui-charts';
 import type { Meta } from '@storybook/react-vite';
 import cx from 'classnames';
 
+import '@osrd-project/ui-charts/dist/theme.css';
+import '@osrd-project/ui-core/dist/theme.css';
+
 import { OPERATIONAL_POINTS, PATHS } from './helpers/paths';
 import {
   MAX_X_ZOOM,
@@ -14,9 +17,6 @@ import {
   Y_ZOOM_LEVEL,
   getDiff,
 } from './helpers/utils';
-
-import '@osrd-project/ui-charts/dist/theme.css';
-import '@osrd-project/ui-core/dist/theme.css';
 
 const DEFAULT_COLOR_1 = '#FF511A';
 const DEFAULT_COLOR_2 = '#FF8B61';

--- a/front/ui/storybook/stories/ui-charts/spaceTimeChart/layers.stories.tsx
+++ b/front/ui/storybook/stories/ui-charts/spaceTimeChart/layers.stories.tsx
@@ -12,6 +12,10 @@ import {
 } from '@osrd-project/ui-charts';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
+import '@osrd-project/ui-core/dist/theme.css';
+import '@osrd-project/ui-charts/dist/theme.css';
+
+import { MINUTE } from '../common/const';
 import {
   KILOMETER,
   OCCUPANCY_FREE,
@@ -20,9 +24,6 @@ import {
 } from './helpers/consts';
 import { OPERATIONAL_POINTS, PATHS, START_DATE } from './helpers/paths';
 import { X_ZOOM_LEVEL, Y_ZOOM_LEVEL } from './helpers/utils';
-import '@osrd-project/ui-core/dist/theme.css';
-import '@osrd-project/ui-charts/dist/theme.css';
-import { MINUTE } from '../common/const';
 
 const CONFLICTS = [
   {

--- a/front/ui/storybook/stories/ui-charts/spaceTimeChart/measuring.stories.tsx
+++ b/front/ui/storybook/stories/ui-charts/spaceTimeChart/measuring.stories.tsx
@@ -4,12 +4,12 @@ import { SpaceTimeChart, PathLayer, type DataPoint, type Point } from '@osrd-pro
 import type { Meta } from '@storybook/react-vite';
 import cx from 'classnames';
 
+import '@osrd-project/ui-core/dist/theme.css';
+import '@osrd-project/ui-charts/dist/theme.css';
+
 import { MouseTracker } from './helpers/components';
 import { OPERATIONAL_POINTS, PATHS } from './helpers/paths';
 import { X_ZOOM_LEVEL, Y_ZOOM_LEVEL, zoom, getDiff } from './helpers/utils';
-
-import '@osrd-project/ui-core/dist/theme.css';
-import '@osrd-project/ui-charts/dist/theme.css';
 
 type WrapperProps = {
   spaceScaleType: 'linear' | 'proportional';

--- a/front/ui/storybook/stories/ui-charts/spaceTimeChart/options.stories.tsx
+++ b/front/ui/storybook/stories/ui-charts/spaceTimeChart/options.stories.tsx
@@ -10,6 +10,9 @@ import type { Meta } from '@storybook/react-vite';
 import cx from 'classnames';
 import FileSaver from 'file-saver';
 
+import '@osrd-project/ui-core/dist/theme.css';
+import '@osrd-project/ui-charts/dist/theme.css';
+
 import { MouseTracker } from './helpers/components';
 import { OPERATIONAL_POINTS, PATHS } from './helpers/paths';
 import {
@@ -21,9 +24,6 @@ import {
   Y_ZOOM_LEVEL,
   getDiff,
 } from './helpers/utils';
-
-import '@osrd-project/ui-core/dist/theme.css';
-import '@osrd-project/ui-charts/dist/theme.css';
 
 const ScreenshotButton = () => {
   const { captureCanvases } = useContext(SpaceTimeChartCanvasContext);

--- a/front/ui/storybook/stories/ui-charts/spaceTimeChart/paths-interactions.stories.tsx
+++ b/front/ui/storybook/stories/ui-charts/spaceTimeChart/paths-interactions.stories.tsx
@@ -12,11 +12,11 @@ import type { Meta } from '@storybook/react-vite';
 import cx from 'classnames';
 import { keyBy } from 'lodash';
 
-import { OPERATIONAL_POINTS, PATHS } from './helpers/paths';
-import { X_ZOOM_LEVEL, Y_ZOOM_LEVEL, zoom, getDiff } from './helpers/utils';
-
 import '@osrd-project/ui-core/dist/theme.css';
 import '@osrd-project/ui-charts/dist/theme.css';
+
+import { OPERATIONAL_POINTS, PATHS } from './helpers/paths';
+import { X_ZOOM_LEVEL, Y_ZOOM_LEVEL, zoom, getDiff } from './helpers/utils';
 
 function delayPath<T extends PathData>(path: T, newTimeOrigin: number): T {
   const delay = newTimeOrigin - path.points[0].time;

--- a/front/ui/storybook/stories/ui-charts/spaceTimeChart/performances.stories.tsx
+++ b/front/ui/storybook/stories/ui-charts/spaceTimeChart/performances.stories.tsx
@@ -10,12 +10,13 @@ import { type Meta } from '@storybook/react-vite';
 import cx from 'classnames';
 import { random, range } from 'lodash';
 
+import '@osrd-project/ui-core/dist/theme.css';
+import '@osrd-project/ui-charts/dist/theme.css';
+
+import { MINUTE } from '../common/const';
 import { KILOMETER } from './helpers/consts';
 import { getPaths, type PATHS } from './helpers/paths';
 import { X_ZOOM_LEVEL, Y_ZOOM_LEVEL, zoom, getDiff } from './helpers/utils';
-import '@osrd-project/ui-core/dist/theme.css';
-import '@osrd-project/ui-charts/dist/theme.css';
-import { MINUTE } from '../common/const';
 
 const DATE_OFFSET = +new Date('2024/01/01');
 const COLORS = [

--- a/front/ui/storybook/stories/ui-charts/spaceTimeChart/quadrilateral.stories.tsx
+++ b/front/ui/storybook/stories/ui-charts/spaceTimeChart/quadrilateral.stories.tsx
@@ -11,13 +11,13 @@ import {
 } from '@osrd-project/ui-charts';
 import type { Meta } from '@storybook/react-vite';
 
+import '@osrd-project/ui-core/dist/theme.css';
+import '@osrd-project/ui-charts/dist/theme.css';
+
 import { HOUR } from '../common/const';
 import { KILOMETER } from './helpers/consts';
 import { OPERATIONAL_POINTS, PATHS, START_DATE } from './helpers/paths';
 import { X_ZOOM_LEVEL, Y_ZOOM_LEVEL } from './helpers/utils';
-
-import '@osrd-project/ui-core/dist/theme.css';
-import '@osrd-project/ui-charts/dist/theme.css';
 
 type WrapperProps = {
   xZoomLevel: number;

--- a/front/ui/storybook/stories/ui-charts/spaceTimeChart/rectangle-zoom.stories.tsx
+++ b/front/ui/storybook/stories/ui-charts/spaceTimeChart/rectangle-zoom.stories.tsx
@@ -17,12 +17,13 @@ import { clamp } from 'lodash';
 
 import '@osrd-project/ui-core/dist/theme.css';
 import '@osrd-project/ui-charts/dist/theme.css';
-import './styles/rectangle-zoom.css';
 
 import { MouseTracker } from './helpers/components';
 import { KILOMETER } from './helpers/consts';
 import { OPERATIONAL_POINTS, PATHS } from './helpers/paths';
 import { getDiff } from './helpers/utils';
+
+import './styles/rectangle-zoom.css';
 
 const DEFAULT_WIDTH = 1000;
 const DEFAULT_HEIGHT = 500;

--- a/front/ui/storybook/stories/ui-charts/spaceTimeChart/scroll-navigation.stories.tsx
+++ b/front/ui/storybook/stories/ui-charts/spaceTimeChart/scroll-navigation.stories.tsx
@@ -13,11 +13,11 @@ import type { Meta } from '@storybook/react-vite';
 import cx from 'classnames';
 import { keyBy } from 'lodash';
 
-import { OPERATIONAL_POINTS, PATHS } from './helpers/paths';
-import { X_ZOOM_LEVEL, Y_ZOOM_LEVEL, zoom, getDiff } from './helpers/utils';
-
 import '@osrd-project/ui-core/dist/theme.css';
 import '@osrd-project/ui-charts/dist/theme.css';
+
+import { OPERATIONAL_POINTS, PATHS } from './helpers/paths';
+import { X_ZOOM_LEVEL, Y_ZOOM_LEVEL, zoom, getDiff } from './helpers/utils';
 
 const PATHS_DICT = keyBy(PATHS, 'id');
 

--- a/front/ui/storybook/stories/ui-charts/spaceTimeChart/split.stories.tsx
+++ b/front/ui/storybook/stories/ui-charts/spaceTimeChart/split.stories.tsx
@@ -1,8 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react';
 
-import '@osrd-project/ui-core/dist/theme.css';
-import '@osrd-project/ui-charts/dist/theme.css';
-
 import {
   PathLayer,
   SpaceTimeChart,
@@ -14,6 +11,9 @@ import {
 } from '@osrd-project/ui-charts';
 import type { Meta } from '@storybook/react-vite';
 import { clamp, keyBy } from 'lodash';
+
+import '@osrd-project/ui-core/dist/theme.css';
+import '@osrd-project/ui-charts/dist/theme.css';
 
 import { AMBIANT_A10 } from './helpers/consts';
 import { OPERATIONAL_POINTS, PATHS } from './helpers/paths';

--- a/front/ui/storybook/stories/ui-charts/spaceTimeChart/stage-interactions.stories.tsx
+++ b/front/ui/storybook/stories/ui-charts/spaceTimeChart/stage-interactions.stories.tsx
@@ -4,6 +4,9 @@ import { SpaceTimeChart, PathLayer, type Point } from '@osrd-project/ui-charts';
 import type { Meta } from '@storybook/react-vite';
 import cx from 'classnames';
 
+import '@osrd-project/ui-core/dist/theme.css';
+import '@osrd-project/ui-charts/dist/theme.css';
+
 import { OPERATIONAL_POINTS, PATHS } from './helpers/paths';
 import {
   MAX_X_ZOOM,
@@ -14,9 +17,6 @@ import {
   Y_ZOOM_LEVEL,
   getDiff,
 } from './helpers/utils';
-
-import '@osrd-project/ui-core/dist/theme.css';
-import '@osrd-project/ui-charts/dist/theme.css';
 
 type WrapperProps = {
   xPan: boolean;

--- a/front/ui/storybook/stories/ui-charts/spaceTimeChart/tooltip.stories.tsx
+++ b/front/ui/storybook/stories/ui-charts/spaceTimeChart/tooltip.stories.tsx
@@ -9,11 +9,11 @@ import {
 } from '@osrd-project/ui-charts';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
-import { OPERATIONAL_POINTS, PATHS } from './helpers/paths';
-import { X_ZOOM_LEVEL, Y_ZOOM_LEVEL } from './helpers/utils';
-
 import '@osrd-project/ui-core/dist/theme.css';
 import '@osrd-project/ui-charts/dist/theme.css';
+
+import { OPERATIONAL_POINTS, PATHS } from './helpers/paths';
+import { X_ZOOM_LEVEL, Y_ZOOM_LEVEL } from './helpers/utils';
 
 const CustomTooltipContent = ({
   tooltipTitle,

--- a/front/ui/storybook/stories/ui-charts/spaceTimeChart/work-schedules.stories.tsx
+++ b/front/ui/storybook/stories/ui-charts/spaceTimeChart/work-schedules.stories.tsx
@@ -11,13 +11,13 @@ import {
 } from '@osrd-project/ui-charts';
 import type { Meta } from '@storybook/react-vite';
 
+import '@osrd-project/ui-core/dist/theme.css';
+import '@osrd-project/ui-charts/dist/theme.css';
+
 import upward from './assets/images/ScheduledMaintenanceUp.svg';
 import { KILOMETER } from './helpers/consts';
 import { OPERATIONAL_POINTS, PATHS } from './helpers/paths';
 import { getDiff } from './helpers/utils';
-
-import '@osrd-project/ui-core/dist/theme.css';
-import '@osrd-project/ui-charts/dist/theme.css';
 
 const SAMPLE_WORK_SCHEDULES: WorkSchedule[] = [
   {

--- a/front/ui/storybook/stories/ui-charts/speedSpaceChart/SpeedSpaceChart.stories.tsx
+++ b/front/ui/storybook/stories/ui-charts/speedSpaceChart/SpeedSpaceChart.stories.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useState } from 'react';
 
-import '@osrd-project/ui-core/dist/theme.css';
-import '@osrd-project/ui-charts/dist/theme.css';
 import { SpeedSpaceChart, type SpeedSpaceChartProps } from '@osrd-project/ui-charts';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import '@osrd-project/ui-core/dist/theme.css';
+import '@osrd-project/ui-charts/dist/theme.css';
 
 import { pathPropertiesPmpLm } from './assets/path_properties_PMP_LM';
 import { powerRestrictionsPmpLm } from './assets/power_restrictions_PMP_LM';

--- a/front/ui/storybook/stories/ui-core/Button.stories.tsx
+++ b/front/ui/storybook/stories/ui-core/Button.stories.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Button } from '@osrd-project/ui-core';
 import { Archive, Bookmark, Cloud, Clock } from '@osrd-project/ui-icons';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+
 import '@osrd-project/ui-core/dist/theme.css';
 
 const icons = { archive: <Archive />, bookmark: <Bookmark />, cloud: <Cloud />, clock: <Clock /> };

--- a/front/ui/storybook/stories/ui-core/ComboBoxCustom.stories.tsx
+++ b/front/ui/storybook/stories/ui-core/ComboBoxCustom.stories.tsx
@@ -4,6 +4,7 @@ import { ComboBox } from '@osrd-project/ui-core';
 import { type StoryObj, type Meta } from '@storybook/react-vite';
 
 import '@osrd-project/ui-core/dist/theme.css';
+
 import './stories.css';
 
 type Suggestion = { id: string; firstname: string; lastname: string };

--- a/front/ui/storybook/stories/ui-core/ComboBoxCustomList/ListElementComponent.tsx
+++ b/front/ui/storybook/stories/ui-core/ComboBoxCustomList/ListElementComponent.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import './ListElementComponent.scss';
 
 import cx from 'classnames';
+
+import './ListElementComponent.scss';
 
 export type secondaryCodeSuggestion = {
   code: string;

--- a/front/ui/storybook/stories/ui-core/ComboBoxCustomSuggestions.stories.tsx
+++ b/front/ui/storybook/stories/ui-core/ComboBoxCustomSuggestions.stories.tsx
@@ -5,6 +5,7 @@ import { KebabHorizontal } from '@osrd-project/ui-icons';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import '@osrd-project/ui-core/dist/theme.css';
+
 import { ListElementComponent } from './ComboBoxCustomList/ListElementComponent';
 
 type OpCh = {

--- a/front/ui/storybook/stories/ui-core/DatePicker.stories.tsx
+++ b/front/ui/storybook/stories/ui-core/DatePicker.stories.tsx
@@ -10,6 +10,7 @@ import {
 import { type StoryObj, type Meta } from '@storybook/react-vite';
 
 import '@osrd-project/ui-core/dist/theme.css';
+
 import './stories.css';
 
 const now = new Date();

--- a/front/ui/storybook/stories/ui-core/Input.stories.tsx
+++ b/front/ui/storybook/stories/ui-core/Input.stories.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import { Input, type StatusWithMessage } from '@osrd-project/ui-core';
 import { ChevronDown, X } from '@osrd-project/ui-icons';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+
 import '@osrd-project/ui-core/dist/theme.css';
 
 const meta: Meta<typeof Input> = {

--- a/front/ui/storybook/stories/ui-warped-map/SampleMap.tsx
+++ b/front/ui/storybook/stories/ui-warped-map/SampleMap.tsx
@@ -3,8 +3,9 @@ import React, { useMemo } from 'react';
 import { BaseMap, Loader, WarpedMap, type SourceDefinition } from '@osrd-project/ui-warped-map';
 import { featureCollection } from '@turf/helpers';
 import type { Feature, LineString } from 'geojson';
-import 'maplibre-gl/dist/maplibre-gl.css';
 import { Layer, type LineLayerSpecification, Source } from 'react-map-gl/maplibre';
+
+import 'maplibre-gl/dist/maplibre-gl.css';
 
 import { OSM_BASE_MAP_STYLE, OSM_SOURCE } from './helpers';
 import { useAsyncMemo } from './useAsyncMemo';

--- a/front/ui/ui-charts/src/chronogram/components/Chronogram.tsx
+++ b/front/ui/ui-charts/src/chronogram/components/Chronogram.tsx
@@ -2,12 +2,12 @@ import React, { useEffect, useRef, useState } from 'react';
 
 import { Slider } from '@osrd-project/ui-core';
 
-import { ChronogramCanvas } from './ChronogramCanvas';
-import ChronogramManchette from './ChronogramManchette';
 import { zoomValueToTimeScale } from '../../manchette/utils/helpers';
 import useChronogram from '../hooks/useChronogram';
 import { CHRONOGRAM_SLIDER_WIDTH, INITIAL_CHRONOGRAM_HEIGHT } from '../lib/const';
 import type { ChronogramProps } from '../lib/types';
+import { ChronogramCanvas } from './ChronogramCanvas';
+import ChronogramManchette from './ChronogramManchette';
 
 export const Chronogram = ({
   levelCrossingData,

--- a/front/ui/ui-charts/src/chronogram/components/ChronogramCanvas.tsx
+++ b/front/ui/ui-charts/src/chronogram/components/ChronogramCanvas.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useMemo, useState } from 'react';
 
 import cx from 'classnames';
 
-import { OccupancyBlocksLayer } from './OccupancyBlocksLayer';
 import { TimeChartCanvasContext } from '../../common/context';
 import { getTimeToPixel, getPixelToTime } from '../../common/helpers/time';
 import { useCanvas } from '../../common/hooks/useCanvas';
@@ -18,6 +17,7 @@ import { validateTheme } from '../../spaceTimeChart/lib/theme';
 import type { DataPoint, MouseContextType } from '../../spaceTimeChart/lib/types';
 import { ChronogramContext } from '../lib/context';
 import type { ChronogramContextType, ChronogramCanvasProps } from '../lib/types';
+import { OccupancyBlocksLayer } from './OccupancyBlocksLayer';
 
 export const ChronogramCanvas = (props: ChronogramCanvasProps) => {
   const {

--- a/front/ui/ui-charts/src/common/hooks/useCanvas.ts
+++ b/front/ui/ui-charts/src/common/hooks/useCanvas.ts
@@ -2,8 +2,6 @@ import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'r
 
 import { isEqual } from 'lodash';
 
-import { useDevicePixelRatio } from './useDevicePixelRatio';
-import { useSize } from './useSize';
 import { PICKING_LAYERS, LAYERS } from '../consts';
 import { rgbToHex, colorToIndex } from '../helpers/colors';
 import getPNGBlob from '../helpers/png';
@@ -19,6 +17,8 @@ import type {
   PickingLayerType,
   Point,
 } from '../types';
+import { useDevicePixelRatio } from './useDevicePixelRatio';
+import { useSize } from './useSize';
 
 const PICKING = 'picking';
 const RENDERING = 'rendering';

--- a/front/ui/ui-charts/src/common/types.ts
+++ b/front/ui/ui-charts/src/common/types.ts
@@ -1,8 +1,8 @@
 import { type HTMLProps } from 'react';
 
 import { type SpaceTimeChartTheme } from '../spaceTimeChart';
-import type { LAYERS, PICKING_LAYERS } from './consts';
 import type { DataPoint, Handler, PointToData, DataToPoint } from '../spaceTimeChart/lib/types';
+import type { LAYERS, PICKING_LAYERS } from './consts';
 
 export type BaseChartContextType = {
   fingerprint: string;

--- a/front/ui/ui-charts/src/manchette/components/Manchette.tsx
+++ b/front/ui/ui-charts/src/manchette/components/Manchette.tsx
@@ -5,8 +5,8 @@ import cx from 'classnames';
 
 import { INITIAL_OP_LIST_HEIGHT, MAX_ZOOM_Y, MIN_ZOOM_Y } from '../consts';
 import type { InteractiveWaypoint } from '../types';
-import Waypoint from './Waypoint';
 import { isInteractiveWaypoint } from '../utils/helpers';
+import Waypoint from './Waypoint';
 
 export type ManchetteProps = {
   contents: (InteractiveWaypoint | React.ReactNode)[];

--- a/front/ui/ui-charts/src/manchette/components/ManchetteWithSpaceTimeChart.tsx
+++ b/front/ui/ui-charts/src/manchette/components/ManchetteWithSpaceTimeChart.tsx
@@ -1,12 +1,12 @@
 import React, { useRef } from 'react';
 
-import Manchette, { type ManchetteProps } from './Manchette';
 import { PathLayer, SpaceTimeChart, type SpaceTimeChartProps } from '../../spaceTimeChart';
 import { INITIAL_SPACE_TIME_CHART_HEIGHT } from '../consts';
 import useManchetteWithSpaceTimeChart, {
   type SplitPoint,
 } from '../hooks/useManchetteWithSpaceTimeChart';
 import type { ChartPath, Waypoint } from '../types';
+import Manchette, { type ManchetteProps } from './Manchette';
 
 export type ManchetteWithSpaceTimeChartProps = {
   waypoints: Waypoint[];

--- a/front/ui/ui-charts/src/manchette/hooks/useManchetteWithSpaceTimeChart.tsx
+++ b/front/ui/ui-charts/src/manchette/hooks/useManchetteWithSpaceTimeChart.tsx
@@ -21,7 +21,6 @@ import {
 } from '../consts';
 import type { InteractiveWaypoint, Waypoint } from '../types';
 import { calcTotalDistance } from '../utils';
-import useSyncManchette, { type SyncManchetteState } from './useSyncManchette';
 import {
   selectWaypointsToDisplay,
   getScales,
@@ -31,6 +30,7 @@ import {
   zoomValueToSpaceScale,
   zoomValueToTimeScale,
 } from '../utils/helpers';
+import useSyncManchette, { type SyncManchetteState } from './useSyncManchette';
 
 export type SplitPoint = {
   /** helper identify nodes for this split point in the React tree */

--- a/front/ui/ui-charts/src/manchette/index.ts
+++ b/front/ui/ui-charts/src/manchette/index.ts
@@ -1,4 +1,5 @@
 import '@osrd-project/ui-core/dist/theme.css';
+
 import './styles/main.css';
 import './consts';
 

--- a/front/ui/ui-charts/src/spaceTimeChart/components/ConflictTooltip.tsx
+++ b/front/ui/ui-charts/src/spaceTimeChart/components/ConflictTooltip.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { Tooltip } from './Tooltip';
 import type { Point } from '../../common/types';
+import { Tooltip } from './Tooltip';
 
 export type ConflictTooltipProps = {
   position: Point;

--- a/front/ui/ui-charts/src/spaceTimeChart/components/SpaceTimeChart.tsx
+++ b/front/ui/ui-charts/src/spaceTimeChart/components/SpaceTimeChart.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useMemo, useState } from 'react';
 
 import cx from 'classnames';
 
-import SpaceGraduations from './SpaceGraduations';
 import { TimeChartCanvasContext } from '../../common/context';
 import { getTimeToPixel, getPixelToTime } from '../../common/helpers/time';
 import { useCanvas } from '../../common/hooks/useCanvas';
@@ -29,6 +28,7 @@ import {
   spaceScalesToBinaryTree,
 } from '../utils/scales';
 import { snapPosition } from '../utils/snapping';
+import SpaceGraduations from './SpaceGraduations';
 
 export const SpaceTimeChart = (props: SpaceTimeChartProps) => {
   const {

--- a/front/ui/ui-charts/src/spaceTimeChart/lib/consts.ts
+++ b/front/ui/ui-charts/src/spaceTimeChart/lib/consts.ts
@@ -1,5 +1,5 @@
-import { type SpaceTimeChartTheme } from './types';
 import { SECOND, MINUTE, HOUR } from '../../common/consts';
+import { type SpaceTimeChartTheme } from './types';
 
 export const BLACK = '#000000';
 export const BLUE = '#2170B9';

--- a/front/ui/ui-charts/src/spaceTimeChart/lib/context.ts
+++ b/front/ui/ui-charts/src/spaceTimeChart/lib/context.ts
@@ -1,7 +1,7 @@
 import { createContext } from 'react';
 
-import type { MouseContextType, SpaceTimeChartContextType } from './types';
 import type { CanvasContextType } from '../../common/types';
+import type { MouseContextType, SpaceTimeChartContextType } from './types';
 
 // There are three different contexts because they have very different lifecycles:
 // - MouseContext

--- a/front/ui/ui-charts/src/spaceTimeChart/utils/geometry.ts
+++ b/front/ui/ui-charts/src/spaceTimeChart/utils/geometry.ts
@@ -1,7 +1,7 @@
 import { inRange } from 'lodash';
 
-import { getDiff } from './vectors';
 import type { Point } from '../../common/types';
+import { getDiff } from './vectors';
 
 /**
  * This function helps to find if two segments do intersect.

--- a/front/ui/ui-charts/src/speedSpaceChart/components/helpers/frontFrame.ts
+++ b/front/ui/ui-charts/src/speedSpaceChart/components/helpers/frontFrame.ts
@@ -1,9 +1,9 @@
 import * as d3selection from 'd3-selection';
 
-import { zoom } from './layersManager';
 import type { DrawFunctionParams } from '../../types';
 import { FRONT_INTERACTIVITY_LAYER_ID } from '../const';
 import { clearCanvas } from '../utils';
+import { zoom } from './layersManager';
 
 export const drawFrame = ({ ctx, width, height, store, setStore }: DrawFunctionParams) => {
   clearCanvas(ctx, width, height);

--- a/front/ui/ui-charts/src/speedSpaceChart/components/utils.ts
+++ b/front/ui/ui-charts/src/speedSpaceChart/components/utils.ts
@@ -1,3 +1,4 @@
+import type { EtcsLayersDisplay, LayerData, OperationalPoints, Store } from '../types';
 import {
   CURSOR_SNAP_DISTANCE,
   LINEAR_LAYER_SEPARATOR_HEIGHT,
@@ -7,7 +8,6 @@ import {
   ETCS_BRAKING_SELECTION,
   ETCS_CURVE_SELECTION,
 } from './const';
-import type { EtcsLayersDisplay, LayerData, OperationalPoints, Store } from '../types';
 
 type SlopesValues = {
   minGradient: number;

--- a/front/ui/ui-charts/src/speedSpaceChart/index.ts
+++ b/front/ui/ui-charts/src/speedSpaceChart/index.ts
@@ -1,4 +1,5 @@
 import '@osrd-project/ui-core/dist/theme.css';
+
 import './styles/main.css';
 
 export {

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/components/TrackOccupancyCanvas.tsx
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/components/TrackOccupancyCanvas.tsx
@@ -2,10 +2,10 @@ import React, { useContext } from 'react';
 
 import { X } from '@osrd-project/ui-icons';
 
-import OccupancyZonesLayer from './layers/OccupancyZonesLayer';
-import TracksLayer from './layers/TracksLayer';
 import { SpaceTimeChartContext } from '../../spaceTimeChart';
 import type { OccupancyZone, Track } from '../lib/types';
+import OccupancyZonesLayer from './layers/OccupancyZonesLayer';
+import TracksLayer from './layers/TracksLayer';
 
 const CloseButton = ({ position, onClose }: { position: number; onClose: () => void }) => {
   const { getSpacePixel } = useContext(SpaceTimeChartContext);

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/components/TrackOccupancyStandalone.tsx
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/components/TrackOccupancyStandalone.tsx
@@ -2,14 +2,14 @@ import React, { useMemo, useRef } from 'react';
 
 import { KebabHorizontal } from '@osrd-project/ui-icons';
 
-import { TRACK_HEIGHT_CONTAINER } from '../lib/consts';
-import { isOccupancyPickingElement } from './layers/OccupancyZonesLayer';
-import TrackOccupancyCanvas from './TrackOccupancyCanvas';
-import TrackOccupancyManchette from './TrackOccupancyManchette';
 import { HOUR } from '../../common/consts';
 import { Manchette, useManchetteWithSpaceTimeChart } from '../../manchette';
 import { DEFAULT_THEME, SpaceTimeChart } from '../../spaceTimeChart';
+import { TRACK_HEIGHT_CONTAINER } from '../lib/consts';
 import type { OccupancyZone, Track } from '../lib/types';
+import { isOccupancyPickingElement } from './layers/OccupancyZonesLayer';
+import TrackOccupancyCanvas from './TrackOccupancyCanvas';
+import TrackOccupancyManchette from './TrackOccupancyManchette';
 
 const TrackOccupancyStandalone = ({
   tracks,

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/components/helpers/drawElements/drawOccupancyZones.ts
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/components/helpers/drawElements/drawOccupancyZones.ts
@@ -1,9 +1,9 @@
-import { drawOccupancyZonesTexts } from './drawOccupancyZonesTexts';
 import { getCrispLineCoordinate } from '../../../../common/helpers/time';
 import { PATH_COLOR_DEFAULT } from '../../../../manchette/consts';
 import type { SpaceTimeChartContextType } from '../../../../spaceTimeChart';
 import { OCCUPANCY_ZONE_Y_START, OCCUPANCY_ZONE_HEIGHT, FONTS, COLORS } from '../../../lib/consts';
 import type { OccupancyZone } from '../../../lib/types';
+import { drawOccupancyZonesTexts } from './drawOccupancyZonesTexts';
 
 const { SANS } = FONTS;
 const { REMAINING_TRAINS_BACKGROUND, WHITE_100, SELECTION_20 } = COLORS;

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/components/helpers/drawElements/drawTracks.ts
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/components/helpers/drawElements/drawTracks.ts
@@ -1,4 +1,3 @@
-import { drawTrack } from './drawTrack';
 import { HOUR, MINUTE } from '../../../../common/consts';
 import type { SpaceTimeChartContextType } from '../../../../spaceTimeChart';
 import { GREY_50 } from '../../../../spaceTimeChart/lib/consts';
@@ -10,6 +9,7 @@ import {
 } from '../../../lib/consts';
 import { type Track } from '../../../lib/types';
 import { getLabelLevels, getLabelMarks } from '../../utils';
+import { drawTrack } from './drawTrack';
 
 const { HOUR_BACKGROUND_1, HOUR_BACKGROUND_2 } = COLORS;
 

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/lib/types.ts
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/lib/types.ts
@@ -1,5 +1,5 @@
-import { type TICKS_PATTERN } from './consts';
 import type { PickingElement } from '../../common/types';
+import { type TICKS_PATTERN } from './consts';
 
 export type Track = {
   id: string;

--- a/front/ui/ui-core/src/components/Checkbox/CheckboxTree.tsx
+++ b/front/ui/ui-core/src/components/Checkbox/CheckboxTree.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
+import FieldWrapper, { type FieldWrapperProps } from '../FieldWrapper';
 import CheckboxList from './CheckboxList';
 import { type CheckboxTreeItem } from './type';
 import { computeNewItemsTree as defaultComputeNewItemsTree } from './utils';
-import FieldWrapper, { type FieldWrapperProps } from '../FieldWrapper';
 
 export type CheckboxesTreeProps = Omit<FieldWrapperProps, 'children'> & {
   readOnly?: boolean;

--- a/front/ui/ui-core/src/components/DatePicker/DatePicker.tsx
+++ b/front/ui/ui-core/src/components/DatePicker/DatePicker.tsx
@@ -4,10 +4,10 @@ import { Calendar as CalendarIcon } from '@osrd-project/ui-icons';
 import cx from 'classnames';
 
 import { type CalendarSlot } from '.';
-import CalendarPicker, { type CalendarPickerPublicProps } from './CalendarPicker';
-import useDatePicker from './useDatePicker';
 import Input, { type InputProps } from '../Input';
 import InputModal from '../InputModal';
+import CalendarPicker, { type CalendarPickerPublicProps } from './CalendarPicker';
+import useDatePicker from './useDatePicker';
 
 type BaseDatePickerProps = {
   selectableSlot?: CalendarSlot;

--- a/front/ui/ui-core/src/components/DatePicker/__tests__/useCalendarPicker.spec.ts
+++ b/front/ui/ui-core/src/components/DatePicker/__tests__/useCalendarPicker.spec.ts
@@ -1,7 +1,6 @@
 import { renderHook, act } from '@testing-library/react';
 import { beforeEach, afterEach, describe, expect, it } from 'vitest';
 
-import { august, december, february, january, july, june } from './useCalendar.spec';
 import useCalendarPicker from '../useCalendarPicker';
 import {
   generateSequentialDates,
@@ -10,6 +9,7 @@ import {
   INVALID_SELECTED_SLOT_BASED_ON_SELECTABLE_SLOT_ERROR,
   INVALID_INITIAL_DATE_ERROR,
 } from '../utils';
+import { august, december, february, january, july, june } from './useCalendar.spec';
 
 const errorsToIgnore = [
   INVALID_SELECTED_SLOT_ERROR,

--- a/front/ui/ui-core/src/components/DatePicker/useDatePicker.ts
+++ b/front/ui/ui-core/src/components/DatePicker/useDatePicker.ts
@@ -1,5 +1,8 @@
 import { useState, useRef, useEffect } from 'react';
 
+import { useModalPosition } from '../../hooks/useModalPosition';
+import useOutsideClick from '../../hooks/useOutsideClick';
+import type { StatusWithMessage } from '../StatusMessage';
 import type { DatePickerProps } from './DatePicker';
 import {
   computeNewSelectedSlot,
@@ -8,9 +11,6 @@ import {
   formatValueToSlot,
   isWithinInterval,
 } from './utils';
-import { useModalPosition } from '../../hooks/useModalPosition';
-import useOutsideClick from '../../hooks/useOutsideClick';
-import type { StatusWithMessage } from '../StatusMessage';
 
 const MODAL_VERTICAL_OFFSET = 3;
 

--- a/front/ui/ui-core/src/components/Input.tsx
+++ b/front/ui/ui-core/src/components/Input.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 
 import cx from 'classnames';
 
-import FieldWrapper, { type FieldWrapperProps } from './FieldWrapper';
 import useFocusByTab from '../hooks/useFocusByTab';
+import FieldWrapper, { type FieldWrapperProps } from './FieldWrapper';
 
 type InputAffixProps = {
   value: InputAffixContent | InputAffixContentWithCallback;

--- a/front/ui/ui-core/src/components/TextArea.tsx
+++ b/front/ui/ui-core/src/components/TextArea.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 
 import cx from 'classnames';
 
-import FieldWrapper, { type FieldWrapperProps } from './FieldWrapper';
 import useFocusByTab from '../hooks/useFocusByTab';
+import FieldWrapper, { type FieldWrapperProps } from './FieldWrapper';
 
 export type TextAreaProps = React.InputHTMLAttributes<HTMLTextAreaElement> &
   Omit<FieldWrapperProps, 'children'>;

--- a/front/ui/ui-core/src/components/TolerancePicker/TolerancePicker.tsx
+++ b/front/ui/ui-core/src/components/TolerancePicker/TolerancePicker.tsx
@@ -1,11 +1,11 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import React, { useState, useRef, useEffect } from 'react';
 
-import { TOLERANCE_RANGES } from './consts';
-import ToleranceRangeGrid from './ToleranceRangeGrid';
 import Input, { type InputProps } from '../Input';
 import Modal from '../InputModal';
 import { type StatusWithMessage } from '../StatusMessage';
+import { TOLERANCE_RANGES } from './consts';
+import ToleranceRangeGrid from './ToleranceRangeGrid';
 
 export type ToleranceValues = {
   minusTolerance: number;

--- a/front/ui/ui-warped-map/src/components/WarpedMap.tsx
+++ b/front/ui/ui-warped-map/src/components/WarpedMap.tsx
@@ -5,12 +5,12 @@ import type { Feature, FeatureCollection, LineString } from 'geojson';
 import { isNil, mapValues, omitBy } from 'lodash';
 import { type LineLayerSpecification, type StyleSpecification } from 'react-map-gl/maplibre';
 
-import DataLoader from './DataLoader';
-import Loader from './Loader';
-import TransformedDataMap from './TransformedDataMap';
 import getWarping, { type WarpingFunction, type WarpingOptions } from '../core/getWarping';
 import { bboxAs2D } from '../core/helpers';
 import type { BBox2D, SourceDefinition } from '../core/types';
+import DataLoader from './DataLoader';
+import Loader from './Loader';
+import TransformedDataMap from './TransformedDataMap';
 
 const TIME_LABEL = 'Warping data';
 


### PR DESCRIPTION
This pull request is the part 2 of the plan described in #15693.

Now that we use `oxfmt` to format our codebase, we should rely on it to _sort our imports_. We had some problems around the inconsistent ordering of the `eslint-plugin-import` plugin, and it's also the moment to figure out if our rules can be tweaked to be more sensible, while limiting code churn.

Here is the configuration I settled with:

```ts
// imports from React
import { type Context, createContext } from 'react';

// imports from builtin Node modules (quite rare)
import fs from 'node:fs';

// imports from external modules, i.e. npm packages (also, NGE)
import SwaggerParser from '@apidevtools/swagger-parser';
import i18next from 'i18next';

// side-effects imports from external styles (any stylesheet with */dist/* or */vendor/*)
import 'maplibre-gl/dist/maplibre-gl.css';
import 'styles/scss/vendor/bootstrap-sncf/site-intern.scss';

// imports from internal modules coming straight from ./src/ (without that prefix)
import { Loader } from 'common/Loaders';
import App from 'main/app';
import { persistor, store } from 'store';

// imports from parents, siblings, or index module from that directory
import { DEFAULT_HALO_WIDTH, getAllowOverlap, getDynamicTextSize } from '../commonLayers';
import OrderedLayer from '../OrderedLayer';
import { getBufferStopsLayerProps } from './BufferStops';
import getMastLayerProps from './getMastLayerProps';

// imports of any style that is not external
import 'styles/styles.scss';
```

You may have _opinions_ about these, but please consider that I really tried to offer a good balance between having a simple, _understandable_ set of rules, and not changing too many files (…which is a good proxy of not changing your habits).

<details>
<summary><em>If you want a sneak peek on my experience trying to iron out these rules, feel free to expand this.</em></summary>

<img src="https://c.tenor.com/QWdPngpHxZ8AAAAd/tenor.gif" />
</details>

> [!NOTE]
> The last commit, that actually apply those rules, will be squashed this the configuration one before merge.