### PR TITLE
editoast: enforce unicity for signaling systems and electrifications

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -444,9 +444,9 @@ dependencies = [
 
 [[package]]
 name = "axum-test"
-version = "19.1.1"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a28640adad0e99978d38bc455b323c62a5cddc4e22f83eacde93f8c395ae7e3"
+checksum = "3a86bfe2ef15bee102ac34912f7f4542b0bb37dc464fa55461763999c4d625e7"
 dependencies = [
  "anyhow",
  "axum",

--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -735,6 +735,7 @@ dependencies = [
 name = "common"
 version = "0.1.0"
 dependencies = [
+ "itertools",
  "opentelemetry",
  "opentelemetry_sdk",
  "rangemap",

--- a/editoast/common/Cargo.toml
+++ b/editoast/common/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+itertools.workspace = true
 opentelemetry.workspace = true
 opentelemetry_sdk.workspace = true
 rangemap.workspace = true

--- a/editoast/common/src/lib.rs
+++ b/editoast/common/src/lib.rs
@@ -4,9 +4,14 @@ pub mod rangemap_utils;
 pub mod tracing;
 pub mod units;
 
+use std::collections::HashSet;
+use std::hash::Hash;
+use std::hash::Hasher;
+
 pub use hash_rounded_float::hash_float;
 pub use hash_rounded_float::hash_float_slice;
 
+use itertools::Itertools as _;
 use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
@@ -31,4 +36,13 @@ pub struct Version {
 /// Tip: provide this to Educe.
 pub fn float_eq(a: &f64, b: &f64) -> bool {
     (a.is_nan() && b.is_nan()) || (a == b)
+}
+
+pub fn hashing_hash_set_string<H>(set: &HashSet<String>, state: &mut H)
+where
+    H: Hasher,
+{
+    let mut vec = set.iter().collect_vec();
+    vec.sort();
+    Hash::hash(&vec, state)
 }

--- a/editoast/core_client/src/pathfinding.rs
+++ b/editoast/core_client/src/pathfinding.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use ordered_float::OrderedFloat;
 use schemas::infra::Direction;
 use schemas::infra::TrackOffset;
@@ -13,7 +15,8 @@ use crate::Json;
 use crate::RawError;
 use crate::WorkerKey;
 
-#[derive(Debug, Hash, Serialize)]
+#[derive(Debug, educe::Educe, Serialize)]
+#[educe(Hash)]
 pub struct PathfindingRequest {
     /// Infrastructure id
     pub infra: i64,
@@ -27,9 +30,11 @@ pub struct PathfindingRequest {
     pub rolling_stock_is_thermal: bool,
     /// List of supported electrification modes.
     /// Empty if does not support any electrification
-    pub rolling_stock_supported_electrifications: Vec<String>,
+    #[educe(Hash(method(common::hashing_hash_set_string)))]
+    pub rolling_stock_supported_electrifications: HashSet<String>,
     /// List of supported signaling systems
-    pub rolling_stock_supported_signaling_systems: Vec<String>,
+    #[educe(Hash(method(common::hashing_hash_set_string)))]
+    pub rolling_stock_supported_signaling_systems: HashSet<String>,
     /// Maximum speed of the rolling stock
     pub rolling_stock_maximum_speed: OrderedFloat<f64>,
     /// Rolling stock length in meters:

--- a/editoast/core_client/src/stdcm.rs
+++ b/editoast/core_client/src/stdcm.rs
@@ -120,11 +120,13 @@ pub struct UndirectedTrackRange {
 }
 
 /// Represents a physics consist.
-#[derive(Serialize, Deserialize, Clone, Debug, ToSchema, Hash, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, Debug, ToSchema, educe::Educe, PartialEq, Eq)]
 #[schema(as = core::ConsistConfiguration)]
+#[educe(Hash)]
 pub struct ConsistConfiguration {
     /// List of supported signaling systems
-    pub supported_signaling_systems: Vec<String>,
+    #[educe(Hash(method(common::hashing_hash_set_string)))]
+    pub supported_signaling_systems: HashSet<String>,
     pub speed_limit_tag: Option<String>,
     /// The loading gauge of the rolling stock
     pub loading_gauge_type: LoadingGaugeType,

--- a/editoast/core_task/src/envs/pathfinding.rs
+++ b/editoast/core_task/src/envs/pathfinding.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::hash::DefaultHasher;
 use std::hash::Hash;
 use std::hash::Hasher as _;
@@ -151,16 +152,19 @@ where
     }
 }
 
-#[derive(Debug, Hash, PartialEq, Eq)]
+#[derive(Debug, educe::Educe, PartialEq, Eq)]
+#[educe(Hash)]
 #[cfg_attr(test, derive(Clone))]
 pub struct PathfindingConsist {
     pub loading_gauge: LoadingGaugeType,
     /// Can the consist run on non-electrified tracks
     pub thermal: bool,
     /// Supported electrification modes (leave empty for unelectrified consists)
-    pub supported_electrifications: Vec<String>,
+    #[educe(Hash(method(common::hashing_hash_set_string)))]
+    pub supported_electrifications: HashSet<String>,
     /// A list of supported signaling systems
-    pub supported_signaling_systems: Vec<String>,
+    #[educe(Hash(method(common::hashing_hash_set_string)))]
+    pub supported_signaling_systems: HashSet<String>,
     pub maximum_speed: OrderedFloat<f64>,
     /// Consist length in meters
     pub length: OrderedFloat<f64>,
@@ -387,6 +391,7 @@ fn build_request(
         rolling_stock_is_thermal: consist.thermal,
         rolling_stock_supported_electrifications: consist.supported_electrifications.clone(),
         rolling_stock_supported_signaling_systems: consist.supported_signaling_systems.clone(),
+
         rolling_stock_maximum_speed: consist.maximum_speed,
         rolling_stock_length: consist.length,
         speed_limit_tag: consist.speed_limit_tag.clone(),
@@ -451,8 +456,8 @@ pub(crate) mod test_data {
         PathfindingConsist {
             loading_gauge: LoadingGaugeType::GB,
             thermal: true,
-            supported_electrifications: vec![],
-            supported_signaling_systems: vec!["BAPR".to_owned()],
+            supported_electrifications: HashSet::new(),
+            supported_signaling_systems: HashSet::from(["BAPR".to_owned()]),
             maximum_speed: OrderedFloat::from(100.0),
             length: OrderedFloat::from(id as f64),
             speed_limit_tag: Some("MA100".to_owned()),

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -11182,11 +11182,13 @@ components:
           description: |-
             List of supported electrification modes.
             Empty if does not support any electrification
+          uniqueItems: true
         rolling_stock_supported_signaling_systems:
           type: array
           items:
             type: string
           description: List of supported signaling systems
+          uniqueItems: true
         speed_limit_tag:
           type:
           - string
@@ -14937,6 +14939,7 @@ components:
           items:
             type: string
           description: List of supported signaling systems
+          uniqueItems: true
     core.ETCSBrakingCurvesResponse:
       type: object
       required:

--- a/editoast/schemas/src/rolling_stock.rs
+++ b/editoast/schemas/src/rolling_stock.rs
@@ -120,7 +120,7 @@ pub struct RollingStock {
 }
 
 impl RollingStock {
-    pub fn supported_signaling_systems(&self) -> Vec<String> {
+    pub fn supported_signaling_systems(&self) -> HashSet<String> {
         self.supported_signaling_systems
             .iter()
             .map(|s| s.to_string())

--- a/editoast/schemas/src/rolling_stock/effort_curves.rs
+++ b/editoast/schemas/src/rolling_stock/effort_curves.rs
@@ -3,6 +3,7 @@ use serde::Deserialize;
 use serde::Deserializer;
 use serde::Serialize;
 use std::collections::BTreeMap;
+use std::collections::HashSet;
 use utoipa::ToSchema;
 
 use crate::train_schedule::Comfort;
@@ -27,7 +28,7 @@ impl EffortCurves {
         self.has_electric_curves()
     }
 
-    pub fn supported_electrification(&self) -> Vec<String> {
+    pub fn supported_electrification(&self) -> HashSet<String> {
         self.modes
             .iter()
             .filter(|(_, mode)| mode.is_electric)

--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::Hash;
 use std::hash::Hasher;
@@ -44,7 +45,8 @@ use editoast_models::rolling_stock::RollingStock;
 
 /// Path input is described by some rolling stock information
 /// and a list of path waypoints
-#[derive(Deserialize, Clone, Debug, Hash, ToSchema)]
+#[derive(Deserialize, Clone, Debug, educe::Educe, ToSchema)]
+#[educe(Hash)]
 #[cfg_attr(test, derive(Serialize))]
 pub(in crate::views) struct PathfindingInput {
     /// The loading gauge of the rolling stock
@@ -53,9 +55,11 @@ pub(in crate::views) struct PathfindingInput {
     rolling_stock_is_thermal: bool,
     /// List of supported electrification modes.
     /// Empty if does not support any electrification
-    rolling_stock_supported_electrifications: Vec<String>,
+    #[educe(Hash(method(common::hashing_hash_set_string)))]
+    rolling_stock_supported_electrifications: HashSet<String>,
     /// List of supported signaling systems
-    rolling_stock_supported_signaling_systems: Vec<String>,
+    #[educe(Hash(method(common::hashing_hash_set_string)))]
+    rolling_stock_supported_signaling_systems: HashSet<String>,
     /// List of waypoints given to the pathfinding
     path_items: Vec<PathItemLocation>,
     /// Rolling stock maximum speed
@@ -510,6 +514,8 @@ pub async fn pathfinding_from_train_batch<T: TrainScheduleLike>(
 
 #[cfg(test)]
 pub mod tests {
+    use std::collections::HashSet;
+
     use axum::http::StatusCode;
     use core_client::mocking::MockingClient;
     use core_client::pathfinding::InvalidPathItem;
@@ -532,8 +538,8 @@ pub mod tests {
         PathfindingInput {
             rolling_stock_loading_gauge: LoadingGaugeType::G1,
             rolling_stock_is_thermal: true,
-            rolling_stock_supported_electrifications: Vec::new(),
-            rolling_stock_supported_signaling_systems: vec!["BAL".into(), "BAPR".into()],
+            rolling_stock_supported_electrifications: HashSet::new(),
+            rolling_stock_supported_signaling_systems: HashSet::from(["BAL".into(), "BAPR".into()]),
             rolling_stock_maximum_speed: 22.0.into(),
             rolling_stock_length: 26.0.into(),
             speed_limit_tag: None,

--- a/editoast/src/views/rolling_stock.rs
+++ b/editoast/src/views/rolling_stock.rs
@@ -820,7 +820,7 @@ pub mod tests {
         assert_eq!(
             rolling_stock
                 .supported_signaling_systems()
-                .contains(&"ETCS_LEVEL2".to_string()),
+                .contains("ETCS_LEVEL2"),
             false
         );
     }
@@ -1086,7 +1086,7 @@ pub mod tests {
         assert_eq!(
             rolling_stock
                 .supported_signaling_systems()
-                .contains(&"ETCS_LEVEL2".to_string()),
+                .contains("ETCS_LEVEL2"),
             true
         );
 


### PR DESCRIPTION
> [!WARNING]
> This PR contains 3 commits (4 actually but the first one is not important). Only one of them is supposed to be merged. The second commit erase the first. So either we only merge the first commit, or I’ll squash them and merge both (the second will basically replace the first). It is intended, as a reviewer, that you give your opinion on which solution you prefer.

# If you look only at [first commit](https://github.com/OpenRailAssociation/osrd/pull/16283/changes/2ed012853238a21765ef41d224046807d9f1525b)

In all of the codebase, we don’t want twice the same value for signaling system or electrification for a rolling stock (or consist parameters, or one of the other structs describing the physic properties of a rolling stock). In some places, we did encode that property with a `HashSet`, but in some other places, we rely on `Vec` which does not enforce that property.

Since some of the `struct` that contain `Vec` needs to implement `Hash`, I chose to use `BTreeSet` (which implements `Hash`) instead of `HashSet` (which does not implement `Hash`).

One of the consequence of using `BTreeSet` is that the contained values need to implement `Ord`. In the case of `SignalingSystem`, it does not make a lot of sense, but in a way, if we want to be able to implement `Hash` on wrapping `struct`, we need some way to order the `SignalingSystem` in a deterministic way.

> [!NOTE]
> The OpenAPI also change a little with an additional `uniqueItems: true`, which has no impact on the generated Typescript file.

# If you look at the [second commit](https://github.com/OpenRailAssociation/osrd/pull/16283/changes/b5f4398582ced801c433cc02cf31b5e2af95e0bd..ed93b463d51e2f203b68e2c4c74ea5ac49998736)

Given that you read the previous paragraph, we need a set, that is able to implement `Hash`. We used a `BTreeSet`, but for that, we had to make an implementation of `Ord` on a `struct` for which it doesn’t make sense. Let’s use `educe` to make `HashSet<String>` implement `Hash`.

# If you look at the [third commit](https://github.com/OpenRailAssociation/osrd/pull/16283/changes/b5f4398582ced801c433cc02cf31b5e2af95e0bd..c749a1071b5f8370b4cbf42593d0a06f559d3040)

The `HashSet` solution above is an improvement over `BTreeSet`, but we still need to sort for implementing `Hash`. With `IndexSet`, we don’t need to sort and can implement `Hash` directly. Seems better but

> [!WARNING]
> is that what we really want? The order of insertion is not an important information, and I would expect 2 rolling stocks to be hashed similarly, even if their signaling systems have been inserted in a different order. What do you think?

> [!WARNING]
> The `IndexSet` has been weirdly implemented by `utoipa` has a whole different object, and not as a simple set. It does change a lot the Typescript generation which is surprising and might not be desirable.