### PR TITLE
front: increase op search size response

### DIFF
--- a/front/src/applications/operationalStudies/hooks/useOperationalPointSearch.ts
+++ b/front/src/applications/operationalStudies/hooks/useOperationalPointSearch.ts
@@ -24,7 +24,7 @@ type Params = {
 };
 
 export const useOperationalPointSearch = ({
-  pageSize = 101,
+  pageSize = 1000,
   minChars = 2,
   debounceMs = 300,
 }: Params) => {
@@ -130,7 +130,6 @@ export const useOperationalPointSearch = ({
           searchPayload: largePayload(infraId, debouncedTrimmedInput),
           pageSize,
         }).unwrap()) as SearchResultItemOperationalPoint[];
-
         if (cancelled) return;
 
         const suggestionsLarge = buildOpSuggestion(largeRes);


### PR DESCRIPTION
closes #15111 

The page size response was capped to 101 results, resulting in some secondary codes being hidden from the search when the response contained more than 101 results. 

Increased the page size to 1000 (limit from the backend) so that we get everything. 