### PR TITLE
front: introduce mocking framework for osrdEditoastApi

### DIFF
--- a/front/eslint.config.js
+++ b/front/eslint.config.js
@@ -108,6 +108,7 @@ export default [
             'eslint.config.js',
             'playwright.config.ts',
             'vite.config.ts',
+            'vitest.setup.ts',
           ],
         },
       ],

--- a/front/eslint.config.js
+++ b/front/eslint.config.js
@@ -102,6 +102,7 @@ export default [
           devDependencies: [
             '**/*.spec.ts',
             '**/__tests__/**',
+            '**/__mocks__/**',
             'tests/**',
             'scripts/**',
             'eslint.config.js',

--- a/front/src/applications/operationalStudies/hooks/__tests__/useCachedTrackSections.spec.ts
+++ b/front/src/applications/operationalStudies/hooks/__tests__/useCachedTrackSections.spec.ts
@@ -1,7 +1,7 @@
 import { renderHook } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-import type { TrackSection } from 'common/api/osrdEditoastApi';
+import type { InfraObjectWithGeometry, TrackSection } from 'common/api/osrdEditoastApi';
 
 import useCachedTrackSections from '../useCachedTrackSections';
 
@@ -16,6 +16,14 @@ function createTrackSection(overrides: Partial<TrackSection> = {}): TrackSection
       coordinates: [],
     },
     ...overrides,
+  };
+}
+
+function createTrackSectionInfraObject(trackSection: TrackSection): InfraObjectWithGeometry {
+  return {
+    obj_id: trackSection.id,
+    geographic: trackSection.geo,
+    railjson: trackSection,
   };
 }
 
@@ -39,6 +47,8 @@ const infraId = 3000;
 
 const trackVA = createTrackSection({ id: 'VA', length: 4815 });
 const trackVB = createTrackSection({ id: 'VB', length: 1623 });
+const trackVAInfraObject = createTrackSectionInfraObject(trackVA);
+const trackVBInfraObject = createTrackSectionInfraObject(trackVB);
 
 describe('useCachedTrackSections', () => {
   beforeEach(() => {
@@ -47,7 +57,7 @@ describe('useCachedTrackSections', () => {
   });
 
   it('should return some track sections', async () => {
-    apiResult.mockResolvedValue([{ railjson: trackVA }, { railjson: trackVB }]);
+    apiResult.mockResolvedValue([trackVAInfraObject, trackVBInfraObject]);
 
     const { result } = renderHook(() => useCachedTrackSections(infraId));
 
@@ -66,7 +76,7 @@ describe('useCachedTrackSections', () => {
   });
 
   it('should always return the full cache even if we only request a subset later', async () => {
-    apiResult.mockResolvedValue([{ railjson: trackVA }, { railjson: trackVB }]);
+    apiResult.mockResolvedValue([trackVAInfraObject, trackVBInfraObject]);
 
     const { result } = renderHook(() => useCachedTrackSections(infraId));
 
@@ -84,7 +94,7 @@ describe('useCachedTrackSections', () => {
   });
 
   it('should deduplicate track IDs to only fetch those that are not in cache', async () => {
-    apiResult.mockResolvedValue([{ railjson: trackVA }]);
+    apiResult.mockResolvedValue([trackVAInfraObject]);
 
     const { result } = renderHook(() => useCachedTrackSections(infraId));
 
@@ -100,7 +110,7 @@ describe('useCachedTrackSections', () => {
       VA: trackVA,
     });
 
-    apiResult.mockResolvedValue([{ railjson: trackVA }, { railjson: trackVB }]);
+    apiResult.mockResolvedValue([trackVAInfraObject, trackVBInfraObject]);
 
     const trackSections2 = await result.current.getTrackSectionsByIds(['VA', 'VB']);
 
@@ -114,7 +124,7 @@ describe('useCachedTrackSections', () => {
   });
 
   it('should not call the API at all once the result is cached', async () => {
-    apiResult.mockResolvedValue([{ railjson: trackVA }, { railjson: trackVB }]);
+    apiResult.mockResolvedValue([trackVAInfraObject, trackVBInfraObject]);
 
     const { result } = renderHook(() => useCachedTrackSections(infraId));
 
@@ -145,7 +155,7 @@ describe('useCachedTrackSections', () => {
   });
 
   it('should change infraId parameter in queries if changed', async () => {
-    apiResult.mockResolvedValue([{ railjson: trackVA }]);
+    apiResult.mockResolvedValue([trackVAInfraObject]);
 
     const { result, rerender } = renderHook(
       (hookInfraId: number) => useCachedTrackSections(hookInfraId),
@@ -163,7 +173,7 @@ describe('useCachedTrackSections', () => {
 
     rerender(5678);
 
-    apiResult.mockResolvedValue([{ railjson: trackVB }]);
+    apiResult.mockResolvedValue([trackVBInfraObject]);
     await result.current.getTrackSectionsByIds(['VB']);
     expect(apiQuery).toHaveBeenCalledWith({
       infraId: 5678,

--- a/front/src/applications/operationalStudies/hooks/__tests__/useCachedTrackSections.spec.ts
+++ b/front/src/applications/operationalStudies/hooks/__tests__/useCachedTrackSections.spec.ts
@@ -1,6 +1,8 @@
-import { renderHook } from '@testing-library/react';
+import { renderHookWithStore } from 'store/__tests__';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+import { mockOsrdEditoastEndpoints } from 'common/api/__mocks__/osrdEditoastApi';
+import type { ApiError } from 'common/api/baseGeneratedApis';
 import type { InfraObjectWithGeometry, TrackSection } from 'common/api/osrdEditoastApi';
 
 import useCachedTrackSections from '../useCachedTrackSections';
@@ -27,21 +29,7 @@ function createTrackSectionInfraObject(trackSection: TrackSection): InfraObjectW
   };
 }
 
-const { apiResult, apiQuery, mockUseLazyQuery } = vi.hoisted(() => ({
-  apiResult: vi.fn(),
-  apiQuery: vi.fn(() => ({ unwrap: apiResult })),
-  mockUseLazyQuery: vi.fn(),
-}));
-
-vi.mock('common/api/osrdEditoastApi', () => ({
-  osrdEditoastApi: {
-    endpoints: {
-      postInfraByInfraIdObjectsAndObjectType: {
-        useLazyQuery: mockUseLazyQuery,
-      },
-    },
-  },
-}));
+const { postInfraByInfraIdObjectsAndObjectType } = mockOsrdEditoastEndpoints;
 
 const infraId = 3000;
 
@@ -53,17 +41,18 @@ const trackVBInfraObject = createTrackSectionInfraObject(trackVB);
 describe('useCachedTrackSections', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockUseLazyQuery.mockReturnValue([apiQuery, { isLoading: false }]);
   });
 
   it('should return some track sections', async () => {
-    apiResult.mockResolvedValue([trackVAInfraObject, trackVBInfraObject]);
+    postInfraByInfraIdObjectsAndObjectType.mockResolvedValue({
+      data: [trackVAInfraObject, trackVBInfraObject],
+    });
 
-    const { result } = renderHook(() => useCachedTrackSections(infraId));
+    const { result } = renderHookWithStore(() => useCachedTrackSections(infraId));
 
     const trackSections = await result.current.getTrackSectionsByIds(['VA', 'VB']);
 
-    expect(apiQuery).toHaveBeenCalledWith({
+    expect(postInfraByInfraIdObjectsAndObjectType).toHaveBeenCalledWith({
       infraId: 3000,
       objectType: 'TrackSection',
       body: ['VA', 'VB'],
@@ -76,9 +65,11 @@ describe('useCachedTrackSections', () => {
   });
 
   it('should always return the full cache even if we only request a subset later', async () => {
-    apiResult.mockResolvedValue([trackVAInfraObject, trackVBInfraObject]);
+    postInfraByInfraIdObjectsAndObjectType.mockResolvedValue({
+      data: [trackVAInfraObject, trackVBInfraObject],
+    });
 
-    const { result } = renderHook(() => useCachedTrackSections(infraId));
+    const { result } = renderHookWithStore(() => useCachedTrackSections(infraId));
 
     const twoTracksRequested = await result.current.getTrackSectionsByIds(['VA', 'VB']);
     expect(twoTracksRequested).toEqual({
@@ -94,13 +85,13 @@ describe('useCachedTrackSections', () => {
   });
 
   it('should deduplicate track IDs to only fetch those that are not in cache', async () => {
-    apiResult.mockResolvedValue([trackVAInfraObject]);
+    postInfraByInfraIdObjectsAndObjectType.mockResolvedValue({ data: [trackVAInfraObject] });
 
-    const { result } = renderHook(() => useCachedTrackSections(infraId));
+    const { result } = renderHookWithStore(() => useCachedTrackSections(infraId));
 
     const trackSections1 = await result.current.getTrackSectionsByIds(['VA', 'VA']);
 
-    expect(apiQuery).toHaveBeenCalledWith({
+    expect(postInfraByInfraIdObjectsAndObjectType).toHaveBeenCalledWith({
       infraId: 3000,
       objectType: 'TrackSection',
       body: ['VA'],
@@ -110,11 +101,13 @@ describe('useCachedTrackSections', () => {
       VA: trackVA,
     });
 
-    apiResult.mockResolvedValue([trackVAInfraObject, trackVBInfraObject]);
+    postInfraByInfraIdObjectsAndObjectType.mockResolvedValue({
+      data: [trackVAInfraObject, trackVBInfraObject],
+    });
 
     const trackSections2 = await result.current.getTrackSectionsByIds(['VA', 'VB']);
 
-    expect(apiQuery).toHaveBeenCalledWith({
+    expect(postInfraByInfraIdObjectsAndObjectType).toHaveBeenCalledWith({
       infraId: 3000,
       objectType: 'TrackSection',
       body: ['VB'],
@@ -124,28 +117,37 @@ describe('useCachedTrackSections', () => {
   });
 
   it('should not call the API at all once the result is cached', async () => {
-    apiResult.mockResolvedValue([trackVAInfraObject, trackVBInfraObject]);
+    postInfraByInfraIdObjectsAndObjectType.mockResolvedValue({
+      data: [trackVAInfraObject, trackVBInfraObject],
+    });
 
-    const { result } = renderHook(() => useCachedTrackSections(infraId));
+    const { result } = renderHookWithStore(() => useCachedTrackSections(infraId));
 
     await result.current.getTrackSectionsByIds(['VA', 'VB']);
     await result.current.getTrackSectionsByIds(['VB']);
     await result.current.getTrackSectionsByIds(['VB', 'VA']);
     await result.current.getTrackSectionsByIds(['VA']);
 
-    expect(apiQuery).toHaveBeenCalledTimes(1);
+    expect(postInfraByInfraIdObjectsAndObjectType).toHaveBeenCalledTimes(1);
 
     await result.current.getTrackSectionsByIds(['VC']);
 
-    expect(apiQuery).toHaveBeenCalledTimes(2);
+    expect(postInfraByInfraIdObjectsAndObjectType).toHaveBeenCalledTimes(2);
   });
 
   it('should emit errors in the console if the call fails', async () => {
-    const someApiError = new Error('Oops! Something crashed.');
-    apiResult.mockRejectedValue(someApiError);
+    const someApiError: ApiError = {
+      data: {
+        type: 'InternalError',
+        message: 'Oops! Something crashed.',
+        context: {},
+      },
+      status: 500,
+    };
+    postInfraByInfraIdObjectsAndObjectType.mockResolvedValue({ error: someApiError });
 
     const mockedConsoleError = vi.spyOn(console, 'error');
-    const { result } = renderHook(() => useCachedTrackSections(infraId));
+    const { result } = renderHookWithStore(() => useCachedTrackSections(infraId));
 
     await result.current.getTrackSectionsByIds(['VA']);
     expect(mockedConsoleError).toHaveBeenCalledWith(
@@ -155,9 +157,9 @@ describe('useCachedTrackSections', () => {
   });
 
   it('should change infraId parameter in queries if changed', async () => {
-    apiResult.mockResolvedValue([trackVAInfraObject]);
+    postInfraByInfraIdObjectsAndObjectType.mockResolvedValue({ data: [trackVAInfraObject] });
 
-    const { result, rerender } = renderHook(
+    const { result, rerender } = renderHookWithStore(
       (hookInfraId: number) => useCachedTrackSections(hookInfraId),
       {
         initialProps: 1234,
@@ -165,7 +167,7 @@ describe('useCachedTrackSections', () => {
     );
 
     await result.current.getTrackSectionsByIds(['VA']);
-    expect(apiQuery).toHaveBeenCalledWith({
+    expect(postInfraByInfraIdObjectsAndObjectType).toHaveBeenCalledWith({
       infraId: 1234,
       objectType: 'TrackSection',
       body: ['VA'],
@@ -173,9 +175,9 @@ describe('useCachedTrackSections', () => {
 
     rerender(5678);
 
-    apiResult.mockResolvedValue([trackVBInfraObject]);
+    postInfraByInfraIdObjectsAndObjectType.mockResolvedValue({ data: [trackVBInfraObject] });
     await result.current.getTrackSectionsByIds(['VB']);
-    expect(apiQuery).toHaveBeenCalledWith({
+    expect(postInfraByInfraIdObjectsAndObjectType).toHaveBeenCalledWith({
       infraId: 5678,
       objectType: 'TrackSection',
       body: ['VB'],

--- a/front/src/common/api/__mocks__/osrdEditoastApi.ts
+++ b/front/src/common/api/__mocks__/osrdEditoastApi.ts
@@ -1,0 +1,88 @@
+import type { QueryReturnValue } from '@reduxjs/toolkit/query';
+import { vi, type Mock } from 'vitest';
+
+import type { ApiError } from '../baseGeneratedApis';
+import { osrdEditoastApi } from '../osrdEditoastApi';
+
+/**
+ * Object type holding all defined API endpoints.
+ */
+type Endpoints = (typeof osrdEditoastApi)['endpoints'];
+
+/**
+ * Given an endpoint type, extract its argument and result types and build a
+ * mock function type.
+ *
+ * This allows us to type-check that the mocked endpoints get the proper query
+ * arguments and returns a type that reflects the one that would actually be
+ * returned by the endpoint if it wasn't mocked.
+ */
+type MockQueryFn<E> = E extends { Types: { QueryArg: infer A; ResultType: infer R } }
+  ? Mock<(arg: A) => QueryReturnValue<R, ApiError>>
+  : never;
+
+/**
+ * Mapped type providing a typed mock function for each defined API endpoint.
+ */
+type MockApi = {
+  [Name in keyof Endpoints]: MockQueryFn<Endpoints[Name]>;
+};
+
+// Create a mock function for each endpoint
+const mockEndpointEntries = Object.keys(osrdEditoastApi.endpoints).map(
+  (name) => [name, vi.fn()] as const
+);
+
+/**
+ * Exposes type-safe mocked functions for each endpoint.
+ *
+ * vitest's .mockResolvedValue() and expect().toHaveBeenCalledWith() functions
+ * can be used on these mocked functions.
+ *
+ * To use these mocks from a test, renderHookWithStore() needs to be used
+ * because rtk-query requires a Redux store.
+ */
+const mockEndpoints = Object.fromEntries(mockEndpointEntries) as MockApi;
+// ↑ Unfortunately we need a cast here: TypeScript disregards
+// Object.fromEntries() input types and always produces objects with string
+// keys.
+
+/**
+ * Given a function taking any number of arguments, return a function which
+ * only accepts the first one.
+ *
+ * rtk-query calls queryFn with 4 arguments, but we only care about the first
+ * one which contains the QueryArg. This allows us to leverage
+ * expect().toHaveBeenCalledWith() to only check QueryArg.
+ */
+function callWithOnlyFirstParam<F extends (arg: unknown) => unknown>(f: F) {
+  return (arg: Parameters<F>[0]) => f(arg);
+}
+
+// Override endpoint query functions with mocks
+const mockApi = osrdEditoastApi.enhanceEndpoints({
+  endpoints: Object.fromEntries(
+    mockEndpointEntries.map(([name, f]) => [
+      name,
+      {
+        query: undefined,
+        queryFn: callWithOnlyFirstParam(f),
+      },
+    ])
+  ),
+}) as unknown as typeof osrdEditoastApi;
+// ↑ Unfortunately we need a cast here, because .enhanceEndpoints() never
+// returns the exact same type as the original even if no new
+// tags/endpoints got added, and Typescript can't know we didn't do that.
+
+export {
+  // This is the test-facing part of the API mocking framework.
+  mockEndpoints as mockOsrdEditoastEndpoints,
+
+  // This is the hook/component-facing part of the mocked API, that will be
+  // used in place of the real osrdEditoastApi.
+  //
+  // Because this file is placed in a __mocks__ directory, vitest will load it
+  // by default when vi.mock('common/api/osrdEditoastApi') is called.
+  mockApi as osrdEditoastApi,
+};

--- a/front/src/common/api/__mocks__/osrdEditoastApi.ts
+++ b/front/src/common/api/__mocks__/osrdEditoastApi.ts
@@ -83,6 +83,7 @@ export {
   // used in place of the real osrdEditoastApi.
   //
   // Because this file is placed in a __mocks__ directory, vitest will load it
-  // by default when vi.mock('common/api/osrdEditoastApi') is called.
+  // by default when vi.mock('common/api/osrdEditoastApi') is called by
+  // vite.setup.ts.
   mockApi as osrdEditoastApi,
 };

--- a/front/src/store/__tests__/index.tsx
+++ b/front/src/store/__tests__/index.tsx
@@ -1,0 +1,41 @@
+import { renderHook, type RenderHookOptions, type RenderHookResult } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { beforeEach } from 'vitest';
+
+import { createStore, type Store } from 'store';
+
+// Create a fresh store before each test, so that tests don't inherit any state
+// from previous tests (e.g. rtk-query's cache isn't polluted with a previous
+// test's mock data). We still want to keep using the same store within a test,
+// for instance to test re-renders after a store change or to retain
+// rtk-query's cache.
+let store: Store;
+beforeEach(() => {
+  store = createStore();
+});
+
+/**
+ * Renders a hook for test purposes with the Redux store in the context.
+ *
+ * This is similar to testing-library/react's renderHook(), but also adds the
+ * store in the context. Among other things, this is required for using
+ * rtk-query API mocks from mockOsrdEditoastEndpoints.
+ *
+ * A fresh store is create before each test for proper isolation. As a result,
+ * this function is incompatible with vitest's .concurrent().
+ */
+export function renderHookWithStore<Result, Props>(
+  render: (initialProps: Props) => Result,
+  options?: RenderHookOptions<Props>
+): RenderHookResult<Result, Props> {
+  return renderHook(render, {
+    ...options,
+    wrapper: ({ children }) => {
+      const inner = <Provider store={store}>{children}</Provider>;
+
+      // If the user has provided their own wrapper, wrap the wrapper! 🕺
+      const Wrapper = options?.wrapper;
+      return Wrapper ? <Wrapper>{inner}</Wrapper> : inner;
+    },
+  });
+}

--- a/front/src/store/index.ts
+++ b/front/src/store/index.ts
@@ -29,23 +29,26 @@ const middlewares: Middleware[] = [
   osrdRailwayManagerApi.middleware,
 ];
 
-const store = configureStore({
-  reducer: persistedReducer,
-  devTools: reduxDevToolsOptions,
-  middleware: (getDefaultMiddleware) =>
-    getDefaultMiddleware({
-      serializableCheck: false,
-      // The following line disables the detection of immutability across the entire Redux state.
-      // Immutability detection can be time-consuming, especially for large stores
-      // and can show warning message : "ImmutableStateInvariantMiddleware took xms, which is more than the warning threshold of 32ms."
-      // Since we use RTK, which incorporates Immer for managing our store slices,
-      // this check is not really necessary since Immer has already ensured the store immutability.
-      // Disabling this feature improve performance. https://github.com/reduxjs/redux-toolkit/issues/415
-      immutableCheck: false,
-    })
-      .prepend(listenerMiddleware.middleware)
-      .concat(...middlewares),
-});
+const createStore = () =>
+  configureStore({
+    reducer: persistedReducer,
+    devTools: reduxDevToolsOptions,
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware({
+        serializableCheck: false,
+        // The following line disables the detection of immutability across the entire Redux state.
+        // Immutability detection can be time-consuming, especially for large stores
+        // and can show warning message : "ImmutableStateInvariantMiddleware took xms, which is more than the warning threshold of 32ms."
+        // Since we use RTK, which incorporates Immer for managing our store slices,
+        // this check is not really necessary since Immer has already ensured the store immutability.
+        // Disabling this feature improve performance. https://github.com/reduxjs/redux-toolkit/issues/415
+        immutableCheck: false,
+      })
+        .prepend(listenerMiddleware.middleware)
+        .concat(...middlewares),
+  });
+
+const store = createStore();
 
 export type AppDispatch = typeof store.dispatch;
 export type GetState = typeof store.getState;
@@ -85,4 +88,4 @@ const createStoreWithoutMiddleware = (initialStateExtra: Partial<RootState>) =>
     },
   });
 
-export { store, persistor, createStoreWithoutMiddleware };
+export { store, persistor, createStore, createStoreWithoutMiddleware };

--- a/front/vite.config.ts
+++ b/front/vite.config.ts
@@ -76,6 +76,7 @@ export default defineConfig(({ mode }) => {
     },
     test: {
       globalSetup: './vitest.global-setup.ts',
+      setupFiles: './vitest.setup.ts',
       dir: 'src',
       include: ['**/*.spec.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
       environment: 'happy-dom',

--- a/front/vite.config.ts
+++ b/front/vite.config.ts
@@ -84,6 +84,7 @@ export default defineConfig(({ mode }) => {
         all: true,
         reportsDirectory: 'coverage',
       },
+      silent: 'passed-only',
     },
   };
 });

--- a/front/vitest.setup.ts
+++ b/front/vitest.setup.ts
@@ -1,0 +1,3 @@
+import { vi } from 'vitest';
+
+vi.mock('common/api/osrdEditoastApi');


### PR DESCRIPTION
_See individual commits._

Up until now, we've been mocking directly the API exposed by
rtk-query: useQuery(), useMutation(), useLazyQuery() and friends.
This is fragile because:

- The relies on the exact way the tested function uses rtk-query.
  If the tested function switches from useLazyQuery() or initiate()
  to useQuery(), tests break.
- rtk-query's complicated API needs to be replicated at multiple
  levels: hooks return objects with unwrap() functions. Only a
  small part of the API can reasonably be mocked, and this falls
  apart when the tested function starts using more.
- None of this is type-safe. If the API changes, either tests
  fail with potentially hard-to-debug errors, either they silently
  pass and become outdated. Nothing prevents mocked functions from
  returning garbage.

This commit introduces a new mocking framework which operates at a
lower level: it integrates with rtk-query with enhanceEndpoints()
and defines a custom queryFn called in place of the HTTP request.

The framework exposes a type-safe collection of mocked functions
with well-defined argument and return types automatically
extracted from the original osrdEditoastApi. Any value passed to
mockResolvedValue() is checked by TypeScript.

Unfortunately two casts cannot be eliminated (one due to objects
being cumbersome to manipulate in TypeScript, the other due to an
rtk-query shortcoming).

This commit is the result of multiple days of head banging against
the table, dozens of litres of tea, countless yells in the direction
of Microsoft headquarters, multiple cups of tears, and a handful of
shower thoughts. But it was all worth it in the end!

Earlier iterations of this work ended up being massively more
complicated, and I only realized quite late in the process how
all of this mess could be simplified. For posterity:
https://paste.sr.ht/~emersion/ab23c2c3cd32a4daa1be228d6e6b5fceed33d76f#testEditoastApi.ts