### PR TITLE
front: fix Error: Maximum update depth exceeded. in useLazyProjectTrains

### DIFF
--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useLazyProjectTrains.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useLazyProjectTrains.ts
@@ -21,12 +21,15 @@ type UseLazyProjectTrainsOptions = {
   operationalPointReferences?: OperationalPointReference[];
 };
 
+const DEFAULT_OP_DISTANCES: number[] = [];
+const DEFAULT_OP_REFERENCES: OperationalPointReference[] = [];
+
 const useLazyProjectTrains = ({
   infraId,
   electricalProfileSetId,
   path,
-  operationalPointDistances = [],
-  operationalPointReferences = [],
+  operationalPointDistances = DEFAULT_OP_DISTANCES,
+  operationalPointReferences = DEFAULT_OP_REFERENCES,
 }: UseLazyProjectTrainsOptions) => {
   const dispatch = useAppDispatch();
   const loaderRef = useRef<TrainProjectionLazyLoaderAbstract>(null);


### PR DESCRIPTION
fix #16284

operationalPointDistances and operationalPointReferences array were recreated on every render causing useEffect to be retriggered causing an infinite loop.

Using constant array fixes the issue.