### PR TITLE
core: scripts: add flag to trim exported trains

### DIFF
--- a/core/scripts/download-timetable.py
+++ b/core/scripts/download-timetable.py
@@ -15,6 +15,7 @@ async def download_timetable(
     editoast_url: str,
     page_size: int,
     gateway_cookie: str,
+    max_train_count: int,
 ) -> Dict:
     paced_trains_url = f"{editoast_url}api/timetable/{timetable_id}/train_schedules/?page=$page&{page_size=}"
     cookies, connector = make_connector(gateway_cookie)
@@ -22,6 +23,9 @@ async def download_timetable(
         trust_env=True, raise_for_status=True, cookies=cookies, connector=connector
     ) as session:
         raw_paced_trains = await get_paginated(paced_trains_url, session)
+    raw_paced_trains.sort(key=lambda train: train["start_time"])
+    if max_train_count > 0:
+        raw_paced_trains = raw_paced_trains[:max_train_count]
     paced_trains = []
     for paced_train in raw_paced_trains:
         del paced_train["id"]
@@ -43,9 +47,20 @@ Downloads a full timetable into a json file that can be reimported in OSRD opera
 @click.option("--path", "-p", default="timetable.json")
 @click.option("--gateway-cookie", "-c", envvar="GATEWAY_COOKIE")
 @click.option("--page-size", "-s", default=100)
-def main(editoast_url, timetable_id, path, gateway_cookie, page_size):
+@click.option(
+    "--max-train-count",
+    "-m",
+    default=0,
+    help="""
+Maximum number of train to export, to avoid issues with uploading large files.
+Trains are sorted by departure time before being trimmed (earliest ones are kept).
+""",
+)
+def main(editoast_url, timetable_id, path, gateway_cookie, page_size, max_train_count):
     trains = asyncio.run(
-        download_timetable(timetable_id, editoast_url, page_size, gateway_cookie)
+        download_timetable(
+            timetable_id, editoast_url, page_size, gateway_cookie, max_train_count
+        )
     )
     with open(path, "w", encoding="utf-8") as jsonfile:
         json.dump(trains, jsonfile, ensure_ascii=False, indent=4)


### PR DESCRIPTION
Trimming isn't hard, but this also sorts the trains first, thus keeping a dense timetable