### PR TITLE
editoast: fix bump axum-test from 19.1.1 to 20.0.0

### DIFF
--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -160,7 +160,7 @@ axum-extra = { version = "0.12.2", default-features = false, features = [
   "typed-header",
 ] }
 axum-streams = { version = "0.25.0", features = ["json"] }
-axum-test = { version = "19.0", default-features = false }
+axum-test = { version = "20.0.0", default-features = false }
 axum-tracing-opentelemetry = { version = "0.33.0", default-features = false, features = [
   "tracing_level_info",
 ] }


### PR DESCRIPTION
dependabot forgot to update Cargo.toml in commit 333fe885492ecacb9661de1015c7d3749115252f (<https://github.com/OpenRailAssociation/osrd/pull/16189>)