### PR TITLE
editoast: actually bump axum-test properly

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -444,9 +444,9 @@ dependencies = [
 
 [[package]]
 name = "axum-test"
-version = "19.1.1"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a28640adad0e99978d38bc455b323c62a5cddc4e22f83eacde93f8c395ae7e3"
+checksum = "3a86bfe2ef15bee102ac34912f7f4542b0bb37dc464fa55461763999c4d625e7"
 dependencies = [
  "anyhow",
  "axum",


### PR DESCRIPTION
d8d3031 bumps the Cargo.toml requirement to 20.0, but doesn't bump the lockfile. Its parent commit did revert the lockfile version to 19.x, so the lockfile is still out of date.