### PR TITLE
editoast: `/match_operational_point` return optional value instead of arrays

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -1188,8 +1188,8 @@ paths:
         '200':
           description: |2
 
-            Take a list of operational point references and return for each of them the list
-            of operational points that they match on a given infrastructure.
+            Take a list of operational point references and return for each of them the
+            operational point that it matches on a given infrastructure.
           content:
             application/json:
               schema:
@@ -1200,9 +1200,9 @@ paths:
                   related_operational_points:
                     type: array
                     items:
-                      type: array
-                      items:
-                        $ref: '#/components/schemas/RelatedOperationalPoint'
+                      oneOf:
+                      - type: 'null'
+                      - $ref: '#/components/schemas/RelatedOperationalPoint'
   /infra/{infra_id}/objects/{object_type}:
     post:
       tags:

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -833,19 +833,17 @@ pub(in crate::views) async fn match_operational_points(
             .await
     })
     .await?;
-    let mut operational_points: Vec<Option<&OperationalPoint>> = vec![];
     let mut conn = db_pool.get().await?;
     let op_refs: Vec<&OperationalPointReference> = operational_point_references.iter().collect();
     let op_cache =
         OperationalPointCache::load_from_operational_points(conn.clone(), infra_id, &op_refs)
             .await?;
-    for operational_point_reference in operational_point_references {
-        // Retrieve related OP based on the input operational point identifier:
-        let related_operational_points = op_cache.get_reference(operational_point_reference);
 
-        // Add the operational point reference related operational point to the response:
-        operational_points.push(related_operational_points);
-    }
+    let operational_points: Vec<Option<&OperationalPoint>> = operational_point_references
+        .into_iter()
+        // Retrieve related OP based on the input operational point identifier:
+        .map(|operational_point_reference| op_cache.get_reference(operational_point_reference))
+        .collect_vec();
     let related_operational_points =
         populate_op_geo(&mut conn, infra_id, &operational_points).await?;
 

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -796,7 +796,7 @@ struct RelatedOperationalPoint {
 #[derive(Serialize, ToSchema)]
 #[cfg_attr(test, derive(Deserialize))]
 pub(in crate::views) struct MatchOperationalPointsResponse {
-    related_operational_points: Vec<Vec<RelatedOperationalPoint>>,
+    related_operational_points: Vec<Option<RelatedOperationalPoint>>,
 }
 
 #[editoast_derive::route]
@@ -807,8 +807,8 @@ pub(in crate::views) struct MatchOperationalPointsResponse {
     request_body = inline(MatchOperationalPointsForm),
     responses(
         (status = 200, description = "
-Take a list of operational point references and return for each of them the list
-of operational points that they match on a given infrastructure.
+Take a list of operational point references and return for each of them the
+operational point that it matches on a given infrastructure.
 ", body = inline(MatchOperationalPointsResponse))
     ),
 )]
@@ -833,19 +833,19 @@ pub(in crate::views) async fn match_operational_points(
             .await
     })
     .await?;
-    let mut operational_points: Vec<Vec<&OperationalPoint>> = vec![];
+    let mut operational_points: Vec<Option<&OperationalPoint>> = vec![];
     let mut conn = db_pool.get().await?;
     let op_refs: Vec<&OperationalPointReference> = operational_point_references.iter().collect();
     let op_cache =
         OperationalPointCache::load_from_operational_points(conn.clone(), infra_id, &op_refs)
             .await?;
     for operational_point_reference in operational_point_references {
-        // Retrieve related OPs based on the input operational point identifier:
+        // Retrieve related OP based on the input operational point identifier:
         let related_operational_points = op_cache
             .get_reference(operational_point_reference)
             .expect("should get the provided reference");
 
-        // Add the operational point reference related operational points to the response:
+        // Add the operational point reference related operational point to the response:
         operational_points.push(related_operational_points);
     }
     let related_operational_points =
@@ -905,21 +905,18 @@ fn build_related_operational_point(
 async fn populate_op_geo(
     conn: &mut DbConnection,
     infra_id: i64,
-    operational_points: &[Vec<&OperationalPoint>],
-) -> Result<Vec<Vec<RelatedOperationalPoint>>> {
+    operational_points: &[Option<&OperationalPoint>],
+) -> Result<Vec<Option<RelatedOperationalPoint>>> {
     let op_ids = operational_points
         .iter()
-        .flatten()
-        .map(|op| op.id.as_str())
+        .filter_map(|opt_op| opt_op.map(|op| op.id.as_str()))
         .collect_vec();
     let geo_points = OperationalPointLayer::get(conn, infra_id, &op_ids).await?;
 
     Ok(operational_points
         .iter()
-        .map(|ops| {
-            ops.iter()
-                .map(|op| build_related_operational_point(op, geo_points.get(op.id.as_str())))
-                .collect_vec()
+        .map(|opt_op| {
+            opt_op.map(|op| build_related_operational_point(op, geo_points.get(op.id.as_str())))
         })
         .collect_vec())
 }
@@ -1411,18 +1408,23 @@ pub mod tests {
         let response_op_identifiers = response
             .related_operational_points
             .iter()
-            .map(|op_ref| op_ref.iter().map(|op| op.id.as_str()).collect::<Vec<_>>())
+            .map(|opt_op| opt_op.as_ref().map(|op| op.id.as_str()))
             .collect_vec();
-        let expected_identifiers = [vec!["West_station"], vec!["Mid_East_station"], vec![]];
+        let expected_identifiers: [Option<&str>; 3] =
+            [Some("West_station"), Some("Mid_East_station"), None];
         assert_eq!(response_op_identifiers, expected_identifiers);
         assert_eq!(
-            response.related_operational_points[0][0].geo,
+            response.related_operational_points[0].as_ref().unwrap().geo,
             Some(geos::geojson::Geometry::new(geos::geojson::Value::Point(
                 vec![-0.3907884636666667, 49.4999],
             )))
         );
         assert_eq!(
-            response.related_operational_points[0][0].parts[1].geo,
+            response.related_operational_points[0]
+                .as_ref()
+                .unwrap()
+                .parts[1]
+                .geo,
             Some(geos::geojson::Geometry::new(geos::geojson::Value::Point(
                 vec![-0.392307692, 49.4999],
             )))
@@ -1457,9 +1459,9 @@ pub mod tests {
         let response_op_identifiers = response
             .related_operational_points
             .iter()
-            .map(|op_ref| op_ref.iter().map(|op| op.id.as_str()).collect::<Vec<_>>())
-            .collect::<Vec<_>>();
-        let expected_identifiers: [Vec<&str>; 2] = [vec![], vec![]];
+            .map(|opt_op| opt_op.as_ref().map(|op| op.id.as_str()))
+            .collect_vec();
+        let expected_identifiers: [Option<&str>; 2] = [None, None];
         assert_eq!(response_op_identifiers, expected_identifiers);
     }
 

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -841,9 +841,7 @@ pub(in crate::views) async fn match_operational_points(
             .await?;
     for operational_point_reference in operational_point_references {
         // Retrieve related OP based on the input operational point identifier:
-        let related_operational_points = op_cache
-            .get_reference(operational_point_reference)
-            .expect("should get the provided reference");
+        let related_operational_points = op_cache.get_reference(operational_point_reference);
 
         // Add the operational point reference related operational point to the response:
         operational_points.push(related_operational_points);

--- a/editoast/src/views/path/operational_point_cache.rs
+++ b/editoast/src/views/path/operational_point_cache.rs
@@ -362,25 +362,22 @@ impl OperationalPointCache {
     pub fn get_reference(
         &self,
         op_ref: OperationalPointReference,
-    ) -> Result<Vec<&OperationalPoint>> {
-        let related_operational_points = match op_ref {
+    ) -> Result<Option<&OperationalPoint>> {
+        let related_operational_point = match op_ref {
             OperationalPointReference::Id {
                 ref operational_point,
             } => self
                 .get_from_id(&operational_point.0)
-                .into_iter()
-                .map(|op_model| &op_model.schema)
-                .collect::<Vec<_>>(),
+                .map(|op_model| &op_model.schema),
             OperationalPointReference::Trigram {
                 ref trigram,
                 secondary_code,
             } => {
                 if let Some(op_models) = self.get_from_trigram(&trigram.0) {
                     find_op_by_secondary_code(secondary_code.as_ref(), op_models.collect())
-                        .map(|op| vec![&op.schema])
-                        .unwrap_or_default()
+                        .map(|op| &op.schema)
                 } else {
-                    vec![]
+                    None
                 }
             }
             OperationalPointReference::Uic {
@@ -389,14 +386,13 @@ impl OperationalPointCache {
             } => {
                 if let Some(op_models) = self.get_from_uic(uic) {
                     find_op_by_secondary_code(secondary_code.as_ref(), op_models.collect())
-                        .map(|op| vec![&op.schema])
-                        .unwrap_or_default()
+                        .map(|op| &op.schema)
                 } else {
-                    vec![]
+                    None
                 }
             }
         };
-        Ok(related_operational_points)
+        Ok(related_operational_point)
     }
 }
 

--- a/editoast/src/views/path/operational_point_cache.rs
+++ b/editoast/src/views/path/operational_point_cache.rs
@@ -369,25 +369,17 @@ impl OperationalPointCache {
             OperationalPointReference::Trigram {
                 ref trigram,
                 secondary_code,
-            } => {
-                if let Some(op_models) = self.get_from_trigram(&trigram.0) {
-                    find_op_by_secondary_code(secondary_code.as_ref(), op_models.collect())
-                        .map(|op| &op.schema)
-                } else {
-                    None
-                }
-            }
+            } => self.get_from_trigram(&trigram.0).and_then(|op_models| {
+                find_op_by_secondary_code(secondary_code.as_ref(), op_models.collect())
+                    .map(|op| &op.schema)
+            }),
             OperationalPointReference::Uic {
                 uic,
                 secondary_code,
-            } => {
-                if let Some(op_models) = self.get_from_uic(uic) {
-                    find_op_by_secondary_code(secondary_code.as_ref(), op_models.collect())
-                        .map(|op| &op.schema)
-                } else {
-                    None
-                }
-            }
+            } => self.get_from_uic(uic).and_then(|op_models| {
+                find_op_by_secondary_code(secondary_code.as_ref(), op_models.collect())
+                    .map(|op| &op.schema)
+            }),
         }
     }
 }

--- a/editoast/src/views/path/operational_point_cache.rs
+++ b/editoast/src/views/path/operational_point_cache.rs
@@ -359,11 +359,8 @@ impl OperationalPointCache {
         }
     }
 
-    pub fn get_reference(
-        &self,
-        op_ref: OperationalPointReference,
-    ) -> Result<Option<&OperationalPoint>> {
-        let related_operational_point = match op_ref {
+    pub fn get_reference(&self, op_ref: OperationalPointReference) -> Option<&OperationalPoint> {
+        match op_ref {
             OperationalPointReference::Id {
                 ref operational_point,
             } => self
@@ -391,8 +388,7 @@ impl OperationalPointCache {
                     None
                 }
             }
-        };
-        Ok(related_operational_point)
+        }
     }
 }
 

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -1289,7 +1289,7 @@ pub(in crate::views) async fn track_occupancy(
     let op_cache =
         OperationalPointCache::load_path_items(db_pool.get().await?, infra_id, &path_items).await?;
 
-    let operational_point = op_cache.get_reference(operational_point_reference.clone())?;
+    let operational_point = op_cache.get_reference(operational_point_reference.clone());
 
     let occupancies = match operational_point {
         Some(operational_point) => {

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -1289,9 +1289,7 @@ pub(in crate::views) async fn track_occupancy(
     let op_cache =
         OperationalPointCache::load_path_items(db_pool.get().await?, infra_id, &path_items).await?;
 
-    let operational_point = op_cache
-        .get_reference(operational_point_reference.clone())?
-        .pop();
+    let operational_point = op_cache.get_reference(operational_point_reference.clone())?;
 
     let occupancies = match operational_point {
         Some(operational_point) => {

--- a/front/src/applications/operationalStudies/hooks/usePathOps.ts
+++ b/front/src/applications/operationalStudies/hooks/usePathOps.ts
@@ -50,7 +50,7 @@ const usePathOps = (
   return useMemo(() => {
     const relatedOps = operationalPoints?.related_operational_points;
     const pathStepIds = [...opRefMap.keys()];
-    return new Map(relatedOps?.map((ops, index) => [pathStepIds[index], ops]));
+    return new Map(relatedOps?.map((op, index) => [pathStepIds[index], op ? [op] : []]));
   }, [operationalPoints]);
 };
 

--- a/front/src/applications/operationalStudies/hooks/usePathProjection.ts
+++ b/front/src/applications/operationalStudies/hooks/usePathProjection.ts
@@ -29,7 +29,6 @@ import {
 } from 'utils/trainId';
 
 import type { PathProjectionResult } from '../types';
-import { getStationFromOps } from '../utils';
 
 /**
  * Generates a display name for a virtual operational point based on available reference data.
@@ -234,8 +233,7 @@ const usePathProjection = (
     const normalizedOps: PathProperties['operational_points'] = [];
 
     opRefs.forEach((opRef, index) => {
-      const matchedOps = matchedOperationalPoints?.related_operational_points[index] || [];
-      const matchedOp = getStationFromOps(matchedOps);
+      const matchedOp = matchedOperationalPoints?.related_operational_points[index];
       const weight = 0; // Uniform weight for consistent manchette spacing
       const position = index * FALLBACK_DISTANCE_MM; // Sequential positioning in manchette
       if (index > 0) {

--- a/front/src/applications/operationalStudies/utils.ts
+++ b/front/src/applications/operationalStudies/utils.ts
@@ -285,17 +285,17 @@ export const getUniqueOpRefsFromTimetableItems = (
 export const addPathOpsToTimetableItems = (
   timetableItems: TimetableItem[],
   timetableOpRefs: OperationalPointReference[],
-  timetableOperationalPoints: RelatedOperationalPoint[][]
+  timetableOperationalPoints: (RelatedOperationalPoint | null)[]
 ): TimetableItemWithPathOps[] => {
   if (timetableOpRefs.length !== timetableOperationalPoints.length) {
     throw new Error('Expected as many OP match lists as OP refs');
   }
 
-  // Map each operational point reference (path step) to its corresponding operational points
+  // Map each operational point reference (path step) to its corresponding operational point
   const opsByKey = new Map<string, RelatedOperationalPoint[]>();
-  timetableOperationalPoints.forEach((ops, i) => {
+  timetableOperationalPoints.forEach((op, i) => {
     const key = JSON.stringify(timetableOpRefs[i]);
-    opsByKey.set(key, ops);
+    opsByKey.set(key, op ? [op] : []);
   });
 
   // For each timetable item, fill the pathOps property with

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -1858,10 +1858,10 @@ export type PostInfraByInfraIdLockApiArg = {
 };
 export type PostInfraByInfraIdMatchOperationalPointsApiResponse =
   /** status 200
-Take a list of operational point references and return for each of them the list
-of operational points that they match on a given infrastructure.
+Take a list of operational point references and return for each of them the
+operational point that it matches on a given infrastructure.
  */ {
-    related_operational_points: RelatedOperationalPoint[][];
+    related_operational_points: (null | RelatedOperationalPoint)[];
   };
 export type PostInfraByInfraIdMatchOperationalPointsApiArg = {
   /** An existing infra ID */

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -184,12 +184,12 @@ const osrdEditoastApi = generatedEditoastApi
         providesTags: ['train_schedule'],
       }),
       matchAllOperationalPoints: builder.query<
-        RelatedOperationalPoint[][],
+        (RelatedOperationalPoint | null)[],
         { infraId: number; opRefs: OperationalPointReference[] }
       >({
         queryFn: async ({ infraId, opRefs }, { dispatch }) => {
           const batchSize = 200;
-          const result: RelatedOperationalPoint[][] = [];
+          const result: (RelatedOperationalPoint | null)[] = [];
 
           // Split opRefs into batches of 200
           for (let i = 0; i < opRefs.length; i += batchSize) {

--- a/front/src/modules/pathfinding/hooks/usePathfinding.ts
+++ b/front/src/modules/pathfinding/hooks/usePathfinding.ts
@@ -89,7 +89,7 @@ const usePathfinding = ({
         return [pathItemLocation.operational_point];
       });
 
-      let ops: RelatedOperationalPoint[][];
+      let ops: (RelatedOperationalPoint | null)[];
       try {
         ops = await matchAllOperationalPoints({
           infraId,
@@ -104,7 +104,7 @@ const usePathfinding = ({
       const updatedSteps = steps.map((step): PathStep => {
         if (step.location.type === 'track_offset') return step;
 
-        const op = ops[opIndex].at(0);
+        const op = ops[opIndex];
         opIndex++;
         if (!op) return step;
 

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useTrackOccupancy.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useTrackOccupancy.ts
@@ -542,8 +542,8 @@ const useTrackOccupancy = ({
 
         if (aborted) return;
 
-        const allTrackIds = data.related_operational_points.flatMap(([points]) =>
-          points ? points.parts.map((part) => part.track) : []
+        const allTrackIds = data.related_operational_points.flatMap((point) =>
+          point ? point.parts.map((part) => part.track) : []
         );
         const fetchedTrackSections = await getTrackSectionsByIds(allTrackIds);
 
@@ -553,7 +553,7 @@ const useTrackOccupancy = ({
         }
 
         opsWithReferences.forEach(({ waypointId: wId }, i) => {
-          const [operationalPoint] = data.related_operational_points[i];
+          const operationalPoint = data.related_operational_points[i];
           if (!operationalPoint) return;
           const mapping = new Map<string, string>();
           for (const part of operationalPoint.parts) {
@@ -566,7 +566,7 @@ const useTrackOccupancy = ({
           opsWithReferences.map(({ waypointId: wId }, i) => [
             wId,
             uniqBy(
-              (data.related_operational_points[i][0]?.parts ?? []).map((part) => {
+              (data.related_operational_points[i]?.parts ?? []).map((part) => {
                 const trackPart = trackSectionByTrackId.get(part.track);
                 return {
                   id: part.track,
@@ -774,7 +774,7 @@ const useTrackOccupancy = ({
         }).unwrap();
 
         requests.forEach(({ side, timetableItemId }, i) => {
-          const op = data.related_operational_points[i].at(0);
+          const op = data.related_operational_points[i];
           trainsStationLabels[timetableItemId] = {
             ...trainsStationLabels[timetableItemId],
             [side]: {


### PR DESCRIPTION
This pull request makes the changes suggested in this issue: #15583 .

The endpoint `/match_operational_points` returns either a point or nothing per operational point reference. So a list of operating points for each reference is not relevent.
As the return value is an optional points, the return value type `MatchOperationalPointsResponse` is modified from `Vec<Vec<...>>` to `Vec<Option<...>>`. Thus all needed functions are adapted to manage `Option<...>` argument.

`get_reference` function has `Result<Option<...>>` return type but always returns `Ok(...)` value. Is it relevant to keep the `Result` type ? Perhaps simplify to have `Option<...>`