### PR TITLE
editoast: migrate uses of `user_roles` to `v2::subject_roles`

### DIFF
--- a/editoast/authz/src/authorizer.rs
+++ b/editoast/authz/src/authorizer.rs
@@ -55,10 +55,6 @@ impl<S: StorageDriver> Authorizer<S> {
         &self.user.name
     }
 
-    pub async fn user_roles(&self) -> Result<HashSet<Role>, Error<S::Error>> {
-        self.regulator.user_roles(&User(self.user_id)).await
-    }
-
     /// Check that the user has any of the required roles
     #[tracing::instrument(skip_all, fields(user = %self.user, ?roles), ret(level = Level::DEBUG))]
     pub async fn check_roles(&self, roles: HashSet<Role>) -> Result<bool, Error<S::Error>> {

--- a/editoast/src/client/roles.rs
+++ b/editoast/src/client/roles.rs
@@ -63,7 +63,7 @@ pub fn list_roles() {
     Role::iter().for_each(|role| println!("{role}"));
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct Subject {
     id: i64,
     info: SubjectInfo,
@@ -93,7 +93,7 @@ impl Subject {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 enum SubjectInfo {
     User(UserInfo),
     Group(GroupInfo),
@@ -143,17 +143,20 @@ pub async fn list_subject_roles(
     pool: Arc<DbConnectionPoolV2>,
     openfga_config: OpenfgaConfig,
 ) -> anyhow::Result<()> {
-    let regulator = openfga_config.into_regulator(pool.clone()).await?;
-    let roles = match parse_and_fetch_subject(&subject, pool.get().await?).await? {
-        Subject {
-            id,
-            info: SubjectInfo::User(_),
-        } => regulator.user_roles(&authz::User(id)).await?,
-        Subject {
-            id,
-            info: SubjectInfo::Group(_),
-        } => regulator.group_roles(&authz::Group(id)).await?,
+    let system = SystemAuthorizer {
+        openfga: &openfga_config.into_client().await?,
+        conn: pool.get().await?,
     };
+    let subject = parse_and_fetch_subject(&subject, pool.get().await?).await?;
+    let subject_roles = authz::v2::subject_roles(subject.clone().into_authz());
+    let roles = match system.authorize(subject_roles).await?.access().await? {
+        Ok(roles) => roles,
+        Err(Check::SubjectExists(_)) => {
+            unreachable!("checked by parse_and_fetch_subject")
+        }
+        Err(rejection) => impossible!(rejection),
+    };
+
     if roles.is_empty() {
         info!("{subject} has no roles assigned");
         return Ok(());

--- a/editoast/src/views.rs
+++ b/editoast/src/views.rs
@@ -34,12 +34,10 @@ pub use server::*;
 mod test_app;
 
 use ::core::str;
-use std::collections::HashSet;
 
 use ::authz::Authorization;
 use ::authz::Authorizer;
 use ::authz::Infra;
-use ::authz::Role;
 use core_client::CoreClient;
 use editoast_derive::EditoastError;
 use editoast_models::PgAuthDriver;
@@ -463,40 +461,12 @@ pub enum Authentication {
     SkipAuthorization {
         #[expect(unused)]
         identity: Option<String>,
+        #[expect(unused)]
         name: Option<String>,
     },
 }
 
 impl Authentication {
-    fn user_id(&self) -> Result<Option<i64>, AuthorizationError> {
-        match self {
-            Authentication::SkipAuthorization { .. } => Ok(None),
-            Authentication::Unauthenticated => Err(AuthorizationError::Unauthorized),
-            Authentication::Authenticated(authorizer) => Ok(Some(authorizer.user_id())),
-        }
-    }
-
-    fn user_name(&self) -> Result<Option<String>, AuthorizationError> {
-        match self {
-            Authentication::SkipAuthorization { name, .. } => Ok(name.clone()),
-            Authentication::Unauthenticated => Err(AuthorizationError::Unauthorized),
-            Authentication::Authenticated(authorizer) => {
-                Ok(Some(authorizer.user_name().to_owned()))
-            }
-        }
-    }
-
-    async fn user_roles(&self) -> Result<HashSet<Role>, AuthorizationError> {
-        match self {
-            Authentication::SkipAuthorization { .. } => Ok(HashSet::from([Role::Admin])),
-            Authentication::Unauthenticated => Err(AuthorizationError::Unauthorized),
-            Authentication::Authenticated(authorizer) => authorizer
-                .user_roles()
-                .await
-                .map_err(AuthorizationError::from),
-        }
-    }
-
     /// Function wrapper that allows you to check if the issuer of the request has the good privilege, grant, role....
     /// If the request is unauthenticated, it will return an Unauthorized error, and for the SkipAuthorization.
     /// The provided function will be called with the authorizer and its result will be checked by the allowed() method.

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
 
+use crate::authorizers::SystemAuthorizer;
 use crate::authorizers::UserAuthorizer;
 use crate::authorizers::impossible;
 use crate::error::Result;
@@ -115,14 +116,22 @@ pub(in crate::views) struct WhoamiResponse {
     ))
 )]
 pub(in crate::views) async fn whoami(
-    Extension(auth): AuthenticationExt,
+    Extension(roles): Extension<Vec<authz::Role>>,
+    Extension(user): Extension<Option<editoast_models::User>>,
+    Extension(authn): Extension<crate::authentication::Authentication>,
 ) -> Result<Json<WhoamiResponse>> {
-    Ok(Json(WhoamiResponse {
+    if let Some(editoast_models::User { id, name }) = user {
+        Ok(Json(WhoamiResponse { id, name, roles }))
+    } else if matches!(authn, crate::authentication::Authentication::Skip { .. }) {
         // TODO: don't return -1 and a hardcoded name, return a different schema instead, requires frontend changes
-        id: auth.user_id()?.unwrap_or(-1),
-        name: auth.user_name()?.unwrap_or_else(|| "OSRD user".to_string()),
-        roles: auth.user_roles().await?.into_iter().collect(),
-    }))
+        Ok(Json(WhoamiResponse {
+            id: -1,
+            name: "OSRD user".to_string(),
+            roles: vec![Role::Admin],
+        }))
+    } else {
+        Err(AuthorizationError::Forbidden.into())
+    }
 }
 
 #[editoast_derive::route]
@@ -256,10 +265,23 @@ pub(in crate::views) async fn users_info(
         .map(|g| (g.id, g))
         .collect::<HashMap<_, _>>();
 
+    let system = SystemAuthorizer {
+        openfga: regulator.openfga(),
+        conn: db_pool.get().await?,
+    };
+
     let mut results = Vec::new();
     for (user_id, user) in users {
         // TODO: optimize by batching calls to OpenFGA
-        let roles = regulator.user_roles(&authz::User(user_id)).await?;
+        let subject_roles: v2::Protected<Vec<Role>> =
+            authz::v2::subject_roles(authz::Subject::user(user_id));
+        let roles = match system.authorize(subject_roles).await?.access().await? {
+            Ok(roles) => roles,
+            Err(Check::SubjectExists(_)) => {
+                unreachable!("checked when retrieving users above")
+            }
+            Err(rejection) => impossible!(rejection),
+        };
         let groups = groups_by_user[&user_id]
             .iter()
             // Skip group if it does not exist
@@ -269,7 +291,7 @@ pub(in crate::views) async fn users_info(
             id: user_id,
             name: user.name,
             identities: user_to_identities[&user_id].clone(),
-            roles,
+            roles: roles.into_iter().collect::<HashSet<Role>>(),
             groups,
         });
     }


### PR DESCRIPTION
I started migrating `user_roles` to `subject_roles`, but I'm a bit lost and the test `views::authz::tests::whoami_authorization_disabled` fail (roles are empty instead of Admin).

I would love a review if possible.