### PR TITLE
front: disable nge std

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -17,7 +17,7 @@
         "@ag-media/react-pdf-table": "^2.0.3",
         "@nivo/core": "^0.99.0",
         "@nivo/line": "^0.99.0",
-        "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.679f64a68e9578d50e995662390b557f2f80c051",
+        "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.67f493cf2502e26b42381bb91451aa525593a7c4",
         "@osrd-project/ui-charts": "0.0.1-dev",
         "@osrd-project/ui-core": "0.0.1-dev",
         "@osrd-project/ui-icons": "0.0.1-dev",
@@ -3487,9 +3487,9 @@
       "link": true
     },
     "node_modules/@osrd-project/netzgrafik-frontend": {
-      "version": "0.0.0-snapshot.679f64a68e9578d50e995662390b557f2f80c051",
-      "resolved": "https://registry.npmjs.org/@osrd-project/netzgrafik-frontend/-/netzgrafik-frontend-0.0.0-snapshot.679f64a68e9578d50e995662390b557f2f80c051.tgz",
-      "integrity": "sha512-oJSXDlUEt8bMo95tUfLcvnAtWBcPbctXScwsCtiOjV3gNXtZGQ6e9d1CI2VIYs96u1dzRmj82cMrPcRbQhMFdQ=="
+      "version": "0.0.0-snapshot.67f493cf2502e26b42381bb91451aa525593a7c4",
+      "resolved": "https://registry.npmjs.org/@osrd-project/netzgrafik-frontend/-/netzgrafik-frontend-0.0.0-snapshot.67f493cf2502e26b42381bb91451aa525593a7c4.tgz",
+      "integrity": "sha512-UNU1ofG+/JypqLrwn5lBPXbLI/JSuAGint/rQsJK4QtpAXfebXI/iWXkHgrqx8yPm2j5e+8g4uNSkAMskOVubg=="
     },
     "node_modules/@osrd-project/storybook": {
       "resolved": "ui/storybook",

--- a/front/package.json
+++ b/front/package.json
@@ -17,7 +17,7 @@
     "@ag-media/react-pdf-table": "^2.0.3",
     "@nivo/core": "^0.99.0",
     "@nivo/line": "^0.99.0",
-    "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.679f64a68e9578d50e995662390b557f2f80c051",
+    "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.67f493cf2502e26b42381bb91451aa525593a7c4",
     "@osrd-project/ui-charts": "0.0.1-dev",
     "@osrd-project/ui-core": "0.0.1-dev",
     "@osrd-project/ui-icons": "0.0.1-dev",


### PR DESCRIPTION
NGE STD is not needed in OSRD since it already has its own STD.
See: https://github.com/osrd-project/netzgrafik-editor-frontend/pull/27