### PR TITLE
core: stdcm: improve failure file by avoiding infinites

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/DelayManager.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/DelayManager.kt
@@ -53,13 +53,13 @@ internal constructor(
                     is BlockAvailabilityInterface.Available -> {
                         if (availability.maximumDelay >= internalMargin) {
                             res.add(time - startTime)
-                            if (prevConflict != null && prevConflict.causedBy != null)
+                            prevConflict?.causes?.forEach { cause ->
                                 failureExplainer?.conflictCallback(
                                     prevNode,
-                                    prevConflict.duration,
-                                    false,
-                                    prevConflict.causedBy,
+                                    cause.duration,
+                                    cause.cause,
                                 )
+                            }
                         }
                         availability.maximumDelay + internalMargin
                     }
@@ -69,13 +69,9 @@ internal constructor(
                     }
                 }
         }
-        if (prevConflict != null && prevConflict.causedBy != null)
-            failureExplainer?.conflictCallback(
-                prevNode,
-                prevConflict.duration,
-                res.isEmpty(),
-                prevConflict.causedBy,
-            )
+        prevConflict?.causes?.forEach { cause ->
+            failureExplainer?.conflictCallback(prevNode, cause.duration, cause.cause)
+        }
         return res
     }
 

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/implementation/BlockAvailability.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/implementation/BlockAvailability.kt
@@ -34,7 +34,7 @@ class BlockAvailability(
         startTime: Double,
     ): BlockAvailabilityInterface.Availability {
         var timeShift = 0.0
-        var conflictCause: String? = null
+        val conflictCauses = mutableListOf<BlockAvailabilityInterface.ConflictCause>()
         var firstConflictOffset: Offset<PhysicsPath>? = null
         while (timeShift.isFinite()) {
             val shiftedStartTime = startTime + timeShift
@@ -63,7 +63,7 @@ class BlockAvailability(
                         return BlockAvailabilityInterface.Unavailable(
                             timeShift,
                             firstConflictOffset ?: startOffset,
-                            conflictCause,
+                            conflictCauses,
                         )
                     }
                     // Availability is directly available without adding any delay
@@ -71,7 +71,7 @@ class BlockAvailability(
                 }
                 is BlockAvailabilityInterface.Unavailable -> {
                     timeShift += availability.duration
-                    availability.causedBy?.let { conflictCause = it }
+                    conflictCauses.addAll(availability.causes)
 
                     // Only update the conflict offset if it hasn't been set
                     firstConflictOffset = firstConflictOffset ?: availability.firstConflictOffset
@@ -82,7 +82,7 @@ class BlockAvailability(
         return BlockAvailabilityInterface.Unavailable(
             Double.POSITIVE_INFINITY,
             firstConflictOffset ?: startOffset,
-            conflictCause,
+            conflictCauses,
         )
     }
 
@@ -122,7 +122,7 @@ class BlockAvailability(
                 return BlockAvailabilityInterface.Unavailable(
                     Double.POSITIVE_INFINITY,
                     availabilityProperties.firstUnavailabilityOffset,
-                    null,
+                    listOf(),
                 )
             } else if (
                 availabilityProperties.minimumDelayToBecomeAvailable > minimumDelayToBecomeAvailable
@@ -143,14 +143,14 @@ class BlockAvailability(
                 return BlockAvailabilityInterface.Unavailable(
                     Double.POSITIVE_INFINITY,
                     firstUnavailabilityOffset,
-                    null,
+                    listOf(),
                 )
             }
             // Adding minimumDelayToBecomeAvailable solves every planned step problem
             return BlockAvailabilityInterface.Unavailable(
                 minimumDelayToBecomeAvailable,
                 firstUnavailabilityOffset,
-                null,
+                listOf(),
             )
         }
         // Every planned step was respected
@@ -271,6 +271,14 @@ class BlockAvailability(
                         ?.metadata[conflictProperties.conflictingZone]
                         ?.firstOrNull { it.from <= endTime && it.to >= startTime }
                         ?.trainName
+                        ?.let {
+                            listOf(
+                                BlockAvailabilityInterface.ConflictCause(
+                                    it,
+                                    conflictProperties.minDelayWithoutConflicts,
+                                )
+                            )
+                        } ?: listOf()
                 return BlockAvailabilityInterface.Unavailable(
                     conflictProperties.minDelayWithoutConflicts,
                     firstConflictOffset,

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/interfaces/BlockAvailabilityInterface.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/interfaces/BlockAvailabilityInterface.kt
@@ -72,8 +72,23 @@ interface BlockAvailabilityInterface {
          * offset where the train would have released a resource it has kept for too long.
          */
         val firstConflictOffset: Offset<PhysicsPath>,
-        val causedBy: String?,
+        /**
+         * Describes the causes for this conflict. [Unavailable] describes how much delay we need to
+         * add to reach a conflict-free opening: there may be more than one other train or work
+         * schedule per instance.
+         */
+        val causes: List<ConflictCause>,
     ) : Availability()
+
+    data class ConflictCause(
+        /**
+         * Describes the actual conflicting object: either "work schedule" for work schedules, or
+         * train names for other trains. TODO: import work schedule IDs as well.
+         */
+        val cause: String,
+        /** How much delay we needed to add to avoid this specific conflict. */
+        val duration: Double,
+    )
 
     /**
      * This is thrown when the availability of the requested section can't be determined, the path

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/tracing/FailureExplainer.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/tracing/FailureExplainer.kt
@@ -38,7 +38,6 @@ class FailureExplainer(
     data class PendingConflict(
         val parentNode: STDCMNode,
         val timeLost: Double,
-        val orphaned: Boolean,
         val cause: String,
         val bestRemainingTime: Double,
     ) {
@@ -67,7 +66,6 @@ class FailureExplainer(
                 wrapDoubleForJson(remainingTime),
                 travelTime,
                 cause,
-                orphaned,
                 geoPoint.lat,
                 geoPoint.lon,
                 lastOPName,
@@ -78,15 +76,11 @@ class FailureExplainer(
             if (this === other) return true
             if (javaClass != other?.javaClass) return false
             val other = other as PendingConflict
-            return other.timeLost == timeLost &&
-                other.orphaned == orphaned &&
-                other.nodeStr == nodeStr &&
-                other.cause == cause
+            return other.timeLost == timeLost && other.nodeStr == nodeStr && other.cause == cause
         }
 
         override fun hashCode(): Int {
             var result = timeLost.hashCode()
-            result = 31 * result + orphaned.hashCode()
             result = 31 * result + nodeStr.hashCode()
             result = 31 * result + cause.hashCode()
             return result
@@ -114,28 +108,15 @@ class FailureExplainer(
         @Json(name = "best_remaining_time") val bestRemainingTime: Double,
         @Json(name = "current_travel_time") val currentTravelTime: Double,
         @Json(name = "caused_by") val causedBy: String,
-        /** True if this node can't lead anywhere else because of conflicts. */
-        @Json(name = "is_blocking") val isBlocking: Boolean,
         val lat: Double,
         val lon: Double,
         val lastOPName: String?,
     )
 
     /** Register a new conflict. */
-    fun conflictCallback(
-        parentNode: STDCMNode,
-        timeLost: Double,
-        orphaned: Boolean,
-        cause: String,
-    ) {
+    fun conflictCallback(parentNode: STDCMNode, timeLost: Double, cause: String) {
         val pendingConflict =
-            PendingConflict(
-                parentNode,
-                timeLost,
-                orphaned,
-                cause,
-                parentNode.remainingTimeEstimation,
-            )
+            PendingConflict(parentNode, timeLost, cause, parentNode.remainingTimeEstimation)
         largestConflicts.register(pendingConflict)
         closestConflicts.register(pendingConflict)
     }

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/DummyBlockAvailability.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/DummyBlockAvailability.kt
@@ -174,7 +174,7 @@ class DummyBlockAvailability(
         return BlockAvailabilityInterface.Unavailable(
             minimumDelay,
             conflictTravelledOffset.cast(),
-            null,
+            listOf(),
         )
     }
 


### PR DESCRIPTION
A single Unavalable instance can reflect several different conflicts, we'd merge them in ways that made us lose useful data and caused infinites in some cases.